### PR TITLE
Add Anet/Zonestar LCD error message to SKR Mini E3 pins

### DIFF
--- a/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32/pins_BTT_SKR_MINI_E3.h
@@ -128,6 +128,8 @@
 
   #elif ENABLED(ZONESTAR_LCD)     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
+    #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3.h' for details. Comment out this line to continue."
+
     #define LCD_PINS_RS    PB9
     #define LCD_PINS_ENABLE PB6
     #define LCD_PINS_D4    PB8


### PR DESCRIPTION
### Description

PR #15931 added `ZONESTAR_LCD` support to the SKR Mini E3, but hardware modification is required or you will damage your board, so this PR adds a error message.

### Benefits

Similar to the error added in PR #16047, users will have to comment out the error before successfully compiling firmware as a safety measure/reminder to perform the mod or they will fry their board.

### Related Issues

 None.