### PR TITLE
[2.0.x] Fix compilation error for MKS Robin

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.h
@@ -130,6 +130,10 @@ void HAL_init();
   #define analogInputToDigitalPin(p) (p)
 #endif
 
+#ifndef digitalPinHasPWM
+  #define digitalPinHasPWM(P) (PIN_MAP[P].timer_device != NULL)
+#endif
+
 #define CRITICAL_SECTION_START  uint32_t primask = __get_primask(); (void)__iCliRetVal()
 #define CRITICAL_SECTION_END    if (!primask) (void)__iSeiRetVal()
 #define ISRS_ENABLED() (!__get_primask())

--- a/Marlin/src/HAL/HAL_STM32F1/u8g_com_stm32duino_fsmc.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/u8g_com_stm32duino_fsmc.cpp
@@ -26,7 +26,7 @@
  * Communication interface for FSMC
  */
 
-#if (defined(STM32F1) || defined(STM32F1xx)) && (defined(STM32_HIGH_DENSITY) || defined(STM32_XL_DENSITY))
+#if defined(ARDUINO_ARCH_STM32F1) && (defined(STM32_HIGH_DENSITY) || defined(STM32_XL_DENSITY))
 
 #include "../../inc/MarlinConfig.h"
 
@@ -267,4 +267,4 @@ uint32_t LCD_IO_ReadData(uint16_t RegValue, uint8_t ReadSize) {
 
 #endif // HAS_GRAPHICAL_LCD
 
-#endif // (STM32F1 || STM32F1xx) && (STM32_HIGH_DENSITY || STM32_XL_DENSITY)
+#endif // ARDUINO_ARCH_STM32F1 && (STM32_HIGH_DENSITY || STM32_XL_DENSITY)

--- a/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
+++ b/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
@@ -47,7 +47,7 @@
   uint8_t u8g_com_HAL_LPC1768_ssd_hw_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
   #define U8G_COM_SSD_I2C_HAL u8g_com_arduino_ssd_i2c_fn
 
-  #if defined(STM32F1) || defined(STM32F1xx)
+  #if defined(ARDUINO_ARCH_STM32F1)
     uint8_t u8g_com_stm32duino_fsmc_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_FSMC_FN u8g_com_stm32duino_fsmc_fn
   #else

--- a/buildroot/share/PlatformIO/scripts/mks_robin.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin.py
@@ -1,7 +1,9 @@
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08007000
-env['CPPDEFINES'].remove(("VECT_TAB_ADDR", 134217728))
+for define in env['CPPDEFINES']:
+    if define[0] == "VECT_TAB_ADDR":
+        env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
 env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/mks_robin.ld")
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -308,6 +308,7 @@ board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   ${common.build_flags}
+  -DSTM32_XL_DENSITY
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
 lib_ignore    = c1921b4


### PR DESCRIPTION
### Description

Fix compilation errors for STM32F103ZET6-based MKS Robin board.
Improve SDIO stability for HAL_STM32F1.

Depends on https://github.com/MarlinFirmware/U8glib-HAL/pull/6

### Benefits

MKS Robin board can run Marlin.
SDIO stability improved on HAL_STM32F1. Prints from SD card should be more reliable.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/13489
https://github.com/MarlinFirmware/Marlin/issues/13503
