### PR TITLE
TMC2209 - Disable spreadcycle in tmc_enable_stallguard(TMC2209Stepper &st)

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -1096,8 +1096,11 @@
   }
 
   bool tmc_enable_stallguard(TMC2209Stepper &st) {
+    const bool stealthchop_was_enabled = !st.en_spreadCycle();
+    
     st.TCOOLTHRS(0xFFFFF);
-    return !st.en_spreadCycle();
+    st.en_spreadCycle(false);
+    return stealthchop_was_enabled;
   }
   void tmc_disable_stallguard(TMC2209Stepper &st, const bool restore_stealth) {
     st.en_spreadCycle(!restore_stealth);


### PR DESCRIPTION
### Description

Sensorless homing doesn't work on TMC2209 if spreadcycle was enabled before the homing operation. The function `bool tmc_enable_stallguard(TMC2209Stepper &st)` is missing a call to disable spreadcycle.

### Benefits

Sensorless homing now works regardless if spreadcycle or stealthchop was enabled before homing. The previous stepping mode is restored after homing.

### Related Issues

#16091 
