### PR TITLE
Correct range of LCD axis step editing

### DIFF
--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -265,7 +265,7 @@ void safe_delay(millis_t ms) {
   }
 
   // Convert unsigned float to string with 1234.5 format omitting trailing zeros
-  char* ftostr61rj(const float &f) {
+  char* ftostr51rj(const float &f) {
     const long i = ((f < 0 ? -f : f) * 100 + 5) / 10;
     conv[0] = ' ';
     conv[1] = RJDIGIT(i, 10000);

--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -264,15 +264,15 @@ void safe_delay(millis_t ms) {
     return conv;
   }
 
-  // Convert unsigned float to string with 1234.56 format omitting trailing zeros
-  char* ftostr62rj(const float &f) {
-    const long i = ((f < 0 ? -f : f) * 1000 + 5) / 10;
-    conv[0] = RJDIGIT(i, 100000);
+  // Convert unsigned float to string with 1234.5 format omitting trailing zeros
+  char* ftostr61rj(const float &f) {
+    const long i = ((f < 0 ? -f : f) * 100 + 5) / 10;
+    conv[0] = ' ';
     conv[1] = RJDIGIT(i, 10000);
     conv[2] = RJDIGIT(i, 1000);
-    conv[3] = DIGIMOD(i, 100);
-    conv[4] = '.';
-    conv[5] = DIGIMOD(i, 10);
+    conv[3] = RJDIGIT(i, 100);
+    conv[4] = DIGIMOD(i, 10);
+    conv[5] = '.';
     conv[6] = DIGIMOD(i, 1);
     return conv;
   }

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -107,7 +107,7 @@ inline void serial_delay(const millis_t ms) {
   char* ftostr52sign(const float &x);
 
   // Convert unsigned float to string with 1234.5 format omitting trailing zeros
-  char* ftostr61rj(const float &x);
+  char* ftostr51rj(const float &x);
 
   // Convert float to rj string with 123 or -12 format
   FORCE_INLINE char* ftostr3(const float &x) { return i16tostr3(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -106,8 +106,8 @@ inline void serial_delay(const millis_t ms) {
   // Convert signed float to string with +123.45 format
   char* ftostr52sign(const float &x);
 
-  // Convert unsigned float to string with 1234.56 format omitting trailing zeros
-  char* ftostr62rj(const float &x);
+  // Convert unsigned float to string with 1234.5 format omitting trailing zeros
+  char* ftostr61rj(const float &x);
 
   // Convert float to rj string with 123 or -12 format
   FORCE_INLINE char* ftostr3(const float &x) { return i16tostr3(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -169,7 +169,7 @@ DEFINE_MENU_EDIT_ITEM(float43);     // 1.234
 DEFINE_MENU_EDIT_ITEM(float5);      // 12345      right-justified
 DEFINE_MENU_EDIT_ITEM(float51);     // +1234.5
 DEFINE_MENU_EDIT_ITEM(float52sign); // +123.45
-DEFINE_MENU_EDIT_ITEM(float62);     // 1234.56    right-justified
+DEFINE_MENU_EDIT_ITEM(float61);     // 1234.5     right-justified
 DEFINE_MENU_EDIT_ITEM(long5);       // 12345      right-justified
 
 void MenuItem_bool::action_edit(PGM_P pstr, bool *ptr, screenFunc_t callback) {

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -167,9 +167,9 @@ DEFINE_MENU_EDIT_ITEM(float3);      // 123        right-justified
 DEFINE_MENU_EDIT_ITEM(float52);     // 123.45
 DEFINE_MENU_EDIT_ITEM(float43);     // 1.234
 DEFINE_MENU_EDIT_ITEM(float5);      // 12345      right-justified
-DEFINE_MENU_EDIT_ITEM(float51);     // +1234.5
+DEFINE_MENU_EDIT_ITEM(float51);     // 1234.5     right-justified
+DEFINE_MENU_EDIT_ITEM(float51sign); // +1234.5
 DEFINE_MENU_EDIT_ITEM(float52sign); // +123.45
-DEFINE_MENU_EDIT_ITEM(float61);     // 1234.5     right-justified
 DEFINE_MENU_EDIT_ITEM(long5);       // 12345      right-justified
 
 void MenuItem_bool::action_edit(PGM_P pstr, bool *ptr, screenFunc_t callback) {

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -56,8 +56,8 @@ DECLARE_MENU_EDIT_TYPE(float,    float3,      ftostr3,         1     );   // 123
 DECLARE_MENU_EDIT_TYPE(float,    float52,     ftostr52,      100     );   // 123.45
 DECLARE_MENU_EDIT_TYPE(float,    float43,     ftostr43sign, 1000     );   // 1.234
 DECLARE_MENU_EDIT_TYPE(float,    float5,      ftostr5rj,       0.01f );   // 12345      right-justified
-DECLARE_MENU_EDIT_TYPE(float,    float51,     ftostr51sign,   10     );   // +1234.5
-DECLARE_MENU_EDIT_TYPE(float,    float61,     ftostr61rj,     10     );   //  1234.5    right-justified
+DECLARE_MENU_EDIT_TYPE(float,    float51,     ftostr51rj,     10     );   // 1234.5     right-justified
+DECLARE_MENU_EDIT_TYPE(float,    float51sign, ftostr51sign,   10     );   // +1234.5
 DECLARE_MENU_EDIT_TYPE(float,    float52sign, ftostr52sign,  100     );   // +123.45
 DECLARE_MENU_EDIT_TYPE(uint32_t, long5,       ftostr5rj,       0.01f );   // 12345      right-justified
 
@@ -121,9 +121,9 @@ DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float3);           // 123        right-justif
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float52);          // 123.45
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float43);          // 1.234
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float5);           // 12345      right-justified
-DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float51);          // +1234.5
+DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float51);          // 1234.5     right-justified
+DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float51sign);      // +1234.5
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float52sign);      // +123.45
-DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float61);          // 1234.5     right-justified
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(long5);            // 12345      right-justified
 
 #define draw_menu_item_edit_bool(sel, row, pstr, pstr2, data, ...)           DRAW_BOOL_SETTING(sel, row, pstr, data)
@@ -203,8 +203,8 @@ DECLARE_MENU_EDIT_ITEM(float52);
 DECLARE_MENU_EDIT_ITEM(float43);
 DECLARE_MENU_EDIT_ITEM(float5);
 DECLARE_MENU_EDIT_ITEM(float51);
+DECLARE_MENU_EDIT_ITEM(float51sign);
 DECLARE_MENU_EDIT_ITEM(float52sign);
-DECLARE_MENU_EDIT_ITEM(float61);
 DECLARE_MENU_EDIT_ITEM(long5);
 
 class MenuItem_bool {

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -182,8 +182,8 @@ class TMenuItem : MenuItemBase {
   public:
     static void action_edit(PGM_P const pstr, type_t * const ptr, const type_t minValue, const type_t maxValue, const screenFunc_t callback=NULL, const bool live=false) {
       // Make sure minv and maxv fit within int16_t
-      const int16_t minv = max(scale(minValue), INT_MIN),
-                    maxv = min(scale(maxValue), INT_MAX);
+      const int16_t minv = MAX(scale(minValue), INT_MIN),
+                    maxv = MIN(scale(maxValue), INT_MAX);
       init(pstr, ptr, minv, maxv - minv, scale(*ptr) - minv, edit, callback, live);
     }
     static void edit() { MenuItemBase::edit(to_string, load); }

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -182,8 +182,8 @@ class TMenuItem : MenuItemBase {
   public:
     static void action_edit(PGM_P const pstr, type_t * const ptr, const type_t minValue, const type_t maxValue, const screenFunc_t callback=NULL, const bool live=false) {
       // Make sure minv and maxv fit within int16_t
-      const int16_t minv = max(scale(minValue), INT_MIN);
-      const int16_t maxv = min(scale(maxValue), INT_MAX);
+      const int16_t minv = max(scale(minValue), INT_MIN),
+                    maxv = min(scale(maxValue), INT_MAX);
       init(pstr, ptr, minv, maxv - minv, scale(*ptr) - minv, edit, callback, live);
     }
     static void edit() { MenuItemBase::edit(to_string, load); }

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -24,6 +24,8 @@
 #include "../ultralcd.h"
 #include "../../inc/MarlinConfig.h"
 
+#include "limits.h"
+
 extern int8_t encoderLine, encoderTopLine, screen_items;
 extern bool screen_changed;
 
@@ -55,8 +57,8 @@ DECLARE_MENU_EDIT_TYPE(float,    float52,     ftostr52,      100     );   // 123
 DECLARE_MENU_EDIT_TYPE(float,    float43,     ftostr43sign, 1000     );   // 1.234
 DECLARE_MENU_EDIT_TYPE(float,    float5,      ftostr5rj,       0.01f );   // 12345      right-justified
 DECLARE_MENU_EDIT_TYPE(float,    float51,     ftostr51sign,   10     );   // +1234.5
+DECLARE_MENU_EDIT_TYPE(float,    float61,     ftostr61rj,     10     );   //  1234.5    right-justified
 DECLARE_MENU_EDIT_TYPE(float,    float52sign, ftostr52sign,  100     );   // +123.45
-DECLARE_MENU_EDIT_TYPE(float,    float62,     ftostr62rj,    100     );   // 1234.56    right-justified
 DECLARE_MENU_EDIT_TYPE(uint32_t, long5,       ftostr5rj,       0.01f );   // 12345      right-justified
 
 ////////////////////////////////////////////
@@ -121,7 +123,7 @@ DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float43);          // 1.234
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float5);           // 12345      right-justified
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float51);          // +1234.5
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float52sign);      // +123.45
-DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float62);          // 1234.56    right-justified
+DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(float61);          // 1234.5     right-justified
 DEFINE_DRAW_MENU_ITEM_SETTING_EDIT(long5);            // 12345      right-justified
 
 #define draw_menu_item_edit_bool(sel, row, pstr, pstr2, data, ...)           DRAW_BOOL_SETTING(sel, row, pstr, data)
