### PR TITLE
Update thermistornames.h

### DIFF
--- a/Marlin/src/lcd/thermistornames.h
+++ b/Marlin/src/lcd/thermistornames.h
@@ -50,8 +50,14 @@
 // Standard thermistors
 #elif THERMISTOR_ID == 1
   #define THERMISTOR_NAME "EPCOS 100K"
+#elif THERMISTOR_ID == 331
+  #define THERMISTOR_NAME "3.3V EPCOS 100K (MEGA)"
+#elif THERMISTOR_ID == 332
+  #define THERMISTOR_NAME "3.3V EPCOS 100K (DUE)"
 #elif THERMISTOR_ID == 2
   #define THERMISTOR_NAME "ATC 204GT-2"
+#elif THERMISTOR_ID == 202
+  #define THERMISTOR_NAME "200k Copymaster 3D"
 #elif THERMISTOR_ID == 3
   #define THERMISTOR_NAME "Mendel-parts"
 #elif THERMISTOR_ID == 4
@@ -96,6 +102,8 @@
   #define THERMISTOR_NAME "Hephestos 2"
 #elif THERMISTOR_ID == 75
   #define THERMISTOR_NAME "MGB18"
+#elif THERMISTOR_ID == 99
+  #define THERMISTOR_NAME "100k with 10k pull-up"
 
 // Modified thermistors
 #elif THERMISTOR_ID == 51


### PR DESCRIPTION
### Description

Added missing thermistors to thermisternames.h. Thermistors with ID's 331, 332, 202 and 99 are available, but not present in those files. There may be required changes to naming to follow guidelines, if there are any.

### Benefits

Fixes compilation issues if there are any of troubled sensors chosen, and LCD_INFO_MENU enabled.

### Related Issues

#18280 
