### PR TITLE
Fix ExtUI onMeshUpdate event

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -819,9 +819,6 @@ namespace ExtUI {
           #endif
         }
       }
-      void onMeshUpdate(const uint8_t xpos, const uint8_t ypos, const float zval) {
-        UNUSED(xpos); UNUSED(ypos); UNUSED(zval);
-      }
     #endif
   #endif
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -138,7 +138,7 @@ namespace ExtUI {
       float getMeshPoint(const xy_uint8_t &pos);
       void setMeshPoint(const xy_uint8_t &pos, const float zval);
       void onMeshUpdate(const uint8_t xpos, const uint8_t ypos, const float zval);
-      inline void onMeshUpdate(const xy_uint8_t &pos, const float zval) { setMeshPoint(pos, zval); }
+      inline void onMeshUpdate(const xy_uint8_t &pos, const float zval) { onMeshUpdate(pos.x, pos.y, zval); }
     #endif
   #endif
 

--- a/Marlin/src/lcd/extui_example.cpp
+++ b/Marlin/src/lcd/extui_example.cpp
@@ -88,6 +88,10 @@ namespace ExtUI {
     // This is called after the entire EEPROM has been read,
     // whether successful or not.
   }
+
+  void onMeshUpdate(const uint8_t xpos, const uint8_t ypos, const float zval) {
+        // This is called when any mesh points are updated
+      }
 }
 
 #endif // EXTUI_EXAMPLE && EXTENSIBLE_UI

--- a/Marlin/src/lcd/extui_example.cpp
+++ b/Marlin/src/lcd/extui_example.cpp
@@ -90,8 +90,8 @@ namespace ExtUI {
   }
 
   void onMeshUpdate(const uint8_t xpos, const uint8_t ypos, const float zval) {
-        // This is called when any mesh points are updated
-      }
+    // This is called when any mesh points are updated
+  }
 }
 
 #endif // EXTUI_EXAMPLE && EXTENSIBLE_UI


### PR DESCRIPTION
Fix event and remove extraneous define calling UNUSED. Set inline call using new format to call legacy method to maintain compatibility.