### PR TITLE
CR-10 Stock Display for SKR Mini 1.1

### DIFF
--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_V1_1.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_V1_1.h
@@ -106,43 +106,55 @@
 #if HAS_SPI_LCD
   #define BEEPER_PIN       PC10
   #define BTN_ENC          PC11
-  #define LCD_PINS_RS      PC12
 
-  #define BTN_EN1          PD2
-  #define BTN_EN2          PB8
+  #if ENABLED(CR10_STOCKDISPLAY)
+    #define LCD_PINS_RS    PC15
 
-  #define LCD_PINS_ENABLE  PB6
+    #define BTN_EN1        PB6
+    #define BTN_EN2        PC13
 
-  #if ENABLED(FYSETC_MINI_12864)
+    #define LCD_PINS_ENABLE PC14
+    #define LCD_PINS_D4    PB7
 
-    #define LCD_BACKLIGHT_PIN -1
-    #define LCD_RESET_PIN  PC13
-    #define DOGLCD_A0      PC12
-    #define DOGLCD_CS      PB6
-    #define DOGLCD_SCK     PB3
-    #define DOGLCD_MOSI    PB5
+  #else
 
-    #define FORCE_SOFT_SPI   // SPI MODE3
+    #define LCD_PINS_RS      PC12
 
-    #define LED_PIN        PB7   // red pwm
-    //#define LED_PIN        PC15   // green
-    //#define LED_PIN        PC14   // blue
+    #define BTN_EN1          PD2
+    #define BTN_EN2          PB8
 
-    //#if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-    //  #ifndef RGB_LED_R_PIN
-    //    #define RGB_LED_R_PIN PB7
-    //  #endif
-    //  #ifndef RGB_LED_G_PIN
-    //    #define RGB_LED_G_PIN PC15
-    //  #endif
-    //  #ifndef RGB_LED_B_PIN
-    //    #define RGB_LED_B_PIN PC14
-    //  #endif
-    //#elif ENABLED(FYSETC_MINI_12864_2_1)
-    //  #define NEOPIXEL_PIN    PB7
-    //#endif
+    #define LCD_PINS_ENABLE  PB6
 
-  #else // !FYSETC_MINI_12864
+    #if ENABLED(FYSETC_MINI_12864)
+
+      #define LCD_BACKLIGHT_PIN -1
+      #define LCD_RESET_PIN  PC13
+      #define DOGLCD_A0      PC12
+      #define DOGLCD_CS      PB6
+      #define DOGLCD_SCK     PB3
+      #define DOGLCD_MOSI    PB5
+
+      #define FORCE_SOFT_SPI   // SPI MODE3
+
+      #define LED_PIN        PB7   // red pwm
+      //#define LED_PIN        PC15   // green
+      //#define LED_PIN        PC14   // blue
+
+      //#if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
+      //  #ifndef RGB_LED_R_PIN
+      //    #define RGB_LED_R_PIN PB7
+      //  #endif
+      //  #ifndef RGB_LED_G_PIN
+      //    #define RGB_LED_G_PIN PC15
+      //  #endif
+      //  #ifndef RGB_LED_B_PIN
+      //    #define RGB_LED_B_PIN PC14
+      //  #endif
+      //#elif ENABLED(FYSETC_MINI_12864_2_1)
+      //  #define NEOPIXEL_PIN    PB7
+      //#endif
+
+    #else // !FYSETC_MINI_12864
 
     #define LCD_PINS_D4    PC13
     #if ENABLED(ULTIPANEL)
@@ -151,7 +163,9 @@
       #define LCD_PINS_D7  PC14
     #endif
 
-  #endif // !FYSETC_MINI_12864
+    #endif // !FYSETC_MINI_12864
+
+  #endif
 
 #endif // HAS_SPI_LCD
 


### PR DESCRIPTION
### Description

This PR adds `CR10_STOCKDISPLAY` support to the SKR Mini 1.1 using a similar pins remap method used on the SKR 1.3.

### Benefits

Adds another type of LCD that can be used with the SKR Mini 1.1.

### Related Issues

None.
