### PR TITLE
G12 soft endstops parameter

### DIFF
--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -92,8 +92,6 @@ struct measurements_t {
   xy_float_t nozzle_outer_dimension = nod;
 };
 
-#define TEMPORARY_SOFT_ENDSTOP_STATE(enable) REMEMBER(tes, soft_endstops_enabled, enable);
-
 #if ENABLED(BACKLASH_GCODE)
   #define TEMPORARY_BACKLASH_CORRECTION(value) REMEMBER(tbst, backlash.correction, value)
 #else

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -37,6 +37,11 @@
 
 /**
  * G12: Clean the nozzle
+ *
+ *  E<bool>          : 0=Never or 1=Always apply the "software endstop" limits
+ *  P0 S<strokes>    : Stroke cleaning with S strokes
+ *  P1 Sn T<objects> : Zigzag cleaning with S repeats and T zigzags
+ *  P2 Sn R<radius>  : Circle cleaning with S repeats and R radius
  */
 void GcodeSuite::G12() {
   // Don't allow nozzle cleaning without homing first
@@ -45,20 +50,20 @@ void GcodeSuite::G12() {
   const uint8_t pattern = parser.ushortval('P', 0),
                 strokes = parser.ushortval('S', NOZZLE_CLEAN_STROKES),
                 objects = parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES);
-  const float radius = parser.floatval('R', NOZZLE_CLEAN_CIRCLE_RADIUS);
+  const float radius = parser.linearval('R', NOZZLE_CLEAN_CIRCLE_RADIUS);
 
   const bool seenxyz = parser.seen("XYZ");
   const uint8_t cleans =  (!seenxyz || parser.boolval('X') ? _BV(X_AXIS) : 0)
                         | (!seenxyz || parser.boolval('Y') ? _BV(Y_AXIS) : 0)
-                        #if DISABLED(NOZZLE_CLEAN_NO_Z)
-                          | (!seenxyz || parser.boolval('Z') ? _BV(Z_AXIS) : 0)
-                        #endif
+                        | TERN(NOZZLE_CLEAN_NO_Z, 0, (!seenxyz || parser.boolval('Z') ? _BV(Z_AXIS) : 0))
                       ;
 
   #if HAS_LEVELING
     // Disable bed leveling if cleaning Z
     TEMPORARY_BED_LEVELING_STATE(!TEST(cleans, Z_AXIS) && planner.leveling_active);
   #endif
+
+  TEMPORARY_SOFT_ENDSTOP_STATE(parser.boolval('E'));
 
   nozzle.clean(pattern, strokes, radius, objects, cleans);
 }

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -152,18 +152,20 @@ Nozzle nozzle;
         LIMIT(   end[arrPos].A, soft_endstop.min.A, soft_endstop.max.A); \
       }while(0)
 
-      LIMIT_AXIS(x);
-      LIMIT_AXIS(y);
-      LIMIT_AXIS(z);
+      if (soft_endstops_enabled) {
 
-      const bool radiusOutOfRange = (middle[arrPos].x + radius > soft_endstop.max.x)
-                                 || (middle[arrPos].x - radius < soft_endstop.min.x)
-                                 || (middle[arrPos].y + radius > soft_endstop.max.y)
-                                 || (middle[arrPos].y - radius < soft_endstop.min.y);
+        LIMIT_AXIS(x);
+        LIMIT_AXIS(y);
+        LIMIT_AXIS(z);
+        const bool radiusOutOfRange = (middle[arrPos].x + radius > soft_endstop.max.x)
+                                   || (middle[arrPos].x - radius < soft_endstop.min.x)
+                                   || (middle[arrPos].y + radius > soft_endstop.max.y)
+                                   || (middle[arrPos].y - radius < soft_endstop.min.y);
+        if (radiusOutOfRange && pattern == 2) {
+          SERIAL_ECHOLNPGM("Warning: Radius Out of Range");
+          return;
+        }
 
-      if (radiusOutOfRange && pattern == 2) {
-        SERIAL_ECHOLNPGM("Warning: Radius Out of Range");
-        return;
       }
 
     #endif

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -152,6 +152,7 @@ typedef struct { xyz_pos_t min, max; } axis_limits_t;
       , const uint8_t old_tool_index=0, const uint8_t new_tool_index=0
     #endif
   );
+  #define TEMPORARY_SOFT_ENDSTOP_STATE(enable) REMEMBER(tes, soft_endstops_enabled, enable);
 #else
   constexpr bool soft_endstops_enabled = false;
   //constexpr axis_limits_t soft_endstop = {
@@ -159,6 +160,7 @@ typedef struct { xyz_pos_t min, max; } axis_limits_t;
   //  { X_MAX_POS, Y_MAX_POS, Z_MAX_POS } };
   #define apply_motion_limits(V)    NOOP
   #define update_software_endstops(...) NOOP
+  #define TEMPORARY_SOFT_ENDSTOP_STATE(...) NOOP
 #endif
 
 void report_real_position();


### PR DESCRIPTION
The `G12` command now checks soft endstop limits when cleaning. This PR makes sure to skip the check when soft endstops are disabled, and adds an option to `G12` to temporarily disable them during the cleaning.

Fixes #17764