### PR TITLE
Clean up PlatformIO lib_ignore

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -262,14 +262,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   -DDEBUG_LEVEL=0
 build_unflags = -std=gnu++11
 lib_deps      = ${common.lib_deps}
-lib_ignore    = U8glib-HAL
-  TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
-#lib_ldf_mode  = chain
+lib_ignore    = U8glib-HAL, TMC26XStepper, Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed = 250000
 
@@ -277,52 +270,44 @@ monitor_speed = 250000
 # fysetc_STM32F1
 #
 [env:fysetc_STM32F1]
-platform      = ststm32
-framework     = arduino
-board         = genericSTM32F103RC
-extra_scripts = buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
-build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
+platform          = ststm32
+framework         = arduino
+board             = genericSTM32F103RC
+#board_build.core = maple
+platform_packages = tool-stm32duino
+extra_scripts     = buildroot/share/PlatformIO/scripts/fysetc_STM32F1.py
+build_flags       = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   ${common.build_flags} -std=gnu++14
   -DDEBUG_LEVEL=0 -DHAVE_SW_SERIAL
-build_unflags = -std=gnu++11
-lib_deps      = ${common.lib_deps}
+build_unflags     = -std=gnu++11
+lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore    = TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
-lib_ldf_mode  = chain
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed = 250000
-debug_tool    = stlink
-upload_protocol = serial
+lib_ignore        = TMC26XStepper, Adafruit NeoPixel
+lib_ldf_mode      = chain
+src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
+monitor_speed     = 250000
+debug_tool        = stlink
+upload_protocol   = serial
 
 #
 # BigTree SKR Mini V1.1 / SKR mini E3 / SKR E3 DIP (STM32F103RCT6 ARM Cortex-M3)
 #
 [env:BIGTREE_SKR_MINI]
-platform      = ststm32
-framework     = arduino
-board         = genericSTM32F103RC
-extra_scripts = buildroot/share/PlatformIO/scripts/STM32F1_SKR_MINI.py
-build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
+platform          = ststm32
+framework         = arduino
+board             = genericSTM32F103RC
+platform_packages = tool-stm32duino
+extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F1_SKR_MINI.py
+build_flags       = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   ${common.build_flags} -std=gnu++14
   -DDEBUG_LEVEL=0
-build_unflags = -std=gnu++11
-lib_deps      = ${common.lib_deps}
-lib_ignore    = TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
-#lib_ldf_mode  = chain
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed = 115200
-upload_protocol = stlink
-debug_tool = stlink
+build_unflags     = -std=gnu++11
+lib_deps          = ${common.lib_deps}
+lib_ignore        = TMC26XStepper, Adafruit NeoPixel
+src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
+monitor_speed     = 115200
+upload_protocol   = stlink
+debug_tool        = stlink
 
 #
 # STM32F4 with STM32GENERIC
@@ -331,10 +316,10 @@ debug_tool = stlink
 platform      = ststm32
 framework     = arduino
 board         = disco_f407vg
