### PR TITLE
Fixed false service interval expiration notification

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -914,8 +914,6 @@ void setup() {
   #endif
 
   ui.init();
-  ui.reset_status();
-
   #if HAS_SPI_LCD && ENABLED(SHOW_BOOTSCREEN)
     ui.show_bootscreen();
   #endif
@@ -943,6 +941,8 @@ void setup() {
   thermalManager.init();    // Initialize temperature loop
 
   print_job_timer.init();   // Initial setup of print job timer
+
+  ui.reset_status();        // Print startup message after print statistics are loaded
 
   endstops.init();          // Init endstops and pullups
 


### PR DESCRIPTION
After I enabled service interval in Configuration_adv.h, my printer started reporting expiration of this service interval on every power on of printer. I've checked printer statistics and service interval had still a few days remaining till expiration.

So, this PR will fix this problem. ui.reset_status() must be called after a print statistics are initialized from EEPROM by print_job_timer.init()