### PR TITLE
Store unscaled PID values in EEPROM

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -37,7 +37,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V70"
+#define EEPROM_VERSION "V71"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -788,7 +788,10 @@ void MarlinSettings::postprocess() {
       _FIELD_TEST(hotendPID);
       HOTEND_LOOP() {
         PIDC_t pidc = {
-          PID_PARAM(Kp, e), PID_PARAM(Ki, e), PID_PARAM(Kd, e), PID_PARAM(Kc, e)
+                       PID_PARAM(Kp, e),
+          unscalePID_i(PID_PARAM(Ki, e)),
+          unscalePID_d(PID_PARAM(Kd, e)),
+                       PID_PARAM(Kc, e)
         };
         EEPROM_WRITE(pidc);
       }
@@ -808,12 +811,17 @@ void MarlinSettings::postprocess() {
     {
       _FIELD_TEST(bedPID);
 
-      #if DISABLED(PIDTEMPBED)
-        const PID_t bed_pid = { DUMMY_PID_VALUE, DUMMY_PID_VALUE, DUMMY_PID_VALUE };
-        EEPROM_WRITE(bed_pid);
-      #else
-        EEPROM_WRITE(thermalManager.temp_bed.pid);
-      #endif
+      const PID_t bed_pid = {
+        #if DISABLED(PIDTEMPBED)
+          DUMMY_PID_VALUE, DUMMY_PID_VALUE, DUMMY_PID_VALUE
+        #else
+          // Store the unscaled PID values
+          thermalManager.temp_bed.pid.Kp,
+          unscalePID_i(thermalManager.temp_bed.pid.Ki),
+          unscalePID_d(thermalManager.temp_bed.pid.Kd)
+        #endif
+      };
+      EEPROM_WRITE(bed_pid);
     }
 
     //
@@ -1585,10 +1593,10 @@ void MarlinSettings::postprocess() {
           EEPROM_READ(pidc);
           #if ENABLED(PIDTEMP)
             if (!validating && pidc.Kp != DUMMY_PID_VALUE) {
-              // No need to scale PID values since EEPROM values are scaled
+              // Scale PID values since EEPROM values are unscaled
               PID_PARAM(Kp, e) = pidc.Kp;
-              PID_PARAM(Ki, e) = pidc.Ki;
-              PID_PARAM(Kd, e) = pidc.Kd;
+              PID_PARAM(Ki, e) = scalePID_i(pidc.Ki);
+              PID_PARAM(Kd, e) = scalePID_d(pidc.Kd);
               #if ENABLED(PID_EXTRUSION_SCALING)
                 PID_PARAM(Kc, e) = pidc.Kc;
               #endif
@@ -1617,8 +1625,12 @@ void MarlinSettings::postprocess() {
         PID_t pid;
         EEPROM_READ(pid);
         #if ENABLED(PIDTEMPBED)
-          if (!validating && pid.Kp != DUMMY_PID_VALUE)
-            memcpy(&thermalManager.temp_bed.pid, &pid, sizeof(pid));
+          if (!validating && pid.Kp != DUMMY_PID_VALUE) {
+            // Scale PID values since EEPROM values are unscaled
+            thermalManager.temp_bed.pid.Kp = pid.Kp;
+            thermalManager.temp_bed.pid.Ki = scalePID_i(pid.Ki);
+            thermalManager.temp_bed.pid.Kd = scalePID_d(pid.Kd);
+          }
         #endif
       }
 


### PR DESCRIPTION
Now that `OVERSAMPLENR` can be changed by a configuration option, it's necessary to store PID values in the un-scaled form.