### PR TITLE
fix step timer on Archim1

### DIFF
--- a/Marlin/src/HAL/HAL_DUE/timers.cpp
+++ b/Marlin/src/HAL/HAL_DUE/timers.cpp
@@ -50,7 +50,7 @@ const tTimerConfig TimerConfig [NUM_HARDWARE_TIMERS] = {
   { TC0, 0, TC0_IRQn,  3}, // 0 - [servo timer5]
   { TC0, 1, TC1_IRQn,  0}, // 1
   { TC0, 2, TC2_IRQn,  2}, // 2 - stepper
-  { TC1, 0, TC3_IRQn,  0}, // 3
+  { TC1, 0, TC3_IRQn,  0}, // 3 - stepper for BOARD_ARCHIM1
   { TC1, 1, TC4_IRQn, 15}, // 4 - temperature
   { TC1, 2, TC5_IRQn,  3}, // 5 - [servo timer3]
   { TC2, 0, TC6_IRQn, 14}, // 6 - tone

--- a/Marlin/src/HAL/HAL_DUE/timers.h
+++ b/Marlin/src/HAL/HAL_DUE/timers.h
@@ -39,7 +39,9 @@ typedef uint32_t hal_timer_t;
 
 #define HAL_TIMER_RATE         ((F_CPU) / 2)    // frequency of timers peripherals
 
+#ifndef STEP_TIMER_NUM
 #define STEP_TIMER_NUM 2  // index of timer to use for stepper
+#endif
 #define TEMP_TIMER_NUM 4  // index of timer to use for temperature
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 #define TONE_TIMER_NUM 6  // index of timer to use for beeper tones
@@ -61,7 +63,9 @@ typedef uint32_t hal_timer_t;
 #define ENABLE_TEMPERATURE_INTERRUPT()  HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
+#ifndef HAL_STEP_TIMER_ISR()
 #define HAL_STEP_TIMER_ISR()  void TC2_Handler()
+#endif
 #define HAL_TEMP_TIMER_ISR()  void TC4_Handler()
 #define HAL_TONE_TIMER_ISR()  void TC6_Handler()
 

--- a/Marlin/src/pins/sam/pins_ARCHIM1.h
+++ b/Marlin/src/pins/sam/pins_ARCHIM1.h
@@ -44,6 +44,12 @@
 #define BOARD_INFO_NAME "Archim 1.0"
 
 //
+// Timers
+//
+#define STEP_TIMER_NUM 3
+#define HAL_STEP_TIMER_ISR()  void TC3_Handler()
+
+//
 // Items marked * have been altered from Archim v1.0
 //
 


### PR DESCRIPTION
### Requirements

Archim 1.0 board (ATSAM3X8E + DRV8825 stepper drivers).

### Description

This pull request fixes the step timer assignments just for Archim1. 

https://github.com/MarlinFirmware/Marlin/pull/13481
Broke Archim1 motor movement. I confirmed on my end and tested the fix.

### Benefits

Archim1 motors work again.

### Related Issues
Archim1 steppers confirmed do not work:
https://github.com/MarlinFirmware/Marlin/issues/14173

