### PR TITLE
Continuous print : Unbed Auto feature (in test)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2011,6 +2011,29 @@
 
   //#define FILAMENT_LOAD_UNLOAD_GCODES           // Add M701/M702 Load/Unload G-codes, plus Load/Unload in the LCD Prepare menu.
   //#define FILAMENT_UNLOAD_ALL_EXTRUDERS         // Allow M702 to unload all extruders above a minimum target temp (as set by M302)
+
+  /**
+   * Unbed object pause
+   * To unbed object in continuous printing
+   * Timeout can be reset by one clic , and skipped by long press.
+   * Beeps happens 5 seconds before timeout
+   * Alert enabled, beeps 10 sec when begins/before ending
+   * Store the higher height for z clearance. (Lower to higher object suggested to avoid long unwanted z raising)
+   * Z raise can be reset after unbed an object to avoid long raising if the others are smaller
+   * Require PARK_HEAD_ON_PAUSE / NOZZLE_PARK_FEATURE / UNBED_AUTO_COUNTDOWN positive
+   *
+   * M600 A/D/C/B/U  Enable/Disable/Clear highest Z clearance/Alert/Unbedding
+   * Experimental printers with xy moves + extrusion, or z moves under object will corrupt this feature
+   */
+   //#define UNBED_AUTO
+   #if ENABLED(UNBED_AUTO)
+     #define UNBED_AUTO_Z_ADD                  10 // Override NOZZLE_PARK_FEATURE (Add from the highest layer printed)
+     //#define UNBED_AUTO_X                       // Override NOZZLE_PARK_FEATURE
+     //#define UNBED_AUTO_Y                       // Override NOZZLE_PARK_FEATURE
+     #define UNBED_AUTO_COUNTDOWN              60 // (s) Only for M125 U, négative or 0 disable feature (Bed timer reset on park for bed manipulations)
+     #define UNBED_AUTO_LONG_PRESS_INTERVAL   500 // (ms) Only for M125 U, increase if long press not applied
+     #define UNBED_AUTO_ALERT                     // Beep each sec, during 10 sec when starting and before continue print
+   #endif
 #endif
 
 // @section tmc

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -53,6 +53,10 @@
   #include "../lcd/extui/ui_api.h"
 #endif
 
+#if ENABLED(POWER_LOSS_RECOVERY)
+  #include "powerloss.h"
+#endif
+
 #include "../lcd/ultralcd.h"
 
 #if HAS_BUZZER
@@ -108,6 +112,89 @@ fil_change_settings_t fc_settings[EXTRUDERS];
 #else
   inline void impatient_beep(const int8_t, const bool=false) {}
   inline void first_impatient_beep(const int8_t) {}
