### PR TITLE
Do not implicitly concatenate localized strings.

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -61,6 +61,13 @@
 // Nanoseconds per cycle
 #define NANOSECONDS_PER_CYCLE (1000000000.0 / F_CPU)
 
+// Macros to make sprintf_P read from PROGMEM (AVR extension)
+#ifdef __AVR__
+  #define S_FMT "%S"
+#else
+  #define S_FMT "%s"
+#endif
+
 // Macros to make a string from a macro
 #define STRINGIFY_(M) #M
 #define STRINGIFY(M) STRINGIFY_(M)

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -144,7 +144,7 @@ extern uint8_t marlin_debug_flags;
 #define SERIAL_ECHOLNPAIR(V...) _SELP_N(NUM_ARGS(V),V)
 
 #define SERIAL_ECHOPGM(S)           (serialprintPGM(PSTR(S)))
-#define SERIAL_ECHOLNPGM(S)         (serialprintPGM(PSTR(S "\n")))
+#define SERIAL_ECHOLNPGM(S)         do{ SERIAL_ECHOPGM(S); SERIAL_EOL(); }while(0)
 
 #define SERIAL_ECHOPAIR_F(S, V...)  do{ SERIAL_ECHOPGM(S); SERIAL_ECHO_F(V); }while(0)
 #define SERIAL_ECHOLNPAIR_F(V...)   do{ SERIAL_ECHOPAIR_F(V); SERIAL_EOL(); }while(0)

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -144,7 +144,7 @@ extern uint8_t marlin_debug_flags;
 #define SERIAL_ECHOLNPAIR(V...) _SELP_N(NUM_ARGS(V),V)
 
 #define SERIAL_ECHOPGM(S)           (serialprintPGM(PSTR(S)))
-#define SERIAL_ECHOLNPGM(S)         do{ SERIAL_ECHOPGM(S); SERIAL_EOL(); }while(0)
+#define SERIAL_ECHOLNPGM(S)         (serialprintPGM(PSTR(S "\n")))
 
 #define SERIAL_ECHOPAIR_F(S, V...)  do{ SERIAL_ECHOPGM(S); SERIAL_ECHO_F(V); }while(0)
 #define SERIAL_ECHOLNPAIR_F(V...)   do{ SERIAL_ECHOPAIR_F(V); SERIAL_EOL(); }while(0)

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -715,7 +715,7 @@ G29_TYPE GcodeSuite::G29() {
 
           if (verbose_level) SERIAL_ECHOLNPAIR("Probing mesh point ", int(pt_index), "/", int(GRID_MAX_POINTS), ".");
           #if HAS_DISPLAY
-            ui.status_printf_P(0, PSTR(MSG_PROBING_MESH " %i/%i"), int(pt_index), int(GRID_MAX_POINTS));
+            ui.status_printf_P(0, PSTR(S_FMT " %i/%i"), PSTR(MSG_PROBING_MESH), int(pt_index), int(GRID_MAX_POINTS));
           #endif
 
           measured_z = faux ? 0.001 * random(-100, 101) : probe_at_point(xProbe, yProbe, raise_after, verbose_level);

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -44,17 +44,15 @@
     ) {
       probe_offset[Z_AXIS] += offs;
       SERIAL_ECHO_START();
-      SERIAL_ECHOPGM(MSG_PROBE_OFFSET);
-      SERIAL_ECHOLNPAIR(MSG_Z ": ", probe_offset[Z_AXIS]);
+      SERIAL_ECHOLNPAIR(MSG_PROBE_OFFSET MSG_Z ": ", probe_offset[Z_AXIS]);
     }
