### PR TITLE
Re-Organize Serial Port Output

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -113,7 +113,6 @@
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
 //#define SERIAL_PORT_2 -1
-//#define ECHO_TO_FIRST_SERIAL_PORT
 
 /**
  * This setting determines the communication speed of the printer.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -113,6 +113,7 @@
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
 //#define SERIAL_PORT_2 -1
+//#define ECHO_TO_FIRST_SERIAL_PORT
 
 /**
  * This setting determines the communication speed of the printer.

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -29,7 +29,11 @@ static const char errormagic[] PROGMEM = "Error:";
 static const char echomagic[]  PROGMEM = "echo:";
 
 #if NUM_SERIAL > 1
-  int8_t serial_port_index = SERIAL_PORT;
+  #if defined(ECHO_TO_FIRST_SERIAL_PORT)
+    int8_t serial_port_index = 0;
+  #else
+    int8_t serial_port_index = SERIAL_PORT;
+  #endif
 #endif
 
 void serialprintPGM(PGM_P str) {

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -29,11 +29,7 @@ static const char errormagic[] PROGMEM = "Error:";
 static const char echomagic[]  PROGMEM = "echo:";
 
 #if NUM_SERIAL > 1
-  #if defined(ECHO_TO_FIRST_SERIAL_PORT)
-    int8_t serial_port_index = 0;
-  #else
-    int8_t serial_port_index = SERIAL_PORT;
-  #endif
+  int8_t serial_port_index = 0;
 #endif
 
 void serialprintPGM(PGM_P str) {

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -191,7 +191,6 @@ bool GCodeQueue::process_injected_command() {
   // Execute command if non-blank
   if (i) {
     parser.parse(cmd);
-    PORT_REDIRECT(SERIAL_PORT);
     gcode.process_parsed_command();
   }
   return true;

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -242,7 +242,7 @@ void GCodeQueue::ok_to_send() {
   #if NUM_SERIAL > 1
     const int16_t pn = port[index_r];
     if (pn < 0) return;
-    PORT_REDIRECT(pn);
+    PORT_REDIRECT(pn);                    // Reply to the serial port that sent the command
   #endif
   if (!send_ok[index_r]) return;
   SERIAL_ECHOPGM(MSG_OK);
@@ -266,9 +266,9 @@ void GCodeQueue::ok_to_send() {
  */
 void GCodeQueue::flush_and_request_resend() {
   #if NUM_SERIAL > 1
-    const int16_t p = port[index_r];
-    if (p < 0) return;
-    PORT_REDIRECT(p);
+    const int16_t pn = port[index_r];
+    if (pn < 0) return;
+    PORT_REDIRECT(pn);                    // Reply to the serial port that sent the command
   #endif
   SERIAL_FLUSH();
   SERIAL_ECHOPGM(MSG_RESEND);
@@ -295,14 +295,14 @@ inline int read_serial(const uint8_t index) {
   }
 }
 
-void GCodeQueue::gcode_line_error(PGM_P const err, const int8_t port) {
-  PORT_REDIRECT(port);
+void GCodeQueue::gcode_line_error(PGM_P const err, const int8_t pn) {
+  PORT_REDIRECT(pn);                      // Reply to the serial port that sent the command
   SERIAL_ERROR_START();
   serialprintPGM(err);
   SERIAL_ECHOLN(last_N);
-  while (read_serial(port) != -1);           // clear out the RX buffer
+  while (read_serial(pn) != -1);          // Clear out the RX buffer
   flush_and_request_resend();
-  serial_count[port] = 0;
+  serial_count[pn] = 0;
 }
 
 FORCE_INLINE bool is_M29(const char * const cmd) {  // matches "M29" & "M29 ", but not "M290", etc

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -150,7 +150,7 @@ private:
    */
   static bool enqueue_one(const char* cmd);
 
-  static void gcode_line_error(PGM_P const err, const int8_t port);
+  static void gcode_line_error(PGM_P const err, const int8_t pn);
 
 };
 


### PR DESCRIPTION
This PR create option to choose which serial port will be use as a HOST. By defining ECHO_TO_FIRST_SERIAL_PORT ,Marlin will Echo to SERIAL_PORT, (not SERIAL_PORT_2).

This done by 
- assign serial_port_index = 0
- remove PORT_REDIRECTION at injected_command.

The Result is in the table below 

![image](https://user-images.githubusercontent.com/4693418/73145157-80709280-40de-11ea-9b3d-8fc097a609a7.png)

![image](https://user-images.githubusercontent.com/4693418/73145169-9a11da00-40de-11ea-85dc-06098e83f12a.png)

This is usefull if we want to use MSerial for Extensible_UI which can also send GCODE command and UsbSerial for Octoprint.