### PR TITLE
Change runout pin on ramps 1.4.4

### DIFF
--- a/Marlin/src/pins/samd/pins_RAMPS_144.h
+++ b/Marlin/src/pins/samd/pins_RAMPS_144.h
@@ -129,9 +129,8 @@
   #define FILWIDTH_PIN                         5  // Analog Input on AUX2
 #endif
 
-// RAMPS 1.4 DIO 4 on the servos connector
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN                       4
+  #define FIL_RUNOUT_PIN                      71
 #endif
 
 #ifndef PS_ON_PIN


### PR DESCRIPTION
This will use a free pin instead of an already used one