### PR TITLE
Disable Tevo Tarantula Pro PIDTEMPBED

### DIFF
--- a/config/examples/Tevo/Tarantula Pro/Configuration.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration.h
@@ -512,7 +512,7 @@
  * heater. If your configuration is significantly different than this and you don't understand
  * the issues involved, don't use bed PID until someone else verifies that your hardware works.
  */
-#define PIDTEMPBED
+//#define PIDTEMPBED
 
 //#define BED_LIMIT_SWITCHING
 


### PR DESCRIPTION
### Description

Disable `PIDTEMPBED` for Tevo Tarantula Pro config.

### Benefits

Allows bed to heat without halting. Users can always enable `PIDTEMPBED` and run `M303 C6 E-1 S60` to get values for their machine if so desired.

### Related Issues

Fix https://github.com/MarlinFirmware/Marlin/issues/15088
