### PR TITLE
Tronxy X5SA Support for V5 and V6 boards

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -307,6 +307,8 @@
 #define BOARD_MKS_ROBIN_E3            4027  // MKS Robin E3 (STM32F103RCT6)
 #define BOARD_MALYAN_M300             4028  // STM32F070-based delta
 #define BOARD_CCROBOT_MEEB_3DP        4029  // ccrobot-online.com MEEB_3DP (STM32F103RC)
+#define BOARD_CHITU3D_V5              4030  // Chitu3D TronXY X5SA V5 Board
+#define BOARD_CHITU3D_V6              4031  // Chitu3D TronXY X5SA V5 Board
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -539,7 +539,7 @@
 #elif MB(CCROBOT_MEEB_3DP)
   #include "stm32f1/pins_CCROBOT_MEEB_3DP.h"    // STM32F1                                env:STM32F103RC_meeb
 #elif MB(CHITU3D_V5)
-  #include "stm32f1/pins_CHITU3D_V5.h"          // STM32F1
+  #include "stm32f1/pins_CHITU3D_V5.h"          // STM32F1                                env:chitu_f103
 #elif MB(CHITU3D_V6)
   #include "stm32f1/pins_CHITU3D_V6.h"          // STM32F1                                env:chitu_f103
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -538,6 +538,10 @@
   #include "stm32f1/pins_MKS_ROBIN_E3.h"        // STM32F1                                env:mks_robin_e3
 #elif MB(CCROBOT_MEEB_3DP)
   #include "stm32f1/pins_CCROBOT_MEEB_3DP.h"    // STM32F1                                env:STM32F103RC_meeb
+#elif MB(CHITU3D_V5)
+  #include "stm32f1/pins_CHITU3D_V5.h"          // STM32F1
+#elif MB(CHITU3D_V6)
+  #include "stm32f1/pins_CHITU3D_V6.h"          // STM32F1                                env:chitu_f103
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -49,63 +49,62 @@
 //
 // Limit Switches
 //
-#define X_MAX_PIN          -1
-#define X_MIN_PIN          PG10 
-#define Y_MAX_PIN          -1
-#define Y_MIN_PIN          PA12 
-#define Z_MAX_PIN          -1 
-#define Z_MIN_PIN          PA14
+#define X_MAX_PIN                           -1
+#define X_MIN_PIN                           PG10
+#define Y_MAX_PIN                           -1
+#define Y_MIN_PIN                           PA12
+#define Z_MAX_PIN                           -1
+#define Z_MIN_PIN                           PA14
 
 //
 // Steppers
 //
-#define X_ENABLE_PIN       PC13
-#define X_STEP_PIN         PE5
-#define X_DIR_PIN          PE6
+#define X_ENABLE_PIN                        PC13
+#define X_STEP_PIN                          PE5
+#define X_DIR_PIN                           PE6
 
-#define Y_ENABLE_PIN       PE4
-#define Y_STEP_PIN         PE2
-#define Y_DIR_PIN          PE3
+#define Y_ENABLE_PIN                        PE4
+#define Y_STEP_PIN                          PE2
+#define Y_DIR_PIN                           PE3
 
-#define Z_ENABLE_PIN       PE1
-#define Z_STEP_PIN         PB9
-#define Z_DIR_PIN          PE0
+#define Z_ENABLE_PIN                        PE1
+#define Z_STEP_PIN                          PB9
+#define Z_DIR_PIN                           PE0
 
-#define E0_ENABLE_PIN      PB8
-#define E0_STEP_PIN        PB4
-#define E0_DIR_PIN         PB5
+#define E0_ENABLE_PIN                       PB8
+#define E0_STEP_PIN                         PB4
+#define E0_DIR_PIN                          PB5
 
-
-#define E1_ENABLE_PIN      PG8
-#define E1_STEP_PIN        PC7
-#define E1_DIR_PIN         PC6
+#define E1_ENABLE_PIN                       PG8
+#define E1_STEP_PIN                         PC7
+#define E1_DIR_PIN                          PC6
 
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN         PA1   // TH1
-#define TEMP_BED_PIN       PA0   // TB1
+#define TEMP_0_PIN                          PA1   // TH1
+#define TEMP_BED_PIN                        PA0   // TB1
 
 //
 // Heaters
 //
-#define HEATER_0_PIN       PG12   // HEATER1
-#define HEATER_BED_PIN     PG11   // HOT BED
+#define HEATER_0_PIN                        PG12  // HEATER1
+#define HEATER_BED_PIN                      PG11  // HOT BED
 
 //
 // Fans
 //
