### PR TITLE
M106/M107 synchronization with motion for use with laser modules (on fan pins)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Report a bug in Marlin
+title: "[BUG] (short description)"
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+Have you read Marlin's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/MarlinFirmware/Marlin/blob/master/.github/code_of_conduct.md
+
+Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use one of the support links at https://github.com/MarlinFirmware/Marlin/issues/new/choose
+
+Before filing an issue be sure to test the "bugfix" branches to see whether the issue has been resolved.
+
+-->
+
+### Bug Description
+
+<!-- Description of the bug -->
+
+### My Configurations
+
+**Required:** Please include a ZIP file containing your `Configuration.h` and `Configuration_adv.h` files.
+
+### Steps to Reproduce
+
+<!-- Please describe the steps needed to reproduce the issue -->
+
+1. [First Step]
+2. [Second Step]
+3. [and so on...]
+
+**Expected behavior:** [What you expect to happen]
+
+**Actual behavior:** [What actually happens]
+
+#### Additional Information
+
+* Provide pictures or links to videos that clearly demonstrate the issue.
+* See [How Can I Contribute](#how-can-i-contribute) for additional guidelines.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,17 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Marlin Documentation
+    url: http://marlinfw.org/
+    about: Lots of documentation on installing and using Marlin.
+  - name: MarlinFirmware Facebook group
+    url: https://www.facebook.com/groups/1049718498464482
+    about: Please ask and answer questions here.
+  - name: Marlin on Discord
+    url: https://discord.gg/n5NJ59y
+    about: Join the Discord server for support and discussion.
+  - name: Marlin Discussion Forum
+    url: http://forums.reprap.org/list.php?415
+    about: A searchable web forum hosted by RepRap dot org.
+  - name: Marlin Videos on YouTube
+    url: https://www.youtube.com/results?search_query=marlin+firmware
+    about: Tutorials and more from Marlin users all around the world. Great for new users!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,35 @@
+---
+name: Feature request
+about: Request a Feature
+title: "[FR] (feature request title)"
+labels: ''
+assignees: ''
+
+---
+
+<!--
+
+Have you read Marlin's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/MarlinFirmware/Marlin/blob/master/.github/code_of_conduct.md
+
+Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use one of the support links at https://github.com/MarlinFirmware/Marlin/issues/new/choose
+
+Before filing an issue be sure to test the "bugfix" branches to see whether the issue has been resolved.
+
+-->
+
+### Description
+
+<!-- Description of the requested feature -->
+
+### Feature Workflow
+
+<!-- Please describe the feature's behavior, user interaction, etc. -->
+
+1. [First Action]
+2. [Second Action]
+3. [and so on...]
+
+#### Additional Information
+
+* Provide pictures or links that demonstrate a similar feature or concept.
+* See [How Can I Contribute](#how-can-i-contribute) for additional guidelines.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,31 +1,16 @@
-<!--
+# NO SUPPORT REQUESTS PLEASE
 
-Have you read Marlin's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.0.x/.github/code_of_conduct.md
+Support Requests posted here will be automatically closed!
 
-Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use the Marlin Firmware forum at http://forums.reprap.org/list.php?415 or the Marlin Facebook Group https://www.facebook.com/groups/1049718498464482/ or the Marlin Discord Server https://discord.gg/n5NJ59y.
+This Issue Queue is for Marlin bug reports and development-related issues, and we prefer not to handle user-support questions here. See https://github.com/MarlinFirmware/Marlin/blob/1.1.x/.github/contributing.md#i-dont-want-to-read-this-whole-thing-i-just-have-a-question.
 
-Before filing an issue be sure to test the 1.1 and/or 2.0 "bugfix" branches to see whether the issue is already addressed.
+For best results getting help with configuration and troubleshooting, please use the following resources:
 
--->
+- RepRap.org Marlin Forum http://forums.reprap.org/list.php?415
+- Tom's 3D Forums https://discuss.toms3d.org/
+- Facebook Group "Marlin Firmware" https://www.facebook.com/groups/1049718498464482/
+- Facebook Group "Marlin Firmware for 3D Printers" https://www.facebook.com/groups/3Dtechtalk/
+- Marlin Configuration https://www.youtube.com/results?search_query=marlin+configuration on YouTube
+- Marlin Discord server. Join link: https://discord.gg/n5NJ59y
 
-### Description
-
-<!-- Description of the bug or requested feature -->
-
-### Steps to Reproduce
-
-<!-- If this is a Bug Report, please describe the steps needed to reproduce the issue -->
-
-1. [First Step]
-2. [Second Step]
-3. [and so on...]
-
-**Expected behavior:** [What you expect to happen]
-
-**Actual behavior:** [What actually happens]
-
-#### Additional Information
-
-* Include a ZIP file containing your `Configuration.h` and `Configuration_adv.h` files.
-* Provide pictures or links to videos that clearly demonstrate the issue.
-* See [How Can I Contribute](#how-can-i-contribute) for additional guidelines.
+After seeking help from the community, if the consensus points to to a bug in Marlin, then you should post a Bug Report at https://github.com/MarlinFirmware/Marlin/issues/new/choose).

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -28,7 +28,7 @@
 /**
  * Marlin release version identifier
  */
-//#define SHORT_BUILD_VERSION "bugfix-2.0.x"
+//#define SHORT_BUILD_VERSION "2.0.x"
 
 /**
  * Verbose version identifier which should contain a reference to the location

--- a/Marlin/src/gcode/temperature/M106_M107.cpp
+++ b/Marlin/src/gcode/temperature/M106_M107.cpp
@@ -26,6 +26,9 @@
 
 #include "../gcode.h"
 #include "../../module/motion.h"
+#if ENABLED(LASER_SYNCHRONOUS_M106_M107)
+  #include "../../module/planner.h"
+#endif
 #include "../../module/temperature.h"
 
 #if ENABLED(SINGLENOZZLE)
@@ -63,6 +66,9 @@ void GcodeSuite::M106() {
     NOMORE(s, 255U);
 
     thermalManager.set_fan_speed(p, s);
+    #if ENABLED(LASER_SYNCHRONOUS_M106_M107)
+      planner.buffer_sync_block(BLOCK_FLAG_SYNC_FANS);
+    #endif
   }
 }
 
@@ -72,6 +78,9 @@ void GcodeSuite::M106() {
 void GcodeSuite::M107() {
   const uint8_t p = parser.byteval('P', _ALT_P);
   thermalManager.set_fan_speed(p, 0);
+  #if ENABLED(LASER_SYNCHRONOUS_M106_M107)
+    planner.buffer_sync_block(BLOCK_FLAG_SYNC_FANS);
+  #endif
 }
 
 #endif // FAN_COUNT > 0

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1022,6 +1022,26 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #endif
 
 /**
+ * Synchronous M106/M107 for laser vs kickstart fan ports
+ * This is highly ill-advised, as the sychronous M106/M107 is for explict use with lasers,
+ * kickstarting them can have unexpected side effects.
+ */
+#if BOTH(LASER_SYNCHRONOUS_M106_M107, FAN_KICKSTART_TIME)
+  #error "Do not use FAN_KICKSTART_TIME in conjunction with LASER_SYNCHRONOUS_M106_M107 as this would start laser in full-power when it's turned on."
+#endif
+
+/**
+ * Synchronous M106/M107 for laser vs defined or non zero FAN_MIN_PWM
+ * Laser should not be run with a FAN_MIN_PWM, as this would mean the laser can never
+ * be turned off fully. Note that FAN_MAX_PWM can be permissible (and perhaps needed)
+ * in order to limit power to the laser under certain conditions.
+ */
+#if ENABLED(LASER_SYNCHRONOUS_M106_M107) && FAN_MIN_PWM > 0
+  #error "Do not use FAN_MIN_PWM in conjuction with LASER_SYNCHRONOUS_M106_M107 as this disallows the laser to be fully off."
+#endif
+
+
+/**
  * Kinematics
  */
 

--- a/Marlin/src/inc/Version.h
+++ b/Marlin/src/inc/Version.h
@@ -25,7 +25,7 @@
  * Release version. Leave the Marlin version or apply a custom scheme.
  */
 #ifndef SHORT_BUILD_VERSION
-  #define SHORT_BUILD_VERSION "bugfix-2.0.x"
+  #define SHORT_BUILD_VERSION "2.0.x"
 #endif
 
 /**
@@ -42,7 +42,7 @@
  * version was tagged.
  */
 #ifndef STRING_DISTRIBUTION_DATE
-  #define STRING_DISTRIBUTION_DATE "2019-11-30"
+  #define STRING_DISTRIBUTION_DATE "2019-12-01"
 #endif
 
 /**

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -920,7 +920,7 @@ void Planner::reverse_pass() {
     block_t *current = &block_buffer[block_index];
 
     // Only consider non sync blocks
-    if (!TEST(current->flag, BLOCK_BIT_SYNC_POSITION)) {
+    if (!TEST(current->flag, BLOCK_BIT_SYNC_POSITION) && !TEST(current->flag, BLOCK_BIT_SYNC_FANS)) {
       reverse_pass_kernel(current, next);
       next = current;
     }
@@ -1015,7 +1015,7 @@ void Planner::forward_pass() {
     block = &block_buffer[block_index];
 
     // Skip SYNC blocks
-    if (!TEST(block->flag, BLOCK_BIT_SYNC_POSITION)) {
+    if (!TEST(block->flag, BLOCK_BIT_SYNC_POSITION) && !TEST(block->flag, BLOCK_BIT_SYNC_FANS)) {
       // If there's no previous block or the previous block is not
       // BUSY (thus, modifiable) run the forward_pass_kernel. Otherwise,
       // the previous block became BUSY, so assume the current block's
@@ -1051,7 +1051,7 @@ void Planner::recalculate_trapezoids() {
     block_t *prev = &block_buffer[prev_index];
 
     // If not dealing with a sync block, we are done. The last block is not a SYNC block
-    if (!TEST(prev->flag, BLOCK_BIT_SYNC_POSITION)) break;
+    if (!TEST(prev->flag, BLOCK_BIT_SYNC_POSITION) && !TEST(prev->flag, BLOCK_BIT_SYNC_FANS)) break;
 
     // Examine the previous block. This and all following are SYNC blocks
     head_block_index = prev_index;
@@ -1065,7 +1065,7 @@ void Planner::recalculate_trapezoids() {
     next = &block_buffer[block_index];
 
     // Skip sync blocks
-    if (!TEST(next->flag, BLOCK_BIT_SYNC_POSITION)) {
+    if (!TEST(next->flag, BLOCK_BIT_SYNC_POSITION) && !TEST(next->flag, BLOCK_BIT_SYNC_FANS)) {
       next_entry_speed = SQRT(next->entry_speed_sqr);
 
       if (block) {

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2469,11 +2469,12 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
 /**
  * Planner::buffer_sync_block
- * Add a block to the buffer that just updates the position
+* Add a block to the buffer that just updates the position or in
+* case of LASER_SYNCHRONOUS_M106_M107 the fan pwm
  */
 void Planner::buffer_sync_block(
   #if ENABLED(LASER_SYNCHRONOUS_M106_M107)
-    uint8_t sync_type = BLOCK_FLAG_SYNC_POSITION
+    uint8_t sync_flag = BLOCK_FLAG_SYNC_POSITION
   #endif
 ) {
   // Wait for the next available block
@@ -2484,7 +2485,7 @@ void Planner::buffer_sync_block(
   memset(block, 0, sizeof(block_t));
 
   #if ENABLED(LASER_SYNCHRONOUS_M106_M107)
-    block->flag = sync_type;
+    block->flag = sync_flag;
   #else
     block->flag = BLOCK_FLAG_SYNC_POSITION;
   #endif

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -627,11 +627,12 @@ class Planner {
 
     /**
      * Planner::buffer_sync_block
-     * Add a block to the buffer that just updates the position
+     * Add a block to the buffer that just updates the position or in
+     * case of LASER_SYNCHRONOUS_M106_M107 the fan pwm
      */
     static void buffer_sync_block(
       #if ENABLED(LASER_SYNCHRONOUS_M106_M107)
-        uint8_t sync_type
+        uint8_t sync_flag
       #endif
     );
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -73,14 +73,18 @@ enum BlockFlagBit : char {
   BLOCK_BIT_CONTINUED,
 
   // Sync the stepper counts from the block
-  BLOCK_BIT_SYNC_POSITION
+  BLOCK_BIT_SYNC_POSITION,
+
+  // Sync the fan speeds from the block
+  BLOCK_BIT_SYNC_FANS
 };
 
 enum BlockFlag : char {
   BLOCK_FLAG_RECALCULATE          = _BV(BLOCK_BIT_RECALCULATE),
   BLOCK_FLAG_NOMINAL_LENGTH       = _BV(BLOCK_BIT_NOMINAL_LENGTH),
   BLOCK_FLAG_CONTINUED            = _BV(BLOCK_BIT_CONTINUED),
-  BLOCK_FLAG_SYNC_POSITION        = _BV(BLOCK_BIT_SYNC_POSITION)
+  BLOCK_FLAG_SYNC_POSITION        = _BV(BLOCK_BIT_SYNC_POSITION),
+  BLOCK_FLAG_SYNC_FANS            = _BV(BLOCK_BIT_SYNC_FANS)
 };
 
 /**
@@ -383,6 +387,11 @@ class Planner {
     // Manage fans, paste pressure, etc.
     static void check_axes_activity();
 
+    // Apply fan speeds
+    #if FAN_COUNT > 0
+      static void sync_fan_speeds(uint8_t fan_speed[FAN_COUNT]);
+    #endif
+
     // Update multipliers based on new diameter measurements
     static void calculate_volumetric_multipliers();
 
@@ -620,7 +629,11 @@ class Planner {
      * Planner::buffer_sync_block
      * Add a block to the buffer that just updates the position
      */
-    static void buffer_sync_block();
+    static void buffer_sync_block(
+      #if ENABLED(LASER_SYNCHRONOUS_M106_M107)
+        uint8_t sync_type
+      #endif
+    );
 
   #if IS_KINEMATIC
     private:

--- a/README.md
+++ b/README.md
@@ -1,76 +1,69 @@
-﻿# Marlin 3D Printer Firmware
+﻿<img align="right" width=175 src="buildroot/share/pixmaps/logo/marlin-250.png" />
 
-[![Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg?branch=bugfix-2.0.x)](https://travis-ci.org/MarlinFirmware/Marlin)
+# Marlin 3D Printer Firmware
+
+[![Build Status](https://travis-ci.org/MarlinFirmware/Marlin.svg?branch=2.0.x)](https://travis-ci.org/MarlinFirmware/Marlin)
 ![GitHub](https://img.shields.io/github/license/marlinfirmware/marlin.svg)
 ![GitHub contributors](https://img.shields.io/github/contributors/marlinfirmware/marlin.svg)
 ![GitHub Release Date](https://img.shields.io/github/release-date/marlinfirmware/marlin.svg)
 
-<img align="top" width=175 src="buildroot/share/pixmaps/logo/marlin-250.png" />
+_Marlin_ is a firmware for RepRap machines, also known as _3D printers_. firmware to the next level by adding support for much faster 32-bit and ARM-based boards while improving support for 8-bit AVR boards through the use of a "hardware abstraction layer."
 
 Additional documentation can be found at the [Marlin Home Page](http://marlinfw.org/).
-Please test this firmware and let us know if it misbehaves in any way. Volunteers are standing by!
+Please let us know if Marlin misbehaves in any way. Volunteers are standing by!
 
-## Marlin 2.0 Bugfix Branch
+## Building Marlin
 
-__Not for production use. Use with caution!__
+To build Marlin you'll need [Arduino IDE 1.8.8 or newer](https://www.arduino.cc/en/main/software) or [PlatformIO](http://docs.platformio.org/en/latest/ide.html#platformio-ide) with _[Visual Studio Code](https://code.visualstudio.com/download)_.
 
-Marlin 2.0 takes this popular RepRap firmware to the next level by adding support for much faster 32-bit and ARM-based boards while improving support for 8-bit AVR boards. Read about Marlin's decision to use a "Hardware Abstraction Layer" below.
+- [Installing Marlin (Arduino)](http://marlinfw.org/docs/basics/install_arduino.html)
+- [Installing Marlin (VSCode)](http://marlinfw.org/docs/basics/install_platformio_vscode.html).
 
-This branch is for patches to the latest 2.0.x release version. Periodically this branch will form the basis for the next minor 2.0.x release.
+### Supported Platforms
 
-Download earlier versions of Marlin on the [Releases page](https://github.com/MarlinFirmware/Marlin/releases).
+Platform|MCU|Example Boards
+--------|---|-------
+[Arduino AVR](https://www.arduino.cc/)|ATmega|RAMPS, Melzi, RAMBo
+[Teensy++ 2.0](http://www.microchip.com/wwwproducts/en/AT90USB1286)|AT90USB1286|Printrboard
+[Arduino Due](https://www.arduino.cc/en/Guide/ArduinoDue)|SAM3X8E|RAMPS-FD, RADDS, RAMPS4DUE
+[LPC1768](http://www.nxp.com/products/microcontrollers-and-processors/arm-based-processors-and-mcus/lpc-cortex-m-mcus/lpc1700-cortex-m3/512kb-flash-64kb-sram-ethernet-usb-lqfp100-package:LPC1768FBD100)|ARM® Cortex-M3|MKS SBASE, Re-ARM, Selena Compact
+[LPC1769](https://www.nxp.com/products/processors-and-microcontrollers/arm-microcontrollers/general-purpose-mcus/lpc1700-cortex-m3/512kb-flash-64kb-sram-ethernet-usb-lqfp100-package:LPC1769FBD100)|ARM® Cortex-M3|Smoothieboard, Azteeg X5 mini, TH3D EZBoard
+[STM32F103](https://www.st.com/en/microcontrollers-microprocessors/stm32f103.html)|ARM® Cortex-M3|Malyan M200, GTM32 Pro, MKS Robin, BTT SKR Mini
+[STM32F401](https://www.st.com/en/microcontrollers-microprocessors/stm32f401.html)|ARM® Cortex-M4|ARMED, Rumba32, SKR Pro, Lerdge, FYSETC S6
+[STM32F7x6](https://www.st.com/en/microcontrollers-microprocessors/stm32f7x6.html)|ARM® Cortex-M4|The Borg, RemRam V1
+[SAMD51P20A](https://www.adafruit.com/product/4064)|ARM® Cortex-M4|Adafruit Grand Central M4
+[Teensy 3.5](https://www.pjrc.com/store/teensy35.html)|ARM® Cortex-M4|
+[Teensy 3.6](https://www.pjrc.com/store/teensy36.html)|ARM® Cortex-M4|
 
-## Building Marlin 2.0
+## Submitting Changes
 
-To build Marlin 2.0 you'll need [Arduino IDE 1.8.8 or newer](https://www.arduino.cc/en/main/software) or [PlatformIO](http://docs.platformio.org/en/latest/ide.html#platformio-ide). We've posted detailed instructions on [Building Marlin with Arduino](http://marlinfw.org/docs/basics/install_arduino.html) and [Building Marlin with PlatformIO for ReArm](http://marlinfw.org/docs/basics/install_rearm.html) (which applies well to other 32-bit boards).
-
-## Hardware Abstraction Layer (HAL)
-
-Marlin 2.0 introduces a layer of abstraction so that all the existing high-level code can be built for 32-bit platforms while still retaining full 8-bit AVR compatibility. Retaining AVR compatibility and a single code-base is important to us, because we want to make sure that features and patches get as much testing and attention as possible, and that all platforms always benefit from the latest improvements.
-
-### Current HALs
-
-  name|processor|speed|flash|sram|logic|fpu
-  ----|---------|-----|-----|----|-----|---
-  [Arduino AVR](https://www.arduino.cc/)|ATmega, ATTiny, etc.|16-20MHz|64-256k|2-16k|5V|no
-  [Teensy++ 2.0](http://www.microchip.com/wwwproducts/en/AT90USB1286)|[AT90USB1286](http://www.microchip.com/wwwproducts/en/AT90USB1286)|16MHz|128k|8k|5V|no
-  [Arduino STM32](https://github.com/rogerclarkmelbourne/Arduino_STM32)|[STM32F1](https://www.st.com/en/microcontrollers-microprocessors/stm32f103.html) ARM-Cortex M3|72MHz|256-512k|48-64k|3.3V|no
-  [Due](https://www.arduino.cc/en/Guide/ArduinoDue), [RAMPS-FD](http://www.reprap.org/wiki/RAMPS-FD), etc.|[SAM3X8E ARM-Cortex M3](http://www.microchip.com/wwwproducts/en/ATsam3x8e)|84MHz|512k|64+32k|3.3V|no
-  [Re-ARM](https://www.kickstarter.com/projects/1245051645/re-arm-for-ramps-simple-32-bit-upgrade)|[LPC1768 ARM-Cortex M3](http://www.nxp.com/products/microcontrollers-and-processors/arm-based-processors-and-mcus/lpc-cortex-m-mcus/lpc1700-cortex-m3/512kb-flash-64kb-sram-ethernet-usb-lqfp100-package:LPC1768FBD100)|100MHz|512k|32+16+16k|3.3-5V|no
-  [MKS SBASE](http://forums.reprap.org/read.php?13,499322)|LPC1768 ARM-Cortex M3|100MHz|512k|32+16+16k|3.3-5V|no
-  [Azteeg X5 GT](https://www.panucatt.com/azteeg_X5_GT_reprap_3d_printer_controller_p/ax5gt.htm)|LPC1769 ARM-Cortex M3|120MHz|512k|32+16+16k|3.3-5V|no
-  [Selena Compact](https://github.com/Ales2-k/Selena)|LPC1768 ARM-Cortex M3|100MHz|512k|32+16+16k|3.3-5V|no
-  [Teensy 3.5](https://www.pjrc.com/store/teensy35.html)|ARM-Cortex M4|120MHz|512k|192k|3.3-5V|yes
-  [Teensy 3.6](https://www.pjrc.com/store/teensy36.html)|ARM-Cortex M4|180MHz|1M|256k|3.3V|yes
-
-### HALs in Development
-
-  name|processor|speed|flash|sram|logic|fpu
-  ----|---------|-----|-----|----|-----|---
-  [STEVAL-3DP001V1](http://www.st.com/en/evaluation-tools/steval-3dp001v1.html)|[STM32F401VE Arm-Cortex M4](http://www.st.com/en/microcontrollers/stm32f401ve.html)|84MHz|512k|64+32k|3.3-5V|yes
-  [Smoothieboard](http://reprap.org/wiki/Smoothieboard)|LPC1769 ARM-Cortex M3|120MHz|512k|64k|3.3-5V|no
-  [Adafruit Grand Central M4](https://www.adafruit.com/product/4064)|[SAMD51P20A ARM-Cortex M4](https://www.microchip.com/wwwproducts/en/ATSAMD51P20A)|120MHz|1M|256k|3.3V|yes
-
-## Submitting Patches
-
-Proposed patches should be submitted as a Pull Request against the ([bugfix-2.0.x](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x)) branch.
-
-- This branch is for fixing bugs and integrating any new features for the duration of the Marlin 2.0.x life-cycle.
+- Submit **Bug Fixes** as Pull Requests to the ([bugfix-2.0.x](https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x)) branch.
+- Submit **New Features** to the ([dev-2.0.x](https://github.com/MarlinFirmware/Marlin/tree/dev-2.0.x)) branch.
 - Follow the [Coding Standards](http://marlinfw.org/docs/development/coding_standards.html) to gain points with the maintainers.
 - Please submit your questions and concerns to the [Issue Queue](https://github.com/MarlinFirmware/Marlin/issues).
 
-### [RepRap.org Wiki Page](http://reprap.org/wiki/Marlin)
+## Marlin Support
+
+For best results getting help with configuration and troubleshooting, please use the following resources:
+
+- [Marlin Documentation](http://marlinfw.org) - Official Marlin documentation
+- [Marlin Discord](https://discord.gg/n5NJ59y) - Discuss issues with Marlin users and developers
+- Facebook Group ["Marlin Firmware"](https://www.facebook.com/groups/1049718498464482/)
+- RepRap.org [Marlin Forum](http://forums.reprap.org/list.php?415)
+- [Tom's 3D Forums](https://discuss.toms3d.org/)
+- Facebook Group ["Marlin Firmware for 3D Printers"](https://www.facebook.com/groups/3Dtechtalk/)
+- [Marlin Configuration](https://www.youtube.com/results?search_query=marlin+configuration) on YouTube
 
 ## Credits
 
 The current Marlin dev team consists of:
 
- - Scott Lahteine [[@thinkyhead](https://github.com/thinkyhead)] - USA &nbsp; [![Flattr Scott](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=thinkyhead&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
- - Roxanne Neufeld [[@Roxy-3D](https://github.com/Roxy-3D)] - USA
- - Bob Kuhn [[@Bob-the-Kuhn](https://github.com/Bob-the-Kuhn)] - USA
- - Chris Pepper [[@p3p](https://github.com/p3p)] - UK
- - João Brazio [[@jbrazio](https://github.com/jbrazio)] - Portugal
- - Erik van der Zalm [[@ErikZalm](https://github.com/ErikZalm)] - Netherlands &nbsp; [![Flattr Erik](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
+- Scott Lahteine [[@thinkyhead](https://github.com/thinkyhead)] - USA &nbsp; [Donate](http://www.thinkyhead.com/donate-to-marlin) / Flattr: [![Flattr Scott](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=thinkyhead&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
+- Roxanne Neufeld [[@Roxy-3D](https://github.com/Roxy-3D)] - USA
+- Chris Pepper [[@p3p](https://github.com/p3p)] - UK
+- Bob Kuhn [[@Bob-the-Kuhn](https://github.com/Bob-the-Kuhn)] - USA
+- João Brazio [[@jbrazio](https://github.com/jbrazio)] - Portugal
+- Erik van der Zalm [[@ErikZalm](https://github.com/ErikZalm)] - Netherlands &nbsp; [![Flattr Erik](http://api.flattr.com/button/flattr-badge-large.png)](https://flattr.com/submit/auto?user_id=ErikZalm&url=https://github.com/MarlinFirmware/Marlin&title=Marlin&language=&tags=github&category=software)
 
 ## License
 

--- a/config/default/Configuration_adv.h
+++ b/config/default/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
+++ b/config/examples/3DFabXYZ/Migbot/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/ADIMLab/Gantry v1/Configuration_adv.h
+++ b/config/examples/ADIMLab/Gantry v1/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/ADIMLab/Gantry v2/Configuration_adv.h
+++ b/config/examples/ADIMLab/Gantry v2/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/AlephObjects/TAZ4/Configuration_adv.h
+++ b/config/examples/AlephObjects/TAZ4/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Alfawise/U20-bltouch/Configuration_adv.h
+++ b/config/examples/Alfawise/U20-bltouch/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Alfawise/U20/Configuration_adv.h
+++ b/config/examples/Alfawise/U20/Configuration_adv.h
@@ -2440,6 +2440,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/AliExpress/UM2pExt/Configuration_adv.h
+++ b/config/examples/AliExpress/UM2pExt/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Anet/A2/Configuration_adv.h
+++ b/config/examples/Anet/A2/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Anet/A2plus/Configuration_adv.h
+++ b/config/examples/Anet/A2plus/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Anet/A6/Configuration_adv.h
+++ b/config/examples/Anet/A6/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Anet/A8/Configuration_adv.h
+++ b/config/examples/Anet/A8/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Anet/A8plus/Configuration_adv.h
+++ b/config/examples/Anet/A8plus/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Anet/E16/Configuration_adv.h
+++ b/config/examples/Anet/E16/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/AnyCubic/i3/Configuration_adv.h
+++ b/config/examples/AnyCubic/i3/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/ArmEd/Configuration_adv.h
+++ b/config/examples/ArmEd/Configuration_adv.h
@@ -2443,6 +2443,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/cyclops/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/BQ/Hephestos/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/BQ/Hephestos_2/Configuration_adv.h
+++ b/config/examples/BQ/Hephestos_2/Configuration_adv.h
@@ -2447,6 +2447,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/BQ/WITBOX/Configuration_adv.h
+++ b/config/examples/BQ/WITBOX/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration_adv.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Cartesio/Configuration_adv.h
+++ b/config/examples/Cartesio/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/CR-10/Configuration_adv.h
+++ b/config/examples/Creality/CR-10/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/CR-10S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10S/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/CR-10_5S/Configuration_adv.h
+++ b/config/examples/Creality/CR-10_5S/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/CR-10mini/Configuration_adv.h
+++ b/config/examples/Creality/CR-10mini/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/CR-20 Pro/Configuration_adv.h
+++ b/config/examples/Creality/CR-20 Pro/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/CR-20/Configuration_adv.h
+++ b/config/examples/Creality/CR-20/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/CR-8/Configuration_adv.h
+++ b/config/examples/Creality/CR-8/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/Ender-2/Configuration_adv.h
+++ b/config/examples/Creality/Ender-2/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/Ender-3/Configuration_adv.h
+++ b/config/examples/Creality/Ender-3/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/Ender-4/Configuration_adv.h
+++ b/config/examples/Creality/Ender-4/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Creality/Ender-5/Configuration_adv.h
+++ b/config/examples/Creality/Ender-5/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
+++ b/config/examples/Dagoma/Disco Ultimate/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
+++ b/config/examples/EVNOVO (Artillery)/Sidewinder X1/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Einstart-S/Configuration_adv.h
+++ b/config/examples/Einstart-S/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FYSETC/AIO_II/Configuration_adv.h
+++ b/config/examples/FYSETC/AIO_II/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/BLTouch/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah 1.2/base/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/BLTouch/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
+++ b/config/examples/FYSETC/Cheetah/base/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FYSETC/F6_13/Configuration_adv.h
+++ b/config/examples/FYSETC/F6_13/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FYSETC/S6/Configuration_adv.h
+++ b/config/examples/FYSETC/S6/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Felix/DUAL/Configuration_adv.h
+++ b/config/examples/Felix/DUAL/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Felix/Single/Configuration_adv.h
+++ b/config/examples/Felix/Single/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FlashForge/CreatorPro/Configuration_adv.h
+++ b/config/examples/FlashForge/CreatorPro/Configuration_adv.h
@@ -2438,6 +2438,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/FolgerTech/i3-2020/Configuration_adv.h
+++ b/config/examples/FolgerTech/i3-2020/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Formbot/Raptor/Configuration_adv.h
+++ b/config/examples/Formbot/Raptor/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_2+/Configuration_adv.h
@@ -2443,6 +2443,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Formbot/T_Rex_3/Configuration_adv.h
+++ b/config/examples/Formbot/T_Rex_3/Configuration_adv.h
@@ -2443,6 +2443,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/A10/Configuration_adv.h
+++ b/config/examples/Geeetech/A10/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/A10M/Configuration_adv.h
+++ b/config/examples/Geeetech/A10M/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/A10T/Configuration_adv.h
+++ b/config/examples/Geeetech/A10T/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/A20/Configuration_adv.h
+++ b/config/examples/Geeetech/A20/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/A20M/Configuration_adv.h
+++ b/config/examples/Geeetech/A20M/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/A20T/Configuration_adv.h
+++ b/config/examples/Geeetech/A20T/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/A30/Configuration_adv.h
+++ b/config/examples/Geeetech/A30/Configuration_adv.h
@@ -2438,6 +2438,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/E180/Configuration_adv.h
+++ b/config/examples/Geeetech/E180/Configuration_adv.h
@@ -2438,6 +2438,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/MeCreator2/Configuration_adv.h
+++ b/config/examples/Geeetech/MeCreator2/Configuration_adv.h
@@ -2438,6 +2438,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro C/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
+++ b/config/examples/Geeetech/Prusa i3 Pro W/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/HMS434/Configuration_adv.h
+++ b/config/examples/HMS434/Configuration_adv.h
@@ -2431,6 +2431,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Infitary/i3-M508/Configuration_adv.h
+++ b/config/examples/Infitary/i3-M508/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/JGAurora/A1/Configuration_adv.h
+++ b/config/examples/JGAurora/A1/Configuration_adv.h
@@ -2444,6 +2444,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/JGAurora/A5/Configuration_adv.h
+++ b/config/examples/JGAurora/A5/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/JGAurora/A5S/Configuration_adv.h
+++ b/config/examples/JGAurora/A5S/Configuration_adv.h
@@ -2444,6 +2444,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/MakerParts/Configuration_adv.h
+++ b/config/examples/MakerParts/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Malyan/M150/Configuration_adv.h
+++ b/config/examples/Malyan/M150/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Malyan/M200/Configuration_adv.h
+++ b/config/examples/Malyan/M200/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Micromake/C1/enhanced/Configuration_adv.h
+++ b/config/examples/Micromake/C1/enhanced/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Mks/Robin/Configuration_adv.h
+++ b/config/examples/Mks/Robin/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Mks/Sbase/Configuration_adv.h
+++ b/config/examples/Mks/Sbase/Configuration_adv.h
@@ -2440,6 +2440,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Modix/Big60/Configuration_adv.h
+++ b/config/examples/Modix/Big60/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/RapideLite/RL200/Configuration_adv.h
+++ b/config/examples/RapideLite/RL200/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Renkforce/RF100/Configuration_adv.h
+++ b/config/examples/Renkforce/RF100/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Renkforce/RF100XL/Configuration_adv.h
+++ b/config/examples/Renkforce/RF100XL/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Renkforce/RF100v2/Configuration_adv.h
+++ b/config/examples/Renkforce/RF100v2/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/RigidBot/Configuration_adv.h
+++ b/config/examples/RigidBot/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/SCARA/MP_SCARA/Configuration_adv.h
+++ b/config/examples/SCARA/MP_SCARA/Configuration_adv.h
@@ -2335,6 +2335,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/SCARA/Morgan/Configuration_adv.h
+++ b/config/examples/SCARA/Morgan/Configuration_adv.h
@@ -2436,6 +2436,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
+++ b/config/examples/STM32/Black_STM32F407VET6/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Sanguinololu/Configuration_adv.h
+++ b/config/examples/Sanguinololu/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Tevo/Michelangelo/Configuration_adv.h
+++ b/config/examples/Tevo/Michelangelo/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
+++ b/config/examples/Tevo/Tarantula Pro/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V1 (MKS Base)/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/TheBorg/Configuration_adv.h
+++ b/config/examples/TheBorg/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/TinyBoy2/Configuration_adv.h
+++ b/config/examples/TinyBoy2/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Tronxy/X3A/Configuration_adv.h
+++ b/config/examples/Tronxy/X3A/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Tronxy/X5S-2E/Configuration_adv.h
+++ b/config/examples/Tronxy/X5S-2E/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/UltiMachine/Archim1/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim1/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/UltiMachine/Archim2/Configuration_adv.h
+++ b/config/examples/UltiMachine/Archim2/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/VORONDesign/Configuration_adv.h
+++ b/config/examples/VORONDesign/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Velleman/K8200/Configuration_adv.h
+++ b/config/examples/Velleman/K8200/Configuration_adv.h
@@ -2452,6 +2452,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Velleman/K8400/Dual-head/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Dual-head/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Velleman/K8400/Single-head/Configuration_adv.h
+++ b/config/examples/Velleman/K8400/Single-head/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/WASP/PowerWASP/Configuration_adv.h
+++ b/config/examples/WASP/PowerWASP/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Wanhao/Duplicator i3 2.1/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 2.1/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
+++ b/config/examples/Wanhao/Duplicator i3 Mini/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
+++ b/config/examples/delta/Anycubic/Kossel/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord/Configuration_adv.h
@@ -2440,6 +2440,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
+++ b/config/examples/delta/Dreammaker/Overlord_Pro/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/auto_calibrate/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/FLSUN/kossel/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/FLSUN/kossel_mini/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
+++ b/config/examples/delta/Geeetech/Rostock 301/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/MKS/SBASE/Configuration_adv.h
+++ b/config/examples/delta/MKS/SBASE/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/Tevo Little Monster/Configuration_adv.h
+++ b/config/examples/delta/Tevo Little Monster/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/generic/Configuration_adv.h
+++ b/config/examples/delta/generic/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/kossel_mini/Configuration_adv.h
+++ b/config/examples/delta/kossel_mini/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/delta/kossel_xl/Configuration_adv.h
+++ b/config/examples/delta/kossel_xl/Configuration_adv.h
@@ -2441,6 +2441,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/gCreate/gMax1.5+/Configuration_adv.h
+++ b/config/examples/gCreate/gMax1.5+/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/makibox/Configuration_adv.h
+++ b/config/examples/makibox/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/tvrrug/Round2/Configuration_adv.h
+++ b/config/examples/tvrrug/Round2/Configuration_adv.h
@@ -2439,6 +2439,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.

--- a/config/examples/wt150/Configuration_adv.h
+++ b/config/examples/wt150/Configuration_adv.h
@@ -2440,6 +2440,24 @@
 #endif
 
 /**
+ * Synchronous M106/M107 laser control
+ * 
+ * By default Marlin will set M106/M107 fan speed as fast as possible on the fan
+ * ports. Considering time needed for fans to spin up/down this is normally fine.
+ * HOWEVER, when the fan header of a board is used in conjunction with controller
+ * a PWM/TTL laser, this means that the control of the laser is out of sync with
+ * the movement systems in X/Y axis.
+ * 
+ * To synchronize the M106/M107 commands with motion, you can enable the 
+ * LASER_SYNCHRONOUS_FAN_CONTROL option below.
+ * 
+ * Enabling this comes as a minor sacrifice to setting fan speeds on a part cooling
+ * fan, however, in most cases the effect will be so minor, that is most like not
+ * even noticeable.
+ */
+//#define LASER_SYNCHRONOUS_M106_M107
+
+/**
  * Coolant Control
  *
  * Add the M7, M8, and M9 commands to turn mist or flood coolant on and off.


### PR DESCRIPTION
### Requirements

Improving laser grayscale scan-line engraving using Marlin on a 3D printer or purpose build machine, when using a fan-port to control the PWM signal to fire the laser module.

### Description

This feature change is aiming to implement synchronous support of M106/M107. The goal of this is to take back control of when these commands fire in the motion cycle of Marlin, so that they can be used to fire the laser at the right moment or turn it off again at the right moment. Default nature of Marlin is to apply M106/M107 gcode commands as soon as it can through use of an interval controlled (~10Hz) call on check_axes_activity() in the planner.

Both the "as soon as possible" and the low call rate of the check_axes_activity() method prevent high quality laser engraving through the fan ports.

Situation before the changes contained in this pull request:
![IMG_1987](https://user-images.githubusercontent.com/6264624/69993774-caa91d80-154c-11ea-86ab-aa7b503806c8.png)
In above image you can clearly see the misfiring of the laser module. It has lines where they should not be due to the laser falsely being turned out, and on the other side it's missing lines where there should have been.

The same engraving redone with the changes contained in this pull request:
![IMG_1992](https://user-images.githubusercontent.com/6264624/69993831-e8768280-154c-11ea-9be1-bc1a355f46ce.jpg)
This image shows that the synchronization of the pwm controls with M106/M107 has a great impact on the engraving quality. Note that the speed of this image at 10mm/s is due to the fact it was testing with a low power 500mW laser, so going fast won't do much otherwise. The synchronization principle is fully functional with high(er) speeds as well.

### Benefits

The M106/M107 commands will become synchronized and will get executed in order of communication to Marlin, which allows highly accurate firing of a laser module on a printers part cooling fan pwm port.

With synchronized M106/M107, people that want to run laser modules on their 3D printers (and may be limited to using the fan port, i.e. Creality Ender for instance with the stock board), can achieve very high quality laser engravings, something that can't be done without the synchronized M106/M107 commands.

Some more examples of the results with the changes in this pull request:
![IMG_1998](https://user-images.githubusercontent.com/6264624/69994067-5e7ae980-154d-11ea-84d4-c35e49ac2523.jpg)
![IMG_1999](https://user-images.githubusercontent.com/6264624/69994078-62a70700-154d-11ea-94ed-2f3435fe3342.jpg)

### Related Issues

Use of M106/M107 has been mentioned in the following ticket, as well as example pictures of the issue of non-synchronous fan pin control in the planner.
- #11575