### PR TITLE
Fix three extruder with auto-fan build

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -473,7 +473,7 @@
     ( DEFER2(__RREPEAT2)()(ADD1(_RPT_I),SUB1(_RPT_N),_RPT_OP,V) ) \
     ( /* Do nothing */ )
 #define __RREPEAT2() _RREPEAT2
-#define RREPEAT_S(S,N,OP)        EVAL(_RREPEAT(S,SUB##S(N),OP))
+#define RREPEAT_S(S,N,OP)        EVAL1024(_RREPEAT(S,SUB##S(N),OP))
 #define RREPEAT(N,OP)            RREPEAT_S(0,N,OP)
-#define RREPEAT2_S(S,N,OP,V...)  EVAL(_RREPEAT2(S,SUB##S(N),OP,V))
+#define RREPEAT2_S(S,N,OP,V...)  EVAL1024(_RREPEAT2(S,SUB##S(N),OP,V))
 #define RREPEAT2(N,OP,V...)      RREPEAT2_S(0,N,OP,V)

--- a/buildroot/share/tests/BIGTREE_SKR_PRO-tests
+++ b/buildroot/share/tests/BIGTREE_SKR_PRO-tests
@@ -14,5 +14,16 @@ opt_set MOTHERBOARD BOARD_BTT_SKR_PRO_V1_1
 opt_set SERIAL_PORT 1
 exec_test $1 $2 "BigTreeTech SKR Pro Default Configuration"
 
+restore_configs
+opt_set MOTHERBOARD BOARD_BTT_SKR_PRO_V1_1
+opt_set SERIAL_PORT -1
+opt_set EXTRUDERS 3
+opt_set TEMP_SENSOR_1 1
+opt_set TEMP_SENSOR_2 1
+opt_set E0_AUTO_FAN_PIN PC10
+opt_set E1_AUTO_FAN_PIN PC11
+opt_set E2_AUTO_FAN_PIN PC12
+exec_test $1 $2 "BigTreeTech SKR Pro 3 Extruders with Auto-Fan"
+
 # clean up
 restore_configs


### PR DESCRIPTION
### Description

Trying to build with 3 extruders and auto-fan resulted in build errors due to incomplete macro expansion in the following code. The nested REPEAT macros overwhelmed the default `EVAL` implementation, which is defined as `EVAL16`.

Increasing to `EVAL64` is enough to fix the test included in this commit, but going to 8 extruders required going all the way to `EVAL1024`. This commit does not include an 8-extruder test, because additional unrelated changes are needed for that to compile, which will be in additional PRs.

```
  void Temperature::checkExtruderAutoFans() {
      ...
      #if HOTENDS > 1
        #define _NEXT_FAN(N) , REPEAT2(N,_EFAN,N) N
        RREPEAT_S(1, HOTENDS, _NEXT_FAN)
      #endif
      ...
    };
```

### Benefits

Fixes 3-extruder builds. I originally discovered this by trying to build the _Cartesio_ example configuration. I used an SKR Pro as the testing platform for this because the _Cartesio_ example currently has other issues, which will be addressed separately from this.

### Related Issues

I did not find issues for this.
