### PR TITLE
Add Ender-3 TMC RMS Current

### DIFF
--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -1727,7 +1727,7 @@
   #define INTERPOLATE       true  // Interpolate X/Y/Z_MICROSTEPS to 256
 
   #if AXIS_IS_TMC(X)
-    #define X_CURRENT     800  // (mA) RMS current. Multiply by 1.414 for peak current.
+    #define X_CURRENT     580  // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_MICROSTEPS   16  // 0..256
     #define X_RSENSE     0.11
     #define X_CHAIN_POS     0  // 0 - Not chained, 1 - MCU MOSI connected, 2 - next in chain, ...
@@ -1741,7 +1741,7 @@
   #endif
 
   #if AXIS_IS_TMC(Y)
-    #define Y_CURRENT     800
+    #define Y_CURRENT     580
     #define Y_MICROSTEPS   16
     #define Y_RSENSE     0.11
     #define Y_CHAIN_POS     0
@@ -1755,7 +1755,7 @@
   #endif
 
   #if AXIS_IS_TMC(Z)
-    #define Z_CURRENT     800
+    #define Z_CURRENT     580
     #define Z_MICROSTEPS   16
     #define Z_RSENSE     0.11
     #define Z_CHAIN_POS     0
@@ -1776,7 +1776,7 @@
   #endif
 
   #if AXIS_IS_TMC(E0)
-    #define E0_CURRENT    800
+    #define E0_CURRENT    650
     #define E0_MICROSTEPS  16
     #define E0_RSENSE    0.11
     #define E0_CHAIN_POS    0


### PR DESCRIPTION
### Description

Add RMS current defaults for a stock Ender-3 to make replacing the mainboard with TMC drivers easier.

| Steppers | X | Y | Z | E |
|---|---|---|---|---|
| Ender-3 | 34mm/580mA | 34mm/580mA | 34mm/580mA | 40mm/650mA |

**Note:** Stock motors are rated from the manufacturer using peak values instead of RMS (See https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3-/issues/22#issuecomment-525808256 and [this gist](https://gist.github.com/knoopx/e6c40a009e796203b93a75a3ed6a5ab8) from @knoopx), which is why these values are less than the advertised ratings of 840mA for X/Y/Z and 1000mA for E.

### Benefits

Easier setup of UART/SPI TMC drivers with an aftermarket mainboard on a stock Ender-3. This also prevents motors from overheating due to users setting current using peak ratings instead of RMS or using Marlin's default values of 800mA.

### Related Issues

None.