### PR TITLE
Changed DEFAULT_AXIS_STEPS_PER_UNIT for latest I3 Pro B version

### DIFF
--- a/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/Marlin/example_configurations/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -616,7 +616,10 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2[, E3[, E4]]]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 78.74, 78.74, 2560, 105 }
+// For use with M8 threaded rod version
+//#define DEFAULT_AXIS_STEPS_PER_UNIT   { 78.74, 78.74, 2560, 105 }
+// For use with M8 leadscrew version
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 78.74, 78.74, 400, 105 }
 
 /**
  * Default Max Feed Rate (mm/s)


### PR DESCRIPTION
The latest version of the I3 Pro B comes with M8 leadscrew rather than M8 threaded rod with the kit.

As a result, the DEFAULT_AXIS_STEPS_PER_UNIT requires changing, I have kept both versions in for completeness.

Alternatively, the read.me should be amended to show the necessary command, i.e. M92 Z400, followed by Z500.
