### PR TITLE
pca9632_buzz fix for PR 14803

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -66,11 +66,14 @@
 
 #if HAS_BUZZER
   #include "../libs/buzzer.h"
+  #if ENABLED(PCA9632_BUZZER)
+    #include "../feature/leds/pca9632.h"
+  #endif
   void MarlinUI::buzz(const long duration, const uint16_t freq) {
     #if ENABLED(LCD_USE_I2C_BUZZER)
       lcd.buzz(duration, freq);
     #elif ENABLED(PCA9632_BUZZER)
-      pca9632_buzz(const long duration, const uint16_t freq) {
+      pca9632_buzz(duration, freq);
     #elif USE_BEEPER
       buzzer.tone(duration, freq);
     #endif


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

PR 14803 when using PCA9632 buzzer doesn't compile.
Fixes typo and adds include for pca9632.h
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

If PCA9632 buffer is defined, ultralcd.cpp doesn't compile.
Fixed typo and missing include file for pca9632.h

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
