### PR TITLE
Tevo Michelangelo config updates

### DIFF
--- a/config/examples/Tevo/Michelangelo/Configuration.h
+++ b/config/examples/Tevo/Michelangelo/Configuration.h
@@ -1334,8 +1334,8 @@
 #endif
 
 // Homing speeds (mm/m)
-#define HOMING_FEEDRATE_XY (50*60)
-#define HOMING_FEEDRATE_Z  (4*60)
+#define HOMING_FEEDRATE_XY (120*60)
+#define HOMING_FEEDRATE_Z  (30*60)
 
 // Validate that endstops are triggered on homing moves
 #define VALIDATE_HOMING_ENDSTOPS

--- a/config/examples/Tevo/Michelangelo/Configuration.h
+++ b/config/examples/Tevo/Michelangelo/Configuration.h
@@ -1686,7 +1686,7 @@
 //
 //  Set this option if CLOCKWISE causes values to DECREASE
 //
-#define REVERSE_ENCODER_DIRECTION
+//#define REVERSE_ENCODER_DIRECTION
 
 //
 // This option reverses the encoder direction for navigating LCD menus.


### PR DESCRIPTION
### Description

Disable `REVERSE_ENCODER_DIRECTION` for Tevo Michelangelo and increase homing feedrates.

### Benefits

Menu selection now moves in the correct direction & printer homes as fast as it did with the  stock firmware.

### Related Issues

None.