### PR TITLE
Fix Ender-2 LCD contrast

### DIFF
--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -1882,7 +1882,7 @@
 // MakerLab Mini Panel with graphic
 // controller and SD support - http://reprap.org/wiki/Mini_panel
 //
-#define MINIPANEL
+//#define MINIPANEL
 
 //
 // MaKr3d Makr-Panel with graphic controller and SD support.
@@ -1942,7 +1942,7 @@
 // MKS MINI12864 with graphic controller and SD support
 // https://reprap.org/wiki/MKS_MINI_12864
 //
-//#define MKS_MINI_12864
+#define MKS_MINI_12864
 
 //
 // FYSETC variant of the MINI12864 graphic controller with SD support


### PR DESCRIPTION
### Description

Changed the default LCD to overcome the changes in:
5018fdacbeb0807fc255f83049044b89323eea55
This commit exposed a bug because the Ender-2 was using a MINIPANEL lcd
and getting default values that were too low, so the text was too weak.
However, the panel should be MKS_MINI_12864, since it
explicitly sets the correct contrast without relying in the defaults.

### Benefits

The text is no longer transparent (almost invisible). You can use the lcd screen again

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/14544
