### PR TITLE
Fix HOST_PROMPT_SUPPORT compile issue

### DIFF
--- a/Marlin/src/feature/host_actions.h
+++ b/Marlin/src/feature/host_actions.h
@@ -21,8 +21,9 @@
  */
 #pragma once
 
-#include <stddef.h>
 #include "../inc/MarlinConfigPre.h"
+
+#include <stdint.h>
 
 void host_action(const char * const pstr, const bool eol=true);
 

--- a/Marlin/src/feature/host_actions.h
+++ b/Marlin/src/feature/host_actions.h
@@ -21,7 +21,8 @@
  */
 #pragma once
 
-#include "../inc/MarlinConfig.h"
+#include <stddef.h>
+#include "../inc/MarlinConfigPre.h"
 
 void host_action(const char * const pstr, const bool eol=true);
 


### PR DESCRIPTION
### Description
Avoid a #Include loop between ``MarlinSerial.h`` and ``emergency_parser.h`` when included from ``host_actions.h``.
### Benefits
Fix a compile error when both ``EMERGENCY_PARSER`` and ``HOST_PROMPT_SUPPORT`` are enabled on LPC1768
### Related Issues
Fixes #13846