### PR TITLE
Squelch compiler warning (#13738)

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -175,14 +175,14 @@ void MarlinUI::set_font(const MarlinFont font_nr) {
 
     // Can the text fit to the right of the bitmap?
     if (text_max_width < rspace) {
-      constexpr uint8_t inter = (width - text_max_width - (START_BMPWIDTH)) / 3; // Evenly distribute horizontal space
+      constexpr int8_t inter = (width - text_max_width - (START_BMPWIDTH)) / 3; // Evenly distribute horizontal space
       offx = inter;                             // First the boot logo...
       offy = (height - (START_BMPHEIGHT)) / 2;  // ...V-aligned in the full height
       txt_offx_1 = txt_offx_2 = inter + (START_BMPWIDTH) + inter; // Text right of the bitmap
       txt_base = (height + MENU_FONT_ASCENT + text_total_height - (MENU_FONT_HEIGHT)) / 2; // Text vertical center
     }
     else {
-      constexpr uint8_t inter = (height - text_total_height - (START_BMPHEIGHT)) / 3; // Evenly distribute vertical space
+      constexpr int8_t inter = (height - text_total_height - (START_BMPHEIGHT)) / 3; // Evenly distribute vertical space
       offy = inter;                             // V-align boot logo proportionally
       offx = rspace / 2;                        // Center the boot logo in the whole space
       txt_offx_1 = (width - text_width_1) / 2;  // Text 1 centered


### PR DESCRIPTION
This fixes a warning reported in #13738:

```
src/lcd/dogm/ultralcd_DOGM.cpp: In static member function ‘static void MarlinUI::show_bootscreen()’:
src/lcd/dogm/ultralcd_DOGM.cpp:185:31: warning: overflow in implicit constant conversion [-Woverflow]
       txt_offx_1 = txt_offx_2 = inter + (START_BMPWIDTH) + inter; // Text right of the bitmap
```
This is probably a workaround to a compiler bug, but it was necessary to make `inter` a signed value. By all accounts, this should not be necessary, because `inter` will always be positive when the `if` statement succeeds -- in the cases in which the warning shows up, the condition is actually false and the code that generates the warning would be discarded. Nonetheless, to silence the warning it is necessary to make at least the first `inter` signed so that the computation of `txt_base` does not overflow on the branch that will be discarded. I made the second `inter` signed as well, just to be consistent.

