### PR TITLE
Introduce SDCARD_READONLY advanced configuration

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1208,6 +1208,19 @@
    */
   //#define SDCARD_CONNECTION LCD
 
+  //#define SDCARD_READONLY   // Disable write support for SD cards (saves ~2192 PROGMEM bytes)
+  #if ENABLED(SDCARD_READONLY)
+    #if ENABLED(POWER_LOSS_RECOVERY)
+      #error Read-only SD-card support is incompatible with power-loss recovery
+    #endif
+    #if ENABLED(BINARY_FILE_TRANSFER)
+      #error Read-only SD-card support is incompatible with binary file transfer
+    #endif
+    #if ENABLED(SDCARD_EEPROM_EMULATION)
+      #error Read-only SD-card support is incompatible with EEPROM emulation
+    #endif
+  #endif
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/sd/SdBaseFile.cpp
+++ b/Marlin/src/sd/SdBaseFile.cpp
@@ -47,6 +47,9 @@ void (*SdBaseFile::dateTime_)(uint16_t* date, uint16_t* time) = 0;
 
 // add a cluster to a file
 bool SdBaseFile::addCluster() {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   if (!vol_->allocContiguous(1, &curCluster_)) return false;
 
   // if first cluster of file link to directory entry
@@ -55,11 +58,15 @@ bool SdBaseFile::addCluster() {
     flags_ |= F_FILE_DIR_DIRTY;
   }
   return true;
+  #endif
 }
 
 // Add a cluster to a directory file and zero the cluster.
 // return with first block of cluster in the cache
 bool SdBaseFile::addDirCluster() {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   uint32_t block;
   // max folder size
   if (fileSize_ / sizeof(dir_t) >= 0xFFFF) return false;
@@ -82,6 +89,7 @@ bool SdBaseFile::addDirCluster() {
   // Increase directory file size by cluster size
   fileSize_ += 512UL << vol_->clusterSizeShift_;
   return true;
+  #endif
 }
 
 // cache a file's directory entry
@@ -153,6 +161,9 @@ bool SdBaseFile::contiguousRange(uint32_t* bgnBlock, uint32_t* endBlock) {
  *
  */
 bool SdBaseFile::createContiguous(SdBaseFile* dirFile, const char* path, uint32_t size) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   uint32_t count;
   // don't allow zero length file
   if (size == 0) return false;
@@ -172,6 +183,7 @@ bool SdBaseFile::createContiguous(SdBaseFile* dirFile, const char* path, uint32_
   flags_ |= F_FILE_DIR_DIRTY;
 
   return sync();
+  #endif
 }
 
 /**
@@ -419,6 +431,9 @@ bool SdBaseFile::make83Name(const char* str, uint8_t* name, const char** ptr) {
  * directory, \a path is invalid or already exists in \a parent.
  */
 bool SdBaseFile::mkdir(SdBaseFile* parent, const char* path, bool pFlag) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   uint8_t dname[11];
   SdBaseFile dir1, dir2;
   SdBaseFile* sub = &dir1;
@@ -446,9 +461,13 @@ bool SdBaseFile::mkdir(SdBaseFile* parent, const char* path, bool pFlag) {
     sub = parent != &dir1 ? &dir1 : &dir2;
   }
   return mkdir(parent, dname);
+  #endif
 }
 
 bool SdBaseFile::mkdir(SdBaseFile* parent, const uint8_t dname[11]) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   uint32_t block;
   dir_t d;
   dir_t* p;
@@ -502,6 +521,7 @@ bool SdBaseFile::mkdir(SdBaseFile* parent, const uint8_t dname[11]) {
 
   // write first block
   return vol_->cacheFlush();
+  #endif
 }
 
 /**
@@ -632,7 +652,7 @@ bool SdBaseFile::open(SdBaseFile* dirFile, const uint8_t dname[11], uint8_t ofla
   }
   else {
     // don't create unless O_CREAT and O_WRITE
-    if (!(oflag & O_CREAT) || !(oflag & O_WRITE)) return false;
+    if (oflag & (O_CREAT | O_WRITE) != (O_CREAT | O_WRITE)) return false;
     if (emptyFound) {
       index = dirIndex_;
       p = cacheDirEntry(SdVolume::CACHE_FOR_WRITE);
@@ -716,6 +736,10 @@ bool SdBaseFile::open(SdBaseFile* dirFile, uint16_t index, uint8_t oflag) {
 
 // open a cached directory entry. Assumes vol_ is initialized
 bool SdBaseFile::openCachedEntry(uint8_t dirIndex, uint8_t oflag) {
+  #if ENABLED(SDCARD_READONLY)
+  if (oflag & (O_WRITE | O_CREAT | O_TRUNC)) goto FAIL;
+  #endif
+
   // location of entry in cache
   dir_t* p = &vol_->cache()->dir[dirIndex];
 
@@ -1135,6 +1159,9 @@ dir_t* SdBaseFile::readDirCache() {
  * or an I/O error occurred.
  */
 bool SdBaseFile::remove() {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   dir_t* d;
   // free any clusters - will fail if read-only or directory
   if (!truncate(0)) return false;
@@ -1152,6 +1179,7 @@ bool SdBaseFile::remove() {
   // write entry to SD
   return vol_->cacheFlush();
   return true;
+  #endif
 }
 
 /**
@@ -1172,8 +1200,12 @@ bool SdBaseFile::remove() {
  * or an I/O error occurred.
  */
 bool SdBaseFile::remove(SdBaseFile* dirFile, const char* path) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   SdBaseFile file;
   return file.open(dirFile, path, O_WRITE) ? file.remove() : false;
+  #endif
 }
 
 /**
@@ -1187,6 +1219,9 @@ bool SdBaseFile::remove(SdBaseFile* dirFile, const char* path) {
  * file, newPath is invalid or already exists, or an I/O error occurs.
  */
 bool SdBaseFile::rename(SdBaseFile* dirFile, const char* newPath) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   dir_t entry;
   uint32_t dirCluster = 0;
   SdBaseFile file;
@@ -1261,6 +1296,7 @@ restore:
     vol_->cacheFlush();
   }
   return false;
