### PR TITLE
Reorder delta _PULSE_WAIT definition

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2327,10 +2327,10 @@ void Stepper::report_positions() {
     #define _SAVE_START NOOP
     #if EXTRA_CYCLES_BABYSTEP > 0
       #define _PULSE_WAIT DELAY_NS(EXTRA_CYCLES_BABYSTEP * NANOSECONDS_PER_CYCLE)
-    #elif STEP_PULSE_CYCLES > 0
-      #define _PULSE_WAIT NOOP
     #elif ENABLED(DELTA)
       #define _PULSE_WAIT DELAY_US(2);
+    #elif STEP_PULSE_CYCLES > 0
+      #define _PULSE_WAIT NOOP
     #else
       #define _PULSE_WAIT DELAY_US(4);
     #endif


### PR DESCRIPTION
Reorder elif branches to force _PULSE_WAIT delta value positive when min stepper pulse is 1

See #13903
#13300
#13384

@MSpencer0 Can you confirm this functions as well? Should define 2 when the value is negative and since its not used anywhere else likely resolves it without forcing it to be exactly 0.