### PR TITLE
Reset position_shift on G28

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1389,6 +1389,11 @@ void set_axis_is_at_home(const AxisEnum axis) {
     babystep.reset_total(axis);
   #endif
 
+  #if HAS_POSITION_SHIFT
+    position_shift[axis] = 0;
+    update_workspace_offset(axis);
+  #endif
+
   if (DEBUGGING(LEVELING)) {
     #if HAS_HOME_OFFSET
       DEBUG_ECHOLNPAIR("> home_offset[", axis_codes[axis], "] = ", home_offset[axis]);


### PR DESCRIPTION
### Description

This PR resets `position_shift` when an axis is homed, as the original comment [here](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.0.x/Marlin/src/module/motion.cpp#L179) suggested.

### Benefits / Related Issues

This is a bug fix for https://github.com/MarlinFirmware/Marlin/issues/15609. 

tl;dr: on non-cartesian printers, there's currently no way to reset this `position_shift` value. Each successive call to `G92` (e.g., from Cura's Z offset plugin at the start of the print) shifts the printer's workspace offsets more and more. The only way to reset this is to turn the printer off and on again.

The comment that is there already would imply that this happened before, and now it doesn't! :smile:

### Extra Notes

Since workspace offsets are [enabled by default, generally](https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.0.x/Marlin/Configuration_adv.h#L2461), this is going to affect everyone with a non-cartesian printer using G92. There's only one Z Offset plugin for Cura and it uses G92 so this could be screwing up prints all over. :smile:
