### PR TITLE
Initial BTT SKR Mini E3 V2 support

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -292,18 +292,19 @@
 #define BOARD_BTT_SKR_MINI_V1_1       4013  // BigTreeTech SKR Mini v1.1 (STM32F103RC)
 #define BOARD_BTT_SKR_MINI_E3_V1_0    4014  // BigTreeTech SKR Mini E3 (STM32F103RC)
 #define BOARD_BTT_SKR_MINI_E3_V1_2    4015  // BigTreeTech SKR Mini E3 V1.2 (STM32F103RC)
-#define BOARD_BTT_SKR_E3_DIP          4016  // BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE)
-#define BOARD_JGAURORA_A5S_A1         4017  // JGAurora A5S A1 (STM32F103ZET6)
-#define BOARD_FYSETC_AIO_II           4018  // FYSETC AIO_II
-#define BOARD_FYSETC_CHEETAH          4019  // FYSETC Cheetah
-#define BOARD_FYSETC_CHEETAH_V12      4020  // FYSETC Cheetah V1.2
-#define BOARD_LONGER3D_LK             4021  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
-#define BOARD_GTM32_MINI              4022  // STM32F103VET6 controller
-#define BOARD_GTM32_MINI_A30          4023  // STM32F103VET6 controller
-#define BOARD_GTM32_REV_B             4024  // STM32F103VET6 controller
-#define BOARD_MKS_ROBIN_E3D           4025  // MKS Robin E3D (STM32F103RCT6)
-#define BOARD_MKS_ROBIN_E3            4026  // MKS Robin E3 (STM32F103RCT6)
-#define BOARD_MALYAN_M300             4027  // STM32F070-based delta
+#define BOARD_BTT_SKR_MINI_E3_V2_0    4016  // BigTreeTech SKR Mini E3 V2.0 (STM32F103RC)
+#define BOARD_BTT_SKR_E3_DIP          4017  // BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE)
+#define BOARD_JGAURORA_A5S_A1         4018  // JGAurora A5S A1 (STM32F103ZET6)
+#define BOARD_FYSETC_AIO_II           4019  // FYSETC AIO_II
+#define BOARD_FYSETC_CHEETAH          4020  // FYSETC Cheetah
+#define BOARD_FYSETC_CHEETAH_V12      4021  // FYSETC Cheetah V1.2
+#define BOARD_LONGER3D_LK             4022  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
+#define BOARD_GTM32_MINI              4023  // STM32F103VET6 controller
+#define BOARD_GTM32_MINI_A30          4024  // STM32F103VET6 controller
+#define BOARD_GTM32_REV_B             4025  // STM32F103VET6 controller
+#define BOARD_MKS_ROBIN_E3D           4026  // MKS Robin E3D (STM32F103RCT6)
+#define BOARD_MKS_ROBIN_E3            4027  // MKS Robin E3 (STM32F103RCT6)
+#define BOARD_MALYAN_M300             4028  // STM32F070-based delta
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -512,6 +512,8 @@
   #include "stm32f1/pins_BTT_SKR_MINI_E3_V1_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(BTT_SKR_MINI_E3_V1_2)
   #include "stm32f1/pins_BTT_SKR_MINI_E3_V1_2.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
+#elif MB(BTT_SKR_MINI_E3_V2_0)
+  #include "stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(BTT_SKR_E3_DIP)
   #include "stm32f1/pins_BTT_SKR_E3_DIP.h"      // STM32F1                                env:STM32F103RE_btt env:STM32F103RE_btt_USB env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(JGAURORA_A5S_A1)

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
@@ -92,15 +92,26 @@
 //
 #define HEATER_0_PIN                        PC8   // "HE"
 #define HEATER_BED_PIN                      PC9   // "HB"
-#define FAN_PIN                             PA8   // "FAN0"
+
+#ifdef SKR_MINI_E3_V2
+  #define FAN_PIN                           PC6
+#else
+  #define FAN_PIN                           PA8   // "FAN0"
+#endif
 
 //
 // USB connect control
 //
-#define USB_CONNECT_PIN                     PC13
+#ifdef SKR_MINI_E3_V2
+  #define USB_CONNECT_PIN                   PA14
+#else
+  #define USB_CONNECT_PIN                   PC13
+#endif
+
+
 #define USB_CONNECT_INVERTING false
 
-/**
+/** SKR Mini E3 V1.0, V1.2
  *                 _____
  *             5V | 1 2 | GND
  *  (LCD_EN) PB7  | 3 4 | PB8  (LCD_RS)
@@ -111,18 +122,39 @@
  *                 EXP1
  */
 
