### PR TITLE
Fix STM32 + SoftwareSerial compile (BTT002)

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -27,10 +27,6 @@
 #include "../../inc/MarlinConfig.h"
 #include "../shared/Delay.h"
 
-#if HAS_TMC_SW_SERIAL
-  #include "SoftwareSerial.h"
-#endif
-
 #if ENABLED(SRAM_EEPROM_EMULATION)
   #if STM32F7xx
     #include <stm32f7xx_ll_pwr.h>
@@ -82,11 +78,7 @@ void HAL_init() {
     while (!LL_PWR_IsActiveFlag_BRR());   // Wait until backup regulator is initialized
   #endif
 
-  #if HAS_TMC_SW_SERIAL
-    SoftwareSerial::setInterruptPriority(SWSERIAL_TIMER_IRQ_PRIO, 0);
-  #endif
-
-  TERN_(HAS_TMC_SW_SERIAL, SoftwareSerial::setInterruptPriority(SWSERIAL_TIMER_IRQ_PRIO, 0));
+  SetSoftwareSerialTimerInterruptPriority();
 }
 
 void HAL_clear_reset_source() { __HAL_RCC_CLEAR_RESET_FLAGS(); }

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -31,9 +31,6 @@
 
 #define NUM_HARDWARE_TIMERS 2
 
-#ifndef SWSERIAL_TIMER_IRQ_PRIO
-  #define SWSERIAL_TIMER_IRQ_PRIO 1
-#endif
 #ifndef STEP_TIMER_IRQ_PRIO
   #define STEP_TIMER_IRQ_PRIO 2
 #endif
@@ -43,10 +40,10 @@
 
 #if HAS_TMC_SW_SERIAL
   #include <SoftwareSerial.h>
+  #ifndef SWSERIAL_TIMER_IRQ_PRIO
+    #define SWSERIAL_TIMER_IRQ_PRIO 1
+  #endif
 #endif
-void SetSoftwareSerialTimerInterruptPriority() {
-  TERN_(HAS_TMC_SW_SERIAL, SoftwareSerial::setInterruptPriority(SWSERIAL_TIMER_IRQ_PRIO, 0));
-}
 
 #ifdef STM32F0xx
   #define HAL_TIMER_RATE (F_CPU)      // Frequency of timer peripherals
@@ -180,6 +177,10 @@ TIM_TypeDef * HAL_timer_device(const uint8_t timer_num) {
     case TEMP_TIMER_NUM: return TEMP_TIMER_DEV;
   }
   return nullptr;
+}
+
+void SetSoftwareSerialTimerInterruptPriority() {
+  TERN_(HAS_TMC_SW_SERIAL, SoftwareSerial::setInterruptPriority(SWSERIAL_TIMER_IRQ_PRIO, 0));
 }
 
 #endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -41,6 +41,13 @@
   #define TEMP_TIMER_IRQ_PRIO 14   // 14 = after hardware ISRs
 #endif
 
+#if HAS_TMC_SW_SERIAL
+  #include <SoftwareSerial.h>
+#endif
+void SetSoftwareSerialTimerInterruptPriority() {
+  TERN_(HAS_TMC_SW_SERIAL, SoftwareSerial::setInterruptPriority(SWSERIAL_TIMER_IRQ_PRIO, 0));
+}
+
 #ifdef STM32F0xx
   #define HAL_TIMER_RATE (F_CPU)      // Frequency of timer peripherals
   #define MCU_STEP_TIMER 16

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -75,6 +75,9 @@ void HAL_timer_enable_interrupt(const uint8_t timer_num);
 void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
+// Exposed here to allow all timer priority information to reside in timers.cpp
+void SetSoftwareSerialTimerInterruptPriority();
+
 //TIM_TypeDef* HAL_timer_device(const uint8_t timer_num); no need to be public for now. not public = not used externally
 
 // FORCE_INLINE because these are used in performance-critical situations

--- a/buildroot/share/tests/BIGTREE_BTT002-tests
+++ b/buildroot/share/tests/BIGTREE_BTT002-tests
@@ -12,7 +12,9 @@ set -e
 restore_configs
 opt_set MOTHERBOARD BOARD_BTT_BTT002_V1_0
 opt_set SERIAL_PORT 1
-exec_test $1 $2 "BigTreeTech BTT002 Default Configuration"
+opt_set X_DRIVER_TYPE TMC2209
+opt_set Y_DRIVER_TYPE TMC2130
+exec_test $1 $2 "BigTreeTech BTT002 Default Configuration plus TMC steppers"
 
 # clean up
 restore_configs

--- a/buildroot/share/tests/BIGTREE_SKR_PRO-tests
+++ b/buildroot/share/tests/BIGTREE_SKR_PRO-tests
@@ -23,7 +23,9 @@ opt_set TEMP_SENSOR_2 1
 opt_set E0_AUTO_FAN_PIN PC10
 opt_set E1_AUTO_FAN_PIN PC11
 opt_set E2_AUTO_FAN_PIN PC12
-exec_test $1 $2 "BigTreeTech SKR Pro 3 Extruders with Auto-Fan"
+opt_set X_DRIVER_TYPE TMC2209
+opt_set Y_DRIVER_TYPE TMC2130
+exec_test $1 $2 "BigTreeTech SKR Pro 3 Extruders with Auto-Fan and mixed TMC drivers"
 
 # clean up
 restore_configs

--- a/platformio.ini
+++ b/platformio.ini
@@ -769,9 +769,10 @@ build_flags       = ${common.build_flags}
   -DHAVE_HWSERIAL3
   -DPIN_SERIAL2_RX=PD_6
   -DPIN_SERIAL2_TX=PD_5
+  -IMarlin/src/HAL/STM32
 build_unflags     = -std=gnu++11
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
-lib_ignore        = Adafruit NeoPixel, SailfishLCD, SlowSoftI2CMaster
+lib_ignore        = Adafruit NeoPixel, SailfishLCD, SlowSoftI2CMaster, SoftwareSerial
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32>
 
 #


### PR DESCRIPTION
### Description

Follow-up to earlier commit which allowed STM32 HAL timer values to be overridden in board pins files (#17805).

That change did not work when using SoftwareSerial with TMC drivers, because HAL.cpp required one of the constants which was moved to `timers.cpp`.

I have added helper which allows `HAL_init` to set the software serial interrupt priority without having to actually know the priority value.

### Benefits

Allows `HAL/STM32` builds which use SoftwareSerial.

I do not currently have hardware set up to test this myself. I'm hoping that @GhostlyCrowd or @thisiskeithb will be able to try it out, since they both encountered this in the attached issue.

### Related Issues

#17823
