### PR TITLE
Fix LPC1768 HAL SSD* screen init

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/u8g/u8g_com_HAL_LPC1768_ssd_hw_i2c.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g/u8g_com_HAL_LPC1768_ssd_hw_i2c.cpp
@@ -137,8 +137,11 @@ uint8_t u8g_com_HAL_LPC1768_ssd_hw_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_v
 
     case U8G_COM_MSG_WRITE_BYTE:
       //u8g->pin_list[U8G_PI_SET_A0] = 1;
-      //if (u8g_com_arduino_ssd_start_sequence(u8g) == 0)
-      //  return u8g_i2c_stop(), 0;
+      if (u8g_com_ssd_I2C_start_sequence(u8g) == 0) {
+        u8g_i2c_stop();
+        return 0;
+      }
+
       if (u8g_i2c_send_byte(arg_val) == 0) {
         u8g_i2c_stop();
         return 0;
@@ -186,9 +189,6 @@ uint8_t u8g_com_HAL_LPC1768_ssd_hw_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_v
     case U8G_COM_MSG_ADDRESS:                     /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
       u8g->pin_list[U8G_PI_A0_STATE] = arg_val;
       u8g->pin_list[U8G_PI_SET_A0] = 1;   /* force a0 to set again */
-
-      u8g_i2c_start(0); // send slave address and write bit
-      u8g_i2c_send_byte(arg_val ? 0x40 : 0x80);  // Write to ? Graphics DRAM mode : Command mode
       break;
 
   } // switch


### PR DESCRIPTION
### Description

Fixed initialization of I2C based SSD1306 displays in LPC1768 HAL.

### Benefits

OLED displays connected to the I2C port on ReARM now display the UI.

### Related Issues

None? I did, however, run into https://github.com/MarlinFirmware/Marlin/issues/13550 issue using an OLED on a ReARM board.