### PR TITLE
Remove unused WRITE_VAR, etc.

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/fastio_Due.h
+++ b/Marlin/src/HAL/HAL_DUE/fastio_Due.h
@@ -63,14 +63,6 @@
 #define _READ(IO) bool(DIO ## IO ## _WPORT -> PIO_PDSR & MASK(DIO ## IO ## _PIN))
 
 // Write to a pin
-#define _WRITE_VAR(IO,V) do { \
-  volatile Pio* port = digitalPinToPort(IO); \
-  const uint32_t mask = digitalPinToBitMask(IO); \
-  if (V) port->PIO_SODR = mask; \
-  else port->PIO_CODR = mask; \
-} while(0)
-
-// Write to a pin
 #define _WRITE(IO,V) do { \
   volatile Pio* port = (DIO ##  IO ## _WPORT); \
   const uint32_t mask = MASK(DIO ## IO ## _PIN); \
@@ -160,7 +152,6 @@
 #define READ(IO)             _READ(IO)
 
 // Write to a pin (wrapper)
-#define WRITE_VAR(IO,V)      _WRITE_VAR(IO,V)
 #define WRITE(IO,V)          _WRITE(IO,V)
 
 // Toggle a pin (wrapper)

--- a/Marlin/src/HAL/HAL_LINUX/fastio.h
+++ b/Marlin/src/HAL/HAL_LINUX/fastio.h
@@ -51,8 +51,6 @@
 #define _READ(IO)             READ_PIN(IO)
 
 /// Write to a pin
-#define _WRITE_VAR(IO,V)      digitalWrite(IO,V)
-
 #define _WRITE(IO,V)          WRITE_PIN(IO,V)
 
 /// toggle a pin
@@ -84,7 +82,6 @@
 #define READ(IO)             _READ(IO)
 
 /// Write to a pin wrapper
-#define WRITE_VAR(IO,V)      _WRITE_VAR(IO,V)
 #define WRITE(IO,V)          _WRITE(IO,V)
 
 /// toggle a pin wrapper

--- a/Marlin/src/HAL/HAL_LPC1768/fastio.h
+++ b/Marlin/src/HAL/HAL_LPC1768/fastio.h
@@ -63,8 +63,6 @@
 #define _READ(IO)             READ_PIN(IO)
 
 /// Write to a pin
-#define _WRITE_VAR(IO,V)      digitalWrite(IO,V)
-
 #define _WRITE(IO,V)          WRITE_PIN(IO,V)
 
 /// toggle a pin
@@ -92,7 +90,6 @@
 #define READ(IO)              _READ(IO)
 
 /// Write to a pin wrapper
-#define WRITE_VAR(IO,V)       _WRITE_VAR(IO,V)
 #define WRITE(IO,V)           _WRITE(IO,V)
 
 /// toggle a pin wrapper

--- a/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
+++ b/Marlin/src/HAL/HAL_STM32/fastio_STM32.h
@@ -65,7 +65,6 @@ void FastIO_init(); // Must be called before using fast io macros
 #define _SET_MODE(IO,M)         pinMode(IO, M)
 #define _SET_OUTPUT(IO)         pinMode(IO, OUTPUT)                               /*!< Output Push Pull Mode & GPIO_NOPULL   */
 
-#define WRITE_VAR(IO,V)         _WRITE(IO,V)
 #define WRITE(IO,V)             _WRITE(IO,V)
 #define READ(IO)                _READ(IO)
 #define TOGGLE(IO)              _TOGGLE(IO)

--- a/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
+++ b/Marlin/src/HAL/HAL_STM32F1/fastio_STM32F1.h
@@ -32,7 +32,6 @@
 #define READ(IO)              (PIN_MAP[IO].gpio_device->regs->IDR & (1U << PIN_MAP[IO].gpio_bit) ? HIGH : LOW)
 #define WRITE(IO,V)           (PIN_MAP[IO].gpio_device->regs->BSRR = (1U << PIN_MAP[IO].gpio_bit) << ((V) ? 0 : 16))
 #define TOGGLE(IO)            (PIN_MAP[IO].gpio_device->regs->ODR = PIN_MAP[IO].gpio_device->regs->ODR ^ (1U << PIN_MAP[IO].gpio_bit))
-#define WRITE_VAR(IO,V)       WRITE(IO,V)
 
 #define _GET_MODE(IO)         gpio_get_mode(PIN_MAP[IO].gpio_device, PIN_MAP[IO].gpio_bit)
 #define _SET_MODE(IO,M)       gpio_set_mode(PIN_MAP[IO].gpio_device, PIN_MAP[IO].gpio_bit, M)

--- a/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
+++ b/Marlin/src/HAL/HAL_STM32F4/fastio_STM32F4.h
@@ -32,7 +32,6 @@
 
 #define READ(IO)                digitalRead(IO)
 #define WRITE(IO,V)             digitalWrite(IO,V)
-#define WRITE_VAR(IO,V)         WRITE(IO,V)
 
 #define _GET_MODE(IO)
 #define _SET_MODE(IO,M)         pinMode(IO, M)

--- a/Marlin/src/HAL/HAL_STM32F7/fastio_STM32F7.h
+++ b/Marlin/src/HAL/HAL_STM32F7/fastio_STM32F7.h
@@ -31,7 +31,6 @@
 
 #define READ(IO)                digitalRead(IO)
 #define WRITE(IO,V)             digitalWrite(IO,V)
-#define WRITE_VAR(IO,V)         WRITE(IO,V)
 
 #define _GET_MODE(IO)
 #define _SET_MODE(IO,M)         pinMode(IO, M)

--- a/Marlin/src/HAL/HAL_TEENSY31_32/fastio_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY31_32/fastio_Teensy.h
@@ -72,7 +72,6 @@
 
 #define READ(IO)              _READ(IO)
 
-#define WRITE_VAR(IO,V)       _WRITE_VAR(IO,V)
 #define WRITE(IO,V)           _WRITE(IO,V)
 #define TOGGLE(IO)            _TOGGLE(IO)
 

--- a/Marlin/src/HAL/HAL_TEENSY35_36/fastio_Teensy.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/fastio_Teensy.h
@@ -71,7 +71,6 @@
 
 #define READ(IO)              _READ(IO)
 
-#define WRITE_VAR(IO,V)       _WRITE_VAR(IO,V)
 #define WRITE(IO,V)           _WRITE(IO,V)
 #define TOGGLE(IO)            _TOGGLE(IO)
 

--- a/Marlin/src/sd/Sd2Card.h
+++ b/Marlin/src/sd/Sd2Card.h
@@ -90,23 +90,6 @@ uint8_t const SD_CARD_TYPE_SD1  = 1,                    // Standard capacity V1 
 //
 #define SD_CHIP_SELECT_PIN SS_PIN
 
-#if 0
-#if DISABLED(SOFTWARE_SPI)
-  // hardware pin defs
-  #define SD_CHIP_SELECT_PIN SS_PIN   // The default chip select pin for the SD card is SS.
-  // The following three pins must not be redefined for hardware SPI.
-  #define SPI_MOSI_PIN MOSI_PIN       // SPI Master Out Slave In pin
-  #define SPI_MISO_PIN MISO_PIN       // SPI Master In Slave Out pin
-  #define SPI_SCK_PIN SCK_PIN         // SPI Clock pin
-#else  // SOFTWARE_SPI
-  #define SD_CHIP_SELECT_PIN SOFT_SPI_CS_PIN  // SPI chip select pin
-  #define SPI_MOSI_PIN SOFT_SPI_MOSI_PIN      // SPI Master Out Slave In pin
-  #define SPI_MISO_PIN SOFT_SPI_MISO_PIN      // SPI Master In Slave Out pin
-  #define SPI_SCK_PIN SOFT_SPI_SCK_PIN        // SPI Clock pin
-#endif  // SOFTWARE_SPI
-
-#endif
-
 /**
  * \class Sd2Card
  * \brief Raw access to SD and SDHC flash memory cards.


### PR DESCRIPTION
It seems that there are some function not used (and on almost all HAL are copy of WRITE).
Don't know if present for "future" use, but in case

There is also a `#if 0` with duplicated defines elsewhere