### PR TITLE
Only assign CS/RX/TX on extra axes with SPI/UART

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -987,11 +987,6 @@
       #error "No E stepper plug left for X2!"
     #endif
   #endif
-  #if AXIS_HAS_SPI(X2)
-    #ifndef X2_CS_PIN
-      #define X2_CS_PIN     _EPIN(E_STEPPERS, CS)
-    #endif
-  #endif
   #ifndef X2_MS1_PIN
     #define X2_MS1_PIN    _EPIN(E_STEPPERS, MS1)
   #endif
@@ -1000,6 +995,9 @@
   #endif
   #ifndef X2_MS3_PIN
     #define X2_MS3_PIN    _EPIN(E_STEPPERS, MS3)
+  #endif
+  #if AXIS_HAS_SPI(X2) && !defined(X2_CS_PIN)
+    #define X2_CS_PIN     _EPIN(E_STEPPERS, CS)
   #endif
   #if AXIS_HAS_UART(X2)
     #ifndef X2_SERIAL_TX_PIN
@@ -1037,11 +1035,6 @@
       #error "No E stepper plug left for Y2!"
     #endif
   #endif
-  #if AXIS_HAS_SPI(Y2)
-    #ifndef Y2_CS_PIN
-      #define Y2_CS_PIN     _EPIN(Y2_E_INDEX, CS)
-    #endif
-  #endif
   #ifndef Y2_MS1_PIN
     #define Y2_MS1_PIN    _EPIN(Y2_E_INDEX, MS1)
   #endif
@@ -1050,6 +1043,9 @@
   #endif
   #ifndef Y2_MS3_PIN
     #define Y2_MS3_PIN    _EPIN(Y2_E_INDEX, MS3)
+  #endif
+  #if AXIS_HAS_SPI(Y2) && !defined(Y2_CS_PIN)
+    #define Y2_CS_PIN     _EPIN(Y2_E_INDEX, CS)
   #endif
   #if AXIS_HAS_UART(Y2)
     #ifndef Y2_SERIAL_TX_PIN
@@ -1087,11 +1083,6 @@
       #error "No E stepper plug left for Z2!"
     #endif
   #endif
-  #if AXIS_HAS_SPI(Z2)
-    #ifndef Z2_CS_PIN
-      #define Z2_CS_PIN     _EPIN(Z2_E_INDEX, CS)
-    #endif
-  #endif
   #ifndef Z2_MS1_PIN
     #define Z2_MS1_PIN    _EPIN(Z2_E_INDEX, MS1)
   #endif
@@ -1100,6 +1091,9 @@
   #endif
   #ifndef Z2_MS3_PIN
     #define Z2_MS3_PIN    _EPIN(Z2_E_INDEX, MS3)
+  #endif
+  #if AXIS_HAS_SPI(Z2) && !defined(Z2_CS_PIN)
+    #define Z2_CS_PIN     _EPIN(Z2_E_INDEX, CS)
   #endif
   #if AXIS_HAS_UART(Z2)
     #ifndef Z2_SERIAL_TX_PIN

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -987,8 +987,10 @@
       #error "No E stepper plug left for X2!"
     #endif
   #endif
-  #ifndef X2_CS_PIN
-    #define X2_CS_PIN     _EPIN(E_STEPPERS, CS)
+  #if AXIS_HAS_SPI(X2)
+    #ifndef X2_CS_PIN
+      #define X2_CS_PIN     _EPIN(E_STEPPERS, CS)
+    #endif
   #endif
   #ifndef X2_MS1_PIN
     #define X2_MS1_PIN    _EPIN(E_STEPPERS, MS1)
@@ -999,7 +1001,7 @@
   #ifndef X2_MS3_PIN
     #define X2_MS3_PIN    _EPIN(E_STEPPERS, MS3)
   #endif
