### PR TITLE
Allow odd mm bed sizes

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -66,22 +66,21 @@
 #endif
 
 // Define center values for future use
+#define _X_HALF_BED ((X_BED_SIZE) / 2)
+#define _Y_HALF_BED ((Y_BED_SIZE) / 2)
 #if ENABLED(BED_CENTER_AT_0_0)
   #define X_CENTER 0
   #define Y_CENTER 0
-  #define X_MIN_BED (-(X_BED_SIZE) / 2)
-  #define X_MAX_BED ( (X_BED_SIZE) / 2)
-  #define Y_MIN_BED (-(Y_BED_SIZE) / 2)
-  #define Y_MAX_BED ( (Y_BED_SIZE) / 2)
 #else
-  #define X_CENTER ((X_BED_SIZE) / 2)
-  #define Y_CENTER ((Y_BED_SIZE) / 2)
-  #define X_MIN_BED 0
-  #define X_MAX_BED (X_BED_SIZE)
-  #define Y_MIN_BED 0
-  #define Y_MAX_BED (Y_BED_SIZE)
+  #define X_CENTER _X_HALF_BED
+  #define Y_CENTER _Y_HALF_BED
 #endif
-#define Z_CENTER ((Z_MIN_POS + Z_MAX_POS) / 2)
+
+// Get the linear boundaries of the bed
+#define X_MIN_BED (X_CENTER - _X_HALF_BED)
+#define X_MAX_BED (X_MIN_BED + X_BED_SIZE)
+#define Y_MIN_BED (Y_CENTER - _Y_HALF_BED)
+#define Y_MAX_BED (Y_MIN_BED + Y_BED_SIZE)
 
 /**
  * Dual X Carriage

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -69,17 +69,19 @@
 #if ENABLED(BED_CENTER_AT_0_0)
   #define X_CENTER 0
   #define Y_CENTER 0
+  #define X_MIN_BED (-(X_BED_SIZE) / 2)
+  #define X_MAX_BED ( (X_BED_SIZE) / 2)
+  #define Y_MIN_BED (-(Y_BED_SIZE) / 2)
+  #define Y_MAX_BED ( (Y_BED_SIZE) / 2)
 #else
   #define X_CENTER ((X_BED_SIZE) / 2)
   #define Y_CENTER ((Y_BED_SIZE) / 2)
+  #define X_MIN_BED 0
+  #define X_MAX_BED (X_BED_SIZE)
+  #define Y_MIN_BED 0
+  #define Y_MAX_BED (Y_BED_SIZE)
 #endif
 #define Z_CENTER ((Z_MIN_POS + Z_MAX_POS) / 2)
-
-// Get the linear boundaries of the bed
-#define X_MIN_BED (X_CENTER - (X_BED_SIZE) / 2)
-#define X_MAX_BED (X_CENTER + (X_BED_SIZE) / 2)
-#define Y_MIN_BED (Y_CENTER - (Y_BED_SIZE) / 2)
-#define Y_MAX_BED (Y_CENTER + (Y_BED_SIZE) / 2)
 
 /**
  * Dual X Carriage


### PR DESCRIPTION
If the Bed Size is 235 then, Bed Size/2 = 117
Bed max Size = 117 + 117 = 234.

It is better to make calculation shorter and simple.
If Bed Center is not 0 then X_MAX_BED = X_BED_SIZE 