### PR TITLE
Fix Pause Print message and behavior

### DIFF
--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -66,10 +66,10 @@ void FWRetract::reset() {
   settings.retract_length = RETRACT_LENGTH;
   settings.retract_feedrate_mm_s = RETRACT_FEEDRATE;
   settings.retract_zraise = RETRACT_ZRAISE;
-  settings.retract_recover_length = RETRACT_RECOVER_LENGTH;
+  settings.retract_recover_extra = RETRACT_RECOVER_LENGTH;
   settings.retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE;
   settings.swap_retract_length = RETRACT_LENGTH_SWAP;
-  settings.swap_retract_recover_length = RETRACT_RECOVER_LENGTH_SWAP;
+  settings.swap_retract_recover_extra = RETRACT_RECOVER_LENGTH_SWAP;
   settings.swap_retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE_SWAP;
   current_hop = 0.0;
 
@@ -175,7 +175,7 @@ void FWRetract::retract(const bool retracting
       planner.synchronize();                              // Wait for move to complete
     }
 
-    const float extra_recover = swapping ? settings.swap_retract_recover_length : settings.retract_recover_length;
+    const float extra_recover = swapping ? settings.swap_retract_recover_extra : settings.retract_recover_extra;
     if (extra_recover != 0.0) {
       current_position[E_AXIS] -= extra_recover;          // Adjust the current E position by the extra amount to recover
       sync_plan_position_e();                             // Sync the planner position so the extra amount is recovered

--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -32,11 +32,11 @@
 typedef struct {
   float retract_length,                     // M207 S - G10 Retract length
         retract_feedrate_mm_s,              // M207 F - G10 Retract feedrate
-        retract_zraise,                      // M207 Z - G10 Retract hop size
-        retract_recover_length,             // M208 S - G11 Recover length
+        retract_zraise,                     // M207 Z - G10 Retract hop size
+        retract_recover_extra,              // M208 S - G11 Recover length
         retract_recover_feedrate_mm_s,      // M208 F - G11 Recover feedrate
         swap_retract_length,                // M207 W - G10 Swap Retract length
-        swap_retract_recover_length,        // M208 W - G11 Swap Recover length
+        swap_retract_recover_extra,         // M208 W - G11 Swap Recover length
         swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
 } fwretract_settings_t;
 

--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -110,7 +110,7 @@ void host_action(const char * const pstr, const bool eol) {
       case PROMPT_FILAMENT_RUNOUT:
         msg = PSTR("FILAMENT_RUNOUT");
         if (response == 0) {
-          advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_EXTRUDE_MORE;
+          pause_menu_response = PAUSE_RESPONSE_EXTRUDE_MORE;
           host_action_prompt_end();   // Close current prompt
           host_action_prompt_begin(PSTR("Paused"));
           host_action_prompt_button(PSTR("Purge More"));
@@ -133,7 +133,7 @@ void host_action(const char * const pstr, const bool eol) {
               runout.reset();
             }
           #endif
-          advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_RESUME_PRINT;
+          pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT;
         }
         break;
       case PROMPT_USER_CONTINUE:

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -58,7 +58,9 @@
 
 static float resume_position[XYZE];
 
-AdvancedPauseMenuResponse advanced_pause_menu_response;
+PauseMode pause_mode = PAUSE_MODE_PAUSE_PRINT;
+
+PauseMenuResponse pause_menu_response;
 
 fil_change_settings_t fc_settings[EXTRUDERS];
 
@@ -68,6 +70,7 @@ fil_change_settings_t fc_settings[EXTRUDERS];
 
 #if HAS_BUZZER
   static void filament_change_beep(const int8_t max_beep_count, const bool init=false) {
+    if (pause_mode == PAUSE_MODE_PAUSE_PRINT) return;
     static millis_t next_buzz = 0;
     static int8_t runout_beep = 0;
 
@@ -93,7 +96,7 @@ fil_change_settings_t fc_settings[EXTRUDERS];
  *
  * Returns 'true' if heating was completed, 'false' for abort
  */
-static bool ensure_safe_temperature(const AdvancedPauseMode mode=ADVANCED_PAUSE_MODE_SAME) {
+static bool ensure_safe_temperature(const PauseMode mode=PAUSE_MODE_SAME) {
 
   #if ENABLED(PREVENT_COLD_EXTRUSION)
     if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(active_extruder)) {
@@ -103,7 +106,7 @@ static bool ensure_safe_temperature(const AdvancedPauseMode mode=ADVANCED_PAUSE_
   #endif
 
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_HEATING, mode);
+    lcd_pause_show_message(PAUSE_MESSAGE_HEATING, mode);
   #else
     UNUSED(mode);
   #endif
@@ -134,7 +137,7 @@ void do_pause_e_move(const float &length, const float &fr_mm_s) {
  */
 bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_length/*=0*/, const float &purge_length/*=0*/, const int8_t max_beep_count/*=0*/,
                    const bool show_lcd/*=false*/, const bool pause_for_user/*=false*/,
-                   const AdvancedPauseMode mode/*=ADVANCED_PAUSE_MODE_PAUSE_PRINT*/
+                   const PauseMode mode/*=PAUSE_MODE_PAUSE_PRINT*/
                    DXC_ARGS
 ) {
   #if !HAS_LCD_MENU
@@ -143,14 +146,14 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
 
   if (!ensure_safe_temperature(mode)) {
     #if HAS_LCD_MENU
-      if (show_lcd) lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_STATUS, mode);
+      if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_STATUS, mode);
     #endif
     return false;
   }
 
   if (pause_for_user) {
     #if HAS_LCD_MENU
-      if (show_lcd) lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_INSERT, mode);
+      if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_INSERT, mode);
     #endif
     SERIAL_ECHO_MSG(MSG_FILAMENT_CHANGE_INSERT);
 
@@ -186,7 +189,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
   }
 
   #if HAS_LCD_MENU
-    if (show_lcd) lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_LOAD, mode);
+    if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_LOAD, mode);
   #endif
 
   #if ENABLED(DUAL_X_CARRIAGE)
@@ -222,7 +225,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
   #if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
 
     #if HAS_LCD_MENU
-      if (show_lcd) lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_PURGE);
+      if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_PURGE);
     #endif
 
     wait_for_user = true;
