### PR TITLE
THERMAL_PROTECTION_GRACE_PERIOD is obsolete

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/HAL.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.h
@@ -148,7 +148,7 @@ using FilteredADC = LPC176x::ADC<ADC_LOWPASS_K_VALUE, ADC_MEDIAN_FILTER_SIZE>;
 
 // A grace period to allow ADC readings to stabilize, preventing false alarms
 #ifndef THERMAL_PROTECTION_GRACE_PERIOD
-  #define THERMAL_PROTECTION_GRACE_PERIOD 1000
+  #define THERMAL_PROTECTION_GRACE_PERIOD 5000
 #endif
 
 // Parse a G-code word into a pin index

--- a/Marlin/src/HAL/HAL_LPC1768/HAL.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.h
@@ -146,15 +146,6 @@ using FilteredADC = LPC176x::ADC<ADC_LOWPASS_K_VALUE, ADC_MEDIAN_FILTER_SIZE>;
 #define HAL_READ_ADC()         FilteredADC::get_result()
 #define HAL_ADC_READY()        FilteredADC::finished_conversion()
 
-// A grace period to allow ADC readings to stabilize, preventing false alarms
-#ifndef THERMAL_PROTECTION_GRACE_PERIOD
-  #if ENABLED(SDSUPPORT)
-    #define THERMAL_PROTECTION_GRACE_PERIOD 5000
-  #else
-    #define THERMAL_PROTECTION_GRACE_PERIOD 1000
-  #endif
-#endif
-
 // Parse a G-code word into a pin index
 int16_t PARSED_PIN_INDEX(const char code, const int16_t dval);
 // P0.6 thru P0.9 are for the onboard SD card

--- a/Marlin/src/HAL/HAL_LPC1768/HAL.h
+++ b/Marlin/src/HAL/HAL_LPC1768/HAL.h
@@ -148,7 +148,11 @@ using FilteredADC = LPC176x::ADC<ADC_LOWPASS_K_VALUE, ADC_MEDIAN_FILTER_SIZE>;
 
 // A grace period to allow ADC readings to stabilize, preventing false alarms
 #ifndef THERMAL_PROTECTION_GRACE_PERIOD
-  #define THERMAL_PROTECTION_GRACE_PERIOD 5000
+  #if ENABLED(SDSUPPORT)
+    #define THERMAL_PROTECTION_GRACE_PERIOD 5000
+  #else
+    #define THERMAL_PROTECTION_GRACE_PERIOD 1000
+  #endif
 #endif
 
 // Parse a G-code word into a pin index

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1130,6 +1130,8 @@ void loop() {
 
   for (;;) {
 
+    idle(); // Do an idle first so boot is slightly faster
+
     #if ENABLED(SDSUPPORT)
 
       card.checkautostart();
@@ -1161,6 +1163,5 @@ void loop() {
     if (queue.length < BUFSIZE) queue.get_available_commands();
     queue.advance();
     endstops.event_handler();
-    idle();
   }
 }


### PR DESCRIPTION
SKR 1.3 Takes long time to boot up if the SD card enabled but SD card is not inserted.
This make the printer halted and show BED MAX TEMP error.

However if the SD Card is inserted or BLTouch ENABLED, BED MAX TEMP error never happened.

I measure on my printer, It need around 4 sec. So I make it 5 sec.  