### PR TITLE
Fix Ender-3 Status Screen Logo Y Offset

### DIFF
--- a/config/examples/Creality/Ender-3/_Statusscreen.h
+++ b/config/examples/Creality/Ender-3/_Statusscreen.h
@@ -34,6 +34,7 @@
 //
 // Status Screen Logo bitmap
 //
+#define STATUS_LOGO_Y            8
 #define STATUS_LOGO_WIDTH       39
 
 const unsigned char status_logo_bmp[] PROGMEM = {


### PR DESCRIPTION
### Description

Commit https://github.com/MarlinFirmware/Marlin/commit/4def8b3b5e01498d0a4358898784b08b886c3202 cleaned up `_Statusscreen.h`, but left the Ender-3 logo/text forced at the top of the LCD:

![ender-3-before](https://user-images.githubusercontent.com/13375512/64086404-f2d67580-ccec-11e9-8ae9-d37753c6b9ed.jpeg)

This PR adds the logo Y offset:

![ender-3-after](https://user-images.githubusercontent.com/13375512/64086694-8e1c1a80-ccee-11e9-85d1-8f50903013bd.jpeg)

### Benefits

The "Ender-3" logo/text is no longer forced to the top of the LCD.

### Related Issues

None.