### PR TITLE
Stored macros and M98 (RepRapFirmware)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2095,6 +2095,10 @@
     #define DEFAULT_SHARED_VOLUME USB_FLASH_DRIVE  // :[ 'SD_ONBOARD', 'USB_FLASH_DRIVE' ]
   #endif
 
+  // Emulate RepRapFirmware with macro files stored in /sys and /macros
+  // Provide the M98 command to run a macro file as a sub-program
+  //#define MACHINE_COMMAND_MACROS
+
 #endif // HAS_MEDIA
 
 /**

--- a/Marlin/src/gcode/sdcard/M98.cpp
+++ b/Marlin/src/gcode/sdcard/M98.cpp
@@ -1,0 +1,49 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2026 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(MACHINE_COMMAND_MACROS)
+
+#include "../gcode.h"
+#include "../../sd/cardreader.h"
+
+/**
+ * M98: Select file and run as sub-procedure
+ *
+ *   P<path> - The plain (DOS 8.3) filepath
+ *
+ * Example:
+ *    M98 P/macros/home.g ; Run home.g (as a procedure)
+ *
+ */
+void GcodeSuite::M98() {
+  if (card.isMounted() && parser.seen('P')) {
+    char *path = parser.value_string();
+    char *lb = strchr(path, ' ');
+    if (!lb) lb = strchr(path, ';');
+    if (lb) *lb = '\0';
+    card.runMacro(path);
+  }
+}
+
+#endif // MACHINE_COMMAND_MACROS

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -921,6 +921,15 @@ bool CardReader::fileExists(const char * const path) {
   return success;
 }
 
+#if ENABLED(MACHINE_COMMAND_MACROS)
+
+  void CardReader::runMacro(const char * const path) {
+    openFileRead(path, 2);
+    startFileprint();
+  }
+
+#endif
+
 //
 // Delete a file by name in the working directory
 //

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -218,6 +218,10 @@ public:
   // The root directory of the current mounted drive
   static MediaFile getroot() { return root; }
 
+  #if ENABLED(MACHINE_COMMAND_MACROS)
+    static void runMacro(const char * const path);
+  #endif
+
   // Basic file ops
   static void openFileRead(const char * const path, const uint8_t subcall=0);
   static void openFileWrite(const char * const path);
@@ -226,6 +230,7 @@ public:
   static void removeFile(const char * const name);
 
   static char* longest_filename() { return longFilename[0] ? longFilename : filename; }
+
   #if ENABLED(LONG_FILENAME_HOST_SUPPORT)
     static void printLongPath(char * const path);   // Used by M33
     static void getLongPath(char * const pathLong, char * const pathShort); // Used by anycubic_vyper


### PR DESCRIPTION
RepRapFirmware uses files stored on the SD card (in `/macros` and `/sys` folders) for common procedures and allows run-time extension of printer behaviors by editing these files.

At this time Marlin has only a single SD card interface, so it's not possible to support this feature when printing from an external SD card. However an SD-based macro feature would be suitable for a setup that's guaranteed to use an onboard (or single) SD card that is always available during printing.

To better support this feature we should continue to wrangle control over SPI interfaces and explore the possibility of multiple SD card interfaces in a manner similar to the multiple serial interfaces.