### PR TITLE
ESP32 HAL: Fix random pauses during prints

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/HAL.h
+++ b/Marlin/src/HAL/HAL_ESP32/HAL.h
@@ -137,3 +137,44 @@ void HAL_adc_start_conversion(uint8_t adc_pin);
 void HAL_idletask();
 void HAL_init();
 void HAL_init_board();
+
+//
+// Delay in cycles (used by DELAY_NS / DELAY_US)
+//
+FORCE_INLINE static void DELAY_CYCLES(uint32_t x) {
+  unsigned long start, ccount, stop;
+
+  /**
+   * It's important to care for race conditions (and overflows) here.
+   * Race condition example: If `stop` calculates to being close to the upper boundary of
+   * `uint32_t` and if at the same time a longer loop interruption kicks in (e.g. due to other
+   * FreeRTOS tasks or interrupts), `ccount` might overflow (and therefore be below `stop` again)
+   * without the loop ever being able to notice that `ccount` had already been above `stop` once
+   * (and that therefore the number of cycles to delay has already passed).
+   * As DELAY_CYCLES (through DELAY_NS / DELAY_US) is used by software SPI bit banging to drive
+   * LCDs and therefore might be called very, very often, this seemingly improbable situation did
+   * actually happen in reality. It resulted in apparently random print pauses of ~17.9 seconds
+   * (0x100000000 / 240 MHz) or multiples thereof, essentially ruining the current print by causing
+   * large blobs of filament.
+   */
+
+  __asm__ __volatile__ ( "rsr     %0, ccount" : "=a" (start) );
+  stop = start + x;
+  ccount = start;
+
+  if (stop >= start) {
+    // no overflow, so only loop while in between start and stop:
+    // 0x00000000 -----------------start****stop-- 0xffffffff
+    while (ccount >= start && ccount < stop) {
+      __asm__ __volatile__ ( "rsr     %0, ccount" : "=a" (ccount) );
+    }
+  }
+  else {
+    // stop did overflow, so only loop while outside of stop and start:
+    // 0x00000000 **stop-------------------start** 0xffffffff
+    while (ccount >= start || ccount < stop) {
+      __asm__ __volatile__ ( "rsr     %0, ccount" : "=a" (ccount) );
+    }
+  }
+
+}

--- a/Marlin/src/HAL/HAL_ESP32/Servo.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/Servo.cpp
@@ -37,7 +37,7 @@ Servo::Servo() {
 
 int8_t Servo::attach(const int inPin) {
   if (channel >= CHANNEL_MAX_NUM) return -1;
-  if (pin > 0) pin = inPin;
+  if (inPin > 0) pin = inPin;
 
   ledcSetup(channel, 50, 16); // channel X, 50 Hz, 16-bit depth
   ledcAttachPin(pin, channel);

--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -145,7 +145,7 @@
   }
   #undef nop
 
-#elif ANY(__PLAT_LINUX__, ESP32)
+#elif defined(__PLAT_LINUX__) || defined(ESP32)
 
   // specified inside platform
 

--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -145,21 +145,7 @@
   }
   #undef nop
 
-#elif defined(ESP32)
-
-  FORCE_INLINE static void DELAY_CYCLES(uint32_t x) {
-    unsigned long ccount, stop;
-
-    __asm__ __volatile__ ( "rsr     %0, ccount" : "=a" (ccount) );
-
-    stop = ccount + x; // This can overflow
-
-    while (ccount < stop) { // This doesn't deal with overflows
-      __asm__ __volatile__ ( "rsr     %0, ccount" : "=a" (ccount) );
-    }
-  }
-
-#elif defined(__PLAT_LINUX__)
+#elif ANY(__PLAT_LINUX__, ESP32)
 
   // specified inside platform
 


### PR DESCRIPTION
### Description
Fixes `DELAY_CYCLES` (and `DELAY_NS` and `DELAY_US`) on ESP32 platform to properly handle race conditions (and overflows).  
Race condition example: If `stop` calculates to being close to the upper boundary of `uint32_t` and if at the same time a longer loop interruption kicks in (e.g. due to other concurrent FreeRTOS tasks or interrupts), `ccount` might overflow (and therefore be below `stop` again) without the loop ever being able to notice that `ccount` had already been above `stop` once (and that therefore the number of cycles to delay has already passed).

Additional (minor) changes:
* Move `DELAY_CYCLES` from shared `Delay.h` to HAL (as nothing here is shared with other platforms) similar to how it's been done for the Linux HAL.
* Fix Servo::attach which apparently had been broken in a recent refactoring commit.

### Benefits
As `DELAY_CYCLES` (through `DELAY_NS` / `DELAY_US`) is used by software SPI bit banging to drive LCDs and therefore might be called very, very often, this seemingly improbable situation did actually happen in reality. It resulted in apparently random print pauses of ~17.9 seconds (0x100000000 / 240 MHz) or multiples thereof, essentially ruining the current print by causing large blobs of filament.

### Related Issues
https://github.com/luc-github/Marlin/issues/1#issuecomment-571448569 (just for demonstration, fix as been further refined after this comment :wink:)