### PR TITLE
Support RET6 in BTT SKR E3 DIP

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -476,7 +476,7 @@
 #elif MB(BTT_SKR_MINI_E3_V1_2)
   #include "stm32/pins_BTT_SKR_MINI_E3_V1_2.h"  // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_NOUSB env:STM32F103RC_bigtree_512K_NOUSB
 #elif MB(BIGTREE_SKR_E3_DIP)
-  #include "stm32/pins_BTT_SKR_E3_DIP.h"        // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_NOUSB env:STM32F103RC_bigtree_512K_NOUSB
+  #include "stm32/pins_BTT_SKR_E3_DIP.h"        // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_NOUSB env:STM32F103RC_bigtree_512K_NOUSB env:STM32F103RE_bigtree
 #elif MB(JGAURORA_A5S_A1)
   #include "stm32/pins_JGAURORA_A5S_A1.h"       // STM32F1                                env:jgaurora_a5s_a1
 #elif MB(FYSETC_AIO_II)

--- a/buildroot/share/PlatformIO/ldscripts/STM32F103RE_SKR_E3_DIP.ld
+++ b/buildroot/share/PlatformIO/ldscripts/STM32F103RE_SKR_E3_DIP.ld
@@ -1,0 +1,14 @@
+MEMORY
+{
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K - 40
+  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K
+}
+
+/* Provide memory region aliases for common.inc */
+REGION_ALIAS("REGION_TEXT", rom);
+REGION_ALIAS("REGION_DATA", ram);
+REGION_ALIAS("REGION_BSS", ram);
+REGION_ALIAS("REGION_RODATA", rom);
+
+/* Let common.inc handle the real work. */
+INCLUDE common.inc

--- a/buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
@@ -1,0 +1,12 @@
+import os
+Import("env")
+
+# Relocate firmware from 0x08000000 to 0x08007000
+env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
+
+custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/STM32F103RE_SKR_E3_DIP.ld")
+for i, flag in enumerate(env["LINKFLAGS"]):
+    if "-Wl,-T" in flag:
+        env["LINKFLAGS"][i] = "-Wl,-T" + custom_ld_script
+    elif flag == "-T":
+        env["LINKFLAGS"][i + 1] = custom_ld_script

--- a/platformio.ini
+++ b/platformio.ini
@@ -298,6 +298,8 @@ upload_protocol   = serial
 #   STM32F103RC_bigtree_NOUSB ........ RCT6 with 256K (no USB)
 #   STM32F103RC_bigtree_512K.......... RCT6 with 512K
 #   STM32F103RC_bigtree_512K_NOUSB ... RCT6 with 512K (no USB)
+#   STM32F103RE_bigtree .............. RET6
+#   STM32F103RE_bigtree_NOUSB ........ RET6 (no USB)
 #
 
 [env:STM32F103RC_bigtree]
@@ -355,6 +357,38 @@ platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512
+build_unflags     = -std=gnu++11
+lib_deps          = ${common.lib_deps}
+  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
+lib_ignore        = Adafruit NeoPixel, SPI
+src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
+monitor_speed     = 115200
+
+[env:STM32F103RE_bigtree]
+platform          = ststm32
+framework         = arduino
+board             = genericSTM32F103RE
+board_upload.maximum_size=524288
+platform_packages = tool-stm32duino
+extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
+build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4
+build_unflags     = -std=gnu++11
+lib_deps          = ${common.lib_deps}
+  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
+lib_ignore        = Adafruit NeoPixel, SPI
+src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
+monitor_speed     = 115200
+
+[env:STM32F103RE_bigtree_NOUSB]
+platform          = ststm32
+framework         = arduino
+board             = genericSTM32F103RE
+board_upload.maximum_size=524288
+platform_packages = tool-stm32duino
+extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
+build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip


### PR DESCRIPTION
### Requirements

SKR mini E3 DIP 1.0 with RET6 mcu

### Description

add support for SKR mini E3 DIP 1.0 with RET6 mcu
### Benefits

see description

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/15890
https://github.com/MarlinFirmware/Marlin/issues/15254
