### PR TITLE
Use MAX_BED_POWER instead of BANG_MAX to heat outside PID_FUNCTIONAL_RANGE

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -943,7 +943,7 @@ void Temperature::min_temp_error(const heater_ind_t heater) {
         pid_reset = true;
       }
       else if (pid_error > PID_FUNCTIONAL_RANGE) {
-        pid_output = BANG_MAX;
+        pid_output = MAX_BED_POWER;
         pid_reset = true;
       }
       else {


### PR DESCRIPTION
 (instead of BANG_MAX)

### Description

Currently, PID code for heated bed use MAX_BED_POWER within PID_FUNCTIONAL_RANGE and BANG_MAX outside PID_FUNCTIONAL_RANGE.
But BANG_MAX option shared between extruders and heated bed.
I have 24V power for electronics with 12V heaters (its power limited through PID_MAX=64 and BANG_MAX=128), and 220V for heated bed (with no needed PWM limits, MAX_BED_POWER=255).

Now, Marlin has strange behavior: in the beginning of heating bed its produce half duty (due to limitation by BANG_MAX=128), then, when temperature goes into PID_FUNCTIONAL_RANGE, Marlin starts to produce full duty (due to MAX_BED_POWER=255).

Seems, this is wrong behavior due to copy-paste of code. We can separate BANG_MAX for bed, but I think, we can use MAX_BED_POWER in all cases of heating bed due to high temperature inertia of bed.

### Benefits

Correct computations when using different power sources for bed and extruders.

### Related Issues

Possible #13434, #9433 and so on...