### PR TITLE
Fix delta_mm.e with zero extruders

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1808,6 +1808,8 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
   #if EXTRUDERS
     delta_mm.e = esteps_float * steps_to_mm[E_AXIS_N(extruder)];
+  #else
+    delta_mm.e = 0.0f;
   #endif
 
   #if ENABLED(LCD_SHOW_E_TOTAL)


### PR DESCRIPTION
### Description

With 0 extruders the uninitialised `delta_mm.e` was used in some calculations which in rare cases could lead to a `max_rate` of 0. With `ADAPTIVE_STEP_SMOOTHING` enabled the silent error becomes obvious by freezing the board.

### Related Issues

A comment by @MitchelBerberich on #15865