### PR TITLE
Fix HOME_BACKOFF_MM type

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1604,7 +1604,7 @@ void homeaxis(const AxisEnum axis) {
 
   #ifdef HOMING_BACKOFF_MM
     constexpr float endstop_backoff[XYZ] = HOMING_BACKOFF_MM;
-    const AxisEnum backoff_mm = endstop_backoff[
+    const float backoff_mm = endstop_backoff[
       #if ENABLED(DELTA)
         Z_AXIS
       #else


### PR DESCRIPTION
### Description

The type for backoff_mm is preventing compilation if HOMING_BACKOFF_MM is enabled.

### Benefits

The code builds.  Correctness of operation is unknown, but appears correct given context.
