### PR TITLE
Add NOZZLE_PARK_Z_RAISE_MIN

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1501,9 +1501,9 @@
 #if ENABLED(NOZZLE_PARK_FEATURE)
   // Specify a park position as { X, Y, Z_raise }
   #define NOZZLE_PARK_POINT { (X_MIN_POS + 10), (Y_MAX_POS - 10), 20 }
-  #define NOZZLE_PARK_Z_RAISE_MIN 2     // (mm) Always raise Z at least this minimum
+  #define NOZZLE_PARK_Z_RAISE_MIN   2   // (mm) Always raise Z by at least this distance
   #define NOZZLE_PARK_XY_FEEDRATE 100   // (mm/s) X and Y axes feedrate (also used for delta Z axis)
-  #define NOZZLE_PARK_Z_FEEDRATE 5      // (mm/s) Z axis feedrate (not used for delta printers)
+  #define NOZZLE_PARK_Z_FEEDRATE    5   // (mm/s) Z axis feedrate (not used for delta printers)
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1501,6 +1501,7 @@
 #if ENABLED(NOZZLE_PARK_FEATURE)
   // Specify a park position as { X, Y, Z_raise }
   #define NOZZLE_PARK_POINT { (X_MIN_POS + 10), (Y_MAX_POS - 10), 20 }
+  #define NOZZLE_PARK_Z_RAISE_MIN 2     // (mm) Always raise Z at least this minimum
   #define NOZZLE_PARK_XY_FEEDRATE 100   // (mm/s) X and Y axes feedrate (also used for delta Z axis)
   #define NOZZLE_PARK_Z_FEEDRATE 5      // (mm/s) Z axis feedrate (not used for delta printers)
 #endif

--- a/Marlin/src/feature/mmu2/mmu2.cpp
+++ b/Marlin/src/feature/mmu2/mmu2.cpp
@@ -575,7 +575,7 @@ void MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
         resume_position = current_position;
 
         if (move_axes && all_axes_homed())
-          nozzle.park(2, park_point /*= NOZZLE_PARK_POINT*/);
+          nozzle.park(0, park_point /*= NOZZLE_PARK_POINT*/);
 
         if (turn_off_nozzle) thermalManager.setTargetHotend(0, active_extruder);
 

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -431,7 +431,7 @@ bool pause_print(const float &retract, const xyz_pos_t &park_point, const float 
 
   // Park the nozzle by moving up by z_lift and then moving to (x_pos, y_pos)
   if (!axes_need_homing())
-    nozzle.park(2, park_point);
+    nozzle.park(0, park_point);
 
   #if ENABLED(DUAL_X_CARRIAGE)
     const int8_t saved_ext        = active_extruder;

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -194,8 +194,18 @@ Nozzle nozzle;
         do_blocking_move_to_z(_MIN(current_position.z + park.z, Z_MAX_POS), fr_z);
         break;
 
-      default: // Raise to at least the Z-park height
-        do_blocking_move_to_z(_MAX(park.z, current_position.z), fr_z);
+      default: // Raise to at least the Z-park height and raise not less than NOZZLE_PARK_Z_RAISE_MIN
+        do_blocking_move_to_z(
+                _MAX(
+                    park.z,
+                    _MIN(current_position.z +
+                        #ifdef NOZZLE_PARK_Z_RAISE_MIN
+                            NOZZLE_PARK_Z_RAISE_MIN
+                        #else
+                            0
+                        #endif // NOZZLE_PARK_Z_RAISE_MIN
+                        , Z_MAX_POS)),
+                fr_z);
     }
 
     do_blocking_move_to_xy(park, fr_xy);

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -194,18 +194,15 @@ Nozzle nozzle;
         do_blocking_move_to_z(_MIN(current_position.z + park.z, Z_MAX_POS), fr_z);
         break;
 
-      default: // Raise to at least the Z-park height and raise not less than NOZZLE_PARK_Z_RAISE_MIN
-        do_blocking_move_to_z(
-                _MAX(
-                    park.z,
-                    _MIN(current_position.z +
-                        #ifdef NOZZLE_PARK_Z_RAISE_MIN
-                            NOZZLE_PARK_Z_RAISE_MIN
-                        #else
-                            0
-                        #endif // NOZZLE_PARK_Z_RAISE_MIN
-                        , Z_MAX_POS)),
-                fr_z);
+      default: {
+        // Apply a minimum raise, overriding G27 Z
+        const float min_raised_z =_MIN(Z_MAX_POS, current_position.z
+          #ifdef NOZZLE_PARK_Z_RAISE_MIN
+            + NOZZLE_PARK_Z_RAISE_MIN
+          #endif
+        );
+        do_blocking_move_to_z(_MAX(park.z, min_raised_z), fr_z);
+      } break;
     }
 
     do_blocking_move_to_xy(park, fr_xy);


### PR DESCRIPTION
### Description

This change behavior of parking nozzle for example during filament
change or pause.

Before this change, nozzle gets lifted everytime by NOZZLE_PARK_POINT.z
with default value 2cm. User want to have this value realativly high,
because it's not possible to manually clean nozzle when nozzle is too
low - near to bed. But this value is too much when nozzle is already
high enough.

After this change, when nozzle gets parked, it's always lifted at least
by NOZZLE_PARK_Z_RAISE_MIN, with default value 2mm. That's enough to not
crash with nozzle into printed model. But if Z is bellow NOZZLE_PARK_POINT.z
nozzle is raised to NOZZLE_PARK_POINT.z. So always high enough to clean
it from bottom manually, but not useless raised if it's high enough.

### Benefits

Faster parking in higher layers.

### Related Issues

none