### PR TITLE
Add extra max-temp safety checks

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -430,11 +430,6 @@
 #define HEATER_5_MAXTEMP 275
 #define BED_MAXTEMP      150
 
-// Set a temperature above which the printer will be halted
-// immediately
-//#define HEATER_KILL_TEMP 310
-//#define BED_KILL_TEMP    160
-
 //===========================================================================
 //============================= PID Settings ================================
 //===========================================================================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -430,6 +430,11 @@
 #define HEATER_5_MAXTEMP 275
 #define BED_MAXTEMP      150
 
+// Set a temperature above which the printer will be halted
+// immediately
+//#define HEATER_KILL_TEMP 310
+//#define BED_KILL_TEMP    160
+
 //===========================================================================
 //============================= PID Settings ================================
 //===========================================================================

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -930,6 +930,9 @@
 #ifndef MSG_HEATING_FAILED_LCD_BED
   #define MSG_HEATING_FAILED_LCD_BED          _UxGT("Bed heating failed")
 #endif
+#ifndef MSG_HEATING_FAILED_LCD_CHAMBER
+  #define MSG_HEATING_FAILED_LCD_CHAMBER      _UxGT("Chamber heating fail")
+#endif
 #ifndef MSG_ERR_REDUNDANT_TEMP
   #define MSG_ERR_REDUNDANT_TEMP              _UxGT("Err: REDUNDANT TEMP")
 #endif
@@ -938,6 +941,9 @@
 #endif
 #ifndef MSG_THERMAL_RUNAWAY_BED
   #define MSG_THERMAL_RUNAWAY_BED             _UxGT("BED THERMAL RUNAWAY")
+#endif
+#ifndef MSG_THERMAL_RUNAWAY_CHAMBER
+  #define MSG_THERMAL_RUNAWAY_CHAMBER         _UxGT("CHAMBER T. RUNAWAY")
 #endif
 #ifndef MSG_ERR_MAXTEMP
   #define MSG_ERR_MAXTEMP                     _UxGT("Err: MAXTEMP")

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -86,12 +86,12 @@ Temperature thermalManager;
  */
 
 #if HAS_HEATED_BED
-  #define _BED_PSTR(M,E) (E) == -1 ? PSTR(MSG_BED " " M) :
+  #define _BED_PSTR(M,E) (E) == -1 ? PSTR(M ## _BED) :
 #else
   #define _BED_PSTR(M,E)
 #endif
 #if HAS_HEATED_CHAMBER
-  #define _CHAMBER_PSTR(M,E) (E) == -2 ? PSTR(MSG_CHAMBER " " M) :
+  #define _CHAMBER_PSTR(M,E) (E) == -2 ? PSTR(M ## _CHAMBER) :
 #else
   #define _CHAMBER_PSTR(M,E)
 #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -86,17 +86,17 @@ Temperature thermalManager;
  */
 
 #if HAS_HEATED_BED
-  #define _BED_PSTR(E) (E) == -1 ? PSTR(MSG ## _BED) :
+  #define _BED_PSTR(M,E) (E) == -1 ? PSTR(MSG_BED " " M) :
 #else
-  #define _BED_PSTR(E)
+  #define _BED_PSTR(M,E)
 #endif
 #if HAS_HEATED_CHAMBER
-  #define _CHAMBER_PSTR(E) (E) == -2 ? PSTR(MSG ## _CHAMBER) :
+  #define _CHAMBER_PSTR(M,E) (E) == -2 ? PSTR(MSG_CHAMBER " " M) :
 #else
-  #define _CHAMBER_PSTR(E)
+  #define _CHAMBER_PSTR(M,E)
 #endif
 #define _E_PSTR(M,E,N) (HOTENDS >= (N) && (E) == (N)-1) ? PSTR(MSG_E##N " " M) :
