### PR TITLE
Reduce Ender-5 bed size

### DIFF
--- a/config/examples/Creality/Ender-5/Configuration.h
+++ b/config/examples/Creality/Ender-5/Configuration.h
@@ -1028,8 +1028,8 @@
 // @section machine
 
 // The size of the print bed
-#define X_BED_SIZE 235
-#define Y_BED_SIZE 235
+#define X_BED_SIZE 220
+#define Y_BED_SIZE 220
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0


### PR DESCRIPTION
### Description

Reduce Ender-5 bed size to 220x220. Confirmed bed size in Simplify3D & [Cura 4.2](https://github.com/Ultimaker/Cura/blob/20c55c09cd47bdb0d3718260cce631ec661867db/resources/definitions/creality_ender5.def.json).

### Benefits

Prevents hotend from hitting frame.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/14600