### PR TITLE
[2.0.x] Fix MKS Robin section in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -302,7 +302,7 @@ monitor_speed = 250000
 # MKS Robin (STM32F103ZET6)
 #
 [env:mks_robin]
-platform      = ststm32@5.1.0
+platform      = ststm32@5.3.0
 framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin.py
@@ -318,6 +318,7 @@ lib_ignore    = c1921b4
   Adafruit NeoPixel
   libf3e
   TMC26XStepper
+  U8glib-HAL
 
 #
 # STM32F407VET6 with RAMPS-like shield


### PR DESCRIPTION
### Description
Updated ststm32 version because with old version we have build errors.
Added U8glib-HAL to ignore list because there are also build errors.

### Benefits
With this changes we have buildable and usable Marlin in MKS Robin board.

### Related Issues
Not found. But I have build errors without this fix.
