### PR TITLE
touch: allow mesh value edit with UBL

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1278,7 +1278,7 @@ void MarlinUI::update() {
 
     } // next_button_update_ms
 
-    #if HAS_ENCODER_WHEEL
+    #if HAS_ENCODER_WHEEL && DISABLED(TOUCH_BUTTONS)
       static uint8_t lastEncoderBits;
 
       #define encrot0 0

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -786,6 +786,9 @@ void MarlinUI::update() {
             encoderDiff = (ENCODER_STEPS_PER_MENU_ITEM) * (ENCODER_PULSES_PER_STEP) * encoderDirection;
             if (buttons & EN_A) encoderDiff *= -1;
             next_button_update_ms = ms + repeat_delay;    // Assume the repeat delay
+            #if ENABLED(AUTO_BED_LEVELING_UBL)
+              ubl.encoder_diff = encoderDiff;
+            #endif
             if (!wait_for_unclick) {
               next_button_update_ms += 250;               // Longer delay on first press
               wait_for_unclick = true;                    // Avoid Back/Select click while repeating

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -787,7 +787,8 @@ void MarlinUI::update() {
             if (buttons & EN_A) encoderDiff *= -1;
             next_button_update_ms = ms + repeat_delay;    // Assume the repeat delay
             #if ENABLED(AUTO_BED_LEVELING_UBL)
-              ubl.encoder_diff = encoderDiff;
+              if (external_control)
+                ubl.encoder_diff = encoderDiff;
             #endif
             if (!wait_for_unclick) {
               next_button_update_ms += 250;               // Longer delay on first press

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -785,11 +785,10 @@ void MarlinUI::update() {
           if (ELAPSED(ms, next_button_update_ms)) {
             encoderDiff = (ENCODER_STEPS_PER_MENU_ITEM) * (ENCODER_PULSES_PER_STEP) * encoderDirection;
             if (buttons & EN_A) encoderDiff *= -1;
-            next_button_update_ms = ms + repeat_delay;    // Assume the repeat delay
             #if ENABLED(AUTO_BED_LEVELING_UBL)
-              if (external_control)
-                ubl.encoder_diff = encoderDiff;
+              if (external_control) ubl.encoder_diff = encoderDiff;
             #endif
+            next_button_update_ms = ms + repeat_delay;    // Assume the repeat delay
             if (!wait_for_unclick) {
               next_button_update_ms += 250;               // Longer delay on first press
               wait_for_unclick = true;                    // Avoid Back/Select click while repeating


### PR DESCRIPTION
actually, with touchscreen buttons, it was only allowed to reduce the Z values and validate

Note: Cancel/Back button is not yet handled (EN_D)