### PR TITLE
TMC Square Wave Stepping mode

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -234,6 +234,9 @@
     chopconf.intpol = INTERPOLATE;
     chopconf.hend = chopper_timing.hend + 3;
     chopconf.hstrt = chopper_timing.hstrt - 1;
+    #if ENABLED(SQUARE_WAVE_STEPPING)
+      chopconf.dedge = true;
+    #endif
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA, HOLD_MULTIPLIER);
@@ -274,6 +277,9 @@
     chopconf.intpol = INTERPOLATE;
     chopconf.hend = timings[1] + 3;
     chopconf.hstrt = timings[2] - 1;
+    #if ENABLED(SQUARE_WAVE_STEPPING)
+      chopconf.dedge = true;
+    #endif
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA, HOLD_MULTIPLIER);
@@ -515,6 +521,9 @@
     chopconf.intpol = INTERPOLATE;
     chopconf.hend = chopper_timing.hend + 3;
     chopconf.hstrt = chopper_timing.hstrt - 1;
+    #if ENABLED(SQUARE_WAVE_STEPPING)
+      chopconf.dedge = true;
+    #endif
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA, HOLD_MULTIPLIER);
@@ -553,6 +562,9 @@
     chopconf.toff = chopper_timing.toff;
     chopconf.hend = chopper_timing.hend + 3;
     chopconf.hstrt = chopper_timing.hstrt - 1;
+    #if ENABLED(SQUARE_WAVE_STEPPING)
+      chopconf.dedge = true;
+    #endif
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA);
@@ -577,6 +589,9 @@
     chopconf.intpol = INTERPOLATE;
     chopconf.hend = chopper_timing.hend + 3;
     chopconf.hstrt = chopper_timing.hstrt - 1;
+    #if ENABLED(SQUARE_WAVE_STEPPING)
+      chopconf.dedge = true;
+    #endif
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA, HOLD_MULTIPLIER);
@@ -617,6 +632,9 @@
     chopconf.intpol = INTERPOLATE;
     chopconf.hend = timings[1] + 3;
     chopconf.hstrt = timings[2] - 1;
+    #if ENABLED(SQUARE_WAVE_STEPPING)
+      chopconf.dedge = true;
+    #endif
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA, HOLD_MULTIPLIER);

--- a/Marlin/src/module/stepper_indirection.h
+++ b/Marlin/src/module/stepper_indirection.h
@@ -127,7 +127,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define X_DIR_READ READ(X_DIR_PIN)
 #endif
 #define X_STEP_INIT SET_OUTPUT(X_STEP_PIN)
-#define X_STEP_WRITE(STATE) WRITE(X_STEP_PIN,STATE)
+#if AXIS_IS_TMC(X) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define X_STEP_WRITE(STATE) do { if(STATE) TOGGLE(X_STEP_PIN); } while(0)
+#else
+  #define X_STEP_WRITE(STATE) WRITE(X_STEP_PIN,STATE)
+#endif
 #define X_STEP_READ READ(X_STEP_PIN)
 
 // Y Stepper
@@ -162,7 +166,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define Y_DIR_READ READ(Y_DIR_PIN)
 #endif
 #define Y_STEP_INIT SET_OUTPUT(Y_STEP_PIN)
-#define Y_STEP_WRITE(STATE) WRITE(Y_STEP_PIN,STATE)
+#if AXIS_IS_TMC(Y) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define Y_STEP_WRITE(STATE) do { if (STATE) TOGGLE(Y_STEP_PIN); } while(0)
+#else
+  #define Y_STEP_WRITE(STATE) WRITE(Y_STEP_PIN,STATE)
+#endif
 #define Y_STEP_READ READ(Y_STEP_PIN)
 
 // Z Stepper
@@ -197,7 +205,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define Z_DIR_READ READ(Z_DIR_PIN)
 #endif
 #define Z_STEP_INIT SET_OUTPUT(Z_STEP_PIN)
-#define Z_STEP_WRITE(STATE) WRITE(Z_STEP_PIN,STATE)
+#if AXIS_IS_TMC(Z) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define Z_STEP_WRITE(STATE) do { if(STATE) TOGGLE(Z_STEP_PIN); } while(0)
+#else
+  #define Z_STEP_WRITE(STATE) WRITE(Z_STEP_PIN,STATE)
+#endif
 #define Z_STEP_READ READ(Z_STEP_PIN)
 
 // X2 Stepper
