### PR TITLE
Squelch warnings about unused parameters.

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/MarlinSerialUSB_Due.cpp
+++ b/Marlin/src/HAL/HAL_DUE/MarlinSerialUSB_Due.cpp
@@ -56,6 +56,7 @@ static int pending_char = -1;
 
 // Public Methods
 void MarlinSerialUSB::begin(const long baud_setting) {
+  UNUSED(baud_setting);
 }
 
 void MarlinSerialUSB::end() {

--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.cpp
@@ -34,6 +34,7 @@ Ctrl_status sd_mmc_spi_read_capacity(uint32_t *nb_sector) {
 }
 
 bool sd_mmc_spi_unload(bool unload) {
+  UNUSED(unload);
   return true;
 }
 

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
@@ -75,14 +75,14 @@ void usb_task_idle(void) {
   bool usb_task_msc_isenabled(void)             { return main_b_msc_enable; }
 #endif
 
-bool usb_task_cdc_enable(const uint8_t port)  { return ((main_b_cdc_enable = true)); }
-void usb_task_cdc_disable(const uint8_t port) { main_b_cdc_enable = false; main_b_dtr_active = false; }
+bool usb_task_cdc_enable(const uint8_t port)  {UNUSED(port); return ((main_b_cdc_enable = true)); }
+void usb_task_cdc_disable(const uint8_t port) {UNUSED(port); main_b_cdc_enable = false; main_b_dtr_active = false; }
 bool usb_task_cdc_isenabled(void)             { return main_b_cdc_enable; }
 
 /*! \brief Called by CDC interface
  * Callback running when CDC device have received data
  */
-void usb_task_cdc_rx_notify(const uint8_t port) { }
+void usb_task_cdc_rx_notify(const uint8_t port) {UNUSED(port);}
 
 /*! \brief Configures communication line
  *
@@ -90,13 +90,14 @@ void usb_task_cdc_rx_notify(const uint8_t port) { }
  */
 static uint16_t dwDTERate = 0;
 void usb_task_cdc_config(const uint8_t port, usb_cdc_line_coding_t *cfg) {
+    UNUSED(port);
     // Store last DTE rate
     dwDTERate = cfg->dwDTERate;
 }
 
 
 void usb_task_cdc_set_dtr(const uint8_t port, const bool b_enable) {
-
+  UNUSED(port);
   // Keep DTR status
   main_b_dtr_active = b_enable;
 

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
@@ -75,14 +75,14 @@ void usb_task_idle(void) {
   bool usb_task_msc_isenabled(void)             { return main_b_msc_enable; }
 #endif
 
-bool usb_task_cdc_enable(const uint8_t port)  {UNUSED(port); return ((main_b_cdc_enable = true)); }
-void usb_task_cdc_disable(const uint8_t port) {UNUSED(port); main_b_cdc_enable = false; main_b_dtr_active = false; }
+bool usb_task_cdc_enable(const uint8_t port)  { UNUSED(port); return ((main_b_cdc_enable = true)); }
+void usb_task_cdc_disable(const uint8_t port) { UNUSED(port); main_b_cdc_enable = false; main_b_dtr_active = false; }
 bool usb_task_cdc_isenabled(void)             { return main_b_cdc_enable; }
 
 /*! \brief Called by CDC interface
  * Callback running when CDC device have received data
  */
-void usb_task_cdc_rx_notify(const uint8_t port) {UNUSED(port);}
+void usb_task_cdc_rx_notify(const uint8_t port) { UNUSED(port); }
 
 /*! \brief Configures communication line
  *
@@ -90,11 +90,10 @@ void usb_task_cdc_rx_notify(const uint8_t port) {UNUSED(port);}
  */
 static uint16_t dwDTERate = 0;
 void usb_task_cdc_config(const uint8_t port, usb_cdc_line_coding_t *cfg) {
-    UNUSED(port);
-    // Store last DTE rate
-    dwDTERate = cfg->dwDTERate;
+  UNUSED(port);
+  // Store last DTE rate
+  dwDTERate = cfg->dwDTERate;
 }
-
 
 void usb_task_cdc_set_dtr(const uint8_t port, const bool b_enable) {
   UNUSED(port);


### PR DESCRIPTION
Silences warnings about unused parameters.