### PR TITLE
Fix ESP32 servo timers, platformio.ini, etc.

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -194,8 +194,7 @@ void HAL_adc_start_conversion(uint8_t adc_pin) {
 
 void analogWrite(int pin, int value) {
 
-  if (!PWM_PIN(pin))
-    return;
+  if (!PWM_PIN(pin)) return;
 
   static int cnt_channel = 1,
              pin_to_channel[40] = {};

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -193,6 +193,10 @@ void HAL_adc_start_conversion(uint8_t adc_pin) {
 }
 
 void analogWrite(int pin, int value) {
+
+  if (!PWM_PIN(pin))
+    return;
+
   static int cnt_channel = 1,
              pin_to_channel[40] = {};
   if (pin_to_channel[pin] == 0) {

--- a/Marlin/src/HAL/HAL_ESP32/HAL_Servo_ESP32.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_Servo_ESP32.cpp
@@ -27,7 +27,9 @@
 
 #include "HAL_Servo_ESP32.h"
 
-int Servo::channel_next_free = 0;
+// Adjacent channels (0/1, 2/3 etc.) share the same timer and therefore the same frequency and resolution settings on ESP32,
+// so we only allocate servo channels up high to avoid side effects with regards to analogWrite (fans, leds, laser pwm etc.)
+int Servo::channel_next_free = 12;
 
 Servo::Servo() {
   this->channel = channel_next_free++;
@@ -42,7 +44,7 @@ int8_t Servo::attach(const int pin) {
   return true;
 }
 
-void Servo::detach() { ledcDetachPin(this->pin) }
+void Servo::detach() { ledcDetachPin(this->pin); }
 
 int Servo::read() { return this->degrees; }
 

--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -21,10 +21,11 @@
  */
 #ifdef ARDUINO_ARCH_ESP32
 
+#include "../../inc/MarlinConfigPre.h"
+
 #include "i2s.h"
 
 #include "../shared/Marduino.h"
-#include "../../core/macros.h"
 #include "driver/periph_ctrl.h"
 #include "rom/lldesc.h"
 #include "soc/i2s_struct.h"

--- a/Marlin/src/HAL/HAL_ESP32/i2s.h
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.h
@@ -33,9 +33,3 @@ uint8_t i2s_state(uint8_t pin);
 void i2s_write(uint8_t pin, uint8_t val);
 
 void i2s_push_sample();
-
-// pin definitions
-
-#define I2S_WS 25
-#define I2S_BCK 26
-#define I2S_DATA 27

--- a/Marlin/src/pins/pins_ESP32.h
+++ b/Marlin/src/pins/pins_ESP32.h
@@ -31,17 +31,23 @@
 #define BOARD_NAME "Espressif ESP32"
 
 //
+// I2S (steppers & other output-only pins)
+//
+#define I2S_STEPPER_STREAM
+#define I2S_WS              25
+#define I2S_BCK             26
+#define I2S_DATA            27
+
+//
 // Limit Switches
 //
-#define X_MIN_PIN          34
-#define Y_MIN_PIN          35
-#define Z_MIN_PIN          15
+#define X_MIN_PIN           34
+#define Y_MIN_PIN           35
+#define Z_MIN_PIN           15
 
 //
 // Steppers
 //
-#define I2S_STEPPER_STREAM
-
 #define X_STEP_PIN         128
 #define X_DIR_PIN          129
 #define X_ENABLE_PIN       130

--- a/platformio.ini
+++ b/platformio.ini
@@ -377,10 +377,10 @@ lib_ignore  =
 # Espressif ESP32
 #
 [env:esp32]
-platform    = https://github.com/platformio/platform-espressif32.git ; #feature/stage
-board       = esp32dev
-framework   = arduino
-upload_speed = 115200
+platform      = espressif32
+board         = esp32dev
+framework     = arduino
+upload_speed  = 115200
 monitor_speed = 115200
 upload_port = /dev/ttyUSB0
 lib_deps =


### PR DESCRIPTION
### Description
Fix some ESP32 issues 

### Benefits
* fix servo support to be compatible with analogWrite
* switch platformio platform to espressif32 release
* move I2S pin definitions to pins_ESP32.h
* ignore non-pwm pins in analogWrite

### Related Issues
n/a