### PR TITLE
Fix LCD on the Tevo Tornado

### DIFF
--- a/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration.h
+++ b/config/examples/Tevo/Tornado/V2 (MKS GEN-L)/Configuration.h
@@ -1882,6 +1882,9 @@
 // http://reprap.org/wiki/RepRapDiscount_Full_Graphic_Smart_Controller
 //
 #define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
+#define ST7920_DELAY_1 DELAY_NS(150)
+#define ST7920_DELAY_2 DELAY_NS(150)
+#define ST7920_DELAY_3 DELAY_NS(150)
 
 //
 // ReprapWorld Graphical LCD


### PR DESCRIPTION
### Description

The Tevo Tornado's config file made the screen have the same problems as the Anet A6's so I added delays as mentioned in issue [#16278](https://github.com/MarlinFirmware/Marlin/issues/16278).
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
### Benefits
<!-- What does this fix or improve? -->
This fixes the problem with the screen on the 2018 Tevo Tornado and makes Marlin functional 