### PR TITLE
correct M240 if condition

### DIFF
--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -31,7 +31,7 @@
   millis_t chdk_timeout; // = 0
 #endif
 
-#ifdef PHOTO_POSITION && PHOTO_DELAY_MS > 0
+#if defined(PHOTO_POSITION) && PHOTO_DELAY_MS > 0
   #include "../../../Marlin.h" // for idle()
 #endif
 


### PR DESCRIPTION
`Ifdef` cannot be used in conjunction with regular if condition. Changed to `if defined..`

Compiler warning:
```
Marlin/src/gcode/feature/camera/M240.cpp:34:23: warning: extra tokens at end of #ifdef directive
 #ifdef PHOTO_POSITION && PHOTO_DELAY_MS > 0
```