### PR TITLE
Add MKS Base 1.6 board

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -180,88 +180,93 @@ else ifeq ($(HARDWARE_MOTHERBOARD),1105)
 else ifeq ($(HARDWARE_MOTHERBOARD),1106)
 # MKS v1.5 with Allegro A4982 stepper drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1107)
-# MKS BASE 1.0 with Heroic HR4982 stepper drivers
+# MKS v1.6 with Allegro A4982 stepper drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1108)
-# MKS GEN v1.3 or 1.4
+
+# MKS BASE 1.0 with Heroic HR4982 stepper drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1109)
-# MKS GEN L
+# MKS GEN v1.3 or 1.4
 else ifeq ($(HARDWARE_MOTHERBOARD),1110)
-# zrib V2.0 control board (Chinese knock off RAMPS replica)
+# MKS GEN L
 else ifeq ($(HARDWARE_MOTHERBOARD),1111)
-# BigTreeTech or BIQU KFB2.0
+# zrib V2.0 control board (Chinese knock off RAMPS replica)
 else ifeq ($(HARDWARE_MOTHERBOARD),1112)
-# Felix 2.0+ Electronics Board (RAMPS like)
+# BigTreeTech or BIQU KFB2.0
 else ifeq ($(HARDWARE_MOTHERBOARD),1113)
-# Invent-A-Part RigidBoard
+# Felix 2.0+ Electronics Board (RAMPS like)
 else ifeq ($(HARDWARE_MOTHERBOARD),1114)
-# Invent-A-Part RigidBoard V2
+# Invent-A-Part RigidBoard
 else ifeq ($(HARDWARE_MOTHERBOARD),1115)
-# Sainsmart 2-in-1 board
+# Invent-A-Part RigidBoard V2
 else ifeq ($(HARDWARE_MOTHERBOARD),1116)
-# Ultimaker
+# Sainsmart 2-in-1 board
 else ifeq ($(HARDWARE_MOTHERBOARD),1117)
-# Ultimaker (Older electronics. Pre 1.5.4. This is rare)
+# Ultimaker
 else ifeq ($(HARDWARE_MOTHERBOARD),1118)
+# Ultimaker (Older electronics. Pre 1.5.4. This is rare)
+else ifeq ($(HARDWARE_MOTHERBOARD),1119)
   MCU ?= atmega1280
 
 # Azteeg X3
-else ifeq ($(HARDWARE_MOTHERBOARD),1119)
-# Azteeg X3 Pro
 else ifeq ($(HARDWARE_MOTHERBOARD),1120)
-# Ultimainboard 2.x (Uses TEMP_SENSOR 20)
+# Azteeg X3 Pro
 else ifeq ($(HARDWARE_MOTHERBOARD),1121)
-# Rumba
+# Ultimainboard 2.x (Uses TEMP_SENSOR 20)
 else ifeq ($(HARDWARE_MOTHERBOARD),1122)
-# Raise3D Rumba
+# Rumba
 else ifeq ($(HARDWARE_MOTHERBOARD),1123)
-# Rapide Lite RL200 Rumba
+# Raise3D Rumba
 else ifeq ($(HARDWARE_MOTHERBOARD),1124)
-# Formbot T-Rex 2 Plus
+# Rapide Lite RL200 Rumba
 else ifeq ($(HARDWARE_MOTHERBOARD),1125)
-# Formbot T-Rex 3
+# Formbot T-Rex 2 Plus
 else ifeq ($(HARDWARE_MOTHERBOARD),1126)
-# Formbot Raptor
+# Formbot T-Rex 3
 else ifeq ($(HARDWARE_MOTHERBOARD),1127)
-# Formbot Raptor 2
+# Formbot Raptor
 else ifeq ($(HARDWARE_MOTHERBOARD),1128)
-# bq ZUM Mega 3D
+# Formbot Raptor 2
 else ifeq ($(HARDWARE_MOTHERBOARD),1129)
-# MakeBoard Mini v2.1.2 is a control board sold by MicroMake
+# bq ZUM Mega 3D
 else ifeq ($(HARDWARE_MOTHERBOARD),1130)
-# TriGorilla Anycubic version 1.3 based on RAMPS EFB
+# MakeBoard Mini v2.1.2 is a control board sold by MicroMake
 else ifeq ($(HARDWARE_MOTHERBOARD),1131)
-# TriGorilla Anycubic version 1.4 based on RAMPS EFB
+# TriGorilla Anycubic version 1.3 based on RAMPS EFB
 else ifeq ($(HARDWARE_MOTHERBOARD),1132)
