### PR TITLE
Nikon IR support for time lapse photos

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -368,7 +368,7 @@
  * FAST_PWM_FAN_FREQUENCY [undefined by default]
  *   Set this to your desired frequency.
  *   If left undefined this defaults to F = F_CPU/(2*255*1)
- *   ie F = 31.4 Khz on 16 MHz microcontrollers or F = 39.2 KHz on 20 MHz microcontrollers
+ *   i.e., F = 31.4kHz on 16MHz microcontrollers or F = 39.2kHz on 20MHz microcontrollers.
  *   These defaults are the same as with the old FAST_PWM_FAN implementation - no migration is required
  *   NOTE: Setting very low frequencies (< 10 Hz) may result in unexpected timer behavior.
  *
@@ -2445,21 +2445,18 @@
   // Duration to hold the switch or keep CHDK_PIN high
   //#define PHOTO_SWITCH_MS   50 // (ms) (M240 D)
 
-  //#define PHOTO_NIKON
-  // Nikon
-  // Data from: https://www.christidis.info/index.php/personal-projects/arduino-nikon-infrared-command-code
-  // IR Wiring: https://github.com/outofjungle/NikonRemote/blob/master/NikonRemote.cpp
-  #if ENABLED(PHOTO_NIKON)
-    // Pulses, might need tweaking depending on board
-    // make sure to use a PHOTOGRAPH_PIN which can rise and fall quick enough. 
-    // On MKS SBase, temp sensor pin was too slow used P1.23 on J8
-    // pin requires to be running at 48.4khz
-
-    // how long the 48.4khz pulses last going high then low {HIGH,LOW,HIGH,LOW,...}
-    #define PHOTO_PULSES_US {2000,27850,400,1580,400,3580,400}  
-
-    // Delay during HIGH pulses to create the 48.4khz frequency HIGH delay LOW delay, repeat for the pulse duration from PHOTO_PULSES_US
-    #define PHOTO_PULES_DELAY_US 13
+  /**
+   * PHOTO_PULSES_US may need adjustment depending on board and camera model.
+   * Pin must be running at 48.4kHz.
+   * Be sure to use a PHOTOGRAPH_PIN which can rise and fall quick enough.
+   * (e.g., MKS SBase temp sensor pin was too slow, so used P1.23 on J8.)
+   *
+   *  Example pulse data for Nikon: https://bit.ly/2FKD0Aq
+   *                     IR Wiring: https://git.io/JvJf7
+   */
+  //#define PHOTO_PULSES_US { 2000, 27850, 400, 1580, 400, 3580, 400 }  // (µs) Durations for each 48.4kHz oscillation
+  #ifdef PHOTO_PULSES_US
+    #define PHOTO_PULSE_DELAY_US 13 // (µs) Approximate duration of each HIGH and LOW pulse in the oscillation
   #endif
 #endif
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2444,6 +2444,23 @@
 
   // Duration to hold the switch or keep CHDK_PIN high
   //#define PHOTO_SWITCH_MS   50 // (ms) (M240 D)
+
+  #define PHOTO_NIKON
+  // Nikon
+  // Data from: https://www.christidis.info/index.php/personal-projects/arduino-nikon-infrared-command-code
+  // IR Wiring: https://github.com/outofjungle/NikonRemote/blob/master/NikonRemote.cpp
+  #if ENABLED(PHOTO_GCODE)
+    // Pulses, might need tweaking depending on board
+    // make sure to use a PHOTOGRAPH_PIN which can rise and fall quick enough. 
+    // On MKS SBase, temp sensor pin was too slow used P1.23 on J8
+    // pin requires to be running at 48.4khz
+
+    // how long the 48.4khz pulses last going high then low {HIGH,LOW,HIGH,LOW,...}
+    #define PHOTO_PULSES_MS {2000,27850,400,1580,400,3580,400}  
+
+    // Delay during HIGH pulses to create the 48.4khz frequency HIGH delay LOW DELAY repeat for the pulse duration
+    #define PHOTO_PULES_DELAY 13
+  #endif
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2449,7 +2449,7 @@
   // Nikon
   // Data from: https://www.christidis.info/index.php/personal-projects/arduino-nikon-infrared-command-code
   // IR Wiring: https://github.com/outofjungle/NikonRemote/blob/master/NikonRemote.cpp
