### PR TITLE
Disable Linear Advance for Artillery Sidewinder X1

### DIFF
--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -1193,10 +1193,10 @@
  * See http://marlinfw.org/docs/features/lin_advance.html for full instructions.
  * Mention @Sebastianv650 on GitHub to alert the author of any issues.
  */
-#define LIN_ADVANCE
+//#define LIN_ADVANCE
 #if ENABLED(LIN_ADVANCE)
   //#define EXTRA_LIN_ADVANCE_K // Enable for second linear advance constants
-  #define LIN_ADVANCE_K 0.0    // Unit: mm compression per 1mm/s extruder speed
+  #define LIN_ADVANCE_K 0.22    // Unit: mm compression per 1mm/s extruder speed
   //#define LA_DEBUG            // If enabled, this will generate debug information output over USB.
 #endif
 


### PR DESCRIPTION
### Description

Disables Linear Advance for the Artillery Sidewinder X1 config.

### Benefits

After further testing, Linear Advance does not work properly with Artillery's cloned TMC2100 drivers and Marlin 2.0, even with `SQUARE_WAVE_STEPPING` enabled.
