### PR TITLE
Fix #18469 menu incorrectly presumes PWM fan exists

### DIFF
--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -307,8 +307,10 @@ void menu_advanced_settings();
     #define MAXTEMP_ALL _MAX(REPEAT(HOTENDS, _MAXTEMP_ITEM) 0)
     START_MENU();
     BACK_ITEM(MSG_CONFIGURATION);
-    editable.uint8 = uint8_t(ui.material_preset[m].fan_speed);
-    EDIT_ITEM_N(percent, m, MSG_FAN_SPEED, &editable.uint8, 0, 255, []{ ui.material_preset[MenuItemBase::itemIndex].fan_speed = editable.uint8; });
+    #if HAS_FAN
+      editable.uint8 = uint8_t(ui.material_preset[m].fan_speed);
+      EDIT_ITEM_N(percent, m, MSG_FAN_SPEED, &editable.uint8, 0, 255, []{ ui.material_preset[MenuItemBase::itemIndex].fan_speed = editable.uint8; });
+    #endif 
     #if HAS_TEMP_HOTEND
       EDIT_ITEM(uint16_3, MSG_NOZZLE, &ui.material_preset[m].hotend_temp, MINTEMP_ALL, MAXTEMP_ALL - HOTEND_OVERSHOOT);
     #endif


### PR DESCRIPTION
### Requirements

A controller without any PWM fans (such as BOARD_SANGUINOLOLU_12)
A LCD with menus.

### Description

The function  _menu_configuration_preheat_settings presumes the existence of PWM controlled fan and produces a compilation error when a fan does not exist. 

`error: 'struct preheat_t' has no member named 'fan_speed' editable.uint8 = uint8_t(ui.material_preset[m].fan_speed);
`

fan_speed is not added to the structure preheat_t unless HAS_FAN has been set.  

### Benefits

Compiles as expected

### Related Issues

Issue https://github.com/MarlinFirmware/Marlin/issues/18469