-    #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
-      else {
+    else {
+      #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
         hotend_offset[Z_AXIS][active_extruder] -= offs;
         SERIAL_ECHO_START();
-        SERIAL_ECHOPGM(MSG_Z_OFFSET);
-        SERIAL_ECHOLNPAIR(": ", hotend_offset[Z_AXIS][active_extruder]);
-      }
-    #endif
+        SERIAL_ECHOLNPAIR(MSG_PROBE_OFFSET MSG_Z ": ", hotend_offset[Z_AXIS][active_extruder]);
+      #endif
+    }
   }
 
 #endif

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -44,13 +44,15 @@
     ) {
       probe_offset[Z_AXIS] += offs;
       SERIAL_ECHO_START();
-      SERIAL_ECHOLNPAIR(MSG_PROBE_OFFSET MSG_Z ": ", probe_offset[Z_AXIS]);
+      SERIAL_ECHOPGM(MSG_PROBE_OFFSET);
+      SERIAL_ECHOLNPAIR(MSG_Z ": ", probe_offset[Z_AXIS]);
     }
     #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
       else {
         hotend_offset[Z_AXIS][active_extruder] -= offs;
         SERIAL_ECHO_START();
-        SERIAL_ECHOLNPAIR(MSG_Z_OFFSET ": ", hotend_offset[Z_AXIS][active_extruder]);
+        SERIAL_ECHOPGM(MSG_Z_OFFSET);
+        SERIAL_ECHOLNPAIR(": ", hotend_offset[Z_AXIS][active_extruder]);
       }
     #endif
   }

--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -49,26 +49,29 @@
     );
 
     char buffer[21];
+
     printStatistics stats = print_job_timer.getStats();
 
+    #define STATIC_PAIR(MSG, VALUE, CNTR)    do {strcpy_P(buffer, PSTR(": ")); strcpy(buffer, VALUE); STATIC_ITEM(MSG, CNTR, false, buffer);} while(0)
+    #define STATIC_PAIR_P(MSG, PVALUE, CNTR) do {strcpy_P(buffer, PSTR(": ")); strcpy_P(buffer, PSTR(PVALUE)); STATIC_ITEM(MSG, CNTR, false, buffer);} while(0)
+
     START_SCREEN();                                                                                // 12345678901234567890
-    STATIC_ITEM(MSG_INFO_PRINT_COUNT ": ", false, false, i16tostr3left(stats.totalPrints));        // Print Count: 999
-    STATIC_ITEM(MSG_INFO_COMPLETED_PRINTS": ", false, false, i16tostr3left(stats.finishedPrints)); // Completed  : 666
+    STATIC_PAIR(MSG_INFO_PRINT_COUNT, i16tostr3left(stats.totalPrints), false, false);             // Print Count: 999
+    STATIC_PAIR(MSG_INFO_COMPLETED_PRINTS, i16tostr3left(stats.finishedPrints), false, false);     // Completed  : 666
 
     duration_t elapsed = stats.printTime;
     elapsed.toString(buffer);
 
-    STATIC_ITEM(MSG_INFO_PRINT_TIME ":", false, false);                                            // Total print Time:
+    STATIC_PAIR_P(MSG_INFO_PRINT_TIME, "", false);                                                 // Total print Time:
     STATIC_ITEM("> ", false, false, buffer);                                                       // > 99y 364d 23h 59m 59s
 
+    STATIC_PAIR_P(MSG_INFO_PRINT_LONGEST, "", false);                                              // Longest job time:
     elapsed = stats.longestPrint;
     elapsed.toString(buffer);
-
-    STATIC_ITEM(MSG_INFO_PRINT_LONGEST ":", false, false);                                         // Longest job time:
     STATIC_ITEM("> ", false, false, buffer);                                                       // > 99y 364d 23h 59m 59s
 
+    STATIC_PAIR_P(MSG_INFO_PRINT_FILAMENT, "", false);                                             // Extruded total:
     sprintf_P(buffer, PSTR("%ld.%im"), long(stats.filamentUsed / 1000), int16_t(stats.filamentUsed / 100) % 10);
-    STATIC_ITEM(MSG_INFO_PRINT_FILAMENT ":", false, false);                                        // Extruded total:
     STATIC_ITEM("> ", false, false, buffer);                                                       // > 125m
 
     #if SERVICE_INTERVAL_1 > 0
