### PR TITLE
Allow Z_STOP_PIN override on SKR 1.4

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -79,14 +79,22 @@
     #define Z_MIN_PIN      P1_00   // PWRDET
   #endif
 #else
-  #define Z_STOP_PIN       P1_27   // Z-STOP
+  #ifndef Z_STOP_PIN
+    #define Z_STOP_PIN     P1_27   // Z-STOP
+  #endif
 #endif
 
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-#ifndef Z_MIN_PROBE_PIN
-  #define Z_MIN_PROBE_PIN  P0_10
+#if Z_STOP_PIN == P0_10
+  #ifndef Z_MIN_PROBE_PIN
+    #define Z_MIN_PROBE_PIN P1_27
+  #endif
+#else
+  #ifndef Z_MIN_PROBE_PIN
+    #define Z_MIN_PROBE_PIN P0_10
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -87,12 +87,10 @@
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-#if Z_STOP_PIN == P0_10
-  #ifndef Z_MIN_PROBE_PIN
+#ifndef Z_MIN_PROBE_PIN
+  #if Z_STOP_PIN != P1_27
     #define Z_MIN_PROBE_PIN P1_27
-  #endif
-#else
-  #ifndef Z_MIN_PROBE_PIN
+  #else
     #define Z_MIN_PROBE_PIN P0_10
   #endif
 #endif


### PR DESCRIPTION
### Description
This is for SKR 1.4 and SKR 1.4 Turbo.
This simple change will allow the Z_STOP_PIN to be definable in the config file.
This is useful for people that don't want to rewire their plug to use the z-stop connector .

For example the BLtouch wouldn't work right using the Z_MIN_PROBE_PIN (doesn't deploy on z home)  but works fine using Z_STOP_PIN so instead of physically changing connectors we can just change the Z_STOP_PIN to the probe port pin (P0_10).

If the Z_STOP_PIN is changed to P0_10 it will make Z_MIN_PROBE_PIN P1_27

### Benefits

- Allows the Z_STOP_PIN to be definable in the config file.
- The user wouldn't need to physically rewire the BLTOUCH to use the z end stop connector on the board just simply redefine the Z_STOP_PIN.

