### PR TITLE
allow bigtree_skr_mini_v1_1 to compile

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -99,7 +99,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
 /**
  * Select a secondary serial port on the board to use for communication with the host.
@@ -108,7 +108,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-//#define SERIAL_PORT_2 -1
+#define SERIAL_PORT_2 1
 
 /**
  * This setting determines the communication speed of the printer.
@@ -119,14 +119,14 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 
 // Enable the Bluetooth serial interface on AT90USB devices
 //#define BLUETOOTH
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_BIGTREE_SKR_MINI_V1_1
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
@@ -1620,7 +1620,7 @@
  * you must uncomment the following option or it won't work.
  *
  */
-//#define SDSUPPORT
+#define SDSUPPORT
 
 /**
  * SD CARD: SPI SPEED

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = megaatmega2560
+default_envs = BIGTREE_SKR_MINI
 
 [common]
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
@@ -296,7 +296,7 @@ upload_protocol   = serial
 # BigTree SKR Mini V1.1 / SKR mini E3 / SKR E3 DIP (STM32F103RCT6 ARM Cortex-M3)
 #
 [env:BIGTREE_SKR_MINI]
-platform          = ststm32
+platform          = https://github.com/platformio/platform-ststm32.git
 framework         = arduino
 board             = genericSTM32F103RC
 platform_packages = tool-stm32duino
@@ -306,7 +306,8 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/STM32F1_flag_script.py
   -DDEBUG_LEVEL=0
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
-lib_ignore        = Adafruit NeoPixel, SPI
+# lib_ignore        = Adafruit NeoPixel, SPI
+lib_ignore    = U8glib-HAL, Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 upload_protocol   = stlink


### PR DESCRIPTION
### Description

I'm trying to compile this firmware for the skr mini 1.1. Had to ignore U8glib-HAL to get it to copy at all. Also copied over a few configurations from the mfgr's repository; obviously they don't belong in the default config.

### Benefits

Allows firmware to compile at all, without "conflicting declaration of random()" errors e.g.
