### PR TITLE
Full Touch support for default Marlin Menus - Touch to Select!

### DIFF
--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -27,6 +27,8 @@
 
 #define BUTTON_AREA_TOP 175
 #define BUTTON_AREA_BOT 234
+#define SCREEN_START_TOP LCD_PIXEL_OFFSET_Y * 240 / LCD_FULL_PIXEL_HEIGHT
+#define TOUCHABLE_Y_HEIGHT BUTTON_AREA_TOP - SCREEN_START_TOP
 
 #ifndef TOUCH_INT_PIN
   #define TOUCH_INT_PIN  -1
@@ -90,11 +92,11 @@ uint8_t XPT2046::read_buttons() {
          : WITHIN(x, 242, 305) ? EN_C
          : 0;
 
-  if (y > BUTTON_AREA_BOT || x > 320) return 0;
+  if (y > BUTTON_AREA_BOT || x > 320 || y < SCREEN_START_TOP) return 0;
 
   // Column and row above BUTTON_AREA_TOP
-  int8_t col = x * (LCD_WIDTH ) / (320),
-         row = y * (LCD_HEIGHT) / (BUTTON_AREA_TOP);
+  int8_t col = x * (LCD_WIDTH) / (320),
+         row = (y - SCREEN_START_TOP) * (LCD_HEIGHT) / (TOUCHABLE_Y_HEIGHT);
 
   // Send the touch to the UI (which will simulate the encoder wheel)
   MarlinUI::screen_click(row, col, x, y);

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -90,11 +90,11 @@ uint8_t XPT2046::read_buttons() {
          : WITHIN(x, 242, 305) ? EN_C
          : 0;
 
-  if (y > BUTTON_AREA_BOT) return 0;
+  if (y > BUTTON_AREA_BOT || x > 320) return 0;
 
   // Column and row above BUTTON_AREA_TOP
-  int8_t col = (x % (320) ) * (LCD_WIDTH ) / (320),
-         row = (y % (240)) * (LCD_HEIGHT) / (BUTTON_AREA_TOP);
+  int8_t col = x * (LCD_WIDTH ) / (320),
+         row = y * (LCD_HEIGHT) / (BUTTON_AREA_TOP);
 
   // Send the touch to the UI (which will simulate the encoder wheel)
   MarlinUI::screen_click(row, col, x, y);

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -90,11 +90,11 @@ uint8_t XPT2046::read_buttons() {
          : WITHIN(x, 242, 305) ? EN_C
          : 0;
 
-  // Column and row above BUTTON_AREA_TOP
-  int8_t col = (x % (LCD_FULL_PIXEL_WIDTH) ) * (LCD_WIDTH ) / (LCD_FULL_PIXEL_WIDTH),
-         row = (y % (LCD_FULL_PIXEL_HEIGHT)) * (LCD_HEIGHT) / (BUTTON_AREA_TOP);
+  if (y > BUTTON_AREA_BOT) return 0;
 
-  row = (LCD_HEIGHT) - row - 1; // TODO: Can LCD or sensor be inverted?
+  // Column and row above BUTTON_AREA_TOP
+  int8_t col = (x % (320) ) * (LCD_WIDTH ) / (320),
+         row = (y % (240)) * (LCD_HEIGHT) / (BUTTON_AREA_TOP);
 
   // Send the touch to the UI (which will simulate the encoder wheel)
   MarlinUI::screen_click(row, col, x, y);

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -23,6 +23,7 @@
 
 #include "xpt2046.h"
 #include "../../inc/MarlinConfig.h"
+#include "../../lcd/dogm/ultralcd_DOGM.h" // for LCD_FULL_PIXEL_WIDTH, etc.
 
 #define BUTTON_AREA_TOP 175
 #define BUTTON_AREA_BOT 234

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -78,8 +78,6 @@ uint8_t XPT2046::read_buttons() {
                  y = uint16_t(((uint32_t(getInTouch(XPT2046_Y))) * tsoffsets[2]) >> 16) + tsoffsets[3];
   if (!isTouched()) return 0; // Fingers must still be on the TS for a valid read.
 
-  if (y < 175 || y > 234) return 0;
-
   // button area
   if (y > 175 && y < 234) {
     return WITHIN(x,  14,  77) ? EN_D

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -27,8 +27,8 @@
 
 #define BUTTON_AREA_TOP 175
 #define BUTTON_AREA_BOT 234
-#define SCREEN_START_TOP LCD_PIXEL_OFFSET_Y * 240 / LCD_FULL_PIXEL_HEIGHT
-#define TOUCHABLE_Y_HEIGHT BUTTON_AREA_TOP - SCREEN_START_TOP
+#define SCREEN_START_TOP ((LCD_PIXEL_OFFSET_Y) * 240 / (LCD_FULL_PIXEL_HEIGHT))
+#define TOUCHABLE_Y_HEIGHT (BUTTON_AREA_TOP - (SCREEN_START_TOP))
 
 #ifndef TOUCH_INT_PIN
   #define TOUCH_INT_PIN  -1
@@ -92,11 +92,11 @@ uint8_t XPT2046::read_buttons() {
          : WITHIN(x, 242, 305) ? EN_C
          : 0;
 
-  if (y > BUTTON_AREA_BOT || x > 320 || y < SCREEN_START_TOP) return 0;
+  if (x > LCD_FULL_PIXEL_WIDTH || !WITHIN(y, SCREEN_START_TOP, BUTTON_AREA_TOP)) return 0;
 
   // Column and row above BUTTON_AREA_TOP
-  int8_t col = x * (LCD_WIDTH) / (320),
-         row = (y - SCREEN_START_TOP) * (LCD_HEIGHT) / (TOUCHABLE_Y_HEIGHT);
+  int8_t col = x * (LCD_WIDTH) / (LCD_FULL_PIXEL_WIDTH),
+         row = (y - (SCREEN_START_TOP)) * (LCD_HEIGHT) / (TOUCHABLE_Y_HEIGHT);
 
   // Send the touch to the UI (which will simulate the encoder wheel)
   MarlinUI::screen_click(row, col, x, y);

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -80,11 +80,26 @@ uint8_t XPT2046::read_buttons() {
 
   if (y < 175 || y > 234) return 0;
 
-  return WITHIN(x,  14,  77) ? EN_D
+  // button area
+  if (y > 175 && y < 234) {
+    return WITHIN(x,  14,  77) ? EN_D
        : WITHIN(x,  90, 153) ? EN_A
        : WITHIN(x, 166, 229) ? EN_B
        : WITHIN(x, 242, 305) ? EN_C
        : 0;
+  }
+
+  // 175 is the max y, because the button area
+  int8_t row = (y % 240) / (175 / LCD_HEIGHT);
+  int8_t col = (x % 320) / (320 / LCD_WIDTH);
+
+  //TODO: need config to invert? or is always inverted Y?
+  row = LCD_HEIGHT - row - 1;
+
+  //We could change the encoderDiff here, but I think it's better to keep all encoder logic in MarlinUI
+  MarlinUI::screen_click(row, col, x, y);
+  
+  return 0;
 }
 
 bool XPT2046::isTouched() {

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -91,8 +91,8 @@ uint8_t XPT2046::read_buttons() {
          : 0;
 
   // Column and row above BUTTON_AREA_TOP
-  int8_t col = (x % (LCD_FULL_PIXEL_WIDTH) ) * (LCD_WIDTH ) / LCD_FULL_PIXEL_WIDTH,
-         row = (y % (LCD_FULL_PIXEL_HEIGHT)) * (LCD_HEIGHT) / BUTTON_AREA_TOP;
+  int8_t col = (x % (LCD_FULL_PIXEL_WIDTH) ) * (LCD_WIDTH ) / (LCD_FULL_PIXEL_WIDTH),
+         row = (y % (LCD_FULL_PIXEL_HEIGHT)) * (LCD_HEIGHT) / (BUTTON_AREA_TOP);
 
   row = (LCD_HEIGHT) - row - 1; // TODO: Can LCD or sensor be inverted?
 

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -81,7 +81,7 @@ uint8_t XPT2046::read_buttons() {
   const uint16_t x = uint16_t(((uint32_t(getInTouch(XPT2046_X))) * tsoffsets[0]) >> 16) + tsoffsets[1],
                  y = uint16_t(((uint32_t(getInTouch(XPT2046_Y))) * tsoffsets[2]) >> 16) + tsoffsets[3];
   if (!isTouched()) return 0; // Fingers must still be on the TS for a valid read.
-  
+
   // Touch within the button area simulates an encoder button
   if (y > BUTTON_AREA_TOP && y < BUTTON_AREA_BOT)
     return WITHIN(x,  14,  77) ? EN_D

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1443,11 +1443,18 @@ void MarlinUI::update() {
     //
     // Screen Click
     //  - On menu screens move directly to the touched item
+    //  - On menu screens, right side (last 3 cols) acts like a scroll - half up => prev page, half down = next page
     //  - On select screens (and others) touch the Right Half for +, Left Half for -
     //
     void MarlinUI::screen_click(const uint8_t row, const uint8_t col, const uint8_t x, const uint8_t y) {
-      if (screen_items > 0)
-        encoderDiff = ENCODER_PULSES_PER_STEP * (row - encoderPosition + encoderTopLine);
+      if (screen_items > 0) {
+        //last 3 cols act as a scroll :-)
+        if (col > (LCD_WIDTH) - 3)
+          //2 * LCD_HEIGHT to scroll to bottom of next page. If we did 1 * LCD_HEIGHT, it just go 1 item down
+          encoderDiff = ENCODER_PULSES_PER_STEP * (encoderLine - encoderTopLine + 2 * (LCD_HEIGHT)) * (row < (LCD_HEIGHT) / 2 ? -1 : 1);
+        else
+          encoderDiff = ENCODER_PULSES_PER_STEP * (row - encoderPosition + encoderTopLine);
+      }
       else if (!on_status_screen())
         encoderDiff = ENCODER_PULSES_PER_STEP * (col < (LCD_WIDTH) / 2 ? -1 : 1);
     }

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1448,7 +1448,7 @@ void MarlinUI::update() {
     void MarlinUI::screen_click(const uint8_t row, const uint8_t col, const uint8_t x, const uint8_t y) {
       if (screen_items > 0)
         encoderDiff = ENCODER_PULSES_PER_STEP * (row - encoderPosition + encoderTopLine);
-      else
+      else if (!on_status_screen())
         encoderDiff = ENCODER_PULSES_PER_STEP * (col < (LCD_WIDTH) / 2 ? -1 : 1);
     }
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1438,6 +1438,22 @@ void MarlinUI::update() {
 
   #endif
 
+  #if ENABLED(TOUCH_BUTTONS)
+    void MarlinUI::screen_click(uint8_t row, uint8_t col, uint8_t x, uint8_t y) {
+      //menu window, go direct to where user touch
+      if (screen_items > 0) {
+        encoderDiff = (row - encoderPosition + encoderTopLine) * ENCODER_PULSES_PER_STEP;
+      }
+      //confirm and other windows, right screen is +, left screen is -
+      else {
+        encoderDiff = row * ENCODER_PULSES_PER_STEP;
+        if (col < LCD_WIDTH / 2) {
+          encoderDiff *= -1; //reverse direction
+        }
+      }
+    }
+  #endif
+
 #else // !HAS_DISPLAY
 
   //

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1440,9 +1440,6 @@ void MarlinUI::update() {
 
   #if ENABLED(TOUCH_BUTTONS)
     void MarlinUI::screen_click(uint8_t row, uint8_t col, uint8_t x, uint8_t y) {
-      SERIAL_ECHOPGM("Text: ");
-      SERIAL_ECHOPAIR("Row: ", row, ", ", col);
-      SERIAL_EOL();
       //menu window, go direct to where user touch
       if (screen_items > 0) {
         encoderDiff = (row - encoderPosition + encoderTopLine) * ENCODER_PULSES_PER_STEP;

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1439,19 +1439,19 @@ void MarlinUI::update() {
   #endif
 
   #if ENABLED(TOUCH_BUTTONS)
-    void MarlinUI::screen_click(uint8_t row, uint8_t col, uint8_t x, uint8_t y) {
-      //menu window, go direct to where user touch
-      if (screen_items > 0) {
-        encoderDiff = (row - encoderPosition + encoderTopLine) * ENCODER_PULSES_PER_STEP;
-      }
-      //confirm and other windows, right screen is +, left screen is -
-      else {
-        encoderDiff = row * ENCODER_PULSES_PER_STEP;
-        if (col < LCD_WIDTH / 2) {
-          encoderDiff *= -1; //reverse direction
-        }
-      }
+
+    //
+    // Screen Click
+    //  - On menu screens move directly to the touched item
+    //  - On select screens (and others) touch the Right Half for +, Left Half for -
+    //
+    void MarlinUI::screen_click(const uint8_t row, const uint8_t col, const uint8_t x, const uint8_t y) {
+      if (screen_items > 0)
+        encoderDiff = ENCODER_PULSES_PER_STEP * (row - encoderPosition + encoderTopLine);
+      else
+        encoderDiff = ENCODER_PULSES_PER_STEP * (row * (col < (LCD_WIDTH) / 2 ? -1 : 1));
     }
+
   #endif
 
 #else // !HAS_DISPLAY

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1449,7 +1449,7 @@ void MarlinUI::update() {
       if (screen_items > 0)
         encoderDiff = ENCODER_PULSES_PER_STEP * (row - encoderPosition + encoderTopLine);
       else
-        encoderDiff = ENCODER_PULSES_PER_STEP * (row * (col < (LCD_WIDTH) / 2 ? -1 : 1));
+        encoderDiff = ENCODER_PULSES_PER_STEP * (col < (LCD_WIDTH) / 2 ? -1 : 1);
     }
 
   #endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -1440,6 +1440,9 @@ void MarlinUI::update() {
 
   #if ENABLED(TOUCH_BUTTONS)
     void MarlinUI::screen_click(uint8_t row, uint8_t col, uint8_t x, uint8_t y) {
+      SERIAL_ECHOPGM("Text: ");
+      SERIAL_ECHOPAIR("Row: ", row, ", ", col);
+      SERIAL_EOL();
       //menu window, go direct to where user touch
       if (screen_items > 0) {
         encoderDiff = (row - encoderPosition + encoderTopLine) * ENCODER_PULSES_PER_STEP;

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -417,6 +417,10 @@ public:
         static void draw_hotend_status(const uint8_t row, const uint8_t extruder);
       #endif
 
+      #if ENABLED(TOUCH_BUTTONS)
+        static void screen_click(uint8_t row, uint8_t col, uint8_t x, uint8_t y);
+      #endif
+
       static void status_screen();
 
     #endif

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -418,7 +418,7 @@ public:
       #endif
 
       #if ENABLED(TOUCH_BUTTONS)
-        static void screen_click(uint8_t row, uint8_t col, uint8_t x, uint8_t y);
+        static void screen_click(const uint8_t row, const uint8_t col, const uint8_t x, const uint8_t y);
       #endif
 
       static void status_screen();


### PR DESCRIPTION
### Description

Hi,

Using a touch screen with default Marlin menu is a bit annoying because we need to use the buttons bellow the screen.
But it changes now :-)

I'm enabling it with TOUCH_BUTTONS. I can emulate a click too, but seems touch to select is better.

The change could be done just in the xpt2046.cpp file, but I think the "screen_click" function must be part of MarlinUI... Tried to keep the thinks in the right place.

### Benefits

It's more easier and user friendly to touch directly where you want, in a TFT display that uses the default marlin menu.

Some users have touch displays that don't have any other UI. Link TronXY users using Marlin. So it helps this users to have a better UI experience.

This videos explains better :-)


![ezgif-4-208ce3332154](https://user-images.githubusercontent.com/81722/84099661-835e8680-a9e0-11ea-9709-924d5d81cae0.gif)
![ezgif-4-b166bfb54b8c](https://user-images.githubusercontent.com/81722/84099958-34652100-a9e1-11ea-9bd8-e22f49fa8c26.gif)

**I think I must explain my code decisions in the PR:**

I could do it a lot better, with more classes and stuff, supporting double-touch, touch on icons, edit screen, and so on.

But, my main goal here was: 

_keep changes at minimum, dont break any compatibility, yet supporting the most used touch actions for the users, to get this PR accepted as soon as possible without any risk to Marlin_

So, with only 3 files and a few lines changed, we get the most action covered:
   - touch to select menus
   - touch to select confirm action
   - touch to go to next/prev pages

Why do I want to keep things so minimum now? Because the TFT users that don't have smart screens need it, as the case of tronxy x5sa users - we had working on this about a week or so.

I already working in a 2.0 version of this full touch, that each screen could define its touchable actions - icons, menus, edit, support double touch, etc. The code is better, but the change is a lot bigger. If I did the big version first, the tronxy x5sa users (and a lot of others users) will need to wait a long time to use it, because a more complex and big PR isnt so easy to merge without break anything - it needs more review, more tests, and so on...

Well, I think I could explain my design/code decisions to help it get accepted as soon as possible :-)
I have a few users testing it, and they are enjoying a lot!

Thanks!
