### PR TITLE
Asynchronous M114 and realtime position option

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -276,8 +276,10 @@
   #define AUTOTEMP_OLDWEIGHT 0.98
 #endif
 
-// Show extra position information with 'M114 D'
-//#define M114_DETAIL
+// Extra options for the M114 "Current Position" report
+//#define M114_DETAIL         // Use 'M114` for details to check planner calculations
+//#define M114_REALTIME       // Real current position based on forward kinematics
+//#define M114_LEGACY         // M114 used to synchronize on every call. Enable if needed.
 
 // Show Temperature ADC value
 // Enable for M105 to include ADC values read from temperature sensors.

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -187,6 +187,12 @@ struct XYval {
   };
   FI void set(const T px)                               { x = px; }
   FI void set(const T px, const T py)                   { x = px; y = py; }
+  FI void set(const T (&arr)[XY])                       { x = arr[0]; y = arr[1]; }
+  FI void set(const T (&arr)[XYZ])                      { x = arr[0]; y = arr[1]; }
+  FI void set(const T (&arr)[XYZE])                     { x = arr[0]; y = arr[1]; }
+  #if XYZE_N > XYZE
+    FI void set(const T (&arr)[XYZE_N])                 { x = arr[0]; y = arr[1]; }
+  #endif
   FI void reset()                                       { x = y = 0; }
   FI T magnitude()                                const { return (T)sqrtf(x*x + y*y); }
   FI operator T* ()                                     { return pos; }
