### PR TITLE
Fix compile errors & temp range

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -389,7 +389,7 @@ volatile bool Temperature::temp_meas_ready = false;
       next_auto_fan_check_ms = next_temp_ms + 2500UL;
     #endif
 
-    if (target > GHV(BED_MAXTEMP, temp_range[heater].maxtemp) - 15) {
+    if (target > GHV(BED_MAXTEMP - 10, temp_range[heater].maxtemp - 15)) {
       SERIAL_ECHOLNPGM(MSG_PID_TEMP_TOO_HIGH);
       return;
     }
@@ -857,7 +857,7 @@ void Temperature::min_temp_error(const heater_ind_t heater) {
             #if HOTENDS == 1
               constexpr bool this_hotend = true;
             #else
-              const bool this_hotend = (e == active_extruder);
+              const bool this_hotend = (ee == active_extruder);
             #endif
             work_pid[ee].Kc = 0;
             if (this_hotend) {
@@ -886,7 +886,7 @@ void Temperature::min_temp_error(const heater_ind_t heater) {
       #endif // PID_OPENLOOP
 
       #if ENABLED(PID_DEBUG)
-        if (e == active_extruder) {
+        if (ee == active_extruder) {
           SERIAL_ECHO_START();
           SERIAL_ECHOPAIR(
             MSG_PID_DEBUG, ee,


### PR DESCRIPTION
BED_MAXTEMP is always subtracted by 10 while extruder by 15...fixed here
Fixed compile errors