### PR TITLE
Use M73 progress instead of byte position if possible

### DIFF
--- a/Marlin/src/gcode/lcd/M73.cpp
+++ b/Marlin/src/gcode/lcd/M73.cpp
@@ -38,7 +38,7 @@
  *   This has no effect during an SD print job
  */
 void GcodeSuite::M73() {
-  if (parser.seen('P') && !IS_SD_PRINTING())
+  if (parser.seen('P'))
     ui.set_progress(parser.value_byte());
 }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1546,7 +1546,7 @@ void MarlinUI::update() {
         uint8_t progress = 0;
       #endif
       #if ENABLED(SDSUPPORT)
-        if (IS_SD_PRINTING()) progress = card.percentDone();
+        if (!_PLIMIT(progress)) progress = card.percentDone();
       #endif
       return _PLIMIT(progress);
     }


### PR DESCRIPTION
### Description

Currently M73 is ignored when printing from SD. But slicers has a lot more info to estimate overall difficulty of gcode in file instead of Marlin, which operates only byte position in file to show progress on LCD. Especially that effect visible on layers with many arcs, each of them results in a lot of gcode strings.

This patch will use provided progress in M73 command after first appearance in g-code file. If g-code file doesn't contains M73 old behavior will not changes.

PS: I wrote simple script for Cura to expose internal time estimation calculation to M73 commands on every layer change, just to usage example: https://github.com/LinFor/Marlin/blob/e-bot-skr/cura-profiles/scripts/EnrichPrintProgress.py

### Benefits

More accurate print progress reporting on LCD if possible.

### Related Issues

#13249, #12682
