### PR TITLE
Allow use of Fysetc SoftwareSerialM

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/SoftwareSerial.cpp
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#ifdef __STM32F1__
+#if defined(__STM32F1__) && !defined(HAVE_SW_SERIAL)
 
 /**
  * Empty class for Software Serial implementation (Custom RX/TX pins)

--- a/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
+++ b/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
@@ -1,8 +1,6 @@
 from os.path import join
 Import("env", "projenv")
 
-platform = env.PioPlatform()
-
 # Relocate firmware from 0x08000000 to 0x08002000
 #env['CPPDEFINES'].remove(("VECT_TAB_ADDR", 134217728))
 #env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08010000"))
@@ -29,10 +27,8 @@ env.AddPostAction(
 
 # In-line command with arguments
 env.Replace(
-	UPLOADER=platform.get_package_dir("tool-stm32duino") + '/stm32flash/stm32flash',
-	UPLOADCMD='"${UPLOADER}" -v -i rts,-dtr,dtr,-rts -R -b 115200 -g 0x8000000 -w "${BUILD_DIR}/${PROGNAME}.hex" ${UPLOAD_PORT}'
+	UPLOADCMD="stm32flash -v -i rts,-dtr,dtr " + '$UPLOAD_PORT' + " -R -w " + join("$BUILD_DIR","${PROGNAME}.hex")
 )
-
 
 # Python callback
 #def on_upload(source, target, env):

--- a/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
+++ b/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
@@ -1,4 +1,5 @@
 from os.path import join
+from os.path import expandvars
 Import("env", "projenv")
 
 # Relocate firmware from 0x08000000 to 0x08002000
@@ -8,14 +9,11 @@ Import("env", "projenv")
 
 # Custom HEX from ELF
 env.AddPostAction(
-	"$BUILD_DIR/${PROGNAME}.elf",
+	join("$BUILD_DIR","${PROGNAME}.elf"),
 	env.VerboseAction(" ".join([
-				"$OBJCOPY",
-				"-O",
-				"ihex",
-				'"$BUILD_DIR/${PROGNAME}.elf"',
-				'"$BUILD_DIR/${PROGNAME}.hex"'
-			]), "Building $TARGET"))
+		"$OBJCOPY", "-O ihex", "$TARGET", # TARGET=.pio/build/fysetc_STM32F1/firmware.elf
+		"'" + join("$BUILD_DIR","${PROGNAME}.hex") + "'", # Note: $BUILD_DIR is a full path
+	]), "Building $TARGET"))
 
 # please keep $SOURCE variable, it will be replaced with a path to firmware
 
@@ -26,8 +24,14 @@ env.AddPostAction(
 #)
 
 # In-line command with arguments
+UPLOAD_TOOL="stm32flash"
+platform = env.PioPlatform()
+if platform.get_package_dir("tool-stm32duino") != None:
+	UPLOAD_TOOL=expandvars("'" + join(platform.get_package_dir("tool-stm32duino"),"stm32flash","stm32flash") + "'")
+
 env.Replace(
-	UPLOADCMD="stm32flash -v -i rts,-dtr,dtr " + '$UPLOAD_PORT' + " -R -w " + join("$BUILD_DIR","${PROGNAME}.hex")
+	UPLOADER=UPLOAD_TOOL,
+	UPLOADCMD=expandvars(UPLOAD_TOOL + " -v -i rts,-dtr,dtr $UPLOAD_PORT -R -w '" + join("$BUILD_DIR","${PROGNAME}.hex") + "'")
 )
 
 # Python callback

--- a/platformio.ini
+++ b/platformio.ini
@@ -280,11 +280,10 @@ monitor_speed = 250000
 platform      = ststm32
 framework     = arduino
 board         = genericSTM32F103RC
-#board_build.core = maple
 extra_scripts = buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   ${common.build_flags} -std=gnu++14
-  -DDEBUG_LEVEL=0
+  -DDEBUG_LEVEL=0 -DHAVE_SW_SERIAL
 build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip


### PR DESCRIPTION
When testing that, i had a python error (on ubuntu 18.04), so i fixed it...

```
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str':
  File "/usr/local/lib/python2.7/dist-packages/platformio/builder/main.py", line 134:
    env.SConscript(item, exports="env")
  File "~/.platformio/packages/tool-scons/script/../engine/SCons/Script/SConscript.py", line 541:
    return _SConscript(self.fs, *files, **subst_kw)
  File "~/.platformio/packages/tool-scons/script/../engine/SCons/Script/SConscript.py", line 250:
    exec _file_ in call_stack[-1].globals
  File "Marlin/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py", line 32:
    UPLOADER=platform.get_package_dir("tool-stm32duino") + "/stm32flash/stm32flash",
```
