### PR TITLE
Apply extends to 8bit avr controllers

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -246,9 +246,6 @@ build_flags   = ${DUE_archim.build_flags} -funwind-tables -mpoke-function-name
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.2.zip
 board             = nxp_lpc1768
 build_flags       = -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g ${common.build_flags}
-# debug options for backtrace
-#  -funwind-tables
-#  -mpoke-function-name
 lib_ldf_mode      = off
 lib_compat_mode   = strict
 extra_scripts     = Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -259,17 +256,22 @@ lib_deps          = Servo
   TMCStepper@>=0.6.2
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
+# debug options for backtrace
+#  -funwind-tables
+#  -mpoke-function-name
 
 #
 # NXP LPC176x ARM Cortex-M3
 #
 [env:LPC1768]
-platform          = ${common_LPC.platform}
-board             = nxp_lpc1768
+platform  = ${common_LPC.platform}
+extends   = common_LPC
+board     = nxp_lpc1768
 
 [env:LPC1769]
-platform          = ${common_LPC.platform}
-board             = nxp_lpc1769
+platform  = ${common_LPC.platform}
+extends   = common_LPC
+board     = nxp_lpc1769
 
 #
 # STM32F103RC

--- a/platformio.ini
+++ b/platformio.ini
@@ -288,7 +288,7 @@ monitor_speed     = 115200
 #
 [env:STM32F103RC_fysetc]
 platform          = ${common_stm32f1.platform}
-extends           = STM32F103RC
+extends           = env:STM32F103RC
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
 build_flags       = ${common_stm32f1.build_flags} -DDEBUG_LEVEL=0
 lib_ldf_mode      = chain
@@ -306,7 +306,7 @@ upload_protocol   = serial
 
 [env:STM32F103RC_btt]
 platform          = ${common_stm32f1.platform}
-extends           = STM32F103RC
+extends           = env:STM32F103RC
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = ${common_stm32f1.build_flags}
   -DDEBUG_LEVEL=0 -DSS_TIMER=4
@@ -314,20 +314,20 @@ monitor_speed     = 115200
 
 [env:STM32F103RC_btt_USB]
 platform          = ${common_stm32f1.platform}
-extends           = STM32F103RC_btt
+extends           = env:STM32F103RC_btt
 build_flags       = ${env:STM32F103RC_btt.build_flags} -DUSE_USB_COMPOSITE
 lib_deps          = ${env:STM32F103RC_btt.lib_deps}
   USBComposite for STM32F1@==0.91
 
 [env:STM32F103RC_btt_512K]
 platform          = ${common_stm32f1.platform}
-extends           = STM32F103RC_btt
+extends           = env:STM32F103RC_btt
 board_upload.maximum_size=524288
 build_flags       = ${env:STM32F103RC_btt.build_flags} -DSTM32_FLASH_SIZE=512
 
 [env:STM32F103RC_btt_512K_USB]
 platform          = ${common_stm32f1.platform}
-extends           = STM32F103RC_btt_512K
+extends           = env:STM32F103RC_btt_512K
 build_flags       = ${env:STM32F103RC_btt_512K.build_flags} -DUSE_USB_COMPOSITE
 lib_deps          = ${env:STM32F103RC_btt_512K.lib_deps}
   USBComposite for STM32F1@==0.91
@@ -348,7 +348,7 @@ monitor_speed     = 115200
 #
 [env:STM32F103RE_btt]
 platform          = ${common_stm32f1.platform}
-extends           = STM32F103RE
+extends           = env:STM32F103RE
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
 build_flags       = ${common_stm32f1.build_flags} -DDEBUG_LEVEL=0 -DSS_TIMER=4
 debug_tool        = stlink
@@ -356,7 +356,7 @@ upload_protocol   = stlink
 
 [env:STM32F103RE_btt_USB]
 platform          = ${common_stm32f1.platform}
-extends           = STM32F103RE_btt
+extends           = env:STM32F103RE_btt
 build_flags       = ${env:STM32F103RE_btt.build_flags} -DUSE_USB_COMPOSITE
 lib_deps          = ${common_stm32f1.lib_deps}
   USBComposite for STM32F1@==0.91
@@ -464,7 +464,7 @@ build_flags   = ${common_stm32f1.build_flags}
 #
 [env:mks_robin_pro]
 platform      = ${common_stm32f1.platform}
