### PR TITLE
Minor JD optimization

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2309,7 +2309,8 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
         const float junction_acceleration = limit_value_by_axis_maximum(block->acceleration, junction_unit_vec),
                     sin_theta_d2 = SQRT(0.5f * (1.0f - junction_cos_theta)); // Trig half angle identity. Always positive.
-        vmax_junction_sqr = JUNC_SQ(junction_deviation_mm, sin_theta_d2);
+
+        vmax_junction_sqr = JUNC_SQ(junction_acceleration, sin_theta_d2);
 
         if (block->millimeters < 1) {
           const float neg = junction_cos_theta < 0 ? -1 : 1,

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -822,9 +822,12 @@ class Planner {
       static void autotemp_M104_M109();
     #endif
 
+    #define JUNC_SQ(N,ST) (junction_deviation_mm * (N) * (ST) / (1.0f - (ST)))
+    #define JUNC_F(N,ST) SQRT(JUNC_SQ(N,ST))
+
     #if HAS_LINEAR_E_JERK
       FORCE_INLINE static void recalculate_max_e_jerk() {
-        #define GET_MAX_E_JERK(N) SQRT(SQRT(0.5) * junction_deviation_mm * (N) * RECIPROCAL(1.0 - SQRT(0.5)))
+        #define GET_MAX_E_JERK(N) JUNC_F(N,SQRT(0.5))
         #if ENABLED(DISTINCT_E_FACTORS)
           LOOP_L_N(i, EXTRUDERS)
             max_e_jerk[i] = GET_MAX_E_JERK(settings.max_acceleration_mm_per_s2[E_AXIS_N(i)]);


### PR DESCRIPTION
Since the calculation doesn't cost any more, get the difference from `RAD(180)` which will be used for the division. This happens to correspond to `acos(-t)`.

Also:

- Perform the multiplication ahead of the division in case this is good for precision.
- Only proceed to the calculation if the input value is under `cos(135)` (i.e., `sin(-45)`).
