### PR TITLE
Do not require SOFTWARE_ENDSTOPS for dual extruders

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2308,8 +2308,6 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
 #if !BOTH(MIN_SOFTWARE_ENDSTOPS, MAX_SOFTWARE_ENDSTOPS)
   #if ENABLED(DUAL_X_CARRIAGE)
     #error "DUAL_X_CARRIAGE requires both MIN_ and MAX_SOFTWARE_ENDSTOPS."
-  #elif HAS_HOTEND_OFFSET
-    #error "MIN_ and MAX_SOFTWARE_ENDSTOPS are both required with offset hotends."
   #endif
 #endif
 


### PR DESCRIPTION
The problem with the sanity check introduced in #13386 is that it doesn't apply to just offset hotends, because `HAS_HOTEND_OFFSET` has nothing to do with offsets:
```
Marlin/src/inc/Conditionals_LCD.h:#define HAS_HOTEND_OFFSET (HOTENDS > 1)
```
The change from #13386 seems to prevent my dual-extruder printer from z-homing on a specific place while printing slightly below `Z0`. I can workaround that by disabling soft endstops using `M211 S0`, which seems to work, but a better "by default" fix would be more convenient.

I also tried to work around this by enabling `MIN_SOFTWARE_ENDSTOPS`, but disabling `MIN_SOFTWARE_ENDSTOP_Z`, which also seems to work and is closer to what I originally needed, but that doesn't IMHO make the sanity check any more justified.

Is there a good reason why we need software endstops for `HOTENDS>1`? Is there a good reason why we need them for real `HOTEND_OFFSET_*`? Can't the user just disable them with `M211` anyway?
