### PR TITLE
own test

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1793,25 +1793,25 @@
  */
 //#define FWRETRACT
 #if ENABLED(FWRETRACT)
- //#define FWRETRACT_AUTORETRACT           // Override slicer retractions
- #if ENABLED(FWRETRACT_AUTORETRACT)
-   #define MIN_AUTORETRACT 0.1           // (mm) Don't convert E moves under this length
-   #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length
- #endif
- #define RETRACT_LENGTH 3                // (mm) Default retract length (positive value)
- #define RETRACT_FEEDRATE 45             // (mm/s) Default feedrate for retracting
- #define RETRACT_ZRAISE 0                // (mm) Default retract Z-raise
- #define RETRACT_RECOVER_LENGTH 0        // (mm) Default additional recover length (added to retract length on recover)
- #define RETRACT_RECOVER_FEEDRATE 8      // (mm/s) Default feedrate for recovering from retraction
- //#define FWRETRACT_SWAP_ENABLE         // Enable swap (instead of specific tool change )
- #if ENABLED(FWRETRACT_SWAP_ENABLE)
-   #define RETRACT_LENGTH_SWAP 13        // (mm) Default swap retract length (positive value)
-   #define RETRACT_RECOVER_LENGTH_SWAP 0 // (mm) Default additional swap recover length (added to retract length on recover from toolchange)
-   #define RETRACT_RECOVER_FEEDRATE_SWAP 8 // (mm/s) Default feedrate for recovering from swap retraction
- #endif
- #if ENABLED(MIXING_EXTRUDER)
-   //#define RETRACT_SYNC_MIXING         // Retract and restore all mixing steppers simultaneously
- #endif
+  //#define FWRETRACT_AUTORETRACT           // Override slicer retractions
+  #if ENABLED(FWRETRACT_AUTORETRACT)
+    #define MIN_AUTORETRACT 0.1           // (mm) Don't convert E moves under this length
+    #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length
+  #endif
+  #define RETRACT_LENGTH 3                // (mm) Default retract length (positive value)
+  #define RETRACT_FEEDRATE 45             // (mm/s) Default feedrate for retracting
+  #define RETRACT_ZRAISE 0                // (mm) Default retract Z-raise
+  #define RETRACT_RECOVER_LENGTH 0        // (mm) Default additional recover length (added to retract length on recover)
+  #define RETRACT_RECOVER_FEEDRATE 8      // (mm/s) Default feedrate for recovering from retraction
+  //#define FWRETRACT_SWAP_ENABLE         // Enable swap (instead of specific tool change )
+  #if ENABLED(FWRETRACT_SWAP_ENABLE)
+    #define RETRACT_LENGTH_SWAP 13        // (mm) Default swap retract length (positive value)
+    #define RETRACT_RECOVER_LENGTH_SWAP 0 // (mm) Default additional swap recover length (added to retract length on recover from toolchange)
+    #define RETRACT_RECOVER_FEEDRATE_SWAP 8 // (mm/s) Default feedrate for recovering from swap retraction
+  #endif
+  #if ENABLED(MIXING_EXTRUDER)
+    //#define RETRACT_SYNC_MIXING         // Retract and restore all mixing steppers simultaneously
+  #endif
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1803,7 +1803,7 @@
    #define RETRACT_ZRAISE 0                // (mm) Default retract Z-raise
    #define RETRACT_RECOVER_LENGTH 0        // (mm) Default additional recover length (added to retract length on recover)
    #define RETRACT_RECOVER_FEEDRATE 25     // (mm/s) Default feedrate for recovering from retraction
-   //#define FWRETRACT_SWAP_ENABLE         // Disable swap (economy of progmem/sram if using TOOLCHANGE_FILAMENT_SWAP )
+   //#define FWRETRACT_SWAP_ENABLE         // Enable swap (instead of specific tool change )
    #if ENABLED(FWRETRACT_SWAP_ENABLE)
      #define RETRACT_LENGTH_SWAP 60          // (mm) Default swap retract length (positive value)
      #define RETRACT_RECOVER_LENGTH_SWAP 0   // (mm) Default additional swap recover length (added to retract length on recover from toolchange)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1793,7 +1793,7 @@
  */
 //#define FWRETRACT
 #if ENABLED(FWRETRACT)
