### PR TITLE
Only Kill on inactivity if PSU_CONTROL is enabled

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -440,11 +440,13 @@ void manage_inactivity(const bool ignore_stepper_queue/*=false*/) {
 
   const millis_t ms = millis();
 
-  if (max_inactive_time && ELAPSED(ms, gcode.previous_move_ms + max_inactive_time)) {
-    SERIAL_ERROR_START();
-    SERIAL_ECHOLNPAIR(MSG_KILL_INACTIVE_TIME, parser.command_ptr);
-    kill();
-  }
+  #if ENABLED(PSU_CONTROL)
+    if (max_inactive_time && ELAPSED(ms, gcode.previous_move_ms + max_inactive_time)) {
+      SERIAL_ERROR_START();
+      SERIAL_ECHOLNPAIR(MSG_KILL_INACTIVE_TIME, parser.command_ptr);
+      kill();
+    }
+  #endif
 
   // Prevent steppers timing-out in the middle of M600
   #if BOTH(ADVANCED_PAUSE_FEATURE, PAUSE_PARK_NO_STEPPER_TIMEOUT)


### PR DESCRIPTION
To enable auto powershutdown after printing User add M85 Sxx at the gcode script. 
If the gcode file used in printer with PSU_CONTROL then the printer will automatically turn off after printing. 
But if the printer dont have PSU_CONTROL than the printer will be halted, which make user have to turn off and turn on the printer. 

This commit make Kill on inactivity only enabled if the printer have PSU_CONTROL