### PR TITLE
Cleaner EEPROM auto init

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -955,15 +955,7 @@ void setup() {
 
   // Load data from EEPROM if available (or use defaults)
   // This also updates variables in the planner, elsewhere
-  #if ENABLED(EEPROM_AUTO_INIT)
-    if (!settings.load()) {
-      (void)settings.reset();
-      (void)settings.save();
-      SERIAL_ECHO_MSG("EEPROM Initialized");
-    }
-  #else
-    (void)settings.load();
-  #endif
+  (void)settings.load();
 
   #if HAS_M206_COMMAND
     // Initialize current position based on home_offset

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2072,7 +2072,7 @@ void MarlinSettings::postprocess() {
     }
     reset();
     #if ENABLED(EEPROM_AUTO_INIT)
-      (void)settings.save();
+      (void)save();
       SERIAL_ECHO_MSG("EEPROM Initialized");
     #endif
     return true;

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2071,6 +2071,10 @@ void MarlinSettings::postprocess() {
       return success;
     }
     reset();
+    #if ENABLED(EEPROM_AUTO_INIT)
+      (void)settings.save();
+      SERIAL_ECHO_MSG("EEPROM Initialized");
+    #endif
     return true;
   }
 


### PR DESCRIPTION
This solution seemed cleaner, since oddly true was returned when validate failed probably because it loaded defaults, missing one scenario this should have reset initially.