### PR TITLE
Sidewinder X1 uses TFT28

### DIFF
--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration.h
@@ -86,7 +86,7 @@
  */
 
 // Show the Marlin bootscreen on startup. ** ENABLE FOR PRODUCTION **
-#define SHOW_BOOTSCREEN
+//#define SHOW_BOOTSCREEN
 
 // Show the bitmap in Marlin/_Bootscreen.h on startup.
 //#define SHOW_CUSTOM_BOOTSCREEN


### PR DESCRIPTION
### Description

Disable the custom bootscreen on the Sidewinder X1 since it uses an MKS TFT28. The custom bootscreen was provided as an option for modders who swap to a full graphics LCD.

### Benefits

Frees up some memory when compiling for a stock X1.

### Related Issues

#14065