### PR TITLE
Fix MKS SBASE 1.6 E1 heater pin

### DIFF
--- a/Marlin/src/pins/ramps/pins_MKS_BASE_common.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_common.h
@@ -29,7 +29,7 @@
   #define BOARD_INFO_NAME "MKS BASE"
 #endif
 
-#if MKS_BASE_VERSION == 14 || MKS_BASE_VERSION == 15
+#if MKS_BASE_VERSION >= 14
   //
   // Heaters / Fans
   //


### PR DESCRIPTION
### Requirements

#define MOTHERBOARD BOARD_MKS_BASE_16

### Description

Pin D7 is not set for MKS_BASE_16, but it is the E1 MOSFET see https://github.com/makerbase-mks/MKS-BASE/blob/master/hardware/MKS%20Base%20V1.6_004/MKS%20Base%20V1.6%20PIN.pdf 

### Benefits

On MKS_BASE_16 E1 MOSFET now works  

### Related Issues

Was raised on Discord by Kimgie 