### PR TITLE
Cortex M3-M7 can all use DWT->CYCCNT

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL.cpp
@@ -49,7 +49,7 @@ uint16_t HAL_adc_result;
 // ------------------------
 
 // Needed for DELAY_NS() / DELAY_US() on CORTEX-M7
-#if (defined(__arm__) || defined(__thumb__)) && __CORTEX_M == 7
+#if (defined(__arm__) || defined(__thumb__)) && WITHIN(__CORTEX_M, 3, 7)
   // HAL pre-initialization task
   // Force the preinit function to run between the premain() and main() function
   // of the STM32 arduino core

--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -34,16 +34,17 @@
 
 #if defined(__arm__) || defined(__thumb__)
 
-  #if __CORTEX_M == 7
+  #if WITHIN(__CORTEX_M, 3, 7)
 
-    // Cortex-M7 can use the cycle counter of the DWT unit
+    // Cortex-M3 through M7 can use the cycle counter of the DWT unit
     // http://www.anthonyvh.com/2017/05/18/cortex_m-cycle_counter/
 
     FORCE_INLINE static void enableCycleCounter() {
       CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
 
-      // Unlock DWT.
-      DWT->LAR = 0xC5ACCE55;
+      #if __CORTEX_M == 7
+        DWT->LAR = 0xC5ACCE55; // Unlock DWT on the M7
+      #endif
 
       DWT->CYCCNT = 0;
       DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;


### PR DESCRIPTION
Suggested by Alex Kenis at https://youtu.be/ZfyPcdhQnAA?t=502

The M7 has to be unlocked, but M3/M4 have the other fields.