### PR TITLE
AUTOTEMP default proportions

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -206,7 +206,7 @@
   // A well-chosen Kc value should add just enough power to melt the increased material volume.
   //#define PID_EXTRUSION_SCALING
   #if ENABLED(PID_EXTRUSION_SCALING)
-    #define DEFAULT_Kc (100) //heating power=Kc*(e_speed)
+    #define DEFAULT_Kc (100) // heating power = Kc * e_speed
     #define LPQ_MAX_LEN 50
   #endif
 
@@ -262,24 +262,27 @@
 #endif
 
 /**
- * Automatic Temperature:
- * The hotend target temperature is calculated by all the buffered lines of gcode.
- * The maximum buffered steps/sec of the extruder motor is called "se".
- * Start autotemp mode with M109 S<mintemp> B<maxtemp> F<factor>
- * The target temperature is set to mintemp+factor*se[steps/sec] and is limited
- * by mintemp and maxtemp. Turn off by executing M109 without F.
- * Also, if the temperature is set to a value below mintemp, it will not be changed by autotemp.
- * On an Ultimaker, some initial testing worked with M109 S215 B260 F1 in the start.gcode
+ * Automatic Temperature Mode
+ *
+ * Dynamically adjust the hotend target temperature based on planned E moves.
+ *
+ * (Contrast with PID_EXTRUSION_SCALING, which tracks E movement and adjusts PID
+ *  behavior using an additional kC value.)
+ *
+ * Autotemp is calculated by (mintemp + factor * mm_per_sec), capped to maxtemp.
+ *
+ * Enable Autotemp Mode with M104/M109 F<factor> S<mintemp> B<maxtemp>.
+ * Disable by sending M104/M109 with no F parameter (or F0 with AUTOTEMP_PROPORTIONAL).
  */
 #define AUTOTEMP
 #if ENABLED(AUTOTEMP)
   #define AUTOTEMP_OLDWEIGHT    0.98
-  // On M109 command start autotemp using these proportions of the target
-  #define AUTOTEMP_PROPORTIONAL
+  // Turn on AUTOTEMP on M104/M109 by default using proportions set here
+  //#define AUTOTEMP_PROPORTIONAL
   #if ENABLED(AUTOTEMP_PROPORTIONAL)
-    #define AUTOTEMP_MIN_P      0 // Added to target temp value
-    #define AUTOTEMP_MAX_P      5 // Added to target temp value
-    #define AUTOTEMP_FACTOR_P   1 // Apply this value always
+    #define AUTOTEMP_MIN_P      0 // (°C) Added to the target temperature
+    #define AUTOTEMP_MAX_P      5 // (°C) Added to the target temperature
+    #define AUTOTEMP_FACTOR_P   1 // Apply this F parameter by default (overridden by M104/M109 F)
   #endif
 #endif
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -271,9 +271,16 @@
  * Also, if the temperature is set to a value below mintemp, it will not be changed by autotemp.
  * On an Ultimaker, some initial testing worked with M109 S215 B260 F1 in the start.gcode
  */
-#define AUTOTEMP
-#if ENABLED(AUTOTEMP)
-  #define AUTOTEMP_OLDWEIGHT 0.98
+ #define AUTOTEMP
+ #if ENABLED(AUTOTEMP)
+   #define AUTOTEMP_OLDWEIGHT 0.98
+   // On M109 command , start autotemp with this proportional values of target hotend temp
+   #define AUTOTEMP_PROPORTIONAL
+   #if ENABLED(AUTOTEMP_PROPORTIONAL)
+     #define AUTOTEMP_MIN_P    0   // Added to target temp value
+     #define AUTOTEMP_MAX_P    5   // Added to target temp value
+    #define AUTOTEMP_FACTOR_P  1  // Apply value
+   #endif
 #endif
 
 // Extra options for the M114 "Current Position" report

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -266,21 +266,21 @@
  * The hotend target temperature is calculated by all the buffered lines of gcode.
  * The maximum buffered steps/sec of the extruder motor is called "se".
  * Start autotemp mode with M109 S<mintemp> B<maxtemp> F<factor>
