### PR TITLE
[2.0.x] M43 - add missing LPC176x defines

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/pinsDebug.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinsDebug.h
@@ -28,6 +28,9 @@
  * Translation of routines & variables used by pinsDebug.h
  */
 
+#ifndef NUM_DIGITAL_PINS
+  #define NUM_DIGITAL_PINS 160
+#endif
 #define NUMBER_PINS_TOTAL NUM_DIGITAL_PINS
 #define pwm_details(pin) pin = pin    // do nothing  // print PWM details
 #define pwm_status(pin) false //Print a pin's PWM status. Return true if it's currently a PWM pin.

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -39,6 +39,11 @@
 #endif
 
 inline void toggle_pins() {
+
+  #ifndef PARSED_PIN_INDEX
+    #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)
+  #endif
+
   const bool ignore_protection = parser.boolval('I');
   const int repeat = parser.intval('R', 1),
             start = PARSED_PIN_INDEX('S', 0),
@@ -47,7 +52,6 @@ inline void toggle_pins() {
 
   for (uint8_t i = start; i <= end; i++) {
     pin_t pin = GET_PIN_MAP_PIN(i);
-    //report_pin_state_extended(pin, ignore_protection, false);
     if (!VALID_PIN(pin)) continue;
     if (!ignore_protection && pin_is_protected(pin)) {
       report_pin_state_extended(pin, ignore_protection, true, "Untouched ");


### PR DESCRIPTION
A couple of LPC176x defines used by M43 seem to have gone missing.  This PR adds them back in.

These changes have been tested on a RE_ARM board.