### PR TITLE
TFT Upscale 2x,3x, .. + Anycubic and TronXY TFT Support

### DIFF
--- a/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
@@ -709,12 +709,12 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
           if (allow_async) {
             if (y > 0 || page > 1) LCD_IO_WaitSequence_Async();
             if (y == 7 && page == 8)
-              LCD_IO_WriteSequence(buffer, sizeof(bufferA)/sizeof(bufferA[0])); // last line of last page
+              LCD_IO_WriteSequence(buffer, COUNT(bufferA)); // last line of last page
             else
-              LCD_IO_WriteSequence_Async(buffer, sizeof(bufferA)/sizeof(bufferA[0]));
+              LCD_IO_WriteSequence_Async(buffer, COUNT(bufferA));
           }
           else
-            LCD_IO_WriteSequence(buffer, sizeof(bufferA)/sizeof(bufferA[0]));
+            LCD_IO_WriteSequence(buffer, COUNT(bufferA));
         #else
           uint8_t* bufptr = (uint8_t*) buffer;
           for (uint8_t i = 2; i--;) {

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
@@ -622,6 +622,7 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
           setWindow = setWindow_ili9328;
           break;
         case 0x9341:   // ILI9341
+        case 0x8066:   // ILI9341 Anycubic / TronXY TFTs      
           #ifdef LCD_USE_DMA_FSMC
             writeEscSequence(ili9341_init);
           #else

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
@@ -533,7 +533,7 @@ static const uint16_t ili9341_init[] = {
   #define BUTTON_SIZE_X 32
   #define BUTTON_SIZE_Y 20
 
-  //14, 90, 166, 242, 185 are the orignal values upscaled 2x.
+  // 14, 90, 166, 242, 185 are the original values upscaled 2x.
   #define BUTTOND_X_LO (14 / 2) * (FSMC_UPSCALE)
   #define BUTTOND_X_HI (BUTTOND_X_LO + (FSMC_UPSCALE) * BUTTON_SIZE_X - 1)
 

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
@@ -73,14 +73,18 @@
   extern void LCD_IO_WriteMultiple(uint16_t color, uint32_t count);
 #endif
 
+#ifndef FSMC_UPSCALE
+ #define FSMC_UPSCALE 2
+#endif
+
 #define WIDTH LCD_PIXEL_WIDTH
 #define HEIGHT LCD_PIXEL_HEIGHT
 #define PAGE_HEIGHT 8
 
 #define X_LO LCD_PIXEL_OFFSET_X
 #define Y_LO LCD_PIXEL_OFFSET_Y
-#define X_HI (X_LO + 2 * WIDTH  - 1)
-#define Y_HI (Y_LO + 2 * HEIGHT - 1)
+#define X_HI (X_LO + FSMC_UPSCALE * WIDTH  - 1)
+#define Y_HI (Y_LO + FSMC_UPSCALE * HEIGHT - 1)
 
 // see https://ee-programming-notepad.blogspot.com/2016/10/16-bit-color-generator-picker.html
 
@@ -526,8 +530,27 @@ static const uint16_t ili9341_init[] = {
     B01111111,B11111111,B11111111,B11111110,
   };
 
+  #define BUTTON_SIZE_X 32
+  #define BUTTON_SIZE_Y 20
+
+  //14, 90, 166, 242, 185 are the orignal values upscaled 2x.
+  #define BUTTOND_X_LO (14 / 2) * FSMC_UPSCALE
+  #define BUTTOND_X_HI (BUTTOND_X_LO + FSMC_UPSCALE * BUTTON_SIZE_X -1)
+
+  #define BUTTONA_X_LO (90 / 2) * FSMC_UPSCALE
+  #define BUTTONA_X_HI (BUTTONA_X_LO + FSMC_UPSCALE * BUTTON_SIZE_X -1)
+
+  #define BUTTONB_X_LO (166 / 2) * FSMC_UPSCALE
+  #define BUTTONB_X_HI (BUTTONB_X_LO + FSMC_UPSCALE * BUTTON_SIZE_X -1)
+
+  #define BUTTONC_X_LO (242 / 2) * FSMC_UPSCALE
+  #define BUTTONC_X_HI (BUTTONC_X_LO + FSMC_UPSCALE * BUTTON_SIZE_X -1)
+
+  #define BUTTON_Y_LO (170 / 2) * FSMC_UPSCALE
+  #define BUTTON_Y_HI (BUTTON_Y_LO + FSMC_UPSCALE * BUTTON_SIZE_Y -1)
+
   void drawImage(const uint8_t *data, u8g_t *u8g, u8g_dev_t *dev, uint16_t length, uint16_t height, uint16_t color) {
-    uint16_t buffer[128];
+    uint16_t buffer[BUTTON_SIZE_X * FSMC_UPSCALE * FSMC_UPSCALE];
 
     for (uint16_t i = 0; i < height; i++) {
       uint16_t k = 0;
@@ -537,17 +560,19 @@ static const uint16_t ili9341_init[] = {
           v = color;
         else
           v = TFT_MARLINBG_COLOR;
-        buffer[k++] = v; buffer[k++] = v;
+        for(uint8_t n=0;n<FSMC_UPSCALE;n++) {
+          buffer[k++] = v;
+        }
       }
       #ifdef LCD_USE_DMA_FSMC
-        if (k <= 80) { // generally is... for our buttons
-          memcpy(&buffer[k], &buffer[0], k * sizeof(uint16_t));
-          LCD_IO_WriteSequence(buffer, k * sizeof(uint16_t));
+        for (k = 1; k < FSMC_UPSCALE; k++) {
+          for (uint16_t l = 0; l < (length * FSMC_UPSCALE); l++)
+          {
+            buffer[l+(length * FSMC_UPSCALE * k)] = buffer[l];
+          }
         }
-        else {
-          LCD_IO_WriteSequence(buffer, k);
-          LCD_IO_WriteSequence(buffer, k);
-        }
+        
+        LCD_IO_WriteSequence(buffer, sizeof(buffer)/sizeof(buffer[0]));
       #else
         u8g_WriteSequence(u8g, dev, k << 1, (uint8_t *)buffer);
         u8g_WriteSequence(u8g, dev, k << 1, (uint8_t *)buffer);
@@ -569,7 +594,7 @@ static uint8_t page;
 uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
   u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
   #ifdef LCD_USE_DMA_FSMC
-    static uint16_t bufferA[512], bufferB[512];
+    static uint16_t bufferA[WIDTH * FSMC_UPSCALE * FSMC_UPSCALE], bufferB[WIDTH * FSMC_UPSCALE * FSMC_UPSCALE];
     uint16_t* buffer = &bufferA[0];
     bool allow_async = true;
   #else
@@ -645,16 +670,16 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
             u8g_WriteSequence(u8g, dev, 150, (uint8_t *)buffer);
         #endif
 
-        setWindow(u8g, dev, 14, 185,  77, 224);
+        setWindow(u8g, dev, BUTTOND_X_LO, BUTTON_Y_LO,  BUTTOND_X_HI, BUTTON_Y_HI);
         drawImage(buttonD, u8g, dev, 32, 20, TFT_BTCANCEL_COLOR);
 
-        setWindow(u8g, dev, 90, 185, 153, 224);
+        setWindow(u8g, dev, BUTTONA_X_LO, BUTTON_Y_LO,  BUTTONA_X_HI, BUTTON_Y_HI);
         drawImage(buttonA, u8g, dev, 32, 20, TFT_BTARROWS_COLOR);
 
-        setWindow(u8g, dev, 166, 185, 229, 224);
+        setWindow(u8g, dev, BUTTONB_X_LO, BUTTON_Y_LO,  BUTTONB_X_HI, BUTTON_Y_HI);
         drawImage(buttonB, u8g, dev, 32, 20, TFT_BTARROWS_COLOR);
 
-        setWindow(u8g, dev, 242, 185, 305, 224);
+        setWindow(u8g, dev, BUTTONC_X_LO, BUTTON_Y_LO,  BUTTONC_X_HI, BUTTON_Y_HI);
         drawImage(buttonC, u8g, dev, 32, 20, TFT_BTOKMENU_COLOR);
       #endif // TOUCH_BUTTONS
 
@@ -678,19 +703,26 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
         for (uint16_t i = 0; i < (uint32_t)pb->width; i++) {
           const uint8_t b = *(((uint8_t *)pb->buf) + i);
           const uint16_t c = TEST(b, y) ? TFT_MARLINUI_COLOR : TFT_MARLINBG_COLOR;
-          buffer[k++] = c; buffer[k++] = c;
+          for(uint8_t n = 0; n < FSMC_UPSCALE; n++) {
+            buffer[k++] = c;
+          }
         }
         #ifdef LCD_USE_DMA_FSMC
-          memcpy(&buffer[256], &buffer[0], 512);
+          for (k = 1; k < FSMC_UPSCALE; k++) {
+            for (uint16_t l = 0; l < (WIDTH * FSMC_UPSCALE); l++)
+            {
+              buffer[l+(WIDTH * FSMC_UPSCALE * k)] = buffer[l];
+            }
+          }
           if (allow_async) {
             if (y > 0 || page > 1) LCD_IO_WaitSequence_Async();
             if (y == 7 && page == 8)
-              LCD_IO_WriteSequence(buffer, 512); // last line of last page
+              LCD_IO_WriteSequence(buffer, sizeof(bufferA)/sizeof(bufferA[0])); // last line of last page
             else
-              LCD_IO_WriteSequence_Async(buffer, 512);
+              LCD_IO_WriteSequence_Async(buffer, sizeof(bufferA)/sizeof(bufferA[0]));
           }
           else
-            LCD_IO_WriteSequence(buffer, 512);
+            LCD_IO_WriteSequence(buffer, sizeof(bufferA)/sizeof(bufferA[0]));
         #else
           uint8_t* bufptr = (uint8_t*) buffer;
           for (uint8_t i = 2; i--;) {

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.h
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.h
@@ -199,10 +199,18 @@
 // LCD_FULL_PIXEL_WIDTH =
 // LCD_PIXEL_OFFSET_X + (LCD_PIXEL_WIDTH * 2) + LCD_PIXEL_OFFSET_X
 #if ENABLED(FSMC_GRAPHICAL_TFT)
-  #define LCD_FULL_PIXEL_WIDTH  320
-  #define LCD_PIXEL_OFFSET_X    32
-  #define LCD_FULL_PIXEL_HEIGHT 240
-  #define LCD_PIXEL_OFFSET_Y    32
+  #ifndef LCD_FULL_PIXEL_WIDTH
+    #define LCD_FULL_PIXEL_WIDTH  320
+  #endif
+  #ifndef LCD_PIXEL_OFFSET_X
+    #define LCD_PIXEL_OFFSET_X    32
+  #endif
+  #ifndef LCD_FULL_PIXEL_HEIGHT
+    #define LCD_FULL_PIXEL_HEIGHT 240
+  #endif
+  #ifndef LCD_PIXEL_OFFSET_Y
+    #define LCD_PIXEL_OFFSET_Y    32
+  #endif
 #endif
 
 // For selective rendering within a Y range


### PR DESCRIPTION
# Description

Some TFT have a "big" resolution of 480x320. The original code just upscale 2x. We can find a lot of forks that did the 3x upscale, but none are in the oficial marlin, neither seems to keep compatibility with the original code.

The new define: FSMC_UPSCALE. Default: 2.

Users will be allowed to change the resolution too:
```cpp
#define FSMC_UPSCALE 3
#define LCD_FULL_PIXEL_WIDTH  480
#define LCD_PIXEL_OFFSET_X    48
#define LCD_FULL_PIXEL_HEIGHT 320
```
The main goal is that: keep the original code, but support 3x scale too.

This PR also add LCD ID codes for Anycubic and TronXY TFTs.

The image show the result with FSMC_UPSCALE 2 (original) and FSMC_UPSCALE 3, in a 480x320 TFT, working in a TronXY.

![IMG_9177](https://user-images.githubusercontent.com/81722/83998784-b862ce80-a937-11ea-94c9-b08e833cae19.jpg)
![IMG_9176](https://user-images.githubusercontent.com/81722/83998785-b993fb80-a937-11ea-9c6f-cfbdc809705d.jpg)


### Benefits

More TFTs supported with a very little change in the current code.

### Related Issues

#14655 