### PR TITLE
Various fixes for ESP32

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -92,6 +92,11 @@ esp_adc_cal_characteristics_t characteristics;
 // --------------------------------------------------------------------------
 
 void HAL_init(void) {
+  i2s_init();
+}
+
+void HAL_init_board(void) {
+
   #if ENABLED(WIFISUPPORT)
     wifi_init();
     #if ENABLED(OTASUPPORT)
@@ -106,7 +111,6 @@ void HAL_init(void) {
     spiffs_init();
   #endif
 
-  i2s_init();
 }
 
 void HAL_idletask(void) {

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -33,6 +33,9 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
+#if ANY(EEPROM_SETTINGS,WEBSUPPORT)
+  #include "spiffs.h"
+#endif
 #if ENABLED(WIFISUPPORT)
   #include <ESPAsyncWebServer.h>
   #include "wifi.h"
@@ -41,10 +44,7 @@
   #endif
   #if ENABLED(WEBSUPPORT)
     #include "web.h"
-    #include "spiffs.h"
   #endif
-#elif ENABLED(EEPROM_SETTINGS)
-  #include "spiffs.h"
 #endif
 
 // --------------------------------------------------------------------------
@@ -97,18 +97,19 @@ void HAL_init(void) {
 
 void HAL_init_board(void) {
 
+  #if ANY(EEPROM_SETTINGS,WEBSUPPORT)
+    spiffs_init();
+  #endif
+
   #if ENABLED(WIFISUPPORT)
     wifi_init();
     #if ENABLED(OTASUPPORT)
       OTA_init();
     #endif
     #if ENABLED(WEBSUPPORT)
-      spiffs_init();
       web_init();
     #endif
     server.begin();
-  #elif ENABLED(EEPROM_SETTINGS)
-    spiffs_init();
   #endif
 
 }

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -33,7 +33,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ANY(EEPROM_SETTINGS, WEBSUPPORT)
+#if EITHER(EEPROM_SETTINGS, WEBSUPPORT)
   #include "spiffs.h"
 #endif
 
@@ -97,8 +97,7 @@ void HAL_init(void) {
 }
 
 void HAL_init_board(void) {
-
-  #if ANY(EEPROM_SETTINGS,WEBSUPPORT)
+  #if EITHER(EEPROM_SETTINGS, WEBSUPPORT)
     spiffs_init();
   #endif
 
@@ -112,7 +111,6 @@ void HAL_init_board(void) {
     #endif
     server.begin();
   #endif
-
 }
 
 void HAL_idletask(void) {
@@ -123,18 +121,12 @@ void HAL_idletask(void) {
 
 void HAL_clear_reset_source(void) { }
 
-uint8_t HAL_get_reset_source(void) {
-  return rtc_get_reset_reason(1);
-}
+uint8_t HAL_get_reset_source(void) { return rtc_get_reset_reason(1); }
 
-void _delay_ms(int delay_ms) {
-  delay(delay_ms);
-}
+void _delay_ms(int delay_ms) { delay(delay_ms); }
 
 // return free memory between end of heap (or end bss) and whatever is current
-int freeMemory() {
-  return ESP.getFreeHeap();
-}
+int freeMemory() { return ESP.getFreeHeap(); }
 
 // --------------------------------------------------------------------------
 // ADC
@@ -150,7 +142,6 @@ adc1_channel_t get_channel(int pin) {
     case 33: return ADC1_CHANNEL(33);
     case 32: return ADC1_CHANNEL(32);
   }
-
   return ADC1_CHANNEL_MAX;
 }
 
@@ -201,9 +192,9 @@ void HAL_adc_start_conversion(uint8_t adc_pin) {
   HAL_adc_result = mv*1023.0/3300.0;
 }
 
-int pin_to_channel[40] = {};
-int cnt_channel = 1;
 void analogWrite(int pin, int value) {
+  static int cnt_channel = 1,
+             pin_to_channel[40] = {};
   if (pin_to_channel[pin] == 0) {
     ledcAttachPin(pin, cnt_channel);
     ledcSetup(cnt_channel, 490, 8);
@@ -214,4 +205,5 @@ void analogWrite(int pin, int value) {
 
   ledcWrite(pin_to_channel[pin], value);
 }
+
 #endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -33,9 +33,10 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ANY(EEPROM_SETTINGS,WEBSUPPORT)
+#if ANY(EEPROM_SETTINGS, WEBSUPPORT)
   #include "spiffs.h"
 #endif
+
 #if ENABLED(WIFISUPPORT)
   #include <ESPAsyncWebServer.h>
   #include "wifi.h"

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -151,12 +151,35 @@ adc1_channel_t get_channel(int pin) {
 void HAL_adc_init() {
   // Configure ADC
   adc1_config_width(ADC_WIDTH_12Bit);
-  adc1_config_channel_atten(get_channel(39), ADC_ATTEN_11db);
-  adc1_config_channel_atten(get_channel(36), ADC_ATTEN_11db);
-  adc1_config_channel_atten(get_channel(35), ADC_ATTEN_11db);
-  adc1_config_channel_atten(get_channel(34), ADC_ATTEN_11db);
-  adc1_config_channel_atten(get_channel(33), ADC_ATTEN_11db);
-  adc1_config_channel_atten(get_channel(32), ADC_ATTEN_11db);
+  
+  // Configure channels only if used as (re-)configuring a pin for ADC that is used elsewhere might have adverse effects
+  #if HAS_TEMP_ADC_0
+    adc1_config_channel_atten(get_channel(TEMP_0_PIN), ADC_ATTEN_11db);
+  #endif
+  #if HAS_TEMP_ADC_1
+    adc1_config_channel_atten(get_channel(TEMP_1_PIN), ADC_ATTEN_11db);
+  #endif
+  #if HAS_TEMP_ADC_2
+    adc1_config_channel_atten(get_channel(TEMP_2_PIN), ADC_ATTEN_11db);
+  #endif
+  #if HAS_TEMP_ADC_3
+    adc1_config_channel_atten(get_channel(TEMP_3_PIN), ADC_ATTEN_11db);
+  #endif
+  #if HAS_TEMP_ADC_4
+    adc1_config_channel_atten(get_channel(TEMP_4_PIN), ADC_ATTEN_11db);
+  #endif
+  #if HAS_TEMP_ADC_5
+    adc1_config_channel_atten(get_channel(TEMP_5_PIN), ADC_ATTEN_11db);
+  #endif
+  #if HAS_HEATED_BED
+    adc1_config_channel_atten(get_channel(TEMP_BED_PIN), ADC_ATTEN_11db);
+  #endif
+  #if HAS_TEMP_CHAMBER
+    adc1_config_channel_atten(get_channel(TEMP_CHAMBER_PIN), ADC_ATTEN_11db);
+  #endif
+  #if ENABLED(FILAMENT_WIDTH_SENSOR)
+    adc1_config_channel_atten(get_channel(FILWIDTH_PIN), ADC_ATTEN_11db);
+  #endif
 
   // Note that adc2 is shared with the WiFi module, which has higher priority, so the conversion may fail.
   // That's why we're not setting it up here.

--- a/Marlin/src/HAL/HAL_ESP32/HAL.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.h
@@ -122,5 +122,7 @@ void HAL_adc_start_conversion(uint8_t adc_pin);
 // Enable hooks into idle and setup for HAL
 #define HAL_IDLETASK 1
 #define HAL_INIT 1
+#define BOARD_INIT() HAL_init_board();
 void HAL_idletask(void);
 void HAL_init(void);
+void HAL_init_board(void);

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
@@ -169,10 +169,8 @@ hal_timer_t HAL_timer_get_compare(const uint8_t timer_num) {
  */
 hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
   const tTimerConfig timer = TimerConfig[timer_num];
-
   uint64_t counter_value;
   timer_get_counter_value(timer.group, timer.idx, &counter_value);
-
   return counter_value;
 }
 
@@ -181,8 +179,8 @@ hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
  * @param timer_num timer number to enable interrupts on
  */
 void HAL_timer_enable_interrupt(const uint8_t timer_num) {
-  // const tTimerConfig timer = TimerConfig[timer_num];
-  // timer_enable_intr(timer.group, timer.idx);
+  //const tTimerConfig timer = TimerConfig[timer_num];
+  //timer_enable_intr(timer.group, timer.idx);
 }
 
 /**
@@ -190,8 +188,8 @@ void HAL_timer_enable_interrupt(const uint8_t timer_num) {
  * @param timer_num timer number to disable interrupts on
  */
 void HAL_timer_disable_interrupt(const uint8_t timer_num) {
-  // const tTimerConfig timer = TimerConfig[timer_num];
-  // timer_disable_intr(timer.group, timer.idx);
+  //const tTimerConfig timer = TimerConfig[timer_num];
+  //timer_disable_intr(timer.group, timer.idx);
 }
 
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num) {

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
@@ -181,8 +181,8 @@ hal_timer_t HAL_timer_get_count(const uint8_t timer_num) {
  * @param timer_num timer number to enable interrupts on
  */
 void HAL_timer_enable_interrupt(const uint8_t timer_num) {
-  const tTimerConfig timer = TimerConfig[timer_num];
-  //timer_enable_intr(timer.group, timer.idx);
+  // const tTimerConfig timer = TimerConfig[timer_num];
+  // timer_enable_intr(timer.group, timer.idx);
 }
 
 /**
@@ -190,7 +190,7 @@ void HAL_timer_enable_interrupt(const uint8_t timer_num) {
  * @param timer_num timer number to disable interrupts on
  */
 void HAL_timer_disable_interrupt(const uint8_t timer_num) {
-  const tTimerConfig timer = TimerConfig[timer_num];
+  // const tTimerConfig timer = TimerConfig[timer_num];
   // timer_disable_intr(timer.group, timer.idx);
 }
 

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.cpp
@@ -132,7 +132,7 @@ void HAL_timer_start(const uint8_t timer_num, uint32_t frequency) {
   timer_enable_intr(timer.group, timer.idx);
 
   // TODO need to deal with timer_group1_isr
-  timer_isr_register(timer.group, timer.idx, timer_group0_isr, (void*)timer.idx, ESP_INTR_FLAG_INTRDISABLED, nullptr);
+  timer_isr_register(timer.group, timer.idx, timer_group0_isr, (void*)timer.idx, 0, nullptr);
 
   timer_start(timer.group, timer.idx);
 }

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.h
@@ -28,6 +28,12 @@
 #include <stdint.h>
 #include "driver/timer.h"
 
+// need this to pull I2S_STEPPER_STREAM definition from pins_*.h based on configured board
+#include "../../inc/MarlinConfig.h"
+// need to also include pins.h explicitly here as the above statement will be ignored if HAL_timers_ESP32.h 
+// is being included from inside MarlinConfig.h / HAL.h (but before pins.h)
+#include "../../pins/pins.h"
+
 // --------------------------------------------------------------------------
 // Defines
 // --------------------------------------------------------------------------

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.h
@@ -28,10 +28,9 @@
 #include <stdint.h>
 #include "driver/timer.h"
 
-// need this to pull I2S_STEPPER_STREAM definition from pins_*.h based on configured board
+// Includes needed to get I2S_STEPPER_STREAM. Note that pins.h
+// is included in case this header is being included early.
 #include "../../inc/MarlinConfig.h"
-// need to also include pins.h explicitly here as the above statement will be ignored if HAL_timers_ESP32.h 
-// is being included from inside MarlinConfig.h / HAL.h (but before pins.h)
 #include "../../pins/pins.h"
 
 // --------------------------------------------------------------------------

--- a/Marlin/src/HAL/HAL_ESP32/WebSocketSerial.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/WebSocketSerial.cpp
@@ -38,9 +38,9 @@ AsyncWebSocket ws("/ws"); // TODO Move inside the class.
 
 RingBuffer::RingBuffer(ring_buffer_pos_t size)
   : data(new uint8_t[size]),
+    size(size),
     read_index(0),
-    write_index(0),
-    size(size)
+    write_index(0)
 {}
 
 RingBuffer::~RingBuffer() { delete[] data; }

--- a/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
@@ -51,15 +51,13 @@ bool PersistentStore::access_start() {
 
       eeprom_file = SPIFFS.open(HAL_ESP32_EEPROM_FILE_PATH, "a");
       for (size_t i = eeprom_file.size(); i < HAL_ESP32_EEPROM_SIZE; i++)
-      {
         eeprom_file.write(0xFF);
-      }
       eeprom_file.close();
 
       eeprom_file = SPIFFS.open(HAL_ESP32_EEPROM_FILE_PATH, "r+");
       file_size = eeprom_file.size();
       if (file_size < HAL_ESP32_EEPROM_SIZE) {
-        SERIAL_ERROR_MSG("Failed to expand " HAL_ESP32_EEPROM_FILE_PATH " to required size, maybe SPIFFS partition is full?");
+        SERIAL_ERROR_MSG("Failed to expand " HAL_ESP32_EEPROM_FILE_PATH " to required size. SPIFFS partition full?");
         SERIAL_ERROR_START(); SERIAL_ECHOLNPAIR(" file size: ", file_size, ", required size: ", HAL_ESP32_EEPROM_SIZE);
         SERIAL_ERROR_START(); SERIAL_ECHOLNPAIR(" SPIFFS used bytes: ", SPIFFS.usedBytes(), ", total bytes: ", SPIFFS.totalBytes());
       }

--- a/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
@@ -28,8 +28,8 @@
 
 #include "../shared/persistent_store_api.h"
 
-#include "SPIFFS.h"
-#include "FS.h"
+#include <SPIFFS.h>
+#include <FS.h>
 #include "spiffs.h"
 
 #define HAL_ESP32_EEPROM_SIZE 4096

--- a/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/persistent_store_spiffs.cpp
@@ -33,20 +33,35 @@
 #include "spiffs.h"
 
 #define HAL_ESP32_EEPROM_SIZE 4096
+#define HAL_ESP32_EEPROM_FILE_PATH "/eeprom.dat"
 
 File eeprom_file;
 
 bool PersistentStore::access_start() {
   if (spiffs_initialized) {
-    eeprom_file = SPIFFS.open("/eeprom.dat", "r+");
+    eeprom_file = SPIFFS.open(HAL_ESP32_EEPROM_FILE_PATH, "r+");
 
     size_t file_size = eeprom_file.size();
     if (file_size < HAL_ESP32_EEPROM_SIZE) {
-      bool write_ok = eeprom_file.seek(file_size);
+      SERIAL_ECHO_MSG("SPIFFS EEPROM settings file " HAL_ESP32_EEPROM_FILE_PATH " is too small or did not exist, expanding.");
+      SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR(" file size: ", file_size, ", required size: ", HAL_ESP32_EEPROM_SIZE);
 
-      while (write_ok && file_size < HAL_ESP32_EEPROM_SIZE) {
-        write_ok = eeprom_file.write(0xFF) == 1;
-        file_size++;
+      // mode r+ does not allow to expand the file (at least on ESP32 SPIFFS9, so we close, reopen "a", append, close, reopen "r+"
+      eeprom_file.close();
+
+      eeprom_file = SPIFFS.open(HAL_ESP32_EEPROM_FILE_PATH, "a");
+      for (size_t i = eeprom_file.size(); i < HAL_ESP32_EEPROM_SIZE; i++)
+      {
+        eeprom_file.write(0xFF);
+      }
+      eeprom_file.close();
+
+      eeprom_file = SPIFFS.open(HAL_ESP32_EEPROM_FILE_PATH, "r+");
+      file_size = eeprom_file.size();
+      if (file_size < HAL_ESP32_EEPROM_SIZE) {
+        SERIAL_ERROR_MSG("Failed to expand " HAL_ESP32_EEPROM_FILE_PATH " to required size, maybe SPIFFS partition is full?");
+        SERIAL_ERROR_START(); SERIAL_ECHOLNPAIR(" file size: ", file_size, ", required size: ", HAL_ESP32_EEPROM_SIZE);
+        SERIAL_ERROR_START(); SERIAL_ECHOLNPAIR(" SPIFFS used bytes: ", SPIFFS.usedBytes(), ", total bytes: ", SPIFFS.totalBytes());
       }
     }
     return true;

--- a/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
@@ -28,8 +28,8 @@
 
 #include "../../core/serial.h"
 
-#include "FS.h"
-#include "SPIFFS.h"
+#include <FS.h>
+#include <SPIFFS.h>
 
 bool spiffs_initialized;
 

--- a/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/spiffs.cpp
@@ -34,10 +34,10 @@
 bool spiffs_initialized;
 
 void spiffs_init() {
-  if (SPIFFS.begin())
+  if (SPIFFS.begin(true))  // formatOnFail = true
     spiffs_initialized = true;
   else
-    SERIAL_ECHO_MSG("SPIFFS mount failed");
+    SERIAL_ERROR_MSG("SPIFFS mount failed");
 }
 
 #endif // WEBSUPPORT

--- a/Marlin/src/HAL/HAL_ESP32/web.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/web.cpp
@@ -26,7 +26,7 @@
 
 #if ENABLED(WEBSUPPORT)
 
-#include "SPIFFS.h"
+#include <SPIFFS.h>
 #include "wifi.h"
 
 AsyncEventSource events("/events"); // event source (Server-Sent events)

--- a/Marlin/src/HAL/HAL_ESP32/wifi.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/wifi.cpp
@@ -22,6 +22,7 @@
 
 #ifdef ARDUINO_ARCH_ESP32
 
+#include "../../core/serial.h"
 #include "../../inc/MarlinConfigPre.h"
 
 #if ENABLED(WIFISUPPORT)
@@ -38,20 +39,28 @@ AsyncWebServer server(80);
 #endif
 
 void wifi_init() {
+
+  SERIAL_ECHO_MSG("Starting WiFi...");
+
   WiFi.mode(WIFI_STA);
   WiFi.begin(WIFI_SSID, WIFI_PWD);
 
   while (WiFi.waitForConnectResult() != WL_CONNECTED) {
+    SERIAL_ERROR_MSG("Unable to connect to WiFi with SSID '" WIFI_SSID "', restarting.");
     delay(5000);
     ESP.restart();
   }
 
   delay(10);
-
-  // Loop forever (watchdog kill) on failure
-  if (!MDNS.begin(WIFI_HOSTNAME)) for(;;) delay(5000);
+  if (!MDNS.begin(WIFI_HOSTNAME)) {
+    SERIAL_ERROR_MSG("Unable to start mDNS with hostname '" WIFI_HOSTNAME "', restarting.");
+    delay(5000);
+    ESP.restart();
+  }
 
   MDNS.addService("http", "tcp", 80);
+
+  SERIAL_ECHOLNPAIR("Successfully connected to WiFi with SSID '" WIFI_SSID "', hostname: '" WIFI_HOSTNAME "', IP address: ", WiFi.localIP().toString().c_str());
 }
 
 #endif // WIFISUPPORT

--- a/Marlin/src/pins/pins_ESP32.h
+++ b/Marlin/src/pins/pins_ESP32.h
@@ -40,6 +40,8 @@
 //
 // Steppers
 //
+#define I2S_STEPPER_STREAM
+
 #define X_STEP_PIN         128
 #define X_DIR_PIN          129
 #define X_ENABLE_PIN       130


### PR DESCRIPTION
### Description
Various fixes for the ESP32 platform

### Benefits
* fix `I2S_STEPPER_STREAM` to be definable in `pins_*.h` (where also the pin numbers on and above 128 are defined which point to "virtual" pins on the shift registers connected to I2S)
* enable only used ADC pins to not interfere with other pin functions
* fix ESP32 HAL_timer_start that somehow suffered from the commit changing NULL to nullptr
* move wifi_init() to BOARD_INIT (called after serial has been initialized) to be able to print status messages
* fix some warnings
* fix SPIFFS includes for compilation on case-insensitive OS
* fix SPIFFS EEPROM storage file creation and expansion

### Related Issues
n/a