### PR TITLE
Update motherboard numbering

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -122,188 +122,194 @@ ifeq ($(HARDWARE_MOTHERBOARD),0)
 #
 
 # MEGA/RAMPS up to 1.2
-else ifeq ($(HARDWARE_MOTHERBOARD),3)
+else ifeq ($(HARDWARE_MOTHERBOARD),1000)
 
 # RAMPS 1.3 (Power outputs: Hotend, Fan, Bed)
-else ifeq ($(HARDWARE_MOTHERBOARD),33)
+else ifeq ($(HARDWARE_MOTHERBOARD),1010)
 # RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Bed)
-else ifeq ($(HARDWARE_MOTHERBOARD),34)
+else ifeq ($(HARDWARE_MOTHERBOARD),1011)
 # RAMPS 1.3 (Power outputs: Hotend, Fan0, Fan1)
-else ifeq ($(HARDWARE_MOTHERBOARD),35)
+else ifeq ($(HARDWARE_MOTHERBOARD),1012)
 # RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Fan)
-else ifeq ($(HARDWARE_MOTHERBOARD),36)
+else ifeq ($(HARDWARE_MOTHERBOARD),1013)
 # RAMPS 1.3 (Power outputs: Spindle, Controller Fan)
-else ifeq ($(HARDWARE_MOTHERBOARD),38)
+else ifeq ($(HARDWARE_MOTHERBOARD),1014)
 
 # RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
-else ifeq ($(HARDWARE_MOTHERBOARD),43)
+else ifeq ($(HARDWARE_MOTHERBOARD),1020)
 # RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
-else ifeq ($(HARDWARE_MOTHERBOARD),44)
+else ifeq ($(HARDWARE_MOTHERBOARD),1021)
 # RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
-else ifeq ($(HARDWARE_MOTHERBOARD),45)
+else ifeq ($(HARDWARE_MOTHERBOARD),1022)
 # RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
-else ifeq ($(HARDWARE_MOTHERBOARD),46)
+else ifeq ($(HARDWARE_MOTHERBOARD),1023)
 # RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
-else ifeq ($(HARDWARE_MOTHERBOARD),48)
+else ifeq ($(HARDWARE_MOTHERBOARD),1024)
 
 # RAMPS Plus 3DYMY (Power outputs: Hotend, Fan, Bed)
-else ifeq ($(HARDWARE_MOTHERBOARD),143)
+else ifeq ($(HARDWARE_MOTHERBOARD),1030)
 # RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Bed)
-else ifeq ($(HARDWARE_MOTHERBOARD),144)
+else ifeq ($(HARDWARE_MOTHERBOARD),1031)
 # RAMPS Plus 3DYMY (Power outputs: Hotend, Fan0, Fan1)
-else ifeq ($(HARDWARE_MOTHERBOARD),145)
+else ifeq ($(HARDWARE_MOTHERBOARD),1032)
 # RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Fan)
-else ifeq ($(HARDWARE_MOTHERBOARD),146)
+else ifeq ($(HARDWARE_MOTHERBOARD),1033)
 # RAMPS Plus 3DYMY (Power outputs: Spindle, Controller Fan)
-else ifeq ($(HARDWARE_MOTHERBOARD),148)
+else ifeq ($(HARDWARE_MOTHERBOARD),1034)
 
 #
 # RAMPS Derivatives - ATmega1280, ATmega2560
 #
 
 # 3Drag Controller
-else ifeq ($(HARDWARE_MOTHERBOARD),77)
+else ifeq ($(HARDWARE_MOTHERBOARD),1100)
 # Velleman K8200 Controller (derived from 3Drag Controller)
-else ifeq ($(HARDWARE_MOTHERBOARD),78)
+else ifeq ($(HARDWARE_MOTHERBOARD),1101)
 # Velleman K8400 Controller (derived from 3Drag Controller)
-else ifeq ($(HARDWARE_MOTHERBOARD),79)
+else ifeq ($(HARDWARE_MOTHERBOARD),1102)
 # 2PrintBeta BAM&DICE with STK drivers
-else ifeq ($(HARDWARE_MOTHERBOARD),401)
+else ifeq ($(HARDWARE_MOTHERBOARD),1103)
 # 2PrintBeta BAM&DICE Due with STK drivers
-else ifeq ($(HARDWARE_MOTHERBOARD),402)
+else ifeq ($(HARDWARE_MOTHERBOARD),1104)
 # MKS BASE v1.0
-else ifeq ($(HARDWARE_MOTHERBOARD),40)
+else ifeq ($(HARDWARE_MOTHERBOARD),1105)
+# MKS v1.4 with A4982 stepper drivers
+else ifeq ($(HARDWARE_MOTHERBOARD),1106)
 # MKS v1.5 with Allegro A4982 stepper drivers
-else ifeq ($(HARDWARE_MOTHERBOARD),405)
+else ifeq ($(HARDWARE_MOTHERBOARD),1107)
 # MKS BASE 1.0 with Heroic HR4982 stepper drivers
-else ifeq ($(HARDWARE_MOTHERBOARD),41)
+else ifeq ($(HARDWARE_MOTHERBOARD),1108)
 # MKS GEN v1.3 or 1.4
-else ifeq ($(HARDWARE_MOTHERBOARD),47)
+else ifeq ($(HARDWARE_MOTHERBOARD),1109)
 # MKS GEN L
-else ifeq ($(HARDWARE_MOTHERBOARD),53)
+else ifeq ($(HARDWARE_MOTHERBOARD),1110)
 # zrib V2.0 control board (Chinese knock off RAMPS replica)
-else ifeq ($(HARDWARE_MOTHERBOARD),504)
+else ifeq ($(HARDWARE_MOTHERBOARD),1111)
+# Bigtreetech or BIQU KFB2.0
+else ifeq ($(HARDWARE_MOTHERBOARD),1112)
 # Felix 2.0+ Electronics Board (RAMPS like)
-else ifeq ($(HARDWARE_MOTHERBOARD),37)
+else ifeq ($(HARDWARE_MOTHERBOARD),1113)
 # Invent-A-Part RigidBoard
-else ifeq ($(HARDWARE_MOTHERBOARD),42)
+else ifeq ($(HARDWARE_MOTHERBOARD),1114)
 # Invent-A-Part RigidBoard V2
-else ifeq ($(HARDWARE_MOTHERBOARD),52)
+else ifeq ($(HARDWARE_MOTHERBOARD),1115)
 # Sainsmart 2-in-1 board
-else ifeq ($(HARDWARE_MOTHERBOARD),49)
+else ifeq ($(HARDWARE_MOTHERBOARD),1116)
 # Ultimaker
-else ifeq ($(HARDWARE_MOTHERBOARD),7)
+else ifeq ($(HARDWARE_MOTHERBOARD),1117)
 # Ultimaker (Older electronics. Pre 1.5.4. This is rare)
-else ifeq ($(HARDWARE_MOTHERBOARD),71)
+else ifeq ($(HARDWARE_MOTHERBOARD),1118)
   MCU ?= atmega1280
 
 # Azteeg X3
-else ifeq ($(HARDWARE_MOTHERBOARD),67)
+else ifeq ($(HARDWARE_MOTHERBOARD),1119)
 # Azteeg X3 Pro
-else ifeq ($(HARDWARE_MOTHERBOARD),68)
+else ifeq ($(HARDWARE_MOTHERBOARD),1120)
 # Ultimainboard 2.x (Uses TEMP_SENSOR 20)
-else ifeq ($(HARDWARE_MOTHERBOARD),72)
+else ifeq ($(HARDWARE_MOTHERBOARD),1121)
 # Rumba
-else ifeq ($(HARDWARE_MOTHERBOARD),80)
+else ifeq ($(HARDWARE_MOTHERBOARD),1122)
 # Raise3D Rumba
