### PR TITLE
Use max feedrate for joystick motion

### DIFF
--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -148,7 +148,7 @@ Joystick joystick;
     float hypot2 = 0;
     LOOP_XYZ(i) if (norm_jog[i]) {
       move_dist[i] = seg_time * norm_jog[i] *
-        #if EITHER(ULTIPANEL, EXTENSIBLE_UI)
+        #if ENABLED(EXTENSIBLE_UI)
           MMM_TO_MMS(manual_feedrate_mm_m[i]);
         #else
           planner.settings.max_feedrate_mm_s[i];


### PR DESCRIPTION

### Description

The whole point of an analog joystick is to have fast and slow speeds available.  The manual feedrates are quite slow and limiting the max joystick speed to the manual speed is painfully slow.  Enabling REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER for example kills the joystick speed.

I can't speak to EXTENSIBLE_UI, so I presume it is limiting to manual feedrate for good reason.

### Benefits

Repairs joystick behavior to previous behavior where whole range of feedrates is available, (even when LCD is enabled).

### Related Issues

Unsure whether manual feedrate cap is appropriate for joystick with EXTENSIBLE_UI, but I am presuming it is.
