### PR TITLE
Kill steppers on Estop/Kill

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -747,6 +747,11 @@ void idle(
  */
 void kill(PGM_P const lcd_msg/*=nullptr*/) {
   thermalManager.disable_all_heaters();
+  stepper.quick_stop();
+  disable_all_steppers();
+  queue.stop();
+  print_job_timer.stop();
+  queue.clear();
 
   SERIAL_ERROR_MSG(MSG_ERR_KILLED);
 
@@ -774,6 +779,11 @@ void minkill() {
   for (int i = 1000; i--;) DELAY_US(250);
 
   thermalManager.disable_all_heaters(); // turn off heaters again
+  stepper.quick_stop();
+  disable_all_steppers();
+  queue.stop();
+  print_job_timer.stop();
+  queue.clear();
 
   #if HAS_POWER_SWITCH
     PSU_OFF();

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -741,17 +741,21 @@ void idle(
   #endif
 }
 
+// Kill heaters, job timer, and queue
+void kill_activity() {
+  thermalManager.disable_all_heaters();
+  stepper.quick_stop();
+  //queue.stop();
+  //print_job_timer.stop();
+  //queue.clear();
+}
+
 /**
  * Kill all activity and lock the machine.
  * After this the machine will need to be reset.
  */
 void kill(PGM_P const lcd_msg/*=nullptr*/) {
-  thermalManager.disable_all_heaters();
-  stepper.quick_stop();
-  disable_all_steppers();
-  queue.stop();
-  print_job_timer.stop();
-  queue.clear();
+  kill_activity();
 
   SERIAL_ERROR_MSG(MSG_ERR_KILLED);
 
@@ -778,12 +782,7 @@ void minkill() {
   // Wait to ensure all interrupts stopped
   for (int i = 1000; i--;) DELAY_US(250);
 
-  thermalManager.disable_all_heaters(); // turn off heaters again
-  stepper.quick_stop();
-  disable_all_steppers();
-  queue.stop();
-  print_job_timer.stop();
-  queue.clear();
+  kill_activity();
 
   #if HAS_POWER_SWITCH
     PSU_OFF();

--- a/Marlin/src/Marlin.h
+++ b/Marlin/src/Marlin.h
@@ -322,8 +322,8 @@ void disable_e_stepper(const uint8_t e);
 void disable_e_steppers();
 void disable_all_steppers();
 
-void kill(PGM_P const lcd_msg=nullptr);
-void minkill();
+void kill(PGM_P const lcd_msg=nullptr, const bool steppers_off=false);
+void minkill(const bool steppers_off=false);
 
 void quickstop_stepper();
 

--- a/Marlin/src/gcode/control/M108_M112_M410.cpp
+++ b/Marlin/src/gcode/control/M108_M112_M410.cpp
@@ -41,7 +41,7 @@ void GcodeSuite::M108() {
  * M112: Full Shutdown
  */
 void GcodeSuite::M112() {
-  kill(PSTR("M112 Shutdown"));
+  kill(PSTR("M112 Shutdown"), true);
 }
 
 /**

--- a/Marlin/src/gcode/control/M108_M112_M410.cpp
+++ b/Marlin/src/gcode/control/M108_M112_M410.cpp
@@ -38,10 +38,10 @@ void GcodeSuite::M108() {
 }
 
 /**
- * M112: Emergency Stop
+ * M112: Full Shutdown
  */
 void GcodeSuite::M112() {
-  kill(PSTR("M112 Estop"));
+  kill(PSTR("M112 Shutdown"));
 }
 
 /**

--- a/Marlin/src/gcode/control/M108_M112_M410.cpp
+++ b/Marlin/src/gcode/control/M108_M112_M410.cpp
@@ -41,7 +41,7 @@ void GcodeSuite::M108() {
  * M112: Emergency Stop
  */
 void GcodeSuite::M112() {
-  kill();
+  kill(PSTR("M112 Estop"));
 }
 
 /**

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -86,7 +86,7 @@
 /**
  * M81: Turn off Power, including Power Supply, if there is one.
  *
- *      This code should ALWAYS be available for EMERGENCY SHUTDOWN!
+ *      This code should ALWAYS be available for FULL SHUTDOWN!
  */
 void GcodeSuite::M81() {
   thermalManager.disable_all_heaters();

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -407,7 +407,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
 
       #if DISABLED(EMERGENCY_PARSER)
         case 108: M108(); break;                                  // M108: Cancel Waiting
-        case 112: M112(); break;                                  // M112: Emergency Stop
+        case 112: M112(); break;                                  // M112: Full Shutdown
         case 410: M410(); break;                                  // M410: Quickstop - Abort all the planned moves.
         #if ENABLED(HOST_PROMPT_SUPPORT)
           case 876: M876(); break;                                  // M876: Handle Host prompt responses

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -132,7 +132,7 @@
  *        If AUTOTEMP is enabled, S<mintemp> B<maxtemp> F<factor>. Exit autotemp by any M109 without F
  * M110 - Set the current line number. (Used by host printing)
  * M111 - Set debug flags: "M111 S<flagbits>". See flag bits defined in enum.h.
- * M112 - Emergency stop.
+ * M112 - Full Shutdown.
  * M113 - Get or set the timeout interval for Host Keepalive "busy" messages. (Requires HOST_KEEPALIVE_FEATURE)
  * M114 - Report current position.
  * M115 - Report capabilities. (Extended capabilities requires EXTENDED_CAPABILITIES_REPORT)

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -715,8 +715,8 @@ class Planner {
       FORCE_INLINE static float get_axis_position_degrees(const AxisEnum axis) { return get_axis_position_mm(axis); }
     #endif
 
-    // Called to force a quick stop of the machine (for example, when an emergency
-    // stop is required, or when endstops are hit)
+    // Called to force a quick stop of the machine (for example, when a Full Shutdown
+    // is required, or when endstops are hit)
     static void quick_stop();
 
     // Called when an endstop is triggered. Causes the machine to stop inmediately

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -715,8 +715,8 @@ class Planner {
       FORCE_INLINE static float get_axis_position_degrees(const AxisEnum axis) { return get_axis_position_mm(axis); }
     #endif
 
-    // Called to force a quick stop of the machine (for example, when a Full Shutdown
-    // is required, or when endstops are hit)
+    // Called to force a quick stop of the machine (for example, when
+    // a Full Shutdown is required, or when endstops are hit)
     static void quick_stop();
 
     // Called when an endstop is triggered. Causes the machine to stop inmediately


### PR DESCRIPTION
By definition Estop needs to kill all motion power. Machine must be in a locked state.

Since the term emergency stop may also implicate electrical requirements depending on where its used, should we relabel this? I have yet to see a printer board compliant to PLd / Class 3 safety....

Note : what we have here is at BEST case PLb  with a category 2 stop. With power cutoff to steppers and heaters we get closer to a category 0 stop but still PLb. Emergency stop needs to be category 0 or 1 and typically is PLd or e

ISO 13850 limits the selection of stop category to Category 0 or 1 and excludes Category 2. This exclusion can be found in NFPA 79, IEC 60204 – 1, and CSA C22.2 No. 301 as well. Category 2 may only be used for operational or “normal” stopping functions.

https://machinerysafety101.com/2010/09/27/emergency-stop-categories/?doing_wp_cron=1566846639.6410090923309326171875

One more critical paragraph to note : 
Both ISO 13849 – 1 and IEC 62061 [8] base the initial requirements for reliability on the outcome of the risk assessment (PLr or SILr). If the stopping condition is part of normal operation, then simple circuit requirements (i.e. PLa, Category 1) are all that may be required. If the stopping condition is intended to be an Emergency Stop, then additional analysis is needed to determine exactly what may be required.

Note that PLa Category 1 is NOT considered an Emergency stop. 