### PR TITLE
[bugfix 1.1.x] Fix G2/G3 so that slicer rounding error does not require impossible arc

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3707,7 +3707,8 @@ inline void gcode_G0_G1(
           const float e = clockwise ^ (r < 0) ? -1 : 1,             // clockwise -1/1, counterclockwise 1/-1
                       dx = p2 - p1, dy = q2 - q1,                   // X and Y differences
                       d = HYPOT(dx, dy),                            // Linear distance between the points
-                      h = SQRT(sq(r) - sq(d * 0.5f)),               // Distance to the arc pivot-point
+                      h2 = ( r - 0.5f * d) * (r + 0.5f * d),        // factor to reduce rounding error                        
+                      h = ( h2 >= 0) ? SQRT(h2) : 0.0f,             // Distance to the arc pivot-point
                       mx = (p1 + p2) * 0.5f, my = (q1 + q2) * 0.5f, // Point between the two points
                       sx = -dy / d, sy = dx / d,                    // Slope of the perpendicular bisector
                       cx = mx + e * h * sx, cy = my + e * h * sy;   // Pivot-point of the arc

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -3707,8 +3707,8 @@ inline void gcode_G0_G1(
           const float e = clockwise ^ (r < 0) ? -1 : 1,             // clockwise -1/1, counterclockwise 1/-1
                       dx = p2 - p1, dy = q2 - q1,                   // X and Y differences
                       d = HYPOT(dx, dy),                            // Linear distance between the points
-                      h2 = ( r - 0.5f * d) * (r + 0.5f * d),        // factor to reduce rounding error                        
-                      h = ( h2 >= 0) ? SQRT(h2) : 0.0f,             // Distance to the arc pivot-point
+                      h2 = (r - 0.5f * d) * (r + 0.5f * d),         // factor to reduce rounding error
+                      h = (h2 >= 0) ? SQRT(h2) : 0.0f,              // Distance to the arc pivot-point
                       mx = (p1 + p2) * 0.5f, my = (q1 + q2) * 0.5f, // Point between the two points
                       sx = -dy / d, sy = dx / d,                    // Slope of the perpendicular bisector
                       cx = mx + e * h * sx, cy = my + e * h * sy;   // Pivot-point of the arc


### PR DESCRIPTION
### Requirements



### Description


This is  a back port of a fix to bugfix-2.0.x
It fixes the problem caused by slicer rounding error creating a G2/G3 request for a geometrically impossible arc whose diameter would be less than the distance to the destination point.


### Benefits

Fixes #14745

### Related Issues

