### PR TITLE
Improve accuracy of G2 and G3 motion

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -117,8 +117,8 @@ void plan_arc(
   uint16_t segments = FLOOR(mm_of_travel / seg_length);
   if (segments < min_segments) {            // Too few segments?
     segments = min_segments;                // More segments
-    seg_length = mm_of_travel / segments;   // but also shorter
   }
+  seg_length = mm_of_travel / segments;
 
   /**
    * Vector rotation by transformation matrix: r is the original vector, r_T is the rotated vector,
@@ -151,8 +151,9 @@ void plan_arc(
   const float theta_per_segment = angular_travel / segments,
               linear_per_segment = linear_travel / segments,
               extruder_per_segment = extruder_travel / segments,
-              sin_T = theta_per_segment,
-              cos_T = 1 - 0.5f * sq(theta_per_segment); // Small angle approximation
+              sq_theta_per_segment = sq(theta_per_segment),
+              sin_T = theta_per_segment - sq_theta_per_segment*theta_per_segment/6,
+              cos_T = 1 - 0.5f * sq_theta_per_segment; // Small angle approximation
 
   // Initialize the linear axis
   raw[l_axis] = current_position[l_axis];
@@ -218,7 +219,7 @@ void plan_arc(
       planner.apply_leveling(raw);
     #endif
 
-    if (!planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, seg_length
+    if (!planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, 0
       #if ENABLED(SCARA_FEEDRATE_SCALING)
         , inv_duration
       #endif


### PR DESCRIPTION
### Description

* Improve small angle sine approximation with an addition term from the MacLaurin series.  This makes the actual arc more closely follow the true arc.
* Allow the planner to correctly calculate the actual distance traveled.  This is important so that the time spent on the motion is accurate.

### Benefits

Smoother arcs and more consistent feedrate during those arcs.

### Related Issues

This fixes #18141 .
This fixes #17348 .