### PR TITLE
Use Flash EEPROM on BTT002

### DIFF
--- a/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
@@ -29,7 +29,9 @@
 
 #define BOARD_INFO_NAME "BIGTREE Btt002 1.0"
 
-#define SRAM_EEPROM_EMULATION
+// Use one of these or SDCard-based Emulation will be used
+//#define SRAM_EEPROM_EMULATION   // Use BackSRAM-based EEPROM emulation
+#define FLASH_EEPROM_EMULATION  // Use Flash-based EEPROM emulation
 
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD 2000


### PR DESCRIPTION
### Description

This PR changes EEPROM emulation on the BTT002 board to use flash instead of SRAM, similar to the SKR Pro 1.1.

### Benefits

EEPROM settings are not lost on reboot.

### Related Issues

None.