### PR TITLE
Fixes #13410 and redeclaration BUTTON_EXISTS

### DIFF
--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -187,6 +187,7 @@
 
 #else
 
+  #undef BUTTON_EXISTS
   #define BUTTON_EXISTS(BN) false
 
   // Shift register bits correspond to buttons:

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -824,8 +824,7 @@ float Temperature::get_pid_output(const int8_t e) {
           MSG_PID_DEBUG_ITERM, work_pid[HOTEND_INDEX].Ki,
           MSG_PID_DEBUG_DTERM, work_pid[HOTEND_INDEX].Kd
           #if ENABLED(PID_EXTRUSION_SCALING)
-            ,
-            MSG_PID_DEBUG_CTERM, work_pid[HOTEND_INDEX].Kc
+            , MSG_PID_DEBUG_CTERM, work_pid[HOTEND_INDEX].Kc
           #endif
         );
       #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -823,7 +823,8 @@ float Temperature::get_pid_output(const int8_t e) {
           MSG_PID_DEBUG_PTERM, work_pid[HOTEND_INDEX].Kp,
           MSG_PID_DEBUG_ITERM, work_pid[HOTEND_INDEX].Ki,
           MSG_PID_DEBUG_DTERM, work_pid[HOTEND_INDEX].Kd
-          #if ENABLED(PID_EXTRUSION_SCALING),
+          #if ENABLED(PID_EXTRUSION_SCALING)
+            ,
             MSG_PID_DEBUG_CTERM, work_pid[HOTEND_INDEX].Kc
           #endif
         );


### PR DESCRIPTION
1. see issue https://github.com/MarlinFirmware/Marlin/issues/13410

2. without LCD declaration is BUTTON_EXISTS redeclaration