### PR TITLE
Move #include <Arduino.h> after redefining _BV preprocessor macro

### DIFF
--- a/Marlin/src/HAL/shared/Marduino.h
+++ b/Marlin/src/HAL/shared/Marduino.h
@@ -30,8 +30,6 @@
 #undef _BV            // Redefined by some
 #undef sq             // Redefined by teensy3/wiring.h
 
-#include <Arduino.h>  // NOTE: If included earlier then this line is a NOOP
-
 #undef DISABLED
 #define DISABLED(V...) DO(DIS,&&,V)
 
@@ -48,3 +46,5 @@
 #ifndef CBI
   #define CBI(A,B) (A &= ~(1 << (B)))
 #endif
+
+#include <Arduino.h>  // NOTE: If included earlier then this line is a NOOP

--- a/Marlin/src/HAL/shared/Marduino.h
+++ b/Marlin/src/HAL/shared/Marduino.h
@@ -30,9 +30,6 @@
 #undef _BV            // Redefined by some
 #undef sq             // Redefined by teensy3/wiring.h
 
-#undef DISABLED
-#define DISABLED(V...) DO(DIS,&&,V)
-
 #undef _BV
 #define _BV(b) (1UL << (b))
 
@@ -48,3 +45,6 @@
 #endif
 
 #include <Arduino.h>  // NOTE: If included earlier then this line is a NOOP
+
+#undef DISABLED
+#define DISABLED(V...) DO(DIS,&&,V)


### PR DESCRIPTION
### Description

This is an attempt to fix what I think is a broken build on AVR, feel free to point me in the right direction, as I'm not exactly sure of the greater impact of such change.

### Benefits

I couldn't build the `bugfix-2.x` branch with `MightyCore:avr` for a Ender 3 Pro board (atmega1284p) since e7682eea425d2173e594b5cfdb5c2e4d6fc953c0.