### PR TITLE
Level Corner Before Bed Leveling

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -243,6 +243,11 @@ void menu_bed_leveling() {
     if (!is_homed) MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
   #endif
 
+  // Level Corner
+  #if ENABLED(LEVEL_BED_CORNERS)
+    MENU_ITEM(submenu, MSG_LEVEL_CORNERS, _lcd_level_bed_corners);
+  #endif
+
   // Level Bed
   #if EITHER(PROBE_MANUALLY, MESH_BED_LEVELING)
     // Manual leveling uses a guided procedure
@@ -279,10 +284,6 @@ void menu_bed_leveling() {
     MENU_ITEM(submenu, MSG_ZPROBE_ZOFFSET, lcd_babystep_zoffset);
   #elif HAS_BED_PROBE
     MENU_ITEM_EDIT(float52, MSG_ZPROBE_ZOFFSET, &zprobe_zoffset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
-  #endif
-
-  #if ENABLED(LEVEL_BED_CORNERS)
-    MENU_ITEM(submenu, MSG_LEVEL_CORNERS, _lcd_level_bed_corners);
   #endif
 
   #if ENABLED(EEPROM_SETTINGS)

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -452,6 +452,10 @@ void menu_motion() {
   //
   // Level Bed
   //
+  #if ENABLED(LEVEL_BED_CORNERS) && DISABLED(LCD_BED_LEVELING)
+    MENU_ITEM(function, MSG_LEVEL_CORNERS, _lcd_level_bed_corners);
+  #endif
+
   #if ENABLED(AUTO_BED_LEVELING_UBL)
 
     MENU_ITEM(submenu, MSG_UBL_LEVEL_BED, _lcd_ubl_level_bed);
@@ -473,10 +477,6 @@ void menu_motion() {
       MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float3, MSG_Z_FADE_HEIGHT, &lcd_z_fade_height, 0, 100, _lcd_set_z_fade_height);
     #endif
 
-  #endif
-
-  #if ENABLED(LEVEL_BED_CORNERS) && DISABLED(LCD_BED_LEVELING)
-    MENU_ITEM(function, MSG_LEVEL_CORNERS, _lcd_level_bed_corners);
   #endif
 
   //


### PR DESCRIPTION
User must Level Corner Before Bed Leveling.
Therefore it is better to put Level Corner Above Bed Leveling. 
It's like a reminder that we must Level Corner First,
Currently Level Corner is burried at bottom.