### PR TITLE
Add BTT002 filament runout, PLR, and RGB pins

### DIFF
--- a/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
@@ -57,6 +57,20 @@
 #endif
 
 //
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN   PA15
+#endif
+
+//
+// Power Loss Detection
+//
+#ifndef POWER_LOSS_PIN
+ #define POWER_LOSS_PIN    PD4
+#endif
+
+//
 // Steppers
 //
 #define X_STEP_PIN         PA9
@@ -226,3 +240,19 @@
   #endif
 
 #endif // HAS_SPI_LCD
+
+//
+// RGB LEDs
+//
+#ifndef RGB_LED_R_PIN
+  #define RGB_LED_R_PIN    PB5
+#endif
+#ifndef RGB_LED_G_PIN
+  #define RGB_LED_G_PIN    PB4
+#endif
+#ifndef RGB_LED_B_PIN
+  #define RGB_LED_B_PIN    PB3
+#endif
+#ifndef RGB_LED_W_PIN
+  #define RGB_LED_W_PIN    -1
+#endif

--- a/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
@@ -50,7 +50,7 @@
 #define Z_MAX_PIN          PD1
 
 //
-// Z Probe must be this pins  ##
+// Z Probe must be this pin
 //
 #ifndef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN  PD1
@@ -67,7 +67,7 @@
 // Power Loss Detection
 //
 #ifndef POWER_LOSS_PIN
- #define POWER_LOSS_PIN    PD4
+  #define POWER_LOSS_PIN   PD4
 #endif
 
 //


### PR DESCRIPTION
### Description

Add BigTreeTech's BTT002 filament runout, power-loss recovery, and RGB pins.

### Related Issues

None.
