### PR TITLE
[1.1.x] MKS_GEN_L_V2 controller

### DIFF
--- a/Marlin/boards.h
+++ b/Marlin/boards.h
@@ -63,6 +63,7 @@
 #define BOARD_MKS_BASE_HEROIC   41    // MKS BASE 1.0 with Heroic HR4982 stepper drivers
 #define BOARD_MKS_GEN_13        47    // MKS GEN v1.3 or 1.4
 #define BOARD_MKS_GEN_L         53    // MKS GEN L
+#define BOARD_MKS_GEN_L_V2      54    // MKS GEN L V2
 #define BOARD_ZRIB_V20          504   // zrib V2.0 control board (Chinese knock off RAMPS replica)
 #define BOARD_FELIX2            37    // Felix 2.0+ Electronics Board (RAMPS like)
 #define BOARD_RIGIDBOARD        42    // Invent-A-Part RigidBoard

--- a/Marlin/pins.h
+++ b/Marlin/pins.h
@@ -140,6 +140,8 @@
   #include "pins_TRIGORILLA_14.h"     // ATmega2560                                 env:megaatmega2560
 #elif MB(RAMPS_ENDER_4)
   #include "pins_RAMPS_ENDER_4.h"     // ATmega2560                                 env:megaatmega2560
+#elif MB(MKS_GEN_L_V2)
+  #include "pins_MKS_GEN_L_V2.h"      // ATmega2560                                 env:megaatmega2560
 
 //
 // Other ATmega1280, ATmega2560

--- a/Marlin/pins_MKS_GEN_L_V2.h
+++ b/Marlin/pins_MKS_GEN_L_V2.h
@@ -1,0 +1,89 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * MKS GEN L V2 – Arduino Mega2560 with RAMPS v1.4 pin assignments
+ */
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "MKS GEN L V2 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+#endif
+
+#define BOARD_NAME "MKS GEN L V2"
+
+//
+// Heaters / Fans
+//
+// Power outputs EFBF or EFBE
+#define MOSFET_D_PIN 7
+
+//
+// CS Pins wired to avoid conflict with the LCD
+// See https://www.thingiverse.com/asset:66604
+//
+
+#ifndef X_CS_PIN
+  #define X_CS_PIN 63
+#endif
+
+#ifndef Y_CS_PIN
+  #define Y_CS_PIN 64
+#endif
+
+#ifndef Z_CS_PIN
+  #define Z_CS_PIN 65
+#endif
+
+#ifndef E0_CS_PIN
+  #define E0_CS_PIN 66
+#endif
+
+#ifndef E1_CS_PIN
+  #define E1_CS_PIN 21
+#endif
+
+// TMC2130 Diag Pins (currently just for reference)
+#define X_DIAG_PIN           3
+#define Y_DIAG_PIN          14
+#define Z_DIAG_PIN          18
+#define E0_DIAG_PIN          2
+#define E1_DIAG_PIN         15
+
+#ifndef SERVO1_PIN
+    #define SERVO1_PIN      12
+#endif
+#ifndef SERVO2_PIN
+    #define SERVO2_PIN      39
+#endif
+#ifndef SERVO3_PIN
+  #define SERVO3_PIN        32
+#endif
+
+#ifndef E1_SERIAL_TX_PIN
+  #define E1_SERIAL_TX_PIN   20
+#endif
+#ifndef E1_SERIAL_RX_PIN
+  #define E1_SERIAL_RX_PIN   21
+#endif
+ 
+
+#include "pins_RAMPS.h"

--- a/Marlin/pins_MKS_GEN_L_V2.h
+++ b/Marlin/pins_MKS_GEN_L_V2.h
@@ -31,59 +31,57 @@
 #define BOARD_NAME "MKS GEN L V2"
 
 //
