### PR TITLE
Add MKS 12864 OLED pins to SGEN-L

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -224,16 +224,17 @@
 
     #else // !MKS_12864OLED_SSD1306
 
-      #define LCD_PINS_RS    P0_16
+      #define LCD_PINS_RS  P0_16
 
       #define LCD_PINS_ENABLE P0_18
-      #define LCD_PINS_D4    P0_15
+      #define LCD_PINS_D4  P0_15
 
       #if ENABLED(FYSETC_MINI_12864)
-        #define DOGLCD_CS    P0_18
-        #define DOGLCD_A0    P0_16
-        #define DOGLCD_SCK   P0_07
-        #define DOGLCD_MOSI  P1_20
+
+        #define DOGLCD_CS  P0_18
+        #define DOGLCD_A0  P0_16
+        #define DOGLCD_SCK P0_07
+        #define DOGLCD_MOSI P1_20
 
         #define LCD_BACKLIGHT_PIN -1
 

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -222,7 +222,7 @@
       #define LCD_PINS_D7  P1_22
       #define KILL_PIN     -1 // NC
 
-    #else
+    #else // !MKS_12864OLED_SSD1306
 
       #define LCD_PINS_RS    P0_16
 
@@ -271,7 +271,7 @@
 
       #endif // !FYSETC_MINI_12864
 
-    #endif //MKS_12864OLED_SSD1306
+    #endif // !MKS_12864OLED_SSD1306
 
   #endif // !CR10_STOCKDISPLAY
 

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -203,60 +203,76 @@
     #define LCD_PINS_D4    P0_17
 
   #else
-    #define LCD_PINS_RS    P0_16
 
     #define BTN_EN1        P3_25
     #define BTN_EN2        P3_26
 
-    #define LCD_PINS_ENABLE P0_18
-    #define LCD_PINS_D4    P0_15
-
     #define LCD_SDSS       P0_28
     #define SD_DETECT_PIN  P0_27
 
-    #if ENABLED(FYSETC_MINI_12864)
-      #define DOGLCD_CS    P0_18
-      #define DOGLCD_A0    P0_16
-      #define DOGLCD_SCK   P0_07
-      #define DOGLCD_MOSI  P1_20
+    #if ENABLED(MKS_12864OLED_SSD1306)
+        #define LCD_PINS_DC  P0_17
+	      #define DOGLCD_CS    P0_16
+        #define DOGLCD_A0    LCD_PINS_DC
+        #define DOGLCD_SCK   P0_15
+        #define DOGLCD_MOSI  P0_18
 
-      #define LCD_BACKLIGHT_PIN -1
+	      #define LCD_PINS_RS  P1_00
+      	#define LCD_PINS_D7  P1_22
+	      #define KILL_PIN     -1 // NC
 
-      #define FORCE_SOFT_SPI      // Use this if default of hardware SPI causes display problems
-                                  //   results in LCD soft SPI mode 3, SD soft SPI mode 0
+    #else
 
-      #define LCD_RESET_PIN P0_15   // Must be high or open for LCD to operate normally.
+      #define LCD_PINS_RS    P0_16
 
-      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
-        #ifndef RGB_LED_R_PIN
-          #define RGB_LED_R_PIN P0_17
+      #define LCD_PINS_ENABLE P0_18
+      #define LCD_PINS_D4    P0_15
+
+      #if ENABLED(FYSETC_MINI_12864)
+        #define DOGLCD_CS    P0_18
+        #define DOGLCD_A0    P0_16
+        #define DOGLCD_SCK   P0_07
+        #define DOGLCD_MOSI  P1_20
+
+        #define LCD_BACKLIGHT_PIN -1
+
+        #define FORCE_SOFT_SPI      // Use this if default of hardware SPI causes display problems
+                                    //   results in LCD soft SPI mode 3, SD soft SPI mode 0
+
+        #define LCD_RESET_PIN P0_15   // Must be high or open for LCD to operate normally.
+
+        #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
+          #ifndef RGB_LED_R_PIN
+            #define RGB_LED_R_PIN P0_17
+          #endif
+          #ifndef RGB_LED_G_PIN
+            #define RGB_LED_G_PIN P1_00
+          #endif
+          #ifndef RGB_LED_B_PIN
+            #define RGB_LED_B_PIN P1_22
+          #endif
+        #elif ENABLED(FYSETC_MINI_12864_2_1)
+          #define NEOPIXEL_PIN    P0_17
         #endif
