### PR TITLE
Allow EXTENSIBLE_UI to use JOYSTICK functionality

### DIFF
--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -36,6 +36,10 @@
 
 Joystick joystick;
 
+#if ENABLED(EXTENSIBLE_UI)
+  #include "../lcd/extensible_ui/ui_api.h"
+#endif
+
 #if HAS_JOY_ADC_X
   temp_info_t Joystick::x; // = { 0 }
 #endif
@@ -65,35 +69,37 @@ Joystick joystick;
   }
 #endif
 
-void Joystick::calculate(float norm_jog[XYZ]) {
-  // Do nothing if enable pin (active-low) is not LOW
-  #if HAS_JOY_ADC_EN
-    if (READ(JOY_EN_PIN)) return;
-  #endif
+#if HAS_JOY_ADC_X || HAS_JOY_ADC_Y || HAS_JOY_ADC_Z
+  void Joystick::calculate(float norm_jog[XYZ]) {
+    // Do nothing if enable pin (active-low) is not LOW
+    #if HAS_JOY_ADC_EN
+      if (READ(JOY_EN_PIN)) return;
+    #endif
 
-  auto _normalize_joy = [](float &adc, const int16_t raw, const int16_t (&joy_limits)[4]) {
-    if (WITHIN(raw, joy_limits[0], joy_limits[3])) {
-      // within limits, check deadzone
-      if (raw > joy_limits[2])
-        adc = (raw - joy_limits[2]) / float(joy_limits[3] - joy_limits[2]);
-      else if (raw < joy_limits[1])
-        adc = (raw - joy_limits[1]) / float(joy_limits[1] - joy_limits[0]);  // negative value
-    }
-  };
+    auto _normalize_joy = [](float &adc, const int16_t raw, const int16_t (&joy_limits)[4]) {
+      if (WITHIN(raw, joy_limits[0], joy_limits[3])) {
+        // within limits, check deadzone
+        if (raw > joy_limits[2])
+          adc = (raw - joy_limits[2]) / float(joy_limits[3] - joy_limits[2]);
+        else if (raw < joy_limits[1])
+          adc = (raw - joy_limits[1]) / float(joy_limits[1] - joy_limits[0]);  // negative value
+      }
+    };
 
-  #if HAS_JOY_ADC_X
-    static constexpr int16_t joy_x_limits[4] = JOY_X_LIMITS;
-    _normalize_joy(norm_jog[X_AXIS], x.raw, joy_x_limits);
-  #endif
-  #if HAS_JOY_ADC_Y
-    static constexpr int16_t joy_y_limits[4] = JOY_Y_LIMITS;
-    _normalize_joy(norm_jog[Y_AXIS], y.raw, joy_y_limits);
-  #endif
-  #if HAS_JOY_ADC_Z
-    static constexpr int16_t joy_z_limits[4] = JOY_Z_LIMITS;
-    _normalize_joy(norm_jog[Z_AXIS], z.raw, joy_z_limits);
-  #endif
-}
+    #if HAS_JOY_ADC_X
+      static constexpr int16_t joy_x_limits[4] = JOY_X_LIMITS;
+      _normalize_joy(norm_jog[X_AXIS], x.raw, joy_x_limits);
+    #endif
+    #if HAS_JOY_ADC_Y
+      static constexpr int16_t joy_y_limits[4] = JOY_Y_LIMITS;
+      _normalize_joy(norm_jog[Y_AXIS], y.raw, joy_y_limits);
+    #endif
+    #if HAS_JOY_ADC_Z
+      static constexpr int16_t joy_z_limits[4] = JOY_Z_LIMITS;
+      _normalize_joy(norm_jog[Z_AXIS], z.raw, joy_z_limits);
+    #endif
+  }
+#endif
 
 #if ENABLED(POLL_JOG)
 
