### PR TITLE
mks_robin infinite boot fix

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -41,6 +41,11 @@
 #define DISABLE_JTAG
 
 //
+// Enable SD EEPROM to prevent infinite boot loop
+//
+#define SDCARD_EEPROM_EMULATION
+
+//
 // Servos
 //
 #define SERVO0_PIN                          PC3   // XS1 - 5
@@ -178,10 +183,10 @@
   //#define E4_HARDWARE_SERIAL Serial1
 
   // Unused servo pins may be repurposed with SoftwareSerialM
-  //#define X_SERIAL_TX_PIN                 PF8   // SERVO3_PIN
-  //#define Y_SERIAL_TX_PIN                 PF9   // SERVO2_PIN
-  //#define Z_SERIAL_TX_PIN                 PA1   // SERVO1_PIN
-  //#define E0_SERIAL_TX_PIN                PC3   // SERVO0_PIN
+  //#define X_SERIAL_TX_PIN                 PF8   // SERVO3_PIN -- XS2 - 6
+  //#define Y_SERIAL_TX_PIN                 PF9   // SERVO2_PIN -- XS2 - 5
+  //#define Z_SERIAL_TX_PIN                 PA1   // SERVO1_PIN -- XS1 - 6
+  //#define E0_SERIAL_TX_PIN                PC3   // SERVO0_PIN -- XS1 - 5
   //#define X_SERIAL_RX_PIN      X_SERIAL_TX_PIN
   //#define Y_SERIAL_RX_PIN      Y_SERIAL_TX_PIN
   //#define Z_SERIAL_RX_PIN      Z_SERIAL_TX_PIN


### PR DESCRIPTION
### Description
- Infinite boot fix was caused by not defining SD card EEPROM emulation
- Added pin descriptions for SoftwareSerial on mks_robin

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
Add define for SD Card EEPROM Emulation as current >= 2.0.5.1 releases prevent the Robin from booting.

<!-- What does this fix or improve? -->

### Related Issues
#17447 
#17376 

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
