### PR TITLE
Fix repeated boot screen

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -219,7 +219,7 @@ bool MarlinUI::detected() { return true; }
     #ifndef BOOTSCREEN_TIMEOUT
       #define BOOTSCREEN_TIMEOUT 2500
     #endif
-    for (uint8_t q = 2; q--;) {
+    for (uint8_t q = 1; q--;) {
       #if DISABLED(BOOT_MARLIN_LOGO_ANIMATED)
         u8g.firstPage();
         do { draw_marlin_bootscreen(q == 0); } while (u8g.nextPage());


### PR DESCRIPTION
The logo will appear twice, as you can see by enable `BOOT_MARLIN_LOGO_ANIMATED`