### PR TITLE
Add pins for Lerdge X and K.

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -294,6 +294,8 @@
 #define BOARD_STEVAL                  4206  // STEVAL-3DP001V1 3D PRINTER BOARD
 #define BOARD_BIGTREE_SKR_PRO_V1_1    4207  // BigTreeTech SKR Pro v1.1 (STM32F407ZG)
 #define BOARD_BIGTREE_BTT002_V1_0     4208  // BigTreeTech BTT002 v1.0 (STM32F407VE)
+#define BOARD_LERDGE_K                4209  // Lerdge K (STM32F407VE)
+#define BOARD_LERDGE_X                4210  // Lerdge X (STM32F407VE)
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -508,6 +508,10 @@
   #include "stm32/pins_BIGTREE_SKR_PRO_V1.1.h"  // STM32F4                                env:BIGTREE_SKR_PRO
 #elif MB(BIGTREE_BTT002_V1_0)
   #include "stm32/pins_BIGTREE_BTT002_V1.0.h"   // STM32F4                                env:BIGTREE_BTT002
+#elif MB(LERDGE_K)
+  #include "stm32/pins_LERDGE_K.h"            // STM32F4                                env:STM32F4
+#elif MB(LERDGE_X)
+  #include "stm32/pins_LERDGE_X.h"              // STM32F4                                env:STM32F4
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -509,7 +509,7 @@
 #elif MB(BIGTREE_BTT002_V1_0)
   #include "stm32/pins_BIGTREE_BTT002_V1.0.h"   // STM32F4                                env:BIGTREE_BTT002
 #elif MB(LERDGE_K)
-  #include "stm32/pins_LERDGE_K.h"            // STM32F4                                env:STM32F4
+  #include "stm32/pins_LERDGE_K.h"              // STM32F4                                env:STM32F4
 #elif MB(LERDGE_X)
   #include "stm32/pins_LERDGE_X.h"              // STM32F4                                env:STM32F4
 

