### PR TITLE
MKS Robin Lite/Lite2 Board Support

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -266,7 +266,7 @@
 #define BOARD_FYSETC_AIO_II           4012  // FYSETC AIO_II
 #define BOARD_FYSETC_CHEETAH          4013  // FYSETC Cheetah
 #define BOARD_LONGER3D_LK             4014  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
-#define BOARD_MKS_ROBIN_LITE          4015  // MKS Robin Lite/Lite2 (STM32F103RCT6)
+#define BOARD_MKS_ROBIN_LITE          4016  // MKS Robin Lite/Lite2 (STM32F103RCT6)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -266,6 +266,7 @@
 #define BOARD_FYSETC_AIO_II           4012  // FYSETC AIO_II
 #define BOARD_FYSETC_CHEETAH          4013  // FYSETC Cheetah
 #define BOARD_LONGER3D_LK             4014  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
+#define BOARD_MKS_ROBIN_LITE          4015  // MKS Robin Lite/Lite2 (STM32F103RCT6)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -259,14 +259,14 @@
 #define BOARD_MKS_ROBIN               4005  // MKS Robin (STM32F103ZET6)
 #define BOARD_MKS_ROBIN_MINI          4006  // MKS Robin Mini (STM32F103VET6)
 #define BOARD_MKS_ROBIN_NANO          4007  // MKS Robin Nano (STM32F103VET6)
-#define BOARD_BIGTREE_SKR_MINI_V1_1   4008  // BigTreeTech SKR Mini v1.1 (STM32F103RC)
-#define BOARD_BIGTREE_SKR_MINI_E3     4009  // BigTreeTech SKR Mini E3 (STM32F103RC)
-#define BOARD_BIGTREE_SKR_E3_DIP      4010  // BigTreeTech SKR E3 DIP V1.0 (STM32F103RC)
-#define BOARD_JGAURORA_A5S_A1         4011  // JGAurora A5S A1 (STM32F103ZET6)
-#define BOARD_FYSETC_AIO_II           4012  // FYSETC AIO_II
-#define BOARD_FYSETC_CHEETAH          4013  // FYSETC Cheetah
-#define BOARD_LONGER3D_LK             4014  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
-#define BOARD_MKS_ROBIN_LITE          4016  // MKS Robin Lite/Lite2 (STM32F103RCT6)
+#define BOARD_MKS_ROBIN_LITE          4008  // MKS Robin Lite/Lite2 (STM32F103RCT6)
+#define BOARD_BIGTREE_SKR_MINI_V1_1   4009  // BigTreeTech SKR Mini v1.1 (STM32F103RC)
+#define BOARD_BIGTREE_SKR_MINI_E3     4010  // BigTreeTech SKR Mini E3 (STM32F103RC)
+#define BOARD_BIGTREE_SKR_E3_DIP      4011  // BigTreeTech SKR E3 DIP V1.0 (STM32F103RC)
+#define BOARD_JGAURORA_A5S_A1         4012  // JGAurora A5S A1 (STM32F103ZET6)
+#define BOARD_FYSETC_AIO_II           4013  // FYSETC AIO_II
+#define BOARD_FYSETC_CHEETAH          4014  // FYSETC Cheetah
+#define BOARD_LONGER3D_LK             4015  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -468,6 +468,8 @@
   #include "stm32/pins_FYSETC_AIO_II.h"         // STM32F1                                env:fysetc_STM32F1
 #elif MB(FYSETC_CHEETAH)
   #include "stm32/pins_FYSETC_CHEETAH.h"        // STM32F1                                env:fysetc_STM32F1
+#elif MB(MKS_ROBIN_LITE)
+  #include "stm32/pins_MKS_ROBIN_LITE.h"        // STM32F1                                env:mks_robin_lite
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -462,14 +462,14 @@
   #include "stm32/pins_MKS_ROBIN_MINI.h"        // STM32F1                                env:mks_robin_mini
 #elif MB(MKS_ROBIN_NANO)
   #include "stm32/pins_MKS_ROBIN_NANO.h"        // STM32F1                                env:mks_robin_nano
