### PR TITLE
[AGCM4] Prevent pin glitches on out commutation

### DIFF
--- a/Marlin/src/HAL/HAL_SAMD51/fastio.h
+++ b/Marlin/src/HAL/HAL_SAMD51/fastio.h
@@ -88,8 +88,8 @@
                                   const EPortType port = (EPortType)GET_SAMD_PORT(IO);              \
                                   const uint32_t pin = GET_SAMD_PIN(IO);                            \
                                                                                                     \
-                                  PORT->Group[port].PINCFG[pin].reg = (uint8_t)(PORT_PINCFG_INEN);  \
                                   PORT->Group[port].DIRSET.reg = MASK(pin);                         \
+                                  PORT->Group[port].PINCFG[pin].reg = 0;                            \
                                 }while(0)
 // Set pin as output (open drain)
 #define SET_OUTPUT_OD(IO)       do{                                                                   \


### PR DESCRIPTION
This should be better when switching from pulled input to output and also set real output (with no input enabled)