### PR TITLE
Add condition for frequency limit - fixes issues with laser

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -321,6 +321,14 @@
 #define TEMP_SENSOR_AD8495_GAIN   1.0
 
 /**
+ * 
+ * Limit check_axes_activity frequency to 10Hz
+ * Affects M106
+ * Undefine this if laser engraving with M106 produces blurry results
+*/
+// #define LIMIT_FREQUENCY
+
+/**
  * Controller Fan
  * To cool down the stepper drivers and MOSFETs.
  *

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -608,12 +608,16 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
     L6470.monitor_driver();
   #endif
 
-  // Limit check_axes_activity frequency to 10Hz
-  static millis_t next_check_axes_ms = 0;
-  if (ELAPSED(ms, next_check_axes_ms)) {
+// Limit check_axes_activity frequency to 10Hz
+  #if ENABLED(LIMIT_FREQUENCY)
+    static millis_t next_check_axes_ms = 0;
+    if (ELAPSED(ms, next_check_axes_ms)) {
+      planner.check_axes_activity();
+      next_check_axes_ms = ms + 100UL;
+    }
+  #else
     planner.check_axes_activity();
-    next_check_axes_ms = ms + 100UL;
-  }
+  #endif
 
   #if PIN_EXISTS(FET_SAFETY)
     static millis_t FET_next;


### PR DESCRIPTION
The frequency limit causes blurry raster engraving (https://github.com/MarlinFirmware/Marlin/issues/16058)
And for the new yet to be merged laser improvements PR (https://github.com/MarlinFirmware/Marlin/pull/15335), it causes the laser to stay on after a job has finished.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
