### PR TITLE
LCD Level Corner is function (not submenu) - for consistency

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -282,7 +282,7 @@ void menu_bed_leveling() {
   #endif
 
   #if ENABLED(LEVEL_BED_CORNERS)
-    MENU_ITEM(submenu, MSG_LEVEL_CORNERS, _lcd_level_bed_corners);
+    MENU_ITEM(function, MSG_LEVEL_CORNERS, _lcd_level_bed_corners);
   #endif
 
   #if ENABLED(EEPROM_SETTINGS)


### PR DESCRIPTION
LCD Level Corner is a function (not submenu)

for comparation check 

menu_motion.cpp lines 478

```
#if ENABLED(LEVEL_BED_CORNERS) && DISABLED(LCD_BED_LEVELING)
    MENU_ITEM(function, MSG_LEVEL_CORNERS, _lcd_level_bed_corners);
#endif

```