### PR TITLE
Fix integer division causing issue #17968

### DIFF
--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -274,7 +274,7 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
     else
       top = *timer.ICRn; // top = ICRn
 
-    _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top / v_size)); // Scale 8/16-bit v to top value
+    _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top) / float(v_size)); // Scale 8/16-bit v to top value
   }
 }
 


### PR DESCRIPTION

### Description

There is a bug in fast_pwm.cpp:277
>     _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top / v_size)); // Scale 8/16-bit v to top value

The intention was most likely (from what the comment says and what would make sense) to 
scale the given duty cycle (based on 255 as maximum) to the capcom *top* value.
But the float cast happens **after** the integer division already happened, thus would be correct only if *top==v_size* or a multiple of it.
So this code assumes top is **always** a multiple of 255.

I was asked to make a PR for this instead of a bug report.

### Details

When dividing two integers, the fraction will be dropped and the number rounded towards zero.
In this line you divide the maximums in integer domain, cast to float and then scale the value to the new maximum.

So the line should look like this:
>    _SET_OCRnQ(timer.OCRnQ, timer.q, v * top / v_size); // Scale 8/16-bit v to top value
or
>    _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top) / float(v_size)); // Scale 8/16-bit v to top value

The first might cause integer overflows during multiplication, so I'd go for the second variant which operates on floats immediately.

### Benefits

The duty cycle values for AVR targets with FAST_PWM_FAN suddenly would make sense and go way up to 100%

### Related Issues

#17968
