### PR TITLE
BTT SKR 1.3 pins for Anet Full Graphics LCD

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -169,14 +169,14 @@
 #endif
 
 /**
- *              _____                                             _____
- *          NC | · · | GND                                    5V | · · | GND
- *       RESET | · · | 1.31(SD_DETECT)             (LCD_D7) 1.23 | · · | 1.22 (LCD_D6)
- *  (MOSI)0.18 | · · | 3.25(BTN_EN2)               (LCD_D5) 1.21 | · · | 1.20 (LCD_D4)
- * (SD_SS)0.16 | · · | 3.26(BTN_EN1)               (LCD_RS) 1.19 | · · | 1.18 (LCD_EN)
- *   (SCK)0.15 | · · | 0.17(MISO)                 (BTN_ENC) 0.28 | · · | 1.30 (BEEPER)
- *              -----                                             -----
- *              EXP2                                              EXP1
+ *               _____                                              _____
+ *           NC | · · | GND                                     5V | · · | GND
+ *        RESET | · · | 1.31 (SD_DETECT)             (LCD_D7) 1.23 | · · | 1.22 (LCD_D6)
+ *  (MOSI) 0.18 | · · | 3.25 (BTN_EN2)               (LCD_D5) 1.21 | · · | 1.20 (LCD_D4)
+ * (SD_SS) 0.16 | · · | 3.26 (BTN_EN1)               (LCD_RS) 1.19 | · · | 1.18 (LCD_EN)
+ *   (SCK) 0.15 | · · | 0.17 (MISO)                 (BTN_ENC) 0.28 | · · | 1.30 (BEEPER)
+ *               -----                                              -----
+ *               EXP2                                               EXP1
  */
 #if HAS_SPI_LCD
 
@@ -212,26 +212,24 @@
     #define LCD_PINS_ENABLE P1_21
     #define LCD_PINS_D4    P1_19
 
-    #endif
+  #elif ENABLED(CR10_STOCKDISPLAY)
 
-#else
-
-  #define BTN_ENC          P0_28   // (58) open-drain
-
-  #if ENABLED(CR10_STOCKDISPLAY)
     #define LCD_PINS_RS    P1_22
 
     #define BTN_EN1        P1_18
     #define BTN_EN2        P1_20
+    #define BTN_ENC        P0_28   // (58) open-drain
 
     #define LCD_PINS_ENABLE P1_23
     #define LCD_PINS_D4    P1_21
 
-  #else
+  #else // !CR10_STOCKDISPLAY
+
     #define LCD_PINS_RS    P1_19
 
     #define BTN_EN1        P3_26   // (31) J3-2 & AUX-4
     #define BTN_EN2        P3_25   // (33) J3-4 & AUX-4
+    #define BTN_ENC        P0_28   // (58) open-drain
 
     #define LCD_PINS_ENABLE P1_18
     #define LCD_PINS_D4    P1_20
@@ -284,7 +282,7 @@
 
     #endif // !FYSETC_MINI_12864
 
-  #endif
+  #endif // !CR10_STOCKDISPLAY
 
 #endif // HAS_SPI_LCD
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -181,26 +181,28 @@
 #if HAS_SPI_LCD
 
   #if ENABLED(ANET_FULL_GRAPHICS_LCD)
