### PR TITLE
Make encoder direction in start print dialog box consistent with menus

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -452,7 +452,11 @@ bool ui_selection; // = false
 void set_ui_selection(const bool sel) { ui_selection = sel; }
 void do_select_screen(PGM_P const yes, PGM_P const no, selectFunc_t yesFunc, selectFunc_t noFunc, PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
   if (ui.encoderPosition) {
-    ui_selection = ((ENCODERBASE) > 0) == (int16_t(ui.encoderPosition) > 0);
+    #if ENABLED(REVERSE_ENCODER_DIRECTION)
+      ui_selection = ((ENCODERBASE) > 0) != (int16_t(ui.encoderPosition) > 0);
+    #else
+      ui_selection = ((ENCODERBASE) > 0) == (int16_t(ui.encoderPosition) > 0);
+    #endif
     ui.encoderPosition = 0;
   }
   const bool got_click = ui.use_click();


### PR DESCRIPTION
Fixed it so the direction the encoder is turned to select the next choice in the "Start print" dialog box is consistent with the direction the encoder is turned for moving down the menu for all combinations of REVERSE_ENCODER_DIRECTION and REVERSE_MENU_DIRECTION

Before this PR, the direction was inconsistent when REVERSE_ENCODER_DIRECTION was true.