### PR TITLE
fix 17940 progressbar off by 1 pixel in Y

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -104,7 +104,7 @@
 #endif
 
 #define PROGRESS_BAR_X 54
-#define PROGRESS_BAR_Y (EXTRAS_BASELINE + 2)
+#define PROGRESS_BAR_Y (EXTRAS_BASELINE + 1)
 #define PROGRESS_BAR_WIDTH (LCD_PIXEL_WIDTH - PROGRESS_BAR_X)
 
 FORCE_INLINE void _draw_centered_temp(const int16_t temp, const uint8_t tx, const uint8_t ty) {


### PR DESCRIPTION
### Requirements

GLCD + SDSUPPORT

### Description

The lcd displays a progress bar when printing from SD, but the infill on the progress bar is out by one pixel in Y

### Benefits

Looks better.   

### Related Issues
#17940