### PR TITLE
Add Leapfrog Xeed 2015 board and pins file

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -138,6 +138,7 @@
 #define BOARD_GT2560_V3_A20           1318  // Geeetech GT2560 Rev B for A20(M/D)
 #define BOARD_EINSTART_S              1319  // Einstart retrofit
 #define BOARD_WANHAO_ONEPLUS          1320  // Wanhao 0ne+ i3 Mini
+#define BOARD_LEAPFROG_XEED2015       1321  // Leapfrog Xeed 2015
 
 //
 // ATmega1281, ATmega2561

--- a/Marlin/src/pins/mega/pins_LEAPFROG_XEED2015.h
+++ b/Marlin/src/pins/mega/pins_LEAPFROG_XEED2015.h
@@ -1,0 +1,114 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Leapfrog Xeed Driver board pin assignments
+ *
+ * This board is used by other Leapfrom printers in addition to the Xeed,
+ * such as the Creatr HS and Bolt. The pin assignments vary wildly between
+ * printer models. As such this file is currently specific to the Xeed.
+ */
+
+#ifndef __AVR_ATmega2560__
+  #error "Oops! Select 'Mega 2560' in 'Tools > Board.'"
+#endif
+
+#define BOARD_INFO_NAME "Leapfrog Xeed 2015"
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN          47 // 'X Min' Connector
+#define Y_MAX_PIN          48 // 'Y Min' Connector
+#define Z_MIN_PIN          49 // 'Z Min' Connector
+
+//
+// Steppers
+// The Xeed utilizes three Z-axis motors, which use the X, Y, and Z stepper connectors
+// on the board. The X and Y steppers use external drivers, attached to signal-level
+// Y-axis and X-axis connectors on the board, which map to distinct CPU pins from
+// the on-board X/Y stepper drivers.
+//
+
+// X-axis signal-level connector
+#define X_STEP_PIN         65
+#define X_DIR_PIN          64
+#define X_ENABLE_PIN       66 // Not actually used on Xeed, could be repurposed
+
+// Y-axis signal-level connector
+#define Y_STEP_PIN         23
+#define Y_DIR_PIN          22
+#define Y_ENABLE_PIN       24 // Not actually used on Xeed, could be repurposed
+
+// ZMOT connector (Front Right Z Motor)
+#define Z_STEP_PIN         31
+#define Z_DIR_PIN          32
+#define Z_ENABLE_PIN       30
+
+// XMOT connector (Rear Z Motor)
+#define Z2_STEP_PIN        28
+#define Z2_DIR_PIN         63
+#define Z2_ENABLE_PIN      29
+
+// YMOT connector (Front Left Z Motor)
+#define Z3_STEP_PIN        14
+#define Z3_DIR_PIN         15
+#define Z3_ENABLE_PIN      39
+
+// EMOT2 connector
+#define E0_STEP_PIN         37
+#define E0_DIR_PIN          40
+#define E0_ENABLE_PIN       36
+
+// EMOT connector
+#define E1_STEP_PIN         34
+#define E1_DIR_PIN          35
+#define E1_ENABLE_PIN       33
+
+// Filament movement sensors
+#define FIL_RUNOUT_PIN     42 // ROT2 Connector
+#define FIL_RUNOUT2_PIN    44 // ROT1 Connector
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         15   // T3 Connector
+#define TEMP_1_PIN         13   // T1 Connector
+#define TEMP_BED_PIN       14   // BED Connector (Between T1 and T3)
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN        8 // Misc Connector, pins 3 and 4 (Out2)
+#define HEATER_1_PIN        9 // Misc Connector, pins 5 and 6 (Out3)
+#define HEATER_BED_PIN      6 // Misc Connector, pins 9(-) and 10(+) (OutA)
+
+// Door Closed Sensor
+// #define DOOR_PIN           45 // HM1 Connector
+
+#define FAN_PIN            10 // Misc Connector, pins 7(-) and 8 (+) (Out4)
+
+#define LED_PIN            13
+
+#define SOL1_PIN           7 // Misc Connector, pins 1(-) and 2(+) (Out1)
+

--- a/Marlin/src/pins/mega/pins_LEAPFROG_XEED2015.h
+++ b/Marlin/src/pins/mega/pins_LEAPFROG_XEED2015.h
@@ -24,7 +24,7 @@
 /**
  * Leapfrog Xeed Driver board pin assignments
  *
- * This board is used by other Leapfrom printers in addition to the Xeed,
+ * This board is used by other Leapfrog printers in addition to the Xeed,
  * such as the Creatr HS and Bolt. The pin assignments vary wildly between
  * printer models. As such this file is currently specific to the Xeed.
  */
