### PR TITLE
Overridable TMC serial pins, update TMC2209 docs

### DIFF
--- a/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
+++ b/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
@@ -294,31 +294,75 @@
    * Software serial
    */
 
-  #define X_SERIAL_TX_PIN    40
-  #define X_SERIAL_RX_PIN    63
-  #define X2_SERIAL_TX_PIN   -1
-  #define X2_SERIAL_RX_PIN   -1
+  #ifndef X_SERIAL_TX_PIN
+    #define X_SERIAL_TX_PIN  40
+  #endif
+  #ifndef X_SERIAL_RX_PIN
+    #define X_SERIAL_RX_PIN  63
+  #endif
+  #ifndef X2_SERIAL_TX_PIN
+    #define X2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef X2_SERIAL_RX_PIN
+    #define X2_SERIAL_RX_PIN -1
+  #endif
 
-  #define Y_SERIAL_TX_PIN    59
-  #define Y_SERIAL_RX_PIN    64
-  #define Y2_SERIAL_TX_PIN   -1
-  #define Y2_SERIAL_RX_PIN   -1
+  #ifndef Y_SERIAL_TX_PIN
+    #define Y_SERIAL_TX_PIN  59
+  #endif
+  #ifndef Y_SERIAL_RX_PIN
+    #define Y_SERIAL_RX_PIN  64
+  #endif
+  #ifndef Y2_SERIAL_TX_PIN
+    #define Y2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef Y2_SERIAL_RX_PIN
+    #define Y2_SERIAL_RX_PIN -1
+  #endif
 
-  #define Z_SERIAL_TX_PIN    42
-  #define Z_SERIAL_RX_PIN    65
-  #define Z2_SERIAL_TX_PIN   -1
-  #define Z2_SERIAL_RX_PIN   -1
+  #ifndef Z_SERIAL_TX_PIN
+    #define Z_SERIAL_TX_PIN  42
+  #endif
+  #ifndef Z_SERIAL_RX_PIN
+    #define Z_SERIAL_RX_PIN  65
+  #endif
+  #ifndef Z2_SERIAL_TX_PIN
+    #define Z2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef Z2_SERIAL_RX_PIN
+    #define Z2_SERIAL_RX_PIN -1
+  #endif
 
-  #define E0_SERIAL_TX_PIN   44
-  #define E0_SERIAL_RX_PIN   66
-  #define E1_SERIAL_TX_PIN   -1
-  #define E1_SERIAL_RX_PIN   -1
-  #define E2_SERIAL_TX_PIN   -1
-  #define E2_SERIAL_RX_PIN   -1
-  #define E3_SERIAL_TX_PIN   -1
-  #define E3_SERIAL_RX_PIN   -1
-  #define E4_SERIAL_TX_PIN   -1
-  #define E4_SERIAL_RX_PIN   -1
+  #ifndef E0_SERIAL_TX_PIN
+    #define E0_SERIAL_TX_PIN 44
+  #endif
+  #ifndef E0_SERIAL_RX_PIN
+    #define E0_SERIAL_RX_PIN 66
+  #endif
+  #ifndef E1_SERIAL_TX_PIN
+    #define E1_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E1_SERIAL_RX_PIN
+    #define E1_SERIAL_RX_PIN -1
+  #endif
+  #ifndef E2_SERIAL_TX_PIN
+    #define E2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E2_SERIAL_RX_PIN
+    #define E2_SERIAL_RX_PIN -1
+  #endif
+  #ifndef E3_SERIAL_TX_PIN
+    #define E3_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E3_SERIAL_RX_PIN
+    #define E3_SERIAL_RX_PIN -1
+  #endif
+  #ifndef E4_SERIAL_TX_PIN
+    #define E4_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E4_SERIAL_RX_PIN
+    #define E4_SERIAL_RX_PIN -1
+  #endif
 #endif
 
 //////////////////////////

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -322,73 +322,73 @@
   //
 
   #ifndef X_SERIAL_TX_PIN
-    #define X_SERIAL_TX_PIN    40
+    #define X_SERIAL_TX_PIN  40
   #endif
   #ifndef X_SERIAL_RX_PIN
-    #define X_SERIAL_RX_PIN    63
+    #define X_SERIAL_RX_PIN  63
   #endif
   #ifndef X2_SERIAL_TX_PIN
-    #define X2_SERIAL_TX_PIN   -1
+    #define X2_SERIAL_TX_PIN -1
   #endif
   #ifndef X2_SERIAL_RX_PIN
