### PR TITLE
[ESP32] Explicitly pin I2S stepper task to core 1 to prevent interference with WiFi task on core 0

### DIFF
--- a/Marlin/src/HAL/HAL_ESP32/i2s.cpp
+++ b/Marlin/src/HAL/HAL_ESP32/i2s.cpp
@@ -308,7 +308,7 @@ int i2s_init() {
   esp_intr_enable(i2s_isr_handle);
 
   // Create the task that will feed the buffer
-  xTaskCreate(stepperTask, "StepperTask", 10000, nullptr, 1, nullptr);
+  xTaskCreatePinnedToCore(stepperTask, "StepperTask", 10000, nullptr, 1, nullptr, CONFIG_ARDUINO_RUNNING_CORE); // run I2S stepper task on same core as rest of Marlin
 
   // Route the i2s pins to the appropriate GPIO
   gpio_matrix_out_check(I2S_DATA, I2S0O_DATA_OUT23_IDX, 0, 0);

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -335,8 +335,8 @@
 // Espressif ESP32 WiFi
 //
 #define BOARD_ESPRESSIF_ESP32         6000  // Generic ESP32
-#define BOARD_MRR_ESPA                6001
-#define BOARD_MRR_ESPE                6002
+#define BOARD_MRR_ESPA                6001  // MRR ESPA board based on ESP32 (native pins only)
+#define BOARD_MRR_ESPE                6002  // MRR ESPE board based on ESP32 (with I2S stepper stream)
 #define BOARD_E4D_BOX                 6003  // E4d@BOX
 
 //


### PR DESCRIPTION
### Description

The ESP32 has two cores. The default core for Arduino code is core 1, while ESP3DLib is set to run on core 0 so that WiFi does not interfere with printing code. However, the I2S stepper stream is called in `HAL_init()` and may result in the I2S stepper task being run on core 0 instead (because core 0 is the unused core; ESP3DLib code is only initialized and pinned to core 0 when `HAL_init_board()` is called, and that is after `HAL_init()`). To prevent possible interference between I2S stepper task and wifi task running on the same core, the I2S stepper task should explicitly be pinned to run on the same core as the rest of the Marlin (non-Wifi related) code.

Interference was actually noticed during prints; I had times when bad Wifi connection resulted in my printings halting every once in a while in a random manner. Such a phenomenon was observed only when Wifi was bad in my area, which made me think interference between Wifi and I2S stepper could be the reason.

Side note: This commit also added description in `boards.h` for MRR ESPA and MRR ESPE as I noticed they are the only two boards without a proper description.

### Benefits

Having the I2S stepper task explicitly pinned to the same core as the rest of the non-wifi related Marlin code should mean that wifi connectivity will not affect the rest of the firmware. I2S stepper timing should also be consistent with other single-core platforms.

The added descriptions in `boards.h` makes for consistency in format.
