### PR TITLE
Use Flash-based EEPROM on SKR Mini E3-DIP

### DIFF
--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_E3_DIP.h
@@ -33,6 +33,12 @@
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD 2000
 
+#define FLASH_EEPROM_EMULATION
+#define EEPROM_PAGE_SIZE     uint16(0x800) // 2KB
+#define EEPROM_START_ADDRESS uint32(0x8000000 + 256 * 1024 - 2 * EEPROM_PAGE_SIZE)
+#undef E2END
+#define E2END                (EEPROM_PAGE_SIZE - 1) // 2KB
+
 //
 // Servos
 //


### PR DESCRIPTION
### Description

This is a follow-up to "Use Flash-based EEPROM on SKR mini-E3" #15126 to add flash-based EEPROM support to the SKR Mini E3-DIP as well since it's also in the same family as the other SKR Mini boards.

### Benefits

Users no longer have to use an SD card to store EEPROM settings.

### Related Issues

None.
