### PR TITLE
PIO: 128K Melzi Boards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -128,7 +128,7 @@ monitor_speed = 250000
 #
 [env:melzi]
 platform      = atmelavr
-board         = sanguino_atmega644p
+board         = sanguino_atmega1284p
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
@@ -142,7 +142,7 @@ upload_speed  = 57600
 #
 [env:melzi_optiboot]
 platform      = atmelavr
-board         = sanguino_atmega644p
+board         = sanguino_atmega1284p
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>


### PR DESCRIPTION
### Description

This PR reverts `melzi` & `melzi_optiboot` environments back to `sanguino_atmega1284p`.

### Benefits

Stock Ender-3 config (and any other melz-based machines) can compile successfully with more than 64k of used flash.

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/16083