### PR TITLE
Simplify platformio.ini with 'extends', default 'env'

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,9 @@ lib_deps =
 # Globally defined properties
 # inherited by all environments
 [env]
-framework = arduino
+framework   = arduino
+build_flags = ${common.build_flags}
+lib_deps    = ${common.lib_deps}
 
 #################################
 #                               #
@@ -57,7 +59,6 @@ framework = arduino
 [env:megaatmega2560]
 platform          = atmelavr
 board             = megaatmega2560
-build_flags       = ${common.build_flags}
 board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
@@ -91,7 +92,6 @@ board             = fysetc_f6_13
 [env:sanguino_atmega644p]
 platform      = atmelavr
 board         = sanguino_atmega644p
-build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
@@ -118,7 +118,6 @@ upload_speed  = 57600
 #
 [env:melzi_optiboot]
 extends       = env:melzi
-build_flags   = ${common.build_flags}
 upload_speed  = 115200
 
 #
@@ -131,7 +130,6 @@ upload_speed  = 115200
 [env:at90usb1286_cdc]
 platform      = teensy
 board         = at90usb1286
-build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
@@ -155,8 +153,6 @@ extends       = env:at90usb1286_cdc
 [env:DUE]
 platform      = atmelsam
 board         = due
-build_flags   = ${common.build_flags}
-lib_deps      = ${common.lib_deps}
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_DUE>
 monitor_speed = 250000
 
@@ -206,7 +202,6 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -std=gnu++14
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, SPI
 monitor_speed = 250000
 
@@ -306,7 +301,6 @@ build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 platform      = ststm32
 board         = disco_f407vg
 build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F4 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -DHAL_IWDG_MODULE_ENABLED
-lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F7>
 monitor_speed = 250000
@@ -318,7 +312,6 @@ monitor_speed = 250000
 platform      = ststm32
 board         = remram_v1
 build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F7 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -DHAL_IWDG_MODULE_ENABLED
-lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F4>
 monitor_speed = 250000
@@ -333,7 +326,6 @@ build_flags   = ${common.build_flags}
   -DUSBCON -DUSBD_VID=0x0483 '-DUSB_MANUFACTURER="Unknown"' '-DUSB_PRODUCT="ARMED_V1"' -DUSBD_USE_CDC
   -O2 -ffreestanding -fsigned-char -fno-move-loop-invariants -fno-strict-aliasing -std=gnu11 -std=gnu++11
   -IMarlin/src/HAL/HAL_STM32
-lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, SoftwareSerial
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 250000
@@ -425,7 +417,6 @@ lib_ignore    = Adafruit NeoPixel
 platform      = ststm32
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
-lib_deps      = ${common.lib_deps}
 monitor_speed = 250000
 
 #
@@ -506,7 +497,6 @@ lib_ignore    = Adafruit NeoPixel, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMast
 [env:teensy31]
 platform      = teensy
 board         = teensy31
-build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 lib_ignore    = Adafruit NeoPixel
@@ -560,7 +550,6 @@ board         = adafruit_grandcentral_m4
 build_flags   = ${common.build_flags} -std=gnu++17
 extra_scripts = ${common.extra_scripts}
 build_unflags = -std=gnu++11
-lib_deps      = ${common.lib_deps}
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_SAMD51>
 debug_tool    = jlink
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -68,14 +68,58 @@ monitor_speed     = 250000
 # ATmega1280
 #
 [env:megaatmega1280]
-platform          = atmelavr
+extends           = env:megaatmega2560
 board             = megaatmega1280
-build_flags       = ${common.build_flags}
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
+
+#
+# RAMBo
+#
+[env:rambo]
+extends           = env:megaatmega2560
+board             = reprap_rambo
+
+#
+# FYSETC F6 V1.3
+#
+[env:fysetc_f6_13]
+extends           = env:megaatmega2560
+board             = fysetc_f6_13
+
+#
+# Sanguinololu (ATmega644p)
+#
+[env:sanguino_atmega644p]
+platform      = atmelavr
+board         = sanguino_atmega644p
+build_flags   = ${common.build_flags}
+lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-monitor_speed     = 250000
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
+monitor_speed = 250000
+
+#
+# Sanguinololu (ATmega1284p)
+#
+[env:sanguino_atmega1284p]
+extends       = env:sanguino_atmega644p
+board         = sanguino_atmega1284p
+
+#
+# Melzi and clones (ATmega1284p)
+#
+[env:melzi]
+extends       = env:sanguino_atmega1284p
+build_flags   = ${common.build_flags} -fmerge-all-constants
+lib_ignore    = TMCStepper
+upload_speed  = 57600
+
+#
+# Melzi and clones (Optiboot bootloader)
+#
+[env:melzi_optiboot]
+extends       = env:melzi
+build_flags   = ${common.build_flags}
+upload_speed  = 115200
 
 #
 # AT90USB1286 boards using CDC bootloader
