### PR TITLE
[In Progress] Intelligent RUNOUT management (and fixes)   

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1152,6 +1152,7 @@
 
   // Tool change on runout or jam
   // Swap to the next extruder automaticly
+  // Set the same temp
   // Stop on the last extruder defined
   //#define FILAMENT_RUNOUT_SWAP_NEXT
   #ifdef FILAMENT_RUNOUT_SWAP_NEXT
@@ -1161,6 +1162,8 @@
     //Custom toolchange process(disabled if SWAP_USE_FW_TOOLCHANGE)
     //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_BEFORE_TOOLCHANGE ""
     //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_AFTER_TOOLCHANGE ""
+
+
   #endif//FILAMENT_RUNOUT_SWAP_NEXT
 
 #endif//ADVANCED_RUNOUT_FEATURE

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1091,65 +1091,20 @@
 #endif
 
 /**
- * Filament Runout Sensors
- * Mechanical or opto endstops are used to check for the presence of filament.
- *
- * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
- * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
- * By default the firmware assumes HIGH=FILAMENT PRESENT.
+ * Advanced Filament runout
  */
-//#define FILAMENT_RUNOUT_SENSOR
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  #define NUM_RUNOUT_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
-  #define FIL_RUNOUT_INVERTING false // Set to true to invert the logic of the sensor.
-  #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
-  //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
 
-  // Set one or more commands to execute on filament runout.
-  // (After 'M412 H' Marlin will ask the host to handle the process.)
-  #define FILAMENT_RUNOUT_SCRIPT "M600"
+ //#define ADVANCED_FILAMENT_RUNOUT
+#if ENABLED(ADVANCED_FILAMENT_RUNOUT)
 
-  // After a runout is detected, continue printing this length of filament
-  // before executing the runout script. Useful for a sensor at the end of
-  // a feed tube. Requires 4 bytes SRAM per sensor, plus 4 bytes overhead.
-  //#define FILAMENT_RUNOUT_DISTANCE_MM 25
-
-  #ifdef FILAMENT_RUNOUT_DISTANCE_MM
-    // Enable this option to use an encoder disc that toggles the runout pin
-    // as the filament moves. (Be sure to set FILAMENT_RUNOUT_DISTANCE_MM
-    // large enough to avoid false positives.)
-    //#define FILAMENT_MOTION_SENSOR
-  #endif
-
-
-  #define NUM_RUNOUT_SW_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
-  #define FIL_RUNOUT_INVERTING false // Set to true to invert the logic of the sensor.
-  #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
-  //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
-
-  // After a runout is detected, continue printing this length of filament
-  // before executing the runout script. Useful for a sensor at the end of
-  // a feed tube. Requires 4 bytes SRAM per sensor, plus 4 bytes overhead.
-  //#define FILAMENT_RUNOUT_DISTANCE_MM 25
-
-  // Enable this option to use an encoder disc that toggles the runout pin
-  // as the filament moves. (Be sure to set FILAMENT_RUNOUT_DISTANCE_MM
-  // large enough to avoid false positives.)
-  //#define FILAMENT_MOTION_SENSOR
-
-  #endif
-  /**
-   * Filament Runout Sensors
-   * Mechanical or opto endstops are used to check for the presence of filament.
-   *
-   * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
-   * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
-   * By default the firmware assumes HIGH=FILAMENT PRESENT.
-   */
+  // Filament Runout Sensors
+  // Mechanical or opto endstops are used to check for the presence of filament.
+  // RAMPS-based boards use SERVO3_PIN for the first runout sensor.
+  // For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
+  // By default the firmware assumes HIGH=FILAMENT PRESENT.
   //#define FILAMENT_RUNOUT_SENSOR
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-
-    #define NUM_RUNOUT_SW_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+    #define NUM_RUNOUT_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
     #define FIL_RUNOUT_INVERTING false // Set to true to invert the logic of the sensor.
     #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
     //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
@@ -1158,13 +1113,44 @@
     // before executing the runout script. Useful for a sensor at the end of
     // a feed tube. Requires 4 bytes SRAM per sensor, plus 4 bytes overhead.
     //#define FILAMENT_RUNOUT_DISTANCE_MM 25
+    #ifdef FILAMENT_RUNOUT_DISTANCE_MM
+      //Extrusion limiter
+      //Divides a gcode extrusion command if no enough remaining filament
+      //Process the remaining extrusion when back of pausing
+      //#define RUNOUT_SEGMENTATION
+    #endif
 
     // Enable this option to use an encoder disc that toggles the runout pin
     // as the filament moves. (Be sure to set FILAMENT_RUNOUT_DISTANCE_MM
     // large enough to avoid false positives.)
     //#define FILAMENT_MOTION_SENSOR
 
