### PR TITLE
platformio.ini update (env:LPC176x)

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -159,28 +159,13 @@ monitor_speed     = 250000
 lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper=https://github.com/p3p/TMCStepper/archive/pr_lpctimingfix.zip
+  TMCStepper@>0.5.2,<1.0.0
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 
 [env:LPC1769]
-platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.2.zip
-framework         = arduino
+extends           = env:LPC1768
 board             = nxp_lpc1769
-build_flags       = -DU8G_HAL_LINKS -IMarlin/src/HAL/HAL_LPC1768/include -IMarlin/src/HAL/HAL_LPC1768/u8g ${common.build_flags}
-# debug options for backtrace
-#  -funwind-tables
-#  -mpoke-function-name
-lib_ldf_mode      = off
-lib_compat_mode   = strict
-extra_scripts     = Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_LPC1768>
-monitor_speed     = 250000
-lib_deps          = Servo
-  LiquidCrystal
-  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper=https://github.com/p3p/TMCStepper/archive/pr_lpctimingfix.zip
-  Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
 
 #
 # Sanguinololu (ATmega644p)

--- a/platformio.ini
+++ b/platformio.ini
@@ -159,7 +159,7 @@ monitor_speed     = 250000
 lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper@>0.5.2,<1.0.0
+  TMCStepper@>=0.6.1,<1.0.0
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 


### PR DESCRIPTION
Update LPC1768 platformio env to use current TMCStepper lib.

Update LPC1769 env to extend LPC1768 as a test case for moving over the other environments to this format.