### PR TITLE
Always supply DEFAULT_[XYZ]JERK in Delta printer configuration examples.

### DIFF
--- a/config/examples/delta/Anycubic/Kossel/Configuration.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration.h
@@ -897,12 +897,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK  5.0
-  #define DEFAULT_YJERK  DEFAULT_XJERK
-  #define DEFAULT_ZJERK  DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK  5.0
+#define DEFAULT_YJERK  DEFAULT_XJERK
+#define DEFAULT_ZJERK  DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/Dreammaker/Overlord/Configuration.h
+++ b/config/examples/delta/Dreammaker/Overlord/Configuration.h
@@ -848,12 +848,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/Dreammaker/Overlord_Pro/Configuration.h
+++ b/config/examples/delta/Dreammaker/Overlord_Pro/Configuration.h
@@ -860,12 +860,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration.h
@@ -849,12 +849,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/FLSUN/kossel/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration.h
@@ -849,12 +849,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration.h
@@ -849,12 +849,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration.h
@@ -839,12 +839,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/Hatchbox_Alpha/Configuration.h
+++ b/config/examples/delta/Hatchbox_Alpha/Configuration.h
@@ -854,12 +854,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 20.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 20.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/MKS/SBASE/Configuration.h
+++ b/config/examples/delta/MKS/SBASE/Configuration.h
@@ -839,12 +839,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/Tevo Little Monster/Configuration.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration.h
@@ -843,12 +843,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/generic/Configuration.h
+++ b/config/examples/delta/generic/Configuration.h
@@ -839,12 +839,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/kossel_mini/Configuration.h
+++ b/config/examples/delta/kossel_mini/Configuration.h
@@ -839,12 +839,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/kossel_pro/Configuration.h
+++ b/config/examples/delta/kossel_pro/Configuration.h
@@ -832,12 +832,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK    5.0  // May be used by Linear Advance
 

--- a/config/examples/delta/kossel_xl/Configuration.h
+++ b/config/examples/delta/kossel_xl/Configuration.h
@@ -842,12 +842,13 @@
  * "Jerk" specifies the minimum speed change that requires acceleration.
  * When changing speed and direction, if the difference is less than the
  * value set here, it may happen instantaneously.
+ *
+ * NOTE: Delta printers still require default jerk values if using
+ * JUNCTION_DEVIATION.
  */
-#if DISABLED(JUNCTION_DEVIATION)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK DEFAULT_XJERK
-  #define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
-#endif
+#define DEFAULT_XJERK 10.0
+#define DEFAULT_YJERK DEFAULT_XJERK
+#define DEFAULT_ZJERK DEFAULT_XJERK // Must be same as XY for delta
 
 #define DEFAULT_EJERK   20.0  // May be used by Linear Advance
 


### PR DESCRIPTION
### Description

Fixes the user facing side of the problem for #14976 by always providing jerk values, even when using JD. I'm not really sure if there's a better core fix to be done here as I'm not too sure of the intricacies.

The file `configuration_store.cpp` sets all the jerk values to `0` if nothing is provided --- maybe this should just be above `0` by default?

### Benefits

Users with delta printers won't experience mad stuttering when using JD --- see #14976 for more details.

### Related Issues

Makes #14976 better for users but maybe doesn't solve the core issue.
