### PR TITLE
MKS Robin: restore the TFT v2.0 support (ST7789V)

### DIFF
--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN.h
@@ -111,9 +111,9 @@
 #define LED_PIN            PB2
 
 /**
- * Note: MKS Robin TFT screens use various TFT controllers. Supported screens
- * are based on the ILI9341, ILI9328 and ST7798V. Define init sequences for
- * other screens in u8g_dev_tft_320x240_upscale_from_128x64.cpp
+ * Note: MKS Robin TFT screens use various TFT controllers
+ * Supported screens are based on the ILI9341 and ST7789V (320x240), ILI9328 and 9488 are not.
+ * Define init sequences for other screens in u8g_dev_tft_320x240_upscale_from_128x64.cpp
  *
  * If the screen stays white, disable 'LCD_RESET_PIN'
  * to let the bootloader init the screen.
@@ -125,6 +125,10 @@
 #define LCD_BACKLIGHT_PIN  PG11
 #define FSMC_CS_PIN        PG12  // NE4
 #define FSMC_RS_PIN        PF0   // A0
+
+#define LCD_USE_DMA_FSMC   // Use DMA transfers to send data to the TFT
+#define FSMC_DMA_DEV       DMA2
+#define FSMC_DMA_CHANNEL   DMA_CH4 // or DMA_CH5
 
 #if ENABLED(TOUCH_BUTTONS)
   #define TOUCH_CS_PIN     PB1   // SPI2_NSS

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN.h
@@ -128,7 +128,7 @@
 
 #define LCD_USE_DMA_FSMC   // Use DMA transfers to send data to the TFT
 #define FSMC_DMA_DEV       DMA2
-#define FSMC_DMA_CHANNEL   DMA_CH4 // or DMA_CH5
+#define FSMC_DMA_CHANNEL   DMA_CH5
 
 #if ENABLED(TOUCH_BUTTONS)
   #define TOUCH_CS_PIN     PB1   // SPI2_NSS

--- a/platformio.ini
+++ b/platformio.ini
@@ -387,7 +387,7 @@ framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
+  ${common.build_flags} -std=gnu++14 -DSTM32_XL_DENSITY
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}

--- a/platformio.ini
+++ b/platformio.ini
@@ -447,7 +447,7 @@ framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DSTM32F1xx -std=gnu++14
+  ${common.build_flags} -DSTM32F1xx -std=gnu++14 -DSTM32_XL_DENSITY
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
@@ -547,7 +547,7 @@ framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DSTM32F1xx -std=gnu++14
+  ${common.build_flags} -DSTM32F1xx -std=gnu++14 -DSTM32_XL_DENSITY
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG= -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}


### PR DESCRIPTION
Main issue was the framework is not adding -DSTM32_XL_DENSITY
automatically like it is doing for the STM32_HIGH_DENSITY define..

After tests, enable the DMA too, to improve the display speed...
