### PR TITLE
Add gitignore for Eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,13 @@ CMakeListsPrivate.txt
 
 #CLion
 cmake-build-*
+
+#Eclipse
+.project
+.cproject
+.pydevproject
+.settings
+.classpath
+
+#Python
+__pycache__


### PR DESCRIPTION
### Description

Add gitignore for Eclipse

### Benefits

Support development in Eclipse CDT https://www.eclipse.org/cdt/
