### PR TITLE
[2.0.x] Enable MULTI_NOZZLE_DUPLICATION for BIBO

### DIFF
--- a/config/examples/BIBO/TouchX/default/Configuration_adv.h
+++ b/config/examples/BIBO/TouchX/default/Configuration_adv.h
@@ -691,7 +691,7 @@
 #define AXIS_RELATIVE_MODES { false, false, false, false }
 
 // Add a Duplicate option for well-separated conjoined nozzles
-//#define MULTI_NOZZLE_DUPLICATION
+#define MULTI_NOZZLE_DUPLICATION
 
 // By default pololu step drivers require an active high signal. However, some high power drivers require an active low signal as step.
 #define INVERT_X_STEP_PIN false


### PR DESCRIPTION
### Description
<!--
We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.
-->
BIBO2 printers currently uses a modified version of the [Old ShaqFoo fork of Marlin 1.0.0 for Ditto printing](https://github.com/ShaqFoo/Marlin_Firmware_Deluxe_With_Ditto_Print-Auto_Leveling). This PR enables the MULTI_NOZZLE_DUPLICATION for the BIBO 2 to provide that printer functionality on this MK8 style direct drive Dual Extruder printer.

### Benefits
<!-- What does this fix or improve? -->
Adds the MULTI_NOZZLE_DUPLICATION for the BIBO 2 to maintain ditto printing capabilities. 

### Related Issues
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
Improves the example BIBO 2 touch code to match with the manufacturer marketed features and the manufacturer's modified firmware. 
Related to PR #16436 for Marlin 1.1.x