### PR TITLE
Remove unused code from Classic Jerk

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2486,11 +2486,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
     previous_safe_speed = safe_speed;
 
-    #if HAS_JUNCTION_DEVIATION
-      vmax_junction_sqr = _MIN(vmax_junction_sqr, sq(vmax_junction));
-    #else
-      vmax_junction_sqr = sq(vmax_junction);
-    #endif
+    vmax_junction_sqr = sq(vmax_junction);
 
   #endif // Classic Jerk Limiting
 


### PR DESCRIPTION
### Description

`HAS_CLASSIC_JERK` and `HAS_JUNCTION_DEVIATION` should never be true at the same time (see [definition](https://github.com/MarlinFirmware/Marlin/blob/86c112538084f7718252966f5f9d9278c4837fb2/Marlin/src/inc/Conditionals_LCD.h#L689)). As this `#if HAS_JUNCTION_DEVIATION` check is inside of an `#if HAS_CLASSIC_JERK` check, the `_MIN(...)` part will never be included.

**Note:** I'm not too familiar with the Marlin codebase, so please have a good look at this to make sure I'm not missing something.

### Benefits

Clarity. Removes code which is never included.

### Related Issues

None.
