### PR TITLE
Z-Homing with BLTouch

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -52,9 +52,15 @@
 //
 #define X_MIN_PIN                           PF2
 #define X_MAX_PIN                           PG14
+
 #define Y_MIN_PIN                           PC13
 #define Y_MAX_PIN                           PG9
-#define Z_MIN_PIN                           PE0
+
+#if ENABLED(TP) && defined(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+  #define Z_MIN_PIN                         PH11 //PE0
+#else
+  #define Z_MIN_PIN                         PE0
+#endif
 #define Z_MAX_PIN                           PD3
 
 //


### PR DESCRIPTION
### Requirements

BLTouch or other probe on BLTouch header

### Description

This way you don't have to manual change the pin definition when using a BLTouch as z-endstop

### Benefits

This way you don't have to manual change the pin definition when using a BLTouch as z-endstop

### Related Issues

No issue, only improvement