### PR TITLE
Make KEEPALIVE_STATE a scoped auto-restore

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -768,8 +768,7 @@
             ui.wait_for_release();
             ui.quick_feedback();
             ui.release();
-            restore_ubl_active_state_and_leave();
-            return;
+            return restore_ubl_active_state_and_leave();
           }
         #endif
 
@@ -844,7 +843,6 @@
     float unified_bed_leveling::measure_point_with_encoder() {
       KEEPALIVE_STATE(PAUSED_FOR_USER);
       move_z_with_encoder(0.01f);
-      KEEPALIVE_STATE(IN_HANDLER);
       return current_position[Z_AXIS];
     }
 
@@ -889,15 +887,6 @@
       return thickness;
     }
 
-    void abort_manual_probe_remaining_mesh() {
-      SERIAL_ECHOLNPGM("\nMesh only partially populated.");
-      do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);
-      ui.release();
-      KEEPALIVE_STATE(IN_HANDLER);
-      ui.quick_feedback();
-      ubl.restore_ubl_active_state_and_leave();
-    }
-
     void unified_bed_leveling::manually_probe_remaining_mesh(const float &rx, const float &ry, const float &z_clearance, const float &thick, const bool do_ubl_mesh_map) {
 
       ui.capture();
@@ -939,9 +928,7 @@
           SERIAL_ECHOLNPGM("\nMesh only partially populated.");
           do_blocking_move_to_z(Z_CLEARANCE_DEPLOY_PROBE);
           ui.release();
-          KEEPALIVE_STATE(IN_HANDLER);
-          restore_ubl_active_state_and_leave();
-          return;
+          return restore_ubl_active_state_and_leave();
         }
 
         z_values[location.x_index][location.y_index] = current_position[Z_AXIS] - thick;
@@ -957,7 +944,6 @@
       if (do_ubl_mesh_map) display_map(g29_map_type);  // show user where we're probing
 
       restore_ubl_active_state_and_leave();
-      KEEPALIVE_STATE(IN_HANDLER);
       do_blocking_move_to(rx, ry, Z_CLEARANCE_DEPLOY_PROBE);
     }
 
@@ -1046,7 +1032,7 @@
 
         if (!lcd_map_control) ui.return_to_status();                // Just editing a single point? Return to status
 
-        if (click_and_hold(abort_fine_tune)) goto FINE_TUNE_EXIT;   // If the click is held down, abort editing
+        if (click_and_hold(abort_fine_tune)) break;                 // Button held down? Abort editing
 
         z_values[location.x_index][location.y_index] = new_z;       // Save the updated Z value
         #if ENABLED(EXTENSIBLE_UI)
@@ -1058,10 +1044,7 @@
 
       } while (location.x_index >= 0 && --g29_repetition_cnt > 0);
 
-      FINE_TUNE_EXIT:
-
       ui.release();
-      KEEPALIVE_STATE(IN_HANDLER);
 
       if (do_ubl_mesh_map) display_map(g29_map_type);
       restore_ubl_active_state_and_leave();

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -189,7 +189,6 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
       #endif
       idle(true);
     }
-    KEEPALIVE_STATE(IN_HANDLER);
   }
 
   #if HAS_LCD_MENU
@@ -278,7 +277,6 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
           wait_for_user = false;
           lcd_pause_show_message(PAUSE_MESSAGE_OPTION);
           while (pause_menu_response == PAUSE_RESPONSE_WAIT_FOR) idle(true);
-          KEEPALIVE_STATE(IN_HANDLER);
         }
       #endif
 
@@ -580,7 +578,6 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
     extruder_duplication_enabled = saved_ext_dup_mode;
     stepper.set_directions();
   #endif
-  KEEPALIVE_STATE(IN_HANDLER);
 }
 
 /**

--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -47,8 +47,8 @@ MMU2 mmu2;
 
 #define MMU_TODELAY 100
 #define MMU_TIMEOUT 10
-#define MMU_CMD_TIMEOUT 60000ul //5min timeout for mmu commands (except P0)
-#define MMU_P0_TIMEOUT 3000ul //timeout for P0 command: 3seconds
+#define MMU_CMD_TIMEOUT 60000ul // 5min timeout for mmu commands (except P0)
+#define MMU_P0_TIMEOUT 3000ul   // Timeout for P0 command: 3seconds
 
 #define MMU_CMD_NONE 0
 #define MMU_CMD_T0   0x10
@@ -327,7 +327,6 @@ void MMU2::mmu_loop() {
   }
 }
 
-
 /**
  * Check if MMU was started
  */
@@ -339,7 +338,6 @@ bool MMU2::rx_start() {
   }
   return false;
 }
