### PR TITLE
G26: Allow to set retraction for UBL mesh test

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1234,6 +1234,7 @@
     #define MESH_TEST_HOTEND_TEMP  205    // (°C) Default nozzle temperature for the G26 Mesh Validation Tool.
     #define MESH_TEST_BED_TEMP      60    // (°C) Default bed temperature for the G26 Mesh Validation Tool.
     #define G26_XY_FEEDRATE         20    // (mm/s) Feedrate for XY Moves for the G26 Mesh Validation Tool.
+    #define G26_RETRACT_MULTIPLIER   1.0  // G26 Q (retraction) used by default between mesh test elements.
   #endif
 
 #endif

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -43,12 +43,15 @@
 #include "../../lcd/ultralcd.h"
 
 #define EXTRUSION_MULTIPLIER 1.0
-#define RETRACTION_MULTIPLIER 1.0
 #define PRIME_LENGTH 10.0
 #define OOZE_AMOUNT 0.3
 
 #define INTERSECTION_CIRCLE_RADIUS 5
 #define CROSSHAIRS_SIZE 3
+
+#ifndef G26_RETRACT_MULTIPLIER
+  #define G26_RETRACT_MULTIPLIER 1.0 // x 1mm
+#endif
 
 #ifndef G26_XY_FEEDRATE
   #define G26_XY_FEEDRATE (PLANNER_XY_FEEDRATE() / 3.0)
@@ -509,7 +512,7 @@ void GcodeSuite::G26() {
   if (parser.seenval('T')) tool_change(parser.value_int());
 
   g26_extrusion_multiplier    = EXTRUSION_MULTIPLIER;
-  g26_retraction_multiplier   = RETRACTION_MULTIPLIER;
+  g26_retraction_multiplier   = G26_RETRACT_MULTIPLIER;
   g26_layer_height            = MESH_TEST_LAYER_HEIGHT;
   g26_prime_length            = PRIME_LENGTH;
   g26_bed_temp                = MESH_TEST_BED_TEMP;


### PR DESCRIPTION
Correct value for my 1.75mm extruder with PLA is around 5.0, far from 1mm default
Without that we see all diagonals of the nozzle moves...

As it is used in default UBL assistant (test mesh), a minimum configuration to get it more proper is useful...