### PR TITLE
Revert "[2.0.x] G33 clean up"

### DIFF
--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -140,6 +140,12 @@ static void print_calibration_settings(const bool end_stops, const bool tower_an
   if ((!end_stops && tower_angles) || (end_stops && !tower_angles)) { // XOR
     SERIAL_ECHOPAIR("  Radius:", delta_radius);
   }
+  #if HAS_BED_PROBE
+    if (!end_stops && !tower_angles) {
+      SERIAL_ECHO_SP(30);
+      print_signed_float(PSTR("Offset"), zprobe_zoffset);
+    }
+  #endif
   SERIAL_EOL();
 }
 
@@ -188,19 +194,30 @@ static float std_dev_points(float z_pt[NPP + 1], const bool _0p_cal, const bool 
 /**
  *  - Probe a point
  */
-static float calibration_probe(const float &nx, const float &ny, const bool stow) {
+static float calibration_probe(const float &nx, const float &ny, const bool stow, const bool set_up) {
   #if HAS_BED_PROBE
-    return probe_pt(nx, ny, stow ? PROBE_PT_STOW : PROBE_PT_RAISE, 0, false);
+    return probe_pt(nx, ny, set_up ? PROBE_PT_BIG_RAISE : stow ? PROBE_PT_STOW : PROBE_PT_RAISE, 0, false);
   #else
     UNUSED(stow);
+    UNUSED(set_up);
     return lcd_probe_pt(nx, ny);
   #endif
 }
 
+#if HAS_BED_PROBE && HAS_LCD_MENU
+  static float probe_z_shift(const float center) {
+    STOW_PROBE();
+    endstops.enable_z_probe(false);
+    float z_shift = lcd_probe_pt(0, 0) - center;
+    endstops.enable_z_probe(true);
+    return z_shift;
+  }
+#endif
+
 /**
  *  - Probe a grid
  */
-static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_points, const bool towers_set, const bool stow_after_each) {
+static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_points, const bool towers_set, const bool stow_after_each, const bool set_up) {
   const bool _0p_calibration      = probe_points == 0,
              _1p_calibration      = probe_points == 1 || probe_points == -1,
              _4p_calibration      = probe_points == 2,
@@ -223,7 +240,7 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
   if (!_0p_calibration) {
 
     if (!_7p_no_intermediates && !_7p_4_intermediates && !_7p_11_intermediates) { // probe the center
-      z_pt[CEN] += calibration_probe(0, 0, stow_after_each);
+      z_pt[CEN] += calibration_probe(0, 0, stow_after_each, set_up);
       if (isnan(z_pt[CEN])) return false;
     }
 
@@ -233,7 +250,7 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
       I_LOOP_CAL_PT(rad, start, steps) {
         const float a = RADIANS(210 + (360 / NPP) *  (rad - 1)),
                     r = delta_calibration_radius * 0.1;
-        z_pt[CEN] += calibration_probe(cos(a) * r, sin(a) * r, stow_after_each);
+        z_pt[CEN] += calibration_probe(cos(a) * r, sin(a) * r, stow_after_each, set_up);
         if (isnan(z_pt[CEN])) return false;
      }
       z_pt[CEN] /= float(_7p_2_intermediates ? 7 : probe_points);
@@ -257,7 +274,7 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
           const float a = RADIANS(210 + (360 / NPP) *  (rad - 1)),
                       r = delta_calibration_radius * (1 - 0.1 * (zig_zag ? offset - circle : circle)),
                       interpol = FMOD(rad, 1);
-          const float z_temp = calibration_probe(cos(a) * r, sin(a) * r, stow_after_each);
+          const float z_temp = calibration_probe(cos(a) * r, sin(a) * r, stow_after_each, set_up);
           if (isnan(z_temp)) return false;
           // split probe point to neighbouring calibration points
           z_pt[uint8_t(LROUND(rad - interpol + NPP - 1)) % NPP + 1] += z_temp * sq(cos(RADIANS(interpol * 90)));
@@ -386,7 +403,10 @@ static float auto_tune_a() {
  *
  * Parameters:
  *
+ *   S   Setup mode; disables probe protection
+ *
  *   Pn  Number of probe points:
+ *      P-1      Checks the z_offset with a center probe and paper test.
  *      P0       Normalizes calibration.
  *      P1       Calibrates height only with center probe.
  *      P2       Probe center and towers. Calibrate height, endstops and delta radius.
@@ -409,15 +429,22 @@ static float auto_tune_a() {
  */
 void GcodeSuite::G33() {
 
-  const int8_t probe_points = parser.intval('P', DELTA_CALIBRATION_DEFAULT_POINTS);
-  if (!WITHIN(probe_points, 0, 10)) {
-    SERIAL_ECHOLNPGM("?(P)oints is implausible (0-10).");
+  const bool set_up =
+    #if HAS_BED_PROBE
+      parser.seen('S');
+    #else
+      false;
+    #endif
+
+  const int8_t probe_points = set_up ? 2 : parser.intval('P', DELTA_CALIBRATION_DEFAULT_POINTS);
+  if (!WITHIN(probe_points, -1, 10)) {
+    SERIAL_ECHOLNPGM("?(P)oints is implausible (-1 - 10).");
     return;
   }
 
   const bool towers_set = !parser.seen('T');
 
-  const float calibration_precision = parser.floatval('C', 0.0);
+  const float calibration_precision = set_up ? Z_CLEARANCE_BETWEEN_PROBES / 5.0 : parser.floatval('C', 0.0);
   if (calibration_precision < 0) {
     SERIAL_ECHOLNPGM("?(C)alibration precision is implausible (>=0).");
     return;
@@ -425,17 +452,25 @@ void GcodeSuite::G33() {
 
   const int8_t force_iterations = parser.intval('F', 0);
   if (!WITHIN(force_iterations, 0, 30)) {
-    SERIAL_ECHOLNPGM("?(F)orce iteration is implausible (0-30).");
+    SERIAL_ECHOLNPGM("?(F)orce iteration is implausible (0 - 30).");
     return;
   }
 
   const int8_t verbose_level = parser.byteval('V', 1);
   if (!WITHIN(verbose_level, 0, 3)) {
-    SERIAL_ECHOLNPGM("?(V)erbose level is implausible (0-3).");
+    SERIAL_ECHOLNPGM("?(V)erbose level is implausible (0 - 3).");
     return;
   }
 
   const bool stow_after_each = parser.seen('E');
+
+  if (set_up) {
+    delta_height = 999.99;
+    delta_radius = DELTA_PRINTABLE_RADIUS;
+    ZERO(delta_endstop_adj);
+    ZERO(delta_tower_angle_trim);
+    recalc_delta_settings();
+  }
 
   const bool _0p_calibration      = probe_points == 0,
              _1p_calibration      = probe_points == 1 || probe_points == -1,
@@ -485,6 +520,7 @@ void GcodeSuite::G33() {
   PGM_P checkingac = PSTR("Checking... AC");
   serialprintPGM(checkingac);
   if (verbose_level == 0) SERIAL_ECHOPGM(" (DRY-RUN)");
+  if (set_up) SERIAL_ECHOPGM("  (SET-UP)");
   SERIAL_EOL();
   ui.set_status_P(checkingac);
 
@@ -503,7 +539,7 @@ void GcodeSuite::G33() {
 
     // Probe the points
     zero_std_dev_old = zero_std_dev;
-    if (!probe_calibration_points(z_at_pt, probe_points, towers_set, stow_after_each)) {
+    if (!probe_calibration_points(z_at_pt, probe_points, towers_set, stow_after_each, set_up)) {
       SERIAL_ECHOLNPGM("Correct delta settings with M665 and M666");
       return AC_CLEANUP();
     }
@@ -551,6 +587,11 @@ void GcodeSuite::G33() {
       delta_calibration_radius = cr_old;
 
       switch (probe_points) {
+        case -1:
+          #if HAS_BED_PROBE && HAS_LCD_MENU
+            zprobe_zoffset += probe_z_shift(z_at_pt[CEN]);
+          #endif
+
         case 0:
           test_precision = 0.00; // forced end
           break;

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -114,6 +114,8 @@ void menu_delta_calibrate() {
 
   #if ENABLED(DELTA_AUTO_CALIBRATION)
     MENU_ITEM(gcode, MSG_DELTA_AUTO_CALIBRATE, PSTR("G33"));
+    MENU_ITEM(gcode, MSG_DELTA_HEIGHT_CALIBRATE, PSTR("G33 S P1"));
+    MENU_ITEM(gcode, MSG_DELTA_Z_OFFSET_CALIBRATE, PSTR("G33 P-1"));
     #if ENABLED(EEPROM_SETTINGS)
       MENU_ITEM(function, MSG_STORE_EEPROM, lcd_store_settings);
       MENU_ITEM(function, MSG_LOAD_EEPROM, lcd_load_settings);

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -499,7 +499,7 @@ void clean_up_after_endstop_or_probe_move() {
       soft_endstop[axis].min = base_min_pos(axis);
       soft_endstop[axis].max = (axis == Z_AXIS ? delta_height
       #if HAS_BED_PROBE
-        - zprobe_zoffset
+        - zprobe_zoffset + Z_PROBE_OFFSET_FROM_EXTRUDER
       #endif
       : base_max_pos(axis));
 
@@ -1294,7 +1294,7 @@ void set_axis_is_at_home(const AxisEnum axis) {
   #elif ENABLED(DELTA)
     current_position[axis] = (axis == Z_AXIS ? delta_height
     #if HAS_BED_PROBE
-      - zprobe_zoffset
+      - zprobe_zoffset + Z_PROBE_OFFSET_FROM_EXTRUDER
     #endif
     : base_home_pos(axis));
   #else


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#12648

This change unnecessarily removed 2 functions that are very useful for calibrating the Anycubic Kossel. With them gone, the user is reduced to guesswork. I scratched up my bed a bit trying to guess the offset...