### PR TITLE
Stop timer when M140 has target temp below mintemp

### DIFF
--- a/Marlin/src/gcode/temperature/M140_M190.cpp
+++ b/Marlin/src/gcode/temperature/M140_M190.cpp
@@ -51,6 +51,15 @@
 void GcodeSuite::M140() {
   if (DEBUGGING(DRYRUN)) return;
   if (parser.seenval('S')) thermalManager.setTargetBed(parser.value_celsius());
+
+  #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
+    /**
+     * Stop the timer at the end of print. Both hotend and bed target
+     * temperatures need to be set below mintemp. Order of M140 and M104
+     * at the end of the print does not matter.
+     */
+    thermalManager.check_timer_autostart(false, true);
+  #endif
 }
 
 /**


### PR DESCRIPTION
### Requirements

1. Print from OctoPrint
1. Have the following as end g-code
> M104 S0 ; turn off temperature  
M140 S0 ; turn off heatbed

At the end of the print, check LCD menu and you will see that Marlin thinks that we are still printing. That sequence of gcode used to work fine until Marlin 2.0.1. I found this PR https://github.com/MarlinFirmware/Marlin/pull/16749 that solves a problem with M104. With this PR we are going to be full backwards compatible.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

The fix was to call _thermalManager.check_timer_autostart_ when executing M140. Just like it is done when executing M104. With this fix the order of gcode commands does not matter.

### Benefits

<!-- What does this fix or improve? -->

Makes Marlin backwards compatible by accepting any order between M140 & M104

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->

https://github.com/MarlinFirmware/Marlin/pull/16749
