### PR TITLE
Fix unused variable warning.

### DIFF
--- a/Marlin/src/feature/caselight.cpp
+++ b/Marlin/src/feature/caselight.cpp
@@ -58,7 +58,7 @@ void update_case_light() {
   if (case_light_arg_flag && case_light_on)
     case_light_brightness = case_light_brightness_sav;  // restore last brightens if this is an S1 argument
 
-  #if ENABLED(CASE_LIGHT_USE_NEOPIXEL) || DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
+  #if ENABLED(CASE_LIGHT_USE_NEOPIXEL) || NONE(CASE_LIGHT_USE_NEOPIXEL, CASE_LIGHT_NO_BRIGHTNESS)
     const uint8_t i = case_light_on ? case_light_brightness : 0, n10ct = INVERT_CASE_LIGHT ? 255 - i : i;
   #endif
 
@@ -73,13 +73,13 @@ void update_case_light() {
 
     #if DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
       if (PWM_PIN(CASE_LIGHT_PIN))
-        analogWrite(pin_t(CASE_LIGHT_PIN),
+        analogWrite(pin_t(CASE_LIGHT_PIN), (
           #if CASE_LIGHT_MAX_PWM == 255
             n10ct
           #else
             map(n10ct, 0, 255, 0, CASE_LIGHT_MAX_PWM)
           #endif
-        );
+        ));
       else
     #endif
       {

--- a/Marlin/src/feature/caselight.cpp
+++ b/Marlin/src/feature/caselight.cpp
@@ -58,7 +58,9 @@ void update_case_light() {
   if (case_light_arg_flag && case_light_on)
     case_light_brightness = case_light_brightness_sav;  // restore last brightens if this is an S1 argument
 
-  const uint8_t i = case_light_on ? case_light_brightness : 0, n10ct = INVERT_CASE_LIGHT ? 255 - i : i;
+  #if ENABLED(CASE_LIGHT_USE_NEOPIXEL) || DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
+    const uint8_t i = case_light_on ? case_light_brightness : 0, n10ct = INVERT_CASE_LIGHT ? 255 - i : i;
+  #endif
 
   #if ENABLED(CASE_LIGHT_USE_NEOPIXEL)
 


### PR DESCRIPTION
### Description
Fixes an unused variable warning if CASE_LIGHT_NO_BRIGHTNESS is used and a case light pin is defined.
### Benefits
Removes build warning.