### PR TITLE
Default to SD EEPROM Emulation for STM32F1

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -58,6 +58,7 @@ jobs:
         - ARMED
         - FYSETC_S6
         - malyan_M300
+        - mks_robin_lite
 
         # Put lengthy tests last
 
@@ -75,7 +76,6 @@ jobs:
         #- at90usb1286_cdc
         #- at90usb1286_dfu
         #- STM32F103CB_malyan
-        #- mks_robin_lite
         #- mks_robin_mini
         #- mks_robin_nano
 

--- a/Marlin/src/HAL/STM32/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_post.h
@@ -22,6 +22,6 @@
 #pragma once
 
 // If no real EEPROM, Flash emulation, or SRAM emulation is available fall back to SD emulation
-#if ENABLED(EEPROM_SETTINGS) && NONE(USE_WIRED_EEPROM, FLASH_EEPROM_EMULATION, SRAM_EEPROM_EMULATION)
+#if USE_FALLBACK_EEPROM
   #define SDCARD_EEPROM_EMULATION
 #endif

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -39,7 +39,7 @@
 #if ENABLED(SDCARD_EEPROM_EMULATION) && DISABLED(SDSUPPORT)
   #undef SDCARD_EEPROM_EMULATION // Avoid additional error noise
   #if USE_FALLBACK_EEPROM
-    #warning "EEPROM mechanism was not specified, SDCARD_EEPROM_EMULATION fallback was used."
+    #warning "EEPROM type not specified. Fallback is SDCARD_EEPROM_EMULATION."
   #endif
-  #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT, disable EEPROM_SETTINGS, or enable a different EEPROM emulation mechanism."
+  #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT or choose another EEPROM emulation."
 #endif

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -35,3 +35,11 @@
 #if ENABLED(FAST_PWM_FAN)
   #error "FAST_PWM_FAN is not yet implemented for this platform."
 #endif
+
+#if ENABLED(SDCARD_EEPROM_EMULATION) && DISABLED(SDSUPPORT)
+  #undef SDCARD_EEPROM_EMULATION // Avoid additional error noise
+  #if USE_FALLBACK_EEPROM
+    #warning "EEPROM mechanism was not specified, SDCARD_EEPROM_EMULATION fallback was used."
+  #endif
+  #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT, disable EEPROM_SETTINGS, or enable a different EEPROM emulation mechanism."
+#endif

--- a/Marlin/src/HAL/STM32F1/eeprom_sdcard.cpp
+++ b/Marlin/src/HAL/STM32F1/eeprom_sdcard.cpp
@@ -32,6 +32,7 @@
 #if ENABLED(SDCARD_EEPROM_EMULATION)
 
 #include "../shared/eeprom_api.h"
+#include "../../sd/cardreader.h"
 
 #ifndef E2END
   #define E2END 0xFFF // 4KB
@@ -41,44 +42,34 @@
 #define _ALIGN(x) __attribute__ ((aligned(x))) // SDIO uint32_t* compat.
 static char _ALIGN(4) HAL_eeprom_data[HAL_EEPROM_SIZE];
 
-#if ENABLED(SDSUPPORT)
+#define EEPROM_FILENAME "eeprom.dat"
 
-  #include "../../sd/cardreader.h"
+bool PersistentStore::access_start() {
+  if (!card.isMounted()) return false;
 
-  #define EEPROM_FILENAME "eeprom.dat"
+  SdFile file, root = card.getroot();
+  if (!file.open(&root, EEPROM_FILENAME, O_RDONLY))
+    return true; // false aborts the save
 
-  bool PersistentStore::access_start() {
-    if (!card.isMounted()) return false;
+  int bytes_read = file.read(HAL_eeprom_data, HAL_EEPROM_SIZE);
+  if (bytes_read < 0) return false;
+  for (; bytes_read < HAL_EEPROM_SIZE; bytes_read++)
+    HAL_eeprom_data[bytes_read] = 0xFF;
+  file.close();
+  return true;
+}
 
-    SdFile file, root = card.getroot();
-    if (!file.open(&root, EEPROM_FILENAME, O_RDONLY))
-      return true; // false aborts the save
+bool PersistentStore::access_finish() {
+  if (!card.isMounted()) return false;
 
-    int bytes_read = file.read(HAL_eeprom_data, HAL_EEPROM_SIZE);
-    if (bytes_read < 0) return false;
-    for (; bytes_read < HAL_EEPROM_SIZE; bytes_read++)
-      HAL_eeprom_data[bytes_read] = 0xFF;
+  SdFile file, root = card.getroot();
+  int bytes_written = 0;
+  if (file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC)) {
+    bytes_written = file.write(HAL_eeprom_data, HAL_EEPROM_SIZE);
     file.close();
-    return true;
   }
-
-  bool PersistentStore::access_finish() {
-    if (!card.isMounted()) return false;
-
-    SdFile file, root = card.getroot();
-    int bytes_written = 0;
-    if (file.open(&root, EEPROM_FILENAME, O_CREAT | O_WRITE | O_TRUNC)) {
-      bytes_written = file.write(HAL_eeprom_data, HAL_EEPROM_SIZE);
-      file.close();
-    }
-    return (bytes_written == HAL_EEPROM_SIZE);
-  }
-
-#else // !SDSUPPORT
-
-  #error "Please define SPI_EEPROM (in Configuration.h) or disable EEPROM_SETTINGS."
-
-#endif // !SDSUPPORT
+  return (bytes_written == HAL_EEPROM_SIZE);
+}
 
 bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   for (size_t i = 0; i < size; i++)

