### PR TITLE
Allow py scripts to handle spaces in paths

### DIFF
--- a/buildroot/share/PlatformIO/scripts/alfawise_Ux0.py
+++ b/buildroot/share/PlatformIO/scripts/alfawise_Ux0.py
@@ -23,4 +23,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         marlin_alfa.close()
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);
+env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);

--- a/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
+++ b/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
@@ -15,8 +15,8 @@ env.AddPostAction(
 				"$OBJCOPY",
 				"-O",
 				"ihex",
-				"$BUILD_DIR/${PROGNAME}.elf",
-				"$BUILD_DIR/${PROGNAME}.hex"
+				'"$BUILD_DIR/${PROGNAME}.elf"',
+				'"$BUILD_DIR/${PROGNAME}.hex"'
 			]), "Building $TARGET"))
 
 # please keep $SOURCE variable, it will be replaced with a path to firmware

--- a/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
+++ b/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
@@ -39,5 +39,5 @@ def addboot(source,target,env):
 	os.rename(target[0].path, firmware_without_bootloader_dir)
 	#os.rename(target[0].dir.path+'/firmware_with_bootloader.bin', target[0].dir.path+'/firmware.bin')
 
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", addboot);
+env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', addboot);
 

--- a/buildroot/share/PlatformIO/scripts/mks_robin.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin.py
@@ -27,4 +27,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         robin.close()
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);
+env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);

--- a/buildroot/share/PlatformIO/scripts/mks_robin_lite.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_lite.py
@@ -27,4 +27,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         robin.close()
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);
+env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);

--- a/buildroot/share/PlatformIO/scripts/mks_robin_mini.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_mini.py
@@ -27,4 +27,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         robin.close()
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);
+env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);

--- a/buildroot/share/PlatformIO/scripts/mks_robin_nano.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_nano.py
@@ -27,4 +27,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         robin.close()
-env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);
+env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);


### PR DESCRIPTION
Fix an issue where spaces in paths would break some build scripts. Solution from @jmz52 at #14697.