### PR TITLE
Keep secure credentials in a separate config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,9 @@ Marlin/*/*/readme.txt
 Marlin/*/*/*/readme.txt
 Marlin/*/*/*/*/readme.txt
 
+# WiFi Credentials
+Marlin/Configuration_creds.h
+
 #Visual Studio
 *.sln
 *.vcxproj

--- a/.gitignore
+++ b/.gitignore
@@ -146,8 +146,8 @@ Marlin/*/*/readme.txt
 Marlin/*/*/*/readme.txt
 Marlin/*/*/*/*/readme.txt
 
-# WiFi Credentials
-Marlin/Configuration_creds.h
+# Secure Credentials
+Configuration_Secure.h
 
 #Visual Studio
 *.sln

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3023,18 +3023,19 @@
 //#define ESP3D_WIFISUPPORT   // ESP3D Library WiFi management (https://github.com/luc-github/ESP3DLib)
 
 #if EITHER(WIFISUPPORT, ESP3D_WIFISUPPORT)
+  //#define WEBSUPPORT          // Start a webserver (which may include auto-discovery)
+  //#define OTASUPPORT          // Support over-the-air firmware updates
+  //#define WIFI_CUSTOM_COMMAND // Accept feature config commands (e.g., WiFi ESP3D) from the host
+
   /**
-   * To hard-code WiFi SSID and password, put the following two #define-lines into a file called
-   * 'Configuration_creds.h', replace 'WiFi SSID' and 'WiFi Password' with your own respective SSID and password
-   * and uncomment the #include-line in this file below. 'Configuration_creds.h' is included in .gitignore to prevent
-   * accidental publishing of WiFi credentials to a (public) Git repository.
-     #define WIFI_SSID "WiFi SSID"
-     #define WIFI_PWD  "WiFi Password"
+   * To set a default WiFi SSID / Password, create a file called Configuration_Secure.h with
+   * the following defines, customized for your network. This specific file is excluded via
+   * .gitignore to prevent it from accidentally leaking to the public.
+   *
+   *   #define WIFI_SSID "WiFi SSID"
+   *   #define WIFI_PWD  "WiFi Password"
    */
-  //#include "Configuration_creds.h" // Include file with hard-coded WiFi SSID and password
-  //#define WEBSUPPORT               // Start a webserver (which may include auto-discovery)
-  //#define OTASUPPORT               // Support over-the-air firmware updates
-  //#define WIFI_CUSTOM_COMMAND      // Accept feature config commands (e.g., WiFi ESP3D) from the host
+  //#include "Configuration_Secure.h" // External file with WiFi SSID / Password
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3023,11 +3023,18 @@
 //#define ESP3D_WIFISUPPORT   // ESP3D Library WiFi management (https://github.com/luc-github/ESP3DLib)
 
 #if EITHER(WIFISUPPORT, ESP3D_WIFISUPPORT)
