### PR TITLE
Home on G34 if steppers slept

### DIFF
--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -132,7 +132,7 @@ void GcodeSuite::G34() {
     );
 
     // Home before the alignment procedure
-    if (homing_needed()) home_all_axes();
+    if (!all_axes_known()) home_all_axes();
 
     // Move the Z coordinate realm towards the positive - dirty trick
     current_position[Z_AXIS] -= z_probe * 0.5;


### PR DESCRIPTION
If Z axes position are not reliable neither is the `G34` result. Hence, force home when in such condition.