### PR TITLE
Wanhao D6 uses TINYBOY2

### DIFF
--- a/config/examples/Wanhao/Duplicator 6/Configuration.h
+++ b/config/examples/Wanhao/Duplicator 6/Configuration.h
@@ -1755,7 +1755,7 @@
 //
 // ULTIPANEL as seen on Thingiverse.
 //
-#define ULTIPANEL
+//#define ULTIPANEL
 
 //
 // PanelOne from T3P3 (via RAMPS 1.4 AUX2/AUX3)
@@ -1988,10 +1988,7 @@
 //
 // SSD1306 OLED full graphics generic display
 //
-#define U8GLIB_SSD1306
-#define LCD_WIDTH 22
-#define LCD_HEIGHT 5
-#define LCD_RESET_PIN 5
+//#define U8GLIB_SSD1306
 
 //
 // SAV OLEd LCD module support using either SSD1306 or SH1106 based LCD modules
@@ -2005,7 +2002,8 @@
 //
 // TinyBoy2 128x64 OLED / Encoder Panel
 //
-//#define OLED_PANEL_TINYBOY2
+#define OLED_PANEL_TINYBOY2
+#define LCD_RESET_PIN 5
 
 //
 // MKS OLED 1.3" 128 × 64 FULL GRAPHICS CONTROLLER


### PR DESCRIPTION
### Description

Double LCD defines for the Wanhao D6 no longer work in Marlin 2.0 due to a sanity check error, so the config now uses `OLED_PANEL_TINYBOY2`.

This supersedes changes made to `2.0.x` directly by @shitcreek: https://github.com/MarlinFirmware/Marlin/commit/4c261313eec206280e1c1163563e9fe62a89ea96

### Benefits

Users can compile without `SanityCheck` errors and they have a working LCD:

![image](https://user-images.githubusercontent.com/13375512/70212935-15619b80-16ed-11ea-874a-94c47314aa93.png)

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/16087