@@ -100,13 +144,7 @@ monitor_speed = 250000
 # - ? 5DPRINT ?
 #
 [env:at90usb1286_dfu]
-platform      = teensy
-board         = at90usb1286
-build_flags   = ${common.build_flags}
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-monitor_speed = 250000
+extends       = env:at90usb1286_cdc
 
 #
 # Due (Atmel SAM3X8E ARM Cortex-M3)
@@ -123,23 +161,15 @@ src_filter    = ${common.default_src_filter} +<src/HAL/HAL_DUE>
 monitor_speed = 250000
 
 [env:DUE_USB]
-platform      = atmelsam
+extends       = env:DUE
 board         = dueUSB
-build_flags   = ${common.build_flags}
-lib_deps      = ${common.lib_deps}
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_DUE>
-monitor_speed = 250000
 
 [env:DUE_debug]
 # Used when WATCHDOG_RESET_MANUAL is enabled
-platform      = atmelsam
-board         = due
+extends       = env:DUE
 build_flags   = ${common.build_flags}
   -funwind-tables
   -mpoke-function-name
-lib_deps      = ${common.lib_deps}
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_DUE>
-monitor_speed = 250000
 
 #
 # NXP LPC176x ARM Cortex-M3
@@ -168,106 +198,54 @@ extends           = env:LPC1768
 board             = nxp_lpc1769
 
 #
-# Sanguinololu (ATmega644p)
+# STM32F1 base
 #
-[env:sanguino_atmega644p]
-platform      = atmelavr
-board         = sanguino_atmega644p
-build_flags   = ${common.build_flags}
+[env:STM32F1_base]
+platform      = ststm32
+build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
+  ${common.build_flags} -std=gnu++14
+build_unflags = -std=gnu++11
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
+lib_ignore    = Adafruit NeoPixel, SPI
 monitor_speed = 250000
 
 #
-# Sanguinololu (ATmega1284p)
+# STM32F103RC
 #
-[env:sanguino_atmega1284p]
-platform      = atmelavr
-board         = sanguino_atmega1284p
-build_flags   = ${common.build_flags}
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-monitor_speed = 250000
-
-#
-# Melzi and clones (ATmega1284p)
-#
-[env:melzi]
-platform      = atmelavr
-board         = sanguino_atmega1284p
-build_flags   = ${common.build_flags} -fmerge-all-constants
-upload_speed  = 57600
-lib_deps      = ${common.lib_deps}
-lib_ignore    = TMCStepper
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-monitor_speed = 250000
-
-#
-# Melzi and clones (Optiboot bootloader)
-#
-[env:melzi_optiboot]
-platform      = atmelavr
-board         = sanguino_atmega1284p
-build_flags   = ${common.build_flags}
-upload_speed  = 115200
-lib_deps      = ${common.lib_deps}
-lib_ignore    = TMCStepper
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-monitor_speed = 250000
-
-#
-# RAMBo
-#
-[env:rambo]
-platform          = atmelavr
-board             = reprap_rambo
-build_flags       = ${common.build_flags}
-board_build.f_cpu = 16000000L
+[env:STM32F103RC_base]
+extends           = env:STM32F1_base
+board             = genericSTM32F103RC
+platform_packages = tool-stm32duino
 lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-monitor_speed     = 250000
+  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
+monitor_speed     = 115200
 
 #
 # STM32F103RE
 #
 [env:STM32F103RE]
-platform      = ststm32
-board         = genericSTM32F103RE
-build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
-  -DDEBUG_LEVEL=0
-build_unflags = -std=gnu++11
-lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed = 250000
-debug_tool    = stlink
+extends         = env:STM32F1_base
+board           = genericSTM32F103RE
+build_flags     = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
+  ${common.build_flags} -std=gnu++14 -DDEBUG_LEVEL=0
+src_filter      = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
+debug_tool      = stlink
 upload_protocol = stlink
 
 #
 # STM32F103RC_fysetc
 #
 [env:STM32F103RC_fysetc]
-platform          = ststm32
-board             = genericSTM32F103RC
+extends           = env:STM32F103RC_base
 #board_build.core = maple
-platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
-  -DDEBUG_LEVEL=0 -DHAVE_SW_SERIAL
-build_unflags     = -std=gnu++11
-lib_deps          = ${common.lib_deps}
-  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
+  ${common.build_flags} -std=gnu++14 -DDEBUG_LEVEL=0 -DHAVE_SW_SERIAL
 lib_ldf_mode      = chain
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed     = 250000
 debug_tool        = stlink
 upload_protocol   = serial
+monitor_speed     = 250000
 
 #
 # BigTree SKR Mini V1.1 / SKR mini E3 / SKR E3 DIP (STM32F103RCT6 ARM Cortex-M3)
@@ -281,92 +259,45 @@ upload_protocol   = serial
 #
 
 [env:STM32F103RC_bigtree]
-platform          = ststm32
-board             = genericSTM32F103RC
-platform_packages = tool-stm32duino
+extends           = env:STM32F103RC_base
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
-build_unflags     = -std=gnu++11
-lib_deps          = ${common.lib_deps}
-  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed     = 115200
 
 [env:STM32F103RC_bigtree_USB]
-platform          = ststm32
-board             = genericSTM32F103RC
-platform_packages = tool-stm32duino
-extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
+extends           = env:STM32F103RC_bigtree
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4
-build_unflags     = -std=gnu++11
-lib_deps          = ${common.lib_deps}
-  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed     = 115200
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DUSE_USB_COMPOSITE
 
 [env:STM32F103RC_bigtree_512K]
-platform          = ststm32
-board             = genericSTM32F103RC
+extends           = env:STM32F103RC_bigtree
 board_upload.maximum_size=524288
-platform_packages = tool-stm32duino
-extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512
-build_unflags     = -std=gnu++11
-lib_deps          = ${common.lib_deps}
-  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed     = 115200
 
 [env:STM32F103RC_bigtree_512K_USB]
-platform          = ststm32
-board             = genericSTM32F103RC
+extends           = env:STM32F103RC_bigtree_512K
 board_upload.maximum_size=524288
-platform_packages = tool-stm32duino
-extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512
-build_unflags     = -std=gnu++11
-lib_deps          = ${common.lib_deps}
-  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed     = 115200
+  ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_FLASH_SIZE=512 -DUSE_USB_COMPOSITE
 
 [env:STM32F103RE_bigtree]
-platform          = ststm32
+extends           = env:STM32F1_base
 board             = genericSTM32F103RE
 board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
-build_unflags     = -std=gnu++11
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 monitor_speed     = 115200
 
 [env:STM32F103RE_bigtree_USB]
-platform          = ststm32
-board             = genericSTM32F103RE
-board_upload.maximum_size=524288
-platform_packages = tool-stm32duino
-extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
+extends           = env:STM32F103RE_bigtree
 build_flags       = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -DDEBUG_LEVEL=0 -std=gnu++14 -DUSE_USB_COMPOSITE -DHAVE_SW_SERIAL -DSS_TIMER=4
-build_unflags     = -std=gnu++11
-lib_deps          = ${common.lib_deps}
-  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-lib_ignore        = Adafruit NeoPixel, SPI
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-monitor_speed     = 115200
 
 #
 # STM32F4 with STM32GENERIC
@@ -379,27 +310,6 @@ lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F7>
 monitor_speed = 250000
-
-#
-# FYSETC S6 (STM32F446VET6 ARM Cortex-M4)
-#
-[env:FYSETC_S6]
-platform          = ststm32
-board             = fysetc_s6
-extra_scripts     = buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
-build_flags       = ${common.build_flags}
-  -DTARGET_STM32F4 -std=gnu++14
-  -DVECT_TAB_OFFSET=0x10000
-  -DUSBCON -DUSBD_USE_CDC -DHAL_PCD_MODULE_ENABLED -DUSBD_VID=0x0483 '-DUSB_PRODUCT="FYSETC_S6"'
-build_unflags     = -std=gnu++11
-lib_deps          = ${common.lib_deps}
-lib_ignore        = Arduino-L6470
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
-monitor_speed     = 250000
-platform_packages = tool-stm32duino
-debug_tool        = stlink
-#upload_protocol   = stlink
-upload_protocol   = serial
 
 #
 # STM32F7 with STM32GENERIC
@@ -432,163 +342,58 @@ monitor_speed = 250000
 # Longer 3D board in Alfawise U20 (STM32F103VET6)
 #
 [env:STM32F103VE_longer]
-platform      = ststm32
+extends       = env:STM32F1_base
 board         = genericSTM32F103VE
