### PR TITLE
Remove extra M503 "M412" report

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2798,12 +2798,6 @@ void MarlinSettings::reset() {
       }
     #endif
 
-    #if HAS_FILAMENT_SENSOR
-      CONFIG_ECHO_HEADING("Filament Runout Sensor:");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR("  M412 S", int(runout.enabled));
-    #endif
-
     /**
      * Bed Leveling
      */


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

MarlinSettings::report prints out the filament runout sensor state twice. Once on line 2801 and once on line 3423.
I dont any reason we need it printed twice so removed the first report. The 2nd prints the runout distance as well as the sensor state, i.e. prints out additional info.

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Saves a few bytes. Removes dup code.

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
