### PR TITLE
Add TMCStepper libs to lib_ignore for Melzi

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -197,6 +197,7 @@ board         = sanguino_atmega1284p
 build_flags   = ${common.build_flags}
 upload_speed  = 57600
 lib_deps      = ${common.lib_deps}
+lib_ignore    = TMCStepper, TMC26XStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
 monitor_speed = 250000
 
@@ -210,6 +211,7 @@ board         = sanguino_atmega1284p
 build_flags   = ${common.build_flags}
 upload_speed  = 115200
 lib_deps      = ${common.lib_deps}
+lib_ignore    = TMCStepper, TMC26XStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
 monitor_speed = 250000
 


### PR DESCRIPTION
Melzi builds fail on SoftwareSerial.h from TMCStepper when to my knowledge no melzi board supports uart or SPI comms to a TMC driver and therefore should not include the library.