+  #endif
 }
 
 /**
@@ -1279,6 +1315,9 @@ restore:
  * directory, is not empty, or an I/O error occurred.
  */
 bool SdBaseFile::rmdir() {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   // must be open subdirectory
   if (!isSubDir()) return false;
 
@@ -1299,6 +1338,7 @@ bool SdBaseFile::rmdir() {
   type_ = FAT_FILE_TYPE_NORMAL;
   flags_ |= O_WRITE;
   return remove();
+  #endif
 }
 
 /**
@@ -1317,6 +1357,9 @@ bool SdBaseFile::rmdir() {
  * \return true for success, false for failure.
  */
 bool SdBaseFile::rmRfStar() {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   uint32_t index;
   SdBaseFile f;
   rewind();
@@ -1356,6 +1399,7 @@ bool SdBaseFile::rmRfStar() {
     if (!rmdir()) return false;
   }
   return true;
+  #endif
 }
 
 /**
@@ -1423,6 +1467,7 @@ void SdBaseFile::setpos(filepos_t* pos) {
  * opened or an I/O error.
  */
 bool SdBaseFile::sync() {
+  #if DISABLED(SDCARD_READONLY)
   // only allow open files and directories
   if (!isOpen()) goto FAIL;
 
@@ -1449,6 +1494,7 @@ bool SdBaseFile::sync() {
   return vol_->cacheFlush();
 
   FAIL:
+  #endif
   writeError = true;
   return false;
 }
@@ -1524,6 +1570,9 @@ bool SdBaseFile::timestamp(SdBaseFile* file) {
  */
 bool SdBaseFile::timestamp(uint8_t flags, uint16_t year, uint8_t month,
                            uint8_t day, uint8_t hour, uint8_t minute, uint8_t second) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   uint16_t dirDate, dirTime;
   dir_t* d;
 
@@ -1561,6 +1610,7 @@ bool SdBaseFile::timestamp(uint8_t flags, uint16_t year, uint8_t month,
     d->lastWriteTime = dirTime;
   }
   return vol_->cacheFlush();
+  #endif
 }
 
 /**
@@ -1575,6 +1625,9 @@ bool SdBaseFile::timestamp(uint8_t flags, uint16_t year, uint8_t month,
  * \a length is greater than the current file size or an I/O error occurs.
  */
 bool SdBaseFile::truncate(uint32_t length) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   uint32_t newPos;
   // error if not a normal file or read-only
   if (!isFile() || !(flags_ & O_WRITE)) return false;
@@ -1617,6 +1670,7 @@ bool SdBaseFile::truncate(uint32_t length) {
 
   // set file to correct position
   return seekSet(newPos);
+  #endif
 }
 
 /**
@@ -1636,6 +1690,7 @@ bool SdBaseFile::truncate(uint32_t length) {
  *
  */
 int16_t SdBaseFile::write(const void* buf, uint16_t nbyte) {
+  #if DISABLED(SDCARD_READONLY)
   // convert void* to uint8_t*  -  must be before goto statements
   const uint8_t* src = reinterpret_cast<const uint8_t*>(buf);
 
@@ -1726,6 +1781,7 @@ int16_t SdBaseFile::write(const void* buf, uint16_t nbyte) {
   return nbyte;
 
   FAIL:
+  #endif
   // return for write error
   writeError = true;
   return -1;

--- a/Marlin/src/sd/SdVolume.cpp
+++ b/Marlin/src/sd/SdVolume.cpp
@@ -46,6 +46,9 @@
 
 // find a contiguous group of clusters
 bool SdVolume::allocContiguous(uint32_t count, uint32_t* curCluster) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   // start of group
   uint32_t bgnCluster;
   // end of group
@@ -114,9 +117,11 @@ bool SdVolume::allocContiguous(uint32_t count, uint32_t* curCluster) {
   if (setStart) allocSearchStart_ = bgnCluster + 1;
 
   return true;
+  #endif
 }
 
 bool SdVolume::cacheFlush() {
+  #if DISABLED(SDCARD_READONLY)
   if (cacheDirty_) {
     if (!sdCard_->writeBlock(cacheBlockNumber_, cacheBuffer_.data))
       return false;
@@ -129,6 +134,7 @@ bool SdVolume::cacheFlush() {
     }
     cacheDirty_ = 0;
   }
+  #endif
   return true;
 }
 
@@ -190,6 +196,9 @@ bool SdVolume::fatGet(uint32_t cluster, uint32_t* value) {
 
 // Store a FAT entry
 bool SdVolume::fatPut(uint32_t cluster, uint32_t value) {
+  #if ENABLED(SDCARD_READONLY)
+  return false;
+  #else
   uint32_t lba;
   // error if reserved cluster
   if (cluster < 2) return false;
@@ -244,6 +253,7 @@ bool SdVolume::fatPut(uint32_t cluster, uint32_t value) {
   // mirror second FAT
   if (fatCount_ > 1) cacheMirrorBlock_ = lba + blocksPerFat_;
   return true;
+  #endif
 }
 
 // free a cluster chain

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -417,8 +417,12 @@ void CardReader::endFilePrint(
 }
 
 void CardReader::openLogFile(char * const path) {
+  #if ENABLED(SDCARD_READONLY)
+  flag.logging = false;
+  #else
   flag.logging = true;
   openFileWrite(path);
+  #endif
 }
 
 //
@@ -544,6 +548,9 @@ void CardReader::openFileWrite(char * const path) {
   const char * const fname = diveToFile(false, curDir, path);
   if (!fname) return;
 
+  #if ENABLED(SDCARD_READONLY)
+  openFailed(fname);
+  #else
   if (file.open(curDir, fname, O_CREAT | O_APPEND | O_WRITE | O_TRUNC)) {
     flag.saving = true;
     selectFileByName(fname);
@@ -555,6 +562,7 @@ void CardReader::openFileWrite(char * const path) {
   }
   else
     openFailed(fname);
+  #endif
 }
 
 //
@@ -569,6 +577,9 @@ void CardReader::removeFile(const char * const name) {
   const char * const fname = diveToFile(false, curDir, name);
   if (!fname) return;
 
+  #if ENABLED(SDCARD_READONLY)
+  SERIAL_ECHOLNPAIR("Deletion failed (read-only), File: ", fname, ".");
+  #else
   if (file.remove(curDir, fname)) {
     SERIAL_ECHOLNPAIR("File deleted:", fname);
     sdpos = 0;
@@ -578,6 +589,7 @@ void CardReader::removeFile(const char * const name) {
   }
   else
     SERIAL_ECHOLNPAIR("Deletion failed, File: ", fname, ".");
+  #endif
 }
 
 void CardReader::report_status() {


### PR DESCRIPTION
### Requirements

* Define `SDCARD_READONLY` in `Configuration_adv.h`

### Description

This saves a little bit over 2000 bytes of PROGMEM, and is useful for those of us that mostly drives their printer over the serial port (e.g. with Octoprint), but don't want to fully disable support for an SD card -- while retaining the ability to print from it.

The default (read-write) doesn't change.

### Benefits

This saves over 2180 bytes of PROGMEM bytes.
