### PR TITLE
[2.0.x] Allows users to home only after heating the nozzle

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1378,6 +1378,18 @@
 #define BUSY_WHILE_HEATING            // Some hosts require "busy" messages even during heating
 
 //
+// Option to heat before homing
+//
+
+//#define HEAT_BEFORE_HOME
+#ifdef HEAT_BEFORE_HOME
+  #define TEMP_BEFORE_HOME 80
+  #define STRINGIZE_NX(A) #A
+  #define STRINGIZE(A) STRINGIZE_NX(A)
+  #define HOMING_SCRIPT "M109 S"STRINGIZE(TEMP_BEFORE_HOME)"\nG28\nM109 S0"
+#endif
+
+//
 // M100 Free Memory Watcher
 //
 //#define M100_FREE_MEMORY_WATCHER    // Add M100 (Free Memory Watcher) to debug memory usage

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -435,7 +435,11 @@ void menu_motion() {
   //
   // Auto Home
   //
-  MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
+  #ifdef HEAT_BEFORE_HOME
+    MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR(HOMING_SCRIPT));
+    #else
+    MENU_ITEM(gcode, MSG_AUTO_HOME, PSTR("G28"));
+  #endif
   #if ENABLED(INDIVIDUAL_AXIS_HOMING_MENU)
     MENU_ITEM(gcode, MSG_AUTO_HOME_X, PSTR("G28 X"));
     MENU_ITEM(gcode, MSG_AUTO_HOME_Y, PSTR("G28 Y"));


### PR DESCRIPTION
### Requirements

* None

### Description

This change gives users the option to heat the nozzle to a temperature of their choosing before homing all axes. I saw an issue in which this feature was requested(#7680).
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
#7680

I always prefer to heat the nozzle before homing so that any residue left on the nozzle from previous prints doesn't interfere with bed leveling.
<!-- What does this fix or improve? -->

### Related Issues
#7680

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
