### PR TITLE
Add Extra Probing option, discarding outliers

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -510,6 +510,9 @@
   #if ENABLED(Z_PROBE_ALLEN_KEY)
     #define PROBE_TRIGGERED_WHEN_STOWED_TEST // Extra test for Allen Key Probe
   #endif
+  #if MULTIPLE_PROBING < 3
+    #undef PROBING_OUTLIERS_REMOVED
+  #endif
 #else
   // Clear probe pin settings when no probe is selected
   #undef Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -504,21 +504,24 @@
 
 #if HAS_BED_PROBE
   #define USES_Z_MIN_PROBE_ENDSTOP DISABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+  #define HOMING_Z_WITH_PROBE      (Z_HOME_DIR < 0 && !USES_Z_MIN_PROBE_ENDSTOP)
   #ifndef Z_PROBE_LOW_POINT
     #define Z_PROBE_LOW_POINT -5
   #endif
   #if ENABLED(Z_PROBE_ALLEN_KEY)
     #define PROBE_TRIGGERED_WHEN_STOWED_TEST // Extra test for Allen Key Probe
   #endif
-  #if MULTIPLE_PROBING < 3
-    #undef PROBING_OUTLIERS_REMOVED
+  #ifdef MULTIPLE_PROBING
+    #if EXTRA_PROBING
+      #define TOTAL_PROBING (MULTIPLE_PROBING + EXTRA_PROBING)
+    #else
+      #define TOTAL_PROBING MULTIPLE_PROBING
+    #endif
   #endif
 #else
   // Clear probe pin settings when no probe is selected
   #undef Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
 #endif
-
-#define HOMING_Z_WITH_PROBE (HAS_BED_PROBE && Z_HOME_DIR < 0 && ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN))
 
 #ifdef GRID_MAX_POINTS_X
   #define GRID_MAX_POINTS ((GRID_MAX_POINTS_X) * (GRID_MAX_POINTS_Y))

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1104,16 +1104,12 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #error "Probes need Z_AFTER_PROBING >= 0."
   #endif
 
-  #if MULTIPLE_PROBING && MULTIPLE_PROBING < 2
-    #error "MULTIPLE_PROBING must be >= 2."
-  #endif
-
-  #if PROBING_OUTLIERS_REMOVED && MULTIPLE_PROBING < 3
-    #error "If using PROBING_OUTLIERS_REMOVED, MULTIPLE_PROBING must be >= 3."
-  #endif
-
-  #if PROBING_OUTLIERS_REMOVED >= MULTIPLE_PROBING
-    #error "MULTIPLE_PROBING must be > PROBING_OUTLIERS_REMOVED."
+  #if MULTIPLE_PROBING
+    #if MULTIPLE_PROBING < 2
+      #error "MULTIPLE_PROBING must be >= 2."
+    #elif PROBING_OUTLIERS_REMOVED >= MULTIPLE_PROBING
+      #error "PROBING_OUTLIERS_REMOVED must be smaller than MULTIPLE_PROBING."
+    #endif
   #endif
 
   #if Z_PROBE_LOW_POINT > 0

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1108,6 +1108,14 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #error "MULTIPLE_PROBING must be >= 2."
   #endif
 
+  #if PROBING_OUTLIERS_REMOVED && MULTIPLE_PROBING < 3
+    #error "If using PROBING_OUTLIERS_REMOVED, MULTIPLE_PROBING must be >= 3."
+  #endif
+
+  #if PROBING_OUTLIERS_REMOVED >= MULTIPLE_PROBING
+    #error "MULTIPLE_PROBING must be > PROBING_OUTLIERS_REMOVED."
+  #endif
+
   #if Z_PROBE_LOW_POINT > 0
     #error "Z_PROBE_LOW_POINT must be less than or equal to 0."
   #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1104,11 +1104,13 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #error "Probes need Z_AFTER_PROBING >= 0."
   #endif
 
