### PR TITLE
STM32F1: various small changes

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
@@ -45,8 +45,7 @@
 
 #define __I
 #define __IO volatile
- typedef struct
- {
+ typedef struct {
    __I  uint32_t CPUID;                   /*!< Offset: 0x000 (R/ )  CPUID Base Register                                   */
    __IO uint32_t ICSR;                    /*!< Offset: 0x004 (R/W)  Interrupt Control and State Register                  */
    __IO uint32_t VTOR;                    /*!< Offset: 0x008 (R/W)  Vector Table Offset Register                          */
@@ -161,11 +160,10 @@ enum TEMP_PINS : char {
   #if ENABLED(FILAMENT_WIDTH_SENSOR)
     FILWIDTH,
   #endif
-    ADC_PIN_COUNT
+  ADC_PIN_COUNT
 };
 
 uint16_t HAL_adc_results[ADC_PIN_COUNT];
-
 
 // --------------------------------------------------------------------------
 // Function prototypes
@@ -209,6 +207,9 @@ static void NVIC_SetPriorityGrouping(uint32_t PriorityGroup) {
 
 void HAL_init(void) {
   NVIC_SetPriorityGrouping(0x3);
+  #if PIN_EXISTS(LED)
+    OUT_WRITE(LED_PIN, LOW);
+  #endif
 }
 
 /* VGPV Done with defines

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_sdio_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_sdio_STM32F1.cpp
@@ -40,7 +40,7 @@ bool SDIO_Init(void) {
 
   dma_init(SDIO_DMA_DEV);
   dma_disable(SDIO_DMA_DEV, SDIO_DMA_CHANNEL);
-  dma_set_priority(SDIO_DMA_DEV, SDIO_DMA_CHANNEL, DMA_PRIORITY_VERY_HIGH);
+  dma_set_priority(SDIO_DMA_DEV, SDIO_DMA_CHANNEL, DMA_PRIORITY_MEDIUM);
 
   if (!SDIO_CmdGoIdleState()) return false;
   if (!SDIO_CmdGoIdleState()) return false; /* Hotplugged cards tends to miss first CMD0, so give them a second chance. */

--- a/Marlin/src/HAL/HAL_STM32F1/u8g_com_stm32duino_fsmc.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/u8g_com_stm32duino_fsmc.cpp
@@ -45,7 +45,7 @@
 
 void LCD_IO_Init(uint8_t cs, uint8_t rs);
 void LCD_IO_WriteData(uint16_t RegValue);
-void LCD_IO_WriteReg(uint8_t Reg);
+void LCD_IO_WriteReg(uint16_t Reg);
 uint32_t LCD_IO_ReadData(uint16_t RegValue, uint8_t ReadSize);
 
 static uint8_t msgInitCount = 2; // Ignore all messages until 2nd U8G_COM_MSG_INIT
@@ -250,8 +250,8 @@ void LCD_IO_WriteData(uint16_t RegValue) {
   __DSB();
 }
 
-void LCD_IO_WriteReg(uint8_t Reg) {
-  LCD->REG = (uint16_t)Reg;
+void LCD_IO_WriteReg(uint16_t Reg) {
+  LCD->REG = Reg;
   __DSB();
 }
 

--- a/Marlin/src/HAL/HAL_STM32F1/watchdog_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/watchdog_STM32F1.cpp
@@ -34,7 +34,7 @@
 #include "watchdog_STM32F1.h"
 
 void watchdog_reset() {
-  #if PIN_EXISTS(LED)
+  #if DISABLED(PINS_DEBUGGING) && PIN_EXISTS(LED)
     TOGGLE(LED_PIN);  // heartbeat indicator
   #endif
   iwdg_feed();

--- a/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
+++ b/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
@@ -51,7 +51,7 @@
   uint8_t u8g_com_HAL_LPC1768_ssd_hw_i2c_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
   #define U8G_COM_SSD_I2C_HAL u8g_com_arduino_ssd_i2c_fn
 
-  #ifdef ARDUINO_ARCH_STM32F1
+  #if defined(ARDUINO_ARCH_STM32F1) && PIN_EXISTS(FSMC_CS)
     uint8_t u8g_com_stm32duino_fsmc_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_FSMC_FN u8g_com_stm32duino_fsmc_fn
   #else


### PR DESCRIPTION
- init the led pin as output (like other HALs)
- reduce sdio dma priority to normal.. highest is never the best...
- allow fsmc only on compatible STM32F1 (like HAL fsmc)
- fsmc: remove an useless C style cast

safe part of M43 commit... all tested on my repo