### PR TITLE
Fix timing for RepRapDiscount Full Graphic Smart Controller on Melzi …

### DIFF
--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -28,7 +28,7 @@
 /**
  * Marlin release version identifier
  */
-#define SHORT_BUILD_VERSION "bugfix-2.0.x"
+//#define SHORT_BUILD_VERSION "bugfix-2.0.x"
 
 /**
  * Verbose version identifier which should contain a reference to the location

--- a/Marlin/Version.h
+++ b/Marlin/Version.h
@@ -28,7 +28,7 @@
 /**
  * Marlin release version identifier
  */
-//#define SHORT_BUILD_VERSION "bugfix-2.0.x"
+#define SHORT_BUILD_VERSION "bugfix-2.0.x"
 
 /**
  * Verbose version identifier which should contain a reference to the location

--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -180,6 +180,13 @@
         // Marlin so this can be used for BEEPER_PIN. You can use this pin
         // with M42 instead of BEEPER_PIN.
         #define BEEPER_PIN                    27
+
+        #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+          #define BOARD_ST7920_DELAY_1 DELAY_NS(0)
+          #define BOARD_ST7920_DELAY_2 DELAY_NS(188)
+          #define BOARD_ST7920_DELAY_3 DELAY_NS(0)
+        #endif
+
       #else                                       // Sanguinololu >=1.3
         #define LCD_PINS_RS                    4
         #define LCD_PINS_ENABLE               17


### PR DESCRIPTION
…V2.0 board

### Requirements

Melzi V2.0 board with RepRapDiscount Full Graphic Smart Controller.

### Description

I've got a RepRapPro Mendel Mono that was running Marlin-1.0.0 s/w. Over the years I have added a RepRapDiscount Full Graphic Smart Controller and it all worked OK.

I tried upgrading to Marlin 2.0.5.3 and selected LCD_FOR_MELZI. There was no display after this, so I tried the '#define REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER'. That sort of worked. Beeps and the encoder worked, but the display was jittery.

Plugged in the delays under the LCD_FOR_MELZI code just up the page and the display is rock solid.

### Benefits

Fixes jitter on LCD disply

### Related Issues

Well, it's a bug isn't it ?

There could be some issues. I'm not sure what the values I put in the delays actually mean. They may be too much or just on the edge. Code appears to work OK though.
