### PR TITLE
fix for BLTouch regression

### DIFF
--- a/Marlin/src/feature/bltouch.h
+++ b/Marlin/src/feature/bltouch.h
@@ -41,9 +41,21 @@ public:
   static bool triggered();
 
   FORCE_INLINE static void reset()       { command(BLTOUCH_RESET); }
-  FORCE_INLINE static void set_5V_mode() { command(BLTOUCH_5V_MODE); }
-  FORCE_INLINE static void set_OD_mode() { command(BLTOUCH_OD_MODE); }
-  FORCE_INLINE static void set_SW_mode() { command(BLTOUCH_SW_MODE); }
+  FORCE_INLINE static void set_5V_mode() { 
+    #if ENABLED(BLTOUCH_V3) 
+      command(BLTOUCH_5V_MODE); 
+    #endif
+  }
+  FORCE_INLINE static void set_OD_mode() { 
+    #if ENABLED(BLTOUCH_V3)
+      command(BLTOUCH_OD_MODE); 
+    #endif
+  }
+  FORCE_INLINE static void set_SW_mode() { 
+    #if ENABLED(BLTOUCH_V3)
+      command(BLTOUCH_SW_MODE); 
+    #endif
+  }
 
   FORCE_INLINE static bool deploy() { return set_deployed(true); }
   FORCE_INLINE static bool stow()   { return set_deployed(false); }


### PR DESCRIPTION
### Description

Recent changes to the BLTouch code (5b2c37d) for compatibility with v3.0 hardware break functionality with earlier BLTouch versions.  They're sending commands that are undefined in earlier versions, which I suspect is confusing the microcontroller within the BLTouch.  Making use of these commands conditional on BLTOUCH_V3 being defined fixes this problem.

### Benefits

Z-axis homing works once again with a BLTouch 2.x or earlier.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/13447
