### PR TITLE
Fix compiling error BIGTREE_SKR_MINI

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/onboard_sd.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/onboard_sd.cpp
@@ -1,17 +1,17 @@
-/*------------------------------------------------------------------------*/
-/* STM32F1: MMCv3/SDv1/SDv2 (SPI mode) control module                     */
-/*------------------------------------------------------------------------*/
-/*
-/ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
-/ * Copyright (c) 2019 BigTreeTech [https://github.com/bigtreetech]
-/ * Copyright (C) 2015, ChaN, all right reserved.
-/
-/ * This software is a free software and there is NO WARRANTY.
-/ * No restriction on use. You can use, modify and redistribute it for
-/   personal, non-profit or commercial products UNDER YOUR RESPONSIBILITY.
-/ * Redistributions of source code must retain the above copyright notice.
-/
-/-------------------------------------------------------------------------*/
+/**
+ * STM32F1: MMCv3/SDv1/SDv2 (SPI mode) control module
+ *
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2019 BigTreeTech [https://github.com/bigtreetech]
+ * Copyright (C) 2015, ChaN, all right reserved.
+ *
+ * This software is a free software and there is NO WARRANTY.
+ * No restriction on use. You can use, modify and redistribute it for
+ * personal, non-profit or commercial products UNDER YOUR RESPONSIBILITY.
+ * Redistributions of source code must retain the above copyright notice.
+ *
+ */
+
 #include "../../inc/MarlinConfig.h"
 
 #ifdef HAS_ONBOARD_SD
@@ -26,7 +26,7 @@
   #endif
   #define ONBOARD_SD_SPI SPI
 #else
-  SPIClass OnBoardSPI(ON_BOARD_SPI_DEVICE)
+  SPIClass OnBoardSPI(ON_BOARD_SPI_DEVICE);
   #define ONBOARD_SD_SPI OnBoardSPI
 #endif
 
@@ -45,8 +45,6 @@
 /*--------------------------------------------------------------------------
    Module Private Functions
 ---------------------------------------------------------------------------*/
-
-#include "onboard_sd.h"
 
 /* MMC/SD command */
 #define CMD0  (0)     /* GO_IDLE_STATE */

--- a/Marlin/src/HAL/HAL_STM32F1/onboard_sd.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/onboard_sd.cpp
@@ -17,7 +17,7 @@
 #ifdef HAS_ONBOARD_SD
 
 #include "onboard_sd.h"
-#include "spi.h"
+#include "SPI.h"
 #include "fastio.h"
 
 #ifdef SHARED_SD_CARD

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -271,6 +271,8 @@ FORCE_INLINE void _draw_heater_status(const heater_ind_t heater, const bool blin
       #endif
       #if HAS_HEATED_CHAMBER
         if (dodraw) _draw_centered_temp(target + 0.5, STATUS_CHAMBER_TEXT_X, 7);
+      #else
+        UNUSED(dodraw);
       #endif
     }
     if (PAGE_CONTAINS(28 - INFO_FONT_ASCENT, 28 - 1))

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_V1_1.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_V1_1.h
@@ -173,7 +173,7 @@
   #define MISO_PIN         PB4
   #define MOSI_PIN         PB5
   #define SS_PIN           PA15
-#if SD_CONNECTION_IS(ONBOARD)
+#elif SD_CONNECTION_IS(ONBOARD)
   #define ENABLE_SPI1
   #define SD_DETECT_PIN    PA3
   #define SCK_PIN          PA5


### PR DESCRIPTION
```c++
In file included from Marlin/src/HAL/HAL_STM32F1/../../inc/../pins/pins.h:466:0,
                 from Marlin/src/HAL/HAL_STM32F1/../../inc/MarlinConfig.h:32,
                 from Marlin/src/HAL/HAL_STM32F1/HAL.cpp:31:
Marlin/src/HAL/HAL_STM32F1/../../inc/../pins/stm32/pins_BIGTREE_SKR_MINI_V1_1.h:169:0: error: unterminated #if
 #if SD_CONNECTION_IS(LCD)
 
In file included from Marlin/src/HAL/HAL_STM32F1/../../inc/../pins/pins.h:466:0,
                 from Marlin/src/HAL/HAL_STM32F1/../../inc/MarlinConfig.h:32,
                 from Marlin/src/HAL/HAL_STM32F1/HAL_SPI.cpp:35:
Marlin/src/HAL/HAL_STM32F1/../../inc/../pins/stm32/pins_BIGTREE_SKR_MINI_V1_1.h:169:0: error: unterminated #if
 #if SD_CONNECTION_IS(LCD)
```