### PR TITLE
Add M22 SD release for onboard cards

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -67,6 +67,9 @@
 #ifndef MSG_SD_REMOVED
   #define MSG_SD_REMOVED                      _UxGT("Card removed")
 #endif
+#ifndef MSG_SD_RELEASED
+  #define MSG_SD_RELEASED                     _UxGT("Card released")
+#endif
 #ifndef MSG_LCD_ENDSTOPS
   #define MSG_LCD_ENDSTOPS                    _UxGT("Endstops") // Max length 8 characters
 #endif
@@ -878,6 +881,9 @@
 #endif
 #ifndef MSG_CHANGE_SDCARD
   #define MSG_CHANGE_SDCARD                   _UxGT("Change SD card")
+#endif
+#ifndef MSG_RELEASE_SDCARD
+  #define MSG_RELEASE_SDCARD                  _UxGT("Release SD card")
 #endif
 #ifndef MSG_ZPROBE_OUT
   #define MSG_ZPROBE_OUT                      _UxGT("Z Probe past bed")

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -178,16 +178,22 @@ void menu_main() {
       if (card_detected) {
         if (!card_open) {
           MENU_ITEM(submenu, MSG_CARD_MENU, menu_sdcard);
-          #if !PIN_EXISTS(SD_DETECT)
-            MENU_ITEM(gcode, MSG_CHANGE_SDCARD, PSTR("M21"));  // SD-card changed by user
-          #endif
+          MENU_ITEM(gcode,
+            #if PIN_EXISTS(SD_DETECT)
+              MSG_CHANGE_SDCARD, PSTR("M21")
+            #else
+              MSG_RELEASE_SDCARD, PSTR("M22")
+            #endif
+          );
         }
       }
       else {
-        #if !PIN_EXISTS(SD_DETECT)
-          MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21")); // Manually init SD-card
+        #if PIN_EXISTS(SD_DETECT)
+          MENU_ITEM(function, MSG_NO_CARD, NULL);
+        #else
+          MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21"));
+          MENU_ITEM(function, MSG_SD_RELEASED, NULL);
         #endif
-        MENU_ITEM(function, MSG_NO_CARD, NULL);
       }
     #endif // !HAS_ENCODER_WHEEL && SDSUPPORT
 
@@ -259,16 +265,22 @@ void menu_main() {
     if (card_detected) {
       if (!card_open) {
         MENU_ITEM(submenu, MSG_CARD_MENU, menu_sdcard);
-        #if !PIN_EXISTS(SD_DETECT)
-          MENU_ITEM(gcode, MSG_CHANGE_SDCARD, PSTR("M21"));  // SD-card changed by user
-        #endif
+        MENU_ITEM(gcode,
+          #if PIN_EXISTS(SD_DETECT)
+            MSG_CHANGE_SDCARD, PSTR("M21")
+          #else
+            MSG_RELEASE_SDCARD, PSTR("M22")
+          #endif
+        );
       }
     }
     else {
-      #if !PIN_EXISTS(SD_DETECT)
-        MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21")); // Manually init SD-card
+      #if PIN_EXISTS(SD_DETECT)
+        MENU_ITEM(function, MSG_NO_CARD, NULL);
+      #elif
+        MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21"));
+        MENU_ITEM(function, MSG_SD_RELEASED, NULL);
       #endif
-      MENU_ITEM(function, MSG_NO_CARD, NULL);
     }
   #endif // HAS_ENCODER_WHEEL && SDSUPPORT
 


### PR DESCRIPTION
### Description

There was no menu item to release onboard SD card for USB access. I was having to resort to cycling power to release it.

This only adds the `M22` "Release SD card" menu item when `USB_SD_ONBOARD` is enabled.

Replaces `M21` menu item with `M22`. I don't think missing the `M21` will be a big concern as you can easily release the SD and initialize it again.

This is my first time using GitHub so please don't hesitate crucifying me for any wrong doings. Hang on, I think I've stuffed up already, Sorry about the double up, I think I've got it right this time...

### Benefits

Speeds up file transfer to the printer without removing the SD card or sending a serial `M22`.

### Related Issues

I have tested this code on my SKR 1.3 and it works great but as I mentioned, someone might not like losing the `M21` if they are manually removing the SD card due to an extra button press..
