### PR TITLE
Use u8g int type for screen coordinates

### DIFF
--- a/Marlin/src/lcd/HD44780/lcdprint_hd44780.cpp
+++ b/Marlin/src/lcd/HD44780/lcdprint_hd44780.cpp
@@ -877,7 +877,7 @@ static int pf_bsearch_cb_comp_hd4map_pgm(void *userdata, size_t idx, void * data
   return hd44780_charmap_compare(&localval, (hd44780_charmap_t *)data_pin);
 }
 
-void lcd_moveto(const uint8_t col, const uint8_t row) { lcd.setCursor(col, row); }
+void lcd_moveto(const lcd_uint_t col, const lcd_uint_t row) { lcd.setCursor(col, row); }
 
 void lcd_put_int(const int i) { lcd.print(i); }
 

--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -364,14 +364,14 @@ void MarlinUI::clear_lcd() { lcd.clear(); }
 
 #if ENABLED(SHOW_BOOTSCREEN)
 
-  void lcd_erase_line(const int16_t line) {
+  void lcd_erase_line(const lcd_uint_t line) {
     lcd_moveto(0, line);
     for (uint8_t i = LCD_WIDTH + 1; --i;)
       lcd_put_wchar(' ');
   }
 
   // Scroll the PSTR 'text' in a 'len' wide field for 'time' milliseconds at position col,line
-  void lcd_scroll(const uint8_t col, const uint8_t line, PGM_P const text, const uint8_t len, const int16_t time) {
+  void lcd_scroll(const lcd_uint_t col, const lcd_uint_t line, PGM_P const text, const uint8_t len, const int16_t time) {
     uint8_t slen = utf8_strlen_P(text);
     if (slen < len) {
       // Fits into,
@@ -1031,9 +1031,9 @@ void MarlinUI::draw_status_screen() {
     if (value != nullptr) {
       lcd_put_wchar(':');
       int len = utf8_strlen(value);
-      const uint8_t valrow = (utf8_strlen_P(pstr) + 1 + len + 1) > (LCD_WIDTH - 2) ? 2 : 1;   // Value on the next row if it won't fit
-      lcd_moveto((LCD_WIDTH - 1) - (len + 1), valrow);                                        // Right-justified, padded by spaces
-      lcd_put_wchar(' ');                                                                     // Overwrite char if value gets shorter
+      const lcd_uint_t valrow = (utf8_strlen_P(pstr) + 1 + len + 1) > (LCD_WIDTH - 2) ? 2 : 1;   // Value on the next row if it won't fit
+      lcd_moveto((LCD_WIDTH - 1) - (len + 1), valrow);                                           // Right-justified, padded by spaces
+      lcd_put_wchar(' ');                                                                        // Overwrite char if value gets shorter
       lcd_put_u8str(value);
     }
   }
@@ -1144,9 +1144,9 @@ void MarlinUI::draw_status_screen() {
     } custom_char;
 
     typedef struct {
-      uint8_t column, row,
-              x_pixel_offset, y_pixel_offset,
-              x_pixel_mask;
+      lcd_uint_t column, row,
+                 x_pixel_offset, y_pixel_offset;
+      uint8_t x_pixel_mask;
     } coordinate;
 
     void add_edges_to_custom_char(custom_char &custom, const coordinate &ul, const coordinate &lr, const coordinate &brc, const uint8_t cell_location);
@@ -1174,16 +1174,16 @@ void MarlinUI::draw_status_screen() {
       return ret_val;
     }
 
-    inline coordinate pixel_location(const uint8_t x, const uint8_t y) { return pixel_location((int16_t)x, (int16_t)y); }
+    inline coordinate pixel_location(const lcd_uint_t x, const lcd_uint_t y) { return pixel_location((int16_t)x, (int16_t)y); }
 
-    void prep_and_put_map_char(custom_char &chrdata, const coordinate &ul, const coordinate &lr, const coordinate &brc, const uint8_t cl, const char c, const uint8_t x, const uint8_t y) {
+    void prep_and_put_map_char(custom_char &chrdata, const coordinate &ul, const coordinate &lr, const coordinate &brc, const uint8_t cl, const char c, const lcd_uint_t x, const lcd_uint_t y) {
       add_edges_to_custom_char(chrdata, ul, lr, brc, cl);
       lcd.createChar(c, (uint8_t*)&chrdata);
       lcd_moveto(x, y);
       lcd_put_wchar(c);
     }
 
-    void MarlinUI::ubl_plot(const uint8_t x, const uint8_t inverted_y) {
+    void MarlinUI::ubl_plot(const uint8_t x_plot, const uint8_t y_plot) {
 
       #if LCD_WIDTH >= 20
         #define _LCD_W_POS 12
@@ -1209,10 +1209,10 @@ void MarlinUI::draw_status_screen() {
          * Show X and Y positions
          */
         _XLABEL(_PLOT_X, 0);
-        lcd_put_u8str(ftostr52(LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x]))));
+        lcd_put_u8str(ftostr52(LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]))));
 
         _YLABEL(_LCD_W_POS, 0);
-        lcd_put_u8str(ftostr52(LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[inverted_y]))));
+        lcd_put_u8str(ftostr52(LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]))));
 
         lcd_moveto(_PLOT_X, 0);
 
