### PR TITLE
MKS SGen-L pins EEBF or EFBF scheme

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -166,7 +166,15 @@
 //
 #define HEATER_BED_PIN     P2_05
 #define HEATER_0_PIN       P2_07
-#define HEATER_1_PIN       P2_06
+#if HOTENDS == 1
+  #ifndef FAN1_PIN
+    #define FAN1_PIN       P2_06
+  #endif
+#else
+  #ifndef HEATER_1_PIN
+    #define HEATER_1_PIN   P2_06
+  #endif
+#endif
 #ifndef FAN_PIN
   #define FAN_PIN          P2_04
 #endif


### PR DESCRIPTION
### Description

Adding FAN1 if only 1 Hotend is enabled, like on other Boards like skr 1.3

### Benefits

Use second Hotendport for an FAN
