### PR TITLE
Fix a bug in G34 where "Decreasing accuracy detected" error would throw

### DIFF
--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -255,21 +255,21 @@ void GcodeSuite::G34() {
       );
 
       #if ENABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
-        // Check if the corrections we are making go in the correct direction.
-        // Therefore, calculate the sum of the absolute deviations from the mean of the probe measurements.
-        // Compare this value to the last iteration to ensure it is getting better.
+        // Check if the applied corrections go in the correct direction.
+        // Calculate the sum of the absolute deviations from the mean of the probe measurements.
+        // Compare to the last iteration to ensure it's getting better.
 
         // Calculate mean value as a reference
         float z_measured_mean = 0.0f;
         LOOP_L_N(zstepper, NUM_Z_STEPPER_DRIVERS) z_measured_mean += z_measured[zstepper];
         z_measured_mean /= NUM_Z_STEPPER_DRIVERS;
 
-        // Calculate the sum of the absolute deviantions from the mean value
+        // Calculate the sum of the absolute deviations from the mean value
         float z_align_level_indicator = 0.0f;
         LOOP_L_N(zstepper, NUM_Z_STEPPER_DRIVERS)
           z_align_level_indicator += ABS(z_measured[zstepper] - z_measured_mean);
 
-        // If it is getting worse, stop and throw an error
+        // If it's getting worse, stop and throw an error
         if (last_z_align_level_indicator < z_align_level_indicator * 0.7f) {
           SERIAL_ECHOLNPGM("Decreasing accuracy detected.");
           err_break = true;

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -290,10 +290,10 @@ void GcodeSuite::G34() {
         float z_align_move = z_measured[zstepper] - z_measured_min;
         const float z_align_abs = ABS(z_align_move);
 
-         #if DISABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
+        #if DISABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
           // Optimize one iteration's correction based on the first measurements
           if (z_align_abs) amplification = (iteration == 1) ? _MIN(last_z_align_move[zstepper] / z_align_abs, 2.0f) : z_auto_align_amplification;
-          
+
           // Check for less accuracy compared to last move
           if (last_z_align_move[zstepper] < z_align_abs * 0.7f) {
             SERIAL_ECHOLNPGM("Decreasing accuracy detected.");
@@ -347,11 +347,9 @@ void GcodeSuite::G34() {
 
     // Restore the active tool after homing
     #if HOTENDS > 1
-      tool_change(old_tool_index, (
+      tool_change(old_tool_index, (true
         #if ENABLED(PARKING_EXTRUDER)
-          false // Fetch the previous toolhead
-        #else
-          true
+          && false // Fetch the previous toolhead
         #endif
       ));
     #endif


### PR DESCRIPTION
Fix a bug in G34 where "Decreasing accuracy detected" error would throw

### Requirements

-Multiple Z axis
-Z_STEPPER_AUTO_ALIGN
-Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS

### Description

Despite of already good accuracy in the first Z auto aligning procedure (G34), the printer could fail (sometimes, not every time) after the second iteration, even when the target accuracy was reached, because it was detecting "decreasing accuracy".

This was caused by the way the accuracy was estimated: A group of probing (one for every Z stepper) values were compared by subtracting the minimum probing value. If any of these differences was 30% larger than the one from the last iteration, G34 would throw an error.

However, one of them - the minimum value - was already zero per definition (difference from the value to itself). Now, if in the next iteration, another value is lower, the old minimum value is not zero anymore and thereby more than 30% larger than the old one, causing the Error.

Example:

First iteration:
z_measured 0.17 -0.30 0.04
z_measured_min -0.30
z_align_move 0.47 0.00 0.34

Second iteration:
z_measured 0.01 0.05 -0.02
z_measured_min -0.02
z_align_move 0.03 0.07 0.00

-> The accuracy gets better, but z_align_move[1] has increased (which is okay), and this throws the error (which is not okay).

### Benefits

In my implementation, the mean of z_measured is computed, then the absolute difference of each of z_measured values to the mean, then the sum of those. This:
-Adds an more useful reference (mean) than the minimum value, at least for evaluating the accuracy
-The mean deviation is taken into account, not the singe deviations. If 2 values get better, but 1 gets worse, the printer does not instantly throw an error.

This is for Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS only. If the user does not use this, the old version is used, which is good for that case.

### Related Issues

(personal bug encountered and researched)
