### PR TITLE
fix 'No homing of y-axis' bug

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1534,8 +1534,7 @@ void homeaxis(const AxisEnum axis) {
     // Only Z homing (with probe) is permitted
     if (axis != Z_AXIS) { BUZZ(100, 880); return; }
   #else
-    #define _CAN_HOME(A) (axis == _AXIS(A) && ( \
-         ENABLED(A##_SPI_SENSORLESS)) \
+    #define _CAN_HOME(A) (axis == _AXIS(A) && ENABLED(A##_SPI_SENSORLESS) \
       || (_AXIS(A) == Z_AXIS && ENABLED(HOMING_Z_WITH_PROBE)) \
       || (A##_MIN_PIN > 0 && A##_HOME_DIR < 0) \
       || (A##_MAX_PIN > 0 && A##_HOME_DIR > 0) \

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1535,11 +1535,11 @@ void homeaxis(const AxisEnum axis) {
     if (axis != Z_AXIS) { BUZZ(100, 880); return; }
   #else
     #define _CAN_HOME(A) (axis == _AXIS(A) && ( \
-         ENABLED(A##_SPI_SENSORLESS) \
+         ENABLED(A##_SPI_SENSORLESS)) \
       || (_AXIS(A) == Z_AXIS && ENABLED(HOMING_Z_WITH_PROBE)) \
       || (A##_MIN_PIN > 0 && A##_HOME_DIR < 0) \
       || (A##_MAX_PIN > 0 && A##_HOME_DIR > 0) \
-    ))
+    )
     if (!_CAN_HOME(X) && !_CAN_HOME(Y) && !_CAN_HOME(Z)) return;
   #endif
 


### PR DESCRIPTION
Signed-off-by: brian park <gouache95@gmail.com>

### Requirements

CoreXY G28 Y is not working, so I fixed related bug.

### Description

_CAN_HOME(A) macro always return 0, threre's some wrong parentheses close.

### Benefits

G28 and G28 Y works well

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/18212
