### PR TITLE
Disable PIO extra_scripts for AT90USB to prevent compile failure

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -88,7 +88,6 @@ build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-extra_scripts = pre:buildroot/share/atom/create_custom_upload_command_CDC.py
 monitor_speed = 250000
 
 #
@@ -105,7 +104,6 @@ build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-extra_scripts = pre:buildroot/share/atom/create_custom_upload_command_DFU.py
 monitor_speed = 250000
 
 #


### PR DESCRIPTION
PIO upload script `buildroot/share/atom/create_custom_upload_command_*.py` for Atom compatible environments are incompatible with latest PIO, causing compile failure (see Issue #15302 for more details).

Removing for now to prevent this non-essential function from preventing compile.

