### PR TITLE
stm32: support ENDSTOP_INTERRUPTS_FEATURE

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2059,7 +2059,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 /**
  * TMC2208/2209 software UART and ENDSTOP_INTERRUPTS both use pin change interrupts (PCI)
  */
-#if HAS_TMC220x && !defined(TARGET_LPC1768) && ENABLED(ENDSTOP_INTERRUPTS_FEATURE) && !( \
+#if HAS_TMC220x && !defined(TARGET_LPC1768) && ENABLED(ENDSTOP_INTERRUPTS_FEATURE) && !defined(TARGET_STM32F1) && !defined(TARGET_STM32F4) && !( \
        defined(X_HARDWARE_SERIAL ) || defined(X2_HARDWARE_SERIAL) \
     || defined(Y_HARDWARE_SERIAL ) || defined(Y2_HARDWARE_SERIAL) \
     || defined(Z_HARDWARE_SERIAL ) || defined(Z2_HARDWARE_SERIAL) \


### PR DESCRIPTION
Older versions of the SKR mini E3 firmware used to have this patched in, and it still seems to work fine with 2.0.1 regarding !defined(TARGET_STM32F1)

https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/blob/73dc0d8fb7a50c1501d68a278a1e657cc0f30841/firmware/V1.2/Marlin-2.0.x-SKR-Mini-E3-V1.2/Marlin/src/inc/SanityCheck.h

I don't know why newer reference versions of the SKR mini E3 firmware have dropped this change...

I don't have access to a STM32F4 board, but given similarities this will likely be valid for the STM32F4 as well.