### PR TITLE
Decrease `MIN_COOLING_SLOPE_DEG_BED`

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -3074,7 +3074,7 @@ void Temperature::tick() {
   #if HAS_HEATED_BED
 
     #ifndef MIN_COOLING_SLOPE_DEG_BED
-      #define MIN_COOLING_SLOPE_DEG_BED 1.50
+      #define MIN_COOLING_SLOPE_DEG_BED 1.00
     #endif
     #ifndef MIN_COOLING_SLOPE_TIME_BED
       #define MIN_COOLING_SLOPE_TIME_BED 60


### PR DESCRIPTION
### Description

I propose to change the default minimum cooling slope to allow for more bed cooling.
With my setup in a room around 25 deg, I have at most been able to drop the bed temperature to 42 deg with `M190`.

By changing `MIN_COOLING_SLOPE_DEG_BED` to `1.00`, I can drop the temperature to around 37 deg.

I know this can be changed in the configuration, but I think this might be a better default, since it can be convenient for e.g. auto-eject, to be able to cool to at least 40 deg.
Maybe the slope value could be even lower, not sure what people think.

Here is some data collection I did of my setup, this chart shows the temperature drop over time:
![Time vs  Temperature (1)](https://user-images.githubusercontent.com/8664776/81007168-0b38fa00-8e51-11ea-91e4-f438b039fa66.png)

and this chart shows the time it took to drop each degree by 1:
![Delta Time vs  Temperature](https://user-images.githubusercontent.com/8664776/81006415-ca8cb100-8e4f-11ea-9568-893aaa673d78.png)
It can be seen that the slope of 1 deg can get the temperature from 38 deg to 37deg in around 1 minute.

### Benefits
It is possible to cool the bed to a lower temperature using the `M190` command before it times out.
