### PR TITLE
Turn Off Fan During Filament Change

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -284,6 +284,10 @@
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
 #endif
 
+// Make Fan Off During Filament Change to prevent temp drop fast.
+//  
+#define TURN_OFF_FAN_DURING_FILAMENT_CHANGE
+
 // When first starting the main fan, run it at full speed for the
 // given number of milliseconds.  This gets the fan spinning reliably
 // before setting a PWM value. (Does not work with software PWM for fan on Sanguinololu)

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -45,6 +45,10 @@
   #include "../../../feature/mixing.h"
 #endif
 
+#if ENABLED(TURN_OFF_FAN_DURING_FILAMENT_CHANGE)
+  #include "../../../module/temperature.h"
+#endif
+
 /**
  * M600: Pause for filament change
  *
@@ -99,6 +103,11 @@ void GcodeSuite::M600() {
   #if ENABLED(HOME_BEFORE_FILAMENT_CHANGE)
     // Don't allow filament change without homing first
     if (axis_unhomed_error()) home_all_axes();
+  #endif
+
+  #if ENABLED(TURN_OFF_FAN_DURING_FILAMENT_CHANGE)
+     const uint8_t current_fanspd = thermalManager.fan_speed[0];
+     thermalManager.set_fan_speed(0, 0);
   #endif
 
   #if EXTRUDERS > 1
@@ -171,6 +180,10 @@ void GcodeSuite::M600() {
     // Restore toolhead if it was changed
     if (active_extruder_before_filament_change != active_extruder)
       tool_change(active_extruder_before_filament_change, false);
+  #endif
+
+  #if ENABLED(TURN_OFF_FAN_DURING_FILAMENT_CHANGE)
+     thermalManager.set_fan_speed(0, current_fanspd);
   #endif
 
   #if ENABLED(MIXING_EXTRUDER)


### PR DESCRIPTION
Turn Off Fan During Filament Change.

With the fan turn on, The temperature drop fast. And if the fan speed is high, we can get Thermal Protection Error. It happened sometimes on mine.

Anyway, we dont need fan to turn on when changing filament.