### PR TITLE
Fix probe temp calibration

### DIFF
--- a/Marlin/src/feature/probe_temp_compensation.h
+++ b/Marlin/src/feature/probe_temp_compensation.h
@@ -48,10 +48,10 @@ class ProbeTempComp {
   public:
 
     static constexpr temp_calib_t cali_info_init[TSI_COUNT] = {
-        {  10,  5, 30,  30 + 10 *  5 },       // Probe
-        {  10,  5, 60,  60 + 10 *  5 },       // Bed
+        {  10,  5,  30,  30 + 10 *  5 },       // Probe
+        {  10,  5,  60,  60 + 10 *  5 },       // Bed
       #if ENABLED(USE_TEMP_EXT_COMPENSATION)
-        {  20,  5, 180, 180 + 5 * 20 }        // Extruder
+        {  20,  5, 180, 180 +  5 * 20 }        // Extruder
       #endif
     };
     static const temp_calib_t cali_info[TSI_COUNT];

--- a/Marlin/src/feature/probe_temp_compensation.h
+++ b/Marlin/src/feature/probe_temp_compensation.h
@@ -48,10 +48,10 @@ class ProbeTempComp {
   public:
 
     static constexpr temp_calib_t cali_info_init[TSI_COUNT] = {
-        {  30, 10,  5,  30 + 10 *  5 },       // Probe
-        {  60, 10,  5,  60 + 10 *  5 },       // Bed
+        {  10,  5, 30,  30 + 10 *  5 },       // Probe
+        {  10,  5, 60,  60 + 10 *  5 },       // Bed
       #if ENABLED(USE_TEMP_EXT_COMPENSATION)
-        { 180,  5, 20, 180 +  5 * 20 }        // Extruder
+        {  20,  5, 180, 180 + 5 * 20 }        // Extruder
       #endif
     };
     static const temp_calib_t cali_info[TSI_COUNT];

--- a/Marlin/src/gcode/calibrate/G76_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M871.cpp
@@ -256,7 +256,7 @@ void GcodeSuite::G76() {
 
     // Initialize temperatures
     uint16_t target_bed = temp_comp.probe_calib_bed_temp,
-             target_probe = temp_comp.cali_info_init[TSI_BED].start_temp;
+             target_probe = temp_comp.cali_info_init[TSI_PROBE].start_temp;
     thermalManager.setTargetBed(target_bed);
     SERIAL_ECHOLNPGM("Waiting for bed and probe temperature.");
     while (fabs(thermalManager.degBed() - float(target_bed)) > 0.1f
@@ -332,13 +332,13 @@ void GcodeSuite::G76() {
       else
         SERIAL_ECHOLNPAIR_F("Measured: ", measured_z);
 
-      if (target_probe == temp_comp.cali_info_init[TSI_BED].start_temp)
+      if (target_probe == temp_comp.cali_info_init[TSI_PROBE].start_temp)
         temp_comp.prepare_new_calibration(measured_z);
       else
         temp_comp.push_back_new_measurement(TSI_PROBE, measured_z);
 
-      target_probe += temp_comp.cali_info_init[TSI_BED].temp_res;
-      if (target_probe > temp_comp.cali_info_init[TSI_BED].end_temp) break;
+      target_probe += temp_comp.cali_info_init[TSI_PROBE].temp_res;
+      if (target_probe > temp_comp.cali_info_init[TSI_PROBE].end_temp) break;
     }
 
     SERIAL_ECHOLNPAIR("Retrieved measurements: ", temp_comp.get_index());


### PR DESCRIPTION
Fix 'waiting for printer to cool down' bug

### Requirements

* Having a probe like P.I.N.D.A v2

### Description

This fix allow users to perform probe temperature calibration.
Array values ​​are in the wrong place
<!--


-->

### Benefits

<!-- What does this fix or improve? -->
Users can perform a G76 without error
### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
#16711 