### PR TITLE
Fix BL Touch debug leveling

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2279,9 +2279,8 @@ void clean_up_after_endstop_or_probe_move() {
       #else
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
-            SERIAL_ECHOLNPAIR(
-              "last_written_mode - ", int(bltouch_last_written_mode),
-              "config mode - "
+            SERIAL_ECHOPAIR("last_written_mode - ", int(bltouch_last_written_mode));
+            SERIAL_ECHOLNPGM("config mode - "
               #if ENABLED(BLTOUCH_SET_5V_MODE)
                 "BLTOUCH_SET_5V_MODE"
               #else

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2279,12 +2279,15 @@ void clean_up_after_endstop_or_probe_move() {
       #else
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
-            SERIAL_ECHOLNPAIR("last_written_mode - ", (int)bltouch_last_written_mode);
-            #if ENABLED(BLTOUCH_SET_5V_MODE)
-              SERIAL_ECHOLNPGM("config mode - BLTOUCH_SET_5V_MODE");
-            #else
-              SERIAL_ECHOLNPGM("config mode - OD");
-            #endif
+            SERIAL_ECHOLNPAIR(
+              "last_written_mode - ", int(bltouch_last_written_mode),
+              "config mode - "
+              #if ENABLED(BLTOUCH_SET_5V_MODE)
+                "BLTOUCH_SET_5V_MODE"
+              #else
+                "OD"
+              #endif
+            );
           }
         #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2125,14 +2125,14 @@ void clean_up_after_endstop_or_probe_move() {
     bool bltouch_deploy_proc() {
       // Do a DEPLOY
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch DEPLOY requested");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch DEPLOY requested");
       #endif
 
       // Attempt to DEPLOY, wait for DEPLOY_DELAY or ALARM
       if (_bltouch_deploy_query_alarm()) {
         // The deploy might have failed or the probe is already triggered (nozzle too low?)
         #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch ALARM or TRIGGER after DEPLOY, recovering");
+          if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch ALARM or TRIGGER after DEPLOY, recovering");
         #endif
 
         bltouch_clear();                               // Get the probe into start condition
@@ -2141,7 +2141,7 @@ void clean_up_after_endstop_or_probe_move() {
         if (_bltouch_deploy_query_alarm()) {
           // The deploy might have failed or the probe is actually triggered (nozzle too low?) again
           #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch Recovery Failed");
+            if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch Recovery Failed");
           #endif
 
           SERIAL_ECHOLN(MSG_STOP_BLTOUCH);  // Tell the user something is wrong, needs action
@@ -2160,7 +2160,7 @@ void clean_up_after_endstop_or_probe_move() {
       // The trigger STOW (see motion.cpp for example) will pull up the probes pin as soon as the pulse
       // is registered.
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("bltouch.deploy_proc() end");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHO("bltouch.deploy_proc() end");
       #endif
 
       return false; // report success to caller
@@ -2169,7 +2169,7 @@ void clean_up_after_endstop_or_probe_move() {
     bool bltouch_stow_proc() {
       // Do a STOW
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch STOW requested");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch STOW requested");
       #endif
 
       // A STOW will clear a triggered condition in the probe (10ms pulse).
@@ -2182,7 +2182,7 @@ void clean_up_after_endstop_or_probe_move() {
       if (_bltouch_stow_query_alarm()) {
         // The stow might have failed
         #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch ALARM or TRIGGER after STOW, recovering");
+          if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch ALARM or TRIGGER after STOW, recovering");
         #endif
 
         _bltouch_reset();                              // This RESET will then also pull up the pin. If it doesn't
@@ -2192,7 +2192,7 @@ void clean_up_after_endstop_or_probe_move() {
         // Last attempt to STOW
         if (_bltouch_stow_query_alarm()) {             // so if there is now STILL an ALARM condition:
           #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch Recovery Failed");
+            if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch Recovery Failed");
           #endif
 
           SERIAL_ECHOLN(MSG_STOP_BLTOUCH);  // Tell the user something is wrong, needs action
@@ -2203,7 +2203,7 @@ void clean_up_after_endstop_or_probe_move() {
       }
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("bltouch.stow_proc() end");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHO("bltouch.stow_proc() end");
       #endif
 
       return false; // report success to caller
@@ -2216,7 +2216,7 @@ void clean_up_after_endstop_or_probe_move() {
        */
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch STATUS requested");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch STATUS requested");
       #endif
 
       _bltouch_set_SW_mode();              // Incidentally, _set_SW_mode() will also RESET any active alarm
@@ -2279,14 +2279,12 @@ void clean_up_after_endstop_or_probe_move() {
       #else
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
-            DEBUG_ECHOLNPAIR("last_written_mode - ", (int)bltouch_last_written_mode);
-            DEBUG_ECHOLNPGM("config mode - "
-              #if ENABLED(BLTOUCH_SET_5V_MODE)
-                "BLTOUCH_SET_5V_MODE"
-              #else
-                "OD"
-              #endif
-            );
+            SERIAL_ECHOLNPAIR("last_written_mode - ", (int)bltouch_last_written_mode);
+            #if ENABLED(BLTOUCH_SET_5V_MODE)
+              SERIAL_ECHOLNPGM("config mode - BLTOUCH_SET_5V_MODE");
+            #else
+              SERIAL_ECHOLNPGM("config mode - OD");
+            #endif
           }
         #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -2125,14 +2125,14 @@ void clean_up_after_endstop_or_probe_move() {
     bool bltouch_deploy_proc() {
       // Do a DEPLOY
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch DEPLOY requested");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch DEPLOY requested");
       #endif
 
       // Attempt to DEPLOY, wait for DEPLOY_DELAY or ALARM
       if (_bltouch_deploy_query_alarm()) {
         // The deploy might have failed or the probe is already triggered (nozzle too low?)
         #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch ALARM or TRIGGER after DEPLOY, recovering");
+          if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch ALARM or TRIGGER after DEPLOY, recovering");
         #endif
 
         bltouch_clear();                               // Get the probe into start condition
@@ -2141,7 +2141,7 @@ void clean_up_after_endstop_or_probe_move() {
         if (_bltouch_deploy_query_alarm()) {
           // The deploy might have failed or the probe is actually triggered (nozzle too low?) again
           #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch Recovery Failed");
+            if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch Recovery Failed");
           #endif
 
           SERIAL_ECHOLN(MSG_STOP_BLTOUCH);  // Tell the user something is wrong, needs action
@@ -2160,7 +2160,7 @@ void clean_up_after_endstop_or_probe_move() {
       // The trigger STOW (see motion.cpp for example) will pull up the probes pin as soon as the pulse
       // is registered.
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHO("bltouch.deploy_proc() end");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("bltouch.deploy_proc() end");
       #endif
 
       return false; // report success to caller
@@ -2169,7 +2169,7 @@ void clean_up_after_endstop_or_probe_move() {
     bool bltouch_stow_proc() {
       // Do a STOW
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch STOW requested");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch STOW requested");
       #endif
 
       // A STOW will clear a triggered condition in the probe (10ms pulse).
@@ -2182,7 +2182,7 @@ void clean_up_after_endstop_or_probe_move() {
       if (_bltouch_stow_query_alarm()) {
         // The stow might have failed
         #if ENABLED(DEBUG_LEVELING_FEATURE)
-          if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch ALARM or TRIGGER after STOW, recovering");
+          if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch ALARM or TRIGGER after STOW, recovering");
         #endif
 
         _bltouch_reset();                              // This RESET will then also pull up the pin. If it doesn't
@@ -2192,7 +2192,7 @@ void clean_up_after_endstop_or_probe_move() {
         // Last attempt to STOW
         if (_bltouch_stow_query_alarm()) {             // so if there is now STILL an ALARM condition:
           #if ENABLED(DEBUG_LEVELING_FEATURE)
-            if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch Recovery Failed");
+            if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch Recovery Failed");
           #endif
 
           SERIAL_ECHOLN(MSG_STOP_BLTOUCH);  // Tell the user something is wrong, needs action
@@ -2203,7 +2203,7 @@ void clean_up_after_endstop_or_probe_move() {
       }
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHO("bltouch.stow_proc() end");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("bltouch.stow_proc() end");
       #endif
 
       return false; // report success to caller
@@ -2216,7 +2216,7 @@ void clean_up_after_endstop_or_probe_move() {
        */
 
       #if ENABLED(DEBUG_LEVELING_FEATURE)
-        if (DEBUGGING(LEVELING)) SERIAL_ECHO("BLTouch STATUS requested");
+        if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch STATUS requested");
       #endif
 
       _bltouch_set_SW_mode();              // Incidentally, _set_SW_mode() will also RESET any active alarm

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -972,12 +972,13 @@ void lcd_quick_feedback(const bool clear_buttons) {
     #if ENABLED(BLTOUCH_LCD_VOLTAGE_MENU)
       void bltouch_report() {
         SERIAL_ECHOLNPAIR("EEPROM Last BLTouch Mode - ", (int)bltouch_last_written_mode);
-        SERIAL_ECHOPGM("Configuration BLTouch Mode - ");
+        SERIAL_ECHOLNPGM("Configuration BLTouch Mode - "
           #if ENABLED(BLTOUCH_SET_5V_MODE)
-            SERIAL_ECHOLNPGM("5V");
+            "5V"
           #else
-            SERIAL_ECHOLNPGM("OD");
+            "OD"
           #endif
+        );
         char mess[21];
         strcpy_P(mess, PSTR("BLTouch Mode - "));
         strcpy_P(&mess[15], bltouch_last_written_mode ? PSTR("5V") : PSTR("OD"));


### PR DESCRIPTION
Hi..

First time contributing here and its been a long time since I wrote any cpp..
Please let me know if I messed something here..


### Description

Looks like #14839 introduced a issue when `DEBUG_LEVELING_FEATURE` is defined
Where `SERIAL_ECHO*` is called with the wrong number of arguments..


if I define 
```
#define BLTOUCH
#define DEBUG_LEVELING_FEATURE
```


There is a compilation error when running `pio run`
```
RCH_AVR -DARDUINO=10805 -IMarlin -I/Users/fabio/.platformio/packages/framework-arduinoavr/libraries/__cores__/arMarlin/Marlin_main.cpp:2128:78: error: macro "SERIAL_ECHOLNPAIR" requires 2 arguments, but only 1 given
         if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch DEPLOY requested");
                                                                              ^
Marlin/Marlin_main.cpp:2135:105: error: macro "SERIAL_ECHOLNPAIR" requires 2 arguments, but only 1 given
           if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch ALARM or TRIGGER after DEPLOY, recovering");
                                                                                                         ^
Marlin/Marlin_main.cpp:2144:81: error: macro "SERIAL_ECHOLNPAIR" requires 2 arguments, but only 1 given
             if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch Recovery Failed");
                                                                                 ^
Marlin/Marlin_main.cpp:2163:79: error: macro "SERIAL_ECHOLNPAIR" requires 2 arguments, but only 1 given
         if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("bltouch.deploy_proc() end");
                                                                               ^
Marlin/Marlin_main.cpp:2172:76: error: macro "SERIAL_ECHOLNPAIR" requires 2 arguments, but only 1 given
         if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch STOW requested");

```

### Benefits

Use `SERIAL_ECHO` instead of `SERIAL_ECHOLNPAIR` to write a single
Use `SERIAL_ECHOLNPGM` instead of undefined `DEBUG_ECHOLNPAIR` ?

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/14839
