### PR TITLE
Add warning when trying to use JD with kinematic systems

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1012,8 +1012,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 /**
  * Junction deviation is not compatible with kinematic systems.
  */
-#if (IS_KINEMATIC && ENABLED(JUNCTION_DEVIATION))
-  #error "Junction deviation is not compatible with kinematic systems."
+#if ENABLED(JUNCTION_DEVIATION) && IS_KINEMATIC
+  #error "Junction deviation is only compatible with Cartesians."
 #endif
 
 /**

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1010,6 +1010,13 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #endif
 
 /**
+ * Junction deviation is not compatible with kinematic systems.
+ */
+#if (IS_KINEMATIC && ENABLED(JUNCTION_DEVIATION))
+  #error "Junction deviation is not compatible with kinematic systems."
+#endif
+
+/**
  * Probes
  */
 


### PR DESCRIPTION
### Description

Follow up for #14978. Error out when trying to use JD with kinematic systems.

### Benefits

Stop people getting in weird situations they shouldn't with kinematic systems. :smile:
The lure of the "new shiny" is strong. None of the configuration files or documentation mention anything about JD being incompatible with kinematic printers currently.

### Related Issues

#14978
