### PR TITLE
Enable use of latest TMCStepper on mks_robin_nano

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -483,11 +483,14 @@ lib_ignore    = Adafruit NeoPixel, SPI
 [env:mks_robin_nano]
 platform      = ststm32
 board         = genericSTM32F103VE
+platform_packages = tool-stm32duino
 build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14
+  ${common.build_flags} -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
 build_unflags = -std=gnu++11
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano.py
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
+lib_deps =
+  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
 lib_ignore    = Adafruit NeoPixel, SPI
 
 #


### PR DESCRIPTION
### Description

I have forced Marlin to use SoftwareSerialM on mks_robin_nano board in order to connect TMC2209 in spi mode. Also tool-stm32duino package was needed to compile the code. Now tmc's are connected  without problems.

### Benefits

It allows to use TMC2209 SPI connection with latest TMC library on mks_robin_nano.