-    /** Be careful! To use this display you have to do some hardware modifications to the wires and the connectors.
 
-    !!! if you are unsure, you better keep your fingers off this change! Your motherboard may be damaged in some circumstances !!!
+    #error "CAUTION! ANET_FULL_GRAPHICS_LCD requires wiring modifications. See 'pins_BTT_SKR_V1_3.h' for details. Comment out this line to continue."
 
-    1. you have to cut the nose off of the connector "LCD", because you have to install it in the other direction to the SKR 1.3 "EXP1" connector.
-    2. The wire for +5V (Pin2) and the wire for GND (Pin1) at the LCD connector have to be swapped. (Keep in mind, this is the critical Part!)
-    3. The "CLK Signal" (Pin9) at the LCD connector has to be rewired to (Pin7) at the LCD Connector. After the modification (Pin9) has to be open, because on SKR 1.3 Mainboard this pin is open drain
-    4. The reset switch at the Display is wired to (Pin7) at connector "J3" at the display. You only neet a single wire to connect (Pin7) at "J3" from the display to (Pin3) at "EXP2" at the Mainboard.
-
-    Here is the LCD Connector of ANET_FULL_GRAPHICS_LCD before and after the modification.
-
-                   before                                            after
-                   _____                                             _____
-              GND | · · | 5V                                     5V | · · | GND
-               CS | · · | BTN_EN2                                CS | · · | BTN_EN2
-              SID | · · | BTN_EN1                               SID | · · | BTN_EN1
-             open | · · | BTN_ENC                               CLK | · · | BTN_ENC
-              CLK | · · | Beeper                               open | · · | beeper
-                  -----                                             -----
-                   LCD                                               LCD
+   /**
+    * 1. Cut the tab off the LCD connector so it can be plugged into the "EXP1" connector the other way.
+    * 2. Swap the LCD's +5V (Pin2) and GND (Pin1) wires. (This is the critical part!)
+    * 3. Rewire the CLK Signal (LCD Pin9) to LCD Pin7. (LCD Pin9 remains open because this pin is open drain.)
+    * 4. A wire is needed to connect the Reset switch at J3 (LCD Pin7) to EXP2 (Pin3) on the board.
+    *
+    * !!! If you are unsure, ask for help! Your motherboard may be damaged in some circumstances !!!
+    *
+    * The ANET_FULL_GRAPHICS_LCD connector plug:
+    *
+    *                  BEFORE                          AFTER
+    *                  _____                           _____
+    *           GND 1 | · · |  2 5V              5V 1 | · · |  2 GND
+    *            CS 3 | · · |  4 BTN_EN2         CS 3 | · · |  4 BTN_EN2
+    *           SID 5 | · · |  6 BTN_EN1        SID 5 | · · |  6 BTN_EN1
+    *          open 7 | · · |  8 BTN_ENC        CLK 7 | · · |  8 BTN_ENC
+    *           CLK 9 | · · | 10 Beeper        open 9 | · · | 10 Beeper
+    *                  -----                           -----
+    *                   LCD                             LCD
     */
 
     #define LCD_PINS_RS    P1_23

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -179,6 +179,43 @@
  *              EXP2                                              EXP1
  */
 #if HAS_SPI_LCD
+
+  #if ENABLED(ANET_FULL_GRAPHICS_LCD)
+    /** Be careful! To use this display you have to do some hardware modifications to the wires and the connectors.
+
+    !!! if you are unsure, you better keep your fingers off this change! Your motherboard may be damaged in some circumstances !!!
+
+    1. you have to cut the nose off of the connector "LCD", because you have to install it in the other direction to the SKR 1.3 "EXP1" connector.
+    2. The wire for +5V (Pin2) and the wire for GND (Pin1) at the LCD connector have to be swapped. (Keep in mind, this is the critical Part!)
+    3. The "CLK Signal" (Pin9) at the LCD connector has to be rewired to (Pin7) at the LCD Connector. After the modification (Pin9) has to be open, because on SKR 1.3 Mainboard this pin is open drain
+    4. The reset switch at the Display is wired to (Pin7) at connector "J3" at the display. You only neet a single wire to connect (Pin7) at "J3" from the display to (Pin3) at "EXP2" at the Mainboard.
+
+    Here is the LCD Connector of ANET_FULL_GRAPHICS_LCD before and after the modification.
+
+                   before                                            after
+                   _____                                             _____
+              GND | · · | 5V                                     5V | · · | GND
+               CS | · · | BTN_EN2                                CS | · · | BTN_EN2
+              SID | · · | BTN_EN1                               SID | · · | BTN_EN1
+             open | · · | BTN_ENC                               CLK | · · | BTN_ENC
+              CLK | · · | Beeper                               open | · · | beeper
+                  -----                                             -----
+                   LCD                                               LCD
+    */
+
+    #define LCD_PINS_RS    P1_23
+
+    #define BTN_EN1        P1_20
+    #define BTN_EN2        P1_22
+    #define BTN_ENC        P1_18
+
+    #define LCD_PINS_ENABLE P1_21
+    #define LCD_PINS_D4    P1_19
+
+    #endif
+
+#else
+
   #define BTN_ENC          P0_28   // (58) open-drain
 
   #if ENABLED(CR10_STOCKDISPLAY)


### PR DESCRIPTION
### Requirements

I need the Anet Full Graphics LCD working with Bigtreetech SKR1.3 Mainboard

### Description



I insert Pin configuration for use with Anet Full Graphics LCD in "pins_BTT_SKR_V1_3.h
In Configuration.h you only have to select "ANET_FULL_GRAPHICS_LCD" as your Display.

I included also a description for rewiring the connectors.

Also included a safety note/warning.



### Benefits

Simply use your old Anet Full Graphics Display with SKR 1.3 Mainboards

### Related Issues

Function not implementet at the moment.
