### PR TITLE
Toggle UBL Activate / Deactivate in menu

### DIFF
--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -615,8 +615,10 @@ void _lcd_ubl_step_by_step() {
 void _lcd_ubl_level_bed() {
   START_MENU();
   MENU_BACK(MSG_MOTION);
-  MENU_ITEM(gcode, MSG_UBL_ACTIVATE_MESH, PSTR("G29 A"));
-  MENU_ITEM(gcode, MSG_UBL_DEACTIVATE_MESH, PSTR("G29 D"));
+  if (planner.leveling_active)
+    MENU_ITEM(gcode, MSG_UBL_DEACTIVATE_MESH, PSTR("G29 D"));
+  else
+    MENU_ITEM(gcode, MSG_UBL_ACTIVATE_MESH, PSTR("G29 A"));
   MENU_ITEM(submenu, MSG_UBL_STEP_BY_STEP_MENU, _lcd_ubl_step_by_step);
   MENU_ITEM(function, MSG_UBL_MESH_EDIT, _lcd_ubl_output_map_lcd_cmd);
   MENU_ITEM(submenu, MSG_UBL_STORAGE_MESH_MENU, _lcd_ubl_storage_mesh);


### PR DESCRIPTION
 to show the current state of bed leveling.

### Requirements

None.

### Description

A simple change, that made the UBL toggle between "Deactivate UBL" or "Activate UBL" when bed leveling is enabled.

### Benefits

In the menu, I noticed that I had a hard time to figure out if bed leveling was enabled, or not. Instead of adding a status line, I decided to just toggle the menu item.

### Related Issues

None