### PR TITLE
Silence warning

### DIFF
--- a/buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
@@ -1,6 +1,10 @@
 import os
 Import("env")
 
+for define in env['CPPDEFINES']:
+    if define[0] == "VECT_TAB_ADDR":
+        env['CPPDEFINES'].remove(define)
+
 # Relocate firmware from 0x08000000 to 0x08007000
 env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08007000"))
 


### PR DESCRIPTION
like:
~~~
<command-line>:0:0: warning: "VECT_TAB_ADDR" redefined
<command-line>:0:0: note: this is the location of the previous definition
~~~

### Requirements

* SKR E3 DIP with RET6 mCU
* default_envs = STM32F103RE_btt / STM32F103RE_btt_USB

### Description

silence warning about `VECT_TAB_ADDR` redefined

### Benefits

silence warning & parity with `STM32F103RC_SKR_MINI.py` script
