### PR TITLE
Fix bugs in TOUCH_UI_FTDI_EVE

### DIFF
--- a/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
@@ -80,7 +80,7 @@ uint16_t CLCD::FontMetrics::get_text_width(progmem_str str, size_t n) const {
 /************************** HOST COMMAND FUNCTION *********************************/
 
 void CLCD::host_cmd (unsigned char host_command, unsigned char byte2) {  // Sends 24-Bit Host Command to LCD
-  if (host_command != ACTIVE) {
+  if (host_command != FTDI::ACTIVE) {
     host_command |= 0x40;
   }
   spi_ftdi_select();
@@ -1062,7 +1062,7 @@ void CLCD::init() {
     host_cmd(CLKINT, 0);
   }
 
-  host_cmd(ACTIVE, 0);                        // Activate the System Clock
+  host_cmd(FTDI::ACTIVE, 0);                        // Activate the System Clock
 
   /* read the device-id until it returns 0x7c or times out, should take less than 150ms */
   uint8_t counter;

--- a/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -133,9 +133,9 @@ namespace ExtUI {
 
   #if HAS_PID_HEATING
     void OnPidTuning(const result_t rst) {
-    // Called for temperature PID tuning result
-      SERIAL_ECHOLNPAIR("OnPidTuning:",rst);
-      switch(rst) {
+      // Called for temperature PID tuning result
+      SERIAL_ECHOLNPAIR("OnPidTuning:", rst);
+      switch (rst) {
         case PID_BAD_EXTRUDER_NUM:
           StatusScreen::setStatusMessage(MSG_PID_BAD_EXTRUDER_NUM);
           break;

--- a/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -151,7 +151,7 @@ namespace ExtUI {
       }
       GOTO_SCREEN(StatusScreen);
     }
-  #endif //HAS_PID_HEATING
+  #endif // HAS_PID_HEATING
 }
 
 #endif // TOUCH_UI_FTDI_EVE

--- a/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -130,6 +130,28 @@ namespace ExtUI {
     void onMeshUpdate(const int8_t, const int8_t, const float) {
     }
   #endif
+
+  #if HAS_PID_HEATING
+    void OnPidTuning(const result_t rst) {
+    // Called for temperature PID tuning result
+      SERIAL_ECHOLNPAIR("OnPidTuning:",rst);
+      switch(rst) {
+        case PID_BAD_EXTRUDER_NUM:
+          StatusScreen::setStatusMessage(MSG_PID_BAD_EXTRUDER_NUM);
+          break;
+        case PID_TEMP_TOO_HIGH:
+          StatusScreen::setStatusMessage(MSG_PID_TEMP_TOO_HIGH);
+          break;
+        case PID_TUNING_TIMEOUT:
+          StatusScreen::setStatusMessage(MSG_PID_TIMEOUT);
+          break;
+        case PID_DONE:
+          StatusScreen::setStatusMessage(MSG_PID_AUTOTUNE_FINISHED);
+          break;
+      }
+      GOTO_SCREEN(StatusScreen);
+    }
+  #endif //HAS_PID_HEATING
 }
 
 #endif // TOUCH_UI_FTDI_EVE

--- a/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/screens/nudge_nozzle_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/screens/nudge_nozzle_screen.cpp
@@ -45,19 +45,19 @@ void NudgeNozzleScreen::onRedraw(draw_mode_t what) {
   widgets_t w(what);
   w.precision(2, BaseNumericAdjustmentScreen::DEFAULT_MIDRANGE).units(GET_TEXT_F(MSG_UNITS_MM));
 
-  w.heading(                   GET_TEXT_F(MSG_NUDGE_NOZZLE));
+  w.heading(GET_TEXT_F(MSG_NUDGE_NOZZLE));
   #if ENABLED(BABYSTEP_XY)
-  w.color(x_axis).adjuster(2,  GET_TEXT_F(MSG_AXIS_X), screen_data.NudgeNozzleScreen.rel.x / getAxisSteps_per_mm(X));
-  w.color(y_axis).adjuster(4,  GET_TEXT_F(MSG_AXIS_Y), screen_data.NudgeNozzleScreen.rel.y / getAxisSteps_per_mm(Y));
+  w.color(x_axis).adjuster(2, GET_TEXT_F(MSG_AXIS_X), screen_data.NudgeNozzleScreen.rel.x / getAxisSteps_per_mm(X));
+  w.color(y_axis).adjuster(4, GET_TEXT_F(MSG_AXIS_Y), screen_data.NudgeNozzleScreen.rel.y / getAxisSteps_per_mm(Y));
   #endif
-  w.color(z_axis).adjuster(6,  GET_TEXT_F(MSG_AXIS_Z), screen_data.NudgeNozzleScreen.rel.z / getAxisSteps_per_mm(Z));
+  w.color(z_axis).adjuster(6, GET_TEXT_F(MSG_AXIS_Z), screen_data.NudgeNozzleScreen.rel.z / getAxisSteps_per_mm(Z));
   w.increments();
   #if EXTRUDERS > 1
-    w.toggle  (8,  GET_TEXT_F(MSG_ADJUST_BOTH_NOZZLES), screen_data.NudgeNozzleScreen.link_nozzles);
+    w.toggle(8, GET_TEXT_F(MSG_ADJUST_BOTH_NOZZLES), screen_data.NudgeNozzleScreen.link_nozzles);
   #endif
 
   #if EXTRUDERS > 1 || HAS_BED_PROBE
-    w.toggle  (9,  GET_TEXT_F(MSG_SHOW_OFFSETS), screen_data.NudgeNozzleScreen.show_offsets);
+    w.toggle(9, GET_TEXT_F(MSG_SHOW_OFFSETS), screen_data.NudgeNozzleScreen.show_offsets);
 
     if (screen_data.NudgeNozzleScreen.show_offsets) {
       char str[19];
@@ -69,38 +69,37 @@ void NudgeNozzleScreen::onRedraw(draw_mode_t what) {
         dtostrf(getZOffset_mm(), 4, 2, str);
         strcat(str, " ");
         strcat_P(str, GET_TEXT(MSG_UNITS_MM));
-        w.text_field  (0,  GET_TEXT_F(MSG_ZPROBE_ZOFFSET), str);
+        w.text_field(0, GET_TEXT_F(MSG_ZPROBE_ZOFFSET), str);
       #endif
 
       #if HOTENDS > 1
         format_position(str, getNozzleOffset_mm(X, E1), getNozzleOffset_mm(Y, E1), getNozzleOffset_mm(Z, E1));
-        w.text_field  (0, GET_TEXT_F(MSG_OFFSETS_MENU), str);
+        w.text_field(0, GET_TEXT_F(MSG_OFFSETS_MENU), str);
       #endif
     }
   #endif
 }
 
 bool NudgeNozzleScreen::onTouchHeld(uint8_t tag) {
-  const float inc  = getIncrement();
+  const float inc = getIncrement();
   #if EXTRUDERS > 1
-    const bool  link = screen_data.NudgeNozzleScreen.link_nozzles;
+    const bool link = screen_data.NudgeNozzleScreen.link_nozzles;
   #else
     constexpr bool link = true;
   #endif
   int16_t steps;
   switch (tag) {
-    case  2: steps = mmToWholeSteps(inc, X); smartAdjustAxis_steps(-steps, X, link); screen_data.NudgeNozzleScreen.rel.x -= steps; break;
-    case  3: steps = mmToWholeSteps(inc, X); smartAdjustAxis_steps( steps, X, link); screen_data.NudgeNozzleScreen.rel.x += steps; break;
-    case  4: steps = mmToWholeSteps(inc, Y); smartAdjustAxis_steps(-steps, Y, link); screen_data.NudgeNozzleScreen.rel.y -= steps; break;
-    case  5: steps = mmToWholeSteps(inc, Y); smartAdjustAxis_steps( steps, Y, link); screen_data.NudgeNozzleScreen.rel.y += steps; break;
-    case  6: steps = mmToWholeSteps(inc, Z); smartAdjustAxis_steps(-steps, Z, link); screen_data.NudgeNozzleScreen.rel.z -= steps; break;
-    case  7: steps = mmToWholeSteps(inc, Z); smartAdjustAxis_steps( steps, Z, link); screen_data.NudgeNozzleScreen.rel.z += steps; break;
+    case 2: steps = mmToWholeSteps(inc, X); smartAdjustAxis_steps(-steps, X, link); screen_data.NudgeNozzleScreen.rel.x -= steps; break;
+    case 3: steps = mmToWholeSteps(inc, X); smartAdjustAxis_steps( steps, X, link); screen_data.NudgeNozzleScreen.rel.x += steps; break;
+    case 4: steps = mmToWholeSteps(inc, Y); smartAdjustAxis_steps(-steps, Y, link); screen_data.NudgeNozzleScreen.rel.y -= steps; break;
+    case 5: steps = mmToWholeSteps(inc, Y); smartAdjustAxis_steps( steps, Y, link); screen_data.NudgeNozzleScreen.rel.y += steps; break;
+    case 6: steps = mmToWholeSteps(inc, Z); smartAdjustAxis_steps(-steps, Z, link); screen_data.NudgeNozzleScreen.rel.z -= steps; break;
+    case 7: steps = mmToWholeSteps(inc, Z); smartAdjustAxis_steps( steps, Z, link); screen_data.NudgeNozzleScreen.rel.z += steps; break;
     #if EXTRUDERS > 1
-      case  8: screen_data.NudgeNozzleScreen.link_nozzles = !link; break;
+      case 8: screen_data.NudgeNozzleScreen.link_nozzles = !link; break;
     #endif
-    case  9: screen_data.NudgeNozzleScreen.show_offsets = !screen_data.NudgeNozzleScreen.show_offsets; break;
-    default:
-      return false;
+    case 9: screen_data.NudgeNozzleScreen.show_offsets = !screen_data.NudgeNozzleScreen.show_offsets; break;
+    default: return false;
   }
   #if EXTRUDERS > 1 || HAS_BED_PROBE
     SaveSettingsDialogBox::settingsChanged();
@@ -112,9 +111,9 @@ bool NudgeNozzleScreen::onTouchEnd(uint8_t tag) {
   if (tag == 1) {
     SaveSettingsDialogBox::promptToSaveSettings();
     return true;
-  } else {
-    return BaseNumericAdjustmentScreen::onTouchEnd(tag);
   }
+  else
+    return BaseNumericAdjustmentScreen::onTouchEnd(tag);
 }
 
 void NudgeNozzleScreen::onIdle() {

--- a/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/screens/nudge_nozzle_screen.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/ftdi_eve_touch_ui/screens/nudge_nozzle_screen.cpp
@@ -72,7 +72,7 @@ void NudgeNozzleScreen::onRedraw(draw_mode_t what) {
         w.text_field  (0,  GET_TEXT_F(MSG_ZPROBE_ZOFFSET), str);
       #endif
 
-      #if EXTRUDERS > 1
+      #if HOTENDS > 1
         format_position(str, getNozzleOffset_mm(X, E1), getNozzleOffset_mm(Y, E1), getNozzleOffset_mm(Z, E1));
         w.text_field  (0, GET_TEXT_F(MSG_OFFSETS_MENU), str);
       #endif


### PR DESCRIPTION
Description

Fixes three bugs

(1) When TOUCH_UI_FTDI_EVE with BABYSTEPPING and EXTRUDERS > 1 Marlin fails to compile. 

The issue:
```cpp
  #if EXTRUDERS > 1
    format_position(str, getNozzleOffset_mm(X, E1), getNozzleOffset_mm(Y, E1), getNozzleOffset_mm(Z, E1));
    w.text_field  (0, GET_TEXT_F(MSG_OFFSETS_MENU), str);
  #endif
```
Errors on getNozzleOffset_mm as this is only defined if HOTENDS > 1 not EXTRUDERS. Updated to HOTENDS

(2) The use of variable ACTIVE in TOUCH_UI_FTDI_EVE code. This variable is used in other code (in particular the LPC1768 framework) If you attempt to use the LPC1768 and TOUCH_UI_FTDI_EVE the compiler does not know which ACTIVE to use.  I forced it to use  FTDI::ACTIVE ie the ACTIVE from the FTDI namespace.  
This is first steps to getting TOUCH_UI_FTDI_EVE working on LPC1768 

(3) after #16317 was applied to bugfix-2.0.x you can no longer compile bugfix-2.0.x with TOUCH_UI_FTDI_EVE enabled. The PR added a new event OnPidTuning and added it to dgus lcd, but not not to TOUCH_UI_FTDI_EVE.  I have added the new event to marlin_events.cpp 

Benefits

Code compiles as expected

Related Issues

These bugs where found while investigating issue #16534