### PR TITLE
Fix tool-change move with hotend offset

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -906,7 +906,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       #endif
 
       #if HAS_HOTEND_OFFSET
-        xyz_pos_t diff = hotend_offset[new_tool];
+        xyz_pos_t diff = hotend_offset[new_tool] - hotend_offset[old_tool];
         #if ENABLED(DUAL_X_CARRIAGE)
           diff.x = 0;
         #endif


### PR DESCRIPTION
### Description

When performing a tool change, calculate the move based on the difference between the old and new tool offsets.

This seems to be a regression that occurred as part of the XYZ struct refactor.

Code before 48f50c54453deb5b65fa0a8dcd6348f5cab338f0, which factored in old_tool:
```
        #if ENABLED(DUAL_X_CARRIAGE)
          constexpr float xdiff = 0;
        #else
          const float xdiff = hotend_offset[X_AXIS][new_tool] - hotend_offset[X_AXIS][old_tool];
        #endif
        const float ydiff = hotend_offset[Y_AXIS][new_tool] - hotend_offset[Y_AXIS][old_tool],
                    zdiff = hotend_offset[Z_AXIS][new_tool] - hotend_offset[Z_AXIS][old_tool];
```

Code after 48f50c54453deb5b65fa0a8dcd6348f5cab338f0, which ignores old_tool:
```
        xyz_pos_t diff = hotend_offset[new_tool];
        #if ENABLED(DUAL_X_CARRIAGE)
          diff.x = 0;
        #endif
```

### Benefits

Allows tool changes to apply an offset correctly after the first change.

Without this, my printer would move the printhead every time I switched to T1, but would not move when switched to T0. The result would be even more interesting with more than two hotends.

With this change, I can alternate tools and see the expected alternating movement on my printer.

### Related Issues

I did not report an issue for this, as reporting it was significantly more work than fixing it.
