### PR TITLE
correct z stop pin skr 1.4

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -88,7 +88,7 @@
   #endif
 #else
   #ifndef Z_STOP_PIN
-    #define Z_STOP_PIN     P1_27   // Z-STOP
+    #define Z_STOP_PIN     P0_10   // Z-STOP
   #endif
 #endif
 


### PR DESCRIPTION
correct the z stop pin on the skr 1.4 so that it works properly with all probes.