### PR TITLE
Fix G90, G91, M82, M83 rel/abs modes

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -215,9 +215,8 @@ void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=
       info.retract_hop = fwretract.current_hop;
     #endif
 
-    // Relative mode
-    info.relative_mode = relative_mode;
-    info.relative_modes_e = gcode.axis_relative_modes[E_AXIS];
+    // Relative axis modes
+    info.axis_relative = gcode.axis_relative;
 
     // Elapsed print job time
     info.print_job_elapsed = print_job_timer.duration();
@@ -392,9 +391,8 @@ void PrintJobRecovery::resume() {
   sprintf_P(cmd, PSTR("G92.9 E%s"), dtostrf(info.current_position[E_AXIS], 1, 3, str_1));
   gcode.process_subcommands_now(cmd);
 
-  // Relative mode
-  relative_mode = info.relative_mode;
-  gcode.axis_relative_modes[E_AXIS] = info.relative_modes_e;
+  // Relative axis modes
+  gcode.axis_relative = info.axis_relative;
 
   #if HAS_HOME_OFFSET || HAS_POSITION_SHIFT
     LOOP_XYZ(i) {

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -89,8 +89,8 @@ typedef struct {
     #endif
   #endif
 
-  // Relative mode
-  bool relative_mode, relative_modes_e;
+  // Relative axis modes
+  uint8_t axis_relative;
 
   // SD Filename and position
   char sd_filename[MAXPATHNAMELENGTH];

--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -698,8 +698,6 @@ void MMU2::filament_runout() {
     }
 
     LCD_MESSAGEPGM(MSG_MMU2_EJECTING_FILAMENT);
-    const bool saved_e_relative_mode = gcode.axis_relative_modes[E_AXIS];
-    gcode.axis_relative_modes[E_AXIS] = true;
 
     enable_E0();
     current_position[E_AXIS] -= MMU2_FILAMENTCHANGE_EJECT_FEED;
@@ -734,8 +732,6 @@ void MMU2::filament_runout() {
     set_runout_valid(false);
 
     BUZZ(200, 404);
-
-    gcode.axis_relative_modes[E_AXIS] = saved_e_relative_mode;
 
     disable_E0();
 
@@ -784,9 +780,6 @@ void MMU2::filament_runout() {
     planner.synchronize();
     enable_E0();
 
-    const bool saved_e_relative_mode = gcode.axis_relative_modes[E_AXIS];
-    gcode.axis_relative_modes[E_AXIS] = true;
-
     const E_Step* step = sequence;
 
     for (uint8_t i = 0; i < steps; i++) {
@@ -803,8 +796,6 @@ void MMU2::filament_runout() {
 
       step++;
     }
-
-    gcode.axis_relative_modes[E_AXIS] = saved_e_relative_mode;
 
     disable_E0();
   }

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -283,12 +283,31 @@
   #include "../feature/I2CPositionEncoder.h"
 #endif
 
+enum AxisRelative : uint8_t { REL_X, REL_Y, REL_Z, REL_E, E_MODE_ABS, E_MODE_REL };
+
 class GcodeSuite {
 public:
 
-  GcodeSuite() {}
+  static uint8_t axis_relative;
 
-  static bool axis_relative_modes[];
+  static inline bool axis_is_relative(const AxisEnum a) {
+    if (a == E_AXIS) {
+      if (TEST(axis_relative, E_MODE_REL)) return true;
+      if (TEST(axis_relative, E_MODE_ABS)) return false;
+    }
+    return TEST(axis_relative, a);
+  }
+  static inline void set_relative_mode(const bool rel) {
+    axis_relative = rel ? _BV(REL_X) | _BV(REL_Y) | _BV(REL_Z) | _BV(REL_E) : 0;
+  }
+  static inline void set_e_relative() {
+    CBI(axis_relative, E_MODE_ABS);
+    SBI(axis_relative, E_MODE_REL);
+  }
+  static inline void set_e_absolute() {
+    CBI(axis_relative, E_MODE_REL);
+    SBI(axis_relative, E_MODE_ABS);
+  }
 
   #if ENABLED(CNC_WORKSPACE_PLANES)
     /**

--- a/Marlin/src/gcode/units/M82_M83.cpp
+++ b/Marlin/src/gcode/units/M82_M83.cpp
@@ -25,9 +25,9 @@
 /**
  * M82: Set E codes absolute (default)
  */
-void GcodeSuite::M82() { axis_relative_modes[E_AXIS] = false; }
+void GcodeSuite::M82() { set_e_absolute(); }
 
 /**
  * M83: Set E codes relative while in Absolute Coordinates (G90) mode
  */
-void GcodeSuite::M83() { axis_relative_modes[E_AXIS] = true; }
+void GcodeSuite::M83() { set_e_relative(); }


### PR DESCRIPTION
Ensure that the `M82` / `M83` overrides for the E axis take precedence over `G90` / `G91` relative mode and reduce storage cost for these flags.