### PR TITLE
Some ESP32 patches

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/WebSocketSerial.h
+++ b/Marlin/src/HAL/HAL_ESP32/WebSocketSerial.h
@@ -25,14 +25,16 @@
 
 #include <Stream.h>
 
-#if !defined(RX_BUFFER_SIZE) && ENABLED(WIFISUPPORT)
-  #define RX_BUFFER_SIZE 128
-#endif
 #ifndef TX_BUFFER_SIZE
   #define TX_BUFFER_SIZE 32
 #endif
-#if (TX_BUFFER_SIZE <= 0) && ENABLED(WIFISUPPORT)
-  #error "TX_BUFFER_SIZE is required for the WebSocket."
+#if ENABLED(WIFISUPPORT)
+  #ifndef RX_BUFFER_SIZE
+    #define RX_BUFFER_SIZE 128
+  #endif
+  #if TX_BUFFER_SIZE <= 0
+    #error "TX_BUFFER_SIZE is required for the WebSocket."
+  #endif
 #endif
 
 typedef uint16_t ring_buffer_pos_t;

--- a/Marlin/src/HAL/HAL_ESP32/WebSocketSerial.h
+++ b/Marlin/src/HAL/HAL_ESP32/WebSocketSerial.h
@@ -25,13 +25,13 @@
 
 #include <Stream.h>
 
-#ifndef RX_BUFFER_SIZE
+#if !defined(RX_BUFFER_SIZE) && ENABLED(WIFISUPPORT)
   #define RX_BUFFER_SIZE 128
 #endif
 #ifndef TX_BUFFER_SIZE
   #define TX_BUFFER_SIZE 32
 #endif
-#if TX_BUFFER_SIZE <= 0
+#if (TX_BUFFER_SIZE <= 0) && ENABLED(WIFISUPPORT)
   #error "TX_BUFFER_SIZE is required for the WebSocket."
 #endif
 

--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
@@ -201,7 +201,7 @@ u8g_dev_t u8g_dev_st7920_128x64_HAL_4x_sw_spi = { u8g_dev_st7920_128x64_HAL_4x_f
 U8G_PB_DEV(u8g_dev_st7920_128x64_HAL_hw_spi, LCD_PIXEL_WIDTH, LCD_PIXEL_HEIGHT, PAGE_HEIGHT, u8g_dev_st7920_128x64_HAL_fn, U8G_COM_ST7920_HAL_HW_SPI);
 u8g_dev_t u8g_dev_st7920_128x64_HAL_4x_hw_spi = { u8g_dev_st7920_128x64_HAL_4x_fn, &u8g_dev_st7920_128x64_HAL_4x_pb, U8G_COM_ST7920_HAL_HW_SPI };
 
-#if NONE(__AVR__, ARDUINO_ARCH_STM32) || defined(U8G_HAL_LINKS)
+#if NONE(__AVR__, ARDUINO_ARCH_STM32, ARDUINO_ARCH_ESP32) || defined(U8G_HAL_LINKS)
   // Also use this device for HAL version of rrd class. This results in the same device being used
   // for the ST7920 for HAL systems no matter what is selected in ultralcd_impl_DOGM.h.
   u8g_dev_t u8g_dev_st7920_128x64_rrd_sw_spi = { u8g_dev_st7920_128x64_HAL_4x_fn, &u8g_dev_st7920_128x64_HAL_4x_pb, U8G_COM_ST7920_HAL_SW_SPI };

--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -25,7 +25,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if !defined(U8G_HAL_LINKS) && ANY(__AVR__, ARDUINO_ARCH_STM32)
+#if !defined(U8G_HAL_LINKS) && ANY(__AVR__, ARDUINO_ARCH_STM32, ARDUINO_ARCH_ESP32)
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2239,7 +2239,12 @@ void Stepper::endstop_triggered(const AxisEnum axis) {
       (axis == CORE_AXIS_2
         ? CORESIGN(count_position[CORE_AXIS_1] - count_position[CORE_AXIS_2])
         : count_position[CORE_AXIS_1] + count_position[CORE_AXIS_2]
-      ) * 0.5f
+      ) * 
+      #ifdef ARDUINO_ARCH_ESP32
+		 (double)0.5
+	  #else 
+		 0.5f
+	  #endif
     #else // !IS_CORE
       count_position[axis]
     #endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2239,12 +2239,7 @@ void Stepper::endstop_triggered(const AxisEnum axis) {
       (axis == CORE_AXIS_2
         ? CORESIGN(count_position[CORE_AXIS_1] - count_position[CORE_AXIS_2])
         : count_position[CORE_AXIS_1] + count_position[CORE_AXIS_2]
-      ) * 
-      #ifdef ARDUINO_ARCH_ESP32
-		 (double)0.5
-	  #else 
-		 0.5f
-	  #endif
+      ) * double(0.5)
     #else // !IS_CORE
       count_position[axis]
     #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -695,7 +695,7 @@ monitor_speed = 250000
 platform      = espressif32
 board         = esp32dev
 build_flags   = ${common.build_flags} -DCORE_DEBUG_LEVEL=0
-lib_deps      =
+lib_deps      = ${common.lib_deps}
   AsyncTCP=https://github.com/me-no-dev/AsyncTCP/archive/master.zip
   ESPAsyncWebServer=https://github.com/me-no-dev/ESPAsyncWebServer/archive/master.zip
 lib_ignore    = LiquidCrystal, LiquidTWI2, SailfishLCD, SailfishRGB_LED


### PR DESCRIPTION
### Requirements

None

### Description
ESP32 related fixes:
* Fix Compilation when WIFISUPPORT not enabled
* Fix Crash on ESP32 on COREXY due to float usage in ISR, fix is based on this feedback : https://github.com/espressif/esp-idf/issues/722
* Fix CR10 LCD Ender 3 clone for ESP32, (no issue on original one), when using CR10_STOCKDISPLAY
, was working before same PR for STM32 so apply same changes, and now work again.
* Fix missing common libs for esp32 entry in platformio.ini (TMCSteppers / U8GLib / ...)

### Benefits

Fix : Compilation glitch and crash and unresponsive lcd under ESP32

### Related Issues

No issue was open in Marlin issue tracker for these problems - need to open ? 