### PR TITLE
Revert Default BigTreeTech STM32F103 Environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 
   # Extended STM32 Environments
   - TEST_PLATFORM="STM32F103RC_bigtree"
-  - TEST_PLATFORM="STM32F103RC_bigtree_NOUSB"
+  - TEST_PLATFORM="STM32F103RC_bigtree_USB"
   - TEST_PLATFORM="STM32F103RC_fysetc"
   - TEST_PLATFORM="jgaurora_a5s_a1"
   - TEST_PLATFORM="STM32F103VE_longer"

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -470,13 +470,13 @@
 #elif MB(MKS_ROBIN_LITE)
   #include "stm32/pins_MKS_ROBIN_LITE.h"        // STM32F1                                env:mks_robin_lite
 #elif MB(BIGTREE_SKR_MINI_V1_1)
-  #include "stm32/pins_BTT_SKR_MINI_V1_1.h"     // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_NOUSB env:STM32F103RC_bigtree_512K_NOUSB
+  #include "stm32/pins_BTT_SKR_MINI_V1_1.h"     // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_USB env:STM32F103RC_bigtree_512K_USB
 #elif MB(BTT_SKR_MINI_E3_V1_0)
-  #include "stm32/pins_BTT_SKR_MINI_E3_V1_0.h"  // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_NOUSB env:STM32F103RC_bigtree_512K_NOUSB
+  #include "stm32/pins_BTT_SKR_MINI_E3_V1_0.h"  // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_USB env:STM32F103RC_bigtree_512K_USB
 #elif MB(BTT_SKR_MINI_E3_V1_2)
-  #include "stm32/pins_BTT_SKR_MINI_E3_V1_2.h"  // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_NOUSB env:STM32F103RC_bigtree_512K_NOUSB
+  #include "stm32/pins_BTT_SKR_MINI_E3_V1_2.h"  // STM32F1                                env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_USB env:STM32F103RC_bigtree_512K_USB
 #elif MB(BIGTREE_SKR_E3_DIP)
-  #include "stm32/pins_BTT_SKR_E3_DIP.h"        // STM32F1                                env:STM32F103RE_bigtree env:STM32F103RE_bigtree_NOUSB env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_NOUSB env:STM32F103RC_bigtree_512K_NOUSB
+  #include "stm32/pins_BTT_SKR_E3_DIP.h"        // STM32F1                                env:STM32F103RE_bigtree env:STM32F103RE_bigtree_USB env:STM32F103RC_bigtree env:STM32F103RC_bigtree_512K env:STM32F103RC_bigtree_USB env:STM32F103RC_bigtree_512K_USB
 #elif MB(JGAURORA_A5S_A1)
   #include "stm32/pins_JGAURORA_A5S_A1.h"       // STM32F1                                env:jgaurora_a5s_a1
 #elif MB(FYSETC_AIO_II)

--- a/buildroot/share/atom/auto_build.py
+++ b/buildroot/share/atom/auto_build.py
@@ -609,9 +609,9 @@ def get_env(board_name, ver_Marlin):
         get_answer(board_name, 'RCT6 Flash Size?', '512K', '256K')
         if 1 == get_answer_val:
           target_env += '_512K'
-      get_answer(board_name, 'USB Support?', 'No USB', 'USB')
+      get_answer(board_name, 'USB Support?', 'USB', 'No USB')
       if 1 == get_answer_val:
-        target_env += '_NOUSB'
+        target_env += '_USB'
     else:
       invalid_board()
 

--- a/buildroot/share/tests/STM32F103RC_bigtree-tests
+++ b/buildroot/share/tests/STM32F103RC_bigtree-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Build tests for STM32F103RC Bigtreetech (SKR Mini v1.1)
+# Build tests for STM32F103RC Bigtreetech (SKR Mini E3)
 #
 
 # exit on first failure
@@ -10,10 +10,10 @@ set -e
 # Build with the default configurations
 #
 restore_configs
-opt_set MOTHERBOARD BOARD_BIGTREE_SKR_MINI_V1_1
+opt_set MOTHERBOARD BOARD_BTT_SKR_MINI_E3_V1_0
 opt_set SERIAL_PORT 1
 opt_set SERIAL_PORT_2 -1
