### PR TITLE
fix missed comments in fwretract.cpp

### DIFF
--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -112,9 +112,11 @@ void FWRetract::retract(const bool retracting
   #endif
 
   /* // debugging
-    SERIAL_ECHOLNPAIR("retracting ", retracting);
-    SERIAL_ECHOLNPAIR("swapping ", swapping);
-    SERIAL_ECHOLNPAIR("active_extruder ", active_extruder);
+    SERIAL_ECHOLNPAIR(
+      "retracting ", retracting,
+      " swapping ", swapping,
+      " active extruder ", active_extruder
+    );
     for (uint8_t i = 0; i < EXTRUDERS; ++i) {
       SERIAL_ECHOLNPAIR("retracted[", i, "] ", retracted[i]);
       #if EXTRUDERS > 1

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -103,7 +103,7 @@ void FWRetract::retract(const bool retracting
 
   // Prevent two swap-retract or recovers in a row
   #if EXTRUDERS > 1
-    // Allow G10 S1 only after G10
+    // Allow G10 S1 only after G11
     if (swapping && retracted_swap[active_extruder] == retracting) return;
     // G11 priority to recover the long retract if activated
     if (!retracting) swapping = retracted_swap[active_extruder];
@@ -112,11 +112,9 @@ void FWRetract::retract(const bool retracting
   #endif
 
   /* // debugging
-    SERIAL_ECHOLNPAIR(
-      "retracting ", retracting,
-      "swapping ", swapping
-      "active extruder ", active_extruder
-    );
+    SERIAL_ECHOLNPAIR("retracting ", retracting);
+    SERIAL_ECHOLNPAIR("swapping ", swapping);
+    SERIAL_ECHOLNPAIR("active_extruder ", active_extruder);
     for (uint8_t i = 0; i < EXTRUDERS; ++i) {
       SERIAL_ECHOLNPAIR("retracted[", i, "] ", retracted[i]);
       #if EXTRUDERS > 1


### PR DESCRIPTION
G10 S1 command after G10 is ignored.
Some commented debug messages are unable to compile with error.
