### PR TITLE
[1.1.x] Fix autostart w/out SD_DETECT_PIN

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -15452,7 +15452,7 @@ void setup() {
     enable_D();
   #endif
 
-  #if ENABLED(SDSUPPORT)
+  #if ENABLED(SDSUPPORT) && !(ENABLED(ULTRA_LCD) && PIN_EXISTS(SD_DETECT))
     card.beginautostart();
   #endif
 }

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -15452,7 +15452,7 @@ void setup() {
     enable_D();
   #endif
 
-  #if ENABLED(SDSUPPORT) && DISABLED(ULTRA_LCD)
+  #if ENABLED(SDSUPPORT)
     card.beginautostart();
   #endif
 }


### PR DESCRIPTION
### Description

This PR is a small fix to bugfix-1.1.x where auto start of SD card is not working on boot time when SDSUPPORT is enabled.

### Benefits

Initialization of sd card takes place on boot when SDSUPPORT is enabled. 

### Related Issues
#7155