### PR TITLE
Disable PRINTCOUNTER in SKR Mini E3 examples.

### DIFF
--- a/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration.h
@@ -1549,7 +1549,7 @@
  *
  * View the current statistics with M78.
  */
-#define PRINTCOUNTER
+//#define PRINTCOUNTER
 
 //=============================================================================
 //============================= LCD and SD support ============================

--- a/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration.h
@@ -1549,7 +1549,7 @@
  *
  * View the current statistics with M78.
  */
-#define PRINTCOUNTER
+//#define PRINTCOUNTER
 
 //=============================================================================
 //============================= LCD and SD support ============================


### PR DESCRIPTION
### Description

PRINTCOUNTER is currently causing configuration corruption on SKR Mini boards. There are multiple problems potentially associated with this feature, but the most significant is that the STM32F1 HAL currently erases the entire flash sector without doing anything to preserve configuration settings stored in it.

I considered adding a check for PRINTCOUNTER into the STM32F1 SanityChecks.h file, but based on Discord discussion there are still a lot of open questions related to exactly what all may be wrong.

### Benefits

Reduces the influx of new users with this issue, where it is currently known to have issues.

### Related Issues

Doesn't solve the root-cause of this issues, but will reduce exposure to new users.
#15982 

