### PR TITLE
Explicitly optimize x/x in Classic Jerk

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2456,22 +2456,16 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       // Pick the smaller of the nominal speeds. Higher speed shall not be achieved at the junction during coasting.
       CACHED_SQRT(previous_nominal_speed, previous_nominal_speed_sqr);
 
+      float smaller_speed_factor = 1.0f;
       if (nominal_speed < previous_nominal_speed) {
         vmax_junction = nominal_speed;
-        const float smaller_speed_factor = vmax_junction / previous_nominal_speed;
+        smaller_speed_factor = vmax_junction / previous_nominal_speed;
       }
-      else {
+      else
         vmax_junction = previous_nominal_speed;
-        const float smaller_speed_factor = 1.0f;  // previous_nominal_speed/previous_nominal_speed = 1.0
-      }
 
       // Now limit the jerk in all axes.
-      #if HAS_LINEAR_E_JERK
-        LOOP_XYZ(axis)
-      #else
-        LOOP_XYZE(axis)
-      #endif
-      {
+      TERN(HAS_LINEAR_E_JERK, LOOP_XYZ, LOOP_XYZE)(axis) {
         // Limit an axis. We have to differentiate: coasting, reversal of an axis, full stop.
         float v_exit = previous_speed[axis] * smaller_speed_factor,
               v_entry = current_speed[axis];

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2456,10 +2456,16 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       // Pick the smaller of the nominal speeds. Higher speed shall not be achieved at the junction during coasting.
       CACHED_SQRT(previous_nominal_speed, previous_nominal_speed_sqr);
 
-      vmax_junction = _MIN(nominal_speed, previous_nominal_speed);
+      if (nominal_speed < previous_nominal_speed) {
+        vmax_junction = nominal_speed;
+        const float smaller_speed_factor = vmax_junction / previous_nominal_speed;
+      }
+      else {
+        vmax_junction = previous_nominal_speed;
+        const float smaller_speed_factor = 1.0f;  // previous_nominal_speed/previous_nominal_speed = 1.0
+      }
 
       // Now limit the jerk in all axes.
-      const float smaller_speed_factor = vmax_junction / previous_nominal_speed;
       #if HAS_LINEAR_E_JERK
         LOOP_XYZ(axis)
       #else


### PR DESCRIPTION
### Description

Avoid unnecessary divison in Classic Jerk code path, in case `nominal_speed >= previous_nominal_speed`. New `if()/else`-check would otherwise be carried out by `_MIN()`-macro, so there's no additional overhead through that.

### Benefits

Avoids one unnecessary divison for about 50% of all moves. 

### Related Issues

None that I know of.
