### PR TITLE
Improvements and bug fixes to FTDI EVE Touch UI

### DIFF
--- a/Marlin/src/gcode/feature/powerloss/M1000.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M1000.cpp
@@ -63,7 +63,7 @@ void GcodeSuite::M1000() {
       #if HAS_LCD_MENU
         ui.goto_screen(menu_job_recovery);
       #elif ENABLED(EXTENSIBLE_UI)
-        ExtUI::OnPowerLossResume();
+        ExtUI::onPowerLossResume();
       #else
         SERIAL_ECHO_MSG("Resume requires LCD.");
       #endif

--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -73,7 +73,7 @@ void GcodeSuite::M303() {
   if (!WITHIN(e, SI, EI)) {
     SERIAL_ECHOLNPGM(STR_PID_BAD_EXTRUDER_NUM);
     #if ENABLED(EXTENSIBLE_UI)
-      ExtUI::OnPidTuning(ExtUI::result_t::PID_BAD_EXTRUDER_NUM);
+      ExtUI::onPidTuning(ExtUI::result_t::PID_BAD_EXTRUDER_NUM);
     #endif
     return;
   }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/spi.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/spi.cpp
@@ -39,8 +39,8 @@ namespace FTDI {
     WRITE(CLCD_SPI_CS, 1);
 
     #ifdef CLCD_SPI_EXTRA_CS
-        SET_OUTPUT(CLCD_SPI_EXTRA_CS);
-        WRITE(CLCD_SPI_EXTRA_CS, 1);
+      SET_OUTPUT(CLCD_SPI_EXTRA_CS);
+      WRITE(CLCD_SPI_EXTRA_CS, 1);
     #endif
 
     #ifdef SPI_FLASH_SS
@@ -117,7 +117,7 @@ namespace FTDI {
     #endif
     WRITE(CLCD_SPI_CS, 0);
     #ifdef CLCD_SPI_EXTRA_CS
-        WRITE(CLCD_SPI_EXTRA_CS, 0);
+      WRITE(CLCD_SPI_EXTRA_CS, 0);
     #endif
     delayMicroseconds(1);
   }
@@ -126,7 +126,7 @@ namespace FTDI {
   void SPI::spi_ftdi_deselect() {
     WRITE(CLCD_SPI_CS, 1);
     #ifdef CLCD_SPI_EXTRA_CS
-        WRITE(CLCD_SPI_EXTRA_CS, 1);
+      WRITE(CLCD_SPI_EXTRA_CS, 1);
     #endif
     #ifndef CLCD_USE_SOFT_SPI
       ::SPI.endTransaction();

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/spi.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/spi.cpp
@@ -38,6 +38,11 @@ namespace FTDI {
     SET_OUTPUT(CLCD_SPI_CS);
     WRITE(CLCD_SPI_CS, 1);
 
+    #ifdef CLCD_SPI_EXTRA_CS
+        SET_OUTPUT(CLCD_SPI_EXTRA_CS);
+        WRITE(CLCD_SPI_EXTRA_CS, 1);
+    #endif
+
     #ifdef SPI_FLASH_SS
       SET_OUTPUT(SPI_FLASH_SS);
       WRITE(SPI_FLASH_SS, 1);
@@ -111,12 +116,18 @@ namespace FTDI {
       ::SPI.beginTransaction(spi_settings);
     #endif
     WRITE(CLCD_SPI_CS, 0);
+    #ifdef CLCD_SPI_EXTRA_CS
+        WRITE(CLCD_SPI_EXTRA_CS, 0);
+    #endif
     delayMicroseconds(1);
   }
 
   // CLCD SPI - Chip Deselect
   void SPI::spi_ftdi_deselect() {
     WRITE(CLCD_SPI_CS, 1);
+    #ifdef CLCD_SPI_EXTRA_CS
+        WRITE(CLCD_SPI_EXTRA_CS, 1);
+    #endif
     #ifndef CLCD_USE_SOFT_SPI
       ::SPI.endTransaction();
     #endif

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/event_loop.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/event_loop.cpp
@@ -191,7 +191,7 @@ namespace FTDI {
 
             #if ENABLED(TOUCH_UI_DEBUG)
               SERIAL_ECHO_START();
-              SERIAL_ECHOLNPAIR("Touch end: ", tag);
+              SERIAL_ECHOLNPAIR("Touch end: ", pressed_tag);
             #endif
 
             const uint8_t saved_pressed_tag = pressed_tag;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
@@ -70,13 +70,15 @@ namespace Language_en {
   PROGMEM Language_Str MSG_PRINT_FINISHED           = u8"Print finished";
   PROGMEM Language_Str MSG_PRINT_ERROR              = u8"Print error";
   PROGMEM Language_Str MSG_ABOUT_TOUCH_PANEL_1      = u8"Color Touch Panel";
-  PROGMEM Language_Str MSG_ABOUT_TOUCH_PANEL_2      = u8"Portions " COPYRIGHT_SIGN " 2019 Aleph Objects, Inc.\n"
-                                                        "Portions " COPYRIGHT_SIGN " 2019 Cocoa Press";
-  PROGMEM Language_Str MSG_FIRMWARE_FOR_TOOLHEAD    = u8"Firmware for toolhead:\n%s\n\n";
+  PROGMEM Language_Str MSG_ABOUT_TOUCH_PANEL_2      = WEBSITE_URL;
+  PROGMEM Language_Str MSG_LICENSE                  = u8"This program is free software: you can redistribute it and/or modify it under the terms of "
+                                                        "the GNU General Public License as published by the Free Software Foundation, either version 3 "
+                                                        "of the License, or (at your option) any later version.\n\nTo view a copy of the GNU General "
+                                                        "Public License, go to the following location: http://www.gnu.org/licenses.";
   PROGMEM Language_Str MSG_RUNOUT_1                 = u8"Runout 1";
   PROGMEM Language_Str MSG_RUNOUT_2                 = u8"Runout 2";
   PROGMEM Language_Str MSG_DISPLAY_MENU             = u8"Display";
-  PROGMEM Language_Str MSG_INTERFACE_SETTINGS       = u8"Interface Settings";
+  PROGMEM Language_Str MSG_INTERFACE                = u8"Interface";
   PROGMEM Language_Str MSG_MEASURE_AUTOMATICALLY    = u8"Measure automatically";
   PROGMEM Language_Str MSG_H_OFFSET                 = u8"H Offset";
   PROGMEM Language_Str MSG_V_OFFSET                 = u8"V Offset";
@@ -129,7 +131,7 @@ namespace Language_en {
   PROGMEM Language_Str MSG_SOUND_VOLUME             = u8"Sound volume";
   PROGMEM Language_Str MSG_SCREEN_LOCK              = u8"Screen lock";
   PROGMEM Language_Str MSG_BOOT_SCREEN              = u8"Boot screen";
-  PROGMEM Language_Str MSG_INTERFACE_SOUNDS         = u8"Interface Sounds";
+  PROGMEM Language_Str MSG_SOUNDS                   = u8"Sounds";
   PROGMEM Language_Str MSG_CLICK_SOUNDS             = u8"Click sounds";
   PROGMEM Language_Str MSG_EEPROM_RESTORED          = u8"Settings restored from backup";
   PROGMEM Language_Str MSG_EEPROM_RESET             = u8"Settings restored to default";
@@ -144,12 +146,12 @@ namespace Language_en {
 
   PROGMEM Language_Str MSG_TOUCH_CALIBRATION_START  = u8"Release to begin screen calibration";
   PROGMEM Language_Str MSG_TOUCH_CALIBRATION_PROMPT = u8"Touch the dots to calibrate";
+  PROGMEM Language_Str MSG_AUTOLEVEL_X_AXIS         = u8"Level X Axis";
 
   #ifdef TOUCH_UI_LULZBOT_BIO
     PROGMEM Language_Str MSG_MOVE_TO_HOME           = u8"Move to Home";
     PROGMEM Language_Str MSG_RAISE_PLUNGER          = u8"Raise Plunger";
     PROGMEM Language_Str MSG_RELEASE_XY_AXIS        = u8"Release X and Y Axis";
-    PROGMEM Language_Str MSG_AUTOLEVEL_X_AXIS       = u8"Auto-level X Axis";
     PROGMEM Language_Str MSG_BED_TEMPERATURE        = u8"Bed Temperature";
     PROGMEM Language_Str MSG_HOME_XYZ_WARNING       = u8"About to move to home position. Ensure the top and the bed of the printer are clear.\n\nContinue?";
     PROGMEM Language_Str MSG_HOME_E_WARNING         = u8"About to re-home plunger and auto-level. Remove syringe prior to proceeding.\n\nContinue?";

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -131,10 +131,16 @@ namespace ExtUI {
     }
   #endif
 
+  #if ENABLED(POWER_LOSS_RECOVERY)
+    void onPowerLossResume() {
+      // Called on resume from power-loss
+    }
+  #endif
+
   #if HAS_PID_HEATING
     void onPidTuning(const result_t rst) {
       // Called for temperature PID tuning result
-      SERIAL_ECHOLNPAIR("onPidTuning:", rst);
+      SERIAL_ECHOLNPAIR("OnPidTuning:", rst);
       switch (rst) {
         case PID_BAD_EXTRUDER_NUM:
           StatusScreen::setStatusMessage(STR_PID_BAD_EXTRUDER_NUM);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -132,9 +132,9 @@ namespace ExtUI {
   #endif
 
   #if HAS_PID_HEATING
-    void OnPidTuning(const result_t rst) {
+    void onPidTuning(const result_t rst) {
       // Called for temperature PID tuning result
-      SERIAL_ECHOLNPAIR("OnPidTuning:", rst);
+      SERIAL_ECHOLNPAIR("onPidTuning:", rst);
       switch (rst) {
         case PID_BAD_EXTRUDER_NUM:
           StatusScreen::setStatusMessage(STR_PID_BAD_EXTRUDER_NUM);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/pin_mappings.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/pin_mappings.h
@@ -129,12 +129,13 @@
  *      9         GND     GND     GND     -->  GND
  *     10         5V      5V      5V      -->  KILL [3]
  *
- * [1] This configuration is not compatible with the
- *     EinsyRetro 1.1a because there is a level shifter
- *     on MISO enabled by SD/USB chip select.
+ * [1] This configuration allows daisy-chaining of the
+ *     display and SD/USB on EXP2, except for [2]
  *
- * [2] This configuration allows daisy-chaining of the
- *     display and SD/USB on EXP2.
+ * [2] The Ultimachine Einsy boards have a level shifter
+ *     on MISO enabled by SD_CSEL chip select, hence it
+ *     is not possible to run both the display and the
+ *     SD/USB on EXP2.
  *
  * [3] Archim Rambo provides 5V on this pin. On any other
  *     board, divert this wire from the ribbon cable and
@@ -148,4 +149,8 @@
 
   #define CLCD_SPI_CS                    BTN_EN1
   #define CLCD_MOD_RESET                 BTN_EN2
+  
+  #if MB(EINSY_RAMBO, EINSY_RETRO) && DISABLED(SDSUPPORT)
+    #define CLCD_SPI_EXTRA_CS            SDSS
+  #endif
 #endif

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
@@ -92,16 +92,15 @@ void AboutScreen::onRedraw(draw_mode_t) {
 bool AboutScreen::onTouchEnd(uint8_t tag) {
   switch (tag) {
     case 1: GOTO_PREVIOUS(); break;
-#if ENABLED(PRINTCOUNTER)
-    case 2: GOTO_SCREEN(StatisticsScreen); break;
-#endif
-#if ENABLED(TOUCH_UI_DEVELOPER_MENU)
-    case 3: GOTO_SCREEN(DeveloperMenu); break;
-#endif
+    #if ENABLED(PRINTCOUNTER)
+      case 2: GOTO_SCREEN(StatisticsScreen); break;
+    #endif
+    #if ENABLED(TOUCH_UI_DEVELOPER_MENU)
+      case 3: GOTO_SCREEN(DeveloperMenu); break;
+    #endif
     default: return false;
   }
   return true;
 }
 
 #endif // TOUCH_UI_FTDI_EVE
-

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
@@ -27,7 +27,7 @@
 #include "screens.h"
 
 #define GRID_COLS 4
-#define GRID_ROWS 9
+#define GRID_ROWS 7
 
 using namespace FTDI;
 using namespace Theme;
@@ -45,7 +45,32 @@ void AboutScreen::onRedraw(draw_mode_t) {
      .cmd(COLOR_RGB(bg_text_enabled))
      .tag(0);
 
-  draw_text_box(cmd, BTN_POS(1,2), BTN_SIZE(4,1),
+  #define HEADING_POS BTN_POS(1,2), BTN_SIZE(4,1)
+  #define FW_VERS_POS BTN_POS(1,3), BTN_SIZE(4,1)
+  #define FW_INFO_POS BTN_POS(1,4), BTN_SIZE(4,1)
+  #define LICENSE_POS BTN_POS(1,5), BTN_SIZE(4,2)
+  #define STATS_POS   BTN_POS(1,7), BTN_SIZE(2,1)
+  #define BACK_POS    BTN_POS(3,7), BTN_SIZE(2,1)
+
+  #define _INSET_POS(x,y,w,h) x + w/10, y, w - w/5, h
+  #define INSET_POS(pos) _INSET_POS(pos)
+
+  char about_str[
+    strlen_P(GET_TEXT(MSG_ABOUT_TOUCH_PANEL_2)) +
+    strlen_P(TOOLHEAD_NAME) + 1
+  ];
+  #ifdef TOOLHEAD_NAME
+    // If MSG_ABOUT_TOUCH_PANEL_2 has %s, substitute in the toolhead name.
+    // But this is optional, so squelch the compiler warning here.
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wformat-extra-args"
+    sprintf_P(about_str, GET_TEXT(MSG_ABOUT_TOUCH_PANEL_2), TOOLHEAD_NAME);
+    #pragma GCC diagnostic pop
+  #else
+    strcpy_P(about_str, GET_TEXT(MSG_ABOUT_TOUCH_PANEL_2));
+  #endif
+
+  draw_text_box(cmd, HEADING_POS,
     #ifdef CUSTOM_MACHINE_NAME
       F(CUSTOM_MACHINE_NAME)
     #else
@@ -53,42 +78,30 @@ void AboutScreen::onRedraw(draw_mode_t) {
     #endif
     , OPT_CENTER, font_xlarge
   );
+  draw_text_box(cmd, FW_VERS_POS, progmem_str(getFirmwareName_str()), OPT_CENTER, font_medium);
+  draw_text_box(cmd, FW_INFO_POS, about_str, OPT_CENTER, font_medium);
+  draw_text_box(cmd, INSET_POS(LICENSE_POS), GET_TEXT_F(MSG_LICENSE), OPT_CENTER, font_tiny);
 
-  #ifdef TOOLHEAD_NAME
-    char about_str[
-      strlen_P(GET_TEXT(FIRMWARE_FOR_TOOLHEAD)) +
-      strlen_P(TOOLHEAD_NAME) +
-      strlen_P(GET_TEXT(MSG_ABOUT_TOUCH_PANEL_2)) + 1
-    ];
-
-    sprintf_P(about_str, GET_TEXT(MSG_FIRMWARE_FOR_TOOLHEAD), TOOLHEAD_NAME);
-    strcat_P (about_str, GET_TEXT(MSG_ABOUT_TOUCH_PANEL_2));
-  #endif
-
-  cmd.tag(2);
-  draw_text_box(cmd, BTN_POS(1,3), BTN_SIZE(4,3),
-    #ifdef TOOLHEAD_NAME
-      about_str
-    #else
-      GET_TEXT_F(MSG_ABOUT_TOUCH_PANEL_2)
-    #endif
-    , OPT_CENTER, font_medium
-  );
-
-  cmd.tag(0);
-  draw_text_box(cmd, BTN_POS(1,6), BTN_SIZE(4,2), progmem_str(getFirmwareName_str()), OPT_CENTER, font_medium);
-
-  cmd.font(font_medium).colors(action_btn).tag(1).button(BTN_POS(2,8), BTN_SIZE(2,1), GET_TEXT_F(MSG_BUTTON_OKAY));
+  cmd.font(font_medium)
+     .colors(normal_btn)
+     .tag(2).button(STATS_POS, GET_TEXT_F(MSG_INFO_STATS_MENU))
+     .colors(action_btn)
+     .tag(1).button(BACK_POS,  GET_TEXT_F(MSG_BACK));
 }
 
 bool AboutScreen::onTouchEnd(uint8_t tag) {
   switch (tag) {
-    case 1: GOTO_PREVIOUS();            return true;
-#if ENABLED(TOUCH_UI_DEVELOPER_MENU)
-    case 2: GOTO_SCREEN(DeveloperMenu); return true;
+    case 1: GOTO_PREVIOUS(); break;
+#if ENABLED(PRINTCOUNTER)
+    case 2: GOTO_SCREEN(StatisticsScreen); break;
 #endif
-    default:                            return false;
+#if ENABLED(TOUCH_UI_DEVELOPER_MENU)
+    case 3: GOTO_SCREEN(DeveloperMenu); break;
+#endif
+    default: return false;
   }
+  return true;
 }
 
 #endif // TOUCH_UI_FTDI_EVE
+

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
@@ -37,127 +37,116 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
        .cmd(CLEAR(true,true,true));
   }
 
+    #ifdef TOUCH_UI_PORTRAIT
+      #if HAS_CASE_LIGHT || ENABLED(SENSORLESS_HOMING)
+        #define GRID_ROWS 9
+      #else
+        #define GRID_ROWS 8
+      #endif
+      #define GRID_COLS 2
+      #define RESTORE_DEFAULTS_POS    BTN_POS(1,1), BTN_SIZE(2,1)
+      #define DISPLAY_POS             BTN_POS(1,2), BTN_SIZE(1,1)
+      #define INTERFACE_POS           BTN_POS(2,2), BTN_SIZE(1,1)
+      #define ZPROBE_ZOFFSET_POS      BTN_POS(1,3), BTN_SIZE(1,1)
+      #define STEPS_PER_MM_POS        BTN_POS(2,3), BTN_SIZE(1,1)
+      #define FILAMENT_POS            BTN_POS(1,4), BTN_SIZE(1,1)
+      #define VELOCITY_POS            BTN_POS(2,4), BTN_SIZE(1,1)
+      #define TMC_CURRENT_POS         BTN_POS(1,5), BTN_SIZE(1,1)
+      #define ACCELERATION_POS        BTN_POS(2,5), BTN_SIZE(1,1)
+      #define ENDSTOPS_POS            BTN_POS(1,6), BTN_SIZE(1,1)
+      #define JERK_POS                BTN_POS(2,6), BTN_SIZE(1,1)
+      #define OFFSETS_POS             BTN_POS(1,7), BTN_SIZE(1,1)
+      #define BACKLASH_POS            BTN_POS(2,7), BTN_SIZE(1,1)
+      #define CASE_LIGHT_POS          BTN_POS(1,8), BTN_SIZE(1,1)
+      #define TMC_HOMING_THRS_POS     BTN_POS(2,8), BTN_SIZE(1,1)
+      #if HAS_CASE_LIGHT || ENABLED(SENSORLESS_HOMING)
+        #define BACK_POS              BTN_POS(1,9), BTN_SIZE(2,1)
+      #else
+        #define BACK_POS              BTN_POS(1,8), BTN_SIZE(2,1)
+      #endif
+    #else
+      #define GRID_ROWS 6
+      #define GRID_COLS 3
+      #define ZPROBE_ZOFFSET_POS      BTN_POS(1,1), BTN_SIZE(1,1)
+      #define CASE_LIGHT_POS          BTN_POS(1,4), BTN_SIZE(1,1)
+      #define STEPS_PER_MM_POS        BTN_POS(2,1), BTN_SIZE(1,1)
+      #define TMC_CURRENT_POS         BTN_POS(3,1), BTN_SIZE(1,1)
+      #define TMC_HOMING_THRS_POS     BTN_POS(3,2), BTN_SIZE(1,1)
+      #define BACKLASH_POS            BTN_POS(3,3), BTN_SIZE(1,1)
+      #define FILAMENT_POS            BTN_POS(1,3), BTN_SIZE(1,1)
+      #define ENDSTOPS_POS            BTN_POS(3,4), BTN_SIZE(1,1)
+      #define DISPLAY_POS             BTN_POS(3,5), BTN_SIZE(1,1)
+      #define INTERFACE_POS           BTN_POS(1,5), BTN_SIZE(2,1)
+      #define RESTORE_DEFAULTS_POS    BTN_POS(1,6), BTN_SIZE(2,1)
+      #define VELOCITY_POS            BTN_POS(2,2), BTN_SIZE(1,1)
+      #define ACCELERATION_POS        BTN_POS(2,3), BTN_SIZE(1,1)
+      #define JERK_POS                BTN_POS(2,4), BTN_SIZE(1,1)
+      #define OFFSETS_POS             BTN_POS(1,2), BTN_SIZE(1,1)
+      #define BACK_POS                BTN_POS(3,6), BTN_SIZE(1,1)
+    #endif
+
   if (what & FOREGROUND) {
     CommandProcessor cmd;
     cmd.colors(normal_btn)
        .font(Theme::font_medium)
-    #ifdef TOUCH_UI_PORTRAIT
-      #define GRID_ROWS 10
-      #define GRID_COLS 2
       .enabled(
         #if HAS_BED_PROBE
           1
         #endif
       )
-      .tag(2) .button( BTN_POS(1,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_ZPROBE_ZOFFSET))
+      .tag(2) .button( ZPROBE_ZOFFSET_POS,     GET_TEXT_F(MSG_ZPROBE_ZOFFSET))
       .enabled(
         #if HAS_CASE_LIGHT
           1
         #endif
       )
-      .tag(16).button( BTN_POS(1,6),  BTN_SIZE(1,1), GET_TEXT_F(MSG_CASE_LIGHT))
-      .tag(3) .button( BTN_POS(2,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_STEPS_PER_MM))
+      .tag(16).button( CASE_LIGHT_POS,         GET_TEXT_F(MSG_CASE_LIGHT))
+      .tag(3) .button( STEPS_PER_MM_POS,       GET_TEXT_F(MSG_STEPS_PER_MM))
       .enabled(
         #if HAS_TRINAMIC_CONFIG
           1
         #endif
       )
-      .tag(13).button( BTN_POS(1,4), BTN_SIZE(1,1), GET_TEXT_F(MSG_TMC_CURRENT))
+      .tag(13).button( TMC_CURRENT_POS,        GET_TEXT_F(MSG_TMC_CURRENT))
       .enabled(
-        #if HAS_TRINAMIC_CONFIG
+        #if ENABLED(SENSORLESS_HOMING)
           1
         #endif
       )
-      .tag(14).button( BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXT_F(MSG_TMC_HOMING_THRS))
+      .tag(14).button( TMC_HOMING_THRS_POS,    GET_TEXT_F(MSG_TMC_HOMING_THRS))
       .enabled(
         #if HOTENDS > 1
           1
         #endif
       )
-      .tag(4) .button( BTN_POS(1,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_OFFSETS_MENU))
+      .tag(4) .button( OFFSETS_POS,            GET_TEXT_F(MSG_OFFSETS_MENU))
       .enabled(
         #if EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
           1
         #endif
       )
-      .tag(11).button( BTN_POS(1,3), BTN_SIZE(1,1), GET_TEXT_F(MSG_FILAMENT))
-      .tag(12).button( BTN_POS(1,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_LCD_ENDSTOPS))
-      .tag(15).button( BTN_POS(2,6), BTN_SIZE(1,1), GET_TEXT_F(MSG_DISPLAY_MENU))
-      .tag(9) .button( BTN_POS(1,8), BTN_SIZE(2,1), GET_TEXT_F(MSG_INTERFACE_SETTINGS))
-      .tag(10).button( BTN_POS(1,9), BTN_SIZE(2,1), GET_TEXT_F(MSG_RESTORE_DEFAULTS))
-      .tag(5) .button( BTN_POS(2,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_VELOCITY))
-      .tag(6) .button( BTN_POS(2,3), BTN_SIZE(1,1), GET_TEXT_F(MSG_ACCELERATION))
-      #if DISABLED(CLASSIC_JERK)
-      .tag(7) .button( BTN_POS(2,4), BTN_SIZE(1,1), GET_TEXT_F(MSG_JUNCTION_DEVIATION))
-      #else
-      .tag(7) .button( BTN_POS(2,4), BTN_SIZE(1,1), GET_TEXT_F(MSG_JERK))
-      #endif
+      .tag(11).button( FILAMENT_POS,           GET_TEXT_F(MSG_FILAMENT))
+      .tag(12).button( ENDSTOPS_POS,           GET_TEXT_F(MSG_LCD_ENDSTOPS))
+      .tag(15).button( DISPLAY_POS,            GET_TEXT_F(MSG_DISPLAY_MENU))
+      .tag(9) .button( INTERFACE_POS,          GET_TEXT_F(MSG_INTERFACE))
+      .tag(10).button( RESTORE_DEFAULTS_POS,   GET_TEXT_F(MSG_RESTORE_DEFAULTS))
+      .tag(5) .button( VELOCITY_POS,           GET_TEXT_F(MSG_VELOCITY))
+      .tag(6) .button( ACCELERATION_POS,       GET_TEXT_F(MSG_ACCELERATION))
+      .tag(7) .button( JERK_POS,               GET_TEXT_F(
+        #if DISABLED(CLASSIC_JERK)
+          MSG_JUNCTION_DEVIATION
+        #else
+          JERK_POS
+        #endif
+       ))
       .enabled(
         #if ENABLED(BACKLASH_GCODE)
           1
         #endif
       )
-      .tag(8).button( BTN_POS(2,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_BACKLASH))
+      .tag(8).button( BACKLASH_POS,            GET_TEXT_F(MSG_BACKLASH))
       .colors(action_btn)
-      .tag(1) .button( BTN_POS(1,10), BTN_SIZE(2,1), GET_TEXT_F(MSG_BACK));
-      #undef GRID_COLS
-      #undef GRID_ROWS
-    #else
-      #define GRID_ROWS 6
-      #define GRID_COLS 3
-      .enabled(
-        #if HAS_BED_PROBE
-          1
-        #endif
-      )
-      .tag(2) .button( BTN_POS(1,1),  BTN_SIZE(1,1), GET_TEXT_F(MSG_ZPROBE_ZOFFSET))
-      .enabled(
-        #if HAS_CASE_LIGHT
-          1
-        #endif
-      )
-      .tag(16).button( BTN_POS(1,4),  BTN_SIZE(1,1), GET_TEXT_F(MSG_CASE_LIGHT))
-      .enabled(1)
-      .tag(3) .button( BTN_POS(2,1),  BTN_SIZE(1,1), GET_TEXT_F(MSG_STEPS_PER_MM))
-      .enabled(
-        #if HAS_TRINAMIC_CONFIG
-          1
-        #endif
-      )
-      .tag(13).button( BTN_POS(3,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_TMC_CURRENT))
-      .enabled(
-        #if HAS_TRINAMIC_CONFIG
-          1
-        #endif
-      )
-      .tag(14).button( BTN_POS(3,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_TMC_HOMING_THRS))
-      .enabled(
-        #if ENABLED(BACKLASH_GCODE)
-          1
-        #endif
-      )
-      .tag(8).button( BTN_POS(3,3),  BTN_SIZE(1,1), GET_TEXT_F(MSG_BACKLASH))
-      .enabled(
-        #if HOTENDS > 1
-          1
-        #endif
-      )
-      .tag(4) .button( BTN_POS(1,2),  BTN_SIZE(1,1), GET_TEXT_F(MSG_OFFSETS_MENU))
-      .tag(12).button( BTN_POS(3,4),  BTN_SIZE(1,1), GET_TEXT_F(MSG_LCD_ENDSTOPS))
-      .tag(5) .button( BTN_POS(2,2),  BTN_SIZE(1,1), GET_TEXT_F(MSG_VELOCITY))
-      .tag(6) .button( BTN_POS(2,3),  BTN_SIZE(1,1), GET_TEXT_F(MSG_ACCELERATION))
-      #if DISABLED(CLASSIC_JERK)
-      .tag(7) .button( BTN_POS(2,4),  BTN_SIZE(1,1), GET_TEXT_F(MSG_JUNCTION_DEVIATION))
-      #else
-      .tag(7) .button( BTN_POS(2,4),  BTN_SIZE(1,1), GET_TEXT_F(MSG_JERK))
-      #endif
-      .tag(11).button( BTN_POS(1,3),  BTN_SIZE(1,1), GET_TEXT_F(MSG_FILAMENT))
-      .tag(15).button( BTN_POS(3,5),  BTN_SIZE(1,1), GET_TEXT_F(MSG_DISPLAY_MENU))
-      .tag(9) .button( BTN_POS(1,5),  BTN_SIZE(2,1), GET_TEXT_F(MSG_INTERFACE_SETTINGS))
-      .tag(10).button( BTN_POS(1,6),  BTN_SIZE(2,1), GET_TEXT_F(MSG_RESTORE_DEFAULTS))
-      .colors(action_btn)
-      .tag(1) .button( BTN_POS(3,6),  BTN_SIZE(1,1), GET_TEXT_F(MSG_BACK));
-    #endif
+      .tag(1).button( BACK_POS,                GET_TEXT_F(MSG_BACK));
   }
 }
 
@@ -191,6 +180,8 @@ bool AdvancedSettingsMenu::onTouchEnd(uint8_t tag) {
     case 12: GOTO_SCREEN(EndstopStatesScreen); break;
     #if HAS_TRINAMIC_CONFIG
     case 13: GOTO_SCREEN(StepperCurrentScreen); break;
+    #endif
+    #if ENABLED(SENSORLESS_HOMING)
     case 14: GOTO_SCREEN(StepperBumpSensitivityScreen); break;
     #endif
     case 15: GOTO_SCREEN(DisplayTuningScreen); break;
@@ -201,5 +192,4 @@ bool AdvancedSettingsMenu::onTouchEnd(uint8_t tag) {
   }
   return true;
 }
-
 #endif // TOUCH_UI_FTDI_EVE

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_numeric_adjustment_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_numeric_adjustment_screen.cpp
@@ -345,10 +345,14 @@ void BaseNumericAdjustmentScreen::widgets_t::home_buttons(uint8_t tag) {
   }
 
   cmd.font(LAYOUT_FONT);
- _button(cmd, tag+0, BTN_POS(5,_line),  BTN_SIZE(2,1), GET_TEXT_F(MSG_AXIS_X));
- _button(cmd, tag+1, BTN_POS(7,_line),  BTN_SIZE(2,1), GET_TEXT_F(MSG_AXIS_Y));
- _button(cmd, tag+2, BTN_POS(9,_line),  BTN_SIZE(2,1), GET_TEXT_F(MSG_AXIS_Z));
- _button(cmd, tag+3, BTN_POS(11,_line), BTN_SIZE(3,1), GET_TEXT_F(MSG_AXIS_ALL));
+ _button(cmd, tag+0, BTN_POS(5,_line),    BTN_SIZE(2,1), GET_TEXT_F(MSG_AXIS_X));
+ _button(cmd, tag+1, BTN_POS(7,_line),    BTN_SIZE(2,1), GET_TEXT_F(MSG_AXIS_Y));
+ #if DISABLED(Z_SAFE_HOMING)
+   _button(cmd, tag+2, BTN_POS(9,_line),  BTN_SIZE(2,1), GET_TEXT_F(MSG_AXIS_Z));
+   _button(cmd, tag+3, BTN_POS(11,_line), BTN_SIZE(3,1), GET_TEXT_F(MSG_AXIS_ALL));
+ #else
+   _button(cmd, tag+3, BTN_POS(9,_line),  BTN_SIZE(3,1), GET_TEXT_F(MSG_AXIS_ALL));
+ #endif
 
   _line++;
 }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_screen.cpp
@@ -46,7 +46,7 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
     return false;
   }
 
-  #ifdef LCD_TIMEOUT_TO_STATUS
+  #if LCD_TIMEOUT_TO_STATUS
     if (EventLoop::get_pressed_tag() != 0) {
       reset_menu_timeout();
     }
@@ -66,7 +66,7 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
 }
 
 void BaseScreen::onIdle() {
-  #ifdef LCD_TIMEOUT_TO_STATUS
+  #if LCD_TIMEOUT_TO_STATUS
     if ((millis() - last_interaction) > LCD_TIMEOUT_TO_STATUS) {
       reset_menu_timeout();
       #if ENABLED(TOUCH_UI_DEBUG)
@@ -78,12 +78,12 @@ void BaseScreen::onIdle() {
 }
 
 void BaseScreen::reset_menu_timeout() {
-  #ifdef LCD_TIMEOUT_TO_STATUS
+  #if LCD_TIMEOUT_TO_STATUS
     last_interaction = millis();
   #endif
 }
 
-#ifdef LCD_TIMEOUT_TO_STATUS
+#if LCD_TIMEOUT_TO_STATUS
   uint32_t BaseScreen::last_interaction;
 #endif
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_advanced_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_advanced_settings.cpp
@@ -85,7 +85,7 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
         #endif
       )
       .tag(12) .button( BTN_POS(1,6), BTN_SIZE(2,1), GET_TEXT_F(MSG_LINEAR_ADVANCE))
-      .tag(13) .button( BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXT_F(MSG_INTERFACE_SETTINGS))
+      .tag(13) .button( BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXT_F(MSG_INTERFACE))
       .tag(14) .button( BTN_POS(1,8), BTN_SIZE(2,1), GET_TEXT_F(MSG_RESTORE_DEFAULTS))
       .colors(action_btn)
       .tag(1). button( BTN_POS(1,9), BTN_SIZE(2,1), GET_TEXT_F(MSG_BACK));

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_confirm_home_e.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_confirm_home_e.cpp
@@ -36,11 +36,13 @@ void BioConfirmHomeE::onRedraw(draw_mode_t) {
 bool BioConfirmHomeE::onTouchEnd(uint8_t tag) {
   switch (tag) {
     case 1:
-      SpinnerDialogBox::enqueueAndWait_P(F(
-        "G28 E\n"
-        AXIS_LEVELING_COMMANDS "\n"
-        PARK_AND_RELEASE_COMMANDS
-      ));
+      #if defined(AXIS_LEVELING_COMMANDS) && defined(PARK_AND_RELEASE_COMMANDS)
+        SpinnerDialogBox::enqueueAndWait_P(F(
+          "G28 E\n"
+          AXIS_LEVELING_COMMANDS "\n"
+          PARK_AND_RELEASE_COMMANDS
+        ));
+      #endif
       current_screen.forget();
       break;
     case 2:

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_confirm_home_xyz.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_confirm_home_xyz.cpp
@@ -36,10 +36,12 @@ void BioConfirmHomeXYZ::onRedraw(draw_mode_t) {
 bool BioConfirmHomeXYZ::onTouchEnd(uint8_t tag) {
   switch (tag) {
     case 1:
-      SpinnerDialogBox::enqueueAndWait_P(F(
-       "G28\n"
-       PARK_AND_RELEASE_COMMANDS
-      ));
+      #ifdef PARK_AND_RELEASE_COMMANDS
+        SpinnerDialogBox::enqueueAndWait_P(F(
+         "G28\n"
+         PARK_AND_RELEASE_COMMANDS
+        ));
+      #endif
       current_screen.forget();
       break;
     case 2:

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_main_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_main_menu.cpp
@@ -51,7 +51,7 @@ void MainMenu::onRedraw(draw_mode_t what) {
        .tag(4).button( BTN_POS(1,4), BTN_SIZE(2,1), GET_TEXT_F(MSG_RELEASE_XY_AXIS))
        .tag(5).button( BTN_POS(1,5), BTN_SIZE(2,1), GET_TEXT_F(MSG_AUTOLEVEL_X_AXIS))
        .tag(6).button( BTN_POS(1,6), BTN_SIZE(2,1), GET_TEXT_F(MSG_BED_TEMPERATURE))
-       .tag(7).button( BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXT_F(MSG_INTERFACE_SETTINGS))
+       .tag(7).button( BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXT_F(MSG_INTERFACE))
        .tag(8).button( BTN_POS(1,8), BTN_SIZE(2,1), GET_TEXT_F(MSG_ADVANCED_SETTINGS))
        .tag(9).button( BTN_POS(1,9), BTN_SIZE(2,1), GET_TEXT_F(MSG_INFO_MENU))
        .colors(action_btn)
@@ -72,7 +72,9 @@ bool MainMenu::onTouchEnd(uint8_t tag) {
     case 2: GOTO_SCREEN(BioConfirmHomeXYZ);                                              break;
     case 3: SpinnerDialogBox::enqueueAndWait_P(e_homed ? F("G0 E0 F120") : F("G112"));   break;
     case 4: StatusScreen::unlockMotors();                                                break;
+    #ifdef AXIS_LEVELING_COMMANDS
     case 5: SpinnerDialogBox::enqueueAndWait_P(F(AXIS_LEVELING_COMMANDS));               break;
+    #endif
     case 6: GOTO_SCREEN(TemperatureScreen);                                              break;
     case 7: GOTO_SCREEN(InterfaceSettingsScreen);                                        break;
     case 8: GOTO_SCREEN(AdvancedSettingsMenu);                                           break;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/boot_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/boot_screen.cpp
@@ -80,12 +80,14 @@ void BootScreen::onIdle() {
       SpinnerDialogBox::hide();
     }
 
-    if (UIData::animations_enabled()) {
-      // If there is a startup video in the flash SPI, play
-      // that, otherwise show a static splash screen.
-      if (!MediaPlayerScreen::playBootMedia())
-        showSplashScreen();
-    }
+    #if DISABLED(TOUCH_UI_NO_BOOTSCREEN)
+      if (UIData::animations_enabled()) {
+        // If there is a startup video in the flash SPI, play
+        // that, otherwise show a static splash screen.
+        if (!MediaPlayerScreen::playBootMedia())
+          showSplashScreen();
+      }
+    #endif
 
     StatusScreen::loadBitmaps();
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/change_filament_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/change_filament_screen.cpp
@@ -111,6 +111,7 @@ void ChangeFilamentScreen::onRedraw(draw_mode_t what) {
   if (what & BACKGROUND) {
     cmd.cmd(CLEAR_COLOR_RGB(bg_color))
        .cmd(CLEAR(true,true,true))
+       .cmd(COLOR_RGB(bg_text_enabled))
        .tag(0)
     #ifdef TOUCH_UI_PORTRAIT
        .font(font_large)
@@ -119,7 +120,7 @@ void ChangeFilamentScreen::onRedraw(draw_mode_t what) {
     #endif
        .text(BTN_POS(1,1), BTN_SIZE(2,1), GET_TEXT_F(MSG_EXTRUDER_SELECTION))
     #ifdef TOUCH_UI_PORTRAIT
-       .text(BTN_POS(1,7), BTN_SIZE(1,1), F(""))
+       .text(BTN_POS(1,7), BTN_SIZE(1,1), GET_TEXT_F(MSG_CURRENT_TEMPERATURE))
     #else
        .text(BTN_POS(3,1), BTN_SIZE(2,1), GET_TEXT_F(MSG_CURRENT_TEMPERATURE))
        .font(font_small)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
@@ -69,7 +69,7 @@ void InterfaceSettingsScreen::onRedraw(draw_mode_t what) {
        .cmd(COLOR_RGB(bg_text_enabled))
        .tag(0)
        .font(font_medium)
-       .text(BTN_POS(1,1), BTN_SIZE(4,1), GET_TEXT_F(MSG_INTERFACE_SETTINGS))
+       .text(BTN_POS(1,1), BTN_SIZE(4,1), GET_TEXT_F(MSG_INTERFACE))
     #undef EDGE_R
     #define EDGE_R 30
        .font(font_small)
@@ -77,7 +77,9 @@ void InterfaceSettingsScreen::onRedraw(draw_mode_t what) {
        .text(BTN_POS(1,2), BTN_SIZE(2,1), GET_TEXT_F(MSG_LCD_BRIGHTNESS), OPT_RIGHTX | OPT_CENTERY)
        .text(BTN_POS(1,3), BTN_SIZE(2,1), GET_TEXT_F(MSG_SOUND_VOLUME),   OPT_RIGHTX | OPT_CENTERY)
        .text(BTN_POS(1,4), BTN_SIZE(2,1), GET_TEXT_F(MSG_SCREEN_LOCK),    OPT_RIGHTX | OPT_CENTERY);
+    #if DISABLED(TOUCH_UI_NO_BOOTSCREEN)
     cmd.text(BTN_POS(1,5), BTN_SIZE(2,1), GET_TEXT_F(MSG_BOOT_SCREEN),    OPT_RIGHTX | OPT_CENTERY);
+    #endif
     #undef EDGE_R
   }
 
@@ -95,16 +97,18 @@ void InterfaceSettingsScreen::onRedraw(draw_mode_t what) {
        .tag(3).slider(BTN_POS(3,3), BTN_SIZE(2,1), screen_data.InterfaceSettingsScreen.volume,     0xFF)
        .colors(ui_toggle)
        .tag(4).toggle2(BTN_POS(3,4), BTN_SIZE(w,1), GET_TEXT_F(MSG_NO), GET_TEXT_F(MSG_YES), LockScreen::is_enabled())
+    #if DISABLED(TOUCH_UI_NO_BOOTSCREEN)
        .tag(5).toggle2(BTN_POS(3,5), BTN_SIZE(w,1), GET_TEXT_F(MSG_NO), GET_TEXT_F(MSG_YES), UIData::animations_enabled())
+    #endif
     #undef EDGE_R
     #define EDGE_R 0
     #ifdef TOUCH_UI_PORTRAIT
        .colors(normal_btn)
-       .tag(6).button (BTN_POS(1,6), BTN_SIZE(4,1), GET_TEXT_F(MSG_INTERFACE_SOUNDS))
+       .tag(6).button (BTN_POS(1,6), BTN_SIZE(4,1), GET_TEXT_F(MSG_SOUNDS))
        .colors(action_btn)
        .tag(1).button (BTN_POS(1,7), BTN_SIZE(4,1), GET_TEXT_F(MSG_BACK));
     #else
-       .tag(6).button (BTN_POS(1,6), BTN_SIZE(2,1), GET_TEXT_F(MSG_INTERFACE_SOUNDS))
+       .tag(6).button (BTN_POS(1,6), BTN_SIZE(2,1), GET_TEXT_F(MSG_SOUNDS))
        .colors(action_btn)
        .tag(1).button (BTN_POS(3,6), BTN_SIZE(2,1), GET_TEXT_F(MSG_BACK));
     #endif

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_sounds_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_sounds_screen.cpp
@@ -71,7 +71,7 @@ void InterfaceSoundsScreen::onRedraw(draw_mode_t what) {
     #define GRID_ROWS 9
 
        .font(font_medium)
-       .text(BTN_POS(1,1), BTN_SIZE(4,1), GET_TEXT_F(MSG_INTERFACE_SOUNDS))
+       .text(BTN_POS(1,1), BTN_SIZE(4,1), GET_TEXT_F(MSG_SOUNDS))
     #undef EDGE_R
     #define EDGE_R 30
        .font(font_small)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/main_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/main_menu.cpp
@@ -37,81 +37,89 @@ void MainMenu::onRedraw(draw_mode_t what) {
        .cmd(CLEAR(true,true,true));
   }
 
+  #ifdef TOUCH_UI_PORTRAIT
+    #define GRID_ROWS 8
+    #define GRID_COLS 2
+    #define ABOUT_PRINTER_POS     BTN_POS(1,1), BTN_SIZE(2,1)
+    #define ADVANCED_SETTINGS_POS BTN_POS(1,2), BTN_SIZE(2,1)
+    #define FILAMENTCHANGE_POS    BTN_POS(1,3), BTN_SIZE(2,1)
+    #define TEMPERATURE_POS       BTN_POS(1,4), BTN_SIZE(2,1)
+    #define MOVE_AXIS_POS         BTN_POS(1,5), BTN_SIZE(1,1)
+    #define DISABLE_STEPPERS_POS  BTN_POS(2,5), BTN_SIZE(1,1)
+    #define AUTO_HOME_POS         BTN_POS(1,6), BTN_SIZE(1,1)
+    #define CLEAN_NOZZLE_POS      BTN_POS(2,6), BTN_SIZE(1,1)
+    #define LEVEL_BED_POS         BTN_POS(1,7), BTN_SIZE(1,1)
+    #define LEVEL_AXIS_POS        BTN_POS(2,7), BTN_SIZE(1,1)
+    #define BACK_POS              BTN_POS(1,8), BTN_SIZE(2,1)
+  #else
+    #define GRID_ROWS 6
+    #define GRID_COLS 2
+    #define ADVANCED_SETTINGS_POS BTN_POS(1,1), BTN_SIZE(1,1)
+    #define ABOUT_PRINTER_POS     BTN_POS(2,1), BTN_SIZE(1,1)
+    #define AUTO_HOME_POS         BTN_POS(1,2), BTN_SIZE(1,1)
+    #define CLEAN_NOZZLE_POS      BTN_POS(2,2), BTN_SIZE(1,1)
+    #define MOVE_AXIS_POS         BTN_POS(1,3), BTN_SIZE(1,1)
+    #define DISABLE_STEPPERS_POS  BTN_POS(2,3), BTN_SIZE(1,1)
+    #define TEMPERATURE_POS       BTN_POS(1,4), BTN_SIZE(1,1)
+    #define FILAMENTCHANGE_POS    BTN_POS(2,4), BTN_SIZE(1,1)
+    #define LEVEL_BED_POS         BTN_POS(1,5), BTN_SIZE(1,1)
+    #define LEVEL_AXIS_POS        BTN_POS(2,5), BTN_SIZE(1,1)
+    #define BACK_POS              BTN_POS(1,6), BTN_SIZE(2,1)
+  #endif
+
   if (what & FOREGROUND) {
     CommandProcessor cmd;
     cmd.colors(normal_btn)
        .font(Theme::font_medium)
-    #ifdef TOUCH_UI_PORTRAIT
-      #define GRID_ROWS 8
-      #define GRID_COLS 2
-        .tag(2).button( BTN_POS(1,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_AUTO_HOME))
-        .enabled(
-          #if ENABLED(NOZZLE_CLEAN_FEATURE)
-            1
-          #endif
+       .tag(2).button( AUTO_HOME_POS, GET_TEXT_F(MSG_AUTO_HOME))
+       .enabled(
+           #if ANY(NOZZLE_CLEAN_FEATURE, TOUCH_UI_COCOA_PRESS)
+             1
+           #endif
+         )
+       .tag(3).button( CLEAN_NOZZLE_POS, GET_TEXT_F(
+         #if ENABLED(TOUCH_UI_COCOA_PRESS)
+            MSG_PREHEAT_1
+         #else
+            MSG_CLEAN_NOZZLE
+         #endif
+       ))
+       .tag(4).button( MOVE_AXIS_POS,        GET_TEXT_F(MSG_MOVE_AXIS))
+       .tag(5).button( DISABLE_STEPPERS_POS, GET_TEXT_F(MSG_DISABLE_STEPPERS))
+       .tag(6).button( TEMPERATURE_POS,      GET_TEXT_F(MSG_TEMPERATURE))
+       .enabled(
+           #if DISABLED(TOUCH_UI_LULZBOT_BIO)
+             1
+           #endif
+         )
+       .tag(7).button( FILAMENTCHANGE_POS, GET_TEXT_F(
+         #if ENABLED(TOUCH_UI_COCOA_PRESS)
+             MSG_CASE_LIGHT
+         #else
+             MSG_FILAMENTCHANGE
+         #endif
+        ))
+       .tag(8).button( ADVANCED_SETTINGS_POS, GET_TEXT_F(MSG_ADVANCED_SETTINGS))
+       .enabled(
+         #ifdef PRINTCOUNTER
+           1
+         #endif
         )
-        .tag(3).button( BTN_POS(2,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_CLEAN_NOZZLE))
-        .tag(4).button( BTN_POS(1,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_MOVE_AXIS))
-        .tag(5).button( BTN_POS(2,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_DISABLE_STEPPERS))
-        .tag(6).button( BTN_POS(1,3), BTN_SIZE(2,1), GET_TEXT_F(MSG_TEMPERATURE))
-        .enabled(
-          #if NONE(TOUCH_UI_LULZBOT_BIO, TOUCH_UI_COCOA_PRESS)
-            1
-          #endif
+       .enabled(
+         #ifdef AXIS_LEVELING_COMMANDS
+           1
+         #endif
         )
-        .tag(7).button( BTN_POS(1,4), BTN_SIZE(2,1), GET_TEXT_F(MSG_FILAMENTCHANGE))
-        .tag(8).button( BTN_POS(1,5), BTN_SIZE(2,1), GET_TEXT_F(MSG_ADVANCED_SETTINGS))
-        .enabled(
-          #ifdef PRINTCOUNTER
-            1
-          #endif
+       .tag(9).button( LEVEL_AXIS_POS, GET_TEXT_F(MSG_AUTOLEVEL_X_AXIS))
+       .enabled(
+         #ifdef HAS_LEVELING
+           1
+         #endif
         )
-        .tag(9).button( BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXT_F(MSG_INFO_STATS_MENU))
-        .tag(10).button( BTN_POS(1,6), BTN_SIZE(2,1), GET_TEXT_F(MSG_INFO_MENU))
-        .colors(action_btn)
-        .tag(1).button( BTN_POS(1,8), BTN_SIZE(2,1), GET_TEXT_F(MSG_BACK));
-      #undef GRID_COLS
-      #undef GRID_ROWS
-    #else
-      #define GRID_ROWS 5
-      #define GRID_COLS 2
-        .tag(2).button( BTN_POS(1,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_AUTO_HOME))
-        #if ENABLED(TOUCH_UI_COCOA_PRESS)
-          .tag(3).button( BTN_POS(2,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_PREHEAT_1))
-        #else
-          .enabled(
-            #if ENABLED(NOZZLE_CLEAN_FEATURE)
-              1
-            #endif
-          )
-          .tag(3).button( BTN_POS(2,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_CLEAN_NOZZLE))
-        #endif
-        .tag(4).button( BTN_POS(1,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_MOVE_AXIS))
-        .tag(5).button( BTN_POS(2,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_DISABLE_STEPPERS))
-        .tag(6).button( BTN_POS(1,3), BTN_SIZE(1,1), GET_TEXT_F(MSG_TEMPERATURE))
-        #if ENABLED(TOUCH_UI_COCOA_PRESS)
-          .tag(7).button( BTN_POS(2,3), BTN_SIZE(1,1), GET_TEXT_F(MSG_CASE_LIGHT))
-        #else
-          .enabled(
-            #if DISABLED(TOUCH_UI_LULZBOT_BIO)
-              1
-            #endif
-          )
-          .tag(7).button( BTN_POS(2,3), BTN_SIZE(1,1), GET_TEXT_F(MSG_FILAMENTCHANGE))
-        #endif
-        .tag(8).button( BTN_POS(1,4), BTN_SIZE(1,1), GET_TEXT_F(MSG_ADVANCED_SETTINGS))
-        .enabled(
-          #ifdef PRINTCOUNTER
-            1
-          #endif
-        )
-        .tag(9).button( BTN_POS(2,4), BTN_SIZE(1,1), GET_TEXT_F(MSG_INFO_STATS_MENU))
-        .tag(10).button( BTN_POS(1,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_INFO_MENU))
-        .colors(action_btn)
-        .tag(1).button( BTN_POS(2,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_BACK));
-      #undef GRID_COLS
-      #undef GRID_ROWS
-    #endif
+       .tag(10).button( LEVEL_BED_POS, GET_TEXT_F(MSG_LEVEL_BED))
+       .tag(11).button( ABOUT_PRINTER_POS, GET_TEXT_F(MSG_INFO_MENU))
+       .colors(action_btn)
+       .tag(1).button( BACK_POS, GET_TEXT_F(MSG_BACK));
   }
 }
 
@@ -122,23 +130,32 @@ bool MainMenu::onTouchEnd(uint8_t tag) {
     case 1:  SaveSettingsDialogBox::promptToSaveSettings();           break;
     case 2:  SpinnerDialogBox::enqueueAndWait_P(F("G28"));            break;
     #if ENABLED(TOUCH_UI_COCOA_PRESS)
-    case 3:  GOTO_SCREEN(PreheatTimerScreen);                         break;
+    case 3:  GOTO_SCREEN(PreheatMenu);                                break;
     #elif ENABLED(NOZZLE_CLEAN_FEATURE)
     case 3: injectCommands_P(PSTR("G12")); GOTO_SCREEN(StatusScreen); break;
     #endif
     case 4:  GOTO_SCREEN(MoveAxisScreen);                             break;
     case 5:  injectCommands_P(PSTR("M84"));                           break;
     case 6:  GOTO_SCREEN(TemperatureScreen);                          break;
-    #if ENABLED(TOUCH_UI_COCOA_PRESS)
+    #if ENABLED(TOUCH_UI_COCOA_PRESS) && HAS_CASE_LIGHT
     case 7:  GOTO_SCREEN(CaseLightScreen);                            break;
     #else
     case 7:  GOTO_SCREEN(ChangeFilamentScreen);                       break;
     #endif
     case 8:  GOTO_SCREEN(AdvancedSettingsMenu);                       break;
-#if ENABLED(PRINTCOUNTER)
-    case 9:  GOTO_SCREEN(StatisticsScreen);                           break;
-#endif
-    case 10: GOTO_SCREEN(AboutScreen);                                break;
+    #ifdef AXIS_LEVELING_COMMANDS
+    case 9: SpinnerDialogBox::enqueueAndWait_P(F(AXIS_LEVELING_COMMANDS)); break;
+    #endif
+    #ifdef HAS_LEVELING
+    case 10:  SpinnerDialogBox::enqueueAndWait_P(F(
+      #ifdef BED_LEVELING_COMMANDS
+        BED_LEVELING_COMMANDS
+      #else
+        "G29"
+      #endif
+    ));            break;
+    #endif
+    case 11: GOTO_SCREEN(AboutScreen);                                break;
     default:
       return false;
   }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/preheat_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/preheat_menu.cpp
@@ -1,0 +1,83 @@
+/********************
+ * preheat_menu.cpp *
+ ********************/
+
+/****************************************************************************
+ *   Written By Marcio Teixeira 2020 - Cocoa Press                          *
+ *                                                                          *
+ *   This program is free software: you can redistribute it and/or modify   *
+ *   it under the terms of the GNU General Public License as published by   *
+ *   the Free Software Foundation, either version 3 of the License, or      *
+ *   (at your option) any later version.                                    *
+ *                                                                          *
+ *   This program is distributed in the hope that it will be useful,        *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU General Public License for more details.                           *
+ *                                                                          *
+ *   To view a copy of the GNU General Public License, go to the following  *
+ *   location: <http://www.gnu.org/licenses/>.                              *
+ ****************************************************************************/
+
+#include "../config.h"
+
+#if ENABLED(TOUCH_UI_FTDI_EVE) && defined(TOUCH_UI_COCOA_PRESS)
+
+#include "screens.h"
+
+using namespace FTDI;
+using namespace ExtUI;
+using namespace Theme;
+
+void PreheatMenu::onRedraw(draw_mode_t what) {
+  if (what & BACKGROUND) {
+    CommandProcessor cmd;
+    cmd.cmd(CLEAR_COLOR_RGB(Theme::bg_color))
+       .cmd(CLEAR(true,true,true))
+       .tag(0);
+  }
+
+  #define GRID_ROWS 3
+  #define GRID_COLS 2
+    
+  if (what & FOREGROUND) {
+    CommandProcessor cmd;
+    cmd.cmd(COLOR_RGB(bg_text_enabled))
+       .font(Theme::font_medium)
+       .text  ( BTN_POS(1,1),  BTN_SIZE(2,1), GET_TEXT_F(MSG_PREHEAT_1))
+       .colors(normal_btn)
+       .tag(2).button( BTN_POS(1,2),  BTN_SIZE(1,1), F("Dark Chocolate"))
+       .tag(3).button( BTN_POS(2,2),  BTN_SIZE(1,1), F("Milk Chocolate"))
+       .tag(4).button( BTN_POS(1,3),  BTN_SIZE(1,1), F("White Chocolate"))
+       .colors(action_btn)
+       .tag(1) .button( BTN_POS(2,3), BTN_SIZE(1,1), GET_TEXT_F(MSG_BACK));
+  }
+}
+
+bool PreheatMenu::onTouchEnd(uint8_t tag) {
+  switch (tag) {
+    case 1: GOTO_PREVIOUS();                   break;
+    case 2:
+      #ifdef COCOA_PRESS_PREHEAT_DARK_CHOCOLATE_SCRIPT
+        injectCommands_P(PSTR(COCOA_PRESS_PREHEAT_DARK_CHOCOLATE_SCRIPT));
+      #endif
+      GOTO_SCREEN(PreheatTimerScreen);
+      break;
+    case 3:
+      #ifdef COCOA_PRESS_PREHEAT_MILK_CHOCOLATE_SCRIPT
+        injectCommands_P(PSTR(COCOA_PRESS_PREHEAT_MILK_CHOCOLATE_SCRIPT));
+      #endif
+      GOTO_SCREEN(PreheatTimerScreen);
+      break;
+    case 4:
+      #ifdef COCOA_PRESS_PREHEAT_WHITE_CHOCOLATE_SCRIPT
+        injectCommands_P(PSTR(COCOA_PRESS_PREHEAT_WHITE_CHOCOLATE_SCRIPT));
+      #endif
+      GOTO_SCREEN(PreheatTimerScreen);
+      break;
+    default: return false;
+  }
+  return true;
+}
+
+#endif // TOUCH_UI_FTDI_EVE

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/preheat_timer_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/preheat_timer_screen.cpp
@@ -77,9 +77,6 @@ void PreheatTimerScreen::draw_interaction_buttons(draw_mode_t what) {
 
 void PreheatTimerScreen::onEntry() {
   screen_data.PreheatTimerScreen.start_ms = millis();
-  #ifdef COCOA_PRESS_PREHEAT_SCRIPT
-    injectCommands_P(PSTR(COCOA_PRESS_PREHEAT_SCRIPT));
-  #endif
 }
 
 void PreheatTimerScreen::onRedraw(draw_mode_t what) {

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.cpp
@@ -105,6 +105,7 @@ SCREEN_TABLE {
   DECL_SCREEN(BioConfirmHomeE),
 #endif
 #if ENABLED(TOUCH_UI_COCOA_PRESS)
+  DECL_SCREEN(PreheatMenu),
   DECL_SCREEN(PreheatTimerScreen),
 #endif
 #if ENABLED(TOUCH_UI_DEVELOPER_MENU)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
@@ -76,6 +76,7 @@ enum {
   PRINTING_SCREEN_CACHE,
 #endif
 #if ENABLED(TOUCH_UI_COCOA_PRESS)
+  PREHEAT_MENU_CACHE,
   PREHEAT_TIMER_SCREEN_CACHE,
 #endif
   CHANGE_FILAMENT_SCREEN_CACHE,
@@ -99,7 +100,7 @@ enum {
 
 class BaseScreen : public UIScreen {
   protected:
-    #ifdef LCD_TIMEOUT_TO_STATUS
+    #if LCD_TIMEOUT_TO_STATUS
       static uint32_t last_interaction;
     #endif
 
@@ -314,6 +315,12 @@ class StatusScreen : public BaseScreen, public CachedScreen<STATUS_SCREEN_CACHE,
 #endif
 
 #if ENABLED(TOUCH_UI_COCOA_PRESS)
+  class PreheatMenu : public BaseScreen, public CachedScreen<PREHEAT_MENU_CACHE> {
+    public:
+      static void onRedraw(draw_mode_t);
+      static bool onTouchEnd(uint8_t tag);
+  };
+
   class PreheatTimerScreen : public BaseScreen, public CachedScreen<PREHEAT_TIMER_SCREEN_CACHE> {
     private:
       static uint16_t secondsRemaining();

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/status_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/status_screen.cpp
@@ -33,9 +33,9 @@ using namespace FTDI;
 using namespace Theme;
 
 #ifdef TOUCH_UI_PORTRAIT
-  #define GRID_ROWS 8
+    #define GRID_ROWS 8
 #else
-  #define GRID_ROWS 8
+    #define GRID_ROWS 8
 #endif
 
 void StatusScreen::draw_axis_position(draw_mode_t what) {
@@ -43,41 +43,41 @@ void StatusScreen::draw_axis_position(draw_mode_t what) {
 
   #define GRID_COLS 3
 
+  #ifdef TOUCH_UI_PORTRAIT
+    #define X_LBL_POS  BTN_POS(1,5), BTN_SIZE(1,1)
+    #define Y_LBL_POS  BTN_POS(1,6), BTN_SIZE(1,1)
+    #define Z_LBL_POS  BTN_POS(1,7), BTN_SIZE(1,1)
+    #define X_VAL_POS  BTN_POS(2,5), BTN_SIZE(2,1)
+    #define Y_VAL_POS  BTN_POS(2,6), BTN_SIZE(2,1)
+    #define Z_VAL_POS  BTN_POS(2,7), BTN_SIZE(2,1)
+  #else
+    #define X_LBL_POS  BTN_POS(1,5), BTN_SIZE(1,1)
+    #define Y_LBL_POS  BTN_POS(2,5), BTN_SIZE(1,1)
+    #define Z_LBL_POS  BTN_POS(3,5), BTN_SIZE(1,1)
+    #define X_VAL_POS  BTN_POS(1,6), BTN_SIZE(1,1)
+    #define Y_VAL_POS  BTN_POS(2,6), BTN_SIZE(1,1)
+    #define Z_VAL_POS  BTN_POS(3,6), BTN_SIZE(1,1)
+  #endif
+
+  #define _UNION_POS(x1,y1,w1,h1,x2,y2,w2,h2) x1,y1,max(x1+w1,x2+w2)-x1,max(y1+h1,y2+h2)-y1
+  #define UNION_POS(p1, p2) _UNION_POS(p1, p2)
+
   if (what & BACKGROUND) {
     cmd.tag(6)
-    #ifdef TOUCH_UI_PORTRAIT
-      .fgcolor(Theme::axis_label)
-        .font(Theme::font_large)
-                         .button( BTN_POS(1,5), BTN_SIZE(2,1), F(""), OPT_FLAT)
-                         .button( BTN_POS(1,6), BTN_SIZE(2,1), F(""), OPT_FLAT)
-                         .button( BTN_POS(1,7), BTN_SIZE(2,1), F(""), OPT_FLAT)
-
-        .font(Theme::font_small)
-                         .text  ( BTN_POS(1,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_AXIS_X))
-                         .text  ( BTN_POS(1,6), BTN_SIZE(1,1), GET_TEXT_F(MSG_AXIS_Y))
-                         .text  ( BTN_POS(1,7), BTN_SIZE(1,1), GET_TEXT_F(MSG_AXIS_Z))
-
-        .font(Theme::font_medium)
-        .fgcolor(Theme::x_axis) .button( BTN_POS(2,5), BTN_SIZE(2,1), F(""), OPT_FLAT)
-        .fgcolor(Theme::y_axis) .button( BTN_POS(2,6), BTN_SIZE(2,1), F(""), OPT_FLAT)
-        .fgcolor(Theme::z_axis) .button( BTN_POS(2,7), BTN_SIZE(2,1), F(""), OPT_FLAT);
-    #else
-      .fgcolor(Theme::axis_label)
-        .font(Theme::font_large)
-                         .button( BTN_POS(1,5), BTN_SIZE(1,2), F(""),  OPT_FLAT)
-                         .button( BTN_POS(2,5), BTN_SIZE(1,2), F(""),  OPT_FLAT)
-                         .button( BTN_POS(3,5), BTN_SIZE(1,2), F(""),  OPT_FLAT)
-
-        .font(Theme::font_small)
-                         .text  ( BTN_POS(1,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_AXIS_X))
-                         .text  ( BTN_POS(2,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_AXIS_Y))
-                         .text  ( BTN_POS(3,5), BTN_SIZE(1,1), GET_TEXT_F(MSG_AXIS_Z))
-                         .font(Theme::font_medium)
-
-        .fgcolor(Theme::x_axis) .button( BTN_POS(1,6), BTN_SIZE(1,1), F(""), OPT_FLAT)
-        .fgcolor(Theme::y_axis) .button( BTN_POS(2,6), BTN_SIZE(1,1), F(""), OPT_FLAT)
-        .fgcolor(Theme::z_axis) .button( BTN_POS(3,6), BTN_SIZE(1,1), F(""), OPT_FLAT);
-    #endif
+       .fgcolor(Theme::axis_label)
+       .font(Theme::font_large)
+                               .button( UNION_POS(X_LBL_POS, X_VAL_POS), F(""), OPT_FLAT)
+                               .button( UNION_POS(Y_LBL_POS, Y_VAL_POS), F(""), OPT_FLAT)
+                               .button( UNION_POS(Z_LBL_POS, Z_VAL_POS), F(""), OPT_FLAT)
+       .font(Theme::font_medium)
+       .fgcolor(Theme::x_axis) .button( X_VAL_POS, F(""), OPT_FLAT)
+       .fgcolor(Theme::y_axis) .button( Y_VAL_POS, F(""), OPT_FLAT)
+       .fgcolor(Theme::z_axis) .button( Z_VAL_POS, F(""), OPT_FLAT)
+       .font(Theme::font_small)
+                               .text  ( X_LBL_POS, GET_TEXT_F(MSG_AXIS_X))
+                               .text  ( Y_LBL_POS, GET_TEXT_F(MSG_AXIS_Y))
+                               .text  ( Z_LBL_POS, GET_TEXT_F(MSG_AXIS_Z))
+       .colors(normal_btn);
   }
 
   if (what & FOREGROUND) {
@@ -101,16 +101,11 @@ void StatusScreen::draw_axis_position(draw_mode_t what) {
     else
       strcpy_P(z_str, PSTR("?"));
 
-    cmd.tag(6).font(Theme::font_medium)
-    #ifdef TOUCH_UI_PORTRAIT
-         .text  ( BTN_POS(2,5), BTN_SIZE(2,1), x_str)
-         .text  ( BTN_POS(2,6), BTN_SIZE(2,1), y_str)
-         .text  ( BTN_POS(2,7), BTN_SIZE(2,1), z_str);
-    #else
-         .text  ( BTN_POS(1,6), BTN_SIZE(1,1), x_str)
-         .text  ( BTN_POS(2,6), BTN_SIZE(1,1), y_str)
-         .text  ( BTN_POS(3,6), BTN_SIZE(1,1), z_str);
-    #endif
+    cmd.tag(6)
+       .font(Theme::font_medium)
+       .text  ( X_VAL_POS, x_str)
+       .text  ( Y_VAL_POS, y_str)
+       .text  ( Z_VAL_POS, z_str);
   }
 
   #undef GRID_COLS
@@ -125,49 +120,49 @@ void StatusScreen::draw_axis_position(draw_mode_t what) {
 void StatusScreen::draw_temperature(draw_mode_t what) {
   using namespace Theme;
 
+  #define TEMP_RECT_1 BTN_POS(1,1), BTN_SIZE(4,2)
+  #define TEMP_RECT_2 BTN_POS(1,1), BTN_SIZE(8,1)
+  #define NOZ_1_POS   BTN_POS(1,1), BTN_SIZE(4,1)
+  #define NOZ_2_POS   BTN_POS(5,1), BTN_SIZE(4,1)
+  #define BED_POS     BTN_POS(1,2), BTN_SIZE(4,1)
+  #define FAN_POS     BTN_POS(5,2), BTN_SIZE(4,1)
+
+  #define _ICON_POS(x,y,w,h) x, y, w/4, h
+  #define _TEXT_POS(x,y,w,h) x + w/4, y, w - w/4, h
+  #define ICON_POS(pos) _ICON_POS(pos)
+  #define TEXT_POS(pos) _TEXT_POS(pos)
+
   CommandProcessor cmd;
 
   if (what & BACKGROUND) {
     cmd.font(Theme::font_small)
-    #ifdef TOUCH_UI_PORTRAIT
        .tag(5)
-       .fgcolor(temp)      .button( BTN_POS(1,1), BTN_SIZE(4,2), F(""), OPT_FLAT)
-                                  .button( BTN_POS(1,1), BTN_SIZE(8,1), F(""), OPT_FLAT)
-       .fgcolor(fan_speed) .button( BTN_POS(5,2), BTN_SIZE(4,1), F(""), OPT_FLAT)
-       .tag(0)
-       .fgcolor(progress)  .button( BTN_POS(1,3), BTN_SIZE(4,1), F(""), OPT_FLAT)
-                                  .button( BTN_POS(5,3), BTN_SIZE(4,1), F(""), OPT_FLAT);
-    #else
-       .tag(5)
-       .fgcolor(temp)      .button( BTN_POS(1,1), BTN_SIZE(4,2), F(""), OPT_FLAT)
-                                  .button( BTN_POS(1,1), BTN_SIZE(8,1), F(""), OPT_FLAT)
-       .fgcolor(fan_speed) .button( BTN_POS(5,2), BTN_SIZE(4,1), F(""), OPT_FLAT)
-       .tag(0)
-       .fgcolor(progress)  .button( BTN_POS(9,1), BTN_SIZE(4,1), F(""), OPT_FLAT)
-                                  .button( BTN_POS(9,2), BTN_SIZE(4,1), F(""), OPT_FLAT);
-    #endif
+       .fgcolor(temp)     .button( TEMP_RECT_1, F(""), OPT_FLAT)
+                          .button( TEMP_RECT_2, F(""), OPT_FLAT)
+       .fgcolor(fan_speed).button( FAN_POS,     F(""), OPT_FLAT)
+       .tag(0);
 
     // Draw Extruder Bitmap on Extruder Temperature Button
 
     cmd.tag(5)
-       .cmd(BITMAP_SOURCE(Extruder_Icon_Info))
-       .cmd(BITMAP_LAYOUT(Extruder_Icon_Info))
-       .cmd(BITMAP_SIZE  (Extruder_Icon_Info))
-       .icon (BTN_POS(1,1), BTN_SIZE(1,1),  Extruder_Icon_Info, icon_scale)
-       .icon (BTN_POS(5,1), BTN_SIZE(1,1),  Extruder_Icon_Info, icon_scale);
+       .cmd (BITMAP_SOURCE(Extruder_Icon_Info))
+       .cmd (BITMAP_LAYOUT(Extruder_Icon_Info))
+       .cmd (BITMAP_SIZE  (Extruder_Icon_Info))
+       .icon(ICON_POS(NOZ_1_POS), Extruder_Icon_Info, icon_scale)
+       .icon(ICON_POS(NOZ_2_POS), Extruder_Icon_Info, icon_scale);
 
     // Draw Bed Heat Bitmap on Bed Heat Button
-    cmd.cmd(BITMAP_SOURCE(Bed_Heat_Icon_Info))
-       .cmd(BITMAP_LAYOUT(Bed_Heat_Icon_Info))
-       .cmd(BITMAP_SIZE  (Bed_Heat_Icon_Info))
-       .icon (BTN_POS(1,2), BTN_SIZE(1,1), Bed_Heat_Icon_Info, icon_scale);
+    cmd.cmd (BITMAP_SOURCE(Bed_Heat_Icon_Info))
+       .cmd (BITMAP_LAYOUT(Bed_Heat_Icon_Info))
+       .cmd (BITMAP_SIZE  (Bed_Heat_Icon_Info))
+       .icon(ICON_POS(BED_POS), Bed_Heat_Icon_Info, icon_scale);
 
     // Draw Fan Percent Bitmap on Bed Heat Button
 
-    cmd.cmd(BITMAP_SOURCE(Fan_Icon_Info))
-       .cmd(BITMAP_LAYOUT(Fan_Icon_Info))
-       .cmd(BITMAP_SIZE  (Fan_Icon_Info))
-       .icon  (BTN_POS(5,2), BTN_SIZE(1,1), Fan_Icon_Info, icon_scale);
+    cmd.cmd (BITMAP_SOURCE(Fan_Icon_Info))
+       .cmd (BITMAP_LAYOUT(Fan_Icon_Info))
+       .cmd (BITMAP_SIZE  (Fan_Icon_Info))
+       .icon(ICON_POS(FAN_POS), Fan_Icon_Info, icon_scale);
 
     #ifdef TOUCH_UI_USE_UTF8
       load_utf8_bitmaps(cmd); // Restore font bitmap handles
@@ -212,10 +207,10 @@ void StatusScreen::draw_temperature(draw_mode_t what) {
 
     cmd.tag(5)
        .font(font_medium)
-       .text(BTN_POS(2,1), BTN_SIZE(3,1), e0_str)
-       .text(BTN_POS(6,1), BTN_SIZE(3,1), e1_str)
-       .text(BTN_POS(2,2), BTN_SIZE(3,1), bed_str)
-       .text(BTN_POS(6,2), BTN_SIZE(3,1), fan_str);
+       .text(TEXT_POS(NOZ_1_POS), e0_str)
+       .text(TEXT_POS(NOZ_2_POS), e1_str)
+       .text(TEXT_POS(BED_POS), bed_str)
+       .text(TEXT_POS(FAN_POS), fan_str);
   }
 }
 
@@ -225,15 +220,18 @@ void StatusScreen::draw_progress(draw_mode_t what) {
 
   CommandProcessor cmd;
 
+  #if ENABLED(TOUCH_UI_PORTRAIT)
+    #define TIME_POS     BTN_POS(1,3), BTN_SIZE(4,1)
+    #define PROGRESS_POS BTN_POS(5,3), BTN_SIZE(4,1)
+  #else
+    #define TIME_POS     BTN_POS(9,1), BTN_SIZE(4,1)
+    #define PROGRESS_POS BTN_POS(9,2), BTN_SIZE(4,1)
+  #endif
+
   if (what & BACKGROUND) {
     cmd.tag(0).font(font_medium)
-    #ifdef TOUCH_UI_PORTRAIT
-       .fgcolor(progress) .button(BTN_POS(1,3), BTN_SIZE(4,1), F(""), OPT_FLAT)
-                                 .button(BTN_POS(5,3), BTN_SIZE(4,1), F(""), OPT_FLAT);
-    #else
-       .fgcolor(progress) .button(BTN_POS(9,1), BTN_SIZE(4,1), F(""), OPT_FLAT)
-                                 .button(BTN_POS(9,2), BTN_SIZE(4,1), F(""), OPT_FLAT);
-    #endif
+       .fgcolor(progress).button(TIME_POS,     F(""), OPT_FLAT)
+                         .button(PROGRESS_POS, F(""), OPT_FLAT);
   }
 
   if (what & FOREGROUND) {
@@ -248,13 +246,8 @@ void StatusScreen::draw_progress(draw_mode_t what) {
     sprintf_P(progress_str, PSTR("%-3d %%"),      getProgress_percent() );
 
     cmd.font(font_medium)
-    #ifdef TOUCH_UI_PORTRAIT
-       .tag(0).text(BTN_POS(1,3), BTN_SIZE(4,1), time_str)
-              .text(BTN_POS(5,3), BTN_SIZE(4,1), progress_str);
-    #else
-       .tag(0).text(BTN_POS(9,1), BTN_SIZE(4,1), time_str)
-              .text(BTN_POS(9,2), BTN_SIZE(4,1), progress_str);
-    #endif
+       .tag(0).text(TIME_POS, time_str)
+              .text(PROGRESS_POS, progress_str);
   }
 }
 
@@ -266,6 +259,14 @@ void StatusScreen::draw_interaction_buttons(draw_mode_t what) {
   if (what & FOREGROUND) {
     using namespace ExtUI;
 
+  #if ENABLED(TOUCH_UI_PORTRAIT)
+    #define MEDIA_BTN_POS  BTN_POS(1,8), BTN_SIZE(2,1)
+    #define MENU_BTN_POS   BTN_POS(3,8), BTN_SIZE(2,1)
+  #else
+    #define MEDIA_BTN_POS  BTN_POS(1,7), BTN_SIZE(2,2)
+    #define MENU_BTN_POS   BTN_POS(3,7), BTN_SIZE(2,2)
+  #endif
+
     const bool has_media = isMediaInserted() && !isPrintingFromMedia();
 
     CommandProcessor cmd;
@@ -273,42 +274,29 @@ void StatusScreen::draw_interaction_buttons(draw_mode_t what) {
        .font(Theme::font_medium)
        .enabled(has_media)
        .colors(has_media ? action_btn : normal_btn)
-       .tag(3).button(
-          #ifdef TOUCH_UI_PORTRAIT
-            BTN_POS(1,8), BTN_SIZE(2,1),
-          #else
-            BTN_POS(1,7), BTN_SIZE(2,2),
-          #endif
-          isPrintingFromMedia() ? GET_TEXT_F(MSG_PRINTING) : GET_TEXT_F(MSG_BUTTON_MEDIA)
-        ).colors(!has_media ? action_btn : normal_btn)
-      #ifdef TOUCH_UI_PORTRAIT
-       .tag(4).button( BTN_POS(3,8), BTN_SIZE(2,1), GET_TEXT_F(MSG_BUTTON_MENU));
-      #else
-       .tag(4).button( BTN_POS(3,7), BTN_SIZE(2,2), GET_TEXT_F(MSG_BUTTON_MENU));
-    #endif
+       .tag(3).button(MEDIA_BTN_POS, isPrintingFromMedia() ? GET_TEXT_F(MSG_PRINTING) : GET_TEXT_F(MSG_BUTTON_MEDIA))
+       .colors(!has_media ? action_btn : normal_btn)
+       .tag(4).button( MENU_BTN_POS, GET_TEXT_F(MSG_BUTTON_MENU));
   }
   #undef  GRID_COLS
 }
 
 void StatusScreen::draw_status_message(draw_mode_t what, const char* message) {
   #define GRID_COLS 1
+
+  #if ENABLED(TOUCH_UI_PORTRAIT)
+    #define STATUS_POS  BTN_POS(1,4), BTN_SIZE(1,1)
+  #else
+    #define STATUS_POS  BTN_POS(1,3), BTN_SIZE(1,2)
+  #endif
+
   if (what & BACKGROUND) {
     CommandProcessor cmd;
     cmd.fgcolor(Theme::status_msg)
        .tag(0)
-    #ifdef TOUCH_UI_PORTRAIT
-       .button( BTN_POS(1,4), BTN_SIZE(1,1), F(""), OPT_FLAT);
-    #else
-       .button( BTN_POS(1,3), BTN_SIZE(1,2), F(""), OPT_FLAT);
-    #endif
+       .button( STATUS_POS, F(""), OPT_FLAT);
 
-    draw_text_box(cmd,
-    #ifdef TOUCH_UI_PORTRAIT
-      BTN_POS(1,4), BTN_SIZE(1,1),
-    #else
-      BTN_POS(1,3), BTN_SIZE(1,2),
-    #endif
-      message, OPT_CENTER, font_large);
+    draw_text_box(cmd, STATUS_POS, message, OPT_CENTER, font_large);
   }
   #undef  GRID_COLS
 }
@@ -326,10 +314,10 @@ void StatusScreen::setStatusMessage(const char* message) {
      .cmd(CLEAR(true,true,true));
 
   draw_temperature(BACKGROUND);
-  draw_progress(BACKGROUND);
-  draw_axis_position(BACKGROUND);
   draw_status_message(BACKGROUND, message);
   draw_interaction_buttons(BACKGROUND);
+  draw_progress(BACKGROUND);
+  draw_axis_position(BACKGROUND);
 
   storeBackground();
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/colors.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/colors.h
@@ -24,121 +24,149 @@
 #pragma once
 
 namespace Theme {
-  #ifdef TOUCH_UI_LULZBOT_BIO
-    // The Lulzbot Bio uses the color PANTONE 2175C on the case silkscreen.
-    // This translates to HSL(208°, 100%, 39%) as an accent color on the GUI.
+  #if ENABLED(TOUCH_UI_COCOA_THEME)
+    constexpr int      accent_hue           = 23;
 
-    constexpr int   accent_hue          = 208;
-    constexpr float accent_sat          = 0.5;
-
-    constexpr uint32_t logo_bg_rgb      = 0xffffff;
-    constexpr uint32_t logo_fill_rgb    = 0xffffff;
-    constexpr uint32_t logo_stroke_rgb  = hsl_to_rgb(accent_hue, 1.0, 0.39);
+    // Browns and Oranges
+    constexpr uint32_t accent_color_1       = hsl_to_rgb(12.8,0.597,0.263); // Darkest
+    constexpr uint32_t accent_color_2       = hsl_to_rgb(12.8,0.597,0.263);
+    constexpr uint32_t accent_color_3       = hsl_to_rgb( 9.6,0.664,0.443);
+    constexpr uint32_t accent_color_4       = hsl_to_rgb(16.3,0.873,0.537);
+    constexpr uint32_t accent_color_5       = hsl_to_rgb(23.0,0.889,0.539);
+    constexpr uint32_t accent_color_6       = hsl_to_rgb(23.0,0.889,0.539); // Lightest
   #else
-    // The Lulzbot logo uses the color PANTONE 382c.
-    // This translates to HSL(68°, 68%, 52%) as an accent color on the GUI.
+    // Use linear accent colors
 
-    constexpr int   accent_hue          = 68;
-    constexpr float accent_sat          = 0.68;
+    #if ANY(TOUCH_UI_ROYAL_THEME, TOUCH_UI_FROZEN_THEME)
+        // Dark blue accent colors
+        constexpr int      accent_hue       = 216;
+        constexpr float    accent_sat       = 0.7;
+    #else
+        // Green accent colors
+        constexpr int      accent_hue       = 68;
+        constexpr float    accent_sat       = 0.68;
+    #endif
 
-    constexpr uint32_t logo_bg_rgb      = hsl_to_rgb(accent_hue, 0.77, 0.64);
-    constexpr uint32_t logo_fill_rgb    = hsl_to_rgb(accent_hue, 0.68, 0.52); // Lulzbot Green
-    constexpr uint32_t logo_stroke_rgb  = 0x000000;
-  #endif
-
-  // Shades of accent color
-
-  #ifdef TOUCH_UI_COCOA_PRESS
-    constexpr uint32_t accent_color_1   = hsl_to_rgb(12.8,0.597,0.263); // Darkest
-    constexpr uint32_t accent_color_2   = hsl_to_rgb(12.8,0.597,0.263);
-    constexpr uint32_t accent_color_3   = hsl_to_rgb( 9.6,0.664,0.443);
-    constexpr uint32_t accent_color_4   = hsl_to_rgb(16.3,0.873,0.537);
-    constexpr uint32_t accent_color_5   = hsl_to_rgb(23.0,0.889,0.539);
-    constexpr uint32_t accent_color_6   = hsl_to_rgb(23.0,0.889,0.539); // Lightest
-  #else
-    constexpr uint32_t accent_color_1   = hsl_to_rgb(accent_hue, accent_sat, 0.26); // Darkest
-    constexpr uint32_t accent_color_2   = hsl_to_rgb(accent_hue, accent_sat, 0.39);
-    constexpr uint32_t accent_color_3   = hsl_to_rgb(accent_hue, accent_sat, 0.52);
-    constexpr uint32_t accent_color_4   = hsl_to_rgb(accent_hue, accent_sat, 0.65);
-    constexpr uint32_t accent_color_5   = hsl_to_rgb(accent_hue, accent_sat, 0.78);
-    constexpr uint32_t accent_color_6   = hsl_to_rgb(accent_hue, accent_sat, 0.91); // Lightest
+    // Shades of accent color
+    constexpr uint32_t accent_color_0       = hsl_to_rgb(accent_hue, accent_sat, 0.15); // Darkest
+    constexpr uint32_t accent_color_1       = hsl_to_rgb(accent_hue, accent_sat, 0.26);
+    constexpr uint32_t accent_color_2       = hsl_to_rgb(accent_hue, accent_sat, 0.39);
+    constexpr uint32_t accent_color_3       = hsl_to_rgb(accent_hue, accent_sat, 0.52);
+    constexpr uint32_t accent_color_4       = hsl_to_rgb(accent_hue, accent_sat, 0.65);
+    constexpr uint32_t accent_color_5       = hsl_to_rgb(accent_hue, accent_sat, 0.78);
+    constexpr uint32_t accent_color_6       = hsl_to_rgb(accent_hue, accent_sat, 0.91); // Lightest
   #endif
 
   // Shades of gray
 
-  constexpr float gray_sat = 0.14;
+  constexpr float    gray_sat               = 0.14;
+  constexpr uint32_t gray_color_0           = hsl_to_rgb(accent_hue, gray_sat, 0.15); // Darkest
+  constexpr uint32_t gray_color_1           = hsl_to_rgb(accent_hue, gray_sat, 0.26);
+  constexpr uint32_t gray_color_2           = hsl_to_rgb(accent_hue, gray_sat, 0.39);
+  constexpr uint32_t gray_color_3           = hsl_to_rgb(accent_hue, gray_sat, 0.52);
+  constexpr uint32_t gray_color_4           = hsl_to_rgb(accent_hue, gray_sat, 0.65);
+  constexpr uint32_t gray_color_5           = hsl_to_rgb(accent_hue, gray_sat, 0.78);
+  constexpr uint32_t gray_color_6           = hsl_to_rgb(accent_hue, gray_sat, 0.91); // Lightest
 
-  constexpr uint32_t gray_color_1       = hsl_to_rgb(accent_hue, gray_sat, 0.26); // Darkest
-  constexpr uint32_t gray_color_2       = hsl_to_rgb(accent_hue, gray_sat, 0.39);
-  constexpr uint32_t gray_color_3       = hsl_to_rgb(accent_hue, gray_sat, 0.52);
-  constexpr uint32_t gray_color_4       = hsl_to_rgb(accent_hue, gray_sat, 0.65);
-  constexpr uint32_t gray_color_5       = hsl_to_rgb(accent_hue, gray_sat, 0.78);
-  constexpr uint32_t gray_color_6       = hsl_to_rgb(accent_hue, gray_sat, 0.91); // Lightest
+  #if ENABLED(TOUCH_UI_ROYAL_THEME)
+    constexpr uint32_t theme_darkest        = accent_color_1;
+    constexpr uint32_t theme_dark           = accent_color_4;
 
-  #if NONE(TOUCH_UI_LULZBOT_BIO, TOUCH_UI_COCOA_PRESS)
-    // Lulzbot TAZ Pro
-    constexpr uint32_t theme_darkest    = gray_color_1;
-    constexpr uint32_t theme_dark       = gray_color_2;
+    constexpr uint32_t bg_color             = gray_color_0;
+    constexpr uint32_t axis_label           = gray_color_1;
 
-    constexpr uint32_t bg_color         = theme_darkest;
-    constexpr uint32_t bg_text_disabled = theme_dark;
-    constexpr uint32_t bg_text_enabled  = 0xFFFFFF;
-    constexpr uint32_t bg_normal        = theme_darkest;
+    constexpr uint32_t bg_text_enabled      = accent_color_6;
+    constexpr uint32_t bg_text_disabled     = gray_color_0;
+    constexpr uint32_t bg_normal            = accent_color_4;
+    constexpr uint32_t fg_disabled          = gray_color_0;
+    constexpr uint32_t fg_normal            = accent_color_0;
+    constexpr uint32_t fg_action            = accent_color_1;
 
-    constexpr uint32_t fg_normal        = theme_dark;
-    constexpr uint32_t fg_action        = accent_color_2;
-    constexpr uint32_t fg_disabled      = theme_darkest;
+    constexpr uint32_t logo_bg_rgb          = accent_color_1;
+    constexpr uint32_t logo_fill_rgb        = accent_color_0;
+    constexpr uint32_t logo_stroke_rgb      = accent_color_4;
+  #elif ANY(TOUCH_UI_COCOA_THEME, TOUCH_UI_FROZEN_THEME)
+    constexpr uint32_t theme_darkest        = accent_color_1;
+    constexpr uint32_t theme_dark           = accent_color_4;
+
+    constexpr uint32_t bg_color             = 0xFFFFFF;
+    constexpr uint32_t axis_label           = gray_color_5;
+
+    constexpr uint32_t bg_text_enabled      = accent_color_1;
+    constexpr uint32_t bg_text_disabled     = gray_color_1;
+    constexpr uint32_t bg_normal            = accent_color_4;
+    constexpr uint32_t fg_disabled          = gray_color_6;
+    constexpr uint32_t fg_normal            = accent_color_1;
+    constexpr uint32_t fg_action            = accent_color_4;
+
+    constexpr uint32_t logo_bg_rgb          = accent_color_5;
+    constexpr uint32_t logo_fill_rgb        = accent_color_6;
+    constexpr uint32_t logo_stroke_rgb      = accent_color_2;
   #else
-    // Lulzbot Bio
-    constexpr uint32_t theme_darkest    = accent_color_1;
-    constexpr uint32_t theme_dark       = accent_color_4;
+    constexpr uint32_t theme_darkest        = gray_color_1;
+    constexpr uint32_t theme_dark           = gray_color_2;
 
-    constexpr uint32_t bg_color         = 0xFFFFFF;
-    constexpr uint32_t bg_text_disabled = gray_color_1;
-    constexpr uint32_t bg_text_enabled  = accent_color_1;
-    constexpr uint32_t bg_normal        = accent_color_4;
+    constexpr uint32_t bg_color             = gray_color_1;
+    constexpr uint32_t axis_label           = gray_color_2;
 
-    constexpr uint32_t fg_normal        = accent_color_1;
-    constexpr uint32_t fg_action        = accent_color_4;
-    constexpr uint32_t fg_disabled      = gray_color_6;
+    constexpr uint32_t bg_text_enabled      = 0xFFFFFF;
+    constexpr uint32_t bg_text_disabled     = gray_color_2;
+    constexpr uint32_t bg_normal            = gray_color_1;
+    constexpr uint32_t fg_disabled          = gray_color_1;
+    constexpr uint32_t fg_normal            = gray_color_2;
+    constexpr uint32_t fg_action            = accent_color_2;
 
-    constexpr uint32_t shadow_rgb       = gray_color_6;
-    constexpr uint32_t stroke_rgb       = accent_color_1;
-    constexpr uint32_t fill_rgb         = accent_color_3;
-    constexpr uint32_t syringe_rgb      = accent_color_5;
+    constexpr uint32_t logo_bg_rgb          = accent_color_4;
+    constexpr uint32_t logo_fill_rgb        = accent_color_3;
+    constexpr uint32_t logo_stroke_rgb      = 0x000000;
   #endif
 
-  constexpr uint32_t x_axis             = 0xFF0000;
-  constexpr uint32_t y_axis             = 0x00BB00;
-  constexpr uint32_t z_axis             = 0x0000BF;
-  constexpr uint32_t e_axis             = gray_color_2;
-  constexpr uint32_t feedrate           = gray_color_2;
-  constexpr uint32_t other              = gray_color_2;
+  constexpr uint32_t shadow_rgb             = gray_color_6;
+  constexpr uint32_t stroke_rgb             = accent_color_1;
+  constexpr uint32_t fill_rgb               = accent_color_3;
+  constexpr uint32_t syringe_rgb            = accent_color_5;
+
+  #if ENABLED(TOUCH_UI_ROYAL_THEME)
+    constexpr uint32_t x_axis               = hsl_to_rgb(0,   1.00, 0.26);
+    constexpr uint32_t y_axis               = hsl_to_rgb(120, 1.00, 0.13);
+    constexpr uint32_t z_axis               = hsl_to_rgb(240, 1.00, 0.10); 
+  #else
+    constexpr uint32_t x_axis               = hsl_to_rgb(0,   1.00, 0.5);
+    constexpr uint32_t y_axis               = hsl_to_rgb(120, 1.00, 0.37);
+    constexpr uint32_t z_axis               = hsl_to_rgb(240, 1.00, 0.37);
+  #endif
+  constexpr uint32_t e_axis                 = axis_label;
+  constexpr uint32_t feedrate               = axis_label;
+  constexpr uint32_t other                  = axis_label;
 
   // Status screen
-  constexpr uint32_t progress           = gray_color_2;
-  constexpr uint32_t status_msg         = gray_color_2;
-  constexpr uint32_t fan_speed          = 0x377198;
-  constexpr uint32_t temp               = 0x892c78;
-  constexpr uint32_t axis_label         = gray_color_2;
+  constexpr uint32_t progress               = axis_label;
+  constexpr uint32_t status_msg             = axis_label;
+  #if ENABLED(TOUCH_UI_ROYAL_THEME)
+    constexpr uint32_t fan_speed            = hsl_to_rgb(240, 0.5, 0.13);
+    constexpr uint32_t temp                 = hsl_to_rgb(343, 1.0, 0.23);
+  #else
+    constexpr uint32_t fan_speed            = hsl_to_rgb(204, 0.47, 0.41);
+    constexpr uint32_t temp                 = hsl_to_rgb(311, 0.51, 0.35);
+  #endif
 
-  constexpr uint32_t disabled_icon      = gray_color_1;
+  constexpr uint32_t disabled_icon          = gray_color_1;
 
   // Calibration Registers Screen
-  constexpr uint32_t transformA         = 0x3010D0;
-  constexpr uint32_t transformB         = 0x4010D0;
-  constexpr uint32_t transformC         = 0x5010D0;
-  constexpr uint32_t transformD         = 0x6010D0;
-  constexpr uint32_t transformE         = 0x7010D0;
-  constexpr uint32_t transformF         = 0x8010D0;
-  constexpr uint32_t transformVal       = 0x104010;
+  constexpr uint32_t transformA             = 0x3010D0;
+  constexpr uint32_t transformB             = 0x4010D0;
+  constexpr uint32_t transformC             = 0x5010D0;
+  constexpr uint32_t transformD             = 0x6010D0;
+  constexpr uint32_t transformE             = 0x7010D0;
+  constexpr uint32_t transformF             = 0x8010D0;
+  constexpr uint32_t transformVal           = 0x104010;
 
-  constexpr btn_colors disabled_btn     = {.bg = bg_color,      .grad = fg_disabled, .fg = fg_disabled,  .rgb = fg_disabled };
-  constexpr btn_colors normal_btn       = {.bg = fg_action,     .grad = 0xFFFFFF,    .fg = fg_normal,    .rgb = 0xFFFFFF };
-  constexpr btn_colors action_btn       = {.bg = bg_color,      .grad = 0xFFFFFF,    .fg = fg_action,    .rgb = 0xFFFFFF };
-  constexpr btn_colors red_btn          = {.bg = 0xFF5555,      .grad = 0xFFFFFF,    .fg = 0xFF0000,     .rgb = 0xFFFFFF };
-  constexpr btn_colors ui_slider        = {.bg = theme_darkest, .grad = 0xFFFFFF,    .fg = theme_dark,   .rgb = accent_color_3 };
-  constexpr btn_colors ui_toggle        = {.bg = theme_darkest, .grad = 0xFFFFFF,    .fg = theme_dark,   .rgb = 0xFFFFFF };
+  constexpr btn_colors disabled_btn         = {.bg = bg_color,      .grad = fg_disabled, .fg = fg_disabled,  .rgb = fg_disabled };
+  constexpr btn_colors normal_btn           = {.bg = fg_action,     .grad = 0xFFFFFF,    .fg = fg_normal,    .rgb = 0xFFFFFF };
+  constexpr btn_colors action_btn           = {.bg = bg_color,      .grad = 0xFFFFFF,    .fg = fg_action,    .rgb = 0xFFFFFF };
+  constexpr btn_colors red_btn              = {.bg = 0xFF5555,      .grad = 0xFFFFFF,    .fg = 0xFF0000,     .rgb = 0xFFFFFF };
+  constexpr btn_colors ui_slider            = {.bg = theme_darkest, .grad = 0xFFFFFF,    .fg = theme_dark,   .rgb = accent_color_3 };
+  constexpr btn_colors ui_toggle            = {.bg = theme_darkest, .grad = 0xFFFFFF,    .fg = theme_dark,   .rgb = 0xFFFFFF };
 
   // Temperature color scale
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/marlin_bootscreen_landscape.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/marlin_bootscreen_landscape.h
@@ -35,5 +35,5 @@ const PROGMEM uint16_t logo_stroke[] = {0xADF3, 0x546C, 0x419D, 0x546F, 0x3D05, 
 
 #define LOGO_BACKGROUND logo_bg_rgb
 #define LOGO_PAINT_PATHS \
-  LOGO_PAINT_PATH(logo_stroke_rgb, logo_stroke) \
-  LOGO_PAINT_PATH(logo_fill_rgb,   logo_fill)
+  LOGO_PAINT_PATH(logo_fill_rgb,   logo_fill) \
+  LOGO_PAINT_PATH(logo_stroke_rgb, logo_stroke)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/marlin_bootscreen_portrait.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/marlin_bootscreen_portrait.h
@@ -35,5 +35,5 @@ const PROGMEM uint16_t logo_stroke[] = {0x3C19, 0x70C5, 0x371A, 0x7159, 0x3302, 
 
 #define LOGO_BACKGROUND logo_bg_rgb
 #define LOGO_PAINT_PATHS \
-  LOGO_PAINT_PATH(logo_stroke_rgb, logo_stroke) \
-  LOGO_PAINT_PATH(logo_fill_rgb,   logo_fill)
+  LOGO_PAINT_PATH(logo_fill_rgb,   logo_fill) \
+  LOGO_PAINT_PATH(logo_stroke_rgb, logo_stroke)

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -341,10 +341,10 @@ namespace ExtUI {
   void onConfigurationStoreWritten(bool success);
   void onConfigurationStoreRead(bool success);
   #if ENABLED(POWER_LOSS_RECOVERY)
-    void OnPowerLossResume();
+    void onPowerLossResume();
   #endif
   #if HAS_PID_HEATING
-    void OnPidTuning(const result_t rst);
+    void onPidTuning(const result_t rst);
   #endif
 };
 

--- a/Marlin/src/lcd/extui_dgus_lcd.cpp
+++ b/Marlin/src/lcd/extui_dgus_lcd.cpp
@@ -123,7 +123,7 @@ namespace ExtUI {
   }
 
   #if ENABLED(POWER_LOSS_RECOVERY)
-    void OnPowerLossResume() {
+    void onPowerLossResume() {
       // Called on resume from power-loss
       ScreenHandler.GotoScreen(DGUSLCD_SCREEN_POWER_LOSS);
     }
@@ -131,9 +131,9 @@ namespace ExtUI {
 
 
   #if HAS_PID_HEATING
-    void OnPidTuning(const result_t rst) {
+    void onPidTuning(const result_t rst) {
       // Called for temperature PID tuning result
-      SERIAL_ECHOLNPAIR("OnPidTuning:",rst);
+      SERIAL_ECHOLNPAIR("onPidTuning:",rst);
       switch(rst) {
         case PID_BAD_EXTRUDER_NUM:
           ScreenHandler.setstatusmessagePGM(PSTR(STR_PID_BAD_EXTRUDER_NUM));

--- a/Marlin/src/lcd/extui_example.cpp
+++ b/Marlin/src/lcd/extui_example.cpp
@@ -94,13 +94,13 @@ namespace ExtUI {
   }
 
   #if ENABLED(POWER_LOSS_RECOVERY)
-    void OnPowerLossResume() {
+    void onPowerLossResume() {
       // Called on resume from power-loss
     }
   #endif
 
   #if HAS_PID_HEATING
-    void OnPidTuning(const result_t rst) {
+    void onPidTuning(const result_t rst) {
       // Called for temperature PID tuning result
     }
   #endif

--- a/Marlin/src/lcd/extui_malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui_malyan_lcd.cpp
@@ -483,7 +483,7 @@ namespace ExtUI {
   void onLoadSettings(const char*) {}
   void onConfigurationStoreWritten(bool) {}
   void onConfigurationStoreRead(bool) {}
-  void OnPidTuning(const result_t) {}
+  void onPidTuning(const result_t) {}
 }
 
 #endif // MALYAN_LCD

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -601,6 +601,9 @@ namespace Language_en {
   PROGMEM Language_Str MSG_BACKLASH_C                      = LCD_STR_C;
   PROGMEM Language_Str MSG_BACKLASH_CORRECTION             = _UxGT("Correction");
   PROGMEM Language_Str MSG_BACKLASH_SMOOTHING              = _UxGT("Smoothing");
+  
+  PROGMEM Language_Str MSG_LEVEL_X_AXIS                    = _UxGT("Level X Axis");
+  PROGMEM Language_Str MSG_AUTO_CALIBRATE                  = _UxGT("Auto Calibrate");
 }
 
 #if FAN_COUNT == 1

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -411,7 +411,7 @@ volatile bool Temperature::raw_temps_ready = false;
     if (target > GHV(BED_MAXTEMP - 10, temp_range[heater].maxtemp - 15)) {
       SERIAL_ECHOLNPGM(STR_PID_TEMP_TOO_HIGH);
       #if ENABLED(EXTENSIBLE_UI)
-        ExtUI::OnPidTuning(ExtUI::result_t::PID_TEMP_TOO_HIGH);
+        ExtUI::onPidTuning(ExtUI::result_t::PID_TEMP_TOO_HIGH);
       #endif
       return;
     }
@@ -527,7 +527,7 @@ volatile bool Temperature::raw_temps_ready = false;
       if (current_temp > target + MAX_OVERSHOOT_PID_AUTOTUNE) {
         SERIAL_ECHOLNPGM(STR_PID_TEMP_TOO_HIGH);
         #if ENABLED(EXTENSIBLE_UI)
-          ExtUI::OnPidTuning(ExtUI::result_t::PID_TEMP_TOO_HIGH);
+          ExtUI::onPidTuning(ExtUI::result_t::PID_TEMP_TOO_HIGH);
         #endif
         break;
       }
@@ -572,7 +572,7 @@ volatile bool Temperature::raw_temps_ready = false;
       #endif
       if (((ms - t1) + (ms - t2)) > (MAX_CYCLE_TIME_PID_AUTOTUNE * 60L * 1000L)) {
         #if ENABLED(EXTENSIBLE_UI)
-          ExtUI::OnPidTuning(ExtUI::result_t::PID_TUNING_TIMEOUT);
+          ExtUI::onPidTuning(ExtUI::result_t::PID_TUNING_TIMEOUT);
         #endif
         SERIAL_ECHOLNPGM(STR_PID_TIMEOUT);
         break;
@@ -623,7 +623,7 @@ volatile bool Temperature::raw_temps_ready = false;
           printerEventLEDs.onPidTuningDone(color);
         #endif
         #if ENABLED(EXTENSIBLE_UI)
-          ExtUI::OnPidTuning(ExtUI::result_t::PID_DONE);
+          ExtUI::onPidTuning(ExtUI::result_t::PID_DONE);
         #endif
 
         goto EXIT_M303;
@@ -637,7 +637,7 @@ volatile bool Temperature::raw_temps_ready = false;
       printerEventLEDs.onPidTuningDone(color);
     #endif
     #if ENABLED(EXTENSIBLE_UI)
-      ExtUI::OnPidTuning(ExtUI::result_t::PID_DONE);
+      ExtUI::onPidTuning(ExtUI::result_t::PID_DONE);
     #endif
 
     EXIT_M303:


### PR DESCRIPTION
### Description

- Fix check for whether LCD_TIMEOUT_TO_STATUS is enabled
- Fix incorrect debugging message
- Make capitalization of callbacks consistent.
- Allow Touch UI to use harware SPI on Einsy boards
- Move print stats to About Printer page.
- More generic about screen with GPL license.
- Added missing handler for power loss event
- Less code duplication on status screen and main/advanced menu; more legible
- Reorg of advanced and main menu to add more features
- Hide home Z button when using Z_SAFE_HOMING
- Fix compilation errors when certain features enabled
- Fixed missing labels in UI
- Improved color scheme
- Added new preheat menus
- Fixed incorrect rendering of Marlin logo on boot
- Added Level X Axis and Auto calibrate buttons

### Benefits

Makes the touch UI mo' betta'!
