### PR TITLE
Ignore Adafruit NeoPixel on BIGTREE_SKR_PRO

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -488,7 +488,7 @@ lib_deps =
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
   LiquidCrystal@1.3.4
   TMCStepper@>=0.5.0,<1.0.0
-  Adafruit NeoPixel
+  Adafruit NeoPixel@>=1.2.5
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip
 src_filter = ${common.default_src_filter} +<src/HAL/HAL_STM32>


### PR DESCRIPTION
### Description

Building BIGTREE_SKR_PRO target fails because of Adafruit NeoPixel library not being compatible.
This PR removes Adafruit NeoPixel from the list of dependencies and adds it to the ignore list.

### Benefits

BIGTREE_SKR_PRO will build correctly
