### PR TITLE
Include configs in serial.h

### DIFF
--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include "../HAL/HAL.h"
+#include "../inc/MarlinConfig.h"
 
 /**
  * Define debug bit-masks


### PR DESCRIPTION
`HAL.h` needs configuration to be defined otherwise will define improper things. It doesn't affect AVR but in AGCM4 will create problem in serial