### PR TITLE
Fix uninitialized call to spindle pwm pin, remove overlap to heater 2

### DIFF
--- a/Marlin/src/gcode/control/M3-M5.cpp
+++ b/Marlin/src/gcode/control/M3-M5.cpp
@@ -74,7 +74,9 @@ inline void delay_for_power_down() { safe_delay(SPINDLE_LASER_POWERDOWN_DELAY); 
 
 inline void set_spindle_laser_ocr(const uint8_t ocr) {
   WRITE(SPINDLE_LASER_ENA_PIN, SPINDLE_LASER_ENABLE_INVERT); // turn spindle on (active low)
-  analogWrite(SPINDLE_LASER_PWM_PIN, (SPINDLE_LASER_PWM_INVERT) ? 255 - ocr : ocr);
+  #if ENABLED(SPINDLE_LASER_PWM)
+    analogWrite(SPINDLE_LASER_PWM_PIN, (SPINDLE_LASER_PWM_INVERT) ? 255 - ocr : ocr);
+  #endif
 }
 
 #if ENABLED(SPINDLE_LASER_PWM)

--- a/Marlin/src/pins/pins_FORMBOT_TREX3.h
+++ b/Marlin/src/pins/pins_FORMBOT_TREX3.h
@@ -143,7 +143,7 @@
   #define LED_PIN          13
 #endif
 
-#define SPINDLE_LASER_PWM_PIN     7   // MUST BE HARDWARE PWM
+#define SPINDLE_LASER_PWM_PIN    -1   // MUST BE HARDWARE PWM
 #define SPINDLE_LASER_ENA_PIN     4   // Pin should have a pullup!
 
 // Use the RAMPS 1.4 Analog input 5 on the AUX2 connector


### PR DESCRIPTION
Fix Spindle laser call to pwm pin when pwm is disabled.

Remove overlapping pwm pin definition for trex3