-else ifeq ($(HARDWARE_MOTHERBOARD),333)
+else ifeq ($(HARDWARE_MOTHERBOARD),1123)
 # Rapide Lite RL200 Rumba
-else ifeq ($(HARDWARE_MOTHERBOARD),801)
+else ifeq ($(HARDWARE_MOTHERBOARD),1124)
 # Formbot T-Rex 2 Plus
-else ifeq ($(HARDWARE_MOTHERBOARD),95)
+else ifeq ($(HARDWARE_MOTHERBOARD),1125)
 # Formbot T-Rex 3
-else ifeq ($(HARDWARE_MOTHERBOARD),96)
+else ifeq ($(HARDWARE_MOTHERBOARD),1126)
 # Formbot Raptor
-else ifeq ($(HARDWARE_MOTHERBOARD),97)
+else ifeq ($(HARDWARE_MOTHERBOARD),1127)
 # Formbot Raptor 2
-else ifeq ($(HARDWARE_MOTHERBOARD),98)
+else ifeq ($(HARDWARE_MOTHERBOARD),1128)
 # bq ZUM Mega 3D
-else ifeq ($(HARDWARE_MOTHERBOARD),503)
+else ifeq ($(HARDWARE_MOTHERBOARD),1129)
 # MakeBoard Mini v2.1.2 is a control board sold by MicroMake
-else ifeq ($(HARDWARE_MOTHERBOARD),431)
+else ifeq ($(HARDWARE_MOTHERBOARD),1130)
 # TriGorilla Anycubic version 1.3 based on RAMPS EFB
-else ifeq ($(HARDWARE_MOTHERBOARD),343)
+else ifeq ($(HARDWARE_MOTHERBOARD),1131)
 # TriGorilla Anycubic version 1.4 based on RAMPS EFB
-else ifeq ($(HARDWARE_MOTHERBOARD),443)
+else ifeq ($(HARDWARE_MOTHERBOARD),1132)
 # TriGorilla Anycubic version 1.4 Rev 1.1
-else ifeq ($(HARDWARE_MOTHERBOARD),444)
+else ifeq ($(HARDWARE_MOTHERBOARD),1133)
 # Creality: Ender-4, CR-8
-else ifeq ($(HARDWARE_MOTHERBOARD),243)
+else ifeq ($(HARDWARE_MOTHERBOARD),1134)
 # Creality: CR10S, CR20, CR-X
-else ifeq ($(HARDWARE_MOTHERBOARD),244)
+else ifeq ($(HARDWARE_MOTHERBOARD),1135)
 # Dagoma F5
-else ifeq ($(HARDWARE_MOTHERBOARD),245)
+else ifeq ($(HARDWARE_MOTHERBOARD),1136)
 # Fysetc F6
-else ifeq ($(HARDWARE_MOTHERBOARD),541)
+else ifeq ($(HARDWARE_MOTHERBOARD),1137)
 # Duplicator i3 Plus
-else ifeq ($(HARDWARE_MOTHERBOARD),31)
+else ifeq ($(HARDWARE_MOTHERBOARD),1138)
 # VORON
-else ifeq ($(HARDWARE_MOTHERBOARD),441)
+else ifeq ($(HARDWARE_MOTHERBOARD),1139)
 # TRONXY V3 1.0
-else ifeq ($(HARDWARE_MOTHERBOARD),442)
+else ifeq ($(HARDWARE_MOTHERBOARD),1140)
 # Z-Bolt X Series
-else ifeq ($(HARDWARE_MOTHERBOARD),550)
+else ifeq ($(HARDWARE_MOTHERBOARD),1141)
 
 #
 # Other ATmega1280, ATmega2560
 #
 
 # Cartesio CN Controls V11
-else ifeq ($(HARDWARE_MOTHERBOARD),111)
+else ifeq ($(HARDWARE_MOTHERBOARD),1200)
 # Cartesio CN Controls V12
-else ifeq ($(HARDWARE_MOTHERBOARD),112)
+else ifeq ($(HARDWARE_MOTHERBOARD),1201)
 # Cheaptronic v1.0
-else ifeq ($(HARDWARE_MOTHERBOARD),2)
+else ifeq ($(HARDWARE_MOTHERBOARD),1202)
 # Cheaptronic v2.0
-else ifeq ($(HARDWARE_MOTHERBOARD),21)
+else ifeq ($(HARDWARE_MOTHERBOARD),1203)
 # Makerbot Mightyboard Revision E
-else ifeq ($(HARDWARE_MOTHERBOARD),200)
+else ifeq ($(HARDWARE_MOTHERBOARD),1204)
 # Megatronics
-else ifeq ($(HARDWARE_MOTHERBOARD),70)
+else ifeq ($(HARDWARE_MOTHERBOARD),1205)
 # Megatronics v2.0
-else ifeq ($(HARDWARE_MOTHERBOARD),701)
+else ifeq ($(HARDWARE_MOTHERBOARD),1206)
 # Megatronics v3.0
-else ifeq ($(HARDWARE_MOTHERBOARD),703)
+else ifeq ($(HARDWARE_MOTHERBOARD),1207)
 # Megatronics v3.1
-else ifeq ($(HARDWARE_MOTHERBOARD),704)
+else ifeq ($(HARDWARE_MOTHERBOARD),1208)
+# Megatronics v3.2
+else ifeq ($(HARDWARE_MOTHERBOARD),1209)
 # Rambo
-else ifeq ($(HARDWARE_MOTHERBOARD),301)
+else ifeq ($(HARDWARE_MOTHERBOARD),1210)
 # Mini-Rambo
-else ifeq ($(HARDWARE_MOTHERBOARD),302)
+else ifeq ($(HARDWARE_MOTHERBOARD),1211)
 # Mini-Rambo 1.0a
-else ifeq ($(HARDWARE_MOTHERBOARD),303)
+else ifeq ($(HARDWARE_MOTHERBOARD),1212)
 # Einsy Rambo
-else ifeq ($(HARDWARE_MOTHERBOARD),304)
+else ifeq ($(HARDWARE_MOTHERBOARD),1213)
 # Einsy Retro
-else ifeq ($(HARDWARE_MOTHERBOARD),305)
+else ifeq ($(HARDWARE_MOTHERBOARD),1214)
 # Elefu Ra Board (v3)
-else ifeq ($(HARDWARE_MOTHERBOARD),23)
+else ifeq ($(HARDWARE_MOTHERBOARD),1215)
 # Leapfrog
-else ifeq ($(HARDWARE_MOTHERBOARD),999)
+else ifeq ($(HARDWARE_MOTHERBOARD),1216)
 # Mega controller
-else ifeq ($(HARDWARE_MOTHERBOARD),310)
+else ifeq ($(HARDWARE_MOTHERBOARD),1217)
 # abee Scoovo X9H
-else ifeq ($(HARDWARE_MOTHERBOARD),321)
+else ifeq ($(HARDWARE_MOTHERBOARD),1218)
 # Geeetech GT2560 Rev B for Mecreator2
-else ifeq ($(HARDWARE_MOTHERBOARD),73)
+else ifeq ($(HARDWARE_MOTHERBOARD),1219)
 # Geeetech GT2560 Rev. A
-else ifeq ($(HARDWARE_MOTHERBOARD),74)
+else ifeq ($(HARDWARE_MOTHERBOARD),1220)
 # Geeetech GT2560 Rev. A+ (with auto level probe)
-else ifeq ($(HARDWARE_MOTHERBOARD),75)
+else ifeq ($(HARDWARE_MOTHERBOARD),1221)
 # Geeetech GT2560 Rev B for A10(M/D)
-else ifeq ($(HARDWARE_MOTHERBOARD),76)
+else ifeq ($(HARDWARE_MOTHERBOARD),1222)
 # Geeetech GT2560 Rev B for A20(M/D)
-else ifeq ($(HARDWARE_MOTHERBOARD),86)
+else ifeq ($(HARDWARE_MOTHERBOARD),1223)
 # Einstart retrofit
