### PR TITLE
Define ANET_FULL_GRAPHICS_LCD pins for SKR 1.4

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -232,9 +232,19 @@
  *              EXP2                                              EXP1
  */
 #if HAS_SPI_LCD
-  #define BTN_ENC          P0_28   // (58) open-drain
+  #if ENABLED(ANET_FULL_GRAPHICS_LCD)
 
-  #if ENABLED(CR10_STOCKDISPLAY)
+    #define LCD_PINS_RS    P1_23
+
+    #define BTN_EN1        P1_20
+    #define BTN_EN2        P1_22
+    #define BTN_ENC        P1_18
+
+    #define LCD_PINS_ENABLE P1_21
+    #define LCD_PINS_D4    P1_19
+
+  #elif  ENABLED(CR10_STOCKDISPLAY)
+    #define BTN_ENC          P0_28   // (58) open-drain
     #define LCD_PINS_RS    P1_22
 
     #define BTN_EN1        P1_18
@@ -244,6 +254,7 @@
     #define LCD_PINS_D4    P1_21
 
   #else
+    #define BTN_ENC          P0_28   // (58) open-drain
     #define LCD_PINS_RS    P1_19
 
     #define BTN_EN1        P3_26   // (31) J3-2 & AUX-4

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -243,7 +243,7 @@
     #define LCD_PINS_ENABLE P1_21
     #define LCD_PINS_D4    P1_19
 
-  #elif  ENABLED(CR10_STOCKDISPLAY)
+  #elif ENABLED(CR10_STOCKDISPLAY)
     #define BTN_ENC        P0_28   // (58) open-drain
     #define LCD_PINS_RS    P1_22
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -244,7 +244,7 @@
     #define LCD_PINS_D4    P1_19
 
   #elif  ENABLED(CR10_STOCKDISPLAY)
-    #define BTN_ENC          P0_28   // (58) open-drain
+    #define BTN_ENC        P0_28   // (58) open-drain
     #define LCD_PINS_RS    P1_22
 
     #define BTN_EN1        P1_18
@@ -254,7 +254,7 @@
     #define LCD_PINS_D4    P1_21
 
   #else
-    #define BTN_ENC          P0_28   // (58) open-drain
+    #define BTN_ENC        P0_28   // (58) open-drain
     #define LCD_PINS_RS    P1_19
 
     #define BTN_EN1        P3_26   // (31) J3-2 & AUX-4


### PR DESCRIPTION
### Description

Fixes the non-working ANET_FULL_GRAPHICS_LCD for the SKR 1.4 and SKR 1.4 Turbo boards by implementing the code from the SKR 1.3 board. Confirmed working by me  (@zmiguel) on SKR 1.4 Turbo

### Benefits

Add support for the ANET_FULL_GRAPHICS_LCD on SKR 1.4 boards, allowing people to easily upgrade their Anet printers without replacing the LCD

### Related Issues

None