### PR TITLE
Add MRR_ESPA/MRR_ESPE boards based on ESP32 pins

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -321,6 +321,8 @@
 // Espressif ESP32 WiFi
 //
 #define BOARD_ESPRESSIF_ESP32         6000
+#define BOARD_MRR_ESPA                6001
+#define BOARD_MRR_ESPE                6002
 
 //
 // Simulations

--- a/Marlin/src/pins/esp32/pins_MRR_ESPA.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPA.h
@@ -1,9 +1,9 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
- * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 #pragma once
 
 /**
@@ -29,7 +28,11 @@
  */
 
 #ifndef ARDUINO_ARCH_ESP32
-  "Oops! Select an ESP32 board in 'Tools > Board.'"
+  #error "Oops! Select an ESP32 board in 'Tools > Board.'"
+#elif EXTRUDERS > 1 || E_STEPPERS > 1
+  #error "MRR ESPA only supports one E Stepper. Comment out this line to continue."
+#elif HOTENDS > 1
+  #error "MRR ESPA currently supports only one hotend. Comment out this line to continue."
 #endif
 
 #define BOARD_INFO_NAME "MRR ESPA"

--- a/Marlin/src/pins/esp32/pins_MRR_ESPA.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPA.h
@@ -1,0 +1,98 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+/**
+ * MRR ESPA pin assignments
+ * MRR ESPA is a 3D printer control board based on the ESP32 microcontroller.
+ * Supports 4 stepper drivers, heated bed, single hotend.
+ */
+
+#ifndef ARDUINO_ARCH_ESP32
+  "Oops! Select an ESP32 board in 'Tools > Board.'"
+#endif
+
+#define BOARD_INFO_NAME "MRR ESPA"
+#define BOARD_WEBSITE_URL "github.com/maplerainresearch/MRR_ESPA"
+#define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
+
+//
+// Disable I2S stepper stream
+//
+#ifdef I2S_STEPPER_STREAM
+  #undef I2S_STEPPER_STREAM
+#endif
+#define I2S_WS              -1
+#define I2S_BCK             -1
+#define I2S_DATA            -1
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          34
+#define Y_MIN_PIN          35
+#define Z_MIN_PIN          15
+
+//
+// Steppers
+//
+#define X_STEP_PIN         27
+#define X_DIR_PIN          26
+#define X_ENABLE_PIN       25
+//#define X_CS_PIN           21
+
+#define Y_STEP_PIN         33
+#define Y_DIR_PIN          32
+#define Y_ENABLE_PIN       X_ENABLE_PIN
+//#define Y_CS_PIN           22
+
+#define Z_STEP_PIN         14
+#define Z_DIR_PIN          12
+#define Z_ENABLE_PIN       X_ENABLE_PIN
+//#define Z_CS_PIN            5 // SS_PIN
+
+#define E0_STEP_PIN        16
+#define E0_DIR_PIN         17
+#define E0_ENABLE_PIN      X_ENABLE_PIN
+//#define E0_CS_PIN          21
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         36   // Analog Input
+#define TEMP_BED_PIN       39   // Analog Input
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN        2
+#define FAN_PIN            13
+#define HEATER_BED_PIN      4
+
+//
+// MicroSD card
+//
+#define MOSI_PIN           23
+#define MISO_PIN           19
+#define SCK_PIN            18
+#define SDSS                5

--- a/Marlin/src/pins/esp32/pins_MRR_ESPA.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPA.h
@@ -35,9 +35,9 @@
   #error "MRR ESPA currently supports only one hotend. Comment out this line to continue."
 #endif
 
-#define BOARD_INFO_NAME "MRR ESPA"
-#define BOARD_WEBSITE_URL "github.com/maplerainresearch/MRR_ESPA"
-#define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
+#define BOARD_INFO_NAME       "MRR ESPA"
+#define BOARD_WEBSITE_URL     "github.com/maplerainresearch/MRR_ESPA"
+#define DEFAULT_MACHINE_NAME  BOARD_INFO_NAME
 
 //
 // Disable I2S stepper stream
