### PR TITLE
Require unix line endings on test files

### DIFF
--- a/buildroot/tests/.gitattributes
+++ b/buildroot/tests/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
### Description

Ensure test files use unix line endings. This was lost then the test files were moved to a new folder.

### Benefits

Allows Windows Subsystem For Linux to be used to execute tests, even though Git for Windows may be configured to checkout with DOS line endings.

### Related Issues

N/A
