### PR TITLE
[1.1.x] Fix compiler warning

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1169,8 +1169,10 @@ void Planner::recalculate() {
  * Maintain fans, paste extruder pressure,
  */
 void Planner::check_axes_activity() {
-  unsigned char axis_active[NUM_AXIS] = { 0 },
-                tail_fan_speed[FAN_COUNT];
+  unsigned char axis_active[NUM_AXIS] = { 0 };
+#if FAN_COUNT > 0
+  unsigned char tail_fan_speed[FAN_COUNT]  = { 0 };
+#endif
 
   #if ENABLED(BARICUDA)
     #if HAS_HEATER_1

--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -1169,10 +1169,11 @@ void Planner::recalculate() {
  * Maintain fans, paste extruder pressure,
  */
 void Planner::check_axes_activity() {
-  unsigned char axis_active[NUM_AXIS] = { 0 };
-#if FAN_COUNT > 0
-  unsigned char tail_fan_speed[FAN_COUNT]  = { 0 };
-#endif
+  uint8_t axis_active[NUM_AXIS] = { 0 };
+
+  #if FAN_COUNT > 0
+    uint8_t tail_fan_speed[FAN_COUNT] = { 0 };
+  #endif
 
   #if ENABLED(BARICUDA)
     #if HAS_HEATER_1


### PR DESCRIPTION
With the current Arduino tool chain, there's a compiler warning about the size-zero array. This PR fixes that.