### PR TITLE
fix compiling error with 6 Hotends

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -884,7 +884,7 @@ namespace ExtUI {
     #endif
       {
         #if HOTENDS
-          static constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP);
+          static constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP, HEATER_5_MAXTEMP);
           const int16_t e = heater - H0;
           thermalManager.setTargetHotend(constrain(value, 0, heater_maxtemp[e] - 15), e);
         #endif
@@ -893,7 +893,7 @@ namespace ExtUI {
 
   void setTargetTemp_celsius(float value, const extruder_t extruder) {
     #if HOTENDS
-      constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP);
+      constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP, HEATER_5_MAXTEMP);
       const int16_t e = extruder - E0;
       enableHeater(extruder);
       thermalManager.setTargetHotend(constrain(value, 0, heater_maxtemp[e] - 15), e);

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -31,7 +31,7 @@ extern int8_t encoderLine, encoderTopLine, screen_items;
 extern bool screen_changed;
 
 #if HOTENDS
-  constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP);
+  constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP, HEATER_5_MAXTEMP);
 #endif
 
 void scroll_screen(const uint8_t limit, const bool is_menu);


### PR DESCRIPTION
```c++
In file included from Marlin\src\lcd\dogm\ultralcd_DOGM.cpp:312:0:
Marlin\src\lcd\dogm\../menu/menu.h:34:1: error: macro "ARRAY_6" requires 7 arguments, but only 5 given
   constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP);
 ^
Compiling .pio\build\megaatmega2560\src\src\lcd\extensible_ui\lib\dgus\DGUSDisplay.cpp.o
In file included from Marlin\src\lcd\dogm\../../inc/MarlinConfigPre.h:36:0,
                 from Marlin\src\lcd\dogm\ultralcd_DOGM.cpp:38:
Marlin\src\lcd\dogm\../../inc/../core/macros.h:225:26: error: 'ARRAY_6' was not declared in this scope
 #define _ARRAY_N(N,V...) ARRAY_##N(V)
                          ^
Marlin\src\lcd\dogm\../../inc/../core/macros.h:226:25: note: in expansion of macro '_ARRAY_N'
 #define ARRAY_N(N,V...) _ARRAY_N(N,V)
                         ^
Marlin\src\lcd\dogm\../../inc/Conditionals_post.h:543:32: note: in expansion of macro 'ARRAY_N'
 #define ARRAY_BY_HOTENDS(V...) ARRAY_N(HOTENDS, V)
                                ^
Marlin\src\lcd\dogm\../menu/menu.h:34:47: note: in expansion of macro 'ARRAY_BY_HOTENDS'
   constexpr int16_t heater_maxtemp[HOTENDS] = ARRAY_BY_HOTENDS(HEATER_0_MAXTEMP, HEATER_1_MAXTEMP, HEATER_2_MAXTEMP, HEATER_3_MAXTEMP, HEATER_4_MAXTEMP);
```