### PR TITLE
Add PID bed edit and autotune LCD menu

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -270,10 +270,6 @@ namespace Language_en {
   PROGMEM Language_Str MSG_PID_BAD_EXTRUDER_NUM            = _UxGT("Autotune failed. Bad extruder.");
   PROGMEM Language_Str MSG_PID_TEMP_TOO_HIGH               = _UxGT("Autotune failed. Temperature too high.");
   PROGMEM Language_Str MSG_PID_TIMEOUT                     = _UxGT("Autotune failed! Timeout.");
-  PROGMEM Language_Str MSG_PID_AUTOTUNE_BED                = _UxGT("PID Autotune Bed");
-  PROGMEM Language_Str MSG_PID_P_BED                       = _UxGT("PID-P Bed");
-  PROGMEM Language_Str MSG_PID_I_BED                       = _UxGT("PID-I Bed");
-  PROGMEM Language_Str MSG_PID_D_BED                       = _UxGT("PID-D Bed");
   PROGMEM Language_Str MSG_PID_P                           = _UxGT("PID-P");
   PROGMEM Language_Str MSG_PID_P_E                         = _UxGT("PID-P *");
   PROGMEM Language_Str MSG_PID_I                           = _UxGT("PID-I");

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -270,6 +270,10 @@ namespace Language_en {
   PROGMEM Language_Str MSG_PID_BAD_EXTRUDER_NUM            = _UxGT("Autotune failed. Bad extruder.");
   PROGMEM Language_Str MSG_PID_TEMP_TOO_HIGH               = _UxGT("Autotune failed. Temperature too high.");
   PROGMEM Language_Str MSG_PID_TIMEOUT                     = _UxGT("Autotune failed! Timeout.");
+  PROGMEM Language_Str MSG_PID_AUTOTUNE_BED                = _UxGT("PID Autotune Bed"); // ADDED
+  PROGMEM Language_Str MSG_PID_P_BED                       = _UxGT("PID-P Bed"); // ADDED
+  PROGMEM Language_Str MSG_PID_I_BED                       = _UxGT("PID-I Bed"); // ADDED
+  PROGMEM Language_Str MSG_PID_D_BED                       = _UxGT("PID-D Bed"); // ADDED
   PROGMEM Language_Str MSG_PID_P                           = _UxGT("PID-P");
   PROGMEM Language_Str MSG_PID_P_E                         = _UxGT("PID-P *");
   PROGMEM Language_Str MSG_PID_I                           = _UxGT("PID-I");
@@ -317,8 +321,6 @@ namespace Language_en {
   PROGMEM Language_Str MSG_MOTION                          = _UxGT("Motion");
   PROGMEM Language_Str MSG_FILAMENT                        = _UxGT("Filament");
   PROGMEM Language_Str MSG_VOLUMETRIC_ENABLED              = _UxGT("E in mm³");
-  PROGMEM Language_Str MSG_VOLUMETRIC_LIMIT                = _UxGT("E Limit in mm³");
-  PROGMEM Language_Str MSG_VOLUMETRIC_LIMIT_E              = _UxGT("E Limit *");
   PROGMEM Language_Str MSG_FILAMENT_DIAM                   = _UxGT("Fil. Dia.");
   PROGMEM Language_Str MSG_FILAMENT_DIAM_E                 = _UxGT("Fil. Dia. *");
   PROGMEM Language_Str MSG_FILAMENT_UNLOAD                 = _UxGT("Unload mm");

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -270,10 +270,10 @@ namespace Language_en {
   PROGMEM Language_Str MSG_PID_BAD_EXTRUDER_NUM            = _UxGT("Autotune failed. Bad extruder.");
   PROGMEM Language_Str MSG_PID_TEMP_TOO_HIGH               = _UxGT("Autotune failed. Temperature too high.");
   PROGMEM Language_Str MSG_PID_TIMEOUT                     = _UxGT("Autotune failed! Timeout.");
-  PROGMEM Language_Str MSG_PID_AUTOTUNE_BED                = _UxGT("PID Autotune Bed"); // ADDED
-  PROGMEM Language_Str MSG_PID_P_BED                       = _UxGT("PID-P Bed"); // ADDED
-  PROGMEM Language_Str MSG_PID_I_BED                       = _UxGT("PID-I Bed"); // ADDED
-  PROGMEM Language_Str MSG_PID_D_BED                       = _UxGT("PID-D Bed"); // ADDED
+  PROGMEM Language_Str MSG_PID_AUTOTUNE_BED                = _UxGT("PID Autotune Bed");
+  PROGMEM Language_Str MSG_PID_P_BED                       = _UxGT("PID-P Bed");
+  PROGMEM Language_Str MSG_PID_I_BED                       = _UxGT("PID-I Bed");
+  PROGMEM Language_Str MSG_PID_D_BED                       = _UxGT("PID-D Bed");
   PROGMEM Language_Str MSG_PID_P                           = _UxGT("PID-P");
   PROGMEM Language_Str MSG_PID_P_E                         = _UxGT("PID-P *");
   PROGMEM Language_Str MSG_PID_I                           = _UxGT("PID-I");
@@ -321,6 +321,8 @@ namespace Language_en {
   PROGMEM Language_Str MSG_MOTION                          = _UxGT("Motion");
   PROGMEM Language_Str MSG_FILAMENT                        = _UxGT("Filament");
   PROGMEM Language_Str MSG_VOLUMETRIC_ENABLED              = _UxGT("E in mm³");
+  PROGMEM Language_Str MSG_VOLUMETRIC_LIMIT                = _UxGT("E Limit in mm³");
+  PROGMEM Language_Str MSG_VOLUMETRIC_LIMIT_E              = _UxGT("E Limit *");
   PROGMEM Language_Str MSG_FILAMENT_DIAM                   = _UxGT("Fil. Dia.");
   PROGMEM Language_Str MSG_FILAMENT_DIAM_E                 = _UxGT("Fil. Dia. *");
   PROGMEM Language_Str MSG_FILAMENT_UNLOAD                 = _UxGT("Unload mm");

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -43,7 +43,7 @@
   #include "../../module/temperature.h"
 #endif
 
-#if ENABLED(FILAMENT_RUNOUT_SENSOR) && FILAMENT_RUNOUT_DISTANCE_MM
+#if HAS_FILAMENT_RUNOUT_DISTANCE
   #include "../../feature/runout.h"
 #endif
 
@@ -117,6 +117,14 @@ void menu_cancelobject();
     #if DISABLED(NO_VOLUMETRICS)
       EDIT_ITEM(bool, MSG_VOLUMETRIC_ENABLED, &parser.volumetric_enabled, planner.calculate_volumetric_multipliers);
 
+      #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
+        EDIT_ITEM_FAST(float42_52, MSG_VOLUMETRIC_LIMIT, &planner.volumetric_extruder_limit[active_extruder], 0.0f, 20.0f, planner.calculate_volumetric_extruder_limits);
+        #if EXTRUDERS > 1
+          LOOP_L_N(n, EXTRUDERS)
+            EDIT_ITEM_FAST_N(float42_52, n, MSG_VOLUMETRIC_LIMIT_E, &planner.volumetric_extruder_limit[n], 0.0f, 20.00f, planner.calculate_volumetric_extruder_limits);
+        #endif
+      #endif
+
       if (parser.volumetric_enabled) {
         EDIT_ITEM_FAST(float43, MSG_FILAMENT_DIAM, &planner.filament_size[active_extruder], 1.5f, 3.25f, planner.calculate_volumetric_multipliers);
         #if EXTRUDERS > 1
@@ -142,7 +150,7 @@ void menu_cancelobject();
       #endif
     #endif
 
-    #if ENABLED(FILAMENT_RUNOUT_SENSOR) && FILAMENT_RUNOUT_DISTANCE_MM
+    #if HAS_FILAMENT_RUNOUT_DISTANCE
       editable.decimal = runout.runout_distance();
       EDIT_ITEM(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, 30,
         []{ runout.set_runout_distance(editable.decimal); }, true

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -271,11 +271,11 @@ void menu_cancelobject();
 
     #if ENABLED(PID_EDIT_MENU)
       #define __PID_BASE_MENU_ITEMS(N) \
-        raw_Ki = unscalePID_i(TERN(PID_BED_MENU_SECTION, Temperature::temp_bed.pid.Ki, PID_PARAM(Ki, N))); \
-        raw_Kd = unscalePID_d(TERN(PID_BED_MENU_SECTION, Temperature::temp_bed.pid.Kd, PID_PARAM(Kd, N))); \
-        EDIT_ITEM_N(float52sign, N, TERN(PID_BED_MENU_SECTION, MSG_PID_P_BED, MSG_PID_P_E), TERN(PID_BED_MENU_SECTION, &Temperature::temp_bed.pid.Kp, &PID_PARAM(Kp, N)), 1, 9990); \
-        EDIT_ITEM_N(float52sign, N, TERN(PID_BED_MENU_SECTION, MSG_PID_I_BED, MSG_PID_I_E), &raw_Ki, 0.01f, 9990, []{ copy_and_scalePID_i(N); }); \
-        EDIT_ITEM_N(float52sign, N, TERN(PID_BED_MENU_SECTION, MSG_PID_D_BED, MSG_PID_D_E), &raw_Kd, 1, 9990, []{ copy_and_scalePID_d(N); })
+        raw_Ki = unscalePID_i(TERN(PID_BED_MENU_SECTION, thermalManager.temp_bed.pid.Ki, PID_PARAM(Ki, N))); \
+        raw_Kd = unscalePID_d(TERN(PID_BED_MENU_SECTION, thermalManager.temp_bed.pid.Kd, PID_PARAM(Kd, N))); \
+        EDIT_ITEM_N(float52sign, N, MSG_PID_P_E, &TERN(PID_BED_MENU_SECTION, thermalManager.temp_bed.pid.Kp, PID_PARAM(Kp, N)), 1, 9990); \
+        EDIT_ITEM_N(float52sign, N, MSG_PID_I_E, &raw_Ki, 0.01f, 9990, []{ copy_and_scalePID_i(N); }); \
+        EDIT_ITEM_N(float52sign, N, MSG_PID_D_E, &raw_Kd, 1, 9990, []{ copy_and_scalePID_d(N); })
 
       #if ENABLED(PID_EXTRUSION_SCALING)
         #define _PID_BASE_MENU_ITEMS(N) \
@@ -307,17 +307,16 @@ void menu_cancelobject();
       #define PID_EDIT_MENU_ITEMS(N) _PID_EDIT_MENU_ITEMS(N);
     #endif
 
-    #define PID_BED_MENU_SECTION false
     PID_EDIT_MENU_ITEMS(0);
     #if BOTH(HAS_MULTI_HOTEND, PID_PARAMS_PER_HOTEND)
       REPEAT_S(1, HOTENDS, PID_EDIT_MENU_ITEMS)
     #endif
 
     #if ENABLED(PIDTEMPBED)
-      #undef PID_BED_MENU_SECTION
-      #define PID_BED_MENU_SECTION true
       #if ENABLED(PID_EDIT_MENU)
+        #define PID_BED_MENU_SECTION
         __PID_BASE_MENU_ITEMS(-1);
+        #undef PID_BED_MENU_SECTION
       #endif
       #if ENABLED(PID_AUTOTUNE_MENU)
         #ifndef BED_OVERSHOOT

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -322,7 +322,7 @@ void menu_cancelobject();
         #ifndef BED_OVERSHOOT
           #define BED_OVERSHOOT 5
         #endif
-        EDIT_ITEM_FAST_N(int3, -1, MSG_PID_AUTOTUNE_BED, &autotune_temp_bed, 70, BED_MAXTEMP - BED_OVERSHOOT, []{ _lcd_autotune(-1); });
+        EDIT_ITEM_FAST_N(int3, -1, MSG_PID_AUTOTUNE_E, &autotune_temp_bed, 70, BED_MAXTEMP - BED_OVERSHOOT, []{ _lcd_autotune(-1); });
       #endif
     #endif
 

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -199,14 +199,14 @@ void menu_cancelobject();
   // Helpers for editing PID Ki & Kd values
   // grab the PID value out of the temp variable; scale it; then update the PID driver
   void copy_and_scalePID_i(int16_t e) {
-    #if DISABLED(PID_PARAMS_PER_HOTEND) || HOTENDS == 1 || e < 0
+    #if DISABLED(PID_PARAMS_PER_HOTEND) || HOTENDS == 1
       UNUSED(e);
     #endif
     PID_PARAM(Ki, e) = scalePID_i(raw_Ki);
     thermalManager.updatePID();
   }
   void copy_and_scalePID_d(int16_t e) {
-    #if DISABLED(PID_PARAMS_PER_HOTEND) || HOTENDS == 1 || e < 0
+    #if DISABLED(PID_PARAMS_PER_HOTEND) || HOTENDS == 1
       UNUSED(e);
     #endif
     PID_PARAM(Kd, e) = scalePID_d(raw_Kd);


### PR DESCRIPTION
### Description

At present there is no LCD menu item for the heated bed to edit or autotune PID values when PID_EDIT_MENU or PID_AUTOTUNE_MENU are enabled alongside PIDTEMPBED in Configuration.h.

### Benefits

Allows for more convenient heated bed PID value edit and autotune.

### Related Issues

#14952

### Additional notes

LCD language files other than English will need to be updated accordingly.
