### PR TITLE
Fix Change Filament menu item with runout

### DIFF
--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -233,7 +233,6 @@ void menu_pause_option() {
   #if HAS_FILAMENT_SENSOR
     if (runout.filament_ran_out)
       EDIT_ITEM(bool, MSG_RUNOUT_SENSOR, &runout.enabled, runout.reset);
-    else
   #endif
       ACTION_ITEM(MSG_FILAMENT_CHANGE_OPTION_RESUME, []{ pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT; });
   END_MENU();


### PR DESCRIPTION
### Description


When the runout filament sensor is triggered, and M600 is activated, the last menu doesn't let you resume your print unless you click in the option to turn off your filament sensor. This is because the continue option is missing from the menu.

This pull request removes an "else" that makes the filament change menu in bugfix-2.0.x to not show the option "continue printing".


### Benefits

Fixes the filament change menu

### Related Issues

Maybe this one: #16161