### PR TITLE
Add RUMBA32 support to PIO builds

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -754,7 +754,7 @@ build_flags   = ${common.build_flags}
   -Os
 lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel
-src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32> +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F7>
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 500000
 upload_protocol = dfu
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -757,6 +757,27 @@ monitor_speed = 500000
 upload_protocol = dfu
 
 #
+# MKS RUMBA32(add TMC2208/2209 UART interface and AUX-1)
+#
+[env:mks_rumba32]
+platform      = ststm32
+board         = rumba32_f446ve
+build_flags   = ${common.build_flags}
+ -DSTM32F4xx -DARDUINO_RUMBA32_F446VE -DARDUINO_ARCH_STM32 "-DBOARD_NAME=\"RUMBA32_F446VE\""
+ -DSTM32F446xx -DUSBCON -DUSBD_VID=0x8000
+  "-DUSB_MANUFACTURER=\"Unknown\""
+  "-DUSB_PRODUCT=\"RUMBA32_F446VE\""
+  -DHAL_PCD_MODULE_ENABLED
+  -DUSBD_USE_CDC
+  -DDISABLE_GENERIC_SERIALUSB
+  -DHAL_UART_MODULE_ENABLED
+  -Os
+lib_ignore    = Adafruit NeoPixel
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32> +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F7>
+monitor_speed = 250000
+upload_protocol = dfu
+
+#
 # Just print the dependency tree
 #
 [env:include_tree]

--- a/platformio.ini
+++ b/platformio.ini
@@ -731,6 +731,34 @@ src_filter    = ${common.default_src_filter} +<src/HAL/HAL_SAMD51>
 debug_tool    = jlink
 
 #
+# RUMBA32
+#
+[env:rumba32_f446ve]
+platform      = ststm32
+framework     = arduino
+board         = rumba32_f446ve
+build_flags   = ${common.build_flags}
+  -DSTM32F4xx
+  -DARDUINO_RUMBA32_F446VE
+  -DARDUINO_ARCH_STM32
+  "-DBOARD_NAME=\"RUMBA32_F446VE\""
+  -DSTM32F446xx
+  -DUSBCON
+  -DUSBD_VID=0x0483
+  "-DUSB_MANUFACTURER=\"Unknown\""
+  "-DUSB_PRODUCT=\"RUMBA32_F446VE\""
+  -DHAL_PCD_MODULE_ENABLED
+  -DUSBD_USE_CDC
+  -DDISABLE_GENERIC_SERIALUSB
+  -DHAL_UART_MODULE_ENABLED
+  -Os
+lib_deps      = ${common.lib_deps}
+lib_ignore    = Adafruit NeoPixel
+src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32> +<src/HAL/HAL_STM32_F4_F7> -<src/HAL/HAL_STM32_F4_F7/STM32F7>
+monitor_speed = 500000
+upload_protocol = dfu
+
+#
 # Just print the dependency tree
 #
 [env:include_tree]

--- a/platformio.ini
+++ b/platformio.ini
@@ -735,7 +735,6 @@ debug_tool    = jlink
 #
 [env:rumba32_f446ve]
 platform      = ststm32
-framework     = arduino
 board         = rumba32_f446ve
 build_flags   = ${common.build_flags}
   -DSTM32F4xx
@@ -752,7 +751,6 @@ build_flags   = ${common.build_flags}
   -DDISABLE_GENERIC_SERIALUSB
   -DHAL_UART_MODULE_ENABLED
   -Os
-lib_deps      = ${common.lib_deps}
 lib_ignore    = Adafruit NeoPixel
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 monitor_speed = 500000


### PR DESCRIPTION
### Description

Add RUMBA32 support when using PIO to build Marlin. I have no way to test this, but was requested in #16201.

### Benefits

Users can compile firmware with PlatformIO.

### Related Issues

#16201, #16029, #14942