-else ifeq ($(HARDWARE_MOTHERBOARD),666)
+else ifeq ($(HARDWARE_MOTHERBOARD),1224)
 
 #
 # ATmega1281, ATmega2561
 #
 
-else ifeq ($(HARDWARE_MOTHERBOARD),702)
+else ifeq ($(HARDWARE_MOTHERBOARD),1300)
   MCU              ?= atmega1281
-else ifeq ($(HARDWARE_MOTHERBOARD),25)
+else ifeq ($(HARDWARE_MOTHERBOARD),1310)
   MCU              ?= atmega1281
 
 #
@@ -311,43 +317,43 @@ else ifeq ($(HARDWARE_MOTHERBOARD),25)
 #
 
 # Sanguinololu < 1.2
-else ifeq ($(HARDWARE_MOTHERBOARD),6)
+else ifeq ($(HARDWARE_MOTHERBOARD),1400)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega644p
 # Sanguinololu 1.2 and above
-else ifeq ($(HARDWARE_MOTHERBOARD),62)
+else ifeq ($(HARDWARE_MOTHERBOARD),1401)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega644p
 # Melzi
-else ifeq ($(HARDWARE_MOTHERBOARD),63)
+else ifeq ($(HARDWARE_MOTHERBOARD),1402)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega644p
 # Melzi with ATmega1284 (MaKr3d version)
-else ifeq ($(HARDWARE_MOTHERBOARD),66)
+else ifeq ($(HARDWARE_MOTHERBOARD),1403)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega1284p
 # Melzi Creality3D board (for CR-10 etc)
-else ifeq ($(HARDWARE_MOTHERBOARD),89)
+else ifeq ($(HARDWARE_MOTHERBOARD),1404)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega1284p
 # Melzi Malyan M150 board
-else ifeq ($(HARDWARE_MOTHERBOARD),92)
+else ifeq ($(HARDWARE_MOTHERBOARD),1405)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega1284p
 # Tronxy X5S
-else ifeq ($(HARDWARE_MOTHERBOARD),505)
+else ifeq ($(HARDWARE_MOTHERBOARD),1406)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega1284p
 # STB V1.1
-else ifeq ($(HARDWARE_MOTHERBOARD),64)
+else ifeq ($(HARDWARE_MOTHERBOARD),1407)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega1284p
 # Azteeg X1
-else ifeq ($(HARDWARE_MOTHERBOARD),65)
+else ifeq ($(HARDWARE_MOTHERBOARD),1408)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega1284p
 # Anet 1.0 (Melzi clone)
-else ifeq ($(HARDWARE_MOTHERBOARD),69)
+else ifeq ($(HARDWARE_MOTHERBOARD),1409)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega1284p
 
@@ -356,51 +362,51 @@ else ifeq ($(HARDWARE_MOTHERBOARD),69)
 #
 
 # Gen3 Monolithic Electronics
-else ifeq ($(HARDWARE_MOTHERBOARD),22)
+else ifeq ($(HARDWARE_MOTHERBOARD),1500)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega644p
 # Gen3+
-else ifeq ($(HARDWARE_MOTHERBOARD),9)
+else ifeq ($(HARDWARE_MOTHERBOARD),1501)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega644p
 # Gen6
-else ifeq ($(HARDWARE_MOTHERBOARD),5)
+else ifeq ($(HARDWARE_MOTHERBOARD),1502)
   HARDWARE_VARIANT ?= Gen6
   MCU              ?= atmega644p
 # Gen6 deluxe
-else ifeq ($(HARDWARE_MOTHERBOARD),51)
+else ifeq ($(HARDWARE_MOTHERBOARD),1503)
   HARDWARE_VARIANT ?= Gen6
   MCU              ?= atmega644p
 # Gen7 custom (Alfons3 Version)
-else ifeq ($(HARDWARE_MOTHERBOARD),10)
+else ifeq ($(HARDWARE_MOTHERBOARD),1504)
   HARDWARE_VARIANT ?= Gen7
   MCU              ?= atmega644
   F_CPU            ?= 20000000
 # Gen7 v1.1, v1.2
-else ifeq ($(HARDWARE_MOTHERBOARD),11)
+else ifeq ($(HARDWARE_MOTHERBOARD),1505)
   HARDWARE_VARIANT ?= Gen7
   MCU              ?= atmega644p
   F_CPU            ?= 20000000
 # Gen7 v1.3
-else ifeq ($(HARDWARE_MOTHERBOARD),12)
+else ifeq ($(HARDWARE_MOTHERBOARD),1506)
   HARDWARE_VARIANT ?= Gen7
   MCU              ?= atmega644p
   F_CPU            ?= 20000000
 # Gen7 v1.4
-else ifeq ($(HARDWARE_MOTHERBOARD),13)
+else ifeq ($(HARDWARE_MOTHERBOARD),1507)
   HARDWARE_VARIANT ?= Gen7
   MCU              ?= atmega1284p
   F_CPU            ?= 20000000
 # Alpha OMCA board
-else ifeq ($(HARDWARE_MOTHERBOARD),90)
+else ifeq ($(HARDWARE_MOTHERBOARD),1508)
   HARDWARE_VARIANT ?= SanguinoA
   MCU              ?= atmega644
 # Final OMCA board
-else ifeq ($(HARDWARE_MOTHERBOARD),91)
+else ifeq ($(HARDWARE_MOTHERBOARD),1509)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega644p
 # Sethi 3D_1
-else ifeq ($(HARDWARE_MOTHERBOARD),20)
+else ifeq ($(HARDWARE_MOTHERBOARD),1510)
   HARDWARE_VARIANT ?= Sanguino
   MCU              ?= atmega644p
 
@@ -409,46 +415,46 @@ else ifeq ($(HARDWARE_MOTHERBOARD),20)
 #
 
 # Teensylu
-else ifeq ($(HARDWARE_MOTHERBOARD),8)
+else ifeq ($(HARDWARE_MOTHERBOARD),1600)
   HARDWARE_VARIANT ?= Teensy
   MCU              ?= at90usb1286
 # Printrboard (AT90USB1286)
-else ifeq ($(HARDWARE_MOTHERBOARD),81)
+else ifeq ($(HARDWARE_MOTHERBOARD),1601)
   HARDWARE_VARIANT ?= Teensy
   MCU              ?= at90usb1286
 # Printrboard Revision F (AT90USB1286)
-else ifeq ($(HARDWARE_MOTHERBOARD),811)
+else ifeq ($(HARDWARE_MOTHERBOARD),1602)
   HARDWARE_VARIANT ?= Teensy
   MCU              ?= at90usb1286
 # Brainwave (AT90USB646)
-else ifeq ($(HARDWARE_MOTHERBOARD),82)
+else ifeq ($(HARDWARE_MOTHERBOARD),1603)
   HARDWARE_VARIANT ?= Teensy
   MCU              ?= at90usb646
 # Brainwave Pro (AT90USB1286)
-else ifeq ($(HARDWARE_MOTHERBOARD),83)
+else ifeq ($(HARDWARE_MOTHERBOARD),1604)
   HARDWARE_VARIANT ?= Teensy
   MCU              ?= at90usb1286
 # SAV Mk-I (AT90USB1286)
-else ifeq ($(HARDWARE_MOTHERBOARD),84)
+else ifeq ($(HARDWARE_MOTHERBOARD),1605)
   HARDWARE_VARIANT ?= Teensy
   MCU              ?= at90usb1286
 # Teensy++2.0 (AT90USB1286)
-else ifeq ($(HARDWARE_MOTHERBOARD),85)
+else ifeq ($(HARDWARE_MOTHERBOARD),1606)
   HARDWARE_VARIANT ?= Teensy
   MCU              ?= at90usb1286
 # 5DPrint D8 Driver Board