--- a/Marlin/src/pins/stm32/pins_LERDGE_K.h
+++ b/Marlin/src/pins/stm32/pins_LERDGE_K.h
@@ -1,0 +1,195 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#if !defined(STM32F4) && !defined(STM32F4xx)
+  #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
+#endif
+
+#define DEFAULT_MACHINE_NAME "LERDGE"
+#define BOARD_NAME "Lerdge K"
+
+#define I2C_EEPROM
+
+// Ignore temp readings during develpment.
+//#define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "LERDGE supports up to 2 hotends / E-steppers."
+#endif
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          PG3
+#define X_MAX_PIN          -1
+#define Y_MIN_PIN          PG4
+#define Y_MAX_PIN          -1
+#define Z_MIN_PIN          PG5
+#define Z_MAX_PIN          -1
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+
+//#ifndef Z_MIN_PROBE_PIN
+//  #define Z_MIN_PROBE_PIN  PB15
+//#endif
+
+//
+// Steppers
+//
+
+#define X_STEP_PIN         PG1
+#define X_DIR_PIN          PB10
+#define X_ENABLE_PIN       PG0
+//#ifndef X_CS_PIN
+//  #define X_CS_PIN         PE0-PE4
+//#endif
+
+#define Y_STEP_PIN         PF14
+#define Y_DIR_PIN          PF15
+#define Y_ENABLE_PIN       PF13
+//#ifndef Y_CS_PIN
+//  #define Y_CS_PIN         PE0-PE4
+//#endif
+
+#define Z_STEP_PIN         PF11
+#define Z_DIR_PIN          PF12
+#define Z_ENABLE_PIN       PC5
+//#ifndef Z_CS_PIN
+//  #define Z_CS_PIN         PE0-PE4
+//#endif
+
+#define E0_STEP_PIN        PC14
+#define E0_DIR_PIN         PC13
+#define E0_ENABLE_PIN      PC15
+//#ifndef E0_CS_PIN
+//  #define E0_CS_PIN         PE0-PE4
+//#endif
+
+#define E1_STEP_PIN        PF1
+#define E1_DIR_PIN         PF0
+#define E1_ENABLE_PIN      PF2
+//#ifndef E1_CS_PIN
+//  #define E1_CS_PIN         PE0-PE4
+//#endif
+
+//
+// Temperature Sensors
+//
+
+#define TEMP_0_PIN         PC1   // Analog Input
+#define TEMP_1_PIN         PC2   // Analog Input
+#define TEMP_BED_PIN       PC0   // Analog Input
+
+//
+// Heaters / Fans
+//
+
+#define HEATER_0_PIN       PA1
+#define HEATER_1_PIN       PA0
+#define HEATER_BED_PIN     PA2
+
+#ifndef FAN_PIN
+  #define FAN_PIN          PC15
+#endif
+#define FAN1_PIN           PF6
+#define FAN2_PIN           PF7
+
+#define ORIG_E0_AUTO_FAN_PIN  FAN1_PIN // Use this by NOT overriding E0_AUTO_FAN_PIN
+
+//
+// Misc. Functions
+//
+
+//#define CASE_LIGHT_PIN_CI -1
+//#define CASE_LIGHT_PIN_DO -1
+//#define NEOPIXEL_PIN      -1
+
+//
+// Prusa i3 MK2 Multi Material Multiplexer Support
+//
+
+//#define E_MUX0_PIN         -1
+//#define E_MUX1_PIN         -1
+
+//
+// Servos
+//
+
+//#define SERVO0_PIN         PD12
+//#define SERVO1_PIN         -1
+
+//
+// SD support
+//
+#define SDIO_SUPPORT
+
+#define SDSS               PC11
+#define LED_PIN            PC7         //Alive
+#define PS_ON_PIN          -1
+#define KILL_PIN           -1
+#define PWR_LOSS           -1         //Power loss / nAC_FAULT
+
+#define SCK_PIN   PC12
+#define MISO_PIN  PC8
+#define MOSI_PIN  PD2
+#define SS_PIN    PC11
+
+//
+// LCD / Controller
+//
+// These are not right since we need to understand However
+// THE FMC data control works.
+#define SD_DETECT_PIN      -1
+#define BEEPER_PIN         PD12
+#define LCD_PINS_RS        -1
+#define LCD_PINS_ENABLE    -1
+#define LCD_PINS_D4        -1
+#define LCD_PINS_D5        -1
+#define LCD_PINS_D6        -1
+#define LCD_PINS_D7        -1
+#define BTN_EN1            PE3
+#define BTN_EN2            PE4
+#define BTN_ENC            PE2
+
+//
+// Filament runout
+//
+
+#define FIL_RUNOUT_PIN     PE6
+#define FIL_RUNOUT2_PIN    PE7
+
+//
+// ST7920 Delays
+//
+#ifndef ST7920_DELAY_1
+  #define ST7920_DELAY_1 DELAY_NS(96)
+#endif
+
+#ifndef ST7920_DELAY_2
+  #define ST7920_DELAY_2 DELAY_NS(48)
+#endif
+
+#ifndef ST7920_DELAY_3
+  #define ST7920_DELAY_3 DELAY_NS(715)
+#endif

--- a/Marlin/src/pins/stm32/pins_LERDGE_K.h
+++ b/Marlin/src/pins/stm32/pins_LERDGE_K.h
@@ -19,84 +19,88 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
 #if !defined(STM32F4) && !defined(STM32F4xx)
   #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
+#elif HOTENDS > 2 || E_STEPPERS > 2
+  #error "LERDGE K supports up to 2 hotends / E-steppers."
 #endif
 
+#define BOARD_INFO_NAME      "Lerdge K"
 #define DEFAULT_MACHINE_NAME "LERDGE"
-#define BOARD_NAME "Lerdge K"
 
 #define I2C_EEPROM
 
 // Ignore temp readings during develpment.
 //#define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
 
-#if HOTENDS > 2 || E_STEPPERS > 2
-  #error "LERDGE supports up to 2 hotends / E-steppers."
-#endif
+//
+// Servos
+//
+//#define SERVO0_PIN         PD12
 
 //
 // Limit Switches
 //
-#define X_MIN_PIN          PG3
-#define X_MAX_PIN          -1
-#define Y_MIN_PIN          PG4
-#define Y_MAX_PIN          -1
-#define Z_MIN_PIN          PG5
-#define Z_MAX_PIN          -1
+#define X_STOP_PIN         PG3
+#define Y_STOP_PIN         PG4
+#define Z_STOP_PIN         PG5
 
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-
 //#ifndef Z_MIN_PROBE_PIN
 //  #define Z_MIN_PROBE_PIN  PB15
 //#endif
 
 //
