### PR TITLE
Save modified files before starting AutoBuild

### DIFF
--- a/buildroot/share/vscode/AutoBuildMarlin/extension.js
+++ b/buildroot/share/vscode/AutoBuildMarlin/extension.js
@@ -8,6 +8,7 @@ function activate(context) {
 
   var NEXT_TERM_ID = 1;
   var pio_build     = vscode.commands.registerCommand('piobuild',     function () {
+    vscode.commands.executeCommand('workbench.action.files.saveAll');
     const terminal = vscode.window.createTerminal(`AB Build #${NEXT_TERM_ID++}`);
     terminal.show(true);
     terminal.sendText("python buildroot/share/atom/auto_build.py build");
@@ -18,11 +19,13 @@ function activate(context) {
     terminal.sendText("python buildroot/share/atom/auto_build.py clean");
   });
   var pio_upload    = vscode.commands.registerCommand('pioupload',    function () {
+    vscode.commands.executeCommand('workbench.action.files.saveAll');
     const terminal = vscode.window.createTerminal(`AB Upload #${NEXT_TERM_ID++}`);
     terminal.show(true);
     terminal.sendText("python buildroot/share/atom/auto_build.py upload");
   });
   var pio_traceback = vscode.commands.registerCommand('piotraceback', function () {
+    vscode.commands.executeCommand('workbench.action.files.saveAll');
     const terminal = vscode.window.createTerminal(`AB Traceback #${NEXT_TERM_ID++}`);
     terminal.show(true);
     terminal.sendText("python buildroot/share/atom/auto_build.py traceback");


### PR DESCRIPTION
### Description
Make AutoBuild save any modified files before starting a build, upload, or traceback upload.
### Benefits
This makes AutoBuild behave more like manual PIO (which auto-saves files before starting to build) and other IDEs such as Visual Studio. Without this fix it is easy to end up with a firmware that does not have the configuration that is expected.
### Related Issues
None