### PR TITLE
HAL_STM32: Fix UNUSED redefine

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -57,7 +57,11 @@
 
 // Remove compiler warning on an unused variable
 #ifndef UNUSED
-  #define UNUSED(x) ((void)(x))
+  #if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+    #define UNUSED(X) (void)X
+  #else
+    #define UNUSED(x) ((void)(x))
+  #endif
 #endif
 
 // Macros to make a string from a macro


### PR DESCRIPTION
### Description

Since #14236, when building for HAL_STM32, there are a lot of warnings for "UNUSED" redefined.

### Benefits

Less warnings.

### Related Issues

#14236 
