### PR TITLE
Adjust GTM32 build flags

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -442,11 +442,10 @@ src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 platform        = ststm32
 board           = genericSTM32F103VE
 build_flags     = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=DEBUG_NONE -std=gnu++11 -MMD -ffunction-sections -fdata-sections -nostdlib
-  -DBOARD_generic_stm32f103v -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1
-  -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DVECT_TAB_ADDR=0x8000000 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
+  ${common.build_flags} -DDEBUG_LEVEL=DEBUG_NONE -std=gnu++14 -MMD -ffunction-sections -fdata-sections -nostdlib -DBOARD_generic_stm32f103v -DVECT_TAB_ADDR=0x8000000 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6 -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1
+build_unflags = -std=gnu++11
 src_filter      = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_ignore      = Adafruit NeoPixel, LiquidTWI2, SPI
+lib_ignore      = Adafruit NeoPixel, SPI
 upload_protocol = serial
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -442,7 +442,9 @@ src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 platform        = ststm32
 board           = genericSTM32F103VE
 build_flags     = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -DDEBUG_LEVEL=DEBUG_NONE -std=gnu++14 -MMD -ffunction-sections -fdata-sections -nostdlib -DBOARD_generic_stm32f103v -DVECT_TAB_ADDR=0x8000000 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6 -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1 -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1
+  ${common.build_flags} -DDEBUG_LEVEL=DEBUG_NONE -std=gnu++14 -MMD -ffunction-sections -fdata-sections -nostdlib
+  -DBOARD_generic_stm32f103v -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1 
+  -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DVECT_TAB_ADDR=0x8000000 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 build_unflags = -std=gnu++11
 src_filter      = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
 lib_ignore      = Adafruit NeoPixel, SPI

--- a/platformio.ini
+++ b/platformio.ini
@@ -443,7 +443,7 @@ platform        = ststm32
 board           = genericSTM32F103VE
 build_flags     = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
   ${common.build_flags} -DDEBUG_LEVEL=DEBUG_NONE -std=gnu++14 -MMD -ffunction-sections -fdata-sections -nostdlib
-  -DBOARD_generic_stm32f103v -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1 
+  -DBOARD_generic_stm32f103v -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1
   -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DVECT_TAB_ADDR=0x8000000 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 build_unflags = -std=gnu++11
 src_filter      = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>


### PR DESCRIPTION
Allows for more LCD types to be compiled & verified on the discount smart LCD no crash.