### PR TITLE
LULZBOT_TOUCH_UI fixes. Fix some warnings.

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -63,7 +63,7 @@
 // Macros for bit masks
 #undef _BV
 #define _BV(n) (1<<(n))
-#define TEST(n,b) !!((n)&_BV(b))
+#define TEST(n,b) (!!((n)&_BV(b)))
 #define SET_BIT_TO(N,B,TF) do{ if (TF) SBI(N,B); else CBI(N,B); }while(0)
 
 #ifndef SBI

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -500,6 +500,8 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
 
   #if HAS_BUZZER
     filament_change_beep(max_beep_count, true);
+  #else
+    UNUSED(max_beep_count);
   #endif
 
   // Start the heater idle timers

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -612,6 +612,8 @@ void ST7920_Lite_Status_Screen::draw_feedrate_percentage(const uint16_t percenta
     begin_data();
     write_number(percentage, 3);
     write_byte('%');
+  #else
+    UNUSED(percentage);
   #endif
 }
 

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/extended/unicode/unicode.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/extended/unicode/unicode.cpp
@@ -142,7 +142,7 @@
   uint16_t FTDI::get_utf8_text_width(progmem_str pstr, font_size_t fs) {
     char str[strlen_P((const char*)pstr) + 1];
     strcpy_P(str, (const char*)pstr);
-    return get_utf8_text_width((const char*) pstr, fs);
+    return get_utf8_text_width(str, fs);
   }
 
    /**

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/base_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/base_screen.cpp
@@ -66,8 +66,7 @@ void BaseScreen::onIdle() {
     if ((millis() - last_interaction) > LCD_TIMEOUT_TO_STATUS) {
       reset_menu_timeout();
       #ifdef UI_FRAMEWORK_DEBUG
-        SERIAL_ECHO_START();
-        SERIAL_ECHOLNPGM("Returning to status due to menu timeout");
+        SERIAL_ECHO_MSG("Returning to status due to menu timeout");
       #endif
       GOTO_SCREEN(StatusScreen);
     }

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/base_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/base_screen.cpp
@@ -32,6 +32,7 @@ using namespace Theme;
 void BaseScreen::onEntry() {
   CommandProcessor cmd;
   cmd.set_button_style_callback(buttonStyleCallback);
+  reset_menu_timeout();
   UIScreen::onEntry();
 }
 
@@ -62,9 +63,12 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
 
 void BaseScreen::onIdle() {
   #ifdef LCD_TIMEOUT_TO_STATUS
-    const uint32_t elapsed = millis() - last_interaction;
-    if (elapsed > uint32_t(LCD_TIMEOUT_TO_STATUS)) {
+    if ((millis() - last_interaction) > LCD_TIMEOUT_TO_STATUS) {
       reset_menu_timeout();
+      #ifdef UI_FRAMEWORK_DEBUG
+        SERIAL_ECHO_START();
+        SERIAL_ECHOLNPGM("Returning to status due to menu timeout");
+      #endif
       GOTO_SCREEN(StatusScreen);
     }
   #endif

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_advanced_settings.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_advanced_settings.cpp
@@ -55,23 +55,23 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
       #else
        .enabled(0)
       #endif
-      .tag(4) .button( BTN_POS(1,3), BTN_SIZE(1,1), GET_TEXTF(BUMP_SENSE))
+      .tag(4) .button( BTN_POS(1,3), BTN_SIZE(1,1), GET_TEXTF(HOME_SENSE))
       .tag(5) .button( BTN_POS(1,4), BTN_SIZE(1,1), GET_TEXTF(ENDSTOPS))
       #if HOTENDS > 1
       .enabled(1)
       #else
       .enabled(0)
       #endif
-      .tag(6) .button( BTN_POS(1,5), BTN_SIZE(1,1), GET_TEXTF(NOZZLE_OFFSETS))
+      .tag(6) .button( BTN_POS(1,5), BTN_SIZE(1,1), GET_TEXTF(TOOL_OFFSETS))
 
 
       .tag(7) .button( BTN_POS(2,1), BTN_SIZE(1,1), GET_TEXTF(STEPS_PER_MM))
-      .tag(8) .button( BTN_POS(2,2), BTN_SIZE(1,1), GET_TEXTF(MAX_VELOCITY))
-      .tag(9) .button( BTN_POS(2,3), BTN_SIZE(1,1), GET_TEXTF(MAX_ACCELERATION))
+      .tag(8) .button( BTN_POS(2,2), BTN_SIZE(1,1), GET_TEXTF(VELOCITY))
+      .tag(9) .button( BTN_POS(2,3), BTN_SIZE(1,1), GET_TEXTF(ACCELERATION))
       #if ENABLED(JUNCTION_DEVIATION)
         .tag(10) .button( BTN_POS(2,4), BTN_SIZE(1,1), GET_TEXTF(JUNCTION_DEVIATION))
       #else
-        .tag(10) .button( BTN_POS(2,4), BTN_SIZE(1,1), GET_TEXTF(MAX_JERK))
+        .tag(10) .button( BTN_POS(2,4), BTN_SIZE(1,1), GET_TEXTF(JERK))
       #endif
       #if ENABLED(BACKLASH_GCODE)
       .enabled(1)
@@ -86,7 +86,7 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
       #endif
       .tag(12) .button( BTN_POS(1,6), BTN_SIZE(2,1), GET_TEXTF(LINEAR_ADVANCE))
       .tag(13) .button( BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXTF(INTERFACE_SETTINGS))
-      .tag(14) .button( BTN_POS(1,8), BTN_SIZE(2,1), GET_TEXTF(RESTORE_FAILSAFE))
+      .tag(14) .button( BTN_POS(1,8), BTN_SIZE(2,1), GET_TEXTF(RESTORE_DEFAULTS))
       .colors(action_btn)
       .tag(1). button( BTN_POS(1,9), BTN_SIZE(2,1), GET_TEXTF(BACK));
     #undef GRID_COLS

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_printing_dialog_box.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_printing_dialog_box.cpp
@@ -113,8 +113,8 @@ bool BioPrintingDialogBox::onTouchEnd(uint8_t tag) {
 }
 
 void BioPrintingDialogBox::setStatusMessage(progmem_str message) {
-  char buff[strlen_P((const char * const)message)+1];
-  strcpy_P(buff, (const char * const) message);
+  char buff[strlen_P((const char*)message)+1];
+  strcpy_P(buff, (const char*) message);
   setStatusMessage(buff);
 }
 

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_status_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_status_screen.cpp
@@ -82,6 +82,10 @@ void StatusScreen::draw_temperature(draw_mode_t what) {
        .icon (x + 2, y + 2, h, v, Bed_Heat_Icon_Info, icon_scale * 2)
        .cmd(COLOR_RGB(bg_text_enabled))
        .icon (x, y, h, v, Bed_Heat_Icon_Info, icon_scale * 2);
+
+    #ifdef TOUCH_UI_USE_UTF8
+      load_utf8_bitmaps(cmd); // Restore font bitmap handles
+    #endif
   }
 
   if (what & FOREGROUND) {
@@ -197,17 +201,9 @@ void StatusScreen::draw_overlay_icons(draw_mode_t what) {
     ui.button_stroke(stroke_rgb, 28);
     ui.button_shadow(shadow_rgb, shadow_depth);
 
-    if (!jog_xy) {
-      ui.button(12, POLY(padlock));
-    }
-
-    if (!e_homed) {
-      ui.button(13, POLY(home_e));
-    }
-
-    if (!z_homed) {
-      ui.button(14, POLY(home_z));
-    }
+    if (!jog_xy)  ui.button(12, POLY(padlock));
+    if (!e_homed) ui.button(13, POLY(home_e));
+    if (!z_homed) ui.button(14, POLY(home_z));
   }
 }
 
@@ -228,19 +224,24 @@ void StatusScreen::draw_buttons(draw_mode_t) {
         isPrintingFromMedia() ?
           GET_TEXTF(PRINTING) :
         #ifdef LULZBOT_MANUAL_USB_STARTUP
-        (Sd2Card::ready() ? GET_TEXTF(MEDIA) : GET_TEXTF(ENABLE_MEDIA))
+          (Sd2Card::ready() ? GET_TEXTF(MEDIA) : GET_TEXTF(ENABLE_MEDIA))
         #else
-        GET_TEXTF(MEDIA)
+          GET_TEXTF(MEDIA)
         #endif
       );
 
-  cmd.colors(!has_media ? action_btn : normal_btn).tag(10).button(BTN_POS(2,9), BTN_SIZE(1,1), F("Menu"));
+  cmd.colors(!has_media ? action_btn : normal_btn).tag(10).button(BTN_POS(2,9), BTN_SIZE(1,1), GET_TEXTF(MENU));
 }
 
 void StatusScreen::loadBitmaps() {
   // Load the bitmaps for the status screen
   constexpr uint32_t base = ftdi_memory_map::RAM_G;
   CLCD::mem_write_pgm(base + Bed_Heat_Icon_Info.RAMG_offset, Bed_Heat_Icon, sizeof(Bed_Heat_Icon));
+
+  // Load fonts for internationalization
+  #ifdef TOUCH_UI_USE_UTF8
+    load_utf8_data(base + UTF8_FONT_OFFSET);
+  #endif
 }
 
 void StatusScreen::onRedraw(draw_mode_t what) {

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_status_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_status_screen.cpp
@@ -91,12 +91,12 @@ void StatusScreen::draw_temperature(draw_mode_t what) {
        .cmd(COLOR_RGB(bg_text_enabled));
 
     if (!isHeaterIdle(BED) && getTargetTemp_celsius(BED) > 0) {
-      sprintf_P(bed_str, F("%3d%S"), ROUND(getTargetTemp_celsius(BED), GET_TEXT(UNITS_C)));
+      sprintf_P(bed_str, PSTR("%3d%S"), ROUND(getTargetTemp_celsius(BED)), GET_TEXT(UNITS_C));
       ui.bounds(POLY(target_temp), x, y, h, v);
       cmd.text(x, y, h, v, bed_str);
     }
 
-    sprintf_P(bed_str, F("%3d%S"), ROUND(getActualTemp_celsius(BED)), GET_TEXT(UNITS_C));
+    sprintf_P(bed_str, PSTR("%3d%S"), ROUND(getActualTemp_celsius(BED)), GET_TEXT(UNITS_C));
     ui.bounds(POLY(actual_temp), x, y, h, v);
     cmd.text(x, y, h, v, bed_str);
   }
@@ -237,7 +237,7 @@ void StatusScreen::draw_buttons(draw_mode_t) {
   cmd.colors(!has_media ? action_btn : normal_btn).tag(10).button(BTN_POS(2,9), BTN_SIZE(1,1), F("Menu"));
 }
 
-void StatusScreen::onStartup() {
+void StatusScreen::loadBitmaps() {
   // Load the bitmaps for the status screen
   constexpr uint32_t base = ftdi_memory_map::RAM_G;
   CLCD::mem_write_pgm(base + Bed_Heat_Icon_Info.RAMG_offset, Bed_Heat_Icon, sizeof(Bed_Heat_Icon));

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/dialog_box_base_class.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/dialog_box_base_class.cpp
@@ -80,4 +80,8 @@ bool DialogBoxBaseClass::onTouchEnd(uint8_t tag) {
   }
 }
 
+void DialogBoxBaseClass::onIdle() {
+  reset_menu_timeout();
+}
+
 #endif // LULZBOT_TOUCH_UI

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/endstop_state_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/endstop_state_screen.cpp
@@ -108,7 +108,8 @@ void EndstopStatesScreen::onRedraw(draw_mode_t) {
   #if HAS_SOFTWARE_ENDSTOPS
     #undef EDGE_R
     #define EDGE_R 30
-    cmd.font(font_small)
+    cmd.cmd(COLOR_RGB(bg_text_enabled))
+       .font(font_small)
        .text         (BTN_POS(1,5), BTN_SIZE(3,1), GET_TEXTF(SOFT_ENDSTOPS), OPT_RIGHTX | OPT_CENTERY)
        .colors(ui_toggle)
        .tag(2).toggle2(BTN_POS(4,5), BTN_SIZE(3,1), GET_TEXTF(NO), GET_TEXTF(YES), getSoftEndstopState());

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/files_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/files_screen.cpp
@@ -91,7 +91,11 @@ void FilesScreen::drawFileButton(const char* filename, uint8_t tag, bool is_dir,
       cmd.cmd(MACRO(0));
     }
   #endif
-  cmd.text  (BTN_POS(1,header_h+line), BTN_SIZE(6,1), filename, OPT_CENTERY);
+  cmd.text  (BTN_POS(1,header_h+line), BTN_SIZE(6,1), filename, OPT_CENTERY
+    #if ENABLED(SCROLL_LONG_FILENAMES)
+      | OPT_NOFIT
+    #endif
+  );
   if (is_dir) {
     cmd.text(BTN_POS(1,header_h+line), BTN_SIZE(6,1), F("> "),  OPT_CENTERY | OPT_RIGHTX);
   }
@@ -234,8 +238,8 @@ bool FilesScreen::onTouchEnd(uint8_t tag) {
           if (FTDI::ftdi_chip >= 810) {
             const char *longFilename = getSelectedLongFilename();
             if (longFilename[0]) {
-              CLCD::FontMetrics fm(font_medium);
-              uint16_t text_width = fm.get_text_width(longFilename);
+              CommandProcessor cmd;
+              uint16_t text_width = cmd.font(font_medium).text_width(longFilename);
               screen_data.FilesScreen.scroll_pos = 0;
               if (text_width > display_width)
                 screen_data.FilesScreen.scroll_max = text_width - display_width + MARGIN_L + MARGIN_R;

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/screens.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/screens.h
@@ -148,6 +148,7 @@ class DialogBoxBaseClass : public BaseScreen {
     static void onRedraw(draw_mode_t) {};
   public:
     static bool onTouchEnd(uint8_t tag);
+    static void onIdle();
 };
 
 class AlertDialogBox : public DialogBoxBaseClass, public CachedScreen<ALERT_BOX_CACHE,ALERT_BOX_DL_SIZE> {

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/screens.h
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/screens.h
@@ -243,12 +243,12 @@ class StatusScreen : public BaseScreen, public CachedScreen<STATUS_SCREEN_CACHE,
       static void draw_fine_motion(draw_mode_t what);
       static void draw_buttons(draw_mode_t what);
     public:
+      static void loadBitmaps();
       static void unlockMotors();
 
       static void setStatusMessage(const char *);
       static void setStatusMessage(progmem_str);
 
-      static void onStartup();
       static void onRedraw(draw_mode_t);
 
       static bool onTouchStart(uint8_t tag);

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/spinner_dialog_box.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/spinner_dialog_box.cpp
@@ -57,6 +57,7 @@ void SpinnerDialogBox::enqueueAndWait_P(const progmem_str message, const progmem
 }
 
 void SpinnerDialogBox::onIdle() {
+  reset_menu_timeout();
   if (screen_data.SpinnerDialogBox.auto_hide && !commandsInQueue()) {
     screen_data.SpinnerDialogBox.auto_hide = false;
     hide();

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/status_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/status_screen.cpp
@@ -181,6 +181,10 @@ void StatusScreen::draw_temperature(draw_mode_t what) {
        .cmd(BITMAP_LAYOUT(Fan_Icon_Info))
        .cmd(BITMAP_SIZE  (Fan_Icon_Info))
        .icon  (BTN_POS(5,2), BTN_SIZE(1,1), Fan_Icon_Info, icon_scale);
+
+    #ifdef TOUCH_UI_USE_UTF8
+      load_utf8_bitmaps(cmd); // Restore font bitmap handles
+    #endif
   }
 
   if (what & FOREGROUND) {
@@ -342,9 +346,6 @@ void StatusScreen::setStatusMessage(const char* message) {
      .cmd(CLEAR(true,true,true));
 
   draw_temperature(BACKGROUND);
-  #ifdef TOUCH_UI_USE_UTF8
-    load_utf8_bitmaps(cmd);
-  #endif
   draw_progress(BACKGROUND);
   draw_axis_position(BACKGROUND);
   draw_status_message(BACKGROUND, message);

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -170,6 +170,8 @@ namespace ExtUI {
   void enableHeater(const extruder_t extruder) {
     #if HOTENDS && HEATER_IDLE_HANDLER
       thermalManager.reset_heater_idle_timer(extruder - E0);
+    #else
+      UNUSED(extruder);
     #endif
   }
 
@@ -190,6 +192,8 @@ namespace ExtUI {
           #endif
           break;
       }
+    #else
+      UNUSED(heater);
     #endif
   }
 
@@ -197,6 +201,8 @@ namespace ExtUI {
     return false
       #if HOTENDS && HEATER_IDLE_HANDLER
         || thermalManager.hotend_idle[extruder - E0].timed_out
+      #else
+        ; UNUSED(extruder)
       #endif
     ;
   }
@@ -218,6 +224,7 @@ namespace ExtUI {
           #endif
       }
     #else
+      UNUSED(heater);
       return false;
     #endif
   }


### PR DESCRIPTION
- Fixed warning about unused variable.
- Needed parenthesis around `TEST()` because it was being used by `READ()` in conditions where the precedence of adjoining "!=" was higher:

```
src/gcode/control/M226.cpp: In function ‘bool _digitalRead(int)’:
src/gcode/control/M226.cpp:35:64: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
    #define TEST_PIN(PIN) case PIN##_PIN: val = READ(PIN##_PIN) != PIN##_ENDSTOP_INVERTING; break
                                                                ^
src/gcode/control/M226.cpp:41:6: note: in expansion of macro ‘TEST_PIN’
      TEST_PIN(X_MAX);
```

And:

```
src/module/endstops.cpp:502:125: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
   #define UPDATE_ENDSTOP_BIT(AXIS, MINMAX) SET_BIT_TO(live_state, _ENDSTOP(AXIS, MINMAX), (READ(_ENDSTOP_PIN(AXIS, MINMAX)) != _ENDSTOP_INVERTING(AXIS, MINMAX)))
                                                                                                                             ^
src/module/../inc/../core/macros.h:76:36: note: in definition of macro ‘SET_BIT_TO’
 #define SET_BIT_TO(N,B,TF) do{ if (TF) SBI(N,B); else CBI(N,B); }while(0)
                                    ^
src/module/endstops.cpp:562:7: note: in expansion of macro ‘UPDATE_ENDSTOP_BIT’
       UPDATE_ENDSTOP_BIT(X, MAX);
```

And:

```
src/module/endstops.cpp: In static member function ‘static void Endstops::M119()’:
src/module/endstops.cpp:403:53: warning: logical not is only applied to the left hand side of comparison [-Wlogical-not-parentheses]
   #define ES_REPORT(S) print_es_state(READ(S##_PIN) != S##_ENDSTOP_INVERTING, PSTR(MSG_##S))
                                                     ^
src/module/endstops.cpp:411:5: note: in expansion of macro ‘ES_REPORT’
     ES_REPORT(X_MAX);
```