### PR TITLE
Add Menu on LCD for Autoleveling TouchMI

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -732,6 +732,15 @@
   //#define BLTOUCH_DELAY 375   // (ms) Enable and increase if needed
 #endif
 
+//For tuning Autoleveling sensor "TouchMi" on lcd 
+//#define TOUCHMI 
+#if ENABLED(TOUCHMI)
+      #define FIX_MOUNTED_PROBE
+	  #define Z_SAFE_HOMING
+	  #define Z_HOMING_HEIGHT 20
+#endif
+//#define TOUCHMI_PREHEAT // Uncomment if you have much memory on your board. (Preheat PLA & ABS on LCD)
+	
 /**
  * Enable one or more of the following if probing seems unreliable.
  * Heaters and/or fans can be disabled during probing to minimize electrical

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -735,9 +735,18 @@
 //For tuning Autoleveling sensor "TouchMi" on lcd 
 //#define TOUCHMI 
 #if ENABLED(TOUCHMI)
-      #define FIX_MOUNTED_PROBE
+	#if DISABLED(FIX_MOUNTED_PROBE)
+	  #define FIX_MOUNTED_PROBE
+	#endif
+	#if DISABLED(Z_SAFE_HOMING)
 	  #define Z_SAFE_HOMING
+	#endif
+	#if ENABLED(Z_HOMING_HEIGHT)
+	  #undef Z_HOMING_HEIGHT
+	#endif
+	#if DISABLED(Z_HOMING_HEIGHT)
 	  #define Z_HOMING_HEIGHT 20
+	#endif
 #endif
 //#define TOUCHMI_PREHEAT // Uncomment if you have much memory on your board. (Preheat PLA & ABS on LCD)
 	

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -744,9 +744,7 @@
 	#if ENABLED(Z_HOMING_HEIGHT)
 	  #undef Z_HOMING_HEIGHT
 	#endif
-	#if DISABLED(Z_HOMING_HEIGHT)
-	  #define Z_HOMING_HEIGHT 20
-	#endif
+	#define Z_HOMING_HEIGHT 20
 #endif
 //#define TOUCHMI_PREHEAT // Uncomment if you have much memory on your board. (Preheat PLA & ABS on LCD)
 	

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -745,6 +745,15 @@
  * Warning: Does not respect endstops!
  */
 //#define BABYSTEPPING
+#if ENABLED(TOUCHMI)
+    #if !ENABLED(BABYSTEPPING)
+	  #define BABYSTEPPING
+    #endif
+    #if !ENABLED(BABYSTEP_ZPROBE_OFFSET)
+		#define BABYSTEP_ZPROBE_OFFSET
+    #endif  
+#endif
+
 #if ENABLED(BABYSTEPPING)
   //#define BABYSTEP_XY              // Also enable X/Y Babystepping. Not supported on DELTA!
   #define BABYSTEP_INVERT_Z false    // Change if Z babysteps should go the other way

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -759,7 +759,7 @@
   #define BABYSTEP_INVERT_Z false    // Change if Z babysteps should go the other way
   #define BABYSTEP_MULTIPLICATOR 1   // Babysteps are very small. Increase for faster motion.
   //#define BABYSTEP_ZPROBE_OFFSET   // Enable to combine M851 and Babystepping
-  //#define DOUBLECLICK_FOR_Z_BABYSTEPPING // Double-click on the Status Screen for Z Babystepping.
+  #define DOUBLECLICK_FOR_Z_BABYSTEPPING // Double-click on the Status Screen for Z Babystepping.
   #define DOUBLECLICK_MAX_INTERVAL 1250 // Maximum interval between clicks, in milliseconds.
                                         // Note: Extra time may be added to mitigate controller latency.
   //#define BABYSTEP_ZPROBE_GFX_OVERLAY // Enable graphical overlay on Z-offset editor

--- a/Marlin/language_an.h
+++ b/Marlin/language_an.h
@@ -168,6 +168,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Sonda Z fuera")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Auto-Test")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reset BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Encetan. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Desfase-Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Alzar TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Home") // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("first")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Desfase Z")

