### PR TITLE
Fix erroneous 4th colour in RGB NEOPIXEL_STARTUP_TEST on LPC176x

### DIFF
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -71,13 +71,11 @@ void Marlin_NeoPixel::set_color_startup(const uint32_t color) {
 }
 
 void Marlin_NeoPixel::init() {
-  SET_OUTPUT(NEOPIXEL_PIN);
   set_brightness(NEOPIXEL_BRIGHTNESS); // 0 - 255 range
   begin();
   show();  // initialize to all off
 
   #if ENABLED(NEOPIXEL_STARTUP_TEST)
-    safe_delay(1000);
     set_color_startup(adaneo1.Color(255, 0, 0, 0));  // red
     safe_delay(1000);
     set_color_startup(adaneo1.Color(0, 255, 0, 0));  // green


### PR DESCRIPTION
### Requirements

A LPC176x based controller
enable NEOPIXEL_LED
setup your NEOPIXEL type and pin
enable NEOPIXEL_STARTUP_TEST

### Description

When the RGB NEOPIXEL STARTUP test is run a extra 4th colour is displayed before the RGB colours. The NEOPIXEL is meant to be off at this time.
The cause is the IO pin being initialized twice. Once in SET_OUTPUT(NEOPIXEL_PIN) and a second time in Adafruit_NeoPixel::begin().
The specific cause is the way the SET_OUTPUT set the pin as output puts data out on the pin confusing the NEOPIXEL. 
I also removed a delay before the first  NEOPIXEL_STARTUP_TEST led is lit, it was just wasting time and slowing down startup of the controller.

### Benefits

Extra colour in RGB test removed. 
Slightly faster board startup. 

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/17218