### PR TITLE
Enable hotend / bed PID separately in ExtUI

### DIFF
--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -894,7 +894,7 @@ namespace ExtUI {
 
   float getFeedrate_percent() { return feedrate_percentage; }
 
-  #if PIDTEMP
+  #if ENABLED(PIDTEMP)
     float getPIDValues_Kp(const extruder_t tool) {
       return PID_PARAM(Kp, tool);
     }
@@ -919,7 +919,7 @@ namespace ExtUI {
     }
   #endif
   
-  #if PIDTEMPBED
+  #if ENABLED(PIDTEMPBED)
     float getBedPIDValues_Kp() {
       return thermalManager.temp_bed.pid.Kp;
     }

--- a/Marlin/src/lcd/extensible_ui/ui_api.cpp
+++ b/Marlin/src/lcd/extensible_ui/ui_api.cpp
@@ -894,24 +894,17 @@ namespace ExtUI {
 
   float getFeedrate_percent() { return feedrate_percentage; }
 
-  #if HAS_PID_HEATING
+  #if PIDTEMP
     float getPIDValues_Kp(const extruder_t tool) {
       return PID_PARAM(Kp, tool);
     }
+    
     float getPIDValues_Ki(const extruder_t tool) {
       return unscalePID_i(PID_PARAM(Ki, tool));
     }
+    
     float getPIDValues_Kd(const extruder_t tool) {
       return unscalePID_d(PID_PARAM(Kd, tool));
-    }
-    float getBedPIDValues_Kp() {
-      return thermalManager.temp_bed.pid.Kp;
-    }
-    float getBedPIDValues_Ki() {
-      return unscalePID_i(thermalManager.temp_bed.pid.Ki);
-    }
-    float getBedPIDValues_Kd() {
-      return unscalePID_d(thermalManager.temp_bed.pid.Kd);
     }
 
     void setPIDValues(const float p, const float i, const float d, extruder_t tool) {
@@ -920,16 +913,32 @@ namespace ExtUI {
       thermalManager.temp_hotend[tool].pid.Kd = scalePID_d(d);
       thermalManager.updatePID();
     }
+
+    void startPIDTune(const float temp, extruder_t tool){
+      thermalManager.PID_autotune(temp, (heater_ind_t)tool, 8, true);
+    }
+  #endif
+  
+  #if PIDTEMPBED
+    float getBedPIDValues_Kp() {
+      return thermalManager.temp_bed.pid.Kp;
+    }
+    
+    float getBedPIDValues_Ki() {
+      return unscalePID_i(thermalManager.temp_bed.pid.Ki);
+    }
+    
+    float getBedPIDValues_Kd() {
+      return unscalePID_d(thermalManager.temp_bed.pid.Kd);
+    }
+    
     void setBedPIDValues(const float p, const float i, const float d) {
       thermalManager.temp_bed.pid.Kp = p;
       thermalManager.temp_bed.pid.Ki = scalePID_i(i);
       thermalManager.temp_bed.pid.Kd = scalePID_d(d);
       thermalManager.updatePID();
     }
-
-    void startPIDTune(const float temp, extruder_t tool){
-      thermalManager.PID_autotune(temp, (heater_ind_t)tool, 8, true);
-    }
+    
     void startBedPIDTune(const float temp) {
       thermalManager.PID_autotune(temp, H_BED, 4, true);
     }

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -249,16 +249,19 @@ namespace ExtUI {
     #endif
   #endif
 
-  #if HAS_PID_HEATING
+  #if PIDTEMP
     float getPIDValues_Kp(const extruder_t);
     float getPIDValues_Ki(const extruder_t);
     float getPIDValues_Kd(const extruder_t);
+    void setPIDValues(const float, const float, const float, extruder_t);
+    void startPIDTune(const float, extruder_t);
+  #endif
+  
+  #if PIDTEMPBED
     float getBedPIDValues_Kp();
     float getBedPIDValues_Ki();
     float getBedPIDValues_Kd();
-    void setPIDValues(const float, const float, const float, extruder_t);
     void setBedPIDValues(const float, const float, const float);
-    void startPIDTune(const float, extruder_t);
     void startBedPIDTune(const float);
   #endif
 

--- a/Marlin/src/lcd/extensible_ui/ui_api.h
+++ b/Marlin/src/lcd/extensible_ui/ui_api.h
@@ -249,7 +249,7 @@ namespace ExtUI {
     #endif
   #endif
 
-  #if PIDTEMP
+  #if ENABLED(PIDTEMP)
     float getPIDValues_Kp(const extruder_t);
     float getPIDValues_Ki(const extruder_t);
     float getPIDValues_Kd(const extruder_t);
@@ -257,7 +257,7 @@ namespace ExtUI {
     void startPIDTune(const float, extruder_t);
   #endif
   
-  #if PIDTEMPBED
+  #if ENABLED(PIDTEMPBED)
     float getBedPIDValues_Kp();
     float getBedPIDValues_Ki();
     float getBedPIDValues_Kd();


### PR DESCRIPTION


### Description

Fix compile error when PIDTEMP defined but PIDTEMPBED not defined.

### Benefits

Fixes compiler error

### Related Issues

none
