### PR TITLE
Add SERIAL_STATS sanity checks for LPC, STM32, and STM32F1 HALs

### DIFF
--- a/Marlin/src/HAL/LPC1768/inc/SanityCheck.h
+++ b/Marlin/src/HAL/LPC1768/inc/SanityCheck.h
@@ -251,3 +251,11 @@ static_assert(DISABLED(BAUD_RATE_GCODE), "BAUD_RATE_GCODE is not yet supported o
 
   #undef USEDI2CDEV_M
 #endif
+
+#if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
+  #error "SERIAL_STATS_MAX_RX_QUEUED is not supported on this platform."
+#endif
+
+#if ENABLED(SERIAL_STATS_DROPPED_RX)
+  #error "SERIAL_STATS_DROPPED_RX is not supported on this platform."
+#endif  

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -48,3 +48,11 @@
 #if !defined(STM32F4xx) && ENABLED(FLASH_EEPROM_LEVELING)
   #error "FLASH_EEPROM_LEVELING is currently only supported on STM32F4 hardware."
 #endif
+
+#if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
+  #error "SERIAL_STATS_MAX_RX_QUEUED is not supported on this platform."
+#endif
+
+#if ENABLED(SERIAL_STATS_DROPPED_RX)
+  #error "SERIAL_STATS_DROPPED_RX is not supported on this platform."
+#endif  

--- a/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
@@ -49,3 +49,11 @@
   #endif
   #error "SDCARD_EEPROM_EMULATION requires SDSUPPORT. Enable SDSUPPORT or choose another EEPROM emulation."
 #endif
+
+#if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
+  #error "SERIAL_STATS_MAX_RX_QUEUED is not supported on this platform."
+#endif
+
+#if ENABLED(SERIAL_STATS_DROPPED_RX)
+  #error "SERIAL_STATS_DROPPED_RX is not supported on this platform."
+#endif  


### PR DESCRIPTION
### Description

Add sanity checks to clarify that `SERIAL_STATS_MAX_RX_QUEUED` and `SERIAL_STATS_DROPPED_RX` are incompatible with LPC and STM32 platforms.

There may be additional HALs which do not support these, but they are more off my radar than these, and less frequently used overall.

### Benefits

Provides intuitive errors on failure:
`sanitycheck.h:54:4: error: #error "SERIAL_STATS_MAX_RX_QUEUED is not supported on this platform."`

Old error:
```
Marlin\src\gcode\control\M111.cpp:72:60: error: 'class USBSerial' has no member named 'rxMaxEnqueued'
         SERIAL_ECHOPAIR("\nMax RX Queue Size: ", MYSERIAL0.rxMaxEnqueued());
                                                            ^
Marlin\src\gcode\control\../../inc/../core/serial.h:105:57: note: in definition of macro '_SEP_2'
 #define _SEP_2(PRE,V)     serial_echopair_PGM(PSTR(PRE),V)
                                                         ^
Marlin\src\gcode\control\../../inc/../core/serial.h:103:27: note: in expansion of macro '__SEP_N'
 #define _SEP_N(N,V...)    __SEP_N(N,V)
                           ^~~~~~~
Marlin\src\gcode\control\../../inc/../core/serial.h:129:31: note: in expansion of macro '_SEP_N'
 #define SERIAL_ECHOPAIR(V...) _SEP_N(NUM_ARGS(V),V)
                               ^~~~~~
Marlin\src\gcode\control\M111.cpp:72:9: note: in expansion of macro 'SERIAL_ECHOPAIR'
         SERIAL_ECHOPAIR("\nMax RX Queue Size: ", MYSERIAL0.rxMaxEnqueued());
```

### Related Issues

#18122
