### PR TITLE
Disable Encoder Click Buzzer - Added Macro

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1745,6 +1745,10 @@
 // By default Marlin assumes you have a buzzer with a fixed frequency.
 //
 //#define SPEAKER
+//
+// Disable buzzer encoder click feedback
+//
+#define DISABLE_BUZZER_CLICK
 
 //
 // The duration and frequency for the UI feedback sound.

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -619,6 +619,10 @@ void MarlinUI::kill_screen(PGM_P lcd_error, PGM_P lcd_component) {
 
 void MarlinUI::quick_feedback(const bool clear_buttons/*=true*/) {
 
+  #ifdef DISABLE_BUZZER_CLICK
+    return;
+  #endif
+  
   #if HAS_LCD_MENU
     refresh();
   #endif


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

Adds a new Macro in the Speaker/Buzzer config section of Configuration.h allowing beeps on encoder clicks to be easily disabled.

-->

### Benefits

Easy fix to allow buzzer to still be utilised for warning etc. but disable irritating noise when using the encoder.

### Related Issues

Have been forums on this in the past such as Issues #1685 #10124
