### PR TITLE
Correct bad pin mapping in AZTEEG_X5_MINI.h

### DIFF
--- a/Marlin/src/pins/pins_AZTEEG_X5_MINI.h
+++ b/Marlin/src/pins/pins_AZTEEG_X5_MINI.h
@@ -55,7 +55,7 @@
 #endif
 
 #ifndef FILWIDTH_PIN
-  #define FILWIDTH_PIN         2 //P0_25 in Analog Mode
+  #define FILWIDTH_PIN         2   // Analog Input (P0_25)
 #endif
 
 //

--- a/Marlin/src/pins/pins_AZTEEG_X5_MINI.h
+++ b/Marlin/src/pins/pins_AZTEEG_X5_MINI.h
@@ -50,8 +50,12 @@
 #define Y_STOP_PIN         P1_26
 #define Z_STOP_PIN         P1_28
 
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN   P2_04
+#endif
+
 #ifndef FILWIDTH_PIN
-  #define FILWIDTH_PIN     P2_04
+  #define FILWIDTH_PIN         2 //P0_25 in Analog Mode
 #endif
 
 //


### PR DESCRIPTION
Issue #13701 was causing the controller to hang as the pin for filament width was defined as a discrete pin. I can only surmise this was intended to be the filament runout and am assuming as such since Azteeg has never responded to emails in the past. Since every other analog capable pin is defined elsewhere, I pointed the user to Analog 2 P0_25 on discord and the issue was resolved.

Verified with pin sheet here

https://os.mbed.com/media/uploads/synvox/lpc1768_mbed_pinout.gif