- * The target temperature is set to mintemp+factor*se[steps/sec] and is limited by
- * mintemp and maxtemp. Turn this off by executing M109 without F*
+ * The target temperature is set to mintemp+factor*se[steps/sec] and is limited
+ * by mintemp and maxtemp. Turn off by executing M109 without F.
  * Also, if the temperature is set to a value below mintemp, it will not be changed by autotemp.
  * On an Ultimaker, some initial testing worked with M109 S215 B260 F1 in the start.gcode
  */
- #define AUTOTEMP
- #if ENABLED(AUTOTEMP)
-   #define AUTOTEMP_OLDWEIGHT 0.98
-   // On M109 command , start autotemp with this proportional values of target hotend temp
-   #define AUTOTEMP_PROPORTIONAL
-   #if ENABLED(AUTOTEMP_PROPORTIONAL)
-     #define AUTOTEMP_MIN_P    0   // Added to target temp value
-     #define AUTOTEMP_MAX_P    5   // Added to target temp value
-    #define AUTOTEMP_FACTOR_P  1  // Apply value
-   #endif
+#define AUTOTEMP
+#if ENABLED(AUTOTEMP)
+  #define AUTOTEMP_OLDWEIGHT    0.98
+  // On M109 command start autotemp using these proportions of the target
+  #define AUTOTEMP_PROPORTIONAL
+  #if ENABLED(AUTOTEMP_PROPORTIONAL)
+    #define AUTOTEMP_MIN_P      0 // Added to target temp value
+    #define AUTOTEMP_MAX_P      5 // Added to target temp value
+    #define AUTOTEMP_FACTOR_P   1 // Apply this value always
+  #endif
 #endif
 
 // Extra options for the M114 "Current Position" report

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2978,17 +2978,13 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
       const int16_t target = thermalManager.degTargetHotend(active_extruder);
       autotemp_min = target + AUTOTEMP_MIN_P;
       autotemp_max = target + AUTOTEMP_MAX_P;
-      autotemp_enabled = autotemp_factor = AUTOTEMP_FACTOR_P;
+      autotemp_factor = AUTOTEMP_FACTOR_P;
     #endif
 
-    // F0 will disable autotemp
-    if (parser.seenval('F')) {
-      autotemp_factor = parser.value_float();
-      if (!autotemp_factor) autotemp_enabled = false;
-      }
     if (parser.seenval('S')) autotemp_min = parser.value_celsius();
     if (parser.seenval('B')) autotemp_max = parser.value_celsius();
-
+    if (parser.seenval('F')) autotemp_factor = parser.value_float();
+    if (!autotemp_factor) autotemp_enabled = false; // F0 will disable autotemp
   }
 
 #endif

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2972,10 +2972,17 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
 
 #if ENABLED(AUTOTEMP)
 
-  void Planner::autotemp_M104_M109() {
-    if ((autotemp_enabled = parser.seen('F'))) autotemp_factor = parser.value_float();
-    if (parser.seen('S')) autotemp_min = parser.value_celsius();
-    if (parser.seen('B')) autotemp_max = parser.value_celsius();
-  }
+void Planner::autotemp_M104_M109() {
+  //F0 gcode to disable autotemp
+  if ((autotemp_enabled = parser.seen('F')? parser.value_float() : false )) autotemp_factor = parser.value_float();
+  if (parser.seen('S')) autotemp_min = parser.value_celsius();
+  if (parser.seen('B')) autotemp_max = parser.value_celsius();
+
+  #if ENABLED(AUTOTEMP_PROPORTIONAL)
+    autotemp_min = thermalManager.degTargetHotend(active_extruder) + AUTOTEMP_MIN_P;
+    autotemp_max = thermalManager.degTargetHotend(active_extruder) + AUTOTEMP_MAX_P;
+    autotemp_factor = AUTOTEMP_FACTOR_P;
+  #endif
+}
 
 #endif

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2986,7 +2986,7 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
       const int16_t target = thermalManager.degTargetHotend(active_extruder);
       autotemp_min = target + AUTOTEMP_MIN_P;
       autotemp_max = target + AUTOTEMP_MAX_P;