-monitor_speed = 250000
 extra_scripts = buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -std=gnu++14 -USERIAL_USB
   -DSTM32F1xx -DU20 -DTS_V12
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel, LiquidTWI2, SPI
 
 #
 # MKS Robin (STM32F103ZET6)
 #
 [env:mks_robin]
-platform      = ststm32
+extends       = env:STM32F1_base
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -std=gnu++14 -DSTM32_XL_DENSITY
-build_unflags = -std=gnu++11
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # MKS ROBIN LITE/LITE2 (STM32F103RCT6)
 #
 [env:mks_robin_lite]
-platform      = ststm32
+extends       = env:STM32F1_base
 board         = genericSTM32F103RC
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_lite.py
-build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
-build_unflags = -std=gnu++11
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # MKS Robin Mini (STM32F103VET6)
 #
 [env:mks_robin_mini]
-platform      = ststm32
+extends       = env:STM32F1_base
 board         = genericSTM32F103VE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_mini.py
-build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
-build_unflags = -std=gnu++11
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # MKS Robin Nano (STM32F103VET6)
 #
 [env:mks_robin_nano]
-platform      = ststm32
+extends       = env:STM32F1_base
 board         = genericSTM32F103VE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano.py
-build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
-build_unflags = -std=gnu++11
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # JGAurora A5S A1 (STM32F103ZET6)
 #
 [env:jgaurora_a5s_a1]
-platform      = ststm32
+extends       = env:STM32F1_base
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -DSTM32F1xx -std=gnu++14 -DSTM32_XL_DENSITY
-build_unflags = -std=gnu++11
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI
-monitor_speed = 250000
-
-#
-# STM32F407VET6 with RAMPS-like shield
-# 'Black' STM32F407VET6 board - http://wiki.stm32duino.com/index.php?title=STM32F407
-# Shield - https://github.com/jmz52/Hardware
-#
-[env:STM32F407VE_black]
-platform          = ststm32
-platform_packages = framework-arduinoststm32@>=3.10700.191028
-board             = blackSTM32F407VET6
-extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
-build_flags       = ${common.build_flags}
- -DTARGET_STM32F4 -DARDUINO_BLACK_F407VE
- -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"BLACK_F407VE\"
-  -IMarlin/src/HAL/HAL_STM32
-lib_deps          = ${common.lib_deps}
-lib_ignore        = Adafruit NeoPixel, TMCStepper, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster, SoftwareSerial
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
-monitor_speed     = 250000
-
-#
-# Bigtreetech SKR Pro (STM32F407ZGT6 ARM Cortex-M4)
-#
-[env:BIGTREE_SKR_PRO]
-platform          = ststm32
-platform_packages = framework-arduinoststm32@>=3.10700.191028
-board             = BigTree_SKR_Pro
-extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
-build_flags       = ${common.build_flags}
-  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407ZG\"
-  -DTARGET_STM32F4 -DSTM32F407_5ZX -DVECT_TAB_OFFSET=0x8000
-  -DHAVE_HWSERIAL6
-  -IMarlin/src/HAL/HAL_STM32
-lib_deps          =
-  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  LiquidCrystal
-  TMCStepper@>=0.5.2,<1.0.0
-  Adafruit NeoPixel
-  LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
-  Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip
-lib_ignore        = SoftwareSerial, SoftwareSerialM
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
-monitor_speed     = 250000
-
-#
-# BIGTREE_SKR_BTT002 (STM32F407VET6 ARM Cortex-M4)
-#
-[env:BIGTREE_BTT002]
-platform      = ststm32@5.6.0
-board         = BigTree_Btt002
-extra_scripts = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
-build_flags   = ${common.build_flags}
-  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407VE\"
-  -DTARGET_STM32F4 -DSTM32F407_5VX -DVECT_TAB_OFFSET=0x8000
-  -DHAVE_HWSERIAL2
-  -DHAVE_HWSERIAL3
-  -DPIN_SERIAL2_RX=PD_6
-  -DPIN_SERIAL2_TX=PD_5
-lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
-monitor_speed = 250000
-
-#
-# Teensy 3.1 / 3.2 (ARM Cortex-M4)
-#
-[env:teensy31]
-platform      = teensy
-board         = teensy31
-build_flags   = ${common.build_flags}
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-lib_ignore    = Adafruit NeoPixel
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_TEENSY31_32>
-monitor_speed = 250000
 
 #
 # Malyan M200 (STM32F103CB)
