### PR TITLE
Pins debugging (M43) AVR serial pins

### DIFF
--- a/Marlin/src/pins/pinsDebug.h
+++ b/Marlin/src/pins/pinsDebug.h
@@ -45,9 +45,35 @@
 #line 46
 
 // manually add pins that have names that are macros which don't play well with these macros
-#if SERIAL_PORT == 0 && (AVR_ATmega2560_FAMILY || AVR_ATmega1284_FAMILY || defined(ARDUINO_ARCH_SAM))
-  static const char RXD_NAME[] PROGMEM = { "RXD" };
-  static const char TXD_NAME[] PROGMEM = { "TXD" };
+#if (AVR_ATmega2560_FAMILY || AVR_ATmega1284_FAMILY || defined(ARDUINO_ARCH_SAM))
+  #if SERIAL_PORT == 0
+    static const char RXD_NAME_0[] PROGMEM = { "RXD0" };
+    static const char TXD_NAME_0[] PROGMEM = { "TXD0" };
+  #elif SERIAL_PORT == 1
+    static const char RXD_NAME_1[] PROGMEM = { "RXD1" };
+    static const char TXD_NAME_1[] PROGMEM = { "TXD1" };
+  #elif SERIAL_PORT == 2
+    static const char RXD_NAME_2[] PROGMEM = { "RXD2" };
+    static const char TXD_NAME_2[] PROGMEM = { "TXD2" };
+  #elif SERIAL_PORT == 3 
+    static const char RXD_NAME_3[] PROGMEM = { "RXD3" };
+    static const char TXD_NAME_3[] PROGMEM = { "TXD3" };
+  #endif
+  #ifdef SERIAL_PORT_2
+    #if SERIAL_PORT_2 == 0
+      static const char RXD_NAME_0[] PROGMEM = { "RXD0" };
+      static const char TXD_NAME_0[] PROGMEM = { "TXD0" };
+    #elif SERIAL_PORT_2 == 1
+      static const char RXD_NAME_1[] PROGMEM = { "RXD1" };
+      static const char TXD_NAME_1[] PROGMEM = { "TXD1" };
+    #elif SERIAL_PORT_2 == 2
+      static const char RXD_NAME_2[] PROGMEM = { "RXD2" };
+      static const char TXD_NAME_2[] PROGMEM = { "TXD2" };
+    #elif SERIAL_PORT_2 == 3
+      static const char RXD_NAME_3[] PROGMEM = { "RXD3" };
+      static const char TXD_NAME_3[] PROGMEM = { "TXD3" };
+    #endif
+  #endif
 #endif
 
 /////////////////////////////////////////////////////////////////////////////
@@ -85,11 +111,57 @@ const PinInfo pin_array[] PROGMEM = {
   // manually add pins ...
   #if SERIAL_PORT == 0
     #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
-      { RXD_NAME, 0, true },
-      { TXD_NAME, 1, true },
+      { RXD_NAME_0, 0, true },
+      { TXD_NAME_0, 1, true },
     #elif AVR_ATmega1284_FAMILY
-      { RXD_NAME, 8, true },
-      { TXD_NAME, 9, true },
+      { RXD_NAME_0, 8, true },
+      { TXD_NAME_0, 9, true },
+    #endif
+  #elif SERIAL_PORT == 1
+    #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
+      { RXD_NAME_1, 19, true },
+      { TXD_NAME_1, 18, true },
+    #elif AVR_ATmega1284_FAMILY
+      { RXD_NAME_1, 10, true },
+      { TXD_NAME_1, 11, true },
+    #endif
+  #elif SERIAL_PORT == 2
+    #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
+      { RXD_NAME_2, 17, true },
+      { TXD_NAME_2, 16, true },
+    #endif
+  #elif SERIAL_PORT == 3
+    #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
+      { RXD_NAME_3, 15, true },
+      { TXD_NAME_3, 14, true },
+    #endif
+  #endif
+
+  #if SERIAL_PORT_2 == 0
+    #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
+      { RXD_NAME_0, 0, true },
+      { TXD_NAME_0, 1, true },
+    #elif AVR_ATmega1284_FAMILY
+      { RXD_NAME_0, 8, true },
+      { TXD_NAME_0, 9, true },
+    #endif
+  #elif SERIAL_PORT_2 == 1
+    #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
+      { RXD_NAME_1, 19, true },
+      { TXD_NAME_1, 18, true },
+    #elif AVR_ATmega1284_FAMILY
+      { RXD_NAME_1, 10, true },
+      { TXD_NAME_1, 11, true },
+    #endif
+  #elif SERIAL_PORT_2 == 2
+    #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
+      { RXD_NAME_2, 17, true },
+      { TXD_NAME_2, 16, true },
+    #endif
+  #elif SERIAL_PORT_2 == 3
+    #if (AVR_ATmega2560_FAMILY || defined(ARDUINO_ARCH_SAM))
+      { RXD_NAME_3, 15, true },
+      { TXD_NAME_3, 14, true },
     #endif
   #endif
 


### PR DESCRIPTION
Description

The current pinsDebug.h only defines the AVR_ATmega serial pins when Configuration.h has  #define SERIAL_PORT 0. Other serial ports and SERIAL_PORT_2 are ignored. 

I have added SERIAL_PORT  1 - 3 and SERIAL_PORT_2 support.

Benefits

When someone assigns the same IO pins as a used serial port on AVR devices M43 will show the conflict. 

Related Issues

I've seen this happen a few times on reprap forum and most recently issue #16393. M43 didn't show the issue, now it will.   
 