### PR TITLE
set pin based on if bltouch enabled

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -78,7 +78,7 @@
   #else
     #define Z_MIN_PIN      P1_00   // PWRDET
   #endif
-#elif ENABLED (BLTOUCH)
+#elif ENABLED (BLTOUCH) && ENABLED (Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
   #define Z_STOP_PIN       P1_27   // Z-STOP
     #else 
       #define Z_STOP_PIN       P0_10   // Z-STOP
@@ -87,7 +87,7 @@
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-#if ENABLED (BLTOUCH)
+#if ENABLED (BLTOUCH) && ENABLED (Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
     #define Z_MIN_PROBE_PIN P1_27
   #else
     #define Z_MIN_PROBE_PIN P0_10

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -78,21 +78,19 @@
   #else
     #define Z_MIN_PIN      P1_00   // PWRDET
   #endif
-#else
-  #ifndef Z_STOP_PIN
-    #define Z_STOP_PIN     P1_27   // Z-STOP
-  #endif
+#elif ENABLED (BLTOUCH)
+  #define Z_STOP_PIN       P1_27   // Z-STOP
+    #else 
+      #define Z_STOP_PIN       P0_10   // Z-STOP
 #endif
 
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-#ifndef Z_MIN_PROBE_PIN
-  #if Z_STOP_PIN != P1_27
+#if ENABLED (BLTOUCH)
     #define Z_MIN_PROBE_PIN P1_27
   #else
     #define Z_MIN_PROBE_PIN P0_10
-  #endif
 #endif
 
 //


### PR DESCRIPTION
solve the issue between bltouch and fixed mounted probe pin assignment.
https://github.com/MarlinFirmware/Marlin/pull/17063