### PR TITLE
Update SD detect pin on MKS SGEN-L

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -208,7 +208,6 @@
     #define BTN_EN2        P3_26
 
     #define LCD_SDSS       P0_28
-    #define SD_DETECT_PIN  P0_27
 
     #if ENABLED(MKS_12864OLED_SSD1306)
 
@@ -285,6 +284,7 @@
 #define ONBOARD_SD_CS_PIN  P0_06   // Chip select for "System" SD card
 
 #if SD_CONNECTION_IS(LCD)
+  #define SD_DETECT_PIN    P0_27
   #define SCK_PIN          P0_07
   #define MISO_PIN         P0_08
   #define MOSI_PIN         P0_09

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -283,18 +283,16 @@
 
 #define ONBOARD_SD_CS_PIN  P0_06   // Chip select for "System" SD card
 
-#if SD_CONNECTION_IS(LCD)
+#if SD_CONNECTION_IS(LCD) || SD_CONNECTION_IS(ONBOARD)
   #define SD_DETECT_PIN    P0_27
   #define SCK_PIN          P0_07
   #define MISO_PIN         P0_08
   #define MOSI_PIN         P0_09
-  #define SS_PIN           P0_28
-#elif SD_CONNECTION_IS(ONBOARD)
-  #define SD_DETECT_PIN    P0_27
-  #define SCK_PIN          P0_07
-  #define MISO_PIN         P0_08
-  #define MOSI_PIN         P0_09
-  #define SS_PIN           ONBOARD_SD_CS_PIN
+  #if SD_CONNECTION_IS(ONBOARD)
+    #define SS_PIN         ONBOARD_SD_CS_PIN
+  #else
+    #define SS_PIN         P0_28
+  #endif
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
   #error "No custom SD drive cable defined for this board."
 #endif


### PR DESCRIPTION
### Description

This PR fixes #16223/allows LCD-based SD cards to be detected on an MKS SGEN-L. 

### Benefits

Allows LCD-based SD cards to be detected on an MKS SGEN-L.

### Related Issues

Fixes #16223