### PR TITLE
Fix Photo G-code CHDK_PIN trigger time

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -199,6 +199,10 @@ bool wait_for_heatup = true;
 millis_t max_inactive_time, // = 0
          stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;
 
+#if PIN_EXISTS(CHDK)
+  extern millis_t chdk_timeout;
+#endif
+
 #if ENABLED(I2C_POSITION_ENCODERS)
   I2CPositionEncodersMgr I2CPEM;
 #endif
@@ -406,6 +410,7 @@ void startOrResumeJob() {
  *  - Keep the command buffer full
  *  - Check for maximum inactive time between commands
  *  - Check for maximum inactive time between stepper commands
+ *  - Check if CHDK_PIN needs to go LOW
  *  - Check for KILL button held down
  *  - Check for HOME button held down
  *  - Check if cooling fan needs to be switched on
@@ -466,6 +471,13 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
     else
       already_shutdown_steppers = false;
   }
+
+  #if PIN_EXISTS(CHDK) // Check if pin should be set to LOW (after M240 set it HIGH)
+    if (chdk_timeout && ELAPSED(ms, chdk_timeout)) {
+      chdk_timeout = 0;
+      WRITE(CHDK_PIN, LOW);
+    }
+  #endif
 
   #if HAS_KILL
 

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -199,10 +199,6 @@ bool wait_for_heatup = true;
 millis_t max_inactive_time, // = 0
          stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL;
 
-#if PIN_EXISTS(CHDK)
-  extern millis_t chdk_timeout;
-#endif
-
 #if ENABLED(I2C_POSITION_ENCODERS)
   I2CPositionEncodersMgr I2CPEM;
 #endif
@@ -410,7 +406,6 @@ void startOrResumeJob() {
  *  - Keep the command buffer full
  *  - Check for maximum inactive time between commands
  *  - Check for maximum inactive time between stepper commands
- *  - Check if CHDK_PIN needs to go LOW
  *  - Check for KILL button held down
  *  - Check for HOME button held down
  *  - Check if cooling fan needs to be switched on
@@ -471,13 +466,6 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
     else
       already_shutdown_steppers = false;
   }
-
-  #if PIN_EXISTS(CHDK) // Check if pin should be set to LOW (after M240 set it HIGH)
-    if (chdk_timeout && ELAPSED(ms, chdk_timeout)) {
-      chdk_timeout = 0;
-      WRITE(CHDK_PIN, LOW);
-    }
-  #endif
 
   #if HAS_KILL
 

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -26,7 +26,6 @@
 
 #include "../../gcode.h"
 #include "../../../module/motion.h" // for active_extruder and current_position
-#include "../../../module/planner.h"
 
 #if PIN_EXISTS(CHDK)
   millis_t chdk_timeout; // = 0

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -26,6 +26,7 @@
 
 #include "../../gcode.h"
 #include "../../../module/motion.h" // for active_extruder and current_position
+#include "../../../module/planner.h"
 
 #if PIN_EXISTS(CHDK)
   millis_t chdk_timeout; // = 0
@@ -148,7 +149,7 @@ void GcodeSuite::M240() {
   #if PIN_EXISTS(CHDK)
 
     OUT_WRITE(CHDK_PIN, HIGH);
-    chdk_timeout = millis() + PHOTO_SWITCH_MS;
+    chdk_timeout = millis() + parser.intval('D', PHOTO_SWITCH_MS);
 
   #elif HAS_PHOTOGRAPH
 
@@ -160,7 +161,7 @@ void GcodeSuite::M240() {
 
   #ifdef PHOTO_POSITION
     #if PHOTO_DELAY_MS > 0
-      const millis_t timeout = millis() + PHOTO_DELAY_MS;
+      const millis_t timeout = millis() + parser.intval('P', PHOTO_DELAY_MS);
       while (PENDING(millis(), timeout)) idle();
     #endif
     do_blocking_move_to(old_pos, fr_mm_s);

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -27,10 +27,6 @@
 #include "../../gcode.h"
 #include "../../../module/motion.h" // for active_extruder and current_position
 
-#if PIN_EXISTS(CHDK)
-  millis_t chdk_timeout; // = 0
-#endif
-
 #ifdef PHOTO_RETRACT_MM
 
   #define _PHOTO_RETRACT_MM (PHOTO_RETRACT_MM + 0)
@@ -148,7 +144,8 @@ void GcodeSuite::M240() {
   #if PIN_EXISTS(CHDK)
 
     OUT_WRITE(CHDK_PIN, HIGH);
-    chdk_timeout = millis() + PHOTO_SWITCH_MS;
+    safe_delay(parser.intval('D', PHOTO_SWITCH_MS));
+    OUT_WRITE(CHDK_PIN, LOW);
 
   #elif HAS_PHOTOGRAPH
 


### PR DESCRIPTION
### Requirements
Enabling the Photo G-code in Configuration_adv.h using CHDK_PIN and with PHOTO_DELAY_MS and PHOTO_SWITCH_MS defined.

### Description
I realized when using the G-code M240 that the parameter [D <ms>] did not work and that the CHDK_PIN high was maintained until the end of the parameter [P <ms>] and start the movement.

### Benefits
Now this is solved and work as expected, I tested in a SKR 1.3 using pin P1_26.




