### PR TITLE
Default TOUCH_MI_DEPLOY_XPOS to min X

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -108,7 +108,7 @@ float zprobe_zoffset; // Initialized by settings.load()
   // Move to the magnet to unlock the probe
   void run_deploy_moves_script() {
     #ifndef TOUCH_MI_DEPLOY_XPOS
-      #define TOUCH_MI_DEPLOY_XPOS 0
+      #define TOUCH_MI_DEPLOY_XPOS X_MIN_POS
     #elif TOUCH_MI_DEPLOY_XPOS > X_MAX_BED
       TemporaryGlobalEndstopsState unlock_x(false);
     #endif


### PR DESCRIPTION
Change value of TOUCH_MI_DEPLOY_XPOS, because when you have a negative offset on X axis, the carriage can't reach the magnet to activate the TouchMI.

