### PR TITLE
PID Autotune LCD Status Message

### DIFF
--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -25,6 +25,7 @@
 #if HAS_PID_HEATING
 
 #include "../gcode.h"
+#include "../../lcd/ultralcd.h"
 #include "../../module/temperature.h"
 
 #if ENABLED(EXTENSIBLE_UI)
@@ -84,7 +85,9 @@ void GcodeSuite::M303() {
     KEEPALIVE_STATE(NOT_BUSY);
   #endif
 
+  ui.set_status("Autotuning PID...");
   thermalManager.PID_autotune(temp, e, c, u);
+  ui.reset_status();
 }
 
 #endif // HAS_PID_HEATING

--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -85,7 +85,7 @@ void GcodeSuite::M303() {
     KEEPALIVE_STATE(NOT_BUSY);
   #endif
 
-  ui.set_status("Autotuning PID...");
+  ui.set_status(GET_TEXT(MSG_PID_AUTOTUNE));
   thermalManager.PID_autotune(temp, e, c, u);
   ui.reset_status();
 }


### PR DESCRIPTION
### Description

Currently when issuing PID Autotune (M303) the printer does the autotune procedure, however on the LCD this is not immediately apparently, except for the temperature swings of the hotend.

This is worse when the autotune was issued via the LCD menu itself, as there will be no feedback when the autotuning has actually finished. And in the meanwhile the printer will simply refuse any print action without any explanation.

### Benefits

This patch issues an LCD status update when starting the autotuning procedure, and clearing the status message when it's done.