### PR TITLE
Remove Unused Serial Port Initialization

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/main.cpp
+++ b/Marlin/src/HAL/HAL_LPC1768/main.cpp
@@ -136,15 +136,6 @@ void HAL_init() {
     #endif
   }
 
-  #if NUM_SERIAL > 0
-    MYSERIAL0.begin(BAUDRATE);
-    #if NUM_SERIAL > 1
-      MYSERIAL1.begin(BAUDRATE);
-    #endif
-    SERIAL_PRINTF("\n\necho:%s (%dMhz) Initialized\n", isLPC1769() ? "LPC1769" : "LPC1768", SystemCoreClock / 1000000);
-    SERIAL_FLUSHTX();
-  #endif
-
   HAL_timer_init();
 }
 

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -880,15 +880,10 @@ void setup() {
 
   #if NUM_SERIAL > 0
     MYSERIAL0.begin(BAUDRATE);
-    #if NUM_SERIAL > 1
-      MYSERIAL1.begin(BAUDRATE);
-    #endif
-  #endif
-
-  #if NUM_SERIAL > 0
     uint32_t serial_connect_timeout = millis() + 1000UL;
     while (!MYSERIAL0 && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
     #if NUM_SERIAL > 1
+      MYSERIAL1.begin(BAUDRATE);
       serial_connect_timeout = millis() + 1000UL;
       while (!MYSERIAL1 && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
     #endif


### PR DESCRIPTION
I found that MYSERIAL0.begin(BAUDRATE) called twice during start up. 
From main.c HAL and From setup() MarlinCore

I think serial port initialization at main.c HAL is too early. I think serial should be initialize after other hardware. (In my case, my serial connection can make the marlin setup halted). Therefore I delete the serial.begin(baud) at HAL