### PR TITLE
Add menu for adjustment of Probe Offsets

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -393,6 +393,9 @@ namespace Language_en {
   PROGMEM Language_Str MSG_MANUAL_DEPLOY                   = _UxGT("Deploy Z-Probe");
   PROGMEM Language_Str MSG_MANUAL_STOW                     = _UxGT("Stow Z-Probe");
   PROGMEM Language_Str MSG_HOME_FIRST                      = _UxGT("Home %s%s%s First");
+  PROGMEM Language_Str MSG_ZPROBE_OFFSETS                  = _UxGT("Probe Offsets");
+  PROGMEM Language_Str MSG_ZPROBE_XOFFSET                  = _UxGT("Probe X Offset");
+  PROGMEM Language_Str MSG_ZPROBE_YOFFSET                  = _UxGT("Probe Y Offset");
   PROGMEM Language_Str MSG_ZPROBE_ZOFFSET                  = _UxGT("Probe Z Offset");
   PROGMEM Language_Str MSG_BABYSTEP_X                      = _UxGT("Babystep X");
   PROGMEM Language_Str MSG_BABYSTEP_Y                      = _UxGT("Babystep Y");

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -514,11 +514,9 @@ void menu_cancelobject();
     void menu_probe_offsets() {
       START_MENU();
       BACK_ITEM(MSG_ADVANCED_SETTINGS);
-
       EDIT_ITEM(float51, MSG_ZPROBE_XOFFSET, &probe_offset.x, -(X_BED_SIZE), X_BED_SIZE);
       EDIT_ITEM(float51, MSG_ZPROBE_YOFFSET, &probe_offset.y, -(Y_BED_SIZE), Y_BED_SIZE);
       EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_ZPROBE_ZOFFSET, &probe_offset.z, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
-
       END_MENU();
     }
   #endif

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -509,6 +509,19 @@ void menu_cancelobject();
     END_MENU();
   }
 
+  #if HAS_BED_PROBE
+    void menu_probe_offsets() {
+      START_MENU();
+      BACK_ITEM(MSG_ADVANCED_SETTINGS);
+
+      EDIT_ITEM(float51, MSG_ZPROBE_XOFFSET, &probe_offset.x, -(X_BED_SIZE), X_BED_SIZE);
+      EDIT_ITEM(float51, MSG_ZPROBE_YOFFSET, &probe_offset.y, -(Y_BED_SIZE), Y_BED_SIZE);
+      EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_ZPROBE_ZOFFSET, &probe_offset.z, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
+
+      END_MENU();
+    }
+  #endif
+
 #endif // !SLIM_LCD_MENUS
 
 void menu_advanced_settings() {
@@ -539,6 +552,11 @@ void menu_advanced_settings() {
     if (!printer_busy()) {
       // M92 - Steps Per mm
       SUBMENU(MSG_STEPS_PER_MM, menu_advanced_steps_per_mm);
+
+      #if HAS_BED_PROBE
+        // M851 - Z Probe Offsets
+        SUBMENU(MSG_ZPROBE_OFFSETS, menu_probe_offsets);
+      #endif
     }
   #endif // !SLIM_LCD_MENUS
 

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -509,6 +509,7 @@ void menu_cancelobject();
     END_MENU();
   }
 
+  // M851 - Z Probe Offsets
   #if HAS_BED_PROBE
     void menu_probe_offsets() {
       START_MENU();


### PR DESCRIPTION
Add menu in advanced configuration for adjustment of probe XY values. Limit with machine busy or slim menus.