### PR TITLE
Add heater timeouts to ExtUI

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -49,6 +49,10 @@
   #include "host_actions.h"
 #endif
 
+#if ENABLED(EXTENSIBLE_UI)
+  #include "../lcd/extensible_ui/ui_api.h"
+#endif
+
 #include "../lcd/ultralcd.h"
 #include "../libs/buzzer.h"
 #include "../libs/nozzle.h"
@@ -538,6 +542,9 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
       #if ENABLED(HOST_PROMPT_SUPPORT)
         host_prompt_do(PROMPT_USER_CONTINUE, PSTR("Reheating"));
       #endif
+      #if ENABLED(EXTENSIBLE_UI)
+        ExtUI::onStatusChanged(PSTR("Reheating..."));
+      #endif
 
       // Re-enable the heaters if they timed out
       HOTEND_LOOP() thermalManager.reset_heater_idle_timer(e);
@@ -554,6 +561,9 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
       HOTEND_LOOP() thermalManager.hotend_idle[e].start(nozzle_timeout);
       #if ENABLED(HOST_PROMPT_SUPPORT)
         host_prompt_do(PROMPT_USER_CONTINUE, PSTR("Reheat Done"), PSTR("Continue"));
+      #endif
+      #if ENABLED(EXTENSIBLE_UI)
+        ExtUI::onUserConfirmRequired("Reheat finished.");
       #endif
       wait_for_user = true;
       nozzle_timed_out = false;

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -164,6 +164,45 @@ namespace ExtUI {
       thermalManager.manage_heater();
   }
 