@@ -38,9 +38,9 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN          47 // 'X Min' Connector
-#define Y_MAX_PIN          48 // 'Y Min' Connector
-#define Z_MIN_PIN          49 // 'Z Min' Connector
+#define X_STOP_PIN         47   // 'X Min'
+#define Y_STOP_PIN         48   // 'Y Min'
+#define Z_STOP_PIN         49   // 'Z Min'
 
 //
 // Steppers
@@ -53,12 +53,12 @@
 // X-axis signal-level connector
 #define X_STEP_PIN         65
 #define X_DIR_PIN          64
-#define X_ENABLE_PIN       66 // Not actually used on Xeed, could be repurposed
+#define X_ENABLE_PIN       66   // Not actually used on Xeed, could be repurposed
 
 // Y-axis signal-level connector
 #define Y_STEP_PIN         23
 #define Y_DIR_PIN          22
-#define Y_ENABLE_PIN       24 // Not actually used on Xeed, could be repurposed
+#define Y_ENABLE_PIN       24   // Not actually used on Xeed, could be repurposed
 
 // ZMOT connector (Front Right Z Motor)
 #define Z_STEP_PIN         31
@@ -76,18 +76,20 @@
 #define Z3_ENABLE_PIN      39
 
 // EMOT2 connector
-#define E0_STEP_PIN         37
-#define E0_DIR_PIN          40
-#define E0_ENABLE_PIN       36
+#define E0_STEP_PIN        37
+#define E0_DIR_PIN         40
+#define E0_ENABLE_PIN      36
 
 // EMOT connector
-#define E1_STEP_PIN         34
-#define E1_DIR_PIN          35
-#define E1_ENABLE_PIN       33
+#define E1_STEP_PIN        34
+#define E1_DIR_PIN         35
+#define E1_ENABLE_PIN      33
 
-// Filament movement sensors
-#define FIL_RUNOUT_PIN     42 // ROT2 Connector
-#define FIL_RUNOUT2_PIN    44 // ROT1 Connector
+//
+// Filament runout
+//
+#define FIL_RUNOUT_PIN     42   // ROT2 Connector
+#define FIL_RUNOUT2_PIN    44   // ROT1 Connector
 
 //
 // Temperature Sensors
@@ -99,16 +101,15 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN        8 // Misc Connector, pins 3 and 4 (Out2)
-#define HEATER_1_PIN        9 // Misc Connector, pins 5 and 6 (Out3)
-#define HEATER_BED_PIN      6 // Misc Connector, pins 9(-) and 10(+) (OutA)
+#define HEATER_0_PIN        8   // Misc Connector, pins 3 and 4 (Out2)
+#define HEATER_1_PIN        9   // Misc Connector, pins 5 and 6 (Out3)
+#define HEATER_BED_PIN      6   // Misc Connector, pins 9(-) and 10(+) (OutA)
 
-// Door Closed Sensor
-// #define DOOR_PIN           45 // HM1 Connector
-
-#define FAN_PIN            10 // Misc Connector, pins 7(-) and 8 (+) (Out4)
+#define FAN_PIN            10   // Misc Connector, pins 7(-) and 8 (+) (Out4)
 
 #define LED_PIN            13
 
-#define SOL1_PIN           7 // Misc Connector, pins 1(-) and 2(+) (Out1)
+#define SOL1_PIN            7   // Misc Connector, pins 1(-) and 2(+) (Out1)
 
+// Door Closed Sensor
+//#define DOOR_PIN           45 // HM1 Connector

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -247,6 +247,8 @@
   #include "mega/pins_OVERLORD.h"               // ATmega2560                             env:megaatmega2560
 #elif MB(HJC2560C_REV2)
   #include "mega/pins_HJC2560C_REV2.h"          // ATmega2560                             env:megaatmega2560
+#elif MB(LEAPFROG_XEED2015)
+  #include "mega/pins_LEAPFROG_XEED2015.h"      // ATmega2560                             env:megaatmega2560
 
 //
 // ATmega1281, ATmega2561


### PR DESCRIPTION
### Description

Add a pins file for the Leapfrog Xeed Control board. I have seen some indication that there is a "2015" version and a "different" version. Not knowing what the differences are, I have included 2015 in the name.

This is a different board than the Leapfrog board already present. This particular board is used on some other printers, but with wildly different pin mappings.

This is the particular board (and layout) I am adding support for:

http://support.lpfrg.com/support/solutions/articles/11000010307-connection-map-for-the-leapfrog-xeed-electronic-motherboard

I will have a configuration example as well, but I need to check a few items related to dual extrusion before posting a PR for it.