### PR TITLE
[BugFix: PowerLostRecovery] Close Recovery File before check

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -222,6 +222,8 @@ void PrintJobRecovery::write() {
   open(false);
   file.seekSet(0);
   const int16_t ret = file.write(&info, sizeof(info));
+  close();
+
   #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
     if (ret == -1) SERIAL_ECHOLNPGM("Power-loss file write failed.");
   #else

--- a/Marlin/src/gcode/feature/powerloss/M413.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M413.cpp
@@ -50,7 +50,7 @@ void GcodeSuite::M413() {
     if (parser.seen('R') || parser.seen('L')) recovery.load();
     if (parser.seen('W')) recovery.save(true);
     if (parser.seen('P')) recovery.purge();
-    if (parser.seen('E')) serialprintPGM(recovery.exists() ? PSTR("BIN Exists\n") : PSTR("No BIN\n"));
+    if (parser.seen('E')) serialprintPGM(recovery.exists() ? PSTR("PLR Exists\n") : PSTR("No PLR\n"));
     if (parser.seen('V')) serialprintPGM(recovery.valid() ? PSTR("Valid\n") : PSTR("Invalid\n"));
   #endif
 }

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1025,9 +1025,7 @@ void CardReader::printingHasFinished() {
   // the file being printed, so during SD printing the file should
   // be zeroed and written instead of deleted.
   void CardReader::removeJobRecoveryFile() {
-    recovery.file.close();
     if (jobRecoverFileExists()) {
-      //closefile();
       removeFile(job_recovery_file_name);
       #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
         SERIAL_ECHOPGM("Power-loss file delete");

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1025,6 +1025,7 @@ void CardReader::printingHasFinished() {
   // the file being printed, so during SD printing the file should
   // be zeroed and written instead of deleted.
   void CardReader::removeJobRecoveryFile() {
+    recovery.file.close();
     if (jobRecoverFileExists()) {
       //closefile();
       removeFile(job_recovery_file_name);

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1004,7 +1004,7 @@ void CardReader::printingHasFinished() {
 
 #if ENABLED(POWER_LOSS_RECOVERY)
 
-  constexpr char job_recovery_file_name[4] = "BIN";
+  constexpr char job_recovery_file_name[4] = "PLR";
 
   bool CardReader::jobRecoverFileExists() {
     const bool exists = recovery.file.open(&root, job_recovery_file_name, O_READ);


### PR DESCRIPTION
### Requirements

BugFix. Recovery File not deleted after print finished or aborted

### Description

Because Recovery file is still opened then jobRecoverFileExists() always return false. Therefore the file not deleted

