### PR TITLE
fix: Fysetc stm32flash usage

### DIFF
--- a/buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
@@ -30,7 +30,7 @@ if platform.get_package_dir("tool-stm32duino") != None:
 
 env.Replace(
 	UPLOADER=UPLOAD_TOOL,
-	UPLOADCMD=expandvars(UPLOAD_TOOL + " -v -i rts,-dtr,dtr $UPLOAD_PORT -R -w \"" + join("$BUILD_DIR","${PROGNAME}.hex")+"\"")
+	UPLOADCMD=expandvars(UPLOAD_TOOL + " -v -i rts,-dtr,dtr -R -b 115200 -g 0x8000000 -w \"" + join("$BUILD_DIR","${PROGNAME}.hex")+"\"" + " $UPLOAD_PORT")
 )
 
 # Python callback


### PR DESCRIPTION
### Requirements

* Fysetc Cheetah Board

### Description

stm32flash usage is currently wrong and trying to upload firmware throws an error:
```
Uploading .pio/build/STM32F103RC_fysetc/firmware.bin
ERROR: Invalid parameter specified
Usage: /Users/eric/.platformio/packages/tool-stm32duino/stm32flash/stm32flash [-bvngfhc] [-[rw] filename] [tty_device | i2c_device]
````

`$UPLOAD_PORT` needs to be last argument.

### Benefits

* Allows uploading firmware from PIO to Fysetc Cheetah Board
* Increase upload speed
* Properly set start address to allow reset after flash.

