### PR TITLE
STM32: Fix SD EEPROM emulation conflict

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
@@ -64,7 +64,7 @@ static char HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
     if (!card.isDetected()) return false;
 
     SdFile file, root = card.getroot();
-    if (!file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC | O_APPEND))
+    if (!file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC))
       return false;
 
     int16_t bytes_written = file.write(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
@@ -64,7 +64,7 @@ static char HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
     if (!card.isDetected()) return false;
 
     SdFile file, root = card.getroot();
-    if (!file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC))
+    if (file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC))
       return false;
 
     int16_t bytes_written = file.write(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
@@ -43,26 +43,32 @@ static char HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
 
   #include "../../sd/cardreader.h"
 
-  static char eeprom_filename[] = "eeprom.dat";
+  #define EEPROM_FILENAME "eeprom.dat"
 
   bool PersistentStore::access_start() {
     if (!card.isDetected()) return false;
-    int16_t bytes_read = 0;
-    constexpr char eeprom_zero = 0xFF;
-    card.openFile(eeprom_filename, true);
-    bytes_read = card.read(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
+
+    SdFile file, root = card.getroot();
+    if (!file.open(&root, EEPROM_FILENAME, O_RDONLY))
+      return false;
+
+    int16_t bytes_read = file.read(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
     if (bytes_read < 0) return false;
     for (; bytes_read < HAL_STM32F1_EEPROM_SIZE; bytes_read++)
-      HAL_STM32F1_eeprom_content[bytes_read] = eeprom_zero;
-    card.closefile();
+      HAL_STM32F1_eeprom_content[bytes_read] = 0xFF;
+    file.close();
     return true;
   }
 
   bool PersistentStore::access_finish() {
     if (!card.isDetected()) return false;
-    card.openFile(eeprom_filename, false);
-    int16_t bytes_written = card.write(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
-    card.closefile();
+
+    SdFile file, root = card.getroot();
+    if (!file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC | O_APPEND))
+      return false;
+
+    int16_t bytes_written = file.write(HAL_STM32F1_eeprom_content, HAL_STM32F1_EEPROM_SIZE);
+    file.close();
     return (bytes_written == HAL_STM32F1_EEPROM_SIZE);
   }
 

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -144,6 +144,7 @@ public:
   static card_flags_t flag;
   static char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
   static int8_t autostart_index;
+  static SdFile getroot() { return root; }
 
   #if ENABLED(BINARY_FILE_TRANSFER)
     #if NUM_SERIAL > 1


### PR DESCRIPTION
current use of the card object may affect prints from sdcard

