### PR TITLE
Allow USB vendor and product ID to be changed from "Config_adv.h"

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/Marlin/src/HAL/HAL_DUE/usb/conf_usb.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/conf_usb.h
@@ -48,9 +48,7 @@
 #define _CONF_USB_H_
 
 #undef UNUSED                           /* To avoid a macro clash as macros.h already defines it */
-#include "../../../core/macros.h"       /* For ENABLED()/DISABLED() */
-#include "../../../core/boards.h"       /* For MB() */
-#include "../../../../Configuration.h"  /* For CUSTOM_MACHINE_NAME definition - We just need the name, no C++ allowed! */
+#include "../../../inc/MarlinConfigPre.h"
 #include "compiler.h"
 
 /**
@@ -59,8 +57,12 @@
  */
 
 //! Device definition (mandatory)
-#define  USB_DEVICE_VENDOR_ID             0x03EB /* ATMEL VID */
-#define  USB_DEVICE_PRODUCT_ID            0x2424 /* MSC / CDC */
+#ifndef USB_DEVICE_VENDOR_ID
+  #define  USB_DEVICE_VENDOR_ID           0x03EB /* ATMEL VID */
+#endif
+#ifndef USB_DEVICE_PRODUCT_ID
+  #define  USB_DEVICE_PRODUCT_ID          0x2424 /* MSC / CDC */
+#endif
 #define  USB_DEVICE_MAJOR_VERSION         1
 #define  USB_DEVICE_MINOR_VERSION         0
 #define  USB_DEVICE_POWER                 100 // Consumption on Vbus line (mA)
@@ -71,7 +73,9 @@
 //  (USB_CONFIG_ATTR_REMOTE_WAKEUP|USB_CONFIG_ATTR_BUS_POWERED)
 
 //! USB Device string definitions (Optional)
-#define  USB_DEVICE_MANUFACTURE_NAME      "marlinfw.org"
+#ifndef USB_DEVICE_MANUFACTURE_NAME
+  #define  USB_DEVICE_MANUFACTURE_NAME    "marlinfw.org"
+#endif
 #ifdef CUSTOM_MACHINE_NAME
   #define  USB_DEVICE_PRODUCT_NAME        CUSTOM_MACHINE_NAME
 #else

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -1008,6 +1008,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -1009,6 +1009,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -1013,6 +1013,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/CR-20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Creality/Ender-5/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   #define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
@@ -1004,6 +1004,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
@@ -1004,6 +1004,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
@@ -1004,6 +1004,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Felix/Configuration_adv.h
+++ b/config/examples/Felix/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -1004,6 +1004,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   #define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -1009,6 +1009,13 @@
   #define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -1009,6 +1009,13 @@
   #define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -1010,6 +1010,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -1010,6 +1010,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -1006,6 +1006,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -1004,6 +1004,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
@@ -1001,6 +1001,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -1004,6 +1004,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -1004,6 +1004,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -1018,6 +1018,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Velleman/K8400/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   #define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   #define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -1007,6 +1007,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -1005,6 +1005,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -1006,6 +1006,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Set the vendor info the serial USB interface, if changable
+   */
+  //#define  USB_DEVICE_VENDOR_ID           0x0000
+  //#define  USB_DEVICE_PRODUCT_ID          0x0000
+  //#define  USB_DEVICE_MANUFACTURE_NAME    "ACME Corporation"
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.


### PR DESCRIPTION
Allow definition of `USB_DEVICE_VENDOR_ID`, `USB_DEVICE_PRODUCT_ID` and `USB_DEVICE_MANUFACTURE_NAME` from "Configuration_adv.h"
