### PR TITLE
Revert "Fix PIO environments for Anet 1.x"

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -314,7 +314,7 @@
 #elif MB(OMCA)
   #include "sanguino/pins_OMCA.h"               // ATmega644P, ATmega644                  env:sanguino644p
 #elif MB(ANET_10)
-  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:melzi env:melzi_optiboot
+  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:sanguino1284p
 #elif MB(SETHI)
   #include "sanguino/pins_SETHI.h"              // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p
 


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#17109

Please revert, it seems that melzi vs. melzi_optiboot has no different meaning. So please apologize the confusion generated by this. I will search for a better way to solve this and then do another pull request if I have a solution.