### PR TITLE
Catch more LPC1768 pin conflicts

### DIFF
--- a/Marlin/src/HAL/HAL_LPC1768/inc/SanityCheck.h
+++ b/Marlin/src/HAL/HAL_LPC1768/inc/SanityCheck.h
@@ -124,4 +124,84 @@
   #elif E_STEPPERS > 1 && (E1_DIR_PIN == P0_00 || E1_STEP_PIN == P0_01)
     #error "Serial port assignment (2) conflicts with other pins!"
   #endif
+
+//
+// Flag any i2c pin conflicts
+//
+#if ANY(DIGIPOT_I2C, DIGIPOT_MCP4018, DAC_STEPPER_CURRENT, EXPERIMENTAL_I2CBUS, I2C_POSITION_ENCODERS, NEOPIXEL_LED, PCA9632, I2C_EEPROM)
+  #define USEDI2CDEV_M 1
+
+  #if USEDI2CDEV_M == 0         // P0_27 [D57] (AUX-1) .......... P0_28 [D58] (AUX-1)
+    #define PIN_IS_SDA0(P) (P##_PIN == P0_27)
+    #define IS_SCL0(P)     (P == P0_28)
+    #if ENABLED(SDSUPPORT) && PIN_IS_SDA0(SD_DETECT)
+      #error "SDA0 overlaps with SD_DETECT_PIN!"
+    #elif PIN_IS_SDA0(E0_AUTO_FAN)
+      #error "SDA0 overlaps with E0_AUTO_FAN_PIN!"
+    #elif PIN_IS_SDA0(BEEPER)
+      #error "SDA0 overlaps with BEEPER_PIN!"
+    #elif IS_SCL0(BTN_ENC)
+      #error "SCL0 overlaps with Encoder Button!"
+    #elif IS_SCL0(SS_PIN)
+      #error "SCL0 overlaps with SS_PIN!"
+    #elif IS_SCL0(LCD_SDSS)
+      #error "SCL0 overlaps with LCD_SDSS!"
+    #endif
+    #undef PIN_IS_SDA0
+    #undef IS_SCL0
+  #elif USEDI2CDEV_M == 1       // P0_00 [D20] (SCA) ............ P0_01 [D21] (SCL)
+    #define PIN_IS_SDA1(P) (PIN_EXISTS(P) && P##_PIN == P0_00)
+    #define PIN_IS_SCL1(P) (PIN_EXISTS(P) && P##_PIN == P0_01)
+    #if PIN_IS_SDA1(X_MIN) || PIN_IS_SCL1(X_MAX)
+      #error "One or more i2c (1) pins overlaps with X endstop pins! Disable i2c peripherals."
+    #elif PIN_IS_SDA1(X2_DIR) || PIN_IS_SCL1(X2_STEP)
+      #error "One or more i2c (1) pins overlaps with X2 pins! Disable i2c peripherals."
+    #elif PIN_IS_SDA1(Y2_DIR) || PIN_IS_SCL1(Y2_STEP)
+      #error "One or more i2c (1) pins overlaps with Y2 pins! Disable i2c peripherals."
+    #elif PIN_IS_SDA1(Z2_DIR) || PIN_IS_SCL1(Z2_STEP)
+      #error "One or more i2c (1) pins overlaps with Z2 pins! Disable i2c peripherals."
+    #elif PIN_IS_SDA1(Z3_DIR) || PIN_IS_SCL1(Z3_STEP)
+      #error "One or more i2c (1) pins overlaps with Z3 pins! Disable i2c peripherals."
+    #elif PIN_IS_SDA1(Z4_DIR) || PIN_IS_SCL1(Z4_STEP)
+      #error "One or more i2c (1) pins overlaps with Z4 pins! Disable i2c peripherals."
+    #elif E_STEPPERS > 1 && (PIN_IS_SDA1(E1_DIR) || PIN_IS_SCL1(E1_STEP))
+      #error "One or more i2c (1) pins overlaps with E1 pins! Disable i2c peripherals."
+    #endif
+    #undef PIN_IS_SDA1
+    #undef PIN_IS_SCL1
+  #elif USEDI2CDEV_M == 2     // P0_10 [D38] (X_ENABLE_PIN) ... P0_11 [D55] (X_DIR_PIN)
+    #define PIN_IS_SDA2(P) (PIN_EXISTS(P) && P##_PIN == P0_10)
+    #define PIN_IS_SCL2(P) (PIN_EXISTS(P) && P##_PIN == P0_11)
+    #if PIN_IS_SDA2(Y_STOP)
+      #error "i2c SDA2 overlaps with Y endstop pin!"
+    #elif HAS_CUSTOM_PROBE_PIN && PIN_IS_SDA2(Z_MIN_PROBE)
+      #error "i2c SDA2 overlaps with Z probe pin!"
+    #elif PIN_IS_SDA2(X_ENABLE) || PIN_IS_SDA2(Y_ENABLE)
+      #error "i2c SDA2 overlaps with X/Y ENABLE pin!"
+    #elif AXIS_HAS_SPI(X) && PIN_IS_SDA2(X_CS)
+      #error "i2c SDA2 overlaps with X CS pin!"
+    #elif PIN_IS_SDA2(X2_ENABLE)
+      #error "i2c SDA2 overlaps with X2 enable pin! Disable i2c peripherals."
+    #elif PIN_IS_SDA2(Y2_ENABLE)
+      #error "i2c SDA2 overlaps with Y2 enable pin! Disable i2c peripherals."
+    #elif PIN_IS_SDA2(Z2_ENABLE)
+      #error "i2c SDA2 overlaps with Z2 enable pin! Disable i2c peripherals."
+    #elif PIN_IS_SDA2(Z3_ENABLE)
+      #error "i2c SDA2 overlaps with Z3 enable pin! Disable i2c peripherals."
+    #elif PIN_IS_SDA2(Z4_ENABLE)
+      #error "i2c SDA2 overlaps with Z4 enable pin! Disable i2c peripherals."
+    #elif EXTRUDERS > 1 && PIN_IS_SDA2(E1_ENABLE)
+      #error "i2c SDA2 overlaps with E1 enable pin! Disable i2c peripherals."
+    #elif EXTRUDERS > 1 && AXIS_HAS_SPI(E1) && PIN_IS_SDA2(E1_CS)
+      #error "i2c SDA2 overlaps with E1 CS pin! Disable i2c peripherals."
+    #elif EXTRUDERS && (PIN_IS_SDA2(E0_STEP) || PIN_IS_SDA2(E0_DIR))
+      #error "i2c SCL2 overlaps with E0 STEP/DIR pin! Disable i2c peripherals."
+    #elif PIN_IS_SDA2(X_DIR) || PIN_IS_SDA2(Y_DIR)
+      #error "One or more i2c pins overlaps with X/Y DIR pin! Disable i2c peripherals."
+    #endif
+    #undef PIN_IS_SDA2
+    #undef PIN_IS_SCL2
+  #endif
+
+  #undef USEDI2CDEV_M
 #endif

