### PR TITLE
Tweaks to finishSDPrinting

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -418,32 +418,37 @@ void startOrResumeJob() {
   }
 
   inline void finishSDPrinting() {
+
     bool did_state = true;
     switch (card.sdprinting_done_state) {
 
-      #if HAS_RESUME_CONTINUE                   // Display "Click to Continue..."
-        case 1:                                 // 30 min timeout with LCD, 1 min without
-          did_state = queue.enqueue_one_P(PSTR("M0Q1S" TERN(HAS_LCD_MENU, "1800", "60")));
-          break;
-      #endif
-
-      case 2: print_job_timer.stop(); break;
-
-      case 3:
+      case 1:
         did_state = print_job_timer.duration() < 60 || queue.enqueue_one_P(PSTR("M31"));
         break;
 
-      case 4:
+      case 2:
+        did_state = queue.enqueue_one_P(PSTR("M77"));
+        break;
+
+      case 3:
+        #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
+          ui.set_progress_done();
+        #endif
+        break;
+
+      case 4:                                   // Display "Click to Continue..."
+        #if HAS_RESUME_CONTINUE                 // 30 min timeout with LCD, 1 min without
+          did_state = queue.enqueue_one_P(PSTR("M0Q1S" TERN(HAS_LCD_MENU, "1800", "60")));
+        #endif
+        break;
+
+      case 5:
         #if ENABLED(POWER_LOSS_RECOVERY)
           recovery.purge();
         #endif
 
         #if ENABLED(SD_FINISHED_STEPPERRELEASE) && defined(SD_FINISHED_RELEASECOMMAND)
           planner.finish_and_disable();
-        #endif
-
-        #if ENABLED(LCD_SET_PROGRESS_MANUALLY)
-          ui.set_progress_done();
         #endif
 
         #if ENABLED(SD_REPRINT_LAST_SELECTED_FILE)

--- a/Marlin/src/gcode/lcd/M0_M1.cpp
+++ b/Marlin/src/gcode/lcd/M0_M1.cpp
@@ -57,14 +57,17 @@ void GcodeSuite::M0_M1() {
   planner.synchronize();
 
   #if HAS_LEDS_OFF_FLAG
-    if (parser.seen('Q')) printerEventLEDs.onPrintCompleted();      // Change LED color for Print Completed
+    const bool seenQ = parser.seen('Q');
+    if (seenQ) printerEventLEDs.onPrintCompleted();      // Change LED color for Print Completed
+  #else
+    constexpr bool seenQ = false;
   #endif
 
   #if HAS_LCD_MENU
 
     if (parser.string_arg)
       ui.set_status(parser.string_arg, true);
-    else {
+    else if (!seenQ) {
       LCD_MESSAGEPGM(MSG_USERWAIT);
       #if ENABLED(LCD_PROGRESS_BAR) && PROGRESS_MSG_EXPIRE > 0
         ui.reset_progress_bar_timeout();


### PR DESCRIPTION
Some users are still experiencing weirdness at the end of SD prints. So this PR aims to refine `finishSDPrinting` and hopefully settle on a stable order of operations.