### PR TITLE
stepper: fix NOMORE() sign warning

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1298,7 +1298,7 @@ void Stepper::isr() {
     ;
 
     // Limit the value to the maximum possible value of the timer
-    NOMORE(interval, HAL_TIMER_TYPE_MAX);
+    NOMORE(interval, uint32_t(HAL_TIMER_TYPE_MAX));
 
     // Compute the time remaining for the main isr
     nextMainISR -= interval;


### PR DESCRIPTION

### Description

cant be set to 0xFFFFFFFFUL in the HAL_timers_STM32.h, cause many other ones

### Benefits

Reduce the possible coding issues as much as possible, we experiment some random Y layer shifts (on medium/big parts)...

### Related Issues

#12403 
