### PR TITLE
Don't define 'valptr' if unused

### DIFF
--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -312,7 +312,9 @@ void GCodeParser::parse(char *p) {
         char * const valptr = has_val ? is_str ? unescape_string(p) : p : nullptr;
       #else
         const bool has_val = valid_float(p);
-        char * const valptr = has_val ? p : nullptr;
+        #if ENABLED(FASTER_GCODE_PARSER)
+         char * const valptr = has_val ? p : nullptr;
+        #endif
       #endif
 
       #if ENABLED(DEBUG_GCODE_PARSER)

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -313,7 +313,7 @@ void GCodeParser::parse(char *p) {
       #else
         const bool has_val = valid_float(p);
         #if ENABLED(FASTER_GCODE_PARSER)
-         char * const valptr = has_val ? p : nullptr;
+          char * const valptr = has_val ? p : nullptr;
         #endif
       #endif
 


### PR DESCRIPTION
### Requirements

In Configuration_adv.h disable FASTER_GCODE_PARSER

### Description

With this define disabled the following warning is produced:
```
Marlin/src/gcode/parser.cpp: In static member function 'static void GCodeParser::parse(char*)':
Marlin/src/gcode/parser.cpp:316:23: warning: unused variable 'valptr' [-Wunused-variable]
          char * const valptr = has_val ? p : nullptr;
```
valptr is only used if FASTER_GCODE_PARSER is enabled.

### Benefits

The creation of this variable is now in a #if ENABLED(FASTER_GCODE_PARSER) block
The warning has been removed

### Related Issues
None