### PR TITLE
Update spanish translation

### DIFF
--- a/Marlin/src/lcd/language/language_es.h
+++ b/Marlin/src/lcd/language/language_es.h
@@ -186,8 +186,8 @@ namespace Language_es {
   PROGMEM Language_Str MSG_UBL_STORAGE_SLOT                = _UxGT("Huecos de memoria");
   PROGMEM Language_Str MSG_UBL_LOAD_MESH                   = _UxGT("Cargar Mallado cama");
   PROGMEM Language_Str MSG_UBL_SAVE_MESH                   = _UxGT("Guardar Mallado cama");
-  PROGMEM Language_Str MSG_MESH_LOADED                     = _UxGT("Mall. %i Carga.");
-  PROGMEM Language_Str MSG_MESH_SAVED                      = _UxGT("Mall. %i Guard.");
+  PROGMEM Language_Str MSG_MESH_LOADED                     = _UxGT("Malla %i Cargada");
+  PROGMEM Language_Str MSG_MESH_SAVED                      = _UxGT("Malla %i Guardada");
   PROGMEM Language_Str MSG_UBL_NO_STORAGE                  = _UxGT("Sin guardar");
   PROGMEM Language_Str MSG_UBL_SAVE_ERROR                  = _UxGT("Error: Guardar UBL");
   PROGMEM Language_Str MSG_UBL_RESTORE_ERROR               = _UxGT("Error: Restaurar UBL");


### PR DESCRIPTION
https://github.com/MarlinFirmware/Marlin/commit/48919c54fb4e793b6bb17022f9badbd3530733ae spanish correction 

Removing `M117` gains more characters to string. then doesn't need cut the words
