### PR TITLE
Release UI on G26 priming timeout

### DIFF
--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -418,7 +418,7 @@ inline bool turn_on_heaters() {
 inline bool prime_nozzle() {
 
   const feedRate_t fr_slow_e = planner.settings.max_feedrate_mm_s[E_AXIS] / 15.0f;
-  #if HAS_LCD_MENU
+  #if HAS_LCD_MENU && DISABLED(TOUCH_BUTTONS) // ui.button_pressed issue with touchscreen
     #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
       float Total_Prime = 0.0;
     #endif

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -424,9 +424,7 @@ inline bool prime_nozzle() {
     #endif
 
     if (g26_prime_flag == -1) {  // The user wants to control how much filament gets purged
-      #if HAS_LCD_MENU
-        ui.capture();
-      #endif
+      ui.capture();
       ui.set_status_P(GET_TEXT(MSG_G26_MANUAL_PRIME), 99);
       ui.chirp();
 
@@ -439,7 +437,10 @@ inline bool prime_nozzle() {
         destination.e += 0.25;
         #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
           Total_Prime += 0.25;
-          if (Total_Prime >= EXTRUDE_MAXLENGTH) return G26_ERR;
+          if (Total_Prime >= EXTRUDE_MAXLENGTH) {
+            ui.release();
+            return G26_ERR;
+          }
         #endif
         prepare_internal_move_to_destination(fr_slow_e);
         destination = current_position;


### PR DESCRIPTION
\+ remove a duplicated ifdef

Unsure if the default extrusion requiring user click (G26 P) is the right thing to do.
Here, that needed 20cm of filament extrusion (make a huge blob in the middle of the bed)

and nothing was explained on the LCD to interrupt it... edit: nvm, MSG_G26_MANUAL_PRIME is shown after a closer look.