-
 
 /**
  * Check if the data received ends with the given string.
@@ -373,7 +371,6 @@ bool MMU2::rx_str_P(const char* str) {
   return true;
 }
 
-
 /**
  * Transfer data to MMU, no argument
  */
@@ -384,7 +381,6 @@ void MMU2::tx_str_P(const char* str) {
   rx_buffer[0] = '\0';
   last_request = millis();
 }
-
 
 /**
  * Transfer data to MMU, single argument
@@ -397,7 +393,6 @@ void MMU2::tx_printf_P(const char* format, int argument = -1) {
   last_request = millis();
 }
 
-
 /**
  * Transfer data to MMU, two arguments
  */
@@ -409,7 +404,6 @@ void MMU2::tx_printf_P(const char* format, int argument1, int argument2) {
   last_request = millis();
 }
 
-
 /**
  * Empty the rx buffer
  */
@@ -417,7 +411,6 @@ void MMU2::clear_rx_buffer() {
   while (mmuSerial.available()) mmuSerial.read();
   rx_buffer[0] = '\0';
 }
-
 
 /**
  * Check if we received 'ok' from MMU
@@ -429,7 +422,6 @@ bool MMU2::rx_ok() {
   }
   return false;
 }
-
 
 /**
  * Check if MMU has compatible firmware
@@ -443,7 +435,6 @@ void MMU2::check_version() {
   }
 }
 
-
 /**
  * Handle tool change
  */
