### PR TITLE
Remove include guard

### DIFF
--- a/Marlin/src/core/debug_out.h
+++ b/Marlin/src/core/debug_out.h
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-#pragma once
 
 //
 // Serial aliases for debugging.


### PR DESCRIPTION
Remove include guard in debug_out.h which breaks EEPROM_CHITCHAT
### Description
The ``#pragma once`` include guard in ``debug_out.h`` breaks ``EEPROM_CHITCHAT``. This was fixed originally by #13716 but the fix was broken by b6546ea33a0f6eebee520dda516e04d3b68ded55
### Benefits
Make ``EEPROM_CHITCHAT`` work again.