### PR TITLE
Fix BTT SKR Pro 1.0 UART4/5

### DIFF
--- a/Marlin/src/HAL/STM32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSerial.cpp
@@ -26,6 +26,14 @@
   #include "../../feature/e_parser.h"
 #endif
 
+#ifndef USART4
+#define USART4 UART4
+#endif
+
+#ifndef USART5
+#define USART5 UART5
+#endif
+
 #define DECLARE_SERIAL_PORT(ser_num) \
   void _rx_complete_irq_ ## ser_num (serial_t * obj); \
   MarlinSerial MSerial ## ser_num (USART ## ser_num, &_rx_complete_irq_ ## ser_num); \

--- a/Marlin/src/HAL/STM32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSerial.cpp
@@ -27,11 +27,11 @@
 #endif
 
 #ifndef USART4
-#define USART4 UART4
+  #define USART4 UART4
 #endif
 
 #ifndef USART5
-#define USART5 UART5
+  #define USART5 UART5
 #endif
 
 #define DECLARE_SERIAL_PORT(ser_num) \


### PR DESCRIPTION
### Description

Those ports are defined in the framework as UARTx, not as USARTx.
As a result, Marlin failed to build if port 4 or 5 was used
(for instance, on BTT SKR Pro v1.0 port 5 is used for BTT ESP01 WiFi
module).

Signed-off-by: Alexander Amelkin <alexander@amelkin.msk.ru>

### Benefits

Allows for using UART4 and UART5 on STM32-based boards

### Related Issues

None
