### PR TITLE
add delay for homing_backoff on coreXY

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1781,7 +1781,7 @@ void homeaxis(const AxisEnum axis) {
       );
    
       #if BOTH(SENSORLESS_HOMING, COREXY)
-        if (axis == ENABLED(HOME_Y_BEFORE_X) ? Y_AXIS : X_AXIS) safe_delay(200);  // Short delay to complete homing backoff
+        if (axis == (ENABLED(HOME_Y_BEFORE_X) ? Y_AXIS : X_AXIS)) safe_delay(200);  // Short delay to complete homing backoff
       #endif
     }
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1780,7 +1780,7 @@ void homeaxis(const AxisEnum axis) {
         homing_feedrate(axis)
       );
 
-      #if IS_CORE && ENABLED(SENSORLESS_HOMING)
+      #if BOTH(IS_CORE, SENSORLESS_HOMING)
         if (axis != NORMAL_AXIS) safe_delay(200);  // Short delay to allow belts to spring back
       #endif
     }

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1780,14 +1780,8 @@ void homeaxis(const AxisEnum axis) {
         homing_feedrate(axis)
       );
    
-      #if ENABLED(SENSORLESS_HOMING) && ENABLED(COREXY)
-        
-        #if ENABLED(HOME_Y_BEFORE_X)
-          if (axis == Y_AXIS) safe_delay(200);  //Short delay to complete homing backoff
-        #else
-          if (axis == X_AXIS) safe_delay(200);
-        #endif
-
+      #if BOTH(SENSORLESS_HOMING, COREXY)
+        if (axis == ENABLED(HOME_Y_BEFORE_X) ? Y_AXIS : X_AXIS) safe_delay(200);  // Short delay to complete homing backoff
       #endif
     }
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1779,6 +1779,16 @@ void homeaxis(const AxisEnum axis) {
         #endif
         homing_feedrate(axis)
       );
+   
+      #if ENABLED(SENSORLESS_HOMING) && ENABLED(COREXY)
+        
+        #if ENABLED(HOME_Y_BEFORE_X)
+          if (axis == Y_AXIS) safe_delay(200);  //Short delay to complete homing backoff
+        #else
+          if (axis == X_AXIS) safe_delay(200);
+        #endif
+
+      #endif
     }
   #endif
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1779,9 +1779,9 @@ void homeaxis(const AxisEnum axis) {
         #endif
         homing_feedrate(axis)
       );
-   
-      #if BOTH(SENSORLESS_HOMING, COREXY)
-        if (axis == (ENABLED(HOME_Y_BEFORE_X) ? Y_AXIS : X_AXIS)) safe_delay(200);  // Short delay to complete homing backoff
+
+      #if IS_CORE && ENABLED(SENSORLESS_HOMING)
+        if (axis != NORMAL_AXIS) safe_delay(200);  // Short delay to allow belts to spring back
       #endif
     }
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1780,8 +1780,9 @@ void homeaxis(const AxisEnum axis) {
         homing_feedrate(axis)
       );
 
-      #if BOTH(IS_CORE, SENSORLESS_HOMING)
-        if (axis != NORMAL_AXIS) safe_delay(200);  // Short delay to allow belts to spring back
+      #if ENABLED(SENSORLESS_HOMING)
+        planner.synchronize();
+        if (ENABLED(IS_CORE)) safe_delay(200);  // Short delay to allow belts to spring back
       #endif
     }
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1782,7 +1782,9 @@ void homeaxis(const AxisEnum axis) {
 
       #if ENABLED(SENSORLESS_HOMING)
         planner.synchronize();
-        if (ENABLED(IS_CORE)) safe_delay(200);  // Short delay to allow belts to spring back
+        #if IS_CORE
+          if (axis != NORMAL_AXIS) safe_delay(200);  // Short delay to allow belts to spring back
+        #endif
       #endif
     }
   #endif


### PR DESCRIPTION

### Description

Make HOMING_BACKOFF work on coreXY, just to loosen the thightend belts after SENSORLESS_HOMING.
Backoff is also needed to make sensorless homing smooth even if it start homing at home position, it prevents from hard stall/crash
-->


### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/17213

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
