### PR TITLE
Add TMCStepper support for MKS Robin Pro

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -59,6 +59,7 @@ jobs:
         - FYSETC_S6
         - malyan_M300
         - mks_robin_lite
+        - mks_robin_pro
 
         # Put lengthy tests last
 

--- a/buildroot/share/tests/mks_robin_pro-tests
+++ b/buildroot/share/tests/mks_robin_pro-tests
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+#
+# Build tests for MKS Robin Pro
+#
+
+# exit on first failure
+set -e
+
+use_example_configs Mks/Robin_Pro
+opt_set SDCARD_CONNECTION LCD
+opt_set X_DRIVER_TYPE TMC2209
+opt_set Y_DRIVER_TYPE TMC2130
+exec_test $1 $2 "MKS Robin Pro with TMC Drivers "
+
+# cleanup
+restore_configs

--- a/platformio.ini
+++ b/platformio.ini
@@ -558,11 +558,12 @@ platform      = ststm32
 board         = genericSTM32F103ZE
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_pro.py
 build_flags   = !python Marlin/src/HAL/STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14 -DSTM32_XL_DENSITY
+  ${common.build_flags} -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4 -DSTM32_XL_DENSITY
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps      = ${common.lib_deps}
-lib_ignore    = Adafruit NeoPixel, SPI, TMCStepper
+  SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
+lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # MKS Robin E3D (STM32F103RCT6) and


### PR DESCRIPTION
### Description

Enable use of TMCStepper on the MKS Robin Pro.

I can't test this, but the timer number matches what MKS specifies in their Robin Pro repo.

### Related Issues

#17654 
