### PR TITLE
Fix compile errors in M43 when USE_WATCHDOG undefined

### DIFF
--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -65,7 +65,9 @@ inline void toggle_pins() {
       SERIAL_EOL();
     }
     else {
-      watchdog_reset();
+      #if ENABLED(USE_WATCHDOG)
+        watchdog_reset();
+      #endif
       report_pin_state_extended(pin, ignore_protection, true, "Pulsing   ");
       #if AVR_AT90USB1286_FAMILY // Teensy IDEs don't know about these pins so must use FASTIO
         if (pin == TEENSY_E2) {
@@ -89,10 +91,24 @@ inline void toggle_pins() {
       {
         pinMode(pin, OUTPUT);
         for (int16_t j = 0; j < repeat; j++) {
-          watchdog_reset(); extDigitalWrite(pin, 0); safe_delay(wait);
-          watchdog_reset(); extDigitalWrite(pin, 1); safe_delay(wait);
-          watchdog_reset(); extDigitalWrite(pin, 0); safe_delay(wait);
-          watchdog_reset();
+          #if ENABLED(USE_WATCHDOG)
+            watchdog_reset();
+          #endif
+          extDigitalWrite(pin, 0);
+          safe_delay(wait);
+          #if ENABLED(USE_WATCHDOG)
+            watchdog_reset();
+          #endif
+          extDigitalWrite(pin, 1);
+          safe_delay(wait);
+          #if ENABLED(USE_WATCHDOG)
+            watchdog_reset();
+          #endif
+          extDigitalWrite(pin, 0);
+          safe_delay(wait);
+          #if ENABLED(USE_WATCHDOG)
+            watchdog_reset();
+          #endif
         }
       }
     }

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -50,6 +50,12 @@
   #define GET_PIN_MAP_PIN_M43(Q) GET_PIN_MAP_PIN(Q)
 #endif
 
+inline void _watchdog_reset() {
+  #if ENABLED(USE_WATCHDOG)
+    watchdog_reset();
+  #endif
+}
+
 inline void toggle_pins() {
   const bool ignore_protection = parser.boolval('I');
   const int repeat = parser.intval('R', 1),
@@ -65,9 +71,7 @@ inline void toggle_pins() {
       SERIAL_EOL();
     }
     else {
-      #if ENABLED(USE_WATCHDOG)
-        watchdog_reset();
-      #endif
+      _watchdog_reset();
       report_pin_state_extended(pin, ignore_protection, true, "Pulsing   ");
       #if AVR_AT90USB1286_FAMILY // Teensy IDEs don't know about these pins so must use FASTIO
         if (pin == TEENSY_E2) {
@@ -91,24 +95,10 @@ inline void toggle_pins() {
       {
         pinMode(pin, OUTPUT);
         for (int16_t j = 0; j < repeat; j++) {
-          #if ENABLED(USE_WATCHDOG)
-            watchdog_reset();
-          #endif
-          extDigitalWrite(pin, 0);
-          safe_delay(wait);
-          #if ENABLED(USE_WATCHDOG)
-            watchdog_reset();
-          #endif
-          extDigitalWrite(pin, 1);
-          safe_delay(wait);
-          #if ENABLED(USE_WATCHDOG)
-            watchdog_reset();
-          #endif
-          extDigitalWrite(pin, 0);
-          safe_delay(wait);
-          #if ENABLED(USE_WATCHDOG)
-            watchdog_reset();
-          #endif
+          _watchdog_reset(); extDigitalWrite(pin, 0); safe_delay(wait);
+          _watchdog_reset(); extDigitalWrite(pin, 1); safe_delay(wait);
+          _watchdog_reset(); extDigitalWrite(pin, 0); safe_delay(wait);
+          _watchdog_reset();
         }
       }
     }


### PR DESCRIPTION
### Description

When `PINS_DEBUGGING` is defined for M43, but `USE_WATCHDOG` is undefined, compilation fails because `watchdog_reset()` is undefined.

### Benefits

I want to disable the watchdog for debugging purposes, while having `PINS_DEBUGGING` enabled as well. This PR allows this.

Without this patch, compilation fails:

```
...
Linking .pio/build/BIGTREE_SKR_PRO/firmware.elf
.pio/build/BIGTREE_SKR_PRO/src/src/gcode/config/M43.cpp.o: In function `toggle_pins()':
Marlin/src/gcode/config/M43.cpp:68: undefined reference to `watchdog_reset()'
Marlin/src/gcode/config/M43.cpp:92: undefined reference to `watchdog_reset()'
Marlin/src/gcode/config/M43.cpp:93: undefined reference to `watchdog_reset()'
Marlin/src/gcode/config/M43.cpp:94: undefined reference to `watchdog_reset()'
Marlin/src/gcode/config/M43.cpp:95: undefined reference to `watchdog_reset()'
```

### Related Issues

N/a