-#define CONTROLLER_FAN_PIN PD6   // BOARD FAN 
-#define FAN_PIN            PG13  // FAN
-#define FAN_PIN_2          PG14 
+#define CONTROLLER_FAN_PIN                  PD6   // BOARD FAN 
+#define FAN_PIN                             PG13  // FAN
+#define FAN_PIN_2                           PG14
 
 //
 // Misc
 //
-#define BEEPER_PIN         PB0  
-#define LED_PIN            -1 
-#define POWER_LOSS_PIN     -1
-#define FIL_RUNOUT_PIN     PA15
+#define BEEPER_PIN                          PB0
+#define LED_PIN                             -1
+#define POWER_LOSS_PIN                      -1
+#define FIL_RUNOUT_PIN                      PA15
 
 /**
  * TronXY TFT Support
@@ -115,49 +114,48 @@
 
 #if ENABLED(FSMC_GRAPHICAL_TFT)
   #define FSMC_UPSCALE 3
-  #define LCD_FULL_PIXEL_WIDTH  480
-  #define LCD_PIXEL_OFFSET_X    48
+  #define LCD_FULL_PIXEL_WIDTH 480
+  #define LCD_PIXEL_OFFSET_X 48
   #define LCD_FULL_PIXEL_HEIGHT 320
 
-  #define LCD_RESET_PIN      PF11
-  #define NO_LCD_REINIT 
-  #define LCD_BACKLIGHT_PIN  PD13
-  #define FSMC_CS_PIN        PD7 
-  #define FSMC_RS_PIN        PD11
+  #define LCD_RESET_PIN                     PF11
+  #define NO_LCD_REINIT
+  #define LCD_BACKLIGHT_PIN                 PD13
+  #define FSMC_CS_PIN                       PD7
+  #define FSMC_RS_PIN                       PD11
 
-  #define LCD_USE_DMA_FSMC   // Use DMA transfers to send data to the TFT
-  #define FSMC_DMA_DEV       DMA2
-  #define FSMC_DMA_CHANNEL   DMA_CH5
+  #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
+  #define FSMC_DMA_DEV                      DMA2
+  #define FSMC_DMA_CHANNEL               DMA_CH5
 
   #if ENABLED(TOUCH_BUTTONS)
-    #define TOUCH_CS_PIN     PB7  // SPI1_NSS
-    #define TOUCH_SCK_PIN    PA5  // SPI1_SCK
-    #define TOUCH_MISO_PIN   PA6  // SPI1_MISO
-    #define TOUCH_MOSI_PIN   PA7  // SPI1_MOSI
+    #define TOUCH_CS_PIN                    PB7   // SPI1_NSS
+    #define TOUCH_SCK_PIN                   PA5   // SPI1_SCK
+    #define TOUCH_MISO_PIN                  PA6   // SPI1_MISO
+    #define TOUCH_MOSI_PIN                  PA7   // SPI1_MOSI
 
-    #define BUTTON_DELAY_EDIT       50 // (ms) Button repeat delay for edit screens
-    #define BUTTON_DELAY_MENU       250 // (ms) Button repeat delay for menus
+    #define BUTTON_DELAY_EDIT 50                  // (ms) Button repeat delay for edit screens
+    #define BUTTON_DELAY_MENU 250                 // (ms) Button repeat delay for menus
 
     #define XPT2046_X_CALIBRATION   -12316
     #define XPT2046_Y_CALIBRATION   -8981
-    #define XPT2046_X_OFFSET        340
-    #define XPT2046_Y_OFFSET        429
+    #define XPT2046_X_OFFSET 340
+    #define XPT2046_Y_OFFSET 429
   #endif
 #endif
 
 // SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available
 // We nee to use the SPI2
 #define ENABLE_SPI2
-#define SCK_PIN           PB13 
-#define MISO_PIN          PB14 
-#define MOSI_PIN          PB15 
-#define SS_PIN            PB12
-
+#define SCK_PIN                             PB13
+#define MISO_PIN                            PB14
+#define MOSI_PIN                            PB15
+#define SS_PIN                              PB12
 
 //
 // SD Card
 //
-#define SDIO_SUPPORT 
-#define SD_DETECT_PIN     -1 // PF0, but it isn't connected
+#define SDIO_SUPPORT
+#define SD_DETECT_PIN                       -1    // PF0, but it isn't connected
 #define SDIO_CLOCK 4500000
 #define SDIO_READ_RETRIES 16

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -1,0 +1,163 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#if !defined(__STM32F1__) && !defined(__STM32F4__)
+  #error "Oops! Select an STM32F1/4 board in 'Tools > Board.'"
+#endif
+
+/**
+ * 2017 Victor Perez Marlin for stm32f1 test
+ */
+
+#define BOARD_INFO_NAME      "Chitu3D V5"
+#define DEFAULT_MACHINE_NAME "STM32F103ZET6"
+
+#define DISABLE_JTAG
+//
+// EEPROM
+//
+#define FLASH_EEPROM_EMULATION
+#if ENABLED(FLASH_EEPROM_EMULATION)
+  // SoC Flash (framework-arduinoststm32-maple/STM32F1/libraries/EEPROM/EEPROM.h)
+  #define EEPROM_START_ADDRESS (0x8000000UL + (512 * 1024) - 2 * EEPROM_PAGE_SIZE)
+  #define EEPROM_PAGE_SIZE     (0x800U)     // 2KB, but will use 2x more (4KB)
+  #define E2END (EEPROM_PAGE_SIZE - 1)
+#else
+  #define E2END (0x7FFU) // On SD, Limit to 2KB, require this amount of RAM
+#endif
+
+//
+// Limit Switches
+//
+#define X_MAX_PIN          -1
+#define X_MIN_PIN          PG10 
+#define Y_MAX_PIN          -1
+#define Y_MIN_PIN          PA12 
+#define Z_MAX_PIN          -1 
+#define Z_MIN_PIN          PA14
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN       PC13
+#define X_STEP_PIN         PE5
+#define X_DIR_PIN          PE6
+
+#define Y_ENABLE_PIN       PE4
+#define Y_STEP_PIN         PE2
+#define Y_DIR_PIN          PE3
+
+#define Z_ENABLE_PIN       PE1
+#define Z_STEP_PIN         PB9
+#define Z_DIR_PIN          PE0
+
+#define E0_ENABLE_PIN      PB8
+#define E0_STEP_PIN        PB4
+#define E0_DIR_PIN         PB5
+
+
+#define E1_ENABLE_PIN      PG8
+#define E1_STEP_PIN        PC7
+#define E1_DIR_PIN         PC6
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         PA1   // TH1
+#define TEMP_BED_PIN       PA0   // TB1
+
+//
+// Heaters
+//
+#define HEATER_0_PIN       PG12   // HEATER1
+#define HEATER_BED_PIN     PG11   // HOT BED
+
+//
+// Fans
+//
+#define CONTROLLER_FAN_PIN PD6   // BOARD FAN 
+#define FAN_PIN            PG13  // FAN
+#define FAN_PIN_2          PG14 
+
+//
+// Misc
+//
+#define BEEPER_PIN         PB0  
+#define LED_PIN            -1 
+#define POWER_LOSS_PIN     -1
+#define FIL_RUNOUT_PIN     PA15
+
+/**
+ * TronXY TFT Support
+ */
+//#define FSMC_GRAPHICAL_TFT
+//#define TOUCH_BUTTONS
+
+#if ENABLED(FSMC_GRAPHICAL_TFT)
+  #define FSMC_UPSCALE 3
+  #define LCD_FULL_PIXEL_WIDTH  480
+  #define LCD_PIXEL_OFFSET_X    48
+  #define LCD_FULL_PIXEL_HEIGHT 320
+
+  #define LCD_RESET_PIN      PF11
+  #define NO_LCD_REINIT 
+  #define LCD_BACKLIGHT_PIN  PD13
+  #define FSMC_CS_PIN        PD7 
+  #define FSMC_RS_PIN        PD11
+
+  #define LCD_USE_DMA_FSMC   // Use DMA transfers to send data to the TFT
+  #define FSMC_DMA_DEV       DMA2
+  #define FSMC_DMA_CHANNEL   DMA_CH5
+
+  #if ENABLED(TOUCH_BUTTONS)
+    #define TOUCH_CS_PIN     PB7  // SPI1_NSS
+    #define TOUCH_SCK_PIN    PA5  // SPI1_SCK
+    #define TOUCH_MISO_PIN   PA6  // SPI1_MISO
+    #define TOUCH_MOSI_PIN   PA7  // SPI1_MOSI
+
+    #define BUTTON_DELAY_EDIT       50 // (ms) Button repeat delay for edit screens
+    #define BUTTON_DELAY_MENU       250 // (ms) Button repeat delay for menus
+
+    #define XPT2046_X_CALIBRATION   -12316
+    #define XPT2046_Y_CALIBRATION   -8981
+    #define XPT2046_X_OFFSET        340
+    #define XPT2046_Y_OFFSET        429
+  #endif
+#endif
+
+// SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available
+// We nee to use the SPI2
+#define ENABLE_SPI2
+#define SCK_PIN           PB13 
+#define MISO_PIN          PB14 
+#define MOSI_PIN          PB15 
+#define SS_PIN            PB12
+
+
+//
+// SD Card
+//
+#define SDIO_SUPPORT 
+#define SD_DETECT_PIN     -1 // PF0, but it isn't connected
+#define SDIO_CLOCK 4500000
+#define SDIO_READ_RETRIES 16

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -33,6 +33,7 @@
 #define DEFAULT_MACHINE_NAME "STM32F103ZET6"
 
 #define DISABLE_JTAG
