### PR TITLE
Fix BTT SKR 1.4 extra endstop pins

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -74,9 +74,9 @@
 #if Z_STALL_SENSITIVITY
   #define Z_STOP_PIN       Z_DIAG_PIN
   #if Z_HOME_DIR < 0
-    #define Z_MAX_PIN      P1_24   // PWRDET
+    #define Z_MAX_PIN      P1_00   // PWRDET
   #else
-    #define Z_MIN_PIN      P1_24   // PWRDET
+    #define Z_MIN_PIN      P1_00   // PWRDET
   #endif
 #else
   #define Z_STOP_PIN       P1_27   // Z-STOP


### PR DESCRIPTION
update config, because P1_24 is for NEOPIXEL and not for PWRDET
P1_00 is the right pin for PWRDET on SKR1.4/TURBO

