### PR TITLE
Fix action_edit int range bug

### DIFF
--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -182,8 +182,8 @@ class TMenuItem : MenuItemBase {
   public:
     static void action_edit(PGM_P const pstr, type_t * const ptr, const type_t minValue, const type_t maxValue, const screenFunc_t callback=NULL, const bool live=false) {
       // Make sure minv and maxv fit within int16_t
-      const int16_t minv = MAX(scale(minValue), INT_MIN),
-                    maxv = MIN(scale(maxValue), INT_MAX);
+      const int16_t minv = MAX(scale(minValue), INT16_MIN),
+                    maxv = MIN(scale(maxValue), INT16_MAX);
       init(pstr, ptr, minv, maxv - minv, scale(*ptr) - minv, edit, callback, live);
     }
     static void edit() { MenuItemBase::edit(to_string, load); }


### PR DESCRIPTION
As reported by @doggyfan, previous PR did not work on 32 boards.

- Changed INT_MAX to INT16_MAX so code works on 32-bit boards as well as 8-bit boards.

Followup to #13696