### PR TITLE
Fix EXTRUDER_RUNOUT_PREVENT compile error

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -553,7 +553,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
         bool oldstatus;
         switch (active_extruder) {
           default:
-          #define _CASE_EN(N) case N: oldstatus = E##N_ENABLE_READ(); enable_E##N(); break;
+          #define _CASE_EN(N) case N: oldstatus = E##N##_ENABLE_READ(); enable_E##N(); break;
           REPEAT(E_STEPPERS, _CASE_EN);
         }
       #endif


### PR DESCRIPTION
### Description

Replaces a `E##N_ENABLE_READ` with `E##N##_ENABLE_READ` so the code will compile.

### Benefits

The code will compile when `ENABLED(SWITCHING_EXTRUDER)`

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/16185
