### PR TITLE
STM32F1: Init EEPROM SPI pin modes

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_eeprom.cpp
@@ -26,7 +26,15 @@
 
 #include "../shared/persistent_store_api.h"
 
-bool PersistentStore::access_start() { return true; }
+bool PersistentStore::access_start() {
+  #if ENABLED(SPI_EEPROM)
+    SET_OUTPUT(BOARD_SPI1_SCK_PIN);
+    SET_OUTPUT(BOARD_SPI1_MOSI_PIN);
+    SET_INPUT(BOARD_SPI1_MISO_PIN);
+    SET_OUTPUT(SPI_EEPROM1_CS);
+  #endif
+  return true;
+}
 bool PersistentStore::access_finish() { return true; }
 
 bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {

--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_eeprom.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_eeprom.cpp
@@ -28,10 +28,13 @@
 
 bool PersistentStore::access_start() {
   #if ENABLED(SPI_EEPROM)
-    SET_OUTPUT(BOARD_SPI1_SCK_PIN);
-    SET_OUTPUT(BOARD_SPI1_MOSI_PIN);
-    SET_INPUT(BOARD_SPI1_MISO_PIN);
-    SET_OUTPUT(SPI_EEPROM1_CS);
+    #if SPI_CHAN_EEPROM1 == 1
+      SET_OUTPUT(BOARD_SPI1_SCK_PIN);
+      SET_OUTPUT(BOARD_SPI1_MOSI_PIN);
+      SET_INPUT(BOARD_SPI1_MISO_PIN);
+      SET_OUTPUT(SPI_EEPROM1_CS);
+    #endif
+    spiInit(0);
   #endif
   return true;
 }


### PR DESCRIPTION
Marlin/src/HAL/shared/SpiEeprom.cpp only use WRITE()
which doesn't set the gpio input/outputs on start.
