### PR TITLE
Fix STM32F1 USB Composite Dependency

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -301,7 +301,7 @@ extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-  USBComposite_stm32f1@==0.91
+  USBComposite for STM32F1@==0.91
 lib_ignore        = Adafruit NeoPixel, SPI
 monitor_speed     = 115200
 
@@ -316,7 +316,7 @@ extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-  USBComposite_stm32f1@==0.91
+  USBComposite for STM32F1@==0.91
 lib_ignore        = Adafruit NeoPixel, SPI
 monitor_speed     = 115200
 
@@ -332,7 +332,7 @@ extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-  USBComposite_stm32f1@==0.91
+  USBComposite for STM32F1@==0.91
 lib_ignore        = Adafruit NeoPixel, SPI
 monitor_speed     = 115200
 
@@ -348,7 +348,7 @@ extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-  USBComposite_stm32f1@==0.91
+  USBComposite for STM32F1@==0.91
 lib_ignore        = Adafruit NeoPixel, SPI
 monitor_speed     = 115200
 


### PR DESCRIPTION
### Description

`USBComposite_stm32f1@==0.91` in `platformio.ini` was causing the error listed below when compiling, but @Lord-Quake provided a fix in #17304.

**Before:**
```prolog
Dependency Graph
[...]
Warning! Library `{'name': 'USBComposite_stm32f1', 'requirements': '==0.91'}` has not been found in PlatformIO Registry.
You can ignore this message, if `{'name': 'USBComposite_stm32f1', 'requirements': '==0.91'}` is a built-in library (included in framework, SDK). E.g., SPI, Wire, etc.
[...]
```
**After:**
```prolog
Dependency Graph
[...]
|-- <USBComposite for STM32F1> 0.91
[...]
```

### Benefits

Fixes STM32F1 USB Composite dependency.

### Related Issues

#17304