### PR TITLE
MBL stops after homing all axes

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -194,7 +194,7 @@
     ui.defer_status_screen();
     set_all_unhomed();
     ui.goto_screen(_lcd_level_bed_homing);
-    enqueue_and_echo_commands_P(PSTR("G28"));
+    enqueue_and_echo_commands_P(PSTR("G28\nG29"));
   }
 
 #endif // PROBE_MANUALLY || MESH_BED_LEVELING


### PR DESCRIPTION
### Description

MBL Stop After Homing.  There is No G29 after G28.

### Related Issues

[BUG] 2.0.x LCD-Bedleveling doesn't work #13591
Manual bed levelling stops after homing all axes #13181
