### PR TITLE
Fix controller and SD on Robin Nano

### DIFF
--- a/Marlin/src/pins/stm32/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32/pins_MKS_ROBIN_NANO.h
@@ -39,11 +39,6 @@
 #define DISABLE_DEBUG
 
 //
-// Note: MKS Robin board is using SPI2 interface.
-//
-#define SPI_MODULE 2
-
-//
 // Limit Switches
 //
 #define X_STOP_PIN        PA15
@@ -109,10 +104,15 @@
 #define LED_PIN            PB2
 
 //
+// SD Card
+//
+#define SDIO_SUPPORT
+#define SD_DETECT_PIN      PD12
+
+//
 // LCD / Controller
 //
 #define BEEPER_PIN         PC5
-#define SD_DETECT_PIN      PD12
 
 /**
  * Note: MKS Robin TFT screens use various TFT controllers.
@@ -123,12 +123,15 @@
   #define FSMC_CS_PIN        PD7    // NE4
   #define FSMC_RS_PIN        PD11   // A0
 
-  #define LCD_RESET_PIN      PF6
+  #define LCD_RESET_PIN      PC6    // FSMC_RST
   #define NO_LCD_REINIT             // Suppress LCD re-initialization
 
   #define LCD_BACKLIGHT_PIN  PD13
 
   #if ENABLED(TOUCH_BUTTONS)
-    #define TOUCH_CS_PIN     PA7
+    #define TOUCH_CS_PIN     PA7  // SPI2_NSS
+    #define TOUCH_SCK_PIN    PB13 // SPI2_SCK
+    #define TOUCH_MISO_PIN   PB14 // SPI2_MISO
+    #define TOUCH_MOSI_PIN   PB15 // SPI2_MOSI
   #endif
 #endif


### PR DESCRIPTION
### Description

- Corrected LCD reset PIN for Robin Nano
- Define all pins required for xpt2046 touch panel to function
- Enabled SDIO_SUPPORT for on-board SD card slot to function

Used https://github.com/makerbase-mks/MKS-Robin-Nano/blob/master/hardware/MKS Robin Nano V1.2_003/MKS Robin Nano V1.2_003 SCH.pdf as pin reference.

### Benefits

Screen and SD card work with MKS Nano board.