### PR TITLE
Fix MKS Robin Lite pins include

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -450,12 +450,12 @@
   #include "stm32/pins_CHITU3D.h"               // STM32F1                                env:STM32F1
 #elif MB(MKS_ROBIN)
   #include "stm32/pins_MKS_ROBIN.h"             // STM32F1                                env:mks_robin
-#elif MB(MKS_ROBIN_LITE)
-  #include "stm32/pins_MKS_ROBIN_LITE.h"        // STM32F1                                env:mks_robin_lite
 #elif MB(MKS_ROBIN_MINI)
   #include "stm32/pins_MKS_ROBIN_MINI.h"        // STM32F1                                env:mks_robin_mini
 #elif MB(MKS_ROBIN_NANO)
   #include "stm32/pins_MKS_ROBIN_NANO.h"        // STM32F1                                env:mks_robin_nano
+#elif MB(MKS_ROBIN_LITE)
+  #include "stm32/pins_MKS_ROBIN_LITE.h"        // STM32F1                                env:mks_robin_lite
 #elif MB(BIGTREE_SKR_MINI_V1_1)
   #include "stm32/pins_BIGTREE_SKR_MINI_V1_1.h" // STM32F1                                env:BIGTREE_SKR_MINI
 #elif MB(BIGTREE_SKR_MINI_E3)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -450,6 +450,8 @@
   #include "stm32/pins_CHITU3D.h"               // STM32F1                                env:STM32F1
 #elif MB(MKS_ROBIN)
   #include "stm32/pins_MKS_ROBIN.h"             // STM32F1                                env:mks_robin
+#elif MB(MKS_ROBIN_LITE)
+  #include "stm32/pins_MKS_ROBIN_LITE.h"        // STM32F1                                env:mks_robin_lite
 #elif MB(MKS_ROBIN_MINI)
   #include "stm32/pins_MKS_ROBIN_MINI.h"        // STM32F1                                env:mks_robin_mini
 #elif MB(MKS_ROBIN_NANO)


### PR DESCRIPTION
### Description

The recently added [MKS Robin Lite](https://github.com/MarlinFirmware/Marlin/pull/14729) board [was removed](https://github.com/MarlinFirmware/Marlin/pull/14723/commits/a7b7d53d2d27c8a081e18e32df8a441953fbf670) from `pins.h` while cleaning up PR https://github.com/MarlinFirmware/Marlin/pull/14723.

### Benefits

This PR re-adds the Robin Lite to `pins.h` so you can use the board again.

### Related Issues

Fixes `"Unknown MOTHERBOARD value set in Configuration.h"` error when using `BOARD_MKS_ROBIN_LITE`.