### PR TITLE
Remove repaint of status screen on stepper timeout (#13623)

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -473,14 +473,11 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
         #if ENABLED(DISABLE_INACTIVE_E)
           disable_e_steppers();
         #endif
-        #if HAS_LCD_MENU
-          ui.status_screen();
-          #if ENABLED(AUTO_BED_LEVELING_UBL)
-            if (ubl.lcd_map_control) {
-              ubl.lcd_map_control = false;
-              ui.defer_status_screen(false);
-            }
-          #endif
+        #if HAS_LCD_MENU && ENABLED(AUTO_BED_LEVELING_UBL)
+          if (ubl.lcd_map_control) {
+            ubl.lcd_map_control = false;
+            ui.defer_status_screen(false);
+          }
         #endif
       }
     }

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -457,7 +457,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
   if (stepper_inactive_time) {
     static bool already_shutdown_steppers; // = false
     if (planner.has_blocks_queued())
-      gcode.previous_move_ms = ms; // reset_stepper_timeout to keep steppers powered
+      gcode.reset_stepper_timeout();
     else if (MOVE_AWAY_TEST && !ignore_stepper_queue && ELAPSED(ms, gcode.previous_move_ms + stepper_inactive_time)) {
       if (!already_shutdown_steppers) {
         already_shutdown_steppers = true;  // L6470 SPI will consume 99% of free time without this
@@ -614,7 +614,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
         }
       #endif // !SWITCHING_EXTRUDER
 
-      gcode.previous_move_ms = ms; // reset_stepper_timeout to keep steppers powered
+      gcode.reset_stepper_timeout();
     }
   #endif // EXTRUDER_RUNOUT_PREVENT
 


### PR DESCRIPTION
- This would cause a garbled LCD with LIGHTWEIGHT_UI and could also interrupt whatever else the user might be doing in a submenu (such as playing games!)

According to @InsanityAutomation, the original intent for that was to return the user the the status screen if they were in the babystepping screen and the steppers were de-energized. This would keep the user from unsuccessfully babystepping inactive steppers.

However, commit https://github.com/MarlinFirmware/Marlin/commit/9cee81d47eea0c8700e265f10f103ca99499511f by @Roxy-3D seems to have enhanced the babystepping code to 1) reset the stepper timeout each time a babystep happens 2) re-energize the steppers if they were de-energized when a babystep was requested, which covers all the possibilities and removes the need for `ui.status_screen()` (which should have been `ui.return_to_status()`)