### PR TITLE
Added a check to not allow a value of zero for the screen brightness.

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
@@ -158,6 +158,9 @@ void InterfaceSettingsScreen::onIdle() {
     switch (cmd.track_tag(value)) {
       case 2:
         screen_data.InterfaceSettingsScreen.brightness = float(value) * 128 / 0xFFFF;
+        if(1 > screen_data.InterfaceSettingsScreen.brightness) { /* sanity check to not allow a value of zero */
+          screen_data.InterfaceSettingsScreen.brightness = 1;
+        }        
         CLCD::set_brightness(screen_data.InterfaceSettingsScreen.brightness);
         SaveSettingsDialogBox::settingsChanged();
         break;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
@@ -158,9 +158,8 @@ void InterfaceSettingsScreen::onIdle() {
     switch (cmd.track_tag(value)) {
       case 2:
         screen_data.InterfaceSettingsScreen.brightness = float(value) * 128 / 0xFFFF;
-        if(1 > screen_data.InterfaceSettingsScreen.brightness) { /* sanity check to not allow a value of zero */
+        if (screen_data.InterfaceSettingsScreen.brightness > 1)
           screen_data.InterfaceSettingsScreen.brightness = 1;
-        }        
         CLCD::set_brightness(screen_data.InterfaceSettingsScreen.brightness);
         SaveSettingsDialogBox::settingsChanged();
         break;


### PR DESCRIPTION
### Requirements
Extui / FTDI_EVE_touch_ui display
### Description
This adds a sanity check to the LCD-Brightness setup in the Advanced Settings/Interface menu to not allow a value of less than 1.
### Benefits
You can not turn the backlight completely off anymore, only down to the min value.
### Related Issues
none