### PR TITLE
Spindle/Laser power in planner blocks

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/HAL_AVR/fast_pwm.cpp
@@ -23,7 +23,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(FAST_PWM_FAN)
+#if ENABLED(FAST_PWM_FAN) || SPINDLE_LASER_PWM
 
 #include "HAL.h"
 
@@ -278,5 +278,5 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
   }
 }
 
-#endif // FAST_PWM_FAN
+#endif // FAST_PWM_FAN || SPINDLE_LASER_PWM
 #endif // __AVR__

--- a/Marlin/src/HAL/HAL_LPC1768/fast_pwm.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/fast_pwm.cpp
@@ -24,7 +24,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(FAST_PWM_FAN)
+#if ENABLED(FAST_PWM_FAN) || SPINDLE_LASER_PWM
 
 #include <pwm.h>
 
@@ -36,5 +36,5 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
   pwm_write_ratio(pin, invert ? 1.0f - (float)v / v_size : (float)v / v_size);
 }
 
-#endif // FAST_PWM_FAN
+#endif // FAST_PWM_FAN || SPINDLE_LASER_PWM
 #endif // TARGET_LPC1768

--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -36,10 +36,10 @@
 #define MSG_CUTTER(M) _MSG_CUTTER(M)
 
 #if SPEED_POWER_MAX > 255
-  #define cutter_power_t   uint16_t
+  typedef uint16_t cutter_power_t;
   #define CUTTER_MENU_TYPE uint16_5
 #else
-  #define cutter_power_t   uint8_t
+  typedef uint8_t cutter_power_t;
   #define CUTTER_MENU_TYPE uint8
 #endif
 
@@ -51,9 +51,17 @@ public:
 
   static inline bool enabled() { return !!power; }
 
-  static inline void set_power(const uint8_t pwr) { power = pwr; update_output(); }
+  static inline void set_power(const cutter_power_t pwr) { power = pwr; }
 
-  static inline void set_enabled(const bool enable) { set_power(enable ? 255 : 0); }
+  static inline void refresh() { apply_power(power); }
+
+  static inline void set_enabled(const bool enable) {
+    const bool was = enabled();
+    set_power(enable ? 255 : 0);
+    if (was != enable) power_delay();
+  }
+
+  static void apply_power(const cutter_power_t inpow);
 
   //static bool active() { return READ(SPINDLE_LASER_ENA_PIN) == SPINDLE_LASER_ACTIVE_HIGH; }
 
@@ -61,11 +69,11 @@ public:
 
   #if ENABLED(SPINDLE_LASER_PWM)
     static void set_ocr(const uint8_t ocr);
-    static inline void set_ocr_power(const uint8_t pwr) { power = pwr; set_ocr(pwr); }
+    static inline void set_ocr_power(const cutter_power_t pwr) { power = pwr; set_ocr(pwr); }
   #endif
 
   // Wait for spindle to spin up or spin down
-  static inline void power_delay(const bool on) { safe_delay(on ? SPINDLE_LASER_POWERUP_DELAY : SPINDLE_LASER_POWERDOWN_DELAY); }
+  static inline void power_delay() { safe_delay(enabled() ? SPINDLE_LASER_POWERUP_DELAY : SPINDLE_LASER_POWERDOWN_DELAY); }
 
   #if ENABLED(SPINDLE_CHANGE_DIR)
     static void set_direction(const bool reverse);

--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -73,7 +73,11 @@ public:
   #endif
 
   // Wait for spindle to spin up or spin down
-  static inline void power_delay() { safe_delay(enabled() ? SPINDLE_LASER_POWERUP_DELAY : SPINDLE_LASER_POWERDOWN_DELAY); }
+  static inline void power_delay() {
+    #if SPINDLE_LASER_POWERUP_DELAY || SPINDLE_LASER_POWERDOWN_DELAY
+      safe_delay(enabled() ? SPINDLE_LASER_POWERUP_DELAY : SPINDLE_LASER_POWERDOWN_DELAY);
+    #endif
+  }
 
   #if ENABLED(SPINDLE_CHANGE_DIR)
     static void set_direction(const bool reverse);

