### PR TITLE
Improve reliability of homing after G34 bed leveling

### DIFF
--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -366,7 +366,11 @@ void GcodeSuite::G34() {
       // After this operation the z position needs correction
       set_axis_not_trusted(Z_AXIS);
       // Home Z after the alignment procedure
-      process_subcommands_now_P(PSTR("G28Z"));
+      #if ENABLED(Z_SAFE_HOMING)
+        process_subcommands_now_P(PSTR("G28"));
+      #else
+        process_subcommands_now_P(PSTR("G28Z"));
+      #endif
     #else
       // Use the probed height from the last iteration to determine the Z height.
       // z_measured_min is used, because all steppers are aligned to z_measured_min.

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -366,11 +366,7 @@ void GcodeSuite::G34() {
       // After this operation the z position needs correction
       set_axis_not_trusted(Z_AXIS);
       // Home Z after the alignment procedure
-      #if ENABLED(Z_SAFE_HOMING)
-        process_subcommands_now_P(PSTR("G28"));
-      #else
-        process_subcommands_now_P(PSTR("G28Z"));
-      #endif
+      process_subcommands_now_P(PSTR(TERN(Z_SAFE_HOMING, "G28", "G28Z")));
     #else
       // Use the probed height from the last iteration to determine the Z height.
       // z_measured_min is used, because all steppers are aligned to z_measured_min.


### PR DESCRIPTION
Signed-off-by: Andy Miller <rhuk@mac.com>

### Description

While implementing Triple Z bed leveling via the `G34` command I ran into an issue where after a successful leveling process, the `G28Z` homing failed and caused the bed to smash into the nozzle. 

After chatting with @sjasonsmith on Discord, he suggested changing this to a full `G28` home. After doing this, `G34` was able to fully complete.  

To make things a bit safer, he also suggested doing this specifically if `Z_SAFE_HOMING` was enabled (which usually would be in these cases).

Example output: https://gist.github.com/rhukster/d0e9aac7adb7f325062fb2b1f25e5f85

### Benefits

Adding this check to the `G34` code ensures that a full `G28` homing is performed to increase the likelihood of bed leveling being completed successfully.