-else ifeq ($(HARDWARE_MOTHERBOARD),88)
+else ifeq ($(HARDWARE_MOTHERBOARD),1607)
   HARDWARE_VARIANT ?= Teensy
   MCU              ?= at90usb1286
 
 # UltiMachine Archim1 (with DRV8825 drivers)
-else ifeq ($(HARDWARE_MOTHERBOARD),1591)
+else ifeq ($(HARDWARE_MOTHERBOARD),3023)
   HARDWARE_VARIANT ?= archim
   MCPU              = cortex-m3
   F_CPU             = 84000000L
   IS_MCU            = 0
 # UltiMachine Archim2 (with TMC2130 drivers)
-else ifeq ($(HARDWARE_MOTHERBOARD),1592)
+else ifeq ($(HARDWARE_MOTHERBOARD),3024)
   HARDWARE_VARIANT ?= archim
   MCPU              = cortex-m3
   F_CPU             = 84000000L

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -27,265 +27,265 @@
 // RAMPS 1.3 / 1.4 - ATmega1280, ATmega2560
 //
 
-#define BOARD_RAMPS_OLD                  3  // MEGA/RAMPS up to 1.2
+#define BOARD_RAMPS_OLD               1000  // MEGA/RAMPS up to 1.2
 
-#define BOARD_RAMPS_13_EFB              33  // RAMPS 1.3 (Power outputs: Hotend, Fan, Bed)
-#define BOARD_RAMPS_13_EEB              34  // RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Bed)
-#define BOARD_RAMPS_13_EFF              35  // RAMPS 1.3 (Power outputs: Hotend, Fan0, Fan1)
-#define BOARD_RAMPS_13_EEF              36  // RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Fan)
-#define BOARD_RAMPS_13_SF               38  // RAMPS 1.3 (Power outputs: Spindle, Controller Fan)
+#define BOARD_RAMPS_13_EFB            1010  // RAMPS 1.3 (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_13_EEB            1011  // RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_13_EFF            1012  // RAMPS 1.3 (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_13_EEF            1013  // RAMPS 1.3 (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_13_SF             1014  // RAMPS 1.3 (Power outputs: Spindle, Controller Fan)
 
-#define BOARD_RAMPS_14_EFB              43  // RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
-#define BOARD_RAMPS_14_EEB              44  // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
-#define BOARD_RAMPS_14_EFF              45  // RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
-#define BOARD_RAMPS_14_EEF              46  // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
-#define BOARD_RAMPS_14_SF               48  // RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
+#define BOARD_RAMPS_14_EFB            1020  // RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_14_EEB            1021  // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_14_EFF            1022  // RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_14_EEF            1023  // RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_14_SF             1024  // RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
 
-#define BOARD_RAMPS_PLUS_EFB           143  // RAMPS Plus 3DYMY (Power outputs: Hotend, Fan, Bed)
-#define BOARD_RAMPS_PLUS_EEB           144  // RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Bed)
-#define BOARD_RAMPS_PLUS_EFF           145  // RAMPS Plus 3DYMY (Power outputs: Hotend, Fan0, Fan1)
-#define BOARD_RAMPS_PLUS_EEF           146  // RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Fan)
-#define BOARD_RAMPS_PLUS_SF            148  // RAMPS Plus 3DYMY (Power outputs: Spindle, Controller Fan)
+#define BOARD_RAMPS_PLUS_EFB          1030  // RAMPS Plus 3DYMY (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_PLUS_EEB          1031  // RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_PLUS_EFF          1032  // RAMPS Plus 3DYMY (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_PLUS_EEF          1033  // RAMPS Plus 3DYMY (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_PLUS_SF           1034  // RAMPS Plus 3DYMY (Power outputs: Spindle, Controller Fan)
 
 //
 // RAMPS Derivatives - ATmega1280, ATmega2560
 //
 
-#define BOARD_3DRAG                     77  // 3Drag Controller
-#define BOARD_K8200                     78  // Velleman K8200 Controller (derived from 3Drag Controller)
-#define BOARD_K8400                     79  // Velleman K8400 Controller (derived from 3Drag Controller)
-#define BOARD_BAM_DICE                 401  // 2PrintBeta BAM&DICE with STK drivers
-#define BOARD_BAM_DICE_DUE             402  // 2PrintBeta BAM&DICE Due with STK drivers
-#define BOARD_MKS_BASE                  40  // MKS BASE v1.0
-#define BOARD_MKS_BASE_14              404  // MKS v1.4 A4982 stepper drivers
-#define BOARD_MKS_BASE_15              405  // MKS v1.5 with Allegro A4982 stepper drivers
-#define BOARD_MKS_BASE_HEROIC           41  // MKS BASE 1.0 with Heroic HR4982 stepper drivers
-#define BOARD_MKS_GEN_13                47  // MKS GEN v1.3 or 1.4
-#define BOARD_MKS_GEN_L                 53  // MKS GEN L
-#define BOARD_KFB_2                    136  // Bigtreetech or BIQU KFB2.0
-#define BOARD_ZRIB_V20                 504  // zrib V2.0 control board (Chinese knock off RAMPS replica)
-#define BOARD_FELIX2                    37  // Felix 2.0+ Electronics Board (RAMPS like)
-#define BOARD_RIGIDBOARD                42  // Invent-A-Part RigidBoard
-#define BOARD_RIGIDBOARD_V2             52  // Invent-A-Part RigidBoard V2
-#define BOARD_SAINSMART_2IN1            49  // Sainsmart 2-in-1 board
-#define BOARD_ULTIMAKER                  7  // Ultimaker
-#define BOARD_ULTIMAKER_OLD             71  // Ultimaker (Older electronics. Pre 1.5.4. This is rare)
-#define BOARD_AZTEEG_X3                 67  // Azteeg X3
-#define BOARD_AZTEEG_X3_PRO             68  // Azteeg X3 Pro
-#define BOARD_ULTIMAIN_2                72  // Ultimainboard 2.x (Uses TEMP_SENSOR 20)
-#define BOARD_RUMBA                     80  // Rumba
-#define BOARD_RUMBA_RAISE3D            333  // Raise3D N series Rumba derivative
-#define BOARD_RL200                    801  // Rapide Lite 200 (v1, low-cost RUMBA clone with drv)
-#define BOARD_FORMBOT_TREX2PLUS         95  // Formbot T-Rex 2 Plus
-#define BOARD_FORMBOT_TREX3             96  // Formbot T-Rex 3
-#define BOARD_FORMBOT_RAPTOR            97  // Formbot Raptor
-#define BOARD_FORMBOT_RAPTOR2           98  // Formbot Raptor 2
-#define BOARD_BQ_ZUM_MEGA_3D           503  // bq ZUM Mega 3D
-#define BOARD_MAKEBOARD_MINI           431  // MakeBoard Mini v2.1.2 is a control board sold by MicroMake
-#define BOARD_TRIGORILLA_13            343  // TriGorilla Anycubic version 1.3 based on RAMPS EFB
-#define BOARD_TRIGORILLA_14            443  //   ... Ver 1.4
-#define BOARD_TRIGORILLA_14_11         444  //   ... Rev 1.1 (new servo pin order)
-#define BOARD_RAMPS_ENDER_4            243  // Creality: Ender-4, CR-8
-#define BOARD_RAMPS_CREALITY           244  // Creality: CR10S, CR20, CR-X
-#define BOARD_RAMPS_DAGOMA             245  // Dagoma F5
-#define BOARD_FYSETC_F6_13             541  // Fysetc F6
-#define BOARD_DUPLICATOR_I3_PLUS        31  // Wanhao Duplicator i3 Plus
-#define BOARD_VORON                    441  // VORON Design
-#define BOARD_TRONXY_V3_1_0            442  // Tronxy TRONXY-V3-1.0
-#define BOARD_Z_BOLT_X_SERIES          550  // Z-Bolt X Series
+#define BOARD_3DRAG                   1100  // 3Drag Controller
+#define BOARD_K8200                   1101  // Velleman K8200 Controller (derived from 3Drag Controller)
+#define BOARD_K8400                   1102  // Velleman K8400 Controller (derived from 3Drag Controller)
+#define BOARD_BAM_DICE                1103  // 2PrintBeta BAM&DICE with STK drivers
+#define BOARD_BAM_DICE_DUE            1104  // 2PrintBeta BAM&DICE Due with STK drivers
+#define BOARD_MKS_BASE                1105  // MKS BASE v1.0
+#define BOARD_MKS_BASE_14             1106  // MKS v1.4 with A4982 stepper drivers
+#define BOARD_MKS_BASE_15             1107  // MKS v1.5 with Allegro A4982 stepper drivers
+#define BOARD_MKS_BASE_HEROIC         1108  // MKS BASE 1.0 with Heroic HR4982 stepper drivers
+#define BOARD_MKS_GEN_13              1109  // MKS GEN v1.3 or 1.4
+#define BOARD_MKS_GEN_L               1110  // MKS GEN L
+#define BOARD_KFB_2                   1111  // Bigtreetech or BIQU KFB2.0
+#define BOARD_ZRIB_V20                1112  // zrib V2.0 control board (Chinese knock off RAMPS replica)
+#define BOARD_FELIX2                  1113  // Felix 2.0+ Electronics Board (RAMPS like)
+#define BOARD_RIGIDBOARD              1114  // Invent-A-Part RigidBoard
+#define BOARD_RIGIDBOARD_V2           1115  // Invent-A-Part RigidBoard V2
+#define BOARD_SAINSMART_2IN1          1116  // Sainsmart 2-in-1 board
+#define BOARD_ULTIMAKER               1117  // Ultimaker
+#define BOARD_ULTIMAKER_OLD           1118  // Ultimaker (Older electronics. Pre 1.5.4. This is rare)
+#define BOARD_AZTEEG_X3               1119  // Azteeg X3
+#define BOARD_AZTEEG_X3_PRO           1120  // Azteeg X3 Pro
+#define BOARD_ULTIMAIN_2              1121  // Ultimainboard 2.x (Uses TEMP_SENSOR 20)
+#define BOARD_RUMBA                   1122  // Rumba
+#define BOARD_RUMBA_RAISE3D           1123  // Raise3D N series Rumba derivative
+#define BOARD_RL200                   1124  // Rapide Lite 200 (v1, low-cost RUMBA clone with drv)
+#define BOARD_FORMBOT_TREX2PLUS       1125  // Formbot T-Rex 2 Plus
+#define BOARD_FORMBOT_TREX3           1126  // Formbot T-Rex 3
+#define BOARD_FORMBOT_RAPTOR          1127  // Formbot Raptor
+#define BOARD_FORMBOT_RAPTOR2         1128  // Formbot Raptor 2
+#define BOARD_BQ_ZUM_MEGA_3D          1129  // bq ZUM Mega 3D
+#define BOARD_MAKEBOARD_MINI          1130  // MakeBoard Mini v2.1.2 is a control board sold by MicroMake
+#define BOARD_TRIGORILLA_13           1131  // TriGorilla Anycubic version 1.3-based on RAMPS EFB
+#define BOARD_TRIGORILLA_14           1132  //   ... Ver 1.4
+#define BOARD_TRIGORILLA_14_11        1133  //   ... Rev 1.1 (new servo pin order)
+#define BOARD_RAMPS_ENDER_4           1134  // Creality: Ender-4, CR-8
+#define BOARD_RAMPS_CREALITY          1135  // Creality: CR10S, CR20, CR-X
+#define BOARD_RAMPS_DAGOMA            1136  // Dagoma F5
+#define BOARD_FYSETC_F6_13            1137  // Fysetc F6
+#define BOARD_DUPLICATOR_I3_PLUS      1138  // Wanhao Duplicator i3 Plus
+#define BOARD_VORON                   1139  // VORON Design
+#define BOARD_TRONXY_V3_1_0           1140  // Tronxy TRONXY-V3-1.0
+#define BOARD_Z_BOLT_X_SERIES         1141  // Z-Bolt X Series
 
 //
 // Other ATmega1280, ATmega2560
 //
 
