### PR TITLE
MKS Robin Mini Board Support

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -247,6 +247,7 @@
 #define BOARD_GTM32_PRO_VB            1805  // STM32f103VET6 controller
 #define BOARD_MORPHEUS                1806  // STM32F103C8/STM32F103CB Libmaple based stm32f1 controller
 #define BOARD_MKS_ROBIN               1808  // MKS Robin / STM32F103ZET6
+#define BOARD_MKS_ROBIN_MINI          1813  // MKS Robin Mini / STM32F103VET6
 #define BOARD_BIGTREE_SKR_MINI_V1_1   1814  // STM32F103RC
 #define BOARD_JGAURORA_A5S_A1         1820  // JGAurora A5S A1 / STM32F103ZET6
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -521,7 +521,9 @@ void MarlinUI::status_screen() {
         next_filament_display = millis() + 5000UL;  // Show status message for 5s
       #endif
       goto_screen(menu_main);
-      init_lcd(); // May revive the LCD if static electricity killed it
+      #if DISABLED(NO_LCD_REINIT)
+        init_lcd(); // May revive the LCD if static electricity killed it
+      #endif
       return;
     }
 
@@ -793,7 +795,9 @@ void MarlinUI::update() {
           }
         }
 
-        init_lcd(); // May revive the LCD if static electricity killed it
+        #if DISABLED(NO_LCD_REINIT)
+          init_lcd(); // May revive the LCD if static electricity killed it
+        #endif
 
       #endif
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -430,8 +430,8 @@
   #include "pins_MORPHEUS.h"          // STM32F1                                    env:STM32F1
 #elif MB(MKS_ROBIN)
   #include "pins_MKS_ROBIN.h"         // STM32F1                                    env:mks_robin
-#elif MB(MKS_ROBIN_MINI)  
-#include "pins_MKS_ROBIN_MINI.h"      // STM32F1                                    env:mks_robin_mini
+#elif MB(MKS_ROBIN_MINI)
+  #include "pins_MKS_ROBIN_MINI.h"    // STM32F1                                    env:mks_robin_mini
 #elif MB(JGAURORA_A5S_A1)
   #include "pins_JGAURORA_A5S_A1.h"   // STM32F1                                    env:JGAURORA_A5S_A1
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -430,6 +430,8 @@
   #include "pins_MORPHEUS.h"          // STM32F1                                    env:STM32F1
 #elif MB(MKS_ROBIN)
   #include "pins_MKS_ROBIN.h"         // STM32F1                                    env:mks_robin
+#elif MB(MKS_ROBIN_MINI)  
+#include "pins_MKS_ROBIN_MINI.h"      // STM32F1                                    env:mks_robin_mini
 #elif MB(JGAURORA_A5S_A1)
   #include "pins_JGAURORA_A5S_A1.h"   // STM32F1                                    env:JGAURORA_A5S_A1
 

--- a/Marlin/src/pins/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/pins_MKS_ROBIN_MINI.h
@@ -45,14 +45,6 @@
 #define SPI_MODULE 2
 
 //
-// Servos
-//
-//#define SERVO0_PIN         -1   // 
-//#define SERVO1_PIN         -1   // 
-//#define SERVO2_PIN         -1   // 
-//#define SERVO3_PIN         -1  // 
-
-//
 // Limit Switches
 //
 #define X_MIN_PIN          PA15
@@ -81,10 +73,6 @@
 #define E0_STEP_PIN        PD6
 #define E0_DIR_PIN         PD3
 
-//#define E1_ENABLE_PIN      PA12
-//#define E1_STEP_PIN        PA11
-//#define E1_DIR_PIN         PA8
-
 //
 // Temperature Sensors
 //
@@ -101,9 +89,7 @@
 
 #define FAN_PIN            PB1   // FAN
 
-#define BTN_ENC            PB3  // Pin is not connected. Real pin is needed to enable encoder's push button functionality used by touch screen
-#define BTN_EN1            -1
-#define BTN_EN2            -1
+#define BTN_ENC            PB3   // Pin is not connected. Real pin is needed to enable encoder's push button functionality used by touch screen
 
 //#define MAX6675_SS_PIN     PE5  // TC1 - CS1
 //#define MAX6675_SS_PIN     PE6  // TC2 - CS2
