### PR TITLE
Add LCD Contrast menu for Fysetc 12864

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -391,6 +391,7 @@
   || ENABLED(AZSMZ_12864)                 \
   || ENABLED(miniVIKI)                    \
   || ENABLED(ELB_FULL_GRAPHIC_CONTROLLER) \
+  || ENABLED(FYSETC_MINI_12864_1_2) \
 )
 #if HAS_LCD_CONTRAST
   #ifndef LCD_CONTRAST_MIN


### PR DESCRIPTION
### Description

No LCD menu to tweak contrast on the Fysetc 12864 1_2. This seems new as of a few weeks ago. Tracked it down to this OR block and just added that LCD but maybe refactoring `HAS_LCD_CONTRAST` to be something defined in the LCD blocks makes more sense?

### Benefits

You can see things! No but seriously without this on my SKR 1.3 I thought LCD had broken entirely. Contrast tweaking works quite well interactively and the defaults that come with `HAS_LCD_CONTRAST` also seem more appropriate.

### Related Issues

N/A