### PR TITLE
STM32F1: Dummy SoftwareSerial (as TMCStepper fallback)

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.cpp
@@ -1,0 +1,60 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifdef __STM32F1__
+
+/**
+ * Empty class for Software Serial implementation (Custom RX/TX pins)
+ *
+ * TODO: Optionally use https://github.com/FYSETC/SoftwareSerialM if TMC UART is wanted
+ */
+
+#include "SoftwareSerial.h"
+
+// Constructor
+
+SoftwareSerial::SoftwareSerial(pin_t RX_pin, pin_t TX_pin) {}
+
+// Public
+
+void SoftwareSerial::begin(const uint32_t baudrate) {
+}
+
+bool SoftwareSerial::available() {
+  return false;
+}
+
+uint8_t SoftwareSerial::read() {
+  return 0;
+}
+
+uint16_t SoftwareSerial::write(uint8_t byte) {
+  return 0;
+}
+
+void SoftwareSerial::flush() {}
+
+void SoftwareSerial::listen() {
+  listening = true;
+}
+
+void SoftwareSerial::stopListening() {
+  listening = false;
+}
+
+#endif //__STM32F1__

--- a/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.h
+++ b/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.h
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
+
 #include "HAL.h"
 
 #define SW_SERIAL_PLACEHOLDER 1

--- a/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.h
+++ b/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.h
@@ -1,0 +1,38 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#include "HAL.h"
+
+class SoftwareSerial {
+public:
+  SoftwareSerial(pin_t RX_pin, pin_t TX_pin);
+
+  void begin(const uint32_t baudrate);
+
+  bool available();
+
+  uint8_t read();
+  uint16_t write(uint8_t byte);
+  void flush();
+
+  void listen();
+  void stopListening();
+
+protected:
+  bool listening;
+};

--- a/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.h
+++ b/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.h
@@ -18,6 +18,8 @@
  */
 #include "HAL.h"
 
+#define SW_SERIAL_PLACEHOLDER 1
+
 class SoftwareSerial {
 public:
   SoftwareSerial(pin_t RX_pin, pin_t TX_pin);


### PR DESCRIPTION
Latest TMCStepper lib includes a lib not available on the F1 for Arduino... so lets simulate it for now...