### PR TITLE
Add missing semicolons to tmc_util.cpp

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Report a bug in Marlin
+title: "[BUG] (short description)"
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+Have you read Marlin's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/MarlinFirmware/Marlin/blob/master/.github/code_of_conduct.md
+
+Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use one of the support links at https://github.com/MarlinFirmware/Marlin/issues/new/choose
+
+Before filing an issue be sure to test the "bugfix" branches to see whether the issue has been resolved.
+
+-->
+
+### Bug Description
+
+<!-- Description of the bug -->
+
+### My Configurations
+
+**Required:** Please include a ZIP file containing your `Configuration.h` and `Configuration_adv.h` files.
+
+### Steps to Reproduce
+
+<!-- Please describe the steps needed to reproduce the issue -->
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+#### Additional Information
+
+* Provide pictures or links to videos that clearly demonstrate the issue.
+* See [How Can I Contribute](#how-can-i-contribute) for additional guidelines.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Marlin Documentation
+    url: http://marlinfw.org/
+    about: Lots of documentation on installing and using Marlin.
+  - name: MarlinFirmware Facebook group
+    url: https://www.facebook.com/groups/1049718498464482
+    about: Please ask and answer questions here.
+  - name: Marlin on Discord
+    url: https://discord.gg/n5NJ59y
+    about: Join the Discord server for support and discussion.
+  - name: Marlin Discussion Forum
+    url: http://forums.reprap.org/list.php?415
+    about: A searchable web forum hosted by RepRap dot org.
+  - name: Marlin Videos on YouTube
+    url: https://www.youtube.com/results?search_query=marlin+firmware
+    about: Tutorials and more from Marlin users all around the world. Great for new users!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Request a Feature
+title: "[FR] (feature request title)"
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+Have you read Marlin's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/MarlinFirmware/Marlin/blob/master/.github/code_of_conduct.md
+
+Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use one of the support links at https://github.com/MarlinFirmware/Marlin/issues/new/choose
+
+Before filing an issue be sure to test the "bugfix" branches to see whether the issue has been resolved.
+
+-->
+
+### Description
+
+<!-- Description of the requested feature -->
+
+### Feature Workflow
+
+<!-- Please describe the feature's behavior, user interaction, etc. -->
+
+1. [First Action]
+2. [Second Action]
+3. [and so on...]
+
+#### Additional Information
+
+* Provide pictures or links that demonstrate a similar feature or concept.
+* See [How Can I Contribute](#how-can-i-contribute) for additional guidelines.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,31 +1,16 @@
-<!--
+# NO SUPPORT REQUESTS PLEASE
 
-Have you read Marlin's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.0.x/.github/code_of_conduct.md
+Support Requests posted here will be automatically closed!
 
-Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use the Marlin Firmware forum at http://forums.reprap.org/list.php?415 or the Marlin Facebook Group https://www.facebook.com/groups/1049718498464482/ or the Marlin Discord Server https://discord.gg/n5NJ59y.
+This Issue Queue is for Marlin bug reports and development-related issues, and we prefer not to handle user-support questions here. See https://github.com/MarlinFirmware/Marlin/blob/1.1.x/.github/contributing.md#i-dont-want-to-read-this-whole-thing-i-just-have-a-question.
 
-Before filing an issue be sure to test the 1.1 and/or 2.0 "bugfix" branches to see whether the issue is already addressed.
+For best results getting help with configuration and troubleshooting, please use the following resources:
 
--->
+- RepRap.org Marlin Forum http://forums.reprap.org/list.php?415
+- Tom's 3D Forums https://discuss.toms3d.org/
+- Facebook Group "Marlin Firmware" https://www.facebook.com/groups/1049718498464482/
+- Facebook Group "Marlin Firmware for 3D Printers" https://www.facebook.com/groups/3Dtechtalk/
+- Marlin Configuration https://www.youtube.com/results?search_query=marlin+configuration on YouTube
+- Marlin Discord server. Join link: https://discord.gg/n5NJ59y
 
-### Description
-
-<!-- Description of the bug or requested feature -->
-
-### Steps to Reproduce
-
-<!-- If this is a Bug Report, please describe the steps needed to reproduce the issue -->
-
-1. [First Step]
-2. [Second Step]
-3. [and so on...]
-
-**Expected behavior:** [What you expect to happen]
-
-**Actual behavior:** [What actually happens]
-
-#### Additional Information
-
-* Include a ZIP file containing your `Configuration.h` and `Configuration_adv.h` files.
-* Provide pictures or links to videos that clearly demonstrate the issue.
-* See [How Can I Contribute](#how-can-i-contribute) for additional guidelines.
+After seeking help from the community, if the consensus points to to a bug in Marlin, then you should post a Bug Report at https://github.com/MarlinFirmware/Marlin/issues/new/choose).

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -349,58 +349,58 @@
       #if AXIS_IS_TMC(X)
         if (monitor_tmc_driver(stepperX, need_update_error_counters, need_debug_reporting)) {
           #if AXIS_IS_TMC(X2)
-            step_current_down(stepperX2)
+            step_current_down(stepperX2);
           #endif
         }
       #endif
       #if AXIS_IS_TMC(X2)
         if (monitor_tmc_driver(stepperX2, need_update_error_counters, need_debug_reporting)) {
           #if AXIS_IS_TMC(X)
-            step_current_down(stepperX)
+            step_current_down(stepperX);
           #endif
         }
       #endif
       #if AXIS_IS_TMC(Y)
         if (monitor_tmc_driver(stepperY, need_update_error_counters, need_debug_reporting)) {
           #if AXIS_IS_TMC(Y2)
-            step_current_down(stepperY2)
+            step_current_down(stepperY2);
           #endif
         }
       #endif
       #if AXIS_IS_TMC(Y2)
         if (monitor_tmc_driver(stepperY2, need_update_error_counters, need_debug_reporting)) {
           #if AXIS_IS_TMC(Y)
-            step_current_down(stepperY)
+            step_current_down(stepperY);
           #endif
         }
       #endif
       #if AXIS_IS_TMC(Z)
         if (monitor_tmc_driver(stepperZ, need_update_error_counters, need_debug_reporting)) {
           #if AXIS_IS_TMC(Z2)
-            step_current_down(stepperZ2)
+            step_current_down(stepperZ2);
           #endif
           #if AXIS_IS_TMC(Z3)
-            step_current_down(stepperZ3)
+            step_current_down(stepperZ3);
           #endif
         }
       #endif
       #if AXIS_IS_TMC(Z2)
         if (monitor_tmc_driver(stepperZ2, need_update_error_counters, need_debug_reporting)) {
           #if AXIS_IS_TMC(Z)
-            step_current_down(stepperZ)
+            step_current_down(stepperZ);
           #endif
           #if AXIS_IS_TMC(Z3)
-            step_current_down(stepperZ3)
+            step_current_down(stepperZ3);
           #endif
         }
       #endif
       #if AXIS_IS_TMC(Z3)
         if (monitor_tmc_driver(stepperZ3, need_update_error_counters, need_debug_reporting)) {
           #if AXIS_IS_TMC(Z)
-            step_current_down(stepperZ)
+            step_current_down(stepperZ);
           #endif
           #if AXIS_IS_TMC(Z2)
-            step_current_down(stepperZ2)
+            step_current_down(stepperZ2);
           #endif
         }
       #endif

--- a/README.md
+++ b/README.md
@@ -1,74 +1,71 @@
 ﻿# Marlin 3D Printer Firmware
 
-[![Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg?branch=bugfix-2.0.x)](https://travis-ci.org/MarlinFirmware/Marlin)
+[![Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg?branch=2.0.x)](https://travis-ci.org/MarlinFirmware/Marlin)
 ![GitHub](https://img.shields.io/github/license/marlinfirmware/marlin.svg)
 ![GitHub contributors](https://img.shields.io/github/contributors/marlinfirmware/marlin.svg)
 ![GitHub Release Date](https://img.shields.io/github/release-date/marlinfirmware/marlin.svg)
 
-<img align="top" width=175 src="buildroot/share/pixmaps/logo/marlin-250.png" />
+<img align="right" width=175 src="buildroot/share/pixmaps/logo/marlin-250.png" />
 
 Additional documentation can be found at the [Marlin Home Page](http://marlinfw.org/).
-Please test this firmware and let us know if it misbehaves in any way. Volunteers are standing by!
+Please let us know if Marlin misbehaves in any way. Volunteers are standing by!
 
-## Marlin 2.0 Bugfix Branch
-
-__Not for production use. Use with caution!__
+## Marlin 2.0
 
 Marlin 2.0 takes this popular RepRap firmware to the next level by adding support for much faster 32-bit and ARM-based boards while improving support for 8-bit AVR boards. Read about Marlin's decision to use a "Hardware Abstraction Layer" below.
-
-This branch is for patches to the latest 2.0.x release version. Periodically this branch will form the basis for the next minor 2.0.x release.
 
 Download earlier versions of Marlin on the [Releases page](https://github.com/MarlinFirmware/Marlin/releases).
 
 ## Building Marlin 2.0
 
-To build Marlin 2.0 you'll need [Arduino IDE 1.8.8 or newer](https://www.arduino.cc/en/main/software) or [PlatformIO](http://docs.platformio.org/en/latest/ide.html#platformio-ide). We've posted detailed instructions on [Building Marlin with Arduino](http://marlinfw.org/docs/basics/install_arduino.html) and [Building Marlin with PlatformIO for ReArm](http://marlinfw.org/docs/basics/install_rearm.html) (which applies well to other 32-bit boards).
+To build Marlin 2.0 you'll need [Arduino IDE 1.8.8 or newer](https://www.arduino.cc/en/main/software) or [PlatformIO](http://docs.platformio.org/en/latest/ide.html#platformio-ide). Detailed build and install instructions are posted at:
 
-## Hardware Abstraction Layer (HAL)
+  - [Installing Marlin (Arduino)](http://marlinfw.org/docs/basics/install_arduino.html)
+  - [Installing Marlin (VSCode)](http://marlinfw.org/docs/basics/install_platformio_vscode.html).
 
-Marlin 2.0 introduces a layer of abstraction so that all the existing high-level code can be built for 32-bit platforms while still retaining full 8-bit AVR compatibility. Retaining AVR compatibility and a single code-base is important to us, because we want to make sure that features and patches get as much testing and attention as possible, and that all platforms always benefit from the latest improvements.
+### Supported Platforms
 
-### Current HALs
+  Platform|MCU|Example Boards
+  --------|---|-------
+  [Arduino AVR](https://www.arduino.cc/)|ATmega|RAMPS, Melzi, RAMBo
+  [Teensy++ 2.0](http://www.microchip.com/wwwproducts/en/AT90USB1286)|AT90USB1286|Printrboard
+  [Arduino Due](https://www.arduino.cc/en/Guide/ArduinoDue)|SAM3X8E|RAMPS-FD, RADDS, RAMPS4DUE
+  [LPC1768](http://www.nxp.com/products/microcontrollers-and-processors/arm-based-processors-and-mcus/lpc-cortex-m-mcus/lpc1700-cortex-m3/512kb-flash-64kb-sram-ethernet-usb-lqfp100-package:LPC1768FBD100)|ARM® Cortex-M3|MKS SBASE, Re-ARM, Selena Compact
+  [LPC1769](https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/lpc1700-cortex-m3/512kb-flash-64kb-sram-ethernet-usb-lqfp100-package:LPC1769FBD100)|ARM® Cortex-M3|Smoothieboard, Azteeg X5 mini, TH3D EZBoard
+  [STM32F103](https://www.st.com/en/microcontrollers-microprocessors/stm32f103.html)|ARM® Cortex-M3|Malyan M200, GTM32 Pro, MKS Robin, BTT SKR Mini
+  [STM32F401](https://www.st.com/en/microcontrollers-microprocessors/stm32f401.html)|ARM® Cortex-M4|ARMED, Rumba32, SKR Pro, Lerdge, FYSETC S6
+  [STM32F7x6](https://www.st.com/en/microcontrollers-microprocessors/stm32f7x6.html)|ARM® Cortex-M4|The Borg, RemRam V1
+  [SAMD51P20A](https://www.adafruit.com/product/4064)|ARM® Cortex-M4|Adafruit Grand Central M4
+  [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)|ARM® Cortex-M4|
+  [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)|ARM® Cortex-M4|
 
-  name|processor|speed|flash|sram|logic|fpu
-  ----|---------|-----|-----|----|-----|---
-  [Arduino AVR](https://www.arduino.cc/)|ATmega, ATTiny, etc.|16-20MHz|64-256k|2-16k|5V|no
-  [Teensy++ 2.0](http://www.microchip.com/wwwproducts/en/AT90USB1286)|[AT90USB1286](http://www.microchip.com/wwwproducts/en/AT90USB1286)|16MHz|128k|8k|5V|no
-  [Arduino STM32](https://github.com/rogerclarkmelbourne/Arduino_STM32)|[STM32F1](https://www.st.com/en/microcontrollers-microprocessors/stm32f103.html) ARM-Cortex M3|72MHz|256-512k|48-64k|3.3V|no
-  [Due](https://www.arduino.cc/en/Guide/ArduinoDue), [RAMPS-FD](http://www.reprap.org/wiki/RAMPS-FD), etc.|[SAM3X8E ARM-Cortex M3](http://www.microchip.com/wwwproducts/en/ATsam3x8e)|84MHz|512k|64+32k|3.3V|no
-  [Re-ARM](https://www.kickstarter.com/projects/1245051645/re-arm-for-ramps-simple-32-bit-upgrade)|[LPC1768 ARM-Cortex M3](http://www.nxp.com/products/microcontrollers-and-processors/arm-based-processors-and-mcus/lpc-cortex-m-mcus/lpc1700-cortex-m3/512kb-flash-64kb-sram-ethernet-usb-lqfp100-package:LPC1768FBD100)|100MHz|512k|32+16+16k|3.3-5V|no
-  [MKS SBASE](http://forums.reprap.org/read.php?13,499322)|LPC1768 ARM-Cortex M3|100MHz|512k|32+16+16k|3.3-5V|no
-  [Azteeg X5 GT](https://www.panucatt.com/azteeg_X5_GT_reprap_3d_printer_controller_p/ax5gt.htm)|LPC1769 ARM-Cortex M3|120MHz|512k|32+16+16k|3.3-5V|no
-  [Selena Compact](https://github.com/Ales2-k/Selena)|LPC1768 ARM-Cortex M3|100MHz|512k|32+16+16k|3.3-5V|no
-  [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)|ARM-Cortex M4|120MHz|512k|192k|3.3-5V|yes
-  [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)|ARM-Cortex M4|180MHz|1M|256k|3.3V|yes
+## Submitting Changes
 
-### HALs in Development
-
-  name|processor|speed|flash|sram|logic|fpu
-  ----|---------|-----|-----|----|-----|---
-  [STEVAL-3DP001V1](http://www.st.com/en/evaluation-tools/steval-3dp001v1.html)|[STM32F401VE Arm-Cortex M4](http://www.st.com/en/microcontrollers/stm32f401ve.html)|84MHz|512k|64+32k|3.3-5V|yes
-  [Smoothieboard](http://reprap.org/wiki/Smoothieboard)|LPC1769 ARM-Cortex M3|120MHz|512k|64k|3.3-5V|no
-  [Adafruit Grand Central M4](https://www.adafruit.com/product/4064)|[SAMD51P20A ARM-Cortex M4](https://www.microchip.com/wwwproducts/en/ATSAMD51P20A)|120MHz|1M|256k|3.3V|yes
-
-## Submitting Patches
-
-Proposed patches should be submitted as a Pull Request against the ([bugfix-2.0.x](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x)) branch.
-
-- This branch is for fixing bugs and integrating any new features for the duration of the Marlin 2.0.x life-cycle.
+- Submit **Bug Fixes** as Pull Requests to the ([bugfix-2.0.x](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x)) branch.
+- Submit **New Features** to the ([dev-2.0.x](https://github.com/MarlinFirmware/Marlin/tree/dev-2.0.x)) branch.
 - Follow the [Coding Standards](http://marlinfw.org/docs/development/coding_standards.html) to gain points with the maintainers.
 - Please submit your questions and concerns to the [Issue Queue](https://github.com/MarlinFirmware/Marlin/issues).
 
-### [RepRap.org Wiki Page](http://reprap.org/wiki/Marlin)
+## Marlin Support
+
+For best results getting help with configuration and troubleshooting, please use the following resources:
+
+- [Marlin Documentation](http://marlinfw.org) - Official Marlin documentation
+- [Marlin Discord](https://discord.gg/n5NJ59y) - Discuss issues with Marlin users and developers
+- Facebook Group ["Marlin Firmware"](https://www.facebook.com/groups/1049718498464482/)
+- RepRap.org [Marlin Forum](http://forums.reprap.org/list.php?415)
+- [Tom's 3D Forums](https://discuss.toms3d.org/)
+- Facebook Group ["Marlin Firmware for 3D Printers"](https://www.facebook.com/groups/3Dtechtalk/)
+- [Marlin Configuration](https://www.youtube.com/results?search_query=marlin+configuration) on YouTube
 
 ## Credits
 
 The current Marlin dev team consists of:
 
- - Scott Lahteine [[@thinkyhead](https://github.com/thinkyhead)] - USA &nbsp; [![Flattr Scott](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=thinkyhead&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
+ - Scott Lahteine [[@thinkyhead](https://github.com/thinkyhead)] - USA &nbsp; [Donate](http://www.thinkyhead.com/donate-to-marlin) / Flattr: [![Flattr Scott](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=thinkyhead&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
  - Roxanne Neufeld [[@Roxy-3D](https://github.com/Roxy-3D)] - USA
- - Bob Kuhn [[@Bob-the-Kuhn](https://github.com/Bob-the-Kuhn)] - USA
  - Chris Pepper [[@p3p](https://github.com/p3p)] - UK
+ - Bob Kuhn [[@Bob-the-Kuhn](https://github.com/Bob-the-Kuhn)] - USA
  - João Brazio [[@jbrazio](https://github.com/jbrazio)] - Portugal
  - Erik van der Zalm [[@ErikZalm](https://github.com/ErikZalm)] - Netherlands &nbsp; [![Flattr Erik](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
 


### PR DESCRIPTION
### Description

In the case of multiple TMC stepper drivers on a single axis, code was being included which was missing the ending semicolon on commands, resulting in a compile failure.

### Benefits

Fixes compile with multiple TMC drivers on a single axis.

### Related Issues

None, so far as I'm aware.
