### PR TITLE
Ability to insert G-code in front of queue

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -381,7 +381,7 @@ void disable_all_steppers() {
     #endif // HOST_ACTION_COMMANDS
 
     if (run_runout_script)
-      enqueue_and_echo_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
+      insert_and_echo_priority_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
   }
 
 #endif // HAS_FILAMENT_SENSOR

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -381,7 +381,7 @@ void disable_all_steppers() {
     #endif // HOST_ACTION_COMMANDS
 
     if (run_runout_script)
-      insert_and_echo_priority_commands_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
+      enqueue_and_echo_commands_front_P(PSTR(FILAMENT_RUNOUT_SCRIPT));
   }
 
 #endif // HAS_FILAMENT_SENSOR

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -142,7 +142,6 @@
 // Serial Console Messages (do not translate those!)
 
 #define MSG_ENQUEUEING                      "enqueueing \""
-#define MSG_INSERTING                       "inserting \""
 #define MSG_POWERUP                         "PowerUp"
 #define MSG_EXTERNAL_RESET                  " External Reset"
 #define MSG_BROWNOUT_RESET                  " Brown out Reset"

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -142,6 +142,7 @@
 // Serial Console Messages (do not translate those!)
 
 #define MSG_ENQUEUEING                      "enqueueing \""
+#define MSG_INSERTING                       "inserting \""
 #define MSG_POWERUP                         "PowerUp"
 #define MSG_EXTERNAL_RESET                  " External Reset"
 #define MSG_BROWNOUT_RESET                  " Brown out Reset"

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -82,15 +82,6 @@ bool send_ok[BUFSIZE];
  */
 static PGM_P injected_commands_P = nullptr;
 
