### PR TITLE
Introduce estimate of the change in junction angle per mm traveled

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -134,8 +134,8 @@ float Planner::steps_to_mm[XYZE_N];             // (mm) Millimeters per step
 
 #if HAS_JUNCTION_DEVIATION
   float Planner::junction_deviation_mm,         // (mm) M205 J
-        Planner::d_theta_decay = 0.75f,              // (1/mm) Fractional reduction of d_theta_indicator per mm traveled
-        Planner::d_theta_threshold = RADIANS(0.1f);  // (rads/mm) Threshold for d_theta_indicator, resulting in recalculation of limit_sqr
+        Planner::d_theta_decay = 1.0f,                // (1/mm) Fractional reduction of d_theta_indicator per mm traveled
+        Planner::d_theta_threshold = RADIANS(0.05f);  // (rads/mm) Threshold for d_theta_indicator, resulting in recalculation of limit_sqr
   #if HAS_LINEAR_E_JERK
     float Planner::max_e_jerk[DISTINCT_E];      // Calculated from junction_deviation_mm
   #endif

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2408,6 +2408,8 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       vmax_junction_sqr = 0;
 
     prev_unit_vec = unit_vec;
+    previous_limit_sqr = limit_sqr;
+    previous_junction_theta = junction_theta;
 
   #endif
 
@@ -2543,10 +2545,6 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
   // Update previous path unit_vector and nominal speed
   previous_speed = current_speed;
   previous_nominal_speed_sqr = block->nominal_speed_sqr;
-  #if HAS_JUNCTION_DEVIATION
-    previous_limit_sqr = limit_sqr;
-    previous_junction_theta = junction_theta;
-  #endif
 
   position = target;  // Update the position
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -134,8 +134,8 @@ float Planner::steps_to_mm[XYZE_N];             // (mm) Millimeters per step
 
 #if HAS_JUNCTION_DEVIATION
   float Planner::junction_deviation_mm,         // (mm) M205 J
-        Planner::del_angle_decay = 0.75f,              // (1/mm) Fractional reduction of del_angle_indicator per mm traveled
-        Planner::del_angle_threshold = RADIANS(0.1f);  // (rads/mm) Threshold for del_angle_indicator, resulting in recalculation of limit_sqr
+        Planner::d_theta_decay = 0.75f,              // (1/mm) Fractional reduction of d_theta_indicator per mm traveled
+        Planner::d_theta_threshold = RADIANS(0.1f);  // (rads/mm) Threshold for d_theta_indicator, resulting in recalculation of limit_sqr
   #if HAS_LINEAR_E_JERK
     float Planner::max_e_jerk[DISTINCT_E];      // Calculated from junction_deviation_mm
   #endif
@@ -199,7 +199,7 @@ float Planner::previous_nominal_speed_sqr;
 #if HAS_JUNCTION_DEVIATION
 float Planner::previous_junction_theta,
       Planner::previous_limit_sqr,
-      Planner::del_angle_indicator;
+      Planner::d_theta_indicator;
 #endif
 
 #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
