### PR TITLE
Fix #17205 Don't setup encoder pins with a ZONESTAR_LCD

### DIFF
--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -707,7 +707,7 @@
 
 #endif // HAS_SPI_LCD
 
-#if ENABLED(REPRAPWORLD_KEYPAD) && DISABLED(ZONESTAR_LCD)
+#if ENABLED(REPRAPWORLD_KEYPAD) && DISABLED(ADC_KEYPAD)
   #define SHIFT_OUT                           40
   #define SHIFT_CLK                           44
   #define SHIFT_LD                            42

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -707,7 +707,7 @@
 
 #endif // HAS_SPI_LCD
 
-#if ENABLED(REPRAPWORLD_KEYPAD) && !ENABLED(ZONESTAR_LCD)
+#if ENABLED(REPRAPWORLD_KEYPAD) && DISABLED(ZONESTAR_LCD)
   #define SHIFT_OUT                           40
   #define SHIFT_CLK                           44
   #define SHIFT_LD                            42

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -707,7 +707,7 @@
 
 #endif // HAS_SPI_LCD
 
-#if ENABLED(REPRAPWORLD_KEYPAD)
+#if ENABLED(REPRAPWORLD_KEYPAD) && !ENABLED(ZONESTAR_LCD)
   #define SHIFT_OUT                           40
   #define SHIFT_CLK                           44
   #define SHIFT_LD                            42


### PR DESCRIPTION
### Requirements

A Zonestar LCD on a controller that includes "pins_RAMPS.h" such as the ZRIB motherboard. 

### Description

The current pins_RAMPS.h incorrectly sets up encoder pins when a ZONESTAR_LCD is selected.
The ZONESTAR_LCD has 5 buttons on a ADC pin not an encoder.
This can (and has) lead to pin conflicts.

### Benefits

Disables setting up to Encoder pins if ZONESTAR_LCD is set.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/17205