### PR TITLE
Update Travis to bionic, remove caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-dist: xenial
-sudo: require
+dist: bionic
+sudo: false
 
 language: python
 python:
@@ -7,13 +7,6 @@ python:
 
 notifications:
   email: false
-
-# Cache PlatformIO packages using Travis CI container-based infrastructure
-sudo: false
-cache:
-  pip: true
-  directories:
-  - "~/.platformio"
 
 env:
   - TEST_PLATFORM="megaatmega2560"
@@ -26,15 +19,7 @@ env:
   - TEST_PLATFORM="esp32"
   - TEST_PLATFORM="alfawise_U20"
 
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-7
-
 before_install:
-  - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 90
   #
   # Fetch the tag information for the current branch
   - git fetch origin --tags


### PR DESCRIPTION
Update Travis to use Ubuntu Bionic Beaver (LTS), g++-7 is default so no extra packages are required.

Caching is turned off, we are creating 1-2GB of cache per PR and it does not improve the test times, last time I cleaned up there was over 300GB of cache. 