### PR TITLE
Fix thermistor names (info menu)

### DIFF
--- a/Marlin/src/lcd/thermistornames.h
+++ b/Marlin/src/lcd/thermistornames.h
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
 
 /**
  * thermistornames.h


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
Remove #pragma once in thermistornames.h file, that was added Jul 5th.
this file is included multiple times in menu_info.cpp to get the thermistor names of the various sensors. Having pragma once means all the names are the same as the first thermistor.

### Benefits

Thermistor names are displayed correctly in menu thermistor info

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
