### PR TITLE
Add SoftwareSerialM for MKS Robin

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -157,3 +157,38 @@
   #define SDSS              PD2
   #define SD_DETECT_PIN     -1
 #endif
+
+#if HAS_TMC_UART
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  Serial1
+  //#define X2_HARDWARE_SERIAL Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Y2_HARDWARE_SERIAL Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define Z2_HARDWARE_SERIAL Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+  //#define E1_HARDWARE_SERIAL Serial1
+  //#define E2_HARDWARE_SERIAL Serial1
+  //#define E3_HARDWARE_SERIAL Serial1
+  //#define E4_HARDWARE_SERIAL Serial1
+
+  // Unused servo pins may be repurposed with SoftwareSerialM
+  //#define X_SERIAL_TX_PIN  PF8   // SERVO3_PIN
+  //#define Y_SERIAL_TX_PIN  PF9   // SERVO2_PIN
+  //#define Z_SERIAL_TX_PIN  PA1   // SERVO1_PIN
+  //#define E0_SERIAL_TX_PIN PC3   // SERVO0_PIN
+  //#define X_SERIAL_RX_PIN  X_SERIAL_TX_PIN
+  //#define Y_SERIAL_RX_PIN  Y_SERIAL_TX_PIN
+  //#define Z_SERIAL_RX_PIN  Z_SERIAL_TX_PIN
+  //#define E0_SERIAL_RX_PIN E0_SERIAL_TX_PIN
+
+  // Reduce baud rate for software serial reliability
+  #if HAS_TMC_SW_SERIAL
+    #define TMC_BAUD_RATE 19200
+  #endif
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -487,7 +487,7 @@ build_flags   = !python Marlin/src/HAL/STM32F1/build_flags.py
 build_unflags = -std=gnu++11
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano.py
 src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
-lib_deps = ${common.lib_deps}
+lib_deps      = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
 lib_ignore    = Adafruit NeoPixel, SPI
 
@@ -498,10 +498,12 @@ lib_ignore    = Adafruit NeoPixel, SPI
 platform      = ststm32
 board         = genericSTM32F103ZE
 build_flags   = !python Marlin/src/HAL/STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14 -DSTM32_XL_DENSITY
+  ${common.build_flags} -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_XL_DENSITY
 build_unflags = -std=gnu++11
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin.py
 src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
+lib_deps      = ${common.lib_deps}
+  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
 lib_ignore    = Adafruit NeoPixel, SPI
 
 #


### PR DESCRIPTION
To use TMC UART on MKS Robin a Software UART is needed. This PR ports `SoftwareSerialM` to the STM32F1 HAL for this purpose and incorporates some other changes based on the comment referenced here:

https://github.com/MarlinFirmware/Marlin/issues/15873#issuecomment-599926848