### PR TITLE
Compiling L6470 stepper drivers w/ marlin 2.0

### DIFF
--- a/Marlin/src/HAL/shared/HAL_spi_L6470.h
+++ b/Marlin/src/HAL/shared/HAL_spi_L6470.h
@@ -19,35 +19,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+#pragma once
 
-/**
- * stepper/indirection.cpp
- *
- * Stepper motor driver indirection to allow some stepper functions to
- * be done via SPI/I2c instead of direct pin manipulation.
- *
- * Copyright (c) 2015 Dominik Wenger
- */
+class HAL_spi_L6470 {
+  public:
+    uint8_t L6470_SpiTransfer_Mode_0(uint8_t b);
+    uint8_t L6470_SpiTransfer_Mode_3(uint8_t b);
+    uint8_t L6470_transfer(uint8_t data, int16_t ss_pin, const uint8_t chain_position);
+    void L6470_transfer(uint8_t L6470_buf[], const uint8_t length);
+    void L6470_spi_init();
+  private:
+};
 
-#include "../../inc/MarlinConfig.h"
-#include "indirection.h"
-
-void restore_stepper_drivers() {
-  #if HAS_TRINAMIC
-    restore_trinamic_drivers();
-  #endif
-}
-
-void reset_stepper_drivers() {
-  #if HAS_DRIVER(TMC26X)
-    tmc26x_init_to_defaults();
-  #endif
-
-  #if HAS_DRIVER(L6470)
-    l6470_marlin.init_to_defaults();
-  #endif
-
-  #if HAS_TRINAMIC
-    reset_trinamic_drivers();
-  #endif
-}
+extern HAL_spi_L6470 hal_spi_l6470;

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -601,7 +601,7 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
   #endif
 
   #if ENABLED(MONITOR_L6470_DRIVER_STATUS)
-    L6470.monitor_driver();
+    l6470_marlin.monitor_driver();
   #endif
 
   // Limit check_axes_activity frequency to 10Hz
