### PR TITLE
Bugfix G28 debug and sensorless homing with spreadcycle enabled.

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -262,7 +262,7 @@ void GcodeSuite::G28(const bool always_home_all) {
 
   #if HAS_HOMING_CURRENT
     auto debug_current = [](const char * const s, const int16_t a, const int16_t b){
-      DEBUG_ECHO(s); DEBUG_ECHOLNPGM(" current: ", a, " -> ", b);
+      DEBUG_ECHO(s); DEBUG_ECHOLNPAIR(" current: ", a, " -> ", b);
     };
     #if HAS_CURRENT_HOME(X)
       const int16_t tmc_save_current_X = stepperX.getMilliamps();
@@ -288,7 +288,7 @@ void GcodeSuite::G28(const bool always_home_all) {
 
   #if BOTH(STEALTHCHOP_XY, HOME_USING_SPREADCYCLE)
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Set XY to spreadCycle...");
-    process_subcommands_now_P(PSTR("M569S0XY"));
+    process_subcommands_now_P(PSTR("M569 S0 X Y"));
   #endif
 
   #if ENABLED(IMPROVE_HOMING_RELIABILITY)
@@ -517,7 +517,7 @@ void GcodeSuite::G28(const bool always_home_all) {
 
   #if BOTH(STEALTHCHOP_XY, HOME_USING_SPREADCYCLE)
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Set XY to StealthChop...");
-    process_subcommands_now_P(PSTR("M569S1XY"));
+    process_subcommands_now_P(PSTR("M569 S1 X Y"));
   #endif
 
   ui.refresh();


### PR DESCRIPTION
### Requirements

There are small bugs in G28. when debug is enabled it can not be compiled.
homing with spreadcycle enabled was not working regarding a typo. 

### Description

smal Bugfix in G28

### Benefits
fix homing with spreadCycle. 
fix debug