@@ -1220,13 +1220,13 @@ void MarlinUI::draw_status_screen() {
 
         coordinate upper_left, lower_right, bottom_right_corner;
         custom_char new_char;
-        uint8_t i, j, k, l, m, n, n_rows, n_cols, y,
-                bottom_line, right_edge,
-                x_map_pixels, y_map_pixels,
-                pixels_per_x_mesh_pnt, pixels_per_y_mesh_pnt,
-                suppress_x_offset = 0, suppress_y_offset = 0;
+        uint8_t i, n, n_rows, n_cols;
+        lcd_uint_t j, k, l, m, bottom_line, right_edge,
+                   x_map_pixels, y_map_pixels,
+                   pixels_per_x_mesh_pnt, pixels_per_y_mesh_pnt,
+                   suppress_x_offset = 0, suppress_y_offset = 0;
 
-        y = GRID_MAX_POINTS_Y - inverted_y - 1;
+        const uint8_t y_plot_inv = (GRID_MAX_POINTS_Y - 1) - y_plot;
 
         upper_left.column  = 0;
         upper_left.row     = 0;
@@ -1310,12 +1310,12 @@ void MarlinUI::draw_status_screen() {
           new_char.custom_char_bits[j] = (uint8_t)_BV(i);                   // Char #3 is used for the box right edge
         lcd.createChar(CHAR_EDGE_R, (uint8_t*)&new_char);
 
-        i = x * pixels_per_x_mesh_pnt - suppress_x_offset;
-        j = y * pixels_per_y_mesh_pnt - suppress_y_offset;
+        i = x_plot * pixels_per_x_mesh_pnt - suppress_x_offset;
+        j = y_plot_inv * pixels_per_y_mesh_pnt - suppress_y_offset;
         upper_left = pixel_location(i, j);
 
-        k = (x + 1) * pixels_per_x_mesh_pnt - 1 - suppress_x_offset;
-        l = (y + 1) * pixels_per_y_mesh_pnt - 1 - suppress_y_offset;
+        k = (x_plot + 1) * pixels_per_x_mesh_pnt - 1 - suppress_x_offset;
+        l = (y_plot_inv + 1) * pixels_per_y_mesh_pnt - 1 - suppress_y_offset;
         lower_right = pixel_location(k, l);
 
         bottom_right_corner = pixel_location(x_map_pixels, y_map_pixels);
@@ -1327,7 +1327,7 @@ void MarlinUI::draw_status_screen() {
          */
 
         clear_custom_char(&new_char);
-        const uint8_t ypix = _MIN(upper_left.y_pixel_offset + pixels_per_y_mesh_pnt, HD44780_CHAR_HEIGHT);
+        const lcd_uint_t ypix = _MIN(upper_left.y_pixel_offset + pixels_per_y_mesh_pnt, HD44780_CHAR_HEIGHT);
         for (j = upper_left.y_pixel_offset; j < ypix; j++) {
           i = upper_left.x_pixel_mask;
           for (k = 0; k < pixels_per_x_mesh_pnt; k++) {
@@ -1400,9 +1400,9 @@ void MarlinUI::draw_status_screen() {
        */
       lcd_moveto(_LCD_W_POS, 0);
       lcd_put_wchar('(');
-      lcd_put_u8str(ui8tostr3(x));
+      lcd_put_u8str(ui8tostr3(x_plot));
       lcd_put_wchar(',');
-      lcd_put_u8str(ui8tostr3(inverted_y));
+      lcd_put_u8str(ui8tostr3(y_plot));
       lcd_put_wchar(')');
 
       #if LCD_HEIGHT <= 3   // 16x2 or 20x2 display
@@ -1411,8 +1411,8 @@ void MarlinUI::draw_status_screen() {
          * Print Z values
          */
         _ZLABEL(_LCD_W_POS, 1);
-        if (!isnan(ubl.z_values[x][inverted_y]))
-          lcd_put_u8str(ftostr43sign(ubl.z_values[x][inverted_y]));
+        if (!isnan(ubl.z_values[x_plot][y_plot]))
+          lcd_put_u8str(ftostr43sign(ubl.z_values[x_plot][y_plot]));
         else
           lcd_put_u8str_P(PSTR(" -----"));
 
@@ -1422,16 +1422,16 @@ void MarlinUI::draw_status_screen() {
          * Show all values at right of screen
          */
         _XLABEL(_LCD_W_POS, 1);
-        lcd_put_u8str(ftostr52(LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x]))));
+        lcd_put_u8str(ftostr52(LOGICAL_X_POSITION(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]))));
         _YLABEL(_LCD_W_POS, 2);
-        lcd_put_u8str(ftostr52(LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[inverted_y]))));
+        lcd_put_u8str(ftostr52(LOGICAL_Y_POSITION(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]))));
 
         /**
          * Show the location value
          */
         _ZLABEL(_LCD_W_POS, 3);