-  #if MULTIPLE_PROBING
-    #if MULTIPLE_PROBING < 2
-      #error "MULTIPLE_PROBING must be >= 2."
-    #elif PROBING_OUTLIERS_REMOVED >= MULTIPLE_PROBING
-      #error "PROBING_OUTLIERS_REMOVED must be smaller than MULTIPLE_PROBING."
+  #if MULTIPLE_PROBING || EXTRA_PROBING
+    #if !MULTIPLE_PROBING
+      #error "EXTRA_PROBING requires MULTIPLE_PROBING."
+    #elif MULTIPLE_PROBING < 2
+      #error "MULTIPLE_PROBING must be 2 or more."
+    #elif MULTIPLE_PROBING <= EXTRA_PROBING
+      #error "EXTRA_PROBING must be less than MULTIPLE_PROBING."
     #endif
   #endif
 

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -908,11 +908,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -909,6 +909,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -904,13 +904,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -923,6 +923,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -918,13 +918,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -922,11 +922,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -913,11 +913,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -909,13 +909,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -914,6 +914,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 //#define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 //#define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -971,6 +971,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -967,13 +967,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 3)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -916,6 +916,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -911,13 +911,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -915,11 +915,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -913,11 +913,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -909,13 +909,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -914,6 +914,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -910,13 +910,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -915,6 +915,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -914,11 +914,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -912,11 +912,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -913,6 +913,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -908,13 +908,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -899,13 +899,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -904,6 +904,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -903,11 +903,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -890,11 +890,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -891,6 +891,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -886,13 +886,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -899,13 +899,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -904,6 +904,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -903,11 +903,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -890,11 +890,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -891,6 +891,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -886,13 +886,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -901,11 +901,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -902,6 +902,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -897,13 +897,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -912,11 +912,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -913,6 +913,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -908,13 +908,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -899,13 +899,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -904,6 +904,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -903,11 +903,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -917,13 +917,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -921,11 +921,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -922,6 +922,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -912,11 +912,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -913,6 +913,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -908,13 +908,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -902,13 +902,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -906,11 +906,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -907,6 +907,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -902,13 +902,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -906,11 +906,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -907,6 +907,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -912,11 +912,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -913,6 +913,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -908,13 +908,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Dagoma/Disco Ultimate/Configuration.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration.h
@@ -902,6 +902,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Dagoma/Disco Ultimate/Configuration.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
@@ -908,6 +908,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
@@ -907,11 +907,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
@@ -903,13 +903,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -912,11 +912,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -913,6 +913,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -908,13 +908,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -885,6 +885,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -884,11 +884,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -880,13 +880,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -885,6 +885,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -884,11 +884,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -880,13 +880,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -890,13 +890,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -894,11 +894,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -895,6 +895,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -908,11 +908,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -909,6 +909,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -904,13 +904,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -979,13 +979,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -983,6 +983,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -927,13 +927,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -932,6 +932,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -931,11 +931,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -914,13 +914,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -918,11 +918,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -919,6 +919,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Geeetech/A10/Configuration.h
+++ b/config/examples/Geeetech/A10/Configuration.h
@@ -881,13 +881,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/A10/Configuration.h
+++ b/config/examples/Geeetech/A10/Configuration.h
@@ -885,6 +885,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -881,13 +881,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -885,6 +885,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -881,13 +881,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -885,6 +885,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -917,11 +917,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -918,6 +918,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -913,13 +913,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -910,6 +910,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -909,11 +909,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -905,13 +905,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -919,10 +919,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 3
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -923,6 +923,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -918,13 +918,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -922,11 +922,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -902,13 +902,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -906,11 +906,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -907,6 +907,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/JGAurora/A1/Configuration.h
+++ b/config/examples/JGAurora/A1/Configuration.h
@@ -904,11 +904,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/JGAurora/A1/Configuration.h
+++ b/config/examples/JGAurora/A1/Configuration.h
@@ -900,13 +900,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/JGAurora/A1/Configuration.h
+++ b/config/examples/JGAurora/A1/Configuration.h
@@ -905,6 +905,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -910,13 +910,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -915,6 +915,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -914,11 +914,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/JGAurora/A5S/Configuration.h
+++ b/config/examples/JGAurora/A5S/Configuration.h
@@ -904,11 +904,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/JGAurora/A5S/Configuration.h
+++ b/config/examples/JGAurora/A5S/Configuration.h
@@ -900,13 +900,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/JGAurora/A5S/Configuration.h
+++ b/config/examples/JGAurora/A5S/Configuration.h
@@ -905,6 +905,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -923,6 +923,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -918,13 +918,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -922,11 +922,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -922,13 +922,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 //#define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -927,6 +927,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -926,11 +926,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -901,11 +901,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -902,6 +902,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -897,13 +897,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -902,13 +902,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -906,11 +906,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -907,6 +907,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -902,13 +902,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -906,6 +906,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -899,13 +899,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -904,6 +904,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -903,11 +903,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -910,11 +910,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -906,13 +906,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -911,6 +911,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -943,6 +943,12 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -938,13 +938,17 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -942,11 +942,8 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -900,11 +900,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -896,13 +896,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -901,6 +901,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -916,6 +916,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -911,13 +911,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -915,11 +915,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -904,11 +904,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -900,13 +900,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -905,6 +905,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -904,11 +904,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -900,13 +900,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -905,6 +905,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -934,6 +934,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -933,11 +933,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -929,13 +929,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -902,6 +902,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -954,6 +954,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -953,11 +953,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -949,13 +949,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -902,6 +902,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -924,6 +924,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -919,13 +919,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -923,11 +923,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -913,11 +913,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -909,13 +909,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -914,6 +914,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -911,11 +911,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -907,13 +907,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -912,6 +912,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -927,13 +927,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -932,6 +932,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -931,11 +931,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -917,13 +917,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -921,11 +921,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -922,6 +922,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -912,11 +912,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -913,6 +913,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -908,13 +908,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -902,11 +902,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -903,6 +903,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -898,13 +898,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -1084,10 +1084,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 3)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 3
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1030,11 +1030,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1026,13 +1026,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST) / 6
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1031,6 +1031,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1029,11 +1029,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1025,13 +1025,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST) / 6
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1030,6 +1030,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -1029,6 +1029,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -1025,13 +1025,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -1017,11 +1017,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -1013,13 +1013,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -1018,6 +1018,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -1028,13 +1028,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 4)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 #define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -1032,6 +1032,9 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 #define MULTIPLE_PROBING 2
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
+#endif
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -1017,11 +1017,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -1013,13 +1013,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -1018,6 +1018,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -1017,13 +1017,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -1022,6 +1022,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -1021,11 +1021,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -1017,11 +1017,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -1013,13 +1013,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -1018,6 +1018,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -1015,13 +1015,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -1019,11 +1019,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -1020,6 +1020,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -1015,13 +1015,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -1019,11 +1019,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -1020,6 +1020,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -1020,11 +1020,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -1021,6 +1021,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -1016,13 +1016,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -916,6 +916,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -911,13 +911,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -915,11 +915,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -906,6 +906,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -901,13 +901,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -905,11 +905,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -897,11 +897,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -898,6 +898,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -893,13 +893,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -908,6 +908,12 @@
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
 