@@ -233,7 +245,12 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     #define X2_DIR_READ READ(X2_DIR_PIN)
   #endif
   #define X2_STEP_INIT SET_OUTPUT(X2_STEP_PIN)
-  #define X2_STEP_WRITE(STATE) WRITE(X2_STEP_PIN,STATE)
+  #if AXIS_IS_TMC(X2) && ENABLED(SQUARE_WAVE_STEPPING)
+    #define X2_STEP_WRITE(STATE) do { if(STATE) TOGGLE(X2_STEP_PIN); } while(0)
+  #else
+    #define X2_STEP_WRITE(STATE) WRITE(X2_STEP_PIN,STATE)
+  #endif
+
   #define X2_STEP_READ READ(X2_STEP_PIN)
 #endif
 
@@ -270,7 +287,12 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     #define Y2_DIR_READ READ(Y2_DIR_PIN)
   #endif
   #define Y2_STEP_INIT SET_OUTPUT(Y2_STEP_PIN)
-  #define Y2_STEP_WRITE(STATE) WRITE(Y2_STEP_PIN,STATE)
+  #if AXIS_IS_TMC(Y2) && ENABLED(SQUARE_WAVE_STEPPING)
+    #define Y2_STEP_WRITE(STATE) do { if(STATE) TOGGLE(Y2_STEP_PIN); } while(0)
+  #else
+    #define Y2_STEP_WRITE(STATE) WRITE(Y2_STEP_PIN,STATE)
+  #endif
+
   #define Y2_STEP_READ READ(Y2_STEP_PIN)
 #else
   #define Y2_DIR_WRITE(STATE) NOOP
@@ -309,7 +331,12 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     #define Z2_DIR_READ READ(Z2_DIR_PIN)
   #endif
   #define Z2_STEP_INIT SET_OUTPUT(Z2_STEP_PIN)
-  #define Z2_STEP_WRITE(STATE) WRITE(Z2_STEP_PIN,STATE)
+  #if AXIS_IS_TMC(Z2) && ENABLED(SQUARE_WAVE_STEPPING)
+    #define Z2_STEP_WRITE(STATE) do { if(STATE) TOGGLE(Z2_STEP_PIN); } while(0)
+  #else
+    #define Z2_STEP_WRITE(STATE) WRITE(Z2_STEP_PIN,STATE)
+  #endif
+
   #define Z2_STEP_READ READ(Z2_STEP_PIN)
 #else
   #define Z2_DIR_WRITE(STATE) NOOP
@@ -348,7 +375,12 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     #define Z3_DIR_READ READ(Z3_DIR_PIN)
   #endif
   #define Z3_STEP_INIT SET_OUTPUT(Z3_STEP_PIN)
-  #define Z3_STEP_WRITE(STATE) WRITE(Z3_STEP_PIN,STATE)
+  #if AXIS_IS_TMC(Z3) && ENABLED(SQUARE_WAVE_STEPPING)
+    #define Z3_STEP_WRITE(STATE) do { if(STATE) TOGGLE(Z3_STEP_PIN); } while(0)
+  #else
+    #define Z3_STEP_WRITE(STATE) WRITE(Z3_STEP_PIN,STATE)
+  #endif
+
   #define Z3_STEP_READ READ(Z3_STEP_PIN)
 #else
   #define Z3_DIR_WRITE(STATE) NOOP
@@ -386,7 +418,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define E0_DIR_READ READ(E0_DIR_PIN)
 #endif
 #define E0_STEP_INIT SET_OUTPUT(E0_STEP_PIN)
-#define E0_STEP_WRITE(STATE) WRITE(E0_STEP_PIN,STATE)
+#if AXIS_IS_TMC(E0) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define E0_STEP_WRITE(STATE) do { if(STATE) TOGGLE(E0_STEP_PIN); } while(0)
+#else
+  #define E0_STEP_WRITE(STATE) WRITE(E0_STEP_PIN,STATE)
+#endif
 #define E0_STEP_READ READ(E0_STEP_PIN)
 
 // E1 Stepper
@@ -421,7 +457,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define E1_DIR_READ READ(E1_DIR_PIN)
 #endif
 #define E1_STEP_INIT SET_OUTPUT(E1_STEP_PIN)
