### PR TITLE
Fix a Chitu V5 board issue that affects random users.

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -541,7 +541,7 @@
 #elif MB(CCROBOT_MEEB_3DP)
   #include "stm32f1/pins_CCROBOT_MEEB_3DP.h"    // STM32F1                                env:STM32F103RC_meeb
 #elif MB(CHITU3D_V5)
-  #include "stm32f1/pins_CHITU3D_V5.h"          // STM32F1                                env:chitu_f103
+  #include "stm32f1/pins_CHITU3D_V5.h"          // STM32F1                                env:chitu_f103 env:chitu_v5_gpio_init
 #elif MB(CHITU3D_V6)
   #include "stm32f1/pins_CHITU3D_V6.h"          // STM32F1                                env:chitu_f103
 

--- a/buildroot/share/PlatformIO/variants/CHITU_F103/wirish/boards_setup.cpp
+++ b/buildroot/share/PlatformIO/variants/CHITU_F103/wirish/boards_setup.cpp
@@ -92,6 +92,14 @@ namespace wirish {
         }
 
         __weak void board_setup_gpio(void) {
+            //PA14 is a pull up pin. But, some V5 boards it start with LOW state! And just behave properly when the Z- PROBE is actived at least once.
+            //So, if the sensor isnt actived, the PA14 pin will be forever in LOW state, telling Marlin the probe IS ALWAYS ACTIVE, that isnt the case!
+            //Chitu original firmware seems to start with every pullup PIN with HIGH to workaround this.
+            //So we are doing the same here.
+            //This hack only works if applied *before* the GPIO Init, it's the reason I did it here.
+            #ifdef CHITU_V5_Z_MIN_BUGFIX
+              GPIOA->regs->BSRR = (1U << PA14);
+            #endif
             gpio_init_all();
         }
 

--- a/buildroot/share/PlatformIO/variants/CHITU_F103/wirish/boards_setup.cpp
+++ b/buildroot/share/PlatformIO/variants/CHITU_F103/wirish/boards_setup.cpp
@@ -92,11 +92,13 @@ namespace wirish {
         }
 
         __weak void board_setup_gpio(void) {
-            //PA14 is a pull up pin. But, some V5 boards it start with LOW state! And just behave properly when the Z- PROBE is actived at least once.
-            //So, if the sensor isnt actived, the PA14 pin will be forever in LOW state, telling Marlin the probe IS ALWAYS ACTIVE, that isnt the case!
-            //Chitu original firmware seems to start with every pullup PIN with HIGH to workaround this.
-            //So we are doing the same here.
-            //This hack only works if applied *before* the GPIO Init, it's the reason I did it here.
+            /**
+             * PA14 is a pull up pin. But, some V5 boards it start with LOW state! And just behave properly when the Z- PROBE is actived at least once.
+             * So, if the sensor isnt actived, the PA14 pin will be forever in LOW state, telling Marlin the probe IS ALWAYS ACTIVE, that isnt the case!
+             * Chitu original firmware seems to start with every pullup PIN with HIGH to workaround this.
+             * So we are doing the same here.
+             * This hack only works if applied *before* the GPIO Init, it's the reason I did it here.
+             */
             #ifdef CHITU_V5_Z_MIN_BUGFIX
               GPIOA->regs->BSRR = (1U << PA14);
             #endif
@@ -104,12 +106,10 @@ namespace wirish {
         }
 
         __weak void board_setup_usb(void) {
-      
 
-  
 #ifdef SERIAL_USB 
 #ifdef GENERIC_BOOTLOADER     
-      //Reset the USB interface on generic boards - developed by Victor PV
+      // Reset the USB interface on generic boards - developed by Victor PV
       gpio_set_mode(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit, GPIO_OUTPUT_PP);
       gpio_write_bit(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit,0);
       
@@ -117,7 +117,7 @@ namespace wirish {
       gpio_set_mode(PIN_MAP[PA12].gpio_device, PIN_MAP[PA12].gpio_bit, GPIO_INPUT_FLOATING);
 #endif  
 
-      Serial.begin();// Roger Clark. Changed SerialUSB to Serial for Arduino sketch compatibility
+      Serial.begin(); // Roger Clark. Changed SerialUSB to Serial for Arduino sketch compatibility
 #endif
         }
 
@@ -126,6 +126,5 @@ namespace wirish {
             // interrupts work out of the box.
             afio_init();
         }
-
     }
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -651,6 +651,8 @@ extra_scripts = pre:buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
   buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = ${common_stm32f1.build_flags}
   -DSTM32F1xx -DSTM32_XL_DENSITY
+  # Random Chitu V5 boards that a problem that need a hack before the GPIO init. Uncomment this if your auto-home keeps pushing bed down, and never work
+  #-DCHITU_V5_Z_MIN_BUGFIX
 build_unflags = ${common_stm32f1.build_unflags}
   -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG= -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -651,10 +651,17 @@ extra_scripts = pre:buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
   buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = ${common_stm32f1.build_flags}
   -DSTM32F1xx -DSTM32_XL_DENSITY
-  # Random Chitu V5 boards that a problem that need a hack before the GPIO init. Uncomment this if your auto-home keeps pushing bed down, and never work
-  #-DCHITU_V5_Z_MIN_BUGFIX
 build_unflags = ${common_stm32f1.build_unflags}
   -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG= -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
+
+#
+# Some Chitu V5 boards have a problem with GPIO init.
+# Use this target if G28 or G29 are always failing.
+#
+[env:chitu_v5_gpio_init]
+platform      = ${common_stm32f1.platform}
+extends       = env:chitu_f103
+build_flags   = ${env:chitu_f103.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
 
 #
 # STM32F401VE


### PR DESCRIPTION
### Description

PA14 is a pull up pin. But, some V5 boards it start with LOW state! And just behave properly when the Z- PROBE is active at least once.

So, if the sensor isn't active once, the PA14 pin will be forever in LOW state, telling Marlin the probe IS ALWAYS ACTIVE, that isn't the case!

Chitu original firmware seems to start with every pullup PIN with HIGH to workaround this.

The fix works. I have this problem! In the beginning I though my sensor is defective. But after more users related the same behaviour, I did a lot of the tests and tracked down the problem to the board.

I waiting more users to test it. To know if more boards are affected and if we can get rid of the "#ifdef" and apply it to all Chitu boards with no risk.

### Benefits

Solve the probe problem of users with this defective board.