-exec_test $1 $2 "Bigtreetech SKR Mini v1.1 - Basic Configuration"
+exec_test $1 $2 "Bigtreetech SKR Mini E3 - Basic Configuration"
 
 # clean up
 restore_configs

--- a/buildroot/share/tests/STM32F103RC_bigtree_USB-tests
+++ b/buildroot/share/tests/STM32F103RC_bigtree_USB-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Build tests for STM32F103RC Bigtreetech (SKR Mini E3)
+# Build tests for STM32F103RC Bigtreetech (SKR Mini v1.1)
 #
 
 # exit on first failure
@@ -10,10 +10,10 @@ set -e
 # Build with the default configurations
 #
 restore_configs
-opt_set MOTHERBOARD BOARD_BTT_SKR_MINI_E3_V1_0
+opt_set MOTHERBOARD BOARD_BIGTREE_SKR_MINI_V1_1
 opt_set SERIAL_PORT 1
 opt_set SERIAL_PORT_2 -1
-exec_test $1 $2 "Bigtreetech SKR Mini E3 - Basic Configuration"
+exec_test $1 $2 "Bigtreetech SKR Mini v1.1 - Basic Configuration"
 
 # clean up
 restore_configs

--- a/platformio.ini
+++ b/platformio.ini
@@ -309,7 +309,7 @@ board             = genericSTM32F103RC
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=256
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -279,12 +279,12 @@ upload_protocol   = serial
 #
 # BigTree SKR Mini V1.1 / SKR mini E3 / SKR E3 DIP (STM32F103RCT6 ARM Cortex-M3)
 #
-#   STM32F103RC_bigtree .............. RCT6 with 256K
-#   STM32F103RC_bigtree_NOUSB ........ RCT6 with 256K (no USB)
-#   STM32F103RC_bigtree_512K.......... RCT6 with 512K
-#   STM32F103RC_bigtree_512K_NOUSB ... RCT6 with 512K (no USB)
-#   STM32F103RE_bigtree .............. RET6
-#   STM32F103RE_bigtree_NOUSB ........ RET6 (no USB)
+#   STM32F103RC_bigtree ............. RCT6 with 256K
+#   STM32F103RC_bigtree_USB ......... RCT6 with 256K (USB)
+#   STM32F103RC_bigtree_512K ........ RCT6 with 512K
+#   STM32F103RC_bigtree_512K_USB .... RCT6 with 512K (USB)
+#   STM32F103RE_bigtree ............. RET6
+#   STM32F103RE_bigtree_USB ......... RET6 (USB)
 #
 
 [env:STM32F103RC_bigtree]
@@ -294,7 +294,7 @@ board             = genericSTM32F103RC
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=256
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
@@ -302,14 +302,14 @@ lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
-[env:STM32F103RC_bigtree_NOUSB]
+[env:STM32F103RC_bigtree_USB]
 platform          = ststm32
 framework         = arduino
 board             = genericSTM32F103RC
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=256
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
@@ -325,7 +325,7 @@ board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
@@ -333,7 +333,7 @@ lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
-[env:STM32F103RC_bigtree_512K_NOUSB]
+[env:STM32F103RC_bigtree_512K_USB]
 platform          = ststm32
 framework         = arduino
 board             = genericSTM32F103RC
@@ -341,7 +341,7 @@ board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
@@ -357,7 +357,7 @@ board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
@@ -365,7 +365,7 @@ lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
-[env:STM32F103RE_bigtree_NOUSB]
+[env:STM32F103RE_bigtree_USB]
 platform          = ststm32
 framework         = arduino
 board             = genericSTM32F103RE
@@ -373,7 +373,7 @@ board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4
 build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip


### PR DESCRIPTION
### Description

Since the `*_512k` environment ended up not working for everyone, this PR reverts the default behavior of `STM32F103R*_bigtree` to not include USB composite support by default.

### Benefits

Restores default environment behavior and smaller build sizes for users upgrading their old configs.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/15993, PR https://github.com/MarlinFirmware/Marlin/pull/15890