### PR TITLE
Fix FIX_MOUNTED_PROBE compile error

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -39,7 +39,7 @@
   #include "../../feature/tmc_util.h"
 #endif
 
-#if HOMING_Z_WITH_PROBE || ENABLED(BLTOUCH)
+#if HAS_BED_PROBE
   #include "../../module/probe.h"
 #endif
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -41,6 +41,7 @@
 
 #if HAS_BED_PROBE
   #include "../../module/probe.h"
+  #define STOW_PROBE_BEFORE_HOMING NONE(Z_PROBE_ALLEN_KEY, Z_PROBE_SLED)
 #endif
 
 #include "../../lcd/ultralcd.h"
@@ -262,7 +263,7 @@ void GcodeSuite::G28(const bool always_home_all) {
 
     set_destination_from_current();
 
-    #if HAS_BED_PROBE
+    #if STOW_PROBE_BEFORE_HOMING
       STOW_PROBE();
     #endif
 


### PR DESCRIPTION
This fixes the following error with FIX_MOUNTED_PROBE:

```
src/gcode/calibrate/G28.cpp: In static member function ‘static void GcodeSuite::G28(bool)’:
src/gcode/calibrate/G28.cpp:267:18: error: ‘STOW_PROBE’ was not declared in this scope
       STOW_PROBE();
```

This PR is a fix that works for us, but may not be the ideal fix. Please review.