### PR TITLE
Revert "Reverse encoder for FYSETC Mini 12864 2.1 + SKR 1.3"

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -300,7 +300,6 @@
         #endif
       #elif ENABLED(FYSETC_MINI_12864_2_1)
         #define NEOPIXEL_PIN    EXPA1_05_PIN
-        #define REVERSE_ENCODER_DIRECTION
       #endif
 
     #else // !FYSETC_MINI_12864


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#17010

Apparently not all FYSETC Mini 12864 2.1 are the same. Some don't need the encoder inverted...

