### PR TITLE
Add reporting to M290

### DIFF
--- a/Marlin/src/feature/babystep.cpp
+++ b/Marlin/src/feature/babystep.cpp
@@ -37,12 +37,12 @@ Babystep babystep;
 
 volatile int16_t Babystep::steps[BS_TODO_AXIS(Z_AXIS) + 1];
 
-#if HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI)
-  int16_t Babystep::accum;
-  #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
-    int16_t Babystep::axis_total[BS_TOTAL_AXIS(Z_AXIS) + 1];
-  #endif
+
+int16_t Babystep::accum;
+#if ENABLED(BABYSTEP_DISPLAY_TOTAL)
+  int16_t Babystep::axis_total[BS_TOTAL_AXIS(Z_AXIS) + 1];
 #endif
+
 
 void Babystep::step_axis(const AxisEnum axis) {
   const int16_t curTodo = steps[BS_TODO_AXIS(axis)]; // get rid of volatile for performance
@@ -75,11 +75,9 @@ void Babystep::add_steps(const AxisEnum axis, const int16_t distance) {
 
   if (!CAN_BABYSTEP(axis)) return;
 
-  #if HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI)
-    accum += distance; // Count up babysteps for the UI
-    #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
-      axis_total[BS_TOTAL_AXIS(axis)] += distance;
-    #endif
+  accum += distance; // Count up babysteps for the UI
+  #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
+    axis_total[BS_TOTAL_AXIS(axis)] += distance;
   #endif
 
   #if ENABLED(BABYSTEP_ALWAYS_AVAILABLE)

--- a/Marlin/src/feature/babystep.cpp
+++ b/Marlin/src/feature/babystep.cpp
@@ -36,13 +36,10 @@
 Babystep babystep;
 
 volatile int16_t Babystep::steps[BS_TODO_AXIS(Z_AXIS) + 1];
-
-
-int16_t Babystep::accum;
 #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
   int16_t Babystep::axis_total[BS_TOTAL_AXIS(Z_AXIS) + 1];
 #endif
-
+int16_t Babystep::accum;
 
 void Babystep::step_axis(const AxisEnum axis) {
   const int16_t curTodo = steps[BS_TODO_AXIS(axis)]; // get rid of volatile for performance

--- a/Marlin/src/feature/babystep.h
+++ b/Marlin/src/feature/babystep.h
@@ -29,7 +29,7 @@
   #define BS_TODO_AXIS(A) 0
 #endif
 
-#if (HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI)) && ENABLED(BABYSTEP_DISPLAY_TOTAL)
+#if ENABLED(BABYSTEP_DISPLAY_TOTAL)
   #if ENABLED(BABYSTEP_XY)
     #define BS_TOTAL_AXIS(A) A
   #else
@@ -40,22 +40,17 @@
 class Babystep {
 public:
   static volatile int16_t steps[BS_TODO_AXIS(Z_AXIS) + 1];
+  static int16_t accum;                                     // Total babysteps in current edit
 
-  #if HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI)
-
-    static int16_t accum;                                     // Total babysteps in current edit
-
-    #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
-      static int16_t axis_total[BS_TOTAL_AXIS(Z_AXIS) + 1];   // Total babysteps since G28
-      static inline void reset_total(const AxisEnum axis) {
-        if (true
-          #if ENABLED(BABYSTEP_XY)
-            && axis == Z_AXIS
-          #endif
-        ) axis_total[BS_TOTAL_AXIS(axis)] = 0;
-      }
-    #endif
-
+  #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
+    static int16_t axis_total[BS_TOTAL_AXIS(Z_AXIS) + 1];   // Total babysteps since G28
+    static inline void reset_total(const AxisEnum axis) {
+      if (true
+        #if ENABLED(BABYSTEP_XY)
+          && axis == Z_AXIS
+        #endif
+      ) axis_total[BS_TOTAL_AXIS(axis)] = 0;
+    }
   #endif
 
   static void add_steps(const AxisEnum axis, const int16_t distance);

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -105,7 +105,7 @@ void GcodeSuite::M290() {
     #if ENABLED(MESH_BED_LEVELING)
       SERIAL_ECHOLNPAIR(MSG_Z_OFFSET ": ", mbl.z_offset);
     #endif
-    #if ENABLED(BABYSTEP_DISPLAY_TOTAL) && (HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI))
+    #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
       #if ENABLED(BABYSTEP_XY)
         SERIAL_ECHOLNPAIR(MSG_BABYSTEP_X ": ", babystep.axis_total[X_AXIS]);
         SERIAL_ECHOLNPAIR(MSG_BABYSTEP_Y ": ", babystep.axis_total[Y_AXIS]);

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -64,13 +64,15 @@
 /**
  * M290: Babystepping
  *
+ * Send 'R' or no parameters for a report.
+ *
  *  X<linear> - Distance to step X
  *  Y<linear> - Distance to step Y
  *  Z<linear> - Distance to step Z
  *  S<linear> - Distance to step Z (alias for Z)
  *
  * With BABYSTEP_ZPROBE_OFFSET:
- *         P0 - Don't adjust the Z probe offset.
+ *  P0 - Don't adjust the Z probe offset
  */
 void GcodeSuite::M290() {
   #if ENABLED(BABYSTEP_XY)
@@ -92,7 +94,7 @@ void GcodeSuite::M290() {
     }
   #endif
 
-  if (!parser.seen("XYZ")) {
+  if (!parser.seen("XYZ") || parser.seen('R')) {
     SERIAL_ECHO_START();
 
     #if ENABLED(BABYSTEP_ZPROBE_OFFSET)

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -34,6 +34,10 @@
   #include "../../core/serial.h"
 #endif
 
+#if ENABLED(MESH_BED_LEVELING)
+  #include "../../feature/bedlevel/bedlevel.h"
+#endif
+
 #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
 
   FORCE_INLINE void mod_zprobe_zoffset(const float &offs) {
@@ -87,6 +91,28 @@ void GcodeSuite::M290() {
       #endif
     }
   #endif
+
+  if (!parser.seen("XYZ")) {
+    SERIAL_ECHO_START();
+    #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
+      SERIAL_ECHOLNPAIR(MSG_PROBE_OFFSET MSG_Z ": ", probe_offset[Z_AXIS]);
+      #if ENABLED(BABYSTEP_XY)
+        SERIAL_ECHOLNPAIR(MSG_X_OFFSET ": ", hotend_offset[X_AXIS][active_extruder]);
+        SERIAL_ECHOLNPAIR(MSG_Y_OFFSET ": ", hotend_offset[Y_AXIS][active_extruder]);
+      #endif
+      SERIAL_ECHOLNPAIR(MSG_Z_OFFSET ": ", hotend_offset[Z_AXIS][active_extruder]);
+    #endif
+    #if ENABLED(MESH_BED_LEVELING)
+      SERIAL_ECHOLNPAIR(MSG_Z_OFFSET ": ", mbl.z_offset);
+    #endif
+    #if ENABLED(BABYSTEP_DISPLAY_TOTAL) && (HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI))
+      #if ENABLED(BABYSTEP_XY)
+        SERIAL_ECHOLNPAIR(MSG_BABYSTEP_X ": ", babystep.axis_total[X_AXIS]);
+        SERIAL_ECHOLNPAIR(MSG_BABYSTEP_Y ": ", babystep.axis_total[Y_AXIS]);
+      #endif
+      SERIAL_ECHOLNPAIR(MSG_BABYSTEP_Z ": ", babystep.axis_total[Z_AXIS]);
+    #endif
+  }
 }
 
 #endif // BABYSTEPPING

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -94,23 +94,37 @@ void GcodeSuite::M290() {
 
   if (!parser.seen("XYZ")) {
     SERIAL_ECHO_START();
+
+    #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
+      SERIAL_ECHOLNPAIR(MSG_PROBE_OFFSET " " MSG_Z, probe_offset[Z_AXIS]);
+    #endif
+
     #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
-      SERIAL_ECHOLNPAIR(MSG_PROBE_OFFSET MSG_Z ": ", probe_offset[Z_AXIS]);
-      #if ENABLED(BABYSTEP_XY)
-        SERIAL_ECHOLNPAIR(MSG_X_OFFSET ": ", hotend_offset[X_AXIS][active_extruder]);
-        SERIAL_ECHOLNPAIR(MSG_Y_OFFSET ": ", hotend_offset[Y_AXIS][active_extruder]);
-      #endif
-      SERIAL_ECHOLNPAIR(MSG_Z_OFFSET ": ", hotend_offset[Z_AXIS][active_extruder]);
+    {
+      SERIAL_ECHOLNPAIR("Hotend ", int(active_extruder), "Offset"
+        #if ENABLED(BABYSTEP_XY)
+          " X", hotend_offset[X_AXIS][active_extruder],
+          " Y", hotend_offset[Y_AXIS][active_extruder],
+        #endif
+        " Z", hotend_offset[Z_AXIS][active_extruder]
+      );
+    }
     #endif
+
     #if ENABLED(MESH_BED_LEVELING)
-      SERIAL_ECHOLNPAIR(MSG_Z_OFFSET ": ", mbl.z_offset);
+      SERIAL_ECHOLNPAIR("MBL Adjust Z", mbl.z_offset);
     #endif
+
     #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
-      #if ENABLED(BABYSTEP_XY)
-        SERIAL_ECHOLNPAIR(MSG_BABYSTEP_X ": ", babystep.axis_total[X_AXIS]);
-        SERIAL_ECHOLNPAIR(MSG_BABYSTEP_Y ": ", babystep.axis_total[Y_AXIS]);
-      #endif
-      SERIAL_ECHOLNPAIR(MSG_BABYSTEP_Z ": ", babystep.axis_total[Z_AXIS]);
+    {
+      SERIAL_ECHOLNPAIR("Babystep"
+        #if ENABLED(BABYSTEP_XY)
+          " X", babystep.axis_total[X_AXIS],
+          " Y", babystep.axis_total[Y_AXIS],
+        #endif
+        " Z", babystep.axis_total[Z_AXIS]
+      );
+    }
     #endif
   }
 }

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1370,7 +1370,7 @@ void set_axis_is_at_home(const AxisEnum axis) {
     I2CPEM.homed(axis);
   #endif
 
-  #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
+  #if ENABLED(BABYSTEP_DISPLAY_TOTAL) && (HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI))
     babystep.reset_total(axis);
   #endif
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1370,7 +1370,7 @@ void set_axis_is_at_home(const AxisEnum axis) {
     I2CPEM.homed(axis);
   #endif
 
-  #if ENABLED(BABYSTEP_DISPLAY_TOTAL) && (HAS_LCD_MENU || ENABLED(EXTENSIBLE_UI))
+  #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
     babystep.reset_total(axis);
   #endif
 


### PR DESCRIPTION
A user reported having no idea where he was babystepping over serial, so add reporting if there is a way to do so. 

Also fix a compile error when report total was enabled with no screen. Since we have a way to report it over serial now we can include those values when the option is set, even without a screen.