### PR TITLE
Include host_actions.h in G34

### DIFF
--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -52,7 +52,7 @@ void _man_probe_pt(const xy_pos_t &xy) {
   #include "../../gcode/gcode.h"
 
   #if ENABLED(HOST_PROMPT_SUPPORT)
-    #include "../../feature/host_actions.h" // for PROMPT_USER_CONTINUE
+    #include "../../feature/host_actions.h" // for host_prompt_do
   #endif
 
   float lcd_probe_pt(const xy_pos_t &xy) {

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -109,14 +109,14 @@ void lcd_delta_settings() {
   BACK_ITEM(MSG_DELTA_CALIBRATE);
   EDIT_ITEM(float52sign, MSG_DELTA_HEIGHT, &delta_height, delta_height - 10, delta_height + 10, _recalc_delta_settings);
   #define EDIT_ENDSTOP_ADJ(LABEL,N) EDIT_ITEM_P(float43, PSTR(LABEL), &delta_endstop_adj.N, -5, 5, _recalc_delta_settings)
-  EDIT_ENDSTOP_ADJ("Ex",a);
-  EDIT_ENDSTOP_ADJ("Ey",b);
-  EDIT_ENDSTOP_ADJ("Ez",c);
+  EDIT_ENDSTOP_ADJ("Ex", a);
+  EDIT_ENDSTOP_ADJ("Ey", b);
+  EDIT_ENDSTOP_ADJ("Ez", c);
   EDIT_ITEM(float52sign, MSG_DELTA_RADIUS, &delta_radius, delta_radius - 5, delta_radius + 5, _recalc_delta_settings);
   #define EDIT_ANGLE_TRIM(LABEL,N) EDIT_ITEM_P(float43, PSTR(LABEL), &delta_tower_angle_trim.N, -5, 5, _recalc_delta_settings)
-  EDIT_ANGLE_TRIM("Tx",a);
-  EDIT_ANGLE_TRIM("Ty",b);
-  EDIT_ANGLE_TRIM("Tz",c);
+  EDIT_ANGLE_TRIM("Tx", a);
+  EDIT_ANGLE_TRIM("Ty", b);
+  EDIT_ANGLE_TRIM("Tz", c);
   EDIT_ITEM(float52sign, MSG_DELTA_DIAG_ROD, &delta_diagonal_rod, delta_diagonal_rod - 5, delta_diagonal_rod + 5, _recalc_delta_settings);
   END_MENU();
 }

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -51,6 +51,10 @@ void _man_probe_pt(const xy_pos_t &xy) {
 
   #include "../../gcode/gcode.h"
 
+  #if ENABLED(HOST_PROMPT_SUPPORT)
+    #include "../../feature/host_actions.h" // for PROMPT_USER_CONTINUE
+  #endif
+
   float lcd_probe_pt(const xy_pos_t &xy) {
     _man_probe_pt(xy);
     KEEPALIVE_STATE(PAUSED_FOR_USER);


### PR DESCRIPTION
### Description
Adds a conditional include in menu_delta_calibrate.cpp to allow it to compile with HOST_PROMPT_SUPPORT enabled. 

### Benefits

Corrects an issue where compile fails on menu_delta_calibrate.cpp with "PROMPT_USER_CONTINUE not defined" due to a missing include.

