### PR TITLE
Fix issue #16493 BOARD_MKS_SGEN fails to build

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
@@ -25,10 +25,10 @@
  * MKS SBASE pin assignments
  */
 
-#ifndef MKS_HAS_LPC1769
-  #ifndef MCU_LPC1768
-    #error "Oops! Make sure you have the LPC1768 environment selected in your IDE."
-  #endif
+#if defined(MKS_HAS_LPC1769) && !defined(MCU_LPC1769)
+  #error "Oops! Make sure you have the LPC1769 environment selected in your IDE."
+#elif !defined(MKS_HAS_LPC1769) && !defined(MCU_LPC1768)
+  #error "Oops! Make sure you have the LPC1768 environment selected in your IDE."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SBASE.h
@@ -25,8 +25,10 @@
  * MKS SBASE pin assignments
  */
 
-#ifndef MCU_LPC1768
-  #error "Oops! Make sure you have the LPC1768 environment selected in your IDE."
+#ifndef MKS_HAS_LPC1769
+  #ifndef MCU_LPC1768
+    #error "Oops! Make sure you have the LPC1768 environment selected in your IDE."
+  #endif
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN.h
@@ -31,6 +31,7 @@
 
 #define BOARD_INFO_NAME   "MKS SGen"
 #define BOARD_WEBSITE_URL "github.com/makerbase-mks/MKS-SGEN"
+#define MKS_HAS_LPC1769
 
 #include "../lpc1768/pins_MKS_SBASE.h"
 


### PR DESCRIPTION
Description

There is a bug when trying to compile MOTHEROARD BOARD_MKS_SGEN.
The file pins_MKS_SGEN.h correctly checks for a LPC1769 but then includes ../lpc1768/pins_MKS_SBASE.h which checks for a LPC1768 which fails

Benefits
MOTHERBOARD BOARD_MKS_SGEN now compiles

Related Issues
#16493 