@@ -605,28 +410,116 @@ lib_ignore  = Adafruit NeoPixel, LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-H
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
 #
 [env:chitu_f103]
-platform      = ststm32
+extends       = env:STM32F1_base
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -DSTM32F1xx -std=gnu++14 -DSTM32_XL_DENSITY
 build_unflags = -std=gnu++11 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG= -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel
+
+#
+# STM32 HAL environments
+#
+[env:STM32_hal]
+platform      = ststm32
+build_unflags = -std=gnu++11
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
+lib_deps      = ${common.lib_deps}
+monitor_speed = 250000
+
+#
+# FYSETC S6 (STM32F446VET6 ARM Cortex-M4)
+#
+[env:FYSETC_S6]
+extends           = env:STM32_hal
+board             = fysetc_s6
+extra_scripts     = buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
+build_flags       = ${common.build_flags}
+  -DTARGET_STM32F4 -std=gnu++14
+  -DVECT_TAB_OFFSET=0x10000
+  -DUSBCON -DUSBD_USE_CDC -DHAL_PCD_MODULE_ENABLED -DUSBD_VID=0x0483 '-DUSB_PRODUCT="FYSETC_S6"'
+lib_ignore        = Arduino-L6470
+platform_packages = tool-stm32duino
+debug_tool        = stlink
+#upload_protocol   = stlink
+upload_protocol   = serial
+
+#
+# STM32F407VET6 with RAMPS-like shield
+# 'Black' STM32F407VET6 board - http://wiki.stm32duino.com/index.php?title=STM32F407
+# Shield - https://github.com/jmz52/Hardware
+#
+[env:STM32F407VE_black]
+extends           = env:STM32_hal
+platform_packages = framework-arduinoststm32@>=3.10700.191028
+board             = blackSTM32F407VET6
+extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
+build_flags       = ${common.build_flags}
+ -DTARGET_STM32F4 -DARDUINO_BLACK_F407VE
+ -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"BLACK_F407VE\"
+  -IMarlin/src/HAL/HAL_STM32
+lib_ignore        = Adafruit NeoPixel, TMCStepper, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster, SoftwareSerial
+
+#
+# Bigtreetech SKR Pro (STM32F407ZGT6 ARM Cortex-M4)
+#
+[env:BIGTREE_SKR_PRO]
+extends           = env:STM32_hal
+platform_packages = framework-arduinoststm32@>=3.10700.191028
+board             = BigTree_SKR_Pro
+extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
+build_flags       = ${common.build_flags}
+  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407ZG\"
+  -DTARGET_STM32F4 -DSTM32F407_5ZX -DVECT_TAB_OFFSET=0x8000
+  -DHAVE_HWSERIAL6
+  -IMarlin/src/HAL/HAL_STM32
+lib_deps          =
+  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
+  LiquidCrystal
+  TMCStepper@>=0.5.2,<1.0.0
+  Adafruit NeoPixel
+  LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
+  Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/dev.zip
+lib_ignore        = SoftwareSerial, SoftwareSerialM
+
+#
+# BIGTREE_SKR_BTT002 (STM32F407VET6 ARM Cortex-M4)
+#
+[env:BIGTREE_BTT002]
+extends       = env:STM32_hal
+platform      = ststm32@5.6.0
+board         = BigTree_Btt002
+extra_scripts = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
+build_flags   = ${common.build_flags}
+  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407VE\"
+  -DTARGET_STM32F4 -DSTM32F407_5VX -DVECT_TAB_OFFSET=0x8000
+  -DHAVE_HWSERIAL2
+  -DHAVE_HWSERIAL3
+  -DPIN_SERIAL2_RX=PD_6
+  -DPIN_SERIAL2_TX=PD_5
+lib_ignore    = Adafruit NeoPixel, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster
+
+#
+# Teensy 3.1 / 3.2 (ARM Cortex-M4)
+#
+[env:teensy31]
+platform      = teensy
+board         = teensy31
+build_flags   = ${common.build_flags}
+lib_deps      = ${common.lib_deps}
+  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
+lib_ignore    = Adafruit NeoPixel
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_TEENSY31_32>
+monitor_speed = 250000
 
 #
 # Teensy 3.5 / 3.6 (ARM Cortex-M4)
 #
 [env:teensy35]
-platform      = teensy
+extends       = env:teensy31
 board         = teensy35
-build_flags   = ${common.build_flags}
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-lib_ignore    = Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_TEENSY35_36>
-monitor_speed = 250000
 
 #
 # Espressif ESP32
