### PR TITLE
Fix SDIO read errors #16672

### DIFF
--- a/Marlin/src/HAL/STM32F1/sdio.cpp
+++ b/Marlin/src/HAL/STM32F1/sdio.cpp
@@ -101,19 +101,19 @@ bool SDIO_ReadBlock_DMA(uint32_t blockAddress, uint8_t *data) {
     return false;
   }
 
-  while (!SDIO_GET_FLAG(SDIO_STA_DATAEND | SDIO_STA_TRX_ERROR_FLAGS)) {}
+  while (!SDIO_GET_FLAG(SDIO_STA_DATAEND | SDIO_STA_TRX_ERROR_FLAGS)) { /* wait */ }
   
   //If there were SDIO errors, do not wait DMA.
-  if(SDIO->STA & SDIO_STA_TRX_ERROR_FLAGS){
+  if (SDIO->STA & SDIO_STA_TRX_ERROR_FLAGS) {
     SDIO_CLEAR_FLAG(SDIO_ICR_CMD_FLAGS | SDIO_ICR_DATA_FLAGS);
     dma_disable(SDIO_DMA_DEV, SDIO_DMA_CHANNEL);
     return false;
 	}
 
   //Wait for DMA transaction to complete
-  while((DMA2_BASE->ISR & (DMA_ISR_TEIF4|DMA_ISR_TCIF4)) == 0 ){};
+  while ((DMA2_BASE->ISR & (DMA_ISR_TEIF4|DMA_ISR_TCIF4)) == 0 ) { /* wait */ }
 
-  if(DMA2_BASE->ISR & DMA_ISR_TEIF4){
+  if (DMA2_BASE->ISR & DMA_ISR_TEIF4) {
     dma_disable(SDIO_DMA_DEV, SDIO_DMA_CHANNEL);
     SDIO_CLEAR_FLAG(SDIO_ICR_CMD_FLAGS | SDIO_ICR_DATA_FLAGS);
     return false;
@@ -162,7 +162,7 @@ bool SDIO_WriteBlock(uint32_t blockAddress, const uint8_t *data) {
 
   sdio_setup_transfer(SDIO_DATA_TIMEOUT * (F_CPU / 1000U), 512U, SDIO_BLOCKSIZE_512 | SDIO_DCTRL_DMAEN | SDIO_DCTRL_DTEN);
 
-  while (!SDIO_GET_FLAG(SDIO_STA_DATAEND | SDIO_STA_TRX_ERROR_FLAGS)) {}
+  while (!SDIO_GET_FLAG(SDIO_STA_DATAEND | SDIO_STA_TRX_ERROR_FLAGS)) { /* wait */ }
 
   dma_disable(SDIO_DMA_DEV, SDIO_DMA_CHANNEL);
 

--- a/Marlin/src/HAL/STM32F1/sdio.cpp
+++ b/Marlin/src/HAL/STM32F1/sdio.cpp
@@ -102,7 +102,23 @@ bool SDIO_ReadBlock_DMA(uint32_t blockAddress, uint8_t *data) {
   }
 
   while (!SDIO_GET_FLAG(SDIO_STA_DATAEND | SDIO_STA_TRX_ERROR_FLAGS)) {}
+  
+  //If there were SDIO errors, do not wait DMA.
+  if(SDIO->STA & SDIO_STA_TRX_ERROR_FLAGS){
+    SDIO_CLEAR_FLAG(SDIO_ICR_CMD_FLAGS | SDIO_ICR_DATA_FLAGS);
+    dma_disable(SDIO_DMA_DEV, SDIO_DMA_CHANNEL);
+    return false;
+	}
 
+  //Wait for DMA transaction to complete
+  while((DMA2_BASE->ISR & (DMA_ISR_TEIF4|DMA_ISR_TCIF4)) == 0 ){};
+
+  if(DMA2_BASE->ISR & DMA_ISR_TEIF4){
+    dma_disable(SDIO_DMA_DEV, SDIO_DMA_CHANNEL);
+    SDIO_CLEAR_FLAG(SDIO_ICR_CMD_FLAGS | SDIO_ICR_DATA_FLAGS);
+    return false;
+  }
+  
   dma_disable(SDIO_DMA_DEV, SDIO_DMA_CHANNEL);
 
   if (SDIO->STA & SDIO_STA_RXDAVL) {


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Reading a block from the SDIO does not complete correctly. At the time of setting the flags for the completion of the SDIO in FIFO, there is still data that the DMA did not manage to pick up. This in some cases leads to the end of the function with the result of false, because the flag SDIO_STA_RXDAVL is still raised. For the correct completion of the work, you must wait for the flags from the DMA.
### Benefits

Stable work when reading from a SD card

### Related Issues
BUG #16672

