### PR TITLE
Fix UBL active state restore after reset

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1531,10 +1531,10 @@ void MarlinSettings::postprocess() {
         _FIELD_TEST(planner_leveling_active);
         #if ENABLED(AUTO_BED_LEVELING_UBL)
           const bool &planner_leveling_active = planner.leveling_active;
-          const uint8_t &ubl_storage_slot = ubl.storage_slot;
+          const int8_t &ubl_storage_slot = ubl.storage_slot;
         #else
           bool planner_leveling_active;
-          uint8_t ubl_storage_slot;
+          int8_t ubl_storage_slot;
         #endif
         EEPROM_READ(planner_leveling_active);
         EEPROM_READ(ubl_storage_slot);


### PR DESCRIPTION
### Description

When using UBL the active state is not restored after a restart. To reproduce:

```
G29 L1 ; Load mesh 1
G29 A ; Activate UBL
G29 S1; Save mesh to slot 1
M500 ; Save settings
M420 ; Get bed leveling state
>Bed Leveling ON
>Fade Height 10.00
```
Reset here

```
M420 ; Get bed leveling state
>Bed Leveling OFF
>Fade Height 10.00
```
Caused by wrong (!?) variable type in MarlinSettings::_load(). 

`const uint8_t &ubl_storage_slot = ubl.storage_slot;`

ubl.storage_slot is defined as:

`static int8_t storage_slot;`
### Benefits

The active state of UBL is restored after reset

