### PR TITLE
Separate line number tracking per port - fix for TFT screens

### DIFF
--- a/Marlin/src/gcode/host/M110.cpp
+++ b/Marlin/src/gcode/host/M110.cpp
@@ -27,5 +27,9 @@
  * M110: Set Current Line Number
  */
 void GcodeSuite::M110() {
-  if (parser.seenval('N')) queue.last_N = parser.value_long();
+  #if NUM_SERIAL > 1
+    if (parser.seenval('N')) queue.last_N[queue.port[queue.index_r]] = parser.value_long();
+  #else
+    if (parser.seenval('N')) queue.last_N[0] = parser.value_long();
+  #endif
 }

--- a/Marlin/src/gcode/host/M110.cpp
+++ b/Marlin/src/gcode/host/M110.cpp
@@ -27,9 +27,8 @@
  * M110: Set Current Line Number
  */
 void GcodeSuite::M110() {
-  #if NUM_SERIAL > 1
-    if (parser.seenval('N')) queue.last_N[queue.port[queue.index_r]] = parser.value_long();
-  #else
-    if (parser.seenval('N')) queue.last_N[0] = parser.value_long();
-  #endif
+
+  if (parser.seenval('N'))
+    queue.last_N[queue.command_port()] = parser.value_long();
+
 }

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -277,7 +277,7 @@ void GCodeQueue::enqueue_now_P(PGM_P const pgcode) {
  */
 void GCodeQueue::ok_to_send() {
   #if NUM_SERIAL > 1
-    const int16_t pn = port[index_r];
+    const int16_t pn = command_port();
     if (pn < 0) return;
     PORT_REDIRECT(pn);                    // Reply to the serial port that sent the command
   #endif

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -302,20 +302,15 @@ void GCodeQueue::ok_to_send() {
  * indicate that a command needs to be re-sent.
  */
 void GCodeQueue::flush_and_request_resend() {
+  const int16_t pn = command_port();
   #if NUM_SERIAL > 1
-    const int16_t pn = port[index_r];
     if (pn < 0) return;
     PORT_REDIRECT(pn);                    // Reply to the serial port that sent the command
   #endif
   SERIAL_FLUSH();
   SERIAL_ECHOPGM(STR_RESEND);
   
-  #if NUM_SERIAL > 1
-    SERIAL_ECHOLN(last_N[port[index_r]] + 1);
-  #else
-    SERIAL_ECHOLN(last_N[0] + 1);
-  #endif
-  
+  SERIAL_ECHOLN(last_N[pn] + 1);  
   ok_to_send();
 }
 
@@ -481,7 +476,7 @@ void GCodeQueue::get_serial_commands() {
             if (n2pos) npos = n2pos;
           }
 
-          long gcode_N = strtol(npos + 1, nullptr, 10);
+          const long gcode_N = strtol(npos + 1, nullptr, 10);
 
           if (gcode_N != last_N[i] + 1 && !M110)
             return gcode_line_error(PSTR(STR_ERR_LINE_NO), i);

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -35,7 +35,8 @@ public:
    * commands to Marlin, and lines will be checked for sequentiality.
    * M110 N<int> sets the current line number.
    */
-  static long last_N;
+
+  static long last_N[NUM_SERIAL];
 
   /**
    * GCode Command Queue

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -52,19 +52,20 @@ public:
 
   static char command_buffer[BUFSIZE][MAX_CMD_SIZE];
 
-  /*
+  /**
    * The port that the command was received on
    */
   #if NUM_SERIAL > 1
     static int16_t port[BUFSIZE];
-    static int16_t command_port() {
-      return (0
-        #if NUM_SERIAL > 1
-          + port[index_r]
-        #endif
-      );
-    }
   #endif
+
+  static int16_t command_port() {
+    return (0
+      #if NUM_SERIAL > 1
+        + port[index_r]
+      #endif
+    );
+  }
 
   GCodeQueue();
 

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -57,6 +57,13 @@ public:
    */
   #if NUM_SERIAL > 1
     static int16_t port[BUFSIZE];
+    static int16_t command_port() {
+      return (0
+        #if NUM_SERIAL > 1
+          + port[index_r]
+        #endif
+      );
+    }
   #endif
 
   GCodeQueue();


### PR DESCRIPTION
### Description
**Revised:** proposed fix is to track gcode line numbers separately for each port instead of globally.

Applies when using a touchscreen at the same time as Octoprint or Repetier.

It is supported to have more than one usart sharing the gcode queue provided the hosts do not interfere with each other. Line numbers were being tracked globally for all ports, so it was an issue when separate hosts sent conflicting line numbers.

### Benefits

Ability to easily use a TFT screen and octoprint/repetier or other host at the same time. Obviously the screen cannot safely issue movement and other gcode that would interfere with the print job, but monitoring commands and z-babystep or changing temperature still work fine.

Many of the available touch screens assume they are the only device connected and print from SD, or they expect to be daisy chained with their own usart or wifi. They falsely assume that the gcode line number is tracked per usart, not globally. The result is that they do not work as the user expects and a negative review is left on Amazon etc. or added to an issue tracker somewhere like Octoprint, when instead this can be accommodated with firmware.

Tested with repetier server and a BigTreeTech TFT35 screen in unified mode. This screen has enough functionality to work standalone via usart, so this is a nice upgrade over being forced to use the rotary encoder screen. Proposed change solves the same issue with other usart based screens like those from Makerbase.

### Related Issues

https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/723
