### PR TITLE
Clarify Home Before Filament Change comments

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1980,7 +1980,7 @@
   #define PAUSE_PARK_NO_STEPPER_TIMEOUT           // Enable for XYZ steppers to stay powered on during filament change.
 
   //#define PARK_HEAD_ON_PAUSE                    // Park the nozzle during pause and filament change.
-  //#define HOME_BEFORE_FILAMENT_CHANGE           // Ensure homing has been completed prior to parking for filament change
+  //#define HOME_BEFORE_FILAMENT_CHANGE           // If homing is needed, home prior to parking for filament change
 
   //#define FILAMENT_LOAD_UNLOAD_GCODES           // Add M701/M702 Load/Unload G-codes, plus Load/Unload in the LCD Prepare menu.
   //#define FILAMENT_UNLOAD_ALL_EXTRUDERS         // Allow M702 to unload all extruders above a minimum target temp (as set by M302)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1980,7 +1980,7 @@
   #define PAUSE_PARK_NO_STEPPER_TIMEOUT           // Enable for XYZ steppers to stay powered on during filament change.
 
   //#define PARK_HEAD_ON_PAUSE                    // Park the nozzle during pause and filament change.
-  //#define HOME_BEFORE_FILAMENT_CHANGE           // If homing is needed, home prior to parking for filament change
+  //#define HOME_BEFORE_FILAMENT_CHANGE           // If needed, home before parking for filament change
 
   //#define FILAMENT_LOAD_UNLOAD_GCODES           // Add M701/M702 Load/Unload G-codes, plus Load/Unload in the LCD Prepare menu.
   //#define FILAMENT_UNLOAD_ALL_EXTRUDERS         // Allow M702 to unload all extruders above a minimum target temp (as set by M302)

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -97,7 +97,7 @@ void GcodeSuite::M600() {
   #endif
 
   #if ENABLED(HOME_BEFORE_FILAMENT_CHANGE)
-    // Don't allow filament change without homing first
+    // If homing is needed, home prior to parking for filament change
     if (!all_axes_known()) home_all_axes();
   #endif
 

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -97,7 +97,7 @@ void GcodeSuite::M600() {
   #endif
 
   #if ENABLED(HOME_BEFORE_FILAMENT_CHANGE)
-    // If homing is needed, home prior to parking for filament change
+    // If needed, home before parking for filament change
     if (!all_axes_known()) home_all_axes();
   #endif
 


### PR DESCRIPTION
### Requirements

`HOME_BEFORE_FILAMENT_CHANGE`

### Description

I've had to correct users about `HOME_BEFORE_FILAMENT_CHANGE` many times because they assume it meant home before a filament change no matter what. This is not the case and will only home if homing is needed like when you disable steppers or first boot up your printer.

I debated renaming the feature for clarity, but updating the comment was less intrusive.

### Benefits

Clearer intent of the feature.

### Related Issues

None, but it originally lead me to look into the code behind `HOME_BEFORE_FILAMENT_CHANGE`. This lead to the fix in https://github.com/MarlinFirmware/Marlin/pull/17681, since the feature would only home a single time after bootup and never again, even if homing was needed.