### PR TITLE
Allow MINIMUM_STEPPER_PULSE override with LV8729

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -164,7 +164,7 @@
 // adding the "start stepper pulse" code section execution cycles to account for that not all
 // pulses start at the beginning of the loop, so an extra time must be added to compensate so
 // the last generated pulse (usually the extruder stepper) has the right length
-#if HAS_DRIVER(LV8729) && !defined(MINIMUM_STEPPER_PULSE)
+#if HAS_DRIVER(LV8729) && MINIMUM_STEPPER_PULSE == 0
   #define MIN_PULSE_TICKS ((((PULSE_TIMER_TICKS_PER_US) + 1) / 2) + ((MIN_ISR_START_LOOP_CYCLES) / uint32_t(PULSE_TIMER_PRESCALE)))
 #else
   #define MIN_PULSE_TICKS (((PULSE_TIMER_TICKS_PER_US) * uint32_t(MINIMUM_STEPPER_PULSE)) + ((MIN_ISR_START_LOOP_CYCLES) / uint32_t(PULSE_TIMER_PRESCALE)))

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -164,7 +164,7 @@
 // adding the "start stepper pulse" code section execution cycles to account for that not all
 // pulses start at the beginning of the loop, so an extra time must be added to compensate so
 // the last generated pulse (usually the extruder stepper) has the right length
-#if HAS_DRIVER(LV8729)
+#if HAS_DRIVER(LV8729) && !defined(MINIMUM_STEPPER_PULSE)
   #define MIN_PULSE_TICKS ((((PULSE_TIMER_TICKS_PER_US) + 1) / 2) + ((MIN_ISR_START_LOOP_CYCLES) / uint32_t(PULSE_TIMER_PRESCALE)))
 #else
   #define MIN_PULSE_TICKS (((PULSE_TIMER_TICKS_PER_US) * uint32_t(MINIMUM_STEPPER_PULSE)) + ((MIN_ISR_START_LOOP_CYCLES) / uint32_t(PULSE_TIMER_PRESCALE)))


### PR DESCRIPTION
### Description

If driver type `LV8729` is selected for any axis the `MINIMUM_STEPPER_PULSE` is not respected.

Driver `LV8729` with `MINIMUM_STEPPER_PULSE = 3`. Actual pulse length is ~500ns => INCORRECT
![LV8729_MinStepPulse3](https://user-images.githubusercontent.com/17763620/64284590-3bdf3180-cf5a-11e9-901a-3e5cd7eb5b0a.png)

Driver `A4988` with `MINIMUM_STEPPER_PULSE = 3`. Actual pulse length is ~3us => CORRECT
![A4988_MinStepPulse3](https://user-images.githubusercontent.com/17763620/64284630-50bbc500-cf5a-11e9-897d-5270bf8d58e0.png)

### Benefits

`MINIMUM_STEPPER_PULSE` can be used to override the driver default, regardless of driver selection.
