### PR TITLE
Fix G29 for updated meshCount type

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -684,7 +684,7 @@ G29_TYPE GcodeSuite::G29() {
       // Outer loop is Y with PROBE_Y_FIRST disabled
       for (PR_OUTER_VAR = 0; PR_OUTER_VAR < PR_OUTER_END && !isnan(measured_z); PR_OUTER_VAR++) {
 
-        uint8_t inStart, inStop, inInc;
+        int8_t inStart, inStop, inInc;
 
         if (zig) { // away from origin
           inStart = 0;
@@ -693,8 +693,8 @@ G29_TYPE GcodeSuite::G29() {
         }
         else {     // towards origin
           inStart = PR_INNER_END - 1;
-          inStop = 0xFF;
-          inInc = 0xFF;
+          inStop = -1;
+          inInc = -1;
         }
 
         zig ^= true; // zag


### PR DESCRIPTION
### Description

Recent commit changed `meshCount` from `xy_uint8_t` to `xy_int8_t`. 

When this was done, the increment and stop values were not changed, causing incorrect advancement through probed points.

On the Anycubic Kossel Linear Plus I'm testing with, this would result in a loop of the same four points being probed repeatedly.

### Benefits

I am able to complete a G29 probing routine with this change.

### Related Issues

This issue was brought up on Discord by zombu2. 