@@ -642,19 +535,6 @@ lib_deps      =
   ESPAsyncWebServer=https://github.com/me-no-dev/ESPAsyncWebServer/archive/master.zip
 lib_ignore    = LiquidCrystal, LiquidTWI2, SailfishLCD, SailfishRGB_LED
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_ESP32>
-
-#
-# FYSETC F6 V1.3
-#
-[env:fysetc_f6_13]
-platform          = atmelavr
-board             = fysetc_f6_13
-build_flags       = ${common.build_flags}
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-monitor_speed     = 250000
 
 #
 # Native

--- a/platformio.ini
+++ b/platformio.ini
@@ -36,6 +36,11 @@ lib_deps =
   SailfishRGB_LED=https://github.com/mikeshub/SailfishRGB_LED/archive/master.zip
   SlowSoftI2CMaster=https://github.com/mikeshub/SlowSoftI2CMaster/archive/master.zip
 
+# Globally defined properties
+# inherited by all environments
+[env]
+framework = arduino
+
 #################################
 #                               #
 #   Unique Core Architectures   #
@@ -51,7 +56,6 @@ lib_deps =
 #
 [env:megaatmega2560]
 platform          = atmelavr
-framework         = arduino
 board             = megaatmega2560
 build_flags       = ${common.build_flags}
 board_build.f_cpu = 16000000L
@@ -65,7 +69,6 @@ monitor_speed     = 250000
 #
 [env:megaatmega1280]
 platform          = atmelavr
-framework         = arduino
 board             = megaatmega1280
 build_flags       = ${common.build_flags}
 board_build.f_cpu = 16000000L
@@ -83,7 +86,6 @@ monitor_speed     = 250000
 #
 [env:at90usb1286_cdc]
 platform      = teensy
-framework     = arduino
 board         = at90usb1286
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
@@ -99,7 +101,6 @@ monitor_speed = 250000
 #
 [env:at90usb1286_dfu]
 platform      = teensy
-framework     = arduino
 board         = at90usb1286
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
@@ -115,24 +116,23 @@ monitor_speed = 250000
 #
 [env:DUE]
 platform      = atmelsam
-framework     = arduino
 board         = due
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_DUE>
 monitor_speed = 250000
+
 [env:DUE_USB]
 platform      = atmelsam
-framework     = arduino
 board         = dueUSB
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_DUE>
 monitor_speed = 250000
+
 [env:DUE_debug]
 # Used when WATCHDOG_RESET_MANUAL is enabled
 platform      = atmelsam
-framework     = arduino
 board         = due
 build_flags   = ${common.build_flags}
   -funwind-tables
@@ -146,7 +146,6 @@ monitor_speed = 250000
 #
 [env:LPC1768]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.2.zip
-framework         = arduino
 board             = nxp_lpc1768
 build_flags       = -DU8G_HAL_LINKS -IMarlin/src/HAL/HAL_LPC1768/include -IMarlin/src/HAL/HAL_LPC1768/u8g ${common.build_flags}
 # debug options for backtrace
@@ -173,7 +172,6 @@ board             = nxp_lpc1769
 #
 [env:sanguino_atmega644p]
 platform      = atmelavr
-framework     = arduino
 board         = sanguino_atmega644p
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
@@ -186,7 +184,6 @@ monitor_speed = 250000
 #
 [env:sanguino_atmega1284p]
 platform      = atmelavr
-framework     = arduino
 board         = sanguino_atmega1284p
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
@@ -199,7 +196,6 @@ monitor_speed = 250000
 #
 [env:melzi]
 platform      = atmelavr
-framework     = arduino
 board         = sanguino_atmega1284p
 build_flags   = ${common.build_flags} -fmerge-all-constants
 upload_speed  = 57600
@@ -213,7 +209,6 @@ monitor_speed = 250000
 #
 [env:melzi_optiboot]
 platform      = atmelavr
-framework     = arduino
 board         = sanguino_atmega1284p
 build_flags   = ${common.build_flags}
 upload_speed  = 115200
@@ -227,7 +222,6 @@ monitor_speed = 250000
 #
 [env:rambo]
 platform          = atmelavr
-framework         = arduino
 board             = reprap_rambo
 build_flags       = ${common.build_flags}
 board_build.f_cpu = 16000000L
@@ -241,7 +235,6 @@ monitor_speed     = 250000
 #
 [env:STM32F103RE]
 platform      = ststm32
-framework     = arduino
 board         = genericSTM32F103RE
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -std=gnu++14
@@ -259,7 +252,6 @@ upload_protocol = stlink
 #
 [env:STM32F103RC_fysetc]
 platform          = ststm32
