### PR TITLE
Fix HAL_STM32 SPI regression

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL_spi_STM32.cpp
@@ -82,12 +82,7 @@ void spiInit(uint8_t spiRate) {
       clock = 4000000; // Default from the SPI library
   }
   spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
-  #if defined(MISO_PIN) && defined(SDSS) && defined(MOSI_PIN) && defined(SCK_PIN)
-    SPI.setMISO(MISO_PIN);
-    SPI.setSSEL(SDSS);
-    SPI.setMOSI(MOSI_PIN);
-    SPI.setSCLK(SCK_PIN);
-  #endif
+
   SPI.begin();
 }
 


### PR DESCRIPTION
### Description

The change to `HAL_spi_STM32.cpp` introduced with commit 0b47558 / PR #14994 causes issues to existing boards that is not using a hardware controlled pin for `SDSS`. Inserting a SDCard causes a watchdog reset.

If a call is made to `SPI.setSSEL()` on Arduino Core STM32 the pin **MUST BE** a SPI hardware controlled pin. Otherwise the call will end up in an endless loop in the core's `ErrorHandler()` function. Also, if this pin is set the pin will controlled by the `SPIClass` and not by Marlin and I don't think we want that as the SdCard class handles the chip-select signaling and **it would probably break** chip-select signalling for SPI displays.

The SPI-pin initialization code for the other SPI pins in `HAL_spi_STM32.cpp` introduced in 0b47558 should be unnecessary as the SPI pins are initialized by the default constructor of SPIClass. 

```cpp
SPIClass::SPIClass() : _CSPinConfig(NO_CONFIG)
{
  _spi.pin_miso = digitalPinToPinName(MISO);
  _spi.pin_mosi = digitalPinToPinName(MOSI);
  _spi.pin_sclk = digitalPinToPinName(SCK);
  _spi.pin_ssel = NC;
}
```

The `MISO`, `MOSI` and `SCK` pins are defined as:

```cpp
static const uint8_t MOSI = PIN_SPI_MOSI;
static const uint8_t MISO = PIN_SPI_MISO;
static const uint8_t SCK  = PIN_SPI_SCK;
```

in the core's `pins_arduino.h` and the `PIN_SPI_x` is defined in the board's `variant.h` file.

From the Arduino Core STM32 SPI documentation:

```cpp
  * @param  ssel: SPI ssel pin (optional). Accepted format: number or
  *         Arduino format (Dx) or ST format (Pxy). By default is set to NC.
  *         This pin must correspond to a hardware CS pin which can be managed
  *         by the SPI peripheral itself. See the datasheet of the microcontroller
  *         or look at PinMap_SPI_SSEL[] inside the file PeripheralPins.c
  *         corresponding to the board. If you configure this pin you can't use
  *         another CS pin and don't pass a CS pin as parameter to any functions
  *         of the class.
```

### Benefits

SDCard works again.