-#define TEMP_ERR_PSTR(M,E) _BED_PSTR(E) _CHAMBER_PSTR(E) _E_PSTR(M,E,2) _E_PSTR(M,E,3) _E_PSTR(M,E,4) _E_PSTR(M,E,5) _E_PSTR(M,E,6) PSTR(MSG_E1 " " M)
+#define TEMP_PSTR(M,E) _BED_PSTR(M,E) _CHAMBER_PSTR(M,E) _E_PSTR(M,E,2) _E_PSTR(M,E,3) _E_PSTR(M,E,4) _E_PSTR(M,E,5) _E_PSTR(M,E,6) PSTR(MSG_E0 " " M)
 
 // public:
 
@@ -507,10 +507,10 @@ temp_range_t Temperature::temp_range[HOTENDS] = ARRAY_BY_HOTENDS(sensor_heater_0
                 if (current > watch_temp_target) heated = true;     // - Flag if target temperature reached
               }
               else if (ELAPSED(ms, temp_change_ms))                 // Watch timer expired
-                _temp_error(heater, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, heater));
+                _temp_error(heater, PSTR(MSG_T_HEATING_FAILED), TEMP_PSTR(MSG_HEATING_FAILED_LCD, heater));
             }
             else if (current < target - (MAX_OVERSHOOT_PID_AUTOTUNE)) // Heated, then temperature fell too far?
-              _temp_error(heater, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_ERR_PSTR(MSG_THERMAL_RUNAWAY, heater));
+              _temp_error(heater, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_PSTR(MSG_THERMAL_RUNAWAY, heater));
           }
         #endif
       } // every 2 seconds
