### PR TITLE
Esp32 HAL - Dynamic ADC attenuation

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -189,15 +189,19 @@ void HAL_adc_start_conversion(uint8_t adc_pin) {
   esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
 
   // Change the attenuation level based on the new reading
+  adc_atten_t atten;
   if (mv < thresholds[ADC_ATTEN_DB_0] - 100)
-    adc1_set_attenuation(chan, ADC_ATTEN_DB_0);
+    atten = ADC_ATTEN_DB_0;
   else if (mv > thresholds[ADC_ATTEN_DB_0] - 50 && mv < thresholds[ADC_ATTEN_DB_2_5] - 100)
-    adc1_set_attenuation(chan, ADC_ATTEN_DB_2_5);
+    atten = ADC_ATTEN_DB_2_5;
   else if (mv > thresholds[ADC_ATTEN_DB_2_5] - 50 && mv < thresholds[ADC_ATTEN_DB_6] - 100)
-    adc1_set_attenuation(chan, ADC_ATTEN_DB_6);
+    atten = ADC_ATTEN_DB_6;
   else if (mv > thresholds[ADC_ATTEN_DB_6] - 50)
-    adc1_set_attenuation(chan, ADC_ATTEN_DB_11);
+    atten = ADC_ATTEN_DB_11;
+  else goto SKIP_ATTEN;
+  adc1_set_attenuation(chan, atten);
 
+  SKIP_ATTEN:
   HAL_adc_result = mv * 1023.0 / 3300.0;
 }
 

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -184,24 +184,21 @@ void HAL_adc_init() {
 }
 
 void HAL_adc_start_conversion(uint8_t adc_pin) {
-  adc1_channel_t chan = get_channel(adc_pin);
+  const adc1_channel_t chan = get_channel(adc_pin);
   uint32_t mv;
   esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
 
   // Change the attenuation level based on the new reading
   adc_atten_t atten;
   if (mv < thresholds[ADC_ATTEN_DB_0] - 100)
-    atten = ADC_ATTEN_DB_0;
+    adc1_set_attenuation(chan, ADC_ATTEN_DB_0);
   else if (mv > thresholds[ADC_ATTEN_DB_0] - 50 && mv < thresholds[ADC_ATTEN_DB_2_5] - 100)
-    atten = ADC_ATTEN_DB_2_5;
+    adc1_set_attenuation(chan, ADC_ATTEN_DB_2_5);
   else if (mv > thresholds[ADC_ATTEN_DB_2_5] - 50 && mv < thresholds[ADC_ATTEN_DB_6] - 100)
-    atten = ADC_ATTEN_DB_6;
+    adc1_set_attenuation(chan, ADC_ATTEN_DB_6);
   else if (mv > thresholds[ADC_ATTEN_DB_6] - 50)
-    atten = ADC_ATTEN_DB_11;
-  else goto SKIP_ATTEN;
-  adc1_set_attenuation(chan, atten);
+    adc1_set_attenuation(chan, ADC_ATTEN_DB_11);
 
-  SKIP_ATTEN:
   HAL_adc_result = mv * 1023.0 / 3300.0;
 }
 

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -67,7 +67,9 @@ uint16_t HAL_adc_result;
 // Private Variables
 // ------------------------
 
-esp_adc_cal_characteristics_t characteristics;
+esp_adc_cal_characteristics_t characteristics[ADC_ATTEN_MAX];
+adc_atten_t attenuations[ADC1_CHANNEL_MAX] = {};
+uint32_t thresholds[ADC_ATTEN_MAX];
 volatile int numPWMUsed = 0,
              pwmPins[MAX_PWM_PINS],
              pwmValues[MAX_PWM_PINS];
@@ -129,50 +131,75 @@ adc1_channel_t get_channel(int pin) {
   return ADC1_CHANNEL_MAX;
 }
 
