### PR TITLE
Fix issue #17728 Incorrect passing of M42 

### DIFF
--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -56,7 +56,7 @@ void GcodeSuite::M42() {
       #ifdef INPUT_PULLDOWN
         case 3: pinMode(pin, INPUT_PULLDOWN); break;
       #endif
-      default: SERIAL_ECHOLNPGM("Invalid Pin Mode");
+      default: SERIAL_ECHOLNPGM("Invalid Pin Mode"); return;
     }
   }
 

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -58,7 +58,6 @@ void GcodeSuite::M42() {
       #endif
       default: SERIAL_ECHOLNPGM("Invalid Pin Mode");
     }
-    return;
   }
 
   if (!parser.seenval('S')) return;


### PR DESCRIPTION
### Requirements

Any Marlin any controller with m42
Optionally enable m43 for debugging results of command

### Description

M42 doesn't action S parameter when M parameter is present. 

Eg Command M42 M1 P46 S255
Result the mode 1 is applied to pin 46, but S255 is not applied.

### Benefits

M42 now processes both M and S parameters.

### Related Issues
issue #17728