-  //#define FWRETRACT_AUTORETRACT           // Override slicer retractions
+//#define FWRETRACT_AUTORETRACT           // Override slicer retractions
   #if ENABLED(FWRETRACT_AUTORETRACT)
     #define MIN_AUTORETRACT 0.1           // (mm) Don't convert E moves under this length
     #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1791,28 +1791,28 @@
  * Note that M207 / M208 / M209 settings are saved to EEPROM.
  *
  */
- //#define FWRETRACT
- #if ENABLED(FWRETRACT)
-   //#define FWRETRACT_AUTORETRACT           // Override slicer retractions
-   #if ENABLED(FWRETRACT_AUTORETRACT)
-     #define MIN_AUTORETRACT 0.1           // (mm) Don't convert E moves under this length
-     #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length
-   #endif
-   #define RETRACT_LENGTH 3                // (mm) Default retract length (positive value)
-   #define RETRACT_FEEDRATE 45             // (mm/s) Default feedrate for retracting
-   #define RETRACT_ZRAISE 0                // (mm) Default retract Z-raise
-   #define RETRACT_RECOVER_LENGTH 0        // (mm) Default additional recover length (added to retract length on recover)
-   #define RETRACT_RECOVER_FEEDRATE 8      // (mm/s) Default feedrate for recovering from retraction
-   //#define FWRETRACT_SWAP_ENABLE         // Enable swap (instead of specific tool change )
-   #if ENABLED(FWRETRACT_SWAP_ENABLE)
-     #define RETRACT_LENGTH_SWAP 13        // (mm) Default swap retract length (positive value)
-     #define RETRACT_RECOVER_LENGTH_SWAP 0 // (mm) Default additional swap recover length (added to retract length on recover from toolchange)
-     #define RETRACT_RECOVER_FEEDRATE_SWAP 8 // (mm/s) Default feedrate for recovering from swap retraction
-   #endif
-   #if ENABLED(MIXING_EXTRUDER)
-     //#define RETRACT_SYNC_MIXING         // Retract and restore all mixing steppers simultaneously
-   #endif
+//#define FWRETRACT
+#if ENABLED(FWRETRACT)
+ //#define FWRETRACT_AUTORETRACT           // Override slicer retractions
+ #if ENABLED(FWRETRACT_AUTORETRACT)
+   #define MIN_AUTORETRACT 0.1           // (mm) Don't convert E moves under this length
+   #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length
  #endif
