### PR TITLE
Suppress compile warning

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -59,7 +59,7 @@ int8_t encoderTopLine, encoderLine, screen_items;
 typedef struct {
   screenFunc_t menu_function;
   uint32_t encoder_position;
-  uint8_t top_line, items;
+  int8_t top_line, items;
 } menuPosition;
 menuPosition screen_history[6];
 uint8_t screen_history_depth = 0;


### PR DESCRIPTION
Match top line and item count in saved screen history to the encoder top line and items count, which are signed to more easily handle underflow.