### PR TITLE
Fix compile error w/out LCD

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1253,9 +1253,13 @@ void do_homing_move(const AxisEnum axis, const float distance, const feedRate_t 
     // Wait for bed to heat back up between probing points
     if (axis == Z_AXIS && distance < 0 && thermalManager.isHeatingBed()) {
       serialprintPGM(msg_wait_for_bed_heating);
-      LCD_MESSAGEPGM(MSG_BED_HEATING);
+      #if HAS_DISPLAY
+         LCD_MESSAGEPGM(MSG_BED_HEATING);
+      #endif
       thermalManager.wait_for_bed();
-      ui.reset_status();
+      #if HAS_DISPLAY
+        ui.reset_status();
+      #endif
     }
   #endif
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1254,7 +1254,7 @@ void do_homing_move(const AxisEnum axis, const float distance, const feedRate_t 
     if (axis == Z_AXIS && distance < 0 && thermalManager.isHeatingBed()) {
       serialprintPGM(msg_wait_for_bed_heating);
       #if HAS_DISPLAY
-         LCD_MESSAGEPGM(MSG_BED_HEATING);
+        LCD_MESSAGEPGM(MSG_BED_HEATING);
       #endif
       thermalManager.wait_for_bed();
       #if HAS_DISPLAY


### PR DESCRIPTION
Description

In motion.cpp the function do_homing_move has code that displays information on the lcd. But it doesn't check if there is actually a display or not. This fails to compile if there is no LCD   

Details 

when the following code block is compiled when a display is not enabled, it will fail to compile.   
```cpp
  #if HOMING_Z_WITH_PROBE && HAS_HEATED_BED && ENABLED(WAIT_FOR_BED_HEATER)
    // Wait for bed to heat back up between probing points
    if (axis == Z_AXIS && distance < 0 && thermalManager.isHeatingBed()) {
      serialprintPGM(msg_wait_for_bed_heating);
      LCD_MESSAGEPGM(MSG_BED_HEATING);
      thermalManager.wait_for_bed();
      ui.reset_status();
    }
  #endif
```
Both these two lines should only be called if it has a display
```cpp
      LCD_MESSAGEPGM(MSG_BED_HEATING);
      ui.reset_status();
```
Benefits

With no display this combination of features it now compiles

Related Issues
As described in issue #16498