-  #if AXIS_DRIVER_TYPE_X2(TMC2208) || AXIS_DRIVER_TYPE_X2(TMC2209)
+  #if AXIS_HAS_UART(X2)
     #ifndef X2_SERIAL_TX_PIN
       #define X2_SERIAL_TX_PIN _EPIN(E_STEPPERS, SERIAL_TX)
     #endif
@@ -1035,8 +1037,10 @@
       #error "No E stepper plug left for Y2!"
     #endif
   #endif
-  #ifndef Y2_CS_PIN
-    #define Y2_CS_PIN     _EPIN(Y2_E_INDEX, CS)
+  #if AXIS_HAS_SPI(Y2)
+    #ifndef Y2_CS_PIN
+      #define Y2_CS_PIN     _EPIN(Y2_E_INDEX, CS)
+    #endif
   #endif
   #ifndef Y2_MS1_PIN
     #define Y2_MS1_PIN    _EPIN(Y2_E_INDEX, MS1)
@@ -1047,7 +1051,7 @@
   #ifndef Y2_MS3_PIN
     #define Y2_MS3_PIN    _EPIN(Y2_E_INDEX, MS3)
   #endif
-  #if AXIS_DRIVER_TYPE_Y2(TMC2208) || AXIS_DRIVER_TYPE_Y2(TMC2209)
+  #if AXIS_HAS_UART(Y2)
     #ifndef Y2_SERIAL_TX_PIN
       #define Y2_SERIAL_TX_PIN _EPIN(Y2_E_INDEX, SERIAL_TX)
     #endif
@@ -1083,8 +1087,10 @@
       #error "No E stepper plug left for Z2!"
     #endif
   #endif
-  #ifndef Z2_CS_PIN
-    #define Z2_CS_PIN     _EPIN(Z2_E_INDEX, CS)
+  #if AXIS_HAS_SPI(Z2)
+    #ifndef Z2_CS_PIN
+      #define Z2_CS_PIN     _EPIN(Z2_E_INDEX, CS)
+    #endif
   #endif
   #ifndef Z2_MS1_PIN
     #define Z2_MS1_PIN    _EPIN(Z2_E_INDEX, MS1)
@@ -1095,7 +1101,7 @@
   #ifndef Z2_MS3_PIN
     #define Z2_MS3_PIN    _EPIN(Z2_E_INDEX, MS3)
   #endif
-  #if AXIS_DRIVER_TYPE_Z2(TMC2208) || AXIS_DRIVER_TYPE_Z2(TMC2209)
+  #if AXIS_HAS_UART(Z2)
     #ifndef Z2_SERIAL_TX_PIN
       #define Z2_SERIAL_TX_PIN _EPIN(Z2_E_INDEX, SERIAL_TX)
     #endif
@@ -1130,8 +1136,10 @@
       #error "No E stepper plug left for Z3!"
     #endif
   #endif
-  #ifndef Z3_CS_PIN
-    #define Z3_CS_PIN     _EPIN(Z3_E_INDEX, CS)
+  #if AXIS_HAS_SPI(Z3)
+    #ifndef Z3_CS_PIN
+      #define Z3_CS_PIN     _EPIN(Z3_E_INDEX, CS)
+    #endif
   #endif
   #ifndef Z3_MS1_PIN
     #define Z3_MS1_PIN    _EPIN(Z3_E_INDEX, MS1)
@@ -1142,7 +1150,7 @@
   #ifndef Z3_MS3_PIN
     #define Z3_MS3_PIN    _EPIN(Z3_E_INDEX, MS3)
   #endif
-  #if AXIS_DRIVER_TYPE_Z3(TMC2208) || AXIS_DRIVER_TYPE_Z3(TMC2209)
+  #if AXIS_HAS_UART(Z3)
     #ifndef Z3_SERIAL_TX_PIN
       #define Z3_SERIAL_TX_PIN _EPIN(Z3_E_INDEX, SERIAL_TX)
     #endif


### PR DESCRIPTION
Credit to gee and sjasonsmith.

`PIN_EXISTS(Z2_CS)` returns true when it shouldn't.
Happens with Dual / Triple stepper motor.

