### PR TITLE
Fix RURAMPS eeprom end

### DIFF
--- a/Marlin/src/pins/pins_RURAMPS4D_13.h
+++ b/Marlin/src/pins/pins_RURAMPS4D_13.h
@@ -172,7 +172,7 @@
 //
 // EEPROM
 //
-#define E2END 0x8000  // 32Kb (24lc256)
+#define E2END 0x7FFF  // 32Kb (24lc256)
 #define I2C_EEPROM    // EEPROM on I2C-0
 //#define EEPROM_SD   // EEPROM on SDCARD
 //#define SPI_EEPROM  // EEPROM on SPI-0


### PR DESCRIPTION
I think there is a typo error, size is 0x8000 but end address should be 0x7FFF