+#elif MB(MKS_ROBIN_LITE)
+  #include "stm32/pins_MKS_ROBIN_LITE.h"        // STM32F1                                env:mks_robin_lite
 #elif MB(JGAURORA_A5S_A1)
   #include "stm32/pins_JGAURORA_A5S_A1.h"       // STM32F1                                env:JGAURORA_A5S_A1
 #elif MB(FYSETC_AIO_II)
   #include "stm32/pins_FYSETC_AIO_II.h"         // STM32F1                                env:fysetc_STM32F1
 #elif MB(FYSETC_CHEETAH)
   #include "stm32/pins_FYSETC_CHEETAH.h"        // STM32F1                                env:fysetc_STM32F1
-#elif MB(MKS_ROBIN_LITE)
-  #include "stm32/pins_MKS_ROBIN_LITE.h"        // STM32F1                                env:mks_robin_lite
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_LITE.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_LITE.h
@@ -40,10 +40,8 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN          PC13
-#define X_MAX_PIN          PC13
-#define Y_MIN_PIN          PC0
-#define Y_MAX_PIN          PC0
+#define X_STOP_PIN         PC13
+#define Y_STOP_PIN         PC0
 #define Z_MIN_PIN          PC12
 #define Z_MAX_PIN          PB9
 

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_LITE.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_LITE.h
@@ -1,0 +1,145 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#ifndef __STM32F1__
+  #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
+#endif
+
+#if HOTENDS > 1 || E_STEPPERS > 1
+  #error "MKS Robin Lite supports up to 1 hotends / E-steppers. Comment out this line to continue."
+#endif
+
+#ifndef BOARD_NAME
+  #define BOARD_NAME "MKS Robin Lite"
+#endif
+#define BOARD_WEBSITE_URL "github.com/makerbase-mks"
+
+//#define DISABLE_DEBUG
+#define DISABLE_JTAG
+#define ENABLE_SPI2
+//
+// Limit Switches
+//
+#define X_MIN_PIN          PC13
+#define X_MAX_PIN          PC13
+#define Y_MIN_PIN          PC0
+#define Y_MAX_PIN          PC0
+#define Z_MIN_PIN          PC12
+#define Z_MAX_PIN          PB9
+
+//
+// Steppers
+//
+
+#define X_STEP_PIN         PC6
+#define X_DIR_PIN          PB12
+#define X_ENABLE_PIN       PB10
+
+#define Y_STEP_PIN         PB11
+#define Y_DIR_PIN          PB2
+#define Y_ENABLE_PIN       PB10
+
+#define Z_STEP_PIN         PB1
+#define Z_DIR_PIN          PC5
+#define Z_ENABLE_PIN       PB10
+
+#define E0_STEP_PIN        PC4
+#define E0_DIR_PIN         PA5
+#define E0_ENABLE_PIN      PA4
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN       PC9
+#define FAN_PIN            PA8
+#define HEATER_BED_PIN     PC8
+
+//
+// Temperature Sensors
+//
+#define TEMP_BED_PIN       PA1
+#define TEMP_0_PIN         PA0
+
+#define FIL_RUNOUT_PIN     PB8  // MT_DET
+
+//
+// LCD Pins
+//
+#if HAS_SPI_LCD
+  #define BEEPER_PIN       PD2
+  #define BTN_ENC          PB3
+  #define LCD_PINS_RS      PC3
+
+  #define BTN_EN1          PB5
+  #define BTN_EN2          PB4
+
+  #define LCD_PINS_ENABLE  PC2
+
+  #if ENABLED(MKS_MINI_12864)
+
+    #define LCD_BACKLIGHT_PIN -1
+    #define LCD_RESET_PIN  -1
+    #define DOGLCD_A0      PC1
+    #define DOGLCD_CS      PC2
+    #define DOGLCD_SCK     PB13
+    #define DOGLCD_MOSI    PB15
+
+  #else // !MKS_MINI_12864
+
+    #define LCD_PINS_D4    PC1
+    #if ENABLED(ULTIPANEL)
+      #define LCD_PINS_D5  -1
+      #define LCD_PINS_D6  -1
+      #define LCD_PINS_D7  -1
+    #endif
+
+  #endif // !MKS_MINI_12864
+
+#endif // HAS_SPI_LCD
+
+// Motor current PWM pins
+#define MOTOR_CURRENT_PWM_XY_PIN   PB0
+#define MOTOR_CURRENT_PWM_Z_PIN    PA7
+#define MOTOR_CURRENT_PWM_E_PIN    PA6
+#define MOTOR_CURRENT_PWM_RANGE    65535/10/3.3 // (255 * (1000mA / 65535)) * 257 = 1000 is equal 1.6v Vref in turn equal 1Amp
+#define DEFAULT_PWM_MOTOR_CURRENT  { 1000, 1000, 1000 } // 1.05Amp per driver, here is XY, Z and E. This values determined empirically.
+
+//
+// SD Card
+//
+  #define ENABLE_SPI2
+  #define SD_DETECT_PIN    PC10
+  #define SCK_PIN          PB13
+  #define MISO_PIN         P1B4
+  #define MOSI_PIN         P1B5
+  #define SS_PIN           PA15
+
+#ifndef ST7920_DELAY_1
+  #define ST7920_DELAY_1 DELAY_NS(125)
+#endif
+#ifndef ST7920_DELAY_2
+  #define ST7920_DELAY_2 DELAY_NS(125)
+#endif
+#ifndef ST7920_DELAY_3
+  #define ST7920_DELAY_3 DELAY_NS(125)
+#endif

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_LITE.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_LITE.h
@@ -32,11 +32,12 @@
 #ifndef BOARD_NAME
   #define BOARD_NAME "MKS Robin Lite"
 #endif
