### PR TITLE
Fix python scripts unhandled quotes

### DIFF
--- a/buildroot/share/PlatformIO/scripts/alfawise_Ux0.py
+++ b/buildroot/share/PlatformIO/scripts/alfawise_Ux0.py
@@ -7,7 +7,7 @@ for define in env['CPPDEFINES']:
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08010000"))
 env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/alfawise_Ux0.ld")
 
-# Encrypt ${PROGNAME}.bin and save it as 'project.bin'
+# Rename ${PROGNAME}.bin and save it as 'project.bin' (No encryption on the Longer3D)
 def encrypt(source, target, env):
     import os
 
@@ -23,4 +23,5 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         marlin_alfa.close()
-env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);
+
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);

--- a/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
+++ b/buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
@@ -12,7 +12,7 @@ env.AddPostAction(
 	join("$BUILD_DIR","${PROGNAME}.elf"),
 	env.VerboseAction(" ".join([
 		"$OBJCOPY", "-O ihex", "$TARGET", # TARGET=.pio/build/fysetc_STM32F1/firmware.elf
-		"'" + join("$BUILD_DIR","${PROGNAME}.hex") + "'", # Note: $BUILD_DIR is a full path
+		"\"" + join("$BUILD_DIR","${PROGNAME}.hex") + "\"", # Note: $BUILD_DIR is a full path
 	]), "Building $TARGET"))
 
 # please keep $SOURCE variable, it will be replaced with a path to firmware
@@ -27,11 +27,11 @@ env.AddPostAction(
 UPLOAD_TOOL="stm32flash"
 platform = env.PioPlatform()
 if platform.get_package_dir("tool-stm32duino") != None:
-	UPLOAD_TOOL=expandvars("'" + join(platform.get_package_dir("tool-stm32duino"),"stm32flash","stm32flash") + "'")
+	UPLOAD_TOOL=expandvars("\"" + join(platform.get_package_dir("tool-stm32duino"),"stm32flash","stm32flash") + "\"")
 
 env.Replace(
 	UPLOADER=UPLOAD_TOOL,
-	UPLOADCMD=expandvars(UPLOAD_TOOL + " -v -i rts,-dtr,dtr $UPLOAD_PORT -R -w '" + join("$BUILD_DIR","${PROGNAME}.hex") + "'")
+	UPLOADCMD=expandvars(UPLOAD_TOOL + " -v -i rts,-dtr,dtr $UPLOAD_PORT -R -w \"" + join("$BUILD_DIR","${PROGNAME}.hex")+"\"")
 )
 
 # Python callback

--- a/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
+++ b/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
@@ -39,5 +39,5 @@ def addboot(source,target,env):
 	os.rename(target[0].path, firmware_without_bootloader_dir)
 	#os.rename(target[0].dir.path+'/firmware_with_bootloader.bin', target[0].dir.path+'/firmware.bin')
 
-env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', addboot);
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", addboot);
 

--- a/buildroot/share/PlatformIO/scripts/mks_robin.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin.py
@@ -27,4 +27,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         robin.close()
-env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);

--- a/buildroot/share/PlatformIO/scripts/mks_robin_lite.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_lite.py
@@ -27,4 +27,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         robin.close()
-env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);

--- a/buildroot/share/PlatformIO/scripts/mks_robin_mini.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_mini.py
@@ -27,4 +27,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         robin.close()
-env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);

--- a/buildroot/share/PlatformIO/scripts/mks_robin_nano.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_nano.py
@@ -27,4 +27,4 @@ def encrypt(source, target, env):
     finally:
         firmware.close()
         robin.close()
-env.AddPostAction('"$BUILD_DIR/${PROGNAME}.bin"', encrypt);
+env.AddPostAction("$BUILD_DIR/${PROGNAME}.bin", encrypt);


### PR DESCRIPTION
This partially reverts commit f9f20bb45448a03e2d4d01e1c5d4ac76ec75d8c6.

The "internal" python function doesnt need quotes to handle spaces, its not a command line part.

fysetc one fixed too for VSCode on windows, different issue