### PR TITLE
M851 bugfix 1.1.x

### DIFF
--- a/Marlin/Conditionals_post.h
+++ b/Marlin/Conditionals_post.h
@@ -1164,15 +1164,23 @@
 // These may be overridden in Configuration.h if a smaller area is desired
 #ifndef MIN_PROBE_X
   #define MIN_PROBE_X _MIN_PROBE_X
+#else
+  #define MIN_PROBE_X_FORCED
 #endif
 #ifndef MIN_PROBE_Y
   #define MIN_PROBE_Y _MIN_PROBE_Y
+#else
+  #define MIN_PROBE_Y_FORCED
 #endif
 #ifndef MAX_PROBE_X
   #define MAX_PROBE_X _MAX_PROBE_X
+#else
+  #define MAX_PROBE_X_FORCED
 #endif
 #ifndef MAX_PROBE_Y
   #define MAX_PROBE_Y _MAX_PROBE_Y
+#else
+  #define MAX_PROBE_Y_FORCED
 #endif
 
 /**

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -471,7 +471,7 @@ void report_current_position();
 #endif
 
 #if HAS_BED_PROBE
-  extern float zprobe_zoffset;
+  extern float probeOffsetFromExtruder[XYZ];
   bool set_probe_deployed(const bool deploy);
   #ifdef Z_AFTER_PROBING
     void move_z_after_probing();
@@ -609,7 +609,7 @@ void do_blocking_move_to_xy(const float &rx, const float &ry, const float &fr_mm
     // Return true if the both nozzle and the probe can reach the given point.
     // Note: This won't work on SCARA since the probe offset rotates with the arm.
     inline bool position_is_reachable_by_probe(const float &rx, const float &ry) {
-      return position_is_reachable(rx - (X_PROBE_OFFSET_FROM_EXTRUDER), ry - (Y_PROBE_OFFSET_FROM_EXTRUDER))
+      return position_is_reachable(rx - (probeOffsetFromExtruder[X_AXIS]), ry - (probeOffsetFromExtruder[Y_AXIS]))
              && position_is_reachable(rx, ry, ABS(MIN_PROBE_EDGE));
     }
   #endif
@@ -632,7 +632,7 @@ void do_blocking_move_to_xy(const float &rx, const float &ry, const float &fr_mm
      *          nozzle must be be able to reach +10,-10.
      */
     inline bool position_is_reachable_by_probe(const float &rx, const float &ry) {
-      return position_is_reachable(rx - (X_PROBE_OFFSET_FROM_EXTRUDER), ry - (Y_PROBE_OFFSET_FROM_EXTRUDER))
+      return position_is_reachable(rx - (probeOffsetFromExtruder[X_AXIS]), ry - (probeOffsetFromExtruder[Y_AXIS]))
           && WITHIN(rx, MIN_PROBE_X - 0.001f, MAX_PROBE_X + 0.001f)
           && WITHIN(ry, MIN_PROBE_Y - 0.001f, MAX_PROBE_Y + 0.001f);
     }

--- a/Marlin/Marlin.h
+++ b/Marlin/Marlin.h
@@ -471,6 +471,9 @@ void report_current_position();
 #endif
 
 #if HAS_BED_PROBE
+  extern float probeMin[2];
+  extern float probeMax[2];
+  void calcProbeMaxMin();
   extern float probeOffsetFromExtruder[XYZ];
   bool set_probe_deployed(const bool deploy);
   #ifdef Z_AFTER_PROBING