+
 //
 // EEPROM
 //
@@ -41,20 +42,17 @@
   // SoC Flash (framework-arduinoststm32-maple/STM32F1/libraries/EEPROM/EEPROM.h)
   #define EEPROM_START_ADDRESS (0x8000000UL + (512 * 1024) - 2 * EEPROM_PAGE_SIZE)
   #define EEPROM_PAGE_SIZE     (0x800U)     // 2KB, but will use 2x more (4KB)
-  #define E2END (EEPROM_PAGE_SIZE - 1)
+  #define MARLIN_EEPROM_SIZE EEPROM_PAGE_SIZE
 #else
-  #define E2END (0x7FFU) // On SD, Limit to 2KB, require this amount of RAM
+  #define MARLIN_EEPROM_SIZE 0x800U         // On SD, Limit to 2KB, require this amount of RAM
 #endif
 
 //
 // Limit Switches
 //
-#define X_MAX_PIN                           -1
-#define X_MIN_PIN                           PG10
-#define Y_MAX_PIN                           -1
-#define Y_MIN_PIN                           PA12
-#define Z_MAX_PIN                           -1
-#define Z_MIN_PIN                           PA14
+#define X_STOP_PIN                          PG10
+#define Y_STOP_PIN                          PA12
+#define Z_STOP_PIN                          PA14
 
 //
 // Steppers
