### PR TITLE
MBL EEPROM Change

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1231,6 +1231,12 @@
 //#define RESTORE_LEVELING_AFTER_G28
 
 /**
+ * Normally rebooting disables mesh leveling. Enable this option to
+ * allow M500 (store EEPROM) to save the prior leveling state for reboot.
+ */
+//#define RESTORE_MESH_LEVELING_AFTER_BOOT
+
+/**
  * Enable detailed logging of G28, G29, M48, etc.
  * Turn on with the command 'M111 S32'.
  * NOTE: Requires a lot of PROGMEM!

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -188,6 +188,7 @@ typedef struct SettingsDataStruct {
   //
   // MESH_BED_LEVELING
   //
+  bool mbl_active;
   float mbl_z_offset;                                   // mbl.z_offset
   uint8_t mesh_num_x, mesh_num_y;                       // GRID_MAX_POINTS_X, GRID_MAX_POINTS_Y
   float mbl_z_values[TERN(MESH_BED_LEVELING, GRID_MAX_POINTS_X, 3)]   // mbl.z_values
@@ -620,6 +621,18 @@ void MarlinSettings::postprocess() {
     {
       const float zfh = TERN(ENABLE_LEVELING_FADE_HEIGHT, planner.z_fade_height, 10.0f);
       EEPROM_WRITE(zfh);
+    }
+
+    //
+    // RESTORE_MESH_LEVELING_AFTER_BOOT
+    //
+    {
+    #if ENABLED(RESTORE_MESH_LEVELING_AFTER_BOOT)
+      const bool mbl_active = planner.leveling_active;
+    #else
+      const bool mbl_active = false;
+    #endif
+    EEPROM_WRITE(mbl_active);
     }
 
     //
@@ -1469,6 +1482,12 @@ void MarlinSettings::postprocess() {
       // Global Leveling
       //
       EEPROM_READ(TERN(ENABLE_LEVELING_FADE_HEIGHT, new_z_fade_height, dummyf));
+
+      //
+      // RESTORE_MESH_LEVELING_AFTER_BOOT
+      //
+      const bool &mbl_active = planner.leveling_active;
+      EEPROM_READ(mbl_active);
 
       //
       // Mesh (Manual) Bed Leveling


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--
We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.
-->

This pull request adds a flag `RESTORE_MESH_LEVELING_AFTER_BOOT` to Configuration.h.

It enables the state of the `planner.leveling_active` boolean to be saved to and loaded from EEPROM. Users can enable by uncommenting `// define RESTORE_MESH_LEVELING_AFTER_BOOT`.

### Benefits

<!-- What does this fix or improve? -->

This optional flag allows users who use MBL (manual mesh bed leveling) to get persistent bed leveling after each boot. 

In the latest version of bugfix-2.0, there is no way to boot with MBL active. For example, If a user creates a mesh and activates MBL, they can run M500 to save the mesh to EEPROM, but the 'leveling_active' state is not stored. This means the user is basically forced to add the M420 S1 command to each gcode file, or enable MBL by some other means after each boot.

There is also a very common misunderstanding that the flag `RESTORE_LEVELING_AFTER_G28` enables leveling before every print. This is not true. This flag only restores the leveling state to on if it was already on before the G28 command. I would like to clear up any confusion. I will aim to do this by explaining a process to keep MBL always on.

**To keep persistent, always active MBL:**
**This only works with both `RESTORE_MESH_LEVELING_AFTER_BOOT` and `RESTORE_LEVELING_AFTER_G28` flags enabled**
1. Create a mesh using preferred method (eg. G29 commands)
2. Activate MBL `M420 S1` 
3. Save to EEPROM. `M500`

This will ensure that every reboot, and every print job should have MBL active.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
Feature request:
https://github.com/MarlinFirmware/Marlin/issues/18151

Common misconception (many bug issues opened and closed on this topic):
https://github.com/MarlinFirmware/Marlin/issues/18091