### PR TITLE
probe.h fix

### DIFF
--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -60,7 +60,7 @@
 
 #endif
 
-#if HAS_LEVELING && (HAS_BED_PROBE || ENABLED(PROBE_MANUALLY))
+#if HAS_BED_PROBE || ENABLED(PROBE_MANUALLY)
   inline float probe_min_x() {
     return _MAX(
       #if IS_KINEMATIC


### PR DESCRIPTION
### Description

This PR fixes issue https://github.com/MarlinFirmware/Marlin/issues/15790 
Some function, for example G34 and M48 use probe.h functions "probe_min_x(), probe_min_y(), probe_max_x(), and probe_max_y()" to check if the position is reachable by the probe. But they are compiled only when bed leveling is enabled.

G34 should be definitely usable without bed leveling. 

Now this functions just halt the printer by returning 0 without giving any suggestion about source of the problem.

### Benefits

G34 and M48 will become functional without bed leveling 

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/15790 
