### PR TITLE
Fixed pid_autotune_menu made pid_label accessible

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -334,7 +334,7 @@ void menu_backlash();
     // PID-P E5, PID-I E5, PID-D E5, PID-C E5, PID Autotune E5
     //
 
-    #if (ENABLED(PID_EDIT_MENU) || ENABLED(PID_AUTOTUNE_MENU))
+    #if EITHER(PID_EDIT_MENU, PID_AUTOTUNE_MENU)
       #if HOTENDS > 1 && ENABLED(PID_PARAMS_PER_HOTEND)
         #define PID_LABEL(MSG,N) MSG##_E##N
       #else

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -333,14 +333,16 @@ void menu_backlash();
     // PID-P E4, PID-I E4, PID-D E4, PID-C E4, PID Autotune E4
     // PID-P E5, PID-I E5, PID-D E5, PID-C E5, PID Autotune E5
     //
-    #if ENABLED(PID_EDIT_MENU)
 
+    #if (ENABLED(PID_EDIT_MENU) || ENABLED(PID_AUTOTUNE_MENU))
       #if HOTENDS > 1 && ENABLED(PID_PARAMS_PER_HOTEND)
         #define PID_LABEL(MSG,N) MSG##_E##N
       #else
         #define PID_LABEL(MSG,N) MSG
       #endif
+    #endif
 
+    #if ENABLED(PID_EDIT_MENU)
       #define _PID_BASE_MENU_ITEMS(N) \
         raw_Ki = unscalePID_i(PID_PARAM(Ki, N)); \
         raw_Kd = unscalePID_d(PID_PARAM(Kd, N)); \


### PR DESCRIPTION
### Description

This fixes a compilation issue when PID_AUTOTUNE_MENU is enabled. 
PID_LABEL was moved and only made accessible to PID_EDIT_MENU. This changes makes PID_LABEL accessible to both PID_EDIT_MENU and PID_AUTOTUNE_MENU, fixing the compilation issues.

### Benefits

PID_AUTOTUNE_MENU can now be enabled again

### Related Issues

#15512 