### PR TITLE
Standardize drivers.h values, add class indirection

### DIFF
--- a/Marlin/src/core/drivers.h
+++ b/Marlin/src/core/drivers.h
@@ -23,30 +23,30 @@
 
 #include "../inc/MarlinConfigPre.h"
 
-#define _A4988              0x001
-#define _A5984              0x002
-#define _DRV8825            0x003
-#define _LV8729             0x004
-#define _L6470              0x105
-#define _TB6560             0x006
-#define _TB6600             0x007
-#define _TMC2100            0x008
-#define _TMC2130            2130
-#define _TMC2130_STANDALONE 0x009
-#define _TMC2160            2160
-#define _TMC2160_STANDALONE 2161
-#define _TMC2208            2208
-#define _TMC2208_STANDALONE 0x00A
-#define _TMC2209            2209
-#define _TMC2209_STANDALONE 0x00D
-#define _TMC26X             0x10B
-#define _TMC26X_STANDALONE  0x00B
-#define _TMC2660            2660
-#define _TMC2660_STANDALONE 0x00C
-#define _TMC5130            5130
-#define _TMC5130_STANDALONE 5131
-#define _TMC5160            5160
-#define _TMC5160_STANDALONE 5161
+#define _A4988              0x4988
+#define _A5984              0x5984
+#define _DRV8825            0x8825
+#define _LV8729             0x8729
+#define _L6470              0x6470
+#define _TB6560             0x6560
+#define _TB6600             0x6600
+#define _TMC2100            0x2100
+#define _TMC2130            0x2130A
+#define _TMC2130_STANDALONE 0x2130B
+#define _TMC2160            0x2160A
+#define _TMC2160_STANDALONE 0x2160B
+#define _TMC2208            0x2208A
+#define _TMC2208_STANDALONE 0x2208B
+#define _TMC2209            0x2209A
+#define _TMC2209_STANDALONE 0x2209B
+#define _TMC26X             0x2600A
+#define _TMC26X_STANDALONE  0x2600B
+#define _TMC2660            0x2660A
+#define _TMC2660_STANDALONE 0x2660B
+#define _TMC5130            0x5130A
+#define _TMC5130_STANDALONE 0x5130B
+#define _TMC5160            0x5160A
+#define _TMC5160_STANDALONE 0x5160B
 
 #define _DRIVER_ID(V) _CAT(_, V)
 #define _AXIS_DRIVER_TYPE(A,T) (_DRIVER_ID(A##_DRIVER_TYPE) == _CAT(_, T))

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -29,22 +29,6 @@
 #include <TMCStepper.h>
 #include "../module/planner.h"
 
-#define TMC_X_LABEL 'X', '0'
-#define TMC_Y_LABEL 'Y', '0'
-#define TMC_Z_LABEL 'Z', '0'
-
-#define TMC_X2_LABEL 'X', '2'
-#define TMC_Y2_LABEL 'Y', '2'
-#define TMC_Z2_LABEL 'Z', '2'
-#define TMC_Z3_LABEL 'Z', '3'
-
-#define TMC_E0_LABEL 'E', '0'
-#define TMC_E1_LABEL 'E', '1'
-#define TMC_E2_LABEL 'E', '2'
-#define TMC_E3_LABEL 'E', '3'
-#define TMC_E4_LABEL 'E', '4'
-#define TMC_E5_LABEL 'E', '5'
-
 #define CHOPPER_DEFAULT_12V  { 3, -1, 1 }
 #define CHOPPER_DEFAULT_19V  { 4,  1, 1 }
 #define CHOPPER_DEFAULT_24V  { 4,  2, 1 }

--- a/Marlin/src/module/stepper/trinamic.h
+++ b/Marlin/src/module/stepper/trinamic.h
@@ -34,15 +34,37 @@
 #include "../../inc/MarlinConfig.h"
 #include "../../feature/tmc_util.h"
 
