### PR TITLE
Include SOLENOID_PROBE in leveling report

### DIFF
--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -72,6 +72,8 @@ void safe_delay(millis_t ms) {
         "Z_PROBE_SLED"
       #elif ENABLED(Z_PROBE_ALLEN_KEY)
         "Z_PROBE_ALLEN_KEY"
+      #elif ENABLED(SOLENOID_PROBE)
+        "SOLENOID_PROBE"
       #else
         "NONE"
       #endif


### PR DESCRIPTION
### Description

When performing a G34 command with bed level debugging enable, the report displayed "Probe: NONE" in the report, even though a solenoid probe was enabled and working.

This modification reports a solenoid probe, if enabled.

### Benefits

Correctly report solenoid probes in the bed level report.

### Related Issues

None found.