--- a/Marlin/language_ca.h
+++ b/Marlin/language_ca.h
@@ -171,6 +171,11 @@
 #define MSG_CNG_SDCARD                      _UxGT("Canvia SD")
 #define MSG_ZPROBE_OUT                      _UxGT("Sonda Z fora")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reinicia BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Decalatge Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Desa TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("primer")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Decalatge Z")

--- a/Marlin/language_cz.h
+++ b/Marlin/language_cz.h
@@ -282,6 +282,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("BLTouch Reset")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("BLTouch Vysunout")
 #define MSG_BLTOUCH_STOW                    _UxGT("BLTouch Zasunout")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Ofset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Ulozit TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")		
 #define MSG_HOME                            _UxGT("Domu")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("prvni")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z ofset")

--- a/Marlin/language_cz_utf8.h
+++ b/Marlin/language_cz_utf8.h
@@ -288,6 +288,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("BLTouch Reset")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("BLTouch Vysunout")
 #define MSG_BLTOUCH_STOW                    _UxGT("BLTouch Zasunout")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Ofset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Uložit TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")		
 #define MSG_HOME                            _UxGT("Domů")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("první")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z ofset")

--- a/Marlin/language_da.h
+++ b/Marlin/language_da.h
@@ -169,6 +169,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Probe udenfor plade")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Selv-Test")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reset BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Init TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Gem i TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("først")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z Offset")

--- a/Marlin/language_de.h
+++ b/Marlin/language_de.h
@@ -198,6 +198,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("BLTouch Reset")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("BLTouch ausfahren")
 #define MSG_BLTOUCH_STOW                    _UxGT("BLTouch einfahren")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Init TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z Versatz")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Registrierung TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")		
 #define MSG_HOME                            _UxGT("Vorher")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("homen")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z Versatz")

--- a/Marlin/language_en.h
+++ b/Marlin/language_en.h
@@ -768,6 +768,21 @@
 #ifndef MSG_BLTOUCH_STOW
   #define MSG_BLTOUCH_STOW                    _UxGT("Stow BLTouch")
 #endif
+#ifndef MSG_TOUCHMI
+  #define MSG_TOUCHMI                         _UxGT("TouchMI")
+#endif
+#ifndef MSG_TOUCHMI_INIT
+  #define MSG_TOUCHMI_INIT                _UxGT("1-Init TouchMI")
+#endif
+#ifndef MSG_TOUCHMI__ZOFFSET
+  #define MSG_TOUCHMI_ZOFFSET               _UxGT("2-Z-Offset")
+#endif
+#ifndef MSG_TOUCHMI_SAVE
+  #define MSG_TOUCHMI_SAVE                   _UxGT("3-Save TouchMI")
+#endif
+#ifndef MSG_TOUCHMI_TEST
+  #define MSG_TOUCHMI_TEST                   _UxGT("Test TouchMI")
+#endif
 #ifndef MSG_HOME
   #define MSG_HOME                            _UxGT("Home") // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #endif

--- a/Marlin/language_es.h
+++ b/Marlin/language_es.h
@@ -185,6 +185,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Sonda Z fuera")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Auto-Prueba")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reiniciar BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Desfase Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Guardar TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("inic.")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Desfase Z")

--- a/Marlin/language_es_utf8.h
+++ b/Marlin/language_es_utf8.h
@@ -175,6 +175,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Sonda Z fuera")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Auto-Prueba")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reiniciar BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Desfase Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Guardar TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Prueba TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("primero")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Desfase Z")

--- a/Marlin/language_eu.h
+++ b/Marlin/language_eu.h
@@ -275,6 +275,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("BLTouch berrabia.")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("BLTouch jaitsi/luzatu")
 #define MSG_BLTOUCH_STOW                    _UxGT("BLTouch igo/jaso")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-hasieratu TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z Konpentsatu")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Gorde TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Proba TouchMI")		
 #define MSG_HOME                            _UxGT("Etxera")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("lehenengo")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z Konpentsatu")

--- a/Marlin/language_fr.h
+++ b/Marlin/language_fr.h
@@ -279,6 +279,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("RaZ BLTouch")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("Deployer BLTouch")
 #define MSG_BLTOUCH_STOW                    _UxGT("Ranger BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Init TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Save TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")															 
 #define MSG_HOME                            _UxGT("Origine")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("Premier")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Decalage Z")

