### PR TITLE
Fix HAL_DUE multiple define error with graphical LCD

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -64,16 +64,7 @@
 
 #include <U8glib.h>
 
-void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index) {
-  PIO_Configure(g_APinDescription[u8g->pin_list[pin_index]].pPort, PIO_OUTPUT_1,
-    g_APinDescription[u8g->pin_list[pin_index]].ulPin, g_APinDescription[u8g->pin_list[pin_index]].ulPinConfiguration);  // OUTPUT
-}
-
-void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level) {
-  volatile Pio* port = g_APinDescription[u8g->pin_list[pin_index]].pPort;
-  uint32_t mask = g_APinDescription[u8g->pin_list[pin_index]].ulPin;
-  if (level) port->PIO_SODR = mask; else port->PIO_CODR = mask;
-}
+#include "u8g_com_HAL_DUE_sw_spi_shared.h"
 
 Pio *SCK_pPio, *MOSI_pPio;
 uint32_t SCK_dwMask, MOSI_dwMask;

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -67,6 +67,8 @@
 
 #include <U8glib.h>
 
+#include "u8g_com_HAL_DUE_sw_spi_shared.h"
+
 void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index) {
   PIO_Configure(g_APinDescription[u8g->pin_list[pin_index]].pPort, PIO_OUTPUT_1,
     g_APinDescription[u8g->pin_list[pin_index]].ulPin, g_APinDescription[u8g->pin_list[pin_index]].ulPinConfiguration);  // OUTPUT

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -57,9 +57,6 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-//C:\Users\bobku\Documents\GitHub\Marlin-Bob-2\Marlin\src\inc\MarlinConfigPre.h
-//C:\Users\bobku\Documents\GitHub\Marlin-Bob-2\Marlin\src\HAL\HAL_DUE\u8g_com_HAL_DUE_sw_spi_shared.cpp
-
 #if HAS_GRAPHICAL_LCD
 
 #include "../shared/Marduino.h"
@@ -96,7 +93,6 @@ void U8G_spiSend_sw_DUE_mode_0(uint8_t val) { // 800KHz
     SCK_pPio->PIO_CODR = SCK_dwMask;
   }
 }
-
 
 void U8G_spiSend_sw_DUE_mode_3(uint8_t val) { // 800KHz
   for (uint8_t i = 0; i < 8; i++) {

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.h
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.h
@@ -1,0 +1,25 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index);
+void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level);


### PR DESCRIPTION
Fix multiple definitions error:

```
applet/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.o: In function `u8g_SetPIOutput_DUE(_u8g_t*, unsigned char)':
u8g_com_HAL_DUE_sw_spi_shared.cpp:(.text._Z19u8g_SetPIOutput_DUEP6_u8g_th+0x0): multiple definition of `u8g_SetPIOutput_DUE(_u8g_t*, unsigned char)'
applet/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.o:u8g_com_HAL_DUE_st7920_sw_spi.cpp:(.text._Z19u8g_SetPIOutput_DUEP6_u8g_th+0x0): first defined here
applet/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.o: In function `u8g_SetPILevel_DUE(_u8g_t*, unsigned char, unsigned char)':
u8g_com_HAL_DUE_sw_spi_shared.cpp:(.text._Z18u8g_SetPILevel_DUEP6_u8g_thh+0x0): multiple definition of `u8g_SetPILevel_DUE(_u8g_t*, unsigned char, unsigned char)'
applet/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.o:u8g_com_HAL_DUE_st7920_sw_spi.cpp:(.text._Z18u8g_SetPILevel_DUEP6_u8g_thh+0x0): first defined here
collect2: error: ld returned 1 exit status
Makefile:862: recipe for target 'applet/Marlin.elf' failed
make: *** [applet/Marlin.elf] Error 1

```