### PR TITLE
fix 'No homing of y-axis' bug

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1537,8 +1537,8 @@ void homeaxis(const AxisEnum axis) {
     #define _CAN_HOME(A) (axis == _AXIS(A) && ( \
          ENABLED(A##_SPI_SENSORLESS) \
       || (_AXIS(A) == Z_AXIS && ENABLED(HOMING_Z_WITH_PROBE)) \
-      || (A##_MIN_PIN > 0 && A##_HOME_DIR < 0) \
-      || (A##_MAX_PIN > 0 && A##_HOME_DIR > 0) \
+      || (A##_MIN_PIN > -1 && A##_HOME_DIR < 0) \
+      || (A##_MAX_PIN > -1 && A##_HOME_DIR > 0) \
     ))
     if (!_CAN_HOME(X) && !_CAN_HOME(Y) && !_CAN_HOME(Z)) return;
   #endif


### PR DESCRIPTION
Signed-off-by: brian park <gouache95@gmail.com>

### Requirements

CoreXY G28 Y is not working, so I fixed related bug.

### Description

_CAN_HOME(Y) macro always return 0.
the reason is Y_MAX_PIN is 0, but _CAN_HOME macro check whether the pin is bigger than 0 or not.

0 is real pin number, not DISABLED.
I can check the variant.h in BIGTREE_SKR_PRO_1v1 like below.

~/.platformio/packages/framework-arduinoststm32/variants/BIGTREE_SKR_PRO_1v1/variant.h
#if STM32F4X_PIN_NUM >= 64  //64 pins mcu, 51 gpio
  **#define PC13  0**
  #define PC14  1 //OSC32_IN
  #define PC15  2 //OSC32_OUT
  .....

pins_BTT_GTR_V1.0.h is
```
//
// Limit Switches
//
#define Y_MIN_PIN                           PG9
#define Y_MAX_PIN                           PC13
```

so I change the comparison number to '-1' from '0'

### Benefits

G28 and G28 Y works well

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/18212
