### PR TITLE
Update BTT comments for USB/SD Composite

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -290,9 +290,9 @@ monitor_speed     = 250000
 # BigTree SKR Mini V1.1 / SKR mini E3 / SKR E3 DIP (STM32F103RCT6 ARM Cortex-M3)
 #
 #   STM32F103RC_bigtree ............. RCT6 with 256K
-#   STM32F103RC_bigtree_USB ......... RCT6 with 256K (USB)
+#   STM32F103RC_bigtree_USB ......... RCT6 with 256K (USB mass storage)
 #   STM32F103RC_bigtree_512K ........ RCT6 with 512K
-#   STM32F103RC_bigtree_512K_USB .... RCT6 with 512K (USB)
+#   STM32F103RC_bigtree_512K_USB .... RCT6 with 512K (USB mass storage)
 #
 
 [env:STM32F103RC_bigtree]
@@ -371,7 +371,7 @@ monitor_speed     = 115200
 
 #
 #   STM32F103RE_bigtree ............. RET6
-#   STM32F103RE_bigtree_USB ......... RET6 (USB)
+#   STM32F103RE_bigtree_USB ......... RET6 (USB mass storage)
 #
 [env:STM32F103RE_bigtree]
 platform          = ststm32


### PR DESCRIPTION
(USB) suffixe is not the best way to explain the difference...

it only adds in fact the USB Mass Storage support (SD card over usb)