-#if ENABLED(ADVANCED_PAUSE_FEATURE)
-  /**
-   * Higher Priority (than Injected) Command pointer. nullptr if no commands are being injected.
-   * Used by Marlin internally. The priority command is inserted infront of the queue.  
-   * Needed to run Pause command immediately before processing any command already in the queue.
-   */
-  static PGM_P priority_commands_P = nullptr;
-#endif
-
 void queue_setup() {
   // Send "ok" after commands by default
   for (uint8_t i = 0; i < COUNT(send_ok); i++) send_ok[i] = true;
@@ -102,48 +93,6 @@ void queue_setup() {
 void clear_command_queue() {
   cmd_queue_index_r = cmd_queue_index_w = commands_in_queue = 0;
 }
-
-#if ENABLED(ADVANCED_PAUSE_FEATURE)
-  /**
-   * Insert a high Priority command from RAM into the main command buffer.
-   * Return true if the command was successfully added.
-   * Return false for a full buffer, or if the 'command' is a comment.
-   */
-  inline bool _insertprioritycommand(const char* cmd, bool say_ok=false
-    #if NUM_SERIAL > 1
-      , int16_t port = -1
-    #endif
-  ) {
-    if (*cmd == ';' || commands_in_queue >= BUFSIZE) return false;
-    if (cmd_queue_index_r == 0) cmd_queue_index_r = BUFSIZE;
-    --cmd_queue_index_r;
-    strcpy(command_queue[cmd_queue_index_r], cmd);
-    send_ok[cmd_queue_index_r] = say_ok;
-    #if NUM_SERIAL > 1
-      command_queue_port[cmd_queue_index_r] = port;
-    #endif
-    commands_in_queue++;
-    return true;
-  }
-
-  /**
-   * Insert a High Priority command with Serial Echo
-   */
-  bool insert_and_echo_priority_command(const char* cmd) {
-
-    if (*cmd == 0 || *cmd == '\n' || *cmd == '\r') {
-      //SERIAL_ECHOLNPGM("Null command found...   Did not insert!");
-      return true;
-    }
-
-    if (_insertprioritycommand(cmd)) {
-      SERIAL_ECHO_START();
-      SERIAL_ECHOLNPAIR(MSG_INSERTING, cmd, "\"");
-      return true;
-    }
-    return false;
-  }
-#endif
 
 /**
  * Once a new command is in the ring buffer, call this to commit it
@@ -183,7 +132,7 @@ inline bool _enqueuecommand(const char* cmd, bool say_ok=false
 
 /**
  * Enqueue with Serial Echo
- * Return true on success
+ * Return true if the command was consumed
  */
 bool enqueue_and_echo_command(const char* cmd) {
 
@@ -191,10 +140,7 @@ bool enqueue_and_echo_command(const char* cmd) {
   //SERIAL_ECHO(cmd);
   //SERIAL_ECHOPGM("\") \n");
 
-  if (*cmd == 0 || *cmd == '\n' || *cmd == '\r') {
-    //SERIAL_ECHOLNPGM("Null command found...   Did not queue!");
-    return true;
-  }
+  if (*cmd == 0 || *cmd == '\n' || *cmd == '\r') return true;
 
   if (_enqueuecommand(cmd)) {
     SERIAL_ECHO_START();
@@ -204,28 +150,47 @@ bool enqueue_and_echo_command(const char* cmd) {
   return false;
 }
 
+#if HAS_QUEUE_FRONT
+
+  bool early_cmd; // = false
+
+  /**
+   * Insert a high Priority command from RAM into the main command buffer.
+   * Return true if the command was consumed
+   * Return false for a full buffer, or if the 'command' is a comment.
+   */
+  inline bool _enqueuecommand_front(const char* cmd) {
+    if (*cmd == 0 || *cmd == '\n' || *cmd == '\r') return true;
+    if (*cmd == ';' || commands_in_queue >= BUFSIZE) return false;
+    if (cmd_queue_index_r == 0) cmd_queue_index_r = BUFSIZE;
+    --cmd_queue_index_r;
+    strcpy(command_queue[cmd_queue_index_r], cmd);
+    send_ok[cmd_queue_index_r] = false;
+    #if NUM_SERIAL > 1
+      command_queue_port[cmd_queue_index_r] = -1;
+    #endif
+    commands_in_queue++;
+    return true;
+  }
+
+  /**
+   * Insert in the front of queue, one or many commands to run from program memory.
+   * Aborts the current queue, if any.
+   * Note: drain_injected_commands_P() must be called repeatedly to drain the commands afterwards
+   */
+  void enqueue_and_echo_commands_front_P(PGM_P const pgcode) {
+    early_cmd = true;
+    enqueue_and_echo_commands_P(pgcode);
+  }
+
+#endif
+
 /**
  * Inject the next "immediate" command, when possible, onto the front of the queue.
  * Return true if any immediate commands remain to inject.
  * Do not inject a comment or use leading space!.
  */
 static bool drain_injected_commands_P() {
-  #if ENABLED(ADVANCED_PAUSE_FEATURE)
-
-    while (priority_commands_P != nullptr) {
-      size_t i = 0;
-      char c, cmd[60];
-      strncpy_P(cmd, priority_commands_P, sizeof(cmd) - 1);
-      cmd[sizeof(cmd) - 1] = '\0';
-      while ((c = cmd[i]) && c != '\n') i++; // find the end of this gcode command
-      cmd[i] = '\0';
-      if (insert_and_echo_priority_command(cmd))     // success?
-        priority_commands_P = c ? priority_commands_P + i + 1 : nullptr; // next command or done
-      else 
-        return true; // buffer is full (or command is comment);
-    }
-  #endif
-
   while (injected_commands_P != nullptr) {
     size_t i = 0;
     char c, cmd[60];
@@ -233,25 +198,23 @@ static bool drain_injected_commands_P() {
     cmd[sizeof(cmd) - 1] = '\0';
     while ((c = cmd[i]) && c != '\n') i++; // find the end of this gcode command
     cmd[i] = '\0';
-    if (enqueue_and_echo_command(cmd))     // success?
+
+    if (
+      #if HAS_QUEUE_FRONT
+        early_cmd ? _enqueuecommand_front(cmd) :
+      #endif
+      enqueue_and_echo_command(cmd)
+    ) {
       injected_commands_P = c ? injected_commands_P + i + 1 : nullptr; // next command or done
+      #if HAS_QUEUE_FRONT
+        if (!c) early_cmd = false;
+      #endif
+    }
     else
-      return true; // buffer is full (or command is comment);   
+      return true; // buffer is full (or command is comment);
   }
   return false;   // return whether any more remain
 }
-
-#if ENABLED(ADVANCED_PAUSE_FEATURE)
-  /**
-   * Insert in the front of queue, one or many commands to run from program memory.
-   * Aborts the current queue, if any.
-   * Note: drain_injected_commands_P() must be called repeatedly to drain the commands afterwards
-   */
-  void insert_and_echo_priority_commands_P(PGM_P const pgcode) {
-    priority_commands_P = pgcode;
-    (void)drain_injected_commands_P(); // first command executed asap (when possible)
-  }
-#endif
 
 /**
  * Enqueue one or many commands to run from program memory.
@@ -259,6 +222,9 @@ static bool drain_injected_commands_P() {
  * Note: drain_injected_commands_P() must be called repeatedly to drain the commands afterwards
  */
 void enqueue_and_echo_commands_P(PGM_P const pgcode) {
+  #if HAS_QUEUE_FRONT
+    early_cmd = false;
+  #endif
   injected_commands_P = pgcode;
   (void)drain_injected_commands_P(); // first command executed asap (when possible)
 }

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -83,8 +83,17 @@ void flush_and_request_resend();
  */
 void ok_to_send();
 
+#if ENABLED(ADVANCED_PAUSE_FEATURE)
+  /**
+   * Insert in the front of queue, one or many commands to run from program memory.
+   * Aborts the current queue, if any.
+   * Note: drain_injected_commands_P() must be called repeatedly to drain the commands afterwards
+   */
+  void insert_and_echo_priority_commands_P(PGM_P const pgcode);
+#endif
+
 /**
- * Record one or many commands to run from program memory.
+ * Enqueue one or many commands to run from program memory.
  * Aborts the current queue, if any.
  * Note: drain_injected_commands_P() must be called repeatedly to drain the commands afterwards
  */
@@ -92,6 +101,7 @@ void enqueue_and_echo_commands_P(PGM_P const pgcode);
 
 /**
  * Enqueue with Serial Echo
+ * Return true on success
  */
 bool enqueue_and_echo_command(const char* cmd);
 

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -89,7 +89,7 @@ void ok_to_send();
    * Aborts the current queue, if any.
    * Note: drain_injected_commands_P() must be called repeatedly to drain the commands afterwards
    */
-  void insert_and_echo_priority_commands_P(PGM_P const pgcode);
+  void enqueue_and_echo_commands_front_P(PGM_P const pgcode);
 #endif
 
 /**
@@ -107,6 +107,7 @@ bool enqueue_and_echo_command(const char* cmd);
 
 #define HAS_LCD_QUEUE_NOW (ENABLED(MALYAN_LCD) || (HAS_LCD_MENU && ANY(AUTO_BED_LEVELING_UBL, PID_AUTOTUNE_MENU, ADVANCED_PAUSE_FEATURE)))
 #define HAS_QUEUE_NOW (ENABLED(SDSUPPORT) || HAS_LCD_QUEUE_NOW)
+#define HAS_QUEUE_FRONT ENABLED(ADVANCED_PAUSE_FEATURE)
 
 #if HAS_QUEUE_NOW
   /**

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1396,7 +1396,7 @@ void MarlinUI::update() {
       #if HAS_SPI_LCD
         lcd_pause_show_message(PAUSE_MESSAGE_PAUSING, PAUSE_MODE_PAUSE_PRINT);  // Show message immediately to let user know about pause in progress
       #endif
-      insert_and_echo_priority_commands_P(PSTR("M25 P\nM24"));
+      enqueue_and_echo_commands_front_P(PSTR("M25 P\nM24"));
     #elif ENABLED(SDSUPPORT)
       enqueue_and_echo_commands_P(PSTR("M25"));
     #elif defined(ACTION_ON_PAUSE)

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1396,7 +1396,7 @@ void MarlinUI::update() {
       #if HAS_SPI_LCD
         lcd_pause_show_message(PAUSE_MESSAGE_PAUSING, PAUSE_MODE_PAUSE_PRINT);  // Show message immediately to let user know about pause in progress
       #endif
-      enqueue_and_echo_commands_P(PSTR("M25 P\nM24"));
+      insert_and_echo_priority_commands_P(PSTR("M25 P\nM24"));
     #elif ENABLED(SDSUPPORT)
       enqueue_and_echo_commands_P(PSTR("M25"));
     #elif defined(ACTION_ON_PAUSE)


### PR DESCRIPTION
Insert a command in front of the queue instead of the end of the queue.
Used in pause from lcd or filament runout, to make the printer response faster. 

But by default BUFFER SIZE for gcode queue is only 4 and defauilt BUFFER SIZE for planner block is 16.
Therefore, maybe doesn't make much differences. 
But if we use Bed Leveling 1 gcode command can be exploded itu many planner block.

This PR is my response for PR #14214