### PR TITLE
Add 'U' flag to M114 to allow reporting position without having to em…

### DIFF
--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -194,11 +194,9 @@ void GcodeSuite::M114() {
       return;
     }
   #endif
-  if (parser.seen('U')) {
-    report_current_position();
-    return;
-  }
 
-  planner.synchronize();
+  if ( ! print_job_timer.isRunning() ) {
+    planner.synchronize();
+  }
   report_current_position();
 }

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -194,6 +194,10 @@ void GcodeSuite::M114() {
       return;
     }
   #endif
+  if (parser.seen('U')) {
+    report_current_position();
+    return;
+  }
 
   planner.synchronize();
   report_current_position();


### PR DESCRIPTION
…pty the planner buffer

### Requirements
Adds a 'U' flag to return the unsynchronized position without waiting for the planner buffer to be empty.

### Benefits
This returns the current position at the time of the command, and not waiting until the planner buffer is empty. This means the position isn't perfect - but good enough for status updates on TFT screens etc without blocking the print causing artefacts and blobbing.

### Related Issues
Re the problem:
https://github.com/MarlinFirmware/Marlin/issues/16894
https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/193

Original info on making M114 sync'ed by default:
https://github.com/MarlinFirmware/Marlin/issues/6037