### PR TITLE
Remove obsolete LULZBOT_TOUCH_UI code

### DIFF
--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_status_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_status_screen.cpp
@@ -36,10 +36,6 @@
 
 #define POLY(A) PolyUI::poly_reader_t(A, sizeof(A)/sizeof(A[0]))
 
-#if ENABLED(SDSUPPORT) && defined(LULZBOT_MANUAL_USB_STARTUP)
-  #include "../../../../sd/cardreader.h"
-#endif
-
 const uint8_t shadow_depth = 5;
 
 using namespace FTDI;
@@ -214,20 +210,12 @@ void StatusScreen::draw_buttons(draw_mode_t) {
 
   cmd.font(font_medium)
      .colors(normal_btn)
-    #if ENABLED(USB_FLASH_DRIVE_SUPPORT) && defined(LULZBOT_MANUAL_USB_STARTUP)
-      .enabled(!Sd2Card::ready() || has_media)
-    #else
-      .enabled(has_media)
-    #endif
+     .enabled(has_media)
      .colors(has_media ? action_btn : normal_btn)
      .tag(9).button(BTN_POS(1,9), BTN_SIZE(1,1),
         isPrintingFromMedia() ?
           GET_TEXTF(PRINTING) :
-        #ifdef LULZBOT_MANUAL_USB_STARTUP
-          (Sd2Card::ready() ? GET_TEXTF(MEDIA) : GET_TEXTF(ENABLE_MEDIA))
-        #else
           GET_TEXTF(MEDIA)
-        #endif
       );
 
   cmd.colors(!has_media ? action_btn : normal_btn).tag(10).button(BTN_POS(2,9), BTN_SIZE(1,1), GET_TEXTF(MENU));
@@ -276,18 +264,7 @@ bool StatusScreen::onTouchEnd(uint8_t tag) {
         injectCommands_P(PSTR("M17"));
       }
       break;
-    case 9:
-      #if ENABLED(USB_FLASH_DRIVE_SUPPORT) && defined(LULZBOT_MANUAL_USB_STARTUP)
-      if (!Sd2Card::ready()) {
-        StatusScreen::setStatusMessage(GET_TEXTF(INSERT_MEDIA));
-        Sd2Card::usbStartup();
-      } else {
-        GOTO_SCREEN(FilesScreen);
-      }
-      #else
-        GOTO_SCREEN(FilesScreen);
-      #endif
-      break;
+    case 9:  GOTO_SCREEN(FilesScreen); break;
     case 10: GOTO_SCREEN(MainMenu); break;
     case 13: SpinnerDialogBox::enqueueAndWait_P(F("G112"));  break;
     case 14: SpinnerDialogBox::enqueueAndWait_P(F("G28 Z")); break;

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/media_player_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/media_player_screen.cpp
@@ -163,6 +163,9 @@ void MediaPlayerScreen::playStream(void *obj, media_streamer_func_t *data_stream
       DLCache::init();
       StatusScreen::loadBitmaps();
     }
+  #else
+    UNUSED(obj);
+    UNUSED(data_stream);
   #endif // FTDI_API_LEVEL >= 810
 }
 

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/status_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/status_screen.cpp
@@ -29,10 +29,6 @@
 
 #include "../archim2-flash/flash_storage.h"
 
-#if BOTH(SDSUPPORT, LULZBOT_MANUAL_USB_STARTUP)
-  #include "../../../../../sd/cardreader.h"
-#endif
-
 using namespace FTDI;
 using namespace Theme;
 
@@ -283,24 +279,16 @@ void StatusScreen::draw_interaction_buttons(draw_mode_t what) {
     CommandProcessor cmd;
     cmd.colors(normal_btn)
        .font(Theme::font_medium)
-    #if BOTH(SDSUPPORT, LULZBOT_MANUAL_USB_STARTUP)
-      .enabled(!Sd2Card::ready() || has_media)
-    #else
-      .enabled(has_media)
-    #endif
+       .enabled(has_media)
        .colors(has_media ? action_btn : normal_btn)
-      #ifdef TOUCH_UI_PORTRAIT
-         .tag(3).button( BTN_POS(1,8), BTN_SIZE(2,1),
-      #else
-         .tag(3).button( BTN_POS(1,7), BTN_SIZE(2,2),
-      #endif
-      isPrintingFromMedia() ? GET_TEXTF(PRINTING) :
-      #if BOTH(SDSUPPORT, LULZBOT_MANUAL_USB_STARTUP)
-      (!Sd2Card::ready() ? GET_TEXTF(ENABLE_MEDIA) :
-      #else
-      GET_TEXTF(MEDIA))
-      #endif
-      .colors(!has_media ? action_btn : normal_btn)
+       .tag(3).button(
+          #ifdef TOUCH_UI_PORTRAIT
+            BTN_POS(1,8), BTN_SIZE(2,1),
+          #else
+            BTN_POS(1,7), BTN_SIZE(2,2),
+          #endif
+          isPrintingFromMedia() ? GET_TEXTF(PRINTING) : GET_TEXTF(MEDIA)
+        ).colors(!has_media ? action_btn : normal_btn)
       #ifdef TOUCH_UI_PORTRAIT
        .tag(4).button( BTN_POS(3,8), BTN_SIZE(2,1), GET_TEXTF(MENU));
       #else
@@ -407,18 +395,7 @@ bool StatusScreen::onTouchEnd(uint8_t tag) {
   using namespace ExtUI;
 
   switch (tag) {
-    case 3:
-      #if BOTH(SDSUPPORT, LULZBOT_MANUAL_USB_STARTUP)
-      if (!Sd2Card::ready()) {
-        StatusScreen::setStatusMessage(GET_TEXTF(INSERT_MEDIA));
-        Sd2Card::usbStartup();
-      } else {
-        GOTO_SCREEN(FilesScreen);
-      }
-      #else
-        GOTO_SCREEN(FilesScreen);
-      #endif
-      break;
+    case 3: GOTO_SCREEN(FilesScreen); break;
     case 4:
       if (isPrinting()) {
         GOTO_SCREEN(TuneMenu);

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -529,12 +529,18 @@ namespace ExtUI {
       switch (axis) {
         #if X_SENSORLESS && AXIS_HAS_STALLGUARD(X)
           case X: stepperX.homing_threshold(value); break;
+        #else
+          UNUSED(value);
         #endif
         #if Y_SENSORLESS && AXIS_HAS_STALLGUARD(Y)
           case Y: stepperY.homing_threshold(value); break;
+        #else
+          UNUSED(value);
         #endif
         #if Z_SENSORLESS && AXIS_HAS_STALLGUARD(Z)
           case Z: stepperZ.homing_threshold(value); break;
+        #else
+          UNUSED(value);
         #endif
         default: break;
       }


### PR DESCRIPTION
Removed `LULZBOT_MANUAL_USB_STARTUP`, which was only used during early testing of the USB code.