### PR TITLE
Disable ARC_SUPPORT on Tevo Tornado

### DIFF
--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -1338,7 +1338,7 @@
 //
 // G2/G3 Arc Support
 //
-#define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
+//#define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
 #if ENABLED(ARC_SUPPORT)
   #define MM_PER_ARC_SEGMENT  1   // Length of each arc segment
   #define MIN_ARC_SEGMENTS   24   // Minimum number of segments in a complete circle

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -1338,7 +1338,7 @@
 //
 // G2/G3 Arc Support
 //
-//#define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
+//#define ARC_SUPPORT             // Disable this feature to save ~3226 bytes
 #if ENABLED(ARC_SUPPORT)
   #define MM_PER_ARC_SEGMENT  1   // Length of each arc segment
   #define MIN_ARC_SEGMENTS   24   // Minimum number of segments in a complete circle

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -1338,7 +1338,7 @@
 //
 // G2/G3 Arc Support
 //
-#define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
+//#define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
 #if ENABLED(ARC_SUPPORT)
   #define MM_PER_ARC_SEGMENT  1   // Length of each arc segment
   #define MIN_ARC_SEGMENTS   24   // Minimum number of segments in a complete circle

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -1338,7 +1338,7 @@
 //
 // G2/G3 Arc Support
 //
-//#define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
+//#define ARC_SUPPORT             // Disable this feature to save ~3226 bytes
 #if ENABLED(ARC_SUPPORT)
   #define MM_PER_ARC_SEGMENT  1   // Length of each arc segment
   #define MIN_ARC_SEGMENTS   24   // Minimum number of segments in a complete circle


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/issues/15357 suggest that #define ARC_SUPPORT is  waste to this pr simply disables it 

### Benefits

~3k of memory is saved

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/15357
