### PR TITLE
Use C++ 'nullptr' in place of 'NULL'

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/endstop_interrupts.h
+++ b/Marlin/src/HAL/HAL_AVR/endstop_interrupts.h
@@ -54,7 +54,7 @@ void endstop_ISR(void) { endstops.update(); }
   #undef  digitalPinToPCICR
   #define digitalPinToPCICR(p)    ( WITHIN(p, 10, 15) || \
                                     WITHIN(p, 50, 53) || \
-                                    WITHIN(p, 62, 69) ? &PCICR : (uint8_t*)0 )
+                                    WITHIN(p, 62, 69) ? &PCICR : nullptr )
   #undef  digitalPinToPCICRbit
   #define digitalPinToPCICRbit(p) ( WITHIN(p, 10, 13) || WITHIN(p, 50, 53) ? 0 : \
                                     WITHIN(p, 14, 15) ? 1 : \
@@ -64,7 +64,7 @@ void endstop_ISR(void) { endstops.update(); }
   #define digitalPinToPCMSK(p)    ( WITHIN(p, 10, 13) || WITHIN(p, 50, 53) ? &PCMSK0 : \
                                     WITHIN(p, 14, 15) ? &PCMSK1 : \
                                     WITHIN(p, 62, 69) ? &PCMSK2 : \
-                                    (uint8_t *)0 )
+                                    nullptr )
   #undef  digitalPinToPCMSKbit
   #define digitalPinToPCMSKbit(p) ( WITHIN(p, 10, 13) ? ((p) - 6) : \
                                     (p) == 14 || (p) == 51 ? 2 : \
@@ -78,9 +78,11 @@ void endstop_ISR(void) { endstops.update(); }
 
 // Install Pin change interrupt for a pin. Can be called multiple times.
 void pciSetup(const int8_t pin) {
-  SBI(*digitalPinToPCMSK(pin), digitalPinToPCMSKbit(pin));  // enable pin
-  SBI(PCIFR, digitalPinToPCICRbit(pin)); // clear any outstanding interrupt
-  SBI(PCICR, digitalPinToPCICRbit(pin)); // enable interrupt for the group
+  if (digitalPinToPCMSK(pin) != nullptr) {
+    SBI(*digitalPinToPCMSK(pin), digitalPinToPCMSKbit(pin));  // enable pin
+    SBI(PCIFR, digitalPinToPCICRbit(pin)); // clear any outstanding interrupt
+    SBI(PCICR, digitalPinToPCICRbit(pin)); // enable interrupt for the group
+  }
 }
 
 // Handlers for pin change interrupts
@@ -107,7 +109,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(X_MAX_PIN), endstop_ISR, CHANGE); // assign it
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(X_MAX_PIN) != NULL, "X_MAX_PIN is not interrupt-capable"); // if pin has no pin change interrupt - error
+      static_assert(digitalPinToPCICR(X_MAX_PIN), "X_MAX_PIN is not interrupt-capable"); // if pin has no pin change interrupt - error
       pciSetup(X_MAX_PIN);                                                            // assign it
     #endif
   #endif
@@ -117,7 +119,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(X_MIN_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(X_MIN_PIN) != NULL, "X_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(X_MIN_PIN), "X_MIN_PIN is not interrupt-capable");
       pciSetup(X_MIN_PIN);
     #endif
   #endif
@@ -127,7 +129,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Y_MAX_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Y_MAX_PIN) != NULL, "Y_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Y_MAX_PIN), "Y_MAX_PIN is not interrupt-capable");
       pciSetup(Y_MAX_PIN);
     #endif
   #endif
@@ -137,7 +139,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Y_MIN_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Y_MIN_PIN) != NULL, "Y_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Y_MIN_PIN), "Y_MIN_PIN is not interrupt-capable");
       pciSetup(Y_MIN_PIN);
     #endif
   #endif
@@ -147,7 +149,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Z_MAX_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Z_MAX_PIN) != NULL, "Z_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Z_MAX_PIN), "Z_MAX_PIN is not interrupt-capable");
       pciSetup(Z_MAX_PIN);
     #endif
   #endif
@@ -157,7 +159,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Z_MIN_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Z_MIN_PIN) != NULL, "Z_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Z_MIN_PIN), "Z_MIN_PIN is not interrupt-capable");
       pciSetup(Z_MIN_PIN);
     #endif
   #endif
@@ -167,7 +169,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(X2_MAX_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(X2_MAX_PIN) != NULL, "X2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(X2_MAX_PIN), "X2_MAX_PIN is not interrupt-capable");
       pciSetup(X2_MAX_PIN);
     #endif
   #endif
@@ -177,7 +179,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(X2_MIN_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(X2_MIN_PIN) != NULL, "X2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(X2_MIN_PIN), "X2_MIN_PIN is not interrupt-capable");
       pciSetup(X2_MIN_PIN);
     #endif
   #endif
@@ -187,7 +189,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Y2_MAX_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Y2_MAX_PIN) != NULL, "Y2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Y2_MAX_PIN), "Y2_MAX_PIN is not interrupt-capable");
       pciSetup(Y2_MAX_PIN);
     #endif
   #endif
@@ -197,7 +199,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Y2_MIN_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Y2_MIN_PIN) != NULL, "Y2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Y2_MIN_PIN), "Y2_MIN_PIN is not interrupt-capable");
       pciSetup(Y2_MIN_PIN);
     #endif
   #endif
@@ -207,7 +209,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Z2_MAX_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Z2_MAX_PIN) != NULL, "Z2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Z2_MAX_PIN), "Z2_MAX_PIN is not interrupt-capable");
       pciSetup(Z2_MAX_PIN);
     #endif
   #endif
@@ -217,7 +219,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Z2_MIN_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Z2_MIN_PIN) != NULL, "Z2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Z2_MIN_PIN), "Z2_MIN_PIN is not interrupt-capable");
       pciSetup(Z2_MIN_PIN);
     #endif
   #endif
@@ -227,7 +229,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Z3_MAX_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Z3_MAX_PIN) != NULL, "Z3_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Z3_MAX_PIN), "Z3_MAX_PIN is not interrupt-capable");
       pciSetup(Z3_MAX_PIN);
     #endif
   #endif
@@ -237,7 +239,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Z3_MIN_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Z3_MIN_PIN) != NULL, "Z3_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Z3_MIN_PIN), "Z3_MIN_PIN is not interrupt-capable");
       pciSetup(Z3_MIN_PIN);
     #endif
   #endif
