### PR TITLE
Improve ExtUI, fix compiler errors, warnings

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -666,8 +666,8 @@ LIBWARN = -w -Wno-packed-bitfield-compat
 CSTANDARD = -std=gnu99
 CXXSTANDARD = -std=gnu++11
 CDEBUG = -g$(DEBUG)
-CWARN   = -Wall -Wstrict-prototypes -Wno-packed-bitfield-compat -Wno-pragmas
-CXXWARN = -Wall                     -Wno-packed-bitfield-compat -Wno-pragmas
+CWARN   = -Wall -Wstrict-prototypes -Wno-packed-bitfield-compat -Wno-pragmas -Wunused-parameter
+CXXWARN = -Wall                     -Wno-packed-bitfield-compat -Wno-pragmas -Wunused-parameter
 CTUNING = -fsigned-char -funsigned-bitfields -fpack-struct -fno-exceptions \
           -fshort-enums -ffunction-sections -fdata-sections
 ifneq ($(HARDWARE_MOTHERBOARD),)

--- a/Marlin/src/feature/backlash.h
+++ b/Marlin/src/feature/backlash.h
@@ -68,6 +68,9 @@ public:
       #endif
       0
     );
+    #if DISABLED(MEASURE_BACKLASH_WHEN_PROBING)
+      UNUSED(e);
+    #endif
   }
 
   static inline bool has_measurement(const uint8_t e) {
@@ -76,6 +79,9 @@ public:
         || (measured_count[e] > 0)
       #endif
     );
+    #if DISABLED(MEASURE_BACKLASH_WHEN_PROBING)
+      UNUSED(e);
+    #endif
   }
 
   static inline bool has_any_measurement() {

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -985,7 +985,7 @@
     st.TCOOLTHRS(0xFFFFF);
     return true;
   }
-  void tmc_disable_stallguard(TMC2209Stepper &st, const bool restore_stealth) {
+  void tmc_disable_stallguard(TMC2209Stepper &st, const bool restore_stealth _UNUSED) {
     st.TCOOLTHRS(0);
   }
 

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -411,9 +411,13 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
     SERIAL_ECHOLNPGM("Nozzle Tip Outer Dimensions:");
     #if HAS_X_CENTER
       SERIAL_ECHOLNPAIR(" X", m.nozzle_outer_dimension[X_AXIS]);
+    #else
+      UNUSED(m);
     #endif
     #if HAS_Y_CENTER
       SERIAL_ECHOLNPAIR(" Y", m.nozzle_outer_dimension[Y_AXIS]);
+    #else
+      UNUSED(m);
     #endif
     SERIAL_EOL();
   }
@@ -518,6 +522,8 @@ inline void calibrate_toolhead(measurements_t &m, const float uncertainty, const
 
   #if HOTENDS > 1
     set_nozzle(m, extruder);
+  #else
+    UNUSED(extruder);
   #endif
 
   probe_sides(m, uncertainty);

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -40,9 +40,9 @@ void report_M92(const bool echo=true, const int8_t e=-1) {
       SERIAL_ECHOPAIR(" M92 T", (int)i);
       SERIAL_ECHOLNPAIR(" E", VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS_N(i)]));
     }
-  #else
-    UNUSED(e);
   #endif
