### PR TITLE
More verbose probing errors

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -549,6 +549,25 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
 
   if (DEBUGGING(LEVELING)) DEBUG_POS(">>> Probe::run_z_probe", current_position);
 
+  auto try_to_probe = [&](PGM_P const plbl, const float &z_probe_low_point, const feedRate_t fr_mm_s, const bool scheck, const float clearance) {
+    // Do a first probe at the fast speed
+    const bool probe_fail = probe_down_to_z(z_probe_low_point, fr_mm_s),            // No probe trigger?
+               early_fail = (scheck && current_position.z > -offset.z + clearance); // Probe triggered too high?
+    #if ENABLED(DEBUG_LEVELING_FEATURE)
+      if (DEBUGGING(LEVELING) && (probe_fail || early_fail)) {
+        DEBUG_PRINT_P(plbl);
+        DEBUG_ECHOPGM(" Probe fail! -");
+        if (probe_fail) DEBUG_ECHOPGM(" No trigger.");
+        if (early_fail) DEBUG_ECHOPGM(" Triggered early.");
+        DEBUG_EOL();
+        DEBUG_POS("<<< run_z_probe", current_position);
+      }
+    #else
+      UNUSED(plbl);
+    #endif
+    return probe_fail || early_fail;
+  };
+
   // Stop the probe before it goes too low to prevent damage.
   // If Z isn't known then probe to -10mm.
   const float z_probe_low_point = TEST(axis_known_position, Z_AXIS) ? -offset.z + Z_PROBE_LOW_POINT : -10.0;
@@ -557,18 +576,8 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
   #if TOTAL_PROBING == 2
 
     // Do a first probe at the fast speed
-    bool probe_failed = probe_down_to_z(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_FAST)); // No probe trigger?
-    bool sanity_failed = (sanity_check && current_position.z > -offset.z + _MAX(Z_CLEARANCE_BETWEEN_PROBES, 4) / 2); // Probe triggered too high?
-    if (probe_failed || sanity_failed) {
-      if (DEBUGGING(LEVELING)) {
-        if (probe_failed)
-          DEBUG_ECHOLNPGM("FAST Probe fail! - No probe trigger.");
-        if (sanity_failed)
-          DEBUG_ECHOLNPGM("FAST Probe fail! - Probe triggered too high.");
-        DEBUG_POS("<<< run_z_probe", current_position);
-      }
-      return NAN;
-    }
+    if (try_to_probe(PSTR("FAST"), z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_FAST),
+                     sanity_check, _MAX(Z_CLEARANCE_BETWEEN_PROBES, 4) / 2) ) return NAN;
 
     const float first_probe_z = current_position.z;
 
@@ -605,18 +614,8 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
   #endif
     {
       // Probe downward slowly to find the bed
-      bool probe_failed = probe_down_to_z(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_SLOW)); // No probe trigger?
-      bool sanity_failed = (sanity_check && current_position.z > -offset.z + _MAX(Z_CLEARANCE_MULTI_PROBE, 4) / 2); // Probe triggered too high?
-      if (probe_failed || sanity_failed) {
-        if (DEBUGGING(LEVELING)) {
-          if (probe_failed)
-            DEBUG_ECHOLNPGM("SLOW Probe fail! - No probe trigger.");
-          if (sanity_failed)
-            DEBUG_ECHOLNPGM("SLOW Probe fail! - Probe triggered too high.");
-          DEBUG_POS("<<< run_z_probe", current_position);
-        }
-        return NAN;
-      }
+      if (try_to_probe(PSTR("SLOW"), z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_SLOW),
+                       sanity_check, _MAX(Z_CLEARANCE_MULTI_PROBE, 4) / 2) ) return NAN;
 
       #if ENABLED(MEASURE_BACKLASH_WHEN_PROBING)
         backlash.measure_with_probe();

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -557,11 +557,14 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
   #if TOTAL_PROBING == 2
 
     // Do a first probe at the fast speed
-    if (probe_down_to_z(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_FAST))         // No probe trigger?
-      || (sanity_check && current_position.z > -offset.z + _MAX(Z_CLEARANCE_BETWEEN_PROBES, 4) / 2)  // Probe triggered too high?
-    ) {
+    bool probe_failed = probe_down_to_z(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_FAST)); // No probe trigger?
+    bool sanity_failed = (sanity_check && current_position.z > -offset.z + _MAX(Z_CLEARANCE_BETWEEN_PROBES, 4) / 2); // Probe triggered too high?
+    if (probe_failed || sanity_failed) {
       if (DEBUGGING(LEVELING)) {
-        DEBUG_ECHOLNPGM("FAST Probe fail!");
+        if (probe_failed)
+          DEBUG_ECHOLNPGM("FAST Probe fail! - No probe trigger.");
+        if (sanity_failed)
+          DEBUG_ECHOLNPGM("FAST Probe fail! - Probe triggered too high.");
         DEBUG_POS("<<< run_z_probe", current_position);
       }
       return NAN;
@@ -602,11 +605,14 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
   #endif
     {
       // Probe downward slowly to find the bed
-      if (probe_down_to_z(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_SLOW))      // No probe trigger?
-        || (sanity_check && current_position.z > -offset.z + _MAX(Z_CLEARANCE_MULTI_PROBE, 4) / 2)  // Probe triggered too high?
-      ) {
+      bool probe_failed = probe_down_to_z(z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_SLOW)); // No probe trigger?
+      bool sanity_failed = (sanity_check && current_position.z > -offset.z + _MAX(Z_CLEARANCE_MULTI_PROBE, 4) / 2); // Probe triggered too high?
+      if (probe_failed || sanity_failed) {
         if (DEBUGGING(LEVELING)) {
-          DEBUG_ECHOLNPGM("SLOW Probe fail!");
+          if (probe_failed)
+            DEBUG_ECHOLNPGM("SLOW Probe fail! - No probe trigger.");
+          if (sanity_failed)
+            DEBUG_ECHOLNPGM("SLOW Probe fail! - Probe triggered too high.");
           DEBUG_POS("<<< run_z_probe", current_position);
         }
         return NAN;


### PR DESCRIPTION
### Description

In case of a seriously bent bed, misconfigured `Z_CLEARANCE_BETWEEN_PROBES` or if the X axis is not aligned horizontally with the bed, `G29` would fail but it would just say `FAST Probe fail!`. I had this issue and the error message didn't help neither me, nor people from the Marlin community who tried to help.

### Benefits

I propose this code change so you immediately know that your probe triggered too high or didn't trigger which makes it easier to identify the reason why probing fails.