### PR TITLE
Fix TMC2208 (SW) boot loop

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -872,7 +872,11 @@ void setup() {
   #endif
 
   setup_killpin();
-
+  
+  #if HAS_DRIVER(TMC2208)
+    tmc2208_serial_begin();
+  #endif
+  
   setup_powerhold();
 
   #if HAS_STEPPER_RESET
@@ -903,9 +907,6 @@ void setup() {
       SPI.begin();
     #endif
     tmc_init_cs_pins();
-  #endif
-  #if HAS_DRIVER(TMC2208)
-    tmc2208_serial_begin();
   #endif
 
   #ifdef BOARD_INIT


### PR DESCRIPTION
Need stepper .begin() before calling susbequent .push()

### Requirements

TMC2208 driver with software UART enabled 

### Description

commenting out PS_DEFAULT_OFF in configuration.h will lead Marlin not to boot correctly. This is due to not calling beginSerial() before trying to push the stepper settings which would try to write to the unconfigured software serial 

### Benefits

Fixes boot loop

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/13998