### PR TITLE
Save/Restore leveling on toolchange for singlenozzle too

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -914,7 +914,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     const uint8_t old_tool = active_extruder;
     const bool can_move_away = !no_move && !idex_full_control;
 
-    #if HAS_LEVELING && DISABLED(SINGLENOZZLE)
+    #if HAS_LEVELING
       // Set current position to the physical position
       TEMPORARY_BED_LEVELING_STATE(false);
     #endif


### PR DESCRIPTION
Related issue #17229

- UBL correction must be frozen during tool change
- For all configurations

Not sure it's the perfect solution , but i have fixed this , with very simple preprocessor line
Need to be evaluated by maintainers
