### PR TITLE
Add reporting of fan speed on speed change

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -211,12 +211,9 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
    * Report print fan speed for a target extruder
    */
   void Temperature::report_fan_speed(const uint8_t target) {
-
     if (target >= FAN_COUNT) return;
-
     PORT_REDIRECT(SERIAL_BOTH);
     SERIAL_ECHOLNPAIR("M106 P", target, " S", fan_speed[target]);
-    PORT_RESTORE();
   }
 
   #if EITHER(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -204,6 +204,8 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
     if (target >= FAN_COUNT) return;
 
     fan_speed[target] = speed;
+    PORT_REDIRECT(SERIAL_BOTH);
+    SERIAL_ECHOLNPAIR("M106 F", target, ":", speed);
   }
 
   #if EITHER(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -206,6 +206,7 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
     fan_speed[target] = speed;
     PORT_REDIRECT(SERIAL_BOTH);
     SERIAL_ECHOLNPAIR("M106 F", target, ":", speed);
+    PORT_RESTORE();
   }
 
   #if EITHER(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -215,7 +215,7 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
     if (target >= FAN_COUNT) return;
 
     PORT_REDIRECT(SERIAL_BOTH);
-    SERIAL_ECHOLNPAIR("M106 F", target, ":", fan_speed[target]);
+    SERIAL_ECHOLNPAIR("M106 P", target, " S", fan_speed[target]);
     PORT_RESTORE();
   }
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -204,8 +204,18 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
     if (target >= FAN_COUNT) return;
 
     fan_speed[target] = speed;
+    report_fan_speed(target);
+  }
+
+  /**
+   * Report print fan speed for a target extruder
+   */
+  void Temperature::report_fan_speed(const uint8_t target) {
+
+    if (target >= FAN_COUNT) return;
+
     PORT_REDIRECT(SERIAL_BOTH);
-    SERIAL_ECHOLNPAIR("M106 F", target, ":", speed);
+    SERIAL_ECHOLNPAIR("M106 F", target, ":", fan_speed[target]);
     PORT_RESTORE();
   }
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -483,6 +483,7 @@ class Temperature {
       #define FANS_LOOP(I) LOOP_L_N(I, FAN_COUNT)
 
       static void set_fan_speed(const uint8_t target, const uint16_t speed);
+      static void report_fan_speed(const uint8_t target);
 
       #if EITHER(PROBING_FANS_OFF, ADVANCED_PAUSE_FANS_PAUSE)
         static bool fans_paused;


### PR DESCRIPTION
### Description
Add reporting of fan speed on speed change only for target fan/extruder index.

### Benefits
Serial hosts have no way of knowing the current fan speed. Because of this, changing the fan speed from host many times gives unexpected results as the hosts assume the current fan speed as 0.
adding this feature enabled the host to keep track of the fan speed and avoid unintentional changes.