--- a/Marlin/language_fr_utf8.h
+++ b/Marlin/language_fr_utf8.h
@@ -280,6 +280,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("RaZ BLTouch")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("Déployer BLTouch")
 #define MSG_BLTOUCH_STOW                    _UxGT("Ranger BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Init TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Save TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")		
 #define MSG_HOME                            _UxGT("Origine")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("Premier")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Décalage Z")

--- a/Marlin/language_gl.h
+++ b/Marlin/language_gl.h
@@ -166,6 +166,11 @@
 #define MSG_INIT_SDCARD                     _UxGT("Iniciando SD")
 #define MSG_CNG_SDCARD                      _UxGT("Cambiar SD")
 #define MSG_ZPROBE_OUT                      _UxGT("Sonda-Z sen cama")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Offset Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Gardar TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Proba TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_BLTOUCH_SELFTEST                _UxGT("Comprobar BLTouch")
 #define MSG_BLTOUCH_RESET                   _UxGT("Iniciar BLTouch")

--- a/Marlin/language_hr.h
+++ b/Marlin/language_hr.h
@@ -167,6 +167,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Z probe out. bed")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Self-Test")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reset BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Init TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Pohrani TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("first")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z Offset")

--- a/Marlin/language_it.h
+++ b/Marlin/language_it.h
@@ -278,6 +278,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("Resetta BLTouch")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("Estendi BLTouch")
 #define MSG_BLTOUCH_STOW                    _UxGT("Ritrai BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Iniz. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Salva TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")		
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("prima")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z Offset")

--- a/Marlin/language_nl.h
+++ b/Marlin/language_nl.h
@@ -175,6 +175,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Z probe uit. bed")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Zelf-Test")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reset BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Init. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Geheugen TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("Eerst")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z Offset")  //accepted English term in Dutch

--- a/Marlin/language_pl-DOGM.h
+++ b/Marlin/language_pl-DOGM.h
@@ -164,6 +164,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Sonda Z za stołem")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Self-Test")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reset BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Offset Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Zapisz TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("first")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Offset Z")

--- a/Marlin/language_pl-HD44780.h
+++ b/Marlin/language_pl-HD44780.h
@@ -165,6 +165,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Sonda Z za stolem")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Self-Test")
 #define MSG_BLTOUCH_RESET                   _UxGT("Reset BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Offset Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Zapisz TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Home")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("first")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Offset Z")

--- a/Marlin/language_pt-br.h
+++ b/Marlin/language_pt-br.h
@@ -278,7 +278,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("Reiniciar BLTouch")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("Implantar BLTouch")
 #define MSG_BLTOUCH_STOW                    _UxGT("Condicionar BLTouch")
-
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Compensar Sonda em Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Salvar TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Testar TouchMI")		
 #define MSG_HOME                            _UxGT("Home")
 #define MSG_FIRST                           _UxGT("Primeiro")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Compensar Sonda em Z")

--- a/Marlin/language_pt-br_utf8.h
+++ b/Marlin/language_pt-br_utf8.h
@@ -280,7 +280,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("Reiniciar BLTouch")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("Implantar BLTouch")
 #define MSG_BLTOUCH_STOW                    _UxGT("Condicionar BLTouch")
-
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Compensar Sonda em Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Salvar TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Testar TouchMI")
 #define MSG_HOME                            _UxGT("Home")
 #define MSG_FIRST                           _UxGT("Primeiro")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Compensar Sonda em Z")

--- a/Marlin/language_ru.h
+++ b/Marlin/language_ru.h
@@ -280,6 +280,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("Сброс BLTouch")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("Установка BLTouch")
 #define MSG_BLTOUCH_STOW                    _UxGT("Набивка BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Инициализация TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Смещение Z")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Сохранить TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("тест TouchMI")		
 #define MSG_HOME                            _UxGT("Паркуй") // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("первый")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Смещение Z")

--- a/Marlin/language_sk_utf8.h
+++ b/Marlin/language_sk_utf8.h
@@ -287,6 +287,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("BLTouch Reset")
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("BLTouch Vysunúť")
 #define MSG_BLTOUCH_STOW                    _UxGT("BLTouch Zasunúť")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Inic. TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Uložiť TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")		
 #define MSG_HOME                            _UxGT("Najprv")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("domov")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z offset")