--- a/Marlin/src/HAL/HAL_LPC1768/inc/SanityCheck.h
+++ b/Marlin/src/HAL/HAL_LPC1768/inc/SanityCheck.h
@@ -88,48 +88,96 @@
  * Serial3 | P0_00 | P0_01 |
  */
 #if (defined(SERIAL_PORT) && SERIAL_PORT == 0) || (defined(SERIAL_PORT_2) && SERIAL_PORT_2 == 0) || (defined(DGUS_SERIAL_PORT) && DGUS_SERIAL_PORT == 0)
-  #if  X_CS_PIN == P0_02 || TMC_SW_MISO == P0_02 || (E_STEPPERS && E_MUX1_PIN == P0_02) \
-    || Y_CS_PIN == P0_03 || TMC_SW_MOSI == P0_03 || (E_STEPPERS && E_MUX0_PIN == P0_03)
-    #error "Serial port assignment (0) conflicts with other pins!"
+  #define IS_TX0(P) (P == P0_02)
+  #define IS_RX0(P) (P == P0_03)
+  #if IS_TX0(TMC_SW_MISO) || IS_RX0(TMC_SW_MOSI)
+    #error "Serial port pins (0) conflict with Trinamic SPI pins!"
+  #elif ENABLED(MK2_MULTIPLEXER) && (IS_TX0(E_MUX1_PIN) || IS_RX0(E_MUX0_PIN))
+    #error "Serial port pins (0) conflict with MK2 multiplexer pins!"
+  #elif (AXIS_HAS_SPI(X) && IS_TX0(X_CS_PIN)) || (AXIS_HAS_SPI(Y) && IS_RX0(Y_CS_PIN))
+    #error "Serial port pins (0) conflict with X/Y axis SPI pins!"
   #endif
+  #undef IS_TX0
+  #undef IS_RX0
 #endif
 
 #if SERIAL_PORT == 1 || SERIAL_PORT_2 == 1 || DGUS_SERIAL_PORT == 1
