### PR TITLE
Add root flag to CardReader

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -968,8 +968,7 @@ namespace ExtUI {
 
   bool FileList::isAtRootDir() {
     #if ENABLED(SDSUPPORT)
-      card.getWorkDirName();
-      return card.filename[0] == '/';
+      card.flag.workDirIsRoot;
     #else
       return true;
     #endif

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -136,7 +136,7 @@ void menu_media() {
 
   START_MENU();
   MENU_BACK(MSG_MAIN);
-  if (card.isWorkDirAtRoot) {
+  if (card.flag.workDirIsRoot) {
     #if !PIN_EXISTS(SD_DETECT)
       MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);
     #endif

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -127,9 +127,7 @@ void menu_media() {
 
   #if HAS_GRAPHICAL_LCD
     static uint16_t fileCnt;
-    if (ui.first_page) {
-      fileCnt = card.get_num_Files();
-    }
+    if (ui.first_page) fileCnt = card.get_num_Files();
   #else
     const uint16_t fileCnt = card.get_num_Files();
   #endif

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -127,21 +127,16 @@ void menu_media() {
 
   #if HAS_GRAPHICAL_LCD
     static uint16_t fileCnt;
-    static bool at_root;
     if (ui.first_page) {
       fileCnt = card.get_num_Files();
-      card.getWorkDirName();
-      at_root = card.filename[0] == '/';
     }
   #else
     const uint16_t fileCnt = card.get_num_Files();
-    card.getWorkDirName();
-    const bool at_root = card.filename[0] == '/';
   #endif
 
   START_MENU();
   MENU_BACK(MSG_MAIN);
-  if (at_root) {
+  if (card.isWorkDirAtRoot) {
     #if !PIN_EXISTS(SD_DETECT)
       MENU_ITEM(function, LCD_STR_REFRESH MSG_REFRESH, lcd_sd_refresh);
     #endif

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -49,6 +49,7 @@
 // public:
 
 card_flags_t CardReader::flag;
+bool CardReader::isWorkDirAtRoot;
 char CardReader::filename[FILENAME_LENGTH], CardReader::longFilename[LONG_FILENAME_LENGTH];
 int8_t CardReader::autostart_index;
 
@@ -707,6 +708,7 @@ void CardReader::chdir(const char * relpath) {
 
   if (newDir.open(parent, relpath, O_READ)) {
     workDir = newDir;
+    isWorkDirAtRoot = false;
     if (workDirDepth < MAX_DIR_DEPTH)
       workDirParents[workDirDepth++] = workDir;
     #if ENABLED(SDCARD_SORT_ALPHA)
@@ -717,6 +719,8 @@ void CardReader::chdir(const char * relpath) {
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR(MSG_SD_CANT_ENTER_SUBDIR, relpath);
   }
+  getnrfilenames();
+  getWorkDirName();
 }
 
 int8_t CardReader::updir() {
@@ -726,6 +730,9 @@ int8_t CardReader::updir() {
       presort();
     #endif
   }
+  isWorkDirAtRoot = workDirDepth ? false : true;
+  getnrfilenames();
+  getWorkDirName();
   return workDirDepth;
 }
 
@@ -734,9 +741,12 @@ void CardReader::setroot() {
     SERIAL_ECHOLNPGM(MSG_SD_WORKDIR_FAIL);
   }*/
   workDir = root;
+  isWorkDirAtRoot = true;
   #if ENABLED(SDCARD_SORT_ALPHA)
     presort();
   #endif
+  getnrfilenames();
+  getWorkDirName();
 }
 
 #if ENABLED(SDCARD_SORT_ALPHA)

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -629,7 +629,7 @@ void CardReader::getfilename(uint16_t nr, const char * const match/*=nullptr*/) 
   lsDive(nullptr, workDir, match);
 }
 
-uint16_t CardReader::getnrfilenames() {
+uint16_t CardReader::countFilesInWorkDir() {
   lsAction = LS_Count;
   nrFiles = 0;
   workDir.rewind();
@@ -718,8 +718,6 @@ void CardReader::chdir(const char * relpath) {
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR(MSG_SD_CANT_ENTER_SUBDIR, relpath);
   }
-  getnrfilenames();
-  getWorkDirName();
 }
 
 int8_t CardReader::updir() {
@@ -730,8 +728,6 @@ int8_t CardReader::updir() {
     #endif
   }
   if (!workDirDepth) flag.workDirIsRoot = true;
-  getnrfilenames();
-  getWorkDirName();
   return workDirDepth;
 }
 
@@ -741,8 +737,6 @@ void CardReader::setroot() {
   #if ENABLED(SDCARD_SORT_ALPHA)
     presort();
   #endif
-  getnrfilenames();
-  getWorkDirName();
 }
 
 #if ENABLED(SDCARD_SORT_ALPHA)
@@ -807,7 +801,7 @@ void CardReader::setroot() {
     #endif
 
     // If there are files, sort up to the limit
-    uint16_t fileCnt = getnrfilenames();
+    uint16_t fileCnt = countFilesInWorkDir();
     if (fileCnt > 0) {
 
       // Never sort more than the max allowed
@@ -987,7 +981,7 @@ uint16_t CardReader::get_num_Files() {
     #if ENABLED(SDCARD_SORT_ALPHA) && SDSORT_USES_RAM && SDSORT_CACHE_NAMES
       nrFiles // no need to access the SD card for filenames
     #else
-      getnrfilenames()
+      countFilesInWorkDir()
     #endif
   ;
 }

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -49,7 +49,6 @@
 // public:
 
 card_flags_t CardReader::flag;
-bool CardReader::isWorkDirAtRoot;
 char CardReader::filename[FILENAME_LENGTH], CardReader::longFilename[LONG_FILENAME_LENGTH];
 int8_t CardReader::autostart_index;
 
@@ -708,7 +707,7 @@ void CardReader::chdir(const char * relpath) {
 
   if (newDir.open(parent, relpath, O_READ)) {
     workDir = newDir;
-    isWorkDirAtRoot = false;
+    flag.workDirIsRoot = false;
     if (workDirDepth < MAX_DIR_DEPTH)
       workDirParents[workDirDepth++] = workDir;
     #if ENABLED(SDCARD_SORT_ALPHA)
@@ -730,18 +729,15 @@ int8_t CardReader::updir() {
       presort();
     #endif
   }
-  isWorkDirAtRoot = workDirDepth ? false : true;
+  if (!workDirDepth) flag.workDirIsRoot = true;
   getnrfilenames();
   getWorkDirName();
   return workDirDepth;
 }
 
 void CardReader::setroot() {
-  /*if (!workDir.openRoot(&volume)) {
-    SERIAL_ECHOLNPGM(MSG_SD_WORKDIR_FAIL);
-  }*/
   workDir = root;
-  isWorkDirAtRoot = true;
+  flag.workDirIsRoot = true;
   #if ENABLED(SDCARD_SORT_ALPHA)
     presort();
   #endif

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -142,6 +142,7 @@ public:
 
 public:
   static card_flags_t flag;
+  static bool isWorkDirAtRoot;
   static char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
   static int8_t autostart_index;
   static SdFile getroot() { return root; }

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -41,6 +41,7 @@ typedef struct {
        sdprinting:1,
        mounted:1,
        filenameIsDir:1,
+       workDirIsRoot:1,
        abort_sd_printing:1
        #if ENABLED(BINARY_FILE_TRANSFER)
          , binary_mode:1
@@ -142,7 +143,6 @@ public:
 
 public:
   static card_flags_t flag;
-  static bool isWorkDirAtRoot;
   static char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
   static int8_t autostart_index;
   static SdFile getroot() { return root; }

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -80,7 +80,7 @@ public:
   #endif
 
   static void getfilename(uint16_t nr, const char* const match=nullptr);
-  static uint16_t getnrfilenames();
+  static uint16_t countFilesInWorkDir();
 
   static void getAbsFilename(char *t);
 


### PR DESCRIPTION
When user touch updir to root, sometimes, at_root still not updated. 
This make some "error glitch" in the screen which will automatically fix after the page loop reach first_page.

Therefore, i prefer to use move at_root to CardReader class. And the variable is updated on 3 function calls : 
- chdir
- updir
- setroot

This will make the problem fixed and make the sdcard even faster. 