### PR TITLE
fix for LIMITED_MAX_FR_EDITING and LIMITED_MAX_ACCEL_EDITING

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2764,8 +2764,8 @@ void Planner::set_max_acceleration(const uint8_t axis, float targetValue) {
       constexpr xyze_float_t max_accel_edit = MAX_ACCEL_EDIT_VALUES;
       const xyze_float_t &max_acc_edit_scaled = max_accel_edit;
     #else
-      constexpr xyze_float_t max_accel_edit = DEFAULT_MAX_ACCELERATION,
-                             max_acc_edit_scaled = max_accel_edit * 2;
+      constexpr xyze_float_t max_accel_edit = DEFAULT_MAX_ACCELERATION;
+      const xyze_float_t max_acc_edit_scaled = max_accel_edit * 2;
     #endif
     limit_and_warn(targetValue, axis, PSTR("Acceleration"), max_acc_edit_scaled);
   #endif
@@ -2781,8 +2781,8 @@ void Planner::set_max_feedrate(const uint8_t axis, float targetValue) {
       constexpr xyze_float_t max_fr_edit = MAX_FEEDRATE_EDIT_VALUES;
       const xyze_float_t &max_fr_edit_scaled = max_fr_edit;
     #else
-      constexpr xyze_float_t max_fr_edit = DEFAULT_MAX_FEEDRATE,
-                             max_fr_edit_scaled = max_fr_edit * 2;
+      constexpr xyze_float_t max_fr_edit = DEFAULT_MAX_FEEDRATE;
+      const xyze_float_t max_fr_edit_scaled = max_fr_edit * 2;
     #endif
     limit_and_warn(targetValue, axis, PSTR("Feedrate"), max_fr_edit_scaled);
   #endif


### PR DESCRIPTION
### Description

bugfix-2.0.x does not compile if LIMITED_MAX_FR_EDITING or LIMITED_MAX_ACCEL_EDITING are used with default values (MAX_{FEEDRATE/ACCEL}_EDIT_VALUES undefined).
This is due to missing constexpr versions for the operators in src/core/types.h.

I just reverted the offending lines back to const.

A better fix might be to implement the constexpr operators, however some platforms seem to target c++11 (atmega) and some c++14 (lpc1768), making this rather complex.

### Benefits

fixes LIMITED_MAX_FR_EDITING and LIMITED_MAX_ACCEL_EDITING
