### PR TITLE
Disable SD_CHECK_AND_RETRY in SKR Mini E3 Configs

### DIFF
--- a/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration.h
@@ -1624,7 +1624,7 @@
  *
  * Use CRC checks and retries on the SD communication.
  */
-#define SD_CHECK_AND_RETRY
+//#define SD_CHECK_AND_RETRY
 
 /**
  * LCD Menu Items

--- a/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration.h
@@ -1624,7 +1624,7 @@
  *
  * Use CRC checks and retries on the SD communication.
  */
-#define SD_CHECK_AND_RETRY
+//#define SD_CHECK_AND_RETRY
 
 /**
  * LCD Menu Items


### PR DESCRIPTION
### Description

Disable `SD_CHECK_AND_RETRY` on BigTreeTech SKR E3 configs due to issues with mass storage.

### Benefits

Mass storage over USB works correctly.

### Related Issues

Mentioned on Discord by niteta:
>Commenting out the #define SD_CHECK_AND_RETRY allows now seeing the SD card content

& https://github.com/MarlinFirmware/Marlin/pull/16130#issuecomment-562748129.