### PR TITLE
added .clang-format file

### DIFF
--- a/Marlin/.clang-format
+++ b/Marlin/.clang-format
@@ -1,0 +1,67 @@
+# Clang format style for the coding style as described here:
+# https://marlinfw.org/docs/development/coding_standards.html
+# 
+# Caveat: Not all required styles can be achieved with Clang but most of them.
+# Use this file optionally, not mandatorily.
+
+Language: Cpp
+IndentWidth: 2
+ColumnLimit: 120
+UseTab: Never
+Standard: Latest
+UseCRLF: false
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterExternBlock: false
+  AfterObjCDeclaration: true
+  AfterFunction: false
+  AfterCaseLabel: false
+  AfterClass:  false
+  AfterStruct: false
+  AfterUnion: false
+  AfterEnum: false
+  AfterControlStatement: false
+  AfterNamespace: false
+  BeforeElse: false
+
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentPPDirectives: None
+#Preprocessor directives shall be formatted as follows:
+#void myFunction() {
+#  if (myCondition == 0) {
+#    #ifdef PETER_PARKER
+#      slingWeb(100);
+#    #else
+#      findPhoneBooth();
+#    #endif
+#  }
+#}
+#
+# At the moment this option seems the best (the minimal invasive):
+#if FOO
+#if BAR
+#include <foo>
+#endif
+#endif
+
+PointerAlignment: Right
+ReflowComments: true
+
+CompactNamespaces: false
+FixNamespaceComments: true
+
+SpaceAfterCStyleCast: false
+SpacesInCStyleCastParentheses: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+
+AlignTrailingComments: true
+AlignEscapedNewlines: Left
+
+BinPackArguments: false
+BinPackParameters: false
+
+SortIncludes: false


### PR DESCRIPTION
### Description
As a developer I want to fulfil to the [coding style](https://marlinfw.org/docs/development/coding_standards.html) requirements as much as possible. For this reason an automated code formatting would be welcome. This PR adds a Clang-format style description for automated code formatting. Most of the [described rules](https://marlinfw.org/docs/development/coding_standards.html) are considered pretty well, except of preprocessor directives indentation which is (AFAIK) not possible as desired. 

For existing code clang formatting shall be seen as optional not mandatory.
For new code it may be helpful.

- References: [Clang 11 documentation](https://clang.llvm.org/docs/ClangFormatStyleOptions.html)

### Benefits
- improves readability of code
- decreases developer's time used for manual formatting
- may reduce merge conflicts in future