@@ -124,19 +110,21 @@
  */
 //#define LCD_RESET_PIN      PF6
 #define LCD_BACKLIGHT_PIN  PD13
-#define FSMC_CS_PIN        PD7  // NE4
+#define FSMC_CS_PIN        PD7    // NE4
 #define FSMC_RS_PIN        PD11   // A0
 #define TOUCH_CS           PC2
 
 #define SD_DETECT_PIN      PD12
+
 // Motor current PWM pins
 #define MOTOR_CURRENT_PWM_XY_PIN   PA6
 #define MOTOR_CURRENT_PWM_Z_PIN    PA7
 #define MOTOR_CURRENT_PWM_E_PIN    PB0
 #define MOTOR_CURRENT_PWM_RANGE    65535 // (255 * (1000mA / 65535)) * 257 = 1000 is equal 1.6v Vref in turn equal 1Amp
-#define DEFAULT_PWM_MOTOR_CURRENT  {1030, 1030, 1030} // 1.05Amp per driver, here is XY, Z and E. This values determined empirically.
+#define DEFAULT_PWM_MOTOR_CURRENT  { 1030, 1030, 1030 } // 1.05Amp per driver, here is XY, Z and E. This values determined empirically.
 
-// this is a kind of workaround in case native marlin "digipot" interface won't work, required to uncomment related code in stm32f1/hal.cpp
+// This is a kind of workaround in case native marlin "digipot" interface won't work.
+// Required to enable related code in STM32F1/HAL.cpp
 //#ifndef MKS_ROBIN_MINI_VREF_PWM
 //  #define MKS_ROBIN_MINI_VREF_PWM
 //#endif

