### PR TITLE
E2 pins for GT 2560 v3

### DIFF
--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -112,6 +112,10 @@
 #define E1_DIR_PIN         47
 #define E1_ENABLE_PIN      48
 
+#define E2_STEP_PIN        43
+#define E2_DIR_PIN         45
+#define E2_ENABLE_PIN      41
+
 //
 // Temperature Sensors
 //


### PR DESCRIPTION
Lets try this again.
Add E2 pins to GT2560.