### PR TITLE
Fix Linux upload path detection

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/HAL_LPC1768/upload_extra_script.py
@@ -9,7 +9,9 @@ target_filename = "FIRMWARE.CUR"
 target_drive = "REARM"
 
 import os
+import getpass
 import platform
+
 current_OS = platform.system()
 Import("env")
 
@@ -77,28 +79,26 @@ try:
         upload_disk = 'Disk not found'
         target_file_found = False
         target_drive_found = False
-        medias = os.listdir('/media')  #
-        for media in medias:
-            drives = os.listdir('/media/' + media)  #
-            if target_drive in drives and target_file_found == False:  # set upload if not found target file yet
-                target_drive_found = True
-                upload_disk = '/media/' + media + '/' + target_drive + '/'
+        drives = os.listdir(os.path.join(os.sep, 'media', getpass.getuser()))
+        if target_drive in drives:  # If target drive is found, use it.
+            target_drive_found = True
+            upload_disk = os.path.join(os.sep, 'media', getpass.getuser(), target_drive) + os.sep
+        else:
             for drive in drives:
                 try:
-                    files = os.listdir('/media/' + media + '/' + drive)
+                    files = os.listdir(os.path.join(os.sep, 'media', getpass.getuser(), drive))
                 except:
                     continue
                 else:
                     if target_filename in files:
-                        if target_file_found == False:
-                            upload_disk = '/media/' + media + '/' + drive + '/'
-                            target_file_found = True
-
+                        upload_disk = os.path.join(os.sep, 'media', getpass.getuser(), drive) + os.sep
+                        target_file_found = True
+                        break
         #
         # set upload_port to drive if found
         #
 
-        if target_file_found == True or target_drive_found == True:
+        if target_file_found or target_drive_found:
             env.Replace(
                 UPLOAD_FLAGS="-P$UPLOAD_PORT",
                 UPLOAD_PORT=upload_disk


### PR DESCRIPTION
### Requirements

None

### Description

Detecting a correct upload drive for LPC1768 on Ubuntu Linux is broken. When an external drive is connected it will be mounted in /media/<username>/<drive>. Right now upload_extra_script.py only checks the /media directory for possible drives. It will always fail since all the drives are mounted in the users media directory.

Also, there's a lot of string concatenation going and I replaced it with os.path.join which is safer to use.


### Benefits

Drive detection will work and the built binary will be copied to the drive.

### Related Issues
None