-        if (!isnan(ubl.z_values[x][inverted_y]))
-          lcd_put_u8str(ftostr43sign(ubl.z_values[x][inverted_y]));
+        if (!isnan(ubl.z_values[x_plot][y_plot]))
+          lcd_put_u8str(ftostr43sign(ubl.z_values[x_plot][y_plot]));
         else
           lcd_put_u8str_P(PSTR(" -----"));
 

--- a/Marlin/src/lcd/dogm/lcdprint_u8g.cpp
+++ b/Marlin/src/lcd/dogm/lcdprint_u8g.cpp
@@ -22,7 +22,7 @@
 
 int lcd_glyph_height(void) { return u8g_GetFontBBXHeight(u8g.getU8g()); }
 
-void lcd_moveto(const uint8_t col, const uint8_t row) { u8g.setPrintPos(col, row); }
+void lcd_moveto(const u8g_uint_t col, const u8g_uint_t row) { u8g.setPrintPos(col, row); }
 
 void lcd_put_int(const int i) { u8g.print(i); }
 

--- a/Marlin/src/lcd/dogm/lcdprint_u8g.cpp
+++ b/Marlin/src/lcd/dogm/lcdprint_u8g.cpp
@@ -22,7 +22,7 @@
 
 int lcd_glyph_height(void) { return u8g_GetFontBBXHeight(u8g.getU8g()); }
 
-void lcd_moveto(const u8g_uint_t col, const u8g_uint_t row) { u8g.setPrintPos(col, row); }
+void lcd_moveto(const lcd_uint_t col, const lcd_uint_t row) { u8g.setPrintPos(col, row); }
 
 void lcd_put_int(const int i) { u8g.print(i); }
 
@@ -33,26 +33,22 @@ int lcd_put_wchar_max(wchar_t c, pixel_len_t max_length) {
     u8g.print((char)c);
     return u8g_GetFontBBXWidth(u8g.getU8g());
   }
-  unsigned int x = u8g.getPrintCol(),
-               y = u8g.getPrintRow(),
-               ret = uxg_DrawWchar(u8g.getU8g(), x, y, c, max_length);
+  u8g_uint_t x = u8g.getPrintCol(), y = u8g.getPrintRow(),
+           ret = uxg_DrawWchar(u8g.getU8g(), x, y, c, max_length);
   u8g.setPrintPos(x + ret, y);
