### PR TITLE
Refactor SD detect handler

### DIFF
--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -1139,28 +1139,7 @@ void MarlinUI::init() {
   ExtUI::onStartup();
 }
 
-void MarlinUI::update() {
-  #if ENABLED(SDSUPPORT)
-    static bool last_sd_status;
-    const bool sd_status = IS_SD_INSERTED();
-    if (sd_status != last_sd_status) {
-      last_sd_status = sd_status;
-      if (sd_status) {
-        card.mount();
-        if (card.isMounted())
-          ExtUI::onMediaInserted();
-        else
-          ExtUI::onMediaError();
-      }
-      else {
-        const bool ok = card.isMounted();
-        card.release();
-        if (ok) ExtUI::onMediaRemoved();
-      }
-    }
-  #endif // SDSUPPORT
-  ExtUI::onIdle();
-}
+void MarlinUI::update() { ExtUI::onIdle(); }
 
 void MarlinUI::kill_screen(PGM_P const error, PGM_P const component) {
   using namespace ExtUI;

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -274,6 +274,10 @@ public:
   // LCD implementations
   static void clear_lcd();
 
+  #if ENABLED(SDSUPPORT)
+    static void media_changed(const uint8_t old_stat, const uint8_t stat);
+  #endif
+
   #if HAS_SPI_LCD
     static bool detected();
     static void init_lcd();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -378,6 +378,35 @@ void CardReader::mount() {
   ui.refresh();
 }
 
+/**
+ * Handle SD card events
+ */
+void CardReader::manage_media() {
+  static uint8_t prev_stat = TERN(INIT_SDCARD_ON_BOOT, 2, 0);
+  uint8_t stat = uint8_t(IS_SD_INSERTED());
+  if (stat != prev_stat && ui.detected()) {
+
+    uint8_t old_stat = prev_stat;
+    prev_stat = stat;                 // Change now to prevent re-entry
+
+    if (stat) {                       // Media Inserted
+      safe_delay(500);                // Some boards need a delay to get settled
+      mount();                        // Try to mount the media
+      if (!isMounted()) stat = 0;     // Not mounted?
+    }
+    else {
+      #if PIN_EXISTS(SD_DETECT)
+        release();                    // Card is released
+      #endif
+    }
+
+    ui.media_changed(old_stat, stat); // Update the UI
+
+    if (stat && old_stat == 2)        // First mount?
+      beginautostart();               // Look for autostart files soon
+  }
+}
+
 void CardReader::release() {
   endFilePrint();
   flag.mounted = false;

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -381,6 +381,10 @@ void CardReader::mount() {
 /**
  * Handle SD card events
  */
+#if MB(FYSETC_CHEETAH)
+  #include "../module/stepper.h"
+#endif
+
 void CardReader::manage_media() {
   static uint8_t prev_stat = TERN(INIT_SDCARD_ON_BOOT, 2, 0);
   uint8_t stat = uint8_t(IS_SD_INSERTED());
@@ -392,6 +396,9 @@ void CardReader::manage_media() {
     if (stat) {                       // Media Inserted
       safe_delay(500);                // Some boards need a delay to get settled
       mount();                        // Try to mount the media
+      #if MB(FYSETC_CHEETAH)
+        reset_stepper_drivers();      // Workaround for Cheetah bug
+      #endif
       if (!isMounted()) stat = 0;     // Not mounted?
     }
     else {

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -73,6 +73,9 @@ public:
   static inline bool isMounted() { return flag.mounted; }
   static void ls();
 
+  // Handle media insert/remove
+  static void manage_media();
+
   // SD Card Logging
   static void openLogFile(char * const path);
   static void write_command(char * const buf);


### PR DESCRIPTION
**Problem:** SD card detection is handled in the LCD or ExtUI update which means isolated SD card readers don't get auto-mounted unless there is a controller. Also, if both UltraLCD and ExtUI LCD controllers are connected, both of them do SD detection and this may be potentially conflicting.

**Solution:** This PR moves SD card detection to the `CardReader` class and UI response to SD events to a separate `MarlinUI` method (instead of doing this in `MarlinUI::update`).

