### PR TITLE
Allow nozzle clean with limited Axis

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -45,6 +45,9 @@ void GcodeSuite::G12() {
   if(parser.seen('X')) clean_x = true;
   if(parser.seen('Y')) clean_y = true;
 
+  #undef XY_PARAM
+  #define XY_PARAM "XY"
+
   #if DISABLED(NOZZLE_CLEAN_NO_Z)
     if(parser.seen('Z')) clean_z = true;
     if (!parser.seen(XY_PARAM "Z")) clean_x = clean_y = clean_z = true;
@@ -57,17 +60,16 @@ void GcodeSuite::G12() {
                 objects = parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES);
   const float radius = parser.floatval('R', NOZZLE_CLEAN_CIRCLE_RADIUS);
 
-  #if HAS_LEVELING
-    if(clean_z) {
-      const bool was_enabled = planner.leveling_active;
+  #if HAS_LEVELING && DISABLED(NOZZLE_CLEAN_NO_Z)
+    const bool was_enabled = planner.leveling_active;
+    if(clean_z)
       set_bed_leveling_enabled(false);
-    }
   #endif
 
   Nozzle::clean(pattern, strokes, radius, objects, clean_x, clean_y, clean_z);
 
   // Re-enable bed level correction if it had been on
-  #if HAS_LEVELING
+  #if HAS_LEVELING && DISABLED(NOZZLE_CLEAN_NO_Z)
     if(clean_z)
       set_bed_leveling_enabled(was_enabled);
   #endif

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -41,6 +41,16 @@
 void GcodeSuite::G12() {
   // Don't allow nozzle cleaning without homing first
   if (axis_unhomed_error()) return;
+  bool clean_x, clean_y, clean_z = false;
+  if(parser.seen('X')) clean_x = true;
+  if(parser.seen('Y')) clean_y = true;
+
+  #if DISABLED(NOZZLE_CLEAN_NO_Z)
+    if(parser.seen('Z')) clean_z = true;
+    if (!parser.seen(XY_PARAM "Z")) clean_x = clean_y = clean_z = true;
+  #else
+    if (!parser.seen(XY_PARAM "Z")) clean_x = clean_y = true;
+  #endif
 
   const uint8_t pattern = parser.ushortval('P', 0),
                 strokes = parser.ushortval('S', NOZZLE_CLEAN_STROKES),
@@ -48,15 +58,18 @@ void GcodeSuite::G12() {
   const float radius = parser.floatval('R', NOZZLE_CLEAN_CIRCLE_RADIUS);
 
   #if HAS_LEVELING
-    const bool was_enabled = planner.leveling_active;
-    set_bed_leveling_enabled(false);
+    if(clean_z) {
+      const bool was_enabled = planner.leveling_active;
+      set_bed_leveling_enabled(false);
+    }
   #endif
 
-  Nozzle::clean(pattern, strokes, radius, objects);
+  Nozzle::clean(pattern, strokes, radius, objects, clean_x, clean_y, clean_z);
 
   // Re-enable bed level correction if it had been on
   #if HAS_LEVELING
-    set_bed_leveling_enabled(was_enabled);
+    if(clean_z)
+      set_bed_leveling_enabled(was_enabled);
   #endif
 }
 

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -46,10 +46,10 @@
     #endif
 
     // Move to the starting point
-    #if DISABLED(NOZZLE_CLEAN_NO_Z)
-      do_blocking_move_to(start.x, start.y, start.z);
-    #else
+    #if ENABLED(NOZZLE_CLEAN_NO_Z)
       do_blocking_move_to_xy(start.x, start.y);
+    #else
+      do_blocking_move_to(start.x, start.y, start.z);
     #endif
 
     // Start the stroke pattern
@@ -80,10 +80,10 @@
       const float ix = current_position[X_AXIS], iy = current_position[Y_AXIS], iz = current_position[Z_AXIS];
     #endif
 
-    #if DISABLED(NOZZLE_CLEAN_NO_Z)
-      do_blocking_move_to(start.x, start.y, start.z);
-    #else
+    #if ENABLED(NOZZLE_CLEAN_NO_Z)
       do_blocking_move_to_xy(start.x, start.y);
+    #else
+      do_blocking_move_to(start.x, start.y, start.z);
     #endif
 
     const uint8_t zigs = objects << 1;
@@ -127,10 +127,10 @@
       const float ix = current_position[X_AXIS], iy = current_position[Y_AXIS], iz = current_position[Z_AXIS];
     #endif
 
-    #if DISABLED(NOZZLE_CLEAN_NO_Z)
-      do_blocking_move_to(start.x, start.y, start.z);
-    #else
+    #if ENABLED(NOZZLE_CLEAN_NO_Z)
       do_blocking_move_to_xy(start.x, start.y);
+    #else
+      do_blocking_move_to(start.x, start.y, start.z);
     #endif
 
     for (uint8_t s = 0; s < strokes; s++)

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -155,23 +155,13 @@
    * @param pattern one of the available patterns
    * @param argument depends on the cleaning pattern
    */
-  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects/*=0*/, const bool clean_x, const bool clean_y, const bool clean_z) {
-
+  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const bool clean_x, const bool clean_y, const bool clean_z) {
     point_t start = NOZZLE_CLEAN_START_POINT;
     point_t end = NOZZLE_CLEAN_END_POINT;
+    if (!clean_x) start.x = end.x = current_position[X_AXIS];
+    if (!clean_y) start.y = end.y = current_position[Y_AXIS];
+    if (!clean_z) start.z = end.z = current_position[Z_AXIS];
 
-    if(!clean_x) {
-      start.x = current_position[X_AXIS];
-      end.x = current_position[X_AXIS];
-    }
-    if(!clean_y) {
-      start.y = current_position[Y_AXIS];
-      end.y = current_position[Y_AXIS];
-    }
-    if(!clean_z) {
-      start.z = current_position[Z_AXIS];
-      end.z = current_position[Z_AXIS];
-    }
     switch (pattern) {
       case 1:
         zigzag(NOZZLE_CLEAN_START_POINT, NOZZLE_CLEAN_END_POINT, strokes, objects);
@@ -190,9 +180,9 @@
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
 
-  void Nozzle::park(const uint8_t z_action, const point_t &park /*= NOZZLE_PARK_POINT*/) {
-    const float fr_xy = NOZZLE_PARK_XY_FEEDRATE;
-    const float fr_z = NOZZLE_PARK_Z_FEEDRATE;
+  void Nozzle::park(const uint8_t z_action, const point_t &park/*=NOZZLE_PARK_POINT*/) {
+    const float fr_xy = NOZZLE_PARK_XY_FEEDRATE,
+                fr_z = NOZZLE_PARK_Z_FEEDRATE;
 
     switch (z_action) {
       case 1: // Go to Z-park height

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -158,7 +158,7 @@
   void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects/*=0*/, const bool clean_x, const bool clean_y, const bool clean_z) {
 
     point_t start = NOZZLE_CLEAN_START_POINT;
-    pont_t end = NOZZLE_CLEAN_END_POINT;
+    point_t end = NOZZLE_CLEAN_END_POINT;
 
     if(!clean_x) {
       start.x = current_position[X_AXIS];

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -46,7 +46,11 @@
     #endif
 
     // Move to the starting point
-    do_blocking_move_to(start.x, start.y, start.z);
+    #if DISABLED(NOZZLE_CLEAN_NO_Z)
+      do_blocking_move_to(start.x, start.y, start.z);
+    #else
+      do_blocking_move_to_xy(start.x, start.y);
+    #endif
 
     // Start the stroke pattern
     for (uint8_t i = 0; i < (strokes >> 1); i++) {
@@ -76,7 +80,11 @@
       const float ix = current_position[X_AXIS], iy = current_position[Y_AXIS], iz = current_position[Z_AXIS];
     #endif
 
-    do_blocking_move_to(start.x, start.y, start.z);
+    #if DISABLED(NOZZLE_CLEAN_NO_Z)
+      do_blocking_move_to(start.x, start.y, start.z);
+    #else
+      do_blocking_move_to_xy(start.x, start.y);
+    #endif
 
     const uint8_t zigs = objects << 1;
     const bool horiz = ABS(diffx) >= ABS(diffy);    // Do a horizontal wipe?
@@ -119,7 +127,11 @@
       const float ix = current_position[X_AXIS], iy = current_position[Y_AXIS], iz = current_position[Z_AXIS];
     #endif
 
-    do_blocking_move_to(start.x, start.y, start.z);
+    #if DISABLED(NOZZLE_CLEAN_NO_Z)
+      do_blocking_move_to(start.x, start.y, start.z);
+    #else
+      do_blocking_move_to_xy(start.x, start.y);
+    #endif
 
     for (uint8_t s = 0; s < strokes; s++)
       for (uint8_t i = 0; i < NOZZLE_CLEAN_CIRCLE_FN; i++)
@@ -143,7 +155,23 @@
    * @param pattern one of the available patterns
    * @param argument depends on the cleaning pattern
    */
-  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects/*=0*/) {
+  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects/*=0*/, const bool clean_x, const bool clean_y, const bool clean_z) {
+
+    point_t start = NOZZLE_CLEAN_START_POINT;
+    pont_t end = NOZZLE_CLEAN_END_POINT;
+
+    if(!clean_x) {
+      start.x = current_position[X_AXIS];
+      end.x = current_position[X_AXIS];
+    }
+    if(!clean_y) {
+      start.y = current_position[Y_AXIS];
+      end.y = current_position[Y_AXIS];
+    }
+    if(!clean_z) {
+      start.z = current_position[Z_AXIS];
+      end.z = current_position[Z_AXIS];
+    }
     switch (pattern) {
       case 1:
         zigzag(NOZZLE_CLEAN_START_POINT, NOZZLE_CLEAN_END_POINT, strokes, objects);

--- a/Marlin/src/libs/nozzle.h
+++ b/Marlin/src/libs/nozzle.h
@@ -78,7 +78,7 @@ class Nozzle {
      * @param pattern one of the available patterns
      * @param argument depends on the cleaning pattern
      */
-    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects=0, const bool clean_x, const bool clean_y, const bool clean_z) _Os;
+    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const bool clean_x, const bool clean_y, const bool clean_z) _Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 

--- a/Marlin/src/libs/nozzle.h
+++ b/Marlin/src/libs/nozzle.h
@@ -78,7 +78,7 @@ class Nozzle {
      * @param pattern one of the available patterns
      * @param argument depends on the cleaning pattern
      */
-    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects=0) _Os;
+    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects=0, const bool clean_x, const bool clean_y, const bool clean_z) _Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/default/Configuration.h
+++ b/config/default/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -1553,10 +1553,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/3DFabXYZ/Migbot/Configuration.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration.h
@@ -1555,6 +1555,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -1542,10 +1542,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/AlephObjects/TAZ4/Configuration.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration.h
@@ -1544,6 +1544,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/AliExpress/CL-260/Configuration.h
+++ b/config/examples/AliExpress/CL-260/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -1533,10 +1533,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/AliExpress/UM2pExt/Configuration.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration.h
@@ -1535,6 +1535,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Anet/A2/Configuration.h
+++ b/config/examples/Anet/A2/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Anet/A2plus/Configuration.h
+++ b/config/examples/Anet/A2plus/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -1675,6 +1675,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Anet/A6/Configuration.h
+++ b/config/examples/Anet/A6/Configuration.h
@@ -1673,10 +1673,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -1537,6 +1537,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Anet/A8/Configuration.h
+++ b/config/examples/Anet/A8/Configuration.h
@@ -1535,10 +1535,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -1533,10 +1533,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Anet/A8plus/Configuration.h
+++ b/config/examples/Anet/A8plus/Configuration.h
@@ -1535,6 +1535,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -1534,10 +1534,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Anet/E16/Configuration.h
+++ b/config/examples/Anet/E16/Configuration.h
@@ -1536,6 +1536,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -1534,6 +1534,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/AnyCubic/i3/Configuration.h
+++ b/config/examples/AnyCubic/i3/Configuration.h
@@ -1532,10 +1532,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -1523,10 +1523,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/ArmEd/Configuration.h
+++ b/config/examples/ArmEd/Configuration.h
@@ -1525,6 +1525,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Azteeg/X5GT/Configuration.h
+++ b/config/examples/Azteeg/X5GT/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/BIBO/TouchX/cyclops/Configuration.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/BIBO/TouchX/default/Configuration.h
+++ b/config/examples/BIBO/TouchX/default/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -1510,10 +1510,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/BQ/Hephestos/Configuration.h
+++ b/config/examples/BQ/Hephestos/Configuration.h
@@ -1512,6 +1512,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/BQ/Hephestos_2/Configuration.h
+++ b/config/examples/BQ/Hephestos_2/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -1510,10 +1510,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/BQ/WITBOX/Configuration.h
+++ b/config/examples/BQ/WITBOX/Configuration.h
@@ -1512,6 +1512,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -1523,6 +1523,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Cartesio/Configuration.h
+++ b/config/examples/Cartesio/Configuration.h
@@ -1521,10 +1521,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -1534,6 +1534,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/CR-10/Configuration.h
+++ b/config/examples/Creality/CR-10/Configuration.h
@@ -1532,10 +1532,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -1523,10 +1523,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/CR-10S/Configuration.h
+++ b/config/examples/Creality/CR-10S/Configuration.h
@@ -1525,6 +1525,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -1525,10 +1525,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/CR-10_5S/Configuration.h
+++ b/config/examples/Creality/CR-10_5S/Configuration.h
@@ -1527,6 +1527,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -1543,6 +1543,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/CR-10mini/Configuration.h
+++ b/config/examples/Creality/CR-10mini/Configuration.h
@@ -1541,10 +1541,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/CR-20 Pro/Configuration.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration.h
@@ -1521,6 +1521,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/CR-20 Pro/Configuration.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration.h
@@ -1519,10 +1519,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/CR-20/Configuration.h
+++ b/config/examples/Creality/CR-20/Configuration.h
@@ -1521,6 +1521,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/CR-20/Configuration.h
+++ b/config/examples/Creality/CR-20/Configuration.h
@@ -1519,10 +1519,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -1534,6 +1534,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/CR-8/Configuration.h
+++ b/config/examples/Creality/CR-8/Configuration.h
@@ -1532,10 +1532,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -1526,10 +1526,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/Ender-2/Configuration.h
+++ b/config/examples/Creality/Ender-2/Configuration.h
@@ -1528,6 +1528,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -1526,10 +1526,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/Ender-3/Configuration.h
+++ b/config/examples/Creality/Ender-3/Configuration.h
@@ -1528,6 +1528,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -1534,6 +1534,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/Ender-4/Configuration.h
+++ b/config/examples/Creality/Ender-4/Configuration.h
@@ -1532,10 +1532,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Creality/Ender-5/Configuration.h
+++ b/config/examples/Creality/Ender-5/Configuration.h
@@ -1521,6 +1521,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Creality/Ender-5/Configuration.h
+++ b/config/examples/Creality/Ender-5/Configuration.h
@@ -1519,10 +1519,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Dagoma/Disco Ultimate/Configuration.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Dagoma/Disco Ultimate/Configuration.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
@@ -1529,6 +1529,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
@@ -1527,10 +1527,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -1534,6 +1534,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Einstart-S/Configuration.h
+++ b/config/examples/Einstart-S/Configuration.h
@@ -1532,10 +1532,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -1506,6 +1506,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Felix/Configuration.h
+++ b/config/examples/Felix/Configuration.h
@@ -1504,10 +1504,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -1506,6 +1506,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Felix/DUAL/Configuration.h
+++ b/config/examples/Felix/DUAL/Configuration.h
@@ -1504,10 +1504,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -1515,6 +1515,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/FlashForge/CreatorPro/Configuration.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration.h
@@ -1513,10 +1513,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -1528,10 +1528,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/FolgerTech/i3-2020/Configuration.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration.h
@@ -1530,6 +1530,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -1627,10 +1627,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Formbot/Raptor/Configuration.h
+++ b/config/examples/Formbot/Raptor/Configuration.h
@@ -1629,6 +1629,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -1558,6 +1558,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Formbot/T_Rex_2+/Configuration.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration.h
@@ -1556,10 +1556,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -1549,6 +1549,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Formbot/T_Rex_3/Configuration.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration.h
@@ -1547,10 +1547,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Fysetc/AIO_II/Configuration.h
+++ b/config/examples/Fysetc/AIO_II/Configuration.h
@@ -1518,6 +1518,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Fysetc/AIO_II/Configuration.h
+++ b/config/examples/Fysetc/AIO_II/Configuration.h
@@ -1516,10 +1516,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Fysetc/CHEETAH/Configuration.h
+++ b/config/examples/Fysetc/CHEETAH/Configuration.h
@@ -1518,6 +1518,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Fysetc/CHEETAH/Configuration.h
+++ b/config/examples/Fysetc/CHEETAH/Configuration.h
@@ -1516,10 +1516,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Fysetc/F6_13/Configuration.h
+++ b/config/examples/Fysetc/F6_13/Configuration.h
@@ -1520,6 +1520,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Fysetc/F6_13/Configuration.h
+++ b/config/examples/Fysetc/F6_13/Configuration.h
@@ -1518,10 +1518,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/A10/Configuration.h
+++ b/config/examples/Geeetech/A10/Configuration.h
@@ -1507,10 +1507,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/A10/Configuration.h
+++ b/config/examples/Geeetech/A10/Configuration.h
@@ -1509,6 +1509,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -1507,10 +1507,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/A10M/Configuration.h
+++ b/config/examples/Geeetech/A10M/Configuration.h
@@ -1509,6 +1509,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -1506,10 +1506,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/A20M/Configuration.h
+++ b/config/examples/Geeetech/A20M/Configuration.h
@@ -1508,6 +1508,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -1537,10 +1537,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/GT2560/Configuration.h
+++ b/config/examples/Geeetech/GT2560/Configuration.h
@@ -1539,6 +1539,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
+++ b/config/examples/Geeetech/I3_Pro_X-GT2560/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -1531,6 +1531,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/MeCreator2/Configuration.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration.h
@@ -1529,10 +1529,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1543,10 +1543,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/bltouch/Configuration.h
@@ -1545,6 +1545,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1542,10 +1542,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro B/noprobe/Configuration.h
@@ -1544,6 +1544,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -1526,10 +1526,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Infitary/i3-M508/Configuration.h
+++ b/config/examples/Infitary/i3-M508/Configuration.h
@@ -1528,6 +1528,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/JGAurora/A1/Configuration.h
+++ b/config/examples/JGAurora/A1/Configuration.h
@@ -1520,6 +1520,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/JGAurora/A1/Configuration.h
+++ b/config/examples/JGAurora/A1/Configuration.h
@@ -1518,10 +1518,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -1534,10 +1534,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/JGAurora/A5/Configuration.h
+++ b/config/examples/JGAurora/A5/Configuration.h
@@ -1536,6 +1536,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/JGAurora/A5S/Configuration.h
+++ b/config/examples/JGAurora/A5S/Configuration.h
@@ -1520,6 +1520,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/JGAurora/A5S/Configuration.h
+++ b/config/examples/JGAurora/A5S/Configuration.h
@@ -1518,10 +1518,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -1542,10 +1542,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/MakerParts/Configuration.h
+++ b/config/examples/MakerParts/Configuration.h
@@ -1544,6 +1544,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -1550,10 +1550,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Malyan/M150/Configuration.h
+++ b/config/examples/Malyan/M150/Configuration.h
@@ -1552,6 +1552,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -1523,6 +1523,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Malyan/M200/Configuration.h
+++ b/config/examples/Malyan/M200/Configuration.h
@@ -1521,10 +1521,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -1526,10 +1526,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Micromake/C1/basic/Configuration.h
+++ b/config/examples/Micromake/C1/basic/Configuration.h
@@ -1528,6 +1528,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -1526,10 +1526,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Micromake/C1/enhanced/Configuration.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration.h
@@ -1528,6 +1528,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -1523,10 +1523,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Mks/Robin/Configuration.h
+++ b/config/examples/Mks/Robin/Configuration.h
@@ -1525,6 +1525,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Mks/Sbase/Configuration.h
+++ b/config/examples/Mks/Sbase/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -1530,10 +1530,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Printrbot/PrintrboardG2/Configuration.h
+++ b/config/examples/Printrbot/PrintrboardG2/Configuration.h
@@ -1532,6 +1532,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/RapideLite/RL200/Configuration.h
+++ b/config/examples/RapideLite/RL200/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -1573,6 +1573,9 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/RepRapPro/Huxley/Configuration.h
+++ b/config/examples/RepRapPro/Huxley/Configuration.h
@@ -1571,10 +1571,10 @@ Black rubber belt(MXL), 18 - tooth aluminium pulley : 87.489 step per mm (Huxley
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/RepRapWorld/Megatronics/Configuration.h
+++ b/config/examples/RepRapWorld/Megatronics/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -1520,10 +1520,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/RigidBot/Configuration.h
+++ b/config/examples/RigidBot/Configuration.h
@@ -1522,6 +1522,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -1531,10 +1531,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/SCARA/Configuration.h
+++ b/config/examples/SCARA/Configuration.h
@@ -1533,6 +1533,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -1526,6 +1526,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/STM32/STM32F10/Configuration.h
+++ b/config/examples/STM32/STM32F10/Configuration.h
@@ -1524,10 +1524,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/STM32/STM32F4/Configuration.h
+++ b/config/examples/STM32/STM32F4/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -1526,6 +1526,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/STM32/stm32f103ret6/Configuration.h
+++ b/config/examples/STM32/stm32f103ret6/Configuration.h
@@ -1524,10 +1524,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -1553,10 +1553,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Sanguinololu/Configuration.h
+++ b/config/examples/Sanguinololu/Configuration.h
@@ -1555,6 +1555,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Tevo/Tarantula Pro/Configuration.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration.h
@@ -1514,10 +1514,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Tevo/Tarantula Pro/Configuration.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration.h
@@ -1516,6 +1516,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/TheBorg/Configuration.h
+++ b/config/examples/TheBorg/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -1578,10 +1578,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/TinyBoy2/Configuration.h
+++ b/config/examples/TinyBoy2/Configuration.h
@@ -1580,6 +1580,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Tronxy/X1/Configuration.h
+++ b/config/examples/Tronxy/X1/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -1526,10 +1526,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Tronxy/X3A/Configuration.h
+++ b/config/examples/Tronxy/X3A/Configuration.h
@@ -1528,6 +1528,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -1543,10 +1543,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Tronxy/X5S-2E/Configuration.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration.h
@@ -1545,6 +1545,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Tronxy/X5S/Configuration.h
+++ b/config/examples/Tronxy/X5S/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -1533,10 +1533,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Tronxy/XY100/Configuration.h
+++ b/config/examples/Tronxy/XY100/Configuration.h
@@ -1535,6 +1535,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/UltiMachine/Archim1/Configuration.h
+++ b/config/examples/UltiMachine/Archim1/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/UltiMachine/Archim2/Configuration.h
+++ b/config/examples/UltiMachine/Archim2/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -1531,10 +1531,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/VORONDesign/Configuration.h
+++ b/config/examples/VORONDesign/Configuration.h
@@ -1533,6 +1533,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -1552,10 +1552,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Velleman/K8200/Configuration.h
+++ b/config/examples/Velleman/K8200/Configuration.h
@@ -1554,6 +1554,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Velleman/K8400/Configuration.h
+++ b/config/examples/Velleman/K8400/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Velleman/K8400/Dual-head/Configuration.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -1543,6 +1543,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/WASP/PowerWASP/Configuration.h
+++ b/config/examples/WASP/PowerWASP/Configuration.h
@@ -1541,10 +1541,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -1534,6 +1534,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -1532,10 +1532,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -1522,10 +1522,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/adafruit/ST7565/Configuration.h
+++ b/config/examples/adafruit/ST7565/Configuration.h
@@ -1524,6 +1524,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -1710,10 +1710,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -1712,6 +1712,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1652,6 +1652,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -1650,10 +1650,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1649,10 +1649,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -1651,6 +1651,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -1649,10 +1649,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -1651,6 +1651,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -1639,6 +1639,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -1637,10 +1637,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -1652,10 +1652,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -1654,6 +1654,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -1639,6 +1639,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -1637,10 +1637,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -1641,10 +1641,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -1643,6 +1643,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -1639,6 +1639,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -1637,10 +1637,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -1639,10 +1639,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -1641,6 +1641,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -1640,10 +1640,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -1642,6 +1642,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -1640,10 +1640,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -1642,6 +1642,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -1536,10 +1536,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/gCreate/gMax1.5+/Configuration.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration.h
@@ -1538,6 +1538,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -1525,10 +1525,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/makibox/Configuration.h
+++ b/config/examples/makibox/Configuration.h
@@ -1527,6 +1527,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -1519,6 +1519,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/tvrrug/Round2/Configuration.h
+++ b/config/examples/tvrrug/Round2/Configuration.h
@@ -1517,10 +1517,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -1529,6 +1529,9 @@
 
   // Moves the nozzle to the initial position
   #define NOZZLE_CLEAN_GOBACK
+
+  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  //#define NOZZLE_CLEAN_NO_Z
 #endif
 
 /**

--- a/config/examples/wt150/Configuration.h
+++ b/config/examples/wt150/Configuration.h
@@ -1527,10 +1527,10 @@
   // Middle point of circle
   #define NOZZLE_CLEAN_CIRCLE_MIDDLE NOZZLE_CLEAN_START_POINT
 
-  // Moves the nozzle to the initial position
+  // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Safety feature for side mounted purge buckets and such expected to be used on tool change
+  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 #endif
 


### PR DESCRIPTION
Allow nozzle clean to be called with limited axis. Specifically enables the use of wiper pads on purge buckets for multi tool machines where a Z movement for the wipe would mean a definitive crash.