### PR TITLE
Bugfix 2.0.x LCD.h compilation error

### DIFF
--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.h
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.h
@@ -90,7 +90,6 @@
 //https://github.com/mikeshub/SailfishLCD
 //uses the code directly from Sailfish
 
-  #include <LCD.h>
   #include <SailfishLCD.h>
   #define LCD_CLASS LiquidCrystalSerial
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ build_dir   = .pioenvs
 lib_dir     = .piolib
 libdeps_dir = .piolibdeps
 boards_dir  = buildroot/share/PlatformIO/boards
-env_default = LPC1768
+env_default = megaatmega2560
 
 [common]
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,7 @@ build_dir   = .pioenvs
 lib_dir     = .piolib
 libdeps_dir = .piolibdeps
 boards_dir  = buildroot/share/PlatformIO/boards
-env_default = megaatmega2560
+env_default = LPC1768
 
 [common]
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
@@ -167,6 +167,7 @@ lib_deps          = Servo
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
   TMCStepper@<1.0.0
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/master.zip
+  https://github.com/mikeshub/SailfishLCD.git
 
 [env:LPC1769]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/master.zip


### PR DESCRIPTION
### Description

When using FF_INTERFACEBOARD LCD.h is not needed for MightyBoard it is causing compilation errors with SKR1.3.

### Benefits

Fixes an issue I am having with upgrading the Creator Pro to 32bit.

### Related Issues

This was added at some point needlessly and can be removed without causing any problems.
