### PR TITLE
Enable stealthChop for TMC2209 homing

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -1038,9 +1038,10 @@
 
   bool tmc_enable_stallguard(TMC2209Stepper &st) {
     st.TCOOLTHRS(0xFFFFF);
-    return true;
+    return stealthchop_was_enabled;
   }
-  void tmc_disable_stallguard(TMC2209Stepper &st, const bool restore_stealth _UNUSED) {
+  void tmc_disable_stallguard(TMC2209Stepper &st, const bool restore_stealth) {
+    st.en_spreadCycle(!restore_stealth);
     st.TCOOLTHRS(0);
   }
 


### PR DESCRIPTION
Description:
Enables stealthchop before homing axes when using TMC2209 and sensorless homing is enabled

Benefits:
This is to address bug #16091 where sensorless homing would fail if the driver was in spreadcycle mode for that axis.

Related Issues
https://github.com/MarlinFirmware/Marlin/issues/16091
