### PR TITLE
Fix DUE HAL SW SPI compile error

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_st7920_sw_spi.cpp
@@ -59,11 +59,11 @@
 
 #if ENABLED(U8GLIB_ST7920)
 
-#include "u8g_com_HAL_DUE_sw_spi_shared.h"
-
 #include "../shared/Delay.h"
 
 #include <U8glib.h>
+
+#include "u8g_com_HAL_DUE_sw_spi_shared.h"
 
 #define SPISEND_SW_DUE u8g_spiSend_sw_DUE_mode_0
 

--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -59,11 +59,11 @@
 
 #if HAS_GRAPHICAL_LCD
 
-#include "u8g_com_HAL_DUE_sw_spi_shared.h"
-
 #include "../shared/Delay.h"
 
 #include <U8glib.h>
+
+#include "u8g_com_HAL_DUE_sw_spi_shared.h"
 
 void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index) {
   PIO_Configure(g_APinDescription[u8g->pin_list[pin_index]].pPort, PIO_OUTPUT_1,


### PR DESCRIPTION
- u8g_com_HAL_DUE_sw_spi_shared.h must come after U8glib.h

To avoid the following error:

```
src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.h:27:26: error: variable or field 'u8g_SetPIOutput_DUE' declared void
 void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index);
```

Not sure how this change did not make it into the previous PR, but here it is.

Followup to #13971.