### PR TITLE
SPIFFS-backed PersistentStore for ESP32

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -43,10 +43,8 @@
     #include "web.h"
     #include "spiffs.h"
   #endif
-#else
-  #if ENABLED(EEPROM_SETTINGS)
-    #include "spiffs.h"
-  #endif
+#elif ENABLED(EEPROM_SETTINGS)
+  #include "spiffs.h"
 #endif
 
 // --------------------------------------------------------------------------
@@ -104,10 +102,8 @@ void HAL_init(void) {
       web_init();
     #endif
     server.begin();
-  #else
-    #if ENABLED(EEPROM_SETTINGS)
-      spiffs_init();
-    #endif
+  #elif ENABLED(EEPROM_SETTINGS)
+    spiffs_init();
   #endif
 
   i2s_init();

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -41,6 +41,11 @@
   #endif
   #if ENABLED(WEBSUPPORT)
     #include "web.h"
+    #include "spiffs.h"
+  #endif
+#else
+  #if ENABLED(EEPROM_SETTINGS)
+    #include "spiffs.h"
   #endif
 #endif
 
@@ -95,9 +100,14 @@ void HAL_init(void) {
       OTA_init();
     #endif
     #if ENABLED(WEBSUPPORT)
+      spiffs_init();
       web_init();
     #endif
     server.begin();
+  #else
+    #if ENABLED(EEPROM_SETTINGS)
+      spiffs_init();
+    #endif
   #endif
 
   i2s_init();

--- a/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
@@ -1,10 +1,9 @@
 /**
  * Marlin 3D Printer Firmware
- *
  * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
- * Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
- * Copyright (c) 2015-2016 Nico Tonnhofer wurstnase.reprap@gmail.com
- * Copyright (c) 2016 Victor Perez victor_pv@hotmail.com
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,7 +20,7 @@
  *
  */
 
-#if defined(ARDUINO_ARCH_ESP32)
+#ifdef ARDUINO_ARCH_ESP32
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
@@ -1,0 +1,95 @@
+/**
+ * Marlin 3D Printer Firmware
+ *
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
+ * Copyright (c) 2015-2016 Nico Tonnhofer wurstnase.reprap@gmail.com
+ * Copyright (c) 2016 Victor Perez victor_pv@hotmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if defined(ARDUINO_ARCH_ESP32)
+
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(EEPROM_SETTINGS) && DISABLED(FLASH_EEPROM_EMULATION)
+
+#include "../shared/persistent_store_api.h"
+
+#include "SPIFFS.h"
+#include "FS.h"
+#include "spiffs.h"
+
+#define HAL_ESP32_EEPROM_SIZE 4096
+
+File eeprom_file;
+
+bool PersistentStore::access_start() {
+  if (spiffs_initialized) {
+    eeprom_file = SPIFFS.open("/eeprom.dat", "r+");
+
+    size_t file_size = eeprom_file.size();
+    if (file_size < HAL_ESP32_EEPROM_SIZE) {
+      bool write_ok = eeprom_file.seek(file_size);
+
+      while (write_ok && file_size < HAL_ESP32_EEPROM_SIZE) {
+        write_ok = eeprom_file.write(0xFF) == 1;
+        file_size++;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+bool PersistentStore::access_finish() {
+  eeprom_file.close();
+  return true;
+}
+
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
+  if (!eeprom_file.seek(pos)) return true; // return true for any error
+  if (eeprom_file.write(value, size) != size) return true;
+
+  crc16(crc, value, size);
+  pos += size;
+
+  return false;
+}
+
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing/*=true*/) {
+  if(!eeprom_file.seek(pos)) return true; // return true for any error
+
+  if (writing) {
+    if (eeprom_file.read(value, size) != size) return true;
+    crc16(crc, value, size);
+  } else {
+    uint8_t tmp[size];
+    if (eeprom_file.read(tmp, size) != size) return true;
+    crc16(crc, tmp, size);
+  }
+
+  pos += size;
+
+  return false;
+}
+
+size_t PersistentStore::capacity() {
+  return HAL_ESP32_EEPROM_SIZE;
+}
+
+#endif // EEPROM_SETTINGS
+#endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
@@ -71,12 +71,13 @@ bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, ui
 }
 
 bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing/*=true*/) {
-  if(!eeprom_file.seek(pos)) return true; // return true for any error
+  if (!eeprom_file.seek(pos)) return true; // return true for any error
 
   if (writing) {
     if (eeprom_file.read(value, size) != size) return true;
     crc16(crc, value, size);
-  } else {
+  }
+  else {
     uint8_t tmp[size];
     if (eeprom_file.read(tmp, size) != size) return true;
     crc16(crc, tmp, size);
@@ -87,9 +88,7 @@ bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t 
   return false;
 }
 
-size_t PersistentStore::capacity() {
-  return HAL_ESP32_EEPROM_SIZE;
-}
+size_t PersistentStore::capacity() { return HAL_ESP32_EEPROM_SIZE; }
 
 #endif // EEPROM_SETTINGS
 #endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
@@ -1,7 +1,9 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
- * Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,6 +17,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 
 #ifdef ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
@@ -21,21 +21,21 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(WEBSUPPORT)
+#if EITHER(WEBSUPPORT, EEPROM_SETTINGS)
 
+#include "../../core/serial.h"
+
+#include "FS.h"
 #include "SPIFFS.h"
-#include "wifi.h"
 
-AsyncEventSource events("/events"); // event source (Server-Sent events)
+bool spiffs_initialized;
 
-void onNotFound(AsyncWebServerRequest *request){
-  request->send(404);
-}
-
-void web_init() {
-  server.addHandler(&events);       // attach AsyncEventSource
-  server.serveStatic("/", SPIFFS, "/www").setDefaultFile("index.html");
-  server.onNotFound(onNotFound);
+void spiffs_init() {
+  if (SPIFFS.begin()) {
+    spiffs_initialized = true;
+  } else {
+    SERIAL_ECHO_MSG("SPIFFS Mount Failed");
+  }
 }
 
 #endif // WEBSUPPORT

--- a/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
@@ -31,11 +31,10 @@
 bool spiffs_initialized;
 
 void spiffs_init() {
-  if (SPIFFS.begin()) {
+  if (SPIFFS.begin())
     spiffs_initialized = true;
-  } else {
-    SERIAL_ECHO_MSG("SPIFFS Mount Failed");
-  }
+  else
+    SERIAL_ECHO_MSG("SPIFFS mount failed");
 }
 
 #endif // WEBSUPPORT

--- a/Marlin/src/HAL/HAL_ESP32/spiffs.h
+++ b/Marlin/src/HAL/HAL_ESP32/spiffs.h
@@ -1,7 +1,9 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
- * Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -15,6 +17,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
  */
 #pragma once
 

--- a/Marlin/src/HAL/HAL_ESP32/spiffs.h
+++ b/Marlin/src/HAL/HAL_ESP32/spiffs.h
@@ -16,27 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#pragma once
 
-#ifdef ARDUINO_ARCH_ESP32
+extern bool spiffs_initialized;
 
-#include "../../inc/MarlinConfigPre.h"
-
-#if ENABLED(WEBSUPPORT)
-
-#include "SPIFFS.h"
-#include "wifi.h"
-
-AsyncEventSource events("/events"); // event source (Server-Sent events)
-
-void onNotFound(AsyncWebServerRequest *request){
-  request->send(404);
-}
-
-void web_init() {
-  server.addHandler(&events);       // attach AsyncEventSource
-  server.serveStatic("/", SPIFFS, "/www").setDefaultFile("index.html");
-  server.onNotFound(onNotFound);
-}
-
-#endif // WEBSUPPORT
-#endif // ARDUINO_ARCH_ESP32
+void spiffs_init();


### PR DESCRIPTION
### Description

Added an implementation of `PersistentStore` for ESP32 HAL that uses SPIFFS undearneath.

### Benefits

Can now enable `EEPROM_SETTINGS` on ESP32. Here's a screenshot:

![Screenshot from 2019-04-03 22-19-46](https://user-images.githubusercontent.com/1641850/55510588-e6c38a80-565e-11e9-94a7-a93362c25fda.png)
