### PR TITLE
Restore Host Prompt Info

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -414,7 +414,7 @@ void disable_all_steppers() {
 
   void event_probe_recover() {
     #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_prompt_do(PROMPT_INFO, PSTR("G29 Retrying"));
+      host_prompt_do(PROMPT_INFO, PSTR("G29 Retrying"), PSTR("Dismiss"));
     #endif
     #ifdef ACTION_ON_G29_RECOVER
       host_action(PSTR(ACTION_ON_G29_RECOVER));

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1155,6 +1155,10 @@ void setup() {
     card.beginautostart();
   #endif
 
+  #if ENABLED(HOST_PROMPT_SUPPORT)
+    host_action_prompt_end();
+  #endif
+
   #if HAS_TRINAMIC && DISABLED(PS_DEFAULT_OFF)
     test_tmc_connection(true, true, true, true);
   #endif

--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -154,6 +154,9 @@ void host_action(const char * const pstr, const bool eol) {
           queue.inject_P(PSTR("M24"));
         #endif
         break;
+      case PROMPT_INFO:
+        msg = PSTR("GCODE_INFO");
+        break;
       default: break;
     }
     say_m876_response(msg);

--- a/Marlin/src/feature/host_actions.h
+++ b/Marlin/src/feature/host_actions.h
@@ -51,7 +51,8 @@ void host_action(const char * const pstr, const bool eol=true);
     PROMPT_FILAMENT_RUNOUT,
     PROMPT_USER_CONTINUE,
     PROMPT_FILAMENT_RUNOUT_REHEAT,
-    PROMPT_PAUSE_RESUME
+    PROMPT_PAUSE_RESUME,
+    PROMPT_INFO
   };
 
   extern PromptReason host_prompt_reason;

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -401,6 +401,10 @@ bool pause_print(const float &retract, const point_t &park_point, const float &u
     #endif
   #endif
 
+  #if ENABLED(HOST_PROMPT_SUPPORT)
+    host_prompt_open(PROMPT_INFO, PSTR("Pause"), PSTR("Dismiss"));
+  #endif
+
   if (!DEBUGGING(DRYRUN) && unload_length && thermalManager.targetTooColdToExtrude(active_extruder)) {
     SERIAL_ECHO_MSG(MSG_ERR_HOTEND_TOO_COLD);
 
@@ -554,7 +558,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
       while (wait_for_user) idle(true);
 
       #if ENABLED(HOST_PROMPT_SUPPORT)
-        host_prompt_do(PROMPT_USER_CONTINUE, PSTR("Reheating"));
+        host_prompt_do(PROMPT_INFO, PSTR("Reheating"));
       #endif
       #if ENABLED(EXTENSIBLE_UI)
         ExtUI::onStatusChanged(PSTR("Reheating..."));
@@ -675,6 +679,10 @@ void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_le
   #endif
 
   --did_pause_print;
+
+  #if ENABLED(HOST_PROMPT_SUPPORT)
+    host_prompt_open(PROMPT_INFO, PSTR("Resuming"), PSTR("Dismiss"));
+  #endif
 
   #if ENABLED(SDSUPPORT)
     if (did_pause_print) {

--- a/Marlin/src/gcode/sdcard/M24_M25.cpp
+++ b/Marlin/src/gcode/sdcard/M24_M25.cpp
@@ -71,6 +71,9 @@ void GcodeSuite::M24() {
     #ifdef ACTION_ON_RESUME
       host_action_resume();
     #endif
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_prompt_open(PROMPT_INFO, PSTR("Resuming SD"), PSTR("Dismiss"));
+    #endif
   #endif
 
   ui.reset_status();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1481,6 +1481,9 @@ void MarlinUI::update() {
     #ifdef ACTION_ON_CANCEL
       host_action_cancel();
     #endif
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_prompt_open(PROMPT_INFO, PSTR("UI Aborted"), PSTR("Dismiss"));
+    #endif
     print_job_timer.stop();
     set_status_P(PSTR(MSG_PRINT_ABORTED));
     #if HAS_LCD_MENU


### PR DESCRIPTION
Restore host prompt info points with dismiss button, except for single use of blocking non-actionable prompt (Reheating).

Revise a few strings

Clear stale messages on init

These prompts are absolutely necessary for machines where octoprint is the only interface.

There are a few prompts that couldbe left for awhile. UI Abort, Resuming, and SD Resuming. We can clear them based on time, moves completed, or just leave them. Regardless there is still a button on all but the one prompt now.