@@ -455,14 +446,12 @@ void MMU2::tool_change(uint8_t index) {
 
   if (index != extruder) {
 
-    KEEPALIVE_STATE(IN_HANDLER);
     disable_E0();
     ui.status_printf_P(0, PSTR(MSG_MMU2_LOADING_FILAMENT), int(index + 1));
 
     command(MMU_CMD_T0 + index);
 
     manage_response(true, true);
-    KEEPALIVE_STATE(IN_HANDLER);
 
     command(MMU_CMD_C0);
     extruder = index; //filament change is finished
@@ -474,12 +463,10 @@ void MMU2::tool_change(uint8_t index) {
     SERIAL_ECHOLNPAIR(MSG_ACTIVE_EXTRUDER, int(extruder));
 
     ui.reset_status();
-    KEEPALIVE_STATE(NOT_BUSY);
   }
 
   set_runout_valid(true);
 }
-
 
 /**
  *
@@ -497,7 +484,6 @@ void MMU2::tool_change(const char* special) {
   #if ENABLED(MMU2_MENUS)
 
     set_runout_valid(false);
-    KEEPALIVE_STATE(IN_HANDLER);
 
     switch (*special) {
       case '?': {
@@ -526,13 +512,10 @@ void MMU2::tool_change(const char* special) {
       } break;
     }
 
-    KEEPALIVE_STATE(NOT_BUSY);
-
     set_runout_valid(true);
 
   #endif
 }
-
 
 /**
  * Set next command
@@ -542,7 +525,6 @@ void MMU2::command(const uint8_t mmu_cmd) {
   cmd = mmu_cmd;
   ready = false;
 }
-
 
 /**
  * Wait for response from MMU
@@ -561,11 +543,10 @@ bool MMU2::get_response(void) {
   return ret;
 }
 
-
 /**
  * Wait for response and deal with timeout if nexcessary
  */
-void MMU2::manage_response(bool move_axes, bool turn_off_nozzle) {
+void MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
 
   bool response = false;
   mmu_print_saved = false;
@@ -573,12 +554,14 @@ void MMU2::manage_response(bool move_axes, bool turn_off_nozzle) {
   float resume_position[XYZE];
   int16_t resume_hotend_temp;
 
+  KEEPALIVE_STATE(PAUSED_FOR_USER);
+
   while (!response) {
 
-    response = get_response(); //wait for "ok" from mmu
+    response = get_response(); // wait for "ok" from mmu
 
-    if (!response) { //no "ok" was received in reserved time frame, user will fix the issue on mmu unit
-      if (!mmu_print_saved) { //first occurence, we are saving current position, park print head in certain position and disable nozzle heater
+    if (!response) {          // No "ok" was received in reserved time frame, user will fix the issue on mmu unit
+      if (!mmu_print_saved) { // First occurrence. Save current position, park print head, disable nozzle heater.
 
         planner.synchronize();
 
@@ -600,13 +583,10 @@ void MMU2::manage_response(bool move_axes, bool turn_off_nozzle) {
         BUZZ(100, 659);
         BUZZ(300, 440);
         BUZZ(100, 659);
-
-        KEEPALIVE_STATE(PAUSED_FOR_USER);
       }
     }
     else if (mmu_print_saved) {
       SERIAL_ECHOLNPGM("MMU starts responding\n");
-      KEEPALIVE_STATE(IN_HANDLER);
 
       if (turn_off_nozzle && resume_hotend_temp) {
         thermalManager.setTargetHotend(resume_hotend_temp, active_extruder);
@@ -639,14 +619,10 @@ void MMU2::manage_response(bool move_axes, bool turn_off_nozzle) {
 void MMU2::set_filament_type(uint8_t index, uint8_t filamentType) {
   if (!enabled) return;
 
-  KEEPALIVE_STATE(IN_HANDLER);
-
   cmd_arg = filamentType;
   command(MMU_CMD_F0 + index);
 
   manage_response(true, true);
-
-  KEEPALIVE_STATE(NOT_BUSY);
 }
 
 void MMU2::filament_runout() {
@@ -679,8 +655,6 @@ void MMU2::filament_runout() {
       return false;
     }
     else {
-      KEEPALIVE_STATE(IN_HANDLER);
-
       command(MMU_CMD_T0 + index);
       manage_response(true, true);
       command(MMU_CMD_C0);
@@ -692,8 +666,6 @@ void MMU2::filament_runout() {
       load_to_nozzle();
 
       BUZZ(200, 404);
-
-      KEEPALIVE_STATE(NOT_BUSY);
       return true;
     }
   }
@@ -721,7 +693,6 @@ void MMU2::filament_runout() {
       return false;
     }
 
-    KEEPALIVE_STATE(IN_HANDLER);
     LCD_MESSAGEPGM(MSG_MMU2_EJECTING_FILAMENT);
     const bool saved_e_relative_mode = gcode.axis_relative_modes[E_AXIS];
     gcode.axis_relative_modes[E_AXIS] = true;
@@ -757,8 +728,6 @@ void MMU2::filament_runout() {
 
     BUZZ(200, 404);
 
-    KEEPALIVE_STATE(NOT_BUSY);
-
     gcode.axis_relative_modes[E_AXIS] = saved_e_relative_mode;
 
     disable_E0();
@@ -781,8 +750,6 @@ void MMU2::filament_runout() {
       return false;
     }
 
-    KEEPALIVE_STATE(IN_HANDLER);
-
     filament_ramming();
 
     command(MMU_CMD_U0);
@@ -794,8 +761,6 @@ void MMU2::filament_runout() {
     extruder = MMU2_NO_TOOL;
 
     set_runout_valid(false);
-
-    KEEPALIVE_STATE(NOT_BUSY);
 
     return true;
   }

--- a/Marlin/src/feature/prusa_MMU2/mmu2.h
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.h
@@ -63,7 +63,7 @@ private:
 
   static void command(const uint8_t cmd);
   static bool get_response(void);
-  static void manage_response(bool move_axes, bool turn_off_nozzle);
+  static void manage_response(const bool move_axes, const bool turn_off_nozzle);
 
   #if HAS_LCD_MENU && ENABLED(MMU2_MENUS)
     static void load_to_nozzle();

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -978,8 +978,6 @@ G29_TYPE GcodeSuite::G29() {
 
   if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< G29");
 
-  KEEPALIVE_STATE(IN_HANDLER);
-
   if (planner.leveling_active)
     sync_plan_position();
 

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -320,11 +320,11 @@ void GcodeSuite::M43() {
     }
 
     #if HAS_RESUME_CONTINUE
+      KEEPALIVE_STATE(PAUSED_FOR_USER);
       wait_for_user = true;
       #if ENABLED(HOST_PROMPT_SUPPORT)
         host_prompt_do(PROMPT_USER_CONTINUE, PSTR("M43 Wait Called"), PSTR("Continue"));
       #endif
-      KEEPALIVE_STATE(PAUSED_FOR_USER);
     #endif
 
     for (;;) {
@@ -346,7 +346,7 @@ void GcodeSuite::M43() {
       }
 
       #if HAS_RESUME_CONTINUE
-        if (!wait_for_user) { KEEPALIVE_STATE(IN_HANDLER); break; }
+        if (!wait_for_user) break;
       #endif
 
       safe_delay(200);

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -430,7 +430,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
         //case 191: M191(); break;                                // M191: Wait for chamber temperature to reach target
       #endif
 
-      case 105: M105(); KEEPALIVE_STATE(NOT_BUSY); return;        // M105: Report Temperatures (and say "ok")
+      case 105: M105(); return;                                   // M105: Report Temperatures (and say "ok")
 
       #if ENABLED(AUTO_REPORT_TEMPERATURES) && HAS_TEMP_SENSOR
         case 155: M155(); break;                                  // M155: Set temperature auto-report interval
@@ -795,8 +795,6 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
 
     default: parser.unknown_command_error();
   }
-
-  KEEPALIVE_STATE(NOT_BUSY);
 
   if (!no_ok) queue.ok_to_send();
 }

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -339,9 +339,9 @@ public:
 
     static void host_keepalive();
 
-    #define KEEPALIVE_STATE(n) gcode.busy_state = gcode.n
+    #define KEEPALIVE_STATE(N) REMEMBER(_KA_, gcode.busy_state, gcode.N)
   #else
-    #define KEEPALIVE_STATE(n) NOOP
+    #define KEEPALIVE_STATE(N) NOOP
   #endif
 
   static void dwell(millis_t time);

--- a/Marlin/src/gcode/lcd/M0_M1.cpp
+++ b/Marlin/src/gcode/lcd/M0_M1.cpp
@@ -118,7 +118,6 @@ void GcodeSuite::M0_M1() {
   #endif
 
   wait_for_user = false;
-  KEEPALIVE_STATE(IN_HANDLER);
 }
 
 #endif // HAS_RESUME_CONTINUE

--- a/Marlin/src/gcode/temperature/M303.cpp
+++ b/Marlin/src/gcode/temperature/M303.cpp
@@ -62,10 +62,6 @@ void GcodeSuite::M303() {
   #endif
 
   thermalManager.PID_autotune(temp, e, c, u);
-
-  #if DISABLED(BUSY_WHILE_HEATING)
-    KEEPALIVE_STATE(IN_HANDLER);
-  #endif
 }
 
 #endif // HAS_PID_HEATING

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -56,7 +56,6 @@ void _man_probe_pt(const float &rx, const float &ry) {
       host_prompt_do(PROMPT_USER_CONTINUE, PSTR("Delta Calibration in progress"), PSTR("Continue"));
     #endif
     while (wait_for_user) idle();
-    KEEPALIVE_STATE(IN_HANDLER);
     ui.goto_previous_screen_no_defer();
     return current_position[Z_AXIS];
   }

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -355,7 +355,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
       #endif
       while (wait_for_user) idle();
       ui.reset_status();
-      KEEPALIVE_STATE(IN_HANDLER);
+
     } while(
       #if ENABLED(PAUSE_PROBE_DEPLOY_WHEN_TRIGGERED)
         true

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2925,7 +2925,6 @@ void Temperature::isr() {
       #endif
 
       #if DISABLED(BUSY_WHILE_HEATING) && ENABLED(HOST_KEEPALIVE_FEATURE)
-        const GcodeSuite::MarlinBusyState old_busy_state = gcode.busy_state;
         KEEPALIVE_STATE(NOT_BUSY);
       #endif
 
@@ -3019,10 +3018,6 @@ void Temperature::isr() {
         #endif
       }
 
-      #if DISABLED(BUSY_WHILE_HEATING) && ENABLED(HOST_KEEPALIVE_FEATURE)
-        gcode.busy_state = old_busy_state;
-      #endif
-
       return wait_for_heatup;
     }
 
@@ -3058,7 +3053,6 @@ void Temperature::isr() {
       millis_t now, next_temp_ms = 0, next_cool_check_ms = 0;
 
       #if DISABLED(BUSY_WHILE_HEATING) && ENABLED(HOST_KEEPALIVE_FEATURE)
-        const GcodeSuite::MarlinBusyState old_busy_state = gcode.busy_state;
         KEEPALIVE_STATE(NOT_BUSY);
       #endif
 
@@ -3145,10 +3139,6 @@ void Temperature::isr() {
 
       if (wait_for_heatup) ui.reset_status();
 
-      #if DISABLED(BUSY_WHILE_HEATING) && ENABLED(HOST_KEEPALIVE_FEATURE)
-        gcode.busy_state = old_busy_state;
-      #endif
-
       return wait_for_heatup;
     }
 
@@ -3179,7 +3169,6 @@ void Temperature::isr() {
       millis_t now, next_temp_ms = 0, next_cool_check_ms = 0;
 
       #if DISABLED(BUSY_WHILE_HEATING) && ENABLED(HOST_KEEPALIVE_FEATURE)
-        const GcodeSuite::MarlinBusyState old_busy_state = gcode.busy_state;
         KEEPALIVE_STATE(NOT_BUSY);
       #endif
 
@@ -3246,10 +3235,6 @@ void Temperature::isr() {
       } while (wait_for_heatup && TEMP_CHAMBER_CONDITIONS);
 
       if (wait_for_heatup) ui.reset_status();
-
-      #if DISABLED(BUSY_WHILE_HEATING) && ENABLED(HOST_KEEPALIVE_FEATURE)
-        gcode.busy_state = old_busy_state;
-      #endif
 
       return wait_for_heatup;
     }


### PR DESCRIPTION
The host keepalive state is an ideal candidate for save and restore while in scope using `REMEMBER`. This PR reduces the amount of C++ but in some instances results in one or two extra bytes in the binary size.

Also:
- Obsolete method from UBL can be removed.
- MMU2 keepalive state handling is simplified, may need refinement.
