### PR TITLE
Invaders compilation error

### DIFF
--- a/Marlin/src/lcd/menu/game/invaders.cpp
+++ b/Marlin/src/lcd/menu/game/invaders.cpp
@@ -182,7 +182,7 @@ typedef struct { int8_t x, y, v; } laser_t;
 
 uint8_t cannons_left;
 int8_t cannon_x;
-laser_t laser, expl, bullet[10];
+laser_t explod, laser, bullet[10];
 constexpr uint8_t inv_off[] = { 2, 1, 0 }, inv_wide[] = { 8, 11, 12 };
 int8_t invaders_x, invaders_y, invaders_dir, leftmost, rightmost, botmost;
 uint8_t invader_count, quit_count, bugs[INVADER_ROWS], shooters[(INVADER_ROWS) * (INVADER_COLS)];
@@ -236,7 +236,9 @@ inline void fire_cannon() {
 }
 
 inline void explode(const int8_t x, const int8_t y, const int8_t v=4) {
-  expl.x = x - (EXPL_W) / 2; expl.y = y; expl.v = v;
+  explod.x = x - (EXPL_W) / 2;
+  explod.y = y;
+  explod.v = v;
 }
 
 inline void kill_cannon(uint8_t &game_state, const uint8_t st) {
@@ -431,9 +433,9 @@ void InvadersGame::game_screen() {
   }
 
   // Draw explosion
-  if (expl.v && PAGE_CONTAINS(expl.y, expl.y + 7 - 1)) {
-    u8g.drawBitmapP(expl.x, expl.y, 2, 7, explosion);
-    --expl.v;
+  if (explod.v && PAGE_CONTAINS(explod.y, explod.y + 7 - 1)) {
+    u8g.drawBitmapP(explod.x, explod.y, 2, 7, explosion);
+    --explod.v;
   }
 
   // Blink GAME OVER when game is over


### PR DESCRIPTION
### Description

I was getting compilation error

```
Marlin\src\lcd\menu\game\invaders.cpp: In function 'void explode(int8_t, int8_t, int8_t)':
Marlin\src\lcd\menu\game\invaders.cpp:239:8: error: request for member 'x' in 'expl', which is of non-class type 'long double(long double)'
expl.x = x - (EXPL_W) / 2;
^
Marlin\src\lcd\menu\game\invaders.cpp:240:8: error: request for member 'y' in 'expl', which is of non-class type 'long double(long double)'
expl.y = y;
^
Marlin\src\lcd\menu\game\invaders.cpp:241:8: error: request for member 'v' in 'expl', which is of non-class type 'long double(long double)'
expl.v = v;
^
Marlin\src\lcd\menu\game\invaders.cpp: In static member function 'static void InvadersGame::game_screen()':
Marlin\src\lcd\menu\game\invaders.cpp:436:12: error: request for member 'v' in 'expl', which is of non-class type 'long double(long double)'
if (expl.v && PAGE_CONTAINS(expl.y, expl.y + 7 - 1)) {
^
compilation terminated due to -fmax-errors=5.
*** [.pioenvs\LPC1768\src\src\lcd\menu\game\invaders.cpp.o] Error 1
```

While compiling using VSCode, but changing "expl" variable name to "explod" solved my problem. No idea if that problem is caused by VSCode or what, but as it helped me, so I decided to pull request
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Brings peace to whole world
<!-- What does this fix or improve? -->

### Related Issues

No issues related
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
