### PR TITLE
Build fix for Servo libs of 32bit HAL

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/Servo.h
+++ b/Marlin/src/HAL/HAL_STM32/Servo.h
@@ -31,6 +31,7 @@ class libServo : public Servo {
     int8_t attach(const int pin, const int min, const int max);
     void move(const int value);
   private:
+    typedef Servo super;
     uint16_t min_ticks, max_ticks;
     uint8_t servoIndex;               // index into the channel data for this servo
 };

--- a/Marlin/src/HAL/HAL_STM32_F4_F7/Servo.h
+++ b/Marlin/src/HAL/HAL_STM32_F4_F7/Servo.h
@@ -35,6 +35,7 @@ class libServo : public Servo {
     int8_t attach(const int pin, const int min, const int max);
     void move(const int value);
   private:
+    typedef Servo super;
     uint16_t min_ticks, max_ticks;
     uint8_t servoIndex;               // index into the channel data for this servo
 };

--- a/Marlin/src/HAL/HAL_TEENSY31_32/Servo.h
+++ b/Marlin/src/HAL/HAL_TEENSY31_32/Servo.h
@@ -30,7 +30,8 @@ class libServo : public Servo {
     int8_t attach(const int pin, const int min, const int max);
     void move(const int value);
   private:
-     uint16_t min_ticks;
-     uint16_t max_ticks;
-     uint8_t servoIndex;               // index into the channel data for this servo
+    typedef Servo super;
+    uint16_t min_ticks;
+    uint16_t max_ticks;
+    uint8_t servoIndex;               // index into the channel data for this servo
 };

--- a/Marlin/src/HAL/HAL_TEENSY35_36/Servo.h
+++ b/Marlin/src/HAL/HAL_TEENSY35_36/Servo.h
@@ -30,7 +30,8 @@ class libServo : public Servo {
     int8_t attach(const int pin, const int min, const int max);
     void move(const int value);
   private:
-     uint16_t min_ticks;
-     uint16_t max_ticks;
-     uint8_t servoIndex; // Index into the channel data for this servo
+    typedef Servo super;
+    uint16_t min_ticks;
+    uint16_t max_ticks;
+    uint8_t servoIndex; // Index into the channel data for this servo
 };


### PR DESCRIPTION
### Description

Commit 0b4aedf13 broke compilation of serveral 32bit HALs, since "super" is used in their Servo libraries, which is not a defined keyword in C++.

This commit add a private typedef for the base class like printcounter.h uses, which fixes the issue
I also took the liberty to fix the indention in HAL_TEENSY_* header files...

Please note that I only compiled this for HAL_STM32, but given the simplicity of the patch, I am confident it will work for the other HALs.

### Benefits

Makes code compile with servos enabled... :)