### PR TITLE
60Hz servo option to reduce LCD flicker (DUE, STM32F1, AVR)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2111,6 +2111,7 @@
 //#define RGBW_LED
 
 #if EITHER(RGB_LED, RGBW_LED)
+  //#define SERVO_60HZ               // (DUE, AVR, STM32F1) *EXPERIMENTAL* Reduces flicker but may adversely affect servos
   //#define RGB_LED_R_PIN 34
   //#define RGB_LED_G_PIN 43
   //#define RGB_LED_B_PIN 35

--- a/Marlin/src/HAL/HAL_LINUX/servo_private.h
+++ b/Marlin/src/HAL/HAL_LINUX/servo_private.h
@@ -55,7 +55,7 @@
 #define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo
 #define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo
 #define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached
-#define REFRESH_INTERVAL    20000     // minimum time to refresh servos in microseconds
+#define REFRESH_INTERVAL (1000000/(SERVOS_HZ)) // minimum time to refresh servos in microseconds
 
 #define MAX_SERVOS             4
 

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_Servo_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_Servo_STM32F1.cpp
@@ -49,7 +49,7 @@ uint8_t ServoCount = 0;
  */
 #define MAX_OVERFLOW    UINT16_MAX //((1 << 16) - 1)
 #define CYC_MSEC        (1000 * CYCLES_PER_MICROSECOND)
-#define TAU_MSEC        20
+#define TAU_MSEC        (1000/(SERVOS_HZ))
 #define TAU_USEC        (TAU_MSEC * 1000)
 #define TAU_CYC         (TAU_MSEC * CYC_MSEC)
 #define SERVO_PRESCALER (TAU_CYC / MAX_OVERFLOW + 1)

--- a/Marlin/src/HAL/shared/servo_private.h
+++ b/Marlin/src/HAL/shared/servo_private.h
@@ -56,7 +56,7 @@
 #define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo
 #define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo
 #define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached
-#define REFRESH_INTERVAL    20000     // minimum time to refresh servos in microseconds
+#define REFRESH_INTERVAL (1000000/(SERVOS_HZ)) // minimum time to refresh servos in microseconds
 
 #define SERVOS_PER_TIMER       12     // the maximum number of servos controlled by one timer
 #define MAX_SERVOS   (_Nbr_16timers  * SERVOS_PER_TIMER)

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1003,8 +1003,16 @@
 #define HAS_SERVO_3 (PIN_EXISTS(SERVO3))
 #define HAS_SERVOS (defined(NUM_SERVOS) && NUM_SERVOS > 0)
 
-#if HAS_SERVOS && !defined(Z_PROBE_SERVO_NR)
-  #define Z_PROBE_SERVO_NR -1
+#if HAS_SERVOS
+  #ifndef Z_PROBE_SERVO_NR
+    #define Z_PROBE_SERVO_NR -1
+  #endif
+  // 60Hz reduces RGB LED flicker but may adversely affect servos
+  #if ENABLED(SERVO_60HZ)
+    #define SERVOS_HZ 60
+  #else
+    #define SERVOS_HZ 50
+  #endif
 #endif
 
 #define HAS_SERVO_ANGLES (EITHER(SWITCHING_EXTRUDER, SWITCHING_NOZZLE) || (HAS_Z_SERVO_PROBE && defined(Z_PROBE_SERVO_NR)))


### PR DESCRIPTION
EXPERIMENTAL

NEEDS TESTING

Reduce the LED flicker by adding an option to set the servo rate to 60Hz.

Devices like the BLTouch are compatible.  It is unknown how other servo based devices will react.

---

In file **Conditionals_post.h** the macro **SERVO_FREQUENCY** is set to 60 if **SERVO_60HZ** is enabled in **configuration.h**.  It is set to 50 if not enabled.

**SERVO_FREQUENCY** is then used to set the servo frequency/period in the various HALs.

I put the **SERVO_60HZ** in the  **#if EITHER(RGB_LED, RGBW_LED)** section so that it was obvious why it would be used.

---

IMPLEMENTATION STATUS:
- DUE - tested on BLTouch
- STM32F1 - not tested
- AVR - tested on BLTouch
- LPC1768 - tested on BLTouch but with a manually edited **pwm.h** file.  Have not been able to automate the selection.
- all others - couldn't find where the servo frequency was set
