### PR TITLE
Require homing to toggle leveling

### DIFF
--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -424,8 +424,6 @@ void menu_motion() {
   //
   MENU_BACK(MSG_MAIN);
 
-  const bool is_homed = all_axes_known();
-
   //
   // Move Axis
   //
@@ -467,7 +465,7 @@ void menu_motion() {
     #if DISABLED(PROBE_MANUALLY)
       MENU_ITEM(gcode, MSG_LEVEL_BED, PSTR("G28\nG29"));
     #endif
-    if (is_homed && leveling_is_valid()) {
+    if (all_axes_homed() && leveling_is_valid()) {
       bool new_level_state = planner.leveling_active;
       MENU_ITEM_EDIT_CALLBACK(bool, MSG_BED_LEVELING, &new_level_state, _lcd_toggle_bed_leveling);
     }

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -424,6 +424,8 @@ void menu_motion() {
   //
   MENU_BACK(MSG_MAIN);
 
+  const bool is_homed = all_axes_known();
+
   //
   // Move Axis
   //
@@ -465,7 +467,7 @@ void menu_motion() {
     #if DISABLED(PROBE_MANUALLY)
       MENU_ITEM(gcode, MSG_LEVEL_BED, PSTR("G28\nG29"));
     #endif
-    if (leveling_is_valid()) {
+    if (is_homed && leveling_is_valid()) {
       bool new_level_state = planner.leveling_active;
       MENU_ITEM_EDIT_CALLBACK(bool, MSG_BED_LEVELING, &new_level_state, _lcd_toggle_bed_leveling);
     }


### PR DESCRIPTION
Leveling can be toggled if Homed and leveling is valid. 

( consistency between Leveling in Motion Menu and in LCD Bed Leveling Menu..)