### PR TITLE
Update platform.io for Fysetc S6 compilation

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -684,10 +684,11 @@ build_flags       = ${common.build_flags}
   -DTARGET_STM32F4 -std=gnu++14
   -DVECT_TAB_OFFSET=0x10000
   -DUSBCON -DUSBD_USE_CDC -DHAL_PCD_MODULE_ENABLED -DUSBD_VID=0x0483 '-DUSB_PRODUCT="FYSETC_S6"'
+  -IMarlin/src/HAL/STM32
 build_unflags     = -std=gnu++11
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32>
-lib_ignore        = Arduino-L6470
+lib_ignore        = Arduino-L6470, SoftwareSerial
 debug_tool        = stlink
 #upload_protocol   = stlink
 upload_protocol   = serial


### PR DESCRIPTION
Fix to avoid errors while compiling for FYSETC_S6
