### PR TITLE
ESP32 HardwareSerial doesn't support flushTX

### DIFF
--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -75,7 +75,7 @@ extern uint8_t marlin_debug_flags;
 #define SERIAL_PRINTF(...)      SERIAL_OUT(printf, __VA_ARGS__)
 #define SERIAL_FLUSH()          SERIAL_OUT(flush)
 
-#if TX_BUFFER_SIZE > 0
+#if TX_BUFFER_SIZE > 0 && !defined(ARDUINO_ARCH_ESP32)
   #define SERIAL_FLUSHTX()      SERIAL_OUT(flushTX)
 #else
   #define SERIAL_FLUSHTX()


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Conditionally disable `flushTX` on ESP32 platform when TX_BUFFER is enabled.

### Benefits

Oddly enough, this only appears when trying to compile with UBL.

### Related Issues

None.
