### PR TITLE
Extends the ESP32 HardwareSerial with the missing flushTX method for compatibility.

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/FlushableHardwareSerial.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/FlushableHardwareSerial.cpp
@@ -1,0 +1,33 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FlushableHardwareSerial.h"
+
+#ifdef ARDUINO_ARCH_ESP32
+
+FlushableHardwareSerial::FlushableHardwareSerial(int uart_nr)
+    : HardwareSerial(uart_nr)
+{}
+
+FlushableHardwareSerial flushableSerial(0);
+
+#endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/HAL_ESP32/FlushableHardwareSerial.h
+++ b/Marlin/src/HAL/HAL_ESP32/FlushableHardwareSerial.h
@@ -1,0 +1,36 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifdef ARDUINO_ARCH_ESP32
+
+#include <HardwareSerial.h>
+
+class FlushableHardwareSerial : public HardwareSerial {
+public:
+  FlushableHardwareSerial(int uart_nr);
+
+  inline void flushTX(void) { /* No need to flush the hardware serial, but defined here for compatibility. */ }
+};
+
+extern FlushableHardwareSerial flushableSerial;
+
+#endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/HAL_ESP32/HAL.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.h
@@ -48,6 +48,7 @@
 #include "HAL_timers_ESP32.h"
 
 #include "WebSocketSerial.h"
+#include "FlushableHardwareSerial.h"
 
 // --------------------------------------------------------------------------
 // Defines
@@ -55,7 +56,7 @@
 
 extern portMUX_TYPE spinlock;
 
-#define MYSERIAL0 Serial
+#define MYSERIAL0 flushableSerial
 
 #if ENABLED(WIFISUPPORT)
   #define NUM_SERIAL 2


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Adds the `flushTX` method to the ESP32 hardware serial.

### Benefits

It is now possible to use UBL on ESP32.

### Related Issues

None?
