### PR TITLE
M503 Mesh Bed Leveling 2.x format

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -2877,10 +2877,12 @@ void MarlinSettings::reset() {
           for (uint8_t py = 0; py < GRID_MAX_POINTS_Y; py++) {
             for (uint8_t px = 0; px < GRID_MAX_POINTS_X; px++) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR_P(PSTR("  G29 S3 X"), (int)px + 1, SP_Y_STR, (int)py + 1);
+              SERIAL_ECHOPAIR_P(PSTR("  G29 S3 I"), (int)px, PSTR(" J"), (int)py);
               SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(mbl.z_values[px][py]), 5);
             }
           }
+          CONFIG_ECHO_START();
+          SERIAL_ECHOLNPAIR_F_P(PSTR("  G29 S4 Z"), LINEAR_UNIT(mbl.z_offset), 5);
         }
 
       #elif ENABLED(AUTO_BED_LEVELING_UBL)


### PR DESCRIPTION

### Description

The Mesh Bed Leveling output in M503 was still using the 1.x format (X/Y
coordinates). This updates it to use the I/J coordinates, as needed to
paste the configuration, e.g. after a M502 reset.

Also adds G29 S4 (Z offset) to the output.

### Benefits

Output from M503 may be captured and stored, then used later to restore MBL after any loss (intentional or not) of EEPROM data.

### Related Issues

Fixes: #16195