### PR TITLE
[2.0.x] M43 & LPC176x - the real fix (PR #13568 was wrong)

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
@@ -52,11 +52,14 @@ int freeMemory() {
   return result;
 }
 
+// scan command line for code
+//   returns index into pin map array if found and the pin is valid
+//   returns dval if not found or not a valid pin
 int16_t PARSED_PIN_INDEX(const char code, const int16_t dval) {
-  const uint16_t val = (uint16_t)parser.intval(code), port = val / 100, pin = val % 100;
+  const uint16_t val = (uint16_t)parser.intval(code, -1), port = val / 100, pin = val % 100;
   const  int16_t ind = (port < (NUM_DIGITAL_PINS >> 5) && (pin < 32))
                       ? GET_PIN_MAP_INDEX(port << 5 | pin) : -2;
-  return ind > -2 ? ind : dval;
+  return ind > -1 ? ind : dval;
 }
 
 void flashFirmware(int16_t value) {

--- a/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.cpp
@@ -53,12 +53,11 @@ int freeMemory() {
 }
 
 // scan command line for code
-//   returns index into pin map array if found and the pin is valid
-//   returns dval if not found or not a valid pin
+//   return index into pin map array if found and the pin is valid.
+//   return dval if not found or not a valid pin.
 int16_t PARSED_PIN_INDEX(const char code, const int16_t dval) {
   const uint16_t val = (uint16_t)parser.intval(code, -1), port = val / 100, pin = val % 100;
-  const  int16_t ind = (port < (NUM_DIGITAL_PINS >> 5) && (pin < 32))
-                      ? GET_PIN_MAP_INDEX(port << 5 | pin) : -2;
+  const  int16_t ind = (port < ((NUM_DIGITAL_PINS) >> 5) && pin < 32) ? GET_PIN_MAP_INDEX((port << 5) | pin) : -2;
   return ind > -1 ? ind : dval;
 }
 

--- a/Marlin/src/HAL/HAL_LPC1768/pinsDebug.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinsDebug.h
@@ -40,6 +40,12 @@
 #define PRINT_PIN(p) do {sprintf_P(buffer, PSTR("%d.%02d"), LPC1768_PIN_PORT(p), LPC1768_PIN_PIN(p)); SERIAL_ECHO(buffer);} while (0)
 #define MULTI_NAME_PAD 16 // space needed to be pretty if not first name assigned to a pin
 
+// pins that will cause hang/reset/disconnect in M43 Toggle and Watch utilities
+//  uses pin index
+#ifndef M43_NEVER_TOUCH
+  #define M43_NEVER_TOUCH(Q)  (Q == 29 || Q == 30 ||  Q == 73)  // USB pins
+#endif
+
 // active ADC function/mode/code values for PINSEL registers
 constexpr int8_t ADC_pin_mode(pin_t pin) {
   return (LPC1768_PIN_PORT(pin) == 0 && LPC1768_PIN_PIN(pin) == 2  ? 2 :

--- a/Marlin/src/HAL/HAL_LPC1768/pinsDebug.h
+++ b/Marlin/src/HAL/HAL_LPC1768/pinsDebug.h
@@ -43,7 +43,7 @@
 // pins that will cause hang/reset/disconnect in M43 Toggle and Watch utilities
 //  uses pin index
 #ifndef M43_NEVER_TOUCH
-  #define M43_NEVER_TOUCH(Q)  (Q == 29 || Q == 30 ||  Q == 73)  // USB pins
+  #define M43_NEVER_TOUCH(Q) ((Q) == 29 || (Q) == 30 || (Q) == 73)  // USB pins
 #endif
 
 // active ADC function/mode/code values for PINSEL registers

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -47,13 +47,13 @@ inline void toggle_pins() {
 
   for (uint8_t i = start; i <= end; i++) {
     pin_t pin = GET_PIN_MAP_PIN(i);
-    //report_pin_state_extended(pin, ignore_protection, false);
     if (!VALID_PIN(pin)) continue;
-    if (!ignore_protection && pin_is_protected(pin)) {
+    if ( (!ignore_protection && pin_is_protected(pin)) || M43_NEVER_TOUCH(i) ) {
       report_pin_state_extended(pin, ignore_protection, true, "Untouched ");
       SERIAL_EOL();
     }
     else {
+      watchdog_reset();  //  beat the dog
       report_pin_state_extended(pin, ignore_protection, true, "Pulsing   ");
       #if AVR_AT90USB1286_FAMILY // Teensy IDEs don't know about these pins so must use FASTIO
         if (pin == TEENSY_E2) {
@@ -77,9 +77,13 @@ inline void toggle_pins() {
       {
         pinMode(pin, OUTPUT);
         for (int16_t j = 0; j < repeat; j++) {
+          watchdog_reset();  //  beat the dog
           extDigitalWrite(pin, 0); safe_delay(wait);
+          watchdog_reset();  //  beat the dog
           extDigitalWrite(pin, 1); safe_delay(wait);
+          watchdog_reset();  //  beat the dog
           extDigitalWrite(pin, 0); safe_delay(wait);
+          watchdog_reset();  //  beat the dog
         }
       }
 
@@ -277,7 +281,7 @@ void GcodeSuite::M43() {
     for (uint8_t i = first_pin; i <= last_pin; i++) {
       pin_t pin = GET_PIN_MAP_PIN(i);
       if (!VALID_PIN(pin)) continue;
-      if (!ignore_protection && pin_is_protected(pin)) continue;
+      if ((!ignore_protection && pin_is_protected(pin)) || M43_NEVER_TOUCH(i)) continue;
       pinMode(pin, INPUT_PULLUP);
       delay(1);
       /*
@@ -300,7 +304,7 @@ void GcodeSuite::M43() {
       for (uint8_t i = first_pin; i <= last_pin; i++) {
         pin_t pin = GET_PIN_MAP_PIN(i);
         if (!VALID_PIN(pin)) continue;
-        if (!ignore_protection && pin_is_protected(pin)) continue;
+        if ( (!ignore_protection && pin_is_protected(pin) ) ||  M43_NEVER_TOUCH(i) ) continue;
         const byte val =
           /*
             IS_ANALOG(pin)

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -48,12 +48,12 @@ inline void toggle_pins() {
   for (uint8_t i = start; i <= end; i++) {
     pin_t pin = GET_PIN_MAP_PIN(i);
     if (!VALID_PIN(pin)) continue;
-    if ( (!ignore_protection && pin_is_protected(pin)) || M43_NEVER_TOUCH(i) ) {
+    if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) {
       report_pin_state_extended(pin, ignore_protection, true, "Untouched ");
       SERIAL_EOL();
     }
     else {
-      watchdog_reset();  //  beat the dog
+      watchdog_reset();
       report_pin_state_extended(pin, ignore_protection, true, "Pulsing   ");
       #if AVR_AT90USB1286_FAMILY // Teensy IDEs don't know about these pins so must use FASTIO
         if (pin == TEENSY_E2) {
@@ -77,16 +77,12 @@ inline void toggle_pins() {
       {
         pinMode(pin, OUTPUT);
         for (int16_t j = 0; j < repeat; j++) {
-          watchdog_reset();  //  beat the dog
-          extDigitalWrite(pin, 0); safe_delay(wait);
-          watchdog_reset();  //  beat the dog
-          extDigitalWrite(pin, 1); safe_delay(wait);
-          watchdog_reset();  //  beat the dog
-          extDigitalWrite(pin, 0); safe_delay(wait);
-          watchdog_reset();  //  beat the dog
+          watchdog_reset(); extDigitalWrite(pin, 0); safe_delay(wait);
+          watchdog_reset(); extDigitalWrite(pin, 1); safe_delay(wait);
+          watchdog_reset(); extDigitalWrite(pin, 0); safe_delay(wait);
+          watchdog_reset();
         }
       }
-
     }
     SERIAL_EOL();
   }
@@ -281,7 +277,7 @@ void GcodeSuite::M43() {
     for (uint8_t i = first_pin; i <= last_pin; i++) {
       pin_t pin = GET_PIN_MAP_PIN(i);
       if (!VALID_PIN(pin)) continue;
-      if ((!ignore_protection && pin_is_protected(pin)) || M43_NEVER_TOUCH(i)) continue;
+      if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) continue;
       pinMode(pin, INPUT_PULLUP);
       delay(1);
       /*
@@ -304,7 +300,7 @@ void GcodeSuite::M43() {
       for (uint8_t i = first_pin; i <= last_pin; i++) {
         pin_t pin = GET_PIN_MAP_PIN(i);
         if (!VALID_PIN(pin)) continue;
-        if ( (!ignore_protection && pin_is_protected(pin) ) ||  M43_NEVER_TOUCH(i) ) continue;
+        if (M43_NEVER_TOUCH(i) || (!ignore_protection && pin_is_protected(pin))) continue;
         const byte val =
           /*
             IS_ANALOG(pin)

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -142,6 +142,16 @@ void menu_led();
   #endif
 #endif
 
+#if HAS_GAME_MENU
+  void menu_game();
+#elif ENABLED(MARLIN_BRICKOUT)
+  void lcd_goto_brickout();
+#elif ENABLED(MARLIN_INVADERS)
+  void lcd_goto_invaders();
+#elif ENABLED(MARLIN_SNAKE)
+  void lcd_goto_snake();
+#endif
+
 void menu_main() {
   START_MENU();
   MENU_BACK(MSG_WATCH);

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -142,16 +142,6 @@ void menu_led();
   #endif
 #endif
 
-#if HAS_GAME_MENU
-  void menu_game();
-#elif ENABLED(MARLIN_BRICKOUT)
-  void lcd_goto_brickout();
-#elif ENABLED(MARLIN_INVADERS)
-  void lcd_goto_invaders();
-#elif ENABLED(MARLIN_SNAKE)
-  void lcd_goto_snake();
-#endif
-
 void menu_main() {
   START_MENU();
   MENU_BACK(MSG_WATCH);

--- a/Marlin/src/pins/pinsDebug.h
+++ b/Marlin/src/pins/pinsDebug.h
@@ -102,6 +102,9 @@ const PinInfo pin_array[] PROGMEM = {
 
 #include HAL_PATH(../HAL, pinsDebug.h)  // get the correct support file for this CPU
 
+#ifndef M43_NEVER_TOUCH
+  #define M43_NEVER_TOUCH(Q) false
+#endif
 
 static void print_input_or_output(const bool isout) {
   serialprintPGM(isout ? PSTR("Output = ") : PSTR("Input  = "));


### PR DESCRIPTION
I got it wrong on PR #13568.   M43's Toggle and Watch utilizes were not working because the **PARSED_PIN_INDEX** function was not handling the default conditions properly.

The PR #13568 changes have already been backed out.

**PARSED_PIN_INDEX** scans the command line for code and returns an index into the pin map.  If the code is found and the pin is valid then the index for the pin is returned.  It returns the default if the code is not found or the pin is not valid.

**PARSED_PIN_INDEX** changes:
- Adding -1 results in getting the default when the code is not present. `const uint16_t val = (uint16_t)parser.intval(code, -1), port = val / 100, pin = val % 100;`
- Changing to -1 results in getting the default value if an invalid pin is specified. `return ind > -1 ? ind : dval;`

---

Additional changes were needed to make the M43 toggle utility work reliably with a LPC176x:

- Toggling the three USB pins causes hangs & disconnects.  The **M43_NEVER_TOUCH** macro was added to cover this.
- Random hangs and disconnects were occurring when the WDT was enabled.  WDT resets were added to minimize. this.