### PR TITLE
Fix MKS Robin Nano FAN_PIN

### DIFF
--- a/Marlin/src/pins/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/pins_MKS_ROBIN_NANO.h
@@ -89,7 +89,7 @@
 #define HEATER_1_PIN       PB0   // HEATER2
 #define HEATER_BED_PIN     PA0   // HOT BED
 
-#define FAN_PIN            PA1   // FAN
+#define FAN_PIN            PB1   // FAN
 
 #define BTN_ENC            PC13  // Pin is not connected. Real pin is needed to enable encoder's push button functionality used by touch screen
 


### PR DESCRIPTION
### Description

The Nano's `FAN_PIN` should be defined as `PB2` instead of `PB1`. (Thanks to Rob Cad in Tevo's Nereus Facebook group for discovering this!)

### Benefits

Setting `E0_AUTO_FAN_PIN` to `FAN1_PIN` works as intended.

### Related Issues

None.