### PR TITLE
Update to Bugfix 2.0.x #16619

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -29,7 +29,7 @@
  * For Stallguard homing to max swap the min / max pins so
  * the MAX physical connectors can be used for other things.
  */
-#if X_HOME_DIR == -1 || !X_STALL_SENSITIVITY
+#if defined(USE_XMAX_PLUG) || X_HOME_DIR == -1 || !X_STALL_SENSITIVITY
   #define X_MIN_PIN          P1_29   // X_MIN
   #define X_MAX_PIN          P1_28   // X_MAX
 #else
@@ -37,7 +37,7 @@
   #define X_MAX_PIN          P1_29   // X_MIN
 #endif
 
-#if Y_HOME_DIR == -1 || !Y_STALL_SENSITIVITY
+#if defined(USE_YMAX_PLUG) || Y_HOME_DIR == -1 || !Y_STALL_SENSITIVITY
   #define Y_MIN_PIN          P1_27   // Y_MIN
   #define Y_MAX_PIN          P1_26   // Y_MAX
 #else
@@ -45,7 +45,7 @@
   #define Y_MAX_PIN          P1_27   // Y_MIN
 #endif
 
-#if Z_HOME_DIR == -1 || !Z_STALL_SENSITIVITY
+#if defined(USE_ZMAX_PLUG) || Z_HOME_DIR == -1 || !Z_STALL_SENSITIVITY
   #define Z_MIN_PIN          P1_25   // Z_MIN
   #define Z_MAX_PIN          P1_24   // Z_MAX
 #else

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -25,32 +25,31 @@
 
 /**
  * Limit Switches
- *
- * For Stallguard homing to max swap the min / max pins so
- * the MAX physical connectors can be used for other things.
  */
-#if defined(USE_XMAX_PLUG) || X_HOME_DIR == -1 || !X_STALL_SENSITIVITY
+#if X_HOME_DIR > 0 && X_STALL_SENSITIVITY && !defined(USE_XMAX_PLUG)
+  // For StallGuard homing to MAX swap the MIN / MAX pins
+  // so the MAX physical connectors may be used for other things.
+  #define X_MIN_PIN          P1_28   // X_MAX (free)
+  #define X_MAX_PIN          P1_29   // X_MIN
+#else                                // else, non-endstop is free and appears in M43 output
   #define X_MIN_PIN          P1_29   // X_MIN
   #define X_MAX_PIN          P1_28   // X_MAX
-#else
-  #define X_MIN_PIN          P1_28   // X_MAX
-  #define X_MAX_PIN          P1_29   // X_MIN
 #endif
 
-#if defined(USE_YMAX_PLUG) || Y_HOME_DIR == -1 || !Y_STALL_SENSITIVITY
+#if Y_HOME_DIR > 0 && Y_STALL_SENSITIVITY && !defined(USE_YMAX_PLUG)
+  #define Y_MIN_PIN          P1_26   // Y_MAX (free)
+  #define Y_MAX_PIN          P1_27   // Y_MIN
+#else
   #define Y_MIN_PIN          P1_27   // Y_MIN
   #define Y_MAX_PIN          P1_26   // Y_MAX
-#else
-  #define Y_MIN_PIN          P1_26   // Y_MAX
-  #define Y_MAX_PIN          P1_27   // Y_MIN
 #endif
 
-#if defined(USE_ZMAX_PLUG) || Z_HOME_DIR == -1 || !Z_STALL_SENSITIVITY
+#if Z_HOME_DIR > 0 && Z_STALL_SENSITIVITY && !defined(USE_ZMAX_PLUG)
+  #define Z_MIN_PIN          P1_24   // Z_MAX (free)
+  #define Z_MAX_PIN          P1_25   // Z_MIN
+#else
   #define Z_MIN_PIN          P1_25   // Z_MIN
   #define Z_MAX_PIN          P1_24   // Z_MAX
-#else
-  #define Z_MIN_PIN          P1_24   // Z_MAX
-  #define Z_MAX_PIN          P1_25   // Z_MIN
 #endif
 
 #define ONBOARD_ENDSTOPPULLUPS     // Board has built-in pullups

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -25,27 +25,34 @@
 
 /**
  * Limit Switches
+ * 
+ * For StallGuard if you home to MAX, swap the MIN / MAX pins over. 
+ * This is require as StallGuard is physically wired to MIN pins only.
  */
-#if X_HOME_DIR > 0 && X_STALL_SENSITIVITY && !defined(USE_XMAX_PLUG)
-  // For StallGuard homing to MAX swap the MIN / MAX pins
-  // so the MAX physical connectors may be used for other things.
-  #define X_MIN_PIN          P1_28   // X_MAX (free)
+
+// For the rare instances you don't want the pins swapped over.
+// #define X_NO_SWAP  
+// #define Y_NO_SWAP  
+// #define Z_NO_SWAP  
+
+#if X_HOME_DIR > 0 && X_STALL_SENSITIVITY && !defined(X_NO_SWAP)
+  #define X_MIN_PIN          P1_28   // X_MAX
   #define X_MAX_PIN          P1_29   // X_MIN
-#else                                // else, non-endstop is free and appears in M43 output
+#else
   #define X_MIN_PIN          P1_29   // X_MIN
   #define X_MAX_PIN          P1_28   // X_MAX
 #endif
 
-#if Y_HOME_DIR > 0 && Y_STALL_SENSITIVITY && !defined(USE_YMAX_PLUG)
-  #define Y_MIN_PIN          P1_26   // Y_MAX (free)
+#if Y_HOME_DIR > 0 && Y_STALL_SENSITIVITY && !defined(Y_NO_SWAP)
+  #define Y_MIN_PIN          P1_26   // Y_MAX
   #define Y_MAX_PIN          P1_27   // Y_MIN
 #else
   #define Y_MIN_PIN          P1_27   // Y_MIN
   #define Y_MAX_PIN          P1_26   // Y_MAX
 #endif
 
-#if Z_HOME_DIR > 0 && Z_STALL_SENSITIVITY && !defined(USE_ZMAX_PLUG)
-  #define Z_MIN_PIN          P1_24   // Z_MAX (free)
+#if Z_HOME_DIR > 0 && Z_STALL_SENSITIVITY && !defined(Z_NO_SWAP)
+  #define Z_MIN_PIN          P1_24   // Z_MAX 
   #define Z_MAX_PIN          P1_25   // Z_MIN
 #else
   #define Z_MIN_PIN          P1_25   // Z_MIN


### PR DESCRIPTION
### Requirements

MOTHERBOARD BOARD_BIGTREE_SKR_V1_3
Home direction 1 for at least one axis.
enable SENSORLESS_HOMING
enable a TMC driver with SENSORLESS_HOMING

### Description

This is a update to PR #16659 
The current test is 
`if {X|Y|Z}HOME_DIR > 0 && {X|Y|Z}STALL_SENSITIVITY && !defined(USE{X|Y|Z}MAX_PLUG)`
the idea being that if USE{X|Y|Z}MAX_PLUG is defined they also have endstops on real ZMAX_PLUG and not swap the pins.

## But 
Marlin will not let you home to 1 without setting USE_{X|Y|Z}MAX_PLUG. so this test always fails. The result is that now MIN and MAX never swap over. This is an issue for anyone who need to home to max using SENSORLESS_HOMING. 

I have removed the MAX_PLUG part of the test and added a simple flag {X|Y|Z}_NO_SWAP  to override pin swapping in obscure cases where it may be needed. 

### Benefits

MIN and MAX pin swap as needed and swapping can be disabled if required. 

### Related Issues
#16619 
#16677
