### PR TITLE
Print progress enhancements

### DIFF
--- a/Marlin/src/gcode/lcd/M117.cpp
+++ b/Marlin/src/gcode/lcd/M117.cpp
@@ -27,7 +27,8 @@
  * M117: Set LCD Status Message
  */
 void GcodeSuite::M117() {
-
-  ui.set_status(parser.string_arg);
-
+  if(strlen(parser.string_arg))
+    ui.set_status(parser.string_arg);
+  else
+    ui.reset_status();
 }

--- a/Marlin/src/gcode/lcd/M117.cpp
+++ b/Marlin/src/gcode/lcd/M117.cpp
@@ -27,8 +27,10 @@
  * M117: Set LCD Status Message
  */
 void GcodeSuite::M117() {
-  if(strlen(parser.string_arg))
-    ui.set_status(parser.string_arg);
+
+  if (parser.string_arg && parser.string_arg[0])
+    ui.set_status(parser.string_arg)
   else
     ui.reset_status();
+
 }

--- a/Marlin/src/gcode/lcd/M73.cpp
+++ b/Marlin/src/gcode/lcd/M73.cpp
@@ -22,7 +22,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(LCD_SET_PROGRESS_MANUALLY) && EITHER(EXTENSIBLE_UI, ULTRA_LCD)
+#if ENABLED(LCD_SET_PROGRESS_MANUALLY)
 
 #include "../gcode.h"
 #include "../../lcd/ultralcd.h"
@@ -42,4 +42,4 @@ void GcodeSuite::M73() {
     ui.set_progress(parser.value_byte());
 }
 
-#endif // LCD_SET_PROGRESS_MANUALLY && (EXTENSIBLE_UI || ULTRA_LCD)
+#endif // LCD_SET_PROGRESS_MANUALLY

--- a/Marlin/src/gcode/sdcard/M23.cpp
+++ b/Marlin/src/gcode/sdcard/M23.cpp
@@ -26,6 +26,7 @@
 
 #include "../gcode.h"
 #include "../../sd/cardreader.h"
+#include "../../lcd/ultralcd.h"
 
 /**
  * M23: Open a file
@@ -36,6 +37,10 @@ void GcodeSuite::M23() {
   // Simplify3D includes the size, so zero out all spaces (#7227)
   for (char *fn = parser.string_arg; *fn; ++fn) if (*fn == ' ') *fn = '\0';
   card.openFile(parser.string_arg, true);
+
+  #if EITHER(ULTRA_LCD, EXTENSIBLE_UI) && ENABLED(LCD_SET_PROGRESS_MANUALLY)
+    ui.progress_bar_percent = 0;
+  #endif
 }
 
 #endif // SDSUPPORT

--- a/Marlin/src/gcode/sdcard/M23.cpp
+++ b/Marlin/src/gcode/sdcard/M23.cpp
@@ -38,8 +38,8 @@ void GcodeSuite::M23() {
   for (char *fn = parser.string_arg; *fn; ++fn) if (*fn == ' ') *fn = '\0';
   card.openFile(parser.string_arg, true);
 
-  #if EITHER(ULTRA_LCD, EXTENSIBLE_UI) && ENABLED(LCD_SET_PROGRESS_MANUALLY)
-    ui.progress_bar_percent = 0;
+  #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
+    ui.set_progress(0);
   #endif
 }
 

--- a/Marlin/src/gcode/temperature/M104_M109.cpp
+++ b/Marlin/src/gcode/temperature/M104_M109.cpp
@@ -125,7 +125,7 @@ void GcodeSuite::M109() {
         print_job_timer.start();
     #endif
 
-    #if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
+    #if HAS_DISPLAY
       if (thermalManager.isHeatingHotend(target_extruder) || !no_wait_for_cooling)
         thermalManager.set_heating_message(target_extruder);
     #endif

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -204,6 +204,10 @@ void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, co
       lcd_z_fade_height = planner.z_fade_height;
     #endif
 
+    #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
+      progress_reset();
+    #endif
+
     #if BOTH(DOUBLECLICK_FOR_Z_BABYSTEPPING, BABYSTEPPING)
       static millis_t doubleclick_expire_ms = 0;
       // Going to menu_main from status screen? Remember first click time.

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1522,13 +1522,15 @@ void MarlinUI::update() {
     uint8_t MarlinUI::get_progress() {
       #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
         uint8_t &progress = progress_bar_percent;
+        #define _PLIMIT(P) ((P) & 0x7F)
       #else
+        #define _PLIMIT(P) P
         uint8_t progress = 0;
       #endif
       #if ENABLED(SDSUPPORT)
         if (IS_SD_PRINTING()) progress = card.percentDone();
       #endif
-      return progress;
+      return _PLIMIT(progress);
     }
   #endif
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -298,6 +298,8 @@ public:
       #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
         static uint8_t progress_bar_percent;
         static void set_progress(const uint8_t progress) { progress_bar_percent = _MIN(progress, 100); }
+        static void set_progress_done() { set_progress(0x80 + 100); }
+        static bool progress_reset() { if (progress_bar_percent & 0x80) set_progress(0); }
       #endif
       static uint8_t get_progress();
     #else

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -51,7 +51,7 @@
   #include "../feature/bltouch.h"
 #endif
 
-#if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
+#if HAS_DISPLAY
   #include "../lcd/ultralcd.h"
 #endif
 
@@ -1044,7 +1044,7 @@ bool axis_unhomed_error(const bool x/*=true*/, const bool y/*=true*/, const bool
     if (zz) SERIAL_CHAR('Z');
     SERIAL_ECHOLNPGM(" " MSG_FIRST);
 
