### PR TITLE
Power Loss Recovery for volumetric extrusion

### DIFF
--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -300,20 +300,20 @@ void PrintJobRecovery::resume() {
     gcode.process_subcommands_now(cmd);
   #endif
 
-  // Recover volumetric exstrusion state
+  // Recover volumetric extrusion state
   #if DISABLED(NO_VOLUMETRICS)    
     #if EXTRUDERS > 1
-      for (int8_t e = 0; e < EXTRUDERS; e++){
+      for (int8_t e = 0; e < EXTRUDERS; e++) {
         dtostrf(info.filament_size[e], 1, 3, str_1);
         sprintf_P(cmd, PSTR("M200 T%i D%s"), e, str_1);
         gcode.process_subcommands_now(cmd);
       }
-      if (!info.volumetric_enabled){
+      if (!info.volumetric_enabled) {
         sprintf_P(cmd, PSTR("M200 T%i D0"), info.active_extruder);
         gcode.process_subcommands_now(cmd);
       }
     #else
-      if (info.volumetric_enabled){
+      if (info.volumetric_enabled) {
         dtostrf(info.filament_size, 1, 3, str_1);
         sprintf_P(cmd, PSTR("M200 D%s"), str_1);
         gcode.process_subcommands_now(cmd);

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -300,7 +300,7 @@ void PrintJobRecovery::resume() {
     gcode.process_subcommands_now(cmd);
   #endif
 
-  // Recover volumetric exstrusion
+  // Recover volumetric exstrusion state
   #if DISABLED(NO_VOLUMETRICS)    
     #if EXTRUDERS > 1
       for (int8_t e = 0; e < EXTRUDERS; e++){
@@ -319,7 +319,6 @@ void PrintJobRecovery::resume() {
         gcode.process_subcommands_now(cmd);
       }
     #endif
-
   #endif
 
   #if HAS_HEATED_BED

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -183,6 +183,15 @@ void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=
       info.active_extruder = active_extruder;
     #endif
 
+    #if DISABLED(NO_VOLUMETRICS)
+      info.volumetric_enabled = parser.volumetric_enabled;
+      #if EXTRUDERS > 1
+        for (int8_t e = 0; e < EXTRUDERS; e++) info.filament_size[e] = planner.filament_size[e]
+      #else
+        if (parser.volumetric_enabled) info.filament_size = planner.filament_size[active_extruder]; 
+      #endif    
+    #endif
+
     #if EXTRUDERS
       HOTEND_LOOP() info.target_temperature[e] = thermalManager.temp_hotend[e].target;
     #endif
@@ -289,6 +298,28 @@ void PrintJobRecovery::resume() {
   #if EXTRUDERS > 1
     sprintf_P(cmd, PSTR("T%i S"), info.active_extruder);
     gcode.process_subcommands_now(cmd);
+  #endif
+
+  // Recover volumetric exstrusion
+  #if DISABLED(NO_VOLUMETRICS)    
+    #if EXTRUDERS > 1
+      for (int8_t e = 0; e < EXTRUDERS; e++){
+        dtostrf(info.filament_size[e], 1, 3, str_1);
+        sprintf_P(cmd, PSTR("M200 T%i D%s"), e, str_1);
+        gcode.process_subcommands_now(cmd);
+      }
+      if (!info.volumetric_enabled){
+        sprintf_P(cmd, PSTR("M200 T%i D0"), info.active_extruder);
+        gcode.process_subcommands_now(cmd);
+      }
+    #else
+      if (info.volumetric_enabled){
+        dtostrf(info.filament_size, 1, 3, str_1);
+        sprintf_P(cmd, PSTR("M200 D%s"), str_1);
+        gcode.process_subcommands_now(cmd);
+      }
+    #endif
+
   #endif
 
   #if HAS_HEATED_BED

--- a/Marlin/src/feature/power_loss_recovery.cpp
+++ b/Marlin/src/feature/power_loss_recovery.cpp
@@ -186,7 +186,7 @@ void PrintJobRecovery::save(const bool force/*=false*/, const bool save_queue/*=
     #if DISABLED(NO_VOLUMETRICS)
       info.volumetric_enabled = parser.volumetric_enabled;
       #if EXTRUDERS > 1
-        for (int8_t e = 0; e < EXTRUDERS; e++) info.filament_size[e] = planner.filament_size[e]
+        for (int8_t e = 0; e < EXTRUDERS; e++) info.filament_size[e] = planner.filament_size[e];
       #else
         if (parser.volumetric_enabled) info.filament_size = planner.filament_size[active_extruder]; 
       #endif    

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -59,6 +59,15 @@ typedef struct {
     uint8_t active_extruder;
   #endif
 
+  #if DISABLED(NO_VOLUMETRICS)
+    bool volumetric_enabled;
+    #if EXTRUDERS > 1
+      float filament_size[EXTRUDERS]; 
+    #else
+      float filament_size; 
+    #endif    
+  #endif
+
   #if HOTENDS
     int16_t target_temperature[HOTENDS];
   #endif


### PR DESCRIPTION
### Description
Adds volumetric extrusion recovery to the power loss recovery feature.

**Problem**: PLR feature doen't recover the volumetric extrusion state. If VOLUMETRIC_DEFAULT_ON is disabled but volumetric extrusion is enabled by gcode , after a PL the printer will resume the print in linear extrusion mode and every filament size setted before the PL will be lost.

**Fix**: Also save and recover the state of volumetric extrusion and the filament size for every extruder.

### Benefits
Can resume volumetric extrusion after a power loss.
