### PR TITLE
Fix framework-arduinoststm32 minimum version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -614,7 +614,7 @@ lib_ignore    = Adafruit NeoPixel
 [env:STM32F401VE_STEVAL]
 platform          = ststm32
 board             = STEVAL_STM32F401VE
-platform_packages = framework-arduinoststm32@>=3.107,<4
+platform_packages = framework-arduinoststm32@>=3.10700,<4
 build_flags       = ${common.build_flags}
  -DTARGET_STM32F4 -DARDUINO_STEVAL -DSTM32F401xE
  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STEVAL_F401VE\"
@@ -632,7 +632,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/STM32>
 [env:FLYF407ZG]
 platform          = ststm32
 board             = FLYF407ZG
-platform_packages = framework-arduinoststm32@>=3.107,<4
+platform_packages = framework-arduinoststm32@>=3.10700,<4
 build_flags       = ${common.build_flags}
   -DSTM32F4 -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407ZG\"
   -DTARGET_STM32F4 -DVECT_TAB_OFFSET=0x8000
@@ -651,7 +651,7 @@ platform          = ststm32
 board             = fysetc_s6
 platform_packages =
    tool-stm32duino
-   framework-arduinoststm32@>=3.107,<4
+   framework-arduinoststm32@>=3.10700,<4
 build_flags       = ${common.build_flags}
   -DTARGET_STM32F4 -std=gnu++14
   -DVECT_TAB_OFFSET=0x10000
@@ -672,7 +672,7 @@ upload_protocol   = serial
 [env:STM32F407VE_black]
 platform          = ststm32
 board             = blackSTM32F407VET6
-platform_packages = framework-arduinoststm32@>=3.107,<4
+platform_packages = framework-arduinoststm32@>=3.10700,<4
 build_flags       = ${common.build_flags}
  -DTARGET_STM32F4 -DARDUINO_BLACK_F407VE
  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"BLACK_F407VE\"
@@ -688,7 +688,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/STM32>
 [env:BIGTREE_SKR_PRO]
 platform          = ststm32
 board             = BigTree_SKR_Pro
-platform_packages = framework-arduinoststm32@>=3.107,<4
+platform_packages = framework-arduinoststm32@>=3.10700,<4
 build_flags       = ${common.build_flags}
   -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407ZG\"
   -DTARGET_STM32F4 -DSTM32F407_5ZX -DVECT_TAB_OFFSET=0x8000
@@ -708,7 +708,7 @@ debug_init_break  =
 [env:BIGTREE_GTR_V1_0]
 platform          = ststm32@>=5.7.0
 framework         = arduino
-platform_packages = framework-arduinoststm32@>=3.107,<4
+platform_packages = framework-arduinoststm32@>=3.10700,<4
 board             = BigTree_SKR_Pro
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 build_flags       = ${common.build_flags}
@@ -732,7 +732,7 @@ monitor_speed     = 250000
 [env:BIGTREE_BTT002]
 platform          = ststm32@5.6.0
 board             = BigTree_Btt002
-platform_packages = framework-arduinoststm32@>=3.107,<4
+platform_packages = framework-arduinoststm32@>=3.10700,<4
 build_flags       = ${common.build_flags}
   -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407VG\"
   -DTARGET_STM32F4 -DSTM32F407_5VX -DVECT_TAB_OFFSET=0x8000


### PR DESCRIPTION
### Description

The minimum version specified for framework-arduinoststm32 allowed stale versions to be used. This is because we specified three digits in the minor version (3.107), but they actually specify 5 (3.10700). This allowed old versions such as 3.10601 to be used, because 10601 > 107.

### Benefits

Helps avoid stale framework versions being used.

### Related Issues

I'm not sure whether this is the only cause of issues for #17495, but that is how I became aware of this.
