### PR TITLE
Fysetc S6: use PIO DFU with proper settings

### DIFF
--- a/buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
+++ b/buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
@@ -31,25 +31,3 @@ for file_name in os.listdir(source_dir):
     full_file_name = os.path.join(source_dir, file_name)
     if os.path.isfile(full_file_name):
         shutil.copy(full_file_name, variant_dir)
-
-# Relocate firmware from 0x08000000 to 0x08002000
-#env['CPPDEFINES'].remove(("VECT_TAB_ADDR", 134217728))
-#env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08010000"))
-#env.Replace(LDSCRIPT_PATH="buildroot/share/PlatformIO/ldscripts/fysetc_aio_ii.ld")
-
-# Custom HEX from ELF
-env.AddPostAction(
-	"$BUILD_DIR/${PROGNAME}.elf",
-	env.VerboseAction(" ".join([
-				"$OBJCOPY",
-				"-O",
-				"ihex",
-				"$BUILD_DIR/${PROGNAME}.elf",
-				"$BUILD_DIR/${PROGNAME}.hex"
-			]), "Building $TARGET"))
-
-# In-line command with arguments
-env.Replace(
-	UPLOADER=platform.get_package_dir("tool-stm32duino") + '/stm32flash/stm32flash',
-	UPLOADCMD='"${UPLOADER}" -v -i rts,-dtr,dtr,-rts -R -b 115200 -g 0x8000000 -w "${BUILD_DIR}/${PROGNAME}.hex" ${UPLOAD_PORT}'
-)

--- a/platformio.ini
+++ b/platformio.ini
@@ -729,8 +729,8 @@ extra_scripts     = pre:buildroot/share/PlatformIO/scripts/fysetc_STM32S6.py
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32>
 lib_ignore        = Arduino-L6470, SoftwareSerial
 debug_tool        = stlink
-#upload_protocol   = stlink
-upload_protocol   = serial
+upload_protocol   = dfu
+upload_command    = dfu-util -a 0 -s 0x08010000:leave -D "$SOURCE"
 
 #
 # STM32F407VET6 with RAMPS-like shield


### PR DESCRIPTION
### Requirements

* Fysetc S6 Board
* Press the BOOT0 button while turning on printer/board to enter DFU
* Upload using PIO

It uses PIO / stm32duino bundled _dfu-util_, so it should work across systems.

### Description

Fysetc S6 doesn't have serial bootloader. It has SD bootloader and DFU instead.

### Benefits

Allows to flash Fysetc S6 from PIO directly.

### Related Issues


