### PR TITLE
Fix SoftwareSerial-based Drivers for SKR Pro

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -481,14 +481,15 @@ board         = BigTree_SKR_Pro
 extra_scripts = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 build_flags   = ${common.build_flags}
   -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407ZG\"
-  -DTARGET_STM32F4 -DSTM32F407_5ZX -DVECT_TAB_OFFSET=0x8000 -DHAVE_HWSERIAL6
+  -DTARGET_STM32F4 -DSTM32F407_5ZX -DVECT_TAB_OFFSET=0x8000 -DHAVE_HWSERIAL6 -DSS_TIMER=4
 lib_deps      =
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
   LiquidCrystal@1.3.4
-  TMCStepper@>=0.5.0,<1.0.0
+  TMCStepper@>=0.5.2,<1.0.0
   Adafruit NeoPixel
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip
+  SoftwareSerialM=https://github.com/sjasonsmith/SoftwareSerialM/archive/SKR_PRO.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
 


### PR DESCRIPTION
# Description

Add a SoftwareSerialM dependency that works with the SKR Pro.
This is currently my own fork of the FYSETC repo. It needed two small changes to fix issues impacting the Pro. Without those fixes it will look like connections are working, but drivers will be sporadically misconfigured.

I understand if using my personal fork isn't something you want to do, but I see it as a way to temporarily resolve the issues with this until issues involving STM32 5.7 are resolved. I am hoping they will actually merge my PR and it could be switched back to their master.

I have a pull request open to the FYSETC/SoftwareSerialM project with the needed fixes, but I don't know if or when it will be accepted.

### Benefits

TMC2208 and TMC2209 work on SKR Pro.

I have tried this with all 6 ports populated. The listing below has a TMC2209 on X and TMC2208 everywhere else:

```
M122
                X       Y       Z       E       E1      E2
Address         0
Enabled         true    true    true    false   false   false
Set current     800     800     800     800     800     800
RMS current     795     795     795     795     795     795
MAX current     1121    1121    1121    1121    1121    1121
Run current     25/31   25/31   25/31   25/31   25/31   25/31
Hold current    12/31   12/31   12/31   12/31   12/31   12/31
CS actual       12/31   12/31   12/31   12/31   12/31   12/31
PWM scale       38      23      44      14      14      14
vsense          1=.18   1=.18   1=.18   1=.18   1=.18   1=.18
stealthChop     true    true    true    true    true    true
msteps          16      16      16      16      16      16
tstep           max     max     max     max     max     max
pwm
threshold
[mm/s]
OT prewarn      false   false   false   false   false   false
off time        4       4       4       4       4       4
blank time      24      24      24      24      24      24
hysteresis
-end            2       2       2       2       2       2
-start          1       1       1       1       1       1
Stallguard thrs 0
DRVSTATUS       X       Y       Z       E       E1      E2
stst            *       *       *       *       *       *
olb
ola
s2gb
s2ga
otpw
ot
157C
150C
143C
120C
s2vsa
s2vsb
Driver registers:
                X       0xC0:0C:00:00
                Y       0xC0:0C:00:00
                Z       0xC0:0C:00:00
                E       0xC0:0C:00:00
                E1      0xC0:0C:00:00
                E2      0xC0:0C:00:00


Testing X connection... OK
Testing Y connection... OK
Testing Z connection... OK
Testing E connection... OK
Testing E1 connection... OK
Testing E2 connection... OK
ok
```

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/15680
https://github.com/MarlinFirmware/Marlin/issues/15538