-extends       = mks_robin
+extends       = env:mks_robin
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_pro.py
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -233,11 +233,15 @@ build_flags   = ${common.build_flags}
   -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
 extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
 
-# Used when WATCHDOG_RESET_MANUAL is enabled
 [env:DUE_archim_debug]
+# Used when WATCHDOG_RESET_MANUAL is enabled
 platform      = atmelsam
-extends       = DUE_archim
-build_flags   = ${DUE_archim.build_flags} -funwind-tables -mpoke-function-name
+board         = due
+src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
+build_flags   = ${common.build_flags}
+  -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
+  -funwind-tables -mpoke-function-name
+extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
 
 #
 # NXP LPC176x ARM Cortex-M3

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,7 +56,7 @@ lib_deps      =
   SlowSoftI2CMaster=https://github.com/mikeshub/SlowSoftI2CMaster/archive/master.zip
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
 
-[common_8bit_avr]
+[common_avr8]
 board_build.f_cpu = 16000000L
 lib_deps          = ${common.lib_deps}
   TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
@@ -85,7 +85,7 @@ monitor_speed = 250000
 #
 [env:mega2560]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = megaatmega2560
 
 #
@@ -93,7 +93,7 @@ board         = megaatmega2560
 #
 [env:mega1280]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = megaatmega1280
 
 #
@@ -101,7 +101,7 @@ board         = megaatmega1280
 #
 [env:MightyBoard1280]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = megaatmega1280
 upload_speed  = 57600
 
@@ -110,7 +110,7 @@ upload_speed  = 57600
 #
 [env:MightyBoard2560]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = megaatmega2560
 upload_protocol = wiring
 upload_speed  = 57600
@@ -121,7 +121,7 @@ board_upload.maximum_size = 253952
 #
 [env:rambo]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = reprap_rambo
 
 #
@@ -129,7 +129,7 @@ board         = reprap_rambo
 #
 [env:FYSETC_F6_13]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = fysetc_f6_13
 
 #
@@ -137,7 +137,7 @@ board         = fysetc_f6_13
 #
 [env:FYSETC_F6_14]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = fysetc_f6_14
 
 #
@@ -145,7 +145,7 @@ board         = fysetc_f6_14
 #
 [env:sanguino644p]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = sanguino_atmega644p
 
 #
@@ -153,7 +153,7 @@ board         = sanguino_atmega644p
 #
 [env:sanguino1284p]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = sanguino_atmega1284p
 
 #
@@ -161,7 +161,7 @@ board         = sanguino_atmega1284p
 #
 [env:melzi]
 platform      = atmelavr
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = sanguino_atmega1284p
 lib_ignore    = TMCStepper
 upload_speed  = 57600
@@ -171,7 +171,7 @@ upload_speed  = 57600
 #
 [env:melzi_optiboot]
 platform      = atmelavr
-extends       = env:melzi
+extends       = melzi
 upload_speed  = 115200
 
 #
@@ -183,7 +183,7 @@ upload_speed  = 115200
 #
 [env:at90usb1286_cdc]
 platform      = teensy
-extends       = common_8bit_avr
+extends       = common_avr8
 board         = at90usb1286
 lib_ignore    = TMCStepper
 
@@ -195,7 +195,7 @@ lib_ignore    = TMCStepper
 #
 [env:at90usb1286_dfu]
 platform      = teensy
-extends       = env:at90usb1286_cdc
+extends       = at90usb1286_cdc
 
 #
 # Due (Atmel SAM3X8E ARM Cortex-M3)
@@ -233,20 +233,16 @@ build_flags   = ${common.build_flags}
   -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
 extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
 
-[env:DUE_archim_debug]
 # Used when WATCHDOG_RESET_MANUAL is enabled
+[env:DUE_archim_debug]
 platform      = atmelsam
-board         = due
-src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
-build_flags   = ${common.build_flags}
-  -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
-  -funwind-tables -mpoke-function-name
-extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
+extends       = DUE_archim
+build_flags   = ${DUE_archim.build_flags} -funwind-tables -mpoke-function-name
 
 #
 # NXP LPC176x ARM Cortex-M3
 #
-[env:LPC1768]
+[env:common_LPC]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.2.zip
 board             = nxp_lpc1768
 build_flags       = -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g ${common.build_flags}
@@ -264,23 +260,16 @@ lib_deps          = Servo
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 
+#
+# NXP LPC176x ARM Cortex-M3
+#
+[env:LPC1768]
+platform          = ${common_LPC.platform}
+board             = nxp_lpc1768
+
 [env:LPC1769]
-platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.2.zip
+platform          = ${common_LPC.platform}
 board             = nxp_lpc1769
-build_flags       = -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g ${common.build_flags}
-# debug options for backtrace
-#  -funwind-tables
-#  -mpoke-function-name
-lib_ldf_mode      = off
-lib_compat_mode   = strict
-extra_scripts     = Marlin/src/HAL/LPC1768/upload_extra_script.py
-src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768>
-lib_deps          = Servo
-  LiquidCrystal
-  U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  TMCStepper@>=0.6.2
-  Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/release.zip
-  SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 
 #
 # STM32F103RC
@@ -297,7 +286,7 @@ monitor_speed     = 115200
 #
 [env:STM32F103RC_fysetc]
 platform          = ${common_stm32f1.platform}
-extends           = env:STM32F103RC
+extends           = STM32F103RC
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
 build_flags       = ${common_stm32f1.build_flags} -DDEBUG_LEVEL=0
 lib_ldf_mode      = chain
@@ -315,7 +304,7 @@ upload_protocol   = serial
 
 [env:STM32F103RC_btt]
 platform          = ${common_stm32f1.platform}
-extends           = env:STM32F103RC
+extends           = STM32F103RC
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = ${common_stm32f1.build_flags}
   -DDEBUG_LEVEL=0 -DSS_TIMER=4
@@ -323,20 +312,20 @@ monitor_speed     = 115200
 
 [env:STM32F103RC_btt_USB]
 platform          = ${common_stm32f1.platform}
-extends           = env:STM32F103RC_btt
+extends           = STM32F103RC_btt
 build_flags       = ${env:STM32F103RC_btt.build_flags} -DUSE_USB_COMPOSITE
 lib_deps          = ${env:STM32F103RC_btt.lib_deps}
   USBComposite for STM32F1@==0.91
 
 [env:STM32F103RC_btt_512K]
 platform          = ${common_stm32f1.platform}
-extends           = env:STM32F103RC_btt
+extends           = STM32F103RC_btt
 board_upload.maximum_size=524288
 build_flags       = ${env:STM32F103RC_btt.build_flags} -DSTM32_FLASH_SIZE=512
 
 [env:STM32F103RC_btt_512K_USB]
 platform          = ${common_stm32f1.platform}
-extends           = env:STM32F103RC_btt_512K
+extends           = STM32F103RC_btt_512K
 build_flags       = ${env:STM32F103RC_btt_512K.build_flags} -DUSE_USB_COMPOSITE
 lib_deps          = ${env:STM32F103RC_btt_512K.lib_deps}
   USBComposite for STM32F1@==0.91
@@ -357,7 +346,7 @@ monitor_speed     = 115200
 #
 [env:STM32F103RE_btt]
 platform          = ${common_stm32f1.platform}
-extends           = env:STM32F103RE
+extends           = STM32F103RE
 extra_scripts     = buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
 build_flags       = ${common_stm32f1.build_flags} -DDEBUG_LEVEL=0 -DSS_TIMER=4
 debug_tool        = stlink
@@ -365,7 +354,7 @@ upload_protocol   = stlink
 
 [env:STM32F103RE_btt_USB]
 platform          = ${common_stm32f1.platform}
-extends           = env:STM32F103RE_btt
+extends           = STM32F103RE_btt
 build_flags       = ${env:STM32F103RE_btt.build_flags} -DUSE_USB_COMPOSITE
 lib_deps          = ${common_stm32f1.lib_deps}
   USBComposite for STM32F1@==0.91
@@ -473,7 +462,7 @@ build_flags   = ${common_stm32f1.build_flags}
 #
 [env:mks_robin_pro]
 platform      = ${common_stm32f1.platform}
-extends       = env:mks_robin
+extends       = mks_robin
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_pro.py
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -225,7 +225,7 @@ build_flags   = ${common.build_flags}
 #
 # Archim SAM
 #
-[env:DUE_archim]
+[DUE_archim_common]
 platform      = atmelsam
 board         = due
 src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
@@ -233,15 +233,15 @@ build_flags   = ${common.build_flags}
   -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
 extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
 
-[env:DUE_archim_debug]
+[env:DUE_archim]
+platform      = ${DUE_archim_common.platform}
+extends       = DUE_archim_common
+
 # Used when WATCHDOG_RESET_MANUAL is enabled
