### PR TITLE
Update Polish language

### DIFF
--- a/Marlin/src/lcd/language/language_pl.h
+++ b/Marlin/src/lcd/language/language_pl.h
@@ -146,9 +146,9 @@ namespace Language_pl {
   PROGMEM Language_Str MSG_A_RETRACT                       = _UxGT("A-wycofanie");
   PROGMEM Language_Str MSG_A_TRAVEL                        = _UxGT("A-przesuń.");
   PROGMEM Language_Str MSG_STEPS_PER_MM                    = _UxGT("kroki/mm");
-  PROGMEM Language_Str MSG_A_STEPS                         = _UxGT("kroki") LCD_MSG_A _UxGT("/mm");
-  PROGMEM Language_Str MSG_B_STEPS                         = _UxGT("kroki") LCD_MSG_B _UxGT("/mm");
-  PROGMEM Language_Str MSG_C_STEPS                         = _UxGT("kroki") LCD_MSG_C _UxGT("/mm");
+  PROGMEM Language_Str MSG_A_STEPS                         = _UxGT("kroki") LCD_STR_A _UxGT("/mm");
+  PROGMEM Language_Str MSG_B_STEPS                         = _UxGT("kroki") LCD_STR_B _UxGT("/mm");
+  PROGMEM Language_Str MSG_C_STEPS                         = _UxGT("kroki") LCD_STR_C _UxGT("/mm");
   PROGMEM Language_Str MSG_E_STEPS                         = _UxGT("krokiE/mm");
   PROGMEM Language_Str MSG_E0_STEPS                        = _UxGT("kroki ") LCD_STR_E0 _UxGT("/mm");
   PROGMEM Language_Str MSG_E1_STEPS                        = _UxGT("kroki ") LCD_STR_E1 _UxGT("/mm");


### PR DESCRIPTION
Probably there is typographic error in language_pl.h

Missing definition of LCD_MSG_A LCD_MSG_B LCD_MSG_C in the Marlin\src\lcd\language\language_pl.h.

In language_en.h in corresponding position are accordingly: LCD_STR_A LCD_STR_B LCD_STR_C

After change in language_pl.h to LCD_STR_A LCD_STR_B LCD_STR_C compilation goes fine.