### PR TITLE
Allow M106 to take index > extruders

### DIFF
--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -33,7 +33,7 @@
   #define _CNT_P EXTRUDERS
 #else
   #define _ALT_P MIN(active_extruder, FAN_COUNT - 1)
-  #define _CNT_P MIN(EXTRUDERS, FAN_COUNT)
+  #define _CNT_P FAN_COUNT
 #endif
 
 /**


### PR DESCRIPTION
### Description

You can not currently control fans (or lasers / spindles) when connected to fan indexes more than the number of extruders,

I'm not sure why this limitation was introduces and therefore am unsure about the fix, but I can't see a reason why it shouldn't just be limited by `FAN_COUNT` when not in singlenozzle mode.