### PR TITLE
Minor optimization to ARC_SUPPORT code.

### DIFF
--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -775,7 +775,7 @@ void GcodeSuite::G26() {
 
         // Figure out where to start and end the arc - we always print counterclockwise
         if (xi == 0) {                             // left edge
-          sx = f ? sx : circle_x;
+          if (!f) sx = circle_x;
           ex = b ? sx : circle_x;
           sy = f ? circle_y : circle_y - (INTERSECTION_CIRCLE_RADIUS);
           ey = b ? circle_y : circle_y + INTERSECTION_CIRCLE_RADIUS;

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -775,8 +775,8 @@ void GcodeSuite::G26() {
 
         // Figure out where to start and end the arc - we always print counterclockwise
         if (xi == 0) {                             // left edge
-          sx = f ? circle_x + INTERSECTION_CIRCLE_RADIUS : circle_x;
-          ex = b ? circle_x + INTERSECTION_CIRCLE_RADIUS : circle_x;
+          sx = f ? sx : circle_x;
+          ex = b ? sx : circle_x;
           sy = f ? circle_y : circle_y - (INTERSECTION_CIRCLE_RADIUS);
           ey = b ? circle_y : circle_y + INTERSECTION_CIRCLE_RADIUS;
           arc_length = (f || b) ? ARC_LENGTH(1) : ARC_LENGTH(2);
@@ -789,15 +789,11 @@ void GcodeSuite::G26() {
           arc_length = (f || b) ? ARC_LENGTH(1) : ARC_LENGTH(2);
         }
         else if (f) {
-          sx = circle_x + INTERSECTION_CIRCLE_RADIUS;
           ex = circle_x - (INTERSECTION_CIRCLE_RADIUS);
-          sy = ey = circle_y;
           arc_length = ARC_LENGTH(2);
         }
         else if (b) {
           sx = circle_x - (INTERSECTION_CIRCLE_RADIUS);
-          ex = circle_x + INTERSECTION_CIRCLE_RADIUS;
-          sy = ey = circle_y;
           arc_length = ARC_LENGTH(2);
         }
         const float arc_offset[2] = {

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -775,10 +775,14 @@ void GcodeSuite::G26() {
 
         // Figure out where to start and end the arc - we always print counterclockwise
         if (xi == 0) {                             // left edge
-          if (!f) sx = circle_x;
-          ex = b ? sx : circle_x;
-          sy = f ? circle_y : circle_y - (INTERSECTION_CIRCLE_RADIUS);
-          ey = b ? circle_y : circle_y + INTERSECTION_CIRCLE_RADIUS;
+          if (!f) {
+            sx = circle_x;
+            sy -= (INTERSECTION_CIRCLE_RADIUS);
+          }
+          if (!b) {
+            ex = circle_x;
+            ey += INTERSECTION_CIRCLE_RADIUS;
+          }
           arc_length = (f || b) ? ARC_LENGTH(1) : ARC_LENGTH(2);
         }
         else if (r) {                             // right edge


### PR DESCRIPTION
### Description
Minor optimization to the code that generates the G26 pattern when ``ARC_SUPPORT`` is enabled.
### Benefits
Small reduction in PROGMEM usage with ``G26_MESH_VALIDATION`` and ``ARC_SUPPORT`` enabled: I measured 132 bytes size reduction on AVR vs. the original code.
### Related Issues
None
