### PR TITLE
Add BigTreeTech SKR Pro 1.2 motherboard

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -333,14 +333,15 @@
 #define BOARD_BLACK_STM32F407ZE       4207  // BLACK_STM32F407ZE
 #define BOARD_STEVAL_3DP001V1         4208  // STEVAL-3DP001V1 3D PRINTER BOARD
 #define BOARD_BTT_SKR_PRO_V1_1        4209  // BigTreeTech SKR Pro v1.1 (STM32F407ZG)
-#define BOARD_BTT_BTT002_V1_0         4210  // BigTreeTech BTT002 v1.0 (STM32F407VG)
-#define BOARD_BTT_GTR_V1_0            4211 // BigTreeTech GTR v1.0 (STM32F407IGT)
-#define BOARD_LERDGE_K                4212  // Lerdge K (STM32F407ZG)
-#define BOARD_LERDGE_X                4213  // Lerdge X (STM32F407VE)
-#define BOARD_VAKE403D                4214  // VAkE 403D (STM32F446VET6)
-#define BOARD_FYSETC_S6               4215  // FYSETC S6 board
-#define BOARD_FLYF407ZG               4216  // FLYF407ZG board (STM32F407ZG)
-#define BOARD_MKS_ROBIN2              4217  // MKS_ROBIN2 (STM32F407ZE)
+#define BOARD_BTT_SKR_PRO_V1_2        4210  // BigTreeTech SKR Pro v1.2 (STM32F407ZG)
+#define BOARD_BTT_BTT002_V1_0         4211  // BigTreeTech BTT002 v1.0 (STM32F407VG)
+#define BOARD_BTT_GTR_V1_0            4212  // BigTreeTech GTR v1.0 (STM32F407IGT)
+#define BOARD_LERDGE_K                4213  // Lerdge K (STM32F407ZG)
+#define BOARD_LERDGE_X                4214  // Lerdge X (STM32F407VE)
+#define BOARD_VAKE403D                4215  // VAkE 403D (STM32F446VET6)
+#define BOARD_FYSETC_S6               4216  // FYSETC S6 board
+#define BOARD_FLYF407ZG               4217  // FLYF407ZG board (STM32F407ZG)
+#define BOARD_MKS_ROBIN2              4218  // MKS_ROBIN2 (STM32F407ZE)
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -578,6 +578,8 @@
   #include "stm32f4/pins_STEVAL_3DP001V1.h"     // STM32F4                                env:STM32F401VE_STEVAL
 #elif MB(BTT_SKR_PRO_V1_1)
   #include "stm32f4/pins_BTT_SKR_PRO_V1_1.h"    // STM32F4                                env:BIGTREE_SKR_PRO
+#elif MB(BTT_SKR_PRO_V1_2)
+  #include "stm32f4/pins_BTT_SKR_PRO_V1_2.h"    // STM32F4                                env:BIGTREE_SKR_PRO
 #elif MB(BTT_GTR_V1_0)
   #include "stm32f4/pins_BTT_GTR_V1_0.h"        // STM32F4                                env:BIGTREE_GTR_V1_0
 #elif MB(BTT_BTT002_V1_0)

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_2.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_2.h
@@ -22,9 +22,9 @@
 #pragma once
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "BIGTREE SKR Pro V1.1 supports up to 3 hotends / E-steppers."
+  #error "BIGTREE SKR Pro V1.2 supports up to 3 hotends / E-steppers."
 #endif
 
