### PR TITLE
STM32: Fix Marduino SBI/CBI redefine (HAL_STM32)

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -28,6 +28,7 @@
 // Includes
 // --------------------------------------------------------------------------
 
+#include "../../core/macros.h"
 #include "../shared/Marduino.h"
 #include "../shared/math_32bit.h"
 #include "../shared/HAL_SPI.h"


### PR DESCRIPTION
### Description

Since the shared include "Marduino.h", there are new warnings about redefined macros.

Force the core/macros.h to be included first (ref #13912, but this one is for HAL_STM32).
### Benefits

Less compiler warnings.

### Related Issues

#13912 
