### PR TITLE
STM32F1: ignore output check for analogWrite()

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
@@ -322,7 +322,7 @@ uint16_t analogRead(pin_t pin) {
 
 // Wrapper to maple unprotected analogWrite
 void analogWrite(pin_t pin, int pwm_val8) {
-  if (PWM_PIN(pin) && IS_OUTPUT(pin))
+  if (PWM_PIN(pin))
     analogWrite(uint8_t(pin), pwm_val8);
 }
 


### PR DESCRIPTION
for issue #14496 