### PR TITLE
Option to rotate Percent, (E)lapsed, and (R)emaining time

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -890,8 +890,10 @@
 //#define LCD_SET_PROGRESS_MANUALLY
 
 #if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  #define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
+  #define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  #define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                       // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -890,10 +890,10 @@
 //#define LCD_SET_PROGRESS_MANUALLY
 
 #if HAS_PRINT_PROGRESS
-  #define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  #define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  #define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                       // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -340,20 +340,20 @@ void MarlinUI::draw_status_screen() {
       #define _SD_DURATION_X(len) (LCD_PIXEL_WIDTH - (len) * (MENU_FONT_WIDTH))
     #endif
 
-    static uint8_t progress_bar_solid_width = 0, lastProgress = 0;
     #if ENABLED(DOGM_SD_PERCENT)
       static char progress_string[5];
     #endif
-    static uint8_t lastElapsed = 0, elapsed_x_pos = 0;
+    static uint8_t lastElapsed = 0, lastProgress = 0;
+    static u8g_uint_t elapsed_x_pos = 0, progress_bar_solid_width = 0;
     static char elapsed_string[16];
     #if ENABLED(SHOW_REMAINING_TIME)
-      static uint8_t estimation_x_pos = 0;
+      static u8g_uint_t estimation_x_pos = 0;
       static char estimation_string[10];
       #if ENABLED(DOGM_SD_PERCENT) && ENABLED(ROTATE_PROGRESS_DISPLAY)
         #define PROGRESS_TIME_PREFIX "PROG"
         #define ELAPSED_TIME_PREFIX "ELAP"
         #define SHOW_REMAINING_TIME_PREFIX "REM"
-        static uint8_t progress_x_pos = 0;
+        static u8g_uint_t progress_x_pos = 0;
         static uint8_t progress_state = 0;
         static bool prev_blink = 0;
       #else