@@ -52,9 +52,9 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN          34
-#define Y_MIN_PIN          35
-#define Z_MIN_PIN          15
+#define X_STOP_PIN         34
+#define Y_STOP_PIN         35
+#define Z_STOP_PIN         15
 
 //
 // Steppers

--- a/Marlin/src/pins/esp32/pins_MRR_ESPE.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPE.h
@@ -1,0 +1,160 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+/**
+ * MRR ESPE pin assignments
+ * MRR ESPE is a 3D printer control board based on the ESP32 microcontroller.
+ * Supports 5 stepper drivers (using I2S stepper stream), heated bed,
+ * single hotend, and LCD controller.
+ */
+
+#ifndef ARDUINO_ARCH_ESP32
+  "Oops! Select an ESP32 board in 'Tools > Board.'"
+#endif
+
+#define BOARD_INFO_NAME "MRR ESPE"
+#define BOARD_WEBSITE_URL "github.com/maplerainresearch/MRR_ESPE"
+#define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          35
+#define Y_MIN_PIN          32
+#define Z_MIN_PIN          33
+
+//
+// Enable I2S stepper stream
+//
+#ifndef I2S_STEPPER_STREAM
+  #define I2S_STEPPER_STREAM
+#endif
+
+#define I2S_WS              26
+#define I2S_BCK             25
+#define I2S_DATA            27
+
+#ifdef LIN_ADVANCE
+  #undef LIN_ADVANCE  // Currently, I2S stream does not work with linear advance
+#endif
+
+//
+// Steppers
+//
+#define X_STEP_PIN         129
+#define X_DIR_PIN          130
+#define X_ENABLE_PIN       128
+//#define X_CS_PIN           21
+
+#define Y_STEP_PIN         132
+#define Y_DIR_PIN          133
+#define Y_ENABLE_PIN       131
+//#define Y_CS_PIN           22
+
+#define Z_STEP_PIN         135
+#define Z_DIR_PIN          136
+#define Z_ENABLE_PIN       134
+//#define Z_CS_PIN            5 // SS_PIN
+
+#define E0_STEP_PIN        138
+#define E0_DIR_PIN         139
+#define E0_ENABLE_PIN      137
+//#define E0_CS_PIN          21
+
+#define E1_STEP_PIN        141
+#define E2_DIR_PIN         142
+#define E3_ENABLE_PIN      140
+//#define E0_CS_PIN          22
+
+#define Z2_STEP_PIN        141
+#define Z2_DIR_PIN         142
+#define Z2_ENABLE_PIN      140
+//#define Z2_CS_PIN            5
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         36   // Analog Input
+#define TEMP_BED_PIN       39   // Analog Input
+#define TEMP_1_PIN         34
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN     145 // 2
+#define FAN_PIN          146 // 15
+#define HEATER_BED_PIN   144 // 4
+
+#define CONTROLLER_FAN_PIN 147
+//#define E0_AUTO_FAN_PIN 148 // need to update Configuration_adv.h @section extruder 
+//#define E1_AUTO_FAN_PIN 149 // need to update Configuration_adv.h @section extruder 
+#define FAN1_PIN 149
+
+//
+// MicroSD card
+//
+#define MOSI_PIN           23
+#define MISO_PIN           19
+#define SCK_PIN            18
+#define SDSS                5
+
+//////////////////////////
+// LCDs and Controllers //
+//////////////////////////
+
+
+//
+// LCD Display output pins
+//
+#if ENABLED(CR10_STOCKDISPLAY)
+  #define LCD_PINS_RS         13
+  #define LCD_PINS_ENABLE     17
+  #define LCD_PINS_D4         16
+  #define BEEPER_PIN          151
+
+#elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+  #define LCD_PINS_RS         13
+  #define LCD_PINS_ENABLE     17
+  #define LCD_PINS_D4         16
+  //#define LCD_PINS_D5         150
+  //#define LCD_PINS_D6         151
+  //#define LCD_PINS_D7         153
+  #define BEEPER_PIN          152
+
+#endif
+
+//
+// LCD Display input pins
+//
+#if ENABLED(CR10_STOCKDISPLAY)
+  #define BTN_EN1             0
+  #define BTN_EN2             12
+  #define BTN_ENC             14
+
+#elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+  #define BTN_EN1             0
+  #define BTN_EN2             12
+  #define BTN_ENC             14
+  
+#endif

