### PR TITLE
Fix Temperature::over_autostart_threshold

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2143,7 +2143,7 @@ void Temperature::disable_all_heaters() {
 
   bool Temperature::over_autostart_threshold() {
     #if HOTENDS
-      HOTEND_LOOP() if (degTargetHotend(e) < (EXTRUDE_MINTEMP) / 2) return true;
+      HOTEND_LOOP() if (degTargetHotend(e) > (EXTRUDE_MINTEMP) / 2) return true;
     #endif
     #if HAS_HEATED_BED
       if (degTargetBed() > BED_MINTEMP) return true;


### PR DESCRIPTION
### Description

@Vertabreak told me that prints were not terminating properly at the end of a print job. The printer was remaining in print mode, with all the "active print" menu options available. I was able to easily reproduce this on my own printer.

This is a followup to #16725. The direction of one compare was backwards, resulting in the behavior.

### Benefits

LCD reflects the printer is idle after a print, as expected.

### Related Issues

I couldn't find an open issue, just @Vertabreak telling me about it.
