### PR TITLE
M200 quality of life

### DIFF
--- a/Marlin/src/HAL/STM32/SoftwareSerial.cpp
+++ b/Marlin/src/HAL/STM32/SoftwareSerial.cpp
@@ -287,7 +287,7 @@ inline void SoftwareSerial::recv() {
 //
 
 /* static */
-inline void SoftwareSerial::handleInterrupt(HardwareTimer*) {
+inline void SoftwareSerial::handleInterrupt() {
   if (active_in)   active_in->recv();
   if (active_out) active_out->send();
 }

--- a/Marlin/src/HAL/STM32/SoftwareSerial.h
+++ b/Marlin/src/HAL/STM32/SoftwareSerial.h
@@ -83,7 +83,7 @@ class SoftwareSerial : public Stream {
     void setRX();
     void setSpeed(uint32_t speed);
     void setRXTX(bool input);
-    static void handleInterrupt(HardwareTimer *timer);
+    static void handleInterrupt();
 
   public:
     // public methods

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -135,10 +135,10 @@
 #define ENABLE_TEMPERATURE_INTERRUPT() HAL_timer_enable_interrupt(TEMP_TIMER_NUM)
 #define DISABLE_TEMPERATURE_INTERRUPT() HAL_timer_disable_interrupt(TEMP_TIMER_NUM)
 
-extern void Step_Handler(HardwareTimer *htim);
-extern void Temp_Handler(HardwareTimer *htim);
-#define HAL_STEP_TIMER_ISR() void Step_Handler(HardwareTimer *htim)
-#define HAL_TEMP_TIMER_ISR() void Temp_Handler(HardwareTimer *htim)
+extern void Step_Handler();
+extern void Temp_Handler();
+#define HAL_STEP_TIMER_ISR() void Step_Handler()
+#define HAL_TEMP_TIMER_ISR() void Temp_Handler()
 
 // ------------------------
 // Public Variables

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -33,6 +33,11 @@
 #define hal_timer_t uint32_t
 #define HAL_TIMER_TYPE_MAX 0xFFFFFFFF // Timers can be 16 or 32 bit
 
+#if MB(MALYANM200, MALYANM300)
+  #define STEP_TIMER 1
+  #define TEMP_TIMER 3
+#endif
+
 #ifdef STM32F0xx
 
   #define HAL_TIMER_RATE (F_CPU) // frequency of timer peripherals


### PR DESCRIPTION
### Benefits

The ST Arduino core has changed the definition for callbacks again. On top of this, board specific overrides do not work, and automatic timer selection code isn't ready to merge. This change fixes the definitions and sets timer overrides for the M200 V1 and V2. 

### Related Issues

