### PR TITLE
[2.0.x-PLR] Save PLR every time Z is change

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -133,8 +133,8 @@ void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=
       #if SAVE_INFO_INTERVAL_MS > 0       // Save if interval is elapsed
         || ELAPSED(ms, next_save_ms)
       #endif
-      // Save every time Z is higher than the last call
-      || current_position[Z_AXIS] > info.current_position[Z_AXIS]
+      // Save every time Z is change
+      || current_position[Z_AXIS] != info.current_position[Z_AXIS]
     #endif
   ) {
 


### PR DESCRIPTION
### Requirements

For Printer with Z HOME DIR to MAX position, then PLR is only saved once. 
It is because the first PLR file is saved with info.current_position[Z_AXIS] = Z MAX

> Write Job Recovery Info...
valid_head:1 valid_foot:1
current_position: -5.00,0.00,299.00,0.00
feedrate: 1500
target_temperature: 240
target_temperature_bed: 45
fan_speed: 0
cmd_queue_index_r: 3
commands_in_queue: 4
> G1 Z0.200 F3000
> G1 X99.186 Y72.621 F6000
> G1 E0.0000 F3000
> G1 E-2.0000 F3000
sd_filename: /CUBE1C~2.GCO
sdpos: 6208
print_job_elapsed: 225
---

Therefore we need to save PLR everytime Z POS is change. 
Note: Already tested with Nozzle Park and FIlament change feature
It is working. But maybe there is better solution.