### PR TITLE
Fix M412 without HOST_ACTION_COMMANDS

### DIFF
--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -31,12 +31,12 @@
  * M412: Enable / Disable filament runout detection
  */
 void GcodeSuite::M412() {
-  if (parser.seen("HS"
+  if (parser.seen("RS"
     #ifdef FILAMENT_RUNOUT_DISTANCE_MM
       "D"
     #endif
     #if ENABLED(HOST_ACTION_COMMANDS)
-      "R"
+      "H"
     #endif
   )) {
     #if ENABLED(HOST_ACTION_COMMANDS)


### PR DESCRIPTION
### Description

Fix bug cannot reset runout by `M412` if didn't enable `HOST_ACTION_COMMANDS`

As you seen, when `HOST_ACTION_COMMANDS` is not enabled, `M412` handler won't eat the parameter "`R`".