### PR TITLE
[FR] CUSTOM_USER_MENU As Submenu To Configuration Menu #18096

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2843,29 +2843,54 @@
 #endif
 
 /**
- * User-defined menu items that execute custom GCode
+ * Custom Main and Configuration Menu items that execute user-defined G-Code
  */
-//#define CUSTOM_USER_MENUS
-#if ENABLED(CUSTOM_USER_MENUS)
-  //#define CUSTOM_USER_MENU_TITLE "Custom Commands"
-  #define USER_SCRIPT_DONE "M117 User Script Done"
-  #define USER_SCRIPT_AUDIBLE_FEEDBACK
-  //#define USER_SCRIPT_RETURN  // Return to status screen after a script
+// Custom Menus, Main Menu 
+//#define CUSTOM_MENUS_MAIN
+#if ENABLED(CUSTOM_MENUS_MAIN)
+  //#define CUSTOM_MENUS_MAIN_TITLE "Custom Commands"
+  #define CUSTOM_MENUS_MAIN_SCRIPT_DONE "M117 User Script Done"
+  #define CUSTOM_MENUS_MAIN_SCRIPT_AUDIBLE_FEEDBACK
+  //#define CUSTOM_MENUS_MAIN_SCRIPT_RETURN  // Return to status screen after a script
 
-  #define USER_DESC_1 "Home & UBL Info"
-  #define USER_GCODE_1 "G28\nG29 W"
+  #define CUSTOM_MENU_MAIN_DESC_1 "Home & UBL Info"
+  #define CUSTOM_MENU_MAIN_GCODE_1 "G28\nG29 W"
 
-  #define USER_DESC_2 "Preheat for " PREHEAT_1_LABEL
-  #define USER_GCODE_2 "M140 S" STRINGIFY(PREHEAT_1_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND)
+  #define CUSTOM_MENU_MAIN_DESC_2 "Preheat for " PREHEAT_1_LABEL
+  #define CUSTOM_MENU_MAIN_GCODE_2 "M140 S" STRINGIFY(PREHEAT_1_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND)
 
-  #define USER_DESC_3 "Preheat for " PREHEAT_2_LABEL
-  #define USER_GCODE_3 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_2_TEMP_HOTEND)
+  //#define CUSTOM_MENU_MAIN_DESC_3 "Preheat for " PREHEAT_2_LABEL
+  //#define CUSTOM_MENU_MAIN_GCODE_3 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_2_TEMP_HOTEND)
 
-  #define USER_DESC_4 "Heat Bed/Home/Level"
-  #define USER_GCODE_4 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nG28\nG29"
+  //#define CUSTOM_MENU_MAIN_DESC_4 "Heat Bed/Home/Level"
+  //#define CUSTOM_MENU_MAIN_GCODE_4 "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nG28\nG29"
 