+  void enableHeater(const extruder_t extruder) {
+    #if HEATER_IDLE_HANDLER
+      thermalManager.reset_heater_idle_timer(extruder - E0);
+    #endif
+  }
+
+  void enableHeater(const heater_t heater) {
+    #if HEATER_IDLE_HANDLER
+      #if HAS_HEATED_BED
+        if(heater == BED)
+          thermalManager.reset_bed_idle_timer();
+        else
+      #endif
+      thermalManager.reset_heater_idle_timer(heater - H0);
+    #endif
+  }
+
+  bool isHeaterIdle(const extruder_t extruder) {
+    #if HEATER_IDLE_HANDLER
+      return thermalManager.hotend_idle[extruder - E0].timed_out;
+    #else
+      return false;
+    #endif
+  }
+
+  bool isHeaterIdle(const heater_t heater) {
+    #if HEATER_IDLE_HANDLER
+      return heater == BED ?
+        #if HAS_HEATED_BED
+          thermalManager.bed_idle.timed_out
+        #else
+          0
+        #endif
+        : thermalManager.hotend_idle[heater - H0].timed_out;
+    #else
+      return false;
+    #endif
+  }
+
   float getActualTemp_celsius(const heater_t heater) {
     return heater == BED ?
       #if HAS_HEATED_BED
@@ -761,6 +800,7 @@ namespace ExtUI {
   void setTargetTemp_celsius(float value, const heater_t heater) {
     constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP);
     const int16_t e = heater - H0;
+    enableHeater(heater);
     #if HAS_HEATED_BED
       if (heater == BED)
         thermalManager.setTargetBed(clamp(value, 0, BED_MAXTEMP - 10));
@@ -772,6 +812,7 @@ namespace ExtUI {
   void setTargetTemp_celsius(float value, const extruder_t extruder) {
     constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP);
     const int16_t e = extruder - E0;
+    enableHeater(extruder);
     thermalManager.setTargetHotend(clamp(value, 0, heater_maxtemp[e] - 15), e);
   }
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -173,11 +173,11 @@ namespace ExtUI {
   void enableHeater(const heater_t heater) {
     #if HEATER_IDLE_HANDLER
       #if HAS_HEATED_BED
-        if(heater == BED)
+        if (heater == BED)
           thermalManager.reset_bed_idle_timer();
         else
       #endif
-      thermalManager.reset_heater_idle_timer(heater - H0);
+          thermalManager.reset_heater_idle_timer(heater - H0);
     #endif
   }
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -148,9 +148,7 @@ namespace ExtUI {
     }
   #endif // __SAM3X8E__
 
-  void delay_us(unsigned long us) {
-    DELAY_US(us);
-  }
+  void delay_us(unsigned long us) { DELAY_US(us); }
 
   void delay_ms(unsigned long ms) {
     if (flags.printer_killed)
@@ -182,35 +180,31 @@ namespace ExtUI {
   }
 
   bool isHeaterIdle(const extruder_t extruder) {
-    #if HEATER_IDLE_HANDLER
-      return thermalManager.hotend_idle[extruder - E0].timed_out;
-    #else
-      return false;
-    #endif
+    return false
+      #if HEATER_IDLE_HANDLER
+        || thermalManager.hotend_idle[extruder - E0].timed_out
+      #endif
+    ;
   }
 
   bool isHeaterIdle(const heater_t heater) {
-    #if HEATER_IDLE_HANDLER
-      return heater == BED ?
-        #if HAS_HEATED_BED
-          thermalManager.bed_idle.timed_out
-        #else
-          0
-        #endif
-        : thermalManager.hotend_idle[heater - H0].timed_out;
-    #else
-      return false;
-    #endif
+    return (false
+      #if HEATER_IDLE_HANDLER
+        || (heater == BED ? (false
+          #if HAS_HEATED_BED
+            || thermalManager.bed_idle.timed_out
+          #endif
+        ) : thermalManager.hotend_idle[heater - H0].timed_out)
+      #endif
+    );
   }
 
   float getActualTemp_celsius(const heater_t heater) {
-    return heater == BED ?
+    return heater == BED ? (0
       #if HAS_HEATED_BED
-        thermalManager.degBed()
-      #else
-        0
+        + thermalManager.degBed()
       #endif
-      : thermalManager.degHotend(heater - H0);
+    ) : thermalManager.degHotend(heater - H0);
   }
 
   float getActualTemp_celsius(const extruder_t extruder) {
@@ -218,13 +212,11 @@ namespace ExtUI {
   }
 
   float getTargetTemp_celsius(const heater_t heater) {
-    return heater == BED ?
+    return heater == BED ? (0
       #if HAS_HEATED_BED
-        thermalManager.degTargetBed()
-      #else
-        0
+        + thermalManager.degTargetBed()
       #endif
-      : thermalManager.degTargetHotend(heater - H0);
+    ) : thermalManager.degTargetHotend(heater - H0);
   }
 
   float getTargetTemp_celsius(const extruder_t extruder) {
@@ -291,8 +283,7 @@ namespace ExtUI {
       }
     #endif
 
-    if (!flags.manual_motion)
-      set_destination_from_current();
+    if (!flags.manual_motion) set_destination_from_current();
     destination[axis] = clamp(position, min, max);
     flags.manual_motion = true;
   }
@@ -300,8 +291,7 @@ namespace ExtUI {
   void setAxisPosition_mm(const float position, const extruder_t extruder) {
     setActiveTool(extruder, true);
 
-    if (!flags.manual_motion)
-      set_destination_from_current();
+    if (!flags.manual_motion) set_destination_from_current();
     destination[E_AXIS] = position;
     flags.manual_motion = true;
   }
@@ -342,8 +332,7 @@ namespace ExtUI {
     #if EXTRUDERS > 1
       const uint8_t e = extruder - E0;
       #if DO_SWITCH_EXTRUDER || EITHER(SWITCHING_NOZZLE, PARKING_EXTRUDER)
-        if (e != active_extruder)
-          tool_change(e, 0, no_move);
+        if (e != active_extruder) tool_change(e, 0, no_move);
       #endif
       active_extruder = e;
     #endif
@@ -380,13 +369,8 @@ namespace ExtUI {
   }
 
   #if HAS_SOFTWARE_ENDSTOPS
-    bool getSoftEndstopState() {
-      return soft_endstops_enabled;
-    }
-
-    void setSoftEndstopState(const bool value) {
-      soft_endstops_enabled = value;
-    }
+    bool getSoftEndstopState() { return soft_endstops_enabled; }
+    void setSoftEndstopState(const bool value) { soft_endstops_enabled = value; }
   #endif
 
   #if HAS_TRINAMIC
@@ -552,13 +536,8 @@ namespace ExtUI {
     void setFilamentRunoutEnabled(const bool value) { runout.enabled = value; }
 
     #ifdef FILAMENT_RUNOUT_DISTANCE_MM
-      float getFilamentRunoutDistance_mm() {
-        return runout.runout_distance();
-      }
-
-      void setFilamentRunoutDistance_mm(const float value) {
-        runout.set_runout_distance(clamp(value, 0, 999));
-      }
+      float getFilamentRunoutDistance_mm()                 { return runout.runout_distance(); }
+      void setFilamentRunoutDistance_mm(const float value) { runout.set_runout_distance(clamp(value, 0, 999)); }
     #endif
   #endif
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -70,6 +70,11 @@ namespace ExtUI {
   void enqueueCommands_P(PGM_P const);
   bool commandsInQueue();
 
+  bool isHeaterIdle(const heater_t);
+  bool isHeaterIdle(const extruder_t);
+  void enableHeater(const heater_t);
+  void enableHeater(const extruder_t);
+
   /**
    * Getters and setters
    * Should be used by the EXTENSIBLE_UI to query or change Marlin's state.


### PR DESCRIPTION
Add heater timeouts to ExtUI.

- Add local UI methods to get heater timeout state.
- Add methods to resume timed-out heaters.
- Re-enable heaters on UI temperature request.
- Make `ExtUI` show a dialog box if pause needs a button press after reheat.