-  #if TMC_SW_SCK == P0_15
-    #error "Serial port assignment (1) conflicts with other pins!"
+  #define IS_TX1(P) (P == P0_15)
+  #define IS_RX1(P) (P == P0_16)
+  #if IS_TX1(TMC_SW_SCK)
+    #error "Serial port pins (1) conflict with other pins!"
   #elif HAS_SPI_LCD
-    #if  BTN_EN2 == P0_15 || SCK_PIN == P0_15 || LCD_PINS_D4 == P0_15 || DOGLCD_SCK == P0_15 || LCD_RESET_PIN == P0_15 || LCD_PINS_RS == P0_15 || SHIFT_CLK == P0_15 \
-      || BTN_EN1 == P0_16 || LCD_SDSS == P0_16 || LCD_PINS_RS == P0_16 || MISO_PIN == P0_16 || DOGLCD_A0 == P0_16 || SS_PIN == P0_16 || LCD_SDSS == P0_16 || DOGLCD_CS == P0_16 || LCD_RESET_PIN == P0_16 || LCD_BACKLIGHT_PIN == P0_16
-      #error "Serial port assignment (1) conflicts with other pins!"
+    #if IS_TX1(BTN_EN2) || IS_RX1(BTN_EN1)
+      #error "Serial port pins (1) conflict with Encoder Buttons!"
+    #elif IS_TX1(SCK_PIN) || IS_TX1(LCD_PINS_D4) || IS_TX1(DOGLCD_SCK) || IS_TX1(LCD_RESET_PIN) || IS_TX1(LCD_PINS_RS) || IS_TX1(SHIFT_CLK) \
+      || IS_RX1(LCD_SDSS) || IS_RX1(LCD_PINS_RS) || IS_RX1(MISO_PIN) || IS_RX1(DOGLCD_A0) || IS_RX1(SS_PIN) || IS_RX1(LCD_SDSS) || IS_RX1(DOGLCD_CS) || IS_RX1(LCD_RESET_PIN) || IS_RX1(LCD_BACKLIGHT_PIN)
+      #error "Serial port pins (1) conflict with LCD pins!"
     #endif
   #endif
+  #undef IS_TX1
+  #undef IS_RX1
 #endif
 
 #if SERIAL_PORT == 2 || SERIAL_PORT_2 == 2 || DGUS_SERIAL_PORT == 2
