### PR TITLE
Use prior endstop pin-to-interrupt macros

### DIFF
--- a/Marlin/src/HAL/HAL_AVR/endstop_interrupts.h
+++ b/Marlin/src/HAL/HAL_AVR/endstop_interrupts.h
@@ -51,28 +51,35 @@ void endstop_ISR() { endstops.update(); }
  * There are more PCI-enabled processor pins on Port J, but they are not connected to Arduino MEGA.
  */
 #if defined(ARDUINO_AVR_MEGA2560) || defined(ARDUINO_AVR_MEGA)
+  #define digitalPinHasPCICR(p)   (WITHIN(p, 10, 15) || WITHIN(p, 50, 53) || WITHIN(p, 62, 69))
+
   #undef  digitalPinToPCICR
-  #define digitalPinToPCICR(p)    ( WITHIN(p, 10, 15) || \
-                                    WITHIN(p, 50, 53) || \
-                                    WITHIN(p, 62, 69) ? &PCICR : nullptr )
+  #define digitalPinToPCICR(p)    (digitalPinHasPCICR(p) ? &PCICR : nullptr)
   #undef  digitalPinToPCICRbit
-  #define digitalPinToPCICRbit(p) ( WITHIN(p, 10, 13) || WITHIN(p, 50, 53) ? 0 : \
-                                    WITHIN(p, 14, 15) ? 1 : \
-                                    WITHIN(p, 62, 69) ? 2 : \
-                                    0 )
+  #define digitalPinToPCICRbit(p) (WITHIN(p, 10, 13) || WITHIN(p, 50, 53) ? 0 : \
+                                   WITHIN(p, 14, 15) ? 1 : \
+                                   WITHIN(p, 62, 69) ? 2 : \
+                                   0)
   #undef  digitalPinToPCMSK
-  #define digitalPinToPCMSK(p)    ( WITHIN(p, 10, 13) || WITHIN(p, 50, 53) ? (&PCMSK0) : \
-                                    WITHIN(p, 14, 15) ? (&PCMSK1) : \
-                                    WITHIN(p, 62, 69) ? (&PCMSK2) : \
-                                    nullptr )
+  #define digitalPinToPCMSK(p)    (WITHIN(p, 10, 13) || WITHIN(p, 50, 53) ? (&PCMSK0) : \
+                                   WITHIN(p, 14, 15) ? (&PCMSK1) : \
+                                   WITHIN(p, 62, 69) ? (&PCMSK2) : \
+                                   nullptr)
   #undef  digitalPinToPCMSKbit
-  #define digitalPinToPCMSKbit(p) ( WITHIN(p, 10, 13) ? ((p) - 6) : \
-                                    (p) == 14 || (p) == 51 ? 2 : \
-                                    (p) == 15 || (p) == 52 ? 1 : \
-                                    (p) == 50 ? 3 : \
-                                    (p) == 53 ? 0 : \
-                                    WITHIN(p, 62, 69) ? ((p) - 62) : \
-                                    0 )
+  #define digitalPinToPCMSKbit(p) (WITHIN(p, 10, 13) ? ((p) - 6) : \
+                                   (p) == 14 || (p) == 51 ? 2 : \
+                                   (p) == 15 || (p) == 52 ? 1 : \
+                                   (p) == 50 ? 3 : \
+                                   (p) == 53 ? 0 : \
+                                   WITHIN(p, 62, 69) ? ((p) - 62) : \
+                                   0)
+#elif defined(__AVR_ATmega164A__) || defined(__AVR_ATmega164P__) || defined(__AVR_ATmega324A__) || \
+      defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega324PB__) || \
+      defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284__) || \
+      defined(__AVR_ATmega1284P__)
+  #define digitalPinHasPCICR(p)   WITHIN(p, 0, NUM_DIGITAL_PINS)
+#else
+  #error "Must be done!"
 #endif
 
 
