### PR TITLE
Make LCD_CONTRAST_MAX >= _LCD_CONTRAST_INIT

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -295,7 +295,7 @@
     #elif _LCD_CONTRAST_INIT > 63
       #define LCD_CONTRAST_MAX _LCD_CONTRAST_INIT
     #else
-      #define LCD_CONTRAST_MAX 63
+      #define LCD_CONTRAST_MAX 63   // ST7567 6-bits contrast
     #endif
   #endif
   #ifndef DEFAULT_LCD_CONTRAST

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -292,12 +292,10 @@
   #ifndef LCD_CONTRAST_MAX
     #ifdef _LCD_CONTRAST_MAX
       #define LCD_CONTRAST_MAX _LCD_CONTRAST_MAX
+    #elif _LCD_CONTRAST_INIT > 63
+      #define LCD_CONTRAST_MAX _LCD_CONTRAST_INIT
     #else
       #define LCD_CONTRAST_MAX 63
-      #if _LCD_CONTRAST_INIT > LCD_CONTRAST_MAX
-        #undef LCD_CONTRAST_MAX
-        #define LCD_CONTRAST_MAX _LCD_CONTRAST_INIT
-      #endif
     #endif
   #endif
   #ifndef DEFAULT_LCD_CONTRAST

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -294,6 +294,10 @@
       #define LCD_CONTRAST_MAX _LCD_CONTRAST_MAX
     #else
       #define LCD_CONTRAST_MAX 63
+      #if _LCD_CONTRAST_INIT > LCD_CONTRAST_MAX
+        #undef LCD_CONTRAST_MAX
+        #define LCD_CONTRAST_MAX _LCD_CONTRAST_INIT
+      #endif
     #endif
   #endif
   #ifndef DEFAULT_LCD_CONTRAST


### PR DESCRIPTION
### Description

If `_LCD_CONTRAST_INIT` is > 63 but `_LCD_CONTRAST_MAX` is not defined then lcd contrast is constrained to a max of 63 rather than at least the init value.
This updates `LCD_CONTRAST_MAX` to the larger of 63 or `_LCD_CONTRAST_INIT`

Bug seen and fix tested with `FYSETC_MINI_12864_2_1`.

### Benefits

LCDs with `_LCD_CONTRAST_INIT` > 63 can be read.

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
