### PR TITLE
Fix PIO environments for Anet 1.x

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -314,7 +314,7 @@
 #elif MB(OMCA)
   #include "sanguino/pins_OMCA.h"               // ATmega644P, ATmega644                  env:sanguino644p
 #elif MB(ANET_10)
-  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:sanguino1284p
+  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:melzi env:melzi_optiboot
 #elif MB(SETHI)
   #include "sanguino/pins_SETHI.h"              // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p
 


### PR DESCRIPTION
### Description

Offering either `melzi` or `melzi_optiboot` in Auto Build Marlin instead of `sanguino1284p`.
This fixes build issues on Windows and improves user experience.

### Benefits

Choice options for boards with normal and optiboot bootloaders.
Also fixes build on Windows, where command size limit of 32K is overrun.
