### PR TITLE
Extui: fix the font-scaling to only use fonts 26 and larger

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/command_processor.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/command_processor.h
@@ -315,7 +315,7 @@ class CommandProcessor : public CLCD::CommandFifo {
       #ifdef TOUCH_UI_USE_UTF8
         const bool is_utf8 = has_utf8_chars(text);
       #endif
-      for (;font >= 26;) {
+      for (;font > 26;) {
         int16_t width, height;
         #ifdef TOUCH_UI_USE_UTF8
           if (is_utf8) {


### PR DESCRIPTION
### Requirements

In order to see the bug in action you need an Extui display with 320x240 resolution.

### Description

The automatic font scaling tries to fit strings in given dimensions and loops thru the fonts from larger to smaller untill it fits or the smallest font is reached.
The issue is that it loops one too far and the result is font number 25 for a coupe of long strings on low resolution displays.
The font number 25 however is a very large font with a different style than fonts 26...32.

#18076

### Benefits

With the fix the smallest font selected is 26.