### PR TITLE
MKS_Robin_nano -- infinite boot loop fix

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -39,6 +39,12 @@
 #define DISABLE_DEBUG
 
 //
+// EEPROM
+//
+//#define FLASH_EEPROM_EMULATION
+#define SDCARD_EEPROM_EMULATION
+
+//
 // Limit Switches
 //
 #define X_STOP_PIN                          PA15
@@ -106,15 +112,12 @@
 //
 // SD Card
 //
-#define SDCARD_CONNECTION ONBOARD
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION              ONBOARD
+#endif
+
 #define SDIO_SUPPORT
 #define SD_DETECT_PIN                       PD12
-
-//
-// EEPROM
-//
-//#define FLASH_EEPROM_EMULATION
-#define SDCARD_EEPROM_EMULATION
 
 //
 // LCD / Controller

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -106,8 +106,15 @@
 //
 // SD Card
 //
+#define SDCARD_CONNECTION ONBOARD
 #define SDIO_SUPPORT
 #define SD_DETECT_PIN                       PD12
+
+//
+// EEPROM
+//
+//#define FLASH_EEPROM_EMULATION
+#define SDCARD_EEPROM_EMULATION
 
 //
 // LCD / Controller


### PR DESCRIPTION
### Description

- Infinite boot fix was caused by not defining SD card EEPROM emulation

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

Add define for SD Card EEPROM Emulation as current >= 2.0.5.1 releases prevent the Robin_Nano from booting.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
#17376