### PR TITLE
STM32F4x SD-based settings storage

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_STM32/persistent_store_impl.cpp
@@ -24,9 +24,11 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(EEPROM_SETTINGS)
+#if ENABLED(EEPROM_SETTINGS)&& EITHER(FLASH_EEPROM_EMULATION,SRAM_EEPROM_EMULATION)
 
 #include "../shared/persistent_store_api.h"
+
+//#if ENABLED(FLASH_EEPROM_EMULATION)                           //使能它表示用芯片flash 模拟EEPROM 
 
 #if NONE(SRAM_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
   #include <EEPROM.h>
@@ -112,7 +114,7 @@ size_t PersistentStore::capacity() {
   #else
     return 4096; // 4kB
   #endif
-}
+} 
 
-#endif // EEPROM_SETTINGS
+#endif // EEPROM_SETTINGS && FLASH_EEPROM_EMULATION
 #endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/HAL/HAL_STM32/persistent_store_impl.cpp
+++ b/Marlin/src/HAL/HAL_STM32/persistent_store_impl.cpp
@@ -24,26 +24,24 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(EEPROM_SETTINGS)&& EITHER(FLASH_EEPROM_EMULATION,SRAM_EEPROM_EMULATION)
+#if ENABLED(EEPROM_SETTINGS) && ANY(FLASH_EEPROM_EMULATION, SRAM_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
 
 #include "../shared/persistent_store_api.h"
 
-//#if ENABLED(FLASH_EEPROM_EMULATION)                           //使能它表示用芯片flash 模拟EEPROM 
-
-#if NONE(SRAM_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
+#if ENABLED(FLASH_EEPROM_EMULATION)
   #include <EEPROM.h>
   static bool eeprom_data_written = false;
 #endif
 
 bool PersistentStore::access_start() {
-  #if NONE(SRAM_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
+  #if ENABLED(FLASH_EEPROM_EMULATION)
     eeprom_buffer_fill();
   #endif
   return true;
 }
 
 bool PersistentStore::access_finish() {
-  #if NONE(SRAM_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
+  #if ENABLED(FLASH_EEPROM_EMULATION)
     if (eeprom_data_written) {
       eeprom_buffer_flush();
       eeprom_data_written = false;
@@ -68,7 +66,7 @@ bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, ui
           return true;
         }
       }
-    #elif DISABLED(SRAM_EEPROM_EMULATION)
+    #elif ENABLED(FLASH_EEPROM_EMULATION)
       eeprom_buffered_write_byte(pos, v);
     #else
       *(__IO uint8_t *)(BKPSRAM_BASE + (uint8_t * const)pos) = v;
@@ -78,7 +76,7 @@ bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, ui
     pos++;
     value++;
   };
-  #if NONE(SRAM_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
+  #if ENABLED(FLASH_EEPROM_EMULATION)
     eeprom_data_written = true;
   #endif
 
@@ -91,7 +89,7 @@ bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t 
     const uint8_t c = (
       #if EITHER(SPI_EEPROM, I2C_EEPROM)
         eeprom_read_byte((uint8_t*)pos)
-      #elif DISABLED(SRAM_EEPROM_EMULATION)
+      #elif ENABLED(FLASH_EEPROM_EMULATION)
         eeprom_buffered_read_byte(pos)
       #else
         (*(__IO uint8_t *)(BKPSRAM_BASE + ((uint8_t*)pos)))
@@ -107,14 +105,14 @@ bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t 
 }
 
 size_t PersistentStore::capacity() {
-  #if EITHER(SPI_EEPROM, I2C_EEPROM)
-    return E2END + 1;
-  #elif DISABLED(SRAM_EEPROM_EMULATION)
-    return E2END + 1;
-  #else
-    return 4096; // 4kB
-  #endif
-} 
+  return (
+    #if ENABLED(SRAM_EEPROM_EMULATION)
+      4096 // 4kB
+    #else
+      E2END + 1
+    #endif
+  );
+}
 
-#endif // EEPROM_SETTINGS && FLASH_EEPROM_EMULATION
+#endif // EEPROM_SETTINGS && (FLASH_EEPROM_EMULATION || SRAM_EEPROM_EMULATION || SPI_EEPROM || I2C_EEPROM)
 #endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/HAL/HAL_STM32/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32/persistent_store_sdcard.cpp
@@ -22,6 +22,7 @@
 
 /**
  * HAL for stm32duino.com based on Libmaple and compatible (STM32F1)
+ * Implementation of EEPROM settings in SD Card
  */
 
 #ifdef TARGET_STM32F4
