### PR TITLE
Add ExtUI::onStatusChanged_P function

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -536,7 +536,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
         host_prompt_do(PROMPT_INFO, GET_TEXT(MSG_REHEATING));
       #endif
       #if ENABLED(EXTENSIBLE_UI)
-        ExtUI::onStatusChanged(GET_TEXT(MSG_REHEATING));
+        ExtUI::onStatusChanged_P(GET_TEXT(MSG_REHEATING));
       #endif
 
       // Re-enable the heaters if they timed out

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -1071,6 +1071,12 @@ namespace ExtUI {
     onUserConfirmRequired(msg);
   }
 
+  void onStatusChanged_P(PGM_P const pstr) {
+    char msg[strlen_P(pstr) + 1];
+    strcpy_P(msg, pstr);
+    onStatusChanged(msg);
+  }
+
   FileList::FileList() { refresh(); }
 
   void FileList::refresh() { num_files = 0xFFFF; }

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -339,6 +339,7 @@ namespace ExtUI {
   void onUserConfirmRequired(const char * const msg);
   void onUserConfirmRequired_P(PGM_P const pstr);
   void onStatusChanged(const char * const msg);
+  void onStatusChanged_P(PGM_P const pstr);
   void onFactoryReset();
   void onStoreSettings(char *);
   void onLoadSettings(const char *);


### PR DESCRIPTION
It copies its parameter to SRAM and passes it to `ExtUI::onStatusChanged` (similar
to `ExtUI::onUserConfirmRequired_P`).

The call to `ExtUI::onStatusChanged` in `pause.cpp` was passing a PROGMEM pointer
in place of an SRAM one. It's now using `ExtUI::onStatusChanged_P`.