### PR TITLE
Reduce default TMC baud rate to 57600 when using Software Serial

### DIFF
--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -117,7 +117,16 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 #endif
 
 #ifndef TMC_BAUD_RATE
-  #define TMC_BAUD_RATE 115200
+  #if HAS_TMC_SW_SERIAL
+    // Reduce baud rate for boards not already overriding TMC_BAUD_RATE for software serial.
+    // Testing has shown that 115200 is not 100% reliable on AVR platforms, occasionally
+    // failing to read status properly. 32-bit platforms typically define an even lower
+    // TMC_BAUD_RATE, due to differences in how SoftwareSerial libraries work on different
+    // platforms.
+    #define TMC_BAUD_RATE 57600
+  #else
+    #define TMC_BAUD_RATE 115200
+  #endif
 #endif
 
 #if HAS_DRIVER(TMC2130)


### PR DESCRIPTION
### Description

AVR boards use the default TMC_BAUD_RATE of 115200, which is not 100% reliable when using software serial. It works most of the time, but sporadic TMC connection failures occur.

The TMCStepper library will attempt to repeat a failed read once before giving up. This further reduces the likelihood of the error, but it still happens.

Using a single TMC2209 I performed 10,000 M122 iterations in three different ways.
TMC_DEBUG was disabled, so this returned a simple pass/fail status for each driver.
My testing was done with the default config on a Mega2560/RAMPS, with the X driver as a TMC2209.

1. With default 115200, and default TMCStepper
2. With default 115200, with TMCStepper modified to only attempt reads one time
3. With baud rate reduced to 57600, also with retries disabled.

This experiment shows that about 4.28% of single-driver M122 calls fail. The retry hides most of these, but doesn't completely solve the problem. About 0.18% of M122 commands still failed, and this increases as more drivers are added. After reducing the baud rate, I see zero failures, even if I am talking to four drivers.

![image](https://user-images.githubusercontent.com/20053467/75102074-2f977100-559a-11ea-9aa7-13732e34b629.png)


### Benefits

Eliminate spurious TMC Connection issues when using AVR controllers with software serial.

### Related Issues

This comes up regularly in Discord, but I can't find an existing issue documenting it directly.
I have certainly encountered it myself when testing the single-pin AVR serial changes a while back.
