### PR TITLE
DGUS: Use DGUS_RX_BUFFER_SIZE and DGUS_TX_BUFFER_SIZE

### DIFF
--- a/Marlin/src/HAL/AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/AVR/MarlinSerial.h
@@ -299,8 +299,8 @@
   template <uint8_t serial>
   struct MarlinInternalSerialCfg {
     static constexpr int PORT               = serial;
-    static constexpr unsigned int RX_SIZE   = 128;
-    static constexpr unsigned int TX_SIZE   = 48;
+    static constexpr unsigned int RX_SIZE   = DGUS_RX_BUFFER_SIZE;
+    static constexpr unsigned int TX_SIZE   = DGUS_TX_BUFFER_SIZE;
     static constexpr bool XONOFF            = false;
     static constexpr bool EMERGENCYPARSER   = false;
     static constexpr bool DROPPED_RX        = false;


### PR DESCRIPTION
The buffer sizes are currently hardcoded for the DGUS interface.

This PR makes it use of the `DGUS_RX_BUFFER_SIZE` and `DGUS_TX_BUFFER_SIZE` constants instead (the values are actually the same).