### PR TITLE
Don't report TMC threshold when not configured

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -575,6 +575,7 @@
           SERIAL_ECHO(tpwmthrs_val);
         }
         break;
+      #if ENABLED(HYBRID_THRESHOLD)
       case TMC_TPWMTHRS_MMS: {
           uint32_t tpwmthrs_val = st.get_pwm_thrs();
           if (tpwmthrs_val)
@@ -583,6 +584,7 @@
             SERIAL_CHAR('-');
         }
         break;
+      #endif
       case TMC_OTPW: serialprint_truefalse(st.otpw()); break;
       #if ENABLED(MONITOR_DRIVER_STATUS)
         case TMC_OTPW_TRIGGERED: serialprint_truefalse(st.getOTPW()); break;


### PR DESCRIPTION
Fixing a compilation error I hit with TMC drivers when hybrid threshold is disabled. Apologies in advance if this PR is incorrectly formatted or I've missed a procedural step, this is my first time contributing.

For reference, my config which causes the compilation failure when targeting LPC1768 hardware is:
https://github.com/elandesign/Marlin/blob/config/Marlin/Configuration.h
https://github.com/elandesign/Marlin/blob/config/Marlin/Configuration_adv.h

### Requirements

To reproduce the bug, set up for TMC2130 stepper drivers, disable `HYBRID_THRESHOLD` and enable `TMC_DEBUG`. Compilation fails with the following error

```
Marlin/src/feature/tmc_util.cpp: In instantiation of 'void tmc_status(TMC&, TMC_debug_enum) [with TMC = TMCMarlin<TMC2130Stepper, 'Z', '0', (AxisEnum)2>]':
Marlin/src/feature/tmc_util.cpp:673:31:   required from here
Marlin/src/feature/tmc_util.cpp:579:38: error: 'class TMCMarlin<TMC2130Stepper, 'Z', '0', (AxisEnum)2>' has no member named 'get_pwm_thrs'; did you mean 'en_pwm_mode'?
uint32_t tpwmthrs_val = st.get_pwm_thrs();
~~~^~~~~~~~~~~~
en_pwm_mode
```

### Description

If the hybrid threshold is not enabled, `get_pwm_thrs` is not defined, and the TMC debug line causes compilation failure.

This is a pretty naive solution, disabling that debug line to allow compilation to complete. There may be a better one for someone with more knowledge of the codebase of course...

### Benefits

Allows compilation to complete