### PR TITLE
Fix samd51 i2c eeprom issues

### DIFF
--- a/Marlin/src/HAL/SAMD51/eeprom_wired.cpp
+++ b/Marlin/src/HAL/SAMD51/eeprom_wired.cpp
@@ -22,7 +22,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if USE_WIRED_EEPROM && DISABLED(QSPI_EEPROM)
+#if USE_WIRED_EEPROM
 
 #include "../shared/eeprom_if.h"
 #include "../shared/eeprom_api.h"

--- a/Marlin/src/HAL/SAMD51/eeprom_wired.cpp
+++ b/Marlin/src/HAL/SAMD51/eeprom_wired.cpp
@@ -22,13 +22,18 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if USE_WIRED_EEPROM
+#if USE_WIRED_EEPROM && DISABLED(QSPI_EEPROM)
 
 #include "../shared/eeprom_if.h"
 #include "../shared/eeprom_api.h"
 
 size_t PersistentStore::capacity()    { return E2END + 1; }
-bool PersistentStore::access_start()  { return true; }
+
+bool PersistentStore::access_start() {
+  TERN_(I2C_EEPROM, eeprom_init());
+  return true;
+}
+
 bool PersistentStore::access_finish() { return true; }
 
 bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {

--- a/Marlin/src/HAL/SAMD51/eeprom_wired.cpp
+++ b/Marlin/src/HAL/SAMD51/eeprom_wired.cpp
@@ -28,13 +28,12 @@
 #include "../shared/eeprom_api.h"
 
 size_t PersistentStore::capacity()    { return E2END + 1; }
+bool PersistentStore::access_finish() { return true; }
 
 bool PersistentStore::access_start() {
-  TERN_(I2C_EEPROM, eeprom_init());
+  eeprom_init();
   return true;
 }
-
-bool PersistentStore::access_finish() { return true; }
 
 bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
   while (size--) {

--- a/Marlin/src/HAL/shared/eeprom_if.h
+++ b/Marlin/src/HAL/shared/eeprom_if.h
@@ -24,6 +24,7 @@
 //
 // EEPROM
 //
+void eeprom_init();
 void eeprom_write_byte(uint8_t *pos, unsigned char value);
 uint8_t eeprom_read_byte(uint8_t *pos);
 void eeprom_read_block(void *__dst, const void *__src, size_t __n);

--- a/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
+++ b/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
@@ -52,7 +52,7 @@ static constexpr uint8_t eeprom_device_address = I2C_ADDRESS(EEPROM_DEVICE_ADDRE
 // Public functions
 // ------------------------
 
-static void eeprom_init() { Wire.begin(); }
+void eeprom_init() { Wire.begin(); }
 
 void eeprom_write_byte(uint8_t *pos, unsigned char value) {
   const unsigned eeprom_address = (unsigned)pos;


### PR DESCRIPTION
When i2c eeprom is enabled samd51 simply hangs on startup. Now it's fixed

Fix #17813
