### PR TITLE
Fix meeb 3dp board SoftwareSerialM lib dep

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -297,7 +297,7 @@ build_flags       = ${common_stm32f1.build_flags}
                     -DGENERIC_BOOTLOADER
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/STM32F103RC_MEEB_3DP_create_variant.py
     buildroot/share/PlatformIO/scripts/STM32F103RC_MEEB_3DP.py
-lib_deps          = ${common.lib_deps}
+lib_deps          = ${common_stm32f1.lib_deps}
     USBComposite for STM32F1@==0.91
     Adafruit NeoPixel=https://github.com/ccccmagicboy/Adafruit_NeoPixel#meeb_3dp_use
 lib_ignore        = SPI, LiquidCrystal


### PR DESCRIPTION
### Description

Although successful compile the source code for meeb 3dp board, there is something wrong on my printer after load the firmware.
Checked the building log and confirm that the lib SoftwareSerialM is missing.
```
/home/runner/work/MEEB_3DP/MEEB_3DP/my_marlin/.pio/libdeps/STM32F103RC_cc_meeb_3dp/TMCStepper_ID5513/src/source/TMC2208Stepper.cpp:191: warning: undefined reference to `SoftwareSerial::read()'
/home/runner/work/MEEB_3DP/MEEB_3DP/my_marlin/.pio/libdeps/STM32F103RC_cc_meeb_3dp/TMCStepper_ID5513/src/source/TMC2208Stepper.cpp:207: warning: undefined reference to `SoftwareSerial::available()'
/home/runner/work/MEEB_3DP/MEEB_3DP/my_marlin/.pio/libdeps/STM32F103RC_cc_meeb_3dp/TMCStepper_ID5513/src/source/TMC2208Stepper.cpp:207: warning: undefined reference to `SoftwareSerial::read()'
/home/runner/work/MEEB_3DP/MEEB_3DP/my_marlin/.pio/libdeps/STM32F103RC_cc_meeb_3dp/TMCStepper_ID5513/src/source/TMC2208Stepper.cpp:224: warning: undefined reference to `SoftwareSerial::stopListening()'
Checking size .pio/build/STM32F103RC_cc_meeb_3dp/firmware.elf
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [=====     ]  48.3% (used 23760 bytes from 49152 bytes)
Flash: [=====     ]  52.4% (used 274748 bytes from 524288 bytes)
Building .pio/build/STM32F103RC_cc_meeb_3dp/firmware.bin
======================== [SUCCESS] Took 100.99 seconds ========================

```

![Snipaste_2020-06-02_13-15-55](https://user-images.githubusercontent.com/4132539/83484046-9e0f9780-a4d6-11ea-9686-5269e93776cd.jpg)

