### PR TITLE
Extend M150 for individual Neopixel control

### DIFF
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -52,14 +52,6 @@ Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIX
 
 #endif
 
-void Marlin_NeoPixel::set_neo_index(const uint8_t neoIndex) {
-  neoindex = neoIndex;
-}
-
-uint8_t Marlin_NeoPixel::get_neo_index() {
-  return neoindex; 
-}
-
 void Marlin_NeoPixel::set_color(const uint32_t color) {
   if (get_neo_index() < NEOPIXEL_PIXELS) { 
     set_pixel_color(get_neo_index(), color);

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -61,8 +61,6 @@ uint8_t Marlin_NeoPixel::get_neo_index() {
 }
 
 void Marlin_NeoPixel::set_color(const uint32_t color) {
-  //SERIAL_ECHO_START();
-  //SERIAL_ECHOLNPAIR("neoindex:",get_index());
   if (get_neo_index() < NEOPIXEL_PIXELS) { 
     set_pixel_color(get_neo_index(), color);
     set_neo_index(NEOPIXEL_PIXELS);

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -53,9 +53,9 @@ Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIX
 #endif
 
 void Marlin_NeoPixel::set_color(const uint32_t color) {
-  if (get_neo_index() < NEOPIXEL_PIXELS) { 
+  if (get_neo_index() < 0) { 
     set_pixel_color(get_neo_index(), color);
-    set_neo_index(NEOPIXEL_PIXELS);
+    set_neo_index(-1);
   }
   else { 
     for (uint16_t i = 0; i < pixels(); ++i) {
@@ -78,8 +78,8 @@ void Marlin_NeoPixel::set_color_startup(const uint32_t color) {
 }
 
 void Marlin_NeoPixel::init() {
-  set_neo_index(NEOPIXEL_PIXELS);      // 0 - NEOPIXEL_PIXELS range
-  set_brightness(NEOPIXEL_BRIGHTNESS); // 0 - 255 range
+  set_neo_index(-1);                   // -1 .. NEOPIXEL_PIXELS-1 range
+  set_brightness(NEOPIXEL_BRIGHTNESS); //  0 .. 255 range
   begin();
   show();  // initialize to all off
 

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -35,7 +35,7 @@
 #endif
 
 Marlin_NeoPixel neo;
-uint8_t Marlin_NeoPixel::neoindex;
+int8_t Marlin_NeoPixel::neoindex;
 
 Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIXEL_TYPE + NEO_KHZ800)
   #if MULTIPLE_NEOPIXEL_TYPES

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -35,6 +35,7 @@
 #endif
 
 Marlin_NeoPixel neo;
+uint8_t Marlin_NeoPixel::neoindex;
 
 Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIXEL_TYPE + NEO_KHZ800)
   #if MULTIPLE_NEOPIXEL_TYPES
@@ -51,15 +52,31 @@ Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIX
 
 #endif
 
+void Marlin_NeoPixel::set_neo_index(const uint8_t neoIndex) {
+  neoindex = neoIndex;
+}
+
+uint8_t Marlin_NeoPixel::get_neo_index() {
+  return neoindex; 
+}
+
 void Marlin_NeoPixel::set_color(const uint32_t color) {
-  for (uint16_t i = 0; i < pixels(); ++i) {
-    #ifdef NEOPIXEL_BKGD_LED_INDEX
-      if (i == NEOPIXEL_BKGD_LED_INDEX && color != 0x000000) {
-        set_color_background();
-        continue;
-      }
-    #endif
-    set_pixel_color(i, color);
+  //SERIAL_ECHO_START();
+  //SERIAL_ECHOLNPAIR("neoindex:",get_index());
+  if (get_neo_index() < NEOPIXEL_PIXELS) { 
+    set_pixel_color(get_neo_index(), color);
+    set_neo_index(NEOPIXEL_PIXELS);
+  }
+  else { 
+    for (uint16_t i = 0; i < pixels(); ++i) {
+      #ifdef NEOPIXEL_BKGD_LED_INDEX
+        if (i == NEOPIXEL_BKGD_LED_INDEX && color != 0x000000) {
+          set_color_background();
+          continue;
+        }
+      #endif
+      set_pixel_color(i, color);
+    }
   }
   show();
 }
@@ -71,6 +88,7 @@ void Marlin_NeoPixel::set_color_startup(const uint32_t color) {
 }
 
 void Marlin_NeoPixel::init() {
+  set_neo_index(NEOPIXEL_PIXELS);      // 0 - NEOPIXEL_PIXELS range
   set_brightness(NEOPIXEL_BRIGHTNESS); // 0 - 255 range
   begin();
   show();  // initialize to all off

--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -73,8 +73,8 @@ public:
 
   static void set_color(const uint32_t c);
 
-  static void set_neo_index(const uint8_t neoIndex);
-  static uint8_t get_neo_index(void);
+  FORCE_INLINE static void set_neo_index(const uint8_t neoIndex) { neoindex = neoIndex; }
+  FORCE_INLINE static uint8_t get_neo_index() { return neoindex; }
 
   #ifdef NEOPIXEL_BKGD_LED_INDEX
     static void set_color_background();

--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -65,12 +65,16 @@ private:
       , adaneo2
     #endif
   ;
+  static uint8_t neoindex;
 
 public:
   static void init();
   static void set_color_startup(const uint32_t c);
 
   static void set_color(const uint32_t c);
+
+  static void set_neo_index(const uint8_t neoIndex);
+  static uint8_t get_neo_index(void);
 
   #ifdef NEOPIXEL_BKGD_LED_INDEX
     static void set_color_background();

--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -65,7 +65,7 @@ private:
       , adaneo2
     #endif
   ;
-  static uint8_t neoindex;
+  static int8_t neoindex;
 
 public:
   static void init();
@@ -73,8 +73,8 @@ public:
 
   static void set_color(const uint32_t c);
 
-  FORCE_INLINE static void set_neo_index(const uint8_t neoIndex) { neoindex = neoIndex; }
-  FORCE_INLINE static uint8_t get_neo_index() { return neoindex; }
+  FORCE_INLINE static void set_neo_index(const int8_t neoIndex) { neoindex = neoIndex; }
+  FORCE_INLINE static int8_t get_neo_index() { return neoindex; }
 
   #ifdef NEOPIXEL_BKGD_LED_INDEX
     static void set_color_background();

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -43,8 +43,12 @@
  *   M150 W          ; Turn LED white using a white LED
  *   M150 P127       ; Set LED 50% brightness
  *   M150 P          ; Set LED full brightness
- */
+ *   M150 I          ; Index of NEOPIXEL LED to change
+ */  
 void GcodeSuite::M150() {
+  #if ENABLED(NEOPIXEL_LED)
+    neo.set_neo_index(parser.seen('I') ? (parser.has_value() ? parser.value_byte() : NEOPIXEL_PIXELS) : NEOPIXEL_PIXELS);
+  #endif
   leds.set_color(MakeLEDColor(
     parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
     parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -50,7 +50,7 @@
  */  
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-    neo.set_neo_index(parser.byteval('I', NEOPIXEL_PIXELS));
+    neo.set_neo_index(parser.intval('I', -1));
   #endif
   leds.set_color(MakeLEDColor(
     parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -34,6 +34,9 @@
  * Always sets all 3 or 4 components. If a component is left out, set to 0.
  *                                    If brightness is left out, no value changed
  *
+ * With NEOPIXEL_LED:
+ *  I<index>  Set the Neopixel index to affect. Default: All
+ *
  * Examples:
  *
  *   M150 R255       ; Turn LED red
@@ -43,11 +46,11 @@
  *   M150 W          ; Turn LED white using a white LED
  *   M150 P127       ; Set LED 50% brightness
  *   M150 P          ; Set LED full brightness
- *   M150 I          ; Index of NEOPIXEL LED to change
+ *   M150 I1 R       ; Set NEOPIXEL index 1 to red
  */  
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-    neo.set_neo_index(parser.seen('I') ? (parser.has_value() ? parser.value_byte() : NEOPIXEL_PIXELS) : NEOPIXEL_PIXELS);
+    neo.set_neo_index(parser.byteval('I', NEOPIXEL_PIXELS));
   #endif
   leds.set_color(MakeLEDColor(
     parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,


### PR DESCRIPTION
### Requirements

#define NEOPIXEL_LED in Configuration.h

### Description

This adds a I parameter (for index) to gcode M150 when NEOPIXEL_LED is defined.
Index is from 0 to NEOPIXEL_PIXELS, when index >= NEOPIXEL_PIXELS all neopixels are selected. 

This allows M150 to set the colours of individual neopixels vs just setting the colour of the entire strip of neopixels.
Egs:
M150 R30 I0   set the 1st neopixel to red brightness 30.
M150 U30 I2   set the 3rd neopixel to green brightness 30.

I wanted this so I could test individual neopixels. Could also be used in as a debugging tool as indicators, or just in your gcode for what ever you can imagine.
Eg Could be used as a percentage display of complected gcode if you sprinkle the M!50 in your gcode.
Or create fancy lights patterns to get your attention in your gcode.end file.
NB PRINTER_EVENT_LEDS will over write any manually set neopixels.
 
### Benefits

More control over attached peripherals 

### Related Issues

None