### PR TITLE
Disable PIDTEMPBED in SKR Mini E3 examples

### DIFF
--- a/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.0/Configuration.h
@@ -498,7 +498,7 @@
  * heater. If your configuration is significantly different than this and you don't understand
  * the issues involved, don't use bed PID until someone else verifies that your hardware works.
  */
-#define PIDTEMPBED
+//#define PIDTEMPBED
 
 //#define BED_LIMIT_SWITCHING
 

--- a/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration.h
+++ b/config/examples/BigTreeTech/SKR Mini E3 1.2/Configuration.h
@@ -498,7 +498,7 @@
  * heater. If your configuration is significantly different than this and you don't understand
  * the issues involved, don't use bed PID until someone else verifies that your hardware works.
  */
-#define PIDTEMPBED
+//#define PIDTEMPBED
 
 //#define BED_LIMIT_SWITCHING
 


### PR DESCRIPTION
### Description
Disable PIDTEMPBED for the SKR Mini E3 boards, both 1.0 and 1.2.

The SKR Mini E3 boards are marketed as a drop-in replacement for the stock Creality control board that ships with the Ender 3. By default, the Creality fork of Marlin uses BANG-BANG for bed heating.

### Benefits
No unexpected changes for users expecting a drop-in experience. No requirement for PID tuning the bed, which isn't always reliable due to high thermal mass.

### Related Issues
