### PR TITLE
Fix probe manually grid position

### DIFF
--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -62,7 +62,7 @@
 
 #endif
 
-#if HAS_LEVELING && HAS_BED_PROBE
+#if HAS_LEVELING && (HAS_BED_PROBE || ENABLED(PROBE_MANUALLY))
   inline float probe_min_x() {
     return _MAX(
       #if IS_KINEMATIC


### PR DESCRIPTION
calculate probe_min and probe_max for PROBE_MANUALLY too.
Currently probe_min and max always return zero.