### PR TITLE
Fix build error when reset flag isn't supported by the HAL

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/HAL.cpp
+++ b/Marlin/src/HAL/HAL_STM32/HAL.cpp
@@ -95,25 +95,27 @@ void HAL_init() {
 void HAL_clear_reset_source() { __HAL_RCC_CLEAR_RESET_FLAGS(); }
 
 uint8_t HAL_get_reset_source() {
-  #ifdef RCC_FLAG_IWDGRST // Some sources may not exist...
-    if (RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST))  return RST_WATCHDOG;
-  #endif
-  #ifdef RCC_FLAG_IWDG1RST
-    if (RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_IWDG1RST)) return RST_WATCHDOG;
-  #endif
-  #ifdef RCC_FLAG_IWDG2RST
-    if (RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_IWDG2RST)) return RST_WATCHDOG;
-  #endif
-  #ifdef RCC_FLAG_SFTRST
-    if (RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST))   return RST_SOFTWARE;
-  #endif
-  #ifdef RCC_FLAG_PINRST
-    if (RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_PINRST))   return RST_EXTERNAL;
-  #endif
-  #ifdef RCC_FLAG_PORRST
-    if (RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_PORRST))   return RST_POWER_ON;
-  #endif
-  return 0;
+  return
+    #ifdef RCC_FLAG_IWDGRST // Some sources may not exist...
+      RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_IWDGRST)  ? RST_WATCHDOG :
+    #endif
+    #ifdef RCC_FLAG_IWDG1RST
+      RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_IWDG1RST) ? RST_WATCHDOG :
+    #endif
+    #ifdef RCC_FLAG_IWDG2RST
+      RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_IWDG2RST) ? RST_WATCHDOG :
+    #endif
+    #ifdef RCC_FLAG_SFTRST
+      RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_SFTRST)   ? RST_SOFTWARE :
+    #endif
+    #ifdef RCC_FLAG_PINRST
+      RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_PINRST)   ? RST_EXTERNAL :
+    #endif
+    #ifdef RCC_FLAG_PORRST
+      RESET != __HAL_RCC_GET_FLAG(RCC_FLAG_PORRST))  ? RST_POWER_ON :
+    #endif
+    0
+  ;
 }
 
 void _delay_ms(const int delay_ms) { delay(delay_ms); }


### PR DESCRIPTION
### Description

Since HAL_STM32 should support every STM32 chip we need to make sure that, if a function isn't supported (for example RCC_FLAG_IWDGRST doesn't exist in STM32H7), the build doesn't fail

### Benefits

HAL_STM32 compatibility broadened 

### Related Issues

Fixes a build error found during internal development.