+ #define RETRACT_LENGTH 3                // (mm) Default retract length (positive value)
+ #define RETRACT_FEEDRATE 45             // (mm/s) Default feedrate for retracting
+ #define RETRACT_ZRAISE 0                // (mm) Default retract Z-raise
+ #define RETRACT_RECOVER_LENGTH 0        // (mm) Default additional recover length (added to retract length on recover)
+ #define RETRACT_RECOVER_FEEDRATE 8      // (mm/s) Default feedrate for recovering from retraction
+ //#define FWRETRACT_SWAP_ENABLE         // Enable swap (instead of specific tool change )
+ #if ENABLED(FWRETRACT_SWAP_ENABLE)
+   #define RETRACT_LENGTH_SWAP 13        // (mm) Default swap retract length (positive value)
+   #define RETRACT_RECOVER_LENGTH_SWAP 0 // (mm) Default additional swap recover length (added to retract length on recover from toolchange)
+   #define RETRACT_RECOVER_FEEDRATE_SWAP 8 // (mm/s) Default feedrate for recovering from swap retraction
+ #endif
+ #if ENABLED(MIXING_EXTRUDER)
+   //#define RETRACT_SYNC_MIXING         // Retract and restore all mixing steppers simultaneously
+ #endif
+#endif
 
 /**
  * Universal tool change settings.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1799,15 +1799,15 @@
      #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length
    #endif
    #define RETRACT_LENGTH 3                // (mm) Default retract length (positive value)
-   #define RETRACT_FEEDRATE 50             // (mm/s) Default feedrate for retracting
+   #define RETRACT_FEEDRATE 45             // (mm/s) Default feedrate for retracting
    #define RETRACT_ZRAISE 0                // (mm) Default retract Z-raise
    #define RETRACT_RECOVER_LENGTH 0        // (mm) Default additional recover length (added to retract length on recover)
-   #define RETRACT_RECOVER_FEEDRATE 25     // (mm/s) Default feedrate for recovering from retraction
+   #define RETRACT_RECOVER_FEEDRATE 8      // (mm/s) Default feedrate for recovering from retraction
    //#define FWRETRACT_SWAP_ENABLE         // Enable swap (instead of specific tool change )
    #if ENABLED(FWRETRACT_SWAP_ENABLE)
-     #define RETRACT_LENGTH_SWAP 60          // (mm) Default swap retract length (positive value)
-     #define RETRACT_RECOVER_LENGTH_SWAP 0   // (mm) Default additional swap recover length (added to retract length on recover from toolchange)
-     #define RETRACT_RECOVER_FEEDRATE_SWAP RETRACT_RECOVER_FEEDRATE // (mm/s) Default feedrate for recovering from swap retraction
+     #define RETRACT_LENGTH_SWAP 13        // (mm) Default swap retract length (positive value)
+     #define RETRACT_RECOVER_LENGTH_SWAP 0 // (mm) Default additional swap recover length (added to retract length on recover from toolchange)
+     #define RETRACT_RECOVER_FEEDRATE_SWAP 8 // (mm/s) Default feedrate for recovering from swap retraction
    #endif
    #if ENABLED(MIXING_EXTRUDER)
      //#define RETRACT_SYNC_MIXING         // Retract and restore all mixing steppers simultaneously

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1793,7 +1793,7 @@
  */
 //#define FWRETRACT
 #if ENABLED(FWRETRACT)
-//#define FWRETRACT_AUTORETRACT           // Override slicer retractions
+  #define FWRETRACT_AUTORETRACT           // Override slicer retractions
   #if ENABLED(FWRETRACT_AUTORETRACT)
     #define MIN_AUTORETRACT 0.1           // (mm) Don't convert E moves under this length
     #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1791,25 +1791,28 @@
  * Note that M207 / M208 / M209 settings are saved to EEPROM.
  *
  */
