### PR TITLE
Remove unused GCodeQueue::Stopped_N

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -798,7 +798,6 @@ void stop() {
   #endif
 
   if (IsRunning()) {
-    queue.stop();
     SERIAL_ERROR_MSG(MSG_ERR_STOPPED);
     LCD_MESSAGEPGM(MSG_STOPPED);
     safe_delay(350);       // allow enough time for messages to get out before stopping

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -52,7 +52,7 @@ GCodeQueue queue;
  * sending commands to Marlin, and lines will be checked for sequentiality.
  * M110 N<int> sets the current line number.
  */
-long gcode_N, GCodeQueue::last_N, GCodeQueue::stopped_N = 0;
+long gcode_N, GCodeQueue::last_N;
 
 /**
  * GCode Command Queue

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -35,9 +35,7 @@ public:
    * commands to Marlin, and lines will be checked for sequentiality.
    * M110 N<int> sets the current line number.
    */
-  static long last_N, stopped_N;
-
-  static inline void stop() { stopped_N = last_N; }
+  static long last_N;
 
   /**
    * GCode Command Queue


### PR DESCRIPTION
`GCodeQueue::stopped_N` is never used. 
Therefore `queue.stop()` is useless too.