### PR TITLE
Update "dual Z" default settings

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -379,7 +379,7 @@
 #if ENABLED(Z_DUAL_STEPPER_DRIVERS)
   //#define Z_DUAL_ENDSTOPS
   #if ENABLED(Z_DUAL_ENDSTOPS)
-    #define Z2_USE_ENDSTOP _XMAX_
+    #define Z2_USE_ENDSTOP _ZMAX_
     #define Z_DUAL_ENDSTOPS_ADJUSTMENT  0
   #endif
 #endif


### PR DESCRIPTION
### Description

The "dual Z" mechanic should default to use the `ZMAX` endstop if a second endstop is requested.
This would be in line with the default settings for "dual X" and "dual Y".

### Benefits

More consistent default settings for "dual Z - dual Z endstop" systems

### Related Issues

None
