### PR TITLE
Add g81 & g83 drilling cycles

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,16 +1,31 @@
-# NO SUPPORT REQUESTS PLEASE
+<!--
 
-Support Requests posted here will be automatically closed!
+Have you read Marlin's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/MarlinFirmware/Marlin/blob/1.1.x/.github/code_of_conduct.md
 
-This Issue Queue is for Marlin bug reports and development-related issues, and we prefer not to handle user-support questions here. See https://github.com/MarlinFirmware/Marlin/blob/1.1.x/.github/contributing.md#i-dont-want-to-read-this-whole-thing-i-just-have-a-question.
+Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use the Marlin Firmware forum at http://forums.reprap.org/list.php?415 or the Marlin Facebook Group https://www.facebook.com/groups/1049718498464482/.
 
-For best results getting help with configuration and troubleshooting, please use the following resources:
+Before filing an issue be sure to test the 1.1 and/or 2.0 "bugfix" branches to see whether the issue is already addressed.
 
-- RepRap.org Marlin Forum http://forums.reprap.org/list.php?415
-- Tom's 3D Forums https://discuss.toms3d.org/
-- Facebook Group "Marlin Firmware" https://www.facebook.com/groups/1049718498464482/
-- Facebook Group "Marlin Firmware for 3D Printers" https://www.facebook.com/groups/3Dtechtalk/
-- Marlin Configuration https://www.youtube.com/results?search_query=marlin+configuration on YouTube
-- Marlin Discord server. Join link: https://discord.gg/n5NJ59y
+-->
 
-After seeking help from the community, if the consensus points to to a bug in Marlin, then you should post a Bug Report at https://github.com/MarlinFirmware/Marlin/issues/new/choose).
+### Description
+
+<!-- Description of the bug or requested feature -->
+
+### Steps to Reproduce
+
+<!-- If this is a Bug Report, please describe the steps needed to reproduce the issue -->
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+#### Additional Information
+
+* Include a ZIP file containing your `Configuration.h` and `Configuration_adv.h` files.
+* Provide pictures or links to videos that clearly demonstrate the issue.
+* See [How Can I Contribute](#how-can-i-contribute) for additional guidelines.


### PR DESCRIPTION
### Requirements

Add G81 and G83 "canned cycles" to marlin firmware for CNC drilling operations.

### Description

I aim to add drilling cycle G81 and peck drilling cycle G83 to Marlin as we're using it on a low cost CNC machine and would like to properly support the drilling operations we're used to our CAM software generating. Where an appropriate drill is available for making a hole, a drill or peck drill operation is the fastest way to remove material.

Please bear in mind I am opening this PR early and don't expect this code to be merged like it is. Am I approaching this correctly? Do you have any suggestions based on work so far?

### Benefits

With G81/G83, many cad/cam packages will work as expected with drilling operations where Marlin is used as the CNC controller.