@@ -37,7 +38,8 @@
 #endif
 #define HAL_STM32F4_EEPROM_SIZE (E2END + 1)     //16K  size
 
-static char HAL_STM32F1_eeprom_content[HAL_STM32F4_EEPROM_SIZE];
+#define _ALIGN(x) __attribute__ ((aligned(x))) // SDIO uint32_t* compat.
+static char _ALIGN(4) HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
 
 #if ENABLED(SDSUPPORT)
 
@@ -99,5 +101,4 @@ bool PersistentStore::read_data(int &pos, uint8_t* value, const size_t size, uin
 size_t PersistentStore::capacity() { return HAL_STM32F4_EEPROM_SIZE; }
 
 #endif // EEPROM_SETTINGS
-
 #endif // __STM32F4__

--- a/Marlin/src/HAL/HAL_STM32/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32/persistent_store_sdcard.cpp
@@ -36,10 +36,10 @@
 #ifndef E2END
   #define E2END 0xFFF // 4KB
 #endif
-#define HAL_STM32F4_EEPROM_SIZE (E2END + 1)     //16K  size
+#define HAL_EEPROM_SIZE (E2END + 1) // 16KB
 
 #define _ALIGN(x) __attribute__ ((aligned(x))) // SDIO uint32_t* compat.
-static char _ALIGN(4) HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
+static char _ALIGN(4) HAL_eeprom_data[HAL_EEPROM_SIZE];
 
 #if ENABLED(SDSUPPORT)
 
@@ -54,10 +54,10 @@ static char _ALIGN(4) HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
     if (!file.open(&root, EEPROM_FILENAME, O_RDONLY))
       return false;
 
-    int16_t bytes_read = file.read(HAL_STM32F1_eeprom_content, HAL_STM32F4_EEPROM_SIZE);
+    int16_t bytes_read = file.read(HAL_eeprom_data, HAL_STM32F4_EEPROM_SIZE);
     if (bytes_read < 0) return false;
     for (; bytes_read < HAL_STM32F4_EEPROM_SIZE; bytes_read++)
-      HAL_STM32F1_eeprom_content[bytes_read] = 0xFF;
+      HAL_eeprom_data[bytes_read] = 0xFF;
     file.close();
     return true;
   }
@@ -68,7 +68,7 @@ static char _ALIGN(4) HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
     SdFile file, root = card.getroot();
     int16_t bytes_written = 0;
     if (file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC)) {
-      bytes_written = file.write(HAL_STM32F1_eeprom_content, HAL_STM32F4_EEPROM_SIZE);
+      bytes_written = file.write(HAL_eeprom_data, HAL_STM32F4_EEPROM_SIZE);
       file.close();
     }
     return (bytes_written == HAL_STM32F4_EEPROM_SIZE);
