### PR TITLE
QUICK_HOME and SENSORLESS_HOMING are not compatible

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2268,6 +2268,10 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #undef Z_ENDSTOP_INVERTING
 #endif
 
+#if ENABLED(QUICK_HOME)
+  #error "QUICK_HOME and SENSORLESS_HOMING are not compatible. Disable QUICK_HOME to continue."
+#endif
+
 // Sensorless probing requirements
 #if ENABLED(SENSORLESS_PROBING)
   #if ENABLED(DELTA) && !(X_SENSORLESS && Y_SENSORLESS && Z_SENSORLESS)


### PR DESCRIPTION
### Requirements

- `SENSORLESS_HOMING`

### Description

After seeing many issues with `QUICK_HOME` and `SENSORLESS_HOMING` enabled in the Facebook groups and again tonight on stream with @codiac2600 & @Vertabreak, disabling `QUICK_HOME` seems to be a common fix for axis not homing correctly.

This PR adds a sanity check to help catch these issues before users update their printer.

### Benefits

`SENSORLESS_HOMING` works correctly.

### Related Issues

~This doesn't fix a specific issue since I've just seen posts in the various Facebook groups.~ https://github.com/MarlinFirmware/Marlin/issues/17057