### PR TITLE
Move progress bar baseline Y back to its original position

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -104,7 +104,7 @@
 #endif
 
 #define PROGRESS_BAR_X 54
-#define PROGRESS_BAR_Y (EXTRAS_BASELINE + 2)
+#define PROGRESS_BAR_Y (EXTRAS_BASELINE + 1)
 #define PROGRESS_BAR_WIDTH (LCD_PIXEL_WIDTH - PROGRESS_BAR_X)
 
 FORCE_INLINE void _draw_centered_temp(const int16_t temp, const uint8_t tx, const uint8_t ty) {


### PR DESCRIPTION
How it looks now:
![Progress bar Y](https://user-images.githubusercontent.com/29223282/82525991-0b184a00-9b33-11ea-86f6-53288ec63dc5.jpg)

How it used to look and should look again:
![Progress bar Y_1](https://user-images.githubusercontent.com/29223282/82526083-53d00300-9b33-11ea-8336-3489729f7618.jpg)

My first pull request so please be gentle :-)