### PR TITLE
Enable BigTreeTech GTR onboard I2C EEPROM by default

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -31,18 +31,10 @@
 
 #define BOARD_INFO_NAME "BIGTREE GTR 1.0"
 
-// Use one of these or SDCard-based Emulation will be used
-#if NO_EEPROM_SELECTED
-  //#define I2C_EEPROM
-  //#define SRAM_EEPROM_EMULATION                 // Use BackSRAM-based EEPROM emulation
-  //#define FLASH_EEPROM_EMULATION                // Use Flash-based EEPROM emulation
-#endif
-
-#if ENABLED(FLASH_EEPROM_EMULATION)
-  // Decrease delays and flash wear by spreading writes across the
-  // 128 kB sector allocated for EEPROM emulation.
-  #define FLASH_EEPROM_LEVELING
-#endif
+// Onboard I2C EEPROM
+#define I2C_EEPROM
+#undef E2END
+#define E2END 0x1FFF // EEPROM end address 24C64 (64Kb = 8KB)
 
 #define TP                                        // Enable to define servo and probe pins
 


### PR DESCRIPTION
### Description

The BigTreeTech GTR ships with a real/onboard EEPROM, so this PR enables it by default. Based on [GTR pin file](https://github.com/bigtreetech/BIGTREETECH-GTR-V1.0/blob/2ba74a975c2f69893e99b7c2bff79c880d946015/firmware/Marlin-2.0.x_BTT_GTR_V1.0_12864p-16div-eeprom_Demo/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h) from the official GTR repo.

I bench tested a GTR with these changes and EEPROM settings were saved/retrieved/reset successfully, but it has been reported to work successfully in the [GTR Facebook group](https://www.facebook.com/groups/485785992127996/) as well.

Also: `#undef E2END` was used, otherwise there'd be a ton of redefined warnings.

### Benefits

Use onboard/real EEPROM on the GTR.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/17799 (SKR Pro & GTR were split up in https://github.com/MarlinFirmware/Marlin/pull/17937).
- https://github.com/bigtreetech/BIGTREETECH-GTR-V1.0/issues/4