### PR TITLE
(SKR 1.3) Assign DIAG pins for homing dir

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
@@ -35,16 +35,8 @@
 #define X_MAX_PIN          P1_28
 #define Y_MIN_PIN          P1_27
 #define Y_MAX_PIN          P1_26
-
-#if EITHER(Z_HOME_DIR == 1, Z_DUAL_ENDSTOPS)
-  // Remaping TMC2130 Z1 diag pin (Z_MIN_PIN) to Z MAX ENDSTOP logic for uplift Z homing
-  #define Z_MIN_PIN          P1_24
-  #define Z_MAX_PIN          P1_25
-#else
-  // Set normal endstop pins
-  #define Z_MIN_PIN          P1_25
-  #define Z_MAX_PIN          P1_24
-#endif
+#define Z_MIN_PIN          P1_25
+#define Z_MAX_PIN          P1_24
 
 //
 // Steppers

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
@@ -35,8 +35,15 @@
 #define X_MAX_PIN          P1_28
 #define Y_MIN_PIN          P1_27
 #define Y_MAX_PIN          P1_26
-#define Z_MIN_PIN          P1_25
-#define Z_MAX_PIN          P1_24
+#if EITHER(Z_HOME_DIR == 1, Z_STALL_SENSITIVITY)
+  // Remaping TMC2130 Z1 diag pin (Z_MIN_PIN) to Z_MAX_PIN when upright Z stallguard homing
+  #define Z_MIN_PIN          P1_24
+  #define Z_MAX_PIN          P1_25
+#else
+  // Use normal endstop pins
+  #define Z_MIN_PIN          P1_25
+  #define Z_MAX_PIN          P1_24
+#endif
 
 //
 // Steppers

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
@@ -35,8 +35,16 @@
 #define X_MAX_PIN          P1_28
 #define Y_MIN_PIN          P1_27
 #define Y_MAX_PIN          P1_26
-#define Z_MIN_PIN          P1_25
-#define Z_MAX_PIN          P1_24
+
+#if EITHER(Z_HOME_DIR == 1, Z_DUAL_ENDSTOPS)
+  // Remaping TMC2130 Z1 diag pin (Z_MIN_PIN) to Z MAX ENDSTOP logic for uplift Z homing
+  #define Z_MIN_PIN          P1_24
+  #define Z_MAX_PIN          P1_25
+#else
+  // Set normal endstop pins
+  #define Z_MIN_PIN          P1_25
+  #define Z_MAX_PIN          P1_24
+#endif
 
 //
 // Steppers

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
@@ -28,19 +28,32 @@
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD 2000
 
-//
-// Limit Switches
-//
-#define X_MIN_PIN          P1_29
-#define X_MAX_PIN          P1_28
-#define Y_MIN_PIN          P1_27
-#define Y_MAX_PIN          P1_26
+/*
+ * Limit Switches
+ * Validation of pins assignement in case stallguard is use
+ * with positive homing direction, in this case, the min and 
+ * max values will be reversed to allow the use of MAX physical 
+ * connectors for other purposes
+ */
+
+#if EITHER(X_HOME_DIR == 1, X_STALL_SENSITIVITY)
+  #define X_MIN_PIN          P1_28
+  #define X_MAX_PIN          P1_29
+#else
+  #define X_MIN_PIN          P1_29
+  #define X_MAX_PIN          P1_28
+#endif
+#if EITHER(Y_HOME_DIR == 1, Y_STALL_SENSITIVITY)
+  #define Y_MIN_PIN          P1_26
+  #define Y_MAX_PIN          P1_27
+#else
+  #define Y_MIN_PIN          P1_27
+  #define Y_MAX_PIN          P1_26
+#endif
 #if EITHER(Z_HOME_DIR == 1, Z_STALL_SENSITIVITY)
-  // Remaping TMC2130 Z1 diag pin (Z_MIN_PIN) to Z_MAX_PIN when upright Z stallguard homing
   #define Z_MIN_PIN          P1_24
   #define Z_MAX_PIN          P1_25
 #else
-  // Use normal endstop pins
   #define Z_MIN_PIN          P1_25
   #define Z_MAX_PIN          P1_24
 #endif

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
@@ -28,36 +28,6 @@
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD 2000
 
-/*
- * Limit Switches
- * Validation of pins assignement in case stallguard is use
- * with positive homing direction, in this case, the min and 
- * max values will be reversed to allow the use of MAX physical 
- * connectors for other purposes
- */
-
-#if EITHER(X_HOME_DIR == 1, X_STALL_SENSITIVITY)
-  #define X_MIN_PIN          P1_28
-  #define X_MAX_PIN          P1_29
-#else
-  #define X_MIN_PIN          P1_29
-  #define X_MAX_PIN          P1_28
-#endif
-#if EITHER(Y_HOME_DIR == 1, Y_STALL_SENSITIVITY)
-  #define Y_MIN_PIN          P1_26
-  #define Y_MAX_PIN          P1_27
-#else
-  #define Y_MIN_PIN          P1_27
-  #define Y_MAX_PIN          P1_26
-#endif
-#if EITHER(Z_HOME_DIR == 1, Z_STALL_SENSITIVITY)
-  #define Z_MIN_PIN          P1_24
-  #define Z_MAX_PIN          P1_25
-#else
-  #define Z_MIN_PIN          P1_25
-  #define Z_MAX_PIN          P1_24
-#endif
-
 //
 // Steppers
 //

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
@@ -24,6 +24,17 @@
 #define BOARD_INFO_NAME "BIGTREE SKR 1.1"
 
 //
