### PR TITLE
Provide some missing Arduino macros

### DIFF
--- a/Marlin/src/feature/dac/dac_mcp4728.h
+++ b/Marlin/src/feature/dac/dac_mcp4728.h
@@ -29,6 +29,24 @@
 
 #include <Wire.h>
 
+/**
+ * The following three macros are only used in this piece of code related to mcp4728.
+ * They are defined in the standard Arduino framework but could be undefined in 32 bits Arduino frameworks.
+ * (For instance not defined in Arduino lpc176x framework)
+ * So we have to define them if needed.
+ */
+#ifndef word
+  #define word(h, l)  ((uint8_t) ((h << 8) | l))
+#endif
+
+#ifndef lowByte
+  #define lowByte(w)  ((uint8_t) ((w) & 0xff))
+#endif
+
+#ifndef highByte
+  #define highByte(w) ((uint8_t) ((w) >> 8))
+#endif
+
 #define defaultVDD     DAC_STEPPER_MAX //was 5000 but differs with internal Vref
 #define BASE_ADDR      0x60
 #define RESET          0b00000110


### PR DESCRIPTION
### Description

The goal of this PR is to define some macros that can be undefined for some 32bits boards Arduino frameworks.
For instance, these macros are missing in the lpc176x Arduino framework. A PR has also been submitted to the related repo but the goal of this one is to make it work (no compilation failure) for any Arduino framework.

### Benefits

It avoids compilation failure when lpc176x + mcp4728 config is used.

### Related Issues

This PR is related to the issue #16285. Please check it for more details.
(Please not it doesn't fix it completely, but it makes one step forward)
