### PR TITLE
regression in 1d8ad7c breaks Re-ARM builds: "Marlin\src\core\utility.h:36:5: error: 'UNUSED' was not declared in this scope"

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -53,6 +53,15 @@
 // Nanoseconds per cycle
 #define NANOSECONDS_PER_CYCLE (1000000000.0 / F_CPU)
 
+// Remove compiler warning on an unused variable
+#ifndef UNUSED
+  #if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+    #define UNUSED(X) (void)X
+  #else
+    #define UNUSED(x) ((void)(x))
+  #endif
+#endif
+
 // Macros to make a string from a macro
 #define STRINGIFY_(M) #M
 #define STRINGIFY(M) STRINGIFY_(M)


### PR DESCRIPTION
### Description

I pulled in the latest round of updates from bugfix-2.0.x last week, but when I went to build it for my Re-ARM-equipped A8, compilation stopped here:

```
Compiling .pio\build\LPC1768\src\src\feature\I2CPositionEncoder.cpp.o
In file included from Marlin\src\core\utility.cpp:23:
Marlin\src\core\utility.h: In function 'void serial_delay(millis_t)':
Marlin\src\core\utility.h:36:5: error: 'UNUSED' was not declared in this scope
     UNUSED(ms);
     ^~~~~~
Marlin\src\core\utility.h:36:5: note: the macro 'UNUSED' had not yet been defined
In file included from e:\tmp\marlin\marlin\src\hal\hal_lpc1768\hal.h:39,
                 from e:\tmp\marlin\marlin\src\hal\hal.h:26,
                 from Marlin\src\core\../inc/MarlinConfig.h:30,
                 from Marlin\src\core\../Marlin.h:24,
                 from Marlin\src\core\utility.cpp:25:
e:\tmp\marlin\marlin\src\hal\shared\marduino.h:84: note: it was later defined here
   #define UNUSED(x) ((void)(x))
```

It looks like commit 1d8ad7c removed the definition of UNUSED in Marlin/src/core/macros.h.  Reversing that commit's change to that file should fix this regression.

### Benefits

Fixes builds for Re-ARM, and possibly other LPC1768 boards.

### Related Issues

#15277
