### PR TITLE
FYSETC Mini 12864 for HAL_STM32

### DIFF
--- a/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
+++ b/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
@@ -40,6 +40,13 @@
     #define U8G_COM_HAL_HW_SPI_FN u8g_com_arduino_hw_spi_fn
     uint8_t u8g_com_arduino_st7920_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_ST7920_HAL_SW_SPI u8g_com_arduino_st7920_spi_fn
+  #elif defined(ARDUINO_ARCH_STM32)
+    uint8_t u8g_com_arduino_std_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+    #define U8G_COM_HAL_SW_SPI_FN u8g_com_arduino_std_sw_spi_fn    
+    uint8_t u8g_com_stm32duino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);   
+    #define U8G_COM_HAL_HW_SPI_FN u8g_com_stm32duino_hw_spi_fn
+    uint8_t u8g_com_arduino_st7920_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+    #define U8G_COM_ST7920_HAL_SW_SPI u8g_com_arduino_st7920_spi_fn    
   #else
     uint8_t u8g_com_HAL_AVR_sw_sp_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_SW_SPI_FN  u8g_com_HAL_AVR_sw_sp_fn // AVR ?

--- a/Marlin/src/pins/stm32/pins_ARMED.h
+++ b/Marlin/src/pins/stm32/pins_ARMED.h
@@ -43,19 +43,23 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN          PE0
-#define X_MAX_PIN          -1
-#define Y_MIN_PIN          PE1
-#define Y_MAX_PIN          -1
-#define Z_MIN_PIN          PE14
-#define Z_MAX_PIN          -1
+#define X_STOP_PIN         PE0
+#define Y_STOP_PIN         PE1
+#define Z_STOP_PIN         PE14
 
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-// #ifndef Z_MIN_PROBE_PIN
-//   #define Z_MIN_PROBE_PIN  PA4
-// #endif
+//#ifndef Z_MIN_PROBE_PIN
+//  #define Z_MIN_PROBE_PIN  PA4
+//#endif
+
+//
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN   PA3
+#endif
 
 //
 // Steppers
@@ -85,13 +89,12 @@
 
 #define E0_STEP_PIN        PB5
 #define E0_DIR_PIN         PB6
-#define E0_CS_PIN          PB4
-
 #ifdef ARMED_V1_1
   #define E0_ENABLE_PIN    PC12
 #else
   #define E0_ENABLE_PIN    PB3
 #endif
+#define E0_CS_PIN          PB4
 
 #ifdef ARMED_SWAP_X_E1
   #define E1_STEP_PIN      PD3
@@ -160,30 +163,25 @@
       #define RGB_LED_B_PIN PB15
     #endif
   #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define NEOPIXEL_PIN    PB13
+    #define NEOPIXEL_PIN   PB13
   #endif
 #else
-  #define LCD_PINS_RS       PE9
-  #define LCD_PINS_ENABLE   PE8
-  #define LCD_PINS_D4       PB12
-  #define LCD_PINS_D5       PB13
-  #define LCD_PINS_D6       PB14
-  #define LCD_PINS_D7       PB15
+  #define LCD_PINS_RS      PE9
+  #define LCD_PINS_ENABLE  PE8
+  #define LCD_PINS_D4      PB12
+  #define LCD_PINS_D5      PB13
+  #define LCD_PINS_D6      PB14
+  #define LCD_PINS_D7      PB15
 
   #if ENABLED(MKS_MINI_12864)
-    #define DOGLCD_CS       PB13
-    #define DOGLCD_A0       PB14
+    #define DOGLCD_CS      PB13
+    #define DOGLCD_A0      PB14
   #endif
 #endif
 
 #define BTN_EN1            PC4
 #define BTN_EN2            PC5
 #define BTN_ENC            PC3
-
-//
-// Filament runout detection
-//
-#define FIL_RUNOUT_PIN     PA3
 
 //
 // Extension pins

--- a/Marlin/src/pins/stm32/pins_ARMED.h
+++ b/Marlin/src/pins/stm32/pins_ARMED.h
@@ -137,12 +137,45 @@
 //
 #define SD_DETECT_PIN      PA15
 #define BEEPER_PIN         PC9
-#define LCD_PINS_RS        PE9
-#define LCD_PINS_ENABLE    PE8
-#define LCD_PINS_D4        PB12
-#define LCD_PINS_D5        PB13
-#define LCD_PINS_D6        PB14
-#define LCD_PINS_D7        PB15
+
+#if ENABLED(FYSETC_MINI_12864)
+  //
+  // See https://wiki.fysetc.com/Mini12864_Panel/?fbclid=IwAR1FyjuNdVOOy9_xzky3qqo_WeM5h-4gpRnnWhQr_O1Ef3h0AFnFXmCehK8
+  //
+  #define DOGLCD_A0        PE9
+  #define DOGLCD_CS        PE8
+
+  #define LCD_BACKLIGHT_PIN -1
+
+  #define LCD_RESET_PIN    PB12   // Must be high or open for LCD to operate normally.
+
+  #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
+    #ifndef RGB_LED_R_PIN
+      #define RGB_LED_R_PIN PB13
+    #endif
+    #ifndef RGB_LED_G_PIN
+      #define RGB_LED_G_PIN PB14
+    #endif
+    #ifndef RGB_LED_B_PIN
+      #define RGB_LED_B_PIN PB15
+    #endif
+  #elif ENABLED(FYSETC_MINI_12864_2_1)
+    #define NEOPIXEL_PIN    PB13
+  #endif
+#else
+  #define LCD_PINS_RS       PE9
+  #define LCD_PINS_ENABLE   PE8
+  #define LCD_PINS_D4       PB12
+  #define LCD_PINS_D5       PB13
+  #define LCD_PINS_D6       PB14
+  #define LCD_PINS_D7       PB15
+
+  #if ENABLED(MKS_MINI_12864)
+    #define DOGLCD_CS       PB13
+    #define DOGLCD_A0       PB14
+  #endif
+#endif
+
 #define BTN_EN1            PC4
 #define BTN_EN2            PC5
 #define BTN_ENC            PC3


### PR DESCRIPTION
### Description

Changes to support FYSETC_MINI_12864 on HAL_STM32 using Arduino Core STM32.

Tested and working on STM32F407VE (ARMED board).