### PR TITLE
elapsed time overflow warning fix

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -345,7 +345,7 @@ void MarlinUI::draw_status_screen() {
       static char progress_string[5];
     #endif
     static uint8_t lastElapsed = 0, elapsed_x_pos = 0;
-    static char elapsed_string[10];
+    static char elapsed_string[22];
     #if ENABLED(SHOW_REMAINING_TIME)
       #define SHOW_REMAINING_TIME_PREFIX 'E'
       static uint8_t estimation_x_pos = 0;

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -345,7 +345,7 @@ void MarlinUI::draw_status_screen() {
       static char progress_string[5];
     #endif
     static uint8_t lastElapsed = 0, elapsed_x_pos = 0;
-    static char elapsed_string[22];
+    static char elapsed_string[16];
     #if ENABLED(SHOW_REMAINING_TIME)
       #define SHOW_REMAINING_TIME_PREFIX 'E'
       static uint8_t estimation_x_pos = 0;

--- a/Marlin/src/libs/duration_t.h
+++ b/Marlin/src/libs/duration_t.h
@@ -151,15 +151,15 @@ struct duration_t {
              m = uint16_t(this->minute() % 60UL);
     if (with_days) {
       uint16_t d = this->day();
-      sprintf_P(buffer, PSTR("%ud %02u:%02u"), d, h % 24, m);
+      sprintf_P(buffer, PSTR("%hud %02hu:%02hu"), d, h % 24, m);
       return d >= 10 ? 9 : 8;
     }
     else if (h < 100) {
-      sprintf_P(buffer, PSTR("%02u:%02u"), h, m);
+      sprintf_P(buffer, PSTR("%02hu:%02hu"), h, m);
       return 5;
     }
     else {
-      sprintf_P(buffer, PSTR("%u:%02u"), h, m);
+      sprintf_P(buffer, PSTR("%hu:%02hu"), h, m);
       return 6;
     }
   }


### PR DESCRIPTION
tried to fix it with `snprintf` in `libs/duration_t.h` but it's worse... :/

can be seen on LPC1768, mks_robin and longer travis tests