--- a/Marlin/src/pins/esp32/pins_MRR_ESPE.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPE.h
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 #pragma once
 
 /**

--- a/Marlin/src/pins/esp32/pins_MRR_ESPE.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPE.h
@@ -30,81 +30,82 @@
  */
 
 #ifndef ARDUINO_ARCH_ESP32
-  "Oops! Select an ESP32 board in 'Tools > Board.'"
+  #error "Oops! Select an ESP32 board in 'Tools > Board.'"
+#elif EXTRUDERS > 2 || E_STEPPERS > 2
+  #error "MRR ESPE only supports two E Steppers. Comment out this line to continue."
+#elif HOTENDS > 1
+  #error "MRR ESPE currently supports only one hotend. Comment out this line to continue."
 #endif
 
-#define BOARD_INFO_NAME "MRR ESPE"
-#define BOARD_WEBSITE_URL "github.com/maplerainresearch/MRR_ESPE"
+#define BOARD_INFO_NAME      "MRR ESPE"
+#define BOARD_WEBSITE_URL    "github.com/maplerainresearch/MRR_ESPE"
 #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
 
 //
 // Limit Switches
 //
-#define X_MIN_PIN          35
-#define Y_MIN_PIN          32
-#define Z_MIN_PIN          33
+#define X_STOP_PIN         35
+#define Y_STOP_PIN         32
+#define Z_STOP_PIN         33
 
 //
 // Enable I2S stepper stream
 //
-#ifndef I2S_STEPPER_STREAM
-  #define I2S_STEPPER_STREAM
-#endif
+#undef I2S_STEPPER_STREAM
+#define I2S_STEPPER_STREAM
 
-#define I2S_WS              26
-#define I2S_BCK             25
-#define I2S_DATA            27
+#undef LIN_ADVANCE  // Currently, I2S stream does not work with linear advance
 
-#ifdef LIN_ADVANCE
-  #undef LIN_ADVANCE  // Currently, I2S stream does not work with linear advance
-#endif
+#define I2S_WS             26
+#define I2S_BCK            25
+#define I2S_DATA           27
 
 //
 // Steppers
 //
-#define X_STEP_PIN         129
-#define X_DIR_PIN          130
-#define X_ENABLE_PIN       128
+#define X_STEP_PIN        129
+#define X_DIR_PIN         130
+#define X_ENABLE_PIN      128
 //#define X_CS_PIN           21
 
-#define Y_STEP_PIN         132
-#define Y_DIR_PIN          133
-#define Y_ENABLE_PIN       131
+#define Y_STEP_PIN        132
+#define Y_DIR_PIN         133
+#define Y_ENABLE_PIN      131
 //#define Y_CS_PIN           22
 
-#define Z_STEP_PIN         135
-#define Z_DIR_PIN          136
-#define Z_ENABLE_PIN       134
+#define Z_STEP_PIN        135
+#define Z_DIR_PIN         136
+#define Z_ENABLE_PIN      134
 //#define Z_CS_PIN            5 // SS_PIN
 
-#define E0_STEP_PIN        138
-#define E0_DIR_PIN         139
-#define E0_ENABLE_PIN      137
+#define E0_STEP_PIN       138
+#define E0_DIR_PIN        139
+#define E0_ENABLE_PIN     137
 //#define E0_CS_PIN          21
 
