### PR TITLE
Fix G53 as prefix, G28 with CNC_COORDINATE_SYSTEMS

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -463,6 +463,19 @@ void GcodeSuite::G28(const bool always_home_all) {
       SERIAL_ECHOLNPGM(MSG_Z_MOVE_COMP);
   #endif
 
+  #if ENABLED(CNC_COORDINATE_SYSTEMS)
+    float current_offset[XYZ] = { 0 };
+    if (active_coordinate_system != -1){
+    COPY(current_offset, coordinate_system[active_coordinate_system]);
+    LOOP_XYZ(i){
+      position_shift[i] = current_offset[i];
+      update_workspace_offset((AxisEnum)i);
+    }
+    SERIAL_ECHOLNPAIR("Selected workspace: ", active_coordinate_system);
+    report_current_position();
+    }
+  #endif
+
   if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< G28");
 
   #if HAS_DRIVER(L6470)

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -452,7 +452,18 @@ void GcodeSuite::G28(const bool always_home_all) {
 
   ui.refresh();
 
+  #if ENABLED(CNC_COORDINATE_SYSTEMS)
+    if (active_coordinate_system != -1) {
+      LOOP_XYZ(i) {
+        position_shift[i] = coordinate_system[active_coordinate_system][i];
+        update_workspace_offset((AxisEnum)i);
+      }
+      SERIAL_ECHOLNPAIR("Selected workspace: ", active_coordinate_system);
+    }
+  #endif
+
   report_current_position();
+
   #if ENABLED(NANODLP_Z_SYNC)
     #if ENABLED(NANODLP_ALL_AXIS)
       #define _HOME_SYNC true       // For any axis, output sync text.
@@ -461,19 +472,6 @@ void GcodeSuite::G28(const bool always_home_all) {
     #endif
     if (_HOME_SYNC)
       SERIAL_ECHOLNPGM(MSG_Z_MOVE_COMP);
-  #endif
-
-  #if ENABLED(CNC_COORDINATE_SYSTEMS)
-    float current_offset[XYZ] = { 0 };
-    if (active_coordinate_system != -1) {
-      COPY(current_offset, coordinate_system[active_coordinate_system]);
-      LOOP_XYZ(i) {
-        position_shift[i] = current_offset[i];
-        update_workspace_offset((AxisEnum)i);
-      }
-      SERIAL_ECHOLNPAIR("Selected workspace: ", active_coordinate_system);
-      report_current_position();
-    }
   #endif
 
   if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< G28");

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -191,6 +191,11 @@ void GcodeSuite::G28(const bool always_home_all) {
     log_machine_info();
   }
 
+  #if ENABLED(CNC_COORDINATE_SYSTEMS)
+    const int8_t old_system = active_coordinate_system;
+    select_coordinate_system(-1);
+  #endif
+
   #if ENABLED(DUAL_X_CARRIAGE)
     bool IDEX_saved_duplication_state = extruder_duplication_enabled;
     DualXMode IDEX_saved_mode = dual_x_carriage_mode;
@@ -453,13 +458,7 @@ void GcodeSuite::G28(const bool always_home_all) {
   ui.refresh();
 
   #if ENABLED(CNC_COORDINATE_SYSTEMS)
-    if (active_coordinate_system != -1) {
-      LOOP_XYZ(i) {
-        position_shift[i] = coordinate_system[active_coordinate_system][i];
-        update_workspace_offset((AxisEnum)i);
-      }
-      SERIAL_ECHOLNPAIR("Selected workspace: ", active_coordinate_system);
-    }
+    select_coordinate_system(old_system);
   #endif
 
   report_current_position();

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -191,11 +191,6 @@ void GcodeSuite::G28(const bool always_home_all) {
     log_machine_info();
   }
 
-  #if ENABLED(CNC_COORDINATE_SYSTEMS)
-    const int8_t old_system = active_coordinate_system;
-    select_coordinate_system(-1);
-  #endif
-
   #if ENABLED(DUAL_X_CARRIAGE)
     bool IDEX_saved_duplication_state = extruder_duplication_enabled;
     DualXMode IDEX_saved_mode = dual_x_carriage_mode;
@@ -456,10 +451,6 @@ void GcodeSuite::G28(const bool always_home_all) {
   #endif
 
   ui.refresh();
-
-  #if ENABLED(CNC_COORDINATE_SYSTEMS)
-    select_coordinate_system(old_system);
-  #endif
 
   report_current_position();
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -465,14 +465,14 @@ void GcodeSuite::G28(const bool always_home_all) {
 
   #if ENABLED(CNC_COORDINATE_SYSTEMS)
     float current_offset[XYZ] = { 0 };
-    if (active_coordinate_system != -1){
-    COPY(current_offset, coordinate_system[active_coordinate_system]);
-    LOOP_XYZ(i){
-      position_shift[i] = current_offset[i];
-      update_workspace_offset((AxisEnum)i);
-    }
-    SERIAL_ECHOLNPAIR("Selected workspace: ", active_coordinate_system);
-    report_current_position();
+    if (active_coordinate_system != -1) {
+      COPY(current_offset, coordinate_system[active_coordinate_system]);
+      LOOP_XYZ(i) {
+        position_shift[i] = current_offset[i];
+        update_workspace_offset((AxisEnum)i);
+      }
+      SERIAL_ECHOLNPAIR("Selected workspace: ", active_coordinate_system);
+      report_current_position();
     }
   #endif
 

--- a/Marlin/src/gcode/geometry/G53-G59.cpp
+++ b/Marlin/src/gcode/geometry/G53-G59.cpp
@@ -29,7 +29,8 @@
 
 /**
  * Select a coordinate system and update the workspace offset.
- * System index -1 is used to specify machine-native.
+ * System index -1 is used to specify machine-
+ ve.
  */
 bool GcodeSuite::select_coordinate_system(const int8_t _new) {
   if (active_coordinate_system == _new) return false;
@@ -62,14 +63,14 @@ void GcodeSuite::G53() {
   planner.synchronize();
   float current_offset[XYZ] = { 0 };
   if (parser.chain()) { // If this command has more following...
-    // Switch to native space, process gcode, reset back to workspace
+    // Switch to native space, process gcode, switch back to selected workspace
     COPY(current_offset, coordinate_system[active_coordinate_system]);
     LOOP_XYZ(i){
       position_shift[i] = 0;
       update_workspace_offset((AxisEnum)i);
     }
     process_parsed_command();
-    SERIAL_ECHOLNPAIR("Switch to natice space ");
+    SERIAL_ECHOLNPAIR("Switch to native space ");
     report_current_position();
     LOOP_XYZ(i){
       position_shift[i] = current_offset[i];
@@ -79,6 +80,7 @@ void GcodeSuite::G53() {
     report_current_position();
   }
   else {
+    //Switch to native space
     LOOP_XYZ(i){
       position_shift[i] = 0;
       update_workspace_offset((AxisEnum)i);

--- a/Marlin/src/gcode/geometry/G53-G59.cpp
+++ b/Marlin/src/gcode/geometry/G53-G59.cpp
@@ -27,23 +27,21 @@
 
 #include "../../module/stepper.h"
 
+//#define DEBUG_M53
+
 /**
  * Select a coordinate system and update the workspace offset.
  * System index -1 is used to specify machine-native.
  */
 bool GcodeSuite::select_coordinate_system(const int8_t _new) {
   if (active_coordinate_system == _new) return false;
-  planner.synchronize();
-  float old_offset[XYZ] = { 0 }, new_offset[XYZ] = { 0 };
-  if (WITHIN(active_coordinate_system, 0, MAX_COORDINATE_SYSTEMS - 1))
-    COPY(old_offset, coordinate_system[active_coordinate_system]);
+  active_coordinate_system = _new;
+  float new_offset[XYZ] = { 0 };
   if (WITHIN(_new, 0, MAX_COORDINATE_SYSTEMS - 1))
     COPY(new_offset, coordinate_system[_new]);
-  active_coordinate_system = _new;
   LOOP_XYZ(i) {
-    const float diff = new_offset[i] - old_offset[i];
-    if (diff) {
-      position_shift[i] += diff;
+    if (position_shift[i] != new_offset[i]) {
+      position_shift[i] = new_offset[i];
       update_workspace_offset((AxisEnum)i);
     }
   }
@@ -60,34 +58,20 @@ bool GcodeSuite::select_coordinate_system(const int8_t _new) {
  * Marlin also uses G53 on a line by itself to go back to native space.
  */
 void GcodeSuite::G53() {
-  planner.synchronize();
-  float current_offset[XYZ] = { 0 };
-  if (parser.chain()) { // If this command has more following...
-    // Switch to native space, process gcode, switch back to selected workspace
-    COPY(current_offset, coordinate_system[active_coordinate_system]);
-    LOOP_XYZ(i) {
-      position_shift[i] = 0;
-      update_workspace_offset((AxisEnum)i);
-    }
-    process_parsed_command();
-    SERIAL_ECHOLNPAIR("Switch to native space");
+  const int8_t old_system = active_coordinate_system;
+  select_coordinate_system(-1);   // Always remove workspace offsets
+  #ifdef DEBUG_M53
+    SERIAL_ECHOLNPGM("Go to native space");
     report_current_position();
-    LOOP_XYZ(i) {
-      position_shift[i] = current_offset[i];
-      update_workspace_offset((AxisEnum)i);
-    }
-    SERIAL_ECHOLNPAIR("Switch back to workspace");
-    report_current_position();
-  }
-  else {
-    // Switch to native space
-    LOOP_XYZ(i) {
-      position_shift[i] = 0;
-      update_workspace_offset((AxisEnum)i);
-    }
-    active_coordinate_system = -1;
-    SERIAL_ECHOLNPAIR("Switch to native space");
-    report_current_position();
+  #endif
+
+  if (parser.chain()) {       // Command to chain?
+    process_parsed_command(); // ...process the chained command
+    select_coordinate_system(old_system);
+    #ifdef DEBUG_M53
+      SERIAL_ECHOLNPAIR("Go back to workspace ", old_system);
+      report_current_position();
+    #endif
   }
 }
 

--- a/Marlin/src/gcode/geometry/G53-G59.cpp
+++ b/Marlin/src/gcode/geometry/G53-G59.cpp
@@ -29,8 +29,7 @@
 
 /**
  * Select a coordinate system and update the workspace offset.
- * System index -1 is used to specify machine-
- ve.
+ * System index -1 is used to specify machine-native.
  */
 bool GcodeSuite::select_coordinate_system(const int8_t _new) {
   if (active_coordinate_system == _new) return false;
@@ -50,6 +49,7 @@ bool GcodeSuite::select_coordinate_system(const int8_t _new) {
   }
   return true;
 }
+
 /**
  * G53: Apply native workspace to the current move
  *
@@ -65,31 +65,32 @@ void GcodeSuite::G53() {
   if (parser.chain()) { // If this command has more following...
     // Switch to native space, process gcode, switch back to selected workspace
     COPY(current_offset, coordinate_system[active_coordinate_system]);
-    LOOP_XYZ(i){
+    LOOP_XYZ(i) {
       position_shift[i] = 0;
       update_workspace_offset((AxisEnum)i);
     }
     process_parsed_command();
-    SERIAL_ECHOLNPAIR("Switch to native space ");
+    SERIAL_ECHOLNPAIR("Switch to native space");
     report_current_position();
-    LOOP_XYZ(i){
+    LOOP_XYZ(i) {
       position_shift[i] = current_offset[i];
       update_workspace_offset((AxisEnum)i);
     }
-    SERIAL_ECHOLNPAIR("Switch back to workspace ");
+    SERIAL_ECHOLNPAIR("Switch back to workspace");
     report_current_position();
   }
   else {
-    //Switch to native space
-    LOOP_XYZ(i){
+    // Switch to native space
+    LOOP_XYZ(i) {
       position_shift[i] = 0;
       update_workspace_offset((AxisEnum)i);
     }
     active_coordinate_system = -1;
-    SERIAL_ECHOLNPAIR("Switch to native space ");
+    SERIAL_ECHOLNPAIR("Switch to native space");
     report_current_position();
   }
 }
+
 /**
  * G54-G59.3: Select a new workspace
  *

--- a/Marlin/src/gcode/geometry/G92.cpp
+++ b/Marlin/src/gcode/geometry/G92.cpp
@@ -52,12 +52,9 @@ void GcodeSuite::G92() {
       case 1: {
         // Zero the G92 values and restore current position
         #if !IS_SCARA
-          LOOP_XYZ(i) {
-            const float v = position_shift[i];
-            if (v) {
-              position_shift[i] = 0;
-              update_workspace_offset((AxisEnum)i);
-            }
+          LOOP_XYZ(i) if (position_shift[i]) {
+            position_shift[i] = 0;
+            update_workspace_offset((AxisEnum)i);
           }
         #endif // Not SCARA
       } return;

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1325,17 +1325,6 @@ void set_axis_is_at_home(const AxisEnum axis) {
   SBI(axis_known_position, axis);
   SBI(axis_homed, axis);
 
-  #if HAS_POSITION_SHIFT && DISABLED(DELTA)
-    position_shift[axis] = (
-      #if ENABLED(CNC_COORDINATE_SYSTEMS)
-        WITHIN(gcode.active_coordinate_system, 0, MAX_COORDINATE_SYSTEMS - 1) ? gcode.coordinate_system[gcode.active_coordinate_system][axis] : 0
-      #else
-        0
-      #endif
-    );
-    update_workspace_offset(axis);
-  #endif
-
   #if ENABLED(DUAL_X_CARRIAGE)
     if (axis == X_AXIS && (active_extruder == 1 || dual_x_carriage_mode == DXC_DUPLICATION_MODE)) {
       current_position[X_AXIS] = x_home_pos(active_extruder);

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1325,8 +1325,14 @@ void set_axis_is_at_home(const AxisEnum axis) {
   SBI(axis_known_position, axis);
   SBI(axis_homed, axis);
 
-  #if HAS_POSITION_SHIFT
-    position_shift[axis] = 0;
+  #if HAS_POSITION_SHIFT && DISABLED(DELTA)
+    position_shift[axis] = (
+      #if ENABLED(CNC_COORDINATE_SYSTEMS)
+        WITHIN(gcode.active_coordinate_system, 0, MAX_COORDINATE_SYSTEMS - 1) ? gcode.coordinate_system[gcode.active_coordinate_system][axis] : 0
+      #else
+        0
+      #endif
+    );
     update_workspace_offset(axis);
   #endif
 


### PR DESCRIPTION
As per #14743 G53 was not behaving as it should.  Explicit calls to 'update_workspace_offset' resolves the issue. Additional condition for G28 to respect the currently selected workspace.

### Requirements

NONE

### Description

G53 was not behaving as it should - see #14743 for more details. Perhaps it has something to do with 'active_coordinate_system' being a static variable, it can only be set once in a function call.

### Benefits

Corrects G53 function and force G28 to respect selected workspace offsets.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
