### PR TITLE
runout.distance_mm LCD edit item

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -1185,6 +1185,9 @@
 #ifndef MSG_RUNOUT_SENSOR
   #define MSG_RUNOUT_SENSOR                   _UxGT("Runout Sensor")
 #endif
+#ifndef MSG_RUNOUT_DISTANCE_MM
+  #define MSG_RUNOUT_DISTANCE_MM              _UxGT("Runout Dist mm")
+#endif
 #ifndef MSG_ERR_HOMING_FAILED
   #define MSG_ERR_HOMING_FAILED               _UxGT("Homing failed")
 #endif

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -50,12 +50,11 @@
 
 #ifdef FILAMENT_RUNOUT_DISTANCE_MM
   #include "../../feature/runout.h"
+  float lcd_runout_distance_mm;
 #endif
 
 void menu_tmc();
 void menu_backlash();
-
-float lcd_runout_distance_mm;
 
 #if ENABLED(DAC_STEPPER_CURRENT)
 
@@ -109,6 +108,12 @@ float lcd_runout_distance_mm;
   void _lcd_set_home_offsets() {
     enqueue_and_echo_commands_P(PSTR("M428"));
     ui.return_to_status();
+  }
+#endif
+
+#ifdef FILAMENT_RUNOUT_DISTANCE_MM
+  void _lcd_set_runout_distance_mm() {
+    runout.set_runout_distance(lcd_runout_distance_mm);
   }
 #endif
 
@@ -237,11 +242,10 @@ float lcd_runout_distance_mm;
     #endif
 
     #ifdef FILAMENT_RUNOUT_DISTANCE_MM
-      MENU_MULTIPLIER_ITEM_EDIT(float3, "Runout Distance mm", &lcd_runout_distance_mm, 1,  30);
+      MENU_ITEM_EDIT_CALLBACK(float3, MSG_RUNOUT_DISTANCE_MM, &lcd_runout_distance_mm, 1, 30, _lcd_set_runout_distance_mm);
     #endif
 
     END_MENU();
-    runout.set_runout_distance(lcd_runout_distance_mm);
   }
 
 #endif // !NO_VOLUMETRICS || ADVANCED_PAUSE_FEATURE
@@ -630,7 +634,9 @@ float lcd_runout_distance_mm;
 #endif // !SLIM_LCD_MENUS
 
 void menu_advanced_settings() {
-  lcd_runout_distance_mm = runout.runout_distance();
+  #ifdef FILAMENT_RUNOUT_DISTANCE_MM
+    lcd_runout_distance_mm = runout.runout_distance();
+  #endif  
   START_MENU();
   MENU_BACK(MSG_CONFIGURATION);
 

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -111,12 +111,6 @@ void menu_backlash();
   }
 #endif
 
-#ifdef FILAMENT_RUNOUT_DISTANCE_MM
-  void _lcd_set_runout_distance_mm() {
-    runout.set_runout_distance(lcd_runout_distance_mm);
-  }
-#endif
-
 #if ENABLED(SD_FIRMWARE_UPDATE)
 
   #include "../../module/configuration_store.h"
@@ -242,7 +236,9 @@ void menu_backlash();
     #endif
 
     #ifdef FILAMENT_RUNOUT_DISTANCE_MM
-      MENU_ITEM_EDIT_CALLBACK(float3, MSG_RUNOUT_DISTANCE_MM, &lcd_runout_distance_mm, 1, 30, _lcd_set_runout_distance_mm);
+      MENU_ITEM_EDIT_CALLBACK(float3, MSG_RUNOUT_DISTANCE_MM, &lcd_runout_distance_mm, 1, 30, []{
+        runout.set_runout_distance(lcd_runout_distance_mm);
+      });
     #endif
 
     END_MENU();

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -48,8 +48,14 @@
   #include "../../module/temperature.h"
 #endif
 
+#ifdef FILAMENT_RUNOUT_DISTANCE_MM
+  #include "../../feature/runout.h"
+#endif
+
 void menu_tmc();
 void menu_backlash();
+
+float lcd_runout_distance_mm;
 
 #if ENABLED(DAC_STEPPER_CURRENT)
 
@@ -230,7 +236,12 @@ void menu_backlash();
       #endif // EXTRUDERS > 1
     #endif
 
+    #ifdef FILAMENT_RUNOUT_DISTANCE_MM
+      MENU_MULTIPLIER_ITEM_EDIT(float3, "Runout Distance mm", &lcd_runout_distance_mm, 1,  30);
+    #endif
+
     END_MENU();
+    runout.set_runout_distance(lcd_runout_distance_mm);
   }
 
 #endif // !NO_VOLUMETRICS || ADVANCED_PAUSE_FEATURE
@@ -619,6 +630,7 @@ void menu_backlash();
 #endif // !SLIM_LCD_MENUS
 
 void menu_advanced_settings() {
+  lcd_runout_distance_mm = runout.runout_distance();
   START_MENU();
   MENU_BACK(MSG_CONFIGURATION);
 


### PR DESCRIPTION
Filament Runout Distance is stored in eeprom. 

If we change FILAMENT_RUNOUT_DISTANCE_MM at configuration.h then upload marlin, 
the value not change. 
It is because Filament Runout Distance is stored in eeprom. 
The problem is, we cannot change Filament Runout Distance in LCD.

This PR add menu at advance setting->filament to edit Filament Runout Distance

Unfortunately, we cannot directly access the response.runout_distance_mm from menu. 
This PR is "not good" workaround. But the simple one. I hope someone can make this better. 

