### PR TITLE
stm32f1: dont declare USBSerial if there no usb

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/HAL.cpp
@@ -82,7 +82,7 @@
 // Public Variables
 // ------------------------
 
-#if (!defined(SERIAL_USB) && !defined(USE_USB_COMPOSITE))
+#if (defined(SERIAL_USB) && !defined(USE_USB_COMPOSITE))
   USBSerial SerialUSB;
 #endif
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -362,7 +362,7 @@ board         = genericSTM32F103VE
 monitor_speed = 250000
 extra_scripts = buildroot/share/PlatformIO/scripts/longer_STM32.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
+  ${common.build_flags} -std=gnu++14 -USERIAL_USB
   -DSTM32F1xx -DU20 -DTS_V12
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>


### PR DESCRIPTION
+ longer3D board use a serial to usb chip, not a "SerialUSB" port so...
