### PR TITLE
Fix DUE wired (i2c) eeprom init

### DIFF
--- a/Marlin/src/HAL/DUE/eeprom_wired.cpp
+++ b/Marlin/src/HAL/DUE/eeprom_wired.cpp
@@ -38,7 +38,7 @@
   #error "MARLIN_EEPROM_SIZE is required for I2C / SPI EEPROM."
 #endif
 size_t PersistentStore::capacity()    { return MARLIN_EEPROM_SIZE; }
-bool PersistentStore::access_start()  { return true; }
+bool PersistentStore::access_start()  { eeprom_init(); return true; }
 bool PersistentStore::access_finish() { return true; }
 
 bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {


### PR DESCRIPTION
Fix the wired eeprom implementation for the DUE platform.

### Related Issues
fix #18070
