### PR TITLE
Faster time to temperature for extruder (intentional overshoot)

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -474,6 +474,10 @@
                                   // Set/get with gcode: M301 E[extruder number, 0-2]
   #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
                                   // is more than PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
+  #ifdef PID_FUNCTIONAL_RANGE
+    //#define PID_OVERSHOOT 0     // Heater stays at max until target temperature + PID_OVERSHOOT reached - minimizes time to target temperature
+                                  // actual overshoot will be more than this value
+  #endif
 
   // If you are using a pre-configured hotend then you can use one of the value sets by uncommenting it
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -475,7 +475,7 @@
   #define PID_FUNCTIONAL_RANGE 10 // If the temperature difference between the target temperature and the actual temperature
                                   // is more than PID_FUNCTIONAL_RANGE then the PID will be shut off and the heater will be set to min/max.
   #ifdef PID_FUNCTIONAL_RANGE
-    //#define PID_OVERSHOOT 0     // Heater stays at max until target temperature + PID_OVERSHOOT reached - minimizes time to target temperature
+    //#define PID_OVERSHOOT -2     // Heater stays at max until target temperature + PID_OVERSHOOT reached - minimizes time to target temperature
                                   // actual overshoot will be more than this value
   #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -883,7 +883,7 @@ void Temperature::min_temp_error(const heater_ind_t heater) {
           pid_output = 0;
           pid_reset[ee] = true;
         }
-        else if (pid_error > PID_FUNCTIONAL_RANGE) {
+        else if ((pid_error > PID_FUNCTIONAL_RANGE) || ((pid_error > 0 ) && pid_overshoot) ) {
           pid_output = BANG_MAX;
           pid_reset[ee] = true;
         }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -883,7 +883,7 @@ void Temperature::min_temp_error(const heater_ind_t heater) {
           pid_output = 0;
           pid_reset[ee] = true;
         }
-        else if ((pid_error > PID_FUNCTIONAL_RANGE) || ((pid_error > 0 ) && pid_overshoot) ) {
+        else if ((pid_error > PID_FUNCTIONAL_RANGE) || ((pid_error >= -PID_OVERSHOOT ) && pid_overshoot) ) {
           pid_output = BANG_MAX;
           pid_reset[ee] = true;
         }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -842,9 +842,6 @@ void Temperature::min_temp_error(const heater_ind_t heater) {
         static bool pid_reset[HOTENDS] = { false };
         const float pid_error = temp_hotend[ee].target - temp_hotend[ee].celsius;
 
-
-        static bool pid_overshoot;
-
         #ifdef PID_OVERSHOOT
           static bool pid_overshoot_flag;
           float pid_overshoot_val = PID_OVERSHOOT;  // can't just use -PID_OVERSHOOT because some tool chains don't allow it


### PR DESCRIPTION
The purpose of this code is to minimize the wait before the M109 command completes.

Right now the PID parameters from M303 auto tune result in an ~under~ over damped extruder temperature curve.  The result is the M109 command waits until the PID algorithm gets to the target temperature.  Allowing overshoot results in faster time to target.

This code keeps the extruder heater on until within a settable value from the target temperature.  This minimizes time to the target temperature but also usually results in overshoot.  

There is a timeout in the code to keep the "overshoot feature" from kicking in within 2 minutes of the last time.  Without the timeout there is a danger that system would be in BANG-BANG mode permanently.