### PR TITLE
Fix BLTOUCH and SPEAKER conflict on SKR E3 boards

### DIFF
--- a/Marlin/src/HAL/HAL_STM32F1/SPI.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/SPI.cpp
@@ -53,7 +53,7 @@ static const spi_pins* dev_to_spi_pins(spi_dev *dev);
 static void configure_gpios(spi_dev *dev, bool as_master);
 static spi_baud_rate determine_baud_rate(spi_dev *dev, uint32_t freq);
 
-#if (BOARD_NR_SPI >= 3) && !defined(STM32_HIGH_DENSITY)
+#if BOARD_NR_SPI >= 3 && !defined(STM32_HIGH_DENSITY)
   #error "The SPI library is misconfigured: 3 SPI ports only available on high density STM32 devices"
 #endif
 

--- a/Marlin/src/HAL/HAL_STM32F1/timers.cpp
+++ b/Marlin/src/HAL/HAL_STM32F1/timers.cpp
@@ -57,7 +57,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
     case 3: irq_num = NVIC_TIMER3; break;
     case 4: irq_num = NVIC_TIMER4; break;
     case 5: irq_num = NVIC_TIMER5; break;
-    #if ENABLED(STM32_HIGH_DENSITY)
+    #ifdef STM32_HIGH_DENSITY
       // 6 & 7 are basic timers, avoid them
       case 8: irq_num = NVIC_TIMER8_CC; break;
     #endif

--- a/Marlin/src/HAL/HAL_STM32F1/timers.h
+++ b/Marlin/src/HAL/HAL_STM32F1/timers.h
@@ -73,7 +73,7 @@ typedef uint16_t hal_timer_t;
 
 #if MB(BIGTREE_SKR_MINI_E3, BIGTREE_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE)
   // SKR Mini E3 boards use PA8 as FAN_PIN, so TIMER 1 is used for Fan PWM.
-  #if defined(STM32_HIGH_DENSITY)
+  #ifdef STM32_HIGH_DENSITY
     #define SERVO0_TIMER_NUM 8  // tone.cpp uses Timer 4
   #else
     #define SERVO0_TIMER_NUM 3  // tone.cpp uses Timer 8

--- a/Marlin/src/HAL/HAL_STM32F1/timers.h
+++ b/Marlin/src/HAL/HAL_STM32F1/timers.h
@@ -48,19 +48,18 @@ typedef uint16_t hal_timer_t;
 #define TEMP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts
 
 /**
- * Note: Some timers that can be already allocated elsewhere
+ * Note: Timers may be used by platforms and libraries
  *
  * FAN PWMs:
- *   When FAN_SOFT_PWM is not defined in Configuration.h, temperature.cpp
- *   uses timers that belong to FANx_PIN pins to generate FAN PWM signals.
+ *   With FAN_SOFT_PWM disabled the Temperature class uses
+ *   FANx_PIN timers to generate FAN PWM signals.
  *
  * Speaker:
- *   When SPEAKER is enabled in Configuration.h, one timer is allocated
- *   by libmaple's tone.cpp to generate tones.
- *   - If BEEPER_PIN has a timer channel (and USE_PIN_TIMER is defined in tone.cpp),
- *     the timer that belongs to this pin is used.
- *   - Otherwise, either TIMER 8 (on boards with high-density MCUs)
- *     or TIMER 4 (on boards with medium-density MCUs) is used.
+ *   When SPEAKER is enabled, one timer is allocated by maple/tone.cpp.
+ *   - If BEEPER_PIN has a timer channel (and USE_PIN_TIMER is
+ *     defined in tone.cpp) it uses the pin's own timer.
+ *   - Otherwise it uses Timer 8 on boards with STM32_HIGH_DENSITY
+ *     or Timer 4 on other boards.
  */
 #if defined(MCU_STM32F103CB) || defined(MCU_STM32F103C8)
   #define STEP_TIMER_NUM 4 // For C8/CB boards, use timer 4

