### PR TITLE
Fix thermistor 501 name

### DIFF
--- a/Marlin/src/lcd/thermistornames.h
+++ b/Marlin/src/lcd/thermistornames.h
@@ -96,8 +96,8 @@
   #define THERMISTOR_NAME "PT100 1K"
 #elif THERMISTOR_ID == 666
   #define THERMISTOR_NAME "Einstart S"
-  #elif THERMISTOR_ID == 501
-    #define THERMISTOR_NAME "Zonestar (Tronxy X3A)"
+#elif THERMISTOR_ID == 501
+  #define THERMISTOR_NAME "Zonestar (Tronxy X3A)"
 
 // High Temperature thermistors
 #elif THERMISTOR_ID == 61

--- a/Marlin/src/lcd/thermistornames.h
+++ b/Marlin/src/lcd/thermistornames.h
@@ -96,6 +96,8 @@
   #define THERMISTOR_NAME "PT100 1K"
 #elif THERMISTOR_ID == 666
   #define THERMISTOR_NAME "Einstart S"
+  #elif THERMISTOR_ID == 501
+    #define THERMISTOR_NAME "Zonestar (Tronxy X3A)"
 
 // High Temperature thermistors
 #elif THERMISTOR_ID == 61


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description



when using the 501 thermistor, compile fails due to missing name in thermistornames.h


### Benefits

Allows you to use the 501 thermistor

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
