### PR TITLE
Fix BACKLASH_COMPENSATION compilation errors

### DIFF
--- a/Marlin/src/feature/backlash.h
+++ b/Marlin/src/feature/backlash.h
@@ -28,28 +28,21 @@ constexpr uint8_t all_on = 0xFF, all_off = 0x00;
 
 class Backlash {
 public:
-  #ifdef BACKLASH_DISTANCE_MM
-    #if ENABLED(BACKLASH_GCODE)
-      static float distance_mm[XYZ];
-    #else
-      static const float distance_mm[XYZ];
-      //static constexpr float distance_mm[XYZ] = BACKLASH_DISTANCE_MM; // compiler barks at this
-    #endif
-  #endif
   #if ENABLED(BACKLASH_GCODE)
+    static float distance_mm[XYZ];
     static uint8_t correction;
     #ifdef BACKLASH_SMOOTHING_MM
       static float smoothing_mm;
     #endif
+
     static inline void set_correction(const float &v) { correction = _MAX(0, _MIN(1.0, v)) * all_on; }
     static inline float get_correction() { return float(ui8_to_percent(correction)) / 100.0f; }
   #else
     static constexpr uint8_t correction = (BACKLASH_CORRECTION) * 0xFF;
+    static const float distance_mm[XYZ];
     #ifdef BACKLASH_SMOOTHING_MM
       static constexpr float smoothing_mm = BACKLASH_SMOOTHING_MM;
     #endif
-    static inline void set_correction(float) { }
-    static inline float get_correction() { return float(ui8_to_percent(correction)) / 100.0f; }
   #endif
 
   #if ENABLED(MEASURE_BACKLASH_WHEN_PROBING)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2324,8 +2324,16 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
   #endif
 #endif
 
-#if ENABLED(BACKLASH_COMPENSATION) && IS_CORE
-  #error "BACKLASH_COMPENSATION is incompatible with CORE kinematics."
+#if ENABLED(BACKLASH_COMPENSATION)
+  #if IS_CORE
+    #error "BACKLASH_COMPENSATION is incompatible with CORE kinematics."
+  #endif
+  #ifndef BACKLASH_DISTANCE_MM
+    #error "BACKLASH_COMPENSATION requires BACKLASH_DISTANCE_MM"
+  #endif
+  #ifndef BACKLASH_CORRECTION
+    #error "BACKLASH_COMPENSATION requires BACKLASH_CORRECTION"
+  #endif
 #endif
 
 #if ENABLED(GRADIENT_MIX) && MIXING_VIRTUAL_TOOLS < 2

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1189,17 +1189,14 @@ void MarlinSettings::postprocess() {
     // Backlash Compensation
     //
     {
-      #ifdef BACKLASH_DISTANCE_MM
+      #if ENABLED(BACKLASH_GCODE)
         const float (&backlash_distance_mm)[XYZ] = backlash.distance_mm;
-      #else
-        const float backlash_distance_mm[XYZ] = { 0 };
-      #endif
-      #if ENABLED(BACKLASH_COMPENSATION)
         const uint8_t &backlash_correction = backlash.correction;
       #else
+        const float backlash_distance_mm[XYZ] = { 0 };
         const uint8_t backlash_correction = 0;
       #endif
-      #ifdef BACKLASH_SMOOTHING_MM
+      #if ENABLED(BACKLASH_GCODE) && defined(BACKLASH_SMOOTHING_MM)
         const float &backlash_smoothing_mm = backlash.smoothing_mm;
       #else
         const float backlash_smoothing_mm = 3;
@@ -1992,17 +1989,14 @@ void MarlinSettings::postprocess() {
       // Backlash Compensation
       //
       {
-        #ifdef BACKLASH_DISTANCE_MM
+        #if ENABLED(BACKLASH_GCODE)
           float (&backlash_distance_mm)[XYZ] = backlash.distance_mm;
-        #else
-          float backlash_distance_mm[XYZ];
-        #endif
-        #if ENABLED(BACKLASH_COMPENSATION)
           uint8_t &backlash_correction = backlash.correction;
         #else
+          float backlash_distance_mm[XYZ];
           uint8_t backlash_correction;
         #endif
-        #ifdef BACKLASH_SMOOTHING_MM
+        #if ENABLED(BACKLASH_GCODE) && defined(BACKLASH_SMOOTHING_MM)
           float &backlash_smoothing_mm = backlash.smoothing_mm;
         #else
           float backlash_smoothing_mm;
@@ -2293,12 +2287,10 @@ void MarlinSettings::reset() {
 
   #if ENABLED(BACKLASH_GCODE)
     backlash.correction = (BACKLASH_CORRECTION) * 255;
-    #ifdef BACKLASH_DISTANCE_MM
-      constexpr float tmp[XYZ] = BACKLASH_DISTANCE_MM;
-      backlash.distance_mm[X_AXIS] = tmp[X_AXIS];
-      backlash.distance_mm[Y_AXIS] = tmp[Y_AXIS];
-      backlash.distance_mm[Z_AXIS] = tmp[Z_AXIS];
-    #endif
+    constexpr float tmp[XYZ] = BACKLASH_DISTANCE_MM;
+    backlash.distance_mm[X_AXIS] = tmp[X_AXIS];
+    backlash.distance_mm[Y_AXIS] = tmp[Y_AXIS];
+    backlash.distance_mm[Z_AXIS] = tmp[Z_AXIS];
     #ifdef BACKLASH_SMOOTHING_MM
       backlash.smoothing_mm = BACKLASH_SMOOTHING_MM;
     #endif


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Update configuration_store.cpp to allow BACKLASH_COMPENSATION without also enabling BACKLASH_GCODE. This previously failed because it wanted to write to const variables when BACKLASH_GCODE was disabled.

I also removed unnecessary checks for defined(BACKLASH_DISTANCE_MM), since it is already required for BACKLASH_COMPENSATION to work. I added corresponding checks to SanityCheck.h.

### Benefits

EEPROM_SETTINGS can be enabled with BACKLASH_COMPENSATION, without requiring BACKLASH_GCODE.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
#15250  - Marlin fails to compile will EEPROM_Settings enabled