### PR TITLE
PID Autotune Temp: change default to 200

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -169,7 +169,13 @@ void menu_cancelobject();
 #if ENABLED(PID_AUTOTUNE_MENU)
 
   #if ENABLED(PIDTEMP)
-    int16_t autotune_temp[HOTENDS] = ARRAY_BY_HOTENDS1(200);
+    #ifdef PREHEAT_1_TEMP_HOTEND
+      #define PID_TUNE_TEMP PREHEAT_1_TEMP_HOTEND
+    #else
+      #define PID_TUNE_TEMP 200
+    #endif
+    int16_t autotune_temp[HOTENDS] = ARRAY_BY_HOTENDS1(PID_TUNE_TEMP);
+    #undef PID_TUNE_TEMP
   #endif
 
   #if ENABLED(PIDTEMPBED)

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -169,7 +169,7 @@ void menu_cancelobject();
 #if ENABLED(PID_AUTOTUNE_MENU)
 
   #if ENABLED(PIDTEMP)
-    int16_t autotune_temp[HOTENDS] = ARRAY_BY_HOTENDS1(150);
+    int16_t autotune_temp[HOTENDS] = ARRAY_BY_HOTENDS1(200);
   #endif
 
   #if ENABLED(PIDTEMPBED)


### PR DESCRIPTION

### Description

The PID Autotune Default temperature is supposed to be the printing temperature,
for which 150 seems like a poor default.

Given the popularity of PLA, 200C seems like a decent default.

### Benefits

It provides a better default to prevent novice users from accidentally getting unwanted printer behavior.