### PR TITLE
Fix progress bar calculation for permyriad.

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -438,7 +438,7 @@ void MarlinUI::draw_status_screen() {
       if (p != lastProgress) {
         lastProgress = p;
 
-        progress_bar_solid_width = u8g_uint_t((PROGRESS_BAR_WIDTH - 2) * progress / (PROGRESS_SCALE) * 0.01f);
+        progress_bar_solid_width = u8g_uint_t((PROGRESS_BAR_WIDTH - 2) * (progress / (PROGRESS_SCALE)) * 0.01f);
 
         #if ENABLED(DOGM_SD_PERCENT)
           if (progress == 0) {


### PR DESCRIPTION
### Description

With combination of `LCD_SET_PROGRESS_MANUALLY `, `HAS_PRINT_PROGRESS `, and `SHOW_REMAINING_TIME` the progress bar on the LCD would not fill the expected amount. Progress bar would only fill up to about 5 or 6 pixels for 100%.

Appears that the settings cause `HAS_PRINT_PROGRESS_PERMYRIAD` to get set. Due to this, progress  gets scaled up by a factor of 100 when set by M73. Calculation for `progress_bar_solid_width` would overflow the uint16_t due to left-to-right associativity. Added parens around `(progress / (PROGRESS_SCALE))` so progress would be scaled back down before multiplying by the bar width to prevent the overflow.

### Benefits

LCD progress bar fills up properly with this particular configuration. 

### Related Issues

Couldn't find any current issues.
