### PR TITLE
Fix a PID_EXTRUSION_SCALING menu item

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -299,7 +299,7 @@ void menu_cancelobject();
       #if ENABLED(PID_EXTRUSION_SCALING)
         #define _PID_EDIT_MENU_ITEMS(N) \
           _PID_BASE_MENU_ITEMS(N); \
-          EDIT_ITEM(float3, MSG_PID_C_E, N, &PID_PARAM(Kc, N), 1, 9990)
+          EDIT_ITEM_N(float3, N, MSG_PID_C_E, &PID_PARAM(Kc, N), 1, 9990)
       #else
         #define _PID_EDIT_MENU_ITEMS(N) _PID_BASE_MENU_ITEMS(N)
       #endif


### PR DESCRIPTION
### Description

The changes from #15593 don't compile when PID_EXTRUSION_SCALING is enabled. Rework its menu item to match the refactor of the other PID values.

I did not actually test the menu item on hardware, but when looking at the change history of this file and comparing it to the other PID items, the solution seems straightforward.

### Related Issues

#15919 
