### PR TITLE
Fix wall of LPC1768 I2C_ADDRESS redefined warnings

### DIFF
--- a/Marlin/src/HAL/LPC1768/HAL.h
+++ b/Marlin/src/HAL/LPC1768/HAL.h
@@ -49,6 +49,7 @@ extern "C" volatile uint32_t _millis;
 #include <CDCSerial.h>
 
 // i2c uses 8-bit shifted address
+#undef  I2C_ADDRESS
 #define I2C_ADDRESS(A) ((A) << 1)
 
 //


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/commit/035d6cd16d8edcbc76d8a1aa4a1d2e2e3cde60ba causes a wall of I2C_ADDRESS redefined warnings (enough that I can't capture that entire log). Small sample below:

```prolog
In file included from Marlin/src/module/../inc/../core/boards.h:24,
                 from Marlin/src/module/../inc/MarlinConfigPre.h:35,
                 from Marlin/src/module/../inc/MarlinConfig.h:28,
                 from Marlin/src/module/planner_bezier.cpp:30:
Marlin/src/module/../inc/../core/macros.h:295: note: this is the location of the previous definition
  295 | #define I2C_ADDRESS(A) (typeof(A))(TERN(TARGET_LPC1768, (A) << 1, A))
      | 
In file included from Marlin/src/module/thermistor/../../inc/../HAL/HAL.h:26,
                 from Marlin/src/module/thermistor/../../inc/MarlinConfig.h:30,
                 from Marlin/src/module/thermistor/thermistors.h:24,
                 from Marlin/src/module/temperature.h:28,
                 from Marlin/src/module/temperature.cpp:27:
```

### Benefits

No more warnings

### Related Issues

None
