### PR TITLE
Fix Mightyboard PIO env

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -86,6 +86,7 @@ board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+upload_speed      = 57600
 
 #
 # MightyBoard ATmega2560 (MegaCore 100 pin boards variants)
@@ -97,6 +98,9 @@ board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+upload_protocol   = wiring
+upload_speed      = 57600
+board_upload.maximum_size = 253952
 
 #
 # RAMBo


### PR DESCRIPTION
This will solve the issues noted in #18010 by altering the default upload speeds for the 1280 and 2560-based Mightyboard environments and the speed, protocol, and the bootloader size for the ATMega2560-based Mightyboard environment.