### PR TITLE
Support M73 remaining time for mks_ui

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_printing.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_printing.cpp
@@ -39,6 +39,9 @@
 #if ENABLED(POWER_LOSS_RECOVERY)
   #include "../../../../feature/powerloss.h"
 #endif
+#if BOTH(LCD_SET_PROGRESS_MANUALLY, USE_M73_REMAINING_TIME)
+  #include "../../../ultralcd.h"
+#endif
 
 static lv_obj_t * scr;
 static lv_obj_t * labelExt1, * labelExt2, * labelFan, * labelZpos, * labelTime;
@@ -364,7 +367,12 @@ void disp_fan_speed() {
 
 void disp_print_time() {
   memset(public_buf_l, 0, sizeof(public_buf_l));
+#if BOTH(LCD_SET_PROGRESS_MANUALLY, USE_M73_REMAINING_TIME)
+  int r = ui.get_remaining_time();
+  sprintf(public_buf_l, "%02d:%02d R", r / 3600, (r % 3600) / 60);
+#else
   sprintf(public_buf_l, "%d%d:%d%d:%d%d", print_time.hours / 10, print_time.hours % 10, print_time.minutes / 10, print_time.minutes % 10, print_time.seconds / 10, print_time.seconds % 10);
+#endif
   lv_label_set_text(labelTime, public_buf_l);
 }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_printing.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_printing.cpp
@@ -367,12 +367,12 @@ void disp_fan_speed() {
 
 void disp_print_time() {
   memset(public_buf_l, 0, sizeof(public_buf_l));
-#if BOTH(LCD_SET_PROGRESS_MANUALLY, USE_M73_REMAINING_TIME)
-  int r = ui.get_remaining_time();
-  sprintf(public_buf_l, "%02d:%02d R", r / 3600, (r % 3600) / 60);
-#else
-  sprintf(public_buf_l, "%d%d:%d%d:%d%d", print_time.hours / 10, print_time.hours % 10, print_time.minutes / 10, print_time.minutes % 10, print_time.seconds / 10, print_time.seconds % 10);
-#endif
+  #if BOTH(LCD_SET_PROGRESS_MANUALLY, USE_M73_REMAINING_TIME)
+    const uint32_t r = ui.get_remaining_time();
+    sprintf(public_buf_l, "%02d:%02d R", r / 3600, (r % 3600) / 60);
+  #else
+    sprintf(public_buf_l, "%d%d:%d%d:%d%d", print_time.hours / 10, print_time.hours % 10, print_time.minutes / 10, print_time.minutes % 10, print_time.seconds / 10, print_time.seconds % 10);
+  #endif
   lv_label_set_text(labelTime, public_buf_l);
 }
 


### PR DESCRIPTION
Slicers like PrusaSlicer inserts M73 command with remaining time, what is really super as it gives much more information to user than just percents. This patch optionally replaces print time with remaining time (hour:minute format + "R" symbol to indicate that as is on Prusa printers)
To enable user have to uncomment LCD_SET_PROGRESS_MANUALLY, SHOW_REMAINING_TIME and USE_M73_REMAINING_TIME in Configuration_adv.h

![printing](https://user-images.githubusercontent.com/4784978/83295047-a920aa00-a1ee-11ea-81b7-e6d7df251e8a.jpg)