-  #define USER_DESC_5 "Home & Info"
-  #define USER_GCODE_5 "G28\nM503"
+  //#define CUSTOM_MENU_MAIN_DESC_5 "Home & Info"
+  //#define CUSTOM_MENU_MAIN_GCODE_5 "G28\nM503"
+#endif
+
+// Custom Menus, Configuration Menu
+//#define CUSTOM_MENUS_CONFIGURATION
+#if ENABLED(CUSTOM_MENUS_CONFIGURATION)
+  //#define CUSTOM_MENUS_CONFIGURATION_TITLE "Custom Commands"
+  #define CUSTOM_MENUS_CONFIGURATION_SCRIPT_DONE "M117 Wireless Script Done"
+  #define CUSTOM_MENUS_CONFIGURATION_SCRIPT_AUDIBLE_FEEDBACK
+  //#define CUSTOM_MENUS_CONFIGURATION_SCRIPT_RETURN  // Return to status screen after a script
+
+  #define CUSTOM_MENU_CONFIGURATION_DESC_1 "Wifi ON"
+  #define CUSTOM_MENU_CONFIGURATION_GCODE_1 "M118 [ESP110] WIFI-STA pwd=12345678"
+
+  #define CUSTOM_MENU_CONFIGURATION_DESC_2 "Bluetooth ON"
+  #define CUSTOM_MENU_CONFIGURATION_GCODE_2 "M118 [ESP110] BT pwd=12345678"
+
+  //#define CUSTOM_MENU_CONFIGURATION_DESC_3 "Radio OFF"
+  //#define CUSTOM_MENU_CONFIGURATION_GCODE_3 "M118 [ESP110] OFF pwd=12345678"
+
+  //#define CUSTOM_MENU_CONFIGURATION_DESC_4 "Wifi ????"
+  //#define CUSTOM_MENU_CONFIGURATION_GCODE_4 "M118 ????"
+  
+  //#define CUSTOM_MENU_CONFIGURATION_DESC_5 "Wifi ????"
+  //#define CUSTOM_MENU_CONFIGURATION_GCODE_5 "M118 ????"
 #endif
 
 /**

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -115,7 +115,8 @@ namespace Language_en {
   PROGMEM Language_Str MSG_MESH_X                          = _UxGT("Index X");
   PROGMEM Language_Str MSG_MESH_Y                          = _UxGT("Index Y");
   PROGMEM Language_Str MSG_MESH_EDIT_Z                     = _UxGT("Z Value");
-  PROGMEM Language_Str MSG_USER_MENU                       = _UxGT("Custom Commands");
+  PROGMEM Language_Str MSG_CUSTOM_MENUS_MAIN               = _UxGT("Custom Commands");
+  PROGMEM Language_Str MSG_CUSTOM_MENUS_CONFIGURATION      = _UxGT("Custom Commands"); 
   PROGMEM Language_Str MSG_M48_TEST                        = _UxGT("M48 Probe Test");
   PROGMEM Language_Str MSG_M48_POINT                       = _UxGT("M48 Point");
   PROGMEM Language_Str MSG_M48_DEVIATION                   = _UxGT("Deviation");

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -323,13 +323,25 @@ void menu_configuration() {
   START_MENU();
   BACK_ITEM(MSG_MAIN);
 
+  #if ENABLED(CUSTOM_MENUS_CONFIGURATION)
+    void custom_menus_configuration();
+  #endif
+  
   //
   // Debug Menu when certain options are enabled
   //
   #if HAS_DEBUG_MENU
     SUBMENU(MSG_DEBUG_MENU, menu_debug);
   #endif
-
+  
+  #if ENABLED(CUSTOM_MENUS_CONFIGURATION)
+    #ifdef CUSTOM_MENUS_CONFIGURATION_TITLE
+      SUBMENU_P(PSTR(CUSTOM_MENUS_CONFIGURATION_TITLE), custom_menus_configuration);
+    #else
+      SUBMENU(MSG_CUSTOM_MENUS_CONFIGURATION, custom_menus_configuration);
+    #endif
+  #endif
+  
   SUBMENU(MSG_ADVANCED_SETTINGS, menu_advanced_settings);
 
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)

--- a/Marlin/src/lcd/menu/menu_custom.cpp
+++ b/Marlin/src/lcd/menu/menu_custom.cpp
@@ -21,113 +21,211 @@
  */
 
 //
-// Custom User Menu
+// Custom Menus
 //
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if HAS_LCD_MENU && ENABLED(CUSTOM_USER_MENUS)
+#if HAS_LCD_MENU && ( ENABLED(CUSTOM_MENUS_MAIN) || ENABLED(CUSTOM_MENUS_CONFIGURATION) )
 
 #include "menu.h"
 #include "../../gcode/queue.h"
 
-#ifdef USER_SCRIPT_DONE
-  #define _DONE_SCRIPT "\n" USER_SCRIPT_DONE
+#ifdef CUSTOM_MENU_MAIN_SCRIPT_DONE
+  #define _DONE_SCRIPT "\n" CUSTOM_MENU_MAIN_SCRIPT_DONE
 #else
   #define _DONE_SCRIPT ""
 #endif
 
