### PR TITLE
Add pins for MKS_MINI_12864 to the SKR boards

### DIFF
--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
@@ -212,7 +212,7 @@
 
 #endif // ULTRA_LCD
 
-#if enabled MKS_MINI_12864       //assign pins for MKS_MINI_12864
+#if ENABLED(MKS_MINI_12864)       //assign pins for MKS_MINI_12864
 	#define DOGLCD_CS P1_21
 	#define DOGLCD_A0 P1_22
 	#define USB_SD_ONBOARD        // Provide the onboard SD card to the host as a USB mass storage device

--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
@@ -212,11 +212,17 @@
 
 #endif // ULTRA_LCD
 
-//#define USB_SD_DISABLED
-#define USB_SD_ONBOARD        // Provide the onboard SD card to the host as a USB mass storage device
-
-#define LPC_SD_LCD            // Marlin uses the SD drive attached to the LCD
-//#define LPC_SD_ONBOARD        // Marlin uses the SD drive on the control board
+#if enabled MKS_MINI_12864       //assign pins for MKS_MINI_12864
+	#define DOGLCD_CS P1_21
+	#define DOGLCD_A0 P1_22
+	#define USB_SD_ONBOARD        // Provide the onboard SD card to the host as a USB mass storage device
+	#define LPC_SD_LCD            // MKS_MINI_12864 uses SD card on the display
+#else
+	//#define USB_SD_DISABLED
+	#define USB_SD_ONBOARD        // Provide the onboard SD card to the host as a USB mass storage device
+	//#define LPC_SD_LCD            // Marlin uses the SD drive attached to the LCD
+	#define LPC_SD_ONBOARD        // Marlin uses the SD drive on the control board
+#endif
 
 #if ENABLED(LPC_SD_LCD)
 

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -145,7 +145,7 @@
 // MKS_MINI_12864 requires jumpers on the SKR V1.1 board as documented in this web page:
 //  https://www.facebook.com/groups/505736576548648/permalink/630639874058317/
 
-#if enabled MKS_MINI_12864       //assign pins for MKS_MINI_12864
+#if ENABLED(MKS_MINI_12864)       //assign pins for MKS_MINI_12864
     #define DOGLCD_CS	P2_06 
     #define DOGLCD_A0	P0_16 
 	#undef	LPC_SD_ONBOARD

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -142,6 +142,17 @@
 
 #endif
 
+// MKS_MINI_12864 requires jumpers on the SKR V1.1 board as documented in this web page:
+//  https://www.facebook.com/groups/505736576548648/permalink/630639874058317/
+
+#if enabled MKS_MINI_12864       //assign pins for MKS_MINI_12864
+    #define DOGLCD_CS	P2_06 
+    #define DOGLCD_A0	P0_16 
+	#undef	LPC_SD_ONBOARD
+	#define LPC_SD_LCD            // MKS_MINI_12864 uses SD card on the display
+#endif
+
+
 // Trinamic driver support
 
 #if HAS_TRINAMIC


### PR DESCRIPTION
### Requirements

Add the needed pins to support the MKS_MINI_12864 to the SKR V1.1 and SKR V1.3 pins files
The SKR V1.1 requires jumpers on the PCB as detailed in https://www.facebook.com/groups/505736576548648/permalink/630639874058317/

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Support for MKS_MINI_12864

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
