### PR TITLE
Fix BigTreeTech STM32F407_5X / PB5 pin

### DIFF
--- a/buildroot/share/PlatformIO/variants/BIGTREE_GENERIC_STM32F407_5X/variant.h
+++ b/buildroot/share/PlatformIO/variants/BIGTREE_GENERIC_STM32F407_5X/variant.h
@@ -110,7 +110,7 @@ extern const PinName digitalPin[];
   #define PD2   43 //1:UART5_RX / SDIO_CMD
   #define PB3   44 //0:JTDO  1:SPI3_SCK / TIM2_CH2 / SPI1_SCK
   #define PB4   45 //0:NJTRST  1:SPI3_MISO / TIM3_CH1 / SPI1_MISO
-  #define PB5   45 //1:TIM3_CH2 / SPI1_MOSI / SPI3_MOSI
+  #define PB5   46 //1:TIM3_CH2 / SPI1_MOSI / SPI3_MOSI
   #define PB6   47 //1:I2C1_SCL / TIM4_CH1 / USART1_TX
   #define PB7   48 //1:I2C1_SDA / TIM4_CH2 / USART1_RX
   #define PB8   49 //1:I2C1_SCL / TIM4_CH3 / SDIO_D4 / TIM10_CH1


### PR DESCRIPTION
### Description

The PB4 and PB5 pins are set to the same number: 45. This sets PB5 to 46.

### Related Issues

Fix #14890