### PR TITLE
Fix 16-bit range check in TMenuItem::action_edit for 32-bit boards

### DIFF
--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -191,8 +191,8 @@ class TMenuItem : MenuItemBase {
   public:
     static void action_edit(PGM_P const pstr, type_t * const ptr, const type_t minValue, const type_t maxValue, const screenFunc_t callback=nullptr, const bool live=false) {
       // Make sure minv and maxv fit within int16_t
-      const int32_t minv = _MAX(scale(minValue), INT_MIN),
-                    maxv = _MIN(scale(maxValue), INT_MAX);
+      const int32_t minv = _MAX(scale(minValue), INT16_MIN),
+                    maxv = _MIN(scale(maxValue), INT16_MAX);
       init(pstr, ptr, minv, maxv - minv, scale(*ptr) - minv, edit, callback, live);
     }
     static void edit() { MenuItemBase::edit(to_string, load); }


### PR DESCRIPTION
This was previously checking against a 32-bit range. This allowed incrementing beyond the range of encoderPosition, causing unexpected wraparound behavior.

### Description

This fixes the menu item range check for 32-bit processors. The comment in this function claims to range-check for `int16_t`, but it actually checked the range against `int`. This worked for AVR, but is incorrect for 32-bit boards.

### Benefits

On 32-bit boards, this prevents the value being editing from overflowing encoderPosition, before reaching the a min/max value. When editing the value, it now stops at the actual possible maximum, rather than wrapping back around to the minimum. This should make the behavior consistent with AVR boards.

The experience is still not good if the existing value falls outside the possible encoder range. In this situation the value will be coerced to the minimum value, effectively losing the user's setting. Additional code changes would be needed to prevent this, or to increase the range of the encoder.

### Related Issues

This fixes the wrap-around symptom described in issue #14821.
I would not consider the issue resolved unless more work is done to allow the larger range, or at least prevent the loss of an existing value if it cannot be edited from the menu.
