### PR TITLE
Option for Trigorilla 1.4 with add-on endstops board

### DIFF
--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -37,6 +37,15 @@
   #define SERVO3_PIN        6
 #endif
 
+//
+// Custom Limit Switches
+//
+//#define ANYCUBIC_4_MAX_PRO_ENDSTOPS
+#if ENABLED(ANYCUBIC_4_MAX_PRO_ENDSTOPS)
+  #define X_MAX_PIN        43
+  #define Y_MIN_PIN        19
+#endif
+
 // Labeled pins
 #define TRIGORILLA_HEATER_BED_PIN  8
 #define TRIGORILLA_HEATER_0_PIN   10

--- a/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
+++ b/Marlin/src/pins/ramps/pins_TRIGORILLA_14.h
@@ -37,12 +37,6 @@
   #define SERVO3_PIN        6
 #endif
 
-//
-// Limit Switches
-//
-#define X_MAX_PIN          43
-#define Y_MIN_PIN          19
-
 // Labeled pins
 #define TRIGORILLA_HEATER_BED_PIN  8
 #define TRIGORILLA_HEATER_0_PIN   10


### PR DESCRIPTION
### Description

This reverts commit 2325bede8a079845dd19ce8020350c1d8f8a18f1.

That commit was made to correct endstop pin assignments for the Anycubic 4 Max Pro, but in the process it broke existing Trigorilla users.

It appears that the Anycubic 4 Max Pro places a daughterboard over portions of the Trigorilla, altering its pin assignments. Something will be needed to address that, but it needs to not break other Trigorilla users in the process.

Picture of the 4 Max Pro motherboard, showing the daughterboard covering the endstop pins:
![image](https://user-images.githubusercontent.com/20053467/73522703-f9f9d080-43bd-11ea-94d2-314bca89fd04.png)

### Related Issues

#16736 - Delta home issue this fixes, which I have reproduced on my own Trigorilla
#16612 - Issue regarding Anycubic 4 Max Pro, which probably should be re-opened and updated.