-//#define FWRETRACT
-#if ENABLED(FWRETRACT)
-  #define FWRETRACT_AUTORETRACT           // Override slicer retractions
-  #if ENABLED(FWRETRACT_AUTORETRACT)
-    #define MIN_AUTORETRACT 0.1           // (mm) Don't convert E moves under this length
-    #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length
-  #endif
-  #define RETRACT_LENGTH 3                // (mm) Default retract length (positive value)
-  #define RETRACT_LENGTH_SWAP 13          // (mm) Default swap retract length (positive value)
-  #define RETRACT_FEEDRATE 45             // (mm/s) Default feedrate for retracting
-  #define RETRACT_ZRAISE 0                // (mm) Default retract Z-raise
-  #define RETRACT_RECOVER_LENGTH 0        // (mm) Default additional recover length (added to retract length on recover)
-  #define RETRACT_RECOVER_LENGTH_SWAP 0   // (mm) Default additional swap recover length (added to retract length on recover from toolchange)
-  #define RETRACT_RECOVER_FEEDRATE 8      // (mm/s) Default feedrate for recovering from retraction
-  #define RETRACT_RECOVER_FEEDRATE_SWAP 8 // (mm/s) Default feedrate for recovering from swap retraction
-  #if ENABLED(MIXING_EXTRUDER)
-    //#define RETRACT_SYNC_MIXING         // Retract and restore all mixing steppers simultaneously
-  #endif
-#endif
+ //#define FWRETRACT
+ #if ENABLED(FWRETRACT)
+   //#define FWRETRACT_AUTORETRACT           // Override slicer retractions
+   #if ENABLED(FWRETRACT_AUTORETRACT)
+     #define MIN_AUTORETRACT 0.1           // (mm) Don't convert E moves under this length
+     #define MAX_AUTORETRACT 10.0          // (mm) Don't convert E moves over this length
+   #endif
+   #define RETRACT_LENGTH 3                // (mm) Default retract length (positive value)
+   #define RETRACT_FEEDRATE 50             // (mm/s) Default feedrate for retracting
+   #define RETRACT_ZRAISE 0                // (mm) Default retract Z-raise
+   #define RETRACT_RECOVER_LENGTH 0        // (mm) Default additional recover length (added to retract length on recover)
+   #define RETRACT_RECOVER_FEEDRATE 25     // (mm/s) Default feedrate for recovering from retraction
+   //#define FWRETRACT_SWAP_ENABLE         // Disable swap (economy of progmem/sram if using TOOLCHANGE_FILAMENT_SWAP )
+   #if ENABLED(FWRETRACT_SWAP_ENABLE)
+     #define RETRACT_LENGTH_SWAP 60          // (mm) Default swap retract length (positive value)
+     #define RETRACT_RECOVER_LENGTH_SWAP 0   // (mm) Default additional swap recover length (added to retract length on recover from toolchange)
+     #define RETRACT_RECOVER_FEEDRATE_SWAP RETRACT_RECOVER_FEEDRATE // (mm/s) Default feedrate for recovering from swap retraction
+   #endif
+   #if ENABLED(MIXING_EXTRUDER)
+     //#define RETRACT_SYNC_MIXING         // Retract and restore all mixing steppers simultaneously
+   #endif
+ #endif
 
 /**
  * Universal tool change settings.

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -42,7 +42,7 @@ FWRetract fwretract; // Single instance - this calls the constructor
 
 // private:
 
-#if EXTRUDERS > 1
+#if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
   bool FWRetract::retracted_swap[EXTRUDERS];          // Which extruders are swap-retracted
 #endif
 
@@ -68,14 +68,16 @@ void FWRetract::reset() {
   settings.retract_zraise = RETRACT_ZRAISE;
   settings.retract_recover_extra = RETRACT_RECOVER_LENGTH;
   settings.retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE;
-  settings.swap_retract_length = RETRACT_LENGTH_SWAP;
-  settings.swap_retract_recover_extra = RETRACT_RECOVER_LENGTH_SWAP;
-  settings.swap_retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE_SWAP;
+  #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+    settings.swap_retract_length = RETRACT_LENGTH_SWAP;
+    settings.swap_retract_recover_extra = RETRACT_RECOVER_LENGTH_SWAP;
+    settings.swap_retract_recover_feedrate_mm_s = RETRACT_RECOVER_FEEDRATE_SWAP;
+  #endif
   current_hop = 0.0;
 
   for (uint8_t i = 0; i < EXTRUDERS; ++i) {
     retracted[i] = false;
-    #if EXTRUDERS > 1
+    #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
       retracted_swap[i] = false;
     #endif
     current_retract[i] = 0.0;
@@ -94,7 +96,7 @@ void FWRetract::reset() {
  *       included in the G-code. Use M207 Z0 to to prevent double hop.
  */
 void FWRetract::retract(const bool retracting
-  #if EXTRUDERS > 1
+  #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
     , bool swapping /* =false */
   #endif
 ) {
@@ -102,13 +104,13 @@ void FWRetract::retract(const bool retracting
   if (retracted[active_extruder] == retracting) return;
 
   // Prevent two swap-retract or recovers in a row
-  #if EXTRUDERS > 1
+  #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
     // Allow G10 S1 only after G11
     if (swapping && retracted_swap[active_extruder] == retracting) return;
     // G11 priority to recover the long retract if activated
     if (!retracting) swapping = retracted_swap[active_extruder];
-  #else
-    constexpr bool swapping = false;
+/*  #else
+    constexpr bool swapping = false; */
   #endif
 
   /* // debugging
@@ -129,7 +131,11 @@ void FWRetract::retract(const bool retracting
   //*/
 
   const float base_retract = (
-                (swapping ? settings.swap_retract_length : settings.retract_length)
+                #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+                  (swapping ? settings.swap_retract_length : settings.retract_length)
+                #else
+                  settings.retract_length
+                #endif
                 #if ENABLED(RETRACT_SYNC_MIXING)
                   * (MIXING_STEPPERS)
                 #endif
@@ -168,8 +174,11 @@ void FWRetract::retract(const bool retracting
       // Lower Z, set_current_to_destination. Maximum Z feedrate
       prepare_internal_move_to_destination(fr_max_z);
     }
-
-    const float extra_recover = swapping ? settings.swap_retract_recover_extra : settings.retract_recover_extra;
+    #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+      const float extra_recover = swapping ? settings.swap_retract_recover_extra : settings.retract_recover_extra;
+    #else
+      const float extra_recover = settings.retract_recover_extra;
+    #endif
     if (extra_recover) {
       current_position.e -= extra_recover;          // Adjust the current E position by the extra amount to recover
       sync_plan_position_e();                             // Sync the planner position so the extra amount is recovered
@@ -178,7 +187,11 @@ void FWRetract::retract(const bool retracting
     current_retract[active_extruder] = 0;
 
     const feedRate_t fr_mm_s = (
-      (swapping ? settings.swap_retract_recover_feedrate_mm_s : settings.retract_recover_feedrate_mm_s)
+      #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+        (swapping ? settings.swap_retract_recover_feedrate_mm_s : settings.retract_recover_feedrate_mm_s)
+      #else
+        settings.retract_recover_feedrate_mm_s
+      #endif
       #if ENABLED(RETRACT_SYNC_MIXING)
         * (MIXING_STEPPERS)
       #endif
@@ -193,7 +206,7 @@ void FWRetract::retract(const bool retracting
   retracted[active_extruder] = retracting;                // Active extruder now retracted / recovered
 
   // If swap retract/recover update the retracted_swap flag too
-  #if EXTRUDERS > 1
+  #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
     if (swapping) retracted_swap[active_extruder] = retracting;
   #endif
 

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -109,8 +109,6 @@ void FWRetract::retract(const bool retracting
     if (swapping && retracted_swap[active_extruder] == retracting) return;
     // G11 priority to recover the long retract if activated
     if (!retracting) swapping = retracted_swap[active_extruder];
-/*  #else
-    constexpr bool swapping = false; */
   #endif
 
   /* // debugging

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -172,7 +172,7 @@ void FWRetract::retract(const bool retracting
       // Lower Z, set_current_to_destination. Maximum Z feedrate
       prepare_internal_move_to_destination(fr_max_z);
     }
-    
+
     #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
       const float extra_recover = swapping ? settings.swap_retract_recover_extra : settings.retract_recover_extra;
     #else

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -172,6 +172,7 @@ void FWRetract::retract(const bool retracting
       // Lower Z, set_current_to_destination. Maximum Z feedrate
       prepare_internal_move_to_destination(fr_max_z);
     }
+    
     #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
       const float extra_recover = swapping ? settings.swap_retract_recover_extra : settings.retract_recover_extra;
     #else

--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -33,16 +33,18 @@ typedef struct {
        float retract_zraise,                      // M207 Z - G10 Retract hop size
              retract_recover_extra;               // M208 S - G11 Recover length
   feedRate_t retract_recover_feedrate_mm_s;       // M208 F - G11 Recover feedrate
-       float swap_retract_length,                 // M207 W - G10 Swap Retract length
-             swap_retract_recover_extra;          // M208 W - G11 Swap Recover length
-  feedRate_t swap_retract_recover_feedrate_mm_s;  // M208 R - G11 Swap Recover feedrate
+  #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+         float swap_retract_length,                 // M207 W - G10 Swap Retract length
+               swap_retract_recover_extra;          // M208 W - G11 Swap Recover length
+    feedRate_t swap_retract_recover_feedrate_mm_s;  // M208 R - G11 Swap Recover feedrate
+  #endif
 } fwretract_settings_t;
 
 #if ENABLED(FWRETRACT)
 
 class FWRetract {
 private:
-  #if EXTRUDERS > 1
+  #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
     static bool retracted_swap[EXTRUDERS];         // Which extruders are swap-retracted
   #endif
 
@@ -75,7 +77,7 @@ public:
   }
 
   static void retract(const bool retracting
-    #if EXTRUDERS > 1
+    #if (ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1)
       , bool swapping = false
     #endif
   );

--- a/Marlin/src/gcode/feature/fwretract/G10_G11.cpp
+++ b/Marlin/src/gcode/feature/fwretract/G10_G11.cpp
@@ -33,11 +33,11 @@
  *       TODO: Handle 'G10 P' for tool settings and 'G10 L' for workspace settings
  */
 void GcodeSuite::G10() {
-  #if EXTRUDERS > 1
+  #if (ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1)
     const bool rs = parser.boolval('S');
   #endif
   fwretract.retract(true
-    #if EXTRUDERS > 1
+    #if (ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1)
       , rs
     #endif
   );

--- a/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
+++ b/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
@@ -39,7 +39,9 @@ void GcodeSuite::M207() {
   if (parser.seen('S')) fwretract.settings.retract_length = parser.value_axis_units(E_AXIS);
   if (parser.seen('F')) fwretract.settings.retract_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
   if (parser.seen('Z')) fwretract.settings.retract_zraise = parser.value_linear_units();
-  if (parser.seen('W')) fwretract.settings.swap_retract_length = parser.value_axis_units(E_AXIS);
+  #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+    if (parser.seen('W')) fwretract.settings.swap_retract_length = parser.value_axis_units(E_AXIS);
+  #endif
 }
 
 /**
@@ -53,8 +55,10 @@ void GcodeSuite::M207() {
 void GcodeSuite::M208() {
   if (parser.seen('S')) fwretract.settings.retract_recover_extra = parser.value_axis_units(E_AXIS);
   if (parser.seen('F')) fwretract.settings.retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-  if (parser.seen('R')) fwretract.settings.swap_retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-  if (parser.seen('W')) fwretract.settings.swap_retract_recover_extra = parser.value_axis_units(E_AXIS);
+  #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+    if (parser.seen('R')) fwretract.settings.swap_retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
+    if (parser.seen('W')) fwretract.settings.swap_retract_recover_extra = parser.value_axis_units(E_AXIS);
+  #endif
 }
 
 #if ENABLED(FWRETRACT_AUTORETRACT)

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -256,17 +256,17 @@ void menu_advanced_settings();
       EDIT_ITEM(bool, MSG_AUTORETRACT, &fwretract.autoretract_enabled, fwretract.refresh_autoretract);
     #endif
     EDIT_ITEM(float52sign, MSG_CONTROL_RETRACT, &fwretract.settings.retract_length, 0, 100);
-    #if EXTRUDERS > 1
+    #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
       EDIT_ITEM(float52sign, MSG_CONTROL_RETRACT_SWAP, &fwretract.settings.swap_retract_length, 0, 100);
     #endif
     EDIT_ITEM(float3, MSG_CONTROL_RETRACTF, &fwretract.settings.retract_feedrate_mm_s, 1, 999);
     EDIT_ITEM(float52sign, MSG_CONTROL_RETRACT_ZHOP, &fwretract.settings.retract_zraise, 0, 999);
     EDIT_ITEM(float52sign, MSG_CONTROL_RETRACT_RECOVER, &fwretract.settings.retract_recover_extra, -100, 100);
-    #if EXTRUDERS > 1
+    #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
       EDIT_ITEM(float52sign, MSG_CONTROL_RETRACT_RECOVER_SWAP, &fwretract.settings.swap_retract_recover_extra, -100, 100);
     #endif
     EDIT_ITEM(float3, MSG_CONTROL_RETRACT_RECOVERF, &fwretract.settings.retract_recover_feedrate_mm_s, 1, 999);
-    #if EXTRUDERS > 1
+    #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
       EDIT_ITEM(float3, MSG_CONTROL_RETRACT_RECOVER_SWAPF, &fwretract.settings.swap_retract_recover_feedrate_mm_s, 1, 999);
     #endif
     END_MENU();

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -897,8 +897,7 @@ void MarlinSettings::postprocess() {
       #if DISABLED(FWRETRACT)
         const fwretract_settings_t fwretract_defaults = { 3, 45, 0, 0, 0 };
         EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, fwretract_defaults));
-      #endif
-      #if ENABLED(FWRETRACT) && ENABLED(FWRETRACT_SWAP_ENABLE)
+      #else
         EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, fwretract.settings));
       #endif
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -896,11 +896,11 @@ void MarlinSettings::postprocess() {
       _FIELD_TEST(fwretract_settings);
       #if DISABLED(FWRETRACT)
         const fwretract_settings_t fwretract_defaults = { 3, 45, 0, 0, 0 };
+        EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, fwretract_defaults));
       #endif
       #if ENABLED(FWRETRACT) && ENABLED(FWRETRACT_SWAP_ENABLE)
-        const fwretract_settings_t fwretract_defaults = { 3, 45, 0, 0, 0, 13, 0, 8 };
+        EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, fwretract.settings));
       #endif
-      EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, fwretract_defaults));
 
       #if DISABLED(FWRETRACT_AUTORETRACT)
         const bool autoretract_enabled = false;

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -3163,10 +3163,10 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
       CONFIG_ECHO_START();
       SERIAL_ECHOLNPAIR_P(
-        PSTR("  M207 S"), LINEAR_UNIT(fwretract.settings.retract_length)
-        #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+          PSTR("  M207 S"), LINEAR_UNIT(fwretract.settings.retract_length)
+          #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
           ,PSTR(" W"), LINEAR_UNIT(fwretract.settings.swap_retract_length)
-        #endif
+          #endif
         , PSTR(" F"), LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_feedrate_mm_s))
         , SP_Z_STR, LINEAR_UNIT(fwretract.settings.retract_zraise)
       );

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -895,9 +895,9 @@ void MarlinSettings::postprocess() {
     {
       _FIELD_TEST(fwretract_settings);
       #if DISABLED(FWRETRACT)
-        const fwretract_settings_t autoretract_defaults = { 3, 45, 0, 0, 0 };
+        const fwretract_settings_t fwretract_defaults = { 3, 45, 0, 0, 0 };
       #endif
-      EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, autoretract_defaults));
+      EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, fwretract_defaults));
 
       #if DISABLED(FWRETRACT_AUTORETRACT)
         const bool autoretract_enabled = false;

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -895,7 +895,7 @@ void MarlinSettings::postprocess() {
     {
       _FIELD_TEST(fwretract_settings);
       #if DISABLED(FWRETRACT)
-        const fwretract_settings_t autoretract_defaults = { 3, 45, 0, 0, 0, 13, 0, 8 };
+        const fwretract_settings_t autoretract_defaults = { 3, 45, 0, 0, 0 };
       #endif
       EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, autoretract_defaults));
 
@@ -3160,22 +3160,26 @@ void MarlinSettings::reset() {
 
     #if ENABLED(FWRETRACT)
 
-      CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-          PSTR("  M207 S"), LINEAR_UNIT(fwretract.settings.retract_length)
-        , PSTR(" W"), LINEAR_UNIT(fwretract.settings.swap_retract_length)
-        , PSTR(" F"), LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_feedrate_mm_s))
-        , SP_Z_STR, LINEAR_UNIT(fwretract.settings.retract_zraise)
-      );
+       CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
+       CONFIG_ECHO_START();
+       SERIAL_ECHOLNPAIR_P(
+         PSTR("  M207 S"), LINEAR_UNIT(fwretract.settings.retract_length)
+         #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+           ,PSTR(" W"), LINEAR_UNIT(fwretract.settings.swap_retract_length)
+         #endif
+         , PSTR(" F"), LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_feedrate_mm_s))
+         , SP_Z_STR, LINEAR_UNIT(fwretract.settings.retract_zraise)
+       );
 
-      CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR(
-          "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_extra)
-        , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_extra)
-        , " F", LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_recover_feedrate_mm_s))
-      );
+       CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
+       CONFIG_ECHO_START();
+       SERIAL_ECHOLNPAIR(
+           "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_extra)
+           #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+             , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_extra)
+           #endif
+         , " F", LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_recover_feedrate_mm_s))
+       );
 
       #if ENABLED(FWRETRACT_AUTORETRACT)
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -897,6 +897,9 @@ void MarlinSettings::postprocess() {
       #if DISABLED(FWRETRACT)
         const fwretract_settings_t fwretract_defaults = { 3, 45, 0, 0, 0 };
       #endif
+      #if ENABLED(FWRETRACT) && ENABLED(FWRETRACT_SWAP_ENABLE)
+        const fwretract_settings_t fwretract_defaults = { 3, 45, 0, 0, 0, 13, 0, 8 };
+      #endif
       EEPROM_WRITE(TERN(FWRETRACT, fwretract.settings, fwretract_defaults));
 
       #if DISABLED(FWRETRACT_AUTORETRACT)

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -3160,26 +3160,26 @@ void MarlinSettings::reset() {
 
     #if ENABLED(FWRETRACT)
 
-       CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
-       CONFIG_ECHO_START();
-       SERIAL_ECHOLNPAIR_P(
-         PSTR("  M207 S"), LINEAR_UNIT(fwretract.settings.retract_length)
-         #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
-           ,PSTR(" W"), LINEAR_UNIT(fwretract.settings.swap_retract_length)
-         #endif
-         , PSTR(" F"), LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_feedrate_mm_s))
-         , SP_Z_STR, LINEAR_UNIT(fwretract.settings.retract_zraise)
-       );
+      CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
+      CONFIG_ECHO_START();
+      SERIAL_ECHOLNPAIR_P(
+        PSTR("  M207 S"), LINEAR_UNIT(fwretract.settings.retract_length)
+        #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+          ,PSTR(" W"), LINEAR_UNIT(fwretract.settings.swap_retract_length)
+        #endif
+        , PSTR(" F"), LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_feedrate_mm_s))
+        , SP_Z_STR, LINEAR_UNIT(fwretract.settings.retract_zraise)
+      );
 
-       CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
-       CONFIG_ECHO_START();
-       SERIAL_ECHOLNPAIR(
-           "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_extra)
-           #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
-             , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_extra)
-           #endif
-         , " F", LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_recover_feedrate_mm_s))
-       );
+      CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
+      CONFIG_ECHO_START();
+      SERIAL_ECHOLNPAIR(
+          "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_extra)
+          #if ENABLED(FWRETRACT_SWAP_ENABLE) && EXTRUDERS > 1
+            , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_extra)
+          #endif
+        , " F", LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_recover_feedrate_mm_s))
+      );
 
       #if ENABLED(FWRETRACT_AUTORETRACT)
 


### PR DESCRIPTION
Fix total desintegration of swapping when unused
+
Option to disable it , for coexistence with TOOL_CHANGE_SWAP or any extruders that have own specific toolchange procedure
+
Renaming of defaults values

Economy of 3 float in EEPROM