--- a/Marlin/src/pins/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/pins_MKS_ROBIN_MINI.h
@@ -1,0 +1,146 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * MKS Robin MINI (STM32F130VET6) board pin assignments
+ */
+
+#ifndef __STM32F1__
+  #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
+#endif
+
+#if HOTENDS > 1 || E_STEPPERS > 1
+  #error "MKS Robin mini supports up to 1 hotends / E-steppers. Comment out this line to continue."
+#endif
+
+#define BOARD_NAME "MKS Robin mini"
+
+//
+// Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
+//
+#define DISABLE_DEBUG
+
+//
+// Note: MKS Robin mini board is using SPI2 interface.
+//
+#define SPI_MODULE 2
+
+//
+// Servos
+//
+//#define SERVO0_PIN         -1   // 
+//#define SERVO1_PIN         -1   // 
+//#define SERVO2_PIN         -1   // 
+//#define SERVO3_PIN         -1  // 
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          PA15
+#define X_MAX_PIN          PA15
+#define Y_MIN_PIN          PA12
+#define Y_MAX_PIN          PA12
+#define Z_MIN_PIN          PA11
+#define Z_MAX_PIN          PC4
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN       PE4
+#define X_STEP_PIN         PE3
+#define X_DIR_PIN          PE2
+
+#define Y_ENABLE_PIN       PE1
+#define Y_STEP_PIN         PE0
+#define Y_DIR_PIN          PB9
+
+#define Z_ENABLE_PIN       PB8
+#define Z_STEP_PIN         PB5
+#define Z_DIR_PIN          PB4
+
+#define E0_ENABLE_PIN      PB3
+#define E0_STEP_PIN        PD6
+#define E0_DIR_PIN         PD3
+
+//#define E1_ENABLE_PIN      PA12
+//#define E1_STEP_PIN        PA11
+//#define E1_DIR_PIN         PA8
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         PC1   // TH1
+//#define TEMP_1_PIN         PC2   // TH2
+#define TEMP_BED_PIN       PC0   // TB1
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN       PC3   // HEATER1
+//#define HEATER_1_PIN       PA6   // HEATER2
+#define HEATER_BED_PIN     PA0   // HOT BED
+
+#define FAN_PIN            PB1   // FAN
+
+#define BTN_ENC            PB3  // Pin is not connected. Real pin is needed to enable encoder's push button functionality used by touch screen
+#define BTN_EN1            -1
+#define BTN_EN2            -1
+
+//#define MAX6675_SS_PIN     PE5  // TC1 - CS1
+//#define MAX6675_SS_PIN     PE6  // TC2 - CS2
+
+#define POWER_LOSS_PIN     PA2   // PW_DET
+#define PS_ON_PIN          PA3   // PW_OFF
+#define FIL_RUNOUT_PIN     PF11  // MT_DET
+
+#define BEEPER_PIN         PC5
+//#define LED_PIN            PB2
+
+/**
+ * Note: MKS Robin TFT screens may have different TFT controllers
+ * If the screen stays white, disable 'LCD_RESET_PIN' to rely on the bootloader to do screen initialization.
+ *
+ * Enabling 'LCD_RESET_PIN' causes flickering when entering the LCD menu due to LCD controller reset.
+ * Reset feature was designed to "revive the LCD if static electricity killed it."
+ */
+//#define LCD_RESET_PIN      PF6
+#define LCD_BACKLIGHT_PIN  PD13
+#define FSMC_CS_PIN        PD7  // NE4
+#define FSMC_RS_PIN        PD11   // A0
+#define TOUCH_CS           PC2
+
+#define SD_DETECT_PIN      PD12
+// Motor current PWM pins
+#define MOTOR_CURRENT_PWM_XY_PIN   PA6
+#define MOTOR_CURRENT_PWM_Z_PIN    PA7
+#define MOTOR_CURRENT_PWM_E_PIN    PB0
+#define MOTOR_CURRENT_PWM_RANGE    65535 // (255 * (1000mA / 65535)) * 257 = 1000 is equal 1.6v Vref in turn equal 1Amp
+#define DEFAULT_PWM_MOTOR_CURRENT  {1030, 1030, 1030} // 1.05Amp per driver, here is XY, Z and E. This values determined empirically.
+
+// this is a kind of workaround in case native marlin "digipot" interface won't work, required to uncomment related code in stm32f1/hal.cpp
+//#ifndef MKS_ROBIN_MINI_VREF_PWM
+//  #define MKS_ROBIN_MINI_VREF_PWM
+//#endif
+
+//#define VREF_XY_PIN        PA6
+//#define VREF_Z_PIN         PA7
+//#define VREF_E1_PIN        PB0

--- a/Marlin/src/pins/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/pins_MKS_ROBIN_MINI.h
@@ -104,11 +104,10 @@
 /**
  * Note: MKS Robin TFT screens may have different TFT controllers
  * If the screen stays white, disable 'LCD_RESET_PIN' to rely on the bootloader to do screen initialization.
- *
- * Enabling 'LCD_RESET_PIN' causes flickering when entering the LCD menu due to LCD controller reset.
- * Reset feature was designed to "revive the LCD if static electricity killed it."
  */
-//#define LCD_RESET_PIN      PF6
+#define LCD_RESET_PIN      PF6
+#define NO_LCD_REINIT             // Suppress LCD re-initialization
+
 #define LCD_BACKLIGHT_PIN  PD13
 #define FSMC_CS_PIN        PD7    // NE4
 #define FSMC_RS_PIN        PD11   // A0

--- a/buildroot/share/PlatformIO/ldscripts/mks_robin_mini.ld
+++ b/buildroot/share/PlatformIO/ldscripts/mks_robin_mini.ld
@@ -1,0 +1,14 @@
+MEMORY
+{
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K - 40
+  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K
+}
+
+/* Provide memory region aliases for common.inc */
+REGION_ALIAS("REGION_TEXT", rom);
+REGION_ALIAS("REGION_DATA", ram);
+REGION_ALIAS("REGION_BSS", ram);
+REGION_ALIAS("REGION_RODATA", rom);
+
+/* Let common.inc handle the real work. */
+INCLUDE common.inc