--- a/Marlin/language_tr.h
+++ b/Marlin/language_tr.h
@@ -180,6 +180,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Z Prob Açık. Tabla")                                 // Z Prob Açık. Tabla
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Self-Test")                                  // BLTouch Self-Test
 #define MSG_BLTOUCH_RESET                   _UxGT("Sıfırla BLTouch")                                    // Sıfırla BLTouch
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Init TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Hafızaya Al TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")    
 #define MSG_HOME                            _UxGT("Sıfırla")                                            // Sıfırla
 #define MSG_FIRST                           _UxGT("önce")                                               // Önce
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z Offset")                                           // Z Offset

--- a/Marlin/language_uk.h
+++ b/Marlin/language_uk.h
@@ -160,6 +160,11 @@
 #define MSG_ZPROBE_OUT                      _UxGT("Z дет. не в межах")
 #define MSG_BLTOUCH_SELFTEST                _UxGT("BLTouch Само-Тест")
 #define MSG_BLTOUCH_RESET                   _UxGT("Скинути BLTouch")
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Старт TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Зміщення Zt")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Зберегти TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Тест TouchMI")    
 #define MSG_HOME                            _UxGT("Дім")  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("перший")
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Зміщення Z")

--- a/Marlin/language_zh_CN.h
+++ b/Marlin/language_zh_CN.h
@@ -275,6 +275,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("重置BLTouch")  // "Reset BLTouch"
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("部署BLTouch") // "Deploy BLTouch"
 #define MSG_BLTOUCH_STOW                    _UxGT("装载BLTouch")   // "Stow BLTouch"
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-初始化 TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z偏移")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-保存 TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("测试 TouchMI")	
 #define MSG_HOME                            _UxGT("归位")  //"Home"  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("先")  //"first"
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z偏移")  //"Z Offset"

--- a/Marlin/language_zh_TW.h
+++ b/Marlin/language_zh_TW.h
@@ -275,6 +275,11 @@
 #define MSG_BLTOUCH_RESET                   _UxGT("重置BLTouch")  // "Reset BLTouch"
 #define MSG_BLTOUCH_DEPLOY                  _UxGT("部署BLTouch") // "Deploy BLTouch"
 #define MSG_BLTOUCH_STOW                    _UxGT("裝載BLTouch")   // "Stow BLTouch"
