### PR TITLE
Treat ABL mesh boundaries as floats, and do not round probe positions

### DIFF
--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -35,7 +35,7 @@
   #include "../../../lcd/extensible_ui/ui_api.h"
 #endif
 
-xy_int_t bilinear_grid_spacing, bilinear_start;
+xy_float_t bilinear_grid_spacing, bilinear_start;
 xy_float_t bilinear_grid_factor;
 bed_mesh_t z_values;
 

--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -35,7 +35,7 @@
   #include "../../../lcd/extensible_ui/ui_api.h"
 #endif
 
-xy_float_t bilinear_grid_spacing, bilinear_start;
+xy_pos_t bilinear_grid_spacing, bilinear_start;
 xy_float_t bilinear_grid_factor;
 bed_mesh_t z_values;
 
@@ -153,7 +153,7 @@ void print_bilinear_leveling_grid() {
   #define ABL_TEMP_POINTS_X (GRID_MAX_POINTS_X + 2)
   #define ABL_TEMP_POINTS_Y (GRID_MAX_POINTS_Y + 2)
   float z_values_virt[ABL_GRID_POINTS_VIRT_X][ABL_GRID_POINTS_VIRT_Y];
-  xy_float_t bilinear_grid_spacing_virt;
+  xy_pos_t bilinear_grid_spacing_virt;
   xy_float_t bilinear_grid_factor_virt;
 
   void print_bilinear_leveling_grid_virt() {

--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -153,7 +153,7 @@ void print_bilinear_leveling_grid() {
   #define ABL_TEMP_POINTS_X (GRID_MAX_POINTS_X + 2)
   #define ABL_TEMP_POINTS_Y (GRID_MAX_POINTS_Y + 2)
   float z_values_virt[ABL_GRID_POINTS_VIRT_X][ABL_GRID_POINTS_VIRT_Y];
-  xy_int_t bilinear_grid_spacing_virt;
+  xy_float_t bilinear_grid_spacing_virt;
   xy_float_t bilinear_grid_factor_virt;
 
   void print_bilinear_leveling_grid_virt() {

--- a/Marlin/src/feature/bedlevel/abl/abl.h
+++ b/Marlin/src/feature/bedlevel/abl/abl.h
@@ -23,7 +23,7 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
-extern xy_int_t bilinear_grid_spacing, bilinear_start;
+extern xy_float_t bilinear_grid_spacing, bilinear_start;
 extern xy_float_t bilinear_grid_factor;
 extern bed_mesh_t z_values;
 float bilinear_z_offset(const xy_pos_t &raw);

--- a/Marlin/src/feature/bedlevel/abl/abl.h
+++ b/Marlin/src/feature/bedlevel/abl/abl.h
@@ -23,7 +23,7 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
-extern xy_float_t bilinear_grid_spacing, bilinear_start;
+extern xy_pos_t bilinear_grid_spacing, bilinear_start;
 extern xy_float_t bilinear_grid_factor;
 extern bed_mesh_t z_values;
 float bilinear_z_offset(const xy_pos_t &raw);

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -465,7 +465,7 @@ G29_TYPE GcodeSuite::G29() {
         reset_bed_level();
 
         // Initialize a grid with the given dimensions
-        bilinear_grid_spacing = gridSpacing.asInt();
+        bilinear_grid_spacing = gridSpacing;
         bilinear_start = probe_position_lf;
 
         // Can't re-enable (on error) until the new grid is written
@@ -583,10 +583,7 @@ G29_TYPE GcodeSuite::G29() {
 
         if (zig) PR_INNER_VAR = (PR_INNER_END - 1) - PR_INNER_VAR;
 
-        const xy_pos_t base = probe_position_lf.asFloat() + gridSpacing * meshCount.asFloat();
-
-        probePos.set(FLOOR(base.x + (base.x < 0 ? 0 : 0.5)),
-                     FLOOR(base.y + (base.y < 0 ? 0 : 0.5)));
+        probePos = probe_position_lf + gridSpacing * meshCount.asFloat();
 
         #if ENABLED(AUTO_BED_LEVELING_LINEAR)
           indexIntoAB[meshCount.x][meshCount.y] = abl_probe_index;
@@ -694,10 +691,7 @@ G29_TYPE GcodeSuite::G29() {
         // Inner loop is X with PROBE_Y_FIRST disabled
         for (PR_INNER_VAR = inStart; PR_INNER_VAR != inStop; pt_index++, PR_INNER_VAR += inInc) {
 
-          const xy_pos_t base = probe_position_lf.asFloat() + gridSpacing * meshCount.asFloat();
-
-          probePos.set(FLOOR(base.x + (base.x < 0 ? 0 : 0.5)),
-                       FLOOR(base.y + (base.y < 0 ? 0 : 0.5)));
+          probePos = probe_position_lf + gridSpacing * meshCount.asFloat();
 
           #if ENABLED(AUTO_BED_LEVELING_LINEAR)
             indexIntoAB[meshCount.x][meshCount.y] = ++abl_probe_index; // 0...

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -37,7 +37,7 @@
  */
 
 // Change EEPROM version if the structure changes
-#define EEPROM_VERSION "V73"
+#define EEPROM_VERSION "V74"
 #define EEPROM_OFFSET 100
 
 // Check the integrity of data offsets.
@@ -192,7 +192,7 @@ typedef struct SettingsDataStruct {
   // AUTO_BED_LEVELING_BILINEAR
   //
   uint8_t grid_max_x, grid_max_y;                       // GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y
-  xy_int_t bilinear_grid_spacing, bilinear_start;       // G29 L F
+  xy_float_t bilinear_grid_spacing, bilinear_start;     // G29 L F
   #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
     bed_mesh_t z_values;                                // G29
   #else
@@ -658,7 +658,7 @@ void MarlinSettings::postprocess() {
       #else
         // For disabled Bilinear Grid write an empty 3x3 grid
         const uint8_t grid_max_x = 3, grid_max_y = 3;
-        const xy_int_t bilinear_start{0}, bilinear_grid_spacing{0};
+        const xy_float_t bilinear_start{0}, bilinear_grid_spacing{0};
         dummy = 0;
         EEPROM_WRITE(grid_max_x);
         EEPROM_WRITE(grid_max_y);
@@ -1469,7 +1469,7 @@ void MarlinSettings::postprocess() {
         #endif // AUTO_BED_LEVELING_BILINEAR
           {
             // Skip past disabled (or stale) Bilinear Grid data
-            xy_int_t bgs, bs;
+            xy_float_t bgs, bs;
             EEPROM_READ(bgs);
             EEPROM_READ(bs);
             for (uint16_t q = grid_max_x * grid_max_y; q--;) EEPROM_READ(dummy);

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -192,7 +192,7 @@ typedef struct SettingsDataStruct {
   // AUTO_BED_LEVELING_BILINEAR
   //
   uint8_t grid_max_x, grid_max_y;                       // GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y
-  xy_float_t bilinear_grid_spacing, bilinear_start;     // G29 L F
+  xy_pos_t bilinear_grid_spacing, bilinear_start;       // G29 L F
   #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
     bed_mesh_t z_values;                                // G29
   #else
@@ -658,7 +658,7 @@ void MarlinSettings::postprocess() {
       #else
         // For disabled Bilinear Grid write an empty 3x3 grid
         const uint8_t grid_max_x = 3, grid_max_y = 3;
-        const xy_float_t bilinear_start{0}, bilinear_grid_spacing{0};
+        const xy_pos_t bilinear_start{0}, bilinear_grid_spacing{0};
         dummy = 0;
         EEPROM_WRITE(grid_max_x);
         EEPROM_WRITE(grid_max_y);
@@ -1469,7 +1469,7 @@ void MarlinSettings::postprocess() {
         #endif // AUTO_BED_LEVELING_BILINEAR
           {
             // Skip past disabled (or stale) Bilinear Grid data
-            xy_float_t bgs, bs;
+            xy_pos_t bgs, bs;
             EEPROM_READ(bgs);
             EEPROM_READ(bs);
             for (uint16_t q = grid_max_x * grid_max_y; q--;) EEPROM_READ(dummy);

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -359,7 +359,6 @@ void homeaxis(const AxisEnum axis);
 #if !HAS_BED_PROBE
   FORCE_INLINE bool position_is_reachable_by_probe(const float &rx, const float &ry) { return position_is_reachable(rx, ry); }
 #endif
-FORCE_INLINE bool position_is_reachable_by_probe(const xy_int_t &pos) { return position_is_reachable_by_probe(pos.x, pos.y); }
 FORCE_INLINE bool position_is_reachable_by_probe(const xy_pos_t &pos) { return position_is_reachable_by_probe(pos.x, pos.y); }
 
 /**


### PR DESCRIPTION
### Description

ABL mesh calculation was still using some integer types, including rounding probe locations away from zero. This caused problems for non-integer probe offsets, causing probing to terminate early.

### Benefits

ABL G29 completes the mesh.

### Related Issues

#16000 
