### PR TITLE
STM32 RODATA LENGTH #16411

### DIFF
--- a/buildroot/share/PlatformIO/ldscripts/STM32F103RC_SKR_MINI_256K.ld
+++ b/buildroot/share/PlatformIO/ldscripts/STM32F103RC_SKR_MINI_256K.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K - 40
-  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 256K - 28K
+  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 256K - 28K - 4K
 }
 
 /* Provide memory region aliases for common.inc */

--- a/buildroot/share/PlatformIO/ldscripts/STM32F103RC_SKR_MINI_512K.ld
+++ b/buildroot/share/PlatformIO/ldscripts/STM32F103RC_SKR_MINI_512K.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K - 40
-  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K
+  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K - 4K
 }
 
 /* Provide memory region aliases for common.inc */

--- a/buildroot/share/PlatformIO/ldscripts/STM32F103RE_SKR_E3_DIP.ld
+++ b/buildroot/share/PlatformIO/ldscripts/STM32F103RE_SKR_E3_DIP.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K - 40
-  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K
+  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K - 4K
 }
 
 /* Provide memory region aliases for common.inc */

--- a/buildroot/share/PlatformIO/ldscripts/fysetc_aio_ii.ld
+++ b/buildroot/share/PlatformIO/ldscripts/fysetc_aio_ii.ld
@@ -5,7 +5,7 @@
 MEMORY
 {
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
-	rom (rx)  : ORIGIN = 0x08010000, LENGTH = 256K-40K
+	rom (rx)  : ORIGIN = 0x08010000, LENGTH = 256K - 40K - 4K
 }
 
 /* Provide memory region aliases for common.inc */

--- a/buildroot/share/PlatformIO/ldscripts/mks_robin_mini.ld
+++ b/buildroot/share/PlatformIO/ldscripts/mks_robin_mini.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K - 40
-  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K
+  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K - 4K
 }
 
 /* Provide memory region aliases for common.inc */


### PR DESCRIPTION
ldscripts: STM32F103RC_SKR_MINI RODATA LENGTH (#16411)
    
The SKR mini E3 boards use FLASH_EEPROM_EMULATION, which reserves a
4KB section of flash (at the end) which is used the emulate the
presence of an EEPROM on the board.
    
This does however imply that the maximum allowed firmware size is
decreased by 4KB as well, in addition to the 28KB for the bootloader.
    
When this 4KB is not subtracted from the RODATA LENGTH, it's possible
to do a successful Marlin firmware build, which works fine on the board,
until someone saves settings, after which the board can exhibit
erratic behavior.

This also decreases RODATA for three additional boards that I have identified
that are very likely affected by this issue:
   - SKR E3 DIP
   - Fysetc AIO II
   - MKS Robin Mini