-#define BOARD_CNCONTROLS_11            111  // Cartesio CN Controls V11
-#define BOARD_CNCONTROLS_12            112  // Cartesio CN Controls V12
-#define BOARD_CHEAPTRONIC                2  // Cheaptronic v1.0
-#define BOARD_CHEAPTRONIC_V2            21  // Cheaptronic v2.0
-#define BOARD_MIGHTYBOARD_REVE         200  // Makerbot Mightyboard Revision E
-#define BOARD_MEGATRONICS               70  // Megatronics
-#define BOARD_MEGATRONICS_2            701  // Megatronics v2.0
-#define BOARD_MEGATRONICS_3            703  // Megatronics v3.0
-#define BOARD_MEGATRONICS_31           704  // Megatronics v3.1
-#define BOARD_MEGATRONICS_32           705  // Megatronics v3.2
-#define BOARD_RAMBO                    301  // Rambo
-#define BOARD_MINIRAMBO                302  // Mini-Rambo
-#define BOARD_MINIRAMBO_10A            303  // Mini-Rambo 1.0a
-#define BOARD_EINSY_RAMBO              304  // Einsy Rambo
-#define BOARD_EINSY_RETRO              305  // Einsy Retro
-#define BOARD_ELEFU_3                   23  // Elefu Ra Board (v3)
-#define BOARD_LEAPFROG                 999  // Leapfrog
-#define BOARD_MEGACONTROLLER           310  // Mega controller
-#define BOARD_SCOOVO_X9H               321  // abee Scoovo X9H
-#define BOARD_GT2560_REV_A              74  // Geeetech GT2560 Rev. A
-#define BOARD_GT2560_REV_A_PLUS         75  // Geeetech GT2560 Rev. A+ (with auto level probe)
-#define BOARD_GT2560_V3                 76  // Geeetech GT2560 Rev B for A10(M/D)
-#define BOARD_GT2560_V3_MC2             73  // Geeetech GT2560 Rev B for Mecreator2
-#define BOARD_GT2560_V3_A20             86  // Geeetech GT2560 Rev B for A20(M/D)
-#define BOARD_EINSTART_S               666  // Einstart retrofit
+#define BOARD_CNCONTROLS_11           1200  // Cartesio CN Controls V11
+#define BOARD_CNCONTROLS_12           1201  // Cartesio CN Controls V12
+#define BOARD_CHEAPTRONIC             1202  // Cheaptronic v1.0
+#define BOARD_CHEAPTRONIC_V2          1203  // Cheaptronic v2.0
+#define BOARD_MIGHTYBOARD_REVE        1204  // Makerbot Mightyboard Revision E
+#define BOARD_MEGATRONICS             1205  // Megatronics
+#define BOARD_MEGATRONICS_2           1206  // Megatronics v2.0
+#define BOARD_MEGATRONICS_3           1207  // Megatronics v3.0
+#define BOARD_MEGATRONICS_31          1208  // Megatronics v3.1
+#define BOARD_MEGATRONICS_32          1209  // Megatronics v3.2
+#define BOARD_RAMBO                   1210  // Rambo
+#define BOARD_MINIRAMBO               1211  // Mini-Rambo
+#define BOARD_MINIRAMBO_10A           1212  // Mini-Rambo 1.0a
+#define BOARD_EINSY_RAMBO             1213  // Einsy Rambo
+#define BOARD_EINSY_RETRO             1214  // Einsy Retro
+#define BOARD_ELEFU_3                 1215  // Elefu Ra Board (v3)
+#define BOARD_LEAPFROG                1216  // Leapfrog
+#define BOARD_MEGACONTROLLER          1217  // Mega controller
+#define BOARD_SCOOVO_X9H              1218  // abee Scoovo X9H
+#define BOARD_GT2560_REV_A            1219  // Geeetech GT2560 Rev. A
+#define BOARD_GT2560_REV_A_PLUS       1220  // Geeetech GT2560 Rev. A+ (with auto level probe)
+#define BOARD_GT2560_V3               1221  // Geeetech GT2560 Rev B for A10(M/D)
+#define BOARD_GT2560_V3_MC2           1222  // Geeetech GT2560 Rev B for Mecreator2
+#define BOARD_GT2560_V3_A20           1223  // Geeetech GT2560 Rev B for A20(M/D)
+#define BOARD_EINSTART_S              1224  // Einstart retrofit
 
 //
 // ATmega1281, ATmega2561
 //
 
