### PR TITLE
Add dithering feature

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -796,6 +796,21 @@
 
 // @section lcd
 
+// @section Dithering
+
+/**
+* Dithering seeks to improve mechanical in the z axis by oscillating the axis about it's intended position 
+* after each z move for a small amount of time and with a decaying amplitude. 
+* This allows the axis to 'average out' and settle more accurately on the intended position.
+* When using dithering babysteps must also be enabled. 
+*/
+
+#define DITHERING
+
+#if ENABLED(DITHERING)
+  #define BABYSTEPPING //dither requires babystepping
+#endif
+
 /**
  * Babystepping enables movement of the axes by tiny increments without changing
  * the current position values. This feature is used primarily to adjust the Z

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -165,6 +165,7 @@
             S<print> T<travel> minimum speeds
             Q<minimum segment time>
             X<max X jerk>, Y<max Y jerk>, Z<max Z jerk>, E<max E jerk>
+             D<Dither Amplitude> T<Dither Time> H<Dither Minimum Layer Height>
  * M206 - Set additional homing offset. (Disabled by NO_WORKSPACE_OFFSETS or DELTA)
  * M207 - Set Retract Length: S<length>, Feedrate: F<units/min>, and Z lift: Z<distance>. (Requires FWRETRACT)
  * M208 - Set Recover (unretract) Additional (!) Length: S<length> and Feedrate: F<units/min>. (Requires FWRETRACT)
@@ -372,6 +373,11 @@
 #if ENABLED(CNC_COORDINATE_SYSTEMS)
   int8_t active_coordinate_system = -1; // machine space
   float coordinate_system[MAX_COORDINATE_SYSTEMS][XYZ];
+#endif
+
+#if ENABLED(DITHERING)
+ #include "dither.h"
+ Dithering Dither;
 #endif
 
 bool Running = true;
@@ -3636,6 +3642,13 @@ inline void gcode_G0_G1(
       fast_move ? prepare_uninterpolated_move_to_destination() : prepare_move_to_destination();
     #else
       prepare_move_to_destination();
+    #endif
+
+    #if ENABLED(DITHERING)
+      if (parser.seenval('Z')) {
+        planner.synchronize();
+        Dither.Handle(parser.value_linear_units());
+      }
     #endif
 
     #if ENABLED(NANODLP_Z_SYNC)
@@ -9696,11 +9709,21 @@ inline void gcode_M204() {
  *    Z = Max Z Jerk (units/sec^2)
  *    E = Max E Jerk (units/sec^2)
  *    J = Junction Deviation (mm) (Requires JUNCTION_DEVIATION)
+ *    D = Dither Amplitude (steps) inital amplitude of dither, set to ~0.5-1.5 times the numer of mircosteps (Requires Dither and Babysteps)
+ *    T = Dither Time (ms) how long to dither for (Requires Dither and Babysteps)
+ *    H = Dither Minimum layer height (mm) minimum layer height interval where dither will be used (ensure compatibility with vase mode) (Requires Dither and Babysteps)
  */
 inline void gcode_M205() {
   if (parser.seen('Q')) planner.min_segment_time_us = parser.value_ulong();
   if (parser.seen('S')) planner.min_feedrate_mm_s = parser.value_linear_units();
   if (parser.seen('T')) planner.min_travel_feedrate_mm_s = parser.value_linear_units();
+
+  #if ENABLED(DITHERING)
+    if (parser.seen('D')) {Dither.Amplitude = parser.value_linear_units(); Dither.CalculateParameters(); SERIAL_ECHOLNPAIR("Dither Amplitude: ", Dither.Amplitude);};
+    if (parser.seen('T')) {Dither.TimeMS = parser.value_linear_units(); Dither.CalculateParameters(); SERIAL_ECHOLNPAIR("Dither Time: ", Dither.TimeMS);};
+    if (parser.seen('H')) {Dither.MinLayerInterval = (parser.value_linear_units()); Dither.CalculateParameters(); SERIAL_ECHOLNPAIR("Dither MinLayerHeight: ", Dither.MinLayerInterval);};
+  #endif
+  
   #if ENABLED(JUNCTION_DEVIATION)
     if (parser.seen('J')) {
       const float junc_dev = parser.value_linear_units();

--- a/Marlin/dither.cpp
+++ b/Marlin/dither.cpp
@@ -1,0 +1,75 @@
+#include "dither.h"
+#include "macros.h"
+#include "math.h"
+#include "stepper.h"
+#include "temperature.h"
+#include "Configuration_adv.h"
+
+uint16_t Dithering::Amplitude = 16; // how many steps for dither
+uint16_t Dithering::TimeMS = 100;
+float Dithering::MinLayerInterval = 0.1;
+float Dithering::PrevZ = 0.0;
+
+uint32_t Dithering::DitherSubTime = 25;
+uint8_t Dithering::Ditherssteps[4] = {16, 8, 4, 2};
+
+void Dithering::Handle(float CurrZ)
+{
+
+  if (Dithering::Amplitude == 0 || Dithering::TimeMS == 0 || (fabs(CurrZ - Dithering::PrevZ) < Dithering::MinLayerInterval))
+  {
+    SERIAL_ECHOLNPGM("Delta Z to small, skipping dithering");
+    return;
+  }
+  else
+  {
+
+    Dithering::PrevZ = CurrZ;
+
+    while (!Temperature::babystepsTodo[Z_AXIS] == 0) // if there are some existing babysteps to do just wait it out
+      ;
+
+    uint32_t DitherStartTime = millis();
+
+    int j = 0;
+
+    SERIAL_ECHOLNPGM("Start Dithering..");
+
+    while (millis() < (DitherStartTime + (Dithering::DitherSubTime * (j + 1))))
+    {
+
+      Temperature::babystepsTodo[Z_AXIS] = Temperature::babystepsTodo[Z_AXIS] + Dithering::Ditherssteps[j];
+      while (!Temperature::babystepsTodo[Z_AXIS] == 0)
+        ;
+
+      Temperature::babystepsTodo[Z_AXIS] = Temperature::babystepsTodo[Z_AXIS] - 2 * Dithering::Ditherssteps[j];
+      while (!Temperature::babystepsTodo[Z_AXIS] == 0)
+        ;
+
+      Temperature::babystepsTodo[Z_AXIS] = Temperature::babystepsTodo[Z_AXIS] + Dithering::Ditherssteps[j];
+      while (!Temperature::babystepsTodo[Z_AXIS] == 0)
+        ;
+
+      j++;
+
+      SERIAL_ECHOLNPGM("Dithering Done.");
+
+      if (j > 3)
+      { //for safety
+        return;
+      }
+    }
+  }
+}
+
+void Dithering::CalculateParameters()
+{
+  Dithering::DitherSubTime = Dithering::TimeMS / 4;
+
+  Dithering::Ditherssteps[0] = Dithering::Amplitude;
+  Dithering::Ditherssteps[1] = Dithering::Amplitude / 2;
+  Dithering::Ditherssteps[2] = Dithering::Amplitude / 4;
+  Dithering::Ditherssteps[3] = Dithering::Amplitude / 8;
+
+
+}

--- a/Marlin/dither.h
+++ b/Marlin/dither.h
@@ -1,0 +1,36 @@
+/**
+* Dithering seeks to improve mechanical in the z axis by oscillating the axis about it's intended position 
+* after each z move for a small amount of time and with a decaying amplitude. 
+* This allows the axis to 'average out' and settle more accurately on the intended position.
+* When using dithering babysteps must also be enabled. 
+
+* Dithering has the following options which can be set with M205 D<Dither Amplitude (steps)> T<Dither Time (ms)> H<Dither Minimum Layer Height (mm)>
+* Default is M205 D16 T100 H0.1, ie dither for 16 steps for 100ms with min layer interval of 0.1mm
+* Dither Values are not retained in eeprom (yet) so if change is needed should be manually set with custom g-code at the start of each print. 
+
+* D = Dither Amplitude (steps) inital amplitude of dither, set to ~0.5-1.5 times the numer of mircosteps (Requires Dither and Babysteps)
+* T = Dither Time (ms) how long to dither for (Requires Dither and Babysteps)
+* H = Dither Minimum layer height (um) minimum layer height interval where dither will be used (ensure compatibility with vase mode) (Requires Dither and Babysteps)
+*/
+
+#ifndef MARLIN_DITHER_H_
+#define MARLIN_DITHER_H_
+
+#include <stdint.h>
+
+class Dithering
+{
+public:
+    static uint16_t Amplitude; // how many steps for dither
+    static uint16_t TimeMS;
+    static float MinLayerInterval;
+    static float PrevZ;
+
+    static uint32_t DitherSubTime;
+    static uint8_t Ditherssteps[4];
+
+    static void Handle(float CurrZ);
+    static void CalculateParameters();
+};
+
+#endif //MARLIN_DITHER_H


### PR DESCRIPTION
Dithering seeks to improve mechanical in the z axis by oscillating the axis about it's intended position after each z move for a small amount of time and with a decaying amplitude. This allows the axis to 'average out' and settle more accurately on the intended position. When using dithering babysteps must also be enabled.

Dithering has the following options which can be set with
M205 D<Dither Amplitude (steps)> T<Dither Time (ms)> H<Dither Minimum Layer Height (mm)>

Default is M205 D16 T100 H0.1, ie dither for 16 steps for 100ms with min layer interval of 0.1mm
Dither Values are not retained in eeprom (yet) so if change is needed should be manually set with custom g-code at the start of each print.

D = Dither Amplitude (steps) inital amplitude of dither, set to ~0.5-1.5 times the numer of mircosteps (Requires Dither and Babysteps)
T = Dither Time (ms) how long to dither for (Requires Dither and Babysteps)
H = Dither Minimum layer height (mm) minimum layer height interval where dither will be used (ensure compatibility with vase mode) (Requires Dither and Babysteps)

https://github.com/MarlinFirmware/Marlin/issues/15354
https://www.youtube.com/watch?v=cjPFJGFkVU0
