### PR TITLE
Small corrections in Galician language

### DIFF
--- a/Marlin/src/lcd/language/language_gl.h
+++ b/Marlin/src/lcd/language/language_gl.h
@@ -323,6 +323,7 @@ namespace Language_gl {
   PROGMEM Language_Str MSG_ERR_EEPROM_CRC                  = _UxGT("Erro: CRC EEPROM");
   PROGMEM Language_Str MSG_ERR_EEPROM_INDEX                = _UxGT("Erro: Índice EEPROM");
   PROGMEM Language_Str MSG_ERR_EEPROM_VERSION              = _UxGT("Erro: Versión EEPROM");
+  PROGMEM Language_Str MSG_SETTINGS_STORED                 = _UxGT("Config Gardada");
   PROGMEM Language_Str MSG_MEDIA_UPDATE                    = _UxGT("Actualizar SD/USB");
   PROGMEM Language_Str MSG_RESET_PRINTER                   = _UxGT("Reiniciar Impresora");
   PROGMEM Language_Str MSG_REFRESH                         = LCD_STR_REFRESH  _UxGT("Recargar");
@@ -339,6 +340,7 @@ namespace Language_gl {
   PROGMEM Language_Str MSG_BUTTON_DONE                     = _UxGT("Listo");
   PROGMEM Language_Str MSG_BUTTON_BACK                     = _UxGT("Atrás");
   PROGMEM Language_Str MSG_BUTTON_PROCEED                  = _UxGT("Proceder");
+  PROGMEM Language_Str MSG_PAUSING                         = _UxGT("Pausando...");
   PROGMEM Language_Str MSG_PAUSE_PRINT                     = _UxGT("Pausar impresión");
   PROGMEM Language_Str MSG_RESUME_PRINT                    = _UxGT("Retomar impresión");
   PROGMEM Language_Str MSG_STOP_PRINT                      = _UxGT("Deter impresión");
@@ -349,8 +351,8 @@ namespace Language_gl {
   PROGMEM Language_Str MSG_MEDIA_MENU                      = _UxGT("Tarxeta SD");
   PROGMEM Language_Str MSG_NO_MEDIA                        = _UxGT("Sen tarxeta SD");
   PROGMEM Language_Str MSG_DWELL                           = _UxGT("En repouso...");
-  PROGMEM Language_Str MSG_USERWAIT                        = _UxGT("A espera...");
-  PROGMEM Language_Str MSG_PRINT_PAUSED                    = _UxGT("Prema para Retomar");
+  PROGMEM Language_Str MSG_USERWAIT                        = _UxGT("Prema para Retomar..");
+  PROGMEM Language_Str MSG_PRINT_PAUSED                    = _UxGT("Impresión Pausada");
   PROGMEM Language_Str MSG_PRINTING                        = _UxGT("Imprimindo...");
   PROGMEM Language_Str MSG_PRINT_ABORTED                   = _UxGT("Impresión Cancelada");
   PROGMEM Language_Str MSG_PRINT_DONE                      = _UxGT("Fin Impresión");

--- a/Marlin/src/lcd/language/language_gl.h
+++ b/Marlin/src/lcd/language/language_gl.h
@@ -30,7 +30,6 @@
  */
 
 #define DISPLAY_CHARSET_ISO10646_1
-#define NOT_EXTENDED_ISO10646_1_5X7
 
 namespace Language_gl {
   using namespace Language_en; // Inherit undefined strings from English


### PR DESCRIPTION
### Description

This pull request allows the use of extended ISO10646 characters for Galician language and fix some Galician texts.

### Benefits

Accents are displayed on the HMI and wrong texts are corrected.

