### PR TITLE
Optimize Media Menu display/scrolling

### DIFF
--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -127,7 +127,7 @@ void menu_media() {
 
   #if HAS_GRAPHICAL_LCD
     static uint16_t fileCnt;
-    if(ui.first_page) {
+    if (ui.first_page) {
       fileCnt = card.get_num_Files();
       card.getWorkDirName();
     }

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -125,11 +125,19 @@ class MenuItem_sdfolder {
 void menu_media() {
   ui.encoder_direction_menus();
 
-  const uint16_t fileCnt = card.get_num_Files();
+  #if HAS_GRAPHICAL_LCD
+    static uint16_t fileCnt;
+    if(ui.first_page) {
+      fileCnt = card.get_num_Files();
+      card.getWorkDirName();
+    }
+  #else
+    const uint16_t fileCnt = card.get_num_Files();
+    card.getWorkDirName();
+  #endif  
 
   START_MENU();
   MENU_BACK(MSG_MAIN);
-  card.getWorkDirName();
   if (card.filename[0] == '/') {
     #if !PIN_EXISTS(SD_DETECT)
       MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -134,7 +134,7 @@ void menu_media() {
   #else
     const uint16_t fileCnt = card.get_num_Files();
     card.getWorkDirName();
-  #endif  
+  #endif
 
   START_MENU();
   MENU_BACK(MSG_MAIN);


### PR DESCRIPTION
Menu media list filename from SD Card or USB. We found that the filename scrolling is slow.

For Graphical LCD, we have 'LCD page' loop. Each Loop we only drar 8 pixel height. 
Each Loop, menu media read filename list. This is wasting time. 

This PR, make the filename read for whole folder only done in if LCD page is on the firstpage only. 
Therefore the process become faster, because we only need once each Wholepage drawing. Now, before this PR, the process is done 1 + 64/8 times. 