### PR TITLE
Fix BOARD_FYSETC_AIO_II builds

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -378,7 +378,7 @@ void CardReader::mount() {
 /**
  * Handle SD card events
  */
-#if MB(FYSETC_CHEETAH)
+#if MB(FYSETC_CHEETAH, FYSETC_AIO_II)
   #include "../module/stepper.h"
 #endif
 


### PR DESCRIPTION
BOARD_FYSETC_AIO_II needs this header for the reset_stepper_drivers function