### PR TITLE
Enable BTN_BACK pull up - ultralcd.cpp #15652

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -295,6 +295,10 @@ void MarlinUI::init() {
       SET_INPUT_PULLUP(BTN_ENC);
     #endif
 
+     #if BUTTON_EXISTS(BACK)
+      SET_INPUT_PULLUP(BTN_BACK);
+    #endif
+
     #if BUTTON_EXISTS(UP)
       SET_INPUT(BTN_UP);
     #endif


### PR DESCRIPTION
BTN_BACK internal pull up resistor was not enabled, leaving the pin floating when not depressed. Also missing in branch 1.1.x.

credit to @ellensp 
#15652

### Related Issues
#15652 