### PR TITLE
Fix EEPROM error when EXTRUDERS == 0

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1145,7 +1145,7 @@ void MarlinSettings::postprocess() {
         EEPROM_WRITE(planner.extruder_advance_K);
       #else
         dummy = 0;
-        for (uint8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummy);
+        for (uint8_t q = MIN(EXTRUDERS, 1); q--;) EEPROM_WRITE(dummy);
       #endif
     }
 
@@ -1934,14 +1934,12 @@ void MarlinSettings::postprocess() {
       // Linear Advance
       //
       {
+        float extruder_advance_K[MIN(EXTRUDERS, 1)];
         _FIELD_TEST(planner_extruder_advance_K);
-        #if EXTRUDERS
-          float extruder_advance_K[EXTRUDERS];
-          EEPROM_READ(extruder_advance_K);
-          #if ENABLED(LIN_ADVANCE)
-            if (!validating)
-              COPY(planner.extruder_advance_K, extruder_advance_K);
-          #endif
+        EEPROM_READ(extruder_advance_K);
+        #if ENABLED(LIN_ADVANCE)
+          if (!validating)
+            COPY(planner.extruder_advance_K, extruder_advance_K);
         #endif
       }
 
@@ -2556,9 +2554,9 @@ void MarlinSettings::reset() {
   #if ENABLED(LIN_ADVANCE)
     LOOP_L_N(i, EXTRUDERS) {
       planner.extruder_advance_K[i] = LIN_ADVANCE_K;
-    #if ENABLED(EXTRA_LIN_ADVANCE_K)
-      saved_extruder_advance_K[i] = LIN_ADVANCE_K;
-    #endif
+      #if ENABLED(EXTRA_LIN_ADVANCE_K)
+        saved_extruder_advance_K[i] = LIN_ADVANCE_K;
+      #endif
     }
   #endif
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1934,12 +1934,14 @@ void MarlinSettings::postprocess() {
       // Linear Advance
       //
       {
-        float extruder_advance_K[EXTRUDERS];
         _FIELD_TEST(planner_extruder_advance_K);
-        EEPROM_READ(extruder_advance_K);
-        #if ENABLED(LIN_ADVANCE)
-          if (!validating)
-            COPY(planner.extruder_advance_K, extruder_advance_K);
+        #if EXTRUDERS
+          float extruder_advance_K[EXTRUDERS];
+          EEPROM_READ(extruder_advance_K);
+          #if ENABLED(LIN_ADVANCE)
+            if (!validating)
+              COPY(planner.extruder_advance_K, extruder_advance_K);
+          #endif
         #endif
       }
 


### PR DESCRIPTION

# Description

When EXTRUDERS == 0, saving and loading EEPROM produces CRC errors.  I tracked it down to this section.

EXTRUDERS == 0 forces LIN_ADVANCE to be false, and ultimately saving does nothing with regard to extruder_advance_K.  Loading attempts to load a zero-length array 

```
          float extruder_advance_K[EXTRUDERS];
          EEPROM_READ(extruder_advance_K);
```

I'm not sure why, but this is not a no-op and alters the CRC.  I'm not sure if it affects the layout and the integrity of the subsequent fields.

This change disables the attempted EEPROM_READ when EXTRUDERS==0.

### Benefits

EEPROM is once again usable when EXTRUDERS == 0.

### Related Issues

