### PR TITLE
Keep C extension for now, restore (void) arg

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/usb/ctrl_access.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/ctrl_access.c
@@ -174,11 +174,11 @@ static xSemaphoreHandle ctrl_access_semphr = NULL;
 //! LUN descriptor table.
 static const struct
 {
-  Ctrl_status (*test_unit_ready)();
+  Ctrl_status (*test_unit_ready)(void);
   Ctrl_status (*read_capacity)(U32 *);
   bool (*unload)(bool);
-  bool (*wr_protect)();
-  bool (*removal)();
+  bool (*wr_protect)(void);
+  bool (*removal)(void);
 #if ACCESS_USB == true
   Ctrl_status (*usb_read_10)(U32, U16);
   Ctrl_status (*usb_write_10)(U32, U16);
@@ -255,7 +255,7 @@ bool g_wr_protect;
 
 #ifdef FREERTOS_USED
 
-bool ctrl_access_init()
+bool ctrl_access_init(void)
 {
   // If the handle to the protecting semaphore is not valid,
   if (!ctrl_access_semphr)
@@ -275,7 +275,7 @@ bool ctrl_access_init()
  *
  * \return \c true if the access was successfully locked, else \c false.
  */
-static bool ctrl_access_lock()
+static bool ctrl_access_lock(void)
 {
   // If the semaphore could not be created, there is no backup solution.
   if (!ctrl_access_semphr) return false;
@@ -289,7 +289,7 @@ static bool ctrl_access_lock()
 #endif  // FREERTOS_USED
 
 
-U8 get_nb_lun()
+U8 get_nb_lun(void)
 {
 #if MEM_USB == ENABLE
 #  ifndef Lun_usb_get_lun
@@ -310,7 +310,7 @@ U8 get_nb_lun()
 }
 
 
-U8 get_cur_lun()
+U8 get_cur_lun(void)
 {
   return LUN_ID_0;
 }

--- a/Marlin/src/HAL/HAL_DUE/usb/ctrl_access.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/ctrl_access.h
@@ -191,7 +191,7 @@ extern bool g_wr_protect;
  *
  * \return \c true if the locker was successfully initialized, else \c false.
  */
-extern bool ctrl_access_init();
+extern bool ctrl_access_init(void);
 
 #endif  // FREERTOS_USED
 
@@ -199,7 +199,7 @@ extern bool ctrl_access_init();
  *
  * \return Number of LUNs in the system.
  */
-extern U8 get_nb_lun();
+extern U8 get_nb_lun(void);
 
 /*! \brief Returns the current LUN.
  *
@@ -207,7 +207,7 @@ extern U8 get_nb_lun();
  *
  * \todo Implement.
  */
-extern U8 get_cur_lun();
+extern U8 get_cur_lun(void);
 
 /*! \brief Tests the memory state and initializes the memory if required.
  *

--- a/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/sd_mmc_spi_mem.h
@@ -78,7 +78,7 @@
 //!
 //! @brief This function initializes the hw/sw resources required to drive the SD_MMC_SPI.
 //!/
-extern void           sd_mmc_spi_mem_init();
+extern void           sd_mmc_spi_mem_init(void);
 
 //!
 //! @brief This function tests the state of the SD_MMC memory and sends it to the Host.
@@ -91,7 +91,7 @@ extern void           sd_mmc_spi_mem_init();
 //!   Media not present    ->    CTRL_NO_PRESENT
 //!   Media has changed    ->    CTRL_BUSY
 //!/
-extern Ctrl_status    sd_mmc_spi_test_unit_ready();
+extern Ctrl_status    sd_mmc_spi_test_unit_ready(void);
 
 //!
 //! @brief This function gives the address of the last valid sector.
@@ -124,14 +124,14 @@ extern bool sd_mmc_spi_unload(bool unload);
 //!
 //! @return false  -> the memory is not write-protected (always)
 //!/
-extern bool           sd_mmc_spi_wr_protect();
+extern bool           sd_mmc_spi_wr_protect(void);
 
 //!
 //! @brief This function tells if the memory has been removed or not.
 //!
 //! @return false  -> The memory isn't removed
 //!
-extern bool           sd_mmc_spi_removal();
+extern bool           sd_mmc_spi_removal(void);
 
 
 //---- ACCESS DATA FONCTIONS ----

--- a/Marlin/src/HAL/HAL_DUE/usb/sysclk.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/sysclk.c
@@ -71,7 +71,7 @@ extern "C" {
  * \param pll_id Source of the USB clock.
  * \param div Actual clock divisor. Must be superior to 0.
  */
-void sysclk_enable_usb()
+void sysclk_enable_usb(void)
 {
 	Assert(CONFIG_USBCLK_DIV > 0);
 
@@ -103,7 +103,7 @@ void sysclk_enable_usb()
  *
  * \note This implementation does not switch off the PLL, it just turns off the USB clock.
  */
-void sysclk_disable_usb()
+void sysclk_disable_usb(void)
 {
 	pmc_disable_udpck();
 }

--- a/Marlin/src/HAL/HAL_DUE/usb/sysclk.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/sysclk.h
@@ -213,8 +213,8 @@ extern "C" {
 #endif
 
 
-extern void sysclk_enable_usb();
-extern void sysclk_disable_usb();
+extern void sysclk_enable_usb(void);
+extern void sysclk_disable_usb(void);
 
 //! @}
 

--- a/Marlin/src/HAL/HAL_DUE/usb/udc.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/udc.c
@@ -132,14 +132,14 @@ static uint8_t udc_string_product_name[] = USB_DEVICE_PRODUCT_NAME;
  * define USB_DEVICE_GET_SERIAL_NAME_LENGTH.
  */
 #if defined USB_DEVICE_GET_SERIAL_NAME_POINTER
-	static const uint8_t *udc_get_string_serial_name()
+	static const uint8_t *udc_get_string_serial_name(void)
 	{
 		return (const uint8_t *)USB_DEVICE_GET_SERIAL_NAME_POINTER;
 	}
 #  define USB_DEVICE_SERIAL_NAME_SIZE \
 	USB_DEVICE_GET_SERIAL_NAME_LENGTH
 #elif defined USB_DEVICE_SERIAL_NAME
-	static const uint8_t *udc_get_string_serial_name()
+	static const uint8_t *udc_get_string_serial_name(void)
 	{
 		return (const uint8_t *)USB_DEVICE_SERIAL_NAME;
 	}
@@ -164,7 +164,7 @@ static UDC_DESC_STORAGE struct udc_string_desc_t udc_string_desc = {
 };
 //! @}
 
-usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc()
+usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc(void)
 {
 	return udc_ptr_iface;
 }
@@ -174,7 +174,7 @@ usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc()
  *
  * \return address after the last byte of USB Configuration descriptor
  */
-static usb_conf_desc_t UDC_DESC_STORAGE *udc_get_eof_conf()
+static usb_conf_desc_t UDC_DESC_STORAGE *udc_get_eof_conf(void)
 {
 	return (UDC_DESC_STORAGE usb_conf_desc_t *) ((uint8_t *)
 			udc_ptr_conf->desc +
@@ -360,14 +360,14 @@ static bool udc_iface_enable(uint8_t iface_num, uint8_t setting_num)
 
 /*! \brief Start the USB Device stack
  */
-void udc_start()
+void udc_start(void)
 {
 	udd_enable();
 }
 
 /*! \brief Stop the USB Device stack
  */
-void udc_stop()
+void udc_stop(void)
 {
 	udd_disable();
 	udc_reset();
@@ -377,7 +377,7 @@ void udc_stop()
  * \brief Reset the current configuration of the USB device,
  * This routines can be called by UDD when a RESET on the USB line occurs.
  */
-void udc_reset()
+void udc_reset(void)
 {
 	uint8_t iface_num;
 
@@ -404,7 +404,7 @@ void udc_reset()
 #endif
 }
 
-void udc_sof_notify()
+void udc_sof_notify(void)
 {
 	uint8_t iface_num;
 
@@ -424,7 +424,7 @@ void udc_sof_notify()
  *
  * \return true if success
  */
-static bool udc_req_std_dev_get_status()
+static bool udc_req_std_dev_get_status(void)
 {
 	if (udd_g_ctrlreq.req.wLength != sizeof(udc_device_status)) {
 		return false;
@@ -441,7 +441,7 @@ static bool udc_req_std_dev_get_status()
  *
  * \return true if success
  */
-static bool udc_req_std_ep_get_status()
+static bool udc_req_std_ep_get_status(void)
 {
 	static le16_t udc_ep_status;
 
@@ -463,7 +463,7 @@ static bool udc_req_std_ep_get_status()
  *
  * \return true if success
  */
-static bool udc_req_std_dev_clear_feature()
+static bool udc_req_std_dev_clear_feature(void)
 {
 	if (udd_g_ctrlreq.req.wLength) {
 		return false;
@@ -486,7 +486,7 @@ static bool udc_req_std_dev_clear_feature()
  *
  * \return true if success
  */
-static bool udc_req_std_ep_clear_feature()
+static bool udc_req_std_ep_clear_feature(void)
 {
 	if (udd_g_ctrlreq.req.wLength) {
 		return false;
@@ -504,7 +504,7 @@ static bool udc_req_std_ep_clear_feature()
  *
  * \return true if success
  */
-static bool udc_req_std_dev_set_feature()
+static bool udc_req_std_dev_set_feature(void)
 {
 	if (udd_g_ctrlreq.req.wLength) {
 		return false;
@@ -567,7 +567,7 @@ static bool udc_req_std_dev_set_feature()
  * \return true if success
  */
 #if (0!=USB_DEVICE_MAX_EP)
-static bool udc_req_std_ep_set_feature()
+static bool udc_req_std_ep_set_feature(void)
 {
 	if (udd_g_ctrlreq.req.wLength) {
 		return false;
@@ -584,7 +584,7 @@ static bool udc_req_std_ep_set_feature()
  * \brief Change the address of device
  * Callback called at the end of request set address
  */
-static void udc_valid_address()
+static void udc_valid_address(void)
 {
 	udd_set_address(udd_g_ctrlreq.req.wValue & 0x7F);
 }
@@ -594,7 +594,7 @@ static void udc_valid_address()
  *
  * \return true if success
  */
-static bool udc_req_std_dev_set_address()
+static bool udc_req_std_dev_set_address(void)
 {
 	if (udd_g_ctrlreq.req.wLength) {
 		return false;
@@ -611,7 +611,7 @@ static bool udc_req_std_dev_set_address()
  *
  * \return true if success
  */
-static bool udc_req_std_dev_get_str_desc()
+static bool udc_req_std_dev_get_str_desc(void)
 {
 	uint8_t i;
 	const uint8_t *str;
@@ -670,7 +670,7 @@ static bool udc_req_std_dev_get_str_desc()
  *
  * \return true if success
  */
-static bool udc_req_std_dev_get_descriptor()
+static bool udc_req_std_dev_get_descriptor(void)
 {
 	uint8_t conf_num;
 
@@ -787,7 +787,7 @@ static bool udc_req_std_dev_get_descriptor()
  *
  * \return true if success
  */
-static bool udc_req_std_dev_get_configuration()
+static bool udc_req_std_dev_get_configuration(void)
 {
 	if (udd_g_ctrlreq.req.wLength != 1) {
 		return false;
@@ -802,7 +802,7 @@ static bool udc_req_std_dev_get_configuration()
  *
  * \return true if success
  */
-static bool udc_req_std_dev_set_configuration()
+static bool udc_req_std_dev_set_configuration(void)
 {
 	uint8_t iface_num;
 
@@ -867,7 +867,7 @@ static bool udc_req_std_dev_set_configuration()
  *
  * \return true if success
  */
-static bool udc_req_std_iface_get_setting()
+static bool udc_req_std_iface_get_setting(void)
 {
 	uint8_t iface_num;
 	udi_api_t UDC_DESC_STORAGE *udi_api;
@@ -905,7 +905,7 @@ static bool udc_req_std_iface_get_setting()
  *
  * \return true if success
  */
-static bool udc_req_std_iface_set_setting()
+static bool udc_req_std_iface_set_setting(void)
 {
 	uint8_t iface_num, setting_num;
 
@@ -933,7 +933,7 @@ static bool udc_req_std_iface_set_setting()
  *
  * \return true if the request is supported
  */
-static bool udc_reqstd()
+static bool udc_reqstd(void)
 {
 	if (Udd_setup_is_in()) {
 		// GET Standard Requests
@@ -1027,7 +1027,7 @@ static bool udc_reqstd()
  *
  * \return true if the request is supported
  */
-static bool udc_req_iface()
+static bool udc_req_iface(void)
 {
 	uint8_t iface_num;
 	udi_api_t UDC_DESC_STORAGE *udi_api;
@@ -1062,7 +1062,7 @@ static bool udc_req_iface()
  *
  * \return true if the request is supported
  */
-static bool udc_req_ep()
+static bool udc_req_ep(void)
 {
 	uint8_t iface_num;
 	udi_api_t UDC_DESC_STORAGE *udi_api;
@@ -1101,7 +1101,7 @@ static bool udc_req_ep()
  *
  * \return true if the request is supported, else the request is stalled by UDD
  */
-bool udc_process_setup()
+bool udc_process_setup(void)
 {
 	// By default no data (receive/send) and no callbacks registered
 	udd_g_ctrlreq.payload_size = 0;

--- a/Marlin/src/HAL/HAL_DUE/usb/udc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udc.h
@@ -172,18 +172,18 @@ extern "C" {
 	}
 \endcode
  */
-static inline bool udc_include_vbus_monitoring()
+static inline bool udc_include_vbus_monitoring(void)
 {
 	return udd_include_vbus_monitoring();
 }
 
 /*! \brief Start the USB Device stack
  */
-void udc_start();
+void udc_start(void);
 
 /*! \brief Stop the USB Device stack
  */
-void udc_stop();
+void udc_stop(void);
 
 /**
  * \brief Attach device to the bus when possible
@@ -192,7 +192,7 @@ void udc_stop();
  * then it will attach device when an acceptable Vbus
  * level from the host is detected.
  */
-static inline void udc_attach()
+static inline void udc_attach(void)
 {
 	udd_attach();
 }
@@ -203,7 +203,7 @@ static inline void udc_attach()
  *
  * The driver must remove pull-up on USB line D- or D+.
  */
-static inline void udc_detach()
+static inline void udc_detach(void)
 {
 	udd_detach();
 }
@@ -212,7 +212,7 @@ static inline void udc_detach()
 /*! \brief The USB driver sends a resume signal called \e "Upstream Resume"
  * This is authorized only when the remote wakeup feature is enabled by host.
  */
-static inline void udc_remotewakeup()
+static inline void udc_remotewakeup(void)
 {
 	udd_send_remotewakeup();
 }
@@ -223,7 +223,7 @@ static inline void udc_remotewakeup()
  *
  * \return pointer on the current interface descriptor.
  */
-usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc();
+usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc(void);
 
 //@}
 
@@ -334,7 +334,7 @@ usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc();
  *
  * Add to application C-file:
  * \code
-	void usb_init()
+	void usb_init(void)
 	{
 	  udc_start();
 	}
@@ -551,23 +551,23 @@ usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc();
 	#define  USB_DEVICE_ATTR \
 	  (USB_CONFIG_ATTR_REMOTE_WAKEUP | USB_CONFIG_ATTR_..._POWERED)
 	#define UDC_REMOTEWAKEUP_ENABLE() my_callback_remotewakeup_enable()
-	extern void my_callback_remotewakeup_enable();
+	extern void my_callback_remotewakeup_enable(void);
 	#define UDC_REMOTEWAKEUP_DISABLE() my_callback_remotewakeup_disable()
-	extern void my_callback_remotewakeup_disable();
+	extern void my_callback_remotewakeup_disable(void);
 \endcode
  *
  * Add to application C-file:
  * \code
-	 void my_callback_remotewakeup_enable()
+	 void my_callback_remotewakeup_enable(void)
 	 {
 	    // Enable application wakeup events (e.g. enable GPIO interrupt)
 	 }
-	 void my_callback_remotewakeup_disable()
+	 void my_callback_remotewakeup_disable(void)
 	 {
 	    // Disable application wakeup events (e.g. disable GPIO interrupt)
 	 }
 
-	 void my_interrupt_event()
+	 void my_interrupt_event(void)
 	 {
 	    udc_remotewakeup();
 	 }
@@ -580,10 +580,10 @@ usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc();
 	     #define  USB_DEVICE_ATTR (USB_CONFIG_ATTR_REMOTE_WAKEUP | USB_CONFIG_ATTR_..._POWERED) \endcode
  *   - \code // Define callback called when the host enables the remotewakeup feature
 	#define UDC_REMOTEWAKEUP_ENABLE() my_callback_remotewakeup_enable()
-	extern void my_callback_remotewakeup_enable(); \endcode
+	extern void my_callback_remotewakeup_enable(void); \endcode
  *   - \code // Define callback called when the host disables the remotewakeup feature
 	#define UDC_REMOTEWAKEUP_DISABLE() my_callback_remotewakeup_disable()
-	extern void my_callback_remotewakeup_disable(); \endcode
+	extern void my_callback_remotewakeup_disable(void); \endcode
  * -# Send a remote wakeup (USB upstream):
  *   - \code udc_remotewakeup(); \endcode
  */
@@ -605,18 +605,18 @@ usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc();
  * \code
 	#define  USB_DEVICE_ATTR (USB_CONFIG_ATTR_BUS_POWERED)
 	#define  UDC_SUSPEND_EVENT()         user_callback_suspend_action()
-	extern void user_callback_suspend_action()
+	extern void user_callback_suspend_action(void)
 	#define  UDC_RESUME_EVENT()          user_callback_resume_action()
-	extern void user_callback_resume_action()
+	extern void user_callback_resume_action(void)
 \endcode
  *
  * Add to application C-file:
  * \code
-	void user_callback_suspend_action()
+	void user_callback_suspend_action(void)
 	{
 	   // Disable hardware component to reduce power consumption
 	}
-	void user_callback_resume_action()
+	void user_callback_resume_action(void)
 	{
 	   // Re-enable hardware component
 	}
@@ -628,12 +628,12 @@ usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc();
 	#define  USB_DEVICE_ATTR (USB_CONFIG_ATTR_BUS_POWERED) \endcode
  *   - \code // Define callback called when the host suspend the USB line
 	#define UDC_SUSPEND_EVENT() user_callback_suspend_action()
-	extern void user_callback_suspend_action(); \endcode
+	extern void user_callback_suspend_action(void); \endcode
  *   - \code // Define callback called when the host or device resume the USB line
 	#define UDC_RESUME_EVENT() user_callback_resume_action()
-	extern void user_callback_resume_action(); \endcode
+	extern void user_callback_resume_action(void); \endcode
  * -# Reduce power consumption in suspend mode (max. 2.5mA on Vbus):
- *   - \code void user_callback_suspend_action()
+ *   - \code void user_callback_suspend_action(void)
 	{
 	turn_off_components();
 	} \endcode
@@ -664,7 +664,7 @@ usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc();
  * \code
 	 uint8_t serial_number[USB_DEVICE_GET_SERIAL_NAME_LENGTH];
 
-	 void init_build_usb_serial_number()
+	 void init_build_usb_serial_number(void)
 	 {
 	 serial_number[0] = 'A';
 	 serial_number[1] = 'B';
@@ -683,7 +683,7 @@ usb_iface_desc_t UDC_DESC_STORAGE *udc_get_interface_desc();
  *   - \code
 	 uint8_t serial_number[USB_DEVICE_GET_SERIAL_NAME_LENGTH];
 
-	 void init_build_usb_serial_number()
+	 void init_build_usb_serial_number(void)
 	 {
 	 serial_number[0] = 'A';
 	 serial_number[1] = 'B';

--- a/Marlin/src/HAL/HAL_DUE/usb/udd.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udd.h
@@ -94,11 +94,11 @@ typedef struct {
 	uint16_t payload_size;
 
 	//! Callback called after reception of ZLP from setup request
-	void (*callback)();
+	void (*callback)(void);
 
 	//! Callback called when the buffer given (.payload) is full or empty.
 	//! This one return false to abort data transfer, or true with a new buffer in .payload.
-	bool (*over_under_run)();
+	bool (*over_under_run)(void);
 } udd_ctrl_request_t;
 extern udd_ctrl_request_t udd_g_ctrlreq;
 
@@ -123,7 +123,7 @@ extern udd_ctrl_request_t udd_g_ctrlreq;
  * Registered by routine udd_ep_wait_stall_clear()
  * Callback called when endpoint stall is cleared.
  */
-typedef void (*udd_callback_halt_cleared_t)();
+typedef void (*udd_callback_halt_cleared_t)(void);
 
 /**
  * \brief End of transfer callback function type.
@@ -142,17 +142,17 @@ typedef void (*udd_callback_trans_t) (udd_ep_status_t status,
  *
  * \return true, if the VBUS monitoring is possible.
  */
-bool udd_include_vbus_monitoring();
+bool udd_include_vbus_monitoring(void);
 
 /**
  * \brief Enables the USB Device mode
  */
-void udd_enable();
+void udd_enable(void);
 
 /**
  * \brief Disables the USB Device mode
  */
-void udd_disable();
+void udd_disable(void);
 
 /**
  * \brief Attach device to the bus when possible
@@ -161,14 +161,14 @@ void udd_disable();
  * then it will attach device when an acceptable Vbus
  * level from the host is detected.
  */
-void udd_attach();
+void udd_attach(void);
 
 /**
  * \brief Detaches the device from the bus
  *
  * The driver must remove pull-up on USB line D- or D+.
  */
-void udd_detach();
+void udd_detach(void);
 
 /**
  * \brief Test whether the USB Device Controller is running at high
@@ -176,7 +176,7 @@ void udd_detach();
  *
  * \return \c true if the Device is running at high speed mode, otherwise \c false.
  */
-bool udd_is_high_speed();
+bool udd_is_high_speed(void);
 
 /**
  * \brief Changes the USB address of device
@@ -190,25 +190,25 @@ void udd_set_address(uint8_t address);
  *
  * \return USB address
  */
-uint8_t udd_getaddress();
+uint8_t udd_getaddress(void);
 
 /**
  * \brief Returns the current start of frame number
  *
  * \return current start of frame number.
  */
-uint16_t udd_get_frame_number();
+uint16_t udd_get_frame_number(void);
 
 /**
  * \brief Returns the current micro start of frame number
  *
  * \return current micro start of frame number required in high speed mode.
  */
-uint16_t udd_get_micro_frame_number();
+uint16_t udd_get_micro_frame_number(void);
 
 /*! \brief The USB driver sends a resume signal called Upstream Resume
  */
-void udd_send_remotewakeup();
+void udd_send_remotewakeup(void);
 
 /**
  * \brief Load setup payload
@@ -346,10 +346,10 @@ void udd_ep_abort(udd_ep_id_t ep);
  * The following functions allow the device to jump to a specific test mode required in high speed mode.
  */
 //@{
-void udd_test_mode_j();
-void udd_test_mode_k();
-void udd_test_mode_se0_nak();
-void udd_test_mode_packet();
+void udd_test_mode_j(void);
+void udd_test_mode_k(void);
+void udd_test_mode_se0_nak(void);
+void udd_test_mode_packet(void);
 //@}
 
 
@@ -370,21 +370,21 @@ void udd_test_mode_packet();
  *
  * \return \c 1 if the request is accepted, otherwise \c 0.
  */
-extern bool udc_process_setup();
+extern bool udc_process_setup(void);
 
 /**
  * \brief Reset the UDC
  *
  * The UDC must reset all configuration.
  */
-extern void udc_reset();
+extern void udc_reset(void);
 
 /**
  * \brief To signal that a SOF is occurred
  *
  * The UDC must send the signal to all UDIs enabled
  */
-extern void udc_sof_notify();
+extern void udc_sof_notify(void);
 
 //@}
 

--- a/Marlin/src/HAL/HAL_DUE/usb/udi.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi.h
@@ -82,7 +82,7 @@ typedef struct {
 	 *
 	 * \return \c 1 if function was successfully done, otherwise \c 0.
 	 */
-	bool (*enable)();
+	bool (*enable)(void);
 
 	/**
 	 * \brief Disable the interface.
@@ -95,7 +95,7 @@ typedef struct {
 	 * - the device is detached from the host (i.e. Vbus is no
 	 *   longer present)
 	 */
-	void (*disable)();
+	void (*disable)(void);
 
 	/**
 	 * \brief Handle a control request directed at an interface.
@@ -108,7 +108,7 @@ typedef struct {
 	 *
 	 * \return \c 1 if this interface supports the SETUP request, otherwise \c 0.
 	 */
-	bool (*setup)();
+	bool (*setup)(void);
 
 	/**
 	 * \brief Returns the current setting of the selected interface.
@@ -117,12 +117,12 @@ typedef struct {
 	 *
 	 * \return alternate setting of selected interface
 	 */
-	uint8_t (*getsetting)();
+	uint8_t (*getsetting)(void);
 
 	/**
 	 * \brief To signal that a SOF is occurred
 	 */
-	void (*sof_notify)();
+	void (*sof_notify)(void);
 } udi_api_t;
 
 //@}

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.c
@@ -84,14 +84,14 @@
  *
  * @{
  */
-bool udi_cdc_comm_enable();
-void udi_cdc_comm_disable();
-bool udi_cdc_comm_setup();
-bool udi_cdc_data_enable();
-void udi_cdc_data_disable();
-bool udi_cdc_data_setup();
-uint8_t udi_cdc_getsetting();
-void udi_cdc_data_sof_notify();
+bool udi_cdc_comm_enable(void);
+void udi_cdc_comm_disable(void);
+bool udi_cdc_comm_setup(void);
+bool udi_cdc_data_enable(void);
+void udi_cdc_data_disable(void);
+bool udi_cdc_data_setup(void);
+uint8_t udi_cdc_getsetting(void);
+void udi_cdc_data_sof_notify(void);
 UDC_DESC_STORAGE udi_api_t udi_api_cdc_comm = {
 	.enable = udi_cdc_comm_enable,
 	.disable = udi_cdc_comm_disable,
@@ -130,14 +130,14 @@ UDC_DESC_STORAGE udi_api_t udi_api_cdc_data = {
  *
  * \return port number
  */
-static uint8_t udi_cdc_setup_to_port();
+static uint8_t udi_cdc_setup_to_port(void);
 
 /**
  * \brief Sends line coding to application
  *
  * Called after SETUP request when line coding data is received.
  */
-static void udi_cdc_line_coding_received();
+static void udi_cdc_line_coding_received(void);
 
 /**
  * \brief Records new state
@@ -267,7 +267,7 @@ static volatile bool udi_cdc_tx_both_buf_to_send[UDI_CDC_PORT_NB];
 
 //@}
 
-bool udi_cdc_comm_enable()
+bool udi_cdc_comm_enable(void)
 {
 	uint8_t port;
 	uint8_t iface_comm_num;
@@ -321,7 +321,7 @@ bool udi_cdc_comm_enable()
 	return true;
 }
 
-bool udi_cdc_data_enable()
+bool udi_cdc_data_enable(void)
 {
 	uint8_t port;
 
@@ -360,13 +360,13 @@ bool udi_cdc_data_enable()
 	return true;
 }
 
-void udi_cdc_comm_disable()
+void udi_cdc_comm_disable(void)
 {
 	Assert(udi_cdc_nb_comm_enabled != 0);
 	udi_cdc_nb_comm_enabled--;
 }
 
-void udi_cdc_data_disable()
+void udi_cdc_data_disable(void)
 {
 	uint8_t port;
 
@@ -377,7 +377,7 @@ void udi_cdc_data_disable()
 	udi_cdc_data_running = false;
 }
 
-bool udi_cdc_comm_setup()
+bool udi_cdc_comm_setup(void)
 {
 	uint8_t port = udi_cdc_setup_to_port();
 
@@ -433,17 +433,17 @@ bool udi_cdc_comm_setup()
 	return false;  // request Not supported
 }
 
-bool udi_cdc_data_setup()
+bool udi_cdc_data_setup(void)
 {
 	return false;  // request Not supported
 }
 
-uint8_t udi_cdc_getsetting()
+uint8_t udi_cdc_getsetting(void)
 {
 	return 0;      // CDC don't have multiple alternate setting
 }
 
-void udi_cdc_data_sof_notify()
+void udi_cdc_data_sof_notify(void)
 {
 	static uint8_t port_notify = 0;
 
@@ -461,7 +461,7 @@ void udi_cdc_data_sof_notify()
 // ------------------------
 //------- Internal routines to control serial line
 
-static uint8_t udi_cdc_setup_to_port()
+static uint8_t udi_cdc_setup_to_port(void)
 {
 	uint8_t port;
 
@@ -479,7 +479,7 @@ static uint8_t udi_cdc_setup_to_port()
 	return port;
 }
 
-static void udi_cdc_line_coding_received()
+static void udi_cdc_line_coding_received(void)
 {
 	uint8_t port = udi_cdc_setup_to_port();
 	UNUSED(port);
@@ -797,17 +797,17 @@ void udi_cdc_ctrl_signal_dsr(bool b_set)
 	udi_cdc_ctrl_state_change(0, b_set, CDC_SERIAL_STATE_DSR);
 }
 
-void udi_cdc_signal_framing_error()
+void udi_cdc_signal_framing_error(void)
 {
 	udi_cdc_ctrl_state_change(0, true, CDC_SERIAL_STATE_FRAMING);
 }
 
-void udi_cdc_signal_parity_error()
+void udi_cdc_signal_parity_error(void)
 {
 	udi_cdc_ctrl_state_change(0, true, CDC_SERIAL_STATE_PARITY);
 }
 
-void udi_cdc_signal_overrun()
+void udi_cdc_signal_overrun(void)
 {
 	udi_cdc_ctrl_state_change(0, true, CDC_SERIAL_STATE_OVERRUN);
 }
@@ -853,7 +853,7 @@ iram_size_t udi_cdc_multi_get_nb_received_data(uint8_t port)
 	return nb_received;
 }
 
-iram_size_t udi_cdc_get_nb_received_data()
+iram_size_t udi_cdc_get_nb_received_data(void)
 {
 	return udi_cdc_multi_get_nb_received_data(0);
 }
@@ -863,7 +863,7 @@ bool udi_cdc_multi_is_rx_ready(uint8_t port)
 	return (udi_cdc_multi_get_nb_received_data(port) > 0);
 }
 
-bool udi_cdc_is_rx_ready()
+bool udi_cdc_is_rx_ready(void)
 {
 	return udi_cdc_multi_is_rx_ready(0);
 }
@@ -912,7 +912,7 @@ udi_cdc_getc_process_one_byte:
 	return rx_data;
 }
 
-int udi_cdc_getc()
+int udi_cdc_getc(void)
 {
 	return udi_cdc_multi_getc(0);
 }
@@ -1041,7 +1041,7 @@ iram_size_t __attribute__((optimize("O0"))) udi_cdc_multi_get_free_tx_buffer(uin
 	return retval;
 }
 
-iram_size_t udi_cdc_get_free_tx_buffer()
+iram_size_t udi_cdc_get_free_tx_buffer(void)
 {
 	return udi_cdc_multi_get_free_tx_buffer(0);
 }
@@ -1051,7 +1051,7 @@ bool udi_cdc_multi_is_tx_ready(uint8_t port)
 	return (udi_cdc_multi_get_free_tx_buffer(port) != 0);
 }
 
-bool udi_cdc_is_tx_ready()
+bool udi_cdc_is_tx_ready(void)
 {
 	return udi_cdc_multi_is_tx_ready(0);
 }

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_cdc.h
@@ -366,38 +366,38 @@ void udi_cdc_ctrl_signal_dsr(bool b_set);
 /**
  * \brief Notify a framing error
  */
-void udi_cdc_signal_framing_error();
+void udi_cdc_signal_framing_error(void);
 
 /**
  * \brief Notify a parity error
  */
-void udi_cdc_signal_parity_error();
+void udi_cdc_signal_parity_error(void);
 
 /**
  * \brief Notify a overrun
  */
-void udi_cdc_signal_overrun();
+void udi_cdc_signal_overrun(void);
 
 /**
  * \brief Gets the number of byte received
  *
  * \return the number of data available
  */
-iram_size_t udi_cdc_get_nb_received_data();
+iram_size_t udi_cdc_get_nb_received_data(void);
 
 /**
  * \brief This function checks if a character has been received on the CDC line
  *
  * \return \c 1 if a byte is ready to be read.
  */
-bool udi_cdc_is_rx_ready();
+bool udi_cdc_is_rx_ready(void);
 
 /**
  * \brief Waits and gets a value on CDC line
  *
  * \return value read on CDC line
  */
-int udi_cdc_getc();
+int udi_cdc_getc(void);
 
 /**
  * \brief Reads a RAM buffer on CDC line
@@ -425,7 +425,7 @@ iram_size_t udi_cdc_read_no_polling(void* buf, iram_size_t size);
  *
  * \return the number of free byte in TX buffer
  */
-iram_size_t udi_cdc_get_free_tx_buffer();
+iram_size_t udi_cdc_get_free_tx_buffer(void);
 
 /**
  * \brief This function checks if a new character sent is possible
@@ -433,7 +433,7 @@ iram_size_t udi_cdc_get_free_tx_buffer();
  *
  * \return \c 1 if a new character can be sent
  */
-bool udi_cdc_is_tx_ready();
+bool udi_cdc_is_tx_ready(void);
 
 /**
  * \brief Puts a byte on CDC line
@@ -611,9 +611,9 @@ iram_size_t udi_cdc_multi_write_buf(uint8_t port, const void* buf, iram_size_t s
  * Content of conf_usb.h:
  * \code
 	 #define UDI_CDC_ENABLE_EXT(port) my_callback_cdc_enable()
-	 extern bool my_callback_cdc_enable();
+	 extern bool my_callback_cdc_enable(void);
 	 #define UDI_CDC_DISABLE_EXT(port) my_callback_cdc_disable()
-	 extern void my_callback_cdc_disable();
+	 extern void my_callback_cdc_disable(void);
 	 #define  UDI_CDC_LOW_RATE
 
 	 #define  UDI_CDC_DEFAULT_RATE             115200
@@ -627,17 +627,17 @@ iram_size_t udi_cdc_multi_write_buf(uint8_t port, const void* buf, iram_size_t s
  * Add to application C-file:
  * \code
 	 static bool my_flag_autorize_cdc_transfert = false;
-	 bool my_callback_cdc_enable()
+	 bool my_callback_cdc_enable(void)
 	 {
 	    my_flag_autorize_cdc_transfert = true;
 	    return true;
 	 }
-	 void my_callback_cdc_disable()
+	 void my_callback_cdc_disable(void)
 	 {
 	    my_flag_autorize_cdc_transfert = false;
 	 }
 
-	 void task()
+	 void task(void)
 	 {
 	    if (my_flag_autorize_cdc_transfert) {
 	        udi_cdc_putc('A');
@@ -652,14 +652,14 @@ iram_size_t udi_cdc_multi_write_buf(uint8_t port, const void* buf, iram_size_t s
  *   - \code #define USB_DEVICE_SERIAL_NAME  "12...EF" // Disk SN for CDC \endcode
  *     \note The USB serial number is mandatory when a CDC interface is used.
  *   - \code #define UDI_CDC_ENABLE_EXT(port) my_callback_cdc_enable()
-	 extern bool my_callback_cdc_enable(); \endcode
+	 extern bool my_callback_cdc_enable(void); \endcode
  *     \note After the device enumeration (detecting and identifying USB devices),
  *     the USB host starts the device configuration. When the USB CDC interface
  *     from the device is accepted by the host, the USB host enables this interface and the
  *     UDI_CDC_ENABLE_EXT() callback function is called and return true.
  *     Thus, when this event is received, the data transfer on CDC interface are authorized.
  *   - \code #define UDI_CDC_DISABLE_EXT(port) my_callback_cdc_disable()
-	 extern void my_callback_cdc_disable(); \endcode
+	 extern void my_callback_cdc_disable(void); \endcode
  *     \note When the USB device is unplugged or is reset by the USB host, the USB
  *     interface is disabled and the UDI_CDC_DISABLE_EXT() callback function
  *     is called. Thus, the data transfer must be stopped on CDC interface.
@@ -673,7 +673,7 @@ iram_size_t udi_cdc_multi_write_buf(uint8_t port, const void* buf, iram_size_t s
  *     \note Default configuration of communication port at startup.
  * -# Send or wait data on CDC line:
  *   - \code // Waits and gets a value on CDC line
-	int udi_cdc_getc();
+	int udi_cdc_getc(void);
 	// Reads a RAM buffer on CDC line
 	iram_size_t udi_cdc_read_buf(int* buf, iram_size_t size);
 	// Puts a byte on CDC line

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_msc.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_msc.c
@@ -71,10 +71,10 @@
  *
  * @{
  */
-bool udi_msc_enable();
-void udi_msc_disable();
-bool udi_msc_setup();
-uint8_t udi_msc_getsetting();
+bool udi_msc_enable(void);
+void udi_msc_disable(void);
+bool udi_msc_setup(void);
+uint8_t udi_msc_getsetting(void);
 
 //! Global structure which contains standard UDI API for UDC
 UDC_DESC_STORAGE udi_api_t udi_api_msc = {
@@ -151,12 +151,12 @@ volatile bool udi_msc_b_reset_trans = true;
 /**
  * \brief Stall CBW request
  */
-static void udi_msc_cbw_invalid();
+static void udi_msc_cbw_invalid(void);
 
 /**
  * \brief Stall CSW request
  */
-static void udi_msc_csw_invalid();
+static void udi_msc_csw_invalid(void);
 
 /**
  * \brief Links a callback and buffer on endpoint OUT reception
@@ -165,7 +165,7 @@ static void udi_msc_csw_invalid();
  * - enable interface
  * - at the end of previous command after sending the CSW
  */
-static void udi_msc_cbw_wait();
+static void udi_msc_cbw_wait(void);
 
 /**
  * \brief Callback called after CBW reception
@@ -228,7 +228,7 @@ static void udi_msc_data_sent(udd_ep_status_t status, iram_size_t nb_sent,
  *
  * Called at the end of SCSI command
  */
-static void udi_msc_csw_process();
+static void udi_msc_csw_process(void);
 
 /**
  * \brief Sends CSW
@@ -236,7 +236,7 @@ static void udi_msc_csw_process();
  * Called by #udi_msc_csw_process()
  * or UDD callback when endpoint halt is cleared
  */
-void udi_msc_csw_send();
+void udi_msc_csw_send(void);
 
 /**
  * \brief Callback called after CSW sent
@@ -259,7 +259,7 @@ static void udi_msc_csw_sent(udd_ep_status_t status, iram_size_t nb_sent,
 /**
  * \brief Reinitialize sense data.
  */
-static void udi_msc_clear_sense();
+static void udi_msc_clear_sense(void);
 
 /**
  * \brief Update sense data with new value to signal a fail
@@ -274,37 +274,37 @@ static void udi_msc_sense_fail(uint8_t sense_key, uint16_t add_sense,
 /**
  * \brief Update sense data with new value to signal success
  */
-static void udi_msc_sense_pass();
+static void udi_msc_sense_pass(void);
 
 /**
  * \brief Update sense data to signal that memory is not present
  */
-static void udi_msc_sense_fail_not_present();
+static void udi_msc_sense_fail_not_present(void);
 
 /**
  * \brief Update sense data to signal that memory is busy
  */
-static void udi_msc_sense_fail_busy_or_change();
+static void udi_msc_sense_fail_busy_or_change(void);
 
 /**
  * \brief Update sense data to signal a hardware error on memory
  */
-static void udi_msc_sense_fail_hardware();
+static void udi_msc_sense_fail_hardware(void);
 
 /**
  * \brief Update sense data to signal that memory is protected
  */
-static void udi_msc_sense_fail_protected();
+static void udi_msc_sense_fail_protected(void);
 
 /**
  * \brief Update sense data to signal that CDB fields are not valid
  */
-static void udi_msc_sense_fail_cdb_invalid();
+static void udi_msc_sense_fail_cdb_invalid(void);
 
 /**
  * \brief Update sense data to signal that command is not supported
  */
-static void udi_msc_sense_command_invalid();
+static void udi_msc_sense_command_invalid(void);
 //@}
 
 
@@ -317,31 +317,31 @@ static void udi_msc_sense_command_invalid();
  * \brief Process SPC Request Sense command
  * Returns error information about last command
  */
-static void udi_msc_spc_requestsense();
+static void udi_msc_spc_requestsense(void);
 
 /**
  * \brief Process SPC Inquiry command
  * Returns information (name,version) about disk
  */
-static void udi_msc_spc_inquiry();
+static void udi_msc_spc_inquiry(void);
 
 /**
  * \brief Checks state of disk
  *
  * \retval true if disk is ready, otherwise false and updates sense data
  */
-static bool udi_msc_spc_testunitready_global();
+static bool udi_msc_spc_testunitready_global(void);
 
 /**
  * \brief Process test unit ready command
  * Returns state of logical unit
  */
-static void udi_msc_spc_testunitready();
+static void udi_msc_spc_testunitready(void);
 
 /**
  * \brief Process prevent allow medium removal command
  */
-static void udi_msc_spc_prevent_allow_medium_removal();
+static void udi_msc_spc_prevent_allow_medium_removal(void);
 
 /**
  * \brief Process mode sense command
@@ -354,12 +354,12 @@ static void udi_msc_spc_mode_sense(bool b_sense10);
 /**
  * \brief Process start stop command
  */
-static void udi_msc_sbc_start_stop();
+static void udi_msc_sbc_start_stop(void);
 
 /**
  * \brief Process read capacity command
  */
-static void udi_msc_sbc_read_capacity();
+static void udi_msc_sbc_read_capacity(void);
 
 /**
  * \brief Process read10 or write10 command
@@ -373,7 +373,7 @@ static void udi_msc_sbc_trans(bool b_read);
 //@}
 
 
-bool udi_msc_enable()
+bool udi_msc_enable(void)
 {
   uint8_t lun;
   udi_msc_b_trans_req = false;
@@ -398,7 +398,7 @@ bool udi_msc_enable()
 }
 
 
-void udi_msc_disable()
+void udi_msc_disable(void)
 {
   udi_msc_b_trans_req = false;
   udi_msc_b_ack_trans = true;
@@ -407,7 +407,7 @@ void udi_msc_disable()
 }
 
 
-bool udi_msc_setup()
+bool udi_msc_setup(void)
 {
   if (Udd_setup_is_in()) {
     // Requests Interface GET
@@ -451,7 +451,7 @@ bool udi_msc_setup()
   return false; // Not supported request
 }
 
-uint8_t udi_msc_getsetting()
+uint8_t udi_msc_getsetting(void)
 {
   return 0; // MSC don't have multiple alternate setting
 }
@@ -460,7 +460,7 @@ uint8_t udi_msc_getsetting()
 // ------------------------
 //------- Routines to process CBW packet
 
-static void udi_msc_cbw_invalid()
+static void udi_msc_cbw_invalid(void)
 {
   if (!udi_msc_b_cbw_invalid)
     return; // Don't re-stall endpoint if error reseted by setup
@@ -469,7 +469,7 @@ static void udi_msc_cbw_invalid()
   udd_ep_wait_stall_clear(UDI_MSC_EP_OUT, udi_msc_cbw_invalid);
 }
 
-static void udi_msc_csw_invalid()
+static void udi_msc_csw_invalid(void)
 {
   if (!udi_msc_b_cbw_invalid)
     return; // Don't re-stall endpoint if error reseted by setup
@@ -478,7 +478,7 @@ static void udi_msc_csw_invalid()
   udd_ep_wait_stall_clear(UDI_MSC_EP_IN, udi_msc_csw_invalid);
 }
 
-static void udi_msc_cbw_wait()
+static void udi_msc_cbw_wait(void)
 {
   // Register buffer and callback on OUT endpoint
   if (!udd_ep_run(UDI_MSC_EP_OUT, true,
@@ -648,7 +648,7 @@ static void udi_msc_data_sent(udd_ep_status_t status, iram_size_t nb_sent,
 // ------------------------
 //------- Routines to process CSW packet
 
-static void udi_msc_csw_process()
+static void udi_msc_csw_process(void)
 {
   if (0 != udi_msc_csw.dCSWDataResidue) {
     // Residue not NULL
@@ -665,7 +665,7 @@ static void udi_msc_csw_process()
 }
 
 
-void udi_msc_csw_send()
+void udi_msc_csw_send(void)
 {
   // Sends CSW on IN endpoint
   if (!udd_ep_run(UDI_MSC_EP_IN, false,
@@ -694,7 +694,7 @@ static void udi_msc_csw_sent(udd_ep_status_t status, iram_size_t nb_sent,
 // ------------------------
 //------- Routines manage sense data
 
-static void udi_msc_clear_sense()
+static void udi_msc_clear_sense(void)
 {
   memset((uint8_t*)&udi_msc_sense, 0, sizeof(struct scsi_request_sense_data));
   udi_msc_sense.valid_reponse_code = SCSI_SENSE_VALID | SCSI_SENSE_CURRENT;
@@ -715,42 +715,42 @@ static void udi_msc_sense_fail(uint8_t sense_key, uint16_t add_sense,
   udi_msc_sense.AddSnsCodeQlfr = add_sense;
 }
 
-static void udi_msc_sense_pass()
+static void udi_msc_sense_pass(void)
 {
   udi_msc_clear_sense();
   udi_msc_csw.bCSWStatus = USB_CSW_STATUS_PASS;
 }
 
 
-static void udi_msc_sense_fail_not_present()
+static void udi_msc_sense_fail_not_present(void)
 {
   udi_msc_sense_fail(SCSI_SK_NOT_READY, SCSI_ASC_MEDIUM_NOT_PRESENT, 0);
 }
 
-static void udi_msc_sense_fail_busy_or_change()
+static void udi_msc_sense_fail_busy_or_change(void)
 {
   udi_msc_sense_fail(SCSI_SK_UNIT_ATTENTION,
       SCSI_ASC_NOT_READY_TO_READY_CHANGE, 0);
 }
 
-static void udi_msc_sense_fail_hardware()
+static void udi_msc_sense_fail_hardware(void)
 {
   udi_msc_sense_fail(SCSI_SK_HARDWARE_ERROR,
       SCSI_ASC_NO_ADDITIONAL_SENSE_INFO, 0);
 }
 
-static void udi_msc_sense_fail_protected()
+static void udi_msc_sense_fail_protected(void)
 {
   udi_msc_sense_fail(SCSI_SK_DATA_PROTECT, SCSI_ASC_WRITE_PROTECTED, 0);
 }
 
-static void udi_msc_sense_fail_cdb_invalid()
+static void udi_msc_sense_fail_cdb_invalid(void)
 {
   udi_msc_sense_fail(SCSI_SK_ILLEGAL_REQUEST,
       SCSI_ASC_INVALID_FIELD_IN_CDB, 0);
 }
 
-static void udi_msc_sense_command_invalid()
+static void udi_msc_sense_command_invalid(void)
 {
   udi_msc_sense_fail(SCSI_SK_ILLEGAL_REQUEST,
       SCSI_ASC_INVALID_COMMAND_OPERATION_CODE, 0);
@@ -760,7 +760,7 @@ static void udi_msc_sense_command_invalid()
 // ------------------------
 //------- Routines manage SCSI Commands
 
-static void udi_msc_spc_requestsense()
+static void udi_msc_spc_requestsense(void)
 {
   uint8_t length = udi_msc_cbw.CDB[4];
 
@@ -775,7 +775,7 @@ static void udi_msc_spc_requestsense()
 }
 
 
-static void udi_msc_spc_inquiry()
+static void udi_msc_spc_inquiry(void)
 {
   uint8_t length, i;
   UDC_DATA(4)
@@ -836,7 +836,7 @@ static void udi_msc_spc_inquiry()
 }
 
 
-static bool udi_msc_spc_testunitready_global()
+static bool udi_msc_spc_testunitready_global(void)
 {
   switch (mem_test_unit_ready(udi_msc_cbw.bCBWLUN)) {
   case CTRL_GOOD:
@@ -856,7 +856,7 @@ static bool udi_msc_spc_testunitready_global()
 }
 
 
-static void udi_msc_spc_testunitready()
+static void udi_msc_spc_testunitready(void)
 {
   if (udi_msc_spc_testunitready_global()) {
     // LUN ready, then update sense data with status pass
@@ -944,7 +944,7 @@ static void udi_msc_spc_mode_sense(bool b_sense10)
 }
 
 
-static void udi_msc_spc_prevent_allow_medium_removal()
+static void udi_msc_spc_prevent_allow_medium_removal(void)
 {
   uint8_t prevent = udi_msc_cbw.CDB[4];
   if (0 == prevent) {
@@ -956,7 +956,7 @@ static void udi_msc_spc_prevent_allow_medium_removal()
 }
 
 
-static void udi_msc_sbc_start_stop()
+static void udi_msc_sbc_start_stop(void)
 {
   bool start = 0x1 & udi_msc_cbw.CDB[4];
   bool loej = 0x2 & udi_msc_cbw.CDB[4];
@@ -968,7 +968,7 @@ static void udi_msc_sbc_start_stop()
 }
 
 
-static void udi_msc_sbc_read_capacity()
+static void udi_msc_sbc_read_capacity(void)
 {
   UDC_BSS(4) static struct sbc_read_capacity10_data udi_msc_capacity;
 
@@ -1039,7 +1039,7 @@ static void udi_msc_sbc_trans(bool b_read)
 }
 
 
-bool udi_msc_process_trans()
+bool udi_msc_process_trans(void)
 {
   Ctrl_status status;
 

--- a/Marlin/src/HAL/HAL_DUE/usb/udi_msc.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/udi_msc.h
@@ -148,7 +148,7 @@ typedef struct {
  *
  * Routine called by the main loop
  */
-bool udi_msc_process_trans();
+bool udi_msc_process_trans(void);
 
 /**
  * \brief Transfers data to/from USB MSC endpoints
@@ -206,26 +206,26 @@ bool udi_msc_trans_block(bool b_read, uint8_t * block, iram_size_t block_size,
 	#define UDI_MSC_GLOBAL_PRODUCT_VERSION \
 	   '1', '.', '0', '0'
 	#define UDI_MSC_ENABLE_EXT() my_callback_msc_enable()
-	extern bool my_callback_msc_enable();
+	extern bool my_callback_msc_enable(void);
 	#define UDI_MSC_DISABLE_EXT() my_callback_msc_disable()
-	extern void my_callback_msc_disable();
+	extern void my_callback_msc_disable(void);
 	#include "udi_msc_conf.h" // At the end of conf_usb.h file
 \endcode
  *
  * Add to application C-file:
  * \code
 	 static bool my_flag_autorize_msc_transfert = false;
-	 bool my_callback_msc_enable()
+	 bool my_callback_msc_enable(void)
 	 {
 	    my_flag_autorize_msc_transfert = true;
 	    return true;
 	 }
-	 void my_callback_msc_disable()
+	 void my_callback_msc_disable(void)
 	 {
 	    my_flag_autorize_msc_transfert = false;
 	 }
 
-	 void task()
+	 void task(void)
 	 {
 	    udi_msc_process_trans();
 	 }
@@ -244,7 +244,7 @@ bool udi_msc_trans_block(bool b_read, uint8_t * block, iram_size_t block_size,
  *     \note The USB MSC interface requires a vendor ID (8 ASCII characters)
  *     and a product version (4 ASCII characters).
  *   - \code #define UDI_MSC_ENABLE_EXT() my_callback_msc_enable()
-	extern bool my_callback_msc_enable(); \endcode
+	extern bool my_callback_msc_enable(void); \endcode
  *     \note After the device enumeration (detecting and identifying USB devices),
  *     the USB host starts the device configuration. When the USB MSC interface
  *     from the device is accepted by the host, the USB host enables this interface and the
@@ -252,7 +252,7 @@ bool udi_msc_trans_block(bool b_read, uint8_t * block, iram_size_t block_size,
  *     Thus, when this event is received, the tasks which call
  *     udi_msc_process_trans() must be enabled.
  *   - \code #define UDI_MSC_DISABLE_EXT() my_callback_msc_disable()
-	extern void my_callback_msc_disable(); \endcode
+	extern void my_callback_msc_disable(void); \endcode
  *     \note When the USB device is unplugged or is reset by the USB host, the USB
  *     interface is disabled and the UDI_MSC_DISABLE_EXT() callback function
  *     is called. Thus, it is recommended to disable the task which is called udi_msc_process_trans().
@@ -260,14 +260,14 @@ bool udi_msc_trans_block(bool b_read, uint8_t * block, iram_size_t block_size,
  * which provides the memories interfaces. However, the memory data transfers
  * must be done outside USB interrupt routine. This is done in the MSC process
  * ("udi_msc_process_trans()") called by main loop:
- *   - \code  * void task() {
+ *   - \code  * void task(void) {
 	udi_msc_process_trans();
 	} \endcode
  * -# The MSC speed depends on task periodicity. To get the best speed
  * the notification callback "UDI_MSC_NOTIFY_TRANS_EXT" can be used to wakeup
  * this task (Example, through a mutex):
  *   - \code #define  UDI_MSC_NOTIFY_TRANS_EXT()    msc_notify_trans()
-	void msc_notify_trans() {
+	void msc_notify_trans(void) {
 	wakeup_my_task();
 	} \endcode
  *

--- a/Marlin/src/HAL/HAL_DUE/usb/uotghs_device_due.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/uotghs_device_due.c
@@ -357,41 +357,41 @@ static uint16_t udd_ctrl_payload_buf_cnt;
  *
  * Called after a USB line reset or when UDD is enabled
  */
-static void udd_reset_ep_ctrl();
+static void udd_reset_ep_ctrl(void);
 
 /**
  * \brief Reset control endpoint management
  *
  * Called after a USB line reset or at the end of SETUP request (after ZLP)
  */
-static void udd_ctrl_init();
+static void udd_ctrl_init(void);
 
 //! \brief Managed reception of SETUP packet on control endpoint
-static void udd_ctrl_setup_received();
+static void udd_ctrl_setup_received(void);
 
 //! \brief Managed reception of IN packet on control endpoint
-static void udd_ctrl_in_sent();
+static void udd_ctrl_in_sent(void);
 
 //! \brief Managed reception of OUT packet on control endpoint
-static void udd_ctrl_out_received();
+static void udd_ctrl_out_received(void);
 
 //! \brief Managed underflow event of IN packet on control endpoint
-static void udd_ctrl_underflow();
+static void udd_ctrl_underflow(void);
 
 //! \brief Managed overflow event of OUT packet on control endpoint
-static void udd_ctrl_overflow();
+static void udd_ctrl_overflow(void);
 
 //! \brief Managed stall event of IN/OUT packet on control endpoint
-static void udd_ctrl_stall_data();
+static void udd_ctrl_stall_data(void);
 
 //! \brief Send a ZLP IN on control endpoint
-static void udd_ctrl_send_zlp_in();
+static void udd_ctrl_send_zlp_in(void);
 
 //! \brief Send a ZLP OUT on control endpoint
-static void udd_ctrl_send_zlp_out();
+static void udd_ctrl_send_zlp_out(void);
 
 //! \brief Call callback associated to setup request
-static void udd_ctrl_endofrequest();
+static void udd_ctrl_endofrequest(void);
 
 
 /**
@@ -401,7 +401,7 @@ static void udd_ctrl_endofrequest();
  *
  * \return \c 1 if an event about control endpoint is occured, otherwise \c 0.
  */
-static bool udd_ctrl_interrupt();
+static bool udd_ctrl_interrupt(void);
 
 //@}
 
@@ -448,10 +448,10 @@ typedef struct {
 static udd_ep_job_t udd_ep_job[USB_DEVICE_MAX_EP];
 
 //! \brief Reset all job table
-static void udd_ep_job_table_reset();
+static void udd_ep_job_table_reset(void);
 
 //! \brief Abort all endpoint jobs on going
-static void udd_ep_job_table_kill();
+static void udd_ep_job_table_kill(void);
 
 #ifdef UDD_EP_FIFO_SUPPORTED
 	/**
@@ -500,7 +500,7 @@ static void udd_ep_finish_job(udd_ep_job_t * ptr_job, bool b_abort, uint8_t ep_n
  *
  * \return \c 1 if an event about bulk/interrupt/isochronous endpoints has occured, otherwise \c 0.
  */
-static bool udd_ep_interrupt();
+static bool udd_ep_interrupt(void);
 
 #endif // (0!=USB_DEVICE_MAX_EP)
 //@}
@@ -524,8 +524,8 @@ static bool udd_ep_interrupt();
  * See Technical reference $3.8.3 Masking interrupt requests in peripheral modules.
  */
 #ifdef UHD_ENABLE
-void udd_interrupt();
-void udd_interrupt()
+void udd_interrupt(void);
+void udd_interrupt(void)
 #else
 ISR(UDD_USB_INT_FUN)
 #endif
@@ -643,13 +643,13 @@ udd_interrupt_sof_end:
 }
 
 
-bool udd_include_vbus_monitoring()
+bool udd_include_vbus_monitoring(void)
 {
 	return true;
 }
 
 
-void udd_enable()
+void udd_enable(void)
 {
 	irqflags_t flags;
 
@@ -736,7 +736,7 @@ void udd_enable()
 }
 
 
-void udd_disable()
+void udd_disable(void)
 {
 	irqflags_t flags;
 
@@ -777,7 +777,7 @@ void udd_disable()
 }
 
 
-void udd_attach()
+void udd_attach(void)
 {
 	irqflags_t flags;
 	flags = cpu_irq_save();
@@ -818,7 +818,7 @@ void udd_attach()
 }
 
 
-void udd_detach()
+void udd_detach(void)
 {
 	otg_unfreeze_clock();
 
@@ -829,7 +829,7 @@ void udd_detach()
 }
 
 
-bool udd_is_high_speed()
+bool udd_is_high_speed(void)
 {
 #ifdef USB_DEVICE_HS_SUPPORT
 	return !Is_udd_full_speed_mode();
@@ -847,23 +847,23 @@ void udd_set_address(uint8_t address)
 }
 
 
-uint8_t udd_getaddress()
+uint8_t udd_getaddress(void)
 {
 	return udd_get_configured_address();
 }
 
 
-uint16_t udd_get_frame_number()
+uint16_t udd_get_frame_number(void)
 {
 	return udd_frame_number();
 }
 
-uint16_t udd_get_micro_frame_number()
+uint16_t udd_get_micro_frame_number(void)
 {
 	return udd_micro_frame_number();
 }
 
-void udd_send_remotewakeup()
+void udd_send_remotewakeup(void)
 {
 #ifndef UDD_NO_SLEEP_MGR
 	if (!udd_b_idle)
@@ -1242,27 +1242,27 @@ bool udd_ep_wait_stall_clear(udd_ep_id_t ep,
 
 #ifdef USB_DEVICE_HS_SUPPORT
 
-void udd_test_mode_j()
+void udd_test_mode_j(void)
 {
 	udd_enable_hs_test_mode();
 	udd_enable_hs_test_mode_j();
 }
 
 
-void udd_test_mode_k()
+void udd_test_mode_k(void)
 {
 	udd_enable_hs_test_mode();
 	udd_enable_hs_test_mode_k();
 }
 
 
-void udd_test_mode_se0_nak()
+void udd_test_mode_se0_nak(void)
 {
 	udd_enable_hs_test_mode();
 }
 
 
-void udd_test_mode_packet()
+void udd_test_mode_packet(void)
 {
 	uint8_t i;
 	uint8_t *ptr_dest;
@@ -1310,7 +1310,7 @@ void udd_test_mode_packet()
 // ------------------------
 //--- INTERNAL ROUTINES TO MANAGED THE CONTROL ENDPOINT
 
-static void udd_reset_ep_ctrl()
+static void udd_reset_ep_ctrl(void)
 {
 	irqflags_t flags;
 
@@ -1334,7 +1334,7 @@ static void udd_reset_ep_ctrl()
 	cpu_irq_restore(flags);
 }
 
-static void udd_ctrl_init()
+static void udd_ctrl_init(void)
 {
 	irqflags_t flags;
 	flags = cpu_irq_save();
@@ -1357,7 +1357,7 @@ static void udd_ctrl_init()
 }
 
 
-static void udd_ctrl_setup_received()
+static void udd_ctrl_setup_received(void)
 {
 	irqflags_t flags;
 	uint8_t i;
@@ -1419,7 +1419,7 @@ static void udd_ctrl_setup_received()
 }
 
 
-static void udd_ctrl_in_sent()
+static void udd_ctrl_in_sent(void)
 {
 	static bool b_shortpacket = false;
 	uint16_t nb_remain;
@@ -1503,7 +1503,7 @@ static void udd_ctrl_in_sent()
 }
 
 
-static void udd_ctrl_out_received()
+static void udd_ctrl_out_received(void)
 {
 	irqflags_t flags;
 	uint8_t i;
@@ -1594,7 +1594,7 @@ static void udd_ctrl_out_received()
 }
 
 
-static void udd_ctrl_underflow()
+static void udd_ctrl_underflow(void)
 {
 	if (Is_udd_out_received(0))
 		return; // Underflow ignored if OUT data is received
@@ -1611,7 +1611,7 @@ static void udd_ctrl_underflow()
 }
 
 
-static void udd_ctrl_overflow()
+static void udd_ctrl_overflow(void)
 {
 	if (Is_udd_in_send(0))
 		return; // Overflow ignored if IN data is received
@@ -1627,7 +1627,7 @@ static void udd_ctrl_overflow()
 }
 
 
-static void udd_ctrl_stall_data()
+static void udd_ctrl_stall_data(void)
 {
 	// Stall all packets on IN & OUT control endpoint
 	udd_ep_control_state = UDD_EPCTRL_STALL_REQ;
@@ -1635,7 +1635,7 @@ static void udd_ctrl_stall_data()
 }
 
 
-static void udd_ctrl_send_zlp_in()
+static void udd_ctrl_send_zlp_in(void)
 {
 	irqflags_t flags;
 
@@ -1653,7 +1653,7 @@ static void udd_ctrl_send_zlp_in()
 }
 
 
-static void udd_ctrl_send_zlp_out()
+static void udd_ctrl_send_zlp_out(void)
 {
 	irqflags_t flags;
 
@@ -1669,7 +1669,7 @@ static void udd_ctrl_send_zlp_out()
 }
 
 
-static void udd_ctrl_endofrequest()
+static void udd_ctrl_endofrequest(void)
 {
 	// If a callback is registered then call it
 	if (udd_g_ctrlreq.callback) {
@@ -1678,7 +1678,7 @@ static void udd_ctrl_endofrequest()
 }
 
 
-static bool udd_ctrl_interrupt()
+static bool udd_ctrl_interrupt(void)
 {
 
 	if (!Is_udd_endpoint_interrupt(0)) {
@@ -1734,7 +1734,7 @@ static bool udd_ctrl_interrupt()
 
 #if (0 != USB_DEVICE_MAX_EP)
 
-static void udd_ep_job_table_reset()
+static void udd_ep_job_table_reset(void)
 {
 	uint8_t i;
 	for (i = 0; i < USB_DEVICE_MAX_EP; i++) {
@@ -1744,7 +1744,7 @@ static void udd_ep_job_table_reset()
 }
 
 
-static void udd_ep_job_table_kill()
+static void udd_ep_job_table_kill(void)
 {
 	uint8_t i;
 
@@ -1970,7 +1970,7 @@ static void udd_ep_out_received(udd_ep_id_t ep)
 }
 #endif // #ifdef UDD_EP_FIFO_SUPPORTED
 
-static bool udd_ep_interrupt()
+static bool udd_ep_interrupt(void)
 {
 	udd_ep_id_t ep;
 	udd_ep_job_t *ptr_job;

--- a/Marlin/src/HAL/HAL_DUE/usb/uotghs_otg.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/uotghs_otg.h
@@ -66,13 +66,13 @@ extern "C" {
  *
  * \return \c true if the ID pin management has been started, otherwise \c false.
  */
-bool otg_dual_enable();
+bool otg_dual_enable(void);
 
 /**
  * \brief Uninitialize the dual role
  * This function is implemented in uotghs_host.c file.
  */
-void otg_dual_disable();
+void otg_dual_disable(void);
 
 
 //! @name UOTGHS OTG ID pin management

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.c
@@ -56,7 +56,7 @@
 static volatile bool main_b_cdc_enable = false;
 static volatile bool main_b_dtr_active = false;
 
-void usb_task_idle() {
+void usb_task_idle(void) {
   #if ENABLED(SDSUPPORT)
     // Attend SD card access from the USB MSD -- Prioritize access to improve speed
     int delay = 2;
@@ -70,14 +70,14 @@ void usb_task_idle() {
 }
 
 #if ENABLED(SDSUPPORT)
-  bool usb_task_msc_enable()                { return ((main_b_msc_enable = true)); }
-  void usb_task_msc_disable()               { main_b_msc_enable = false; }
-  bool usb_task_msc_isenabled()             { return main_b_msc_enable; }
+  bool usb_task_msc_enable(void)                { return ((main_b_msc_enable = true)); }
+  void usb_task_msc_disable(void)               { main_b_msc_enable = false; }
+  bool usb_task_msc_isenabled(void)             { return main_b_msc_enable; }
 #endif
 
 bool usb_task_cdc_enable(const uint8_t port)  { UNUSED(port); return ((main_b_cdc_enable = true)); }
 void usb_task_cdc_disable(const uint8_t port) { UNUSED(port); main_b_cdc_enable = false; main_b_dtr_active = false; }
-bool usb_task_cdc_isenabled()             { return main_b_cdc_enable; }
+bool usb_task_cdc_isenabled(void)             { return main_b_cdc_enable; }
 
 /*! \brief Called by CDC interface
  * Callback running when CDC device have received data
@@ -121,7 +121,7 @@ void usb_task_cdc_set_dtr(const uint8_t port, const bool b_enable) {
   }
 }
 
-bool usb_task_cdc_dtr_active()             { return main_b_dtr_active; }
+bool usb_task_cdc_dtr_active(void)             { return main_b_dtr_active; }
 
 /// Microsoft WCID descriptor
 typedef struct USB_MicrosoftCompatibleDescriptor_Interface {
@@ -202,7 +202,7 @@ static USB_MicrosoftExtendedPropertiesDescriptor microsoft_extended_properties_d
 ** WCID configuration information
 ** Hooked into UDC via UDC_GET_EXTRA_STRING #define.
 */
-bool usb_task_extra_string() {
+bool usb_task_extra_string(void) {
   static uint8_t udi_msft_magic[] = "MSFT100\xEE";
   static uint8_t udi_cdc_name[] = "CDC interface";
   #if ENABLED(SDSUPPORT)
@@ -262,7 +262,7 @@ bool usb_task_extra_string() {
 /**************************************************************************************************
 ** Handle device requests that the ASF stack doesn't
 */
-bool usb_task_other_requests() {
+bool usb_task_other_requests(void) {
   uint8_t* ptr = 0;
   uint16_t size = 0;
 
@@ -297,7 +297,7 @@ bool usb_task_other_requests() {
   return true;
 }
 
-void usb_task_init() {
+void usb_task_init(void) {
 
   uint16_t *ptr;
 

--- a/Marlin/src/HAL/HAL_DUE/usb/usb_task.h
+++ b/Marlin/src/HAL/HAL_DUE/usb/usb_task.h
@@ -58,12 +58,12 @@ extern "C" {
  *
  * \retval true if MSC startup is ok
  */
-bool usb_task_msc_enable();
+bool usb_task_msc_enable(void);
 
 /*! \brief Called by MSC interface
  * Callback running when USB Host disable MSC interface
  */
-void usb_task_msc_disable();
+void usb_task_msc_disable(void);
 
 /*! \brief Opens the communication port
  * This is called by CDC interface when USB Host enable it.
@@ -84,25 +84,25 @@ void usb_task_cdc_set_dtr(const uint8_t port, const bool b_enable);
 
 /*! \brief Check if MSC is enumerated and configured on the PC side
  */
-bool usb_task_msc_isenabled();
+bool usb_task_msc_isenabled(void);
 
 /*! \brief Check if CDC is enumerated and configured on the PC side
  */
-bool usb_task_cdc_isenabled();
+bool usb_task_cdc_isenabled(void);
 
 /*! \brief Check if CDC is actually OPEN by an application on the PC side
  *  assuming DTR signal means a program is listening to messages
  */
-bool usb_task_cdc_dtr_active();
+bool usb_task_cdc_dtr_active(void);
 
 /*! \brief Called by UDC when USB Host request a extra string different
  * of this specified in USB device descriptor
  */
-bool usb_task_extra_string();
+bool usb_task_extra_string(void);
 
 /*! \brief Called by UDC when USB Host performs unknown requests
  */
-bool usb_task_other_requests();
+bool usb_task_other_requests(void);
 
 /*! \brief Called by CDC interface
  * Callback running when CDC device have received data
@@ -117,15 +117,15 @@ void usb_task_cdc_config(const uint8_t port, usb_cdc_line_coding_t *cfg);
 
 /*! \brief The USB device interrupt
  */
-void USBD_ISR();
+void USBD_ISR(void);
 
 /*! \brief USB task init
  */
-void usb_task_init();
+void usb_task_init(void);
 
 /*! \brief USB task idle
  */
-void usb_task_idle();
+void usb_task_idle(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- Fix for https://github.com/MarlinFirmware/Marlin/issues/15291
- Suppress C compiler warnings about "function declaration isn't a prototype"
- Use "void" for empty argument list to keep the C compiler from assuming function takes a variable number of arguments, as [explained here](https://stackoverflow.com/questions/693788/is-it-better-to-use-c-void-arguments-void-foovoid-or-not-void-foo)
