### PR TITLE
Increase display timings for FYSETC S6

### DIFF
--- a/Marlin/src/pins/stm32/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32/pins_FYSETC_S6.h
@@ -214,9 +214,9 @@
 
 // Alter timing for graphical display
 #if HAS_GRAPHICAL_LCD
-  #define BOARD_ST7920_DELAY_1 DELAY_NS(96)
-  #define BOARD_ST7920_DELAY_2 DELAY_NS(48)
-  #define BOARD_ST7920_DELAY_3 DELAY_NS(600)
+  #define BOARD_ST7920_DELAY_1 DELAY_NS(103)
+  #define BOARD_ST7920_DELAY_2 DELAY_NS(51)
+  #define BOARD_ST7920_DELAY_3 DELAY_NS(642)
 #endif
 
 #ifndef RGB_LED_R_PIN

--- a/Marlin/src/pins/stm32/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32/pins_FYSETC_S6.h
@@ -95,7 +95,6 @@
 #if HAS_TMC220x
   /**
    * TMC2208/TMC2209 stepper drivers
-   *
    */
 
   //
@@ -214,9 +213,15 @@
 
 // Alter timing for graphical display
 #if HAS_GRAPHICAL_LCD
-  #define BOARD_ST7920_DELAY_1 DELAY_NS(103)
-  #define BOARD_ST7920_DELAY_2 DELAY_NS(51)
-  #define BOARD_ST7920_DELAY_3 DELAY_NS(642)
+  #ifndef BOARD_ST7920_DELAY_1
+    #define BOARD_ST7920_DELAY_1 DELAY_NS(103)
+  #endif
+  #ifndef BOARD_ST7920_DELAY_2
+    #define BOARD_ST7920_DELAY_2 DELAY_NS(51)
+  #endif
+  #ifndef BOARD_ST7920_DELAY_3
+    #define BOARD_ST7920_DELAY_3 DELAY_NS(642)
+  #endif
 #endif
 
 #ifndef RGB_LED_R_PIN
@@ -231,4 +236,3 @@
 #ifndef RGB_LED_W_PIN
   #define RGB_LED_W_PIN    -1
 #endif
-


### PR DESCRIPTION
RRD Full Graphic Smart Controller had display problems with the existing timings.

The old timings were pulled straight from the SKR Pro, which has a slightly slower processor. I scaled those values by the ratio of the two processor speeds and the display is now clean.

They could _probably_ be tuned tighter, but the few attempts I made to reduce these caused display problems to return.