@@ -104,13 +107,16 @@ void menu_info_thermistors() {
       true
     #endif
   );
+
+  char buffer[21];
+
   START_SCREEN();
   #if EXTRUDERS
     #define THERMISTOR_ID TEMP_SENSOR_0
     #include "../thermistornames.h"
     STATIC_ITEM("T0: " THERMISTOR_NAME, false, true);
-    STATIC_ITEM(MSG_INFO_MIN_TEMP ": " STRINGIFY(HEATER_0_MINTEMP), false);
-    STATIC_ITEM(MSG_INFO_MAX_TEMP ": " STRINGIFY(HEATER_0_MAXTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MIN_TEMP, STRINGIFY(HEATER_0_MINTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MAX_TEMP, STRINGIFY(HEATER_0_MAXTEMP), false);
   #endif
 
   #if TEMP_SENSOR_1 != 0
@@ -118,8 +124,8 @@ void menu_info_thermistors() {
     #define THERMISTOR_ID TEMP_SENSOR_1
     #include "../thermistornames.h"
     STATIC_ITEM("T1: " THERMISTOR_NAME, false, true);
-    STATIC_ITEM(MSG_INFO_MIN_TEMP ": " STRINGIFY(HEATER_1_MINTEMP), false);
-    STATIC_ITEM(MSG_INFO_MAX_TEMP ": " STRINGIFY(HEATER_1_MAXTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MIN_TEMP, STRINGIFY(HEATER_1_MINTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MAX_TEMP, STRINGIFY(HEATER_1_MAXTEMP), false);
   #endif
 
   #if TEMP_SENSOR_2 != 0
@@ -127,8 +133,8 @@ void menu_info_thermistors() {
     #define THERMISTOR_ID TEMP_SENSOR_2
     #include "../thermistornames.h"
     STATIC_ITEM("T2: " THERMISTOR_NAME, false, true);
-    STATIC_ITEM(MSG_INFO_MIN_TEMP ": " STRINGIFY(HEATER_2_MINTEMP), false);
-    STATIC_ITEM(MSG_INFO_MAX_TEMP ": " STRINGIFY(HEATER_2_MAXTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MIN_TEMP, STRINGIFY(HEATER_2_MINTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MAX_TEMP, STRINGIFY(HEATER_2_MAXTEMP), false);
   #endif
 
   #if TEMP_SENSOR_3 != 0
@@ -136,8 +142,8 @@ void menu_info_thermistors() {
     #define THERMISTOR_ID TEMP_SENSOR_3
     #include "../thermistornames.h"
     STATIC_ITEM("T3: " THERMISTOR_NAME, false, true);
-    STATIC_ITEM(MSG_INFO_MIN_TEMP ": " STRINGIFY(HEATER_3_MINTEMP), false);
-    STATIC_ITEM(MSG_INFO_MAX_TEMP ": " STRINGIFY(HEATER_3_MAXTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MIN_TEMP, STRINGIFY(HEATER_3_MINTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MAX_TEMP, STRINGIFY(HEATER_3_MAXTEMP), false);
   #endif
 
   #if TEMP_SENSOR_4 != 0
@@ -145,8 +151,8 @@ void menu_info_thermistors() {
     #define THERMISTOR_ID TEMP_SENSOR_4
     #include "../thermistornames.h"
     STATIC_ITEM("T4: " THERMISTOR_NAME, false, true);
-    STATIC_ITEM(MSG_INFO_MIN_TEMP ": " STRINGIFY(HEATER_4_MINTEMP), false);
-    STATIC_ITEM(MSG_INFO_MAX_TEMP ": " STRINGIFY(HEATER_4_MAXTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MIN_TEMP, STRINGIFY(HEATER_4_MINTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MAX_TEMP, STRINGIFY(HEATER_4_MAXTEMP), false);
   #endif
 
   #if TEMP_SENSOR_5 != 0
@@ -154,8 +160,8 @@ void menu_info_thermistors() {
     #define THERMISTOR_ID TEMP_SENSOR_5
     #include "../thermistornames.h"
     STATIC_ITEM("T5: " THERMISTOR_NAME, false, true);
-    STATIC_ITEM(MSG_INFO_MIN_TEMP ": " STRINGIFY(HEATER_5_MINTEMP), false);
-    STATIC_ITEM(MSG_INFO_MAX_TEMP ": " STRINGIFY(HEATER_5_MAXTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MIN_TEMP, STRINGIFY(HEATER_5_MINTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MAX_TEMP, STRINGIFY(HEATER_5_MAXTEMP), false);
   #endif
 
   #if HAS_HEATED_BED
@@ -163,8 +169,8 @@ void menu_info_thermistors() {
     #define THERMISTOR_ID TEMP_SENSOR_BED
     #include "../thermistornames.h"
     STATIC_ITEM("TBed:" THERMISTOR_NAME, false, true);
-    STATIC_ITEM(MSG_INFO_MIN_TEMP ": " STRINGIFY(BED_MINTEMP), false);
-    STATIC_ITEM(MSG_INFO_MAX_TEMP ": " STRINGIFY(BED_MAXTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MIN_TEMP, STRINGIFY(BED_MINTEMP), false);
+    STATIC_PAIR_P(MSG_INFO_MAX_TEMP, STRINGIFY(BED_MAXTEMP), false);
   #endif
   END_SCREEN();
 }
@@ -178,14 +184,17 @@ void menu_info_board() {
       true
     #endif
   );
+
+  char buffer[21];
+
   START_SCREEN();
   STATIC_ITEM(BOARD_INFO_NAME, true, true);                       // MyPrinterController
   #ifdef BOARD_WEBSITE_URL
     STATIC_ITEM(BOARD_WEBSITE_URL, false, false);                 // www.my3dprinter.com
   #endif
-  STATIC_ITEM(MSG_INFO_BAUDRATE ": " STRINGIFY(BAUDRATE), true);  // Baud: 250000
-  STATIC_ITEM(MSG_INFO_PROTOCOL ": " PROTOCOL_VERSION, true);     // Protocol: 1.0
-  STATIC_ITEM(MSG_INFO_PSU ": " PSU_NAME, true);
+  STATIC_PAIR_P(MSG_INFO_BAUDRATE, STRINGIFY(BAUDRATE), true);    // Baud: 250000
+  STATIC_PAIR_P(MSG_INFO_PROTOCOL, PROTOCOL_VERSION, true);       // Protocol: 1.0
+  STATIC_PAIR_P(MSG_INFO_PSU,      PSU_NAME, true);
   END_SCREEN();
 }
 

--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -34,6 +34,9 @@
   #include "game/game.h"
 #endif
 
+#define STATIC_PAIR(MSG, VALUE, CNTR)    do {strcpy_P(buffer, PSTR(": ")); strcpy(buffer, VALUE); STATIC_ITEM(MSG, CNTR, false, buffer);} while(0)
+#define STATIC_PAIR_P(MSG, PVALUE, CNTR) do {strcpy_P(buffer, PSTR(": ")); strcpy_P(buffer, PSTR(PVALUE)); STATIC_ITEM(MSG, CNTR, false, buffer);} while(0)
+
 #if ENABLED(PRINTCOUNTER)
 
   #include "../../module/printcounter.h"
@@ -48,12 +51,9 @@
       #endif
     );
 
-    char buffer[21];
+    char buffer[21];  // for STATIC_PAIR_P
 
     printStatistics stats = print_job_timer.getStats();
-
-    #define STATIC_PAIR(MSG, VALUE, CNTR)    do {strcpy_P(buffer, PSTR(": ")); strcpy(buffer, VALUE); STATIC_ITEM(MSG, CNTR, false, buffer);} while(0)
-    #define STATIC_PAIR_P(MSG, PVALUE, CNTR) do {strcpy_P(buffer, PSTR(": ")); strcpy_P(buffer, PSTR(PVALUE)); STATIC_ITEM(MSG, CNTR, false, buffer);} while(0)
 
     START_SCREEN();                                                                                // 12345678901234567890
     STATIC_PAIR(MSG_INFO_PRINT_COUNT, i16tostr3left(stats.totalPrints), false, false);             // Print Count: 999
@@ -80,12 +80,14 @@
       STATIC_ITEM(SERVICE_NAME_1 MSG_SERVICE_IN, false, false);                                    // Service X in:
       STATIC_ITEM("> ", false, false, buffer);                                                     // > 7d 12h 11m 10s
     #endif
+
     #if SERVICE_INTERVAL_2 > 0
       elapsed = stats.nextService2;
       elapsed.toString(buffer);
       STATIC_ITEM(SERVICE_NAME_2 MSG_SERVICE_IN, false, false);
       STATIC_ITEM("> ", false, false, buffer);
     #endif
+
     #if SERVICE_INTERVAL_3 > 0
       elapsed = stats.nextService3;
       elapsed.toString(buffer);
@@ -108,7 +110,7 @@ void menu_info_thermistors() {
     #endif
   );
 
-  char buffer[21];
+  char buffer[21];  // for STATIC_PAIR_P
 
   START_SCREEN();
   #if EXTRUDERS
@@ -185,7 +187,7 @@ void menu_info_board() {
     #endif
   );
 
-  char buffer[21];
+  char buffer[21];  // for STATIC_PAIR_P
 
   START_SCREEN();
   STATIC_ITEM(BOARD_INFO_NAME, true, true);                       // MyPrinterController

--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -34,8 +34,8 @@
   #include "game/game.h"
 #endif
 
-#define STATIC_PAIR(MSG, VALUE, CNTR)    do {strcpy_P(buffer, PSTR(": ")); strcpy(buffer, VALUE); STATIC_ITEM(MSG, CNTR, false, buffer);} while(0)
-#define STATIC_PAIR_P(MSG, PVALUE, CNTR) do {strcpy_P(buffer, PSTR(": ")); strcpy_P(buffer, PSTR(PVALUE)); STATIC_ITEM(MSG, CNTR, false, buffer);} while(0)
+#define STATIC_PAIR(MSG, VALUE, CNTR)    do{ strcpy_P(buffer, PSTR(": ")); strcpy(buffer + 2, VALUE); STATIC_ITEM(MSG, CNTR, false, buffer); }while(0)
+#define STATIC_PAIR_P(MSG, PVALUE, CNTR) do{ strcpy_P(buffer, PSTR(": ")); strcpy_P(buffer + 2, PSTR(PVALUE)); STATIC_ITEM(MSG, CNTR, false, buffer); }while(0)
 
 #if ENABLED(PRINTCOUNTER)
 
@@ -56,8 +56,8 @@
     printStatistics stats = print_job_timer.getStats();
 
     START_SCREEN();                                                                                // 12345678901234567890
-    STATIC_PAIR(MSG_INFO_PRINT_COUNT, i16tostr3left(stats.totalPrints), false, false);             // Print Count: 999
-    STATIC_PAIR(MSG_INFO_COMPLETED_PRINTS, i16tostr3left(stats.finishedPrints), false, false);     // Completed  : 666
+    STATIC_PAIR(MSG_INFO_PRINT_COUNT, i16tostr3left(stats.totalPrints), false);                    // Print Count: 999
+    STATIC_PAIR(MSG_INFO_COMPLETED_PRINTS, i16tostr3left(stats.finishedPrints), false);            // Completed  : 666
 
     duration_t elapsed = stats.printTime;
     elapsed.toString(buffer);

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -82,10 +82,13 @@ inline void sdcard_start_selected_file() {
 #if ENABLED(SD_MENU_CONFIRM_START)
 
   void menu_sd_confirm() {
+    char buffer[strlen(card.longest_filename())+2];
+    strcpy_P(buffer, PSTR(" "));
+    strcat(buffer, card.longest_filename());
     do_select_screen(
       PSTR(MSG_BUTTON_PRINT), PSTR(MSG_BUTTON_CANCEL),
       sdcard_start_selected_file, ui.goto_previous_screen,
-      PSTR(MSG_START_PRINT " "), card.longest_filename(), PSTR("?")
+      PSTR(MSG_START_PRINT), buffer, PSTR("?")
     );
   }
 

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -82,9 +82,10 @@ inline void sdcard_start_selected_file() {
 #if ENABLED(SD_MENU_CONFIRM_START)
 
   void menu_sd_confirm() {
-    char buffer[strlen(card.longest_filename())+2];
-    strcpy_P(buffer, PSTR(" "));
-    strcat(buffer, card.longest_filename());
+    char * const longest = card.longest_filename();
+    char buffer[strlen(longest) + 2];
+    buffer[0] = ' ';
+    strcpy(buffer + 1, longest);
     do_select_screen(
       PSTR(MSG_BUTTON_PRINT), PSTR(MSG_BUTTON_CANCEL),
       sdcard_start_selected_file, ui.goto_previous_screen,

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -373,7 +373,7 @@ void Endstops::event_handler() {
     SERIAL_EOL();
 
     #if HAS_SPI_LCD
-      ui.status_printf_P(0, PSTR(MSG_LCD_ENDSTOPS " %c %c %c %c"), chrX, chrY, chrZ, chrP);
+      ui.status_printf_P(0, PSTR(S_FMT " %c %c %c %c"), PSTR(MSG_LCD_ENDSTOPS), chrX, chrY, chrZ, chrP);
     #endif
 
     #if BOTH(SD_ABORT_ON_ENDSTOP_HIT, SDSUPPORT)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2935,11 +2935,11 @@ void Temperature::isr() {
       const bool heating = isHeatingHotend(e);
       ui.status_printf_P(0,
         #if HOTENDS > 1
-          PSTR("E%c " S_FMT), '1' + e,
+          PSTR("E%c " S_FMT), '1' + e
         #else
-          PSTR("E " S_FMT),
+          PSTR("E " S_FMT)
         #endif
-        heating ? PSTR(MSG_HEATING) : PSTR(MSG_COOLING)
+        , heating ? PSTR(MSG_HEATING) : PSTR(MSG_COOLING)
       );
     }
   #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2933,11 +2933,14 @@ void Temperature::isr() {
   #if HOTENDS && HAS_DISPLAY
     void Temperature::set_heating_message(const uint8_t e) {
       const bool heating = isHeatingHotend(e);
-      #if HOTENDS > 1
-        ui.status_printf_P(0, heating ? PSTR("E%c " MSG_HEATING) : PSTR("E%c " MSG_COOLING), '1' + e);
-      #else
-        ui.set_status_P(heating ? PSTR("E " MSG_HEATING) : PSTR("E " MSG_COOLING));
-      #endif
+      ui.status_printf_P(0,
+        #if HOTENDS > 1
+          PSTR("E%c " S_FMT), '1' + e,
+        #else
+          PSTR("E " S_FMT),
+        #endif
+        heating ? PSTR(MSG_HEATING) : PSTR(MSG_COOLING)
+      );
     }
   #endif
 


### PR DESCRIPTION
- Clears the way for language-specific strings to be wrapped in `GET_TEXT()` macro in future PR.
- As a bonus, saves 282 bytes of PROGMEM on AVR.

**Rationale:**

In order to allow the language selection to be performed at run-time, all localizable strings will need to be wrapped in a function call or macro. This presents a problem with implicit concatenation, such as `PSTR("E%c " MSG_HEATING)` which would cause a compile error when re-written as `PSTR("E%c " GET_TEXT(MSG_HEATING))`

A future PR will complete the localization work, but this PR clears away some of the trouble spots identified in the code.
