### PR TITLE
Esp32 HAL - fixed i2s stream, added PWM to extended pins

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -68,9 +68,9 @@ uint16_t HAL_adc_result;
 // ------------------------
 
 esp_adc_cal_characteristics_t characteristics;
-volatile int numPWMUsed=0;
-volatile int pwmPins[MAX_PWM_PINS];
-volatile int pwmValues[MAX_PWM_PINS];
+volatile int numPWMUsed = 0,
+             pwmPins[MAX_PWM_PINS],
+             pwmValues[MAX_PWM_PINS];
 
 // ------------------------
 // Public functions
@@ -172,50 +172,39 @@ void HAL_adc_init() {
 void HAL_adc_start_conversion(uint8_t adc_pin) {
   uint32_t mv;
   esp_adc_cal_get_voltage((adc_channel_t)get_channel(adc_pin), &characteristics, &mv);
-
-  HAL_adc_result = mv*1023.0/3300.0;
+  HAL_adc_result = mv * 1023.0 / 3300.0;
 }
 
 void analogWrite(pin_t pin, int value) {
   // Use ledc hardware for internal pins
-  if (pin < 34){
-    static int cnt_channel = 1,
-            pin_to_channel[40] = {};
+  if (pin < 34) {
+    static int cnt_channel = 1, pin_to_channel[40] = { 0 };
     if (pin_to_channel[pin] == 0) {
       ledcAttachPin(pin, cnt_channel);
       ledcSetup(cnt_channel, 490, 8);
       ledcWrite(cnt_channel, value);
-
       pin_to_channel[pin] = cnt_channel++;
     }
-
-   ledcWrite(pin_to_channel[pin], value);
-   return;
+    ledcWrite(pin_to_channel[pin], value);
+    return;
   }
 
-  int idx=-1;
+  int idx = -1;
 
   // Search Pin
-  for (int i=0; i<numPWMUsed; ++i){
-    // Found
-    if (pwmPins[i] == pin){
+  for (int i = 0; i < numPWMUsed; ++i)
+    if (pwmPins[i] == pin) { idx = i; break; }
 
-      idx=i;
-      break;
-    }
-  }
   // not found ?
   if (idx < 0) {
     // No slots remaining
-    if (numPWMUsed >= MAX_PWM_PINS-1)
-      return;
+    if (numPWMUsed >= MAX_PWM_PINS) return;
 
-    // take new slot for pin
+    // Take new slot for pin
     idx = numPWMUsed;
     pwmPins[idx] = pin;
     // Start timer on first use
-    if (numPWMUsed == 0)
-      HAL_timer_start(PWM_TIMER_NUM, PWM_TIMER_FREQUENCY);
+    if (idx == 0) HAL_timer_start(PWM_TIMER_NUM, PWM_TIMER_FREQUENCY);
 
     ++numPWMUsed;
   }
@@ -225,27 +214,22 @@ void analogWrite(pin_t pin, int value) {
 }
 
 // Handle PWM timer interrupt
-HAL_PWM_TIMER_ISR(){
+HAL_PWM_TIMER_ISR() {
   HAL_timer_isr_prologue(PWM_TIMER_NUM);
 
-  static unsigned int count = 0;
+  static uint8_t count = 0;
 
-  for (int i=0; i<numPWMUsed; ++i){
-    if (count == 0)
-       // Start of interval
-        WRITE(pwmPins[i], (pwmValues[i] ? 1 : 0));
-    else
-      //end of duration
-      if (pwmValues[i] == count)
-        WRITE(pwmPins[i], 0);
+  for (int i = 0; i < numPWMUsed; ++i) {
+    if (count == 0)                   // Start of interval
+      WRITE(pwmPins[i], pwmValues[i] ? HIGH : LOW);
+    else if (pwmValues[i] == count)   // End of duration
+      WRITE(pwmPins[i], LOW);
   }
 
   // 128 for 7 Bit resolution
-  if (++count>127)
-    count=0;
+  count = (count + 1) & 0x7F;
 
   HAL_timer_isr_epilogue(PWM_TIMER_NUM);
 }
-
 
 #endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL_timers_ESP32.h
@@ -40,6 +40,7 @@ typedef uint64_t hal_timer_t;
 
 #define STEP_TIMER_NUM 0  // index of timer to use for stepper
 #define TEMP_TIMER_NUM 1  // index of timer to use for temperature
+#define PWM_TIMER_NUM  2  // index of timer to use for PWM outputs
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 
 #define HAL_TIMER_RATE APB_CLK_FREQ // frequency of timer peripherals
@@ -59,6 +60,14 @@ typedef uint64_t hal_timer_t;
 #define TEMP_TIMER_PRESCALE    1000 // prescaler for setting Temp timer, 72Khz
 #define TEMP_TIMER_FREQUENCY   1000 // temperature interrupt frequency
 
+#define PWM_TIMER_PRESCALE       10
+#if ENABLED(FAST_PWM_FAN)
+  #define PWM_TIMER_FREQUENCY  FAST_PWM_FAN_FREQUENCY
+#else
+  #define PWM_TIMER_FREQUENCY  (50*128) // 50Hz and 7bit resolution
+#endif
+#define MAX_PWM_PINS             32 // Number of PWM pin-slots
+
 #define PULSE_TIMER_RATE         STEPPER_TIMER_RATE   // frequency of pulse timer
 #define PULSE_TIMER_PRESCALE     STEPPER_TIMER_PRESCALE
 #define PULSE_TIMER_TICKS_PER_US STEPPER_TIMER_TICKS_PER_US
@@ -72,10 +81,11 @@ typedef uint64_t hal_timer_t;
 
 #define HAL_TEMP_TIMER_ISR() extern "C" void tempTC_Handler(void)
 #define HAL_STEP_TIMER_ISR() extern "C" void stepTC_Handler(void)
+#define HAL_PWM_TIMER_ISR() extern "C" void pwmTC_Handler(void)
 
 extern "C" void tempTC_Handler(void);
 extern "C" void stepTC_Handler(void);
-
+extern "C" void pwmTC_Handler(void);
 
 // ------------------------
 // Types

--- a/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
+++ b/Marlin/src/HAL/HAL_ESP32/fastio_ESP32.h
@@ -66,7 +66,7 @@
 #define extDigitalWrite(IO,V)   digitalWrite(IO,V)
 
 // PWM outputs
-#define PWM_PIN(P)              (P < 34) // NOTE Pins >= 34 are input only on ESP32, so they can't be used for output.
+#define PWM_PIN(P)              (P < 34 || P > 127) // NOTE Pins >= 34 are input only on ESP32, so they can't be used for output.
 
 // Toggle pin value
 #define TOGGLE(IO)              WRITE(IO, !READ(IO))

--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -146,7 +146,7 @@ void stepperTask(void* parameter) {
     xQueueReceive(dma.queue, &dma.current, portMAX_DELAY);
     dma.rw_pos = 0;
 
-    for (i = 0; i < DMA_SAMPLE_COUNT; i++) {
+    while (dma.rw_pos < DMA_SAMPLE_COUNT) {
       // Fill with the port data post pulse_phase until the next step
       if (remaining) {
         i2s_push_sample();

--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -254,11 +254,13 @@ int i2s_init() {
 
   I2S0.fifo_conf.dscr_en = 0;
 
-  #if ENABLED(I2S_STEPPER_SPLIT_STREAM)
-    I2S0.conf_chan.tx_chan_mod = 4;
-  #else
-    I2S0.conf_chan.tx_chan_mod = 0;
-  #endif
+  I2S0.conf_chan.tx_chan_mod = (
+    #if ENABLED(I2S_STEPPER_SPLIT_STREAM)
+      4
+    #else
+      0
+    #endif
+  );
   I2S0.fifo_conf.tx_fifo_mod = 0;
   I2S0.conf.tx_mono = 0;
 
@@ -329,8 +331,7 @@ void i2s_write(uint8_t pin, uint8_t val) {
 
 uint8_t i2s_state(uint8_t pin) {
   #if ENABLED(I2S_STEPPER_SPLIT_STREAM)
-    if (pin >= 16)
-      return TEST(I2S0.conf_single_data, pin);
+    if (pin >= 16) return TEST(I2S0.conf_single_data, pin);
   #endif
   return TEST(i2s_port_data, pin);
 }


### PR DESCRIPTION
### Description
Fixes I2S Stream in ESP32 HAL. Last code didn't fill up the DMA buffer completely, leaving last ~4 samples from older calculation when no more steps were needed. This could result in permanent motor drift if a step was in the last 4 samples.

To direct access the last 16bit of the extension bypassing the DMA a new define I2S_STEPPER_SPLIT_STREAM was introduced for using in pins.h

To handle the extended pins as PWM - a timer inside the HAL adds PWM features - as current Marlin doesn't handle CONTROLLER_FAN, E?_AUTO_FAN by FAN_SOFT_PWM
This also resolves conflicting hardware usage for PWM and servos.

### Benefits
Working Stepper Motors via i2s extender.
Working PWM for Controller, E0,E.. FANS via i2s extender in split mode

