### PR TITLE
Support GT2560 3rd extruder

### DIFF
--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -121,7 +121,7 @@
 //
 #define TEMP_0_PIN                            11  // Analog Input
 #define TEMP_1_PIN                             9  // Analog Input
-#define TEMP_2_PIN                             1  // Analog Input
+#define TEMP_2_PIN                             8  // Analog Input
 #define TEMP_BED_PIN                          10  // Analog Input
 
 //
@@ -129,7 +129,7 @@
 //
 #define HEATER_0_PIN                          10
 #define HEATER_1_PIN                           3
-#define HEATER_2_PIN                           1
+#define HEATER_2_PIN                           2
 #define HEATER_BED_PIN                         4
 #define FAN_PIN                                9
 #define FAN1_PIN                               8
@@ -140,7 +140,7 @@
 //
 #define SD_DETECT_PIN                         38
 #define SDSS                                  53
-#define LED_PIN                                6
+#define LED_PIN                               13   // Use pin 6 (case light) for external LED. Internal LED (yellow) is on pin 13.
 #define PS_ON_PIN                             12
 #define SUICIDE_PIN                           54  // This pin must be enabled at boot to keep power flowing
 

--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -140,7 +140,7 @@
 //
 #define SD_DETECT_PIN                         38
 #define SDSS                                  53
-#define LED_PIN                               13   // Use pin 6 (case light) for external LED. Internal LED (yellow) is on pin 13.
+#define LED_PIN                               13  // Use 6 (case light) for external LED. 13 is internal (yellow) LED.
 #define PS_ON_PIN                             12
 #define SUICIDE_PIN                           54  // This pin must be enabled at boot to keep power flowing
 

--- a/Marlin/src/pins/mega/pins_GT2560_V3_A20.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3_A20.h
@@ -30,6 +30,9 @@
 #define LCD_PINS_D4                          21
 #define LCD_PINS_D7                           6
 
+// enable speaker that can produce tones
+#define SPEAKER
+
 #if ENABLED(NEWPANEL)
   #define BTN_EN1                            16
   #define BTN_EN2                            17

--- a/Marlin/src/pins/mega/pins_GT2560_V3_A20.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3_A20.h
@@ -30,8 +30,7 @@
 #define LCD_PINS_D4                          21
 #define LCD_PINS_D7                           6
 
-// enable speaker that can produce tones
-#define SPEAKER
+#define SPEAKER  // The speaker can produce tones
 
 #if ENABLED(NEWPANEL)
   #define BTN_EN1                            16


### PR DESCRIPTION
### Description

The Geeetech GT2560 v3 board is prepared for 3 extruders. Normally only 2 extruders are populated with connectors and stepper drivers (for A20M), however the 3rd extruder (E2) would work as well. The only thing you need is an additional stepper motor and a connector.

This patch configures the pins for E2 thermistor and heater.
As well as setting SPEAKER as the default configuration for A20 boards.

### Benefits

Enables 3rd extruder for GT2560 v3 boards.