+// Filament runout
+//
+#define FIL_RUNOUT_PIN     PE6
+#define FIL_RUNOUT2_PIN    PE7
+
+//
 // Steppers
 //
-
 #define X_STEP_PIN         PG1
 #define X_DIR_PIN          PB10
 #define X_ENABLE_PIN       PG0
 //#ifndef X_CS_PIN
-//  #define X_CS_PIN         PE0-PE4
+//  #define X_CS_PIN       PE0
 //#endif
 
 #define Y_STEP_PIN         PF14
 #define Y_DIR_PIN          PF15
 #define Y_ENABLE_PIN       PF13
 //#ifndef Y_CS_PIN
-//  #define Y_CS_PIN         PE0-PE4
+//  #define Y_CS_PIN       PE1
 //#endif
 
 #define Z_STEP_PIN         PF11
 #define Z_DIR_PIN          PF12
 #define Z_ENABLE_PIN       PC5
 //#ifndef Z_CS_PIN
-//  #define Z_CS_PIN         PE0-PE4
+//  #define Z_CS_PIN       PE2
 //#endif
 
 #define E0_STEP_PIN        PC14
 #define E0_DIR_PIN         PC13
 #define E0_ENABLE_PIN      PC15
 //#ifndef E0_CS_PIN
-//  #define E0_CS_PIN         PE0-PE4
+//  #define E0_CS_PIN      PE3
 //#endif
 
 #define E1_STEP_PIN        PF1
 #define E1_DIR_PIN         PF0
 #define E1_ENABLE_PIN      PF2
 //#ifndef E1_CS_PIN
-//  #define E1_CS_PIN         PE0-PE4
+//  #define E1_CS_PIN      PE4
 //#endif
 
 //
 // Temperature Sensors
 //
-
 #define TEMP_0_PIN         PC1   // Analog Input
 #define TEMP_1_PIN         PC2   // Analog Input
 #define TEMP_BED_PIN       PC0   // Analog Input
@@ -104,7 +108,6 @@
 //
 // Heaters / Fans
 //
-
 #define HEATER_0_PIN       PA1
 #define HEATER_1_PIN       PA0
 #define HEATER_BED_PIN     PA2
@@ -118,48 +121,42 @@
 #define ORIG_E0_AUTO_FAN_PIN  FAN1_PIN // Use this by NOT overriding E0_AUTO_FAN_PIN
 
 //
-// Misc. Functions
+// LED / Lighting
 //
-
 //#define CASE_LIGHT_PIN_CI -1
 //#define CASE_LIGHT_PIN_DO -1
 //#define NEOPIXEL_PIN      -1
 
 //
-// Prusa i3 MK2 Multi Material Multiplexer Support
+// Prusa i3 MK2 Multi-Material Multiplexer Support
 //
-
 //#define E_MUX0_PIN         -1
 //#define E_MUX1_PIN         -1
-
-//
-// Servos
-//
-
-//#define SERVO0_PIN         PD12
-//#define SERVO1_PIN         -1
 
 //
 // SD support
 //
 #define SDIO_SUPPORT
 
+//
+// Misc. Functions
+//
 #define SDSS               PC11
-#define LED_PIN            PC7         //Alive
+#define LED_PIN            PC7   // Alive
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
-#define PWR_LOSS           -1         //Power loss / nAC_FAULT
+#define POWER_LOSS_PIN     -1    // Power-loss / nAC_FAULT
 
-#define SCK_PIN   PC12
-#define MISO_PIN  PC8
-#define MOSI_PIN  PD2
-#define SS_PIN    PC11
+#define SCK_PIN            PC12
+#define MISO_PIN           PC8
+#define MOSI_PIN           PD2
+#define SS_PIN             PC11
 
 //
 // LCD / Controller
 //
-// These are not right since we need to understand However
-// THE FMC data control works.
+
+// TODO: Replace these with the correct FSMC pins, once known
 #define SD_DETECT_PIN      -1
 #define BEEPER_PIN         PD12
 #define LCD_PINS_RS        -1
