### PR TITLE
Add OnPidTuning event to Malyan LCD

### DIFF
--- a/Marlin/src/lcd/extui_malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui_malyan_lcd.cpp
@@ -483,6 +483,7 @@ namespace ExtUI {
   void onLoadSettings(const char*) {}
   void onConfigurationStoreWritten(bool) {}
   void onConfigurationStoreRead(bool) {}
+  void OnPidTuning(const result_t) {}
 }
 
 #endif // MALYAN_LCD


### PR DESCRIPTION
### Description

With MALYAN_LCD option on, Marlin fails to compile as a new extended UI event was added (OnPidTuning), but this has not been added to extui_malyan_lcd.  This PR addes this event.  The malyan LCD does not handle a PID tuning, so nothing was needed other than adding a placeholder for this event.

### Benefits

Marlin compiles successfully with the Malyan_LCD option on.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
