### PR TITLE
Fix Malyan Extui (printer crash)

### DIFF
--- a/Marlin/src/lcd/extui_malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui_malyan_lcd.cpp
@@ -378,12 +378,12 @@ void parse_lcd_byte(const byte b) {
       || (!is_lcd && c == '\n')                 // LF on a G-code command
     ) {
       inbound_buffer[inbound_count] = '\0';     // Reset before processing
-      parsing = 0;                              // Unflag and...
       inbound_count = 0;                        // Reset buffer index
       if (parsing == 1)
         process_lcd_command(inbound_buffer);    // Handle the LCD command
       else
         queue.enqueue_one_now(inbound_buffer);  // Handle the G-code command
+      parsing = 0;                              // Unflag and...
     }
     else if (inbound_count < MAX_CURLY_COMMAND - 2)
       inbound_buffer[inbound_count++] = is_lcd ? c : b; // Buffer while space remains


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

The Malyan M300 did not respond anymore from the lcd interface nor usb.
The bug was introduced in [d5b791a] where the parsing flag was reset before
being used. It implies all command were interpreted as gcode.
Moving the reset  flag after the test fixed the issue.

[d5b791a] Fix Malyan ExtUI parse_lcd_byte

### Benefits

The Malyan M300 does not crash anymore.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
