### PR TITLE
[2.0.x] PWM is not defined on Arduino Core STM32

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
@@ -45,6 +45,10 @@ void FastIO_init(); // Must be called before using fast io macros
 
 #define _BV32(b) (1UL << (b))
 
+#if !defined(PWM)
+  #define PWM OUTPUT
+#endif
+
 #if defined(STM32F0xx) || defined(STM32F1xx) || defined(STM32F3xx) || defined(STM32L0xx) || defined(STM32L4xx)
   #define _WRITE(IO, V) do { \
     if (V) FastIOPortMap[STM_PORT(digitalPin[IO])]->BSRR = _BV32(STM_PIN(digitalPin[IO])) ; \


### PR DESCRIPTION
### Description

PR #13383 breaks build on HAL_STM32 as `PWM` is not defined in Arduino Core STM32

### Benefits

HAL_STM32 builds again.

### Related Issues

#13383 