-    #define X2_SERIAL_RX_PIN   -1
+    #define X2_SERIAL_RX_PIN -1
   #endif
 
   #ifndef Y_SERIAL_TX_PIN
-    #define Y_SERIAL_TX_PIN    59
+    #define Y_SERIAL_TX_PIN  59
   #endif
   #ifndef Y_SERIAL_RX_PIN
-    #define Y_SERIAL_RX_PIN    64
+    #define Y_SERIAL_RX_PIN  64
   #endif
   #ifndef Y2_SERIAL_TX_PIN
-    #define Y2_SERIAL_TX_PIN   -1
+    #define Y2_SERIAL_TX_PIN -1
   #endif
   #ifndef Y2_SERIAL_RX_PIN
-    #define Y2_SERIAL_RX_PIN   -1
+    #define Y2_SERIAL_RX_PIN -1
   #endif
 
   #ifndef Z_SERIAL_TX_PIN
-    #define Z_SERIAL_TX_PIN    42
+    #define Z_SERIAL_TX_PIN  42
   #endif
   #ifndef Z_SERIAL_RX_PIN
-    #define Z_SERIAL_RX_PIN    65
+    #define Z_SERIAL_RX_PIN  65
   #endif
   #ifndef Z2_SERIAL_TX_PIN
-    #define Z2_SERIAL_TX_PIN   -1
+    #define Z2_SERIAL_TX_PIN -1
   #endif
   #ifndef Z2_SERIAL_RX_PIN
-    #define Z2_SERIAL_RX_PIN   -1
+    #define Z2_SERIAL_RX_PIN -1
   #endif
 
   #ifndef E0_SERIAL_TX_PIN
-    #define E0_SERIAL_TX_PIN   44
+    #define E0_SERIAL_TX_PIN 44
   #endif
   #ifndef E0_SERIAL_RX_PIN
-    #define E0_SERIAL_RX_PIN   66
+    #define E0_SERIAL_RX_PIN 66
   #endif
   #ifndef E1_SERIAL_TX_PIN
-    #define E1_SERIAL_TX_PIN   -1
+    #define E1_SERIAL_TX_PIN -1
   #endif
   #ifndef E1_SERIAL_RX_PIN
-    #define E1_SERIAL_RX_PIN   -1
+    #define E1_SERIAL_RX_PIN -1
   #endif
   #ifndef E2_SERIAL_TX_PIN
-    #define E2_SERIAL_TX_PIN   -1
+    #define E2_SERIAL_TX_PIN -1
   #endif
   #ifndef E2_SERIAL_RX_PIN
-    #define E2_SERIAL_RX_PIN   -1
+    #define E2_SERIAL_RX_PIN -1
   #endif
   #ifndef E3_SERIAL_TX_PIN
-    #define E3_SERIAL_TX_PIN   -1
+    #define E3_SERIAL_TX_PIN -1
   #endif
   #ifndef E3_SERIAL_RX_PIN
-    #define E3_SERIAL_RX_PIN   -1
+    #define E3_SERIAL_RX_PIN -1
   #endif
   #ifndef E4_SERIAL_TX_PIN
-    #define E4_SERIAL_TX_PIN   -1
+    #define E4_SERIAL_TX_PIN -1
   #endif
   #ifndef E4_SERIAL_RX_PIN
-    #define E4_SERIAL_RX_PIN   -1
+    #define E4_SERIAL_RX_PIN -1
   #endif
 #endif
 

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -321,31 +321,75 @@
   // Software serial
   //
 
-  #define X_SERIAL_TX_PIN    40
-  #define X_SERIAL_RX_PIN    63
-  #define X2_SERIAL_TX_PIN   -1
-  #define X2_SERIAL_RX_PIN   -1
+  #ifndef X_SERIAL_TX_PIN
+    #define X_SERIAL_TX_PIN    40
+  #endif
+  #ifndef X_SERIAL_RX_PIN
+    #define X_SERIAL_RX_PIN    63
+  #endif
+  #ifndef X2_SERIAL_TX_PIN
+    #define X2_SERIAL_TX_PIN   -1
+  #endif
+  #ifndef X2_SERIAL_RX_PIN
+    #define X2_SERIAL_RX_PIN   -1
+  #endif
 
