### PR TITLE
Fix CR10 Stock Display timing with SKR_PRO V1.1

### DIFF
--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_PRO_V1.1.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_PRO_V1.1.h
@@ -207,6 +207,13 @@
     #define LCD_PINS_ENABLE PG7
     #define LCD_PINS_D4    PG3
 
+    // CR10_Stock Display needs a different delay setting on SKR PRO v1.1, so undef it here. 
+    // It will be defined again at the #HAS_GRAPHICAL_LCD section below.
+    #undef ST7920_DELAY_1
+    #undef ST7920_DELAY_2
+    #undef ST7920_DELAY_3
+
+
   #else
 
     #define LCD_PINS_RS    PD10


### PR DESCRIPTION
### Requirements

SKR Pro v1.1 and the CR10 Display (as used on CR10, Ender 3, Ender 5 etc.) 

### Description

Using the BIGTREETECH SKR Pro v1.1 and the Creality CR10 StockDisplay (Also used on Ender 3 / 5) the timings are off and the display will show pixel garbage only. So just for the CR10 StockDisplay an undef of the timings, will allow setting them as used for other display. 


### Benefits

CR10 Displays will work on SKR Pro v1.1 

### Related Issues