-  #if  Y_MIN_PIN == P0_10 || Z_MIN_PROBE_PIN == P0_10 \
-    || X_ENABLE_PIN == P0_10 || Y_ENABLE_PIN == P0_10 || X2_ENABLE_PIN == P0_10 || Y2_ENABLE_PIN == P0_10 || Z2_ENABLE_PIN == P0_10 || Z3_ENABLE_PIN == P0_10 || Z4_ENABLE_PIN == P0_10 \
-    || X2_CS_PIN == P0_10 || Y2_CS_PIN == P0_10 || Z2_CS_PIN == P0_10 || Z3_CS_PIN == P0_10 || Z4_CS_PIN == P0_10 \
-    || X_DIR_PIN == P0_11 || Y_DIR_PIN == P0_11 || X2_DIR_PIN == P0_11 || Y2_DIR_PIN == P0_11 || Z2_DIR_PIN == P0_11 || Z3_DIR_PIN == P0_11 || Z4_DIR_PIN == P0_11 \
-    || X2_STEP_PIN == P0_11 || Y2_STEP_PIN == P0_11 || Z2_STEP_PIN == P0_11 || Z3_STEP_PIN == P0_11 || Z4_STEP_PIN == P0_11
-    #error "Serial port assignment (2) conflicts with other pins!"
-  #elif  (E_STEPPERS > 1 && (E1_ENABLE_PIN == P0_10 || E1_CS_PIN == P0_10)) || (E_STEPPERS > 0 && (E0_DIR_PIN == P0_11 || E0_STEP_PIN == P0_11))
-    #error "Serial port assignment (2) conflicts with other pins!"
+  #define IS_TX2(P) (P == P0_10)
+  #define IS_RX2(P) (P == P0_11)
+  #if  IS_TX2(X2_ENABLE_PIN) || IS_RX2(X2_DIR_PIN) || IS_RX2(X2_STEP_PIN) || (AXIS_HAS_SPI(X2) && IS_TX2(X2_CS_PIN))
+    #error "Serial port pins (2) conflict with X2 pins!"
+  #elif IS_TX2(Y2_ENABLE_PIN) || IS_RX2(Y2_DIR_PIN) || IS_RX2(Y2_STEP_PIN) || (AXIS_HAS_SPI(Y2) && IS_TX2(Y2_CS_PIN))
+    #error "Serial port pins (2) conflict with Y2 pins!"
+  #elif IS_TX2(Z2_ENABLE_PIN) || IS_RX2(Z2_DIR_PIN) || IS_RX2(Z2_STEP_PIN) || (AXIS_HAS_SPI(Z2) && IS_TX2(Z2_CS_PIN))
+    #error "Serial port pins (2) conflict with Z2 pins!"
+  #elif IS_TX2(Z3_ENABLE_PIN) || IS_RX2(Z3_DIR_PIN) || IS_RX2(Z3_STEP_PIN) || (AXIS_HAS_SPI(Z3) && IS_TX2(Z3_CS_PIN))
+    #error "Serial port pins (2) conflict with Z3 pins!"
+  #elif IS_TX2(Z4_ENABLE_PIN) || IS_RX2(Z4_DIR_PIN) || IS_RX2(Z4_STEP_PIN) || (AXIS_HAS_SPI(Z4) && IS_TX2(Z4_CS_PIN))
+    #error "Serial port pins (2) conflict with Z4 pins!"
+  #elif IS_RX2(X_DIR_PIN) || IS_RX2(Y_DIR_PIN)
+    #error "Serial port pins (2) conflict with other pins!"
+  #elif Y_HOME_DIR < 0 && IS_TX2(Y_STOP_PIN)
+    #error "Serial port pins (2) conflict with Y endstop pin!"
+  #elif HAS_CUSTOM_PROBE_PIN && IS_TX2(Z_MIN_PROBE_PIN)
+    #error "Serial port pins (2) conflict with probe pin!"
+  #elif IS_TX2(X_ENABLE_PIN) || IS_RX2(X_DIR_PIN) || IS_TX2(Y_ENABLE_PIN) || IS_RX2(Y_DIR_PIN)
+    #error "Serial port pins (2) conflict with X/Y stepper pins!"
+  #elif EXTRUDERS > 1 && (IS_TX2(E1_ENABLE_PIN) || (AXIS_HAS_SPI(E1) && IS_TX2(E1_CS_PIN)))
+    #error "Serial port pins (2) conflict with E1 stepper pins!"
+  #elif EXTRUDERS && (IS_RX2(E0_DIR_PIN) || IS_RX2(E0_STEP_PIN))
+    #error "Serial port pins (2) conflict with E stepper pins!"
   #endif
+  #undef IS_TX2
+  #undef IS_RX2
 #endif
 
 #if SERIAL_PORT == 3 || SERIAL_PORT_2 == 3 || DGUS_SERIAL_PORT == 3
-  #if  X_MIN_PIN == P0_00 || Y_SERIAL_TX_PIN == P0_00 || Y_SERIAL_RX_PIN == P0_00 \
-    || X_MAX_PIN == P0_01 || X_SERIAL_TX_PIN == P0_01 || X_SERIAL_RX_PIN == P0_01
-    #error "Serial port assignment (2) conflicts with other pins!"
-  #elif E_STEPPERS > 1 && (E1_DIR_PIN == P0_00 || E1_STEP_PIN == P0_01)
-    #error "Serial port assignment (2) conflicts with other pins!"
+  #define PIN_IS_TX3(P) (PIN_EXISTS(P) && P##_PIN == P0_00)
+  #define PIN_IS_RX3(P) (P##_PIN == P0_01)
+  #if PIN_IS_TX3(X_MIN) || PIN_IS_RX3(X_MAX)
+    #error "Serial port pins (3) conflict with X endstop pins!"
+  #elif PIN_IS_TX3(Y_SERIAL_TX) || PIN_IS_TX3(Y_SERIAL_RX) \
+    ||  PIN_IS_RX3(X_SERIAL_TX) || PIN_IS_RX3(X_SERIAL_RX)
+    #error "Serial port pins (3) conflict with X/Y axis UART pins!"
+  #elif PIN_IS_TX3(X2_DIR) || PIN_IS_RX3(X2_STEP)
+    #error "Serial port pins (3) conflict with X2 pins!"
+  #elif PIN_IS_TX3(Y2_DIR) || PIN_IS_RX3(Y2_STEP)
+    #error "Serial port pins (3) conflict with Y2 pins!"
+  #elif PIN_IS_TX3(Z2_DIR) || PIN_IS_RX3(Z2_STEP)
+    #error "Serial port pins (3) conflict with Z2 pins!"
+  #elif PIN_IS_TX3(Z3_DIR) || PIN_IS_RX3(Z3_STEP)
+    #error "Serial port pins (3) conflict with Z3 pins!"
+  #elif PIN_IS_TX3(Z4_DIR) || PIN_IS_RX3(Z4_STEP)
+    #error "Serial port pins (3) conflict with Z4 pins!"
+  #elif EXTRUDERS > 1 && (PIN_IS_TX3(E1_DIR) || PIN_IS_RX3(E1_STEP))
+    #error "Serial port pins (3) conflict with E1 pins!"
   #endif
