### PR TITLE
 Add 'E' argument to G34 to allow stowing between probes

### DIFF
--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -162,7 +162,7 @@ void GcodeSuite::G34() {
         if (iteration == 0 || izstepper > 0) do_blocking_move_to_z(z_probe);
 
         // Probe a Z height for each stepper.
-        float z_probed_height = probe_pt(z_auto_align_xpos[zstepper], z_auto_align_ypos[zstepper], raise_after, 0, true);
+        const float z_probed_height = probe_pt(z_auto_align_xpos[zstepper], z_auto_align_ypos[zstepper], raise_after, 0, true);
         if (isnan(z_probed_height)) {
           SERIAL_ECHOLNPGM("Probing failed.");
           err_break = true;


### PR DESCRIPTION
### Description

This adds an 'E' argument to the G34 command, to allow stowing the probe between each probe point. This is consistent with the argument already available with existing multi-probe commands, such as G29.

As part of this change, I had to modify the G34 code to use the return value from probe_pt. The prior assumption that the probed bed position could be derived from current_position[Z_AXIS] is no longer valid after stowing the probe.

### Benefits

When using a solenoid probe, stowing the probe after each point reduces the duty cycle of the solenoid. This reduces the heat which can build up during an extended probing cycle.

This also makes G34 more consistent with other probing commands, such as G29.

### Related Issues

None that I could find.
