### PR TITLE
BTT_SKR_E3_DIP - Always use 512K USB environment

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -501,7 +501,7 @@
 #elif MB(BTT_SKR_MINI_E3_V1_2)
   #include "stm32f1/pins_BTT_SKR_MINI_E3_V1_2.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(BTT_SKR_E3_DIP)
-  #include "stm32f1/pins_BTT_SKR_E3_DIP.h"      // STM32F1                                env:STM32F103RE_btt env:STM32F103RE_btt_USB env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
+  #include "stm32f1/pins_BTT_SKR_E3_DIP.h"      // STM32F1                                env:STM32F103RE_btt_USB
 #elif MB(JGAURORA_A5S_A1)
   #include "stm32f1/pins_JGAURORA_A5S_A1.h"     // STM32F1                                env:jgaurora_a5s_a1
 #elif MB(FYSETC_AIO_II)


### PR DESCRIPTION
The CPU on the  BTT_SKR_E3_DIP is a STM32F103RE which has 512K FLASH and a native USB port.

This PR reduces the environments offered for this board to one - 512K FLASH with USB composite support.  This allows immediate start of the build/upload process when using Auto Build.

Currently the BTT_SKR_E3_DIP presents with four environments - 256K FLASH vs. 512K, USB composite vs. no USB.  