### PR TITLE
GTM32 Env adjustment

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -442,8 +442,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 platform        = ststm32
 board           = genericSTM32F103VE
 build_flags     = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
-build_unflags   = -std=gnu++11
+  ${common.build_flags} -DDEBUG_LEVEL=DEBUG_NONE -std=gnu++11 -MMD -ffunction-sections -fdata-sections -nostdlib -DBOARD_generic_stm32f103v -DVECT_TAB_ADDR=0x8000000 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6 -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1
 src_filter      = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_ignore      = Adafruit NeoPixel, LiquidTWI2, SPI
 upload_protocol = serial


### PR DESCRIPTION
Fix crashing of marlin when LCD knob turned or pressed.