+  #undef PIN_IS_TX3
+  #undef PIN_IS_RX3
+#endif
 
 //
 // Flag any i2c pin conflicts
 //
 #if ANY(DIGIPOT_I2C, DIGIPOT_MCP4018, DAC_STEPPER_CURRENT, EXPERIMENTAL_I2CBUS, I2C_POSITION_ENCODERS, NEOPIXEL_LED, PCA9632, I2C_EEPROM)
-  #define USEDI2CDEV_M 1
+  #define USEDI2CDEV_M 1  // <Arduino>/Wire.cpp
 
   #if USEDI2CDEV_M == 0         // P0_27 [D57] (AUX-1) .......... P0_28 [D58] (AUX-1)
     #define PIN_IS_SDA0(P) (P##_PIN == P0_27)
@@ -151,7 +199,7 @@
     #undef IS_SCL0
   #elif USEDI2CDEV_M == 1       // P0_00 [D20] (SCA) ............ P0_01 [D21] (SCL)
     #define PIN_IS_SDA1(P) (PIN_EXISTS(P) && P##_PIN == P0_00)
-    #define PIN_IS_SCL1(P) (PIN_EXISTS(P) && P##_PIN == P0_01)
+    #define PIN_IS_SCL1(P) (P##_PIN == P0_01)
     #if PIN_IS_SDA1(X_MIN) || PIN_IS_SCL1(X_MAX)
       #error "One or more i2c (1) pins overlaps with X endstop pins! Disable i2c peripherals."
     #elif PIN_IS_SDA1(X2_DIR) || PIN_IS_SCL1(X2_STEP)
@@ -164,14 +212,14 @@
       #error "One or more i2c (1) pins overlaps with Z3 pins! Disable i2c peripherals."
     #elif PIN_IS_SDA1(Z4_DIR) || PIN_IS_SCL1(Z4_STEP)
       #error "One or more i2c (1) pins overlaps with Z4 pins! Disable i2c peripherals."
-    #elif E_STEPPERS > 1 && (PIN_IS_SDA1(E1_DIR) || PIN_IS_SCL1(E1_STEP))
+    #elif EXTRUDERS > 1 && (PIN_IS_SDA1(E1_DIR) || PIN_IS_SCL1(E1_STEP))
       #error "One or more i2c (1) pins overlaps with E1 pins! Disable i2c peripherals."
     #endif
     #undef PIN_IS_SDA1
     #undef PIN_IS_SCL1
   #elif USEDI2CDEV_M == 2     // P0_10 [D38] (X_ENABLE_PIN) ... P0_11 [D55] (X_DIR_PIN)
-    #define PIN_IS_SDA2(P) (PIN_EXISTS(P) && P##_PIN == P0_10)
-    #define PIN_IS_SCL2(P) (PIN_EXISTS(P) && P##_PIN == P0_11)
+    #define PIN_IS_SDA2(P) (P##_PIN == P0_10)
+    #define PIN_IS_SCL2(P) (P##_PIN == P0_11)
     #if PIN_IS_SDA2(Y_STOP)
       #error "i2c SDA2 overlaps with Y endstop pin!"
     #elif HAS_CUSTOM_PROBE_PIN && PIN_IS_SDA2(Z_MIN_PROBE)

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -433,22 +433,41 @@
 #ifndef HOTENDS
   #define HOTENDS EXTRUDERS
 #endif
-
 #ifndef E_STEPPERS
   #define E_STEPPERS EXTRUDERS
 #endif
-
 #ifndef E_MANUAL
   #define E_MANUAL EXTRUDERS
 #endif
 
+// Helper macros for extruder and hotend arrays
 #define HOTEND_LOOP() for (int8_t e = 0; e < HOTENDS; e++)