@@ -168,16 +165,10 @@
 #define LCD_PINS_D5        -1
 #define LCD_PINS_D6        -1
 #define LCD_PINS_D7        -1
+
 #define BTN_EN1            PE3
 #define BTN_EN2            PE4
 #define BTN_ENC            PE2
-
-//
-// Filament runout
-//
-
-#define FIL_RUNOUT_PIN     PE6
-#define FIL_RUNOUT2_PIN    PE7
 
 //
 // ST7920 Delays
@@ -185,11 +176,9 @@
 #ifndef ST7920_DELAY_1
   #define ST7920_DELAY_1 DELAY_NS(96)
 #endif
-
 #ifndef ST7920_DELAY_2
   #define ST7920_DELAY_2 DELAY_NS(48)
 #endif
-
 #ifndef ST7920_DELAY_3
   #define ST7920_DELAY_3 DELAY_NS(715)
 #endif

--- a/Marlin/src/pins/stm32/pins_LERDGE_X.h
+++ b/Marlin/src/pins/stm32/pins_LERDGE_X.h
@@ -19,38 +19,40 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
+#pragma once
 
 #if !defined(STM32F4) && !defined(STM32F4xx)
   #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
+#elif HOTENDS > 2 || E_STEPPERS > 2
+  #error "LERDGE X supports up to 2 hotends / E-steppers."
 #endif
 
+#define BOARD_INFO_NAME      "Lerdge X"
 #define DEFAULT_MACHINE_NAME "LERDGE"
-#define BOARD_NAME "Lerdge X"
 
 //#define I2C_EEPROM
 
-// Ignore temp readings during develpment.
-//#define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
-
-#if HOTENDS > 2 || E_STEPPERS > 2
-  #error "LERDGE supports up to 2 hotends / E-steppers."
-#endif
+//
+// Servos
+//
+//#define SERVO0_PIN         PD12
+//#define SERVO1_PIN         -1
 
 //
 // Limit Switches
 //
-#define X_MIN_PIN          PB12
-#define X_MAX_PIN          -1
-#define Y_MIN_PIN          PB13
-#define Y_MAX_PIN          -1
-#define Z_MIN_PIN          PB14
-#define Z_MAX_PIN          -1
+#define X_STOP_PIN         PB12
+#define Y_STOP_PIN         PB13
+#define Z_STOP_PIN         PB14
+
+//
+// Filament runout
+//
+#define FIL_RUNOUT_PIN     PE1
 
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-
 //#ifndef Z_MIN_PROBE_PIN
 //  #define Z_MIN_PROBE_PIN  PB15
 //#endif
@@ -58,99 +60,89 @@
 //
 // Steppers
 //
-
 #define X_STEP_PIN         PB10
 #define X_DIR_PIN          PB2
 #define X_ENABLE_PIN       PB11
 //#ifndef X_CS_PIN
-//  #define X_CS_PIN         PD1
+//  #define X_CS_PIN       PD1
 //#endif
 
 #define Y_STEP_PIN         PB0
 #define Y_DIR_PIN          PC5
 #define Y_ENABLE_PIN       PB1
 //#ifndef Y_CS_PIN
-//  #define Y_CS_PIN         PE12
+//  #define Y_CS_PIN       PE12
 //#endif
 
 #define Z_STEP_PIN         PA7
 #define Z_DIR_PIN          PA6
 #define Z_ENABLE_PIN       PC4
 //#ifndef Z_CS_PIN
-//  #define Z_CS_PIN         PD5
+//  #define Z_CS_PIN       PD5
 //#endif
 
 #define E0_STEP_PIN        PA4
 #define E0_DIR_PIN         PA3
 #define E0_ENABLE_PIN      PA5
 //#ifndef E0_CS_PIN
-//  #define E0_CS_PIN         PB4
+//  #define E0_CS_PIN      PB4
 //#endif
 
 #define E1_STEP_PIN        -1
 #define E1_DIR_PIN         -1
 #define E1_ENABLE_PIN      -1
 //#ifndef E1_CS_PIN
-//  #define E1_CS_PIN         PE5
+//  #define E1_CS_PIN      PE5
 //#endif
 
 //
 // Temperature Sensors
 //
-
 #define TEMP_0_PIN         PC0   // Analog Input
