### PR TITLE
Add #ifndefs to limit switch definitions for BigTreeTech SKR Pro V1.1

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_1.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_1.h
@@ -41,12 +41,24 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN                           PB10
-#define X_MAX_PIN                           PE15
-#define Y_MIN_PIN                           PE12
-#define Y_MAX_PIN                           PE10
-#define Z_MIN_PIN                           PG8
-#define Z_MAX_PIN                           PG5
+#ifndef X_MIN_PIN
+  #define X_MIN_PIN                           PB10
+#endif
+#ifndef X_MAX_PIN
+  #define X_MAX_PIN                           PE15
+#endif
+#ifndef Y_MIN_PIN
+  #define Y_MIN_PIN                           PE12
+#endif
+#ifndef Y_MAX_PIN
+  #define Y_MAX_PIN                           PE10
+#endif
+#ifndef Z_MIN_PIN
+  #define Z_MIN_PIN                           PG8
+#endif
+#ifndef Z_MAX_PIN
+  #define Z_MAX_PIN                           PG5
+#endif
 
 //
 // Z Probe must be this pins


### PR DESCRIPTION
### Requirements

The BigTreeTech SKR Pro V1.1 has a ~bug~ feature where the stall guard pins are shared with the limit switches. The board features many spare pins, so Merlin should allow remapping the pins in the `Configuration.h` file.

### Description

My proposed changes are to simply wrap the #ifndef definitions for the limit switches in the `pins_*.h` file. This allows them to be defined in the `Configuration.h` file instead. I don't think there is a single common remapping that makes sense for any user, and I assume changes should ideally be made in `Configuration.h` rather than the `pins_*.h` file.

Essentially it is just doing this:
```
//
// Limit Switches
//
#ifndef X_MIN_PIN
  #define X_MIN_PIN                           PB10
#endif
...
```

### Benefits

Offers a software fix for malfunctioning limit switches without having to alter the hardware.

### Related Issues

The limit switch issue is described here:
https://github.com/bigtreetech/BIGTREETECH-SKR-PRO-V1.1/issues/47
