### PR TITLE
SAMD51: Neopixel pin mapping

### DIFF
--- a/Marlin/src/HAL/HAL_SAMD51/fastio_SAMD51.h
+++ b/Marlin/src/HAL/HAL_SAMD51/fastio_SAMD51.h
@@ -243,6 +243,7 @@
   #define DIO5_PIN    PIN_PC21
   #define DIO16_PIN   PIN_PC22
   #define DIO17_PIN   PIN_PC23
+  #define DIO88_PIN   PIN_PC24    // NEOPIXEL
   // PORTD
   #define DIO22_PIN   PIN_PD12
   #define DIO6_PIN    PIN_PD20


### PR DESCRIPTION
Added onboard neopixel mapping.

Tested (M150) and it works, so neopixel should be marked as working