### PR TITLE
Encoder direction: Wrangle, Revert select screen change

### DIFF
--- a/Marlin/src/lcd/menu/game/game.cpp
+++ b/Marlin/src/lcd/menu/game/game.cpp
@@ -56,7 +56,6 @@ void MarlinGame::draw_game_over() {
 void MarlinGame::init_game(const uint8_t init_state, const screenFunc_t screen) {
   score = 0;
   game_state = init_state;
-  ui.encoder_direction_normal();
   ui.goto_screen(screen);
   ui.defer_status_screen();
 }

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -130,7 +130,6 @@ void MenuItem_gcode::action(PGM_P const pgcode) { queue.inject_P(pgcode); }
  *       MenuItem_int3::action_edit(PSTR(MSG_SPEED), &feedrate_percentage, 10, 999)
  */
 void MenuItemBase::edit(strfunc_t strfunc, loadfunc_t loadfunc) {
-  ui.encoder_direction_normal();
   if (int16_t(ui.encoderPosition) < 0) ui.encoderPosition = 0;
   if (int16_t(ui.encoderPosition) > maxEditValue) ui.encoderPosition = maxEditValue;
   if (ui.should_draw())
@@ -272,6 +271,10 @@ void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, co
       drawing_screen = false;
     #endif
 
+    #if HAS_LCD_MENU
+      encoder_direction_normal();
+    #endif
+
     set_ui_selection(false);
   }
 }
