### PR TITLE
Init i2c for all i2c EEPROM use

### DIFF
--- a/Marlin/src/HAL/shared/eeprom_i2c.cpp
+++ b/Marlin/src/HAL/shared/eeprom_i2c.cpp
@@ -43,11 +43,7 @@ static uint8_t eeprom_device_address = 0x50;
 // ------------------------
 
 static void eeprom_init() {
-  static bool eeprom_initialized = false;
-  if (!eeprom_initialized) {
-    Wire.begin();
-    eeprom_initialized = true;
-  }
+  Wire.begin();
 }
 
 void eeprom_write_byte(uint8_t *pos, unsigned char value) {


### PR DESCRIPTION
Initialize Wire for every iteraction with EEPROM. This is needed
due to conflict with U8Glib, which has its own methods for I2C.

### Requirements

This pull request fixes compatibility issue when using both I2C LCD and I2C EEPROM

### Description

Initialize Wire for every interaction with EEPROM. This is needed
due to conflict with U8Glib, which has its own methods for I2C.

### Benefits

This fix allows to use both I2C LCD and I2C EEPROM

### Related Issues

Fixes bug #14695 
