### PR TITLE
fix #18405 correct uneven parentheses

### DIFF
--- a/Marlin/src/lcd/dogm/dogm_Statusscreen.h
+++ b/Marlin/src/lcd/dogm/dogm_Statusscreen.h
@@ -1370,7 +1370,7 @@
     #define STATUS_LOGO_X 0
   #endif
   #ifndef STATUS_LOGO_Y
-    #define STATUS_LOGO_Y _MIN(0U, (20 - STATUS_LOGO_HEIGHT) / 2)
+    #define STATUS_LOGO_Y _MIN(0U, (20 - (STATUS_LOGO_HEIGHT)) / 2)
   #endif
   #ifndef STATUS_LOGO_HEIGHT
     #define STATUS_LOGO_HEIGHT (sizeof(status_logo_bmp) / (STATUS_LOGO_BYTEWIDTH))

--- a/Marlin/src/lcd/dogm/dogm_Statusscreen.h
+++ b/Marlin/src/lcd/dogm/dogm_Statusscreen.h
@@ -1370,7 +1370,7 @@
     #define STATUS_LOGO_X 0
   #endif
   #ifndef STATUS_LOGO_Y
-    #define STATUS_LOGO_Y _MIN(0U, ((20 - (STATUS_LOGO_HEIGHT)) / 2)
+    #define STATUS_LOGO_Y _MIN(0U, (20 - STATUS_LOGO_HEIGHT) / 2)
   #endif
   #ifndef STATUS_LOGO_HEIGHT
     #define STATUS_LOGO_HEIGHT (sizeof(status_logo_bmp) / (STATUS_LOGO_BYTEWIDTH))


### PR DESCRIPTION
### Requirements

a graphics LCD
#define CUSTOM_STATUS_SCREEN_IMAGE
add file _Statusscreen.h
check _Statusscreen.h has no #define STATUS_LOGO_Y or remove it. 

### Description

When marlin is setup with CUSTOM_STATUS_SCREEN_IMAGE but the  _Statusscreen.h files does not set STATUS_LOGO_Y
dogm_Statusscreen.h is meant to add the missing #define STATUS_LOGO_Y
 
But dogm_Statusscreen.h defines STATUS_LOGO_Y as  this function `_MIN(0U, ((20 - (STATUS_LOGO_HEIGHT)) / 2)`  

This is invalid as it has uneven parentheses. 4 opening brackets and only 3 closing brackets.

### Benefits

Allows marlin to compile when STATUS_LOGO_Y is not defined

### Related Issues

Issue https://github.com/MarlinFirmware/Marlin/issues/18405