+/** SKR Mini E3 V2.0
+ *                 _____
+ *             5V | 1 2 | GND
+ *  (LCD_EN) PB15 | 3 4 | PB8  (LCD_RS)
+ *  (LCD_D4) PB9  | 5 6   PA10 (BTN_EN2)
+ *          RESET | 7 8 | PA9  (BTN_EN1)
+ * (BTN_ENC) PA15 | 9 10| PB5  (BEEPER)
+ *                 -----
+ *                 EXP1
+ */
 #if HAS_SPI_LCD
 
   #if ENABLED(CR10_STOCKDISPLAY)
 
     #define BEEPER_PIN                      PB5
 
-    #define BTN_ENC                         PB6
+    #ifdef SKR_MINI_E3_V2
+      #define BTN_ENC                       PA15
+    #else
+      #define BTN_ENC                       PB6
+    #endif
+
     #define BTN_EN1                         PA9
     #define BTN_EN2                         PA10
 
     #define LCD_PINS_RS                     PB8
-    #define LCD_PINS_ENABLE                 PB7
+
+    #ifdef SKR_MINI_E3_V2
+      #define LCD_PINS_ENABLE               PB15
+    #else
+      #define LCD_PINS_ENABLE               PB7
+    #endif
+
     #define LCD_PINS_D4                     PB9
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
@@ -130,7 +162,13 @@
     #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3.h' for details. Comment out this line to continue."
 
     #define LCD_PINS_RS                     PB9
-    #define LCD_PINS_ENABLE                 PB6
+
+    #ifdef SKR_MINI_E3_V2
+      #define LCD_PINS_ENABLE               PA15
+    #else
+      #define LCD_PINS_ENABLE               PB6
+    #endif
+
     #define LCD_PINS_D4                     PB8
     #define LCD_PINS_D5                     PA10
     #define LCD_PINS_D6                     PA9
@@ -150,14 +188,25 @@
      *                    EXP1
      */
 
-    #define BTN_ENC                         PB6
+    #ifdef SKR_MINI_E3_V2
+      #define BTN_ENC                       PA15
+    #else
+      #define BTN_ENC                       PB6
+    #endif
+
     #define BTN_EN1                         PA9
     #define BTN_EN2                         PA10
 
     #define DOGLCD_CS                       PB8
     #define DOGLCD_A0                       PB9
     #define DOGLCD_SCK                      PB5
-    #define DOGLCD_MOSI                     PB7
+
+    #ifdef SKR_MINI_E3_V2
+      #define DOGLCD_MOSI                   PB15
+    #else
+      #define DOGLCD_MOSI                   PB7
+    #endif
+
     #define FORCE_SOFT_SPI
     #define LCD_BACKLIGHT_PIN               -1
 
@@ -202,7 +251,11 @@
 
   #define CLCD_SPI_BUS 1                          // SPI1 connector
 
-  #define BEEPER_PIN                        PB6
+  #ifdef SKR_MINI_E3_V2
+    #define BEEPER_PIN                      PA15
+  #else
+    #define BEEPER_PIN                      PB6
+  #endif
 
   #define CLCD_MOD_RESET                    PA9
   #define CLCD_SPI_CS                       PB8

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3.h
@@ -108,53 +108,39 @@
   #define USB_CONNECT_PIN                   PC13
 #endif
 
-
 #define USB_CONNECT_INVERTING false
 
-/** SKR Mini E3 V1.0, V1.2
- *                 _____
- *             5V | 1 2 | GND
- *  (LCD_EN) PB7  | 3 4 | PB8  (LCD_RS)
- *  (LCD_D4) PB9  | 5 6   PA10 (BTN_EN2)
- *          RESET | 7 8 | PA9  (BTN_EN1)
- * (BTN_ENC) PB6  | 9 10| PB5  (BEEPER)
- *                 -----
- *                 EXP1
+/**
+ *        SKR Mini E3 V1.0, V1.2                      SKR Mini E3 V2.0
+ *                _____                                     _____
+ *            5V | 1 2 | GND                            5V | 1 2 | GND
+ *  (LCD_EN) PB7 | 3 4 | PB8  (LCD_RS)       (LCD_EN) PB15 | 3 4 | PB8  (LCD_RS)
+ *  (LCD_D4) PB9 | 5 6   PA10 (BTN_EN2)      (LCD_D4) PB9  | 5 6   PA10 (BTN_EN2)
+ *         RESET | 7 8 | PA9  (BTN_EN1)              RESET | 7 8 | PA9  (BTN_EN1)
+ * (BTN_ENC) PB6 | 9 10| PB5  (BEEPER)      (BTN_ENC) PA15 | 9 10| PB5  (BEEPER)
+ *                -----                                     -----
+ *                EXP1                                      EXP1
  */
