### PR TITLE
Fix EEPROM_CHITCHAT

### DIFF
--- a/Marlin/src/core/debug_out.h
+++ b/Marlin/src/core/debug_out.h
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
 
 //
 // Serial aliases for debugging.


### PR DESCRIPTION
Actually allow debug_out.h to be included more than once so that it works correctly for files which include ``ubl.h``.

### Description
This fixes a problem with the new ``DEBUG_OUT`` code when it is used more than once in the same compilation unit (in this case in the ``ubl.h`` header as well as in ``configuration_store.cpp``).
It looks like the intention in ``ubl.h`` was for the initial call to only apply to code in the header file, and then get turned off by the second ``#include "../../../core/debug_out.h"`` at the end of the file. Then ``configuration_store.cpp`` could do its own ``#include "../../../core/debug_out.h"`` and turn on debugging for ``EEPROM_CHITCHAT``. However, the ``#pragma once`` made the second and third ``#include`` be NOOPs so the ``EEPROM_CHITCHAT`` debugging was never enabled. This fix removes the ``#pragma once`` so the code can work as intended.

### Benefits

Allows ``EEPROM_CHITCHAT`` to work without ``DEBUG_LEVELING_FEATURE`` enabled.

### Related Issues
#13688
#13641
