### PR TITLE
Suppress thisItemNr warning

### DIFF
--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -322,10 +322,10 @@ class MenuItem_bool : public MenuEditItemBase {
  *   _menuLineNr is the menu item to draw and process
  *   _thisItemNr is the index of each MENU_ITEM or STATIC_ITEM
  */
-#define SCREEN_OR_MENU_LOOP(IS_MENU)                \
-  scroll_screen(IS_MENU ? 1 : LCD_HEIGHT, IS_MENU); \
-  int8_t _menuLineNr = encoderTopLine, _thisItemNr; \
-  bool _skipStatic = IS_MENU; UNUSED(_thisItemNr);  \
+#define SCREEN_OR_MENU_LOOP(IS_MENU)                    \
+  scroll_screen(IS_MENU ? 1 : LCD_HEIGHT, IS_MENU);     \
+  int8_t _menuLineNr = encoderTopLine, _thisItemNr = 0; \
+  bool _skipStatic = IS_MENU; UNUSED(_thisItemNr);      \
   for (int8_t _lcdLineNr = 0; _lcdLineNr < LCD_HEIGHT; _lcdLineNr++, _menuLineNr++) { \
     _thisItemNr = 0
 


### PR DESCRIPTION
### Requirements

Default configuration + 
#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
#define MOTHERBOARD BOARD_BTT_SKR_V1_3

### Description

The following warning is produced
```
Marlin/src/lcd/menu/menu.h: In function 'void menu_temperature()':
Marlin/src/lcd/menu/menu.h:343:37: warning: '_thisItemNr' may be used uninitialized in this function [-Wmaybe-uninitialized]
  343 | #define END_SCREEN() } screen_items = _thisItemNr
      |                                     ^
Marlin/src/lcd/menu/menu.h:327:40: note: '_thisItemNr' was declared here
  327 |   int8_t _menuLineNr = encoderTopLine, _thisItemNr; \
      |                                        ^~~~~~~~~~~
Marlin/src/lcd/menu/menu.h:340:22: note: in expansion of macro 'SCREEN_OR_MENU_LOOP'
  340 | #define START_MENU() SCREEN_OR_MENU_LOOP(true)
      |                      ^~~~~~~~~~~~~~~~~~~
Marlin/src/lcd/menu/menu_temperature.cpp:165:3: note: in expansion of macro 'START_MENU'
  165 |   START_MENU();
      |   ^~~~~~~~~~
```

### Benefits
Removes these warning.

### Related Issues
None