### PR TITLE
Neopixel doesn't require pwm pin for brightness

### DIFF
--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -358,13 +358,11 @@ void menu_configuration() {
   //
   #if ENABLED(CASE_LIGHT_MENU)
     #if DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
-      if (
-        #if ENABLED(CASE_LIGHT_USE_NEOPIXEL)
-          true
-        #else
-          PWM_PIN(CASE_LIGHT_PIN)
+      if (true
+        #if DISABLED(CASE_LIGHT_USE_NEOPIXEL)
+          && PWM_PIN(CASE_LIGHT_PIN)
         #endif
-        )
+      )
         SUBMENU(MSG_CASE_LIGHT, menu_case_light);
       else
     #endif

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -358,7 +358,13 @@ void menu_configuration() {
   //
   #if ENABLED(CASE_LIGHT_MENU)
     #if DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
-      if (PWM_PIN(CASE_LIGHT_PIN))
+      if (
+        #if ENABLED(CASE_LIGHT_USE_NEOPIXEL)
+          true
+        #else
+          PWM_PIN(CASE_LIGHT_PIN)
+        #endif
+        )
         SUBMENU(MSG_CASE_LIGHT, menu_case_light);
       else
     #endif


### PR DESCRIPTION
### Description

When using neopixel for case lights and enabling the case light menu, you do not get a menu option for adjusting the brightness because the code checks to see if it is on a pwm pin.

I am using `PE2` on an SKR PRO 1.1. Before the change, no option on the screen (but gcode worked). After the change, I have a menu option that has been tested to change the brightness.

### Benefits

User can change neopixel case light brightness from the printer.

### Related Issues

None
