### PR TITLE
Fix a memset pointer cast

### DIFF
--- a/Marlin/src/HAL/HAL_SAMD51/Servo_SAMD51.cpp
+++ b/Marlin/src/HAL/HAL_SAMD51/Servo_SAMD51.cpp
@@ -163,7 +163,7 @@ void initISR(timer16_Sequence_t timer) {
     SYNC(tc->COUNT16.SYNCBUSY.bit.CTRLB);
 
     // Reset all servo indexes
-    memset(currentServoIndex, 0xFF, sizeof(currentServoIndex));
+    memset((void *)currentServoIndex, 0xFF, sizeof(currentServoIndex));
 
     // Configure interrupt request
     NVIC_ClearPendingIRQ(SERVO_IRQn);


### PR DESCRIPTION
Don't know why but vscode refuse to compile this. I'm almost sure it compiled correctly before within visual studio