### PR TITLE
Fix PLR file delete bug

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1008,7 +1008,7 @@ void CardReader::printingHasFinished() {
 
 #if ENABLED(POWER_LOSS_RECOVERY)
 
-  constexpr char job_recovery_file_name[4] = "PLR";
+  constexpr char job_recovery_file_name[5] = "/PLR";
 
   bool CardReader::jobRecoverFileExists() {
     const bool exists = recovery.file.open(&root, job_recovery_file_name, O_READ);


### PR DESCRIPTION
If we print file from sub folder, 2 things happened.

1. After printing finished, or we Stop Printing, PLR file delete will fail.
This is because current code try to delete PLR file at Working Directory.
This PR just add simple fix by add "/" at the beginning of Filename.

2. After first resume, marlin will fail on second resume.
After first resume, Marlin save Filename without Directory.
This happened because **workDirParents** is not set.
Therefore when writing PLR

`card.getAbsFilename(info.sd_filename);
`
will only write Filename Part without Directory.

Problem no 1 is fixed by this PR. 
But problem no 2 is not fixed yet. 
