### PR TITLE
Fix BTT002 timer conflict with SPEAKER enabled

### DIFF
--- a/buildroot/share/PlatformIO/variants/BIGTREE_BTT002/variant.h
+++ b/buildroot/share/PlatformIO/variants/BIGTREE_BTT002/variant.h
@@ -245,11 +245,9 @@ extern "C" {
 
 // Timer Definitions
 //Do not use timer used by PWM pins when possible. See PinMap_PWM in PeripheralPins.c
-#define TIMER_TONE              TIM6
-#define TIMER_SERIAL            TIM7
-
-// Do not use basic timer: OC is required
-#define TIMER_SERVO             TIM2  //TODO: advanced-control timers don't work
+#define TIMER_TONE              TIM7
+#define TIMER_SERVO             TIM5
+#define TIMER_SERIAL            TIM2
 
 // UART Definitions
 // Define here Serial instance number to map on Serial generic name


### PR DESCRIPTION
### Description

The TONE timer on the BTT002 conflicted with the STEP timer. If using the `SPEAKER` feature this caused neither the speaker nor steppers to function.

This now uses the same timers as the SKR Pro, which does not appear to conflict with other board resources.

I originally pushed this to my PR to update STM32 dependencies (#17970), but there is no reason for this fix to wait for that entire PR. 

@thisiskeithb already confirmed this change works on his BTT002 board, inside the above referenced PR.

### Benefits

Allows enabling `SPEAKER` on BTT002 boards.


### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
