### PR TITLE
Mount the SD card early

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -981,9 +981,9 @@ void setup() {
     ui.show_bootscreen();
   #endif
 
-  #if ENABLED(SDIO_SUPPORT) && !PIN_EXISTS(SD_DETECT)
-    // Auto-mount the SD for EEPROM.dat emulation
-    if (!card.isDetected()) card.initsd();
+  #if ENABLED(SDSUPPORT)
+    // Auto-mount the SD
+    card.initsd();
   #endif
 
   // Load data from EEPROM if available (or use defaults)


### PR DESCRIPTION
on the SKRmini default (sd onboard) which has a SD_DETECT_PIN,
the card is never loaded early nor lately, and cant load eeprom sd.

Also avoid to manually mount it via the menu, and seems to keep
same boot behavior, no issues nor a big delay if there is no card...

If some platforms have issues with this simple change, maybe we could ifdef them or do some new config flag for that...