### PR TITLE
Remove arbitrary segment length limit in JD

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2305,8 +2305,8 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
         vmax_junction_sqr = junction_acceleration * junction_deviation_mm * sin_theta_d2 / (1.0f - sin_theta_d2);
 
-        // For small moves with >135° junction (octagon) find speed for approximate arc
-        if (block->millimeters < 1 && junction_cos_theta < -0.7071067812f) {
+        // For moves with >135° junction angle (octagon), find the speed for an equivalent circle segment
+        if (junction_cos_theta < -0.7071067812f) {
 
           #if ENABLED(JD_USE_MATH_ACOS)
 
@@ -2384,7 +2384,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
           #endif
 
-          const float limit_sqr = (block->millimeters * junction_acceleration) / junction_theta;
+          const float limit_sqr = (block->millimeters * junction_acceleration) / junction_theta; // Using sin() small angle approximation
           NOMORE(vmax_junction_sqr, limit_sqr);
         }
       }


### PR DESCRIPTION
### Description

This is more of a "let's think about that together" type of PR. Please add your thoughts.

When introducing the >135° additional `limit_sqr` into JD, an arbitrary cut-off of 1 mm for small segments was chosen (see https://github.com/MarlinFirmware/Marlin/issues/10341#issuecomment-388191754). This works most of the time, but sometimes causes problems (see #17920). If you have segments just below and just above 1 mm of length in a curve, the junction speed limit will vary _wildly_ for junction angles close to 180°.

Further, I think the 1 mm limit is technically incorrect. The original JD calculates cornering speeds based on the two junction unit vectors. As the vector lengths are unknown, only the junction angle affects cornering speeds. From my understanding, this means that JD essentially assumes, that the vector leading into the junction is of infinite length. Or, in other words, that there is no form of disturbance or lateral force acting on the moving head, when it hits the junction. The [original grbl article](https://onehossshay.wordpress.com/2011/09/24/improving_grbl_cornering_algorithm/) said about JD
> In other words, we assume the tangential velocity is zero...

which supports this. Now, in practice, the segment leading into the junction does not need to be infinitely long - "no relevant lateral disturbance" will be sufficient. For me, this means we can run the regular JD code, whenever the straight segment _before_ the junction was long enough to dampen any previous disturbance to pretty much zero. If the segment is shorter, we should run the additional limit_sqr code. 

Looking at a worst case scenario for my printer (Ender 3, Y-axis), I see that ringing artifacts - caused by such a residual lateral disturbance - fade away in about 6 mm of X movement. That's of course specific to print speed, acceleration and a lot more. For very stiff CoreXY machines, the critical length may be closer to 1 or 2 mm. For wiggly large format machines like a CR-10, it may be closer to 12 or 15 mm.

In my opinion, there's two ways to go about this:

1. We make the limit configurable and set a decent base value per machine. It should be higher than 1 mm, though.
2. We remove the limit alltogether. This ensures, that the result will always be technically correct, at least for angles above 135°.

If we keep any limit, it would also make more sense to decide on it's application based on the length of the _preceding_ segment, not the current one. That's what decides, whether there may be any lateral disturbance left when reaching the junction. So all calculations can stay the same, but the `if()`-check should be against the previous `block->millimeters`, not the current one.

### Benefits

- Reduces excessive stutter in some (rare) situations.
- Makes JD math more consistent.
- Opens up options to deal with residual stutter on curved moves with some segments above 1 mm.

### Related Issues

Affects #17920, but does not fix it for now. Additional changes will be required to get rid of the stutter: `limit_sqr` also varies a lot for the example code of that issue, because segments have close to identical junction angles, but varying length (~0.4 mm vs ~1.1 mm, alternating). I have some ideas how to tackle the problem seen in #17920, but they require the 1 mm limit to be raised or abolished.
