### PR TITLE
Shorter LCD remaining time to prevent overlap

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -448,14 +448,10 @@ void MarlinUI::draw_status_screen() {
         #endif
       }
 
+      constexpr bool can_show_days = DISABLED(DOGM_SD_PERCENT) || ENABLED(ROTATE_PROGRESS_DISPLAY);
       if (ev != lastElapsed) {
         lastElapsed = ev;
-        #if DISABLED(DOGM_SD_PERCENT) || ENABLED(ROTATE_PROGRESS_DISPLAY)
-          const bool has_days = (elapsed.value >= 60*60*24L);
-        #else
-          const bool has_days = false; // consistent behavior with remaining time below
-        #endif
-        const uint8_t len = elapsed.toDigital(elapsed_string, has_days);
+        const uint8_t len = elapsed.toDigital(elapsed_string, can_show_days && elapsed.value >= 60*60*24L);
         elapsed_x_pos = _SD_INFO_X(len);
 
         #if ENABLED(SHOW_REMAINING_TIME)
@@ -472,12 +468,7 @@ void MarlinUI::draw_status_screen() {
             }
             else {
               duration_t estimation = timeval;
-              #if DISABLED(DOGM_SD_PERCENT) || ENABLED(ROTATE_PROGRESS_DISPLAY)
-                const bool has_days = (estimation.value >= 60*60*24L);
-              #else
-                const bool has_days = false; // avoid remaining time overlap with percentage
-              #endif
-              const uint8_t len = estimation.toDigital(estimation_string, has_days);
+              const uint8_t len = estimation.toDigital(estimation_string, can_show_days && estimation.value >= 60*60*24L);
               estimation_x_pos = _SD_INFO_X(len
                 #if !BOTH(DOGM_SD_PERCENT, ROTATE_PROGRESS_DISPLAY)
                   + 1

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -450,7 +450,11 @@ void MarlinUI::draw_status_screen() {
 
       if (ev != lastElapsed) {
         lastElapsed = ev;
-        const bool has_days = (elapsed.value >= 60*60*24L);
+        #if DISABLED(DOGM_SD_PERCENT) || ENABLED(ROTATE_PROGRESS_DISPLAY)
+          const bool has_days = (elapsed.value >= 60*60*24L);
+        #else
+          const bool has_days = false; // consistent behavior with remaining time below
+        #endif
         const uint8_t len = elapsed.toDigital(elapsed_string, has_days);
         elapsed_x_pos = _SD_INFO_X(len);
 
@@ -468,7 +472,11 @@ void MarlinUI::draw_status_screen() {
             }
             else {
               duration_t estimation = timeval;
-              const bool has_days = (estimation.value >= 60*60*24L);
+              #if DISABLED(DOGM_SD_PERCENT) || ENABLED(ROTATE_PROGRESS_DISPLAY)
+                const bool has_days = (estimation.value >= 60*60*24L);
+              #else
+                const bool has_days = false; // avoid remaining time overlap with percentage
+              #endif
               const uint8_t len = estimation.toDigital(estimation_string, has_days);
               estimation_x_pos = _SD_INFO_X(len
                 #if !BOTH(DOGM_SD_PERCENT, ROTATE_PROGRESS_DISPLAY)


### PR DESCRIPTION
### Description
Currently, the 'R' in remaining time overlaps with the percentage sign '%' of DOGM_SD_PERCENT, when days are present in the estimated remaining time resulting in a garbled character. This happens commonly during hot-end warm-up.

This actually means we have two chars too little room, as we don't want the overlap, and we want an additional space for legibility.

This effectively means when DOGM_SD_PERCENT is enabled, the "days" indication should be avoided unless ROTATE_PROGRESS_DISPLAY is enabled. So each "blink" has the full line to it's own.

### Benefits

No garbled character on the LCD display.

### Note

Please do verify my logic carefully as I'm not _that_ familiar with the Marlin codebase.