### PR TITLE
Fix extraneous redefine of vsnprintf_P in Marduino.h

### DIFF
--- a/Marlin/src/HAL/shared/Marduino.h
+++ b/Marlin/src/HAL/shared/Marduino.h
@@ -41,6 +41,10 @@
 #undef sq
 #define sq(x) ((x)*(x))
 
+#ifndef vsnprintf_P
+  #define vsnprintf_P vsnprintf
+#endif
+
 #ifndef SBI
   #define SBI(A,B) (A |= (1 << (B)))
 #endif

--- a/Marlin/src/HAL/shared/Marduino.h
+++ b/Marlin/src/HAL/shared/Marduino.h
@@ -29,7 +29,6 @@
 #undef M_PI           // Redefined by all
 #undef _BV            // Redefined by some
 #undef sq             // Redefined by teensy3/wiring.h
-#undef vsnprintf_P    // Defined by avr/pgmspace.h in some platforms
 
 #include <Arduino.h>  // NOTE: If included earlier then this line is a NOOP
 
@@ -41,10 +40,6 @@
 
 #undef sq
 #define sq(x) ((x)*(x))
-
-#ifndef vsnprintf_P
-  #define vsnprintf_P vsnprintf
-#endif
 
 #ifndef SBI
   #define SBI(A,B) (A |= (1 << (B)))


### PR DESCRIPTION
There was a change in commit cf9ac4c847 that caused the machine to lock up while executing GCODE via `MENU_ITEM(gcode, _UxGT(...), PSTR(...));`

Our FW contains the following code:

```
    #define LULZBOT_XLEVEL_POS "G0 X150 F9999\n"

    #define LULZBOT_MENU_AXIS_LEVELING_COMMANDS \
        "M117 Leveling X Axis\n" /* Set LCD status */ \
        LULZBOT_XLEVEL_POS       /* Center axis */ \
        "G28 Z0\n"               /* Home Axis */ \
        "M117 Leveling done.\n"  /* Set LCD status */

    #define LULZBOT_CALIBRATION_SCRIPT \
        "M117 Starting Auto-Calibration\n"   /* Status message */ \
        "T0\n"                               /* Switch to first nozzle */ \
        "M218 T1 X43 Y0 Z0\n"                /* Restore default nozzle offset */ \
        "G28\n"                              /* Auto-Home */ \
        LULZBOT_MENU_AXIS_LEVELING_COMMANDS  /* Level X-Axis */ \
        "G12\n"                              /* Wipe the Nozzles */ \
        "M117 Calibrating...\n"              /* Status message */ \
        "G425\n"                             /* Calibrate Nozzles */ \
        "M500\n"                             /* Save settings */ \
        "M117 Calibration data saved"        /* Status message */

MENU_ITEM(gcode, _UxGT("Auto calibrate"), PSTR(LULZBOT_CALIBRATION_SCRIPT));
```

Prior to commit cf9ac4c847, this would work fine. Following the commit, it would crash the machine. I managed to narrow it down to the two changes which this PR reverts.

I do not know if there is a better way to fix this regression, but I am posting this to demonstrate a possible fix for the issue. Regardless, it seems like it would be an error to redefine 'vsnprintf_P' as 'vsnprintf'