-# TriGorilla Anycubic version 1.4 Rev 1.1
+# TriGorilla Anycubic version 1.4 based on RAMPS EFB
 else ifeq ($(HARDWARE_MOTHERBOARD),1133)
-# Creality: Ender-4, CR-8
+# TriGorilla Anycubic version 1.4 Rev 1.1
 else ifeq ($(HARDWARE_MOTHERBOARD),1134)
-# Creality: CR10S, CR20, CR-X
+# Creality: Ender-4, CR-8
 else ifeq ($(HARDWARE_MOTHERBOARD),1135)
-# Dagoma F5
+# Creality: CR10S, CR20, CR-X
 else ifeq ($(HARDWARE_MOTHERBOARD),1136)
-# FYSETC F6
+# Dagoma F5
 else ifeq ($(HARDWARE_MOTHERBOARD),1137)
-# Duplicator i3 Plus
+# FYSETC F6 1.3
 else ifeq ($(HARDWARE_MOTHERBOARD),1138)
-# VORON
+# FYSETC F6 1.5
 else ifeq ($(HARDWARE_MOTHERBOARD),1139)
-# TRONXY V3 1.0
+# Duplicator i3 Plus
 else ifeq ($(HARDWARE_MOTHERBOARD),1140)
-# Z-Bolt X Series
+# VORON
 else ifeq ($(HARDWARE_MOTHERBOARD),1141)
-# TT OSCAR
+# TRONXY V3 1.0
 else ifeq ($(HARDWARE_MOTHERBOARD),1142)
-# Overlord/Overlord Pro
+# Z-Bolt X Series
 else ifeq ($(HARDWARE_MOTHERBOARD),1143)
-# ADIMLab Gantry v1
+# TT OSCAR
 else ifeq ($(HARDWARE_MOTHERBOARD),1144)
-# ADIMLab Gantry v2
+# Overlord/Overlord Pro
 else ifeq ($(HARDWARE_MOTHERBOARD),1145)
-# BIQU Tango V1
+# ADIMLab Gantry v1
 else ifeq ($(HARDWARE_MOTHERBOARD),1146)
-# MKS GEN L V2
+# ADIMLab Gantry v2
 else ifeq ($(HARDWARE_MOTHERBOARD),1147)
+# BIQU Tango V1
+else ifeq ($(HARDWARE_MOTHERBOARD),1148)
+# MKS GEN L V2
+else ifeq ($(HARDWARE_MOTHERBOARD),1149)
 
 #
 # RAMBo and derivatives

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -59,49 +59,50 @@
 #define BOARD_BAM_DICE                1103  // 2PrintBeta BAM&DICE with STK drivers
 #define BOARD_BAM_DICE_DUE            1104  // 2PrintBeta BAM&DICE Due with STK drivers
 #define BOARD_MKS_BASE                1105  // MKS BASE v1.0
