### PR TITLE
Remove extraneous commas in M115_GEOMETRY_REPORT

### DIFF
--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -134,11 +134,11 @@ void GcodeSuite::M115() {
         "area:{"
           "full:{"
             "min:{x:", lmin.x, ",y:", lmin.y, ",z:", lmin.z, "},"
-            "max:{x:", lmax.x, ",y:", lmax.y, ",z:", lmax.z, "},"
+            "max:{x:", lmax.x, ",y:", lmax.y, ",z:", lmax.z, "}"
           "},"
           "work:{"
             "min:{x:", wmin.x, ",y:", wmin.y, ",z:", wmin.z, "},"
-            "max:{x:", wmax.x, ",y:", wmax.y, ",z:", wmax.z, "},"
+            "max:{x:", wmax.x, ",y:", wmax.y, ",z:", wmax.z, "}",
           "}"
         "}"
       );


### PR DESCRIPTION
### Description

The output M115_GEOMETRY_REPORT seems to have extra trailing commas between closing breakes after each `max` element.

I'm not completely sure of the intended output format, but this seems incorrect.

### Benefits

Old output:
`area:{full:{min:{x:0.00,y:0.00,z:0.00},max:{x:220.00,y:220.00,z:300.00},},work:{min:{x:0.00,y:0.00,z:0.00},max:{x:220.00,y:220.00,z:300.00},}}`

New Output:
`area:{full:{min:{x:0.00,y:0.00,z:0.00},max:{x:220.00,y:220.00,z:300.00}},work:{min:{x:0.00,y:0.00,z:0.00},max:{x:220.00,y:220.00,z:300.00}}}`

### Related Issues

None
