### PR TITLE
Non-fatal error from ps::access_start, fix test_index typo

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/persistent_store_sdcard.cpp
@@ -52,7 +52,7 @@ static char _ALIGN(4) HAL_eeprom_data[HAL_EEPROM_SIZE];
 
     SdFile file, root = card.getroot();
     if (!file.open(&root, EEPROM_FILENAME, O_RDONLY))
-      return false;
+      return true; // false aborts the save
 
     int bytes_read = file.read(HAL_eeprom_data, HAL_EEPROM_SIZE);
     if (bytes_read < 0) return false;

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -450,7 +450,7 @@ void MarlinSettings::postprocess() {
   #define WORD_PADDED_EEPROM ENABLED(__STM32F1__, FLASH_EEPROM_EMULATION)
 
   #if WORD_PADDED_EEPROM && ENABLED(DEBUG_EEPROM_READWRITE)
-    #define UPDATE_TEST_INDEX(VAR) (text_index += sizeof(VAR))
+    #define UPDATE_TEST_INDEX(VAR) (test_index += sizeof(VAR))
   #else
     #define UPDATE_TEST_INDEX(VAR) NOOP
   #endif


### PR DESCRIPTION
Variant of the PR #14824, required since the PR #14776 (31 july)

The EEPROM_START() macro in ::save() can now abort the save if if the EEPROM.dat file doesn't exist on the SD

the typo is only seen with DEBUG_EEPROM_READWRITE
