### PR TITLE
Use center defines for Z Safe Homing XY

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1368,13 +1368,8 @@
 //#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-  #if ENABLED(BED_CENTER_AT_0_0)
-    #define Z_SAFE_HOMING_X_POINT 0    // X point for Z homing when homing all axes (G28).
-    #define Z_SAFE_HOMING_Y_POINT 0    // Y point for Z homing when homing all axes (G28).
-  #else
-    #define Z_SAFE_HOMING_X_POINT ((X_MIN_POS + X_MAX_POS) / 2)    // X point for Z homing when homing all axes (G28).
-    #define Z_SAFE_HOMING_Y_POINT ((X_MIN_POS + X_MAX_POS) / 2)    // Y point for Z homing when homing all axes (G28).
-  #endif
+  #define Z_SAFE_HOMING_X_POINT X_CENTER  // X point for Z homing when homing all axes (G28).
+  #define Z_SAFE_HOMING_Y_POINT Y_CENTER  // Y point for Z homing when homing all axes (G28).
 #endif
 
 // Homing speeds (mm/m)

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1368,8 +1368,13 @@
 //#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
-  #define Z_SAFE_HOMING_X_POINT ((X_BED_SIZE) / 2)    // X point for Z homing when homing all axes (G28).
-  #define Z_SAFE_HOMING_Y_POINT ((Y_BED_SIZE) / 2)    // Y point for Z homing when homing all axes (G28).
+  #if ENABLED(BED_CENTER_AT_0_0)
+    #define Z_SAFE_HOMING_X_POINT 0    // X point for Z homing when homing all axes (G28).
+    #define Z_SAFE_HOMING_Y_POINT 0    // Y point for Z homing when homing all axes (G28).
+  #else
+    #define Z_SAFE_HOMING_X_POINT ((X_MIN_POS + X_MAX_POS) / 2)    // X point for Z homing when homing all axes (G28).
+    #define Z_SAFE_HOMING_Y_POINT ((X_MIN_POS + X_MAX_POS) / 2)    // Y point for Z homing when homing all axes (G28).
+  #endif
 #endif
 
 // Homing speeds (mm/m)


### PR DESCRIPTION
### Description

Safe Homing position calculation is incorrect if bed center is at 0,0.
The current implementation moves the print head to the border of the bed if BED_CENTER_AT_0_0
 is enabled.

### Benefits

fix Safe Homing calculation

