### PR TITLE
Proceed with Teensy 3.5/3.6 HAL

### DIFF
--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL.h
@@ -58,9 +58,6 @@
 // Defines
 // --------------------------------------------------------------------------
 
-#undef MOTHERBOARD
-#define MOTHERBOARD BOARD_TEENSY35_36
-
 #define IS_32BIT_TEENSY (defined(__MK64FX512__) || defined(__MK66FX1M0__))
 #define IS_TEENSY35 defined(__MK64FX512__)
 #define IS_TEENSY36 defined(__MK66FX1M0__)

--- a/buildroot/share/tests/teensy35-tests
+++ b/buildroot/share/tests/teensy35-tests
@@ -15,6 +15,7 @@ exec_test $1 $2 "Teensy3.5 with default config"
 # Test as many features together as possible
 #
 restore_configs
+opt_set MOTHERBOARD BOARD_TEENSY35_36
 opt_set EXTRUDERS 2
 opt_set TEMP_SENSOR_0 1
 opt_set TEMP_SENSOR_1 5
@@ -35,6 +36,7 @@ exec_test $1 $2 "Teensy3.5 with many features"
 # Test a Sled Z Probe with Linear leveling
 #
 restore_configs
+opt_set MOTHERBOARD BOARD_TEENSY35_36
 opt_enable EEPROM_SETTINGS Z_PROBE_SLED AUTO_BED_LEVELING_LINEAR DEBUG_LEVELING_FEATURE GCODE_MACROS
 exec_test $1 $2 "Sled Z Probe with Linear leveling"
 
@@ -42,6 +44,7 @@ exec_test $1 $2 "Sled Z Probe with Linear leveling"
 # Test a Servo Probe
 #
 # restore_configs
+# opt_set MOTHERBOARD BOARD_TEENSY35_36
 # opt_enable Z_PROBE_SERVO_NR Z_SERVO_ANGLES DEACTIVATE_SERVOS_AFTER_MOVE \
 #            AUTO_BED_LEVELING_3POINT DEBUG_LEVELING_FEATURE EEPROM_SETTINGS
 # opt_set NUM_SERVOS 1
@@ -57,6 +60,7 @@ exec_test $1 $2 "Sled Z Probe with Linear leveling"
 # Test MAGNETIC_PARKING_EXTRUDER with LCD
 #
 restore_configs
+opt_set MOTHERBOARD BOARD_TEENSY35_36
 opt_set EXTRUDERS 2
 opt_set TEMP_SENSOR_1 1
 opt_enable MAGNETIC_PARKING_EXTRUDER ULTIMAKERCONTROLLER
@@ -66,6 +70,7 @@ exec_test $1 $2 "MAGNETIC_PARKING_EXTRUDER with LCD"
 # Mixing Extruder
 #
 restore_configs
+opt_set MOTHERBOARD BOARD_TEENSY35_36
 opt_enable MIXING_EXTRUDER DIRECT_MIXING_IN_G1 GRADIENT_MIX GRADIENT_VTOOL REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 opt_set MIXING_STEPPERS 2
 exec_test $1 $2 "Mixing Extruder"
@@ -74,6 +79,7 @@ exec_test $1 $2 "Mixing Extruder"
 # Test SWITCHING_EXTRUDER
 #
 # restore_configs
+# opt_set MOTHERBOARD BOARD_TEENSY35_36
 # opt_set EXTRUDERS 2
 # opt_set NUM_SERVOS 1
 # opt_enable SWITCHING_EXTRUDER ULTIMAKERCONTROLLER
@@ -82,6 +88,7 @@ exec_test $1 $2 "Mixing Extruder"
 # Enable COREXY
 #
 restore_configs
+opt_set MOTHERBOARD BOARD_TEENSY35_36
 opt_enable COREXY
 exec_test $1 $2 "COREXY"
 
@@ -89,6 +96,7 @@ exec_test $1 $2 "COREXY"
 # Enable COREXZ
 #
 restore_configs
+opt_set MOTHERBOARD BOARD_TEENSY35_36
 opt_enable COREXZ
 exec_test $1 $2 "COREXZ"
 
@@ -96,6 +104,7 @@ exec_test $1 $2 "COREXZ"
 # Enable Z_DUAL_STEPPER_DRIVERS, Z_DUAL_ENDSTOPS
 #
 restore_configs
+opt_set MOTHERBOARD BOARD_TEENSY35_36
 opt_enable Z_DUAL_STEPPER_DRIVERS Z_DUAL_ENDSTOPS
 pins_set RAMPS X_MAX_PIN -1
 opt_add Z2_MAX_PIN 2


### PR DESCRIPTION
It keeps it from being set to a different value in Configuration.h.  

### Description

I'm working on a RAMPS-like adapter board for the Teensy 3.6 and want to use my own pin definitions, but defining MOTHERBOARD in src/HAL/HAL_TEENSY35_36/HAL.h keeps a different selection from being made in Configuration.h.

Other HALs don't define MOTHERBOARD.  HAL_TEENSY31_32 did at one point, but the definition has since been commented out.

### Benefits

Allows other board configurations that use the Teensy 3.5 or 3.6 to be added to Marlin.




