### PR TITLE
env: SKRmini can't use STLink

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -265,6 +265,8 @@ lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, SPI
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed = 250000
+debug_tool    = stlink
+upload_protocol = stlink
 
 #
 # STM32F103RC_fysetc
@@ -305,8 +307,6 @@ lib_deps          = ${common.lib_deps}
 lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
-upload_protocol   = stlink
-debug_tool        = stlink
 
 [env:STM32F103RC_bigtree_USB]
 platform          = ststm32
@@ -315,14 +315,12 @@ board             = genericSTM32F103RC
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -DUSE_USB_COMPOSITE -std=gnu++14
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
 lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
-upload_protocol   = stlink
-debug_tool        = stlink
 
 #
 # STM32F4 with STM32GENERIC


### PR DESCRIPTION
Using vendor bootloader memory map is meant to stay compatible
with original firmware SD update without the use of an USB STLink device.

Due to the custom offsets altered by the python scrypt and the .ld file,
stlink upload is not possible as it may replace it....

It's either stlink & hw debug, or vendor SD compatibility (.py), for now...
