### PR TITLE
Don't compile STM32 SoftwareSerial unless STM32

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/SoftwareSerial.cpp
+++ b/Marlin/src/HAL/HAL_STM32/SoftwareSerial.cpp
@@ -34,6 +34,8 @@
 //
 // Includes
 //
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+
 #include "SoftwareSerial.h"
 #include <timer.h>
 
@@ -389,3 +391,5 @@ int SoftwareSerial::peek() {
   // Read from "head"
   return _receive_buffer[_receive_buffer_head];
 }
+
+#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC


### PR DESCRIPTION
### Description

New Softwareserial lacks a #if that makes arduino skip the build when not needed

### Benefits

Fixes build on Arduino IDE for non-STM32 platform
https://github.com/MarlinFirmware/Marlin/pull/15655#issuecomment-553512205

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/15655#issuecomment-553512205