### PR TITLE
Support Ender-2 display on SKR E3 boards

### DIFF
--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_E3_DIP.h
@@ -176,6 +176,7 @@
   #define BTN_ENC          PB6
 
   #if ENABLED(CR10_STOCKDISPLAY)
+
     #define LCD_PINS_RS    PB8
 
     #define BTN_EN1        PA9
@@ -184,8 +185,30 @@
     #define LCD_PINS_ENABLE PB7
     #define LCD_PINS_D4    PB9
 
+  #elif ENABLED(MKS_MINI_12864)
+
+    /** Creality Ender-2 display pinout
+     *                   _____
+     *               5V | · · | GND
+     *      (MOSI) PB7  | · · | PB8  (LCD_RS)
+     *    (LCD_A0) PB9  | · · | PA10 (BTN_EN2)
+     *            RESET | · · | PA9  (BTN_EN1)
+     *   (BTN_ENC) PB6  | · · | PA15 (SCK)
+     *                   -----
+     *                    EXP1
+     */
+
+    #define BTN_EN1      PA9
+    #define BTN_EN2      PA10
+    #define DOGLCD_CS    PB8
+    #define DOGLCD_A0    PB9
+    #define DOGLCD_SCK   PA15
+    #define DOGLCD_MOSI  PB7
+    #define FORCE_SOFT_SPI
+    #define LCD_BACKLIGHT_PIN -1
+
   #else
-    #error "Only CR10_STOCKDISPLAY is currently supported on the BIGTREE_SKR_E3_DIP."
+    #error "Only CR10_STOCKDISPLAY and MKS_MINI_12864 are currently supported on the BIGTREE_SKR_E3_DIP."
   #endif
 
 #endif // HAS_SPI_LCD

--- a/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32/pins_BIGTREE_SKR_MINI_E3.h
@@ -137,8 +137,30 @@
     #define LCD_PINS_ENABLE PB7
     #define LCD_PINS_D4    PB9
 
+  #elif ENABLED(MKS_MINI_12864)
+
+    /** Creality Ender-2 display pinout
+     *                   _____
+     *               5V | · · | GND
+     *      (MOSI) PB7  | · · | PB8  (LCD_RS)
+     *    (LCD_A0) PB9  | · · | PA10 (BTN_EN2)
+     *            RESET | · · | PA9  (BTN_EN1)
+     *   (BTN_ENC) PB6  | · · | PA15 (SCK)
+     *                   -----
+     *                    EXP1
+     */
+
+    #define BTN_EN1      PA9
+    #define BTN_EN2      PA10
+    #define DOGLCD_CS    PB8
+    #define DOGLCD_A0    PB9
+    #define DOGLCD_SCK   PA15
+    #define DOGLCD_MOSI  PB7
+    #define FORCE_SOFT_SPI
+    #define LCD_BACKLIGHT_PIN -1
+
   #else
-    #error "Only CR10_STOCKDISPLAY is currently supported on the BIGTREE_SKR_MINI_E3."
+    #error "Only CR10_STOCKDISPLAY and MKS_MINI_12864 are currently supported on the BIGTREE_SKR_MINI_E3."
   #endif
 
 #endif // HAS_SPI_LCD


### PR DESCRIPTION
### Description

This commit adds support for the MKS Mini 12864 style displays used on the Creality Ender-2 for the STM32 based compatible SKR E3 DIP and SKR Mini E3 boards by BigTreeTech.

I do not know whether other MKS Mini 12864 boards are supported with the pinout defined by this commit, but the Ender-2 ones work reliably.

This solution has been suggested by user @Grrby after a lengthy investigation conducted in #15624. If someone can confirm the suggested solution works on the SKR 1.3 as well, this issue could be closed.

I tested this change with today's upstream `bugfix-2.0.x` branch in a minimal-working-example like environment. All I had to change are the following variables:

```sh
sed -i 's|^//#define MKS_MINI_12864|#define MKS_MINI_12864|' Marlin/Configuration.h
sed -i 's|^  #define MOTHERBOARD .*|  #define MOTHERBOARD BOARD_BIGTREE_SKR_E3_DIP|' Marlin/Configuration.h
sed -i 's|^#define SERIAL_PORT .*|#define SERIAL_PORT -1|' Marlin/Configuration.h
```

Then build like `pio run -e STM32F103RC_bigtree`.

Of course this minimal build won't work with the printer, but it proves that the display is working. You need additional changes to the configuration, you need the alternative TMC stepper library from BTT etc. Also there's a new series of boards shipping an STM32 with a larger ROM, which I'll send a PR for soon. (However, it seems the bootloader isn't willing to flash larger firmwares anyway right now).
You can find my complete changes in https://github.com/TheAssassin/Marlin-Ender2-SKR-E3-DIP/. I intend to send a PR to add support for the 

### Benefits

You can use the SKR E3 DIP / SKR Mini E3 boards, which were originally designed for the Creality Ender-3, with the older Ender-2. This PR makes the stock display work.

### Related Issues

#15624 (isn't fixed by this PR, though, as the issue is about the SKR 1.3, not the SKR E3 series)
