### PR TITLE
Fix missing % on DOGM Status Screen

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -438,7 +438,7 @@ void MarlinUI::draw_status_screen() {
             ));
           }
           #if BOTH(SHOW_REMAINING_TIME, ROTATE_PROGRESS_DISPLAY) // Tri-state progress display mode
-            progress_x_pos = _SD_INFO_X(strlen(progress_string));
+            progress_x_pos = _SD_INFO_X(strlen(progress_string)+1);
           #endif
         #endif
       }

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -438,7 +438,7 @@ void MarlinUI::draw_status_screen() {
             ));
           }
           #if BOTH(SHOW_REMAINING_TIME, ROTATE_PROGRESS_DISPLAY) // Tri-state progress display mode
-            progress_x_pos = _SD_INFO_X(strlen(progress_string)+1);
+            progress_x_pos = _SD_INFO_X(strlen(progress_string) + 1);
           #endif
         #endif
       }


### PR DESCRIPTION
The "%" char now show up at Dogm Status Screen. 
It is because we forget to add this Char when counting string pos for Percent Progress.