### PR TITLE
Set LCD status for EEPROM errors

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -937,6 +937,8 @@ void setup() {
     ui.show_bootscreen();
   #endif
 
+  ui.reset_status();        // Load welcome message early so its retained if no errors exist
+
   #if ENABLED(SDSUPPORT)
     card.mount(); // Mount the SD card before settings.first_load
   #endif
@@ -961,7 +963,9 @@ void setup() {
 
   print_job_timer.init();   // Initial setup of print job timer
 
-  ui.reset_status();        // Print startup message after print statistics are loaded
+  #if HAS_SERVICE_INTERVALS
+    ui.reset_status(true);        // Run again to get service interval messages if required
+  #endif
 
   endstops.init();          // Init endstops and pullups
 

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -937,35 +937,27 @@ void setup() {
     ui.show_bootscreen();
   #endif
 
-  ui.reset_status();        // Load welcome message early so its retained if no errors exist
+  ui.reset_status();        // Load welcome message early. (Retained if no errors exist.)
 
   #if ENABLED(SDSUPPORT)
-    card.mount(); // Mount the SD card before settings.first_load
+    card.mount();           // Mount the SD card before settings.first_load
   #endif
-
-  // Load data from EEPROM if available (or use defaults)
-  // This also updates variables in the planner, elsewhere
-  settings.first_load();
+                            // Load data from EEPROM if available (or use defaults)
+  settings.first_load();    // This also updates variables in the planner, elsewhere
 
   #if ENABLED(TOUCH_BUTTONS)
     touch.init();
   #endif
 
-  #if HAS_M206_COMMAND
-    // Initialize current position based on home_offset
+  #if HAS_M206_COMMAND      // Initialize current position based on home_offset
     current_position += home_offset;
   #endif
 
-  // Vital to init stepper/planner equivalent for current_position
-  sync_plan_position();
+  sync_plan_position();     // Vital to init stepper/planner equivalent for current_position
 
   thermalManager.init();    // Initialize temperature loop
 
   print_job_timer.init();   // Initial setup of print job timer
-
-  #if HAS_SERVICE_INTERVALS
-    ui.reset_status(true);        // Run again to get service interval messages if required
-  #endif
 
   endstops.init();          // Init endstops and pullups
 
@@ -1120,6 +1112,10 @@ void setup() {
 
   #if ENABLED(PRUSA_MMU2)
     mmu2.init();
+  #endif
+
+  #if HAS_SERVICE_INTERVALS
+    ui.reset_status(true);  // Show service messages or keep current status
   #endif
 }
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -314,6 +314,9 @@ namespace Language_en {
   PROGMEM Language_Str MSG_LOAD_EEPROM                     = _UxGT("Load Settings");
   PROGMEM Language_Str MSG_RESTORE_FAILSAFE                = _UxGT("Restore failsafe");
   PROGMEM Language_Str MSG_INIT_EEPROM                     = _UxGT("Initialize EEPROM");
+  PROGMEM Language_Str MSG_ERR_EEPROM_CRC                  = _UxGT("Err: EEPROM CRC");
+  PROGMEM Language_Str MSG_ERR_EEPROM_INDEX                = _UxGT("Err: EEPROM Index");
+  PROGMEM Language_Str MSG_ERR_EEPROM_VERSION              = _UxGT("Err: EEPROM Version");
   PROGMEM Language_Str MSG_MEDIA_UPDATE                    = _UxGT("Media Update");
   PROGMEM Language_Str MSG_RESET_PRINTER                   = _UxGT("Reset Printer");
   PROGMEM Language_Str MSG_REFRESH                         = LCD_STR_REFRESH  _UxGT("Refresh");

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1453,7 +1453,7 @@ void MarlinUI::update() {
   /**
    * Reset the status message
    */
-  void MarlinUI::reset_status() {
+  void MarlinUI::reset_status(bool no_welcome) {
     PGM_P printing = GET_TEXT(MSG_PRINTING);
     PGM_P welcome  = GET_TEXT(WELCOME_MSG);
     #if SERVICE_INTERVAL_1 > 0
@@ -1485,8 +1485,10 @@ void MarlinUI::update() {
       else if (print_job_timer.needsService(3)) msg = service3;
     #endif
 
-    else
+    else if (!no_welcome)
       msg = welcome;
+    else
+      return;
 
     set_status_P(msg, -1);
   }

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1453,7 +1453,7 @@ void MarlinUI::update() {
   /**
    * Reset the status message
    */
-  void MarlinUI::reset_status(bool no_welcome) {
+  void MarlinUI::reset_status(const bool no_welcome) {
     PGM_P printing = GET_TEXT(MSG_PRINTING);
     PGM_P welcome  = GET_TEXT(WELCOME_MSG);
     #if SERVICE_INTERVAL_1 > 0

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -402,7 +402,7 @@ public:
     static void set_status(const char* const message, const bool persist=false);
     static void set_status_P(PGM_P const message, const int8_t level=0);
     static void status_printf_P(const uint8_t level, PGM_P const fmt, ...);
-    static void reset_status();
+    static void reset_status(bool no_welcome=false);
 
   #else // No LCD
 
@@ -416,7 +416,7 @@ public:
     static inline void refresh() {}
     static inline void return_to_status() {}
     static inline void set_alert_status_P(PGM_P const) {}
-    static inline void reset_status() {}
+    static inline void reset_status(bool no_welcome=false) {}
     static inline void reset_alert_level() {}
     static constexpr bool has_status() { return false; }
 

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -402,7 +402,7 @@ public:
     static void set_status(const char* const message, const bool persist=false);
     static void set_status_P(PGM_P const message, const int8_t level=0);
     static void status_printf_P(const uint8_t level, PGM_P const fmt, ...);
-    static void reset_status(bool no_welcome=false);
+    static void reset_status(const bool no_welcome=false);
 
   #else // No LCD
 
@@ -416,7 +416,7 @@ public:
     static inline void refresh() {}
     static inline void return_to_status() {}
     static inline void set_alert_status_P(PGM_P const) {}
-    static inline void reset_status(bool no_welcome=false) {}
+    static inline void reset_status(const bool=false) {}
     static inline void reset_alert_level() {}
     static constexpr bool has_status() { return false; }
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1397,6 +1397,9 @@ void MarlinSettings::postprocess() {
       }
       DEBUG_ECHO_START();
       DEBUG_ECHOLNPAIR("EEPROM version mismatch (EEPROM=", stored_ver, " Marlin=" EEPROM_VERSION ")");
+      #if HAS_LCD_MENU && DISABLED(EEPROM_AUTO_INIT)
+        ui.set_status("EEPROM version mismatch");
+      #endif
       eeprom_error = true;
     }
     else {
@@ -2205,11 +2208,17 @@ void MarlinSettings::postprocess() {
       if (eeprom_error) {
         DEBUG_ECHO_START();
         DEBUG_ECHOLNPAIR("Index: ", int(eeprom_index - (EEPROM_OFFSET)), " Size: ", datasize());
+        #if HAS_LCD_MENU && DISABLED(EEPROM_AUTO_INIT)
+          ui.set_status("EEPROM Index Error");
+        #endif
       }
       else if (working_crc != stored_crc) {
         eeprom_error = true;
         DEBUG_ERROR_START();
         DEBUG_ECHOLNPAIR("EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
+        #if HAS_LCD_MENU && DISABLED(EEPROM_AUTO_INIT)
+          ui.set_status("EEPROM CRC mismatch");
+        #endif
       }
       else if (!validating) {
         DEBUG_ECHO_START();

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1398,7 +1398,7 @@ void MarlinSettings::postprocess() {
       DEBUG_ECHO_START();
       DEBUG_ECHOLNPAIR("EEPROM version mismatch (EEPROM=", stored_ver, " Marlin=" EEPROM_VERSION ")");
       #if HAS_LCD_MENU && DISABLED(EEPROM_AUTO_INIT)
-        ui.set_status("EEPROM version mismatch");
+        ui.set_status_P(GET_TEXT(MSG_ERR_EEPROM_VERSION));
       #endif
       eeprom_error = true;
     }
@@ -2209,7 +2209,7 @@ void MarlinSettings::postprocess() {
         DEBUG_ECHO_START();
         DEBUG_ECHOLNPAIR("Index: ", int(eeprom_index - (EEPROM_OFFSET)), " Size: ", datasize());
         #if HAS_LCD_MENU && DISABLED(EEPROM_AUTO_INIT)
-          ui.set_status("EEPROM Index Error");
+          ui.set_status_P(GET_TEXT(MSG_ERR_EEPROM_INDEX));
         #endif
       }
       else if (working_crc != stored_crc) {
@@ -2217,7 +2217,7 @@ void MarlinSettings::postprocess() {
         DEBUG_ERROR_START();
         DEBUG_ECHOLNPAIR("EEPROM CRC mismatch - (stored) ", stored_crc, " != ", working_crc, " (calculated)!");
         #if HAS_LCD_MENU && DISABLED(EEPROM_AUTO_INIT)
-          ui.set_status("EEPROM CRC mismatch");
+          ui.set_status_P(GET_TEXT(MSG_ERR_EEPROM_CRC));
         #endif
       }
       else if (!validating) {


### PR DESCRIPTION
Addresses #16965 by showing eeprom errors on the LCD at startup if auto init is not enabled to automatically handle them. Some handling for service messages to still function.

I have not validated this and tested it here, ill leave that to the requester.