### PR TITLE
Init servo pins in HAL_init

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/HAL.cpp
+++ b/Marlin/src/HAL/HAL_AVR/HAL.cpp
@@ -67,6 +67,22 @@
 // Public functions
 // --------------------------------------------------------------------------
 
+void HAL_init(void) {
+  // Init Servo Pins
+  #if PIN_EXISTS(SERVO0)
+    OUT_WRITE(SERVO0_PIN, LOW);
+  #endif
+  #if PIN_EXISTS(SERVO1)
+    OUT_WRITE(SERVO1_PIN, LOW);
+  #endif
+  #if PIN_EXISTS(SERVO2)
+    OUT_WRITE(SERVO2_PIN, LOW);
+  #endif
+  #if PIN_EXISTS(SERVO3)
+    OUT_WRITE(SERVO3_PIN, LOW);
+  #endif
+}
+
 #if ENABLED(SDSUPPORT)
 
   #include "../../sd/SdFatUtil.h"

--- a/Marlin/src/HAL/HAL_AVR/HAL.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL.h
@@ -109,6 +109,8 @@ typedef int8_t pin_t;
 // Public functions
 // --------------------------------------------------------------------------
 
+void HAL_init(void);
+
 //void cli(void);
 
 //void _delay_ms(const int delay);

--- a/Marlin/src/HAL/HAL_DUE/HAL.h
+++ b/Marlin/src/HAL/HAL_DUE/HAL.h
@@ -153,7 +153,6 @@ void noTone(const pin_t _pin);
 
 // Enable hooks into idle and setup for HAL
 #define HAL_IDLETASK 1
-#define HAL_INIT 1
 void HAL_idletask(void);
 void HAL_init(void);
 

--- a/Marlin/src/HAL/HAL_ESP32/HAL.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.h
@@ -123,7 +123,6 @@ void HAL_adc_start_conversion(uint8_t adc_pin);
 
 // Enable hooks into idle and setup for HAL
 #define HAL_IDLETASK 1
-#define HAL_INIT 1
 #define BOARD_INIT() HAL_init_board();
 void HAL_idletask(void);
 void HAL_init(void);

--- a/Marlin/src/HAL/HAL_LINUX/HAL.h
+++ b/Marlin/src/HAL/HAL_LINUX/HAL.h
@@ -82,7 +82,9 @@ extern HalSerial usb_serial;
 #define ENABLE_ISRS()
 #define DISABLE_ISRS()
 
-//Utility functions
+inline void HAL_init(void) { }
+
+// Utility functions
 int freeMemory(void);
 
 // SPI: Extended functions which take a channel number (hardware SPI only)

--- a/Marlin/src/HAL/HAL_LPC1768/HAL.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.h
@@ -27,9 +27,8 @@
  */
 
 #define CPU_32_BIT
-#define HAL_INIT
 
-void HAL_init();
+void HAL_init(void);
 
 #include <stdint.h>
 #include <stdarg.h>

--- a/Marlin/src/HAL/HAL_LPC1768/main.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/main.cpp
@@ -48,9 +48,9 @@ void SysTick_Callback() {
   disk_timerproc();
 }
 
-void HAL_init() {
+void HAL_init(void) {
 
-  // Support the 4 LEDs some LPC176x boards have
+  // Init LEDs
   #if PIN_EXISTS(LED)
     SET_DIR_OUTPUT(LED_PIN);
     WRITE_PIN_CLR(LED_PIN);
@@ -72,6 +72,20 @@ void HAL_init() {
       TOGGLE(LED_PIN);
       delay(100);
     }
+  #endif
+
+  // Init Servo Pins
+  #if PIN_EXISTS(SERVO0)
+    OUT_WRITE(SERVO0_PIN, LOW);
+  #endif
+  #if PIN_EXISTS(SERVO1)
+    OUT_WRITE(SERVO1_PIN, LOW);
+  #endif
+  #if PIN_EXISTS(SERVO2)
+    OUT_WRITE(SERVO2_PIN, LOW);
+  #endif
+  #if PIN_EXISTS(SERVO3)
+    OUT_WRITE(SERVO3_PIN, LOW);
   #endif
 
   //debug_frmwrk_init();

--- a/Marlin/src/HAL/HAL_STM32/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32/HAL.h
@@ -151,7 +151,6 @@ extern uint16_t HAL_adc_result;
 #define __bss_end __bss_end__
 
 // Enable hooks into  setup for HAL
-#define HAL_INIT 1
 void HAL_init(void);
 
 /** clear reset reason */

--- a/Marlin/src/HAL/HAL_STM32F1/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.h
@@ -117,9 +117,8 @@
   #define NUM_SERIAL 1
 #endif
 
-// Use HAL_init() to set interrupt grouping.
-#define HAL_INIT
-void HAL_init();
+// Set interrupt grouping for this MCU
+void HAL_init(void);
 
 /**
  * TODO: review this to return 1 for pins that are not analog input

--- a/Marlin/src/HAL/HAL_STM32F4/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F4/HAL.h
@@ -158,6 +158,8 @@ extern uint16_t HAL_adc_result;
 // Memory related
 #define __bss_end __bss_end__
 
+inline void HAL_init(void) { }
+
 /** clear reset reason */
 void HAL_clear_reset_source (void);
 

--- a/Marlin/src/HAL/HAL_STM32F7/HAL.h
+++ b/Marlin/src/HAL/HAL_STM32F7/HAL.h
@@ -145,6 +145,8 @@ extern uint16_t HAL_adc_result;
 // Memory related
 #define __bss_end __bss_end__
 
+inline void HAL_init(void) { }
+
 /** clear reset reason */
 void HAL_clear_reset_source (void);
 

--- a/Marlin/src/HAL/HAL_TEENSY31_32/HAL.h
+++ b/Marlin/src/HAL/HAL_TEENSY31_32/HAL.h
@@ -89,6 +89,8 @@ typedef int8_t pin_t;
 #undef pgm_read_word
 #define pgm_read_word(addr) (*((uint16_t*)(addr)))
 
+inline void HAL_init(void) { }
+
 // Clear the reset reason
 void HAL_clear_reset_source(void);
 

--- a/Marlin/src/HAL/HAL_TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/HAL.h
@@ -97,6 +97,8 @@ typedef int8_t pin_t;
 #undef pgm_read_word
 #define pgm_read_word(addr) (*((uint16_t*)(addr)))
 
+inline void HAL_init(void) { }
+
 /** clear reset reason */
 void HAL_clear_reset_source(void);
 

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -825,9 +825,7 @@ void stop() {
  */
 void setup() {
 
-  #ifdef HAL_INIT
-    HAL_init();
-  #endif
+  HAL_init();
 
   #if HAS_DRIVER(L6470)
     L6470.init();         // setup SPI and then init chips


### PR DESCRIPTION
Following up on #14350…

- Make `HAL_init` required for all HALs.
- Init servo pins for AVR and LPC1768 in `HAL_init`.