+// Servos
+//
+#ifndef SERVO1_PIN
+  #define SERVO1_PIN       12
+#endif
+#ifndef SERVO2_PIN
+  #define SERVO2_PIN       39
+#endif
+#ifndef SERVO3_PIN
+  #define SERVO3_PIN       32
+#endif
+
+//
 // Heaters / Fans
 //
+
 // Power outputs EFBF or EFBE
-#define MOSFET_D_PIN 7
+#define MOSFET_D_PIN        7
 
 //
 // CS Pins wired to avoid conflict with the LCD
 // See https://www.thingiverse.com/asset:66604
 //
-
 #ifndef X_CS_PIN
   #define X_CS_PIN 63
 #endif
-
 #ifndef Y_CS_PIN
-  #define Y_CS_PIN 64
+  #define Y_CS_PIN         64
 #endif
-
 #ifndef Z_CS_PIN
-  #define Z_CS_PIN 65
+  #define Z_CS_PIN         65
 #endif
-
 #ifndef E0_CS_PIN
-  #define E0_CS_PIN 66
+  #define E0_CS_PIN        66
 #endif
-
 #ifndef E1_CS_PIN
-  #define E1_CS_PIN 21
+  #define E1_CS_PIN        21
 #endif
 
 // TMC2130 Diag Pins (currently just for reference)
-#define X_DIAG_PIN           3
-#define Y_DIAG_PIN          14
-#define Z_DIAG_PIN          18
-#define E0_DIAG_PIN          2
-#define E1_DIAG_PIN         15
-
-#ifndef SERVO1_PIN
-    #define SERVO1_PIN      12
-#endif
-#ifndef SERVO2_PIN
-    #define SERVO2_PIN      39
-#endif
-#ifndef SERVO3_PIN
-  #define SERVO3_PIN        32
-#endif
+#define X_DIAG_PIN          3
+#define Y_DIAG_PIN         14
+#define Z_DIAG_PIN         18
+#define E0_DIAG_PIN         2
+#define E1_DIAG_PIN        15
 
 #ifndef E1_SERIAL_TX_PIN
-  #define E1_SERIAL_TX_PIN   20
+  #define E1_SERIAL_TX_PIN 20
 #endif
 #ifndef E1_SERIAL_RX_PIN
-  #define E1_SERIAL_RX_PIN   21
+  #define E1_SERIAL_RX_PIN 21
 #endif
  
-
 #include "pins_RAMPS.h"

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -165,35 +165,75 @@
    * Software serial
    */
 
-  #define X_SERIAL_TX_PIN    40
-  #define X_SERIAL_RX_PIN    63
-  #define X2_SERIAL_TX_PIN   -1
-  #define X2_SERIAL_RX_PIN   -1
+  #ifndef X_SERIAL_TX_PIN
+    #define X_SERIAL_TX_PIN  40
+  #endif
+  #ifndef X_SERIAL_RX_PIN
+    #define X_SERIAL_RX_PIN  63
+  #endif
+  #ifndef X2_SERIAL_TX_PIN
+    #define X2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef X2_SERIAL_RX_PIN
+    #define X2_SERIAL_RX_PIN -1
+  #endif
 
-  #define Y_SERIAL_TX_PIN    59
-  #define Y_SERIAL_RX_PIN    64
-  #define Y2_SERIAL_TX_PIN   -1
-  #define Y2_SERIAL_RX_PIN   -1
+  #ifndef Y_SERIAL_TX_PIN
+    #define Y_SERIAL_TX_PIN  59
+  #endif
+  #ifndef Y_SERIAL_RX_PIN
+    #define Y_SERIAL_RX_PIN  64
+  #endif
+  #ifndef Y2_SERIAL_TX_PIN
+    #define Y2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef Y2_SERIAL_RX_PIN
+    #define Y2_SERIAL_RX_PIN -1
+  #endif
 