-    #endif
+  #endif//Filament runout sensors
+
+  /**
+   * Filament Jam Sensors
+   * Rotary wheels are used to check for the feeding of filament.
+   * All extrusion commands are divided 'segmentized' by the sensor pulse distance
+   * The encoder is checked each time a change is waited
+   */
+  //#define FILAMENT_JAM_SENSOR
+  #if ENABLED(FILAMENT_JAM_SENSOR)
+
+      #define NUM_FIL_JAM_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+      #define FIL_JAM_PULLUP          // If sensor wired to V+
+      //#define FIL_JAM_PULLDOWN      // If sensor wired to Gnd
+
+      //Encoder wheel distance by pulse(Require precision)
+      #define FIL_JAM_SENSOR_PULSE_DISTANCE_MM 3
+      //Detection offsets(require 20% to 80%)
+      //Require : pulse < check < 2x pulses :1=100% , 1.2=20% .
+      #define FIL_JAM_SENSOR_PULSE_OFFSET 1.2
+
+      //Disable linear advance,only when segmentation in progress
+      //Because no direction changes or brakes
+      #define FIL_JAM_SENSOR_DISABLE_LINEAR_ADVANCE
+
+  #endif
 
 #endif
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1150,16 +1150,45 @@
     #define FIL_JAM_SENSORS_DISABLE_LINEAR_ADVANCE
   #endif//FILAMENT_JAM_SENSORS
 
-  // Tool change on runout or jam
-  // Swap to the next extruder automaticly
-  // Set the same temp
-  // Stop on the last extruder defined
+    /**
+     * FILAMENT_RUNOUT_SWAPPING
+     *   Tool/Spool Swapping during a print(On Runout/LCD/Gcode)
+     *   Transfer all properties : Temp + Flow + Gear position + Fwretract
+     *   Utility to : Finish old ended spool without human intervention
+     *              : Swap the current extruder to automaticly with only one click
+     *              : Rescue a broken spool/jammed extruder by using others extruders/spools
+     *              Requires 2 or more extruders.
+     *              Requires same nozzle size or single nozzle
+     *
+     *   : L[int]: 0=disable : 1/2/3/4 - Last extruder to reach after runouts - One or more migrations possible(By LCD/Gcode)
+     *   : T[int]: 0/1/2/3/4 : Migration to desired extruder(By LCD/Gcode)
+     *   : Default value     : Migration to next extruder (By Runout/LCD/Gcode)
+     *
+     * Purge
+     *   Utility to : Extrude/Retract/Recover with the values stored in the machine
+     *              : Settings by LCD/G-code
+     *              : Adjust purge length/retraction values during a print
+     *   Settings
+     *   : D[count] - s    - Fan dwell
+     *   : E[count] - mm   - Purge length
+     *   : F[count] - mm/s - Purge feedrate
+     *   : G[count] - mm   - Recovery length
+     *   : H[count] - mm/s - Retract  feedrate - If FWRETRACT disabled
+     *   : I[count] - mm/s - Recovery feedrate - If FWRETRACT disabled
+     *
+     *   Commands
+     *   : P1 - Extrusion
+    	*   : Q1 - Fan dwell
+     *   : R1 - Retract
+     *   : S1	- Recover
+     *
+     */
   //#define FILAMENT_RUNOUT_SWAP_NEXT
   #ifdef FILAMENT_RUNOUT_SWAP_NEXT
-    //Automatic firmware tool change (require FW_TOOLCHANGE/ADVANCED PAUSE FEATURE)
-    //#define FILAMENT_RUNOUT_SWAP_USE_FW_TOOLCHANGE
+    //Pause park and settings for swapping
+    //#define FILAMENT_RUNOUT_SWAP_USE_ADVANCED_PAUSE_FEATURE
 
-    //Custom toolchange process(disabled if SWAP_USE_FW_TOOLCHANGE)
+    //Custom toolchange process(Disabled if USE_ADVANCED_PAUSE_FEATURE)
     //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_BEFORE_TOOLCHANGE ""
     //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_AFTER_TOOLCHANGE ""
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1135,26 +1135,24 @@
    */
   //#define FILAMENT_JAM_SENSOR
   #if ENABLED(FILAMENT_JAM_SENSORS)
