### PR TITLE
Fix Auto Build VScode for MELZI_CREALITY bords.

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -283,7 +283,7 @@
 #elif MB(MELZI_MAKR3D)
   #include "sanguino/pins_MELZI_MAKR3D.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
 #elif MB(MELZI_CREALITY)
-  #include "sanguino/pins_MELZI_CREALITY.h"     // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_MELZI_CREALITY.h"     // ATmega1284P                            env:melzi env:melzi_optiboot
 #elif MB(MELZI_MALYAN)
   #include "sanguino/pins_MELZI_MALYAN.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
 #elif MB(MELZI_TRONXY)


### PR DESCRIPTION
### Requirements

* Creality board, from 1.1.2 to 1.1.5

### Description

Actually, MELZI_CREALITY boards (from 1.1.2, to 1.1.5) is only ATmega1284P platform, and builds with `melzi` and `melzi_optiboot` environments.

### Benefits

Able to build Marlin with this board with autibuild plugin
