### PR TITLE
Optimize SD card reader, alpha sorting with SRAM

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -1002,14 +1002,14 @@ namespace ExtUI {
 
   void FileList::upDir() {
     #if ENABLED(SDSUPPORT)
-      card.updir();
+      card.cdup();
       num_files = 0xFFFF;
     #endif
   }
 
   void FileList::changeDir(const char * const dirname) {
     #if ENABLED(SDSUPPORT)
-      card.chdir(dirname);
+      card.cd(dirname);
       num_files = 0xFFFF;
     #endif
   }

--- a/Marlin/src/lcd/extui_malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui_malyan_lcd.cpp
@@ -246,13 +246,13 @@ void process_lcd_p_command(const char* command) {
         // Find the name of the file to print.
         // It's needed to echo the PRINTFILE option.
         // The {S:L} command should've ensured the SD card was mounted.
-        card.getfilename(atoi(command));
+        card.selectFileByIndex(atoi(command));
 
         // There may be a difference in how V1 and V2 LCDs handle subdirectory
         // prints. Investigate more. This matches the V1 motion controller actions
         // but the V2 LCD switches to "print" mode on {SYS:DIR} response.
         if (card.flag.filenameIsDir) {
-          card.chdir(card.filename);
+          card.cd(card.filename);
           write_to_lcd_P(PSTR("{SYS:DIR}"));
         }
         else {
@@ -309,7 +309,7 @@ void process_lcd_s_command(const char* command) {
         char message_buffer[MAX_CURLY_COMMAND];
         uint16_t file_count = card.get_num_Files();
         for (uint16_t i = 0; i < file_count; i++) {
-          card.getfilename(i);
+          card.selectFileByIndex(i);
           sprintf_P(message_buffer, card.flag.filenameIsDir ? PSTR("{DIR:%s}") : PSTR("{FILE:%s}"), card.longest_filename());
           write_to_lcd(message_buffer);
         }

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -39,7 +39,7 @@
 #endif
 
 void lcd_sd_updir() {
-  ui.encoderPosition = card.updir() ? ENCODER_STEPS_PER_MENU_ITEM : 0;
+  ui.encoderPosition = card.cdup() ? ENCODER_STEPS_PER_MENU_ITEM : 0;
   encoderTopLine = 0;
   screen_changed = true;
   ui.refresh();
@@ -115,7 +115,7 @@ class MenuItem_sdfile {
 class MenuItem_sdfolder {
   public:
     static void action(CardReader &theCard) {
-      card.chdir(theCard.filename);
+      card.cd(theCard.filename);
       encoderTopLine = 0;
       ui.encoderPosition = 2 * (ENCODER_STEPS_PER_MENU_ITEM);
       screen_changed = true;

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -33,8 +33,6 @@
 
 #include "SdFile.h"
 
-enum LsAction : uint8_t { LS_SerialPrint, LS_Count, LS_GetFilename };
-
 typedef struct {
   bool saving:1,
        logging:1,
@@ -51,47 +49,79 @@ typedef struct {
 
 class CardReader {
 public:
+  static card_flags_t flag;                         // Flags (above)
+  static char filename[FILENAME_LENGTH],            // DOS 8.3 filename of the selected item
+              longFilename[LONG_FILENAME_LENGTH];   // Long name of the selected item
+
+  // Fast! binary file transfer
+  #if ENABLED(BINARY_FILE_TRANSFER)
+    #if NUM_SERIAL > 1
+      static int8_t transfer_port_index;
+    #else
+      static constexpr int8_t transfer_port_index = 0;
+    #endif
+  #endif
+
+  // // // Methods // // //
+
   CardReader();
 
-  static void mount();
-  static void write_command(char *buf);
+  static SdFile getroot() { return root; }
 
+  static void mount();
+  static void release();
+  static inline bool isMounted() { return flag.mounted; }
+  static void ls();
+
+  // SD Card Logging
+  static void openLogFile(char * const path);
+  static void write_command(char * const buf);
+
+  // Auto-Start files
+  static int8_t autostart_index;                    // Index of autoX.g files
   static void beginautostart();
   static void checkautostart();
 
+  // Basic file ops
   static void openFile(char * const path, const bool read, const bool subcall=false);
-  static void openLogFile(char * const path);
-  static void removeFile(const char * const name);
   static void closefile(const bool store_location=false);
-  static void release();
-  static void openAndPrintFile(const char *name);
+  static void removeFile(const char * const name);
+
+  static inline char* longest_filename() { return longFilename[0] ? longFilename : filename; }
+  #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
+    static void printLongPath(char * const path);   // Used by M33
+  #endif
+
+  // Working Directory for SD card menu
+  static void cdroot();
+  static void cd(const char *relpath);
+  static int8_t cdup();
+  static uint16_t countFilesInWorkDir();
+  static uint16_t get_num_Files();
+
+  // Select a file
+  static void selectFileByIndex(const uint16_t nr);
+  static void selectFileByName(const char* const match);
+
+  // Print job
+  static void openAndPrintFile(const char *name);   // (working directory)
+  static void printingHasFinished();
+  static void getAbsFilename(char *dst);
   static void startFileprint();
+  static void printFilename();
   static void stopSDPrint(
     #if SD_RESORT
       const bool re_sort=false
     #endif
   );
   static void report_status();
-  static void printingHasFinished();
-  static void printFilename();
+  static inline void pauseSDPrint() { flag.sdprinting = false; }
+  static inline bool isPaused() { return isFileOpen() && !flag.sdprinting; }
+  static inline bool isPrinting() { return flag.sdprinting; }
+  static inline uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
 
-  #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
-    static void printLongPath(char *path);
-  #endif
-
-  static void getfilename(uint16_t nr, const char* const match=nullptr);
-  static uint16_t countFilesInWorkDir();
-
-  static void getAbsFilename(char *t);
-
-  static void ls();
-  static void chdir(const char *relpath);
-  static int8_t updir();
-  static void setroot();
-
+  // Helper for open and remove
   static const char* diveToFile(SdFile*& curDir, const char * const path, const bool echo=false);
-
-  static uint16_t get_num_Files();
 
   #if ENABLED(SDCARD_SORT_ALPHA)
     static void presort();
@@ -102,7 +132,7 @@ public:
       //FORCE_INLINE static void setSortReverse(bool b) { sort_reverse = b; }
     #endif
   #else
-    FORCE_INLINE static void getfilename_sorted(const uint16_t nr) { getfilename(nr); }
+    FORCE_INLINE static void getfilename_sorted(const uint16_t nr) { selectFileByIndex(nr); }
   #endif
 
   #if ENABLED(POWER_LOSS_RECOVERY)
@@ -111,17 +141,12 @@ public:
     static void removeJobRecoveryFile();
   #endif
 
-  static inline void pauseSDPrint() { flag.sdprinting = false; }
-  static inline bool isMounted() { return flag.mounted; }
   static inline bool isFileOpen() { return isMounted() && file.isOpen(); }
-  static inline bool isPaused() { return isFileOpen() && !flag.sdprinting; }
-  static inline bool isPrinting() { return flag.sdprinting; }
-  static inline bool eof() { return sdpos >= filesize; }
-  static inline int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }
-  static inline void setIndex(const uint32_t index) { sdpos = index; file.seekSet(index); }
   static inline uint32_t getIndex() { return sdpos; }
-  static inline uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
+  static inline bool eof() { return sdpos >= filesize; }
+  static inline void setIndex(const uint32_t index) { sdpos = index; file.seekSet(index); }
   static inline char* getWorkDirName() { workDir.getDosName(filename); return filename; }
+  static inline int16_t get() { sdpos = file.curPosition(); return (int16_t)file.read(); }
   static inline int16_t read(void* buf, uint16_t nbyte) { return file.isOpen() ? file.read(buf, nbyte) : -1; }
   static inline int16_t write(void* buf, uint16_t nbyte) { return file.isOpen() ? file.write(buf, nbyte) : -1; }
 
@@ -139,27 +164,16 @@ public:
     }
   #endif
 
-  static inline char* longest_filename() { return longFilename[0] ? longFilename : filename; }
-
-public:
-  static card_flags_t flag;
-  static char filename[FILENAME_LENGTH], longFilename[LONG_FILENAME_LENGTH];
-  static int8_t autostart_index;
-  static SdFile getroot() { return root; }
-
-  #if ENABLED(BINARY_FILE_TRANSFER)
-    #if NUM_SERIAL > 1
-      static int8_t transfer_port_index;
-    #else
-      static constexpr int8_t transfer_port_index = 0;
-    #endif
-  #endif
-
 private:
+  //
+  // Working directory and parents
+  //
   static SdFile root, workDir, workDirParents[MAX_DIR_DEPTH];
   static uint8_t workDirDepth;
 
-  // Sort files and folders alphabetically.
+  //
+  // Alphabetical file and folder sorting
+  //
   #if ENABLED(SDCARD_SORT_ALPHA)
     static uint16_t sort_count;   // Count of sorted items in the current directory
     #if ENABLED(SDSORT_GCODE)
@@ -188,6 +202,7 @@ private:
 
       // If using dynamic ram for names, allocate on the heap.
       #if ENABLED(SDSORT_CACHE_NAMES)
+        static uint16_t nrFiles; // Cache the total count
         #if ENABLED(SDSORT_DYNAMIC_RAM)
           static char **sortshort, **sortnames;
         #else
@@ -216,31 +231,40 @@ private:
   static SdVolume volume;
   static SdFile file;
 
+  static uint32_t filesize, sdpos;
+
+  //
+  // Procedure calls to other files
+  //
   #ifndef SD_PROCEDURE_DEPTH
     #define SD_PROCEDURE_DEPTH 1
   #endif
-
   static uint8_t file_subcall_ctr;
   static uint32_t filespos[SD_PROCEDURE_DEPTH];
   static char proc_filenames[SD_PROCEDURE_DEPTH][MAXPATHNAMELENGTH];
 
-  static uint32_t filesize, sdpos;
-
-  static LsAction lsAction; //stored for recursion.
-  static uint16_t nrFiles; //counter for the files in the current directory and recycled as position counter for getting the nrFiles'th name in the directory.
-  static char *diveDirName;
-  static void lsDive(const char *prepend, SdFile parent, const char * const match=nullptr);
-
-  #if ENABLED(SDCARD_SORT_ALPHA)
-    static void flush_presort();
-  #endif
-
+  //
+  // SD Auto Reporting
+  //
   #if ENABLED(AUTO_REPORT_SD_STATUS)
     static uint8_t auto_report_sd_interval;
     static millis_t next_sd_report_ms;
     #if NUM_SERIAL > 1
       static int8_t auto_report_port;
     #endif
+  #endif
+
+  //
+  // Directory items
+  //
+  static bool is_dir_or_gcode(const dir_t &p);
+  static int countItems(SdFile dir);
+  static void selectByIndex(SdFile dir, const uint8_t index);
+  static void selectByName(SdFile dir, const char * const match);
+  static void printListing(SdFile parent, const char * const prepend=nullptr);
+
+  #if ENABLED(SDCARD_SORT_ALPHA)
+    static void flush_presort();
   #endif
 };
 


### PR DESCRIPTION
The overloading of `cardreader::lsDive` was getting out of hand. And the SD card sorting algorithm was causing watchdog reset when sorting 100 files.

This PR…

- Splits up the `lsDive` method into four smaller methods: `countItems`, `selectByIndex`, `selectByName`, and `printListing`, all sharing a common method, `is_dir_or_gcode`.

- Optimizes SD card sorting by cutting the number of SD card fetches by ~half in `presort`.

References: #14326, #15353