### PR TITLE
Fix USE_BIG_EDIT_FONT bug

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -418,7 +418,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
         onpage = PAGE_CONTAINS(baseline - (EDIT_FONT_ASCENT - 1), baseline);
       }
       if (onpage) {
-        lcd_moveto((lcd_chr_fit - (vallen + 1)) * one_chr_width, baseline); // Right-justified, leaving padded by spaces
+        lcd_moveto(((lcd_chr_fit - 1) - (vallen + 1)) * one_chr_width, baseline); // Right-justified, leaving padded by spaces
         lcd_put_wchar(' '); // overwrite char if value gets shorter
         lcd_put_u8str(value);
       }


### PR DESCRIPTION
### Description

Reverts changes from https://github.com/MarlinFirmware/Marlin/commit/44caf70917d249b6175ef671d9659d408d1dde08 to restore `USE_BIG_EDIT_FONT` functionality.

### Benefits

Values are no longer cut off.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/14140