### PR TITLE
Squelch LCD_CONTRAST_* Redefined Warnings for Wanhao Duplicator i3 Mini

### DIFF
--- a/Marlin/src/pins/mega/pins_WANHAO_ONEPLUS.h
+++ b/Marlin/src/pins/mega/pins_WANHAO_ONEPLUS.h
@@ -105,6 +105,9 @@
   #define BTN_ENC           5
 
   // This display has adjustable contrast
+  #undef LCD_CONTRAST_MIN
+  #undef LCD_CONTRAST_MAX
+  #undef LCD_CONTRAST_INIT
   #define LCD_CONTRAST_MIN       0
   #define LCD_CONTRAST_MAX     255
   #define LCD_CONTRAST_INIT LCD_CONTRAST_MAX


### PR DESCRIPTION
### Description

Since LCD contrast settings are now defined in this printer's board's pins file, users will receive a ton of `warning: "LCD_CONTRAST_*" redefined` warnings. This PR squelches those warnings by undefining the `LCD_CONTRAST_*` defaults before defining them.
