### PR TITLE
Enhance and fix FTDI EVE Touch UI

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
@@ -147,6 +147,8 @@ namespace Language_en {
   PROGMEM Language_Str MSG_TOUCH_CALIBRATION_START  = u8"Release to begin screen calibration";
   PROGMEM Language_Str MSG_TOUCH_CALIBRATION_PROMPT = u8"Touch the dots to calibrate";
   PROGMEM Language_Str MSG_AUTOLEVEL_X_AXIS         = u8"Level X Axis";
+  PROGMEM Language_Str MSG_BED_MAPPING_DONE         = u8"Bed mapping finished";
+  PROGMEM Language_Str MSG_RESET_BLTOUCH            = u8"Reset BLTouch";
 
   #ifdef TOUCH_UI_LULZBOT_BIO
     PROGMEM Language_Str MSG_MOVE_TO_HOME           = u8"Move to Home";

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -51,17 +51,17 @@ namespace ExtUI {
   }
 
   void onMediaRemoved() {
-    if(isPrintingFromMedia()) {
+    if (isPrintingFromMedia()) {
       stopPrint();
       InterfaceSoundsScreen::playEventSound(InterfaceSoundsScreen::PRINTING_FAILED);
-    } else {
-      sound.play(media_removed, PLAY_ASYNCHRONOUS);
     }
+    else
+      sound.play(media_removed, PLAY_ASYNCHRONOUS);
+
     if (AT_SCREEN(StatusScreen) || isPrintingFromMedia())
       StatusScreen::setStatusMessage(GET_TEXT_F(MSG_MEDIA_REMOVED));
-    if (AT_SCREEN(FilesScreen)) {
-      GOTO_SCREEN(StatusScreen)
-    }
+
+    if (AT_SCREEN(FilesScreen)) GOTO_SCREEN(StatusScreen)
   }
 
   void onMediaError() {

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -51,9 +51,14 @@ namespace ExtUI {
   }
 
   void onMediaRemoved() {
-    if (AT_SCREEN(StatusScreen))
+    if(isPrintingFromMedia()) {
+      stopPrint();
+      InterfaceSoundsScreen::playEventSound(InterfaceSoundsScreen::PRINTING_FAILED);
+    } else {
+      sound.play(media_removed, PLAY_ASYNCHRONOUS);
+    }
+    if (AT_SCREEN(StatusScreen) || isPrintingFromMedia())
       StatusScreen::setStatusMessage(GET_TEXT_F(MSG_MEDIA_REMOVED));
-    sound.play(media_removed, PLAY_ASYNCHRONOUS);
     if (AT_SCREEN(FilesScreen)) {
       GOTO_SCREEN(StatusScreen)
     }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
@@ -80,9 +80,15 @@ void AboutScreen::onRedraw(draw_mode_t) {
     #endif
     , OPT_CENTER, font_xlarge
   );
-  draw_text_box(cmd, FW_VERS_POS, progmem_str(getFirmwareName_str()), OPT_CENTER, font_medium);
+  draw_text_box(cmd, FW_VERS_POS,
+  #ifdef TOUCH_UI_VERSION
+    F(TOUCH_UI_VERSION)
+  #else
+    progmem_str(getFirmwareName_str())
+  #endif
+  , OPT_CENTER, font_medium);
   draw_text_box(cmd, FW_INFO_POS, about_str, OPT_CENTER, font_medium);
-  draw_text_box(cmd.tag(3), INSET_POS(LICENSE_POS), GET_TEXT_F(MSG_LICENSE), OPT_CENTER, font_tiny);
+  draw_text_box(cmd, INSET_POS(LICENSE_POS), GET_TEXT_F(MSG_LICENSE), OPT_CENTER, font_tiny);
 
   cmd.font(font_medium)
      .colors(normal_btn)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
@@ -115,11 +115,17 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
       )
       .tag(14).button( TMC_HOMING_THRS_POS,    GET_TEXT_F(MSG_TMC_HOMING_THRS))
       .enabled(
-        #if HAS_MULTI_HOTEND
+        #if HAS_MULTI_HOTEND || ENABLED(BLTOUCH)
           1
         #endif
       )
-      .tag(4) .button( OFFSETS_POS,            GET_TEXT_F(MSG_OFFSETS_MENU))
+      .tag(4) .button( OFFSETS_POS, GET_TEXT_F(
+          #if HOTENDS > 1
+            MSG_OFFSETS_MENU
+          #else
+            MSG_RESET_BLTOUCH
+          #endif
+      ))
       .enabled(
         #if EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
           1
@@ -157,9 +163,13 @@ bool AdvancedSettingsMenu::onTouchEnd(uint8_t tag) {
     case 2:  GOTO_SCREEN(ZOffsetScreen);              break;
     #endif
     case 3:  GOTO_SCREEN(StepsScreen);                break;
-    #if HAS_MULTI_HOTEND
-    case 4:  GOTO_SCREEN(NozzleOffsetScreen);         break;
-    #endif
+    case 4:
+      #if HAS_MULTI_HOTEND
+        GOTO_SCREEN(NozzleOffsetScreen);
+      #elif ENABLED(BLTOUCH)
+        injectCommands_P(PSTR("M280 P0 S60"));
+      #endif
+      break;
     case 5:  GOTO_SCREEN(MaxVelocityScreen);          break;
     case 6:  GOTO_SCREEN(DefaultAccelerationScreen);  break;
     case 7:

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
@@ -89,47 +89,18 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
     CommandProcessor cmd;
     cmd.colors(normal_btn)
        .font(Theme::font_medium)
-      .enabled(
-        #if HAS_BED_PROBE
-          1
-        #endif
-      )
+      .enabled(ENABLED(HAS_BED_PROBE))
       .tag(2) .button( ZPROBE_ZOFFSET_POS,     GET_TEXT_F(MSG_ZPROBE_ZOFFSET))
-      .enabled(
-        #if HAS_CASE_LIGHT
-          1
-        #endif
-      )
+      .enabled(ENABLED(HAS_CASE_LIGHT))
       .tag(16).button( CASE_LIGHT_POS,         GET_TEXT_F(MSG_CASE_LIGHT))
       .tag(3) .button( STEPS_PER_MM_POS,       GET_TEXT_F(MSG_STEPS_PER_MM))
-      .enabled(
-        #if HAS_TRINAMIC_CONFIG
-          1
-        #endif
-      )
+      .enabled(ENABLED(HAS_TRINAMIC_CONFIG))
       .tag(13).button( TMC_CURRENT_POS,        GET_TEXT_F(MSG_TMC_CURRENT))
-      .enabled(
-        #if ENABLED(SENSORLESS_HOMING)
-          1
-        #endif
-      )
+      .enabled(ENABLED(SENSORLESS_HOMING))
       .tag(14).button( TMC_HOMING_THRS_POS,    GET_TEXT_F(MSG_TMC_HOMING_THRS))
-      .enabled(
-        #if HAS_MULTI_HOTEND || ENABLED(BLTOUCH)
-          1
-        #endif
-      )
-      .tag(4) .button( OFFSETS_POS, GET_TEXT_F(
-          #if HOTENDS > 1
-            MSG_OFFSETS_MENU
-          #else
-            MSG_RESET_BLTOUCH
-          #endif
-      ))
-      .enabled(
-        #if EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
-          1
-        #endif
+      .enabled(EITHER(HAS_MULTI_HOTEND, BLTOUCH))
+      .tag(4) .button( OFFSETS_POS,            GET_TEXT_F(TERN(HAS_MULTI_HOTEND, MSG_OFFSETS_MENU, MSG_RESET_BLTOUCH))
+      .enabled(EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
       )
       .tag(11).button( FILAMENT_POS,           GET_TEXT_F(MSG_FILAMENT))
       .tag(12).button( ENDSTOPS_POS,           GET_TEXT_F(MSG_LCD_ENDSTOPS))
@@ -138,18 +109,8 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
       .tag(10).button( RESTORE_DEFAULTS_POS,   GET_TEXT_F(MSG_RESTORE_DEFAULTS))
       .tag(5) .button( VELOCITY_POS,           GET_TEXT_F(MSG_VELOCITY))
       .tag(6) .button( ACCELERATION_POS,       GET_TEXT_F(MSG_ACCELERATION))
-      .tag(7) .button( JERK_POS,               GET_TEXT_F(
-        #if HAS_JUNCTION_DEVIATION
-          MSG_JUNCTION_DEVIATION
-        #else
-          MSG_JERK
-        #endif
-       ))
-      .enabled(
-        #if ENABLED(BACKLASH_GCODE)
-          1
-        #endif
-      )
+      .tag(7) .button( JERK_POS,               GET_TEXT_F(TERN(HAS_JUNCTION_DEVIATION, MSG_JUNCTION_DEVIATION, MSG_JERK))
+      .enabled(ENABLED(BACKLASH_GCODE))
       .tag(8).button( BACKLASH_POS,            GET_TEXT_F(MSG_BACKLASH))
       .colors(action_btn)
       .tag(1).button( BACK_POS,                GET_TEXT_F(MSG_BACK));
@@ -158,31 +119,25 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
 
 bool AdvancedSettingsMenu::onTouchEnd(uint8_t tag) {
   switch (tag) {
-    case 1: SaveSettingsDialogBox::promptToSaveSettings(); break;
+    case  1: SaveSettingsDialogBox::promptToSaveSettings(); break;
     #if HAS_BED_PROBE
-    case 2:  GOTO_SCREEN(ZOffsetScreen);              break;
+    case  2: GOTO_SCREEN(ZOffsetScreen);              break;
     #endif
-    case 3:  GOTO_SCREEN(StepsScreen);                break;
-    case 4:
+    case  3: GOTO_SCREEN(StepsScreen);                break;
+    case  4:
       #if HAS_MULTI_HOTEND
         GOTO_SCREEN(NozzleOffsetScreen);
       #elif ENABLED(BLTOUCH)
         injectCommands_P(PSTR("M280 P0 S60"));
       #endif
       break;
-    case 5:  GOTO_SCREEN(MaxVelocityScreen);          break;
-    case 6:  GOTO_SCREEN(DefaultAccelerationScreen);  break;
-    case 7:
-      #if HAS_JUNCTION_DEVIATION
-        GOTO_SCREEN(JunctionDeviationScreen);
-      #else
-        GOTO_SCREEN(JerkScreen);
-      #endif
-      break;
+    case  5: GOTO_SCREEN(MaxVelocityScreen);          break;
+    case  6: GOTO_SCREEN(DefaultAccelerationScreen);  break;
+    case  7: GOTO_SCREEN(TERN(HAS_JUNCTION_DEVIATION, JunctionDeviationScreen, JerkScreen)); break;
     #if ENABLED(BACKLASH_GCODE)
-    case 8:  GOTO_SCREEN(BacklashCompensationScreen); break;
+    case  8: GOTO_SCREEN(BacklashCompensationScreen); break;
     #endif
-    case 9:  GOTO_SCREEN(InterfaceSettingsScreen);  LockScreen::check_passcode(); break;
+    case  9: GOTO_SCREEN(InterfaceSettingsScreen);  LockScreen::check_passcode(); break;
     case 10: GOTO_SCREEN(RestoreFailsafeDialogBox); LockScreen::check_passcode(); break;
     #if EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
     case 11: GOTO_SCREEN(FilamentMenu); break;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
@@ -35,19 +35,19 @@ using namespace ExtUI;
   #define GRID_ROWS 10
 
   #define MESH_POS    BTN_POS(1, 2), BTN_SIZE(2,5)
+  #define MESSAGE_POS BTN_POS(1, 7), BTN_SIZE(2,1)
   #define Z_LABEL_POS BTN_POS(1, 8), BTN_SIZE(1,1)
   #define Z_VALUE_POS BTN_POS(2, 8), BTN_SIZE(1,1)
-  #define WAIT_POS    BTN_POS(1, 8), BTN_SIZE(2,1)
-  #define BACK_POS    BTN_POS(1,10), BTN_SIZE(2,1)
+  #define OKAY_POS    BTN_POS(1,10), BTN_SIZE(2,1)
 #else
   #define GRID_COLS 5
   #define GRID_ROWS 5
 
-  #define MESH_POS       BTN_POS(1,1), BTN_SIZE(3,5)
-  #define Z_LABEL_POS    BTN_POS(4,2), BTN_SIZE(2,1)
-  #define Z_VALUE_POS    BTN_POS(4,3), BTN_SIZE(2,1)
-  #define WAIT_POS       BTN_POS(4,2), BTN_SIZE(2,2)
-  #define BACK_POS       BTN_POS(4,5), BTN_SIZE(2,1)
+  #define MESH_POS    BTN_POS(1,1), BTN_SIZE(3,5)
+  #define MESSAGE_POS BTN_POS(4,1), BTN_SIZE(2,1)
+  #define Z_LABEL_POS BTN_POS(4,2), BTN_SIZE(2,1)
+  #define Z_VALUE_POS BTN_POS(4,3), BTN_SIZE(2,1)
+  #define OKAY_POS    BTN_POS(4,5), BTN_SIZE(2,1)
 #endif
 
 void BedMeshScreen::drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max) {
@@ -238,7 +238,7 @@ void BedMeshScreen::drawHighlightedPointValue() {
      .text(Z_LABEL_POS, GET_TEXT_F(MSG_MESH_EDIT_Z))
      .text(Z_VALUE_POS, str)
      .colors(action_btn)
-     .tag(1).button( BACK_POS, GET_TEXT_F(MSG_BACK))
+     .tag(1).button( OKAY_POS, GET_TEXT_F(MSG_BUTTON_OKAY))
      .tag(0);
 }
 
@@ -261,7 +261,12 @@ void BedMeshScreen::onRedraw(draw_mode_t what) {
     constexpr float autoscale_max_amplitude = 0.03;
     const bool levelingFinished = screen_data.BedMeshScreen.count >= GRID_MAX_POINTS;
     const float levelingProgress = sq(float(screen_data.BedMeshScreen.count) / GRID_MAX_POINTS);
-    if (levelingFinished) drawHighlightedPointValue();
+    if (levelingFinished) {
+      drawHighlightedPointValue();
+      CommandProcessor cmd;
+      cmd.font(Theme::font_medium)
+         .text(MESSAGE_POS, GET_TEXT_F(MSG_BED_MAPPING_DONE));
+    }
 
     BedMeshScreen::drawMesh(INSET_POS(MESH_POS), ExtUI::getMeshArray(),
       USE_POINTS | USE_HIGHLIGHT | USE_AUTOSCALE | (levelingFinished ? USE_COLORS : 0),

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_start_print_dialog_box.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_start_print_dialog_box.cpp
@@ -31,11 +31,6 @@ using namespace FTDI;
 using namespace Theme;
 using namespace ExtUI;
 
-void ConfirmStartPrintDialogBox::onEntry() {
-  BaseScreen::onEntry();
-  sound.play(twinkle, PLAY_ASYNCHRONOUS);
-}
-
 void ConfirmStartPrintDialogBox::onRedraw(draw_mode_t) {
   const char *filename = getLongFilename();
   char buffer[strlen_P(GET_TEXT(MSG_START_PRINT_CONFIRMATION)) + strlen(filename) + 1];

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
@@ -223,7 +223,6 @@ class ConfirmStartPrintDialogBox : public DialogBoxBaseClass, public UncachedScr
 
     static const char *getFilename(bool longName);
   public:
-    static void onEntry();
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t);
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/status_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/status_screen.cpp
@@ -246,7 +246,7 @@ void StatusScreen::draw_progress(draw_mode_t what) {
     sprintf_P(progress_str, PSTR("%-3d %%"),      getProgress_percent() );
 
     cmd.font(font_medium)
-       .tag(0).text(TIME_POS, time_str)
+       .tag(7).text(TIME_POS, time_str)
               .text(PROGRESS_POS, progress_str);
   }
 }
@@ -386,10 +386,19 @@ bool StatusScreen::onTouchEnd(uint8_t tag) {
       break;
     case 5:  GOTO_SCREEN(TemperatureScreen); break;
     case 6:
-      if (!isPrinting()) {
+      if (isPrinting()) {
+        #if ENABLED(BABYSTEPPING)
+          GOTO_SCREEN(NudgeNozzleScreen);
+        #elif HAS_BED_PROBE
+          GOTO_SCREEN(ZOffsetScreen);
+        #else
+          return false;
+        #endif
+      } else {
         GOTO_SCREEN(MoveAxisScreen);
       }
       break;
+    case 7:  GOTO_SCREEN(FeedratePercentScreen); break;
     default:
       return true;
   }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/temperature_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/temperature_screen.cpp
@@ -35,7 +35,7 @@ void TemperatureScreen::onRedraw(draw_mode_t what) {
   #if TOUCH_UI_LCD_TEMP_SCALING == 10
     w.precision(1)
   #else
-    w.precision(0)
+    w.precision(0, getTargetTemp_celsius(E0) == 0 ? DEFAULT_HIGHEST : DEFAULT_MIDRANGE)
   #endif
    .color(temp).units(GET_TEXT_F(MSG_UNITS_C));
   w.heading(GET_TEXT_F(MSG_TEMPERATURE));

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/tune_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/tune_menu.cpp
@@ -39,9 +39,25 @@ void TuneMenu::onRedraw(draw_mode_t what) {
   #ifdef TOUCH_UI_PORTRAIT
     #define GRID_ROWS 8
     #define GRID_COLS 2
+    #define TEMPERATURE_POS BTN_POS(1,1), BTN_SIZE(2,1)
+    #define FIL_CHANGE_POS  BTN_POS(1,2), BTN_SIZE(2,1)
+    #define FILAMENT_POS    BTN_POS(1,3), BTN_SIZE(2,1)
+    #define NUDGE_NOZ_POS   BTN_POS(1,4), BTN_SIZE(2,1)
+    #define SPEED_POS       BTN_POS(1,5), BTN_SIZE(2,1)
+    #define PAUSE_POS       BTN_POS(1,6), BTN_SIZE(2,1)
+    #define STOP_POS        BTN_POS(1,7), BTN_SIZE(2,1)
+    #define BACK_POS        BTN_POS(1,8), BTN_SIZE(2,1)
   #else
     #define GRID_ROWS 4
     #define GRID_COLS 2
+    #define TEMPERATURE_POS BTN_POS(1,1), BTN_SIZE(1,1)
+    #define NUDGE_NOZ_POS   BTN_POS(2,1), BTN_SIZE(1,1)
+    #define FIL_CHANGE_POS  BTN_POS(1,2), BTN_SIZE(1,1)
+    #define SPEED_POS       BTN_POS(2,2), BTN_SIZE(1,1)
+    #define PAUSE_POS       BTN_POS(1,3), BTN_SIZE(1,1)
+    #define STOP_POS        BTN_POS(2,3), BTN_SIZE(1,1)
+    #define FILAMENT_POS    BTN_POS(1,4), BTN_SIZE(1,1)
+    #defome BACK_POS        BTN_POS(2,4), BTN_SIZE(1,1)
   #endif
 
   if (what & FOREGROUND) {
@@ -50,81 +66,43 @@ void TuneMenu::onRedraw(draw_mode_t what) {
     CommandProcessor cmd;
     cmd.colors(normal_btn)
        .font(font_medium)
-    #ifdef TOUCH_UI_PORTRAIT
-       .tag(2).enabled(1)      .button( BTN_POS(1,1), BTN_SIZE(2,1), GET_TEXT_F(MSG_TEMPERATURE))
-       .tag(3).enabled(!isPrinting()).button( BTN_POS(1,2), BTN_SIZE(2,1), GET_TEXT_F(MSG_FILAMENTCHANGE))
+       .tag(2).button( TEMPERATURE_POS, GET_TEXT_F(MSG_TEMPERATURE))
+       .enabled((!isPrinting()) || isPrintingFromMediaPaused())
+       .tag(3).button( FIL_CHANGE_POS,  GET_TEXT_F(MSG_FILAMENTCHANGE))
        .enabled(
-         #if EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
-           1
-         #endif
+          #if EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
+            1
+          #endif
        )
-       .tag(9).button( BTN_POS(1,3), BTN_SIZE(2,1), GET_TEXT_F(MSG_FILAMENT))
-      #if ENABLED(BABYSTEPPING)
-       .tag(4).enabled(1)      .button( BTN_POS(1,4), BTN_SIZE(2,1), GET_TEXT_F(MSG_NUDGE_NOZZLE))
-      #else
-        .enabled(
-          #if HAS_BED_PROBE
+       .tag(9).button( FILAMENT_POS, GET_TEXT_F(MSG_FILAMENT))
+       .enabled(
+          #if HAS_BED_PROBE || ENABLED(BABYSTEPPING)
             1
           #endif
         )
-       .tag(4)                 .button( BTN_POS(1,4), BTN_SIZE(2,1), GET_TEXT_F(MSG_ZPROBE_ZOFFSET))
-      #endif
-       .tag(5).enabled(1)      .button( BTN_POS(1,5), BTN_SIZE(2,1), GET_TEXT_F(MSG_PRINT_SPEED))
+       .tag(4).button( NUDGE_NOZ_POS, GET_TEXT_F(
+          #if ENABLED(BABYSTEPPING)
+            MSG_NUDGE_NOZZLE
+          #else
+            MSG_ZPROBE_ZOFFSET
+          #endif
+       ))
+       .tag(5).button( SPEED_POS, GET_TEXT_F(MSG_PRINT_SPEED))
        .tag(isPrintingFromMediaPaused() ? 7 : 6)
        .enabled(
-         #if ENABLED(SDSUPPORT)
-           isPrintingFromMedia()
-         #endif
+          #if ENABLED(SDSUPPORT)
+            isPrintingFromMedia()
+          #endif
        )
-        .button( BTN_POS(1,6), BTN_SIZE(2,1), isPrintingFromMediaPaused() ? GET_TEXT_F(MSG_RESUME_PRINT) : GET_TEXT_F(MSG_PAUSE_PRINT))
-        .enabled(
+       .button( PAUSE_POS, isPrintingFromMediaPaused() ? GET_TEXT_F(MSG_RESUME_PRINT) : GET_TEXT_F(MSG_PAUSE_PRINT))
+       .enabled(
           #if ENABLED(SDSUPPORT)
             isPrintingFromMedia()
           #endif
         )
-      .tag(8)             .button( BTN_POS(1,7), BTN_SIZE(2,1), GET_TEXT_F(MSG_STOP_PRINT))
+      .tag(8).button( STOP_POS, GET_TEXT_F(MSG_STOP_PRINT))
       .tag(1).colors(action_btn)
-                          .button( BTN_POS(1,8), BTN_SIZE(2,1), GET_TEXT_F(MSG_BACK));
-    #else // TOUCH_UI_PORTRAIT
-       .tag(2).enabled(1) .button( BTN_POS(1,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_TEMPERATURE))
-       .tag(3).enabled(!isPrinting()).button( BTN_POS(1,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_FILAMENTCHANGE))
-       .enabled(
-         #if ENABLED(BABYSTEPPING)
-           isPrintingFromMedia()
-         #endif
-       )
-        #if ENABLED(BABYSTEPPING)
-          .tag(4)         .button( BTN_POS(2,1), BTN_SIZE(1,1), GET_TEXT_F(MSG_NUDGE_NOZZLE))
-        #else
-          .enabled(
-            #if HAS_BED_PROBE
-              isPrintingFromMedia()
-            #endif
-          )
-          .tag(4)         .button( BTN_POS(1,4), BTN_SIZE(2,1), GET_TEXT_F(MSG_ZPROBE_ZOFFSET))
-        #endif
-       .tag(5).enabled(1) .button( BTN_POS(2,2), BTN_SIZE(1,1), GET_TEXT_F(MSG_PRINT_SPEED))
-       .tag(isPrintingFromMediaPaused() ? 7 : 6)
-       .enabled(
-         #if ENABLED(SDSUPPORT)
-           isPrintingFromMedia()
-         #endif
-       )
-                          .button( BTN_POS(1,3), BTN_SIZE(1,1), isPrintingFromMediaPaused() ? GET_TEXT_F(MSG_RESUME_PRINT) : GET_TEXT_F(MSG_PAUSE_PRINT))
-       .enabled(
-         #if ENABLED(SDSUPPORT)
-           isPrintingFromMedia()
-         #endif
-       )
-       .tag(8).           button( BTN_POS(2,3), BTN_SIZE(1,1), GET_TEXT_F(MSG_STOP_PRINT))
-       .enabled(
-         #if ANY(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
-           1
-         #endif
-       )
-       .tag(9).button( BTN_POS(1,4), BTN_SIZE(1,1), GET_TEXT_F(MSG_FILAMENT))
-       .tag(1).colors(action_btn) .button( BTN_POS(2,4), BTN_SIZE(1,1), GET_TEXT_F(MSG_BACK));
-    #endif
+             .button( BACK_POS, GET_TEXT_F(MSG_BACK));
   }
   #undef GRID_COLS
   #undef GRID_ROWS

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/tune_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/tune_menu.cpp
@@ -67,39 +67,17 @@ void TuneMenu::onRedraw(draw_mode_t what) {
     cmd.colors(normal_btn)
        .font(font_medium)
        .tag(2).button( TEMPERATURE_POS, GET_TEXT_F(MSG_TEMPERATURE))
-       .enabled((!isPrinting()) || isPrintingFromMediaPaused())
+       .enabled(!isPrinting() || isPrintingFromMediaPaused())
        .tag(3).button( FIL_CHANGE_POS,  GET_TEXT_F(MSG_FILAMENTCHANGE))
-       .enabled(
-          #if EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR)
-            1
-          #endif
-       )
+       .enabled(EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR))
        .tag(9).button( FILAMENT_POS, GET_TEXT_F(MSG_FILAMENT))
-       .enabled(
-          #if HAS_BED_PROBE || ENABLED(BABYSTEPPING)
-            1
-          #endif
-        )
-       .tag(4).button( NUDGE_NOZ_POS, GET_TEXT_F(
-          #if ENABLED(BABYSTEPPING)
-            MSG_NUDGE_NOZZLE
-          #else
-            MSG_ZPROBE_ZOFFSET
-          #endif
-       ))
+       .enabled(EITHER(HAS_BED_PROBE, BABYSTEPPING))
+       .tag(4).button( NUDGE_NOZ_POS, GET_TEXT_F(TERN(BABYSTEPPING, MSG_NUDGE_NOZZLE, MSG_ZPROBE_ZOFFSET))
        .tag(5).button( SPEED_POS, GET_TEXT_F(MSG_PRINT_SPEED))
        .tag(isPrintingFromMediaPaused() ? 7 : 6)
-       .enabled(
-          #if ENABLED(SDSUPPORT)
-            isPrintingFromMedia()
-          #endif
-       )
+       .enabled(TERN0(SDSUPPORT, isPrintingFromMedia()))
        .button( PAUSE_POS, isPrintingFromMediaPaused() ? GET_TEXT_F(MSG_RESUME_PRINT) : GET_TEXT_F(MSG_PAUSE_PRINT))
-       .enabled(
-          #if ENABLED(SDSUPPORT)
-            isPrintingFromMedia()
-          #endif
-        )
+       .enabled(TERN0(SDSUPPORT, isPrintingFromMedia()))
       .tag(8).button( STOP_POS, GET_TEXT_F(MSG_STOP_PRINT))
       .tag(1).colors(action_btn)
              .button( BACK_POS, GET_TEXT_F(MSG_BACK));


### PR DESCRIPTION
- Stop print and play error sound if USB drive is removed.
- Allow configuration of version string in touch UI.
- Print a completion message in the bed mesh leveling screen.
- Don't play redundant sound at the start of a print.
- Clicking on percentage in status screen now goes into print speed screen
- Clicking on axis in status screen now goes to nozzle motion screens
- Use default increment of 100 when nozzle is preheated in temp screen, 10 otherwise
- Fixed grayed out change filament button in tune menu
- Eliminated code duplication in tune menu
- Add button for resetting BLTouch to advanced settings menu
