### PR TITLE
Add 'M114 E' to get E stepper position (M114_DETAIL)

### DIFF
--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -189,6 +189,10 @@ void GcodeSuite::M114() {
       return;
     }
   #endif
+  if (parser.seen('E')) {
+    SERIAL_ECHOLNPAIR("Count E:", stepper.position(E_AXIS));
+    return;
+  }
 
   planner.synchronize();
   report_current_position();

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -188,11 +188,11 @@ void GcodeSuite::M114() {
       report_current_position_detail();
       return;
     }
+    if (parser.seen('E')) {
+      SERIAL_ECHOLNPAIR("Count E:", stepper.position(E_AXIS));
+      return;
+    }
   #endif
-  if (parser.seen('E')) {
-    SERIAL_ECHOLNPAIR("Count E:", stepper.position(E_AXIS));
-    return;
-  }
 
   planner.synchronize();
   report_current_position();


### PR DESCRIPTION
# Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
 - Add command to get the pulse count of extruder in real time

### Benefits

<!-- What does this fix or improve? -->
- When using touch screen for printing, the touch screen can get the actual position of the extruder in real time, and then detect the encoder filament sensor to determine whether the filament is extruded normally