@@ -397,19 +397,26 @@ void MarlinUI::draw_status_screen() {
       ;
       duration_t elapsed = print_job_timer.duration();
       const uint8_t p = progress & 0xFF, ev = elapsed.value & 0xFF;
-      if (progress > 1 && p != lastProgress) {
+      if (progress > 1 || p != lastProgress) {
         lastProgress = p;
 
-        progress_bar_solid_width = uint8_t((PROGRESS_BAR_WIDTH - 2) * progress / (PROGRESS_SCALE) * 0.01f);
+        progress_bar_solid_width = u8g_uint_t((PROGRESS_BAR_WIDTH - 2) * progress / (PROGRESS_SCALE) * 0.01f);
 
         #if ENABLED(DOGM_SD_PERCENT)
-          strcpy(progress_string, (
-            #if ENABLED(PRINT_PROGRESS_SHOW_DECIMALS)
-              permyriadtostr4(progress)
-            #else
-              ui8tostr3(progress / (PROGRESS_SCALE))
-            #endif
-          ));
+          if (progress == 0) {
+            progress_string[0] = '\0';
+            estimation_string[0] = '\0';
+            estimation_x_pos = _PROGRESS_CENTER_X(0);
+          }
+          else {
+            strcpy(progress_string, (
+              #if ENABLED(PRINT_PROGRESS_SHOW_DECIMALS)
+                permyriadtostr4(progress)
+              #else
+                ui8tostr3(progress / (PROGRESS_SCALE))
+              #endif
+            ));
+          }
           #if ENABLED(SHOW_REMAINING_TIME)  && ENABLED(ROTATE_PROGRESS_DISPLAY) // Tristate progress display mode
             progress_x_pos = _SD_DURATION_X(strlen(progress_string)+1);
           #endif

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -349,7 +349,7 @@ void MarlinUI::draw_status_screen() {
     #if ENABLED(SHOW_REMAINING_TIME)
       static u8g_uint_t estimation_x_pos = 0;
       static char estimation_string[10];
-      #if ENABLED(DOGM_SD_PERCENT) && ENABLED(ROTATE_PROGRESS_DISPLAY)
+      #if BOTH(DOGM_SD_PERCENT, ROTATE_PROGRESS_DISPLAY)
         #define PROGRESS_TIME_PREFIX "PROG"
         #define ELAPSED_TIME_PREFIX "ELAP"
         #define SHOW_REMAINING_TIME_PREFIX "REM"
@@ -419,8 +419,8 @@ void MarlinUI::draw_status_screen() {
               #endif
             ));
           }
-          #if ENABLED(SHOW_REMAINING_TIME)  && ENABLED(ROTATE_PROGRESS_DISPLAY) // Tristate progress display mode
-            progress_x_pos = _SD_DURATION_X(strlen(progress_string)+1);
+          #if BOTH(SHOW_REMAINING_TIME, ROTATE_PROGRESS_DISPLAY) // Tri-state progress display mode
+            progress_x_pos = _SD_DURATION_X(strlen(progress_string) + 1);
           #endif
         #endif
       }
@@ -441,7 +441,7 @@ void MarlinUI::draw_status_screen() {
             else {
               const bool has_days = (estimation.value >= 60*60*24L);
               const uint8_t len = estimation.toDigital(estimation_string, has_days);
-              #if ENABLED(DOGM_SD_PERCENT) && ENABLED(ROTATE_PROGRESS_DISPLAY)
+              #if BOTH(DOGM_SD_PERCENT, ROTATE_PROGRESS_DISPLAY)
                 estimation_x_pos = _SD_DURATION_X(len);
               #else
                 estimation_x_pos = _SD_DURATION_X(len + 1);

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -432,13 +432,19 @@ void MarlinUI::draw_status_screen() {
         #if ENABLED(SHOW_REMAINING_TIME)
           if (!(ev & 0x3)) {
             duration_t estimation = elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress;
-            const bool has_days = (estimation.value >= 60*60*24L);
-            const uint8_t len = estimation.toDigital(estimation_string, has_days);
-            #if ENABLED(DOGM_SD_PERCENT) && ENABLED(ROTATE_PROGRESS_DISPLAY)
-              estimation_x_pos = _SD_DURATION_X(len);
-            #else
-              estimation_x_pos = _SD_DURATION_X(len + 1);
-            #endif
+            if (estimation.value == 0) {
+              estimation_string[0] = '\0';
+              estimation_x_pos = _PROGRESS_CENTER_X(0);
+            }
+            else {
+              const bool has_days = (estimation.value >= 60*60*24L);
+              const uint8_t len = estimation.toDigital(estimation_string, has_days);
+              #if ENABLED(DOGM_SD_PERCENT) && ENABLED(ROTATE_PROGRESS_DISPLAY)
+                estimation_x_pos = _SD_DURATION_X(len);
+              #else
+                estimation_x_pos = _SD_DURATION_X(len + 1);
+              #endif
+            }
           }
         #endif
       }

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -397,7 +397,7 @@ void MarlinUI::draw_status_screen() {
       ;
       duration_t elapsed = print_job_timer.duration();
       const uint8_t p = progress & 0xFF, ev = elapsed.value & 0xFF;
-      if (progress > 1 || p != lastProgress) {
+      if (p != lastProgress) {
         lastProgress = p;
 
         progress_bar_solid_width = u8g_uint_t((PROGRESS_BAR_WIDTH - 2) * progress / (PROGRESS_SCALE) * 0.01f);

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -597,7 +597,7 @@ void MarlinUI::draw_status_screen() {
           lcd_put_wchar(PROGRESS_BAR_X, EXTRAS_BASELINE, SHOW_REMAINING_TIME_PREFIX);
           lcd_put_u8str(estimation_x_pos, EXTRAS_BASELINE, estimation_string);
         }
-        else {
+        else if (elapsed_string[0] != '\0'){
           lcd_put_wchar(PROGRESS_BAR_X, EXTRAS_BASELINE, ELAPSED_TIME_PREFIX);
           lcd_put_u8str(elapsed_x_pos, EXTRAS_BASELINE, elapsed_string);
         }

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -335,9 +335,9 @@ void MarlinUI::draw_status_screen() {
 
   #if HAS_PRINT_PROGRESS
     #if DISABLED(DOGM_SD_PERCENT)
-      #define _SD_DURATION_X(len) (PROGRESS_BAR_X + (PROGRESS_BAR_WIDTH) / 2 - (len) * (MENU_FONT_WIDTH) / 2)
+      #define _SD_INFO_X(len) (PROGRESS_BAR_X + (PROGRESS_BAR_WIDTH) / 2 - (len) * (MENU_FONT_WIDTH) / 2)
     #else
-      #define _SD_DURATION_X(len) (LCD_PIXEL_WIDTH - (len) * (MENU_FONT_WIDTH))
+      #define _SD_INFO_X(len) (LCD_PIXEL_WIDTH - (len) * (MENU_FONT_WIDTH))
     #endif
 
     #if ENABLED(DOGM_SD_PERCENT)
@@ -350,14 +350,9 @@ void MarlinUI::draw_status_screen() {
       static u8g_uint_t estimation_x_pos = 0;
       static char estimation_string[10];
       #if BOTH(DOGM_SD_PERCENT, ROTATE_PROGRESS_DISPLAY)
-        #define PROGRESS_TIME_PREFIX "PROG"
-        #define ELAPSED_TIME_PREFIX "ELAP"
-        #define SHOW_REMAINING_TIME_PREFIX "REM"
         static u8g_uint_t progress_x_pos = 0;
         static uint8_t progress_state = 0;
         static bool prev_blink = 0;
-      #else
-        #define SHOW_REMAINING_TIME_PREFIX 'R'
       #endif
     #endif
   #endif
@@ -407,7 +402,7 @@ void MarlinUI::draw_status_screen() {
             progress_string[0] = '\0';
             #if ENABLED(SHOW_REMAINING_TIME)
               estimation_string[0] = '\0';
-              estimation_x_pos = _SD_DURATION_X(0);
+              estimation_x_pos = _SD_INFO_X(0);
             #endif
           }
           else {
@@ -420,7 +415,7 @@ void MarlinUI::draw_status_screen() {
             ));
           }
           #if BOTH(SHOW_REMAINING_TIME, ROTATE_PROGRESS_DISPLAY) // Tri-state progress display mode
-            progress_x_pos = _SD_DURATION_X(strlen(progress_string) + 1);
+            progress_x_pos = _SD_INFO_X(strlen(progress_string));
           #endif
         #endif
       }
@@ -429,22 +424,22 @@ void MarlinUI::draw_status_screen() {
         lastElapsed = ev;
         const bool has_days = (elapsed.value >= 60*60*24L);
         const uint8_t len = elapsed.toDigital(elapsed_string, has_days);
-        elapsed_x_pos = _SD_DURATION_X(len);
+        elapsed_x_pos = _SD_INFO_X(len);
 
         #if ENABLED(SHOW_REMAINING_TIME)
           if (!(ev & 0x3)) {
             duration_t estimation = elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress;
             if (estimation.value == 0) {
               estimation_string[0] = '\0';
-              estimation_x_pos = _SD_DURATION_X(0);
+              estimation_x_pos = _SD_INFO_X(0);
             }
             else {
               const bool has_days = (estimation.value >= 60*60*24L);
               const uint8_t len = estimation.toDigital(estimation_string, has_days);
               #if BOTH(DOGM_SD_PERCENT, ROTATE_PROGRESS_DISPLAY)
-                estimation_x_pos = _SD_DURATION_X(len);
+                estimation_x_pos = _SD_INFO_X(len);
               #else
-                estimation_x_pos = _SD_DURATION_X(len + 1);
+                estimation_x_pos = _SD_INFO_X(len + 1);
               #endif
             }
           }
@@ -605,17 +600,16 @@ void MarlinUI::draw_status_screen() {
 
         if (progress_state == 0) {
           if (progress_string[0]) {
-            lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, PROGRESS_TIME_PREFIX);
             lcd_put_u8str(progress_x_pos, EXTRAS_BASELINE, progress_string);
             lcd_put_wchar('%');
           }
         }
         else if (progress_state == 2 && estimation_string[0]) {
-          lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, SHOW_REMAINING_TIME_PREFIX);
+          lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, "R:");
           lcd_put_u8str(estimation_x_pos, EXTRAS_BASELINE, estimation_string);
         }
         else if (elapsed_string[0]) {
-          lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, ELAPSED_TIME_PREFIX);
+          lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, "E:");
           lcd_put_u8str(elapsed_x_pos, EXTRAS_BASELINE, elapsed_string);
         }
 
@@ -638,7 +632,7 @@ void MarlinUI::draw_status_screen() {
 
         #if ENABLED(SHOW_REMAINING_TIME)
           if (blink && estimation_string[0]) {
-            lcd_put_wchar(estimation_x_pos, EXTRAS_BASELINE, SHOW_REMAINING_TIME_PREFIX);
+            lcd_put_wchar(estimation_x_pos, EXTRAS_BASELINE, 'R');
             lcd_put_u8str(estimation_string);
           }
           else

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -405,8 +405,10 @@ void MarlinUI::draw_status_screen() {
         #if ENABLED(DOGM_SD_PERCENT)
           if (progress == 0) {
             progress_string[0] = '\0';
-            estimation_string[0] = '\0';
-            estimation_x_pos = _PROGRESS_CENTER_X(0);
+            #if ENABLED(SHOW_REMAINING_TIME)
+              estimation_string[0] = '\0';
+              estimation_x_pos = _SD_DURATION_X(0);
+            #endif
           }
           else {
             strcpy(progress_string, (

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -596,38 +596,38 @@ void MarlinUI::draw_status_screen() {
 
     if (PAGE_CONTAINS(EXTRAS_BASELINE - INFO_FONT_ASCENT, EXTRAS_BASELINE - 1)) {
 
-      #if ENABLED(DOGM_SD_PERCENT) && ENABLED(SHOW_REMAINING_TIME) && ENABLED(ROTATE_PROGRESS_DISPLAY)
+      #if ALL(DOGM_SD_PERCENT, SHOW_REMAINING_TIME, ROTATE_PROGRESS_DISPLAY)
+
         if (prev_blink != blink) {
           prev_blink = blink;
-          progress_state++;
-          if (progress_state >=3) progress_state = 0;
+          if (++progress_state >= 3) progress_state = 0;
         }
 
         if (progress_state == 0) {
-          if (progress_string[0] != '\0') {
+          if (progress_string[0]) {
             lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, PROGRESS_TIME_PREFIX);
             lcd_put_u8str(progress_x_pos, EXTRAS_BASELINE, progress_string);
             lcd_put_wchar('%');
           }
         }
-        else if (progress_state == 2  && estimation_string[0] != '\0') {
+        else if (progress_state == 2 && estimation_string[0]) {
           lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, SHOW_REMAINING_TIME_PREFIX);
           lcd_put_u8str(estimation_x_pos, EXTRAS_BASELINE, estimation_string);
         }
-        else if (elapsed_string[0] != '\0'){
+        else if (elapsed_string[0]) {
           lcd_put_u8str(PROGRESS_BAR_X, EXTRAS_BASELINE, ELAPSED_TIME_PREFIX);
           lcd_put_u8str(elapsed_x_pos, EXTRAS_BASELINE, elapsed_string);
         }
-      #else
+
+      #else // !DOGM_SD_PERCENT || !SHOW_REMAINING_TIME || !ROTATE_PROGRESS_DISPLAY
 
         //
         // SD Percent Complete
         //
 
         #if ENABLED(DOGM_SD_PERCENT)
-          if (progress_string[0] != '\0') {
-            // Percent complete
-            lcd_put_u8str(55, 48, progress_string);
+          if (progress_string[0]) {
+            lcd_put_u8str(55, 48, progress_string); // Percent complete
             lcd_put_wchar('%');
           }
         #endif
@@ -637,7 +637,7 @@ void MarlinUI::draw_status_screen() {
         //
 
         #if ENABLED(SHOW_REMAINING_TIME)
-          if (blink && (estimation_string[0] != '\0')) {
+          if (blink && estimation_string[0]) {
             lcd_put_wchar(estimation_x_pos, EXTRAS_BASELINE, SHOW_REMAINING_TIME_PREFIX);
             lcd_put_u8str(estimation_string);
           }
@@ -645,8 +645,9 @@ void MarlinUI::draw_status_screen() {
         #endif
             lcd_put_u8str(elapsed_x_pos, EXTRAS_BASELINE, elapsed_string);
 
-      #endif
+      #else // !DOGM_SD_PERCENT || !SHOW_REMAINING_TIME || !ROTATE_PROGRESS_DISPLAY
     }
+
   #endif // HAS_PRINT_PROGRESS
 
   //

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -436,7 +436,7 @@ void MarlinUI::draw_status_screen() {
             duration_t estimation = elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress;
             if (estimation.value == 0) {
               estimation_string[0] = '\0';
-              estimation_x_pos = _PROGRESS_CENTER_X(0);
+              estimation_x_pos = _SD_DURATION_X(0);
             }
             else {
               const bool has_days = (estimation.value >= 60*60*24L);

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY        // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY        // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/ADIMLab/Gantry v1/Configuration_adv.h
+++ b/config/examples/ADIMLab/Gantry v1/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/ADIMLab/Gantry v1/Configuration_adv.h
+++ b/config/examples/ADIMLab/Gantry v1/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/ADIMLab/Gantry v2/Configuration_adv.h
+++ b/config/examples/ADIMLab/Gantry v2/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/ADIMLab/Gantry v2/Configuration_adv.h
+++ b/config/examples/ADIMLab/Gantry v2/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Alfawise/U20-bltouch/Configuration_adv.h
+++ b/config/examples/Alfawise/U20-bltouch/Configuration_adv.h
@@ -893,6 +893,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Alfawise/U20-bltouch/Configuration_adv.h
+++ b/config/examples/Alfawise/U20-bltouch/Configuration_adv.h
@@ -890,11 +890,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -893,11 +893,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -896,6 +896,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -897,11 +897,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -900,6 +900,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/Ender-5/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Creality/Ender-5/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Felix/DUAL/Configuration_adv.h
+++ b/config/examples/Felix/DUAL/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Felix/DUAL/Configuration_adv.h
+++ b/config/examples/Felix/DUAL/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Felix/Single/Configuration_adv.h
+++ b/config/examples/Felix/Single/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Felix/Single/Configuration_adv.h
+++ b/config/examples/Felix/Single/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -891,6 +891,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -888,11 +888,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -896,6 +896,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -893,11 +893,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/HMS434/Configuration_adv.h
+++ b/config/examples/HMS434/Configuration_adv.h
@@ -860,6 +860,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/HMS434/Configuration_adv.h
+++ b/config/examples/HMS434/Configuration_adv.h
@@ -857,11 +857,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -894,11 +894,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -897,6 +897,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -894,11 +894,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -897,6 +897,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -893,6 +893,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -890,11 +890,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
@@ -888,6 +888,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
@@ -885,11 +885,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -902,11 +902,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -905,6 +905,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Velleman/K8400/Dual-head/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Velleman/K8400/Dual-head/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Velleman/K8400/Single-head/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Single-head/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Velleman/K8400/Single-head/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Single-head/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 #define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -894,6 +894,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -891,11 +891,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -889,11 +889,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -892,6 +892,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -893,6 +893,8 @@
 #if HAS_PRINT_PROGRESS
   //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
   //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
+  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
+                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -890,11 +890,10 @@
 // Add an 'M73' G-code to set the current percentage
 //#define LCD_SET_PROGRESS_MANUALLY
 
-#if HAS_PRINT_PROGRESS
-  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits (Graphical LCD only)
-  //#define SHOW_REMAINING_TIME          // Display estimated time to completion (Graphical LCD only)
-  //#define ROTATE_PROGRESS_DISPLAY      // if DOGM_SD_PERCENT enabled and SHOW_REMAINING_TIME enabled,
-                                         // rotate diplay for (P)rogress, (E)laspsed and (R)emaining Time.
+#if HAS_GRAPHICAL_LCD && HAS_PRINT_PROGRESS
+  //#define PRINT_PROGRESS_SHOW_DECIMALS // Show progress with decimal digits
+  //#define SHOW_REMAINING_TIME          // Display estimated time to completion
+  //#define ROTATE_PROGRESS_DISPLAY      // Display (P)rogress, (E)lapsed, and (R)emaining time
 #endif
 
 #if HAS_CHARACTER_LCD && HAS_PRINT_PROGRESS


### PR DESCRIPTION
For long time printing, Percent display can be overlap with Remaining time. 
This PR make the display rotate between (**P**)ercent, (**E**)lapsed, and (**R**)emaining time