### PR TITLE
Fix bug: diveToFile breaks M23

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -392,7 +392,6 @@ void PrintJobRecovery::resume() {
 
   // Resume the SD file from the last position
   char *fn = info.sd_filename;
-  while (*fn == '/') fn++;
   sprintf_P(cmd, PSTR("M23 %s"), fn);
   gcode.process_subcommands_now(cmd);
   sprintf_P(cmd, PSTR("M24 S%ld T%ld"), info.sdpos, info.print_job_elapsed);

--- a/Marlin/src/gcode/sdcard/M23.cpp
+++ b/Marlin/src/gcode/sdcard/M23.cpp
@@ -29,6 +29,8 @@
 
 /**
  * M23: Open a file
+ *
+ * The path is relative to the root directory
  */
 void GcodeSuite::M23() {
   // Simplify3D includes the size, so zero out all spaces (#7227)

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -461,7 +461,7 @@ void CardReader::openFile(char * const path, const bool read, const bool subcall
   stopSDPrint();
 
   SdFile *curDir;
-  const char * const fname = diveToFile(curDir, path, false);
+  const char * const fname = diveToFile(curDir, path);
   if (!fname) return;
 
   if (read) {
@@ -501,7 +501,7 @@ void CardReader::removeFile(const char * const name) {
   //stopSDPrint();
 
   SdFile *curDir;
-  const char * const fname = diveToFile(curDir, name, false);
+  const char * const fname = diveToFile(curDir, name);
   if (!fname) return;
 
   if (file.remove(curDir, fname)) {
@@ -641,7 +641,7 @@ uint16_t CardReader::getnrfilenames() {
  *
  * A NULL result indicates an unrecoverable error.
  */
-const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, const bool echo) {
+const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, const bool echo/*=false*/) {
   // need 2 static SdFile, for parent and sub.
   static SdFile newDir1, newDir2;
   SdFile *sub = &newDir1, *startDir;

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -646,6 +646,7 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
   SdFile *sub = &newDir1;
 
   const char *dirname_start = path;
+  char echo_fn[105];
   
   if (path[0] == '/') { 
     curDir = &root;
@@ -653,6 +654,11 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
     dirname_start++;
   } else {
     curDir = &workDir; 
+  }
+  if (echo) {
+    SERIAL_ECHOLNPAIR("==== Dive ====\nPath: ", path);
+    curDir->getFilename(echo_fn);
+    SERIAL_ECHOLNPAIR("Cur Dir: ", echo_fn);
   }
 
   while (dirname_start) {
@@ -663,7 +669,7 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
     strncpy(dosSubdirname, dirname_start, len);
     dosSubdirname[len] = 0;
 
-    if (echo) SERIAL_ECHOLN(dosSubdirname);
+    if (echo) SERIAL_ECHOLNPAIR("Sub Dir Name: ", dosSubdirname);
 
     if (!sub->open(curDir, dosSubdirname, O_READ)) {
       SERIAL_ECHOLNPAIR(MSG_SD_OPEN_FILE_FAIL, dosSubdirname, ".");
@@ -671,8 +677,14 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
     }
     if (curDir != &root) curDir->close();
     curDir = sub;
-    sub = curDir != &newDir1 ? &newDir1 : &newDir2;
+
+    if (echo) {
+      curDir->getFilename(echo_fn);
+      SERIAL_ECHOLNPAIR("New Dir: ", echo_fn);
+      SERIAL_ECHOLNPAIR("Work Dir Depth: ", workDirDepth);
+    }
     if (workDirDepth < MAX_DIR_DEPTH) workDirParents[workDirDepth++] = *curDir;
+    sub = curDir != &newDir1 ? &newDir1 : &newDir2;
     dirname_start = dirname_end + 1;
   }
   return dirname_start;

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -644,7 +644,7 @@ uint16_t CardReader::getnrfilenames() {
 const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, const bool echo) {
   // need 2 static SdFile, for parent and sub.
   static SdFile newDir1, newDir2;
-  SdFile *sub = &newDir1;
+  SdFile *sub = &newDir1, *startDir;
 
   const char *dirname_start = path;
   char echo_fn[105];
@@ -657,6 +657,8 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
   } else {
     curDir = &workDir; 
   }
+  startDir = curDir;
+
   if (echo) {
     SERIAL_ECHOLNPAIR("==== Dive ====\nPath: ", path);
     curDir->getFilename(echo_fn);
@@ -684,7 +686,7 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
     }
 
     // close curDir if not root
-    if (curDir != &root) curDir->close();
+    if (curDir != startDir) curDir->close();
 
     // subDir now curDir   
     curDir = sub;

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -88,7 +88,7 @@ public:
   static int8_t updir();
   static void setroot();
 
-  static const char* diveToFile(SdFile*& curDir, const char * const path, const bool echo);
+  static const char* diveToFile(SdFile*& curDir, const char * const path, const bool echo=false);
 
   static uint16_t get_num_Files();
 


### PR DESCRIPTION
Open FIle from gcode M23 cannot set workParentDir.
This make M23 cannot resume on power loss.

This PR fix the problem when open file on subdir using M23.
Related with #13860
