### PR TITLE
Respect soft stops when jogging with joystick

### DIFF
--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -173,6 +173,7 @@ Joystick joystick;
 
     if (!UNEAR_ZERO(hypot2)) {
       current_position += move_dist;
+      apply_motion_limits(current_position);
       const float length = sqrt(hypot2);
       injecting_now = true;
       planner.buffer_line(current_position, length / seg_time, active_extruder, length);


### PR DESCRIPTION

### Description

Tiny change to apply motion limits when jogging via joystick.

### Benefits

A bit safer when zooming around.
