### PR TITLE
Use Flash-based EEPROM on SKR mini-E3

### DIFF
--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_E3.h
@@ -33,6 +33,12 @@
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD 2000
 
+#define FLASH_EEPROM_EMULATION
+#define EEPROM_PAGE_SIZE     uint16(0x800) // 2KB
+#define EEPROM_START_ADDRESS uint32(0x8000000 + 256 * 1024 - 2 * EEPROM_PAGE_SIZE)
+#undef E2END
+#define E2END                (EEPROM_PAGE_SIZE - 1) // 2KB
+
 //
 // Servos
 //
@@ -136,9 +142,3 @@
   #endif
 
 #endif // HAS_SPI_LCD
-
-#define FLASH_EEPROM_EMULATION
-#define EEPROM_PAGE_SIZE     uint16(0x800) // 2KB
-#define EEPROM_START_ADDRESS uint32(0x8000000 + 256 * 1024 - 2 * EEPROM_PAGE_SIZE)
-#undef E2END
-#define E2END                (EEPROM_PAGE_SIZE - 1) // 2KB

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_E3.h
@@ -136,3 +136,9 @@
   #endif
 
 #endif // HAS_SPI_LCD
+
+#define FLASH_EEPROM_EMULATION
+#define EEPROM_PAGE_SIZE     uint16(0x800) // 2KB
+#define EEPROM_START_ADDRESS uint32(0x8000000 + 256 * 1024 - 2 * EEPROM_PAGE_SIZE)
+#undef E2END
+#define E2END                (EEPROM_PAGE_SIZE - 1) // 2KB


### PR DESCRIPTION
Copied from earlier commit for different board with similar chip. Verified to also work with SKR mini-E3 board.
Based on this commit:
https://github.com/tpruvot/Marlin/commit/1bc5c97b95ac3f265b291955ecebb58886613f57

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Same EEPROM fix for same or similar chip on different board. This should work with few others, but I only have SKR Mini-E3 to test it with.

### Benefits

Save settings on board instead of external sdcard.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
