### PR TITLE
 Remove M73 doesn't work on SD print comment

### DIFF
--- a/Marlin/src/gcode/lcd/M73.cpp
+++ b/Marlin/src/gcode/lcd/M73.cpp
@@ -33,9 +33,6 @@
  *
  * Example:
  *   M73 P25 ; Set progress to 25%
- *
- * Notes:
- *   This has no effect during an SD print job
  */
 void GcodeSuite::M73() {
   if (parser.seen('P'))


### PR DESCRIPTION
### Description

This comment does not appear to be true. I've used M73 in prints running from SD cards and found the values from the M73 commands to be honored.

### Benefits

Removes misleading comment

### Related Issues

n/a
