### PR TITLE
[2.0.x] Killed because it is a duplication of PR #13985

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
@@ -43,7 +43,7 @@ static char HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
 
   #include "../../sd/cardreader.h"
 
-  static const char eeprom_filename[] = "eeprom.dat";
+  static char eeprom_filename[] = "eeprom.dat";
 
   bool PersistentStore::access_start() {
     if (!card.isDetected()) return false;


### PR DESCRIPTION
Per issue #13981 - the fix STM32F1 Travis error is to modify the declaration for file name array.