### PR TITLE
Enable FLASH_EEPROM_LEVELING by default for STM32F4 boards

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -35,6 +35,12 @@
   #define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation
 #endif
 
+#if ENABLED(FLASH_EEPROM_EMULATION)
+  // Decrease delays and flash wear by spreading writes across the
+  // 128 kB sector allocated for EEPROM emulation.
+  #define FLASH_EEPROM_LEVELING
+#endif
+
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD 2000
 

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -38,6 +38,12 @@
   //#define FLASH_EEPROM_EMULATION                // Use Flash-based EEPROM emulation
 #endif
 
+#if ENABLED(FLASH_EEPROM_EMULATION)
+  // Decrease delays and flash wear by spreading writes across the
+  // 128 kB sector allocated for EEPROM emulation.
+  #define FLASH_EEPROM_LEVELING
+#endif
+
 #define TP                                        // Enable to define servo and probe pins
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_1.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_1.h
@@ -35,6 +35,12 @@
   #define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation
 #endif
 
+#if ENABLED(FLASH_EEPROM_EMULATION)
+  // Decrease delays and flash wear by spreading writes across the
+  // 128 kB sector allocated for EEPROM emulation.
+  #define FLASH_EEPROM_LEVELING
+#endif
+
 //
 // Servos
 //

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -47,6 +47,8 @@
 #endif
 
 #if ENABLED(FLASH_EEPROM_EMULATION)
+  // Decrease delays and flash wear by spreading writes across the
+  // 128 kB sector allocated for EEPROM emulation.
   #define FLASH_EEPROM_LEVELING
 #elif ENABLED(I2C_EEPROM)
   #undef E2END                                    // Defined in Arduino Core STM32 to be used with EEPROM emulation. This board uses a real EEPROM.


### PR DESCRIPTION
### Description

Enable `FLASH_EEPROM_LEVELING` by default for several boards.

### Benefits

These boards use a 128kB flash sector to store 4kB of configuration settings. Erasing this sector takes about one second, and subjects the sector to unnecessary wear.

This change allows the sector to be erased only every 32rd time settings are stored.

I was going to submit this change along with #17946, but it mostly hides the problems that PR is improving. Testing that PR with `FLASH_EEPROM_LEVELING` enabled would reduce the frequency of errors by about 97%, so I moved it to a separate PR.