### PR TITLE
Add Malyan M300 / Monoprice Delta Mini support 

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -57,6 +57,7 @@ jobs:
         - mks_robin
         - ARMED
         - FYSETC_S6
+        - malyan_M300
 
         # Put lengthy tests last
 

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -298,6 +298,7 @@
 #define BOARD_GTM32_MINI              4021  // STM32F103VET6 controller
 #define BOARD_GTM32_MINI_A30          4022  // STM32F103VET6 controller
 #define BOARD_GTM32_REV_B             4023  // STM32F103VET6 controller
+#define BOARD_MALYAN_M300             4024  // STM32F070 based delta
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -465,6 +465,12 @@
   #include "sam/pins_CNCONTROLS_15D.h"          // SAM3X8E                                env:DUE env:DUE_USB
 
 //
+// STM32 ARM Cortex-M0
+//
+#elif MB(MALYAN_M300)
+  #include "stm32f0/pins_MALYAN_M300.h"         // STM32F070
+
+//
 // STM32 ARM Cortex-M3
 //
 

--- a/Marlin/src/pins/stm32f0/pins_MALYAN_M300.h
+++ b/Marlin/src/pins/stm32f0/pins_MALYAN_M300.h
@@ -1,0 +1,89 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#if NONE(__STM32F1__, STM32F1xx, STM32F0xx)
+  #error "Oops! Select a 'Malyan M300' board in 'Tools > Board.'"
+#endif
+
+#define BOARD_INFO_NAME "Malyan M300"
+
+//
+// EEPROM Emulation
+//
+#define FLASH_EEPROM_EMULATION
+
+//
+// SD CARD SPI
+//
+#define SDSS      SS_PIN
+
+//
+// Timers
+//
+#undef STEP_TIMER
+#undef TEMP_TIMER
+#define STEP_TIMER 6
+#define TEMP_TIMER 7
+
+//
+// Limit Switches
+//
+#define X_MAX_PIN          PC13
+#define Y_MAX_PIN          PC14
+#define Z_MAX_PIN          PC15
+#define Z_MIN_PIN          PB7
+
+//
+// Steppers
+//
+#define X_STEP_PIN         PB14
+#define X_DIR_PIN          PB13
+#define X_ENABLE_PIN       PB10
+
+#define Y_STEP_PIN         PB12
+#define Y_DIR_PIN          PB11
+#define Y_ENABLE_PIN       PB10
+
+#define Z_STEP_PIN         PB2
+#define Z_DIR_PIN          PB1
+#define Z_ENABLE_PIN       PB10
+
+#define E0_STEP_PIN        PA7
+#define E0_DIR_PIN         PA6
+#define E0_ENABLE_PIN      PB0
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         PA0   // Analog Input (HOTEND0 thermistor)
+#define TEMP_BED_PIN       PA4   // Analog Input (BED thermistor)
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN       PA1   // HOTEND0 MOSFET
+#define HEATER_BED_PIN     PA5   // BED MOSFET
+
+#define AUTO_FAN_PIN       PA8
+

--- a/buildroot/share/tests/malyan_M300-tests
+++ b/buildroot/share/tests/malyan_M300-tests
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Build tests for STM32F070CB Malyan M300
+#
+
+# exit on first failure
+set -e
+
+use_example_configs delta/generic
+opt_set MOTHERBOARD BOARD_MALYAN_M300
+opt_set SERIAL_PORT -1
+opt_enable MALYAN_LCD
+opt_disable PSU_CONTROL
+exec_test $1 $2 "Malyan M300"
+
+# cleanup
+restore_configs

--- a/platformio.ini
+++ b/platformio.ini
@@ -593,6 +593,18 @@ src_filter  = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_ignore  = Adafruit NeoPixel, LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-HAL, SPI
 
 #
+# Malyan M300 (STM32F070CB)
+#
+[env:malyan_M300]
+platform    = ststm32@>=6.1.0
+board       = malyanm300_f070cb
+build_flags = ${common.build_flags}
+    -DUSBCON -DUSBD_VID=0x0483 "-DUSB_MANUFACTURER=\"Unknown\"" "-DUSB_PRODUCT=\"MALYAN_M300\"" 
+    -DHAL_PCD_MODULE_ENABLED -DUSBD_USE_CDC -DDISABLE_GENERIC_SERIALUSB -DHAL_UART_MODULE_ENABLED 
+src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
+lib_ignore  = U8glib, LiquidCrystal_I2C, LiquidCrystal, NewliquidCrystal, LiquidTWI2, Adafruit NeoPixel, TMCStepper, Servo(STM32F1), TMC26XStepper, U8glib-HAL
+
+#
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
 #
 [env:chitu_f103]


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Add support for the Malyan M300 / Monoprice Delta mini based on the STM32F070.
ststm32 6.1.0 minimum is required in order to get the M300 variant.

The last commit activate the autobuild but this should not be merged since the M300 has
only 123K flash and if the default config somehow activate too many features, it will exceed
this limit and mark the build has failed.

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
