### PR TITLE
fix stm32 _WRITE(IO, V) bug

### DIFF
--- a/Marlin/src/HAL/HAL_STM32/fastio.h
+++ b/Marlin/src/HAL/HAL_STM32/fastio.h
@@ -55,7 +55,7 @@ void FastIO_init(); // Must be called before using fast io macros
     else   FastIOPortMap[STM_PORT(digitalPin[IO])]->BRR  = _BV32(STM_PIN(digitalPin[IO])) ; \
   }while(0)
 #else
-  #define _WRITE(IO, V) (FastIOPortMap[STM_PORT(digitalPin[IO])]->BSRR = _BV32(STM_PIN(digitalPin[IO]) + (V ? 0 : 16)))
+  #define _WRITE(IO, V) (FastIOPortMap[STM_PORT(digitalPin[IO])]->BSRR = _BV32(STM_PIN(digitalPin[IO]) + ((V) ? 0 : 16)))
 #endif
 
 #define _READ(IO)               bool(READ_BIT(FastIOPortMap[STM_PORT(digitalPin[IO])]->IDR, _BV32(STM_PIN(digitalPin[IO]))))


### PR DESCRIPTION
### Description
https://github.com/MarlinFirmware/Marlin/blob/d6e767e36be5852a32526c08d9ade974b18f6546/Marlin/src/module/stepper.cpp#L341

After precompiling `X2_DIR_WRITE(mirrored_duplication_mode ? !(v) : v)` parameter will be expanded to “(mirrored_duplication_mode ? !(v) : v ? 0 : 16)"
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
* fix X2 axis motor always move to one direction in BCN printer(DUAL_X_CARRIAGE) `mirrored_duplication_mode`
* This bug may also cause some other undetected issues
<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
