### PR TITLE
Respond to M105 even if there are no thermistors

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -168,7 +168,6 @@
 #define MSG_INVALID_E_STEPPER               "Invalid E stepper"
 #define MSG_E_STEPPER_NOT_SPECIFIED         "E stepper not specified"
 #define MSG_INVALID_SOLENOID                "Invalid solenoid"
-#define MSG_ERR_NO_THERMISTORS              "No thermistors - no temperature"
 #define MSG_M115_REPORT                     "FIRMWARE_NAME:Marlin " DETAILED_BUILD_VERSION " SOURCE_CODE_URL:" SOURCE_CODE_URL " PROTOCOL_VERSION:" PROTOCOL_VERSION " MACHINE_TYPE:" MACHINE_NAME " EXTRUDER_COUNT:" STRINGIFY(EXTRUDERS) " UUID:" MACHINE_UUID
 #define MSG_COUNT_X                         " Count X:"
 #define MSG_COUNT_A                         " Count A:"

--- a/Marlin/src/gcode/temperature/M105.cpp
+++ b/Marlin/src/gcode/temperature/M105.cpp
@@ -39,7 +39,9 @@ void GcodeSuite::M105() {
       #endif
     );
   #else // !HAS_TEMP_SENSOR
-    SERIAL_ERROR_MSG(MSG_ERR_NO_THERMISTORS);
+    // Hosts such as printrun send M105 to check if firmware is responding.
+    SERIAL_ECHOPGM(MSG_OK);
+    SERIAL_ECHOPGM(" T:0");
   #endif
 
   SERIAL_EOL();


### PR DESCRIPTION
Hosts such as printrun use M105 to "ping" the firmware. When M105 returns an error the hosts refuse to connect.

<img width="332" alt="Screen Shot 2019-10-15 at 12 56 56 PM" src="https://user-images.githubusercontent.com/870901/66856828-a7e68980-ef4b-11e9-897a-dd2fe6492a36.png">

Tested with

- Printrun (pronterface / pronsole)
- Octoprint

### Requirements

* When setting EXTRUDERS = 0, hosts such as printrun and octoprint should still be able to connect and work

### Description

Hosts use M105 to "ping" the firmware. When M105 returns an error the hosts refuse to connect.

This is readily observed when setting EXTRUDERS = 0

Klipper firmware responds to M105 with "ok T:0" when it has no connection to MCU and no temperature reading. This seems to work as expected: Both printrun and Octoprint ignore the temperature returned in this manner while they continue polling as usual.

### Benefits

Makes it possible to connect to firmware with pronterface and octoprint even if there are no configured thermistors

### Related Issues

None

Please let me know if a configurable option is preferred to removing the error message.
