### PR TITLE
Update Robin Nano Pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -105,7 +105,7 @@
   #endif
 #endif
 #ifndef FAN_PIN
-  #define FAN_PIN                           PB1
+  #define FAN_PIN                           PB1   // FAN
 #endif
 #ifndef HEATER_BED_PIN
   #define HEATER_BED_PIN                    PA0

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -92,11 +92,24 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN                        PC3   // HEATER1
-#define HEATER_1_PIN                        PB0   // HEATER2
-#define HEATER_BED_PIN                      PA0   // HOT BED
-
-#define FAN_PIN                             PB1   // FAN
+#ifndef HEATER_0_PIN
+  #define HEATER_0_PIN                      PC3
+#endif
+#if HOTENDS == 1
+  #ifndef FAN1_PIN
+    #define FAN1_PIN                        PB0
+  #endif
+#else
+  #ifndef HEATER_1_PIN
+    #define HEATER_1_PIN                    PB0
+  #endif
+#endif
+#ifndef FAN_PIN
+  #define FAN_PIN                           PB1
+#endif
+#ifndef HEATER_BED_PIN
+  #define HEATER_BED_PIN                    PA0
+#endif
 
 //
 // Thermocouples
@@ -127,11 +140,13 @@
 // SD Card
 //
 #ifndef SDCARD_CONNECTION
-  //#define SDCARD_CONNECTION            ONBOARD
+  #define SDCARD_CONNECTION              ONBOARD
 #endif
 
 #define SDIO_SUPPORT
+#define SDIO_CLOCK                       4500000   // 4.5 MHz
 #define SD_DETECT_PIN                       PD12
+#define ONBOARD_SD_CS_PIN                   PC11
 
 //
 // LCD / Controller


### PR DESCRIPTION
### Description

Hotend/fan-related fixes: Users can now override pins in their configs. `FAN1_PIN` is now defined for automatic hotend cooling, similar to how it's done in other pins files. 

SD-related fixes: `SDIO_CLOCK` is now defined to prevent read errors. `ONBOARD_SD_CS_PIN` is also defined to fix the "not in scope" error. `SDCARD_CONNECTION` is set to `ONBOARD` by default if not defined.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/18217, https://github.com/MarlinFirmware/Marlin/issues/18346