### PR TITLE
remove comments from EINSY RAMBo pin definitions

### DIFF
--- a/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
@@ -172,8 +172,8 @@
       #define BTN_EN2         72
     #endif
 
-    #define BTN_ENC            9   // AUX-2
-    #define BEEPER_PIN        84   // AUX-4
+    #define BTN_ENC            9 
+    #define BEEPER_PIN        84 
     #define SD_DETECT_PIN     15
 
   #endif // ULTIPANEL || TOUCH_UI_ULTIPANEL


### PR DESCRIPTION
to prevent this compilation error:
```
sketch/src/inc/../pins/rambo/pins_EINSY_RAMBO.h:176:36: error: pasting "/* AUX-4*/" and "_RPORT" does not give a valid preprocessing token
     #define BEEPER_PIN        84   // AUX-4
```
