### PR TITLE
Enable runout sensor in EEPROM by default

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -574,7 +574,7 @@ void MarlinSettings::postprocess() {
       #if HAS_FILAMENT_SENSOR
         const bool &runout_sensor_enabled = runout.enabled;
       #else
-        const bool runout_sensor_enabled = false;
+        const bool runout_sensor_enabled = true;
       #endif
       #if HAS_FILAMENT_SENSOR && defined(FILAMENT_RUNOUT_DISTANCE_MM)
         const float &runout_distance_mm = runout.runout_distance();


### PR DESCRIPTION
Users have reported issues with Filament runout not working when flashing an identical eeprom version build with runout on when it was previously disabled. They are finding the sensor comes in disabled by default. This changes the storage to enabled when the feature is disabled so that when it is added they no longer need to initialize eeprom explicitly for this or enable it with M412 S1 thereby eliminating the confusing situation.