### PR TITLE
Fix TERN usage in DIGIPOT_MCP4451

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -193,6 +193,10 @@
 #define ENABLED(V...)       DO(ENA,&&,V)
 #define DISABLED(V...)      DO(DIS,&&,V)
 
+#define _ARGS(...)          __VA_ARGS__
+#define _STRIP_PARENS(X)    X
+#define STRIP_PARENS(X)     _STRIP_PARENS( _ARGS X )
+
 #define TERN(O,A,B)         _TERN(_ENA_1(O),B,A)    // OPTION converted to '0' or '1'
 #define TERN0(O,A)          _TERN(_ENA_1(O),0,A)    // OPTION converted to A or '0'
 #define TERN1(O,A)          _TERN(_ENA_1(O),1,A)    // OPTION converted to A or '1'

--- a/Marlin/src/feature/digipot/digipot_mcp4451.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4451.cpp
@@ -82,7 +82,7 @@ void digipot_i2c_init() {
     Wire.begin();
   #endif
   // Set up initial currents as defined in Configuration_adv.h
-  static const float digipot_motor_current[] PROGMEM = TERN(DIGIPOT_USE_RAW_VALUES, DIGIPOT_MOTOR_CURRENT, DIGIPOT_I2C_MOTOR_CURRENTS);
+  static const float digipot_motor_current[] PROGMEM = STRIP_PARENS(TERN(DIGIPOT_USE_RAW_VALUES, (DIGIPOT_MOTOR_CURRENT), (DIGIPOT_I2C_MOTOR_CURRENTS)));
   LOOP_L_N(i, COUNT(digipot_motor_current))
     digipot_i2c_set_current(i, pgm_read_float(&digipot_motor_current[i]));
 }


### PR DESCRIPTION
### Description

The use of `TERN` in the digipot source did not work because the arguments are curly-brace enclosed array initializers. The preprocessor doesn't understand curly braces, causes incorrect macro expansion.

I've addressed this by wrapping the `TERN` arguments in parenthesis, and adding a macro to strip parenthesis from the result.

### Benefits

Build is fixed.

### Related Issues

#17776 
