### PR TITLE
More compatible uint8_t for Experimental i2c Bus buffer

### DIFF
--- a/Marlin/src/feature/twibus.h
+++ b/Marlin/src/feature/twibus.h
@@ -62,7 +62,7 @@ class TWIBus {
      * @brief Internal buffer
      * @details A fixed buffer. TWI commands can be no longer than this.
      */
-    char buffer[TWIBUS_BUFFER_SIZE];
+    uint8_t buffer[TWIBUS_BUFFER_SIZE];
 
 
   public:


### PR DESCRIPTION
Fix compile error in twibus.h for LPC1768 (SKR 1.3)