@@ -179,8 +181,10 @@ class TMenuItem : MenuItemBase {
     static char* to_string(const int16_t value)       { return NAME::strfunc(unscale(value)); }
   public:
     static void action_edit(PGM_P const pstr, type_t * const ptr, const type_t minValue, const type_t maxValue, const screenFunc_t callback=NULL, const bool live=false) {
-      const int16_t minv = scale(minValue);
-      init(pstr, ptr, minv, int16_t(scale(maxValue)) - minv, int16_t(scale(*ptr)) - minv, edit, callback, live);
+      // Make sure minv and maxv fit within int16_t
+      const int16_t minv = max(scale(minValue), INT_MIN);
+      const int16_t maxv = min(scale(maxValue), INT_MAX);
+      init(pstr, ptr, minv, maxv - minv, scale(*ptr) - minv, edit, callback, live);
     }
     static void edit() { MenuItemBase::edit(to_string, load); }
 };
@@ -200,7 +204,7 @@ DECLARE_MENU_EDIT_ITEM(float43);
 DECLARE_MENU_EDIT_ITEM(float5);
 DECLARE_MENU_EDIT_ITEM(float51);
 DECLARE_MENU_EDIT_ITEM(float52sign);
-DECLARE_MENU_EDIT_ITEM(float62);
+DECLARE_MENU_EDIT_ITEM(float61);
 DECLARE_MENU_EDIT_ITEM(long5);
 
 class MenuItem_bool {

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -571,14 +571,14 @@ void menu_backlash();
     START_MENU();
     MENU_BACK(MSG_ADVANCED_SETTINGS);
 
-    #define EDIT_QSTEPS(Q) MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float61, MSG_##Q##STEPS, &planner.settings.axis_steps_per_mm[_AXIS(Q)], 5, 9999, _planner_refresh_positioning)
+    #define EDIT_QSTEPS(Q) MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float51, MSG_##Q##STEPS, &planner.settings.axis_steps_per_mm[_AXIS(Q)], 5, 9999, _planner_refresh_positioning)
     EDIT_QSTEPS(A);
     EDIT_QSTEPS(B);
     EDIT_QSTEPS(C);
 
     #if ENABLED(DISTINCT_E_FACTORS)
-      #define EDIT_ESTEPS(N,E) MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float61, MSG_E##N##STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(E)], 5, 9999, _planner_refresh_e##E##_positioning)
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float61, MSG_ESTEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(active_extruder)], 5, 9999, _planner_refresh_positioning);
+      #define EDIT_ESTEPS(N,E) MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float51, MSG_E##N##STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(E)], 5, 9999, _planner_refresh_e##E##_positioning)
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float51, MSG_ESTEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(active_extruder)], 5, 9999, _planner_refresh_positioning);
       EDIT_ESTEPS(1,0);
       EDIT_ESTEPS(2,1);
       #if E_STEPPERS > 2
