### PR TITLE
Fix G60/G61 slots > 8 and compile error

### DIFF
--- a/Marlin/src/gcode/feature/pause/G60.cpp
+++ b/Marlin/src/gcode/feature/pause/G60.cpp
@@ -45,7 +45,7 @@ void GcodeSuite::G60() {
   }
 
   stored_position[slot] = current_position;
-  SBI(saved_slots, slot);
+  SBI(saved_slots[slot >> 3], slot & 0b00000111);
 
   #if ENABLED(SAVED_POSITIONS_DEBUG)
     const xyze_pos_t &pos = stored_position[slot];

--- a/Marlin/src/gcode/feature/pause/G61.cpp
+++ b/Marlin/src/gcode/feature/pause/G61.cpp
@@ -25,7 +25,7 @@
 #if SAVED_POSITIONS
 
 #include "../../../core/language.h"
-#include "../../module/planner.h"
+#include "../../../module/planner.h"
 #include "../../gcode.h"
 #include "../../../module/motion.h"
 
@@ -48,7 +48,7 @@ void GcodeSuite::G61(void) {
   #endif
 
   // No saved position? No axes being restored?
-  if (!TEST(saved_slots, slot) || !parser.seen("XYZ")) return;
+  if (!TEST(saved_slots[slot >> 3], slot & 0b00000111) || !parser.seen("XYZ")) return;
 
   // Apply any given feedrate over 0.0
   const float fr = parser.linearval('F');

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -111,7 +111,7 @@ xyze_pos_t destination; // {0}
 
 // G60/G61 Position Save and Return
 #if SAVED_POSITIONS
-  uint8_t saved_slots[(SAVED_POSITIONS >> 3) + 1];
+  uint8_t saved_slots[(SAVED_POSITIONS + 7) >> 3];
   xyz_pos_t stored_position[SAVED_POSITIONS];
 #endif
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -111,7 +111,7 @@ xyze_pos_t destination; // {0}
 
 // G60/G61 Position Save and Return
 #if SAVED_POSITIONS
-  uint8_t saved_slots;
+  uint8_t saved_slots[(SAVED_POSITIONS >> 3) + 1];
   xyz_pos_t stored_position[SAVED_POSITIONS];
 #endif
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -67,7 +67,7 @@ extern xyze_pos_t current_position,  // High-level current tool position
 
 // G60/G61 Position Save and Return
 #if SAVED_POSITIONS
-  extern uint8_t saved_slots;
+  extern uint8_t saved_slots[(SAVED_POSITIONS >> 3) + 1];
   extern xyz_pos_t stored_position[SAVED_POSITIONS];
 #endif
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -67,7 +67,7 @@ extern xyze_pos_t current_position,  // High-level current tool position
 
 // G60/G61 Position Save and Return
 #if SAVED_POSITIONS
-  extern uint8_t saved_slots[(SAVED_POSITIONS >> 3) + 1];
+  extern uint8_t saved_slots[(SAVED_POSITIONS + 7) >> 3];
   extern xyz_pos_t stored_position[SAVED_POSITIONS];
 #endif
 


### PR DESCRIPTION
### Description

The new G60/G61 only works for the first 8 slots.
I discovered this by reading the code and tested to be sure.

This PR tries to fix the code, so that all slots should work.
I tested up to 64 slots on my printer.

**Please note that this is the first time I am doing this (github PR/marlin/c++).
Please review the proposed changes carefully.**

Attached file contains a test gcode scripts and the LINQPad query used to generate the gcode.
[G60Test.zip](https://github.com/MarlinFirmware/Marlin/files/4128144/G60Test.zip)

### Benefits

Fixes the G60/G61 commands

### Related Issues

None that I am aware of.
