### PR TITLE
Port redirect for movement command message when stop

### DIFF
--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -469,6 +469,7 @@ void GCodeQueue::get_serial_commands() {
               #if ENABLED(BEZIER_CURVE_SUPPORT)
                 case 5:
               #endif
+                PORT_REDIRECT(i);                      // Reply to the serial port that sent the command
                 SERIAL_ECHOLNPGM(MSG_ERR_STOPPED);
                 LCD_MESSAGEPGM(MSG_STOPPED);
                 break;


### PR DESCRIPTION
Small fix, add Port Redirect for movement command message when printer stop.