### PR TITLE
Fixed M43 compare bug

### DIFF
--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -218,7 +218,7 @@ inline void servo_probe_test() {
       if (deploy_state != READ(PROBE_TEST_PIN)) {               // probe triggered
         for (probe_counter = 0; probe_counter < 15 && deploy_state != READ(PROBE_TEST_PIN); ++probe_counter) safe_delay(2);
 
-        if (probe_counter = 15)
+        if (probe_counter == 15)
           SERIAL_ECHOLNPGM(". Pulse width: 30ms or more");
         else 
           SERIAL_ECHOLNPAIR(". Pulse width (+/- 4ms): ", probe_counter * 2);


### PR DESCRIPTION
### Description

Fixed use of `=` instead of `==` in `src/gcode/config/M43.cpp`

### Benefits

Code should now function as its author intended.

Fixes classic use of `=` instead of `==` comparator in `if (conditional)` `src/gcode/config/M43.cpp`, line 221.

### Related Issues

n/a
