### PR TITLE
Fix M48 build

### DIFF
--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -54,7 +54,7 @@
  * This function requires the machine to be homed before invocation.
  */
 
-extern const char SP_X_STR[], SP_Y_STR[], SP_Z_STR[];
+extern const char SP_Y_STR[];
 
 void GcodeSuite::M48() {
 

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -53,6 +53,9 @@
  *
  * This function requires the machine to be homed before invocation.
  */
+
+extern const char SP_X_STR[], SP_Y_STR[], SP_Z_STR[];
+
 void GcodeSuite::M48() {
 
   if (axis_unhomed_error()) return;


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

This fixes the following build issue:

```
In file included from Marlin/src/gcode/calibrate/../../inc/MarlinConfig.h:45,
                 from Marlin/src/gcode/calibrate/M48.cpp:23:
Marlin/src/gcode/calibrate/M48.cpp: In static member function 'static void GcodeSuite::M48()':
Marlin/src/gcode/calibrate/M48.cpp:187:66: error: 'SP_Y_STR' was not declared in this scope
             SERIAL_ECHOLNPAIR_P(PSTR("Going to: X"), next_pos.x, SP_Y_STR, next_pos.y);
```

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
