### PR TITLE
Use LCD conditionals in pins files

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1093,7 +1093,7 @@ void setup() {
     init_closedloop();
   #endif
 
-  #if ENABLED(INIT_SDCARD_ON_BOOT) && DISABLED(ULTRA_LCD)
+  #if ENABLED(INIT_SDCARD_ON_BOOT) && !HAS_SPI_LCD
     card.beginautostart();
   #endif
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -876,14 +876,21 @@
 #ifndef LCD_PINS_D4
   #define LCD_PINS_D4 -1
 #endif
-#ifndef LCD_PINS_D5
-  #define LCD_PINS_D5 -1
-#endif
-#ifndef LCD_PINS_D6
-  #define LCD_PINS_D6 -1
-#endif
-#ifndef LCD_PINS_D7
-  #define LCD_PINS_D7 -1
+
+#if HAS_CHARACTER_LCD
+  #ifndef LCD_PINS_D5
+    #define LCD_PINS_D5 -1
+  #endif
+  #ifndef LCD_PINS_D6
+    #define LCD_PINS_D6 -1
+  #endif
+  #ifndef LCD_PINS_D7
+    #define LCD_PINS_D7 -1
+  #endif
+#else
+  #undef LCD_PINS_D5
+  #undef LCD_PINS_D6
+  #undef LCD_PINS_D7
 #endif
 
 /**

--- a/Marlin/src/pins/pins_3DRAG.h
+++ b/Marlin/src/pins/pins_3DRAG.h
@@ -103,7 +103,7 @@
 
   #define BEEPER_PIN       33
 
-#endif // ULTRA_LCD && NEWPANEL
+#endif // HAS_SPI_LCD && NEWPANEL
 
 /**
  *  M3/M4/M5 - Spindle/Laser Control

--- a/Marlin/src/pins/pins_ANET_10.h
+++ b/Marlin/src/pins/pins_ANET_10.h
@@ -151,7 +151,7 @@
  *  REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
  */
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define LCD_SDSS           28
   #if ENABLED(ADC_KEYPAD)
     #define SERVO0_PIN       27   // free for BLTouch/3D-Touch

--- a/Marlin/src/pins/pins_ARCHIM1.h
+++ b/Marlin/src/pins/pins_ARCHIM1.h
@@ -175,7 +175,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define BEEPER_PIN       23   // D24 PA15_CTS1
   #define LCD_PINS_RS      17   // D17 PA12_RXD1
   #define LCD_PINS_ENABLE  24   // D23 PA14_RTS1
@@ -192,4 +192,4 @@
     #define BTN_EN2        13   // D13 PB27_TIOB0
     #define BTN_ENC        16   // D16 PA13_TXD1
   #endif // NEWPANEL
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_ARCHIM2.h
+++ b/Marlin/src/pins/pins_ARCHIM2.h
@@ -224,7 +224,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define BEEPER_PIN       23   // D24 PA15_CTS1
   #define LCD_PINS_RS      17   // D17 PA12_RXD1
   #define LCD_PINS_ENABLE  24   // D23 PA14_RTS1
@@ -241,4 +241,4 @@
     #define BTN_EN2        13   // D13 PB27_TIOB0
     #define BTN_ENC        16   // D16 PA13_TXD1 // the click
   #endif // NEWPANEL
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_AZTEEG_X5_MINI.h
+++ b/Marlin/src/pins/pins_AZTEEG_X5_MINI.h
@@ -108,7 +108,7 @@
 //
 // Display
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ENABLED(CR10_STOCKDISPLAY)
 
@@ -184,7 +184,7 @@
 
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // SD Support

--- a/Marlin/src/pins/pins_BEAST.h
+++ b/Marlin/src/pins/pins_BEAST.h
@@ -120,7 +120,7 @@
 //
 // LCD Pins
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
     #define LCD_PINS_RS         49   // CS chip select /SS chip slave select
@@ -282,7 +282,7 @@
     #endif
   #endif // NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 #define U_MIN_PIN          -1
 #define V_MIN_PIN          -1

--- a/Marlin/src/pins/pins_BIGTREE_SKR_MINI_V1_1.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_MINI_V1_1.h
@@ -102,7 +102,7 @@
  *                EXP2                                              EXP1
  */
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define BEEPER_PIN       PC10
   #define BTN_ENC          PC11
   #define LCD_PINS_RS      PC12
@@ -152,7 +152,7 @@
 
   #endif // !FYSETC_MINI_12864
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // SD Card

--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.3.h
@@ -179,7 +179,7 @@
 |               ￣￣                                               ￣￣
 |               EXP2                                              EXP1
 */
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define BEEPER_PIN       P1_30   // (37) not 5V tolerant
   #define BTN_ENC          P0_28   // (58) open-drain
 
@@ -249,7 +249,7 @@
 
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // SD Support

--- a/Marlin/src/pins/pins_BIQU_B300_V1.0.h
+++ b/Marlin/src/pins/pins_BIQU_B300_V1.0.h
@@ -119,7 +119,7 @@
  * for the onboard SD card, and a chip select signal is not provided for the remote
  * SD card.
  */
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define BEEPER_PIN       P1_31   // EXP1-1
 
@@ -132,15 +132,15 @@
   #define LCD_PINS_ENABLE  P0_18   // (MOSI) EXP1-3
   #define LCD_PINS_D4      P0_15   // (SCK)  EXP1-5
 
-  #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) && DISABLED(DOGLCD)
-    #error "REPRAP_DISCOUNT_SMART_CONTROLLER is not supported by the BIQU BQ111-A4"
+  #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) && HAS_CHARACTER_LCD
+    #error "REPRAP_DISCOUNT_SMART_CONTROLLER is not supported by the BIQU B300 v1.0"
   #endif
 
   #if ENABLED(SDSUPPORT)
-    #error "SDSUPPORT is not supported by the BIQU BQ111-A4 when an LCD controller is used"
+    #error "SDSUPPORT is not supported by the BIQU B300 v1.0 when an LCD controller is used"
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 /**
  * SD Card Reader

--- a/Marlin/src/pins/pins_BIQU_BQ111_A4.h
+++ b/Marlin/src/pins/pins_BIQU_BQ111_A4.h
@@ -99,7 +99,7 @@
  * for the onboard SD card, and a chip select signal is not provided for the remote
  * SD card.
  */
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define BEEPER_PIN          P1_31   // EXP1-1
 
@@ -112,7 +112,7 @@
   #define LCD_PINS_ENABLE     P0_18   // (MOSI) EXP1-3
   #define LCD_PINS_D4         P0_15   // (SCK)  EXP1-5
 
-  #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) && DISABLED(DOGLCD)
+  #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) && HAS_CHARACTER_LCD
     #error "REPRAP_DISCOUNT_SMART_CONTROLLER is not supported by the BIQU BQ111-A4"
   #endif
 
@@ -120,7 +120,7 @@
     #error "SDSUPPORT is not supported by the BIQU BQ111-A4 when an LCD controller is used"
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 
 /**

--- a/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIQU_SKR_V1.1.h
@@ -94,7 +94,7 @@
  * by redrawing the screen after SD card accesses.
  */
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define BEEPER_PIN       P1_30
   #define BTN_EN1          P3_26
   #define BTN_EN2          P3_25

--- a/Marlin/src/pins/pins_CHITU3D.h
+++ b/Marlin/src/pins/pins_CHITU3D.h
@@ -119,7 +119,7 @@
 //
 // LCD Pins
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
     #define LCD_PINS_RS         49   // CS chip select /SS chip slave select
@@ -280,7 +280,7 @@
     #endif
   #endif // NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 #define U_MIN_PIN          -1
 #define V_MIN_PIN          -1

--- a/Marlin/src/pins/pins_COHESION3D_MINI.h
+++ b/Marlin/src/pins/pins_COHESION3D_MINI.h
@@ -135,7 +135,7 @@
 // connector are shared with the onboard SD card, and Marlin does not support reading
 // G-code files from the onboard SD card.
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define BEEPER_PIN       P0_27   // EXP2-7 - open drain
 
@@ -154,7 +154,7 @@
     #error "SDSUPPORT is not currently supported by the Cohesion3D boards"
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // Ethernet pins

--- a/Marlin/src/pins/pins_COHESION3D_REMIX.h
+++ b/Marlin/src/pins/pins_COHESION3D_REMIX.h
@@ -192,7 +192,7 @@
     #define NEOPIXEL_PIN  P1_16   // EXP1-6  =>  Ethernet pin  6 (top row, 3 from left)
   #endif
 
-#elif ENABLED(ULTRA_LCD)
+#elif HAS_SPI_LCD
 
   #define BEEPER_PIN      P1_31   // EXP1-1
   //#define SD_DETECT_PIN P0_27   // EXP2-7
@@ -208,7 +208,7 @@
 
   #define KILL_PIN        P2_11   // EXP2-10
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // SD Support

--- a/Marlin/src/pins/pins_DUE3DOM.h
+++ b/Marlin/src/pins/pins_DUE3DOM.h
@@ -112,7 +112,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define LCD_PINS_RS       42
   #define LCD_PINS_ENABLE   43
@@ -167,4 +167,4 @@
 
     #define BEEPER_PIN      -1
   #endif // SPARK_FULL_GRAPHICS
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_DUE3DOM_MINI.h
+++ b/Marlin/src/pins/pins_DUE3DOM_MINI.h
@@ -104,7 +104,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define LCD_PINS_RS       42
   #define LCD_PINS_ENABLE   43
@@ -170,4 +170,4 @@
     #define DOGLCD_CS       45
 
   #endif // SPARK_FULL_GRAPHICS
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_DUPLICATOR_I3_PLUS.h
+++ b/Marlin/src/pins/pins_DUPLICATOR_I3_PLUS.h
@@ -86,7 +86,7 @@
 //
 // LCDs and Controllers
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #if ENABLED(ZONESTAR_LCD)
     #define LCD_PINS_RS        2
     #define LCD_PINS_ENABLE   36

--- a/Marlin/src/pins/pins_EINSY_RAMBO.h
+++ b/Marlin/src/pins/pins_EINSY_RAMBO.h
@@ -148,7 +148,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define KILL_PIN         32
 
@@ -176,4 +176,4 @@
     #define SD_DETECT_PIN     15
 
   #endif // NEWPANEL
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_EINSY_RETRO.h
+++ b/Marlin/src/pins/pins_EINSY_RETRO.h
@@ -162,7 +162,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define KILL_PIN         32
 
@@ -190,4 +190,4 @@
     #define SD_DETECT_PIN     15
 
   #endif // NEWPANEL
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_FYSETC_AIO_II.h
+++ b/Marlin/src/pins/pins_FYSETC_AIO_II.h
@@ -121,7 +121,7 @@
 //
 // LCD Pins
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define BEEPER_PIN       PC9
 

--- a/Marlin/src/pins/pins_FYSETC_CHEETAH.h
+++ b/Marlin/src/pins/pins_FYSETC_CHEETAH.h
@@ -96,7 +96,7 @@
 //
 // LCD Pins
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define BEEPER_PIN       PC9
 

--- a/Marlin/src/pins/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/pins_GT2560_REV_A.h
@@ -95,7 +95,7 @@
 #define SUICIDE_PIN        54   // Must be enabled at startup to keep power flowing
 #define KILL_PIN           -1
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define BEEPER_PIN       18
 
@@ -138,4 +138,4 @@
 
   #endif // !NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_GTM32_PRO_VB.h
+++ b/Marlin/src/pins/pins_GTM32_PRO_VB.h
@@ -108,7 +108,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
     #define LCD_PINS_RS    PE6   // CS chip select /SS chip slave select
@@ -142,7 +142,7 @@
   //#define LCD_PINS_D14   PD9   // RXD3
   //#define LCD_PINS_D13   PD8   // TXD3
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // SPI2 on LCD conn

--- a/Marlin/src/pins/pins_MEGATRONICS.h
+++ b/Marlin/src/pins/pins_MEGATRONICS.h
@@ -120,7 +120,7 @@
 
   #define SD_DETECT_PIN   -1   // RAMPS doesn't use this
 
-#endif // ULTRA_LCD && NEWPANEL
+#endif // HAS_SPI_LCD && NEWPANEL
 
 //
 // M3/M4/M5 - Spindle/Laser Control

--- a/Marlin/src/pins/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/pins_MIGHTYBOARD_REVE.h
@@ -206,7 +206,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
 
@@ -254,7 +254,7 @@
   #define BTN_CENTER       15   // J0
   #define BTN_ENC          BTN_CENTER
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // SD Card

--- a/Marlin/src/pins/pins_MINIRAMBO.h
+++ b/Marlin/src/pins/pins_MINIRAMBO.h
@@ -140,7 +140,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if !MB(MINIRAMBO_10A)
     #define KILL_PIN       32
@@ -188,4 +188,4 @@
 
   #endif // NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/pins_MKS_SBASE.h
@@ -214,7 +214,7 @@
  * that the garbage/lines are erased immediately after the SD card accesses are completed.
  */
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define BEEPER_PIN       P1_31   // EXP1.1
   #define BTN_ENC          P1_30   // EXP1.2
   #define BTN_EN1          P3_26   // EXP2.5

--- a/Marlin/src/pins/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/pins_MKS_SGEN_L.h
@@ -180,7 +180,7 @@
  *                -----                                            -----
  *                EXP1                                             EXP2
  */
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define BEEPER_PIN       P1_31
   #define BTN_ENC          P1_30
 
@@ -250,7 +250,7 @@
 
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 #ifndef SDCARD_CONNECTION
   #define SDCARD_CONNECTION ONBOARD

--- a/Marlin/src/pins/pins_PRINTRBOARD.h
+++ b/Marlin/src/pins/pins_PRINTRBOARD.h
@@ -165,4 +165,4 @@
 
   #endif
 
-#endif // ULTRA_LCD && NEWPANEL
+#endif // HAS_SPI_LCD && NEWPANEL

--- a/Marlin/src/pins/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/src/pins/pins_PRINTRBOARD_REVF.h
@@ -200,7 +200,7 @@
 //
 //#define USE_INTERNAL_SD
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define LCD_PINS_RS       9   // E1       JP11-11
   #define LCD_PINS_ENABLE   8   // E0       JP11-10
   #define LCD_PINS_D4       7   // D7       JP11-8

--- a/Marlin/src/pins/pins_RADDS.h
+++ b/Marlin/src/pins/pins_RADDS.h
@@ -207,7 +207,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ENABLED(RADDS_DISPLAY)
 
@@ -268,7 +268,7 @@
 
   #endif // SPARK_FULL_GRAPHICS
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 #ifndef SDSS
   #define SDSS              4

--- a/Marlin/src/pins/pins_RAMBO.h
+++ b/Marlin/src/pins/pins_RAMBO.h
@@ -168,7 +168,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define KILL_PIN         80
 
@@ -234,4 +234,4 @@
 
   #endif // !NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_RAMPS.h
+++ b/Marlin/src/pins/pins_RAMPS.h
@@ -360,7 +360,7 @@
 // LCDs and Controllers //
 //////////////////////////
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   //
   // LCD Display output pins
@@ -638,4 +638,4 @@
     #endif
   #endif // NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_RAMPS_DUO.h
+++ b/Marlin/src/pins/pins_RAMPS_DUO.h
@@ -74,7 +74,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if BOTH(NEWPANEL, PANEL_ONE)
     #undef LCD_PINS_D4
@@ -127,4 +127,4 @@
 
   #endif // NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/pins_RAMPS_FD_V1.h
@@ -138,7 +138,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   // ramps-fd lcd adaptor
 
   #define BEEPER_PIN       37
@@ -202,7 +202,7 @@
     #define DOGLCD_MISO    74   // MISO_PIN
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 #if HAS_DRIVER(TMC2208) || HAS_DRIVER(TMC2209)
   /**

--- a/Marlin/src/pins/pins_RAMPS_LINUX.h
+++ b/Marlin/src/pins/pins_RAMPS_LINUX.h
@@ -322,7 +322,7 @@
 // LCDs and Controllers //
 //////////////////////////
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   //
   // LCD Display output pins
@@ -565,4 +565,4 @@
     #endif
   #endif // NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/pins_RAMPS_RE_ARM.h
@@ -296,7 +296,7 @@
   #define LCD_PINS_ENABLE  P0_18   // J3-10 & AUX-3 (SID, MOSI)
   #define LCD_PINS_D4      P2_06   // J3-8 & AUX-3 (SCK, CLK)
 
-#elif ENABLED(ULTRA_LCD)
+#elif HAS_SPI_LCD
 
   //#define SCK_PIN        P0_15   // (52)  system defined J3-9 & AUX-3
   //#define MISO_PIN       P0_17   // (50)  system defined J3-10 & AUX-3
@@ -392,7 +392,7 @@
     //#define LCD_SCREEN_ROT_270
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // Ethernet pins

--- a/Marlin/src/pins/pins_RURAMPS4D_11.h
+++ b/Marlin/src/pins/pins_RURAMPS4D_11.h
@@ -200,7 +200,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ANY(RADDS_DISPLAY, REPRAP_DISCOUNT_SMART_CONTROLLER, REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
     #define BEEPER_PIN      62
@@ -271,4 +271,4 @@
     #define BTN_ENC         40
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_RURAMPS4D_13.h
+++ b/Marlin/src/pins/pins_RURAMPS4D_13.h
@@ -186,7 +186,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ANY(RADDS_DISPLAY, REPRAP_DISCOUNT_SMART_CONTROLLER, REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
     #define BEEPER_PIN      62
@@ -255,4 +255,4 @@
     #define BTN_ENC         40
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/pins_SANGUINOLOLU_11.h
@@ -153,9 +153,9 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
-  #if ENABLED(DOGLCD)
+  #if HAS_GRAPHICAL_LCD
 
     #if ENABLED(U8GLIB_ST7920) // SPI GLCD 12864 ST7920 ( like [www.digole.com] ) For Melzi V2.0
 
@@ -205,7 +205,7 @@
     //#define LCD_SCREEN_ROT_180
     //#define LCD_SCREEN_ROT_270
 
-  #else // !DOGLCD
+  #else // !HAS_GRAPHICAL_LCD
 
     #define LCD_PINS_RS          4
     #define LCD_PINS_ENABLE     17
@@ -214,7 +214,7 @@
     #define LCD_PINS_D6         28
     #define LCD_PINS_D7         27
 
-  #endif // !DOGLCD
+  #endif // !HAS_GRAPHICAL_LCD
 
   #if ENABLED(LCD_I2C_PANELOLU2)
 
@@ -271,7 +271,7 @@
 
   #define SD_DETECT_PIN         -1
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // M3/M4/M5 - Spindle/Laser Control

--- a/Marlin/src/pins/pins_SILVER_GATE.h
+++ b/Marlin/src/pins/pins_SILVER_GATE.h
@@ -68,7 +68,7 @@
 #define HEATER_BED_PIN      8
 #define TEMP_BED_PIN        6
 
-#if ENABLED(DOGLCD)
+#if HAS_GRAPHICAL_LCD
   #if ENABLED(U8GLIB_ST7920)    // SPI GLCD 12864 ST7920
     #define LCD_PINS_RS    30
     #define LCD_PINS_ENABLE 20

--- a/Marlin/src/pins/pins_STM32F1R.h
+++ b/Marlin/src/pins/pins_STM32F1R.h
@@ -99,7 +99,7 @@
 //
 // LCD Pins
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
     #define LCD_PINS_RS         49   // CS chip select /SS chip slave select
@@ -260,4 +260,4 @@
     #endif
   #endif // NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_STM3R_MINI.h
+++ b/Marlin/src/pins/pins_STM3R_MINI.h
@@ -114,7 +114,7 @@
 //
 // LCD Pins
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
     #define LCD_PINS_RS         49   // CS chip select /SS chip slave select
@@ -276,4 +276,4 @@
     #endif
   #endif // NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_TEENSY35_36.h
+++ b/Marlin/src/pins/pins_TEENSY35_36.h
@@ -139,7 +139,7 @@ D8    HEATER_BED_PIN      CS1     RX4  A12 31 |   46 * * 47   | 34 A15 PWM      
 #endif
 #endif
 
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
   #define LCD_PINS_RS      40
   #define LCD_PINS_ENABLE  41
   #define LCD_PINS_D4      42

--- a/Marlin/src/pins/pins_TEENSYLU.h
+++ b/Marlin/src/pins/pins_TEENSYLU.h
@@ -153,7 +153,7 @@
 
   #define SD_DETECT_PIN    -1
 
-#endif // ULTRA_LCD && NEWPANEL
+#endif // HAS_SPI_LCD && NEWPANEL
 
 //
 // M3/M4/M5 - Spindle/Laser Control

--- a/Marlin/src/pins/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/pins_TRIGORILLA_14.h
@@ -81,7 +81,7 @@
 // AnyCubic made the following changes to 1.1.0-RC8
 // If these are appropriate for your LCD let us know.
 //
-#if 0 && ENABLED(ULTRA_LCD)
+#if 0 && HAS_SPI_LCD
 
   // LCD Display output pins
   #if BOTH(NEWPANEL, PANEL_ONE)
@@ -107,4 +107,4 @@
     #define DOGLCD_A0      42
   #endif
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/pins_ULTIMAKER.h
+++ b/Marlin/src/pins/pins_ULTIMAKER.h
@@ -115,7 +115,7 @@
 //
 // LCD / Controller
 //
-#if ENABLED(ULTRA_LCD)
+#if HAS_SPI_LCD
 
   #define BEEPER_PIN 18
 
@@ -154,7 +154,7 @@
 
   #endif // !NEWPANEL
 
-#endif // ULTRA_LCD
+#endif // HAS_SPI_LCD
 
 //
 // M3/M4/M5 - Spindle/Laser Control

--- a/Marlin/src/pins/pins_ULTIMAKER_OLD.h
+++ b/Marlin/src/pins/pins_ULTIMAKER_OLD.h
@@ -24,7 +24,7 @@
  * Ultimaker pin assignments (Old electronics)
  */
 
- /**
+/**
  * Rev B   3 JAN 2017
  *
  * Details on pin definitions for M3, M4 & M5 spindle control commands and for
@@ -55,10 +55,9 @@
  *      and repeat steps 2 - 5
  */
 
-#define board_rev_1_1_TO_1_3
-//#define board_rev_1_0
-//#define board_rev_1_5
-
+#define BOARD_REV_1_1_TO_1_3
+//#define BOARD_REV_1_0
+//#define BOARD_REV_1_5
 
 #if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
   #error "Oops! Select 'Arduino/Genuino Mega or Mega 2560' in 'Tools > Board.'"
@@ -71,37 +70,43 @@
 //
 // Limit Switches
 //
-#if ENABLED(board_rev_1_1_TO_1_3)
-  #define X_MIN_PIN          15   // SW1
-  #define X_MAX_PIN          14   // SW2
-  #define Y_MIN_PIN          17   // SW3
-  #define Y_MAX_PIN          16   // SW4
-  #define Z_MIN_PIN          19   // SW5
-  #define Z_MAX_PIN          18   // SW6
+#if ENABLED(BOARD_REV_1_1_TO_1_3)
+  #define X_MIN_PIN        15   // SW1
+  #define X_MAX_PIN        14   // SW2
+  #define Y_MIN_PIN        17   // SW3
+  #define Y_MAX_PIN        16   // SW4
+  #define Z_MIN_PIN        19   // SW5
+  #define Z_MAX_PIN        18   // SW6
 #endif
 
-#if ENABLED(board_rev_1_0)
-  #define X_MIN_PIN          13   // SW1
-  #define X_MAX_PIN          12   // SW2
-  #define Y_MIN_PIN          11   // SW3
-  #define Y_MAX_PIN          10   // SW4
-  #define Z_MIN_PIN           9   // SW5
-  #define Z_MAX_PIN           8   // SW6
+#if ENABLED(BOARD_REV_1_0)
+  #if ENABLED(SPINDLE_LASER_ENABLE)
+    #define X_STOP_PIN     13   // SW1  (didn't change) - also has a useable hardware PWM
+    #define Y_STOP_PIN     12   // SW2
+    #define Z_STOP_PIN     11   // SW3
+  #else
+    #define X_MIN_PIN      13   // SW1
+    #define X_MAX_PIN      12   // SW2
+    #define Y_MIN_PIN      11   // SW3
+    #define Y_MAX_PIN      10   // SW4
+    #define Z_MIN_PIN       9   // SW5
+    #define Z_MAX_PIN       8   // SW6
+  #endif
 #endif
 
-#if ENABLED(board_rev_1_5)
-  #define X_MIN_PIN          22
-  #define X_MAX_PIN          24
-  #define Y_MIN_PIN          26
-  #define Y_MAX_PIN          28
-  #define Z_MIN_PIN          30
-  #define Z_MAX_PIN          32
+#if ENABLED(BOARD_REV_1_5)
+  #define X_MIN_PIN        22
+  #define X_MAX_PIN        24
+  #define Y_MIN_PIN        26
+  #define Y_MAX_PIN        28
+  #define Z_MIN_PIN        30
+  #define Z_MAX_PIN        32
 #endif
 
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-#ifndef Z_MIN_PROBE_PIN
+#if !defined(Z_MIN_PROBE_PIN) && !BOTH(SPINDLE_LASER_ENABLE, BOARD_REV_1_0)
   #define Z_MIN_PROBE_PIN  Z_MAX_PIN
 #endif
 
@@ -120,13 +125,20 @@
 #define Z_DIR_PIN          39
 #define Z_ENABLE_PIN       35
 
-#define E0_STEP_PIN        43
-#define E0_DIR_PIN         45
-#define E0_ENABLE_PIN      41
+#if BOTH(SPINDLE_LASER_ENABLE, BOARD_REV_1_1_TO_1_3) && EXTRUDERS == 1
+  // Move E0 to the spare and get Spindle/Laser signals from E0
+  #define E0_STEP_PIN      49
+  #define E0_DIR_PIN       47
+  #define E0_ENABLE_PIN    48
+#else
+  #define E0_STEP_PIN      43
+  #define E0_DIR_PIN       45
+  #define E0_ENABLE_PIN    41
 
-#define E1_STEP_PIN        -1   // 49
-#define E1_DIR_PIN         -1   // 47
-#define E1_ENABLE_PIN      -1   // 48
+  #define E1_STEP_PIN      49
+  #define E1_DIR_PIN       47
+  #define E1_ENABLE_PIN    48
+#endif
 
 //
 // Temperature Sensors
@@ -144,50 +156,49 @@
 //
 // LCD / Controller
 //
-#if ANY(board_rev_1_0, board_rev_1_1_TO_1_3)
-  #define LCD_PINS_RS        24
-  #define LCD_PINS_ENABLE    22
-  #define LCD_PINS_D4        36
-  #define LCD_PINS_D5        34
-  #define LCD_PINS_D6        32
-  #define LCD_PINS_D7        30
+#if ANY(BOARD_REV_1_0, BOARD_REV_1_1_TO_1_3)
 
-#elif ENABLED(board_rev_1_5, ULTRA_LCD)
+  #define LCD_PINS_RS      24
+  #define LCD_PINS_ENABLE  22
+  #define LCD_PINS_D4      36
+  #define LCD_PINS_D5      34
+  #define LCD_PINS_D6      32
+  #define LCD_PINS_D7      30
 
-  #define BEEPER_PIN 18
+#elif ENABLED(BOARD_REV_1_5, ULTRA_LCD)
+
+  #define BEEPER_PIN       18
 
   #if ENABLED(NEWPANEL)
 
-    #define LCD_PINS_RS 20
+    #define LCD_PINS_RS    20
     #define LCD_PINS_ENABLE 17
-    #define LCD_PINS_D4 16
-    #define LCD_PINS_D5 21
-    #define LCD_PINS_D6 5
-    #define LCD_PINS_D7 6
+    #define LCD_PINS_D4    16
+    #define LCD_PINS_D5    21
+    #define LCD_PINS_D6     5
+    #define LCD_PINS_D7     6
 
     // buttons are directly attached
-    #define BTN_EN1 40
-    #define BTN_EN2 42
-    #define BTN_ENC 19
+    #define BTN_EN1        40
+    #define BTN_EN2        42
+    #define BTN_ENC        19
 
-    #define SD_DETECT_PIN 38
+    #define SD_DETECT_PIN  38
 
   #else // !NEWPANEL - Old style panel with shift register
 
     // buttons are attached to a shift register
-    #define SHIFT_CLK 38
-    #define SHIFT_LD 42
-    #define SHIFT_OUT 40
-    #define SHIFT_EN 17
+    #define SHIFT_CLK      38
+    #define SHIFT_LD       42
+    #define SHIFT_OUT      40
+    #define SHIFT_EN       17
 
-    #define LCD_PINS_RS 16
+    #define LCD_PINS_RS    16
     #define LCD_PINS_ENABLE 5
-    #define LCD_PINS_D4 6
-    #define LCD_PINS_D5 21
-    #define LCD_PINS_D6 20
-    #define LCD_PINS_D7 19
-
-    #define SD_DETECT_PIN -1
+    #define LCD_PINS_D4     6
+    #define LCD_PINS_D5    21
+    #define LCD_PINS_D6    20
+    #define LCD_PINS_D7    19
 
   #endif // !NEWPANEL
 
@@ -196,7 +207,7 @@
 //
 // case light  - see spindle section for more info on available hardware PWMs
 //
-#if !PIN_EXISTS(CASE_LIGHT) && ENABLED(board_rev_1_5)
+#if !PIN_EXISTS(CASE_LIGHT) && ENABLED(BOARD_REV_1_5)
   #define CASE_LIGHT_PIN        7   // use PWM -  MUST BE HARDWARE PWM
 #endif
 
@@ -204,51 +215,23 @@
 // M3/M4/M5 - Spindle/Laser Control
 //
 #if ENABLED(SPINDLE_LASER_ENABLE)
-
-  #if ENABLED(board_rev_1_0)       // use the last three SW positions
-
-    #undef Z_MIN_PROBE_PIN
-    #undef X_MIN_PIN              // SW1
-    #undef X_MAX_PIN              // SW2
-    #undef Y_MIN_PIN              // SW3
-    #undef Y_MAX_PIN              // SW4
-    #undef Z_MIN_PIN              // SW5
-    #undef Z_MAX_PIN              // SW6
-
-    #define X_STOP_PIN         13   // SW1  (didn't change) - also has a useable hardware PWM
-    #define Y_STOP_PIN         12   // SW2
-    #define Z_STOP_PIN         11   // SW3
-
-    #define SPINDLE_DIR_PIN          10   // SW4
-    #define SPINDLE_LASER_PWM_PIN     9   // SW5  MUST BE HARDWARE PWM
-    #define SPINDLE_LASER_ENA_PIN     8   // SW6  Pin should have a pullup!
-
-  #elif ENABLED(board_rev_1_5)      // use the same pins - but now they are on a different connector
-
-    #define SPINDLE_DIR_PIN          10   // EXP3-6 (silkscreen says 10)
-    #define SPINDLE_LASER_PWM_PIN     9   // EXP3-7 (silkscreen says 9) MUST BE HARDWARE PWM
-    #define SPINDLE_LASER_ENA_PIN     8   // EXP3-8 (silkscreen says 8) Pin should have a pullup!
-
-  #elif ENABLED(board_rev_1_1_TO_1_3)
-
+  #if EITHER(BOARD_REV_1_0, BOARD_REV_1_5) // Use the last three SW positions
+    #define SPINDLE_DIR_PIN          10   // 1.0: SW4  1.5: EXP3-6 ("10")
+    #define SPINDLE_LASER_PWM_PIN     9   // 1.0: SW5  1.5: EXP3-7 ( "9") .. MUST BE HARDWARE PWM
+    #define SPINDLE_LASER_ENA_PIN     8   // 1.0: SW6  1.5: EXP3-8 ( "8") .. Pin should have a pullup!
+  #elif ENABLED(BOARD_REV_1_1_TO_1_3)
     /**
-     *  Only four hardware PWMs physically connected to anything on these boards:
+     * Only four hardware PWMs physically connected to anything on these boards:
      *
-     *    HEATER_0_PIN    2  silkscreen varies - usually "PWM 1" or "HEATER1"
-     *    HEATER_1_PIN    3  silkscreen varies - usually "PWM 2" or "HEATER2"
-     *    HEATER_BED_PIN  4  silkscreen varies - usually "PWM 3" or "HEATED BED"
-     *    E0_DIR_PIN     45
+     *   HEATER_0_PIN    2  silkscreen varies - usually "PWM 1" or "HEATER1"
+     *   HEATER_1_PIN    3  silkscreen varies - usually "PWM 2" or "HEATER2"
+     *   HEATER_BED_PIN  4  silkscreen varies - usually "PWM 3" or "HEATED BED"
+     *   E0_DIR_PIN     45
      *
-     *   If one of the heaters is used then special precautions will usually be needed.
-     *   They have an LED and resistor pullup to +24V which could damage 3.3V-5V ICs.
+     * If one of the heaters is used then special precautions will usually be needed.
+     * They have an LED and resistor pullup to +24V which could damage 3.3V-5V ICs.
      */
-    #if EXTRUDERS == 1                     // Move E0 stepper module to the spare and get signals from E0
-      #undef E0_STEP_PIN
-      #undef E0_DIR_PIN
-      #undef E0_ENABLE_PIN
-      #define E0_STEP_PIN              49
-      #define E0_DIR_PIN               47
-      #define E0_ENABLE_PIN            48
+    #if EXTRUDERS == 1
       #define SPINDLE_DIR_PIN          43
       #define SPINDLE_LASER_PWM_PIN    45   // MUST BE HARDWARE PWM
       #define SPINDLE_LASER_ENA_PIN    41   // Pin should have a pullup!

--- a/Marlin/src/pins/pins_ULTIMAKER_OLD.h
+++ b/Marlin/src/pins/pins_ULTIMAKER_OLD.h
@@ -191,7 +191,7 @@
 
   #endif // !NEWPANEL
 
-#endif // ULTRA_LCD
+#endif
 
 //
 // case light  - see spindle section for more info on available hardware PWMs

--- a/buildroot/share/tests/megaatmega2560-tests
+++ b/buildroot/share/tests/megaatmega2560-tests
@@ -43,7 +43,7 @@ opt_enable PIDTEMPBED FIX_MOUNTED_PROBE Z_SAFE_HOMING EEPROM_SETTINGS \
 opt_enable SLOW_PWM_HEATERS THERMAL_PROTECTION_CHAMBER
 opt_set TEMP_SENSOR_CHAMBER 3
 opt_set HEATER_CHAMBER_PIN 45
-exec_test $1 $2 "RAMPS with 2 extruders, RRDFGSC, Linear ABL, LEDs, and many options"
+exec_test $1 $2 "RAMPS with 2 extruders, RepRap LCD, Linear ABL, LEDs, and many options"
 
 #
 # Test a probeless build of AUTO_BED_LEVELING_UBL, with lots of extruders


### PR DESCRIPTION
Conditionals defined in `Conditionals_LCD.h` can be used in pins files to replace older conditions … now that we have more confidence in these flags.