### PR TITLE
G34 configurable angle limit

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -125,10 +125,7 @@ void GcodeSuite::G34() {
       #define Z_BASIC_CLEARANCE Z_CLEARANCE_BETWEEN_PROBES
     #endif
 
-    // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-    // This angle is the maximum misalignment catered for
-    #define MAX_ANGLE 0.05f
-    float z_probe = Z_BASIC_CLEARANCE + MAX_ANGLE * (
+    float z_probe = Z_BASIC_CLEARANCE + G34_MAX_INCLINE_PERCENT * (
       #if ENABLED(Z_TRIPLE_STEPPER_DRIVERS)
          SQRT(MAX(HYPOT2(z_auto_align_xpos[0] - z_auto_align_ypos[0], z_auto_align_xpos[1] - z_auto_align_ypos[1]),
                   HYPOT2(z_auto_align_xpos[1] - z_auto_align_ypos[1], z_auto_align_xpos[2] - z_auto_align_ypos[2]),

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -125,7 +125,7 @@ void GcodeSuite::G34() {
       #define Z_BASIC_CLEARANCE Z_CLEARANCE_BETWEEN_PROBES
     #endif
 
-    float z_probe = Z_BASIC_CLEARANCE + G34_MAX_INCLINE_PERCENT * (
+    float z_probe = Z_BASIC_CLEARANCE + (G34_MAX_GRADE) * 0.01f * (
       #if ENABLED(Z_TRIPLE_STEPPER_DRIVERS)
          SQRT(MAX(HYPOT2(z_auto_align_xpos[0] - z_auto_align_ypos[0], z_auto_align_xpos[1] - z_auto_align_ypos[1]),
                   HYPOT2(z_auto_align_xpos[1] - z_auto_align_ypos[1], z_auto_align_xpos[2] - z_auto_align_ypos[2]),
@@ -157,7 +157,7 @@ void GcodeSuite::G34() {
       float z_measured_min = 100000.0f;
       // Probe all positions (one per Z-Stepper)
       for (uint8_t izstepper = 0; izstepper < Z_STEPPER_COUNT; ++izstepper) {
-        // iteration odd/even --> downward / upward stepper sequence 
+        // iteration odd/even --> downward / upward stepper sequence
         const uint8_t zstepper = (iteration & 1) ? Z_STEPPER_COUNT - 1 - izstepper : izstepper;
 
         // Safe clearance even on an incline

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -608,6 +608,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -608,11 +608,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Felix/Configuration_adv.h
+++ b/config/examples/Felix/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Felix/Configuration_adv.h
+++ b/config/examples/Felix/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -608,6 +608,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -608,11 +608,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -608,6 +608,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -608,11 +608,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -609,11 +609,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -609,6 +609,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -609,11 +609,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -609,6 +609,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -617,6 +617,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -617,11 +617,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -604,11 +604,10 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
-  
-  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
-  // This angle is the maximum misalignment catered for
-  #define G34_MAX_INCLINE_PERCENT 0.05f
-  
+
+  // On a 300mm bed a 5% grade would give a misalignment of ~1.5cm
+  #define G34_MAX_GRADE  5  // (%) Maximum incline G34 will handle
+
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -604,6 +604,11 @@
   #define Z_STEPPER_ALIGN_ITERATIONS 3
   // Enable to restore leveling setup after operation
   #define RESTORE_LEVELING_AFTER_G34
+  
+  // 0.05 is a 5% incline. On a 300mm bed that would be a misalignment of about 1.5cm.
+  // This angle is the maximum misalignment catered for
+  #define G34_MAX_INCLINE_PERCENT 0.05f
+  
   // Use the amplification factor to de-/increase correction step.
   // In case the stepper (spindle) position is further out than the test point
   // Use a value > 1. NOTE: This may cause instability


### PR DESCRIPTION
Allows configuration of Angle Limit on G34 as some users may wish to allow a larger deviation to be corrected for automatically depending on size and mechanics of machine.