### PR TITLE
Fixed missing parenthesis in dogm_statusscreen.h

### DIFF
--- a/Marlin/src/lcd/dogm/dogm_Statusscreen.h
+++ b/Marlin/src/lcd/dogm/dogm_Statusscreen.h
@@ -1370,7 +1370,7 @@
     #define STATUS_LOGO_X 0
   #endif
   #ifndef STATUS_LOGO_Y
-    #define STATUS_LOGO_Y _MIN(0U, ((20 - (STATUS_LOGO_HEIGHT)) / 2)
+    #define STATUS_LOGO_Y _MIN(0U, ((20 - (STATUS_LOGO_HEIGHT)) / 2))
   #endif
   #ifndef STATUS_LOGO_HEIGHT
     #define STATUS_LOGO_HEIGHT (sizeof(status_logo_bmp) / (STATUS_LOGO_BYTEWIDTH))


### PR DESCRIPTION
### Description

I found a missing parenthesis that caused build to fail if custom status screen or boot screen was enabled.

### Benefits

allows building with custom status and boot screens
### Related Issues
Didn't see the point in creating an issue for a single paren.