### PR TITLE
Fix HAL_STM32 + Arduino IDE SoftwareSerial conflict

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/SoftwareSerial.cpp
+++ b/Marlin/src/HAL/HAL_STM32/SoftwareSerial.cpp
@@ -34,7 +34,7 @@
 //
 // Includes
 //
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+#if defined(PLATFORMIO) && defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
 
 #include "SoftwareSerial.h"
 #include "timers.h"


### PR DESCRIPTION
### Description

Skip building the HAL_STM32/SoftwareSerial.cpp when building outside of Platform IO.

This prevents duplicate definitions when both the Marlin and Arduino_Core_STM32 versions of SoftwareSerial.cpp are compiled.

### Benefits

Allows building Rumba32 inside the Arduino IDE with TMCStepper installed.

The only downside to this is that the Arduino_Core_STM32 1.7 SoftwareSerial.cpp won't work for single-pin serial. This is probably not a major issue since prior to Arduino_Core_STM32 1.7 there was no SoftwareSerial for this HAL at all, so existing boards building in Arduino are unlikely to already depend on it.

### Related Issues

#15952 