@@ -594,7 +594,7 @@ void menu_backlash();
         #endif // E_STEPPERS > 3
       #endif // E_STEPPERS > 2
     #elif E_STEPPERS
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float61, MSG_ESTEPS, &planner.settings.axis_steps_per_mm[E_AXIS], 5, 9999, _planner_refresh_positioning);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float51, MSG_ESTEPS, &planner.settings.axis_steps_per_mm[E_AXIS], 5, 9999, _planner_refresh_positioning);
     #endif
 
     END_MENU();

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -571,14 +571,14 @@ void menu_backlash();
     START_MENU();
     MENU_BACK(MSG_ADVANCED_SETTINGS);
 
-    #define EDIT_QSTEPS(Q) MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float62, MSG_##Q##STEPS, &planner.settings.axis_steps_per_mm[_AXIS(Q)], 5, 9999, _planner_refresh_positioning)
+    #define EDIT_QSTEPS(Q) MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float61, MSG_##Q##STEPS, &planner.settings.axis_steps_per_mm[_AXIS(Q)], 5, 9999, _planner_refresh_positioning)
     EDIT_QSTEPS(A);
     EDIT_QSTEPS(B);
     EDIT_QSTEPS(C);
 
     #if ENABLED(DISTINCT_E_FACTORS)
