### PR TITLE
STM32F1 SPI1 bugfix

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
@@ -204,7 +204,7 @@ void HAL_init(void) {
   #if PIN_EXISTS(USB_CONNECT)
     OUT_WRITE(USB_CONNECT_PIN, !USB_CONNECT_INVERTING);  // USB clear connection
     delay(1000);                                         // Give OS time to notice
-    OUT_WRITE(USB_CONNECT_PIN, USB_CONNECT_INVERTING);;
+    OUT_WRITE(USB_CONNECT_PIN, USB_CONNECT_INVERTING);
   #endif
 }
 

--- a/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
@@ -201,6 +201,11 @@ void HAL_init(void) {
   #if PIN_EXISTS(LED)
     OUT_WRITE(LED_PIN, LOW);
   #endif
+  #if PIN_EXISTS(USB_CONNECT)
+    OUT_WRITE(USB_CONNECT_PIN, !USB_CONNECT_INVERTING);  // USB clear connection
+    delay(1000);                                         // Give OS time to notice
+    OUT_WRITE(USB_CONNECT_PIN, USB_CONNECT_INVERTING);;
+  #endif
 }
 
 /* VGPV Done with defines

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
@@ -84,7 +84,7 @@ void spiInit(uint8_t spiRate) {
    * STM32F1 has 3 SPI ports, SPI1 in APB1, SPI2/SPI3 in APB2
    * so the minimum prescale of SPI1 is DIV4, SPI2/SPI3 is DIV2
   */
-  #if SPI_DEVICE ==1
+  #if SPI_DEVICE == 1
     #define SPI_CLOCK_MAX SPI_CLOCK_DIV4
   #else
     #define SPI_CLOCK_MAX SPI_CLOCK_DIV2

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
@@ -79,15 +79,25 @@ void spiBegin() {
  * @details
  */
 void spiInit(uint8_t spiRate) {
+  /**
+   * STM32F1 APB1 = 72MHz, APB2 = 36MHz, max SPI speed of this MCU if 18Mhz 
+   * STM32F1 has 3 SPI ports, SPI1 in APB1, SPI2/SPI3 in APB2
+   * so the minimum prescale of SPI1 is DIV4, SPI2/SPI3 is DIV2
+  */
+  #if SPI_DEVICE ==1
+    #define SPI_CLOCK_MAX SPI_CLOCK_DIV4
+  #else
+    #define SPI_CLOCK_MAX SPI_CLOCK_DIV2
+  #endif
   uint8_t  clock;
   switch (spiRate) {
-    case SPI_FULL_SPEED:    clock = SPI_CLOCK_DIV2 ; break;
+    case SPI_FULL_SPEED:    clock = SPI_CLOCK_MAX ;  break;
     case SPI_HALF_SPEED:    clock = SPI_CLOCK_DIV4 ; break;
     case SPI_QUARTER_SPEED: clock = SPI_CLOCK_DIV8 ; break;
     case SPI_EIGHTH_SPEED:  clock = SPI_CLOCK_DIV16; break;
     case SPI_SPEED_5:       clock = SPI_CLOCK_DIV32; break;
     case SPI_SPEED_6:       clock = SPI_CLOCK_DIV64; break;
-    default:                clock = SPI_CLOCK_DIV2; // Default from the SPI library
+    default:                clock = SPI_CLOCK_MAX;  // Default from the SPI library
   }
   SPI.setModule(SPI_DEVICE);
   SPI.begin();

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
@@ -97,7 +97,7 @@ void spiInit(uint8_t spiRate) {
     case SPI_EIGHTH_SPEED:  clock = SPI_CLOCK_DIV16; break;
     case SPI_SPEED_5:       clock = SPI_CLOCK_DIV32; break;
     case SPI_SPEED_6:       clock = SPI_CLOCK_DIV64; break;
-    default:                clock = SPI_CLOCK_MAX;  // Default from the SPI library
+    default:                clock = SPI_CLOCK_DIV2;  // Default from the SPI library
   }
   SPI.setModule(SPI_DEVICE);
   SPI.begin();

--- a/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL_spi_STM32F1.cpp
@@ -83,7 +83,7 @@ void spiInit(uint8_t spiRate) {
    * STM32F1 APB1 = 72MHz, APB2 = 36MHz, max SPI speed of this MCU if 18Mhz 
    * STM32F1 has 3 SPI ports, SPI1 in APB1, SPI2/SPI3 in APB2
    * so the minimum prescale of SPI1 is DIV4, SPI2/SPI3 is DIV2
-  */
+   */
   #if SPI_DEVICE == 1
     #define SPI_CLOCK_MAX SPI_CLOCK_DIV4
   #else

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_E3_DIP.h
@@ -148,7 +148,7 @@
 //
 // USB connect control
 //
-#define USB_CONNECT        PC13
+#define USB_CONNECT_PIN    PC13
 #define USB_CONNECT_INVERTING false
 
 #define SD_DETECT_PIN      PC4

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_E3.h
@@ -19,6 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
 #ifndef TARGET_STM32F1
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
@@ -102,7 +103,7 @@
 //
 // USB connect control
 //
-#define USB_CONNECT        PC13
+#define USB_CONNECT_PIN    PC13
 #define USB_CONNECT_INVERTING false
 
 #define SD_DETECT_PIN      PC4


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
1. add USB Connect Pin control，USB slave needs to connect a pull-up 1.5k resistor to VCC in D + to tell USB host it's own device type, we use a P-MOS to control whether the 1.5k is pulled up or not, if without this, when Marlin restart up, the PC will not recognise the port automatically,  and only re-plug the USB wire to recognise again.
2. fix STM32F1 SPI1 bug,   
    STM32F1 APB1 = 72MHz, APB2 = 36MHz, max SPI speed of this MCU if 18Mhz 
    STM32F1 has 3 SPI ports, SPI1 in APB1, SPI2/SPI3 in APB2
    so the minimum prescale of SPI1 is DIV4, SPI2/SPI3 is DIV2
If SPI1 is used and the prescale is DIV2,  now SPI1 is over-frequency statue,  "SD read error" will appear after sometimes print
### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
