### PR TITLE
Add option to include Z position in M27 output

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1090,6 +1090,13 @@
   //#define AUTO_REPORT_SD_STATUS
 
   /**
+   * Report current Z layer height with M27. useful for showing current layer 
+   * height on serial host controller without the need of sending M114 or setting
+   * up M117 messages before each layer during printing.
+   */
+  //#define REPORT_CURRENT_LAYER_HEIGHT
+
+  /**
    * Support for USB thumb drives using an Arduino USB Host Shield or
    * equivalent MAX3421E breakout board. The USB thumb drive will appear
    * to Marlin as an SD card.

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -576,7 +576,13 @@ void CardReader::report_status() {
     SERIAL_ECHOPGM(MSG_SD_PRINTING_BYTE);
     SERIAL_ECHO(sdpos);
     SERIAL_CHAR('/');
-    SERIAL_ECHOLN(filesize);
+    #if ENABLED(REPORT_CURRENT_LAYER_HEIGHT)
+      SERIAL_ECHO(filesize);
+      const xyz_pos_t lpos = current_position.asLogical();
+      SERIAL_ECHOLNPAIR(" Z:", lpos.z);
+    #else
+      SERIAL_ECHOLN(filesize);
+    #endif
   }
   else
     SERIAL_ECHOLNPGM(MSG_SD_NOT_PRINTING);


### PR DESCRIPTION
### Description
Add option for reporting Current Z layer height with M27 command when printing through onboard SD Card.

### Benefits
Useful for showing current layer height on serial host controller without the need of sending M114 or setting up M117 messages before each layer during printing.