@@ -82,7 +82,7 @@ static char _ALIGN(4) HAL_STM32F1_eeprom_content[HAL_STM32F1_EEPROM_SIZE];
 
 bool PersistentStore::write_data(int &pos, const uint8_t *value, const size_t size, uint16_t *crc) {
   for (size_t i = 0; i < size; i++)
-    HAL_STM32F1_eeprom_content[pos + i] = value[i];
+    HAL_eeprom_data[pos + i] = value[i];
   crc16(crc, value, size);
   pos += size;
   return false;
@@ -90,7 +90,7 @@ bool PersistentStore::write_data(int &pos, const uint8_t *value, const size_t si
 
 bool PersistentStore::read_data(int &pos, uint8_t* value, const size_t size, uint16_t *crc, const bool writing/*=true*/) {
   for (size_t i = 0; i < size; i++) {
-    uint8_t c = HAL_STM32F1_eeprom_content[pos + i];
+    uint8_t c = HAL_eeprom_data[pos + i];
     if (writing) value[i] = c;
     crc16(crc, &c, 1);
   }

--- a/Marlin/src/HAL/HAL_STM32/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32/persistent_store_sdcard.cpp
@@ -1,0 +1,103 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * HAL for stm32duino.com based on Libmaple and compatible (STM32F1)
+ */
+
+#ifdef TARGET_STM32F4
+
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(EEPROM_SETTINGS) && NONE(FLASH_EEPROM_EMULATION, SPI_EEPROM, I2C_EEPROM)
+
+#include "../shared/persistent_store_api.h"
+
+#ifndef E2END
+  #define E2END 0xFFF // 4KB
+#endif
+#define HAL_STM32F4_EEPROM_SIZE (E2END + 1)     //16K  size
+
+static char HAL_STM32F1_eeprom_content[HAL_STM32F4_EEPROM_SIZE];
+
+#if ENABLED(SDSUPPORT)
+
+  #include "../../sd/cardreader.h"
+
+  #define EEPROM_FILENAME "eeprom.dat"
+
+  bool PersistentStore::access_start() {
+    if (!card.isDetected()) return false;
+
+    SdFile file, root = card.getroot();
+    if (!file.open(&root, EEPROM_FILENAME, O_RDONLY))
+      return false;
+
+    int16_t bytes_read = file.read(HAL_STM32F1_eeprom_content, HAL_STM32F4_EEPROM_SIZE);
+    if (bytes_read < 0) return false;
+    for (; bytes_read < HAL_STM32F4_EEPROM_SIZE; bytes_read++)
+      HAL_STM32F1_eeprom_content[bytes_read] = 0xFF;
+    file.close();
+    return true;
+  }
+
+  bool PersistentStore::access_finish() {
+    if (!card.isDetected()) return false;
+
+    SdFile file, root = card.getroot();
+    int16_t bytes_written = 0;
+    if (file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC)) {
+      bytes_written = file.write(HAL_STM32F1_eeprom_content, HAL_STM32F4_EEPROM_SIZE);
+      file.close();
+    }
+    return (bytes_written == HAL_STM32F4_EEPROM_SIZE);
+  }
+
+#else // !SDSUPPORT
+
+  #error "Please define SPI_EEPROM (in Configuration.h) or disable EEPROM_SETTINGS."
+
+#endif // !SDSUPPORT
+
+bool PersistentStore::write_data(int &pos, const uint8_t *value, const size_t size, uint16_t *crc) {
+  for (size_t i = 0; i < size; i++)
+    HAL_STM32F1_eeprom_content[pos + i] = value[i];
+  crc16(crc, value, size);
+  pos += size;
+  return false;
+}
+
+bool PersistentStore::read_data(int &pos, uint8_t* value, const size_t size, uint16_t *crc, const bool writing/*=true*/) {
+  for (size_t i = 0; i < size; i++) {
+    uint8_t c = HAL_STM32F1_eeprom_content[pos + i];
+    if (writing) value[i] = c;
+    crc16(crc, &c, 1);
+  }
+  pos += size;
+  return false;
+}
+
+size_t PersistentStore::capacity() { return HAL_STM32F4_EEPROM_SIZE; }
+
+#endif // EEPROM_SETTINGS
+
+#endif // __STM32F4__

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_PRO_V1.1.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_PRO_V1.1.h
@@ -29,8 +29,9 @@
 
 #define BOARD_NAME "BIGTREE SKR Pro 1.1"
 
-//#define SRAM_EEPROM_EMULATION                   //Use BackSRAM Emulation Eeprom Store Data Otherwise Use SDCard Emulation EEprom Store Data
-//#define FLASH_EEPROM_EMULATION                  //Use Flash Emulation Eeprom Store Data Otherwise Use SDCard Emulation EEprom Store Data
+// Use one of these or SDCard-based Emulation will be used
+//#define SRAM_EEPROM_EMULATION   // Use BackSRAM-based EEPROM emulation
+//#define FLASH_EEPROM_EMULATION  // Use Flash-based EEPROM emulation
 
 //
 // Servos

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_PRO_V1.1.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_PRO_V1.1.h
@@ -29,7 +29,8 @@
 
 #define BOARD_NAME "BIGTREE SKR Pro 1.1"
 
-#define SRAM_EEPROM_EMULATION
+//#define SRAM_EEPROM_EMULATION                   //Use BackSRAM Emulation Eeprom Store Data Otherwise Use SDCard Emulation EEprom Store Data
+//#define FLASH_EEPROM_EMULATION                  //Use Flash Emulation Eeprom Store Data Otherwise Use SDCard Emulation EEprom Store Data
 
 //
 // Servos


### PR DESCRIPTION
### Requirements
     1.Add SD card to simulate eeprom to store data drive file .
### Description
     1.Add sd card to simulate eeprom driver
     2.Modify SKR Pro V1.1 pin file, support SRAM, Flash, SD card simulation Eeprom storage data, three options
     3.If there is not perfect place, can help optimize, thank you
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
       1.An external eeprom chip or module is not required
<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