-  #define Z_SERIAL_TX_PIN    42
-  #define Z_SERIAL_RX_PIN    65
-  #define Z2_SERIAL_TX_PIN   -1
-  #define Z2_SERIAL_RX_PIN   -1
+  #ifndef Z_SERIAL_TX_PIN
+    #define Z_SERIAL_TX_PIN  42
+  #endif
+  #ifndef Z_SERIAL_RX_PIN
+    #define Z_SERIAL_RX_PIN  65
+  #endif
+  #ifndef Z2_SERIAL_TX_PIN
+    #define Z2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef Z2_SERIAL_RX_PIN
+    #define Z2_SERIAL_RX_PIN -1
+  #endif
 
-  #define E0_SERIAL_TX_PIN   44
-  #define E0_SERIAL_RX_PIN   66
+  #ifndef E0_SERIAL_TX_PIN
+    #define E0_SERIAL_TX_PIN 44
+  #endif
+  #ifndef E0_SERIAL_RX_PIN
+    #define E0_SERIAL_RX_PIN 66
+  #endif
   #ifndef E1_SERIAL_TX_PIN
     #define E1_SERIAL_TX_PIN -1
   #endif
   #ifndef E1_SERIAL_RX_PIN
     #define E1_SERIAL_RX_PIN -1
   #endif
-  #define E2_SERIAL_TX_PIN   -1
-  #define E2_SERIAL_RX_PIN   -1
-  #define E3_SERIAL_TX_PIN   -1
-  #define E3_SERIAL_RX_PIN   -1
-  #define E4_SERIAL_TX_PIN   -1
-  #define E4_SERIAL_RX_PIN   -1
+  #ifndef E2_SERIAL_TX_PIN
+    #define E2_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E2_SERIAL_RX_PIN
+    #define E2_SERIAL_RX_PIN -1
+  #endif
+  #ifndef E3_SERIAL_TX_PIN
+    #define E3_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E3_SERIAL_RX_PIN
+    #define E3_SERIAL_RX_PIN -1
+  #endif
+  #ifndef E4_SERIAL_TX_PIN
+    #define E4_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E4_SERIAL_RX_PIN
+    #define E4_SERIAL_RX_PIN -1
+  #endif
 #endif
 
 //

--- a/Marlin/pins_RAMPS.h
+++ b/Marlin/pins_RAMPS.h
@@ -60,8 +60,12 @@
 #else
   #define SERVO0_PIN       11
 #endif
-#define SERVO1_PIN          6
-#define SERVO2_PIN          5
+#ifndef SERVO1_PIN
+  #define SERVO1_PIN        6
+#endif
+#ifndef SERVO2_PIN
+  #define SERVO2_PIN        5
+#endif
 #ifndef SERVO3_PIN
   #define SERVO3_PIN        4
 #endif
@@ -178,8 +182,12 @@
 
   #define E0_SERIAL_TX_PIN   44
   #define E0_SERIAL_RX_PIN   66
-  #define E1_SERIAL_TX_PIN   -1
-  #define E1_SERIAL_RX_PIN   -1
+  #ifndef E1_SERIAL_TX_PIN
+    #define E1_SERIAL_TX_PIN -1
+  #endif
+  #ifndef E1_SERIAL_RX_PIN
+    #define E1_SERIAL_RX_PIN -1
+  #endif
   #define E2_SERIAL_TX_PIN   -1
   #define E2_SERIAL_RX_PIN   -1
   #define E3_SERIAL_TX_PIN   -1


### PR DESCRIPTION
### Description

Add a new controller the MKS_GEN_L_V2. Its basically a RAMPS with a few changes.
A few #ifndef blocks had to be added to the pins_RAMPS.h to enable pins_MKS_GEN_L_V2.h to override E1 TX and E1 Rx pins and to override SERVO1, SERVO2 and SERVO3 pins.

Details of this controller can be found here https://github.com/makerbase-mks/MKS-GEN_L/tree/master/hardware/MKS%20Gen_L%20V2.0_001 

### Benefits

Another controller board is supported 

### Related Issues

Feature request #15794