### PR TITLE
Arc segment radius scaling

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1527,15 +1527,15 @@
 //
 // G2/G3 Arc Support
 //
-#define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
+#define ARC_SUPPORT                 // Disable this feature to save ~3226 bytes
 #if ENABLED(ARC_SUPPORT)
-  #define MM_PER_ARC_SEGMENT    1 // (mm) Length (or minimum length) of each arc segment
-  //#define ARC_SEGMENTS_PER_R   1  //Max segment length, MM_PER = Min
-  #define MIN_ARC_SEGMENTS     24 // Minimum number of segments in a complete circle
+  #define MM_PER_ARC_SEGMENT      1 // (mm) Length (or minimum length) of each arc segment
+  //#define ARC_SEGMENTS_PER_R    1 // Max segment length, MM_PER = Min
+  #define MIN_ARC_SEGMENTS       24 // Minimum number of segments in a complete circle
   //#define ARC_SEGMENTS_PER_SEC 50 // Use feedrate to choose segment length (with MM_PER_ARC_SEGMENT as the minimum)
-  #define N_ARC_CORRECTION     25 // Number of interpolated segments between corrections
-  //#define ARC_P_CIRCLES         // Enable the 'P' parameter to specify complete circles
-  //#define CNC_WORKSPACE_PLANES  // Allow G2/G3 to operate in XY, ZX, or YZ planes
+  #define N_ARC_CORRECTION       25 // Number of interpolated segments between corrections
+  //#define ARC_P_CIRCLES           // Enable the 'P' parameter to specify complete circles
+  //#define CNC_WORKSPACE_PLANES    // Allow G2/G3 to operate in XY, ZX, or YZ planes
 #endif
 
 // Support for G5 with XYZE destination and IJPQ offsets. Requires ~2666 bytes.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1530,6 +1530,7 @@
 #define ARC_SUPPORT               // Disable this feature to save ~3226 bytes
 #if ENABLED(ARC_SUPPORT)
   #define MM_PER_ARC_SEGMENT    1 // (mm) Length (or minimum length) of each arc segment
+  //#define ARC_SEGMENTS_PER_R   1  //Max segment length, MM_PER = Min
   #define MIN_ARC_SEGMENTS     24 // Minimum number of segments in a complete circle
   //#define ARC_SEGMENTS_PER_SEC 50 // Use feedrate to choose segment length (with MM_PER_ARC_SEGMENT as the minimum)
   #define N_ARC_CORRECTION     25 // Number of interpolated segments between corrections

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -107,8 +107,7 @@ void plan_arc(
 
   #ifdef ARC_SEGMENTS_PER_R
     float seg_length = MM_PER_ARC_SEGMENT * radius;
-    NOLESS(seg_length, MM_PER_ARC_SEGMENT);
-    NOMORE(seg_length, ARC_SEGMENTS_PER_R);
+    LIMIT(seg_length, MM_PER_ARC_SEGMENT, ARC_SEGMENTS_PER_R);
   #elif ARC_SEGMENTS_PER_SEC
     float seg_length = scaled_fr_mm_s * RECIPROCAL(ARC_SEGMENTS_PER_SEC);
     NOLESS(seg_length, MM_PER_ARC_SEGMENT);

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -105,7 +105,11 @@ void plan_arc(
 
   const feedRate_t scaled_fr_mm_s = MMS_SCALED(feedrate_mm_s);
 
-  #ifdef ARC_SEGMENTS_PER_SEC
+  #ifdef ARC_SEGMENTS_PER_R
+    float seg_length = MM_PER_ARC_SEGMENT * radius;
+    NOLESS(seg_length, MM_PER_ARC_SEGMENT);
+    NOMORE(seg_length, ARC_SEGMENTS_PER_R);
+  #elif ARC_SEGMENTS_PER_SEC
     float seg_length = scaled_fr_mm_s * RECIPROCAL(ARC_SEGMENTS_PER_SEC);
     NOLESS(seg_length, MM_PER_ARC_SEGMENT);
   #else


### PR DESCRIPTION
This allow arcs segment to be smaller for small arcs and large for large arcs, with a defined minimum and maximum. This allows small details to have great resolution and large radius arcs not to choke the planner, buffer, or CPU (not really sure where things go wrong).

With larger 3D printers out there and CNC's of all sizes getting more common this really helps keep accelerations working correctly. As a side effect it also helps with the laser issue a bit as well!

Setting a maximum lets you figure out what your board/system can handle and leave it at that. I think it works great at a 0.2mm min and a 1mm max. With those settings you can not see any segments as far as I can tell at any size arc and no slowdowns seem to happen either.

I tested a ton of things and made a quick video showing the differences of the best I could get before and with these changes.
https://youtu.be/zebPmGkMnAU
There are a few timestamps in the comments to do a side by side. This is done with a 0.3mm gel pen and the bounding box is 100mm square to use as a reference.

I tried to accomplish the same thing with the minimum_segments_per_arc but for the life of me I could not figure out why it does not work. I dug through the code and I guess I am not fluent enough to catch the error. It slows to a crawl on every arc.

