### PR TITLE
Fix axis display name in serial echo

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -501,4 +501,4 @@ struct XYZEval {
 #undef FI
 
 const xyze_char_t axis_codes { 'X', 'Y', 'Z', 'E' };
-#define XYZ_CHAR(A) ('X' + char(A))
+#define XYZ_CHAR(A) ((char)('X' + A))


### PR DESCRIPTION
Display proper axis name instead of ascii representation in serial echoed commands