### PR TITLE
lcd: start print confirm. workaround

### DIFF
--- a/Marlin/src/lcd/language/language_cz.h
+++ b/Marlin/src/lcd/language/language_cz.h
@@ -282,7 +282,7 @@
 #define MSG_WATCH                           _UxGT("Info obrazovka")
 #define MSG_PREPARE                         _UxGT("Připrava tisku")
 #define MSG_TUNE                            _UxGT("Doladění tisku")
-#define MSG_START_PRINT                     _UxGT("Spustit tisk")
+#define MSG_START_PRINT                     _UxGT("Spustit tisk")
 #define MSG_BUTTON_PRINT                    _UxGT("Tisk")
 #define MSG_BUTTON_CANCEL                   _UxGT("Zrušit")
 #define MSG_PAUSE_PRINT                     _UxGT("Pozastavit tisk")

--- a/Marlin/src/lcd/language/language_de.h
+++ b/Marlin/src/lcd/language/language_de.h
@@ -273,7 +273,7 @@
 #define MSG_WATCH                           _UxGT("Info")
 #define MSG_PREPARE                         _UxGT("Vorbereitung")
 #define MSG_TUNE                            _UxGT("Justierung")
-#define MSG_START_PRINT                     _UxGT("Starte Druck")
+#define MSG_START_PRINT                     _UxGT("Starte Druck")
 #define MSG_BUTTON_NEXT                     _UxGT("Weiter")
 #define MSG_BUTTON_INIT                     _UxGT("Init")
 #define MSG_BUTTON_STOP                     _UxGT("Stop")

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -760,7 +760,7 @@
   #define MSG_TUNE                            _UxGT("Tune")
 #endif
 #ifndef MSG_START_PRINT
-  #define MSG_START_PRINT                     _UxGT("Start print")
+  #define MSG_START_PRINT                     _UxGT("Start print")
 #endif
 #ifndef MSG_BUTTON_NEXT
   #define MSG_BUTTON_NEXT                     _UxGT("Next")

--- a/Marlin/src/lcd/language/language_fr.h
+++ b/Marlin/src/lcd/language/language_fr.h
@@ -276,7 +276,7 @@
 #define MSG_WATCH                           _UxGT("Surveiller")
 #define MSG_PREPARE                         _UxGT("Préparer")
 #define MSG_TUNE                            _UxGT("Régler")
-#define MSG_START_PRINT                     _UxGT("Démarrer impression")
+#define MSG_START_PRINT                     _UxGT("Démarrer impression")
 #define MSG_BUTTON_NEXT                     _UxGT("Suivant")
 #define MSG_BUTTON_INIT                     _UxGT("Init.")
 #define MSG_BUTTON_STOP                     _UxGT("Stop")

--- a/Marlin/src/lcd/language/language_it.h
+++ b/Marlin/src/lcd/language/language_it.h
@@ -273,7 +273,7 @@
 #define MSG_WATCH                           _UxGT("Schermata info")
 #define MSG_PREPARE                         _UxGT("Prepara")
 #define MSG_TUNE                            _UxGT("Regola")
-#define MSG_START_PRINT                     _UxGT("Avvia stampa")
+#define MSG_START_PRINT                     _UxGT("Avvia stampa")
 #define MSG_BUTTON_NEXT                     _UxGT("Prossimo")
 #define MSG_BUTTON_INIT                     _UxGT("Inizializza")
 #define MSG_BUTTON_STOP                     _UxGT("Stop")

--- a/Marlin/src/lcd/language/language_sk.h
+++ b/Marlin/src/lcd/language/language_sk.h
@@ -282,7 +282,7 @@
 #define MSG_WATCH                           _UxGT("Info. obrazovka")
 #define MSG_PREPARE                         _UxGT("Príprava tlače")
 #define MSG_TUNE                            _UxGT("Doladenie tlače")
-#define MSG_START_PRINT                     _UxGT("Spustiť tlač")
+#define MSG_START_PRINT                     _UxGT("Spustiť tlač")
 #define MSG_BUTTON_NEXT                     _UxGT("Ďalší")
 #define MSG_BUTTON_INIT                     _UxGT("Inicial.")
 #define MSG_BUTTON_STOP                     _UxGT("Zastaviť")

--- a/Marlin/src/lcd/menu/menu_sdcard.cpp
+++ b/Marlin/src/lcd/menu/menu_sdcard.cpp
@@ -85,7 +85,7 @@ inline void sdcard_start_selected_file() {
     do_select_screen(
       PSTR(MSG_BUTTON_PRINT), PSTR(MSG_BUTTON_CANCEL),
       sdcard_start_selected_file, ui.goto_previous_screen,
-      PSTR(MSG_START_PRINT " "), card.longest_filename(), PSTR("?")
+      PSTR(MSG_START_PRINT " "), card.longest_filename(), PSTR("?")
     );
   }
 


### PR DESCRIPTION
the space character in this menu corrupt the display on various
implementations...

Using a "&nbsp;" (ALT+0160) fixes it...