@@ -239,7 +242,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
       if (purge_length > 0) {
         // "Wait for filament purge"
         #if HAS_LCD_MENU
-          if (show_lcd) lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_PURGE);
+          if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_PURGE);
         #endif
 
         // Extrude filament to get into hotend
@@ -269,8 +272,8 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
         if (show_lcd) {
           KEEPALIVE_STATE(PAUSED_FOR_USER);
           wait_for_user = false;
-          lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_OPTION);
-          while (advanced_pause_menu_response == ADVANCED_PAUSE_RESPONSE_WAIT_FOR) idle(true);
+          lcd_pause_show_message(PAUSE_MESSAGE_OPTION);
+          while (pause_menu_response == PAUSE_RESPONSE_WAIT_FOR) idle(true);
           KEEPALIVE_STATE(IN_HANDLER);
         }
       #endif
@@ -278,7 +281,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
       // Keep looping if "Purge More" was selected
     } while (false
       #if HAS_LCD_MENU
-        || (show_lcd && advanced_pause_menu_response == ADVANCED_PAUSE_RESPONSE_EXTRUDE_MORE)
+        || (show_lcd && pause_menu_response == PAUSE_RESPONSE_EXTRUDE_MORE)
       #endif
     );
 
@@ -298,7 +301,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
  * Returns 'true' if unload was completed, 'false' for abort
  */
 bool unload_filament(const float &unload_length, const bool show_lcd/*=false*/,
-                     const AdvancedPauseMode mode/*=ADVANCED_PAUSE_MODE_PAUSE_PRINT*/
+                     const PauseMode mode/*=PAUSE_MODE_PAUSE_PRINT*/
 ) {
   #if !HAS_LCD_MENU
     UNUSED(show_lcd);
@@ -306,14 +309,14 @@ bool unload_filament(const float &unload_length, const bool show_lcd/*=false*/,
 
   if (!ensure_safe_temperature(mode)) {
     #if HAS_LCD_MENU
-      if (show_lcd) lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_STATUS);
+      if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_STATUS);
     #endif
 
     return false;
   }
 
   #if HAS_LCD_MENU
-    if (show_lcd) lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_UNLOAD, mode);
+    if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_UNLOAD, mode);
   #endif
 
   // Retract filament
@@ -387,7 +390,7 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
 
     #if HAS_LCD_MENU
       if (show_lcd) { // Show status screen
-        lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_STATUS);
+        lcd_pause_show_message(PAUSE_MESSAGE_STATUS);
         LCD_MESSAGEPGM(MSG_M600_TOO_COLD);
       }
     #endif
@@ -464,7 +467,7 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
 
 void show_continue_prompt(const bool is_reload) {
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(is_reload ? ADVANCED_PAUSE_MESSAGE_INSERT : ADVANCED_PAUSE_MESSAGE_WAITING);
+    lcd_pause_show_message(is_reload ? PAUSE_MESSAGE_INSERT : PAUSE_MESSAGE_WAITING);
   #endif
   SERIAL_ECHO_START();
   serialprintPGM(is_reload ? PSTR(_PMSG(MSG_FILAMENT_CHANGE_INSERT) "\n") : PSTR(_PMSG(MSG_FILAMENT_CHANGE_WAIT) "\n"));
@@ -510,7 +513,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
     // re-heat the nozzle, re-show the continue prompt, restart idle timers, start over
     if (nozzle_timed_out) {
       #if HAS_LCD_MENU
-        lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_HEAT);
+        lcd_pause_show_message(PAUSE_MESSAGE_HEAT);
       #endif
       SERIAL_ECHO_MSG(_PMSG(MSG_FILAMENT_CHANGE_HEAT));
 
@@ -597,10 +600,10 @@ void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_le
   }
 
   if (nozzle_timed_out || thermalManager.hotEnoughToExtrude(active_extruder)) // Load the new filament
-    load_filament(slow_load_length, fast_load_length, purge_length, max_beep_count, true, nozzle_timed_out, ADVANCED_PAUSE_MODE_PAUSE_PRINT DXC_PASS);
+    load_filament(slow_load_length, fast_load_length, purge_length, max_beep_count, true, nozzle_timed_out, PAUSE_MODE_PAUSE_PRINT DXC_PASS);
 
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_RESUME);
+    lcd_pause_show_message(PAUSE_MESSAGE_RESUME);
   #endif
 
   // Intelligent resuming
@@ -628,7 +631,7 @@ void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_le
   planner.set_e_position_mm((destination[E_AXIS] = current_position[E_AXIS] = resume_position[E_AXIS]));
 
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_STATUS);
+    lcd_pause_show_message(PAUSE_MESSAGE_STATUS);
   #endif
 
   #ifdef ACTION_ON_RESUMED

