### PR TITLE
Fix FYSETC S6 FLASH_PAGE_SIZE

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -54,6 +54,7 @@ jobs:
         - BIGTREE_SKR_PRO
         - mks_robin
         - ARMED
+        - FYSETC_S6
 
         # Put lengthy tests last
 

--- a/buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
+++ b/buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
@@ -1,5 +1,5 @@
 from os.path import join
-Import("env", "projenv")
+Import("env")
 
 import os,shutil
 from SCons.Script import DefaultEnvironment

--- a/buildroot/share/PlatformIO/variants/FYSETC_S6/variant.h
+++ b/buildroot/share/PlatformIO/variants/FYSETC_S6/variant.h
@@ -149,7 +149,7 @@ extern "C" {
 /* HAL configuration */
 #define HSE_VALUE               12000000U
 
-#define FLASH_PAGE_SIZE         uint32(4 * 1024)
+#define FLASH_PAGE_SIZE         (4U * 1024U)
 
 #ifdef __cplusplus
 } // extern "C"

--- a/buildroot/share/git/mftest
+++ b/buildroot/share/git/mftest
@@ -34,6 +34,7 @@ case $TESTENV in
      f1)  TESTENV='STM32F103RE' ;;
      f4)  TESTENV='STM32F4' ;;
      f7)  TESTENV='STM32F7' ;;
+     s6)  TESTENV='FYSETC_S6' ;;
   teensy) TESTENV='teensy31' ;;
      t31) TESTENV='teensy31' ;;
      t32) TESTENV='teensy31' ;;

--- a/buildroot/share/tests/FYSETC_S6-tests
+++ b/buildroot/share/tests/FYSETC_S6-tests
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#
+# Build tests for FYSETC_S6
+#
+
+# exit on first failure
+set -e
+
+# Build examples
+restore_configs
+use_example_configs FYSETC/S6
+exec_test $1 $2 "FYSETC S6 Example"
+
+# cleanup
+restore_configs

--- a/platformio.ini
+++ b/platformio.ini
@@ -627,7 +627,7 @@ build_flags       = ${common.build_flags}
   -DVECT_TAB_OFFSET=0x10000
   -DUSBCON -DUSBD_USE_CDC -DHAL_PCD_MODULE_ENABLED -DUSBD_VID=0x0483 '-DUSB_PRODUCT="FYSETC_S6"'
 build_unflags     = -std=gnu++11
-extra_scripts     = buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
+extra_scripts     = pre:buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
 src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 lib_ignore        = Arduino-L6470
 debug_tool        = stlink

--- a/platformio.ini
+++ b/platformio.ini
@@ -619,7 +619,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 # FYSETC S6 (STM32F446VET6 ARM Cortex-M4)
 #
 [env:FYSETC_S6]
-platform          = ststm32@<6
+platform          = ststm32
 board             = fysetc_s6
 platform_packages = tool-stm32duino
 build_flags       = ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -619,7 +619,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 # FYSETC S6 (STM32F446VET6 ARM Cortex-M4)
 #
 [env:FYSETC_S6]
-platform          = ststm32
+platform          = ststm32@<6
 board             = fysetc_s6
 platform_packages = tool-stm32duino
 build_flags       = ${common.build_flags}


### PR DESCRIPTION
### Description

The Maple framework used for the STM32F1 HAL defines the type `uint32`, but the framework used by the STM32 HAL does not.

The S6 variants file was modified to use `uint32`, which caused the compilation error shown below. I have correct this, and added a test to avoid future regressions, and to provide some coverage of the STM32 HAL.

```
arduinoststm32\cores\arduino\stm32\stm32_eeprom.c:35:
C:\Users\jason\.platformio\packages\framework-arduinoststm32\variants\FYSETC_S6/variant.h:152:33: warning: implicit declaration of function 'uint32' [-Wimplicit-function-declaration]
 #define FLASH_PAGE_SIZE         uint32(4 * 1024)
```

### Benefits

Fix S6 builds.

### Related Issues

I think this was broken only a few days ago, so I don't believe there is an open issue.