### PR TITLE
Robin E3/E3D EEPROM size, E3 name, LCD pins comment

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3.h
@@ -128,9 +128,16 @@
 
 #define FIL_RUNOUT_PIN                      PB10  // MT_DET
 
-//
-// LCD Pins
-//
+/**
+ *                _____                                      _____                                     _____
+ *  (BEEPER) PC1 | 1 2 | PC3 (BTN_ENC)          (MISO) PB14 | 1 2 | PB13 (SD_SCK)                  5V | 1 2 | GND
+ *  (LCD_EN) PA4 | 3 4 | PA5 (LCD_RS)        (BTN_EN1) PB11 | 3 4 | PA15 (SD_SS)         (LCD_EN) PA4 | 3 4 | PA5  (LCD_RS)
+ *  (LCD_D4) PA6 | 5 6   PA7 (LCD_D5)        (BTN_EN2)  PB0 | 5 6   PB15 (SD_MOSI)       (LCD_D4) PA6 | 5 6   PB0  (BTN_EN2)
+ *  (LCD_D6) PC4 | 7 8 | PC5 (LCD_D7)      (SD_DETECT) PC10 | 7 8 | RESET                       RESET | 7 8 | PB11 (BTN_EN1)
+ *           GND | 9 10| 5V                             GND | 9 10| NC                  (BTN_ENC) PC3 | 9 10| PC1  (BEEPER)
+ *                -----                                      -----                                     -----
+ *                EXP1                                       EXP2                                      EXP3
+ */
 #if HAS_SPI_LCD
 
   #define BEEPER_PIN                        PC1

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3.h
@@ -32,7 +32,7 @@
 #endif
 
 #ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME "MKS Robin E3D"
+  #define BOARD_INFO_NAME "MKS Robin E3"
 #endif
 #define BOARD_WEBSITE_URL "github.com/makerbase-mks"
 
@@ -47,8 +47,7 @@
   #define FLASH_EEPROM_EMULATION
   #define EEPROM_PAGE_SIZE     (0x800U) // 2KB
   #define EEPROM_START_ADDRESS (0x8000000UL + (STM32_FLASH_SIZE) * 1024UL - (EEPROM_PAGE_SIZE) * 2UL)
-  #undef E2END
-  #define E2END                (EEPROM_PAGE_SIZE - 1) // 2KB
+  #define MARLIN_EEPROM_SIZE   EEPROM_PAGE_SIZE  // 2KB
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D.h
@@ -47,8 +47,7 @@
   #define FLASH_EEPROM_EMULATION
   #define EEPROM_PAGE_SIZE     (0x800U) // 2KB
   #define EEPROM_START_ADDRESS (0x8000000UL + (STM32_FLASH_SIZE) * 1024UL - (EEPROM_PAGE_SIZE) * 2UL)
-  #undef E2END
-  #define E2END                (EEPROM_PAGE_SIZE - 1) // 2KB
+  #define MARLIN_EEPROM_SIZE   EEPROM_PAGE_SIZE  // 2KB
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D.h
@@ -155,9 +155,16 @@
 
 #define FIL_RUNOUT_PIN                      PB10  // MT_DET
 
-//
-// LCD Pins
-//
+/**
+ *                _____                                      _____                                     _____
+ *  (BEEPER) PC1 | 1 2 | PC3 (BTN_ENC)          (MISO) PB14 | 1 2 | PB13 (SD_SCK)                  5V | 1 2 | GND
+ *  (LCD_EN) PA4 | 3 4 | PA5 (LCD_RS)        (BTN_EN1) PB11 | 3 4 | PA15 (SD_SS)         (LCD_EN) PA4 | 3 4 | PA5  (LCD_RS)
+ *  (LCD_D4) PA6 | 5 6   PA7 (LCD_D5)        (BTN_EN2)  PB0 | 5 6   PB15 (SD_MOSI)       (LCD_D4) PA6 | 5 6   PB0  (BTN_EN2)
+ *  (LCD_D6) PC4 | 7 8 | PC5 (LCD_D7)      (SD_DETECT) PC10 | 7 8 | RESET                       RESET | 7 8 | PB11 (BTN_EN1)
+ *           GND | 9 10| 5V                             GND | 9 10| NC                  (BTN_ENC) PC3 | 9 10| PC1  (BEEPER)
+ *                -----                                      -----                                     -----
+ *                EXP1                                       EXP2                                      EXP3
+ */
 #if HAS_SPI_LCD
 
   #define BEEPER_PIN                        PC1


### PR DESCRIPTION
### Description

1. Use `MARLIN_EEPROM_SIZE` instead of `E2END` for the MKS Robin E3 & E3D boards
2. Update Robin E3 board name
3. Add LCD pin graphic (*reminder: MKS' `EXP1` and `EXP2` pins are 180° out from normal EXP headers*. `EXP3` follows Creality/`CR10_STOCKDISPLAY` standard pinout.)

### Benefits

1. Follow  Marlin's new EEPROM standard
2. Correct board name for the Robin E3
3. Easier mapping of pins when adding new LCDs

### Related Issues

Partially a follow-up to https://github.com/MarlinFirmware/Marlin/pull/18219