### PR TITLE
support turbo back for menu info submenu items

### DIFF
--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -42,7 +42,11 @@
   // About Printer > Printer Stats
   //
   void menu_info_stats() {
-    if (ui.use_click()) return ui.goto_previous_screen();
+    if (ui.use_click()) return ui.goto_previous_screen(
+      #if ENABLED(TURBO_BACK_MENU_ITEM)
+        true
+      #endif
+    );
 
     char buffer[21];
     printStatistics stats = print_job_timer.getStats();
@@ -95,7 +99,11 @@
 // About Printer > Thermistors
 //
 void menu_info_thermistors() {
-  if (ui.use_click()) return ui.goto_previous_screen();
+  if (ui.use_click()) return ui.goto_previous_screen(
+    #if ENABLED(TURBO_BACK_MENU_ITEM)
+      true
+    #endif
+  );
   START_SCREEN();
   #define THERMISTOR_ID TEMP_SENSOR_0
   #include "../thermistornames.h"
@@ -163,7 +171,11 @@ void menu_info_thermistors() {
 // About Printer > Board Info
 //
 void menu_info_board() {
-  if (ui.use_click()) return ui.goto_previous_screen();
+  if (ui.use_click()) return ui.goto_previous_screen(
+    #if ENABLED(TURBO_BACK_MENU_ITEM)
+      true
+    #endif
+  );
   START_SCREEN();
   STATIC_ITEM(BOARD_INFO_NAME, true, true);                      // MyPrinterController
   STATIC_ITEM(MSG_INFO_BAUDRATE ": " STRINGIFY(BAUDRATE), true); // Baud: 250000
@@ -177,7 +189,11 @@ void menu_info_board() {
 //
 #if DISABLED(LCD_PRINTER_INFO_IS_BOOTSCREEN)
   void menu_info_printer() {
-    if (ui.use_click()) return ui.goto_previous_screen();
+    if (ui.use_click()) return ui.goto_previous_screen(
+      #if ENABLED(TURBO_BACK_MENU_ITEM)
+        true
+      #endif
+    );
     START_SCREEN();
     STATIC_ITEM(MSG_MARLIN, true, true);                             // Marlin
     STATIC_ITEM(SHORT_BUILD_VERSION, true);                          // x.x.x-Branch


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

TURBO BACK menu works for normal submenus but not for info submenus.
This supports turbo back for info submenus

info submenus dont use a MENU_BACK menu item but any click goes back. This isn't handled by the current turbo back code.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Info submenus support turbo back behavior consistently with other menus

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
