### PR TITLE
Fix build with more than 2 Trinamic E steppers

### DIFF
--- a/Marlin/src/module/stepper/trinamic.h
+++ b/Marlin/src/module/stepper/trinamic.h
@@ -181,7 +181,7 @@ void reset_trinamic_drivers();
 
 // E2 Stepper
 #if AXIS_IS_TMC(E2)
-  extern TMC_CLASS_E(1) stepperE2;
+  extern TMC_CLASS_E(2) stepperE2;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E2)
     #define E2_ENABLE_INIT NOOP
     #define E2_ENABLE_WRITE(STATE) stepperE2.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
@@ -194,7 +194,7 @@ void reset_trinamic_drivers();
 
 // E3 Stepper
 #if AXIS_IS_TMC(E3)
-  extern TMC_CLASS_E(1) stepperE3;
+  extern TMC_CLASS_E(3) stepperE3;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E3)
     #define E3_ENABLE_INIT NOOP
     #define E3_ENABLE_WRITE(STATE) stepperE3.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
@@ -207,7 +207,7 @@ void reset_trinamic_drivers();
 
 // E4 Stepper
 #if AXIS_IS_TMC(E4)
-  extern TMC_CLASS_E(1) stepperE4;
+  extern TMC_CLASS_E(4) stepperE4;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E4)
     #define E4_ENABLE_INIT NOOP
     #define E4_ENABLE_WRITE(STATE) stepperE4.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
@@ -220,7 +220,7 @@ void reset_trinamic_drivers();
 
 // E5 Stepper
 #if AXIS_IS_TMC(E5)
-  extern TMC_CLASS_E(1) stepperE5;
+  extern TMC_CLASS_E(5) stepperE5;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E5)
     #define E5_ENABLE_INIT NOOP
     #define E5_ENABLE_WRITE(STATE) stepperE5.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)


### PR DESCRIPTION
### Description

Allows building with more than 2 Trinamic E steppers.

### Benefits

Eliminates the following build error (Config had 3 TMC2008 steppers specified)
```
Marlin\src\module\stepper\trinamic.cpp:53:84: error: conflicting declaration 'TMCMarlin<TMC2208Stepper, 'E', '2', (AxisEnum)3> stepperE2'
 #define TMC_UART_SW_DEFINE(IC, ST, L, AI) TMCMarlin<IC##Stepper, L, AI> stepper##ST(ST##_SERIAL_RX_PIN, ST##_SERIAL_TX_PIN, ST##_RSENSE, ST##_SLAVE_ADDRESS, ST##_SERIAL_RX_PIN > -1)
                                                                                    ^
Marlin\src\module\stepper\trinamic.cpp:58:44: note: in expansion of macro 'TMC_UART_SW_DEFINE'
 #define _TMC_UART_DEFINE(SWHW, IC, ST, AI) TMC_UART_##SWHW##_DEFINE(IC, ST, TMC_##ST##_LABEL, AI)
                                            ^~~~~~~~~
Marlin\src\module\stepper\trinamic.cpp:59:39: note: in expansion of macro '_TMC_UART_DEFINE'
 #define TMC_UART_DEFINE(SWHW, ST, AI) _TMC_UART_DEFINE(SWHW, ST##_DRIVER_TYPE, ST, AI##_AXIS)
                                       ^~~~~~~~~~~~~~~~
Marlin\src\module\stepper\trinamic.cpp:66:39: note: in expansion of macro 'TMC_UART_DEFINE'
   #define TMC_UART_DEFINE_E(SWHW, AI) TMC_UART_DEFINE(SWHW, E##AI, E)
                                       ^~~~~~~~~~~~~~~
Marlin\src\module\stepper\trinamic.cpp:266:7: note: in expansion of macro 'TMC_UART_DEFINE_E'
       TMC_UART_DEFINE_E(SW, 2);
       ^~~~~~~~~~~~~~~~~
In file included from Marlin\src\module\stepper\trinamic.cpp:32:0:
Marlin\src\module\stepper\trinamic.h:184:25: note: previous declaration as 'TMCMarlin<TMC2208Stepper, 'E', '1', (AxisEnum)3> stepperE2'
   extern TMC_CLASS_E(1) stepperE2;
                         ^~~~~~~~~
*** [.pio\build\BIGTREE_SKR_PRO\src\src\module\stepper\trinamic.cpp.o] Error 1
```

### Related Issues

This does not fix any open issues I could fine. The failing config came from the unrelated issue #15185.

