### PR TITLE
M114: Only call planner.synchronize() when the print timer is stopped.

### DIFF
--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -195,6 +195,8 @@ void GcodeSuite::M114() {
     }
   #endif
 
-  planner.synchronize();
+  if ( ! print_job_timer.isRunning() ) {
+    planner.synchronize();
+  }
   report_current_position();
 }


### PR DESCRIPTION
When position reports are requested by TFT displays on a serial port,
currently planner.synchronize() is called. When the printer is doing
stuff and the planner buffer is not empty, this causes the buffer to
empty before an accurate position is reported.

The side-effect for this is that the print stalls for a fraction of
a second when the planner buffer becomes empty - and usually a blob
appears on the output of the print. If the TFT requests position
reports quite often, this can really screw up the quality of a print.

This patch will skip the call to planner.synchronize() if the print
timer is running. This way, if we only have a few commands in the
buffer, but we're not printing, we still wait until the buffer is
completed before doing a position report.

When M114 is called and the print job timer is NOT running, the current
behaviour will be observed - ie the buffer will be completed, then the
position report will be given.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/16894
https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/193