+#ifdef SKR_MINI_E3_V2
+  #define EXP1_9                            PA15
+  #define EXP1_3                            PB15
+#else
+  #define EXP1_9                            PB6
+  #define EXP1_3                            PB7
+#endif
 
-/** SKR Mini E3 V2.0
- *                 _____
- *             5V | 1 2 | GND
- *  (LCD_EN) PB15 | 3 4 | PB8  (LCD_RS)
- *  (LCD_D4) PB9  | 5 6   PA10 (BTN_EN2)
- *          RESET | 7 8 | PA9  (BTN_EN1)
- * (BTN_ENC) PA15 | 9 10| PB5  (BEEPER)
- *                 -----
- *                 EXP1
- */
 #if HAS_SPI_LCD
 
   #if ENABLED(CR10_STOCKDISPLAY)
 
     #define BEEPER_PIN                      PB5
-
-    #ifdef SKR_MINI_E3_V2
-      #define BTN_ENC                       PA15
-    #else
-      #define BTN_ENC                       PB6
-    #endif
+    #define BTN_ENC                       EXP1_9
 
     #define BTN_EN1                         PA9
     #define BTN_EN2                         PA10
 
     #define LCD_PINS_RS                     PB8
-
-    #ifdef SKR_MINI_E3_V2
-      #define LCD_PINS_ENABLE               PB15
-    #else
-      #define LCD_PINS_ENABLE               PB7
-    #endif
-
+    #define LCD_PINS_ENABLE               EXP1_3
     #define LCD_PINS_D4                     PB9
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
@@ -162,13 +148,7 @@
     #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3.h' for details. Comment out this line to continue."
 
     #define LCD_PINS_RS                     PB9
-
-    #ifdef SKR_MINI_E3_V2
-      #define LCD_PINS_ENABLE               PA15
-    #else
-      #define LCD_PINS_ENABLE               PB6
-    #endif
-
+    #define LCD_PINS_ENABLE               EXP1_9
     #define LCD_PINS_D4                     PB8
     #define LCD_PINS_D5                     PA10
     #define LCD_PINS_D6                     PA9
@@ -177,35 +157,14 @@
 
   #elif EITHER(MKS_MINI_12864, ENDER2_STOCKDISPLAY)
 
-    /** Creality Ender-2 display pinout
-     *                   _____
-     *               5V | 1 2 | GND
-     *      (MOSI) PB7  | 3 4 | PB8  (LCD_RS)
-     *    (LCD_A0) PB9  | 5 6   PA10 (BTN_EN2)
-     *            RESET | 7 8 | PA9  (BTN_EN1)
-     *   (BTN_ENC) PB6  | 9 10| PB5  (SCK)
-     *                   -----
-     *                    EXP1
-     */
-
-    #ifdef SKR_MINI_E3_V2
-      #define BTN_ENC                       PA15
-    #else
-      #define BTN_ENC                       PB6
-    #endif
-
+    #define BTN_ENC                       EXP1_9
     #define BTN_EN1                         PA9
     #define BTN_EN2                         PA10
 
     #define DOGLCD_CS                       PB8
     #define DOGLCD_A0                       PB9
     #define DOGLCD_SCK                      PB5
-
-    #ifdef SKR_MINI_E3_V2
-      #define DOGLCD_MOSI                   PB15
-    #else
-      #define DOGLCD_MOSI                   PB7
-    #endif
+    #define DOGLCD_MOSI                   EXP1_3
 
     #define FORCE_SOFT_SPI
     #define LCD_BACKLIGHT_PIN               -1
@@ -220,7 +179,7 @@
 
   #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_MINI_E3.h' for details. Comment out this line to continue."
 
