### PR TITLE
Fix GTM32 Rev.B LCD Pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_GTM32_REV_B.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_REV_B.h
@@ -145,9 +145,9 @@
     // RepRapDiscount Smart Controller, but adds an FFC40 connector
     // connected with a flat wire to J2 connector on the board.
     //
-    #define LCD_PINS_RS                     PA12   // CS chip select /SS chip slave select
+    #define LCD_PINS_RS                     PA12  // CS chip select /SS chip slave select
     // RW is hardwired to VSS
-    #define LCD_PINS_ENABLE                 PC7  // SID (MOSI)
+    #define LCD_PINS_ENABLE                 PC7   // SID (MOSI)
     #define LCD_PINS_D4                     PD1   // SCK (CLK) clock
     #define LCD_PINS_D5                     PD4
     #define LCD_PINS_D6                     PD5

--- a/Marlin/src/pins/stm32f1/pins_GTM32_REV_B.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_REV_B.h
@@ -145,12 +145,13 @@
     // RepRapDiscount Smart Controller, but adds an FFC40 connector
     // connected with a flat wire to J2 connector on the board.
     //
-    #define LCD_PINS_RS                     PE6   // CS chip select /SS chip slave select
-    #define LCD_PINS_ENABLE                 PE14  // SID (MOSI)
-    #define LCD_PINS_D4                     PD8   // SCK (CLK) clock
-    #define LCD_PINS_D5                     PD9
-    #define LCD_PINS_D6                     PD10
-    #define LCD_PINS_D7                     PE15
+    #define LCD_PINS_RS                     PA12   // CS chip select /SS chip slave select
+    // RW is hardwired to VSS
+    #define LCD_PINS_ENABLE                 PC7  // SID (MOSI)
+    #define LCD_PINS_D4                     PD1   // SCK (CLK) clock
+    #define LCD_PINS_D5                     PD4
+    #define LCD_PINS_D6                     PD5
+    #define LCD_PINS_D7                     PD7
 
     #define BTN_EN1                         PE8
     #define BTN_EN2                         PE9


### PR DESCRIPTION
### Description

This PR fixes GTM32 Rev.B LCD pinout.

GTM32 Rev.B is a Geeetech board used only in an early version of their
I3 M201 printer, and no schematics have been released. Schematics have
been released for most other variants of their GTM32 board, but all of
them have different pinouts to the Rev. B board.

The existing pins in the `pins_GTM32_REV_B.h`  were copied from GTM32 Pro VB which is incorrect. As far as I am aware there is no other "GTM32 REV B" board where these pins would fit. I have had some contact with @Vertabreak who added the pin files and IIRC Vertabreak did not have access to a Rev B board, which makes me believe this is why the Pro VB pins were copied.

I reverse-engineered the LCD Pins by directly probing the LCD pins
and MCU pins to find the connected pins.

### Benefits

Getting the LCD working is the first step to fully enable the GTM32
Rev.B board in Marlin.

### Related Issues

The pinouts were originally added in this PR: https://github.com/MarlinFirmware/Marlin/pull/16020 and no functional changes were made since.
