### PR TITLE
Add Host Prompt Notification Method

### DIFF
--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -70,6 +70,12 @@ void host_action(const char * const pstr, const bool eol) {
 
   PromptReason host_prompt_reason = PROMPT_NOT_DEFINED;
 
+  void host_action_notify(const char * const message) {
+    host_action(PSTR("notification "), false);
+    serialprintPGM(message);
+    SERIAL_EOL();
+  }
+
   void host_action_prompt(const char * const ptype, const bool eol=true) {
     host_action(PSTR("prompt_"), false);
     serialprintPGM(ptype);

--- a/Marlin/src/feature/host_actions.h
+++ b/Marlin/src/feature/host_actions.h
@@ -58,6 +58,7 @@ void host_action(const char * const pstr, const bool eol=true);
   extern PromptReason host_prompt_reason;
 
   void host_response_handler(const uint8_t response);
+  void host_action_notify(const char * const message);
   void host_action_prompt_begin(const char * const pstr, const bool eol=true);
   void host_action_prompt_button(const char * const pstr);
   void host_action_prompt_end();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1578,17 +1578,17 @@ void MarlinUI::update() {
 
   #endif
 #else // HAS_DISPLAY
-  void MarlinUI::set_status(const char* message, const bool=false) {
+  void MarlinUI::set_status(const char* message, bool persist) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
     #endif
   }
-  void MarlinUI::set_status_P(PGM_P message, const int8_t=0) {
+  void MarlinUI::set_status_P(PGM_P message, int8_t i) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
     #endif
   }
-  void MarlinUI::status_printf_P(const uint8_t, PGM_P message, ...) {
+  void MarlinUI::status_printf_P(const uint8_t i, PGM_P message, ...) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
     #endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1584,7 +1584,7 @@ void MarlinUI::update() {
   // Send the status line as a host notification
   //
 
-  void MarlinUI::set_status(const char *message, const bool) {
+  void MarlinUI::set_status(const char * const message, const bool) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
     #else

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -26,18 +26,20 @@
   #include "../feature/leds/leds.h"
 #endif
 
+#if ENABLED(HOST_ACTION_COMMANDS)
+  #include "../feature/host_actions.h"
+#endif
+
+#include "ultralcd.h"
+MarlinUI ui;
+
 // All displays share the MarlinUI class
 #if HAS_DISPLAY
   #include "../gcode/queue.h"
-  #include "ultralcd.h"
   #include "fontutils.h"
-  MarlinUI ui;
   #include "../sd/cardreader.h"
   #if ENABLED(EXTENSIBLE_UI)
     #define START_OF_UTF8_CHAR(C) (((C) & 0xC0u) != 0x80u)
-  #endif
-  #if ENABLED(HOST_ACTION_COMMANDS)
-    #include "../feature/host_actions.h"
   #endif
 #endif
 
@@ -1575,5 +1577,21 @@ void MarlinUI::update() {
     }
 
   #endif
+#else // HAS_DISPLAY
+  void MarlinUI::set_status(const char* message, const bool=false) {
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_action_notify(message);
+    #endif
+  }
+  void MarlinUI::set_status_P(PGM_P message, const int8_t=0) {
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_action_notify(message);
+    #endif
+  }
+  void MarlinUI::status_printf_P(const uint8_t, PGM_P message, ...) {
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_action_notify(message);
+    #endif
+  }
 
-#endif // HAS_DISPLAY
+#endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1577,21 +1577,29 @@ void MarlinUI::update() {
     }
 
   #endif
-#else // HAS_DISPLAY
-  void MarlinUI::set_status(const char* message, bool persist) {
-    #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_action_notify(message);
-    #endif
-  }
-  void MarlinUI::set_status_P(PGM_P message, int8_t i) {
-    #if ENABLED(HOST_PROMPT_SUPPORT)
-      host_action_notify(message);
-    #endif
-  }
-  void MarlinUI::status_printf_P(const uint8_t i, PGM_P message, ...) {
+
+#else // !HAS_DISPLAY
+
+  //
+  // Send the status line as a host notification
+  //
+
+  void MarlinUI::set_status(const char* message, bool) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
     #endif
   }
 
-#endif
+  void MarlinUI::set_status_P(PGM_P message, int8_t) {
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_action_notify(message);
+    #endif
+  }
+
+  void MarlinUI::status_printf_P(const uint8_t, PGM_P message, ...) {
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_action_notify(message);
+    #endif
+  }
+
+#endif // !HAS_DISPLAY

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1369,6 +1369,10 @@ void MarlinUI::update() {
   void MarlinUI::set_status(const char * const message, const bool persist) {
     if (alert_level) return;
 
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_action_notify(message);
+    #endif
+
     // Here we have a problem. The message is encoded in UTF8, so
     // arbitrarily cutting it will be a problem. We MUST be sure
     // that there is no cutting in the middle of a multibyte character!
@@ -1407,6 +1411,10 @@ void MarlinUI::update() {
     if (level < 0) level = alert_level = 0;
     if (level < alert_level) return;
     alert_level = level;
+
+    #if ENABLED(HOST_PROMPT_SUPPORT)
+      host_action_notify(message);
+    #endif
 
     // Since the message is encoded in UTF8 it must
     // only be cut on a character boundary.

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1584,21 +1584,27 @@ void MarlinUI::update() {
   // Send the status line as a host notification
   //
 
-  void MarlinUI::set_status(const char* message, const bool) {
+  void MarlinUI::set_status(const char *message, const bool) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
+    #else
+      UNUSED(message);
     #endif
   }
 
   void MarlinUI::set_status_P(PGM_P message, const int8_t) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
+    #else
+      UNUSED(message);
     #endif
   }
 
   void MarlinUI::status_printf_P(const uint8_t, PGM_P const message, ...) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
+    #else
+      UNUSED(message);
     #endif
   }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1584,19 +1584,19 @@ void MarlinUI::update() {
   // Send the status line as a host notification
   //
 
-  void MarlinUI::set_status(const char* message, bool) {
+  void MarlinUI::set_status(const char* message, const bool) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
     #endif
   }
 
-  void MarlinUI::set_status_P(PGM_P message, int8_t) {
+  void MarlinUI::set_status_P(PGM_P message, const int8_t) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
     #endif
   }
 
-  void MarlinUI::status_printf_P(const uint8_t, PGM_P message, ...) {
+  void MarlinUI::status_printf_P(const uint8_t, PGM_P const message, ...) {
     #if ENABLED(HOST_PROMPT_SUPPORT)
       host_action_notify(message);
     #endif

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -406,14 +406,16 @@ public:
 
   #else // No LCD
 
+    // Send status to host as a notification
+    void set_status(const char* message, const bool=false);
+    void set_status_P(PGM_P message, const int8_t=0);
+    void status_printf_P(const uint8_t, PGM_P message, ...);
+
     static inline void init() {}
     static inline void update() {}
     static inline void refresh() {}
     static inline void return_to_status() {}
     static inline void set_alert_status_P(PGM_P const) {}
-    void set_status(const char* message, const bool=false);
-    void set_status_P(PGM_P message, const int8_t=0);
-    void status_printf_P(const uint8_t, PGM_P message, ...);
     static inline void reset_status() {}
     static inline void reset_alert_level() {}
     static constexpr bool has_status() { return false; }
@@ -421,7 +423,6 @@ public:
   #endif
 
   #if HAS_LCD_MENU
-
 
     #if ENABLED(TOUCH_BUTTONS)
       static uint8_t repeat_delay;

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -411,9 +411,9 @@ public:
     static inline void refresh() {}
     static inline void return_to_status() {}
     static inline void set_alert_status_P(PGM_P const) {}
-    static inline void set_status(const char* const, const bool=false) {}
-    static inline void set_status_P(PGM_P const, const int8_t=0) {}
-    static inline void status_printf_P(const uint8_t, PGM_P const, ...) {}
+    void set_status(const char* message, const bool=false);
+    void set_status_P(PGM_P message, const int8_t=0);
+    void status_printf_P(const uint8_t, PGM_P message, ...);
     static inline void reset_status() {}
     static inline void reset_alert_level() {}
     static constexpr bool has_status() { return false; }
@@ -421,6 +421,7 @@ public:
   #endif
 
   #if HAS_LCD_MENU
+
 
     #if ENABLED(TOUCH_BUTTONS)
       static uint8_t repeat_delay;


### PR DESCRIPTION
Based on discussion with @foosel on discord, this adds the host prompt notification method which triggers a non-blocking modal which will be in an upcoming Octoprint release. Currently this just grabs the display messages. Once the function is available for proper testing, I will look at breaking out the set status methods to function with no other display so this will bring a new layer of functionality to machines with Octoprint as the only display.