### PR TITLE
STEVAL_3DP001V1 - easier Serial2 (for WIFI interface)

### DIFF
--- a/buildroot/share/PlatformIO/variants/STEVAL_F401VE/variant.h
+++ b/buildroot/share/PlatformIO/variants/STEVAL_F401VE/variant.h
@@ -183,17 +183,17 @@ extern "C" {
 #define USER_BTN                PE7
 
 // UART Definitions
-#define SERIAL_UART_INSTANCE    1 //Connected to ST-Link
-//#define SERIAL_UART_INSTANCE    2 //Connected to WIFI
+#define SERIAL_UART_INSTANCE    1 // Connected to ST-Link
+//#define SERIAL_UART_INSTANCE    2 // Connected to WIFI
 
 // Default pin used for 'Serial' instance (ex: ST-Link)
 // Mandatory for Firmata
 #if SERIAL_UART_INSTANCE == 1             // ST-Link & J23
-  #define PIN_SERIAL_RX           PA10
-  #define PIN_SERIAL_TX           PA9
-#elif SERIAL_UART_INSTANCE == 2           // WIFI interface
-  #define PIN_SERIAL2_RX          PD6
-  #define PIN_SERIAL2_TX          PD5
+  #define PIN_SERIAL_RX         PA10
+  #define PIN_SERIAL_TX         PA9
+#elif SERIAL_UART_INSTANCE == 2         // WIFI interface
+  #define PIN_SERIAL2_RX        PD6
+  #define PIN_SERIAL2_TX        PD5
 #else
   #error'Invaqlid setting for SERIAL_UART_INSTANCE'
 #endif

--- a/buildroot/share/PlatformIO/variants/STEVAL_F401VE/variant.h
+++ b/buildroot/share/PlatformIO/variants/STEVAL_F401VE/variant.h
@@ -51,7 +51,7 @@ extern "C" {
 #define PA9  0 //TX
 #define PA10 1 //RX
 
-// WIFI
+// WIFI (USART2)
 #define PD3   2 // CTS
 #define PD4   3 // RTS
 #define PD5   4 // TX
@@ -184,11 +184,19 @@ extern "C" {
 
 // UART Definitions
 #define SERIAL_UART_INSTANCE    1 //Connected to ST-Link
+//#define SERIAL_UART_INSTANCE    2 //Connected to WIFI
 
 // Default pin used for 'Serial' instance (ex: ST-Link)
 // Mandatory for Firmata
-#define PIN_SERIAL_RX           PA10
-#define PIN_SERIAL_TX           PA9
+#if SERIAL_UART_INSTANCE == 1             // ST-Link & J23
+  #define PIN_SERIAL_RX           PA10
+  #define PIN_SERIAL_TX           PA9
+#elif SERIAL_UART_INSTANCE == 2           // WIFI interface
+  #define PIN_SERIAL2_RX          PD6
+  #define PIN_SERIAL2_TX          PD5
+#else
+  #error'Invaqlid setting for SERIAL_UART_INSTANCE'
+#endif
 
 // Timer Definitions
 #define TIMER_SERVO             TIM4  // TIMER_SERVO must be defined in this file


### PR DESCRIPTION
On the STEVAL_3DP001V1 the WIFI module is connected to USART2.  Currently there isn't a definition that allows this USART to be used.

This PR adds to **variant.h** the defines needed to connect USART2 to **Serial2**.

---

To enable the WIFI USART do the following:
- In **\buildroot\share\PlatformIO\variants\STEVAL_F401VE\variant.h** change the **SERIAL_UART_INSTANCE** define from "1" to "2"
- In Configuration.h set **SERIAL_PORT_2** to "2"

---

The default of making Serial1 available is being retained.  Serial1 connects to the ST-LINK.  

The STEVAL_3DP001V1's WIFI module won't be useful until a lot more work is done.  The current status/state is:
- Connecting to the WIFI is a real pain.  90% of the connection attempts either fail or the web pages won't load.
- Chances are the connection woes can be fixed by a WIFI firmware upgrade but the upgrade process isn't user friendly.   In addition this is not an ESP based module so the popular tools can't be used.
- The current WIFI firmware sends the gcodes but does not append the line number and checksum.  Without the line number and checksum Marlin will ignore the gcodes or respond with an error message .