### PR TITLE
add back TOUCH_MI_DEPLOY_XPOS

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -114,7 +114,7 @@ xyz_pos_t probe_offset; // Initialized by settings.load()
   // Move to the magnet to unlock the probe
   void run_deploy_moves_script() {
     #ifndef TOUCH_MI_DEPLOY_XPOS
-     #define TOUCH_MI_DEPLOY_XPOS X_MIN_POS
+      #define TOUCH_MI_DEPLOY_XPOS X_MIN_POS
     #elif TOUCH_MI_DEPLOY_XPOS > X_MAX_BED
       TemporaryGlobalEndstopsState unlock_x(false);
     #endif

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -113,7 +113,9 @@ xyz_pos_t probe_offset; // Initialized by settings.load()
 
   // Move to the magnet to unlock the probe
   void run_deploy_moves_script() {
-    #if TOUCH_MI_DEPLOY_XPOS > X_MAX_BED
+    #ifndef TOUCH_MI_DEPLOY_XPOS
+     #define TOUCH_MI_DEPLOY_XPOS X_MIN_POS
+    #elif TOUCH_MI_DEPLOY_XPOS > X_MAX_BED
       TemporaryGlobalEndstopsState unlock_x(false);
     #endif
     #if TOUCH_MI_DEPLOY_YPOS > Y_MAX_BED


### PR DESCRIPTION
Without declaring TOUCH_MI_DEPLOY_XPOS, **M401** (DEPLOY_PROBE) for the Touch MI probe doesn't work.
This bit of code was removed sometime in the last couple of months - I am not certain why it was removed, but without it, the Touch MI probe would not deploy.
Related issue:
https://github.com/MarlinFirmware/Marlin/issues/16212