### PR TITLE
Fix runout trigger on "inactive" sensor

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -249,6 +249,8 @@ class FilamentSensorBase {
               && (dual_x_carriage_mode == DXC_DUPLICATION_MODE || dual_x_carriage_mode == DXC_MIRRORED_MODE)
             #elif ENABLED(MULTI_NOZZLE_DUPLICATION)
               && extruder_duplication_enabled
+            #else
+              && false
             #endif
           #endif
         ) return runout_states;               // Any extruder


### PR DESCRIPTION
When more than 1 runout sensor is on, runout is triggered on any sensor. Should only be active sensor. When no duplication was activated, this always returned on either sensor.