### PR TITLE
Fix 32-bit crash due to fwretract_settings_t pack(1)

### DIFF
--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -27,8 +27,6 @@
 
 #include "../inc/MarlinConfigPre.h"
 
-#pragma pack(push, 1) // No padding between fields
-
 typedef struct {
   float retract_length,                     // M207 S - G10 Retract length
         retract_feedrate_mm_s,              // M207 F - G10 Retract feedrate
@@ -39,8 +37,6 @@ typedef struct {
         swap_retract_recover_extra,         // M208 W - G11 Swap Recover length
         swap_retract_recover_feedrate_mm_s; // M208 R - G11 Swap Recover feedrate
 } fwretract_settings_t;
-
-#pragma pack(pop)
 
 #if ENABLED(FWRETRACT)
 


### PR DESCRIPTION
### Description

Remove pragma pack which resulted in unaligned float accesses on ARM boards. This caused Marlin to crash when editing any values inside this struct from the retract menu.

This wasn't a problem for the M207/M208 commands, probably because the compiler was inserting extra instructions to account for the misalignment.

The data size increases by a few bytes since the struct has to be aligned in memory. When I did a comparison for an SKR Pro I saw a 4 byte increase in data size, and a 56 byte decrease in program size. This should only come from padding outside the struct. The compiler has no reason to pad anywhere inside the struct, since everything is already a 4-byte type.

When I built for AVR there was no change in data or program size. I do not know if this would change if a configuration happened to align things differently, or if AVR always single-byte aligns everything.


### Benefits

Configuring retract options through the menu does not crash the controller.

### Related Issues

#15185 - Firmware Retract - crash when changing value via LCD