-        #ifndef RGB_LED_G_PIN
-          #define RGB_LED_G_PIN P1_00
+
+      #else // !FYSETC_MINI_12864
+
+        #if ENABLED(MKS_MINI_12864)
+          #define DOGLCD_CS  P0_17
+          #define DOGLCD_A0  P1_00
         #endif
-        #ifndef RGB_LED_B_PIN
-          #define RGB_LED_B_PIN P1_22
+
+        #if ENABLED(ULTIPANEL)
+          #define LCD_PINS_D5 P0_17
+          #define LCD_PINS_D6 P1_00
+          #define LCD_PINS_D7 P1_22
         #endif
-      #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN    P0_17
-      #endif
 
-    #else // !FYSETC_MINI_12864
+      #endif // !FYSETC_MINI_12864
 
-      #if ENABLED(MKS_MINI_12864)
-        #define DOGLCD_CS  P0_17
-        #define DOGLCD_A0  P1_00
-      #endif
+    #endif //MKS_12864OLED_SSD1306
 
-      #if ENABLED(ULTIPANEL)
-        #define LCD_PINS_D5 P0_17
-        #define LCD_PINS_D6 P1_00
-        #define LCD_PINS_D7 P1_22
-      #endif
-
-    #endif // !FYSETC_MINI_12864
-
-  #endif
+  #endif // !CR10_STOCKDISPLAY
 
 #endif // HAS_SPI_LCD
 

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -211,15 +211,16 @@
     #define SD_DETECT_PIN  P0_27
 
     #if ENABLED(MKS_12864OLED_SSD1306)
-        #define LCD_PINS_DC  P0_17
-	      #define DOGLCD_CS    P0_16
-        #define DOGLCD_A0    LCD_PINS_DC
-        #define DOGLCD_SCK   P0_15
-        #define DOGLCD_MOSI  P0_18
 
-	      #define LCD_PINS_RS  P1_00
-      	#define LCD_PINS_D7  P1_22
-	      #define KILL_PIN     -1 // NC
+      #define LCD_PINS_DC  P0_17
+      #define DOGLCD_CS    P0_16
+      #define DOGLCD_A0    LCD_PINS_DC
+      #define DOGLCD_SCK   P0_15
+      #define DOGLCD_MOSI  P0_18
+
+      #define LCD_PINS_RS  P1_00
+      #define LCD_PINS_D7  P1_22
+      #define KILL_PIN     -1 // NC
 
     #else
 


### PR DESCRIPTION
### Description

Add MKS 12864 OLED support to MKS SGEN-L.

I used the `MKS_12864OLED_SSD1306` pinout in the RAMPS pins to figure out the pin order & then mapped them to the SGEN-L pins as the following:
```c
#define BEEPER_PIN   P1_31
#define BTN_ENC      P1_30
#define DOGLCD_MOSI  P0_18
#define DOGLCD_CS    P0_16
#define DOGLCD_SCK   P0_15
#define LCD_PINS_DC  P0_17
#define DOGLCD_A0    LCD_PINS_DC
#define LCD_PINS_RS  P1_00
#define LCD_PINS_D7  P1_22
#define BTN_EN1      P3_25
#define BTN_EN2      P3_26
#define SD_DETECT_PIN P0_27
#define KILL_PIN     -1 // NC
```

### Benefits

MKS 12864 OLED can be used on an MKS SGEN-L.

### Related Issues

#16142