+#define ARRAY_BY_EXTRUDERS(V...) ARRAY_N(EXTRUDERS, V)
+#define ARRAY_BY_EXTRUDERS1(v1) ARRAY_BY_EXTRUDERS(v1, v1, v1, v1, v1, v1)
+#define ARRAY_BY_HOTENDS(V...) ARRAY_N(HOTENDS, V)
+#define ARRAY_BY_HOTENDS1(v1) ARRAY_BY_HOTENDS(v1, v1, v1, v1, v1, v1)
 
 #define DO_SWITCH_EXTRUDER (ENABLED(SWITCHING_EXTRUDER) && (DISABLED(SWITCHING_NOZZLE) || SWITCHING_EXTRUDER_SERVO_NR != SWITCHING_NOZZLE_SERVO_NR))
 #define SWITCHING_NOZZLE_TWO_SERVOS defined(SWITCHING_NOZZLE_E1_SERVO_NR)
 
-#define HAS_HOTEND_OFFSET (HOTENDS > 1)
 #define HAS_DUPLICATION_MODE EITHER(DUAL_X_CARRIAGE, MULTI_NOZZLE_DUPLICATION)
+
+#define HAS_HOTEND_OFFSET (HOTENDS > 1)
+
+/**
+ * Default hotend offsets, if not defined
+ */
+#if HAS_HOTEND_OFFSET
+  #ifndef HOTEND_OFFSET_X
+    #define HOTEND_OFFSET_X { 0 } // X offsets for each extruder
+  #endif
+  #ifndef HOTEND_OFFSET_Y
+    #define HOTEND_OFFSET_Y { 0 } // Y offsets for each extruder
+  #endif
+  #ifndef HOTEND_OFFSET_Z
+    #define HOTEND_OFFSET_Z { 0 } // Z offsets for each extruder
+  #endif
+#endif
 
 /**
  * DISTINCT_E_FACTORS affects how some E factors are accessed
@@ -575,8 +594,23 @@
 
 #define IS_RE_ARM_BOARD MB(RAMPS_14_RE_ARM_EFB, RAMPS_14_RE_ARM_EEB, RAMPS_14_RE_ARM_EFF, RAMPS_14_RE_ARM_EEF, RAMPS_14_RE_ARM_SF)
 
-#define HAS_LINEAR_E_JERK (DISABLED(CLASSIC_JERK) && ENABLED(LIN_ADVANCE))
+// Linear advance uses Jerk since E is an isolated axis
+#define HAS_LINEAR_E_JERK  (DISABLED(CLASSIC_JERK) && ENABLED(LIN_ADVANCE))
+
+// This flag indicates some kind of jerk storage is needed
+#define HAS_CLASSIC_JERK   (ENABLED(CLASSIC_JERK) || IS_KINEMATIC)
+
+// E jerk exists with JD disabled (of course) but also when Linear Advance is disabled on Delta/SCARA
+#define HAS_CLASSIC_E_JERK (ENABLED(CLASSIC_JERK) || (IS_KINEMATIC && DISABLED(LIN_ADVANCE)))
 
 #ifndef SPI_SPEED
   #define SPI_SPEED SPI_FULL_SPEED
+#endif
+
+/**
+ * This setting is also used by M109 when trying to calculate
+ * a ballpark safe margin to prevent wait-forever situation.
+ */
+#ifndef EXTRUDE_MINTEMP
+  #define EXTRUDE_MINTEMP 170
 #endif

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -40,9 +40,6 @@
   #define NOT_A_PIN 0 // For PINS_DEBUGGING
 #endif
 
-#define HAS_CLASSIC_JERK (ENABLED(CLASSIC_JERK) || IS_KINEMATIC)
-#define HAS_CLASSIC_E_JERK (ENABLED(CLASSIC_JERK) || DISABLED(LIN_ADVANCE))
-
 /**
  * Axis lengths and center
  */
@@ -578,99 +575,6 @@
 #define HOTEND_USES_THERMISTOR ANY( \
   HEATER_0_USES_THERMISTOR, HEATER_1_USES_THERMISTOR, HEATER_2_USES_THERMISTOR, HEATER_3_USES_THERMISTOR, \
   HEATER_4_USES_THERMISTOR, HEATER_5_USES_THERMISTOR, HEATER_6_USES_THERMISTOR, HEATER_7_USES_THERMISTOR )
