### PR TITLE
Kill steppers when M112 is processed by the emergency parser

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1050,7 +1050,7 @@ void Temperature::manage_heater() {
   #endif
 
   #if ENABLED(EMERGENCY_PARSER)
-    if (emergency_parser.killed_by_M112) kill();
+    if (emergency_parser.killed_by_M112) kill(M112_KILL_STR, nullptr, true);
   #endif
 
   if (!raw_temps_ready) return;


### PR DESCRIPTION
### Description

This is a followup to commit 79c2f05e7d1e83817f23e09bcafa3b9f55c3acf5.

There are three possible code paths that kill the printer due to M112, depending on whether it comes from the emergency parser, the serial buffer, or an SD card.

The path used by the emergency parser was missed in the earlier commit, preventing motors from being disabled if EMERGENCY_PARSER is enabled.

### Benefits

M112 disables motors both with and without EMERGENCY_PARSER.

### Related Issues

#14863 
