### PR TITLE
Fix for SD card pause not working with PARK_HEAD_ON_PAUSE

### DIFF
--- a/Marlin/src/gcode/sd/M24_M25.cpp
+++ b/Marlin/src/gcode/sd/M24_M25.cpp
@@ -82,16 +82,16 @@ void GcodeSuite::M24() {
  */
 void GcodeSuite::M25() {
 
-  // Set initial pause flag to prevent more commands from landing in the queue while we try to pause
-  #if ENABLED(SDSUPPORT)
-    if (IS_SD_PRINTING()) card.pauseSDPrint();
-  #endif
-
   #if ENABLED(PARK_HEAD_ON_PAUSE)
 
     M125();
 
   #else
+
+    // Set initial pause flag to prevent more commands from landing in the queue while we try to pause
+    #if ENABLED(SDSUPPORT)
+      if (IS_SD_PRINTING()) card.pauseSDPrint();
+    #endif
 
     #if ENABLED(POWER_LOSS_RECOVERY)
       if (recovery.enabled) recovery.save(true);


### PR DESCRIPTION
### Description

Currently SD card pause is not working with PARK_HEAD_ON_PAUSE. On further investigation, I determined that this was because M25 is pre-maturely pausing the SD print prior to calling M125. M125 then checks whether an SD print is running and takes the wrong code execution path because it finds the print is already paused,

This PR modified the code to pass control directly to M125 when PARK_HEAD_ON_PAUSE is enabled.

### Benefits

Now it is possible to pause a print without having it immediately restart.
