### PR TITLE
Add and apply Timeout class

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/main.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/main.cpp
@@ -37,6 +37,8 @@ extern "C" {
 
 #include "../../sd/cardreader.h"
 #include "../../inc/MarlinConfig.h"
+#include "../../libs/timeout.h"
+
 #include "HAL.h"
 #include "HAL_timers.h"
 
@@ -96,8 +98,8 @@ void HAL_init() {
     MSC_SD_Init(0);                         // Enable USB SD card access
   #endif
 
-  const millis_t usb_timeout = millis() + 2000;
-  while (!USB_Configuration && PENDING(millis(), usb_timeout)) {
+  Timeout usb_timeout(2000, true);
+  while (!USB_Configuration && usb_timeout.pending()) {
     delay(50);
     HAL_idletask();
     #if PIN_EXISTS(LED)
@@ -110,7 +112,10 @@ void HAL_init() {
     #if NUM_SERIAL > 1
       MYSERIAL1.begin(BAUDRATE);
     #endif
-    SERIAL_PRINTF("\n\necho:%s (%dMhz) Initialized\n", isLPC1769() ? "LPC1769" : "LPC1768", SystemCoreClock / 1000000);
+    SERIAL_EOL(); SERIAL_EOL();
+    SERIAL_ECHO_START();
+    serialprintPGM(isLPC1769() ? PSTR("LPC1769") : PSTR("LPC1768"));
+    SERIAL_ECHOLNPGM(" (", SystemCoreClock / 1000000, "Mhz) Initialized");
     SERIAL_FLUSHTX();
   #endif
 

--- a/Marlin/src/HAL/HAL_LPC1768/u8g/HAL_LCD_I2C_routines.c
+++ b/Marlin/src/HAL/HAL_LPC1768/u8g/HAL_LCD_I2C_routines.c
@@ -25,6 +25,8 @@
 
 #ifdef TARGET_LPC1768
 
+#include "../../../core/millis_t.h"
+
 #ifdef __cplusplus
   extern "C" {
 #endif
@@ -32,8 +34,6 @@
 #include <lpc17xx_i2c.h>
 #include <lpc17xx_pinsel.h>
 #include <lpc17xx_libcfg_default.h>
-
-#include "../../../core/millis_t.h"
 
 //////////////////////////////////////////////////////////////////////////////////////
 

--- a/Marlin/src/core/utility.h
+++ b/Marlin/src/core/utility.h
@@ -131,6 +131,9 @@ inline void serial_delay(const millis_t ms) {
   #define log_machine_info() NOOP
 #endif
 
+//
+// Restorer class for REMEMBER/RESTORE objects
+//
 template<typename T>
 class restorer {
   T& ref_;

--- a/Marlin/src/feature/I2CPositionEncoder.cpp
+++ b/Marlin/src/feature/I2CPositionEncoder.cpp
@@ -187,11 +187,9 @@ void I2CPositionEncoder::update() {
     #endif
 
     if (ABS(error) > I2CPE_ERR_CNT_THRESH * planner.settings.axis_steps_per_mm[encoderAxis]) {
-      const millis_t ms = millis();
-      if (ELAPSED(ms, nextErrorCountTime)) {
+      if (nextErrorTimeout.advance()) {
         SERIAL_ECHOLNPAIR("Large error on ", axis_codes[encoderAxis], " axis. error: ", (int)error, "; diffSum: ", diffSum);
         errorCount++;
-        nextErrorCountTime = ms + I2CPE_ERR_CNT_DEBOUNCE_MS;
       }
     }
   }

--- a/Marlin/src/feature/I2CPositionEncoder.h
+++ b/Marlin/src/feature/I2CPositionEncoder.h
@@ -24,6 +24,7 @@
 #include "../inc/MarlinConfig.h"
 
 #include "../module/planner.h"
+#include "../libs/timeout.h"
 
 #include <Wire.h>
 
@@ -128,8 +129,9 @@ class I2CPositionEncoder {
               position;
 
     millis_t  lastPositionTime    = 0,
-              nextErrorCountTime  = 0,
               lastErrorTime;
+
+    Timeout nextErrorTimeout;
 
     #if ENABLED(I2CPE_ERR_ROLLING_AVERAGE)
       uint8_t errIdx = 0, errPrstIdx = 0;
@@ -138,6 +140,8 @@ class I2CPositionEncoder {
     #endif
 
   public:
+    I2CPositionEncoder() { nextErrorTimeout.dura = I2CPE_ERR_CNT_DEBOUNCE_MS; }
+
     void init(const uint8_t address, const AxisEnum axis);
     void reset();
 

--- a/Marlin/src/feature/Max7219_Debug_LEDs.cpp
+++ b/Marlin/src/feature/Max7219_Debug_LEDs.cpp
@@ -47,6 +47,7 @@
 #include "../module/stepper.h"
 #include "../Marlin.h"
 #include "../HAL/shared/Delay.h"
+#include "../libs/timeout.h"
 
 Max7219 max7219;
 
@@ -532,9 +533,8 @@ void Max7219::idle_tasks() {
   #if ENABLED(MAX7219_DEBUG_PRINTER_ALIVE)
     static uint8_t refresh_cnt; // = 0
     constexpr uint16_t refresh_limit = 5;
-    static millis_t next_blink = 0;
-    const millis_t ms = millis();
-    const bool do_blink = ELAPSED(ms, next_blink);
+    static Timeout next_blink(1000);
+    const bool do_blink = next_blink.advance();
   #else
     static uint16_t refresh_cnt; // = 0
     constexpr bool do_blink = true;
@@ -550,10 +550,7 @@ void Max7219::idle_tasks() {
   }
 
   #if ENABLED(MAX7219_DEBUG_PRINTER_ALIVE)
-    if (do_blink) {
-      led_toggle(MAX7219_X_LEDS - 1, MAX7219_Y_LEDS - 1);
-      next_blink = ms + 1000;
-    }
+    if (do_blink) led_toggle(MAX7219_X_LEDS - 1, MAX7219_Y_LEDS - 1);
   #endif
 
   #if defined(MAX7219_DEBUG_PLANNER_HEAD) && defined(MAX7219_DEBUG_PLANNER_TAIL) && MAX7219_DEBUG_PLANNER_HEAD == MAX7219_DEBUG_PLANNER_TAIL

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -39,6 +39,7 @@
   #include "../../../gcode/parser.h"
   #include "../../../feature/bedlevel/bedlevel.h"
   #include "../../../libs/least_squares_fit.h"
+  #include "../../../libs/timeout.h"
 
   #if ENABLED(DUAL_X_CARRIAGE)
     #include "../../../module/tool_change.h"
@@ -800,11 +801,11 @@
 
     bool click_and_hold(const clickFunc_t func=nullptr) {
       if (ui.button_pressed()) {
-        ui.quick_feedback(false);                // Preserve button state for click-and-hold
-        const millis_t nxt = millis() + 1500UL;
-        while (ui.button_pressed()) {                // Loop while the encoder is pressed. Uses hardware flag!
-          idle();                                 // idle, of course
-          if (ELAPSED(millis(), nxt)) {           // After 1.5 seconds
+        ui.quick_feedback(false);               // Preserve button state for click-and-hold
+        const Timeout nxt(1500, true);
+        while (ui.button_pressed()) {           // Loop while the encoder is pressed. Uses hardware flag!
+          idle();                               // idle, of course
+          if (nxt.elapsed()) {                  // After 1.5 seconds
             ui.quick_feedback();
             if (func) (*func)();
             ui.wait_for_release();

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -26,15 +26,17 @@
 
 #include "../module/stepper_indirection.h"
 #include "../module/temperature.h"
+#include "../libs/timeout.h"
 
 uint8_t controllerfan_speed;
 
 void controllerfan_update() {
-  static millis_t lastMotorOn = 0, // Last time a motor was turned on
-                  nextMotorCheck = 0; // Last time the state was checked
   const millis_t ms = millis();
-  if (ELAPSED(ms, nextMotorCheck)) {
-    nextMotorCheck = ms + 2500UL; // Not a time critical function, so only check every 2.5s
+
+  static millis_t lastMotorOn = 0; // Last time a motor was turned on
+  static Timeout check_motor_timeout(2500, ms); // Not time-critical, so only check every 2.5s
+
+  if (check_motor_timeout.advance(ms)) {
 
     // If any of the drivers or the bed are enabled...
     if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON

--- a/Marlin/src/feature/leds/tempstat.cpp
+++ b/Marlin/src/feature/leds/tempstat.cpp
@@ -30,12 +30,12 @@
 
 #include "tempstat.h"
 #include "../../module/temperature.h"
+#include "../../libs/timeout.h"
 
 void handle_status_leds(void) {
   static int8_t old_red = -1;  // Invalid value to force LED initialization
-  static millis_t next_status_led_update_ms = 0;
-  if (ELAPSED(millis(), next_status_led_update_ms)) {
-    next_status_led_update_ms += 500; // Update every 0.5s
+  static Timeout status_led_timeout(500); // Update every 0.5s
+  if (status_led_timeout.advance()) {
     float max_temp = 0.0;
     #if HAS_HEATED_BED
       max_temp = MAX(thermalManager.degTargetBed(), thermalManager.degBed());

--- a/Marlin/src/feature/power.h
+++ b/Marlin/src/feature/power.h
@@ -25,7 +25,9 @@
  * power.h - power control
  */
 
+#include "../inc/MarlinConfigPre.h"
 #include "../core/millis_t.h"
+#include "../libs/timeout.h"
 
 class Power {
   public:
@@ -33,7 +35,7 @@ class Power {
     static void power_on();
     static void power_off();
   private:
-    static millis_t lastPowerOn;
+    static Timeout power_off_timeout;
     static bool is_power_needed();
 };
 

--- a/Marlin/src/feature/prusa_MMU2/mmu2.h
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include "../../inc/MarlinConfig.h"
+#include "../../libs/timeout.h"
 
 #if HAS_FILAMENT_SENSOR
   #include "../runout.h"
@@ -79,7 +80,8 @@ private:
   static volatile int8_t finda;
   static volatile bool finda_runout_valid;
   static int16_t version, buildnr;
-  static millis_t last_request, next_P0_request;
+  static millis_t last_request;
+  static Timeout P0_request_timeout;
   static char rx_buffer[16], tx_buffer[16];
 
   static inline void set_runout_valid(const bool valid) {

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -31,6 +31,7 @@
 #include "../gcode/queue.h"
 
 #include "../inc/MarlinConfig.h"
+#include "../libs/timeout.h"
 
 #if ENABLED(EXTENSIBLE_UI)
   #include "../lcd/extensible_ui/ui_api.h"
@@ -298,10 +299,8 @@ class FilamentSensorBase {
 
       static inline void run() {
         #ifdef FILAMENT_RUNOUT_SENSOR_DEBUG
-          static millis_t t = 0;
-          const millis_t ms = millis();
-          if (ELAPSED(ms, t)) {
-            t = millis() + 1000UL;
+          static Timeout t(1000);
+          if (t.advance()) {
             LOOP_L_N(i, EXTRUDERS) {
               serialprintPGM(i ? PSTR(", ") : PSTR("Remaining mm: "));
               SERIAL_ECHO(runout_mm_countdown[i]);

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -28,7 +28,8 @@
 #include "../../../module/motion.h" // for active_extruder and current_position
 
 #if PIN_EXISTS(CHDK)
-  millis_t chdk_timeout; // = 0
+  #include "../../../libs/timeout.h"
+  Timeout chdk_timeout(PHOTO_SWITCH_MS);
 #endif
 
 #ifdef PHOTO_RETRACT_MM
@@ -148,7 +149,7 @@ void GcodeSuite::M240() {
   #if PIN_EXISTS(CHDK)
 
     OUT_WRITE(CHDK_PIN, HIGH);
-    chdk_timeout = millis() + PHOTO_SWITCH_MS;
+    chdk_timeout.reset();
 
   #elif HAS_PHOTOGRAPH
 

--- a/Marlin/src/gcode/lcd/M0_M1.cpp
+++ b/Marlin/src/gcode/lcd/M0_M1.cpp
@@ -26,6 +26,7 @@
 
 #include "../gcode.h"
 #include "../../module/stepper.h"
+#include "../../libs/timeout.h"
 
 #if HAS_LCD_MENU
   #include "../../lcd/ultralcd.h"
@@ -99,8 +100,8 @@ void GcodeSuite::M0_M1() {
   #endif
 
   if (ms > 0) {
-    ms += millis();  // wait until this time for a click
-    while (PENDING(millis(), ms) && wait_for_user) idle();
+    Timeout soon(ms);
+    while (soon.pending() && wait_for_user) idle(); // Wait for timeout or click
   }
   else
     while (wait_for_user) idle();

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -28,6 +28,7 @@
 #include "../../module/motion.h"
 #include "../../module/planner.h"
 #include "../../module/temperature.h"
+#include "../../libs/timeout.h"
 
 #if ENABLED(DELTA)
   #include "../../module/delta.h"
@@ -152,7 +153,7 @@ void plan_arc(
     const float inv_duration = fr_mm_s / MM_PER_ARC_SEGMENT;
   #endif
 
-  millis_t next_idle_ms = millis() + 200UL;
+  Timeout idle_timeout(200, true);
 
   #if N_ARC_CORRECTION > 1
     int8_t arc_recalc_count = N_ARC_CORRECTION;
@@ -161,10 +162,7 @@ void plan_arc(
   for (uint16_t i = 1; i < segments; i++) { // Iterate (segments-1) times
 
     thermalManager.manage_heater();
-    if (ELAPSED(millis(), next_idle_ms)) {
-      next_idle_ms = millis() + 200UL;
-      idle();
-    }
+    if (idle_timeout.advance()) idle();
 
     #if N_ARC_CORRECTION > 1
       if (--arc_recalc_count) {

--- a/Marlin/src/gcode/sdcard/M28_M29.cpp
+++ b/Marlin/src/gcode/sdcard/M28_M29.cpp
@@ -49,8 +49,7 @@ void GcodeSuite::M28() {
     // Binary transfer mode
     if ((card.flag.binary_mode = binary_mode)) {
       SERIAL_ECHO_START();
-      SERIAL_ECHO(" preparing to receive: ");
-      SERIAL_ECHOLN(p);
+      SERIAL_ECHOLNPAIR(" preparing to receive: ", p);
       card.openFile(p, false);
       #if NUM_SERIAL > 1
         card.transfer_port_index = command_queue_port[cmd_queue_index_r];

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -488,6 +488,12 @@
 #define ARRAY_BY_HOTENDS1(v1) ARRAY_BY_HOTENDS(v1, v1, v1, v1, v1, v1)
 
 /**
+ * ARRAY_BY_FANS based on FAN_COUNT
+ */
+#define ARRAY_BY_FANS(...) ARRAY_N(FAN_COUNT, __VA_ARGS__)
+#define ARRAY_BY_FANS1(v1) ARRAY_BY_FANS(v1, v1, v1, v1, v1, v1)
+
+/**
  * Driver Timings
  * NOTE: Driver timing order is longest-to-shortest duration.
  *       Preserve this ordering when adding new drivers.

--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -631,7 +631,7 @@ void MarlinUI::draw_status_message(const bool blink) {
   #elif BOTH(FILAMENT_LCD_DISPLAY, SDSUPPORT)
 
     // Alternate Status message and Filament display
-    if (ELAPSED(millis(), next_filament_display)) {
+    if (filament_display_timeout.elapsed()) {
       lcd_put_u8str_P(PSTR("Dia "));
       lcd_put_u8str(ftostr12ns(filament_width_meas));
       lcd_put_u8str_P(PSTR(" V"));

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -622,7 +622,7 @@ void MarlinUI::draw_status_screen() {
 
     #if BOTH(FILAMENT_LCD_DISPLAY, SDSUPPORT)
       // Alternate Status message and Filament display
-      if (ELAPSED(millis(), next_filament_display)) {
+      if (filament_display_timeout.elapsed()) {
         lcd_put_u8str_P(PSTR(LCD_STR_FILAM_DIA));
         lcd_put_wchar(':');
         lcd_put_u8str(wstring);

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -44,7 +44,9 @@
   #include "../../feature/bedlevel/bedlevel.h"
 #endif
 
-extern millis_t manual_move_start_time;
+#include "../../libs/timeout.h"
+extern Timeout manual_move_timeout;
+
 extern int8_t manual_move_axis;
 #if ENABLED(MANUAL_E_MOVES_RELATIVE)
   float manual_move_e_origin = 0;
@@ -64,7 +66,7 @@ inline void manual_move_to_current(AxisEnum axis
   #if E_MANUAL > 1
     if (axis == E_AXIS) ui.manual_move_e_index = eindex >= 0 ? eindex : active_extruder;
   #endif
-  manual_move_start_time = millis() + (move_menu_scale < 0.99f ? 0UL : 250UL); // delay for bigger moves
+  if (move_menu_scale >= 1.0f) manual_move_timeout.reset(); // delay for bigger moves
   manual_move_axis = (int8_t)axis;
 }
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "../inc/MarlinConfig.h"
+#include "../libs/timeout.h"
 
 #if HAS_BUZZER
   #include "../libs/buzzer.h"
@@ -289,7 +290,7 @@ public:
     static void abort_print();
     static void pause_print();
     static void resume_print();
-    
+
     #if HAS_PRINT_PROGRESS
       #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
         static uint8_t progress_bar_percent;
@@ -329,8 +330,8 @@ public:
           static millis_t progress_bar_ms;  // Start time for the current progress bar cycle
           static void draw_progress_bar(const uint8_t percent);
           #if PROGRESS_MSG_EXPIRE > 0
-            static millis_t MarlinUI::expire_status_ms; // = 0
-            static inline void reset_progress_bar_timeout() { expire_status_ms = 0; }
+            static Timeout MarlinUI::status_message_timeout; // = 0
+            static inline void reset_progress_bar_timeout() { status_message_timeout.stop(); }
           #endif
         #endif
 
@@ -345,7 +346,7 @@ public:
       #endif
 
       #if BOTH(FILAMENT_LCD_DISPLAY, SDSUPPORT)
-        static millis_t next_filament_display;
+        static Timeout filament_display_timeout;
       #endif
 
       static void quick_feedback(const bool clear_buttons=true);

--- a/Marlin/src/libs/timeout.h
+++ b/Marlin/src/libs/timeout.h
@@ -1,0 +1,52 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include <Arduino.h>            // for millis()
+#include "../core/millis_t.h"
+
+//
+// Timeout class for timed events
+//
+
+class Timeout {
+public:
+  millis_t dura, ms;
+  Timeout() /* dura(0), ms(0) */ {}
+  Timeout(const millis_t d, const bool pr=false) : dura(d) { if (pr) reset(); }
+  Timeout(const millis_t d, const millis_t now) : dura(d) { reset(now); }
+  void stop() { ms = 0; }
+  void reset(const millis_t now=millis()) { ms = dura ? now + dura : 0; }
+  void prime(const millis_t d, const millis_t now=millis()) { dura = d; reset(now); }
+  bool primed() { return !!ms; }
+  bool stopped() { return !ms; }
+  bool elapsed(const millis_t now=millis()) const { return ELAPSED(now, ms); }
+  bool pending(const millis_t now=millis()) const { return PENDING(now, ms); }
+  bool advance(const millis_t now=millis()) { const bool e = ELAPSED(now, ms); if (e) reset(); return e; }
+  bool primed_elapsed(const millis_t now=millis()) { return primed() && elapsed(now); }
+  bool primed_pending(const millis_t now=millis()) { return primed() && pending(now); }
+  bool primed_advance(const millis_t now=millis()) { return primed() && advance(now); }
+  bool once(const millis_t now=millis()) { const bool e = ms && ELAPSED(now, ms); if (e) stop(); return e; }
+  Timeout& operator=(const millis_t &d) { dura = d; return *this; }
+  operator millis_t() const { return ms; }
+  operator bool() const { return ms != 0; }
+};

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1237,17 +1237,17 @@ void Planner::check_axes_activity() {
 
     #if FAN_KICKSTART_TIME > 0
 
-      static millis_t fan_kick_end[FAN_COUNT] = { 0 };
+      static Timeout fan_kick_timeout[FAN_COUNT] = { 0 };
 
       #define KICKSTART_FAN(f) \
         if (tail_fan_speed[f]) { \
           millis_t ms = millis(); \
-          if (fan_kick_end[f] == 0) { \
-            fan_kick_end[f] = ms + FAN_KICKSTART_TIME; \
+          if (fan_kick_timeout[f].stopped()) { \
+            fan_kick_timeout[f].prime(FAN_KICKSTART_TIME); \
             tail_fan_speed[f] = 255; \
-          } else if (PENDING(ms, fan_kick_end[f])) \
+          } else if (fan_kick_timeout[f].pending(ms)) \
             tail_fan_speed[f] = 255; \
-        } else fan_kick_end[f] = 0
+        } else fan_kick_timeout[f].stop()
 
       #if HAS_FAN0
         KICKSTART_FAN(0);

--- a/Marlin/src/module/planner_bezier.cpp
+++ b/Marlin/src/module/planner_bezier.cpp
@@ -38,6 +38,7 @@
 #include "../Marlin.h"
 #include "../core/language.h"
 #include "../gcode/queue.h"
+#include "../libs/timeout.h"
 
 // See the meaning in the documentation of cubic_b_spline().
 #define MIN_STEP 0.002f
@@ -120,16 +121,12 @@ void cubic_b_spline(const float position[NUM_AXIS], const float target[NUM_AXIS]
   bez_target[Y_AXIS] = position[Y_AXIS];
   float step = MAX_STEP;
 
-  millis_t next_idle_ms = millis() + 200UL;
+  Timeout idle_timeout(200);
 
   while (t < 1) {
 
     thermalManager.manage_heater();
-    millis_t now = millis();
-    if (ELAPSED(now, next_idle_ms)) {
-      next_idle_ms = now + 200UL;
-      idle();
-    }
+    if (idle_timeout.advance()) idle();
 
     // First try to reduce the step in order to make it sufficiently
     // close to a linear interpolation.


### PR DESCRIPTION
Background: We currently use a `millis_t` variable and the `ELAPSED`/`PENDING` macros to test for event and action timeouts.

This PR adds a `Timeout` class to encapsulate the data and actions associated with timeouts and applies them where possible throughout the code-base.