### PR TITLE
U8glib-HAL extern cleanup

### DIFF
--- a/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
+++ b/Marlin/src/lcd/dogm/HAL_LCD_com_defines.h
@@ -27,6 +27,12 @@
 
 #ifndef U8G_HAL_LINKS
 
+  // generic prototypes
+  uint8_t u8g_com_arduino_std_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+  uint8_t u8g_com_arduino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+  uint8_t u8g_com_arduino_st7920_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+  uint8_t u8g_com_arduino_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
+
   #ifdef __SAM3X8E__
     uint8_t u8g_com_HAL_DUE_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_SW_SPI_FN  u8g_com_HAL_DUE_sw_spi_fn
@@ -38,21 +44,19 @@
   #elif defined(__STM32F1__)
     uint8_t u8g_com_HAL_STM32F1_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_SW_SPI_FN u8g_com_HAL_STM32F1_sw_spi_fn
+    uint8_t u8g_com_stm32duino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_HW_SPI_FN u8g_com_stm32duino_hw_spi_fn
     #define U8G_COM_ST7920_HAL_SW_SPI u8g_com_std_sw_spi_fn
     #define U8G_COM_ST7920_HAL_HW_SPI u8g_com_stm32duino_hw_spi_fn
   #elif defined(ARDUINO_ARCH_STM32)
-    uint8_t u8g_com_arduino_std_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_SW_SPI_FN u8g_com_arduino_std_sw_spi_fn
     uint8_t u8g_com_stm32duino_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_HAL_HW_SPI_FN u8g_com_stm32duino_hw_spi_fn
-    uint8_t u8g_com_arduino_st7920_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_ST7920_HAL_SW_SPI u8g_com_arduino_st7920_spi_fn
-    uint8_t u8g_com_arduino_st7920_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
     #define U8G_COM_ST7920_HAL_HW_SPI u8g_com_arduino_st7920_hw_spi_fn
   #elif defined(__AVR__)
     uint8_t u8g_com_HAL_AVR_sw_sp_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_ptr);
-    #define U8G_COM_HAL_SW_SPI_FN  u8g_com_HAL_AVR_sw_sp_fn
+    #define U8G_COM_HAL_SW_SPI_FN u8g_com_HAL_AVR_sw_sp_fn
     #define U8G_COM_HAL_HW_SPI_FN u8g_com_arduino_hw_spi_fn
     #define U8G_COM_ST7920_HAL_SW_SPI u8g_com_arduino_st7920_spi_fn
     #define U8G_COM_ST7920_HAL_HW_SPI u8g_com_arduino_st7920_hw_spi_fn


### PR DESCRIPTION
was U8glib-HAL changed recently ? i only see commits from 2 years ago.

seems to bug on .c files... now, on "c++ only" headers