-#define ____TMC_CLASS(MODEL, A, I, E) TMCMarlin<TMC##MODEL##Stepper, A, I, E>
-#define ___TMC_CLASS(MODEL, A, I, E) ____TMC_CLASS(MODEL, A, I, E)
-#define __TMC_CLASS(MODEL, A, I, E) ___TMC_CLASS(_##MODEL, A, I, E)
-#define _TMC_CLASS(MODEL, L, E) __TMC_CLASS(MODEL, L, E)
+#define CLASS_TMC2130 TMC2130Stepper
+#define CLASS_TMC2160 TMC2160Stepper
+#define CLASS_TMC2208 TMC2208Stepper
+#define CLASS_TMC2209 TMC2209Stepper
+#define CLASS_TMC2660 TMC2660Stepper
+#define CLASS_TMC5130 TMC5130Stepper
+#define CLASS_TMC5160 TMC5160Stepper
+
+#define TMC_X_LABEL 'X', '0'
+#define TMC_Y_LABEL 'Y', '0'
+#define TMC_Z_LABEL 'Z', '0'
+
+#define TMC_X2_LABEL 'X', '2'
+#define TMC_Y2_LABEL 'Y', '2'
+#define TMC_Z2_LABEL 'Z', '2'
+#define TMC_Z3_LABEL 'Z', '3'
+
+#define TMC_E0_LABEL 'E', '0'
+#define TMC_E1_LABEL 'E', '1'
+#define TMC_E2_LABEL 'E', '2'
+#define TMC_E3_LABEL 'E', '3'
+#define TMC_E4_LABEL 'E', '4'
+#define TMC_E5_LABEL 'E', '5'
+
+#define __TMC_CLASS(TYPE, L, I, A) TMCMarlin<CLASS_##TYPE, L, I, A>
+#define _TMC_CLASS(TYPE, LandI, A) __TMC_CLASS(TYPE, LandI, A)
 #define TMC_CLASS(ST, A) _TMC_CLASS(ST##_DRIVER_TYPE, TMC_##ST##_LABEL, A##_AXIS)
 #if ENABLED(DISTINCT_E_FACTORS)
-  #define TMC_CLASS_E(I) TMC_CLASS(E##I, E##I)
+  #define TMC_CLASS_E(N) TMC_CLASS(E##N, E##N)
 #else
-  #define TMC_CLASS_E(I) TMC_CLASS(E##I, E)
+  #define TMC_CLASS_E(N) TMC_CLASS(E##N, E)
 #endif
 
 typedef struct {

--- a/buildroot/share/tests/megaatmega2560-tests
+++ b/buildroot/share/tests/megaatmega2560-tests
@@ -322,7 +322,7 @@ exec_test $1 $2 "RAMPS 1.3 | DELTA | FLSUN AC Config"
 #exec_test $1 $2 "Stuff"
 
 #
-# SCARA with TMC2130
+# SCARA with Mixed TMC
 #
 use_example_configs SCARA/Morgan
 opt_set LCD_LANGUAGE es
@@ -332,7 +332,7 @@ opt_enable USE_ZMIN_PLUG FIX_MOUNTED_PROBE AUTO_BED_LEVELING_BILINEAR PAUSE_BEFO
 opt_set X_MAX_ENDSTOP_INVERTING false
 opt_set X_DRIVER_TYPE TMC2209
 opt_set Y_DRIVER_TYPE TMC2130
-opt_set Z_DRIVER_TYPE TMC2130
+opt_set Z_DRIVER_TYPE TMC2130_STANDALONE
 opt_set E0_DRIVER_TYPE TMC2660
 exec_test $1 $2 "RAMPS | SCARA | Mixed TMC | EEPROM"
 
@@ -343,7 +343,7 @@ restore_configs
 opt_set LCD_LANGUAGE vi
 opt_set X_DRIVER_TYPE TMC2160
 opt_set Y_DRIVER_TYPE TMC5160
-opt_set Z_DRIVER_TYPE TMC2208
+opt_set Z_DRIVER_TYPE TMC2208_STANDALONE
 opt_set E0_DRIVER_TYPE TMC2130
 opt_set X_MIN_ENDSTOP_INVERTING true
 opt_set Y_MIN_ENDSTOP_INVERTING true


### PR DESCRIPTION
The values in `drivers.h` were ugly, so this makes them a little more readable. To make the `TMC_CLASS` macro independent of the `drivers.h` values this adds class indirection. This brings Marlin a step closer to allowing the `TMCMarlin` class to be generalized to other drivers that might need special handling, following the model of `TMCStepper`.