### PR TITLE
Split out & fix STM401, STM4xx & STM32F7xx timers - also fix STEVAL_3DP001V1 compil warning

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/timers.h
+++ b/Marlin/src/HAL/HAL_STM32/timers.h
@@ -84,7 +84,7 @@
     #define TEMP_TIMER 14
   #endif
 
-#elif defined(STM32F7xx
+#elif defined(STM32F7xx)
 
   #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
 

--- a/Marlin/src/HAL/HAL_STM32/timers.h
+++ b/Marlin/src/HAL/HAL_STM32/timers.h
@@ -59,7 +59,7 @@
 
 #elif defined(STM32F401xC) || defined(STM32F401xE)
 
-  #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
+  #define HAL_TIMER_RATE (F_CPU / 2) // frequency of timer peripherals
 
   // STM32F401 only has timers 1-5 & 9-11 with timers 4 & 5 usually assigned to TIMER_SERVO and TIMER_TONE
 
@@ -73,8 +73,7 @@
 
 #elif defined(STM32F4xx)
 
-  #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
-
+  #define HAL_TIMER_RATE (F_CPU / 2) // frequency of timer peripherals
 
   #ifndef STEP_TIMER
     #define STEP_TIMER 6
@@ -98,8 +97,6 @@
 
 #endif
 
-
-
 #ifndef SWSERIAL_TIMER_IRQ_PRIO
   #define SWSERIAL_TIMER_IRQ_PRIO 1
 #endif
@@ -109,16 +106,16 @@
 #endif
 
 #ifndef TEMP_TIMER_IRQ_PRIO
-  #define TEMP_TIMER_IRQ_PRIO 14 //14 = after hardware ISRs
+  #define TEMP_TIMER_IRQ_PRIO 14   // 14 = after hardware ISRs
 #endif
 
 #define STEP_TIMER_NUM 0  // index of timer to use for stepper
 #define TEMP_TIMER_NUM 1  // index of timer to use for temperature
 #define PULSE_TIMER_NUM STEP_TIMER_NUM
 
-#define TEMP_TIMER_FREQUENCY 1000 //Temperature::isr() is expected to be called at around 1kHz
+#define TEMP_TIMER_FREQUENCY 1000   // Temperature::isr() is expected to be called at around 1kHz
 
-//TODO: get rid of manual rate/prescale/ticks/cycles taken for procedures in stepper.cpp
+// TODO: get rid of manual rate/prescale/ticks/cycles taken for procedures in stepper.cpp
 #define STEPPER_TIMER_RATE 2000000 // 2 Mhz
 #define STEPPER_TIMER_PRESCALE ((HAL_TIMER_RATE)/(STEPPER_TIMER_RATE))
 #define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs

--- a/Marlin/src/HAL/HAL_STM32/timers.h
+++ b/Marlin/src/HAL/HAL_STM32/timers.h
@@ -57,7 +57,7 @@
     #define TEMP_TIMER 2
   #endif
 
-#elif defined(STM32F4xx) || defined(STM32F7xx)
+#elif defined(STM32F401xC) || defined(STM32F401xE)
 
   #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
 
@@ -71,7 +71,34 @@
     #define TEMP_TIMER 10
   #endif
 
+#elif defined(STM32F4xx)
+
+  #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
+
+
+  #ifndef STEP_TIMER
+    #define STEP_TIMER 6
+  #endif
+
+  #ifndef TEMP_TIMER
+    #define TEMP_TIMER 14
+  #endif
+
+#elif defined(STM32F7xx
+
+  #define HAL_TIMER_RATE (F_CPU/2) // frequency of timer peripherals
+
+  #ifndef STEP_TIMER
+    #define STEP_TIMER 6
+  #endif
+
+  #ifndef TEMP_TIMER
+    #define TEMP_TIMER 14
+  #endif
+
 #endif
+
+
 
 #ifndef SWSERIAL_TIMER_IRQ_PRIO
   #define SWSERIAL_TIMER_IRQ_PRIO 1

--- a/Marlin/src/pins/stm32/pins_STEVAL_3DP001V1.h
+++ b/Marlin/src/pins/stm32/pins_STEVAL_3DP001V1.h
@@ -48,8 +48,6 @@
   #define MACHINE_NAME "STEVAL-3DP001V1"
 #endif
 
-#define TIMER_TONE  5
-
 //
 // Limit Switches
 //

--- a/buildroot/share/PlatformIO/variants/STEVAL_F401VE/variant.h
+++ b/buildroot/share/PlatformIO/variants/STEVAL_F401VE/variant.h
@@ -200,6 +200,7 @@ extern "C" {
 
 // Timer Definitions
 #define TIMER_SERVO             TIM4  // TIMER_SERVO must be defined in this file
+#define TIMER_TONE              TIM5  // TIMER_TONE must be defined in this file
 
 /* SD detect signal */
 /*


### PR DESCRIPTION
Per issue #16604, the current STM32F407 timer defines are not working.

**CHANGES:**
- **timers.h** - split STM32F401, STM32F4xx & STM32F7xx devices into seperate sections.  STM32F4xx is now effectively all 4xx devices ecept the 401 devices.
- **timers.h** - revert  STM32F4xx & STM32F7xx devices to the timers used before PR #16450 (a known good set of definitions).
- **variant.h** in STEVAL_F401VE and **pins_STEVAL_3DP001V1** - move the TIMER_TONE definition back into  **variant.h** .  The resolves a compile warning.


The STM401 devices retain:
```
#define STEP_TIMER 9
#define TEMP_TIMER 10
```

All other STM4xx devices revert to:
```
#define STEP_TIMER 6
#define TEMP_TIMER 14

```

The STM7xx devices also revert to:
```
#define STEP_TIMER 6
#define TEMP_TIMER 14

```