### PR TITLE
Fixed Z homing to support using custom probe pins

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1537,8 +1537,8 @@ void homeaxis(const AxisEnum axis) {
     #define _CAN_HOME(A) (axis == _AXIS(A) && ( \
          ENABLED(A##_SPI_SENSORLESS) \
       || (_AXIS(A) == Z_AXIS && ENABLED(HOMING_Z_WITH_PROBE)) \
-      || (PIN_EXISTS(A##_MIN) && A##_HOME_DIR < 0) \
-      || (PIN_EXISTS(A##_MAX) && A##_HOME_DIR > 0) \
+      || (A##_MIN_PIN > 0 && A##_HOME_DIR < 0) \
+      || (A##_MAX_PIN > 0 && A##_HOME_DIR > 0) \
     ))
     if (!_CAN_HOME(X) && !_CAN_HOME(Y) && !_CAN_HOME(Z)) return;
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1535,8 +1535,8 @@ void homeaxis(const AxisEnum axis) {
     if (axis != Z_AXIS) { BUZZ(100, 880); return; }
   #else
     #define _CAN_HOME(A) (axis == _AXIS(A) && ( \
-         A##_SPI_SENSORLESS \
-      || (_AXIS(A) == Z_AXIS && HOMING_Z_WITH_PROBE) \
+         ENABLED(A##_SPI_SENSORLESS) \
+      || (_AXIS(A) == Z_AXIS && ENABLED(HOMING_Z_WITH_PROBE)) \
       || (PIN_EXISTS(A##_MIN) && A##_HOME_DIR < 0) \
       || (PIN_EXISTS(A##_MAX) && A##_HOME_DIR > 0) \
     ))

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1549,7 +1549,11 @@ void homeaxis(const AxisEnum axis) {
     #if Z_SPI_SENSORLESS
       #define CAN_HOME_Z true
     #else
-      #define CAN_HOME_Z _CAN_HOME(Z)
+      #define CAN_HOME_Z_WITH_ENDSTOP _CAN_HOME(Z)
+      #define CAN_HOME_Z_WITH_PROBE \
+        ((axis == Z_AXIS) && ENABLED(USE_PROBE_FOR_Z_HOMING) && Z_HOME_DIR < 0 && Z_MIN_PROBE_PIN > -1)
+
+      #define CAN_HOME_Z (CAN_HOME_Z_WITH_ENDSTOP || CAN_HOME_Z_WITH_PROBE)
     #endif
     if (!CAN_HOME_X && !CAN_HOME_Y && !CAN_HOME_Z) return;
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1537,8 +1537,8 @@ void homeaxis(const AxisEnum axis) {
     #define _CAN_HOME(A) (axis == _AXIS(A) && ( \
          A##_SPI_SENSORLESS \
       || (_AXIS(A) == Z_AXIS && HOMING_Z_WITH_PROBE) \
-      || (A##_MIN_PIN > -1 && A##_HOME_DIR < 0) \
-      || (A##_MAX_PIN > -1 && A##_HOME_DIR > 0) \
+      || (PIN_EXISTS(A##_MIN) && A##_HOME_DIR < 0) \
+      || (PIN_EXISTS(A##_MAX) && A##_HOME_DIR > 0) \
     ))
     if (!_CAN_HOME(X) && !_CAN_HOME(Y) && !_CAN_HOME(Z)) return;
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1534,28 +1534,13 @@ void homeaxis(const AxisEnum axis) {
     // Only Z homing (with probe) is permitted
     if (axis != Z_AXIS) { BUZZ(100, 880); return; }
   #else
-    #define _CAN_HOME(A) \
-      (axis == _AXIS(A) && ((A##_MIN_PIN > -1 && A##_HOME_DIR < 0) || (A##_MAX_PIN > -1 && A##_HOME_DIR > 0)))
-    #if X_SPI_SENSORLESS
-      #define CAN_HOME_X true
-    #else
-      #define CAN_HOME_X _CAN_HOME(X)
-    #endif
-    #if Y_SPI_SENSORLESS
-      #define CAN_HOME_Y true
-    #else
-      #define CAN_HOME_Y _CAN_HOME(Y)
-    #endif
-    #if Z_SPI_SENSORLESS
-      #define CAN_HOME_Z true
-    #else
-      #define CAN_HOME_Z_WITH_ENDSTOP _CAN_HOME(Z)
-      #define CAN_HOME_Z_WITH_PROBE \
-        ((axis == Z_AXIS) && ENABLED(USE_PROBE_FOR_Z_HOMING) && Z_HOME_DIR < 0 && Z_MIN_PROBE_PIN > -1)
-
-      #define CAN_HOME_Z (CAN_HOME_Z_WITH_ENDSTOP || CAN_HOME_Z_WITH_PROBE)
-    #endif
-    if (!CAN_HOME_X && !CAN_HOME_Y && !CAN_HOME_Z) return;
+    #define _CAN_HOME(A) (axis == _AXIS(A) && ( \
+         A##_SPI_SENSORLESS \
+      || (_AXIS(A) == Z_AXIS && HOMING_Z_WITH_PROBE) \
+      || (A##_MIN_PIN > -1 && A##_HOME_DIR < 0) \
+      || (A##_MAX_PIN > -1 && A##_HOME_DIR > 0) \
+    ))
+    if (!_CAN_HOME(X) && !_CAN_HOME(Y) && !_CAN_HOME(Z)) return;
   #endif
 
   if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR(">>> homeaxis(", axis_codes[axis], ")");


### PR DESCRIPTION
### Description

I configured a printer with only a Z probe and no dedicated Z min sensor. The board I am using, the SKR 1.4, has a dedicated probe port on it, so my board doesn't actually have anything plugged in for Z min. The configuration suggests that Marlin supports this, with options such as:
```
//#define USE_ZMIN_PLUG
//#define Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
#define USE_PROBE_FOR_Z_HOMING
```
However, when I tried a build configured this way, Z homing would simply do nothing. A full G28 would home X, home Y, get ready to home Z and then just stop with no further output.

I investigated, and discovered that the cause is that `homeaxis` in motion.cpp only tries to home Z if the macro `CAN_HOME_Z` is true, and `CAN_HOME_Z` is defined in a way that depends solely on the presence of a standard Z min endstop. This means that even with `USE_PROBE_FOR_Z_HOMING`, where it is only paying attention to the probe for homing purposes, it won't actually _start_ homing if there's no Z min pin.

I propose a fix for this that extends the `CAN_HOME_Z` macro in motion.cpp so that it can be true _either_ if there is a Z min pin (the old behaviour, using `_CAN_HOME(Z)`) _or_ if `USE_PROBE_FOR_Z_HOMING` is true _and_ `Z_MIN_PROBE_PIN` is set _and_ the home direction is toward the probe.

This change is working for my local build customized to my printer.

### Benefits

This means that you don't have to tell Marlin that something is plugged into Z min only to use something else for Z homing.

### Related Issues

None that I know of.
