### PR TITLE
Fix apply_rotation function

### DIFF
--- a/Marlin/src/libs/vector_3.cpp
+++ b/Marlin/src/libs/vector_3.cpp
@@ -71,7 +71,9 @@ void vector_3::normalize() {
 // Apply a rotation to the matrix
 void vector_3::apply_rotation(const matrix_3x3 &matrix) {
   const float _x = x, _y = y, _z = z;
-  *this = matrix.vectors[0] * _x + matrix.vectors[1] * _y + matrix.vectors[2] * _z;
+  x = _x * matrix.vectors[0][0] + _y * matrix.vectors[1][0] + _z * matrix.vectors[2][0];
+  y = _x * matrix.vectors[0][1] + _y * matrix.vectors[1][1] + _z * matrix.vectors[2][1];
+  z = _x * matrix.vectors[0][2] + _y * matrix.vectors[1][2] + _z * matrix.vectors[2][2];
 }
 
 void vector_3::debug(PGM_P const title) {


### PR DESCRIPTION
### Description

This PR fixes BUG "Apply rotation function always gives Z = 1" discussed in issue https://github.com/MarlinFirmware/Marlin/issues/15610

### Benefits

3-point bed leveling will be functional 

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/15610
https://github.com/MarlinFirmware/Marlin/issues/15495