@@ -820,7 +820,7 @@ void setup() {
   HAL_init();
 
   #if HAS_DRIVER(L6470)
-    L6470.init();         // setup SPI and then init chips
+    l6470_marlin.init();         // setup SPI and then init chips
   #endif
 
   #if ENABLED(MAX7219_DEBUG)

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -540,7 +540,7 @@ void GcodeSuite::G28(const bool always_home_all) {
     // Set L6470 absolute position registers to counts
     for (uint8_t j = 1; j <= L6470::chain[0]; j++) {
       const uint8_t cv = L6470::chain[j];
-      L6470.set_param(cv, L6470_ABS_POS, stepper.position((AxisEnum)L6470.axis_xref[cv]));
+      l6470_marlin.set_param(cv, L6470_ABS_POS, stepper.position((AxisEnum)l6470_marlin.axis_xref[cv]));
     }
   #endif
 }

--- a/Marlin/src/gcode/feature/L6470/M122.cpp
+++ b/Marlin/src/gcode/feature/L6470/M122.cpp
@@ -31,8 +31,8 @@
 inline void echo_yes_no(const bool yes) { serialprintPGM(yes ? PSTR(" YES") : PSTR(" NO ")); }
 
 void L6470_status_decode(const uint16_t status, const uint8_t axis) {
-  if (L6470.spi_abort) return;  // don't do anything if set_directions() has occurred
-  L6470.say_axis(axis);
+  if (l6470_marlin.spi_abort) return;  // don't do anything if set_directions() has occurred
+  l6470_marlin.say_axis(axis);
   #if ENABLED(L6470_CHITCHAT)
     char temp_buf[20];
     sprintf_P(temp_buf, PSTR("   status: %4x   "), status);
@@ -43,15 +43,15 @@ void L6470_status_decode(const uint16_t status, const uint8_t axis) {
   serialprintPGM(status & STATUS_HIZ ? PSTR("OFF") : PSTR("ON "));
   SERIAL_ECHOPGM("   BUSY: "); echo_yes_no(!(status & STATUS_BUSY));
   SERIAL_ECHOPGM("   DIR: ");
-  serialprintPGM((((status & STATUS_DIR) >> 4) ^ L6470.index_to_dir[axis]) ? PSTR("FORWARD") : PSTR("REVERSE"));
+  serialprintPGM((((status & STATUS_DIR) >> 4) ^ l6470_marlin.index_to_dir[axis]) ? PSTR("FORWARD") : PSTR("REVERSE"));
   SERIAL_ECHOPGM("   Last Command: ");
-  if (status & STATUS_WRONG_CMD) SERIAL_ECHOPGM("IN");
+  if (status & L6470::STATUS_WRONG_CMD) SERIAL_ECHOPGM("IN");
   SERIAL_ECHOPGM("VALID    ");
-  serialprintPGM(status & STATUS_NOTPERF_CMD ? PSTR("Not PERFORMED") : PSTR("COMPLETED    "));
-  SERIAL_ECHOPAIR("\n...THERMAL: ", !(status & STATUS_TH_SD) ? "SHUTDOWN" : !(status & STATUS_TH_WRN) ? "WARNING " : "OK      ");
-  SERIAL_ECHOPGM("   OVERCURRENT:"); echo_yes_no(!(status & STATUS_OCD));
-  SERIAL_ECHOPGM("   STALL:"); echo_yes_no(!(status & STATUS_STEP_LOSS_A) || !(status & STATUS_STEP_LOSS_B));
-  SERIAL_ECHOPGM("   STEP-CLOCK MODE:"); echo_yes_no(status & STATUS_SCK_MOD);
+  serialprintPGM(status & L6470::STATUS_NOTPERF_CMD ? PSTR("Not PERFORMED") : PSTR("COMPLETED    "));
+  SERIAL_ECHOPAIR("\n...THERMAL: ", !(status & L6470::STATUS_TH_SD) ? "SHUTDOWN" : !(status & L6470::STATUS_TH_WRN) ? "WARNING " : "OK      ");
+  SERIAL_ECHOPGM("   OVERCURRENT:"); echo_yes_no(!(status & L6470::STATUS_OCD));
+  SERIAL_ECHOPGM("   STALL:"); echo_yes_no(!(status & L6470::STATUS_STEP_LOSS_A) || !(status & L6470::STATUS_STEP_LOSS_B));
+  SERIAL_ECHOPGM("   STEP-CLOCK MODE:"); echo_yes_no(status & L6470::STATUS_SCK_MOD);
   SERIAL_EOL();
 }
 
@@ -60,7 +60,7 @@ void L6470_status_decode(const uint16_t status, const uint8_t axis) {
  */
 void GcodeSuite::M122() {
 
-  L6470.spi_active = true;    // let set_directions() know we're in the middle of a series of SPI transfers
+  l6470_marlin.spi_active = true;    // let set_directions() know we're in the middle of a series of SPI transfers
 
   #define L6470_SAY_STATUS(Q) L6470_status_decode(stepper##Q.getStatus(), Q)
 
@@ -108,8 +108,8 @@ void GcodeSuite::M122() {
     L6470_SAY_STATUS(E5);
   #endif
 
-  L6470.spi_active = false;   // done with all SPI transfers - clear handshake flags
-  L6470.spi_abort = false;
+  l6470_marlin.spi_active = false;   // done with all SPI transfers - clear handshake flags
+  l6470_marlin.spi_abort = false;
 }
 
 #endif // HAS_DRIVER(L6470)

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -83,7 +83,7 @@
  */
 
 void L6470_report_current(L6470 &motor, const uint8_t axis) {
-  if (L6470.spi_abort) return;  // don't do anything if set_directions() has occurred
+  if (l6470_marlin.spi_abort) return;  // don't do anything if set_directions() has occurred
   const uint16_t status = motor.getStatus() ;
   const uint8_t overcurrent_threshold = (uint8_t)motor.GetParam(L6470_OCD_TH),
                 stall_threshold = (uint8_t)motor.GetParam(L6470_STALL_TH),
@@ -93,7 +93,7 @@ void L6470_report_current(L6470 &motor, const uint8_t axis) {
   const float comp_coef = 1600.0f / adc_out_limited;
   const int microsteps = _BV(motor.GetParam(L6470_STEP_MODE) & 0x07);
   char temp_buf[80];
-  L6470.say_axis(axis);
+  l6470_marlin.say_axis(axis);
   #if ENABLED(L6470_CHITCHAT)
     sprintf_P(temp_buf, PSTR("   status: %4x   "), status);
     DEBUG_ECHO(temp_buf);
@@ -122,7 +122,7 @@ void L6470_report_current(L6470 &motor, const uint8_t axis) {
   SERIAL_ECHOPAIR("...microsteps: ", microsteps);
   SERIAL_ECHOPAIR("   ADC_OUT: ", adc_out);
   SERIAL_ECHOPGM("   Vs_compensation: ");
-  serialprintPGM((motor.GetParam(L6470_CONFIG) & CONFIG_EN_VSCOMP) ? PSTR("ENABLED ") : PSTR("DISABLED"));
+  serialprintPGM((motor.GetParam(L6470::L64XX_CONFIG) & CONFIG_EN_VSCOMP) ? PSTR("ENABLED ") : PSTR("DISABLED"));
 
   SERIAL_ECHOLNPAIR("   Compensation coefficient: ", dtostrf(comp_coef * 0.01f, 7, 2, numstr));
   SERIAL_ECHOPAIR("...KVAL_HOLD: ", motor.GetParam(L6470_KVAL_HOLD));
@@ -234,7 +234,7 @@ void GcodeSuite::M906() {
   if (report_current) {
     #define L6470_REPORT_CURRENT(Q) L6470_report_current(stepper##Q, Q)
 
-    L6470.spi_active = true;    // let set_directions() know we're in the middle of a series of SPI transfers
+    l6470_marlin.spi_active = true;    // let set_directions() know we're in the middle of a series of SPI transfers
 
     #if AXIS_DRIVER_TYPE_X(L6470)
       L6470_REPORT_CURRENT(X);
@@ -276,8 +276,8 @@ void GcodeSuite::M906() {
       L6470_REPORT_CURRENT(E5);
     #endif
 
-    L6470.spi_active = false;   // done with all SPI transfers - clear handshake flags
-    L6470.spi_abort = false;
+    l6470_marlin.spi_active = false;   // done with all SPI transfers - clear handshake flags
+    l6470_marlin.spi_abort = false;
   }
 }
 

--- a/Marlin/src/libs/L6470/L6470_Marlin.cpp
+++ b/Marlin/src/libs/L6470/L6470_Marlin.cpp
@@ -30,11 +30,12 @@
 
 #include "L6470_Marlin.h"
 
-L6470_Marlin L6470;
+L6470_Marlin l6470_marlin;
 
 #include "../../module/stepper/indirection.h"
 #include "../../module/planner.h"
 #include "../../gcode/gcode.h"
+#include "../../../src/HAL/shared/HAL_spi_L6470.h"
 
 #define DEBUG_OUT ENABLED(L6470_CHITCHAT)
 #include "../../core/debug_out.h"
@@ -138,8 +139,8 @@ void L6470_Marlin::init() {               // Set up SPI and then init chips
     OUT_WRITE(L6470_RESET_CHAIN_PIN, HIGH);
     delay(1);                     // need about 650uS for the chip to fully start up
   #endif
-  populate_chain_array();   // Set up array to control where in the SPI transfer sequence a particular stepper's data goes
-  L6470_spi_init();               // Set up L6470 soft SPI pins
+  l6470_marlin.populate_chain_array();   // Set up array to control where in the SPI transfer sequence a particular stepper's data goes
+  hal_spi_l6470.L6470_spi_init();               // Set up L6470 soft SPI pins
   init_to_defaults();             // init the chips
 }
 
@@ -433,7 +434,7 @@ bool L6470_Marlin::get_user_input(uint8_t &driver_count, uint8_t axis_index[3], 
 
   DEBUG_ECHOPGM("Monitoring:");
   for (j = 0; j < driver_count; j++) DEBUG_ECHOPAIR("  ", axis_mon[j]);
-  L6470_EOL();
+  // L6470_EOL();
 
   // now have a list of driver(s) to monitor
 

--- a/Marlin/src/libs/L6470/L6470_Marlin.h
+++ b/Marlin/src/libs/L6470/L6470_Marlin.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "../../inc/MarlinConfig.h"
+#include "../../../src/HAL/shared/HAL_spi_L6470.h"
 
 #include <L6470.h>
 
@@ -29,7 +30,7 @@
 
 enum L6470_driver_enum : unsigned char { X, Y, Z, X2, Y2, Z2, Z3, E0, E1, E2, E3, E4, E5, MAX_L6470 };
 
-#define L6470_ERROR_MASK  (STATUS_UVLO | STATUS_TH_WRN | STATUS_TH_SD  | STATUS_OCD | STATUS_STEP_LOSS_A | STATUS_STEP_LOSS_B)
+#define L6470_ERROR_MASK  (L6470::STATUS_UVLO | L6470::STATUS_TH_WRN | L6470::STATUS_TH_SD  | L6470::STATUS_OCD | L6470::STATUS_STEP_LOSS_A | L6470::STATUS_STEP_LOSS_B)
 #define dSPIN_STEP_CLOCK_FWD dSPIN_STEP_CLOCK
 #define dSPIN_STEP_CLOCK_REV dSPIN_STEP_CLOCK+1
 
@@ -69,4 +70,4 @@ private:
   void populate_chain_array();
 };
 
-extern L6470_Marlin L6470;
+extern L6470_Marlin l6470_marlin;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -409,22 +409,22 @@ void Stepper::set_directions() {
 
   #if HAS_DRIVER(L6470)
 
-    if (L6470.spi_active) {
-      L6470.spi_abort = true;                     // interrupted a SPI transfer - need to shut it down gracefully
+    if (l6470_marlin.spi_active) {
+      l6470_marlin.spi_abort = true;                     // interrupted a SPI transfer - need to shut it down gracefully
       for (uint8_t j = 1; j <= L6470::chain[0]; j++)
         L6470_buf[j] = dSPIN_NOP;                 // fill buffer with NOOP commands
-      L6470.transfer(L6470_buf, L6470::chain[0]);  // send enough NOOPs to complete any command
-      L6470.transfer(L6470_buf, L6470::chain[0]);
-      L6470.transfer(L6470_buf, L6470::chain[0]);
+      hal_spi_l6470.L6470_transfer(L6470_buf, L6470::chain[0]);  // send enough NOOPs to complete any command
+      hal_spi_l6470.L6470_transfer(L6470_buf, L6470::chain[0]);
+      hal_spi_l6470.L6470_transfer(L6470_buf, L6470::chain[0]);
     }
 
     // The L6470.dir_commands[] array holds the direction command for each stepper
 
     //scan command array and copy matches into L6470.transfer
     for (uint8_t j = 1; j <= L6470::chain[0]; j++)
-      L6470_buf[j] = L6470.dir_commands[L6470::chain[j]];
+      L6470_buf[j] = l6470_marlin.dir_commands[L6470::chain[j]];
 
-    L6470.transfer(L6470_buf, L6470::chain[0]);  // send the command stream to the drivers
+    hal_spi_l6470.L6470_transfer(L6470_buf, L6470::chain[0]);  // send the command stream to the drivers
 
   #endif
 

--- a/Marlin/src/module/stepper/L6470.cpp
+++ b/Marlin/src/module/stepper/L6470.cpp
@@ -80,9 +80,9 @@
 #define _L6470_INIT_CHIP(Q) do{                             \
   stepper##Q.resetDev();                                    \
   stepper##Q.softFree();                                    \
-  stepper##Q.SetParam(L6470_CONFIG, CONFIG_PWM_DIV_1        \
+  stepper##Q.SetParam(L6470::L64XX_CONFIG, CONFIG_PWM_DIV_1 \
                                   | CONFIG_PWM_MUL_2        \
-                                  | CONFIG_SR_290V_us       \
+                                  | CONFIG_SR_260V_us       \
                                   | CONFIG_OC_SD_DISABLE    \
                                   | CONFIG_VS_COMP_DISABLE  \
                                   | CONFIG_SW_HARD_STOP     \

--- a/Marlin/src/module/stepper/L6470.h
+++ b/Marlin/src/module/stepper/L6470.h
@@ -30,7 +30,7 @@
 #include "../../libs/L6470/L6470_Marlin.h"
 
 // L6470 has STEP on normal pins, but DIR/ENABLE via SPI
-#define L6470_WRITE_DIR_COMMAND(STATE,Q) do{ L6470_dir_commands[Q] = (STATE ?  dSPIN_STEP_CLOCK_REV : dSPIN_STEP_CLOCK_FWD); }while(0)
+#define _L6470_WRITE_DIR_COMMAND(STATE,Q) do{ stepper##Q.Step_Clock(STATE ?  dSPIN_STEP_CLOCK_REV : dSPIN_STEP_CLOCK_FWD); } while(0)
 
 // X Stepper
 #if AXIS_DRIVER_TYPE_X(L6470)
@@ -39,7 +39,7 @@
   #define X_ENABLE_WRITE(STATE) NOOP
   #define X_ENABLE_READ() (stepperX.getStatus() & STATUS_HIZ)
   #define X_DIR_INIT NOOP
-  #define X_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,X)
+  #define X_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,X)
   #define X_DIR_READ() (stepperX.getStatus() & STATUS_DIR)
 #endif
 
@@ -50,7 +50,7 @@
   #define Y_ENABLE_WRITE(STATE) NOOP
   #define Y_ENABLE_READ() (stepperY.getStatus() & STATUS_HIZ)
   #define Y_DIR_INIT NOOP
-  #define Y_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Y)
+  #define Y_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,Y)
   #define Y_DIR_READ() (stepperY.getStatus() & STATUS_DIR)
 #endif
 
@@ -61,7 +61,7 @@
   #define Z_ENABLE_WRITE(STATE) NOOP
   #define Z_ENABLE_READ() (stepperZ.getStatus() & STATUS_HIZ)
   #define Z_DIR_INIT NOOP
-  #define Z_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Z)
+  #define Z_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,Z)
   #define Z_DIR_READ() (stepperZ.getStatus() & STATUS_DIR)
 #endif
 
@@ -72,7 +72,7 @@
   #define X2_ENABLE_WRITE(STATE) NOOP
   #define X2_ENABLE_READ() (stepperX2.getStatus() & STATUS_HIZ)
   #define X2_DIR_INIT NOOP
-  #define X2_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,X2)
+  #define X2_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,X2)
   #define X2_DIR_READ() (stepperX2.getStatus() & STATUS_DIR)
 #endif
 
@@ -83,7 +83,7 @@
   #define Y2_ENABLE_WRITE(STATE) NOOP
   #define Y2_ENABLE_READ() (stepperY2.getStatus() & STATUS_HIZ)
   #define Y2_DIR_INIT NOOP
-  #define Y2_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Y2)
+  #define Y2_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,Y2)
   #define Y2_DIR_READ() (stepperY2.getStatus() & STATUS_DIR)
 #endif
 
@@ -94,7 +94,7 @@
   #define Z2_ENABLE_WRITE(STATE) NOOP
   #define Z2_ENABLE_READ() (stepperZ2.getStatus() & STATUS_HIZ)
   #define Z2_DIR_INIT NOOP
-  #define Z2_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Z2)
+  #define Z2_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,Z2)
   #define Z2_DIR_READ() (stepperZ2.getStatus() & STATUS_DIR)
 #endif
 
@@ -105,7 +105,7 @@
   #define Z3_ENABLE_WRITE(STATE) NOOP
   #define Z3_ENABLE_READ() (stepperZ3.getStatus() & STATUS_HIZ)
   #define Z3_DIR_INIT NOOP
-  #define Z3_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,Z3)
+  #define Z3_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,Z3)
   #define Z3_DIR_READ() (stepperZ3.getStatus() & STATUS_DIR)
 #endif
 
@@ -116,7 +116,7 @@
   #define E0_ENABLE_WRITE(STATE) NOOP
   #define E0_ENABLE_READ() (stepperE0.getStatus() & STATUS_HIZ)
   #define E0_DIR_INIT NOOP
-  #define E0_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E0)
+  #define E0_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,E0)
   #define E0_DIR_READ() (stepperE0.getStatus() & STATUS_DIR)
 #endif
 
@@ -127,7 +127,7 @@
   #define E1_ENABLE_WRITE(STATE) NOOP
   #define E1_ENABLE_READ() (stepperE1.getStatus() & STATUS_HIZ)
   #define E1_DIR_INIT NOOP
-  #define E1_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E1)
+  #define E1_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,E1)
   #define E1_DIR_READ() (stepperE1.getStatus() & STATUS_DIR)
 #endif
 
@@ -138,7 +138,7 @@
   #define E2_ENABLE_WRITE(STATE) NOOP
   #define E2_ENABLE_READ() (stepperE2.getStatus() & STATUS_HIZ)
   #define E2_DIR_INIT NOOP
-  #define E2_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E2)
+  #define E2_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,E2)
   #define E2_DIR_READ() (stepperE2.getStatus() & STATUS_DIR)
 #endif
 
@@ -149,7 +149,7 @@
   #define E3_ENABLE_WRITE(STATE) NOOP
   #define E3_ENABLE_READ() (stepperE3.getStatus() & STATUS_HIZ)
   #define E3_DIR_INIT NOOP
-  #define E3_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E3)
+  #define E3_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,E3)
   #define E3_DIR_READ() (stepperE3.getStatus() & STATUS_DIR)
 #endif
 
@@ -160,7 +160,7 @@
   #define E4_ENABLE_WRITE(STATE) NOOP
   #define E4_ENABLE_READ() (stepperE4.getStatus() & STATUS_HIZ)
   #define E4_DIR_INIT NOOP
-  #define E4_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E4)
+  #define E4_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,E4)
   #define E4_DIR_READ() (stepperE4.getStatus() & STATUS_DIR)
 #endif
 
@@ -171,6 +171,6 @@
   #define E5_ENABLE_WRITE(STATE) NOOP
   #define E5_ENABLE_READ() (stepperE5.getStatus() & STATUS_HIZ)
   #define E5_DIR_INIT NOOP
-  #define E5_DIR_WRITE(STATE) L6470_WRITE_DIR_COMMAND(STATE,E5)
+  #define E5_DIR_WRITE(STATE) _L6470_WRITE_DIR_COMMAND(STATE,E5)
   #define E5_DIR_READ() (stepperE5.getStatus() & STATUS_DIR)
 #endif


### PR DESCRIPTION
### Description

Ti's L6470 stepper drivers wouldn't compile when I selected these types of drivers. This FR is submitted as requested from this thread : https://github.com/MarlinFirmware/Marlin/issues/15946

### Benefits

Can now compile when you select L6470 drivers.