@@ -633,8 +636,8 @@ void do_blocking_move_to_xy(const float &rx, const float &ry, const float &fr_mm
      */
     inline bool position_is_reachable_by_probe(const float &rx, const float &ry) {
       return position_is_reachable(rx - (probeOffsetFromExtruder[X_AXIS]), ry - (probeOffsetFromExtruder[Y_AXIS]))
-          && WITHIN(rx, MIN_PROBE_X - 0.001f, MAX_PROBE_X + 0.001f)
-          && WITHIN(ry, MIN_PROBE_Y - 0.001f, MAX_PROBE_Y + 0.001f);
+          && WITHIN(rx, probeMin[X_AXIS] - 0.001f, probeMax[X_AXIS] + 0.001f)
+          && WITHIN(ry, probeMin[Y_AXIS] - 0.001f, probeMax[Y_AXIS] + 0.001f);
     }
   #endif
 

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -553,10 +553,6 @@ static millis_t stepper_inactive_time = (DEFAULT_STEPPER_DEACTIVE_TIME) * 1000UL
 
 uint8_t target_extruder;
 
-#if HAS_BED_PROBE
-  float zprobe_zoffset; // Initialized by settings.load()
-#endif
-
 #if HAS_ABL
   float xy_probe_feedrate_mm_s = MMM_TO_MMS(XY_PROBE_SPEED);
   #define XY_PROBE_FEEDRATE_MM_S xy_probe_feedrate_mm_s
@@ -745,6 +741,11 @@ XYZ_CONSTS_FROM_CONFIG(float, base_home_pos,  HOME_POS);
 XYZ_CONSTS_FROM_CONFIG(float, max_length,     MAX_LENGTH);
 XYZ_CONSTS_FROM_CONFIG(float, home_bump_mm,   HOME_BUMP_MM);
 XYZ_CONSTS_FROM_CONFIG(signed char, home_dir, HOME_DIR);
+
+#if HAS_BED_PROBE
+  // Adjustable with M851
+  float probeOffsetFromExtruder[XYZ] = { X_PROBE_OFFSET_FROM_EXTRUDER, Y_PROBE_OFFSET_FROM_EXTRUDER, Z_PROBE_OFFSET_FROM_EXTRUDER }; // Initialized by settings.load()
+#endif
 
 /**
  * ***************************************************************************
@@ -1379,7 +1380,7 @@ bool get_target_extruder_from_command(const uint16_t code) {
       soft_endstop_min[axis] = base_min_pos(axis);
       soft_endstop_max[axis] = axis == Z_AXIS ? delta_height
       #if HAS_BED_PROBE
-        - zprobe_zoffset
+        - probeOffsetFromExtruder[Z_AXIS];
       #endif
       : base_max_pos(axis);
     #else
@@ -1512,7 +1513,7 @@ static void set_axis_is_at_home(const AxisEnum axis) {
   #elif ENABLED(DELTA)
     current_position[axis] = (axis == Z_AXIS ? delta_height
     #if HAS_BED_PROBE
-      - zprobe_zoffset
+      - probeOffsetFromExtruder[Z_AXIS]
     #endif
     : base_home_pos(axis));
   #else
@@ -1526,12 +1527,12 @@ static void set_axis_is_at_home(const AxisEnum axis) {
     if (axis == Z_AXIS) {
       #if HOMING_Z_WITH_PROBE
 
-        current_position[Z_AXIS] -= zprobe_zoffset;
+        current_position[Z_AXIS] -= probeOffsetFromExtruder[Z_AXIS];
 
         #if ENABLED(DEBUG_LEVELING_FEATURE)
           if (DEBUGGING(LEVELING)) {
             SERIAL_ECHOLNPGM("*** Z HOMED WITH PROBE (Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN) ***");
-            SERIAL_ECHOLNPAIR("> zprobe_zoffset = ", zprobe_zoffset);
+            SERIAL_ECHOLNPAIR("> zprobe_zoffset = ", probeOffsetFromExtruder[Z_AXIS]);
           }
         #endif
 
@@ -2320,7 +2321,7 @@ void clean_up_after_endstop_or_probe_move() {
     #endif
 
     float z_dest = z_raise;
-    if (zprobe_zoffset < 0) z_dest -= zprobe_zoffset;
+    if (probeOffsetFromExtruder[Z_AXIS] < 0) z_dest -= probeOffsetFromExtruder[Z_AXIS];
 
     NOMORE(z_dest, Z_MAX_POS);
 
@@ -2510,7 +2511,7 @@ void clean_up_after_endstop_or_probe_move() {
 
     // Stop the probe before it goes too low to prevent damage.
     // If Z isn't known then probe to -10mm.
-    const float z_probe_low_point = TEST(axis_known_position, Z_AXIS) ? -zprobe_zoffset + Z_PROBE_LOW_POINT : -10.0;
+    const float z_probe_low_point = TEST(axis_known_position, Z_AXIS) ? -probeOffsetFromExtruder[Z_AXIS] + Z_PROBE_LOW_POINT : -10.0;
 
     // Double-probing does a fast probe followed by a slow probe
     #if MULTIPLE_PROBING == 2
@@ -2540,7 +2541,7 @@ void clean_up_after_endstop_or_probe_move() {
       // If the nozzle is well over the travel height then
       // move down quickly before doing the slow probe
       float z = Z_CLEARANCE_DEPLOY_PROBE + 5.0;
-      if (zprobe_zoffset < 0) z -= zprobe_zoffset;
+      if (probeOffsetFromExtruder[Z_AXIS] < 0) z -= probeOffsetFromExtruder[Z_AXIS];
 
       if (current_position[Z_AXIS] > z) {
         // If we don't make it to the z position (i.e. the probe triggered), move up to make clearance for the probe
@@ -2630,8 +2631,8 @@ void clean_up_after_endstop_or_probe_move() {
     float nx = rx, ny = ry;
     if (probe_relative) {
       if (!position_is_reachable_by_probe(rx, ry)) return NAN;  // The given position is in terms of the probe
-      nx -= (X_PROBE_OFFSET_FROM_EXTRUDER);                     // Get the nozzle position
-      ny -= (Y_PROBE_OFFSET_FROM_EXTRUDER);
+      nx -= (probeOffsetFromExtruder[X_AXIS]);                     // Get the nozzle position
+      ny -= (probeOffsetFromExtruder[Y_AXIS]);
     }
     else if (!position_is_reachable(nx, ny)) return NAN;        // The given position is in terms of the nozzle
 
@@ -2652,7 +2653,7 @@ void clean_up_after_endstop_or_probe_move() {
 
     float measured_z = NAN;
     if (!DEPLOY_PROBE()) {
-      measured_z = run_z_probe() + zprobe_zoffset;
+      measured_z = run_z_probe() + probeOffsetFromExtruder[Z_AXIS];
 
       const bool big_raise = raise_after == PROBE_PT_BIG_RAISE;
       if (big_raise || raise_after == PROBE_PT_RAISE)
@@ -4111,9 +4112,9 @@ inline void gcode_G4() {
     #endif
 
     #if HAS_BED_PROBE
-      SERIAL_ECHOPAIR("Probe Offset X:", X_PROBE_OFFSET_FROM_EXTRUDER);
-      SERIAL_ECHOPAIR(" Y:", Y_PROBE_OFFSET_FROM_EXTRUDER);
-      SERIAL_ECHOPAIR(" Z:", zprobe_zoffset);
+      SERIAL_ECHOPAIR("Probe Offset X:", probeOffsetFromExtruder[X_AXIS]);
+      SERIAL_ECHOPAIR(" Y:", probeOffsetFromExtruder[Y_AXIS]);
+      SERIAL_ECHOPAIR(" Z:", probeOffsetFromExtruder[Z_AXIS]);
       #if X_PROBE_OFFSET_FROM_EXTRUDER > 0
         SERIAL_ECHOPGM(" (Right");
       #elif X_PROBE_OFFSET_FROM_EXTRUDER < 0
@@ -4138,9 +4139,9 @@ inline void gcode_G4() {
       #elif X_PROBE_OFFSET_FROM_EXTRUDER != 0
         SERIAL_ECHOPGM("-Center");
       #endif
-      if (zprobe_zoffset < 0)
+      if (probeOffsetFromExtruder[Z_AXIS] < 0)
         SERIAL_ECHOPGM(" & Below");
-      else if (zprobe_zoffset > 0)
+      else if (probeOffsetFromExtruder[Z_AXIS] > 0)
         SERIAL_ECHOPGM(" & Above");
       else
         SERIAL_ECHOPGM(" & Same Z as");
@@ -4264,7 +4265,7 @@ inline void gcode_G4() {
     // Move all carriages together linearly until an endstop is hit.
     current_position[X_AXIS] = current_position[Y_AXIS] = current_position[Z_AXIS] = (delta_height + 10
       #if HAS_BED_PROBE
-        - zprobe_zoffset
+        - probeOffsetFromExtruder[Z_AXIS]
       #endif
     );
     feedrate_mm_s = homing_feedrate(X_AXIS);
@@ -4342,8 +4343,8 @@ inline void gcode_G4() {
     destination[Z_AXIS] = current_position[Z_AXIS]; // Z is already at the right height
 
     #if HOMING_Z_WITH_PROBE
-      destination[X_AXIS] -= X_PROBE_OFFSET_FROM_EXTRUDER;
-      destination[Y_AXIS] -= Y_PROBE_OFFSET_FROM_EXTRUDER;
+      destination[X_AXIS] -= probeOffsetFromExtruder[X_AXIS];
+      destination[Y_AXIS] -= probeOffsetFromExtruder[Y_AXIS];
     #endif
 
     if (position_is_reachable(destination[X_AXIS], destination[Y_AXIS])) {
@@ -5724,8 +5725,8 @@ void home_all_axes() { gcode_G28(true); }
           planner.leveling_active = false;
 
           // Use the last measured distance to the bed, if possible
-          if ( NEAR(current_position[X_AXIS], xProbe - (X_PROBE_OFFSET_FROM_EXTRUDER))
-            && NEAR(current_position[Y_AXIS], yProbe - (Y_PROBE_OFFSET_FROM_EXTRUDER))
+          if ( NEAR(current_position[X_AXIS], xProbe - (probeOffsetFromExtruder[X_AXIS]))
+            && NEAR(current_position[Y_AXIS], yProbe - (probeOffsetFromExtruder[Y_AXIS]))
           ) {
             const float simple_z = current_position[Z_AXIS] - measured_z;
             #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -5809,8 +5810,8 @@ void home_all_axes() { gcode_G28(true); }
    *   E   Engage the probe for each probe (default 1)
    */
   inline void gcode_G30() {
-    const float xpos = parser.linearval('X', current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER),
-                ypos = parser.linearval('Y', current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER);
+    const float xpos = parser.linearval('X', current_position[X_AXIS] + probeOffsetFromExtruder[X_AXIS]),
+                ypos = parser.linearval('Y', current_position[Y_AXIS] + probeOffsetFromExtruder[Y_AXIS]);
 
     if (!position_is_reachable_by_probe(xpos, ypos)) return;
 
@@ -6618,8 +6619,8 @@ void home_all_axes() { gcode_G28(true); }
       if (hasI) destination[X_AXIS] = _GET_MESH_X(ix);
       if (hasJ) destination[Y_AXIS] = _GET_MESH_Y(iy);
       if (parser.boolval('P')) {
-        if (hasI) destination[X_AXIS] -= X_PROBE_OFFSET_FROM_EXTRUDER;
-        if (hasJ) destination[Y_AXIS] -= Y_PROBE_OFFSET_FROM_EXTRUDER;
+        if (hasI) destination[X_AXIS] -= probeOffsetFromExtruder[X_AXIS];
+        if (hasJ) destination[Y_AXIS] -= probeOffsetFromExtruder[Y_AXIS];
       }
 
       const float fval = parser.linearval('F');
@@ -8157,8 +8158,8 @@ inline void gcode_M42() {
     float X_current = current_position[X_AXIS],
           Y_current = current_position[Y_AXIS];
 
-    const float X_probe_location = parser.linearval('X', X_current + X_PROBE_OFFSET_FROM_EXTRUDER),
-                Y_probe_location = parser.linearval('Y', Y_current + Y_PROBE_OFFSET_FROM_EXTRUDER);
+    const float X_probe_location = parser.linearval('X', X_current + probeOffsetFromExtruder[X_AXIS]),
+                Y_probe_location = parser.linearval('Y', Y_current + probeOffsetFromExtruder[Y_AXIS]);
 
     if (!position_is_reachable_by_probe(X_probe_location, Y_probe_location)) {
       SERIAL_PROTOCOLLNPGM("? (X,Y) out of bounds.");
@@ -8243,8 +8244,8 @@ inline void gcode_M42() {
             while (angle < 0.0)     // outside of this range.   It looks like they behave correctly with
               angle += 360.0;       // numbers outside of the range, but just to be safe we clamp them.
 
-            X_current = X_probe_location - (X_PROBE_OFFSET_FROM_EXTRUDER) + cos(RADIANS(angle)) * radius;
-            Y_current = Y_probe_location - (Y_PROBE_OFFSET_FROM_EXTRUDER) + sin(RADIANS(angle)) * radius;
+            X_current = X_probe_location - (probeOffsetFromExtruder[X_AXIS]) + cos(RADIANS(angle)) * radius;
+            Y_current = Y_probe_location - (probeOffsetFromExtruder[Y_AXIS]) + sin(RADIANS(angle)) * radius;
 
             #if DISABLED(DELTA)
               X_current = constrain(X_current, X_MIN_POS, X_MAX_POS);
@@ -10188,9 +10189,9 @@ inline void gcode_M226() {
 
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
     FORCE_INLINE void mod_zprobe_zoffset(const float &offs) {
-      zprobe_zoffset += offs;
+      probeOffsetFromExtruder[Z_AXIS] += offs;
       SERIAL_ECHO_START();
-      SERIAL_ECHOLNPAIR(MSG_PROBE_Z_OFFSET ": ", zprobe_zoffset);
+      SERIAL_ECHOLNPAIR(MSG_PROBE_Z_OFFSET ": ", probeOffsetFromExtruder[Z_AXIS]);
     }
   #endif
 
@@ -11032,16 +11033,28 @@ inline void gcode_M502() {
     if (parser.seenval('Z')) {
       const float value = parser.value_linear_units();
       if (WITHIN(value, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX))
-        zprobe_zoffset = value;
+        probeOffsetFromExtruder[Z_AXIS] = value;
       else {
         SERIAL_ERROR_START();
         SERIAL_ERRORLNPGM("?Z out of range (" STRINGIFY(Z_PROBE_OFFSET_RANGE_MIN) " to " STRINGIFY(Z_PROBE_OFFSET_RANGE_MAX) ")");
       }
       return;
     }
+    if (parser.seenval('X')) {
+      const float value = parser.value_linear_units();
+      probeOffsetFromExtruder[X_AXIS] = value;
+      return;
+    }
+    if (parser.seenval('Y')) {
+      const float value = parser.value_linear_units();
+      probeOffsetFromExtruder[Y_AXIS] = value;
+      return;
+    }
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM(MSG_PROBE_Z_OFFSET);
-    SERIAL_ECHOLNPAIR(": ", zprobe_zoffset);
+    SERIAL_ECHOLNPAIR(": ", probeOffsetFromExtruder[Z_AXIS]);
+    SERIAL_ECHOLNPAIR("X: ", probeOffsetFromExtruder[X_AXIS]);
+    SERIAL_ECHOLNPAIR("Y: ", probeOffsetFromExtruder[Y_AXIS]);
   }
 
 #endif // HAS_BED_PROBE

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -745,6 +745,8 @@ XYZ_CONSTS_FROM_CONFIG(signed char, home_dir, HOME_DIR);
 #if HAS_BED_PROBE
   // Adjustable with M851
   float probeOffsetFromExtruder[XYZ] = { X_PROBE_OFFSET_FROM_EXTRUDER, Y_PROBE_OFFSET_FROM_EXTRUDER, Z_PROBE_OFFSET_FROM_EXTRUDER }; // Initialized by settings.load()
+  float probeMin[2] = { MIN_PROBE_X, MIN_PROBE_Y }; // Initialized by settings.load()
+  float probeMax[2] = { MAX_PROBE_X, MAX_PROBE_Y }; // Initialized by settings.load()
 #endif
 
 /**
@@ -752,6 +754,33 @@ XYZ_CONSTS_FROM_CONFIG(signed char, home_dir, HOME_DIR);
  * ******************************** FUNCTIONS ********************************
  * ***************************************************************************
  */
+
+void calcProbeMaxMin() {
+  #ifdef MIN_PROBE_X_FORCED
+      probeMin[X_AXIS] = MIN_PROBE_X;
+  #else
+      probeMin[X_AXIS] = (max(X_MIN_BED + MIN_PROBE_EDGE, X_MIN_POS + probeOffsetFromExtruder[X_AXIS]));
+  #endif
+
+  #ifdef MIN_PROBE_Y_FORCED
+    probeMin[Y_AXIS] = MIN_PROBE_Y;
+  #else
+    probeMin[Y_AXIS] = (max(Y_MIN_BED + MIN_PROBE_EDGE, Y_MIN_POS + probeOffsetFromExtruder[Y_AXIS])); 
+  #endif
+
+  #ifdef MAX_PROBE_X_FORCED
+    probeMax[X_AXIS] = MAX_PROBE_X;
+  #else
+    probeMax[X_AXIS] = (min(X_MAX_BED - (MIN_PROBE_EDGE), X_MAX_POS + probeOffsetFromExtruder[X_AXIS]));
+  #endif
+
+  #ifdef MAX_PROBE_Y_FORCED
+    probeMax[Y_AXIS] = MAX_PROBE_Y;
+  #else
+    probeMax[Y_AXIS] = (min(Y_MAX_BED - (MIN_PROBE_EDGE), Y_MAX_POS + probeOffsetFromExtruder[Y_AXIS]));
+  #endif
+}
+
 
 void stop();
 
@@ -11038,17 +11067,14 @@ inline void gcode_M502() {
         SERIAL_ERROR_START();
         SERIAL_ERRORLNPGM("?Z out of range (" STRINGIFY(Z_PROBE_OFFSET_RANGE_MIN) " to " STRINGIFY(Z_PROBE_OFFSET_RANGE_MAX) ")");
       }
-      return;
     }
     if (parser.seenval('X')) {
       const float value = parser.value_linear_units();
       probeOffsetFromExtruder[X_AXIS] = value;
-      return;
     }
     if (parser.seenval('Y')) {
       const float value = parser.value_linear_units();
       probeOffsetFromExtruder[Y_AXIS] = value;
-      return;
     }
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM(MSG_PROBE_Z_OFFSET);

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -138,7 +138,7 @@ typedef struct SettingsDataStruct {
   //
   // HAS_BED_PROBE
   //
-  float zprobe_zoffset;                                 // M851 Z
+  float probeOffsetFromExtruder[XYZ];                                 // M851 Z
 
   //
   // ABL_PLANAR
@@ -524,12 +524,12 @@ void MarlinSettings::postprocess() {
       for (uint8_t q = mesh_num_x * mesh_num_y; q--;) EEPROM_WRITE(dummy);
     #endif // MESH_BED_LEVELING
 
-    _FIELD_TEST(zprobe_zoffset);
+    _FIELD_TEST(probeOffsetFromExtruder);
 
     #if !HAS_BED_PROBE
-      const float zprobe_zoffset = 0;
+      const float probeOffsetFromExtruder[XYZ] = {0, 0, 0};
     #endif
-    EEPROM_WRITE(zprobe_zoffset);
+    EEPROM_WRITE(probeOffsetFromExtruder);
 
     //
     // Planar Bed Leveling matrix
@@ -1158,12 +1158,12 @@ void MarlinSettings::postprocess() {
         for (uint16_t q = mesh_num_x * mesh_num_y; q--;) EEPROM_READ(dummy);
       #endif // MESH_BED_LEVELING
 
-      _FIELD_TEST(zprobe_zoffset);
+      _FIELD_TEST(probeOffsetFromExtruder);
 
       #if !HAS_BED_PROBE
-        float zprobe_zoffset;
+        float probeOffsetFromExtruder[XYZ];
       #endif
-      EEPROM_READ(zprobe_zoffset);
+      EEPROM_READ(probeOffsetFromExtruder);
 
       //
       // Planar Bed Leveling matrix
@@ -1870,7 +1870,9 @@ void MarlinSettings::reset() {
   #endif
 
   #if HAS_BED_PROBE
-    zprobe_zoffset = Z_PROBE_OFFSET_FROM_EXTRUDER;
+    probeOffsetFromExtruder[X_AXIS] = float(X_PROBE_OFFSET_FROM_EXTRUDER);
+    probeOffsetFromExtruder[Y_AXIS] = float(Y_PROBE_OFFSET_FROM_EXTRUDER);
+    probeOffsetFromExtruder[Z_AXIS] = float(Z_PROBE_OFFSET_FROM_EXTRUDER);
   #endif
 
   #if ENABLED(DELTA)
@@ -2554,11 +2556,13 @@ void MarlinSettings::reset() {
     #if HAS_BED_PROBE
       if (!forReplay) {
         CONFIG_ECHO_START;
-        SERIAL_ECHOPGM("Z-Probe Offset");
+        SERIAL_ECHOPGM("Probe Offset");
         say_units(true);
       }
       CONFIG_ECHO_START;
-      SERIAL_ECHOLNPAIR("  M851 Z", LINEAR_UNIT(zprobe_zoffset));
+      SERIAL_ECHOLNPAIR("  M851 X", LINEAR_UNIT(probeOffsetFromExtruder[X_AXIS]));
+      SERIAL_ECHOLNPAIR("  M851 Y", LINEAR_UNIT(probeOffsetFromExtruder[Y_AXIS]));
+      SERIAL_ECHOLNPAIR("  M851 Z", LINEAR_UNIT(probeOffsetFromExtruder[Z_AXIS]));
     #endif
 
     /**

--- a/Marlin/configuration_store.cpp
+++ b/Marlin/configuration_store.cpp
@@ -138,7 +138,7 @@ typedef struct SettingsDataStruct {
   //
   // HAS_BED_PROBE
   //
-  float probeOffsetFromExtruder[XYZ];                                 // M851 Z
+  float probeOffsetFromExtruder[XYZ];                                 // M851
 
   //
   // ABL_PLANAR
@@ -1164,7 +1164,8 @@ void MarlinSettings::postprocess() {
         float probeOffsetFromExtruder[XYZ];
       #endif
       EEPROM_READ(probeOffsetFromExtruder);
-
+      calcProbeMaxMin();
+      
       //
       // Planar Bed Leveling matrix
       //
@@ -1873,6 +1874,7 @@ void MarlinSettings::reset() {
     probeOffsetFromExtruder[X_AXIS] = float(X_PROBE_OFFSET_FROM_EXTRUDER);
     probeOffsetFromExtruder[Y_AXIS] = float(Y_PROBE_OFFSET_FROM_EXTRUDER);
     probeOffsetFromExtruder[Z_AXIS] = float(Z_PROBE_OFFSET_FROM_EXTRUDER);
+    calcProbeMaxMin();
   #endif
 
   #if ENABLED(DELTA)

--- a/Marlin/ubl.cpp
+++ b/Marlin/ubl.cpp
@@ -213,8 +213,8 @@
     // Add XY_PROBE_OFFSET_FROM_EXTRUDER because probe_pt() subtracts these when
     // moving to the xy position to be measured. This ensures better agreement between
     // the current Z position after G28 and the mesh values.
-    const float current_xi = find_closest_x_index(current_position[X_AXIS] + X_PROBE_OFFSET_FROM_EXTRUDER),
-                current_yi = find_closest_y_index(current_position[Y_AXIS] + Y_PROBE_OFFSET_FROM_EXTRUDER);
+    const float current_xi = find_closest_x_index(current_position[X_AXIS] + probeOffsetFromExtruder[X_AXIS]),
+                current_yi = find_closest_y_index(current_position[Y_AXIS] + probeOffsetFromExtruder[Y_AXIS]);
 
     if (!lcd) SERIAL_EOL();
     for (int8_t j = GRID_MAX_POINTS_Y - 1; j >= 0; j--) {

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -275,7 +275,7 @@
    *   especially better for Delta printers, since it populates the center of the mesh first, allowing for
    *   a quicker test print to verify settings. You don't need to populate the entire mesh to use it.
    *   After all, you don't want to spend a lot of time generating a mesh only to realize the resolution
-   *   or zprobe_zoffset are incorrect. Mesh-generation gathers points starting closest to the nozzle unless
+   *   or probeOffsetFromExtruder[Z_AXIS] are incorrect. Mesh-generation gathers points starting closest to the nozzle unless
    *   an (X,Y) coordinate pair is given.
    *
    *   Unified Bed Leveling uses a lot of EEPROM storage to hold its data, and it takes some effort to get
@@ -415,7 +415,7 @@
               SERIAL_PROTOCOL(g29_y_pos);
               SERIAL_PROTOCOLLNPGM(").\n");
             }
-            probe_entire_mesh(g29_x_pos + X_PROBE_OFFSET_FROM_EXTRUDER, g29_y_pos + Y_PROBE_OFFSET_FROM_EXTRUDER,
+            probe_entire_mesh(g29_x_pos + probeOffsetFromExtruder[X_AXIS], g29_y_pos + probeOffsetFromExtruder[Y_AXIS],
                               parser.seen('T'), parser.seen('E'), parser.seen('U'));
 
             report_current_position();
@@ -443,8 +443,8 @@
                 g29_x_pos = X_HOME_POS;
                 g29_y_pos = Y_HOME_POS;
               #else // cartesian
-                g29_x_pos = X_PROBE_OFFSET_FROM_EXTRUDER > 0 ? X_BED_SIZE : 0;
-                g29_y_pos = Y_PROBE_OFFSET_FROM_EXTRUDER < 0 ? Y_BED_SIZE : 0;
+                g29_x_pos = probeOffsetFromExtruder[X_AXIS] > 0 ? X_BED_SIZE : 0;
+                g29_y_pos = probeOffsetFromExtruder[Y_AXIS] < 0 ? Y_BED_SIZE : 0;
               #endif
             }
 
@@ -759,8 +759,8 @@
       restore_ubl_active_state_and_leave();
 
       do_blocking_move_to_xy(
-        constrain(rx - (X_PROBE_OFFSET_FROM_EXTRUDER), MESH_MIN_X, MESH_MAX_X),
-        constrain(ry - (Y_PROBE_OFFSET_FROM_EXTRUDER), MESH_MIN_Y, MESH_MAX_Y)
+        constrain(rx - (probeOffsetFromExtruder[X_AXIS]), MESH_MIN_X, MESH_MAX_X),
+        constrain(ry - (probeOffsetFromExtruder[Y_AXIS]), MESH_MIN_Y, MESH_MAX_Y)
       );
     }
 
@@ -1081,7 +1081,7 @@
 
     #if HAS_BED_PROBE
       SERIAL_PROTOCOLPGM("zprobe_zoffset: ");
-      SERIAL_PROTOCOL_F(zprobe_zoffset, 7);
+      SERIAL_PROTOCOL_F(probeOffsetFromExtruder[Z_AXIS], 7);
       SERIAL_EOL();
     #endif
 
@@ -1287,8 +1287,8 @@
     out_mesh.distance = -99999.9f;
 
     // Get our reference position. Either the nozzle or probe location.
-    const float px = rx + (probe_as_reference == USE_PROBE_AS_REFERENCE ? X_PROBE_OFFSET_FROM_EXTRUDER : 0),
-                py = ry + (probe_as_reference == USE_PROBE_AS_REFERENCE ? Y_PROBE_OFFSET_FROM_EXTRUDER : 0);
+    const float px = rx + (probe_as_reference == USE_PROBE_AS_REFERENCE ? probeOffsetFromExtruder[X_AXIS] : 0),
+                py = ry + (probe_as_reference == USE_PROBE_AS_REFERENCE ? probeOffsetFromExtruder[Y_AXIS] : 0);
 
     float best_so_far = 99999.99f;
 
@@ -1601,7 +1601,7 @@
                 }
               #endif
 
-              measured_z -= get_z_correction(rx, ry) /* + zprobe_zoffset */ ;
+              measured_z -= get_z_correction(rx, ry) /* + probeOffsetFromExtruder[Z_AXIS] */ ;
 
               #if ENABLED(DEBUG_LEVELING_FEATURE)
                 if (DEBUGGING(LEVELING)) {

--- a/Marlin/ubl_G29.cpp
+++ b/Marlin/ubl_G29.cpp
@@ -1498,10 +1498,10 @@
     #include "vector_3.h"
 
     void unified_bed_leveling::tilt_mesh_based_on_probed_grid(const bool do_3_pt_leveling) {
-      constexpr int16_t x_min = MAX(MIN_PROBE_X, MESH_MIN_X),
-                        x_max = MIN(MAX_PROBE_X, MESH_MAX_X),
-                        y_min = MAX(MIN_PROBE_Y, MESH_MIN_Y),
-                        y_max = MIN(MAX_PROBE_Y, MESH_MAX_Y);
+      constexpr int16_t x_min = MAX(probeMin[X_AXIS], MESH_MIN_X),
+                        x_max = MIN(probeMax[X_AXIS], MESH_MAX_X),
+                        y_min = MAX(probeMin[Y_AXIS], MESH_MIN_Y),
+                        y_max = MIN(probeMax[Y_AXIS], MESH_MAX_Y);
 
       bool abort_flag = false;
 

--- a/Marlin/ultralcd.cpp
+++ b/Marlin/ultralcd.cpp
@@ -1268,17 +1268,17 @@ void lcd_quick_feedback(const bool clear_buttons) {
           const int16_t babystep_increment = (int32_t)encoderPosition * (BABYSTEP_MULTIPLICATOR);
           encoderPosition = 0;
 
-          const float new_zoffset = zprobe_zoffset + planner.steps_to_mm[Z_AXIS] * babystep_increment;
+          const float new_zoffset = probeOffsetFromExtruder[Z_AXIS] + planner.steps_to_mm[Z_AXIS] * babystep_increment;
           if (WITHIN(new_zoffset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX)) {
             thermalManager.babystep_axis(Z_AXIS, babystep_increment);
-            zprobe_zoffset = new_zoffset;
+            probeOffsetFromExtruder[Z_AXIS] = new_zoffset;
             lcdDrawUpdate = LCDVIEW_CALL_REDRAW_NEXT;
           }
         }
         if (lcdDrawUpdate) {
-          lcd_implementation_drawedit(PSTR(MSG_ZPROBE_ZOFFSET), ftostr43sign(zprobe_zoffset));
+          lcd_implementation_drawedit(PSTR(MSG_ZPROBE_ZOFFSET), ftostr43sign(probeOffsetFromExtruder[Z_AXIS]));
           #if ENABLED(BABYSTEP_ZPROBE_GFX_OVERLAY)
-            _lcd_zoffset_overlay_gfx(zprobe_zoffset);
+            _lcd_zoffset_overlay_gfx(probeOffsetFromExtruder[Z_AXIS]);
           #endif
         }
       }
@@ -2661,7 +2661,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
       #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
         MENU_ITEM(submenu, MSG_ZPROBE_ZOFFSET, lcd_babystep_zoffset);
       #elif HAS_BED_PROBE
-        MENU_ITEM_EDIT(float52, MSG_ZPROBE_ZOFFSET, &zprobe_zoffset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
+        MENU_ITEM_EDIT(float52, MSG_ZPROBE_ZOFFSET, &probeOffsetFromExtruder[Z_AXIS], Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
       #endif
 
       #if ENABLED(LEVEL_BED_CORNERS)
@@ -3849,7 +3849,7 @@ void lcd_quick_feedback(const bool clear_buttons) {
     #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
       MENU_ITEM(submenu, MSG_ZPROBE_ZOFFSET, lcd_babystep_zoffset);
     #elif HAS_BED_PROBE
-      MENU_ITEM_EDIT(float52, MSG_ZPROBE_ZOFFSET, &zprobe_zoffset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
+      MENU_ITEM_EDIT(float52, MSG_ZPROBE_ZOFFSET, &probeOffsetFromExtruder[Z_AXIS], Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
     #endif
 
     #if DISABLED(SLIM_LCD_MENUS)


### PR DESCRIPTION
### Description

This branch allow you to use the gcode M851 to adjust X and Y probe offsets as well as Z. It seems it's already implemented in its own way in v2.0 beta but I need v1.

### Benefits

By adjusting the X and Y probe offsets with M851 you can change the probe or it's position without flashing. I personally need it because I attached a drill to my 3D printer to mill PCBs and I need to change from using the capacitive probe to using the drill bit as probe when I need to level the copper PCB before milling it.

### Tested... Tested?

I tested it only on my cartesian 3D printer and with bilinear leveling but I changed from constants to variables almost everywhere. I think it should work on any kind of machine.
I didn't change sanity checks, that are run with the default static values. I think it's ok that default values are checked statically but you can change them later.

### Other comments

Probing limits are updated too unless they are enforced with MAX_PROBE_* MIN_PROBE_* static configuration.

I know you don't accept any new features on v1 but I did it for myself and I want to try to share it. Why not.

