### PR TITLE
Fix Malyan M200 config and protocol

### DIFF
--- a/Marlin/src/lcd/extui_malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui_malyan_lcd.cpp
@@ -113,7 +113,8 @@ void write_to_lcd(const char * const message) {
  */
 void process_lcd_c_command(const char* command) {
   switch (command[0]) {
-    case 'C': {
+    case 'C': // Cope with both V1 early rev and later LCDs.
+    case 'S': {
       int raw_feedrate = atoi(command + 1);
       feedrate_percentage = raw_feedrate * 10;
       feedrate_percentage = constrain(feedrate_percentage, 10, 999);
@@ -319,11 +320,6 @@ void process_lcd_s_command(const char* command) {
       write_to_lcd(message_buffer);
     } break;
 
-    case 'H':
-      // Home all axis
-      queue.inject_P(PSTR("G28"));
-      break;
-
     case 'L': {
       #if ENABLED(SDSUPPORT)
         if (!card.isDetected()) card.initsd();
@@ -474,14 +470,15 @@ namespace ExtUI {
     #endif
   }
 
-  void onStatusChanged(const char * const msg) {
+  // {E:<msg>} is for error states.
+  void onPrinterKilled(PGM_P msg) {
     write_to_lcd_P(PSTR("{E:"));
-    write_to_lcd(msg);
+    write_to_lcd_P(msg);
     write_to_lcd_P("}");
   }
 
   // Not needed for Malyan LCD
-  void onPrinterKilled(PGM_P const msg) { UNUSED(msg); }
+  void onStatusChanged(const char * const msg) { UNUSED(msg); }
   void onMediaInserted() {};
   void onMediaError() {};
   void onMediaRemoved() {};

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -104,7 +104,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
 /**
  * Select a secondary serial port on the board to use for communication with the host.
@@ -132,7 +132,7 @@
 // The following define selects which electronics board you have.
 // Please choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_MALYAN_M200
 #endif
 
 // Optional custom name for your RepStrap or other custom machine


### PR DESCRIPTION
### Description

Minor fixes to Malyan LCD code to support feedrate commands from V2, V3 and Delta LCDs. 
Set motherboard to m200 in example config to prevent users having to edit. PIO had this in the -D section for the board.
Use {E:<msg>} to output error, not status messages. Kill messages now correctly appear on the LCD.

### Benefits

Feedrate updates work for all known variants of the LCD. 
Kill messages appear on the LCD.

### Related Issues
