### PR TITLE
Update BTT002 pins

### DIFF
--- a/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
@@ -41,7 +41,7 @@
 //
 #define X_STOP_PIN         PD3
 #define Y_STOP_PIN         PD2
-#define Z_STOP_PIN         PD1 // Shares J4 connector with PC3
+#define Z_STOP_PIN         PD1   // Shares J4 connector with PC3
 
 //
 // Z Probe must be this pin
@@ -151,10 +151,10 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN         PA2  // T0 <-> E0
-#define TEMP_1_PIN         PA0  // T1 <-> E1
-#define TEMP_BED_PIN       PA1  // T2 <-> Bed
-#define TEMP_PROBE_PIN     PC3  // Shares J4 connector with PD1
+#define TEMP_0_PIN         PA2   // T0 <-> E0
+#define TEMP_1_PIN         PA0   // T1 <-> E1
+#define TEMP_BED_PIN       PA1   // T2 <-> Bed
+#define TEMP_PROBE_PIN     PC3   // Shares J4 connector with PD1
 
 //
 // Heaters / Fans

--- a/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
@@ -159,17 +159,17 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN         PA0   // T1 <-> E0
-#define TEMP_1_PIN         PA1   // T2 <-> E1
-#define TEMP_BED_PIN       PA2   // T0 <-> Bed
+#define TEMP_0_PIN         PA2  // T0 <-> E0
+#define TEMP_1_PIN         PA0  // T1 <-> E1  // Not used on the MK3
+#define TEMP_BED_PIN       PA1  // T2 <-> Bed
 
 //
 // Heaters / Fans
 //
 #define HEATER_0_PIN       PE6   // Heater0
 #define HEATER_BED_PIN     PE5   // Hotbed
-#define FAN_PIN            PB9   // Fan0
-#define FAN1_PIN           PB8   // Fan1
+#define FAN_PIN            PB8   // Fan1
+#define FAN1_PIN           PB9   // Fan0
 
 // HAL SPI1 pins
 #define CUSTOM_SPI_PINS

--- a/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
@@ -39,9 +39,9 @@
 //
 // Limit Switches
 //
-#define X_STOP_PIN          PD3
-#define Y_STOP_PIN          PD2
-#define Z_STOP_PIN          PD1 // Shares J4 connector with PC3
+#define X_STOP_PIN         PD3
+#define Y_STOP_PIN         PD2
+#define Z_STOP_PIN         PD1 // Shares J4 connector with PC3
 
 //
 // Z Probe must be this pin

--- a/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
@@ -37,16 +37,11 @@
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD 2000
 
 //
-// Servos
-//
-#define SERVO0_PIN         PC3
-
-//
 // Limit Switches
 //
 #define X_STOP_PIN          PD3
 #define Y_STOP_PIN          PD2
-#define Z_STOP_PIN          PD1
+#define Z_STOP_PIN          PD1 // Shares J4 connector with PC3
 
 //
 // Z Probe must be this pin
@@ -157,8 +152,9 @@
 // Temperature Sensors
 //
 #define TEMP_0_PIN         PA2  // T0 <-> E0
-#define TEMP_1_PIN         PA0  // T1 <-> E1  // Not used on the MK3
+#define TEMP_1_PIN         PA0  // T1 <-> E1
 #define TEMP_BED_PIN       PA1  // T2 <-> Bed
+#define TEMP_PROBE_PIN     PC3  // Shares J4 connector with PD1
 
 //
 // Heaters / Fans

--- a/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32/pins_BTT_BTT002_V1_0.h
@@ -44,12 +44,9 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN          PD3
-#define X_MAX_PIN          PD3
-#define Y_MIN_PIN          PD2
-#define Y_MAX_PIN          PD2
-#define Z_MIN_PIN          PD1
-#define Z_MAX_PIN          PD1
+#define X_STOP_PIN          PD3
+#define Y_STOP_PIN          PD2
+#define Z_STOP_PIN          PD1
 
 //
 // Z Probe must be this pin


### PR DESCRIPTION
### Description

This PR fixes the thermistor & fan pins on the BTT002, removes the duplicate MIN/MAX endstop pins, and adds `TEMP_PROBE_PIN` now that PINDA V2 support is merged.

### Benefits

You can now plug thermistors & fans in the same locations as the [stock MK3/Einsy board](https://user-images.githubusercontent.com/13375512/72650829-78725f00-3936-11ea-812f-b267bf46bf20.png)
([source](https://manual.prusa3d.com/Guide/8.+Electronics+assembly+(B7-R3+design)/823?lang=en)) and use a PINDA V2.

### Related Issues

None.
