### PR TITLE
Fix STM32F7 compile error

### DIFF
--- a/Marlin/src/HAL/HAL_STM32_F4_F7/STM32F7/TMC2660.cpp
+++ b/Marlin/src/HAL/HAL_STM32_F4_F7/STM32F7/TMC2660.cpp
@@ -895,4 +895,6 @@ inline void TMC26XStepper::send262(uint32_t datagram) {
   driver_status_result = i_datagram;
 }
 
+#endif // HAS_DRIVER(TMC2660)
+
 #endif // STM32GENERIC && STM32F7


### PR DESCRIPTION
add missing `#endif`