### PR TITLE
[BUGFIX] E0 auto fan pin

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -429,15 +429,6 @@
  * Multiple extruders can be assigned to the same pin in which case
  * the fan will turn on when any selected extruder is above the threshold.
  */
-#define E0_AUTO_FAN_PIN -1
-#define E1_AUTO_FAN_PIN -1
-#define E2_AUTO_FAN_PIN -1
-#define E3_AUTO_FAN_PIN -1
-#define E4_AUTO_FAN_PIN -1
-#define E5_AUTO_FAN_PIN -1
-#define E6_AUTO_FAN_PIN -1
-#define E7_AUTO_FAN_PIN -1
-#define CHAMBER_AUTO_FAN_PIN -1
 
 #define EXTRUDER_AUTO_FAN_TEMPERATURE 50
 #define EXTRUDER_AUTO_FAN_SPEED 255   // 255 == full speed

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1,4 +1,4 @@
-/** 
+/**
  * Marlin 3D Printer Firmware
  * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1,4 +1,4 @@
-/**
+/** 
  * Marlin 3D Printer Firmware
  * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *


### PR DESCRIPTION
Definitions removed the pin number from the file `xxx_pins.h`
The fan did not turn on after exceeding 50 * C.
Now it works, even as nothing is defined in `xxx_pins.h` this of course doesn't work

There is such a thing in the `sensitive_pins.h` file.

```
//
// Heaters, Fans, Temp Sensors
//

#ifndef E0_AUTO_FAN_PIN
   #define E0_AUTO_FAN_PIN -1
#endif
#ifndef E1_AUTO_FAN_PIN
   #define E1_AUTO_FAN_PIN -1
#endif
#ifndef E2_AUTO_FAN_PIN
   #define E2_AUTO_FAN_PIN -1
#endif
#ifndef E3_AUTO_FAN_PIN
   #define E3_AUTO_FAN_PIN -1
#endif
#ifndef E4_AUTO_FAN_PIN
   #define E4_AUTO_FAN_PIN -1
#endif
#ifndef E5_AUTO_FAN_PIN
   #define E5_AUTO_FAN_PIN -1
#endif
#ifndef E6_AUTO_FAN_PIN
   #define E6_AUTO_FAN_PIN -1
#endif
#ifndef E7_AUTO_FAN_PIN
   #define E7_AUTO_FAN_PIN -1
#endif


```