### PR TITLE
Fix issue #16569   M85 - Inactivity Shutdown issues.

### DIFF
--- a/Marlin/src/gcode/control/M85.cpp
+++ b/Marlin/src/gcode/control/M85.cpp
@@ -28,6 +28,9 @@
  */
 void GcodeSuite::M85() {
 
-  if (parser.seen('S')) max_inactive_time = parser.value_millis_from_seconds();
+  if (parser.seen('S')) {
+    reset_stepper_timeout();
+    max_inactive_time = parser.value_millis_from_seconds();
+  }
 
 }


### PR DESCRIPTION
### Description

Setting M85 can prematurely trigger.

### Cause 

The test is "ELAPSED(ms, gcode.previous_move_ms + max_inactive_time)"
M85 just sets max_inactive_time, but gcode.previous_move_ms is what ever random value it was set to last..  So if you wait 30 seconds then issue a  M85 S30, it instantly kills the printer vs waiting 30 seconds.

### Benefits

Now works as expected.

### Related Issues

#16569