### PR TITLE
Simultaneous use of rotary encoder and touch buttons

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -779,7 +779,7 @@ void MarlinUI::update() {
     #if ENABLED(TOUCH_BUTTONS)
       if (touch_buttons) {
         RESET_STATUS_TIMEOUT();
-        if (touch_buttons & (EN_A | EN_B)) {                    // Menu arrows, in priority
+        if (touch_buttons & (EN_A | EN_B)) {              // Menu arrows, in priority
           if (ELAPSED(ms, next_button_update_ms)) {
             encoderDiff = (ENCODER_STEPS_PER_MENU_ITEM) * (ENCODER_PULSES_PER_STEP) * encoderDirection;
             if (touch_buttons & EN_A) encoderDiff *= -1;

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1245,11 +1245,11 @@ void MarlinUI::update() {
             | slow_buttons
           #endif
           #if ENABLED(TOUCH_BUTTONS) && HAS_ENCODER_ACTION
-            #if HAS_ENCODER_WHEEL
-              | (touch_buttons & (~(EN_A | EN_B)))
-            #else
-              | touch_buttons
-            #endif
+            | (touch_buttons
+              #if HAS_ENCODER_WHEEL
+                & (~(EN_A | EN_B))
+              #endif
+            )
           #endif
         );
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -777,13 +777,12 @@ void MarlinUI::update() {
     static bool wait_for_unclick; // = false
 
     #if ENABLED(TOUCH_BUTTONS)
-
       if (touch_buttons) {
         RESET_STATUS_TIMEOUT();
-        if (buttons & (EN_A | EN_B)) {                    // Menu arrows, in priority
+        if (touch_buttons & (EN_A | EN_B)) {                    // Menu arrows, in priority
           if (ELAPSED(ms, next_button_update_ms)) {
             encoderDiff = (ENCODER_STEPS_PER_MENU_ITEM) * (ENCODER_PULSES_PER_STEP) * encoderDirection;
-            if (buttons & EN_A) encoderDiff *= -1;
+            if (touch_buttons & EN_A) encoderDiff *= -1;
             #if ENABLED(AUTO_BED_LEVELING_UBL)
               if (external_control) ubl.encoder_diff = encoderDiff;
             #endif
@@ -1246,7 +1245,11 @@ void MarlinUI::update() {
             | slow_buttons
           #endif
           #if ENABLED(TOUCH_BUTTONS) && HAS_ENCODER_ACTION
-            | touch_buttons
+            #if HAS_ENCODER_WHEEL
+              | (touch_buttons & (~(EN_A | EN_B)))
+            #else
+              | touch_buttons
+            #endif
           #endif
         );
 
@@ -1277,7 +1280,7 @@ void MarlinUI::update() {
 
     } // next_button_update_ms
 
-    #if HAS_ENCODER_WHEEL && DISABLED(TOUCH_BUTTONS)
+    #if HAS_ENCODER_WHEEL
       static uint8_t lastEncoderBits;
 
       #define encrot0 0


### PR DESCRIPTION
### Description

Allow usage of rotary encoder along with on-screen buttons

### Benefits

Rotary encoder can be used along with on-screen buttons
Unused pins on MKS Robin boards can be used to connect rotary encoder

### Related Issues

n/a