### PR TITLE
Bring Raptor pins in parity with others

### DIFF
--- a/Marlin/src/pins/ramps/pins_FORMBOT_RAPTOR.h
+++ b/Marlin/src/pins/ramps/pins_FORMBOT_RAPTOR.h
@@ -31,8 +31,12 @@
   #error "Formbot supports up to 3 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_INFO_NAME      "Formbot Raptor"
-#define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME      "Formbot Raptor"
+#endif
+#ifndef DEFAULT_MACHINE_NAME
+  #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
+#endif
 
 //
 // Servos


### PR DESCRIPTION
Prevent overlapping defines as Raptor 2 includes the original Raptor pins file.