### PR TITLE
Fix ExtUI compilation errors

### DIFF
--- a/Marlin/src/lcd/extui_example.cpp
+++ b/Marlin/src/lcd/extui_example.cpp
@@ -89,13 +89,15 @@ namespace ExtUI {
     // whether successful or not.
   }
 
-  void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
-    // Called when any mesh points are updated
-  }
+  #if HAS_MESH
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
+      // Called when any mesh points are updated
+    }
 
-  void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {
-    // Called to indicate a special condition
-  }
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {
+      // Called to indicate a special condition
+    }
+  #endif
 
   #if ENABLED(POWER_LOSS_RECOVERY)
     void onPowerLossResume() {

--- a/Marlin/src/lcd/extui_malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui_malyan_lcd.cpp
@@ -491,8 +491,11 @@ namespace ExtUI {
   void onLoadSettings(const char*) {}
   void onConfigurationStoreWritten(bool) {}
   void onConfigurationStoreRead(bool) {}
-  void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {}
-  void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {}
+
+  #if HAS_MESH
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {}
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {}
+  #endif
 
   #if ENABLED(POWER_LOSS_RECOVERY)
     void onPowerLossResume() {}


### PR DESCRIPTION
The compilation fails when HAS_MESH is not defined.
The enum ExtUI::probe_state_t is only available when HAS_MESH is defined.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
