### PR TITLE
Fix (re-)defines in HAL_ESP32

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/HAL.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.h
@@ -30,13 +30,18 @@
 
 #include <stdint.h>
 
+// these are going to be re-defined in Arduino.h
 #undef DISABLED
 #undef M_PI
+#undef _BV
 
 #include <Arduino.h>
 
+// revert back to the correct (old) definition
 #undef DISABLED
 #define DISABLED(V...) DO(DIS,&&,V)
+// re-define in case Arduino.h has been skipped due to earlier inclusion (i.e. in Marlin\src\HAL\HAL_ESP32\i2s.cpp)
+#define _BV(b) (1UL << (b))
 
 #include "../shared/math_32bit.h"
 #include "../shared/HAL_SPI.h"

--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -21,7 +21,12 @@
  */
 #ifdef ARDUINO_ARCH_ESP32
 
-#include <Arduino.h> // replace that with the proper imports
+// replace that with the proper imports, then cleanup workarounds in Marlin\src\HAL\HAL_ESP32\HAL.h
+#include <Arduino.h>
+// revert back to the correct definition
+#undef DISABLED
+#define DISABLED(V...) DO(DIS,&&,V)
+
 #include "i2s.h"
 #include "../../core/macros.h"
 #include "driver/periph_ctrl.h"


### PR DESCRIPTION
### Description

Undefined and redefined `_BV` before and after inclusion of `Arduino.h` in `HAL_ESP32/HAL.h`. Corrected definition of `DISABLED` after inclusion of `Arduino.h` in `HAL_ESP32/i2s.cpp`.

### Benefits

Proper compilation, ~~less~~ fewer warnings.