### PR TITLE
Fix Fysetc SD FW bootloader addr / size requirement 

### DIFF
--- a/buildroot/share/PlatformIO/ldscripts/fysetc_stm32f103rc.ld
+++ b/buildroot/share/PlatformIO/ldscripts/fysetc_stm32f103rc.ld
@@ -5,7 +5,7 @@
 MEMORY
 {
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K
-	rom (rx)  : ORIGIN = 0x08010000, LENGTH = 256K - 64K
+	rom (rx)  : ORIGIN = 0x08008000, LENGTH = 256K - 32K
 }
 
 /* Provide memory region aliases for common.inc */

--- a/buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
+++ b/buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
@@ -3,11 +3,11 @@ from os.path import join
 from os.path import expandvars
 Import("env")
 
-# Relocate firmware from 0x08000000 to 0x08010000
+# Relocate firmware from 0x08000000 to 0x08008000
 #for define in env['CPPDEFINES']:
 #    if define[0] == "VECT_TAB_ADDR":
 #        env['CPPDEFINES'].remove(define)
-#env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08010000"))
+#env['CPPDEFINES'].append(("VECT_TAB_ADDR", "0x08008000"))
 
 #custom_ld_script = os.path.abspath("buildroot/share/PlatformIO/ldscripts/fysetc_stm32f103rc.ld")
 #for i, flag in enumerate(env["LINKFLAGS"]):


### PR DESCRIPTION
### Requirements

### Description

Fixed the SD Firmware capable bootloader start address and space requirements as per latest info from Fysetc so that it actually works.

Their original code reserved 64K for a bootloader that is only 30K. 

### Benefits

The bootloader starts higher up and reserves only 32K. The newly liberated progmem lets you build Marlin with all the options you want AND enables Marlin Firmware updates from an SD Card.

### Related Issues

This fixes the large bootloader memory requirement that limited Marlin options. Please note you will need to use the new [bootloader](https://github.com/MarlinFirmware/Marlin/issues/18163#issuecomment-641316689) I modified.
