### PR TITLE
Fix E0_SERIAL_RX_PIN typo

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
@@ -152,7 +152,7 @@
   #ifndef E0_SERIAL_TX_PIN
     #define E0_SERIAL_TX_PIN P2_08
   #endif
-  #ifndef E0_SESIAL_RX_PIN
+  #ifndef E0_SERIAL_RX_PIN
     #define E0_SERIAL_RX_PIN P2_08
   #endif
 


### PR DESCRIPTION
Fixes a spelling mistake with E0_SERIAL

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

This fixes a spelling mistake to prevent `E0_SERIAL_RX_PIN` getting redefined in `pins_RAMPS_RE_ARM.h`

### Benefits

<!-- What does this fix or improve? -->

Fixes this exceptionally minor bug
