### PR TITLE
revert Mightyboard envs to MegaCore board variants

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -94,7 +94,7 @@ board         = megaatmega1280
 [env:MightyBoard1280]
 platform      = atmelavr
 extends       = common_avr8
-board         = megaatmega1280
+board         = ATmega1280
 upload_speed  = 57600
 
 #
@@ -103,7 +103,7 @@ upload_speed  = 57600
 [env:MightyBoard2560]
 platform      = atmelavr
 extends       = common_avr8
-board         = megaatmega2560
+board         = ATmega2560
 upload_protocol = wiring
 upload_speed  = 57600
 board_upload.maximum_size = 253952


### PR DESCRIPTION
Revert to the MegaCore board variants because the Arduino versions don't support some of the required pins

_Edit: Correction of library name_