### PR TITLE
Additional core homing pin tests

### DIFF
--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -674,6 +674,15 @@ void Endstops::update() {
     } \
   }while(0)
 
+  // Core Sensorless Homing needs to test an Extra Pin
+  #define CORE_DIAG(QQ,A,MM) (CORE_IS_##QQ && A##_SENSORLESS && !A##_SPI_SENSORLESS && HAS_##A##_##MM)
+  #define PROCESS_CORE_ENDSTOP(A1,M1,A2,M2) do { \
+    if (TEST_ENDSTOP(_ENDSTOP(A1,M1))) { \
+      _ENDSTOP_HIT(A2,M2); \
+      planner.endstop_triggered(_AXIS(A2)); \
+    } \
+  }while(0)
+
   // Call the endstop triggered routine for dual endstops
   #define PROCESS_DUAL_ENDSTOP(A, MINMAX) do { \
     const byte dual_hit = TEST_ENDSTOP(_ENDSTOP(A, MINMAX)) | (TEST_ENDSTOP(_ENDSTOP(A##2, MINMAX)) << 1); \
@@ -748,11 +757,29 @@ void Endstops::update() {
     if (stepper.motor_direction(X_AXIS_HEAD)) { // -direction
       #if HAS_X_MIN || (X_SPI_SENSORLESS && X_HOME_DIR < 0)
         PROCESS_ENDSTOP_X(MIN);
+        #if   CORE_DIAG(XY, Y, MIN)
+          PROCESS_CORE_ENDSTOP(Y,MIN,X,MIN);
+        #elif CORE_DIAG(XY, Y, MAX)
+          PROCESS_CORE_ENDSTOP(Y,MAX,X,MIN);
+        #elif CORE_DIAG(XZ, Z, MIN)
+          PROCESS_CORE_ENDSTOP(Z,MIN,X,MIN);
+        #elif CORE_DIAG(XZ, Z, MAX)
+          PROCESS_CORE_ENDSTOP(Z,MAX,X,MIN);
+        #endif
       #endif
     }
     else { // +direction
       #if HAS_X_MAX || (X_SPI_SENSORLESS && X_HOME_DIR > 0)
         PROCESS_ENDSTOP_X(MAX);
+        #if   CORE_DIAG(XY, Y, MIN)
+          PROCESS_CORE_ENDSTOP(Y,MIN,X,MAX);
+        #elif CORE_DIAG(XY, Y, MAX)
+          PROCESS_CORE_ENDSTOP(Y,MAX,X,MAX);
+        #elif CORE_DIAG(XZ, Z, MIN)
+          PROCESS_CORE_ENDSTOP(Z,MIN,X,MAX);
+        #elif CORE_DIAG(XZ, Z, MAX)
+          PROCESS_CORE_ENDSTOP(Z,MAX,X,MAX);
+        #endif
       #endif
     }
   }
@@ -761,11 +788,29 @@ void Endstops::update() {
     if (stepper.motor_direction(Y_AXIS_HEAD)) { // -direction
       #if HAS_Y_MIN || (Y_SPI_SENSORLESS && Y_HOME_DIR < 0)
         PROCESS_ENDSTOP_Y(MIN);
+        #if   CORE_DIAG(XY, X, MIN)
+          PROCESS_CORE_ENDSTOP(X,MIN,Y,MIN);
+        #elif CORE_DIAG(XY, X, MAX)
+          PROCESS_CORE_ENDSTOP(X,MAX,Y,MIN);
+        #elif CORE_DIAG(YZ, Z, MIN)
+          PROCESS_CORE_ENDSTOP(Z,MIN,Y,MIN);
+        #elif CORE_DIAG(YZ, Z, MAX)
+          PROCESS_CORE_ENDSTOP(Z,MAX,Y,MIN);
+        #endif
       #endif
     }
     else { // +direction
       #if HAS_Y_MAX || (Y_SPI_SENSORLESS && Y_HOME_DIR > 0)
         PROCESS_ENDSTOP_Y(MAX);
+        #if   CORE_DIAG(XY, X, MIN)
+          PROCESS_CORE_ENDSTOP(X,MIN,Y,MAX);
+        #elif CORE_DIAG(XY, X, MAX)
+          PROCESS_CORE_ENDSTOP(X,MAX,Y,MAX);
+        #elif CORE_DIAG(YZ, Z, MIN)
+          PROCESS_CORE_ENDSTOP(Z,MIN,Y,MAX);
+        #elif CORE_DIAG(YZ, Z, MAX)
+          PROCESS_CORE_ENDSTOP(Z,MAX,Y,MAX);
+        #endif
       #endif
     }
   }
@@ -777,6 +822,15 @@ void Endstops::update() {
         if ( TERN1(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN, z_probe_enabled)
           && TERN1(HAS_CUSTOM_PROBE_PIN, !z_probe_enabled)
         ) PROCESS_ENDSTOP_Z(MIN);
+        #if   CORE_DIAG(XZ, X, MIN)
+          PROCESS_CORE_ENDSTOP(X,MIN,Z,MIN);
+        #elif CORE_DIAG(XZ, X, MAX)
+          PROCESS_CORE_ENDSTOP(X,MAX,Z,MIN);
+        #elif CORE_DIAG(YZ, Y, MIN)
+          PROCESS_CORE_ENDSTOP(Y,MIN,Z,MIN);
+        #elif CORE_DIAG(YZ, Y, MAX)
+          PROCESS_CORE_ENDSTOP(Y,MAX,Z,MIN);
+        #endif
       #endif
 
       // When closing the gap check the enabled probe
@@ -790,6 +844,15 @@ void Endstops::update() {
           PROCESS_ENDSTOP_Z(MAX);
         #elif !HAS_CUSTOM_PROBE_PIN || Z_MAX_PIN != Z_MIN_PROBE_PIN  // No probe or probe is Z_MIN || Probe is not Z_MAX
           PROCESS_ENDSTOP(Z, MAX);
+        #endif
+        #if   CORE_DIAG(XZ, X, MIN)
+          PROCESS_CORE_ENDSTOP(X,MIN,Z,MAX);
+        #elif CORE_DIAG(XZ, X, MAX)
+          PROCESS_CORE_ENDSTOP(X,MAX,Z,MAX);
+        #elif CORE_DIAG(YZ, Y, MIN)
+          PROCESS_CORE_ENDSTOP(Y,MIN,Z,MAX);
+        #elif CORE_DIAG(YZ, Y, MAX)
+          PROCESS_CORE_ENDSTOP(Y,MAX,Z,MAX);
         #endif
       #endif
     }

--- a/buildroot/share/tests/teensy35-tests
+++ b/buildroot/share/tests/teensy35-tests
@@ -90,6 +90,13 @@ exec_test $1 $2 "Mixing Extruder"
 restore_configs
 opt_set MOTHERBOARD BOARD_TEENSY35_36
 opt_enable COREXY
+opt_set X_DRIVER_TYPE TMC5160
+opt_set Y_DRIVER_TYPE TMC5160
+opt_set X_MIN_ENDSTOP_INVERTING true
+opt_set Y_MIN_ENDSTOP_INVERTING true
+opt_add X_CS_PIN 46
+opt_add Y_CS_PIN 47
+opt_enable USE_ZMIN_PLUG MONITOR_DRIVER_STATUS SENSORLESS_HOMING
 exec_test $1 $2 "Teensy 3.5/3.6 COREXY"
 
 #


### PR DESCRIPTION
In reference to #17838 and #17687 

Core homing for SPI is now handled at the level of the SPI tests. However, core sensorless endstop tests for sensorless DIAG pin homing still needs to be done at the pins level.