### PR TITLE
BTT002 V1.0 (retail) uses STM32F407VGT6

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -319,7 +319,7 @@
 #define BOARD_BLACK_STM32F407ZE       4206  // BLACK_STM32F407ZE
 #define BOARD_STEVAL_3DP001V1         4207  // STEVAL-3DP001V1 3D PRINTER BOARD
 #define BOARD_BTT_SKR_PRO_V1_1        4208  // BigTreeTech SKR Pro v1.1 (STM32F407ZG)
-#define BOARD_BTT_BTT002_V1_0         4209  // BigTreeTech BTT002 v1.0 (STM32F407VE)
+#define BOARD_BTT_BTT002_V1_0         4209  // BigTreeTech BTT002 v1.0 (STM32F407VG)
 #define BOARD_BTT_GTR_V1_0            4210  // BigTreeTech GTR v1.0 (STM32F407IGT)
 #define BOARD_LERDGE_K                4211  // Lerdge K (STM32F407ZG)
 #define BOARD_LERDGE_X                4212  // Lerdge X (STM32F407VE)

--- a/buildroot/share/PlatformIO/boards/BigTree_Btt002.json
+++ b/buildroot/share/PlatformIO/boards/BigTree_Btt002.json
@@ -15,22 +15,22 @@
       ]
     ],
     "ldscript": "stm32f407xg.ld",
-    "mcu": "stm32f407vet6",
+    "mcu": "stm32f407vgt6",
     "variant": "BIGTREE_BTT002"
   },
   "debug": {
-    "jlink_device": "STM32F407VE",
+    "jlink_device": "STM32F407VG",
     "openocd_target": "stm32f4x",
     "svd_path": "STM32F40x.svd"
   },
   "frameworks": [
     "arduino"
   ],
-  "name": "STM32F407VE (192k RAM. 512k Flash)",
+  "name": "STM32F407VG (192k RAM. 1024k Flash)",
   "upload": {
     "disable_flushing": false,
     "maximum_ram_size": 131072,
-    "maximum_size": 524288,
+    "maximum_size": 1048576,
     "protocol": "stlink",
     "protocols": [
       "stlink",
@@ -41,6 +41,6 @@
     "use_1200bps_touch": false,
     "wait_for_upload_port": false
   },
-  "url": "http://www.st.com/en/microcontrollers/stm32f407ve.html",
+  "url": "http://www.st.com/en/microcontrollers/stm32f407vg.html",
   "vendor": "Generic"
 }

--- a/buildroot/share/tests/BIGTREE_BTT002-tests
+++ b/buildroot/share/tests/BIGTREE_BTT002-tests
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Build tests for STM32F407VET6 BigTreeTech BTT002
+# Build tests for STM32F407VGT6 BigTreeTech BTT002 V1.0
 #
 
 # exit on first failure

--- a/platformio.ini
+++ b/platformio.ini
@@ -708,14 +708,14 @@ src_filter        = ${common.default_src_filter} +<src/HAL/STM32>
 monitor_speed     = 250000
 
 #
-# BigTreeTech BTT002 (STM32F407VET6 ARM Cortex-M4)
+# BigTreeTech BTT002 V1.0 (STM32F407VGT6 ARM Cortex-M4)
 #
 [env:BIGTREE_BTT002]
 platform          = ststm32@5.6.0
 board             = BigTree_Btt002
 platform_packages = framework-arduinoststm32@>=3.107,<4
 build_flags       = ${common.build_flags}
-  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407VE\"
+  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407VG\"
   -DTARGET_STM32F4 -DSTM32F407_5VX -DVECT_TAB_OFFSET=0x8000
   -DHAVE_HWSERIAL2
   -DHAVE_HWSERIAL3


### PR DESCRIPTION
### Description

BigTreeTech's [BTT002 V1.0](https://www.biqu.equipment/products/bigtreetech-btt002-v1-0-32-bit-motherboard-with-tmc2209-driver-3d-printer-parts-for-i3-mk3) was updated from a `STM32F407VET6` (512k flash) to `STM32F407VGT6` (1024k flash) before launching to retail.

### Benefits

Marlin will have updated support for a retail BTT002 V1.0.

### Related Issues

None.

Edit: BigTreeTech didn't change the version number and I know we're trying to limit the amount of environments, so it didn't make sense to keep both due to limited distribution of the beta board.