### PR TITLE
Set Y_MAX pin on Copymaster  board

### DIFF
--- a/Marlin/src/pins/ramps/pins_COPYMASTER_3D.h
+++ b/Marlin/src/pins/ramps/pins_COPYMASTER_3D.h
@@ -24,6 +24,7 @@
 #define BOARD_INFO_NAME "Copymaster 3D RAMPS"
 
 #define Z_STEP_PIN        47
+#define Y_MAX_PIN         14
 #define FIL_RUNOUT_PIN    15
 #define SD_DETECT_PIN     66
 


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Changed the pin configuration for Copymaster board to use Y_MAX_PIN instead of Y_MIN_PIN.
See https://github.com/MarlinFirmware/Configurations/pull/37 for config changes

### Benefits

Fix homing on Copymaster printers, since they home to Y_MAX

### Related Issues