-#define BOARD_INFO_NAME "BTT SKR Pro V1.1"
+#define BOARD_INFO_NAME "BTT SKR Pro V1.2"
 
 #include "pins_BTT_SKR_PRO_common.h"

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -1,0 +1,356 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#ifndef TARGET_STM32F4
+  #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
+#endif
+
+// Use one of these or SDCard-based Emulation will be used
+#if NO_EEPROM_SELECTED
+  //#define SRAM_EEPROM_EMULATION                 // Use BackSRAM-based EEPROM emulation
+  #define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation
+#endif
+
+#if ENABLED(FLASH_EEPROM_EMULATION)
+  // Decrease delays and flash wear by spreading writes across the
+  // 128 kB sector allocated for EEPROM emulation.
+  #define FLASH_EEPROM_LEVELING
+#endif
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PA1
+
+//
+// Trinamic Stallguard pins
+//
+#define X_DIAG_PIN                          PB10  // X-
+#define Y_DIAG_PIN                          PE12  // Y-
+#define Z_DIAG_PIN                          PG8   // Z-
+#define E0_DIAG_PIN                         PE15  // E0
+#define E1_DIAG_PIN                         PE10  // E1
+#define E2_DIAG_PIN                         PG5   // E2
+
+//
+// Limit Switches
+//
+#ifdef X_STALL_SENSITIVITY
+  #define X_STOP_PIN                  X_DIAG_PIN
+  #if X_HOME_DIR < 0
+    #define X_MAX_PIN                       PE15  // E0
+  #else
+    #define X_MIN_PIN                       PE15  // E0
+  #endif
+#else
+  #define X_MIN_PIN                         PB10  // X-
+  #define X_MAX_PIN                         PE15  // E0
+#endif
+
+#ifdef Y_STALL_SENSITIVITY
+  #define Y_STOP_PIN                  Y_DIAG_PIN
+  #if Y_HOME_DIR < 0
+    #define Y_MAX_PIN                       PE10  // E1
+  #else
+    #define Y_MIN_PIN                       PE10  // E1
+  #endif
+#else
+  #define Y_MIN_PIN                         PE12  // Y-
+  #define Y_MAX_PIN                         PE10  // E1
+#endif
+
+#ifdef Z_STALL_SENSITIVITY
+  #define Z_STOP_PIN                  Z_DIAG_PIN
+  #if Z_HOME_DIR < 0
+    #define Z_MAX_PIN                       PG5   // E2
+  #else
+    #define Z_MIN_PIN                       PG5   // E2
+  #endif
+#else
+  #define Z_MIN_PIN                         PG8   // Z-
+  #define Z_MAX_PIN                         PG5   // E2
+#endif
+
+//
+// Z Probe must be this pin
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PA2
+#endif
+
+//
+// Steppers
+//
+#define X_STEP_PIN                          PE9
+#define X_DIR_PIN                           PF1
+#define X_ENABLE_PIN                        PF2
+#ifndef X_CS_PIN
+  #define X_CS_PIN                          PA15
+#endif
+
+#define Y_STEP_PIN                          PE11
+#define Y_DIR_PIN                           PE8
+#define Y_ENABLE_PIN                        PD7
+ #ifndef Y_CS_PIN
+  #define Y_CS_PIN                          PB8
+#endif
+
+#define Z_STEP_PIN                          PE13
+#define Z_DIR_PIN                           PC2
+#define Z_ENABLE_PIN                        PC0
+#ifndef Z_CS_PIN
+  #define Z_CS_PIN                          PB9
+#endif
+
+#define E0_STEP_PIN                         PE14
+#define E0_DIR_PIN                          PA0
+#define E0_ENABLE_PIN                       PC3
+#ifndef E0_CS_PIN
+  #define E0_CS_PIN                         PB3
+#endif
+
+#define E1_STEP_PIN                         PD15
+#define E1_DIR_PIN                          PE7
+#define E1_ENABLE_PIN                       PA3
+#ifndef E1_CS_PIN
+  #define E1_CS_PIN                         PG15
+#endif
+
+#define E2_STEP_PIN                         PD13
+#define E2_DIR_PIN                          PG9
+#define E2_ENABLE_PIN                       PF0
+#ifndef E2_CS_PIN
+  #define E2_CS_PIN                         PG12
+#endif
+
+//
+// Software SPI pins for TMC2130 stepper drivers
+//
+#if ENABLED(TMC_USE_SW_SPI)
+  #ifndef TMC_SW_MOSI
+    #define TMC_SW_MOSI                     PC12
+  #endif
+  #ifndef TMC_SW_MISO
+    #define TMC_SW_MISO                     PC11
+  #endif
+  #ifndef TMC_SW_SCK
+    #define TMC_SW_SCK                      PC10
+  #endif
+#endif
+
+#if HAS_TMC_UART
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  Serial
+  //#define X2_HARDWARE_SERIAL Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Y2_HARDWARE_SERIAL Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define Z2_HARDWARE_SERIAL Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+  //#define E1_HARDWARE_SERIAL Serial1
+  //#define E2_HARDWARE_SERIAL Serial1
+  //#define E3_HARDWARE_SERIAL Serial1
+  //#define E4_HARDWARE_SERIAL Serial1
+
+  //
+  // Software serial
+  //
+  #define X_SERIAL_TX_PIN                   PC13
+  #define X_SERIAL_RX_PIN                   PC13
+
+  #define Y_SERIAL_TX_PIN                   PE3
+  #define Y_SERIAL_RX_PIN                   PE3
+
+  #define Z_SERIAL_TX_PIN                   PE1
+  #define Z_SERIAL_RX_PIN                   PE1
+
+  #define E0_SERIAL_TX_PIN                  PD4
+  #define E0_SERIAL_RX_PIN                  PD4
+
+  #define E1_SERIAL_TX_PIN                  PD1
+  #define E1_SERIAL_RX_PIN                  PD1
+
+  #define E2_SERIAL_TX_PIN                  PD6
+  #define E2_SERIAL_RX_PIN                  PD6
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
+#endif
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN                          PF4   // T1 <-> E0
+#define TEMP_1_PIN                          PF5   // T2 <-> E1
+#define TEMP_2_PIN                          PF6   // T3 <-> E2
+#define TEMP_BED_PIN                        PF3   // T0 <-> Bed
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                        PB1   // Heater0
+#define HEATER_1_PIN                        PD14  // Heater1
+#define HEATER_2_PIN                        PB0   // Heater1
+#define HEATER_BED_PIN                      PD12  // Hotbed
+#define FAN_PIN                             PC8   // Fan0
+#define FAN1_PIN                            PE5   // Fan1
+#define FAN2_PIN                            PE6
+
+#ifndef E0_AUTO_FAN_PIN
+  #define E0_AUTO_FAN_PIN               FAN1_PIN
+#endif
+
+//
+// Misc. Functions
+//
+
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION                  LCD
+#endif
+
+//
+// Onboard SD card
+// Must use soft SPI because Marlin's default hardware SPI is tied to LCD's EXP2
+//
+#if SD_CONNECTION_IS(ONBOARD)
+  #define SOFTWARE_SPI                            // Use soft SPI for onboard SD
+  #define SDSS                              PA4
+  #define SCK_PIN                           PA5
+  #define MISO_PIN                          PA6
+  #define MOSI_PIN                          PB5
+#endif
+
+/**
+ *               _____                                             _____
+ *           NC | · · | GND                                    5V | · · | GND
+ *        RESET | · · | PF12(SD_DETECT)             (LCD_D7)  PG7 | · · | PG6  (LCD_D6)
+ *   (MOSI)PB15 | · · | PF11(BTN_EN2)               (LCD_D5)  PG3 | · · | PG2  (LCD_D4)
+ *  (SD_SS)PB12 | · · | PG10(BTN_EN1)               (LCD_RS) PD10 | · · | PD11 (LCD_EN)
+ *    (SCK)PB13 | · · | PB14(MISO)                 (BTN_ENC)  PA8 | · · | PG4  (BEEPER)
+ *               ￣￣                                               ￣￣
+ *               EXP2                                              EXP1
+ */
+
+//
+// LCDs and Controllers
+//
+#if HAS_SPI_LCD
+  #define BEEPER_PIN                        PG4
+  #define BTN_ENC                           PA8
+  #if SD_CONNECTION_IS(LCD)
+    #define SDSS                            PB12  // Uses default hardware SPI for LCD's SD
+  #endif
+
+  #if ENABLED(CR10_STOCKDISPLAY)
+    #define LCD_PINS_RS                     PG6
+
+    #define BTN_EN1                         PD11
+    #define BTN_EN2                         PG2
+
+    #define LCD_PINS_ENABLE                 PG7
+    #define LCD_PINS_D4                     PG3
+
+    // CR10_Stock Display needs a different delay setting on SKR PRO v1.1, so undef it here.
+    // It will be defined again at the #HAS_GRAPHICAL_LCD section below.
+    #undef ST7920_DELAY_1
+    #undef ST7920_DELAY_2
+    #undef ST7920_DELAY_3
+
+  #elif ENABLED(MKS_MINI_12864)
+    #define DOGLCD_A0                       PG6
+    #define DOGLCD_CS                       PG3
+
+  #else
+
+    #define LCD_PINS_RS                     PD10
+
+    #define BTN_EN1                         PG10
+    #define BTN_EN2                         PF11
+    #define SD_DETECT_PIN                   PF12
+
+    #define LCD_SDSS                        PB12
+
+    #define LCD_PINS_ENABLE                 PD11
+    #define LCD_PINS_D4                     PG2
+
+    #if ENABLED(FYSETC_MINI_12864)
+      #define DOGLCD_CS                     PD11
+      #define DOGLCD_A0                     PD10
+      //#define LCD_BACKLIGHT_PIN           -1
+      #define LCD_RESET_PIN                 PG2   // Must be high or open for LCD to operate normally.
+      #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
+        #ifndef RGB_LED_R_PIN
+          #define RGB_LED_R_PIN             PG3
+        #endif
+        #ifndef RGB_LED_G_PIN
+          #define RGB_LED_G_PIN             PG6
+        #endif
+        #ifndef RGB_LED_B_PIN
+          #define RGB_LED_B_PIN             PG7
+        #endif
+      #elif ENABLED(FYSETC_MINI_12864_2_1)
+        #define NEOPIXEL_PIN                PG3
+      #endif
+    #endif // !FYSETC_MINI_12864
+
+    #if ENABLED(ULTIPANEL)
+      #define LCD_PINS_D5                   PG3
+      #define LCD_PINS_D6                   PG6
+      #define LCD_PINS_D7                   PG7
+    #endif
+
+  #endif
+
+  // Alter timing for graphical display
+  #if HAS_GRAPHICAL_LCD
+    #define BOARD_ST7920_DELAY_1 DELAY_NS(96)
+    #define BOARD_ST7920_DELAY_2 DELAY_NS(48)
+    #define BOARD_ST7920_DELAY_3 DELAY_NS(600)
+  #endif
+
+#endif // HAS_SPI_LCD
+
+//
+// WIFI
+//
+
+/**
+ *          _____
+ *      TX | 1 2 | GND      Enable PG1   // Must be high for module to run
+ *  Enable | 3 4 | GPIO2    Reset  PG0   // active low, probably OK to leave floating
+ *   Reset | 5 6 | GPIO0    GPIO2  PF15  // must be high (ESP3D software configures this with a pullup so OK to leave as floating)
+ *     3.3V| 7 8 | RX       GPIO0  PF14  // Leave as unused (ESP3D software configures this with a pullup so OK to leave as floating)
+ *           ￣￣
+ *            W1
+ */
+#define ESP_WIFI_MODULE_COM 6                     // Must also set either SERIAL_PORT or SERIAL_PORT_2 to this
+#define ESP_WIFI_MODULE_BAUDRATE        BAUDRATE  // Must use same BAUDRATE as SERIAL_PORT & SERIAL_PORT_2
+#define ESP_WIFI_MODULE_RESET_PIN           PG0
+#define ESP_WIFI_MODULE_ENABLE_PIN          PG1
+#define ESP_WIFI_MODULE_GPIO0_PIN           PF14
+#define ESP_WIFI_MODULE_GPIO2_PIN           PF15


### PR DESCRIPTION
### Description

BigTreeTech made some improvements to the SKR Pro series and released the SKR Pro 1.2:

- Fix the the reversed bed voltage silkscreen.
- Optimize circuit design / improve heat dissipation.
- Add clamping diode for reverse voltage protection.

There are no pin changes, but this PR will allow users to define the correct board/have the correct board name show up in the About screen.

### Benefits

Adds SKR Pro 1.2 support.

### Related Issues

None.