### PR TITLE
Fix #16566   Z move menu LCD Positioning error 

### DIFF
--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -250,7 +250,13 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
     if (axis == Z_AXIS && (SHORT_MANUAL_Z_MOVE) > 0.0f && (SHORT_MANUAL_Z_MOVE) < 0.1f) {
       extern const char NUL_STR[];
       SUBMENU_P(NUL_STR, []{ _goto_manual_move(float(SHORT_MANUAL_Z_MOVE)); });
-      MENU_ITEM_ADDON_START(0);
+      MENU_ITEM_ADDON_START(
+      #if HAS_GRAPHICAL_LCD
+        0
+      #else 
+        1
+      #endif
+      );
         char tmp[20], numstr[10];
         // Determine digits needed right of decimal
         const uint8_t digs = !UNEAR_ZERO((SHORT_MANUAL_Z_MOVE) * 1000 - int((SHORT_MANUAL_Z_MOVE) * 1000)) ? 4 :

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -250,12 +250,10 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
     if (axis == Z_AXIS && (SHORT_MANUAL_Z_MOVE) > 0.0f && (SHORT_MANUAL_Z_MOVE) < 0.1f) {
       extern const char NUL_STR[];
       SUBMENU_P(NUL_STR, []{ _goto_manual_move(float(SHORT_MANUAL_Z_MOVE)); });
-      MENU_ITEM_ADDON_START(
-      #if HAS_GRAPHICAL_LCD
-        0
-      #else 
-        1
-      #endif
+      MENU_ITEM_ADDON_START(0
+        #if HAS_CHARACTER_LCD
+          + 1
+        #endif
       );
         char tmp[20], numstr[10];
         // Determine digits needed right of decimal


### PR DESCRIPTION
### Requirements

Enable a character based display in current default Configuration.h file. 
Ensure SHORT_MANUAL_Z_MOVE is set to a value in Configuration_adv.h  (it is by default)
Examine the menu Motion|Move Axis|Move Z|Move 0.025mm note it is one character left of where it should be.

### Description

The Z move menu has a custom move length defined by SHORT_MANUAL_Z_MOVE.
Adding a menus item requires the Menu name in flash ram. But this particular name is dynamically generated.
To get around this the code adds a empty menu item then uses lcd_put_u8str to display the dynamically generated name.
This doesn't work on char based displays as the menu items are offset one character right for the '>' cursor.
The fix is to offset the position of lcd_put_u8str by 1 character if HAS_GRAPHICAL_LCD is false.
This is done at compile time. MENU_ITEM_ADDON_START() is set to 0 for GLCD or 1 for character LCD's

### Benefits

All Z move menu Items are now positioned correctly on character and GLCD displays.

### Related Issues
#16566 