### PR TITLE
fix BABYSTEP_XY problem on CoreXY

### DIFF
--- a/Marlin/src/feature/babystep.cpp
+++ b/Marlin/src/feature/babystep.cpp
@@ -54,22 +54,12 @@ void Babystep::add_mm(const AxisEnum axis, const float &mm) {
 }
 
 void Babystep::add_steps(const AxisEnum axis, const int16_t distance) {
-
   if (DISABLED(BABYSTEP_WITHOUT_HOMING) && !TEST(axis_known_position, axis)) return;
 
   accum += distance; // Count up babysteps for the UI
-  TERN_(BABYSTEP_DISPLAY_TOTAL, axis_total[BS_TOTAL_IND(axis)] += distance);
-
-  #if ENABLED(BABYSTEP_ALWAYS_AVAILABLE)
-    #define BSA_ENABLE(AXIS) do{ switch (AXIS) { case X_AXIS: ENABLE_AXIS_X(); break; case Y_AXIS: ENABLE_AXIS_Y(); break; case Z_AXIS: ENABLE_AXIS_Z(); break; default: break; } }while(0)
-  #else
-    #define BSA_ENABLE(AXIS) NOOP
-  #endif
-
   steps[BS_AXIS_IND(axis)] += distance;
-
+  TERN_(BABYSTEP_DISPLAY_TOTAL, axis_total[BS_TOTAL_IND(axis)] += distance);
   TERN_(BABYSTEP_ALWAYS_AVAILABLE, gcode.reset_stepper_timeout());
-
   TERN_(INTEGRATED_BABYSTEPPING, if (has_steps()) stepper.initiateBabystepping());
 }
 

--- a/Marlin/src/feature/babystep.cpp
+++ b/Marlin/src/feature/babystep.cpp
@@ -66,45 +66,7 @@ void Babystep::add_steps(const AxisEnum axis, const int16_t distance) {
     #define BSA_ENABLE(AXIS) NOOP
   #endif
 
-  #if IS_CORE
-    #if ENABLED(BABYSTEP_XY)
-      switch (axis) {
-        case CORE_AXIS_1: // X on CoreXY and CoreXZ, Y on CoreYZ
-          BSA_ENABLE(CORE_AXIS_1);
-          BSA_ENABLE(CORE_AXIS_2);
-          steps[CORE_AXIS_1] += distance * 2;
-          steps[CORE_AXIS_2] += distance * 2;
-          break;
-        case CORE_AXIS_2: // Y on CoreXY, Z on CoreXZ and CoreYZ
-          BSA_ENABLE(CORE_AXIS_1);
-          BSA_ENABLE(CORE_AXIS_2);
-          steps[CORE_AXIS_1] += CORESIGN(distance * 2);
-          steps[CORE_AXIS_2] -= CORESIGN(distance * 2);
-          break;
-        case NORMAL_AXIS: // Z on CoreXY, Y on CoreXZ, X on CoreYZ
-        default:
-          BSA_ENABLE(NORMAL_AXIS);
-          steps[NORMAL_AXIS] += distance;
-          break;
-      }
-    #elif CORE_IS_XZ || CORE_IS_YZ
-      // Only Z stepping needs to be handled here
-      BSA_ENABLE(CORE_AXIS_1);
-      BSA_ENABLE(CORE_AXIS_2);
-      steps[CORE_AXIS_1] += CORESIGN(distance * 2);
-      steps[CORE_AXIS_2] -= CORESIGN(distance * 2);
-    #else
-      BSA_ENABLE(Z_AXIS);
-      steps[Z_AXIS] += distance;
-    #endif
-  #else
-    #if ENABLED(BABYSTEP_XY)
-      BSA_ENABLE(axis);
-    #else
-      BSA_ENABLE(Z_AXIS);
-    #endif
-    steps[BS_AXIS_IND(axis)] += distance;
-  #endif
+  steps[BS_AXIS_IND(axis)] += distance;
 
   TERN_(BABYSTEP_ALWAYS_AVAILABLE, gcode.reset_stepper_timeout());
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2850,7 +2850,7 @@ void Stepper::report_positions() {
 
         case Y_AXIS:
           #if CORE_IS_XY
-            BABYSTEP_CORE(X, Y, 0, direction, (CORESIGN(1)<0));
+            BABYSTEP_CORE(X, Y, 1, !direction, (CORESIGN(1)>0));
           #elif CORE_IS_YZ
             BABYSTEP_CORE(Y, Z, 0, direction, (CORESIGN(1)<0));
           #else


### PR DESCRIPTION
Signed-off-by: brian park <gouache95@gmail.com>

### Requirements

BABYSTEP_XY is not working on CoreXY

### Description

there's duplicated code for CORE kinematics in babystep.cpp and stepper.cpp

### Benefits

CoreXY babystep_xy feature works well

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/18134
https://github.com/MarlinFirmware/Marlin/issues/18330
another CORE system (CORE_IS_YZ or CORE_IS_XZ) needs testing
