### PR TITLE
MKS Robin Nano flash-based emulated EEPROM

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -31,7 +31,7 @@
   #error "MKS Robin nano supports up to 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_INFO_NAME "MKS Robin nano"
+#define BOARD_INFO_NAME "MKS Robin Nano"
 
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
@@ -41,10 +41,13 @@
 //
 // EEPROM
 //
-#if NO_EEPROM_SELECTED
-  //#define FLASH_EEPROM_EMULATION
-  #define SDCARD_EEPROM_EMULATION
+#if EITHER(NO_EEPROM_SELECTED, FLASH_EEPROM_EMULATION)
+  #define FLASH_EEPROM_EMULATION
+  #define EEPROM_PAGE_SIZE     (0x800U) // 2KB
+  #define EEPROM_START_ADDRESS (0x8000000UL + (STM32_FLASH_SIZE) * 1024UL - (EEPROM_PAGE_SIZE) * 2UL)
+  #define MARLIN_EEPROM_SIZE   EEPROM_PAGE_SIZE  // 2KB
 #endif
+
 #define ENABLE_SPI2
 
 //

--- a/buildroot/share/PlatformIO/ldscripts/mks_robin_nano.ld
+++ b/buildroot/share/PlatformIO/ldscripts/mks_robin_nano.ld
@@ -1,7 +1,7 @@
 MEMORY
 {
   ram (rwx) : ORIGIN = 0x20000000, LENGTH = 64K - 40
-  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K
+  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 512K - 28K - 4K
 }
 
 /* Provide memory region aliases for common.inc */


### PR DESCRIPTION
### Description

Use flash-based emulated EEPROM on MKS Robin Nano.

### Benefits

Users no longer need to have an SD card inserted for EEPROM to work.

### Related Issues

None.