### PR TITLE
Fix missing U8glib.h include

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/dogm/u8g_com_HAL_DUE_sw_spi_shared.h
+++ b/Marlin/src/HAL/HAL_DUE/dogm/u8g_com_HAL_DUE_sw_spi_shared.h
@@ -23,6 +23,7 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 #include "../../shared/Marduino.h"
+#include <U8glib.h>
 
 void u8g_SetPIOutput_DUE(u8g_t *u8g, uint8_t pin_index);
 void u8g_SetPILevel_DUE(u8g_t *u8g, uint8_t pin_index, uint8_t level);


### PR DESCRIPTION
This fixes the problem reported by Issue #14932.

Compile errors were being generated by DUE's U8G SPI code.  The fix is to add a reference to the UG8 library to u8g_com_HAL_DUE_sw_spi_shared.h