--- a/Marlin/src/HAL/STM32F1/inc/Conditionals_post.h
+++ b/Marlin/src/HAL/STM32F1/inc/Conditionals_post.h
@@ -20,3 +20,8 @@
  *
  */
 #pragma once
+
+// If no real EEPROM, Flash emulation, or SRAM emulation is available fall back to SD emulation
+#if USE_FALLBACK_EEPROM
+  #define SDCARD_EEPROM_EMULATION
+#endif

--- a/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
@@ -45,7 +45,7 @@
 #if ENABLED(SDCARD_EEPROM_EMULATION) && DISABLED(SDSUPPORT)
   #undef SDCARD_EEPROM_EMULATION // Avoid additional error noise
   #if USE_FALLBACK_EEPROM
-    #warning "EEPROM mechanism was not specified, SDCARD_EEPROM_EMULATION fallback was used."
+    #warning "EEPROM type not specified. Fallback is SDCARD_EEPROM_EMULATION."
   #endif
-  #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT, disable EEPROM_SETTINGS, or enable a different EEPROM emulation mechanism."
+  #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT or choose another EEPROM emulation."
 #endif

--- a/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
@@ -41,3 +41,11 @@
   #warning "With TMC2208/9 consider using SoftwareSerialM with HAVE_SW_SERIAL and appropriate SS_TIMER."
   #error "Missing SoftwareSerial implementation."
 #endif
+
+#if ENABLED(SDCARD_EEPROM_EMULATION) && DISABLED(SDSUPPORT)
+  #undef SDCARD_EEPROM_EMULATION // Avoid additional error noise
+  #if USE_FALLBACK_EEPROM
+    #warning "EEPROM mechanism was not specified, SDCARD_EEPROM_EMULATION fallback was used."
+  #endif
+  #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT, disable EEPROM_SETTINGS, or enable a different EEPROM emulation mechanism."
+#endif

--- a/buildroot/share/tests/mks_robin_lite-tests
+++ b/buildroot/share/tests/mks_robin_lite-tests
@@ -6,12 +6,12 @@
 # exit on first failure
 set -e
 
-use_example_configs Mks/Robin
+restore_configs
 opt_set MOTHERBOARD BOARD_MKS_ROBIN_LITE
-opt_set EXTRUDERS 1
-opt_set TEMP_SENSOR_1 0
-opt_disable FSMC_GRAPHICAL_TFT
-exec_test $1 $2 "Default Configuration"
+opt_set SERIAL_PORT -1
+opt_enable EEPROM_SETTINGS
+opt_enable SDSUPPORT
+exec_test $1 $2 "Default Configuration with Fallback SD EEPROM"
 
 # cleanup
 restore_configs


### PR DESCRIPTION
### Description

The STM32F1 HAL did not provide a default EEPROM mechanism when `USE_FALLBACK_EEPROM` is set.

Surprisingly the missing PersistentStorage functions were only a warning, so people would build firmware and have no idea why their boards did not work.

This change will fall back to SD EEPROM emulation when possible, otherwise it will print error messages to the user rather than completing the build.

### Benefits

EEPROM storage "just works" for any STM32F1 board with SDSUPPORT.
Less confusion for other users where this cannot be enabled, due to improved error reporting.

I enabled testing for the Robin lite, because this is the board the Discord user reporting this used.

### Related Issues

I believe this is related to #17376. It may not 100% resolve it, as additional configuration might be needed or various boards (such as ONBOARD vs. LCD).

**I have not actually tested this on hardware. I only tested that compilation was successful where it previously had warnings about missing persistent storage functions.**
