### PR TITLE
'M105 R' to report redundant temp sensor

### DIFF
--- a/Marlin/src/gcode/temperature/M105.cpp
+++ b/Marlin/src/gcode/temperature/M105.cpp
@@ -33,7 +33,11 @@ void GcodeSuite::M105() {
 
   #if HAS_TEMP_SENSOR
     SERIAL_ECHOPGM(MSG_OK);
-    thermalManager.print_heater_states(target_extruder);
+    thermalManager.print_heater_states(target_extruder
+      #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+        , parser.boolval('R')
+      #endif
+    );
   #else // !HAS_TEMP_SENSOR
     SERIAL_ERROR_MSG(MSG_ERR_NO_THERMISTORS);
   #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2284,3 +2284,11 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
     #error "MIN_ and MAX_SOFTWARE_ENDSTOPS are both required with offset hotends."
   #endif
 #endif
+
+#if ENABLED(AUTO_POWER_CONTROL)
+  #if ENABLED(AUTO_POWER_E_TEMP) && !defined(EXTRUDER_AUTO_FAN_TEMPERATURE)
+    #error "EXTRUDER_AUTO_FAN_TEMPERATURE is required for AUTO_POWER_E_TEMP."
+  #elif ENABLED(AUTO_POWER_CHAMBER_TEMP) && !defined(CHAMBER_AUTO_FAN_TEMPERATURE)
+    #error "CHAMBER_AUTO_FAN_TEMPERATURE is required for AUTO_POWER_CHAMBER_TEMP."
+  #endif
+#endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2284,11 +2284,3 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
     #error "MIN_ and MAX_SOFTWARE_ENDSTOPS are both required with offset hotends."
   #endif
 #endif
-
-#if ENABLED(AUTO_POWER_CONTROL)
-  #if ENABLED(AUTO_POWER_E_TEMP) && !defined(EXTRUDER_AUTO_FAN_TEMPERATURE)
-    #error "EXTRUDER_AUTO_FAN_TEMPERATURE is required for AUTO_POWER_E_TEMP."
-  #elif ENABLED(AUTO_POWER_CHAMBER_TEMP) && !defined(CHAMBER_AUTO_FAN_TEMPERATURE)
-    #error "CHAMBER_AUTO_FAN_TEMPERATURE is required for AUTO_POWER_CHAMBER_TEMP."
-  #endif
-#endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -112,7 +112,11 @@ Temperature thermalManager;
   bool Temperature::adaptive_fan_slowing = true;
 #endif
 
-hotend_info_t Temperature::temp_hotend[HOTENDS]; // = { 0 }
+hotend_info_t Temperature::temp_hotend[HOTENDS
+  #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+    + 1
+  #endif
+]; // = { 0 }
 
 #if ENABLED(AUTO_POWER_E_FANS)
   uint8_t Temperature::autofan_speed[HOTENDS]; // = { 0 }
@@ -2773,22 +2777,27 @@ void Temperature::isr() {
     #endif
     , const int8_t e=-3
   ) {
-    #if !(HAS_HEATED_BED && HAS_TEMP_HOTEND && HAS_TEMP_CHAMBER) && HOTENDS <= 1
-      UNUSED(e);
-    #endif
-
-    SERIAL_CHAR(' ');
-    SERIAL_CHAR(
-      #if HAS_TEMP_CHAMBER && HAS_HEATED_BED && HAS_TEMP_HOTEND
-        e == -2 ? 'C' : e == -1 ? 'B' : 'T'
-      #elif HAS_HEATED_BED && HAS_TEMP_HOTEND
-        e == -1 ? 'B' : 'T'
-      #elif HAS_TEMP_HOTEND
-        'T'
-      #else
-        'B'
+    char k;
+    switch (e) {
+      #if HAS_TEMP_CHAMBER
+        case -2: k = 'C'; break;
       #endif
-    );
+      #if HAS_TEMP_HOTEND
+        default: k = 'T'; break;
+        #if HAS_HEATED_BED
+          case -1: k = 'B'; break;
+        #endif
+        #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+          case -3: k = 'R'; break;
+        #endif
+      #elif HAS_HEATED_BED
+        default: k = 'B'; break;
+      #else
+        default: break;
+      #endif
+    }
+    SERIAL_CHAR(' ');
+    SERIAL_CHAR(k);
     #if HOTENDS > 1
       if (e >= 0) SERIAL_CHAR('0' + e);
     #endif
@@ -2796,19 +2805,31 @@ void Temperature::isr() {
     SERIAL_ECHO(c);
     SERIAL_ECHOPAIR(" /" , t);
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
-      SERIAL_ECHOPAIR(" (", r / OVERSAMPLENR);
+      SERIAL_ECHOPAIR(" (", r * RECIPROCAL(OVERSAMPLENR));
       SERIAL_CHAR(')');
     #endif
     delay(2);
   }
 
-  void Temperature::print_heater_states(const uint8_t target_extruder) {
+  void Temperature::print_heater_states(const uint8_t target_extruder
+    #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+      , const bool include_r/*=false*/
+    #endif
+  ) {
     #if HAS_TEMP_HOTEND
       print_heater_state(degHotend(target_extruder), degTargetHotend(target_extruder)
         #if ENABLED(SHOW_TEMP_ADC_VALUES)
           , rawHotendTemp(target_extruder)
         #endif
       );
+      #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+        if (include_r) print_heater_state(redundant_temperature, degTargetHotend(target_extruder)
+          #if ENABLED(SHOW_TEMP_ADC_VALUES)
+            , redundant_temperature_raw
+          #endif
+          , -3 // REDUNDANT
+        );
+      #endif
     #endif
     #if HAS_HEATED_BED
       print_heater_state(degBed(), degTargetBed()

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2792,8 +2792,6 @@ void Temperature::isr() {
         #endif
       #elif HAS_HEATED_BED
         default: k = 'B'; break;
-      #else
-        default: break;
       #endif
     }
     SERIAL_CHAR(' ');

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -756,7 +756,11 @@ class Temperature {
     #endif // HEATER_IDLE_HANDLER
 
     #if HAS_TEMP_SENSOR
-      static void print_heater_states(const uint8_t target_extruder);
+      static void print_heater_states(const uint8_t target_extruder
+        #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
+          , const bool include_r=false
+        #endif
+      );
       #if ENABLED(AUTO_REPORT_TEMPERATURES)
         static uint8_t auto_report_temp_interval;
         static millis_t next_temp_report_ms;


### PR DESCRIPTION
### Description
When configuring redundant temp sensor, halts immediately. Temp_0 and Temp1 different. 
Changes:
1. Temp_hotend array in temperature.h and temperature.cpp are sized by number of HOTENDS, this array needs +1 when redundant temp sensor is used.
2. temp_hotend[1].acc = 0 is needed in readings_ready when using redundant temp to reset adc accumulator for redundant sensor
3. Updated print_heater_state and print_heater_states to display redundant temp sensor values

### Benefits
First 2 changes fix the halt issue, 3rd change displays the redundant sensor readings, helps find redundant temperature sensor issues.

### Related Issues
I entered Issue  #14305 for this bug
