### PR TITLE
Follow #17935 for SKR E3/DIP

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1381,8 +1381,6 @@
   //#define AO_EXP2_PINMAP      // AlephObjects CLCD UI EXP2 mapping
   //#define CR10_TFT_PINMAP     // Rudolph Riedel's CR10 pin mapping
   //#define S6_TFT_PINMAP       // FYSETC S6 pin mapping
-  //#define E3_EXP1_PINMAP      // E3 type boards (SKR E3/DIP, and Stock boards) EXP1 pin mapping
-  //#define GENERIC_EXP2_PINMAP // GENERIC EXP2 pin mapping
 
   //#define OTHER_PIN_LAYOUT  // Define pins manually below
   #if ENABLED(OTHER_PIN_LAYOUT)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/pin_mappings.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/pin_mappings.h
@@ -154,12 +154,3 @@
     #define CLCD_SPI_EXTRA_CS            SDSS
   #endif
 #endif
-
-#if EITHER(E3_EXP1_PINMAP, GENERIC_EXP2_PINMAP)
-  #ifndef __MARLIN_FIRMWARE__
-    #error "This pin mapping requires Marlin."
-  #endif
-
-  #define CLCD_MOD_RESET                 BTN_EN1
-  #define CLCD_SPI_CS                    LCD_PINS_RS
-#endif

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -759,11 +759,8 @@
 
   #define BEEPER_PIN                          37
 
-  #define BTN_EN1                             31
-  #define LCD_PINS_RS                         33
-
   #define SD_DETECT_PIN                       49
 
-  #define KILL_PIN                            -1
-
+  #define CLCD_MOD_RESET                      31
+  #define CLCD_SPI_CS                         33
 #endif // TOUCH_UI_FTDI_EVE && LCD_FYSETC_TFT81050

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
@@ -172,39 +172,31 @@
  *                 EXP1
  */
 
-#define EXPA1_03_PIN                        PB7
-#define EXPA1_04_PIN                        PB8
-#define EXPA1_05_PIN                        PB9
-#define EXPA1_06_PIN                        PA10
-#define EXPA1_07_PIN                        -1
-#define EXPA1_08_PIN                        PA9
-#define EXPA1_09_PIN                        PB6
-#define EXPA1_10_PIN                        PA15
 
 #if HAS_SPI_LCD
 
   #if ENABLED(CR10_STOCKDISPLAY)
 
-    #define BEEPER_PIN              EXPA1_10_PIN
+    #define BEEPER_PIN                      PA15
 
-    #define BTN_ENC                 EXPA1_09_PIN
-    #define BTN_EN1                 EXPA1_08_PIN
-    #define BTN_EN2                 EXPA1_06_PIN
+    #define BTN_ENC                         PB6
+    #define BTN_EN1                         PA9
+    #define BTN_EN2                         PA10
 
-    #define LCD_PINS_RS             EXPA1_04_PIN
-    #define LCD_PINS_ENABLE         EXPA1_03_PIN
-    #define LCD_PINS_D4             EXPA1_05_PIN
+    #define LCD_PINS_RS                     PB8
+    #define LCD_PINS_ENABLE                 PB7
+    #define LCD_PINS_D4                     PB9
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
     #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3.h' for details. Comment out this line to continue."
 
-    #define LCD_PINS_RS             EXPA1_05_PIN
-    #define LCD_PINS_ENABLE         EXPA1_09_PIN
-    #define LCD_PINS_D4             EXPA1_04_PIN
-    #define LCD_PINS_D5             EXPA1_06_PIN
-    #define LCD_PINS_D6             EXPA1_08_PIN
-    #define LCD_PINS_D7             EXPA1_10_PIN
+    #define LCD_PINS_RS                     PB9
+    #define LCD_PINS_ENABLE                 PB6
+    #define LCD_PINS_D4                     PB8
+    #define LCD_PINS_D5                     PA10
+    #define LCD_PINS_D6                     PA9
+    #define LCD_PINS_D7                     PA15
     #define ADC_KEYPAD_PIN                  PA1   // Repurpose servo pin for ADC - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
   #elif EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
@@ -220,14 +212,14 @@
      *                    EXP1
      */
 
-    #define BTN_ENC                 EXPA1_09_PIN
-    #define BTN_EN1                 EXPA1_08_PIN
-    #define BTN_EN2                 EXPA1_06_PIN
+    #define BTN_ENC                         PB6
+    #define BTN_EN1                         PA9
+    #define BTN_EN2                         PA10
 
-    #define DOGLCD_CS               EXPA1_04_PIN
-    #define DOGLCD_A0               EXPA1_05_PIN
-    #define DOGLCD_SCK              EXPA1_10_PIN
-    #define DOGLCD_MOSI             EXPA1_03_PIN
+    #define DOGLCD_CS                       PB8
+    #define DOGLCD_A0                       PB9
+    #define DOGLCD_SCK                      PA15
+    #define DOGLCD_MOSI                     PB7
     #define FORCE_SOFT_SPI
     #define LCD_BACKLIGHT_PIN               -1
 
@@ -272,10 +264,10 @@
 
   #define CLCD_SPI_BUS 1                          // SPI1 connector
 
-  #define BEEPER_PIN                EXPA1_09_PIN
+  #define BEEPER_PIN                        PB6
 
-  #define BTN_EN1                   EXPA1_08_PIN
-  #define LCD_PINS_RS               EXPA1_04_PIN
+  #define CLCD_MOD_RESET                    PA9
+  #define CLCD_SPI_CS                       PA8
 
 #endif // TOUCH_UI_FTDI_EVE && LCD_FYSETC_TFT81050
 
