### PR TITLE
Raise Z before homing X/Y if Z position is unknown

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -308,7 +308,7 @@ void GcodeSuite::G28(const bool always_home_all) {
 
     if (z_homing_height && (doX || doY)) {
       // Raise Z before homing any other axes and z is not already high enough (never lower z)
-      destination.z = z_homing_height;
+      destination.z = TEST(axis_known_position, Z_AXIS) ? z_homing_height : current_position.z + z_homing_height;
       if (destination.z > current_position.z) {
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) to ", destination.z);
         do_blocking_move_to_z(destination.z);

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -308,7 +308,7 @@ void GcodeSuite::G28(const bool always_home_all) {
 
     if (z_homing_height && (doX || doY)) {
       // Raise Z before homing any other axes and z is not already high enough (never lower z)
-      destination.z = TEST(axis_known_position, Z_AXIS) ? z_homing_height : current_position.z + z_homing_height;
+      destination.z = z_homing_height + (TEST(axis_known_position, Z_AXIS) ? 0.0f : current_position.z);
       if (destination.z > current_position.z) {
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) to ", destination.z);
         do_blocking_move_to_z(destination.z);


### PR DESCRIPTION
### Description

Currently if X/Y are homed after disabling Z, Z is not lifted and the nozzle can scrape across the bed.

To reproduce this:

1. Home all axes
    - Z lifts before X/Y home
1. Home X/Y
    - No Z lift before X/Y home, because Z position is known and safe
1. Disable Steppers
1. Home X/Y
    - **Old Behavior** - No Z lift, because homing code doesn't check whether position is known, and _current_position_ reports >= homing height.
    - **New Behavior** - Lifts Z if and only if Z position is not known or is too low

### Benefits

Avoids bed and nozzle damage on printers with a moving X axis, which droops into the bed.

### Related Issues

#15827, although that reported is using 1.x.