### PR TITLE
Fix vector normalization in JD

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2257,20 +2257,18 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       #endif
     ;
 
-    #if IS_CORE && HAS_JUNCTION_DEVIATION
+    #if IS_CORE
       /**
        * On CoreXY the length of the vector [A,B] is SQRT(2) times the length of the head movement vector [X,Y].
        * So taking Z and E into account, we cannot scale to a unit vector with "inverse_millimeters".
        * => normalize the complete junction vector
        */
       normalize_junction_vector(unit_vec);
-    #elif HAS_JUNCTION_DEVIATION
+    #else
       if (esteps)
         normalize_junction_vector(unit_vec); // Normalize with XYZE components
       else
-        unit_vec *= inverse_millimeters;     // Normalize with 1 / length
-    #else
-      unit_vec *= inverse_millimeters;       // Normalize with 1 / length
+        unit_vec *= inverse_millimeters;     // Normalize with 1 / sqrt(x^2 + y^2 + z^2)
     #endif
 
     // Skip first block or when previous_nominal_speed is used as a flag for homing and offset cycles.

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2264,14 +2264,13 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
        * => normalize the complete junction vector
        */
       normalize_junction_vector(unit_vec);
+    #elif HAS_JUNCTION_DEVIATION
+      if (esteps)
+        normalize_junction_vector(unit_vec); // Normalize with XYZE components
+      else
+        unit_vec *= inverse_millimeters;     // Normalize with 1 / length
     #else
-      if (esteps) {
-        // inverse_millimeters does not include extruder steps -> NORM(unit_vec) != inverse_millimeters
-        normalize_junction_vector(unit_vec);
-      }
-      else {
-        unit_vec *= inverse_millimeters;
-      }
+      unit_vec *= inverse_millimeters;       // Normalize with 1 / length
     #endif
 
     // Skip first block or when previous_nominal_speed is used as a flag for homing and offset cycles.

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2256,7 +2256,6 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
         { steps_dist_mm.x, steps_dist_mm.y, steps_dist_mm.z, steps_dist_mm.e }
       #endif
     ;
-    unit_vec *= inverse_millimeters;
 
     #if IS_CORE && HAS_JUNCTION_DEVIATION
       /**
@@ -2265,6 +2264,14 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
        * => normalize the complete junction vector
        */
       normalize_junction_vector(unit_vec);
+    #else
+      if (esteps) {
+        // inverse_millimeters does not include extruder steps -> NORM(unit_vec) != inverse_millimeters
+        normalize_junction_vector(unit_vec);
+      }
+      else {
+        unit_vec *= inverse_millimeters;
+      }
     #endif
 
     // Skip first block or when previous_nominal_speed is used as a flag for homing and offset cycles.

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2257,19 +2257,16 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       #endif
     ;
 
-    #if IS_CORE
-      /**
-       * On CoreXY the length of the vector [A,B] is SQRT(2) times the length of the head movement vector [X,Y].
-       * So taking Z and E into account, we cannot scale to a unit vector with "inverse_millimeters".
-       * => normalize the complete junction vector
-       */
-      normalize_junction_vector(unit_vec);
-    #else
-      if (esteps)
-        normalize_junction_vector(unit_vec); // Normalize with XYZE components
-      else
-        unit_vec *= inverse_millimeters;     // Normalize with 1 / sqrt(x^2 + y^2 + z^2)
-    #endif
+    /**
+     * On CoreXY the length of the vector [A,B] is SQRT(2) times the length of the head movement vector [X,Y].
+     * So taking Z and E into account, we cannot scale to a unit vector with "inverse_millimeters".
+     * => normalize the complete junction vector.
+     * Elsewise, when needed JD factors in the E component
+     */
+    if (ENABLED(IS_CORE) || esteps > 0)
+      normalize_junction_vector(unit_vec);  // Normalize with XYZE components
+    else
+      unit_vec *= inverse_millimeters;      // Use pre-calculated (1 / SQRT(x^2 + y^2 + z^2))
 
     // Skip first block or when previous_nominal_speed is used as a flag for homing and offset cycles.
     if (moves_queued && !UNEAR_ZERO(previous_nominal_speed_sqr)) {


### PR DESCRIPTION
### Description

As far as I can see in the code, `block->millimeters` and thereby `inverse_millimeters` does not include extruder steps (see [this code](https://github.com/MarlinFirmware/Marlin/blob/86c112538084f7718252966f5f9d9278c4837fb2/Marlin/src/module/planner.cpp#L1868)). Using `inverse_millimeters` to normalize `unit_vec` will therefore lead to incorrect results for non-travel moves and cause `junction_cos_theta` to be incorrect as well. This PR fixes that by correctly normalizing `unit_vec` in case the extruder moves.

**Note:** I'm not too familiar with the Marlin codebase, so please have a good look at this to make sure I'm not missing something. If I'm wrong and `block->millimeters` does include extruder steps, please let me know and I'll close this.

### Benefits

- `unit_vec` will actually be a unit vector after normalization.
- Computation of `junction_cos_theta` will be correct for non-travel moves.

### Related Issues

Might affect #17920, because the incorrect normalization should result in a further reduced `limit_sqr`. The effect might be too small to notice, though.
