### PR TITLE
STM32F1: C++14 instead of 2011 std for static_assert compat

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
+++ b/Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
@@ -9,7 +9,6 @@ if __name__ == "__main__":
                     "-mcpu=cortex-m3",
                     "-mthumb",
 
-                    "-ffreestanding",
                     "-fsigned-char",
                     "-fno-move-loop-invariants",
                     "-fno-strict-aliasing",

--- a/platformio.ini
+++ b/platformio.ini
@@ -258,7 +258,8 @@ platform      = ststm32
 framework     = arduino
 board         = genericSTM32F103RE
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
-  ${common.build_flags}
+  ${common.build_flags} -std=gnu++14
+build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
 lib_ignore    = U8glib-HAL
   c1921b4
@@ -268,7 +269,7 @@ lib_ignore    = U8glib-HAL
   Adafruit NeoPixel
   libf3e
   TMC26XStepper
-lib_ldf_mode  = 1
+#lib_ldf_mode  = 1
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed = 250000
 
@@ -281,8 +282,9 @@ framework     = arduino
 board         = genericSTM32F103RC
 extra_scripts = buildroot/share/PlatformIO/scripts/STM32F1_SKR_MINI.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
-  ${common.build_flags}
+  ${common.build_flags} -std=gnu++14
   -g
+build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
 lib_ignore    = U8glib-HAL
   c1921b4
@@ -292,7 +294,7 @@ lib_ignore    = U8glib-HAL
   Adafruit NeoPixel
   libf3e
   TMC26XStepper
-lib_ldf_mode  = 1
+#lib_ldf_mode  = 1
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed = 115200
 upload_protocol = stlink
@@ -328,13 +330,14 @@ monitor_speed = 250000
 # MKS Robin (STM32F103ZET6)
 #
 [env:mks_robin]
-platform      = ststm32@5.3.0
+platform      = ststm32
 framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
-  ${common.build_flags}
+  ${common.build_flags} -std=gnu++14
   -DSTM32_XL_DENSITY
+build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
 lib_ignore    = c1921b4


### PR DESCRIPTION
C++14 std is required for the constexpr FLOOR static_assert (with BL_TOUCH or others z-probes)

also remove -ffreestanding to allow to build with CUSTOM_USER_MENUS

and disable lib_ldf_mode which is not required at all...

Tested ok on the SKRmini and alfawise F1 boards