### PR TITLE
Add M220 B/R with PRUSA_MMU2

### DIFF
--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -29,12 +29,13 @@
  * M220 R: restore previously saved speed override
  */
 void GcodeSuite::M220() {
-  static int16_t backup_feedrate_percentage = 100;
-  if (parser.seenval('S'))
-    feedrate_percentage = parser.value_int();
-  if (parser.seen('B'))
-    backup_feedrate_percentage = feedrate_percentage;
-  if (parser.seen('R'))
-    feedrate_percentage = backup_feedrate_percentage;
+
+  #if ENABLED(PRUSA_MMU2)
+    static int16_t backup_feedrate_percentage = 100;
+    if (parser.seen('B')) backup_feedrate_percentage = feedrate_percentage;
+    if (parser.seen('R')) feedrate_percentage = backup_feedrate_percentage;
+  #endif
+
+  if (parser.seenval('S')) feedrate_percentage = parser.value_int();
 
 }

--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -24,11 +24,17 @@
 #include "../../module/motion.h"
 
 /**
- * M220: Set speed percentage factor, aka "Feed Rate" (M220 S95)
+ * M220 Sxxx: Set speed percentage factor, aka "Feed Rate" (M220 S95)
+ * M220 B: backup current speed override
+ * M220 R: restore previously saved speed override
  */
 void GcodeSuite::M220() {
-
+  static int16_t backup_feedrate_percentage = 100;
   if (parser.seenval('S'))
     feedrate_percentage = parser.value_int();
+  if (parser.seen('B'))
+    backup_feedrate_percentage = feedrate_percentage;
+  if (parser.seen('R'))
+    feedrate_percentage = backup_feedrate_percentage;
 
 }

--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -24,9 +24,14 @@
 #include "../../module/motion.h"
 
 /**
- * M220 Sxxx: Set speed percentage factor, aka "Feed Rate" (M220 S95)
- * M220 B: backup current speed override
- * M220 R: restore previously saved speed override
+ * M220: Set speed percentage factor, aka "Feed Rate"
+ *
+ * Parameters
+ *   S<percent> : Set the feed rate percentage factor
+ *
+ * With PRUSA_MMU2...
+ *   B : Flag to back up the current factor
+ *   R : Flag to restore the last-saved factor
  */
 void GcodeSuite::M220() {
 

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -177,7 +177,7 @@
  * M217 - Set filament swap parameters: "M217 S<length> P<feedrate> R<feedrate>". (Requires SINGLENOZZLE)
  * M218 - Set/get a tool offset: "M218 T<index> X<offset> Y<offset>". (Requires 2 or more extruders)
  * M220 - Set Feedrate Percentage: "M220 S<percent>" (i.e., "FR" on the LCD)
- *        Use "M220 B" / "M220 R" to backup or restore currently set override
+ *        Use "M220 B" to back up the Feedrate Percentage and "M220 R" to restore it. (Requires PRUSA_MMU2)
  * M221 - Set Flow Percentage: "M221 S<percent>"
  * M226 - Wait until a pin is in a given state: "M226 P<pin> S<state>"
  * M240 - Trigger a camera to take a photograph. (Requires PHOTO_GCODE)

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -177,6 +177,7 @@
  * M217 - Set filament swap parameters: "M217 S<length> P<feedrate> R<feedrate>". (Requires SINGLENOZZLE)
  * M218 - Set/get a tool offset: "M218 T<index> X<offset> Y<offset>". (Requires 2 or more extruders)
  * M220 - Set Feedrate Percentage: "M220 S<percent>" (i.e., "FR" on the LCD)
+ *        Use "M220 B" / "M220 R" to backup or restore currently set override
  * M221 - Set Flow Percentage: "M221 S<percent>"
  * M226 - Wait until a pin is in a given state: "M226 P<pin> S<state>"
  * M240 - Trigger a camera to take a photograph. (Requires PHOTO_GCODE)


### PR DESCRIPTION
### Description

prusa3d/Prusa-Firmware fork has extended the M220 gcode (set speed override) to allow stashing the current override value (`M220 B`) and restoring the stashed value (`M220 R`). The reason was Prusa MMU unit and its tip-shaping technique before filament unload, which cannot be arbitrarily sped up/down. The override was therefore reset to 100% before the unload, which lost the user-set value. The extended command solves this issue.

I suggest this extension is mirrored in Marlin firmware too. The code introduces a new static variable, but I don't see a way to do something like this without it.

### Benefits

The change allows user/custom gcode/slicer to reset the speed override and later restore the value that the user had set. This provides more flexibility and I'm sure there are other use cases than just the toolchange-related one mentioned above.