### PR TITLE
Update fastio.h

### DIFF
--- a/Marlin/src/HAL/AVR/fastio.h
+++ b/Marlin/src/HAL/AVR/fastio.h
@@ -98,6 +98,7 @@
 
 #define SET_INPUT(IO)         _SET_INPUT(IO)
 #define SET_INPUT_PULLUP(IO)  do{ _SET_INPUT(IO); _WRITE(IO, HIGH); }while(0)
+#define SET_INPUT_PULLDOWN(IO)  do{ _SET_INPUT(IO); _WRITE(IO, LOW); }while(0)
 #define SET_OUTPUT(IO)        _SET_OUTPUT(IO)
 
 #define SET_PWM(IO)           SET_OUTPUT(IO)


### PR DESCRIPTION
ADD #define SET_INPUT_PULLDOWN(IO)  do{ _SET_INPUT(IO); _WRITE(IO, LOW); }while(0) 

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
Required to compile power loss recovery function on mega2560 with HIGH state pin 69 like geeetech a20
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
compile
<!-- What does this fix or improve? -->

### Related Issues
not compile
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