--- a/Marlin/src/gcode/control/M3-M5.cpp
+++ b/Marlin/src/gcode/control/M3-M5.cpp
@@ -29,10 +29,20 @@
 #include "../../module/stepper.h"
 
 /**
- *  M3 - Cutter ON (Clockwise)
- *  M4 - Cutter ON (Counter-clockwise)
+ * Laser:
  *
- *    S<power> - Set power. S0 turns it off.
+ *  M3 - Laser ON/Power (Ramped power)
+ *  M4 - Laser ON/Power (Continuous power)
+ *
+ *    S<power> - Set power. S0 will turn the laser off.
+ *    O<ocr>   - Set power and OCR
+ *
+ * Spindle:
+ *
+ *  M3 - Spindle ON (Clockwise)
+ *  M4 - Spindle ON (Counter-clockwise)
+ *
+ *    S<power> - Set power. S0 will turn the spindle off.
  *    O<ocr>   - Set power and OCR
  *
  *  If no PWM pin is defined then M3/M4 just turns it on.

--- a/Marlin/src/gcode/control/M3-M5.cpp
+++ b/Marlin/src/gcode/control/M3-M5.cpp
@@ -61,12 +61,14 @@
  */
 void GcodeSuite::M3_M4(const bool is_M4) {
 
-  planner.synchronize();   // Wait for previous movement commands (G0/G0/G2/G3) to complete before changing power
+  #if ENABLED(SPINDLE_FEATURE)
+    planner.synchronize();   // Wait for movement to complete before changing power
+  #endif
 
   cutter.set_direction(is_M4);
 
   #if ENABLED(SPINDLE_LASER_PWM)
-    if (parser.seen('O'))
+    if (parser.seenval('O'))
       cutter.set_ocr_power(parser.value_byte()); // The OCR is a value from 0 to 255 (uint8_t)
     else
       cutter.set_power(parser.intval('S', 255));
@@ -79,7 +81,9 @@ void GcodeSuite::M3_M4(const bool is_M4) {
  * M5 - Cutter OFF
  */
 void GcodeSuite::M5() {
-  planner.synchronize();
+  #if ENABLED(SPINDLE_FEATURE)
+    planner.synchronize();
+  #endif
   cutter.set_enabled(false);
 }
 

--- a/Marlin/src/lcd/menu/menu_spindle_laser.cpp
+++ b/Marlin/src/lcd/menu/menu_spindle_laser.cpp
@@ -38,7 +38,7 @@
     BACK_ITEM(MSG_MAIN);
     if (cutter.enabled()) {
       #if ENABLED(SPINDLE_LASER_PWM)
-        EDIT_ITEM(CUTTER_MENU_TYPE, MSG_CUTTER(POWER), &cutter.power, SPEED_POWER_MIN, SPEED_POWER_MAX, cutter.update_output);
+        EDIT_ITEM(CUTTER_MENU_TYPE, MSG_CUTTER(POWER), &cutter.power, SPEED_POWER_MIN, SPEED_POWER_MAX);
       #endif
       ACTION_ITEM(MSG_CUTTER(OFF), cutter.disable);
     }

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -100,6 +100,10 @@
   #include "../feature/power_loss_recovery.h"
 #endif
 
+#if HAS_CUTTER
+  #include "../feature/spindle_laser.h"
+#endif
+
 // Delay for delivery of first block to the stepper ISR, if the queue contains 2 or
 // fewer movements. The delay is measured in milliseconds, and must be less than 250ms
 #define BLOCK_DELAY_FOR_1ST_MOVE 100
@@ -1220,6 +1224,11 @@ void Planner::check_axes_activity() {
     #endif
   }
   else {
+
+    #if HAS_CUTTER
+      cutter.refresh();
+    #endif
+
     #if FAN_COUNT > 0
       FANS_LOOP(i)
         tail_fan_speed[i] = thermalManager.scaledFanSpeed(i);
@@ -1235,6 +1244,9 @@ void Planner::check_axes_activity() {
     #endif
   }
 
+  //
+  // Disable inactive axes
+  //
   #if ENABLED(DISABLE_X)
     if (!axis_active.x) disable_X();
   #endif
@@ -1248,6 +1260,9 @@ void Planner::check_axes_activity() {
     if (!axis_active.e) disable_e_steppers();
   #endif
 
+  //
+  // Update Fan speeds
+  //
   #if FAN_COUNT > 0
 
     #if FAN_KICKSTART_TIME > 0
@@ -1839,6 +1854,10 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
   #if ENABLED(MIXING_EXTRUDER)
     MIXER_POPULATE_BLOCK();
+  #endif
+
+  #if HAS_CUTTER
+    block->cutter_power = cutter.power;
   #endif
 
   #if FAN_COUNT > 0

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -51,6 +51,10 @@
   #include "../feature/mixing.h"
 #endif
 
+#if HAS_CUTTER
+  #include "../feature/spindle_laser.h"
+#endif
+
 // Feedrate for manual moves
 #ifdef MANUAL_FEEDRATE
   constexpr xyze_feedrate_t manual_feedrate_mm_m = MANUAL_FEEDRATE;
@@ -144,6 +148,10 @@ typedef struct block_t {
            initial_rate,                    // The jerk-adjusted step rate at start of block
            final_rate,                      // The minimal rate at exit
            acceleration_steps_per_s2;       // acceleration steps/sec^2
+
+  #if HAS_CUTTER
+    cutter_power_t cutter_power;            // Power level for Spindle, Laser, etc.
+  #endif
 
   #if FAN_COUNT > 0
     uint8_t fan_speed[FAN_COUNT];

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1667,6 +1667,10 @@ uint32_t Stepper::stepper_block_phase_isr() {
           return interval; // No more queued movements!
       }
 
+      #if HAS_CUTTER
+        cutter.apply_power(current_block->cutter_power);
+      #endif
+
       #if ENABLED(POWER_LOSS_RECOVERY)
         recovery.info.sdpos = current_block->sdpos;
       #endif


### PR DESCRIPTION
**Background:** Currently users are required to use the `M106`/`M107` commands to get laser or spindle power synchronized with planner blocks. The `M3`-`M5` commands are still incomplete and always synchronize the planner with every call.

**Solution:** This PR causes `M3`-`M5` to set spindle/laser power following the same methodology as the fan speed. The speed/power is only set in a variable at first. When planner blocks are created the speed/power is copied into the planner block. If a planner block is being processed, the spindle/laser power will be updated from the block, but if no block is being processed then the last-set power is applied.

### Considerations:
- The power-up / power-down delay is applied in the G-codes.
- Spindle direction change is not handled as a special case. Commands to change spindle direction must perform a stop (and power-down delay) for safety.
- This allows `FAN_PIN` to be used for a fan, so `M106`/`M107` will not control the spindle/laser. This may be expanded so that if `FAN_PIN` is used then `M106`/`M107` can be used as aliases for `M3`/`M5`, as is common with laser add-ons. At that time, `M451`/`M452` may be used to switch between extrusion and engraving.