--- a/buildroot/share/PlatformIO/scripts/mks_robin_mini.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_mini.py
@@ -1,0 +1,30 @@
+Import("env")
+
+# Relocate firmware from 0x08000000 to 0x08007000
+for define in env['CPPDEFINES']:
+    if define[0] == "VECT_TAB_ADDR":
+        env['CPPDEFINES'].remove(define)
+env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
+env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/mks_robin_mini.ld")
+
+# Encrypt ${PROGNAME}.bin and save it as 'Robin_mini.bin'
+def encrypt(source, target, env):
+    import os
+
+    key = [0xA3, 0xBD, 0xAD, 0x0D, 0x41, 0x11, 0xBB, 0x8D, 0xDC, 0x80, 0x2D, 0xD0, 0xD2, 0xC4, 0x9B, 0x1E, 0x26, 0xEB, 0xE3, 0x33, 0x4A, 0x15, 0xE4, 0x0A, 0xB3, 0xB1, 0x3C, 0x93, 0xBB, 0xAF, 0xF7, 0x3E]
+
+    firmware = open(target[0].path, "rb")
+    robin = open(target[0].dir.path +'/Robin_mini.bin', "wb")
+    length = os.path.getsize(target[0].path)
+    position = 0
+    try:
+        while position < length:
+            byte = firmware.read(1)
+            if position >= 320 and position < 31040:
+                byte = chr(ord(byte) ^ key[position & 31])
+            robin.write(byte)
+            position += 1
+    finally:
+        firmware.close()
+        robin.close()
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);

--- a/platformio.ini
+++ b/platformio.ini
@@ -351,6 +351,27 @@ lib_ignore    = c1921b4
   U8glib-HAL
 
 #
+# MKS Robin nano(STM32F103VET6)
+#
+[env:mks_robin_mini]
+platform      = ststm32
+framework     = arduino
+board         = genericSTM32F103VE
+extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_mini.py
+build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
+  ${common.build_flags}
+  -DSTM32_HIGH_DENSITY
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
+lib_deps      = ${common.lib_deps}
+lib_ignore    = c1921b4
+  libf3c
+  lib066
+  Adafruit NeoPixel_ID28
+  Adafruit NeoPixel
+  libf3e
+  TMC26XStepper
+
+#
 # JGAurora A5S A1 (STM32F103ZET6)
 #
 [env:JGAURORA_A5S_A1]

--- a/platformio.ini
+++ b/platformio.ini
@@ -284,7 +284,6 @@ board         = genericSTM32F103RC
 extra_scripts = buildroot/share/PlatformIO/scripts/STM32F1_SKR_MINI.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   ${common.build_flags} -std=gnu++14
-  -g
 build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
 lib_ignore    = U8glib-HAL

--- a/platformio.ini
+++ b/platformio.ini
@@ -351,7 +351,7 @@ lib_ignore    = c1921b4
   U8glib-HAL
 
 #
-# MKS Robin nano(STM32F103VET6)
+# MKS Robin nano (STM32F103VET6)
 #
 [env:mks_robin_mini]
 platform      = ststm32

--- a/platformio.ini
+++ b/platformio.ini
@@ -337,7 +337,6 @@ board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   ${common.build_flags} -std=gnu++14
-  -DSTM32_XL_DENSITY
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
@@ -359,8 +358,8 @@ framework     = arduino
 board         = genericSTM32F103VE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_mini.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
-  ${common.build_flags}
-  -DSTM32_HIGH_DENSITY
+  ${common.build_flags} -std=gnu++14
+build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
 lib_ignore    = c1921b4
@@ -380,7 +379,7 @@ framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
-  ${common.build_flags} -DSTM32_XL_DENSITY
+  ${common.build_flags}
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
 lib_ignore    = c1921b4


### PR DESCRIPTION

### Description

Initial MKS Robin Mini (STM32F103VET6) support brought over from Makerbase's [Robin Mini repo](https://github.com/makerbase-mks/MKS-Robin/tree/master/MKS%20Robin%20Mini).

### Benefits

Brings MKS Robin Mini board support into Marlin.

### Related Issues

None.