+// If multiple probing is used, removes the n samples with largest deviation from the
+// median and averages over the remaining samples to yield the result.
+#ifdef MULTIPLE_PROBING
+  #define PROBING_OUTLIERS_REMOVED 0
+#endif
+
 /**
  * Z probes require clearance when deploying, stowing, and moving between
  * probe points to avoid hitting the bed and other hardware.

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -907,11 +907,8 @@
 //   Set to 2 for a fast/slow probe, using the second probe result.
 //   Set to 3 or more for slow probes, averaging the results.
 //#define MULTIPLE_PROBING 2
-
-// If multiple probing is used, removes the n samples with largest deviation from the
-// median and averages over the remaining samples to yield the result.
-#ifdef MULTIPLE_PROBING
-  #define PROBING_OUTLIERS_REMOVED 0
+#if MULTIPLE_PROBING > 2
+  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
 #endif
 
 /**

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -903,13 +903,17 @@
 // Feedrate (mm/m) for the "accurate" probe of each point
 #define Z_PROBE_SPEED_SLOW (Z_PROBE_SPEED_FAST / 2)
 
-// The number of probes to perform at each point.
-//   Set to 2 for a fast/slow probe, using the second probe result.
-//   Set to 3 or more for slow probes, averaging the results.
+/**
+ * Multiple Probing
+ *
+ * You may get improved results by probing 2 or more times.
+ * With EXTRA_PROBING the more atypical reading(s) will be disregarded.
+ *
+ * A total of 2 does fast/slow probes with a weighted average.
+ * A total of 3 or more adds more slow probes, taking the average.
+ */
 //#define MULTIPLE_PROBING 2
-#if MULTIPLE_PROBING > 2
-  //#define PROBING_OUTLIERS_REMOVED 1  // Remove this number of atypical readings
-#endif
+//#define EXTRA_PROBING    1
 
 /**
  * Z probes require clearance when deploying, stowing, and moving between


### PR DESCRIPTION
### Description

Currently, when MULTIPLE_PROBING is used for the Z-Probe to increase accuracy, all the probe points are simply averaged. If a probe is unreliable and produces outliers from time to time, they still may affect the average considerably. The current change computes the median of values and allows to discard n values that deviate the most from the median, and average over the remaining probing values.

### Benefits

Improves accuracy of Z-Probing.

### Related Issues

None
