### PR TITLE
Don't loop forever in loop procedure

### DIFF
--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1128,10 +1128,7 @@ void setup() {
  *  - Call inactivity manager
  */
 void loop() {
-
-  for (;;) {
-
-    idle(); // Do an idle first so boot is slightly faster
+    idle(); 
 
     #if ENABLED(SDSUPPORT)
       card.checkautostart();
@@ -1141,5 +1138,4 @@ void loop() {
     queue.advance();
 
     endstops.event_handler();
-  }
 }

--- a/Marlin/src/Marlin.cpp
+++ b/Marlin/src/Marlin.cpp
@@ -1128,7 +1128,9 @@ void setup() {
  *  - Call inactivity manager
  */
 void loop() {
-    idle(); 
+  do {
+
+    idle();
 
     #if ENABLED(SDSUPPORT)
       card.checkautostart();
@@ -1138,4 +1140,10 @@ void loop() {
     queue.advance();
 
     endstops.event_handler();
+
+  } while (false        // Return to caller for best compatibility
+    #ifdef __AVR__
+      || true           // Loop forever on slower (AVR) boards
+    #endif
+  );
 }


### PR DESCRIPTION
### Description

Actually Marlin has an infinite loop in the loop() procedure.
While this can perform better on some architectures (because it "skips" the jump-in/out from the loop sub, saving a few opcodes to push/pull to/from stack) it can introduce unintended bugs in some architectures/frameworks.
For example, in STM32, this is the code which calls the `loop()`:
```cpp
int main(void)
{
  initVariant();
  setup();
  for (;;) {
#if defined(CORE_CALLBACK)
    CoreCallback();
#endif
    loop();
    if (serialEventRun) {
      serialEventRun();
    }
  }
  return 0;
}
```
It's obvious that a never-ending `loop()` will mess with logical, intended, flow of the program causing unexpected bugs.

Also..that comment on `idle()` was wrong. It doesn't make the boot faster at all (it's the opposite, for everything that the idle sub does now)

### Benefits

Although it will make Marlin a few cpu cycles slower it will be more "clean" and less bug-prone on every platform.

### Related Issues
Since this bug was found while developing https://github.com/MarlinFirmware/Marlin/pull/16260 it was included in the PR but I think it should be "extracted" from it to keep a reference about why this change is necessary.
https://github.com/MarlinFirmware/Marlin/pull/16260#pullrequestreview-335591692