-#define E1_STEP_PIN        141
-#define E2_DIR_PIN         142
-#define E3_ENABLE_PIN      140
-//#define E0_CS_PIN          22
+#define E1_STEP_PIN       141
+#define E1_DIR_PIN        142
+#define E1_ENABLE_PIN     140
+//#define E1_CS_PIN          22
 
-#define Z2_STEP_PIN        141
-#define Z2_DIR_PIN         142
-#define Z2_ENABLE_PIN      140
+#define Z2_STEP_PIN       141
+#define Z2_DIR_PIN        142
+#define Z2_ENABLE_PIN     140
 //#define Z2_CS_PIN            5
 
 //
 // Temperature Sensors
 //
 #define TEMP_0_PIN         36   // Analog Input
+#define TEMP_1_PIN         34   // Analog Input
 #define TEMP_BED_PIN       39   // Analog Input
-#define TEMP_1_PIN         34
 
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN     145 // 2
-#define FAN_PIN          146 // 15
-#define HEATER_BED_PIN   144 // 4
+#define HEATER_0_PIN      145 // 2
+#define FAN_PIN           146 // 15
+#define HEATER_BED_PIN    144 // 4
 
 #define CONTROLLER_FAN_PIN 147
 //#define E0_AUTO_FAN_PIN 148 // need to update Configuration_adv.h @section extruder 
@@ -123,38 +124,32 @@
 // LCDs and Controllers //
 //////////////////////////
 
+#if HAS_GRAPHICAL_LCD
 
-//
-// LCD Display output pins
-//
-#if ENABLED(CR10_STOCKDISPLAY)
-  #define LCD_PINS_RS         13
-  #define LCD_PINS_ENABLE     17
-  #define LCD_PINS_D4         16
-  #define BEEPER_PIN          151
+  #define LCD_PINS_RS        13
+  #define LCD_PINS_ENABLE    17
+  #define LCD_PINS_D4        16
 
-#elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
-  #define LCD_PINS_RS         13
-  #define LCD_PINS_ENABLE     17
-  #define LCD_PINS_D4         16
-  //#define LCD_PINS_D5         150
-  //#define LCD_PINS_D6         151
-  //#define LCD_PINS_D7         153
-  #define BEEPER_PIN          152
+  #if ENABLED(CR10_STOCKDISPLAY)
 
-#endif
+    #define BEEPER_PIN      151
 
-//
-// LCD Display input pins
-//
-#if ENABLED(CR10_STOCKDISPLAY)
+  #elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+
+    #define BEEPER_PIN      152
+
+    //#define LCD_PINS_D5     150
+    //#define LCD_PINS_D6     151
+    //#define LCD_PINS_D7     153
+
+  #else
+
+    #error "Only CR10_STOCKDISPLAY and REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER are currently supported. Comment out this line to continue."
+
+  #endif
+
   #define BTN_EN1             0
-  #define BTN_EN2             12
-  #define BTN_ENC             14
+  #define BTN_EN2            12
+  #define BTN_ENC            14
 
-#elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
-  #define BTN_EN1             0
-  #define BTN_EN2             12
-  #define BTN_ENC             14
-  
-#endif
+#endif // HAS_GRAPHICAL_LCD

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -551,6 +551,10 @@
 #elif MB(ESPRESSIF_ESP32)
 
   #include "esp32/pins_ESP32.h"                 // ESP32                                  env:esp32
+#elif MB(MRR_ESPA)
+  #include "esp32/pins_MRR_ESPA.h"              // ESP32                                  env:esp32
+#elif MB(MRR_ESPE)
+  #include "esp32/pins_MRR_ESPE.h"              // ESP32                                  env:esp32
 
 //
 // Linux Native Debug board


### PR DESCRIPTION
### Requirements

None

### Description

Add MRR_ESPA and MRR_ESPE boards based on ESP32 MCU

### Benefits

Add new boards support

### Related Issues

None