### PR TITLE
Require TMCStepper >= 0.5.0 in platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ build_flags = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__
 lib_deps =
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
   LiquidCrystal@1.3.4
-  TMCStepper@<1.0.0
+  TMCStepper@>=0.5.0,<1.0.0
   Adafruit NeoPixel@1.1.3
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip
@@ -159,7 +159,7 @@ monitor_speed     = 250000
 lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper@<1.0.0
+  TMCStepper@>=0.5.0,<1.0.0
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/master.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 
@@ -179,7 +179,7 @@ monitor_speed     = 250000
 lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper@<1.0.0
+  TMCStepper@>=0.5.0,<1.0.0
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/master.zip
 
 #
@@ -487,7 +487,7 @@ build_flags = ${common.build_flags}
 lib_deps =
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
   LiquidCrystal@1.3.4
-  TMCStepper@<1.0.0
+  TMCStepper@>=0.5.0,<1.0.0
   Adafruit NeoPixel
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip


### PR DESCRIPTION
### Description

Specify a minimum TMCStepper version in platformio.ini, to match the version enforced in trinamic.h.

### Benefits

Prevents PlatformIO from using an old version if it already has one available. This will hopefully reduce the number of issues with the version check failing on build.

### Related Issues

Related to #15012, although it doesn't completely solve it, since the SKR E3 DIP still requires some extra workarounds.
