### PR TITLE
Fix LCD_TIMEOUT_TO_STATUS bug

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/base_screen.cpp
@@ -46,11 +46,9 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
     return false;
   }
 
-  #if LCD_TIMEOUT_TO_STATUS
-    if (EventLoop::get_pressed_tag() != 0) {
-      reset_menu_timeout();
-    }
-  #endif
+  if (EventLoop::get_pressed_tag() != 0) {
+    reset_menu_timeout();
+  }
 
   if (buttonIsPressed(tag)) {
     options = OPT_FLAT;
@@ -66,25 +64,19 @@ bool BaseScreen::buttonStyleCallback(CommandProcessor &cmd, uint8_t tag, uint8_t
 }
 
 void BaseScreen::onIdle() {
-  #if LCD_TIMEOUT_TO_STATUS
-    if ((millis() - last_interaction) > LCD_TIMEOUT_TO_STATUS) {
-      reset_menu_timeout();
-      #if ENABLED(TOUCH_UI_DEBUG)
-        SERIAL_ECHO_MSG("Returning to status due to menu timeout");
-      #endif
-      GOTO_SCREEN(StatusScreen);
-    }
-  #endif
+  if ((millis() - last_interaction) > LCD_TIMEOUT_TO_STATUS) {
+    reset_menu_timeout();
+    #if ENABLED(TOUCH_UI_DEBUG)
+      SERIAL_ECHO_MSG("Returning to status due to menu timeout");
+    #endif
+    GOTO_SCREEN(StatusScreen);
+  }
 }
 
 void BaseScreen::reset_menu_timeout() {
-  #if LCD_TIMEOUT_TO_STATUS
     last_interaction = millis();
-  #endif
 }
 
-#if LCD_TIMEOUT_TO_STATUS
-  uint32_t BaseScreen::last_interaction;
-#endif
+uint32_t BaseScreen::last_interaction;
 
 #endif // TOUCH_UI_FTDI_EVE

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
@@ -103,9 +103,7 @@ enum {
 
 class BaseScreen : public UIScreen {
   protected:
-    #if LCD_TIMEOUT_TO_STATUS
-      static uint32_t last_interaction;
-    #endif
+    static uint32_t last_interaction;
 
     static bool buttonIsPressed(uint8_t tag);
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -121,7 +121,7 @@ MarlinUI ui;
   #endif
 #endif
 
-#if HAS_LCD_MENU && LCD_TIMEOUT_TO_STATUS
+#if HAS_LCD_MENU
   bool MarlinUI::defer_return_to_status;
 #endif
 
@@ -732,7 +732,7 @@ void MarlinUI::update() {
   static uint16_t max_display_update_time = 0;
   millis_t ms = millis();
 
-  #if HAS_LCD_MENU && LCD_TIMEOUT_TO_STATUS
+  #if HAS_LCD_MENU
     static millis_t return_to_status_ms = 0;
     #define RESET_STATUS_TIMEOUT() (return_to_status_ms = ms + LCD_TIMEOUT_TO_STATUS)
   #else
@@ -967,7 +967,7 @@ void MarlinUI::update() {
         NOLESS(max_display_update_time, millis() - ms);
     }
 
-    #if HAS_LCD_MENU && LCD_TIMEOUT_TO_STATUS
+    #if HAS_LCD_MENU
       // Return to Status Screen after a timeout
       if (on_status_screen() || defer_return_to_status)
         RESET_STATUS_TIMEOUT();

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -508,7 +508,7 @@ public:
     #endif
 
     FORCE_INLINE static void defer_status_screen(const bool defer=true) {
-      TERN(LCD_TIMEOUT_TO_STATUS, defer_return_to_status = defer, UNUSED(defer));
+      defer_return_to_status = defer;
     }
 
     static inline void goto_previous_screen_no_defer() {
@@ -612,11 +612,7 @@ private:
 
   #if HAS_SPI_LCD
     #if HAS_LCD_MENU
-      #if LCD_TIMEOUT_TO_STATUS
-        static bool defer_return_to_status;
-      #else
-        static constexpr bool defer_return_to_status = false;
-      #endif
+      static bool defer_return_to_status;
     #endif
     static void draw_status_screen();
   #endif


### PR DESCRIPTION
### Description

Remove checks for `LCD_TIMEOUT_TO_STATUS` as it always gets set in `Conditionals_post.h`.

### Benefits

Removes unneeded `#if` and `TERN` guards.

### Related Issues

This will fix https://github.com/MarlinFirmware/Marlin/issues/17883 and https://github.com/MarlinFirmware/Marlin/issues/17885 since there will be no `TERN` anymore. :)

Specifically: deferring the return to status screen is totally broken right now. Any modal will always get returned to the status screen eventually (i.e., bed leveling corner.)

The core problem with the above issues is that `TERN` breaks because `LCD_TIMEOUT_TO_STATUS` expands to a value rather than being empty. This doesn't solve the issue with `TERN` as it just gets rid of it entirely, but it does solve the timeout issue.