### PR TITLE
Add pins for dual z uart on skr 1.3 (fixes #13470)

### DIFF
--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
@@ -140,6 +140,10 @@
 
   #define E1_SERIAL_TX_PIN P1_04
   #define E1_SERIAL_RX_PIN P1_01
+
+  #define Z2_SERIAL_TX_PIN P1_04
+  #define Z2_SERIAL_RX_PIN P1_01
+
 #endif
 
 //


### PR DESCRIPTION
### Requirements

Add pins for dual z uart on skr 1.3. This fixes #13470.
