### PR TITLE
Correct New Laser Inline Code

### DIFF
--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -91,8 +91,8 @@ public:
     static cutter_frequency_t frequency;  // Set PWM frequency; range: 2K-50K
   #endif
 
-  static cutter_power_t menuPower;        // Power as set via LCD menu in PWM, Percentage or RPM
-  static cutter_power_t unitPower;        // Power as displayed status in PWM, Percentage or RPM
+  static cutter_power_t menuPower,        // Power as set via LCD menu in PWM, Percentage or RPM
+                        unitPower;        // Power as displayed status in PWM, Percentage or RPM
 
   static void init();
 
@@ -254,7 +254,7 @@ public:
           inline_ocr_power(upower_to_ocr(upwr));
         #endif
       #else
-        planner.laser_inline.status.isEnabled = enabled(upwr) ? true : false;
+        planner.laser_inline.status.isEnabled = enabled(upwr);
         planner.laser_inline.power = upwr;
         isReady = enabled(upwr);
       #endif
@@ -264,8 +264,8 @@ public:
 
     #if ENABLED(SPINDLE_LASER_PWM)
       static inline void inline_ocr_power(const uint8_t ocrpwr) {
-        isReady = ocrpwr ? true : false;
-        planner.laser_inline.status.isEnabled = ocrpwr ? true : false;
+        isReady = ocrpwr > 0;
+        planner.laser_inline.status.isEnabled = ocrpwr > 0;
         planner.laser_inline.power = ocrpwr;
       }
     #endif

--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -232,21 +232,26 @@ public:
 
     // Inline modes of all other functions; all enable planner inline power control
     static inline void set_inline_enabled(const bool enable) {
-      if (enable) { inline_power(cpwr_to_upwr(SPEED_POWER_STARTUP)); }
-      else { unitPower = 0; isReady = false; menuPower = 0; planner.laser_inline.status.isPlanned = false; TERN(SPINDLE_LASER_PWM, inline_ocr_power, inline_power)(0);}
+      if (enable)
+        inline_power(cpwr_to_upwr(SPEED_POWER_STARTUP)); 
+      else {
+        isReady = false;
+        unitPower = menuPower = 0;
+        planner.laser_inline.status.isPlanned = false;
+        TERN(SPINDLE_LASER_PWM, inline_ocr_power, inline_power)(0);
+      }
     }
 
     // Set the power for subsequent movement blocks
     static void inline_power(const cutter_power_t upwr) {
-      unitPower = upwr;
-      menuPower = unitPower;
+      unitPower = menuPower = upwr;
       #if ENABLED(SPINDLE_LASER_PWM)
         #if ENABLED(SPEED_POWER_RELATIVE) && !CUTTER_UNIT_IS(RPM) // relative mode does not turn laser off at 0, except for RPM
           planner.laser_inline.status.isEnabled = true;
           planner.laser_inline.power = upower_to_ocr(upwr);
           isReady = true;
         #else
-            inline_ocr_power(upower_to_ocr(upwr));
+          inline_ocr_power(upower_to_ocr(upwr));
         #endif
       #else
         planner.laser_inline.status.isEnabled = enabled(upwr) ? true : false;

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1826,6 +1826,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
   // Update block laser power
   #if ENABLED(LASER_POWER_INLINE)
+    laser_inline.status.isPlanned = true;
     block->laser.status = laser_inline.status;
     block->laser.power = laser_inline.power;
   #endif

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -355,7 +355,7 @@ class Stepper {
     #if ENABLED(LASER_POWER_INLINE_TRAPEZOID)
 
       typedef struct {
-        bool trap_en;       // Trapezoid needed flag (i.e., laser on, planner in control)
+        bool enabled;       // Trapezoid needed flag (i.e., laser on, planner in control)
         uint8_t cur_power;  // Current laser power
         bool cruise_set;    // Power set up for cruising?
 
@@ -367,7 +367,7 @@ class Stepper {
         #endif
       } stepper_laser_t;
 
-      static stepper_laser_t laser;
+      static stepper_laser_t laser_trap;
 
     #endif
 


### PR DESCRIPTION
New laser code has compilation issues as pointed out by @gminadak : https://github.com/MarlinFirmware/Marlin/pull/17661#issuecomment-640697079
Issue was `planner.laser_inline.status` now needs to be `planner.laser_inline.status.isEnabled`
Also `trap_en` and `laser` in `Stepper.h` are now `enable` and `laser_trap` respectively

`planner.laser_inline.status.isPlanned = true` is in `planner.cpp` instead of `spindle_laser.h` because the latter would not turn the laser off in between moves and at end of the job.