### PR TITLE
Clarify singlenozzle stored fan speed menus

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -249,6 +249,7 @@ namespace Language_en {
   PROGMEM Language_Str MSG_CHAMBER                         = _UxGT("Enclosure");
   PROGMEM Language_Str MSG_FAN_SPEED                       = _UxGT("Fan Speed");
   PROGMEM Language_Str MSG_FAN_SPEED_N                     = _UxGT("Fan Speed =");
+  PROGMEM Language_Str MSG_STORED_FAN_N                    = _UxGT("Stored Fan =");
   PROGMEM Language_Str MSG_EXTRA_FAN_SPEED                 = _UxGT("Extra Fan Speed");
   PROGMEM Language_Str MSG_EXTRA_FAN_SPEED_N               = _UxGT("Extra Fan Speed =");
   PROGMEM Language_Str MSG_FLOW                            = _UxGT("Flow");

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -211,6 +211,9 @@ void menu_temperature() {
       #if ENABLED(EXTRA_FAN_SPEED)
         EDIT_ITEM_FAST_N(percent, 2, MSG_EXTRA_FAN_SPEED_N, &thermalManager.new_fan_speed[1], 3, 255);
       #endif
+    #elif ENABLED(SINGLENOZZLE) && EXTRUDERS > 1
+      editable.uint8 = thermalManager.fan_speed[1];
+      EDIT_ITEM_FAST_N(percent, 2, MSG_STORED_FAN_N, &editable.uint8, 0, 255, []{ thermalManager.set_fan_speed(1, editable.uint8); });
     #endif
     #if HAS_FAN2
       editable.uint8 = thermalManager.fan_speed[2];
@@ -218,6 +221,9 @@ void menu_temperature() {
       #if ENABLED(EXTRA_FAN_SPEED)
         EDIT_ITEM_FAST_N(percent, 3, MSG_EXTRA_FAN_SPEED_N, &thermalManager.new_fan_speed[2], 3, 255);
       #endif
+    #elif ENABLED(SINGLENOZZLE) && EXTRUDERS > 2
+      editable.uint8 = thermalManager.fan_speed[2];
+      EDIT_ITEM_FAST_N(percent, 3, MSG_STORED_FAN_N, &editable.uint8, 0, 255, []{ thermalManager.set_fan_speed(2, editable.uint8); });
     #endif
   #endif // FAN_COUNT > 0
 

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -160,6 +160,9 @@ void menu_tune() {
       #if ENABLED(EXTRA_FAN_SPEED)
         EDIT_ITEM_FAST_N(percent, 2, MSG_EXTRA_FAN_SPEED_N, &thermalManager.new_fan_speed[1], 3, 255);
       #endif
+    #elif ENABLED(SINGLENOZZLE) && EXTRUDERS > 1
+      editable.uint8 = thermalManager.fan_speed[1];
+      EDIT_ITEM_FAST_N(percent, 2, MSG_STORED_FAN_N, &editable.uint8, 0, 255, []{ thermalManager.set_fan_speed(1, editable.uint8); });
     #endif
     #if HAS_FAN2
       editable.uint8 = thermalManager.fan_speed[2];
@@ -167,6 +170,9 @@ void menu_tune() {
       #if ENABLED(EXTRA_FAN_SPEED)
         EDIT_ITEM_FAST_N(percent, 3, MSG_EXTRA_FAN_SPEED_N, &thermalManager.new_fan_speed[2], 3, 255);
       #endif
+    #elif ENABLED(SINGLENOZZLE) && EXTRUDERS > 2
+      editable.uint8 = thermalManager.fan_speed[2];
+      EDIT_ITEM_FAST_N(percent, 3, MSG_STORED_FAN_N, &editable.uint8, 0, 255, []{ thermalManager.set_fan_speed(2, editable.uint8); });
     #endif
   #endif // FAN_COUNT > 0
 


### PR DESCRIPTION
Add custom message to avoid confusion as seen in.
#15714 
#15711 
#15712 

Fan speed 2 is the stored speed that is recalled on tool change for the matching extruder number. Similar stored values are present for the hotend. If any confusion shows up there, ill look at adding new messages for it as well. Given the space issues we have been seeing even on Atmega2560 though I do not want to keep adding more strings and eating memory....