### PR TITLE
Add "Bed" / "Chamber" substitutions

### DIFF
--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -35,7 +35,7 @@
  * lcd_put_u8str_ind_P
  * Print a string with an index substituted within it
  */
-lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const uint8_t ind, const lcd_uint_t maxlen/*=LCD_WIDTH*/) {
+lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const int8_t ind, const lcd_uint_t maxlen/*=LCD_WIDTH*/) {
   uint8_t *p = (uint8_t*)pstr;
   lcd_uint_t n = maxlen;
   for (; n; n--) {
@@ -43,15 +43,17 @@ lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const uint8_t ind, const lcd_ui
     p = get_utf8_value_cb(p, read_byte_rom, &ch);
     if (!ch) break;
     if (ch == '=' || ch == '~' || ch == '*') {
-      if (ch == '*') { lcd_put_wchar('E'); n--; }
       // lcd_put_int(ind); n--; if (ind >= 10) n--;
-      // if (ind >= 0)
-        {
-          lcd_put_wchar(ind + ((ch == '=') ? '0' : LCD_FIRST_TOOL));
-          n--;
-        }
-      // else if (ind == -1) { PGM_P const b = GET_TEXT(MSG_BED); lcd_put_u8str_P(b); n -= utf8_strlen_P(b); }
-      // else if (ind == -2) { PGM_P const c = GET_TEXT(MSG_CHAMBER); lcd_put_u8str_P(c); n -= utf8_strlen_P(c); }
+      if (ind >= 0) {
+        if (ch == '*') { lcd_put_wchar('E'); n--; }
+        lcd_put_wchar(ind + ((ch == '=') ? '0' : LCD_FIRST_TOOL));
+        n--;
+      }
+      else {
+        PGM_P const b = ind == -2 ? GET_TEXT(MSG_CHAMBER) : GET_TEXT(MSG_BED);
+        lcd_put_u8str_P(b);
+        n -= utf8_strlen_P(b);
+      }
       if (n) n -= lcd_put_u8str_max_P((PGM_P)p, n);
       break;
     }

--- a/Marlin/src/lcd/lcdprint.h
+++ b/Marlin/src/lcd/lcdprint.h
@@ -71,8 +71,8 @@ inline int lcd_put_u8str_P(const lcd_uint_t col, const lcd_uint_t row, PGM_P con
   return lcd_put_u8str_P(pstr);
 }
 
-lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const uint8_t ind, const lcd_uint_t maxlen=LCD_WIDTH);
-inline lcd_uint_t lcd_put_u8str_ind_P(const lcd_uint_t col, const lcd_uint_t row, PGM_P const pstr, const uint8_t ind, const lcd_uint_t maxlen=LCD_WIDTH) {
+lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const int8_t ind, const lcd_uint_t maxlen=LCD_WIDTH);
+inline lcd_uint_t lcd_put_u8str_ind_P(const lcd_uint_t col, const lcd_uint_t row, PGM_P const pstr, const int8_t ind, const lcd_uint_t maxlen=LCD_WIDTH) {
   lcd_moveto(col, row);
   return lcd_put_u8str_ind_P(pstr, ind, maxlen);
 }

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -61,7 +61,7 @@ typedef struct {
 menuPosition screen_history[6];
 uint8_t screen_history_depth = 0;
 
-uint8_t MenuItemBase::itemIndex;  // Index number for draw and action
+int8_t MenuItemBase::itemIndex;   // Index number for draw and action
 chimera_t editable;               // Value Editing
 
 // Menu Edit Items

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -65,10 +65,10 @@ class MenuItemBase {
   public:
     // An index to interject in the item label and for
     // use by the action
-    static uint8_t itemIndex;
+    static int8_t itemIndex;
 
     // Store the index of the item ahead of use by indexed items
-    FORCE_INLINE static void init(const uint8_t ind) { itemIndex = ind; }
+    FORCE_INLINE static void init(const int8_t ind) { itemIndex = ind; }
 
     // Draw an item either selected (pre_char) or not (space) with post_char
     static void _draw(const bool sel, const uint8_t row, PGM_P const pstr, const char pre_char, const char post_char);


### PR DESCRIPTION
Allow indexed menu item strings to substitute "Bed" / "Chamber" for "*".