### PR TITLE
Fix Custom Menu Title

### DIFF
--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -171,10 +171,10 @@ void menu_main() {
 
   #if ENABLED(CUSTOM_USER_MENUS)
     #ifdef CUSTOM_USER_MENU_TITLE
-      #undef MSG_USER_MENU
-      #define MSG_USER_MENU CUSTOM_USER_MENU_TITLE
+      SUBMENU(CUSTOM_USER_MENU_TITLE, menu_user);
+    #else
+      SUBMENU(MSG_USER_MENU, menu_user);
     #endif
-    SUBMENU(MSG_USER_MENU, menu_user);
   #endif
 
   #if ENABLED(ADVANCED_PAUSE_FEATURE)


### PR DESCRIPTION
Fix compile error defining custom user menu title.

With the language refactor, override strings can no longer share the same name.