@@ -94,7 +92,7 @@
 //
 // Fans
 //
-#define CONTROLLER_FAN_PIN                  PD6   // BOARD FAN 
+#define CONTROLLER_FAN_PIN                  PD6   // BOARD FAN
 #define FAN_PIN                             PG13  // FAN
 #define FAN_PIN_2                           PG14
 
@@ -102,13 +100,13 @@
 // Misc
 //
 #define BEEPER_PIN                          PB0
-#define LED_PIN                             -1
-#define POWER_LOSS_PIN                      -1
+//#define LED_PIN                           -1
+//#define POWER_LOSS_PIN                    -1
 #define FIL_RUNOUT_PIN                      PA15
 
-/**
- * TronXY TFT Support
- */
+//
+// TronXY TFT Support
+//
 //#define FSMC_GRAPHICAL_TFT
 //#define TOUCH_BUTTONS
 

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -135,10 +135,10 @@
     #define BUTTON_DELAY_EDIT 50                  // (ms) Button repeat delay for edit screens
     #define BUTTON_DELAY_MENU 250                 // (ms) Button repeat delay for menus
 
-    #define XPT2046_X_CALIBRATION   -12316
-    #define XPT2046_Y_CALIBRATION   -8981
-    #define XPT2046_X_OFFSET 340
-    #define XPT2046_Y_OFFSET 429
+    #define XPT2046_X_CALIBRATION  -12316
+    #define XPT2046_Y_CALIBRATION   8981
+    #define XPT2046_X_OFFSET        340
+    #define XPT2046_Y_OFFSET        -20
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -140,10 +140,10 @@
     #define BUTTON_DELAY_EDIT 50                  // (ms) Button repeat delay for edit screens
     #define BUTTON_DELAY_MENU 250                 // (ms) Button repeat delay for menus
 