-  #define Y_SERIAL_TX_PIN    59
-  #define Y_SERIAL_RX_PIN    64
-  #define Y2_SERIAL_TX_PIN   -1
-  #define Y2_SERIAL_RX_PIN   -1
+  #ifndef Y_SERIAL_TX_PIN
+    #define Y_SERIAL_TX_PIN    59
+  #endif
+  #ifndef Y_SERIAL_RX_PIN
+    #define Y_SERIAL_RX_PIN    64
+  #endif
+  #ifndef Y2_SERIAL_TX_PIN
+    #define Y2_SERIAL_TX_PIN   -1
+  #endif
+  #ifndef Y2_SERIAL_RX_PIN
+    #define Y2_SERIAL_RX_PIN   -1
+  #endif
 
-  #define Z_SERIAL_TX_PIN    42
-  #define Z_SERIAL_RX_PIN    65
-  #define Z2_SERIAL_TX_PIN   -1
-  #define Z2_SERIAL_RX_PIN   -1
+  #ifndef Z_SERIAL_TX_PIN
+    #define Z_SERIAL_TX_PIN    42
+  #endif
+  #ifndef Z_SERIAL_RX_PIN
+    #define Z_SERIAL_RX_PIN    65
+  #endif
+  #ifndef Z2_SERIAL_TX_PIN
+    #define Z2_SERIAL_TX_PIN   -1
+  #endif
+  #ifndef Z2_SERIAL_RX_PIN
+    #define Z2_SERIAL_RX_PIN   -1
+  #endif
 
-  #define E0_SERIAL_TX_PIN   44
-  #define E0_SERIAL_RX_PIN   66
-  #define E1_SERIAL_TX_PIN   -1
-  #define E1_SERIAL_RX_PIN   -1
-  #define E2_SERIAL_TX_PIN   -1
-  #define E2_SERIAL_RX_PIN   -1
-  #define E3_SERIAL_TX_PIN   -1
-  #define E3_SERIAL_RX_PIN   -1
-  #define E4_SERIAL_TX_PIN   -1
-  #define E4_SERIAL_RX_PIN   -1
+  #ifndef E0_SERIAL_TX_PIN
+    #define E0_SERIAL_TX_PIN   44
+  #endif
+  #ifndef E0_SERIAL_RX_PIN
+    #define E0_SERIAL_RX_PIN   66
+  #endif
+  #ifndef E1_SERIAL_TX_PIN
+    #define E1_SERIAL_TX_PIN   -1
+  #endif
+  #ifndef E1_SERIAL_RX_PIN
+    #define E1_SERIAL_RX_PIN   -1
+  #endif
+  #ifndef E2_SERIAL_TX_PIN
+    #define E2_SERIAL_TX_PIN   -1
+  #endif
+  #ifndef E2_SERIAL_RX_PIN
+    #define E2_SERIAL_RX_PIN   -1
+  #endif
+  #ifndef E3_SERIAL_TX_PIN
+    #define E3_SERIAL_TX_PIN   -1
+  #endif
+  #ifndef E3_SERIAL_RX_PIN
+    #define E3_SERIAL_RX_PIN   -1
+  #endif
+  #ifndef E4_SERIAL_TX_PIN
+    #define E4_SERIAL_TX_PIN   -1
+  #endif
+  #ifndef E4_SERIAL_RX_PIN
+    #define E4_SERIAL_RX_PIN   -1
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/ramps/pins_Z_BOLT_X_SERIES.h
+++ b/Marlin/src/pins/ramps/pins_Z_BOLT_X_SERIES.h
@@ -216,29 +216,73 @@
   // Software serial
   //
 
-  #define X_SERIAL_TX_PIN    40
-  #define X_SERIAL_RX_PIN    63
-  #define X2_SERIAL_TX_PIN   -1
-  #define X2_SERIAL_RX_PIN   -1
+  #ifndef X_SERIAL_TX_PIN
+    #define X_SERIAL_TX_PIN  40
+  #endif
+  #ifndef X_SERIAL_RX_PIN
+    #define X_SERIAL_RX_PIN  63
+  #endif
+  #ifndef X2_SERIAL_TX_PIN
+    #define X2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef X2_SERIAL_RX_PIN
+    #define X2_SERIAL_RX_PIN -1
+  #endif
 
-  #define Y_SERIAL_TX_PIN    59
-  #define Y_SERIAL_RX_PIN    64
-  #define Y2_SERIAL_TX_PIN   -1
-  #define Y2_SERIAL_RX_PIN   -1
+  #ifndef Y_SERIAL_TX_PIN
+    #define Y_SERIAL_TX_PIN  59
+  #endif
+  #ifndef Y_SERIAL_RX_PIN
+    #define Y_SERIAL_RX_PIN  64
+  #endif
+  #ifndef Y2_SERIAL_TX_PIN
+    #define Y2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef Y2_SERIAL_RX_PIN
+    #define Y2_SERIAL_RX_PIN -1
+  #endif
 
