### PR TITLE
Clean up BIGTREE_BTT022 board definition

### DIFF
--- a/buildroot/share/PlatformIO/boards/BigTree_Btt002.json
+++ b/buildroot/share/PlatformIO/boards/BigTree_Btt002.json
@@ -2,7 +2,7 @@
   "build": {
     "core": "stm32",
     "cpu": "cortex-m4",
-    "extra_flags": "-DSTM32F407xx",
+    "extra_flags": "-DSTM32F4 -DSTM32F407xx -DSTM32F40_41xxx",
     "f_cpu": "168000000L",
     "hwids": [
       [
@@ -21,34 +21,17 @@
   "debug": {
     "jlink_device": "STM32F407VE",
     "openocd_target": "stm32f4x",
-    "svd_path": "STM32F40x.svd",
-    "tools": {
-      "stlink": {
-        "server": {
-          "arguments": [
-            "-f",
-            "scripts/interface/stlink.cfg",
-            "-c",
-            "transport select hla_swd",
-            "-f",
-            "scripts/target/stm32f4x.cfg",
-            "-c",
-            "reset_config none"
-          ],
-          "executable": "bin/openocd",
-          "package": "tool-openocd"
-        }
-      }
-    }
+    "svd_path": "STM32F40x.svd"
   },
   "frameworks": [
     "arduino",
+    "cmsis",
     "stm32cube"
   ],
-  "name": "STM32F407VE (64k RAM. 512k Flash)",
+  "name": "STM32F407VE (192k RAM. 512k Flash)",
   "upload": {
     "disable_flushing": false,
-    "maximum_ram_size": 65536,
+    "maximum_ram_size": 131072,
     "maximum_size": 524288,
     "protocol": "stlink",
     "protocols": [
@@ -60,6 +43,6 @@
     "use_1200bps_touch": false,
     "wait_for_upload_port": false
   },
-  "url": "http://www.st.com/en/microcontrollers/stm32f407zg.html",
+  "url": "http://www.st.com/en/microcontrollers/stm32f407ve.html",
   "vendor": "Generic"
 }

--- a/buildroot/share/PlatformIO/variants/BIGTREE_GENERIC_STM32F407_5X/variant.h
+++ b/buildroot/share/PlatformIO/variants/BIGTREE_GENERIC_STM32F407_5X/variant.h
@@ -208,10 +208,6 @@ extern "C" {
   #define PI7   (115+STM32F4X_ADC_NUM) //1:TIM8_CH3
 #endif
 
-#ifdef HAL_GPIO_MODULE_ENABLED
-#error foo
-#endif
-
 
 // This must be a literal
 #define NUM_DIGITAL_PINS        (STM32F4X_GPIO_NUM)


### PR DESCRIPTION
### Description

Some remaining cleanup that I wanted to push to #15285.

### Benefits

* Corrects the metadata of the board (based on [this](http://www.st.com/en/microcontrollers/stm32f407ve.html)).
* Same cleanup can be performed on the `BIGTREE_BTT002` board that was applied to `BIGTREE_SKR_PRO`.
* Removes a small piece of 'debug' code that I left in the PlatformIO variant (sorry!)

### Related Issues

#15285 