-#define BOARD_WEBSITE_URL "github.com/makerbase-mks"
+#define BOARD_WEBSITE_URL "https://github.com/makerbase-mks"
 
 //#define DISABLE_DEBUG
 #define DISABLE_JTAG
 #define ENABLE_SPI2
+
 //
 // Limit Switches
 //
@@ -48,7 +49,6 @@
 //
 // Steppers
 //
-
 #define X_STEP_PIN         PC6
 #define X_DIR_PIN          PB12
 #define X_ENABLE_PIN       PB10
@@ -116,21 +116,21 @@
 #endif // HAS_SPI_LCD
 
 // Motor current PWM pins
-#define MOTOR_CURRENT_PWM_XY_PIN   PB0
-#define MOTOR_CURRENT_PWM_Z_PIN    PA7
-#define MOTOR_CURRENT_PWM_E_PIN    PA6
-#define MOTOR_CURRENT_PWM_RANGE    65535/10/3.3 // (255 * (1000mA / 65535)) * 257 = 1000 is equal 1.6v Vref in turn equal 1Amp
-#define DEFAULT_PWM_MOTOR_CURRENT  { 1000, 1000, 1000 } // 1.05Amp per driver, here is XY, Z and E. This values determined empirically.
+#define MOTOR_CURRENT_PWM_XY_PIN PB0
+#define MOTOR_CURRENT_PWM_Z_PIN  PA7
+#define MOTOR_CURRENT_PWM_E_PIN  PA6
+#define MOTOR_CURRENT_PWM_RANGE (65535/10/3.3) // (255 * (1000mA / 65535)) * 257 = 1000 is equal 1.6v Vref in turn equal 1Amp
+#define DEFAULT_PWM_MOTOR_CURRENT { 1000, 1000, 1000 } // 1.05Amp per driver, here is XY, Z and E. This values determined empirically.
 
 //
 // SD Card
 //
