### PR TITLE
Fix compile error if PIDTEMP is disabled

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -788,11 +788,16 @@ void MarlinSettings::postprocess() {
       _FIELD_TEST(hotendPID);
       HOTEND_LOOP() {
         PIDCF_t pidcf = {
-                       PID_PARAM(Kp, e),
-          unscalePID_i(PID_PARAM(Ki, e)),
-          unscalePID_d(PID_PARAM(Kd, e)),
-                       PID_PARAM(Kc, e),
-                       PID_PARAM(Kf, e)
+          #if DISABLED(PIDTEMP)
+            DUMMY_PID_VALUE, DUMMY_PID_VALUE, DUMMY_PID_VALUE,
+            DUMMY_PID_VALUE, DUMMY_PID_VALUE
+          #else
+                         PID_PARAM(Kp, e),
+            unscalePID_i(PID_PARAM(Ki, e)),
+            unscalePID_d(PID_PARAM(Kd, e)),
+                         PID_PARAM(Kc, e),
+                         PID_PARAM(Kf, e)
+          #endif
         };
         EEPROM_WRITE(pidcf);
       }


### PR DESCRIPTION
The build would fail with "error: 'unscalePID_i' was not declared in this scope"
if both PIDTEMP and PIDTEMPBED are disabled.

### Requirements

Marlin should compile with PIDs disabled and EEPROM_SETTINGS enabled.

### Description

Fixes a following compile error if both PIDTEMP and PIDTEMPBED are disabled but EEPROM_SETTINGS is enabled in config.

```
Compiling .pio/build/megaatmega2560/src/src/module/planner.cpp.o
Marlin/src/module/configuration_store.cpp: In static member function 'static bool MarlinSettings::save()':
Marlin/src/module/configuration_store.cpp:792:40: error: 'unscalePID_i' was not declared in this scope
           unscalePID_i(PID_PARAM(Ki, e)),
                                        ^
Marlin/src/module/configuration_store.cpp:793:40: error: 'unscalePID_d' was not declared in this scope
           unscalePID_d(PID_PARAM(Kd, e)),
                                        ^
In file included from Marlin/src/module/configuration_store.cpp:52:0:
Marlin/src/module/temperature.h:101:34: error: '_PID_Kf' was not declared in this scope
 #define PID_PARAM(F,H) _PID_##F(H)
                                  ^
Marlin/src/module/configuration_store.cpp:795:24: note: in expansion of macro 'PID_PARAM'
                        PID_PARAM(Kf, e)
                        ^
*** [.pio/build/megaatmega2560/src/src/module/configuration_store.cpp.o] Error 1
```
