### PR TITLE
Improve Due SW SPI, Fysetc sanity checks, &c.

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/u8g_com_HAL_AVR_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_AVR/u8g_com_HAL_AVR_sw_spi.cpp
@@ -124,9 +124,9 @@ void U8G_spiSend_sw_AVR_mode_3(uint8_t val) {
 
 
 #if ENABLED(FYSETC_MINI_12864)
-  #define U8G_spiSend_sw_AVR U8G_spiSend_sw_AVR_mode_3
+  #define SPISEND_SW_AVR u8g_spiSend_sw_AVR_mode_3
 #else
-  #define U8G_spiSend_sw_AVR U8G_spiSend_sw_AVR_mode_0
+  #define SPISEND_SW_AVR u8g_spiSend_sw_AVR_mode_0
 #endif
 
 uint8_t u8g_com_HAL_AVR_sw_sp_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
@@ -162,13 +162,13 @@ uint8_t u8g_com_HAL_AVR_sw_sp_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
       break;
 
     case U8G_COM_MSG_WRITE_BYTE:
-      U8G_spiSend_sw_AVR(arg_val);
+      SPISEND_SW_AVR(arg_val);
       break;
 
     case U8G_COM_MSG_WRITE_SEQ: {
         uint8_t *ptr = (uint8_t *)arg_ptr;
         while (arg_val > 0) {
-          U8G_spiSend_sw_AVR(*ptr++);
+          SPISEND_SW_AVR(*ptr++);
           arg_val--;
         }
       }
@@ -177,7 +177,7 @@ uint8_t u8g_com_HAL_AVR_sw_sp_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void 
       case U8G_COM_MSG_WRITE_SEQ_P: {
         uint8_t *ptr = (uint8_t *)arg_ptr;
         while (arg_val > 0) {
-          U8G_spiSend_sw_AVR(u8g_pgm_read(ptr));
+          SPISEND_SW_AVR(u8g_pgm_read(ptr));
           ptr++;
           arg_val--;
         }

--- a/Marlin/src/HAL/HAL_AVR/u8g_com_HAL_AVR_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_AVR/u8g_com_HAL_AVR_sw_spi.cpp
@@ -64,10 +64,8 @@
 
 #include <U8glib.h>
 
-uint8_t u8g_bitData, u8g_bitNotData;
-uint8_t u8g_bitClock, u8g_bitNotClock;
-volatile uint8_t *u8g_outData;
-volatile uint8_t *u8g_outClock;
+uint8_t u8g_bitData, u8g_bitNotData, u8g_bitClock, u8g_bitNotClock;
+volatile uint8_t *u8g_outData, *u8g_outClock;
 
 static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin) {
   u8g_outData = portOutputRegister(digitalPinToPort(dataPin));
@@ -82,13 +80,13 @@ static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin) {
   u8g_bitNotData ^= 0xFF;
 }
 
-void U8G_spiSend_sw_AVR_mode_0(uint8_t val) {
-  uint8_t bitData = u8g_bitData;
-  uint8_t bitNotData = u8g_bitNotData;
-  uint8_t bitClock = u8g_bitClock;
-  uint8_t bitNotClock = u8g_bitNotClock;
-  volatile uint8_t *outData = u8g_outData;
-  volatile uint8_t *outClock = u8g_outClock;
+void u8g_spiSend_sw_AVR_mode_0(uint8_t val) {
+  uint8_t bitData = u8g_bitData,
+          bitNotData = u8g_bitNotData,
+          bitClock = u8g_bitClock,
+          bitNotClock = u8g_bitNotClock;
+  volatile uint8_t *outData = u8g_outData,
+                   *outClock = u8g_outClock;
   U8G_ATOMIC_START();
   for (uint8_t i = 0; i < 8; i++) {
     if (val & 0x80)
@@ -102,13 +100,13 @@ void U8G_spiSend_sw_AVR_mode_0(uint8_t val) {
   U8G_ATOMIC_END();
 }
 
-void U8G_spiSend_sw_AVR_mode_3(uint8_t val) {
-  uint8_t bitData = u8g_bitData;
-  uint8_t bitNotData = u8g_bitNotData;
-  uint8_t bitClock = u8g_bitClock;
-  uint8_t bitNotClock = u8g_bitNotClock;
-  volatile uint8_t *outData = u8g_outData;
-  volatile uint8_t *outClock = u8g_outClock;
+void u8g_spiSend_sw_AVR_mode_3(uint8_t val) {
+  uint8_t bitData = u8g_bitData,
+          bitNotData = u8g_bitNotData,
+          bitClock = u8g_bitClock,
+          bitNotClock = u8g_bitNotClock;
+  volatile uint8_t *outData = u8g_outData,
+                   *outClock = u8g_outClock;
   U8G_ATOMIC_START();
   for (uint8_t i = 0; i < 8; i++) {
     *outClock &= bitNotClock;

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -59,40 +59,24 @@
 
 #if HAS_GRAPHICAL_LCD
 
-#include "../shared/Marduino.h"
+#include "u8g_com_HAL_DUE_sw_spi_shared.h"
+
 #include "../shared/Delay.h"
 
 #include <U8glib.h>
 
-#include "u8g_com_HAL_DUE_sw_spi_shared.h"
-
-Pio *SCK_pPio, *MOSI_pPio;
-uint32_t SCK_dwMask, MOSI_dwMask;
-
-static void spiSend_sw_DUE(uint8_t val) { // 800KHz
-  for (uint8_t i = 0; i < 8; i++) {
-    if (val & 0x80)
-      MOSI_pPio->PIO_SODR = MOSI_dwMask;
-    else
-      MOSI_pPio->PIO_CODR = MOSI_dwMask;
-    DELAY_NS(48);
-    SCK_pPio->PIO_SODR = SCK_dwMask;
-    DELAY_NS(905); // 762 dead, 810 garbage, 858/0 900kHz, 905/1 825k, 953/1 800k, 1000/2 725KHz
-    val <<= 1;
-    SCK_pPio->PIO_CODR = SCK_dwMask;
-  }
-}
+#define SPISEND_SW_DUE U8G_spiSend_sw_DUE_mode_0
 
 static uint8_t rs_last_state = 255;
 
 static void u8g_com_DUE_st7920_write_byte_sw_spi(uint8_t rs, uint8_t val) {
   if (rs != rs_last_state) {  // time to send a command/data byte
     rs_last_state = rs;
-    spiSend_sw_DUE(rs ? 0x0FA : 0x0F8); // Command or Data
+    SPISEND_SW_DUE(rs ? 0x0FA : 0x0F8); // Command or Data
     DELAY_US(40); // give the controller some time to process the data: 20 is bad, 30 is OK, 40 is safe
   }
-  spiSend_sw_DUE(val & 0xF0);
-  spiSend_sw_DUE(val << 4);
+  SPISEND_SW_DUE(val & 0xF0);
+  SPISEND_SW_DUE(val << 4);
 }
 
 uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
@@ -182,18 +166,18 @@ uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
   }
 
   void ST7920_set_cmd() {
-    spiSend_sw_DUE(0xF8);
+    SPISEND_SW_DUE(0xF8);
     DELAY_US(40);
   }
 
   void ST7920_set_dat() {
-    spiSend_sw_DUE(0xFA);
+    SPISEND_SW_DUE(0xFA);
     DELAY_US(40);
   }
 
   void ST7920_write_byte(const uint8_t val) {
-    spiSend_sw_DUE(val & 0xF0);
-    spiSend_sw_DUE(val << 4);
+    SPISEND_SW_DUE(val & 0xF0);
+    SPISEND_SW_DUE(val << 4);
   }
 #endif // LIGHTWEIGHT_UI
 

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -65,7 +65,7 @@
 
 #include <U8glib.h>
 
-#define SPISEND_SW_DUE U8G_spiSend_sw_DUE_mode_0
+#define SPISEND_SW_DUE u8g_spiSend_sw_DUE_mode_0
 
 static uint8_t rs_last_state = 255;
 

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -57,7 +57,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if HAS_GRAPHICAL_LCD
+#if ENABLED(U8GLIB_ST7920)
 
 #include "u8g_com_HAL_DUE_sw_spi_shared.h"
 
@@ -181,5 +181,5 @@ uint8_t u8g_com_HAL_DUE_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_va
   }
 #endif // LIGHTWEIGHT_UI
 
-#endif // HAS_GRAPHICAL_LCD
+#endif // U8GLIB_ST7920
 #endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi.cpp
@@ -62,23 +62,17 @@
 #undef SPI_SPEED
 #define SPI_SPEED 2  // About 2 MHz
 
+#include "u8g_com_HAL_DUE_sw_spi_shared.h"
+
 #include "../shared/Marduino.h"
 #include "../shared/Delay.h"
 
 #include <U8glib.h>
 
-void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index);
-void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level);
-void U8G_spiSend_sw_DUE_mode_0(uint8_t val);
-void U8G_spiSend_sw_DUE_mode_3(uint8_t val);
-
-Pio *SCK_pPio, *MOSI_pPio;
-uint32_t SCK_dwMask, MOSI_dwMask;
-
 #if ENABLED(FYSETC_MINI_12864)
-  #define U8G_spiSend_sw_DUE U8G_spiSend_sw_DUE_mode_3
+  #define SPISEND_SW_DUE U8G_spiSend_sw_DUE_mode_3
 #else
-  #define U8G_spiSend_sw_DUE U8G_spiSend_sw_DUE_mode_0
+  #define SPISEND_SW_DUE U8G_spiSend_sw_DUE_mode_0
 #endif
 
 uint8_t u8g_com_HAL_DUE_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {
@@ -121,13 +115,13 @@ uint8_t u8g_com_HAL_DUE_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void
       break;
 
     case U8G_COM_MSG_WRITE_BYTE:
-      U8G_spiSend_sw_DUE(arg_val);
+      SPISEND_SW_DUE(arg_val);
       break;
 
     case U8G_COM_MSG_WRITE_SEQ: {
         uint8_t *ptr = (uint8_t *)arg_ptr;
         while (arg_val > 0) {
-          U8G_spiSend_sw_DUE(*ptr++);
+          SPISEND_SW_DUE(*ptr++);
           arg_val--;
         }
       }
@@ -136,7 +130,7 @@ uint8_t u8g_com_HAL_DUE_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void
       case U8G_COM_MSG_WRITE_SEQ_P: {
         uint8_t *ptr = (uint8_t *)arg_ptr;
         while (arg_val > 0) {
-          U8G_spiSend_sw_DUE(u8g_pgm_read(ptr));
+          SPISEND_SW_DUE(u8g_pgm_read(ptr));
           ptr++;
           arg_val--;
         }

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi.cpp
@@ -70,9 +70,9 @@
 #include <U8glib.h>
 
 #if ENABLED(FYSETC_MINI_12864)
-  #define SPISEND_SW_DUE U8G_spiSend_sw_DUE_mode_3
+  #define SPISEND_SW_DUE u8g_spiSend_sw_DUE_mode_3
 #else
-  #define SPISEND_SW_DUE U8G_spiSend_sw_DUE_mode_0
+  #define SPISEND_SW_DUE u8g_spiSend_sw_DUE_mode_0
 #endif
 
 uint8_t u8g_com_HAL_DUE_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr) {

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -79,7 +79,7 @@ void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level) {
 Pio *SCK_pPio, *MOSI_pPio;
 uint32_t SCK_dwMask, MOSI_dwMask;
 
-void U8G_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
+void u8g_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
   for (uint8_t i = 0; i < 8; i++) {
     if (val & 0x80)
       MOSI_pPio->PIO_SODR = MOSI_dwMask;
@@ -93,7 +93,7 @@ void U8G_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
   }
 }
 
-void U8G_spiSend_sw_DUE_mode_3(uint8_t val) { // 3.5MHz
+void u8g_spiSend_sw_DUE_mode_3(uint8_t val) { // 3.5MHz
   for (uint8_t i = 0; i < 8; i++) {
     SCK_pPio->PIO_CODR = SCK_dwMask;
     DELAY_NS(50);

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -80,7 +80,7 @@ void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level) {
 extern Pio *SCK_pPio, *MOSI_pPio;
 extern uint32_t SCK_dwMask, MOSI_dwMask;
 
-void U8G_spiSend_sw_DUE_mode_0(uint8_t val) { // 800KHz
+void U8G_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
   for (uint8_t i = 0; i < 8; i++) {
     if (val & 0x80)
       MOSI_pPio->PIO_SODR = MOSI_dwMask;
@@ -88,23 +88,24 @@ void U8G_spiSend_sw_DUE_mode_0(uint8_t val) { // 800KHz
       MOSI_pPio->PIO_CODR = MOSI_dwMask;
     DELAY_NS(48);
     SCK_pPio->PIO_SODR = SCK_dwMask;
-    DELAY_NS(905); // 762 dead, 810 garbage, 858/0 900kHz, 905/1 825k, 953/1 800k, 1000/2 725KHz
+    DELAY_NS(125);
     val <<= 1;
     SCK_pPio->PIO_CODR = SCK_dwMask;
   }
 }
 
-void U8G_spiSend_sw_DUE_mode_3(uint8_t val) { // 800KHz
+void U8G_spiSend_sw_DUE_mode_3(uint8_t val) { // 3.5MHz
   for (uint8_t i = 0; i < 8; i++) {
     SCK_pPio->PIO_CODR = SCK_dwMask;
-    DELAY_NS(48);
+    DELAY_NS(50);
     if (val & 0x80)
       MOSI_pPio->PIO_SODR = MOSI_dwMask;
     else
       MOSI_pPio->PIO_CODR = MOSI_dwMask;
-    SCK_pPio->PIO_SODR = SCK_dwMask;
-    DELAY_NS(905); // 762 dead, 810 garbage, 858/0 900kHz, 905/1 825k, 953/1 800k, 1000/2 725KHz
     val <<= 1;
+    DELAY_NS(10);
+    SCK_pPio->PIO_SODR = SCK_dwMask;
+    DELAY_NS(70);
   }
 }
 

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -59,12 +59,11 @@
 
 #if HAS_GRAPHICAL_LCD
 
-#include "../shared/Marduino.h"
+#include "u8g_com_HAL_DUE_sw_spi_shared.h"
+
 #include "../shared/Delay.h"
 
 #include <U8glib.h>
-
-#include "u8g_com_HAL_DUE_sw_spi_shared.h"
 
 void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index) {
   PIO_Configure(g_APinDescription[u8g->pin_list[pin_index]].pPort, PIO_OUTPUT_1,
@@ -77,8 +76,8 @@ void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level) {
   if (level) port->PIO_SODR = mask; else port->PIO_CODR = mask;
 }
 
-extern Pio *SCK_pPio, *MOSI_pPio;
-extern uint32_t SCK_dwMask, MOSI_dwMask;
+Pio *SCK_pPio, *MOSI_pPio;
+uint32_t SCK_dwMask, MOSI_dwMask;
 
 void U8G_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
   for (uint8_t i = 0; i < 8; i++) {

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.h
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.h
@@ -27,8 +27,8 @@
 void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index);
 void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level);
 
-void U8G_spiSend_sw_DUE_mode_0(uint8_t val);
-void U8G_spiSend_sw_DUE_mode_3(uint8_t val);
+void u8g_spiSend_sw_DUE_mode_0(uint8_t val);
+void u8g_spiSend_sw_DUE_mode_3(uint8_t val);
 
 extern Pio *SCK_pPio, *MOSI_pPio;
 extern uint32_t SCK_dwMask, MOSI_dwMask;

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.h
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.h
@@ -21,5 +21,14 @@
  */
 #pragma once
 
+#include "../../inc/MarlinConfigPre.h"
+#include "../shared/Marduino.h"
+
 void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index);
 void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level);
+
+void U8G_spiSend_sw_DUE_mode_0(uint8_t val);
+void U8G_spiSend_sw_DUE_mode_3(uint8_t val);
+
+extern Pio *SCK_pPio, *MOSI_pPio;
+extern uint32_t SCK_dwMask, MOSI_dwMask;

--- a/Marlin/src/HAL/HAL_LPC1768/u8g/u8g_com_HAL_LPC1768_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g/u8g_com_HAL_LPC1768_st7920_sw_spi.cpp
@@ -57,7 +57,7 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
-#if HAS_GRAPHICAL_LCD
+#if ENABLED(U8GLIB_ST7920)
 
 #include <U8glib.h>
 #include "SoftwareSPI.h"
@@ -141,6 +141,5 @@ uint8_t u8g_com_HAL_LPC1768_ST7920_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t ar
   return 1;
 }
 
-#endif // HAS_GRAPHICAL_LCD
-
+#endif // U8GLIB_ST7920
 #endif // TARGET_LPC1768

--- a/Marlin/src/HAL/HAL_LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g/u8g_com_HAL_LPC1768_sw_spi.cpp
@@ -57,7 +57,7 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
-#if HAS_GRAPHICAL_LCD
+#if HAS_GRAPHICAL_LCD && DISABLED(U8GLIB_ST7920)
 
 #include "SoftwareSPI.h"
 
@@ -203,5 +203,5 @@ uint8_t u8g_com_HAL_LPC1768_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
   return 1;
 }
 
-#endif // HAS_GRAPHICAL_LCD
+#endif // HAS_GRAPHICAL_LCD && !U8GLIB_ST7920
 #endif // TARGET_LPC1768

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -156,9 +156,14 @@
     #define RGB_LED
   #elif ENABLED(FYSETC_MINI_12864_2_1)
     #define NEOPIXEL_LED
-    #define NEOPIXEL_TYPE       NEO_GRB
+    #undef NEOPIXEL_TYPE
+    #define NEOPIXEL_TYPE       NEO_RGB
+    #undef NEOPIXEL_PIXELS
     #define NEOPIXEL_PIXELS     3
-    #define NEOPIXEL_BRIGHTNESS 127
+    #ifndef NEOPIXEL_BRIGHTNESS
+      #define NEOPIXEL_BRIGHTNESS 127
+    #endif
+    #define NEOPIXEL_STARTUP_TEST
   #endif
 
 #endif

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -79,3 +79,30 @@
     #endif
   #endif
 #endif
+
+#if ENABLED(FYSETC_MINI_12864_2_1)
+  #ifndef LED_CONTROL_MENU
+    #define LED_CONTROL_MENU
+  #endif
+  #ifndef LED_USER_PRESET_STARTUP
+    #define LED_USER_PRESET_STARTUP
+  #endif
+  #ifndef LED_COLOR_PRESETS
+    #define LED_COLOR_PRESETS
+  #endif
+  #ifndef LED_USER_PRESET_RED
+    #define LED_USER_PRESET_RED        255
+  #endif
+  #ifndef LED_USER_PRESET_GREEN
+    #define LED_USER_PRESET_GREEN      128
+  #endif
+  #ifndef LED_USER_PRESET_BLUE
+    #define LED_USER_PRESET_BLUE         0
+  #endif
+  #ifndef LED_USER_PRESET_BRIGHTNESS
+    #define LED_USER_PRESET_BRIGHTNESS 255
+  #endif
+  #ifndef LED_USER_PRESET_STARTUP
+    #define LED_USER_PRESET_STARTUP
+  #endif
+#endif

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -81,15 +81,9 @@
 #endif
 
 #if ENABLED(FYSETC_MINI_12864_2_1)
-  #ifndef LED_CONTROL_MENU
-    #define LED_CONTROL_MENU
-  #endif
-  #ifndef LED_USER_PRESET_STARTUP
-    #define LED_USER_PRESET_STARTUP
-  #endif
-  #ifndef LED_COLOR_PRESETS
-    #define LED_COLOR_PRESETS
-  #endif
+  #define LED_CONTROL_MENU
+  #define LED_USER_PRESET_STARTUP
+  #define LED_COLOR_PRESETS
   #ifndef LED_USER_PRESET_RED
     #define LED_USER_PRESET_RED        255
   #endif
@@ -101,8 +95,5 @@
   #endif
   #ifndef LED_USER_PRESET_BRIGHTNESS
     #define LED_USER_PRESET_BRIGHTNESS 255
-  #endif
-  #ifndef LED_USER_PRESET_STARTUP
-    #define LED_USER_PRESET_STARTUP
   #endif
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1830,26 +1830,6 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #error "RGB_LED is required for FYSETC_MINI_12864 1.2 and 2.0."
 #elif EITHER(FYSETC_MINI_12864_2_0, FYSETC_MINI_12864_2_1) && DISABLED(LED_USER_PRESET_STARTUP)
   #error "LED_USER_PRESET_STARTUP is required for FYSETC_MINI_12864 2.x displays."
-#elif ENABLED(FYSETC_MINI_12864_2_1)
-  #if DISABLED(NEOPIXEL_LED)
-    #error "NEOPIXEL_LED is required for FYSETC_MINI_12864 Rev. 2.1."
-  #elif NEOPIXEL_PIXELS != 3
-    #error "NEOPIXEL_PIXELS should be 3 for FYSETC_MINI_12864 Rev. 2.1."
-  #elif NEOPIXEL_BRIGHTNESS != 127
-    #error "NEOPIXEL_BRIGHTNESS should be 127 for FYSETC_MINI_12864 Rev. 2.1."
-  #else
-    #ifndef NEO_GRB
-      #define NEO_GRB 0xFAD
-      #define _UNDO_NEO_GRB
-    #endif
-    #if NEOPIXEL_TYPE != NEO_GRB
-      #error "NEOPIXEL_TYPE should be NEO_GRB for FYSETC_MINI_12864 Rev. 2.1."
-    #endif
-    #ifdef _UNDO_NEO_GRB
-      #undef NEO_GRB
-      #undef _UNDO_NEO_GRB
-    #endif
-  #endif
 #endif
 
 /**


### PR DESCRIPTION
PR #13900 contained two bug:
- u8g_com_HAL_DUE_sw_spi_shared.cpp had extra code in it that resulted in "multiple definitions" compiler errors
- The the new DUE and LPC1768 SW SPI routines were not mutually exclusive with the U8G ST7920 SW spi routines which resulted in "multiple definitions" compiler errors

This PR fixes those two bugs.

NOTE: The DUE version of the U8G ST7920 SW spi routine already had the needed logic so it isn't on the PR