--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -36,34 +36,36 @@ typedef struct {
 
 #include "../libs/nozzle.h"
 
-enum AdvancedPauseMode : char {
-  ADVANCED_PAUSE_MODE_SAME,
-  ADVANCED_PAUSE_MODE_PAUSE_PRINT,
-  ADVANCED_PAUSE_MODE_LOAD_FILAMENT,
-  ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT
+enum PauseMode : char {
+  PAUSE_MODE_SAME,
+  PAUSE_MODE_PAUSE_PRINT,
+  PAUSE_MODE_LOAD_FILAMENT,
+  PAUSE_MODE_UNLOAD_FILAMENT
 };
 
-enum AdvancedPauseMessage : char {
-  ADVANCED_PAUSE_MESSAGE_INIT,
-  ADVANCED_PAUSE_MESSAGE_WAITING,
-  ADVANCED_PAUSE_MESSAGE_UNLOAD,
-  ADVANCED_PAUSE_MESSAGE_INSERT,
-  ADVANCED_PAUSE_MESSAGE_LOAD,
-  ADVANCED_PAUSE_MESSAGE_PURGE,
-  ADVANCED_PAUSE_MESSAGE_OPTION,
-  ADVANCED_PAUSE_MESSAGE_RESUME,
-  ADVANCED_PAUSE_MESSAGE_STATUS,
-  ADVANCED_PAUSE_MESSAGE_HEAT,
-  ADVANCED_PAUSE_MESSAGE_HEATING
+enum PauseMessage : char {
+  PAUSE_MESSAGE_PAUSING,
+  PAUSE_MESSAGE_CHANGING,
+  PAUSE_MESSAGE_WAITING,
+  PAUSE_MESSAGE_UNLOAD,
+  PAUSE_MESSAGE_INSERT,
+  PAUSE_MESSAGE_LOAD,
+  PAUSE_MESSAGE_PURGE,
+  PAUSE_MESSAGE_OPTION,
+  PAUSE_MESSAGE_RESUME,
+  PAUSE_MESSAGE_STATUS,
+  PAUSE_MESSAGE_HEAT,
+  PAUSE_MESSAGE_HEATING
 };
 
-enum AdvancedPauseMenuResponse : char {
-  ADVANCED_PAUSE_RESPONSE_WAIT_FOR,
-  ADVANCED_PAUSE_RESPONSE_EXTRUDE_MORE,
-  ADVANCED_PAUSE_RESPONSE_RESUME_PRINT
+enum PauseMenuResponse : char {
+  PAUSE_RESPONSE_WAIT_FOR,
+  PAUSE_RESPONSE_EXTRUDE_MORE,
+  PAUSE_RESPONSE_RESUME_PRINT
 };
 
-extern AdvancedPauseMenuResponse advanced_pause_menu_response;
+extern PauseMode pause_mode;
+extern PauseMenuResponse pause_menu_response;
 
 extern fil_change_settings_t fc_settings[EXTRUDERS];
 
@@ -88,8 +90,8 @@ void wait_for_confirmation(const bool is_reload=false, const int8_t max_beep_cou
 void resume_print(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=ADVANCED_PAUSE_PURGE_LENGTH, const int8_t max_beep_count=0 DXC_PARAMS);
 
 bool load_filament(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=0, const int8_t max_beep_count=0, const bool show_lcd=false,
-                          const bool pause_for_user=false, const AdvancedPauseMode mode=ADVANCED_PAUSE_MODE_PAUSE_PRINT DXC_PARAMS);
+                          const bool pause_for_user=false, const PauseMode mode=PAUSE_MODE_PAUSE_PRINT DXC_PARAMS);
 
-bool unload_filament(const float &unload_length, const bool show_lcd=false, const AdvancedPauseMode mode=ADVANCED_PAUSE_MODE_PAUSE_PRINT);
+bool unload_filament(const float &unload_length, const bool show_lcd=false, const PauseMode mode=PAUSE_MODE_PAUSE_PRINT);
 
 #endif // ADVANCED_PAUSE_FEATURE

--- a/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
+++ b/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
@@ -45,16 +45,16 @@ void GcodeSuite::M207() {
 /**
  * M208: Set firmware un-retraction values
  *
- *   S[+units]    retract_recover_length (in addition to M207 S*)
- *   W[+units]    swap_retract_recover_length (multi-extruder)
+ *   S[+units]    retract_recover_extra (in addition to M207 S*)
+ *   W[+units]    swap_retract_recover_extra (multi-extruder)
  *   F[units/min] retract_recover_feedrate_mm_s
  *   R[units/min] swap_retract_recover_feedrate_mm_s
  */
 void GcodeSuite::M208() {
-  if (parser.seen('S')) fwretract.settings.retract_recover_length = parser.value_axis_units(E_AXIS);
+  if (parser.seen('S')) fwretract.settings.retract_recover_extra = parser.value_axis_units(E_AXIS);
   if (parser.seen('F')) fwretract.settings.retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
   if (parser.seen('R')) fwretract.settings.swap_retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-  if (parser.seen('W')) fwretract.settings.swap_retract_recover_length = parser.value_axis_units(E_AXIS);
+  if (parser.seen('W')) fwretract.settings.swap_retract_recover_extra = parser.value_axis_units(E_AXIS);
 }
 
 #if ENABLED(FWRETRACT_AUTORETRACT)

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -36,7 +36,7 @@
 #endif
 
 /**
- * M125: Store current position and move to filament change position.
+ * M125: Store current position and move to parking position.
  *       Called on pause (by M25) to prevent material leaking onto the
  *       object. On resume (M24) the head will be moved back and the
  *       print will resume.
@@ -79,14 +79,14 @@ void GcodeSuite::M125() {
   #endif
 
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_INIT, ADVANCED_PAUSE_MODE_PAUSE_PRINT);
+    lcd_pause_show_message(PAUSE_MESSAGE_PAUSING, PAUSE_MODE_PAUSE_PRINT);
     const bool show_lcd = parser.seenval('P');
   #else
     constexpr bool show_lcd = false;
   #endif
 
   if (pause_print(retract, park_point, 0, show_lcd)) {
-    if (!sd_printing || show_lcd ) {
+    if (!sd_printing || show_lcd) {
       wait_for_confirmation(false, 0);
       resume_print(0, 0, PAUSE_PARK_RETRACT_LENGTH, 0);
     }

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -76,7 +76,7 @@ void GcodeSuite::M600() {
 
   // Show initial "wait for start" message
   #if HAS_LCD_MENU && DISABLED(MMU2_MENUS)
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_INIT, ADVANCED_PAUSE_MODE_PAUSE_PRINT, target_extruder);
+    lcd_pause_show_message(PAUSE_MESSAGE_CHANGING, PAUSE_MODE_PAUSE_PRINT, target_extruder);
   #endif
 
   #if ENABLED(HOME_BEFORE_FILAMENT_CHANGE)

--- a/Marlin/src/gcode/feature/pause/M701_M702.cpp
+++ b/Marlin/src/gcode/feature/pause/M701_M702.cpp
@@ -68,7 +68,7 @@ void GcodeSuite::M701() {
 
   // Show initial "wait for load" message
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_LOAD, ADVANCED_PAUSE_MODE_LOAD_FILAMENT, target_extruder);
+    lcd_pause_show_message(PAUSE_MESSAGE_LOAD, PAUSE_MODE_LOAD_FILAMENT, target_extruder);
   #endif
 
   #if EXTRUDERS > 1 && DISABLED(PRUSA_MMU2)
@@ -90,7 +90,7 @@ void GcodeSuite::M701() {
     const float fast_load_length = ABS(parser.seen('L') ? parser.value_axis_units(E_AXIS)
                                                         : fc_settings[active_extruder].load_length);
     load_filament(slow_load_length, fast_load_length, ADVANCED_PAUSE_PURGE_LENGTH, FILAMENT_CHANGE_ALERT_BEEPS,
-                  true, thermalManager.still_heating(target_extruder), ADVANCED_PAUSE_MODE_LOAD_FILAMENT
+                  true, thermalManager.still_heating(target_extruder), PAUSE_MODE_LOAD_FILAMENT
                   #if ENABLED(DUAL_X_CARRIAGE)
                     , target_extruder
                   #endif
@@ -109,7 +109,7 @@ void GcodeSuite::M701() {
 
   // Show status screen
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_STATUS);
+    lcd_pause_show_message(PAUSE_MESSAGE_STATUS);
   #endif
 }
 
@@ -139,7 +139,7 @@ void GcodeSuite::M702() {
 
   // Show initial "wait for unload" message
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_UNLOAD, ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT, target_extruder);
+    lcd_pause_show_message(PAUSE_MESSAGE_UNLOAD, PAUSE_MODE_UNLOAD_FILAMENT, target_extruder);
   #endif
 
   #if EXTRUDERS > 1 && DISABLED(PRUSA_MMU2)
@@ -161,7 +161,7 @@ void GcodeSuite::M702() {
       if (!parser.seenval('T')) {
         HOTEND_LOOP() {
           if (e != active_extruder) tool_change(e, 0, false);
-          unload_filament(-fc_settings[e].unload_length, true, ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT);
+          unload_filament(-fc_settings[e].unload_length, true, PAUSE_MODE_UNLOAD_FILAMENT);
         }
       }
       else
@@ -171,7 +171,7 @@ void GcodeSuite::M702() {
       const float unload_length = -ABS(parser.seen('U') ? parser.value_axis_units(E_AXIS)
                                                         : fc_settings[target_extruder].unload_length);
 
-      unload_filament(unload_length, true, ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT);
+      unload_filament(unload_length, true, PAUSE_MODE_UNLOAD_FILAMENT);
     }
   #endif
 
@@ -187,7 +187,7 @@ void GcodeSuite::M702() {
 
   // Show status screen
   #if HAS_LCD_MENU
-    lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_STATUS);
+    lcd_pause_show_message(PAUSE_MESSAGE_STATUS);
   #endif
 }
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1278,6 +1278,9 @@
     #define MSG_ADVANCED_PAUSE_WAITING_1      _UxGT("Press button")
     #define MSG_ADVANCED_PAUSE_WAITING_2      _UxGT("to resume print")
   #endif
+  #ifndef MSG_PAUSE_PRINT_INIT_1
+    #define MSG_PAUSE_PRINT_INIT_1            _UxGT("Parking...")
+  #endif
   #ifndef MSG_FILAMENT_CHANGE_INIT_1
     #define MSG_FILAMENT_CHANGE_INIT_1        _UxGT("Wait for")
     #define MSG_FILAMENT_CHANGE_INIT_2        _UxGT("filament change")

--- a/Marlin/src/lcd/language/language_zh_CN.h
+++ b/Marlin/src/lcd/language/language_zh_CN.h
@@ -256,8 +256,8 @@
 #define MSG_CONTROL_RETRACT_SWAP            _UxGT("换手回抽长度mm")  //"Swap Re.mm" swap_retract_length, swap retract length (positive mm), for extruder change
 #define MSG_CONTROL_RETRACTF                _UxGT("回抽速率mm/s")  //"Retract  V" retract_feedrate_mm_s, feedrate for retracting (mm/s)
 #define MSG_CONTROL_RETRACT_ZHOP            _UxGT("Hop mm")  //"Hop mm" retract_zraise, retract Z-lift
-#define MSG_CONTROL_RETRACT_RECOVER         _UxGT("回抽恢复长度mm")  //"UnRet +mm" retract_recover_length, additional recover length (mm, added to retract length when recovering)
-#define MSG_CONTROL_RETRACT_RECOVER_SWAP    _UxGT("换手回抽恢复长度mm")  //"S UnRet+mm" swap_retract_recover_length, additional swap recover length (mm, added to retract length when recovering from extruder change)
+#define MSG_CONTROL_RETRACT_RECOVER         _UxGT("回抽恢复长度mm")  //"UnRet +mm" retract_recover_extra, additional recover length (mm, added to retract length when recovering)
+#define MSG_CONTROL_RETRACT_RECOVER_SWAP    _UxGT("换手回抽恢复长度mm")  //"S UnRet+mm" swap_retract_recover_extra, additional swap recover length (mm, added to retract length when recovering from extruder change)
 #define MSG_CONTROL_RETRACT_RECOVERF        _UxGT("回抽恢复后进料速率mm/s")  //"UnRet  V" retract_recover_feedrate_mm_s, feedrate for recovering from retraction (mm/s)
 #define MSG_CONTROL_RETRACT_RECOVER_SWAPF   _UxGT("S UnRet V") // "S UnRet V"
 #define MSG_AUTORETRACT                     _UxGT("自动抽回")  //"AutoRetr." autoretract_enabled,

--- a/Marlin/src/lcd/language/language_zh_TW.h
+++ b/Marlin/src/lcd/language/language_zh_TW.h
@@ -256,8 +256,8 @@
 #define MSG_CONTROL_RETRACT_SWAP            _UxGT("換手回抽長度mm")  //"Swap Re.mm" swap_retract_length, swap retract length (positive mm), for extruder change
 #define MSG_CONTROL_RETRACTF                _UxGT("回縮速率mm/s")  //"Retract  V" retract_feedrate_mm_s, feedrate for retracting (mm/s)
 #define MSG_CONTROL_RETRACT_ZHOP            _UxGT("Hop mm")  //"Hop mm" retract_zraise, retract Z-lift
-#define MSG_CONTROL_RETRACT_RECOVER         _UxGT("回縮恢復長度mm")  //"UnRet +mm" retract_recover_length, additional recover length (mm, added to retract length when recovering)
-#define MSG_CONTROL_RETRACT_RECOVER_SWAP    _UxGT("換手回縮恢復長度mm")  //"S UnRet+mm" swap_retract_recover_length, additional swap recover length (mm, added to retract length when recovering from extruder change)
+#define MSG_CONTROL_RETRACT_RECOVER         _UxGT("回縮恢復長度mm")  //"UnRet +mm" retract_recover_extra, additional recover length (mm, added to retract length when recovering)
+#define MSG_CONTROL_RETRACT_RECOVER_SWAP    _UxGT("換手回縮恢復長度mm")  //"S UnRet+mm" swap_retract_recover_extra, additional swap recover length (mm, added to retract length when recovering from extruder change)
 #define MSG_CONTROL_RETRACT_RECOVERF        _UxGT("回縮恢復後進料速率mm/s")  //"UnRet V" retract_recover_feedrate_mm_s, feedrate for recovering from retraction (mm/s)
 #define MSG_CONTROL_RETRACT_RECOVER_SWAPF   _UxGT("S UnRet V") // "S UnRet V"
 #define MSG_AUTORETRACT                     _UxGT("自動回縮")  //"AutoRetr." autoretract_enabled,

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -196,9 +196,9 @@ static void lcd_factory_settings() {
     #endif
     MENU_ITEM_EDIT(float3, MSG_CONTROL_RETRACTF, &fwretract.settings.retract_feedrate_mm_s, 1, 999);
     MENU_ITEM_EDIT(float52sign, MSG_CONTROL_RETRACT_ZHOP, &fwretract.settings.retract_zraise, 0, 999);
-    MENU_ITEM_EDIT(float52sign, MSG_CONTROL_RETRACT_RECOVER, &fwretract.settings.retract_recover_length, -100, 100);
+    MENU_ITEM_EDIT(float52sign, MSG_CONTROL_RETRACT_RECOVER, &fwretract.settings.retract_recover_extra, -100, 100);
     #if EXTRUDERS > 1
-      MENU_ITEM_EDIT(float52sign, MSG_CONTROL_RETRACT_RECOVER_SWAP, &fwretract.settings.swap_retract_recover_length, -100, 100);
+      MENU_ITEM_EDIT(float52sign, MSG_CONTROL_RETRACT_RECOVER_SWAP, &fwretract.settings.swap_retract_recover_extra, -100, 100);
     #endif
     MENU_ITEM_EDIT(float3, MSG_CONTROL_RETRACT_RECOVERF, &fwretract.settings.retract_recover_feedrate_mm_s, 1, 999);
     #if EXTRUDERS > 1

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -34,19 +34,20 @@
 #if HAS_FILAMENT_SENSOR
   #include "../../feature/runout.h"
 #endif
+
 //
 // Change Filament > Change/Unload/Load Filament
 //
-static AdvancedPauseMode _change_filament_temp_mode; // =ADVANCED_PAUSE_MODE_PAUSE_PRINT
+static PauseMode _change_filament_temp_mode; // =PAUSE_MODE_PAUSE_PRINT
 static int8_t _change_filament_temp_extruder; // =0
 
 inline PGM_P _change_filament_temp_command() {
   switch (_change_filament_temp_mode) {
-    case ADVANCED_PAUSE_MODE_LOAD_FILAMENT:
+    case PAUSE_MODE_LOAD_FILAMENT:
       return PSTR("M701 T%d");
-    case ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT:
+    case PAUSE_MODE_UNLOAD_FILAMENT:
       return _change_filament_temp_extruder >= 0 ? PSTR("M702 T%d") : PSTR("M702 ;%d");
-    case ADVANCED_PAUSE_MODE_PAUSE_PRINT:
+    case PAUSE_MODE_PAUSE_PRINT:
     default:
       return PSTR("M600 B0 T%d");
   }
@@ -63,18 +64,18 @@ inline void _lcd_change_filament_temp_1_func()    { _change_filament_temp(ui.pre
 inline void _lcd_change_filament_temp_2_func()    { _change_filament_temp(ui.preheat_hotend_temp[1]); }
 inline void _lcd_change_filament_temp_custom_cb() { _change_filament_temp(thermalManager.temp_hotend[_change_filament_temp_extruder].target); }
 
-static PGM_P change_filament_header(const AdvancedPauseMode mode) {
+static PGM_P change_filament_header(const PauseMode mode) {
   switch (mode) {
-    case ADVANCED_PAUSE_MODE_LOAD_FILAMENT:
+    case PAUSE_MODE_LOAD_FILAMENT:
       return PSTR(MSG_FILAMENTLOAD);
-    case ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT:
+    case PAUSE_MODE_UNLOAD_FILAMENT:
       return PSTR(MSG_FILAMENTUNLOAD);
     default: break;
   }
   return PSTR(MSG_FILAMENTCHANGE);
 }
 
-void _menu_temp_filament_op(const AdvancedPauseMode mode, const int8_t extruder) {
+void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
   _change_filament_temp_mode = mode;
   _change_filament_temp_extruder = extruder;
   START_MENU();
@@ -105,28 +106,28 @@ void _menu_temp_filament_op(const AdvancedPauseMode mode, const int8_t extruder)
   END_MENU();
 }
 #if E_STEPPERS
-  void menu_temp_e0_filament_change()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_PAUSE_PRINT, 0); }
-  void menu_temp_e0_filament_load()    { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_LOAD_FILAMENT, 0); }
-  void menu_temp_e0_filament_unload()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT, 0); }
+  void menu_temp_e0_filament_change()  { _menu_temp_filament_op(PAUSE_MODE_PAUSE_PRINT, 0); }
+  void menu_temp_e0_filament_load()    { _menu_temp_filament_op(PAUSE_MODE_LOAD_FILAMENT, 0); }
+  void menu_temp_e0_filament_unload()  { _menu_temp_filament_op(PAUSE_MODE_UNLOAD_FILAMENT, 0); }
   #if E_STEPPERS > 1
-    void menu_temp_e1_filament_change()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_PAUSE_PRINT, 1); }
-    void menu_temp_e1_filament_load()    { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_LOAD_FILAMENT, 1); }
-    void menu_temp_e1_filament_unload()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT, 1); }
+    void menu_temp_e1_filament_change()  { _menu_temp_filament_op(PAUSE_MODE_PAUSE_PRINT, 1); }
+    void menu_temp_e1_filament_load()    { _menu_temp_filament_op(PAUSE_MODE_LOAD_FILAMENT, 1); }
+    void menu_temp_e1_filament_unload()  { _menu_temp_filament_op(PAUSE_MODE_UNLOAD_FILAMENT, 1); }
     #if ENABLED(FILAMENT_UNLOAD_ALL_EXTRUDERS)
-      void menu_unload_filament_all_temp() { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT, -1); }
+      void menu_unload_filament_all_temp() { _menu_temp_filament_op(PAUSE_MODE_UNLOAD_FILAMENT, -1); }
     #endif
     #if E_STEPPERS > 2
-      void menu_temp_e2_filament_change()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_PAUSE_PRINT, 2); }
-      void menu_temp_e2_filament_load()    { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_LOAD_FILAMENT, 2); }
-      void menu_temp_e2_filament_unload()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT, 2); }
+      void menu_temp_e2_filament_change()  { _menu_temp_filament_op(PAUSE_MODE_PAUSE_PRINT, 2); }
+      void menu_temp_e2_filament_load()    { _menu_temp_filament_op(PAUSE_MODE_LOAD_FILAMENT, 2); }
+      void menu_temp_e2_filament_unload()  { _menu_temp_filament_op(PAUSE_MODE_UNLOAD_FILAMENT, 2); }
       #if E_STEPPERS > 3
-        void menu_temp_e3_filament_change()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_PAUSE_PRINT, 3); }
-        void menu_temp_e3_filament_load()    { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_LOAD_FILAMENT, 3); }
-        void menu_temp_e3_filament_unload()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT, 3); }
+        void menu_temp_e3_filament_change()  { _menu_temp_filament_op(PAUSE_MODE_PAUSE_PRINT, 3); }
+        void menu_temp_e3_filament_load()    { _menu_temp_filament_op(PAUSE_MODE_LOAD_FILAMENT, 3); }
+        void menu_temp_e3_filament_unload()  { _menu_temp_filament_op(PAUSE_MODE_UNLOAD_FILAMENT, 3); }
         #if E_STEPPERS > 4
-          void menu_temp_e4_filament_change()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_PAUSE_PRINT, 4); }
-          void menu_temp_e4_filament_load()    { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_LOAD_FILAMENT, 4); }
-          void menu_temp_e4_filament_unload()  { _menu_temp_filament_op(ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT, 4); }
+          void menu_temp_e4_filament_change()  { _menu_temp_filament_op(PAUSE_MODE_PAUSE_PRINT, 4); }
+          void menu_temp_e4_filament_load()    { _menu_temp_filament_op(PAUSE_MODE_LOAD_FILAMENT, 4); }
+          void menu_temp_e4_filament_unload()  { _menu_temp_filament_op(PAUSE_MODE_UNLOAD_FILAMENT, 4); }
         #endif // E_STEPPERS > 4
       #endif // E_STEPPERS > 3
     #endif // E_STEPPERS > 2
@@ -310,14 +311,13 @@ void _menu_temp_filament_op(const AdvancedPauseMode mode, const int8_t extruder)
   }
 #endif
 
-static AdvancedPauseMode advanced_pause_mode = ADVANCED_PAUSE_MODE_PAUSE_PRINT;
 static uint8_t hotend_status_extruder = 0;
 
-static PGM_P advanced_pause_header() {
-  switch (advanced_pause_mode) {
-    case ADVANCED_PAUSE_MODE_LOAD_FILAMENT:
+static PGM_P pause_header() {
+  switch (pause_mode) {
+    case PAUSE_MODE_LOAD_FILAMENT:
       return PSTR(MSG_FILAMENT_CHANGE_HEADER_LOAD);
-    case ADVANCED_PAUSE_MODE_UNLOAD_FILAMENT:
+    case PAUSE_MODE_UNLOAD_FILAMENT:
       return PSTR(MSG_FILAMENT_CHANGE_HEADER_UNLOAD);
     default: break;
   }
@@ -340,26 +340,26 @@ static PGM_P advanced_pause_header() {
   ++_thisItemNr; \
 }while(0)
 
-void lcd_advanced_pause_resume_print() {
-  advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_RESUME_PRINT;
+void lcd_pause_resume_print() {
+  pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT;
 }
 
-void lcd_advanced_pause_extrude_more() {
-  advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_EXTRUDE_MORE;
+void lcd_pause_extrude_more() {
+  pause_menu_response = PAUSE_RESPONSE_EXTRUDE_MORE;
 }
 
-void menu_advanced_pause_option() {
+void menu_pause_option() {
   START_MENU();
   #if LCD_HEIGHT > 2
     STATIC_ITEM(MSG_FILAMENT_CHANGE_OPTION_HEADER, true, false);
   #endif
-  MENU_ITEM(function, MSG_FILAMENT_CHANGE_OPTION_PURGE, lcd_advanced_pause_extrude_more);
+  MENU_ITEM(function, MSG_FILAMENT_CHANGE_OPTION_PURGE, lcd_pause_extrude_more);
   #if HAS_FILAMENT_SENSOR
     if (runout.filament_ran_out)
       MENU_ITEM_EDIT_CALLBACK(bool, MSG_RUNOUT_SENSOR, &runout.enabled, runout.reset);
     else
   #endif
-      MENU_ITEM(function, MSG_FILAMENT_CHANGE_OPTION_RESUME, lcd_advanced_pause_resume_print);
+      MENU_ITEM(function, MSG_FILAMENT_CHANGE_OPTION_RESUME, lcd_pause_resume_print);
   END_MENU();
 }
 
@@ -367,9 +367,9 @@ void menu_advanced_pause_option() {
 // ADVANCED_PAUSE_FEATURE message screens
 //
 
-void _lcd_advanced_pause_message(PGM_P const msg1, PGM_P const msg2=NULL, PGM_P const msg3=NULL) {
+void _lcd_pause_message(PGM_P const msg1, PGM_P const msg2=NULL, PGM_P const msg3=NULL) {
   START_SCREEN();
-  STATIC_ITEM_P(advanced_pause_header(), true, true);
+  STATIC_ITEM_P(pause_header(), true, true);
   STATIC_ITEM_P(msg1);
   if (msg2) STATIC_ITEM_P(msg2);
   if (msg3) STATIC_ITEM_P(msg3);
@@ -378,8 +378,19 @@ void _lcd_advanced_pause_message(PGM_P const msg1, PGM_P const msg2=NULL, PGM_P 
   END_SCREEN();
 }
 
-void lcd_advanced_pause_init_message() {
-  _lcd_advanced_pause_message(PSTR(MSG_FILAMENT_CHANGE_INIT_1)
+void lcd_pause_pausing_message() {
+  _lcd_pause_message(PSTR(MSG_PAUSE_PRINT_INIT_1)
+    #ifdef MSG_PAUSE_PRINT_INIT_2
+      , PSTR(MSG_PAUSE_PRINT_INIT_2)
+      #ifdef MSG_PAUSE_PRINT_INIT_3
+        , PSTR(MSG_PAUSE_PRINT_INIT_3)
+      #endif
+    #endif
+  );
+}
+
+void lcd_pause_changing_message() {
+  _lcd_pause_message(PSTR(MSG_FILAMENT_CHANGE_INIT_1)
     #ifdef MSG_FILAMENT_CHANGE_INIT_2
       , PSTR(MSG_FILAMENT_CHANGE_INIT_2)
       #ifdef MSG_FILAMENT_CHANGE_INIT_3
@@ -389,8 +400,8 @@ void lcd_advanced_pause_init_message() {
   );
 }
 
-void lcd_advanced_pause_unload_message() {
-  _lcd_advanced_pause_message(PSTR(MSG_FILAMENT_CHANGE_UNLOAD_1)
+void lcd_pause_unload_message() {
+  _lcd_pause_message(PSTR(MSG_FILAMENT_CHANGE_UNLOAD_1)
     #ifdef MSG_FILAMENT_CHANGE_UNLOAD_2
       , PSTR(MSG_FILAMENT_CHANGE_UNLOAD_2)
       #ifdef MSG_FILAMENT_CHANGE_UNLOAD_3
@@ -400,8 +411,8 @@ void lcd_advanced_pause_unload_message() {
   );
 }
 
-void lcd_advanced_pause_heating_message() {
-  _lcd_advanced_pause_message(PSTR(MSG_FILAMENT_CHANGE_HEATING_1)
+void lcd_pause_heating_message() {
+  _lcd_pause_message(PSTR(MSG_FILAMENT_CHANGE_HEATING_1)
     #ifdef MSG_FILAMENT_CHANGE_HEATING_2
       , PSTR(MSG_FILAMENT_CHANGE_HEATING_2)
       #ifdef MSG_FILAMENT_CHANGE_HEATING_3
@@ -411,8 +422,8 @@ void lcd_advanced_pause_heating_message() {
   );
 }
 
-void lcd_advanced_pause_heat_message() {
-  _lcd_advanced_pause_message(PSTR(MSG_FILAMENT_CHANGE_HEAT_1)
+void lcd_pause_heat_message() {
+  _lcd_pause_message(PSTR(MSG_FILAMENT_CHANGE_HEAT_1)
     #ifdef MSG_FILAMENT_CHANGE_HEAT_2
       , PSTR(MSG_FILAMENT_CHANGE_HEAT_2)
       #ifdef MSG_FILAMENT_CHANGE_HEAT_3
@@ -422,8 +433,8 @@ void lcd_advanced_pause_heat_message() {
   );
 }
 
-void lcd_advanced_pause_insert_message() {
-  _lcd_advanced_pause_message(PSTR(MSG_FILAMENT_CHANGE_INSERT_1)
+void lcd_pause_insert_message() {
+  _lcd_pause_message(PSTR(MSG_FILAMENT_CHANGE_INSERT_1)
     #ifdef MSG_FILAMENT_CHANGE_INSERT_2
       , PSTR(MSG_FILAMENT_CHANGE_INSERT_2)
       #ifdef MSG_FILAMENT_CHANGE_INSERT_3
@@ -433,8 +444,8 @@ void lcd_advanced_pause_insert_message() {
   );
 }
 
-void lcd_advanced_pause_load_message() {
-  _lcd_advanced_pause_message(PSTR(MSG_FILAMENT_CHANGE_LOAD_1)
+void lcd_pause_load_message() {
+  _lcd_pause_message(PSTR(MSG_FILAMENT_CHANGE_LOAD_1)
     #ifdef MSG_FILAMENT_CHANGE_LOAD_2
       , PSTR(MSG_FILAMENT_CHANGE_LOAD_2)
       #ifdef MSG_FILAMENT_CHANGE_LOAD_3
@@ -444,8 +455,8 @@ void lcd_advanced_pause_load_message() {
   );
 }
 
-void lcd_advanced_pause_waiting_message() {
-  _lcd_advanced_pause_message(PSTR(MSG_ADVANCED_PAUSE_WAITING_1)
+void lcd_pause_waiting_message() {
+  _lcd_pause_message(PSTR(MSG_ADVANCED_PAUSE_WAITING_1)
     #ifdef MSG_ADVANCED_PAUSE_WAITING_2
       , PSTR(MSG_ADVANCED_PAUSE_WAITING_2)
       #ifdef MSG_ADVANCED_PAUSE_WAITING_3
@@ -455,8 +466,8 @@ void lcd_advanced_pause_waiting_message() {
   );
 }
 
-void lcd_advanced_pause_resume_message() {
-  _lcd_advanced_pause_message(PSTR(MSG_FILAMENT_CHANGE_RESUME_1)
+void lcd_pause_resume_message() {
+  _lcd_pause_message(PSTR(MSG_FILAMENT_CHANGE_RESUME_1)
     #ifdef MSG_FILAMENT_CHANGE_RESUME_2
       , PSTR(MSG_FILAMENT_CHANGE_RESUME_2)
       #ifdef MSG_FILAMENT_CHANGE_RESUME_3
@@ -466,8 +477,8 @@ void lcd_advanced_pause_resume_message() {
   );
 }
 
-void lcd_advanced_pause_purge_message() {
-  _lcd_advanced_pause_message(
+void lcd_pause_purge_message() {
+  _lcd_pause_message(
     #if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
       PSTR(MSG_FILAMENT_CHANGE_CONT_PURGE_1)
       #ifdef MSG_FILAMENT_CHANGE_CONT_PURGE_2
@@ -488,31 +499,32 @@ void lcd_advanced_pause_purge_message() {
   );
 }
 
-FORCE_INLINE screenFunc_t ap_message_screen(const AdvancedPauseMessage message) {
+FORCE_INLINE screenFunc_t ap_message_screen(const PauseMessage message) {
   switch (message) {
-    case ADVANCED_PAUSE_MESSAGE_INIT:     return lcd_advanced_pause_init_message;
-    case ADVANCED_PAUSE_MESSAGE_UNLOAD:   return lcd_advanced_pause_unload_message;
-    case ADVANCED_PAUSE_MESSAGE_WAITING:  return lcd_advanced_pause_waiting_message;
-    case ADVANCED_PAUSE_MESSAGE_INSERT:   return lcd_advanced_pause_insert_message;
-    case ADVANCED_PAUSE_MESSAGE_LOAD:     return lcd_advanced_pause_load_message;
-    case ADVANCED_PAUSE_MESSAGE_PURGE:    return lcd_advanced_pause_purge_message;
-    case ADVANCED_PAUSE_MESSAGE_RESUME:   return lcd_advanced_pause_resume_message;
-    case ADVANCED_PAUSE_MESSAGE_HEAT:     return lcd_advanced_pause_heat_message;
-    case ADVANCED_PAUSE_MESSAGE_HEATING:  return lcd_advanced_pause_heating_message;
-    case ADVANCED_PAUSE_MESSAGE_OPTION:   advanced_pause_menu_response = ADVANCED_PAUSE_RESPONSE_WAIT_FOR;
-                                          return menu_advanced_pause_option;
-    case ADVANCED_PAUSE_MESSAGE_STATUS:
+    case PAUSE_MESSAGE_PAUSING:  return lcd_pause_pausing_message;
+    case PAUSE_MESSAGE_CHANGING: return lcd_pause_changing_message;
+    case PAUSE_MESSAGE_UNLOAD:   return lcd_pause_unload_message;
+    case PAUSE_MESSAGE_WAITING:  return lcd_pause_waiting_message;
+    case PAUSE_MESSAGE_INSERT:   return lcd_pause_insert_message;
+    case PAUSE_MESSAGE_LOAD:     return lcd_pause_load_message;
+    case PAUSE_MESSAGE_PURGE:    return lcd_pause_purge_message;
+    case PAUSE_MESSAGE_RESUME:   return lcd_pause_resume_message;
+    case PAUSE_MESSAGE_HEAT:     return lcd_pause_heat_message;
+    case PAUSE_MESSAGE_HEATING:  return lcd_pause_heating_message;
+    case PAUSE_MESSAGE_OPTION:   pause_menu_response = PAUSE_RESPONSE_WAIT_FOR;
+                                          return menu_pause_option;
+    case PAUSE_MESSAGE_STATUS:
     default: break;
   }
   return NULL;
 }
 
-void lcd_advanced_pause_show_message(
-  const AdvancedPauseMessage message,
-  const AdvancedPauseMode mode/*=ADVANCED_PAUSE_MODE_SAME*/,
+void lcd_pause_show_message(
+  const PauseMessage message,
+  const PauseMode mode/*=PAUSE_MODE_SAME*/,
   const uint8_t extruder/*=active_extruder*/
 ) {
-  if (mode != ADVANCED_PAUSE_MODE_SAME) advanced_pause_mode = mode;
+  if (mode != PAUSE_MODE_SAME) pause_mode = mode;
   hotend_status_extruder = extruder;
   const screenFunc_t next_screen = ap_message_screen(message);
   if (next_screen) {

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -61,7 +61,7 @@
     #endif
 
     #if ENABLED(PARK_HEAD_ON_PAUSE)
-      lcd_advanced_pause_show_message(ADVANCED_PAUSE_MESSAGE_INIT, ADVANCED_PAUSE_MODE_PAUSE_PRINT);  // Show message immediately to let user know about pause in progress
+      lcd_pause_show_message(PAUSE_MESSAGE_PAUSING, PAUSE_MODE_PAUSE_PRINT);  // Show message immediately to let user know about pause in progress
       enqueue_and_echo_commands_P(PSTR("M25 P\nM24"));
     #elif ENABLED(SDSUPPORT)
       enqueue_and_echo_commands_P(PSTR("M25"));

--- a/Marlin/src/lcd/menu/menu_mmu2.cpp
+++ b/Marlin/src/lcd/menu/menu_mmu2.cpp
@@ -183,7 +183,7 @@ inline void action_mmu2_M600_loadCurrentFilamentToNozzle() { mmu2.loadFilamentTo
 inline void action_mmu2_M600_unloadFilament()              { mmu2.unload(); }
 inline void action_mmu2_M600_resume()                      { mmuMenuWait = false; }
 
-void menu_mmu2_advanced_pause() {
+void menu_mmu2_pause() {
   currentTool = mmu2.getCurrentTool();
   START_MENU();
   #if LCD_HEIGHT > 2
@@ -198,7 +198,7 @@ void menu_mmu2_advanced_pause() {
 
 void mmu2_M600() {
   ui.defer_status_screen(true);
-  ui.goto_screen(menu_mmu2_advanced_pause);
+  ui.goto_screen(menu_mmu2_pause);
   mmuMenuWait = true;
   while (mmuMenuWait) idle();
 }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -89,8 +89,8 @@
     extern float move_menu_scale;
 
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
-      void lcd_advanced_pause_show_message(const AdvancedPauseMessage message,
-                                           const AdvancedPauseMode mode=ADVANCED_PAUSE_MODE_SAME,
+      void lcd_pause_show_message(const PauseMessage message,
+                                           const PauseMode mode=PAUSE_MODE_SAME,
                                            const uint8_t extruder=active_extruder);
     #endif
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2752,8 +2752,8 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
       CONFIG_ECHO_START();
       SERIAL_ECHOLNPAIR(
-          "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_length)
-        , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_length)
+          "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_extra)
+        , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_extra)
         , " F", MMS_TO_MMM(LINEAR_UNIT(fwretract.settings.retract_recover_feedrate_mm_s))
       );
 


### PR DESCRIPTION
- Display "Parking..." when the nozzle is moving to the park position on print pause.
- Don't play the beeps associated with filament change when just pausing.
- Shorten symbol names for advanced pause, to raise it to a more core element.