### PR TITLE
Allow compilation with Windows Subsystem for Linux

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/HAL.h
+++ b/Marlin/src/HAL/HAL_AVR/HAL.h
@@ -38,6 +38,14 @@
 #include <avr/interrupt.h>
 #include <avr/io.h>
 
+#ifndef pgm_read_ptr
+  // Compatibility for avr-libc 1.8.0-4.1 included with Ubuntu for
+  // Windows Subsystem for Linux on Windows 10 as of 10/18/2019
+  #define pgm_read_ptr_far(address_long) (void*)__ELPM_word((uint32_t)(address_long)) 
+  #define pgm_read_ptr_near(address_short) (void*)__LPM_word((uint16_t)(address_short))
+  #define pgm_read_ptr(address_short) pgm_read_ptr_near(address_short)
+#endif
+
 // ------------------------
 // Defines
 // ------------------------

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -279,7 +279,7 @@
 #define ATAN2(y, x) atan2f(y, x)
 #define POW(x, y)   powf(x, y)
 #define SQRT(x)     sqrtf(x)
-#define RSQRT(x)    float(1 / sqrtf(x))
+#define RSQRT(x)    (1.0f / sqrtf(x))
 #define CEIL(x)     ceilf(x)
 #define FLOOR(x)    floorf(x)
 #define LROUND(x)   lroundf(x)

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -279,7 +279,7 @@
 #define ATAN2(y, x) atan2f(y, x)
 #define POW(x, y)   powf(x, y)
 #define SQRT(x)     sqrtf(x)
-#define RSQRT(x)    (1 / sqrtf(x))
+#define RSQRT(x)    float(1 / sqrtf(x))
 #define CEIL(x)     ceilf(x)
 #define FLOOR(x)    floorf(x)
 #define LROUND(x)   lroundf(x)


### PR DESCRIPTION
Since I no longer work at Lulzbot, I've been experimenting with using Windows Subsystem for Linux (WSL) at home on my Windows 10 PC to compile Marlin using "avr-gcc". Although I was able to compile Marlin, I found a few weird glitches with the version of "avr-libc" which comes with that right now.

This PR makes two tweaks that solves the problem:

- For the `RSQRT(x)` macro, it seems that in that version of "avr-libc" `sqrtf` is returning a `double`, which causes `RSQRT` to return a `double`, which causes a compile error due to operator overloading in `Vector3` being ambiguous between a `float` or `int`. The fix is to cast `RSQRT` into a `float` -- this should not affect platforms where this is already the a `float` but ensures consistent behavior in WSL.

- The second fix is to define `pgm_read_ptr` when they are not available. The version of "avr-libc" seems to be fairly ancient in WSL.

Although this adds weird compatibility stuff to Marlin, I think it may be useful because being able to compile under Windows with WSL is kinda cool.