-
   return ret;
 }
 
 int lcd_put_u8str_max(const char * utf8_str, pixel_len_t max_length) {
-  unsigned int x = u8g.getPrintCol(),
-               y = u8g.getPrintRow(),
-               ret = uxg_DrawUtf8Str(u8g.getU8g(), x, y, utf8_str, max_length);
+  u8g_uint_t x = u8g.getPrintCol(), y = u8g.getPrintRow(),
+           ret = uxg_DrawUtf8Str(u8g.getU8g(), x, y, utf8_str, max_length);
   u8g.setPrintPos(x + ret, y);
   return ret;
 }
 
 int lcd_put_u8str_max_P(PGM_P utf8_str_P, pixel_len_t max_length) {
-  unsigned int x = u8g.getPrintCol(),
-               y = u8g.getPrintRow(),
-               ret = uxg_DrawUtf8StrP(u8g.getU8g(), x, y, utf8_str_P, max_length);
+  u8g_uint_t x = u8g.getPrintCol(), y = u8g.getPrintRow(),
+           ret = uxg_DrawUtf8StrP(u8g.getU8g(), x, y, utf8_str_P, max_length);
   u8g.setPrintPos(x + ret, y);
   return ret;
 }

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -164,22 +164,22 @@ void MarlinUI::set_font(const MarlinFont font_nr) {
   void MarlinUI::draw_marlin_bootscreen() {
     // Screen dimensions.
     //const uint8_t width = u8g.getWidth(), height = u8g.getHeight();
-    constexpr uint8_t width = LCD_PIXEL_WIDTH, height = LCD_PIXEL_HEIGHT;
+    constexpr u8g_uint_t width = LCD_PIXEL_WIDTH, height = LCD_PIXEL_HEIGHT;
 
     // Determine text space needed
     #ifndef STRING_SPLASH_LINE2
-      constexpr uint8_t text_total_height = MENU_FONT_HEIGHT,
+      constexpr u8g_uint_t text_total_height = MENU_FONT_HEIGHT,
                         text_width_1 = uint8_t(sizeof(STRING_SPLASH_LINE1) - 1) * uint8_t(MENU_FONT_WIDTH),
                         text_width_2 = 0;
     #else
-      constexpr uint8_t text_total_height = uint8_t(MENU_FONT_HEIGHT) * 2,
-                        text_width_1 = uint8_t(sizeof(STRING_SPLASH_LINE1) - 1) * uint8_t(MENU_FONT_WIDTH),
-                        text_width_2 = uint8_t(sizeof(STRING_SPLASH_LINE2) - 1) * uint8_t(MENU_FONT_WIDTH);
+      constexpr u8g_uint_t text_total_height = u8g_uint_t(MENU_FONT_HEIGHT) * 2,
+                        text_width_1 = u8g_uint_t(sizeof(STRING_SPLASH_LINE1) - 1) * uint8_t(MENU_FONT_WIDTH),
+                        text_width_2 = u8g_uint_t(sizeof(STRING_SPLASH_LINE2) - 1) * uint8_t(MENU_FONT_WIDTH);
     #endif
-    constexpr uint8_t text_max_width = _MAX(text_width_1, text_width_2),
+    constexpr u8g_uint_t text_max_width = _MAX(text_width_1, text_width_2),
                       rspace = width - (START_BMPWIDTH);
 
-    int8_t offx, offy, txt_base, txt_offx_1, txt_offx_2;
+    u8g_int_t offx, offy, txt_base, txt_offx_1, txt_offx_2;
 
     // Can the text fit to the right of the bitmap?
     if (text_max_width < rspace) {

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -108,7 +108,7 @@ void MarlinUI::set_font(const MarlinFont font_nr) {
     // Draws a slice of a particular frame of the custom bootscreen, without the u8g loop
     void MarlinUI::draw_custom_bootscreen(const uint8_t frame/*=0*/) {
       constexpr u8g_uint_t left = u8g_uint_t((LCD_PIXEL_WIDTH  - (CUSTOM_BOOTSCREEN_BMPWIDTH)) / 2),
-                           top = u8g_uint_t((LCD_PIXEL_HEIGHT - (CUSTOM_BOOTSCREEN_BMPHEIGHT)) / 2);
+                            top = u8g_uint_t((LCD_PIXEL_HEIGHT - (CUSTOM_BOOTSCREEN_BMPHEIGHT)) / 2);
       #if ENABLED(CUSTOM_BOOTSCREEN_INVERTED)
         constexpr u8g_uint_t right = left + CUSTOM_BOOTSCREEN_BMPWIDTH,
                             bottom = top + CUSTOM_BOOTSCREEN_BMPHEIGHT;
@@ -163,21 +163,21 @@ void MarlinUI::set_font(const MarlinFont font_nr) {
   // Draws a slice of the Marlin bootscreen, without the u8g loop
   void MarlinUI::draw_marlin_bootscreen() {
     // Screen dimensions.
-    //const uint8_t width = u8g.getWidth(), height = u8g.getHeight();
+    //const u8g_uint_t width = u8g.getWidth(), height = u8g.getHeight();
     constexpr u8g_uint_t width = LCD_PIXEL_WIDTH, height = LCD_PIXEL_HEIGHT;
 
     // Determine text space needed
     #ifndef STRING_SPLASH_LINE2
       constexpr u8g_uint_t text_total_height = MENU_FONT_HEIGHT,
-                        text_width_1 = uint8_t(sizeof(STRING_SPLASH_LINE1) - 1) * uint8_t(MENU_FONT_WIDTH),
-                        text_width_2 = 0;
+                           text_width_1 = u8g_uint_t(sizeof(STRING_SPLASH_LINE1) - 1) * u8g_uint_t(MENU_FONT_WIDTH),
+                           text_width_2 = 0;
     #else
       constexpr u8g_uint_t text_total_height = u8g_uint_t(MENU_FONT_HEIGHT) * 2,
-                        text_width_1 = u8g_uint_t(sizeof(STRING_SPLASH_LINE1) - 1) * uint8_t(MENU_FONT_WIDTH),
-                        text_width_2 = u8g_uint_t(sizeof(STRING_SPLASH_LINE2) - 1) * uint8_t(MENU_FONT_WIDTH);
+                           text_width_1 = u8g_uint_t(sizeof(STRING_SPLASH_LINE1) - 1) * u8g_uint_t(MENU_FONT_WIDTH),
+                           text_width_2 = u8g_uint_t(sizeof(STRING_SPLASH_LINE2) - 1) * u8g_uint_t(MENU_FONT_WIDTH);
     #endif
     constexpr u8g_uint_t text_max_width = _MAX(text_width_1, text_width_2),
-                      rspace = width - (START_BMPWIDTH);
+                         rspace = width - (START_BMPWIDTH);
 
     u8g_int_t offx, offy, txt_base, txt_offx_1, txt_offx_2;
 
@@ -286,7 +286,7 @@ void MarlinUI::draw_kill_screen() {
   #if ENABLED(LIGHTWEIGHT_UI)
     ST7920_Lite_Status_Screen::clear_text_buffer();
   #endif
-  const uint8_t h4 = u8g.getHeight() / 4;
+  const u8g_uint_t h4 = u8g.getHeight() / 4;
   u8g.firstPage();
   do {
     set_font(FONT_MENU);
@@ -303,7 +303,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
 #if HAS_LCD_MENU
 
-  uint8_t row_y1, row_y2;
+  u8g_uint_t row_y1, row_y2;
 
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
 
@@ -360,7 +360,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
     if (mark_as_selected(row, invert)) {
 
-      uint8_t n = LCD_PIXEL_WIDTH; // pixel width of string allowed
+      u8g_uint_t n = LCD_PIXEL_WIDTH; // pixel width of string allowed
 
       if (center && !valstr) {
         int8_t pad = (LCD_WIDTH - utf8_strlen_P(pstr)) / 2;
@@ -377,7 +377,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
     UNUSED(pre_char);
 
     if (mark_as_selected(row, sel)) {
-      uint8_t n = (LCD_WIDTH - 2) * (MENU_FONT_WIDTH);
+      u8g_uint_t n = (LCD_WIDTH - 2) * (MENU_FONT_WIDTH);
       n -= lcd_put_u8str_max_P(pstr, n);
       while (n > MENU_FONT_WIDTH) n -= lcd_put_wchar(' ');
       lcd_moveto(LCD_PIXEL_WIDTH - (MENU_FONT_WIDTH), row_y2);
@@ -390,7 +390,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
   void _draw_menu_item_edit(const bool sel, const uint8_t row, PGM_P const pstr, const char* const data, const bool pgm) {
     if (mark_as_selected(row, sel)) {
       const uint8_t vallen = (pgm ? utf8_strlen_P(data) : utf8_strlen((char*)data));
-      uint8_t n = (LCD_WIDTH - 2 - vallen) * (MENU_FONT_WIDTH);
+      u8g_uint_t n = (LCD_WIDTH - 2 - vallen) * (MENU_FONT_WIDTH);
       n -= lcd_put_u8str_max_P(pstr, n);
       lcd_put_wchar(':');
       while (n > MENU_FONT_WIDTH) n -= lcd_put_wchar(' ');
@@ -402,13 +402,13 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
   void draw_edit_screen(PGM_P const pstr, const char* const value/*=nullptr*/) {
     ui.encoder_direction_normal();
 
-    const uint8_t labellen = utf8_strlen_P(pstr), vallen = utf8_strlen(value);
+    const u8g_uint_t labellen = utf8_strlen_P(pstr), vallen = utf8_strlen(value);
     bool extra_row = labellen > LCD_WIDTH - 2 - vallen;
 
     #if ENABLED(USE_BIG_EDIT_FONT)
       // Use the menu font if the label won't fit on a single line
-      constexpr uint8_t lcd_edit_width = (LCD_PIXEL_WIDTH) / (EDIT_FONT_WIDTH);
-      uint8_t lcd_chr_fit, one_chr_width;
+      constexpr u8g_uint_t lcd_edit_width = (LCD_PIXEL_WIDTH) / (EDIT_FONT_WIDTH);
+      u8g_uint_t lcd_chr_fit, one_chr_width;
       if (labellen <= lcd_edit_width - 1) {
         if (labellen + vallen + 1 > lcd_edit_width) extra_row = true;
         lcd_chr_fit = lcd_edit_width + 1;
@@ -421,13 +421,13 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
         ui.set_font(FONT_MENU);
       }
     #else
-      constexpr uint8_t lcd_chr_fit = LCD_WIDTH,
-                        one_chr_width = MENU_FONT_WIDTH;
+      constexpr u8g_uint_t lcd_chr_fit = LCD_WIDTH,
+                           one_chr_width = MENU_FONT_WIDTH;
     #endif
 
     // Center the label and value lines on the middle line
-    uint8_t baseline = extra_row ? (LCD_PIXEL_HEIGHT) / 2 - 1
-                                 : (LCD_PIXEL_HEIGHT + EDIT_FONT_ASCENT) / 2;
+    u8g_uint_t baseline = extra_row ? (LCD_PIXEL_HEIGHT) / 2 - 1
+                                    : (LCD_PIXEL_HEIGHT + EDIT_FONT_ASCENT) / 2;
 
     // Assume the label is alpha-numeric (with a descender)
     bool onpage = PAGE_CONTAINS(baseline - (EDIT_FONT_ASCENT - 1), baseline + EDIT_FONT_DESCENT);
@@ -452,9 +452,9 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
     }
   }
 
-  inline void draw_boxed_string(const uint8_t x, const uint8_t y, PGM_P const pstr, const bool inv) {
-    const uint8_t len = utf8_strlen_P(pstr), bw = len * (MENU_FONT_WIDTH),
-                  bx = x * (MENU_FONT_WIDTH), by = (y + 1) * (MENU_FONT_HEIGHT);
+  inline void draw_boxed_string(const u8g_uint_t x, const u8g_uint_t y, PGM_P const pstr, const bool inv) {
+    const u8g_uint_t len = utf8_strlen_P(pstr), bw = len * (MENU_FONT_WIDTH),
+                     bx = x * (MENU_FONT_WIDTH), by = (y + 1) * (MENU_FONT_HEIGHT);
     if (inv) {
       u8g.setColorIndex(1);
       u8g.drawBox(bx - 1, by - (MENU_FONT_ASCENT) + 1, bw + 2, MENU_FONT_HEIGHT - 1);
@@ -479,8 +479,8 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
       if (mark_as_selected(row, sel)) {
         if (isDir) lcd_put_wchar(LCD_STR_FOLDER[0]);
         constexpr uint8_t maxlen = LCD_WIDTH - 1;
-        const uint8_t pixw = maxlen * (MENU_FONT_WIDTH);
-        uint8_t n = pixw - lcd_put_u8str_max(ui.scrolled_filename(theCard, maxlen, row, sel), pixw);
+        const u8g_uint_t pixw = maxlen * (MENU_FONT_WIDTH);
+        u8g_uint_t n = pixw - lcd_put_u8str_max(ui.scrolled_filename(theCard, maxlen, row, sel), pixw);
         while (n > MENU_FONT_WIDTH) n -= lcd_put_wchar(' ');
       }
     }
@@ -499,8 +499,8 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
     void MarlinUI::ubl_plot(const uint8_t x_plot, const uint8_t y_plot) {
       // Scale the box pixels appropriately
-      uint8_t x_map_pixels = ((MAP_MAX_PIXELS_X - 4) / (GRID_MAX_POINTS_X)) * (GRID_MAX_POINTS_X),
-              y_map_pixels = ((MAP_MAX_PIXELS_Y - 4) / (GRID_MAX_POINTS_Y)) * (GRID_MAX_POINTS_Y),
+      u8g_uint_t x_map_pixels = ((MAP_MAX_PIXELS_X - 4) / (GRID_MAX_POINTS_X)) * (GRID_MAX_POINTS_X),
+                 y_map_pixels = ((MAP_MAX_PIXELS_Y - 4) / (GRID_MAX_POINTS_Y)) * (GRID_MAX_POINTS_Y),
 
               pixels_per_x_mesh_pnt = x_map_pixels / (GRID_MAX_POINTS_X),
               pixels_per_y_mesh_pnt = y_map_pixels / (GRID_MAX_POINTS_Y),
@@ -522,8 +522,8 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
       // Display Mesh Point Locations
 
       u8g.setColorIndex(1);
-      const uint8_t sx = x_offset + pixels_per_x_mesh_pnt / 2;
-            uint8_t  y = y_offset + pixels_per_y_mesh_pnt / 2;
+      const u8g_uint_t sx = x_offset + pixels_per_x_mesh_pnt / 2;
+            u8g_uint_t  y = y_offset + pixels_per_y_mesh_pnt / 2;
       for (uint8_t j = 0; j < GRID_MAX_POINTS_Y; j++, y += pixels_per_y_mesh_pnt)
         if (PAGE_CONTAINS(y, y))
           for (uint8_t i = 0, x = sx; i < GRID_MAX_POINTS_X; i++, x += pixels_per_x_mesh_pnt)
@@ -531,10 +531,10 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
       // Fill in the Specified Mesh Point
 
-      uint8_t inverted_y = GRID_MAX_POINTS_Y - y_plot - 1;  // The origin is typically in the lower right corner.  We need to
-                                                            // invert the Y to get it to plot in the right location.
+      const uint8_t y_plot_inv = (GRID_MAX_POINTS_Y - 1) - y_plot;  // The origin is typically in the lower right corner.  We need to
+                                                                    // invert the Y to get it to plot in the right location.
 
-      const uint8_t by = y_offset + inverted_y * pixels_per_y_mesh_pnt;
+      const u8g_uint_t by = y_offset + y_plot_inv * pixels_per_y_mesh_pnt;
       if (PAGE_CONTAINS(by, by + pixels_per_y_mesh_pnt))
         u8g.drawBox(
           x_offset + x_plot * pixels_per_x_mesh_pnt, by,

--- a/Marlin/src/lcd/lcdprint.h
+++ b/Marlin/src/lcd/lcdprint.h
@@ -48,7 +48,11 @@ int lcd_put_u8str_max(const char * utf8_str, pixel_len_t max_length);
  */
 int lcd_put_u8str_max_P(PGM_P utf8_str_P, pixel_len_t max_length);
 
-void lcd_moveto(const u8g_uint_t col, const u8g_uint_t row);
+#if HAS_GRAPHICAL_LCD
+  void lcd_moveto(const u8g_uint_t col, const u8g_uint_t row);
+#else
+  void lcd_moveto(const u_int8_t col, const u_int8_t row);
+#endif
 
 void lcd_put_int(const int i);
 

--- a/Marlin/src/lcd/lcdprint.h
+++ b/Marlin/src/lcd/lcdprint.h
@@ -48,7 +48,7 @@ int lcd_put_u8str_max(const char * utf8_str, pixel_len_t max_length);
  */
 int lcd_put_u8str_max_P(PGM_P utf8_str_P, pixel_len_t max_length);
 
-void lcd_moveto(const uint8_t col, const uint8_t row);
+void lcd_moveto(const u8g_uint_t col, const u8g_uint_t row);
 
 void lcd_put_int(const int i);
 

--- a/Marlin/src/lcd/lcdprint.h
+++ b/Marlin/src/lcd/lcdprint.h
@@ -14,8 +14,10 @@
 
 #if HAS_GRAPHICAL_LCD
   #include "dogm/u8g_fontutf8.h"
+  typedef u8g_uint_t lcd_uint_t;
 #else
   #define _UxGT(a) a
+  typedef uint8_t lcd_uint_t;
 #endif
 
 #define START_OF_UTF8_CHAR(C) (((C) & 0xC0u) != 0x80u)
@@ -48,11 +50,7 @@ int lcd_put_u8str_max(const char * utf8_str, pixel_len_t max_length);
  */
 int lcd_put_u8str_max_P(PGM_P utf8_str_P, pixel_len_t max_length);
 
-#if HAS_GRAPHICAL_LCD
-  void lcd_moveto(const u8g_uint_t col, const u8g_uint_t row);
-#else
-  void lcd_moveto(const u_int8_t col, const u_int8_t row);
-#endif
+void lcd_moveto(const lcd_uint_t col, const lcd_uint_t row);
 
 void lcd_put_int(const int i);
 

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -37,10 +37,9 @@ static int16_t ubl_storage_slot = 0,
                custom_hotend_temp = 190,
                side_points = 3,
                ubl_fillin_amount = 5,
-               ubl_height_amount = 1,
-               n_edit_pts = 1,
-               x_plot = 0,
-               y_plot = 0;
+               ubl_height_amount = 1;
+
+static uint8_t n_edit_pts = 1, x_plot = 0, y_plot = 0;
 
 #if HAS_HEATED_BED
   static int16_t custom_bed_temp = 50;
@@ -423,7 +422,7 @@ void _lcd_ubl_map_lcd_edit_cmd() {
   char ubl_lcd_gcode[50], str[10], str2[10];
   dtostrf(pgm_read_float(&ubl._mesh_index_to_xpos[x_plot]), 0, 2, str);
   dtostrf(pgm_read_float(&ubl._mesh_index_to_ypos[y_plot]), 0, 2, str2);
-  snprintf_P(ubl_lcd_gcode, sizeof(ubl_lcd_gcode), PSTR("G29 P4 X%s Y%s R%i"), str, str2, n_edit_pts);
+  snprintf_P(ubl_lcd_gcode, sizeof(ubl_lcd_gcode), PSTR("G29 P4 X%s Y%s R%i"), str, str2, int(n_edit_pts));
   lcd_enqueue_one_now(ubl_lcd_gcode);
 }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -205,13 +205,13 @@ millis_t next_button_update_ms;
 
   #endif
 
-  void _wrap_string(uint8_t &x, uint8_t &y, const char * const string, read_byte_cb_t cb_read_byte, bool wordwrap/*=false*/) {
-    SETCURSOR(x, y);
+  void _wrap_string(uint8_t &col, uint8_t &row, const char * const string, read_byte_cb_t cb_read_byte, bool wordwrap/*=false*/) {
+    SETCURSOR(col, row);
     if (!string) return;
 
-    auto _newline = [&x, &y]() {
-      x = 0; y++;               // move x to string len (plus space)
-      SETCURSOR(0, y);          // simulate carriage return
+    auto _newline = [&col, &row]() {
+      col = 0; row++;                 // Move col to string len (plus space)
+      SETCURSOR(0, row);              // Simulate carriage return
     };
 
     uint8_t *p = (uint8_t*)string;
@@ -227,9 +227,9 @@ millis_t next_button_update_ms;
         if (eol || ch == ' ' || ch == '-' || ch == '+' || ch == '.') {
           if (!c && ch == ' ') { if (wrd) wrd++; continue; } // collapse extra spaces
           // Past the right and the word is not too long?
-          if (x + c > LCD_WIDTH && x >= (LCD_WIDTH) / 4) _newline(); // should it wrap?
+          if (col + c > LCD_WIDTH && col >= (LCD_WIDTH) / 4) _newline(); // should it wrap?
           c += !eol;                  // +1 so the space will be printed
-          x += c;                     // advance x to new position
+          col += c;                   // advance col to new position
           while (c) {                 // character countdown
             --c;                      // count down to zero
             wrd = get_utf8_value_cb(wrd, cb_read_byte, &ch); // get characters again
@@ -246,25 +246,25 @@ millis_t next_button_update_ms;
         p = get_utf8_value_cb(p, cb_read_byte, &ch);
         if (!ch) break;
         lcd_put_wchar(ch);
-        x++;
-        if (x >= LCD_WIDTH) _newline();
+        col++;
+        if (col >= LCD_WIDTH) _newline();
       }
     }
   }
 
   void MarlinUI::draw_select_screen_prompt(PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
     const uint8_t plen = utf8_strlen_P(pref), slen = suff ? utf8_strlen_P(suff) : 0;
-    uint8_t x = 0, y = 0;
+    uint8_t row = 0, col = 0;
     if (!string && plen + slen <= LCD_WIDTH) {
-      x = (LCD_WIDTH - plen - slen) / 2;
-      y = LCD_HEIGHT > 3 ? 1 : 0;
+      row = (LCD_WIDTH - plen - slen) / 2;
+      col = LCD_HEIGHT > 3 ? 1 : 0;
     }
-    wrap_string_P(x, y, pref, true);
+    wrap_string_P(row, col, pref, true);
     if (string) {
-      if (x) { x = 0; y++; } // Move to the start of the next line
-      wrap_string(x, y, string);
+      if (row) { row = 0; col++; } // Move to the start of the next line
+      wrap_string(row, col, string);
     }
-    if (suff) wrap_string_P(x, y, suff);
+    if (suff) wrap_string_P(row, col, suff);
   }
 
 #endif // HAS_LCD_MENU

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -76,11 +76,11 @@
       #define LCDWRITE(c) lcd_put_wchar(c)
     #endif
 
-    #include "fontutils.h"
+    #include "lcdprint.h"
 
-    void _wrap_string(uint8_t &x, uint8_t &y, const char * const string, read_byte_cb_t cb_read_byte, const bool wordwrap=false);
-    inline void wrap_string_P(uint8_t &x, uint8_t &y, PGM_P const pstr, const bool wordwrap=false) { _wrap_string(x, y, pstr, read_byte_rom, wordwrap); }
-    inline void wrap_string(uint8_t &x, uint8_t &y, const char * const string, const bool wordwrap=false) { _wrap_string(x, y, string, read_byte_ram, wordwrap); }
+    void _wrap_string(uint8_t &col, uint8_t &row, const char * const string, read_byte_cb_t cb_read_byte, const bool wordwrap=false);
+    inline void wrap_string_P(uint8_t &col, uint8_t &row, PGM_P const pstr, const bool wordwrap=false) { _wrap_string(col, row, pstr, read_byte_rom, wordwrap); }
+    inline void wrap_string(uint8_t &col, uint8_t &row, const char * const string, const bool wordwrap=false) { _wrap_string(col, row, string, read_byte_ram, wordwrap); }
 
     #if ENABLED(SDSUPPORT)
       #include "../sd/cardreader.h"
@@ -486,7 +486,7 @@ public:
     #endif
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-      static void ubl_plot(const uint8_t x, const uint8_t inverted_y);
+      static void ubl_plot(const uint8_t x_plot, const uint8_t y_plot);
     #endif
 
     static void draw_select_screen_prompt(PGM_P const pref, const char * const string=nullptr, PGM_P const suff=nullptr);


### PR DESCRIPTION
if the screen bigger than 240 then uint8 is not enough, we have to use uint16. 

Lucky, u8g.h have make it easy. 
Just enable U8G_16BIT in u8g.h file (better enable it from platformio)

Here is u8g.h line no 170
```
#if defined(U8G_16BIT)
  typedef uint16_t u8g_uint_t;
  typedef int16_t u8g_int_t;
#else
  typedef uint8_t u8g_uint_t;
  typedef int8_t u8g_int_t;
#endif
```
now we can use u8g_uint_t and u8g_int_t variable type.
