### PR TITLE
SKR V1.3 auto XY endstop pins on sensorless homing

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR.h
@@ -31,10 +31,16 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN          P1_29
-#define X_MAX_PIN          P1_28
-#define Y_MIN_PIN          P1_27
-#define Y_MAX_PIN          P1_26
+#if ENABLED(SENSORLESS_HOMING) && MB(BIGTREE_SKR_V1_3)
+  #define X_STOP_PIN       P1_29
+  #define Y_STOP_PIN       P1_27
+#else
+  #define X_MIN_PIN        P1_29
+  #define X_MAX_PIN        P1_28
+  #define Y_MIN_PIN        P1_27
+  #define Y_MAX_PIN        P1_26
+#endif
+
 #define Z_MIN_PIN          P1_25
 #define Z_MAX_PIN          P1_24
 


### PR DESCRIPTION
### Description

Change X/Y_MIN/MAX pin assignment to X/Y_STOP pin assignment for sensorless homing on Bigtreetech SKR V1.3 (it has integrated sensorless homing connection, for SKR V1.1 it doesn't really matter because it don't have integrated connection for DIAG pins)

### Benefits

It's easier to set up sensorless homing for machines with XY home position other than X_MIN Y_MIN because it does not require any modifications in pins file

### Related Issues

No issues related
