### PR TITLE
Fix probe clearance calculation (#17242)

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -544,7 +544,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
 
     // Do a first probe at the fast speed
     if (try_to_probe(PSTR("FAST"), z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_FAST),
-                     sanity_check, _MAX(Z_CLEARANCE_BETWEEN_PROBES, 4) / 2) ) return NAN;
+                     sanity_check, Z_CLEARANCE_BETWEEN_PROBES) ) return NAN;
 
     const float first_probe_z = current_position.z;
 
@@ -582,7 +582,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
     {
       // Probe downward slowly to find the bed
       if (try_to_probe(PSTR("SLOW"), z_probe_low_point, MMM_TO_MMS(Z_PROBE_SPEED_SLOW),
-                       sanity_check, _MAX(Z_CLEARANCE_MULTI_PROBE, 4) / 2) ) return NAN;
+                       sanity_check, Z_CLEARANCE_MULTI_PROBE) ) return NAN;
 
       TERN_(MEASURE_BACKLASH_WHEN_PROBING, backlash.measure_with_probe());
 


### PR DESCRIPTION
### Description

This pull request fixes the clearance calculation for z probing with zero probe offset which often causes the probe to fail. The calculation of required clearance of half the configured distance requres a probe to be mounted at least twice as far as the clearance between probe distance. Additionally, the calculation is done in integer math which also requires the probe to be mounted even slightly higher than twice the clearance.

### Benefits

Increases the range of allowable z probe mounting distances for the z probe. Also allows probing with zero offset to find the initial settings for z offset.

### Related Issues

Fixes #17242
