### PR TITLE
Case-insensitive G-code option

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2791,6 +2791,8 @@
   //#define GCODE_QUOTED_STRINGS  // Support for quoted string parameters
 #endif
 
+//#define GCODE_CASE_INSENSITIVE  // Accept G-code sent to the firmware in lowercase
+
 /**
  * CNC G-code options
  * Support CNC-style G-code dialects used by laser cutters, drawing machine cams, etc.

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -118,11 +118,18 @@ void GCodeParser::parse(char *p) {
 
   reset(); // No codes to report
 
+  auto uppercase = [](char c) {
+    #if ENABLED(GCODE_CASE_INSENSITIVE)
+      if (WITHIN(c, 'a', 'z')) c += 'A' - 'a';
+    #endif
+    return c;
+  };
+
   // Skip spaces
   while (*p == ' ') ++p;
 
   // Skip N[-0-9] if included in the command line
-  if (*p == 'N' && NUMERIC_SIGNED(p[1])) {
+  if (uppercase(*p) == 'N' && NUMERIC_SIGNED(p[1])) {
     #if ENABLED(FASTER_GCODE_PARSER)
       //set('N', p + 1);     // (optional) Set the 'N' parameter value
     #endif
@@ -135,7 +142,7 @@ void GCodeParser::parse(char *p) {
   command_ptr = p;
 
   // Get the command letter, which must be G, M, or T
-  const char letter = *p++;
+  const char letter = uppercase(*p++);
 
   // Nullify asterisk and trailing whitespace
   char *starpos = strchr(p, '*');
@@ -271,7 +278,7 @@ void GCodeParser::parse(char *p) {
     bool quoted_string_arg = false;
   #endif
   string_arg = nullptr;
-  while (const char param = *p++) {              // Get the next parameter. A NUL ends the loop
+  while (const char param = uppercase(*p++)) {  // Get the next parameter. A NUL ends the loop
 
     // Special handling for M32 [P] !/path/to/file.g#
     // The path must be the last parameter
@@ -289,14 +296,14 @@ void GCodeParser::parse(char *p) {
       }
     #endif
 
-    // Arguments MUST be uppercase for fast GCode parsing
     #if ENABLED(FASTER_GCODE_PARSER)
-      #define PARAM_TEST WITHIN(param, 'A', 'Z')
+      // Arguments MUST be uppercase for fast GCode parsing
+      #define PARAM_OK(P) WITHIN((P), 'A', 'Z')
     #else
-      #define PARAM_TEST true
+      #define PARAM_OK(P) true
     #endif
 
-    if (PARAM_TEST) {
+    if (PARAM_OK(param)) {
 
       while (*p == ' ') p++;                    // Skip spaces between parameters & values
 


### PR DESCRIPTION
What does a case-insensitive g-code parser look like? This is the answer. It adds a little more overhead, but it can then interpret lowercase letters in g-code as if they were uppercase letters.