### PR TITLE
Restore declarations of G53-G59

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -269,6 +269,16 @@ void GcodeSuite::process_parsed_command(
           break;
       #endif
 
+      #if ENABLED(CNC_COORDINATE_SYSTEMS)
+        case 53: G53(); break;
+        case 54: G54(); break;
+        case 55: G55(); break;
+        case 56: G56(); break;
+        case 57: G57(); break;
+        case 58: G58(); break;
+        case 59: G59(); break;
+      #endif
+      
       #if ENABLED(GCODE_MOTION_MODES)
         case 80: G80(); break;                                    // G80: Reset the current motion mode
       #endif

--- a/Marlin/src/gcode/geometry/G53-G59.cpp
+++ b/Marlin/src/gcode/geometry/G53-G59.cpp
@@ -59,7 +59,7 @@ bool GcodeSuite::select_coordinate_system(const int8_t _new) {
  *
  * Marlin also uses G53 on a line by itself to go back to native space.
  */
-inline void GcodeSuite::G53() {
+void GcodeSuite::G53() {
   const int8_t _system = active_coordinate_system;
   active_coordinate_system = -1;
   if (parser.chain()) { // If this command has more following...


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Fixes support for G53-G59, which are apparently implemented but not available, even when CNC_COORDINATE_SYSTEMS is defined.  I have tested the functionality only briefly, far from a detailed test!  The assumption is that the functionality is already working and that only the parsing was missing.

I specifically wanted G53-G59 for a particular project I'm working on, and I found mention that it had been implemented in Marlin, which is why I went digging for it.

### Benefits

Allows work offsets (functionality provided by G53-G59).

### Related Issues

I apologize in advance if this suggestion or pull request is not in the proper format or going through the proper channels.  I have been developing software for many years but open source collaboration is unfamiliar to me.
