### PR TITLE
Fix compile warning

### DIFF
--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -299,7 +299,7 @@ public:
         static uint8_t progress_bar_percent;
         static void set_progress(const uint8_t progress) { progress_bar_percent = _MIN(progress, 100); }
         static void set_progress_done() { set_progress(0x80 + 100); }
-        static bool progress_reset() { if (progress_bar_percent & 0x80) set_progress(0); }
+        static void progress_reset() { if (progress_bar_percent & 0x80) set_progress(0); }
       #endif
       static uint8_t get_progress();
     #else


### PR DESCRIPTION
bool function without a return. No need for it to be bool.