### PR TITLE
Fixes for ExtUI compilation errors (#16628)

### DIFF
--- a/Marlin/src/core/multi_language.h
+++ b/Marlin/src/core/multi_language.h
@@ -76,7 +76,7 @@ typedef const char Language_Str[];
 #endif
 #define GET_TEXT_F(MSG) (const __FlashStringHelper*)GET_TEXT(MSG)
 
-#define MSG_CONCAT(A,B) pgm_p_pair_t(GET_TEXT(A),GET_TEXT(B))
+#define GET_LANGUAGE_NAME(INDEX) GET_LANG(LCD_LANGUAGE_##INDEX)::LANGUAGE
 
 #define MSG_1_LINE(A)     A "\0"   "\0"
 #define MSG_2_LINE(A,B)   A "\0" B "\0"

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
@@ -57,7 +57,10 @@ void AboutScreen::onRedraw(draw_mode_t) {
 
   char about_str[
     strlen_P(GET_TEXT(MSG_ABOUT_TOUCH_PANEL_2)) +
-    strlen_P(TOOLHEAD_NAME) + 1
+    #ifdef TOOLHEAD_NAME
+      strlen_P(TOOLHEAD_NAME) +
+    #endif
+    1
   ];
   #ifdef TOOLHEAD_NAME
     // If MSG_ABOUT_TOUCH_PANEL_2 has %s, substitute in the toolhead name.

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
@@ -55,12 +55,11 @@ void AboutScreen::onRedraw(draw_mode_t) {
   #define _INSET_POS(x,y,w,h) x + w/10, y, w - w/5, h
   #define INSET_POS(pos) _INSET_POS(pos)
 
-  char about_str[
-    strlen_P(GET_TEXT(MSG_ABOUT_TOUCH_PANEL_2)) +
+  char about_str[1
+    + strlen_P(GET_TEXT(MSG_ABOUT_TOUCH_PANEL_2))
     #ifdef TOOLHEAD_NAME
-      strlen_P(TOOLHEAD_NAME) +
+      + strlen_P(TOOLHEAD_NAME)
     #endif
-    1
   ];
   #ifdef TOOLHEAD_NAME
     // If MSG_ABOUT_TOUCH_PANEL_2 has %s, substitute in the toolhead name.

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
@@ -136,7 +136,7 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
         #if DISABLED(CLASSIC_JERK)
           MSG_JUNCTION_DEVIATION
         #else
-          JERK_POS
+          MSG_JERK
         #endif
        ))
       .enabled(


### PR DESCRIPTION
Fixes compile errors when TOOLHEAD_NAME not defined or CLASSIC_JERK enabled or when multiple languages are enabled.

See #16628