### PR TITLE
Add SW-SPI for MINIPANEL

### DIFF
--- a/Marlin/ultralcd_impl_DOGM.h
+++ b/Marlin/ultralcd_impl_DOGM.h
@@ -204,8 +204,14 @@
   U8GLIB_SSD1309_128X64 u8g(U8G_I2C_OPT_NONE | U8G_I2C_OPT_FAST);
 #elif ENABLED(MINIPANEL)
   // The MINIPanel display
-  //U8GLIB_MINI12864 u8g(DOGLCD_CS, DOGLCD_A0);  // 8 stripes
-  U8GLIB_MINI12864_2X u8g(DOGLCD_CS, DOGLCD_A0); // 4 stripes
+  #if DOGLCD_MOSI != -1 && DOGLCD_SCK != -1
+    // using SW-SPI
+    //U8GLIB_MINI12864 u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0);  // 8 stripes
+    U8GLIB_MINI12864_2X u8g(DOGLCD_SCK, DOGLCD_MOSI, DOGLCD_CS, DOGLCD_A0); // 4 stripes
+  #else
+    //U8GLIB_MINI12864 u8g(DOGLCD_CS, DOGLCD_A0);  // 8 stripes
+    U8GLIB_MINI12864_2X u8g(DOGLCD_CS, DOGLCD_A0); // 4 stripes
+  #endif
 #else
   // for regular DOGM128 display with HW-SPI
   //U8GLIB_DOGM128 u8g(DOGLCD_CS, DOGLCD_A0);  // HW-SPI Com: CS, A0  // 8 stripes


### PR DESCRIPTION
### Description

Create the abbility to use U8GLIB_MINI12864_2X with the SW SPI by definition of DOGLCD_SCK DOGLCD_MOSI.

### Benefits

MINIPANEL compatible displays can be used on any pins which support the SW SPI.

### Related Issues

Workaround to get an original Ender 2  Display working with an Ender 3 Creality board V1.1.5 (Silent Board with TMC2208) as the Display Connector is not connected to MOSI and SCK. 

Works by adding this patch an the following lines to the config:  
```
#define DOGLCD_SCK 27
#define DOGLCD_MOSI 17
```
