### PR TITLE
Integrate BABYSTEPPING into the stepper ISR

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1447,6 +1447,7 @@
  */
 //#define BABYSTEPPING
 #if ENABLED(BABYSTEPPING)
+  //#define INTEGRATED_BABYSTEPPING         // EXPERIMENTAL integration of babystepping into the Stepper ISR
   //#define BABYSTEP_WITHOUT_HOMING
   //#define BABYSTEP_XY                     // Also enable X/Y Babystepping. Not supported on DELTA!
   #define BABYSTEP_INVERT_Z false           // Change if Z babysteps should go the other way

--- a/Marlin/src/feature/babystep.cpp
+++ b/Marlin/src/feature/babystep.cpp
@@ -117,6 +117,10 @@ void Babystep::add_steps(const AxisEnum axis, const int16_t distance) {
   #if ENABLED(BABYSTEP_ALWAYS_AVAILABLE)
     gcode.reset_stepper_timeout();
   #endif
+
+  #if ENABLED(INTEGRATED_BABYSTEPPING)
+    if (has_steps()) stepper.initiateBabystepping();
+  #endif
 }
 
 #endif // BABYSTEPPING

--- a/Marlin/src/feature/babystep.h
+++ b/Marlin/src/feature/babystep.h
@@ -23,6 +23,14 @@
 
 #include "../inc/MarlinConfigPre.h"
 
+#if ENABLED(INTEGRATED_BABYSTEPPING)
+  #define BABYSTEPS_PER_SEC 1000UL
+  #define BABYSTEP_TICKS ((STEPPER_TIMER_RATE) / (BABYSTEPS_PER_SEC))
+#else
+  #define BABYSTEPS_PER_SEC 976UL
+  #define BABYSTEP_TICKS ((TEMP_TIMER_RATE) / (BABYSTEPS_PER_SEC))
+#endif
+
 #if IS_CORE || EITHER(BABYSTEP_XY, I2C_POSITION_ENCODERS)
   #define BS_TODO_AXIS(A) A
 #else
@@ -56,8 +64,12 @@ public:
   static void add_steps(const AxisEnum axis, const int16_t distance);
   static void add_mm(const AxisEnum axis, const float &mm);
 
+  static inline bool has_steps() {
+    return steps[BS_TODO_AXIS(X_AXIS)] || steps[BS_TODO_AXIS(Y_AXIS)] || steps[BS_TODO_AXIS(Z_AXIS)];
+  }
+
   //
-  // Called by the Temperature ISR to
+  // Called by the Temperature or Stepper ISR to
   // apply accumulated babysteps to the axes.
   //
   static inline void task() {

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -329,6 +329,11 @@ class Stepper {
       static bool LA_use_advance_lead;
     #endif
 
+    #if ENABLED(INTEGRATED_BABYSTEPPING)
+      static constexpr uint32_t BABYSTEP_NEVER = 0xFFFFFFFF;
+      static uint32_t nextBabystepISR;
+    #endif
+
     static int32_t ticks_nominal;
     #if DISABLED(S_CURVE_ACCELERATION)
       static uint32_t acc_step_rate; // needed for deceleration start point
@@ -381,6 +386,17 @@ class Stepper {
       // The Linear advance ISR phase
       static uint32_t advance_isr();
       FORCE_INLINE static void initiateLA() { nextAdvanceISR = 0; }
+    #endif
+
+    #if ENABLED(INTEGRATED_BABYSTEPPING)
+      // The Babystepping ISR phase
+      static uint32_t babystepping_isr();
+      FORCE_INLINE static void initiateBabystepping() {
+        if (nextBabystepISR == BABYSTEP_NEVER) {
+          nextBabystepISR = 0;
+          wake_up();
+        }
+      }
     #endif
 
     // Check if the given block is busy or not - Must not be called from ISR contexts

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -69,7 +69,7 @@
   #include "stepper.h"
 #endif
 
-#if ENABLED(BABYSTEPPING)
+#if ENABLED(BABYSTEPPING) && DISABLED(INTEGRATED_BABYSTEPPING)
   #include "../feature/babystep.h"
 #endif
 
@@ -3010,7 +3010,7 @@ void Temperature::tick() {
   // Additional ~1KHz Tasks
   //
 
-  #if ENABLED(BABYSTEPPING)
+  #if ENABLED(BABYSTEPPING) && DISABLED(INTEGRATED_BABYSTEPPING)
     babystep.task();
   #endif
 


### PR DESCRIPTION
### Description

This PR adds an option to move the call to `babystep.task` out of the Temperature ISR, where timing control is not easily possible, and into the Stepper ISR scheduler, so that we can address TMC drivers that respond to babystepping with a standstill shutdown.

- The first step is to get the function working in the same manner as it does currently.
- The next step is to add a buffering interval so that the added STEP pulses always occur at some minimum interval from regular steps (in order to prevent the TMC StandStill error from being thrown).
- For boards that can handle the extra processing, I will attempt to add more logic to this feature to intentionally skip steps at regular intervals instead of reversing the stepper direction when babysteps oppose the current direction of motion, at which point babystepping will be wholly integrated into the stepper class.

### Benefits
- The Temperature ISR no longer has to call the babystep task
- The Stepper ISR is not blocked from outside
- The `babystepping_isr` is scheduled from `Stepper::isr`
