### PR TITLE
Fix for probe with multiple endstops

### DIFF
--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -791,11 +791,29 @@ void Endstops::update() {
       #if HAS_Z_MIN || (Z_SPI_SENSORLESS && Z_HOME_DIR < 0)
         #if ENABLED(Z_MULTI_ENDSTOPS)
           #if NUM_Z_STEPPER_DRIVERS == 4
-            PROCESS_QUAD_ENDSTOP(Z, Z2, Z3, Z4, MIN);
+			#if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+              if (z_probe_enabled) PROCESS_QUAD_ENDSTOP(Z, Z2, Z3, Z4, MIN);
+            #elif HAS_CUSTOM_PROBE_PIN
+              if (!z_probe_enabled) PROCESS_QUAD_ENDSTOP(Z, Z2, Z3, Z4, MIN);
+            #else
+              PROCESS_QUAD_ENDSTOP(Z, Z2, Z3, Z4, MIN);
+            #endif            
           #elif NUM_Z_STEPPER_DRIVERS == 3
-            PROCESS_TRIPLE_ENDSTOP(Z, Z2, Z3, MIN);
+			#if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+              if (z_probe_enabled) PROCESS_TRIPLE_ENDSTOP(Z, Z2, Z3, MIN);
+            #elif HAS_CUSTOM_PROBE_PIN
+              if (!z_probe_enabled) PROCESS_TRIPLE_ENDSTOP(Z, Z2, Z3, MIN);
+            #else
+              PROCESS_TRIPLE_ENDSTOP(Z, Z2, Z3, MIN);
+            #endif
           #else
-            PROCESS_DUAL_ENDSTOP(Z, Z2, MIN);
+		    #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+              if (z_probe_enabled) PROCESS_DUAL_ENDSTOP(Z, Z2, MIN);
+            #elif HAS_CUSTOM_PROBE_PIN
+              if (!z_probe_enabled) PROCESS_DUAL_ENDSTOP(Z, Z2, MIN);
+            #else
+              PROCESS_DUAL_ENDSTOP(Z, Z2, MIN);
+            #endif
           #endif
         #else
           #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -798,16 +798,14 @@ void Endstops::update() {
             true
           #endif
         ) {
-          #if ENABLED(Z_MULTI_ENDSTOPS)
-            #if NUM_Z_STEPPER_DRIVERS == 4
-              PROCESS_QUAD_ENDSTOP(MIN, Z, Z2, Z3, Z4);
-            #elif NUM_Z_STEPPER_DRIVERS == 3
-              PROCESS_TRIPLE_ENDSTOP(MIN, Z, Z2, Z3);
-            #else
-              PROCESS_DUAL_ENDSTOP(MIN, Z, Z2);
-            #endif
-          #else
+          #if DISABLED(Z_MULTI_ENDSTOPS)
             PROCESS_ENDSTOP(MIN, Z);
+          #elif NUM_Z_STEPPER_DRIVERS == 4
+            PROCESS_QUAD_ENDSTOP(MIN, Z, Z2, Z3, Z4);
+          #elif NUM_Z_STEPPER_DRIVERS == 3
+            PROCESS_TRIPLE_ENDSTOP(MIN, Z, Z2, Z3);
+          #else
+            PROCESS_DUAL_ENDSTOP(MIN, Z, Z2);
           #endif
         }
       #endif

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -811,12 +811,12 @@ void Endstops::update() {
       #endif
     }
     else { // Z +direction. Gantry up, bed down.
-      #if (HAS_Z_MAX || (Z_SPI_SENSORLESS && Z_HOME_DIR > 0)) /* Real or sensorless exists, and... */ \
-        && (   ENABLED(Z_MULTI_ENDSTOPS)      /* ...multi-endstop, or... */ \
-            || !HAS_CUSTOM_PROBE_PIN          /* ...no probe, or probe uses the min pin... */ \
-            || Z_MAX_PIN != Z_MIN_PROBE_PIN   /* ...no probe, or probe not using the Z max pin. */ \
-      )
-        PROCESS_ENDSTOP_Z(MAX);
+      #if (HAS_Z_MAX || (Z_SPI_SENSORLESS && Z_HOME_DIR > 0))
+        #if ENABLED(Z_MULTI_ENDSTOPS)
+          PROCESS_ENDSTOP_Z(MAX);
+        #elif !HAS_CUSTOM_PROBE_PIN || Z_MAX_PIN != Z_MIN_PROBE_PIN  // No probe or probe is Z_MIN || Probe is not Z_MAX
+          PROCESS_ENDSTOP(Z, MAX);
+        #endif
       #endif
     }
   }

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -811,7 +811,7 @@ void Endstops::update() {
       #endif
     }
     else { // Z +direction. Gantry up, bed down.
-      #if (HAS_Z_MAX || (Z_SPI_SENSORLESS && Z_HOME_DIR > 0))
+      #if HAS_Z_MAX || (Z_SPI_SENSORLESS && Z_HOME_DIR > 0)
         #if ENABLED(Z_MULTI_ENDSTOPS)
           PROCESS_ENDSTOP_Z(MAX);
         #elif !HAS_CUSTOM_PROBE_PIN || Z_MAX_PIN != Z_MIN_PROBE_PIN  // No probe or probe is Z_MIN || Probe is not Z_MAX


### PR DESCRIPTION
### Requirements
More than one endstop on z axis and probe functionality

### Description
This feature is still missing (was fixed multiple times but is again not in marlin). I use an printer with multiple endstops, dual, connected on z-max and z-min, also an probe, connected on probe pin, on an SKR1.4 Turbo. The problem, when i try to probe this result in an error on the first point when the probe point is under 0 (0 is set bei G28). The Z-Axis endstop pins are triggered before the probe touch the bed. The configured value, that i allow to probe with an negative offset to Z is ignored. I discovered the problem in the endstops. With this code currently it is only allowed to probe when one endstop is used, but not 2 or more

### Benefits
Probing also fully functional on multiply endstops-
