### PR TITLE
Improve STM32F4 Flash Behavior

### DIFF
--- a/Marlin/src/HAL/STM32/Servo.cpp
+++ b/Marlin/src/HAL/STM32/Servo.cpp
@@ -29,31 +29,65 @@
 #include "Servo.h"
 
 static uint_fast8_t servoCount = 0;
+static libServo *servos[NUM_SERVOS] = {0};
 constexpr millis_t servoDelay[] = SERVO_DELAY;
 static_assert(COUNT(servoDelay) == NUM_SERVOS, "SERVO_DELAY must be an array NUM_SERVOS long.");
 
 libServo::libServo()
-: delay(servoDelay[servoCount++])
-{}
+: delay(servoDelay[servoCount]),
+  was_attached_before_pause(false),
+  value_before_pause(0)
+{
+  servos[servoCount++] = this;
+}
 
 int8_t libServo::attach(const int pin) {
   if (servoCount >= MAX_SERVOS) return -1;
   if (pin > 0) servo_pin = pin;
-  return super::attach(servo_pin);
+  return stm32_servo.attach(servo_pin);
 }
 
 int8_t libServo::attach(const int pin, const int min, const int max) {
   if (servoCount >= MAX_SERVOS) return -1;
   if (pin > 0) servo_pin = pin;
-  return super::attach(servo_pin, min, max);
+  return stm32_servo.attach(servo_pin, min, max);
 }
 
 void libServo::move(const int value) {
   if (attach(0) >= 0) {
-    write(value);
+    stm32_servo.write(value);
     safe_delay(delay);
     TERN_(DEACTIVATE_SERVOS_AFTER_MOVE, detach());
   }
+}
+
+void libServo::pause()
+{
+  was_attached_before_pause = stm32_servo.attached();
+  if (was_attached_before_pause) {
+    value_before_pause = stm32_servo.read();
+    stm32_servo.detach();
+  }
+}
+
+void libServo::resume()
+{
+  if (was_attached_before_pause) {
+    attach();
+    move(value_before_pause);
+  }
+}
+
+void libServo::pause_all_servos()
+{
+  for (auto& servo : servos)
+    if (servo) servo->pause();
+}
+
+void libServo::resume_all_servos()
+{
+  for (auto& servo : servos)
+    if (servo) servo->resume();
 }
 #endif // HAS_SERVOS
 

--- a/Marlin/src/HAL/STM32/Servo.cpp
+++ b/Marlin/src/HAL/STM32/Servo.cpp
@@ -61,8 +61,7 @@ void libServo::move(const int value) {
   }
 }
 
