### PR TITLE
travis: update to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 sudo: require
 
 language: python


### PR DESCRIPTION
travis is using outdated ubuntu version 14.04 LTS, move to 16.04 LTS (5 years support)

bionic (18.04 LTS) doesn't include g++7 ppa
