### PR TITLE
Fix CMSIS / USB-FD name conflicts

### DIFF
--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/Usb.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/Usb.cpp
@@ -428,7 +428,7 @@ void USB::Task() { //USB state machine
   uint8_t rcode;
   uint8_t tmpdata;
   static uint32_t delay = 0;
-  //USB_DEVICE_DESCRIPTOR buf;
+  //USB_FD_DEVICE_DESCRIPTOR buf;
   bool lowspeed = false;
 
   MAX3421E::Task();
@@ -647,8 +647,8 @@ uint8_t USB::Configuring(uint8_t parent, uint8_t port, bool lowspeed) {
   //printf("Configuring: parent = %i, port = %i\r\n", parent, port);
   uint8_t devConfigIndex;
   uint8_t rcode = 0;
-  uint8_t buf[sizeof (USB_DEVICE_DESCRIPTOR)];
-  USB_DEVICE_DESCRIPTOR *udd = reinterpret_cast<USB_DEVICE_DESCRIPTOR *>(buf);
+  uint8_t buf[sizeof (USB_FD_DEVICE_DESCRIPTOR)];
+  USB_FD_DEVICE_DESCRIPTOR *udd = reinterpret_cast<USB_FD_DEVICE_DESCRIPTOR *>(buf);
   UsbDevice *p = nullptr;
   EpInfo *oldep_ptr = nullptr;
   EpInfo epInfo;
@@ -678,13 +678,13 @@ uint8_t USB::Configuring(uint8_t parent, uint8_t port, bool lowspeed) {
 
   p->lowspeed = lowspeed;
   // Get device descriptor
-  rcode = getDevDescr(0, 0, sizeof (USB_DEVICE_DESCRIPTOR), (uint8_t*)buf);
+  rcode = getDevDescr(0, 0, sizeof (USB_FD_DEVICE_DESCRIPTOR), (uint8_t*)buf);
 
   // Restore p->epinfo
   p->epinfo = oldep_ptr;
 
   if (rcode) {
-    //printf("Configuring error: Can't get USB_DEVICE_DESCRIPTOR\r\n");
+    //printf("Configuring error: Can't get USB_FD_DEVICE_DESCRIPTOR\r\n");
     return rcode;
   }
 
@@ -762,7 +762,7 @@ uint8_t USB::getConfDescr(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t con
 uint8_t USB::getConfDescr(uint8_t addr, uint8_t ep, uint8_t conf, USBReadParser *p) {
   const uint8_t bufSize = 64;
   uint8_t buf[bufSize];
-  USB_CONFIGURATION_DESCRIPTOR *ucd = reinterpret_cast<USB_CONFIGURATION_DESCRIPTOR *>(buf);
+  USB_FD_CONFIGURATION_DESCRIPTOR *ucd = reinterpret_cast<USB_FD_CONFIGURATION_DESCRIPTOR *>(buf);
 
   uint8_t ret = getConfDescr(addr, ep, 9, conf, buf);
   if (ret) return ret;

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/confdescparser.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/confdescparser.h
@@ -30,10 +30,10 @@
 
 class UsbConfigXtracter {
 public:
-  //virtual void ConfigXtract(const USB_CONFIGURATION_DESCRIPTOR *conf) = 0;
-  //virtual void InterfaceXtract(uint8_t conf, const USB_INTERFACE_DESCRIPTOR *iface) = 0;
+  //virtual void ConfigXtract(const USB_FD_CONFIGURATION_DESCRIPTOR *conf) = 0;
+  //virtual void InterfaceXtract(uint8_t conf, const USB_FD_INTERFACE_DESCRIPTOR *iface) = 0;
 
-  virtual void EndpointXtract(uint8_t conf __attribute__((unused)), uint8_t iface __attribute__((unused)), uint8_t alt __attribute__((unused)), uint8_t proto __attribute__((unused)), const USB_ENDPOINT_DESCRIPTOR *ep __attribute__((unused))) {
+  virtual void EndpointXtract(uint8_t conf __attribute__((unused)), uint8_t iface __attribute__((unused)), uint8_t alt __attribute__((unused)), uint8_t proto __attribute__((unused)), const USB_FD_ENDPOINT_DESCRIPTOR *ep __attribute__((unused))) {
   }
 };
 
@@ -50,7 +50,7 @@ class ConfigDescParser : public USBReadParser {
   MultiValueBuffer theBuffer;
   MultiByteValueParser valParser;
   ByteSkipper theSkipper;
-  uint8_t varBuffer[16 /*sizeof(USB_CONFIGURATION_DESCRIPTOR)*/];
+  uint8_t varBuffer[16 /*sizeof(USB_FD_CONFIGURATION_DESCRIPTOR)*/];
 
   uint8_t stateParseDescr; // ParseDescriptor state
 
@@ -97,8 +97,8 @@ void ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::Parse(const uin
   compare masks for them. When the match is found, calls EndpointXtract passing buffer containing endpoint descriptor */
 template <const uint8_t CLASS_ID, const uint8_t SUBCLASS_ID, const uint8_t PROTOCOL_ID, const uint8_t MASK>
 bool ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::ParseDescriptor(uint8_t **pp, uint16_t *pcntdn) {
-  USB_CONFIGURATION_DESCRIPTOR* ucd = reinterpret_cast<USB_CONFIGURATION_DESCRIPTOR*>(varBuffer);
-  USB_INTERFACE_DESCRIPTOR* uid = reinterpret_cast<USB_INTERFACE_DESCRIPTOR*>(varBuffer);
+  USB_FD_CONFIGURATION_DESCRIPTOR* ucd = reinterpret_cast<USB_FD_CONFIGURATION_DESCRIPTOR*>(varBuffer);
+  USB_FD_INTERFACE_DESCRIPTOR* uid = reinterpret_cast<USB_FD_INTERFACE_DESCRIPTOR*>(varBuffer);
   switch (stateParseDescr) {
     case 0:
       theBuffer.valueSize = 2;
@@ -155,7 +155,7 @@ bool ConfigDescParser<CLASS_ID, SUBCLASS_ID, PROTOCOL_ID, MASK>::ParseDescriptor
         case USB_DESCRIPTOR_ENDPOINT:
           if (!valParser.Parse(pp, pcntdn)) return false;
           if (isGoodInterface && theXtractor)
-            theXtractor->EndpointXtract(confValue, ifaceNumber, ifaceAltSet, protoValue, (USB_ENDPOINT_DESCRIPTOR*)varBuffer);
+            theXtractor->EndpointXtract(confValue, ifaceNumber, ifaceAltSet, protoValue, (USB_FD_ENDPOINT_DESCRIPTOR*)varBuffer);
           break;
           //case HID_DESCRIPTOR_HID:
           //  if (!valParser.Parse(pp, pcntdn)) return false;

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.cpp
@@ -250,10 +250,10 @@ bLastUsbError(0) {
  */
 uint8_t BulkOnly::ConfigureDevice(uint8_t parent, uint8_t port, bool lowspeed) {
 
-  const uint8_t constBufSize = sizeof (USB_DEVICE_DESCRIPTOR);
+  const uint8_t constBufSize = sizeof (USB_FD_DEVICE_DESCRIPTOR);
 
   uint8_t buf[constBufSize];
-  USB_DEVICE_DESCRIPTOR * udd = reinterpret_cast<USB_DEVICE_DESCRIPTOR*>(buf);
+  USB_FD_DEVICE_DESCRIPTOR * udd = reinterpret_cast<USB_FD_DEVICE_DESCRIPTOR*>(buf);
   uint8_t rcode;
   UsbDevice *p = nullptr;
   EpInfo *oldep_ptr = nullptr;
@@ -529,7 +529,7 @@ uint8_t BulkOnly::Init(uint8_t parent __attribute__((unused)), uint8_t port __at
  * @param proto
  * @param pep
  */
-void BulkOnly::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint8_t proto __attribute__((unused)), const USB_ENDPOINT_DESCRIPTOR * pep) {
+void BulkOnly::EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint8_t proto __attribute__((unused)), const USB_FD_ENDPOINT_DESCRIPTOR * pep) {
   ErrorMessage<uint8_t> (PSTR("Conf.Val"), conf);
   ErrorMessage<uint8_t> (PSTR("Iface Num"), iface);
   ErrorMessage<uint8_t> (PSTR("Alt.Set"), alt);
@@ -1166,7 +1166,7 @@ uint8_t BulkOnly::HandleSCSIError(uint8_t status) {
  *
  * @param ep_ptr
  */
-void BulkOnly::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR * ep_ptr) {
+void BulkOnly::PrintEndpointDescriptor(const USB_FD_ENDPOINT_DESCRIPTOR * ep_ptr) {
   Notify(PSTR("Endpoint descriptor:"), 0x80);
   Notify(PSTR("\r\nLength:\t\t"), 0x80);
   D_PrintHex<uint8_t> (ep_ptr->bLength, 0x80);

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.h
@@ -491,7 +491,7 @@ protected:
   uint16_t CurrentSectorSize[MASS_MAX_SUPPORTED_LUN]; // Sector size, clipped to 16 bits
   bool LUNOk[MASS_MAX_SUPPORTED_LUN]; // use this to check for media changes.
   bool WriteOk[MASS_MAX_SUPPORTED_LUN];
-  void PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr);
+  void PrintEndpointDescriptor(const USB_FD_ENDPOINT_DESCRIPTOR* ep_ptr);
 
   // Additional Initialization Method for Subclasses
 
@@ -526,7 +526,7 @@ public:
   virtual uint8_t GetAddress() { return bAddress; }
 
   // UsbConfigXtracter implementation
-  void EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint8_t proto, const USB_ENDPOINT_DESCRIPTOR *ep);
+  void EndpointXtract(uint8_t conf, uint8_t iface, uint8_t alt, uint8_t proto, const USB_FD_ENDPOINT_DESCRIPTOR *ep);
 
   virtual bool DEVCLASSOK(uint8_t klass) { return klass == USB_CLASS_MASS_STORAGE; }
 

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/message.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/message.cpp
@@ -37,7 +37,7 @@ int UsbDEBUGlvl = 0x80;
 void E_Notifyc(char c, int lvl) {
   if (UsbDEBUGlvl < lvl) return;
   USB_HOST_SERIAL.print(c
-    #if !defined(ARDUINO) || ARDUINO < 100
+    #if !defined(ARDUINO) && !defined(ARDUINO_ARCH_LPC176X)
       , BYTE
     #endif
   );

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/usb_ch9.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/usb_ch9.h
@@ -116,7 +116,7 @@ typedef struct {
         uint8_t iProduct; // Index of String Descriptor describing the product.
         uint8_t iSerialNumber; // Index of String Descriptor with the device's serial number.
         uint8_t bNumConfigurations; // Number of possible configurations.
-} __attribute__((packed)) USB_DEVICE_DESCRIPTOR;
+} __attribute__((packed)) USB_FD_DEVICE_DESCRIPTOR;
 
 /* Configuration descriptor structure */
 typedef struct {
@@ -128,7 +128,7 @@ typedef struct {
         uint8_t iConfiguration; // Index of String Descriptor describing the configuration.
         uint8_t bmAttributes; // Configuration characteristics.
         uint8_t bMaxPower; // Maximum power consumed by this configuration.
-} __attribute__((packed)) USB_CONFIGURATION_DESCRIPTOR;
+} __attribute__((packed)) USB_FD_CONFIGURATION_DESCRIPTOR;
 
 /* Interface descriptor structure */
 typedef struct {
@@ -141,7 +141,7 @@ typedef struct {
         uint8_t bInterfaceSubClass; // Subclass code (assigned by the USB-IF).
         uint8_t bInterfaceProtocol; // Protocol code (assigned by the USB-IF).  0xFF-Vendor specific.
         uint8_t iInterface; // Index of String Descriptor describing the interface.
-} __attribute__((packed)) USB_INTERFACE_DESCRIPTOR;
+} __attribute__((packed)) USB_FD_INTERFACE_DESCRIPTOR;
 
 /* Endpoint descriptor structure */
 typedef struct {
@@ -151,7 +151,7 @@ typedef struct {
         uint8_t bmAttributes; // Endpoint transfer type.
         uint16_t wMaxPacketSize; // Maximum packet size.
         uint8_t bInterval; // Polling interval in frames.
-} __attribute__((packed)) USB_ENDPOINT_DESCRIPTOR;
+} __attribute__((packed)) USB_FD_ENDPOINT_DESCRIPTOR;
 
 /* HID descriptor */
 typedef struct {

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_BULK_STORAGE/UHS_BULK_STORAGE.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_BULK_STORAGE/UHS_BULK_STORAGE.h
@@ -174,7 +174,7 @@ protected:
         volatile uint16_t CurrentSectorSize[MASS_MAX_SUPPORTED_LUN]; // Sector size, clipped to 16 bits
         volatile bool LUNOk[MASS_MAX_SUPPORTED_LUN]; // use this to check for media changes.
         volatile bool WriteOk[MASS_MAX_SUPPORTED_LUN];
-        void PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR* ep_ptr);
+        void PrintEndpointDescriptor(const USB_FD_ENDPOINT_DESCRIPTOR* ep_ptr);
 
 public:
         UHS_Bulk_Storage(UHS_USB_HOST_BASE *p);

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_BULK_STORAGE/UHS_BULK_STORAGE_INLINE.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_BULK_STORAGE/UHS_BULK_STORAGE_INLINE.h
@@ -1188,7 +1188,7 @@ uint8_t UHS_NI UHS_Bulk_Storage::HandleSCSIError(uint8_t status) {
  *
  * @param ep_ptr
  */
-void UHS_NI UHS_Bulk_Storage::PrintEndpointDescriptor(const USB_ENDPOINT_DESCRIPTOR * ep_ptr) {
+void UHS_NI UHS_Bulk_Storage::PrintEndpointDescriptor(const USB_FD_ENDPOINT_DESCRIPTOR * ep_ptr) {
         Notify(PSTR("Endpoint descriptor:"), 0x80);
         Notify(PSTR("\r\nLength:\t\t"), 0x80);
         D_PrintHex<uint8_t > (ep_ptr->bLength, 0x80);

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_host_INLINE.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_host_INLINE.h
@@ -239,12 +239,12 @@ uint8_t UHS_USB_HOST_BASE::Configuring(uint8_t parent, uint8_t port, uint8_t spe
         // wrap in {} to throw away the 64 byte buffer when we are done with it
         {
                 uint8_t buf[biggest];
-                USB_DEVICE_DESCRIPTOR *udd = reinterpret_cast<USB_DEVICE_DESCRIPTOR *>(buf);
+                USB_FD_DEVICE_DESCRIPTOR *udd = reinterpret_cast<USB_FD_DEVICE_DESCRIPTOR *>(buf);
 #else
         const uint8_t biggest = 18;
         uint8_t buf[biggest];
-        USB_DEVICE_DESCRIPTOR *udd = reinterpret_cast<USB_DEVICE_DESCRIPTOR *>(buf);
-        USB_CONFIGURATION_DESCRIPTOR *ucd = reinterpret_cast<USB_CONFIGURATION_DESCRIPTOR *>(buf);
+        USB_FD_DEVICE_DESCRIPTOR *udd = reinterpret_cast<USB_FD_DEVICE_DESCRIPTOR *>(buf);
+        USB_FD_CONFIGURATION_DESCRIPTOR *ucd = reinterpret_cast<USB_FD_CONFIGURATION_DESCRIPTOR *>(buf);
 #endif
 
                 //for(devConfigIndex = 0; devConfigIndex < UHS_HOST_MAX_INTERFACE_DRIVERS; devConfigIndex++) {
@@ -309,7 +309,7 @@ again:
                                 sof_delay(200);
                                 goto again;
                         }
-                        HOST_DEBUG("Configuring error: 0x%2.2x Can't get USB_DEVICE_DESCRIPTOR\r\n", rcode);
+                        HOST_DEBUG("Configuring error: 0x%2.2x Can't get USB_FD_DEVICE_DESCRIPTOR\r\n", rcode);
                         return rcode;
                 }
 
@@ -378,7 +378,7 @@ again:
         } // unwrapped, old large buf now invalid and discarded.
 
         uint8_t buf[18];
-        USB_CONFIGURATION_DESCRIPTOR *ucd = reinterpret_cast<USB_CONFIGURATION_DESCRIPTOR *>(buf);
+        USB_FD_CONFIGURATION_DESCRIPTOR *ucd = reinterpret_cast<USB_FD_CONFIGURATION_DESCRIPTOR *>(buf);
 #endif
 
         ei.address = addrPool.AllocAddress(parent, IsHub(ei.klass), port);
@@ -415,9 +415,9 @@ again:
                 HOST_DEBUG("configs: %i\r\n", configs);
                 for(uint8_t conf = 0; (!rcode) && (conf < configs); conf++) {
                         // read the config descriptor into a buffer.
-                        rcode = getConfDescr(ei.address, sizeof (USB_CONFIGURATION_DESCRIPTOR), conf, buf);
+                        rcode = getConfDescr(ei.address, sizeof (USB_FD_CONFIGURATION_DESCRIPTOR), conf, buf);
                         if(rcode) {
-                                HOST_DEBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR\r\n", rcode);
+                                HOST_DEBUG("Configuring error: %2.2x Can't get USB_FD_INTERFACE_DESCRIPTOR\r\n", rcode);
                                 rcode = UHS_HOST_ERROR_FailGetConfDescr;
                                 continue;
                         }
@@ -438,7 +438,7 @@ again:
                         uint8_t offset;
                         rcode = initDescrStream(&ei, ucd, pep, data, &left, &read, &offset);
                         if(rcode) {
-                                HOST_DEBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
+                                HOST_DEBUG("Configuring error: %2.2x Can't get USB_FD_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
                                 break;
                         }
                         for(; (numinf) && (!rcode); inf++) {
@@ -451,7 +451,7 @@ again:
                                         break;
                                 }
                                 if(rcode) {
-                                        HOST_DEBUG("Configuring error: %2.2x Can't close USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
+                                        HOST_DEBUG("Configuring error: %2.2x Can't close USB_FD_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
                                         continue;
                                 }
                                 rcode = TestInterface(&ei);
@@ -471,9 +471,9 @@ again:
                 if(!bestsuccess) rcode = UHS_HOST_ERROR_DEVICE_NOT_SUPPORTED;
         }
         if(!rcode) {
-                rcode = getConfDescr(ei.address, sizeof (USB_CONFIGURATION_DESCRIPTOR), bestconf, buf);
+                rcode = getConfDescr(ei.address, sizeof (USB_FD_CONFIGURATION_DESCRIPTOR), bestconf, buf);
                 if(rcode) {
-                        HOST_DEBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR\r\n", rcode);
+                        HOST_DEBUG("Configuring error: %2.2x Can't get USB_FD_INTERFACE_DESCRIPTOR\r\n", rcode);
                         rcode = UHS_HOST_ERROR_FailGetConfDescr;
                 }
         }
@@ -497,7 +497,7 @@ again:
                                 uint8_t offset;
                                 rcode = initDescrStream(&ei, ucd, pep, data, &left, &read, &offset);
                                 if(rcode) {
-                                        HOST_DEBUG("Configuring error: %2.2x Can't get USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
+                                        HOST_DEBUG("Configuring error: %2.2x Can't get USB_FD_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
                                 } else {
                                         for(; (numinf) && (!rcode); inf++) {
                                                 // iterate for each interface on this config
@@ -508,7 +508,7 @@ again:
                                                         break;
                                                 }
                                                 if(rcode) {
-                                                        HOST_DEBUG("Configuring error: %2.2x Can't close USB_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
+                                                        HOST_DEBUG("Configuring error: %2.2x Can't close USB_FD_INTERFACE_DESCRIPTOR stream.\r\n", rcode);
                                                         continue;
                                                 }
 
@@ -721,7 +721,7 @@ uint8_t UHS_USB_HOST_BASE::inTransfer(uint8_t addr, uint8_t ep, uint16_t *nbytes
  * @param offset
  * @return zero for success or error code
  */
-uint8_t UHS_USB_HOST_BASE::initDescrStream(ENUMERATION_INFO *ei, USB_CONFIGURATION_DESCRIPTOR *ucd, UHS_EpInfo *pep, uint8_t *data, uint16_t *left, uint16_t *read, uint8_t *offset) {
+uint8_t UHS_USB_HOST_BASE::initDescrStream(ENUMERATION_INFO *ei, USB_FD_CONFIGURATION_DESCRIPTOR *ucd, UHS_EpInfo *pep, uint8_t *data, uint16_t *left, uint16_t *read, uint8_t *offset) {
         if(!ei || !ucd) return UHS_HOST_ERROR_BAD_ARGUMENT;
         if(!pep) return UHS_HOST_ERROR_NULL_EPINFO;
         *left = ucd->wTotalLength;
@@ -837,7 +837,7 @@ uint8_t UHS_USB_HOST_BASE::getNextInterface(ENUMERATION_INFO *ei, UHS_EpInfo *pe
         return rcode;
 }
 
-uint8_t UHS_USB_HOST_BASE::seekInterface(ENUMERATION_INFO *ei, uint16_t inf, USB_CONFIGURATION_DESCRIPTOR *ucd) {
+uint8_t UHS_USB_HOST_BASE::seekInterface(ENUMERATION_INFO *ei, uint16_t inf, USB_FD_CONFIGURATION_DESCRIPTOR *ucd) {
         if(!ei || !ucd) return UHS_HOST_ERROR_BAD_ARGUMENT;
         uint8_t data[ei->bMaxPacketSize0];
         UHS_EpInfo *pep;

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_usb_ch9.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_usb_ch9.h
@@ -164,7 +164,7 @@ typedef struct {
         uint8_t iProduct; // Index of String Descriptor describing the product.
         uint8_t iSerialNumber; // Index of String Descriptor with the device's serial number.
         uint8_t bNumConfigurations; // Number of possible configurations.
-} __attribute__((packed)) USB_DEVICE_DESCRIPTOR;
+} __attribute__((packed)) USB_FD_DEVICE_DESCRIPTOR;
 
 /* Configuration descriptor structure */
 typedef struct {
@@ -176,7 +176,7 @@ typedef struct {
         uint8_t iConfiguration; // Index of String Descriptor describing the configuration.
         uint8_t bmAttributes; // Configuration characteristics.
         uint8_t bMaxPower; // Maximum power consumed by this configuration.
-} __attribute__((packed)) USB_CONFIGURATION_DESCRIPTOR;
+} __attribute__((packed)) USB_FD_CONFIGURATION_DESCRIPTOR;
 
 /* Interface descriptor structure */
 typedef struct {
@@ -189,7 +189,7 @@ typedef struct {
         uint8_t bInterfaceSubClass; // Subclass code (assigned by the USB-IF).
         uint8_t bInterfaceProtocol; // Protocol code (assigned by the USB-IF).  0xFF-Vendor specific.
         uint8_t iInterface; // Index of String Descriptor describing the interface.
-} __attribute__((packed)) USB_INTERFACE_DESCRIPTOR;
+} __attribute__((packed)) USB_FD_INTERFACE_DESCRIPTOR;
 
 /* Endpoint descriptor structure */
 typedef struct {
@@ -199,7 +199,7 @@ typedef struct {
         uint8_t bmAttributes; // Endpoint transfer type.
         uint16_t wMaxPacketSize; // Maximum packet size.
         uint8_t bInterval; // Polling interval in frames.
-} __attribute__((packed)) USB_ENDPOINT_DESCRIPTOR;
+} __attribute__((packed)) USB_FD_ENDPOINT_DESCRIPTOR;
 
 /* HID descriptor */
 /*

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_usbhost.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_usbhost.h
@@ -207,7 +207,7 @@ public:
                 interrupts();
         }
 
-        uint8_t UHS_NI seekInterface(ENUMERATION_INFO *ei, uint16_t inf, USB_CONFIGURATION_DESCRIPTOR *ucd);
+        uint8_t UHS_NI seekInterface(ENUMERATION_INFO *ei, uint16_t inf, USB_FD_CONFIGURATION_DESCRIPTOR *ucd);
 
         uint8_t UHS_NI setEpInfoEntry(uint8_t addr, uint8_t iface, uint8_t epcount, volatile UHS_EpInfo* eprecord_ptr);
 
@@ -261,7 +261,7 @@ public:
         uint8_t TestInterface(ENUMERATION_INFO *ei);
         uint8_t enumerateInterface(ENUMERATION_INFO *ei);
         uint8_t getNextInterface(ENUMERATION_INFO *ei, UHS_EpInfo *pep, uint8_t data[], uint16_t *left, uint16_t *read, uint8_t *offset);
-        uint8_t initDescrStream(ENUMERATION_INFO *ei, USB_CONFIGURATION_DESCRIPTOR *ucd, UHS_EpInfo *pep, uint8_t *data, uint16_t *left, uint16_t *read, uint8_t *offset);
+        uint8_t initDescrStream(ENUMERATION_INFO *ei, USB_FD_CONFIGURATION_DESCRIPTOR *ucd, UHS_EpInfo *pep, uint8_t *data, uint16_t *left, uint16_t *read, uint8_t *offset);
         uint8_t outTransfer(uint8_t addr, uint8_t ep, uint16_t nbytes, uint8_t* data);
         uint8_t inTransfer(uint8_t addr, uint8_t ep, uint16_t *nbytesptr, uint8_t* data);
         uint8_t doSoftReset(uint8_t parent, uint8_t port, uint8_t address);


### PR DESCRIPTION
### Requirements

A LPC1768/9 based board. 
```cpp
#define SDSUPPORT
#define USB_FLASH_DRIVE_SUPPORT
```
and set some pins
```cpp
    #define USB_CS_PIN    P0_16 //SDSS
    #define USB_INTR_PIN  P1_31 //SD_DETECT_PIN
```
### Description

This Combination of hardware will not currently compile. 
There are conflicts in the names of variables in the USB flashdrive subsystem and the LPC CMSIS
Renamed the variables not to conflict with LPC CMSIS  

### Benefits

It now compiles.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/18313