### PR TITLE
Bring SPI_SENSORLESS code up to date

### DIFF
--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -537,7 +537,7 @@ void Endstops::update() {
   /**
    * Check and update endstops
    */
-  #if HAS_X_MIN
+  #if HAS_X_MIN && !X_SPI_SENSORLESS
     #if ENABLED(X_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(X, MIN);
       #if HAS_X2_MIN
@@ -550,7 +550,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_X_MAX
+  #if HAS_X_MAX && !X_SPI_SENSORLESS
     #if ENABLED(X_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(X, MAX);
       #if HAS_X2_MAX
@@ -563,7 +563,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_Y_MIN
+  #if HAS_Y_MIN && !Y_SPI_SENSORLESS
     #if ENABLED(Y_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(Y, MIN);
       #if HAS_Y2_MIN
@@ -576,7 +576,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_Y_MAX
+  #if HAS_Y_MAX && !Y_SPI_SENSORLESS
     #if ENABLED(Y_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(Y, MAX);
       #if HAS_Y2_MAX
@@ -589,7 +589,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_Z_MIN
+  #if HAS_Z_MIN && !Z_SPI_SENSORLESS
     #if Z_MULTI_ENDSTOPS
       UPDATE_ENDSTOP_BIT(Z, MIN);
       #if HAS_Z2_MIN
@@ -616,7 +616,7 @@ void Endstops::update() {
     UPDATE_ENDSTOP_BIT(Z, MIN_PROBE);
   #endif
 
-  #if HAS_Z_MAX
+  #if HAS_Z_MAX && !Z_SPI_SENSORLESS
     // Check both Z dual endstops
     #if Z_MULTI_ENDSTOPS
       UPDATE_ENDSTOP_BIT(Z, MAX);


### PR DESCRIPTION
### Description

This PR addresses the issues I'm having with the `SPI_SENSORLESS` feature, as described in #14929 My axis kept crashing into the frame during homing without ever triggering stallGuard.
 
For me the SW SPI communication was returning all zeros. I replaced the code with the example code from the TMCStepper library and now it seems to work fine. I think the lib does a dummy read before trying to get the actual data; maybe that fixes some weird timing quirks.

Afterwards I saw that the check now returned the correct stallGuard result, but it was ignored by the endstop update routine. The live endstop state is overwritten by `UPDATE_ENDSTOP_BIT`.

My commit fixes this, however I find it a bit clunky.

An alternative would be to allow users to disable HAS_XMIN when `[XYZ]_SPI_SENSORLESS` is set, however this is currently not possible and also would not be very intuitive imho.

I also suspect that this code…
```cpp
if (stepper.axis_is_moving(X_AXIS)) {
    if (stepper.motor_direction(X_AXIS_HEAD)) { // -direction
      #if HAS_X_MIN || (X_SPI_SENSORLESS && X_HOME_DIR < 0)
        #if ENABLED(X_DUAL_ENDSTOPS)
          PROCESS_DUAL_ENDSTOP(X, X2, MIN);
        #else
          if (X_MIN_TEST) PROCESS_ENDSTOP(X, MIN);
        #endif
      #endif
    }
```
…does not do what it is supposed to do.

I've tested it with SKR 1.3/LPC1768 and TMC2130s, but I hope it should apply to other architectures as well.
I'm running a CoreXY setup, so maybe this triggers some edge case.

### Benefits

Makes `SPI_SENSORLESS` functional

### Related Issues

#14929 
