### PR TITLE
ExtUI parity with SPI LCDs

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -812,6 +812,7 @@ namespace ExtUI {
 
   void printFile(const char *filename) {
     IFSD(card.openAndPrintFile(filename), NOOP);
+    print_job_timer.start();
   }
 
   bool isPrintingFromMediaPaused() {
@@ -831,27 +832,39 @@ namespace ExtUI {
   }
 
   void pausePrint() {
-    #if ENABLED(SDSUPPORT)
-      card.pauseSDPrint();
-      print_job_timer.pause();
-      #if ENABLED(PARK_HEAD_ON_PAUSE)
-        enqueue_and_echo_commands_P(PSTR("M125"));
-      #endif
+    ui.synchronize(PSTR(MSG_PAUSE_PRINT));
+
+    #if ENABLED(POWER_LOSS_RECOVERY)
+      if (recovery.enabled) recovery.save(true, false);
+    #endif
+
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("UI Pause"), PSTR("Resume"));
+    #endif
+
+    #if ENABLED(PARK_HEAD_ON_PAUSE)
       ui.set_status_P(PSTR(MSG_PRINT_PAUSED));
+      enqueue_and_echo_commands_P(PSTR("M25 P\nM24"));
+    #elif ENABLED(SDSUPPORT)
+      enqueue_and_echo_commands_P(PSTR("M25"));
+    #elif defined(ACTION_ON_PAUSE)
+      host_action_pause();
     #endif
   }
 
   void resumePrint() {
-    #if ENABLED(SDSUPPORT)
-      ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
-      #if ENABLED(PARK_HEAD_ON_PAUSE)
+    ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
+     #if ENABLED(PARK_HEAD_ON_PAUSE)
         wait_for_heatup = wait_for_user = false;
-        enqueue_and_echo_commands_P(PSTR("M24"));
-      #else
-        card.startFileprint();
-        print_job_timer.start();
-      #endif
     #endif
+    #if ENABLED(SDSUPPORT)
+      if (card.isPaused()) enqueue_and_echo_commands_P(PSTR("M24"));
+    #endif
+    #ifdef ACTION_ON_RESUME
+      host_action_resume();
+    #endif
+    
+    print_job_timer.start();
   }
 
   void stopPrint() {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -832,55 +832,15 @@ namespace ExtUI {
   }
 
   void pausePrint() {
-    ui.synchronize(PSTR(MSG_PAUSE_PRINT));
-
-    #if ENABLED(POWER_LOSS_RECOVERY)
-      if (recovery.enabled) recovery.save(true, false);
-    #endif
-
-    #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("UI Pause"), PSTR("Resume"));
-    #endif
-
-    #if ENABLED(PARK_HEAD_ON_PAUSE)
-      ui.set_status_P(PSTR(MSG_PRINT_PAUSED));
-      enqueue_and_echo_commands_P(PSTR("M25 P\nM24"));
-    #elif ENABLED(SDSUPPORT)
-      enqueue_and_echo_commands_P(PSTR("M25"));
-    #elif defined(ACTION_ON_PAUSE)
-      host_action_pause();
-    #endif
+    ui.pause_print();
   }
 
   void resumePrint() {
-    ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
-     #if ENABLED(PARK_HEAD_ON_PAUSE)
-        wait_for_heatup = wait_for_user = false;
-    #endif
-    #if ENABLED(SDSUPPORT)
-      if (card.isPaused()) enqueue_and_echo_commands_P(PSTR("M24"));
-    #endif
-    #ifdef ACTION_ON_RESUME
-      host_action_resume();
-    #endif
-    
-    print_job_timer.start();
+    ui.resume_print();
   }
 
   void stopPrint() {
-    #if ENABLED(SDSUPPORT)
-      wait_for_heatup = wait_for_user = false;
-      card.flag.abort_sd_printing = true;
-    #endif
-    #ifdef ACTION_ON_CANCEL
-      host_action_cancel();
-    #endif
-    #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_open(PROMPT_INFO, PSTR("UI Abort"));
-    #endif
-    print_job_timer.stop()
-    ui.set_status_P(PSTR(MSG_PRINT_ABORTED));
-    ui.return_to_status();
+    ui.stop_print();
   }
 
   FileList::FileList() { refresh(); }

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -858,8 +858,16 @@ namespace ExtUI {
     #if ENABLED(SDSUPPORT)
       wait_for_heatup = wait_for_user = false;
       card.flag.abort_sd_printing = true;
-      ui.set_status_P(PSTR(MSG_PRINT_ABORTED));
     #endif
+    #ifdef ACTION_ON_CANCEL
+      host_action_cancel();
+    #endif
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_prompt_open(PROMPT_INFO, PSTR("UI Abort"));
+    #endif
+    print_job_timer.stop()
+    ui.set_status_P(PSTR(MSG_PRINT_ABORTED));
+    ui.return_to_status();
   }
 
   FileList::FileList() { refresh(); }

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -812,7 +812,6 @@ namespace ExtUI {
 
   void printFile(const char *filename) {
     IFSD(card.openAndPrintFile(filename), NOOP);
-    print_job_timer.start();
   }
 
   bool isPrintingFromMediaPaused() {

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -50,61 +50,10 @@
 #define MACHINE_CAN_STOP (EITHER(SDSUPPORT, HOST_PROMPT_SUPPORT) || defined(ACTION_ON_CANCEL))
 #define MACHINE_CAN_PAUSE (ANY(SDSUPPORT, HOST_PROMPT_SUPPORT, PARK_HEAD_ON_PAUSE) || defined(ACTION_ON_PAUSE))
 
-#if MACHINE_CAN_PAUSE
-
-  void lcd_pause_job() {
-    ui.synchronize(PSTR(MSG_PAUSE_PRINT));
-
-    #if ENABLED(POWER_LOSS_RECOVERY)
-      if (recovery.enabled) recovery.save(true, false);
-    #endif
-
-    #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("UI Pause"), PSTR("Resume"));
-    #endif
-
-    #if ENABLED(PARK_HEAD_ON_PAUSE)
-      lcd_pause_show_message(PAUSE_MESSAGE_PAUSING, PAUSE_MODE_PAUSE_PRINT);  // Show message immediately to let user know about pause in progress
-      enqueue_and_echo_commands_P(PSTR("M25 P\nM24"));
-    #elif ENABLED(SDSUPPORT)
-      enqueue_and_echo_commands_P(PSTR("M25"));
-    #elif defined(ACTION_ON_PAUSE)
-      host_action_pause();
-    #endif
-  }
-
-  void lcd_resume() {
-    #if ENABLED(SDSUPPORT)
-      if (card.isPaused()) enqueue_and_echo_commands_P(PSTR("M24"));
-    #endif
-    #ifdef ACTION_ON_RESUME
-      host_action_resume();
-    #endif
-  }
-
-#endif // MACHINE_CAN_PAUSE
-
 #if MACHINE_CAN_STOP
-
-  void lcd_abort_job() {
-    #if ENABLED(SDSUPPORT)
-      wait_for_heatup = wait_for_user = false;
-      card.flag.abort_sd_printing = true;
-    #endif
-    #ifdef ACTION_ON_CANCEL
-      host_action_cancel();
-    #endif
-    #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_open(PROMPT_INFO, PSTR("UI Abort"));
-    #endif
-    ui.set_status_P(PSTR(MSG_PRINT_ABORTED), -1);
-    ui.return_to_status();
-  }
-
   void menu_abort_confirm() {
-    do_select_screen(PSTR(MSG_BUTTON_STOP), PSTR(MSG_BACK), lcd_abort_job, ui.goto_previous_screen, PSTR(MSG_STOP_PRINT), nullptr, PSTR("?"));
+    do_select_screen(PSTR(MSG_BUTTON_STOP), PSTR(MSG_BACK), ui.abort_print, ui.goto_previous_screen, PSTR(MSG_STOP_PRINT), nullptr, PSTR("?"));
   }
-
 #endif // MACHINE_CAN_STOP
 
 #if ENABLED(PRUSA_MMU2)
@@ -160,7 +109,7 @@ void menu_main() {
 
   if (busy) {
     #if MACHINE_CAN_PAUSE
-      MENU_ITEM(function, MSG_PAUSE_PRINT, lcd_pause_job);
+      MENU_ITEM(function, MSG_PAUSE_PRINT, ui.pause_print);
     #endif
     #if MACHINE_CAN_STOP
       MENU_ITEM(submenu, MSG_STOP_PRINT, menu_abort_confirm);
@@ -204,7 +153,7 @@ void menu_main() {
           || card.isPaused()
         #endif
       );
-      if (paused) MENU_ITEM(function, MSG_RESUME_PRINT, lcd_resume);
+      if (paused) MENU_ITEM(function, MSG_RESUME_PRINT, ui.resume_print);
     #endif
 
     MENU_ITEM(submenu, MSG_MOTION, menu_motion);

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -39,10 +39,6 @@
   #include "../../feature/power_loss_recovery.h"
 #endif
 
-#if ENABLED(HOST_ACTION_COMMANDS)
-  #include "../../feature/host_actions.h"
-#endif
-
 #if HAS_GAMES
   #include "game/game.h"
 #endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1369,7 +1369,7 @@ void MarlinUI::update() {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_prompt_open(PROMPT_INFO, PSTR("UI Abort"));
     #endif
-    print_job_timer.stop()
+    print_job_timer.stop();
     ui.set_status_P(PSTR(MSG_PRINT_ABORTED));
     #if HAS_SPI_LCD
       ui.return_to_status();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1358,7 +1358,7 @@ void MarlinUI::update() {
     set_status_P(msg, -1);
   }
 
-  static void abort_print() {
+  void abort_print() {
     #if ENABLED(SDSUPPORT)
       wait_for_heatup = wait_for_user = false;
       card.flag.abort_sd_printing = true;
@@ -1376,7 +1376,7 @@ void MarlinUI::update() {
     #endif
   }
 
-  static void pause_print() {
+  void pause_print() {
     ui.synchronize(PSTR(MSG_PAUSE_PRINT));
 
     #if ENABLED(POWER_LOSS_RECOVERY)
@@ -1401,7 +1401,7 @@ void MarlinUI::update() {
     #endif
   }
 
-  static void resume_print() {
+  void resume_print() {
     ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
      #if ENABLED(PARK_HEAD_ON_PAUSE)
         wait_for_heatup = wait_for_user = false;

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -32,7 +32,7 @@
     #define START_OF_UTF8_CHAR(C) (((C) & 0xC0u) != 0x80u)
   #endif
   #if ENABLED(HOST_ACTION_COMMANDS)
-    #include "../../feature/host_actions.h"
+    #include "../feature/host_actions.h"
   #endif
 #endif
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -31,6 +31,9 @@
   #if ENABLED(EXTENSIBLE_UI)
     #define START_OF_UTF8_CHAR(C) (((C) & 0xC0u) != 0x80u)
   #endif
+  #if ENABLED(HOST_ACTION_COMMANDS)
+    #include "../../feature/host_actions.h"
+  #endif
 #endif
 
 #if HAS_SPI_LCD
@@ -1356,6 +1359,64 @@ void MarlinUI::update() {
       msg = welcome;
 
     set_status_P(msg, -1);
+  }
+
+  void MarlinUI::abort_print() {
+    #if ENABLED(SDSUPPORT)
+      wait_for_heatup = wait_for_user = false;
+      card.flag.abort_sd_printing = true;
+    #endif
+    #ifdef ACTION_ON_CANCEL
+      host_action_cancel();
+    #endif
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_prompt_open(PROMPT_INFO, PSTR("UI Abort"));
+    #endif
+    print_job_timer.stop();
+    ui.set_status_P(PSTR(MSG_PRINT_ABORTED));
+    #if HAS_SPI_LCD
+      ui.return_to_status();
+    #endif
+  }
+
+  void MarlinUI::pause_print() {
+    ui.synchronize(PSTR(MSG_PAUSE_PRINT));
+
+    #if ENABLED(POWER_LOSS_RECOVERY)
+      if (recovery.enabled) recovery.save(true, false);
+    #endif
+
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("UI Pause"), PSTR("Resume"));
+    #endif
+
+    ui.set_status_P(PSTR(MSG_PRINT_PAUSED));
+
+    #if ENABLED(PARK_HEAD_ON_PAUSE)
+      #if HAS_SPI_LCD
+        lcd_pause_show_message(PAUSE_MESSAGE_PAUSING, PAUSE_MODE_PAUSE_PRINT);  // Show message immediately to let user know about pause in progress
+      #endif
+      enqueue_and_echo_commands_P(PSTR("M25 P\nM24"));
+    #elif ENABLED(SDSUPPORT)
+      enqueue_and_echo_commands_P(PSTR("M25"));
+    #elif defined(ACTION_ON_PAUSE)
+      host_action_pause();
+    #endif
+  }
+
+  void MarlinUI::resume_print() {
+    ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
+     #if ENABLED(PARK_HEAD_ON_PAUSE)
+        wait_for_heatup = wait_for_user = false;
+    #endif
+    #if ENABLED(SDSUPPORT)
+      if (card.isPaused()) enqueue_and_echo_commands_P(PSTR("M24"));
+    #endif
+    #ifdef ACTION_ON_RESUME
+      host_action_resume();
+    #endif
+    
+    print_job_timer.start();
   }
 
   #if HAS_PRINT_PROGRESS

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1358,7 +1358,7 @@ void MarlinUI::update() {
     set_status_P(msg, -1);
   }
 
-  void abort_print() {
+  void MarlinUI::abort_print() {
     #if ENABLED(SDSUPPORT)
       wait_for_heatup = wait_for_user = false;
       card.flag.abort_sd_printing = true;
@@ -1376,7 +1376,7 @@ void MarlinUI::update() {
     #endif
   }
 
-  void pause_print() {
+  void MarlinUI::pause_print() {
     ui.synchronize(PSTR(MSG_PAUSE_PRINT));
 
     #if ENABLED(POWER_LOSS_RECOVERY)
@@ -1401,7 +1401,7 @@ void MarlinUI::update() {
     #endif
   }
 
-  void resume_print() {
+  void MarlinUI::resume_print() {
     ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
      #if ENABLED(PARK_HEAD_ON_PAUSE)
         wait_for_heatup = wait_for_user = false;

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1405,9 +1405,9 @@ void MarlinUI::update() {
   }
 
   void MarlinUI::resume_print() {
-    ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
-     #if ENABLED(PARK_HEAD_ON_PAUSE)
-        wait_for_heatup = wait_for_user = false;
+    ui.reset_status();
+    #if ENABLED(PARK_HEAD_ON_PAUSE)
+      wait_for_heatup = wait_for_user = false;
     #endif
     #if ENABLED(SDSUPPORT)
       if (card.isPaused()) enqueue_and_echo_commands_P(PSTR("M24"));
@@ -1415,8 +1415,7 @@ void MarlinUI::update() {
     #ifdef ACTION_ON_RESUME
       host_action_resume();
     #endif
-    
-    print_job_timer.start();
+    print_job_timer.start(); // Also called by M24
   }
 
   #if HAS_PRINT_PROGRESS

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1358,6 +1358,64 @@ void MarlinUI::update() {
     set_status_P(msg, -1);
   }
 
+  static void abort_print() {
+    #if ENABLED(SDSUPPORT)
+      wait_for_heatup = wait_for_user = false;
+      card.flag.abort_sd_printing = true;
+    #endif
+    #ifdef ACTION_ON_CANCEL
+      host_action_cancel();
+    #endif
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_prompt_open(PROMPT_INFO, PSTR("UI Abort"));
+    #endif
+    print_job_timer.stop()
+    ui.set_status_P(PSTR(MSG_PRINT_ABORTED));
+    #if HAS_SPI_LCD
+      ui.return_to_status();
+    #endif
+  }
+
+  static void pause_print() {
+    ui.synchronize(PSTR(MSG_PAUSE_PRINT));
+
+    #if ENABLED(POWER_LOSS_RECOVERY)
+      if (recovery.enabled) recovery.save(true, false);
+    #endif
+
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("UI Pause"), PSTR("Resume"));
+    #endif
+
+    ui.set_status_P(PSTR(MSG_PRINT_PAUSED));
+
+    #if ENABLED(PARK_HEAD_ON_PAUSE)
+      #if ENABLED(HAS_SPI_LCD)
+        lcd_pause_show_message(PAUSE_MESSAGE_PAUSING, PAUSE_MODE_PAUSE_PRINT);  // Show message immediately to let user know about pause in progress
+      #endif
+      enqueue_and_echo_commands_P(PSTR("M25 P\nM24"));
+    #elif ENABLED(SDSUPPORT)
+      enqueue_and_echo_commands_P(PSTR("M25"));
+    #elif defined(ACTION_ON_PAUSE)
+      host_action_pause();
+    #endif
+  }
+
+  static void resume_print() {
+    ui.set_status_P(PSTR(MSG_FILAMENT_CHANGE_RESUME_1));
+     #if ENABLED(PARK_HEAD_ON_PAUSE)
+        wait_for_heatup = wait_for_user = false;
+    #endif
+    #if ENABLED(SDSUPPORT)
+      if (card.isPaused()) enqueue_and_echo_commands_P(PSTR("M24"));
+    #endif
+    #ifdef ACTION_ON_RESUME
+      host_action_resume();
+    #endif
+    
+    print_job_timer.start();
+  }
+
   #if HAS_PRINT_PROGRESS
     uint8_t MarlinUI::get_progress() {
       #if ENABLED(LCD_SET_PROGRESS_MANUALLY)

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1390,7 +1390,7 @@ void MarlinUI::update() {
     ui.set_status_P(PSTR(MSG_PRINT_PAUSED));
 
     #if ENABLED(PARK_HEAD_ON_PAUSE)
-      #if ENABLED(HAS_SPI_LCD)
+      #if HAS_SPI_LCD
         lcd_pause_show_message(PAUSE_MESSAGE_PAUSING, PAUSE_MODE_PAUSE_PRINT);  // Show message immediately to let user know about pause in progress
       #endif
       enqueue_and_echo_commands_P(PSTR("M25 P\nM24"));

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -31,6 +31,9 @@
   #if ENABLED(EXTENSIBLE_UI)
     #define START_OF_UTF8_CHAR(C) (((C) & 0xC0u) != 0x80u)
   #endif
+  #if ENABLED(HOST_ACTION_COMMANDS)
+    #include "../../feature/host_actions.h"
+  #endif
 #endif
 
 #if HAS_SPI_LCD

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1373,14 +1373,14 @@ void MarlinUI::update() {
       host_prompt_open(PROMPT_INFO, PSTR("UI Abort"));
     #endif
     print_job_timer.stop();
-    ui.set_status_P(PSTR(MSG_PRINT_ABORTED));
+    set_status_P(PSTR(MSG_PRINT_ABORTED));
     #if HAS_SPI_LCD
-      ui.return_to_status();
+      return_to_status();
     #endif
   }
 
   void MarlinUI::pause_print() {
-    ui.synchronize(PSTR(MSG_PAUSE_PRINT));
+    synchronize(PSTR(MSG_PAUSE_PRINT));
 
     #if ENABLED(POWER_LOSS_RECOVERY)
       if (recovery.enabled) recovery.save(true, false);
@@ -1390,7 +1390,7 @@ void MarlinUI::update() {
       host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("UI Pause"), PSTR("Resume"));
     #endif
 
-    ui.set_status_P(PSTR(MSG_PRINT_PAUSED));
+    set_status_P(PSTR(MSG_PRINT_PAUSED));
 
     #if ENABLED(PARK_HEAD_ON_PAUSE)
       #if HAS_SPI_LCD
@@ -1405,7 +1405,7 @@ void MarlinUI::update() {
   }
 
   void MarlinUI::resume_print() {
-    ui.reset_status();
+    reset_status();
     #if ENABLED(PARK_HEAD_ON_PAUSE)
       wait_for_heatup = wait_for_user = false;
     #endif

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -286,6 +286,10 @@ public:
       static char* status_and_len(uint8_t &len);
     #endif
 
+    static void abort_print();
+    static void pause_print();
+    static void resume_print();
+    
     #if HAS_PRINT_PROGRESS
       #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
         static uint8_t progress_bar_percent;


### PR DESCRIPTION
Get pause, resume, and abort to function identically to graphical LCD with host printing and parking modes.