### PR TITLE
Simplify set/get progress percentage

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1546,10 +1546,13 @@ void MarlinUI::update() {
       #if ENABLED(SDSUPPORT)
         if (IS_SD_PRINTING()) return card.percentDone();
       #endif
-      #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
-        return progress_bar_percent;
-      #endif
-      return 0;
+      return (
+        #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
+          progress_bar_percent
+        #else
+          0
+        #endif
+      );
     }
   #endif
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1543,17 +1543,13 @@ void MarlinUI::update() {
 
   #if HAS_PRINT_PROGRESS
     uint8_t MarlinUI::get_progress() {
-      #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
-        uint8_t &progress = progress_bar_percent;
-        #define _PLIMIT(P) ((P) & 0x7F)
-      #else
-        #define _PLIMIT(P) P
-        uint8_t progress = 0;
-      #endif
       #if ENABLED(SDSUPPORT)
-        if (IS_SD_PRINTING()) progress = card.percentDone();
+        if (IS_SD_PRINTING()) return card.percentDone();
       #endif
-      return _PLIMIT(progress);
+      #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
+        return progress_bar_percent;
+      #endif
+      return 0;
     }
   #endif
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -296,8 +296,8 @@ public:
       #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
         static uint8_t progress_bar_percent;
         static void set_progress(const uint8_t progress) { progress_bar_percent = _MIN(progress, 100); }
-        static void set_progress_done() { set_progress(0x80 + 100); }
-        static void progress_reset() { if (progress_bar_percent & 0x80) set_progress(0); }
+        static void set_progress_done() { set_progress(100); }
+        static void progress_reset() { set_progress(0); }
       #endif
       static uint8_t get_progress();
     #else


### PR DESCRIPTION
Since the manual progress send is only processed in once place, and clamped to 100 the additional code is unnecessary.