### PR TITLE
KILL PIN invertion

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -340,6 +340,15 @@
   #endif
 #endif
 
+/**
+ * Invert KILL_PIN switch+
+ * Default is when KILL_PIN is set to LOW, Marlin will turn off. Invert this behaviour here
+ */
+
+//#define KILL_SWITCH_INVERTING
+
+
+
 // @section temperature
 
 //===========================================================================

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -517,7 +517,7 @@ inline void manage_inactivity(const bool ignore_stepper_queue=false) {
     // -------------------------------------------------------------------------------
     static int killCount = 0;   // make the inactivity button a bit less responsive
     const int KILL_DELAY = 750;
-    if (!readKillPin())
+    if (readKillPin())
       killCount++;
     else if (killCount > 0)
       killCount--;

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -384,6 +384,12 @@ bool printingIsActive() {
   return !did_pause_print && (print_job_timer.isRunning() || IS_SD_PRINTING());
 }
 
+bool readKill() {
+    if (ENABLED(KILL_SWITCH_INVERTING))
+        return READ(KILL_PIN);
+    return !READ(KILL_PIN);
+}
+
 /**
  * Printing is paused according to SD or host indicators
  */
@@ -505,7 +511,7 @@ inline void manage_inactivity(const bool ignore_stepper_queue=false) {
     // -------------------------------------------------------------------------------
     static int killCount = 0;   // make the inactivity button a bit less responsive
     const int KILL_DELAY = 750;
-    if (!READ(KILL_PIN))
+    if (!readKill())
       killCount++;
     else if (killCount > 0)
       killCount--;
@@ -819,10 +825,10 @@ void minkill(const bool steppers_off/*=false*/) {
   #if HAS_KILL
 
     // Wait for kill to be released
-    while (!READ(KILL_PIN)) watchdog_refresh();
+    while (!readKill()) watchdog_refresh();
 
     // Wait for kill to be pressed
-    while (READ(KILL_PIN)) watchdog_refresh();
+    while (readKill()) watchdog_refresh();
 
     void (*resetFunc)() = 0;      // Declare resetFunc() at address 0
     resetFunc();                  // Jump to address 0

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -384,10 +384,16 @@ bool printingIsActive() {
   return !did_pause_print && (print_job_timer.isRunning() || IS_SD_PRINTING());
 }
 
-bool readKill() {
-    if (ENABLED(KILL_SWITCH_INVERTING))
-        return READ(KILL_PIN);
-    return !READ(KILL_PIN);
+/**
+ * Reads KILL_PIN
+ */
+bool readKillPin() {
+    #if HAS_KILL
+        if (ENABLED(KILL_SWITCH_INVERTING))
+            return READ(KILL_PIN);
+        return !READ(KILL_PIN);
+    #endif
+        return false;
 }
 
 /**
@@ -511,7 +517,7 @@ inline void manage_inactivity(const bool ignore_stepper_queue=false) {
     // -------------------------------------------------------------------------------
     static int killCount = 0;   // make the inactivity button a bit less responsive
     const int KILL_DELAY = 750;
-    if (!readKill())
+    if (!readKillPin())
       killCount++;
     else if (killCount > 0)
       killCount--;
@@ -825,10 +831,10 @@ void minkill(const bool steppers_off/*=false*/) {
   #if HAS_KILL
 
     // Wait for kill to be released
-    while (!readKill()) watchdog_refresh();
+    while (!readKillPin()) watchdog_refresh();
 
     // Wait for kill to be pressed
-    while (readKill()) watchdog_refresh();
+    while (readKillPin()) watchdog_refresh();
 
     void (*resetFunc)() = 0;      // Declare resetFunc() at address 0
     resetFunc();                  // Jump to address 0

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -112,6 +112,8 @@ extern millis_t max_inactive_time, stepper_inactive_time;
   #endif
 #endif
 
+bool readKill();
+
 bool pin_is_protected(const pin_t pin);
 void protected_pin_err();
 

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -112,7 +112,7 @@ extern millis_t max_inactive_time, stepper_inactive_time;
   #endif
 #endif
 
-bool readKill();
+bool readKillPin();
 
 bool pin_is_protected(const pin_t pin);
 void protected_pin_err();


### PR DESCRIPTION
### Description

Currently Marlin powers off when KILL_PIN is LOW. I want to reverse this so Marlin .kill()s itself when KILL_PIN is momentarily in HIGH.
My code simply makes it configurable. Default stays whatever it is right now of course.

### Benefits

For my use: I have a relay connected to a momentary switch. I want to be able to turn off my printer when i click the switch again. If i don't do this change, printer will turn off a few seconds after it being turned on because KILL_PIN is LOW which Marlin considers as kill.

### Related Issues

No related issues