-build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB
+build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F4 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, TMC26XStepper, TMCStepper
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/*> +<src/HAL/HAL_STM32_F4_F7/STM32F4>
+lib_ignore    = Adafruit NeoPixel, TMCStepper, TMC26XStepper
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F7>
 monitor_speed = 250000
 
 #
@@ -343,11 +328,11 @@ monitor_speed = 250000
 [env:STM32F7]
 platform      = ststm32
 framework     = arduino
-board         = disco_f765vg
-build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB
+board         = remram_v1
+build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F7 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, TMC26XStepper, TMCStepper
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/*> +<src/HAL/HAL_STM32_F4_F7/STM32F7>
+lib_ignore    = Adafruit NeoPixel, TMCStepper, TMC26XStepper
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F4>
 monitor_speed = 250000
 
 #
@@ -364,7 +349,7 @@ src_filter  = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
 
 #
-# Alfawise U20 (STM32F103VET6)
+# Longer 3D board in Alfawise U20 (STM32F103VET6)
 #
 [env:alfawise_U20]
 platform      = ststm32
@@ -378,12 +363,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
+lib_ignore    = Adafruit NeoPixel, TMC26XStepper
 
 #
 # MKS Robin (STM32F103ZET6)
@@ -398,13 +378,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
-  U8glib-HAL
+lib_ignore    = Adafruit NeoPixel, TMC26XStepper
 
 #
 # MKS ROBIN LITE/LITE2 (STM32F103RCT6)
@@ -419,12 +393,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
+lib_ignore    = Adafruit NeoPixel, TMC26XStepper
 
 #
 # MKS Robin Mini (STM32F103VET6)
@@ -439,12 +408,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
+lib_ignore    = Adafruit NeoPixel, TMC26XStepper
 
 #
 # MKS Robin Nano (STM32F103VET6)
@@ -459,12 +423,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
+lib_ignore    = Adafruit NeoPixel, TMC26XStepper
 
 #
 # JGAurora A5S A1 (STM32F103ZET6)
@@ -479,12 +438,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = TMC26XStepper
-  libf3c
-  lib066
-  Adafruit NeoPixel_ID28
-  Adafruit NeoPixel
-  libf3e
+lib_ignore    = Adafruit NeoPixel, TMC26XStepper
 monitor_speed = 250000
 
 #
@@ -498,14 +452,14 @@ framework = arduino
 board = blackSTM32F407VET6
 extra_scripts = pre:buildroot/share/PlatformIO/scripts/black_stm32f407vet6.py
 build_flags = ${common.build_flags}
-  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"BLACK_F407VE\"
+  -DSTM32F4 -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"BLACK_F407VE\"
 lib_deps = ${common.lib_deps}
-lib_ignore = Adafruit NeoPixel, TMC26XStepper, TMCStepper, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster
+lib_ignore = Adafruit NeoPixel, TMCStepper, TMC26XStepper, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster
 src_filter = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
 
 #
-# BIGTREE_SKR_PRO (STM32F407ZGT6 ARM Cortex-M4)
+# Bigtreetech SKR Pro (STM32F407ZGT6 ARM Cortex-M4)
 #
 [env:BIGTREE_SKR_PRO]
 platform = ststm32@5.4.3
@@ -557,16 +511,7 @@ build_flags = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py -DMCU_ST
   -DDEBUG_LEVEL=0
 src_filter  = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 #-<frameworks>
-lib_ignore  = Adafruit NeoPixel
-  U8glib
-  LiquidCrystal_I2C
-  LiquidCrystal
-  NewliquidCrystal
-  LiquidTWI2
-  TMC26XStepper
-  TMCStepper
-  Servo(STM32F1)
-  U8glib-HAL
+lib_ignore  = Adafruit NeoPixel, LiquidCrystal, LiquidTWI2, TMCStepper, TMC26XStepper, U8glib-HAL
 
 #
 # Espressif ESP32
@@ -581,13 +526,7 @@ upload_port = /dev/ttyUSB0
 lib_deps =
   AsyncTCP=https://github.com/me-no-dev/AsyncTCP/archive/master.zip
   ESPAsyncWebServer=https://github.com/me-no-dev/ESPAsyncWebServer/archive/master.zip
-lib_ignore  = TMC26XStepper
-  LiquidCrystal_I2C
-  LiquidCrystal
-  NewliquidCrystal
-  LiquidTWI2
-  SailfishLCD
-  SailfishRGB_LED
+lib_ignore  = TMC26XStepper, LiquidCrystal, LiquidTWI2, SailfishLCD, SailfishRGB_LED
 src_filter  = ${common.default_src_filter} +<src/HAL/HAL_ESP32>
 
 #


### PR DESCRIPTION
Originally from #14832. Users may need to delete platformio work folders before building.
