### PR TITLE
Flash leveling for some STM32 boards (and more later?)

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/persistent_store_flash.cpp
+++ b/Marlin/src/HAL/HAL_STM32/persistent_store_flash.cpp
@@ -1,0 +1,256 @@
+/**
+ * Marlin 3D Printer Firmware
+ *
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2016 Bob Cousins bobcousins42@googlemail.com
+ * Copyright (c) 2015-2016 Nico Tonnhofer wurstnase.reprap@gmail.com
+ * Copyright (c) 2016 Victor Perez victor_pv@hotmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(EEPROM_SETTINGS) && ENABLED(FLASH_EEPROM_EMULATION)
+
+#include "../shared/persistent_store_api.h"
+
+/*
+  The STM32 HAL supports chips that deal with "pages" and some with "sectors" and some that
+  even have multiple "banks" of flash.
+
+  This code is a bit of a mashup of
+    framework-arduinoststm32/cores/arduino/stm32/stm32_eeprom.c
+    hal/hal_lpc1768/persistent_store_flash.cpp
+
+  This has only be written against those that use a single "sector" design. Probably all the
+  STM32F4 chips, but I don't know. Expect the F42/43, those have to worry about banks too.
+
+  Those that deal with "pages" could be made to work. Looking at the STM32F07 for example, there are
+  128 "pages", each 2kB in size. If we continued with our EEPROM being 4Kb, we'd always need to operate
+  on 2 of these pages. Each write, we'd use 2 different pages from a pool of pages until we are done.
+*/
+#if ENABLED(FLASH_EEPROM_LEVELING) && (defined(STM32F407xx) || defined(STM32F446xx))
+
+  #include "stm32_def.h"
+
+  #define DEBUG_OUT ENABLED(FLASH_DEBUG)
+  #include "src/core/debug_out.h"
+
+  #ifndef FLASH_SECTOR
+    #define FLASH_SECTOR          (FLASH_SECTOR_TOTAL - 1)
+  #endif
+  #ifndef FLASH_UNIT_SIZE
+    #define FLASH_UNIT_SIZE       0x20000 // 128kB
+  #endif
+  #ifndef FLASH_ADDRESS_START
+    #define FLASH_ADDRESS_START   0x080E0000
+  #endif
+  #ifndef EEPROM_SIZE
+    #define EEPROM_SIZE           0x1000    // 4kB, we could bump this up if we want to go crazy with ubl meshes
+  #endif
+
+  #define FLASH_ADDRESS_END       (FLASH_ADDRESS_START + FLASH_UNIT_SIZE)
+  #define EEPROM_SLOTS            (FLASH_UNIT_SIZE/EEPROM_SIZE)
+  #define SLOT_ADDRESS(slot)      (FLASH_ADDRESS_START + (slot * EEPROM_SIZE))
+
+  //#define DISABLE_IRQ()         prim = __get_PRIMASK();__disable_irq()
+  //#define ENABLE_IRQ()          if (!prim) __enable_irq()
+
+  #define UNLOCK_FLASH()          if (!flash_unlocked) { \
+                                    HAL_FLASH_Unlock(); \
+                                    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_EOP | FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | \
+                                                           FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR); \
+                                    flash_unlocked = true; \
+                                  }
+  #define LOCK_FLASH()            if (flash_unlocked) { HAL_FLASH_Lock(); flash_unlocked = false; }
+
+  #define EMPTY_UINT32            ((uint32_t)-1)
+  #define EMPTY_UINT8             ((uint8_t)-1)
+
+  static uint8_t ram_eeprom[EEPROM_SIZE] __attribute__((aligned(4))) = {0};
+  static int current_slot = 0;
+#else
+  #undef FLASH_EEPROM_LEVELING
+#endif
+
+static bool eeprom_data_written = false;
+
+bool PersistentStore::access_start() {
+
+  #if defined(FLASH_EEPROM_LEVELING)
+
+    static_assert(true == IS_FLASH_SECTOR(FLASH_SECTOR), "FLASH_SECTOR is invalid");
+    static_assert(0 == EEPROM_SIZE % 4, "EEPROM_SIZE must be a multiple of 4"); // Ensure copying as uint32_t is safe
+    static_assert(0 == (FLASH_UNIT_SIZE & (FLASH_UNIT_SIZE - 1)), "FLASH_UNIT_SIZE should be a power of 2, please check your chips spec sheet");
+    static_assert(0 == FLASH_UNIT_SIZE % EEPROM_SIZE, "EEPROM_SIZE must divide evenly into your FLASH_UNIT_SIZE");
+
+    current_slot = -1;
+
+    // Look to see if we have any data stored yet, and where
+    uint32_t address = FLASH_ADDRESS_START;
+    while (address < FLASH_ADDRESS_END) {
+      uint32_t address_value = (*(__IO uint32_t*)address);
+      if (address_value != EMPTY_UINT32) {
+        current_slot = (address - FLASH_ADDRESS_START) / EEPROM_SIZE;
+        break;
+      }
+      address += sizeof(uint32_t);
+    }
+
+    if (current_slot == -1) {
+      // we have no data yet, so we'll just intialize to empty
+      for (int i = 0; i < EEPROM_SIZE; i++) ram_eeprom[i] = EMPTY_UINT8;
+      current_slot = EEPROM_SLOTS;
+    }
+    else {
+      // load current settings
+      uint8_t *eeprom_data = (uint8_t *)SLOT_ADDRESS(current_slot);
+      for (int i = 0; i < EEPROM_SIZE; i++) ram_eeprom[i] = eeprom_data[i];
+    }
+
+    DEBUG_ECHOLNPAIR("Slot=", current_slot);
+    eeprom_data_written = false;
+
+  #else
+    eeprom_buffer_fill();
+  #endif
+
+  return true;
+}
+
+bool PersistentStore::access_finish() {
+
+  if (eeprom_data_written) {
+
+    #if defined(FLASH_EEPROM_LEVELING)
+
+      HAL_StatusTypeDef status = HAL_ERROR;
+      bool flash_unlocked = false;
+
+      if (--current_slot < 0) {
+        // all slots have been used, erase everything and start again
+
+        FLASH_EraseInitTypeDef EraseInitStruct;
+        uint32_t SectorError = 0;
+
+        EraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
+        EraseInitStruct.VoltageRange = FLASH_VOLTAGE_RANGE_3;
+        EraseInitStruct.Sector = FLASH_SECTOR;
+        EraseInitStruct.NbSectors = 1;
+
+        current_slot = EEPROM_SLOTS - 1;
+        UNLOCK_FLASH();
+
+        status = HAL_FLASHEx_Erase(&EraseInitStruct, &SectorError);
+        if (status != HAL_OK) {
+          DEBUG_ECHOLNPAIR("HAL_FLASHEx_Erase=", status);
+          DEBUG_ECHOLNPAIR("GetError=", HAL_FLASH_GetError());
+          DEBUG_ECHOLNPAIR("SectorError=", SectorError);
+          LOCK_FLASH();
+          return false;
+        }
+      }
+
+      UNLOCK_FLASH();
+
+      uint32_t offset = 0;
+      uint32_t address = SLOT_ADDRESS(current_slot);
+      uint32_t address_end = address + EEPROM_SIZE;
+      uint32_t data = 0;
+
+      bool success = true;
+
+      DEBUG_ECHOLNPAIR("current_slot=", current_slot);
+      DEBUG_ECHOLNPAIR("address=", address);
+      DEBUG_ECHOLNPAIR("address_end=", address_end);
+
+      while (address < address_end) {
+        memcpy(&data, ram_eeprom + offset, sizeof(uint32_t));
+        status = HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, data);
+        if (status == HAL_OK) {
+          address += sizeof(uint32_t);
+          offset += sizeof(uint32_t);
+        }
+        else {
+          DEBUG_ECHOLNPAIR("HAL_FLASH_Program=", status);
+          DEBUG_ECHOLNPAIR("GetError=", HAL_FLASH_GetError());
+          DEBUG_ECHOLNPAIR("address=", address);
+          success = false;
+          break;
+        }
+      }
+
+      LOCK_FLASH();
+
+      if (success) eeprom_data_written = false;
+      return success;
+
+    #else
+      eeprom_buffer_flush();
+      eeprom_data_written = false;
+    #endif
+  }
+
+  return true;
+}
+
+bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
+  while (size--) {
+    uint8_t v = *value;
+    #if defined(FLASH_EEPROM_LEVELING)
+      ram_eeprom[pos] = v;
+    #else
+      eeprom_buffered_write_byte(pos, v);
+    #endif
+    crc16(crc, &v, 1);
+    pos++;
+    value++;
+  }
+  eeprom_data_written = true;
+  return false;
+
+}
+
+bool PersistentStore::read_data(int &pos, uint8_t* value, size_t size, uint16_t *crc, const bool writing/*=true*/) {
+  do {
+    const uint8_t c = (
+      #if defined(FLASH_EEPROM_LEVELING)
+        ram_eeprom[pos]
+      #else
+        eeprom_buffered_read_byte(pos)
+      #endif
+    );
+    if (writing) *value = c;
+    crc16(crc, &c, 1);
+    pos++;
+    value++;
+  } while (--size);
+  return false;
+}
+
+size_t PersistentStore::capacity() {
+  return (
+    #if defined(FLASH_EEPROM_LEVELING)
+      EEPROM_SIZE
+    #else
+      E2END + 1
+    #endif
+  );
+}
+
+#endif // ENABLED(EEPROM_SETTINGS) && ENABLED(FLASH_EEPROM_EMULATION)
+#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/lcd/language/language_da.h
+++ b/Marlin/src/lcd/language/language_da.h
@@ -180,7 +180,7 @@ namespace Language_da {
   PROGMEM Language_Str MSG_DAC_PERCENT_Y                   = _UxGT("Y Driv %");
   PROGMEM Language_Str MSG_DAC_PERCENT_Z                   = _UxGT("Z Driv %");
   PROGMEM Language_Str MSG_DAC_PERCENT_E                   = _UxGT("E Driv %");
-  
+
   PROGMEM Language_Str MSG_DAC_EEPROM_WRITE                = _UxGT("DAC EEPROM Skriv");
 
   PROGMEM Language_Str MSG_FILAMENT_CHANGE_OPTION_RESUME   = _UxGT("Forsæt print");


### PR DESCRIPTION
**This is currently a draft.** It works on my board. I welcome contributions to include other variations of the STM32 platform, if it is something the community would like to pursue.

My C/C++ skills are beginner level so I'm sure things can "better".

#### Description

The STM32 library, specifically framework-adruinoststm32 as used by the SKR PRO 1.1 has a simple flash eeprom implementation that writes a buffer in the same location on all the STM32 boards.

This PR is the basis (more work will be needed if we want to try to cover everything) of adding LPC style wear leveling to the flash operations.

Currently, only `STM32F407xx` and `STM32F446xx` have the option of enabling this new feature. To enabled:

`#define EEPROM_SETTINGS`
`#define FLASH_EEPROM_EMULATION`
`#define FLASH_EEPROM_LEVELING`

If you do not add `#define FLASH_EEPROM_LEVELING` then it will just use the platforms version of eeprom saving. It supports more versions, but again, only writes to the same flash locations.

#### Why isn't everything supported?

The STM32 platform is a circus. Some chips have a concept of `sectors` and some `pages`. Really, there isn't that much difference between the 2. A `sector` and a `page` are still the smallest unit you can erase. It is just that a `page` is generally around 2 or 4kB in size, whereas a `sector` is between 16kB and 128kB. The ones at the end of the flash that we can use are always (?) 128kB.

To complicate matters further, some chips have multiple `banks`. From what I can gather, there are different ways to use the banks.

In order to support everything, we'd have to look more into `stm32_eeprom.c` (where I took inspiration) and add in all the different `#define` they have.

The hard part, is, for those that use small `pages` of 2kB, we'd have to keep track of multiple pages. If we want to keep the 4kB eeprom, then we'd have to manage 2 pages per `slot`.

This simple implementation defines a maximum number of `slots` by dividing the sector by the eeprom size. The out of the box defines means we have 32 slots.

#### What's next?

The LPC code included disabling interrupts during operations. I am unsure if the STM32 platform needs that or not. I don't really see anything in the platform eeprom version, nor on the internet about it.

More boards. I know there is talk of merging the other STM32 HALs. At a minimum we might want to add in support for the F103 board (a `pages` board). This would, I think, cover over 80% of the current STM32 boards.

#### Benefits

Flash doesn't wear out as fast.

#### Credit

Most of the code is a mashup of the HAL_STM32 and HAL_LPC1768 and the framework-arduinoststm32/cores/arduino/stm32/stm32_eeprom.* (and other files).

