### PR TITLE
Add reporting of Speed/Feed rate percentage to M220

### DIFF
--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -43,8 +43,7 @@ void GcodeSuite::M220() {
     if (parser.seen('R')) feedrate_percentage = backup_feedrate_percentage;
   #endif
 
-  if (parser.seenval('S'))
-    feedrate_percentage = parser.value_int();
+  if (parser.seenval('S')) feedrate_percentage = parser.value_int();
 
   if (!parser.seen_any()) {
     SERIAL_ECHOPAIR("FR:", feedrate_percentage);

--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -29,6 +29,8 @@
  * Parameters
  *   S<percent> : Set the feed rate percentage factor
  *
+ * Report the current speed percentage factor if no parameter is specified
+ * 
  * With PRUSA_MMU2...
  *   B : Flag to back up the current factor
  *   R : Flag to restore the last-saved factor
@@ -41,6 +43,12 @@ void GcodeSuite::M220() {
     if (parser.seen('R')) feedrate_percentage = backup_feedrate_percentage;
   #endif
 
-  if (parser.seenval('S')) feedrate_percentage = parser.value_int();
-
+  if (parser.seenval('S')) {
+    feedrate_percentage = parser.value_int();
+  }
+  else{
+    SERIAL_ECHOPAIR("Speed: ", feedrate_percentage);
+    SERIAL_CHAR('%');
+    SERIAL_EOL();
+  }
 }

--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -43,11 +43,11 @@ void GcodeSuite::M220() {
     if (parser.seen('R')) feedrate_percentage = backup_feedrate_percentage;
   #endif
 
-  if (parser.seenval('S')) {
+  if (parser.seenval('S'))
     feedrate_percentage = parser.value_int();
-  }
-  else{
-    SERIAL_ECHOPAIR("Speed: ", feedrate_percentage);
+
+  if (!parser.seen_any()) {
+    SERIAL_ECHOPAIR("FR:", feedrate_percentage);
     SERIAL_CHAR('%');
     SERIAL_EOL();
   }


### PR DESCRIPTION
### Description
Add reporting of Speed/feed rate percentage to `M220` to Serial hosts

### Benefits
In a multi-host setup like Octoprint and Serial Touch screens like BTT TFT, if the Feed rate is changed by one host, the second host will still have the older values.
This can lead to problems when a print is started through the second host, it will still show old Feed rate values when the user switches to feed rate setting in the second host.

This PR solves this problem by allowing the hosts to poll `M220` to get the current Feed rate percentage.