### PR TITLE
Add CONTROLLERFAN_SPEED_Z_ONLY

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -539,28 +539,28 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
       #if ENABLED(SWITCHING_EXTRUDER)
         bool oldstatus;
         switch (active_extruder) {
-          default: oldstatus = E0_ENABLE_READ; enable_E0(); break;
+          default: oldstatus = E0_ENABLE_READ(); enable_E0(); break;
           #if E_STEPPERS > 1
-            case 2: case 3: oldstatus = E1_ENABLE_READ; enable_E1(); break;
+            case 2: case 3: oldstatus = E1_ENABLE_READ(); enable_E1(); break;
             #if E_STEPPERS > 2
-              case 4: case 5: oldstatus = E2_ENABLE_READ; enable_E2(); break;
+              case 4: case 5: oldstatus = E2_ENABLE_READ(); enable_E2(); break;
             #endif // E_STEPPERS > 2
           #endif // E_STEPPERS > 1
         }
       #else // !SWITCHING_EXTRUDER
         bool oldstatus;
         switch (active_extruder) {
-          default: oldstatus = E0_ENABLE_READ; enable_E0(); break;
+          default: oldstatus = E0_ENABLE_READ(); enable_E0(); break;
           #if E_STEPPERS > 1
-            case 1: oldstatus = E1_ENABLE_READ; enable_E1(); break;
+            case 1: oldstatus = E1_ENABLE_READ(); enable_E1(); break;
             #if E_STEPPERS > 2
-              case 2: oldstatus = E2_ENABLE_READ; enable_E2(); break;
+              case 2: oldstatus = E2_ENABLE_READ(); enable_E2(); break;
               #if E_STEPPERS > 3
-                case 3: oldstatus = E3_ENABLE_READ; enable_E3(); break;
+                case 3: oldstatus = E3_ENABLE_READ(); enable_E3(); break;
                 #if E_STEPPERS > 4
-                  case 4: oldstatus = E4_ENABLE_READ; enable_E4(); break;
+                  case 4: oldstatus = E4_ENABLE_READ(); enable_E4(); break;
                   #if E_STEPPERS > 5
-                    case 5: oldstatus = E5_ENABLE_READ; enable_E5(); break;
+                    case 5: oldstatus = E5_ENABLE_READ(); enable_E5(); break;
                   #endif // E_STEPPERS > 5
                 #endif // E_STEPPERS > 4
               #endif // E_STEPPERS > 3

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -37,34 +37,34 @@ void controllerfan_update() {
     nextMotorCheck = ms + 2500UL; // Not a time critical function, so only check every 2.5s
 
     // If any of the drivers or the bed are enabled...
-    if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON
+    if (X_ENABLE_READ() == X_ENABLE_ON || Y_ENABLE_READ() == Y_ENABLE_ON || Z_ENABLE_READ() == Z_ENABLE_ON
       #if HAS_HEATED_BED
         || thermalManager.temp_bed.soft_pwm_amount > 0
       #endif
         #if HAS_X2_ENABLE
-          || X2_ENABLE_READ == X_ENABLE_ON
+          || X2_ENABLE_READ() == X_ENABLE_ON
         #endif
         #if HAS_Y2_ENABLE
-          || Y2_ENABLE_READ == Y_ENABLE_ON
+          || Y2_ENABLE_READ() == Y_ENABLE_ON
         #endif
         #if HAS_Z2_ENABLE
-          || Z2_ENABLE_READ == Z_ENABLE_ON
+          || Z2_ENABLE_READ() == Z_ENABLE_ON
         #endif
         #if HAS_Z3_ENABLE
-          || Z3_ENABLE_READ == Z_ENABLE_ON
+          || Z3_ENABLE_READ() == Z_ENABLE_ON
         #endif
         #if E_STEPPERS
-          || E0_ENABLE_READ == E_ENABLE_ON
+          || E0_ENABLE_READ() == E_ENABLE_ON
           #if E_STEPPERS > 1
-            || E1_ENABLE_READ == E_ENABLE_ON
+            || E1_ENABLE_READ() == E_ENABLE_ON
             #if E_STEPPERS > 2
-              || E2_ENABLE_READ == E_ENABLE_ON
+              || E2_ENABLE_READ() == E_ENABLE_ON
               #if E_STEPPERS > 3
-                || E3_ENABLE_READ == E_ENABLE_ON
+                || E3_ENABLE_READ() == E_ENABLE_ON
                 #if E_STEPPERS > 4
-                  || E4_ENABLE_READ == E_ENABLE_ON
+                  || E4_ENABLE_READ() == E_ENABLE_ON
                   #if E_STEPPERS > 5
-                    || E5_ENABLE_READ == E_ENABLE_ON
+                    || E5_ENABLE_READ() == E_ENABLE_ON
                   #endif // E_STEPPERS > 5
                 #endif // E_STEPPERS > 4
               #endif // E_STEPPERS > 3

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -77,6 +77,10 @@ void controllerfan_update() {
 
     // Fan off if no steppers have been enabled for CONTROLLERFAN_SECS seconds
     uint8_t speed = (!lastMotorOn || ELAPSED(ms, lastMotorOn + (CONTROLLERFAN_SECS) * 1000UL)) ? 0 : CONTROLLERFAN_SPEED;
+    #ifdef CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE
+      if ((speed != 0) && (X_ENABLE_READ != X_ENABLE_ON) && (Y_ENABLE_READ != Y_ENABLE_ON))
+        speed = CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE;
+    #endif
     controllerfan_speed = speed;
 
     // allows digital or PWM fan output to be used (see M42 handling)

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -55,31 +55,31 @@ bool Power::is_power_needed() {
   #endif
 
   // If any of the drivers or the bed are enabled...
-  if (X_ENABLE_READ == X_ENABLE_ON || Y_ENABLE_READ == Y_ENABLE_ON || Z_ENABLE_READ == Z_ENABLE_ON
+  if (X_ENABLE_READ() == X_ENABLE_ON || Y_ENABLE_READ() == Y_ENABLE_ON || Z_ENABLE_READ() == Z_ENABLE_ON
     #if HAS_HEATED_BED
       || thermalManager.temp_bed.soft_pwm_amount > 0
     #endif
       #if HAS_X2_ENABLE
-        || X2_ENABLE_READ == X_ENABLE_ON
+        || X2_ENABLE_READ() == X_ENABLE_ON
       #endif
       #if HAS_Y2_ENABLE
-        || Y2_ENABLE_READ == Y_ENABLE_ON
+        || Y2_ENABLE_READ() == Y_ENABLE_ON
       #endif
       #if HAS_Z2_ENABLE
-        || Z2_ENABLE_READ == Z_ENABLE_ON
+        || Z2_ENABLE_READ() == Z_ENABLE_ON
       #endif
       #if E_STEPPERS
-        || E0_ENABLE_READ == E_ENABLE_ON
+        || E0_ENABLE_READ() == E_ENABLE_ON
         #if E_STEPPERS > 1
-          || E1_ENABLE_READ == E_ENABLE_ON
+          || E1_ENABLE_READ() == E_ENABLE_ON
           #if E_STEPPERS > 2
-            || E2_ENABLE_READ == E_ENABLE_ON
+            || E2_ENABLE_READ() == E_ENABLE_ON
             #if E_STEPPERS > 3
-              || E3_ENABLE_READ == E_ENABLE_ON
+              || E3_ENABLE_READ() == E_ENABLE_ON
               #if E_STEPPERS > 4
-                || E4_ENABLE_READ == E_ENABLE_ON
+                || E4_ENABLE_READ() == E_ENABLE_ON
                 #if E_STEPPERS > 5
-                  || E5_ENABLE_READ == E_ENABLE_ON
+                  || E5_ENABLE_READ() == E_ENABLE_ON
                 #endif // E_STEPPERS > 5
               #endif // E_STEPPERS > 4
             #endif // E_STEPPERS > 3

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2316,7 +2316,7 @@ void Stepper::report_positions() {
   #define EXTRA_CYCLES_BABYSTEP (STEP_PULSE_CYCLES - (CYCLES_EATEN_BABYSTEP))
 
   #define _ENABLE(AXIS) enable_## AXIS()
-  #define _READ_DIR(AXIS) AXIS ##_DIR_READ
+  #define _READ_DIR(AXIS) AXIS ##_DIR_READ()
   #define _INVERT_DIR(AXIS) INVERT_## AXIS ##_DIR
   #define _APPLY_DIR(AXIS, INVERT) AXIS ##_APPLY_DIR(INVERT, true)
 
@@ -2404,9 +2404,9 @@ void Stepper::report_positions() {
           enable_Y();
           enable_Z();
 
-          const uint8_t old_x_dir_pin = X_DIR_READ,
-                        old_y_dir_pin = Y_DIR_READ,
-                        old_z_dir_pin = Z_DIR_READ;
+          const uint8_t old_x_dir_pin = X_DIR_READ(),
+                        old_y_dir_pin = Y_DIR_READ(),
+                        old_z_dir_pin = Z_DIR_READ();
 
           X_DIR_WRITE(INVERT_X_DIR ^ z_direction);
           Y_DIR_WRITE(INVERT_Y_DIR ^ z_direction);

--- a/Marlin/src/module/stepper_indirection.h
+++ b/Marlin/src/module/stepper_indirection.h
@@ -90,10 +90,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperX;
   #define X_ENABLE_INIT NOOP
   #define X_ENABLE_WRITE(STATE) NOOP
-  #define X_ENABLE_READ (stepperX.getStatus() & STATUS_HIZ)
+  #define X_ENABLE_READ() (stepperX.getStatus() & STATUS_HIZ)
   #define X_DIR_INIT NOOP
   #define X_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,X)
-  #define X_DIR_READ (stepperX.getStatus() & STATUS_DIR)
+  #define X_DIR_READ() (stepperX.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(X)
     extern TMC_CLASS(X, X) stepperX;
@@ -102,19 +102,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperX;
     #define X_ENABLE_INIT NOOP
     #define X_ENABLE_WRITE(STATE) stepperX.setEnabled(STATE)
-    #define X_ENABLE_READ stepperX.isEnabled()
+    #define X_ENABLE_READ() stepperX.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(X)
     #define X_ENABLE_INIT NOOP
     #define X_ENABLE_WRITE(STATE) stepperX.toff((STATE)==X_ENABLE_ON ? chopper_timing.toff : 0)
-    #define X_ENABLE_READ stepperX.isEnabled()
+    #define X_ENABLE_READ() stepperX.isEnabled()
   #else
     #define X_ENABLE_INIT SET_OUTPUT(X_ENABLE_PIN)
     #define X_ENABLE_WRITE(STATE) WRITE(X_ENABLE_PIN,STATE)
-    #define X_ENABLE_READ READ(X_ENABLE_PIN)
+    #define X_ENABLE_READ() READ(X_ENABLE_PIN)
   #endif
   #define X_DIR_INIT SET_OUTPUT(X_DIR_PIN)
   #define X_DIR_WRITE(STATE) WRITE(X_DIR_PIN,STATE)
-  #define X_DIR_READ READ(X_DIR_PIN)
+  #define X_DIR_READ() READ(X_DIR_PIN)
 #endif
 #define X_STEP_INIT SET_OUTPUT(X_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(X)
@@ -129,10 +129,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperY;
   #define Y_ENABLE_INIT NOOP
   #define Y_ENABLE_WRITE(STATE) NOOP
-  #define Y_ENABLE_READ (stepperY.getStatus() & STATUS_HIZ)
+  #define Y_ENABLE_READ() (stepperY.getStatus() & STATUS_HIZ)
   #define Y_DIR_INIT NOOP
   #define Y_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Y)
-  #define Y_DIR_READ (stepperY.getStatus() & STATUS_DIR)
+  #define Y_DIR_READ() (stepperY.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(Y)
     extern TMC_CLASS(Y, Y) stepperY;
@@ -141,19 +141,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperY;
     #define Y_ENABLE_INIT NOOP
     #define Y_ENABLE_WRITE(STATE) stepperY.setEnabled(STATE)
-    #define Y_ENABLE_READ stepperY.isEnabled()
+    #define Y_ENABLE_READ() stepperY.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(Y)
     #define Y_ENABLE_INIT NOOP
     #define Y_ENABLE_WRITE(STATE) stepperY.toff((STATE)==Y_ENABLE_ON ? chopper_timing.toff : 0)
-    #define Y_ENABLE_READ stepperY.isEnabled()
+    #define Y_ENABLE_READ() stepperY.isEnabled()
   #else
     #define Y_ENABLE_INIT SET_OUTPUT(Y_ENABLE_PIN)
     #define Y_ENABLE_WRITE(STATE) WRITE(Y_ENABLE_PIN,STATE)
-    #define Y_ENABLE_READ READ(Y_ENABLE_PIN)
+    #define Y_ENABLE_READ() READ(Y_ENABLE_PIN)
   #endif
   #define Y_DIR_INIT SET_OUTPUT(Y_DIR_PIN)
   #define Y_DIR_WRITE(STATE) WRITE(Y_DIR_PIN,STATE)
-  #define Y_DIR_READ READ(Y_DIR_PIN)
+  #define Y_DIR_READ() READ(Y_DIR_PIN)
 #endif
 #define Y_STEP_INIT SET_OUTPUT(Y_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(Y)
@@ -168,10 +168,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperZ;
   #define Z_ENABLE_INIT NOOP
   #define Z_ENABLE_WRITE(STATE) NOOP
-  #define Z_ENABLE_READ (stepperZ.getStatus() & STATUS_HIZ)
+  #define Z_ENABLE_READ() (stepperZ.getStatus() & STATUS_HIZ)
   #define Z_DIR_INIT NOOP
   #define Z_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Z)
-  #define Z_DIR_READ (stepperZ.getStatus() & STATUS_DIR)
+  #define Z_DIR_READ() (stepperZ.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(Z)
     extern TMC_CLASS(Z, Z) stepperZ;
@@ -180,19 +180,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperZ;
     #define Z_ENABLE_INIT NOOP
     #define Z_ENABLE_WRITE(STATE) stepperZ.setEnabled(STATE)
-    #define Z_ENABLE_READ stepperZ.isEnabled()
+    #define Z_ENABLE_READ() stepperZ.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(Z)
     #define Z_ENABLE_INIT NOOP
     #define Z_ENABLE_WRITE(STATE) stepperZ.toff((STATE)==Z_ENABLE_ON ? chopper_timing.toff : 0)
-    #define Z_ENABLE_READ stepperZ.isEnabled()
+    #define Z_ENABLE_READ() stepperZ.isEnabled()
   #else
     #define Z_ENABLE_INIT SET_OUTPUT(Z_ENABLE_PIN)
     #define Z_ENABLE_WRITE(STATE) WRITE(Z_ENABLE_PIN,STATE)
-    #define Z_ENABLE_READ READ(Z_ENABLE_PIN)
+    #define Z_ENABLE_READ() READ(Z_ENABLE_PIN)
   #endif
   #define Z_DIR_INIT SET_OUTPUT(Z_DIR_PIN)
   #define Z_DIR_WRITE(STATE) WRITE(Z_DIR_PIN,STATE)
-  #define Z_DIR_READ READ(Z_DIR_PIN)
+  #define Z_DIR_READ() READ(Z_DIR_PIN)
 #endif
 #define Z_STEP_INIT SET_OUTPUT(Z_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(Z)
@@ -208,10 +208,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern L6470 stepperX2;
     #define X2_ENABLE_INIT NOOP
     #define X2_ENABLE_WRITE(STATE) NOOP
-    #define X2_ENABLE_READ (stepperX2.getStatus() & STATUS_HIZ)
+    #define X2_ENABLE_READ() (stepperX2.getStatus() & STATUS_HIZ)
     #define X2_DIR_INIT NOOP
     #define X2_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,X2)
-    #define X2_DIR_READ (stepperX2.getStatus() & STATUS_DIR)
+    #define X2_DIR_READ() (stepperX2.getStatus() & STATUS_DIR)
   #else
     #if AXIS_IS_TMC(X2)
       extern TMC_CLASS(X2, X) stepperX2;
@@ -220,19 +220,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
       extern TMC26XStepper stepperX2;
       #define X2_ENABLE_INIT NOOP
       #define X2_ENABLE_WRITE(STATE) stepperX2.setEnabled(STATE)
-      #define X2_ENABLE_READ stepperX2.isEnabled()
+      #define X2_ENABLE_READ() stepperX2.isEnabled()
     #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(X2)
       #define X2_ENABLE_INIT NOOP
       #define X2_ENABLE_WRITE(STATE) stepperX2.toff((STATE)==X_ENABLE_ON ? chopper_timing.toff : 0)
-      #define X2_ENABLE_READ stepperX2.isEnabled()
+      #define X2_ENABLE_READ() stepperX2.isEnabled()
     #else
       #define X2_ENABLE_INIT SET_OUTPUT(X2_ENABLE_PIN)
       #define X2_ENABLE_WRITE(STATE) WRITE(X2_ENABLE_PIN,STATE)
-      #define X2_ENABLE_READ READ(X2_ENABLE_PIN)
+      #define X2_ENABLE_READ() READ(X2_ENABLE_PIN)
     #endif
     #define X2_DIR_INIT SET_OUTPUT(X2_DIR_PIN)
     #define X2_DIR_WRITE(STATE) WRITE(X2_DIR_PIN,STATE)
-    #define X2_DIR_READ READ(X2_DIR_PIN)
+    #define X2_DIR_READ() READ(X2_DIR_PIN)
   #endif
   #define X2_STEP_INIT SET_OUTPUT(X2_STEP_PIN)
   #if AXIS_HAS_SQUARE_WAVE(X2)
@@ -250,10 +250,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern L6470 stepperY2;
     #define Y2_ENABLE_INIT NOOP
     #define Y2_ENABLE_WRITE(STATE) NOOP
-    #define Y2_ENABLE_READ (stepperY2.getStatus() & STATUS_HIZ)
+    #define Y2_ENABLE_READ() (stepperY2.getStatus() & STATUS_HIZ)
     #define Y2_DIR_INIT NOOP
     #define Y2_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Y2)
-    #define Y2_DIR_READ (stepperY2.getStatus() & STATUS_DIR)
+    #define Y2_DIR_READ() (stepperY2.getStatus() & STATUS_DIR)
   #else
     #if AXIS_IS_TMC(Y2)
       extern TMC_CLASS(Y2, Y) stepperY2;
@@ -262,19 +262,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
       extern TMC26XStepper stepperY2;
       #define Y2_ENABLE_INIT NOOP
       #define Y2_ENABLE_WRITE(STATE) stepperY2.setEnabled(STATE)
-      #define Y2_ENABLE_READ stepperY2.isEnabled()
+      #define Y2_ENABLE_READ() stepperY2.isEnabled()
     #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(Y2)
       #define Y2_ENABLE_INIT NOOP
       #define Y2_ENABLE_WRITE(STATE) stepperY2.toff((STATE)==Y_ENABLE_ON ? chopper_timing.toff : 0)
-      #define Y2_ENABLE_READ stepperY2.isEnabled()
+      #define Y2_ENABLE_READ() stepperY2.isEnabled()
     #else
       #define Y2_ENABLE_INIT SET_OUTPUT(Y2_ENABLE_PIN)
       #define Y2_ENABLE_WRITE(STATE) WRITE(Y2_ENABLE_PIN,STATE)
-      #define Y2_ENABLE_READ READ(Y2_ENABLE_PIN)
+      #define Y2_ENABLE_READ() READ(Y2_ENABLE_PIN)
     #endif
     #define Y2_DIR_INIT SET_OUTPUT(Y2_DIR_PIN)
     #define Y2_DIR_WRITE(STATE) WRITE(Y2_DIR_PIN,STATE)
-    #define Y2_DIR_READ READ(Y2_DIR_PIN)
+    #define Y2_DIR_READ() READ(Y2_DIR_PIN)
   #endif
   #define Y2_STEP_INIT SET_OUTPUT(Y2_STEP_PIN)
   #if AXIS_HAS_SQUARE_WAVE(Y2)
@@ -294,10 +294,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern L6470 stepperZ2;
     #define Z2_ENABLE_INIT NOOP
     #define Z2_ENABLE_WRITE(STATE) NOOP
-    #define Z2_ENABLE_READ (stepperZ2.getStatus() & STATUS_HIZ)
+    #define Z2_ENABLE_READ() (stepperZ2.getStatus() & STATUS_HIZ)
     #define Z2_DIR_INIT NOOP
     #define Z2_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Z2)
-    #define Z2_DIR_READ (stepperZ2.getStatus() & STATUS_DIR)
+    #define Z2_DIR_READ() (stepperZ2.getStatus() & STATUS_DIR)
   #else
     #if AXIS_IS_TMC(Z2)
       extern TMC_CLASS(Z2, Z) stepperZ2;
@@ -306,19 +306,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
       extern TMC26XStepper stepperZ2;
       #define Z2_ENABLE_INIT NOOP
       #define Z2_ENABLE_WRITE(STATE) stepperZ2.setEnabled(STATE)
-      #define Z2_ENABLE_READ stepperZ2.isEnabled()
+      #define Z2_ENABLE_READ() stepperZ2.isEnabled()
     #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(Z2)
       #define Z2_ENABLE_INIT NOOP
       #define Z2_ENABLE_WRITE(STATE) stepperZ2.toff((STATE)==Z_ENABLE_ON ? chopper_timing.toff : 0)
-      #define Z2_ENABLE_READ stepperZ2.isEnabled()
+      #define Z2_ENABLE_READ() stepperZ2.isEnabled()
     #else
       #define Z2_ENABLE_INIT SET_OUTPUT(Z2_ENABLE_PIN)
       #define Z2_ENABLE_WRITE(STATE) WRITE(Z2_ENABLE_PIN,STATE)
-      #define Z2_ENABLE_READ READ(Z2_ENABLE_PIN)
+      #define Z2_ENABLE_READ() READ(Z2_ENABLE_PIN)
     #endif
     #define Z2_DIR_INIT SET_OUTPUT(Z2_DIR_PIN)
     #define Z2_DIR_WRITE(STATE) WRITE(Z2_DIR_PIN,STATE)
-    #define Z2_DIR_READ READ(Z2_DIR_PIN)
+    #define Z2_DIR_READ() READ(Z2_DIR_PIN)
   #endif
   #define Z2_STEP_INIT SET_OUTPUT(Z2_STEP_PIN)
   #if AXIS_HAS_SQUARE_WAVE(Z2)
@@ -338,10 +338,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern L6470 stepperZ3;
     #define Z3_ENABLE_INIT NOOP
     #define Z3_ENABLE_WRITE(STATE) NOOP
-    #define Z3_ENABLE_READ (stepperZ3.getStatus() & STATUS_HIZ)
+    #define Z3_ENABLE_READ() (stepperZ3.getStatus() & STATUS_HIZ)
     #define Z3_DIR_INIT NOOP
     #define Z3_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Z3)
-    #define Z3_DIR_READ (stepperZ3.getStatus() & STATUS_DIR)
+    #define Z3_DIR_READ() (stepperZ3.getStatus() & STATUS_DIR)
   #else
     #if AXIS_IS_TMC(Z3)
       extern TMC_CLASS(Z3, Z) stepperZ3;
@@ -350,19 +350,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
       extern TMC26XStepper stepperZ3;
       #define Z3_ENABLE_INIT NOOP
       #define Z3_ENABLE_WRITE(STATE) stepperZ3.setEnabled(STATE)
-      #define Z3_ENABLE_READ stepperZ3.isEnabled()
+      #define Z3_ENABLE_READ() stepperZ3.isEnabled()
     #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(Z3)
       #define Z3_ENABLE_INIT NOOP
       #define Z3_ENABLE_WRITE(STATE) stepperZ3.toff((STATE)==Z_ENABLE_ON ? chopper_timing.toff : 0)
-      #define Z3_ENABLE_READ stepperZ3.isEnabled()
+      #define Z3_ENABLE_READ() stepperZ3.isEnabled()
     #else
       #define Z3_ENABLE_INIT SET_OUTPUT(Z3_ENABLE_PIN)
       #define Z3_ENABLE_WRITE(STATE) WRITE(Z3_ENABLE_PIN,STATE)
-      #define Z3_ENABLE_READ READ(Z3_ENABLE_PIN)
+      #define Z3_ENABLE_READ() READ(Z3_ENABLE_PIN)
     #endif
     #define Z3_DIR_INIT SET_OUTPUT(Z3_DIR_PIN)
     #define Z3_DIR_WRITE(STATE) WRITE(Z3_DIR_PIN,STATE)
-    #define Z3_DIR_READ READ(Z3_DIR_PIN)
+    #define Z3_DIR_READ() READ(Z3_DIR_PIN)
   #endif
   #define Z3_STEP_INIT SET_OUTPUT(Z3_STEP_PIN)
   #if AXIS_HAS_SQUARE_WAVE(Z3)
@@ -381,10 +381,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperE0;
   #define E0_ENABLE_INIT NOOP
   #define E0_ENABLE_WRITE(STATE) NOOP
-  #define E0_ENABLE_READ (stepperE0.getStatus() & STATUS_HIZ)
+  #define E0_ENABLE_READ() (stepperE0.getStatus() & STATUS_HIZ)
   #define E0_DIR_INIT NOOP
   #define E0_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E0)
-  #define E0_DIR_READ (stepperE0.getStatus() & STATUS_DIR)
+  #define E0_DIR_READ() (stepperE0.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(E0)
     extern TMC_CLASS_E(0) stepperE0;
@@ -393,19 +393,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperE0;
     #define E0_ENABLE_INIT NOOP
     #define E0_ENABLE_WRITE(STATE) stepperE0.setEnabled(STATE)
-    #define E0_ENABLE_READ stepperE0.isEnabled()
+    #define E0_ENABLE_READ() stepperE0.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E0)
     #define E0_ENABLE_INIT NOOP
     #define E0_ENABLE_WRITE(STATE) stepperE0.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
-    #define E0_ENABLE_READ stepperE0.isEnabled()
+    #define E0_ENABLE_READ() stepperE0.isEnabled()
   #else
     #define E0_ENABLE_INIT SET_OUTPUT(E0_ENABLE_PIN)
     #define E0_ENABLE_WRITE(STATE) WRITE(E0_ENABLE_PIN,STATE)
-    #define E0_ENABLE_READ READ(E0_ENABLE_PIN)
+    #define E0_ENABLE_READ() READ(E0_ENABLE_PIN)
   #endif
   #define E0_DIR_INIT SET_OUTPUT(E0_DIR_PIN)
   #define E0_DIR_WRITE(STATE) WRITE(E0_DIR_PIN,STATE)
-  #define E0_DIR_READ READ(E0_DIR_PIN)
+  #define E0_DIR_READ() READ(E0_DIR_PIN)
 #endif
 #define E0_STEP_INIT SET_OUTPUT(E0_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(E0)
@@ -420,10 +420,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperE1;
   #define E1_ENABLE_INIT NOOP
   #define E1_ENABLE_WRITE(STATE) NOOP
-  #define E1_ENABLE_READ (stepperE1.getStatus() & STATUS_HIZ)
+  #define E1_ENABLE_READ() (stepperE1.getStatus() & STATUS_HIZ)
   #define E1_DIR_INIT NOOP
   #define E1_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E1)
-  #define E1_DIR_READ (stepperE1.getStatus() & STATUS_DIR)
+  #define E1_DIR_READ() (stepperE1.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(E1)
     extern TMC_CLASS_E(1) stepperE1;
@@ -432,19 +432,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperE1;
     #define E1_ENABLE_INIT NOOP
     #define E1_ENABLE_WRITE(STATE) stepperE1.setEnabled(STATE)
-    #define E1_ENABLE_READ stepperE1.isEnabled()
+    #define E1_ENABLE_READ() stepperE1.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E1)
     #define E1_ENABLE_INIT NOOP
     #define E1_ENABLE_WRITE(STATE) stepperE1.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
-    #define E1_ENABLE_READ stepperE1.isEnabled()
+    #define E1_ENABLE_READ() stepperE1.isEnabled()
   #else
     #define E1_ENABLE_INIT SET_OUTPUT(E1_ENABLE_PIN)
     #define E1_ENABLE_WRITE(STATE) WRITE(E1_ENABLE_PIN,STATE)
-    #define E1_ENABLE_READ READ(E1_ENABLE_PIN)
+    #define E1_ENABLE_READ() READ(E1_ENABLE_PIN)
   #endif
   #define E1_DIR_INIT SET_OUTPUT(E1_DIR_PIN)
   #define E1_DIR_WRITE(STATE) WRITE(E1_DIR_PIN,STATE)
-  #define E1_DIR_READ READ(E1_DIR_PIN)
+  #define E1_DIR_READ() READ(E1_DIR_PIN)
 #endif
 #define E1_STEP_INIT SET_OUTPUT(E1_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(E1)
@@ -459,10 +459,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperE2;
   #define E2_ENABLE_INIT NOOP
   #define E2_ENABLE_WRITE(STATE) NOOP
-  #define E2_ENABLE_READ (stepperE2.getStatus() & STATUS_HIZ)
+  #define E2_ENABLE_READ() (stepperE2.getStatus() & STATUS_HIZ)
   #define E2_DIR_INIT NOOP
   #define E2_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E2)
-  #define E2_DIR_READ (stepperE2.getStatus() & STATUS_DIR)
+  #define E2_DIR_READ() (stepperE2.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(E2)
     extern TMC_CLASS_E(2) stepperE2;
@@ -471,19 +471,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperE2;
     #define E2_ENABLE_INIT NOOP
     #define E2_ENABLE_WRITE(STATE) stepperE2.setEnabled(STATE)
-    #define E2_ENABLE_READ stepperE2.isEnabled()
+    #define E2_ENABLE_READ() stepperE2.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E2)
     #define E2_ENABLE_INIT NOOP
     #define E2_ENABLE_WRITE(STATE) stepperE2.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
-    #define E2_ENABLE_READ stepperE2.isEnabled()
+    #define E2_ENABLE_READ() stepperE2.isEnabled()
   #else
     #define E2_ENABLE_INIT SET_OUTPUT(E2_ENABLE_PIN)
     #define E2_ENABLE_WRITE(STATE) WRITE(E2_ENABLE_PIN,STATE)
-    #define E2_ENABLE_READ READ(E2_ENABLE_PIN)
+    #define E2_ENABLE_READ() READ(E2_ENABLE_PIN)
   #endif
   #define E2_DIR_INIT SET_OUTPUT(E2_DIR_PIN)
   #define E2_DIR_WRITE(STATE) WRITE(E2_DIR_PIN,STATE)
-  #define E2_DIR_READ READ(E2_DIR_PIN)
+  #define E2_DIR_READ() READ(E2_DIR_PIN)
 #endif
 #define E2_STEP_INIT SET_OUTPUT(E2_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(E2)
@@ -498,10 +498,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperE3;
   #define E3_ENABLE_INIT NOOP
   #define E3_ENABLE_WRITE(STATE) NOOP
-  #define E3_ENABLE_READ (stepperE3.getStatus() & STATUS_HIZ)
+  #define E3_ENABLE_READ() (stepperE3.getStatus() & STATUS_HIZ)
   #define E3_DIR_INIT NOOP
   #define E3_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E3)
-  #define E3_DIR_READ (stepperE3.getStatus() & STATUS_DIR)
+  #define E3_DIR_READ() (stepperE3.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(E3)
     extern TMC_CLASS_E(3) stepperE3;
@@ -510,19 +510,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperE3;
     #define E3_ENABLE_INIT NOOP
     #define E3_ENABLE_WRITE(STATE) stepperE3.setEnabled(STATE)
-    #define E3_ENABLE_READ stepperE3.isEnabled()
+    #define E3_ENABLE_READ() stepperE3.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E3)
     #define E3_ENABLE_INIT NOOP
     #define E3_ENABLE_WRITE(STATE) stepperE3.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
-    #define E3_ENABLE_READ stepperE3.isEnabled()
+    #define E3_ENABLE_READ() stepperE3.isEnabled()
   #else
     #define E3_ENABLE_INIT SET_OUTPUT(E3_ENABLE_PIN)
     #define E3_ENABLE_WRITE(STATE) WRITE(E3_ENABLE_PIN,STATE)
-    #define E3_ENABLE_READ READ(E3_ENABLE_PIN)
+    #define E3_ENABLE_READ() READ(E3_ENABLE_PIN)
   #endif
   #define E3_DIR_INIT SET_OUTPUT(E3_DIR_PIN)
   #define E3_DIR_WRITE(STATE) WRITE(E3_DIR_PIN,STATE)
-  #define E3_DIR_READ READ(E3_DIR_PIN)
+  #define E3_DIR_READ() READ(E3_DIR_PIN)
 #endif
 #define E3_STEP_INIT SET_OUTPUT(E3_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(E3)
@@ -537,10 +537,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperE4;
   #define E4_ENABLE_INIT NOOP
   #define E4_ENABLE_WRITE(STATE) NOOP
-  #define E4_ENABLE_READ (stepperE4.getStatus() & STATUS_HIZ)
+  #define E4_ENABLE_READ() (stepperE4.getStatus() & STATUS_HIZ)
   #define E4_DIR_INIT NOOP
   #define E4_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E4)
-  #define E4_DIR_READ (stepperE4.getStatus() & STATUS_DIR)
+  #define E4_DIR_READ() (stepperE4.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(E4)
     extern TMC_CLASS_E(4) stepperE4;
@@ -549,19 +549,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperE4;
     #define E4_ENABLE_INIT NOOP
     #define E4_ENABLE_WRITE(STATE) stepperE4.setEnabled(STATE)
-    #define E4_ENABLE_READ stepperE4.isEnabled()
+    #define E4_ENABLE_READ() stepperE4.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E4)
     #define E4_ENABLE_INIT NOOP
     #define E4_ENABLE_WRITE(STATE) stepperE4.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
-    #define E4_ENABLE_READ stepperE4.isEnabled()
+    #define E4_ENABLE_READ() stepperE4.isEnabled()
   #else
     #define E4_ENABLE_INIT SET_OUTPUT(E4_ENABLE_PIN)
     #define E4_ENABLE_WRITE(STATE) WRITE(E4_ENABLE_PIN,STATE)
-    #define E4_ENABLE_READ READ(E4_ENABLE_PIN)
+    #define E4_ENABLE_READ() READ(E4_ENABLE_PIN)
   #endif
   #define E4_DIR_INIT SET_OUTPUT(E4_DIR_PIN)
   #define E4_DIR_WRITE(STATE) WRITE(E4_DIR_PIN,STATE)
-  #define E4_DIR_READ READ(E4_DIR_PIN)
+  #define E4_DIR_READ() READ(E4_DIR_PIN)
 #endif
 #define E4_STEP_INIT SET_OUTPUT(E4_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(E4)
@@ -576,10 +576,10 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   extern L6470 stepperE5;
   #define E5_ENABLE_INIT NOOP
   #define E5_ENABLE_WRITE(STATE) NOOP
-  #define E5_ENABLE_READ (stepperE5.getStatus() & STATUS_HIZ)
+  #define E5_ENABLE_READ() (stepperE5.getStatus() & STATUS_HIZ)
   #define E5_DIR_INIT NOOP
   #define E5_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E5)
-  #define E5_DIR_READ (stepperE5.getStatus() & STATUS_DIR)
+  #define E5_DIR_READ() (stepperE5.getStatus() & STATUS_DIR)
 #else
   #if AXIS_IS_TMC(E5)
     extern TMC_CLASS_E(5) stepperE5;
@@ -588,19 +588,19 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     extern TMC26XStepper stepperE5;
     #define E5_ENABLE_INIT NOOP
     #define E5_ENABLE_WRITE(STATE) stepperE5.setEnabled(STATE)
-    #define E5_ENABLE_READ stepperE5.isEnabled()
+    #define E5_ENABLE_READ() stepperE5.isEnabled()
   #elif ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E5)
     #define E5_ENABLE_INIT NOOP
     #define E5_ENABLE_WRITE(STATE) stepperE5.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
-    #define E5_ENABLE_READ stepperE5.isEnabled()
+    #define E5_ENABLE_READ() stepperE5.isEnabled()
   #else
     #define E5_ENABLE_INIT SET_OUTPUT(E5_ENABLE_PIN)
     #define E5_ENABLE_WRITE(STATE) WRITE(E5_ENABLE_PIN,STATE)
-    #define E5_ENABLE_READ READ(E5_ENABLE_PIN)
+    #define E5_ENABLE_READ() READ(E5_ENABLE_PIN)
   #endif
   #define E5_DIR_INIT SET_OUTPUT(E5_DIR_PIN)
   #define E5_DIR_WRITE(STATE) WRITE(E5_DIR_PIN,STATE)
-  #define E5_DIR_READ READ(E5_DIR_PIN)
+  #define E5_DIR_READ() READ(E5_DIR_PIN)
 #endif
 #define E5_STEP_INIT SET_OUTPUT(E5_STEP_PIN)
 #if AXIS_HAS_SQUARE_WAVE(E5)

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -282,6 +282,10 @@
   #define CONTROLLER_FAN_PIN 9           // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  #define CONTROLLER_FAN_PIN 9           // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  #define CONTROLLER_FAN_PIN 9              // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -279,9 +279,10 @@
  */
 #define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  #define CONTROLLER_FAN_PIN 2           // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 130        // 255 == full speed
+  #define CONTROLLER_FAN_PIN 2              // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 130           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -282,6 +282,10 @@
   #define CONTROLLER_FAN_PIN 7        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 #define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  #define CONTROLLER_FAN_PIN 7        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  #define CONTROLLER_FAN_PIN  7             // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -283,13 +283,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -286,6 +286,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/Ender-5/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Creality/Ender-5/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Felix/Configuration_adv.h
+++ b/config/examples/Felix/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Felix/Configuration_adv.h
+++ b/config/examples/Felix/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -284,13 +284,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -287,6 +287,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -284,13 +284,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -287,6 +287,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 #define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  #define CONTROLLER_FAN_PIN 4           // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  #define CONTROLLER_FAN_PIN 4              // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -282,6 +282,10 @@
   #define CONTROLLER_FAN_PIN 4           // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -295,6 +295,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -292,13 +292,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Configuration_adv.h
@@ -282,6 +282,10 @@
   #define CONTROLLER_FAN_PIN 2           // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 #define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  #define CONTROLLER_FAN_PIN 2           // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  #define CONTROLLER_FAN_PIN 2              // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -282,6 +282,10 @@
   #define CONTROLLER_FAN_PIN 23          // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 #define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  #define CONTROLLER_FAN_PIN 23          // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  #define CONTROLLER_FAN_PIN 23             // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -279,13 +279,10 @@
  */
 //#define USE_CONTROLLER_FAN
 #if ENABLED(USE_CONTROLLER_FAN)
-  //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
-  #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
-  #define CONTROLLERFAN_SPEED 255        // 255 == full speed
-
-  // Use a different speed when only the Z motors are enabled.
-  // This reduces noise on Z-belt printers that keep Z enabled when idle.
-  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
+  //#define CONTROLLER_FAN_PIN -1           // Set a custom pin for the controller fan
+  #define CONTROLLERFAN_SECS 60             // Duration in seconds for the fan to run after all motors are disabled
+  #define CONTROLLERFAN_SPEED 255           // 255 == full speed
+  //#define CONTROLLERFAN_SPEED_Z_ONLY 127  // Reduce noise on machines that keep Z enabled
 #endif
 
 // When first starting the main fan, run it at full speed for the

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -282,6 +282,10 @@
   //#define CONTROLLER_FAN_PIN -1        // Set a custom pin for the controller fan
   #define CONTROLLERFAN_SECS 60          // Duration in seconds for the fan to run after all motors are disabled
   #define CONTROLLERFAN_SPEED 255        // 255 == full speed
+
+  // Use a different speed when only the Z motors are enabled.
+  // This reduces noise on Z-belt printers that keep Z enabled when idle.
+  //#define CONTROLLERFAN_SPEED_WHEN_ONLY_Z_ACTIVE 127
 #endif
 
 // When first starting the main fan, run it at full speed for the


### PR DESCRIPTION
This option allows a reduction in fan noise on Z-belt printers that keep the Z axis enabled even when idle