### PR TITLE
Use BED_MAXTEMP for PTC_MAX_BED_TEMP

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1584,7 +1584,7 @@
   #if ENABLED(PROBE_TEMP_COMPENSATION)
     // Max temperature that can be reached by heated bed.
     // This is required only for the calibration process.
-    #define PTC_MAX_BED_TEMP 110
+    #define PTC_MAX_BED_TEMP BED_MAXTEMP
 
     // Park position to wait for probe cooldown
     #define PTC_PARK_POS_X 0.0F


### PR DESCRIPTION
### Description

Instead of having to define both `BED_MAXTEMP` and `PTC_MAX_BED_TEMP`, just use `BED_MAXTEMP`.

### Benefits

Easier setup of `G76`/Thermal Probe Compensation

### Related Issues

None.