### PR TITLE
Fix bad opcode in LIGHTWEIGHT_UI; add 32-bit HAL and Due compatibility

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -99,7 +99,7 @@ static void u8g_com_DUE_st7920_write_byte_sw_spi(uint8_t rs, uint8_t val) {
     spiSend_sw_DUE(rs ? 0x0FA : 0x0F8); // Command or Data
     DELAY_US(40); // give the controller some time to process the data: 20 is bad, 30 is OK, 40 is safe
   }
-  spiSend_sw_DUE(val & 0x0F0);
+  spiSend_sw_DUE(val & 0xF0);
   spiSend_sw_DUE(val << 4);
 }
 
@@ -190,17 +190,17 @@ uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
   }
 
   void ST7920_set_cmd() {
-    spiSend_sw_DUE(0x0F8);
+    spiSend_sw_DUE(0xF8);
     DELAY_US(40);
   }
 
   void ST7920_set_dat() {
-    spiSend_sw_DUE(0x0FA);
+    spiSend_sw_DUE(0xFA);
     DELAY_US(40);
   }
 
   void ST7920_write_byte(const uint8_t val) {
-    spiSend_sw_DUE(val & 0x0F0);
+    spiSend_sw_DUE(val & 0xF0);
     spiSend_sw_DUE(val << 4);
   }
 #endif // LIGHTWEIGHT_UI

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -181,12 +181,12 @@ uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
   #endif
 
   void ST7920_cs() {
-    WRITE(ST7920_CS_PIN,1);
+    WRITE(ST7920_CS_PIN, HIGH);
     U8G_DELAY();
   }
 
   void ST7920_ncs() {
-    WRITE(ST7920_CS_PIN,0);
+    WRITE(ST7920_CS_PIN, LOW);
   }
 
   void ST7920_set_cmd() {
@@ -203,8 +203,7 @@ uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
     spiSend_sw_DUE(val & 0x0F0);
     spiSend_sw_DUE(val << 4);
   }
-#endif // ENABLED(LIGHTWEIGHT_UI)
+#endif // LIGHTWEIGHT_UI
 
 #endif // HAS_GRAPHICAL_LCD
-
 #endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -168,6 +168,43 @@ uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
   return 1;
 }
 
+#if ENABLED(LIGHTWEIGHT_UI)
+  #include "../../lcd/ultralcd.h"
+  #include "../shared/HAL_ST7920.h"
+
+  #define ST7920_CS_PIN LCD_PINS_RS
+
+  #if DOGM_SPI_DELAY_US > 0
+    #define U8G_DELAY() DELAY_US(DOGM_SPI_DELAY_US)
+  #else
+    #define U8G_DELAY() DELAY_US(10)
+  #endif
+
+  void ST7920_cs() {
+    WRITE(ST7920_CS_PIN,1);
+    U8G_DELAY();
+  }
+
+  void ST7920_ncs() {
+    WRITE(ST7920_CS_PIN,0);
+  }
+
+  void ST7920_set_cmd() {
+    spiSend_sw_DUE(0x0F8);
+    DELAY_US(40);
+  }
+
+  void ST7920_set_dat() {
+    spiSend_sw_DUE(0x0FA);
+    DELAY_US(40);
+  }
+
+  void ST7920_write_byte(const uint8_t val) {
+    spiSend_sw_DUE(val & 0x0F0);
+    spiSend_sw_DUE(val << 4);
+  }
+#endif // ENABLED(LIGHTWEIGHT_UI)
+
 #endif // HAS_GRAPHICAL_LCD
 
 #endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -158,9 +158,7 @@ void ST7920_Lite_Status_Screen::entry_mode_select(const bool ac_increase, const 
 // function for scroll_or_addr_select()
 void ST7920_Lite_Status_Screen::_scroll_or_addr_select(const bool sa) {
   extended_function_set(true);
-  cmd(0b00000010 |
-    (sa   ? 0b000001 : 0)
-  );
+  cmd(0b00000010 | (sa ? 0b00000001 : 0));
   current_bits.sa = sa;
 }
 

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -907,34 +907,6 @@ void ST7920_Lite_Status_Screen::clear_text_buffer() {
   ncs();
 }
 
