### PR TITLE
Update Display Throttling

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1033,7 +1033,8 @@ void MarlinUI::update() {
           // If still drawing and there's another page, update max-time and return now.
           // The nextPage will already be set up on the next call.
           if (drawing_screen && (drawing_screen = u8g.nextPage())) {
-            NOLESS(max_display_update_time, millis() - ms);
+            if (on_status_screen())
+              NOLESS(max_display_update_time, millis() - ms);
             return;
           }
         }
@@ -1050,7 +1051,8 @@ void MarlinUI::update() {
 
       // Keeping track of the longest time for an individual LCD update.
       // Used to do screen throttling when the planner starts to fill up.
-      NOLESS(max_display_update_time, millis() - ms);
+      if (on_status_screen())
+        NOLESS(max_display_update_time, millis() - ms);
     }
 
     #if HAS_LCD_MENU && LCD_TIMEOUT_TO_STATUS


### PR DESCRIPTION
Times for drawing different screens vary a lot (8-180 ms measured).
To get 180\*2 ms into the planner-buffer is rare.
For that measure only the duration of status-screen draws. Their drawing times appear about constant.

Follow up to #14960

Should improve: #12461, #15045, #15414, #15169, #15293