-  #if ENABLED(PHOTO_GCODE)
+  #if ENABLED(PHOTO_NIKON)
     // Pulses, might need tweaking depending on board
     // make sure to use a PHOTOGRAPH_PIN which can rise and fall quick enough. 
     // On MKS SBase, temp sensor pin was too slow used P1.23 on J8

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2445,7 +2445,7 @@
   // Duration to hold the switch or keep CHDK_PIN high
   //#define PHOTO_SWITCH_MS   50 // (ms) (M240 D)
 
-  #define PHOTO_NIKON
+  //#define PHOTO_NIKON
   // Nikon
   // Data from: https://www.christidis.info/index.php/personal-projects/arduino-nikon-infrared-command-code
   // IR Wiring: https://github.com/outofjungle/NikonRemote/blob/master/NikonRemote.cpp
@@ -2456,10 +2456,10 @@
     // pin requires to be running at 48.4khz
 
     // how long the 48.4khz pulses last going high then low {HIGH,LOW,HIGH,LOW,...}
-    #define PHOTO_PULSES_MS {2000,27850,400,1580,400,3580,400}  
+    #define PHOTO_PULSES_US {2000,27850,400,1580,400,3580,400}  
 
-    // Delay during HIGH pulses to create the 48.4khz frequency HIGH delay LOW DELAY repeat for the pulse duration
-    #define PHOTO_PULES_DELAY 13
+    // Delay during HIGH pulses to create the 48.4khz frequency HIGH delay LOW delay, repeat for the pulse duration from PHOTO_PULSES_US
+    #define PHOTO_PULES_DELAY_US 13
   #endif
 #endif
 

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -64,40 +64,40 @@
 #if PIN_EXISTS(PHOTOGRAPH)
   #if ENABLED(PHOTO_NIKON)
     inline void pulse(unsigned long duration, uint8_t state) {  
-      if(state == HIGH)
-      {
-        unsigned long stop = micros() + duration;  
-        while( micros() < stop ) {
-            digitalWrite( PHOTOGRAPH_PIN, HIGH );
-            delayMicroseconds(PHOTO_PULES_DELAY);
-            digitalWrite( PHOTOGRAPH_PIN, LOW );
-            delayMicroseconds(PHOTO_PULES_DELAY);
-        }
+    if(state == HIGH)
+    {
+      unsigned long stop = micros() + duration;  
+      while( micros() < stop ) {
+          digitalWrite( PHOTOGRAPH_PIN, HIGH );
+          delayMicroseconds(PHOTO_PULES_DELAY_US);
+          digitalWrite( PHOTOGRAPH_PIN, LOW );
+          delayMicroseconds(PHOTO_PULES_DELAY_US);
       }
-      else
-      {
-        delayMicroseconds(duration);
-      }        
     }
+    else
+    {
+      delayMicroseconds(duration);
+    }        
+  }
   
-    inline void spin_photo_pin() {     
-      unsigned long sequence[] = PHOTO_PULSES_MS;
-      int seq_l;
+  inline void spin_photo_pin() {     
+    unsigned long sequence[] = PHOTO_PULSES_US;
+    int seq_l;
 
-      seq_l = sizeof(sequence)/sizeof(unsigned long);
+    seq_l = sizeof(sequence)/sizeof(unsigned long);
 
-      int i;
-		  for(i=0;i<seq_l;i++) {
-  			pulse(sequence[i], i%2==0);
-	  	}    
-    }
+    int i;
+    for(i=0;i<seq_l;i++) {
+      pulse(sequence[i], i%2==0);
+    }    
+  }
   #else
     constexpr uint8_t NUM_PULSES = 16;
     constexpr float PULSE_LENGTH = 0.01524;
     inline void set_photo_pin(const uint8_t state) { WRITE(PHOTOGRAPH_PIN, state); _delay_ms(PULSE_LENGTH); }
     inline void tweak_photo_pin() { set_photo_pin(HIGH); set_photo_pin(LOW); }
     inline void spin_photo_pin() {for (uint8_t i = NUM_PULSES; i--;) tweak_photo_pin();}
-  #endif  
+  #endif    
 #endif
 
 /**

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -62,11 +62,47 @@
 #endif
 
 #if PIN_EXISTS(PHOTOGRAPH)
-  constexpr uint8_t NUM_PULSES = 16;
-  constexpr float PULSE_LENGTH = 0.01524;
-  inline void set_photo_pin(const uint8_t state) { WRITE(PHOTOGRAPH_PIN, state); _delay_ms(PULSE_LENGTH); }
-  inline void tweak_photo_pin() { set_photo_pin(HIGH); set_photo_pin(LOW); }
-  inline void spin_photo_pin() { for (uint8_t i = NUM_PULSES; i--;) tweak_photo_pin(); }
+  #if ENABLED(PHOTO_GCODE)
+    inline void pulse(unsigned long duration, uint8_t state) {  
+      if(state == HIGH)
+      {
+        unsigned long stop = micros() + duration;  
+        while( micros() < stop ) {
+            digitalWrite( PHOTOGRAPH_PIN, HIGH );
+            delayMicroseconds(PHOTO_PULES_DELAY);
+            digitalWrite( PHOTOGRAPH_PIN, LOW );
+            delayMicroseconds(PHOTO_PULES_DELAY);
+        }
+      }
+      else
+      {
+        delayMicroseconds(duration);
+      }        
+    }
+  
+  inline void spin_photo_pin() {     
+    #if ENABLED(PHOTO_NIKON)
+      unsigned long sequence[] = PHOTO_PULSES_MS;
+      int seq_l;
+
+      seq_l = sizeof(sequence)/sizeof(unsigned long);
+
+      int i;
+		  for(i=0;i<seq_l;i++) {
+  			pulse(sequence[i], i%2==0);
+	  	}
+    #else
+      for (uint8_t i = NUM_PULSES; i--;) tweak_photo_pin();     
+    #endif
+    
+    }
+  #else
+    constexpr uint8_t NUM_PULSES = 16;
+    constexpr float PULSE_LENGTH = 0.01524;
+    inline void set_photo_pin(const uint8_t state) { WRITE(PHOTOGRAPH_PIN, state); _delay_ms(PULSE_LENGTH); }
+    inline void tweak_photo_pin() { set_photo_pin(HIGH); set_photo_pin(LOW); }
+    inline void spin_photo_pin() {for (uint8_t i = NUM_PULSES; i--;) tweak_photo_pin();}
+  #endif  
 #endif
 
 /**

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -62,7 +62,7 @@
 #endif
 
 #if PIN_EXISTS(PHOTOGRAPH)
-  #if ENABLED(PHOTO_GCODE)
+  #if ENABLED(PHOTO_NIKON)
     inline void pulse(unsigned long duration, uint8_t state) {  
       if(state == HIGH)
       {
@@ -80,8 +80,7 @@
       }        
     }
   
-  inline void spin_photo_pin() {     
-    #if ENABLED(PHOTO_NIKON)
+    inline void spin_photo_pin() {     
       unsigned long sequence[] = PHOTO_PULSES_MS;
       int seq_l;
 
@@ -90,11 +89,7 @@
       int i;
 		  for(i=0;i<seq_l;i++) {
   			pulse(sequence[i], i%2==0);
-	  	}
-    #else
-      for (uint8_t i = NUM_PULSES; i--;) tweak_photo_pin();     
-    #endif
-    
+	  	}    
     }
   #else
     constexpr uint8_t NUM_PULSES = 16;


### PR DESCRIPTION
### Requirements

* Need to support Nikon IR remote trigger protocol on the photo pin. 
### Description

Nikon IR requires pulses on the photo pin in a 48.4khz frequency at stated on and off intervals which are different to the currently supported way the pin works, which is for Canon cameras. The details of the protocol can be found here

https://www.christidis.info/index.php/personal-projects/arduino-nikon-infrared-command-code

To support this an additional option has been added in the configurations to enable support for Nikon, this will then generate the correct pulses on the configured photo pin. When a IR LED is connected to the pin in the way stated in this diagram

https://github.com/outofjungle/NikonRemote/blob/master/example_wiring.png

When the camera is in remote trigger mode, it will receive the command from the IR LED on the photo pin, and then triggering the photo to be taken.

If the Nikon support is not enabled, the existing camera code works in the same way as it did before.

### Benefits

Adds Nikon IR remote trigger support with the addition of an IR attached to the photo pin.

### Related Issues
Depending on the board been used, and the response times for the pin going high and low, different pulse lengths, and delays to create the 48.4khz frequency might be needed. This has so far been tested with a MKS SBase running version 2 with this code included.
