### PR TITLE
Update SKR mini E3 1.2 Filament Runout pin

### DIFF
--- a/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3_V1_2.h
+++ b/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3_V1_2.h
@@ -60,7 +60,7 @@
 // Filament Runout Sensor
 //
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN   PC15
+  #define FIL_RUNOUT_PIN   PC15   // "E0-STOP"
 #endif
 
 //

--- a/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3_V1_2.h
+++ b/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3_V1_2.h
@@ -60,7 +60,7 @@
 // Filament Runout Sensor
 //
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN   PC12
+  #define FIL_RUNOUT_PIN   PC15
 #endif
 
 //


### PR DESCRIPTION
### Description

Based on the manufacture documentation[1], the filament detector
should be connected to the PC15 pin (shown as E0-STOP on the image).

[1] https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/blob/master/hardware/BTT%20SKR%20MINI%20E3%20V1.2/BTT%20SKR%20MINI%20E3%20V1.2PIN.pdf

### Benefits

User will not have to redefine this pin themselves to use a filament detector.

### Related Issues

Not aware of.
