### PR TITLE
Fix  manual mesh leveling with multiple extruders

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -332,9 +332,6 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
         case 76: G76(); break;                                    // G76: Calibrate first layer compensation values
       #endif
 
-      case 60: G60(); break;                                      // G60:  save current position
-      case 61: G61(); break;                                      // G61:  Apply/restore saved coordinates.
-
       #if ENABLED(GCODE_MOTION_MODES)
         case 80: G80(); break;                                    // G80: Reset the current motion mode
       #endif

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -119,7 +119,7 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
           SUBMENU_N_P(s, msg, []{ _menu_temp_filament_op(PAUSE_MODE_CHANGE_FILAMENT, MenuItemBase::itemIndex); });
         else {
           ACTION_ITEM_N_P(s, msg, []{
-            char cmd[12];
+            char cmd[13];
             sprintf_P(cmd, PSTR("M600 B0 T%i"), int(MenuItemBase::itemIndex));
             lcd_enqueue_one_now(cmd);
           });

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -821,10 +821,6 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("No move (not homed)");
     }
 
-    #if HAS_LCD_MENU
-      ui.return_to_status();
-    #endif
-
     #if ENABLED(DUAL_X_CARRIAGE)
       const bool idex_full_control = dual_x_carriage_mode == DXC_FULL_CONTROL_MODE;
     #else


### PR DESCRIPTION
### Description

Manual mesh leveling  has been broken for machines with multiple extruders. The problem is that the tool_change function issues a call to return to the status screen, which bypasses the leveling process.

I didn't see a compelling reason for `tool_change()` to change the active menu, so simply removing that call solves the problem.

An alternate solution was to change `MarlinUI::return_to_status()` to do nothing if `MarlinUI::defer_return_to_status` is set. This seemed to alter the intent of `defer_return_to_status`, and also increased the risk of side effects impacting other features.

### Benefits

Resolves issue preventing manual mesh leveling from working with multiple extruders.

### Related Issues

#13591 
#13181 
#13655
#16614 
#16458
