### PR TITLE
Keep filament runout pin for Creality Melzi

### DIFF
--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
@@ -61,7 +61,6 @@
 #undef LCD_PINS_D5
 #undef LCD_PINS_D6
 #undef LCD_PINS_D7
-#undef FIL_RUNOUT_PIN                             // Uses Beeper/LED Pin Pulled to GND
 
 #define LCD_SDSS                             31   // Smart Controller SD card reader (rather than the Melzi)
 #define LCD_PINS_RS                          28   // ST9720 CS
@@ -69,8 +68,16 @@
 #define LCD_PINS_D4                          30   // ST9720 CLK
 
 #if ENABLED(BLTOUCH)
+  #undef FIL_RUNOUT_PIN                           // Uses Beeper/LED Pin Pulled to GND
   #define SERVO0_PIN                         27
   #undef BEEPER_PIN
+#elif ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #ifndef FIL_RUNOUT_PIN
+    #define FIL_RUNOUT_PIN                     27
+  #endif
+  #if (FIL_RUNOUT_PIN == BEEPER_PIN)
+    #undef BEEPER_PIN
+  #endif
 #endif
 
 #if ENABLED(MINIPANEL)

--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
@@ -68,14 +68,13 @@
 #define LCD_PINS_D4                          30   // ST9720 CLK
 
 #if ENABLED(BLTOUCH)
-  #undef FIL_RUNOUT_PIN                           // Uses Beeper/LED Pin Pulled to GND
   #define SERVO0_PIN                         27
   #undef BEEPER_PIN
 #elif ENABLED(FILAMENT_RUNOUT_SENSOR)
   #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN                     27
+    #define FIL_RUNOUT_PIN                   27
   #endif
-  #if (FIL_RUNOUT_PIN == BEEPER_PIN)
+  #if FIL_RUNOUT_PIN == BEEPER_PIN
     #undef BEEPER_PIN
   #endif
 #endif


### PR DESCRIPTION
Issue with TH3D ez out board was reported where runout pin could not be defined. Allows use of runout pin if enabled, and prevents overriding pin if set in configuration.h