### PR TITLE
Fix FILAMENT_RUNOUT_SCRIPT without ADVANCED_PAUSE_FEATURE build

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -102,7 +102,7 @@ class TFilamentMonitor : public FilamentMonitorBase {
         #if ENABLED(ADVANCED_PAUSE_FEATURE)
           || did_pause_print
         #endif
-        )) {
+      )) {
         #ifdef FILAMENT_RUNOUT_DISTANCE_MM
           cli(); // Prevent RunoutResponseDelayed::block_completed from accumulating here
         #endif

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -98,7 +98,11 @@ class TFilamentMonitor : public FilamentMonitorBase {
 
     // Give the response a chance to update its counter.
     static inline void run() {
-      if (enabled && !filament_ran_out && (IS_SD_PRINTING() || print_job_timer.isRunning() || did_pause_print)) {
+      if (enabled && !filament_ran_out && (IS_SD_PRINTING() || print_job_timer.isRunning()
+        #if ENABLED(ADVANCED_PAUSE_FEATURE)
+          || did_pause_print
+        #endif
+        )) {
         #ifdef FILAMENT_RUNOUT_DISTANCE_MM
           cli(); // Prevent RunoutResponseDelayed::block_completed from accumulating here
         #endif


### PR DESCRIPTION
### Description

FILAMENT_RUNOUT_SENSOR should only require ADVANCED_PAUSE_FEATURE when M600 is used in FILAMENT_RUNOUT_SCRIPT, according to existing sanity checks.

I have not tested this fix beyond compiling, as I don't have the hardware for it and the change is quite simple.

### Benefits

Fix the build when FILAMENT_RUNOUT_SCRIPT passes existing sanity checks, and ADVANCED_PAUSE_FEATURE is disabled.

### Related Issues

#15308 - Compile error with FILAMENT_RUNOUT_SENSOR enabled and ADVANCED_PAUSE_FEATURE disabled