### PR TITLE
Fix HOST_PROMPT_SUPPORT include in ExtUI API

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -98,6 +98,10 @@
   #include "../../feature/babystep.h"
 #endif
 
+#if ENABLED(HOST_PROMPT_SUPPORT)
+  #include "../../feature/host_actions.h"
+#endif
+
 inline float clamp(const float value, const float minimum, const float maximum) {
   return _MAX(_MIN(value, maximum), minimum);
 }


### PR DESCRIPTION
Missing include file for host_prompt_support 

line 784
```
  #if ENABLED(HOST_PROMPT_SUPPORT)
    void setHostResponse(const uint8_t response) { host_response_handler(response); }
  #endif
```