### PR TITLE
Use PSU powerup delay for all powerups

### DIFF
--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -109,7 +109,7 @@ void Power::power_on() {
     PSU_PIN_ON();
 
     #if HAS_TRINAMIC
-      delay(100); // Wait for power to settle
+      delay(PSU_POWERUP_DELAY); // Wait for power to settle
       restore_stepper_drivers();
     #endif
   }

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -333,7 +333,7 @@
   #endif
 #endif
 
-#if !defined(PSU_POWERUP_DELAY) && ENABLED(PSU_CONTROL) && DISABLED(AUTO_POWER_CONTROL)
+#if !defined(PSU_POWERUP_DELAY) && ENABLED(PSU_CONTROL)
   #define PSU_POWERUP_DELAY 100
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2486,8 +2486,6 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
     #error "PSU_CONTROL requires PSU_ACTIVE_HIGH to be defined as 'true' or 'false'."
   #elif !PIN_EXISTS(PS_ON)
     #error "PSU_CONTROL requires PS_ON_PIN."
-  #elif defined(PSU_POWERUP_DELAY) && ENABLED(AUTO_POWER_CONTROL)
-    #error "PSU_POWERUP_DELAY has no effect with AUTO_POWER_CONTROL enabled."
   #endif
 #elif ENABLED(AUTO_POWER_CONTROL)
   #error "AUTO_POWER_CONTROL requires PSU_CONTROL."


### PR DESCRIPTION

### Description
Apply configurable power on delay to auto power control.
### Benefits
Allows configuring the power on delay when auto power control is enabled. Completes #16050.

