### PR TITLE
Ignore intermittent errors in the MAX31855K (and MAX6675) thermocouple sensor.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -39,6 +39,19 @@
 //=============================Thermal Settings  ============================
 //===========================================================================
 
+/**
+ * Thermocouple sensors are quite sensitive to noise.  Any noise induced in
+ * the sensor wires, such as by stepper motor wires run in parallel to them,
+ * may result in the thermocouple sensor reporting spurious errors.  This
+ * value is the number of errors which can occur in a row before the error
+ * is reported.  This allows us to ignore intermittent error conditions while
+ * still detecting an actual failure, which should result in a continuous
+ * stream of errors from the sensor.
+ * 
+ * Set this value to 0 to fail on the first error to occur.
+ */
+#define THERMOCOUPLE_MAX_ERRORS 15
+
 //
 // Custom Thermistor 1000 parameters
 //

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2060,6 +2060,10 @@ void Temperature::disable_all_heaters() {
 
 #if HAS_MAX6675
 
+  #ifndef THERMOCOUPLE_MAX_BAD_READINGS
+    #define THERMOCOUPLE_MAX_BAD_READINGS 15
+  #endif
+
   int Temperature::read_max6675(
     #if COUNT_6675 > 1
       const uint8_t hindex
@@ -2070,6 +2074,7 @@ void Temperature::disable_all_heaters() {
     #else
       // Needed to return the correct temp when this is called too soon
       static uint16_t max6675_temp_previous[COUNT_6675] = { 0 };
+      static uint8_t max6675_errors[COUNT_6675] = { 0 };
     #endif
 
     #define MAX6675_HEAT_INTERVAL 250UL
@@ -2144,33 +2149,41 @@ void Temperature::disable_all_heaters() {
     WRITE_MAX6675(HIGH); // disable TT_MAX6675
 
     if (max6675_temp & MAX6675_ERROR_MASK) {
-      SERIAL_ERROR_START();
-      SERIAL_ECHOPGM("Temp measurement error! ");
-      #if MAX6675_ERROR_MASK == 7
-        SERIAL_ECHOPGM("MAX31855 ");
-        if (max6675_temp & 1)
-          SERIAL_ECHOLNPGM("Open Circuit");
-        else if (max6675_temp & 2)
-          SERIAL_ECHOLNPGM("Short to GND");
-        else if (max6675_temp & 4)
-          SERIAL_ECHOLNPGM("Short to VCC");
-      #else
-        SERIAL_ECHOLNPGM("MAX6675");
-      #endif
-
-      // Thermocouple open
-      max6675_temp = 4 * (
-        #if COUNT_6675 > 1
-          hindex ? HEATER_1_MAX6675_TMAX : HEATER_0_MAX6675_TMAX
-        #elif ENABLED(HEATER_1_USES_MAX6675)
-          HEATER_1_MAX6675_TMAX
+      max6675_errors[hindex] += 1;
+      if (max6675_errors[hindex] > THERMOCOUPLE_MAX_BAD_READINGS) {
+        SERIAL_ERROR_START();
+        SERIAL_ECHOPGM("Temp measurement error! ");
+        #if MAX6675_ERROR_MASK == 7
+          SERIAL_ECHOPGM("MAX31855 ");
+          if (max6675_temp & 1)
+            SERIAL_ECHOLNPGM("Open Circuit");
+          else if (max6675_temp & 2)
+            SERIAL_ECHOLNPGM("Short to GND");
+          else if (max6675_temp & 4)
+            SERIAL_ECHOLNPGM("Short to VCC");
         #else
-          HEATER_0_MAX6675_TMAX
+          SERIAL_ECHOLNPGM("MAX6675");
         #endif
-      );
+
+        // Thermocouple open
+        max6675_temp = 4 * (
+          #if COUNT_6675 > 1
+            hindex ? HEATER_1_MAX6675_TMAX : HEATER_0_MAX6675_TMAX
+          #elif ENABLED(HEATER_1_USES_MAX6675)
+            HEATER_1_MAX6675_TMAX
+          #else
+            HEATER_0_MAX6675_TMAX
+          #endif
+        );
+      }
+      else {
+        max6675_temp >>= MAX6675_DISCARD_BITS;
+      }
     }
-    else
+    else {
       max6675_temp >>= MAX6675_DISCARD_BITS;
+      max6675_errors[hindex] = 0;
+    }
 
     #if ENABLED(MAX6675_IS_MAX31855)
       if (max6675_temp & 0x00002000) max6675_temp |= 0xFFFFC000; // Support negative temperature

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2060,8 +2060,8 @@ void Temperature::disable_all_heaters() {
 
 #if HAS_MAX6675
 
-  #ifndef THERMOCOUPLE_MAX_BAD_READINGS
-    #define THERMOCOUPLE_MAX_BAD_READINGS 15
+  #ifndef THERMOCOUPLE_MAX_ERRORS
+    #define THERMOCOUPLE_MAX_ERRORS 15
   #endif
 
   int Temperature::read_max6675(
@@ -2074,8 +2074,9 @@ void Temperature::disable_all_heaters() {
     #else
       // Needed to return the correct temp when this is called too soon
       static uint16_t max6675_temp_previous[COUNT_6675] = { 0 };
-      static uint8_t max6675_errors[COUNT_6675] = { 0 };
     #endif
+    
+    static uint8_t max6675_errors[COUNT_6675] = { 0 };
 
     #define MAX6675_HEAT_INTERVAL 250UL
 
@@ -2150,7 +2151,7 @@ void Temperature::disable_all_heaters() {
 
     if (max6675_temp & MAX6675_ERROR_MASK) {
       max6675_errors[hindex] += 1;
-      if (max6675_errors[hindex] > THERMOCOUPLE_MAX_BAD_READINGS) {
+      if (max6675_errors[hindex] > THERMOCOUPLE_MAX_ERRORS) {
         SERIAL_ERROR_START();
         SERIAL_ECHOPGM("Temp measurement error! ");
         #if MAX6675_ERROR_MASK == 7


### PR DESCRIPTION
### Description

Ignore intermittent errors in the MAX31855K (and MAX6675) thermocouple sensor.  This replicates behavior in Sailfish firmware for handling thermocouple sensors on the Makerbot Replicator & numerous clones.

Require a number of errors from a thermocouple sensor in series before triggering a fault.  The default is set to 15 as this is the default in Sailfish firmware.

### Benefits

Current behaviour of Marlin is that a single error event in a thermocouple sensor will cause the printer to halt with a MAXTEMP error.   This change ignores intermittent errors from a thermocouple sensor due to noise.  Marlin will no longer halt with an MAXTEMP error due to a spurious error report.

Safety is still maintained.  The error is reported within 3 seconds when a failure resulting in a persistent error condition occurs.

### Related Issues

See #18025 

I have tested this code by shorting the thermocouples to GND and to VCC.  I verified that the error condition is reported and that max_temp_error() is still called.