### PR TITLE
Auto-mount the SDIO SD card

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -939,8 +939,8 @@ void setup() {
 
   queue_setup();
 
-  #if defined(SDIO_SUPPORT) && SD_DETECT_PIN == -1
-    // auto mount the SD for EEPROM.dat emulation
+  #if ENABLED(SDIO_SUPPORT) && SD_DETECT_PIN == -1
+    // Auto-mount the SD for EEPROM.dat emulation
     if (!card.isDetected()) card.initsd();
   #endif
 

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -939,6 +939,11 @@ void setup() {
 
   queue_setup();
 
+  #if defined(SDIO_SUPPORT) && SD_DETECT_PIN == -1
+    // auto mount the SD for EEPROM.dat emulation
+    if (!card.isDetected()) card.initsd();
+  #endif
+
   // Load data from EEPROM if available (or use defaults)
   // This also updates variables in the planner, elsewhere
   (void)settings.load();


### PR DESCRIPTION
required to load settings with eeprom on SD (STM32F1 feature)
