### PR TITLE
Added missing opening quotation marks

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -252,13 +252,13 @@
 #elif defined(UBL_PROBE_PT_1_X) || defined(UBL_PROBE_PT_1_Y) || defined(UBL_PROBE_PT_2_X) || defined(UBL_PROBE_PT_2_Y) || defined(UBL_PROBE_PT_3_X) || defined(UBL_PROBE_PT_3_Y)
   #error "UBL_PROBE_PT_[123]_[XY] is no longer required. Please remove it from Configuration.h."
 #elif defined(LEFT_PROBE_BED_POSITION)
-  #error LEFT_PROBE_BED_POSITION has been replaced by MIN_PROBE_EDGE_LEFT. Please note the differences and update your configuration."
+  #error "LEFT_PROBE_BED_POSITION has been replaced by MIN_PROBE_EDGE_LEFT. Please note the differences and update your configuration."
 #elif defined(RIGHT_PROBE_BED_POSITION)
-  #error RIGHT_PROBE_BED_POSITION has been replaced by MIN_PROBE_EDGE_RIGHT. Please note the differences and update your configuration."
+  #error "RIGHT_PROBE_BED_POSITION has been replaced by MIN_PROBE_EDGE_RIGHT. Please note the differences and update your configuration."
 #elif defined(FRONT_PROBE_BED_POSITION)
-  #error FRONT_PROBE_BED_POSITION has been replaced by MIN_PROBE_EDGE_FRONT. Please note the differences and update your configuration."
+  #error "FRONT_PROBE_BED_POSITION has been replaced by MIN_PROBE_EDGE_FRONT. Please note the differences and update your configuration."
 #elif defined(BACK_PROBE_BED_POSITION)
-  #error BACK_PROBE_BED_POSITION has been replaced by MIN_PROBE_EDGE_BACK. Please note the differences and update your configuration."
+  #error "BACK_PROBE_BED_POSITION has been replaced by MIN_PROBE_EDGE_BACK. Please note the differences and update your configuration."
 #elif defined(ENABLE_MESH_EDIT_GFX_OVERLAY)
   #error "ENABLE_MESH_EDIT_GFX_OVERLAY is now MESH_EDIT_GFX_OVERLAY. Please update your configuration."
 #elif defined(BABYSTEP_ZPROBE_GFX_REVERSE)


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

This pull request fixes an issue where some lines in `SanityCheck.h` were missing opening quotation marks and were flooding the console with warnings at compilation time.

### Benefits

Removes unnecessary warnings from console

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/15400
