### PR TITLE
Prevent SD access from resetting ESP32

### DIFF
--- a/Marlin/src/sd/SdVolume.cpp
+++ b/Marlin/src/sd/SdVolume.cpp
@@ -291,6 +291,15 @@ int32_t SdVolume::freeClusterCount() {
       for (uint16_t i = 0; i < n; i++)
         if (cacheBuffer_.fat32[i] == 0) free++;
     }
+    #if defined(ESP32)
+      // Needed in order to reset the idle task watchdog timer on the ESP32 as reading the complete FAT may easily 
+      // block for 10+ seconds. yield() is not sufficient here as it will not let lower prio tasks (i.e. idle) run.
+      static uint32_t lastTaskDelay = 0;
+      if (millis() - lastTaskDelay > 1000) {
+        vTaskDelay(1); // delay 1 tick (minimum amount, usually 10 or 1 ms depending on skdconfig.h)
+        lastTaskDelay = millis();
+      }
+    #endif // ESP32
   }
   return free;
 }

--- a/Marlin/src/sd/SdVolume.cpp
+++ b/Marlin/src/sd/SdVolume.cpp
@@ -291,13 +291,14 @@ int32_t SdVolume::freeClusterCount() {
       for (uint16_t i = 0; i < n; i++)
         if (cacheBuffer_.fat32[i] == 0) free++;
     }
-    #if defined(ESP32)
-      // Needed in order to reset the idle task watchdog timer on the ESP32 as reading the complete FAT may easily 
-      // block for 10+ seconds. yield() is not sufficient here as it will not let lower prio tasks (i.e. idle) run.
-      static uint32_t lastTaskDelay = 0;
-      if (millis() - lastTaskDelay > 1000) {
-        vTaskDelay(1); // delay 1 tick (minimum amount, usually 10 or 1 ms depending on skdconfig.h)
-        lastTaskDelay = millis();
+    #ifdef ESP32
+      // Needed to reset the idle task watchdog timer on ESP32 as reading the complete FAT may easily 
+      // block for 10+ seconds. yield() is insufficient since it blocks lower prio tasks (e.g., idle).
+      static millis_t nextTaskTime = 0;
+      const millis_t ms = millis();
+      if (ELAPSED(ms, nextTaskTime) {
+        vTaskDelay(1);            // delay 1 tick (Minimum. Usually 10 or 1 ms depending on skdconfig.h)
+        nextTaskTime = ms + 1000; // tickle the task manager again in 1 second
       }
     #endif // ESP32
   }


### PR DESCRIPTION
### Description
`SdVolume::freeClusterCount()` (apparently not used inside Marlin but by https://github.com/luc-github/ESP3DLib) can easily block for 10+ seconds on first run reading all FAT sectors from SD to calculate free cluster count. This triggers the ESP32 idle task watchdog timer causing Marlin to reboot.

### Benefits
Delay for 1 tick every 1 second to let idle task run - no reboots anymore.

### Related Issues
https://github.com/luc-github/ESP3DLib/issues/7