### PR TITLE
Fix undefined behavior in process_injected_command()

### DIFF
--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -173,7 +173,7 @@ bool GCodeQueue::process_injected_command() {
 
   // Extract current command and move pointer to next command
   char cmd[i + 1];
-  if (i) memcpy_P(cmd, injected_commands_P, i);
+  memcpy_P(cmd, injected_commands_P, i);
   cmd[i] = '\0';
   injected_commands_P = c ? injected_commands_P + i + 1 : nullptr;
 

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -170,16 +170,19 @@ bool GCodeQueue::process_injected_command() {
   char c;
   size_t i = 0;
   while ((c = pgm_read_byte(&injected_commands_P[i])) && c != '\n') i++;
-  if (i) {
-    char cmd[i + 1];
-    memcpy_P(cmd, injected_commands_P, i);
-    cmd[i] = '\0';
 
+  // Extract current command and move pointer to next command
+  char cmd[i + 1];
+  memcpy_P(cmd, injected_commands_P, i);
+  cmd[i] = '\0';
+  injected_commands_P = c ? injected_commands_P + i + 1 : nullptr;
+
+  // Execute command if non-blank
+  if(i) {
     parser.parse(cmd);
     PORT_REDIRECT(SERIAL_PORT);
     gcode.process_parsed_command();
   }
-  injected_commands_P = c ? injected_commands_P + i + 1 : nullptr;
   return true;
 }
 

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -173,12 +173,12 @@ bool GCodeQueue::process_injected_command() {
 
   // Extract current command and move pointer to next command
   char cmd[i + 1];
-  memcpy_P(cmd, injected_commands_P, i);
+  if (i) memcpy_P(cmd, injected_commands_P, i);
   cmd[i] = '\0';
   injected_commands_P = c ? injected_commands_P + i + 1 : nullptr;
 
   // Execute command if non-blank
-  if(i) {
+  if (i) {
     parser.parse(cmd);
     PORT_REDIRECT(SERIAL_PORT);
     gcode.process_parsed_command();


### PR DESCRIPTION
Running injected commands can cause inject_P() to be called with a new string.
When this happens, process_injected_command() increments injected_commands_P
incorrectly, possibly past the end of the new string, causing undefined
behavior.

To avoid this, complete adjustment of injected_commands_P prior to executing a
command. If a new call to inject_P() happens, the prior list of commands will
be interrupted and the new commands will start executing.