### PR TITLE
Fix clear of Z position last digit

### DIFF
--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -517,7 +517,7 @@ FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char *value, const
     else {
       #if DISABLED(HOME_AFTER_DEACTIVATE, DISABLE_REDUCED_ACCURACY_WARNING)
         if (!TEST(axis_known_position, axis))
-          lcd_put_u8str_P(axis == Z_AXIS ? PSTR("      ") : PSTR("    "));
+          lcd_put_u8str_P(axis == Z_AXIS ? PSTR("       ") : PSTR("    "));
         else
       #endif
           lcd_put_u8str(value);

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -245,7 +245,7 @@ FORCE_INLINE void _draw_axis_value(const AxisEnum axis, const char *value, const
     else {
       #if DISABLED(HOME_AFTER_DEACTIVATE, DISABLE_REDUCED_ACCURACY_WARNING)
         if (!TEST(axis_known_position, axis))
-          lcd_put_u8str_P(axis == Z_AXIS ? PSTR("      ") : PSTR("    "));
+          lcd_put_u8str_P(axis == Z_AXIS ? PSTR("       ") : PSTR("    "));
         else
       #endif
           lcd_put_u8str(value);


### PR DESCRIPTION
### Description

Z position has 7 digits but only 6 were cleaned.

![clear_z_position](https://user-images.githubusercontent.com/180601/56249469-2c934080-60ac-11e9-9fbd-a0f199f4fc1b.gif)

Once fixed:

![clear_z_position_fixed](https://user-images.githubusercontent.com/180601/56249493-40d73d80-60ac-11e9-96c9-a1f9d83a6af9.gif)
