### PR TITLE
Refactor heater watch, job timer auto-start

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -564,7 +564,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
       #endif
 
       // Re-enable the heaters if they timed out
-      HOTEND_LOOP() thermalManager.reset_heater_idle_timer(e);
+      HOTEND_LOOP() thermalManager.reset_hotend_idle_timer(e);
 
       // Wait for the heaters to reach the target temperatures
       ensure_safe_temperature();
@@ -633,7 +633,7 @@ void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_le
   bool nozzle_timed_out = false;
   HOTEND_LOOP() {
     nozzle_timed_out |= thermalManager.hotend_idle[e].timed_out;
-    thermalManager.reset_heater_idle_timer(e);
+    thermalManager.reset_hotend_idle_timer(e);
   }
 
   if (nozzle_timed_out || thermalManager.hotEnoughToExtrude(active_extruder)) // Load the new filament

--- a/Marlin/src/gcode/temperature/M104_M109.cpp
+++ b/Marlin/src/gcode/temperature/M104_M109.cpp
@@ -20,6 +20,12 @@
  *
  */
 
+/**
+ * gcode/temperature/M104_M109.cpp
+ *
+ * Hotend target temperature control
+ */
+
 #include "../../inc/MarlinConfigPre.h"
 
 #if EXTRUDERS
@@ -73,14 +79,11 @@ void GcodeSuite::M104() {
     #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
       /**
        * Stop the timer at the end of print. Start is managed by 'heat and wait' M109.
-       * We use half EXTRUDE_MINTEMP here to allow nozzles to be put into hot
-       * standby mode, for instance in a dual extruder setup, without affecting
-       * the running print timer.
+       * Hotends use EXTRUDE_MINTEMP / 2 to allow nozzles to be put into hot standby
+       * mode, for instance in a dual extruder setup, without affecting the running
+       * print timer.
        */
-      if (temp <= (EXTRUDE_MINTEMP) / 2) {
-        print_job_timer.stop();
-        ui.reset_status();
-      }
+      thermalManager.check_timer_autostart(false, true);
     #endif
   }
 
@@ -90,8 +93,10 @@ void GcodeSuite::M104() {
 }
 
 /**
- * M109: Sxxx Wait for extruder(s) to reach temperature. Waits only when heating.
- *       Rxxx Wait for extruder(s) to reach temperature. Waits when heating and cooling.
+ * M109: Sxxx Wait for hotend(s) to reach temperature. Waits only when heating.
+ *       Rxxx Wait for hotend(s) to reach temperature. Waits when heating and cooling.
+ *
+ * With PRINTJOB_TIMER_AUTOSTART also start the job timer on heating and stop it if turned off.
  */
 void GcodeSuite::M109() {
 
@@ -125,12 +130,7 @@ void GcodeSuite::M109() {
        * standby mode, (e.g., in a dual extruder setup) without affecting
        * the running print timer.
        */
-      if (parser.value_celsius() <= (EXTRUDE_MINTEMP) / 2) {
-        print_job_timer.stop();
-        ui.reset_status();
-      }
-      else
-        startOrResumeJob();
+      thermalManager.check_timer_autostart(true, true);
     #endif
 
     #if HAS_DISPLAY

--- a/Marlin/src/gcode/temperature/M140_M190.cpp
+++ b/Marlin/src/gcode/temperature/M140_M190.cpp
@@ -20,6 +20,12 @@
  *
  */
 
+/**
+ * gcode/temperature/M140_M190.cpp
+ *
+ * Bed target temperature control
+ */
+
 #include "../../inc/MarlinConfig.h"
 
 #if HAS_HEATED_BED
@@ -50,6 +56,8 @@ void GcodeSuite::M140() {
 /**
  * M190: Sxxx Wait for bed current temp to reach target temp. Waits only when heating
  *       Rxxx Wait for bed current temp to reach target temp. Waits when heating and cooling
+ *
+ * With PRINTJOB_TIMER_AUTOSTART also start the job timer on heating.
  */
 void GcodeSuite::M190() {
   if (DEBUGGING(DRYRUN)) return;
@@ -58,8 +66,7 @@ void GcodeSuite::M190() {
   if (no_wait_for_cooling || parser.seenval('R')) {
     thermalManager.setTargetBed(parser.value_celsius());
     #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
-      if (parser.value_celsius() > BED_MINTEMP)
-        startOrResumeJob();
+      thermalManager.check_timer_autostart(true, false);
     #endif
   }
   else return;

--- a/Marlin/src/gcode/temperature/M141_M191.cpp
+++ b/Marlin/src/gcode/temperature/M141_M191.cpp
@@ -20,6 +20,12 @@
  *
  */
 
+/**
+ * gcode/temperature/M141_M191.cpp
+ *
+ * Chamber target temperature control
+ */
+
 #include "../../inc/MarlinConfig.h"
 
 #if HAS_HEATED_CHAMBER
@@ -59,8 +65,7 @@ void GcodeSuite::M191() {
   if (no_wait_for_cooling || parser.seenval('R')) {
     thermalManager.setTargetChamber(parser.value_celsius());
     #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
-      if (parser.value_celsius() > CHAMBER_MINTEMP)
-        startOrResumeJob();
+      thermalManager.check_timer_autostart(true, false);
     #endif
   }
   else return;

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -171,7 +171,7 @@ namespace ExtUI {
 
   void enableHeater(const extruder_t extruder) {
     #if HOTENDS && HEATER_IDLE_HANDLER
-      thermalManager.reset_heater_idle_timer(extruder - E0);
+      thermalManager.reset_hotend_idle_timer(extruder - E0);
     #else
       UNUSED(extruder);
     #endif
@@ -190,7 +190,7 @@ namespace ExtUI {
         #endif
         default:
           #if HOTENDS
-            thermalManager.reset_heater_idle_timer(heater - H0);
+            thermalManager.reset_hotend_idle_timer(heater - H0);
           #endif
           break;
       }


### PR DESCRIPTION
Common logic for heater watch and start/stop the print job timer can be consolidated and moved into the `Temperature` class. The job timer code is simplified so it's easier to choose to consider all the heaters when deciding whether or not to start or suspend the print job timer.