### PR TITLE
Archim Fix p.io upload issues, and Arduino IDE LCD issue.

### DIFF
--- a/Marlin/src/HAL/DUE/upload_extra_script.py
+++ b/Marlin/src/HAL/DUE/upload_extra_script.py
@@ -1,0 +1,18 @@
+#
+# Set upload_command
+#
+#  Windows: bossac.exe
+#  Other: leave unchanged
+#
+
+import platform
+current_OS = platform.system()
+
+if current_OS == 'Windows':
+
+	Import("env")
+
+	# Use bossac.exe on Windows
+	env.Replace(
+	    UPLOADCMD="bossac --info --unlock --write --verify --reset --erase -U false --boot"
+	)

--- a/Marlin/src/HAL/DUE/usb/conf_usb.h
+++ b/Marlin/src/HAL/DUE/usb/conf_usb.h
@@ -78,10 +78,6 @@
 //! To define a Full speed device
 //#define USB_DEVICE_FULL_SPEED
 
-#if MB(ARCHIM1)
-  #define USB_DEVICE_FULL_SPEED
-#endif
-
 //! To authorize the High speed
 #ifndef USB_DEVICE_FULL_SPEED
   #if (UC3A3||UC3A4)

--- a/platformio.ini
+++ b/platformio.ini
@@ -215,6 +215,7 @@ board         = due
 src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
 build_flags   = ${common.build_flags}
   -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
+upload_command = bossac --info --unlock --write --verify --reset --erase -U false --boot $SOURCE
 
 [env:DUE_archim_debug]
 # Used when WATCHDOG_RESET_MANUAL is enabled
@@ -224,6 +225,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
 build_flags   = ${common.build_flags}
   -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
   -funwind-tables -mpoke-function-name
+upload_command = bossac --info --unlock --write --verify --reset --erase -U false --boot $SOURCE
 
 #
 # NXP LPC176x ARM Cortex-M3

--- a/platformio.ini
+++ b/platformio.ini
@@ -215,7 +215,7 @@ board         = due
 src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
 build_flags   = ${common.build_flags}
   -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
-upload_command = bossac --info --unlock --write --verify --reset --erase -U false --boot $SOURCE
+extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
 
 [env:DUE_archim_debug]
 # Used when WATCHDOG_RESET_MANUAL is enabled
@@ -225,7 +225,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
 build_flags   = ${common.build_flags}
   -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
   -funwind-tables -mpoke-function-name
-upload_command = bossac --info --unlock --write --verify --reset --erase -U false --boot $SOURCE
+extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
 
 #
 # NXP LPC176x ARM Cortex-M3


### PR DESCRIPTION
I have been working with Ultimachine the last few days to fix these issues. 

1-The Archim p.io updates from last night compile fine but will not upload, the added line fixes that (windows 10, VSC if that matters). 

We had been using;

```
[env:DUE_ARCHIM]
platform      = atmelsam
framework     = arduino
board         = due
build_flags   = -DARDUINO_SAM_ARCHIM ${common.build_flags}
lib_deps      = 
  LiquidCrystal
  https://github.com/MarlinFirmware/U8glib-HAL/archive/dev.zip
  ${common.lib_deps}
lib_ignore    = c1921b4
upload_command = bossac --info --unlock --write --verify --reset --erase -U false --boot $SOURCE

```
I am not sure if there are any important differences, what I just submitted seems to work perfectly.

2-The removed USB lines were a fix we submitted a year or so back that is no longer needed. Those lines didn't seem to do anything when flashed with P.io (it worked fine with them) but would crash the board on reset if flashed with Arduino IDE for some reason.