### PR TITLE
TMC updates, capture LCD changes

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1053,10 +1053,6 @@ void setup() {
     fanmux_init();
   #endif
 
-  #if HAS_TRINAMIC && HAS_LCD_MENU
-    init_tmc_section();
-  #endif
-
   #if ENABLED(MIXING_EXTRUDER)
     mixer.init();
   #endif

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -470,7 +470,7 @@
   static void print_vsense(TMC &st) { serialprintPGM(st.vsense() ? PSTR("1=.18") : PSTR("0=.325")); }
 
   #if HAS_DRIVER(TMC2130) || HAS_DRIVER(TMC5130)
-    static void tmc_status(TMC2130Stepper &st, const TMC_debug_enum i) {
+    static void _tmc_status(TMC2130Stepper &st, const TMC_debug_enum i) {
       switch (i) {
         case TMC_PWM_SCALE: SERIAL_PRINT(st.PWM_SCALE(), DEC); break;
         case TMC_SGT: SERIAL_PRINT(st.sgt(), DEC); break;
@@ -498,7 +498,7 @@
     template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
     void print_vsense(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &) { }
 
-    static void tmc_status(TMC2160Stepper &st, const TMC_debug_enum i) {
+    static void _tmc_status(TMC2160Stepper &st, const TMC_debug_enum i) {
       switch (i) {
         case TMC_PWM_SCALE: SERIAL_PRINT(st.PWM_SCALE(), DEC); break;
         case TMC_SGT: SERIAL_PRINT(st.sgt(), DEC); break;
@@ -516,7 +516,7 @@
   #endif
 
   #if HAS_DRIVER(TMC2208)
-    static void tmc_status(TMC2208Stepper &st, const TMC_debug_enum i) {
+    static void _tmc_status(TMC2208Stepper &st, const TMC_debug_enum i) {
       switch (i) {
         case TMC_PWM_SCALE: SERIAL_PRINT(st.pwm_scale_sum(), DEC); break;
         case TMC_STEALTHCHOP: serialprint_truefalse(st.stealth()); break;
@@ -542,7 +542,7 @@
   #endif
 
   template <typename TMC>
-  static void tmc_status(TMC &st, const TMC_debug_enum i, const float spmm) {
+  static void tmc_status(TMC &st, const TMC_debug_enum i) {
     SERIAL_CHAR('\t');
     switch (i) {
       case TMC_CODES: st.printLabel(); break;
@@ -576,9 +576,9 @@
         }
         break;
       case TMC_TPWMTHRS_MMS: {
-          uint32_t tpwmthrs_val = st.TPWMTHRS();
+          uint32_t tpwmthrs_val = st.get_pwm_thrs();
           if (tpwmthrs_val)
-            SERIAL_ECHO(12650000UL * st.microsteps() / (256 * tpwmthrs_val * spmm));
+            SERIAL_ECHO(tpwmthrs_val);
           else
             SERIAL_CHAR('-');
         }
@@ -591,13 +591,13 @@
       case TMC_TBL: SERIAL_PRINT(st.blank_time(), DEC); break;
       case TMC_HEND: SERIAL_PRINT(st.hysteresis_end(), DEC); break;
       case TMC_HSTRT: SERIAL_PRINT(st.hysteresis_start(), DEC); break;
-      default: tmc_status(st, i); break;
+      default: _tmc_status(st, i); break;
     }
   }
 
   #if HAS_DRIVER(TMC2660)
     template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
-    void tmc_status(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const TMC_debug_enum i, const float) {
+    void tmc_status(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const TMC_debug_enum i) {
       SERIAL_CHAR('\t');
       switch (i) {
         case TMC_CODES: st.printLabel(); break;
@@ -652,72 +652,52 @@
   static void tmc_debug_loop(const TMC_debug_enum i, const bool print_x, const bool print_y, const bool print_z, const bool print_e) {
     if (print_x) {
       #if AXIS_IS_TMC(X)
-        tmc_status(stepperX, i, planner.settings.axis_steps_per_mm[X_AXIS]);
+        tmc_status(stepperX, i);
       #endif
       #if AXIS_IS_TMC(X2)
-        tmc_status(stepperX2, i, planner.settings.axis_steps_per_mm[X_AXIS]);
+        tmc_status(stepperX2, i);
       #endif
     }
 
     if (print_y) {
       #if AXIS_IS_TMC(Y)
-        tmc_status(stepperY, i, planner.settings.axis_steps_per_mm[Y_AXIS]);
+        tmc_status(stepperY, i);
       #endif
       #if AXIS_IS_TMC(Y2)
-        tmc_status(stepperY2, i, planner.settings.axis_steps_per_mm[Y_AXIS]);
+        tmc_status(stepperY2, i);
       #endif
     }
 
     if (print_z) {
       #if AXIS_IS_TMC(Z)
-        tmc_status(stepperZ, i, planner.settings.axis_steps_per_mm[Z_AXIS]);
+        tmc_status(stepperZ, i);
       #endif
       #if AXIS_IS_TMC(Z2)
-        tmc_status(stepperZ2, i, planner.settings.axis_steps_per_mm[Z_AXIS]);
+        tmc_status(stepperZ2, i);
       #endif
       #if AXIS_IS_TMC(Z3)
-        tmc_status(stepperZ3, i, planner.settings.axis_steps_per_mm[Z_AXIS]);
+        tmc_status(stepperZ3, i);
       #endif
     }
 
     if (print_e) {
       #if AXIS_IS_TMC(E0)
-        tmc_status(stepperE0, i, planner.settings.axis_steps_per_mm[E_AXIS]);
+        tmc_status(stepperE0, i);
       #endif
       #if AXIS_IS_TMC(E1)
-        tmc_status(stepperE1, i, planner.settings.axis_steps_per_mm[E_AXIS
-          #if ENABLED(DISTINCT_E_FACTORS)
-            + 1
-          #endif
-        ]);
+        tmc_status(stepperE1, i);
       #endif
       #if AXIS_IS_TMC(E2)
-        tmc_status(stepperE2, i, planner.settings.axis_steps_per_mm[E_AXIS
-          #if ENABLED(DISTINCT_E_FACTORS)
-            + 2
-          #endif
-        ]);
+        tmc_status(stepperE2, i);
       #endif
       #if AXIS_IS_TMC(E3)
-        tmc_status(stepperE3, i, planner.settings.axis_steps_per_mm[E_AXIS
-          #if ENABLED(DISTINCT_E_FACTORS)
-            + 3
-          #endif
-        ]);
+        tmc_status(stepperE3, i);
       #endif
       #if AXIS_IS_TMC(E4)
-        tmc_status(stepperE4, i, planner.settings.axis_steps_per_mm[E_AXIS
-          #if ENABLED(DISTINCT_E_FACTORS)
-            + 4
-          #endif
-        ]);
+        tmc_status(stepperE4, i);
       #endif
       #if AXIS_IS_TMC(E5)
-        tmc_status(stepperE5, i, planner.settings.axis_steps_per_mm[E_AXIS
-          #if ENABLED(DISTINCT_E_FACTORS)
-            + 5
-          #endif
-        ]);
+        tmc_status(stepperE5, i);
       #endif
     }
 
@@ -1120,50 +1100,5 @@ void test_tmc_connection(const bool test_x, const bool test_y, const bool test_z
 
   if (axis_connection) ui.set_status_P(PSTR("TMC CONNECTION ERROR"));
 }
-
-#if HAS_LCD_MENU
-
-  void init_tmc_section() {
-    #if AXIS_IS_TMC(X)
-      stepperX.init_lcd_variables(X_AXIS);
-    #endif
-    #if AXIS_IS_TMC(Y)
-      stepperY.init_lcd_variables(Y_AXIS);
-    #endif
-    #if AXIS_IS_TMC(Z)
-      stepperZ.init_lcd_variables(Z_AXIS);
-    #endif
-    #if AXIS_IS_TMC(X2)
-      stepperX2.init_lcd_variables(X_AXIS);
-    #endif
-    #if AXIS_IS_TMC(Y2)
-      stepperY2.init_lcd_variables(Y_AXIS);
-    #endif
-    #if AXIS_IS_TMC(Z2)
-      stepperZ2.init_lcd_variables(Z_AXIS);
-    #endif
-    #if AXIS_IS_TMC(Z3)
-      stepperZ3.init_lcd_variables(Z_AXIS);
-    #endif
-    #if AXIS_IS_TMC(E0)
-      stepperE0.init_lcd_variables(E_AXIS);
-    #endif
-    #if AXIS_IS_TMC(E1)
-      stepperE1.init_lcd_variables(E_AXIS_N(1));
-    #endif
-    #if AXIS_IS_TMC(E2)
-      stepperE2.init_lcd_variables(E_AXIS_N(2));
-    #endif
-    #if AXIS_IS_TMC(E3)
-      stepperE3.init_lcd_variables(E_AXIS_N(3));
-    #endif
-    #if AXIS_IS_TMC(E4)
-      stepperE4.init_lcd_variables(E_AXIS_N(4));
-    #endif
-    #if AXIS_IS_TMC(E5)
-      stepperE5.init_lcd_variables(E_AXIS_N(5));
-    #endif
-  }
-#endif
 
 #endif // HAS_TRINAMIC

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -492,8 +492,11 @@
   #endif
 
   #if HAS_DRIVER(TMC2160) || HAS_DRIVER(TMC5160)
-    template<char AXIS_LETTER, char DRIVER_ID> void print_vsense(TMCMarlin<TMC2160Stepper, AXIS_LETTER, DRIVER_ID> &st) { UNUSED(st); }
-    template<char AXIS_LETTER, char DRIVER_ID> void print_vsense(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID> &st) { UNUSED(st); }
+    template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+    void print_vsense(TMCMarlin<TMC2160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &) { }
+
+    template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+    void print_vsense(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &) { }
 
     static void tmc_status(TMC2160Stepper &st, const TMC_debug_enum i) {
       switch (i) {
@@ -593,8 +596,8 @@
   }
 
   #if HAS_DRIVER(TMC2660)
-    template<char AXIS_LETTER, char DRIVER_ID>
-    void tmc_status(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID> &st, const TMC_debug_enum i, const float) {
+    template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+    void tmc_status(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const TMC_debug_enum i, const float) {
       SERIAL_CHAR('\t');
       switch (i) {
         case TMC_CODES: st.printLabel(); break;
@@ -877,8 +880,8 @@
     }
   #endif
   #if HAS_DRIVER(TMC2660)
-    template <char AXIS_LETTER, char DRIVER_ID>
-    static void tmc_get_registers(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID> &st, const TMC_get_registers_enum i) {
+    template <char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+    static void tmc_get_registers(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const TMC_get_registers_enum i) {
       switch (i) {
         case TMC_AXIS_CODES: SERIAL_CHAR('\t'); st.printLabel(); break;
         PRINT_TMC_REGISTER(DRVCONF);

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -469,7 +469,7 @@
   template<class TMC>
   static void print_vsense(TMC &st) { serialprintPGM(st.vsense() ? PSTR("1=.18") : PSTR("0=.325")); }
 
-  #if HAS_TMCX1X0
+  #if HAS_DRIVER(TMC2130) || HAS_DRIVER(TMC5130)
     static void tmc_status(TMC2130Stepper &st, const TMC_debug_enum i) {
       switch (i) {
         case TMC_PWM_SCALE: SERIAL_PRINT(st.PWM_SCALE(), DEC); break;
@@ -478,6 +478,8 @@
         default: break;
       }
     }
+  #endif
+  #if HAS_TMCX1X0
     static void _tmc_parse_drv_status(TMC2130Stepper &st, const TMC_drv_status_enum i) {
       switch (i) {
         case TMC_STALLGUARD: if (st.stallguard()) SERIAL_CHAR('X'); break;

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -313,8 +313,6 @@
     #endif
   }
 
-  #define HAS_HW_COMMS(ST) AXIS_DRIVER_TYPE(ST, TMC2130) || AXIS_DRIVER_TYPE(ST, TMC2160) || AXIS_DRIVER_TYPE(ST, TMC2660) || AXIS_DRIVER_TYPE(ST, TMC5130) || AXIS_DRIVER_TYPE(ST, TMC5160) || (AXIS_DRIVER_TYPE(ST, TMC2208) && defined(ST##_HARDWARE_SERIAL))
-
   void monitor_tmc_driver() {
     static millis_t next_poll = 0;
     const millis_t ms = millis();
@@ -330,43 +328,43 @@
       }
     #endif
     if (need_update_error_counters || need_debug_reporting) {
-      #if HAS_HW_COMMS(X)
+      #if AXIS_IS_TMC(X)
         monitor_tmc_driver(stepperX, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(Y)
+      #if AXIS_IS_TMC(Y)
         monitor_tmc_driver(stepperY, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(Z)
+      #if AXIS_IS_TMC(Z)
         monitor_tmc_driver(stepperZ, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(X2)
+      #if AXIS_IS_TMC(X2)
         monitor_tmc_driver(stepperX2, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(Y2)
+      #if AXIS_IS_TMC(Y2)
         monitor_tmc_driver(stepperY2, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(Z2)
+      #if AXIS_IS_TMC(Z2)
         monitor_tmc_driver(stepperZ2, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(Z3)
+      #if AXIS_IS_TMC(Z3)
         monitor_tmc_driver(stepperZ3, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(E0)
+      #if AXIS_IS_TMC(E0)
         monitor_tmc_driver(stepperE0, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(E1)
+      #if AXIS_IS_TMC(E1)
         monitor_tmc_driver(stepperE1, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(E2)
+      #if AXIS_IS_TMC(E2)
         monitor_tmc_driver(stepperE2, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(E3)
+      #if AXIS_IS_TMC(E3)
         monitor_tmc_driver(stepperE3, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(E4)
+      #if AXIS_IS_TMC(E4)
         monitor_tmc_driver(stepperE4, need_update_error_counters, need_debug_reporting);
       #endif
-      #if HAS_HW_COMMS(E5)
+      #if AXIS_IS_TMC(E5)
         monitor_tmc_driver(stepperE5, need_update_error_counters, need_debug_reporting);
       #endif
 

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -23,12 +23,11 @@
 
 #include "../inc/MarlinConfig.h"
 #include "../lcd/ultralcd.h"
+
 #if HAS_TRINAMIC
-  #include <TMCStepper.h>
-#endif
-#if HAS_LCD_MENU
-  #include "../module/planner.h"
-#endif
+
+#include <TMCStepper.h>
+#include "../module/planner.h"
 
 #define TMC_X_LABEL 'X', '0'
 #define TMC_Y_LABEL 'Y', '0'
@@ -57,7 +56,7 @@
   #define MONITOR_DRIVER_STATUS_INTERVAL_MS 500u
 #endif
 
-constexpr uint16_t _tmc_thrs(const uint16_t msteps, const int32_t thrs, const uint32_t spmm) {
+constexpr uint16_t _tmc_thrs(const uint16_t msteps, const uint32_t thrs, const uint32_t spmm) {
   return 12650000UL * msteps / (256 * thrs * spmm);
 }
 
@@ -121,25 +120,35 @@ class TMCMarlin : public TMC, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
       inline void refresh_stepping_mode() { this->en_pwm_mode(this->stored.stealthChop_enabled); }
       inline bool get_stealthChop_status() { return this->en_pwm_mode(); }
     #endif
-
-    #if HAS_LCD_MENU
-
-      inline void init_lcd_variables(const AxisEnum spmm_id) {
-        #if ENABLED(HYBRID_THRESHOLD)
-          this->stored.hybrid_thrs = _tmc_thrs(this->microsteps(), this->TPWMTHRS(), planner.settings.axis_steps_per_mm[spmm_id]);
-        #endif
-        #if ENABLED(SENSORLESS_HOMING)
-          this->stored.homing_thrs = this->sgt();
+    #if ENABLED(HYBRID_THRESHOLD)
+      uint32_t get_pwm_thrs() {
+        return _tmc_thrs(this->microsteps(), this->TPWMTHRS(), planner.settings.axis_steps_per_mm[AXIS_ID]);
+      }
+      void set_pwm_thrs(const uint32_t thrs) {
+        TMC::TPWMTHRS(_tmc_thrs(this->microsteps(), thrs, planner.settings.axis_steps_per_mm[AXIS_ID]));
+        #if HAS_LCD_MENU
+          this->stored.hybrid_thrs = thrs;
         #endif
       }
+    #endif
+    #if ENABLED(SENSORLESS_HOMING)
+      inline int8_t sgt() { return TMC::sgt(); }
+      void sgt(const int8_t sgt_val) {
+        TMC::sgt(sgt_val);
+        #if HAS_LCD_MENU
+          this->stored.homing_thrs = sgt_val;
+        #endif
+      }
+    #endif
 
+    #if HAS_LCD_MENU
       inline void refresh_stepper_current() { rms_current(this->val_mA); }
 
       #if ENABLED(HYBRID_THRESHOLD)
-        inline void refresh_hybrid_thrs(float spmm) { this->TPWMTHRS(_tmc_thrs(this->microsteps(), this->stored.hybrid_thrs, spmm)); }
+        inline void refresh_hybrid_thrs() { set_pwm_thrs(this->stored.hybrid_thrs); }
       #endif
       #if ENABLED(SENSORLESS_HOMING)
-        inline void refresh_homing_thrs() { this->sgt(this->stored.homing_thrs); }
+        inline void refresh_homing_thrs() { sgt(this->stored.homing_thrs); }
       #endif
     #endif
 };
@@ -166,19 +175,23 @@ class TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC220
       inline void refresh_stepping_mode() { en_spreadCycle(!this->stored.stealthChop_enabled); }
       inline bool get_stealthChop_status() { return !this->en_spreadCycle(); }
     #endif
-
-    #if HAS_LCD_MENU
-
-      inline void init_lcd_variables(const AxisEnum spmm_id) {
-        #if ENABLED(HYBRID_THRESHOLD)
-          this->stored.hybrid_thrs = _tmc_thrs(this->microsteps(), this->TPWMTHRS(), planner.settings.axis_steps_per_mm[spmm_id]);
+    #if ENABLED(HYBRID_THRESHOLD)
+      uint32_t get_pwm_thrs() {
+        return _tmc_thrs(this->microsteps(), this->TPWMTHRS(), planner.settings.axis_steps_per_mm[AXIS_ID]);
+      }
+      void set_pwm_thrs(const uint32_t thrs) {
+        TMC2208Stepper::TPWMTHRS(_tmc_thrs(this->microsteps(), thrs, planner.settings.axis_steps_per_mm[AXIS_ID]));
+        #if HAS_LCD_MENU
+          this->stored.hybrid_thrs = thrs;
         #endif
       }
+    #endif
 
+    #if HAS_LCD_MENU
       inline void refresh_stepper_current() { rms_current(this->val_mA); }
 
       #if ENABLED(HYBRID_THRESHOLD)
-        inline void refresh_hybrid_thrs(float spmm) { this->TPWMTHRS(_tmc_thrs(this->microsteps(), this->stored.hybrid_thrs, spmm)); }
+        inline void refresh_hybrid_thrs() { set_pwm_thrs(this->stored.hybrid_thrs); }
       #endif
     #endif
 };
@@ -197,29 +210,29 @@ class TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC266
       TMC2660Stepper::rms_current(mA);
     }
 
-    #if HAS_LCD_MENU
-      inline void init_lcd_variables(const AxisEnum spmm_id) {
-        #if ENABLED(SENSORLESS_HOMING)
-          this->stored.homing_thrs = this->sgt();
+    #if ENABLED(SENSORLESS_HOMING)
+      inline int8_t sgt() { return TMC2660Stepper::sgt(); }
+      void sgt(const int8_t sgt_val) {
+        TMC2660Stepper::sgt(sgt_val);
+        #if HAS_LCD_MENU
+          this->stored.homing_thrs = sgt_val;
         #endif
       }
+    #endif
 
+    #if HAS_LCD_MENU
       inline void refresh_stepper_current() { rms_current(this->val_mA); }
 
       #if ENABLED(SENSORLESS_HOMING)
-        inline void refresh_homing_thrs() { this->sgt(this->stored.homing_thrs); }
+        inline void refresh_homing_thrs() { sgt(this->stored.homing_thrs); }
       #endif
     #endif
 };
 
 template<typename TMC>
-void tmc_get_current(TMC &st) {
+void tmc_print_current(TMC &st) {
   st.printLabel();
   SERIAL_ECHOLNPAIR(" driver current: ", st.getMilliamps());
-}
-template<typename TMC>
-void tmc_set_current(TMC &st, const int mA) {
-  st.rms_current(mA);
 }
 
 #if ENABLED(MONITOR_DRIVER_STATUS)
@@ -237,25 +250,21 @@ void tmc_set_current(TMC &st, const int mA) {
     SERIAL_ECHOLNPGM(" prewarn flag cleared");
   }
 #endif
-template<typename TMC>
-void tmc_get_pwmthrs(TMC &st, const uint16_t spmm) {
-  st.printLabel();
-  SERIAL_ECHOLNPAIR(" stealthChop max speed: ", _tmc_thrs(st.microsteps(), st.TPWMTHRS(), spmm));
-}
-template<typename TMC>
-void tmc_set_pwmthrs(TMC &st, const int32_t thrs, const uint32_t spmm) {
-  st.TPWMTHRS(_tmc_thrs(st.microsteps(), thrs, spmm));
-}
-template<typename TMC>
-void tmc_get_sgt(TMC &st) {
-  st.printLabel();
-  SERIAL_ECHOPGM(" homing sensitivity: ");
-  SERIAL_PRINTLN(st.sgt(), DEC);
-}
-template<typename TMC>
-void tmc_set_sgt(TMC &st, const int8_t sgt_val) {
-  st.sgt(sgt_val);
-}
+#if ENABLED(HYBRID_THRESHOLD)
+  template<typename TMC>
+  void tmc_print_pwmthrs(TMC &st) {
+    st.printLabel();
+    SERIAL_ECHOLNPAIR(" stealthChop max speed: ", st.get_pwm_thrs());
+  }
+#endif
+#if ENABLED(SENSORLESS_HOMING)
+  template<typename TMC>
+  void tmc_print_sgt(TMC &st) {
+    st.printLabel();
+    SERIAL_ECHOPGM(" homing sensitivity: ");
+    SERIAL_PRINTLN(st.sgt(), DEC);
+  }
+#endif
 
 void monitor_tmc_driver();
 void test_tmc_connection(const bool test_x, const bool test_y, const bool test_z, const bool test_e);
@@ -266,10 +275,6 @@ void test_tmc_connection(const bool test_x, const bool test_y, const bool test_z
   #endif
   void tmc_report_all(const bool print_x, const bool print_y, const bool print_z, const bool print_e);
   void tmc_get_registers(const bool print_x, const bool print_y, const bool print_z, const bool print_e);
-#endif
-
-#if HAS_LCD_MENU
-  void init_tmc_section();
 #endif
 
 /**
@@ -295,3 +300,5 @@ void test_tmc_connection(const bool test_x, const bool test_y, const bool test_z
 #if TMC_HAS_SPI
   void tmc_init_cs_pins();
 #endif
+
+#endif // HAS_TRINAMIC

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -98,7 +98,7 @@ class TMCStorage {
     } stored;
 };
 
-template<class TMC, char AXIS_LETTER, char DRIVER_ID>
+template<class TMC, char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
 class TMCMarlin : public TMC, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
   public:
     TMCMarlin(uint16_t cs_pin, float RS) :
@@ -143,8 +143,8 @@ class TMCMarlin : public TMC, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
       #endif
     #endif
 };
-template<char AXIS_LETTER, char DRIVER_ID>
-class TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID> : public TMC2208Stepper, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
+template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+class TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC2208Stepper, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
   public:
     TMCMarlin(Stream * SerialPort, float RS, bool has_rx=true) :
       TMC2208Stepper(SerialPort, RS, has_rx=true)
@@ -182,8 +182,8 @@ class TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID> : public TMC2208Stepper,
       #endif
     #endif
 };
-template<char AXIS_LETTER, char DRIVER_ID>
-class TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID> : public TMC2660Stepper, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
+template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+class TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC2660Stepper, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
   public:
     TMCMarlin(uint16_t cs_pin, float RS) :
       TMC2660Stepper(cs_pin, RS)

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -91,7 +91,7 @@ class TMCStorage {
       #if ENABLED(HYBRID_THRESHOLD)
         uint8_t hybrid_thrs = 0;
       #endif
-      #if ENABLED(SENSORLESS_HOMING)
+      #if USE_SENSORLESS
         int8_t homing_thrs = 0;
       #endif
     } stored;
@@ -131,7 +131,7 @@ class TMCMarlin : public TMC, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
         #endif
       }
     #endif
-    #if ENABLED(SENSORLESS_HOMING)
+    #if USE_SENSORLESS
       inline int8_t sgt() { return TMC::sgt(); }
       void sgt(const int8_t sgt_val) {
         TMC::sgt(sgt_val);
@@ -147,7 +147,7 @@ class TMCMarlin : public TMC, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
       #if ENABLED(HYBRID_THRESHOLD)
         inline void refresh_hybrid_thrs() { set_pwm_thrs(this->stored.hybrid_thrs); }
       #endif
-      #if ENABLED(SENSORLESS_HOMING)
+      #if USE_SENSORLESS
         inline void refresh_homing_thrs() { sgt(this->stored.homing_thrs); }
       #endif
     #endif
@@ -210,7 +210,7 @@ class TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC266
       TMC2660Stepper::rms_current(mA);
     }
 
-    #if ENABLED(SENSORLESS_HOMING)
+    #if USE_SENSORLESS
       inline int8_t sgt() { return TMC2660Stepper::sgt(); }
       void sgt(const int8_t sgt_val) {
         TMC2660Stepper::sgt(sgt_val);
@@ -223,7 +223,7 @@ class TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC266
     #if HAS_LCD_MENU
       inline void refresh_stepper_current() { rms_current(this->val_mA); }
 
-      #if ENABLED(SENSORLESS_HOMING)
+      #if USE_SENSORLESS
         inline void refresh_homing_thrs() { sgt(this->stored.homing_thrs); }
       #endif
     #endif
@@ -257,7 +257,7 @@ void tmc_print_current(TMC &st) {
     SERIAL_ECHOLNPAIR(" stealthChop max speed: ", st.get_pwm_thrs());
   }
 #endif
-#if ENABLED(SENSORLESS_HOMING)
+#if USE_SENSORLESS
   template<typename TMC>
   void tmc_print_sgt(TMC &st) {
     st.printLabel();

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -43,8 +43,8 @@
  * With no parameters report driver currents.
  */
 void GcodeSuite::M906() {
-  #define TMC_SAY_CURRENT(Q) tmc_get_current(stepper##Q)
-  #define TMC_SET_CURRENT(Q) tmc_set_current(stepper##Q, value)
+  #define TMC_SAY_CURRENT(Q) tmc_print_current(stepper##Q)
+  #define TMC_SET_CURRENT(Q) stepper##Q.rms_current(value)
 
   bool report = true;
 

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -192,10 +192,10 @@
  */
 #if ENABLED(HYBRID_THRESHOLD)
   void GcodeSuite::M913() {
-    #define TMC_SAY_PWMTHRS(A,Q) tmc_get_pwmthrs(stepper##Q, planner.settings.axis_steps_per_mm[_AXIS(A)])
-    #define TMC_SET_PWMTHRS(A,Q) tmc_set_pwmthrs(stepper##Q, value, planner.settings.axis_steps_per_mm[_AXIS(A)])
-    #define TMC_SAY_PWMTHRS_E(E) tmc_get_pwmthrs(stepperE##E, planner.settings.axis_steps_per_mm[E_AXIS_N(E)])
-    #define TMC_SET_PWMTHRS_E(E) tmc_set_pwmthrs(stepperE##E, value, planner.settings.axis_steps_per_mm[E_AXIS_N(E)])
+    #define TMC_SAY_PWMTHRS(A,Q) tmc_print_pwmthrs(stepper##Q)
+    #define TMC_SET_PWMTHRS(A,Q) stepper##Q.set_pwm_thrs(value)
+    #define TMC_SAY_PWMTHRS_E(E) tmc_print_pwmthrs(stepperE##E)
+    #define TMC_SET_PWMTHRS_E(E) stepperE##E.set_pwm_thrs(value)
 
     bool report = true;
     #if AXIS_IS_TMC(X) || AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z) || AXIS_IS_TMC(Z2) || AXIS_IS_TMC(Z3)
@@ -309,8 +309,6 @@
  */
 #if USE_SENSORLESS
   void GcodeSuite::M914() {
-    #define TMC_SAY_SGT(Q) tmc_get_sgt(stepper##Q)
-    #define TMC_SET_SGT(Q) tmc_set_sgt(stepper##Q, value)
 
     bool report = true;
     const uint8_t index = parser.byteval('I');
@@ -321,33 +319,33 @@
         #if X_SENSORLESS
           case X_AXIS:
             #if AXIS_HAS_STALLGUARD(X)
-              if (index < 2) TMC_SET_SGT(X);
+              if (index < 2) stepperX.sgt(value);
             #endif
             #if AXIS_HAS_STALLGUARD(X2)
-              if (!(index & 1)) TMC_SET_SGT(X2);
+              if (!(index & 1)) stepperX2.sgt(value);
             #endif
             break;
         #endif
         #if Y_SENSORLESS
           case Y_AXIS:
             #if AXIS_HAS_STALLGUARD(Y)
-              if (index < 2) TMC_SET_SGT(Y);
+              if (index < 2) stepperY.sgt(value);
             #endif
             #if AXIS_HAS_STALLGUARD(Y2)
-              if (!(index & 1)) TMC_SET_SGT(Y2);
+              if (!(index & 1)) stepperY2.sgt(value);
             #endif
             break;
         #endif
         #if Z_SENSORLESS
           case Z_AXIS:
             #if AXIS_HAS_STALLGUARD(Z)
-              if (index < 2) TMC_SET_SGT(Z);
+              if (index < 2) stepperZ.sgt(value);
             #endif
             #if AXIS_HAS_STALLGUARD(Z2)
-              if (index == 0 || index == 2) TMC_SET_SGT(Z2);
+              if (index == 0 || index == 2) stepperZ2.sgt(value);
             #endif
             #if AXIS_HAS_STALLGUARD(Z3)
-              if (index == 0 || index == 3) TMC_SET_SGT(Z3);
+              if (index == 0 || index == 3) stepperZ3.sgt(value);
             #endif
             break;
         #endif
@@ -357,29 +355,29 @@
     if (report) {
       #if X_SENSORLESS
         #if AXIS_HAS_STALLGUARD(X)
-          TMC_SAY_SGT(X);
+          tmc_print_sgt(stepperX);
         #endif
         #if AXIS_HAS_STALLGUARD(X2)
-          TMC_SAY_SGT(X2);
+          tmc_print_sgt(stepperX2);
         #endif
       #endif
       #if Y_SENSORLESS
         #if AXIS_HAS_STALLGUARD(Y)
-          TMC_SAY_SGT(Y);
+          tmc_print_sgt(stepperY);
         #endif
         #if AXIS_HAS_STALLGUARD(Y2)
-          TMC_SAY_SGT(Y2);
+          tmc_print_sgt(stepperY2);
         #endif
       #endif
       #if Z_SENSORLESS
         #if AXIS_HAS_STALLGUARD(Z)
-          TMC_SAY_SGT(Z);
+          tmc_print_sgt(stepperZ);
         #endif
         #if AXIS_HAS_STALLGUARD(Z2)
-          TMC_SAY_SGT(Z2);
+          tmc_print_sgt(stepperZ2);
         #endif
         #if AXIS_HAS_STALLGUARD(Z3)
-          TMC_SAY_SGT(Z3);
+          tmc_print_sgt(stepperZ3);
         #endif
       #endif
     }

--- a/Marlin/src/lcd/menu/menu_tmc.cpp
+++ b/Marlin/src/lcd/menu/menu_tmc.cpp
@@ -124,43 +124,43 @@ void menu_tmc_current() {
   #define TMC_EDIT_STORED_HYBRID_THRS(ST, MSG) MENU_ITEM_EDIT_CALLBACK(uint8, MSG, &stepper##ST.stored.hybrid_thrs, 0, 255, refresh_hybrid_thrs_##ST);
 
   #if AXIS_HAS_STEALTHCHOP(X)
-    void refresh_hybrid_thrs_X()  {  stepperX.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[X_AXIS]); }
+    void refresh_hybrid_thrs_X()  {  stepperX.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(Y)
-    void refresh_hybrid_thrs_Y()  {  stepperY.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[Y_AXIS]); }
+    void refresh_hybrid_thrs_Y()  {  stepperY.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(Z)
-    void refresh_hybrid_thrs_Z()  {  stepperZ.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[Z_AXIS]); }
+    void refresh_hybrid_thrs_Z()  {  stepperZ.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(X2)
-    void refresh_hybrid_thrs_X2() { stepperX2.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[X_AXIS]); }
+    void refresh_hybrid_thrs_X2() { stepperX2.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(Y2)
-    void refresh_hybrid_thrs_Y2() { stepperY2.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[Y_AXIS]); }
+    void refresh_hybrid_thrs_Y2() { stepperY2.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(Z2)
-    void refresh_hybrid_thrs_Z2() { stepperZ2.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[Z_AXIS]); }
+    void refresh_hybrid_thrs_Z2() { stepperZ2.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(Z3)
-    void refresh_hybrid_thrs_Z3() { stepperZ3.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[Z_AXIS]); }
+    void refresh_hybrid_thrs_Z3() { stepperZ3.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(E0)
-    void refresh_hybrid_thrs_E0() { stepperE0.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[E_AXIS]); }
+    void refresh_hybrid_thrs_E0() { stepperE0.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(E1)
-    void refresh_hybrid_thrs_E1() { stepperE1.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[E_AXIS_N(1)]); }
+    void refresh_hybrid_thrs_E1() { stepperE1.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(E2)
-    void refresh_hybrid_thrs_E2() { stepperE2.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[E_AXIS_N(2)]); }
+    void refresh_hybrid_thrs_E2() { stepperE2.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(E3)
-    void refresh_hybrid_thrs_E3() { stepperE3.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[E_AXIS_N(3)]); }
+    void refresh_hybrid_thrs_E3() { stepperE3.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(E4)
-    void refresh_hybrid_thrs_E4() { stepperE4.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[E_AXIS_N(4)]); }
+    void refresh_hybrid_thrs_E4() { stepperE4.refresh_hybrid_thrs(); }
   #endif
   #if AXIS_HAS_STEALTHCHOP(E5)
-    void refresh_hybrid_thrs_E5() { stepperE5.refresh_hybrid_thrs(planner.settings.axis_steps_per_mm[E_AXIS_N(5)]); }
+    void refresh_hybrid_thrs_E5() { stepperE5.refresh_hybrid_thrs(); }
   #endif
 
   void menu_tmc_hybrid_thrs() {

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -112,7 +112,6 @@ extern float saved_extruder_advance_K[EXTRUDERS];
 #if HAS_TRINAMIC
   #include "stepper_indirection.h"
   #include "../feature/tmc_util.h"
-  #define TMC_GET_PWMTHRS(A,Q) _tmc_thrs(stepper##Q.microsteps(), stepper##Q.TPWMTHRS(), planner.settings.axis_steps_per_mm[_AXIS(A)])
 #endif
 
 #pragma pack(push, 1) // No padding between variables
@@ -962,49 +961,49 @@ void MarlinSettings::postprocess() {
       #if ENABLED(HYBRID_THRESHOLD)
        tmc_hybrid_threshold_t tmc_hybrid_threshold = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         #if AXIS_HAS_STEALTHCHOP(X)
-          tmc_hybrid_threshold.X = TMC_GET_PWMTHRS(X, X);
+          tmc_hybrid_threshold.X = stepperX.get_pwm_thrs();
         #endif
         #if AXIS_HAS_STEALTHCHOP(Y)
-          tmc_hybrid_threshold.Y = TMC_GET_PWMTHRS(Y, Y);
+          tmc_hybrid_threshold.Y = stepperY.get_pwm_thrs();
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z)
-          tmc_hybrid_threshold.Z = TMC_GET_PWMTHRS(Z, Z);
+          tmc_hybrid_threshold.Z = stepperZ.get_pwm_thrs();
         #endif
         #if AXIS_HAS_STEALTHCHOP(X2)
-          tmc_hybrid_threshold.X2 = TMC_GET_PWMTHRS(X, X2);
+          tmc_hybrid_threshold.X2 = stepperX2.get_pwm_thrs();
         #endif
         #if AXIS_HAS_STEALTHCHOP(Y2)
-          tmc_hybrid_threshold.Y2 = TMC_GET_PWMTHRS(Y, Y2);
+          tmc_hybrid_threshold.Y2 = stepperY2.get_pwm_thrs();
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z2)
-          tmc_hybrid_threshold.Z2 = TMC_GET_PWMTHRS(Z, Z2);
+          tmc_hybrid_threshold.Z2 = stepperZ2.get_pwm_thrs();
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z3)
-          tmc_hybrid_threshold.Z3 = TMC_GET_PWMTHRS(Z, Z3);
+          tmc_hybrid_threshold.Z3 = stepperZ3.get_pwm_thrs();
         #endif
         #if MAX_EXTRUDERS
           #if AXIS_HAS_STEALTHCHOP(E0)
-            tmc_hybrid_threshold.E0 = TMC_GET_PWMTHRS(E, E0);
+            tmc_hybrid_threshold.E0 = stepperE0.get_pwm_thrs();
           #endif
           #if MAX_EXTRUDERS > 1
             #if AXIS_HAS_STEALTHCHOP(E1)
-              tmc_hybrid_threshold.E1 = TMC_GET_PWMTHRS(E, E1);
+              tmc_hybrid_threshold.E1 = stepperE1.get_pwm_thrs();
             #endif
             #if MAX_EXTRUDERS > 2
               #if AXIS_HAS_STEALTHCHOP(E2)
-                tmc_hybrid_threshold.E2 = TMC_GET_PWMTHRS(E, E2);
+                tmc_hybrid_threshold.E2 = stepperE2.get_pwm_thrs();
               #endif
               #if MAX_EXTRUDERS > 3
                 #if AXIS_HAS_STEALTHCHOP(E3)
-                  tmc_hybrid_threshold.E3 = TMC_GET_PWMTHRS(E, E3);
+                  tmc_hybrid_threshold.E3 = stepperE3.get_pwm_thrs();
                 #endif
                 #if MAX_EXTRUDERS > 4
                   #if AXIS_HAS_STEALTHCHOP(E4)
-                    tmc_hybrid_threshold.E4 = TMC_GET_PWMTHRS(E, E4);
+                    tmc_hybrid_threshold.E4 = stepperE4.get_pwm_thrs();
                   #endif
                   #if MAX_EXTRUDERS > 5
                     #if AXIS_HAS_STEALTHCHOP(E5)
-                      tmc_hybrid_threshold.E5 = TMC_GET_PWMTHRS(E, E5);
+                      tmc_hybrid_threshold.E5 = stepperE5.get_pwm_thrs();
                     #endif
                   #endif // MAX_EXTRUDERS > 5
                 #endif // MAX_EXTRUDERS > 4
@@ -1742,46 +1741,45 @@ void MarlinSettings::postprocess() {
         EEPROM_READ(tmc_hybrid_threshold);
 
         #if ENABLED(HYBRID_THRESHOLD)
-          #define TMC_SET_PWMTHRS(A,Q) tmc_set_pwmthrs(stepper##Q, tmc_hybrid_threshold.Q, planner.settings.axis_steps_per_mm[_AXIS(A)])
           if (!validating) {
             #if AXIS_HAS_STEALTHCHOP(X)
-              TMC_SET_PWMTHRS(X, X);
+              stepperX.set_pwm_thrs(tmc_hybrid_threshold.X);
             #endif
             #if AXIS_HAS_STEALTHCHOP(Y)
-              TMC_SET_PWMTHRS(Y, Y);
+              stepperY.set_pwm_thrs(tmc_hybrid_threshold.Y);
             #endif
             #if AXIS_HAS_STEALTHCHOP(Z)
-              TMC_SET_PWMTHRS(Z, Z);
+              stepperZ.set_pwm_thrs(tmc_hybrid_threshold.Z);
             #endif
             #if AXIS_HAS_STEALTHCHOP(X2)
-              TMC_SET_PWMTHRS(X, X2);
+              stepperX2.set_pwm_thrs(tmc_hybrid_threshold.X2);
             #endif
             #if AXIS_HAS_STEALTHCHOP(Y2)
-              TMC_SET_PWMTHRS(Y, Y2);
+              stepperY2.set_pwm_thrs(tmc_hybrid_threshold.Y2);
             #endif
             #if AXIS_HAS_STEALTHCHOP(Z2)
-              TMC_SET_PWMTHRS(Z, Z2);
+              stepperZ2.set_pwm_thrs(tmc_hybrid_threshold.Z2);
             #endif
             #if AXIS_HAS_STEALTHCHOP(Z3)
-              TMC_SET_PWMTHRS(Z, Z3);
+              stepperZ3.set_pwm_thrs(tmc_hybrid_threshold.Z3);
             #endif
             #if AXIS_HAS_STEALTHCHOP(E0)
-              TMC_SET_PWMTHRS(E, E0);
+              stepperE0.set_pwm_thrs(tmc_hybrid_threshold.E0);
             #endif
             #if AXIS_HAS_STEALTHCHOP(E1)
-              TMC_SET_PWMTHRS(E, E1);
+              stepperE1.set_pwm_thrs(tmc_hybrid_threshold.E1);
             #endif
             #if AXIS_HAS_STEALTHCHOP(E2)
-              TMC_SET_PWMTHRS(E, E2);
+              stepperE2.set_pwm_thrs(tmc_hybrid_threshold.E2);
             #endif
             #if AXIS_HAS_STEALTHCHOP(E3)
-              TMC_SET_PWMTHRS(E, E3);
+              stepperE3.set_pwm_thrs(tmc_hybrid_threshold.E3);
             #endif
             #if AXIS_HAS_STEALTHCHOP(E4)
-              TMC_SET_PWMTHRS(E, E4);
+              stepperE4.set_pwm_thrs(tmc_hybrid_threshold.E4);
             #endif
             #if AXIS_HAS_STEALTHCHOP(E5)
-              TMC_SET_PWMTHRS(E, E5);
+              stepperE5.set_pwm_thrs(tmc_hybrid_threshold.E5);
             #endif
           }
         #endif
@@ -3149,13 +3147,13 @@ void MarlinSettings::reset() {
           say_M913();
         #endif
         #if AXIS_HAS_STEALTHCHOP(X)
-          SERIAL_ECHOPAIR(" X", TMC_GET_PWMTHRS(X, X));
+          SERIAL_ECHOPAIR(" X", stepperX.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(Y)
-          SERIAL_ECHOPAIR(" Y", TMC_GET_PWMTHRS(Y, Y));
+          SERIAL_ECHOPAIR(" Y", stepperY.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z)
-          SERIAL_ECHOPAIR(" Z", TMC_GET_PWMTHRS(Z, Z));
+          SERIAL_ECHOPAIR(" Z", stepperZ.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(X) || AXIS_HAS_STEALTHCHOP(Y) || AXIS_HAS_STEALTHCHOP(Z)
           SERIAL_EOL();
@@ -3166,13 +3164,13 @@ void MarlinSettings::reset() {
           SERIAL_ECHOPGM(" I1");
         #endif
         #if AXIS_HAS_STEALTHCHOP(X2)
-          SERIAL_ECHOPAIR(" X", TMC_GET_PWMTHRS(X, X2));
+          SERIAL_ECHOPAIR(" X", stepperX2.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(Y2)
-          SERIAL_ECHOPAIR(" Y", TMC_GET_PWMTHRS(Y, Y2));
+          SERIAL_ECHOPAIR(" Y", stepperY2.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(Z2)
-          SERIAL_ECHOPAIR(" Z", TMC_GET_PWMTHRS(Z, Z2));
+          SERIAL_ECHOPAIR(" Z", stepperZ2.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(X2) || AXIS_HAS_STEALTHCHOP(Y2) || AXIS_HAS_STEALTHCHOP(Z2)
           SERIAL_EOL();
@@ -3180,32 +3178,32 @@ void MarlinSettings::reset() {
 
         #if AXIS_HAS_STEALTHCHOP(Z3)
           say_M913();
-          SERIAL_ECHOLNPAIR(" I2 Z", TMC_GET_PWMTHRS(Z, Z3));
+          SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.get_pwm_thrs());
         #endif
 
         #if AXIS_HAS_STEALTHCHOP(E0)
           say_M913();
-          SERIAL_ECHOLNPAIR(" T0 E", TMC_GET_PWMTHRS(E, E0));
+          SERIAL_ECHOLNPAIR(" T0 E", stepperE0.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(E1)
           say_M913();
-          SERIAL_ECHOLNPAIR(" T1 E", TMC_GET_PWMTHRS(E, E1));
+          SERIAL_ECHOLNPAIR(" T1 E", stepperE1.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(E2)
           say_M913();
-          SERIAL_ECHOLNPAIR(" T2 E", TMC_GET_PWMTHRS(E, E2));
+          SERIAL_ECHOLNPAIR(" T2 E", stepperE2.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(E3)
           say_M913();
-          SERIAL_ECHOLNPAIR(" T3 E", TMC_GET_PWMTHRS(E, E3));
+          SERIAL_ECHOLNPAIR(" T3 E", stepperE3.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(E4)
           say_M913();
-          SERIAL_ECHOLNPAIR(" T4 E", TMC_GET_PWMTHRS(E, E4));
+          SERIAL_ECHOLNPAIR(" T4 E", stepperE4.get_pwm_thrs());
         #endif
         #if AXIS_HAS_STEALTHCHOP(E5)
           say_M913();
-          SERIAL_ECHOLNPAIR(" T5 E", TMC_GET_PWMTHRS(E, E5));
+          SERIAL_ECHOLNPAIR(" T5 E", stepperE5.get_pwm_thrs());
         #endif
         SERIAL_EOL();
       #endif // HYBRID_THRESHOLD

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -144,67 +144,86 @@
 #endif // TMC26X
 
 #if HAS_TRINAMIC
-  enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
-  #define _TMC_INIT(ST, SPMM_INDEX, STEALTH_INDEX) tmc_init(stepper##ST, ST##_CURRENT, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, stealthchop_by_axis[STEALTH_INDEX])
-#endif
-
-//
-// TMC2130 Driver objects and inits
-//
-#if HAS_DRIVER(TMC2130)
-
+  #include <HardwareSerial.h>
   #include <SPI.h>
   #include "planner.h"
   #include "../core/enum.h"
 
+  enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
+  #define _TMC_INIT(ST, STEALTH_INDEX) tmc_init(stepper##ST, ST##_CURRENT, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, stealthchop_by_axis[STEALTH_INDEX])
+
+  //   IC = TMC model number
+  //   ST = Stepper object letter
+  //   L  = Label characters
+  //   AI = Axis Enum Index
+  // SWHW = SW/SH UART selection
   #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC2130_DEFINE(ST, L, E) TMCMarlin<TMC2130Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC2130_DEFINE(ST) _TMC2130_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
+    #define __TMC_SPI_DEFINE(IC, ST, L, AI) TMCMarlin<IC##Stepper, L, AI> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
   #else
-    #define _TMC2130_DEFINE(ST, L, E) TMCMarlin<TMC2130Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC2130_DEFINE(ST) _TMC2130_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #endif
-  // Stepper objects of TMC2130 steppers used
-  #if AXIS_DRIVER_TYPE_X(TMC2130)
-    TMC2130_DEFINE(X);
-  #endif
-  #if AXIS_DRIVER_TYPE_X2(TMC2130)
-    TMC2130_DEFINE(X2);
-  #endif
-  #if AXIS_DRIVER_TYPE_Y(TMC2130)
-    TMC2130_DEFINE(Y);
-  #endif
-  #if AXIS_DRIVER_TYPE_Y2(TMC2130)
-    TMC2130_DEFINE(Y2);
-  #endif
-  #if AXIS_DRIVER_TYPE_Z(TMC2130)
-    TMC2130_DEFINE(Z);
-  #endif
-  #if AXIS_DRIVER_TYPE_Z2(TMC2130)
-    TMC2130_DEFINE(Z2);
-  #endif
-  #if AXIS_DRIVER_TYPE_Z3(TMC2130)
-    TMC2130_DEFINE(Z3);
-  #endif
-  #if AXIS_DRIVER_TYPE_E0(TMC2130)
-    TMC2130_DEFINE(E0);
-  #endif
-  #if AXIS_DRIVER_TYPE_E1(TMC2130)
-    TMC2130_DEFINE(E1);
-  #endif
-  #if AXIS_DRIVER_TYPE_E2(TMC2130)
-    TMC2130_DEFINE(E2);
-  #endif
-  #if AXIS_DRIVER_TYPE_E3(TMC2130)
-    TMC2130_DEFINE(E3);
-  #endif
-  #if AXIS_DRIVER_TYPE_E4(TMC2130)
-    TMC2130_DEFINE(E4);
-  #endif
-  #if AXIS_DRIVER_TYPE_E5(TMC2130)
-    TMC2130_DEFINE(E5);
+    #define __TMC_SPI_DEFINE(IC, ST, L, AI) TMCMarlin<IC##Stepper, L, AI> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
   #endif
 
+  #define TMC_UART_HW_DEFINE(IC, ST, L, AI) TMCMarlin<IC##Stepper, L, AI> stepper##ST(&ST##_HARDWARE_SERIAL, ST##_RSENSE)
+  #define TMC_UART_SW_DEFINE(IC, ST, L, AI) TMCMarlin<IC##Stepper, L, AI> stepper##ST(ST##_SERIAL_RX_PIN, ST##_SERIAL_TX_PIN, ST##_RSENSE, ST##_SERIAL_RX_PIN > -1)
+
+  #define _TMC_SPI_DEFINE(IC, ST, AI) __TMC_SPI_DEFINE(IC, ST, TMC_##ST##_LABEL, AI)
+  #define TMC_SPI_DEFINE(ST, AI) _TMC_SPI_DEFINE(ST##_DRIVER_TYPE, ST, AI##_AXIS)
+
+  #define _TMC_UART_DEFINE(SWHW, IC, ST, AI) TMC_UART_##SWHW##_DEFINE(IC, ST, TMC_##ST##_LABEL, AI)
+  #define TMC_UART_DEFINE(SWHW, ST, AI) _TMC_UART_DEFINE(SWHW, ST##_DRIVER_TYPE, ST, AI##_AXIS)
+
+  #if ENABLED(DISTINCT_E_FACTORS) && E_STEPPERS > 1
+    #define TMC_SPI_DEFINE_E(AI) TMC_SPI_DEFINE(E##AI, E##AI)
+    #define TMC_UART_DEFINE_E(SWHW, AI) TMC_UART_DEFINE(SWHW, E##AI, E##AI)
+  #else
+    #define TMC_SPI_DEFINE_E(AI) TMC_SPI_DEFINE(E##AI, E)
+    #define TMC_UART_DEFINE_E(SWHW, AI) TMC_UART_DEFINE(SWHW, E##AI, E)
+  #endif
+
+  // Stepper objects of TMC2130/TMC2160/TMC2660/TMC5130/TMC5160 steppers used
+  #if AXIS_HAS_SPI(X)
+    TMC_SPI_DEFINE(X, X);
+  #endif
+  #if AXIS_HAS_SPI(X2)
+    TMC_SPI_DEFINE(X2, X);
+  #endif
+  #if AXIS_HAS_SPI(Y)
+    TMC_SPI_DEFINE(Y, Y);
+  #endif
+  #if AXIS_HAS_SPI(Y2)
+    TMC_SPI_DEFINE(Y2, Y);
+  #endif
+  #if AXIS_HAS_SPI(Z)
+    TMC_SPI_DEFINE(Z, Z);
+  #endif
+  #if AXIS_HAS_SPI(Z2)
+    TMC_SPI_DEFINE(Z2, Z);
+  #endif
+  #if AXIS_HAS_SPI(Z3)
+    TMC_SPI_DEFINE(Z3, Z);
+  #endif
+  #if AXIS_HAS_SPI(E0)
+    TMC_SPI_DEFINE_E(0);
+  #endif
+  #if AXIS_HAS_SPI(E1)
+    TMC_SPI_DEFINE_E(1);
+  #endif
+  #if AXIS_HAS_SPI(E2)
+    TMC_SPI_DEFINE_E(2);
+  #endif
+  #if AXIS_HAS_SPI(E3)
+    TMC_SPI_DEFINE_E(3);
+  #endif
+  #if AXIS_HAS_SPI(E4)
+    TMC_SPI_DEFINE_E(4);
+  #endif
+  #if AXIS_HAS_SPI(E5)
+    TMC_SPI_DEFINE_E(5);
+  #endif
+
+#endif
+
+#if HAS_DRIVER(TMC2130)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
   void tmc_init(TMCMarlin<TMC2130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
@@ -242,63 +261,7 @@
   }
 #endif // TMC2130
 
-//
-// TMC2160 Driver objects and inits
-//
 #if HAS_DRIVER(TMC2160)
-
-  #include <SPI.h>
-  #include "planner.h"
-  #include "../core/enum.h"
-
-  #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC2160_DEFINE(ST, L, E) TMCMarlin<TMC2160Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC2160_DEFINE(ST) _TMC2160_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #else
-    #define _TMC2160_DEFINE(ST, L, E) TMCMarlin<TMC2160Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC2160_DEFINE(ST) _TMC2160_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #endif
-  // Stepper objects of TMC2160 steppers used
-  #if AXIS_DRIVER_TYPE(X, TMC2160)
-    TMC2160_DEFINE(X);
-  #endif
-  #if AXIS_DRIVER_TYPE(X2, TMC2160)
-    TMC2160_DEFINE(X2);
-  #endif
-  #if AXIS_DRIVER_TYPE(Y, TMC2160)
-    TMC2160_DEFINE(Y);
-  #endif
-  #if AXIS_DRIVER_TYPE(Y2, TMC2160)
-    TMC2160_DEFINE(Y2);
-  #endif
-  #if AXIS_DRIVER_TYPE(Z, TMC2160)
-    TMC2160_DEFINE(Z);
-  #endif
-  #if AXIS_DRIVER_TYPE(Z2, TMC2160)
-    TMC2160_DEFINE(Z2);
-  #endif
-  #if AXIS_DRIVER_TYPE(Z3, TMC2160)
-    TMC2160_DEFINE(Z3);
-  #endif
-  #if AXIS_DRIVER_TYPE(E0, TMC2160)
-    TMC2160_DEFINE(E0);
-  #endif
-  #if AXIS_DRIVER_TYPE(E1, TMC2160)
-    TMC2160_DEFINE(E1);
-  #endif
-  #if AXIS_DRIVER_TYPE(E2, TMC2160)
-    TMC2160_DEFINE(E2);
-  #endif
-  #if AXIS_DRIVER_TYPE(E3, TMC2160)
-    TMC2160_DEFINE(E3);
-  #endif
-  #if AXIS_DRIVER_TYPE(E4, TMC2160)
-    TMC2160_DEFINE(E4);
-  #endif
-  #if AXIS_DRIVER_TYPE(E5, TMC2160)
-    TMC2160_DEFINE(E5);
-  #endif
-
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
   void tmc_init(TMCMarlin<TMC2160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
@@ -349,105 +312,96 @@
 // TMC2208 Driver objects and inits
 //
 #if HAS_DRIVER(TMC2208)
-  #include <HardwareSerial.h>
-  #include "planner.h"
-
-  #define _TMC2208_DEFINE_HARDWARE(ST, L, E) TMCMarlin<TMC2208Stepper, L, E> stepper##ST(&ST##_HARDWARE_SERIAL, ST##_RSENSE)
-  #define TMC2208_DEFINE_HARDWARE(ST) _TMC2208_DEFINE_HARDWARE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-
-  #define _TMC2208_DEFINE_SOFTWARE(ST, L, E) TMCMarlin<TMC2208Stepper, L, E> stepper##ST(ST##_SERIAL_RX_PIN, ST##_SERIAL_TX_PIN, ST##_RSENSE, ST##_SERIAL_RX_PIN > -1)
-  #define TMC2208_DEFINE_SOFTWARE(ST) _TMC2208_DEFINE_SOFTWARE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-
   // Stepper objects of TMC2208 steppers used
   #if AXIS_DRIVER_TYPE_X(TMC2208)
     #ifdef X_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(X);
+      TMC_UART_DEFINE(HW, X, X);
     #else
-      TMC2208_DEFINE_SOFTWARE(X);
+      TMC_UART_DEFINE(SW, X, X);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_X2(TMC2208)
     #ifdef X2_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(X2);
+      TMC_UART_DEFINE(HW, X2, X);
     #else
-      TMC2208_DEFINE_SOFTWARE(X2);
+      TMC_UART_DEFINE(SW, X2, X);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_Y(TMC2208)
     #ifdef Y_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(Y);
+      TMC_UART_DEFINE(HW, Y, Y);
     #else
-      TMC2208_DEFINE_SOFTWARE(Y);
+      TMC_UART_DEFINE(SW, Y, Y);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_Y2(TMC2208)
     #ifdef Y2_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(Y2);
+      TMC_UART_DEFINE(HW, Y2, Y);
     #else
-      TMC2208_DEFINE_SOFTWARE(Y2);
+      TMC_UART_DEFINE(SW, Y2, Y);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_Z(TMC2208)
     #ifdef Z_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(Z);
+      TMC_UART_DEFINE(HW, Z, Z);
     #else
-      TMC2208_DEFINE_SOFTWARE(Z);
+      TMC_UART_DEFINE(SW, Z, Z);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_Z2(TMC2208)
     #ifdef Z2_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(Z2);
+      TMC_UART_DEFINE(HW, Z2, Z);
     #else
-      TMC2208_DEFINE_SOFTWARE(Z2);
+      TMC_UART_DEFINE(SW, Z2, Z);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_Z3(TMC2208)
     #ifdef Z3_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(Z3);
+      TMC_UART_DEFINE(HW, Z3, Z);
     #else
-      TMC2208_DEFINE_SOFTWARE(Z3);
+      TMC_UART_DEFINE(SW, Z3, Z);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_E0(TMC2208)
     #ifdef E0_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(E0);
+      TMC_UART_DEFINE_E(HW, 0);
     #else
-      TMC2208_DEFINE_SOFTWARE(E0);
+      TMC_UART_DEFINE_E(SW, 0);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_E1(TMC2208)
     #ifdef E1_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(E1);
+      TMC_UART_DEFINE_E(HW, 1);
     #else
-      TMC2208_DEFINE_SOFTWARE(E1);
+      TMC_UART_DEFINE_E(SW, 1);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_E2(TMC2208)
     #ifdef E2_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(E2);
+      TMC_UART_DEFINE_E(HW, 2);
     #else
-      TMC2208_DEFINE_SOFTWARE(E2);
+      TMC_UART_DEFINE_E(SW, 2);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_E3(TMC2208)
     #ifdef E3_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(E3);
+      TMC_UART_DEFINE_E(HW, 3);
     #else
-      TMC2208_DEFINE_SOFTWARE(E3);
+      TMC_UART_DEFINE_E(SW, 3);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_E4(TMC2208)
     #ifdef E4_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(E4);
+      TMC_UART_DEFINE_E(HW, 4);
     #else
-      TMC2208_DEFINE_SOFTWARE(E4);
+      TMC_UART_DEFINE_E(SW, 4);
     #endif
   #endif
   #if AXIS_DRIVER_TYPE_E5(TMC2208)
     #ifdef E5_HARDWARE_SERIAL
-      TMC2208_DEFINE_HARDWARE(E5);
+      TMC_UART_DEFINE_E(HW, 5);
     #else
-      TMC2208_DEFINE_SOFTWARE(E5);
+      TMC_UART_DEFINE_E(SW, 5);
     #endif
   #endif
 
@@ -589,61 +543,7 @@
   }
 #endif // TMC2208
 
-//
-// TMC2660 Driver objects and inits
-//
 #if HAS_DRIVER(TMC2660)
-
-  #include <SPI.h>
-  #include "planner.h"
-  #include "../core/enum.h"
-
-  #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC2660_DEFINE(ST, L, E) TMCMarlin<TMC2660Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC2660_DEFINE(ST) _TMC2660_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #else
-    #define _TMC2660_DEFINE(ST, L, E) TMCMarlin<TMC2660Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC2660_DEFINE(ST) _TMC2660_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #endif
-
-  // Stepper objects of TMC2660 steppers used
-  #if AXIS_DRIVER_TYPE_X(TMC2660)
-    TMC2660_DEFINE(X);
-  #endif
-  #if AXIS_DRIVER_TYPE_X2(TMC2660)
-    TMC2660_DEFINE(X2);
-  #endif
-  #if AXIS_DRIVER_TYPE_Y(TMC2660)
-    TMC2660_DEFINE(Y);
-  #endif
-  #if AXIS_DRIVER_TYPE_Y2(TMC2660)
-    TMC2660_DEFINE(Y2);
-  #endif
-  #if AXIS_DRIVER_TYPE_Z(TMC2660)
-    TMC2660_DEFINE(Z);
-  #endif
-  #if AXIS_DRIVER_TYPE_Z2(TMC2660)
-    TMC2660_DEFINE(Z2);
-  #endif
-  #if AXIS_DRIVER_TYPE_E0(TMC2660)
-    TMC2660_DEFINE(E0);
-  #endif
-  #if AXIS_DRIVER_TYPE_E1(TMC2660)
-    TMC2660_DEFINE(E1);
-  #endif
-  #if AXIS_DRIVER_TYPE_E2(TMC2660)
-    TMC2660_DEFINE(E2);
-  #endif
-  #if AXIS_DRIVER_TYPE_E3(TMC2660)
-    TMC2660_DEFINE(E3);
-  #endif
-  #if AXIS_DRIVER_TYPE_E4(TMC2660)
-    TMC2660_DEFINE(E4);
-  #endif
-  #if AXIS_DRIVER_TYPE_E5(TMC2660)
-    TMC2660_DEFINE(E5);
-  #endif
-
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
   void tmc_init(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t, const bool) {
     st.begin();
@@ -666,63 +566,7 @@
   }
 #endif // TMC2660
 
-//
-// TMC5130 Driver objects and inits
-//
 #if HAS_DRIVER(TMC5130)
-
-  #include <SPI.h>
-  #include "planner.h"
-  #include "../core/enum.h"
-
-  #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC5130_DEFINE(ST, L, E) TMCMarlin<TMC5130Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC5130_DEFINE(ST) _TMC5130_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #else
-    #define _TMC5130_DEFINE(ST, L, E) TMCMarlin<TMC5130Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC5130_DEFINE(ST) _TMC5130_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #endif
-  // Stepper objects of TMC5130 steppers used
-  #if AXIS_DRIVER_TYPE_X(TMC5130)
-    TMC5130_DEFINE(X);
-  #endif
-  #if AXIS_DRIVER_TYPE_X2(TMC5130)
-    TMC5130_DEFINE(X2);
-  #endif
-  #if AXIS_DRIVER_TYPE_Y(TMC5130)
-    TMC5130_DEFINE(Y);
-  #endif
-  #if AXIS_DRIVER_TYPE_Y2(TMC5130)
-    TMC5130_DEFINE(Y2);
-  #endif
-  #if AXIS_DRIVER_TYPE_Z(TMC5130)
-    TMC5130_DEFINE(Z);
-  #endif
-  #if AXIS_DRIVER_TYPE_Z2(TMC5130)
-    TMC5130_DEFINE(Z2);
-  #endif
-  #if AXIS_DRIVER_TYPE_Z3(TMC5130)
-    TMC5130_DEFINE(Z3);
-  #endif
-  #if AXIS_DRIVER_TYPE_E0(TMC5130)
-    TMC5130_DEFINE(E0);
-  #endif
-  #if AXIS_DRIVER_TYPE_E1(TMC5130)
-    TMC5130_DEFINE(E1);
-  #endif
-  #if AXIS_DRIVER_TYPE_E2(TMC5130)
-    TMC5130_DEFINE(E2);
-  #endif
-  #if AXIS_DRIVER_TYPE_E3(TMC5130)
-    TMC5130_DEFINE(E3);
-  #endif
-  #if AXIS_DRIVER_TYPE_E4(TMC5130)
-    TMC5130_DEFINE(E4);
-  #endif
-  #if AXIS_DRIVER_TYPE_E5(TMC5130)
-    TMC5130_DEFINE(E5);
-  #endif
-
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
   void tmc_init(TMCMarlin<TMC5130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
@@ -760,63 +604,7 @@
   }
 #endif // TMC5130
 
-//
-// TMC5160 Driver objects and inits
-//
 #if HAS_DRIVER(TMC5160)
-
-  #include <SPI.h>
-  #include "planner.h"
-  #include "../core/enum.h"
-
-  #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC5160_DEFINE(ST, L, E) TMCMarlin<TMC5160Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC5160_DEFINE(ST) _TMC5160_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #else
-    #define _TMC5160_DEFINE(ST, L, E) TMCMarlin<TMC5160Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC5160_DEFINE(ST) _TMC5160_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
-  #endif
-  // Stepper objects of TMC5160 steppers used
-  #if AXIS_DRIVER_TYPE(X, TMC5160)
-    TMC5160_DEFINE(X);
-  #endif
-  #if AXIS_DRIVER_TYPE(X2, TMC5160)
-    TMC5160_DEFINE(X2);
-  #endif
-  #if AXIS_DRIVER_TYPE(Y, TMC5160)
-    TMC5160_DEFINE(Y);
-  #endif
-  #if AXIS_DRIVER_TYPE(Y2, TMC5160)
-    TMC5160_DEFINE(Y2);
-  #endif
-  #if AXIS_DRIVER_TYPE(Z, TMC5160)
-    TMC5160_DEFINE(Z);
-  #endif
-  #if AXIS_DRIVER_TYPE(Z2, TMC5160)
-    TMC5160_DEFINE(Z2);
-  #endif
-  #if AXIS_DRIVER_TYPE(Z3, TMC5160)
-    TMC5160_DEFINE(Z3);
-  #endif
-  #if AXIS_DRIVER_TYPE(E0, TMC5160)
-    TMC5160_DEFINE(E0);
-  #endif
-  #if AXIS_DRIVER_TYPE(E1, TMC5160)
-    TMC5160_DEFINE(E1);
-  #endif
-  #if AXIS_DRIVER_TYPE(E2, TMC5160)
-    TMC5160_DEFINE(E2);
-  #endif
-  #if AXIS_DRIVER_TYPE(E3, TMC5160)
-    TMC5160_DEFINE(E3);
-  #endif
-  #if AXIS_DRIVER_TYPE(E4, TMC5160)
-    TMC5160_DEFINE(E4);
-  #endif
-  #if AXIS_DRIVER_TYPE(E5, TMC5160)
-    TMC5160_DEFINE(E5);
-  #endif
-
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
   void tmc_init(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
@@ -936,43 +724,43 @@ void reset_stepper_drivers() {
   #endif
 
   #if AXIS_IS_TMC(X)
-    _TMC_INIT(X, X_AXIS, STEALTH_AXIS_XY);
+    _TMC_INIT(X, STEALTH_AXIS_XY);
   #endif
   #if AXIS_IS_TMC(X2)
-    _TMC_INIT(X2, X_AXIS, STEALTH_AXIS_XY);
+    _TMC_INIT(X2, STEALTH_AXIS_XY);
   #endif
   #if AXIS_IS_TMC(Y)
-    _TMC_INIT(Y, Y_AXIS, STEALTH_AXIS_XY);
+    _TMC_INIT(Y, STEALTH_AXIS_XY);
   #endif
   #if AXIS_IS_TMC(Y2)
-    _TMC_INIT(Y2, Y_AXIS, STEALTH_AXIS_XY);
+    _TMC_INIT(Y2, STEALTH_AXIS_XY);
   #endif
   #if AXIS_IS_TMC(Z)
-    _TMC_INIT(Z, Z_AXIS, STEALTH_AXIS_Z);
+    _TMC_INIT(Z, STEALTH_AXIS_Z);
   #endif
   #if AXIS_IS_TMC(Z2)
-    _TMC_INIT(Z2, Z_AXIS, STEALTH_AXIS_Z);
+    _TMC_INIT(Z2, STEALTH_AXIS_Z);
   #endif
   #if AXIS_IS_TMC(Z3)
-    _TMC_INIT(Z3, Z_AXIS, STEALTH_AXIS_Z);
+    _TMC_INIT(Z3, STEALTH_AXIS_Z);
   #endif
   #if AXIS_IS_TMC(E0)
-    _TMC_INIT(E0, E_AXIS, STEALTH_AXIS_E);
+    _TMC_INIT(E0, STEALTH_AXIS_E);
   #endif
   #if AXIS_IS_TMC(E1)
-    _TMC_INIT(E1, E_AXIS_N(1), STEALTH_AXIS_E);
+    _TMC_INIT(E1, STEALTH_AXIS_E);
   #endif
   #if AXIS_IS_TMC(E2)
-    _TMC_INIT(E2, E_AXIS_N(2), STEALTH_AXIS_E);
+    _TMC_INIT(E2, STEALTH_AXIS_E);
   #endif
   #if AXIS_IS_TMC(E3)
-    _TMC_INIT(E3, E_AXIS_N(3), STEALTH_AXIS_E);
+    _TMC_INIT(E3, STEALTH_AXIS_E);
   #endif
   #if AXIS_IS_TMC(E4)
-    _TMC_INIT(E4, E_AXIS_N(4), STEALTH_AXIS_E);
+    _TMC_INIT(E4, STEALTH_AXIS_E);
   #endif
   #if AXIS_IS_TMC(E5)
-    _TMC_INIT(E5, E_AXIS_N(5), STEALTH_AXIS_E);
+    _TMC_INIT(E5, STEALTH_AXIS_E);
   #endif
 
   #if USE_SENSORLESS

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -145,7 +145,7 @@
 
 #if HAS_TRINAMIC
   enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
-  #define _TMC_INIT(ST, SPMM_INDEX, STEALTH_INDEX) tmc_init(stepper##ST, ST##_CURRENT, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, planner.settings.axis_steps_per_mm[SPMM_INDEX], stealthchop_by_axis[STEALTH_INDEX])
+  #define _TMC_INIT(ST, SPMM_INDEX, STEALTH_INDEX) tmc_init(stepper##ST, ST##_CURRENT, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, stealthchop_by_axis[STEALTH_INDEX])
 #endif
 
 //
@@ -233,10 +233,9 @@
     st.PWMCONF(pwmconf.sr);
 
     #if ENABLED(HYBRID_THRESHOLD)
-      st.TPWMTHRS(12650000UL*microsteps/(256*thrs*spmm));
+      st.set_pwm_thrs(thrs);
     #else
       UNUSED(thrs);
-      UNUSED(spmm);
     #endif
 
     st.GSTAT(); // Clear GSTAT
@@ -337,10 +336,9 @@
     st.PWMCONF(pwmconf.sr);
 
     #if ENABLED(HYBRID_THRESHOLD)
-      st.TPWMTHRS(12650000UL*microsteps/(256*thrs*spmm));
+      st.set_pwm_thrs(thrs);
     #else
       UNUSED(thrs);
-      UNUSED(spmm);
     #endif
 
     st.GSTAT(); // Clear GSTAT
@@ -581,10 +579,9 @@
     st.PWMCONF(pwmconf.sr);
 
     #if ENABLED(HYBRID_THRESHOLD)
-      st.TPWMTHRS(12650000UL*microsteps/(256*thrs*spmm));
+      st.set_pwm_thrs(thrs);
     #else
       UNUSED(thrs);
-      UNUSED(spmm);
     #endif
 
     st.GSTAT(0b111); // Clear
@@ -754,10 +751,9 @@
     st.PWMCONF(pwmconf.sr);
 
     #if ENABLED(HYBRID_THRESHOLD)
-      st.TPWMTHRS(12650000UL*microsteps/(256*thrs*spmm));
+      st.set_pwm_thrs(thrs);
     #else
       UNUSED(thrs);
-      UNUSED(spmm);
     #endif
 
     st.GSTAT(); // Clear GSTAT
@@ -857,10 +853,9 @@
     st.PWMCONF(pwmconf.sr);
 
     #if ENABLED(HYBRID_THRESHOLD)
-      st.TPWMTHRS(12650000UL*microsteps/(256*thrs*spmm));
+      st.set_pwm_thrs(thrs);
     #else
       UNUSED(thrs);
-      UNUSED(spmm);
     #endif
     st.GSTAT(); // Clear GSTAT
   }

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -158,11 +158,11 @@
   #include "../core/enum.h"
 
   #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC2130_DEFINE(ST, L) TMCMarlin<TMC2130Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC2130_DEFINE(ST) _TMC2130_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC2130_DEFINE(ST, L, E) TMCMarlin<TMC2130Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
+    #define TMC2130_DEFINE(ST) _TMC2130_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #else
-    #define _TMC2130_DEFINE(ST, L) TMCMarlin<TMC2130Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC2130_DEFINE(ST) _TMC2130_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC2130_DEFINE(ST, L, E) TMCMarlin<TMC2130Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
+    #define TMC2130_DEFINE(ST) _TMC2130_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #endif
   // Stepper objects of TMC2130 steppers used
   #if AXIS_DRIVER_TYPE_X(TMC2130)
@@ -205,8 +205,8 @@
     TMC2130_DEFINE(E5);
   #endif
 
-  template<char AXIS_LETTER, char DRIVER_ID>
-  void tmc_init(TMCMarlin<TMC2130Stepper, AXIS_LETTER, DRIVER_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const float spmm, const bool stealth) {
+  template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+  void tmc_init(TMCMarlin<TMC2130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
 
     CHOPCONF_t chopconf{0};
@@ -253,11 +253,11 @@
   #include "../core/enum.h"
 
   #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC2160_DEFINE(ST, L) TMCMarlin<TMC2160Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC2160_DEFINE(ST) _TMC2160_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC2160_DEFINE(ST, L, E) TMCMarlin<TMC2160Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
+    #define TMC2160_DEFINE(ST) _TMC2160_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #else
-    #define _TMC2160_DEFINE(ST, L) TMCMarlin<TMC2160Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC2160_DEFINE(ST) _TMC2160_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC2160_DEFINE(ST, L, E) TMCMarlin<TMC2160Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
+    #define TMC2160_DEFINE(ST) _TMC2160_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #endif
   // Stepper objects of TMC2160 steppers used
   #if AXIS_DRIVER_TYPE(X, TMC2160)
@@ -300,8 +300,8 @@
     TMC2160_DEFINE(E5);
   #endif
 
-  template<char AXIS_LETTER, char DRIVER_ID>
-  void tmc_init(TMCMarlin<TMC2160Stepper, AXIS_LETTER, DRIVER_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const float spmm, const bool stealth) {
+  template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+  void tmc_init(TMCMarlin<TMC2160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
 
     static constexpr int8_t timings[] = CHOPPER_TIMING; // Default 4, -2, 1
@@ -354,11 +354,11 @@
   #include <HardwareSerial.h>
   #include "planner.h"
 
-  #define _TMC2208_DEFINE_HARDWARE(ST, L) TMCMarlin<TMC2208Stepper, L> stepper##ST(&ST##_HARDWARE_SERIAL, ST##_RSENSE)
-  #define TMC2208_DEFINE_HARDWARE(ST) _TMC2208_DEFINE_HARDWARE(ST, TMC_##ST##_LABEL)
+  #define _TMC2208_DEFINE_HARDWARE(ST, L, E) TMCMarlin<TMC2208Stepper, L, E> stepper##ST(&ST##_HARDWARE_SERIAL, ST##_RSENSE)
+  #define TMC2208_DEFINE_HARDWARE(ST) _TMC2208_DEFINE_HARDWARE(ST, TMC_##ST##_LABEL, ST##_AXIS)
 
-  #define _TMC2208_DEFINE_SOFTWARE(ST, L) TMCMarlin<TMC2208Stepper, L> stepper##ST(ST##_SERIAL_RX_PIN, ST##_SERIAL_TX_PIN, ST##_RSENSE, ST##_SERIAL_RX_PIN > -1)
-  #define TMC2208_DEFINE_SOFTWARE(ST) _TMC2208_DEFINE_SOFTWARE(ST, TMC_##ST##_LABEL)
+  #define _TMC2208_DEFINE_SOFTWARE(ST, L, E) TMCMarlin<TMC2208Stepper, L, E> stepper##ST(ST##_SERIAL_RX_PIN, ST##_SERIAL_TX_PIN, ST##_RSENSE, ST##_SERIAL_RX_PIN > -1)
+  #define TMC2208_DEFINE_SOFTWARE(ST) _TMC2208_DEFINE_SOFTWARE(ST, TMC_##ST##_LABEL, ST##_AXIS)
 
   // Stepper objects of TMC2208 steppers used
   #if AXIS_DRIVER_TYPE_X(TMC2208)
@@ -547,8 +547,8 @@
     #endif
   }
 
-  template<char AXIS_LETTER, char DRIVER_ID>
-  void tmc_init(TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const float spmm, const bool stealth) {
+  template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+  void tmc_init(TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     TMC2208_n::GCONF_t gconf{0};
     gconf.pdn_disable = true; // Use UART
     gconf.mstep_reg_select = true; // Select microsteps with UART
@@ -602,11 +602,11 @@
   #include "../core/enum.h"
 
   #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC2660_DEFINE(ST, L) TMCMarlin<TMC2660Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC2660_DEFINE(ST) _TMC2660_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC2660_DEFINE(ST, L, E) TMCMarlin<TMC2660Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
+    #define TMC2660_DEFINE(ST) _TMC2660_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #else
-    #define _TMC2660_DEFINE(ST, L) TMCMarlin<TMC2660Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC2660_DEFINE(ST) _TMC2660_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC2660_DEFINE(ST, L, E) TMCMarlin<TMC2660Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
+    #define TMC2660_DEFINE(ST) _TMC2660_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #endif
 
   // Stepper objects of TMC2660 steppers used
@@ -647,8 +647,8 @@
     TMC2660_DEFINE(E5);
   #endif
 
-  template<char AXIS_LETTER, char DRIVER_ID>
-  void tmc_init(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t, const float, const bool) {
+  template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+  void tmc_init(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t, const bool) {
     st.begin();
 
     TMC2660_n::CHOPCONF_t chopconf{0};
@@ -679,11 +679,11 @@
   #include "../core/enum.h"
 
   #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC5130_DEFINE(ST, L) TMCMarlin<TMC5130Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC5130_DEFINE(ST) _TMC5130_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC5130_DEFINE(ST, L, E) TMCMarlin<TMC5130Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
+    #define TMC5130_DEFINE(ST) _TMC5130_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #else
-    #define _TMC5130_DEFINE(ST, L) TMCMarlin<TMC5130Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC5130_DEFINE(ST) _TMC5130_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC5130_DEFINE(ST, L, E) TMCMarlin<TMC5130Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
+    #define TMC5130_DEFINE(ST) _TMC5130_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #endif
   // Stepper objects of TMC5130 steppers used
   #if AXIS_DRIVER_TYPE_X(TMC5130)
@@ -726,8 +726,8 @@
     TMC5130_DEFINE(E5);
   #endif
 
-  template<char AXIS_LETTER, char DRIVER_ID>
-  void tmc_init(TMCMarlin<TMC5130Stepper, AXIS_LETTER, DRIVER_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const float spmm, const bool stealth) {
+  template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+  void tmc_init(TMCMarlin<TMC5130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
 
     CHOPCONF_t chopconf{0};
@@ -774,11 +774,11 @@
   #include "../core/enum.h"
 
   #if ENABLED(TMC_USE_SW_SPI)
-    #define _TMC5160_DEFINE(ST, L) TMCMarlin<TMC5160Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
-    #define TMC5160_DEFINE(ST) _TMC5160_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC5160_DEFINE(ST, L, E) TMCMarlin<TMC5160Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE, TMC_SW_MOSI, TMC_SW_MISO, TMC_SW_SCK)
+    #define TMC5160_DEFINE(ST) _TMC5160_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #else
-    #define _TMC5160_DEFINE(ST, L) TMCMarlin<TMC5160Stepper, L> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
-    #define TMC5160_DEFINE(ST) _TMC5160_DEFINE(ST, TMC_##ST##_LABEL)
+    #define _TMC5160_DEFINE(ST, L, E) TMCMarlin<TMC5160Stepper, L, E> stepper##ST(ST##_CS_PIN, ST##_RSENSE)
+    #define TMC5160_DEFINE(ST) _TMC5160_DEFINE(ST, TMC_##ST##_LABEL, ST##_AXIS)
   #endif
   // Stepper objects of TMC5160 steppers used
   #if AXIS_DRIVER_TYPE(X, TMC5160)
@@ -821,8 +821,8 @@
     TMC5160_DEFINE(E5);
   #endif
 
-  template<char AXIS_LETTER, char DRIVER_ID>
-  void tmc_init(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const float spmm, const bool stealth) {
+  template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
+  void tmc_init(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
 
     int8_t timings[] = CHOPPER_TIMING; // Default 4, -2, 1

--- a/Marlin/src/module/stepper_indirection.h
+++ b/Marlin/src/module/stepper_indirection.h
@@ -62,11 +62,11 @@
     #error "Update TMCStepper library to 0.2.2 or newer."
   #endif
 
-  #define ____TMC_CLASS(MODEL, A, I) TMCMarlin<TMC##MODEL##Stepper, A, I>
-  #define ___TMC_CLASS(MODEL, A, I) ____TMC_CLASS(MODEL, A, I)
-  #define __TMC_CLASS(MODEL, A, I) ___TMC_CLASS(_##MODEL, A, I)
-  #define _TMC_CLASS(MODEL, L) __TMC_CLASS(MODEL, L)
-  #define TMC_CLASS(ST) _TMC_CLASS(ST##_DRIVER_TYPE, TMC_##ST##_LABEL)
+  #define ____TMC_CLASS(MODEL, A, I, E) TMCMarlin<TMC##MODEL##Stepper, A, I, E>
+  #define ___TMC_CLASS(MODEL, A, I, E) ____TMC_CLASS(MODEL, A, I, E)
+  #define __TMC_CLASS(MODEL, A, I, E) ___TMC_CLASS(_##MODEL, A, I, E)
+  #define _TMC_CLASS(MODEL, L, E) __TMC_CLASS(MODEL, L, E)
+  #define TMC_CLASS(ST) _TMC_CLASS(ST##_DRIVER_TYPE, TMC_##ST##_LABEL, ST##_AXIS)
 
   typedef struct {
     uint8_t toff;


### PR DESCRIPTION
In an effort to crack down on some bugs

* If a user has an LCD configured, capture the LCD shadow variables any time a write happens. This will keep the variables always up to date when viewed (or modified) either from the LCD menu or from gcode commands. Initiating the shadow variables at boot time is no longer necessary.
* `TMCMarlin` class is now aware of the AxisEnum axis ID number. For now it is only used for determining the steps per mm setting from planner array, but it may become useful later on.
* `MONITOR_DRIVER_STATUS` now works with TMC2208 SW Serial communication as well. This was an artificial limitation as it is considerable slower than the HW counterpart, but perhaps not too slow after all.
* Removed many unnecessary functions and references with planner spmm as arguments. The same functionality can be handled inside the class which is now aware of the planner array and indexing.
* Addressed a compile warning about some unused functions in tmc_util.

--- 

Current state: Final maybe