-    #if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
+    #if HAS_DISPLAY
       ui.status_printf_P(0, PSTR(MSG_HOME " %s%s%s " MSG_FIRST), xx ? MSG_X : "", yy ? MSG_Y : "", zz ? MSG_Z : "");
     #endif
     return true;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2926,7 +2926,7 @@ void Temperature::isr() {
 
   #endif // AUTO_REPORT_TEMPERATURES
 
-  #if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
+  #if HAS_DISPLAY
     void Temperature::set_heating_message(const uint8_t e) {
       const bool heating = isHeatingHotend(e);
       #if HOTENDS > 1

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -785,7 +785,7 @@ class Temperature {
       #endif
     #endif
 
-    #if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
+    #if HAS_DISPLAY
       static void set_heating_message(const uint8_t e);
     #endif
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -982,7 +982,7 @@ void tool_change(const uint8_t tmp_extruder, bool no_move/*=false*/) {
           singlenozzle_temp[active_extruder] = thermalManager.temp_hotend[0].target;
           if (singlenozzle_temp[tmp_extruder] && singlenozzle_temp[tmp_extruder] != singlenozzle_temp[active_extruder]) {
             thermalManager.setTargetHotend(singlenozzle_temp[tmp_extruder], 0);
-            #if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
+            #if HAS_DISPLAY
               thermalManager.set_heating_message(0);
             #endif
             (void)thermalManager.wait_for_hotend(0, false);  // Wait for heating or cooling

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1015,7 +1015,7 @@ void CardReader::printingHasFinished() {
     #endif
 
     #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
-      ui.progress_bar_percent = 100;
+      ui.set_progress(100);
     #endif
 
     #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1015,7 +1015,7 @@ void CardReader::printingHasFinished() {
     #endif
 
     #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
-      ui.set_progress(100);
+      ui.set_progress_done();
     #endif
 
     #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1014,7 +1014,7 @@ void CardReader::printingHasFinished() {
       presort();
     #endif
 
-    #if EITHER(ULTRA_LCD, EXTENSIBLE_UI) && ENABLED(LCD_SET_PROGRESS_MANUALLY)
+    #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
       ui.progress_bar_percent = 100;
     #endif
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1008,7 +1008,7 @@ void CardReader::printingHasFinished() {
     #endif
 
     print_job_timer.stop();
-    if (print_job_timer.duration() > 60) queue.inject_P(PSTR("M31"));
+    queue.enqueue_now_P(print_job_timer.duration() > 60 ? PSTR("M31") : PSTR("M117"));
 
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();
@@ -1017,8 +1017,6 @@ void CardReader::printingHasFinished() {
     #if EITHER(ULTRA_LCD, EXTENSIBLE_UI) && ENABLED(LCD_SET_PROGRESS_MANUALLY)
       ui.progress_bar_percent = 100;
     #endif
-
-    ui.reset_status();
 
     #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
       ui.reselect_last_file();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1015,7 +1015,7 @@ void CardReader::printingHasFinished() {
     #endif
 
     #if EITHER(ULTRA_LCD, EXTENSIBLE_UI) && ENABLED(LCD_SET_PROGRESS_MANUALLY)
-      ui.progress_bar_percent = 0;
+      ui.progress_bar_percent = 100;
     #endif
 
     ui.reset_status();

--- a/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
+++ b/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
@@ -31,7 +31,7 @@
 
 #include "Sd2Card_FlashDrive.h"
 
-#if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
+#if HAS_DISPLAY
   #include "../../lcd/ultralcd.h"
 #endif
 
@@ -63,7 +63,7 @@ void Sd2Card::idle() {
       SERIAL_ECHOPGM("Starting USB host...");
       if (!usb.start()) {
         SERIAL_ECHOPGM(" Failed. Retrying in 2s.");
-        #if EITHER(ULTRA_LCD, EXTENSIBLE_UI)
+        #if HAS_DISPLAY
           LCD_MESSAGEPGM("USB start failed");
         #endif
         state = USB_HOST_DELAY_INIT;


### PR DESCRIPTION
Implement changes as discussed in #14646

- The progress bar will now stay at 100% following the end of the print, so the user can walk up to their printer and see their last print is done.
- The print time "XXd XXm" or "Printer ready" is enqueued so it shows up at the actual end of the print and isn't overwritten by subsequent M117 commands