### PR TITLE
MKS SBase Digipot init fix

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/include/digipot_mcp4451_I2C_routines.h
+++ b/Marlin/src/HAL/HAL_LPC1768/include/digipot_mcp4451_I2C_routines.h
@@ -36,6 +36,7 @@
 
 uint8_t digipot_mcp4451_start(uint8_t sla);
 uint8_t digipot_mcp4451_send_byte(uint8_t data);
+void configure_i2c(const uint8_t clock_option);
 
 #ifdef __cplusplus
   }

--- a/Marlin/src/feature/digipot/digipot_mcp4451.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4451.cpp
@@ -77,7 +77,7 @@ void digipot_i2c_set_current(const uint8_t channel, const float current) {
 
 void digipot_i2c_init() {
   #if MB(MKS_SBASE)
-    configure_i2c();
+    configure_i2c(0xFF);
   #else
     Wire.begin();
   #endif


### PR DESCRIPTION
MKS SBASE boards no longer compile because of a bug introduced by PR #16584.  This PR replaced **digipot_mcp4451_init()** with **configure_i2c()** but the replacement was not completed.

**CHANGES:**
- **digipot_mcp4451.cpp** - replace **configure_i2c()** with **configure_i2c(0xFF)**.  That routine reqwuires one argument.  The 0xFF value guarantees the faster speed is always selected (the speed specified by **digipot_mcp4451_init**).
- **digipot_mcp4451_I2C_routines.h** - add declaration for **configure_i2c**

This fix has been tested on a MKS SBase V1.3 board.