-
-/**
- * Default hotend offsets, if not defined
- */
-#if HAS_HOTEND_OFFSET
-  #ifndef HOTEND_OFFSET_X
-    #define HOTEND_OFFSET_X { 0 } // X offsets for each extruder
-  #endif
-  #ifndef HOTEND_OFFSET_Y
-    #define HOTEND_OFFSET_Y { 0 } // Y offsets for each extruder
-  #endif
-  #ifndef HOTEND_OFFSET_Z
-    #define HOTEND_OFFSET_Z { 0 } // Z offsets for each extruder
-  #endif
-#endif
-
-/**
- * ARRAY_BY_EXTRUDERS based on EXTRUDERS
- */
-#define ARRAY_BY_EXTRUDERS(V...) ARRAY_N(EXTRUDERS, V)
-#define ARRAY_BY_EXTRUDERS1(v1) ARRAY_BY_EXTRUDERS(v1, v1, v1, v1, v1, v1)
-
-/**
- * ARRAY_BY_HOTENDS based on HOTENDS
- */
-#define ARRAY_BY_HOTENDS(V...) ARRAY_N(HOTENDS, V)
-#define ARRAY_BY_HOTENDS1(v1) ARRAY_BY_HOTENDS(v1, v1, v1, v1, v1, v1)
-
-/**
- * Driver Timings
- * NOTE: Driver timing order is longest-to-shortest duration.
- *       Preserve this ordering when adding new drivers.
- */
-
-#ifndef MINIMUM_STEPPER_POST_DIR_DELAY
-  #if HAS_DRIVER(TB6560)
-    #define MINIMUM_STEPPER_POST_DIR_DELAY 15000
-  #elif HAS_DRIVER(TB6600)
-    #define MINIMUM_STEPPER_POST_DIR_DELAY 1500
-  #elif HAS_DRIVER(DRV8825)
-    #define MINIMUM_STEPPER_POST_DIR_DELAY 650
-  #elif HAS_DRIVER(LV8729)
-    #define MINIMUM_STEPPER_POST_DIR_DELAY 500
-  #elif HAS_DRIVER(A5984)
-    #define MINIMUM_STEPPER_POST_DIR_DELAY 400
-  #elif HAS_DRIVER(A4988)
-    #define MINIMUM_STEPPER_POST_DIR_DELAY 200
-  #elif HAS_TRINAMIC || HAS_TRINAMIC_STANDALONE
-    #define MINIMUM_STEPPER_POST_DIR_DELAY 20
-  #else
-    #define MINIMUM_STEPPER_POST_DIR_DELAY 0   // Expect at least 10µS since one Stepper ISR must transpire
-  #endif
-#endif
-
-#ifndef MINIMUM_STEPPER_PRE_DIR_DELAY
-  #define MINIMUM_STEPPER_PRE_DIR_DELAY MINIMUM_STEPPER_POST_DIR_DELAY
-#endif
-
-#ifndef MINIMUM_STEPPER_PULSE
-  #if HAS_DRIVER(TB6560)
-    #define MINIMUM_STEPPER_PULSE 30
-  #elif HAS_DRIVER(TB6600)
-    #define MINIMUM_STEPPER_PULSE 3
-  #elif HAS_DRIVER(DRV8825)
-    #define MINIMUM_STEPPER_PULSE 2
-  #elif HAS_DRIVER(A4988) || HAS_DRIVER(A5984)
-    #define MINIMUM_STEPPER_PULSE 1
-  #elif HAS_TRINAMIC || HAS_TRINAMIC_STANDALONE
-    #define MINIMUM_STEPPER_PULSE 0
-  #elif HAS_DRIVER(LV8729)
-    #define MINIMUM_STEPPER_PULSE 0
-  #else
-    #define MINIMUM_STEPPER_PULSE 2
-  #endif
-#endif
-
-#ifndef MAXIMUM_STEPPER_RATE
-  #if HAS_DRIVER(TB6560)
-    #define MAXIMUM_STEPPER_RATE 15000
-  #elif HAS_DRIVER(TB6600)
-    #define MAXIMUM_STEPPER_RATE 150000
-  #elif HAS_DRIVER(DRV8825)
-    #define MAXIMUM_STEPPER_RATE 250000
-  #elif HAS_DRIVER(A4988)
-    #define MAXIMUM_STEPPER_RATE 500000
-  #elif HAS_DRIVER(LV8729)
-    #define MAXIMUM_STEPPER_RATE 1000000
-  #elif HAS_TRINAMIC || HAS_TRINAMIC_STANDALONE
-    #define MAXIMUM_STEPPER_RATE 5000000
-  #else
-    #define MAXIMUM_STEPPER_RATE 250000
-  #endif
-#endif
 
 /**
  * X_DUAL_ENDSTOPS endstop reassignment
@@ -1522,6 +1426,7 @@
 #if !HAS_TEMP_SENSOR
   #undef AUTO_REPORT_TEMPERATURES
 #endif
+#define HAS_AUTO_REPORTING EITHER(AUTO_REPORT_TEMPERATURES, AUTO_REPORT_SD_STATUS)
 
 #if !HAS_AUTO_CHAMBER_FAN || AUTO_CHAMBER_IS_E
   #undef AUTO_POWER_CHAMBER_FAN
@@ -1617,20 +1522,6 @@
   #define HAS_MICROSTEP128 defined(MICROSTEP128)
 
 #endif // HAS_MICROSTEPS
-
-#if !HAS_TEMP_SENSOR
-  #undef AUTO_REPORT_TEMPERATURES
-#endif
-
-#define HAS_AUTO_REPORTING EITHER(AUTO_REPORT_TEMPERATURES, AUTO_REPORT_SD_STATUS)
-
-/**
- * This setting is also used by M109 when trying to calculate
- * a ballpark safe margin to prevent wait-forever situation.
- */
-#ifndef EXTRUDE_MINTEMP
-  #define EXTRUDE_MINTEMP 170
-#endif
 
 /**
  * Heater signal inversion defaults
@@ -2121,29 +2012,6 @@
   #define MAX_VFAT_ENTRIES (2)
 #endif
 
-// Set defaults for unspecified LED user colors
-#if ENABLED(LED_CONTROL_MENU)
-  #ifndef LED_USER_PRESET_RED
-    #define LED_USER_PRESET_RED       255
-  #endif
-  #ifndef LED_USER_PRESET_GREEN
-    #define LED_USER_PRESET_GREEN     255
-  #endif
-  #ifndef LED_USER_PRESET_BLUE
-    #define LED_USER_PRESET_BLUE      255
-  #endif
-  #ifndef LED_USER_PRESET_WHITE
-    #define LED_USER_PRESET_WHITE     0
-  #endif
-  #ifndef LED_USER_PRESET_BRIGHTNESS
-    #ifdef NEOPIXEL_BRIGHTNESS
-      #define LED_USER_PRESET_BRIGHTNESS NEOPIXEL_BRIGHTNESS
-    #else
-      #define LED_USER_PRESET_BRIGHTNESS 255
-    #endif
-  #endif
-#endif
-
 // Nozzle park for Delta
 #if BOTH(NOZZLE_PARK_FEATURE, DELTA)
   #undef NOZZLE_PARK_Z_FEEDRATE
@@ -2180,12 +2048,9 @@
 #endif
 
 // Defined here to catch the above defines
-#if ENABLED(SDCARD_SORT_ALPHA)
-  #define HAS_FOLDER_SORTING (FOLDER_SORTING || ENABLED(SDSORT_GCODE))
+#if ENABLED(SDCARD_SORT_ALPHA) && (FOLDER_SORTING || ENABLED(SDSORT_GCODE))
+  #define HAS_FOLDER_SORTING 1
 #endif
-
-// If platform requires early initialization of watchdog to properly boot
-#define EARLY_WATCHDOG (ENABLED(USE_WATCHDOG) && defined(ARDUINO_ARCH_SAM))
 
 #if HAS_SPI_LCD
   // Get LCD character width/height, which may be overridden by pins, configs, etc.
@@ -2222,15 +2087,4 @@
   #if DISABLED(SHARED_SD_CARD)
     #define INIT_SDCARD_ON_BOOT
   #endif
-#endif
-
-#if !NUM_SERIAL
-  #undef BAUD_RATE_GCODE
-#endif
-
-#if ENABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
-  #undef Z_STEPPER_ALIGN_AMP
-#endif
-#ifndef Z_STEPPER_ALIGN_AMP
-  #define Z_STEPPER_ALIGN_AMP 1.0
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2732,3 +2732,8 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
 #if HAS_TMC_SPI && ALL(MONITOR_DRIVER_STATUS, SDSUPPORT, USES_SHARED_SPI)
   #error "MONITOR_DRIVER_STATUS and SDSUPPORT cannot be used together on boards with shared SPI."
 #endif
+
+// G60/G61 Position Save
+#if SAVED_POSITIONS > 256
+  #error "SAVED_POSITIONS must be an integer from 0 to 256."
+#endif


### PR DESCRIPTION
- Add sanity checks to catch conflicts between enabled features and i2c pins.
- Improve the serial port pin conflict tests.
- Move some conditionals around, with more in `Conditionals_adv.h`.