### PR TITLE
Prevent Z misaligments on tool change

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -930,20 +930,17 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
         // Raise by a configured distance to avoid workpiece, except with
         // SWITCHING_NOZZLE_TWO_SERVOS, as both nozzles will lift instead.
         if (!no_move) {
+          #if HAS_SOFTWARE_ENDSTOPS
+            const float maxz = _MIN(soft_endstop.max.z, Z_MAX_POS);
+          #else
+            constexpr float maxz = Z_MAX_POS;
+          #endif
+
+          // Check if Z has space to compensate at least z_offset, and if not, just abort now
           const float newz = current_position.z + _MAX(-diff.z, 0.0);
+          if (newz > maxz) return;
 
-          #if HAS_SOFTWARE_ENDSTOPS
-            // Check if Z has space to compensate at least z_offset, and if not, just abort now
-            if (newz > soft_endstop.max.z) return;
-          #endif
-
-          newz += toolchange_settings.z_raise;
-
-          #if HAS_SOFTWARE_ENDSTOPS
-            NOMORE(newz, soft_endstop.max.z);
-          #endif
-
-          current_position.z = newz;
+          current_position.z = _MIN(newz + toolchange_settings.z_raise, maxz);
           fast_line_to_current(Z_AXIS);
         }
         move_nozzle_servo(new_tool);

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -931,6 +931,9 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
         // SWITCHING_NOZZLE_TWO_SERVOS, as both nozzles will lift instead.
         current_position.z += _MAX(-diff.z, 0.0);
         if (!no_move) {
+          // Check if Z has space to compensate at least z_offset, if not enough space abort tool change
+          if (current_position.z > soft_endstop.max.z) return
+
           current_position.z += toolchange_settings.z_raise;
           #if HAS_SOFTWARE_ENDSTOPS
             NOMORE(current_position.z, soft_endstop.max.z);

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -931,8 +931,10 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
         // SWITCHING_NOZZLE_TWO_SERVOS, as both nozzles will lift instead.
         current_position.z += _MAX(-diff.z, 0.0);
         if (!no_move) {
-          // Check if Z has space to compensate at least z_offset, if not enough space abort tool change
-          if (current_position.z > soft_endstop.max.z) return
+          #if HAS_SOFTWARE_ENDSTOPS
+            // Check if Z has space to compensate at least z_offset, if not enough space abort tool change
+            if (current_position.z > soft_endstop.max.z) return
+          #endif
 
           current_position.z += toolchange_settings.z_raise;
           #if HAS_SOFTWARE_ENDSTOPS

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -929,11 +929,14 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       #elif ENABLED(SWITCHING_NOZZLE) && !SWITCHING_NOZZLE_TWO_SERVOS   // Switching Nozzle (single servo)
         // Raise by a configured distance to avoid workpiece, except with
         // SWITCHING_NOZZLE_TWO_SERVOS, as both nozzles will lift instead.
-        current_position.z += _MAX(-diff.z, 0.0) + toolchange_settings.z_raise;
-        #if HAS_SOFTWARE_ENDSTOPS
-          NOMORE(current_position.z, soft_endstop.max.z);
-        #endif
-        if (!no_move) fast_line_to_current(Z_AXIS);
+        current_position.z += _MAX(-diff.z, 0.0);
+        if (!no_move) {
+          current_position.z += toolchange_settings.z_raise;
+          #if HAS_SOFTWARE_ENDSTOPS
+            NOMORE(current_position.z, soft_endstop.max.z);
+          #endif
+          fast_line_to_current(Z_AXIS);
+        }
         move_nozzle_servo(new_tool);
       #endif
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -929,8 +929,8 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       #elif ENABLED(SWITCHING_NOZZLE) && !SWITCHING_NOZZLE_TWO_SERVOS   // Switching Nozzle (single servo)
         // Raise by a configured distance to avoid workpiece, except with
         // SWITCHING_NOZZLE_TWO_SERVOS, as both nozzles will lift instead.
-        const float newz = current_position.z + _MAX(-diff.z, 0.0);
         if (!no_move) {
+          const float newz = current_position.z + _MAX(-diff.z, 0.0);
 
           #if HAS_SOFTWARE_ENDSTOPS
             // Check if Z has space to compensate at least z_offset, and if not, just abort now


### PR DESCRIPTION
This should prevent z misaligments when changing tool when axis no homed (Fix #16429) 
This also prevent z misaligment, when axis homed, when tool change is done too near z max limit (when defined)

Only valid for SWITCHING_NOZZLE configuration