-  #define Z_SERIAL_TX_PIN    42
-  #define Z_SERIAL_RX_PIN    65
-  #define Z2_SERIAL_TX_PIN   -1
-  #define Z2_SERIAL_RX_PIN   -1
+  #ifndef Z_SERIAL_TX_PIN
+    #define Z_SERIAL_TX_PIN  42
+  #endif
+  #ifndef Z_SERIAL_RX_PIN
+    #define Z_SERIAL_RX_PIN  65
+  #endif
+  #ifndef Z2_SERIAL_TX_PIN
+    #define Z2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef Z2_SERIAL_RX_PIN
+    #define Z2_SERIAL_RX_PIN -1
+  #endif
 
-  #define E0_SERIAL_TX_PIN   44
-  #define E0_SERIAL_RX_PIN   66
-  #define E1_SERIAL_TX_PIN   -1
-  #define E1_SERIAL_RX_PIN   -1
-  #define E2_SERIAL_TX_PIN   -1
-  #define E2_SERIAL_RX_PIN   -1
-  #define E3_SERIAL_TX_PIN   -1
-  #define E3_SERIAL_RX_PIN   -1
-  #define E4_SERIAL_TX_PIN   -1
-  #define E4_SERIAL_RX_PIN   -1
+  #ifndef E0_SERIAL_TX_PIN
+    #define E0_SERIAL_TX_PIN 44
+  #endif
+  #ifndef E0_SERIAL_RX_PIN
+    #define E0_SERIAL_RX_PIN 66
+  #endif
+  #ifndef E1_SERIAL_TX_PIN
+    #define E1_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E1_SERIAL_RX_PIN
+    #define E1_SERIAL_RX_PIN -1
+  #endif
+  #ifndef E2_SERIAL_TX_PIN
+    #define E2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E2_SERIAL_RX_PIN
+    #define E2_SERIAL_RX_PIN -1
+  #endif
+  #ifndef E3_SERIAL_TX_PIN
+    #define E3_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E3_SERIAL_RX_PIN
+    #define E3_SERIAL_RX_PIN -1
+  #endif
+  #ifndef E4_SERIAL_TX_PIN
+    #define E4_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E4_SERIAL_RX_PIN
+    #define E4_SERIAL_RX_PIN -1
+  #endif
 #endif

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -1752,6 +1752,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -1753,8 +1753,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -1753,6 +1753,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -1754,8 +1754,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1757,6 +1757,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1758,8 +1758,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/Ender-5/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Creality/Ender-5/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 1

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 1

--- a/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 1

--- a/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 1

--- a/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 1

--- a/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 1

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Felix/Configuration_adv.h
+++ b/config/examples/Felix/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Felix/Configuration_adv.h
+++ b/config/examples/Felix/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -1748,6 +1748,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -1749,8 +1749,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -1753,6 +1753,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -1754,8 +1754,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -1753,6 +1753,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -1754,8 +1754,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -1748,6 +1748,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -1749,8 +1749,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -1754,6 +1754,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -1755,8 +1755,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -1754,6 +1754,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -1755,8 +1755,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1750,6 +1750,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1751,8 +1751,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
@@ -1746,8 +1746,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
@@ -1745,6 +1745,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1762,6 +1762,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1763,8 +1763,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1751,6 +1751,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1752,8 +1752,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1749,6 +1749,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1750,8 +1750,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -1750,6 +1750,9 @@
    *       1 | HIGH | LOW
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
+   *
+   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
+   * either below or in your pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -1751,8 +1751,8 @@
    *       2 | LOW  | HIGH
    *       3 | HIGH | HIGH
    *
-   * Set ##_SERIAL_TX_PIN and ##_SERIAL_RX_PIN to match for all drivers on the same serial port
-   * either below or in your pins file.
+   * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
+   * on the same serial port, either here or in your board's pins file.
    */
   #define  X_SLAVE_ADDRESS 0
   #define  Y_SLAVE_ADDRESS 0


### PR DESCRIPTION
Makes configuration for TMC2209 multiplexed drivers easier and clearer by allowing pins to be defined in configuration file and stating that pins for multiplexed drivers need to match shared port instead of the default.