-platform      = atmelsam
-board         = due
-src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
-build_flags   = ${common.build_flags}
-  -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
-  -funwind-tables -mpoke-function-name
-extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
+[env:DUE_archim_debug]
+platform      = ${DUE_archim_common.platform}
+extends       = DUE_archim_common
+build_flags   = ${DUE_archim_common.build_flags} -funwind-tables -mpoke-function-name
 
 #
 # NXP LPC176x ARM Cortex-M3
@@ -575,9 +575,10 @@ platform          = ststm32
 platform_packages = framework-arduinoststm32@${common.arduinoststm32_ver}
 board             = STEVAL_STM32F401VE
 build_flags       = ${common.build_flags}
-  -DTARGET_STM32F4 -DARDUINO_STEVAL -DSTM32F401xE
-  -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STEVAL_F401VE\"
-  -DDISABLE_GENERIC_SERIALUSB -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
+  -DTARGET_STM32F4 -DSTM32F401xE -DUSBCON
+  -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STEVAL_F401VE\"
+  -DARDUINO_STEVAL -DDISABLE_GENERIC_SERIALUSB
+  -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
   -IMarlin/src/HAL/STM32
 build_unflags     = -std=gnu++11
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -593,9 +594,9 @@ platform          = ststm32
 platform_packages = framework-arduinoststm32@${common.arduinoststm32_ver}
 board             = FLYF407ZG
 build_flags       = ${common.build_flags}
-  -DSTM32F4 -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407ZG\"
-  -DTARGET_STM32F4 -DVECT_TAB_OFFSET=0x8000
-  -IMarlin/src/HAL/STM32
+  -DTARGET_STM32F4 -DSTM32F4 -DUSBCON
+  -DUSBD_USE_CDC -DUSBD_VID=0x0483 -DUSB_PRODUCT=\"STM32F407ZG\"
+  -DVECT_TAB_OFFSET=0x8000 -IMarlin/src/HAL/STM32
 build_unflags     = -std=gnu++11
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 lib_ignore        = Adafruit NeoPixel, SailfishLCD, SlowSoftI2CMaster, SoftwareSerial

--- a/platformio.ini
+++ b/platformio.ini
@@ -56,6 +56,12 @@ lib_deps      =
   SlowSoftI2CMaster=https://github.com/mikeshub/SlowSoftI2CMaster/archive/master.zip
   SoftwareSerialM=https://github.com/FYSETC/SoftwareSerialM/archive/master.zip
 
+[common_8bit_avr]
+board_build.f_cpu = 16000000L
+lib_deps          = ${common.lib_deps}
+  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
+src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+
 # Globally defined properties
 # inherited by all environments
 [env]
@@ -78,112 +84,85 @@ monitor_speed = 250000
 # ATmega2560
 #
 [env:mega2560]
-platform          = atmelavr
-board             = megaatmega2560
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+platform      = atmelavr
+extends       = common_8bit_avr
+board         = megaatmega2560
 
 #
 # ATmega1280
 #
 [env:mega1280]
-platform          = atmelavr
-board             = megaatmega1280
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+platform      = atmelavr
+extends       = common_8bit_avr
+board         = megaatmega1280
 
 #
 # MightyBoard ATmega2560 (MegaCore 100 pin boards variants)
 #
 [env:MightyBoard1280]
-platform          = atmelavr
-board             = ATmega1280
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
-upload_speed      = 57600
+platform      = atmelavr
+extends       = common_8bit_avr
+board         = megaatmega1280
+upload_speed  = 57600
 
 #
 # MightyBoard ATmega2560 (MegaCore 100 pin boards variants)
 #
 [env:MightyBoard2560]
-platform          = atmelavr
-board             = ATmega2560
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
-upload_protocol   = wiring
-upload_speed      = 57600
+platform      = atmelavr
+extends       = common_8bit_avr
+board         = megaatmega2560
+upload_protocol = wiring
+upload_speed  = 57600
 board_upload.maximum_size = 253952
 
 #
 # RAMBo
 #
 [env:rambo]
-platform          = atmelavr
-board             = reprap_rambo
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+platform      = atmelavr
+extends       = common_8bit_avr
+board         = reprap_rambo
 
 #
 # FYSETC F6 V1.3
 #
 [env:FYSETC_F6_13]