-void libServo::pause()
-{
+void libServo::pause() {
   was_attached_before_pause = stm32_servo.attached();
   if (was_attached_before_pause) {
     value_before_pause = stm32_servo.read();
@@ -70,25 +69,22 @@ void libServo::pause()
   }
 }
 
-void libServo::resume()
-{
+void libServo::resume() {
   if (was_attached_before_pause) {
     attach();
     move(value_before_pause);
   }
 }
 
-void libServo::pause_all_servos()
-{
+void libServo::pause_all_servos() {
   for (auto& servo : servos)
     if (servo) servo->pause();
 }
 
-void libServo::resume_all_servos()
-{
+void libServo::resume_all_servos() {
   for (auto& servo : servos)
     if (servo) servo->resume();
 }
-#endif // HAS_SERVOS
 
+#endif // HAS_SERVOS
 #endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/HAL/STM32/Servo.h
+++ b/Marlin/src/HAL/STM32/Servo.h
@@ -27,15 +27,27 @@
 #include "../../core/millis_t.h"
 
 // Inherit and expand on the official library
-class libServo : public Servo {
+class libServo {
   public:
     libServo();
-    int8_t attach(const int pin);
+    int8_t attach(const int pin = 0); // pin == 0 uses value from previous call
     int8_t attach(const int pin, const int min, const int max);
+    void detach() { stm32_servo.detach(); }
+    int read() { return stm32_servo.read(); }
     void move(const int value);
+
+    void pause();
+    void resume();
+
+    static void pause_all_servos();
+    static void resume_all_servos();
+
   private:
-    typedef Servo super;
+    Servo stm32_servo;
 
     int servo_pin = 0;
     millis_t delay = 0;
+
+    bool was_attached_before_pause;
+    int value_before_pause;
 };

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -27,7 +27,15 @@
 #if ENABLED(FLASH_EEPROM_EMULATION)
 
 #include "../shared/eeprom_api.h"
-#include "Servo.h"
+
+#if HAS_SERVOS
+  #include "Servo.h"
+  #define PAUSE_SERVO_OUTPUT() libServo::pause_all_servos()
+  #define RESUME_SERVO_OUTPUT() libServo::resume_all_servos()
+#else  
+  #define PAUSE_SERVO_OUTPUT()
+  #define RESUME_SERVO_OUTPUT()
+#endif
 
 /**
  * The STM32 HAL supports chips that deal with "pages" and some with "sectors" and some that
@@ -159,11 +167,11 @@ bool PersistentStore::access_finish() {
         current_slot = EEPROM_SLOTS - 1;
         UNLOCK_FLASH();
 
-        libServo::pause_all_servos();
+        PAUSE_SERVO_OUTPUT();
         DISABLE_ISRS();
         status = HAL_FLASHEx_Erase(&EraseInitStruct, &SectorError);
         ENABLE_ISRS();
-        libServo::resume_all_servos();
+        RESUME_SERVO_OUTPUT();
         if (status != HAL_OK) {
           DEBUG_ECHOLNPAIR("HAL_FLASHEx_Erase=", status);
           DEBUG_ECHOLNPAIR("GetError=", HAL_FLASH_GetError());
@@ -214,11 +222,11 @@ bool PersistentStore::access_finish() {
       // Interrupts during this time can have unpredictable results, such as killing Servo
       // output. Servo output still glitches with interrupts disabled, but recovers after the
       // erase.
-      libServo::pause_all_servos();
+      PAUSE_SERVO_OUTPUT();
       DISABLE_ISRS();
       eeprom_buffer_flush();
       ENABLE_ISRS();
-      libServo::resume_all_servos();
+      RESUME_SERVO_OUTPUT();
 
       eeprom_data_written = false;
     #endif

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -29,12 +29,6 @@
 #include "../shared/eeprom_api.h"
 #include "Servo.h"
 
-
-// Only STM32F4 can support wear leveling at this time
-#ifndef STM32F4xx
-  #undef FLASH_EEPROM_LEVELING
-#endif
-
 /**
  * The STM32 HAL supports chips that deal with "pages" and some with "sectors" and some that
  * even have multiple "banks" of flash.

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -139,6 +139,11 @@ bool PersistentStore::access_start() {
 bool PersistentStore::access_finish() {
 
   if (eeprom_data_written) {
+    #ifdef STM32F4xx
+      // MCU may come up with flash error bits which prevent some flash operations.
+      // Clear flags prior to flash operations to prevent errors.
+      __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPERR | FLASH_FLAG_WRPERR | FLASH_FLAG_PGAERR | FLASH_FLAG_PGPERR | FLASH_FLAG_PGSERR);
+    #endif    
 
     #if ENABLED(FLASH_EEPROM_LEVELING)
 

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -48,3 +48,7 @@
   #warning "FLASH_EEPROM_EMULATION may cause long delays when writing and should not be used while printing."
   #error "Disable PRINTCOUNTER or choose another EEPROM emulation."
 #endif
+
+#if !defined(STM32F4xx) && ENABLED(FLASH_EEPROM_LEVELING)
+  #error "FLASH_EEPROM_LEVELING is currently only supported on STM32F4 hardware."
+#endif

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -43,3 +43,8 @@
   #endif
   #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT or choose another EEPROM emulation."
 #endif
+
+#if defined(STM32F4xx) && BOTH(PRINTCOUNTER, FLASH_EEPROM_EMULATION)
+  #warning "FLASH_EEPROM_EMULATION may cause long delays when writing and should not be used while printing."
+  #error "Disable PRINTCOUNTER or choose another EEPROM emulation."
+#endif


### PR DESCRIPTION
### Description

Improves several issues related to FLASH_EEPROM_EMULATION for STM32F4 environments using HAL/STM32.

**Hopefully several people will volunteer to test this prior to it being merged. While I believe this resolves the issues stated, I have only tried it on my SKR Pro board, and perhaps it causes issues for other configurations of non-STM32F4 boards using this HAL.**

#### 1. Clear flash error bits prior to writing to flash
Apparently STM32F4 MCUs come up with flash error bits set, that need to be cleared prior to flash operations. This caused the erase operation to fail, resulting in no data being stored. A second M500 was previously needed to succesfully store settings.

This is discussed in [this post on the ST forums](https://community.st.com/s/question/0D50X0000A4qiL0/why-would-flashflagpgperr-and-flashflagpgserr-be-set-after-a-successful-flash-write-and-at-powerup-before-any-flash-write-operations "Why would FLASH_FLAG_PGPERR and FLASH_FLAG_PGSERR be set after a successful flash write, and at power-up before any flash write operations?")

#### 2. Disallow PRINTCOUNTER when using FLASH_EEPROM_EMULATION with STM32F4
It takes just over one second on my SKR Pro to erase the 128kB flash sector used for EEPROM emulation. During this time the flash cannot be accessed at all, including to execute code from other sectors. This greatly interferes with timing and would be a generally bad idea during prints.

#### 3. Pause servo output during flash erase
As mentioned above, erasing the flash sector takes just over one second on my board. This disrupts servo (BLTOUCH) output to the extent that it does not recover.

Prior to performing a flash erase, this now pauses all active Servo output and disables interrupts, to avoid scenarios where interrupts misbehave if they run while flash is inaccessible. Previous Servo output is restored after the flash operation is complete. My BLTouch seems perfectly happy with this arrangement.

The following image demonstrates the duration of the gap in Servo output:
![image](https://user-images.githubusercontent.com/20053467/81509418-65a5e080-92bf-11ea-8f13-08fba61a6a48.png)

#### 4. Add sanity check to report error if `FLASH_EEPROM_LEVELING` is specified incorrectly
`FLASH_EEPROM_LEVELING` is very useful to reduce/hide the impacts of the issues this PR addresses. This is because it only erases the flash every 33rd time it is written. I wanted to be sure people could not specify it hoping for those benefits, and have it be silently disabled.

### Benefits

This makes `FLASH_EEPROM_EMULATION` much more usable on STM32F4 boards, in the two primary ways:
- Does not require two M500 commands to store settings for the first time after boot.
- Does not kill BLTouch after an M500.

### Related Issues

#17627 - SKR PRO, M502 M500 twice to update EEPROM
#16169 - SKR PRO Bltouch doesn't work after M502/M500/M501 (flash emulation related)
