### PR TITLE
STM32: fix Marduino SBI/CBI redefine

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.h
@@ -36,6 +36,7 @@
 // Includes
 // --------------------------------------------------------------------------
 
+#include "../../core/macros.h"
 #include "../shared/Marduino.h"
 #include "../shared/math_32bit.h"
 #include "../shared/HAL_SPI.h"


### PR DESCRIPTION
Since the shared include "Marduino.h", there are new warnings about redefined macros.

Force the core/macros.h to be included first.