### PR TITLE
Remove extra MMU (non-12V) code

### DIFF
--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -207,8 +207,6 @@ void MMU2::mmu_loop() {
       if (rx_ok()) {
         DEBUG_ECHOLNPGM("MMU => ok");
 
-        check_version();
-
         DEBUG_ECHOLNPGM("MMU <= 'P0'");
 
         tx_str_P(PSTR("P0\n")); // read finda
@@ -302,7 +300,7 @@ void MMU2::mmu_loop() {
 
         if (!finda && finda_runout_valid) filament_runout();
       }
-      else if (ELAPSED(millis(), last_request + MMU_P0_TIMEOUT)) // Resend request after timeout (30s)
+      else if (ELAPSED(millis(), last_request + MMU_P0_TIMEOUT)) // Resend request after timeout (3s)
         state = 1;
 
       break;

--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -202,6 +202,7 @@ void MMU2::mmu_loop() {
       }
       break;
 
+    #if ENABLED(MMU2_MODE_12V)
     case -5:
       // response to M1
       if (rx_ok()) {
@@ -213,6 +214,7 @@ void MMU2::mmu_loop() {
         state = -4;
       }
       break;
+    #endif
 
     case -4:
       if (rx_ok()) {


### PR DESCRIPTION
`check_version` in state -5 should not be needed since it has been already called in previous state (-4) and build nr, checked by this function, is only update in state -4