### PR TITLE
Fix Runout pin in ReARM board

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
@@ -241,9 +241,9 @@
 //
 #define LED_PIN            P4_28   // (13)
 
-// define digital pin 4 for the filament runout sensor. Use the RAMPS 1.4 digital input 4 on the servos connector
+// define digital pin 5 for the filament runout sensor. Use the RAMPS 1.4 digital input 5 on the servos connector
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN   P1_18   // (4)
+  #define FIL_RUNOUT_PIN   P1_19   // (5)
 #endif
 
 #define PS_ON_PIN          P2_12   // (12)


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

According of this https://github.com/MarlinFirmware/Marlin/issues/10231#issuecomment-439280303, Runout sensor conected to the Ramps 1.4 Servo3 (D5, P1_18) is unable to detect the signal when the runout sensor is triggered. change to other pin, like the Servo2 (D5, P1_19), fix the problem. this fix https://github.com/MarlinFirmware/Marlin/issues/15200

### Benefits

Fix the runout sensor in the combo ReARM+Ramps 1.4

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/15200