-#define TEMP_1_PIN         -1   // Analog Input
+#define TEMP_1_PIN         -1    // Analog Input
 #define TEMP_BED_PIN       PC1   // Analog Input
 
 //
 // Heaters / Fans
 //
-
 #define HEATER_0_PIN       PA1
 #define HEATER_1_PIN       -1
 #define HEATER_BED_PIN     PA2
 
 #ifndef FAN_PIN
-  //#define FAN_PIN          PC15
+//  #define FAN_PIN        PC15
 #endif
 #define FAN1_PIN           PC15
 #define FAN2_PIN           PA0
 
-#define ORIG_E0_AUTO_FAN_PIN  PC15 // Use this by NOT overriding E0_AUTO_FAN_PIN
-
-//
-// Misc. Functions
-//
-
-//#define CASE_LIGHT_PIN_CI -1
-//#define CASE_LIGHT_PIN_DO -1
-//#define NEOPIXEL_PIN      -1
+#define ORIG_E0_AUTO_FAN_PIN PC15   // Use this by NOT overriding E0_AUTO_FAN_PIN
 
 //
 // Prusa i3 MK2 Multi Material Multiplexer Support
 //
-
-//#define E_MUX0_PIN         -1
-//#define E_MUX1_PIN         -1
+//#define E_MUX0_PIN       -1
+//#define E_MUX1_PIN       -1
 
 //
-// Servos
+// LED / Lighting
 //
+//#define CASE_LIGHT_PIN_CI -1
+//#define CASE_LIGHT_PIN_DO -1
+//#define NEOPIXEL_PIN     -1
 
-//#define SERVO0_PIN         PD12
-//#define SERVO1_PIN         -1
-
-
+//
+// Misc. Functions
+//
 #define SDSS               PC11
-#define LED_PIN            PC7         //Alive
+#define LED_PIN            PC7   // Alive
 #define PS_ON_PIN          -1
 #define KILL_PIN           -1
-#define PWR_LOSS           -1         //Power loss / nAC_FAULT
+#define POWER_LOSS_PIN     -1    // Power-loss / nAC_FAULT
 
-#define SCK_PIN   PC12
-#define MISO_PIN  PC8
-#define MOSI_PIN  PD2
-#define SS_PIN    PC11
+#define SCK_PIN            PC12
+#define MISO_PIN           PC8
+#define MOSI_PIN           PD2
+#define SS_PIN             PC11
 
 //
 // SD support
@@ -160,6 +152,7 @@
 //
 // LCD / Controller
 //
+
 // The LCD is initialized in FSMC mode
 #define SD_DETECT_PIN      -1
 #define BEEPER_PIN         PD12
@@ -175,22 +168,14 @@
 #define TOUCH_CS           PB6
 
 //
-// Filament runout
-//
-
-#define FIL_RUNOUT_PIN     PE1
-
-//
 // ST7920 Delays
 //
 #ifndef ST7920_DELAY_1
   #define ST7920_DELAY_1 DELAY_NS(96)
 #endif
-
 #ifndef ST7920_DELAY_2
   #define ST7920_DELAY_2 DELAY_NS(48)
 #endif
-
 #ifndef ST7920_DELAY_3
   #define ST7920_DELAY_3 DELAY_NS(715)
 #endif

