### PR TITLE
Change default Re-ARM UART pin order

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
@@ -128,17 +128,33 @@
   // P2_08 E1-Step
   // P2_13 E1-Dir
 
-  #define X_SERIAL_TX_PIN  P2_13
-  #define X_SERIAL_RX_PIN  P2_13
+  #ifndef  X_SERIAL_TX_PIN
+    #define X_SERIAL_TX_PIN  P0_01
+  #endif
+  #ifndef X_SERIAL_RX_PIN
+    #define X_SERIAL_RX_PIN  P0_01
+  #endif
 
-  #define Y_SERIAL_TX_PIN  P0_00
-  #define Y_SERIAL_RX_PIN  P0_00
+  #ifndef Y_SERIAL_TX_PIN
+    #define Y_SERIAL_TX_PIN  P0_00
+  #endif
+  #ifndef Y_SERIAL_RX_PIN
+    #define Y_SERIAL_RX_PIN  P0_00
+  #endif
 
-  #define Z_SERIAL_TX_PIN  P0_01
-  #define Z_SERIAL_RX_PIN  P0_01
+  #ifndef Z_SERIAL_TX_PIN
+    #define Z_SERIAL_TX_PIN  P2_13
+  #endif
+  #ifndef Z_SERIAL_RX_PIN
+    #define Z_SERIAL_RX_PIN  P2_13
+  #endif
 
-  #define E0_SERIAL_TX_PIN P2_08
-  #define E0_SERIAL_RX_PIN P2_08
+  #ifndef E0_SERIAL_TX_PIN
+    #define E0_SERIAL_TX_PIN P2_08
+  #endif
+  #ifndef E0_SESIAL_RX_PIN
+    #define E0_SERIAL_RX_PIN P2_08
+  #endif
 
 #endif
 


### PR DESCRIPTION
Also allow overriding pins in Configuration_adv.h

### Description

The UART pins defined by #13819 by necessity steals the E1-DIR and E1-Step from the E1 stepper driver (due to the requirement that the pins be interrupt-capable). However, of the four defined pins, these two are used for X and E0 while Y and Z are on independent pins. It is relatively common to replace X and Y drivers with TMC while leaving other drivers on Z and E0, so it makes sense to have the independent pins on X and Y instead of Y and Z, allowing for TMC drivers on X and Y while still using two extruders. This change swaps the pins for Z and X so that X and Y are independent pins while Z and E0 use the E1-DIR and E1-Step pins.

Also, this allows overriding the pins by adding them to ``Configuration_adv.h``.

### Benefits

Allows using UART on TMC drivers on X and Y without losing the capability of using a second extruder.