### PR TITLE
Save and Restore WorkdirDepth when removeFile

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1135,7 +1135,9 @@ void CardReader::printingHasFinished() {
   void CardReader::removeJobRecoveryFile() {
     if (jobRecoverFileExists()) {
       recovery.init();
+      const uint8_t saveWorkDirDepth = workDirDepth;
       removeFile(recovery.filename);
+      workDirDepth = saveWorkDirDepth;
       #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
         SERIAL_ECHOPGM("Power-loss file delete");
         serialprintPGM(jobRecoverFileExists() ? PSTR(" failed.\n") : PSTR("d.\n"));

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -504,7 +504,7 @@ void CardReader::openFileRead(char * const path, const uint8_t subcall_type/*=0*
   stopSDPrint();
 
   SdFile *curDir;
-  const char * const fname = diveToFile(curDir, path);
+  const char * const fname = diveToFile(true, curDir, path);
   if (!fname) return;
 
   if (file.open(curDir, fname, O_READ)) {
@@ -532,7 +532,7 @@ void CardReader::openFileWrite(char * const path) {
   stopSDPrint();
 
   SdFile *curDir;
-  const char * const fname = diveToFile(curDir, path);
+  const char * const fname = diveToFile(false, curDir, path);
   if (!fname) return;
 
   if (file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC)) {
@@ -557,7 +557,7 @@ void CardReader::removeFile(const char * const name) {
   //stopSDPrint();
 
   SdFile *curDir;
-  const char * const fname = diveToFile(curDir, name);
+  const char * const fname = diveToFile(false, curDir, name);
   if (!fname) return;
 
   if (file.remove(curDir, fname)) {
@@ -704,26 +704,28 @@ uint16_t CardReader::countFilesInWorkDir() {
  *
  * A nullptr result indicates an unrecoverable error.
  */
-const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, const bool echo/*=false*/) {
+const char* CardReader::diveToFile(const bool update_cwd, SdFile*& curDir, const char * const path, const bool echo/*=false*/) {
   // Track both parent and subfolder
   static SdFile newDir1, newDir2;
   SdFile *sub = &newDir1, *startDir;
 
+  // Parsing the path string
   const char *item_name_adr = path;
-  if (path[0] == '/') {
+
+  if (path[0] == '/') {               // Starting at the root directory?
     curDir = &root;
-    workDirDepth = 0;
+    if (update_cwd) workDirDepth = 0; // The cwd can be updated for the benefit of sub-programs
     item_name_adr++;
   }
   else
-    curDir = &workDir;
+    curDir = &workDir;                // Dive from workDir (as set by the UI)
 
   startDir = curDir;
-
-  // Start dive
   while (item_name_adr) {
-    // Find next sub
+    // Find next subdirectory delimiter
     char * const name_end = strchr(item_name_adr, '/');
+
+    // Last atom in the path? Item found.
     if (name_end <= item_name_adr) break;
 
     // Set subDirName
@@ -746,13 +748,16 @@ const char* CardReader::diveToFile(SdFile*& curDir, const char * const path, con
     // curDir now subDir
     curDir = sub;
 
-    // Update workDirParents and workDirDepth
-    if (workDirDepth < MAX_DIR_DEPTH) workDirParents[workDirDepth++] = *curDir;
+    // Update workDirParents, workDirDepth, and workDir
+    if (update_cwd) {
+      if (workDirDepth < MAX_DIR_DEPTH) workDirParents[workDirDepth++] = *curDir;
+      workDir = *curDir;
+    }
 
-    // Point sub pointer to unused newDir
+    // Point sub at the other scratch object
     sub = (curDir != &newDir1) ? &newDir1 : &newDir2;
 
-    // item_name_adr point to next sub
+    // Next path atom address
     item_name_adr = name_end + 1;
   }
   return item_name_adr;
@@ -1135,9 +1140,7 @@ void CardReader::printingHasFinished() {
   void CardReader::removeJobRecoveryFile() {
     if (jobRecoverFileExists()) {
       recovery.init();
-      const uint8_t saveWorkDirDepth = workDirDepth;
       removeFile(recovery.filename);
-      workDirDepth = saveWorkDirDepth;
       #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
         SERIAL_ECHOPGM("Power-loss file delete");
         serialprintPGM(jobRecoverFileExists() ? PSTR(" failed.\n") : PSTR("d.\n"));

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -125,7 +125,7 @@ public:
   static inline uint8_t percentDone() { return (isFileOpen() && filesize) ? sdpos / ((filesize + 99) / 100) : 0; }
 
   // Helper for open and remove
-  static const char* diveToFile(SdFile*& curDir, const char * const path, const bool echo=false);
+  static const char* diveToFile(const bool update_cwd, SdFile*& curDir, const char * const path, const bool echo=false);
 
   #if ENABLED(SDCARD_SORT_ALPHA)
     static void presort();


### PR DESCRIPTION
When remove recovery file. (in the root dir), workDirDepth will be set to 0. 
Therefore we need to save and restore workDirDepth when removing recovery file. 

This will fix Power Loss Recovery bug when Resume from second power loss.