### PR TITLE
Fix GTR10 Overlapping Defines

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -687,12 +687,6 @@ extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_varian
 build_flags       = ${common.build_flags}
   -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407IG\"
   -DTARGET_STM32F4 -DSTM32F407IX -DVECT_TAB_OFFSET=0x8000
-  -DHAVE_HWSERIAL3
-  -DHAVE_HWSERIAL6
-  -DPIN_SERIAL3_RX=PD_9
-  -DPIN_SERIAL3_TX=PD_8
-  -DPIN_SERIAL6_RX=PC_7
-  -DPIN_SERIAL6_TX=PC_6
 
   -IMarlin/src/HAL/HAL_STM32
 lib_deps          =


### PR DESCRIPTION
Defines in platformio.ini overlap with variants.h and the platform. Removing these stops a flood of duplicate define errors in vscode.