### PR TITLE
ADIMLab Gantry - Spelling Correction

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -251,9 +251,9 @@ else ifeq ($(HARDWARE_MOTHERBOARD),1141)
 else ifeq ($(HARDWARE_MOTHERBOARD),1142)
 # Overlord/Overlord Pro
 else ifeq ($(HARDWARE_MOTHERBOARD),1143)
-# ADIMLab Granty v1
+# ADIMLab Gantry v1
 else ifeq ($(HARDWARE_MOTHERBOARD),1144)
-# ADIMLab Granty v2
+# ADIMLab Gantry v2
 else ifeq ($(HARDWARE_MOTHERBOARD),1145)
 
 #

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -95,8 +95,8 @@
 #define BOARD_Z_BOLT_X_SERIES         1141  // Z-Bolt X Series
 #define BOARD_TT_OSCAR                1142  // TT OSCAR
 #define BOARD_OVERLORD                1143  // Overlord/Overlord Pro
-#define BOARD_HJC2560C_REV1           1144  // ADIMLab Granty v1
-#define BOARD_HJC2560C_REV2           1145  // ADIMLab Granty v2
+#define BOARD_HJC2560C_REV1           1144  // ADIMLab Gantry v1
+#define BOARD_HJC2560C_REV2           1145  // ADIMLab Gantry v2
 
 //
 // RAMBo and derivatives

--- a/Marlin/src/pins/mega/pins_HJC2560C_REV2.h
+++ b/Marlin/src/pins/mega/pins_HJC2560C_REV2.h
@@ -29,7 +29,7 @@
   #error "Oops! Select 'Arduino/Genuino Mega or Mega 2560' in 'Tools > Board.'"
 #endif
 
-#define DEFAULT_MACHINE_NAME "ADIMLab Granty v2"
+#define DEFAULT_MACHINE_NAME "ADIMLab Gantry v2"
 #define BOARD_INFO_NAME      "HJC2560-C"
 
 //

--- a/config/examples/ADIMLab/Granty v1/Configuration.h
+++ b/config/examples/ADIMLab/Granty v1/Configuration.h
@@ -135,7 +135,7 @@
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
-#define CUSTOM_MACHINE_NAME "ADIMLab Granty v1"
+#define CUSTOM_MACHINE_NAME "ADIMLab Gantry v1"
 
 // Printer's unique ID, used by some programs to differentiate between machines.
 // Choose your own or use a service like http://www.uuidgenerator.net/version4

--- a/config/examples/ADIMLab/Granty v2/Configuration.h
+++ b/config/examples/ADIMLab/Granty v2/Configuration.h
@@ -135,7 +135,7 @@
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
-#define CUSTOM_MACHINE_NAME "ADIMLab Granty v2"
+#define CUSTOM_MACHINE_NAME "ADIMLab Gantry v2"
 
 // Printer's unique ID, used by some programs to differentiate between machines.
 // Choose your own or use a service like http://www.uuidgenerator.net/version4


### PR DESCRIPTION
Pls. Change directory names from Granty to Gantry, have also corrected it in the files.