### PR TITLE
Disable SPEAKER on several BigTreeTech boards

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -338,6 +338,10 @@
  *   P0_28  (58) (Open collector)
  */
 
+#ifdef SPEAKER
+  #undef SPEAKER
+#endif
+
 //
 // Include common SKR pins
 //

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
@@ -189,3 +189,7 @@
 
 #define ON_BOARD_SPI_DEVICE 1                     // SPI1
 #define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
+
+#ifdef SPEAKER
+  #undef SPEAKER
+#endif

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -251,3 +251,7 @@
 #ifndef RGB_LED_W_PIN
   #define RGB_LED_W_PIN                     -1
 #endif
+
+#ifdef SPEAKER
+  #undef SPEAKER
+#endif


### PR DESCRIPTION
### Description

`SPEAKER` should be disabled on the BigTreeTech SKR Mini E3 1.1, 1.2, SKR 1.4, and BTT002. There may be other BigTreeTech boards this should apply to (especially `STM32`-based boards), but I can't easily verify right now.

Note: `SPEAKER` _does_ work on the SKR 1.3, so that's why I didn't add the change to `pins_BTT_SKR_common.h`.


### Benefits

Users won't accidentally enable an option that is not compatible.

### Related Issues

#15828, #16784