### PR TITLE
Fix 2.0.5 Configuration link again

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -1,3 +1,3 @@
 # Where have all the configurations gone?
 
-## https://github.com/MarlinFirmware/Configurations/archive/release-2.0.5.2.zip
+## https://github.com/MarlinFirmware/Configurations/archive/release-2.0.5.zip


### PR DESCRIPTION
### Description

Fixing again:
The URL in the `2.0.x` [config readme](https://github.com/MarlinFirmware/Marlin/blob/2.0.x/config/README.md) points to https://github.com/MarlinFirmware/Configurations/archive/release-2.0.5.2.zip, but should point to https://github.com/MarlinFirmware/Configurations/archive/release-2.0.5.zip (no .2)

I know this won't pass checks, but the bad URL only exists in the `2.0.x` branch.

### Benefits

Correct URL for downloading configs.

### Related Issues

#17509, #17368, #17289, #17324, #17314