@@ -247,7 +249,7 @@ void setup_endstop_interrupts( void ) {
       attachInterrupt(digitalPinToInterrupt(Z_MIN_PROBE_PIN), endstop_ISR, CHANGE);
     #else
       // Not all used endstop/probe -pins can raise interrupts. Please deactivate ENDSTOP_INTERRUPTS or change the pin configuration!
-      static_assert(digitalPinToPCICR(Z_MIN_PROBE_PIN) != NULL, "Z_MIN_PROBE_PIN is not interrupt-capable");
+      static_assert(digitalPinToPCICR(Z_MIN_PROBE_PIN), "Z_MIN_PROBE_PIN is not interrupt-capable");
       pciSetup(Z_MIN_PROBE_PIN);
     #endif
   #endif

--- a/Marlin/src/HAL/HAL_AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/HAL_AVR/fast_pwm.cpp
@@ -38,9 +38,9 @@
         #ifdef TCCR2
           case TIMER2: {
             Timer timer = {
-              /*TCCRnQ*/  { &TCCR2, NULL, NULL},
-              /*OCRnQ*/   { (uint16_t*)&OCR2, NULL, NULL},
-              /*ICRn*/      NULL,
+              /*TCCRnQ*/  { &TCCR2, nullptr, nullptr},
+              /*OCRnQ*/   { (uint16_t*)&OCR2, nullptr, nullptr},
+              /*ICRn*/      nullptr,
               /*n, q*/      2, 0
             };
           }
@@ -49,9 +49,9 @@
             case TIMER2A:   break; // protect TIMER2A
             case TIMER2B: {
               Timer timer = {
-                /*TCCRnQ*/  { &TCCR2A,  &TCCR2B,  NULL},
-                /*OCRnQ*/   { (uint16_t*)&OCR2A, (uint16_t*)&OCR2B, NULL},
-                /*ICRn*/      NULL,
+                /*TCCRnQ*/  { &TCCR2A,  &TCCR2B,  nullptr},
+                /*OCRnQ*/   { (uint16_t*)&OCR2A, (uint16_t*)&OCR2B, nullptr},
+                /*ICRn*/      nullptr,
                 /*n, q*/      2, 1
               };
               return timer;
@@ -60,9 +60,9 @@
             case TIMER2B:   ++q;
             case TIMER2A: {
               Timer timer = {
-                /*TCCRnQ*/  { &TCCR2A,  &TCCR2B,  NULL},
-                /*OCRnQ*/   { (uint16_t*)&OCR2A, (uint16_t*)&OCR2B, NULL},
-                /*ICRn*/      NULL,
+                /*TCCRnQ*/  { &TCCR2A,  &TCCR2B,  nullptr},
+                /*OCRnQ*/   { (uint16_t*)&OCR2A, (uint16_t*)&OCR2B, nullptr},
+                /*ICRn*/      nullptr,
                               2, q
               };
               return timer;
@@ -111,9 +111,9 @@
       #endif
     }
     Timer timer = {
-        /*TCCRnQ*/  { NULL, NULL, NULL},
-        /*OCRnQ*/   { NULL, NULL, NULL},
-        /*ICRn*/      NULL,
+        /*TCCRnQ*/  { nullptr, nullptr, nullptr},
+        /*OCRnQ*/   { nullptr, nullptr, nullptr},
+        /*ICRn*/      nullptr,
                       0, 0
     };
     return timer;

--- a/Marlin/src/HAL/HAL_AVR/fastio_1280.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_1280.h
@@ -71,13 +71,13 @@
 #define DIO0_RPORT  PINE
 #define DIO0_WPORT  PORTE
 #define DIO0_DDR    DDRE
-#define DIO0_PWM    NULL
+#define DIO0_PWM    nullptr
 
 #define DIO1_PIN    PINE1
 #define DIO1_RPORT  PINE
 #define DIO1_WPORT  PORTE
 #define DIO1_DDR    DDRE
-#define DIO1_PWM    NULL
+#define DIO1_PWM    nullptr
 
 #define DIO2_PIN    PINE4
 #define DIO2_RPORT  PINE
@@ -137,13 +137,13 @@
 #define DIO11_RPORT PINB
 #define DIO11_WPORT PORTB
 #define DIO11_DDR   DDRB
-#define DIO11_PWM   NULL
+#define DIO11_PWM   nullptr
 
 #define DIO12_PIN   PINB6
 #define DIO12_RPORT PINB
 #define DIO12_WPORT PORTB
 #define DIO12_DDR   DDRB
-#define DIO12_PWM   NULL
+#define DIO12_PWM   nullptr
 
 #define DIO13_PIN   PINB7
 #define DIO13_RPORT PINB
@@ -155,181 +155,181 @@
 #define DIO14_RPORT PINJ
 #define DIO14_WPORT PORTJ
 #define DIO14_DDR   DDRJ
-#define DIO14_PWM   NULL
+#define DIO14_PWM   nullptr
 
 #define DIO15_PIN   PINJ0
 #define DIO15_RPORT PINJ
 #define DIO15_WPORT PORTJ
 #define DIO15_DDR   DDRJ
-#define DIO15_PWM   NULL
+#define DIO15_PWM   nullptr
 
 #define DIO16_PIN   PINH1
 #define DIO16_RPORT PINH
 #define DIO16_WPORT PORTH
 #define DIO16_DDR   DDRH
-#define DIO16_PWM   NULL
+#define DIO16_PWM   nullptr
 
 #define DIO17_PIN   PINH0
 #define DIO17_RPORT PINH
 #define DIO17_WPORT PORTH
 #define DIO17_DDR   DDRH
-#define DIO17_PWM   NULL
+#define DIO17_PWM   nullptr
 
 #define DIO18_PIN   PIND3
 #define DIO18_RPORT PIND
 #define DIO18_WPORT PORTD
 #define DIO18_DDR   DDRD
-#define DIO18_PWM   NULL
+#define DIO18_PWM   nullptr
 
 #define DIO19_PIN   PIND2
 #define DIO19_RPORT PIND
 #define DIO19_WPORT PORTD
 #define DIO19_DDR   DDRD
-#define DIO19_PWM   NULL
+#define DIO19_PWM   nullptr
 
 #define DIO20_PIN   PIND1
 #define DIO20_RPORT PIND
 #define DIO20_WPORT PORTD
 #define DIO20_DDR   DDRD
-#define DIO20_PWM   NULL
+#define DIO20_PWM   nullptr
 
 #define DIO21_PIN   PIND0
 #define DIO21_RPORT PIND
 #define DIO21_WPORT PORTD
 #define DIO21_DDR   DDRD
-#define DIO21_PWM   NULL
+#define DIO21_PWM   nullptr
 
 #define DIO22_PIN   PINA0
 #define DIO22_RPORT PINA
 #define DIO22_WPORT PORTA
 #define DIO22_DDR   DDRA
-#define DIO22_PWM   NULL
+#define DIO22_PWM   nullptr
 
 #define DIO23_PIN   PINA1
 #define DIO23_RPORT PINA
 #define DIO23_WPORT PORTA
 #define DIO23_DDR   DDRA
-#define DIO23_PWM   NULL
+#define DIO23_PWM   nullptr
 
 #define DIO24_PIN   PINA2
 #define DIO24_RPORT PINA
 #define DIO24_WPORT PORTA
 #define DIO24_DDR   DDRA
-#define DIO24_PWM   NULL
+#define DIO24_PWM   nullptr
 
 #define DIO25_PIN   PINA3
 #define DIO25_RPORT PINA
 #define DIO25_WPORT PORTA
 #define DIO25_DDR   DDRA
-#define DIO25_PWM   NULL
+#define DIO25_PWM   nullptr
 
 #define DIO26_PIN   PINA4
 #define DIO26_RPORT PINA
 #define DIO26_WPORT PORTA
 #define DIO26_DDR   DDRA
-#define DIO26_PWM   NULL
+#define DIO26_PWM   nullptr
 
 #define DIO27_PIN   PINA5
 #define DIO27_RPORT PINA
 #define DIO27_WPORT PORTA
 #define DIO27_DDR   DDRA
-#define DIO27_PWM   NULL
+#define DIO27_PWM   nullptr
 
 #define DIO28_PIN   PINA6
 #define DIO28_RPORT PINA
 #define DIO28_WPORT PORTA
 #define DIO28_DDR   DDRA
-#define DIO28_PWM   NULL
+#define DIO28_PWM   nullptr
 
 #define DIO29_PIN   PINA7
 #define DIO29_RPORT PINA
 #define DIO29_WPORT PORTA
 #define DIO29_DDR   DDRA
-#define DIO29_PWM   NULL
+#define DIO29_PWM   nullptr
 
 #define DIO30_PIN   PINC7
 #define DIO30_RPORT PINC
 #define DIO30_WPORT PORTC
 #define DIO30_DDR   DDRC
-#define DIO30_PWM   NULL
+#define DIO30_PWM   nullptr
 
 #define DIO31_PIN   PINC6
 #define DIO31_RPORT PINC
 #define DIO31_WPORT PORTC
 #define DIO31_DDR   DDRC
-#define DIO31_PWM   NULL
+#define DIO31_PWM   nullptr
 
 #define DIO32_PIN   PINC5
 #define DIO32_RPORT PINC
 #define DIO32_WPORT PORTC
 #define DIO32_DDR   DDRC
-#define DIO32_PWM   NULL
+#define DIO32_PWM   nullptr
 
 #define DIO33_PIN   PINC4
 #define DIO33_RPORT PINC
 #define DIO33_WPORT PORTC
 #define DIO33_DDR   DDRC
-#define DIO33_PWM   NULL
+#define DIO33_PWM   nullptr
 
 #define DIO34_PIN   PINC3
 #define DIO34_RPORT PINC
 #define DIO34_WPORT PORTC
 #define DIO34_DDR   DDRC
-#define DIO34_PWM   NULL
+#define DIO34_PWM   nullptr
 
 #define DIO35_PIN   PINC2
 #define DIO35_RPORT PINC
 #define DIO35_WPORT PORTC
 #define DIO35_DDR   DDRC
-#define DIO35_PWM   NULL
+#define DIO35_PWM   nullptr
 
 #define DIO36_PIN   PINC1
 #define DIO36_RPORT PINC
 #define DIO36_WPORT PORTC
 #define DIO36_DDR   DDRC
-#define DIO36_PWM   NULL
+#define DIO36_PWM   nullptr
 
 #define DIO37_PIN   PINC0
 #define DIO37_RPORT PINC
 #define DIO37_WPORT PORTC
 #define DIO37_DDR   DDRC
-#define DIO37_PWM   NULL
+#define DIO37_PWM   nullptr
 
 #define DIO38_PIN   PIND7
 #define DIO38_RPORT PIND
 #define DIO38_WPORT PORTD
 #define DIO38_DDR   DDRD
-#define DIO38_PWM   NULL
+#define DIO38_PWM   nullptr
 
 #define DIO39_PIN   PING2
 #define DIO39_RPORT PING
 #define DIO39_WPORT PORTG
 #define DIO39_DDR   DDRG
-#define DIO39_PWM   NULL
+#define DIO39_PWM   nullptr
 
 #define DIO40_PIN   PING1
 #define DIO40_RPORT PING
 #define DIO40_WPORT PORTG
 #define DIO40_DDR   DDRG
-#define DIO40_PWM   NULL
+#define DIO40_PWM   nullptr
 
 #define DIO41_PIN   PING0
 #define DIO41_RPORT PING
 #define DIO41_WPORT PORTG
 #define DIO41_DDR   DDRG
-#define DIO41_PWM   NULL
+#define DIO41_PWM   nullptr
 
 #define DIO42_PIN   PINL7
 #define DIO42_RPORT PINL
 #define DIO42_WPORT PORTL
 #define DIO42_DDR   DDRL
-#define DIO42_PWM   NULL
+#define DIO42_PWM   nullptr
 
 #define DIO43_PIN   PINL6
 #define DIO43_RPORT PINL
 #define DIO43_WPORT PORTL
 #define DIO43_DDR   DDRL
-#define DIO43_PWM   NULL
+#define DIO43_PWM   nullptr
 
 #define DIO44_PIN   PINL5
 #define DIO44_RPORT PINL
@@ -353,139 +353,139 @@
 #define DIO47_RPORT PINL
 #define DIO47_WPORT PORTL
 #define DIO47_DDR   DDRL
-#define DIO47_PWM   NULL
+#define DIO47_PWM   nullptr
 
 #define DIO48_PIN   PINL1
 #define DIO48_RPORT PINL
 #define DIO48_WPORT PORTL
 #define DIO48_DDR   DDRL
-#define DIO48_PWM   NULL
+#define DIO48_PWM   nullptr
 
 #define DIO49_PIN   PINL0
 #define DIO49_RPORT PINL
 #define DIO49_WPORT PORTL
 #define DIO49_DDR   DDRL
-#define DIO49_PWM   NULL
+#define DIO49_PWM   nullptr
 
 #define DIO50_PIN   PINB3
 #define DIO50_RPORT PINB
 #define DIO50_WPORT PORTB
 #define DIO50_DDR   DDRB
-#define DIO50_PWM   NULL
+#define DIO50_PWM   nullptr
 
 #define DIO51_PIN   PINB2
 #define DIO51_RPORT PINB
 #define DIO51_WPORT PORTB
 #define DIO51_DDR   DDRB
-#define DIO51_PWM   NULL
+#define DIO51_PWM   nullptr
 
 #define DIO52_PIN   PINB1
 #define DIO52_RPORT PINB
 #define DIO52_WPORT PORTB
 #define DIO52_DDR   DDRB
-#define DIO52_PWM   NULL
+#define DIO52_PWM   nullptr
 
 #define DIO53_PIN   PINB0
 #define DIO53_RPORT PINB
 #define DIO53_WPORT PORTB
 #define DIO53_DDR   DDRB
-#define DIO53_PWM   NULL
+#define DIO53_PWM   nullptr
 
 #define DIO54_PIN   PINF0
 #define DIO54_RPORT PINF
 #define DIO54_WPORT PORTF
 #define DIO54_DDR   DDRF
-#define DIO54_PWM   NULL
+#define DIO54_PWM   nullptr
 
 #define DIO55_PIN   PINF1
 #define DIO55_RPORT PINF
 #define DIO55_WPORT PORTF
 #define DIO55_DDR   DDRF
-#define DIO55_PWM   NULL
+#define DIO55_PWM   nullptr
 
 #define DIO56_PIN   PINF2
 #define DIO56_RPORT PINF
 #define DIO56_WPORT PORTF
 #define DIO56_DDR   DDRF
-#define DIO56_PWM   NULL
+#define DIO56_PWM   nullptr
 
 #define DIO57_PIN   PINF3
 #define DIO57_RPORT PINF
 #define DIO57_WPORT PORTF
 #define DIO57_DDR   DDRF
-#define DIO57_PWM   NULL
+#define DIO57_PWM   nullptr
 
 #define DIO58_PIN   PINF4
 #define DIO58_RPORT PINF
 #define DIO58_WPORT PORTF
 #define DIO58_DDR   DDRF
-#define DIO58_PWM   NULL
+#define DIO58_PWM   nullptr
 
 #define DIO59_PIN   PINF5
 #define DIO59_RPORT PINF
 #define DIO59_WPORT PORTF
 #define DIO59_DDR   DDRF
-#define DIO59_PWM   NULL
+#define DIO59_PWM   nullptr
 
 #define DIO60_PIN   PINF6
 #define DIO60_RPORT PINF
 #define DIO60_WPORT PORTF
 #define DIO60_DDR   DDRF
-#define DIO60_PWM   NULL
+#define DIO60_PWM   nullptr
 
 #define DIO61_PIN   PINF7
 #define DIO61_RPORT PINF
 #define DIO61_WPORT PORTF
 #define DIO61_DDR   DDRF
-#define DIO61_PWM   NULL
+#define DIO61_PWM   nullptr
 
 #define DIO62_PIN   PINK0
 #define DIO62_RPORT PINK
 #define DIO62_WPORT PORTK
 #define DIO62_DDR   DDRK
-#define DIO62_PWM   NULL
+#define DIO62_PWM   nullptr
 
 #define DIO63_PIN   PINK1
 #define DIO63_RPORT PINK
 #define DIO63_WPORT PORTK
 #define DIO63_DDR   DDRK
-#define DIO63_PWM   NULL
+#define DIO63_PWM   nullptr
 
 #define DIO64_PIN   PINK2
 #define DIO64_RPORT PINK
 #define DIO64_WPORT PORTK
 #define DIO64_DDR   DDRK
-#define DIO64_PWM   NULL
+#define DIO64_PWM   nullptr
 
 #define DIO65_PIN   PINK3
 #define DIO65_RPORT PINK
 #define DIO65_WPORT PORTK
 #define DIO65_DDR   DDRK
-#define DIO65_PWM   NULL
+#define DIO65_PWM   nullptr
 
 #define DIO66_PIN   PINK4
 #define DIO66_RPORT PINK
 #define DIO66_WPORT PORTK
 #define DIO66_DDR   DDRK
-#define DIO66_PWM   NULL
+#define DIO66_PWM   nullptr
 
 #define DIO67_PIN   PINK5
 #define DIO67_RPORT PINK
 #define DIO67_WPORT PORTK
 #define DIO67_DDR   DDRK
-#define DIO67_PWM   NULL
+#define DIO67_PWM   nullptr
 
 #define DIO68_PIN   PINK6
 #define DIO68_RPORT PINK
 #define DIO68_WPORT PORTK
 #define DIO68_DDR   DDRK
-#define DIO68_PWM   NULL
+#define DIO68_PWM   nullptr
 
 #define DIO69_PIN   PINK7
 #define DIO69_RPORT PINK
 #define DIO69_WPORT PORTK
 #define DIO69_DDR   DDRK
-#define DIO69_PWM   NULL
+#define DIO69_PWM   nullptr
 
 //#define FASTIO_EXT_START 70
 //#define FASTIO_EXT_END   85
@@ -494,171 +494,171 @@
 #define DIO70_RPORT PING
 #define DIO70_WPORT PORTG
 #define DIO70_DDR   DDRG
-#define DIO70_PWM   NULL
+#define DIO70_PWM   nullptr
 
 #define DIO71_PIN   PING3
 #define DIO71_RPORT PING
 #define DIO71_WPORT PORTG
 #define DIO71_DDR   DDRG
-#define DIO71_PWM   NULL
+#define DIO71_PWM   nullptr
 
 #define DIO72_PIN   PINJ2
 #define DIO72_RPORT PINJ
 #define DIO72_WPORT PORTJ
 #define DIO72_DDR   DDRJ
-#define DIO72_PWM   NULL
+#define DIO72_PWM   nullptr
 
 #define DIO73_PIN   PINJ3
 #define DIO73_RPORT PINJ
 #define DIO73_WPORT PORTJ
 #define DIO73_DDR   DDRJ
-#define DIO73_PWM   NULL
+#define DIO73_PWM   nullptr
 
 #define DIO74_PIN   PINJ7
 #define DIO74_RPORT PINJ
 #define DIO74_WPORT PORTJ
 #define DIO74_DDR   DDRJ
-#define DIO74_PWM   NULL
+#define DIO74_PWM   nullptr
 
 #define DIO75_PIN   PINJ4
 #define DIO75_RPORT PINJ
 #define DIO75_WPORT PORTJ
 #define DIO75_DDR   DDRJ
-#define DIO75_PWM   NULL
+#define DIO75_PWM   nullptr
 
 #define DIO76_PIN   PINJ5
 #define DIO76_RPORT PINJ
 #define DIO76_WPORT PORTJ
 #define DIO76_DDR   DDRJ
-#define DIO76_PWM   NULL
+#define DIO76_PWM   nullptr
 
 #define DIO77_PIN   PINJ6
 #define DIO77_RPORT PINJ
 #define DIO77_WPORT PORTJ
 #define DIO77_DDR   DDRJ
-#define DIO77_PWM   NULL
+#define DIO77_PWM   nullptr
 
 #define DIO78_PIN   PINE2
 #define DIO78_RPORT PINE
 #define DIO78_WPORT PORTE
 #define DIO78_DDR   DDRE
-#define DIO78_PWM   NULL
+#define DIO78_PWM   nullptr
 
 #define DIO79_PIN   PINE6
 #define DIO79_RPORT PINE
 #define DIO79_WPORT PORTE
 #define DIO79_DDR   DDRE
-#define DIO79_PWM   NULL
+#define DIO79_PWM   nullptr
 
 #define DIO80_PIN   PINE7
 #define DIO80_RPORT PINE
 #define DIO80_WPORT PORTE
 #define DIO80_DDR   DDRE
-#define DIO80_PWM   NULL
+#define DIO80_PWM   nullptr
 
 #define DIO81_PIN   PIND4
 #define DIO81_RPORT PIND
 #define DIO81_WPORT PORTD
 #define DIO81_DDR   DDRD
-#define DIO81_PWM   NULL
+#define DIO81_PWM   nullptr
 
 #define DIO82_PIN   PIND5
 #define DIO82_RPORT PIND
 #define DIO82_WPORT PORTD
 #define DIO82_DDR   DDRD
-#define DIO82_PWM   NULL
+#define DIO82_PWM   nullptr
 
 #define DIO83_PIN   PIND6
 #define DIO83_RPORT PIND
 #define DIO83_WPORT PORTD
 #define DIO83_DDR   DDRD
-#define DIO83_PWM   NULL
+#define DIO83_PWM   nullptr
 
 #define DIO84_PIN   PINH2
 #define DIO84_RPORT PINH
 #define DIO84_WPORT PORTH
 #define DIO84_DDR   DDRH
-#define DIO84_PWM   NULL
+#define DIO84_PWM   nullptr
 
 #define DIO85_PIN   PINH7
 #define DIO85_RPORT PINH
 #define DIO85_WPORT PORTH
 #define DIO85_DDR   DDRH
-#define DIO85_PWM   NULL
+#define DIO85_PWM   nullptr
 
 #undef PA0
 #define PA0_PIN     PINA0
 #define PA0_RPORT   PINA
 #define PA0_WPORT   PORTA
 #define PA0_DDR     DDRA
-#define PA0_PWM     NULL
+#define PA0_PWM     nullptr
 #undef PA1
 #define PA1_PIN     PINA1
 #define PA1_RPORT   PINA
 #define PA1_WPORT   PORTA
 #define PA1_DDR     DDRA
-#define PA1_PWM     NULL
+#define PA1_PWM     nullptr
 #undef PA2
 #define PA2_PIN     PINA2
 #define PA2_RPORT   PINA
 #define PA2_WPORT   PORTA
 #define PA2_DDR     DDRA
-#define PA2_PWM     NULL
+#define PA2_PWM     nullptr
 #undef PA3
 #define PA3_PIN     PINA3
 #define PA3_RPORT   PINA
 #define PA3_WPORT   PORTA
 #define PA3_DDR     DDRA
-#define PA3_PWM     NULL
+#define PA3_PWM     nullptr
 #undef PA4
 #define PA4_PIN     PINA4
 #define PA4_RPORT   PINA
 #define PA4_WPORT   PORTA
 #define PA4_DDR     DDRA
-#define PA4_PWM     NULL
+#define PA4_PWM     nullptr
 #undef PA5
 #define PA5_PIN     PINA5
 #define PA5_RPORT   PINA
 #define PA5_WPORT   PORTA
 #define PA5_DDR     DDRA
-#define PA5_PWM     NULL
+#define PA5_PWM     nullptr
 #undef PA6
 #define PA6_PIN     PINA6
 #define PA6_RPORT   PINA
 #define PA6_WPORT   PORTA
 #define PA6_DDR     DDRA
-#define PA6_PWM     NULL
+#define PA6_PWM     nullptr
 #undef PA7
 #define PA7_PIN     PINA7
 #define PA7_RPORT   PINA
 #define PA7_WPORT   PORTA
 #define PA7_DDR     DDRA
-#define PA7_PWM     NULL
+#define PA7_PWM     nullptr
 
 #undef PB0
 #define PB0_PIN     PINB0
 #define PB0_RPORT   PINB
 #define PB0_WPORT   PORTB
 #define PB0_DDR     DDRB
-#define PB0_PWM     NULL
+#define PB0_PWM     nullptr
 #undef PB1
 #define PB1_PIN     PINB1
 #define PB1_RPORT   PINB
 #define PB1_WPORT   PORTB
 #define PB1_DDR     DDRB
-#define PB1_PWM     NULL
+#define PB1_PWM     nullptr
 #undef PB2
 #define PB2_PIN     PINB2
 #define PB2_RPORT   PINB
 #define PB2_WPORT   PORTB
 #define PB2_DDR     DDRB
-#define PB2_PWM     NULL
+#define PB2_PWM     nullptr
 #undef PB3
 #define PB3_PIN     PINB3
 #define PB3_RPORT   PINB
 #define PB3_WPORT   PORTB
 #define PB3_DDR     DDRB
-#define PB3_PWM     NULL
+#define PB3_PWM     nullptr
 #undef PB4
 #define PB4_PIN     PINB4
 #define PB4_RPORT   PINB
@@ -670,13 +670,13 @@
 #define PB5_RPORT   PINB
 #define PB5_WPORT   PORTB
 #define PB5_DDR     DDRB
-#define PB5_PWM     NULL
+#define PB5_PWM     nullptr
 #undef PB6
 #define PB6_PIN     PINB6
 #define PB6_RPORT   PINB
 #define PB6_WPORT   PORTB
 #define PB6_DDR     DDRB
-#define PB6_PWM     NULL
+#define PB6_PWM     nullptr
 #undef PB7
 #define PB7_PIN     PINB7
 #define PB7_RPORT   PINB
@@ -689,117 +689,117 @@
 #define PC0_RPORT   PINC
 #define PC0_WPORT   PORTC
 #define PC0_DDR     DDRC
-#define PC0_PWM     NULL
+#define PC0_PWM     nullptr
 #undef PC1
 #define PC1_PIN     PINC1
 #define PC1_RPORT   PINC
 #define PC1_WPORT   PORTC
 #define PC1_DDR     DDRC
-#define PC1_PWM     NULL
+#define PC1_PWM     nullptr
 #undef PC2
 #define PC2_PIN     PINC2
 #define PC2_RPORT   PINC
 #define PC2_WPORT   PORTC
 #define PC2_DDR     DDRC
-#define PC2_PWM     NULL
+#define PC2_PWM     nullptr
 #undef PC3
 #define PC3_PIN     PINC3
 #define PC3_RPORT   PINC
 #define PC3_WPORT   PORTC
 #define PC3_DDR     DDRC
-#define PC3_PWM     NULL
+#define PC3_PWM     nullptr
 #undef PC4
 #define PC4_PIN     PINC4
 #define PC4_RPORT   PINC
 #define PC4_WPORT   PORTC
 #define PC4_DDR     DDRC
-#define PC4_PWM     NULL
+#define PC4_PWM     nullptr
 #undef PC5
 #define PC5_PIN     PINC5
 #define PC5_RPORT   PINC
 #define PC5_WPORT   PORTC
 #define PC5_DDR     DDRC
-#define PC5_PWM     NULL
+#define PC5_PWM     nullptr
 #undef PC6
 #define PC6_PIN     PINC6
 #define PC6_RPORT   PINC
 #define PC6_WPORT   PORTC
 #define PC6_DDR     DDRC
-#define PC6_PWM     NULL
+#define PC6_PWM     nullptr
 #undef PC7
 #define PC7_PIN     PINC7
 #define PC7_RPORT   PINC
 #define PC7_WPORT   PORTC
 #define PC7_DDR     DDRC
-#define PC7_PWM     NULL
+#define PC7_PWM     nullptr
 
 #undef PD0
 #define PD0_PIN     PIND0
 #define PD0_RPORT   PIND
 #define PD0_WPORT   PORTD
 #define PD0_DDR     DDRD
-#define PD0_PWM     NULL
+#define PD0_PWM     nullptr
 #undef PD1
 #define PD1_PIN     PIND1
 #define PD1_RPORT   PIND
 #define PD1_WPORT   PORTD
 #define PD1_DDR     DDRD
-#define PD1_PWM     NULL
+#define PD1_PWM     nullptr
 #undef PD2
 #define PD2_PIN     PIND2
 #define PD2_RPORT   PIND
 #define PD2_WPORT   PORTD
 #define PD2_DDR     DDRD
-#define PD2_PWM     NULL
+#define PD2_PWM     nullptr
 #undef PD3
 #define PD3_PIN     PIND3
 #define PD3_RPORT   PIND
 #define PD3_WPORT   PORTD
 #define PD3_DDR     DDRD
-#define PD3_PWM     NULL
+#define PD3_PWM     nullptr
 #undef PD4
 #define PD4_PIN     PIND4
 #define PD4_RPORT   PIND
 #define PD4_WPORT   PORTD
 #define PD4_DDR     DDRD
-#define PD4_PWM     NULL
+#define PD4_PWM     nullptr
 #undef PD5
 #define PD5_PIN     PIND5
 #define PD5_RPORT   PIND
 #define PD5_WPORT   PORTD
 #define PD5_DDR     DDRD
-#define PD5_PWM     NULL
+#define PD5_PWM     nullptr
 #undef PD6
 #define PD6_PIN     PIND6
 #define PD6_RPORT   PIND
 #define PD6_WPORT   PORTD
 #define PD6_DDR     DDRD
-#define PD6_PWM     NULL
+#define PD6_PWM     nullptr
 #undef PD7
 #define PD7_PIN     PIND7
 #define PD7_RPORT   PIND
 #define PD7_WPORT   PORTD
 #define PD7_DDR     DDRD
-#define PD7_PWM     NULL
+#define PD7_PWM     nullptr
 
 #undef PE0
 #define PE0_PIN     PINE0
 #define PE0_RPORT   PINE
 #define PE0_WPORT   PORTE
 #define PE0_DDR     DDRE
-#define PE0_PWM     NULL
+#define PE0_PWM     nullptr
 #undef PE1
 #define PE1_PIN     PINE1
 #define PE1_RPORT   PINE
 #define PE1_WPORT   PORTE
 #define PE1_DDR     DDRE
-#define PE1_PWM     NULL
+#define PE1_PWM     nullptr
 #undef PE2
 #define PE2_PIN     PINE2
 #define PE2_RPORT   PINE
 #define PE2_WPORT   PORTE
 #define PE2_DDR     DDRE
-#define PE2_PWM     NULL
+#define PE2_PWM     nullptr
 #undef PE3
 #define PE3_PIN     PINE3
 #define PE3_RPORT   PINE
@@ -823,93 +823,93 @@
 #define PE6_RPORT   PINE
 #define PE6_WPORT   PORTE
 #define PE6_DDR     DDRE
-#define PE6_PWM     NULL
+#define PE6_PWM     nullptr
 #undef PE7
 #define PE7_PIN     PINE7
 #define PE7_RPORT   PINE
 #define PE7_WPORT   PORTE
 #define PE7_DDR     DDRE
-#define PE7_PWM     NULL
+#define PE7_PWM     nullptr
 
 #undef PF0
 #define PF0_PIN     PINF0
 #define PF0_RPORT   PINF
 #define PF0_WPORT   PORTF
 #define PF0_DDR     DDRF
-#define PF0_PWM     NULL
+#define PF0_PWM     nullptr
 #undef PF1
 #define PF1_PIN     PINF1
 #define PF1_RPORT   PINF
 #define PF1_WPORT   PORTF
 #define PF1_DDR     DDRF
-#define PF1_PWM     NULL
+#define PF1_PWM     nullptr
 #undef PF2
 #define PF2_PIN     PINF2
 #define PF2_RPORT   PINF
 #define PF2_WPORT   PORTF
 #define PF2_DDR     DDRF
-#define PF2_PWM     NULL
+#define PF2_PWM     nullptr
 #undef PF3
 #define PF3_PIN     PINF3
 #define PF3_RPORT   PINF
 #define PF3_WPORT   PORTF
 #define PF3_DDR     DDRF
-#define PF3_PWM     NULL
+#define PF3_PWM     nullptr
 #undef PF4
 #define PF4_PIN     PINF4
 #define PF4_RPORT   PINF
 #define PF4_WPORT   PORTF
 #define PF4_DDR     DDRF
-#define PF4_PWM     NULL
+#define PF4_PWM     nullptr
 #undef PF5
 #define PF5_PIN     PINF5
 #define PF5_RPORT   PINF
 #define PF5_WPORT   PORTF
 #define PF5_DDR     DDRF
-#define PF5_PWM     NULL
+#define PF5_PWM     nullptr
 #undef PF6
 #define PF6_PIN     PINF6
 #define PF6_RPORT   PINF
 #define PF6_WPORT   PORTF
 #define PF6_DDR     DDRF
-#define PF6_PWM     NULL
+#define PF6_PWM     nullptr
 #undef PF7
 #define PF7_PIN     PINF7
 #define PF7_RPORT   PINF
 #define PF7_WPORT   PORTF
 #define PF7_DDR     DDRF
-#define PF7_PWM     NULL
+#define PF7_PWM     nullptr
 
 #undef PG0
 #define PG0_PIN     PING0
 #define PG0_RPORT   PING
 #define PG0_WPORT   PORTG
 #define PG0_DDR     DDRG
-#define PG0_PWM     NULL
+#define PG0_PWM     nullptr
 #undef PG1
 #define PG1_PIN     PING1
 #define PG1_RPORT   PING
 #define PG1_WPORT   PORTG
 #define PG1_DDR     DDRG
-#define PG1_PWM     NULL
+#define PG1_PWM     nullptr
 #undef PG2
 #define PG2_PIN     PING2
 #define PG2_RPORT   PING
 #define PG2_WPORT   PORTG
 #define PG2_DDR     DDRG
-#define PG2_PWM     NULL
+#define PG2_PWM     nullptr
 #undef PG3
 #define PG3_PIN     PING3
 #define PG3_RPORT   PING
 #define PG3_WPORT   PORTG
 #define PG3_DDR     DDRG
-#define PG3_PWM     NULL
+#define PG3_PWM     nullptr
 #undef PG4
 #define PG4_PIN     PING4
 #define PG4_RPORT   PING
 #define PG4_WPORT   PORTG
 #define PG4_DDR     DDRG
-#define PG4_PWM     NULL
+#define PG4_PWM     nullptr
 #undef PG5
 #define PG5_PIN     PING5
 #define PG5_RPORT   PING
@@ -922,19 +922,19 @@
 #define PH0_RPORT   PINH
 #define PH0_WPORT   PORTH
 #define PH0_DDR     DDRH
-#define PH0_PWM     NULL
+#define PH0_PWM     nullptr
 #undef PH1
 #define PH1_PIN     PINH1
 #define PH1_RPORT   PINH
 #define PH1_WPORT   PORTH
 #define PH1_DDR     DDRH
-#define PH1_PWM     NULL
+#define PH1_PWM     nullptr
 #undef PH2
 #define PH2_PIN     PINH2
 #define PH2_RPORT   PINH
 #define PH2_WPORT   PORTH
 #define PH2_DDR     DDRH
-#define PH2_PWM     NULL
+#define PH2_PWM     nullptr
 #undef PH3
 #define PH3_PIN     PINH3
 #define PH3_RPORT   PINH
@@ -964,124 +964,124 @@
 #define PH7_RPORT   PINH
 #define PH7_WPORT   PORTH
 #define PH7_DDR     DDRH
-#define PH7_PWM     NULL
+#define PH7_PWM     nullptr
 
 #undef PJ0
 #define PJ0_PIN     PINJ0
 #define PJ0_RPORT   PINJ
 #define PJ0_WPORT   PORTJ
 #define PJ0_DDR     DDRJ
-#define PJ0_PWM     NULL
+#define PJ0_PWM     nullptr
 #undef PJ1
 #define PJ1_PIN     PINJ1
 #define PJ1_RPORT   PINJ
 #define PJ1_WPORT   PORTJ
 #define PJ1_DDR     DDRJ
-#define PJ1_PWM     NULL
+#define PJ1_PWM     nullptr
 #undef PJ2
 #define PJ2_PIN     PINJ2
 #define PJ2_RPORT   PINJ
 #define PJ2_WPORT   PORTJ
 #define PJ2_DDR     DDRJ
-#define PJ2_PWM     NULL
+#define PJ2_PWM     nullptr
 #undef PJ3
 #define PJ3_PIN     PINJ3
 #define PJ3_RPORT   PINJ
 #define PJ3_WPORT   PORTJ
 #define PJ3_DDR     DDRJ
-#define PJ3_PWM     NULL
+#define PJ3_PWM     nullptr
 #undef PJ4
 #define PJ4_PIN     PINJ4
 #define PJ4_RPORT   PINJ
 #define PJ4_WPORT   PORTJ
 #define PJ4_DDR     DDRJ
-#define PJ4_PWM     NULL
+#define PJ4_PWM     nullptr
 #undef PJ5
 #define PJ5_PIN     PINJ5
 #define PJ5_RPORT   PINJ
 #define PJ5_WPORT   PORTJ
 #define PJ5_DDR     DDRJ
-#define PJ5_PWM     NULL
+#define PJ5_PWM     nullptr
 #undef PJ6
 #define PJ6_PIN     PINJ6
 #define PJ6_RPORT   PINJ
 #define PJ6_WPORT   PORTJ
 #define PJ6_DDR     DDRJ
-#define PJ6_PWM     NULL
+#define PJ6_PWM     nullptr
 #undef PJ7
 #define PJ7_PIN     PINJ7
 #define PJ7_RPORT   PINJ
 #define PJ7_WPORT   PORTJ
 #define PJ7_DDR     DDRJ
-#define PJ7_PWM     NULL
+#define PJ7_PWM     nullptr
 
 #undef PK0
 #define PK0_PIN     PINK0
 #define PK0_RPORT   PINK
 #define PK0_WPORT   PORTK
 #define PK0_DDR     DDRK
-#define PK0_PWM     NULL
+#define PK0_PWM     nullptr
 #undef PK1
 #define PK1_PIN     PINK1
 #define PK1_RPORT   PINK
 #define PK1_WPORT   PORTK
 #define PK1_DDR     DDRK
-#define PK1_PWM     NULL
+#define PK1_PWM     nullptr
 #undef PK2
 #define PK2_PIN     PINK2
 #define PK2_RPORT   PINK
 #define PK2_WPORT   PORTK
 #define PK2_DDR     DDRK
-#define PK2_PWM     NULL
+#define PK2_PWM     nullptr
 #undef PK3
 #define PK3_PIN     PINK3
 #define PK3_RPORT   PINK
 #define PK3_WPORT   PORTK
 #define PK3_DDR     DDRK
-#define PK3_PWM     NULL
+#define PK3_PWM     nullptr
 #undef PK4
 #define PK4_PIN     PINK4
 #define PK4_RPORT   PINK
 #define PK4_WPORT   PORTK
 #define PK4_DDR     DDRK
-#define PK4_PWM     NULL
+#define PK4_PWM     nullptr
 #undef PK5
 #define PK5_PIN     PINK5
 #define PK5_RPORT   PINK
 #define PK5_WPORT   PORTK
 #define PK5_DDR     DDRK
-#define PK5_PWM     NULL
+#define PK5_PWM     nullptr
 #undef PK6
 #define PK6_PIN     PINK6
 #define PK6_RPORT   PINK
 #define PK6_WPORT   PORTK
 #define PK6_DDR     DDRK
-#define PK6_PWM     NULL
+#define PK6_PWM     nullptr
 #undef PK7
 #define PK7_PIN     PINK7
 #define PK7_RPORT   PINK
 #define PK7_WPORT   PORTK
 #define PK7_DDR     DDRK
-#define PK7_PWM     NULL
+#define PK7_PWM     nullptr
 
 #undef PL0
 #define PL0_PIN     PINL0
 #define PL0_RPORT   PINL
 #define PL0_WPORT   PORTL
 #define PL0_DDR     DDRL
-#define PL0_PWM     NULL
+#define PL0_PWM     nullptr
 #undef PL1
 #define PL1_PIN     PINL1
 #define PL1_RPORT   PINL
 #define PL1_WPORT   PORTL
 #define PL1_DDR     DDRL
-#define PL1_PWM     NULL
+#define PL1_PWM     nullptr
 #undef PL2
 #define PL2_PIN     PINL2
 #define PL2_RPORT   PINL
 #define PL2_WPORT   PORTL
 #define PL2_DDR     DDRL
-#define PL2_PWM     NULL
+#define PL2_PWM     nullptr
 #undef PL3
 #define PL3_PIN     PINL3
 #define PL3_RPORT   PINL
@@ -1105,10 +1105,10 @@
 #define PL6_RPORT   PINL
 #define PL6_WPORT   PORTL
 #define PL6_DDR     DDRL
-#define PL6_PWM     NULL
+#define PL6_PWM     nullptr
 #undef PL7
 #define PL7_PIN     PINL7
 #define PL7_RPORT   PINL
 #define PL7_WPORT   PORTL
 #define PL7_DDR     DDRL
-#define PL7_PWM     NULL
+#define PL7_PWM     nullptr

--- a/Marlin/src/HAL/HAL_AVR/fastio_1281.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_1281.h
@@ -63,13 +63,13 @@
 #define DIO0_RPORT  PINE
 #define DIO0_WPORT  PORTE
 #define DIO0_DDR    DDRE
-#define DIO0_PWM    NULL
+#define DIO0_PWM    nullptr
 
 #define DIO1_PIN    PINE1
 #define DIO1_RPORT  PINE
 #define DIO1_WPORT  PORTE
 #define DIO1_DDR    DDRE
-#define DIO1_PWM    NULL
+#define DIO1_PWM    nullptr
 
 #define DIO2_PIN    PINE4
 #define DIO2_RPORT  PINE
@@ -123,339 +123,339 @@
 #define DIO10_RPORT PINB
 #define DIO10_WPORT PORTB
 #define DIO10_DDR   DDRB
-#define DIO10_PWM   NULL
+#define DIO10_PWM   nullptr
 
 #define DIO11_PIN   PINB2
 #define DIO11_RPORT PINB
 #define DIO11_WPORT PORTB
 #define DIO11_DDR   DDRB
-#define DIO11_PWM   NULL
+#define DIO11_PWM   nullptr
 
 #define DIO12_PIN   PINB3
 #define DIO12_RPORT PINB
 #define DIO12_WPORT PORTB
 #define DIO12_DDR   DDRB
-#define DIO12_PWM   NULL
+#define DIO12_PWM   nullptr
 
 #define DIO13_PIN   PINE2
 #define DIO13_RPORT PINE
 #define DIO13_WPORT PORTE
 #define DIO13_DDR   DDRE
-#define DIO13_PWM   NULL
+#define DIO13_PWM   nullptr
 
 #define DIO14_PIN   PINE6
 #define DIO14_RPORT PINE
 #define DIO14_WPORT PORTE
 #define DIO14_DDR   DDRE
-#define DIO14_PWM   NULL
+#define DIO14_PWM   nullptr
 
 #define DIO15_PIN   PINE7
 #define DIO15_RPORT PINE
 #define DIO15_WPORT PORTE
 #define DIO15_DDR   DDRE
-#define DIO15_PWM   NULL
+#define DIO15_PWM   nullptr
 
 #define DIO16_PIN   PINB0
 #define DIO16_RPORT PINB
 #define DIO16_WPORT PORTB
 #define DIO16_DDR   DDRB
-#define DIO16_PWM   NULL
+#define DIO16_PWM   nullptr
 
 #define DIO17_PIN   PIND0
 #define DIO17_RPORT PIND
 #define DIO17_WPORT PORTD
 #define DIO17_DDR   DDRD
-#define DIO17_PWM   NULL
+#define DIO17_PWM   nullptr
 
 #define DIO18_PIN   PIND1
 #define DIO18_RPORT PIND
 #define DIO18_WPORT PORTD
 #define DIO18_DDR   DDRD
-#define DIO18_PWM   NULL
+#define DIO18_PWM   nullptr
 
 #define DIO19_PIN   PIND2
 #define DIO19_RPORT PIND
 #define DIO19_WPORT PORTD
 #define DIO19_DDR   DDRD
-#define DIO19_PWM   NULL
+#define DIO19_PWM   nullptr
 
 #define DIO20_PIN   PIND3
 #define DIO20_RPORT PIND
 #define DIO20_WPORT PORTD
 #define DIO20_DDR   DDRD
-#define DIO20_PWM   NULL
+#define DIO20_PWM   nullptr
 
 #define DIO21_PIN   PIND4
 #define DIO21_RPORT PIND
 #define DIO21_WPORT PORTD
 #define DIO21_DDR   DDRD
-#define DIO21_PWM   NULL
+#define DIO21_PWM   nullptr
 
 #define DIO22_PIN   PIND5
 #define DIO22_RPORT PIND
 #define DIO22_WPORT PORTD
 #define DIO22_DDR   DDRD
-#define DIO22_PWM   NULL
+#define DIO22_PWM   nullptr
 
 #define DIO23_PIN   PIND6
 #define DIO23_RPORT PIND
 #define DIO23_WPORT PORTD
 #define DIO23_DDR   DDRD
-#define DIO23_PWM   NULL
+#define DIO23_PWM   nullptr
 
 #define DIO24_PIN   PIND7
 #define DIO24_RPORT PIND
 #define DIO24_WPORT PORTD
 #define DIO24_DDR   DDRD
-#define DIO24_PWM   NULL
+#define DIO24_PWM   nullptr
 
 #define DIO25_PIN   PING0
 #define DIO25_RPORT PING
 #define DIO25_WPORT PORTG
 #define DIO25_DDR   DDRG
-#define DIO25_PWM   NULL
+#define DIO25_PWM   nullptr
 
 #define DIO26_PIN   PING1
 #define DIO26_RPORT PING
 #define DIO26_WPORT PORTG
 #define DIO26_DDR   DDRG
-#define DIO26_PWM   NULL
+#define DIO26_PWM   nullptr
 
 #define DIO27_PIN   PING2
 #define DIO27_RPORT PING
 #define DIO27_WPORT PORTG
 #define DIO27_DDR   DDRG
-#define DIO27_PWM   NULL
+#define DIO27_PWM   nullptr
 
 #define DIO28_PIN   PING3
 #define DIO28_RPORT PING
 #define DIO28_WPORT PORTG
 #define DIO28_DDR   DDRG
-#define DIO28_PWM   NULL
+#define DIO28_PWM   nullptr
 
 #define DIO29_PIN   PING4
 #define DIO29_RPORT PING
 #define DIO29_WPORT PORTG
 #define DIO29_DDR   DDRG
-#define DIO29_PWM   NULL
+#define DIO29_PWM   nullptr
 
 #define DIO30_PIN   PINC0
 #define DIO30_RPORT PINC
 #define DIO30_WPORT PORTC
 #define DIO30_DDR   DDRC
-#define DIO30_PWM   NULL
+#define DIO30_PWM   nullptr
 
 #define DIO31_PIN   PINC1
 #define DIO31_RPORT PINC
 #define DIO31_WPORT PORTC
 #define DIO31_DDR   DDRC
-#define DIO31_PWM   NULL
+#define DIO31_PWM   nullptr
 
 #define DIO32_PIN   PINC2
 #define DIO32_RPORT PINC
 #define DIO32_WPORT PORTC
 #define DIO32_DDR   DDRC
-#define DIO32_PWM   NULL
+#define DIO32_PWM   nullptr
 
 #define DIO33_PIN   PINC3
 #define DIO33_RPORT PINC
 #define DIO33_WPORT PORTC
 #define DIO33_DDR   DDRC
-#define DIO33_PWM   NULL
+#define DIO33_PWM   nullptr
 
 #define DIO34_PIN   PINC4
 #define DIO34_RPORT PINC
 #define DIO34_WPORT PORTC
 #define DIO34_DDR   DDRC
-#define DIO34_PWM   NULL
+#define DIO34_PWM   nullptr
 
 #define DIO35_PIN   PINC5
 #define DIO35_RPORT PINC
 #define DIO35_WPORT PORTC
 #define DIO35_DDR   DDRC
-#define DIO35_PWM   NULL
+#define DIO35_PWM   nullptr
 
 #define DIO36_PIN   PINC6
 #define DIO36_RPORT PINC
 #define DIO36_WPORT PORTC
 #define DIO36_DDR   DDRC
-#define DIO36_PWM   NULL
+#define DIO36_PWM   nullptr
 
 #define DIO37_PIN   PINC7
 #define DIO37_RPORT PINC
 #define DIO37_WPORT PORTC
 #define DIO37_DDR   DDRC
-#define DIO37_PWM   NULL
+#define DIO37_PWM   nullptr
 
 #define DIO38_PIN   PINA0
 #define DIO38_RPORT PINA
 #define DIO38_WPORT PORTA
 #define DIO38_DDR   DDRA
-#define DIO38_PWM   NULL
+#define DIO38_PWM   nullptr
 
 #define DIO39_PIN   PINA1
 #define DIO39_RPORT PINA
 #define DIO39_WPORT PORTA
 #define DIO39_DDR   DDRA
-#define DIO39_PWM   NULL
+#define DIO39_PWM   nullptr
 
 #define DIO40_PIN   PINA2
 #define DIO40_RPORT PINA
 #define DIO40_WPORT PORTA
 #define DIO40_DDR   DDRA
-#define DIO40_PWM   NULL
+#define DIO40_PWM   nullptr
 
 #define DIO41_PIN   PINA3
 #define DIO41_RPORT PINA
 #define DIO41_WPORT PORTA
 #define DIO41_DDR   DDRA
-#define DIO41_PWM   NULL
+#define DIO41_PWM   nullptr
 
 #define DIO42_PIN   PINA4
 #define DIO42_RPORT PINA
 #define DIO42_WPORT PORTA
 #define DIO42_DDR   DDRA
-#define DIO42_PWM   NULL
+#define DIO42_PWM   nullptr
 
 #define DIO43_PIN   PINA5
 #define DIO43_RPORT PINA
 #define DIO43_WPORT PORTA
 #define DIO43_DDR   DDRA
-#define DIO43_PWM   NULL
+#define DIO43_PWM   nullptr
 
 #define DIO44_PIN   PINA6
 #define DIO44_RPORT PINA
 #define DIO44_WPORT PORTA
 #define DIO44_DDR   DDRA
-#define DIO44_PWM   NULL
+#define DIO44_PWM   nullptr
 
 #define DIO45_PIN   PINA7
 #define DIO45_RPORT PINA
 #define DIO45_WPORT PORTA
 #define DIO45_DDR   DDRA
-#define DIO45_PWM   NULL
+#define DIO45_PWM   nullptr
 
 #define DIO46_PIN   PINF0
 #define DIO46_RPORT PINF
 #define DIO46_WPORT PORTF
 #define DIO46_DDR   DDRF
-#define DIO46_PWM   NULL
+#define DIO46_PWM   nullptr
 
 #define DIO47_PIN   PINF1
 #define DIO47_RPORT PINF
 #define DIO47_WPORT PORTF
 #define DIO47_DDR   DDRF
-#define DIO47_PWM   NULL
+#define DIO47_PWM   nullptr
 
 #define DIO48_PIN   PINF2
 #define DIO48_RPORT PINF
 #define DIO48_WPORT PORTF
 #define DIO48_DDR   DDRF
-#define DIO48_PWM   NULL
+#define DIO48_PWM   nullptr
 
 #define DIO49_PIN   PINF3
 #define DIO49_RPORT PINF
 #define DIO49_WPORT PORTF
 #define DIO49_DDR   DDRF
-#define DIO49_PWM   NULL
+#define DIO49_PWM   nullptr
 
 #define DIO50_PIN   PINF4
 #define DIO50_RPORT PINF
 #define DIO50_WPORT PORTF
 #define DIO50_DDR   DDRF
-#define DIO50_PWM   NULL
+#define DIO50_PWM   nullptr
 
 #define DIO51_PIN   PINF5
 #define DIO51_RPORT PINF
 #define DIO51_WPORT PORTF
 #define DIO51_DDR   DDRF
-#define DIO51_PWM   NULL
+#define DIO51_PWM   nullptr
 
 #define DIO52_PIN   PINF6
 #define DIO52_RPORT PINF
 #define DIO52_WPORT PORTF
 #define DIO52_DDR   DDRF
-#define DIO52_PWM   NULL
+#define DIO52_PWM   nullptr
 
 #define DIO53_PIN   PINF7
 #define DIO53_RPORT PINF
 #define DIO53_WPORT PORTF
 #define DIO53_DDR   DDRF
-#define DIO53_PWM   NULL
+#define DIO53_PWM   nullptr
 
 #undef PA0
 #define PA0_PIN     PINA0
 #define PA0_RPORT   PINA
 #define PA0_WPORT   PORTA
 #define PA0_DDR     DDRA
-#define PA0_PWM     NULL
+#define PA0_PWM     nullptr
 #undef PA1
 #define PA1_PIN     PINA1
 #define PA1_RPORT   PINA
 #define PA1_WPORT   PORTA
 #define PA1_DDR     DDRA
-#define PA1_PWM     NULL
+#define PA1_PWM     nullptr
 #undef PA2
 #define PA2_PIN     PINA2
 #define PA2_RPORT   PINA
 #define PA2_WPORT   PORTA
 #define PA2_DDR     DDRA
-#define PA2_PWM     NULL
+#define PA2_PWM     nullptr
 #undef PA3
 #define PA3_PIN     PINA3
 #define PA3_RPORT   PINA
 #define PA3_WPORT   PORTA
 #define PA3_DDR     DDRA
-#define PA3_PWM     NULL
+#define PA3_PWM     nullptr
 #undef PA4
 #define PA4_PIN     PINA4
 #define PA4_RPORT   PINA
 #define PA4_WPORT   PORTA
 #define PA4_DDR     DDRA
-#define PA4_PWM     NULL
+#define PA4_PWM     nullptr
 #undef PA5
 #define PA5_PIN     PINA5
 #define PA5_RPORT   PINA
 #define PA5_WPORT   PORTA
 #define PA5_DDR     DDRA
-#define PA5_PWM     NULL
+#define PA5_PWM     nullptr
 #undef PA6
 #define PA6_PIN     PINA6
 #define PA6_RPORT   PINA
 #define PA6_WPORT   PORTA
 #define PA6_DDR     DDRA
-#define PA6_PWM     NULL
+#define PA6_PWM     nullptr
 #undef PA7
 #define PA7_PIN     PINA7
 #define PA7_RPORT   PINA
 #define PA7_WPORT   PORTA
 #define PA7_DDR     DDRA
-#define PA7_PWM     NULL
+#define PA7_PWM     nullptr
 
 #undef PB0
 #define PB0_PIN     PINB0
 #define PB0_RPORT   PINB
 #define PB0_WPORT   PORTB
 #define PB0_DDR     DDRB
-#define PB0_PWM     NULL
+#define PB0_PWM     nullptr
 #undef PB1
 #define PB1_PIN     PINB1
 #define PB1_RPORT   PINB
 #define PB1_WPORT   PORTB
 #define PB1_DDR     DDRB
-#define PB1_PWM     NULL
+#define PB1_PWM     nullptr
 #undef PB2
 #define PB2_PIN     PINB2
 #define PB2_RPORT   PINB
 #define PB2_WPORT   PORTB
 #define PB2_DDR     DDRB
-#define PB2_PWM     NULL
+#define PB2_PWM     nullptr
 #undef PB3
 #define PB3_PIN     PINB3
 #define PB3_RPORT   PINB
 #define PB3_WPORT   PORTB
 #define PB3_DDR     DDRB
-#define PB3_PWM     NULL
+#define PB3_PWM     nullptr
 #undef PB4
 #define PB4_PIN     PINB4
 #define PB4_RPORT   PINB
@@ -467,13 +467,13 @@
 #define PB5_RPORT   PINB
 #define PB5_WPORT   PORTB
 #define PB5_DDR     DDRB
-#define PB5_PWM     NULL
+#define PB5_PWM     nullptr
 #undef PB6
 #define PB6_PIN     PINB6
 #define PB6_RPORT   PINB
 #define PB6_WPORT   PORTB
 #define PB6_DDR     DDRB
-#define PB6_PWM     NULL
+#define PB6_PWM     nullptr
 #undef PB7
 #define PB7_PIN     PINB7
 #define PB7_RPORT   PINB
@@ -486,117 +486,117 @@
 #define PC0_RPORT   PINC
 #define PC0_WPORT   PORTC
 #define PC0_DDR     DDRC
-#define PC0_PWM     NULL
+#define PC0_PWM     nullptr
 #undef PC1
 #define PC1_PIN     PINC1
 #define PC1_RPORT   PINC
 #define PC1_WPORT   PORTC
 #define PC1_DDR     DDRC
-#define PC1_PWM     NULL
+#define PC1_PWM     nullptr
 #undef PC2
 #define PC2_PIN     PINC2
 #define PC2_RPORT   PINC
 #define PC2_WPORT   PORTC
 #define PC2_DDR     DDRC
-#define PC2_PWM     NULL
+#define PC2_PWM     nullptr
 #undef PC3
 #define PC3_PIN     PINC3
 #define PC3_RPORT   PINC
 #define PC3_WPORT   PORTC
 #define PC3_DDR     DDRC
-#define PC3_PWM     NULL
+#define PC3_PWM     nullptr
 #undef PC4
 #define PC4_PIN     PINC4
 #define PC4_RPORT   PINC
 #define PC4_WPORT   PORTC
 #define PC4_DDR     DDRC
-#define PC4_PWM     NULL
+#define PC4_PWM     nullptr
 #undef PC5
 #define PC5_PIN     PINC5
 #define PC5_RPORT   PINC
 #define PC5_WPORT   PORTC
 #define PC5_DDR     DDRC
-#define PC5_PWM     NULL
+#define PC5_PWM     nullptr
 #undef PC6
 #define PC6_PIN     PINC6
 #define PC6_RPORT   PINC
 #define PC6_WPORT   PORTC
 #define PC6_DDR     DDRC
-#define PC6_PWM     NULL
+#define PC6_PWM     nullptr
 #undef PC7
 #define PC7_PIN     PINC7
 #define PC7_RPORT   PINC
 #define PC7_WPORT   PORTC
 #define PC7_DDR     DDRC
-#define PC7_PWM     NULL
+#define PC7_PWM     nullptr
 
 #undef PD0
 #define PD0_PIN     PIND0
 #define PD0_RPORT   PIND
 #define PD0_WPORT   PORTD
 #define PD0_DDR     DDRD
-#define PD0_PWM     NULL
+#define PD0_PWM     nullptr
 #undef PD1
 #define PD1_PIN     PIND1
 #define PD1_RPORT   PIND
 #define PD1_WPORT   PORTD
 #define PD1_DDR     DDRD
-#define PD1_PWM     NULL
+#define PD1_PWM     nullptr
 #undef PD2
 #define PD2_PIN     PIND2
 #define PD2_RPORT   PIND
 #define PD2_WPORT   PORTD
 #define PD2_DDR     DDRD
-#define PD2_PWM     NULL
+#define PD2_PWM     nullptr
 #undef PD3
 #define PD3_PIN     PIND3
 #define PD3_RPORT   PIND
 #define PD3_WPORT   PORTD
 #define PD3_DDR     DDRD
-#define PD3_PWM     NULL
+#define PD3_PWM     nullptr
 #undef PD4
 #define PD4_PIN     PIND4
 #define PD4_RPORT   PIND
 #define PD4_WPORT   PORTD
 #define PD4_DDR     DDRD
-#define PD4_PWM     NULL
+#define PD4_PWM     nullptr
 #undef PD5
 #define PD5_PIN     PIND5
 #define PD5_RPORT   PIND
 #define PD5_WPORT   PORTD
 #define PD5_DDR     DDRD
-#define PD5_PWM     NULL
+#define PD5_PWM     nullptr
 #undef PD6
 #define PD6_PIN     PIND6
 #define PD6_RPORT   PIND
 #define PD6_WPORT   PORTD
 #define PD6_DDR     DDRD
-#define PD6_PWM     NULL
+#define PD6_PWM     nullptr
 #undef PD7
 #define PD7_PIN     PIND7
 #define PD7_RPORT   PIND
 #define PD7_WPORT   PORTD
 #define PD7_DDR     DDRD
-#define PD7_PWM     NULL
+#define PD7_PWM     nullptr
 
 #undef PE0
 #define PE0_PIN     PINE0
 #define PE0_RPORT   PINE
 #define PE0_WPORT   PORTE
 #define PE0_DDR     DDRE
-#define PE0_PWM     NULL
+#define PE0_PWM     nullptr
 #undef PE1
 #define PE1_PIN     PINE1
 #define PE1_RPORT   PINE
 #define PE1_WPORT   PORTE
 #define PE1_DDR     DDRE
-#define PE1_PWM     NULL
+#define PE1_PWM     nullptr
 #undef PE2
 #define PE2_PIN     PINE2
 #define PE2_RPORT   PINE
 #define PE2_WPORT   PORTE
 #define PE2_DDR     DDRE
-#define PE2_PWM     NULL
+#define PE2_PWM     nullptr
 #undef PE3
 #define PE3_PIN     PINE3
 #define PE3_RPORT   PINE
@@ -620,93 +620,93 @@
 #define PE6_RPORT   PINE
 #define PE6_WPORT   PORTE
 #define PE6_DDR     DDRE
-#define PE6_PWM     NULL
+#define PE6_PWM     nullptr
 #undef PE7
 #define PE7_PIN     PINE7
 #define PE7_RPORT   PINE
 #define PE7_WPORT   PORTE
 #define PE7_DDR     DDRE
-#define PE7_PWM     NULL
+#define PE7_PWM     nullptr
 
 #undef PF0
 #define PF0_PIN     PINF0
 #define PF0_RPORT   PINF
 #define PF0_WPORT   PORTF
 #define PF0_DDR     DDRF
-#define PF0_PWM     NULL
+#define PF0_PWM     nullptr
 #undef PF1
 #define PF1_PIN     PINF1
 #define PF1_RPORT   PINF
 #define PF1_WPORT   PORTF
 #define PF1_DDR     DDRF
-#define PF1_PWM     NULL
+#define PF1_PWM     nullptr
 #undef PF2
 #define PF2_PIN     PINF2
 #define PF2_RPORT   PINF
 #define PF2_WPORT   PORTF
 #define PF2_DDR     DDRF
-#define PF2_PWM     NULL
+#define PF2_PWM     nullptr
 #undef PF3
 #define PF3_PIN     PINF3
 #define PF3_RPORT   PINF
 #define PF3_WPORT   PORTF
 #define PF3_DDR     DDRF
-#define PF3_PWM     NULL
+#define PF3_PWM     nullptr
 #undef PF4
 #define PF4_PIN     PINF4
 #define PF4_RPORT   PINF
 #define PF4_WPORT   PORTF
 #define PF4_DDR     DDRF
-#define PF4_PWM     NULL
+#define PF4_PWM     nullptr
 #undef PF5
 #define PF5_PIN     PINF5
 #define PF5_RPORT   PINF
 #define PF5_WPORT   PORTF
 #define PF5_DDR     DDRF
-#define PF5_PWM     NULL
+#define PF5_PWM     nullptr
 #undef PF6
 #define PF6_PIN     PINF6
 #define PF6_RPORT   PINF
 #define PF6_WPORT   PORTF
 #define PF6_DDR     DDRF
-#define PF6_PWM     NULL
+#define PF6_PWM     nullptr
 #undef PF7
 #define PF7_PIN     PINF7
 #define PF7_RPORT   PINF
 #define PF7_WPORT   PORTF
 #define PF7_DDR     DDRF
-#define PF7_PWM     NULL
+#define PF7_PWM     nullptr
 
 #undef PG0
 #define PG0_PIN     PING0
 #define PG0_RPORT   PING
 #define PG0_WPORT   PORTG
 #define PG0_DDR     DDRG
-#define PG0_PWM     NULL
+#define PG0_PWM     nullptr
 #undef PG1
 #define PG1_PIN     PING1
 #define PG1_RPORT   PING
 #define PG1_WPORT   PORTG
 #define PG1_DDR     DDRG
-#define PG1_PWM     NULL
+#define PG1_PWM     nullptr
 #undef PG2
 #define PG2_PIN     PING2
 #define PG2_RPORT   PING
 #define PG2_WPORT   PORTG
 #define PG2_DDR     DDRG
-#define PG2_PWM     NULL
+#define PG2_PWM     nullptr
 #undef PG3
 #define PG3_PIN     PING3
 #define PG3_RPORT   PING
 #define PG3_WPORT   PORTG
 #define PG3_DDR     DDRG
-#define PG3_PWM     NULL
+#define PG3_PWM     nullptr
 #undef PG4
 #define PG4_PIN     PING4
 #define PG4_RPORT   PING
 #define PG4_WPORT   PORTG
 #define PG4_DDR     DDRG
-#define PG4_PWM     NULL
+#define PG4_PWM     nullptr
 #undef PG5
 #define PG5_PIN     PING5
 #define PG5_RPORT   PING

--- a/Marlin/src/HAL/HAL_AVR/fastio_168.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_168.h
@@ -60,19 +60,19 @@
 #define DIO0_RPORT  PIND
 #define DIO0_WPORT  PORTD
 #define DIO0_DDR    DDRD
-#define DIO0_PWM    NULL
+#define DIO0_PWM    nullptr
 
 #define DIO1_PIN    PIND1
 #define DIO1_RPORT  PIND
 #define DIO1_WPORT  PORTD
 #define DIO1_DDR    DDRD
-#define DIO1_PWM    NULL
+#define DIO1_PWM    nullptr
 
 #define DIO2_PIN    PIND2
 #define DIO2_RPORT  PIND
 #define DIO2_WPORT  PORTD
 #define DIO2_DDR    DDRD
-#define DIO2_PWM    NULL
+#define DIO2_PWM    nullptr
 
 #define DIO3_PIN    PIND3
 #define DIO3_RPORT  PIND
@@ -84,7 +84,7 @@
 #define DIO4_RPORT  PIND
 #define DIO4_WPORT  PORTD
 #define DIO4_DDR    DDRD
-#define DIO4_PWM    NULL
+#define DIO4_PWM    nullptr
 
 #define DIO5_PIN    PIND5
 #define DIO5_RPORT  PIND
@@ -102,25 +102,25 @@
 #define DIO7_RPORT  PIND
 #define DIO7_WPORT  PORTD
 #define DIO7_DDR    DDRD
-#define DIO7_PWM    NULL
+#define DIO7_PWM    nullptr
 
 #define DIO8_PIN    PINB0
 #define DIO8_RPORT  PINB
 #define DIO8_WPORT  PORTB
 #define DIO8_DDR    DDRB
-#define DIO8_PWM    NULL
+#define DIO8_PWM    nullptr
 
 #define DIO9_PIN    PINB1
 #define DIO9_RPORT  PINB
 #define DIO9_WPORT  PORTB
 #define DIO9_DDR    DDRB
-#define DIO9_PWM    NULL
+#define DIO9_PWM    nullptr
 
 #define DIO10_PIN   PINB2
 #define DIO10_RPORT PINB
 #define DIO10_WPORT PORTB
 #define DIO10_DDR   DDRB
-#define DIO10_PWM   NULL
+#define DIO10_PWM   nullptr
 
 #define DIO11_PIN   PINB3
 #define DIO11_RPORT PINB
@@ -132,82 +132,82 @@
 #define DIO12_RPORT PINB
 #define DIO12_WPORT PORTB
 #define DIO12_DDR   DDRB
-#define DIO12_PWM   NULL
+#define DIO12_PWM   nullptr
 
 #define DIO13_PIN   PINB5
 #define DIO13_RPORT PINB
 #define DIO13_WPORT PORTB
 #define DIO13_DDR   DDRB
-#define DIO13_PWM   NULL
+#define DIO13_PWM   nullptr
 
 #define DIO14_PIN   PINC0
 #define DIO14_RPORT PINC
 #define DIO14_WPORT PORTC
 #define DIO14_DDR   DDRC
-#define DIO14_PWM   NULL
+#define DIO14_PWM   nullptr
 
 #define DIO15_PIN   PINC1
 #define DIO15_RPORT PINC
 #define DIO15_WPORT PORTC
 #define DIO15_DDR   DDRC
-#define DIO15_PWM   NULL
+#define DIO15_PWM   nullptr
 
 #define DIO16_PIN   PINC2
 #define DIO16_RPORT PINC
 #define DIO16_WPORT PORTC
 #define DIO16_DDR   DDRC
-#define DIO16_PWM   NULL
+#define DIO16_PWM   nullptr
 
 #define DIO17_PIN   PINC3
 #define DIO17_RPORT PINC
 #define DIO17_WPORT PORTC
 #define DIO17_DDR   DDRC
-#define DIO17_PWM   NULL
+#define DIO17_PWM   nullptr
 
 #define DIO18_PIN   PINC4
 #define DIO18_RPORT PINC
 #define DIO18_WPORT PORTC
 #define DIO18_DDR   DDRC
-#define DIO18_PWM   NULL
+#define DIO18_PWM   nullptr
 
 #define DIO19_PIN   PINC5
 #define DIO19_RPORT PINC
 #define DIO19_WPORT PORTC
 #define DIO19_DDR   DDRC
-#define DIO19_PWM   NULL
+#define DIO19_PWM   nullptr
 
 #define DIO20_PIN   PINC6
 #define DIO20_RPORT PINC
 #define DIO20_WPORT PORTC
 #define DIO20_DDR   DDRC
-#define DIO20_PWM   NULL
+#define DIO20_PWM   nullptr
 
 #define DIO21_PIN   PINC7
 #define DIO21_RPORT PINC
 #define DIO21_WPORT PORTC
 #define DIO21_DDR   DDRC
-#define DIO21_PWM   NULL
+#define DIO21_PWM   nullptr
 
 #undef PB0
 #define PB0_PIN     PINB0
 #define PB0_RPORT   PINB
 #define PB0_WPORT   PORTB
 #define PB0_DDR     DDRB
-#define PB0_PWM     NULL
+#define PB0_PWM     nullptr
 
 #undef PB1
 #define PB1_PIN     PINB1
 #define PB1_RPORT   PINB
 #define PB1_WPORT   PORTB
 #define PB1_DDR     DDRB
-#define PB1_PWM     NULL
+#define PB1_PWM     nullptr
 
 #undef PB2
 #define PB2_PIN     PINB2
 #define PB2_RPORT   PINB
 #define PB2_WPORT   PORTB
 #define PB2_DDR     DDRB
-#define PB2_PWM     NULL
+#define PB2_PWM     nullptr
 
 #undef PB3
 #define PB3_PIN     PINB3
@@ -221,105 +221,105 @@
 #define PB4_RPORT   PINB
 #define PB4_WPORT   PORTB
 #define PB4_DDR     DDRB
-#define PB4_PWM     NULL
+#define PB4_PWM     nullptr
 
 #undef PB5
 #define PB5_PIN     PINB5
 #define PB5_RPORT   PINB
 #define PB5_WPORT   PORTB
 #define PB5_DDR     DDRB
-#define PB5_PWM     NULL
+#define PB5_PWM     nullptr
 
 #undef PB6
 #define PB6_PIN     PINB6
 #define PB6_RPORT   PINB
 #define PB6_WPORT   PORTB
 #define PB6_DDR     DDRB
-#define PB6_PWM     NULL
+#define PB6_PWM     nullptr
 
 #undef PB7
 #define PB7_PIN     PINB7
 #define PB7_RPORT   PINB
 #define PB7_WPORT   PORTB
 #define PB7_DDR     DDRB
-#define PB7_PWM     NULL
+#define PB7_PWM     nullptr
 
 #undef PC0
 #define PC0_PIN     PINC0
 #define PC0_RPORT   PINC
 #define PC0_WPORT   PORTC
 #define PC0_DDR     DDRC
-#define PC0_PWM     NULL
+#define PC0_PWM     nullptr
 
 #undef PC1
 #define PC1_PIN     PINC1
 #define PC1_RPORT   PINC
 #define PC1_WPORT   PORTC
 #define PC1_DDR     DDRC
-#define PC1_PWM     NULL
+#define PC1_PWM     nullptr
 
 #undef PC2
 #define PC2_PIN     PINC2
 #define PC2_RPORT   PINC
 #define PC2_WPORT   PORTC
 #define PC2_DDR     DDRC
-#define PC2_PWM     NULL
+#define PC2_PWM     nullptr
 
 #undef PC3
 #define PC3_PIN     PINC3
 #define PC3_RPORT   PINC
 #define PC3_WPORT   PORTC
 #define PC3_DDR     DDRC
-#define PC3_PWM     NULL
+#define PC3_PWM     nullptr
 
 #undef PC4
 #define PC4_PIN     PINC4
 #define PC4_RPORT   PINC
 #define PC4_WPORT   PORTC
 #define PC4_DDR     DDRC
-#define PC4_PWM     NULL
+#define PC4_PWM     nullptr
 
 #undef PC5
 #define PC5_PIN     PINC5
 #define PC5_RPORT   PINC
 #define PC5_WPORT   PORTC
 #define PC5_DDR     DDRC
-#define PC5_PWM     NULL
+#define PC5_PWM     nullptr
 
 #undef PC6
 #define PC6_PIN     PINC6
 #define PC6_RPORT   PINC
 #define PC6_WPORT   PORTC
 #define PC6_DDR     DDRC
-#define PC6_PWM     NULL
+#define PC6_PWM     nullptr
 
 #undef PC7
 #define PC7_PIN     PINC7
 #define PC7_RPORT   PINC
 #define PC7_WPORT   PORTC
 #define PC7_DDR     DDRC
-#define PC7_PWM     NULL
+#define PC7_PWM     nullptr
 
 #undef PD0
 #define PD0_PIN     PIND0
 #define PD0_RPORT   PIND
 #define PD0_WPORT   PORTD
 #define PD0_DDR     DDRD
-#define PD0_PWM     NULL
+#define PD0_PWM     nullptr
 
 #undef PD1
 #define PD1_PIN     PIND1
 #define PD1_RPORT   PIND
 #define PD1_WPORT   PORTD
 #define PD1_DDR     DDRD
-#define PD1_PWM     NULL
+#define PD1_PWM     nullptr
 
 #undef PD2
 #define PD2_PIN     PIND2
 #define PD2_RPORT   PIND
 #define PD2_WPORT   PORTD
 #define PD2_DDR     DDRD
-#define PD2_PWM     NULL
+#define PD2_PWM     nullptr
 
 #undef PD3
 #define PD3_PIN     PIND3
@@ -333,7 +333,7 @@
 #define PD4_RPORT   PIND
 #define PD4_WPORT   PORTD
 #define PD4_DDR     DDRD
-#define PD4_PWM     NULL
+#define PD4_PWM     nullptr
 
 #undef PD5
 #define PD5_PIN     PIND5
@@ -354,4 +354,4 @@
 #define PD7_RPORT   PIND
 #define PD7_WPORT   PORTD
 #define PD7_DDR     DDRD
-#define PD7_PWM     NULL
+#define PD7_PWM     nullptr

--- a/Marlin/src/HAL/HAL_AVR/fastio_644.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_644.h
@@ -91,462 +91,462 @@
 #define DIO0_RPORT  PINB
 #define DIO0_WPORT  PORTB
 #define DIO0_DDR    DDRB
-#define DIO0_PWM    NULL
+#define DIO0_PWM    nullptr
 
 #define DIO1_PIN    PINB1
 #define DIO1_RPORT  PINB
 #define DIO1_WPORT  PORTB
 #define DIO1_DDR    DDRB
-#define DIO1_PWM    NULL
+#define DIO1_PWM    nullptr
 
 #define DIO2_PIN    PINB2
 #define DIO2_RPORT  PINB
 #define DIO2_WPORT  PORTB
 #define DIO2_DDR    DDRB
-#define DIO2_PWM    NULL
+#define DIO2_PWM    nullptr
 
 #define DIO3_PIN    PINB3
 #define DIO3_RPORT  PINB
 #define DIO3_WPORT  PORTB
 #define DIO3_DDR    DDRB
-#define DIO3_PWM    OCR0A
+#define DIO3_PWM    &OCR0A
 
 #define DIO4_PIN    PINB4
 #define DIO4_RPORT  PINB
 #define DIO4_WPORT  PORTB
 #define DIO4_DDR    DDRB
-#define DIO4_PWM    OCR0B
+#define DIO4_PWM    &OCR0B
 
 #define DIO5_PIN    PINB5
 #define DIO5_RPORT  PINB
 #define DIO5_WPORT  PORTB
 #define DIO5_DDR    DDRB
-#define DIO5_PWM    NULL
+#define DIO5_PWM    nullptr
 
 #define DIO6_PIN    PINB6
 #define DIO6_RPORT  PINB
 #define DIO6_WPORT  PORTB
 #define DIO6_DDR    DDRB
-#define DIO6_PWM    NULL
+#define DIO6_PWM    nullptr
 
 #define DIO7_PIN    PINB7
 #define DIO7_RPORT  PINB
 #define DIO7_WPORT  PORTB
 #define DIO7_DDR    DDRB
-#define DIO7_PWM    NULL
+#define DIO7_PWM    nullptr
 
 #define DIO8_PIN    PIND0
 #define DIO8_RPORT  PIND
 #define DIO8_WPORT  PORTD
 #define DIO8_DDR    DDRD
-#define DIO8_PWM    NULL
+#define DIO8_PWM    nullptr
 
 #define DIO9_PIN    PIND1
 #define DIO9_RPORT  PIND
 #define DIO9_WPORT  PORTD
 #define DIO9_DDR    DDRD
-#define DIO9_PWM    NULL
+#define DIO9_PWM    nullptr
 
 #define DIO10_PIN   PIND2
 #define DIO10_RPORT PIND
 #define DIO10_WPORT PORTD
 #define DIO10_DDR   DDRD
-#define DIO10_PWM   NULL
+#define DIO10_PWM   nullptr
 
 #define DIO11_PIN   PIND3
 #define DIO11_RPORT PIND
 #define DIO11_WPORT PORTD
 #define DIO11_DDR   DDRD
-#define DIO11_PWM   NULL
+#define DIO11_PWM   nullptr
 
 #define DIO12_PIN   PIND4
 #define DIO12_RPORT PIND
 #define DIO12_WPORT PORTD
 #define DIO12_DDR   DDRD
-#define DIO12_PWM   OCR1B
+#define DIO12_PWM   &OCR1B
 
 #define DIO13_PIN   PIND5
 #define DIO13_RPORT PIND
 #define DIO13_WPORT PORTD
 #define DIO13_DDR   DDRD
-#define DIO13_PWM   OCR1A
+#define DIO13_PWM   &OCR1A
 
 #define DIO14_PIN   PIND6
 #define DIO14_RPORT PIND
 #define DIO14_WPORT PORTD
 #define DIO14_DDR   DDRD
-#define DIO14_PWM   OCR2B
+#define DIO14_PWM   &OCR2B
 
 #define DIO15_PIN   PIND7
 #define DIO15_RPORT PIND
 #define DIO15_WPORT PORTD
 #define DIO15_DDR   DDRD
-#define DIO15_PWM   OCR2A
+#define DIO15_PWM   &OCR2A
 
 #define DIO16_PIN   PINC0
 #define DIO16_RPORT PINC
 #define DIO16_WPORT PORTC
 #define DIO16_DDR   DDRC
-#define DIO16_PWM   NULL
+#define DIO16_PWM   nullptr
 
 #define DIO17_PIN   PINC1
 #define DIO17_RPORT PINC
 #define DIO17_WPORT PORTC
 #define DIO17_DDR   DDRC
-#define DIO17_PWM   NULL
+#define DIO17_PWM   nullptr
 
 #define DIO18_PIN   PINC2
 #define DIO18_RPORT PINC
 #define DIO18_WPORT PORTC
 #define DIO18_DDR   DDRC
-#define DIO18_PWM   NULL
+#define DIO18_PWM   nullptr
 
 #define DIO19_PIN   PINC3
 #define DIO19_RPORT PINC
 #define DIO19_WPORT PORTC
 #define DIO19_DDR   DDRC
-#define DIO19_PWM   NULL
+#define DIO19_PWM   nullptr
 
 #define DIO20_PIN   PINC4
 #define DIO20_RPORT PINC
 #define DIO20_WPORT PORTC
 #define DIO20_DDR   DDRC
-#define DIO20_PWM   NULL
+#define DIO20_PWM   nullptr
 
 #define DIO21_PIN   PINC5
 #define DIO21_RPORT PINC
 #define DIO21_WPORT PORTC
 #define DIO21_DDR   DDRC
-#define DIO21_PWM   NULL
+#define DIO21_PWM   nullptr
 
 #define DIO22_PIN   PINC6
 #define DIO22_RPORT PINC
 #define DIO22_WPORT PORTC
 #define DIO22_DDR   DDRC
-#define DIO22_PWM   NULL
+#define DIO22_PWM   nullptr
 
 #define DIO23_PIN   PINC7
 #define DIO23_RPORT PINC
 #define DIO23_WPORT PORTC
 #define DIO23_DDR   DDRC
-#define DIO23_PWM   NULL
+#define DIO23_PWM   nullptr
 
 #define DIO24_PIN   PINA7
 #define DIO24_RPORT PINA
 #define DIO24_WPORT PORTA
 #define DIO24_DDR   DDRA
-#define DIO24_PWM   NULL
+#define DIO24_PWM   nullptr
 
 #define DIO25_PIN   PINA6
 #define DIO25_RPORT PINA
 #define DIO25_WPORT PORTA
 #define DIO25_DDR   DDRA
-#define DIO25_PWM   NULL
+#define DIO25_PWM   nullptr
 
 #define DIO26_PIN   PINA5
 #define DIO26_RPORT PINA
 #define DIO26_WPORT PORTA
 #define DIO26_DDR   DDRA
-#define DIO26_PWM   NULL
+#define DIO26_PWM   nullptr
 
 #define DIO27_PIN   PINA4
 #define DIO27_RPORT PINA
 #define DIO27_WPORT PORTA
 #define DIO27_DDR   DDRA
-#define DIO27_PWM   NULL
+#define DIO27_PWM   nullptr
 
 #define DIO28_PIN   PINA3
 #define DIO28_RPORT PINA
 #define DIO28_WPORT PORTA
 #define DIO28_DDR   DDRA
-#define DIO28_PWM   NULL
+#define DIO28_PWM   nullptr
 
 #define DIO29_PIN   PINA2
 #define DIO29_RPORT PINA
 #define DIO29_WPORT PORTA
 #define DIO29_DDR   DDRA
-#define DIO29_PWM   NULL
+#define DIO29_PWM   nullptr
 
 #define DIO30_PIN   PINA1
 #define DIO30_RPORT PINA
 #define DIO30_WPORT PORTA
 #define DIO30_DDR   DDRA
-#define DIO30_PWM   NULL
+#define DIO30_PWM   nullptr
 
 #define DIO31_PIN   PINA0
 #define DIO31_RPORT PINA
 #define DIO31_WPORT PORTA
 #define DIO31_DDR   DDRA
-#define DIO31_PWM   NULL
+#define DIO31_PWM   nullptr
 
 #define AIO0_PIN    PINA0
 #define AIO0_RPORT  PINA
 #define AIO0_WPORT  PORTA
 #define AIO0_DDR    DDRA
-#define AIO0_PWM    NULL
+#define AIO0_PWM    nullptr
 
 #define AIO1_PIN    PINA1
 #define AIO1_RPORT  PINA
 #define AIO1_WPORT  PORTA
 #define AIO1_DDR    DDRA
-#define AIO1_PWM    NULL
+#define AIO1_PWM    nullptr
 
 #define AIO2_PIN    PINA2
 #define AIO2_RPORT  PINA
 #define AIO2_WPORT  PORTA
 #define AIO2_DDR    DDRA
-#define AIO2_PWM    NULL
+#define AIO2_PWM    nullptr
 
 #define AIO3_PIN    PINA3
 #define AIO3_RPORT  PINA
 #define AIO3_WPORT  PORTA
 #define AIO3_DDR    DDRA
-#define AIO3_PWM    NULL
+#define AIO3_PWM    nullptr
 
 #define AIO4_PIN    PINA4
 #define AIO4_RPORT  PINA
 #define AIO4_WPORT  PORTA
 #define AIO4_DDR    DDRA
-#define AIO4_PWM    NULL
+#define AIO4_PWM    nullptr
 
 #define AIO5_PIN    PINA5
 #define AIO5_RPORT  PINA
 #define AIO5_WPORT  PORTA
 #define AIO5_DDR    DDRA
-#define AIO5_PWM    NULL
+#define AIO5_PWM    nullptr
 
 #define AIO6_PIN    PINA6
 #define AIO6_RPORT  PINA
 #define AIO6_WPORT  PORTA
 #define AIO6_DDR    DDRA
-#define AIO6_PWM    NULL
+#define AIO6_PWM    nullptr
 
 #define AIO7_PIN    PINA7
 #define AIO7_RPORT  PINA
 #define AIO7_WPORT  PORTA
 #define AIO7_DDR    DDRA
-#define AIO7_PWM    NULL
+#define AIO7_PWM    nullptr
 
 #undef PA0
 #define PA0_PIN     PINA0
 #define PA0_RPORT   PINA
 #define PA0_WPORT   PORTA
 #define PA0_DDR     DDRA
-#define PA0_PWM     NULL
+#define PA0_PWM     nullptr
 
 #undef PA1
 #define PA1_PIN     PINA1
 #define PA1_RPORT   PINA
 #define PA1_WPORT   PORTA
 #define PA1_DDR     DDRA
-#define PA1_PWM     NULL
+#define PA1_PWM     nullptr
 
 #undef PA2
 #define PA2_PIN     PINA2
 #define PA2_RPORT   PINA
 #define PA2_WPORT   PORTA
 #define PA2_DDR     DDRA
-#define PA2_PWM     NULL
+#define PA2_PWM     nullptr
 
 #undef PA3
 #define PA3_PIN     PINA3
 #define PA3_RPORT   PINA
 #define PA3_WPORT   PORTA
 #define PA3_DDR     DDRA
-#define PA3_PWM     NULL
+#define PA3_PWM     nullptr
 
 #undef PA4
 #define PA4_PIN     PINA4
 #define PA4_RPORT   PINA
 #define PA4_WPORT   PORTA
 #define PA4_DDR     DDRA
-#define PA4_PWM     NULL
+#define PA4_PWM     nullptr
 
 #undef PA5
 #define PA5_PIN     PINA5
 #define PA5_RPORT   PINA
 #define PA5_WPORT   PORTA
 #define PA5_DDR     DDRA
-#define PA5_PWM     NULL
+#define PA5_PWM     nullptr
 
 #undef PA6
 #define PA6_PIN     PINA6
 #define PA6_RPORT   PINA
 #define PA6_WPORT   PORTA
 #define PA6_DDR     DDRA
-#define PA6_PWM     NULL
+#define PA6_PWM     nullptr
 
 #undef PA7
 #define PA7_PIN     PINA7
 #define PA7_RPORT   PINA
 #define PA7_WPORT   PORTA
 #define PA7_DDR     DDRA
-#define PA7_PWM     NULL
+#define PA7_PWM     nullptr
 
 #undef PB0
 #define PB0_PIN     PINB0
 #define PB0_RPORT   PINB
 #define PB0_WPORT   PORTB
 #define PB0_DDR     DDRB
-#define PB0_PWM     NULL
+#define PB0_PWM     nullptr
 
 #undef PB1
 #define PB1_PIN     PINB1
 #define PB1_RPORT   PINB
 #define PB1_WPORT   PORTB
 #define PB1_DDR     DDRB
-#define PB1_PWM     NULL
+#define PB1_PWM     nullptr
 
 #undef PB2
 #define PB2_PIN     PINB2
 #define PB2_RPORT   PINB
 #define PB2_WPORT   PORTB
 #define PB2_DDR     DDRB
-#define PB2_PWM     NULL
+#define PB2_PWM     nullptr
 
 #undef PB3
 #define PB3_PIN     PINB3
 #define PB3_RPORT   PINB
 #define PB3_WPORT   PORTB
 #define PB3_DDR     DDRB
-#define PB3_PWM     OCR0A
+#define PB3_PWM     &OCR0A
 
 #undef PB4
 #define PB4_PIN     PINB4
 #define PB4_RPORT   PINB
 #define PB4_WPORT   PORTB
 #define PB4_DDR     DDRB
-#define PB4_PWM     OCR0B
+#define PB4_PWM     &OCR0B
 
 #undef PB5
 #define PB5_PIN     PINB5
 #define PB5_RPORT   PINB
 #define PB5_WPORT   PORTB
 #define PB5_DDR     DDRB
-#define PB5_PWM     NULL
+#define PB5_PWM     nullptr
 
 #undef PB6
 #define PB6_PIN     PINB6
 #define PB6_RPORT   PINB
 #define PB6_WPORT   PORTB
 #define PB6_DDR     DDRB
-#define PB6_PWM     NULL
+#define PB6_PWM     nullptr
 
 #undef PB7
 #define PB7_PIN     PINB7
 #define PB7_RPORT   PINB
 #define PB7_WPORT   PORTB
 #define PB7_DDR     DDRB
-#define PB7_PWM     NULL
+#define PB7_PWM     nullptr
 
 #undef PC0
 #define PC0_PIN     PINC0
 #define PC0_RPORT   PINC
 #define PC0_WPORT   PORTC
 #define PC0_DDR     DDRC
-#define PC0_PWM     NULL
+#define PC0_PWM     nullptr
 
 #undef PC1
 #define PC1_PIN     PINC1
 #define PC1_RPORT   PINC
 #define PC1_WPORT   PORTC
 #define PC1_DDR     DDRC
-#define PC1_PWM     NULL
+#define PC1_PWM     nullptr
 
 #undef PC2
 #define PC2_PIN     PINC2
 #define PC2_RPORT   PINC
 #define PC2_WPORT   PORTC
 #define PC2_DDR     DDRC
-#define PC2_PWM     NULL
+#define PC2_PWM     nullptr
 
 #undef PC3
 #define PC3_PIN     PINC3
 #define PC3_RPORT   PINC
 #define PC3_WPORT   PORTC
 #define PC3_DDR     DDRC
-#define PC3_PWM     NULL
+#define PC3_PWM     nullptr
 
 #undef PC4
 #define PC4_PIN     PINC4
 #define PC4_RPORT   PINC
 #define PC4_WPORT   PORTC
 #define PC4_DDR     DDRC
-#define PC4_PWM     NULL
+#define PC4_PWM     nullptr
 
 #undef PC5
 #define PC5_PIN     PINC5
 #define PC5_RPORT   PINC
 #define PC5_WPORT   PORTC
 #define PC5_DDR     DDRC
-#define PC5_PWM     NULL
+#define PC5_PWM     nullptr
 
 #undef PC6
 #define PC6_PIN     PINC6
 #define PC6_RPORT   PINC
 #define PC6_WPORT   PORTC
 #define PC6_DDR     DDRC
-#define PC6_PWM     NULL
+#define PC6_PWM     nullptr
 
 #undef PC7
 #define PC7_PIN     PINC7
 #define PC7_RPORT   PINC
 #define PC7_WPORT   PORTC
 #define PC7_DDR     DDRC
-#define PC7_PWM     NULL
+#define PC7_PWM     nullptr
 
 #undef PD0
 #define PD0_PIN     PIND0
 #define PD0_RPORT   PIND
 #define PD0_WPORT   PORTD
 #define PD0_DDR     DDRD
-#define PD0_PWM     NULL
+#define PD0_PWM     nullptr
 
 #undef PD1
 #define PD1_PIN     PIND1
 #define PD1_RPORT   PIND
 #define PD1_WPORT   PORTD
 #define PD1_DDR     DDRD
-#define PD1_PWM     NULL
+#define PD1_PWM     nullptr
 
 #undef PD2
 #define PD2_PIN     PIND2
 #define PD2_RPORT   PIND
 #define PD2_WPORT   PORTD
 #define PD2_DDR     DDRD
-#define PD2_PWM     NULL
+#define PD2_PWM     nullptr
 
 #undef PD3
 #define PD3_PIN     PIND3
 #define PD3_RPORT   PIND
 #define PD3_WPORT   PORTD
 #define PD3_DDR     DDRD
-#define PD3_PWM     NULL
+#define PD3_PWM     nullptr
 
 #undef PD4
 #define PD4_PIN     PIND4
 #define PD4_RPORT   PIND
 #define PD4_WPORT   PORTD
 #define PD4_DDR     DDRD
-#define PD4_PWM     NULL
+#define PD4_PWM     nullptr
 
 #undef PD5
 #define PD5_PIN     PIND5
 #define PD5_RPORT   PIND
 #define PD5_WPORT   PORTD
 #define PD5_DDR     DDRD
-#define PD5_PWM     NULL
+#define PD5_PWM     nullptr
 
 #undef PD6
 #define PD6_PIN     PIND6
 #define PD6_RPORT   PIND
 #define PD6_WPORT   PORTD
 #define PD6_DDR     DDRD
-#define PD6_PWM     OCR2B
+#define PD6_PWM     &OCR2B
 
 #undef PD7
 #define PD7_PIN     PIND7
 #define PD7_RPORT   PIND
 #define PD7_WPORT   PORTD
 #define PD7_DDR     DDRD
-#define PD7_PWM     OCR2A
+#define PD7_PWM     &OCR2A

--- a/Marlin/src/HAL/HAL_AVR/fastio_AT90USB.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_AT90USB.h
@@ -45,325 +45,325 @@
 #define DIO0_PIN    PIND0
 #define DIO0_RPORT  PIND
 #define DIO0_WPORT  PORTD
-#define DIO0_PWM    NULL
+#define DIO0_PWM    0
 #define DIO0_DDR    DDRD
 
 #define DIO1_PIN    PIND1
 #define DIO1_RPORT  PIND
 #define DIO1_WPORT  PORTD
-#define DIO1_PWM    NULL
+#define DIO1_PWM    0
 #define DIO1_DDR    DDRD
 
 #define DIO2_PIN    PIND2
 #define DIO2_RPORT  PIND
 #define DIO2_WPORT  PORTD
-#define DIO2_PWM    NULL
+#define DIO2_PWM    0
 #define DIO2_DDR    DDRD
 
 #define DIO3_PIN    PIND3
 #define DIO3_RPORT  PIND
 #define DIO3_WPORT  PORTD
-#define DIO3_PWM    NULL
+#define DIO3_PWM    0
 #define DIO3_DDR    DDRD
 
 #define DIO4_PIN    PIND4
 #define DIO4_RPORT  PIND
 #define DIO4_WPORT  PORTD
-#define DIO4_PWM    NULL
+#define DIO4_PWM    0
 #define DIO4_DDR    DDRD
 
 #define DIO5_PIN    PIND5
 #define DIO5_RPORT  PIND
 #define DIO5_WPORT  PORTD
-#define DIO5_PWM    NULL
+#define DIO5_PWM    0
 #define DIO5_DDR    DDRD
 
 #define DIO6_PIN    PIND6
 #define DIO6_RPORT  PIND
 #define DIO6_WPORT  PORTD
-#define DIO6_PWM    NULL
+#define DIO6_PWM    0
 #define DIO6_DDR    DDRD
 
 #define DIO7_PIN    PIND7
 #define DIO7_RPORT  PIND
 #define DIO7_WPORT  PORTD
-#define DIO7_PWM    NULL
+#define DIO7_PWM    0
 #define DIO7_DDR    DDRD
 
 #define DIO8_PIN    PINE0
 #define DIO8_RPORT  PINE
 #define DIO8_WPORT  PORTE
-#define DIO8_PWM    NULL
+#define DIO8_PWM    0
 #define DIO8_DDR    DDRE
 
 #define DIO9_PIN    PINE1
 #define DIO9_RPORT  PINE
 #define DIO9_WPORT  PORTE
-#define DIO9_PWM    NULL
+#define DIO9_PWM    0
 #define DIO9_DDR    DDRE
 
 #define DIO10_PIN   PINC0
 #define DIO10_RPORT PINC
 #define DIO10_WPORT PORTC
-#define DIO10_PWM   NULL
+#define DIO10_PWM   0
 #define DIO10_DDR   DDRC
 
 #define DIO11_PIN   PINC1
 #define DIO11_RPORT PINC
 #define DIO11_WPORT PORTC
-#define DIO11_PWM   NULL
+#define DIO11_PWM   0
 #define DIO11_DDR   DDRC
 
 #define DIO12_PIN   PINC2
 #define DIO12_RPORT PINC
 #define DIO12_WPORT PORTC
-#define DIO12_PWM   NULL
+#define DIO12_PWM   0
 #define DIO12_DDR   DDRC
 
 #define DIO13_PIN   PINC3
 #define DIO13_RPORT PINC
 #define DIO13_WPORT PORTC
-#define DIO13_PWM   NULL
+#define DIO13_PWM   0
 #define DIO13_DDR   DDRC
 
 #define DIO14_PIN   PINC4
 #define DIO14_RPORT PINC
 #define DIO14_WPORT PORTC
-#define DIO14_PWM   NULL
+#define DIO14_PWM   0 // OC3C
 #define DIO14_DDR   DDRC
 
 #define DIO15_PIN   PINC5
 #define DIO15_RPORT PINC
 #define DIO15_WPORT PORTC
-#define DIO15_PWM   NULL
+#define DIO15_PWM   0 // OC3B
 #define DIO15_DDR   DDRC
 
 #define DIO16_PIN   PINC6
 #define DIO16_RPORT PINC
 #define DIO16_WPORT PORTC
-#define DIO16_PWM   NULL
+#define DIO16_PWM   0 // OC3A
 #define DIO16_DDR   DDRC
 
 #define DIO17_PIN   PINC7
 #define DIO17_RPORT PINC
 #define DIO17_WPORT PORTC
-#define DIO17_PWM   NULL
+#define DIO17_PWM   0
 #define DIO17_DDR   DDRC
 
 #define DIO18_PIN   PINE6
 #define DIO18_RPORT PINE
 #define DIO18_WPORT PORTE
-#define DIO18_PWM   NULL
+#define DIO18_PWM   0
 #define DIO18_DDR   DDRE
 
 #define DIO19_PIN   PINE7
 #define DIO19_RPORT PINE
 #define DIO19_WPORT PORTE
-#define DIO19_PWM   NULL
+#define DIO19_PWM   0
 #define DIO19_DDR   DDRE
 
 #define DIO20_PIN   PINB0
 #define DIO20_RPORT PINB
 #define DIO20_WPORT PORTB
-#define DIO20_PWM   NULL
+#define DIO20_PWM   0
 #define DIO20_DDR   DDRB
 
 #define DIO21_PIN   PINB1
 #define DIO21_RPORT PINB
 #define DIO21_WPORT PORTB
-#define DIO21_PWM   NULL
+#define DIO21_PWM   0
 #define DIO21_DDR   DDRB
 
 #define DIO22_PIN   PINB2
 #define DIO22_RPORT PINB
 #define DIO22_WPORT PORTB
-#define DIO22_PWM   NULL
+#define DIO22_PWM   0
 #define DIO22_DDR   DDRB
 
 #define DIO23_PIN   PINB3
 #define DIO23_RPORT PINB
 #define DIO23_WPORT PORTB
-#define DIO23_PWM   NULL
+#define DIO23_PWM   0
 #define DIO23_DDR   DDRB
 
 #define DIO24_PIN   PINB4
 #define DIO24_RPORT PINB
 #define DIO24_WPORT PORTB
-#define DIO24_PWM   NULL
+#define DIO24_PWM   0 // OC2A
 #define DIO24_DDR   DDRB
 
 #define DIO25_PIN   PINB5
 #define DIO25_RPORT PINB
 #define DIO25_WPORT PORTB
-#define DIO25_PWM   NULL
+#define DIO25_PWM   0 // OC1A
 #define DIO25_DDR   DDRB
 
 #define DIO26_PIN   PINB6
 #define DIO26_RPORT PINB
 #define DIO26_WPORT PORTB
-#define DIO26_PWM   NULL
+#define DIO26_PWM   0 // OC1B
 #define DIO26_DDR   DDRB
 
 #define DIO27_PIN   PINB7
 #define DIO27_RPORT PINB
 #define DIO27_WPORT PORTB
-#define DIO27_PWM   NULL
+#define DIO27_PWM   0 // OC1C
 #define DIO27_DDR   DDRB
 
 #define DIO28_PIN   PINA0
 #define DIO28_RPORT PINA
 #define DIO28_WPORT PORTA
-#define DIO28_PWM   NULL
+#define DIO28_PWM   0
 #define DIO28_DDR   DDRA
 
 #define DIO29_PIN   PINA1
 #define DIO29_RPORT PINA
 #define DIO29_WPORT PORTA
-#define DIO29_PWM   NULL
+#define DIO29_PWM   0
 #define DIO29_DDR   DDRA
 
 #define DIO30_PIN   PINA2
 #define DIO30_RPORT PINA
 #define DIO30_WPORT PORTA
-#define DIO30_PWM   NULL
+#define DIO30_PWM   0
 #define DIO30_DDR   DDRA
 
 #define DIO31_PIN   PINA3
 #define DIO31_RPORT PINA
 #define DIO31_WPORT PORTA
-#define DIO31_PWM   NULL
+#define DIO31_PWM   0
 #define DIO31_DDR   DDRA
 
 #define DIO32_PIN   PINA4
 #define DIO32_RPORT PINA
 #define DIO32_WPORT PORTA
-#define DIO32_PWM   NULL
+#define DIO32_PWM   0
 #define DIO32_DDR   DDRA
 
 #define DIO33_PIN   PINA5
 #define DIO33_RPORT PINA
 #define DIO33_WPORT PORTA
-#define DIO33_PWM   NULL
+#define DIO33_PWM   0
 #define DIO33_DDR   DDRA
 
 #define DIO34_PIN   PINA6
 #define DIO34_RPORT PINA
 #define DIO34_WPORT PORTA
-#define DIO34_PWM   NULL
+#define DIO34_PWM   0
 #define DIO34_DDR   DDRA
 
 #define DIO35_PIN   PINA7
 #define DIO35_RPORT PINA
 #define DIO35_WPORT PORTA
-#define DIO35_PWM   NULL
+#define DIO35_PWM   0
 #define DIO35_DDR   DDRA
 
 #define DIO36_PIN   PINE4
 #define DIO36_RPORT PINE
 #define DIO36_WPORT PORTE
-#define DIO36_PWM   NULL
+#define DIO36_PWM   0
 #define DIO36_DDR   DDRE
 
 #define DIO37_PIN   PINE5
 #define DIO37_RPORT PINE
 #define DIO37_WPORT PORTE
-#define DIO37_PWM   NULL
+#define DIO37_PWM   0
 #define DIO37_DDR   DDRE
 
 #define DIO38_PIN   PINF0
 #define DIO38_RPORT PINF
 #define DIO38_WPORT PORTF
-#define DIO38_PWM   NULL
+#define DIO38_PWM   0
 #define DIO38_DDR   DDRF
 
 #define DIO39_PIN   PINF1
 #define DIO39_RPORT PINF
 #define DIO39_WPORT PORTF
-#define DIO39_PWM   NULL
+#define DIO39_PWM   0
 #define DIO39_DDR   DDRF
 
 #define DIO40_PIN   PINF2
 #define DIO40_RPORT PINF
 #define DIO40_WPORT PORTF
-#define DIO40_PWM   NULL
+#define DIO40_PWM   0
 #define DIO40_DDR   DDRF
 
 #define DIO41_PIN   PINF3
 #define DIO41_RPORT PINF
 #define DIO41_WPORT PORTF
-#define DIO41_PWM   NULL
+#define DIO41_PWM   0
 #define DIO41_DDR   DDRF
 
 #define DIO42_PIN   PINF4
 #define DIO42_RPORT PINF
 #define DIO42_WPORT PORTF
-#define DIO42_PWM   NULL
+#define DIO42_PWM   0
 #define DIO42_DDR   DDRF
 
 #define DIO43_PIN   PINF5
 #define DIO43_RPORT PINF
 #define DIO43_WPORT PORTF
-#define DIO43_PWM   NULL
+#define DIO43_PWM   0
 #define DIO43_DDR   DDRF
 
 #define DIO44_PIN   PINF6
 #define DIO44_RPORT PINF
 #define DIO44_WPORT PORTF
-#define DIO44_PWM   NULL
+#define DIO44_PWM   0
 #define DIO44_DDR   DDRF
 
 #define DIO45_PIN   PINF7
 #define DIO45_RPORT PINF
 #define DIO45_WPORT PORTF
-#define DIO45_PWM   NULL
+#define DIO45_PWM   0
 #define DIO45_DDR   DDRF
 
 #define AIO0_PIN    PINF0
 #define AIO0_RPORT  PINF
 #define AIO0_WPORT  PORTF
-#define AIO0_PWM    NULL
+#define AIO0_PWM    0
 #define AIO0_DDR    DDRF
 
 #define AIO1_PIN    PINF1
 #define AIO1_RPORT  PINF
 #define AIO1_WPORT  PORTF
-#define AIO1_PWM    NULL
+#define AIO1_PWM    0
 #define AIO1_DDR    DDRF
 
 #define AIO2_PIN    PINF2
 #define AIO2_RPORT  PINF
 #define AIO2_WPORT  PORTF
-#define AIO2_PWM    NULL
+#define AIO2_PWM    0
 #define AIO2_DDR    DDRF
 
 #define AIO3_PIN    PINF3
 #define AIO3_RPORT  PINF
 #define AIO3_WPORT  PORTF
-#define AIO3_PWM    NULL
+#define AIO3_PWM    0
 #define AIO3_DDR    DDRF
 
 #define AIO4_PIN    PINF4
 #define AIO4_RPORT  PINF
 #define AIO4_WPORT  PORTF
-#define AIO4_PWM    NULL
+#define AIO4_PWM    0
 #define AIO4_DDR    DDRF
 
 #define AIO5_PIN    PINF5
 #define AIO5_RPORT  PINF
 #define AIO5_WPORT  PORTF
-#define AIO5_PWM    NULL
+#define AIO5_PWM    0
 #define AIO5_DDR    DDRF
 
 #define AIO6_PIN    PINF6
 #define AIO6_RPORT  PINF
 #define AIO6_WPORT  PORTF
-#define AIO6_PWM    NULL
+#define AIO6_PWM    0
 #define AIO6_DDR    DDRF
 
 #define AIO7_PIN    PINF7
 #define AIO7_RPORT  PINF
 #define AIO7_WPORT  PORTF
-#define AIO7_PWM    NULL
+#define AIO7_PWM    0
 #define AIO7_DDR    DDRF
 
 //-- Begin not supported by Teensyduino
@@ -371,13 +371,13 @@
 #define DIO46_PIN   PINE2
 #define DIO46_RPORT PINE
 #define DIO46_WPORT PORTE
-#define DIO46_PWM   NULL
+#define DIO46_PWM   0
 #define DIO46_DDR   DDRE
 
 #define DIO47_PIN   PINE3
 #define DIO47_RPORT PINE
 #define DIO47_WPORT PORTE
-#define DIO47_PWM   NULL
+#define DIO47_PWM   0
 #define DIO47_DDR   DDRE
 
 #define TEENSY_E2   46
@@ -389,300 +389,300 @@
 #define PA0_PIN     PINA0
 #define PA0_RPORT   PINA
 #define PA0_WPORT   PORTA
-#define PA0_PWM     NULL
+#define PA0_PWM     0
 #define PA0_DDR     DDRA
 #undef PA1
 #define PA1_PIN     PINA1
 #define PA1_RPORT   PINA
 #define PA1_WPORT   PORTA
-#define PA1_PWM     NULL
+#define PA1_PWM     0
 #define PA1_DDR     DDRA
 #undef PA2
 #define PA2_PIN     PINA2
 #define PA2_RPORT   PINA
 #define PA2_WPORT   PORTA
-#define PA2_PWM     NULL
+#define PA2_PWM     0
 #define PA2_DDR     DDRA
 #undef PA3
 #define PA3_PIN     PINA3
 #define PA3_RPORT   PINA
 #define PA3_WPORT   PORTA
-#define PA3_PWM     NULL
+#define PA3_PWM     0
 #define PA3_DDR     DDRA
 #undef PA4
 #define PA4_PIN     PINA4
 #define PA4_RPORT   PINA
 #define PA4_WPORT   PORTA
-#define PA4_PWM     NULL
+#define PA4_PWM     0
 #define PA4_DDR     DDRA
 #undef PA5
 #define PA5_PIN     PINA5
 #define PA5_RPORT   PINA
 #define PA5_WPORT   PORTA
-#define PA5_PWM     NULL
+#define PA5_PWM     0
 #define PA5_DDR     DDRA
 #undef PA6
 #define PA6_PIN     PINA6
 #define PA6_RPORT   PINA
 #define PA6_WPORT   PORTA
-#define PA6_PWM     NULL
+#define PA6_PWM     0
 #define PA6_DDR     DDRA
 #undef PA7
 #define PA7_PIN     PINA7
 #define PA7_RPORT   PINA
 #define PA7_WPORT   PORTA
-#define PA7_PWM     NULL
+#define PA7_PWM     0
 #define PA7_DDR     DDRA
 
 #undef PB0
 #define PB0_PIN     PINB0
 #define PB0_RPORT   PINB
 #define PB0_WPORT   PORTB
-#define PB0_PWM     NULL
+#define PB0_PWM     0
 #define PB0_DDR     DDRB
 #undef PB1
 #define PB1_PIN     PINB1
 #define PB1_RPORT   PINB
 #define PB1_WPORT   PORTB
-#define PB1_PWM     NULL
+#define PB1_PWM     0
 #define PB1_DDR     DDRB
 #undef PB2
 #define PB2_PIN     PINB2
 #define PB2_RPORT   PINB
 #define PB2_WPORT   PORTB
-#define PB2_PWM     NULL
+#define PB2_PWM     0
 #define PB2_DDR     DDRB
 #undef PB3
 #define PB3_PIN     PINB3
 #define PB3_RPORT   PINB
 #define PB3_WPORT   PORTB
-#define PB3_PWM     NULL
+#define PB3_PWM     0
 #define PB3_DDR     DDRB
 #undef PB4
 #define PB4_PIN     PINB4
 #define PB4_RPORT   PINB
 #define PB4_WPORT   PORTB
-#define PB4_PWM     NULL
+#define PB4_PWM     0
 #define PB4_DDR     DDRB
 #undef PB5
 #define PB5_PIN     PINB5
 #define PB5_RPORT   PINB
 #define PB5_WPORT   PORTB
-#define PB5_PWM     NULL
+#define PB5_PWM     0
 #define PB5_DDR     DDRB
 #undef PB6
 #define PB6_PIN     PINB6
 #define PB6_RPORT   PINB
 #define PB6_WPORT   PORTB
-#define PB6_PWM     NULL
+#define PB6_PWM     0
 #define PB6_DDR     DDRB
 #undef PB7
 #define PB7_PIN     PINB7
 #define PB7_RPORT   PINB
 #define PB7_WPORT   PORTB
-#define PB7_PWM     NULL
+#define PB7_PWM     0
 #define PB7_DDR     DDRB
 
 #undef PC0
 #define PC0_PIN     PINC0
 #define PC0_RPORT   PINC
 #define PC0_WPORT   PORTC
-#define PC0_PWM     NULL
+#define PC0_PWM     0
 #define PC0_DDR     DDRC
 #undef PC1
 #define PC1_PIN     PINC1
 #define PC1_RPORT   PINC
 #define PC1_WPORT   PORTC
-#define PC1_PWM     NULL
+#define PC1_PWM     0
 #define PC1_DDR     DDRC
 #undef PC2
 #define PC2_PIN     PINC2
 #define PC2_RPORT   PINC
 #define PC2_WPORT   PORTC
-#define PC2_PWM     NULL
+#define PC2_PWM     0
 #define PC2_DDR     DDRC
 #undef PC3
 #define PC3_PIN     PINC3
 #define PC3_RPORT   PINC
 #define PC3_WPORT   PORTC
-#define PC3_PWM     NULL
+#define PC3_PWM     0
 #define PC3_DDR     DDRC
 #undef PC4
 #define PC4_PIN     PINC4
 #define PC4_RPORT   PINC
 #define PC4_WPORT   PORTC
-#define PC4_PWM     NULL
+#define PC4_PWM     0
 #define PC4_DDR     DDRC
 #undef PC5
 #define PC5_PIN     PINC5
 #define PC5_RPORT   PINC
 #define PC5_WPORT   PORTC
-#define PC5_PWM     NULL
+#define PC5_PWM     0
 #define PC5_DDR     DDRC
 #undef PC6
 #define PC6_PIN     PINC6
 #define PC6_RPORT   PINC
 #define PC6_WPORT   PORTC
-#define PC6_PWM     NULL
+#define PC6_PWM     0
 #define PC6_DDR     DDRC
 #undef PC7
 #define PC7_PIN     PINC7
 #define PC7_RPORT   PINC
 #define PC7_WPORT   PORTC
-#define PC7_PWM     NULL
+#define PC7_PWM     0
 #define PC7_DDR     DDRC
 
 #undef PD0
 #define PD0_PIN     PIND0
 #define PD0_RPORT   PIND
 #define PD0_WPORT   PORTD
-#define PD0_PWM     NULL
+#define PD0_PWM     0 // OC0B
 #define PD0_DDR     DDRD
 #undef PD1
 #define PD1_PIN     PIND1
 #define PD1_RPORT   PIND
 #define PD1_WPORT   PORTD
-#define PD1_PWM     NULL
+#define PD1_PWM     0 // OC2B
 #define PD1_DDR     DDRD
 #undef PD2
 #define PD2_PIN     PIND2
 #define PD2_RPORT   PIND
 #define PD2_WPORT   PORTD
-#define PD2_PWM     NULL
+#define PD2_PWM     0
 #define PD2_DDR     DDRD
 #undef PD3
 #define PD3_PIN     PIND3
 #define PD3_RPORT   PIND
 #define PD3_WPORT   PORTD
-#define PD3_PWM     NULL
+#define PD3_PWM     0
 #define PD3_DDR     DDRD
 #undef PD4
 #define PD4_PIN     PIND4
 #define PD4_RPORT   PIND
 #define PD4_WPORT   PORTD
-#define PD4_PWM     NULL
+#define PD4_PWM     0
 #define PD4_DDR     DDRD
 #undef PD5
 #define PD5_PIN     PIND5
 #define PD5_RPORT   PIND
 #define PD5_WPORT   PORTD
-#define PD5_PWM     NULL
+#define PD5_PWM     0
 #define PD5_DDR     DDRD
 #undef PD6
 #define PD6_PIN     PIND6
 #define PD6_RPORT   PIND
 #define PD6_WPORT   PORTD
-#define PD6_PWM     NULL
+#define PD6_PWM     0
 #define PD6_DDR     DDRD
 #undef PD7
 #define PD7_PIN     PIND7
 #define PD7_RPORT   PIND
 #define PD7_WPORT   PORTD
-#define PD7_PWM     NULL
+#define PD7_PWM     0
 #define PD7_DDR     DDRD
 
 #undef PE0
 #define PE0_PIN     PINE0
 #define PE0_RPORT   PINE
 #define PE0_WPORT   PORTE
-#define PE0_PWM     NULL
+#define PE0_PWM     0
 #define PE0_DDR     DDRE
 #undef PE1
 #define PE1_PIN     PINE1
 #define PE1_RPORT   PINE
 #define PE1_WPORT   PORTE
-#define PE1_PWM     NULL
+#define PE1_PWM     0
 #define PE1_DDR     DDRE
 #undef PE2
 #define PE2_PIN     PINE2
 #define PE2_RPORT   PINE
 #define PE2_WPORT   PORTE
-#define PE2_PWM     NULL
+#define PE2_PWM     0
 #define PE2_DDR     DDRE
 #undef PE3
 #define PE3_PIN     PINE3
 #define PE3_RPORT   PINE
 #define PE3_WPORT   PORTE
-#define PE3_PWM     NULL
+#define PE3_PWM     0
 #define PE3_DDR     DDRE
 #undef PE4
 #define PE4_PIN     PINE4
 #define PE4_RPORT   PINE
 #define PE4_WPORT   PORTE
-#define PE4_PWM     NULL
+#define PE4_PWM     0
 #define PE4_DDR     DDRE
 #undef PE5
 #define PE5_PIN     PINE5
 #define PE5_RPORT   PINE
 #define PE5_WPORT   PORTE
-#define PE5_PWM     NULL
+#define PE5_PWM     0
 #define PE5_DDR     DDRE
 #undef PE6
 #define PE6_PIN     PINE6
 #define PE6_RPORT   PINE
 #define PE6_WPORT   PORTE
-#define PE6_PWM     NULL
+#define PE6_PWM     0
 #define PE6_DDR     DDRE
 #undef PE7
 #define PE7_PIN     PINE7
 #define PE7_RPORT   PINE
 #define PE7_WPORT   PORTE
-#define PE7_PWM     NULL
+#define PE7_PWM     0
 #define PE7_DDR     DDRE
 
 #undef PF0
 #define PF0_PIN     PINF0
 #define PF0_RPORT   PINF
 #define PF0_WPORT   PORTF
-#define PF0_PWM     NULL
+#define PF0_PWM     0
 #define PF0_DDR     DDRF
 #undef PF1
 #define PF1_PIN     PINF1
 #define PF1_RPORT   PINF
 #define PF1_WPORT   PORTF
-#define PF1_PWM     NULL
+#define PF1_PWM     0
 #define PF1_DDR     DDRF
 #undef PF2
 #define PF2_PIN     PINF2
 #define PF2_RPORT   PINF
 #define PF2_WPORT   PORTF
-#define PF2_PWM     NULL
+#define PF2_PWM     0
 #define PF2_DDR     DDRF
 #undef PF3
 #define PF3_PIN     PINF3
 #define PF3_RPORT   PINF
 #define PF3_WPORT   PORTF
-#define PF3_PWM     NULL
+#define PF3_PWM     0
 #define PF3_DDR     DDRF
 #undef PF4
 #define PF4_PIN     PINF4
 #define PF4_RPORT   PINF
 #define PF4_WPORT   PORTF
-#define PF4_PWM     NULL
+#define PF4_PWM     0
 #define PF4_DDR     DDRF
 #undef PF5
 #define PF5_PIN     PINF5
 #define PF5_RPORT   PINF
 #define PF5_WPORT   PORTF
-#define PF5_PWM     NULL
+#define PF5_PWM     0
 #define PF5_DDR     DDRF
 #undef PF6
 #define PF6_PIN     PINF6
 #define PF6_RPORT   PINF
 #define PF6_WPORT   PORTF
-#define PF6_PWM     NULL
+#define PF6_PWM     0
 #define PF6_DDR     DDRF
 #undef PF7
 #define PF7_PIN     PINF7
 #define PF7_RPORT   PINF
 #define PF7_WPORT   PORTF
-#define PF7_PWM     NULL
+#define PF7_PWM     0
 #define PF7_DDR     DDRF
 
 
 /**
- *  some of the pin mapping functions of the Teensduino extension to the Arduino IDE
- *  do not function the same as the other Arduino extensions
+ * Some of the pin mapping functions of the Teensduino extension to the Arduino IDE
+ * do not function the same as the other Arduino extensions.
  */
 
 //digitalPinToTimer(pin) function works like Arduino but Timers are not defined

--- a/Marlin/src/HAL/HAL_AVR/fastio_AVR.h
+++ b/Marlin/src/HAL/HAL_AVR/fastio_AVR.h
@@ -83,7 +83,7 @@
 
 #define _IS_INPUT(IO)        !TEST(DIO ## IO ## _DDR, DIO ## IO ## _PIN)
 #define _IS_OUTPUT(IO)        TEST(DIO ## IO ## _DDR, DIO ## IO ## _PIN)
-#define _HAS_TIMER(IO)        DIO ## IO ## _PWM
+#define _HAS_TIMER(IO)        bool(DIO ## IO ## _PWM)
 
 // digitalRead/Write wrappers
 #ifdef FASTIO_EXT_START

--- a/Marlin/src/HAL/HAL_DUE/G2_pins.h
+++ b/Marlin/src/HAL/HAL_DUE/G2_pins.h
@@ -248,7 +248,7 @@ const G2_PinDescription G2_g_APinDescription[] = {
   { PIOB, PIO_PB15A_CANRX1|PIO_PB14A_CANTX1, ID_PIOB, PIO_PERIPH_A, PIO_DEFAULT, (PIN_ATTR_DIGITAL|PIN_ATTR_COMBO), NO_ADC, NO_ADC, NOT_ON_PWM,  NOT_ON_TIMER },
 
   // END
-  { NULL, 0, 0, PIO_NOT_A_PIN, PIO_DEFAULT, 0, NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }
+  { nullptr, 0, 0, PIO_NOT_A_PIN, PIO_DEFAULT, 0, NO_ADC, NO_ADC, NOT_ON_PWM, NOT_ON_TIMER }
 };
 
 // This section replaces the FASTIO definitions of pins 34-41

--- a/Marlin/src/HAL/HAL_DUE/InterruptVectors_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/InterruptVectors_Due.cpp
@@ -41,7 +41,7 @@
    practice, we need alignment to 256 bytes to make this work in all
    cases */
 __attribute__ ((aligned(256)))
-static DeviceVectors ram_tab = { NULL };
+static DeviceVectors ram_tab = { nullptr };
 
 /**
  * This function checks if the exception/interrupt table is already in SRAM or not.

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
@@ -64,8 +64,8 @@ static timg_dev_t *TG[2] = {&TIMERG0, &TIMERG1};
 const tTimerConfig TimerConfig [NUM_HARDWARE_TIMERS] = {
   { TIMER_GROUP_0, TIMER_0, STEPPER_TIMER_PRESCALE, stepTC_Handler }, // 0 - Stepper
   { TIMER_GROUP_0, TIMER_1,    TEMP_TIMER_PRESCALE, tempTC_Handler }, // 1 - Temperature
-  { TIMER_GROUP_1, TIMER_0,                      1, NULL }, // 2
-  { TIMER_GROUP_1, TIMER_1,                      1, NULL }, // 3
+  { TIMER_GROUP_1, TIMER_0,                      1, nullptr }, // 2
+  { TIMER_GROUP_1, TIMER_1,                      1, nullptr }, // 3
 };
 
 // --------------------------------------------------------------------------
@@ -132,7 +132,7 @@ void HAL_timer_start(const uint8_t timer_num, uint32_t frequency) {
   timer_enable_intr(timer.group, timer.idx);
 
   // TODO need to deal with timer_group1_isr
-  timer_isr_register(timer.group, timer.idx, timer_group0_isr, (void*)timer.idx, NULL, NULL);
+  timer_isr_register(timer.group, timer.idx, timer_group0_isr, (void*)timer.idx, ESP_INTR_FLAG_INTRDISABLED, nullptr);
 
   timer_start(timer.group, timer.idx);
 }

--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -183,22 +183,22 @@ int i2s_init() {
 
   // Allocate the array of pointers to the buffers
   dma.buffers = (uint32_t **)malloc(sizeof(uint32_t*) * DMA_BUF_COUNT);
-  if (dma.buffers == NULL) return -1;
+  if (dma.buffers == nullptr) return -1;
 
   // Allocate each buffer that can be used by the DMA controller
   for (int buf_idx = 0; buf_idx < DMA_BUF_COUNT; buf_idx++) {
     dma.buffers[buf_idx] = (uint32_t*) heap_caps_calloc(1, DMA_BUF_LEN, MALLOC_CAP_DMA);
-    if (dma.buffers[buf_idx] == NULL) return -1;
+    if (dma.buffers[buf_idx] == nullptr) return -1;
   }
 
   // Allocate the array of DMA descriptors
   dma.desc = (lldesc_t**) malloc(sizeof(lldesc_t*) * DMA_BUF_COUNT);
-  if (dma.desc == NULL) return -1;
+  if (dma.desc == nullptr) return -1;
 
   // Allocate each DMA descriptor that will be used by the DMA controller
   for (int buf_idx = 0; buf_idx < DMA_BUF_COUNT; buf_idx++) {
     dma.desc[buf_idx] = (lldesc_t*) heap_caps_malloc(sizeof(lldesc_t), MALLOC_CAP_DMA);
-    if (dma.desc[buf_idx] == NULL) return -1;
+    if (dma.desc[buf_idx] == nullptr) return -1;
   }
 
   // Initialize
@@ -297,11 +297,11 @@ int i2s_init() {
 
   // Allocate and Enable the I2S interrupt
   intr_handle_t i2s_isr_handle;
-  esp_intr_alloc(ETS_I2S0_INTR_SOURCE, 0, i2s_intr_handler_default, NULL, &i2s_isr_handle);
+  esp_intr_alloc(ETS_I2S0_INTR_SOURCE, 0, i2s_intr_handler_default, nullptr, &i2s_isr_handle);
   esp_intr_enable(i2s_isr_handle);
 
   // Create the task that will feed the buffer
-  xTaskCreate(stepperTask, "StepperTask", 10000, NULL, 1, NULL);
+  xTaskCreate(stepperTask, "StepperTask", 10000, nullptr, 1, nullptr);
 
   // Route the i2s pins to the appropriate GPIO
   gpio_matrix_out_check(I2S_DATA, I2S0O_DATA_OUT23_IDX, 0, 0);

--- a/Marlin/src/HAL/HAL_LINUX/hardware/Timer.cpp
+++ b/Marlin/src/HAL/HAL_LINUX/hardware/Timer.cpp
@@ -51,7 +51,7 @@ void Timer::init(uint32_t sig_id, uint32_t sim_freq, callback_fn* fn) {
   sa.sa_flags = SA_SIGINFO;
   sa.sa_sigaction = Timer::handler;
   sigemptyset(&sa.sa_mask);
-  if (sigaction(SIGRTMIN, &sa, NULL) == -1) {
+  if (sigaction(SIGRTMIN, &sa, nullptr) == -1) {
     return; // todo: handle error
   }
 
@@ -74,7 +74,7 @@ void Timer::start(uint32_t frequency) {
 }
 
 void Timer::enable() {
-  if (sigprocmask(SIG_UNBLOCK, &mask, NULL) == -1) {
+  if (sigprocmask(SIG_UNBLOCK, &mask, nullptr) == -1) {
     return; // todo: handle error
   }
   active = true;
@@ -82,7 +82,7 @@ void Timer::enable() {
 }
 
 void Timer::disable() {
-  if (sigprocmask(SIG_SETMASK, &mask, NULL) == -1) {
+  if (sigprocmask(SIG_SETMASK, &mask, nullptr) == -1) {
     return; // todo: handle error
   }
   active = false;
@@ -102,7 +102,7 @@ void Timer::setCompare(uint32_t compare) {
   its.it_interval.tv_sec = its.it_value.tv_sec;
   its.it_interval.tv_nsec = its.it_value.tv_nsec;
 
-  if (timer_settime(timerid, 0, &its, NULL) == -1) {
+  if (timer_settime(timerid, 0, &its, nullptr) == -1) {
     printf("timer(%ld) failed, compare: %d(%ld)\n", getID(), compare, its.it_value.tv_nsec);
     return; // todo: handle error
   }

--- a/Marlin/src/HAL/HAL_LINUX/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_LINUX/persistent_store_impl.cpp
@@ -35,7 +35,7 @@ char filename[] = "eeprom.dat";
 bool PersistentStore::access_start() {
   const char eeprom_erase_value = 0xFF;
   FILE * eeprom_file = fopen(filename, "rb");
-  if (eeprom_file == NULL) return false;
+  if (eeprom_file == nullptr) return false;
 
   fseek(eeprom_file, 0L, SEEK_END);
   std::size_t file_size = ftell(eeprom_file);
@@ -54,7 +54,7 @@ bool PersistentStore::access_start() {
 
 bool PersistentStore::access_finish() {
   FILE * eeprom_file = fopen(filename, "wb");
-  if (eeprom_file == NULL) return false;
+  if (eeprom_file == nullptr) return false;
   fwrite(buffer, sizeof(uint8_t), sizeof(buffer), eeprom_file);
   fclose(eeprom_file);
   return true;

--- a/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
@@ -270,7 +270,7 @@ void HAL_adc_init(void) {
   adc.calibrate();
   adc.setSampleRate(ADC_SMPR_41_5); // ?
   adc.setPins(adc_pins, ADC_PIN_COUNT);
-  adc.setDMA(HAL_adc_results, (uint16_t)ADC_PIN_COUNT, (uint32_t)(DMA_MINC_MODE | DMA_CIRC_MODE), (void (*)())NULL);
+  adc.setDMA(HAL_adc_results, (uint16_t)ADC_PIN_COUNT, (uint32_t)(DMA_MINC_MODE | DMA_CIRC_MODE), nullptr);
   adc.setScanMode();
   adc.setContinuous();
   adc.startConversion();

--- a/Marlin/src/HAL/HAL_STM32F1/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.h
@@ -129,7 +129,7 @@ void HAL_init();
 #endif
 
 #ifndef digitalPinHasPWM
-  #define digitalPinHasPWM(P) (PIN_MAP[P].timer_device != NULL)
+  #define digitalPinHasPWM(P) (PIN_MAP[P].timer_device != nullptr)
 #endif
 
 #define CRITICAL_SECTION_START  uint32_t primask = __get_primask(); (void)__iCliRetVal()

--- a/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
@@ -47,7 +47,7 @@
 
 #define IS_INPUT(IO)          (_GET_MODE(IO) == GPIO_INPUT_FLOATING || _GET_MODE(IO) == GPIO_INPUT_ANALOG || _GET_MODE(IO) == GPIO_INPUT_PU || _GET_MODE(IO) == GPIO_INPUT_PD)
 #define IS_OUTPUT(IO)         (_GET_MODE(IO) == GPIO_OUTPUT_PP)
-#define HAS_TIMER(IO)         (PIN_MAP[IO].timer_device != NULL)
+#define HAS_TIMER(IO)         (PIN_MAP[IO].timer_device != nullptr)
 
 #define PWM_PIN(P)              HAS_TIMER(P)
 #define USEABLE_HARDWARE_PWM(P) PWM_PIN(P)

--- a/Marlin/src/HAL/HAL_STM32F1/u8g_com_stm32duino_fsmc.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/u8g_com_stm32duino_fsmc.cpp
@@ -67,7 +67,7 @@ uint8_t u8g_com_stm32duino_fsmc_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, voi
       LCD_IO_Init(u8g->pin_list[U8G_PI_CS], u8g->pin_list[U8G_PI_A0]);
       u8g_Delay(100);
 
-      if (arg_ptr != NULL)
+      if (arg_ptr != nullptr)
         *((uint32_t *)arg_ptr) = LCD_IO_ReadData(LCD_READ_ID, 3);
 
       isCommand = 0;

--- a/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL_spi_STM32F4.cpp
@@ -165,7 +165,7 @@ void spiSendBlock(uint8_t token, const uint8_t* buf) {
   #ifdef STM32GENERIC
     SPI.dmaSend(const_cast<uint8_t*>(buf), 512);
   #else
-    SPI.transfer((uint8_t*)buf, (uint8_t*)0, 512);
+    SPI.transfer((uint8_t*)buf, nullptr, 512);
   #endif
 
   SPI.endTransaction();

--- a/Marlin/src/HAL/shared/backtrace/unwarm.cpp
+++ b/Marlin/src/HAL/shared/backtrace/unwarm.cpp
@@ -93,7 +93,7 @@ bool UnwReportRetAddr(UnwState * const state, uint32_t addr) {
   UnwReport entry;
 
   // We found two acceptable values.
-  entry.name = NULL;
+  entry.name = nullptr;
   entry.address = addr & 0xFFFFFFFE; // Remove Thumb bit
   entry.function = 0;
 

--- a/Marlin/src/HAL/shared/backtrace/unwarmbytab.cpp
+++ b/Marlin/src/HAL/shared/backtrace/unwarmbytab.cpp
@@ -47,17 +47,17 @@ static const UnwTabEntry *UnwTabSearchIndex(const UnwTabEntry *start, const UnwT
 }
 
 /*
- * Get the function name or NULL if not found
+ * Get the function name or nullptr if not found
  */
 static const char *UnwTabGetFunctionName(const UnwindCallbacks *cb, uint32_t address) {
   uint32_t flag_word = 0;
   if (!cb->readW(address-4,&flag_word))
-    return NULL;
+    return nullptr;
 
   if ((flag_word & 0xFF000000) == 0xFF000000) {
     return (const char *)(address - 4 - (flag_word & 0x00FFFFFF));
   }
-  return NULL;
+  return nullptr;
 }
 
 /**

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -728,7 +728,7 @@ void idle(
  * Kill all activity and lock the machine.
  * After this the machine will need to be reset.
  */
-void kill(PGM_P const lcd_msg/*=NULL*/) {
+void kill(PGM_P const lcd_msg/*=nullptr*/) {
   thermalManager.disable_all_heaters();
 
   SERIAL_ERROR_MSG(MSG_ERR_KILLED);

--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -321,7 +321,7 @@ void disable_e_stepper(const uint8_t e);
 void disable_e_steppers();
 void disable_all_steppers();
 
-void kill(PGM_P const lcd_msg=NULL);
+void kill(PGM_P const lcd_msg=nullptr);
 void minkill();
 
 void quickstop_stepper();

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -50,7 +50,7 @@ void serial_echopair_PGM(PGM_P const s_P, unsigned long v) { serialprintPGM(s_P)
 
 void serial_spaces(uint8_t count) { count *= (PROPORTIONAL_FONT_RATIO); while (count--) SERIAL_CHAR(' '); }
 
-void serial_ternary(const bool onoff, PGM_P const pre, PGM_P const on, PGM_P const off, PGM_P const post/*=NULL*/) {
+void serial_ternary(const bool onoff, PGM_P const pre, PGM_P const on, PGM_P const off, PGM_P const post/*=nullptr*/) {
   if (pre) serialprintPGM(pre);
   serialprintPGM(onoff ? on : off);
   if (post) serialprintPGM(post);

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -174,7 +174,7 @@ inline void serial_echopair_PGM(PGM_P const s_P, void *v)   { serial_echopair_PG
 void serialprintPGM(PGM_P str);
 void serial_echo_start();
 void serial_error_start();
-void serial_ternary(const bool onoff, PGM_P const pre, PGM_P const on, PGM_P const off, PGM_P const post=NULL);
+void serial_ternary(const bool onoff, PGM_P const pre, PGM_P const on, PGM_P const off, PGM_P const post=nullptr);
 void serialprint_onoff(const bool onoff);
 void serialprintln_onoff(const bool onoff);
 void serialprint_truefalse(const bool tf);
@@ -185,4 +185,4 @@ void print_bin(const uint16_t val);
 void print_xyz(PGM_P const prefix, PGM_P const suffix, const float x, const float y, const float z);
 void print_xyz(PGM_P const prefix, PGM_P const suffix, const float xyz[]);
 #define SERIAL_POS(SUFFIX,VAR) do { print_xyz(PSTR("  " STRINGIFY(VAR) "="), PSTR(" : " SUFFIX "\n"), VAR); } while(0)
-#define SERIAL_XYZ(PREFIX,...) do { print_xyz(PSTR(PREFIX), NULL, __VA_ARGS__); } while(0)
+#define SERIAL_XYZ(PREFIX,...) do { print_xyz(PSTR(PREFIX), nullptr, __VA_ARGS__); } while(0)

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -330,7 +330,7 @@
       else {
         while (g29_repetition_cnt--) {
           if (cnt > 20) { cnt = 0; idle(); }
-          const mesh_index_pair location = find_closest_mesh_point_of_type(REAL, g29_x_pos, g29_y_pos, USE_NOZZLE_AS_REFERENCE, NULL);
+          const mesh_index_pair location = find_closest_mesh_point_of_type(REAL, g29_x_pos, g29_y_pos, USE_NOZZLE_AS_REFERENCE, nullptr);
           if (location.x_index < 0) {
             // No more REACHABLE mesh points to invalidate, so we ASSUME the user
             // meant to invalidate the ENTIRE mesh, which cannot be done with
@@ -528,7 +528,7 @@
             }
             else {
               while (g29_repetition_cnt--) {  // this only populates reachable mesh points near
-                const mesh_index_pair location = find_closest_mesh_point_of_type(INVALID, g29_x_pos, g29_y_pos, USE_NOZZLE_AS_REFERENCE, NULL);
+                const mesh_index_pair location = find_closest_mesh_point_of_type(INVALID, g29_x_pos, g29_y_pos, USE_NOZZLE_AS_REFERENCE, nullptr);
                 if (location.x_index < 0) {
                   // No more REACHABLE INVALID mesh points to populate, so we ASSUME
                   // user meant to populate ALL INVALID mesh points to value
@@ -759,7 +759,7 @@
         if (do_furthest)
           location = find_furthest_invalid_mesh_point();
         else
-          location = find_closest_mesh_point_of_type(INVALID, rx, ry, USE_PROBE_AS_REFERENCE, NULL);
+          location = find_closest_mesh_point_of_type(INVALID, rx, ry, USE_PROBE_AS_REFERENCE, nullptr);
 
         if (location.x_index >= 0) {    // mesh point found and is reachable by probe
           const float rawx = mesh_index_to_xpos(location.x_index),
@@ -793,7 +793,7 @@
 
     typedef void (*clickFunc_t)();
 
-    bool click_and_hold(const clickFunc_t func=NULL) {
+    bool click_and_hold(const clickFunc_t func=nullptr) {
       if (ui.button_pressed()) {
         ui.quick_feedback(false);                // Preserve button state for click-and-hold
         const millis_t nxt = millis() + 1500UL;
@@ -891,7 +891,7 @@
 
       mesh_index_pair location;
       do {
-        location = find_closest_mesh_point_of_type(INVALID, rx, ry, USE_NOZZLE_AS_REFERENCE, NULL);
+        location = find_closest_mesh_point_of_type(INVALID, rx, ry, USE_NOZZLE_AS_REFERENCE, nullptr);
         // It doesn't matter if the probe can't reach the NAN location. This is a manual probe.
         if (location.x_index < 0 && location.y_index < 0) continue;
 

--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -84,7 +84,7 @@ void host_action(const char * const pstr, const bool eol) {
   void host_action_prompt_button(const char * const pstr) { host_action_prompt_plus(PSTR("button"), pstr); }
   void host_action_prompt_end() { host_action_prompt(PSTR("end")); }
   void host_action_prompt_show() { host_action_prompt(PSTR("show")); }
-  void host_prompt_do(const PromptReason reason, const char * const pstr, const char * const pbtn/*=NULL*/) {
+  void host_prompt_do(const PromptReason reason, const char * const pstr, const char * const pbtn/*=nullptr*/) {
     host_prompt_reason = reason;
     host_action_prompt_end();
     host_action_prompt_begin(pstr);

--- a/Marlin/src/feature/host_actions.h
+++ b/Marlin/src/feature/host_actions.h
@@ -64,8 +64,8 @@ void host_action(const char * const pstr, const bool eol=true);
   void host_action_prompt_button(const char * const pstr);
   void host_action_prompt_end();
   void host_action_prompt_show();
-  void host_prompt_do(const PromptReason type, const char * const pstr, const char * const pbtn=NULL);
-  inline void host_prompt_open(const PromptReason reason, const char * const pstr, const char * const pbtn=NULL) {
+  void host_prompt_do(const PromptReason type, const char * const pstr, const char * const pbtn=nullptr);
+  inline void host_prompt_open(const PromptReason reason, const char * const pstr, const char * const pbtn=nullptr) {
     if (host_prompt_reason == PROMPT_NOT_DEFINED) host_prompt_do(reason, pstr, pbtn);
   }
 

--- a/Marlin/src/feature/twibus.cpp
+++ b/Marlin/src/feature/twibus.cpp
@@ -162,7 +162,7 @@ void TWIBus::flush() {
     echodata(bytes, PSTR("i2c-receive"), 0);
   }
 
-  void TWIBus::reply(char str[]/*=NULL*/) {
+  void TWIBus::reply(char str[]/*=nullptr*/) {
     #if ENABLED(DEBUG_TWIBUS)
       debug(PSTR("reply"), str);
     #endif

--- a/Marlin/src/feature/twibus.h
+++ b/Marlin/src/feature/twibus.h
@@ -217,7 +217,7 @@ class TWIBus {
        * @details Send the buffer and clear it.
        *          If a string is passed, write it into the buffer first.
        */
-      void reply(char str[]=NULL);
+      void reply(char str[]=nullptr);
       inline void reply(const char str[]) { this->reply((char*)str); }
 
     #endif

--- a/Marlin/src/gcode/bedlevel/ubl/M421.cpp
+++ b/Marlin/src/gcode/bedlevel/ubl/M421.cpp
@@ -55,7 +55,7 @@ void GcodeSuite::M421() {
              hasQ = !hasZ && parser.seen('Q');
 
   if (hasC) {
-    const mesh_index_pair location = ubl.find_closest_mesh_point_of_type(REAL, current_position[X_AXIS], current_position[Y_AXIS], USE_NOZZLE_AS_REFERENCE, NULL);
+    const mesh_index_pair location = ubl.find_closest_mesh_point_of_type(REAL, current_position[X_AXIS], current_position[Y_AXIS], USE_NOZZLE_AS_REFERENCE, nullptr);
     ix = location.x_index;
     iy = location.y_index;
   }

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -205,7 +205,7 @@ float measuring_movement(const AxisEnum axis, const int dir, const bool stop_sta
  *   axis               in     - Axis along which the measurement will take place
  *   dir                in     - Direction along that axis (-1 or 1)
  *   stop_state         in     - Move until probe pin becomes this value
- *   backlash_ptr       in/out - When not NULL, measure and record axis backlash
+ *   backlash_ptr       in/out - When not nullptr, measure and record axis backlash
  *   uncertainty        in     - If uncertainty is CALIBRATION_MEASUREMENT_UNKNOWN, do a fast probe.
  */
 inline float measure(const AxisEnum axis, const int dir, const bool stop_state, float * const backlash_ptr, const float uncertainty) {

--- a/Marlin/src/gcode/calibrate/M100.cpp
+++ b/Marlin/src/gcode/calibrate/M100.cpp
@@ -194,7 +194,7 @@ inline int check_for_free_memory_corruption(PGM_P const title) {
   }
   SERIAL_ECHOPAIR("  block_found=", block_cnt);
 
-  if (block_cnt != 1 || __brkval != NULL)
+  if (block_cnt != 1 || __brkval != nullptr)
     SERIAL_ECHOLNPGM("\nMemory Corruption detected in free memory area.");
 
   if (block_cnt == 0)       // Make sure the special case of no free blocks shows up as an
@@ -217,7 +217,7 @@ inline int check_for_free_memory_corruption(PGM_P const title) {
  */
 inline void free_memory_pool_report(char * const ptr, const int32_t size) {
   int32_t max_cnt = -1, block_cnt = 0;
-  char *max_addr = NULL;
+  char *max_addr = nullptr;
   // Find the longest block of test bytes in the buffer
   for (int32_t i = 0; i < size; i++) {
     char *addr = ptr + i;

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -80,7 +80,7 @@ GCodeParser parser;
  * this may be optimized by commenting out ZERO(param)
  */
 void GCodeParser::reset() {
-  string_arg = NULL;                    // No whole line argument
+  string_arg = nullptr;                 // No whole line argument
   command_letter = '?';                 // No command letter
   codenum = 0;                          // No command code
   #if USE_GCODE_SUBCODES
@@ -245,7 +245,7 @@ void GCodeParser::parse(char *p) {
    * This allows M0/M1 with expire time to work: "M0 S5 You Win!"
    * For 'M118' you must use 'E1' and 'A1' rather than just 'E' or 'A'
    */
-  string_arg = NULL;
+  string_arg = nullptr;
   while (const char code = *p++) {                    // Get the next parameter. A NUL ends the loop
 
     // Special handling for M32 [P] !/path/to/file.g#
@@ -289,7 +289,7 @@ void GCodeParser::parse(char *p) {
       #endif
 
       #if ENABLED(FASTER_GCODE_PARSER)
-        set(code, has_num ? p : NULL);          // Set parameter exists and pointer (NULL for no number)
+        set(code, has_num ? p : nullptr);       // Set parameter exists and pointer (nullptr for no number)
       #endif
     }
     else if (!string_arg) {                     // Not A-Z? First time, keep as the string_arg
@@ -315,7 +315,7 @@ void GCodeParser::parse(char *p) {
       if (next_command) {
         while (*next_command && *next_command != ' ') ++next_command;
         while (*next_command == ' ') ++next_command;
-        if (!*next_command) next_command = NULL;
+        if (!*next_command) next_command = nullptr;
       }
     #else
       const char *next_command = command_args;

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -135,7 +135,7 @@ public:
       const bool b = TEST32(codebits, ind);
       if (b) {
         char * const ptr = command_ptr + param[ind];
-        value_ptr = param[ind] && valid_float(ptr) ? ptr : (char*)NULL;
+        value_ptr = param[ind] && valid_float(ptr) ? ptr : nullptr;
       }
       return b;
     }
@@ -178,7 +178,7 @@ public:
     static inline bool seen(const char c) {
       char *p = strchr(command_args, c);
       const bool b = !!p;
-      if (b) value_ptr = valid_float(&p[1]) ? &p[1] : (char*)NULL;
+      if (b) value_ptr = valid_float(&p[1]) ? &p[1] : nullptr;
       return b;
     }
 
@@ -210,7 +210,7 @@ public:
   #endif
 
   // The code value pointer was set
-  FORCE_INLINE static bool has_value() { return value_ptr != NULL; }
+  FORCE_INLINE static bool has_value() { return value_ptr != nullptr; }
 
   // Seen a parameter with a value
   static inline bool seenval(const char c) { return seen(c) && has_value(); }
@@ -224,20 +224,20 @@ public:
         if (c == '\0' || c == ' ') break;
         if (c == 'E' || c == 'e') {
           *e = '\0';
-          const float ret = strtof(value_ptr, NULL);
+          const float ret = strtof(value_ptr, nullptr);
           *e = c;
           return ret;
         }
         ++e;
       }
-      return strtof(value_ptr, NULL);
+      return strtof(value_ptr, nullptr);
     }
     return 0;
   }
 
   // Code value as a long or ulong
-  static inline int32_t value_long() { return value_ptr ? strtol(value_ptr, NULL, 10) : 0L; }
-  static inline uint32_t value_ulong() { return value_ptr ? strtoul(value_ptr, NULL, 10) : 0UL; }
+  static inline int32_t value_long() { return value_ptr ? strtol(value_ptr, nullptr, 10) : 0L; }
+  static inline uint32_t value_ulong() { return value_ptr ? strtoul(value_ptr, nullptr, 10) : 0UL; }
 
   // Code value for use as time
   static inline millis_t value_millis() { return value_ulong(); }

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -76,11 +76,11 @@ static int serial_count[NUM_SERIAL] = { 0 };
 bool send_ok[BUFSIZE];
 
 /**
- * Next Injected Command pointer. NULL if no commands are being injected.
+ * Next Injected Command pointer. nullptr if no commands are being injected.
  * Used by Marlin internally to ensure that commands initiated from within
  * are enqueued ahead of any pending serial or sd card commands.
  */
-static PGM_P injected_commands_P = NULL;
+static PGM_P injected_commands_P = nullptr;
 
 void queue_setup() {
   // Send "ok" after commands by default
@@ -157,7 +157,7 @@ bool enqueue_and_echo_command(const char* cmd) {
  * Return true if any immediate commands remain to inject.
  */
 static bool drain_injected_commands_P() {
-  if (injected_commands_P != NULL) {
+  if (injected_commands_P != nullptr) {
     size_t i = 0;
     char c, cmd[60];
     strncpy_P(cmd, injected_commands_P, sizeof(cmd) - 1);
@@ -165,9 +165,9 @@ static bool drain_injected_commands_P() {
     while ((c = cmd[i]) && c != '\n') i++; // find the end of this gcode command
     cmd[i] = '\0';
     if (enqueue_and_echo_command(cmd))     // success?
-      injected_commands_P = c ? injected_commands_P + i + 1 : NULL; // next command or done
+      injected_commands_P = c ? injected_commands_P + i + 1 : nullptr; // next command or done
   }
-  return (injected_commands_P != NULL);    // return whether any more remain
+  return (injected_commands_P != nullptr);    // return whether any more remain
 }
 
 /**
@@ -597,18 +597,18 @@ inline void get_serial_commands() {
         char* command = serial_line_buffer[i];
 
         while (*command == ' ') command++;                // Skip leading spaces
-        char *npos = (*command == 'N') ? command : NULL;  // Require the N parameter to start the line
+        char *npos = (*command == 'N') ? command : nullptr;  // Require the N parameter to start the line
 
         if (npos) {
 
-          bool M110 = strstr_P(command, PSTR("M110")) != NULL;
+          bool M110 = strstr_P(command, PSTR("M110")) != nullptr;
 
           if (M110) {
             char* n2pos = strchr(command + 4, 'N');
             if (n2pos) npos = n2pos;
           }
 
-          gcode_N = strtol(npos + 1, NULL, 10);
+          gcode_N = strtol(npos + 1, nullptr, 10);
 
           if (gcode_N != gcode_LastN + 1 && !M110)
             return gcode_line_error(PSTR(MSG_ERR_LINE_NO), i);
@@ -617,7 +617,7 @@ inline void get_serial_commands() {
           if (apos) {
             uint8_t checksum = 0, count = uint8_t(apos - command);
             while (count) checksum ^= command[--count];
-            if (strtol(apos + 1, NULL, 10) != checksum)
+            if (strtol(apos + 1, nullptr, 10) != checksum)
               return gcode_line_error(PSTR(MSG_ERR_CHECKSUM_MISMATCH), i);
           }
           else
@@ -635,7 +635,7 @@ inline void get_serial_commands() {
         if (IsStopped()) {
           char* gpos = strchr(command, 'G');
           if (gpos) {
-            switch (strtol(gpos + 1, NULL, 10)) {
+            switch (strtol(gpos + 1, nullptr, 10)) {
               case 0:
               case 1:
               #if ENABLED(ARC_SUPPORT)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -560,7 +560,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #endif
 
 #if defined(EVENT_GCODE_SD_STOP) && DISABLED(NOZZLE_PARK_FEATURE)
-  static_assert(NULL == strstr(EVENT_GCODE_SD_STOP, "G27"), "NOZZLE_PARK_FEATURE is required to use G27 in EVENT_GCODE_SD_STOP.");
+  static_assert(nullptr == strstr(EVENT_GCODE_SD_STOP, "G27"), "NOZZLE_PARK_FEATURE is required to use G27 in EVENT_GCODE_SD_STOP.");
 #endif
 
 /**
@@ -620,7 +620,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #elif FILAMENT_RUNOUT_DISTANCE_MM < 0
     #error "FILAMENT_RUNOUT_DISTANCE_MM must be greater than or equal to zero."
   #elif DISABLED(ADVANCED_PAUSE_FEATURE)
-    static_assert(NULL == strstr(FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with FILAMENT_RUNOUT_SENSOR.");
+    static_assert(nullptr == strstr(FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with FILAMENT_RUNOUT_SENSOR.");
   #endif
 #endif
 
@@ -2176,7 +2176,7 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
   #elif EXTRUDERS != 5
     #error "PRUSA_MMU2 requires EXTRUDERS = 5."
   #elif DISABLED(ADVANCED_PAUSE_FEATURE)
-    static_assert(NULL == strstr(MMU2_FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with PRUSA_MMU2.");
+    static_assert(nullptr == strstr(MMU2_FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with PRUSA_MMU2.");
   #endif
 #endif
 

--- a/Marlin/src/lcd/HD44780/lcdprint_hd44780.cpp
+++ b/Marlin/src/lcd/HD44780/lcdprint_hd44780.cpp
@@ -889,7 +889,7 @@ int lcd_put_wchar_max(wchar_t c, pixel_len_t max_length) {
   int ret;
   size_t idx = 0;
   hd44780_charmap_t pinval;
-  hd44780_charmap_t *copy_address = NULL;
+  hd44780_charmap_t *copy_address = nullptr;
   pinval.uchar = c;
   pinval.idx = -1;
 
@@ -900,7 +900,7 @@ int lcd_put_wchar_max(wchar_t c, pixel_len_t max_length) {
     lcd.write((uint8_t)c);
     return 1;
   }
-  copy_address = NULL;
+  copy_address = nullptr;
   ret = pf_bsearch_r((void *)g_hd44780_charmap_device, COUNT(g_hd44780_charmap_device), pf_bsearch_cb_comp_hd4map_pgm, (void *)&pinval, &idx);
   if (ret >= 0) {
     copy_address = (hd44780_charmap_t *)(g_hd44780_charmap_device + idx);

--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -992,7 +992,7 @@ void MarlinUI::draw_status_screen() {
 
   #endif // ADVANCED_PAUSE_FEATURE
 
-  void draw_menu_item_static(const uint8_t row, PGM_P pstr, const bool center/*=true*/, const bool invert/*=false*/, const char *valstr/*=NULL*/) {
+  void draw_menu_item_static(const uint8_t row, PGM_P pstr, const bool center/*=true*/, const bool invert/*=false*/, const char *valstr/*=nullptr*/) {
     UNUSED(invert);
     int8_t n = LCD_WIDTH;
     lcd_moveto(0, row);
@@ -1024,10 +1024,10 @@ void MarlinUI::draw_status_screen() {
     if (pgm) lcd_put_u8str_P(data); else lcd_put_u8str(data);
   }
 
-  void draw_edit_screen(PGM_P const pstr, const char* const value/*=NULL*/) {
+  void draw_edit_screen(PGM_P const pstr, const char* const value/*=nullptr*/) {
     lcd_moveto(0, 1);
     lcd_put_u8str_P(pstr);
-    if (value != NULL) {
+    if (value != nullptr) {
       lcd_put_wchar(':');
       int len = utf8_strlen(value);
       const uint8_t valrow = (utf8_strlen_P(pstr) + 1 + len + 1) > (LCD_WIDTH - 2) ? 2 : 1;   // Value on the next row if it won't fit

--- a/Marlin/src/lcd/dogm/u8g_fontutf8.cpp
+++ b/Marlin/src/lcd/dogm/u8g_fontutf8.cpp
@@ -64,10 +64,10 @@ static const font_t* fontgroup_find(font_group_t * root, wchar_t val) {
   uxg_fontinfo_t vcmp = {(uint16_t)(val / 128), (uint8_t)(val % 128 + 128), (uint8_t)(val % 128 + 128), 0, 0};
   size_t idx = 0;
 
-  if (val < 256) return NULL;
+  if (val < 256) return nullptr;
 
   if (pf_bsearch_r((void*)root->m_fntifo, root->m_fntinfo_num, pf_bsearch_cb_comp_fntifo_pgm, (void*)&vcmp, &idx) < 0)
-    return NULL;
+    return nullptr;
 
   memcpy_P(&vcmp, root->m_fntifo + idx, sizeof(vcmp));
   return vcmp.fntdata;
@@ -114,7 +114,7 @@ static void fontgroup_drawstring(font_group_t *group, const font_t *fnt_default,
 }
 
 static bool flag_fontgroup_was_inited = false;
-static font_group_t g_fontgroup_root = {NULL, 0};
+static font_group_t g_fontgroup_root = { nullptr, 0 };
 
 /**
  * @brief check if font is loaded
@@ -176,7 +176,7 @@ unsigned int uxg_DrawWchar(u8g_t *pu8g, unsigned int x, unsigned int y, wchar_t 
   data.y = y;
   data.adv = 0;
   data.max_width = max_width;
-  data.fnt_prev = NULL;
+  data.fnt_prev = nullptr;
   fontgroup_drawwchar(group, fnt_default, ch, (void*)&data, fontgroup_cb_draw_u8g);
   u8g_SetFont(pu8g, (const u8g_fntpgm_uint8_t*)fnt_default);
 
@@ -210,7 +210,7 @@ unsigned int uxg_DrawUtf8Str(u8g_t *pu8g, unsigned int x, unsigned int y, const 
   data.y = y;
   data.adv = 0;
   data.max_width = max_width;
-  data.fnt_prev = NULL;
+  data.fnt_prev = nullptr;
   fontgroup_drawstring(group, fnt_default, utf8_msg, read_byte_ram, (void*)&data, fontgroup_cb_draw_u8g);
   u8g_SetFont(pu8g, (const u8g_fntpgm_uint8_t*)fnt_default);
 
@@ -244,7 +244,7 @@ unsigned int uxg_DrawUtf8StrP(u8g_t *pu8g, unsigned int x, unsigned int y, PGM_P
   data.y = y;
   data.adv = 0;
   data.max_width = max_width;
-  data.fnt_prev = NULL;
+  data.fnt_prev = nullptr;
   fontgroup_drawstring(group, fnt_default, utf8_msg, read_byte_rom, (void*)&data, fontgroup_cb_draw_u8g);
   u8g_SetFont(pu8g, (const u8g_fntpgm_uint8_t*)fnt_default);
 

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -330,7 +330,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
   }
 
   // Draw a static line of text in the same idiom as a menu item
-  void draw_menu_item_static(const uint8_t row, PGM_P pstr, const bool center/*=true*/, const bool invert/*=false*/, const char* valstr/*=NULL*/) {
+  void draw_menu_item_static(const uint8_t row, PGM_P pstr, const bool center/*=true*/, const bool invert/*=false*/, const char* valstr/*=nullptr*/) {
 
     if (mark_as_selected(row, invert)) {
 
@@ -373,7 +373,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
     }
   }
 
-  void draw_edit_screen(PGM_P const pstr, const char* const value/*=NULL*/) {
+  void draw_edit_screen(PGM_P const pstr, const char* const value/*=nullptr*/) {
     const uint8_t labellen = utf8_strlen_P(pstr), vallen = utf8_strlen(value);
 
     bool extra_row = labellen > LCD_WIDTH - 2 - vallen;
@@ -410,7 +410,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
     }
 
     // If a value is included, print a colon, then print the value right-justified
-    if (value != NULL) {
+    if (value != nullptr) {
       lcd_put_wchar(':');
       if (extra_row) {
         // Assume that value is numeric (with no descender)

--- a/Marlin/src/lcd/menu/game/invaders.cpp
+++ b/Marlin/src/lcd/menu/game/invaders.cpp
@@ -302,7 +302,7 @@ void InvadersGame::game_screen() {
         if (invader_count && !random(0, 20)) {
 
           // Find a free bullet
-          laser_t *b = NULL;
+          laser_t *b = nullptr;
           LOOP_L_N(i, COUNT(bullet)) if (!bullet[i].v) { b = &bullet[i]; break; }
           if (b) {
             // Pick a random shooter and update the bullet

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -136,7 +136,7 @@ void MenuItemBase::edit(strfunc_t strfunc, loadfunc_t loadfunc) {
   if (ui.should_draw())
     draw_edit_screen(editLabel, strfunc(ui.encoderPosition + minEditValue));
   if (ui.lcd_clicked || (liveEdit && ui.should_draw())) {
-    if (editValue != NULL) loadfunc(editValue, ui.encoderPosition + minEditValue);
+    if (editValue != nullptr) loadfunc(editValue, ui.encoderPosition + minEditValue);
     if (callbackFunc && (liveEdit || ui.lcd_clicked)) (*callbackFunc)();
     if (ui.use_click()) ui.goto_previous_screen();
   }
@@ -300,7 +300,7 @@ void MarlinUI::_synchronize() {
 
 // Display the synchronize screen with a custom message
 // ** This blocks the command queue! **
-void MarlinUI::synchronize(PGM_P const msg/*=NULL*/) {
+void MarlinUI::synchronize(PGM_P const msg/*=nullptr*/) {
   static const char moving[] PROGMEM = MSG_MOVING;
   sync_message = msg ? msg : moving;
   _synchronize();
@@ -445,7 +445,7 @@ void _lcd_draw_homing() {
 //
 bool ui_selection; // = false
 void set_ui_selection(const bool sel) { ui_selection = sel; }
-void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string/*=NULL*/, PGM_P const suff/*=NULL*/) {
+void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
   if (ui.encoderPosition) {
     ui_selection = int16_t(ui.encoderPosition) > 0;
     ui.encoderPosition = 0;

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -70,14 +70,14 @@ DECLARE_MENU_EDIT_TYPE(uint32_t, long5_25,    ftostr5rj,       0.04f );   // 123
 typedef void (*selectFunc_t)();
 void draw_select_screen(PGM_P const yes, PGM_P const no, const bool yesno, PGM_P const pref, const char * const string, PGM_P const suff);
 void set_ui_selection(const bool sel);
-void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string=NULL, PGM_P const suff=NULL);
-inline void do_select_screen_yn(selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string=NULL, PGM_P const suff=NULL) {
+void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string=nullptr, PGM_P const suff=nullptr);
+inline void do_select_screen_yn(selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string=nullptr, PGM_P const suff=nullptr) {
   do_select_screen(PSTR(MSG_YES), PSTR(MSG_NO), yesFunc, noFunc, pref, string, suff);
 }
 
-void draw_edit_screen(PGM_P const pstr, const char* const value=NULL);
+void draw_edit_screen(PGM_P const pstr, const char* const value=nullptr);
 void draw_menu_item(const bool sel, const uint8_t row, PGM_P const pstr, const char pre_char, const char post_char);
-void draw_menu_item_static(const uint8_t row, PGM_P const pstr, const bool center=true, const bool invert=false, const char *valstr=NULL);
+void draw_menu_item_static(const uint8_t row, PGM_P const pstr, const bool center=true, const bool invert=false, const char *valstr=nullptr);
 void _draw_menu_item_edit(const bool sel, const uint8_t row, PGM_P const pstr, const char* const data, const bool pgm);
 FORCE_INLINE void draw_menu_item_back(const bool sel, const uint8_t row, PGM_P const pstr) { draw_menu_item(sel, row, pstr, LCD_STR_UPLEVEL[0], LCD_STR_UPLEVEL[0]); }
 FORCE_INLINE void draw_menu_item_edit(const bool sel, const uint8_t row, PGM_P const pstr, const char* const data) { _draw_menu_item_edit(sel, row, pstr, data, false); }
@@ -187,7 +187,7 @@ class TMenuItem : MenuItemBase {
     static void load(void *ptr, const int16_t value)  { *((type_t*)ptr) = unscale(value);     }
     static char* to_string(const int16_t value)       { return NAME::strfunc(unscale(value)); }
   public:
-    static void action_edit(PGM_P const pstr, type_t * const ptr, const type_t minValue, const type_t maxValue, const screenFunc_t callback=NULL, const bool live=false) {
+    static void action_edit(PGM_P const pstr, type_t * const ptr, const type_t minValue, const type_t maxValue, const screenFunc_t callback=nullptr, const bool live=false) {
       // Make sure minv and maxv fit within int16_t
       const int16_t minv = MAX(scale(minValue), INT16_MIN),
                     maxv = MIN(scale(maxValue), INT16_MAX);
@@ -218,7 +218,7 @@ DECLARE_MENU_EDIT_ITEM(long5_25);
 
 class MenuItem_bool {
   public:
-    static void action_edit(PGM_P const pstr, bool* ptr, const screenFunc_t callbackFunc=NULL);
+    static void action_edit(PGM_P const pstr, bool* ptr, const screenFunc_t callbackFunc=nullptr);
 };
 
 ////////////////////////////////////////////

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -610,7 +610,7 @@ void menu_backlash();
         PSTR(MSG_BUTTON_INIT), PSTR(MSG_BUTTON_CANCEL),
         []{ ui.completion_feedback(settings.init_eeprom()); },
         ui.goto_previous_screen,
-        PSTR(MSG_INIT_EEPROM), NULL, PSTR("?")
+        PSTR(MSG_INIT_EEPROM), nullptr, PSTR("?")
       );
     }
 

--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -102,7 +102,7 @@ static inline void menu_level_bed_corners() {
       #else
         MSG_NEXT_CORNER
       #endif
-    ), NULL, PSTR("?")
+    ), nullptr, PSTR("?")
   );
 }
 

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -367,7 +367,7 @@ void menu_pause_option() {
 // ADVANCED_PAUSE_FEATURE message screens
 //
 
-void _lcd_pause_message(PGM_P const msg1, PGM_P const msg2=NULL, PGM_P const msg3=NULL) {
+void _lcd_pause_message(PGM_P const msg1, PGM_P const msg2=nullptr, PGM_P const msg3=nullptr) {
   START_SCREEN();
   STATIC_ITEM_P(pause_header(), true, true);
   STATIC_ITEM_P(msg1);
@@ -516,7 +516,7 @@ FORCE_INLINE screenFunc_t ap_message_screen(const PauseMessage message) {
     case PAUSE_MESSAGE_STATUS:
     default: break;
   }
-  return NULL;
+  return nullptr;
 }
 
 void lcd_pause_show_message(

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -101,7 +101,7 @@
   }
 
   void menu_abort_confirm() {
-    do_select_screen(PSTR(MSG_BUTTON_STOP), PSTR(MSG_BACK), lcd_abort_job, ui.goto_previous_screen, PSTR(MSG_STOP_PRINT), NULL, PSTR("?"));
+    do_select_screen(PSTR(MSG_BUTTON_STOP), PSTR(MSG_BACK), lcd_abort_job, ui.goto_previous_screen, PSTR(MSG_STOP_PRINT), nullptr, PSTR("?"));
   }
 
 #endif // MACHINE_CAN_STOP
@@ -189,10 +189,10 @@ void menu_main() {
       }
       else {
         #if PIN_EXISTS(SD_DETECT)
-          MENU_ITEM(function, MSG_NO_CARD, NULL);
+          MENU_ITEM(function, MSG_NO_CARD, nullptr);
         #else
           MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21"));
-          MENU_ITEM(function, MSG_SD_RELEASED, NULL);
+          MENU_ITEM(function, MSG_SD_RELEASED, nullptr);
         #endif
       }
     #endif // !HAS_ENCODER_WHEEL && SDSUPPORT
@@ -276,10 +276,10 @@ void menu_main() {
     }
     else {
       #if PIN_EXISTS(SD_DETECT)
-        MENU_ITEM(function, MSG_NO_CARD, NULL);
+        MENU_ITEM(function, MSG_NO_CARD, nullptr);
       #else
         MENU_ITEM(gcode, MSG_INIT_SDCARD, PSTR("M21"));
-        MENU_ITEM(function, MSG_SD_RELEASED, NULL);
+        MENU_ITEM(function, MSG_SD_RELEASED, nullptr);
       #endif
     }
   #endif // HAS_ENCODER_WHEEL && SDSUPPORT

--- a/Marlin/src/lcd/menu/menu_mixer.cpp
+++ b/Marlin/src/lcd/menu/menu_mixer.cpp
@@ -259,7 +259,7 @@ void menu_mixer_vtools_reset_confirm() {
       ui.return_to_status();
     },
     ui.goto_previous_screen,
-    PSTR(MSG_RESET_VTOOLS), NULL, PSTR("?")
+    PSTR(MSG_RESET_VTOOLS), nullptr, PSTR("?")
   );
 }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -211,7 +211,7 @@ millis_t next_button_update_ms;
     }
   }
 
-  void MarlinUI::draw_select_screen_prompt(PGM_P const pref, const char * const string/*=NULL*/, PGM_P const suff/*=NULL*/) {
+  void MarlinUI::draw_select_screen_prompt(PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
     const uint8_t plen = utf8_strlen_P(pref), slen = suff ? utf8_strlen_P(suff) : 0;
     uint8_t x = 0, y = 0;
     if (!string && plen + slen <= LCD_WIDTH) {

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -419,7 +419,7 @@ public:
     static bool lcd_clicked;
     static bool use_click();
 
-    static void synchronize(PGM_P const msg=NULL);
+    static void synchronize(PGM_P const msg=nullptr);
 
     static screenFunc_t currentScreen;
     static void goto_screen(const screenFunc_t screen, const uint16_t encoder=0, const uint8_t top=0, const uint8_t items=0);
@@ -458,7 +458,7 @@ public:
       static void ubl_plot(const uint8_t x, const uint8_t inverted_y);
     #endif
 
-    static void draw_select_screen_prompt(PGM_P const pref, const char * const string=NULL, PGM_P const suff=NULL);
+    static void draw_select_screen_prompt(PGM_P const pref, const char * const string=nullptr, PGM_P const suff=nullptr);
 
   #elif HAS_SPI_LCD
 

--- a/Marlin/src/libs/L6470/L6470_Marlin.cpp
+++ b/Marlin/src/libs/L6470/L6470_Marlin.cpp
@@ -624,7 +624,7 @@ void L6470_Marlin::error_status_decode(const uint16_t status, const uint8_t axis
     #endif
   };
 
-  inline void append_stepper_err(char * &p, const uint8_t stepper_index, const char * const err=NULL) {
+  inline void append_stepper_err(char * &p, const uint8_t stepper_index, const char * const err=nullptr) {
     p += sprintf_P(p, PSTR("Stepper %c%c "), char(index_to_axis[stepper_index][0]), char(index_to_axis[stepper_index][1]));
     if (err) p += sprintf_P(p, err);
   }

--- a/Marlin/src/libs/vector_3.cpp
+++ b/Marlin/src/libs/vector_3.cpp
@@ -140,7 +140,7 @@ matrix_3x3 matrix_3x3::transpose(const matrix_3x3 &original) {
 }
 
 void matrix_3x3::debug(PGM_P const title) {
-  if (title != NULL) {
+  if (title != nullptr) {
     serialprintPGM(title);
     SERIAL_EOL();
   }

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2132,7 +2132,7 @@ void MarlinSettings::postprocess() {
       #endif
     }
 
-    void MarlinSettings::load_mesh(const int8_t slot, void * const into/*=NULL*/) {
+    void MarlinSettings::load_mesh(const int8_t slot, void * const into/*=nullptr*/) {
 
       #if ENABLED(AUTO_BED_LEVELING_UBL)
 
@@ -2545,7 +2545,7 @@ void MarlinSettings::reset() {
   #if HAS_TRINAMIC
     inline void say_M906(const bool forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOPGM("  M906"); }
     #if HAS_STEALTHCHOP
-      void say_M569(const char * const etc=NULL) {
+      void say_M569(const char * const etc=nullptr) {
         SERIAL_ECHOPGM("  M569 S1");
         if (etc) {
           SERIAL_CHAR(' ');

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -65,7 +65,7 @@ class MarlinSettings {
         static uint16_t calc_num_meshes();
         static int mesh_slot_offset(const int8_t slot);
         static void store_mesh(const int8_t slot);
-        static void load_mesh(const int8_t slot, void * const into=NULL);
+        static void load_mesh(const int8_t slot, void * const into=nullptr);
 
         //static void delete_mesh();    // necessary if we have a MAT
         //static void defrag_meshes();  // "

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -377,7 +377,7 @@ void Endstops::event_handler() {
   prev_hit_state = hit_state;
 }
 
-static void print_es_state(const bool is_hit, PGM_P const label=NULL) {
+static void print_es_state(const bool is_hit, PGM_P const label=nullptr) {
   if (label) serialprintPGM(label);
   SERIAL_ECHOPGM(": ");
   serialprintPGM(is_hit ? PSTR(MSG_ENDSTOP_HIT) : PSTR(MSG_ENDSTOP_OPEN));

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -900,7 +900,7 @@ void Planner::reverse_pass() {
   // Reverse Pass: Coarsely maximize all possible deceleration curves back-planning from the last
   // block in buffer. Cease planning when the last optimal planned or tail pointer is reached.
   // NOTE: Forward pass will later refine and correct the reverse pass to create an optimal plan.
-  const block_t *next = NULL;
+  const block_t *next = nullptr;
   while (block_index != planned_block_index) {
 
     // Perform the reverse pass
@@ -995,7 +995,7 @@ void Planner::forward_pass() {
   uint8_t block_index = block_buffer_planned;
 
   block_t *current;
-  const block_t * previous = NULL;
+  const block_t * previous = nullptr;
   while (block_index != block_buffer_head) {
 
     // Perform the forward pass
@@ -1045,7 +1045,7 @@ void Planner::recalculate_trapezoids() {
   }
 
   // Go from the tail (currently executed block) to the first block, without including it)
-  block_t *current = NULL, *next = NULL;
+  block_t *current = nullptr, *next = nullptr;
   float current_entry_speed = 0.0, next_entry_speed = 0.0;
   while (block_index != head_block_index) {
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -746,7 +746,7 @@ class Planner {
     FORCE_INLINE static bool has_blocks_queued() { return (block_buffer_head != block_buffer_tail); }
 
     /**
-     * The current block. NULL if the buffer is empty.
+     * The current block. nullptr if the buffer is empty.
      * This also marks the block as busy.
      * WARNING: Called from Stepper ISR context!
      */
@@ -763,7 +763,7 @@ class Planner {
           --delay_before_delivering;
           // If the number of movements queued is less than 3, and there is still time
           //  to wait, do not deliver anything
-          if (nr_moves < 3 && delay_before_delivering) return NULL;
+          if (nr_moves < 3 && delay_before_delivering) return nullptr;
           delay_before_delivering = 0;
         }
 
@@ -771,7 +771,7 @@ class Planner {
         block_t * const block = &block_buffer[block_buffer_tail];
 
         // No trapezoid calculated? Don't execute yet.
-        if (TEST(block->flag, BLOCK_BIT_RECALCULATE)) return NULL;
+        if (TEST(block->flag, BLOCK_BIT_RECALCULATE)) return nullptr;
 
         #if ENABLED(ULTRA_LCD)
           block_buffer_runtime_us -= block->segment_time_us; // We can't be sure how long an active block will take, so don't count it.
@@ -793,7 +793,7 @@ class Planner {
         clear_block_buffer_runtime(); // paranoia. Buffer is empty now - so reset accumulated time to zero.
       #endif
 
-      return NULL;
+      return nullptr;
     }
 
     /**

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -133,7 +133,7 @@ Stepper stepper; // Singleton
 
 // private:
 
-block_t* Stepper::current_block; // (= NULL) A pointer to the block currently being traced
+block_t* Stepper::current_block; // (= nullptr) A pointer to the block currently being traced
 
 uint8_t Stepper::last_direction_bits, // = 0
         Stepper::axis_did_move; // = 0
@@ -1394,7 +1394,7 @@ void Stepper::stepper_pulse_phase_isr() {
     abort_current_block = false;
     if (current_block) {
       axis_did_move = 0;
-      current_block = NULL;
+      current_block = nullptr;
       planner.discard_current_block();
     }
   }
@@ -1541,7 +1541,7 @@ uint32_t Stepper::stepper_block_phase_isr() {
         runout.block_completed(current_block);
       #endif
       axis_did_move = 0;
-      current_block = NULL;
+      current_block = nullptr;
       planner.discard_current_block();
     }
     else {

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1264,7 +1264,7 @@ void Temperature::manage_heater() {
       #if ENABLED(CHAMBER_USER_THERMISTOR)
         t_index == CTI_CHAMBER ? PSTR("CHAMBER") :
       #endif
-      NULL
+      nullptr
     );
     SERIAL_EOL();
   }

--- a/Marlin/src/module/thermistor/thermistors.h
+++ b/Marlin/src/module/thermistor/thermistors.h
@@ -147,7 +147,7 @@
 #elif defined(HEATER_0_USES_THERMISTOR)
   #error "No heater 0 thermistor table specified"
 #else
-  #define HEATER_0_TEMPTABLE NULL
+  #define HEATER_0_TEMPTABLE nullptr
   #define HEATER_0_TEMPTABLE_LEN 0
 #endif
 
@@ -157,7 +157,7 @@
 #elif defined(HEATER_1_USES_THERMISTOR)
   #error "No heater 1 thermistor table specified"
 #else
-  #define HEATER_1_TEMPTABLE NULL
+  #define HEATER_1_TEMPTABLE nullptr
   #define HEATER_1_TEMPTABLE_LEN 0
 #endif
 
@@ -167,7 +167,7 @@
 #elif defined(HEATER_2_USES_THERMISTOR)
   #error "No heater 2 thermistor table specified"
 #else
-  #define HEATER_2_TEMPTABLE NULL
+  #define HEATER_2_TEMPTABLE nullptr
   #define HEATER_2_TEMPTABLE_LEN 0
 #endif
 
@@ -177,7 +177,7 @@
 #elif defined(HEATER_3_USES_THERMISTOR)
   #error "No heater 3 thermistor table specified"
 #else
-  #define HEATER_3_TEMPTABLE NULL
+  #define HEATER_3_TEMPTABLE nullptr
   #define HEATER_3_TEMPTABLE_LEN 0
 #endif
 
@@ -187,7 +187,7 @@
 #elif defined(HEATER_4_USES_THERMISTOR)
   #error "No heater 4 thermistor table specified"
 #else
-  #define HEATER_4_TEMPTABLE NULL
+  #define HEATER_4_TEMPTABLE nullptr
   #define HEATER_4_TEMPTABLE_LEN 0
 #endif
 
@@ -197,7 +197,7 @@
 #elif defined(HEATER_5_USES_THERMISTOR)
   #error "No heater 5 thermistor table specified"
 #else
-  #define HEATER_5_TEMPTABLE NULL
+  #define HEATER_5_TEMPTABLE nullptr
   #define HEATER_5_TEMPTABLE_LEN 0
 #endif
 

--- a/Marlin/src/sd/SdBaseFile.cpp
+++ b/Marlin/src/sd/SdBaseFile.cpp
@@ -81,7 +81,7 @@ bool SdBaseFile::addDirCluster() {
 // cache a file's directory entry
 // return pointer to cached entry or null for failure
 dir_t* SdBaseFile::cacheDirEntry(uint8_t action) {
-  if (!vol_->cacheRawBlock(dirBlock_, action)) return NULL;
+  if (!vol_->cacheRawBlock(dirBlock_, action)) return nullptr;
   return vol_->cache()->dir + dirIndex_;
 }
 
@@ -841,7 +841,7 @@ bool SdBaseFile::openParent(SdBaseFile* dir) {
 
   // search for parent in '../..'
   do {
-    if (file.readDir(&entry, NULL) != 32) return false;
+    if (file.readDir(&entry, nullptr) != 32) return false;
     c = entry.firstClusterLow;
     c |= (uint32_t)entry.firstClusterHigh << 16;
   } while (c != cluster);

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -158,7 +158,7 @@ char *createFilename(char *buffer, const dir_t &p) {
 
 uint16_t nrFile_index;
 
-void CardReader::lsDive(const char *prepend, SdFile parent, const char * const match/*=NULL*/) {
+void CardReader::lsDive(const char *prepend, SdFile parent, const char * const match/*=nullptr*/) {
   dir_t p;
   uint8_t cnt = 0;
 
@@ -226,7 +226,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 
         case LS_GetFilename:
           createFilename(filename, p);
-          if (match != NULL) {
+          if (match != nullptr) {
             if (strcasecmp(match, filename) == 0) return;
           }
           else if (cnt == nrFile_index) return;  // 0 based index
@@ -241,7 +241,7 @@ void CardReader::lsDive(const char *prepend, SdFile parent, const char * const m
 void CardReader::ls() {
   lsAction = LS_SerialPrint;
   root.rewind();
-  lsDive(NULL, root);
+  lsDive(nullptr, root);
 }
 
 #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
@@ -276,7 +276,7 @@ void CardReader::ls() {
 
       // Find the item, setting the long filename
       diveDir.rewind();
-      lsDive(NULL, diveDir, segment);
+      lsDive(nullptr, diveDir, segment);
 
       // Print /LongNamePart to serial output
       SERIAL_CHAR('/');
@@ -528,11 +528,11 @@ void CardReader::report_status() {
 
 void CardReader::write_command(char *buf) {
   char* begin = buf;
-  char* npos = NULL;
+  char* npos = nullptr;
   char* end = buf + strlen(buf) - 1;
 
   file.writeError = false;
-  if ((npos = strchr(buf, 'N')) != NULL) {
+  if ((npos = strchr(buf, 'N')) != nullptr) {
     begin = strchr(npos, ' ') + 1;
     end = strchr(npos, '*') - 1;
   }
@@ -566,7 +566,7 @@ void CardReader::checkautostart() {
     sprintf_P(autoname, PSTR("auto%c.g"), autostart_index + '0');
     dir_t p;
     root.rewind();
-    while (root.readDir(&p, NULL) > 0) {
+    while (root.readDir(&p, nullptr) > 0) {
       for (int8_t i = (int8_t)strlen((char*)p.name); i--;) p.name[i] = tolower(p.name[i]);
       if (p.name[9] != '~' && strncmp((char*)p.name, autoname, 5) == 0) {
         openAndPrintFile(autoname);
@@ -602,9 +602,9 @@ void CardReader::closefile(const bool store_location) {
  * Get the name of a file in the current directory by index
  * with optional name to match.
  */
-void CardReader::getfilename(uint16_t nr, const char * const match/*=NULL*/) {
+void CardReader::getfilename(uint16_t nr, const char * const match/*=nullptr*/) {
   #if ENABLED(SDSORT_CACHE_NAMES)
-    if (match != NULL) {
+    if (match != nullptr) {
       while (nr < sort_count) {
         if (strcasecmp(match, sortshort[nr]) == 0) break;
         nr++;
@@ -620,14 +620,14 @@ void CardReader::getfilename(uint16_t nr, const char * const match/*=NULL*/) {
   lsAction = LS_GetFilename;
   nrFile_index = nr;
   workDir.rewind();
-  lsDive(NULL, workDir, match);
+  lsDive(nullptr, workDir, match);
 }
 
 uint16_t CardReader::getnrfilenames() {
   lsAction = LS_Count;
   nrFiles = 0;
   workDir.rewind();
-  lsDive(NULL, workDir);
+  lsDive(nullptr, workDir);
   //SERIAL_ECHOLN(nrFiles);
   return nrFiles;
 }
@@ -639,7 +639,7 @@ uint16_t CardReader::getnrfilenames() {
  *
  * Returns a pointer to the last segment (filename) of the given DOS 8.3 path.
  *
- * A NULL result indicates an unrecoverable error.
+ * A nullptr result indicates an unrecoverable error.
  */
 const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, const bool echo/*=false*/) {
   // Track both parent and subfolder
@@ -647,13 +647,13 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
   SdFile *sub = &newDir1, *startDir;
 
   const char *dirname_start = path;
-  if (path[0] == '/') { 
+  if (path[0] == '/') {
     curDir = &root;
     workDirDepth = 0;
     dirname_start++;
   }
   else
-    curDir = &workDir; 
+    curDir = &workDir;
 
   startDir = curDir;
 
@@ -674,7 +674,7 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
     // Open curDir
     if (!sub->open(curDir, dosSubdirname, O_READ)) {
       SERIAL_ECHOLNPAIR(MSG_SD_OPEN_FILE_FAIL, dosSubdirname, ".");
-      return NULL;
+      return nullptr;
     }
 
     // Close curDir if not at starting-point

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -78,7 +78,7 @@ public:
     static void printLongPath(char *path);
   #endif
 
-  static void getfilename(uint16_t nr, const char* const match=NULL);
+  static void getfilename(uint16_t nr, const char* const match=nullptr);
   static uint16_t getnrfilenames();
 
   static void getAbsFilename(char *t);
@@ -224,7 +224,7 @@ private:
   static LsAction lsAction; //stored for recursion.
   static uint16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.
   static char *diveDirName;
-  static void lsDive(const char *prepend, SdFile parent, const char * const match=NULL);
+  static void lsDive(const char *prepend, SdFile parent, const char * const match=nullptr);
 
   #if ENABLED(SDCARD_SORT_ALPHA)
     static void flush_presort();

--- a/Marlin/src/sd/usb_flashdrive/lib/Usb.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib/Usb.cpp
@@ -57,7 +57,7 @@ EpInfo* USB::getEpInfoEntry(uint8_t addr, uint8_t ep) {
   UsbDevice *p = addrPool.GetUsbDevicePtr(addr);
 
   if (!p || !p->epinfo)
-    return NULL;
+    return nullptr;
 
   EpInfo *pep = p->epinfo;
 
@@ -67,7 +67,7 @@ EpInfo* USB::getEpInfoEntry(uint8_t addr, uint8_t ep) {
 
     pep++;
   }
-  return NULL;
+  return nullptr;
 }
 
 /* set device table entry */
@@ -141,7 +141,7 @@ uint8_t USB::ctrlReq(uint8_t addr, uint8_t ep, uint8_t bmReqType, uint8_t bReque
   uint8_t rcode;
   SETUP_PKT setup_pkt;
 
-  EpInfo *pep = NULL;
+  EpInfo *pep = nullptr;
   uint16_t nak_limit = 0;
 
   rcode = SetAddress(addr, ep, &pep, &nak_limit);
@@ -162,7 +162,7 @@ uint8_t USB::ctrlReq(uint8_t addr, uint8_t ep, uint8_t bmReqType, uint8_t bReque
   rcode = dispatchPkt(tokSETUP, ep, nak_limit); //dispatch packet
   if (rcode) return rcode; // Return HRSLT if not zero
 
-  if (dataptr != NULL) { //data stage, if present
+  if (dataptr != nullptr) { //data stage, if present
     if (direction) { //IN transfer
       uint16_t left = total;
       pep->bmRcvToggle = 1; //bmRCVTOG1;
@@ -205,7 +205,7 @@ uint8_t USB::ctrlReq(uint8_t addr, uint8_t ep, uint8_t bmReqType, uint8_t bReque
 /* rcode 0 if no errors. rcode 01-0f is relayed from dispatchPkt(). Rcode f0 means RCVDAVIRQ error,
       fe USB xfer timeout */
 uint8_t USB::inTransfer(uint8_t addr, uint8_t ep, uint16_t *nbytesptr, uint8_t* data, uint8_t bInterval /*= 0*/) {
-  EpInfo *pep = NULL;
+  EpInfo *pep = nullptr;
   uint16_t nak_limit = 0;
 
   uint8_t rcode = SetAddress(addr, ep, &pep, &nak_limit);
@@ -289,7 +289,7 @@ uint8_t USB::InTransfer(EpInfo *pep, uint16_t nak_limit, uint16_t *nbytesptr, ui
 
 /* rcode 0 if no errors. rcode 01-0f is relayed from HRSL                       */
 uint8_t USB::outTransfer(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* data) {
-  EpInfo *pep = NULL;
+  EpInfo *pep = nullptr;
   uint16_t nak_limit = 0;
 
   uint8_t rcode = SetAddress(addr, ep, &pep, &nak_limit);
@@ -529,7 +529,7 @@ void USB::Task(void) { //USB state machine
 uint8_t USB::DefaultAddressing(uint8_t parent, uint8_t port, bool lowspeed) {
   //uint8_t                buf[12];
   uint8_t rcode;
-  UsbDevice *p0 = NULL, *p = NULL;
+  UsbDevice *p0 = nullptr, *p = nullptr;
 
   // Get pointer to pseudo device with address 0 assigned
   p0 = addrPool.GetUsbDevicePtr(0);
@@ -649,8 +649,8 @@ uint8_t USB::Configuring(uint8_t parent, uint8_t port, bool lowspeed) {
   uint8_t rcode = 0;
   uint8_t buf[sizeof (USB_DEVICE_DESCRIPTOR)];
   USB_DEVICE_DESCRIPTOR *udd = reinterpret_cast<USB_DEVICE_DESCRIPTOR *>(buf);
-  UsbDevice *p = NULL;
-  EpInfo *oldep_ptr = NULL;
+  UsbDevice *p = nullptr;
+  EpInfo *oldep_ptr = nullptr;
   EpInfo epInfo;
 
   epInfo.epAddr = 0;
@@ -749,12 +749,12 @@ uint8_t USB::ReleaseDevice(uint8_t addr) {
 //get device descriptor
 
 uint8_t USB::getDevDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* dataptr) {
-  return ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, 0x00, USB_DESCRIPTOR_DEVICE, 0x0000, nbytes, nbytes, dataptr, NULL);
+  return ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, 0x00, USB_DESCRIPTOR_DEVICE, 0x0000, nbytes, nbytes, dataptr, nullptr);
 }
 //get configuration descriptor
 
 uint8_t USB::getConfDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t conf, uint8_t* dataptr) {
-  return ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, conf, USB_DESCRIPTOR_CONFIGURATION, 0x0000, nbytes, nbytes, dataptr, NULL);
+  return ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, conf, USB_DESCRIPTOR_CONFIGURATION, 0x0000, nbytes, nbytes, dataptr, nullptr);
 }
 
 /* Requests Configuration Descriptor. Sends two Get Conf Descr requests. The first one gets the total length of all descriptors, then the second one requests this
@@ -777,21 +777,21 @@ uint8_t USB::getConfDescr(uint8_t addr, uint8_t ep, uint8_t conf, USBReadParser 
 //get string descriptor
 
 uint8_t USB::getStrDescr(uint8_t addr, uint8_t ep, uint16_t ns, uint8_t index, uint16_t langid, uint8_t* dataptr) {
-  return ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, index, USB_DESCRIPTOR_STRING, langid, ns, ns, dataptr, NULL);
+  return ctrlReq(addr, ep, bmREQ_GET_DESCR, USB_REQUEST_GET_DESCRIPTOR, index, USB_DESCRIPTOR_STRING, langid, ns, ns, dataptr, nullptr);
 }
 //set address
 
 uint8_t USB::setAddr(uint8_t oldaddr, uint8_t ep, uint8_t newaddr) {
-  uint8_t rcode = ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, 0x0000, NULL, NULL);
+  uint8_t rcode = ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, 0x0000, nullptr, nullptr);
   //delay(2); //per USB 2.0 sect.9.2.6.3
   delay(300); // Older spec says you should wait at least 200ms
   return rcode;
-  //return ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, 0x0000, NULL, NULL);
+  //return ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, 0x0000, nullptr, nullptr);
 }
 //set configuration
 
 uint8_t USB::setConf(uint8_t addr, uint8_t ep, uint8_t conf_value) {
-  return ctrlReq(addr, ep, bmREQ_SET, USB_REQUEST_SET_CONFIGURATION, conf_value, 0x00, 0x0000, 0x0000, 0x0000, NULL, NULL);
+  return ctrlReq(addr, ep, bmREQ_SET, USB_REQUEST_SET_CONFIGURATION, conf_value, 0x00, 0x0000, 0x0000, 0x0000, nullptr, nullptr);
 }
 
 #endif // defined(USB_METHODS_INLINE)

--- a/Marlin/src/sd/usb_flashdrive/lib/UsbCore.h
+++ b/Marlin/src/sd/usb_flashdrive/lib/UsbCore.h
@@ -301,12 +301,12 @@ inline uint8_t USB::getStrDescr(uint8_t addr, uint8_t ep, uint16_t nuint8_ts, ui
 //set address
 
 inline uint8_t USB::setAddr(uint8_t oldaddr, uint8_t ep, uint8_t newaddr) {
-  return ( ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, NULL));
+  return ( ctrlReq(oldaddr, ep, bmREQ_SET, USB_REQUEST_SET_ADDRESS, newaddr, 0x00, 0x0000, 0x0000, nullptr));
 }
 //set configuration
 
 inline uint8_t USB::setConf(uint8_t addr, uint8_t ep, uint8_t conf_value) {
-  return ( ctrlReq(addr, ep, bmREQ_SET, USB_REQUEST_SET_CONFIGURATION, conf_value, 0x00, 0x0000, 0x0000, NULL));
+  return ( ctrlReq(addr, ep, bmREQ_SET, USB_REQUEST_SET_CONFIGURATION, conf_value, 0x00, 0x0000, 0x0000, nullptr));
 }
 
 #endif // defined(USB_METHODS_INLINE)

--- a/Marlin/src/sd/usb_flashdrive/lib/address.h
+++ b/Marlin/src/sd/usb_flashdrive/lib/address.h
@@ -183,7 +183,7 @@ public:
   virtual UsbDevice* GetUsbDevicePtr(uint8_t addr) {
     if (!addr) return thePool;
     uint8_t index = FindAddressIndex(addr);
-    return index ? thePool + index : NULL;
+    return index ? thePool + index : nullptr;
   }
 
   // Perform an operation specified by pfunc for each addressed device

--- a/Marlin/src/sd/usb_flashdrive/lib/masstorage.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib/masstorage.cpp
@@ -118,7 +118,7 @@ uint8_t BulkOnly::LockMedia(uint8_t lun, uint8_t lock) {
   Notify(PSTR("---------\r\n"), 0x80);
 
   CDB6_t cdb = CDB6_t(SCSI_CMD_PREVENT_REMOVAL, lun, (uint8_t)0, lock);
-  return SCSITransaction6(&cdb, (uint16_t)0, NULL, (uint8_t)MASS_CMD_DIR_IN);
+  return SCSITransaction6(&cdb, (uint16_t)0, nullptr, (uint8_t)MASS_CMD_DIR_IN);
 }
 
 /**
@@ -136,7 +136,7 @@ uint8_t BulkOnly::MediaCTL(uint8_t lun, uint8_t ctl) {
   uint8_t rcode = MASS_ERR_UNIT_NOT_READY;
   if (bAddress) {
     CDB6_t cdb = CDB6_t(SCSI_CMD_START_STOP_UNIT, lun, ctl & 0x03, 0);
-    rcode = SCSITransaction6(&cdb, (uint16_t)0, NULL, (uint8_t)MASS_CMD_DIR_OUT);
+    rcode = SCSITransaction6(&cdb, (uint16_t)0, nullptr, (uint8_t)MASS_CMD_DIR_OUT);
   }
   else
     SetCurLUN(lun);
@@ -255,8 +255,8 @@ uint8_t BulkOnly::ConfigureDevice(uint8_t parent, uint8_t port, bool lowspeed) {
   uint8_t buf[constBufSize];
   USB_DEVICE_DESCRIPTOR * udd = reinterpret_cast<USB_DEVICE_DESCRIPTOR*>(buf);
   uint8_t rcode;
-  UsbDevice *p = NULL;
-  EpInfo *oldep_ptr = NULL;
+  UsbDevice *p = nullptr;
+  EpInfo *oldep_ptr = nullptr;
   USBTRACE("MS ConfigureDevice\r\n");
   ClearAllEP();
   AddressPool &addrPool = pUsb->GetAddressPool();
@@ -668,7 +668,7 @@ uint8_t BulkOnly::Poll() {
  * @return
  */
 uint8_t BulkOnly::GetMaxLUN(uint8_t *plun) {
-        uint8_t ret = pUsb->ctrlReq(bAddress, 0, bmREQ_MASSIN, MASS_REQ_GET_MAX_LUN, 0, 0, bIface, 1, 1, plun, NULL);
+        uint8_t ret = pUsb->ctrlReq(bAddress, 0, bmREQ_MASSIN, MASS_REQ_GET_MAX_LUN, 0, 0, bIface, 1, 1, plun, nullptr);
 
         if (ret == hrSTALL)
                 *plun = 0;
@@ -709,7 +709,7 @@ uint8_t BulkOnly::TestUnitReady(uint8_t lun) {
         Notify(PSTR("-----------------\r\n"), 0x80);
 
         CDB6_t cdb = CDB6_t(SCSI_CMD_TEST_UNIT_READY, lun, (uint8_t)0, 0);
-        return SCSITransaction6(&cdb, 0, NULL, (uint8_t)MASS_CMD_DIR_IN);
+        return SCSITransaction6(&cdb, 0, nullptr, (uint8_t)MASS_CMD_DIR_IN);
 
 }
 
@@ -813,7 +813,7 @@ uint8_t BulkOnly::ClearEpHalt(uint8_t index) {
 
         uint8_t ret = 0;
 
-        while ((ret = (pUsb->ctrlReq(bAddress, 0, USB_SETUP_HOST_TO_DEVICE | USB_SETUP_TYPE_STANDARD | USB_SETUP_RECIPIENT_ENDPOINT, USB_REQUEST_CLEAR_FEATURE, USB_FEATURE_ENDPOINT_HALT, 0, ((index == epDataInIndex) ? (0x80 | epInfo[index].epAddr) : epInfo[index].epAddr), 0, 0, NULL, NULL)) == 0x01))
+        while ((ret = (pUsb->ctrlReq(bAddress, 0, USB_SETUP_HOST_TO_DEVICE | USB_SETUP_TYPE_STANDARD | USB_SETUP_RECIPIENT_ENDPOINT, USB_REQUEST_CLEAR_FEATURE, USB_FEATURE_ENDPOINT_HALT, 0, ((index == epDataInIndex) ? (0x80 | epInfo[index].epAddr) : epInfo[index].epAddr), 0, 0, nullptr, nullptr)) == 0x01))
                 delay(6);
 
         if (ret) {
@@ -831,7 +831,7 @@ uint8_t BulkOnly::ClearEpHalt(uint8_t index) {
  *
  */
 void BulkOnly::Reset() {
-        while (pUsb->ctrlReq(bAddress, 0, bmREQ_MASSOUT, MASS_REQ_BOMSR, 0, 0, bIface, 0, 0, NULL, NULL) == 0x01) delay(6);
+        while (pUsb->ctrlReq(bAddress, 0, bmREQ_MASSOUT, MASS_REQ_BOMSR, 0, 0, bIface, 0, 0, nullptr, nullptr) == 0x01) delay(6);
 }
 
 /**

--- a/Marlin/src/sd/usb_flashdrive/lib/parsetools.h
+++ b/Marlin/src/sd/usb_flashdrive/lib/parsetools.h
@@ -40,7 +40,7 @@ class MultiByteValueParser {
 
 public:
 
-  MultiByteValueParser() : pBuf(NULL), countDown(0), valueSize(0) {
+  MultiByteValueParser() : pBuf(nullptr), countDown(0), valueSize(0) {
   };
 
   const uint8_t* GetBuffer() { return pBuf; }
@@ -60,7 +60,7 @@ class ByteSkipper {
 
 public:
 
-  ByteSkipper() : pBuf(NULL), nStage(0), countDown(0) {
+  ByteSkipper() : pBuf(nullptr), nStage(0), countDown(0) {
   }
 
   void Initialize(MultiValueBuffer *pbuf) {
@@ -119,7 +119,7 @@ public:
     arLenCntdn(0),
     lenSize(0),
     valSize(0),
-    pBuf(NULL),
+    pBuf(nullptr),
     prsMode(modeArray) { }
   ;
 
@@ -141,5 +141,5 @@ public:
     theParser.Initialize(p);
   }
 
-  bool Parse(uint8_t **pp, uint16_t *pcntdn, PTP_ARRAY_EL_FUNC pf, const void *me = NULL);
+  bool Parse(uint8_t **pp, uint16_t *pcntdn, PTP_ARRAY_EL_FUNC pf, const void *me = nullptr);
 };

--- a/buildroot/share/pin_interrupt_test/pin_interrupt_test.ino
+++ b/buildroot/share/pin_interrupt_test/pin_interrupt_test.ino
@@ -5,7 +5,7 @@
     #undef  digitalPinToPCICR
     #define digitalPinToPCICR(p)    ( ((p) >= 10 && (p) <= 15) || \
                                       ((p) >= 50 && (p) <= 53) || \
-                                      ((p) >= 62 && (p) <= 69) ? &PCICR : (uint8_t *)0)
+                                      ((p) >= 62 && (p) <= 69) ? &PCICR : nullptr)
 #endif
 
 void setup() {


### PR DESCRIPTION
It is now recommended to use `nullptr` which is the C++ language-supported equivalent to the `NULL` macro. Other than being a language built-in and not a macro, there are some minor advantages to this small modernization, such as not needing to cast `nullptr` to the current pointer type.