### PR TITLE
pins_ARMED overrides STM32 defines

### DIFF
--- a/Marlin/src/pins/stm32/pins_ARMED.h
+++ b/Marlin/src/pins/stm32/pins_ARMED.h
@@ -29,7 +29,7 @@
   #define ARMED_V1_1
 #endif
 
-#undef BOARD_NAME// Defined on the command line by Arduino Core STM32
+#undef BOARD_NAME // Defined on the command line by Arduino Core STM32
 #define BOARD_NAME           "Arm'ed"
 #define DEFAULT_MACHINE_NAME BOARD_NAME
 

--- a/Marlin/src/pins/stm32/pins_ARMED.h
+++ b/Marlin/src/pins/stm32/pins_ARMED.h
@@ -25,13 +25,17 @@
   #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
 #endif
 
-#define ARMED_V1_1
+#ifndef ARMED_V1_0
+  #define ARMED_V1_1
+#endif
 
+#undef BOARD_NAME// Defined on the command line by Arduino Core STM32
 #define BOARD_NAME           "Arm'ed"
 #define DEFAULT_MACHINE_NAME BOARD_NAME
 
 #define I2C_EEPROM
 
+#undef E2END // Defined in Arduino Core STM32 to be used with EEPROM emulation. This board uses a real EEPROM.
 #define E2END 0xFFF // 4KB
 
 #if HOTENDS > 2 || E_STEPPERS > 2


### PR DESCRIPTION
### Description

Fix warnings introduced with the following commits when building for the ARMED board:

3ae3bf5 Get E2END from pins, fix Linux buffer
cb60001 Clean up BOARD_NAME in pins.

When building with Arduino Core STM32:
- BOARD_NAME is defined in the Arduino Core STM32 and has to be undefined to avoid warnings.
- E2END is defined in the core for EEPROM emulation. The ARMED board is using a real EEPROM. It has to be undefined to avoid warnings.
