### PR TITLE
Fix: ANALOG_OK always fails

### DIFF
--- a/Marlin/src/pins/pinsDebug_list.h
+++ b/Marlin/src/pins/pinsDebug_list.h
@@ -30,7 +30,7 @@
 // Analog Pin Assignments
 //
 
-#define ANALOG_OK(PN) ((PN) >= 0 && (PN) < NUM_ANALOG_PINS)
+#define ANALOG_OK(PN) ((PN) >= 0 && (PN) < NUM_ANALOG_INPUTS)
 
 #if defined(EXT_AUX_A0) && ANALOG_OK(EXT_AUX_A0)
   REPORT_NAME_ANALOG(__LINE__, EXT_AUX_A0)


### PR DESCRIPTION
### Requirements

Enable PINS_DEBUGGING. 

### Description

Send a M43, note there are no analog pins with any names

### Benefits

M43 now contains analog pin names

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/18329
https://github.com/MarlinFirmware/Marlin/issues/17205