### PR TITLE
Chamber heating doesn't stop printjob timer

### DIFF
--- a/Marlin/src/gcode/temp/M140_M190.cpp
+++ b/Marlin/src/gcode/temp/M140_M190.cpp
@@ -50,16 +50,18 @@
  */
 void GcodeSuite::M140() {
   if (DEBUGGING(DRYRUN)) return;
-  if (parser.seenval('S')) thermalManager.setTargetBed(parser.value_celsius());
+  if (parser.seenval('S')) {
+    thermalManager.setTargetBed(parser.value_celsius());
 
-  #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
-    /**
-     * Stop the timer at the end of print. Both hotend and bed target
-     * temperatures need to be set below mintemp. Order of M140 and M104
-     * at the end of the print does not matter.
-     */
-    thermalManager.check_timer_autostart(false, true);
-  #endif
+    #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
+      /**
+       * Stop the timer at the end of print. Both hotend and bed target
+       * temperatures need to be set below mintemp. Order of M140 and M104
+       * at the end of the print does not matter.
+       */
+      thermalManager.check_timer_autostart(false, true);
+    #endif
+  }
 }
 
 /**

--- a/Marlin/src/gcode/temp/M140_M190.cpp
+++ b/Marlin/src/gcode/temp/M140_M190.cpp
@@ -55,8 +55,8 @@ void GcodeSuite::M140() {
 
     #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
       /**
-       * Stop the timer at the end of print. Both hotend and bed target
-       * temperatures need to be set below mintemp. Order of M140 and M104
+       * Stop the timer at the end of print. Hotend, bed target, and chamber
+       * temperatures need to be set below mintemp. Order of M140, M104, and M141
        * at the end of the print does not matter.
        */
       thermalManager.check_timer_autostart(false, true);

--- a/Marlin/src/gcode/temp/M141_M191.cpp
+++ b/Marlin/src/gcode/temp/M141_M191.cpp
@@ -56,10 +56,9 @@ void GcodeSuite::M141() {
 
     #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
       /**
-       * Stop the timer at the end of print. Start is managed by 'heat and wait' M109.
-       * Hotends use EXTRUDE_MINTEMP / 2 to allow nozzles to be put into hot standby
-       * mode, for instance in a dual extruder setup, without affecting the running
-       * print timer.
+       * Stop the timer at the end of print. Hotend, bed target, and chamber
+       * temperatures need to be set below mintemp. Order of M140, M104, and M141
+       * at the end of the print does not matter.
        */
       thermalManager.check_timer_autostart(false, true);
     #endif

--- a/Marlin/src/gcode/temp/M141_M191.cpp
+++ b/Marlin/src/gcode/temp/M141_M191.cpp
@@ -51,7 +51,19 @@
  */
 void GcodeSuite::M141() {
   if (DEBUGGING(DRYRUN)) return;
-  if (parser.seenval('S')) thermalManager.setTargetChamber(parser.value_celsius());
+  if (parser.seenval('S')) {
+    thermalManager.setTargetChamber(parser.value_celsius());
+
+    #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
+      /**
+       * Stop the timer at the end of print. Start is managed by 'heat and wait' M109.
+       * Hotends use EXTRUDE_MINTEMP / 2 to allow nozzles to be put into hot standby
+       * mode, for instance in a dual extruder setup, without affecting the running
+       * print timer.
+       */
+      thermalManager.check_timer_autostart(false, true);
+    #endif
+  }
 }
 
 /**


### PR DESCRIPTION
### Description

Whenever an `M104` or `M140` is called, it will `check_timer_autostart` to see if it needs to stop the print timer. The order of those 2 is not important.

`M141` however does not call `check_timer_autostart`.

`check_timer_autostart` evaluates extruders, bed, *and* chamber.

Without this change, `M141` would have to be placed before `M104` or `M140`.

NOTE: `M104` has its call to `check_timer_autostart` wrapped in a `parser.seenval('s')`. This PR also changes `M140` look for the same seenval. Please let me know if this shouldn't change.

### Benefits

Stops the print timer if chamber temp is turned off after extruder and bed

### Related Issues

None
