### PR TITLE
Added BIQU TANGO V1 Support

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -99,6 +99,7 @@
 #define BOARD_OVERLORD                1143  // Overlord/Overlord Pro
 #define BOARD_HJC2560C_REV1           1144  // ADIMLab Gantry v1
 #define BOARD_HJC2560C_REV2           1145  // ADIMLab Gantry v2
+#define BOARD_TANGO                   1146  // BIQU Tango V1
 
 //
 // RAMBo and derivatives

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -180,6 +180,8 @@
   #include "ramps/pins_Z_BOLT_X_SERIES.h"       // ATmega2560                             env:megaatmega2560
 #elif MB(TT_OSCAR)
   #include "ramps/pins_TT_OSCAR.h"              // ATmega2560                             env:megaatmega2560
+#elif MB(TANGO)
+  #include "ramps/pins_TANGO.h"                 // ATmega2560                             env:megaatmega2560
 
 //
 // RAMBo and derivatives

--- a/Marlin/src/pins/ramps/pins_RUMBA.h
+++ b/Marlin/src/pins/ramps/pins_RUMBA.h
@@ -162,7 +162,7 @@
   #define SPINDLE_LASER_PWM_PIN 4   // Hardware PWM. Pin 4 interrupts OC0* and OC1* always in use?
 #endif
 #ifndef SPINDLE_LASER_ENA_PIN
-  #define SPINDLE_LASER_ENA_PIN    14   // Pullup!
+  #define SPINDLE_LASER_ENA_PIN 14   // Pullup!
 #endif
 #ifndef SPINDLE_DIR_PIN
   #define SPINDLE_DIR_PIN  15

--- a/Marlin/src/pins/ramps/pins_RUMBA.h
+++ b/Marlin/src/pins/ramps/pins_RUMBA.h
@@ -143,8 +143,9 @@
 #ifndef FAN_PIN
   #define FAN_PIN           7
 #endif
-#define FAN1_PIN            8
-
+#ifndef FAN1_PIN
+  #define FAN1_PIN            8
+#endif
 //
 // Misc. Functions
 //

--- a/Marlin/src/pins/ramps/pins_RUMBA.h
+++ b/Marlin/src/pins/ramps/pins_RUMBA.h
@@ -143,7 +143,7 @@
 #ifndef FAN_PIN
   #define FAN_PIN           7
 #endif
-#ifndef FAN1_PIN
+#if !defined(FAN1_PIN)
   #define FAN1_PIN            8
 #endif
 //

--- a/Marlin/src/pins/ramps/pins_RUMBA.h
+++ b/Marlin/src/pins/ramps/pins_RUMBA.h
@@ -143,9 +143,10 @@
 #ifndef FAN_PIN
   #define FAN_PIN           7
 #endif
-#if !defined(FAN1_PIN)
-  #define FAN1_PIN            8
+#ifndef FAN1_PIN
+  #define FAN1_PIN          8
 #endif
+
 //
 // Misc. Functions
 //

--- a/Marlin/src/pins/ramps/pins_TANGO.h
+++ b/Marlin/src/pins/ramps/pins_TANGO.h
@@ -27,15 +27,12 @@
 
 #define BOARD_INFO_NAME "Tango"
 
- #define FAN_PIN           8
- #define FAN1_PIN          -1
- 
- #if  !defined(E0_AUTO_FAN_PIN) || (E0_AUTO_FAN_PIN==-1)
-   #undef E0_AUTO_FAN_PIN
-   #define E0_AUTO_FAN_PIN 7
- #endif
+#define FAN_PIN             8
+#define FAN1_PIN           -1
 
- #ifndef TEMP_0_PIN
+#define ORIG_E0_AUTO_FAN_PIN 7
+
+#ifndef TEMP_0_PIN
   #if TEMP_SENSOR_0 == -1
     #define TEMP_0_PIN     10   // Analog Input (connector *K1* on Tango thermocouple ADD ON is used)
   #else
@@ -51,4 +48,4 @@
   #endif
 #endif
 
- #include "pins_RUMBA.h"
+#include "pins_RUMBA.h"

--- a/Marlin/src/pins/ramps/pins_TANGO.h
+++ b/Marlin/src/pins/ramps/pins_TANGO.h
@@ -1,0 +1,54 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * BIQU Tango pin assignments
+ */
+
+#define BOARD_INFO_NAME "Tango"
+
+ #define FAN_PIN           8
+ #define FAN1_PIN          -1
+ 
+ #if  !defined(E0_AUTO_FAN_PIN) || (E0_AUTO_FAN_PIN==-1)
+   #undef E0_AUTO_FAN_PIN
+   #define E0_AUTO_FAN_PIN 7
+ #endif
+
+ #ifndef TEMP_0_PIN
+  #if TEMP_SENSOR_0 == -1
+    #define TEMP_0_PIN     10   // Analog Input (connector *K1* on Tango thermocouple ADD ON is used)
+  #else
+    #define TEMP_0_PIN     15   // Analog Input (default connector for thermistor *T0* on rumba board is used)
+  #endif
+#endif
+
+#ifndef TEMP_1_PIN
+  #if TEMP_SENSOR_1 == -1
+    #define TEMP_1_PIN      9   // Analog Input (connector *K2* on Tango thermocouple ADD ON is used)
+  #else
+    #define TEMP_1_PIN     14   // Analog Input (default connector for thermistor *T1* on rumba board is used)
+  #endif
+#endif
+
+ #include "pins_RUMBA.h"


### PR DESCRIPTION
### Description

These three changes offer support for the BIQU Tango V1 controller board.  The Tango board is based on the Rumba board with the exception of a few digital pin changes for fans and analog inputs.

### Benefits

Board output Fan 0 is now the extruder fan. 
Board output Fan 1 is now the FAN_PIN
Analog A, and Analog B digital pins are adjusted as well.
 
### Related Issues
Fixes #15651
Fixes #13567

Note: Without these changes :
1.) The installer would likely experience thermal runaway because the part cooling fan is swapped with the Extruder.  
2.) Installer would likely experience a false error while using Thermocouple attached to unmatched digital pins.
 