### PR TITLE
Improve acos()-approximation used for Junction Deviation

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2390,13 +2390,22 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
                     sin_theta_d2 = SQRT(0.5f * (1.0f - junction_cos_theta)); // Trig half angle identity. Always positive.
 
         vmax_junction_sqr = (junction_acceleration * junction_deviation_mm * sin_theta_d2) / (1.0f - sin_theta_d2);
-        if (block->millimeters < 1) {
 
-          // Fast acos approximation, minus the error bar to be safe
-          const float junction_theta = (RADIANS(-40) * sq(junction_cos_theta) - RADIANS(50)) * junction_cos_theta + RADIANS(90) - 0.18f;
+        if (block->millimeters < 1) {
+          // Fast acos approximation (max. error +-0.033 rads)
+          // Based on MinMax polynomial published by W. Randolph Franklin, see
+          // https://wrf.ecse.rpi.edu/Research/Short_Notes/arcsin/onlyelem.html
+          // (acos(x) = pi/2 - asin(x) with pi/2 = 1.5707963268f)
+          float junction_theta = 0;
+          if (junction_cos_theta >= 0){
+            junction_theta =  1.5707963268f - (0.032843707f+(-1.451838349f+(29.66153956f+(-131.1123477f+(262.8130562f+(-242.7199627f+84.31466202f*junction_cos_theta)*junction_cos_theta)*junction_cos_theta)*junction_cos_theta)*junction_cos_theta)*junction_cos_theta);
+          } else {
+            junction_theta =  1.5707963268f + (0.032843707f+(-1.451838349f+(29.66153956f+(-131.1123477f+(262.8130562f+(-242.7199627f+84.31466202f*(-junction_cos_theta))*(-junction_cos_theta))*(-junction_cos_theta))*(-junction_cos_theta))*(-junction_cos_theta))*(-junction_cos_theta));
+          }
 
           // If angle is greater than 135 degrees (octagon), find speed for approximate arc
           if (junction_theta > RADIANS(135)) {
+            // NOTE: MinMax acos approximation and thereby also junction_theta top out at pi-0.033, which avoids division by 0
             const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * junction_acceleration;
             NOMORE(vmax_junction_sqr, limit_sqr);
           }

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2425,7 +2425,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
           #endif
 
           // If angle is greater than 135 degrees (octagon), find speed for approximate arc
-          if ((M_PI / 2) - junction_theta > RADIANS(135)) {
+          if (junction_theta > RADIANS(135)) {
             // NOTE: MinMax acos approximation and thereby also junction_theta top out at pi-0.033, which avoids division by 0
             const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * junction_acceleration;
             NOMORE(vmax_junction_sqr, limit_sqr);

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2409,7 +2409,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
                                 + t * ( FIXED(262.8130562f)
                                 + t * (-FIXED(242.7199627f) + t * FIXED(84.31466202f)) ))));
 
-            const float junction_theta = RADIANS(90) - (float(neg * n) * RECIPROCAL(0x10000L));
+            const float junction_theta = RADIANS(90) - (float(neg * asinx) * RECIPROCAL(0x10000L));
 
           #else
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2395,16 +2395,19 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
           // Fast acos approximation (max. error +-0.033 rads)
           // Based on MinMax polynomial published by W. Randolph Franklin, see
           // https://wrf.ecse.rpi.edu/Research/Short_Notes/arcsin/onlyelem.html
-          // (acos(x) = pi/2 - asin(x) with pi/2 = 1.5707963268f)
-          float junction_theta = 0;
-          if (junction_cos_theta >= 0){
-            junction_theta =  1.5707963268f - (0.032843707f+(-1.451838349f+(29.66153956f+(-131.1123477f+(262.8130562f+(-242.7199627f+84.31466202f*junction_cos_theta)*junction_cos_theta)*junction_cos_theta)*junction_cos_theta)*junction_cos_theta)*junction_cos_theta);
-          } else {
-            junction_theta =  1.5707963268f + (0.032843707f+(-1.451838349f+(29.66153956f+(-131.1123477f+(262.8130562f+(-242.7199627f+84.31466202f*(-junction_cos_theta))*(-junction_cos_theta))*(-junction_cos_theta))*(-junction_cos_theta))*(-junction_cos_theta))*(-junction_cos_theta));
-          }
+          // (acos(x) = pi / 2 - asin(x))
+          const float neg = junction_cos_theta < 0 ? -1 : 1,
+                      t = neg * junction_cos_theta,
+                      asinx =       0.032843707f
+                            + t * (-1.451838349f
+                            + t * ( 29.66153956f
+                            + t * (-131.1123477f
+                            + t * ( 262.8130562f
+                            + t * (-242.7199627f + t * 84.31466202f) )))),
+                      junction_theta = RADIANS(90) - neg * asinx;
 
           // If angle is greater than 135 degrees (octagon), find speed for approximate arc
-          if (junction_theta > RADIANS(135)) {
+          if ((M_PI / 2) - junction_theta > RADIANS(135)) {
             // NOTE: MinMax acos approximation and thereby also junction_theta top out at pi-0.033, which avoids division by 0
             const float limit_sqr = block->millimeters / (RADIANS(180) - junction_theta) * junction_acceleration;
             NOMORE(vmax_junction_sqr, limit_sqr);

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2397,32 +2397,15 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
           // https://wrf.ecse.rpi.edu/Research/Short_Notes/arcsin/onlyelem.html
           // (acos(x) = pi / 2 - asin(x))
 
-          #if ENABLED(FIXED_POINT_ACOS)
-
-            #define FIXED(f) int32_t(0x10000L * f)
-            const int32_t neg = junction_cos_theta < 0 ? -1 : 1,
-                          t = neg * FIXED(junction_cos_theta),
-                          asinx =       FIXED(0.032843707f)
-                                + t * (-FIXED(1.451838349f)
-                                + t * ( FIXED(29.66153956f)
-                                + t * (-FIXED(131.1123477f)
-                                + t * ( FIXED(262.8130562f)
-                                + t * (-FIXED(242.7199627f) + t * FIXED(84.31466202f)) ))));
-
-            const float junction_theta = RADIANS(90) - (float(neg * asinx) * RECIPROCAL(0x10000L));
-
-          #else
-
-            const float neg = junction_cos_theta < 0 ? -1 : 1,
-                        t = neg * junction_cos_theta,
-                        asinx =       0.032843707f
-                              + t * (-1.451838349f
-                              + t * ( 29.66153956f
-                              + t * (-131.1123477f
-                              + t * ( 262.8130562f
-                              + t * (-242.7199627f + t * 84.31466202f) )))),
-                        junction_theta = RADIANS(90) - neg * asinx;
-          #endif
+          const float neg = junction_cos_theta < 0 ? -1 : 1,
+                      t = neg * junction_cos_theta,
+                      asinx =       0.032843707f
+                            + t * (-1.451838349f
+                            + t * ( 29.66153956f
+                            + t * (-131.1123477f
+                            + t * ( 262.8130562f
+                            + t * (-242.7199627f + t * 84.31466202f) )))),
+                      junction_theta = RADIANS(90) - neg * asinx;
 
           // If angle is greater than 135 degrees (octagon), find speed for approximate arc
           if (junction_theta > RADIANS(135)) {


### PR DESCRIPTION
### Description

This improves the `acos()` approximation used for JD calculation. Where the old approx. had a maximum error of -0.18 rads and thereby limited the max computed angle to 169.69°, this has an error of +-0.033 rads and tops out at 178.12°. In consequence, the speed limit `limit_sqr` for all angles larger than 169.69° and some angles smaller than this is increased (significantly). Wherever `vmax_junction_sqr` is not limited by the [default JD calculations](https://github.com/MarlinFirmware/Marlin/blob/9b555f2fee4061d6031dcdc71559eb55d86e36e3/Marlin/planner.cpp#L2336), but by the [small segment "hack"](https://github.com/MarlinFirmware/Marlin/blob/9b555f2fee4061d6031dcdc71559eb55d86e36e3/Marlin/planner.cpp#L2337), this results in increased (and more precisely calculated) cornering speeds.

### Benefits

Stutter on curves with intermittent small segments is greatly reduced and - in most cases - totally eliminated. Depending on the junction deviation and max acceleration values set by the user, some residual stutter may occur: If `DEFAULT_MAX_ACCELERATION` is set very low (i.e. {200, 200, EEE, ZZZ} and JD is set very high (i.e. 0.3), `limit_sqr < vmax_junction_sqr` may be true for long stretches of a curve with small segments. Because limit_sqr appears to be still somewhat [borked due to how `junction_cos_theta` is calculated](https://github.com/MarlinFirmware/Marlin/issues/17342#issuecomment-614250871), some stutter may still emerge. This is unrelated to the `acos()` approximation and is not the target of this PR.

Before patch (left) / after patch (right) image:
![IMG_20200416_122430](https://user-images.githubusercontent.com/1209896/79456059-20f39600-7fee-11ea-8e87-779235c3b00b.png)


### Related Issues

This mitigates #17342 ("JUNCTION_DEVIATION creates unexpected decelerations/accelerations on smooth curves") and should make the issue disappear for all but the most extreme circumstances (see explanation above).
