### PR TITLE
CoreXY Babystepping hotfix followup

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2564,7 +2564,7 @@ void Stepper::report_positions() {
           #elif CORE_IS_XZ
             BABYSTEP_CORE(X, Z, 0, direction, 0);
           #else
-            BABYSTEP_AXIS(X, 0, direction, 0);
+            BABYSTEP_AXIS(X, 0, direction);
           #endif
           break;
 
@@ -2574,7 +2574,7 @@ void Stepper::report_positions() {
           #elif CORE_IS_YZ
             BABYSTEP_CORE(Y, Z, 0, direction, (CORESIGN(1)<0));
           #else
-            BABYSTEP_AXIS(Y, 0, direction, (CORESIGN(1)<0));
+            BABYSTEP_AXIS(Y, 0, direction);
           #endif
           break;
 
@@ -2587,7 +2587,7 @@ void Stepper::report_positions() {
         #elif CORE_IS_YZ
           BABYSTEP_CORE(Y, Z, BABYSTEP_INVERT_Z, direction, (CORESIGN(1)<0));
         #elif DISABLED(DELTA)
-          BABYSTEP_AXIS(Z, BABYSTEP_INVERT_Z, direction, (CORESIGN(1)<0));
+          BABYSTEP_AXIS(Z, BABYSTEP_INVERT_Z, direction);
 
         #else // DELTA
 


### PR DESCRIPTION
### Description

CoreXY Babystepping hotfix (484e1a6) was applied to `2.0.x`, but not `bugfix-2.0.x`.

### Benefits

Cartesian users running `bugfix-2.0.x` can successfully compile if babystepping is enabled.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/16920, https://github.com/MarlinFirmware/Marlin/issues/16889