### PR TITLE
Allow PID_DEBUG to be turned on and off

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -473,7 +473,7 @@
 #if ENABLED(PIDTEMP)
   //#define PID_EDIT_MENU         // Add PID editing to the "Advanced Settings" menu. (~700 bytes of PROGMEM)
   //#define PID_AUTOTUNE_MENU     // Add PID auto-tuning to the "Advanced Settings" menu. (~250 bytes of PROGMEM)
-  //#define PID_DEBUG             // Sends debug data to the serial port.
+  //#define PID_DEBUG             // Sends debug data to the serial port.  Use M303 D to toggle activation.
   //#define PID_OPENLOOP 1        // Puts PID in open loop. M104/M140 sets the output power from 0 to PID_MAX
   //#define SLOW_PWM_HEATERS      // PWM with very low frequency (roughly 0.125Hz=8s) and minimum state time of approximately 1s useful for heaters driven by a relay
   //#define PID_PARAMS_PER_HOTEND // Uses separate PID parameters for each extruder (useful for mismatched extruders)

--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -38,7 +38,13 @@
  *       E<extruder> (-1 for the bed) (default 0)
  *       C<cycles> Minimum 3. Default 5.
  *       U<bool> with a non-zero value will apply the result to current settings
+ *       D Toggles PID_DEBUG flag. No other action happens even if more parameters are specified.
  */
+
+#if ENABLED(PID_DEBUG)
+  bool PID_Debug_Flag = 0;
+#endif
+
 void GcodeSuite::M303() {
   #if ENABLED(PIDTEMPBED)
     #define SI H_BED
@@ -62,6 +68,16 @@ void GcodeSuite::M303() {
   const int c = parser.intval('C', 5);
   const bool u = parser.boolval('U');
   const int16_t temp = parser.celsiusval('S', e < 0 ? 70 : 150);
+
+  #if ENABLED(PID_DEBUG)
+    bool d = parser.boolval('D');
+    if (d) {
+      PID_Debug_Flag = !PID_Debug_Flag;
+      SERIAL_ECHOPGM("PID Debug set to: ");
+      SERIAL_ECHOLN( PID_Debug_Flag );
+      return;
+    }
+  #endif
 
   #if DISABLED(BUSY_WHILE_HEATING)
     KEEPALIVE_STATE(NOT_BUSY);

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -830,6 +830,9 @@ void Temperature::min_temp_error(const heater_ind_t heater) {
 }
 
 #if HOTENDS
+  #if ENABLED(PID_DEBUG)
+    extern bool PID_Debug_Flag;
+  #endif
 
   float Temperature::get_pid_output_hotend(const uint8_t E_NAME) {
     const uint8_t ee = HOTEND_INDEX;
@@ -911,24 +914,15 @@ void Temperature::min_temp_error(const heater_ind_t heater) {
       #endif // PID_OPENLOOP
 
       #if ENABLED(PID_DEBUG)
-        if (ee == active_extruder) {
+        if (ee == active_extruder && PID_Debug_Flag) {
           SERIAL_ECHO_START();
-          SERIAL_ECHOPAIR(
-            STR_PID_DEBUG, ee,
-            STR_PID_DEBUG_INPUT, temp_hotend[ee].celsius,
-            STR_PID_DEBUG_OUTPUT, pid_output
-          );
+          SERIAL_ECHOPAIR(STR_PID_DEBUG, ee, STR_PID_DEBUG_INPUT, temp_hotend[ee].celsius, STR_PID_DEBUG_OUTPUT, pid_output);
           #if DISABLED(PID_OPENLOOP)
-          {
-            SERIAL_ECHOPAIR(
-              STR_PID_DEBUG_PTERM, work_pid[ee].Kp,
-              STR_PID_DEBUG_ITERM, work_pid[ee].Ki,
-              STR_PID_DEBUG_DTERM, work_pid[ee].Kd
+            SERIAL_ECHOPAIR( STR_PID_DEBUG_PTERM, work_pid[ee].Kp, STR_PID_DEBUG_ITERM, work_pid[ee].Ki, STR_PID_DEBUG_DTERM, work_pid[ee].Kd
               #if ENABLED(PID_EXTRUSION_SCALING)
                 , STR_PID_DEBUG_CTERM, work_pid[ee].Kc
               #endif
             );
-          }
           #endif
           SERIAL_EOL();
         }


### PR DESCRIPTION
M303 D will now toggle activation of PID_DEBUG output.   This allows the debug capability to be built into the firmware, but turned on and off as needed.

### Requirements

PID_DEBUG enabled.

### Description

Allows the verbose  PID_DEBUG information to be toggled on or off as needed.

### Benefits

Ah...   well it allows the verbose PID_DEBUG information to be toggled on or off as needed.

### Related Issues

Updated Configuration.h files coming next....
