### PR TITLE
[2.0.x] Autobuild formatting update

### DIFF
--- a/buildroot/share/atom/auto_build.py
+++ b/buildroot/share/atom/auto_build.py
@@ -707,7 +707,7 @@ def line_print(line_input):
           if r_loc > 0 and r_loc < len(text):  # need to split this line
             text = text.split('\r')
             for line in text:
-              if not(line == ""):
+              if line != "":
                 write_to_screen_queue(line + '\n')
           else:
             write_to_screen_queue(text + '\n')

--- a/buildroot/share/atom/auto_build.py
+++ b/buildroot/share/atom/auto_build.py
@@ -660,7 +660,9 @@ def line_print(line_input):
       platformio_highlights = [
               ['Environment', 0, 'highlight_blue'],
               ['[SKIP]', 1, 'warning'],
+              ['[IGNORED]', 1, 'warning'],
               ['[ERROR]', 1, 'error'],
+              ['[FAILED]', 1, 'error'],
               ['[SUCCESS]', 1, 'highlight_green']
       ]
 
@@ -698,14 +700,15 @@ def line_print(line_input):
               found_right = text.find(']', found + 1)
               write_to_screen_queue(text[               : found + 1   ])
               write_to_screen_queue(text[found + 1      : found_right ], highlight[2])
-              write_to_screen_queue(text[found_right :                ] + '\n')
+              write_to_screen_queue(text[found_right :                ] + '\n' + '\n')
             break
         if did_something == False:
           r_loc = text.find('\r') + 1
           if r_loc > 0 and r_loc < len(text):  # need to split this line
             text = text.split('\r')
             for line in text:
-              write_to_screen_queue(line + '\n')
+              if not(line == ""):
+                write_to_screen_queue(line + '\n')
           else:
             write_to_screen_queue(text + '\n')
       # end - write_to_screen_with_replace


### PR DESCRIPTION
The new version of PlatformIO made some changes that threw off the formatting of the Autobuild script's display window. 
- In the SUMMARY section at the end the names of the results changed from SKIP to IGNORED and ERROR to FAILED.  The new names were added to the list of items needing special color handling.
- "\r\r" is now showing up which results in unwanted blank lines.  A test was added that kills blank lines.
- Killing all blank lines resulted in one place that wasn't as readable as before.  A '\n' was added to the display write for that place.

The same changes are being done for bugfix-1.1.x via PR #14859.