### PR TITLE
Increase MMU2 serial buffer size with USB serial

### DIFF
--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -97,7 +97,11 @@ volatile int8_t MMU2::finda = 1;
 volatile bool MMU2::finda_runout_valid;
 int16_t MMU2::version = -1, MMU2::buildnr = -1;
 millis_t MMU2::last_request, MMU2::next_P0_request;
-char MMU2::rx_buffer[16], MMU2::tx_buffer[16];
+#if SERIAL_USB
+  char MMU2::rx_buffer[256], MMU2::tx_buffer[256];
+#else
+  char MMU2::rx_buffer[16], MMU2::tx_buffer[16];
+#endif
 
 #if HAS_LCD_MENU && ENABLED(MMU2_MENUS)
 

--- a/Marlin/src/feature/prusa_MMU2/mmu2.cpp
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.cpp
@@ -97,11 +97,7 @@ volatile int8_t MMU2::finda = 1;
 volatile bool MMU2::finda_runout_valid;
 int16_t MMU2::version = -1, MMU2::buildnr = -1;
 millis_t MMU2::last_request, MMU2::next_P0_request;
-#if SERIAL_USB
-  char MMU2::rx_buffer[256], MMU2::tx_buffer[256];
-#else
-  char MMU2::rx_buffer[16], MMU2::tx_buffer[16];
-#endif
+char MMU2::rx_buffer[MMU_RX_SIZE], MMU2::tx_buffer[MMU_TX_SIZE];
 
 #if HAS_LCD_MENU && ENABLED(MMU2_MENUS)
 

--- a/Marlin/src/feature/prusa_MMU2/mmu2.h
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.h
@@ -79,7 +79,11 @@ private:
   static volatile bool finda_runout_valid;
   static int16_t version, buildnr;
   static millis_t last_request, next_P0_request;
-  static char rx_buffer[16], tx_buffer[16];
+  #if SERIAL_USB
+    static char rx_buffer[256], tx_buffer[256];
+  #else
+    static char rx_buffer[16], tx_buffer[16];
+  #endif
 
   static inline void set_runout_valid(const bool valid) {
     finda_runout_valid = valid;

--- a/Marlin/src/feature/prusa_MMU2/mmu2.h
+++ b/Marlin/src/feature/prusa_MMU2/mmu2.h
@@ -27,6 +27,14 @@
   #include "../runout.h"
 #endif
 
+#if SERIAL_USB
+  #define MMU_RX_SIZE 256
+  #define MMU_TX_SIZE 256
+#else
+  #define MMU_RX_SIZE  16
+  #define MMU_TX_SIZE  16
+#endif
+
 struct E_Step;
 
 class MMU2 {
@@ -79,11 +87,7 @@ private:
   static volatile bool finda_runout_valid;
   static int16_t version, buildnr;
   static millis_t last_request, next_P0_request;
-  #if SERIAL_USB
-    static char rx_buffer[256], tx_buffer[256];
-  #else
-    static char rx_buffer[16], tx_buffer[16];
-  #endif
+  static char rx_buffer[MMU_RX_SIZE], tx_buffer[MMU_TX_SIZE];
 
   static inline void set_runout_valid(const bool valid) {
     finda_runout_valid = valid;


### PR DESCRIPTION
### Requirements

### Description
The fix addresses the issue #15149. There is a buffer overflow while USB serial is used. Increasing the buffer size prevents overflowing. The buffer size is only increased for boards with USB serial. So no extra memory for smaller controllers is used.

### Benefits
Prevents a buffer overflow using the MMU2. The buffer may overflow while USB serial is used.

### Related Issues
Addresses issue #15149 
