### PR TITLE
Fix for Panelolu 2 and Viki 1 LCD

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1839,7 +1839,7 @@
 // Panucatt VIKI LCD with status LEDs,
 // integrated click & L/R/U/D buttons, separate encoder inputs.
 //
-#define LCD_I2C_VIKI
+//#define LCD_I2C_VIKI
 
 //
 // CONTROLLER TYPE: Shift register panels

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1833,7 +1833,7 @@
 // Note: The PANELOLU2 encoder click input can either be directly connected to
 // a pin (if BTN_ENC defined to != -1) or read through I2C (when BTN_ENC == -1).
 //
-//#define LCD_I2C_PANELOLU2
+#define LCD_I2C_PANELOLU2
 
 //
 // Panucatt VIKI LCD with status LEDs,

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1833,13 +1833,13 @@
 // Note: The PANELOLU2 encoder click input can either be directly connected to
 // a pin (if BTN_ENC defined to != -1) or read through I2C (when BTN_ENC == -1).
 //
-#define LCD_I2C_PANELOLU2
+//#define LCD_I2C_PANELOLU2
 
 //
 // Panucatt VIKI LCD with status LEDs,
 // integrated click & L/R/U/D buttons, separate encoder inputs.
 //
-//#define LCD_I2C_VIKI
+#define LCD_I2C_VIKI
 
 //
 // CONTROLLER TYPE: Shift register panels

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -65,7 +65,7 @@
   #include "feature/host_actions.h"
 #endif
 
-#if HAS_BUZZER && DISABLED(LCD_USE_I2C_BUZZER)
+#if HAS_BUZZER && PIN_EXISTS(BEEPER)
   #include "libs/buzzer.h"
 #endif
 
