### PR TITLE
Restrict arduinoststm32 version for FYSETC S6

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -624,7 +624,9 @@ src_filter        = ${common.default_src_filter} +<src/HAL/HAL_STM32>
 [env:FYSETC_S6]
 platform          = ststm32
 board             = fysetc_s6
-platform_packages = tool-stm32duino
+platform_packages =
+   tool-stm32duino
+   framework-arduinoststm32@>=3.107,<4
 build_flags       = ${common.build_flags}
   -DTARGET_STM32F4 -std=gnu++14
   -DVECT_TAB_OFFSET=0x10000


### PR DESCRIPTION
### Description

framework_arduinoststm32 4.0 causes a lot of warnings and build failures with Marlin.

Other environments already limit this to prevent the upgrade. This simply extends the same rule to the S6.

### Benefits

Builds cleanly without thousands of warnings and eventual failure.

### Related Issues

N/A
