### PR TITLE
Improve MKS MINI 12864 stability (LPC176x)

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -943,10 +943,15 @@ void setup() {
   // (because EEPROM code calls the UI).
   ui.init();
   ui.reset_status();
-
-  #if HAS_SPI_LCD && ENABLED(SHOW_BOOTSCREEN)
-    ui.show_bootscreen();
+  //In order to recover brokem custom _Bootscreen
+  //if the installes lcd is a MKS_MINI_12864
+  //The Boot Logos show process has being moved to the ui.init();
+  #if !ENABLED(MKS_MINI_12864)
+    #if HAS_SPI_LCD && ENABLED(SHOW_BOOTSCREEN)
+      ui.show_bootscreen();
+    #endif
   #endif
+
 
   #if ENABLED(SDIO_SUPPORT) && SD_DETECT_PIN == -1
     // Auto-mount the SD for EEPROM.dat emulation

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -943,15 +943,11 @@ void setup() {
   // (because EEPROM code calls the UI).
   ui.init();
   ui.reset_status();
-  //In order to recover brokem custom _Bootscreen
-  //if the installes lcd is a MKS_MINI_12864
-  //The Boot Logos show process has being moved to the ui.init();
-  #if !ENABLED(MKS_MINI_12864)
-    #if HAS_SPI_LCD && ENABLED(SHOW_BOOTSCREEN)
-      ui.show_bootscreen();
-    #endif
-  #endif
 
+  // (For MKS_MINI_12864 the bootscreen is shown in ui.init)
+  #if HAS_SPI_LCD && ENABLED(SHOW_BOOTSCREEN) && DISABLED(MKS_MINI_12864)
+    ui.show_bootscreen();
+  #endif
 
   #if ENABLED(SDIO_SUPPORT) && SD_DETECT_PIN == -1
     // Auto-mount the SD for EEPROM.dat emulation

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -75,7 +75,8 @@
 #define UC1701_V5_RATIO(N)       (0x20 | ((N) & 0x7))
 #define UC1701_CONTRAST(N)       (0x81), (N)
 
-#define UC1701_COLUMN_ADR(N)     (0x10 | (((N) >> 4) & 0xF)), ((N) & 0xF)
+#define UC1701_COLUMN_HI(N)      (0x10 | (((N) >> 4) & 0xF))
+#define UC1701_COLUMN_ADR(N)     UC1701_COLUMN_HI(N), ((N) & 0xF)
 #define UC1701_PAGE_ADR(N)       (0xB0 | (N))
 #define UC1701_START_LINE(N)     (0x40 | (N))
 #define UC1701_INDICATOR(N)      (0xAC), (N)
@@ -99,7 +100,7 @@ static const uint8_t u8g_dev_uc1701_mini12864_HAL_init_seq[] PROGMEM = {
   UC1701_BOOST_RATIO(0x0),    /* set booster ratio to 4x */
   UC1701_V5_RATIO(3),         /* set V0 voltage resistor ratio to large */
   UC1701_CONTRAST(0x27),      /* set contrast */
-  UC1701_INDICATOR(0),        /* indicator */
+  UC1701_INDICATOR(0),        /* indicator disable */
   UC1701_ON(1),               /* display on */
 
   U8G_ESC_CS(0),              /* disable chip */
@@ -117,29 +118,24 @@ static const uint8_t u8g_dev_uc1701_mini12864_HAL_init_seq[] PROGMEM = {
 };
 
 static const uint8_t u8g_dev_uc1701_mini12864_HAL_data_start[] PROGMEM = {
-      #if ENABLED(MKS_MINI_12864)
-          U8G_ESC_ADR(0),             /* instruction mode */
-          U8G_ESC_CS(1),              /* enable chip */
-          0x040, /* set display start line to 0 */
-          0x0a0, /* ADC set to reverse */
-          0x0c8, /* common output mode */
-          0x0a6, /* display normal, bit val 0: LCD pixel off. */
-          0x0a2, /* LCD bias 1/9 */
-          0x02f, /* all power control circuits on */
-          0x0f8, /* set booster ratio to */
-          0x000, /* 4x */
-          0x023, /* set V0 voltage resistor ratio to large */
-          0x0ac, /* indicator */
-          0x000, /* disable */
-          0x0af, /* display on */
-          0x010, /* set upper 4 bit of the col adr to 0 */
-          U8G_ESC_END                 /* end of sequence */
-      #else
-          U8G_ESC_ADR(0),             /* instruction mode */
-          U8G_ESC_CS(1),              /* enable chip */
-          UC1701_COLUMN_ADR(0),       /* address 0 */
-          U8G_ESC_END                 /* end of sequence */
-      #endif
+  U8G_ESC_ADR(0),             /* instruction mode */
+  U8G_ESC_CS(1),              /* enable chip */
+  #if ENABLED(MKS_MINI_12864)
+    UC1701_START_LINE(0),     /* set display start line to 0 */
+    UC1701_ADC_REVERSE(0),    /* ADC set to reverse */
+    UC1701_OUT_MODE(1),       /* common output mode */
+    UC1701_INVERTED(0),       /* display normal, bit val 0: LCD pixel off. */
+    UC1701_BIAS_MODE(0),      /* LCD bias 1/9 */
+    UC1701_POWER_CONTROL(0x7), /* all power control circuits on */
+    UC1701_BOOST_RATIO(0x0),  /* set booster ratio to 4x */
+    UC1701_V5_RATIO(3),       /* set V0 voltage resistor ratio to large */
+    UC1701_INDICATOR(0),      /* indicator disable */
+    UC1701_ON(1),             /* display on */
+    UC1701_COLUMN_HI(0),      /* set upper 4 bits of the col adr to 0 */
+  #else
+    UC1701_COLUMN_ADR(0),     /* address 0 */
+  #endif
+  U8G_ESC_END                 /* end of sequence */
 };
 
 uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -117,10 +117,29 @@ static const uint8_t u8g_dev_uc1701_mini12864_HAL_init_seq[] PROGMEM = {
 };
 
 static const uint8_t u8g_dev_uc1701_mini12864_HAL_data_start[] PROGMEM = {
-  U8G_ESC_ADR(0),             /* instruction mode */
-  U8G_ESC_CS(1),              /* enable chip */
-  UC1701_COLUMN_ADR(0),       /* address 0 */
-  U8G_ESC_END                 /* end of sequence */
+      #if ENABLED(MKS_MINI_12864)
+          U8G_ESC_ADR(0),             /* instruction mode */
+          U8G_ESC_CS(1),              /* enable chip */
+          0x040, /* set display start line to 0 */
+          0x0a0, /* ADC set to reverse */
+          0x0c8, /* common output mode */
+          0x0a6, /* display normal, bit val 0: LCD pixel off. */
+          0x0a2, /* LCD bias 1/9 */
+          0x02f, /* all power control circuits on */
+          0x0f8, /* set booster ratio to */
+          0x000, /* 4x */
+          0x023, /* set V0 voltage resistor ratio to large */
+          0x0ac, /* indicator */
+          0x000, /* disable */
+          0x0af, /* display on */
+          0x010, /* set upper 4 bit of the col adr to 0 */
+          U8G_ESC_END                 /* end of sequence */
+      #else
+          U8G_ESC_ADR(0),             /* instruction mode */
+          U8G_ESC_CS(1),              /* enable chip */
+          UC1701_COLUMN_ADR(0),       /* address 0 */
+          U8G_ESC_END                 /* end of sequence */
+      #endif
 };
 
 uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -118,24 +118,31 @@ static const uint8_t u8g_dev_uc1701_mini12864_HAL_init_seq[] PROGMEM = {
 };
 
 static const uint8_t u8g_dev_uc1701_mini12864_HAL_data_start[] PROGMEM = {
-  U8G_ESC_ADR(0),             /* instruction mode */
-  U8G_ESC_CS(1),              /* enable chip */
-  #if ENABLED(MKS_MINI_12864)
-    UC1701_START_LINE(0),     /* set display start line to 0 */
-    UC1701_ADC_REVERSE(0),    /* ADC set to reverse */
-    UC1701_OUT_MODE(1),       /* common output mode */
-    UC1701_INVERTED(0),       /* display normal, bit val 0: LCD pixel off. */
-    UC1701_BIAS_MODE(0),      /* LCD bias 1/9 */
-    UC1701_POWER_CONTROL(0x7), /* all power control circuits on */
-    UC1701_BOOST_RATIO(0x0),  /* set booster ratio to 4x */
-    UC1701_V5_RATIO(3),       /* set V0 voltage resistor ratio to large */
-    UC1701_INDICATOR(0),      /* indicator disable */
-    UC1701_ON(1),             /* display on */
-    UC1701_COLUMN_HI(0),      /* set upper 4 bits of the col adr to 0 */
-  #else
-    UC1701_COLUMN_ADR(0),     /* address 0 */
-  #endif
-  U8G_ESC_END                 /* end of sequence */
+  //DrDitto
+      #if ENABLED(MKS_MINI_12864)
+          U8G_ESC_ADR(0),             /* instruction mode */
+          U8G_ESC_CS(1),              /* enable chip */
+          0x040, /* set display start line to 0 */
+          0x0a0, /* ADC set to reverse */
+          0x0c8, /* common output mode */
+          0x0a6, /* display normal, bit val 0: LCD pixel off. */
+          0x0a2, /* LCD bias 1/9 */
+          0x02f, /* all power control circuits on */
+          0x0f8, /* set booster ratio to */
+          0x000, /* 4x */
+          0x023, /* set V0 voltage resistor ratio to large */
+          0x0ac, /* indicator */
+          0x000, /* disable */
+          0x0af, /* display on */
+          0x010, /* set upper 4 bit of the col adr to 0 */
+          U8G_ESC_END                 /* end of sequence */
+      #else
+          U8G_ESC_ADR(0),             /* instruction mode */
+          U8G_ESC_CS(1),              /* enable chip */
+          UC1701_COLUMN_ADR(0),       /* address 0 */
+          U8G_ESC_END                 /* end of sequence */
+      #endif
+
 };
 
 uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -118,31 +118,24 @@ static const uint8_t u8g_dev_uc1701_mini12864_HAL_init_seq[] PROGMEM = {
 };
 
 static const uint8_t u8g_dev_uc1701_mini12864_HAL_data_start[] PROGMEM = {
-  //DrDitto
-      #if ENABLED(MKS_MINI_12864)
-          U8G_ESC_ADR(0),             /* instruction mode */
-          U8G_ESC_CS(1),              /* enable chip */
-          0x040, /* set display start line to 0 */
-          0x0a0, /* ADC set to reverse */
-          0x0c8, /* common output mode */
-          0x0a6, /* display normal, bit val 0: LCD pixel off. */
-          0x0a2, /* LCD bias 1/9 */
-          0x02f, /* all power control circuits on */
-          0x0f8, /* set booster ratio to */
-          0x000, /* 4x */
-          0x023, /* set V0 voltage resistor ratio to large */
-          0x0ac, /* indicator */
-          0x000, /* disable */
-          0x0af, /* display on */
-          0x010, /* set upper 4 bit of the col adr to 0 */
-          U8G_ESC_END                 /* end of sequence */
-      #else
-          U8G_ESC_ADR(0),             /* instruction mode */
-          U8G_ESC_CS(1),              /* enable chip */
-          UC1701_COLUMN_ADR(0),       /* address 0 */
-          U8G_ESC_END                 /* end of sequence */
-      #endif
-
+  U8G_ESC_ADR(0),             /* instruction mode */
+  U8G_ESC_CS(1),              /* enable chip */
+  #if ENABLED(MKS_MINI_12864)
+    UC1701_START_LINE(0),     /* set display start line to 0 */
+    UC1701_ADC_REVERSE(0),    /* ADC set to normal */
+    UC1701_OUT_MODE(1),       /* common output mode */
+    UC1701_INVERTED(0),       /* display normal, bit val 0: LCD pixel off. */
+    UC1701_BIAS_MODE(0),      /* LCD bias 1/9 */
+    UC1701_POWER_CONTROL(0x7),/* all power control circuits on */
+    UC1701_BOOST_RATIO(0x0),  /* set booster ratio to 4x */
+    UC1701_V5_RATIO(3),       /* set V0 voltage resistor ratio to large */
+    UC1701_INDICATOR(0),      /* indicator disable */
+    UC1701_ON(1),             /* display on */
+    UC1701_COLUMN_HI(0),      /* set upper 4 bit of the col adr to 0 */
+  #else
+    UC1701_COLUMN_ADR(0),     /* address 0 */
+  #endif
+  U8G_ESC_END                 /* end of sequence */
 };
 
 uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -233,7 +233,7 @@ void MarlinUI::init_lcd() {
     OUT_WRITE(LCD_RESET_PIN, LOW); // perform a clean hardware reset
     _delay_ms(5);
     OUT_WRITE(LCD_RESET_PIN, HIGH);
-    _delay_ms(5); // delay to allow the display to initialize
+    _delay_ms(5);                  // delay to allow the display to initialize
   #endif
 
   #if PIN_EXISTS(LCD_RESET)

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.h
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.h
@@ -110,8 +110,12 @@
 #elif ENABLED(MINIPANEL)
   // MINIPanel display
   //#define U8G_CLASS U8GLIB_MINI12864
-  //#define U8G_PARAM DOGLCD_CS, DOGLCD_A0                            // 8 stripes
-  #define U8G_CLASS U8GLIB_MINI12864_2X
+  //#define U8G_PARAM DOGLCD_CS, DOGLCD_A0                            // 8 stripes}
+  #if ENABLED(MKS_MINI_12864)
+    #define U8G_CLASS U8GLIB_MINI12864_2X_HAL  
+  #else
+    #define U8G_CLASS U8GLIB_MINI12864_2X
+  #endif
   #define U8G_PARAM DOGLCD_CS, DOGLCD_A0                              // 8 stripes
 #elif ENABLED(FYSETC_MINI_12864)
   // The FYSETC_MINI_12864 display

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -232,24 +232,25 @@ millis_t next_button_update_ms;
 #endif // HAS_LCD_MENU
 
 void MarlinUI::init() {
-  //Recovering custom _Bootscreen showing for the MKS_MINI_12864
+
+  // MKS_MINI_12864 needs to do this early
   #if ENABLED(MKS_MINI_12864)
-      #if !defined(LCD_RESET_PIN)
-        #define LCD_RESET_PIN LCD_PINS_RS
-      #endif
-      //Reset the MKS_MINI_12864
-      #if PIN_EXISTS(LCD_RESET)
-        OUT_WRITE(LCD_RESET_PIN, LOW); // perform a clean hardware reset
-        _delay_ms(5);
-        OUT_WRITE(LCD_RESET_PIN, HIGH);
-        _delay_ms(5); // delay to allow the display to initialize
-      #endif
-      #if ENABLED(DEFAULT_LCD_CONTRAST)
-        u8g.setContrast(DEFAULT_LCD_CONTRAST);
-      #endif
-      #if HAS_SPI_LCD && ENABLED(SHOW_BOOTSCREEN)
-        ui.show_bootscreen();
-      #endif
+    #ifndef LCD_RESET_PIN
+      #define LCD_RESET_PIN LCD_PINS_RS
+    #endif
+    // Reset the MKS LCD
+    #if PIN_EXISTS(LCD_RESET)
+      OUT_WRITE(LCD_RESET_PIN, LOW);
+      _delay_ms(5);
+      OUT_WRITE(LCD_RESET_PIN, HIGH);
+      _delay_ms(5);
+    #endif
+    #if ENABLED(DEFAULT_LCD_CONTRAST)
+      u8g.setContrast(DEFAULT_LCD_CONTRAST);
+    #endif
+    #if ENABLED(SHOW_BOOTSCREEN)
+      ui.show_bootscreen();
+    #endif
   #endif
 
   init_lcd();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -232,6 +232,25 @@ millis_t next_button_update_ms;
 #endif // HAS_LCD_MENU
 
 void MarlinUI::init() {
+  //Recovering custom _Bootscreen showing for the MKS_MINI_12864
+  #if ENABLED(MKS_MINI_12864)
+      #if !defined(LCD_RESET_PIN)
+        #define LCD_RESET_PIN LCD_PINS_RS
+      #endif
+      //Reset the MKS_MINI_12864
+      #if PIN_EXISTS(LCD_RESET)
+        OUT_WRITE(LCD_RESET_PIN, LOW); // perform a clean hardware reset
+        _delay_ms(5);
+        OUT_WRITE(LCD_RESET_PIN, HIGH);
+        _delay_ms(5); // delay to allow the display to initialize
+      #endif
+      #if ENABLED(DEFAULT_LCD_CONTRAST)
+        u8g.setContrast(DEFAULT_LCD_CONTRAST);
+      #endif
+      #if HAS_SPI_LCD && ENABLED(SHOW_BOOTSCREEN)
+        ui.show_bootscreen();
+      #endif
+  #endif
 
   init_lcd();
 


### PR DESCRIPTION

### **Description**
MKS MINI 12864 display is unstable when used with fast MCUs.
Observed glitches:

mirrored picture
wrapped picture
contrast glitches
display turned off

###**Steps to Reproduce**
Install Marlin on LPC1768 with MKS Mini 12864 display
Wait for 15-180 minutes

###**Expected behavior:**
No visual glitches on display

###**Actual behavior:**
Various screen glitches

vertically mirrored image
horizontally mirrored image
wrapped image

### Related Issues
BUG #13550

###**After patching  behavior:**
No visual glitches on display
[Config.zip](https://github.com/MarlinFirmware/Marlin/files/3250746/Config.zip)
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
