### PR TITLE
Fix ESP32 TOGGLE() with I2S expander

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
@@ -37,7 +37,7 @@
 #define _PULLUP(IO, v)          pinMode(IO, v ? INPUT_PULLUP : INPUT)
 
 // Read a pin wrapper
-#define READ(IO)                digitalRead(IO)
+#define READ(IO)                (TEST(IO, 7) ? i2s_state(IO & 0x7F) : digitalRead(IO))
 
 // Write to a pin wrapper
 #define WRITE(IO, v)            (TEST(IO, 7) ? i2s_write(IO & 0x7F, v) : digitalWrite(IO, v))

--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -315,6 +315,10 @@ void i2s_write(uint8_t pin, uint8_t val) {
   SET_BIT_TO(i2s_port_data, pin, val);
 }
 
+uint8_t i2s_state(uint8_t pin) {
+  return TEST(i2s_port_data, pin);
+}
+
 void i2s_push_sample() {
   dma.current[dma.rw_pos++] = i2s_port_data;
 }

--- a/Marlin/src/HAL/HAL_ESP32/i2s.h
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.h
@@ -26,6 +26,8 @@ extern uint32_t i2s_port_data;
 
 int i2s_init();
 
+uint8_t i2s_state(uint8_t pin);
+
 void i2s_write(uint8_t pin, uint8_t val);
 
 void i2s_push_sample();


### PR DESCRIPTION
### Description

If the selected pin is an I2S-expander pin, then `READ()` will return the current state of the I2S pin instead of some garbage.

### Benefits

I think the buzzer code is using `TOGGLE()`, which I previously implemented in terms of `READ()`, now this should work correctly.

### Related Issues

None.
