### PR TITLE
Fix probeless delta build

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1020,6 +1020,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #error "ENABLE_LEVELING_FADE_HEIGHT on DELTA requires AUTO_BED_LEVELING_BILINEAR or AUTO_BED_LEVELING_UBL."
   #elif ENABLED(DELTA_AUTO_CALIBRATION) && !(HAS_BED_PROBE || HAS_LCD_MENU)
     #error "DELTA_AUTO_CALIBRATION requires a probe or LCD Controller."
+  #elif ENABLED(DELTA_CALIBRATION_MENU) && !HAS_LCD_MENU
+    #error "DELTA_CALIBRATION_MENU requires an LCD Controller."
   #elif ABL_GRID
     #if (GRID_MAX_POINTS_X & 1) == 0 || (GRID_MAX_POINTS_Y & 1) == 0
       #error "DELTA requires GRID_MAX_POINTS_X and GRID_MAX_POINTS_Y to be odd numbers."

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -90,9 +90,16 @@ void recalc_delta_settings() {
   float calibration_radius_factor = 1;
 #endif
 
-float delta_calibration_radius() {
-  return FLOOR((DELTA_PRINTABLE_RADIUS - _MAX(HYPOT(probe_offset_xy.x, probe_offset_xy.y), MIN_PROBE_EDGE)) * calibration_radius_factor);
-}
+#if EITHER(DELTA_AUTO_CALIBRATION, DELTA_CALIBRATION_MENU)
+  float delta_calibration_radius() {
+    return calibration_radius_factor *
+      #if HAS_BED_PROBE
+        FLOOR(((DELTA_PRINTABLE_RADIUS) - _MAX(HYPOT(probe_offset_xy.x, probe_offset_xy.y), (MIN_PROBE_EDGE))));
+      #else
+        (DELTA_PRINTABLE_RADIUS);
+      #endif
+  }
+#endif
 
 /**
  * Delta Inverse Kinematics

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -86,19 +86,22 @@ void recalc_delta_settings() {
  * Get a safe radius for calibration
  */
 
-#if ENABLED(DELTA_AUTO_CALIBRATION)
-  float calibration_radius_factor = 1;
-#endif
-
 #if EITHER(DELTA_AUTO_CALIBRATION, DELTA_CALIBRATION_MENU)
+
+  #if ENABLED(DELTA_AUTO_CALIBRATION)
+    float calibration_radius_factor = 1;
+  #endif
+
   float delta_calibration_radius() {
-    return calibration_radius_factor *
+    return calibration_radius_factor * (
       #if HAS_BED_PROBE
-        FLOOR(((DELTA_PRINTABLE_RADIUS) - _MAX(HYPOT(probe_offset_xy.x, probe_offset_xy.y), (MIN_PROBE_EDGE))));
+        FLOOR((DELTA_PRINTABLE_RADIUS) - _MAX(HYPOT(probe_offset_xy.x, probe_offset_xy.y), MIN_PROBE_EDGE))
       #else
-        (DELTA_PRINTABLE_RADIUS);
+        DELTA_PRINTABLE_RADIUS
       #endif
+    );
   }
+
 #endif
 
 /**

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -52,7 +52,9 @@ void recalc_delta_settings();
   constexpr float calibration_radius_factor = 1;
 #endif
 
-float delta_calibration_radius();
+#if EITHER(DELTA_AUTO_CALIBRATION, DELTA_CALIBRATION_MENU)
+  float delta_calibration_radius();
+#endif
 
 /**
  * Delta Inverse Kinematics

--- a/buildroot/share/tests/megaatmega2560-tests
+++ b/buildroot/share/tests/megaatmega2560-tests
@@ -310,6 +310,13 @@ opt_enable AUTO_BED_LEVELING_UBL RESTORE_LEVELING_AFTER_G28 Z_PROBE_ALLEN_KEY EE
 exec_test $1 $2 "RAMPS | DELTA | OLED_PANEL_TINYBOY2 | UBL | Allen Key | EEPROM"
 
 #
+# Delta Config (generic) + Probeless
+#
+use_example_configs delta/generic
+opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER DELTA_AUTO_CALIBRATION DELTA_CALIBRATION_MENU
+exec_test $1 $2 "RAMPS | DELTA | RRD LCD | DELTA_AUTO_CALIBRATION | DELTA_CALIBRATION_MENU"
+
+#
 # Delta Config (FLSUN AC because it's complex)
 #
 use_example_configs delta/FLSUN/auto_calibrate


### PR DESCRIPTION
### Description

Fix delta builds that do not use a probe.
This seems to be an easy regression to cause, so I've added a test case for it.

I have only build-tested this, I have not actually tested it on a printer.

### Related Issues

I accidentally discovered this, I don't think there is an open issue for it.
