### PR TITLE
Ensure easter egg stays hidden

### DIFF
--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -240,6 +240,7 @@ void menu_info() {
     #if ENABLED(GAMES_EASTER_EGG)
       MENU_ITEM_DUMMY();
       MENU_ITEM_DUMMY();
+      MENU_ITEM_DUMMY();
     #endif
     MENU_ITEM(submenu, MSG_GAMES, (
       #if HAS_GAME_MENU


### PR DESCRIPTION
Adds an extra dummy item. When ENABLED(LCD_PRINTER_INFO_IS_BOOTSCREEN) and DISABLED(PRINTCOUNTER), there are only two items in the menu, so three dummy items are needed to push the games menu out of the visible area on a 5-line graphical display.

Although it may be possible to make something more sophisticated that dynamically adjusts the number of dummy items, I think this fix is good enough. At worst case, some folks may need to scroll a bit further to find the easter egg...