### PR TITLE
apply extends to env:LPC1769

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -295,7 +295,7 @@ lib_deps          = Servo
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 
 [env:LPC1769]
-platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.2.zip
+platform          = ${env:LPC1768.platform}
 extends           = env:LPC1768
 board             = nxp_lpc1769
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -296,21 +296,8 @@ lib_deps          = Servo
 
 [env:LPC1769]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.2.zip
+extends           = env:LPC1768
 board             = nxp_lpc1769
-build_flags       = -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g ${common.build_flags}
-# debug options for backtrace
-#  -funwind-tables
-#  -mpoke-function-name
-lib_ldf_mode      = off
-lib_compat_mode   = strict
-extra_scripts     = Marlin/src/HAL/LPC1768/upload_extra_script.py
-src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768>
-lib_deps          = Servo
-  LiquidCrystal
-  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper@>=0.6.2
-  Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
-  SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 
 #
 # STM32F103RC


### PR DESCRIPTION
### Requirements

LPC1769 based board.


### Description

Apply extends to env LPC1769

### Benefits

Reduces duplication in platformio.ini 

### Related Issues
none