@@ -108,7 +115,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(X_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(X_MAX_PIN);
     #else
-      static_assert(digitalPinToPCICR(X_MAX_PIN), "X_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(X_MAX_PIN), "X_MAX_PIN is not interrupt-capable");
       pciSetup(X_MAX_PIN);
     #endif
   #endif
@@ -116,7 +123,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(X_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(X_MIN_PIN);
     #else
-      static_assert(digitalPinToPCICR(X_MIN_PIN), "X_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(X_MIN_PIN), "X_MIN_PIN is not interrupt-capable");
       pciSetup(X_MIN_PIN);
     #endif
   #endif
@@ -124,7 +131,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Y_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Y_MAX_PIN);
     #else
-      static_assert(digitalPinToPCICR(Y_MAX_PIN), "Y_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Y_MAX_PIN), "Y_MAX_PIN is not interrupt-capable");
       pciSetup(Y_MAX_PIN);
     #endif
   #endif
@@ -132,7 +139,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Y_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Y_MIN_PIN);
     #else
-      static_assert(digitalPinToPCICR(Y_MIN_PIN), "Y_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Y_MIN_PIN), "Y_MIN_PIN is not interrupt-capable");
       pciSetup(Y_MIN_PIN);
     #endif
   #endif
@@ -140,7 +147,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z_MAX_PIN);
     #else
-      static_assert(digitalPinToPCICR(Z_MAX_PIN), "Z_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z_MAX_PIN), "Z_MAX_PIN is not interrupt-capable");
       pciSetup(Z_MAX_PIN);
     #endif
   #endif
@@ -148,7 +155,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z_MIN_PIN);
     #else
-      static_assert(digitalPinToPCICR(Z_MIN_PIN), "Z_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z_MIN_PIN), "Z_MIN_PIN is not interrupt-capable");
       pciSetup(Z_MIN_PIN);
     #endif
   #endif
@@ -156,7 +163,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(X2_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(X2_MAX_PIN);
     #else
-      static_assert(digitalPinToPCICR(X2_MAX_PIN), "X2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(X2_MAX_PIN), "X2_MAX_PIN is not interrupt-capable");
       pciSetup(X2_MAX_PIN);
     #endif
   #endif
@@ -164,7 +171,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(X2_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(X2_MIN_PIN);
     #else
-      static_assert(digitalPinToPCICR(X2_MIN_PIN), "X2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(X2_MIN_PIN), "X2_MIN_PIN is not interrupt-capable");
       pciSetup(X2_MIN_PIN);
     #endif
   #endif
@@ -172,7 +179,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Y2_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Y2_MAX_PIN);
     #else
-      static_assert(digitalPinToPCICR(Y2_MAX_PIN), "Y2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Y2_MAX_PIN), "Y2_MAX_PIN is not interrupt-capable");
       pciSetup(Y2_MAX_PIN);
     #endif
   #endif
@@ -180,7 +187,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Y2_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Y2_MIN_PIN);
     #else
-      static_assert(digitalPinToPCICR(Y2_MIN_PIN), "Y2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Y2_MIN_PIN), "Y2_MIN_PIN is not interrupt-capable");
       pciSetup(Y2_MIN_PIN);
     #endif
   #endif
@@ -188,7 +195,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z2_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z2_MAX_PIN);
     #else
-      static_assert(digitalPinToPCICR(Z2_MAX_PIN), "Z2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z2_MAX_PIN), "Z2_MAX_PIN is not interrupt-capable");
       pciSetup(Z2_MAX_PIN);
     #endif
   #endif
@@ -196,7 +203,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z2_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z2_MIN_PIN);
     #else
-      static_assert(digitalPinToPCICR(Z2_MIN_PIN), "Z2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z2_MIN_PIN), "Z2_MIN_PIN is not interrupt-capable");
       pciSetup(Z2_MIN_PIN);
     #endif
   #endif
@@ -204,7 +211,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z3_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z3_MAX_PIN);
     #else
-      static_assert(digitalPinToPCICR(Z3_MAX_PIN), "Z3_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z3_MAX_PIN), "Z3_MAX_PIN is not interrupt-capable");
       pciSetup(Z3_MAX_PIN);
     #endif
   #endif
@@ -212,7 +219,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z3_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z3_MIN_PIN);
     #else
-      static_assert(digitalPinToPCICR(Z3_MIN_PIN), "Z3_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z3_MIN_PIN), "Z3_MIN_PIN is not interrupt-capable");
       pciSetup(Z3_MIN_PIN);
     #endif
   #endif
@@ -220,7 +227,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z_MIN_PROBE_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z_MIN_PROBE_PIN);
     #else
-      static_assert(digitalPinToPCICR(Z_MIN_PROBE_PIN), "Z_MIN_PROBE_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z_MIN_PROBE_PIN), "Z_MIN_PROBE_PIN is not interrupt-capable");
       pciSetup(Z_MIN_PROBE_PIN);
     #endif
   #endif

--- a/Marlin/src/HAL/HAL_AVR/endstop_interrupts.h
+++ b/Marlin/src/HAL/HAL_AVR/endstop_interrupts.h
@@ -51,20 +51,24 @@ void endstop_ISR() { endstops.update(); }
  * There are more PCI-enabled processor pins on Port J, but they are not connected to Arduino MEGA.
  */
 #if defined(ARDUINO_AVR_MEGA2560) || defined(ARDUINO_AVR_MEGA)
+
   #define digitalPinHasPCICR(p)   (WITHIN(p, 10, 15) || WITHIN(p, 50, 53) || WITHIN(p, 62, 69))
 
   #undef  digitalPinToPCICR
-  #define digitalPinToPCICR(p)    (digitalPinHasPCICR(p) ? &PCICR : nullptr)
+  #define digitalPinToPCICR(p)    (digitalPinHasPCICR(p) ? (&PCICR) : nullptr)
+
   #undef  digitalPinToPCICRbit
   #define digitalPinToPCICRbit(p) (WITHIN(p, 10, 13) || WITHIN(p, 50, 53) ? 0 : \
                                    WITHIN(p, 14, 15) ? 1 : \
                                    WITHIN(p, 62, 69) ? 2 : \
                                    0)
+  
   #undef  digitalPinToPCMSK
   #define digitalPinToPCMSK(p)    (WITHIN(p, 10, 13) || WITHIN(p, 50, 53) ? (&PCMSK0) : \
                                    WITHIN(p, 14, 15) ? (&PCMSK1) : \
                                    WITHIN(p, 62, 69) ? (&PCMSK2) : \
                                    nullptr)
+
   #undef  digitalPinToPCMSKbit
   #define digitalPinToPCMSKbit(p) (WITHIN(p, 10, 13) ? ((p) - 6) : \
                                    (p) == 14 || (p) == 51 ? 2 : \
@@ -73,13 +77,18 @@ void endstop_ISR() { endstops.update(); }
                                    (p) == 53 ? 0 : \
                                    WITHIN(p, 62, 69) ? ((p) - 62) : \
                                    0)
+
 #elif defined(__AVR_ATmega164A__) || defined(__AVR_ATmega164P__) || defined(__AVR_ATmega324A__) || \
       defined(__AVR_ATmega324P__) || defined(__AVR_ATmega324PA__) || defined(__AVR_ATmega324PB__) || \
       defined(__AVR_ATmega644A__) || defined(__AVR_ATmega644P__) || defined(__AVR_ATmega1284__) || \
       defined(__AVR_ATmega1284P__)
+
   #define digitalPinHasPCICR(p)   WITHIN(p, 0, NUM_DIGITAL_PINS)
+
 #else
-  #error "Must be done!"
+
+  #error "Unsupported AVR variant!"
+
 #endif
 
 

--- a/buildroot/share/pin_interrupt_test/pin_interrupt_test.ino
+++ b/buildroot/share/pin_interrupt_test/pin_interrupt_test.ino
@@ -2,16 +2,17 @@
 // Compile with the same build settings you'd use for Marlin.
 
 #if defined(ARDUINO_AVR_MEGA2560) || defined(ARDUINO_AVR_MEGA)
-  #define moreDigitalPinToPCICR(p) digitalPinToPCICR(WITHIN(p, 14, 15) ? 10 : p)
-#else
-  #define moreDigitalPinToPCICR(p) digitalPinToPCICR(p)
+    #undef  digitalPinToPCICR
+    #define digitalPinToPCICR(p)    ( ((p) >= 10 && (p) <= 15) || \
+                                      ((p) >= 50 && (p) <= 53) || \
+                                      ((p) >= 62 && (p) <= 69) ? (&PCICR) : nullptr)
 #endif
 
 void setup() {
   Serial.begin(9600);
   Serial.println("PINs causing interrupts are:");
   for (int i = 2; i < NUM_DIGITAL_PINS; i++) {
-    if (moreDigitalPinToPCICR(i) || (int)digitalPinToInterrupt(i) != -1) {
+    if (digitalPinToPCICR(i) || (int)digitalPinToInterrupt(i) != -1) {
       for (int j = 0; j < NUM_ANALOG_INPUTS; j++) {
         if (analogInputToDigitalPin(j) == i) {
           Serial.print('A');


### PR DESCRIPTION
Revert recent AVR interrupt PRs and fix #15770 

Compiled ANET A8 and mega2560 with arduino 1.8.10 without any problem