### PR TITLE
Creality pin updates

### DIFF
--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -39,7 +39,7 @@
   #define FIL_RUNOUT2_PIN 15 // Creality CR-X can use dual runout sensors
 #endif
 
-#define SD_DETECT_PIN 49 //always define it here, even without an LCD as its onboard
+#define SD_DETECT_PIN 49   // Always define onboard SD detect
 
 #include "pins_RAMPS.h"
 

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -35,6 +35,10 @@
 #define MOSFET_D_PIN 7
 
 #define FIL_RUNOUT_PIN 2
+#if NUM_RUNOUT_SENSORS > 1
+  #define FIL_RUNOUT2_PIN 15 // Creality CR-X can use dual runout sensors
+#endif
+
 #define SD_DETECT_PIN 49 //always define it here, even without an LCD as its onboard
 
 #include "pins_RAMPS.h"

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -35,6 +35,7 @@
 #define MOSFET_D_PIN 7
 
 #define FIL_RUNOUT_PIN 2
+#define SD_DETECT_PIN 49 //always define it here, even without an LCD as its onboard
 
 #include "pins_RAMPS.h"
 


### PR DESCRIPTION
Since the CR10SPro, 10Max, CRX, and Ender5Plus all use external touchscreens but still have onboard displays, they need the sddetect pin defined regardless of if a lcd is defined in the ramps file.

Also adds filament runout 2 pin for CR-X