### PR TITLE
Fix missed set of changes for G12

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -436,7 +436,7 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
 
   // Park the nozzle by moving up by z_lift and then moving to (x_pos, y_pos)
   if (!axis_unhomed_error())
-    Nozzle::park(2, park_point);
+    nozzle.park(2, park_point);
 
   #if ENABLED(DUAL_X_CARRIAGE)
     const int8_t saved_ext        = active_extruder;

--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -573,7 +573,7 @@ void MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
         COPY(resume_position, current_position);
 
         if (move_axes && all_axes_homed())
-          Nozzle::park(2, park_point /*= NOZZLE_PARK_POINT*/);
+          nozzle.park(2, park_point /*= NOZZLE_PARK_POINT*/);
 
         if (turn_off_nozzle) thermalManager.setTargetHotend(0, active_extruder);
 

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -42,27 +42,25 @@ void GcodeSuite::G12() {
   // Don't allow nozzle cleaning without homing first
   if (axis_unhomed_error()) return;
 
-  const bool seenxyz = parser.seen("XYZ"),
-             clean_x = !seenxyz || parser.boolval('X'),
-             clean_y = !seenxyz || parser.boolval('Y');
-
-  #if ENABLED(NOZZLE_CLEAN_NO_Z)
-    static constexpr bool clean_z = false;
-  #else
-    const bool clean_z = !seenxyz || parser.boolval('Z');
-  #endif
-
   const uint8_t pattern = parser.ushortval('P', 0),
                 strokes = parser.ushortval('S', NOZZLE_CLEAN_STROKES),
                 objects = parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES);
   const float radius = parser.floatval('R', NOZZLE_CLEAN_CIRCLE_RADIUS);
+
+  const bool seenxyz = parser.seen("XYZ");
+  const uint8_t cleans =  (!seenxyz || parser.boolval('X') ? _BV(X_AXIS) : 0)
+                        | (!seenxyz || parser.boolval('Y') ? _BV(Y_AXIS) : 0)
+                        #if DISABLED(NOZZLE_CLEAN_NO_Z)
+                          | (!seenxyz || parser.boolval('Z') ? _BV(Z_AXIS) : 0)
+                        #endif
+                      ;
 
   #if HAS_LEVELING
     const bool was_enabled = planner.leveling_active;
     if (clean_z) set_bed_leveling_enabled(false);
   #endif
 
-  Nozzle::clean(pattern, strokes, radius, objects, clean_x, clean_y, clean_z);
+  Nozzle::clean(pattern, strokes, radius, objects, cleans);
 
   // Re-enable bed level correction if it had been on
   #if HAS_LEVELING

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -60,7 +60,7 @@ void GcodeSuite::G12() {
     if (clean_z) set_bed_leveling_enabled(false);
   #endif
 
-  Nozzle::clean(pattern, strokes, radius, objects, cleans);
+  nozzle.clean(pattern, strokes, radius, objects, cleans);
 
   // Re-enable bed level correction if it had been on
   #if HAS_LEVELING

--- a/Marlin/src/gcode/feature/pause/G27.cpp
+++ b/Marlin/src/gcode/feature/pause/G27.cpp
@@ -35,7 +35,7 @@
 void GcodeSuite::G27() {
   // Don't allow nozzle parking without homing first
   if (axis_unhomed_error()) return;
-  Nozzle::park(parser.ushortval('P'));
+  nozzle.park(parser.ushortval('P'));
 }
 
 #endif // NOZZLE_PARK_FEATURE

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -155,20 +155,22 @@
    * @param pattern one of the available patterns
    * @param argument depends on the cleaning pattern
    */
-  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const bool clean_x, const bool clean_y, const bool clean_z) {
+  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const bool cleans) {
     point_t start = NOZZLE_CLEAN_START_POINT;
     point_t end = NOZZLE_CLEAN_END_POINT;
-    if(pattern==2) {
-      if(!clean_x || !clean_y) {
-        SERIAL_ECHOLNPGM("Warning : Clean Circle requires both X and Y");
+
+    if (pattern == 2) {
+      if (!(cleans & (_BV(X_AXIS) | _BV(Y_AXIS)))) {
+        SERIAL_ECHOLNPGM("Warning : Clean Circle requires XY");
         return;
       }
       end = NOZZLE_CLEAN_CIRCLE_MIDDLE;
     }
-
-    if (!clean_x) start.x = end.x = current_position[X_AXIS];
-    if (!clean_y) start.y = end.y = current_position[Y_AXIS];
-    if (!clean_z) start.z = end.z = current_position[Z_AXIS];
+    else {
+      if (!TEST(cleans, X_AXIS)) start.x = end.x = current_position[X_AXIS];
+      if (!TEST(cleans, Y_AXIS)) start.y = end.y = current_position[Y_AXIS];
+    }
+    if (!TEST(cleans, Z_AXIS)) start.z = end.z = current_position[Z_AXIS];
 
     switch (pattern) {
       case 1:

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -26,6 +26,8 @@
 
 #include "nozzle.h"
 
+Nozzle nozzle;
+
 #include "../Marlin.h"
 #include "../module/motion.h"
 #include "point_t.h"

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -158,21 +158,29 @@
   void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const bool clean_x, const bool clean_y, const bool clean_z) {
     point_t start = NOZZLE_CLEAN_START_POINT;
     point_t end = NOZZLE_CLEAN_END_POINT;
+    if(pattern==2) {
+      if(!clean_x || !clean_y) {
+        SERIAL_ECHOLNPGM("Warning : Clean Circle requires both X and Y");
+        return;
+      }
+      end = NOZZLE_CLEAN_CIRCLE_MIDDLE;
+    }
+
     if (!clean_x) start.x = end.x = current_position[X_AXIS];
     if (!clean_y) start.y = end.y = current_position[Y_AXIS];
     if (!clean_z) start.z = end.z = current_position[Z_AXIS];
 
     switch (pattern) {
       case 1:
-        zigzag(NOZZLE_CLEAN_START_POINT, NOZZLE_CLEAN_END_POINT, strokes, objects);
+        zigzag(start, end, strokes, objects);
         break;
 
       case 2:
-        circle(NOZZLE_CLEAN_START_POINT, NOZZLE_CLEAN_CIRCLE_MIDDLE, strokes, radius);
+        circle(start, end, strokes, radius);
         break;
 
       default:
-        stroke(NOZZLE_CLEAN_START_POINT, NOZZLE_CLEAN_END_POINT, strokes);
+        stroke(start, end, strokes);
     }
   }
 

--- a/Marlin/src/libs/nozzle.h
+++ b/Marlin/src/libs/nozzle.h
@@ -78,7 +78,7 @@ class Nozzle {
      * @param pattern one of the available patterns
      * @param argument depends on the cleaning pattern
      */
-    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const bool clean_x, const bool clean_y, const bool clean_z) _Os;
+    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const uint8_t cleans) _Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 

--- a/Marlin/src/libs/nozzle.h
+++ b/Marlin/src/libs/nozzle.h
@@ -88,3 +88,5 @@ class Nozzle {
 
   #endif
 };
+
+extern Nozzle nozzle;


### PR DESCRIPTION
Usage of a couple variables was missed when I moved things to a branch to open a PR. Also added an error check for a circle pattern if called without both X and Y since it will move Y regardless prevent erroneous commands.

See #14641 