-  /** FYSECT TFT TFT81050 display pinout
+  /** FYSETC TFT TFT81050 display pinout
    *
    *               Board                                      Display
    *               _____                                       _____
@@ -251,11 +210,7 @@
 
   #define CLCD_SPI_BUS 1                          // SPI1 connector
 
-  #ifdef SKR_MINI_E3_V2
-    #define BEEPER_PIN                      PA15
-  #else
-    #define BEEPER_PIN                      PB6
-  #endif
+  #define BEEPER_PIN                      EXP1_9
 
   #define CLCD_MOD_RESET                    PA9
   #define CLCD_SPI_CS                       PB8

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -31,8 +31,7 @@
 
 // Onboard I2C EEPROM
 #define I2C_EEPROM
-#undef E2END
-#define E2END       (0xFFF) // 4KB
+#define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
 
 #define NEOPIXEL_PIN                       PA8   // LED driving pin
 

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -1,0 +1,56 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define SKR_MINI_E3_V2
+#include "pins_BTT_SKR_MINI_E3.h"
+
+#define BOARD_INFO_NAME "BIGTREE SKR Mini E3 V2.0"
+
+// Release PA13/PA14 (led, usb control) from SWD pins
+#define DISABLE_DEBUG
+
+// Onboard I2C EEPROM
+#define I2C_EEPROM
+#undef E2END
+#define E2END       (0xFFF) // 4KB
+
+#define NEOPIXEL_PIN                       PA8   // LED driving pin
+
+#define PS_ON_PIN                          PC13  // Power Supply Control
+
+#define FAN1_PIN                           PC7
+
+#ifndef CONTROLLER_FAN_PIN
+  #define CONTROLLER_FAN_PIN               FAN1_PIN
+#endif
+
+/**
+ * TMC220x stepper drivers
+ * Hardware serial communication ports.
+ */
+#if HAS_TMC_UART
+  #define X_HARDWARE_SERIAL  Serial4
+  #define Y_HARDWARE_SERIAL  Serial4
+  #define Z_HARDWARE_SERIAL  Serial4
+  #define E0_HARDWARE_SERIAL Serial4
+#endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -22,16 +22,19 @@
 #pragma once
 
 #define SKR_MINI_E3_V2
+
+// Onboard I2C EEPROM
+#undef FLASH_EEPROM_EMULATION //temporary EEPROM include hack
+#undef NO_EEPROM_SELECTED     //temporary EEPROM include hack
+#define I2C_EEPROM
+#define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+
 #include "pins_BTT_SKR_MINI_E3.h"
 
 #define BOARD_INFO_NAME "BIGTREE SKR Mini E3 V2.0"
 
 // Release PA13/PA14 (led, usb control) from SWD pins
 #define DISABLE_DEBUG
-
-// Onboard I2C EEPROM
-#define I2C_EEPROM
-#define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
 
 #define NEOPIXEL_PIN                       PA8   // LED driving pin
 

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -27,6 +27,7 @@
 #if NO_EEPROM_SELECTED
   #define I2C_EEPROM
   #define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+  #undef NO_EEPROM_SELECTED
 #endif
 
 #include "pins_BTT_SKR_MINI_E3.h"

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -24,10 +24,10 @@
 #define SKR_MINI_E3_V2
 
 // Onboard I2C EEPROM
-#undef FLASH_EEPROM_EMULATION //temporary EEPROM include hack
-#undef NO_EEPROM_SELECTED     //temporary EEPROM include hack
-#define I2C_EEPROM
-#define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+#if NO_EEPROM_SELECTED
+  #define I2C_EEPROM
+  #define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+#endif
 
 #include "pins_BTT_SKR_MINI_E3.h"
 


### PR DESCRIPTION
### Description

Initial SKR Mini E3 V2 support. I don't have one on hand yet, so I marked this PR as draft so it can be tested.

BigTreeTech changed two pin numbers in the EXP1 connector, but I tried to keep this PR "DRY" since `pins_BTT_SKR_MINI_E3.h` still contains most of the correct pins. If there's a better way to handle this, like moving the EXP pins to their respective SKR Mini E3 pins files, that would be fine.

### To-do:
- [X] Convert old `E2END` EEPROM method to `MARLIN_EEPROM_SIZE`
- [X] Buy a V2 board off Amazon since shipping from China is taking 2+ months
- [x] Figure out why defining `I2C_EEPROM` in pins file still returns `NO_EEPROM_SELECTED`/`FLASH_EEPROM_EMULATION`. Likely a file include order issue.
- [x] Figure out why using onboard `I2C_EEPROM` causes lockup on boot with latest Marlin/after commit https://github.com/MarlinFirmware/Marlin/commit/5f7a75979f8c1f7cf1f3adbb61e862f17409047b. Using emulated EEPROM works fine.

### Benefits

SKR Mini E3 V2 support.

### Related Issues

V2 config is marked as draft & ready for testing/review: https://github.com/MarlinFirmware/Configurations/pull/111