-#define BOARD_MINITRONICS              702  // Minitronics v1.0/1.1
-#define BOARD_SILVER_GATE               25  // Silvergate v1.0
+#define BOARD_MINITRONICS             1300  // Minitronics v1.0/1.1
+#define BOARD_SILVER_GATE             1301  // Silvergate v1.0
 
 //
 // Sanguinololu and Derivatives - ATmega644P, ATmega1284P
 //
 
-#define BOARD_SANGUINOLOLU_11            6  // Sanguinololu < 1.2
-#define BOARD_SANGUINOLOLU_12           62  // Sanguinololu 1.2 and above
-#define BOARD_MELZI                     63  // Melzi
-#define BOARD_MELZI_MAKR3D              66  // Melzi with ATmega1284 (MaKr3d version)
-#define BOARD_MELZI_CREALITY            89  // Melzi Creality3D board (for CR-10 etc)
-#define BOARD_MELZI_MALYAN              92  // Melzi Malyan M150 board
-#define BOARD_MELZI_TRONXY             505  // Tronxy X5S
-#define BOARD_STB_11                    64  // STB V1.1
-#define BOARD_AZTEEG_X1                 65  // Azteeg X1
-#define BOARD_ANET_10                   69  // Anet 1.0 (Melzi clone)
+#define BOARD_SANGUINOLOLU_11         1400  // Sanguinololu < 1.2
+#define BOARD_SANGUINOLOLU_12         1401  // Sanguinololu 1.2 and above
+#define BOARD_MELZI                   1402  // Melzi
+#define BOARD_MELZI_MAKR3D            1403  // Melzi with ATmega1284 (MaKr3d version)
+#define BOARD_MELZI_CREALITY          1404  // Melzi Creality3D board (for CR-10 etc)
+#define BOARD_MELZI_MALYAN            1405  // Melzi Malyan M150 board
+#define BOARD_MELZI_TRONXY            1406  // Tronxy X5S
+#define BOARD_STB_11                  1407  // STB V1.1
+#define BOARD_AZTEEG_X1               1408  // Azteeg X1
+#define BOARD_ANET_10                 1409  // Anet 1.0 (Melzi clone)
 
 //
 // Other ATmega644P, ATmega644, ATmega1284P
 //
 
-#define BOARD_GEN3_MONOLITHIC           22  // Gen3 Monolithic Electronics
-#define BOARD_GEN3_PLUS                  9  // Gen3+
-#define BOARD_GEN6                       5  // Gen6
-#define BOARD_GEN6_DELUXE               51  // Gen6 deluxe
-#define BOARD_GEN7_CUSTOM               10  // Gen7 custom (Alfons3 Version) "https://github.com/Alfons3/Generation_7_Electronics"
-#define BOARD_GEN7_12                   11  // Gen7 v1.1, v1.2
-#define BOARD_GEN7_13                   12  // Gen7 v1.3
-#define BOARD_GEN7_14                   13  // Gen7 v1.4
-#define BOARD_OMCA_A                    90  // Alpha OMCA board
-#define BOARD_OMCA                      91  // Final OMCA board
-#define BOARD_SETHI                     20  // Sethi 3D_1
+#define BOARD_GEN3_MONOLITHIC         1500  // Gen3 Monolithic Electronics
+#define BOARD_GEN3_PLUS               1501  // Gen3+
+#define BOARD_GEN6                    1502  // Gen6
+#define BOARD_GEN6_DELUXE             1503  // Gen6 deluxe
+#define BOARD_GEN7_CUSTOM             1504  // Gen7 custom (Alfons3 Version) "https://github.com/Alfons3/Generation_7_Electronics"
+#define BOARD_GEN7_12                 1505  // Gen7 v1.1, v1.2
+#define BOARD_GEN7_13                 1506  // Gen7 v1.3
+#define BOARD_GEN7_14                 1507  // Gen7 v1.4
+#define BOARD_OMCA_A                  1508  // Alpha OMCA board
+#define BOARD_OMCA                    1509  // Final OMCA board
+#define BOARD_SETHI                   1510  // Sethi 3D_1
 
 //
 // Teensyduino - AT90USB1286, AT90USB1286P
 //
 
-#define BOARD_TEENSYLU                   8  // Teensylu
-#define BOARD_PRINTRBOARD               81  // Printrboard (AT90USB1286)
-#define BOARD_PRINTRBOARD_REVF         811  // Printrboard Revision F (AT90USB1286)
-#define BOARD_BRAINWAVE                 82  // Brainwave (AT90USB646)
-#define BOARD_BRAINWAVE_PRO             85  // Brainwave Pro (AT90USB1286)
-#define BOARD_SAV_MKI                   83  // SAV Mk-I (AT90USB1286)
-#define BOARD_TEENSY2                   84  // Teensy++2.0 (AT90USB1286)
-#define BOARD_5DPRINT                   88  // 5DPrint D8 Driver Board
+#define BOARD_TEENSYLU                1600  // Teensylu
+#define BOARD_PRINTRBOARD             1601  // Printrboard (AT90USB1286)
+#define BOARD_PRINTRBOARD_REVF        1602  // Printrboard Revision F (AT90USB1286)
+#define BOARD_BRAINWAVE               1603  // Brainwave (AT90USB646)
+#define BOARD_BRAINWAVE_PRO           1604  // Brainwave Pro (AT90USB1286)
+#define BOARD_SAV_MKI                 1605  // SAV Mk-I (AT90USB1286)
+#define BOARD_TEENSY2                 1606  // Teensy++2.0 (AT90USB1286)
+#define BOARD_5DPRINT                 1607  // 5DPrint D8 Driver Board
 
 //
 // LPC1768 ARM Cortex M3
 //
 
