### PR TITLE
fix stm32f1  WRITE(IO,V) bug

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
@@ -30,7 +30,7 @@
 #include <libmaple/gpio.h>
 
 #define READ(IO)              (PIN_MAP[IO].gpio_device->regs->IDR & (1U << PIN_MAP[IO].gpio_bit) ? HIGH : LOW)
-#define WRITE(IO,V)           (PIN_MAP[IO].gpio_device->regs->BSRR = (1U << PIN_MAP[IO].gpio_bit) << (16 * !((bool)V)))
+#define WRITE(IO,V)           (PIN_MAP[IO].gpio_device->regs->BSRR = (1U << PIN_MAP[IO].gpio_bit) << ((V) ? 0 : 16))
 #define TOGGLE(IO)            (PIN_MAP[IO].gpio_device->regs->ODR = PIN_MAP[IO].gpio_device->regs->ODR ^ (1U << PIN_MAP[IO].gpio_bit))
 #define WRITE_VAR(IO,V)       WRITE(IO,V)
 


### PR DESCRIPTION
### Description
`#define WRITE(IO,V)           (PIN_MAP[IO].gpio_device->regs->BSRR = (1U << PIN_MAP[IO].gpio_bit) << (16 * !((bool)V)))`

if
```
uint8_t  a = 0xAA;
WRITE(pins, a & 0x80);
```
it will be replaced to
```
uint8_t  a = 0xAA;
(PIN_MAP[IO].gpio_device->regs->BSRR = (1U << PIN_MAP[IO].gpio_bit) << (16 * !((bool)a & 0x80)))
```
((bool)a & 0x80)) always equal to 0
This cause ST7920 software SPI MOSI pin output always 0
### Benefits

1. stm32f1 can use LCD12864 now

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
