### PR TITLE
Update MKS Robin Nano build environments

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -507,7 +507,7 @@
 #elif MB(MKS_ROBIN_MINI)
   #include "stm32f1/pins_MKS_ROBIN_MINI.h"      // STM32F1                                env:mks_robin_mini
 #elif MB(MKS_ROBIN_NANO)
-  #include "stm32f1/pins_MKS_ROBIN_NANO.h"      // STM32F1                                env:mks_robin_nano
+  #include "stm32f1/pins_MKS_ROBIN_NANO.h"      // STM32F1                                env:mks_robin_nano env:mks_robin_nano35
 #elif MB(MKS_ROBIN_LITE)
   #include "stm32f1/pins_MKS_ROBIN_LITE.h"      // STM32F1                                env:mks_robin_lite
 #elif MB(BTT_SKR_MINI_V1_1)

--- a/platformio.ini
+++ b/platformio.ini
@@ -541,7 +541,7 @@ build_flags   = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE
 
 #
-# MKS Robin Nano (STM32F103VET6)
+# MKS Robin Nano (STM32F103VET6) - Emulated Graphical 128x64 (DOGM) UI
 #
 [env:mks_robin_nano]
 platform      = ${common_stm32f1.platform}
@@ -628,7 +628,7 @@ lib_ignore    = ${common_stm32f1.lib_ignore}
   LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-HAL, SoftwareSerialM
 
 #
-# MKS Robin Nano (STM32F103VET6)
+# MKS Robin Nano (STM32F103VET6) - MKS UI (LVGL)
 #
 [env:mks_robin_nano35]
 platform      = ststm32


### PR DESCRIPTION
### Description

Add `mks_robin_nano35` environment for the MKS Robin Nano.

### Benefits

Allows users to compile for the Robin Nano with MKS LVGL UI (once it's working) with Auto Build Marlin.

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/18071