### PR TITLE
Add missing dedge init for TMC2209

### DIFF
--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -573,6 +573,9 @@
     chopconf.intpol = INTERPOLATE;
     chopconf.hend = chopper_timing.hend + 3;
     chopconf.hstrt = chopper_timing.hstrt - 1;
+    #if ENABLED(SQUARE_WAVE_STEPPING)
+      chopconf.dedge = true;
+    #endif
     st.CHOPCONF(chopconf.sr);
 
     st.rms_current(mA, HOLD_MULTIPLIER);

--- a/Marlin/src/module/stepper_indirection.cpp
+++ b/Marlin/src/module/stepper_indirection.cpp
@@ -269,14 +269,12 @@
   void tmc_init(TMCMarlin<TMC2160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
 
-    static constexpr int8_t timings[] = CHOPPER_TIMING; // Default 4, -2, 1
-
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 1;
-    chopconf.toff = timings[0];
+    chopconf.toff = chopper_timing.toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = timings[1] + 3;
-    chopconf.hstrt = timings[2] - 1;
+    chopconf.hend = chopper_timing.hend + 3;
+    chopconf.hstrt = chopper_timing.hstrt - 1;
     #if ENABLED(SQUARE_WAVE_STEPPING)
       chopconf.dedge = true;
     #endif
@@ -286,16 +284,9 @@
     st.microsteps(microsteps);
     st.iholddelay(10);
     st.TPOWERDOWN(128); // ~2s until driver lowers to hold current
-    st.TCOOLTHRS(0xFFFFF);
-
-    #if ENABLED(ADAPTIVE_CURRENT)
-      COOLCONF_t coolconf{0};
-      coolconf.semin = INCREASE_CURRENT_THRS;
-      coolconf.semax = REDUCE_CURRENT_THRS;
-      st.COOLCONF(coolconf.sr);
-    #endif
 
     st.en_pwm_mode(stealth);
+    st.stored.stealthChop_enabled = stealth;
 
     TMC2160_n::PWMCONF_t pwmconf{0};
     pwmconf.pwm_lim = 12;
@@ -676,14 +667,12 @@
   void tmc_init(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
     st.begin();
 
-    int8_t timings[] = CHOPPER_TIMING; // Default 4, -2, 1
-
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 1;
-    chopconf.toff = timings[0];
+    chopconf.toff = chopper_timing.toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = timings[1] + 3;
-    chopconf.hstrt = timings[2] - 1;
+    chopconf.hend = chopper_timing.hend + 3;
+    chopconf.hstrt = chopper_timing.hstrt - 1;
     #if ENABLED(SQUARE_WAVE_STEPPING)
       chopconf.dedge = true;
     #endif
@@ -694,14 +683,8 @@
     st.iholddelay(10);
     st.TPOWERDOWN(128); // ~2s until driver lowers to hold current
 
-    #if ENABLED(ADAPTIVE_CURRENT)
-      COOLCONF_t coolconf{0};
-      coolconf.semin = INCREASE_CURRENT_THRS;
-      coolconf.semax = REDUCE_CURRENT_THRS;
-      st.COOLCONF(coolconf.sr);
-    #endif
-
     st.en_pwm_mode(stealth);
+    st.stored.stealthChop_enabled = stealth;
 
     TMC2160_n::PWMCONF_t pwmconf{0};
     pwmconf.pwm_lim = 12;


### PR DESCRIPTION
The new TMC2209 init section is missing a required option enabler for `SQUARE_WAVE_STEPPING`.

Bring TMC2160 and TMC5160 init sections up-to-date.
Remove references to `ADAPTIVE_CURRENT`. It's not a thing yet.