### PR TITLE
Fix the half utf character display

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -376,28 +376,19 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
   // Draw a menu item with an editable value
   void MenuEditItemBase::draw(const bool sel, const uint8_t row, PGM_P const pstr, const char* const data, const bool pgm) {
-    int test, test1, test2;
+    int all_string_length;
   
     if (mark_as_selected(row, sel)) {
       const uint8_t vallen = (pgm ? utf8_strlen_P(data) : utf8_strlen((char*)data));
       const uint8_t pixelwidth = (pgm ? uxg_GetUtf8StrPixelWidthP(u8g.getU8g(),data) : uxg_GetUtf8StrPixelWidth(u8g.getU8g(),(char*)data));
       
-      test1 = (MENU_FONT_WIDTH) * vallen;
-      test2 = pixelwidth + 2;
-      if  (test1 > test2)
-      {
-        test = test1;
-      }
-      else
-      {
-        test = test2;
-      }
+      all_string_length = (MENU_FONT_WIDTH) * vallen;
       
       u8g_uint_t n = lcd_put_u8str_ind_P(pstr, itemIndex, LCD_WIDTH - 2 - vallen) * (MENU_FONT_WIDTH);
       if (vallen) {
         lcd_put_wchar(':');
         while (n > MENU_FONT_WIDTH) n -= lcd_put_wchar(' ');
-        lcd_moveto(LCD_PIXEL_WIDTH - test, row_y2);
+        lcd_moveto(LCD_PIXEL_WIDTH - ( all_string_length > (pixelwidth + 2) ? all_string_length : (pixelwidth + 2) ), row_y2);
         if (pgm) lcd_put_u8str_P(data); else lcd_put_u8str((char*)data);
       }
     }

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -376,19 +376,17 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
   // Draw a menu item with an editable value
   void MenuEditItemBase::draw(const bool sel, const uint8_t row, PGM_P const pstr, const char* const data, const bool pgm) {
-    int all_string_length;
-  
     if (mark_as_selected(row, sel)) {
-      const uint8_t vallen = (pgm ? utf8_strlen_P(data) : utf8_strlen((char*)data));
-      const uint8_t pixelwidth = (pgm ? uxg_GetUtf8StrPixelWidthP(u8g.getU8g(),data) : uxg_GetUtf8StrPixelWidth(u8g.getU8g(),(char*)data));
+      const uint8_t vallen = (pgm ? utf8_strlen_P(data) : utf8_strlen((char*)data)),
+                    pixelwidth = (pgm ? uxg_GetUtf8StrPixelWidthP(u8g.getU8g(), data) : uxg_GetUtf8StrPixelWidth(u8g.getU8g(), (char*)data));
       
-      all_string_length = (MENU_FONT_WIDTH) * vallen;
+      const uint16_t calc_width = (MENU_FONT_WIDTH) * vallen;
       
       u8g_uint_t n = lcd_put_u8str_ind_P(pstr, itemIndex, LCD_WIDTH - 2 - vallen) * (MENU_FONT_WIDTH);
       if (vallen) {
         lcd_put_wchar(':');
         while (n > MENU_FONT_WIDTH) n -= lcd_put_wchar(' ');
-        lcd_moveto(LCD_PIXEL_WIDTH - ( all_string_length > (pixelwidth + 2) ? all_string_length : (pixelwidth + 2) ), row_y2);
+        lcd_moveto(LCD_PIXEL_WIDTH - _MAX(calc_width, pixelwidth + 2), row_y2);
         if (pgm) lcd_put_u8str_P(data); else lcd_put_u8str((char*)data);
       }
     }

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -376,13 +376,28 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
   // Draw a menu item with an editable value
   void MenuEditItemBase::draw(const bool sel, const uint8_t row, PGM_P const pstr, const char* const data, const bool pgm) {
+    int test, test1, test2;
+  
     if (mark_as_selected(row, sel)) {
       const uint8_t vallen = (pgm ? utf8_strlen_P(data) : utf8_strlen((char*)data));
+      const uint8_t pixelwidth = (pgm ? uxg_GetUtf8StrPixelWidthP(u8g.getU8g(),data) : uxg_GetUtf8StrPixelWidth(u8g.getU8g(),(char*)data));
+      
+      test1 = (MENU_FONT_WIDTH) * vallen;
+      test2 = pixelwidth + 2;
+      if  (test1 > test2)
+      {
+        test = test1;
+      }
+      else
+      {
+        test = test2;
+      }
+      
       u8g_uint_t n = lcd_put_u8str_ind_P(pstr, itemIndex, LCD_WIDTH - 2 - vallen) * (MENU_FONT_WIDTH);
       if (vallen) {
         lcd_put_wchar(':');
         while (n > MENU_FONT_WIDTH) n -= lcd_put_wchar(' ');
-        lcd_moveto(LCD_PIXEL_WIDTH - (MENU_FONT_WIDTH) * vallen, row_y2);
+        lcd_moveto(LCD_PIXEL_WIDTH - test, row_y2);
         if (pgm) lcd_put_u8str_P(data); else lcd_put_u8str((char*)data);
       }
     }

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -379,14 +379,12 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
     if (mark_as_selected(row, sel)) {
       const uint8_t vallen = (pgm ? utf8_strlen_P(data) : utf8_strlen((char*)data)),
                     pixelwidth = (pgm ? uxg_GetUtf8StrPixelWidthP(u8g.getU8g(), data) : uxg_GetUtf8StrPixelWidth(u8g.getU8g(), (char*)data));
-      
-      const uint16_t calc_width = (MENU_FONT_WIDTH) * vallen;
-      
+
       u8g_uint_t n = lcd_put_u8str_ind_P(pstr, itemIndex, LCD_WIDTH - 2 - vallen) * (MENU_FONT_WIDTH);
       if (vallen) {
         lcd_put_wchar(':');
         while (n > MENU_FONT_WIDTH) n -= lcd_put_wchar(' ');
-        lcd_moveto(LCD_PIXEL_WIDTH - _MAX(calc_width, pixelwidth + 2), row_y2);
+        lcd_moveto(LCD_PIXEL_WIDTH - _MAX((MENU_FONT_WIDTH) * vallen, pixelwidth + 2), row_y2);
         if (pgm) lcd_put_u8str_P(data); else lcd_put_u8str((char*)data);
       }
     }


### PR DESCRIPTION
## Description
  When use the zh_CN as language, some place in the LCD menu only display half the character at the edge, it is sure a problem for utf language lcd display. After I posted a issue #18269, @ellensp given awesome clue that MenuEditItemBase::draw is the place focus to. I tested his code sample and find some side effect, and do some dirty code to fix, so far so good!

### Benefits

![utf_edge](https://user-images.githubusercontent.com/4132539/84588644-d494cd00-ae5b-11ea-8c21-8876317d9667.gif)

### Related Issues

#18269 