-#define E1_STEP_WRITE(STATE) WRITE(E1_STEP_PIN,STATE)
+#if AXIS_IS_TMC(E1) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define E1_STEP_WRITE(STATE) do { if(STATE) TOGGLE(E1_STEP_PIN); } while(0)
+#else
+  #define E1_STEP_WRITE(STATE) WRITE(E1_STEP_PIN,STATE)
+#endif
 #define E1_STEP_READ READ(E1_STEP_PIN)
 
 // E2 Stepper
@@ -456,7 +496,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define E2_DIR_READ READ(E2_DIR_PIN)
 #endif
 #define E2_STEP_INIT SET_OUTPUT(E2_STEP_PIN)
-#define E2_STEP_WRITE(STATE) WRITE(E2_STEP_PIN,STATE)
+#if AXIS_IS_TMC(E2) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define E2_STEP_WRITE(STATE) do { if(STATE) TOGGLE(E2_STEP_PIN); } while(0)
+#else
+  #define E2_STEP_WRITE(STATE) WRITE(E2_STEP_PIN,STATE)
+#endif
 #define E2_STEP_READ READ(E2_STEP_PIN)
 
 // E3 Stepper
@@ -491,7 +535,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define E3_DIR_READ READ(E3_DIR_PIN)
 #endif
 #define E3_STEP_INIT SET_OUTPUT(E3_STEP_PIN)
-#define E3_STEP_WRITE(STATE) WRITE(E3_STEP_PIN,STATE)
+#if AXIS_IS_TMC(E3) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define E3_STEP_WRITE(STATE) do { if(STATE) TOGGLE(E3_STEP_PIN); } while(0)
+#else
+  #define E3_STEP_WRITE(STATE) WRITE(E3_STEP_PIN,STATE)
+#endif
 #define E3_STEP_READ READ(E3_STEP_PIN)
 
 // E4 Stepper
@@ -526,7 +574,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define E4_DIR_READ READ(E4_DIR_PIN)
 #endif
 #define E4_STEP_INIT SET_OUTPUT(E4_STEP_PIN)
-#define E4_STEP_WRITE(STATE) WRITE(E4_STEP_PIN,STATE)
+#if AXIS_IS_TMC(E4) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define E4_STEP_WRITE(STATE) do { if(STATE) TOGGLE(E4_STEP_PIN); } while(0)
+#else
+  #define E4_STEP_WRITE(STATE) WRITE(E4_STEP_PIN,STATE)
+#endif
 #define E4_STEP_READ READ(E4_STEP_PIN)
 
 // E5 Stepper
@@ -561,7 +613,11 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #define E5_DIR_READ READ(E5_DIR_PIN)
 #endif
 #define E5_STEP_INIT SET_OUTPUT(E5_STEP_PIN)
-#define E5_STEP_WRITE(STATE) WRITE(E5_STEP_PIN,STATE)
+#if AXIS_IS_TMC(E5) && ENABLED(SQUARE_WAVE_STEPPING)
+  #define E5_STEP_WRITE(STATE) do { if(STATE) TOGGLE(E5_STEP_PIN); } while(0)
+#else
+  #define E5_STEP_WRITE(STATE) WRITE(E5_STEP_PIN,STATE)
+#endif
 #define E5_STEP_READ READ(E5_STEP_PIN)
 
 /**

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -1764,6 +1764,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -1766,6 +1766,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1770,6 +1770,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Felix/Configuration_adv.h
+++ b/config/examples/Felix/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -1764,6 +1764,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -1766,6 +1766,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -1766,6 +1766,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1763,6 +1763,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -1760,6 +1760,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1775,6 +1775,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1764,6 +1764,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1760,6 +1760,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1761,6 +1761,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1762,6 +1762,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -1763,6 +1763,12 @@
   #endif
 
   /**
+   * Beta feature!
+   * Create a 50/50 square wave step pulse optimal for stepper drivers.
+   */
+  //#define SQUARE_WAVE_STEPPING
+
+  /**
    * Enable M122 debugging command for TMC stepper drivers.
    * M122 S0/1 will enable continous reporting.
    */


### PR DESCRIPTION
Stepper drivers can benefit from a step signal which is closer to 50/50 square wave.
In normal conditions this ensures adequate high/low times.

The changes to Marlin are very basic. In short, from the current ISR code we filter out the STOP calls and on START calls instead of `write high` we use `toggle`. This means the step signal "frequency" is halved but we still drive the correct number of steps because a step is executed on both edges of the signal.

The increased timing is especially helpful when using Linear Advance.

If the feature does not cause issues I'd expect it be turned on by default after a test period.