+// Limit Switches
+//
+
+#define X_MIN_PIN          P1_29
+#define X_MAX_PIN          P1_28
+#define Y_MIN_PIN          P1_27
+#define Y_MAX_PIN          P1_26
+#define Z_MIN_PIN          P1_25
+#define Z_MAX_PIN          P1_24
+
+//
 // Steppers
 //
 #define X_STEP_PIN         P0_04

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -23,43 +23,34 @@
 
 #define BOARD_INFO_NAME "BIGTREE SKR 1.3"
 
-/*
+/**
  * Limit Switches
- * 
- * Validation of pins assignement in case stallguard is use
- * with positive homing direction, in this case, the min and 
- * max values will be reversed to allow the use of MAX physical 
- * connectors for other purposes
+ *
+ * For Stallguard homing to max swap the min / max pins so
+ * the MAX physical connectors can be used for other things.
  */
-
-#if EITHER(X_HOME_DIR == 1, X_STALL_SENSITIVITY)
-  // Reverse pins assignement
-  #define X_MIN_PIN          P1_28
-  #define X_MAX_PIN          P1_29
+#if X_HOME_DIR == -1 || !X_STALL_SENSITIVITY
+  #define X_MIN_PIN          P1_29   // X_MIN
+  #define X_MAX_PIN          P1_28   // X_MAX
 #else
-  // Normal pin assignement
-  #define X_MIN_PIN          P1_29
-  #define X_MAX_PIN          P1_28
+  #define X_MIN_PIN          P1_28   // X_MAX
+  #define X_MAX_PIN          P1_29   // X_MIN
 #endif
 
-#if EITHER(Y_HOME_DIR == 1, Y_STALL_SENSITIVITY)
-  // Reverse pins assignement
-  #define Y_MIN_PIN          P1_26
-  #define Y_MAX_PIN          P1_27
+#if Y_HOME_DIR == -1 || !Y_STALL_SENSITIVITY
+  #define Y_MIN_PIN          P1_27   // Y_MIN
+  #define Y_MAX_PIN          P1_26   // Y_MAX
 #else
-  // Normal pin assignement
-  #define Y_MIN_PIN          P1_27
-  #define Y_MAX_PIN          P1_26
+  #define Y_MIN_PIN          P1_26   // Y_MAX
+  #define Y_MAX_PIN          P1_27   // Y_MIN
 #endif
 
-#if EITHER(Z_HOME_DIR == 1, Z_STALL_SENSITIVITY)
-  // Reverse pins assignement
-  #define Z_MIN_PIN          P1_24
-  #define Z_MAX_PIN          P1_25
+#if Z_HOME_DIR == -1 || !Z_STALL_SENSITIVITY
+  #define Z_MIN_PIN          P1_25   // Z_MIN
+  #define Z_MAX_PIN          P1_24   // Z_MAX
 #else
-  // Normal pin assignement
-  #define Z_MIN_PIN          P1_25
-  #define Z_MAX_PIN          P1_24
+  #define Z_MIN_PIN          P1_24   // Z_MAX
+  #define Z_MAX_PIN          P1_25   // Z_MIN
 #endif
 
 //

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -23,6 +23,45 @@
 
 #define BOARD_INFO_NAME "BIGTREE SKR 1.3"
 
+/*
+ * Limit Switches
+ * 
+ * Validation of pins assignement in case stallguard is use
+ * with positive homing direction, in this case, the min and 
+ * max values will be reversed to allow the use of MAX physical 
+ * connectors for other purposes
+ */
+
+#if EITHER(X_HOME_DIR == 1, X_STALL_SENSITIVITY)
+  // Reverse pins assignement
+  #define X_MIN_PIN          P1_28
+  #define X_MAX_PIN          P1_29
+#else
+  // Normal pin assignement
+  #define X_MIN_PIN          P1_29
+  #define X_MAX_PIN          P1_28
+#endif
+
+#if EITHER(Y_HOME_DIR == 1, Y_STALL_SENSITIVITY)
+  // Reverse pins assignement
+  #define Y_MIN_PIN          P1_26
+  #define Y_MAX_PIN          P1_27
+#else
+  // Normal pin assignement
+  #define Y_MIN_PIN          P1_27
+  #define Y_MAX_PIN          P1_26
+#endif
+
+#if EITHER(Z_HOME_DIR == 1, Z_STALL_SENSITIVITY)
+  // Reverse pins assignement
+  #define Z_MIN_PIN          P1_24
+  #define Z_MAX_PIN          P1_25
+#else
+  // Normal pin assignement
+  #define Z_MIN_PIN          P1_25
+  #define Z_MAX_PIN          P1_24
+#endif
+
 //
 // Servos
 //


### PR DESCRIPTION
### Requirements
SKR 1.3
Stepstick that use stallguard diag pin
sensorless homing with stallguard
(X,Y,Z)_HOME_DIR == 1

### Description


Added a condition to correctly assign the pins of SKR 1.3 when using sensorless homing in positive direction  with stallguard. In the case that the printer use positive homing direction, marlin use (X,Y,Z)_MAX_PIN to trigger but the stallguard diagnostic pin is physically on (X,Y,Z)_MIN_PIN


### Benefits

The code automatically validates the need to change the allocation of pins

### Related Issues


