### PR TITLE
Fix various warnings found when testing example configurations

### DIFF
--- a/Marlin/src/feature/dac/stepper_dac.cpp
+++ b/Marlin/src/feature/dac/stepper_dac.cpp
@@ -68,7 +68,7 @@ void dac_current_percent(uint8_t channel, float val) {
 void dac_current_raw(uint8_t channel, uint16_t val) {
   if (!dac_present) return;
 
-  NOMORE(val, DAC_STEPPER_MAX);
+  NOMORE(val, uint16_t(DAC_STEPPER_MAX));
 
   mcp4728_analogWrite(dac_order[channel], val);
   mcp4728_simpleCommand(UPDATE);

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1395,7 +1395,7 @@ void Planner::check_axes_activity() {
 
       #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
         const float fade_scaling_factor = fade_scaling_factor_for_z(raw.z);
-      #else
+      #elif DISABLED(MESH_BED_LEVELING)
         constexpr float fade_scaling_factor = 1.0;
       #endif
 
@@ -1432,7 +1432,7 @@ void Planner::check_axes_activity() {
 
         #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
           const float fade_scaling_factor = fade_scaling_factor_for_z(raw.z);
-        #else
+        #elif DISABLED(MESH_BED_LEVELING)
           constexpr float fade_scaling_factor = 1.0;
         #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2909,6 +2909,7 @@ void Temperature::tick() {
     ) {
       #if TEMP_RESIDENCY_TIME > 0
         millis_t residency_start_ms = 0;
+        bool first_loop = true;
         // Loop until the temperature has stabilized
         #define TEMP_CONDITIONS (!residency_start_ms || PENDING(now, residency_start_ms + (TEMP_RESIDENCY_TIME) * 1000UL))
       #else
@@ -2926,7 +2927,7 @@ void Temperature::tick() {
       #endif
 
       float target_temp = -1.0, old_temp = 9999.0;
-      bool wants_to_cool = false, first_loop = true;
+      bool wants_to_cool = false;
       wait_for_heatup = true;
       millis_t now, next_temp_ms = 0, next_cool_check_ms = 0;
       do {
@@ -2979,6 +2980,8 @@ void Temperature::tick() {
             residency_start_ms = now;
           }
 
+          first_loop = false;
+
         #endif
 
         // Prevent a wait-forever situation if R is misused i.e. M109 R0
@@ -2998,8 +3001,6 @@ void Temperature::tick() {
             ui.quick_feedback();
           }
         #endif
-
-        first_loop = false;
 
       } while (wait_for_heatup && TEMP_CONDITIONS);
 
@@ -3148,6 +3149,7 @@ void Temperature::tick() {
     bool Temperature::wait_for_chamber(const bool no_wait_for_cooling/*=true*/) {
       #if TEMP_CHAMBER_RESIDENCY_TIME > 0
         millis_t residency_start_ms = 0;
+        bool first_loop = true;
         // Loop until the temperature has stabilized
         #define TEMP_CHAMBER_CONDITIONS (!residency_start_ms || PENDING(now, residency_start_ms + (TEMP_CHAMBER_RESIDENCY_TIME) * 1000UL))
       #else
@@ -3156,7 +3158,7 @@ void Temperature::tick() {
       #endif
 
       float target_temp = -1, old_temp = 9999;
-      bool wants_to_cool = false, first_loop = true;
+      bool wants_to_cool = false;
       wait_for_heatup = true;
       millis_t now, next_temp_ms = 0, next_cool_check_ms = 0;
 
@@ -3209,6 +3211,7 @@ void Temperature::tick() {
             residency_start_ms = now;
           }
 
+          first_loop = false;
         #endif // TEMP_CHAMBER_RESIDENCY_TIME > 0
 
         // Prevent a wait-forever situation if R is misused i.e. M191 R0
@@ -3221,9 +3224,6 @@ void Temperature::tick() {
             old_temp = temp;
           }
         }
-
-        first_loop = false;
-
       } while (wait_for_heatup && TEMP_CHAMBER_CONDITIONS);
 
       if (wait_for_heatup) ui.reset_status();

--- a/Marlin/src/pins/mega/pins_CNCONTROLS_15.h
+++ b/Marlin/src/pins/mega/pins_CNCONTROLS_15.h
@@ -2,6 +2,8 @@
  * CNControls V15 for HMS434 pin assignments
  */
 
+#pragma once
+
 #if !defined(__AVR_ATmega1280__) && !defined(__AVR_ATmega2560__)
   #error "Oops! Select 'Arduino/Genuino Mega or Mega 2560' in 'Tools > Board.'"
 #endif
@@ -64,7 +66,7 @@
 //
 // Fans
 //
-#define FAN0_PIN              8
+#define FAN_PIN               8
 #define ORIG_E0_AUTO_FAN_PIN 30
 #define ORIG_E1_AUTO_FAN_PIN 30
 #define ORIG_E2_AUTO_FAN_PIN 30

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -508,7 +508,9 @@
       #ifndef SD_DETECT_PIN
         #define SD_DETECT_PIN   49
       #endif
-      #define KILL_PIN          41
+      #ifndef KILL_PIN
+        #define KILL_PIN        41
+      #endif
 
       #if ENABLED(BQ_LCD_SMART_CONTROLLER)
         #define LCD_BACKLIGHT_PIN 39

--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -156,7 +156,7 @@
 //
 #if HAS_SPI_LCD
 
-  #if HAS_GRAPHICAL_LCD
+  #if HAS_GRAPHICAL_LCD && DISABLED(LCD_FOR_MELZI)
 
     #if ENABLED(U8GLIB_ST7920) // SPI GLCD 12864 ST7920 ( like [www.digole.com] ) For Melzi V2.0
 
@@ -201,12 +201,11 @@
     #endif
 
     // Uncomment screen orientation
-    #define LCD_SCREEN_ROT_0
     //#define LCD_SCREEN_ROT_90
     //#define LCD_SCREEN_ROT_180
     //#define LCD_SCREEN_ROT_270
 
-  #else // !HAS_GRAPHICAL_LCD
+  #elif NONE(LCD_FOR_MELZI, ZONESTAR_LCD)
 
     #define LCD_PINS_RS          4
     #define LCD_PINS_ENABLE     17

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -678,7 +678,7 @@ void CardReader::selectFileByIndex(const uint16_t nr) {
 //
 void CardReader::selectFileByName(const char * const match) {
   #if ENABLED(SDSORT_CACHE_NAMES)
-    for (int nr = 0; nr < sort_count; nr++)
+    for (uint16_t nr = 0; nr < sort_count; nr++)
       if (strcasecmp(match, sortshort[nr]) == 0) {
         strcpy(filename, sortshort[nr]);
         strcpy(longFilename, sortnames[nr]);


### PR DESCRIPTION
### Description

When testing the building of example configurations (as posted in https://github.com/MarlinFirmware/Configurations/pull/3) I encountered a lot of warnings for various examples.

These changes address many of these warnings. These were mostly constant redefinitions or unused variables.

These changes are mostly straightforward. The most confusing are the changes in `pins_SANGUINOLOLU_11.h`, where there is quite a mess of LCD-related options which can easily lead to pin redefinitions. I attempted to eliminate the redefinitions related to `LCD_FOR_MELZI` and `ZONESTAR_LCD` without breaking any behavior, but it is possible I have made a mistake.

### Benefits

Many fewer warnings displayed during example builds.

### Related Issues

None that I am aware of, but I have not searched for them.