+
+  UNUSED_E(e);
 }
 
 /**

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -90,6 +90,13 @@ GCodeQueue::GCodeQueue() {
 }
 
 /**
+ * Checks whether there are any commands yet to be executed
+ */
+bool GCodeQueue::has_commands_queued() {
+  return queue.length || injected_commands_P;
+}
+
+/**
  * Clear the Marlin command queue
  */
 void GCodeQueue::clear() {
@@ -161,7 +168,10 @@ bool GCodeQueue::process_injected_command() {
   char c;
   size_t i = 0;
   while ((c = pgm_read_byte(&injected_commands_P[i])) && c != '\n') i++;
-  if (!i) return false;
+  if (!i) {
+    injected_commands_P = nullptr;
+    return false;
+  }
 
   char cmd[i + 1];
   memcpy_P(cmd, injected_commands_P, i);

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -90,7 +90,7 @@ GCodeQueue::GCodeQueue() {
 }
 
 /**
- * Checks whether there are any commands yet to be executed
+ * Check whether there are any commands yet to be executed
  */
 bool GCodeQueue::has_commands_queued() {
   return queue.length || injected_commands_P;

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -85,6 +85,11 @@ public:
   static void enqueue_now_P(PGM_P const cmd);
 
   /**
+   * Checks whether there are any commands in the queue
+   */
+  static bool has_commands_queued();
+
+  /**
    * Get the next command in the queue, optionally log it to SD, then dispatch it
    */
   static void advance();

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -85,7 +85,7 @@ public:
   static void enqueue_now_P(PGM_P const cmd);
 
   /**
-   * Checks whether there are any commands in the queue
+   * Check whether there are any commands in the queue
    */
   static bool has_commands_queued();
 

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -85,7 +85,7 @@ public:
   static void enqueue_now_P(PGM_P const cmd);
 
   /**
-   * Check whether there are any commands in the queue
+   * Check whether there are any commands yet to be executed
    */
   static bool has_commands_queued();
 

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -451,10 +451,12 @@
 #if ENABLED(DISTINCT_E_FACTORS) && E_STEPPERS > 1
   #define XYZE_N (XYZ + E_STEPPERS)
   #define E_AXIS_N(E) AxisEnum(E_AXIS + E)
+  #define UNUSED_E(E) NOOP
 #else
   #undef DISTINCT_E_FACTORS
   #define XYZE_N XYZE
   #define E_AXIS_N(E) E_AXIS
+  #define UNUSED_E(E) UNUSED(E)
 #endif
 
 /**

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -242,11 +242,19 @@ namespace ExtUI {
   }
 
   float getTargetFan_percent(const fan_t fan) {
-    return thermalManager.fanPercent(thermalManager.fan_speed[fan - FAN0]);
+    #if FAN_COUNT > 0
+      return thermalManager.fanPercent(thermalManager.fan_speed[fan - FAN0]);
+    #else
+      return 0;
+    #endif
   }
 
   float getActualFan_percent(const fan_t fan) {
-    return thermalManager.fanPercent(thermalManager.scaledFanSpeed(fan - FAN0));
+    #if FAN_COUNT > 0
+      return thermalManager.fanPercent(thermalManager.scaledFanSpeed(fan - FAN0));
+    #else
+      return 0;
+    #endif
   }
 
   float getAxisPosition_mm(const axis_t axis) {
@@ -814,8 +822,10 @@ namespace ExtUI {
   }
 
   void setTargetFan_percent(const float value, const fan_t fan) {
-    if (fan < FAN_COUNT)
-      thermalManager.set_fan_speed(fan - FAN0, map(clamp(value, 0, 100), 0, 100, 0, 255));
+    #if FAN_COUNT > 0
+      if (fan < FAN_COUNT)
+        thermalManager.set_fan_speed(fan - FAN0, map(clamp(value, 0, 100), 0, 100, 0, 255));
+    #endif
   }
 
   void setFeedrate_percent(const float value) {

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -794,6 +794,10 @@ namespace ExtUI {
     return TEST(axis_known_position, axis);
   }
 
+  bool isAxisPositionKnown(const extruder_t) {
+    return TEST(axis_known_position, E_AXIS);
+  }
+
   bool isPositionKnown() { return all_axes_known(); }
   bool isMachineHomed() { return all_axes_homed(); }
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -245,6 +245,7 @@ namespace ExtUI {
     #if FAN_COUNT > 0
       return thermalManager.fanPercent(thermalManager.fan_speed[fan - FAN0]);
     #else
+      UNUSED(fan);
       return 0;
     #endif
   }
@@ -253,6 +254,7 @@ namespace ExtUI {
     #if FAN_COUNT > 0
       return thermalManager.fanPercent(thermalManager.scaledFanSpeed(fan - FAN0));
     #else
+      UNUSED(fan);
       return 0;
     #endif
   }
@@ -261,7 +263,7 @@ namespace ExtUI {
     return flags.manual_motion ? destination[axis] : current_position[axis];
   }
 
-  float getAxisPosition_mm(const extruder_t extruder) {
+  float getAxisPosition_mm(const extruder_t) {
     return flags.manual_motion ? destination[E_AXIS] : current_position[E_AXIS];
   }
 
@@ -361,6 +363,9 @@ namespace ExtUI {
         if (e != active_extruder) tool_change(e, no_move);
       #endif
       active_extruder = e;
+    #else
+      UNUSED(extruder);
+      UNUSED(no_move);
     #endif
   }
 
@@ -514,6 +519,9 @@ namespace ExtUI {
   }
 
   float getAxisSteps_per_mm(const extruder_t extruder) {
+    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
+      UNUSED(extruder);
+    #endif
     return planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)];
   }
 
@@ -522,6 +530,9 @@ namespace ExtUI {
   }
 
   void setAxisSteps_per_mm(const float value, const extruder_t extruder) {
+    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
+      UNUSED(extruder);
+    #endif
     planner.settings.axis_steps_per_mm[E_AXIS_N(axis - E0)] = value;
   }
 
@@ -530,6 +541,9 @@ namespace ExtUI {
   }
 
   float getAxisMaxFeedrate_mm_s(const extruder_t extruder) {
+    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
+      UNUSED(extruder);
+    #endif
     return planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E0)];
   }
 
@@ -538,6 +552,9 @@ namespace ExtUI {
   }
 
   void setAxisMaxFeedrate_mm_s(const float value, const extruder_t extruder) {
+    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
+      UNUSED(extruder);
+    #endif
     planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E0)] = value;
   }
 
@@ -546,6 +563,9 @@ namespace ExtUI {
   }
 
   float getAxisMaxAcceleration_mm_s2(const extruder_t extruder) {
+    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
+      UNUSED(extruder);
+    #endif
     return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)];
   }
 
@@ -554,6 +574,9 @@ namespace ExtUI {
   }
 
   void setAxisMaxAcceleration_mm_s2(const float value, const extruder_t extruder) {
+    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
+      UNUSED(extruder);
+    #endif
     planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)] = value;
   }
 
@@ -597,7 +620,7 @@ namespace ExtUI {
       return planner.max_jerk[axis];
     }
 
-    float getAxisMaxJerk_mm_s(const extruder_t extruder) {
+    float getAxisMaxJerk_mm_s(const extruder_t) {
       return planner.max_jerk[E_AXIS];
     }
 
@@ -605,7 +628,7 @@ namespace ExtUI {
       planner.max_jerk[axis] = value;
     }
 
-    void setAxisMaxJerk_mm_s(const float value, const extruder_t extruder) {
+    void setAxisMaxJerk_mm_s(const float value, const extruder_t) {
       planner.max_jerk[E_AXIS] = value;
     }
   #endif
@@ -829,6 +852,9 @@ namespace ExtUI {
     #if FAN_COUNT > 0
       if (fan < FAN_COUNT)
         thermalManager.set_fan_speed(fan - FAN0, map(clamp(value, 0, 100), 0, 100, 0, 255));
+    #else
+      UNUSED(value);
+      UNUSED(fan);
     #endif
   }
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -519,9 +519,7 @@ namespace ExtUI {
   }
 
   float getAxisSteps_per_mm(const extruder_t extruder) {
-    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
-      UNUSED(extruder);
-    #endif
+    UNUSED_E(extruder);
     return planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)];
   }
 
@@ -530,9 +528,7 @@ namespace ExtUI {
   }
 
   void setAxisSteps_per_mm(const float value, const extruder_t extruder) {
-    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
-      UNUSED(extruder);
-    #endif
+    UNUSED_E(extruder);
     planner.settings.axis_steps_per_mm[E_AXIS_N(axis - E0)] = value;
   }
 
@@ -541,9 +537,7 @@ namespace ExtUI {
   }
 
   float getAxisMaxFeedrate_mm_s(const extruder_t extruder) {
-    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
-      UNUSED(extruder);
-    #endif
+    UNUSED_E(extruder);
     return planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E0)];
   }
 
@@ -552,9 +546,7 @@ namespace ExtUI {
   }
 
   void setAxisMaxFeedrate_mm_s(const float value, const extruder_t extruder) {
-    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
-      UNUSED(extruder);
-    #endif
+    UNUSED_E(extruder);
     planner.settings.max_feedrate_mm_s[E_AXIS_N(axis - E0)] = value;
   }
 
@@ -563,9 +555,7 @@ namespace ExtUI {
   }
 
   float getAxisMaxAcceleration_mm_s2(const extruder_t extruder) {
-    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
-      UNUSED(extruder);
-    #endif
+    UNUSED_E(extruder);
     return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)];
   }
 
@@ -574,9 +564,7 @@ namespace ExtUI {
   }
 
   void setAxisMaxAcceleration_mm_s2(const float value, const extruder_t extruder) {
-    #if DISABLED(DISTINCT_E_FACTORS) || E_STEPPERS == 1
-      UNUSED(extruder);
-    #endif
+    UNUSED_E(extruder);
     planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)] = value;
   }
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -780,7 +780,7 @@ namespace ExtUI {
     queue.inject_P(gcode);
   }
 
-  bool commandsInQueue() { return (planner.movesplanned() || queue.length); }
+  bool commandsInQueue() { return (planner.movesplanned() || queue.has_commands_queued()); }
 
   bool isAxisPositionKnown(const axis_t axis) {
     return TEST(axis_known_position, axis);

--- a/Marlin/src/lcd/menu/menu_sdcard.cpp
+++ b/Marlin/src/lcd/menu/menu_sdcard.cpp
@@ -93,7 +93,7 @@ inline void sdcard_start_selected_file() {
 
 class MenuItem_sdfile {
   public:
-    static void action(CardReader &theCard) {
+    static void action(CardReader &) {
       #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
         // Save menu state for the selected file
         sd_encoder_position = ui.encoderPosition;


### PR DESCRIPTION
- Fix ExtUI::commandsInQueue so it counts injected commands.
- Fix compile error when compiling for printers with no fans
- Allow ExtUI::isAxisPositionKnown to take E_AXIS **
- Silence warnings about unused parameters


** Currently this flag is never true in Marlin, but in our bioprinter branch we home the extruder and set this flag to true.