### PR TITLE
Fix SCARA build from Arduino IDE

### DIFF
--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -260,11 +260,6 @@ void homeaxis(const AxisEnum axis);
  */
 
 #if IS_KINEMATIC // (DELTA or SCARA)
-
-  #if IS_SCARA
-    extern const float L1, L2;
-  #endif
-
   #if HAS_SCARA_OFFSET
     extern float scara_home_offset[ABC]; // A and B angular offsets, Z mm offset
   #endif


### PR DESCRIPTION
### Description

Delete redundant extern definition in motion.h. This built fine in PlatformIO, but in Arduino it failed due to a const/constexpr mismatch.

The constexpr is already included from scara.h, so there is no need to redefine it here.

### Benefits

Fix build from Arduino IDE.

### Related Issues

#14995 - SCARA will not compile in Bugfix 2.0