+#endif
+
+#if UNBED_AUTO_COUNTDOWN > 0
+  float unbed_min_z_height = 0;
+  bool unbed_auto = false,
+      unbed_alert = ENABLED(UNBED_AUTO_ALERT);
+  millis_t unbed_timeout;
+  void clear_unbed_min_z_height() {unbed_min_z_height = 0;};
+
+  void unbed(){
+    xyz_pos_t park_point = NOZZLE_PARK_POINT;
+    const bool sd_printing = TERN0(SDSUPPORT, IS_SD_PRINTING());
+    millis_t diff_clic,
+             clic = 0,
+             unbed_alert_period = 0,
+             start;
+    TERN_(THERMAL_PROTECTION_BED, millis_t bed_period = WATCH_BED_TEMP_PERIOD - 2000);
+    constexpr millis_t add = SEC_TO_MS(UNBED_AUTO_COUNTDOWN);
+    bool one_on_two = 0, buzz_ok = 1 ;
+
+    #ifdef UNBED_AUTO_Z_ADD
+      park_point.z = unbed_min_z_height - current_position.z + UNBED_AUTO_Z_ADD;
+    #else
+      park_point.z += (unbed_min_z_height - current_position.z);
+    #endif
+    LIMIT(park_point.z, current_position.z, Z_MAX_POS);
+    #ifdef UNBED_AUTO_X
+      park_point.x = UNBED_AUTO_X;
+    #endif
+    #ifdef UNBED_AUTO_Y
+      park_point.y = UNBED_AUTO_Y;
+    #endif
+
+    if (pause_print(PAUSE_PARK_RETRACT_LENGTH, park_point, 0, true)) {
+      TERN_(POWER_LOSS_RECOVERY, if (recovery.enabled) recovery.save(true));
+      TERN_(HAS_LCD_MENU, lcd_pause_show_message(PAUSE_MESSAGE_TIMED, PAUSE_MODE_PAUSE_PRINT));
+
+      if (!sd_printing) {
+        clic = millis();
+        unbed_timeout = clic + add;
+        wait_for_user = true;
+        start = millis();
+        while (unbed_timeout > (millis()))  {
+          // diff_clic have double usage, for diff, or for storing old clic
+          if(!wait_for_user) { //Click/M108 detected
+            diff_clic = clic ;// Used to temporary store the old clic value too
+            if(one_on_two) diff_clic = (clic = millis()) - diff_clic ; //3 clics diff test for no unwanted skipping
+            one_on_two++;
+            unbed_timeout += add;
+            if (diff_clic < UNBED_AUTO_LONG_PRESS_INTERVAL) unbed_timeout = 0;
+            wait_for_user = true;
+          }
+          #if ENABLED(THERMAL_PROTECTION_BED)
+            if( !(bed_period--) ) {
+               thermalManager.reset_bed_idle_timer();
+               bed_period = WATCH_BED_TEMP_PERIOD - 2000;
+            }
+          #endif
+          idle_no_sleep();
+          //Beep when close to the end
+          #if HAS_BUZZER
+            if (unbed_alert && ( (millis() > (unbed_timeout - 10000)) || ( millis() < (start + 10000)))) {
+              if(unbed_alert_period++ > 2000){
+                unbed_alert_period = 0;
+                BUZZ(200, 5000);
+              }
+            }
+            else
+              if( buzz_ok )
+                if ((millis() > (unbed_timeout - 5000)) && (millis() < (unbed_timeout - 4900)) )  {
+                  buzz_ok = false;
+                  BUZZ(200, 5000);
+                }
+          #endif
+        }//while
+      }
+      unbed_timeout = 0;
+      TERN_(HAS_LCD_MENU, ui.return_to_status());
+      TERN_(THERMAL_PROTECTION_BED, thermalManager.reset_bed_idle_timer());
+      TERN_(THERMAL_PROTECTION_BED, thermalManager.wait_for_bed_heating());
+      resume_print(0, 0, -PAUSE_PARK_RETRACT_LENGTH, 0);
+    }
+  } //unbed()
 #endif
 
 /**

--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -48,6 +48,7 @@ enum PauseMessage : char {
   PAUSE_MESSAGE_PARKING,
   PAUSE_MESSAGE_CHANGING,
   PAUSE_MESSAGE_WAITING,
+  PAUSE_MESSAGE_TIMED,
   PAUSE_MESSAGE_UNLOAD,
   PAUSE_MESSAGE_INSERT,
   PAUSE_MESSAGE_LOAD,
@@ -72,6 +73,14 @@ enum PauseMessage : char {
 extern fil_change_settings_t fc_settings[EXTRUDERS];
 
 extern uint8_t did_pause_print;
+
+#if UNBED_AUTO_COUNTDOWN > 0
+  extern float unbed_min_z_height;
+  extern bool unbed_auto, unbed_alert;
+  extern millis_t unbed_timeout;
+  extern void clear_unbed_min_z_height();
+  extern void unbed();
+#endif
 
 #if ENABLED(DUAL_X_CARRIAGE)
   #define DXC_PARAMS , const int8_t DXC_ext=-1

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -48,6 +48,12 @@
 /**
  * M600: Pause for filament change
  *
+ *  A           - Enable UNBED_AUTO
+ *  D           - Disable UNBED_AUTO
+ *  C           - Clear Z highest clearance
+ *  B[0/1]      - Enable/disable UNBED_ALERT
+ *  U           - Unbed
+ *
  *  E[distance] - Retract the filament this far
  *  Z[distance] - Move the Z axis by this distance
  *  X[position] - Move to this X position, with Y
@@ -61,6 +67,14 @@
  *  Default values are used for omitted arguments.
  */
 void GcodeSuite::M600() {
+
+  #if UNBED_AUTO_COUNTDOWN > 0
+    if (parser.seen('A')) { unbed_auto = true; return;}
+    if (parser.seen('D')) { unbed_auto = false; return;}
+    if (parser.seen('C')) { unbed_min_z_height = 0; return;}
+    if (parser.seen('U')) { unbed(); return;}
+    if (parser.seenval('B')) {unbed_alert = parser.linearval('B'); return;}
+  #endif
 
   #if ENABLED(MIXING_EXTRUDER)
     const int8_t target_e_stepper = get_target_e_stepper_from_command();

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -316,6 +316,22 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
         lcd_put_u8str(i16tostr3rj(thermalManager.degTargetHotend(extruder)));
     }
 