-    #define XPT2046_X_CALIBRATION   -12316
-    #define XPT2046_Y_CALIBRATION   -8981
-    #define XPT2046_X_OFFSET 340
-    #define XPT2046_Y_OFFSET 429
+    #define XPT2046_X_CALIBRATION  -12316
+    #define XPT2046_Y_CALIBRATION   8981
+    #define XPT2046_X_OFFSET        340
+    #define XPT2046_Y_OFFSET        -20
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -1,0 +1,163 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#if !defined(__STM32F1__) && !defined(__STM32F4__)
+  #error "Oops! Select an STM32F1/4 board in 'Tools > Board.'"
+#endif
+
+/**
+ * 2017 Victor Perez Marlin for stm32f1 test
+ */
+
+#define BOARD_INFO_NAME      "Chitu3D"
+#define DEFAULT_MACHINE_NAME "STM32F103ZET6"
+
+#define DISABLE_JTAG
+//
+// EEPROM
+//
+#define FLASH_EEPROM_EMULATION
+#if ENABLED(FLASH_EEPROM_EMULATION)
+  // SoC Flash (framework-arduinoststm32-maple/STM32F1/libraries/EEPROM/EEPROM.h)
+  #define EEPROM_START_ADDRESS (0x8000000UL + (512 * 1024) - 2 * EEPROM_PAGE_SIZE)
+  #define EEPROM_PAGE_SIZE     (0x800U)     // 2KB, but will use 2x more (4KB)
+  #define E2END (EEPROM_PAGE_SIZE - 1)
+#else
+  #define E2END (0x7FFU) // On SD, Limit to 2KB, require this amount of RAM
+#endif
+//
+// Limit Switches
+//
+//#define X_MAX_PIN         
+#define X_MIN_PIN          PG10 
+//#define Y_MAX_PIN           
+#define Y_MIN_PIN          PA12 
+//#define Z_MAX_PIN          -1 
+#define Z_MIN_PIN          PG9
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN       PC13
+#define X_STEP_PIN         PE5
+#define X_DIR_PIN          PE6
+
+#define Y_ENABLE_PIN       PE4
+#define Y_STEP_PIN         PE2
+#define Y_DIR_PIN          PE3
+
+#define Z_ENABLE_PIN       PE1
+#define Z_STEP_PIN         PB9
+#define Z_DIR_PIN          PE0
+
+#define E0_ENABLE_PIN      PB8
+#define E0_STEP_PIN        PB4
+#define E0_DIR_PIN         PB5
+
+
+#define E1_ENABLE_PIN      PG8
+#define E1_STEP_PIN        PC7
+#define E1_DIR_PIN         PC6
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         PA1   // TH1
+#define TEMP_BED_PIN       PA0   // TB1
+
+//
+// Heaters
+//
+#define HEATER_0_PIN       PG12   // HEATER1
+#define HEATER_BED_PIN     PG11   // HOT BED
+//#define HEATER_BED_INVERTING true
+
+//
+// Fans
+//
+#define CONTROLLER_FAN_PIN PD6   // BOARD FAN 
+#define FAN_PIN            PG13  // FAN
+#define FAN_PIN_2          PG14 
+
+//
+// Misc
+//
+#define BEEPER_PIN         PB0  
+//#define LED_PIN            PD3 
+//#define POWER_LOSS_PIN     PG2   // PG4 PW_DET
+#define FIL_RUNOUT_PIN     PA15  // MT_DET 
+
+/**
+ * TronXY TFT Support
+ */
+#define FSMC_GRAPHICAL_TFT
+#define TOUCH_BUTTONS
+
+#if ENABLED(FSMC_GRAPHICAL_TFT)
+  #define FSMC_UPSCALE 3
+  #define LCD_FULL_PIXEL_WIDTH  480
+  #define LCD_PIXEL_OFFSET_X    48
+  #define LCD_FULL_PIXEL_HEIGHT 320
+
+  #define LCD_RESET_PIN      PF11
+  #define NO_LCD_REINIT 
+  #define LCD_BACKLIGHT_PIN  PD13
+  #define FSMC_CS_PIN        PD7 
+  #define FSMC_RS_PIN        PD11
+
+  #define LCD_USE_DMA_FSMC   // Use DMA transfers to send data to the TFT
+  #define FSMC_DMA_DEV       DMA2
+  #define FSMC_DMA_CHANNEL   DMA_CH5
+
+  #if ENABLED(TOUCH_BUTTONS)
+    #define TOUCH_CS_PIN     PB7  // SPI1_NSS
+    #define TOUCH_SCK_PIN    PA5  // SPI1_SCK
+    #define TOUCH_MISO_PIN   PA6  // SPI1_MISO
+    #define TOUCH_MOSI_PIN   PA7  // SPI1_MOSI
+
+    #define BUTTON_DELAY_EDIT       50 // (ms) Button repeat delay for edit screens
+    #define BUTTON_DELAY_MENU       250 // (ms) Button repeat delay for menus
+
+    #define XPT2046_X_CALIBRATION   -12316
+    #define XPT2046_Y_CALIBRATION   -8981
+    #define XPT2046_X_OFFSET        340
+    #define XPT2046_Y_OFFSET        429
+  #endif
+#endif
+
+// SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available
+// We nee to use the SPI2
+#define ENABLE_SPI2
+#define SCK_PIN           PB13 
+#define MISO_PIN          PB14 
+#define MOSI_PIN          PB15 
+#define SS_PIN            PB12
+
+
+//
+// SD Card
+//
+#define SDIO_SUPPORT 
+#define SD_DETECT_PIN     -1 // PF0, but it isn't connected
+#define SDIO_CLOCK 4500000
+#define SDIO_READ_RETRIES 16

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -33,27 +33,30 @@
 #define DEFAULT_MACHINE_NAME "STM32F103ZET6"
 
 #define DISABLE_JTAG
