### PR TITLE
Fix includes in RAMPS_DUO and RAMPS_SMART

### DIFF
--- a/Marlin/src/pins/sam/pins_RAMPS_DUO.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_DUO.h
@@ -50,7 +50,7 @@
 #define BOARD_INFO_NAME "RAMPS Duo"
 
 #define IS_RAMPS_DUO
-#include "pins_RAMPS.h"
+#include "../ramps/pins_RAMPS.h"
 
 //
 // Temperature Sensors

--- a/Marlin/src/pins/sam/pins_RAMPS_SMART.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_SMART.h
@@ -67,7 +67,7 @@
 #define BOARD_INFO_NAME "RAMPS-SMART"
 
 #define IS_RAMPS_SMART
-#include "pins_RAMPS.h"
+#include "../ramps/pins_RAMPS.h"
 
 // I2C EEPROM with 4K of space
 #define I2C_EEPROM


### PR DESCRIPTION
### Description

Fix include paths in RAMPS_DUO and RAMPS_SMART pins files.

### Benefits

Compiles when either of these boards are selected.

### Related Issues

#14569 Not the original cause of the issue, but I believe the issue is now fixed with this change.