@@ -367,7 +370,6 @@ void MarlinUI::completion_feedback(const bool good/*=true*/) {
     #else
       constexpr bool do_probe = true;
     #endif
-    ui.encoder_direction_normal();
     if (ui.encoderPosition) {
       const int16_t babystep_increment = int16_t(ui.encoderPosition) * (BABYSTEP_MULTIPLICATOR);
       ui.encoderPosition = 0;

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -449,7 +449,7 @@ void _lcd_draw_homing() {
 bool MarlinUI::selection; // = false
 bool MarlinUI::update_selection() {
   if (encoderPosition) {
-    selection = ((encoderDirection > 0) == int16_t(encoderPosition) > 0);
+    selection = int16_t(encoderPosition) > 0;
     encoderPosition = 0;
   }
   return selection;

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -448,7 +448,7 @@ bool ui_selection; // = false
 void set_ui_selection(const bool sel) { ui_selection = sel; }
 void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
   if (ui.encoderPosition) {
-    ui_selection = int16_t(ui.encoderPosition) > 0;
+    ui_selection = ((ui.encoderDirection > 0) == int16_t(ui.encoderPosition) > 0);
     ui.encoderPosition = 0;
   }
   const bool got_click = ui.use_click();

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -275,7 +275,7 @@ void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, co
       encoder_direction_normal();
     #endif
 
-    set_ui_selection(false);
+    set_selection(false);
   }
 }
 
@@ -446,14 +446,16 @@ void _lcd_draw_homing() {
 //
 // Selection screen presents a prompt and two options
 //
-bool ui_selection; // = false
-void set_ui_selection(const bool sel) { ui_selection = sel; }
-void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
-  if (ui.encoderPosition) {
-    ui_selection = ((ui.encoderDirection > 0) == int16_t(ui.encoderPosition) > 0);
-    ui.encoderPosition = 0;
+bool MarlinUI::selection; // = false
+bool MarlinUI::update_selection() {
+  if (encoderPosition) {
+    selection = ((encoderDirection > 0) == int16_t(encoderPosition) > 0);
+    encoderPosition = 0;
   }
-  const bool got_click = ui.use_click();
+  return selection;
+}
+void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
+  const bool ui_selection = ui.update_selection(), got_click = ui.use_click();
   if (got_click || ui.should_draw()) {
     draw_select_screen(yes, no, ui_selection, pref, string, suff);
     if (got_click) { ui_selection ? yesFunc() : noFunc(); }

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -448,7 +448,7 @@ bool ui_selection; // = false
 void set_ui_selection(const bool sel) { ui_selection = sel; }
 void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
   if (ui.encoderPosition) {
-    ui_selection = ((ENCODERBASE) > 0) == (int16_t(ui.encoderPosition) > 0);
+    ui_selection = int16_t(ui.encoderPosition) > 0;
     ui.encoderPosition = 0;
   }
   const bool got_click = ui.use_click();

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -71,7 +71,6 @@ DECLARE_MENU_EDIT_TYPE(uint32_t, long5_25,    ftostr5rj,       0.04f );   // 123
 
 typedef void (*selectFunc_t)();
 void draw_select_screen(PGM_P const yes, PGM_P const no, const bool yesno, PGM_P const pref, const char * const string, PGM_P const suff);
-void set_ui_selection(const bool sel);
 void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string=nullptr, PGM_P const suff=nullptr);
 inline void do_select_screen_yn(selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string=nullptr, PGM_P const suff=nullptr) {
   do_select_screen(PSTR(MSG_YES), PSTR(MSG_NO), yesFunc, noFunc, pref, string, suff);

--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -111,7 +111,7 @@ static inline void _lcd_level_bed_corners_homing() {
   if (all_axes_homed()) {
     bed_corner = 0;
     ui.goto_screen(menu_level_bed_corners);
-    set_ui_selection(true);
+    ui.set_selection(true);
     _lcd_goto_next_corner();
   }
 }

--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -89,7 +89,6 @@
   // Step 7: Get the Z coordinate, click goes to the next point or exits
   //
   void _lcd_level_bed_get_z() {
-    ui.encoder_direction_normal();
 
     if (ui.use_click()) {
 

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -62,7 +62,6 @@ static void lcd_factory_settings() {
   #include "../lcdprint.h"
 
   static void progress_bar_test() {
-    ui.encoder_direction_normal();
     static int8_t bar_percent = 0;
     if (ui.use_click()) {
       ui.goto_previous_screen();

--- a/Marlin/src/lcd/menu/menu_mixer.cpp
+++ b/Marlin/src/lcd/menu/menu_mixer.cpp
@@ -41,7 +41,6 @@
 
   void lcd_mixer_gradient_z_start_edit() {
     ui.defer_status_screen();
-    ui.encoder_direction_normal();
     ENCODER_RATE_MULTIPLY(true);
     if (ui.encoderPosition != 0) {
       mixer.gradient.start_z += float(int16_t(ui.encoderPosition)) * 0.1;
@@ -66,7 +65,6 @@
 
   void lcd_mixer_gradient_z_end_edit() {
     ui.defer_status_screen();
-    ui.encoder_direction_normal();
     ENCODER_RATE_MULTIPLY(true);
     if (ui.encoderPosition != 0) {
       mixer.gradient.end_z += float(int16_t(ui.encoderPosition)) * 0.1;

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -74,7 +74,6 @@ inline void manual_move_to_current(AxisEnum axis
 
 static void _lcd_move_xyz(PGM_P name, AxisEnum axis) {
   if (ui.use_click()) return ui.goto_previous_screen_no_defer();
-  ui.encoder_direction_normal();
   if (ui.encoderPosition && !ui.processing_manual_move) {
 
     // Start with no limits to movement
@@ -158,7 +157,6 @@ static void _lcd_move_e(
   #endif
 ) {
   if (ui.use_click()) return ui.goto_previous_screen_no_defer();
-  ui.encoder_direction_normal();
   if (ui.encoderPosition) {
     if (!ui.processing_manual_move) {
       const float diff = float(int16_t(ui.encoderPosition)) * move_menu_scale;

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -73,7 +73,6 @@
 
   void _lcd_babystep(const AxisEnum axis, PGM_P const msg) {
     if (ui.use_click()) return ui.goto_previous_screen_no_defer();
-    ui.encoder_direction_normal();
     if (ui.encoderPosition) {
       const int16_t steps = int16_t(ui.encoderPosition) * (BABYSTEP_MULTIPLICATOR);
       ui.encoderPosition = 0;

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -468,7 +468,6 @@ void _lcd_ubl_output_map_lcd() {
   static int16_t step_scaler = 0;
 
   if (ui.use_click()) return _lcd_ubl_map_lcd_edit_cmd();
-  ui.encoder_direction_normal();
 
   if (ui.encoderPosition) {
     step_scaler += int16_t(ui.encoderPosition);

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -392,7 +392,7 @@ bool MarlinUI::get_blink() {
         #if HAS_ENCODER_ACTION
           refresh(LCDVIEW_REDRAW_NOW);
           #if HAS_LCD_MENU
-            if (encoderDirection == -1) {     // ADC_KEYPAD forces REVERSE_MENU_DIRECTION, so this indicates menu navigation
+            if (encoderDirection == -(ENCODERBASE)) { // ADC_KEYPAD forces REVERSE_MENU_DIRECTION, so this indicates menu navigation
                    if (RRK(EN_KEYPAD_UP))     encoderPosition += ENCODER_STEPS_PER_MENU_ITEM;
               else if (RRK(EN_KEYPAD_DOWN))   encoderPosition -= ENCODER_STEPS_PER_MENU_ITEM;
               else if (RRK(EN_KEYPAD_LEFT))   { MenuItem_back::action(); quick_feedback(); }
@@ -480,7 +480,6 @@ bool MarlinUI::get_blink() {
 void MarlinUI::status_screen() {
 
   #if HAS_LCD_MENU
-    encoder_direction_normal();
     ENCODER_RATE_MULTIPLY(false);
   #endif
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -422,6 +422,11 @@ public:
     static int16_t preheat_hotend_temp[2], preheat_bed_temp[2];
     static uint8_t preheat_fan_speed[2];
 
+    // Select Screen (modal NO/YES style dialog)
+    static bool selection;
+    static void set_selection(const bool sel) { selection = sel; }
+    static bool update_selection();
+
     static void manage_manual_move();
 
     static bool lcd_clicked;


### PR DESCRIPTION
I use Reprap Smart Discount LCD 2004

This commit [https://github.com/marlinfirmware/marlin/commit/3cd9a92dcc525e97768330651c40e5dc349c9e19](https://github.com/marlinfirmware/marlin/commit/3cd9a92dcc525e97768330651c40e5dc349c9e19
), makes me cannot reverse Encoder Direction in do_select_screen.
It working good before this commit.

REVERSE_ENCODER_DIRECTION already have effect in do_select_screen.

```
ultralcd.h 


    #if ENABLED(REVERSE_ENCODER_DIRECTION)
      #define ENCODERBASE -1
    #else
      #define ENCODERBASE +1
    #endif
    #if ENABLED(REVERSE_MENU_DIRECTION)
      static int8_t encoderDirection;
      static inline void encoder_direction_normal() { encoderDirection = +(ENCODERBASE); }
      static inline void encoder_direction_menus()  { encoderDirection = -(ENCODERBASE); }
    #else
      static constexpr int8_t encoderDirection = ENCODERBASE;
      static inline void encoder_direction_normal() {}
      static inline void encoder_direction_menus()  {}
    #endif
```

```
ultralcd.cpp
      // Manage encoder rotation
      #define ENCODER_SPIN(_E1, _E2) 
        switch (lastEncoderBits) { 
          case _E1: encoderDiff += encoderDirection; 
                        break; 
          case _E2: encoderDiff -= encoderDirection; 
        }
...
          encoderPosition += (encoderDiff * encoderMultiplier) / (ENCODER_PULSES_PER_STEP);
          encoderDiff = 0;

```