### PR TITLE
Fix HOMING_BACKOFF_MM for DELTA

### DIFF
--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -254,7 +254,7 @@ void home_delta() {
       - probe_offset.z
     #endif
   );
-  line_to_current_position(homing_feedrate(X_AXIS));
+  line_to_current_position(homing_feedrate(Z_AXIS));
   planner.synchronize();
 
   // Re-enable stealthChop if used. Disable diag1 pin on driver.
@@ -279,6 +279,16 @@ void home_delta() {
   LOOP_XYZ(i) set_axis_is_at_home((AxisEnum)i);
 
   sync_plan_position();
+
+  #ifdef HOMING_BACKOFF_MM
+    constexpr xyz_float_t endstop_backoff = HOMING_BACKOFF_MM;
+    const float backoff_mm = endstop_backoff[Z_AXIS];
+    if (backoff_mm) {
+      current_position.z -= ABS(backoff_mm) * Z_HOME_DIR;
+      line_to_current_position(homing_feedrate(Z_AXIS));
+    }
+  #endif
+
 
   if (DEBUGGING(LEVELING)) DEBUG_POS("<<< home_delta", current_position);
 }

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -280,7 +280,7 @@ void home_delta() {
 
   sync_plan_position();
 
-  #ifdef HOMING_BACKOFF_MM
+  #if DISABLED(DELTA_HOME_TO_SAFE_ZONE) && defined(HOMING_BACKOFF_MM)
     constexpr xyz_float_t endstop_backoff = HOMING_BACKOFF_MM;
     if (endstop_backoff.z) {
       current_position.z -= ABS(endstop_backoff.z) * Z_HOME_DIR;

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -282,13 +282,11 @@ void home_delta() {
 
   #ifdef HOMING_BACKOFF_MM
     constexpr xyz_float_t endstop_backoff = HOMING_BACKOFF_MM;
-    const float backoff_mm = endstop_backoff[Z_AXIS];
-    if (backoff_mm) {
-      current_position.z -= ABS(backoff_mm) * Z_HOME_DIR;
+    if (endstop_backoff.z) {
+      current_position.z -= ABS(endstop_backoff.z) * Z_HOME_DIR;
       line_to_current_position(homing_feedrate(Z_AXIS));
     }
   #endif
-
 
   if (DEBUGGING(LEVELING)) DEBUG_POS("<<< home_delta", current_position);
 }

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1748,15 +1748,9 @@ void homeaxis(const AxisEnum axis) {
     if (axis == Z_AXIS && STOW_PROBE()) return;
   #endif
 
-  #ifdef HOMING_BACKOFF_MM
+  #if defined(HOMING_BACKOFF_MM) && DISABLED(DELTA)
     constexpr xyz_float_t endstop_backoff = HOMING_BACKOFF_MM;
-    const float backoff_mm = endstop_backoff[
-      #if ENABLED(DELTA)
-        Z_AXIS
-      #else
-        axis
-      #endif
-    ];
+    const float backoff_mm = endstop_backoff[axis];
     if (backoff_mm) {
       current_position[axis] -= ABS(backoff_mm) * axis_home_dir;
       line_to_current_position(

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1748,7 +1748,7 @@ void homeaxis(const AxisEnum axis) {
     if (axis == Z_AXIS && STOW_PROBE()) return;
   #endif
 
-  #if defined(HOMING_BACKOFF_MM) && DISABLED(DELTA)
+  #if DISABLED(DELTA) && defined(HOMING_BACKOFF_MM)
     constexpr xyz_float_t endstop_backoff = HOMING_BACKOFF_MM;
     const float backoff_mm = endstop_backoff[axis];
     if (backoff_mm) {


### PR DESCRIPTION
### Description

Trying to use HOMING_BACKOFF_MM with a delta printer causes all axis to crash into the endstops, rather than back off as expected.

This change was originally authored by @DickyMcCockpants and attached to issue #16366. It was attached as raw source rather than as a patch, so I had to manually merge and guess which changes were actually intended. It is entirely possible I have left things out from his original change.

I have tested it on my delta and verified both the erroneous old behavior and that it behaves as expected after updating.

### Benefits

Avoids crashing axis when using HOMING_BACKOFF_MM.

### Related Issues

 #16366