+
 //
 // EEPROM
 //
-#define FLASH_EEPROM_EMULATION
+
+#if NO_EEPROM_SELECTED
+  #define FLASH_EEPROM_EMULATION
+#endif
+
 #if ENABLED(FLASH_EEPROM_EMULATION)
   // SoC Flash (framework-arduinoststm32-maple/STM32F1/libraries/EEPROM/EEPROM.h)
   #define EEPROM_START_ADDRESS (0x8000000UL + (512 * 1024) - 2 * EEPROM_PAGE_SIZE)
   #define EEPROM_PAGE_SIZE     (0x800U)     // 2KB, but will use 2x more (4KB)
-  #define E2END (EEPROM_PAGE_SIZE - 1)
+  #define MARLIN_EEPROM_SIZE EEPROM_PAGE_SIZE
 #else
-  #define E2END (0x7FFU) // On SD, Limit to 2KB, require this amount of RAM
+  #define MARLIN_EEPROM_SIZE 0x800U         // On SD, Limit to 2KB, require this amount of RAM
 #endif
+
 //
 // Limit Switches
 //
-//#define X_MAX_PIN
-#define X_MIN_PIN                           PG10
-//#define Y_MAX_PIN
-#define Y_MIN_PIN                           PA12
-//#define Z_MAX_PIN                         -1
-#define Z_MIN_PIN                           PG9
+#define X_STOP_PIN                          PG10
+#define Y_STOP_PIN                          PA12
+#define Z_STOP_PIN                          PG9
 
 //
 // Steppers
@@ -94,7 +97,7 @@
 //
 // Fans
 //
-#define CONTROLLER_FAN_PIN                  PD6   // BOARD FAN 
+#define CONTROLLER_FAN_PIN                  PD6   // BOARD FAN
 #define FAN_PIN                             PG13  // FAN
 #define FAN_PIN_2                           PG14
 
@@ -104,11 +107,11 @@
 #define BEEPER_PIN                          PB0
 //#define LED_PIN                           PD3
 //#define POWER_LOSS_PIN                    PG2   // PG4 PW_DET
-#define FIL_RUNOUT_PIN                      PA15  // MT_DET 
+#define FIL_RUNOUT_PIN                      PA15  // MT_DET
 
-/**
- * TronXY TFT Support
- */
+//
+// TronXY TFT Support
+//
 #define FSMC_GRAPHICAL_TFT
 #define TOUCH_BUTTONS
 
@@ -145,7 +148,7 @@
 #endif
 
 // SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available
-// We nee to use the SPI2
+// so SPI2 is required.
 #define ENABLE_SPI2
 #define SCK_PIN                             PB13
 #define MISO_PIN                            PB14

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -48,64 +48,63 @@
 //
 // Limit Switches
 //
-//#define X_MAX_PIN         
-#define X_MIN_PIN          PG10 
-//#define Y_MAX_PIN           
-#define Y_MIN_PIN          PA12 
-//#define Z_MAX_PIN          -1 
-#define Z_MIN_PIN          PG9
+//#define X_MAX_PIN
+#define X_MIN_PIN                           PG10
+//#define Y_MAX_PIN
+#define Y_MIN_PIN                           PA12
+//#define Z_MAX_PIN                         -1
+#define Z_MIN_PIN                           PG9
 
 //
 // Steppers
 //
-#define X_ENABLE_PIN       PC13
-#define X_STEP_PIN         PE5
-#define X_DIR_PIN          PE6
+#define X_ENABLE_PIN                        PC13
+#define X_STEP_PIN                          PE5
+#define X_DIR_PIN                           PE6
 
-#define Y_ENABLE_PIN       PE4
-#define Y_STEP_PIN         PE2
-#define Y_DIR_PIN          PE3
+#define Y_ENABLE_PIN                        PE4
+#define Y_STEP_PIN                          PE2
+#define Y_DIR_PIN                           PE3
 
-#define Z_ENABLE_PIN       PE1
-#define Z_STEP_PIN         PB9
-#define Z_DIR_PIN          PE0
+#define Z_ENABLE_PIN                        PE1
+#define Z_STEP_PIN                          PB9
+#define Z_DIR_PIN                           PE0
 
-#define E0_ENABLE_PIN      PB8
-#define E0_STEP_PIN        PB4
-#define E0_DIR_PIN         PB5
+#define E0_ENABLE_PIN                       PB8
+#define E0_STEP_PIN                         PB4
+#define E0_DIR_PIN                          PB5
 
