### PR TITLE
[FIX] ADD Follow up ToolMigration/Autotemp/fanspeed

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2960,7 +2960,9 @@ void Temperature::tick() {
       #endif
     ) {
 
-      TERN_(AUTOTEMP, planner.autotemp_enabled = false);
+      #if ENABLED(AUTOTEMP)
+        REMEMBER(1, planner.autotemp_enabled, false);
+      #endif
 
       #if TEMP_RESIDENCY_TIME > 0
         millis_t residency_start_ms = 0;
@@ -3063,8 +3065,6 @@ void Temperature::tick() {
         ui.reset_status();
         TERN_(PRINTER_EVENT_LEDS, printerEventLEDs.onHeatingDone());
       }
-      
-      TERN_(AUTOTEMP, planner.autotemp_enabled = true);
 
       return wait_for_heatup;
     }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2959,6 +2959,9 @@ void Temperature::tick() {
         , const bool click_to_cancel/*=false*/
       #endif
     ) {
+
+      TERN_(AUTOTEMP, planner.autotemp_enabled = false);
+
       #if TEMP_RESIDENCY_TIME > 0
         millis_t residency_start_ms = 0;
         bool first_loop = true;
@@ -3060,6 +3063,8 @@ void Temperature::tick() {
         ui.reset_status();
         TERN_(PRINTER_EVENT_LEDS, printerEventLEDs.onHeatingDone());
       }
+      
+      TERN_(AUTOTEMP, planner.autotemp_enabled = true);
 
       return wait_for_heatup;
     }

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1292,7 +1292,6 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
 
     planner.synchronize();
     planner.set_e_position_mm(current_position.e); // New extruder primed and ready
