### PR TITLE
fix issue #18169 Insufficient digits displayed in spindle RPM 

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -542,7 +542,7 @@ void MarlinUI::draw_status_screen() {
     // Laser / Spindle
     #if DO_DRAW_CUTTER
       if (cutter.power && PAGE_CONTAINS(STATUS_CUTTER_TEXT_Y - INFO_FONT_ASCENT, STATUS_CUTTER_TEXT_Y - 1)) {
-        lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, i16tostr3rj(cutter.power));
+        lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, i16tostr5rj(cutter.power));
         #if CUTTER_DISPLAY_IS(PERCENT)
           lcd_put_wchar('%');
         #elif CUTTER_DISPLAY_IS(RPM)

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -542,10 +542,11 @@ void MarlinUI::draw_status_screen() {
     // Laser / Spindle
     #if DO_DRAW_CUTTER
       if (cutter.power && PAGE_CONTAINS(STATUS_CUTTER_TEXT_Y - INFO_FONT_ASCENT, STATUS_CUTTER_TEXT_Y - 1)) {
-        lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, i16tostr5rj(cutter.power));
-        #if CUTTER_DISPLAY_IS(PERCENT)
+        #if CUTTER_DISPLAY_IS(PERCENT) || CUTTER_DISPLAY_IS(PWM)
+          lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, i16tostr3rj(cutter.power));
           lcd_put_wchar('%');
         #elif CUTTER_DISPLAY_IS(RPM)
+          lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, i16tostr5rj(cutter.power));
           lcd_put_wchar('K');
         #endif
       }

--- a/Marlin/src/libs/numtostr.cpp
+++ b/Marlin/src/libs/numtostr.cpp
@@ -114,6 +114,27 @@ const char* ui16tostr3rj(const uint16_t xx) {
   return &conv[4];
 }
 
+// Convert signed 16bit int to rj string with 12345 or -1234 format
+const char* i16tostr5rj(const int16_t x) {
+  int xx = x;
+  conv[2] = MINUSOR(xx, RJDIGIT(xx, 10000));
+  conv[3] = RJDIGIT(xx, 1000);
+  conv[4] = RJDIGIT(xx, 100);
+  conv[5] = RJDIGIT(xx, 10);
+  conv[6] = DIGIMOD(xx, 1);
+  return &conv[2];
+}
+
+// Convert signed 16bit int to rj string with 1234 or -123 format
+const char* i16tostr4rj(const int16_t x) {
+  int xx = x;
+  conv[3] = MINUSOR(xx, RJDIGIT(xx, 1000));
+  conv[4] = RJDIGIT(xx, 100);
+  conv[5] = RJDIGIT(xx, 10);
+  conv[6] = DIGIMOD(xx, 1);
+  return &conv[3];
+}
+
 // Convert signed 16bit int to rj string with 123 or -12 format
 const char* i16tostr3rj(const int16_t x) {
   int xx = x;

--- a/Marlin/src/libs/numtostr.h
+++ b/Marlin/src/libs/numtostr.h
@@ -46,6 +46,12 @@ const char* ui16tostr4rj(const uint16_t x);
 // Convert uint16_t to string with 123 format
 const char* ui16tostr3rj(const uint16_t x);
 
+// Convert signed 16bit int to rj string with 12345 or -1234 format
+const char* i16tostr5rj(const int16_t x);
+
+// Convert signed 16bit int to rj string with 1234 or -123 format
+const char* i16tostr4rj(const int16_t x);
+
 // Convert int16_t to string with 123 format
 const char* i16tostr3rj(const int16_t x);
 


### PR DESCRIPTION
NB. At this time it still needs tested 

### Requirements

A 12864 display, and a spindle enabled.

### Description

RPM value limited to 3 digits. 5 are required.
Added i16tostr5rj and i16tostr4rj so display size can be increased.

### Benefits

Displays correct RPM

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/18169

