### PR TITLE
Fix incompatible types error

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -268,7 +268,7 @@ namespace ExtUI {
   }
 
   float getAxisPosition_mm(const extruder_t extruder) {
-    const extruder_t old_tool =  getActiveTool();
+    const extruder_t old_tool = getActiveTool();
     setActiveTool(extruder, true);
     const float pos = flags.manual_motion ? destination[E_AXIS] : current_position[E_AXIS];
     setActiveTool(old_tool, true);

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -268,7 +268,7 @@ namespace ExtUI {
   }
 
   float getAxisPosition_mm(const extruder_t extruder) {
-    const uint8_t old_tool = active_extruder;
+    const extruder_t old_tool =  getActiveTool();
     setActiveTool(extruder, true);
     const float pos = flags.manual_motion ? destination[E_AXIS] : current_position[E_AXIS];
     setActiveTool(old_tool, true);


### PR DESCRIPTION
Fixed error where `setActiveToolhead` was being passed an integer.