### PR TITLE
Fix CHAMBER_MAXTEMP overshoot margin

### DIFF
--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -191,7 +191,7 @@ void menu_temperature() {
   // Chamber:
   //
   #if HAS_HEATED_CHAMBER
-    EDIT_ITEM_FAST(int3, MSG_CHAMBER, &thermalManager.temp_chamber.target, 0, CHAMBER_MAXTEMP - 5, thermalManager.start_watching_chamber);
+    EDIT_ITEM_FAST(int3, MSG_CHAMBER, &thermalManager.temp_chamber.target, 0, CHAMBER_MAXTEMP - 10, thermalManager.start_watching_chamber);
   #endif
 
   //

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -711,7 +711,7 @@ class Temperature {
       static void setTargetChamber(const int16_t celsius) {
         temp_chamber.target =
           #ifdef CHAMBER_MAXTEMP
-            _MIN(celsius, CHAMBER_MAXTEMP)
+            _MIN(celsius, CHAMBER_MAXTEMP - 10)
           #else
             celsius
           #endif


### PR DESCRIPTION
Hotend drift offset is 15
Bed drift offset is 10
Chamber drift offset was 0, 5, 10 depending on code part. Now fixed to 10

Fix #16586