### PR TITLE
Fix PrintrBoard build by ignoring TMC libraries

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -176,7 +176,7 @@ monitor_speed = 250000
 platform      = teensy
 board         = at90usb1286
 lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
+lib_ignore    = TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
 monitor_speed = 250000
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -163,6 +163,7 @@ platform      = teensy
 board         = at90usb1286
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
+lib_ignore    = TMCStepper
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
 monitor_speed = 250000
 


### PR DESCRIPTION
### Description

Ignore TMCStepper for PrintrBoard builds, since they have non-TMC drivers permanently installed. This works around The teensy framework's  SoftwareSerial incompatibility with TMCStepper.

### Related Issues

#15302 - @drphil3d verified that this solved their compilation issue.
