### PR TITLE
M118 multiserial support

### DIFF
--- a/Marlin/src/gcode/host/M118.cpp
+++ b/Marlin/src/gcode/host/M118.cpp
@@ -55,7 +55,14 @@ void GcodeSuite::M118() {
   #if NUM_SERIAL > 1
     const int8_t old_serial = serial_port_index;
     if (WITHIN(port, 0, NUM_SERIAL))
-      serial_port_index = (port == 0 ? SERIAL_BOTH : port == 1 ? SERIAL_PORT : port == 2 ? SERIAL_PORT_2 : SERIAL_PORT);
+      serial_port_index = (
+        port == 0 ? SERIAL_BOTH
+        : port == 1 ? SERIAL_PORT
+        #ifdef SERIAL_PORT_2
+          : port == 2 ? SERIAL_PORT_2
+        #endif
+        : SERIAL_PORT
+      );
   #endif
 
   if (hasE) SERIAL_ECHO_START();

--- a/Marlin/src/gcode/host/M118.cpp
+++ b/Marlin/src/gcode/host/M118.cpp
@@ -30,18 +30,29 @@
  */
 void GcodeSuite::M118() {
   bool hasE = false, hasA = false;
-  byte serial = 1;
   char *p = parser.string_arg;
   for (uint8_t i = 2; i--;)
     if ((p[0] == 'A' || p[0] == 'E') && (p[1] == '1' || p[1] == '2' || p[1] == '*')) {
       if (p[0] == 'A') hasA = true;
       if (p[0] == 'E') hasE = true;
-      if (p[1] == '*') serial = p[1];
-      else serial = p[1] - '0';
+      switch (p[1])
+      {
+      case '*':
+        PORT_REDIRECT(SERIAL_BOTH);
+        break;
+      #ifdef SERIAL_PORT_2  
+      case '2':
+        PORT_REDIRECT(SERIAL_PORT_2);  
+      #endif  
+      case '1':
+      default:
+        PORT_REDIRECT(SERIAL_PORT);  
+        break;
+      }
       p += 2;
       while (*p == ' ') ++p;
     }
-  if (hasE || hasA) PORT_REDIRECT(serial == '*'?SERIAL_BOTH:serial);  
+//  if (hasE || hasA) PORT_REDIRECT(serial);  
   if (hasE) SERIAL_ECHO_START();
   if (hasA) SERIAL_ECHOPGM("// ");
   SERIAL_ECHOLN(p);

--- a/Marlin/src/gcode/host/M118.cpp
+++ b/Marlin/src/gcode/host/M118.cpp
@@ -40,10 +40,11 @@ void GcodeSuite::M118() {
       case '*':
         PORT_REDIRECT(SERIAL_BOTH);
         break;
-      #ifdef SERIAL_PORT_2  
       case '2':
-        PORT_REDIRECT(SERIAL_PORT_2);  
-      #endif  
+        #ifdef SERIAL_PORT_2  
+          PORT_REDIRECT(SERIAL_PORT_2);
+          break;  
+        #endif  
       case '1':
       default:
         PORT_REDIRECT(SERIAL_PORT);  
@@ -52,9 +53,8 @@ void GcodeSuite::M118() {
       p += 2;
       while (*p == ' ') ++p;
     }
-//  if (hasE || hasA) PORT_REDIRECT(serial);  
   if (hasE) SERIAL_ECHO_START();
   if (hasA) SERIAL_ECHOPGM("// ");
   SERIAL_ECHOLN(p);
-  PORT_RESTORE();
+  if (hasE || hasA) PORT_RESTORE();  
 }

--- a/Marlin/src/gcode/host/M118.cpp
+++ b/Marlin/src/gcode/host/M118.cpp
@@ -28,30 +28,41 @@
  *
  *  A1  Prepend '// ' for an action command, as in OctoPrint
  *  E1  Have the host 'echo:' the text
+ *  Pn  Redirect to another serial port
+ *        0 : Announce to all ports
+ *      1-9 : Serial ports 1 to 9
  */
 void GcodeSuite::M118() {
   bool hasE = false, hasA = false;
+  #if NUM_SERIAL > 1
+    int8_t port = -1; // Assume no redirect
+  #endif
   char *p = parser.string_arg;
-  int8_t ser_index = 0xFE; // No redirect as default -2 serial
-  for (uint8_t i = 2; i--;)
-    if ((p[0] == 'A' || p[0] == 'E') && (p[1] == '1' || p[1] == '2' || p[1] == '*')) {
-      if (p[0] == 'A') hasA = true;
-      if (p[0] == 'E') hasE = true;
-      if(p[1] == '*')ser_index = SERIAL_BOTH; 
-      else if(p[1] == '1')ser_index = SERIAL_PORT; 
-      #ifdef SERIAL_PORT_2
-      else if(p[1] == '2')ser_index = SERIAL_PORT_2; 
+  for (uint8_t i = 3; i--;) {
+    // A1, E1, and Pn are always parsed out
+    if (!( ((p[0] == 'A' || p[0] == 'E') && p[1] == '1') || (p[0] == 'P' && NUMERIC(p[1])) )) break;
+    switch (p[0]) {
+      case 'A': hasA = true; break;
+      case 'E': hasE = true; break;
+      #if NUM_SERIAL > 1
+        case 'P': port = p[1] - '0'; break;
       #endif
-      p += 2;
-      while (*p == ' ') ++p;
     }
-  if(ser_index != 0xFE){
-    PORT_REDIRECT(ser_index);
-    if (hasE) SERIAL_ECHO_START();
-    if (hasA) SERIAL_ECHOPGM("// ");
-    SERIAL_ECHOLN(p);
-    PORT_RESTORE(); 
-  } else {
-    SERIAL_ECHOLN(p);
+    p += 2;
+    while (*p == ' ') ++p;
   }
+
+  #if NUM_SERIAL > 1
+    const int8_t old_serial = serial_port_index;
+    if (WITHIN(port, 0, NUM_SERIAL))
+      serial_port_index = (port == 0 ? SERIAL_BOTH : port == 1 ? SERIAL_PORT : port == 2 ? SERIAL_PORT_2 : SERIAL_PORT);
+  #endif
+
+  if (hasE) SERIAL_ECHO_START();
+  if (hasA) SERIAL_ECHOPGM("// ");
+  SERIAL_ECHOLN(p);
+
+  #if NUM_SERIAL > 1
+    serial_port_index = old_serial;
+  #endif
 }

--- a/Marlin/src/gcode/host/M118.cpp
+++ b/Marlin/src/gcode/host/M118.cpp
@@ -30,15 +30,20 @@
  */
 void GcodeSuite::M118() {
   bool hasE = false, hasA = false;
+  byte serial = 1;
   char *p = parser.string_arg;
   for (uint8_t i = 2; i--;)
-    if ((p[0] == 'A' || p[0] == 'E') && p[1] == '1') {
+    if ((p[0] == 'A' || p[0] == 'E') && (p[1] == '1' || p[1] == '2' || p[1] == '*')) {
       if (p[0] == 'A') hasA = true;
       if (p[0] == 'E') hasE = true;
+      if (p[1] == '*') serial = p[1];
+      else serial = p[1] - '0';
       p += 2;
       while (*p == ' ') ++p;
     }
+  if (hasE || hasA) PORT_REDIRECT(serial == '*'?SERIAL_BOTH:serial);  
   if (hasE) SERIAL_ECHO_START();
   if (hasA) SERIAL_ECHOPGM("// ");
   SERIAL_ECHOLN(p);
+  PORT_RESTORE();
 }


### PR DESCRIPTION
### Description

In an environment where 2 serials are configured (for example one to communicate with the host and one to communicate with a TFT lcd) the use of the M118 command is not deterministic especially in the use of option A and E.
This patch adds the possibility to indicate the target serial at the GCODE command level.

Meaning is added to the number next to the A or E flag which indicates the destination serial number (1 based). * Is also added as a broadcast to send on both series.

**New command documentation:**

*M118 [A<n|\*>|E<n|\*>] \<message\>*

n: serial number 1 based
\*: broadcast ( send on both serial )
 



### Benefits
- Support for a destination for Echo commands. Eg M118 E1 Hello World --> Send only on the first serial
- Suppot for a destination for Action Commans. Eg M118 A2 action:pause --> Send pause to host or TFT connected on serial 2.
- Support for a broadcast destination: Eg M118 A* action:disconnect --> Request disconnect from all host
- Support for intra-serial comunication. Eg Serial TFT on serial1 can send action command to Octoprint on serial 2 ( BIGTREETECH TFT35 1.2 with SKR 1.3 case as example )




