### PR TITLE
Fix compile error when using TURBO_BACK_MENU_ITEM

### DIFF
--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -449,9 +449,15 @@ public:
     static void save_previous_screen();
     static void goto_previous_screen(
       #if ENABLED(TURBO_BACK_MENU_ITEM)
-        const bool is_back=false
+        const bool is_back
       #endif
     );
+
+    #if ENABLED(TURBO_BACK_MENU_ITEM)
+      // Various menu items require a "void (*)()" to point to
+      // this function so a default argument will *not* work
+      static void goto_previous_screen() {goto_previous_screen(false);}
+    #endif
 
     static void return_to_status();
     static inline bool on_status_screen() { return currentScreen == status_screen; }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -455,8 +455,8 @@ public:
 
     #if ENABLED(TURBO_BACK_MENU_ITEM)
       // Various menu items require a "void (*)()" to point to
-      // this function so a default argument will *not* work
-      static void goto_previous_screen() {goto_previous_screen(false);}
+      // this function so a default argument *won't* work
+      static inline void goto_previous_screen() { goto_previous_screen(false); }
     #endif
 
     static void return_to_status();


### PR DESCRIPTION
Some menu items require "ui.goto_previous_function" to be pointed to by "void (*)()" and using a default parameter would change the function signature, causing pointer incompatibility errors.