-platform          = atmelavr
-board             = fysetc_f6_13
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+platform      = atmelavr
+extends       = common_8bit_avr
+board         = fysetc_f6_13
 
 #
 # FYSETC F6 V1.4
 #
 [env:FYSETC_F6_14]
-platform          = atmelavr
-board             = fysetc_f6_14
-board_build.f_cpu = 16000000L
-lib_deps          = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
+platform      = atmelavr
+extends       = common_8bit_avr
+board         = fysetc_f6_14
 
 #
 # Sanguinololu (ATmega644p)
 #
 [env:sanguino644p]
 platform      = atmelavr
+extends       = common_8bit_avr
 board         = sanguino_atmega644p
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
 # Sanguinololu (ATmega1284p)
 #
 [env:sanguino1284p]
 platform      = atmelavr
+extends       = common_8bit_avr
 board         = sanguino_atmega1284p
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
 # Melzi and clones (ATmega1284p)
 #
 [env:melzi]
 platform      = atmelavr
+extends       = common_8bit_avr
 board         = sanguino_atmega1284p
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 lib_ignore    = TMCStepper
 upload_speed  = 57600
 
@@ -192,11 +171,7 @@ upload_speed  = 57600
 #
 [env:melzi_optiboot]
 platform      = atmelavr
-board         = sanguino_atmega1284p
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
-src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
-lib_ignore    = TMCStepper
+extends       = env:melzi
 upload_speed  = 115200
 
 #
@@ -208,11 +183,9 @@ upload_speed  = 115200
 #
 [env:at90usb1286_cdc]
 platform      = teensy
+extends       = common_8bit_avr
 board         = at90usb1286
-lib_deps      = ${common.lib_deps}
-  TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
 lib_ignore    = TMCStepper
-src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 
 #
 # AT90USB1286 boards using DFU bootloader
@@ -222,10 +195,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
 #
 [env:at90usb1286_dfu]
 platform      = teensy
-board         = at90usb1286
-lib_deps      = ${common.lib_deps}
-lib_ignore    = TMCStepper
-src_filter    = ${common.default_src_filter} +<src/HAL/AVR>
+extends       = env:at90usb1286_cdc
 
 #
 # Due (Atmel SAM3X8E ARM Cortex-M3)

--- a/platformio.ini
+++ b/platformio.ini
@@ -171,7 +171,7 @@ upload_speed  = 57600
 #
 [env:melzi_optiboot]
 platform      = atmelavr
-extends       = melzi
+extends       = env:melzi
 upload_speed  = 115200
 
 #
@@ -195,7 +195,7 @@ lib_ignore    = TMCStepper
 #
 [env:at90usb1286_dfu]
 platform      = teensy
-extends       = at90usb1286_cdc
+extends       = env:at90usb1286_cdc
 
 #
 # Due (Atmel SAM3X8E ARM Cortex-M3)
@@ -242,7 +242,7 @@ build_flags   = ${DUE_archim.build_flags} -funwind-tables -mpoke-function-name
 #
 # NXP LPC176x ARM Cortex-M3
 #
-[env:common_LPC]
+[common_LPC]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.2.zip
 board             = nxp_lpc1768
 build_flags       = -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -225,7 +225,7 @@ build_flags   = ${common.build_flags}
 #
 # Archim SAM
 #
-[DUE_archim_common]
+[common_DUE_archim]
 platform      = atmelsam
 board         = due
 src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
@@ -234,14 +234,14 @@ build_flags   = ${common.build_flags}
 extra_scripts = Marlin/src/HAL/DUE/upload_extra_script.py
 
 [env:DUE_archim]
-platform      = ${DUE_archim_common.platform}
-extends       = DUE_archim_common
+platform      = ${common_DUE_archim.platform}
+extends       = common_DUE_archim
 
 # Used when WATCHDOG_RESET_MANUAL is enabled
 [env:DUE_archim_debug]
-platform      = ${DUE_archim_common.platform}
-extends       = DUE_archim_common
-build_flags   = ${DUE_archim_common.build_flags} -funwind-tables -mpoke-function-name
+platform      = ${common_DUE_archim.platform}
+extends       = common_DUE_archim
+build_flags   = ${common_DUE_archim.build_flags} -funwind-tables -mpoke-function-name
 
 #
 # NXP LPC176x ARM Cortex-M3


### PR DESCRIPTION
### Requirements

8bit avr controller

### Description

Apply extends to 8bit avr's

### Benefits

Reduces duplication in platformio.ini

### Related Issues

None