### PR TITLE
Bugfix: EEPROM Index Error (implemented via PR #17017)

### DIFF
--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -1796,9 +1796,7 @@ void MarlinSettings::postprocess() {
         struct {
           bool volumetric_enabled;
           float filament_size[EXTRUDERS];
-          #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-            float volumetric_extruder_limit[EXTRUDERS];
-          #endif
+          float volumetric_extruder_limit[EXTRUDERS];
         } storage;
 
         _FIELD_TEST(parser_volumetric_enabled);


### PR DESCRIPTION

### Description

In my PR #17017 was a small bug in terms on reading EEPROM values (M501). I'm very sorry for the trouble caused.

### Related Issues

#18229
