### PR TITLE
Simpler mesh edit loop

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -498,12 +498,7 @@ inline void manage_inactivity(const bool ignore_stepper_queue=false) {
         if (ENABLED(DISABLE_INACTIVE_Z)) DISABLE_AXIS_Z();
         if (ENABLED(DISABLE_INACTIVE_E)) disable_e_steppers();
 
-        #if BOTH(HAS_LCD_MENU, AUTO_BED_LEVELING_UBL)
-          if (ubl.lcd_map_control) {
-            ubl.lcd_map_control = false;
-            ui.defer_status_screen(false);
-          }
-        #endif
+        TERN_(AUTO_BED_LEVELING_UBL, ubl.steppers_were_disabled());
       }
     }
     else

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -84,11 +84,7 @@
     _GRIDPOS(Y, 12), _GRIDPOS(Y, 13), _GRIDPOS(Y, 14), _GRIDPOS(Y, 15)
   );
 
-  #if HAS_LCD_MENU
-    bool unified_bed_leveling::lcd_map_control = false;
-  #endif
-
-  volatile int unified_bed_leveling::encoder_diff;
+  volatile int16_t unified_bed_leveling::encoder_diff;
 
   unified_bed_leveling::unified_bed_leveling() {
     reset();

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -111,6 +111,9 @@ class unified_bed_leveling {
 
     #if HAS_LCD_MENU
       static bool lcd_map_control;
+      static void steppers_were_disabled();
+    #else
+      static inline void steppers_were_disabled() {}
     #endif
 
     static volatile int encoder_diff; // Volatile because it's changed at interrupt time.

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -116,7 +116,7 @@ class unified_bed_leveling {
       static inline void steppers_were_disabled() {}
     #endif
 
-    static volatile int encoder_diff; // Volatile because it's changed at interrupt time.
+    static volatile int16_t encoder_diff; // Volatile because buttons may changed it at interrupt time
 
     unified_bed_leveling();
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -55,6 +55,13 @@
 
   #if HAS_LCD_MENU
     void _lcd_ubl_output_map_lcd();
+
+    void unified_bed_leveling::steppers_were_disabled() {
+      if (lcd_map_control) {
+        lcd_map_control = false;
+        ui.defer_status_screen(false);
+      }
+    }
   #endif
 
   #define SIZE_OF_LITTLE_RAISE 1
@@ -789,11 +796,11 @@
 
     bool click_and_hold(const clickFunc_t func=nullptr) {
       if (ui.button_pressed()) {
-        ui.quick_feedback(false);                // Preserve button state for click-and-hold
+        ui.quick_feedback(false);         // Preserve button state for click-and-hold
         const millis_t nxt = millis() + 1500UL;
-        while (ui.button_pressed()) {                // Loop while the encoder is pressed. Uses hardware flag!
-          idle();                                 // idle, of course
-          if (ELAPSED(millis(), nxt)) {           // After 1.5 seconds
+        while (ui.button_pressed()) {     // Loop while the encoder is pressed. Uses hardware flag!
+          idle();                         // idle, of course
+          if (ELAPSED(millis(), nxt)) {   // After 1.5 seconds
             ui.quick_feedback();
             if (func) (*func)();
             ui.wait_for_release();

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -54,7 +54,8 @@
   #define UBL_G29_P31
 
   #if HAS_LCD_MENU
-    void _lcd_ubl_output_map_lcd();
+
+    bool unified_bed_leveling::lcd_map_control = false;
 
     void unified_bed_leveling::steppers_were_disabled() {
       if (lcd_map_control) {
@@ -62,6 +63,9 @@
         ui.defer_status_screen(false);
       }
     }
+
+    void ubl_map_screen();
+
   #endif
 
   #define SIZE_OF_LITTLE_RAISE 1
@@ -1002,9 +1006,9 @@
         lcd_mesh_edit_setup(new_z);
 
         do {
+          idle();
           new_z = lcd_mesh_edit();
           TERN_(UBL_MESH_EDIT_MOVES_Z, do_blocking_move_to_z(h_offset + new_z)); // Move the nozzle as the point is edited
-          idle();
           SERIAL_FLUSH();                                   // Prevent host M105 buffer overrun.
         } while (!ui.button_pressed());
 
@@ -1029,7 +1033,7 @@
       SERIAL_ECHOLNPGM("Done Editing Mesh");
 
       if (lcd_map_control)
-        ui.goto_screen(_lcd_ubl_output_map_lcd);
+        ui.goto_screen(ubl_map_screen);
       else
         ui.return_to_status();
     }

--- a/Marlin/src/feature/touch/xpt2046.cpp
+++ b/Marlin/src/feature/touch/xpt2046.cpp
@@ -81,7 +81,6 @@
 #endif
 
 XPT2046 touch;
-extern int8_t encoderDiff;
 
 void XPT2046::init() {
   SET_INPUT(TOUCH_MISO_PIN);

--- a/Marlin/src/gcode/control/M17_M18_M84.cpp
+++ b/Marlin/src/gcode/control/M17_M18_M84.cpp
@@ -64,11 +64,6 @@ void GcodeSuite::M18_M84() {
     else
       planner.finish_and_disable();
 
-    #if BOTH(HAS_LCD_MENU, AUTO_BED_LEVELING_UBL)
-      if (ubl.lcd_map_control) {
-        ubl.lcd_map_control = false;
-        ui.defer_status_screen(false);
-      }
-    #endif
+    TERN_(AUTO_BED_LEVELING_UBL, ubl.steppers_were_disabled());
   }
 }

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -230,7 +230,7 @@ void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, co
           screen = TERN(BABYSTEP_ZPROBE_OFFSET, lcd_babystep_zoffset, lcd_babystep_z);
         else {
           #if ENABLED(MOVE_Z_WHEN_IDLE)
-            move_menu_scale = MOVE_Z_IDLE_MULTIPLICATOR;
+            ui.manual_move.menu_scale = MOVE_Z_IDLE_MULTIPLICATOR;
             screen = lcd_move_z;
           #endif
         }

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -46,7 +46,7 @@ void _man_probe_pt(const xy_pos_t &xy) {
     do_blocking_move_to_xy_z(xy, Z_CLEARANCE_BETWEEN_PROBES);
     ui.wait_for_move = false;
     ui.synchronize();
-    move_menu_scale = _MAX(PROBE_MANUALLY_STEP, MIN_STEPS_PER_SEGMENT / float(DEFAULT_XYZ_STEPS_PER_UNIT));
+    ui.manual_move.menu_scale = _MAX(PROBE_MANUALLY_STEP, MIN_STEPS_PER_SEGMENT / float(DEFAULT_XYZ_STEPS_PER_UNIT));
     ui.goto_screen(lcd_move_z);
   }
 }

--- a/Marlin/src/lcd/ultralcd.h
+++ b/Marlin/src/lcd/ultralcd.h
@@ -99,9 +99,6 @@
     typedef void (*screenFunc_t)();
     typedef void (*menuAction_t)();
 
-    // Manual Movement
-    extern float move_menu_scale;
-
     #if ENABLED(ADVANCED_PAUSE_FEATURE)
       void lcd_pause_show_message(const PauseMessage message,
                                   const PauseMode mode=PAUSE_MODE_SAME,
@@ -262,6 +259,35 @@
     TERN_(HAS_HEATED_BED, uint16_t bed_temp   );
     TERN_(HAS_FAN,        uint16_t fan_speed  );
   } preheat_t;
+#endif
+
+#if HAS_LCD_MENU
+
+  // Manual Movement class
+  class ManualMove {
+  public:
+    static millis_t start_time;
+    static float menu_scale;
+    TERN_(IS_KINEMATIC, static float offset);
+    #if IS_KINEMATIC
+      static bool processing;
+    #else
+      static bool constexpr processing = false;
+    #endif
+    #if MULTI_MANUAL
+      static int8_t e_index;
+    #else
+      static int8_t constexpr e_index = 0;
+    #endif
+    static uint8_t axis;
+    static void task();
+    static void soon(AxisEnum axis
+      #if MULTI_MANUAL
+        , const int8_t eindex=-1
+      #endif
+    );
+  };
+
 #endif
 
 ////////////////////////////////////////////
@@ -494,28 +520,13 @@ public:
       static void enable_encoder_multiplier(const bool onoff);
     #endif
 
-    static int8_t manual_move_axis;
-    static millis_t manual_move_start_time;
-
-    #if IS_KINEMATIC
-      static float manual_move_offset;
-      static bool processing_manual_move;
-    #else
-      static constexpr bool processing_manual_move = false;
-    #endif
-
-    #if E_MANUAL > 1
-      static int8_t manual_move_e_index;
-    #else
-      static constexpr int8_t manual_move_e_index = 0;
-    #endif
+    // Manual Movement
+    static ManualMove manual_move;
 
     // Select Screen (modal NO/YES style dialog)
     static bool selection;
     static void set_selection(const bool sel) { selection = sel; }
     static bool update_selection();
-
-    static void manage_manual_move();
 
     static bool lcd_clicked;
     static bool use_click();
@@ -609,6 +620,9 @@ public:
     static bool external_control;
     FORCE_INLINE static void capture() { external_control = true; }
     FORCE_INLINE static void release() { external_control = false; }
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      static void external_encoder();
+    #endif
   #else
     static constexpr bool external_control = false;
   #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1316,16 +1316,18 @@ void do_homing_move(const AxisEnum axis, const float distance, const feedRate_t 
     current_position[axis] = distance;
     line_to_current_position(real_fr_mm_s);
   #else
+    // Get the ABC or XYZ positions in mm
     abce_pos_t target = planner.get_axis_positions_mm();
-    target[axis] = 0;
-    planner.set_machine_position_mm(target);
-    target[axis] = distance;
+
+    target[axis] = 0;                         // Set the single homing axis to 0
+    planner.set_machine_position_mm(target);  // Update the machine position
 
     #if HAS_DIST_MM_ARG
       const xyze_float_t cart_dist_mm{0};
     #endif
 
     // Set delta/cartesian axes directly
+    target[axis] = distance;                  // The move will be towards the endstop
     planner.buffer_segment(target
       #if HAS_DIST_MM_ARG
         , cart_dist_mm

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1654,7 +1654,7 @@ void Planner::synchronize() {
  *  extruder      - target extruder
  *  millimeters   - the length of the movement, if known
  *
- * Returns true if movement was properly queued, false otherwise
+ * Returns true if movement was properly queued, false otherwise (if cleaning)
  */
 bool Planner::_buffer_steps(const xyze_long_t &target
   #if HAS_POSITION_FLOAT
@@ -2637,6 +2637,8 @@ void Planner::buffer_sync_block() {
  *  fr_mm_s     - (target) speed of the move
  *  extruder    - target extruder
  *  millimeters - the length of the movement, if known
+ *
+ * Return 'false' if no segment was queued due to cleaning, cold extrusion, full queue, etc.
  */
 bool Planner::buffer_segment(const float &a, const float &b, const float &c, const float &e
   #if HAS_DIST_MM_ARG
@@ -2706,7 +2708,7 @@ bool Planner::buffer_segment(const float &a, const float &b, const float &c, con
     SERIAL_ECHOLNPGM(")");
   //*/
 
-  // Queue the movement
+  // Queue the movement. Return 'false' if the move was not queued.
   if (!_buffer_steps(target
       #if HAS_POSITION_FLOAT
         , target_float


### PR DESCRIPTION
For UBL mesh editing via `G29 P4`, instead of using a null screen handler and a tight control loop, use normal screen handling and read the available edit value as it changes.

Intended to address a partial screen update issue by staying within the normal LCD update and control loop so draw flags will have appropriate values during the screen update.

TODO: The screen could be made modeless by moving all the mesh editing state control to the screen handler and should reduce some redundancies.

Closing #18174