@@ -197,6 +203,8 @@ struct XYval {
   FI XYval<int16_t>    asInt()                    const { return { int16_t(x), int16_t(y) }; }
   FI XYval<int32_t>   asLong()                          { return { int32_t(x), int32_t(y) }; }
   FI XYval<int32_t>   asLong()                    const { return { int32_t(x), int32_t(y) }; }
+  FI XYval<int32_t>   ROUNDL()                          { return { int32_t(LROUND(x)), int32_t(LROUND(y)) }; }
+  FI XYval<int32_t>   ROUNDL()                    const { return { int32_t(LROUND(x)), int32_t(LROUND(y)) }; }
   FI XYval<float>    asFloat()                          { return {   float(x),   float(y) }; }
   FI XYval<float>    asFloat()                    const { return {   float(x),   float(y) }; }
   FI XYval<float> reciprocal()                    const { return {  _RECIP(x),  _RECIP(y) }; }
@@ -290,6 +298,12 @@ struct XYZval {
   FI void set(const T px, const T py)                  { x = px; y = py; }
   FI void set(const T px, const T py, const T pz)      { x = px; y = py; z = pz; }
   FI void set(const XYval<T> pxy, const T pz)          { x = pxy.x; y = pxy.y; z = pz; }
+  FI void set(const T (&arr)[XY])                      { x = arr[0]; y = arr[1]; }
+  FI void set(const T (&arr)[XYZ])                     { x = arr[0]; y = arr[1]; z = arr[2]; }
+  FI void set(const T (&arr)[XYZE])                    { x = arr[0]; y = arr[1]; z = arr[2]; }
+  #if XYZE_N > XYZE
+    FI void set(const T (&arr)[XYZE_N])                { x = arr[0]; y = arr[1]; z = arr[2]; }
+  #endif
   FI void reset()                                      { x = y = z = 0; }
   FI T magnitude()                               const { return (T)sqrtf(x*x + y*y + z*z); }
   FI operator T* ()                                    { return pos; }
@@ -300,6 +314,8 @@ struct XYZval {
   FI XYZval<int16_t>   asInt()                   const { return { int16_t(x), int16_t(y), int16_t(z) }; }
   FI XYZval<int32_t>  asLong()                         { return { int32_t(x), int32_t(y), int32_t(z) }; }
   FI XYZval<int32_t>  asLong()                   const { return { int32_t(x), int32_t(y), int32_t(z) }; }
+  FI XYZval<int32_t>  ROUNDL()                         { return { int32_t(LROUND(x)), int32_t(LROUND(y)), int32_t(LROUND(z)) }; }
+  FI XYZval<int32_t>  ROUNDL()                   const { return { int32_t(LROUND(x)), int32_t(LROUND(y)), int32_t(LROUND(z)) }; }
   FI XYZval<float>   asFloat()                         { return {   float(x),   float(y),   float(z) }; }
   FI XYZval<float>   asFloat()                   const { return {   float(x),   float(y),   float(z) }; }
   FI XYZval<float> reciprocal()                  const { return {  _RECIP(x),  _RECIP(y),  _RECIP(z) }; }
@@ -397,12 +413,20 @@ struct XYZEval {
   FI void set(const XYval<T> pxy, const T pz, const T pe)     { x = pxy.x;  y = pxy.y;  z = pz;     e = pe;    }
   FI void set(const XYval<T> pxy, const XYval<T> pze)         { x = pxy.x;  y = pxy.y;  z = pze.z;  e = pze.e; }
   FI void set(const XYZval<T> pxyz, const T pe)               { x = pxyz.x; y = pxyz.y; z = pxyz.z; e = pe;    }
+  FI void set(const T (&arr)[XY])                             { x = arr[0]; y = arr[1]; }
+  FI void set(const T (&arr)[XYZ])                            { x = arr[0]; y = arr[1]; z = arr[2]; }
+  FI void set(const T (&arr)[XYZE])                           { x = arr[0]; y = arr[1]; z = arr[2]; e = arr[3]; }
+  #if XYZE_N > XYZE
+    FI void set(const T (&arr)[XYZE_N])                       { x = arr[0]; y = arr[1]; z = arr[2]; e = arr[3]; }
+  #endif
   FI XYZEval<T>          copy()                         const { return *this; }
   FI XYZEval<T>           ABS()                         const { return { T(_ABS(x)), T(_ABS(y)), T(_ABS(z)), T(_ABS(e)) }; }
   FI XYZEval<int16_t>   asInt()                               { return { int16_t(x), int16_t(y), int16_t(z), int16_t(e) }; }
   FI XYZEval<int16_t>   asInt()                         const { return { int16_t(x), int16_t(y), int16_t(z), int16_t(e) }; }
-  FI XYZEval<int32_t>  asLong()                         const { return { int32_t(x), int32_t(y), int32_t(z), int32_t(e) }; }
   FI XYZEval<int32_t>  asLong()                               { return { int32_t(x), int32_t(y), int32_t(z), int32_t(e) }; }
+  FI XYZEval<int32_t>  asLong()                         const { return { int32_t(x), int32_t(y), int32_t(z), int32_t(e) }; }
+  FI XYZEval<int32_t>  ROUNDL()                               { return { int32_t(LROUND(x)), int32_t(LROUND(y)), int32_t(LROUND(z)), int32_t(LROUND(e)) }; }
+  FI XYZEval<int32_t>  ROUNDL()                         const { return { int32_t(LROUND(x)), int32_t(LROUND(y)), int32_t(LROUND(z)), int32_t(LROUND(e)) }; }
   FI XYZEval<float>   asFloat()                               { return {   float(x),   float(y),   float(z),   float(e) }; }
   FI XYZEval<float>   asFloat()                         const { return {   float(x),   float(y),   float(z),   float(e) }; }
   FI XYZEval<float> reciprocal()                        const { return {  _RECIP(x),  _RECIP(y),  _RECIP(z),  _RECIP(e) }; }

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -34,7 +34,7 @@
     #include "../../core/debug_out.h"
   #endif
 
-  void report_xyze(const xyze_pos_t &pos, const uint8_t n=4, const uint8_t precision=3) {
+  void report_xyze(const xyze_pos_t &pos, const uint8_t n=XYZE, const uint8_t precision=3) {
     char str[12];
     for (uint8_t a = 0; a < n; a++) {
       SERIAL_CHAR(' ', axis_codes[a], ':');
@@ -42,6 +42,7 @@
     }
     SERIAL_EOL();
   }
+  inline void report_xyz(const xyze_pos_t &pos) { report_xyze(pos, 3); }
 
   void report_xyz(const xyz_pos_t &pos, const uint8_t precision=3) {
     char str[12];
@@ -51,23 +52,26 @@
     }
     SERIAL_EOL();
   }
-  inline void report_xyz(const xyze_pos_t &pos) { report_xyze(pos, 3); }
 
   void report_current_position_detail() {
 
+    // Position as sent by G-code
     SERIAL_ECHOPGM("\nLogical:");
     report_xyz(current_position.asLogical());
 
+    // Cartesian position in native machine space
     SERIAL_ECHOPGM("Raw:    ");
     report_xyz(current_position);
 
     xyze_pos_t leveled = current_position;
 
     #if HAS_LEVELING
+      // Current position with leveling applied
       SERIAL_ECHOPGM("Leveled:");
       planner.apply_leveling(leveled);
       report_xyz(leveled);
 
+      // Test planner un-leveling. This should match the Raw result.
       SERIAL_ECHOPGM("UnLevel:");
       xyze_pos_t unleveled = leveled;
       planner.unapply_leveling(unleveled);
@@ -75,6 +79,7 @@
     #endif
 
     #if IS_KINEMATIC
+      // Kinematics applied to the leveled position
       #if IS_SCARA
         SERIAL_ECHOPGM("ScaraK: ");
       #else
@@ -180,12 +185,21 @@
 #endif // M114_DETAIL
 
 /**
- * M114: Report current position to host
+ * M114: Report the current position to host.
+ *       Since steppers are moving, the count positions are
+ *       projected by using planner calculations.
+ *   D - Report more detail. This syncs the planner. (Requires M114_DETAIL)
+ *   E - Report E stepper position (Requires M114_DETAIL)
+ *   R - Report the realtime position instead of projected.
  */
 void GcodeSuite::M114() {
 
   #if ENABLED(M114_DETAIL)
     if (parser.seen('D')) {
+      #if DISABLED(M114_LEGACY)
+        planner.synchronize();
+      #endif
+      report_current_position();
       report_current_position_detail();
       return;
     }
@@ -195,6 +209,12 @@ void GcodeSuite::M114() {
     }
   #endif
 
-  planner.synchronize();
-  report_current_position();
+  #if ENABLED(M114_REALTIME)
+    if (parser.seen('R')) { report_real_position(); return; }
+  #endif
+
+  #if ENABLED(M114_LEGACY)
+    planner.synchronize();
+  #endif
+  report_current_position_projected();
 }

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -162,7 +162,9 @@ typedef struct { xyz_pos_t min, max; } axis_limits_t;
   #define update_software_endstops(...) NOOP
 #endif
 
+void report_real_position();
 void report_current_position();
+void report_current_position_projected();
 
 void get_cartesian_from_steppers();
 void set_current_from_steppers_for_axis(const AxisEnum axis);

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -289,6 +289,12 @@ class Planner {
       static float extruder_advance_K[EXTRUDERS];
     #endif
 
+    /**
+     * The current position of the tool in absolute steps
+     * Recalculated if any axis_steps_per_mm are changed by gcode
+     */
+    static xyze_long_t position;
+
     #if HAS_POSITION_FLOAT
       static xyze_pos_t position_float;
     #endif
@@ -304,12 +310,6 @@ class Planner {
     #endif
 
   private:
-
-    /**
-     * The current position of the tool in absolute steps
-     * Recalculated if any axis_steps_per_mm are changed by gcode
-     */
-    static xyze_long_t position;
 
     /**
      * Speed of previous path line segment
@@ -724,6 +724,16 @@ class Planner {
      * For CORE machines apply translation from ABC to XYZ.
      */
     static float get_axis_position_mm(const AxisEnum axis);
+
+    static inline abce_pos_t get_axis_positions_mm() {
+      const abce_pos_t out = {
+        get_axis_position_mm(A_AXIS),
+        get_axis_position_mm(B_AXIS),
+        get_axis_position_mm(C_AXIS),
+        get_axis_position_mm(E_AXIS)
+      };
+      return out;
+    }
 
     // SCARA AB axes are in degrees, not mm
     #if IS_SCARA

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2448,6 +2448,19 @@ int32_t Stepper::triggered_position(const AxisEnum axis) {
   return v;
 }
 
+void Stepper::report_a_position(const xyz_long_t &pos) {
+  #if CORE_IS_XY || CORE_IS_XZ || ENABLED(DELTA) || IS_SCARA
+    SERIAL_ECHOPAIR(STR_COUNT_A, pos.x, " B:", pos.y);
+  #else
+    SERIAL_ECHOPAIR_P(PSTR(STR_COUNT_X), pos.x, SP_Y_LBL, pos.y);
+  #endif
+  #if CORE_IS_XZ || CORE_IS_YZ || ENABLED(DELTA)
+    SERIAL_ECHOLNPAIR(" C:", pos.z);
+  #else
+    SERIAL_ECHOLNPAIR_P(SP_Z_LBL, pos.z);
+  #endif
+}
+
 void Stepper::report_positions() {
 
   #ifdef __AVR__
@@ -2461,16 +2474,7 @@ void Stepper::report_positions() {
     if (was_enabled) wake_up();
   #endif
 
-  #if CORE_IS_XY || CORE_IS_XZ || ENABLED(DELTA) || IS_SCARA
-    SERIAL_ECHOPAIR(STR_COUNT_A, pos.x, " B:", pos.y);
-  #else
-    SERIAL_ECHOPAIR_P(PSTR(STR_COUNT_X), pos.x, SP_Y_LBL, pos.y);
-  #endif
-  #if CORE_IS_XZ || CORE_IS_YZ || ENABLED(DELTA)
-    SERIAL_ECHOLNPAIR(" C:", pos.z);
-  #else
-    SERIAL_ECHOLNPAIR_P(SP_Z_LBL, pos.z);
-  #endif
+  report_a_position(pos);
 }
 
 #if ENABLED(BABYSTEPPING)

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -411,6 +411,7 @@ class Stepper {
     static void set_axis_position(const AxisEnum a, const int32_t &v);
 
     // Report the positions of the steppers, in steps
+    static void report_a_position(const xyz_long_t &pos);
     static void report_positions();
 
     // Quickly stop all steppers


### PR DESCRIPTION
The `M114` command is now used by some serial-attached LCDs to get position information to display on the screen. This is causing problems because `M114` calls `planner.synchronize` so that the positions reported from the planner and the G-code parser match up, and the planner values can be compared expected values to verify that kinematics and leveling are working properly.

Since the specification about `M114` doesn't require (or even mention) planner synchronization, this PR includes a couple of methods to produce an `M114` report that doesn't stop the planner but still produces values that match up with expectations.

1. Read the position from the steppers right now and apply Forward Kinematics, un-skew, un-leveling, and un-backlash to give a corresponding Cartesian position.
2. Report the logical Current Position as set by the most recent G-code command, then apply skew, leveling, backlash compensation, and Inverse Kinematics to calculate the Stepper positions.

For this PR I've chosen to use the second method since you can send `G1` and then `M114` and you'll get back the position just set in `G1`. However, an option is included so `M114 R` can be used to apply the first method above.

References: #6037, #6039, #16894