### PR TITLE
[Bugfix 2.0.x] Inverse Home Feature

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1016,11 +1016,14 @@
 /** 
  *  Inverse home AWAY commands
  */
-#define STRINGIZE_NX(A) #A
-#define STRINGIZE(A) STRINGIZE_NX(A)
-#define AWAY_10_MM "G28\nG0 X10\nG0 Y10\nG0 Z10"
-#define AWAY_50_MM "G28\nG0 X50\nG0 Y50\nG0 Z50"
-#define AWAY_MAX_MM "G28\nG0 X"STRINGIZE(X_MAX_POS)"\nG0 Y"STRINGIZE(Y_MAX_POS)"\nG0 Z"STRINGIZE(Z_MAX_POS)
+#define INVERSE_HOME
+#ifdef INVERSE_HOME
+  #define STRINGIZE_NX(A) #A
+  #define STRINGIZE(A) STRINGIZE_NX(A)
+  #define AWAY_10_MM "G28\nG0 X10\nG0 Y10\nG0 Z10"
+  #define AWAY_50_MM "G28\nG0 X50\nG0 Y50\nG0 Z50"
+  #define AWAY_MAX_MM "G28\nG0 X"STRINGIZE(X_MAX_POS)"\nG0 Y"STRINGIZE(Y_MAX_POS)"\nG0 Z"STRINGIZE(Z_MAX_POS)
+#endif
 
 /**
  * Software Endstops

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1013,6 +1013,15 @@
 #define Y_MAX_POS Y_BED_SIZE
 #define Z_MAX_POS 200
 
+/** 
+ *  Inverse home AWAY commands
+ */
+#define STRINGIZE_NX(A) #A
+#define STRINGIZE(A) STRINGIZE_NX(A)
+#define AWAY_10_MM "G28\nG0 X10\nG0 Y10\nG0 Z10"
+#define AWAY_50_MM "G28\nG0 X50\nG0 Y50\nG0 Z50"
+#define AWAY_MAX_MM "G28\nG0 X"STRINGIZE(X_MAX_POS)"\nG0 Y"STRINGIZE(Y_MAX_POS)"\nG0 Z"STRINGIZE(Z_MAX_POS)
+
 /**
  * Software Endstops
  *

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1015,8 +1015,9 @@
 
 /** 
  *  Inverse home AWAY commands
+ *  Uncomment the below line of code for the inverse home feature
  */
-#define INVERSE_HOME
+//#define INVERSE_HOME
 #ifdef INVERSE_HOME
   #define STRINGIZE_NX(A) #A
   #define STRINGIZE(A) STRINGIZE_NX(A)

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -106,6 +106,18 @@
 #ifndef MSG_AUTO_HOME_Z
   #define MSG_AUTO_HOME_Z                     _UxGT("Home Z")
 #endif
+#ifndef MSG_INVERSE_HOME
+  #define MSG_INVERSE_HOME                    _UxGT("Inverse home")
+#endif
+#ifndef MSG_10MM_AWAY
+  #define MSG_10MM_AWAY                       _UxGT("Away 10mm")
+#endif
+#ifndef MSG_50MM_AWAY
+  #define MSG_50MM_AWAY                       _UxGT("Away 50mm")
+#endif
+#ifndef MSG_MAX_AWAY
+  #define MSG_MAX_AWAY                       _UxGT("Away Max")
+#endif
 #ifndef MSG_AUTO_Z_ALIGN
   #define MSG_AUTO_Z_ALIGN                    _UxGT("Auto Z-Align")
 #endif

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -413,6 +413,15 @@ void menu_move() {
   END_MENU();
 }
 
+void inverse_home_menu(){
+  START_MENU();
+  MENU_BACK(MSG_MOTION);
+  MENU_ITEM(gcode, MSG_10MM_AWAY, PSTR(AWAY_10_MM));
+  MENU_ITEM(gcode, MSG_50MM_AWAY, PSTR(AWAY_50_MM));
+  MENU_ITEM(gcode, MSG_MAX_AWAY, PSTR(AWAY_MAX_MM));
+  END_MENU();
+}
+
 void _lcd_ubl_level_bed();
 void menu_bed_leveling();
 
@@ -442,6 +451,11 @@ void menu_motion() {
     MENU_ITEM(gcode, MSG_AUTO_HOME_Z, PSTR("G28 Z"));
   #endif
 
+  //
+  // Inverse Home
+  //
+  MENU_ITEM(submenu, MSG_INVERSE_HOME, inverse_home_menu);
+  
   //
   // Auto Z-Align
   //

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -415,9 +415,11 @@ void menu_move() {
 void inverse_home_menu(){
   START_MENU();
   MENU_BACK(MSG_MOTION);
-  MENU_ITEM(gcode, MSG_10MM_AWAY, PSTR(AWAY_10_MM));
-  MENU_ITEM(gcode, MSG_50MM_AWAY, PSTR(AWAY_50_MM));
-  MENU_ITEM(gcode, MSG_MAX_AWAY, PSTR(AWAY_MAX_MM));
+  #ifdef INVERSE_HOME
+    MENU_ITEM(gcode, MSG_10MM_AWAY, PSTR(AWAY_10_MM));
+    MENU_ITEM(gcode, MSG_50MM_AWAY, PSTR(AWAY_50_MM));
+    MENU_ITEM(gcode, MSG_MAX_AWAY, PSTR(AWAY_MAX_MM));
+  #endif
   END_MENU();
 }
 

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -23,7 +23,6 @@
 //
 // Motion Menu
 //
-
 #include "../../inc/MarlinConfigPre.h"
 
 #if HAS_LCD_MENU
@@ -454,8 +453,9 @@ void menu_motion() {
   //
   // Inverse Home
   //
-  MENU_ITEM(submenu, MSG_INVERSE_HOME, inverse_home_menu);
-  
+  #ifdef INVERSE_HOME
+    MENU_ITEM(submenu, MSG_INVERSE_HOME, inverse_home_menu);
+  #endif
   //
   // Auto Z-Align
   //


### PR DESCRIPTION
### Requirements

* This feature is only supported in English for now. Also, I don't think this feature will work with delta printers.

### Description
This feature allows the user to move all of the axes to 10mm, 50mm, or the maximum distance away from the home position with one click. First, the printer *will home*, and then the axes will start to move to the given distances one by one. I've tested it on my printer, and works.
### Benefits

<!-- What does this fix or improve? -->
I work a lot with DIY printers and after assembling a printer I would like to see if the gantry is smooth. I believe that this feature would allow me and many others who work with DIY printers to test this.  
### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
