### PR TITLE
Revert previous change for Anet 1.X boards.

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -314,7 +314,7 @@
 #elif MB(OMCA)
   #include "sanguino/pins_OMCA.h"               // ATmega644P, ATmega644                  env:sanguino644p
 #elif MB(ANET_10)
-  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:melzi env:melzi_optiboot
+  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:sanguino1284p
 #elif MB(SETHI)
   #include "sanguino/pins_SETHI.h"              // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p
 


### PR DESCRIPTION
No effect on maximum build size when selecting the environment.
Will look for a fix, then re-post the changes if they work.

### Description

My previous change was ineffetive to block users with "normal" bootloaders on their Anet 1.X boards to not be able to build firmware larger than the required 126976 bytes when they select "melzi" instead of "melzi_optiboot". Instead for both environments that value is 130048. Also flashing with the melzi option and a "stock" bootloader did not work. I will look for another solution. This fix reverts back to one available environment.

### Benefits

Revert back to the only option needed.