### PR TITLE
Move menus for usability

### DIFF
--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -265,7 +265,6 @@ void menu_main() {
 
     if (card_detected) {
       if (!card_open) {
-        MENU_ITEM(submenu, MSG_CARD_MENU, menu_sdcard);
         MENU_ITEM(gcode,
           #if PIN_EXISTS(SD_DETECT)
             MSG_CHANGE_SDCARD, PSTR("M21")
@@ -273,6 +272,7 @@ void menu_main() {
             MSG_RELEASE_SDCARD, PSTR("M22")
           #endif
         );
+        MENU_ITEM(submenu, MSG_CARD_MENU, menu_sdcard);
       }
     }
     else {

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -414,17 +414,11 @@ void menu_temperature() {
     #endif
   #endif // FAN_COUNT > 0
 
+  #if ENABLED(SPINDLE_LASER_ENABLE)
+    MENU_ITEM(submenu, MSG_LASER_MENU, menu_spindle_laser);
+  #endif
+  
   #if HAS_TEMP_HOTEND
-
-    //
-    // Cooldown
-    //
-    bool has_heat = false;
-    HOTEND_LOOP() if (thermalManager.temp_hotend[HOTEND_INDEX].target) { has_heat = true; break; }
-    #if HAS_TEMP_BED
-      if (thermalManager.temp_bed.target) has_heat = true;
-    #endif
-    if (has_heat) MENU_ITEM(function, MSG_COOLDOWN, lcd_cooldown);
 
     //
     // Preheat for Material 1 and 2
@@ -437,11 +431,17 @@ void menu_temperature() {
       MENU_ITEM(function, MSG_PREHEAT_2, lcd_preheat_m2_e0_only);
     #endif
 
-  #endif // HAS_TEMP_HOTEND
+    //
+    // Cooldown
+    //
+    bool has_heat = false;
+    HOTEND_LOOP() if (thermalManager.temp_hotend[HOTEND_INDEX].target) { has_heat = true; break; }
+    #if HAS_TEMP_BED
+      if (thermalManager.temp_bed.target) has_heat = true;
+    #endif
+    if (has_heat) MENU_ITEM(function, MSG_COOLDOWN, lcd_cooldown);
 
-  #if ENABLED(SPINDLE_LASER_ENABLE)
-    MENU_ITEM(submenu, MSG_LASER_MENU, menu_spindle_laser);
-  #endif
+  #endif // HAS_TEMP_HOTEND
 
   END_MENU();
 }


### PR DESCRIPTION
Following discussion with @marcio-ao earlier, put SD menu below change SD so its at the bottom again. Also move cooldown to the bottom of the temperature menu for the same reasoning.