### PR TITLE
STM32F1: Don't toggle EEPROM SPI SS

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
@@ -162,17 +162,17 @@ void spiSendBlock(uint8_t token, const uint8_t* buf) {
   WRITE(SS_PIN, HIGH);
 }
 
-#if ENABLED(SPI_EEPROM)
+#if ENABLED(SPI_EEPROM) || MB(ALLIGATOR) /* DAC SPI */
 
 // Read single byte from specified SPI channel
-uint8_t spiRec(uint32_t chan) { return spiRec(); }
+uint8_t spiRec(uint32_t chan) { return SPI.transfer(ff); }
 
 // Write single byte to specified SPI channel
-void spiSend(uint32_t chan, byte b) { spiSend(b); }
+void spiSend(uint32_t chan, byte b) { SPI.send(b); }
 
 // Write buffer to specified SPI channel
 void spiSend(uint32_t chan, const uint8_t* buf, size_t n) {
-  for (size_t p = 0; p < n; p++) spiSend(buf[p]);
+  for (size_t p = 0; p < n; p++) spiSend(chan, buf[p]);
 }
 
 #endif // SPI_EEPROM

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
@@ -162,7 +162,7 @@ void spiSendBlock(uint8_t token, const uint8_t* buf) {
   WRITE(SS_PIN, HIGH);
 }
 
-#if ENABLED(SPI_EEPROM) || MB(ALLIGATOR) /* DAC SPI */
+#if ENABLED(SPI_EEPROM)
 
 // Read single byte from specified SPI channel
 uint8_t spiRec(uint32_t chan) { return SPI.transfer(ff); }


### PR DESCRIPTION
The "simplified" HAL spiSend is only used for sdcard in Marlin

But some extended version of the function is also used from the SPI EEPROM and from a DAC with an extra channel parameter. For those, the "Slave Select" SS pin is already handled in their functions as "CS" or "DAC_SYNC". this DAC is specific to a SAM3X board, so... unhandled for now