### PR TITLE
Fix Teensy 3.5/3.6 __get_primask

### DIFF
--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL.h
@@ -49,6 +49,7 @@
 #include "HAL_timers_Teensy.h"
 
 #include <stdint.h>
+#include <util/atomic.h>
 
 #define ST7920_DELAY_1 DELAY_NS(600)
 #define ST7920_DELAY_2 DELAY_NS(750)
@@ -84,9 +85,9 @@ typedef int8_t pin_t;
   #define analogInputToDigitalPin(p) ((p < 12u) ? (p) + 54u : -1)
 #endif
 
-#define CRITICAL_SECTION_START  uint32_t primask = __get_PRIMASK(); __disable_irq()
+#define CRITICAL_SECTION_START  uint32_t primask = __get_primask(); __disable_irq()
 #define CRITICAL_SECTION_END    if (!primask) __enable_irq()
-#define ISRS_ENABLED() (!__get_PRIMASK())
+#define ISRS_ENABLED() (!__get_primask())
 #define ENABLE_ISRS()  __enable_irq()
 #define DISABLE_ISRS() __disable_irq()
 


### PR DESCRIPTION
### Description

Marlin/src/HAL/HAL_TEENSY35_36/HAL.h is missing an ```#include```, and ```__get_PRIMASK()``` is declared in <util/atomic.h> for the Teensy build environment as ```__get_primask()``` (lowercase, not uppercase).  I found this when I set BEEPER_PIN in the pins file for the Teensy-based printer shield I'm designing. 

### Benefits

Allows Marlin to compile for Teensy 3.5/3.6 if BEEPER_PIN is defined, at a minimum.  It might also come into play under other conditions.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/13513
