### PR TITLE
Adds fan speeds to temperature output for remote displays

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2505,6 +2505,11 @@
 #define EXTENDED_CAPABILITIES_REPORT
 
 /**
+ * Include fan speeds in temperature report
+ */
+ #define INCLUDE_FAN_SPEEDS
+ 
+/**
  * Expected Printer Check
  * Add the M16 G-code to compare a string to the MACHINE_NAME.
  * M16 with a non-matching string causes the printer to halt.

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2821,13 +2821,11 @@ void Temperature::tick() {
         , H_CHAMBER
       );
     #endif // HAS_TEMP_CHAMBER
+
     #if ENABLED(INCLUDE_FAN_SPEEDS)
-      FANS_LOOP(f){
-        SERIAL_ECHO(" ");
-        SERIAL_ECHOPAIR("F",f);
-        SERIAL_ECHOPAIR(":", fan_speed[f]);
-      }    
-    #endif // INCLUDE FAN SPEEDS
+      FANS_LOOP(f) SERIAL_ECHOPAIR(" F", f, ":", fan_speed[f]);
+    #endif
+
     #if HOTENDS > 1
       HOTEND_LOOP() print_heater_state(degHotend(e), degTargetHotend(e)
         #if ENABLED(SHOW_TEMP_ADC_VALUES)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2821,6 +2821,13 @@ void Temperature::tick() {
         , H_CHAMBER
       );
     #endif // HAS_TEMP_CHAMBER
+    #if ENABLED(INCLUDE_FAN_SPEEDS)
+      FANS_LOOP(f){
+        SERIAL_ECHO(" ");
+        SERIAL_ECHOPAIR("F",f);
+        SERIAL_ECHOPAIR(":", fan_speed[f]);
+      }    
+    #endif // INCLUDE FAN SPEEDS
     #if HOTENDS > 1
       HOTEND_LOOP() print_heater_state(degHotend(e), degTargetHotend(e)
         #if ENABLED(SHOW_TEMP_ADC_VALUES)


### PR DESCRIPTION
Description:
This allows the optional addition of fan speeds in the temperature output

Benefits:
This allows serial remote displays such as the bigtreetech tft24, tft35, etc. to display the current fan speed when sending gcode from another host (eg: octoprint)

Related Issues:
https://github.com/MarlinFirmware/Marlin/issues/9846