### PR TITLE
Add missing AZSMZ Mini SPI pins

### DIFF
--- a/Marlin/src/pins/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/pins_AZSMZ_MINI.h
@@ -85,6 +85,9 @@
 #endif
 #define FAN1_PIN           P0_26
 
+#define LCD_SDSS         P0_16  // LCD SD chip select
+#define ONBOARD_SD_CS    P0_06  // On board SD chip select
+
 #if ENABLED(AZSMZ_12864)
   #define BEEPER_PIN       P1_30
   #define DOGLCD_A0        P2_06
@@ -92,8 +95,28 @@
   #define BTN_EN1          P4_28
   #define BTN_EN2          P1_27
   #define BTN_ENC          P3_26
-  #define LCD_SDSS         P0_16
+  #if !ENABLED(LPC_SD_ONBOARD)
+  #define LPC_SD_LCD
+  #endif
+#endif
+
+#if ENABLED(LPC_SD_LCD)
+  #define SCK_PIN          P0_15
+  #define MISO_PIN         P0_17
+  #define MOSI_PIN         P0_18
+  #define SS_PIN           LCD_SDSS
   #define SD_DETECT_PIN    P3_25
+#elif ENABLED(LPC_SD_ONBOARD)
+  #if ENABLED(USB_SD_ONBOARD)
+    // When sharing the SD card with a PC we want the menu options to
+    // mount/unmount the card and refresh it. So we disable card detect.
+    #define SHARED_SD_CARD
+    #undef SD_DETECT_PIN
+  #endif
+  #define SCK_PIN          P0_07
+  #define MISO_PIN         P0_08
+  #define MOSI_PIN         P0_09
+  #define SS_PIN           ONBOARD_SD_CS
 #endif
 
 //

--- a/Marlin/src/pins/pins_AZSMZ_MINI.h
+++ b/Marlin/src/pins/pins_AZSMZ_MINI.h
@@ -85,8 +85,8 @@
 #endif
 #define FAN1_PIN           P0_26
 
-#define LCD_SDSS         P0_16  // LCD SD chip select
-#define ONBOARD_SD_CS    P0_06  // On board SD chip select
+#define LCD_SDSS           P0_16   // LCD SD chip select
+#define ONBOARD_SD_CS      P0_06   // On board SD chip select
 
 #if ENABLED(AZSMZ_12864)
   #define BEEPER_PIN       P1_30
@@ -95,8 +95,8 @@
   #define BTN_EN1          P4_28
   #define BTN_EN2          P1_27
   #define BTN_ENC          P3_26
-  #if !ENABLED(LPC_SD_ONBOARD)
-  #define LPC_SD_LCD
+  #if DISABLED(LPC_SD_ONBOARD)
+    #define LPC_SD_LCD
   #endif
 #endif
 


### PR DESCRIPTION
This pull request adds missing SPI pin definitions for LCD and onboard SD card access to the pins file for the AZSMZ mini.

Without this definition it picks up the default pin (P1_23) for SS_PIN from the HAL which is used for servo output on the AZSMZ mini.