### PR TITLE
Allow TMC baud rate override

### DIFF
--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -107,6 +107,10 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
   TMC_SPI_DEFINE_E(5);
 #endif
 
+#ifndef TMC_BAUD_RATE
+  #define TMC_BAUD_RATE 115200
+#endif
+
 #if HAS_DRIVER(TMC2130)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
   void tmc_init(TMCMarlin<TMC2130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t thrs, const bool stealth) {
@@ -291,93 +295,93 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
   void tmc_serial_begin() {
     #if AXIS_HAS_UART(X)
       #ifdef X_HARDWARE_SERIAL
-        X_HARDWARE_SERIAL.begin(115200);
+        X_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperX.beginSerial(115200);
+        stepperX.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(X2)
       #ifdef X2_HARDWARE_SERIAL
-        X2_HARDWARE_SERIAL.begin(115200);
+        X2_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperX2.beginSerial(115200);
+        stepperX2.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(Y)
       #ifdef Y_HARDWARE_SERIAL
-        Y_HARDWARE_SERIAL.begin(115200);
+        Y_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperY.beginSerial(115200);
+        stepperY.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(Y2)
       #ifdef Y2_HARDWARE_SERIAL
-        Y2_HARDWARE_SERIAL.begin(115200);
+        Y2_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperY2.beginSerial(115200);
+        stepperY2.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(Z)
       #ifdef Z_HARDWARE_SERIAL
-        Z_HARDWARE_SERIAL.begin(115200);
+        Z_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperZ.beginSerial(115200);
+        stepperZ.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(Z2)
       #ifdef Z2_HARDWARE_SERIAL
-        Z2_HARDWARE_SERIAL.begin(115200);
+        Z2_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperZ2.beginSerial(115200);
+        stepperZ2.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(Z3)
       #ifdef Z3_HARDWARE_SERIAL
-        Z3_HARDWARE_SERIAL.begin(115200);
+        Z3_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperZ3.beginSerial(115200);
+        stepperZ3.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(E0)
       #ifdef E0_HARDWARE_SERIAL
-        E0_HARDWARE_SERIAL.begin(115200);
+        E0_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperE0.beginSerial(115200);
+        stepperE0.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(E1)
       #ifdef E1_HARDWARE_SERIAL
-        E1_HARDWARE_SERIAL.begin(115200);
+        E1_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperE1.beginSerial(115200);
+        stepperE1.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(E2)
       #ifdef E2_HARDWARE_SERIAL
-        E2_HARDWARE_SERIAL.begin(115200);
+        E2_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperE2.beginSerial(115200);
+        stepperE2.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(E3)
       #ifdef E3_HARDWARE_SERIAL
-        E3_HARDWARE_SERIAL.begin(115200);
+        E3_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperE3.beginSerial(115200);
+        stepperE3.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(E4)
       #ifdef E4_HARDWARE_SERIAL
-        E4_HARDWARE_SERIAL.begin(115200);
+        E4_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperE4.beginSerial(115200);
+        stepperE4.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
     #if AXIS_HAS_UART(E5)
       #ifdef E5_HARDWARE_SERIAL
-        E5_HARDWARE_SERIAL.begin(115200);
+        E5_HARDWARE_SERIAL.begin(TMC_BAUD_RATE);
       #else
-        stepperE5.beginSerial(115200);
+        stepperE5.beginSerial(TMC_BAUD_RATE);
       #endif
     #endif
   }

--- a/Marlin/src/pins/lpc1768/pins_BIGTREE_SKR_V1.3.h
+++ b/Marlin/src/pins/lpc1768/pins_BIGTREE_SKR_V1.3.h
@@ -154,6 +154,8 @@
   #define Z2_SERIAL_TX_PIN P1_04
   #define Z2_SERIAL_RX_PIN P1_01
 
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
 #endif
 
 //

--- a/Marlin/src/pins/lpc1768/pins_GMARSH_X6_REV1.h
+++ b/Marlin/src/pins/lpc1768/pins_GMARSH_X6_REV1.h
@@ -95,6 +95,9 @@
   #define E1_SERIAL_RX_PIN P2_02
   #define E2_SERIAL_TX_PIN P2_06
   #define E2_SERIAL_RX_PIN P2_06
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
 #else
   #error "TMC2208 UART configuration is required for GMarsh X6."
 #endif

--- a/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
@@ -320,6 +320,9 @@
   #define Z_SERIAL_RX_PIN  P0_25   // TH3
   #define E0_SERIAL_TX_PIN P4_28   // J8-6
   #define E0_SERIAL_RX_PIN P0_26   // TH4
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
 #endif
 
 // UNUSED

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -149,6 +149,8 @@
   #define Z2_SERIAL_TX_PIN P4_29
   #define Z2_SERIAL_RX_PIN P1_17
 
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
 #endif // TMC2208 || TMC2209
 
 //

--- a/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
@@ -156,6 +156,8 @@
     #define E0_SERIAL_RX_PIN P2_08
   #endif
 
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
 #endif
 
 //

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN.h
@@ -61,4 +61,7 @@
   #define Z_SERIAL_RX_PIN  P2_11   // J8-4
   #define E0_SERIAL_TX_PIN P2_13   // J8-5
   #define E0_SERIAL_RX_PIN P2_13   // J8-5
+  
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
 #endif

--- a/Marlin/src/pins/lpc1769/pins_TH3D_EZBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_TH3D_EZBOARD.h
@@ -87,6 +87,9 @@
   #define Z_SERIAL_RX_PIN  P0_20
   #define E0_SERIAL_TX_PIN P0_22
   #define E0_SERIAL_RX_PIN P0_21
+    
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
 #endif
 
 //

--- a/Marlin/src/pins/stm32/pins_BIGTREE_BTT002_V1.0.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_BTT002_V1.0.h
@@ -157,6 +157,9 @@
 
   //#define E2_SERIAL_TX_PIN PD6
   //#define E2_SERIAL_RX_PIN PD6
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200  
 #endif
 
 //

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_E3_DIP.h
@@ -142,6 +142,8 @@
   #define E0_SERIAL_TX_PIN PD2
   #define E0_SERIAL_RX_PIN PD2
 
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200  
 #endif
 
 //

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_PRO_V1.1.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_PRO_V1.1.h
@@ -154,6 +154,9 @@
 
   #define E2_SERIAL_TX_PIN PD6
   #define E2_SERIAL_RX_PIN PD6
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
 #endif
 
 //

--- a/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3_V1_2.h
+++ b/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3_V1_2.h
@@ -100,6 +100,9 @@
 
   #define E0_SERIAL_TX_PIN PC11
   #define E0_SERIAL_RX_PIN PC11
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200  
 #endif
 
 //

--- a/Marlin/src/pins/stm32/pins_FYSETC_CHEETAH_V12.h
+++ b/Marlin/src/pins/stm32/pins_FYSETC_CHEETAH_V12.h
@@ -59,4 +59,6 @@
   #define E0_SERIAL_TX_PIN PA2
   #define E0_SERIAL_RX_PIN PA3
 
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200  
 #endif


### PR DESCRIPTION
### Description

Allow overriding TMC baud rate by defining TMC_BAUD_RATE. This is prepatory to using the SoftwareSerial provided by the STM32 framework. Unlike the 1768 version of  SoftwareSerial, the STM32 implementation of SoftwareSerial does not force the baud rate to 19200.

Set this to 19200 for the BTT SKR Pro and BTT002, which are the only two boards currently using the STM32 HAL which define software serial pin numbers.

### Benefits

Allows using slower baud rates with STM32 and SoftwareSerial, to reduce the chance of bit timing errors.

### Related Issues

This is related to PR #15655.
