### PR TITLE
Confirm object cancellation

### DIFF
--- a/Marlin/src/feature/cancel_object.cpp
+++ b/Marlin/src/feature/cancel_object.cpp
@@ -42,6 +42,13 @@ void CancelObject::set_active_object(const int8_t obj) {
   }
   else
     skipping = false;
+
+  #if HAS_DISPLAY
+    if (active_object >= 0)
+      ui.status_printf_P(0, PSTR(S_FMT " %i"), GET_TEXT(MSG_PRINTING_OBJECT), int(active_object + 1));
+    else
+      ui.reset_status();
+  #endif
 }
 
 void CancelObject::cancel_object(const int8_t obj) {

--- a/Marlin/src/feature/cancel_object.h
+++ b/Marlin/src/feature/cancel_object.h
@@ -32,6 +32,7 @@ public:
   static void cancel_object(const int8_t obj);
   static void uncancel_object(const int8_t obj);
   static void report();
+  static inline bool is_canceled(const int8_t obj) { return TEST(canceled, obj); }
   static inline void clear_active_object() { set_active_object(-1); }
   static inline void cancel_active_object() { cancel_object(active_object); }
   static inline void reset() { canceled = 0x0000; object_count = 0; clear_active_object(); }

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -427,6 +427,7 @@ namespace Language_en {
   PROGMEM Language_Str MSG_PAUSE_PRINT                     = _UxGT("Pause Print");
   PROGMEM Language_Str MSG_RESUME_PRINT                    = _UxGT("Resume Print");
   PROGMEM Language_Str MSG_STOP_PRINT                      = _UxGT("Stop Print");
+  PROGMEM Language_Str MSG_PRINTING_OBJECT                 = _UxGT("Printing Object");
   PROGMEM Language_Str MSG_CANCEL_OBJECT                   = _UxGT("Cancel Object");
   PROGMEM Language_Str MSG_OUTAGE_RECOVERY                 = _UxGT("Outage Recovery");
   PROGMEM Language_Str MSG_MEDIA_MENU                      = _UxGT("Print from Media");

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -299,10 +299,7 @@ class MenuItem_bool {
   } \
   screen_items = _thisItemNr
 
-#define END_MENU() \
-  } \
-  screen_items = _thisItemNr; \
-  UNUSED(_skipStatic)
+#define END_MENU() END_SCREEN(); UNUSED(_skipStatic)
 
 #if ENABLED(ENCODER_RATE_MULTIPLIER)
   #define ENCODER_RATE_MULTIPLY(F) (ui.encoderRateMultiplierEnabled = F)


### PR DESCRIPTION
Add a confirmation step to Object Cancel, put the active object at the top of the menu with its index number, and number objects starting from 1.