### PR TITLE
Neopixel background LED option

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2088,6 +2088,8 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -89,6 +89,12 @@ void LEDLights::set_color(const LEDColor &incol
                             : pixels.Color(incol.r, incol.g, incol.b, incol.w);
     static uint16_t nextLed = 0;
 
+    #ifdef BACKGROUND_NEOPIXEL_LED
+      if (BACKGROUND_NEOPIXEL_LED == nextLed) {
+        nextLed++;
+        return;
+      }
+    #endif
     pixels.setBrightness(incol.i);
     if (!isSequence)
       set_neopixel_color(neocolor);

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -89,11 +89,8 @@ void LEDLights::set_color(const LEDColor &incol
                             : pixels.Color(incol.r, incol.g, incol.b, incol.w);
     static uint16_t nextLed = 0;
 
-    #ifdef BACKGROUND_NEOPIXEL_LED_INDEX
-      if (BACKGROUND_NEOPIXEL_LED_INDEX == nextLed) {
-        nextLed++;
-        return;
-      }
+    #ifdef NEOPIXEL_BKGD_LED_INDEX
+      if (NEOPIXEL_BKGD_LED_INDEX == nextLed) { nextLed++; return; }
     #endif
     pixels.setBrightness(incol.i);
     if (!isSequence)

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -89,8 +89,8 @@ void LEDLights::set_color(const LEDColor &incol
                             : pixels.Color(incol.r, incol.g, incol.b, incol.w);
     static uint16_t nextLed = 0;
 
-    #ifdef BACKGROUND_NEOPIXEL_LED
-      if (BACKGROUND_NEOPIXEL_LED == nextLed) {
+    #ifdef BACKGROUND_NEOPIXEL_LED_INDEX
+      if (BACKGROUND_NEOPIXEL_LED_INDEX == nextLed) {
         nextLed++;
         return;
       }

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -38,8 +38,8 @@ Adafruit_NeoPixel pixels(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIXEL_TYPE + NEO_KHZ8
 
 void set_neopixel_color(const uint32_t color) {
   for (uint16_t i = 0; i < pixels.numPixels(); ++i) {
-    #ifdef BACKGROUND_NEOPIXEL_LED_INDEX
-      if (BACKGROUND_NEOPIXEL_LED_INDEX == i) i++;
+    #ifdef NEOPIXEL_BKGD_LED_INDEX
+      if (NEOPIXEL_BKGD_LED_INDEX == i) i++;
     #endif
     pixels.setPixelColor(i, color);
   }
@@ -52,10 +52,10 @@ void set_neopixel_color_startup(const uint32_t color) {
   pixels.show();
 }
 
-#ifdef BACKGROUND_NEOPIXEL_LED_INDEX
+#ifdef NEOPIXEL_BKGD_LED_INDEX
   void set_neopixel_color_background() {
-    uint8_t background_color[4] = BACKGROUND_NEOPIXEL_LED_INDEX_COLOR;
-    pixels.setPixelColor(BACKGROUND_NEOPIXEL_LED_INDEX, pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
+    uint8_t background_color[4] = NEOPIXEL_BKGD_COLOR;
+    pixels.setPixelColor(NEOPIXEL_BKGD_LED_INDEX, pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
     pixels.show();
   }
 #endif
@@ -76,7 +76,7 @@ void setup_neopixel() {
     safe_delay(1000);
   #endif
 
-  #ifdef BACKGROUND_NEOPIXEL_LED_INDEX
+  #ifdef NEOPIXEL_BKGD_LED_INDEX
     set_neopixel_color_background();
   #endif
 

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -85,10 +85,7 @@ void setup_neopixel() {
   #else
     set_neopixel_color(pixels.Color(0, 0, 0, 0));
   #endif
-
 }
-
-
 
 #if 0
 bool neopixel_set_led_color(const uint8_t r, const uint8_t g, const uint8_t b, const uint8_t w, const uint8_t p) {

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -38,8 +38,8 @@ Adafruit_NeoPixel pixels(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIXEL_TYPE + NEO_KHZ8
 
 void set_neopixel_color(const uint32_t color) {
   for (uint16_t i = 0; i < pixels.numPixels(); ++i) {
-    #ifdef BACKGROUND_NEOPIXEL_LED
-      if (BACKGROUND_NEOPIXEL_LED == i) i++;
+    #ifdef BACKGROUND_NEOPIXEL_LED_INDEX
+      if (BACKGROUND_NEOPIXEL_LED_INDEX == i) i++;
     #endif
     pixels.setPixelColor(i, color);
   }
@@ -52,10 +52,10 @@ void set_neopixel_color_startup(const uint32_t color) {
   pixels.show();
 }
 
-#ifdef BACKGROUND_NEOPIXEL_LED
+#ifdef BACKGROUND_NEOPIXEL_LED_INDEX
   void set_neopixel_color_background() {
-    uint8_t background_color[4] = BACKGROUND_NEOPIXEL_LED_COLOR;
-    pixels.setPixelColor(BACKGROUND_NEOPIXEL_LED, pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
+    uint8_t background_color[4] = BACKGROUND_NEOPIXEL_LED_INDEX_COLOR;
+    pixels.setPixelColor(BACKGROUND_NEOPIXEL_LED_INDEX, pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
     pixels.show();
   }
 #endif
@@ -76,7 +76,7 @@ void setup_neopixel() {
     safe_delay(1000);
   #endif
 
-  #ifdef BACKGROUND_NEOPIXEL_LED
+  #ifdef BACKGROUND_NEOPIXEL_LED_INDEX
     set_neopixel_color_background();
   #endif
 

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -29,7 +29,6 @@
 #if ENABLED(NEOPIXEL_LED)
 
 #include "neopixel.h"
-#include "leds.h"
 
 #if ENABLED(NEOPIXEL_STARTUP_TEST)
   #include "../../core/utility.h"
@@ -47,9 +46,16 @@ void set_neopixel_color(const uint32_t color) {
   pixels.show();
 }
 
+void set_neopixel_color_startup(const uint32_t color) {
+  for (uint16_t i = 0; i < pixels.numPixels(); ++i)
+    pixels.setPixelColor(i, color);
+  pixels.show();
+}
+
 #ifdef BACKGROUND_NEOPIXEL_LED
-  void set_neopixel_color_background(const uint32_t color) {
-    pixels.setPixelColor(BACKGROUND_NEOPIXEL_LED, color);
+  void set_neopixel_color_background() {
+    uint8_t background_color[4] = BACKGROUND_NEOPIXEL_LED_COLOR;
+    pixels.setPixelColor(BACKGROUND_NEOPIXEL_LED, pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
     pixels.show();
   }
 #endif
@@ -62,12 +68,16 @@ void setup_neopixel() {
 
   #if ENABLED(NEOPIXEL_STARTUP_TEST)
     safe_delay(1000);
-    set_neopixel_color(pixels.Color(255, 0, 0, 0));  // red
+    set_neopixel_color_startup(pixels.Color(255, 0, 0, 0));  // red
     safe_delay(1000);
-    set_neopixel_color(pixels.Color(0, 255, 0, 0));  // green
+    set_neopixel_color_startup(pixels.Color(0, 255, 0, 0));  // green
     safe_delay(1000);
-    set_neopixel_color(pixels.Color(0, 0, 255, 0));  // blue
+    set_neopixel_color_startup(pixels.Color(0, 0, 255, 0));  // blue
     safe_delay(1000);
+  #endif
+
+  #ifdef BACKGROUND_NEOPIXEL_LED
+    set_neopixel_color_background();
   #endif
 
   #if ENABLED(LED_USER_PRESET_STARTUP)
@@ -76,11 +86,6 @@ void setup_neopixel() {
     set_neopixel_color(pixels.Color(0, 0, 0, 0));
   #endif
 
-  #ifdef BACKGROUND_NEOPIXEL_LED
-//    set_neopixel_color_background(MakeLEDColor(255,255,255,255,255));
-    uint8_t background_color[4] = BACKGROUND_NEOPIXEL_LED_COLOR;
-    set_neopixel_color_background(pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
-  #endif
 }
 
 

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -29,6 +29,7 @@
 #if ENABLED(NEOPIXEL_LED)
 
 #include "neopixel.h"
+#include "leds.h"
 
 #if ENABLED(NEOPIXEL_STARTUP_TEST)
   #include "../../core/utility.h"
@@ -37,10 +38,21 @@
 Adafruit_NeoPixel pixels(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIXEL_TYPE + NEO_KHZ800);
 
 void set_neopixel_color(const uint32_t color) {
-  for (uint16_t i = 0; i < pixels.numPixels(); ++i)
+  for (uint16_t i = 0; i < pixels.numPixels(); ++i) {
+    #ifdef BACKGROUND_NEOPIXEL_LED
+      if (BACKGROUND_NEOPIXEL_LED == i) i++;
+    #endif
     pixels.setPixelColor(i, color);
+  }
   pixels.show();
 }
+
+#ifdef BACKGROUND_NEOPIXEL_LED
+  void set_neopixel_color_background(const uint32_t color) {
+    pixels.setPixelColor(BACKGROUND_NEOPIXEL_LED, color);
+    pixels.show();
+  }
+#endif
 
 void setup_neopixel() {
   SET_OUTPUT(NEOPIXEL_PIN);
@@ -63,7 +75,15 @@ void setup_neopixel() {
   #else
     set_neopixel_color(pixels.Color(0, 0, 0, 0));
   #endif
+
+  #ifdef BACKGROUND_NEOPIXEL_LED
+//    set_neopixel_color_background(MakeLEDColor(255,255,255,255,255));
+    uint8_t background_color[4] = BACKGROUND_NEOPIXEL_LED_COLOR;
+    set_neopixel_color_background(pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
+  #endif
 }
+
+
 
 #if 0
 bool neopixel_set_led_color(const uint8_t r, const uint8_t g, const uint8_t b, const uint8_t w, const uint8_t p) {

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -29,7 +29,6 @@
 #if ENABLED(NEOPIXEL_LED)
 
 #include "neopixel.h"
-#include "leds.h"
 
 #if ENABLED(NEOPIXEL_STARTUP_TEST)
   #include "../../core/utility.h"

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -47,9 +47,16 @@ void set_neopixel_color(const uint32_t color) {
   pixels.show();
 }
 
+void set_neopixel_color_startup(const uint32_t color) {
+  for (uint16_t i = 0; i < pixels.numPixels(); ++i)
+    pixels.setPixelColor(i, color);
+  pixels.show();
+}
+
 #ifdef BACKGROUND_NEOPIXEL_LED
-  void set_neopixel_color_background(const uint32_t color) {
-    pixels.setPixelColor(BACKGROUND_NEOPIXEL_LED, color);
+  void set_neopixel_color_background() {
+    uint8_t background_color[4] = BACKGROUND_NEOPIXEL_LED_COLOR;
+    pixels.setPixelColor(BACKGROUND_NEOPIXEL_LED, pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
     pixels.show();
   }
 #endif
@@ -62,12 +69,16 @@ void setup_neopixel() {
 
   #if ENABLED(NEOPIXEL_STARTUP_TEST)
     safe_delay(1000);
-    set_neopixel_color(pixels.Color(255, 0, 0, 0));  // red
+    set_neopixel_color_startup(pixels.Color(255, 0, 0, 0));  // red
     safe_delay(1000);
-    set_neopixel_color(pixels.Color(0, 255, 0, 0));  // green
+    set_neopixel_color_startup(pixels.Color(0, 255, 0, 0));  // green
     safe_delay(1000);
-    set_neopixel_color(pixels.Color(0, 0, 255, 0));  // blue
+    set_neopixel_color_startup(pixels.Color(0, 0, 255, 0));  // blue
     safe_delay(1000);
+  #endif
+
+  #ifdef BACKGROUND_NEOPIXEL_LED
+    set_neopixel_color_background();
   #endif
 
   #if ENABLED(LED_USER_PRESET_STARTUP)
@@ -76,11 +87,6 @@ void setup_neopixel() {
     set_neopixel_color(pixels.Color(0, 0, 0, 0));
   #endif
 
-  #ifdef BACKGROUND_NEOPIXEL_LED
-//    set_neopixel_color_background(MakeLEDColor(255,255,255,255,255));
-    uint8_t background_color[4] = BACKGROUND_NEOPIXEL_LED_COLOR;
-    set_neopixel_color_background(pixels.Color(background_color[0], background_color[1], background_color[2], background_color[3]));
-  #endif
 }
 
 

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -2119,9 +2119,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -2118,7 +2118,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -2118,7 +2118,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -2119,7 +2119,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -2107,7 +2107,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -2108,7 +2108,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -2108,9 +2108,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -2107,7 +2107,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -2099,7 +2099,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -2099,9 +2099,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -2098,7 +2098,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -2098,7 +2098,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -2089,7 +2089,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -2090,7 +2090,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -2090,9 +2090,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -2089,7 +2089,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -2090,7 +2090,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -2090,9 +2090,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -2242,7 +2242,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -2241,7 +2241,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -2241,7 +2241,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -2242,9 +2242,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -2102,7 +2102,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -2103,7 +2103,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -2102,7 +2102,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -2103,9 +2103,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -2099,7 +2099,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -2099,9 +2099,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -2098,7 +2098,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -2098,7 +2098,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -2099,7 +2099,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -2099,7 +2099,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -2100,9 +2100,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -2100,7 +2100,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -2098,7 +2098,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -2097,7 +2097,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -2097,7 +2097,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -2098,9 +2098,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -2088,7 +2088,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -2089,9 +2089,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -2075,7 +2075,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -2076,7 +2076,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -2076,9 +2076,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -2075,7 +2075,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -2075,7 +2075,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -2076,7 +2076,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -2076,9 +2076,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -2075,7 +2075,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -2086,7 +2086,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -2086,7 +2086,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -2087,9 +2087,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -2098,7 +2098,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -2097,7 +2097,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -2097,7 +2097,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -2098,9 +2098,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -2088,7 +2088,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -2089,9 +2089,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -2091,9 +2091,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -2090,7 +2090,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -2090,7 +2090,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -2106,7 +2106,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -2107,9 +2107,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -2106,7 +2106,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -2107,7 +2107,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -2098,7 +2098,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -2097,7 +2097,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -2097,7 +2097,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -2098,9 +2098,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -2092,7 +2092,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -2092,9 +2092,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -2091,7 +2091,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -2092,7 +2092,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -2092,9 +2092,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -2091,7 +2091,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -2098,7 +2098,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -2097,7 +2097,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -2097,7 +2097,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -2098,9 +2098,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -2092,7 +2092,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -2092,9 +2092,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -2091,7 +2091,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -2069,7 +2069,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -2069,7 +2069,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -2070,7 +2070,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -2070,9 +2070,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -2069,7 +2069,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -2069,7 +2069,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -2070,7 +2070,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -2070,9 +2070,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -2078,7 +2078,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -2079,7 +2079,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -2078,7 +2078,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -2079,9 +2079,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -2093,7 +2093,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -2093,7 +2093,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -2094,9 +2094,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -2094,7 +2094,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -2192,7 +2192,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -2192,7 +2192,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -2193,7 +2193,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -2193,9 +2193,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -2123,7 +2123,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -2123,9 +2123,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -2122,7 +2122,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -2122,7 +2122,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -2116,9 +2116,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -2115,7 +2115,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -2116,7 +2116,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -2115,7 +2115,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -2072,7 +2072,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -2073,7 +2073,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -2073,9 +2073,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -2072,7 +2072,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -2077,9 +2077,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -2077,7 +2077,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -2076,7 +2076,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -2076,7 +2076,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -2102,7 +2102,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -2103,7 +2103,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -2102,7 +2102,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -2103,9 +2103,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -2081,7 +2081,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -2080,7 +2080,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -2080,7 +2080,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -2081,9 +2081,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -2094,7 +2094,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -2095,9 +2095,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -2094,7 +2094,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -2095,7 +2095,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -2107,7 +2107,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -2108,7 +2108,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -2108,9 +2108,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -2107,7 +2107,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -2107,7 +2107,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -2108,7 +2108,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -2108,9 +2108,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -2107,7 +2107,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -2092,7 +2092,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -2092,9 +2092,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -2091,7 +2091,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -2099,7 +2099,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -2099,7 +2099,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -2100,9 +2100,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -2100,7 +2100,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -2107,7 +2107,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -2108,7 +2108,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -2108,9 +2108,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -2107,7 +2107,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -2116,9 +2116,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -2115,7 +2115,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -2116,7 +2116,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -2115,7 +2115,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -2086,7 +2086,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -2086,7 +2086,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -2087,9 +2087,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -2092,7 +2092,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -2092,9 +2092,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -2091,7 +2091,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -2092,7 +2092,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -2092,9 +2092,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -2091,7 +2091,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -2089,7 +2089,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -2090,7 +2090,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -2090,9 +2090,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -2096,7 +2096,7 @@
   #define NEOPIXEL_PIXELS 3      // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   #define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -2092,13 +2092,15 @@
 #define NEOPIXEL_LED
 #if ENABLED(NEOPIXEL_LED)
   #define NEOPIXEL_TYPE   NEO_GRBW // NEO_GRBW / NEO_GRB - four/three channel driver type (defined in Adafruit_NeoPixel.h)
-  #define NEOPIXEL_PIN    20        // LED driving pin
-  #define NEOPIXEL_PIXELS 3      // Number of LEDs in the strip
+  #define NEOPIXEL_PIN    20       // LED driving pin
+  #define NEOPIXEL_PIXELS 3        // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
-  #define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+  #define NEOPIXEL_STARTUP_TEST    // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -2096,6 +2096,8 @@
   #define NEOPIXEL_PIXELS 3      // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   #define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -2136,7 +2136,9 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -2137,7 +2137,7 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -2137,9 +2137,11 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -2136,7 +2136,7 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -2101,7 +2101,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -2100,7 +2100,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -2101,9 +2101,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -2100,7 +2100,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -2089,7 +2089,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -2090,7 +2090,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -2090,9 +2090,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -2089,7 +2089,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -2090,7 +2090,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -2090,9 +2090,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -2119,9 +2119,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -2118,7 +2118,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -2118,7 +2118,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -2119,7 +2119,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -2144,7 +2144,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -2143,7 +2143,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -2144,9 +2144,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -2143,7 +2143,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -2092,7 +2092,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -2092,9 +2092,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -2091,7 +2091,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -2109,7 +2109,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -2108,7 +2108,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -2108,7 +2108,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -2109,9 +2109,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -2086,7 +2086,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -2086,7 +2086,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -2087,9 +2087,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -2099,7 +2099,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -2099,9 +2099,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -2098,7 +2098,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -2098,7 +2098,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -2097,9 +2097,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -2096,7 +2096,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -2097,7 +2097,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -2096,7 +2096,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -2123,7 +2123,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -2123,9 +2123,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -2122,7 +2122,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -2122,7 +2122,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -2088,7 +2088,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -2089,9 +2089,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -2089,7 +2089,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -2088,7 +2088,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -2089,9 +2089,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -2106,7 +2106,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -2107,9 +2107,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -2106,7 +2106,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -2107,7 +2107,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -2101,7 +2101,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -2100,7 +2100,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -2101,9 +2101,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -2100,7 +2100,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -2088,9 +2088,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -2087,7 +2087,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -2088,7 +2088,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -2087,7 +2087,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -2275,7 +2275,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -2274,7 +2274,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -2274,7 +2274,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -2275,9 +2275,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -2215,7 +2215,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -2215,7 +2215,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -2216,7 +2216,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -2216,9 +2216,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -2214,7 +2214,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -2215,9 +2215,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -2215,7 +2215,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -2214,7 +2214,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -2214,7 +2214,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -2215,9 +2215,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -2215,7 +2215,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -2214,7 +2214,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -2203,9 +2203,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -2202,7 +2202,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -2202,7 +2202,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -2203,7 +2203,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -2218,7 +2218,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -2217,7 +2217,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -2217,7 +2217,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -2218,9 +2218,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -2203,9 +2203,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -2202,7 +2202,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -2202,7 +2202,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -2203,7 +2203,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -2199,7 +2199,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -2200,7 +2200,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -2199,7 +2199,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -2200,9 +2200,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -2203,9 +2203,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -2202,7 +2202,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -2202,7 +2202,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -2203,7 +2203,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -2205,9 +2205,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -2205,7 +2205,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -2204,7 +2204,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -2204,7 +2204,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -2205,7 +2205,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -2206,7 +2206,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -2206,9 +2206,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -2205,7 +2205,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -2205,7 +2205,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -2206,7 +2206,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -2206,9 +2206,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -2205,7 +2205,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -2094,7 +2094,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -2095,9 +2095,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -2094,7 +2094,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -2095,7 +2095,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -2091,9 +2091,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -2090,7 +2090,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -2090,7 +2090,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -2091,7 +2091,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -2082,7 +2082,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -2082,7 +2082,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -2083,7 +2083,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -2083,9 +2083,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -2092,7 +2092,7 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
   //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -2093,7 +2093,7 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
   //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -2093,9 +2093,11 @@
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
   #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
-  //#define BACKGROUND_NEOPIXEL_LED_INDEX  0 // 0, 1, 2 .. index of LED in chain that never changes color
-  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
+
+  // Use a single Neopixel LED for static (background) lighting
+  //#define NEOPIXEL_BKGD_LED_INDEX  0               // Index of the LED to use
+  //#define NEOPIXEL_BKGD_COLOR { 255, 255, 255, 0 } // R, G, B, W
 #endif
 
 /**

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -2092,7 +2092,9 @@
   #define NEOPIXEL_PIN    4        // LED driving pin
   #define NEOPIXEL_PIXELS 30       // Number of LEDs in the strip
   #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
-  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+    #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
+  //#define BACKGROUND_NEOPIXEL_LED 0  // number of LED in chain that never changes color
+  //#define BACKGROUND_NEOPIXEL_LED_COLOR  {255, 255, 255, 0} // { Red, Green, Blue, White }
   //#define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup
 #endif
 


### PR DESCRIPTION
This PR adds the ability to designate one of the neopixel LEDs as the background LED and to set it's color.  The color of this LED is set after reset and can't be changed by M150 or by the printer_event_leds code.

After reset, the LEDs will go through the NEOPIXEL_STARTUP_TEST (if enabled) , set all the non-background LED colors and then set the background LED color.

This is mostly so the FYSETC_MINI_12864_2_1 can have a constant color backlight.

---

Configuration.h - added defines BACKGROUND_NEOPIXEL_LED and
BACKGROUND_NEOPIXEL_LED_COLOR

leds.cpp - set_color - skip setting LED if index equals background LED number

neopixel.cpp - neopixel_color- skip setting LED if index equals background LED number

neopixel.cpp - setup_neopixel - added setting of background LED color
