### PR TITLE
ExtUI Fixes

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -319,6 +319,9 @@ namespace ExtUI {
       }
     #endif
 
+    constexpr float max_manual_feedrate[XYZE] = MAX_MANUAL_FEEDRATE;
+    setFeedrate_mm_s(max_manual_feedrate[axis]);
+
     if (!flags.manual_motion) set_destination_from_current();
     destination[axis] = clamp(position, min, max);
     flags.manual_motion = true;
@@ -327,6 +330,8 @@ namespace ExtUI {
   void setAxisPosition_mm(const float position, const extruder_t extruder) {
     setActiveTool(extruder, true);
 
+    constexpr float max_manual_feedrate[XYZE] = MAX_MANUAL_FEEDRATE;
+    setFeedrate_mm_s(max_manual_feedrate[E_AXIS]);
     if (!flags.manual_motion) set_destination_from_current();
     destination[E_AXIS] = position;
     flags.manual_motion = true;

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -60,7 +60,7 @@
   #include "../../libs/numtostr.h"
 #endif
 
-#if DO_SWITCH_EXTRUDER || EITHER(SWITCHING_NOZZLE, PARKING_EXTRUDER)
+#if EXTRUDERS > 1
   #include "../../module/tool_change.h"
 #endif
 
@@ -267,8 +267,12 @@ namespace ExtUI {
     return flags.manual_motion ? destination[axis] : current_position[axis];
   }
 
-  float getAxisPosition_mm(const extruder_t) {
-    return flags.manual_motion ? destination[E_AXIS] : current_position[E_AXIS];
+  float getAxisPosition_mm(const extruder_t extruder) {
+    const unit8_t old_tool = active_extruder;
+    setActiveTool(extruder, true);
+    float pos = flags.manual_motion ? destination[E_AXIS] : current_position[E_AXIS];
+    setActiveTool(old_tool, true);
+    return pos;
   }
 
   void setAxisPosition_mm(const float position, const axis_t axis) {
@@ -363,9 +367,7 @@ namespace ExtUI {
   void setActiveTool(const extruder_t extruder, bool no_move) {
     #if EXTRUDERS > 1
       const uint8_t e = extruder - E0;
-      #if DO_SWITCH_EXTRUDER || EITHER(SWITCHING_NOZZLE, PARKING_EXTRUDER)
-        if (e != active_extruder) tool_change(e, no_move);
-      #endif
+      if (e != active_extruder) tool_change(e, no_move);
       active_extruder = e;
     #else
       UNUSED(extruder);

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -268,7 +268,7 @@ namespace ExtUI {
   }
 
   float getAxisPosition_mm(const extruder_t extruder) {
-    const unit8_t old_tool = active_extruder;
+    const uint8_t old_tool = active_extruder;
     setActiveTool(extruder, true);
     float pos = flags.manual_motion ? destination[E_AXIS] : current_position[E_AXIS];
     setActiveTool(old_tool, true);
@@ -319,7 +319,7 @@ namespace ExtUI {
       }
     #endif
 
-    constexpr float max_manual_feedrate[XYZE] = MAX_MANUAL_FEEDRATE;
+    constexpr float max_manual_feedrate[XYZE] = MANUAL_FEEDRATE;
     setFeedrate_mm_s(max_manual_feedrate[axis]);
 
     if (!flags.manual_motion) set_destination_from_current();
@@ -330,7 +330,7 @@ namespace ExtUI {
   void setAxisPosition_mm(const float position, const extruder_t extruder) {
     setActiveTool(extruder, true);
 
-    constexpr float max_manual_feedrate[XYZE] = MAX_MANUAL_FEEDRATE;
+    constexpr float max_manual_feedrate[XYZE] = MANUAL_FEEDRATE;
     setFeedrate_mm_s(max_manual_feedrate[E_AXIS]);
     if (!flags.manual_motion) set_destination_from_current();
     destination[E_AXIS] = position;

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -270,7 +270,7 @@ namespace ExtUI {
   float getAxisPosition_mm(const extruder_t extruder) {
     const uint8_t old_tool = active_extruder;
     setActiveTool(extruder, true);
-    float pos = flags.manual_motion ? destination[E_AXIS] : current_position[E_AXIS];
+    const float pos = flags.manual_motion ? destination[E_AXIS] : current_position[E_AXIS];
     setActiveTool(old_tool, true);
     return pos;
   }


### PR DESCRIPTION
Fix extui get position for inactive extruder
Ensure all tool types utilize tool_change instead of just a select few
Set manual moves to use configured feedrate instead of prior