### PR TITLE
Fix insufficient digits displayed in spindle RPM

### DIFF
--- a/Marlin/src/feature/spindle_laser_types.h
+++ b/Marlin/src/feature/spindle_laser_types.h
@@ -38,10 +38,12 @@
   #define cutter_power_t              uint16_t
   #define cutter_setPower_t           uint16_t
   #define CUTTER_MENU_POWER_TYPE      uint16_5
+  #define cutter_power2str            ui16tostr5rj
 #else
   #define cutter_power_t              uint8_t
   #define cutter_setPower_t           uint8_t
   #define CUTTER_MENU_POWER_TYPE      uint8
+  #define cutter_power2str            ui8tostr3rj
 #endif
 
 #if ENABLED(MARLIN_DEV_MODE)

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -542,7 +542,7 @@ void MarlinUI::draw_status_screen() {
     // Laser / Spindle
     #if DO_DRAW_CUTTER
       if (cutter.power && PAGE_CONTAINS(STATUS_CUTTER_TEXT_Y - INFO_FONT_ASCENT, STATUS_CUTTER_TEXT_Y - 1)) {
-        lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, i16tostr3rj(cutter.power));
+        lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, cutter_power2str(cutter.power));
         #if CUTTER_DISPLAY_IS(PERCENT)
           lcd_put_wchar('%');
         #elif CUTTER_DISPLAY_IS(RPM)


### PR DESCRIPTION
This should fix #18169
I changed old `i16tostr3rj` to `ui8tostr3rj` to reflect real variable type. Don't know if it's ok

To be tested