### PR TITLE
Restore the configs before running these tests.

### DIFF
--- a/buildroot/share/tests/rambo-tests
+++ b/buildroot/share/tests/rambo-tests
@@ -20,6 +20,7 @@ exec_test $1 $2 "Default Configuration"
 #
 # Full size Rambo Dual Endstop CNC
 #
+restore_configs
 opt_set MOTHERBOARD BOARD_RAMBO
 opt_set EXTRUDERS 0
 opt_set TEMP_SENSOR_0 999


### PR DESCRIPTION
# Description

Fixes bug intruduced in #16126. I think when the test was squashed, it removed the restore line, so it still thought it had tmc drivers (The rambo does not have TMC drivers).

### Benefits
Tests (hopefully) pass now
### Related Issues