@@ -122,10 +128,18 @@ void Joystick::calculate(float norm_jog[XYZ]) {
     float norm_jog[XYZ] = { 0 };
 
     // Use ADC values and defined limits. The active zone is normalized: -1..0 (dead) 0..1
-    joystick.calculate(norm_jog);
+    #if HAS_JOY_ADC_X || HAS_JOY_ADC_Y || HAS_JOY_ADC_Z
+      joystick.calculate(norm_jog);
+    #endif
 
     // Other non-joystick poll-based jogging could be implemented here
     // with "jogging" encapsulated as a more general class.
+
+    #if ENABLED(EXTENSIBLE_UI)
+      norm_jog[X_AXIS] = ExtUI::norm_jog[X_AXIS];
+      norm_jog[Y_AXIS] = ExtUI::norm_jog[Y_AXIS];
+      norm_jog[Z_AXIS] = ExtUI::norm_jog[Z_AXIS];
+    #endif
 
     // Jogging value maps continuously (quadratic relationship) to feedrate
     float move_dist[XYZ] = { 0 }, hypot2 = 0;

--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -70,7 +70,8 @@ Joystick joystick;
 #endif
 
 #if HAS_JOY_ADC_X || HAS_JOY_ADC_Y || HAS_JOY_ADC_Z
-  void Joystick::calculate(float norm_jog[XYZ]) {
+
+  void Joystick::calculate(float (&norm_jog)[XYZ]) {
     // Do nothing if enable pin (active-low) is not LOW
     #if HAS_JOY_ADC_EN
       if (READ(JOY_EN_PIN)) return;
@@ -99,6 +100,7 @@ Joystick joystick;
       _normalize_joy(norm_jog[Z_AXIS], z.raw, joy_z_limits);
     #endif
   }
+
 #endif
 
 #if ENABLED(POLL_JOG)

--- a/Marlin/src/feature/joystick.h
+++ b/Marlin/src/feature/joystick.h
@@ -46,7 +46,7 @@ class Joystick {
     #if ENABLED(JOYSTICK_DEBUG)
       static void report();
     #endif
-    static void calculate(float norm_jog[XYZ]);
+    static void calculate(float (&norm_jog)[XYZ]);
     static void inject_jog_moves();
 };
 

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/extended/event_loop.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/ftdi_eve_lib/extended/event_loop.cpp
@@ -156,9 +156,11 @@ namespace FTDI {
         if (!UIData::flags.bits.touch_debouncing) {
           if (tag == pressed_tag) {
             // The user is holding down a button.
-            if (touch_timer.elapsed(1000 / TOUCH_REPEATS_PER_SECOND) && current_screen.onTouchHeld(tag)) {
-              current_screen.onRefresh();
-              if (UIData::flags.bits.touch_repeat_sound) sound.play(repeat_sound);
+            if (touch_timer.elapsed(1000 / TOUCH_REPEATS_PER_SECOND)) {
+              if (current_screen.onTouchHeld(tag)) {
+                current_screen.onRefresh();
+                if (UIData::flags.bits.touch_repeat_sound) sound.play(repeat_sound);
+              }
               touch_timer.start();
             }
           }

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_confirm_home_e.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_confirm_home_e.cpp
@@ -36,13 +36,7 @@ void BioConfirmHomeE::onRedraw(draw_mode_t) {
 bool BioConfirmHomeE::onTouchEnd(uint8_t tag) {
   switch (tag) {
     case 1:
-      SpinnerDialogBox::enqueueAndWait_P(F(
-        "G112\n"                            /* Home extruder */
-        LULZBOT_AXIS_LEVELING_COMMANDS      /* Level X axis */
-        "G0 X115 Z50 F6000\n"               /* Goto loading position */
-        "M400\n"                            /* Wait for moves to finish */
-        "M18 X Y"                           /* Unlock motors */
-      ));
+      SpinnerDialogBox::enqueueAndWait_P(F(LULZBOT_HOME_E_COMMANDS));
       current_screen.forget();
       break;
     case 2:

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_confirm_home_xyz.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_confirm_home_xyz.cpp
@@ -36,10 +36,7 @@ void BioConfirmHomeXYZ::onRedraw(draw_mode_t) {
 bool BioConfirmHomeXYZ::onTouchEnd(uint8_t tag) {
   switch (tag) {
     case 1:
-      SpinnerDialogBox::enqueueAndWait_P(F(
-        "G28 X Y Z\n"             /* Home all axis */
-        "G0 X115 Z50 F6000"       /* Move to park position */
-      ));
+      SpinnerDialogBox::enqueueAndWait_P(F(LULZBOT_HOME_XYZ_COMMANDS));
       current_screen.forget();
       break;
     case 2:

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_printing_dialog_box.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/bio_printing_dialog_box.cpp
@@ -141,6 +141,7 @@ void BioPrintingDialogBox::setStatusMessage(const char* message) {
 }
 
 void BioPrintingDialogBox::onIdle() {
+  reset_menu_timeout();
   if (refresh_timer.elapsed(STATUS_UPDATE_INTERVAL)) {
     onRefresh();
     refresh_timer.start();

--- a/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/main_menu.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/lulzbot/screens/main_menu.cpp
@@ -69,7 +69,7 @@ void MainMenu::onRedraw(draw_mode_t what) {
     #else
       #define GRID_ROWS 5
       #define GRID_COLS 2
-        .tag(2).button( BTN_POS(1,1), BTN_SIZE(1,1), GET_TEXT(AUTO_HOME))
+        .tag(2).button( BTN_POS(1,1), BTN_SIZE(1,1), GET_TEXTF(AUTO_HOME))
         #if ENABLED(NOZZLE_CLEAN_FEATURE)
          .enabled(1)
         #else

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -102,12 +102,16 @@
   #include "../../feature/host_actions.h"
 #endif
 
-static struct {
-  uint8_t printer_killed  : 1;
-  uint8_t manual_motion : 1;
-} flags;
-
 namespace ExtUI {
+  static struct {
+    uint8_t printer_killed  : 1;
+    uint8_t manual_motion   : 1;
+  } flags;
+
+  #if ENABLED(JOYSTICK)
+    float norm_jog[XYZ];
+  #endif
+
   #ifdef __SAM3X8E__
     /**
      * Implement a special millis() to allow time measurement
@@ -190,6 +194,14 @@ namespace ExtUI {
       }
     #else
       UNUSED(heater);
+    #endif
+  }
+
+  void jog(float dx, float dy, float dz) {
+    #if ENABLED(JOYSTICK)
+      norm_jog[X] = dx;
+      norm_jog[Y] = dy;
+      norm_jog[Z] = dz;
     #endif
   }
 
@@ -1037,9 +1049,10 @@ void MarlinUI::update() {
 }
 
 void MarlinUI::kill_screen(PGM_P const msg) {
+  using namespace ExtUI;
   if (!flags.printer_killed) {
     flags.printer_killed = true;
-    ExtUI::onPrinterKilled(msg);
+    onPrinterKilled(msg);
   }
 }
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -45,6 +45,11 @@
 #include "../../inc/MarlinConfig.h"
 
 namespace ExtUI {
+
+  #if ENABLED(JOYSTICK)
+    extern float norm_jog[];
+  #endif
+
   // The ExtUI implementation can store up to this many bytes
   // in the EEPROM when the methods onStoreSettings and
   // onLoadSettings are called.
@@ -78,6 +83,8 @@ namespace ExtUI {
   bool isHeaterIdle(const extruder_t);
   void enableHeater(const heater_t);
   void enableHeater(const extruder_t);
+
+  void jog(float dx, float dy, float dz);
 
   /**
    * Getters and setters


### PR DESCRIPTION
Added methods to "ui_api.h" for accessing the new joystick functionality from within an EXTENSIBLE_UI. This allows a touchpad joystick to be implemented.

This PR also contains updates to LULZBOT_TOUCH_UI for our bio-printer:
   - Use new JOYSTICK code to jog the tool-head for smoother motion
   - Fix periodic glitch in print progress screen
   - Made startup homing scripts configurable