-#define BOARD_MKS_BASE_14             1106  // MKS v1.4 with A4982 stepper drivers
-#define BOARD_MKS_BASE_15             1107  // MKS v1.5 with Allegro A4982 stepper drivers
-#define BOARD_MKS_BASE_HEROIC         1108  // MKS BASE 1.0 with Heroic HR4982 stepper drivers
-#define BOARD_MKS_GEN_13              1109  // MKS GEN v1.3 or 1.4
-#define BOARD_MKS_GEN_L               1110  // MKS GEN L
-#define BOARD_KFB_2                   1111  // BigTreeTech or BIQU KFB2.0
-#define BOARD_ZRIB_V20                1112  // zrib V2.0 control board (Chinese knock off RAMPS replica)
-#define BOARD_FELIX2                  1113  // Felix 2.0+ Electronics Board (RAMPS like)
-#define BOARD_RIGIDBOARD              1114  // Invent-A-Part RigidBoard
-#define BOARD_RIGIDBOARD_V2           1115  // Invent-A-Part RigidBoard V2
-#define BOARD_SAINSMART_2IN1          1116  // Sainsmart 2-in-1 board
-#define BOARD_ULTIMAKER               1117  // Ultimaker
-#define BOARD_ULTIMAKER_OLD           1118  // Ultimaker (Older electronics. Pre 1.5.4. This is rare)
-#define BOARD_AZTEEG_X3               1119  // Azteeg X3
-#define BOARD_AZTEEG_X3_PRO           1120  // Azteeg X3 Pro
-#define BOARD_ULTIMAIN_2              1121  // Ultimainboard 2.x (Uses TEMP_SENSOR 20)
-#define BOARD_RUMBA                   1122  // Rumba
-#define BOARD_RUMBA_RAISE3D           1123  // Raise3D N series Rumba derivative
-#define BOARD_RL200                   1124  // Rapide Lite 200 (v1, low-cost RUMBA clone with drv)
-#define BOARD_FORMBOT_TREX2PLUS       1125  // Formbot T-Rex 2 Plus
-#define BOARD_FORMBOT_TREX3           1126  // Formbot T-Rex 3
-#define BOARD_FORMBOT_RAPTOR          1127  // Formbot Raptor
-#define BOARD_FORMBOT_RAPTOR2         1128  // Formbot Raptor 2
-#define BOARD_BQ_ZUM_MEGA_3D          1129  // bq ZUM Mega 3D
-#define BOARD_MAKEBOARD_MINI          1130  // MakeBoard Mini v2.1.2 is a control board sold by MicroMake
-#define BOARD_TRIGORILLA_13           1131  // TriGorilla Anycubic version 1.3-based on RAMPS EFB
-#define BOARD_TRIGORILLA_14           1132  //   ... Ver 1.4
-#define BOARD_TRIGORILLA_14_11        1133  //   ... Rev 1.1 (new servo pin order)
-#define BOARD_RAMPS_ENDER_4           1134  // Creality: Ender-4, CR-8
-#define BOARD_RAMPS_CREALITY          1135  // Creality: CR10S, CR20, CR-X
-#define BOARD_RAMPS_DAGOMA            1136  // Dagoma F5
-#define BOARD_FYSETC_F6_13            1137  // FYSETC F6 1.3
-#define BOARD_FYSETC_F6_14            1138  // FYSETC F6 1.4
-#define BOARD_DUPLICATOR_I3_PLUS      1139  // Wanhao Duplicator i3 Plus
-#define BOARD_VORON                   1140  // VORON Design
-#define BOARD_TRONXY_V3_1_0           1141  // Tronxy TRONXY-V3-1.0
-#define BOARD_Z_BOLT_X_SERIES         1142  // Z-Bolt X Series
-#define BOARD_TT_OSCAR                1143  // TT OSCAR
-#define BOARD_OVERLORD                1144  // Overlord/Overlord Pro
-#define BOARD_HJC2560C_REV1           1145  // ADIMLab Gantry v1
-#define BOARD_HJC2560C_REV2           1146  // ADIMLab Gantry v2
-#define BOARD_TANGO                   1147  // BIQU Tango V1
-#define BOARD_MKS_GEN_L_V2            1148  // MKS GEN L V2
+#define BOARD_MKS_BASE_14             1106  // MKS BASE v1.4 with Allegro A4982 stepper drivers
+#define BOARD_MKS_BASE_15             1107  // MKS BASE v1.5 with Allegro A4982 stepper drivers
+#define BOARD_MKS_BASE_16             1108  // MKS BASE v1.6 with Allegro A4982 stepper drivers
+#define BOARD_MKS_BASE_HEROIC         1109  // MKS BASE 1.0 with Heroic HR4982 stepper drivers
+#define BOARD_MKS_GEN_13              1110  // MKS GEN v1.3 or 1.4
+#define BOARD_MKS_GEN_L               1111  // MKS GEN L
+#define BOARD_KFB_2                   1112  // BigTreeTech or BIQU KFB2.0
+#define BOARD_ZRIB_V20                1113  // zrib V2.0 control board (Chinese knock off RAMPS replica)
+#define BOARD_FELIX2                  1114  // Felix 2.0+ Electronics Board (RAMPS like)
+#define BOARD_RIGIDBOARD              1115  // Invent-A-Part RigidBoard
+#define BOARD_RIGIDBOARD_V2           1116  // Invent-A-Part RigidBoard V2
+#define BOARD_SAINSMART_2IN1          1117  // Sainsmart 2-in-1 board
+#define BOARD_ULTIMAKER               1118  // Ultimaker
+#define BOARD_ULTIMAKER_OLD           1119  // Ultimaker (Older electronics. Pre 1.5.4. This is rare)
+#define BOARD_AZTEEG_X3               1120  // Azteeg X3
+#define BOARD_AZTEEG_X3_PRO           1121  // Azteeg X3 Pro
+#define BOARD_ULTIMAIN_2              1122  // Ultimainboard 2.x (Uses TEMP_SENSOR 20)
+#define BOARD_RUMBA                   1123  // Rumba
+#define BOARD_RUMBA_RAISE3D           1124  // Raise3D N series Rumba derivative
+#define BOARD_RL200                   1125  // Rapide Lite 200 (v1, low-cost RUMBA clone with drv)
+#define BOARD_FORMBOT_TREX2PLUS       1126  // Formbot T-Rex 2 Plus
+#define BOARD_FORMBOT_TREX3           1127  // Formbot T-Rex 3
+#define BOARD_FORMBOT_RAPTOR          1128  // Formbot Raptor
+#define BOARD_FORMBOT_RAPTOR2         1129  // Formbot Raptor 2
+#define BOARD_BQ_ZUM_MEGA_3D          1130  // bq ZUM Mega 3D
+#define BOARD_MAKEBOARD_MINI          1131  // MakeBoard Mini v2.1.2 is a control board sold by MicroMake
+#define BOARD_TRIGORILLA_13           1132  // TriGorilla Anycubic version 1.3-based on RAMPS EFB
+#define BOARD_TRIGORILLA_14           1133  //   ... Ver 1.4
+#define BOARD_TRIGORILLA_14_11        1134  //   ... Rev 1.1 (new servo pin order)
+#define BOARD_RAMPS_ENDER_4           1135  // Creality: Ender-4, CR-8
+#define BOARD_RAMPS_CREALITY          1136  // Creality: CR10S, CR20, CR-X
+#define BOARD_RAMPS_DAGOMA            1137  // Dagoma F5
+#define BOARD_FYSETC_F6_13            1138  // FYSETC F6 1.3
+#define BOARD_FYSETC_F6_14            1139  // FYSETC F6 1.4
+#define BOARD_DUPLICATOR_I3_PLUS      1140  // Wanhao Duplicator i3 Plus
+#define BOARD_VORON                   1141  // VORON Design
+#define BOARD_TRONXY_V3_1_0           1142  // Tronxy TRONXY-V3-1.0
+#define BOARD_Z_BOLT_X_SERIES         1143  // Z-Bolt X Series
+#define BOARD_TT_OSCAR                1144  // TT OSCAR
+#define BOARD_OVERLORD                1145  // Overlord/Overlord Pro
+#define BOARD_HJC2560C_REV1           1146  // ADIMLab Gantry v1
+#define BOARD_HJC2560C_REV2           1147  // ADIMLab Gantry v2
+#define BOARD_TANGO                   1148  // BIQU Tango V1
+#define BOARD_MKS_GEN_L_V2            1149  // MKS GEN L V2
 
 //
 // RAMBo and derivatives

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -110,6 +110,8 @@
   #include "ramps/pins_MKS_BASE_14.h"           // ATmega2560                             env:megaatmega2560
 #elif MB(MKS_BASE_15)
   #include "ramps/pins_MKS_BASE_15.h"           // ATmega1280, ATmega2560                 env:megaatmega1280 env:megaatmega2560