-      #define NUM_FIL_JAM_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
-      #define FIL_JAM_PULLUP          // If sensor wired to Gnd
-      //#define FIL_JAM_PULLDOWN      // If sensor wired to V+
+    #define NUM_FIL_JAM_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+    #define FIL_JAM_PULLUP          // If sensor wired to Gnd
+    //#define FIL_JAM_PULLDOWN      // If sensor wired to V+
 
-      //Encoder wheel distance by pulse(Require precision)
-      #define FIL_JAM_SENSOR_PULSE_DISTANCE_MM 3
-      //Detection offsets(require 20% to 80%)
-      //Require : pulse < check < 2x pulses :1=100% , 1.2=20% .
-      #define FIL_JAM_SENSOR_PULSE_OFFSET 1.2
+    //Encoder wheel distance by pulse(Require precision)
+    #define FIL_JAM_SENSOR_PULSE_DISTANCE_MM 3
+    //Detection offsets(require 20% to 80%)
+    //Require : pulse < check < 2x pulses :1=100% , 1.2=20% .
+    #define FIL_JAM_SENSOR_PULSE_OFFSET 1.2
 
-      //Disable linear advance,only when segmentation in progress
-      //Because no direction changes or brakes
-      #define FIL_JAM_SENSORS_DISABLE_LINEAR_ADVANCE
+    //Disable linear advance,only when segmentation in progress
+    //Because no direction changes or brakes
+    #define FIL_JAM_SENSORS_DISABLE_LINEAR_ADVANCE
   #endif//FILAMENT_JAM_SENSORS
 
-  /**
-   * Tool change on runout or jam
-   * Swap to the next extruder automaticly
-   * Stop on the last extruder defined
-   */
+  // Tool change on runout or jam
+  // Swap to the next extruder automaticly
+  // Stop on the last extruder defined
   //#define FILAMENT_RUNOUT_SWAP_NEXT
   #ifdef FILAMENT_RUNOUT_SWAP_NEXT
     //Automatic firmware tool change (require FW_TOOLCHANGE/ADVANCED PAUSE FEATURE)
@@ -1164,6 +1162,7 @@
     //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_BEFORE_TOOLCHANGE ""
     //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_AFTER_TOOLCHANGE ""
   #endif//FILAMENT_RUNOUT_SWAP_NEXT
+
 #endif//ADVANCED_RUNOUT_FEATURE
 
 //===========================================================================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1137,8 +1137,8 @@
   #if ENABLED(FILAMENT_JAM_SENSOR)
 
       #define NUM_FIL_JAM_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
-      #define FIL_JAM_PULLUP          // If sensor wired to V+
-      //#define FIL_JAM_PULLDOWN      // If sensor wired to Gnd
+      #define FIL_JAM_PULLUP          // If sensor wired to Gnd
+      //#define FIL_JAM_PULLDOWN      // If sensor wired to V+
 
       //Encoder wheel distance by pulse(Require precision)
       #define FIL_JAM_SENSOR_PULSE_DISTANCE_MM 3
@@ -1150,6 +1150,21 @@
       //Because no direction changes or brakes
       #define FIL_JAM_SENSOR_DISABLE_LINEAR_ADVANCE
 
+  #endif
+
+  /**
+   * Tool change on runout or jam
+   * Swap to the next extruder automaticly
+   * Stop on the last extruder defined
+   */
+  //#define FILAMENT_RUNOUT_SWAP_NEXT
+  #ifdef FILAMENT_RUNOUT_SWAP_NEXT
+    //Automatic firmware tool change (require FW_TOOLCHANGE/ADVANCED PAUSE FEATURE)
+    //#define FILAMENT_RUNOUT_SWAP_USE_FW_TOOLCHANGE
+
+    //Custom toolchange process(disabled if SWAP_USE_FW_TOOLCHANGE)
+    //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_BEFORE_TOOLCHANGE ""
+    //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_AFTER_TOOLCHANGE ""
   #endif
 
 #endif

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1095,7 +1095,7 @@
  */
 
  //#define ADVANCED_FILAMENT_RUNOUT
-#if ENABLED(ADVANCED_FILAMENT_RUNOUT)
+#if ENABLED(ADVANCED_RUNOUT_FEATURE)
 
   // Filament Runout Sensors
   // Mechanical or opto endstops are used to check for the presence of filament.
@@ -1134,8 +1134,7 @@
    * The encoder is checked each time a change is waited
    */
   //#define FILAMENT_JAM_SENSOR
-  #if ENABLED(FILAMENT_JAM_SENSOR)
-
+  #if ENABLED(FILAMENT_JAM_SENSORS)
       #define NUM_FIL_JAM_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
       #define FIL_JAM_PULLUP          // If sensor wired to Gnd
       //#define FIL_JAM_PULLDOWN      // If sensor wired to V+
