### PR TITLE
CR10_STOCKDISPLAY support for Bigtreetech SKR V1.3

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1897,8 +1897,8 @@
 // Factory display for Creality CR-10
 // https://www.aliexpress.com/item/Universal-LCD-12864-3D-Printer-Display-Screen-With-Encoder-For-CR-10-CR-7-Model/32833148327.html
 //
-// This is RAMPS-compatible using a single 10-pin connector.
-// (For CR-10 owners who want to replace the Melzi Creality board but retain the display)
+// This is RAMPS and Bigtreetech SKR V1.3 compatible using a single 10-pin connector (connect EXP3 on display to EXP1 on board).
+// (For CR-10 and Ender-3 owners who want to replace the Melzi Creality board but retain the display)
 //
 //#define CR10_STOCKDISPLAY
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1897,8 +1897,8 @@
 // Factory display for Creality CR-10
 // https://www.aliexpress.com/item/Universal-LCD-12864-3D-Printer-Display-Screen-With-Encoder-For-CR-10-CR-7-Model/32833148327.html
 //
-// This is RAMPS and Bigtreetech SKR V1.3 compatible using a single 10-pin connector (connect EXP3 on display to EXP1 on board).
-// (For CR-10 and Ender-3 owners who want to replace the Melzi Creality board but retain the display)
+// This is RAMPS-compatible using a single 10-pin connector.
+// (For CR-10 owners who want to replace the Melzi Creality board but retain the display)
 //
 //#define CR10_STOCKDISPLAY
 

--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
@@ -178,9 +178,10 @@
 */
 #if ENABLED(ULTRA_LCD)
 
+  #define BEEPER_PIN        P1_30   // (37) not 5V tolerant
+  #define BTN_ENC           P0_28   // (58) open-drain
+
   #if ENABLED(CR10_STOCKDISPLAY)
-    #define BEEPER_PIN      P1_30
-    #define BTN_ENC         P0_28
     #define LCD_PINS_RS     P1_22
 
     #define BTN_EN1         P1_18
@@ -190,25 +191,26 @@
     #define LCD_PINS_D4     P1_21
 
   #else
-    #define BEEPER_PIN       P1_30   // (37) not 5V tolerant
-    #define BTN_ENC          P0_28   // (58) open-drain
-    #define LCD_PINS_RS      P1_19
 
-    #define BTN_EN1          P3_26   // (31) J3-2 & AUX-4
-    #define BTN_EN2          P3_25   // (33) J3-4 & AUX-4
-    #define SD_DETECT_PIN    P1_31   // (49) (NOT 5V tolerant)
+    #define LCD_PINS_RS     P1_19
 
-    #define LCD_SDSS         P0_16   // (16) J3-7 & AUX-4
+    #define BTN_EN1         P3_26   // (31) J3-2 & AUX-4
+    #define BTN_EN2         P3_25   // (33) J3-4 & AUX-4
+    #define SD_DETECT_PIN   P1_31   // (49) (NOT 5V tolerant)
 
-    #define LCD_PINS_ENABLE  P1_18
-    #define LCD_PINS_D4      P1_20
+    #define LCD_SDSS        P0_16   // (16) J3-7 & AUX-4
+
+    #define LCD_PINS_ENABLE P1_18
+    #define LCD_PINS_D4     P1_20
 
     #if ENABLED(ULTIPANEL)
-      #define LCD_PINS_D5    P1_21
-      #define LCD_PINS_D6    P1_22
-      #define LCD_PINS_D7    P1_23
+      #define LCD_PINS_D5   P1_21
+      #define LCD_PINS_D6   P1_22
+      #define LCD_PINS_D7   P1_23
     #endif
+
   #endif
+
 #endif // ULTRA_LCD
 
 //#define USB_SD_DISABLED

--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
@@ -177,23 +177,37 @@
 |               EXP2                                              EXP1
 */
 #if ENABLED(ULTRA_LCD)
-  #define BEEPER_PIN       P1_30   // (37) not 5V tolerant
-  #define BTN_ENC          P0_28   // (58) open-drain
-  #define LCD_PINS_RS      P1_19
 
-  #define BTN_EN1          P3_26   // (31) J3-2 & AUX-4
-  #define BTN_EN2          P3_25   // (33) J3-4 & AUX-4
-  #define SD_DETECT_PIN    P1_31   // (49) (NOT 5V tolerant)
+  #if ENABLED(CR10_STOCKDISPLAY)
+    #define BEEPER_PIN      P1_30
+    #define BTN_ENC         P0_28
+    #define LCD_PINS_RS     P1_22
 
-  #define LCD_SDSS         P0_16   // (16) J3-7 & AUX-4
+    #define BTN_EN1         P1_18
+    #define BTN_EN2         P1_20
 
-  #define LCD_PINS_ENABLE  P1_18
-  #define LCD_PINS_D4      P1_20
+    #define LCD_PINS_ENABLE P1_23
+    #define LCD_PINS_D4     P1_21
 
-  #if ENABLED(ULTIPANEL)
-    #define LCD_PINS_D5    P1_21
-    #define LCD_PINS_D6    P1_22
-    #define LCD_PINS_D7    P1_23
+  #else
+    #define BEEPER_PIN       P1_30   // (37) not 5V tolerant
+    #define BTN_ENC          P0_28   // (58) open-drain
+    #define LCD_PINS_RS      P1_19
+
+    #define BTN_EN1          P3_26   // (31) J3-2 & AUX-4
+    #define BTN_EN2          P3_25   // (33) J3-4 & AUX-4
+    #define SD_DETECT_PIN    P1_31   // (49) (NOT 5V tolerant)
+
+    #define LCD_SDSS         P0_16   // (16) J3-7 & AUX-4
+
+    #define LCD_PINS_ENABLE  P1_18
+    #define LCD_PINS_D4      P1_20
+
+    #if ENABLED(ULTIPANEL)
+      #define LCD_PINS_D5    P1_21
+      #define LCD_PINS_D6    P1_22
+      #define LCD_PINS_D7    P1_23
+    #endif
   #endif
 #endif // ULTRA_LCD
 

--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
@@ -177,7 +177,6 @@
 |               EXP2                                              EXP1
 */
 #if ENABLED(ULTRA_LCD)
-
   #define BEEPER_PIN        P1_30   // (37) not 5V tolerant
   #define BTN_ENC           P0_28   // (58) open-drain
 


### PR DESCRIPTION
### Description

Added CR10_STOCKDISPLAY support for Bigtreetech SKR V1.3 board
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Creality CR-10/Ender-3 stock controller will work with SKR V1.3 board using single ribbon cable, leaving EXP2 connector available for use to, for example, connect SPI card reader
<!-- What does this fix or improve? -->

### Related Issues

No related issues
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
