### PR TITLE
Correct MKS Robin Mini pins

### DIFF
--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
@@ -126,9 +126,9 @@
 
   #if ENABLED(TOUCH_BUTTONS)
     #define TOUCH_CS_PIN   PC2
-	#define TOUCH_SCK_PIN PB13
-	#define TOUCH_MOSI_PIN PB15
-	#define TOUCH_MISO_PIN PB14
+    #define TOUCH_SCK_PIN  PB13
+    #define TOUCH_MOSI_PIN PB15
+    #define TOUCH_MISO_PIN PB14
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_MINI.h
@@ -54,7 +54,7 @@
 #define Z_MAX_PIN          PC4
 
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN   PF11  // MT_DET
+  #define FIL_RUNOUT_PIN   PA4  // MT_DET
 #endif
 
 //
@@ -119,13 +119,16 @@
   #define FSMC_CS_PIN      PD7    // NE4
   #define FSMC_RS_PIN      PD11   // A0
 
-  #define LCD_RESET_PIN    PF6
+  #define LCD_RESET_PIN    PC6
   #define NO_LCD_REINIT           // Suppress LCD re-initialization
 
   #define LCD_BACKLIGHT_PIN PD13
 
   #if ENABLED(TOUCH_BUTTONS)
     #define TOUCH_CS_PIN   PC2
+	#define TOUCH_SCK_PIN PB13
+	#define TOUCH_MOSI_PIN PB15
+	#define TOUCH_MISO_PIN PB14
   #endif
 #endif
 


### PR DESCRIPTION
### Description

Pins for mks robin mini board corrected so they match the schema found at: https://github.com/makerbase-mks/MKS-Robin/blob/master/MKS%20Robin%20Mini/hardware/MKS%20Robin%20Mini%20V2.0_004/MKS%20Robin%20Mini%20V2.0_004%20SCH.pdf

Pins for filament detection and touch reset was incorrect and touch screen SPI was missing probably copy paste errors by using MKS Robin as template.

### Benefits

With these changes and a proper config (example will be uploaded at a later time) the Flsun QQ-S with stock board can run Marlin 2.0 
