### PR TITLE
Require TMCStepper >=0.6.2 for LPC176x controllers

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -265,7 +265,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768>
 lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper@>=0.6.1,<1.0.0
+  TMCStepper@>=0.6.2
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 
@@ -283,7 +283,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768>
 lib_deps          = Servo
   LiquidCrystal
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper@>=0.6.1,<1.0.0
+  TMCStepper@>=0.6.2
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 


### PR DESCRIPTION
### Description

Update the minimum version of TMCStepper required for LPC1768/9 environments.

### Benefits

TMCStepper 0.6.2 includes the following fix, which resolves communication issues when using single-pin software serial. This most significantly impacts SKR 1.4 boards, which use single-pin serial by default.

Without this change impacted boards could sometimes (but not always) fail to properly configure their last TMC driver, usually their extruder. When this occurred TMC status would report OK, but the wrong number of microsteps were often used.

https://github.com/teemuatlut/TMCStepper/pull/101

### Related Issues

I'm not aware of currently open issues, but this came to my attention due to a Discord user having issues with their extruder driver travelling the wrong distance. This might not be the root cause, but it is very possible.
