### PR TITLE
Fix 'pause_menu_response' compile error

### DIFF
--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -110,7 +110,9 @@ void host_action(const char * const pstr, const bool eol) {
       case PROMPT_FILAMENT_RUNOUT:
         msg = PSTR("FILAMENT_RUNOUT");
         if (response == 0) {
+          #if ENABLED(ADVANCED_PAUSE_FEATURE)
           pause_menu_response = PAUSE_RESPONSE_EXTRUDE_MORE;
+          #endif
           host_action_prompt_end();   // Close current prompt
           host_action_prompt_begin(PSTR("Paused"));
           host_action_prompt_button(PSTR("Purge More"));
@@ -133,7 +135,9 @@ void host_action(const char * const pstr, const bool eol) {
               runout.reset();
             }
           #endif
+          #if ENABLED(ADVANCED_PAUSE_FEATURE)
           pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT;
+          #endif
         }
         break;
       case PROMPT_USER_CONTINUE:
@@ -142,7 +146,9 @@ void host_action(const char * const pstr, const bool eol) {
         break;
       case PROMPT_PAUSE_RESUME:
         msg = PSTR("LCD_PAUSE_RESUME");
+        #if ENABLED(ADVANCED_PAUSE_FEATURE)
         queue.inject_P(PSTR("M24"));
+        #endif
         break;
       case PROMPT_INFO:
         msg = PSTR("GCODE_INFO");

--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -111,7 +111,7 @@ void host_action(const char * const pstr, const bool eol) {
         msg = PSTR("FILAMENT_RUNOUT");
         if (response == 0) {
           #if ENABLED(ADVANCED_PAUSE_FEATURE)
-          pause_menu_response = PAUSE_RESPONSE_EXTRUDE_MORE;
+            pause_menu_response = PAUSE_RESPONSE_EXTRUDE_MORE;
           #endif
           host_action_prompt_end();   // Close current prompt
           host_action_prompt_begin(PSTR("Paused"));
@@ -136,7 +136,7 @@ void host_action(const char * const pstr, const bool eol) {
             }
           #endif
           #if ENABLED(ADVANCED_PAUSE_FEATURE)
-          pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT;
+            pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT;
           #endif
         }
         break;
@@ -147,7 +147,7 @@ void host_action(const char * const pstr, const bool eol) {
       case PROMPT_PAUSE_RESUME:
         msg = PSTR("LCD_PAUSE_RESUME");
         #if ENABLED(ADVANCED_PAUSE_FEATURE)
-        queue.inject_P(PSTR("M24"));
+          queue.inject_P(PSTR("M24"));
         #endif
         break;
       case PROMPT_INFO:


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

This fixes a compiler error resulting from host_actions.cpp setting variables that are only present when ADVANCED_PAUSE_FEATURE is defined.

### Benefits

<!-- What does this fix or improve? -->
Allows the host_actions.cpp to compile in the absence of ADVANCED_PAUSE_FEATURE.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
