### PR TITLE
UltraLCD enhancements (fan as percent, add backlash menu)

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -30,6 +30,7 @@
 
 #include "Marlin.h"
 
+#include "core/utility.h"
 #include "lcd/ultralcd.h"
 #include "module/motion.h"
 #include "module/planner.h"

--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -57,6 +57,16 @@ void safe_delay(millis_t ms) {
   #define RJDIGIT(n, f) ((n) >= (f) ? DIGIMOD(n, f) : ' ')
   #define MINUSOR(n, alt) (n >= 0 ? (alt) : (n = -n, '-'))
 
+  // Convert a full-range unsigned 8bit int to a percentage
+  char* ui8tostr_percent(const uint8_t i) {
+    const uint16_t percent = 100 * i / 255;
+    conv[3] = RJDIGIT(percent, 100);
+    conv[4] = RJDIGIT(percent, 10);
+    conv[5] = DIGIMOD(percent, 1);
+    conv[6] = '%';
+    return &conv[3];
+  }
+
   // Convert unsigned 8bit int to string 123 format
   char* ui8tostr3(const uint8_t i) {
     conv[4] = RJDIGIT(i, 100);

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -55,6 +55,9 @@ inline void serial_delay(const millis_t ms) {
 
 #if ANY(ULTRA_LCD, DEBUG_LEVELING_FEATURE, EXTENSIBLE_UI)
 
+  // Convert a full-range unsigned 8bit int to a percentage
+  char* ui8tostr_percent(const uint8_t i);
+
   // Convert uint8_t to string with 123 format
   char* ui8tostr3(const uint8_t x);
 
@@ -135,3 +138,9 @@ public:
 
 #define REMEMBER(N,X, ...) restorer<typeof(X)> restorer_##N(X, ##__VA_ARGS__)
 #define RESTORE(N) restorer_##N.restore()
+
+// Converts from an uint8_t in the range of 0-255 to an uint8_t
+// in the range 0-100 while avoiding rounding artifacts
+constexpr uint8_t ui8_to_percent(const uint8_t i) {return (int(i) * 100 + 127) / 255;}
+constexpr uint8_t all_on  = 255;
+constexpr uint8_t all_off = 0;

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -141,6 +141,5 @@ public:
 
 // Converts from an uint8_t in the range of 0-255 to an uint8_t
 // in the range 0-100 while avoiding rounding artifacts
-constexpr uint8_t ui8_to_percent(const uint8_t i) {return (int(i) * 100 + 127) / 255;}
-constexpr uint8_t all_on  = 255;
-constexpr uint8_t all_off = 0;
+constexpr uint8_t ui8_to_percent(const uint8_t i) { return (int(i) * 100 + 127) / 255; }
+constexpr uint8_t all_on = 0xFF, all_off = 0x00;

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -56,7 +56,8 @@
 #define HAS_Y_CENTER BOTH(CALIBRATION_MEASURE_FRONT, CALIBRATION_MEASURE_BACK)
 
 #if ENABLED(BACKLASH_GCODE)
-  extern float backlash_distance_mm[], backlash_correction, backlash_smoothing_mm;
+  extern float backlash_distance_mm[], backlash_smoothing_mm;
+  extern uint8_t backlash_correction;
 #endif
 
 enum side_t : uint8_t { TOP, RIGHT, FRONT, LEFT, BACK, NUM_SIDES };
@@ -446,7 +447,7 @@ inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
 
   {
     // New scope for TEMPORARY_BACKLASH_CORRECTION
-    TEMPORARY_BACKLASH_CORRECTION(0.0f);
+    TEMPORARY_BACKLASH_CORRECTION(all_off);
     TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
     probe_sides(m, uncertainty);
@@ -478,7 +479,7 @@ inline void calibrate_backlash(measurements_t &m, const float uncertainty) {
 
     {
       // New scope for TEMPORARY_BACKLASH_CORRECTION
-      TEMPORARY_BACKLASH_CORRECTION(1.0f);
+      TEMPORARY_BACKLASH_CORRECTION(all_on);
       TEMPORARY_BACKLASH_SMOOTHING(0.0f);
       move_to(
         X_AXIS, current_position[X_AXIS] + 3,
@@ -513,7 +514,7 @@ inline void update_measurements(measurements_t &m, const AxisEnum axis) {
  *    - Call calibrate_backlash() beforehand for best accuracy
  */
 inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const uint8_t extruder) {
-  TEMPORARY_BACKLASH_CORRECTION(1.0f);
+  TEMPORARY_BACKLASH_CORRECTION(all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
   #if HOTENDS > 1
@@ -556,7 +557,7 @@ inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const
  *   uncertainty    in     - How far away from the object to begin probing
  */
 inline void calibrate_all_toolheads(measurements_t &m, const float uncertainty) {
-  TEMPORARY_BACKLASH_CORRECTION(1.0f);
+  TEMPORARY_BACKLASH_CORRECTION(all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
   HOTEND_LOOP() calibrate_toolhead(m, uncertainty, e);
@@ -588,7 +589,7 @@ inline void calibrate_all() {
     reset_hotend_offsets();
   #endif
 
-  TEMPORARY_BACKLASH_CORRECTION(1.0f);
+  TEMPORARY_BACKLASH_CORRECTION(all_on);
   TEMPORARY_BACKLASH_SMOOTHING(0.0f);
 
   // Do a fast and rough calibration of the toolheads

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -90,8 +90,7 @@ void GcodeSuite::M425() {
     SERIAL_ECHOPGM("Backlash correction is ");
     if (!backlash_correction) SERIAL_ECHOPGM("in");
     SERIAL_ECHOLNPGM("active:");
-    SERIAL_ECHOPAIR("  Correction Amount/Fade-out:     F", float(ui8_to_percent(backlash_correction))/100);
-    SERIAL_ECHOLNPGM("     (F1.0 = full, F0.0 = none)");
+    SERIAL_ECHOLNPAIR("  Correction Amount/Fade-out:     F", float(ui8_to_percent(backlash_correction)) / 100, "     (F1.0 = full, F0.0 = none)");
     SERIAL_ECHOPGM("  Backlash Distance (mm):        ");
     LOOP_XYZ(a) {
       SERIAL_CHAR(' ');

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -26,8 +26,8 @@
 
 #include "../../module/planner.h"
 
-float backlash_distance_mm[XYZ] = BACKLASH_DISTANCE_MM,
-      backlash_correction = BACKLASH_CORRECTION;
+float   backlash_distance_mm[XYZ] = BACKLASH_DISTANCE_MM;
+uint8_t backlash_correction = BACKLASH_CORRECTION * all_on;
 
 #ifdef BACKLASH_SMOOTHING_MM
   float backlash_smoothing_mm = BACKLASH_SMOOTHING_MM;
@@ -74,7 +74,7 @@ void GcodeSuite::M425() {
 
   if (parser.seen('F')) {
     planner.synchronize();
-    backlash_correction = MAX(0, MIN(1.0, parser.value_linear_units()));
+    backlash_correction = MAX(0, MIN(1.0, parser.value_float())) * all_on;
     noArgs = false;
   }
 
@@ -90,7 +90,7 @@ void GcodeSuite::M425() {
     SERIAL_ECHOPGM("Backlash correction is ");
     if (!backlash_correction) SERIAL_ECHOPGM("in");
     SERIAL_ECHOLNPGM("active:");
-    SERIAL_ECHOPAIR("  Correction Amount/Fade-out:     F", backlash_correction);
+    SERIAL_ECHOPAIR("  Correction Amount/Fade-out:     F", float(ui8_to_percent(backlash_correction))/100);
     SERIAL_ECHOLNPGM("     (F1.0 = full, F0.0 = none)");
     SERIAL_ECHOPGM("  Backlash Distance (mm):        ");
     LOOP_XYZ(a) {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -82,7 +82,8 @@
 #include "ui_api.h"
 
 #if ENABLED(BACKLASH_GCODE)
-  extern float backlash_distance_mm[XYZ], backlash_correction;
+  extern float backlash_distance_mm[XYZ];
+  extern uint8_t backlash_correction;
   #ifdef BACKLASH_SMOOTHING_MM
     extern float backlash_smoothing_mm;
   #endif
@@ -686,8 +687,8 @@ namespace ExtUI {
     void setAxisBacklash_mm(const float value, const axis_t axis)
                                                       { backlash_distance_mm[axis] = clamp(value,0,5); }
 
-    float getBacklashCorrection_percent()             { return backlash_correction * 100; }
-    void setBacklashCorrection_percent(const float value) { backlash_correction = clamp(value, 0, 100) / 100.0f; }
+    float getBacklashCorrection_percent()             { return ui8_to_percent(backlash_correction); }
+    void setBacklashCorrection_percent(const float value) { backlash_correction = map(clamp(value, 0, 100), 0, 100, 0, 255); }
 
     #ifdef BACKLASH_SMOOTHING_MM
       float getBacklashSmoothing_mm()                 { return backlash_smoothing_mm; }

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1386,3 +1386,15 @@
 #ifndef MSG_SERVICE_IN
   #define MSG_SERVICE_IN                      _UxGT(" in:")
 #endif
+
+#ifndef MSG_BACKLASH
+  #define MSG_BACKLASH                        _UxGT("Backlash")
+#endif
+
+#ifndef MSG_BACKLASH_CORRECTION
+  #define MSG_BACKLASH_CORRECTION             _UxGT("Correction")
+#endif
+
+#ifndef MSG_BACKLASH_SMOOTHING
+  #define MSG_BACKLASH_SMOOTHING              _UxGT("Smoothing")
+#endif

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1390,11 +1390,9 @@
 #ifndef MSG_BACKLASH
   #define MSG_BACKLASH                        _UxGT("Backlash")
 #endif
-
 #ifndef MSG_BACKLASH_CORRECTION
   #define MSG_BACKLASH_CORRECTION             _UxGT("Correction")
 #endif
-
 #ifndef MSG_BACKLASH_SMOOTHING
   #define MSG_BACKLASH_SMOOTHING              _UxGT("Smoothing")
 #endif

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -43,6 +43,7 @@ bool printer_busy();
     static inline char* strfunc(const float value) { return STRFUNC((TYPE) value); } \
   };
 
+DECLARE_MENU_EDIT_TYPE(uint8_t,  percent,     ui8tostr_percent,1     );   // 100%       right-justified
 DECLARE_MENU_EDIT_TYPE(int16_t,  int3,        i16tostr3,       1     );   // 123, -12   right-justified
 DECLARE_MENU_EDIT_TYPE(int16_t,  int4,        i16tostr4sign,   1     );   // 1234, -123 right-justified
 DECLARE_MENU_EDIT_TYPE(int8_t,   int8,        i8tostr3,        1     );   // 123, -12   right-justified
@@ -102,6 +103,7 @@ FORCE_INLINE void draw_menu_item_edit_P(const bool sel, const uint8_t row, PGM_P
   typedef void NAME##_void
 #define DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(NAME) _DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(MenuItemInfo_##NAME::type_t, NAME, MenuItemInfo_##NAME::strfunc)
 
+DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(percent);          // 100%       right-justified
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(int3);             // 123, -12   right-justified
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(int4);             // 1234, -123 right-justified
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(int8);             // 123, -12   right-justified
@@ -174,6 +176,7 @@ class TMenuItem : MenuItemBase {
 
 #define DECLARE_MENU_EDIT_ITEM(NAME) typedef TMenuItem<MenuItemInfo_##NAME> MenuItem_##NAME;
 
+DECLARE_MENU_EDIT_ITEM(percent);
 DECLARE_MENU_EDIT_ITEM(int3);
 DECLARE_MENU_EDIT_ITEM(int4);
 DECLARE_MENU_EDIT_ITEM(int8);

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -49,6 +49,7 @@
 #endif
 
 void menu_tmc();
+void menu_backlash();
 
 #if ENABLED(DAC_STEPPER_CURRENT)
 
@@ -646,6 +647,10 @@ void menu_advanced_settings() {
       MENU_ITEM(submenu, MSG_STEPS_PER_MM, menu_advanced_steps_per_mm);
     }
   #endif // !SLIM_LCD_MENUS
+
+  #if ENABLED(BACKLASH_GCODE)
+    MENU_ITEM(submenu, MSG_BACKLASH, menu_backlash);
+  #endif
 
   #if ENABLED(DAC_STEPPER_CURRENT)
     MENU_ITEM(submenu, MSG_DRIVE_STRENGTH, menu_dac);

--- a/Marlin/src/lcd/menu/menu_backlash.cpp
+++ b/Marlin/src/lcd/menu/menu_backlash.cpp
@@ -49,7 +49,7 @@ void menu_backlash() {
   EDIT_BACKLASH_DISTANCE(C);
 
   #ifdef BACKLASH_SMOOTHING_MM
-    MENU_MULTIPLIER_ITEM_EDIT(float43, MSG_BACKLASH_SMOOTHING,  &backlash_smoothing_mm, 0.0f, 9.9f);
+    MENU_MULTIPLIER_ITEM_EDIT(float43, MSG_BACKLASH_SMOOTHING, &backlash_smoothing_mm, 0.0f, 9.9f);
   #endif
 
   END_MENU();

--- a/Marlin/src/lcd/menu/menu_backlash.cpp
+++ b/Marlin/src/lcd/menu/menu_backlash.cpp
@@ -1,0 +1,58 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+//
+// Backlash Menu
+//
+
+#include "../../inc/MarlinConfigPre.h"
+
+#if HAS_LCD_MENU && ENABLED(BACKLASH_GCODE)
+
+#include "menu.h"
+
+extern float backlash_distance_mm[XYZ];
+extern uint8_t backlash_correction;
+
+#ifdef BACKLASH_SMOOTHING_MM
+  extern float backlash_smoothing_mm;
+#endif
+
+void menu_backlash() {
+  START_MENU();
+  MENU_BACK(MSG_MAIN);
+
+  MENU_MULTIPLIER_ITEM_EDIT(percent, MSG_BACKLASH_CORRECTION, &backlash_correction, all_off, all_on);
+
+  #define EDIT_BACKLASH_DISTANCE(N) MENU_MULTIPLIER_ITEM_EDIT(float43, MSG_##N, &backlash_distance_mm[_AXIS(N)], 0.0f, 9.9f);
+  EDIT_BACKLASH_DISTANCE(A);
+  EDIT_BACKLASH_DISTANCE(B);
+  EDIT_BACKLASH_DISTANCE(C);
+
+  #ifdef BACKLASH_SMOOTHING_MM
+    MENU_MULTIPLIER_ITEM_EDIT(float43, MSG_BACKLASH_SMOOTHING,  &backlash_smoothing_mm, 0.0f, 9.9f);
+  #endif
+
+  END_MENU();
+}
+
+#endif // HAS_LCD_MENU && BACKLASH_COMPENSATION

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -395,21 +395,21 @@ void menu_temperature() {
   //
   #if FAN_COUNT > 0
     #if HAS_FAN0
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.lcd_tmpfan_speed[0], 0, 255, thermalManager.lcd_setFanSpeed0);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(percent, MSG_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.lcd_tmpfan_speed[0], 0, 255, thermalManager.lcd_setFanSpeed0);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.new_fan_speed[0], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(percent, MSG_EXTRA_FAN_SPEED FAN_SPEED_1_SUFFIX, &thermalManager.new_fan_speed[0], 3, 255);
       #endif
     #endif
     #if HAS_FAN1 || (ENABLED(SINGLENOZZLE) && EXTRUDERS > 1)
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED " 2", &thermalManager.lcd_tmpfan_speed[1], 0, 255, thermalManager.lcd_setFanSpeed1);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(percent, MSG_FAN_SPEED " 2", &thermalManager.lcd_tmpfan_speed[1], 0, 255, thermalManager.lcd_setFanSpeed1);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED " 2", &thermalManager.new_fan_speed[1], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(percent, MSG_EXTRA_FAN_SPEED " 2", &thermalManager.new_fan_speed[1], 3, 255);
       #endif
     #endif
     #if HAS_FAN2 || (ENABLED(SINGLENOZZLE) && EXTRUDERS > 2)
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(uint8, MSG_FAN_SPEED " 3", &thermalManager.lcd_tmpfan_speed[2], 0, 255, thermalManager.lcd_setFanSpeed2);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(percent, MSG_FAN_SPEED " 3", &thermalManager.lcd_tmpfan_speed[2], 0, 255, thermalManager.lcd_setFanSpeed2);
       #if ENABLED(EXTRA_FAN_SPEED)
-        MENU_MULTIPLIER_ITEM_EDIT(uint8, MSG_EXTRA_FAN_SPEED " 3", &thermalManager.new_fan_speed[2], 3, 255);
+        MENU_MULTIPLIER_ITEM_EDIT(percent, MSG_EXTRA_FAN_SPEED " 3", &thermalManager.new_fan_speed[2], 3, 255);
       #endif
     #endif
   #endif // FAN_COUNT > 0

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1572,13 +1572,14 @@ void Planner::synchronize() {
  */
 #if ENABLED(BACKLASH_COMPENSATION)
   #if ENABLED(BACKLASH_GCODE)
-    extern float backlash_distance_mm[], backlash_correction;
+    extern float backlash_distance_mm[];
+    extern uint8_t backlash_correction;
     #ifdef BACKLASH_SMOOTHING_MM
       extern float backlash_smoothing_mm;
     #endif
   #else
     constexpr float backlash_distance_mm[XYZ] = BACKLASH_DISTANCE_MM,
-                    backlash_correction = BACKLASH_CORRECTION;
+    constexpr uint8_t backlash_correction = BACKLASH_CORRECTION * 255;
     #ifdef BACKLASH_SMOOTHING_MM
       constexpr float backlash_smoothing_mm = BACKLASH_SMOOTHING_MM;
     #endif
@@ -1612,13 +1613,15 @@ void Planner::synchronize() {
       if (!changed_dir) return;
     #endif
 
+    const float f_corr = float(backlash_correction)/255.0f;
+
     LOOP_XYZ(axis) {
       if (backlash_distance_mm[axis]) {
         const bool reversing = TEST(dm,axis);
 
         // When an axis changes direction, add axis backlash to the residual error
         if (TEST(changed_dir, axis))
-          residual_error[axis] += backlash_correction * (reversing ? -1.0f : 1.0f) * backlash_distance_mm[axis] * planner.settings.axis_steps_per_mm[axis];
+          residual_error[axis] += (reversing ? -f_corr : f_corr) * backlash_distance_mm[axis] * planner.settings.axis_steps_per_mm[axis];
 
         // Decide how much of the residual error to correct in this segment
         int32_t error_correction = residual_error[axis];

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1613,7 +1613,7 @@ void Planner::synchronize() {
       if (!changed_dir) return;
     #endif
 
-    const float f_corr = float(backlash_correction)/255.0f;
+    const float f_corr = float(backlash_correction) / 255.0f;
 
     LOOP_XYZ(axis) {
       if (backlash_distance_mm[axis]) {

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -420,7 +420,7 @@ class Temperature {
         static uint8_t paused_fan_speed[FAN_COUNT];
       #endif
 
-      static constexpr inline uint8_t fanPercent(const uint8_t speed) { return (int(speed) * 100 + 127) / 255; }
+      static constexpr inline uint8_t fanPercent(const uint8_t speed) {return ui8_to_percent(speed);}
 
       #if ENABLED(ADAPTIVE_FAN_SLOWING)
         static uint8_t fan_speed_scaler[FAN_COUNT];

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -420,7 +420,7 @@ class Temperature {
         static uint8_t paused_fan_speed[FAN_COUNT];
       #endif
 
-      static constexpr inline uint8_t fanPercent(const uint8_t speed) {return ui8_to_percent(speed);}
+      static constexpr inline uint8_t fanPercent(const uint8_t speed) { return ui8_to_percent(speed); }
 
       #if ENABLED(ADAPTIVE_FAN_SLOWING)
         static uint8_t fan_speed_scaler[FAN_COUNT];


### PR DESCRIPTION
- Added UltraLCD editor type for showing full scale (0-255) uint8_t values as percentages (0%-100%)
- Show fan speed editor as percentage for consistency with status screen
- Changed backlash correction amount from float to uint8_t (save 3 bytes SRAM)
- Added backlash menu to UltraLCD (makes use of new UltraLCD percentage editor)