-
   }
 
 #endif // TOOLCHANGE_MIGRATION_FEATURE

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -791,7 +791,7 @@ void tool_change_prime() {
     const bool ok = TERN1(TOOLCHANGE_PARK, all_axes_homed() && toolchange_settings.enable_park);
 
     // Store and stop fan
-    #if TOOLCHANGE_FS_FAN >= 0 && HAS_FAN
+    #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
       const int16_t fansp = thermalManager.fan_speed[TOOLCHANGE_FS_FAN];
       thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = 0;
     #endif
@@ -826,7 +826,7 @@ void tool_change_prime() {
     #endif
 
     // Cool down with fan
-    #if TOOLCHANGE_FS_FAN >= 0 && HAS_FAN
+    #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
       thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = toolchange_settings.fan_speed;
       gcode.dwell(toolchange_settings.fan_time * 1000);
       thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = 0;
@@ -851,7 +851,7 @@ void tool_change_prime() {
     sync_plan_position_e(); // Resume at the old E position
 
     // Restart Fan
-    #if TOOLCHANGE_FS_FAN >= 0 && HAS_FAN
+    #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
       thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = fansp;
     #endif
   }
@@ -944,7 +944,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       destination = current_position;
 
       // Store and stop fan
-      #if BOTH(TOOLCHANGE_FILAMENT_SWAP && HAS_FAN) && (TOOLCHANGE_FS_FAN >= 0)
+      #if BOTH(TOOLCHANGE_FILAMENT_SWAP, HAS_FAN) && (TOOLCHANGE_FS_FAN >= 0)
         const int16_t fansp = thermalManager.fan_speed[TOOLCHANGE_FS_FAN];
         thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = 0;
       #endif
@@ -1120,7 +1120,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
             #endif
 
             // Cool down with fan
-            #if BOTH(TOOLCHANGE_FILAMENT_SWAP && HAS_FAN) && (TOOLCHANGE_FS_FAN >= 0)
+            #if HAS_FAN && (TOOLCHANGE_FS_FAN >= 0)
               thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = toolchange_settings.fan_speed;
               gcode.dwell(toolchange_settings.fan_time * 1000);
               thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = 0;
@@ -1174,8 +1174,9 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
             sync_plan_position_e(); // New extruder primed and set to 0
 
             // Restart Fan
-            #if BOTH(TOOLCHANGE_FILAMENT_SWAP && (TOOLCHANGE_FS_FAN >= 0) )
-              TERN(HAS_FAN, thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = fansp);
+            #if HAS_FAN && (TOOLCHANGE_FS_FAN >= 0)
+
+              TERN_(HAS_FAN, thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = fansp);
             #endif
 
           }

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -790,10 +790,9 @@ void tool_change_prime() {
 
     const bool ok = TERN1(TOOLCHANGE_PARK, all_axes_homed() && toolchange_settings.enable_park);
 
-    // Store and stop fan
     #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
-      const int16_t fansp = thermalManager.fan_speed[TOOLCHANGE_FS_FAN];
-      thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = 0;
+      // Store and stop fan. Restored on any exit.
+      REMEMBER(1, thermalManager.fan_speed[TOOLCHANGE_FS_FAN], 0);
     #endif
 
     // Z raise
@@ -849,11 +848,6 @@ void tool_change_prime() {
     planner.synchronize();
     current_position.e = destination.e;
     sync_plan_position_e(); // Resume at the old E position
-
-    // Restart Fan
-    #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
-      thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = fansp;
-    #endif
   }
 }
 #endif

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1270,7 +1270,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       thermalManager.wait_for_hotend(active_extruder);
     #endif
 
-    //Migrate linear advance
+    // Migrate Linear Advance K factor to the new extruder
     TERN_(LIN_ADVANCE, planner.extruder_advance_K[active_extruder] = planner.extruder_advance_K[migration_extruder]);
 
     // Perform the tool change

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1174,11 +1174,9 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
             sync_plan_position_e(); // New extruder primed and set to 0
 
             // Restart Fan
-            #if HAS_FAN && (TOOLCHANGE_FS_FAN >= 0)
-
-              TERN_(HAS_FAN, thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = fansp);
+            #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
+              thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = fansp;
             #endif
-
           }
         #endif
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -792,7 +792,7 @@ void tool_change_prime() {
 
     #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
       // Store and stop fan. Restored on any exit.
-      REMEMBER(1, thermalManager.fan_speed[TOOLCHANGE_FS_FAN], 0);
+      REMEMBER(fan, thermalManager.fan_speed[TOOLCHANGE_FS_FAN], 0);
     #endif
 
     // Z raise
@@ -937,10 +937,9 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     if (new_tool != old_tool) {
       destination = current_position;
 
-      // Store and stop fan
-      #if BOTH(TOOLCHANGE_FILAMENT_SWAP, HAS_FAN) && (TOOLCHANGE_FS_FAN >= 0)
-        const int16_t fansp = thermalManager.fan_speed[TOOLCHANGE_FS_FAN];
-        thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = 0;
+      #if BOTH(TOOLCHANGE_FILAMENT_SWAP, HAS_FAN) && TOOLCHANGE_FS_FAN >= 0
+        // Store and stop fan. Restored on any exit.
+        REMEMBER(fan, thermalManager.fan_speed[TOOLCHANGE_FS_FAN], 0);
       #endif
 
       // Z raise before retraction
@@ -1114,7 +1113,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
             #endif
 
             // Cool down with fan
-            #if HAS_FAN && (TOOLCHANGE_FS_FAN >= 0)
+            #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
               thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = toolchange_settings.fan_speed;
               gcode.dwell(toolchange_settings.fan_time * 1000);
               thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = 0;
@@ -1169,7 +1168,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
 
             // Restart Fan
             #if HAS_FAN && TOOLCHANGE_FS_FAN >= 0
-              thermalManager.fan_speed[TOOLCHANGE_FS_FAN] = fansp;
+              RESTORE(fan);
             #endif
           }
         #endif


### PR DESCRIPTION
- Linear advance  settings transfer on toolmigration 
- Stop print blowing during toolchange/migration
- Autotemp disabled on 'wait_for_hotend' ( infinite loop of autotemp that shut down the hotend at a less temp and pause that fight to reach the temp ,no steps/no power in hotend , and nozzle timeout  )