@@ -1148,9 +1147,8 @@
 
       //Disable linear advance,only when segmentation in progress
       //Because no direction changes or brakes
-      #define FIL_JAM_SENSOR_DISABLE_LINEAR_ADVANCE
-
-  #endif
+      #define FIL_JAM_SENSORS_DISABLE_LINEAR_ADVANCE
+  #endif//FILAMENT_JAM_SENSORS
 
   /**
    * Tool change on runout or jam
@@ -1165,9 +1163,8 @@
     //Custom toolchange process(disabled if SWAP_USE_FW_TOOLCHANGE)
     //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_BEFORE_TOOLCHANGE ""
     //#define FILAMENT_RUNOUT_SWAP_USE_SCRIPT_AFTER_TOOLCHANGE ""
-  #endif
-
-#endif
+  #endif//FILAMENT_RUNOUT_SWAP_NEXT
+#endif//ADVANCED_RUNOUT_FEATURE
 
 //===========================================================================
 //=============================== Bed Leveling ==============================

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
+#pragma once 
 
 /**
  * Configuration.h

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once 
+#pragma once
 
 /**
  * Configuration.h
@@ -1120,6 +1120,52 @@
     // large enough to avoid false positives.)
     //#define FILAMENT_MOTION_SENSOR
   #endif
+
+
+  #define NUM_RUNOUT_SW_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+  #define FIL_RUNOUT_INVERTING false // Set to true to invert the logic of the sensor.
+  #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
+  //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+  // After a runout is detected, continue printing this length of filament
+  // before executing the runout script. Useful for a sensor at the end of
+  // a feed tube. Requires 4 bytes SRAM per sensor, plus 4 bytes overhead.
+  //#define FILAMENT_RUNOUT_DISTANCE_MM 25
+
+  // Enable this option to use an encoder disc that toggles the runout pin
+  // as the filament moves. (Be sure to set FILAMENT_RUNOUT_DISTANCE_MM
+  // large enough to avoid false positives.)
+  //#define FILAMENT_MOTION_SENSOR
+
+  #endif
+  /**
+   * Filament Runout Sensors
+   * Mechanical or opto endstops are used to check for the presence of filament.
+   *
+   * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
+   * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
+   * By default the firmware assumes HIGH=FILAMENT PRESENT.
+   */
+  //#define FILAMENT_RUNOUT_SENSOR
+  #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+
+    #define NUM_RUNOUT_SW_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+    #define FIL_RUNOUT_INVERTING false // Set to true to invert the logic of the sensor.
+    #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
+    //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+
+    // After a runout is detected, continue printing this length of filament
+    // before executing the runout script. Useful for a sensor at the end of
+    // a feed tube. Requires 4 bytes SRAM per sensor, plus 4 bytes overhead.
+    //#define FILAMENT_RUNOUT_DISTANCE_MM 25
+
+    // Enable this option to use an encoder disc that toggles the runout pin
+    // as the filament moves. (Be sure to set FILAMENT_RUNOUT_DISTANCE_MM
+    // large enough to avoid false positives.)
+    //#define FILAMENT_MOTION_SENSOR
+
+    #endif
+
 #endif
 
 //===========================================================================


### PR DESCRIPTION
_Please be patient , it's just the beginning , i will make it when i will have time  , help welcome_

### Description
- Precision Jam detection (if motion sensor enabled)
- Motion sensor multi usage , runout or jamming , or both 
- Multi type , motion or switch or both
- Better calculation of the remaining filament remaining distance
- Tool migration ( swap to the next extruder when runout )

### Benefits
This project will give Marlin, a complete securised printing process, very precise jam detection, runout , and possibility to swap extruder if jam or runout detected.

### Related Issues
  - RUnoutSwitch polling after block completed => if runoutdistance=25 , planner have made 24 , and the next planner block is 20 ' big outline with 0.8 nozzle ' , print dye
  - Motion sensors  ... same issue
  - If runout switch trig while a block not completed , impossible to know what distance of filament remains , (in little printing , no problem , but in big size printing , print dye ) 
  - If motions sensors have no regular polling , then you can sometimes have repetition of no change , the motion sensor must be checked every     1 pulse <Polling Motion sensor< 2 pulses , if not , impossible to have a serious detection , it's possible to have low state 1000x and no detection 


### The job

-Extrusion segmentation by the motion sensor pulse distance, by slicing in G1 command all extrusions>pulse distance.
-Improvements of Runout.h to adds all feature, many sensors and usage , and tool migration in lcd and gcode