+void adc1_set_attenuation(adc1_channel_t chan, adc_atten_t atten) {
+  if (attenuations[chan] != atten) {
+    adc1_config_channel_atten(chan, atten);
+    attenuations[chan] = atten;
+  }
+}
+
 void HAL_adc_init() {
   // Configure ADC
   adc1_config_width(ADC_WIDTH_12Bit);
 
   // Configure channels only if used as (re-)configuring a pin for ADC that is used elsewhere might have adverse effects
   #if HAS_TEMP_ADC_0
-    adc1_config_channel_atten(get_channel(TEMP_0_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(TEMP_0_PIN), ADC_ATTEN_11db);
   #endif
   #if HAS_TEMP_ADC_1
-    adc1_config_channel_atten(get_channel(TEMP_1_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(TEMP_1_PIN), ADC_ATTEN_11db);
   #endif
   #if HAS_TEMP_ADC_2
-    adc1_config_channel_atten(get_channel(TEMP_2_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(TEMP_2_PIN), ADC_ATTEN_11db);
   #endif
   #if HAS_TEMP_ADC_3
-    adc1_config_channel_atten(get_channel(TEMP_3_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(TEMP_3_PIN), ADC_ATTEN_11db);
   #endif
   #if HAS_TEMP_ADC_4
-    adc1_config_channel_atten(get_channel(TEMP_4_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(TEMP_4_PIN), ADC_ATTEN_11db);
   #endif
   #if HAS_TEMP_ADC_5
-    adc1_config_channel_atten(get_channel(TEMP_5_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(TEMP_5_PIN), ADC_ATTEN_11db);
   #endif
   #if HAS_HEATED_BED
-    adc1_config_channel_atten(get_channel(TEMP_BED_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(TEMP_BED_PIN), ADC_ATTEN_11db);
   #endif
   #if HAS_TEMP_CHAMBER
-    adc1_config_channel_atten(get_channel(TEMP_CHAMBER_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(TEMP_CHAMBER_PIN), ADC_ATTEN_11db);
   #endif
   #if ENABLED(FILAMENT_WIDTH_SENSOR)
-    adc1_config_channel_atten(get_channel(FILWIDTH_PIN), ADC_ATTEN_11db);
+    adc1_set_attenuation(get_channel(FILWIDTH_PIN), ADC_ATTEN_11db);
   #endif
 
   // Note that adc2 is shared with the WiFi module, which has higher priority, so the conversion may fail.
   // That's why we're not setting it up here.
 
-  // Calculate ADC characteristics i.e. gain and offset factors
-  esp_adc_cal_characterize(ADC_UNIT_1, ADC_ATTEN_DB_11, ADC_WIDTH_BIT_12, V_REF, &characteristics);
+  // Calculate ADC characteristics i.e. gain and offset factors for each attenuation level
+  for (int i = 0; i < ADC_ATTEN_MAX; i++) {
+    esp_adc_cal_characterize(ADC_UNIT_1, (adc_atten_t)i, ADC_WIDTH_BIT_12, V_REF, &characteristics[i]);
+    
+    // change attenuation 100mV below the calibrated threshold
+    thresholds[i] = esp_adc_cal_raw_to_voltage(4095, &characteristics[i]);
+  }
 }
 
 void HAL_adc_start_conversion(uint8_t adc_pin) {
+  adc1_channel_t chan = get_channel(adc_pin);
   uint32_t mv;
-  esp_adc_cal_get_voltage((adc_channel_t)get_channel(adc_pin), &characteristics, &mv);
-  HAL_adc_result = mv * 1023.0 / 3300.0;
+  esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
+
+  // Change the attenuation level based on the new reading
+  if (mv < thresholds[ADC_ATTEN_DB_0] - 100) {
+    adc1_set_attenuation(chan, ADC_ATTEN_DB_0);
+  } else if (mv > thresholds[ADC_ATTEN_DB_0] - 50 && mv < thresholds[ADC_ATTEN_DB_2_5] - 100) {
+    adc1_set_attenuation(chan, ADC_ATTEN_DB_2_5);
+  } else if (mv > thresholds[ADC_ATTEN_DB_2_5] - 50 && mv < thresholds[ADC_ATTEN_DB_6] - 100) {
+    adc1_set_attenuation(chan, ADC_ATTEN_DB_6);
+  } else if (mv > thresholds[ADC_ATTEN_DB_6] - 50){
+    adc1_set_attenuation(chan, ADC_ATTEN_DB_11);
+  }
+
+  HAL_adc_result = mv*1023.0/3300.0;
 }
 
 void analogWrite(pin_t pin, int value) {

--- a/Marlin/src/HAL/HAL_ESP32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.cpp
@@ -174,11 +174,11 @@ void HAL_adc_init() {
   // Note that adc2 is shared with the WiFi module, which has higher priority, so the conversion may fail.
   // That's why we're not setting it up here.
 
-  // Calculate ADC characteristics i.e. gain and offset factors for each attenuation level
+  // Calculate ADC characteristics (i.e., gain and offset factors for each attenuation level)
   for (int i = 0; i < ADC_ATTEN_MAX; i++) {
     esp_adc_cal_characterize(ADC_UNIT_1, (adc_atten_t)i, ADC_WIDTH_BIT_12, V_REF, &characteristics[i]);
     
-    // change attenuation 100mV below the calibrated threshold
+    // Change attenuation 100mV below the calibrated threshold
     thresholds[i] = esp_adc_cal_raw_to_voltage(4095, &characteristics[i]);
   }
 }
@@ -189,17 +189,16 @@ void HAL_adc_start_conversion(uint8_t adc_pin) {
   esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
 
   // Change the attenuation level based on the new reading
-  if (mv < thresholds[ADC_ATTEN_DB_0] - 100) {
+  if (mv < thresholds[ADC_ATTEN_DB_0] - 100)
     adc1_set_attenuation(chan, ADC_ATTEN_DB_0);
-  } else if (mv > thresholds[ADC_ATTEN_DB_0] - 50 && mv < thresholds[ADC_ATTEN_DB_2_5] - 100) {
+  else if (mv > thresholds[ADC_ATTEN_DB_0] - 50 && mv < thresholds[ADC_ATTEN_DB_2_5] - 100)
     adc1_set_attenuation(chan, ADC_ATTEN_DB_2_5);
-  } else if (mv > thresholds[ADC_ATTEN_DB_2_5] - 50 && mv < thresholds[ADC_ATTEN_DB_6] - 100) {
+  else if (mv > thresholds[ADC_ATTEN_DB_2_5] - 50 && mv < thresholds[ADC_ATTEN_DB_6] - 100)
     adc1_set_attenuation(chan, ADC_ATTEN_DB_6);
-  } else if (mv > thresholds[ADC_ATTEN_DB_6] - 50){
+  else if (mv > thresholds[ADC_ATTEN_DB_6] - 50)
     adc1_set_attenuation(chan, ADC_ATTEN_DB_11);
-  }
 
-  HAL_adc_result = mv*1023.0/3300.0;
+  HAL_adc_result = mv * 1023.0 / 3300.0;
 }
 
 void analogWrite(pin_t pin, int value) {


### PR DESCRIPTION
The ESP32 ADC operates in the range of 0V to ~1.1V (1.0V -- 1.2V). In order for this ADC to work with the full range input of 3.3V the attenuation must be configured to attenuate the input voltage below 1.1V.

In the current implementation of the HAL the ADC attenuation is always the maximum of 11dB allowing the full 3.3V range input (well almost but that's for another discussion). Using the full 111dB attenuation works but also decreases precision when the voltage is lower.

In this patch I use the ADC calibration characteristics to get the operating voltage range of each attenuation level. Using the last ADC reading the attenuation level can be changed to the nearest operating range. This allows much higher precision, which is especially relevant for higher temperatures (close to 0V).

In this code the attenuation is switched when the reading is 100mV below the nominal characteristics and 50mV above the previous attenuation. This range is used to compensate for inaccuracies when shifting range. (e.g when you change to a higher attenuation the value might be less precise and therefore change back to a higher attenuation, repeating multiple times and oscillating around two attenuations).

The 100mV and 50mV values have not been picked for any specific reason and some (better) values might be more suitable, but with this the attenuation do shift properly without oscillations.