-  #define ENABLE_SPI2
-  #define SD_DETECT_PIN    PC10
-  #define SCK_PIN          PB13
-  #define MISO_PIN         P1B4
-  #define MOSI_PIN         P1B5
-  #define SS_PIN           PA15
+#define ENABLE_SPI2
+#define SD_DETECT_PIN      PC10
+#define SCK_PIN            PB13
+#define MISO_PIN           P1B4
+#define MOSI_PIN           P1B5
+#define SS_PIN             PA15
 
 #ifndef ST7920_DELAY_1
   #define ST7920_DELAY_1 DELAY_NS(125)

--- a/buildroot/share/PlatformIO/ldscripts/mks_robin_lite.ld
+++ b/buildroot/share/PlatformIO/ldscripts/mks_robin_lite.ld
@@ -1,0 +1,14 @@
+MEMORY
+{
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K - 40
+  rom (rx)  : ORIGIN = 0x08005000, LENGTH = 256K - 20K
+}
+
+/* Provide memory region aliases for common.inc */
+REGION_ALIAS("REGION_TEXT", rom);
+REGION_ALIAS("REGION_DATA", ram);
+REGION_ALIAS("REGION_BSS", ram);
+REGION_ALIAS("REGION_RODATA", rom);
+
+/* Let common.inc handle the real work. */
+INCLUDE common.inc

--- a/buildroot/share/PlatformIO/scripts/mks_robin_lite.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_lite.py
@@ -1,0 +1,30 @@
+Import("env")
+
+# Relocate firmware from 0x08000000 to 0x08005000
+for define in env['CPPDEFINES']:
+    if define[0] == "VECT_TAB_ADDR":
+        env['CPPDEFINES'].remove(define)
+env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08005000"))
+env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/mks_robin_lite.ld")
+
+# Encrypt ${PROGNAME}.bin and save it as 'mksLite.bin'
+def encrypt(source, target, env):
+    import os
+
+    key = [0xA3, 0xBD, 0xAD, 0x0D, 0x41, 0x11, 0xBB, 0x8D, 0xDC, 0x80, 0x2D, 0xD0, 0xD2, 0xC4, 0x9B, 0x1E, 0x26, 0xEB, 0xE3, 0x33, 0x4A, 0x15, 0xE4, 0x0A, 0xB3, 0xB1, 0x3C, 0x93, 0xBB, 0xAF, 0xF7, 0x3E]
+
+    firmware = open(target[0].path, "rb")
+    robin = open(target[0].dir.path +'/mksLite.bin', "wb")
+    length = os.path.getsize(target[0].path)
+    position = 0
+    try:
+        while position < length:
+            byte = firmware.read(1)
+            if position >= 320 and position < 31040:
+                byte = chr(ord(byte) ^ key[position & 31])
+            robin.write(byte)
+            position += 1
+    finally:
+        firmware.close()
+        robin.close()
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);

--- a/platformio.ini
+++ b/platformio.ini
@@ -413,6 +413,27 @@ lib_ignore    = c1921b4
   U8glib-HAL
 
 #
+# MKS ROBIN LITE/LITE2 (STM32F103RCT6)
+#
+[env:mks_robin_lite]
+platform      = ststm32
+framework     = arduino
+board         = genericSTM32F103RC
+extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_lite.py
+build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
+  ${common.build_flags} -std=gnu++14
+build_unflags = -std=gnu++11
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
+lib_deps      = ${common.lib_deps}
+lib_ignore    = c1921b4
+  libf3c
+  lib066
+  Adafruit NeoPixel_ID28
+  Adafruit NeoPixel
+  libf3e
+  TMC26XStepper
+
+#
 # MKS Robin Mini (STM32F103VET6)
 #
 [env:mks_robin_mini]


### PR DESCRIPTION
### Description
Adds support for MKS Robin Lite/Lite2 boards from [MKS' repo](https://github.com/makerbase-mks/MKS-Robin/tree/master/MKS%20Robin%20Lite).

### Benefits
Brings MKS Robin Lite/Lite2 (STM32F103RCT6) board support into Marlin 2.0.

### Related Issues
Related to PR https://github.com/MarlinFirmware/Marlin/pull/14681