### PR TITLE
Fix for Arduino Due + 12864 Full Graphic Display

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
+++ b/Marlin/src/HAL/HAL_DUE/u8g_com_HAL_DUE_sw_spi_shared.cpp
@@ -87,7 +87,7 @@ void u8g_spiSend_sw_DUE_mode_0(uint8_t val) { // 3MHz
       MOSI_pPio->PIO_CODR = MOSI_dwMask;
     DELAY_NS(48);
     SCK_pPio->PIO_SODR = SCK_dwMask;
-    DELAY_NS(125);
+    DELAY_NS(905);
     val <<= 1;
     SCK_pPio->PIO_CODR = SCK_dwMask;
   }


### PR DESCRIPTION
### Description

Pull request for fixing this problem:
https://github.com/MarlinFirmware/Marlin/issues/14067

### Benefits

12864 Full Graphic Display function is correct again when used with an Arduino Due.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/14067
