### PR TITLE
Fix build issues with REPRAPWORLD_KEYPAD

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -391,7 +391,7 @@ bool MarlinUI::get_blink() {
 
     void _reprapworld_keypad_move(const AxisEnum axis, const int16_t dir) {
       move_menu_scale = REPRAPWORLD_KEYPAD_MOVE_STEP;
-      MarlinUI::encoderPosition = dir;
+      ui.encoderPosition = dir;
       switch (axis) {
         case X_AXIS: lcd_move_x(); break;
         case Y_AXIS: lcd_move_y(); break;
@@ -1149,27 +1149,6 @@ void MarlinUI::update() {
 
 #if HAS_ENCODER_ACTION
 
-  #if DISABLED(ADC_KEYPAD) && (ENABLED(REPRAPWORLD_KEYPAD) || !HAS_DIGITAL_BUTTONS)
-
-    /**
-     * Setup Rotary Encoder Bit Values (for two pin encoders to indicate movement)
-     * These values are independent of which pins are used for EN_A and EN_B indications
-     * The rotary encoder part is also independent to the chipset used for the LCD
-     */
-    #define GET_SHIFT_BUTTON_STATES(DST) \
-      uint8_t new_##DST = 0; \
-      WRITE(SHIFT_LD, LOW); \
-      WRITE(SHIFT_LD, HIGH); \
-      for (int8_t i = 0; i < 8; i++) { \
-        new_##DST >>= 1; \
-        if (READ(SHIFT_OUT)) SBI(new_##DST, 7); \
-        WRITE(SHIFT_CLK, HIGH); \
-        WRITE(SHIFT_CLK, LOW); \
-      } \
-      DST = ~new_##DST; //invert it, because a pressed switch produces a logical 0
-
-  #endif
-
   /**
    * Read encoder buttons from the hardware registers
    * Warning: This function is called from interrupt context!
@@ -1266,11 +1245,25 @@ void MarlinUI::update() {
         }
       #endif
 
-      #if HAS_SHIFT_ENCODER
+      #if HAS_SHIFT_ENCODER      
+        /**
+         * Set up Rotary Encoder bit values (for two pin encoders to indicate movement).
+         * These values are independent of which pins are used for EN_A / EN_B indications.
+         * The rotary encoder part is also independent of the LCD chipset.
+         */
+        uint8_t val = 0;
+        WRITE(SHIFT_LD, LOW);
+        WRITE(SHIFT_LD, HIGH);
+        LOOP_L_N(i, 8) {
+          val >>= 1;
+          if (READ(SHIFT_OUT)) SBI(val, 7);
+          WRITE(SHIFT_CLK, HIGH);
+          WRITE(SHIFT_CLK, LOW);
+        }
         #if ENABLED(REPRAPWORLD_KEYPAD)
-          GET_SHIFT_BUTTON_STATES(keypad_buttons);
+          keypad_buttons = ~val;
         #else
-          GET_SHIFT_BUTTON_STATES(buttons);
+          buttons = ~val;
         #endif
       #endif
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -391,7 +391,7 @@ bool MarlinUI::get_blink() {
 
     void _reprapworld_keypad_move(const AxisEnum axis, const int16_t dir) {
       move_menu_scale = REPRAPWORLD_KEYPAD_MOVE_STEP;
-      encoderPosition = dir;
+      MarlinUI::encoderPosition = dir;
       switch (axis) {
         case X_AXIS: lcd_move_x(); break;
         case Y_AXIS: lcd_move_y(); break;
@@ -1267,15 +1267,11 @@ void MarlinUI::update() {
       #endif
 
       #if HAS_SHIFT_ENCODER
-
-        GET_SHIFT_BUTTON_STATES((
-          #if ENABLED(REPRAPWORLD_KEYPAD)
-            keypad_buttons
-          #else
-            buttons
-          #endif
-        ));
-
+        #if ENABLED(REPRAPWORLD_KEYPAD)
+          GET_SHIFT_BUTTON_STATES(keypad_buttons);
+        #else
+          GET_SHIFT_BUTTON_STATES(buttons);
+        #endif
       #endif
 
     } // next_button_update_ms

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -647,7 +647,7 @@
           #define NEOPIXEL_PIN    25
         #endif
 
-    #endif
+      #endif
 
     #elif ENABLED(MINIPANEL)
 
@@ -685,14 +685,7 @@
       #define BEEPER_PIN        33
 
       // Buttons are directly attached to AUX-2
-      #if ENABLED(REPRAPWORLD_KEYPAD)
-        #define SHIFT_OUT       40
-        #define SHIFT_CLK       44
-        #define SHIFT_LD        42
-        #define BTN_EN1         64
-        #define BTN_EN2         59
-        #define BTN_ENC         63
-      #elif ENABLED(PANEL_ONE)
+      #if ENABLED(PANEL_ONE)
         #define BTN_EN1         59   // AUX2 PIN 3
         #define BTN_EN2         63   // AUX2 PIN 4
         #define BTN_ENC         49   // AUX3 PIN 7
@@ -711,3 +704,18 @@
   #endif // NEWPANEL
 
 #endif // HAS_SPI_LCD
+
+#if ENABLED(REPRAPWORLD_KEYPAD)
+  #define SHIFT_OUT        40
+  #define SHIFT_CLK        44
+  #define SHIFT_LD         42
+  #ifndef BTN_EN1
+    #define BTN_EN1        64
+  #endif
+  #ifndef BTN_EN2
+    #define BTN_EN2        59
+  #endif
+  #ifndef BTN_ENC
+    #define BTN_ENC        63
+  #endif
+#endif

--- a/buildroot/share/tests/megaatmega2560-tests
+++ b/buildroot/share/tests/megaatmega2560-tests
@@ -146,12 +146,14 @@ exec_test $1 $2 "Azteeg X3 | Mixing Extruder (x5) | Gradient Mix | Cyrillic"
 # Test DUAL_X_CARRIAGE
 #
 restore_configs
-opt_set MOTHERBOARD BOARD_RUMBA
+opt_set MOTHERBOARD BOARD_TT_OSCAR
 opt_set LCD_LANGUAGE pt
 opt_set EXTRUDERS 2
 opt_set TEMP_SENSOR_1 1
 opt_enable USE_XMAX_PLUG DUAL_X_CARRIAGE
-exec_test $1 $2 "Rumba | DUAL_X_CARRIAGE"
+opt_enable REPRAPWORLD_KEYPAD
+opt_set REPRAPWORLD_KEYPAD_MOVE_STEP 10.0
+exec_test $1 $2 "TT Oscar | DUAL_X_CARRIAGE"
 
 #
 # Test SPEAKER with BOARD_BQ_ZUM_MEGA_3D and BQ_LCD_SMART_CONTROLLER
@@ -370,14 +372,6 @@ opt_set Y_DRIVER_TYPE TMC2130
 opt_set Z_DRIVER_TYPE TMC2130_STANDALONE
 opt_set E0_DRIVER_TYPE TMC2660
 exec_test $1 $2 "RAMPS | SCARA | Mixed TMC | EEPROM"
-
-#
-# Ultipanel with keypad
-#
-restore_configs
-opt_enable REPRAPWORLD_KEYPAD ULTIPANEL
-opt_set REPRAPWORLD_KEYPAD_MOVE_STEP 10.0
-exec_test $1 $2 "RAMPS | Ultipanel | RRW Keypad"
 
 #
 # tvrrug Config need to check board type for sanguino atmega644p

--- a/buildroot/share/tests/megaatmega2560-tests
+++ b/buildroot/share/tests/megaatmega2560-tests
@@ -372,6 +372,14 @@ opt_set E0_DRIVER_TYPE TMC2660
 exec_test $1 $2 "RAMPS | SCARA | Mixed TMC | EEPROM"
 
 #
+# Ultipanel with keypad
+#
+restore_configs
+opt_enable REPRAPWORLD_KEYPAD ULTIPANEL
+opt_set REPRAPWORLD_KEYPAD_MOVE_STEP 10.0
+exec_test $1 $2 "RAMPS | Ultipanel | RRW Keypad"
+
+#
 # tvrrug Config need to check board type for sanguino atmega644p
 #
 #use_example_configs tvrrug/Round2


### PR DESCRIPTION
### Description

Fix the following build errors when using REPRAPWORLD_KEYPAD.

```
Marlin\src\lcd\ultralcd.cpp: In function 'void _reprapworld_keypad_move(AxisEnum, int16_t)':
Marlin\src\lcd\ultralcd.cpp:394:7: error: 'encoderPosition' was not declared in this scope
       encoderPosition = dir;
       ^
```

```
Marlin\src\lcd\ultralcd.cpp:1160:15: error: pasting "new_" and "(" does not give a valid preprocessing token
       uint8_t new_##DST = 0; \
               ^
Marlin\src\lcd\ultralcd.cpp:1271:9: note: in expansion of macro 'GET_SHIFT_BUTTON_STATES'
         GET_SHIFT_BUTTON_STATES((
         ^
```

### Benefits

Allows REPRAPWORLD_KEYPAD to be compiled. When combined with #17035 this fixes the Cartesio example build.

### Related Issues

None