-#if ENABLED(U8GLIB_ST7920) && !defined(U8G_HAL_LINKS) && !defined(__SAM3X8E__)
-
-  #include "ultralcd_st7920_u8glib_rrd_AVR.h"
-
-  void ST7920_Lite_Status_Screen::cs() {
-    ST7920_CS();
-    current_bits.synced = false;
-  }
-
-  void ST7920_Lite_Status_Screen::ncs() {
-    ST7920_NCS();
-    current_bits.synced = false;
-  }
-
-  void ST7920_Lite_Status_Screen::sync_cmd() {
-    ST7920_SET_CMD();
-  }
-
-  void ST7920_Lite_Status_Screen::sync_dat() {
-    ST7920_SET_DAT();
-  }
-
-  void ST7920_Lite_Status_Screen::write_byte(const uint8_t data) {
-    ST7920_WRITE_BYTE(data);
-  }
-
-#endif
-
 void MarlinUI::draw_status_screen() {
   ST7920_Lite_Status_Screen::update(false);
 }

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -158,7 +158,7 @@ void ST7920_Lite_Status_Screen::entry_mode_select(const bool ac_increase, const 
 // function for scroll_or_addr_select()
 void ST7920_Lite_Status_Screen::_scroll_or_addr_select(const bool sa) {
   extended_function_set(true);
-  cmd(0b00100010 |
+  cmd(0b00000010 |
     (sa   ? 0b000001 : 0)
   );
   current_bits.sa = sa;

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include "../../HAL/shared/HAL_ST7920.h"
+
 #include "../../core/macros.h"
 #include "../../libs/duration_t.h"
 
@@ -28,11 +30,11 @@ class ST7920_Lite_Status_Screen {
       uint8_t sa       : 1;
     } current_bits;
 
-    static void cs();
-    static void ncs();
-    static void sync_cmd();
-    static void sync_dat();
-    static void write_byte(const uint8_t w);
+    static void cs()                        {ST7920_cs(); current_bits.synced = false;}
+    static void ncs()                       {ST7920_cs(); current_bits.synced = false;}
+    static void sync_cmd()                  {ST7920_set_cmd();}
+    static void sync_dat()                  {ST7920_set_dat();}
+    static void write_byte(const uint8_t w) {ST7920_write_byte(w);}
 
     FORCE_INLINE static void write_word(const uint16_t w) {
       write_byte((w >> 8) & 0xFF);

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
@@ -30,11 +30,11 @@ class ST7920_Lite_Status_Screen {
       uint8_t sa       : 1;
     } current_bits;
 
-    static void cs()                        {ST7920_cs(); current_bits.synced = false;}
-    static void ncs()                       {ST7920_cs(); current_bits.synced = false;}
-    static void sync_cmd()                  {ST7920_set_cmd();}
-    static void sync_dat()                  {ST7920_set_dat();}
-    static void write_byte(const uint8_t w) {ST7920_write_byte(w);}
+    static void cs()                        { ST7920_cs(); current_bits.synced = false; }
+    static void ncs()                       { ST7920_cs(); current_bits.synced = false; }
+    static void sync_cmd()                  { ST7920_set_cmd(); }
+    static void sync_dat()                  { ST7920_set_dat(); }
+    static void write_byte(const uint8_t w) { ST7920_write_byte(w); }
 
     FORCE_INLINE static void write_word(const uint16_t w) {
       write_byte((w >> 8) & 0xFF);

--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -134,4 +134,14 @@ u8g_dev_t u8g_dev_st7920_128x64_rrd_sw_spi = {u8g_dev_rrd_st7920_128x64_fn, &u8g
 
 #pragma GCC reset_options
 
+#if ENABLED(LIGHTWEIGHT_UI)
+  #include "../../HAL/shared/HAL_ST7920.h"
+
+  void ST7920_cs()                          {ST7920_CS();}
+  void ST7920_ncs()                         {ST7920_NCS();}
+  void ST7920_set_cmd()                     {ST7920_SET_CMD();}
+  void ST7920_set_dat()                     {ST7920_SET_DAT();}
+  void ST7920_write_byte(const uint8_t val) {ST7920_WRITE_BYTE(val);}
+#endif // ENABLED(LIGHTWEIGHT_UI)
+
 #endif // U8GLIB_ST7920 && !U8G_HAL_LINKS && !__SAM3X8E__

--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -136,12 +136,11 @@ u8g_dev_t u8g_dev_st7920_128x64_rrd_sw_spi = {u8g_dev_rrd_st7920_128x64_fn, &u8g
 
 #if ENABLED(LIGHTWEIGHT_UI)
   #include "../../HAL/shared/HAL_ST7920.h"
-
-  void ST7920_cs()                          {ST7920_CS();}
-  void ST7920_ncs()                         {ST7920_NCS();}
-  void ST7920_set_cmd()                     {ST7920_SET_CMD();}
-  void ST7920_set_dat()                     {ST7920_SET_DAT();}
-  void ST7920_write_byte(const uint8_t val) {ST7920_WRITE_BYTE(val);}
-#endif // ENABLED(LIGHTWEIGHT_UI)
+  void ST7920_cs()                          { ST7920_CS(); }
+  void ST7920_ncs()                         { ST7920_NCS(); }
+  void ST7920_set_cmd()                     { ST7920_SET_CMD(); }
+  void ST7920_set_dat()                     { ST7920_SET_DAT(); }
+  void ST7920_write_byte(const uint8_t val) { ST7920_WRITE_BYTE(val); }
+#endif
 
 #endif // U8GLIB_ST7920 && !U8G_HAL_LINKS && !__SAM3X8E__


### PR DESCRIPTION
- Cleans up the LIGHTWEIGHT_UI so it uses a HAL layer for compatibility with 32-bit boards
- Implemented the HAL layer for 32-bit Due, adding support for LIGHTWEIGHT_UI
- This fixes an incorrect opcode in LIGHTWEIGHT_UI. This was causing a garbled screen in 32-bit boards but should never have worked in 8-bit boards either... a classic schrödinbug!