-      autotemp_factor = AUTOTEMP_FACTOR_P;
+      autotemp_enabled = autotemp_factor = AUTOTEMP_FACTOR_P;
     #endif
   }
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2973,14 +2973,6 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
 #if ENABLED(AUTOTEMP)
 
   void Planner::autotemp_M104_M109() {
-    // F0 will disable autotemp
-    autotemp_enabled = parser.seenval('F');
-    if (autotemp_enabled) {
-      autotemp_factor = parser.value_float();
-      if (!autotemp_factor) autotemp_enabled = false;
-    }
-    if (parser.seenval('S')) autotemp_min = parser.value_celsius();
-    if (parser.seenval('B')) autotemp_max = parser.value_celsius();
 
     #if ENABLED(AUTOTEMP_PROPORTIONAL)
       const int16_t target = thermalManager.degTargetHotend(active_extruder);
@@ -2988,6 +2980,15 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
       autotemp_max = target + AUTOTEMP_MAX_P;
       autotemp_enabled = autotemp_factor = AUTOTEMP_FACTOR_P;
     #endif
+
+    // F0 will disable autotemp
+    if (parser.seenval('F')) {
+      autotemp_factor = parser.value_float();
+      if (!autotemp_factor) autotemp_enabled = false;
+      }
+    if (parser.seenval('S')) autotemp_min = parser.value_celsius();
+    if (parser.seenval('B')) autotemp_max = parser.value_celsius();
+
   }
 
 #endif

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2974,9 +2974,10 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
 
   void Planner::autotemp_M104_M109() {
     // F0 will disable autotemp
-    if (parser.seenval('F')) {
+    autotemp_enabled = parser.seenval('F');
+    if (autotemp_enabled) {
       autotemp_factor = parser.value_float();
-      autotemp_enabled = autotemp_factor != 0;
+      if (!autotemp_factor) autotemp_enabled = false;
     }
     if (parser.seenval('S')) autotemp_min = parser.value_celsius();
     if (parser.seenval('B')) autotemp_max = parser.value_celsius();

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2972,17 +2972,21 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
 
 #if ENABLED(AUTOTEMP)
 
-void Planner::autotemp_M104_M109() {
-  //F0 gcode to disable autotemp
-  if ((autotemp_enabled = parser.seen('F')? parser.value_float() : false )) autotemp_factor = parser.value_float();
-  if (parser.seen('S')) autotemp_min = parser.value_celsius();
-  if (parser.seen('B')) autotemp_max = parser.value_celsius();
+  void Planner::autotemp_M104_M109() {
+    // F0 will disable autotemp
+    if (parser.seenval('F')) {
+      autotemp_factor = parser.value_float();
+      autotemp_enabled = autotemp_factor != 0;
+    }
+    if (parser.seenval('S')) autotemp_min = parser.value_celsius();
+    if (parser.seenval('B')) autotemp_max = parser.value_celsius();
 
-  #if ENABLED(AUTOTEMP_PROPORTIONAL)
-    autotemp_min = thermalManager.degTargetHotend(active_extruder) + AUTOTEMP_MIN_P;
-    autotemp_max = thermalManager.degTargetHotend(active_extruder) + AUTOTEMP_MAX_P;
-    autotemp_factor = AUTOTEMP_FACTOR_P;
-  #endif
-}
+    #if ENABLED(AUTOTEMP_PROPORTIONAL)
+      const int16_t target = thermalManager.degTargetHotend(active_extruder);
+      autotemp_min = target + AUTOTEMP_MIN_P;
+      autotemp_max = target + AUTOTEMP_MAX_P;
+      autotemp_factor = AUTOTEMP_FACTOR_P;
+    #endif
+  }
 
 #endif


### PR DESCRIPTION
Because : 
PID temp doesn't auto tune while extruding , to set TRUE values of heating when printing , and of course always in late to heat
PID scaling ,  same problem

There is only AUTOTEMP that can bring an approximative stable temp , in all situation of extrusion , light or massive

It's why i updated this , to have , an AUTOTEMP , automaticly setted on the current target temps , by experience i know ,   min= target  and max = target +5 or 10

And the temp is now a little correct while massive extrusion 

Help needed:
Because i have singlenozzle machine , i have no experience on gcode or anything with more than one hotend , and , i need someone , to write the correct code , to be used with other than single hotend

Thks