### PR TITLE
fix build error

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -97,13 +97,13 @@ static inline void _lcd_level_bed_corners_homing() {
         #endif
         ui.goto_previous_screen_no_defer();
       },
-      GET_TEXT((
+      GET_TEXT(
         #if ENABLED(LEVEL_CENTER_TOO)
           MSG_LEVEL_BED_NEXT_POINT
         #else
           MSG_NEXT_CORNER
         #endif
-      )), (PGM_P)nullptr, PSTR("?")
+      ), (PGM_P)nullptr, PSTR("?")
     );
     ui.set_selection(true);
     _lcd_goto_next_corner();


### PR DESCRIPTION
### Requirements

none

### Description

Someone pushed a wrong commit with a syntax error and the source isn't buildable anymore

### Benefits

everyone's happy

### Related Issues
```
In file included from Marlin\src\lcd\menu\../../inc/../core/language.h:376:0,
                 from Marlin\src\lcd\menu\../../inc/MarlinConfig.h:43,
                 from Marlin\src\lcd\menu\../ultralcd.h:24,
                 from Marlin\src\lcd\menu\menu.h:24,
                 from Marlin\src\lcd\menu\menu_bed_corners.cpp:31:
Marlin\src\lcd\menu\menu_bed_corners.cpp: In function 'void _lcd_level_bed_corners_homing()':
Marlin\src\lcd\menu\menu_bed_corners.cpp:100:16: error: expected unqualified-id before '(' token
       GET_TEXT((
                ^
Marlin\src\lcd\menu\../../inc/../core/multi_language.h:74:49: note: in definition of macro 'GET_TEXT'
   #define GET_TEXT(MSG) GET_LANG(LCD_LANGUAGE)::MSG
                                                 ^~~
Marlin\src\lcd\menu\menu_bed_corners.cpp:102:11: error: 'MSG_LEVEL_BED_NEXT_POINT' was not declared in this scope
           MSG_LEVEL_BED_NEXT_POINT
           ^
Marlin\src\lcd\menu\../../inc/../core/multi_language.h:74:49: note: in definition of macro 'GET_TEXT'
   #define GET_TEXT(MSG) GET_LANG(LCD_LANGUAGE)::MSG
                                                 ^~~
Marlin\src\lcd\menu\menu_bed_corners.cpp:102:11: note: suggested alternatives:
           MSG_LEVEL_BED_NEXT_POINT
           ^
Marlin\src\lcd\menu\../../inc/../core/multi_language.h:74:49: note: in definition of macro 'GET_TEXT'
   #define GET_TEXT(MSG) GET_LANG(LCD_LANGUAGE)::MSG
                                                 ^~~
In file included from Marlin\src\lcd\menu\../../inc/../core/language.h:378:0,
                 from Marlin\src\lcd\menu\../../inc/MarlinConfig.h:43,
                 from Marlin\src\lcd\menu\../ultralcd.h:24,
                 from Marlin\src\lcd\menu\menu.h:24,
                 from Marlin\src\lcd\menu\menu_bed_corners.cpp:31:
Marlin\src\lcd\menu\../../inc/../core/../lcd/language/language_en.h:76:24: note:   'Language_en::MSG_LEVEL_BED_NEXT_POINT'
   PROGMEM Language_Str MSG_LEVEL_BED_NEXT_POINT            = _UxGT("Next Point");
                        ^~~~~~~~~~~~~~~~~~~~~~~~
```