-      #define EDIT_ESTEPS(N,E) MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float62, MSG_E##N##STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(E)], 5, 9999, _planner_refresh_e##E##_positioning)
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float62, MSG_ESTEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(active_extruder)], 5, 9999, _planner_refresh_positioning);
+      #define EDIT_ESTEPS(N,E) MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float61, MSG_E##N##STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(E)], 5, 9999, _planner_refresh_e##E##_positioning)
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float61, MSG_ESTEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(active_extruder)], 5, 9999, _planner_refresh_positioning);
       EDIT_ESTEPS(1,0);
       EDIT_ESTEPS(2,1);
       #if E_STEPPERS > 2
@@ -594,7 +594,7 @@ void menu_backlash();
         #endif // E_STEPPERS > 3
       #endif // E_STEPPERS > 2
     #elif E_STEPPERS
-      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float62, MSG_ESTEPS, &planner.settings.axis_steps_per_mm[E_AXIS], 5, 9999, _planner_refresh_positioning);
+      MENU_MULTIPLIER_ITEM_EDIT_CALLBACK(float61, MSG_ESTEPS, &planner.settings.axis_steps_per_mm[E_AXIS], 5, 9999, _planner_refresh_positioning);
     #endif
 
     END_MENU();


### PR DESCRIPTION
- Replaced the "float62" with a "float51" data type
  - Reduce multiplier from 100 to 10
  - The old data type's range was severely limited due to the limitation of int16_t for the encoder
- If the scaled max and min limits exceed the value of int16_t, clamp to max size
- Fixed bug in max computation that was further halving the effective range
- Changed steps editing screen to use "float51" instead of "float62"
  - Old effective limits: 0.00 to 163.83
  - New effective limits: 0.0 to 3276.7

This fixes bug #13696