### PR TITLE
Fix build if EXTRUDERS = 0

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -325,8 +325,10 @@ void _internal_move_to_destination(const feedRate_t &fr_mm_s/*=0.0f*/
   const uint16_t old_pct = feedrate_percentage;
   feedrate_percentage = 100;
 
-  const float old_fac = planner.e_factor[active_extruder];
-  planner.e_factor[active_extruder] = 1.0f;
+  #if EXTRUDERS
+     const float old_fac = planner.e_factor[active_extruder];
+     planner.e_factor[active_extruder] = 1.0f;
+  #endif
 
   #if IS_KINEMATIC
     if (is_fast)
@@ -337,7 +339,9 @@ void _internal_move_to_destination(const feedRate_t &fr_mm_s/*=0.0f*/
 
   feedrate_mm_s = old_feedrate;
   feedrate_percentage = old_pct;
-  planner.e_factor[active_extruder] = old_fac;
+  #if EXTRUDERS
+    planner.e_factor[active_extruder] = old_fac;
+  #endif
 }
 
 /**


### PR DESCRIPTION
### Description

Fixes issue #15416 

### Benefits

Allows to build if EXTRUDERS = 0

### Related Issues

 #15416 