-void _lcd_user_gcode(PGM_P const cmd) {
+#ifdef CUSTOM_MENUS_CONFIGURATION_SCRIPT_DONE
+  #define _DONE_SCRIPT "\n" CUSTOM_MENUS_CONFIGURATION_SCRIPT_DONE
+#else
+  #define _DONE_SCRIPT ""
+#endif
+
+void _lcd_custom_menu_main_gcode(PGM_P const cmd) {
   queue.inject_P(cmd);
-  #if ENABLED(USER_SCRIPT_AUDIBLE_FEEDBACK) && HAS_BUZZER
+  #if ENABLED(CUSTOM_MENU_MAIN_SCRIPT_AUDIBLE_FEEDBACK) && HAS_BUZZER
     ui.completion_feedback();
   #endif
-  #if ENABLED(USER_SCRIPT_RETURN)
+  #if ENABLED(CUSTOM_MENU_MAIN_SCRIPT_RETURN)
     ui.return_to_status();
   #endif
 }
 
-void menu_user() {
+void _lcd_custom_menus_configuration_gcode(PGM_P const cmd) {
+  queue.inject_P(cmd);
+  #if ENABLED(CUSTOM_MENUS_CONFIGURATION_SCRIPT_AUDIBLE_FEEDBACK) && HAS_BUZZER
+    ui.completion_feedback();
+  #endif
+  #if ENABLED(CUSTOM_MENUS_CONFIGURATION_SCRIPT_RETURN)
+    ui.return_to_status();
+  #endif
+
+void custom_menus_main() {
   START_MENU();
   BACK_ITEM(MSG_MAIN);
-  #define HAS_USER_ITEM(N) (defined(USER_DESC_##N) && defined(USER_GCODE_##N))
-  #define USER_ITEM(N) ACTION_ITEM_P(PSTR(USER_DESC_##N), []{ _lcd_user_gcode(PSTR(USER_GCODE_##N _DONE_SCRIPT)); });
-  #if HAS_USER_ITEM(1)
-    USER_ITEM(1);
+  #define HAS_CUSTOM_MENU_ITEM(N) (defined(CUSTOM_MENU_MAIN_DESC_##N) && defined(CUSTOM_MENU_MAIN_GCODE_##N))
+  #define CUSTOM_MENU_ITEM(N) ACTION_ITEM_P(PSTR(CUSTOM_MENU_MAIN_DESC_##N), []{ _lcd_custom_menu_main_gcode(PSTR(CUSTOM_MENU_MAIN_GCODE_##N _DONE_SCRIPT)); });
+  #if HAS_CUSTOM_MENU_ITEM(1)
+    CUSTOM_MENU_ITEM(1);
   #endif
-  #if HAS_USER_ITEM(2)
-    USER_ITEM(2);
+  #if HAS_CUSTOM_MENU_ITEM(2)
+    CUSTOM_MENU_ITEM(2);
   #endif
-  #if HAS_USER_ITEM(3)
-    USER_ITEM(3);
+  #if HAS_CUSTOM_MENU_ITEM(3)
+    CUSTOM_MENU_ITEM(3);
   #endif
-  #if HAS_USER_ITEM(4)
-    USER_ITEM(4);
+  #if HAS_CUSTOM_MENU_ITEM(4)
+    CUSTOM_MENU_ITEM(4);
   #endif
-  #if HAS_USER_ITEM(5)
-    USER_ITEM(5);
+  #if HAS_CUSTOM_MENU_ITEM(5)
+    CUSTOM_MENU_ITEM(5);
   #endif
-  #if HAS_USER_ITEM(6)
-    USER_ITEM(6);
+  #if HAS_CUSTOM_MENU_ITEM(6)
+    CUSTOM_MENU_ITEM(6);
   #endif
-  #if HAS_USER_ITEM(7)
-    USER_ITEM(7);
+  #if HAS_CUSTOM_MENU_ITEM(7)
+    CUSTOM_MENU_ITEM(7);
   #endif
-  #if HAS_USER_ITEM(8)
-    USER_ITEM(8);
+  #if HAS_CUSTOM_MENU_ITEM(8)
+    CUSTOM_MENU_ITEM(8);
   #endif
-  #if HAS_USER_ITEM(9)
-    USER_ITEM(9);
+  #if HAS_CUSTOM_MENU_ITEM(9)
+    CUSTOM_MENU_ITEM(9);
   #endif
-  #if HAS_USER_ITEM(10)
-    USER_ITEM(10);
+  #if HAS_CUSTOM_MENU_ITEM(10)
+    CUSTOM_MENU_ITEM(10);
   #endif
-  #if HAS_USER_ITEM(11)
-    USER_ITEM(11);
+  #if HAS_CUSTOM_MENU_ITEM(11)
+    CUSTOM_MENU_ITEM(11);
   #endif
-  #if HAS_USER_ITEM(12)
-    USER_ITEM(12);
+  #if HAS_CUSTOM_MENU_ITEM(12)
+    CUSTOM_MENU_ITEM(12);
   #endif
-  #if HAS_USER_ITEM(13)
-    USER_ITEM(13);
+  #if HAS_CUSTOM_MENU_ITEM(13)
+    CUSTOM_MENU_ITEM(13);
   #endif
-  #if HAS_USER_ITEM(14)
-    USER_ITEM(14);
+  #if HAS_CUSTOM_MENU_ITEM(14)
+    CUSTOM_MENU_ITEM(14);
   #endif
-  #if HAS_USER_ITEM(15)
-    USER_ITEM(15);
+  #if HAS_CUSTOM_MENU_ITEM(15)
+    CUSTOM_MENU_ITEM(15);
   #endif
-  #if HAS_USER_ITEM(16)
-    USER_ITEM(16);
+  #if HAS_CUSTOM_MENU_ITEM(16)
+    CUSTOM_MENU_ITEM(16);
   #endif
-  #if HAS_USER_ITEM(17)
-    USER_ITEM(17);
+  #if HAS_CUSTOM_MENU_ITEM(17)
+    CUSTOM_MENU_ITEM(17);
   #endif
-  #if HAS_USER_ITEM(18)
-    USER_ITEM(18);
+  #if HAS_CUSTOM_MENU_ITEM(18)
+    CUSTOM_MENU_ITEM(18);
   #endif
-  #if HAS_USER_ITEM(19)
-    USER_ITEM(19);
+  #if HAS_CUSTOM_MENU_ITEM(19)
+    CUSTOM_MENU_ITEM(19);
   #endif
-  #if HAS_USER_ITEM(20)
-    USER_ITEM(20);
+  #if HAS_CUSTOM_MENU_ITEM(20)
+    CUSTOM_MENU_ITEM(20);
   #endif
-  #if HAS_USER_ITEM(21)
-    USER_ITEM(21);
+  #if HAS_CUSTOM_MENU_ITEM(21)
+    CUSTOM_MENU_ITEM(21);
   #endif
-  #if HAS_USER_ITEM(22)
-    USER_ITEM(22);
+  #if HAS_CUSTOM_MENU_ITEM(22)
+    CUSTOM_MENU_ITEM(22);
   #endif
-  #if HAS_USER_ITEM(23)
-    USER_ITEM(23);
+  #if HAS_CUSTOM_MENU_ITEM(23)
+    CUSTOM_MENU_ITEM(23);
   #endif
-  #if HAS_USER_ITEM(24)
-    USER_ITEM(24);
+  #if HAS_CUSTOM_MENU_ITEM(24)
+    CUSTOM_MENU_ITEM(24);
   #endif
-  #if HAS_USER_ITEM(25)
-    USER_ITEM(25);
+  #if HAS_CUSTOM_MENU_ITEM(25)
+    CUSTOM_MENU_ITEM(25);
   #endif
   END_MENU();
 }
 
-#endif // HAS_LCD_MENU && CUSTOM_USER_MENUS
+void custom_menus_configuration() {
+  START_MENU();
+  BACK_ITEM(MSG_MAIN);
+  #define HAS_CUSTOM_MENU_ITEM(N) (defined(CUSTOM_MENU_CONFIGURATION_DESC_##N) && defined(CUSTOM_MENU_CONFIGURATION_GCODE_##N))
+  #define CUSTOM_MENU_ITEM(N) ACTION_ITEM_P(PSTR(CUSTOM_MENU_CONFIGURATION_DESC_##N), []{ _lcd_custom_menus_configuration_gcode(PSTR(CUSTOM_MENU_CONFIGURATION_GCODE_##N _DONE_SCRIPT)); });
+  #if HAS_CUSTOM_MENU_ITEM(1)
+    CUSTOM_MENU_ITEM(1);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(2)
+    CUSTOM_MENU_ITEM(2);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(3)
+    CUSTOM_MENU_ITEM(3);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(4)
+    CUSTOM_MENU_ITEM(4);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(5)
+    CUSTOM_MENU_ITEM(5);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(6)
+    CUSTOM_MENU_ITEM(6);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(7)
+    CUSTOM_MENU_ITEM(7);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(8)
+    CUSTOM_MENU_ITEM(8);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(9)
+    CUSTOM_MENU_ITEM(9);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(10)
+    CUSTOM_MENU_ITEM(10);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(11)
+    CUSTOM_MENU_ITEM(11);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(12)
+    CUSTOM_MENU_ITEM(12);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(13)
+    CUSTOM_MENU_ITEM(13);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(14)
+    CUSTOM_MENU_ITEM(14);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(15)
+    CUSTOM_MENU_ITEM(15);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(16)
+    CUSTOM_MENU_ITEM(16);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(17)
+    CUSTOM_MENU_ITEM(17);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(18)
+    CUSTOM_MENU_ITEM(18);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(19)
+    CUSTOM_MENU_ITEM(19);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(20)
+    CUSTOM_MENU_ITEM(20);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(21)
+    CUSTOM_MENU_ITEM(21);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(22)
+    CUSTOM_MENU_ITEM(22);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(23)
+    CUSTOM_MENU_ITEM(23);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(24)
+    CUSTOM_MENU_ITEM(24);
+  #endif
+  #if HAS_CUSTOM_MENU_ITEM(25)
+    CUSTOM_MENU_ITEM(25);
+  #endif
+  END_MENU();
+}
+
+#endif // HAS_LCD_MENU && (  CUSTOM_MENUS_MAIN || CUSTOM_MENUS_CONFIGURATION )

--- a/Marlin/src/lcd/menu/menu_custom.cpp
+++ b/Marlin/src/lcd/menu/menu_custom.cpp
@@ -61,6 +61,7 @@ void _lcd_custom_menus_configuration_gcode(PGM_P const cmd) {
   #if ENABLED(CUSTOM_MENUS_CONFIGURATION_SCRIPT_RETURN)
     ui.return_to_status();
   #endif
+}
 
 void custom_menus_main() {
   START_MENU();

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -51,8 +51,8 @@ void menu_motion();
 void menu_temperature();
 void menu_configuration();
 
-#if ENABLED(CUSTOM_USER_MENUS)
-  void menu_user();
+#if ENABLED(CUSTOM_MENUS_MAIN)
+  void custom_menus_main();
 #endif
 
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
@@ -164,14 +164,14 @@ void menu_main() {
 
   SUBMENU(MSG_CONFIGURATION, menu_configuration);
 
-  #if ENABLED(CUSTOM_USER_MENUS)
-    #ifdef CUSTOM_USER_MENU_TITLE
-      SUBMENU_P(PSTR(CUSTOM_USER_MENU_TITLE), menu_user);
+  #if ENABLED(CUSTOM_MENUS_MAIN)
+    #ifdef CUSTOM_MENUS_MAIN_TITLE
+      SUBMENU_P(PSTR(CUSTOM_MENUS_MAIN_TITLE), custom_menus_main);
     #else
-      SUBMENU(MSG_USER_MENU, menu_user);
+      SUBMENU(MSG_CUSTOM_MENUS_MAIN, custom_menus_main);
     #endif
   #endif
-
+  
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     #if E_STEPPERS == 1 && DISABLED(FILAMENT_LOAD_UNLOAD_GCODES)
       if (thermalManager.targetHotEnoughToExtrude(active_extruder))


### PR DESCRIPTION
Proposed PR adds option for user defined g-code script custom menus in Configuration Menu.
See Issue #18096

[https://github.com/MarlinFirmware/Marlin/issues/18096]

### Requirements

For peripheral hardware that can be configured by G-code (e.g., a Wireless Serial WiFi/Bluetooth Radio), placing Custom Menus in the Main Menu seems awkward and can cause menu clutter.  

### Description

This proposed change provides for placing Custom user defined g-code menus in the Configuration Menu.

### Benefits

Less menu clutter. Places less used menus further inside menu tree.