-  #define WIFI_SSID "Wifi SSID"
-  #define WIFI_PWD  "Wifi Password"
-  //#define WEBSUPPORT          // Start a webserver (which may include auto-discovery)
-  //#define OTASUPPORT          // Support over-the-air firmware updates
-  //#define WIFI_CUSTOM_COMMAND // Accept feature config commands (e.g., WiFi ESP3D) from the host
+  /**
+   * To hard-code WiFi SSID and password, put the following two #define-lines into a file called
+   * 'Configuration_creds.h', replace 'WiFi SSID' and 'WiFi Password' with your own respective SSID and password
+   * and uncomment the #include-line in this file below. 'Configuration_creds.h' is included in .gitignore to prevent
+   * accidental publishing of WiFi credentials to a (public) Git repository.
+     #define WIFI_SSID "WiFi SSID"
+     #define WIFI_PWD  "WiFi Password"
+   */
+  //#include "Configuration_creds.h" // Include file with hard-coded WiFi SSID and password
+  //#define WEBSUPPORT               // Start a webserver (which may include auto-discovery)
+  //#define OTASUPPORT               // Support over-the-air firmware updates
+  //#define WIFI_CUSTOM_COMMAND      // Accept feature config commands (e.g., WiFi ESP3D) from the host
 #endif
 
 /**

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -28,19 +28,6 @@
 #include "../inc/MarlinConfig.h"
 
 #if HAS_BED_PROBE
-
-  extern xyz_pos_t probe_offset;
-
-  #if HAS_PROBE_XY_OFFSET
-    extern xyz_pos_t &probe_offset_xy;
-  #else
-    constexpr xy_pos_t probe_offset_xy{0};
-  #endif
-
-  bool set_probe_deployed(const bool deploy);
-  #ifdef Z_AFTER_PROBING
-    void move_z_after_probing();
-  #endif
   enum ProbePtRaise : uint8_t {
     PROBE_PT_NONE,      // No raise or stow after run_z_probe
     PROBE_PT_STOW,      // Do a complete stow after run_z_probe

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -28,6 +28,19 @@
 #include "../inc/MarlinConfig.h"
 
 #if HAS_BED_PROBE
+
+  extern xyz_pos_t probe_offset;
+
+  #if HAS_PROBE_XY_OFFSET
+    extern xyz_pos_t &probe_offset_xy;
+  #else
+    constexpr xy_pos_t probe_offset_xy{0};
+  #endif
+
+  bool set_probe_deployed(const bool deploy);
+  #ifdef Z_AFTER_PROBING
+    void move_z_after_probing();
+  #endif
   enum ProbePtRaise : uint8_t {
     PROBE_PT_NONE,      // No raise or stow after run_z_probe
     PROBE_PT_STOW,      // Do a complete stow after run_z_probe

--- a/buildroot/bin/opt_set
+++ b/buildroot/bin/opt_set
@@ -8,4 +8,5 @@ SED=$(which gsed || which sed)
 # Logic for returning nonzero based on answer here: https://stackoverflow.com/a/15966279/104648
 eval "${SED} -i '/\(\/\/\)*\([[:blank:]]*\)\(#define \b${1}\b\).*$/{s//\2\3 ${2}/;h};\${x;/./{x;q0};x;q9}' Marlin/Configuration.h" ||
 eval "${SED} -i '/\(\/\/\)*\([[:blank:]]*\)\(#define \b${1}\b\).*$/{s//\2\3 ${2}/;h};\${x;/./{x;q0};x;q9}' Marlin/Configuration_adv.h" ||
-(echo "ERROR: opt_set Can't find ${1}" >&2 && exit 9)
+eval "echo '#define ${@}' >>Marlin/Configuration_adv.h" ||
+(echo "ERROR: opt_set Can't set or add ${1}" >&2 && exit 9)

--- a/buildroot/share/tests/esp32-tests
+++ b/buildroot/share/tests/esp32-tests
@@ -12,8 +12,8 @@ set -e
 restore_configs
 opt_set MOTHERBOARD BOARD_ESPRESSIF_ESP32
 opt_enable WIFISUPPORT GCODE_MACROS BAUD_RATE_GCODE
-opt_set WIFI_SSID "\"ssid\""
-opt_set WIFI_PWD "\"password\""
+opt_add WIFI_SSID "\"ssid\""
+opt_add WIFI_PWD "\"password\""
 opt_set TX_BUFFER_SIZE 64
 opt_add WEBSUPPORT
 exec_test $1 $2 "ESP32 with WIFISUPPORT and WEBSUPPORT"


### PR DESCRIPTION
### Description
Store hard-coded WiFi credentials in a separate configuration file named `Configuration_creds.h` that precautionary gets excluded using `.gitignore`.

As far as I know, WiFi is currently only being used by the ESP32 platform.

### Benefits
Prevent accidental upload of secret information to public Git repositories.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/16588