### PR TITLE
Change to CHOPPER_TIMING to 24V for Ender3

### DIFF
--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1595,7 +1595,7 @@
    * Define you own with
    * { <off_time[1..15]>, <hysteresis_end[-3..12]>, hysteresis_start[1..8] }
    */
-  #define CHOPPER_TIMING CHOPPER_DEFAULT_12V
+  #define CHOPPER_TIMING CHOPPER_DEFAULT_24V
 
   /**
    * Monitor Trinamic drivers for error conditions,


### PR DESCRIPTION
### Description

Ender 3 is a 24V machine. Fixes #13551.

> Current definition of CHOPPER_TIMING at Ender 3 Configuration_adv.h file:
> #define CHOPPER_TIMING CHOPPER_DEFAULT_12V
> Ender 3 is using 24V for steppers so CHOPPER_TIMING need to be set CHOPPER_DEFAULT_24V
