### PR TITLE
Clean up Touch pins. Better up/down touch response.

### DIFF
--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -63,10 +63,6 @@ void XPT2046::init(void) {
 uint8_t XPT2046::read_buttons() {
   int16_t tsoffsets[4] = { 0 };
 
-  static uint32_t touchtimeout = 0;
-  if (PENDING(millis(), touchtimeout)) return 0;
-  touchtimeout = millis() + 80; // ideally want to set this lower for the games... 30 or 40.
-
   if (tsoffsets[0] + tsoffsets[1] == 0) {
     // Not yet set, so use defines as fallback...
     tsoffsets[0] = XPT2046_X_CALIBRATION;
@@ -84,9 +80,9 @@ uint8_t XPT2046::read_buttons() {
 
   if (y < 175 || y > 234) return 0;
 
-       if (WITHIN(x,  11, 109)) encoderDiff = -(ENCODER_STEPS_PER_MENU_ITEM) * ENCODER_PULSES_PER_STEP;
-  else if (WITHIN(x, 111, 209)) encoderDiff =   ENCODER_STEPS_PER_MENU_ITEM  * ENCODER_PULSES_PER_STEP;
-  else if (WITHIN(x, 211, 309)) return EN_C;
+  if (WITHIN(x,  11, 109)) return EN_A; //encoderDiff = -(ENCODER_STEPS_PER_MENU_ITEM) * ENCODER_PULSES_PER_STEP;
+  if (WITHIN(x, 111, 209)) return EN_B; //encoderDiff =   ENCODER_STEPS_PER_MENU_ITEM  * ENCODER_PULSES_PER_STEP;
+  if (WITHIN(x, 211, 309)) return EN_C;
   return 0;
 }
 

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -80,10 +80,10 @@ uint8_t XPT2046::read_buttons() {
 
   if (y < 175 || y > 234) return 0;
 
-  if (WITHIN(x,  11, 109)) return EN_A; //encoderDiff = -(ENCODER_STEPS_PER_MENU_ITEM) * ENCODER_PULSES_PER_STEP;
-  if (WITHIN(x, 111, 209)) return EN_B; //encoderDiff =   ENCODER_STEPS_PER_MENU_ITEM  * ENCODER_PULSES_PER_STEP;
-  if (WITHIN(x, 211, 309)) return EN_C;
-  return 0;
+  return WITHIN(x,  11, 109) ? EN_A
+       : WITHIN(x, 111, 209) ? EN_B
+       : WITHIN(x, 211, 309) ? EN_C
+       : 0;
 }
 
 bool XPT2046::isTouched() {

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -764,7 +764,35 @@ void MarlinUI::update() {
 
     // If the action button is pressed...
     static bool wait_for_unclick; // = 0
-    if (!external_control && button_pressed()) {
+    if (touch_buttons) {
+      if ((buttons & EN_A) || (buttons & EN_B)) {
+        if (ELAPSED(millis(), next_button_update_ms)) {
+          if (buttons & EN_A) 
+            encoderDiff = -(ENCODER_STEPS_PER_MENU_ITEM) * ENCODER_PULSES_PER_STEP;
+          else
+            encoderDiff = ENCODER_STEPS_PER_MENU_ITEM * ENCODER_PULSES_PER_STEP;
+
+          if (!wait_for_unclick) {
+            next_button_update_ms = millis() + 300;
+            #if HAS_BUZZER
+              buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
+            #endif
+            wait_for_unclick = true;                      //  - Set debounce flag to ignore continous clicks
+          }
+          else
+            next_button_update_ms = millis() + 50;
+        }
+      }
+      if (buttons & EN_C) {
+        if (!wait_for_unclick) {                        // If not waiting for a debounce release:
+          wait_for_unclick = true;                      //  - Set debounce flag to ignore continous clicks
+          lcd_clicked = !wait_for_user && !no_reentry;  //  - Keep the click if not waiting for a user-click
+          wait_for_user = false;                        //  - Any click clears wait for user
+          quick_feedback();                             //  - Always make a click sound
+        }
+      }
+    }
+    else if (!external_control && button_pressed()) {
       if (!wait_for_unclick) {                        // If not waiting for a debounce release:
         wait_for_unclick = true;                      //  - Set debounce flag to ignore continous clicks
         lcd_clicked = !wait_for_user && !no_reentry;  //  - Keep the click if not waiting for a user-click

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -777,7 +777,7 @@ void MarlinUI::update() {
         const millis_t ms = millis();
         if (ELAPSED(ms, next_button_update_ms)) {
           next_button_update_ms = ms + 50;
-          encoderDiff = ENCODER_STEPS_PER_MENU_ITEM * ENCODER_PULSES_PER_STEP;
+          encoderDiff = (ENCODER_STEPS_PER_MENU_ITEM) * (ENCODER_PULSES_PER_STEP);
           if (buttons & EN_A) encoderDiff *= -1;
           if (!wait_for_unclick) {
             next_button_update_ms += 250;
@@ -789,12 +789,17 @@ void MarlinUI::update() {
         }
       }
     }
-    else if (!external_control && button_pressed()) {
-      if (!wait_for_unclick) {                        // If not waiting for a debounce release:
-        wait_for_unclick = true;                      //  - Set debounce flag to ignore continous clicks
-        lcd_clicked = !wait_for_user && !no_reentry;  //  - Keep the click if not waiting for a user-click
-        wait_for_user = false;                        //  - Any click clears wait for user
-        quick_feedback();                             //  - Always make a click sound
+    else {
+      //
+      // Integrated LCD click handling via button_pressed()
+      //
+      if (!external_control && button_pressed()) {
+        if (!wait_for_unclick) {                        // If not waiting for a debounce release:
+          wait_for_unclick = true;                      //  - Set debounce flag to ignore continous clicks
+          lcd_clicked = !wait_for_user && !no_reentry;  //  - Keep the click if not waiting for a user-click
+          wait_for_user = false;                        //  - Any click clears wait for user
+          quick_feedback();                             //  - Always make a click sound
+        }
       }
     }
     else wait_for_unclick = false;
@@ -809,7 +814,9 @@ void MarlinUI::update() {
   #endif // HAS_LCD_MENU
 
   #if ENABLED(INIT_SDCARD_ON_BOOT)
-
+    //
+    // SPI SD Card detection (and first card init when the LCD is present)
+    //
     const uint8_t sd_status = (uint8_t)IS_SD_INSERTED();
     if (sd_status != lcd_sd_status && detected()) {
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -765,30 +765,27 @@ void MarlinUI::update() {
     // If the action button is pressed...
     static bool wait_for_unclick; // = 0
     if (touch_buttons) {
-      if ((buttons & EN_A) || (buttons & EN_B)) {
-        if (ELAPSED(millis(), next_button_update_ms)) {
-          if (buttons & EN_A) 
-            encoderDiff = -(ENCODER_STEPS_PER_MENU_ITEM) * ENCODER_PULSES_PER_STEP;
-          else
-            encoderDiff = ENCODER_STEPS_PER_MENU_ITEM * ENCODER_PULSES_PER_STEP;
-
-          if (!wait_for_unclick) {
-            next_button_update_ms = millis() + 300;
-            #if HAS_BUZZER
-              buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
-            #endif
-            wait_for_unclick = true;                      //  - Set debounce flag to ignore continous clicks
-          }
-          else
-            next_button_update_ms = millis() + 50;
-        }
-      }
       if (buttons & EN_C) {
         if (!wait_for_unclick) {                        // If not waiting for a debounce release:
           wait_for_unclick = true;                      //  - Set debounce flag to ignore continous clicks
           lcd_clicked = !wait_for_user && !no_reentry;  //  - Keep the click if not waiting for a user-click
           wait_for_user = false;                        //  - Any click clears wait for user
           quick_feedback();                             //  - Always make a click sound
+        }
+      }
+      else if (buttons & (EN_A | EN_B)) {               // Ignore the encoder if clicked, to prevent "slippage"
+        const millis_t ms = millis();
+        if (ELAPSED(ms, next_button_update_ms)) {
+          next_button_update_ms = ms + 50;
+          encoderDiff = ENCODER_STEPS_PER_MENU_ITEM * ENCODER_PULSES_PER_STEP;
+          if (buttons & EN_A) encoderDiff *= -1;
+          if (!wait_for_unclick) {
+            next_button_update_ms += 250;
+            #if HAS_BUZZER
+              buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ);
+            #endif
+            wait_for_unclick = true;                      //  - Set debounce flag to ignore continous clicks
+          }
         }
       }
     }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -151,7 +151,7 @@
 
   #define BUTTON_PRESSED(BN) !READ(BTN_## BN)
 
-  #if BUTTON_EXISTS(ENC)
+  #if BUTTON_EXISTS(ENC) || ENABLED(TOUCH_BUTTONS)
     #define BLEN_C 2
     #define EN_C _BV(BLEN_C)
   #endif

--- a/Marlin/src/pins/stm32/pins_JGAURORA_A5S_A1.h
+++ b/Marlin/src/pins/stm32/pins_JGAURORA_A5S_A1.h
@@ -122,7 +122,7 @@
 // Touch support
 //
 #if ENABLED(TOUCH_BUTTONS)
-//#define BTN_ENC          PA11   // Real pin needed to enable encoder's push button functionality used by touch screen. PA11 gives stable value.
+  //#define BTN_ENC        PA11   // Real pin needed to enable encoder's push button functionality used by touch screen. PA11 gives stable value.
   #define TOUCH_CS_PIN     PA4
   #define TOUCH_INT_PIN    PC4
 #endif

--- a/Marlin/src/pins/stm32/pins_JGAURORA_A5S_A1.h
+++ b/Marlin/src/pins/stm32/pins_JGAURORA_A5S_A1.h
@@ -122,7 +122,6 @@
 // Touch support
 //
 #if ENABLED(TOUCH_BUTTONS)
-  //#define BTN_ENC        PA11   // Real pin needed to enable encoder's push button functionality used by touch screen. PA11 gives stable value.
   #define TOUCH_CS_PIN     PA4
   #define TOUCH_INT_PIN    PC4
 #endif

--- a/Marlin/src/pins/stm32/pins_JGAURORA_A5S_A1.h
+++ b/Marlin/src/pins/stm32/pins_JGAURORA_A5S_A1.h
@@ -122,7 +122,7 @@
 // Touch support
 //
 #if ENABLED(TOUCH_BUTTONS)
-  #define BTN_ENC          PA11   // Real pin needed to enable encoder's push button functionality used by touch screen. PA11 gives stable value.
+//#define BTN_ENC          PA11   // Real pin needed to enable encoder's push button functionality used by touch screen. PA11 gives stable value.
   #define TOUCH_CS_PIN     PA4
   #define TOUCH_INT_PIN    PC4
 #endif

--- a/Marlin/src/pins/stm32/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32/pins_LONGER3D_LK.h
@@ -137,7 +137,7 @@
   #define TOUCH_MISO_PIN   PB15  // pin 54
   #define TOUCH_INT_PIN    PC6   // pin 63 (PenIRQ coming from ADS7843)
 
-//#define BTN_ENC          PB0   // pin 35 unconnected pin on Alfawise. (PC13 to try)
+  //#define BTN_ENC        PB0   // pin 35 unconnected pin on Alfawise. (PC13 to try)
   #define BTN_EN1          -1    // Real pin is needed to enable encoder's push button
   #define BTN_EN2          -1    // functionality used by touch screen
 #endif

--- a/Marlin/src/pins/stm32/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32/pins_LONGER3D_LK.h
@@ -136,10 +136,6 @@
   #define TOUCH_MOSI_PIN   PB14  // pin 53
   #define TOUCH_MISO_PIN   PB15  // pin 54
   #define TOUCH_INT_PIN    PC6   // pin 63 (PenIRQ coming from ADS7843)
-
-  //#define BTN_ENC        PB0   // pin 35 unconnected pin on Alfawise. (PC13 to try)
-  #define BTN_EN1          -1    // Real pin is needed to enable encoder's push button
-  #define BTN_EN2          -1    // functionality used by touch screen
 #endif
 
 //

--- a/Marlin/src/pins/stm32/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32/pins_LONGER3D_LK.h
@@ -137,7 +137,7 @@
   #define TOUCH_MISO_PIN   PB15  // pin 54
   #define TOUCH_INT_PIN    PC6   // pin 63 (PenIRQ coming from ADS7843)
 
-  #define BTN_ENC          PB0   // pin 35 unconnected pin on Alfawise. (PC13 to try)
+//#define BTN_ENC          PB0   // pin 35 unconnected pin on Alfawise. (PC13 to try)
   #define BTN_EN1          -1    // Real pin is needed to enable encoder's push button
   #define BTN_EN2          -1    // functionality used by touch screen
 #endif

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
@@ -125,7 +125,6 @@
   #define LCD_BACKLIGHT_PIN PD13
 
   #if ENABLED(TOUCH_BUTTONS)
-    //#define BTN_ENC      PB3   // Not connected. TODO: Replace this hack to enable button code
     #define TOUCH_CS_PIN   PC2
   #endif
 #endif

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
@@ -125,7 +125,7 @@
   #define LCD_BACKLIGHT_PIN PD13
 
   #if ENABLED(TOUCH_BUTTONS)
-    //#define BTN_ENC        PB3    // Not connected. TODO: Replace this hack to enable button code
+    //#define BTN_ENC      PB3   // Not connected. TODO: Replace this hack to enable button code
     #define TOUCH_CS_PIN   PC2
   #endif
 #endif

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
@@ -125,7 +125,7 @@
   #define LCD_BACKLIGHT_PIN PD13
 
   #if ENABLED(TOUCH_BUTTONS)
-    #define BTN_ENC        PB3    // Not connected. TODO: Replace this hack to enable button code
+    //#define BTN_ENC        PB3    // Not connected. TODO: Replace this hack to enable button code
     #define TOUCH_CS_PIN   PC2
   #endif
 #endif
@@ -134,7 +134,7 @@
 #define MOTOR_CURRENT_PWM_XY_PIN   PA6
 #define MOTOR_CURRENT_PWM_Z_PIN    PA7
 #define MOTOR_CURRENT_PWM_E_PIN    PB0
-#define MOTOR_CURRENT_PWM_RANGE    65535 // (255 * (1000mA / 65535)) * 257 = 1000 is equal 1.6v Vref in turn equal 1Amp
+#define MOTOR_CURRENT_PWM_RANGE    1500 // (255 * (1000mA / 65535)) * 257 = 1000 is equal 1.6v Vref in turn equal 1Amp
 #define DEFAULT_PWM_MOTOR_CURRENT  { 1030, 1030, 1030 } // 1.05Amp per driver, here is XY, Z and E. This values determined empirically.
 
 // This is a kind of workaround in case native marlin "digipot" interface won't work.

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_NANO.h
@@ -129,7 +129,7 @@
   #define LCD_BACKLIGHT_PIN  PD13
 
   #if ENABLED(TOUCH_BUTTONS)
-  //#define BTN_ENC          PC13   // Not connected. TODO: Replace this hack to enable button code
+    //#define BTN_ENC        PC13   // Not connected. TODO: Replace this hack to enable button code
     #define TOUCH_CS_PIN     PA7
   #endif
 #endif

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_NANO.h
@@ -129,7 +129,7 @@
   #define LCD_BACKLIGHT_PIN  PD13
 
   #if ENABLED(TOUCH_BUTTONS)
-    #define BTN_ENC          PC13   // Not connected. TODO: Replace this hack to enable button code
+  //#define BTN_ENC          PC13   // Not connected. TODO: Replace this hack to enable button code
     #define TOUCH_CS_PIN     PA7
   #endif
 #endif

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_NANO.h
@@ -129,7 +129,6 @@
   #define LCD_BACKLIGHT_PIN  PD13
 
   #if ENABLED(TOUCH_BUTTONS)
-    //#define BTN_ENC        PC13   // Not connected. TODO: Replace this hack to enable button code
     #define TOUCH_CS_PIN     PA7
   #endif
 #endif


### PR DESCRIPTION
Remove BTN_ENC PIN definition for Touch Button TFT. 
Enable EN_C at ultralcd.h is enough to make touch button working.

CC: @tpruvot 