--- a/Marlin/src/HAL/HAL_STM32F1/timers.h
+++ b/Marlin/src/HAL/HAL_STM32F1/timers.h
@@ -49,11 +49,11 @@ typedef uint16_t hal_timer_t;
 
 /**
  * Note: Some timers that can be already allocated elsewhere
- * 
+ *
  * FAN PWMs:
  *   When FAN_SOFT_PWM is not defined in Configuration.h, temperature.cpp
  *   uses timers that belong to FANx_PIN pins to generate FAN PWM signals.
- * 
+ *
  * Speaker:
  *   When SPEAKER is enabled in Configuration.h, one timer is allocated
  *   by libmaple's tone.cpp to generate tones.
@@ -73,7 +73,11 @@ typedef uint16_t hal_timer_t;
 
 #if MB(BIGTREE_SKR_MINI_E3, BIGTREE_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE)
   // SKR Mini E3 boards use PA8 as FAN_PIN, so TIMER 1 is used for Fan PWM.
-  #define SERVO0_TIMER_NUM 3
+  #if defined(STM32_HIGH_DENSITY) || DISABLED(SPEAKER)
+    #define SERVO0_TIMER_NUM 8  // tone.cpp uses Timer 4
+  #else
+    #define SERVO0_TIMER_NUM 3  // tone.cpp uses Timer 8
+  #endif
 #else
   #define SERVO0_TIMER_NUM 1  // SERVO0 or BLTOUCH
 #endif

--- a/Marlin/src/HAL/HAL_STM32F1/timers.h
+++ b/Marlin/src/HAL/HAL_STM32F1/timers.h
@@ -50,7 +50,7 @@ typedef uint16_t hal_timer_t;
 /**
  * Note: Some timers that can be already allocated elsewhere
  * 
- * FAN0 PWM:
+ * FAN PWM:
  *   When FAN_SOFT_PWM is not defined in Configuration.h, temperature.cpp
  *   uses the timer that belongs to FAN_PIN to generate FAN0 PWM signal.
  * 

--- a/Marlin/src/HAL/HAL_STM32F1/timers.h
+++ b/Marlin/src/HAL/HAL_STM32F1/timers.h
@@ -50,9 +50,9 @@ typedef uint16_t hal_timer_t;
 /**
  * Note: Some timers that can be already allocated elsewhere
  * 
- * FAN PWM:
+ * FAN PWMs:
  *   When FAN_SOFT_PWM is not defined in Configuration.h, temperature.cpp
- *   uses the timer that belongs to FAN_PIN to generate FAN0 PWM signal.
+ *   uses timers that belong to FANx_PIN pins to generate FAN PWM signals.
  * 
  * Speaker:
  *   When SPEAKER is enabled in Configuration.h, one timer is allocated

--- a/Marlin/src/HAL/HAL_STM32F1/timers.h
+++ b/Marlin/src/HAL/HAL_STM32F1/timers.h
@@ -47,6 +47,21 @@ typedef uint16_t hal_timer_t;
 #define STEP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts
 #define TEMP_TIMER_CHAN 1 // Channel of the timer to use for compare and interrupts
 
+/**
+ * Note: Some timers that can be already allocated elsewhere
+ * 
+ * FAN0 PWM:
+ *   When FAN_SOFT_PWM is not defined in Configuration.h, temperature.cpp
+ *   uses the timer that belongs to FAN_PIN to generate FAN0 PWM signal.
+ * 
+ * Speaker:
+ *   When SPEAKER is enabled in Configuration.h, one timer is allocated
+ *   by libmaple's tone.cpp to generate tones.
+ *   - If BEEPER_PIN has a timer channel (and USE_PIN_TIMER is defined in tone.cpp),
+ *     the timer that belongs to this pin is used.
+ *   - Otherwise, either TIMER 8 (on boards with high-density MCUs)
+ *     or TIMER 4 (on boards with medium-density MCUs) is used.
+ */
 #if defined(MCU_STM32F103CB) || defined(MCU_STM32F103C8)
   #define STEP_TIMER_NUM 4 // For C8/CB boards, use timer 4
 #else
@@ -58,7 +73,7 @@ typedef uint16_t hal_timer_t;
 
 #if MB(BIGTREE_SKR_MINI_E3, BIGTREE_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE)
   // SKR Mini E3 boards use PA8 as FAN_PIN, so TIMER 1 is used for Fan PWM.
-  #define SERVO0_TIMER_NUM 8
+  #define SERVO0_TIMER_NUM 3
 #else
   #define SERVO0_TIMER_NUM 1  // SERVO0 or BLTOUCH
 #endif

--- a/Marlin/src/HAL/HAL_STM32F1/timers.h
+++ b/Marlin/src/HAL/HAL_STM32F1/timers.h
@@ -73,7 +73,7 @@ typedef uint16_t hal_timer_t;
 
 #if MB(BIGTREE_SKR_MINI_E3, BIGTREE_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE)
   // SKR Mini E3 boards use PA8 as FAN_PIN, so TIMER 1 is used for Fan PWM.
-  #if defined(STM32_HIGH_DENSITY) || DISABLED(SPEAKER)
+  #if defined(STM32_HIGH_DENSITY)
     #define SERVO0_TIMER_NUM 8  // tone.cpp uses Timer 4
   #else
     #define SERVO0_TIMER_NUM 3  // tone.cpp uses Timer 8

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -62,10 +62,10 @@ typedef struct {
   #if DISABLED(NO_VOLUMETRICS)
     bool volumetric_enabled;
     #if EXTRUDERS > 1
-      float filament_size[EXTRUDERS]; 
+      float filament_size[EXTRUDERS];
     #else
-      float filament_size; 
-    #endif    
+      float filament_size;
+    #endif
   #endif
 
   #if HOTENDS

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -1312,7 +1312,7 @@
   #define BABYSTEP_INVERT_Z false           // Change if Z babysteps should go the other way
   #define BABYSTEP_MULTIPLICATOR_Z  10      // Babysteps are very small. Increase for faster motion.
   #define BABYSTEP_MULTIPLICATOR_XY  10
-  
+
   #define DOUBLECLICK_FOR_Z_BABYSTEPPING    // Double-click on the Status Screen for Z Babystepping.
   #if ENABLED(DOUBLECLICK_FOR_Z_BABYSTEPPING)
     #define DOUBLECLICK_MAX_INTERVAL 1250   // Maximum interval between clicks, in milliseconds.


### PR DESCRIPTION
### Description
Previous fix https://github.com/MarlinFirmware/Marlin/pull/15547/commits solved the conflict when both SERVO0 and FAN0 PWM were using TIMER 1 by assigning TIMER 8 to SERVO0.
However, when SPEAKER is enabled on SKR E3 boards, TIMER 8 is actually [used by libmaple's tone.cpp to generate tones](https://github.com/rogerclarkmelbourne/Arduino_STM32/blob/83ae7019d8085181e8d9b622ce90201b61b5c719/STM32F1/cores/maple/tone.cpp#L31).

This fix changes `SERVO0_TIMER_NUM` to TIMER 3 on SKR E3 boards. As far as I can tell this timer is not used by any other functionality.

See also this discussion: https://github.com/MarlinFirmware/Marlin/pull/15547#issuecomment-549094349 .

### Benefits
This PR fixes possible problems with BLTOUCH on SKR E3 boards when `SPEAKER` is enabled in `Configuration.h`.

### Related Issues
- https://github.com/MarlinFirmware/Marlin/pull/15547/commits