### PR TITLE
Disable HYBRID_THRESHOLD in SKR Mini E3 examples

### DIFF
--- a/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration_adv.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration_adv.h
@@ -2090,7 +2090,7 @@
    * STEALTHCHOP_(XY|Z|E) must be enabled to use HYBRID_THRESHOLD.
    * M913 X/Y/Z/E to live tune the setting
    */
-  #define HYBRID_THRESHOLD
+  //#define HYBRID_THRESHOLD
 
   #define X_HYBRID_THRESHOLD     100  // [mm/s]
   #define X2_HYBRID_THRESHOLD    100

--- a/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration_adv.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration_adv.h
@@ -2090,7 +2090,7 @@
    * STEALTHCHOP_(XY|Z|E) must be enabled to use HYBRID_THRESHOLD.
    * M913 X/Y/Z/E to live tune the setting
    */
-  #define HYBRID_THRESHOLD
+  //#define HYBRID_THRESHOLD
 
   #define X_HYBRID_THRESHOLD     100  // [mm/s]
   #define X2_HYBRID_THRESHOLD    100


### PR DESCRIPTION
# Description

These are the only two examples which enable HYBRID_THRESHOLD by default, and the noise catches people off-guard when they switch to using the new example files with the boards and cross the threshold into SpreadCycle without realizing it (which is pretty easy with the default thresholds).

Unless we take a broader stance to enable HYBRID_THRESHOLD in more examples, I think it makes sense to just turn it off.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/16355

