### PR TITLE
Ensure machine name defined in Version.h is used

### DIFF
--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -46,7 +46,7 @@
 /**
  * Defines a generic printer name to be output to the LCD after booting Marlin.
  */
-//#define MACHINE_NAME "3D Printer"
+//#define CUSTOM_MACHINE_NAME "3D Printer"
 
 /**
  * The SOURCE_CODE_URL is the location where users will find the Marlin Source


### PR DESCRIPTION
### Description
The MACHINE_NAME defined in the Version.h file will be overridden by the DEFAULT_MACHINE_NAME defined for the specified motherboard. To prevent this specify the CUSTOM_MACHINE_NAME in the Version.h file instead.

### Benefits
The MACHINE_NAME can be set for the firmware in the Version.h file when a DEFAULT_MACHINE_NAME is defined for the board the firmware is targeting.

### Related Issues
none
