### PR TITLE
Fix M420 (UBL) undefined variables

### DIFF
--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -64,9 +64,9 @@ void GcodeSuite::M420() {
 
   #if ENABLED(MARLIN_DEV_MODE)
     if (parser.intval('S') == 2) {
+      const float x_min = probe_min_x(), x_max = probe_max_x(),
+                  y_min = probe_min_y(), y_max = probe_max_y();
       #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-        const float x_min = probe_min_x(), x_max = probe_max_x(),
-                    y_min = probe_min_y(), y_max = probe_max_y();
         bilinear_start.set(x_min, y_min);
         bilinear_grid_spacing.set((x_max - x_min) / (GRID_MAX_POINTS_X - 1),
                                   (y_max - y_min) / (GRID_MAX_POINTS_Y - 1));


### PR DESCRIPTION
Relates to https://github.com/MarlinFirmware/Marlin/issues/15618

Details:

I am at 2.0 "bugfix" and try to enable `AUTO_BED_LEVELING_UBL` (for SKR 1.3). While compiling with Platformio@Atom I get:

<details><summary>Error Log</summary>

```
Compiling .pio\build\LPC1768\src\src\gcode\bedlevel\abl\M421.cpp.o
Compiling .pio\build\LPC1768\src\src\gcode\bedlevel\mbl\G29.cpp.o
In file included from Marlin\src\gcode\bedlevel\../../inc/MarlinConfig.h:45,
                 from Marlin\src\gcode\bedlevel\M420.cpp:23:
Marlin\src\gcode\bedlevel\M420.cpp: In static member function 'static void GcodeSuite::M420()':
Marlin\src\gcode\bedlevel\M420.cpp:82:29: error: 'x_min' was not declared in this scope
       SERIAL_ECHOPAIR(" (", x_min);

                             ^~~~~
c:\repositories\marlin\marlin\src\core\serial.h:90:57: note: in definition of macro '_SEP_2'
 #define _SEP_2(PRE,V)     serial_echopair_PGM(PSTR(PRE),V)
                                                         ^
c:\repositories\marlin\marlin\src\core\serial.h:88:27: note: in expansion of macro '__SEP_N'
 #define _SEP_N(N,V...)    __SEP_N(N,V)
                           ^~~~~~~
c:\repositories\marlin\marlin\src\core\serial.h:114:31: note: in expansion of macro '_SEP_N'
 #define SERIAL_ECHOPAIR(V...) _SEP_N(NUM_ARGS(V),V)
                               ^~~~~~
Marlin\src\gcode\bedlevel\M420.cpp:82:7: note: in expansion of macro 'SERIAL_ECHOPAIR'
       SERIAL_ECHOPAIR(" (", x_min);
       ^~~~~~~~~~~~~~~
Marlin\src\gcode\bedlevel\M420.cpp:82:29: note: suggested alternative: 'fmin'
       SERIAL_ECHOPAIR(" (", x_min);
                             ^~~~~
c:\repositories\marlin\marlin\src\core\serial.h:90:57: note: in definition of macro '_SEP_2'
 #define _SEP_2(PRE,V)     serial_echopair_PGM(PSTR(PRE),V)
                                                         ^
c:\repositories\marlin\marlin\src\core\serial.h:88:27: note: in expansion of macro '__SEP_N'
 #define _SEP_N(N,V...)    __SEP_N(N,V)
                           ^~~~~~~
c:\repositories\marlin\marlin\src\core\serial.h:114:31: note: in expansion of macro '_SEP_N'
 #define SERIAL_ECHOPAIR(V...) _SEP_N(NUM_ARGS(V),V)
                               ^~~~~~
Marlin\src\gcode\bedlevel\M420.cpp:82:7: note: in expansion of macro 'SERIAL_ECHOPAIR'
       SERIAL_ECHOPAIR(" (", x_min);
       ^~~~~~~~~~~~~~~
Marlin\src\gcode\bedlevel\M420.cpp:83:37: error: 'y_min' was not declared in this scope
       SERIAL_CHAR(','); SERIAL_ECHO(y_min);
...
```
</details>

While `AUTO_BED_LEVELING_BILINEAR` compiles fine. Having a look into `Marlin\src\gcode\bedlevel\M420.cpp` line 68 I found this block:

```cpp
  #if ENABLED(MARLIN_DEV_MODE)
    if (parser.intval('S') == 2) {
      #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
        const float x_min = probe_min_x(), x_max = probe_max_x(),
                    y_min = probe_min_y(), y_max = probe_max_y();
        bilinear_start.set(x_min, y_min);
        bilinear_grid_spacing.set((x_max - x_min) / (GRID_MAX_POINTS_X - 1),
                                  (y_max - y_min) / (GRID_MAX_POINTS_Y - 1));
      #endif
      for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
        for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
          Z_VALUES(x, y) = 0.001 * random(-200, 200);
          #if ENABLED(EXTENSIBLE_UI)
            ExtUI::onMeshUpdate(x, y, Z_VALUES(x, y));
          #endif
        }
      SERIAL_ECHOPGM("Simulated " STRINGIFY(GRID_MAX_POINTS_X) "x" STRINGIFY(GRID_MAX_POINTS_Y) " mesh ");
      SERIAL_ECHOPAIR(" (", x_min);
      SERIAL_CHAR(','); SERIAL_ECHO(y_min);
      SERIAL_ECHOPAIR(")-(", x_max);
      SERIAL_CHAR(','); SERIAL_ECHO(y_max);
      SERIAL_ECHOLNPGM(")");
    }
  #endif
```
`x_min, x_max, y_min,...` are `const float`s defined in the `#if ENABLED(AUTO_BED_LEVELING_BILINEAR)` case but used outside of it: see `SERIAL*` lines a little down. So if `AUTO_BED_LEVELING_BILINEAR` is not enabled, the `const floats` arent defined and so the compilation fails, due to the use of non-existing values in the serial command.

**Fix:**
```
$ git diff -- Marlin/src/gcode/
diff --git a/Marlin/src/gcode/bedlevel/M420.cpp b/Marlin/src/gcode/bedlevel/M420.cpp
index 9e4de215e..9e96b456e 100644
--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -64,9 +64,9 @@ void GcodeSuite::M420() {

   #if ENABLED(MARLIN_DEV_MODE)
     if (parser.intval('S') == 2) {
+      const float x_min = probe_min_x(), x_max = probe_max_x(),
+                  y_min = probe_min_y(), y_max = probe_max_y();
       #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
-        const float x_min = probe_min_x(), x_max = probe_max_x(),
-                    y_min = probe_min_y(), y_max = probe_max_y();
         bilinear_start.set(x_min, y_min);
         bilinear_grid_spacing.set((x_max - x_min) / (GRID_MAX_POINTS_X - 1),
                                   (y_max - y_min) / (GRID_MAX_POINTS_Y - 1));
```
This moves the variable definitions outside of the `if` statement. So `x_min, x_max, y_min,...` will be available in any case.