### PR TITLE
Steval_3DP001V1 timers, create/fix definitions for analog inputs & improve formatting

### DIFF
--- a/Marlin/src/pins/stm32/pins_STEVAL_3DP001V1.h
+++ b/Marlin/src/pins/stm32/pins_STEVAL_3DP001V1.h
@@ -127,8 +127,8 @@
 /**
  * macro to reset/enable L6474 chips
  *
- * IMPORTANT - to disable (bypass a L6474, install the corresponding
- *             resistor (R11 - R17 and change the "V" to zero for the
+ * IMPORTANT - to disable (bypass) a L6474, install the corresponding
+ *             resistor (R11 - R17) and change the "V" to zero for the
  *             corresponding pin.
  */
 #define ENABLE_RESET_L64XX_CHIPS(V)   do{OUT_WRITE(X_ENABLE_PIN, V);\


### PR DESCRIPTION
CURRENT PROBLEMS:
- The current timer definitions result in compile errors because **timers.h** specifies timers that are not in the STM32F401 device.
- The analog inputs do not work because the pin definitions are not correct.


CHANGES:
- **timers.h** - switch to timers common to both the F401 and F407 and add a note about F401 timer useage/availability.
- **variant.h** and **pins_STEVAL_3DP001V1.h** - move definition of TIMER_TONE to **pins_STEVAL_3DP001V1.h**
- **pins_STEVAL_3DP001V1.h** - a) create/fix definitions for analog inputs and b) improve formatting

Net result is:
```
#define TIMER_SERVO    TIM4    // STEVAL_3DP001V1 only
#define TIMER_TONE       5     // STEVAL_3DP001V1 only
#define STEP_TIMER       9     // all STM32F4xx & STM32F7xx boards
#define TEMP_TIMER      10     // all STM32F4xx & STM32F7xx boards
```