+    #if UNBED_AUTO_COUNTDOWN > 0
+      void MarlinUI::draw_unbed_timeout_status(const uint8_t row) {
+        row_y1 = row * (MENU_FONT_HEIGHT) + 1;
+        row_y2 = row_y1 + MENU_FONT_HEIGHT - 1;
+
+        if (!PAGE_CONTAINS(row_y1 + 1, row_y2 + 2)) return;
+
+        lcd_put_wchar(LCD_PIXEL_WIDTH - 11 * (MENU_FONT_WIDTH), row_y2, ' ');
+        lcd_put_u8str(i16tostr3rj(LROUND(MS_TO_SEC(unbed_timeout - millis()))));
+        lcd_put_wchar(' ');
+        lcd_put_wchar('s');
+        lcd_put_wchar('e');
+        lcd_put_wchar('c');
+      }
+    #endif
+    
   #endif // ADVANCED_PAUSE_FEATURE
 
   // Set the colors for a menu item based on whether it is selected

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -352,6 +352,10 @@ namespace Language_en {
   PROGMEM Language_Str MSG_PAUSING                         = _UxGT("Pausing...");
   PROGMEM Language_Str MSG_PAUSE_PRINT                     = _UxGT("Pause Print");
   PROGMEM Language_Str MSG_RESUME_PRINT                    = _UxGT("Resume Print");
+  PROGMEM Language_Str MSG_UNBED_AUTO                      = _UxGT("Unbed auto");
+  PROGMEM Language_Str MSG_UNBED_CLEAR                     = _UxGT("Clear Z raise");
+  PROGMEM Language_Str MSG_UNBED_AUTO_TIME_OUT             = _UxGT(" Countdown");
+  PROGMEM Language_Str MSG_UNBED_ALERT                     = _UxGT("Alert");
   PROGMEM Language_Str MSG_STOP_PRINT                      = _UxGT("Stop Print");
   PROGMEM Language_Str MSG_PRINTING_OBJECT                 = _UxGT("Printing Object");
   PROGMEM Language_Str MSG_CANCEL_OBJECT                   = _UxGT("Cancel Object");
@@ -587,6 +591,7 @@ namespace Language_en {
   //
   #if LCD_HEIGHT >= 4
     PROGMEM Language_Str MSG_ADVANCED_PAUSE_WAITING        = _UxGT(MSG_2_LINE("Press Button", "to resume print"));
+    PROGMEM Language_Str MSG_ADVANCED_TIMED_WAITING        = _UxGT(MSG_3_LINE("Short/Long clic", "to add time","or continue"));
     PROGMEM Language_Str MSG_PAUSE_PRINT_PARKING           = _UxGT(MSG_1_LINE("Parking..."));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_INIT          = _UxGT(MSG_3_LINE("Wait for", "filament change", "to start"));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_INSERT        = _UxGT(MSG_3_LINE("Insert filament", "and press button", "to continue"));
@@ -599,6 +604,7 @@ namespace Language_en {
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_RESUME        = _UxGT(MSG_2_LINE("Wait for print", "to resume..."));
   #else
     PROGMEM Language_Str MSG_ADVANCED_PAUSE_WAITING        = _UxGT(MSG_1_LINE("Click to continue"));
+    PROGMEM Language_Str MSG_ADVANCED_TIMED_WAITING        = _UxGT(MSG_1_LINE("Add/Skip"));
     PROGMEM Language_Str MSG_PAUSE_PRINT_PARKING           = _UxGT(MSG_1_LINE("Parking..."));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_INIT          = _UxGT(MSG_1_LINE("Please wait..."));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_INSERT        = _UxGT(MSG_1_LINE("Insert and Click"));

--- a/Marlin/src/lcd/language/language_fr.h
+++ b/Marlin/src/lcd/language/language_fr.h
@@ -306,6 +306,10 @@ namespace Language_fr {
   PROGMEM Language_Str MSG_PAUSE_PRINT                     = _UxGT("Pause impression");
   PROGMEM Language_Str MSG_RESUME_PRINT                    = _UxGT("Reprendre impr.");
   PROGMEM Language_Str MSG_STOP_PRINT                      = _UxGT("Arrêter impr.");
+  PROGMEM Language_Str MSG_UNBED_AUTO                      = _UxGT("Enlèvement auto");
+  PROGMEM Language_Str MSG_UNBED_CLEAR                     = _UxGT("RaZ hauteur");
+  PROGMEM Language_Str MSG_UNBED_AUTO_TIME_OUT             = _UxGT(" Reste");
+  PROGMEM Language_Str MSG_UNBED_ALERT                     = _UxGT("Alerte");
   PROGMEM Language_Str MSG_PRINTING_OBJECT                 = _UxGT("Impression objet");
   PROGMEM Language_Str MSG_CANCEL_OBJECT                   = _UxGT("Annuler objet");
   PROGMEM Language_Str MSG_CANCEL_OBJECT_N                 = _UxGT("Annuler objet =");
@@ -523,6 +527,7 @@ namespace Language_fr {
   #if LCD_HEIGHT >= 4
     // Up to 3 lines allowed
     PROGMEM Language_Str MSG_ADVANCED_PAUSE_WAITING        = _UxGT(MSG_2_LINE("Presser bouton", "pour reprendre"));
+    PROGMEM Language_Str MSG_ADVANCED_TIMED_WAITING        = _UxGT(MSG_3_LINE("Clic court/long", "pour augmenter","ou continuer"));
     PROGMEM Language_Str MSG_PAUSE_PRINT_PARKING           = _UxGT(MSG_1_LINE("Parking..."));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_INIT          = _UxGT(MSG_2_LINE("Attente filament", "pour démarrer"));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_INSERT        = _UxGT(MSG_3_LINE("Insérer filament", "et app. bouton", "pour continuer..."));
@@ -536,6 +541,7 @@ namespace Language_fr {
   #else // LCD_HEIGHT < 4
     // Up to 2 lines allowed
     PROGMEM Language_Str MSG_ADVANCED_PAUSE_WAITING        = _UxGT(MSG_1_LINE("Clic pour continuer"));
+    PROGMEM Language_Str MSG_ADVANCED_TIMED_WAITING        = _UxGT(MSG_1_LINE("+Temps/Retour"));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_INIT          = _UxGT(MSG_1_LINE("Patience..."));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_INSERT        = _UxGT(MSG_1_LINE("Insérer fil."));
     PROGMEM Language_Str MSG_FILAMENT_CHANGE_HEAT          = _UxGT(MSG_1_LINE("Chauffer ?"));

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -149,6 +149,18 @@ void menu_advanced_settings();
 
 #endif
 
+#if UNBED_AUTO_COUNTDOWN > 0
+  void menu_unbed_auto() {
+    START_MENU();
+    BACK_ITEM(MSG_CONFIGURATION);
+    EDIT_ITEM(bool, MSG_UNBED_AUTO, &unbed_auto);
+    EDIT_ITEM(bool, MSG_UNBED_ALERT, &unbed_alert);
+    ACTION_ITEM(MSG_UNBED_CLEAR, clear_unbed_min_z_height);
+    ACTION_ITEM(MSG_UNBED_AUTO, unbed);
+    END_MENU();
+  }
+#endif
+
 #if HAS_HOTEND_OFFSET
   #include "../../module/motion.h"
   #include "../../gcode/queue.h"
@@ -401,6 +413,10 @@ void menu_configuration() {
     #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
       SUBMENU(MSG_TOOL_MIGRATION, menu_toolchange_migration);
     #endif
+  #endif
+
+  #if UNBED_AUTO_COUNTDOWN > 0
+    SUBMENU(MSG_UNBED_AUTO, menu_unbed_auto);
   #endif
 
   //

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -36,6 +36,10 @@
   #include "../../feature/runout.h"
 #endif
 
+#if UNBED_AUTO_COUNTDOWN > 0
+  #include "../../feature/pause.h"
+#endif
+
 //
 // Change Filament > Change/Unload/Load Filament
 //
@@ -221,6 +225,23 @@ static PGM_P pause_header() {
   ++_thisItemNr; \
 }while(0)
 
+#if UNBED_AUTO_COUNTDOWN > 0
+  #define UNBED_TIME_STATUS_ITEM() do { \
+    if (_menuLineNr == _thisItemNr) { \
+      if (ui.should_draw()) { \
+        MenuItem_static::draw(_lcdLineNr, GET_TEXT(MSG_UNBED_AUTO_TIME_OUT), SS_INVERT); \
+        ui.draw_unbed_timeout_status(_lcdLineNr); \
+      } \
+      if (_skipStatic && encoderLine <= _thisItemNr) { \
+        ui.encoderPosition += ENCODER_STEPS_PER_MENU_ITEM; \
+        ++encoderLine; \
+      } \
+      ui.refresh(LCDVIEW_CALL_REDRAW_NEXT); \
+    } \
+    ++_thisItemNr; \
+  }while(0)
+#endif
+
 void menu_pause_option() {
   START_MENU();
   #if LCD_HEIGHT > 2
@@ -261,7 +282,12 @@ void _lcd_pause_message(PGM_P const msg) {
   if (has2) STATIC_ITEM_P(msg2);                                // 3: Message Line 2
   if (has3 && (LCD_HEIGHT) >= 5) STATIC_ITEM_P(msg3);           // 4: Message Line 3 (if LCD has 5 lines)
   if (skip1 + 1 + has2 + has3 < (LCD_HEIGHT) - 2) SKIP_ITEM();  // Push Hotend Status down, if needed
-  HOTEND_STATUS_ITEM();                                         // 5: Hotend Status
+  #if UNBED_AUTO_COUNTDOWN > 0
+    if (unbed_timeout) UNBED_TIME_STATUS_ITEM();                  // 5: Hotend Status/Unbed countdown
+    else HOTEND_STATUS_ITEM();
+  #else
+    HOTEND_STATUS_ITEM();
+  #endif
   END_SCREEN();
 }
 
@@ -274,6 +300,7 @@ void lcd_pause_insert_message()   { _lcd_pause_message(GET_TEXT(MSG_FILAMENT_CHA
 void lcd_pause_load_message()     { _lcd_pause_message(GET_TEXT(MSG_FILAMENT_CHANGE_LOAD));    }
 void lcd_pause_waiting_message()  { _lcd_pause_message(GET_TEXT(MSG_ADVANCED_PAUSE_WAITING));  }
 void lcd_pause_resume_message()   { _lcd_pause_message(GET_TEXT(MSG_FILAMENT_CHANGE_RESUME));  }
+void lcd_pause_timed_message()    { _lcd_pause_message(GET_TEXT(MSG_ADVANCED_TIMED_WAITING));  }
 
 void lcd_pause_purge_message() {
   #if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
@@ -289,6 +316,7 @@ FORCE_INLINE screenFunc_t ap_message_screen(const PauseMessage message) {
     case PAUSE_MESSAGE_CHANGING: return lcd_pause_changing_message;
     case PAUSE_MESSAGE_UNLOAD:   return lcd_pause_unload_message;
     case PAUSE_MESSAGE_WAITING:  return lcd_pause_waiting_message;
+    case PAUSE_MESSAGE_TIMED  :  return lcd_pause_timed_message;
     case PAUSE_MESSAGE_INSERT:   return lcd_pause_insert_message;
     case PAUSE_MESSAGE_LOAD:     return lcd_pause_load_message;
     case PAUSE_MESSAGE_PURGE:    return lcd_pause_purge_message;

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -415,6 +415,7 @@ public:
 
       #if ENABLED(ADVANCED_PAUSE_FEATURE)
         static void draw_hotend_status(const uint8_t row, const uint8_t extruder);
+        static void draw_unbed_timeout_status(const uint8_t row);
       #endif
 
       static void status_screen();


### PR DESCRIPTION
Implementation of : 
Feature to stop the printer between objects in continuous printing , by giving enough time needed and skip timeout when ready. Detect the new build by Z go under current printed layer0

**UNBED_AUTO** (implemented in ADVANCED_PAUSE_FEATURE)
- M600 A/D/C/B/U(enable/disable/clear z raise/alert/unbed)
- Park head with time out 
- LCD clic add more time / Long press skip and return to print
- Beep 5 seconds before timeout
- Store the max Z height used in the printing for CLEARANCE
- Can clear z raise , for unwanted too long z raise if little other objects
- Park head with timeout , when Z axis wants to go under the current Z height
-- (The only situation a printer go under an object is for printing a new )
          