### PR TITLE
[1.1.x] Fix G29 Z position after bilinear ABL with fade height

### DIFF
--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5752,16 +5752,16 @@ void home_all_axes() { gcode_G28(true); }
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("G29 uncorrected Z:", current_position[Z_AXIS]);
           #endif
-          
 
           // Unapply the offset because it is going to be immediately applied
           // and cause compensation movement in Z
           #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-            const float fade_scaling_factor = planner.fade_scaling_factor_for_z(current_position[Z_AXIS]);
-            current_position[Z_AXIS] -= fade_scaling_factor ? fade_scaling_factor * bilinear_z_offset(current_position) : 0.0;
+            const float fade_scaling_factor = planner.fade_scaling_factor_for_z(current_position.z);
           #else
-            current_position[Z_AXIS] -= bilinear_z_offset(current_position);
+            constexpr float fade_scaling_factor = 1.0f;
           #endif
+          current_position[Z_AXIS] -= fade_scaling_factor * bilinear_z_offset(current_position);
+
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR(" corrected Z:", current_position[Z_AXIS]);
           #endif

--- a/Marlin/Marlin_main.cpp
+++ b/Marlin/Marlin_main.cpp
@@ -5752,11 +5752,16 @@ void home_all_axes() { gcode_G28(true); }
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("G29 uncorrected Z:", current_position[Z_AXIS]);
           #endif
+          
 
           // Unapply the offset because it is going to be immediately applied
           // and cause compensation movement in Z
-          current_position[Z_AXIS] -= bilinear_z_offset(current_position);
-
+          #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+            const float fade_scaling_factor = planner.fade_scaling_factor_for_z(current_position[Z_AXIS]);
+            current_position[Z_AXIS] -= fade_scaling_factor ? fade_scaling_factor * bilinear_z_offset(current_position) : 0.0;
+          #else
+            current_position[Z_AXIS] -= bilinear_z_offset(current_position);
+          #endif
           #if ENABLED(DEBUG_LEVELING_FEATURE)
             if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR(" corrected Z:", current_position[Z_AXIS]);
           #endif


### PR DESCRIPTION

### Description

After doing a G29 bed leveling using bilinear ABL with fade height enabled and a non-zero value the current Z position is incorrect. This causes inconsistent bed leveling results.

The bilinear_z_offset is subtracted from the current Z position at the end of G29. It is expected that it will be added back in planner.apply_leveling. However the fade_scaling_factor is not taken into consideration for the subtraction in G29. If fade height is a non-zero value the resulting Z position will be incorrect.

This change takes the fade_scaling_factor into account when subtracting the bilinear offset in G29.

I have tested the change on my Ender 3 with a BLTouch under different scenarios and it fixes the issue.
### Benefits

Fixes the incorrect Z position after bilinear ABL when using fade height.

### Related Issues

Fixes bug as described in issue #17166.
