### PR TITLE
115K baud for Ender-3 and -5

### DIFF
--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -124,7 +124,7 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 
 // Enable the Bluetooth serial interface on AT90USB devices
 //#define BLUETOOTH

--- a/config/examples/Creality/Ender-5/Configuration.h
+++ b/config/examples/Creality/Ender-5/Configuration.h
@@ -124,7 +124,7 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 
 // Enable the Bluetooth serial interface on AT90USB devices
 //#define BLUETOOTH


### PR DESCRIPTION
### Description

Reverts Ender-3 & Ender-5 baudrates back to 115200. See comments on https://github.com/MarlinFirmware/Marlin/commit/9722038ad3217b4d88763eb18659a6b6d22dab39.

### Benefits

Fixes incorrect baudrate for the Ender-3 & Ender-5.

### Related Issues

None.