### PR TITLE
Fix Z_MIN_PROBE_PIN on MKS SGen-L, SKR 1.3/4

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -96,11 +96,7 @@
 // Z Probe (when not Z_MIN_PIN)
 //
 #ifndef Z_MIN_PROBE_PIN
-  #if Z_STOP_PIN != P1_27
-    #define Z_MIN_PROBE_PIN P1_27
-  #else
-    #define Z_MIN_PROBE_PIN P0_10
-  #endif
+  #define Z_MIN_PROBE_PIN  P0_10
 #endif
 
 //


### PR DESCRIPTION
Followup to #17063

The `Z_MIN_PROBE_PIN` can always be defined as `P0_10`, since it has a dedicated pin. Sensorless homing changes and `Z_STOP_PIN` reassignment should not affect this.
