### PR TITLE
Fix: Ensure brightness >0 in ExtUI

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
@@ -157,9 +157,7 @@ void InterfaceSettingsScreen::onIdle() {
     CommandProcessor cmd;
     switch (cmd.track_tag(value)) {
       case 2:
-        screen_data.InterfaceSettingsScreen.brightness = float(value) * 128 / 0xFFFF;
-        if (screen_data.InterfaceSettingsScreen.brightness > 1)
-          screen_data.InterfaceSettingsScreen.brightness = 1;
+        screen_data.InterfaceSettingsScreen.brightness = max(1, (value * 128UL) / 0xFFFF);
         CLCD::set_brightness(screen_data.InterfaceSettingsScreen.brightness);
         SaveSettingsDialogBox::settingsChanged();
         break;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
@@ -157,7 +157,7 @@ void InterfaceSettingsScreen::onIdle() {
     CommandProcessor cmd;
     switch (cmd.track_tag(value)) {
       case 2:
-        screen_data.InterfaceSettingsScreen.brightness = max(1, (value * 128UL) / 0xFFFF);
+        screen_data.InterfaceSettingsScreen.brightness = constrain((value * 128UL) / 0xFFFF, 1, 11);
         CLCD::set_brightness(screen_data.InterfaceSettingsScreen.brightness);
         SaveSettingsDialogBox::settingsChanged();
         break;


### PR DESCRIPTION
### Requirements

Extui Display

### Description

This is a fix for the previous pull request, sorry.
This time the code below really is what I entered to be included here.
And of course I tried it before committing it.

### Benefits

Prevents a blacked-out display buy making sure the brightness level is at least 1.

### Related Issues

None.