### PR TITLE
Allow G12 defaults per tool & Tool Change Post Script

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1524,9 +1524,10 @@
   // Default number of triangles
   #define NOZZLE_CLEAN_TRIANGLES  3
 
-  // Specify positions as { X, Y, Z }
-  #define NOZZLE_CLEAN_START_POINT {  30, 30, (Z_MIN_POS + 1) }
-  #define NOZZLE_CLEAN_END_POINT   { 100, 60, (Z_MIN_POS + 1) }
+  // Specify positions for each tool as { { X, Y, Z }, { X, Y, Z } }
+  // Dual hotend system may use { {  -20, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) },  {  420, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) }}
+  #define NOZZLE_CLEAN_START_POINT { {  -20, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) },  {  420, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) }}
+  #define NOZZLE_CLEAN_END_POINT   { {  -20, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) },  {  420, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) }}
 
   // Circular pattern radius
   #define NOZZLE_CLEAN_CIRCLE_RADIUS 6.5

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1526,8 +1526,8 @@
 
   // Specify positions for each tool as { { X, Y, Z }, { X, Y, Z } }
   // Dual hotend system may use { {  -20, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) },  {  420, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) }}
-  #define NOZZLE_CLEAN_START_POINT { {  -20, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) },  {  420, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) }}
-  #define NOZZLE_CLEAN_END_POINT   { {  -20, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) },  {  420, (Y_BED_SIZE / 2), (Z_MIN_POS + 1) }}
+  #define NOZZLE_CLEAN_START_POINT { {  30, 30, (Z_MIN_POS + 1) } }
+  #define NOZZLE_CLEAN_END_POINT   { { 100, 60, (Z_MIN_POS + 1) } }
 
   // Circular pattern radius
   #define NOZZLE_CLEAN_CIRCLE_RADIUS 6.5

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1771,6 +1771,10 @@
   // Z raise distance for tool-change, as needed for some extruders
   #define TOOLCHANGE_ZRAISE     2  // (mm)
   //#define TOOLCHANGE_NO_RETURN   // Never return to the previous position on tool-change
+  #if ENABLED(TOOLCHANGE_NO_RETURN)
+    // Tool Change Post Process
+    //#define TOOLCHANGE_POST_PROCESS "G12X"
+  #endif
 
   // Retract and prime filament on tool-change
   //#define TOOLCHANGE_FILAMENT_SWAP

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1772,8 +1772,7 @@
   #define TOOLCHANGE_ZRAISE     2  // (mm)
   //#define TOOLCHANGE_NO_RETURN   // Never return to the previous position on tool-change
   #if ENABLED(TOOLCHANGE_NO_RETURN)
-    // Tool Change Post Process
-    //#define TOOLCHANGE_POST_PROCESS "G12X"
+    //#define EVENT_GCODE_AFTER_TOOLCHANGE "G12X"   // G-code to run after tool-change is complete
   #endif
 
   // Retract and prime filament on tool-change

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -157,26 +157,24 @@ Nozzle nozzle;
    * @param argument depends on the cleaning pattern
    */
   void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const uint8_t cleans) {
-    xyz_pos_t start = NOZZLE_CLEAN_START_POINT, end = NOZZLE_CLEAN_END_POINT;
+    xyz_pos_t start[HOTENDS] = NOZZLE_CLEAN_START_POINT, end[HOTENDS] = NOZZLE_CLEAN_END_POINT, middle[HOTENDS] = NOZZLE_CLEAN_CIRCLE_MIDDLE;
 
     if (pattern == 2) {
       if (!(cleans & (_BV(X_AXIS) | _BV(Y_AXIS)))) {
         SERIAL_ECHOLNPGM("Warning : Clean Circle requires XY");
         return;
       }
-      constexpr xyz_pos_t middle NOZZLE_CLEAN_CIRCLE_MIDDLE;
-      end = middle;
     }
     else {
-      if (!TEST(cleans, X_AXIS)) start.x = end.x = current_position.x;
-      if (!TEST(cleans, Y_AXIS)) start.y = end.y = current_position.y;
+      if (!TEST(cleans, X_AXIS)) start[active_extruder].x = end[active_extruder].x = current_position.x;
+      if (!TEST(cleans, Y_AXIS)) start[active_extruder].y = end[active_extruder].y = current_position.y;
     }
-    if (!TEST(cleans, Z_AXIS)) start.z = end.z = current_position.z;
+    if (!TEST(cleans, Z_AXIS)) start[active_extruder].z = end[active_extruder].z = current_position.z;
 
     switch (pattern) {
-       case 1: zigzag(start, end, strokes, objects); break;
-       case 2: circle(start, end, strokes, radius);  break;
-      default: stroke(start, end, strokes);
+       case 1: zigzag(start[active_extruder], end[active_extruder], strokes, objects); break;
+       case 2: circle(start[active_extruder], middle[active_extruder], strokes, radius);  break;
+      default: stroke(start[active_extruder], end[active_extruder], strokes);
     }
   }
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1067,7 +1067,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       fanmux_switch(active_extruder);
     #endif
 
-    #if defined(EVENT_GCODE_AFTER_TOOLCHANGE)
+    #ifdef EVENT_GCODE_AFTER_TOOLCHANGE
       gcode.process_subcommands_now_P(EVENT_GCODE_AFTER_TOOLCHANGE);
     #endif
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1067,6 +1067,10 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       fanmux_switch(active_extruder);
     #endif
 
+    #if defined(TOOLCHANGE_POST_PROCESS)
+      gcode.process_subcommands_now_P(TOOLCHANGE_POST_PROCESS);
+    #endif
+
     SERIAL_ECHO_START();
     SERIAL_ECHOLNPAIR(MSG_ACTIVE_EXTRUDER, int(active_extruder));
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1067,8 +1067,8 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       fanmux_switch(active_extruder);
     #endif
 
-    #if defined(TOOLCHANGE_POST_PROCESS)
-      gcode.process_subcommands_now_P(TOOLCHANGE_POST_PROCESS);
+    #if defined(EVENT_GCODE_AFTER_TOOLCHANGE)
+      gcode.process_subcommands_now_P(EVENT_GCODE_AFTER_TOOLCHANGE);
     #endif
 
     SERIAL_ECHO_START();


### PR DESCRIPTION
Allows setting default G12 points per active tool and a Tool Change post process script. In the case of IDEX such as on the Formbot Trex machines they have individual purge buckets on each side. This allows tool change to complete by wiping the nozzles.