### PR TITLE
Fixed  preprocessor #endif compile error.

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -639,7 +639,7 @@ void MarlinUI::draw_status_screen() {
         #endif
             lcd_put_u8str(elapsed_x_pos, EXTRAS_BASELINE, elapsed_string);
 
-      #else // !DOGM_SD_PERCENT || !SHOW_REMAINING_TIME || !ROTATE_PROGRESS_DISPLAY
+      #endif // !DOGM_SD_PERCENT || !SHOW_REMAINING_TIME || !ROTATE_PROGRESS_DISPLAY
     }
 
   #endif // HAS_PRINT_PROGRESS


### PR DESCRIPTION
### Description

Changes a simple typo that, if left as-is, doesn't compile. It likely was just an oversight that wasn't caught due to an untested combination of lcd-related configuration flags.

### Benefits

...it compiles. :)

### Related Issues

NA
