### PR TITLE
Force unix-style line endings for testing scripts

### DIFF
--- a/buildroot/bin/.gitattributes
+++ b/buildroot/bin/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/buildroot/share/tests/.gitattributes
+++ b/buildroot/share/tests/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
### Description

Add `.gitattributes` files to test folders so that unix-style line endings are retained when checking out on Windows.

### Benefits

Allows `run_tests` and related scripts to work in repos which were checked out in Windows, but Windows Subsystem for Linux is used to execute tests.

### Related Issues

This came up in a Discord discussion the other day, although I've already been working around this for some time.
[Discord discussion about running tests locally](https://discordapp.com/channels/461605380783472640/593010746431111196/702282588693200946)