@@ -284,7 +276,7 @@
 //
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION              ONBOARD
+  #define SDCARD_CONNECTION                 ONBOARD
 #endif
 
 #if SD_CONNECTION_IS(ONBOARD)
@@ -292,8 +284,8 @@
 #endif
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050) && SD_CONNECTION_IS(LCD)
-  #define SD_DETECT_PIN             EXPA1_10_PIN
-  #define SS_PIN                    EXPA1_06_PIN
+  #define SD_DETECT_PIN                     PA15
+  #define SS_PIN                            PA10
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
   #error "SD CUSTOM_CABLE is not compatible with SKR E3 DIP."
 #endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
@@ -112,39 +112,30 @@
  *                 EXP1
  */
 
-#define EXPA1_03_PIN                        PB7
-#define EXPA1_04_PIN                        PB8
-#define EXPA1_05_PIN                        PB9
-#define EXPA1_06_PIN                        PA10
-#define EXPA1_07_PIN                        -1
-#define EXPA1_08_PIN                        PA9
-#define EXPA1_09_PIN                        PB6
-#define EXPA1_10_PIN                        PB5
-
 #if HAS_SPI_LCD
 
   #if ENABLED(CR10_STOCKDISPLAY)
 
-    #define BEEPER_PIN              EXPA1_10_PIN
+    #define BEEPER_PIN                      PB5
 
-    #define BTN_ENC                 EXPA1_09_PIN
-    #define BTN_EN1                 EXPA1_08_PIN
-    #define BTN_EN2                 EXPA1_06_PIN
+    #define BTN_ENC                         PB6
+    #define BTN_EN1                         PA9
+    #define BTN_EN2                         PA10
 
-    #define LCD_PINS_RS             EXPA1_04_PIN
-    #define LCD_PINS_ENABLE         EXPA1_03_PIN
-    #define LCD_PINS_D4             EXPA1_05_PIN
+    #define LCD_PINS_RS                     PB8
+    #define LCD_PINS_ENABLE                 PB7
+    #define LCD_PINS_D4                     PB9
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
     #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3.h' for details. Comment out this line to continue."
 
-    #define LCD_PINS_RS             EXPA1_05_PIN
-    #define LCD_PINS_ENABLE         EXPA1_09_PIN
-    #define LCD_PINS_D4             EXPA1_04_PIN
-    #define LCD_PINS_D5             EXPA1_06_PIN
-    #define LCD_PINS_D6             EXPA1_08_PIN
-    #define LCD_PINS_D7             EXPA1_10_PIN
+    #define LCD_PINS_RS                     PB9
+    #define LCD_PINS_ENABLE                 PB6
+    #define LCD_PINS_D4                     PB8
+    #define LCD_PINS_D5                     PA10
+    #define LCD_PINS_D6                     PA9
+    #define LCD_PINS_D7                     PB5
     #define ADC_KEYPAD_PIN                  PA1   // Repurpose servo pin for ADC - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
   #elif EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
@@ -160,14 +151,14 @@
      *                    EXP1
      */
 
-    #define BTN_ENC                 EXPA1_09_PIN
-    #define BTN_EN1                 EXPA1_08_PIN
-    #define BTN_EN2                 EXPA1_06_PIN
+    #define BTN_ENC                         PB6
+    #define BTN_EN1                         PA9
+    #define BTN_EN2                         PA10
 
-    #define DOGLCD_CS               EXPA1_04_PIN
-    #define DOGLCD_A0               EXPA1_05_PIN
-    #define DOGLCD_SCK              EXPA1_10_PIN
-    #define DOGLCD_MOSI             EXPA1_03_PIN
+    #define DOGLCD_CS                       PB8
+    #define DOGLCD_A0                       PB9
+    #define DOGLCD_SCK                      PB5
+    #define DOGLCD_MOSI                     PB7
     #define FORCE_SOFT_SPI
     #define LCD_BACKLIGHT_PIN               -1
 
@@ -212,12 +203,10 @@
 
   #define CLCD_SPI_BUS 1                          // SPI1 connector
 
-  #define BEEPER_PIN                EXPA1_09_PIN
+  #define BEEPER_PIN                        PB6
 
-  #define BTN_EN1                   EXPA1_08_PIN
-  #define LCD_PINS_RS               EXPA1_04_PIN
-  #define LCD_PINS_ENABLE           EXPA1_03_PIN
-  #define LCD_PINS_D4               EXPA1_05_PIN
+  #define CLCD_MOD_RESET                    PA9
+  #define CLCD_SPI_CS                       PB8
 
 #endif // TOUCH_UI_FTDI_EVE && LCD_FYSETC_TFT81050
 
@@ -226,7 +215,7 @@
 //
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION              ONBOARD
+  #define SDCARD_CONNECTION                 ONBOARD
 #endif
 
 #if SD_CONNECTION_IS(ONBOARD)
@@ -234,8 +223,8 @@
 #endif
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050) && SD_CONNECTION_IS(LCD)
-  #define SD_DETECT_PIN             EXPA1_10_PIN
-  #define SS_PIN                    EXPA1_06_PIN
+  #define SD_DETECT_PIN                     PB5
+  #define SS_PIN                            PA10
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
   #error "SD CUSTOM_CABLE is not compatible with SKR Mini E3."
 #endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
@@ -215,7 +215,7 @@
 //
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION                 ONBOARD
+  #define SDCARD_CONNECTION              ONBOARD
 #endif
 
 #if SD_CONNECTION_IS(ONBOARD)


### PR DESCRIPTION
Follow #17935 in `pins_BTT_SKR_E3_DIP` and `pins_BTT_SKRMINI-E3.h`

remove extra bit in `pins_RAMPS.h` (not need in this EVE display)

related issue: https://github.com/MarlinFirmware/Marlin/issues/16628