### PR TITLE
Enable M191

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -446,7 +446,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
 
       #if HAS_HEATED_CHAMBER
         case 141: M141(); break;                                  // M141: Set chamber temperature
-        //case 191: M191(); break;                                // M191: Wait for chamber temperature to reach target
+        case 191: M191(); break;                                // M191: Wait for chamber temperature to reach target
       #endif
 
       #if ENABLED(AUTO_REPORT_TEMPERATURES) && HAS_TEMP_SENSOR

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -446,7 +446,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
 
       #if HAS_HEATED_CHAMBER
         case 141: M141(); break;                                  // M141: Set chamber temperature
-        case 191: M191(); break;                                // M191: Wait for chamber temperature to reach target
+        case 191: M191(); break;                                  // M191: Wait for chamber temperature to reach target
       #endif
 
       #if ENABLED(AUTO_REPORT_TEMPERATURES) && HAS_TEMP_SENSOR

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -620,7 +620,7 @@ private:
 
   #if HAS_HEATED_CHAMBER
     static void M141();
-    //static void M191();
+    static void M191();
   #endif
 
   #if HOTENDS && HAS_LCD_MENU

--- a/Marlin/src/gcode/temperature/M141_M191.cpp
+++ b/Marlin/src/gcode/temperature/M141_M191.cpp
@@ -27,7 +27,6 @@
 #include "../gcode.h"
 #include "../../module/temperature.h"
 
-/*
 #include "../../module/motion.h"
 #include "../../lcd/ultralcd.h"
 
@@ -40,7 +39,6 @@
 #endif
 
 #include "../../Marlin.h" // for wait_for_heatup and idle()
-*/
 
 /**
  * M141: Set chamber temperature
@@ -54,7 +52,6 @@ void GcodeSuite::M141() {
  * M191: Sxxx Wait for chamber current temp to reach target temp. Waits only when heating
  *       Rxxx Wait for chamber current temp to reach target temp. Waits when heating and cooling
  */
-/*
 void GcodeSuite::M191() {
   if (DEBUGGING(DRYRUN)) return;
 
@@ -72,6 +69,5 @@ void GcodeSuite::M191() {
 
   thermalManager.wait_for_chamber(no_wait_for_cooling);
 }
-*/
 
 #endif // HAS_HEATED_CHAMBER

--- a/Marlin/src/gcode/temperature/M141_M191.cpp
+++ b/Marlin/src/gcode/temperature/M141_M191.cpp
@@ -65,9 +65,11 @@ void GcodeSuite::M191() {
   }
   else return;
 
-  lcd_setstatusPGM(thermalManager.isHeatingChamber() ? GET_TEXT(MSG_CHAMBER_HEATING) : GET_TEXT(MSG_CHAMBER_COOLING));
-
-  thermalManager.wait_for_chamber(no_wait_for_cooling);
+  const bool is_heating = thermalManager.isHeatingChamber();
+  if (is_heating || !no_wait_for_cooling) {
+    lcd_setstatusPGM(is_heating ? GET_TEXT(MSG_CHAMBER_HEATING) : GET_TEXT(MSG_CHAMBER_COOLING));
+    thermalManager.wait_for_chamber(false);
+  }
 }
 
 #endif // HAS_HEATED_CHAMBER

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -3160,7 +3160,7 @@ void Temperature::isr() {
 
   #endif // HAS_HEATED_BED
 
-  #if 0 && HAS_HEATED_CHAMBER
+  #if HAS_HEATED_CHAMBER
 
     #ifndef MIN_COOLING_SLOPE_DEG_CHAMBER
       #define MIN_COOLING_SLOPE_DEG_CHAMBER 1.50


### PR DESCRIPTION
### Requirements

-None

### Description

Enables M191 for heated chambers

### Benefits

we can do wait for chamber to reach target