+#elif MB(MKS_BASE_16)
+  #include "ramps/pins_MKS_BASE_16.h"           // ATmega1280, ATmega2560                 env:megaatmega1280 env:megaatmega2560
 #elif MB(MKS_BASE_HEROIC)
   #include "ramps/pins_MKS_BASE_HEROIC.h"       // ATmega1280, ATmega2560                 env:megaatmega1280 env:megaatmega2560
 #elif MB(MKS_GEN_13)

--- a/Marlin/src/pins/ramps/pins_MKS_BASE.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE.h
@@ -31,7 +31,9 @@
   #error "MKS BASE 1.0 supports up to 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_INFO_NAME "MKS BASE 1.0"
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME "MKS BASE 1.0"
+#endif
 
 //
 // Heaters / Fans

--- a/Marlin/src/pins/ramps/pins_MKS_BASE_14.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_14.h
@@ -22,7 +22,7 @@
 #pragma once
 
 /**
- * MKS BASE v1.4
+ * MKS BASE v1.4 with A4982 stepper drivers and digital micro-stepping
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2

--- a/Marlin/src/pins/ramps/pins_MKS_BASE_16.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_16.h
@@ -22,14 +22,14 @@
 #pragma once
 
 /**
- * MKS BASE v1.5 with A4982 stepper drivers and digital micro-stepping
+ * MKS BASE v1.6 with A4982 stepper drivers and digital micro-stepping
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS BASE 1.5 only supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS BASE 1.6 only supports up to 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_INFO_NAME "MKS BASE 1.5"
+#define BOARD_INFO_NAME "MKS BASE 1.6"
 
 #include "pins_MKS_BASE.h"
 


### PR DESCRIPTION
### Description

#16764 requested MKS Base 1.6 support, which was pin compatible with the 1.5.

### Benefits

Marlin will now report the correct board name.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/16764