-framework         = arduino
 board             = genericSTM32F103RC
 #board_build.core = maple
 platform_packages = tool-stm32duino
@@ -290,7 +282,6 @@ upload_protocol   = serial
 
 [env:STM32F103RC_bigtree]
 platform          = ststm32
-framework         = arduino
 board             = genericSTM32F103RC
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
@@ -305,7 +296,6 @@ monitor_speed     = 115200
 
 [env:STM32F103RC_bigtree_USB]
 platform          = ststm32
-framework         = arduino
 board             = genericSTM32F103RC
 platform_packages = tool-stm32duino
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
@@ -320,7 +310,6 @@ monitor_speed     = 115200
 
 [env:STM32F103RC_bigtree_512K]
 platform          = ststm32
-framework         = arduino
 board             = genericSTM32F103RC
 board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
@@ -336,7 +325,6 @@ monitor_speed     = 115200
 
 [env:STM32F103RC_bigtree_512K_USB]
 platform          = ststm32
-framework         = arduino
 board             = genericSTM32F103RC
 board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
@@ -352,7 +340,6 @@ monitor_speed     = 115200
 
 [env:STM32F103RE_bigtree]
 platform          = ststm32
-framework         = arduino
 board             = genericSTM32F103RE
 board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
@@ -368,7 +355,6 @@ monitor_speed     = 115200
 
 [env:STM32F103RE_bigtree_USB]
 platform          = ststm32
-framework         = arduino
 board             = genericSTM32F103RE
 board_upload.maximum_size=524288
 platform_packages = tool-stm32duino
@@ -387,7 +373,6 @@ monitor_speed     = 115200
 #
 [env:STM32F4]
 platform      = ststm32
-framework     = arduino
 board         = disco_f407vg
 build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F4 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -DHAL_IWDG_MODULE_ENABLED
 lib_deps      = ${common.lib_deps}
@@ -400,7 +385,6 @@ monitor_speed = 250000
 #
 [env:FYSETC_S6]
 platform          = ststm32
-framework         = arduino
 board             = fysetc_s6
 extra_scripts     = buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
 build_flags       = ${common.build_flags}
@@ -422,7 +406,6 @@ upload_protocol   = serial
 #
 [env:STM32F7]
 platform      = ststm32
-framework     = arduino
 board         = remram_v1
 build_flags   = ${common.build_flags} -DUSE_STM32GENERIC -DSTM32GENERIC -DSTM32F7 -DMENU_USB_SERIAL -DMENU_SERIAL=SerialUSB -DHAL_IWDG_MODULE_ENABLED
 lib_deps      = ${common.lib_deps}
@@ -435,7 +418,6 @@ monitor_speed = 250000
 #
 [env:ARMED]
 platform      = ststm32
-framework     = arduino
 board         = armed_v1
 build_flags   = ${common.build_flags}
   -DUSBCON -DUSBD_VID=0x0483 '-DUSB_MANUFACTURER="Unknown"' '-DUSB_PRODUCT="ARMED_V1"' -DUSBD_USE_CDC
@@ -451,7 +433,6 @@ monitor_speed = 250000
 #
 [env:STM32F103VE_longer]
 platform      = ststm32
-framework     = arduino
 board         = genericSTM32F103VE
 monitor_speed = 250000
 extra_scripts = buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
@@ -468,7 +449,6 @@ lib_ignore    = Adafruit NeoPixel, LiquidTWI2, SPI
 #
 [env:mks_robin]
 platform      = ststm32
-framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
@@ -483,7 +463,6 @@ lib_ignore    = Adafruit NeoPixel, SPI
 #
 [env:mks_robin_lite]
 platform      = ststm32
-framework     = arduino
 board         = genericSTM32F103RC
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_lite.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
@@ -498,7 +477,6 @@ lib_ignore    = Adafruit NeoPixel, SPI
 #
 [env:mks_robin_mini]
 platform      = ststm32
-framework     = arduino
 board         = genericSTM32F103VE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_mini.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
@@ -513,7 +491,6 @@ lib_ignore    = Adafruit NeoPixel, SPI
 #
 [env:mks_robin_nano]
 platform      = ststm32
-framework     = arduino
 board         = genericSTM32F103VE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
@@ -528,7 +505,6 @@ lib_ignore    = Adafruit NeoPixel, SPI
 #
 [env:jgaurora_a5s_a1]
 platform      = ststm32
-framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
@@ -546,7 +522,6 @@ monitor_speed = 250000
 #
 [env:STM32F407VE_black]
 platform          = ststm32
-framework         = arduino
 platform_packages = framework-arduinoststm32@>=3.10700.191028
 board             = blackSTM32F407VET6
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -564,7 +539,6 @@ monitor_speed     = 250000
 #
 [env:BIGTREE_SKR_PRO]
 platform          = ststm32
-framework         = arduino
 platform_packages = framework-arduinoststm32@>=3.10700.191028
 board             = BigTree_SKR_Pro
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -589,7 +563,6 @@ monitor_speed     = 250000
 #
 [env:BIGTREE_BTT002]
 platform      = ststm32@5.6.0
-framework     = arduino
 board         = BigTree_Btt002
 extra_scripts = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 build_flags   = ${common.build_flags}
@@ -609,7 +582,6 @@ monitor_speed = 250000
 #
 [env:teensy31]
 platform      = teensy
-framework     = arduino
 board         = teensy31
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
@@ -623,7 +595,6 @@ monitor_speed = 250000
 #
 [env:STM32F103CB_malyan]
 platform    = ststm32
-framework   = arduino
 board       = malyanM200
 build_flags = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py -DMCU_STM32F103CB -D __STM32F1__=1 -std=c++1y -D MOTHERBOARD="BOARD_MALYAN_M200" -DSERIAL_USB -ffunction-sections -fdata-sections -Wl,--gc-sections
   -DDEBUG_LEVEL=0 -D__MARLIN_FIRMWARE__
@@ -635,7 +606,6 @@ lib_ignore  = Adafruit NeoPixel, LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-H
 #
 [env:chitu_f103]
 platform      = ststm32
-framework     = arduino
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
@@ -650,7 +620,6 @@ lib_ignore    = Adafruit NeoPixel
 #
 [env:teensy35]
 platform      = teensy
-framework     = arduino
 board         = teensy35
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
@@ -665,7 +634,6 @@ monitor_speed = 250000
 [env:esp32]
 platform      = espressif32
 board         = esp32dev
-framework     = arduino
 upload_speed  = 115200
 monitor_speed = 115200
 upload_port   = /dev/ttyUSB0
@@ -680,7 +648,6 @@ src_filter    = ${common.default_src_filter} +<src/HAL/HAL_ESP32>
 #
 [env:fysetc_f6_13]
 platform          = atmelavr
-framework         = arduino
 board             = fysetc_f6_13
 build_flags       = ${common.build_flags}
 board_build.f_cpu = 16000000L
@@ -695,6 +662,7 @@ monitor_speed     = 250000
 #
 [env:linux_native]
 platform        = native
+framework       =
 build_flags     = -D__PLAT_LINUX__ -std=gnu++17 -ggdb -g -lrt -lpthread -D__MARLIN_FIRMWARE__ -Wno-expansion-to-defined
 src_build_flags = -Wall -IMarlin/src/HAL/HAL_LINUX/include
 build_unflags   = -Wall
@@ -709,7 +677,6 @@ src_filter      = ${common.default_src_filter} +<src/HAL/HAL_LINUX>
 [env:SAMD51_grandcentral_m4]
 platform      = atmelsam
 board         = adafruit_grandcentral_m4
-framework     = arduino
 build_flags   = ${common.build_flags} -std=gnu++17
 extra_scripts = ${common.extra_scripts}
 build_unflags = -std=gnu++11
@@ -722,7 +689,6 @@ debug_tool    = jlink
 #
 [env:include_tree]
 platform    = atmelavr
-framework   = arduino
 board       = megaatmega2560
 build_flags = -c -H -std=gnu++11 -Wall -Os -D__MARLIN_FIRMWARE__
 lib_deps    = ${common.lib_deps}


### PR DESCRIPTION
### Requirements
Take advantage of platfomrio's global [env] section to define framwwork=arduino globally.

### Description
1. created `[env] framework=arduino`
2. deleted `[env:...]` `framework=arduino` for all `[env:...]`
3. inserted `framework=` on `[env:linux_native]`, because none was defined before


### Benefits

- Created a global [env] framework= arduino for global inheritance **(+2 lines)**
  - platformio.ini becomes more readable 
- Removed 42 [env:...] framework=arduino statements (-42 lines)
Inserted once framework= for [env:linux_native] (+1 line)
  - platformio.ini is reduced in lines due to using inheritance **(-41 lines)**
 - approach can be extended to other properties also
  - i.e. for src_filter or other not freque3ntly changing properties

### Related Issues

- none
