### PR TITLE
Better error messages

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -252,10 +252,10 @@
 #define MSG_FILAMENT_CHANGE_INSERT_M108     "Insert filament and send M108"
 #define MSG_FILAMENT_CHANGE_WAIT_M108       "Send M108 to resume"
 
-#define MSG_STOP_BLTOUCH                    "STOP called because of BLTouch error - restart with M999"
-#define MSG_STOP_UNHOMED                    "STOP called because of unhomed error - restart with M999"
-#define MSG_KILL_INACTIVE_TIME              "KILL caused by too much inactive time - current command: "
-#define MSG_KILL_BUTTON                     "KILL caused by KILL button/pin"
+#define MSG_STOP_BLTOUCH                    "!! STOP called because of BLTouch error - restart with M999"
+#define MSG_STOP_UNHOMED                    "!! STOP called because of unhomed error - restart with M999"
+#define MSG_KILL_INACTIVE_TIME              "!! KILL caused by too much inactive time - current command: "
+#define MSG_KILL_BUTTON                     "!! KILL caused by KILL button/pin"
 
 // temperature.cpp strings
 #define MSG_PID_AUTOTUNE_PREFIX             "PID Autotune"


### PR DESCRIPTION
### Requirements
no requirement.

### Description
After a failed levelling, Marlin will not accept any more commands, expecting M999, yet it will not let OctoPrint or other server properly know that something is wrong..  ending up in OctoPrint thinking it is printing , resulting in this:
```

Recv: Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)
Send: N1418 G1 X147.071 Y162.293 E275.84429*84
Recv: ok
Send: N1419 G1 X153.413 Y166.534 F9000.000*103
Recv: Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)
Recv: ok
Recv: Printer stopped due to errors. Fix the error and use M999 to restart. (Temperature is reset. Set it after restarting)
Send: N1420 G1 F3600.000*98
Recv: ok
```

OctoPrint  / others require critical errors to start with: 
"Error:"
"!!"
"fatal:"


### Benefits

The errors will be "understood" as such, and octoprint will stop hammering, and report an error.

### Related Issues

