### PR TITLE
Fix encoder directions, followup to PR#14628

### DIFF
--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -1024,6 +1024,8 @@ void MarlinUI::draw_status_screen() {
   }
 
   void draw_edit_screen(PGM_P const pstr, const char* const value/*=nullptr*/) {
+    ui.encoder_direction_normal();
+
     lcd_moveto(0, 1);
     lcd_put_u8str_P(pstr);
     if (value != nullptr) {

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -383,11 +383,10 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
   }
 
   void draw_edit_screen(PGM_P const pstr, const char* const value/*=nullptr*/) {
-    const uint8_t labellen = utf8_strlen_P(pstr), vallen = utf8_strlen(value);
-
-    bool extra_row = labellen > LCD_WIDTH - 2 - vallen;
-
     ui.encoder_direction_normal();
+
+    const uint8_t labellen = utf8_strlen_P(pstr), vallen = utf8_strlen(value);
+    bool extra_row = labellen > LCD_WIDTH - 2 - vallen;
 
     #if ENABLED(USE_BIG_EDIT_FONT)
       // Use the menu font if the label won't fit on a single line

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -387,6 +387,8 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
     bool extra_row = labellen > LCD_WIDTH - 2 - vallen;
 
+    ui.encoder_direction_normal();
+
     #if ENABLED(USE_BIG_EDIT_FONT)
       // Use the menu font if the label won't fit on a single line
       constexpr uint8_t lcd_edit_width = (LCD_PIXEL_WIDTH) / (EDIT_FONT_WIDTH);


### PR DESCRIPTION
Although PR #14628 was a step in the right direction, it left much of the encoder directions in a state of inconsistency. Here are the encoder directions after PR#14628, for various values of `REVERSE_ENCODER_DIRECTION` (RED) and `REVERSE_MENU_DIRECTION` (RMD):

| RED | RMD | FR+ | Temp+ | Menu Down | Sel Right | 
|-----|-----|-----|-----|-----|-----|
| false | false | ~CW~ | CCW | CCW | CCW | ~CW~ | CCW |
| false | true |  ~CW~ | ~CW~ | CW  |  ~CCW~ | 
| true  | false | CW | CW | CW | CW | 
| true | true |  CW | ~CCW~ | CCW | ~CW~ | 

The directions with the strike-through are incorrect and was caused by not properly calling `encoder_direction_menus()` and `encoder_direction_normal()`  in the right places. This PR corrects this problem and was verified to lead to the following table:

| RED | RMD | FR+ | Temp+ | Menu Down | Sel Right | 
|-----|-----|-----|-----|-----|-----|
| false | false | CCW | CCW | CCW | CCW | 
| false | true |  CCW | CCW | CW  |  CW | 
| true  | false | CW | CW | CW | CW | 
| true | true | CW | CW | CCW | CCW | 

Legend:

- RED - REVERSE_ENCODER_DIRECTION
- RMD - REVERSE_MENU_DIRECTION
- FR+ - Direction required to turn encoder to increase feedrate on status screen
- Temp+ - Direction required to turn encoder to increase nozzle temperature in menu
- Menu Down - Direction required to turn encoder to move down the menu
- Sel Right - Direction required to change from 'Cancel' to 'Print' at the start of the print
- CCW - Counter-clockwise on a Lulzbot Mini 2, could be CW on some encoders.
- CW - Clockwise on a Lulzbot Mini 2, could be CCW on some encoders.

Personally, I think `REVERSE_MENU_DIRECTION` is not worth the extra complexity in the code, but this PR at least ensures that it works as designed.

**Note:** I made a change in "ultralcd_HD44780.cpp" but this has not been tested.