### PR TITLE
Indirect 'defined' in AXIS_HAS_SW_SERIAL for REPEAT compatibility

### DIFF
--- a/Marlin/src/core/drivers.h
+++ b/Marlin/src/core/drivers.h
@@ -131,7 +131,7 @@
 #define AXIS_HAS_UART(A) (    AXIS_DRIVER_TYPE(A,TMC2208) \
                            || AXIS_DRIVER_TYPE(A,TMC2209) )
 
-#define AXIS_HAS_SW_SERIAL(A) ((AXIS_HAS_UART(A) && !defined(A##_HARDWARE_SERIAL)))
+#define AXIS_HAS_SW_SERIAL(A) ((AXIS_HAS_UART(A) && !HAS_##A##_HARDWARE_SERIAL))
 
 #define AXIS_HAS_STALLGUARD(A)   (    AXIS_DRIVER_TYPE(A,TMC2130) \
                                    || AXIS_DRIVER_TYPE(A,TMC2160) \

--- a/Marlin/src/core/drivers.h
+++ b/Marlin/src/core/drivers.h
@@ -131,7 +131,7 @@
 #define AXIS_HAS_UART(A) (    AXIS_DRIVER_TYPE(A,TMC2208) \
                            || AXIS_DRIVER_TYPE(A,TMC2209) )
 
-#define AXIS_HAS_SW_SERIAL(A) ((AXIS_HAS_UART(A) && !HAS_##A##_HARDWARE_SERIAL))
+#define AXIS_HAS_SW_SERIAL(A) (AXIS_HAS_UART(A) && ISDEF(A##_HARDWARE_SERIAL))
 
 #define AXIS_HAS_STALLGUARD(A)   (    AXIS_DRIVER_TYPE(A,TMC2130) \
                                    || AXIS_DRIVER_TYPE(A,TMC2160) \

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -195,6 +195,8 @@
 #define BOTH(V1,V2)         ALL(V1,V2)
 #define EITHER(V1,V2)       ANY(V1,V2)
 
+#define ISDEF(X)            defined(X)
+
 // Macros to support pins/buttons exist testing
 #define PIN_EXISTS(PN)      (defined(PN##_PIN) && PN##_PIN >= 0)
 #define _PINEX_1            PIN_EXISTS

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1444,59 +1444,6 @@
 #define HAS_Z4_MAX (PIN_EXISTS(Z4_MAX))
 #define HAS_Z_MIN_PROBE_PIN (HAS_CUSTOM_PROBE_PIN && PIN_EXISTS(Z_MIN_PROBE))
 
-// Cannot use a macro with a defined() statement inside REPEAT macros.
-// [AXIS]_HARDWARE_SERIAL definitions are typically strings which cannot be
-// tested directly, as they will evaluate to 0.
-#ifdef X_HARDWARE_SERIAL
-  #define HAS_X_HARDWARE_SERIAL 1
-#endif
-#ifdef X2_HARDWARE_SERIAL
-  #define HAS_X2_HARDWARE_SERIAL 1
-#endif
-#ifdef Y_HARDWARE_SERIAL
-  #define HAS_Y_HARDWARE_SERIAL 1
-#endif
-#ifdef Y2_HARDWARE_SERIAL
-  #define HAS_Y2_HARDWARE_SERIAL 1
-#endif
-#ifdef Z_HARDWARE_SERIAL
-  #define HAS_Z_HARDWARE_SERIAL 1
-#endif
-#ifdef Z2_HARDWARE_SERIAL
-  #define HAS_Z2_HARDWARE_SERIAL 1
-#endif
-#ifdef Z3_HARDWARE_SERIAL
-  #define HAS_Z3_HARDWARE_SERIAL 1
-#endif
-#ifdef Z4_HARDWARE_SERIAL
-  #define HAS_Z4_HARDWARE_SERIAL 1
-#endif
-#ifdef E0_HARDWARE_SERIAL
-  #define HAS_E0_HARDWARE_SERIAL 1
-#endif
-#ifdef E1_HARDWARE_SERIAL
-  #define HAS_E1_HARDWARE_SERIAL 1
-#endif
-#ifdef E2_HARDWARE_SERIAL
-  #define HAS_E2_HARDWARE_SERIAL 1
-#endif
-#ifdef E3_HARDWARE_SERIAL
-  #define HAS_E3_HARDWARE_SERIAL 1
-#endif
-#ifdef E4_HARDWARE_SERIAL
-  #define HAS_E4_HARDWARE_SERIAL 1
-#endif
-#ifdef E5_HARDWARE_SERIAL
-  #define HAS_E5_HARDWARE_SERIAL 1
-#endif
-#ifdef E6_HARDWARE_SERIAL
-  #define HAS_E6_HARDWARE_SERIAL 1
-#endif
-#ifdef E7_HARDWARE_SERIAL
-  #define HAS_E7_HARDWARE_SERIAL 1
-#endif
-
-
 //
 // ADC Temp Sensors (Thermistor or Thermocouple with amplifier ADC interface)
 //

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1444,6 +1444,59 @@
 #define HAS_Z4_MAX (PIN_EXISTS(Z4_MAX))
 #define HAS_Z_MIN_PROBE_PIN (HAS_CUSTOM_PROBE_PIN && PIN_EXISTS(Z_MIN_PROBE))
 
