### PR TITLE
Ensure proper SD print completion

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -391,7 +391,7 @@ void startOrResumeJob() {
 #if ENABLED(SDSUPPORT)
 
   inline void abortSDPrinting() {
-    card.stopSDPrint(
+    card.endFilePrint(
       #if SD_RESORT
         true
       #endif

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -390,7 +390,7 @@ void startOrResumeJob() {
 
 #if ENABLED(SDSUPPORT)
 
-  void abortSDPrinting() {
+  inline void abortSDPrinting() {
     card.stopSDPrint(
       #if SD_RESORT
         true
@@ -412,10 +412,68 @@ void startOrResumeJob() {
     #endif
   }
 
-#endif
+  #if ENABLED(PRINTER_EVENT_LEDS)
+    #include "feature/leds/printer_event_leds.h"
+  #endif
+
+  inline void finishSDPrinting() {
+    bool did_state = true;
+    switch (card.sdprinting_done_state) {
+
+      #if ENABLED(PRINTER_EVENT_LEDS)
+        case 1:
+          printerEventLEDs.onPrintCompleted();  // Change LED color for Print Completed
+          break;
+      #endif
+
+      #if HAS_RESUME_CONTINUE                   // Display "Click to Continue..."
+        case 2:
+          did_state = queue.enqueue_P(PSTR("M0 S"
+            #if HAS_LCD_MENU
+              "1800"                            // ...for 30 minutes with LCD
+            #else
+              "60"                              // ...for 1 minute with no LCD
+            #endif
+          ));
+          break;
+      #endif
+
+      case 3: print_job_timer.stop(); break;
+
+      case 4:
+        did_state = print_job_timer.duration() < 60 || queue.enqueue_P(PSTR("M31"));
+        break;
+
+      case 5:
+        #if ENABLED(POWER_LOSS_RECOVERY)
+          recovery.purge();
+        #endif
+
+        #if ENABLED(SD_FINISHED_STEPPERRELEASE) && defined(SD_FINISHED_RELEASECOMMAND)
+          planner.finish_and_disable();
+        #endif
+
+        #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
+          ui.set_progress_done();
+        #endif
+
+        #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
+          ui.reselect_last_file();
+        #endif
+
+        SERIAL_ECHOLNPGM(MSG_FILE_PRINTED);
+
+      default:
+        did_state = false;
+        card.sdprinting_done_state = 0;
+    }
+    if (did_state) ++card.sdprinting_done_state;
+  }
+
+#endif // SDSUPPORT
 
 /**
- * Manage several activities:
+ * Minimal management of Marlin's core activities:
  *  - Check for Filament Runout
  *  - Keep the command buffer full
  *  - Check for maximum inactive time between commands
@@ -1122,10 +1180,15 @@ void setup() {
 /**
  * The main Marlin program loop
  *
- *  - Save or log commands to SD
- *  - Process available commands (if not saving)
- *  - Call endstop manager
- *  - Call inactivity manager
+ *  - Call idle() to handle all tasks between G-code commands
+ *      Note that no G-codes from the queue can be executed during idle()
+ *      but many G-codes can be called directly anytime like macros.
+ *  - Check whether SD card auto-start is needed now.
+ *  - Check whether SD print finishing is needed now.
+ *  - Run one G-code command from the immediate or main command queue
+ *    and open up one space. Commands in the main queue may come from sd
+ *    card, host, or by direct injection. The queue will continue to fill
+ *    as long as idle() or manage_inactivity() are being called.
  */
 void loop() {
   do {
@@ -1135,6 +1198,7 @@ void loop() {
     #if ENABLED(SDSUPPORT)
       card.checkautostart();
       if (card.flag.abort_sd_printing) abortSDPrinting();
+      if (card.sdprinting_done_state) finishSDPrinting();
     #endif
 
     queue.advance();

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -117,6 +117,12 @@ public:
    */
   static void flush_and_request_resend();
 
+  /**
+   * Attempt to enqueue a single G-code command
+   * and return 'true' if successful.
+   */
+  FORCE_INLINE static bool enqueue_P(const char* cmd) { return _enqueue(cmd); }
+
 private:
 
   static uint8_t index_w;  // Ring buffer write position

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -324,9 +324,9 @@ void MarlinUI::_synchronize() {
   if (should_draw()) MenuItem_static::draw(LCD_HEIGHT >= 4, sync_message);
   if (no_reentry) return;
   // Make this the current handler till all moves are done
-  no_reentry = true;
   const screenFunc_t old_screen = currentScreen;
   goto_screen(_synchronize);
+  no_reentry = true;
   planner.synchronize(); // idle() is called until moves complete
   no_reentry = false;
   goto_screen(old_screen);

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -403,7 +403,7 @@ void Endstops::event_handler() {
 
     #if BOTH(SD_ABORT_ON_ENDSTOP_HIT, SDSUPPORT)
       if (planner.abort_on_endstop_hit) {
-        card.stopSDPrint();
+        card.endFilePrint();
         quickstop_stepper();
         thermalManager.disable_all_heaters();
         print_job_timer.stop();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -28,7 +28,7 @@
 
 #include "../MarlinCore.h"
 #include "../lcd/ultralcd.h"
-#include "../module/planner.h"
+#include "../module/planner.h"        // for synchronize
 #include "../module/printcounter.h"
 #include "../core/language.h"
 #include "../gcode/queue.h"
@@ -49,6 +49,7 @@
 // public:
 
 card_flags_t CardReader::flag;
+uint8_t CardReader::sdprinting_done_state;
 char CardReader::filename[FILENAME_LENGTH], CardReader::longFilename[LONG_FILENAME_LENGTH];
 int8_t CardReader::autostart_index;
 
@@ -1075,28 +1076,11 @@ void CardReader::fileHasFinished() {
   else {
     stopSDPrint();
 
-    #if ENABLED(POWER_LOSS_RECOVERY)
-      recovery.purge();
-    #endif
-
-    #if ENABLED(SD_FINISHED_STEPPERRELEASE) && defined(SD_FINISHED_RELEASECOMMAND)
-      planner.finish_and_disable();
-    #endif
-
-    print_job_timer.stop();
-    queue.enqueue_now_P(print_job_timer.duration() > 60 ? PSTR("M31") : PSTR("M117"));
-
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();
     #endif
 
-    #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
-      ui.set_progress_done();
-    #endif
-
-    #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
-      ui.reselect_last_file();
-    #endif
+    sdprinting_done_state = 1;
   }
 }
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -380,7 +380,7 @@ void CardReader::mount() {
 }
 
 void CardReader::release() {
-  stopSDPrint();
+  endFilePrint();
   flag.mounted = false;
 }
 
@@ -402,7 +402,7 @@ void CardReader::startFileprint() {
   }
 }
 
-void CardReader::stopSDPrint(
+void CardReader::endFilePrint(
   #if SD_RESORT
     const bool re_sort/*=false*/
   #endif
@@ -502,7 +502,7 @@ void CardReader::openFileRead(char * const path, const uint8_t subcall_type/*=0*
       break;
   }
 
-  stopSDPrint();
+  endFilePrint();
 
   SdFile *curDir;
   const char * const fname = diveToFile(true, curDir, path);
@@ -530,7 +530,7 @@ void CardReader::openFileWrite(char * const path) {
   announceOpen(2, path);
   file_subcall_ctr = 0;
 
-  stopSDPrint();
+  endFilePrint();
 
   SdFile *curDir;
   const char * const fname = diveToFile(false, curDir, path);
@@ -555,7 +555,7 @@ void CardReader::openFileWrite(char * const path) {
 void CardReader::removeFile(const char * const name) {
   if (!isMounted()) return;
 
-  //stopSDPrint();
+  //endFilePrint();
 
   SdFile *curDir;
   const char * const fname = diveToFile(false, curDir, name);
@@ -938,7 +938,7 @@ void CardReader::cdroot() {
           bool didSwap = false;
           uint8_t o1 = sort_order[0];
           #if DISABLED(SDSORT_USES_RAM)
-            selectFileByIndex(o1);                // Pre-fetch the first entry and save it
+            selectFileByIndex(o1);              // Pre-fetch the first entry and save it
             strcpy(name1, longest_filename());  // so the loop only needs one fetch
             #if HAS_FOLDER_SORTING
               bool dir1 = flag.filenameIsDir;
@@ -1074,7 +1074,7 @@ void CardReader::fileHasFinished() {
     startFileprint();
   }
   else {
-    stopSDPrint();
+    endFilePrint();
 
     #if ENABLED(SDCARD_SORT_ALPHA)
       presort();

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -49,6 +49,7 @@ typedef struct {
 
 class CardReader {
 public:
+  static uint8_t sdprinting_done_state;
   static card_flags_t flag;                         // Flags (above)
   static char filename[FILENAME_LENGTH],            // DOS 8.3 filename of the selected item
               longFilename[LONG_FILENAME_LENGTH];   // Long name of the selected item

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -109,9 +109,9 @@ public:
   static void openAndPrintFile(const char *name);   // (working directory)
   static void fileHasFinished();
   static void getAbsFilename(char *dst);
-  static void startFileprint();
   static void printFilename();
-  static void stopSDPrint(
+  static void startFileprint();
+  static void endFilePrint(
     #if SD_RESORT
       const bool re_sort=false
     #endif


### PR DESCRIPTION
**The Problem:** When print event LEDs are enabled the SD print gets stuck at the end and fails to run the complete contents of the file.

**The Cause:** Commands can't be forcibly injected from certain points in the Marlin program flow because this causes `idle` to be called until a space in the queue opens up. Unfortunately, `idle` does not advance the command queue. It is sort-of common knowledge that `idle` blocks the command queue from advancing. As a result no space will ever open up and `inject_now_P` will never return.

The only way the command queue can ever advance and open up space is if the program flow is allowed to periodically return all the way back to the main `loop()`. (It does seem that Marlin always leaves one space open in the queue so that it should be possible to get at least one command in without getting stuck, but more than one would still be problematic, and `card.fileHasFinished` also happens to inject `M31`.)

**The Solution:** This PR adds a completion state to the `CardReader` class so that Marlin can clean up after a print job in stages and deal with the possibility that the queue may be full. The completion state decrements until all stages of the print job completion are done. The resulting `finishSDPrinting` function fits well with the small suite of print state handlers.

References: #16808