@@ -738,11 +738,11 @@ void Temperature::_temp_error(const int8_t heater, PGM_P const serial_msg, PGM_P
 }
 
 void Temperature::max_temp_error(const int8_t heater) {
-  _temp_error(heater, PSTR(MSG_T_MAXTEMP), TEMP_ERR_PSTR(MSG_ERR_MAXTEMP, heater));
+  _temp_error(heater, PSTR(MSG_T_MAXTEMP), TEMP_PSTR(MSG_ERR_MAXTEMP, heater));
 }
 
 void Temperature::min_temp_error(const int8_t heater) {
-  _temp_error(heater, PSTR(MSG_T_MINTEMP), TEMP_ERR_PSTR(MSG_ERR_MINTEMP, heater));
+  _temp_error(heater, PSTR(MSG_T_MINTEMP), TEMP_PSTR(MSG_ERR_MINTEMP, heater));
 }
 
 float Temperature::get_pid_output(const int8_t e) {
@@ -949,7 +949,6 @@ void Temperature::manage_heater() {
   #endif
 
   HOTEND_LOOP() {
-
     #if HEATER_IDLE_HANDLER
       hotend_idle[e].update(ms);
     #endif
@@ -965,7 +964,7 @@ void Temperature::manage_heater() {
       // Make sure temperature is increasing
       if (watch_hotend[e].next_ms && ELAPSED(ms, watch_hotend[e].next_ms)) { // Time to check this extruder?
         if (degHotend(e) < watch_hotend[e].target)                             // Failed to increase enough?
-          _temp_error(e, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, e));
+          _temp_error(e, PSTR(MSG_T_HEATING_FAILED), TEMP_PSTR(MSG_HEATING_FAILED_LCD, e));
         else                                                                 // Start again if the target is still far off
           start_watching_heater(e);
       }
@@ -1005,7 +1004,7 @@ void Temperature::manage_heater() {
       // Make sure temperature is increasing
       if (watch_bed.elapsed(ms)) {        // Time to check the bed?
         if (degBed() < watch_bed.target)                                // Failed to increase enough?
-          _temp_error(-1, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, -1));
+          _temp_error(-1, PSTR(MSG_T_HEATING_FAILED), TEMP_PSTR(MSG_HEATING_FAILED_LCD, -1));
         else                                                            // Start again if the target is still far off
           start_watching_bed();
       }
@@ -1075,7 +1074,7 @@ void Temperature::manage_heater() {
         // Make sure temperature is increasing
         if (watch_chamber.elapsed(ms)) {                  // Time to check the chamber?
           if (degChamber() < watch_chamber.target)   // Failed to increase enough?
-            _temp_error(-2, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, -2));
+            _temp_error(-2, PSTR(MSG_T_HEATING_FAILED), TEMP_PSTR(MSG_HEATING_FAILED_LCD, -2));
           else
             start_watching_chamber();                     // Start again if the target is still far off
         }
@@ -1689,7 +1688,7 @@ void Temperature::init() {
         sm.state = TRRunaway;
 
       case TRRunaway:
-        _temp_error(heater_id, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_ERR_PSTR(MSG_THERMAL_RUNAWAY, heater_id));
+        _temp_error(heater_id, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_PSTR(MSG_THERMAL_RUNAWAY, heater_id));
     }
   }
 
@@ -2646,11 +2645,7 @@ void Temperature::isr() {
   #if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
     void Temperature::set_heating_message(const uint8_t e) {
       const bool heating = isHeatingHotend(e);
-      #if HOTENDS > 1
-        ui.status_printf_P(0, heating ? PSTR("E%i " MSG_HEATING) : PSTR("E%i " MSG_COOLING), int(e + 1));
-      #else
-        ui.set_status_P(heating ? PSTR("E " MSG_HEATING) : PSTR("E " MSG_COOLING));
-      #endif
+      ui.set_status_P(heating ? TEMP_PSTR(MSG_HEATING, e) : TEMP_PSTR(MSG_COOLING, e));
     }
   #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -950,8 +950,7 @@ void Temperature::manage_heater() {
 
   HOTEND_LOOP() {
     #ifdef HEATER_KILL_TEMP
-      if (degHotend(e) > HEATER_KILL_TEMP)
-        max_temp_error(e);
+      if (degHotend(e) >= HEATER_KILL_TEMP) max_temp_error(e);
     #endif
 
     #if HEATER_IDLE_HANDLER
@@ -1006,8 +1005,7 @@ void Temperature::manage_heater() {
   #if HAS_HEATED_BED
 
     #ifdef BED_KILL_TEMP
-      if (degBed() > BED_KILL_TEMP)
-        max_temp_error(-1);
+      if (degBed() >= BED_KILL_TEMP) max_temp_error(-1);
     #endif
 
     #if WATCH_BED

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -949,9 +949,8 @@ void Temperature::manage_heater() {
   #endif
 
   HOTEND_LOOP() {
-    #ifdef HEATER_KILL_TEMP
-      if (degHotend(e) >= HEATER_KILL_TEMP) max_temp_error(e);
-    #endif
+    if (degHotend(e) > temp_range[e].maxtemp)
+      temp_error(e, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_PSTR(MSG_THERMAL_RUNAWAY, e));
 
     #if HEATER_IDLE_HANDLER
       hotend_idle[e].update(ms);
@@ -1004,9 +1003,8 @@ void Temperature::manage_heater() {
 
   #if HAS_HEATED_BED
 
-    #ifdef BED_KILL_TEMP
-      if (degBed() >= BED_KILL_TEMP) max_temp_error(-1);
-    #endif
+    if (degBed() > BED_MAXTEMP)
+      temp_error(-1, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_PSTR(MSG_THERMAL_RUNAWAY, -1));
 
     #if WATCH_BED
       // Make sure temperature is increasing

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -96,7 +96,7 @@ Temperature thermalManager;
   #define _CHAMBER_PSTR(M,E)
 #endif
 #define _E_PSTR(M,E,N) (HOTENDS >= (N) && (E) == (N)-1) ? PSTR(MSG_E##N " " M) :
-#define TEMP_PSTR(M,E) _BED_PSTR(M,E) _CHAMBER_PSTR(M,E) _E_PSTR(M,E,2) _E_PSTR(M,E,3) _E_PSTR(M,E,4) _E_PSTR(M,E,5) _E_PSTR(M,E,6) PSTR(MSG_E0 " " M)
+#define TEMP_PSTR(M,E) _BED_PSTR(M,E) _CHAMBER_PSTR(M,E) _E_PSTR(M,E,2) _E_PSTR(M,E,3) _E_PSTR(M,E,4) _E_PSTR(M,E,5) _E_PSTR(M,E,6) PSTR(MSG_E1 " " M)
 
 // public:
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -949,6 +949,11 @@ void Temperature::manage_heater() {
   #endif
 
   HOTEND_LOOP() {
+    #ifdef HEATER_KILL_TEMP
+      if (degHotend(e) > HEATER_KILL_TEMP)
+        max_temp_error(e);
+    #endif
+
     #if HEATER_IDLE_HANDLER
       hotend_idle[e].update(ms);
     #endif
@@ -999,6 +1004,11 @@ void Temperature::manage_heater() {
   #endif // FILAMENT_WIDTH_SENSOR
 
   #if HAS_HEATED_BED
+
+    #ifdef BED_KILL_TEMP
+      if (degBed() > BED_KILL_TEMP)
+        max_temp_error(-1);
+    #endif
 
     #if WATCH_BED
       // Make sure temperature is increasing

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -95,8 +95,8 @@ Temperature thermalManager;
 #else
   #define _CHAMBER_PSTR(M,E)
 #endif
-#define _E_PSTR(M,E,N) (HOTENDS >= (N) && (E) == (N)-1) ? PSTR(MSG_E##N " " M) :
-#define TEMP_PSTR(M,E) _BED_PSTR(M,E) _CHAMBER_PSTR(M,E) _E_PSTR(M,E,2) _E_PSTR(M,E,3) _E_PSTR(M,E,4) _E_PSTR(M,E,5) _E_PSTR(M,E,6) PSTR(MSG_E1 " " M)
+#define _E_PSTR(M,E,N) ((HOTENDS) >= (N) && (E) == (N)-1) ? PSTR(MSG_E##N " " M) :
+#define TEMP_ERR_PSTR(M,E) _BED_PSTR(M,E) _CHAMBER_PSTR(M,E) _E_PSTR(M,E,2) _E_PSTR(M,E,3) _E_PSTR(M,E,4) _E_PSTR(M,E,5) _E_PSTR(M,E,6) PSTR(MSG_E1 " " M)
 
 // public:
 
@@ -507,10 +507,10 @@ temp_range_t Temperature::temp_range[HOTENDS] = ARRAY_BY_HOTENDS(sensor_heater_0
                 if (current > watch_temp_target) heated = true;     // - Flag if target temperature reached
               }
               else if (ELAPSED(ms, temp_change_ms))                 // Watch timer expired
-                _temp_error(heater, PSTR(MSG_T_HEATING_FAILED), TEMP_PSTR(MSG_HEATING_FAILED_LCD, heater));
+                _temp_error(heater, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, heater));
             }
             else if (current < target - (MAX_OVERSHOOT_PID_AUTOTUNE)) // Heated, then temperature fell too far?
-              _temp_error(heater, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_PSTR(MSG_THERMAL_RUNAWAY, heater));
+              _temp_error(heater, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_ERR_PSTR(MSG_THERMAL_RUNAWAY, heater));
           }
         #endif
       } // every 2 seconds
@@ -738,11 +738,11 @@ void Temperature::_temp_error(const int8_t heater, PGM_P const serial_msg, PGM_P
 }
 
 void Temperature::max_temp_error(const int8_t heater) {
-  _temp_error(heater, PSTR(MSG_T_MAXTEMP), TEMP_PSTR(MSG_ERR_MAXTEMP, heater));
+  _temp_error(heater, PSTR(MSG_T_MAXTEMP), TEMP_ERR_PSTR(MSG_ERR_MAXTEMP, heater));
 }
 
 void Temperature::min_temp_error(const int8_t heater) {
-  _temp_error(heater, PSTR(MSG_T_MINTEMP), TEMP_PSTR(MSG_ERR_MINTEMP, heater));
+  _temp_error(heater, PSTR(MSG_T_MINTEMP), TEMP_ERR_PSTR(MSG_ERR_MINTEMP, heater));
 }
 
 float Temperature::get_pid_output(const int8_t e) {
@@ -950,7 +950,7 @@ void Temperature::manage_heater() {
 
   HOTEND_LOOP() {
     if (degHotend(e) > temp_range[e].maxtemp)
-      temp_error(e, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_PSTR(MSG_THERMAL_RUNAWAY, e));
+      temp_error(e, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_ERR_PSTR(MSG_THERMAL_RUNAWAY, e));
 
     #if HEATER_IDLE_HANDLER
       hotend_idle[e].update(ms);
@@ -967,7 +967,7 @@ void Temperature::manage_heater() {
       // Make sure temperature is increasing
       if (watch_hotend[e].next_ms && ELAPSED(ms, watch_hotend[e].next_ms)) { // Time to check this extruder?
         if (degHotend(e) < watch_hotend[e].target)                             // Failed to increase enough?
-          _temp_error(e, PSTR(MSG_T_HEATING_FAILED), TEMP_PSTR(MSG_HEATING_FAILED_LCD, e));
+          _temp_error(e, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, e));
         else                                                                 // Start again if the target is still far off
           start_watching_heater(e);
       }
@@ -1004,13 +1004,13 @@ void Temperature::manage_heater() {
   #if HAS_HEATED_BED
 
     if (degBed() > BED_MAXTEMP)
-      temp_error(-1, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_PSTR(MSG_THERMAL_RUNAWAY, -1));
+      temp_error(-1, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_ERR_PSTR(MSG_THERMAL_RUNAWAY, -1));
 
     #if WATCH_BED
       // Make sure temperature is increasing
       if (watch_bed.elapsed(ms)) {        // Time to check the bed?
         if (degBed() < watch_bed.target)                                // Failed to increase enough?
-          _temp_error(-1, PSTR(MSG_T_HEATING_FAILED), TEMP_PSTR(MSG_HEATING_FAILED_LCD, -1));
+          _temp_error(-1, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, -1));
         else                                                            // Start again if the target is still far off
           start_watching_bed();
       }
@@ -1080,7 +1080,7 @@ void Temperature::manage_heater() {
         // Make sure temperature is increasing
         if (watch_chamber.elapsed(ms)) {                  // Time to check the chamber?
           if (degChamber() < watch_chamber.target)   // Failed to increase enough?
-            _temp_error(-2, PSTR(MSG_T_HEATING_FAILED), TEMP_PSTR(MSG_HEATING_FAILED_LCD, -2));
+            _temp_error(-2, PSTR(MSG_T_HEATING_FAILED), TEMP_ERR_PSTR(MSG_HEATING_FAILED_LCD, -2));
           else
             start_watching_chamber();                     // Start again if the target is still far off
         }
@@ -1694,7 +1694,7 @@ void Temperature::init() {
         sm.state = TRRunaway;
 
       case TRRunaway:
-        _temp_error(heater_id, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_PSTR(MSG_THERMAL_RUNAWAY, heater_id));
+        _temp_error(heater_id, PSTR(MSG_T_THERMAL_RUNAWAY), TEMP_ERR_PSTR(MSG_THERMAL_RUNAWAY, heater_id));
     }
   }
 
@@ -2651,7 +2651,11 @@ void Temperature::isr() {
   #if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
     void Temperature::set_heating_message(const uint8_t e) {
       const bool heating = isHeatingHotend(e);
-      ui.set_status_P(heating ? TEMP_PSTR(MSG_HEATING, e) : TEMP_PSTR(MSG_COOLING, e));
+      #if HOTENDS > 1
+        ui.status_printf_P(0, heating ? PSTR("E%c " MSG_HEATING) : PSTR("E%c " MSG_COOLING), '1' + e);
+      #else
+        ui.set_status_P(heating ? PSTR("E " MSG_HEATING) : PSTR("E " MSG_COOLING));
+      #endif
     }
   #endif
 


### PR DESCRIPTION
I fixed a few errors that rendered the temperature error messages incomplete.

I implemented and tested the BED_MAXTEMP suggestion in https://github.com/MarlinFirmware/Marlin/issues/13711, but decided to make the checks optional and called them HEATER_KILL_TEMP and BED_KILL_TEMP.

I also changed the MSG_COOLING and MSG_HEATING to use the same macro (now renamed TEMP_PSTR). This allows those messages to use the `MSG_E##n` strings for consistency with everything else.
