### PR TITLE
Fix MKS Robin Nano platformio.ini entry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -489,7 +489,7 @@ build_flags   = !python Marlin/src/HAL/HAL_STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano.py
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_STM32F1>
-lib_deps =
+lib_deps = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
 lib_ignore    = Adafruit NeoPixel, SPI
 


### PR DESCRIPTION
Fix lib dep in mks_robin_nano

Description
There was only the additional library that needed the board.
It is necessary to specify that you add that library in addition to the default.

Benefits
mks_robin_nano can compiles