### PR TITLE
Define I2S pins for ESP32

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -303,9 +303,9 @@ int i2s_init() {
   xTaskCreate(stepperTask, "StepperTask", 10000, NULL, 1, NULL);
 
   // Route the i2s pins to the appropriate GPIO
-  gpio_matrix_out_check(22, I2S0O_DATA_OUT23_IDX, 0, 0);
-  gpio_matrix_out_check(25, I2S0O_WS_OUT_IDX, 0, 0);
-  gpio_matrix_out_check(26, I2S0O_BCK_OUT_IDX, 0, 0);
+  gpio_matrix_out_check(I2S_DATA, I2S0O_DATA_OUT23_IDX, 0, 0);
+  gpio_matrix_out_check(I2S_BCK, I2S0O_BCK_OUT_IDX, 0, 0);
+  gpio_matrix_out_check(I2S_WS, I2S0O_WS_OUT_IDX, 0, 0);
 
   // Start the I2S peripheral
   return i2s_start(I2S_NUM_0);

--- a/Marlin/src/HAL/HAL_ESP32/i2s.h
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.h
@@ -29,3 +29,9 @@ int i2s_init();
 void i2s_write(uint8_t pin, uint8_t val);
 
 void i2s_push_sample();
+
+// pin definitions
+
+#define I2S_WS 25
+#define I2S_BCK 26
+#define I2S_DATA 27


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Added defines for the I2S expander pins & moved the data pin to 27 instead of 22 (which is usually used for I2C). Is that OK @simon-jouet?

### Benefits

Not very many, really.

### Related Issues

None.
