### PR TITLE
LulzBot Touch UI Followup

### DIFF
--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/archim2-flash/flash_storage.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/archim2-flash/flash_storage.h
@@ -20,7 +20,7 @@
  *   location: <http://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#ifdef LULZBOT_TOUCH_UI
+#if ENABLED(LULZBOT_TOUCH_UI)
 
 class SPIFlash {
   public:

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/archim2-flash/flash_storage.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/archim2-flash/flash_storage.h
@@ -20,8 +20,6 @@
  *   location: <http://www.gnu.org/licenses/>.                              *
  ****************************************************************************/
 
-#if ENABLED(LULZBOT_TOUCH_UI)
-
 class SPIFlash {
   public:
     static constexpr uint32_t erase_unit_size = 4 * 1024; // Minimum erase unit
@@ -106,5 +104,3 @@ class UIFlashStorage::BootMediaReader {
 
     static int16_t read(void *obj, void *buffer, const size_t size);
 };
-
-#endif // LULZBOT_TOUCH_UI

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/archim2-flash/media_file_reader.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/archim2-flash/media_file_reader.h
@@ -22,6 +22,8 @@
 
 #pragma once
 
+#if ENABLED(LULZBOT_TOUCH_UI)
+
 #include "../../../../../sd/SdFile.h"
 #include "../../../../../sd/cardreader.h"
 
@@ -42,3 +44,5 @@ class MediaFileReader {
 
     static int16_t read(void *obj, void *buff, size_t bytes);
 };
+
+#endif // LULZBOT_TOUCH_UI

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/archim2-flash/media_file_reader.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/archim2-flash/media_file_reader.h
@@ -22,10 +22,12 @@
 
 #pragma once
 
-#if ENABLED(LULZBOT_TOUCH_UI)
+#include "../../../../../inc/MarlinConfigPre.h"
 
-#include "../../../../../sd/SdFile.h"
-#include "../../../../../sd/cardreader.h"
+#if ENABLED(SDSUPPORT)
+  #include "../../../../../sd/SdFile.h"
+  #include "../../../../../sd/cardreader.h"
+#endif
 
 class MediaFileReader {
   private:
@@ -44,5 +46,3 @@ class MediaFileReader {
 
     static int16_t read(void *obj, void *buff, size_t bytes);
 };
-
-#endif // LULZBOT_TOUCH_UI

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/compat.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/compat.h
@@ -40,16 +40,9 @@
     #include "pin_mappings.h"
 #else
   // Messages that are declared in Marlin
-  #define WELCOME_MSG     "Printer Ready"
-  #define MSG_SD_INSERTED "Media Inserted"
-  #define MSG_SD_REMOVED  "Media Removed"
-
-  // Define macros for compatibility
-  #define EXTENSIBLE_UI
-  #define _CAT(a, ...) a ## __VA_ARGS__
-  #define SWITCH_ENABLED_      1
-  #define ENABLED(b) _CAT(SWITCH_ENABLED_, b)
-  #define DISABLED(b) !ENABLED(b)
+  #define WELCOME_MSG        "Printer Ready"
+  #define MSG_MEDIA_INSERTED "Media Inserted"
+  #define MSG_MEDIA_REMOVED  "Media Removed"
 
   namespace UI {
     static inline uint32_t safe_millis() {return millis();};

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/compat.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/compat.h
@@ -35,9 +35,8 @@
 #endif
 
 #ifdef __MARLIN_FIRMWARE__
-    // If __MARLIN_FIRMWARE__ exists, then we are being
-    // compiled inside Marlin.
-    #include "pin_mappings.h"
+  // __MARLIN_FIRMWARE__ exists when compiled within Marlin.
+  #include "pin_mappings.h"
 #else
   // Messages that are declared in Marlin
   #define WELCOME_MSG        "Printer Ready"

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/config.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/config.h
@@ -80,9 +80,8 @@
 // This is a recommended for smaller displays.
 //#define TOUCH_UI_PASSCODE
 
-// Define number of seconds after which the menu screens
-// timeout and returns the user to the status screen
-//#define LCD_TIMEOUT_TO_STATUS 120
+// The timeout (in ms) to return to the status screen from sub-menus
+//#define LCD_TIMEOUT_TO_STATUS 15000
 
 // Enable this to debug the event framework
 //#define UI_FRAMEWORK_DEBUG

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/basic/commands.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/basic/commands.cpp
@@ -1160,7 +1160,7 @@ void CLCD::default_display_orientation() {
       cmd.execute();
     }
     else {
-      #ifdef TOUCH_UI_INVERTED
+      #if ENABLED(TOUCH_UI_INVERTED)
         mem_write_32(REG::ROTATE, 1);
       #endif
     }

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/compat.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/compat.h
@@ -200,6 +200,14 @@
 
   #define safe_delay delay
 
+  // Define macros for compatibility
+
+  #define _CAT(a, ...)       a ## __VA_ARGS__
+  #define SWITCH_ENABLED_    1
+  #define ENABLED(b)         _CAT(SWITCH_ENABLED_, b)
+  #define DISABLED(b)        !ENABLED(b)
+  #define ANY(A,B)           ENABLED(A) || ENABLED(B)
+
   // Remove compiler warning on an unused variable
   #ifndef UNUSED
     #if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/compat.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/compat.h
@@ -20,13 +20,15 @@
 #include "../config.h"
 
 #ifdef __MARLIN_FIRMWARE__
-  // Marlin will define the I/O functions for us
 
+  // Marlin will define the I/O functions for us
   #if ENABLED(LULZBOT_TOUCH_UI)
     #define FTDI_BASIC
     #define FTDI_EXTENDED
   #endif
-#else
+
+#else // !__MARLIN_FIRMWARE__
+
   #include "Arduino.h"
 
   #if !defined(CLCD_USE_SOFT_SPI)
@@ -216,4 +218,5 @@
       #define UNUSED(x) ((void)(x))
     #endif
   #endif
-#endif //!defined(__MARLIN_FIRMWARE__)
+
+#endif // !__MARLIN_FIRMWARE__

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/base_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/base_screen.cpp
@@ -63,7 +63,7 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
 void BaseScreen::onIdle() {
   #ifdef LCD_TIMEOUT_TO_STATUS
     const uint32_t elapsed = millis() - last_interaction;
-    if (elapsed > uint32_t(LCD_TIMEOUT_TO_STATUS) * 1000) {
+    if (elapsed > uint32_t(LCD_TIMEOUT_TO_STATUS)) {
       reset_menu_timeout();
       GOTO_SCREEN(StatusScreen);
     }

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/endstop_state_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/endstop_state_screen.cpp
@@ -32,16 +32,10 @@ using namespace ExtUI;
 
 void EndstopStatesScreen::onEntry() {
   BaseScreen::onEntry();
-  #ifdef LULZBOT_SET_PROBE_PINS_STATE
-    LULZBOT_SET_PROBE_PINS_STATE(true)
-  #endif
 }
 
 void EndstopStatesScreen::onExit() {
   BaseScreen::onExit();
-  #ifdef LULZBOT_SET_PROBE_PINS_STATE
-    LULZBOT_SET_PROBE_PINS_STATE(false)
-  #endif
 }
 
 void EndstopStatesScreen::onRedraw(draw_mode_t) {

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/status_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/status_screen.cpp
@@ -30,7 +30,7 @@
 #include "../archim2-flash/flash_storage.h"
 
 #if ENABLED(SDSUPPORT) && defined(LULZBOT_MANUAL_USB_STARTUP)
-  #include "../../../../sd/cardreader.h"
+  #include "../../../../../sd/cardreader.h"
 #endif
 
 using namespace FTDI;


### PR DESCRIPTION
Follow up to #14967

- Change units of LCD_TIMEOUT_TO_STATUS from seconds to milliseconds to match definition in "Configuration_adv.h"
- Fix inconsistent use of ENABLE()
- Added compatibility macros so `ftdi_eve_library` can be compiled outside of Marlin as Arduino sketch.
- Removed LULZBOT specific code that should not have been part of original PR
- Fixed incorrect include path