### PR TITLE
ReARM: Fix SDSS pin for RRD Full/Smart Graphics

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
@@ -353,7 +353,7 @@
   #define SD_DETECT_PIN                    P1_31  // (49) J3-1 & AUX-3 (NOT 5V tolerant)
   #define KILL_PIN                         P1_22  // (41) J5-4 & AUX-4
   #define LCD_PINS_RS                      P0_16  // (16) J3-7 & AUX-4
-  #define LCD_SDSS                         P0_16  // (16) J3-7 & AUX-4
+  #define LCD_SDSS                         P1_23  // (53) J3-5 & AUX-3
 
   #if ENABLED(NEWPANEL)
     #if ENABLED(REPRAPWORLD_KEYPAD)


### PR DESCRIPTION
### Requirements

-Rearm board + RRD Full/Smart Graphics

### Description

`LCD_SDSS` uses the same pin as `LCD_PINS_RS` . according with the ReARM Pinout, `SDSS` is D53 ~ P1_23 (J3-5 & AUX-3)


![Screenshot_20200425_000937](https://user-images.githubusercontent.com/462213/80260831-1047bd80-8689-11ea-8f15-2f14ee4e6532.png)![Screenshot_20200425_001018](https://user-images.githubusercontent.com/462213/80260865-28b7d800-8689-11ea-8a24-aeeb28b7745f.png)


### Benefits

Fix the pinout asignament for RDD RRD Full/Smart Graphics

