### PR TITLE
Fix I2C address of MCP4728 on LPC176x

### DIFF
--- a/Marlin/src/feature/dac/dac_mcp4728.cpp
+++ b/Marlin/src/feature/dac/dac_mcp4728.cpp
@@ -43,7 +43,7 @@ xyze_uint_t mcp4728_values;
  */
 void mcp4728_init() {
   Wire.begin();
-  Wire.requestFrom(int(DAC_DEV_ADDRESS), 24);
+  Wire.requestFrom(I2C_ADDRESS(DAC_DEV_ADDRESS), 24);
   while (Wire.available()) {
     char deviceID = Wire.read(),
          hiByte = Wire.read(),


### PR DESCRIPTION
Hi all,

Here is small PR to fix a single line of code.

### Description

The I2C address provided to Wire.requestFrom() must be a 8 bits one according the the lpc176x framework implementation.
Please check the Wire.requestFrom() implementation and especially the followinf line:
https://github.com/p3p/pio-framework-arduino-lpc176x/blob/91b9f7cae8e1a1de04e8a2a9246bb36dd9e4c5dc/cores/arduino/Wire.cpp#L118

You can see the address argument is right shifted to set the 7-bits I2C address.

Regards,
Orel