### PR TITLE
Fixes #16672 SDIO read errors

### DIFF
--- a/Marlin/src/HAL/STM32F1/sdio.cpp
+++ b/Marlin/src/HAL/STM32F1/sdio.cpp
@@ -120,7 +120,7 @@ bool SDIO_ReadBlock_DMA(uint32_t blockAddress, uint8_t *data) {
 }
 
 bool SDIO_ReadBlock(uint32_t blockAddress, uint8_t *data) {
-  uint32_t retries = 3;
+  uint32_t retries = SDIO_READ_RETRIES;
   while (retries--) if (SDIO_ReadBlock_DMA(blockAddress, data)) return true;
   return false;
 }

--- a/Marlin/src/HAL/STM32F1/sdio.h
+++ b/Marlin/src/HAL/STM32F1/sdio.h
@@ -100,7 +100,13 @@
 #define SDIO_DATA_TIMEOUT                    100U           /* Read data transfer timeout */
 #define SDIO_WRITE_TIMEOUT                   200U           /* Write data transfer timeout */
 
-#define SDIO_CLOCK                           18000000       /* 18 MHz */
+#ifndef SDIO_CLOCK
+  #define SDIO_CLOCK                           18000000       /* 18 MHz */
+#endif
+
+#ifndef SDIO_READ_RETRIES
+  #define SDIO_READ_RETRIES                     3
+#endif
 
 // ------------------------
 // Types

--- a/Marlin/src/HAL/STM32F1/sdio.h
+++ b/Marlin/src/HAL/STM32F1/sdio.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include "../shared/Marduino.h"
+#include "../../inc/MarlinConfig.h" // Allow pins/pins.h to override SDIO clock / retries
 
 #include <libmaple/sdio.h>
 #include <libmaple/dma.h>
@@ -105,7 +105,7 @@
 #endif
 
 #ifndef SDIO_READ_RETRIES
-  #define SDIO_READ_RETRIES                   3
+  #define SDIO_READ_RETRIES                  3
 #endif
 
 // ------------------------

--- a/Marlin/src/HAL/STM32F1/sdio.h
+++ b/Marlin/src/HAL/STM32F1/sdio.h
@@ -101,11 +101,11 @@
 #define SDIO_WRITE_TIMEOUT                   200U           /* Write data transfer timeout */
 
 #ifndef SDIO_CLOCK
-  #define SDIO_CLOCK                           18000000       /* 18 MHz */
+  #define SDIO_CLOCK                         18000000       /* 18 MHz */
 #endif
 
 #ifndef SDIO_READ_RETRIES
-  #define SDIO_READ_RETRIES                     3
+  #define SDIO_READ_RETRIES                   3
 #endif
 
 // ------------------------


### PR DESCRIPTION
### Description

Some boards have problems with SDIO_CLOCK and READ Retries, getting SD Read Errors very frequently (Chitu boards, for example). The original code have hardcoded values.

### Benefits

This PR just add the ability the user or the board define their on SDIO_CLOCK and READ Retries. Now Marlin can have board with different setups, yet maintaining the compatibility with the actual code.

We are using this in a future PR that will support the TronXY Chitu Boards.

Thanks.

### Related Issues

#16672

