### PR TITLE
Fix 3-point leveling middle point

### DIFF
--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -190,7 +190,7 @@ public:
           #else
             points[0].set(min_x(), min_y());
             points[1].set(max_x(), min_y());
-            points[2].set((max_x() - min_x()) / 2, max_y());
+            points[2].set((min_x() + max_x()) / 2, max_y());
           #endif
         #endif
       }


### PR DESCRIPTION
### Description

Please kindly see the communication in #17203

Having the 3rd probe location centered on X to the mesh makes it as far away from 1st and 2nd probe location as possible. Any other location will bring it (IMHO) closer to either the 1st or the 2nd probe location.

### Benefits

Currently the 3rd probe location is not centered on X to the bed nor is it centered on X to the mesh. This PR is centering the 3rd probe location on X to the mesh.

### Related Issues

#17203