@@ -243,7 +243,7 @@ void Planner::init() {
   #if HAS_JUNCTION_DEVIATION
     previous_limit_sqr = 0.0f;
     previous_junction_theta = 0.0f;
-    del_angle_indicator = 0.0f;
+    d_theta_indicator = 0.0f;
   #endif
   TERN_(ABL_PLANAR, bed_level_matrix.set_to_identity());
   clear_block_buffer();
@@ -2385,13 +2385,13 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
         limit_sqr = (block->millimeters * junction_acceleration) / junction_theta;
 
         // Estimate, how much the junction angle is changing per mm traveled
-        // NOTE: To keep the math involved simple & fast(-ish), changes in del_angle_indicator are not fully independent of the block length.
+        // NOTE: To keep the math involved simple & fast(-ish), changes in d_theta_indicator are not fully independent of the block length.
         //       Therefore, three segments of length 0.2 mm will result in a slightly different decay than two segments of length 0.3 mm.
-        const float del_theta = junction_theta - previous_junction_theta;
-        del_angle_indicator = del_angle_indicator * _MAX(0.0f, 1.0f - del_angle_decay * block->millimeters) + ABS(del_theta) * inverse_millimeters;
+        const float d_theta = junction_theta - previous_junction_theta;
+        d_theta_indicator = d_theta_indicator * _MAX(0.0f, 1.0f - d_theta_decay * block->millimeters) + ABS(d_theta) * inverse_millimeters;
 
         // In case theta is changing slower than our threshold, we just keep the higher speed and "coast".
-        if (del_angle_indicator < del_angle_threshold) {
+        if (d_theta_indicator < d_theta_threshold) {
           limit_sqr = _MAX(limit_sqr, previous_limit_sqr);
         }
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -135,7 +135,7 @@ float Planner::steps_to_mm[XYZE_N];             // (mm) Millimeters per step
 #if HAS_JUNCTION_DEVIATION
   float Planner::junction_deviation_mm,         // (mm) M205 J
         Planner::d_theta_decay = 1.0f,                // (1/mm) Fractional reduction of d_theta_indicator per mm traveled
-        Planner::d_theta_threshold = RADIANS(0.05f);  // (rads/mm) Threshold for d_theta_indicator, resulting in recalculation of limit_sqr
+        Planner::d_theta_threshold = RADIANS(0.15f);  // (rads/mm) Threshold for d_theta_indicator, resulting in recalculation of limit_sqr
   #if HAS_LINEAR_E_JERK
     float Planner::max_e_jerk[DISTINCT_E];      // Calculated from junction_deviation_mm
   #endif

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -407,6 +407,11 @@ class Planner {
        * Indicator of current angular change per mm traveled (rads/mm)
        */
       static float d_theta_indicator;
+	  
+	  /**
+       * Counter of consecutive segments below d_theta_threshold
+       */
+	  static uint8_t below_thresh_cnt;
     #endif
 
     /**

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -315,8 +315,8 @@ class Planner {
 
     #if HAS_JUNCTION_DEVIATION
       static float junction_deviation_mm,       // (mm) M205 J
-                   del_angle_decay,             // (1/mm) Fractional reduction of del_angle_indicator per mm traveled
-                   del_angle_threshold;         // (rads/mm) Threshold for delta_angle_indicator, resulting in recalculation of limit_sqr
+                   d_theta_decay,               // (1/mm) Fractional reduction of d_theta_indicator per mm traveled
+                   d_theta_threshold;           // (rads/mm) Threshold for d_theta_indicator, resulting in recalculation of limit_sqr
       #if HAS_LINEAR_E_JERK
         static float max_e_jerk[DISTINCT_E];    // Calculated from junction_deviation_mm
       #endif
@@ -404,9 +404,9 @@ class Planner {
       static float previous_junction_theta;
   
       /**
-       * Indicator of current angular change per mm traveled (°/mm)
+       * Indicator of current angular change per mm traveled (rads/mm)
        */
-      static float del_angle_indicator;
+      static float d_theta_indicator;
     #endif
 
     /**

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -314,7 +314,9 @@ class Planner {
     static float steps_to_mm[XYZE_N];           // Millimeters per step
 
     #if HAS_JUNCTION_DEVIATION
-      static float junction_deviation_mm;       // (mm) M205 J
+      static float junction_deviation_mm,       // (mm) M205 J
+                   del_angle_decay,             // (1/mm) Fractional reduction of del_angle_indicator per mm traveled
+                   del_angle_threshold;         // (rads/mm) Threshold for delta_angle_indicator, resulting in recalculation of limit_sqr
       #if HAS_LINEAR_E_JERK
         static float max_e_jerk[DISTINCT_E];    // Calculated from junction_deviation_mm
       #endif
@@ -389,6 +391,23 @@ class Planner {
      * Nominal speed of previous path line segment (mm/s)^2
      */
     static float previous_nominal_speed_sqr;
+
+    #if HAS_JUNCTION_DEVIATION
+      /**
+       * Speed limit of previous segment (mm^2/s^2)
+       */
+      static float previous_limit_sqr;
+      
+      /**
+       * Junction angle theta of previous segment (rads)
+       */
+      static float previous_junction_theta;
+  
+      /**
+       * Indicator of current angular change per mm traveled (°/mm)
+       */
+      static float del_angle_indicator;
+    #endif
 
     /**
      * Limit where 64bit math is necessary for acceleration calculation


### PR DESCRIPTION
### Description

_**NOTE:** Re-submitted without duplicate upstream commits._

This introduces `d_theta_indicator` as an exponentially decaying estimate of the change in junction angle per mm traveled. Based on this indicator and a threshold value, the speed limit `limit_sqr` can be kept constant during tiny changes in the junction angle, avoiding stutter and leading to a smoother print. Details are given in posts [[1]](https://github.com/MarlinFirmware/Marlin/issues/17342#issuecomment-617469776) and [[2]](https://github.com/MarlinFirmware/Marlin/issues/17342#issuecomment-617473757).
Essentially, this accumulates changes in `junction_theta` over the traveled path, while at the same time "forgetting" a fixed fraction of the accumulated change per length traveled. If the accumulated value `d_theta_indicator` is below `d_theta_threshold`, we act as if there was no change in angle at all and keep our speed limit `limit_sqr` reasonably high. If `d_theta_indicator` surpasses `d_theta_threshold`, we instantly reset `limit_sqr` to the default value for the current block/segment.

**Notes:** 
- `d_theta_decay` and `d_theta_threshold` should probably be made configurable, if this method is introduced to Marlin.
- Typical values for `d_theta_decay`: `0.3f` (slow decay, angle changes have long lasting effect which leads to less coasting) to `1.0f` (fast decay, coasting is seen more often).
- Typical values for `d_theta_threshold`: `RADIANS(0.001f)` (very sensitive, little coasting) to `RADIANS(0.5f)` (very low sensitivity, coasting is often applied and many angle changes do not affect `limit_sqr`)

### Benefits

This reduces frequent changes in `limit_sqr` during printing of nearly straight segments of a part. It also avoids some dips in `limit_sqr` caused by tiny segments combined with an unfortunate distribution of angles around those segments as found in #17342 .

### Not-so-Benefits

Currently requires `limit_sqr` and `junction_theta` to be calculated for every move, independent of segment length and junction angle. This uses additional resources. Feel free to suggest any solution where this can be avoided.

### Related Issues

Further mitigates #17342 .
