### PR TITLE
Fix EEPROM errors when EXTRUDERS == 0

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -323,7 +323,7 @@ typedef struct SettingsDataStruct {
   //
   // LIN_ADVANCE
   //
-  float planner_extruder_advance_K[EXTRUDERS];          // M900 K  planner.extruder_advance_K
+  float planner_extruder_advance_K[_MAX(EXTRUDERS, 1)]; // M900 K  planner.extruder_advance_K
 
   //
   // HAS_MOTOR_CURRENT_PWM
@@ -1246,7 +1246,7 @@ void MarlinSettings::postprocess() {
         EEPROM_WRITE(planner.extruder_advance_K);
       #else
         dummy = 0;
-        for (uint8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummy);
+        for (uint8_t q = _MAX(EXTRUDERS, 1); q--;) EEPROM_WRITE(dummy);
       #endif
     }
 
@@ -2091,14 +2091,12 @@ void MarlinSettings::postprocess() {
       // Linear Advance
       //
       {
+        float extruder_advance_K[_MAX(EXTRUDERS, 1)];
         _FIELD_TEST(planner_extruder_advance_K);
-        #if EXTRUDERS
-          float extruder_advance_K[EXTRUDERS];
-          EEPROM_READ(extruder_advance_K);
-          #if ENABLED(LIN_ADVANCE)
-            if (!validating)
-              COPY(planner.extruder_advance_K, extruder_advance_K);
-          #endif
+        EEPROM_READ(extruder_advance_K);
+        #if ENABLED(LIN_ADVANCE)
+          if (!validating)
+            COPY(planner.extruder_advance_K, extruder_advance_K);
         #endif
       }
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1246,7 +1246,7 @@ void MarlinSettings::postprocess() {
         EEPROM_WRITE(planner.extruder_advance_K);
       #else
         dummy = 0;
-        for (uint8_t q = _MAX(EXTRUDERS, 1); q--;) EEPROM_WRITE(dummy);
+        for (uint8_t q = EXTRUDERS; q--;) EEPROM_WRITE(dummy);
       #endif
     }
 
@@ -2091,12 +2091,14 @@ void MarlinSettings::postprocess() {
       // Linear Advance
       //
       {
-        float extruder_advance_K[_MAX(EXTRUDERS, 1)];
         _FIELD_TEST(planner_extruder_advance_K);
-        EEPROM_READ(extruder_advance_K);
-        #if ENABLED(LIN_ADVANCE)
-          if (!validating)
-            COPY(planner.extruder_advance_K, extruder_advance_K);
+        #if EXTRUDERS
+          float extruder_advance_K[EXTRUDERS];
+          EEPROM_READ(extruder_advance_K);
+          #if ENABLED(LIN_ADVANCE)
+            if (!validating)
+              COPY(planner.extruder_advance_K, extruder_advance_K);
+          #endif
         #endif
       }
 


### PR DESCRIPTION

### Description

This is a fix for an error (partly mine) on a previous PR that fixed EEPROM for EXTRUDERS == 0.  (https://github.com/MarlinFirmware/Marlin/pull/16464)

Previously, the MIN(EXTRUDERS, 1) was a bonehead mistake that would have broken multi-extruders but had no meaningful effect for EXTRUDERS == 0.  A subsequent change to the more 'sane' MAX(EXTRUDERS, 1) ended up breaking EXTRUDERS == 0.

The problem in its current state appears to be that forcing store/retrieve of one element (even when EXTRUDERS == 0) is inconsistent with offsetof() calculation based on the size of planner_extruder_advance_K which is zero.  Instead, use save/retrieve of zero elements. This is natural for the saving (remove _MAX()), no special consideration needed.  For the retrieval, a simple #ifdef covers it.  Reading a zero-sized object is not equivalent to suppressing the reading altogether, which is why this is needed.

### Benefits

EEPROM data size error no longer occurs when EXTRUDERS == 0.

### Related Issues

Related to PR https://github.com/MarlinFirmware/Marlin/pull/16464