### PR TITLE
FIx #18501 Incorrect sanguino_atmega1284p board_upload maximum_size

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = sanguino1284p
+default_envs = mega2560
 
 #
 # The 'common' values are used for most Marlin builds

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = mega2560
+default_envs = sanguino1284p
 
 #
 # The 'common' values are used for most Marlin builds
@@ -147,6 +147,7 @@ board         = sanguino_atmega644p
 platform      = atmelavr
 extends       = common_avr8
 board         = sanguino_atmega1284p
+board_upload.maximum_size = 126976
 
 #
 # Melzi and clones (ATmega1284p)
@@ -157,13 +158,16 @@ extends       = common_avr8
 board         = sanguino_atmega1284p
 lib_ignore    = TMCStepper
 upload_speed  = 57600
+board_upload.maximum_size = 126976
 
 #
 # Melzi and clones (Optiboot bootloader)
 #
 [env:melzi_optiboot]
 platform      = atmelavr
-extends       = env:melzi
+extends       = common_avr8
+board         = sanguino_atmega1284p
+lib_ignore    = TMCStepper
 upload_speed  = 115200
 
 #
@@ -171,8 +175,7 @@ upload_speed  = 115200
 #
 [env:melzi_optimized]
 platform      = atmelavr
-extends       = env:melzi
-upload_speed  = 115200
+extends       = env:melzi_optiboot
 build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
 build_unflags = -g -ggdb
 


### PR DESCRIPTION
### Requirements

sanguino_atmega1284p based controller

### Description

Platformio presumes all sanguino_atmega1284p uses the newer optiboot bootloader and incorrectly set sets 130048 bytes for maximum_size of firmware size. This Can overwrite larger bootloader.

### Benefits

Doesn't overwrite larger bootloader

### Related Issues

Issue: https://github.com/MarlinFirmware/Marlin/issues/18501
