### PR TITLE
[2.0.x] Due stepper & Neopixel ISR conflict (relocate DUE's stepper ISR to TC0,2)

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.cpp
@@ -63,8 +63,8 @@
 const tTimerConfig TimerConfig [NUM_HARDWARE_TIMERS] = {
   { TC0, 0, TC0_IRQn,  3}, // 0 - [servo timer5]
   { TC0, 1, TC1_IRQn,  0}, // 1
-  { TC0, 2, TC2_IRQn,  0}, // 2
-  { TC1, 0, TC3_IRQn,  2}, // 3 - stepper
+  { TC0, 2, TC2_IRQn,  2}, // 2 - stepper
+  { TC1, 0, TC3_IRQn,  0}, // 3
   { TC1, 1, TC4_IRQn, 15}, // 4 - temperature
   { TC1, 2, TC5_IRQn,  3}, // 5 - [servo timer3]
   { TC2, 0, TC6_IRQn, 14}, // 6 - tone

--- a/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL_timers_Due.h
@@ -43,7 +43,7 @@ typedef uint32_t hal_timer_t;
 
 #define HAL_TIMER_RATE         ((F_CPU) / 2)    // frequency of timers peripherals
 
-#define STEP_TIMER_NUM 3  // index of timer to use for stepper
+#define STEP_TIMER_NUM 2  // index of timer to use for stepper
 #define TEMP_TIMER_NUM 4  // index of timer to use for temperature
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 #define TONE_TIMER_NUM 6  // index of timer to use for beeper tones
@@ -65,7 +65,7 @@ typedef uint32_t hal_timer_t;
 #define ENABLE_TEMPERATURE_INTERRUPT()  HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
-#define HAL_STEP_TIMER_ISR()  void TC3_Handler()
+#define HAL_STEP_TIMER_ISR()  void TC2_Handler()
 #define HAL_TEMP_TIMER_ISR()  void TC4_Handler()
 #define HAL_TONE_TIMER_ISR()  void TC6_Handler()
 


### PR DESCRIPTION
Per issues #9486 and #13020, when DUE is selected, the Neopixel library uses the same ISR as the stepper.  The result is the Neolpixel display works but the steppers do not.

This PR moves DUE's stepper ISR from TC1,0 to TC0,2.

This has been tested on a RAMPS-FD-V1 system and a Printrboard-G2 system.