### PR TITLE
Use RECIPROCAL macro (not _RECIP)

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -106,7 +106,7 @@ void plan_arc(
   const feedRate_t scaled_fr_mm_s = MMS_SCALED(feedrate_mm_s);
 
   #ifdef ARC_SEGMENTS_PER_SEC
-    float seg_length = scaled_fr_mm_s * _RECIP(ARC_SEGMENTS_PER_SEC);
+    float seg_length = scaled_fr_mm_s * RECIPROCAL(ARC_SEGMENTS_PER_SEC);
     NOLESS(seg_length, MM_PER_ARC_SEGMENT);
   #else
     constexpr float seg_length = MM_PER_ARC_SEGMENT;


### PR DESCRIPTION
Would not compile as is, replaced with the macro from the Marlin documents.