@@ -681,7 +681,7 @@ void idle(
     print_job_timer.tick();
   #endif
 
-  #if HAS_BUZZER && DISABLED(LCD_USE_I2C_BUZZER)
+  #if HAS_BUZZER && PIN_EXISTS(BEEPER)
     buzzer.tick();
   #endif
 

--- a/Marlin/src/feature/leds/pca9632.cpp
+++ b/Marlin/src/feature/leds/pca9632.cpp
@@ -137,8 +137,9 @@ void pca9632_set_led_color(const LEDColor &color) {
 }
 
 #if ENABLED(PCA9632_BUZZER)
-  void pca9632_buzz(uint16_t const f, uint16_t d) {
-    UNUSED(f); UNUSED(d);
+  #include "../../lcd/ultralcd.h"
+  void MarlinUI::buzz(const long duration, const uint16_t freq) {
+    UNUSED(duration); UNUSED(freq);
     uint8_t data[] = PCA9632_BUZZER_DATA;
     Wire.beginTransmission(I2C_ADDRESS(PCA9632_ADDRESS));
     Wire.write(data, sizeof(data));

--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -1103,9 +1103,13 @@ void MarlinUI::draw_status_screen() {
       static uint8_t ledsprev = 0;
       uint8_t leds = 0;
 
-      if (thermalManager.degTargetBed() > 0) leds |= LED_A;
-
-      if (thermalManager.degTargetHotend(0) > 0) leds |= LED_B;
+	  #if HAS_HEATED_BED
+		if (thermalManager.degTargetBed() > 0) leds |= LED_A;
+	  #endif
+	  
+	  #if HOTENDS > 0
+		if (thermalManager.degTargetHotend(0) > 0) leds |= LED_B;
+	  #endif
 
       #if FAN_COUNT > 0
         if (0

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -102,6 +102,14 @@ void MarlinUI::set_font(const MarlinFont font_nr) {
   }
 }
 
+#if HAS_BUZZER && DISABLED(LCD_USE_I2C_BUZZER) && DISABLED(PCA9632_BUZZER)
+  void MarlinUI::buzz(const long duration, const uint16_t freq) {
+    buzzer.tone(duration, freq);
+  }
+#endif
+
+bool MarlinUI::detected() { return true; }
+
 #if ENABLED(SHOW_BOOTSCREEN)
 
   #if ENABLED(SHOW_CUSTOM_BOOTSCREEN)

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -568,7 +568,7 @@ void MarlinUI::status_screen() {
           const millis_t ms = millis();
         #endif
         if (ELAPSED(ms, next_beep)) {
-          BUZZ(FEEDRATE_CHANGE_BEEP_DURATION, FEEDRATE_CHANGE_BEEP_FREQUENCY);
+          buzz(FEEDRATE_CHANGE_BEEP_DURATION, FEEDRATE_CHANGE_BEEP_FREQUENCY);
           next_beep = ms + 500UL;
         }
       #endif
@@ -728,16 +728,6 @@ void MarlinUI::quick_feedback(const bool clear_buttons/*=true*/) {
  */
 
 LCDViewAction MarlinUI::lcdDrawUpdate = LCDVIEW_CLEAR_CALL_REDRAW;
-
-bool MarlinUI::detected() {
-  return
-    #if EITHER(LCD_I2C_TYPE_MCP23017, LCD_I2C_TYPE_MCP23008) && defined(DETECT_DEVICE)
-      lcd.LcdDetected() == 1
-    #else
-      true
-    #endif
-  ;
-}
 
 void MarlinUI::update() {
 
@@ -1263,23 +1253,6 @@ void MarlinUI::update() {
 
     #endif // HAS_ENCODER_WHEEL
   }
-
-  #if HAS_SLOW_BUTTONS
-
-    uint8_t MarlinUI::read_slow_buttons() {
-      #if ENABLED(LCD_I2C_TYPE_MCP23017)
-        // Reading these buttons this is likely to be too slow to call inside interrupt context
-        // so they are called during normal lcd_update
-        uint8_t slow_bits = lcd.readButtons() << B_I2C_BTN_OFFSET;
-        #if ENABLED(LCD_I2C_VIKI)
-          if ((slow_bits & (B_MI | B_RI)) && PENDING(millis(), next_button_update_ms)) // LCD clicked
-            slow_bits &= ~(B_MI | B_RI); // Disable LCD clicked buttons if screen is updated
-        #endif // LCD_I2C_VIKI
-        return slow_bits;
-      #endif // LCD_I2C_TYPE_MCP23017
-    }
-
-  #endif
 
 #endif // HAS_ENCODER_ACTION
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -259,15 +259,11 @@ public:
   }
 
   #if HAS_BUZZER
-    static inline void buzz(const long duration, const uint16_t freq) {
-      #if ENABLED(LCD_USE_I2C_BUZZER)
-        lcd.buzz(duration, freq);
-      #elif PIN_EXISTS(BEEPER)
-        buzzer.tone(duration, freq);
-      #elif ENABLED(PCA9632_BUZZER)
-        pca9632_buzz(duration, freq);
-      #endif
-    }
+    static void buzz(const long duration, const uint16_t freq);
+  #endif
+  
+  #if ENABLED(LCD_HAS_STATUS_INDICATORS)
+    static void update_indicators();
   #endif
 
   // LCD implementations
@@ -395,6 +391,7 @@ public:
     static inline void init() {}
     static inline void update() {}
     static inline void refresh() {}
+    static inline void return_to_status() {}
     static inline void set_alert_status_P(PGM_P message) { UNUSED(message); }
     static inline void set_status(const char* const message, const bool persist=false) { UNUSED(message); UNUSED(persist); }
     static inline void set_status_P(PGM_P const message, const int8_t level=0) { UNUSED(message); UNUSED(level); }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -162,7 +162,8 @@
   #if ENABLED(LCD_I2C_VIKI)
 
     #define B_I2C_BTN_OFFSET 3 // (the first three bit positions reserved for EN_A, EN_B, EN_C)
-
+    #include <Wire.h>
+    #include <LiquidTWI2.h>
     // button and encoder bit positions within 'buttons'
     #define B_LE (BUTTON_LEFT   << B_I2C_BTN_OFFSET)      // The remaining normalized buttons are all read via I2C
     #define B_UP (BUTTON_UP     << B_I2C_BTN_OFFSET)

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -34,6 +34,9 @@
 
 // I2C buttons must be read in the main thread
 #define HAS_SLOW_BUTTONS EITHER(LCD_I2C_VIKI, LCD_I2C_PANELOLU2)
+#ifdef HAS_SLOW_BUTTONS
+	extern millis_t next_button_update_ms;
+#endif
 
 #if HAS_SPI_LCD
 

--- a/Marlin/src/libs/buzzer.h
+++ b/Marlin/src/libs/buzzer.h
@@ -23,7 +23,7 @@
 
 #include "../inc/MarlinConfig.h"
 
-#if ENABLED(LCD_USE_I2C_BUZZER)
+#if ENABLED(LCD_USE_I2C_BUZZER) || ENABLED(PCA9632_BUZZER)
 
   #define BUZZ(d,f) ui.buzz(d,f)
 

--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -157,6 +157,8 @@ void PrintCounter::loadStats() {
     #endif
     #if HAS_BUZZER && SERVICE_WARNING_BUZZES > 0
       if (doBuzz) for (int i = 0; i < SERVICE_WARNING_BUZZES; i++) BUZZ(200, 404);
+    #else
+      UNUSED(doBuzz);
     #endif
   #endif // HAS_SERVICE_INTERVALS
 }

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -66,7 +66,7 @@
 //
 #ifndef SERVO0_PIN
   #ifdef IS_RAMPS_13
-    #define SERVO0_PIN      7   // RAMPS_13 // Will conflict with BTN_EN2 on LCD_I2C_VIKI
+    #define SERVO0_PIN      7   // RAMPS_13 
   #else
     #define SERVO0_PIN     11
   #endif
@@ -531,8 +531,8 @@
 
     #elif ENABLED(LCD_I2C_VIKI)
 
-      #define BTN_EN1           22   // http://files.panucatt.com/datasheets/viki_wiring_diagram.pdf explains 40/42.
-      #define BTN_EN2            7   // 22/7 are unused on RAMPS_14. 22 is unused and 7 the SERVO0_PIN on RAMPS_13.
+      #define BTN_EN1           40   // http://files.panucatt.com/datasheets/viki_wiring_diagram.pdf explains 40/42.
+      #define BTN_EN2           42   
       #define BTN_ENC           -1
 
       #define LCD_SDSS          SDSS


### PR DESCRIPTION
 ### Description

major changes from @Ludy87, https://github.com/Ludy87/Marlin/tree/bf2_buzzer2. 
Added conditionals led status when heat bed no enabled (throwed errors)
Changes pin definition for ramps when Viki I2C enabled (to match official wiring diagram)
Tested with ramps and Viki 1.0 hardware

### Benefits
solves compiling issues for Panelolu2 and viki 1 LCD I2C using Ramps board

### Related Issues
should fix #14812 (compiles, not tested working) and #15765 (tested working) 