### PR TITLE
Fix power loss recovery with SINGLENOZZLE

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -170,8 +170,8 @@ void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=
     #endif
     info.feedrate = uint16_t(feedrate_mm_s * 60.0f);
 
-    #if HOTENDS > 1
-      info.active_hotend = active_extruder;
+    #if EXTRUDERS > 1
+      info.active_extruder = active_extruder;
     #endif
 
     HOTEND_LOOP() info.target_temperature[e] = thermalManager.temp_hotend[e].target;
@@ -282,7 +282,7 @@ void PrintJobRecovery::resume() {
 
   // Select the previously active tool (with no_move)
   #if EXTRUDERS > 1
-    sprintf_P(cmd, PSTR("T%i S"), info.active_hotend);
+    sprintf_P(cmd, PSTR("T%i S"), info.active_extruder);
     gcode.process_subcommands_now(cmd);
   #endif
 
@@ -443,8 +443,8 @@ void PrintJobRecovery::resume() {
 
         DEBUG_ECHOLNPAIR("feedrate: ", info.feedrate);
 
-        #if HOTENDS > 1
-          DEBUG_ECHOLNPAIR("active_hotend: ", int(info.active_hotend));
+        #if EXTRUDERS > 1
+          DEBUG_ECHOLNPAIR("active_extruder: ", int(info.active_extruder));
         #endif
 
         DEBUG_ECHOPGM("target_temperature: ");

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -51,8 +51,8 @@ typedef struct {
 
   uint16_t feedrate;
 
-  #if HOTENDS > 1
-    uint8_t active_hotend;
+  #if EXTRUDERS > 1
+    uint8_t active_extruder;
   #endif
 
   int16_t target_temperature[HOTENDS];


### PR DESCRIPTION
This should fix the #14031  now build succeed.

I've replaced the references to active_hotend with active_extruders and changed the conditionals to EXTRUDERS and not anymore HOTEND as we want to restore the active extruder (like the original variable name) and not the hotend

I'm unable to test atm (a very long print is running and my second extruded isn't currently enabled), so, before merging this, someone with a working dual extruder setup should test the power loss feature.