### PR TITLE
Fix warning regarding possible buffer overrun

### DIFF
--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -188,8 +188,8 @@ void _lcd_ubl_edit_mesh() {
  */
 void _lcd_ubl_validate_custom_mesh() {
   char ubl_lcd_gcode[24];
-  const int temp = TERN(HAS_HEATED_BED, custom_bed_temp, 0);
-  sprintf_P(ubl_lcd_gcode, PSTR("G28\nG26 C B%i H%i P"), temp, custom_hotend_temp);
+  const int16_t temp = TERN(HAS_HEATED_BED, custom_bed_temp, 0);
+  sprintf_P(ubl_lcd_gcode, PSTR("G28\nG26 C B%" PRIi16 " H%" PRIi16 " P"), temp, custom_hotend_temp);
   queue.inject(ubl_lcd_gcode);
 }
 


### PR DESCRIPTION
### Description

Fix a warning indicating the sprintf command could overrun the destination buffer.

`'%i' directive writing between 1 and 6 bytes into a region of size between 5 and 10 [-Wformat-overflow=]`

The solution was two-fold:
- Make `temp` an int16_t to reduce the maximum printed length (this matches the source data size)
- Use C99-style format specifier to ensure the format specifier matches the argument length on all platforms.

### Related Issues

#17506
