### PR TITLE
STM32F1: AUTO_BED_LEVELING_UBL build fixes

### DIFF
--- a/Marlin/src/HAL/shared/Marduino.h
+++ b/Marlin/src/HAL/shared/Marduino.h
@@ -58,6 +58,9 @@
     //#define strchr_P(s,c) strchr(s,c)
   #endif
 
+  #ifndef snprintf_P
+    #define snprintf_P snprintf
+  #endif
   #ifndef vsnprintf_P
     #define vsnprintf_P vsnprintf
   #endif

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -75,7 +75,9 @@ extern uint8_t marlin_debug_flags;
 #define SERIAL_PRINTF(V...)     SERIAL_OUT(printf, V)
 #define SERIAL_FLUSH()          SERIAL_OUT(flush)
 
-#if TX_BUFFER_SIZE > 0
+#ifdef __STM32F1__
+  #define SERIAL_FLUSHTX()      SERIAL_OUT(flush)
+#elif TX_BUFFER_SIZE > 0
   #define SERIAL_FLUSHTX()      SERIAL_OUT(flushTX)
 #else
   #define SERIAL_FLUSHTX()


### PR DESCRIPTION
On the STM32F1 HardwareSerial::flush() is a tx flush, unsure how a flush can exist on RX

may be the wrong function is used there : Marlin/src/feature/bedlevel/ubl/ubl.cpp:207

in doubt for other platforms (DUE/AVR/ESP32), link it to the right function.

cf. Issue #15235
