### PR TITLE
Allow overriding STM32 HAL_TIMER_RATE

### DIFF
--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -44,23 +44,26 @@
 #endif
 
 #ifdef STM32F0xx
-  #define HAL_TIMER_RATE (F_CPU)      // Frequency of timer peripherals
+  #define MCU_TIMER_RATE (F_CPU)      // Frequency of timer peripherals
   #define MCU_STEP_TIMER 16
   #define MCU_TEMP_TIMER 17
 #elif defined(STM32F1xx)
-  #define HAL_TIMER_RATE (F_CPU)
+  #define MCU_TIMER_RATE (F_CPU)
   #define MCU_STEP_TIMER  4
   #define MCU_TEMP_TIMER  2
 #elif defined(STM32F401xC) || defined(STM32F401xE)
-  #define HAL_TIMER_RATE (F_CPU / 2)
+  #define MCU_TIMER_RATE (F_CPU / 2)
   #define MCU_STEP_TIMER  9
   #define MCU_TEMP_TIMER 10
 #elif defined(STM32F4xx) || defined(STM32F7xx)
-  #define HAL_TIMER_RATE (F_CPU / 2)
+  #define MCU_TIMER_RATE (F_CPU / 2)
   #define MCU_STEP_TIMER  6           // STM32F401 has no TIM6, TIM7, or TIM8
   #define MCU_TEMP_TIMER 14           // TIM7 is consumed by Software Serial if used.
 #endif
 
+#ifndef HAL_TIMER_RATE
+  #define HAL_TIMER_RATE MCU_TIMER_RATE
+#endif
 #ifndef STEP_TIMER
   #define STEP_TIMER MCU_STEP_TIMER
 #endif

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
@@ -47,6 +47,7 @@
 #define STEP_TIMER                          10
 #define TEMP_TIMER                          14
 #define TIMER_SERIAL                        TIM9
+#define HAL_TIMER_RATE                      F_CPU
 
 //
 // Limit Switches


### PR DESCRIPTION
### Description

This allows boards using the STM32 HAL to override the default `HAL_TIMER_RATE` of `F_CPU/2`. This is desirable because not all timers on all STM32 MCUs clock from `F_CPU/2` - for example, some clock directly from `F_CPU`.

This is raised in response to an error introduced in my previous PR (#18249), in which I changed the `STEP_TIMER` for RUMBA32 boards from the default `TIM6` to `TIM10` (in order to address a timer conflict). However, `TIM6` clocks from `F_CPU/2`, whereas `TIM10` clocks from `F_CPU` - resulting in the stepper ISR / all motions running twice as fast as intended.

Here is an example of the timers in the STM32F446 MCU that RUMBA32 uses:
![image](https://user-images.githubusercontent.com/5538631/85216091-dad8fb00-b3bf-11ea-8bb8-ac0d9a7fa1d5.png)

Those timers marked with a max timer clock of 90/180MHz default to clocking from `F_CPU/2`, while others marked only as 180MHz clock only from `F_CPU`. Therefore, the current implementation before this PR, which assumes a clock source of `F_CPU/2`, limits selection of timers for the `STEP_TIMER` to those which list their max speed as 90/180MHz. This PR allows the selection of any timers (provided the `HAL_TIMER_RATE` is overridden appropriately).

Note that the `HAL_TIMER_RATE` define is only used by the HAL to configure the `STEP_TIMER`, and is not used to configure any other timers (for instance, the temperature timer). Therefore it is not necessary to consider the clock source of other timers when selecting `HAL_TIMER_RATE`, only the `STEP_TIMER`. 

This PR overrides the `HAL_TIMER_RATE` for RUMBA32 boards, in order to correct the above speed issue. There is no change in `HAL_TIMER_RATE` to other boards.
