### PR TITLE
Custom config files for PlatformIO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,13 @@ applet/
 tags
 
 #
+# User configuration files
+#
+/config/user/*
+!/config/user/Configuration_example.h
+!/config/user/platformio.ini
+ 
+#
 # C++
 #
 # Compiled Object files

--- a/Marlin/src/inc/MarlinConfigPre.h
+++ b/Marlin/src/inc/MarlinConfigPre.h
@@ -56,3 +56,13 @@
 
 #include "Conditionals_adv.h"
 #include HAL_PATH(../HAL, inc/Conditionals_adv.h)
+
+#ifdef CUSTOM_CONFIG_FILE
+  #if defined(__has_include)
+    #if __has_include(XSTR(../../CUSTOM_CONFIG_FILE))
+      #include XSTR(../../CUSTOM_CONFIG_FILE)
+    #endif
+  #else
+    #include XSTR(../../CUSTOM_CONFIG_FILE)
+  #endif
+#endif

--- a/config/user/Configuration_example.h
+++ b/config/user/Configuration_example.h
@@ -1,0 +1,43 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/* This file is included after Configuration.h and Configuration_adv.h 
+ * Keep the Configuration.h as is and undef or define customizations 
+ * here.
+ * Include this file by setting the CUSTOM_CONFIG_FILE define in 
+ * platformio_user.ini
+ * 
+ * If you have multiple boards or configurations, like one for testing
+ * that disables from safety features and another one for production,
+ * you can have a separate Configuration_***.h file for each, and use
+ * platformio_user.ini to define multiple envs / build configurations
+ *
+ * NOTE: it would be nice if this file was included before Configuration.h
+ * and Configuration_adv.h, but then we should make sure that any #define
+ * in those files is surrounded by #ifndef/#endif
+ */
+
+#undef  STRING_CONFIG_H_AUTHOR
+#define STRING_CONFIG_H_AUTHOR "(none, --user config)"
+
+#error This is an example

--- a/config/user/platformio.ini
+++ b/config/user/platformio.ini
@@ -1,0 +1,5 @@
+[platformio]
+default_envs = megaatmega2560
+
+[extra]
+build_flags =  -D CUSTOM_CONFIG_FILE=../config/user/Configuration_example.h

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,6 +19,7 @@
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
 default_envs = megaatmega2560
+#extra_configs = config/user/platformio.ini
 
 [common]
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
@@ -40,8 +41,9 @@ lib_deps =
 # inherited by all environments
 [env]
 framework     = arduino
-build_flags   = ${common.build_flags}
-lib_deps      = ${common.lib_deps}
+build_flags   = ${common.build_flags} ${extra.build_flags}
+build_unflags = ${extra.build_unflags}
+lib_deps      = ${common.lib_deps} ${extra.lib_deps}
 monitor_speed = 250000
 
 #################################


### PR DESCRIPTION
### Description

This is a proposed solution for issue #16670 for PlatformIO. I don't use the arduino IDE so I don't know if this solution translates well to something that has to be implemented on that side.

### Benefits

Allows the user to have (multiple) configuration files outside of the source tree. Also, platformIO settings can be overridden outside of the main platformio.ini file and custom env:myboard can be added. Instead of changing the default_envs in patformio, you can change extra_configs and link to your own platformio.ini containing the customizations. You can set a define there for CUSTOM_CONFIG_FILE which is included after Configuration.h and Configuration_adv.h

Ideally it would be nice if it could be included before both those files, but that would need some extra work.
 
### Related Issues
#16670
