### PR TITLE
A couple of small changes for extui/eve.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1379,6 +1379,7 @@
   //#define AO_EXP2_PINMAP      // AlephObjects CLCD UI EXP2 mapping
   //#define CR10_TFT_PINMAP     // Rudolph Riedel's CR10 pin mapping
   //#define S6_TFT_PINMAP       // FYSETC S6 pin mapping
+  //#define CHEETAH_TFT_PINMAP  // FYSETC Cheetah pin mapping
   //#define E3_EXP1_PINMAP      // E3 type boards (SKR E3/DIP, FYSETC Cheetah and Stock boards) EXP1 pin mapping
   //#define GENERIC_EXP2_PINMAP // GENERIC EXP2 pin mapping
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
@@ -1057,6 +1057,8 @@ void CLCD::init() {
   host_cmd(Use_Crystal ? CLKEXT : CLKINT, 0);
   host_cmd(FTDI::ACTIVE, 0);                        // Activate the System Clock
 
+  delay(40); // FTDI/BRT recommendation: no SPI traffic during startup. EVE needs at the very least 45ms to start, so leave her alone for a little while.
+
   /* read the device-id until it returns 0x7c or times out, should take less than 150ms */
   uint8_t counter;
   for (counter = 0; counter < 250; counter++) {
@@ -1074,6 +1076,26 @@ void CLCD::init() {
      #if ENABLED(TOUCH_UI_DEBUG)
        SERIAL_ECHO_START();
        SERIAL_ECHOLNPAIR("Timeout waiting for device ID, should be 124, got ", device_id);
+     #endif
+   }
+  }
+
+  /* make sure that all units are in working conditions, usually the touch-controller needs a little more time */
+  for (counter = 0; counter < 100; counter++) {
+   uint8_t reset_status = mem_read_8(REG::CPURESET) & 0x03;
+   if (reset_status == 0x00) {
+     #if ENABLED(TOUCH_UI_DEBUG)
+       SERIAL_ECHO_MSG("FTDI chip all units running ");
+     #endif
+     break;
+   }
+   else
+     delay(1);
+
+   if (counter == 99) {
+     #if ENABLED(TOUCH_UI_DEBUG)
+       SERIAL_ECHO_START();
+       SERIAL_ECHOLNPAIR("Timeout waiting for resets status, should be 0x00, got ", reset_status);
      #endif
    }
   }
@@ -1129,9 +1151,6 @@ void CLCD::init() {
   // Turning off dithering seems to help prevent horizontal line artifacts on certain colors
   mem_write_8(REG::DITHER,  0);
 
-  // Initialize the command FIFO
-  CommandFifo::reset();
-
   default_touch_transform();
   default_display_orientation();
 }
@@ -1151,17 +1170,13 @@ void CLCD::default_display_orientation() {
   #if FTDI_API_LEVEL >= 810
     // Set the initial display orientation. On the FT810, we use the command
     // processor to do this since it will also update the transform matrices.
-    if (FTDI::ftdi_chip >= 810) {
-      CommandFifo cmd;
-      cmd.setrotate(
-          ENABLED(TOUCH_UI_MIRRORED) * 4
-        + ENABLED(TOUCH_UI_PORTRAIT) * 2
-        + ENABLED(TOUCH_UI_INVERTED) * 1
-      );
-      cmd.execute();
-    }
-    else
-      TERN_(TOUCH_UI_INVERTED, mem_write_32(REG::ROTATE, 1));
+    CommandFifo cmd;
+    cmd.setrotate(
+        ENABLED(TOUCH_UI_MIRRORED) * 4
+      + ENABLED(TOUCH_UI_PORTRAIT) * 2
+      + ENABLED(TOUCH_UI_INVERTED) * 1
+    );
+    cmd.execute();
   #elif ANY(TOUCH_UI_PORTRAIT, TOUCH_UI_MIRRORED)
     #error "PORTRAIT or MIRRORED orientation not supported on the FT800."
   #elif ENABLED(TOUCH_UI_INVERTED)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
@@ -1082,22 +1082,20 @@ void CLCD::init() {
 
   /* make sure that all units are in working conditions, usually the touch-controller needs a little more time */
   for (counter = 0; counter < 100; counter++) {
-   uint8_t reset_status = mem_read_8(REG::CPURESET) & 0x03;
-   if (reset_status == 0x00) {
-     #if ENABLED(TOUCH_UI_DEBUG)
-       SERIAL_ECHO_MSG("FTDI chip all units running ");
-     #endif
-     break;
-   }
-   else
-     delay(1);
+    uint8_t reset_status = mem_read_8(REG::CPURESET) & 0x03;
+    if (reset_status == 0x00) {
+      #if ENABLED(TOUCH_UI_DEBUG)
+        SERIAL_ECHO_MSG("FTDI chip all units running ");
+      #endif
+      break;
+    }
+    else
+      delay(1);
 
-   if (counter == 99) {
-     #if ENABLED(TOUCH_UI_DEBUG)
-       SERIAL_ECHO_START();
-       SERIAL_ECHOLNPAIR("Timeout waiting for resets status, should be 0x00, got ", reset_status);
-     #endif
-   }
+    if (ENABLED(TOUCH_UI_DEBUG) && counter == 99) {
+      SERIAL_ECHO_START();
+      SERIAL_ECHOLNPAIR("Timeout waiting for reset status. Should be 0x00, got ", reset_status);
+    }
   }
 
   mem_write_8(REG::PWM_DUTY, 0);   // turn off Backlight, Frequency already is set to 250Hz default

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/spi.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/spi.h
@@ -55,7 +55,7 @@ namespace FTDI {
       #ifdef CLCD_USE_SOFT_SPI
         return _soft_spi_xfer(0x00);
       #else
-        SPI_OBJ.transfer(0x00);
+        return SPI_OBJ.transfer(0x00);
       #endif
     };
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/pin_mappings.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/pin_mappings.h
@@ -27,6 +27,24 @@
  * without adding new pin definitions to the board.
  */
 
+#ifdef CHEETAH_TFT_PINMAP
+  #ifndef __MARLIN_FIRMWARE__
+    #error "This pin mapping requires Marlin."
+  #endif    
+  
+    #define CLCD_SPI_BUS    2
+
+    #define CLCD_MOD_RESET  PC9
+    #define CLCD_SPI_CS     PB12
+
+    //#define CLCD_USE_SOFT_SPI
+    #if ENABLED(CLCD_USE_SOFT_SPI)
+      #define CLCD_SOFT_SPI_MOSI PB15
+      #define CLCD_SOFT_SPI_MISO PB14
+      #define CLCD_SOFT_SPI_SCLK PB13
+    #endif
+#endif
+
 #ifdef S6_TFT_PINMAP
   #ifndef __MARLIN_FIRMWARE__
     #error "This pin mapping requires Marlin."

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/interface_settings_screen.cpp
@@ -161,7 +161,7 @@ void InterfaceSettingsScreen::onIdle() {
     CommandProcessor cmd;
     switch (cmd.track_tag(value)) {
       case 2:
-        screen_data.InterfaceSettingsScreen.brightness = _MAX(11, (value * 128UL) / 0xFFFF);
+        screen_data.InterfaceSettingsScreen.brightness = max(11, (value * 128UL) / 0xFFFF);
         CLCD::set_brightness(screen_data.InterfaceSettingsScreen.brightness);
         SaveSettingsDialogBox::settingsChanged();
         break;


### PR DESCRIPTION
### Requirements

EVE display

### Description

A couple of small changes to improve the extui/eve interface.

### Benefits

pin_mappings.h : Added settings for the Fysetc Cheetah

Configuration_adv.h: added a define for CHEETAH_TFT_PINMAP

interface_settings_screen.cpp: _MAX replaced with max as the former threw a bunch of warnings

commands.cpp:
 CLCD::init()
  - added a short delay after the ACTIVE command to give the EVE a moment of no SPI traffic as recommend by FTDI/BRT
 - added a loop to check for the reset status as recommended by FTDI/BRT
 - removed the CommandFifo::reset(); as it did nothing but delaying the startup by 0.4s, the FIFO literally just went thru a power-down reset
CLCD::default_display_orientation()
 - removed the "if (FTDI::ftdi_chip >= 810)" inside the "#if FTDI_API_LEVEL >= 810"

spi.h: spi_recv() was missing a return for the hardware spi

### Related Issues

#16628