### PR TITLE
Fix kill screen with null string

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -740,7 +740,7 @@ void kill(PGM_P const lcd_error/*=nullptr*/, PGM_P const lcd_component/*=nullptr
   SERIAL_ERROR_MSG(MSG_ERR_KILLED);
 
   #if HAS_DISPLAY
-    ui.kill_screen(lcd_error ?: GET_TEXT(MSG_KILLED), lcd_component);
+    ui.kill_screen(lcd_error ?: GET_TEXT(MSG_KILLED), lcd_component ?: PSTR(""));
   #else
     UNUSED(lcd_error);
     UNUSED(lcd_component);


### PR DESCRIPTION
### Description

Fix garbage showing up after KILLED: on RepRepDiscount Full Graphics Smart display on LPC1768 if the Kill button is pressed.

### Benefits

Removes garbage from the display.
