### PR TITLE
[1.1.x] Enable DUAL_NOZZLE_DUPLICATION_MODE for BIBO

### DIFF
--- a/Marlin/example_configurations/BIBO/TouchX/default/Configuration_adv.h
+++ b/Marlin/example_configurations/BIBO/TouchX/default/Configuration_adv.h
@@ -458,7 +458,7 @@
 #define AXIS_RELATIVE_MODES {false, false, false, false}
 
 // Allow duplication mode with a basic dual-nozzle extruder
-//#define DUAL_NOZZLE_DUPLICATION_MODE
+#define DUAL_NOZZLE_DUPLICATION_MODE
 
 // By default pololu step drivers require an active high signal. However, some high power drivers require an active low signal as step.
 #define INVERT_X_STEP_PIN false


### PR DESCRIPTION
### Description
<!--
We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.
-->
BIBO2 printers currently uses a modified version of the Old ShaqFoo fork of Marlin 1.0.0 for Ditto printing. This PR enables the DUAL_NOZZLE_DUPLICATION_MODE for the BIBO 2 to provide that printer functionality on this MK8 style direct drive Dual Extruder printer.

### Benefits
<!-- What does this fix or improve? -->
Adds the DUAL_NOZZLE_DUPLICATION_MODE for the BIBO 2 to maintain ditto printing capabilities.

### Related Issues
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
Improves the example BIBO 2 Touch setup to match with the manufacturer marketed features and the manufacturer's modified firmware.
Related to #16435 for Marlin 2.0.x