+#define MSG_TOUCHMI                         _UxGT("TouchMI")
+#define MSG_TOUCHMI_INIT                    _UxGT("1-Init TouchMI")
+#define MSG_TOUCHMI_ZOFFSET                 _UxGT("2-Z-Offset")
+#define MSG_TOUCHMI_SAVE                    _UxGT("3-Save TouchMI")
+#define MSG_TOUCHMI_TEST                    _UxGT("Test TouchMI")		
 #define MSG_HOME                            _UxGT("歸位")  //"Home"  // Used as MSG_HOME " " MSG_X MSG_Y MSG_Z " " MSG_FIRST
 #define MSG_FIRST                           _UxGT("先")  //"first"
 #define MSG_ZPROBE_ZOFFSET                  _UxGT("Z偏移")  //"Z Offset"

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -979,6 +979,29 @@ void lcd_quick_feedback(const bool clear_buttons) {
 
   #endif // BLTOUCH
 
+ #if ENABLED(TOUCHMI)
+     /**
+     *
+     * "TouchMI" submenu
+     *
+     */
+    static void touchmi_menu() {
+      defer_return_to_status = true;
+      START_MENU();
+      //
+      // ^ Main
+      //
+      MENU_ITEM(function, MSG_BACK, lcd_goto_previous_menu_no_defer);
+      MENU_ITEM(gcode, MSG_TOUCHMI_INIT, PSTR("M851 Z0\nG28\nM500\nG1 Z0 F200"));
+      #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
+          MENU_ITEM(submenu, MSG_TOUCHMI_ZOFFSET, lcd_babystep_zoffset);
+      #endif 
+      MENU_ITEM(gcode, MSG_TOUCHMI_SAVE, PSTR("M500\nG28 X Y"));
+      MENU_ITEM(gcode, MSG_TOUCHMI_TEST, PSTR("G28\nG1 Z0"));
+      END_MENU();
+      
+    }
+  #endif // TOUCHMI					  
   #if ENABLED(LCD_PROGRESS_BAR_TEST)
 
     static void progress_bar_test() {
@@ -1566,6 +1589,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
 
   constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP);
 
+#if DISABLED(TOUCHMI) || ENABLED(TOUCHMI_PREHEAT)												   
   /**
    *
    * "Prepare" submenu items
@@ -1784,6 +1808,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
     }
 
   #endif // HAS_TEMP_HOTEND || HAS_HEATED_BED
+	#endif //DISABLED(TOUCHMI) || ENABLED(TOUCHMI_PREHEAT)													
 
   void lcd_cooldown() {
     #if FAN_COUNT > 0
@@ -2756,6 +2781,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       #endif
       if (has_heat) MENU_ITEM(function, MSG_COOLDOWN, lcd_cooldown);
 
+	#if DISABLED(TOUCHMI) || ENABLED(TOUCHMI_PREHEAT)												   
       //
       // Preheat for Material 1 and 2
       //
@@ -2766,7 +2792,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
         MENU_ITEM(function, MSG_PREHEAT_1, lcd_preheat_m1_e0_only);
         MENU_ITEM(function, MSG_PREHEAT_2, lcd_preheat_m2_e0_only);
       #endif
-
+   #endif //DISABLED(TOUCHMI) || ENABLED(TOUCHMI_PREHEAT)
     #endif // HAS_TEMP_HOTEND
 
     //
@@ -3357,6 +3383,9 @@ void lcd_quick_feedback(const bool clear_buttons) {
       MENU_ITEM(submenu, MSG_BLTOUCH, bltouch_menu);
     #endif
 
+	#if ENABLED(TOUCHMI)
+      MENU_ITEM(submenu, MSG_TOUCHMI, touchmi_menu);
+    #endif				
     #if ENABLED(EEPROM_SETTINGS)
       MENU_ITEM(function, MSG_STORE_EEPROM, lcd_store_settings);
       MENU_ITEM(function, MSG_LOAD_EEPROM, lcd_load_settings);
@@ -3576,6 +3605,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
 
     #endif // PIDTEMP
 
+	#if DISABLED(TOUCHMI) || ENABLED(TOUCHMI_PREHEAT)												 
     #if DISABLED(SLIM_LCD_MENUS)
       //
       // Preheat Material 1 conf
@@ -3587,7 +3617,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       //
       MENU_ITEM(submenu, MSG_PREHEAT_2_SETTINGS, lcd_control_temperature_preheat_material2_settings_menu);
     #endif
-
+    #endif // DISABLED(TOUCHMI) || ENABLED(TOUCHMI_PREHEAT)
     END_MENU();
   }
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -992,11 +992,11 @@ void lcd_quick_feedback(const bool clear_buttons) {
       // ^ Main
       //
       MENU_ITEM(function, MSG_BACK, lcd_goto_previous_menu_no_defer);
-      MENU_ITEM(gcode, MSG_TOUCHMI_INIT, PSTR("M851 Z0\nG28\nM500\nG1 Z0 F200"));
+      MENU_ITEM(gcode, MSG_TOUCHMI_INIT, PSTR("M851 Z0\nG28\nM500\nG1 Z0 F200\nM211 S0"));
       #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
           MENU_ITEM(submenu, MSG_TOUCHMI_ZOFFSET, lcd_babystep_zoffset);
       #endif 
-      MENU_ITEM(gcode, MSG_TOUCHMI_SAVE, PSTR("M500\nG28 X Y"));
+      MENU_ITEM(gcode, MSG_TOUCHMI_SAVE, PSTR("M211 S1\nM500\nG28 X Y"));
       MENU_ITEM(gcode, MSG_TOUCHMI_TEST, PSTR("G28\nG1 Z0"));
       END_MENU();
       

--- a/README.md
+++ b/README.md
@@ -1,68 +1,69 @@
 # Marlin 3D Printer Firmware
 <img align="right" src="../../raw/1.1.x/buildroot/share/pixmaps/logo/marlin-250.png" />
 
-## Marlin 1.1
+Marlin is the world's most popular open source firmware for Replicating Rapid Prototyper (RepRap) machines, commonly referred to as "3D printers." Marlin Firmware is highly efficient, running even on modest 16MHz embedded AVR processors. While Marlin 1.1 only supports ATmega AVR (Arduino, etc.) and AT90USB (Teensy++ 2.0), [Marlin 2.0](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x) also adds support for several ARM processors, including the SAM3X8E (Arduino Due), NXP LPC1768/LPC1769 ARM Cortex-M3 (Re-Arm, MKS SBASE, Smoothieboard), and ARM Cortex-M4 (Teensy 3.5/3.6, STM32F1/4/7).
 
-Marlin 1.1 represents an evolutionary leap over Marlin 1.0.2. It is the result of over two years of effort by several volunteers around the world who have paid meticulous and sometimes obsessive attention to every detail. For this release we focused on code quality, performance, stability, and overall user experience. Several new features have also been added, many of which require no extra hardware.
+A monumental amount of talent and effort goes into Marlin production, and thanks are due to many volunteers around the world. We work closely with the community, contributors, vendors, host and library developers, etc. to improve the quality, configurability, and compatibility of Marlin Firmware with a [huge variety](http://marlinfw.org/docs/configuration/configuration.html#motherboard) of boards. For the final 1.1 release we focused on code quality, performance, stability, and overall user experience. Several new features were added, many of which require no extra hardware.
 
-For complete Marlin documentation click over to the [Marlin Homepage <marlinfw.org>](http://marlinfw.org/), where you will find in-depth articles, how-to videos, and tutorials on every aspect of Marlin, as the site develops. For release notes, see the [Releases](https://github.com/MarlinFirmware/Marlin/releases) page.
+## Documentation
 
-The 1.1.x branch is home to all tagged releases of Marlin 1.1 (final version 1.1.9 – August 2018).
+- Visit [marlinfw.org](http://marlinfw.org/) for complete documentation on [configuration](http://marlinfw.org/docs/configuration/configuration.html), [installation](http://marlinfw.org/docs/basics/install.html), [features](http://marlinfw.org/meta/features/), and the many [G-codes](http://marlinfw.org/meta/gcode/) that Marlin supports. We will continue to expand the site to include in-depth articles, tutorials, and how-to videos on all of Marlin's features.
+- See the [Releases](https://github.com/MarlinFirmware/Marlin/releases) page for Release Notes on all current and previous versions of Marlin.
+- Check out the [RepRap.org Marlin Page](http://reprap.org/wiki/Marlin) for an overview of Marlin and its role in the RepRap project.
 
-This branch will receive no further updates. All future development —including all bug fixes— will take place in the [`bugfix-2.0.x`](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x) branch, which will also serve as the root for all future Marlin development. Be sure to test [`bugfix-2.0.x`](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x) before reporting any bugs you find in 1.1.9.
+## Marlin 1.1.x
 
-Marlin 1.1.9 is the final release of the 8-bit flat version of Marlin Firmware. A monumental amount of talent and effort has gone into its production, and thanks are due to many people around the world. Throughout Marlin 1.1 development we worked closely with the community, contributors, vendors, host developers, library developers, etc. to improve the quality, configurability, and compatibility of Marlin Firmware, all while continuing to support a wide variety of Arduino-based boards.
+The 1.1.x branch is home to all tagged releases of Marlin 1.1.
 
-## Marlin 1.0.x
+Marlin 1.1.9 is the final release of the AVR-only flat version of Marlin Firmware, so there will be no further 1.1.x releases. However [`bugfix-1.1.x`](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x) will continue to receive patches for critical bugs, so be sure to test it (or [`bugfix-2.0.x`](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x)) before reporting any bugs you find in 1.1.9.
 
-Previous releases of Marlin include [1.0.2-2](https://github.com/MarlinFirmware/Marlin/tree/1.0.2-2) (December 2016) and [1.0.1](https://github.com/MarlinFirmware/Marlin/tree/1.0.1) (December 2014). Any version of Marlin prior to 1.0.1 (when we started tagging versions) can be collectively referred to as Marlin 1.0.0.
+## Marlin 2.0.x
+
+[Marlin 2.0](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x) is the future, featuring a much-improved hierarchical file structure and full [32-bit support](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x) via a Hardware Access Layer (HAL). Marlin 2.0 continues to work with [Arduino IDE](https://www.arduino.cc/en/Main/Software) for the platforms it supports, and the excellent [PlatformIO IDE](https://platformio.org/platformio-ide) is recommended for the next generation of ARM-based boards. If you're looking for the very best that Marlin has to offer and aren't bothered by a few rough edges, give version 2.0 a try!
 
 ## Contributing to Marlin
 
 Click on the [Issue Queue](https://github.com/MarlinFirmware/Marlin/issues) and [Pull Requests](https://github.com/MarlinFirmware/Marlin/pulls) links above at any time to see what we're currently working on.
 
-To submit patches and new features for Marlin 1.1 check out the [bugfix-1.1.x](https://github.com/MarlinFirmware/Marlin/tree/bugfix-1.1.x) branch, add your commits, and submit a Pull Request back to the `bugfix-1.1.x` branch. Periodically that branch will form the basis for the next minor release.
+To submit patches and new features for Marlin 2.0 check out the [bugfix-2.0.x](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x) branch, add your commits, and submit a Pull Request back to the `bugfix-2.0.x` branch. Once 2.0.x has been certified for a critical mass of common 32-bit boards, it will become the next major release and will be the basis for all future major and minor releases.
 
-Note that our "bugfix" branch will always contain the latest patches to the current release version. These patches may not be widely tested. As always, when using "nightly" builds of Marlin, proceed with full caution.
-
-## Current Status: In Development
-
-Marlin development has reached an important milestone with its first stable release in over 2 years. During this period we focused on cleaning up the code and making it more modern, consistent, readable, and sensible.
-
-## Future Development
-
-Marlin 1.1 is the last "flat" version of Marlin!
-
-Arduino IDE now has support for folder hierarchies, so Marlin 1.2 will have a [hierarchical file structure](https://github.com/MarlinFirmware/Marlin/tree/breakup-marlin-idea). Marlin's newly reorganized code will be easier to work with and form a stronger starting-point as we get into [32-bit CPU support](https://github.com/MarlinFirmware/Marlin/tree/32-Bit-RCBugFix-new) and the Hardware Access Layer (HAL).
-
-[![Coverity Scan Build Status](https://scan.coverity.com/projects/2224/badge.svg)](https://scan.coverity.com/projects/2224)
-[![Travis Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg)](https://travis-ci.org/MarlinFirmware/Marlin)
+Note that our "bugfix" branches always contain the latest patches and new code. These patches may not be widely tested. As always, when using "nightly" builds of Marlin, proceed with full caution.
 
 ## Marlin Resources
 
-- [Marlin Home Page](http://marlinfw.org/) - The Marlin Documentation Project. Join us!
-- [RepRap.org Wiki Page](http://reprap.org/wiki/Marlin) - An overview of Marlin and its role in RepRap.
-- [Marlin Firmware Forum](http://forums.reprap.org/list.php?415) - Find help with configuration, get up and running.
+- [Marlin Home Page](http://marlinfw.org/) - The Marlin Documentation Project. [Help us](https://github.com/MarlinFirmware/MarlinDocumentation) expand this site!
 - [@MarlinFirmware](https://twitter.com/MarlinFirmware) on Twitter - Follow for news, release alerts, and tips & tricks. (Maintained by [@thinkyhead](https://github.com/thinkyhead).)
+
+## Marlin User Support
+
+Looking for help? Our GitHub Issue Queue is only for development-related issues, feature requests, and bug reports. But there are several places where you can get help from experienced users:
+
+- [RepRap.org Marlin Forum](http://forums.reprap.org/list.php?415)
+- ["Marlin Firmware" Facebook Group](https://www.facebook.com/groups/1049718498464482/)
+- [Tom's 3D Forums](https://discuss.toms3d.org/)
+- [Marlin on Discord](https://discord.gg/n5NJ59y)
 
 ## Credits
 
-The current Marlin dev team consists of:
- - Roxanne Neufeld [[@Roxy-3D](https://github.com/Roxy-3D)]
+Marlin Admins:
+ - Erik van der Zalm [[@ErikZalm](https://github.com/ErikZalm)]
  - Scott Lahteine [[@thinkyhead](https://github.com/thinkyhead)]
+ - Roxanne Neufeld [[@Roxy-3D](https://github.com/Roxy-3D)]
  - Bob Kuhn [[@Bob-the-Kuhn](https://github.com/Bob-the-Kuhn)]
 
-Notable contributors include:
+Notable contributors:
  - Alberto Cotronei [[@MagoKimbra](https://github.com/MagoKimbra)]
  - Andreas Hardtung [[@AnHardt](https://github.com/AnHardt)]
  - Bernhard Kubicek [[@bkubicek](https://github.com/bkubicek)]
  - Bob Cousins [[@bobc](https://github.com/bobc)]
  - Chris Palmer [[@nophead](https://github.com/nophead)]
+ - Chris Pepper [[@p3p](https://github.com/p3p)]
  - David Braam [[@daid](https://github.com/daid)]
+ - Éduardo Tagle [[@ejtagle](https://github.com/ejtagle)]
  - Edward Patel [[@epatel](https://github.com/epatel)]
- - Erik van der Zalm [[@ErikZalm](https://github.com/ErikZalm)]
  - Ernesto Martinez [[@emartinez167](https://github.com/emartinez167)]
  - F. Malpartida [[@fmalpartida](https://github.com/fmalpartida)]
+ - Giuliano Zaro [[@GMagician](https://github.com/GMagician)]
  - Jochen Groppe [[@CONSULitAS](https://github.com/CONSULitAS)]
  - João Brazio [[@jbrazio](https://github.com/jbrazio)]
  - Kai [[@Kaibob2](https://github.com/Kaibob2)]
@@ -74,7 +75,6 @@ Notable contributors include:
  - [[@android444](https://github.com/android444)]
  - [[@benlye](https://github.com/benlye)]
  - [[@bgort](https://github.com/bgort)]
- - [[@ejtagle](https://github.com/ejtagle)]
  - [[@Grogyan](https://github.com/Grogyan)]
  - [[@marcio-ao](https://github.com/marcio-ao)]
  - [[@maverikou](https://github.com/maverikou)]
@@ -85,7 +85,7 @@ Notable contributors include:
  - [[@psavva](https://github.com/psavva)]
  - [[@Tannoo](https://github.com/Tannoo)]
  - [[@teemuatlut](https://github.com/teemuatlut)]
- - ...and many others
+ - ...and you!
 
 ## License
 
@@ -93,4 +93,8 @@ Marlin is published under the [GPL license](https://github.com/COPYING.md) becau
 
 While we can't prevent the use of this code in products (3D printers, CNC, etc.) that are closed source or crippled by a patent, we would prefer that you choose another firmware or, better yet, make your own.
 
-[![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
+---
+
+<!-- [![Coverity Scan Build Status](https://scan.coverity.com/projects/2224/badge.svg)](https://scan.coverity.com/projects/2224) -->
+- [![Travis Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg)](https://travis-ci.org/MarlinFirmware/Marlin)
+- [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)

--- a/README.md
+++ b/README.md
@@ -97,4 +97,5 @@ While we can't prevent the use of this code in products (3D printers, CNC, etc.)
 
 <!-- [![Coverity Scan Build Status](https://scan.coverity.com/projects/2224/badge.svg)](https://scan.coverity.com/projects/2224) -->
 - [![Travis Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg)](https://travis-ci.org/MarlinFirmware/Marlin)
-- [![Flattr this git repo](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
+- [![Flattr Scott Lahteine](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=thinkhead&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software) - Flattr Scott Lahteine
+- [![Flattr Erik van der Zalm](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software) - Flattr Erik van der Zalm


### PR DESCRIPTION
### Requirements

For tuning Autoleveling TouchMI
### Description

Tuning the sensor is really difficult for a beginner, so i decided to facilitate the task by offering a single-page adjustment of the LCD.
3 steps to perform:
1 - Init TouchMI ( Home all axis, deactivate endstop )
2 - Z-offset ( Tune the Z-offset & save with M851 on eeprom)
3 - Save TouchMI ( Re-activate endstop & M500)
Test TouchMi > To check the tuning at Z0

https://gyazo.com/2179001d15bfc6874a18272980165033

### Benefits

Tuning your TouchMI in 30 sec. on single page with 3 steps

