### PR TITLE
Fix SS pin in ESP32 HW SPI

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/spi_pins.h
+++ b/Marlin/src/HAL/HAL_ESP32/spi_pins.h
@@ -18,7 +18,7 @@
  */
 #pragma once
 
-#define SS_PIN    5
+#define SS_PIN   SDSS
 #define SCK_PIN  18
 #define MISO_PIN 19
 #define MOSI_PIN 23

--- a/Marlin/src/pins/pins_ESP32.h
+++ b/Marlin/src/pins/pins_ESP32.h
@@ -72,3 +72,6 @@
 #define HEATER_0_PIN         2
 #define FAN_PIN             13
 #define HEATER_BED_PIN       4
+
+// SPI
+#define SDSS                 5


### PR DESCRIPTION
### Description

Defined `SDSS` to be pin 5 in `pins_ESP32.h` (default for `SDSS` was `-1`) and based `SS_PIN` on `SDSS` in ESP32 HAL.

### Benefits

Sd2Card does now use the correct SS pin for SPI / SD card access and SD cards access does work now (which was not the case before).