+// Cannot use a macro with a defined() statement inside REPEAT macros.
+// [AXIS]_HARDWARE_SERIAL definitions are typically strings which cannot be
+// tested directly, as they will evaluate to 0.
+#ifdef X_HARDWARE_SERIAL
+  #define HAS_X_HARDWARE_SERIAL 1
+#endif
+#ifdef X2_HARDWARE_SERIAL
+  #define HAS_X2_HARDWARE_SERIAL 1
+#endif
+#ifdef Y_HARDWARE_SERIAL
+  #define HAS_Y_HARDWARE_SERIAL 1
+#endif
+#ifdef Y2_HARDWARE_SERIAL
+  #define HAS_Y2_HARDWARE_SERIAL 1
+#endif
+#ifdef Z_HARDWARE_SERIAL
+  #define HAS_Z_HARDWARE_SERIAL 1
+#endif
+#ifdef Z2_HARDWARE_SERIAL
+  #define HAS_Z2_HARDWARE_SERIAL 1
+#endif
+#ifdef Z3_HARDWARE_SERIAL
+  #define HAS_Z3_HARDWARE_SERIAL 1
+#endif
+#ifdef Z4_HARDWARE_SERIAL
+  #define HAS_Z4_HARDWARE_SERIAL 1
+#endif
+#ifdef E0_HARDWARE_SERIAL
+  #define HAS_E0_HARDWARE_SERIAL 1
+#endif
+#ifdef E1_HARDWARE_SERIAL
+  #define HAS_E1_HARDWARE_SERIAL 1
+#endif
+#ifdef E2_HARDWARE_SERIAL
+  #define HAS_E2_HARDWARE_SERIAL 1
+#endif
+#ifdef E3_HARDWARE_SERIAL
+  #define HAS_E3_HARDWARE_SERIAL 1
+#endif
+#ifdef E4_HARDWARE_SERIAL
+  #define HAS_E4_HARDWARE_SERIAL 1
+#endif
+#ifdef E5_HARDWARE_SERIAL
+  #define HAS_E5_HARDWARE_SERIAL 1
+#endif
+#ifdef E6_HARDWARE_SERIAL
+  #define HAS_E6_HARDWARE_SERIAL 1
+#endif
+#ifdef E7_HARDWARE_SERIAL
+  #define HAS_E7_HARDWARE_SERIAL 1
+#endif
+
+
 //
 // ADC Temp Sensors (Thermistor or Thermocouple with amplifier ADC interface)
 //

--- a/buildroot/share/tests/esp32-tests
+++ b/buildroot/share/tests/esp32-tests
@@ -18,5 +18,20 @@ opt_set TX_BUFFER_SIZE 64
 opt_add WEBSUPPORT
 exec_test $1 $2 "ESP32 with WIFISUPPORT and WEBSUPPORT"
 
+#
+# Build with TMC drivers using hardware serial
+#
+restore_configs
+opt_set MOTHERBOARD BOARD_ESPRESSIF_ESP32
+opt_set X_DRIVER_TYPE TMC2209
+opt_set Y_DRIVER_TYPE TMC2208
+opt_set Z_DRIVER_TYPE TMC2209
+opt_set E0_DRIVER_TYPE TMC2209
+opt_set X_HARDWARE_SERIAL Serial1
+opt_set Y_HARDWARE_SERIAL Serial1
+opt_set Z_HARDWARE_SERIAL Serial1
+opt_set E0_HARDWARE_SERIAL Serial1
+exec_test $1 $2 "ESP32 with TMC Hardware Serial"
+
 # cleanup
 restore_configs


### PR DESCRIPTION
### Description

The `HAS_TMC_SW_SERIAL` is always returning true when TMC2208 or TMC2209 drivers are used, even when `HARDWARE_SERIAL` is defined for all axis.

This is occurring because the `defined(A##_HARDWARE_SERIAL)` portion of `AXIS_HAS_SW_SERIAL` is always evaluating to false when used inside the `RREPEAT2` macro.

I have tried to find a way to get the `defined` statement to resolve properly inside `RREPEAT2`, without success. 

I see three possible solutions to this:

1. Fix the `AXIS_HAS_SW_SERIAL` macro so that `defined()` works as expected (I was unsuccessful)
2. Do not use a REPEAT macro in `HAS_E_DRIVER` (smallest change)
3. Define constants that are evaluated directly, as I have done in this review.

**A lot less code will be needed if RREPEAT2 is simply not used in drivers.h. I posted this alternative to facilitate a discussion regarding limitations of these repeat macros, which might influence their usage in other places. Trying to use RREPEAT2 with other similar macros (such as `PIN_EXISTS`) probably would have the same issue.**

### Benefits

Fixes `HAS_TMC_SW_SERIAL`.
esp32 was unable to build with 2208/9 drivers, because the HAL doesn't support software serial.
AVR users were probably also hitting sanity checks if using `MONITOR_DRIVER_STATUS` with hardware serial ports.

### Related Issues

#16915 
