### PR TITLE
Home before filament change if XYZ position is unknown

### DIFF
--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -97,7 +97,7 @@ void GcodeSuite::M600() {
 
   #if ENABLED(HOME_BEFORE_FILAMENT_CHANGE)
     // Don't allow filament change without homing first
-    if (axes_need_homing()) home_all_axes();
+    if (!all_axes_known()) home_all_axes();
   #endif
 
   #if EXTRUDERS > 1


### PR DESCRIPTION
### Description

Currently, if `HOME_BEFORE_FILAMENT_CHANGE` is enabled and you issue a filament change, the printer will home one time and never again before subsequent filament changes until power is cycled. This is a problem if steppers are disabled after a print or manually through the controller/`M18` and XYZ position has become unknown. Sending another filament change/`M600` while idle would cause hotend/bed to slam into the frame.

After this PR, if `HOME_BEFORE_FILAMENT_CHANGE` is enabled and you issue a filament change, printer will home if XYZ position is unknown and not just one time after power up.

### Benefits

Printer no longer crashes into frame if XYZ position is unknown and you issue a filament change, which I believe was the original intent of `HOME_BEFORE_FILAMENT_CHANGE`, or at least makes the most sense from a safety perspective.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/17663, https://github.com/MarlinFirmware/Marlin/issues/16307