### PR TITLE
Show 3 decimal places for Z babystepping

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -428,7 +428,7 @@ void scroll_screen(const uint8_t limit, const bool is_menu) {
           MenuEditItemBase::draw_edit_screen(GET_TEXT(MSG_HOTEND_OFFSET_Z), ftostr54sign(hotend_offset[active_extruder].z));
       #endif
       if (do_probe) {
-        MenuEditItemBase::draw_edit_screen(GET_TEXT(MSG_ZPROBE_ZOFFSET), ftostr43sign(probe.offset.z));
+        MenuEditItemBase::draw_edit_screen(GET_TEXT(MSG_ZPROBE_ZOFFSET), BABYSTEP_TO_STR(probe.offset.z));
         #if ENABLED(BABYSTEP_ZPROBE_GFX_OVERLAY)
           _lcd_zoffset_overlay_gfx(probe.offset.z);
         #endif

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -193,7 +193,7 @@ DEFINE_MENU_EDIT_ITEM(uint16_3);    // 123        right-justified
 DEFINE_MENU_EDIT_ITEM(uint16_4);    // 1234       right-justified
 DEFINE_MENU_EDIT_ITEM(uint16_5);    // 12345      right-justified
 DEFINE_MENU_EDIT_ITEM(float3);      // 123        right-justified
-DEFINE_MENU_EDIT_ITEM(float52);     // _2.34, 12.34, -2.34 or 123.45, -23.45
+DEFINE_MENU_EDIT_ITEM(float42_52);  // _2.34, 12.34, -2.34 or 123.45, -23.45
 DEFINE_MENU_EDIT_ITEM(float43);     // 1.234
 DEFINE_MENU_EDIT_ITEM(float5);      // 12345      right-justified
 DEFINE_MENU_EDIT_ITEM(float5_25);   // 12345      right-justified (25 increment)

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -428,7 +428,7 @@ void scroll_screen(const uint8_t limit, const bool is_menu) {
           MenuEditItemBase::draw_edit_screen(GET_TEXT(MSG_HOTEND_OFFSET_Z), ftostr54sign(hotend_offset[active_extruder].z));
       #endif
       if (do_probe) {
-        MenuEditItemBase::draw_edit_screen(GET_TEXT(MSG_ZPROBE_ZOFFSET), ftostr52sign(probe.offset.z));
+        MenuEditItemBase::draw_edit_screen(GET_TEXT(MSG_ZPROBE_ZOFFSET), ftostr43sign(probe.offset.z));
         #if ENABLED(BABYSTEP_ZPROBE_GFX_OVERLAY)
           _lcd_zoffset_overlay_gfx(probe.offset.z);
         #endif

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -55,12 +55,10 @@ typedef void (*selectFunc_t)();
   #endif
 #endif
 
-#if ENABLED(BABYSTEPPING)
-  #if ENABLED(BABYSTEP_ZPROBE_OFFSET) && Z_PROBE_OFFSET_RANGE_MIN >= -9 && Z_PROBE_OFFSET_RANGE_MAX <= 9
-    #define BABYSTEP_TO_STR(N) ftostr43sign(N)
-  #else
-    #define BABYSTEP_TO_STR(N) ftostr53sign(N)
-  #endif
+#if ENABLED(BABYSTEP_ZPROBE_OFFSET) && Z_PROBE_OFFSET_RANGE_MIN >= -9 && Z_PROBE_OFFSET_RANGE_MAX <= 9
+  #define BABYSTEP_TO_STR(N) ftostr43sign(N)
+#elif ENABLED(BABYSTEPPING)
+  #define BABYSTEP_TO_STR(N) ftostr53sign(N)
 #endif
 
 ////////////////////////////////////////////

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -47,14 +47,20 @@ typedef void (*selectFunc_t)();
   void _lcd_zoffset_overlay_gfx(const float zvalue);
 #endif
 
-#if Z_PROBE_OFFSET_RANGE_MIN >= -9 && Z_PROBE_OFFSET_RANGE_MAX <= 9
-  // Only values from -9.999 to 9.999
-  #define LCD_Z_OFFSET_FUNC(N) ftostr54sign(N)
-  #define LCD_Z_OFFSET_TYPE float43
-#else
-  // Values from -99.99 to 99.99
-  #define LCD_Z_OFFSET_FUNC(N) ftostr52sign(N)
-  #define LCD_Z_OFFSET_TYPE float52
+#if HAS_BED_PROBE
+  #if Z_PROBE_OFFSET_RANGE_MIN >= -9 && Z_PROBE_OFFSET_RANGE_MAX <= 9
+    #define LCD_Z_OFFSET_TYPE float43    // Values from -9.000 to +9.000
+  #else
+    #define LCD_Z_OFFSET_TYPE float42_52 // Values from -99.99 to 99.99
+  #endif
+#endif
+
+#if ENABLED(BABYSTEPPING)
+  #if ENABLED(BABYSTEP_ZPROBE_OFFSET) && Z_PROBE_OFFSET_RANGE_MIN >= -9 && Z_PROBE_OFFSET_RANGE_MAX <= 9
+    #define BABYSTEP_TO_STR(N) ftostr43sign(N)
+  #else
+    #define BABYSTEP_TO_STR(N) ftostr53sign(N)
+  #endif
 #endif
 
 ////////////////////////////////////////////

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -289,7 +289,7 @@ DEFINE_MENU_EDIT_ITEM_TYPE(uint16_3    ,uint16_t ,ui16tostr3rj    ,   1     );  
 DEFINE_MENU_EDIT_ITEM_TYPE(uint16_4    ,uint16_t ,ui16tostr4rj    ,   0.1f  );   // 1234       right-justified
 DEFINE_MENU_EDIT_ITEM_TYPE(uint16_5    ,uint16_t ,ui16tostr5rj    ,   0.01f );   // 12345      right-justified
 DEFINE_MENU_EDIT_ITEM_TYPE(float3      ,float    ,ftostr3         ,   1     );   // 123        right-justified
-DEFINE_MENU_EDIT_ITEM_TYPE(float52     ,float    ,ftostr42_52     , 100     );   // _2.34, 12.34, -2.34 or 123.45, -23.45
+DEFINE_MENU_EDIT_ITEM_TYPE(float42_52  ,float    ,ftostr42_52     , 100     );   // _2.34, 12.34, -2.34 or 123.45, -23.45
 DEFINE_MENU_EDIT_ITEM_TYPE(float43     ,float    ,ftostr43sign    ,1000     );   // -1.234, _1.234, +1.234
 DEFINE_MENU_EDIT_ITEM_TYPE(float5      ,float    ,ftostr5rj       ,   1     );   // 12345      right-justified
 DEFINE_MENU_EDIT_ITEM_TYPE(float5_25   ,float    ,ftostr5rj       ,   0.04f );   // 12345      right-justified (25 increment)

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -112,10 +112,10 @@ void menu_cancelobject();
 
     #if ENABLED(LIN_ADVANCE)
       #if EXTRUDERS == 1
-        EDIT_ITEM(float52, MSG_ADVANCE_K, &planner.extruder_advance_K[0], 0, 999);
+        EDIT_ITEM(float42_52, MSG_ADVANCE_K, &planner.extruder_advance_K[0], 0, 999);
       #elif EXTRUDERS > 1
         LOOP_L_N(n, EXTRUDERS)
-          EDIT_ITEM_N(float52, n, MSG_ADVANCE_K_E, &planner.extruder_advance_K[n], 0, 999);
+          EDIT_ITEM_N(float42_52, n, MSG_ADVANCE_K_E, &planner.extruder_advance_K[n], 0, 999);
       #endif
     #endif
 
@@ -257,7 +257,7 @@ void menu_cancelobject();
       EDIT_ITEM(bool, MSG_AUTOTEMP, &planner.autotemp_enabled);
       EDIT_ITEM(float3, MSG_MIN, &planner.autotemp_min, 0, float(HEATER_0_MAXTEMP) - 15);
       EDIT_ITEM(float3, MSG_MAX, &planner.autotemp_max, 0, float(HEATER_0_MAXTEMP) - 15);
-      EDIT_ITEM(float52, MSG_FACTOR, &planner.autotemp_factor, 0, 10);
+      EDIT_ITEM(float42_52, MSG_FACTOR, &planner.autotemp_factor, 0, 10);
     #endif
 
     //
@@ -556,10 +556,10 @@ void menu_advanced_settings() {
     SUBMENU(MSG_FILAMENT, menu_advanced_filament);
   #elif ENABLED(LIN_ADVANCE)
     #if EXTRUDERS == 1
-      EDIT_ITEM(float52, MSG_ADVANCE_K, &planner.extruder_advance_K[0], 0, 999);
+      EDIT_ITEM(float42_52, MSG_ADVANCE_K, &planner.extruder_advance_K[0], 0, 999);
     #elif EXTRUDERS > 1
       LOOP_L_N(n, E_STEPPERS)
-        EDIT_ITEM_N(float52, n, MSG_ADVANCE_K_E, &planner.extruder_advance_K[n], 0, 999);
+        EDIT_ITEM_N(float42_52, n, MSG_ADVANCE_K_E, &planner.extruder_advance_K[n], 0, 999);
     #endif
   #endif
 

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -138,12 +138,12 @@ void menu_advanced_settings();
     START_MENU();
     BACK_ITEM(MSG_CONFIGURATION);
     #if ENABLED(DUAL_X_CARRIAGE)
-      EDIT_ITEM_FAST(float52, MSG_HOTEND_OFFSET_X, &hotend_offset[1].x, float(X2_HOME_POS - 25), float(X2_HOME_POS + 25), _recalc_offsets);
+      EDIT_ITEM_FAST(float42_52, MSG_HOTEND_OFFSET_X, &hotend_offset[1].x, float(X2_HOME_POS - 25), float(X2_HOME_POS + 25), _recalc_offsets);
     #else
-      EDIT_ITEM_FAST(float52, MSG_HOTEND_OFFSET_X, &hotend_offset[1].x, -99.0, 99.0, _recalc_offsets);
+      EDIT_ITEM_FAST(float42_52, MSG_HOTEND_OFFSET_X, &hotend_offset[1].x, -99.0, 99.0, _recalc_offsets);
     #endif
-    EDIT_ITEM_FAST(float52,   MSG_HOTEND_OFFSET_Y, &hotend_offset[1].y, -99.0, 99.0, _recalc_offsets);
-    EDIT_ITEM_FAST(float52,   MSG_HOTEND_OFFSET_Z, &hotend_offset[1].z, Z_PROBE_LOW_POINT, 10.0, _recalc_offsets);
+    EDIT_ITEM_FAST(float42_52, MSG_HOTEND_OFFSET_Y, &hotend_offset[1].y, -99.0, 99.0, _recalc_offsets);
+    EDIT_ITEM_FAST(float42_52, MSG_HOTEND_OFFSET_Z, &hotend_offset[1].z, Z_PROBE_LOW_POINT, 10.0, _recalc_offsets);
     #if ENABLED(EEPROM_SETTINGS)
       ACTION_ITEM(MSG_STORE_EEPROM, lcd_store_settings);
     #endif

--- a/Marlin/src/lcd/menu/menu_mixer.cpp
+++ b/Marlin/src/lcd/menu/menu_mixer.cpp
@@ -182,7 +182,7 @@ void lcd_mixer_mix_edit() {
     #if CHANNEL_MIX_EDITING
 
       LOOP_S_LE_N(n, 1, MIXING_STEPPERS)
-        EDIT_ITEM_FAST_N(float52, n, MSG_MIX_COMPONENT_N, &mixer.collector[n-1], 0, 10);
+        EDIT_ITEM_FAST_N(float42_52, n, MSG_MIX_COMPONENT_N, &mixer.collector[n-1], 0, 10);
 
       ACTION_ITEM(MSG_CYCLE_MIX, _lcd_mixer_cycle_mix);
       ACTION_ITEM(MSG_COMMIT_VTOOL, _lcd_mixer_commit_vtool);

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -232,10 +232,10 @@ void menu_tune() {
   //
   #if ENABLED(LIN_ADVANCE) && DISABLED(SLIM_LCD_MENUS)
     #if EXTRUDERS == 1
-      EDIT_ITEM(float52, MSG_ADVANCE_K, &planner.extruder_advance_K[0], 0, 999);
+      EDIT_ITEM(float42_52, MSG_ADVANCE_K, &planner.extruder_advance_K[0], 0, 999);
     #elif EXTRUDERS > 1
       LOOP_L_N(n, EXTRUDERS)
-        EDIT_ITEM_N(float52, n, MSG_ADVANCE_K_E, &planner.extruder_advance_K[n], 0, 999);
+        EDIT_ITEM_N(float42_52, n, MSG_ADVANCE_K_E, &planner.extruder_advance_K[n], 0, 999);
     #endif
   #endif
 

--- a/Marlin/src/lcd/menu/menu_tune.cpp
+++ b/Marlin/src/lcd/menu/menu_tune.cpp
@@ -65,7 +65,7 @@
     }
     if (ui.should_draw()) {
       const float spm = planner.steps_to_mm[axis];
-      MenuEditItemBase::draw_edit_screen(msg, LCD_Z_OFFSET_FUNC(spm * babystep.accum));
+      MenuEditItemBase::draw_edit_screen(msg, BABYSTEP_TO_STR(spm * babystep.accum));
       #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
         const bool in_view = (true
           #if HAS_GRAPHICAL_LCD
@@ -81,7 +81,7 @@
           #endif
           lcd_put_u8str_P(GET_TEXT(MSG_BABYSTEP_TOTAL));
           lcd_put_wchar(':');
-          lcd_put_u8str(LCD_Z_OFFSET_FUNC(spm * babystep.axis_total[BS_TOTAL_IND(axis)]));
+          lcd_put_u8str(BABYSTEP_TO_STR(spm * babystep.axis_total[BS_TOTAL_IND(axis)]));
         }
       #endif
     }

--- a/Marlin/src/libs/numtostr.cpp
+++ b/Marlin/src/libs/numtostr.cpp
@@ -174,9 +174,9 @@ const char* ftostr12ns(const float &f) {
   return &conv[3];
 }
 
-// Convert signed float to fixed-length string with 12.34 / -2.34 or 023.45 / -23.45 format
+// Convert signed float to fixed-length string with 12.34 / _2.34 / -2.34 or -23.45 / 123.45 format
 const char* ftostr42_52(const float &f) {
-  if (f <= -10 || f >= 100) return ftostr52(f); // need more digits
+  if (f <= -10 || f >= 100) return ftostr52(f); // -23.45 / 123.45
   long i = (f * 1000 + (f < 0 ? -5: 5)) / 10;
   conv[2] = (f >= 0 && f < 10) ? ' ' : MINUSOR(i, DIGIMOD(i, 1000));
   conv[3] = DIGIMOD(i, 100);
@@ -198,9 +198,9 @@ const char* ftostr52(const float &f) {
   return &conv[1];
 }
 
-// Convert signed float to fixed-length string with 12.345 / -2.345 or 023.456 / -23.456 format
-const char* ftostr43_53(const float &f) {
-  if (f <= -10 || f >= 100) return ftostr53(f); // need more digits
+// Convert signed float to fixed-length string with 12.345 / _2.345 / -2.345 or -23.45 / 123.45 format
+const char* ftostr53_63(const float &f) {
+  if (f <= -10 || f >= 100) return ftostr63(f); // -23.456 / 123.456
   long i = (f * 10000 + (f < 0 ? -5: 5)) / 10;
   conv[1] = (f >= 0 && f < 10) ? ' ' : MINUSOR(i, DIGIMOD(i, 10000));
   conv[2] = DIGIMOD(i, 1000);
@@ -212,7 +212,7 @@ const char* ftostr43_53(const float &f) {
 }
 
 // Convert signed float to fixed-length string with 023.456 / -23.456 format
-const char* ftostr53(const float &f) {
+const char* ftostr63(const float &f) {
   long i = (f * 10000 + (f < 0 ? -5: 5)) / 10;
   conv[0] = MINUSOR(i, DIGIMOD(i, 100000));
   conv[1] = DIGIMOD(i, 10000);
@@ -305,6 +305,19 @@ const char* ftostr52sign(const float &f) {
   conv[2] = DIGIMOD(i, 1000);
   conv[3] = DIGIMOD(i, 100);
   conv[4] = '.';
+  conv[5] = DIGIMOD(i, 10);
+  conv[6] = DIGIMOD(i, 1);
+  return conv;
+}
+
+// Convert signed float to string with +12.345 format
+const char* ftostr53sign(const float &f) {
+  long i = (f * 1000 + (f < 0 ? -5: 5)) / 10;
+  conv[0] = MINUSOR(i, '+');
+  conv[1] = DIGIMOD(i, 10000);
+  conv[2] = DIGIMOD(i, 1000);
+  conv[3] = '.';
+  conv[4] = DIGIMOD(i, 100);
   conv[5] = DIGIMOD(i, 10);
   conv[6] = DIGIMOD(i, 1);
   return conv;

--- a/Marlin/src/libs/numtostr.h
+++ b/Marlin/src/libs/numtostr.h
@@ -58,17 +58,17 @@ const char* i16tostr4signrj(const int16_t x);
 // Convert unsigned float to string with 1.23 format
 const char* ftostr12ns(const float &x);
 
-// Convert signed float to fixed-length string with 12.34 / -2.34 or 023.45 / -23.45 format
+// Convert signed float to fixed-length string with 12.34 / _2.34 / -2.34 or -23.45 / 123.45 format
 const char* ftostr42_52(const float &x);
 
 // Convert signed float to fixed-length string with 023.45 / -23.45 format
 const char* ftostr52(const float &x);
 
 // Convert signed float to fixed-length string with 12.345 / -2.345 or 023.456 / -23.456 format
-const char* ftostr43_53(const float &x);
+const char* ftostr53_63(const float &x);
 
 // Convert signed float to fixed-length string with 023.456 / -23.456 format
-const char* ftostr53(const float &x);
+const char* ftostr63(const float &x);
 
 // Convert float to fixed-length string with +123.4 / -123.4 format
 const char* ftostr41sign(const float &x);
@@ -90,6 +90,9 @@ const char* ftostr52sp(const float &x);
 
 // Convert signed float to string with +123.45 format
 const char* ftostr52sign(const float &x);
+
+// Convert signed float to string with +12.345 format
+const char* ftostr53sign(const float &f);
 
 // Convert unsigned float to string with 1234.5 format omitting trailing zeros
 const char* ftostr51rj(const float &x);


### PR DESCRIPTION

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description


Change in menu.cpp to modify babystep Z displayed coordinate with 3 decimal places (0.000) using Prusa style display format



### Benefits

Improves readibility

### Related Issues

Z babystep value shows only 2 decimal places (000.00)