-#define BOARD_RAMPS_14_RE_ARM_EFB     1743  // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
-#define BOARD_RAMPS_14_RE_ARM_EEB     1744  // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
-#define BOARD_RAMPS_14_RE_ARM_EFF     1745  // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
-#define BOARD_RAMPS_14_RE_ARM_EEF     1746  // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
-#define BOARD_RAMPS_14_RE_ARM_SF      1748  // Re-ARM with RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
-#define BOARD_MKS_SBASE               1750  // MKS-Sbase (Power outputs: Hotend0, Hotend1, Bed, Fan)
-#define BOARD_AZSMZ_MINI              1751  // AZSMZ Mini
-#define BOARD_AZTEEG_X5_GT            1752  // Azteeg X5 GT (Power outputs: Hotend0, Hotend1, Bed, Fan)
-#define BOARD_BIQU_BQ111_A4           1753  // BIQU BQ111-A4 (Power outputs: Hotend, Fan, Bed)
-#define BOARD_SELENA_COMPACT          1754  // Selena Compact (Power outputs: Hotend0, Hotend1, Bed0, Bed1, Fan0, Fan1)
-#define BOARD_COHESION3D_REMIX        1755  // Cohesion3D ReMix
-#define BOARD_COHESION3D_MINI         1756  // Cohesion3D Mini
-#define BOARD_SMOOTHIEBOARD           1757  // Smoothieboard
-#define BOARD_AZTEEG_X5_MINI_WIFI     1758  // Azteeg X5 Mini Wifi (Power outputs: Hotend0, Bed, Fan)
-#define BOARD_BIQU_SKR_V1_1           1759  // BIQU SKR_V1.1 (Power outputs: Hotend0,Hotend1, Fan, Bed)
-#define BOARD_BIQU_B300_V1_0          1760  // BIQU B300_V1.0 (Power outputs: Hotend0, Fan, Bed, SPI Driver)
-#define BOARD_BIGTREE_SKR_V1_3        1761  // BIGTREE SKR_V1.3 (Power outputs: Hotend0, Hotend1, Fan, Bed)
-#define BOARD_AZTEEG_X5_MINI          1762  // Azteeg X5 Mini (Power outputs: Hotend0, Bed, Fan)
-#define BOARD_MKS_SGEN                1763  // MKS-SGen (Power outputs: Hotend0, Hotend1, Bed, Fan)
-#define BOARD_MKS_SGEN_L              1764  // MKS-SGen-L (Power outputs: Hotend0, Hotend1, Bed, Fan)
+#define BOARD_RAMPS_14_RE_ARM_EFB     2000  // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_14_RE_ARM_EEB     2001  // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_14_RE_ARM_EFF     2002  // Re-ARM with RAMPS 1.4 (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_14_RE_ARM_EEF     2003  // Re-ARM with RAMPS 1.4 (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_14_RE_ARM_SF      2004  // Re-ARM with RAMPS 1.4 (Power outputs: Spindle, Controller Fan)
+#define BOARD_MKS_SBASE               2005  // MKS-Sbase (Power outputs: Hotend0, Hotend1, Bed, Fan)
+#define BOARD_AZSMZ_MINI              2006  // AZSMZ Mini
+#define BOARD_AZTEEG_X5_GT            2007  // Azteeg X5 GT (Power outputs: Hotend0, Hotend1, Bed, Fan)
+#define BOARD_BIQU_BQ111_A4           2008  // BIQU BQ111-A4 (Power outputs: Hotend, Fan, Bed)
+#define BOARD_SELENA_COMPACT          2009  // Selena Compact (Power outputs: Hotend0, Hotend1, Bed0, Bed1, Fan0, Fan1)
+#define BOARD_COHESION3D_REMIX        2010  // Cohesion3D ReMix
+#define BOARD_COHESION3D_MINI         2011  // Cohesion3D Mini
+#define BOARD_SMOOTHIEBOARD           2012  // Smoothieboard
+#define BOARD_AZTEEG_X5_MINI_WIFI     2013  // Azteeg X5 Mini Wifi (Power outputs: Hotend0, Bed, Fan)
+#define BOARD_BIQU_SKR_V1_1           2014  // BIQU SKR_V1.1 (Power outputs: Hotend0,Hotend1, Fan, Bed)
+#define BOARD_BIQU_B300_V1_0          2015  // BIQU B300_V1.0 (Power outputs: Hotend0, Fan, Bed, SPI Driver)
+#define BOARD_BIGTREE_SKR_V1_3        2016  // BIGTREE SKR_V1.3 (Power outputs: Hotend0, Hotend1, Fan, Bed)
+#define BOARD_AZTEEG_X5_MINI          2017  // Azteeg X5 Mini (Power outputs: Hotend0, Bed, Fan)
+#define BOARD_MKS_SGEN                2018  // MKS-SGen (Power outputs: Hotend0, Hotend1, Bed, Fan)
+#define BOARD_MKS_SGEN_L              2019  // MKS-SGen-L (Power outputs: Hotend0, Hotend1, Bed, Fan)
 
 //
 // SAM3X8E ARM Cortex M3
 //
 
-#define BOARD_DUE3DOM                 1411  // DUE3DOM for Arduino DUE
-#define BOARD_DUE3DOM_MINI            1412  // DUE3DOM MINI for Arduino DUE
-#define BOARD_RADDS                   1502  // RADDS
-#define BOARD_RAMPS_FD_V1             1503  // RAMPS-FD v1
-#define BOARD_RAMPS_FD_V2             1504  // RAMPS-FD v2
-#define BOARD_RAMPS_SMART_EFB         1523  // RAMPS-SMART (Power outputs: Hotend, Fan, Bed)
-#define BOARD_RAMPS_SMART_EEB         1524  // RAMPS-SMART (Power outputs: Hotend0, Hotend1, Bed)
-#define BOARD_RAMPS_SMART_EFF         1525  // RAMPS-SMART (Power outputs: Hotend, Fan0, Fan1)
-#define BOARD_RAMPS_SMART_EEF         1526  // RAMPS-SMART (Power outputs: Hotend0, Hotend1, Fan)
-#define BOARD_RAMPS_SMART_SF          1528  // RAMPS-SMART (Power outputs: Spindle, Controller Fan)
-#define BOARD_RAMPS_DUO_EFB           1533  // RAMPS Duo (Power outputs: Hotend, Fan, Bed)
-#define BOARD_RAMPS_DUO_EEB           1534  // RAMPS Duo (Power outputs: Hotend0, Hotend1, Bed)
-#define BOARD_RAMPS_DUO_EFF           1535  // RAMPS Duo (Power outputs: Hotend, Fan0, Fan1)
-#define BOARD_RAMPS_DUO_EEF           1536  // RAMPS Duo (Power outputs: Hotend0, Hotend1, Fan)
-#define BOARD_RAMPS_DUO_SF            1538  // RAMPS Duo (Power outputs: Spindle, Controller Fan)
-#define BOARD_RAMPS4DUE_EFB           1543  // RAMPS4DUE (Power outputs: Hotend, Fan, Bed)
-#define BOARD_RAMPS4DUE_EEB           1544  // RAMPS4DUE (Power outputs: Hotend0, Hotend1, Bed)
-#define BOARD_RAMPS4DUE_EFF           1545  // RAMPS4DUE (Power outputs: Hotend, Fan0, Fan1)
-#define BOARD_RAMPS4DUE_EEF           1546  // RAMPS4DUE (Power outputs: Hotend0, Hotend1, Fan)
-#define BOARD_RAMPS4DUE_SF            1548  // RAMPS4DUE (Power outputs: Spindle, Controller Fan)
-#define BOARD_RURAMPS4D_11            1550  // RuRAMPS4Duo v1.1 (Power outputs: Hotend0, Hotend1, Hotend2, Fan0, Fan1, Bed)
-#define BOARD_RURAMPS4D_13            1551  // RuRAMPS4Duo v1.3 (Power outputs: Hotend0, Hotend1, Hotend2, Fan0, Fan1, Bed)
-#define BOARD_ULTRATRONICS_PRO        1560  // ReprapWorld Ultratronics Pro V1.0
-#define BOARD_ARCHIM1                 1591  // UltiMachine Archim1 (with DRV8825 drivers)
-#define BOARD_ARCHIM2                 1592  // UltiMachine Archim2 (with TMC2130 drivers)
-#define BOARD_ALLIGATOR               1602  // Alligator Board R2
+#define BOARD_DUE3DOM                 3000  // DUE3DOM for Arduino DUE
+#define BOARD_DUE3DOM_MINI            3001  // DUE3DOM MINI for Arduino DUE
+#define BOARD_RADDS                   3002  // RADDS
+#define BOARD_RAMPS_FD_V1             3003  // RAMPS-FD v1
+#define BOARD_RAMPS_FD_V2             3004  // RAMPS-FD v2
+#define BOARD_RAMPS_SMART_EFB         3005  // RAMPS-SMART (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_SMART_EEB         3006  // RAMPS-SMART (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_SMART_EFF         3007  // RAMPS-SMART (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_SMART_EEF         3008  // RAMPS-SMART (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_SMART_SF          3009  // RAMPS-SMART (Power outputs: Spindle, Controller Fan)
+#define BOARD_RAMPS_DUO_EFB           3010  // RAMPS Duo (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS_DUO_EEB           3011  // RAMPS Duo (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS_DUO_EFF           3012  // RAMPS Duo (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS_DUO_EEF           3013  // RAMPS Duo (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS_DUO_SF            3014  // RAMPS Duo (Power outputs: Spindle, Controller Fan)
+#define BOARD_RAMPS4DUE_EFB           3015  // RAMPS4DUE (Power outputs: Hotend, Fan, Bed)
+#define BOARD_RAMPS4DUE_EEB           3016  // RAMPS4DUE (Power outputs: Hotend0, Hotend1, Bed)
+#define BOARD_RAMPS4DUE_EFF           3017  // RAMPS4DUE (Power outputs: Hotend, Fan0, Fan1)
+#define BOARD_RAMPS4DUE_EEF           3018  // RAMPS4DUE (Power outputs: Hotend0, Hotend1, Fan)
+#define BOARD_RAMPS4DUE_SF            3019  // RAMPS4DUE (Power outputs: Spindle, Controller Fan)
+#define BOARD_RURAMPS4D_11            3020  // RuRAMPS4Duo v1.1 (Power outputs: Hotend0, Hotend1, Hotend2, Fan0, Fan1, Bed)
+#define BOARD_RURAMPS4D_13            3021  // RuRAMPS4Duo v1.3 (Power outputs: Hotend0, Hotend1, Hotend2, Fan0, Fan1, Bed)
+#define BOARD_ULTRATRONICS_PRO        3022  // ReprapWorld Ultratronics Pro V1.0
+#define BOARD_ARCHIM1                 3023  // UltiMachine Archim1 (with DRV8825 drivers)
+#define BOARD_ARCHIM2                 3024  // UltiMachine Archim2 (with TMC2130 drivers)
+#define BOARD_ALLIGATOR               3025  // Alligator Board R2
 
 //
 // SAM3X8C ARM Cortex M3
 //
 
