### PR TITLE
[bf2] Fix Fan 0 responding to all fan speeds. 

### DIFF
--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -58,8 +58,8 @@ void GcodeSuite::M106() {
       const uint16_t t = parser.intval('T');
       if (t > 0) return thermalManager.set_temp_fan_speed(p, t);
     #endif
-
-    uint16_t s = parser.ushortval('S', 255);
+    uint16_t d = parser.seen('A') ? thermalManager.fan_speed[active_extruder] : 255;
+    uint16_t s = parser.ushortval('S', d);
     NOMORE(s, 255U);
 
     thermalManager.set_fan_speed(p, s);

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2379,7 +2379,7 @@ void Temperature::isr() {
       #if ENABLED(FAN_SOFT_PWM)
         #define _FAN_PWM(N) do{ \
           soft_pwm_count_fan[N] = (soft_pwm_count_fan[N] & pwm_mask) + (soft_pwm_amount_fan[N] >> 1); \
-          WRITE_FAN(soft_pwm_count_fan[N] > pwm_mask ? HIGH : LOW); \
+          WRITE_FAN_N(N,soft_pwm_count_fan[N] > pwm_mask ? HIGH : LOW); \
         }while(0)
         #if HAS_FAN0
           _FAN_PWM(0);

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2379,7 +2379,7 @@ void Temperature::isr() {
       #if ENABLED(FAN_SOFT_PWM)
         #define _FAN_PWM(N) do{ \
           soft_pwm_count_fan[N] = (soft_pwm_count_fan[N] & pwm_mask) + (soft_pwm_amount_fan[N] >> 1); \
-          WRITE_FAN_N(N,soft_pwm_count_fan[N] > pwm_mask ? HIGH : LOW); \
+          WRITE_FAN_N(N, soft_pwm_count_fan[N] > pwm_mask ? HIGH : LOW); \
         }while(0)
         #if HAS_FAN0
           _FAN_PWM(0);


### PR DESCRIPTION
This PR is a small fix for preventing Fan 0 from responding to all set fan speeds. This has the effect of needing every other fan to be set to 100% to drive Fan0, and stops other fans from running at all. 