### PR TITLE
Fix extui and plr

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -406,7 +406,7 @@ void startOrResumeJob() {
     thermalManager.zero_fan_speeds();
     wait_for_heatup = false;
     #if ENABLED(POWER_LOSS_RECOVERY)
-      card.removeJobRecoveryFile();
+      recovery.purge();
     #endif
     #ifdef EVENT_GCODE_SD_STOP
       queue.inject_P(PSTR(EVENT_GCODE_SD_STOP));

--- a/Marlin/src/feature/power_loss_recovery.h
+++ b/Marlin/src/feature/power_loss_recovery.h
@@ -148,14 +148,16 @@ class PrintJobRecovery {
     static void enable(const bool onoff);
     static void changed();
 
-    static void check();
-    static void resume();
-
     static inline bool exists() { return card.jobRecoverFileExists(); }
     static inline void open(const bool read) { card.openJobRecoveryFile(read); }
     static inline void close() { file.close(); }
 
+    static void check();
+    static void resume();
     static void purge();
+
+    static inline void cancel() { purge(); card.autostart_index = 0; }
+
     static void load();
     static void save(const bool force=
       #if ENABLED(SAVE_EACH_CMD_MODE)

--- a/Marlin/src/gcode/feature/powerloss/M1000.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M1000.cpp
@@ -64,6 +64,15 @@ void GcodeSuite::M1000() {
         SERIAL_ECHO_MSG("Resume requires LCD.");
       #endif
     }
+    else if (parser.seen('C')) {
+      card.removeJobRecoveryFile();
+      card.autostart_index = 0;
+      #if HAS_LCD_MENU
+        ui.return_to_status();
+      #elif ENABLED(EXTENSIBLE_UI)
+        ExtUI::onPrintTimerStopped();
+      #endif
+    }
     else
       recovery.resume();
   }

--- a/Marlin/src/gcode/feature/powerloss/M1000.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M1000.cpp
@@ -47,6 +47,10 @@ inline void plr_error(PGM_P const prefix) {
   #endif
 }
 
+#if HAS_LCD_MENU
+  void lcd_power_loss_recovery_cancel();
+#endif
+
 /**
  * M1000: Resume from power-loss (undocumented)
  *   - With 'S' go to the Resume/Cancel menu
@@ -65,11 +69,13 @@ void GcodeSuite::M1000() {
       #endif
     }
     else if (parser.seen('C')) {
-      card.removeJobRecoveryFile();
-      card.autostart_index = 0;
       #if HAS_LCD_MENU
-        ui.return_to_status();
-      #elif ENABLED(EXTENSIBLE_UI)
+        lcd_power_loss_recovery_cancel();
+      #else
+        card.removeJobRecoveryFile();
+        card.autostart_index = 0;
+      #endif
+      #if ENABLED(EXTENSIBLE_UI)
         ExtUI::onPrintTimerStopped();
       #endif
     }

--- a/Marlin/src/gcode/feature/powerloss/M1000.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M1000.cpp
@@ -72,8 +72,7 @@ void GcodeSuite::M1000() {
       #if HAS_LCD_MENU
         lcd_power_loss_recovery_cancel();
       #else
-        card.removeJobRecoveryFile();
-        card.autostart_index = 0;
+        recovery.cancel();
       #endif
       #if ENABLED(EXTENSIBLE_UI)
         ExtUI::onPrintTimerStopped();

--- a/Marlin/src/gcode/sdcard/M24_M25.cpp
+++ b/Marlin/src/gcode/sdcard/M24_M25.cpp
@@ -86,6 +86,10 @@ void GcodeSuite::M24() {
  */
 void GcodeSuite::M25() {
 
+  #if ENABLED(POWER_LOSS_RECOVERY)
+    if (recovery.enabled) recovery.save(true, false);
+  #endif
+
   // Set initial pause flag to prevent more commands from landing in the queue while we try to pause
   #if ENABLED(SDSUPPORT)
     if (IS_SD_PRINTING()) card.pauseSDPrint();

--- a/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extensible_ui/lib/dgus/DGUSDisplay.cpp
@@ -702,6 +702,7 @@ void DGUSScreenVariableHandler::HandleMotorLockUnlock(DGUS_VP_Variable &var, voi
 }
 
 #if ENABLED(POWER_LOSS_RECOVERY)
+
   void DGUSScreenVariableHandler::HandlePowerLossRecovery(DGUS_VP_Variable &var, void *val_ptr) {
     uint16_t value = swap16(*(uint16_t*)val_ptr);
     if (value) {
@@ -709,11 +710,11 @@ void DGUSScreenVariableHandler::HandleMotorLockUnlock(DGUS_VP_Variable &var, voi
       ScreenHandler.GotoScreen(DGUSLCD_SCREEN_SDPRINTMANIPULATION);
     }
     else {
-      card.removeJobRecoveryFile();
-      card.autostart_index = 0;
+      recovery.cancel();
       ScreenHandler.GotoScreen(DGUSLCD_SCREEN_STATUS);
     }
   }
+
 #endif
 
 void DGUSScreenVariableHandler::HandleSettings(DGUS_VP_Variable &var, void *val_ptr) {

--- a/Marlin/src/lcd/menu/menu_job_recovery.cpp
+++ b/Marlin/src/lcd/menu/menu_job_recovery.cpp
@@ -39,8 +39,7 @@ static void lcd_power_loss_recovery_resume() {
 }
 
 void lcd_power_loss_recovery_cancel() {
-  card.removeJobRecoveryFile();
-  card.autostart_index = 0;
+  recovery.cancel();
   ui.return_to_status();
 }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -95,10 +95,6 @@ MarlinUI ui;
 #include "../module/planner.h"
 #include "../module/motion.h"
 
-#if ENABLED(POWER_LOSS_RECOVERY)
-  #include "../feature/power_loss_recovery.h"
-#endif
-
 #if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "../feature/bedlevel/bedlevel.h"
 #endif
@@ -1517,10 +1513,6 @@ void MarlinUI::update() {
   void MarlinUI::pause_print() {
     #if HAS_LCD_MENU
       synchronize(GET_TEXT(MSG_PAUSE_PRINT));
-    #endif
-
-    #if ENABLED(POWER_LOSS_RECOVERY)
-      if (recovery.enabled) recovery.save(true, false);
     #endif
 
     #if ENABLED(HOST_PROMPT_SUPPORT)

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1071,7 +1071,7 @@ void CardReader::printingHasFinished() {
     stopSDPrint();
 
     #if ENABLED(POWER_LOSS_RECOVERY)
-      removeJobRecoveryFile();
+      recovery.purge();
     #endif
 
     #if ENABLED(SD_FINISHED_STEPPERRELEASE) && defined(SD_FINISHED_RELEASECOMMAND)

--- a/platformio.ini
+++ b/platformio.ini
@@ -437,7 +437,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 
 #
 # Geeetech GTM32 (STM32F103VET6)
-#  
+#
 [env:STM32F103VE_GTM32]
 platform        = ststm32
 board           = genericSTM32F103VE


### PR DESCRIPTION
Since UI is initialized prior to PLR recovery was not defined. Moved to M25 to get it in scope.

Added C option to M1000 for extui to send an explicit cancel.