### PR TITLE
Update FYSETC S6 variant

### DIFF
--- a/buildroot/share/PlatformIO/variants/FYSETC_S6/variant.h
+++ b/buildroot/share/PlatformIO/variants/FYSETC_S6/variant.h
@@ -132,7 +132,7 @@ extern "C" {
 // Timer Definitions
 // Do not use timer used by PWM pin. See PinMap_PWM.
 #define TIMER_TONE              TIM6
-#define TIMER_SERVO             TIM2
+#define TIMER_SERVO             TIM5
 #define TIMER_SERIAL            TIM7
 
 // UART Definitions


### PR DESCRIPTION
Change TIMER_SERVO from TIM2 -> TIM5, TIM2 is for FAN2 and heater control.
