### PR TITLE
Fix Incorrect display of spindle speed for issue #18169

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -545,9 +545,11 @@ void MarlinUI::draw_status_screen() {
         #if CUTTER_DISPLAY_IS(PERCENT)
           lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr3rj(cutter.power));
           lcd_put_wchar('%');
+        #elif CUTTER_DISPLAY_IS(PWM)
+          lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr3rj(cutter.power));
         #elif CUTTER_DISPLAY_IS(RPM)
           lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr5rj(cutter.power));
-          //lcd_put_wchar('K');    //does "K" effectively indicate RPM? And is it necessary or helpful?
+          lcd_put_wchar('K');
         #endif
       }
     #endif

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -545,7 +545,7 @@ void MarlinUI::draw_status_screen() {
         #if CUTTER_DISPLAY_IS(PERCENT)
           lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr3rj(cutter.power));
           lcd_put_wchar('%');
-        #elif CUTTER_DISPLAY_IS(PWM)
+        #elif CUTTER_DISPLAY_IS(PWM255)
           lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr3rj(cutter.power));
         #elif CUTTER_DISPLAY_IS(RPM)
           lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr5rj(cutter.power));

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -542,11 +542,12 @@ void MarlinUI::draw_status_screen() {
     // Laser / Spindle
     #if DO_DRAW_CUTTER
       if (cutter.power && PAGE_CONTAINS(STATUS_CUTTER_TEXT_Y - INFO_FONT_ASCENT, STATUS_CUTTER_TEXT_Y - 1)) {
-        lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, i16tostr3rj(cutter.power));
         #if CUTTER_DISPLAY_IS(PERCENT)
+          lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr3rj(cutter.power));  //should i16tostr3rj be ui16tostr3rj to match the RPM case?
           lcd_put_wchar('%');
         #elif CUTTER_DISPLAY_IS(RPM)
-          lcd_put_wchar('K');
+          lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr5rj(cutter.power));
+          //lcd_put_wchar('K');    //does "K" effectively indicate RPM? And is it necessary or helpful?
         #endif
       }
     #endif

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -543,7 +543,7 @@ void MarlinUI::draw_status_screen() {
     #if DO_DRAW_CUTTER
       if (cutter.power && PAGE_CONTAINS(STATUS_CUTTER_TEXT_Y - INFO_FONT_ASCENT, STATUS_CUTTER_TEXT_Y - 1)) {
         #if CUTTER_DISPLAY_IS(PERCENT)
-          lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr3rj(cutter.power));  //should i16tostr3rj be ui16tostr3rj to match the RPM case?
+          lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr3rj(cutter.power));
           lcd_put_wchar('%');
         #elif CUTTER_DISPLAY_IS(RPM)
           lcd_put_u8str(STATUS_CUTTER_TEXT_X, STATUS_CUTTER_TEXT_Y, ui16tostr5rj(cutter.power));


### PR DESCRIPTION
### Requirements

A 12864 display such as the "Reprap Discount Full Graphic Smart Controller", and a spindle enabled.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Fixes the issue with significant digits being truncated from the spindle speed readout, fixing issue #18169 

This fix has been tested, and verified to work with no issues, solving the problem.
### Related Issues

This fix is equivalent to #18189 but has been thoroughly tested and verified to work. 

Honestly, I'm sick of recompiling Marlin to thoroughly test various suggested fixes (recompiling takes a long time on my computer), and I spent a long time losing sleep to to help test #18184 (which didn't work, and inexplicably broke lots of other things) when I had a working fix already (this PR), so if the style of code implemented in #18189 is considered preferable, I don't mind it being accepted instead of this one, but someone else will need to do (at least most of) the testing for it, I'm burnt out of being the guinea pig for this particular issue. 
