### PR TITLE
Followup to SD menu optimization

### DIFF
--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -125,11 +125,19 @@ class MenuItem_sdfolder {
 void menu_media() {
   ui.encoder_direction_menus();
 
-  const uint16_t fileCnt = card.get_num_Files();
+  #if HAS_GRAPHICAL_LCD
+    static uint16_t fileCnt;
+    if (ui.first_page) {
+      fileCnt = card.get_num_Files();
+      card.getWorkDirName();
+    }
+  #else
+    const uint16_t fileCnt = card.get_num_Files();
+    card.getWorkDirName();
+  #endif
 
   START_MENU();
   MENU_BACK(MSG_MAIN);
-  card.getWorkDirName();
   if (card.filename[0] == '/') {
     #if !PIN_EXISTS(SD_DETECT)
       MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -125,19 +125,11 @@ class MenuItem_sdfolder {
 void menu_media() {
   ui.encoder_direction_menus();
 
-  #if HAS_GRAPHICAL_LCD
-    static uint16_t fileCnt;
-    if (ui.first_page) {
-      fileCnt = card.get_num_Files();
-      card.getWorkDirName();
-    }
-  #else
-    const uint16_t fileCnt = card.get_num_Files();
-    card.getWorkDirName();
-  #endif
+  const uint16_t fileCnt = card.get_num_Files();
 
   START_MENU();
   MENU_BACK(MSG_MAIN);
+  card.getWorkDirName();
   if (card.filename[0] == '/') {
     #if !PIN_EXISTS(SD_DETECT)
       MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -127,18 +127,21 @@ void menu_media() {
 
   #if HAS_GRAPHICAL_LCD
     static uint16_t fileCnt;
+    static bool at_root;
     if (ui.first_page) {
       fileCnt = card.get_num_Files();
       card.getWorkDirName();
+      at_root = card.filename[0] == '/';
     }
   #else
     const uint16_t fileCnt = card.get_num_Files();
     card.getWorkDirName();
+    const bool at_root = card.filename[0] == '/';
   #endif
 
   START_MENU();
   MENU_BACK(MSG_MAIN);
-  if (card.filename[0] == '/') {
+  if (at_root) {
     #if !PIN_EXISTS(SD_DETECT)
       MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);
     #endif

--- a/Marlin/src/sd/SdBaseFile.cpp
+++ b/Marlin/src/sd/SdBaseFile.cpp
@@ -273,7 +273,7 @@ int16_t SdBaseFile::fgets(char* str, int16_t num, char* delim) {
  *
  * \return true for success, false for failure.
  */
-bool SdBaseFile::getFilename(char * const name) {
+bool SdBaseFile::getDosName(char * const name) {
   if (!isOpen()) return false;
 
   if (isRoot()) {
@@ -957,7 +957,7 @@ void SdBaseFile::printFatTime(uint16_t fatTime) {
  */
 bool SdBaseFile::printName() {
   char name[FILENAME_LENGTH];
-  if (!getFilename(name)) return false;
+  if (!getDosName(name)) return false;
   SERIAL_ECHO(name);
   return true;
 }

--- a/Marlin/src/sd/SdBaseFile.h
+++ b/Marlin/src/sd/SdBaseFile.h
@@ -286,7 +286,7 @@ class SdBaseFile {
    */
   bool isRoot() const { return type_ == FAT_FILE_TYPE_ROOT_FIXED || type_ == FAT_FILE_TYPE_ROOT32; }
 
-  bool getFilename(char * const name);
+  bool getDosName(char * const name);
   void ls(uint8_t flags = 0, uint8_t indent = 0);
 
   bool mkdir(SdBaseFile* dir, const char* path, bool pFlag = true);

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -313,7 +313,7 @@ void CardReader::ls() {
 void CardReader::printFilename() {
   if (file.isOpen()) {
     char dosFilename[FILENAME_LENGTH];
-    file.getFilename(dosFilename);
+    file.getDosName(dosFilename);
     SERIAL_ECHO(dosFilename);
     #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
       getfilename(0, dosFilename);
@@ -404,7 +404,7 @@ void CardReader::openLogFile(char * const path) {
 }
 
 void appendAtom(SdFile &file, char *& dst, uint8_t &cnt) {
-  file.getFilename(dst);
+  file.getDosName(dst);
   while (*dst && cnt < MAXPATHNAMELENGTH) { dst++; cnt++; }
   if (cnt < MAXPATHNAMELENGTH) { *dst = '/'; dst++; cnt++; }
 }

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -120,7 +120,7 @@ public:
   static inline void setIndex(const uint32_t index) { sdpos = index; file.seekSet(index); }
   static inline uint32_t getIndex() { return sdpos; }
   static inline uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
-  static inline char* getWorkDirName() { workDir.getFilename(filename); return filename; }
+  static inline char* getWorkDirName() { workDir.getDosName(filename); return filename; }
   static inline int16_t read(void* buf, uint16_t nbyte) { return file.isOpen() ? file.read(buf, nbyte) : -1; }
   static inline int16_t write(void* buf, uint16_t nbyte) { return file.isOpen() ? file.write(buf, nbyte) : -1; }
 


### PR DESCRIPTION
For some esoteric reason, `card.filename[0] != '/'` even if i change
the condition to `if (ui.first_page || fileCnt == 0)...`

`card.filename` is first gcode filename, but without `'/'`

If the sd menu is too slow, consider using `SDCARD_SORT_ALPHA`
with `SDSORT_USES_RAM` + `SDSORT_CACHE_NAMES`

Seen on both the fysetc mini LCD (on skr mini) and TFT on longer3D, unrelated to `SD_DETECT`

This reverts commit 1ab3521351dc5c139861c1944f011f5ecb845e4f.

new behavior is a "folder up" item which do nothing : https://drive.google.com/file/d/133wlVJZ_mWoGGB_MA1MqUQmAh2Ral05Q/view?usp=sharing