### PR TITLE
Avoid division in JD calc, when possible

### DIFF
--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -910,8 +910,12 @@ class Planner {
 
       FORCE_INLINE static float limit_value_by_axis_maximum(const float &max_value, xyze_float_t &unit_vec) {
         float limit_value = max_value;
-        LOOP_XYZE(idx) if (unit_vec[idx]) // Avoid divide by zero
-          NOMORE(limit_value, ABS(settings.max_acceleration_mm_per_s2[idx] / unit_vec[idx]));
+        LOOP_XYZE(idx) {
+          if (unit_vec[idx]) {
+            if (limit_value * ABS(unit_vec[idx]) > settings.max_acceleration_mm_per_s2[idx])
+              limit_value = ABS(settings.max_acceleration_mm_per_s2[idx] / unit_vec[idx]);
+          }
+        }
         return limit_value;
       }
 


### PR DESCRIPTION
### Description

There's no need for a division, if the axis is not limiting. This solution typically requires three to four multiplications instead of three to four divisions. In the worst case (all axis limiting in descending order), four divisions + four multiplications can be necessary, but that should be exceedingly rare.

Technically, the `if (unit_vec[idx]) {` check is not required anymore, since a divide by zero is avoided by `limit_value * ABS(unit_vec[idx]) > settings.max_acceleration_mm_per_s2[idx]`. I kept the check nonetheless, to avoid another multiplication when possible.

### Benefits

Typically saves three to four divides per block planned and only requires three to four multiplications in return.

### Related Issues

None.
