### PR TITLE
Fix PSU_POWERUP_DELAY compile error

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -321,27 +321,25 @@
 #endif
 
 /**
- * Power Supply Control
+ * Power Supply
  */
-#if ENABLED(PSU_CONTROL)
-	#ifndef PSU_NAME
-		#if PSU_ACTIVE_HIGH
-      		#define PSU_NAME "XBox"     // X-Box 360 (203W)
-    	#else
-      	  	#define PSU_NAME "ATX"      // ATX style
-		#endif // PSU_NAME
-	#endif
+#ifndef PSU_NAME
+  #if DISABLED(PSU_CONTROL)
+    #define PSU_NAME "Generic"  // No control
+  #elif PSU_ACTIVE_HIGH
+    #define PSU_NAME "XBox"     // X-Box 360 (203W)
+  #else
+    #define PSU_NAME "ATX"      // ATX style
+  #endif
+#endif
 
-	#if DISABLED(AUTO_POWER_CONTROL)
-      #ifndef PSU_POWERUP_DELAY
-        #define PSU_POWERUP_DELAY 100
-      #endif
-    #elif defined(PSU_POWERUP_DELAY)
-      #error "PSU_POWERUP_DELAY has no effect if AUTO_POWER_CONTROL is enabled."
+#if ENABLED(PSU_CONTROL)
+  #if DISABLED(AUTO_POWER_CONTROL)
+    #ifndef PSU_POWERUP_DELAY
+      #define PSU_POWERUP_DELAY 100
     #endif
-#else
-	#ifndef PSU_NAME
-		#define PSU_NAME "Generic"    // No control
+  #elif defined(PSU_POWERUP_DELAY)
+    #error "PSU_POWERUP_DELAY has no effect if AUTO_POWER_CONTROL is enabled."
   #endif
 #endif
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -333,14 +333,8 @@
   #endif
 #endif
 
-#if ENABLED(PSU_CONTROL)
-  #if DISABLED(AUTO_POWER_CONTROL)
-    #ifndef PSU_POWERUP_DELAY
-      #define PSU_POWERUP_DELAY 100
-    #endif
-  #elif defined(PSU_POWERUP_DELAY)
-    #error "PSU_POWERUP_DELAY has no effect if AUTO_POWER_CONTROL is enabled."
-  #endif
+#if !defined(PSU_POWERUP_DELAY) && ENABLED(PSU_CONTROL) && DISABLED(AUTO_POWER_CONTROL)
+  #define PSU_POWERUP_DELAY 100
 #endif
 
 /**

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -323,22 +323,25 @@
 /**
  * Power Supply Control
  */
-#ifndef PSU_NAME
-  #if ENABLED(PSU_CONTROL)
-    #if PSU_ACTIVE_HIGH
-      #define PSU_NAME "XBox"     // X-Box 360 (203W)
-    #else
-      #define PSU_NAME "ATX"      // ATX style
-    #endif
-    #if DISABLED(AUTO_POWER_CONTROL)
+#if ENABLED(PSU_CONTROL)
+	#ifndef PSU_NAME
+		#if PSU_ACTIVE_HIGH
+      		#define PSU_NAME "XBox"     // X-Box 360 (203W)
+    	#else
+      	  	#define PSU_NAME "ATX"      // ATX style
+		#endif // PSU_NAME
+	#endif
+
+	#if DISABLED(AUTO_POWER_CONTROL)
       #ifndef PSU_POWERUP_DELAY
         #define PSU_POWERUP_DELAY 100
       #endif
     #elif defined(PSU_POWERUP_DELAY)
       #error "PSU_POWERUP_DELAY has no effect if AUTO_POWER_CONTROL is enabled."
     #endif
-  #else
-    #define PSU_NAME "Generic"    // No control
+#else
+	#ifndef PSU_NAME
+		#define PSU_NAME "Generic"    // No control
   #endif
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1605,7 +1605,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 /**
  * LED Backlight Timeout
  */
-#if defined(LED_BACKLIGHT_TIMEOUT) && !(EITHER(FYSETC_MINI_12864_2_0, FYSETC_MINI_12864_2_1) && ENABLED(PSU_CONTROL))
+#if defined(LED_BACKLIGHT_TIMEOUT) && !(ENABLED(PSU_CONTROL) && EITHER(FYSETC_MINI_12864_2_0, FYSETC_MINI_12864_2_1))
   #error "LED_BACKLIGHT_TIMEOUT requires a FYSETC Mini Panel and a Power Switch."
 #endif
 
@@ -2486,6 +2486,8 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
     #error "PSU_CONTROL requires PSU_ACTIVE_HIGH to be defined as 'true' or 'false'."
   #elif !PIN_EXISTS(PS_ON)
     #error "PSU_CONTROL requires PS_ON_PIN."
+  #elif defined(PSU_POWERUP_DELAY) && ENABLED(AUTO_POWER_CONTROL)
+    #error "PSU_POWERUP_DELAY has no effect with AUTO_POWER_CONTROL enabled."
   #endif
 #elif ENABLED(AUTO_POWER_CONTROL)
   #error "AUTO_POWER_CONTROL requires PSU_CONTROL."


### PR DESCRIPTION
Fixes a compile error if `PSU_NAME` is defined and `PSU_POWERUP_DELAY` is not.