### PR TITLE
fix compile-error "MSerial6 was not declared in this scope"

### DIFF
--- a/Marlin/src/HAL/STM32/MarlinSerial.h
+++ b/Marlin/src/HAL/STM32/MarlinSerial.h
@@ -53,3 +53,8 @@ extern MarlinSerial MSerial3;
 extern MarlinSerial MSerial4;
 extern MarlinSerial MSerial5;
 extern MarlinSerial MSerial6;
+extern MarlinSerial MSerial7;
+extern MarlinSerial MSerial8;
+extern MarlinSerial MSerial9;
+extern MarlinSerial MSerial10;
+extern MarlinSerial MSerialLP1;

--- a/Marlin/src/HAL/STM32/MarlinSerial.h
+++ b/Marlin/src/HAL/STM32/MarlinSerial.h
@@ -52,3 +52,4 @@ extern MarlinSerial MSerial2;
 extern MarlinSerial MSerial3;
 extern MarlinSerial MSerial4;
 extern MarlinSerial MSerial5;
+extern MarlinSerial MSerial6;


### PR DESCRIPTION
### Requirements

* none

### Description

This fix a compile-error after PR #18095 got merged

### Benefits

no compile-error

### Related Issues

no issues yet