### PR TITLE
Remove PlatformIO folder structure override

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
@@ -17,7 +17,7 @@ def print_error(e):
     print('\nUnable to find destination disk (' + e + ')\n' \
           'Please select it in platformio.ini using the upload_port keyword ' \
           '(https://docs.platformio.org/en/latest/projectconf/section_env_upload.html) ' \
-          'or copy the firmware (.pioenvs/' + env.get('PIOENV') + '/firmware.bin) manually to the appropriate disk\n')
+          'or copy the firmware (.pio/build/' + env.get('PIOENV') + '/firmware.bin) manually to the appropriate disk\n')
 
 try:
     if current_OS == 'Windows':

--- a/buildroot/bin/env_clean
+++ b/buildroot/bin/env_clean
@@ -3,6 +3,7 @@
 rm -rf .pioenvs
 rm -rf .piolibdeps
 rm -rf .piolib
+rm -rf .pio
 
 if [[ $1 = "--deep" ]]; then
   rm -rf ~/.platformio/packages/*

--- a/buildroot/share/atom/auto_build.py
+++ b/buildroot/share/atom/auto_build.py
@@ -421,17 +421,17 @@ def open_file(path):
 def get_build_last():
       env_last = ''
       DIR_PWD = os.listdir('.')
-      if '.pioenvs' in DIR_PWD:
+      if '.pio' in DIR_PWD:
         date_last = 0.0
-        DIR__pioenvs = os.listdir('.pioenvs')
+        DIR__pioenvs = os.listdir('.pio')
         for name in DIR__pioenvs:
           if 0 <= name.find('.') or 0 <= name.find('-'):   # skip files in listing
             continue
-          DIR_temp = os.listdir('.pioenvs/' + name)
+          DIR_temp = os.listdir('.pio/build/' + name)
           for names_temp in DIR_temp:
 
             if 0 == names_temp.find('firmware.'):
-              date_temp = os.path.getmtime('.pioenvs/' + name + '/' + names_temp)
+              date_temp = os.path.getmtime('.pio/build/' + name + '/' + names_temp)
               if date_temp > date_last:
                 date_last = date_temp
                 env_last = name

--- a/buildroot/share/atom/create_custom_upload_command_CDC.py
+++ b/buildroot/share/atom/create_custom_upload_command_CDC.py
@@ -97,7 +97,7 @@ else:
       avrdude_exe_path =  'buildroot\\share\\atom\\avrdude_5.10.exe'
 
   #    source_path = env.get("PROJECTBUILD_DIR") + '\\' + env.get("PIOENV") + '\\firmware.hex'
-      source_path =  '.pioenvs\\' + env.get("PIOENV") + '\\firmware.hex'
+      source_path =  '.pio\\build\\' + env.get("PIOENV") + '\\firmware.hex'
 
       upload_string = avrdude_exe_path + ' -p usb1286 -c avr109 -P ' + com_CDC + ' -U flash:w:' + source_path + ':i'
 
@@ -113,7 +113,7 @@ else:
       avrdude_exe_path =  'buildroot/share/atom/avrdude_5.10_macOS'
 
 #      source_path = env.get("PROJECTBUILD_DIR") + '/' + env.get("PIOENV") + '/firmware.hex'
-      source_path = '.pioenvs/' + env.get("PIOENV") + '/firmware.hex'
+      source_path = '.pio/build/' + env.get("PIOENV") + '/firmware.hex'
 
 
 #      upload_string = 'avrdude -p usb1286 -c avr109 -P ' + com_CDC + ' -U flash:w:' + source_path + ':i'
@@ -132,7 +132,7 @@ else:
 
       avrdude_exe_path =  'buildroot/share/atom/avrdude_5.10_linux'
 #      source_path = env.get("PROJECTBUILD_DIR") + '/' + env.get("PIOENV") + '/firmware.hex'
-      source_path = '.pioenvs/' + env.get("PIOENV") + '/firmware.hex'
+      source_path = '.pio/build/' + env.get("PIOENV") + '/firmware.hex'
 
 #      upload_string = 'avrdude -p usb1286 -c avr109 -P ' + com_CDC + ' -U flash:w:' + source_path + ':i'
       upload_string = avrdude_exe_path + ' -p usb1286 -c avr109 -P ' + com_CDC + ' -C ' + avrdude_conf_path  + ' -U flash:w:' + source_path + ':i'

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,9 +17,6 @@
 
 [platformio]
 src_dir      = Marlin
-build_dir    = .pioenvs
-lib_dir      = .piolib
-libdeps_dir  = .piolibdeps
 boards_dir   = buildroot/share/PlatformIO/boards
 default_envs = megaatmega2560
 


### PR DESCRIPTION
### Description
PlatformIO 4 introduced changes to its folder hierarchy to fix interenvironment library conflicts we are currently overriding, just remove the override and let PlatformIO do what it wants.