### PR TITLE
Sort out USBComposite for STM32F1 confusion

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -320,7 +320,6 @@ extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-  USBComposite for STM32F1@==0.91
 lib_ignore        = Adafruit NeoPixel, SPI
 monitor_speed     = 115200
 
@@ -351,7 +350,6 @@ extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
-  USBComposite for STM32F1@==0.91
 lib_ignore        = Adafruit NeoPixel, SPI
 monitor_speed     = 115200
 
@@ -418,6 +416,7 @@ extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
+  USBComposite for STM32F1@==0.91
 lib_ignore        = Adafruit NeoPixel, SPI
 debug_tool        = stlink
 upload_protocol   = stlink


### PR DESCRIPTION
Also remove it from non-usbcomposite environments

### Requirements

* BTT SKR E3 DIP 1.0 with RET6 mcu

### Description

This adds support to build USB composite like the RCT6 boards

### Benefits

parity between BTT SKR E3/DIP environments

