### PR TITLE
Fix M122 column alignment

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -787,7 +787,7 @@
     #if HAS_DRIVER(TMC2160) || HAS_DRIVER(TMC5160)
       TMC_REPORT("Global scaler",    TMC_GLOBAL_SCALER);
     #endif
-    TMC_REPORT("CS actual\t",        TMC_CS_ACTUAL);
+    TMC_REPORT("CS actual",          TMC_CS_ACTUAL);
     TMC_REPORT("PWM scale",          TMC_PWM_SCALE);
     #if HAS_DRIVER(TMC2130) || HAS_DRIVER(TMC2224) || HAS_DRIVER(TMC2660) || HAS_TMC220x
       TMC_REPORT("vsense\t",         TMC_VSENSE);
@@ -795,14 +795,14 @@
     TMC_REPORT("stealthChop",        TMC_STEALTHCHOP);
     TMC_REPORT("msteps\t",           TMC_MICROSTEPS);
     TMC_REPORT("tstep\t",            TMC_TSTEP);
-    TMC_REPORT("pwm\nthreshold\t",   TMC_TPWMTHRS);
+    TMC_REPORT("pwm\nthreshold",     TMC_TPWMTHRS);
     TMC_REPORT("[mm/s]\t",           TMC_TPWMTHRS_MMS);
     TMC_REPORT("OT prewarn",         TMC_OTPW);
     #if ENABLED(MONITOR_DRIVER_STATUS)
       TMC_REPORT("OT prewarn has\n"
                  "been triggered",   TMC_OTPW_TRIGGERED);
     #endif
-    TMC_REPORT("off time\t",         TMC_TOFF);
+    TMC_REPORT("off time",           TMC_TOFF);
     TMC_REPORT("blank time",         TMC_TBL);
     TMC_REPORT("hysteresis\n-end\t", TMC_HEND);
     TMC_REPORT("-start\t",           TMC_HSTRT);
@@ -811,7 +811,7 @@
     DRV_REPORT("DRVSTATUS",          TMC_DRV_CODES);
     #if HAS_TMCX1X0
       DRV_REPORT("stallguard\t",     TMC_STALLGUARD);
-      DRV_REPORT("sg_result\t",      TMC_SG_RESULT);
+      DRV_REPORT("sg_result",        TMC_SG_RESULT);
       DRV_REPORT("fsactive\t",       TMC_FSACTIVE);
     #endif
     DRV_REPORT("stst\t",             TMC_STST);


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Fix ident when run `M122` with TMC steppers

Without this PR:

```
M122
		X	Y	Z	E
Enabled		false	false	false	false
Set current	610	300	300	300
RMS current	604	295	295	295
MAX current	852	416	416	416
Run current	17/31	8/31	8/31	8/31
Hold current	8/31	4/31	4/31	4/31
Global scaler	132/256	130/256	130/256	130/256
CS actual		8/31	4/31	4/31	4/31
PWM scale	0	0	0	0
stealthChop	true	true	true	true
msteps		16	16	16	16
tstep		max	max	max	max
pwm
threshold		98	98	658	64
[mm/s]		100	100	3	30
OT prewarn	false	false	false	false
OT prewarn has
been triggered	false	false	false	false
off time		4	4	4	4
blank time	24	24	24	24
hysteresis
-end		2	2	2	2
-start		1	1	1	1
Stallguard thrs	-64	15	0	0
DRVSTATUS	X	Y	Z	E
stallguard					
sg_result		0	0	0	0
fsactive					
stst		*	*	*	*
olb					
ola					
s2gb					
s2ga					
otpw					
ot					
Driver registers:
		X	0x80:08:00:00
		Y	0x80:04:00:00
		Z	0x80:04:00:00
		E	0x80:04:00:00


Testing X connection... OK
Testing Y connection... OK
Testing Z connection... OK
Testing E connection... OK
```

with this PR:

```
M122
		X	Y	Z	E
Enabled		false	false	false	false
Set current	610	300	300	300
RMS current	604	295	295	295
MAX current	852	416	416	416
Run current	17/31	8/31	8/31	8/31
Hold current	8/31	4/31	4/31	4/31
Global scaler	132/256	130/256	130/256	130/256
CS actual	8/31	4/31	4/31	4/31
PWM scale	0	0	0	0
stealthChop	true	true	true	true
msteps		16	16	16	16
tstep		max	max	max	max
pwm
threshold	98	98	658	64
[mm/s]		100	100	3	30
OT prewarn	false	false	false	false
OT prewarn has
been triggered	false	false	false	false
off time	4	4	4	4
blank time	24	24	24	24
hysteresis
-end		2	2	2	2
-start		1	1	1	1
Stallguard thrs	-64	15	0	0
DRVSTATUS	X	Y	Z	E
stallguard					
sg_result	0	0	0	0
fsactive					
stst		*	*	*	*
olb					
ola					
s2gb					
s2ga					
otpw					
ot					
Driver registers:
		X	0x80:08:00:00
		Y	0x80:04:00:00
		Z	0x80:04:00:00
		E	0x80:04:00:00


Testing X connection... OK
Testing Y connection... OK
Testing Z connection... OK
Testing E connection... OK
```

i'm sure have more indent issues, but i can't see it
