### PR TITLE
Double ADC read frequency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -138,7 +138,6 @@ board         = sanguino_atmega1284p
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-build_flags   = ${common.build_flags}
 lib_ignore    = TMCStepper
 upload_speed  = 57600
 
@@ -151,7 +150,6 @@ board         = sanguino_atmega1284p
 lib_deps      = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter    = ${common.default_src_filter} +<src/HAL/HAL_AVR>
-build_flags   = ${common.build_flags}
 lib_ignore    = TMCStepper
 upload_speed  = 115200
 


### PR DESCRIPTION
**Background:** ADC needs a small (one ISR run = ~1ms) delay between readings in instances where the same device is being read, but this delay is not needed when reading devices in sequence.

**Problem:** Marlin only does a single phase in each Temperature ISR, waiting until the next 1ms tick after an ADC Read phase before doing the next ADC Prepare phase.

**Solution:** This PR splits up the ADC phases into two groups. The current read phase will be run first, then the next Prepare (or other) phase will be run. It is guaranteed that at least one ADC Prepare phase will be run in every Temperature ISR.

**Benefits:**
- New sensor readings are ready in only half the time.
- Improved resolution should improve PID dynamics.
- Deals with the Heisenberg uncertainty principle.

[[Concise Diff](16864/files?w=1)]