-#define BOARD_PRINTRBOARD_G2          1620  // PRINTRBOARD G2
-#define BOARD_ADSK                    1610  // Arduino DUE Shield Kit (ADSK)
+#define BOARD_PRINTRBOARD_G2          3100  // PRINTRBOARD G2
+#define BOARD_ADSK                    3101  // Arduino DUE Shield Kit (ADSK)
 
 //
 // STM32 ARM Cortex-M3
 //
 
-#define BOARD_STM32F1R                1800  // STM32R Libmaple based STM32F1 controller
-#define BOARD_MALYAN_M200             1801  // STM32C8T6 Libmaple based stm32f1 controller
-#define BOARD_STM3R_MINI              1803  // STM32 Libmaple based stm32f1 controller
-#define BOARD_GTM32_PRO_VB            1805  // STM32F103VET6 controller
-#define BOARD_MORPHEUS                1806  // STM32F103C8/STM32F103CB Libmaple based stm32f1 controller
-#define BOARD_MKS_ROBIN               1808  // MKS Robin / STM32F103ZET6
-#define BOARD_MKS_ROBIN_MINI          1813  // MKS Robin Mini / STM32F103VET6
-#define BOARD_MKS_ROBIN_NANO          1812  // MKS Robin Nano / STM32F103VET6
-#define BOARD_BIGTREE_SKR_MINI_V1_1   1814  // BigTreeTech SKR Mini v1.1 / STM32F103RC
-#define BOARD_BIGTREE_SKR_MINI_E3     1815  // BigTreeTech SKR Mini E3 / STM32F103RC
-#define BOARD_JGAURORA_A5S_A1         1820  // JGAurora A5S A1 / STM32F103ZET6
-#define BOARD_FYSETC_AIO_II           1890  // FYSETC AIO_II
-#define BOARD_FYSETC_CHEETAH          1891  // FYSETC CHEETAH
+#define BOARD_STM32F1R                4000  // STM32R    Libmaple-based STM32F1 controller
+#define BOARD_MALYAN_M200             4001  // STM32C8T6 Libmaple-based STM32F1 controller
+#define BOARD_STM3R_MINI              4002  // STM32     Libmaple-based STM32F1 controller
+#define BOARD_GTM32_PRO_VB            4003  // STM32F103VET6 controller
+#define BOARD_MORPHEUS                4004  // STM32F103C8 / STM32F103CB  Libmaple-based STM32F1 controller
+#define BOARD_MKS_ROBIN               4005  // MKS Robin (STM32F103ZET6)
+#define BOARD_MKS_ROBIN_MINI          4006  // MKS Robin Mini (STM32F103VET6)
+#define BOARD_MKS_ROBIN_NANO          4007  // MKS Robin Nano (STM32F103VET6)
+#define BOARD_BIGTREE_SKR_MINI_V1_1   4008  // BigTreeTech SKR Mini v1.1 (STM32F103RC)
+#define BOARD_BIGTREE_SKR_MINI_E3     4009  // BigTreeTech SKR Mini E3 (STM32F103RC)
+#define BOARD_JGAURORA_A5S_A1         4010  // JGAurora A5S A1 (STM32F103ZET6)
+#define BOARD_FYSETC_AIO_II           4011  // FYSETC AIO_II
+#define BOARD_FYSETC_CHEETAH          4012  // FYSETC CHEETAH
 
 //
 // STM32 ARM Cortex-M4F
 //
 
-#define BOARD_TEENSY31_32             1552  // Teensy3.1 and Teensy3.2
-#define BOARD_TEENSY35_36              841  // Teensy3.5 and Teensy3.6
-#define BOARD_BEAST                   1802  // STM32FxxxVxT6 Libmaple based stm32f4 controller
-#define BOARD_STM32F4                 1804  // STM32 STM32GENERIC based STM32F4 controller
-#define BOARD_ARMED                   1807  // Arm'ed STM32F4 based controller
-#define BOARD_RUMBA32                 1809  // RUMBA32 STM32F4 based controller
-#define BOARD_BLACK_STM32F407VE       1810  // BLACK_STM32F407VE
-#define BOARD_BLACK_STM32F407ZE       1811  // BLACK_STM32F407ZE
-#define BOARD_STEVAL                  1866  // STEVAL-3DP001V1 3D PRINTER BOARD
+#define BOARD_TEENSY31_32             4100  // Teensy3.1 and Teensy3.2
+#define BOARD_TEENSY35_36             4101  // Teensy3.5 and Teensy3.6
+#define BOARD_BEAST                   4102  // STM32F4xxVxT6 Libmaple-based STM32F4 controller
+#define BOARD_STM32F4                 4103  // STM32 STM32GENERIC-based STM32F4 controller
+#define BOARD_ARMED                   4104  // Arm'ed STM32F4-based controller
+#define BOARD_RUMBA32                 4105  // RUMBA32 STM32F4-based controller
+#define BOARD_BLACK_STM32F407VE       4106  // BLACK_STM32F407VE
+#define BOARD_BLACK_STM32F407ZE       4107  // BLACK_STM32F407ZE
+#define BOARD_STEVAL                  4108  // STEVAL-3DP001V1 3D PRINTER BOARD
 
 //
 // ARM Cortex M7
 //
 
-#define BOARD_THE_BORG                1860  // THE-BORG (Power outputs: Hotend0, Hotend1, Bed, Fan)
-#define BOARD_REMRAM_V1               1862  // RemRam v1
+#define BOARD_THE_BORG                5000  // THE-BORG (Power outputs: Hotend0, Hotend1, Bed, Fan)
+#define BOARD_REMRAM_V1               5001  // RemRam v1
 
 //
 // Espressif ESP32 WiFi
 //
-#define BOARD_ESP32                   1900
+#define BOARD_ESP32                   6000
 
 //
 // Simulations
 //
 
-#define BOARD_LINUX_RAMPS             2000
+#define BOARD_LINUX_RAMPS             9999
 
 #define MB(board) (defined(BOARD_##board) && MOTHERBOARD==BOARD_##board)


### PR DESCRIPTION
- Number boards in a more generic manner, grouping by MCU type.
- Add more boards missing from `Makefile`.