### PR TITLE
Quiet warning about signed to unsigned comparison.

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -85,7 +85,7 @@ void plan_arc(
   if (angular_travel < 0) angular_travel += RADIANS(360);
   #ifdef MIN_ARC_SEGMENTS
     uint16_t min_segments = CEIL((MIN_ARC_SEGMENTS) * (angular_travel / RADIANS(360)));
-    NOLESS(min_segments, 1);
+    NOLESS(min_segments, 1u);
   #else
     constexpr uint16_t min_segments = 1;
   #endif

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -85,7 +85,7 @@ void plan_arc(
   if (angular_travel < 0) angular_travel += RADIANS(360);
   #ifdef MIN_ARC_SEGMENTS
     uint16_t min_segments = CEIL((MIN_ARC_SEGMENTS) * (angular_travel / RADIANS(360)));
-    NOLESS(min_segments, 1u);
+    NOLESS(min_segments, 1U);
   #else
     constexpr uint16_t min_segments = 1;
   #endif


### PR DESCRIPTION
Quiets the following warning:

```
In file included from src/gcode/motion/../../inc/MarlinConfigPre.h:32:0,
                 from src/gcode/motion/../../inc/MarlinConfig.h:28,
                 from src/gcode/motion/G2_G3.cpp:23:
src/gcode/motion/../../inc/../core/macros.h: In instantiation of ‘constexpr void NOLESS(V&, N) [with V = unsigned int; N = int]’:
src/gcode/motion/G2_G3.cpp:88:27:   required from here
src/gcode/motion/../../inc/../core/macros.h:100:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (v < n) v = n;
           ^
```