### PR TITLE
Return 'false' on EEPROM connection fail

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -460,7 +460,7 @@ void MarlinSettings::postprocess() {
     #define EEPROM_SKIP(VAR) (eeprom_index += sizeof(VAR))
   #endif
 
-  #define EEPROM_START()          if (!persistentStore.access_start()) { SERIAL_ERROR_MSG("EEPROM connect error."); return false; } \
+  #define EEPROM_START()          if (!persistentStore.access_start()) { SERIAL_ECHO_MSG("No EEPROM."); return false; } \
                                   int eeprom_index = EEPROM_OFFSET
   #define EEPROM_FINISH()         persistentStore.access_finish()
   #define EEPROM_WRITE(VAR)       do{ persistentStore.write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc);              UPDATE_TEST_INDEX(VAR); }while(0)

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -460,7 +460,7 @@ void MarlinSettings::postprocess() {
     #define EEPROM_SKIP(VAR) (eeprom_index += sizeof(VAR))
   #endif
 
-  #define EEPROM_START()          int eeprom_index = EEPROM_OFFSET; persistentStore.access_start()
+  #define EEPROM_START()          int eeprom_index = EEPROM_OFFSET; if (!persistentStore.access_start()) { return false; }
   #define EEPROM_FINISH()         persistentStore.access_finish()
   #define EEPROM_WRITE(VAR)       do{ persistentStore.write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc);              UPDATE_TEST_INDEX(VAR); }while(0)
   #define EEPROM_READ(VAR)        do{ persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc, !validating);  UPDATE_TEST_INDEX(VAR); }while(0)
@@ -2111,7 +2111,7 @@ void MarlinSettings::postprocess() {
       (void)save();
       SERIAL_ECHO_MSG("EEPROM Initialized");
     #endif
-    return true;
+    return false;
   }
 
   #if ENABLED(AUTO_BED_LEVELING_UBL)

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -460,7 +460,8 @@ void MarlinSettings::postprocess() {
     #define EEPROM_SKIP(VAR) (eeprom_index += sizeof(VAR))
   #endif
 
-  #define EEPROM_START()          int eeprom_index = EEPROM_OFFSET; if (!persistentStore.access_start()) { return false; }
+  #define EEPROM_START()          if (!persistentStore.access_start()) { SERIAL_ERROR_MSG("EEPROM connect error."); return false; } \
+                                  int eeprom_index = EEPROM_OFFSET
   #define EEPROM_FINISH()         persistentStore.access_finish()
   #define EEPROM_WRITE(VAR)       do{ persistentStore.write_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc);              UPDATE_TEST_INDEX(VAR); }while(0)
   #define EEPROM_READ(VAR)        do{ persistentStore.read_data(eeprom_index, (uint8_t*)&VAR, sizeof(VAR), &working_crc, !validating);  UPDATE_TEST_INDEX(VAR); }while(0)


### PR DESCRIPTION
### Requirements

* STM32F1 MCU
* #define SD_DETECT_PIN

### Description

With FYSETC Cheetah board, EEPROM file doesn't get loaded when booting.
After debugging with SWD probe, I found the `first_load` function sets `loaded=true` no matter of the access return, avoiding to properly load EEPROM file when SD got detected.

Without this fix, here is the console output:
```
[Connected]
start
echo:PowerUp
Marlin 2.0.0-RC0

echo: Last Updated: 2019-07-19 | Author: (trouch, config)
echo:Compiled: Jul 27 2019
echo: Free Memory: 28631  PlannerBufferBytes: 1728
echo:EEPROM version mismatch (EEPROM= Marlin=V68)
echo:Hardcoded Default Settings Loaded
Testing X connection... OK
Testing Y connection... OK
Testing Z connection... OK
Testing E connection... OK
echo:SD card ok
```

With that fix:
```
[Connected]
start
echo:PowerUp
Marlin 2.0.0-RC0

echo: Last Updated: 2019-07-19 | Author: (trouch, config)
echo:Compiled: Jul 27 2019
echo: Free Memory: 28631  PlannerBufferBytes: 1728
echo:Hardcoded Default Settings Loaded
Testing X connection... OK
Testing Y connection... OK
Testing Z connection... OK
Testing E connection... OK
echo:SD card ok
echo:V68 stored settings retrieved (614 bytes; crc 176)
```

IDK if that's the right approach to fix it, but it's the simpler one I found to avoid extra pre-compiler conditions and make it a general improvement.