### PR TITLE
Fix build when using HOST_PROMPT_SUPPORT with G29_RETRY_AND_RECOVER

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -413,9 +413,6 @@ void disable_all_steppers() {
   }
 
   void event_probe_recover() {
-    #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_do(PROMPT_INFO, PSTR("G29 Retrying"));
-    #endif
     #ifdef ACTION_ON_G29_RECOVER
       host_action(PSTR(ACTION_ON_G29_RECOVER));
     #endif


### PR DESCRIPTION
### Description

Delete PROMPT_INFO usage that wasn't deleted when PROMPT_INFO was removed.

It seems that other usages of PROMPT_INFO were simply deleted, so I took the same approach here.

Earlier change which removed it everywhere else, with accompanying discussion.
#15210 

### Benefits

Fix build when combining HOST_PROMPT_SUPPORT with G29_RETRY_AND_RECOVER.

### Related Issues

#15322 
