### PR TITLE
Apply soft limits to G2/G3 final target

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -220,6 +220,8 @@ void plan_arc(
     raw[l_axis] = start_L;
   #endif
 
+  apply_motion_limits(raw);
+  
   #if HAS_LEVELING && !PLANNER_LEVELING
     planner.apply_leveling(raw);
   #endif


### PR DESCRIPTION
### Description

Observed strange behavior when G2/G3 interacts with soft limits.  Here is one example: https://www.v1engineering.com/forum/topic/strange-movement/

This strange behavior appears to be due to incorrect application of limits in G2/G3 movements.

Upon examining the code, found that the final movement to reach the target location does not have limits applied (apply_motion_limits).

### Benefits

Proper clipping of G2/G3 movements when endpoint is outside working volume.

### Related Issues

Unfortunately my machine is down so I can't test it right now.  I'll test shortly and update with the findings.