### PR TITLE
Fix Azteeg X5 mini board name

### DIFF
--- a/Marlin/src/pins/pins_AZTEEG_X5_MINI.h
+++ b/Marlin/src/pins/pins_AZTEEG_X5_MINI.h
@@ -29,7 +29,7 @@
 #endif
 
 #ifndef BOARD_NAME
-  #define BOARD_NAME        "Azteeg X5 MINI WIFI"
+  #define BOARD_NAME        "Azteeg X5 MINI"
 #endif
 #define BOARD_WEBSITE_URL "http://www.panucatt.com/azteeg_X5_mini_reprap_3d_printer_controller_p/ax5mini.htm"
 


### PR DESCRIPTION
Fixes the Azteeg X5 mini board name in the file: `Marlin/src/pins/pins_AZTEEG_X5_MINI.h`

Commit reference:
https://github.com/MarlinFirmware/Marlin/pull/13632/commits/1606caa230bced4564eae1c6542a3d33db018f3e

For some reason all of my commits are appearing in this pull request. I probably did something wrong..