### PR TITLE
[ABL-UBL] Option to REMEMBER_LEVELING_STATE_AFTER_REBOOT

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1113,6 +1113,13 @@
 //#define RESTORE_LEVELING_AFTER_G28
 
 /**
+ * This save ABL and UBL Leveling State On or Off to EPROM.
+ * Enable this option makes printer back to previous state after reboot.
+ * Disable this option makes Leveling State Off after reboot.
+ */
+#define REMEMBER_LEVELING_STATE_AFTER_REBOOT
+
+/**
  * Enable detailed logging of G28, G29, M48, etc.
  * Turn on with the command 'M111 S32'.
  * NOTE: Requires a lot of PROGMEM!

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -601,18 +601,22 @@ void MarlinSettings::postprocess() {
     }
 
     //
-    // Unified Bed Leveling
+    // Unified Bed Leveling & Leveling state
     //
     {
       _FIELD_TEST(planner_leveling_active);
 
-      #if ENABLED(AUTO_BED_LEVELING_UBL)
+      #if HAS_ABL_OR_UBL && ENABLED(REMEMBER_LEVELING_STATE_AFTER_REBOOT)
         EEPROM_WRITE(planner.leveling_active);
-        EEPROM_WRITE(ubl.storage_slot);
       #else
         const bool ubl_active = false;
-        const int8_t storage_slot = -1;
         EEPROM_WRITE(ubl_active);
+      #endif // HAS_ABL_OR_UBL && REMEMBER_LEVELING_STATE_AFTER_REBOOT
+
+      #if ENABLED(AUTO_BED_LEVELING_UBL) 
+        EEPROM_WRITE(ubl.storage_slot);
+      #else
+        const int8_t storage_slot = -1;
         EEPROM_WRITE(storage_slot);
       #endif // AUTO_BED_LEVELING_UBL
     }
@@ -1315,20 +1319,24 @@ void MarlinSettings::postprocess() {
       }
 
       //
-      // Unified Bed Leveling active state
+      // Unified Bed Leveling & Leveling state
       //
       {
         _FIELD_TEST(planner_leveling_active);
 
-        #if ENABLED(AUTO_BED_LEVELING_UBL)
+        #if HAS_ABL_OR_UBL && ENABLED(REMEMBER_LEVELING_STATE_AFTER_REBOOT)
           EEPROM_READ(planner.leveling_active);
-          EEPROM_READ(ubl.storage_slot);
         #else
           bool planner_leveling_active;
-          uint8_t ubl_storage_slot;
           EEPROM_READ(planner_leveling_active);
+        #endif // HAS_ABL_OR_UBL && REMEMBER_LEVELING_STATE_AFTER_REBOOT
+
+        #if ENABLED(AUTO_BED_LEVELING_UBL)
+          EEPROM_READ(ubl.storage_slot);
+        #else
+          uint8_t ubl_storage_slot;
           EEPROM_READ(ubl_storage_slot);
-        #endif
+        #endif // AUTO_BED_LEVELING_UBL
       }
 
       //


### PR DESCRIPTION
### Requirements

Add option to makes ABL and UBL remember or reset Leveling State after Reboot.
Currently Marlin Remember UBL Leveling state but Reset ABL Leveling State.

### Description

Add
#define REMEMBER_LEVELING_STATE_AFTER_REBOOT
 /**
 * This save ABL and UBL Leveling State On or Off to EPROM.
 * Enable this option makes printer back to previous state after reboot.
 * Disable this option makes Leveling State Off after reboot.
 */

### Benefits

User usually forget to turn on Bed Leveling before printing.

### Related Issues

There are many issue about saving leveling state. Hope this will solve them all.