### PR TITLE
Revert babystep check from 52aa459 to fix double-click for babystep

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -224,7 +224,7 @@ void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, co
         if (on_status_screen())
           doubleclick_expire_ms = millis() + DOUBLECLICK_MAX_INTERVAL;
       }
-      else if (on_status_screen() && currentScreen == menu_main && PENDING(millis(), doubleclick_expire_ms)) {
+      else if (screen == status_screen && currentScreen == menu_main && PENDING(millis(), doubleclick_expire_ms)) {
         if ( (ENABLED(BABYSTEP_WITHOUT_HOMING) || all_axes_known())
           && (ENABLED(BABYSTEP_ALWAYS_AVAILABLE) || printer_busy()) )
           screen = TERN(BABYSTEP_ZPROBE_OFFSET, lcd_babystep_zoffset, lcd_babystep_z);


### PR DESCRIPTION
### Description

Revert change on this line from 52aa459 to fix double-click for babystep.

### Related Issues

See https://github.com/MarlinFirmware/Marlin/issues/17959.