### PR TITLE
Fix G34 Z_STEPPER_AUTO_ALIGN is sometimes moving steppers in wrong direction

### DIFF
--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -299,8 +299,8 @@ void GcodeSuite::G34() {
             adjustment_reverse = !adjustment_reverse;
           }
 
-          // Remember the alignment for the next iteration
-          // but only if we do any stepper move otherwise it would be just zero (in case this stepper was at z_measured_min already)
+          // Remember the alignment for the next iteration, but only if steppers move,
+          // otherwise it would be just zero (in case this stepper was at z_measured_min already)
           if (z_align_abs > 0) last_z_align_move[zstepper] = z_align_abs;
         #endif
 

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -294,11 +294,14 @@ void GcodeSuite::G34() {
           // Check for less accuracy compared to last move
           if (last_z_align_move[zstepper] < z_align_abs * 0.7f) {
             SERIAL_ECHOLNPGM("Decreasing accuracy detected.");
+            if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", int(zstepper + 1), " last_z_align_move = ", last_z_align_move[zstepper]);
+            if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", int(zstepper + 1), " z_align_abs = ", z_align_abs);
             adjustment_reverse = !adjustment_reverse;
           }
 
           // Remember the alignment for the next iteration
-          last_z_align_move[zstepper] = z_align_abs;
+          // but only if we do any stepper move otherwise it would be just zero (in case this stepper was at z_measured_min already)
+          if (z_align_abs > 0) last_z_align_move[zstepper] = z_align_abs;
         #endif
 
         // Stop early if all measured points achieve accuracy target
@@ -312,8 +315,10 @@ void GcodeSuite::G34() {
         #if DISABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
           // Decreasing accuracy was detected so move was inverted.
           // Will match reversed Z steppers on dual steppers. Triple will need more work to map.
-          if (adjustment_reverse)
+          if (adjustment_reverse) {
             z_align_move = -z_align_move;
+            if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", int(zstepper + 1), " correction reversed to ", z_align_move);
+          }
         #endif
 
         // Do a move to correct part of the misalignment for the current stepper


### PR DESCRIPTION
### Requirements

`Z_STEPPER_AUTO_ALIGN` enabled
`Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS` disabled

### Description

As per current code, one stepper will always be at **`z_measured_min`** and therefore not be corrected (**`z_measured[zstepper]`** and **`z_measured_min`** are the same). This leads to **`z_align_move = 0`** and therefore no correction for this stepper. However the zero correction (**`z_align_move = 0`**) is stored per stepper in **`last_z_align_move[zstepper]`**.

IMHO the alignment (correction move of the related stepper; **z_align_move**) should only be stored for the next iteration if the related stepper was actually moved. Otherwise **last_z_align_move[zstepper]** will be 0 (zero) (because z_align_abs was 0 (zero) and this leads to reversed adjustments in the next iteration due to

```cpp
// Check for less accuracy compared to last move
if (last_z_align_move[zstepper] < z_align_abs * 0.7f) {
  SERIAL_ECHOLNPGM("Decreasing accuracy detected.");
  adjustment_reverse = !adjustment_reverse;
}

....
....

if (adjustment_reverse)
  z_align_move = -z_align_move;
```

This PR was tested with `Z_STEPPER_AUTO_ALIGN` on Z1 and Z2. I did no testing with Z3 or Z4 because I only have Z1 and Z2. So it might need more testing ;-)

### Benefits

`Z_STEPPER_AUTO_ALIGN` is working correctly

### Related Issues

#18161