### PR TITLE
TMCStepper 0.6.x is now Marlin-compatible

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ build_flags = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__
 lib_deps =
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
   LiquidCrystal@1.3.4
-  TMCStepper@>=0.5.2,<0.6.0
+  TMCStepper@>=0.5.2,<0.6.2
   Adafruit NeoPixel@1.2.5
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,7 +27,7 @@ build_flags = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__
 lib_deps =
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
   LiquidCrystal@1.3.4
-  TMCStepper@>=0.5.2,<0.6.2
+  TMCStepper@>=0.5.2,<1.0.0
   Adafruit NeoPixel@1.2.5
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip


### PR DESCRIPTION
### Description
TMCStepper 0.6.0 released with connection errors on some platforms, release 0.6.1 fixes these issues.

### Benefits
Prevent TMCStepper connection errors on some platforms.

### Related Issues
https://github.com/teemuatlut/TMCStepper/issues/93
