### PR TITLE
Cleanup

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -594,32 +594,6 @@
   #define INVERT_E_DIR false
 #endif
 
-#if ENABLED(HOST_ACTION_COMMANDS)
-  #ifndef ACTION_ON_PAUSE
-    #define ACTION_ON_PAUSE   "pause"
-  #endif
-  #ifndef ACTION_ON_RESUME
-    #define ACTION_ON_RESUME  "resume"
-  #endif
-  #ifndef ACTION_ON_PAUSED
-    #define ACTION_ON_PAUSED  "paused"
-  #endif
-  #ifndef ACTION_ON_RESUMED
-    #define ACTION_ON_RESUMED "resumed"
-  #endif
-  #ifndef ACTION_ON_CANCEL
-    #define ACTION_ON_CANCEL  "cancel"
-  #endif
-  #if ENABLED(G29_RETRY_AND_RECOVER)
-    #ifndef ACTION_ON_G29_RECOVER
-      #define ACTION_ON_G29_RECOVER "probe_rewipe"
-    #endif
-    #ifndef ACTION_ON_G29_FAILURE
-      #define ACTION_ON_G29_FAILURE "probe_failed"
-    #endif
-  #endif
-#endif
-
 #if ENABLED(SLIM_LCD_MENUS)
   #define BOOT_MARLIN_LOGO_SMALL
 #endif

--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -269,7 +269,7 @@ void MarlinUI::set_custom_characters(const HD44780CharSet screen_charset/*=CHARS
 
   #endif // LCD_PROGRESS_BAR
 
-  #if ENABLED(SDSUPPORT)
+  #if ENABLED(SDSUPPORT) && HAS_LCD_MENU
 
     // CHARSET_MENU
     const static PROGMEM byte refresh[8] = {
@@ -319,7 +319,7 @@ void MarlinUI::set_custom_characters(const HD44780CharSet screen_charset/*=CHARS
       #endif
         {
           createChar_P(LCD_STR_UPLEVEL[0], uplevel);
-          #if ENABLED(SDSUPPORT)
+          #if ENABLED(SDSUPPORT) && HAS_LCD_MENU
             // SD Card sub-menu special characters
             createChar_P(LCD_STR_REFRESH[0], refresh);
             createChar_P(LCD_STR_FOLDER[0], folder);


### PR DESCRIPTION
- multiple declaration removes `Conditionals_LCD.h` and` Conditionals_adv.h`
- If `NO_LCD_MENUS` ENABLED is not needed SD Card sub-menu