### PR TITLE
Quick-homing sensorless back-off

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -106,7 +106,7 @@
       #if AXIS_HAS_STALLGUARD(Y2)
         tmc_disable_stallguard(stepperY2, stealth_states.y2);
       #endif
-      do_blocking_move_to_xy(0.5 * x_axis_home_dir, 0.5 * home_dir(Y_AXIS), fr_mm_s / 2);
+      do_blocking_move_to_xy(-0.5 * x_axis_home_dir, -0.5 * home_dir(Y_AXIS), fr_mm_s / 2);
       safe_delay(100);
     #endif
   }

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -106,6 +106,8 @@
       #if AXIS_HAS_STALLGUARD(Y2)
         tmc_disable_stallguard(stepperY2, stealth_states.y2);
       #endif
+      do_blocking_move_to_xy(0.5 * x_axis_home_dir, 0.5 * home_dir(Y_AXIS), fr_mm_s / 2);
+      safe_delay(100);
     #endif
   }
 


### PR DESCRIPTION
Add a small backoff and small delay to help quick homing with sensorless homing.