### PR TITLE
mks_robin: missing TOUCH_CS_PIN

### DIFF
--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN.h
@@ -124,6 +124,10 @@
 #define FSMC_CS_PIN        PG12  // NE4
 #define FSMC_RS_PIN        PF0   // A0
 
+#if ENABLED(TOUCH_BUTTONS)
+  #define TOUCH_CS_PIN     PB1
+#endif
+
 //
 // Custom SPI pins
 //


### PR DESCRIPTION
The pin definition was forgotten when TOUCH_BUTTONS was enabled in config sample