### PR TITLE
Allow UBL G29 J1 with PAUSE_BEFORE_DEPLOY_STOW

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -741,13 +741,13 @@
      * This attempts to fill in locations closest to the nozzle's start location first.
      */
     void unified_bed_leveling::probe_entire_mesh(const xy_pos_t &near, const bool do_ubl_mesh_map, const bool stow_probe, const bool do_furthest) {
+      DEPLOY_PROBE(); // Deploy before ui.capture() to allow for PAUSE_BEFORE_DEPLOY_STOW
+
       #if HAS_LCD_MENU
         ui.capture();
       #endif
 
       save_ubl_active_state_and_disable();  // No bed level correction so only raw data is obtained
-      DEPLOY_PROBE();
-
       uint8_t count = GRID_MAX_POINTS;
 
       mesh_index_pair best;
@@ -764,10 +764,10 @@
           if (ui.button_pressed()) {
             ui.quick_feedback(false); // Preserve button state for click-and-hold
             SERIAL_ECHOLNPGM("\nMesh only partially populated.\n");
-            STOW_PROBE();
             ui.wait_for_release();
             ui.quick_feedback();
             ui.release();
+            STOW_PROBE(); // Release UI before stow to allow for PAUSE_BEFORE_DEPLOY_STOW
             return restore_ubl_active_state_and_leave();
           }
         #endif
@@ -790,7 +790,9 @@
 
       } while (best.pos.x >= 0 && --count);
 
-      STOW_PROBE();
+      ui.release();
+      STOW_PROBE(); // Release UI during stow to allow for PAUSE_BEFORE_DEPLOY_STOW
+      ui.capture();
 
       #ifdef Z_AFTER_PROBING
         move_z_after_probing();
@@ -1504,18 +1506,20 @@
 
               abort_flag = isnan(measured_z);
 
-              if (DEBUGGING(LEVELING)) {
-                const xy_pos_t lpos = rpos.asLogical();
-                DEBUG_CHAR('(');
-                DEBUG_ECHO_F(rpos.x, 7);
-                DEBUG_CHAR(',');
-                DEBUG_ECHO_F(rpos.y, 7);
-                DEBUG_ECHOPAIR_F(")   logical: (", lpos.x, 7);
-                DEBUG_CHAR(',');
-                DEBUG_ECHO_F(lpos.y, 7);
-                DEBUG_ECHOPAIR_F(")   measured: ", measured_z, 7);
-                DEBUG_ECHOPAIR_F("   correction: ", get_z_correction(rpos), 7);
-              }
+              #if ENABLED(DEBUG_LEVELING_FEATURE)
+                if (DEBUGGING(LEVELING)) {
+                  const xy_pos_t lpos = rpos.asLogical();
+                  DEBUG_CHAR('(');
+                  DEBUG_ECHO_F(rpos.x, 7);
+                  DEBUG_CHAR(',');
+                  DEBUG_ECHO_F(rpos.y, 7);
+                  DEBUG_ECHOPAIR_F(")   logical: (", lpos.x, 7);
+                  DEBUG_CHAR(',');
+                  DEBUG_ECHO_F(lpos.y, 7);
+                  DEBUG_ECHOPAIR_F(")   measured: ", measured_z, 7);
+                  DEBUG_ECHOPAIR_F("   correction: ", get_z_correction(rpos), 7);
+                }
+              #endif
 
               measured_z -= get_z_correction(rpos) /* + probe_offset.z */ ;
 


### PR DESCRIPTION
### Description

When using FIX_MOUNTED_PROBE with PAUSE_BEFORE_DEPLOY_STOW (common for Delta printers), UBL's `G29 P1` command would prompt for probe deployment, then get stuck.

This happened because UBL takes over encoder interactions, preventing the DEPLOY_PROBE() and STOW_PROBE() commands from ever completing.

In addition, the added #if around debug prints eliminated a compiler warning in this file when DEBUG_LEVELING_FEATURE is not enabled.


### Benefits

Allows users of these probes to use UBL mesh leveling.

### Related Issues
The same issue has been reported three times, but has been closed without resolution twice.
#15927 
#13114
#13705  

