### PR TITLE
Improve Power-loss Recovery

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -672,6 +672,9 @@ void idle(
     bool no_stepper_sleep/*=false*/
   #endif
 ) {
+  #if ENABLED(POWER_LOSS_RECOVERY) && PIN_EXISTS(POWER_LOSS)
+    recovery.outage();
+  #endif
 
   #if ENABLED(SPI_ENDSTOPS)
     if (endstops.tmc_spi_homing.any

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -36,6 +36,9 @@ bool PrintJobRecovery::enabled; // Initialized by settings.load()
 SdFile PrintJobRecovery::file;
 job_recovery_info_t PrintJobRecovery::info;
 const char PrintJobRecovery::filename[5] = "/PLR";
+uint8_t PrintJobRecovery::queue_index_r;
+uint32_t PrintJobRecovery::cmd_sdpos, // = 0
+         PrintJobRecovery::sdpos[BUFSIZE];
 
 #include "../sd/cardreader.h"
 #include "../lcd/ultralcd.h"
@@ -249,6 +252,8 @@ void PrintJobRecovery::resume() {
 
   #define RECOVERY_ZRAISE 2
 
+  const uint32_t resume_sdpos = info.sdpos; // Get here before the stepper ISR overwrites it
+
   #if HAS_LEVELING
     // Make sure leveling is off before any G92 and G28
     gcode.process_subcommands_now_P(PSTR("M420 S0 Z0"));
@@ -403,7 +408,7 @@ void PrintJobRecovery::resume() {
   char *fn = info.sd_filename;
   sprintf_P(cmd, PSTR("M23 %s"), fn);
   gcode.process_subcommands_now(cmd);
-  sprintf_P(cmd, PSTR("M24 S%ld T%ld"), info.sdpos, info.print_job_elapsed);
+  sprintf_P(cmd, PSTR("M24 S%ld T%ld"), resume_sdpos, info.print_job_elapsed);
   gcode.process_subcommands_now(cmd);
 }
 

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -148,9 +148,6 @@ void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=
   // Did Z change since the last call?
   if (force
     #if DISABLED(SAVE_EACH_CMD_MODE)      // Always save state when enabled
-      #if PIN_EXISTS(POWER_LOSS)          // Save if power loss pin is triggered
-        || READ(POWER_LOSS_PIN) == POWER_LOSS_STATE
-      #endif
       #if SAVE_INFO_INTERVAL_MS > 0       // Save if interval is elapsed
         || ELAPSED(ms, next_save_ms)
       #endif
@@ -228,13 +225,15 @@ void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=
     info.sdpos = card.getIndex();
 
     write();
-
-    // KILL now if the power-loss pin was triggered
-    #if PIN_EXISTS(POWER_LOSS)
-      if (READ(POWER_LOSS_PIN) == POWER_LOSS_STATE) kill(PSTR(MSG_OUTAGE_RECOVERY));
-    #endif
   }
 }
+
+#if PIN_EXISTS(POWER_LOSS)
+  void PrintJobRecovery::_outage() {
+    save(true);
+    kill(PSTR(MSG_OUTAGE_RECOVERY));
+  }
+#endif
 
 /**
  * Save the recovery info the recovery file

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -125,6 +125,13 @@ void PrintJobRecovery::load() {
 }
 
 /**
+ * Set info fields that won't change
+ */
+void PrintJobRecovery::prepare() {
+  card.getAbsFilename(info.sd_filename);  // SD filename
+}
+
+/**
  * Save the current machine state to the power-loss recovery file
  */
 void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=true*/) {
@@ -218,7 +225,6 @@ void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=
     info.print_job_elapsed = print_job_timer.duration();
 
     // SD file position
-    card.getAbsFilename(info.sd_filename);
     info.sdpos = card.getIndex();
 
     write();

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -113,6 +113,7 @@ class PrintJobRecovery {
     static job_recovery_info_t info;
 
     static void init();
+    static void prepare();
 
     static inline void setup() {
       #if PIN_EXISTS(POWER_LOSS)

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -151,6 +151,13 @@ class PrintJobRecovery {
       , const bool save_queue=true
     );
 
+  #if PIN_EXISTS(POWER_LOSS)
+    static inline void outage() {
+      if (enabled && IS_SD_PRINTING() && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE)
+        _outage();
+    }
+  #endif
+
   static inline bool valid() { return info.valid_head && info.valid_head == info.valid_foot; }
 
   #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
@@ -161,6 +168,10 @@ class PrintJobRecovery {
 
   private:
     static void write();
+
+  #if PIN_EXISTS(POWER_LOSS)
+    static void _outage();
+  #endif
 };
 
 extern PrintJobRecovery recovery;

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -92,7 +92,7 @@ typedef struct {
 
   // SD Filename and position
   char sd_filename[MAXPATHNAMELENGTH];
-  uint32_t sdpos;
+  volatile uint32_t sdpos;
 
   // Job elapsed time
   millis_t print_job_elapsed;
@@ -108,6 +108,7 @@ class PrintJobRecovery {
     static SdFile file;
     static job_recovery_info_t info;
 
+    static uint8_t queue_index_r;     //!< Queue index of the active command
     static uint32_t cmd_sdpos,        //!< SD position of the next command
                     sdpos[BUFSIZE];   //!< SD positions of queued commands
 
@@ -129,9 +130,7 @@ class PrintJobRecovery {
     }
 
     // Track each command's file offsets
-    static inline void update_sdpos(const uint8_t index_r) {
-      if (sdpos[index_r]) info.sdpos = sdpos[index_r];
-    }
+    static inline uint32_t command_sdpos() { return sdpos[queue_index_r]; }
     static inline void commit_sdpos(const uint8_t index_w) { sdpos[index_w] = cmd_sdpos; }
 
     static bool enabled;

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -90,10 +90,6 @@ typedef struct {
   // Relative mode
   bool relative_mode, relative_modes_e;
 
-  // Command queue
-  uint8_t queue_length, queue_index_r;
-  char queue_buffer[BUFSIZE][MAX_CMD_SIZE];
-
   // SD Filename and position
   char sd_filename[MAXPATHNAMELENGTH];
   uint32_t sdpos;
@@ -112,6 +108,9 @@ class PrintJobRecovery {
     static SdFile file;
     static job_recovery_info_t info;
 
+    static uint32_t cmd_sdpos,        //!< SD position of the next command
+                    sdpos[BUFSIZE];   //!< SD positions of queued commands
+
     static void init();
     static void prepare();
 
@@ -128,6 +127,12 @@ class PrintJobRecovery {
         #endif
       #endif
     }
+
+    // Track each command's file offsets
+    static inline void update_sdpos(const uint8_t index_r) {
+      if (sdpos[index_r]) info.sdpos = sdpos[index_r];
+    }
+    static inline void commit_sdpos(const uint8_t index_w) { sdpos[index_w] = cmd_sdpos; }
 
     static bool enabled;
     static void enable(const bool onoff);

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -817,7 +817,7 @@ void GcodeSuite::process_next_command() {
   PORT_REDIRECT(queue.port[queue.index_r]);
 
   #if ENABLED(POWER_LOSS_RECOVERY)
-    recovery.update_sdpos(queue.index_r);
+    recovery.queue_index_r = queue.index_r;
   #endif
 
   if (DEBUGGING(ECHO)) {

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -816,6 +816,10 @@ void GcodeSuite::process_next_command() {
 
   PORT_REDIRECT(queue.port[queue.index_r]);
 
+  #if ENABLED(POWER_LOSS_RECOVERY)
+    recovery.update_sdpos(queue.index_r);
+  #endif
+
   if (DEBUGGING(ECHO)) {
     SERIAL_ECHO_START();
     SERIAL_ECHOLN(current_command);

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -118,7 +118,7 @@ void GcodeSuite::get_destination_from_command() {
       destination[i] = current_position[i];
   }
 
-  #if ENABLED(POWER_LOSS_RECOVERY)
+  #if ENABLED(POWER_LOSS_RECOVERY) && !PIN_EXISTS(POWER_LOSS)
     // Only update power loss recovery on moves with E
     if (recovery.enabled && IS_SD_PRINTING() && seen[E_AXIS] && (seen[X_AXIS] || seen[Y_AXIS]))
       recovery.save();

--- a/Marlin/src/gcode/sdcard/M24_M25.cpp
+++ b/Marlin/src/gcode/sdcard/M24_M25.cpp
@@ -38,6 +38,10 @@
   #include "../../feature/host_actions.h"
 #endif
 
+#if ENABLED(POWER_LOSS_RECOVERY)
+  #include "../../feature/power_loss_recovery.h"
+#endif
+
 /**
  * M24: Start or Resume SD Print
  */
@@ -58,6 +62,9 @@ void GcodeSuite::M24() {
   if (card.isFileOpen()) {
     card.startFileprint();
     print_job_timer.start();
+    #if ENABLED(POWER_LOSS_RECOVERY)
+      recovery.prepare();
+    #endif
   }
 
   #if ENABLED(HOST_ACTION_COMMANDS)

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -96,6 +96,10 @@
   #include "../feature/backlash.h"
 #endif
 
+#if ENABLED(POWER_LOSS_RECOVERY)
+  #include "../feature/power_loss_recovery.h"
+#endif
+
 // Delay for delivery of first block to the stepper ISR, if the queue contains 2 or
 // fewer movements. The delay is measured in milliseconds, and must be less than 250ms
 #define BLOCK_DELAY_FOR_1ST_MOVE 100
@@ -2511,6 +2515,10 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
   #if ENABLED(GRADIENT_MIX)
     mixer.gradient_control(target_float[Z_AXIS]);
+  #endif
+
+  #if ENABLED(POWER_LOSS_RECOVERY)
+    block->sdpos = recovery.command_sdpos();
   #endif
 
   // Movement was accepted

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -159,6 +159,10 @@ typedef struct block_t {
     uint32_t segment_time_us;
   #endif
 
+  #if ENABLED(POWER_LOSS_RECOVERY)
+    uint32_t sdpos;
+  #endif
+
 } block_t;
 
 #define HAS_POSITION_FLOAT ANY(LIN_ADVANCE, SCARA_FEEDRATE_SCALING, GRADIENT_MIX)

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -121,6 +121,10 @@ Stepper stepper; // Singleton
   #include "../libs/L6470/L6470_Marlin.h"
 #endif
 
+#if ENABLED(POWER_LOSS_RECOVERY)
+  #include "../feature/power_loss_recovery.h"
+#endif
+
 // public:
 
 #if HAS_EXTRA_ENDSTOPS || ENABLED(Z_STEPPER_AUTO_ALIGN)
@@ -1662,6 +1666,10 @@ uint32_t Stepper::stepper_block_phase_isr() {
         if (!(current_block = planner.get_current_block()))
           return interval; // No more queued movements!
       }
+
+      #if ENABLED(POWER_LOSS_RECOVERY)
+        recovery.info.sdpos = current_block->sdpos;
+      #endif
 
       // Flag all moving axes for proper endstop handling
 


### PR DESCRIPTION
In reference to #15120

- Check the power loss pin in the `idle` loop instead of only when fetching the next G-code move command that includes E plus X or Y.
- Track the SD position of queued commands to make the PLR file smaller, saving 368-920 bytes of SRAM and improving PLR performance.
- Set unchanging fields (filename) just once at the start of the print job.

---
- Level 2 — Track the SD file position in planner blocks so PLR is able to save the SD file position of the actual line being actively processed by the Stepper ISR.