### PR TITLE
Update "StallGuard threshold" heading

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -3254,7 +3254,7 @@ void MarlinSettings::reset() {
        * TMC Sensorless homing thresholds
        */
       #if USE_SENSORLESS
-        CONFIG_ECHO_HEADING("TMC2130 StallGuard threshold:");
+        CONFIG_ECHO_HEADING("StallGuard threshold:");
         CONFIG_ECHO_START();
         #if X_SENSORLESS || Y_SENSORLESS || Z_SENSORLESS
           say_M914();


### PR DESCRIPTION

### Requirements


### Description

Minor code cleanup:
Renamed "TMC2130 StallGuard threshold:" to "StallGuard threshold:" since TMC2209 also supports StallGuard.

### Benefits

Output of capabilities is correct.

### Related Issues

None
