### PR TITLE
Fix TMC EEPROM regression (#14003)

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1053,6 +1053,10 @@ void setup() {
     fanmux_init();
   #endif
 
+  #if HAS_TRINAMIC && HAS_LCD_MENU
+    init_tmc_section();
+  #endif
+
   #if ENABLED(MIXING_EXTRUDER)
     mixer.init();
   #endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -293,10 +293,6 @@ void MarlinUI::init() {
   #if HAS_ENCODER_ACTION
     encoderDiff = 0;
   #endif
-
-  #if HAS_TRINAMIC && HAS_LCD_MENU
-    init_tmc_section();
-  #endif
 }
 
 bool MarlinUI::get_blink() {


### PR DESCRIPTION
This is a partial undo of commit 15357af to unbreak things.

- Earlier commit moved `ui.init` and `ui.reset_status` before `settings.load`
- However, `init_tmc_section` was called from `ui.init`, but needs to be called after `settings.load`
- ~Also, 'ui.reset_status' prints a "Printer ready" message, so it should be called later in the setup process.~
- This PR moves `init_tmc_section` ~and `ui.reset_status`~ back to its original location in "Marlin.cpp"

EDIT: Due to https://github.com/MarlinFirmware/Marlin/pull/14012, it no longer is necessary to revert `ui.reset_status` to its original place.