### PR TITLE
Minor Pin Updates

### DIFF
--- a/Marlin/src/pins/ramps/pins_FORMBOT_RAPTOR2.h
+++ b/Marlin/src/pins/ramps/pins_FORMBOT_RAPTOR2.h
@@ -47,7 +47,7 @@
     #define SPINDLE_LASER_PWM_PIN     4 // Hardware PWM
     #define SPINDLE_DIR_PIN           5
   #elif !GREEDY_PANEL                   // Try to use AUX2
-    #define SPINDLE_LASER_ENA_PIN    40 // Pullup or pulldown!
+    #define SPINDLE_LASER_ENA_PIN     4 // Pullup or pulldown!
     #define SPINDLE_LASER_PWM_PIN    44 // Hardware PWM
     #define SPINDLE_DIR_PIN          65
   #endif

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -39,7 +39,8 @@
   #define FIL_RUNOUT2_PIN 15 // Creality CR-X can use dual runout sensors
 #endif
 
-#define SD_DETECT_PIN 49   // Always define onboard SD detect
+#define SD_DETECT_PIN 49  // Always define onboard SD detect
+#define BEEPER_PIN    37  // Always define beeper pin so Play Tone works with ExtUI
 
 #include "pins_RAMPS.h"
 

--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
@@ -53,8 +53,9 @@
 #define LCD_PINS_ENABLE    17   // ST9720 DAT
 #define LCD_PINS_D4        30   // ST9720 CLK
 
-#if DISABLED(SPEAKER) && ENABLED(BLTOUCH)
+#if ENABLED(BLTOUCH)
   #define SERVO0_PIN 27
+  #undef BEEPER_PIN
 #endif
 
 // Alter timing for graphical display


### PR DESCRIPTION
Formbot stock Spindle Laser Enable on provided source was found to be incorrect.

Define BEEPER_PIN on Creality Ramps regardless of display to allow EXTui functions to trigger PlayTone; This requirement for a physical beeper pin should probably be eliminated at some point.

As discussed in a prior issues thread, Creality Melzi undefine beeper pin if a bltouch is configured as it uses the pin.