-
-#define E1_ENABLE_PIN      PG8
-#define E1_STEP_PIN        PC7
-#define E1_DIR_PIN         PC6
+#define E1_ENABLE_PIN                       PG8
+#define E1_STEP_PIN                         PC7
+#define E1_DIR_PIN                          PC6
 
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN         PA1   // TH1
-#define TEMP_BED_PIN       PA0   // TB1
+#define TEMP_0_PIN                          PA1   // TH1
+#define TEMP_BED_PIN                        PA0   // TB1
 
 //
 // Heaters
 //
-#define HEATER_0_PIN       PG12   // HEATER1
-#define HEATER_BED_PIN     PG11   // HOT BED
+#define HEATER_0_PIN                        PG12  // HEATER1
+#define HEATER_BED_PIN                      PG11  // HOT BED
 //#define HEATER_BED_INVERTING true
 
 //
 // Fans
 //
-#define CONTROLLER_FAN_PIN PD6   // BOARD FAN 
-#define FAN_PIN            PG13  // FAN
-#define FAN_PIN_2          PG14 
+#define CONTROLLER_FAN_PIN                  PD6   // BOARD FAN 
+#define FAN_PIN                             PG13  // FAN
+#define FAN_PIN_2                           PG14
 
 //
 // Misc
 //
-#define BEEPER_PIN         PB0  
-//#define LED_PIN            PD3 
-//#define POWER_LOSS_PIN     PG2   // PG4 PW_DET
-#define FIL_RUNOUT_PIN     PA15  // MT_DET 
+#define BEEPER_PIN                          PB0
+//#define LED_PIN                           PD3
+//#define POWER_LOSS_PIN                    PG2   // PG4 PW_DET
+#define FIL_RUNOUT_PIN                      PA15  // MT_DET 
 
 /**
  * TronXY TFT Support
@@ -115,49 +114,48 @@
 
 #if ENABLED(FSMC_GRAPHICAL_TFT)
   #define FSMC_UPSCALE 3
-  #define LCD_FULL_PIXEL_WIDTH  480
-  #define LCD_PIXEL_OFFSET_X    48
+  #define LCD_FULL_PIXEL_WIDTH 480
+  #define LCD_PIXEL_OFFSET_X 48
   #define LCD_FULL_PIXEL_HEIGHT 320
 
-  #define LCD_RESET_PIN      PF11
-  #define NO_LCD_REINIT 
-  #define LCD_BACKLIGHT_PIN  PD13
-  #define FSMC_CS_PIN        PD7 
-  #define FSMC_RS_PIN        PD11
+  #define LCD_RESET_PIN                     PF11
+  #define NO_LCD_REINIT
+  #define LCD_BACKLIGHT_PIN                 PD13
+  #define FSMC_CS_PIN                       PD7
+  #define FSMC_RS_PIN                       PD11
 
-  #define LCD_USE_DMA_FSMC   // Use DMA transfers to send data to the TFT
-  #define FSMC_DMA_DEV       DMA2
-  #define FSMC_DMA_CHANNEL   DMA_CH5
+  #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
+  #define FSMC_DMA_DEV                      DMA2
+  #define FSMC_DMA_CHANNEL               DMA_CH5
 
   #if ENABLED(TOUCH_BUTTONS)
-    #define TOUCH_CS_PIN     PB7  // SPI1_NSS
-    #define TOUCH_SCK_PIN    PA5  // SPI1_SCK
-    #define TOUCH_MISO_PIN   PA6  // SPI1_MISO
-    #define TOUCH_MOSI_PIN   PA7  // SPI1_MOSI
+    #define TOUCH_CS_PIN                    PB7   // SPI1_NSS
+    #define TOUCH_SCK_PIN                   PA5   // SPI1_SCK
+    #define TOUCH_MISO_PIN                  PA6   // SPI1_MISO
+    #define TOUCH_MOSI_PIN                  PA7   // SPI1_MOSI
 
-    #define BUTTON_DELAY_EDIT       50 // (ms) Button repeat delay for edit screens
-    #define BUTTON_DELAY_MENU       250 // (ms) Button repeat delay for menus
+    #define BUTTON_DELAY_EDIT 50                  // (ms) Button repeat delay for edit screens
+    #define BUTTON_DELAY_MENU 250                 // (ms) Button repeat delay for menus
 
     #define XPT2046_X_CALIBRATION   -12316
     #define XPT2046_Y_CALIBRATION   -8981
-    #define XPT2046_X_OFFSET        340
-    #define XPT2046_Y_OFFSET        429
+    #define XPT2046_X_OFFSET 340
+    #define XPT2046_Y_OFFSET 429
   #endif
 #endif
 
 // SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available
 // We nee to use the SPI2
 #define ENABLE_SPI2
-#define SCK_PIN           PB13 
-#define MISO_PIN          PB14 
-#define MOSI_PIN          PB15 
-#define SS_PIN            PB12
-
+#define SCK_PIN                             PB13
+#define MISO_PIN                            PB14
+#define MOSI_PIN                            PB15
+#define SS_PIN                              PB12
 
 //
 // SD Card
 //
-#define SDIO_SUPPORT 
-#define SD_DETECT_PIN     -1 // PF0, but it isn't connected
+#define SDIO_SUPPORT
+#define SD_DETECT_PIN                       -1    // PF0, but it isn't connected
 #define SDIO_CLOCK 4500000
 #define SDIO_READ_RETRIES 16

--- a/buildroot/share/PlatformIO/ldscripts/chitu_f103.ld
+++ b/buildroot/share/PlatformIO/ldscripts/chitu_f103.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
-  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K
-  rom (rx)  : ORIGIN = 0x08008800, LENGTH = 512K - 32K
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 60K
+  rom (rx)  : ORIGIN = 0x08008800, LENGTH = 512K - 34K
 }
 
 /* Provide memory region aliases for common.inc */

