### PR TITLE
Fixed FYSETC MINI 12864 2.1 bugs

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -156,7 +156,7 @@
     #define RGB_LED
   #elif ENABLED(FYSETC_MINI_12864_2_1)
     #define NEOPIXEL_LED
-    #define NEOPIXEL_TYPE       NEO_GRB
+    #define NEOPIXEL_TYPE       NEO_RGB
     #define NEOPIXEL_PIXELS     3
     #define NEOPIXEL_BRIGHTNESS 127
   #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1828,6 +1828,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
  */
 #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0) && DISABLED(RGB_LED)
   #error "RGB_LED is required for FYSETC_MINI_12864 1.2 and 2.0."
+#elif EITHER(FYSETC_MINI_12864_2_0, FYSETC_MINI_12864_2_1) && DISABLED(LED_CONTROL_MENU)
+  #error "LED_CONTROL_MENU is required for FYSETC_MINI_12864 2.x displays."
 #elif EITHER(FYSETC_MINI_12864_2_0, FYSETC_MINI_12864_2_1) && DISABLED(LED_USER_PRESET_STARTUP)
   #error "LED_USER_PRESET_STARTUP is required for FYSETC_MINI_12864 2.x displays."
 #elif ENABLED(FYSETC_MINI_12864_2_1)
@@ -1842,8 +1844,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
       #define NEO_GRB 0xFAD
       #define _UNDO_NEO_GRB
     #endif
-    #if NEOPIXEL_TYPE != NEO_GRB
-      #error "NEOPIXEL_TYPE should be NEO_GRB for FYSETC_MINI_12864 Rev. 2.1."
+    #if NEOPIXEL_TYPE != NEO_RGB
+      #error "NEOPIXEL_TYPE should be NEO_RGB for FYSETC_MINI_12864 Rev. 2.1."
     #endif
     #ifdef _UNDO_NEO_GRB
       #undef NEO_GRB

--- a/Marlin/src/pins/pins_RAMPS.h
+++ b/Marlin/src/pins/pins_RAMPS.h
@@ -532,12 +532,12 @@
       #define DOGLCD_A0         16
       #define DOGLCD_CS         17
 
-      #define BTN_EN1           31
-      #define BTN_EN2           33
+      #define BTN_EN1           33
+      #define BTN_EN2           31
       #define BTN_ENC           35
 
       #define SD_DETECT_PIN     49
-
+      #define KILL_PIN          41
 
 
       //#define FORCE_SOFT_SPI    // Use this if default of hardware SPI causes display problems


### PR DESCRIPTION
### Requirements

FYSETC MINI 12864 2.1 LCD display

### Description

The RGB channels have R and G where swapped. Correct NEO_RGB definition used and sanity check updated. The encoder was backwards, swapped BTN_EN1 and BTN_EN2  pin definitions to resolve. Added a new sanity check to make sure  LED_CONTROL_MENU is enabled for this display. Added KILL_PIN define for this display to pins_RAMPS.h as it was missing.

### Benefits

Display now works as expected.

### Related Issues
