### PR TITLE
STM32F1: Reduce binary by 2K by dropping full path asserts

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -262,6 +262,7 @@ framework     = arduino
 board         = genericSTM32F103RE
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   ${common.build_flags} -std=gnu++14
+  -DDEBUG_LEVEL=0
 build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
 lib_ignore    = U8glib-HAL
@@ -286,7 +287,9 @@ board         = genericSTM32F103RC
 #board_build.core = maple
 extra_scripts = buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
-  ${common.build_flags}
+  ${common.build_flags} -std=gnu++14
+  -DDEBUG_LEVEL=0
+build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
 lib_ignore    =
   c1921b4
@@ -312,6 +315,7 @@ board         = genericSTM32F103RC
 extra_scripts = buildroot/share/PlatformIO/scripts/STM32F1_SKR_MINI.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   ${common.build_flags} -std=gnu++14
+  -DDEBUG_LEVEL=0
 build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
 lib_ignore    =
@@ -551,6 +555,7 @@ platform    = ststm32
 framework   = arduino
 board       = malyanM200
 build_flags = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py -DMCU_STM32F103CB -D __STM32F1__=1 -std=c++1y -D MOTHERBOARD="BOARD_MALYAN_M200" -DSERIAL_USB -ffunction-sections -fdata-sections -Wl,--gc-sections
+  -DDEBUG_LEVEL=0
 src_filter  = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 #-<frameworks>
 lib_ignore  =


### PR DESCRIPTION
```
PROGRAM: [====      ]  44.9% (used 235436 bytes from 524288 bytes)
PROGRAM: [====      ]  44.5% (used 233300 bytes from 524288 bytes)
```
Only set for F1 devices with lower flash size (STM32F103CB is 128KB)

Another way to do it, while keeping asserts is possible using :
```
  -D__FILE__=__func__ -Wno-builtin-macro-redefined
```

```
STM32F1/system/libmaple/include/libmaple/util.h:91:        _fail(__FILE__, __LINE__, #exp);
STM32F1/system/libmaple/include/libmaple/util.h:101:        _fail(__FILE__, __LINE__, #exp);
```

```cpp
#ifndef DEBUG_LEVEL
#define DEBUG_LEVEL DEBUG_ALL
#endif

#define DEBUG_NONE      0
#define DEBUG_FAULT     1
#define DEBUG_ALL       2
```