### PR TITLE
Fix #16619, SKR 1.3 swaps MIN and MAX endstops if homing to max. 

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -29,7 +29,7 @@
  * For Stallguard homing to max swap the min / max pins so
  * the MAX physical connectors can be used for other things.
  */
-#if X_HOME_DIR == -1 || !X_STALL_SENSITIVITY
+#if defined(USE_XMAX_PLUG) || X_HOME_DIR == -1 || !X_STALL_SENSITIVITY
   #define X_MIN_PIN          P1_29   // X_MIN
   #define X_MAX_PIN          P1_28   // X_MAX
 #else
@@ -37,7 +37,7 @@
   #define X_MAX_PIN          P1_29   // X_MIN
 #endif
 
-#if Y_HOME_DIR == -1 || !Y_STALL_SENSITIVITY
+#if defined(USE_YMAX_PLUG) || Y_HOME_DIR == -1 || !Y_STALL_SENSITIVITY
   #define Y_MIN_PIN          P1_27   // Y_MIN
   #define Y_MAX_PIN          P1_26   // Y_MAX
 #else
@@ -45,7 +45,7 @@
   #define Y_MAX_PIN          P1_27   // Y_MIN
 #endif
 
-#if Z_HOME_DIR == -1 || !Z_STALL_SENSITIVITY
+#if defined(USE_ZMAX_PLUG) || Z_HOME_DIR == -1 || !Z_STALL_SENSITIVITY
   #define Z_MIN_PIN          P1_25   // Z_MIN
   #define Z_MAX_PIN          P1_24   // Z_MAX
 #else

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -25,32 +25,31 @@
 
 /**
  * Limit Switches
- *
- * For Stallguard homing to max swap the min / max pins so
- * the MAX physical connectors can be used for other things.
  */
-#if defined(USE_XMAX_PLUG) || X_HOME_DIR == -1 || !X_STALL_SENSITIVITY
+#if X_HOME_DIR > 0 && X_STALL_SENSITIVITY && !defined(USE_XMAX_PLUG)
+  // For StallGuard homing to MAX swap the MIN / MAX pins
+  // so the MAX physical connectors may be used for other things.
+  #define X_MIN_PIN          P1_28   // X_MAX (free)
+  #define X_MAX_PIN          P1_29   // X_MIN
+#else                                // else, non-endstop is free and appears in M43 output
   #define X_MIN_PIN          P1_29   // X_MIN
   #define X_MAX_PIN          P1_28   // X_MAX
-#else
-  #define X_MIN_PIN          P1_28   // X_MAX
-  #define X_MAX_PIN          P1_29   // X_MIN
 #endif
 
-#if defined(USE_YMAX_PLUG) || Y_HOME_DIR == -1 || !Y_STALL_SENSITIVITY
+#if Y_HOME_DIR > 0 && Y_STALL_SENSITIVITY && !defined(USE_YMAX_PLUG)
+  #define Y_MIN_PIN          P1_26   // Y_MAX (free)
+  #define Y_MAX_PIN          P1_27   // Y_MIN
+#else
   #define Y_MIN_PIN          P1_27   // Y_MIN
   #define Y_MAX_PIN          P1_26   // Y_MAX
-#else
-  #define Y_MIN_PIN          P1_26   // Y_MAX
-  #define Y_MAX_PIN          P1_27   // Y_MIN
 #endif
 
-#if defined(USE_ZMAX_PLUG) || Z_HOME_DIR == -1 || !Z_STALL_SENSITIVITY
+#if Z_HOME_DIR > 0 && Z_STALL_SENSITIVITY && !defined(USE_ZMAX_PLUG)
+  #define Z_MIN_PIN          P1_24   // Z_MAX (free)
+  #define Z_MAX_PIN          P1_25   // Z_MIN
+#else
   #define Z_MIN_PIN          P1_25   // Z_MIN
   #define Z_MAX_PIN          P1_24   // Z_MAX
-#else
-  #define Z_MIN_PIN          P1_24   // Z_MAX
-  #define Z_MAX_PIN          P1_25   // Z_MIN
 #endif
 
 #define ONBOARD_ENDSTOPPULLUPS     // Board has built-in pullups


### PR DESCRIPTION
### Requirements

With MOTHERBOARD BOARD_BIGTREE_SKR_V1_3
and any HOME_DIR set to 1 (home to max) 

### Description

With the above settings pins_BTT_SKR_V1_3.h swaps the MAX and MIN end stop pins.
This is required if your doing sensor less homing, but not if you have real end stops plugged into  
the max end stops plugs. ie  when USE_(X|Y|Z)MAX_PLUG is set.

### Benefits

This keeps the end stops from swapping if your using real MAX end stops and still swaps them if using sensor-less homing. This is far less confusing for the user as it behaves like all other boards with real MIN and MAX end stops plugs.

This does have a negative. If anyone has already fallen into this trap and moved their MAX endstops to the MIN endstops plugs to make it work they will have to move them back after applying this PR.  

### Related Issues
#16619