### PR TITLE
Fix probing for large offsets

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -572,7 +572,7 @@ float Probe::run_z_probe() {
 
     // Do a first probe at the fast speed
     if (probe_down_to_z(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_FAST))         // No probe trigger?
-      || current_position.z > -offset.z + _MAX(Z_CLEARANCE_BETWEEN_PROBES, 4) / 2  // Probe triggered too high?
+      || current_position.z > -offset.z + Z_PROBE_OFFSET_RANGE_MAX                 // Probe triggered too high?
     ) {
       if (DEBUGGING(LEVELING)) {
         DEBUG_ECHOLNPGM("FAST Probe fail!");
@@ -617,7 +617,7 @@ float Probe::run_z_probe() {
     {
       // Probe downward slowly to find the bed
       if (probe_down_to_z(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_SLOW))      // No probe trigger?
-        || current_position.z > -offset.z + _MAX(Z_CLEARANCE_MULTI_PROBE, 4) / 2  // Probe triggered too high?
+        || current_position.z > -offset.z + Z_PROBE_OFFSET_RANGE_MAX              // Probe triggered too high?
       ) {
         if (DEBUGGING(LEVELING)) {
           DEBUG_ECHOLNPGM("SLOW Probe fail!");


### PR DESCRIPTION
Address #16923 by allowing larger positional differences depending on configured probe values. 

While I don't have a delta to test with myself, which seems the most likely to trigger this, Ive gotten 1 report of it working and would like to see more before this gets merged.