### PR TITLE
sd-eeprom: avoid duplicated settings.load()

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -941,7 +941,7 @@ void setup() {
 
   // Load data from EEPROM if available (or use defaults)
   // This also updates variables in the planner, elsewhere
-  if (!settings.loaded) (void)settings.load();
+  settings.first_load();
 
   #if HAS_M206_COMMAND
     // Initialize current position based on home_offset

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -941,7 +941,7 @@ void setup() {
 
   // Load data from EEPROM if available (or use defaults)
   // This also updates variables in the planner, elsewhere
-  (void)settings.load();
+  if (!settings.loaded) (void)settings.load();
 
   #if HAS_M206_COMMAND
     // Initialize current position based on home_offset

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -341,6 +341,8 @@ typedef struct SettingsDataStruct {
 
 MarlinSettings settings;
 
+bool MarlinSettings::loaded; // = false
+
 uint16_t MarlinSettings::datasize() { return sizeof(SettingsData); }
 
 /**
@@ -2107,6 +2109,7 @@ void MarlinSettings::postprocess() {
       #if ENABLED(EXTENSIBLE_UI)
         ExtUI::onConfigurationStoreRead(success);
       #endif
+      if (success) loaded = true;
       return success;
     }
     reset();

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -341,8 +341,6 @@ typedef struct SettingsDataStruct {
 
 MarlinSettings settings;
 
-bool MarlinSettings::loaded; // = false
-
 uint16_t MarlinSettings::datasize() { return sizeof(SettingsData); }
 
 /**
@@ -2109,7 +2107,6 @@ void MarlinSettings::postprocess() {
       #if ENABLED(EXTENSIBLE_UI)
         ExtUI::onConfigurationStoreRead(success);
       #endif
-      if (success) loaded = true;
       return success;
     }
     reset();

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -29,8 +29,6 @@
 
 class MarlinSettings {
   public:
-    static bool loaded;
-
     static uint16_t datasize();
 
     static void reset();
@@ -55,8 +53,14 @@ class MarlinSettings {
     #endif
 
     #if ENABLED(EEPROM_SETTINGS)
+
       static bool load();      // Return 'true' if data was loaded ok
       static bool validate();  // Return 'true' if EEPROM data is ok
+
+      static inline void first_load() {
+        static bool loaded = false;
+        if (!loaded && load()) loaded = true;
+      }
 
       #if ENABLED(AUTO_BED_LEVELING_UBL) // Eventually make these available if any leveling system
                                          // That can store is enabled
@@ -73,6 +77,8 @@ class MarlinSettings {
     #else
       FORCE_INLINE
       static bool load() { reset(); report(); return true; }
+      FORCE_INLINE
+      static void first_load() { (void)load(); }
     #endif
 
     #if DISABLED(DISABLE_M503)

--- a/Marlin/src/module/configuration_store.h
+++ b/Marlin/src/module/configuration_store.h
@@ -29,7 +29,7 @@
 
 class MarlinSettings {
   public:
-    MarlinSettings() { }
+    static bool loaded;
 
     static uint16_t datasize();
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -354,7 +354,7 @@ void CardReader::initsd() {
     flag.detected = true;
     SERIAL_ECHO_MSG(MSG_SD_CARD_OK);
     #if ENABLED(EEPROM_SETTINGS) && NONE(FLASH_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
-      if (!settings.loaded) (void)settings.load();
+      settings.first_load();
     #endif
   }
   setroot();
@@ -561,10 +561,7 @@ void CardReader::checkautostart() {
 
   if (!isDetected()) initsd();
   #if ENABLED(EEPROM_SETTINGS) && NONE(FLASH_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
-    else if (!settings.loaded) {
-      SERIAL_ECHOLNPGM("Loading settings from SD");
-      (void)settings.load();
-    }
+    else settings.first_load();
   #endif
 
   if (isDetected()

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -353,8 +353,8 @@ void CardReader::initsd() {
   else {
     flag.detected = true;
     SERIAL_ECHO_MSG(MSG_SD_CARD_OK);
-    #if ENABLED(EEPROM_SETTINGS) && DISABLED(FLASH_EEPROM_EMULATION)
-      (void)settings.load();
+    #if ENABLED(EEPROM_SETTINGS) && NONE(FLASH_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
+      if (!settings.loaded) (void)settings.load();
     #endif
   }
   setroot();
@@ -560,10 +560,11 @@ void CardReader::checkautostart() {
   if (autostart_index < 0 || flag.sdprinting) return;
 
   if (!isDetected()) initsd();
-
-  #if ENABLED(EEPROM_SETTINGS) && DISABLED(FLASH_EEPROM_EMULATION)
-    SERIAL_ECHOLNPGM("Loading settings from SD");
-    (void)settings.load();
+  #if ENABLED(EEPROM_SETTINGS) && NONE(FLASH_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
+    else if (!settings.loaded) {
+      SERIAL_ECHOLNPGM("Loading settings from SD");
+      (void)settings.load();
+    }
   #endif
 
   if (isDetected()


### PR DESCRIPTION
initsd() do the settings.load, no need to do it twice (or more)
