### PR TITLE
Multiple endstops on BTT SKR 1.4 / 1.4 Turbo

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -72,6 +72,31 @@
 #endif
 
 //
+// Extra Remaps for more limit switches
+// Enable over "Configuration.h" after board definition
+// (XMin and XMax, YMin and YMax and/or ZMin and ZMax)
+//
+#ifdef ENABLE_XMAX_PIN
+    #define X_MIN_PIN         P1_29
+    #define X_MAX_PIN         P1_26
+    #undef X_STOP_PIN
+    #undef FIL_RUNOUT_PIN
+#endif
+#ifdef ENABLE_YMAX_PIN
+    #define Y_MIN_PIN         P1_28
+    #define Y_MAX_PIN         P1_25
+    #undef Y_STOP_PIN
+    #undef FIL_RUNOUT2_PIN
+#endif
+#ifdef ENABLE_ZMAX_PIN
+    #define Z_MIN_PIN         P1_27
+    #define Z_MAX_PIN         P1_00
+    #undef Z_STOP_PIN
+    #undef PS_ON_PIN
+	#undef POWER_LOSS_PIN
+#endif
+
+//
 // Steppers
 //
 #define X_STEP_PIN         P2_02

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -38,11 +38,52 @@
 #define SERVO0_PIN         P2_00
 
 //
+// TMC StallGuard DIAG pins
+//
+#define X_DIAG_PIN         P1_29   // X-STOP
+#define Y_DIAG_PIN         P1_28   // Y-STOP
+#define Z_DIAG_PIN         P1_27   // Z-STOP
+#define E0_DIAG_PIN        P1_26   // E0DET
+#define E1_DIAG_PIN        P1_25   // E1DET
+
+//
 // Limit Switches
 //
-#define X_STOP_PIN         P1_29
-#define Y_STOP_PIN         P1_28
-#define Z_STOP_PIN         P1_27
+#if X_STALL_SENSITIVITY
+  #if X_HOME_DIR < 0
+    #define X_MIN_PIN      X_DIAG_PIN
+    #define X_MAX_PIN      P1_26   // E0DET
+  #else
+    #define X_MAX_PIN      X_DIAG_PIN
+    #define X_MIN_PIN      P1_26   // E0DET
+  #endif
+#else
+  #define X_STOP_PIN       P1_29   // X-STOP
+#endif
+
+#if Y_STALL_SENSITIVITY
+  #if Y_HOME_DIR < 0
+    #define Y_MIN_PIN      Y_DIAG_PIN
+    #define Y_MAX_PIN      P1_25   // E1DET
+  #else
+    #define Y_MAX_PIN      Y_DIAG_PIN
+    #define Y_MIN_PIN      P1_25   // E1DET
+  #endif
+#else
+  #define Y_STOP_PIN       P1_28   // Y-STOP
+#endif
+
+#if Z_STALL_SENSITIVITY
+  #if Z_HOME_DIR < 0
+    #define Z_MIN_PIN      Z_DIAG_PIN
+    #define Z_MAX_PIN      P1_24   // PWRDET
+  #else
+    #define Z_MAX_PIN      Z_DIAG_PIN
+    #define Z_MIN_PIN      P1_24   // PWRDET
+  #endif
+#else
+  #define Z_STOP_PIN       P1_27   // Z-STOP
+#endif
 
 //
 // Z Probe (when not Z_MIN_PIN)
@@ -54,46 +95,21 @@
 //
 // Filament Runout Sensor
 //
-#define FIL_RUNOUT_PIN     P1_26
-#define FIL_RUNOUT2_PIN    P1_25
+#define FIL_RUNOUT_PIN     P1_26   // E0DET
+#define FIL_RUNOUT2_PIN    P1_25   // E1DET
 
 //
 // Power Supply Control
 //
 #ifndef PS_ON_PIN
-  #define PS_ON_PIN        P1_00
+  #define PS_ON_PIN        P1_00   // PWRDET
 #endif
 
 //
 // Power Loss Detection
 //
 #ifndef POWER_LOSS_PIN
-  #define POWER_LOSS_PIN   P1_00
-#endif
-
-//
-// Extra Remaps for more limit switches
-// Enable over "Configuration.h" after board definition
-// (XMin and XMax, YMin and YMax and/or ZMin and ZMax)
-//
-#ifdef ENABLE_XMAX_PIN
-  #define X_MIN_PIN        P1_29   // X-Stop
-  #define X_MAX_PIN        P1_26   // Runout 1
-  #undef X_STOP_PIN
-  #undef FIL_RUNOUT_PIN
-#endif
-#ifdef ENABLE_YMAX_PIN
-  #define Y_MIN_PIN        P1_28   // Y-Stop
-  #define Y_MAX_PIN        P1_25   // Runout 2
-  #undef Y_STOP_PIN
-  #undef FIL_RUNOUT2_PIN
-#endif
-#ifdef ENABLE_ZMAX_PIN
-  #define Z_MIN_PIN        P1_27   // Z-Stop
-  #define Z_MAX_PIN        P1_00   // PS-ON / Power-Loss
-  #undef Z_STOP_PIN
-  #undef PS_ON_PIN
-  #undef POWER_LOSS_PIN
+  #define POWER_LOSS_PIN   P1_00   // PWRDET
 #endif
 
 //

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -77,23 +77,23 @@
 // (XMin and XMax, YMin and YMax and/or ZMin and ZMax)
 //
 #ifdef ENABLE_XMAX_PIN
-    #define X_MIN_PIN         P1_29
-    #define X_MAX_PIN         P1_26
-    #undef X_STOP_PIN
-    #undef FIL_RUNOUT_PIN
+  #define X_MIN_PIN        P1_29   // X-Stop
+  #define X_MAX_PIN        P1_26   // Runout 1
+  #undef X_STOP_PIN
+  #undef FIL_RUNOUT_PIN
 #endif
 #ifdef ENABLE_YMAX_PIN
-    #define Y_MIN_PIN         P1_28
-    #define Y_MAX_PIN         P1_25
-    #undef Y_STOP_PIN
-    #undef FIL_RUNOUT2_PIN
+  #define Y_MIN_PIN        P1_28   // Y-Stop
+  #define Y_MAX_PIN        P1_25   // Runout 2
+  #undef Y_STOP_PIN
+  #undef FIL_RUNOUT2_PIN
 #endif
 #ifdef ENABLE_ZMAX_PIN
-    #define Z_MIN_PIN         P1_27
-    #define Z_MAX_PIN         P1_00
-    #undef Z_STOP_PIN
-    #undef PS_ON_PIN
-	#undef POWER_LOSS_PIN
+  #define Z_MIN_PIN        P1_27   // Z-Stop
+  #define Z_MAX_PIN        P1_00   // PS-ON / Power-Loss
+  #undef Z_STOP_PIN
+  #undef PS_ON_PIN
+  #undef POWER_LOSS_PIN
 #endif
 
 //


### PR DESCRIPTION
### Requirements
Bigtreetech SKR 1.4/1.4 Turbo multiply endstops usage

### Description
Bigtreetech board has defined only 3 endstop pins. If more needed (eg. when dual endstops needed) you have to change the pins directly in the file, because the pins are used for 3 other functions.
The definition of X_STOP_PIN, Y_STOP_PIN and Z_STOP_PIN also prevents to set an these es limit switches and has to be defined as MIN pins. 

### Benefits
When set in Configuration.h per define (ENABLE_XMAX_PIN, ENABLE_YMAX_PIN and/or ENABLE_ZMAX_PIN) the previous definitions disabled and MIN_PIN/MAX_PIN for endtsops are set correctly
