### PR TITLE
Fix mks_robin_nano35 PIO environment

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -560,7 +560,7 @@ platform      = ${common_stm32f1.platform}
 extends       = env:mks_robin_nano
 extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
 lib_deps      = ${common_stm32f1.lib_deps}
-     MKS-LittlevGL=https://github.com/makerbase-mks/MKS-LittlevGL/archive/master.zip
+  MKS-LittlevGL=https://github.com/makerbase-mks/MKS-LittlevGL/archive/master.zip
 
 #
 # MKS Robin (STM32F103ZET6)
@@ -692,8 +692,8 @@ platform      = ${common_stm32f1.platform}
 extends       = env:chitu_f103
 src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_deps      = ${common.lib_deps}
-   SoftwareSerialM
-   MKS-LittlevGL=https://github.com/makerbase-mks/MKS-LittlevGL/archive/master.zip
+  SoftwareSerialM
+  MKS-LittlevGL=https://github.com/makerbase-mks/MKS-LittlevGL/archive/master.zip
 
 #
 # Creality (STM32F103RET6)

--- a/platformio.ini
+++ b/platformio.ini
@@ -553,6 +553,16 @@ build_flags   = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSS_TIMER=4
 
 #
+# MKS Robin Nano (STM32F103VET6) - MKS UI (LVGL)
+#
+[env:mks_robin_nano35]
+platform      = ${common_stm32f1.platform}
+extends       = env:mks_robin_nano
+extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
+lib_deps      = ${common_stm32f1.lib_deps}
+     MKS-LittlevGL=https://github.com/makerbase-mks/MKS-LittlevGL/archive/master.zip
+
+#
 # MKS Robin (STM32F103ZET6)
 #
 [env:mks_robin]
@@ -626,23 +636,6 @@ build_flags   = ${common_stm32f1.build_flags}
   -Wl,--gc-sections -DDEBUG_LEVEL=0 -D__MARLIN_FIRMWARE__
 lib_ignore    = ${common_stm32f1.lib_ignore}
   LiquidCrystal, LiquidTWI2, TMCStepper, U8glib-HAL, SoftwareSerialM
-
-#
-# MKS Robin Nano (STM32F103VET6) - MKS UI (LVGL)
-#
-[env:mks_robin_nano35]
-platform      = ststm32
-board         = genericSTM32F103VE
-platform_packages = tool-stm32duino
-build_flags   = !python Marlin/src/HAL/STM32F1/build_flags.py
-  ${common.build_flags} -std=gnu++14 -DHAVE_SW_SERIAL -DSS_TIMER=4
-build_unflags = -std=gnu++11
-extra_scripts = buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
-src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
-lib_deps      = ${common.lib_deps}
-  SoftwareSerialM
-  MKS-LittlevGL=https://github.com/makerbase-mks/MKS-LittlevGL/archive/master.zip
-lib_ignore    = Adafruit NeoPixel, SPI
 
 #
 # Malyan M200 v2 (STM32F070RB)


### PR DESCRIPTION
### Requirements

`TFT_LVGL_UI`-based Robin Nano build, compiled with the `mks_robin_nano35` environment.

### Description

Extend `mks_robin_nano35` from `mks_robin_nano` so it will now build correctly (and be locked to STM32 < 7.0 which was causing build issues).

H/t to @sjasonsmith for the fix.

### Benefits

See above.

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/18505
