### PR TITLE
Biqu SKR 1.1 => BigTreeTech SKR 1.1

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -193,7 +193,7 @@
 #define BOARD_COHESION3D_MINI         2011  // Cohesion3D Mini
 #define BOARD_SMOOTHIEBOARD           2012  // Smoothieboard
 #define BOARD_AZTEEG_X5_MINI_WIFI     2013  // Azteeg X5 Mini Wifi (Power outputs: Hotend0, Bed, Fan)
-#define BOARD_BIQU_SKR_V1_1           2014  // BIQU SKR_V1.1 (Power outputs: Hotend0,Hotend1, Fan, Bed)
+#define BOARD_BIGTREE_SKR_V1_1        2014  // BIGTREE SKR_V1.1 (Power outputs: Hotend0,Hotend1, Fan, Bed)
 #define BOARD_BIQU_B300_V1_0          2015  // BIQU B300_V1.0 (Power outputs: Hotend0, Fan, Bed, SPI Driver)
 #define BOARD_BIGTREE_SKR_V1_3        2016  // BIGTREE SKR_V1.3 (Power outputs: Hotend0, Hotend1, Fan, Bed)
 #define BOARD_AZTEEG_X5_MINI          2017  // Azteeg X5 Mini (Power outputs: Hotend0, Bed, Fan)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -344,8 +344,8 @@
   #include "pins_COHESION3D_MINI.h"     // LPC1769                                    env:LPC1769
 #elif MB(SMOOTHIEBOARD)
   #include "pins_SMOOTHIEBOARD.h"       // LPC1769                                    env:LPC1769
-#elif MB(BIQU_SKR_V1_1)
-  #include "pins_BIQU_SKR_V1.1.h"       // LPC1768                                    env:LPC1768
+#elif MB(BIGTREE_SKR_V1_1)
+  #include "pins_BIGTREE_SKR_V1.1.h"    // LPC1768                                    env:LPC1768
 #elif MB(BIQU_B300_V1_0)
   #include "pins_BIQU_B300_V1.0.h"      // LPC1768                                    env:LPC1768
 #elif MB(BIGTREE_SKR_V1_3)

--- a/Marlin/src/pins/pins_BIGTREE_SKR_V1.1.h
+++ b/Marlin/src/pins/pins_BIGTREE_SKR_V1.1.h
@@ -26,7 +26,7 @@
 #endif
 
 #ifndef BOARD_NAME
-  #define BOARD_NAME "BIQU SKR V1.1"
+  #define BOARD_NAME "BIGTREE SKR V1.1"
 #endif
 
 //


### PR DESCRIPTION
### Description

Renames Biqu SKR 1.1 board to BigTreeTech SKR 1.1.

### Benefits

Biqu/BigTreeTech might be the same company, but the board is sold under the BigTreeTech brand and has BigTreeTech screen printed on the PCB.

See BigTreeTech SKR 1.3, BigTreeTech SKR Mini 1.1, BigTreeTech SKR Mini E3, BigTreeTech SKR Mini E3-DIP, etc.

### Related Issues

None.