### PR TITLE
Fix HOTEND_OFFSET_Z + PARKING_EXTRUDER bug

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -369,12 +369,6 @@ inline void fast_line_to_current(const AxisEnum fr_axis) {
         pe_activate_solenoid(active_extruder); // Just save power for inverted magnets
       #endif
     }
-
-    #if HAS_HOTEND_OFFSET
-      current_position[Z_AXIS] += hotend_offset[Z_AXIS][active_extruder] - hotend_offset[Z_AXIS][tmp_extruder];
-    #endif
-
-    if (DEBUGGING(LEVELING)) DEBUG_POS("Applying Z-offset", current_position);
   }
 
 #endif // PARKING_EXTRUDER


### PR DESCRIPTION

### Description

The HOTEND_OFFSET_Z is applied twice in opposite directions ind different code sections 
First in the code section modified by this commit 
Second in [tool_change.ccp L715](https://github.com/MarlinFirmware/Marlin/blob/692a0198f941e34aa02e53079694a10e4ce35fc9/Marlin/src/module/tool_change.cpp#L715)

### Benefits

The HOTEND_OFFSET_Z works with PARKING_EXTRUDER after applying this patch

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/13581
