### PR TITLE
Shorten pause message for 4 line LCD

### DIFF
--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -372,7 +372,7 @@ void _lcd_pause_message(PGM_P const msg1, PGM_P const msg2=nullptr, PGM_P const 
   STATIC_ITEM_P(pause_header(), true, true);
   STATIC_ITEM_P(msg1);
   if (msg2) STATIC_ITEM_P(msg2);
-  if (msg3) STATIC_ITEM_P(msg3);
+  if ((!!msg3) & (LCD_HEIGHT > 4)) STATIC_ITEM_P(msg3);
   if ((!!msg2) + (!!msg3) + 2 < LCD_HEIGHT - 1) STATIC_ITEM(" ");
   HOTEND_STATUS_ITEM();
   END_SCREEN();

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -372,7 +372,7 @@ void _lcd_pause_message(PGM_P const msg1, PGM_P const msg2=nullptr, PGM_P const 
   STATIC_ITEM_P(pause_header(), true, true);
   STATIC_ITEM_P(msg1);
   if (msg2) STATIC_ITEM_P(msg2);
-  if ((!!msg3) && (LCD_HEIGHT) >= 4) STATIC_ITEM_P(msg3);
+  if ((!!msg3) && (LCD_HEIGHT) >= 5) STATIC_ITEM_P(msg3);
   if ((!!msg2) + (!!msg3) + 2 < (LCD_HEIGHT) - 1) STATIC_ITEM(" ");
   HOTEND_STATUS_ITEM();
   END_SCREEN();

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -372,7 +372,7 @@ void _lcd_pause_message(PGM_P const msg1, PGM_P const msg2=nullptr, PGM_P const 
   STATIC_ITEM_P(pause_header(), true, true);
   STATIC_ITEM_P(msg1);
   if (msg2) STATIC_ITEM_P(msg2);
-  if ((!!msg3) && (LCD_HEIGHT) >= 5) STATIC_ITEM_P(msg3);
+  if (msg3 && (LCD_HEIGHT) >= 5) STATIC_ITEM_P(msg3);
   if ((!!msg2) + (!!msg3) + 2 < (LCD_HEIGHT) - 1) STATIC_ITEM(" ");
   HOTEND_STATUS_ITEM();
   END_SCREEN();

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -372,8 +372,8 @@ void _lcd_pause_message(PGM_P const msg1, PGM_P const msg2=nullptr, PGM_P const 
   STATIC_ITEM_P(pause_header(), true, true);
   STATIC_ITEM_P(msg1);
   if (msg2) STATIC_ITEM_P(msg2);
-  if ((!!msg3) & (LCD_HEIGHT > 4)) STATIC_ITEM_P(msg3);
-  if ((!!msg2) + (!!msg3) + 2 < LCD_HEIGHT - 1) STATIC_ITEM(" ");
+  if ((!!msg3) && (LCD_HEIGHT) >= 4) STATIC_ITEM_P(msg3);
+  if ((!!msg2) + (!!msg3) + 2 < (LCD_HEIGHT) - 1) STATIC_ITEM(" ");
   HOTEND_STATUS_ITEM();
   END_SCREEN();
 }


### PR DESCRIPTION
Some Pause messages have 5 lines.
1 line Header + 3 lines + 1 line of temperature info

For 2004 Display, the line will scroll if the LCD encoder is rotated. But it is not convenient and the message text at line 3 is not really necessary.

This PR removes line number 3 if the LCD has only 4 lines.
