### PR TITLE
Hotend Idle Timeout fixes

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -9,7 +9,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ *TIMEOUT_
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -336,10 +336,10 @@
  */
 //#define HOTEND_IDLE_TIMEOUT
 #if ENABLED(HOTEND_IDLE_TIMEOUT)
-  #define HOTEND_IDLE_TIMEOUT_DURATION   5     // (minutes) Time without extruder movement to trigger protection
-  #define HOTEND_IDLE_MIN_TRIGGER      180     // (°C) Minimum temperature to enable hotend protection
-  #define HOTEND_IDLE_NOZZLE_TARGET      0     // (°C) Safe temperature for the nozzle after timeout
-  #define HOTEND_IDLE_BED_TARGET         0     // (°C) Safe temperature for the bed after timeout
+  #define HOTEND_IDLE_TIMEOUT_SEC (5*60)  // (seconds) Time without extruder movement to trigger protection
+  #define HOTEND_IDLE_MIN_TRIGGER   180   // (°C) Minimum temperature to enable hotend protection
+  #define HOTEND_IDLE_NOZZLE_TARGET   0   // (°C) Safe temperature for the nozzle after timeout
+  #define HOTEND_IDLE_BED_TARGET      0   // (°C) Safe temperature for the bed after timeout
 #endif
 
 // @section temperature

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -336,10 +336,10 @@
  */
 //#define HOTEND_IDLE_TIMEOUT
 #if ENABLED(HOTEND_IDLE_TIMEOUT)
-  #define HOTEND_IDLE_DURATION_SEC    5     // (minutes) Time without extruder movement to trigger protection
-  #define HOTEND_IDLE_MIN_TRIGGER   180     // (°C) Minimum temperature to enable hotend protection
-  #define HOTEND_IDLE_NOZZLE_TARGET   0     // (°C) Safe temperature for the nozzle after timeout
-  #define HOTEND_IDLE_BED_TARGET      0     // (°C) Safe temperature for the bed after timeout
+  #define HOTEND_IDLE_TIMEOUT_DURATION   5     // (minutes) Time without extruder movement to trigger protection
+  #define HOTEND_IDLE_MIN_TRIGGER      180     // (°C) Minimum temperature to enable hotend protection
+  #define HOTEND_IDLE_NOZZLE_TARGET      0     // (°C) Safe temperature for the nozzle after timeout
+  #define HOTEND_IDLE_BED_TARGET         0     // (°C) Safe temperature for the bed after timeout
 #endif
 
 // @section temperature

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -9,7 +9,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *TIMEOUT_
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
@@ -336,10 +336,10 @@
  */
 //#define HOTEND_IDLE_TIMEOUT
 #if ENABLED(HOTEND_IDLE_TIMEOUT)
-  #define HOTEND_IDLE_TIMEOUT_SEC (5*60)  // (seconds) Time without extruder movement to trigger protection
-  #define HOTEND_IDLE_MIN_TRIGGER   180   // (°C) Minimum temperature to enable hotend protection
-  #define HOTEND_IDLE_NOZZLE_TARGET   0   // (°C) Safe temperature for the nozzle after timeout
-  #define HOTEND_IDLE_BED_TARGET      0   // (°C) Safe temperature for the bed after timeout
+  #define HOTEND_IDLE_TIMEOUT_SEC (5*60)    // (seconds) Time without extruder movement to trigger protection
+  #define HOTEND_IDLE_MIN_TRIGGER   180     // (°C) Minimum temperature to enable hotend protection
+  #define HOTEND_IDLE_NOZZLE_TARGET   0     // (°C) Safe temperature for the nozzle after timeout
+  #define HOTEND_IDLE_BED_TARGET      0     // (°C) Safe temperature for the bed after timeout
 #endif
 
 // @section temperature

--- a/Marlin/src/feature/hotend_idle.h
+++ b/Marlin/src/feature/hotend_idle.h
@@ -27,7 +27,7 @@ class HotendIdleProtection {
 public:
   static void check();
 private:
-  static constexpr millis_t hp_interval = MIN_TO_MS(HOTEND_IDLE_TIMEOUT_DURATION);
+  static constexpr millis_t hp_interval = SEC_TO_MS(HOTEND_IDLE_TIMEOUT_SEC);
   static millis_t next_protect_ms;
   static void check_hotends(const millis_t &ms);
   static void check_e_motion(const millis_t &ms);

--- a/Marlin/src/feature/hotend_idle.h
+++ b/Marlin/src/feature/hotend_idle.h
@@ -27,7 +27,7 @@ class HotendIdleProtection {
 public:
   static void check();
 private:
-  static constexpr millis_t hp_interval = SEC_TO_MS(HOTEND_IDLE_DURATION_SEC);
+  static constexpr millis_t hp_interval = MIN_TO_MS(HOTEND_IDLE_TIMEOUT_DURATION);
   static millis_t next_protect_ms;
   static void check_hotends(const millis_t &ms);
   static void check_e_motion(const millis_t &ms);


### PR DESCRIPTION
### Requirements

`HOTEND_IDLE_TIMEOUT`

### Description

Use `MIN_TO_MS` instead of `SEC_TO_MS` and rename "duration" variable.

### Benefits

Instead of X seconds, duration will be X minutes.

### Related Issues

None, but see comments from https://github.com/MarlinFirmware/Marlin/commit/213d4b890ea4997db63b0946cde766581d7f96e5.