### PR TITLE
implement check for disabled XY backlash compensation on COREXY

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2649,14 +2649,15 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
 #endif
 
 #if ENABLED(BACKLASH_COMPENSATION)
-  #if IS_CORE
-    #error "BACKLASH_COMPENSATION is incompatible with CORE kinematics."
-  #endif
   #ifndef BACKLASH_DISTANCE_MM
     #error "BACKLASH_COMPENSATION requires BACKLASH_DISTANCE_MM"
   #endif
   #ifndef BACKLASH_CORRECTION
     #error "BACKLASH_COMPENSATION requires BACKLASH_CORRECTION"
+  #endif
+  #if IS_CORE
+    constexpr float backlash_arr[] = BACKLASH_DISTANCE_MM;
+    static_assert(backlash_arr[0] == 0.0f && backlash_arr[1] == 0.0f, "BACKLASH_COMPENSATION is only supported for Z-axis with CORE kinematics.");
   #endif
 #endif
 


### PR DESCRIPTION
### Requirements

This pull requests enables backlash compensation for the Z-axis on corexy printers

### Description

Backlash compensation for the Z-axis only is nicely running on CORE-XY printers.
to reflect this I implemented a proper check that the backlash compensation is disabled for the X- and Y-axis.

### Benefits

Z-axis backlash compensation for corexy printers

### Related Issues

