### PR TITLE
STM32 PIO: Override default LD Script using LINKFLAGS build scope

### DIFF
--- a/buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
@@ -1,3 +1,4 @@
+import os
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08007000
@@ -5,4 +6,10 @@ for define in env['CPPDEFINES']:
     if define[0] == "VECT_TAB_ADDR":
         env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/STM32F103RC_SKR_MINI.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/STM32F103RC_SKR_MINI.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script

--- a/buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
@@ -5,7 +5,6 @@ Import("env", "projenv")
 # Relocate firmware from 0x08000000 to 0x08002000
 #env['CPPDEFINES'].remove(("VECT_TAB_ADDR", 134217728))
 #env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08010000"))
-#env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/fysetc_aio_ii.ld")
 
 # Custom HEX from ELF
 env.AddPostAction(

--- a/buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
@@ -1,3 +1,4 @@
+import os
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08010000
@@ -5,7 +6,14 @@ for define in env['CPPDEFINES']:
     if define[0] == "VECT_TAB_ADDR":
         env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08010000"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/STM32F103VE_longer.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/STM32F103VE_longer.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script
+
 
 # Rename ${PROGNAME}.bin and save it as 'project.bin' (No encryption on the Longer3D)
 def encrypt(source, target, env):

--- a/buildroot/share/PlatformIO/scripts/chitu_crypt.py
+++ b/buildroot/share/PlatformIO/scripts/chitu_crypt.py
@@ -1,12 +1,20 @@
-Import("env")
+import os
 import struct
+Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08008800
 for define in env['CPPDEFINES']:
     if define[0] == "VECT_TAB_ADDR":
         env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x8008800"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/chitu_f103.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/chitu_f103.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script
+
 
 def calculate_crc(contents, seed):
     accumulating_xor_value = seed;

--- a/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
+++ b/buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
@@ -1,3 +1,4 @@
+import os
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x0800A000
@@ -5,7 +6,13 @@ env['CPPDEFINES'].remove(("VECT_TAB_ADDR", "0x8000000"))
 #alternatively, for STSTM <=5.1.0 use line below
 #env['CPPDEFINES'].remove(("VECT_TAB_ADDR", 134217728))
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x0800A000"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/jgaurora_a5s_a1.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/jgaurora_a5s_a1.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script
 
 #append ${PROGNAME}.bin firmware after bootloader and save it as 'jgaurora_firmware.bin'
 def addboot(source,target,env):

--- a/buildroot/share/PlatformIO/scripts/mks_robin.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin.py
@@ -1,3 +1,4 @@
+import os
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08007000
@@ -5,7 +6,13 @@ for define in env['CPPDEFINES']:
     if define[0] == "VECT_TAB_ADDR":
         env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/mks_robin.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/mks_robin.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script
 
 # Encrypt ${PROGNAME}.bin and save it as 'Robin.bin'
 def encrypt(source, target, env):

--- a/buildroot/share/PlatformIO/scripts/mks_robin_lite.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_lite.py
@@ -1,3 +1,4 @@
+import os
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08005000
@@ -5,7 +6,14 @@ for define in env['CPPDEFINES']:
     if define[0] == "VECT_TAB_ADDR":
         env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08005000"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/mks_robin_lite.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/mks_robin_lite.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script
+
 
 # Encrypt ${PROGNAME}.bin and save it as 'mksLite.bin'
 def encrypt(source, target, env):

--- a/buildroot/share/PlatformIO/scripts/mks_robin_mini.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_mini.py
@@ -1,3 +1,5 @@
+import os
+
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08007000
@@ -5,7 +7,14 @@ for define in env['CPPDEFINES']:
     if define[0] == "VECT_TAB_ADDR":
         env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/mks_robin_mini.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/mks_robin_mini.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script
+
 
 # Encrypt ${PROGNAME}.bin and save it as 'Robin_mini.bin'
 def encrypt(source, target, env):

--- a/buildroot/share/PlatformIO/scripts/mks_robin_nano.py
+++ b/buildroot/share/PlatformIO/scripts/mks_robin_nano.py
@@ -1,3 +1,4 @@
+import os
 Import("env")
 
 # Relocate firmware from 0x08000000 to 0x08007000
@@ -5,7 +6,14 @@ for define in env['CPPDEFINES']:
     if define[0] == "VECT_TAB_ADDR":
         env['CPPDEFINES'].remove(define)
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
-env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/mks_robin_nano.ld")
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/mks_robin_nano.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script
+
 
 # Encrypt ${PROGNAME}.bin and save it as 'Robin_nano.bin'
 def encrypt(source, target, env):


### PR DESCRIPTION
Resolves https://github.com/MarlinFirmware/Marlin/issues/15767

This is a temporary low-level solution that works with previous PIO Core versions and will work with the future. However, there is a better way to do this via `board_build.ldscript`. There is a bug in ST STM32 dev/platform which overrides user custom LD Script declared in `board_build.ldscript` way. We will fix it soon. So, you can simplify your configuration later.

Sorry for the issue.