--- a/Marlin/src/pins/stm32/pins_LERDGE_X.h
+++ b/Marlin/src/pins/stm32/pins_LERDGE_X.h
@@ -1,0 +1,196 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#if !defined(STM32F4) && !defined(STM32F4xx)
+  #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
+#endif
+
+#define DEFAULT_MACHINE_NAME "LERDGE"
+#define BOARD_NAME "Lerdge X"
+
+//#define I2C_EEPROM
+
+// Ignore temp readings during develpment.
+//#define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "LERDGE supports up to 2 hotends / E-steppers."
+#endif
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          PB12
+#define X_MAX_PIN          -1
+#define Y_MIN_PIN          PB13
+#define Y_MAX_PIN          -1
+#define Z_MIN_PIN          PB14
+#define Z_MAX_PIN          -1
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+
+//#ifndef Z_MIN_PROBE_PIN
+//  #define Z_MIN_PROBE_PIN  PB15
+//#endif
+
+//
+// Steppers
+//
+
+#define X_STEP_PIN         PB10
+#define X_DIR_PIN          PB2
+#define X_ENABLE_PIN       PB11
+//#ifndef X_CS_PIN
+//  #define X_CS_PIN         PD1
+//#endif
+
+#define Y_STEP_PIN         PB0
+#define Y_DIR_PIN          PC5
+#define Y_ENABLE_PIN       PB1
+//#ifndef Y_CS_PIN
+//  #define Y_CS_PIN         PE12
+//#endif
+
+#define Z_STEP_PIN         PA7
+#define Z_DIR_PIN          PA6
+#define Z_ENABLE_PIN       PC4
+//#ifndef Z_CS_PIN
+//  #define Z_CS_PIN         PD5
+//#endif
+
+#define E0_STEP_PIN        PA4
+#define E0_DIR_PIN         PA3
+#define E0_ENABLE_PIN      PA5
+//#ifndef E0_CS_PIN
+//  #define E0_CS_PIN         PB4
+//#endif
+
+#define E1_STEP_PIN        -1
+#define E1_DIR_PIN         -1
+#define E1_ENABLE_PIN      -1
+//#ifndef E1_CS_PIN
+//  #define E1_CS_PIN         PE5
+//#endif
+
+//
+// Temperature Sensors
+//
+
+#define TEMP_0_PIN         PC0   // Analog Input
+#define TEMP_1_PIN         -1   // Analog Input
+#define TEMP_BED_PIN       PC1   // Analog Input
+
+//
+// Heaters / Fans
+//
+
+#define HEATER_0_PIN       PA1
+#define HEATER_1_PIN       -1
+#define HEATER_BED_PIN     PA2
+
+#ifndef FAN_PIN
+  //#define FAN_PIN          PC15
+#endif
+#define FAN1_PIN           PC15
+#define FAN2_PIN           PA0
+
+#define ORIG_E0_AUTO_FAN_PIN  PC15 // Use this by NOT overriding E0_AUTO_FAN_PIN
+
+//
+// Misc. Functions
+//
+
+//#define CASE_LIGHT_PIN_CI -1
+//#define CASE_LIGHT_PIN_DO -1
+//#define NEOPIXEL_PIN      -1
+
+//
+// Prusa i3 MK2 Multi Material Multiplexer Support
+//
+
+//#define E_MUX0_PIN         -1
+//#define E_MUX1_PIN         -1
+
+//
+// Servos
+//
+
+//#define SERVO0_PIN         PD12
+//#define SERVO1_PIN         -1
+
+
+#define SDSS               PC11
+#define LED_PIN            PC7         //Alive
+#define PS_ON_PIN          -1
+#define KILL_PIN           -1
+#define PWR_LOSS           -1         //Power loss / nAC_FAULT
+
+#define SCK_PIN   PC12
+#define MISO_PIN  PC8
+#define MOSI_PIN  PD2
+#define SS_PIN    PC11
+
+//
+// SD support
+//
+#define SDIO_SUPPORT
+
+//
+// LCD / Controller
+//
+// The LCD is initialized in FSMC mode
+#define SD_DETECT_PIN      -1
+#define BEEPER_PIN         PD12
+
+#define BTN_EN1            PE3
+#define BTN_EN2            PE4
+#define BTN_ENC            PE2
+
+#define LCD_RESET_PIN      PD6
+#define LCD_BACKLIGHT_PIN  PD3
+#define FSMC_CS_PIN        PD4
+#define FSMC_RS_PIN        PD11
+#define TOUCH_CS           PB6
+
+//
+// Filament runout
+//
+
+#define FIL_RUNOUT_PIN     PE1
+
+//
+// ST7920 Delays
+//
+#ifndef ST7920_DELAY_1
+  #define ST7920_DELAY_1 DELAY_NS(96)
+#endif
+
+#ifndef ST7920_DELAY_2
+  #define ST7920_DELAY_2 DELAY_NS(48)
+#endif
+
+#ifndef ST7920_DELAY_3
+  #define ST7920_DELAY_3 DELAY_NS(715)
+#endif


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Adds pins definitions for Lerdge's X and K boards.

### Benefits

Allows one, with the help of an encryption script and some Arduino board definitions, to compile Marlin for the Lerdge X and K.

### Related Issues

#12624 