### PR TITLE
Fix Ender-2 display on SKR mini E3 boards

### DIFF
--- a/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3.h
@@ -144,15 +144,17 @@
      *      (MOSI) PB7  | · · | PB8  (LCD_RS)
      *    (LCD_A0) PB9  | · · | PA10 (BTN_EN2)
      *            RESET | · · | PA9  (BTN_EN1)
-     *   (BTN_ENC) PB6  | · · | PA15 (SCK)
+     *   (BTN_ENC) PB6  | · · | PB5  (SCK)
      *                   -----
      *                    EXP1
      */
     #define BTN_EN1        PA9
     #define BTN_EN2        PA10
+    #define BTN_ENC        PB6
+
     #define DOGLCD_CS      PB8
     #define DOGLCD_A0      PB9
-    #define DOGLCD_SCK     PA15
+    #define DOGLCD_SCK     PB5
     #define DOGLCD_MOSI    PB7
     #define FORCE_SOFT_SPI
     #define LCD_BACKLIGHT_PIN -1


### PR DESCRIPTION
### Description

#15924 added support on the `SKR mini E3` boards for the `Ender 2` display. This PR corrects a minor bug in the pin configuration (using PB5 as[ the `CR10` display pinout specifies](https://github.com/brenca/Marlin/blob/f441fdb5b06c522c234c3a47381a548df28220f0/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3.h#L110)) that caused the screen to remain blank.
This PR also corrects another minor bug introduced by #15931, where the definition of `BTN_ENC` was moved into the `CR10` display's `#if` (was before under `HAS_SPI_LCD`, thus applying to all displays), which we need for the button presses to work properly. I added that pin definition to the `MKS_MINI_12864`, and the button works as expected.

### Benefits

This PR fixes two minor issues with the `Ender 2` screen when hooked up to an `SKR mini E3`.

### Related Issues

#15624
