### PR TITLE
Add FastIO TOGGLE for ESP32

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
@@ -65,7 +65,7 @@
 #define USEABLE_HARDWARE_PWM(P) PWM_PIN(P)
 
 // Toggle pin value
-#define TOGGLE(IO)            WRITE(IO, !READ(IO))
+#define TOGGLE(IO)              WRITE(IO, !READ(IO))
 
 //
 // Ports and functions

--- a/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
@@ -64,6 +64,9 @@
 #define PWM_PIN(P)              true
 #define USEABLE_HARDWARE_PWM(P) PWM_PIN(P)
 
+// Toggle pin value
+#define TOGGLE(IO)            WRITE(IO, !READ(IO))
+
 //
 // Ports and functions
 //


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Adds the missing `TOGGLE` macro to the ESP32 HAL.

### Benefits

Can now use a buzzer on ESP32.

### Related Issues

None.