--- a/buildroot/share/PlatformIO/scripts/chitu_crypt.py
+++ b/buildroot/share/PlatformIO/scripts/chitu_crypt.py
@@ -1,12 +1,12 @@
-import os
-import struct
 Import("env")
+import os
+import random
+import struct
+import uuid
 
 # Relocate firmware from 0x08000000 to 0x08008800
-for define in env['CPPDEFINES']:
-    if define[0] == "VECT_TAB_ADDR":
-        env['CPPDEFINES'].remove(define)
-env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x8008800"))
+env['CPPDEFINES'].remove(("VECT_TAB_ADDR", "0x8000000"))
+env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08008800"))
 
 custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/chitu_f103.ld")
 for i, flag in enumerate(env["LINKFLAGS"]):
@@ -73,7 +73,9 @@ def encrypt_file(input, output_file, file_length):
     input_file = bytearray(input.read())
     block_size = 0x800
     key_length = 0x18
-    file_key = 0xDAB27F94
+
+    uid_value = uuid.uuid4()
+    file_key = int(uid_value.hex[0:8], 16)
 
     xor_crc = 0xef3d4323;
 
@@ -87,7 +89,7 @@ def encrypt_file(input, output_file, file_length):
     # encrypt the contents using a known file header key
 
     # write the file_key
-    output_file.write(struct.pack(">I", 0x947FB2DA))
+    output_file.write(struct.pack("<I", file_key))
 
     #TODO - how to enforce that the firmware aligns to block boundaries?
     block_count = int(len(input_file) / block_size)

--- a/buildroot/share/PlatformIO/scripts/chitu_crypt.py
+++ b/buildroot/share/PlatformIO/scripts/chitu_crypt.py
@@ -91,7 +91,7 @@ def encrypt_file(input, output_file, file_length):
 
     #TODO - how to enforce that the firmware aligns to block boundaries?
     block_count = int(len(input_file) / block_size)
-    print "Block Count is ", block_count
+    print ("Block Count is ", block_count)
     for block_number in range(0, block_count):
         block_offset = (block_number * block_size)
         block_end = block_offset + block_size

--- a/platformio.ini
+++ b/platformio.ini
@@ -589,7 +589,7 @@ lib_ignore  = LiquidCrystal, LiquidTWI2, Adafruit NeoPixel, TMCStepper, U8glib-H
 platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103ZE
-extra_scripts = buildroot/share/PlatformIO/scripts/chitu_crypt.py
+#extra_scripts = buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = ${common_stm32f1.build_flags}
   -DSTM32F1xx -DSTM32_XL_DENSITY
 build_unflags = ${common_stm32f1.build_unflags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -589,7 +589,7 @@ lib_ignore  = LiquidCrystal, LiquidTWI2, Adafruit NeoPixel, TMCStepper, U8glib-H
 platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103ZE
-#extra_scripts = buildroot/share/PlatformIO/scripts/chitu_crypt.py
+extra_scripts = buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = ${common_stm32f1.build_flags}
   -DSTM32F1xx -DSTM32_XL_DENSITY
 build_unflags = ${common_stm32f1.build_unflags}


### PR DESCRIPTION
### Description

Support for Tronxy X5SA V5 and V6 boards.

V5 and V6 have almost the same pins, but not all. So I kept them separated.

I have send a PR to Configurations repo too.

### Benefits

Now all Tronxy X5SA users can use marlin!!

### Related Issues

Fixes #14655
Together with: #18224 
