### PR TITLE
Fix Z4 stepper indirection macros

### DIFF
--- a/Marlin/src/module/stepper/indirection.h
+++ b/Marlin/src/module/stepper/indirection.h
@@ -185,18 +185,18 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
   #ifndef Z4_ENABLE_INIT
     #define Z4_ENABLE_INIT() SET_OUTPUT(Z4_ENABLE_PIN)
     #define Z4_ENABLE_WRITE(STATE) WRITE(Z4_ENABLE_PIN,STATE)
-    #define Z4_ENABLE_READ() READ(Z4_ENABLE_PIN)
+    #define Z4_ENABLE_READ() bool(READ(Z4_ENABLE_PIN))
   #endif
   #ifndef Z4_DIR_INIT
     #define Z4_DIR_INIT() SET_OUTPUT(Z4_DIR_PIN)
     #define Z4_DIR_WRITE(STATE) WRITE(Z4_DIR_PIN,STATE)
-    #define Z4_DIR_READ() READ(Z4_DIR_PIN)
+    #define Z4_DIR_READ() bool(READ(Z4_DIR_PIN))
   #endif
-  #define Z4_STEP_INIT SET_OUTPUT(Z4_STEP_PIN)
+  #define Z4_STEP_INIT() SET_OUTPUT(Z4_STEP_PIN)
   #ifndef Z4_STEP_WRITE
     #define Z4_STEP_WRITE(STATE) WRITE(Z4_STEP_PIN,STATE)
   #endif
-  #define Z4_STEP_READ READ(Z4_STEP_PIN)
+  #define Z4_STEP_READ() bool(READ(Z4_STEP_PIN))
 #else
   #define Z4_DIR_WRITE(STATE) NOOP
 #endif


### PR DESCRIPTION
allows compile with 4 z steppers.
compile tested working.

