### PR TITLE
Fix M226 sign warning (for most platforms)

### DIFF
--- a/Marlin/src/gcode/control/M226.cpp
+++ b/Marlin/src/gcode/control/M226.cpp
@@ -45,7 +45,7 @@ void GcodeSuite::M226() {
           case 0: target = LOW; break;
           case -1: target = !extDigitalRead(pin); break;
         }
-        while ((int) extDigitalRead(pin) != target) idle();
+        while (int(extDigitalRead(pin)) != target) idle();
       }
     } // pin_state -1 0 1 && pin > -1
   } // parser.seen('P')

--- a/Marlin/src/gcode/control/M226.cpp
+++ b/Marlin/src/gcode/control/M226.cpp
@@ -45,7 +45,7 @@ void GcodeSuite::M226() {
           case 0: target = LOW; break;
           case -1: target = !extDigitalRead(pin); break;
         }
-        while (extDigitalRead(pin) != target) idle();
+        while ((int) extDigitalRead(pin) != target) idle();
       }
     } // pin_state -1 0 1 && pin > -1
   } // parser.seen('P')


### PR DESCRIPTION
use local/arduino variable (target) type to compare
