### PR TITLE
Fix Axis CS Sanity Check

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1957,7 +1957,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 /**
  * Check existing CS pins against enabled TMC SPI drivers.
  */
-#define INVALID_TMC_SPI(ST) (AXIS_HAS_SPI && !PIN_EXISTS(ST##_CS))
+#define INVALID_TMC_SPI(ST) (AXIS_HAS_SPI(ST) && !PIN_EXISTS(ST##_CS))
 #if INVALID_TMC_SPI(X)
   #error "An SPI driven TMC driver on X requires X_CS_PIN."
 #elif INVALID_TMC_SPI(X2)


### PR DESCRIPTION
### Description

Fix incorrect usage of `AXIS_HAS_SPI` macro, which prevented axis CS sanity checks from working.

I checked other usages of axis-related macros and did not find any other issues.

### Related Issues

#13734 - TMC5160 is compiling without errors without CS pins defined
