### PR TITLE
[2.0.x] Remove gpio.h

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
@@ -67,7 +67,6 @@
 
 #include <algorithm>
 #include <LPC17xx.h>
-#include <gpio.h>
 
 #include <Arduino.h>
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -150,7 +150,7 @@ monitor_speed = 250000
 # NXP LPC176x ARM Cortex-M3
 #
 [env:LPC1768]
-platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/master.zip
+platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/master.zip@>=0.0.2
 framework         = arduino
 board             = nxp_lpc1768
 build_flags       = -DTARGET_LPC1768 -DU8G_HAL_LINKS -IMarlin/src/HAL/HAL_LPC1768/include -IMarlin/src/HAL/HAL_LPC1768/u8g ${common.build_flags}
@@ -169,7 +169,7 @@ lib_deps          = Servo
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/master.zip
 
 [env:LPC1769]
-platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/master.zip
+platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/master.zip@>=0.0.2
 framework         = arduino
 board             = nxp_lpc1769
 build_flags       = -DTARGET_LPC1768 -DLPC1769 -DU8G_HAL_LINKS -IMarlin/src/HAL/HAL_LPC1768/include -IMarlin/src/HAL/HAL_LPC1768/u8g ${common.build_flags}


### PR DESCRIPTION
### Description

u8g_com_HAL_LPC1768_sw_spi.cpp #includes gpio.h (added in #13717), which doesn't seem to exist in a clean build, and causes the compilation to fail. However, the necessary functions are already available through Arduino.h, which is already #included in the file. This PR simply removes the gpio.h #include.
