### PR TITLE
Fix STM32 timer warnings

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_STM32F1.cpp
@@ -121,7 +121,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
       timer_set_count(STEP_TIMER_DEV, 0);
       timer_set_prescaler(STEP_TIMER_DEV, (uint16_t)(STEPPER_TIMER_PRESCALE - 1));
       timer_set_reload(STEP_TIMER_DEV, 0xFFFF);
-      timer_set_compare(STEP_TIMER_DEV, STEP_TIMER_CHAN, MIN(HAL_TIMER_TYPE_MAX, (STEPPER_TIMER_RATE / frequency)));
+      timer_set_compare(STEP_TIMER_DEV, STEP_TIMER_CHAN, MIN(hal_timer_t(HAL_TIMER_TYPE_MAX), (STEPPER_TIMER_RATE / frequency)));
       timer_attach_interrupt(STEP_TIMER_DEV, STEP_TIMER_CHAN, stepTC_Handler);
       nvic_irq_set_priority(irq_num, 1);
       timer_generate_update(STEP_TIMER_DEV);
@@ -132,7 +132,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
       timer_set_count(TEMP_TIMER_DEV, 0);
       timer_set_prescaler(TEMP_TIMER_DEV, (uint16_t)(TEMP_TIMER_PRESCALE - 1));
       timer_set_reload(TEMP_TIMER_DEV, 0xFFFF);
-      timer_set_compare(TEMP_TIMER_DEV, TEMP_TIMER_CHAN, MIN(HAL_TIMER_TYPE_MAX, ((F_CPU / TEMP_TIMER_PRESCALE) / frequency)));
+      timer_set_compare(TEMP_TIMER_DEV, TEMP_TIMER_CHAN, MIN(hal_timer_t(HAL_TIMER_TYPE_MAX), ((F_CPU / TEMP_TIMER_PRESCALE) / frequency)));
       timer_attach_interrupt(TEMP_TIMER_DEV, TEMP_TIMER_CHAN, tempTC_Handler);
       nvic_irq_set_priority(irq_num, 2);
       timer_generate_update(TEMP_TIMER_DEV);
@@ -213,6 +213,7 @@ timer_dev* get_timer_dev(int number) {
     #if STM32_HAVE_TIMER(14)
       case 14: return &timer14;
     #endif
+      default: // need to return something...
   }
 }
 

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_timers_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_timers_STM32F1.cpp
@@ -213,7 +213,7 @@ timer_dev* get_timer_dev(int number) {
     #if STM32_HAVE_TIMER(14)
       case 14: return &timer14;
     #endif
-      default: // need to return something...
+      default: return nullptr;
   }
 }
 


### PR DESCRIPTION
Fix sign warnings in STM32F1 timers, HAL_TIMER_TYPE_MAX seems signed by default... and should not be