### PR TITLE
Fixes: #18525  trying to read from thermistor when there is none.

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1804,16 +1804,16 @@ void Temperature::init() {
         temp_range[NR].raw_max -= TEMPDIR(NR) * (OVERSAMPLENR); \
     }while(0)
 
-    #if THERMISTOR_HEATER_0
+    #if THERMISTOR_HEATER_0 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
       #ifdef HEATER_0_MINTEMP
       _TEMP_MIN_E(0);
       #endif
       #ifdef HEATER_0_MAXTEMP
-        _TEMP_MAX_E(0);
+        _TEMP_MAX_E(0); 
       #endif
     #endif
 
-    #if HAS_MULTI_HOTEND && THERMISTOR_HEATER_1
+    #if HAS_MULTI_HOTEND && THERMISTOR_HEATER_1 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
       #ifdef HEATER_1_MINTEMP
         _TEMP_MIN_E(1);
       #endif
@@ -1822,7 +1822,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 2 && THERMISTOR_HEATER_2
+    #if HOTENDS > 2 && THERMISTOR_HEATER_2 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
       #ifdef HEATER_2_MINTEMP
         _TEMP_MIN_E(2);
       #endif
@@ -1831,7 +1831,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 3 && THERMISTOR_HEATER_3
+    #if HOTENDS > 3 && THERMISTOR_HEATER_3 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
       #ifdef HEATER_3_MINTEMP
         _TEMP_MIN_E(3);
       #endif
@@ -1840,7 +1840,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 4 && THERMISTOR_HEATER_4
+    #if HOTENDS > 4 && THERMISTOR_HEATER_4 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
       #ifdef HEATER_4_MINTEMP
         _TEMP_MIN_E(4);
       #endif
@@ -1849,7 +1849,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 5 && THERMISTOR_HEATER_5
+    #if HOTENDS > 5 && THERMISTOR_HEATER_5 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
       #ifdef HEATER_5_MINTEMP
         _TEMP_MIN_E(5);
       #endif
@@ -1858,7 +1858,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 6 && THERMISTOR_HEATER_6
+    #if HOTENDS > 6 && THERMISTOR_HEATER_6 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
       #ifdef HEATER_6_MINTEMP
         _TEMP_MIN_E(6);
       #endif
@@ -1867,7 +1867,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 7 && THERMISTOR_HEATER_7
+    #if HOTENDS > 7 && THERMISTOR_HEATER_7 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
       #ifdef HEATER_7_MINTEMP
         _TEMP_MIN_E(7);
       #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1813,7 +1813,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HAS_MULTI_HOTEND && THERMISTOR_HEATER_1 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
+    #if HAS_MULTI_HOTEND && THERMISTOR_HEATER_1 && THERMISTOR_HEATER_1 != 999 && THERMISTOR_HEATER_1 != 998
       #ifdef HEATER_1_MINTEMP
         _TEMP_MIN_E(1);
       #endif
@@ -1822,7 +1822,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 2 && THERMISTOR_HEATER_2 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
+    #if HOTENDS > 2 && THERMISTOR_HEATER_2 && THERMISTOR_HEATER_2 != 999 && THERMISTOR_HEATER_2 != 998
       #ifdef HEATER_2_MINTEMP
         _TEMP_MIN_E(2);
       #endif
@@ -1831,7 +1831,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 3 && THERMISTOR_HEATER_3 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
+    #if HOTENDS > 3 && THERMISTOR_HEATER_3 && THERMISTOR_HEATER_3 != 999 && THERMISTOR_HEATER_3 != 998
       #ifdef HEATER_3_MINTEMP
         _TEMP_MIN_E(3);
       #endif
@@ -1840,7 +1840,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 4 && THERMISTOR_HEATER_4 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
+    #if HOTENDS > 4 && THERMISTOR_HEATER_4 && THERMISTOR_HEATER_4 != 999 && THERMISTOR_HEATER_4 != 998
       #ifdef HEATER_4_MINTEMP
         _TEMP_MIN_E(4);
       #endif
@@ -1849,7 +1849,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 5 && THERMISTOR_HEATER_5 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
+    #if HOTENDS > 5 && THERMISTOR_HEATER_5 && THERMISTOR_HEATER_5 != 999 && THERMISTOR_HEATER_5 != 998
       #ifdef HEATER_5_MINTEMP
         _TEMP_MIN_E(5);
       #endif
@@ -1858,7 +1858,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 6 && THERMISTOR_HEATER_6 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
+    #if HOTENDS > 6 && THERMISTOR_HEATER_6 && THERMISTOR_HEATER_6 != 999 && THERMISTOR_HEATER_6 != 998
       #ifdef HEATER_6_MINTEMP
         _TEMP_MIN_E(6);
       #endif
@@ -1867,7 +1867,7 @@ void Temperature::init() {
       #endif
     #endif
 
-    #if HOTENDS > 7 && THERMISTOR_HEATER_7 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
+    #if HOTENDS > 7 && THERMISTOR_HEATER_7 && THERMISTOR_HEATER_7 != 999 && THERMISTOR_HEATER_7 != 998
       #ifdef HEATER_7_MINTEMP
         _TEMP_MIN_E(7);
       #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1804,76 +1804,55 @@ void Temperature::init() {
         temp_range[NR].raw_max -= TEMPDIR(NR) * (OVERSAMPLENR); \
     }while(0)
 
-    #if THERMISTOR_HEATER_0 && THERMISTOR_HEATER_0 != 999 && THERMISTOR_HEATER_0 != 998
-      #ifdef HEATER_0_MINTEMP
+    #define _MINMAX_TEST(N,M) (HOTENDS > N && THERMISTOR_HEATER_##N && THERMISTOR_HEATER_##N != 998 && THERMISTOR_HEATER_##N != 999 && defined(HEATER_##N##_##M##TEMP))
+  
+    #if _MINMAX_TEST(0, MIN)
       _TEMP_MIN_E(0);
-      #endif
-      #ifdef HEATER_0_MAXTEMP
-        _TEMP_MAX_E(0); 
-      #endif
     #endif
-
-    #if HAS_MULTI_HOTEND && THERMISTOR_HEATER_1 && THERMISTOR_HEATER_1 != 999 && THERMISTOR_HEATER_1 != 998
-      #ifdef HEATER_1_MINTEMP
-        _TEMP_MIN_E(1);
-      #endif
-      #ifdef HEATER_1_MAXTEMP
-        _TEMP_MAX_E(1);
-      #endif
+    #if _MINMAX_TEST(0, MAX)
+      _TEMP_MAX_E(0); 
     #endif
-
-    #if HOTENDS > 2 && THERMISTOR_HEATER_2 && THERMISTOR_HEATER_2 != 999 && THERMISTOR_HEATER_2 != 998
-      #ifdef HEATER_2_MINTEMP
-        _TEMP_MIN_E(2);
-      #endif
-      #ifdef HEATER_2_MAXTEMP
-        _TEMP_MAX_E(2);
-      #endif
+    #if _MINMAX_TEST(1, MIN)
+      _TEMP_MIN_E(1);
     #endif
-
-    #if HOTENDS > 3 && THERMISTOR_HEATER_3 && THERMISTOR_HEATER_3 != 999 && THERMISTOR_HEATER_3 != 998
-      #ifdef HEATER_3_MINTEMP
-        _TEMP_MIN_E(3);
-      #endif
-      #ifdef HEATER_3_MAXTEMP
-        _TEMP_MAX_E(3);
-      #endif
+    #if _MINMAX_TEST(1, MAX)
+      _TEMP_MAX_E(1);
     #endif
-
-    #if HOTENDS > 4 && THERMISTOR_HEATER_4 && THERMISTOR_HEATER_4 != 999 && THERMISTOR_HEATER_4 != 998
-      #ifdef HEATER_4_MINTEMP
-        _TEMP_MIN_E(4);
-      #endif
-      #ifdef HEATER_4_MAXTEMP
-        _TEMP_MAX_E(4);
-      #endif
+    #if _MINMAX_TEST(2, MIN)
+      _TEMP_MIN_E(2);
     #endif
-
-    #if HOTENDS > 5 && THERMISTOR_HEATER_5 && THERMISTOR_HEATER_5 != 999 && THERMISTOR_HEATER_5 != 998
-      #ifdef HEATER_5_MINTEMP
-        _TEMP_MIN_E(5);
-      #endif
-      #ifdef HEATER_5_MAXTEMP
-        _TEMP_MAX_E(5);
-      #endif
+    #if _MINMAX_TEST(2, MAX)
+      _TEMP_MAX_E(2);
     #endif
-
-    #if HOTENDS > 6 && THERMISTOR_HEATER_6 && THERMISTOR_HEATER_6 != 999 && THERMISTOR_HEATER_6 != 998
-      #ifdef HEATER_6_MINTEMP
-        _TEMP_MIN_E(6);
-      #endif
-      #ifdef HEATER_6_MAXTEMP
-        _TEMP_MAX_E(6);
-      #endif
+    #if _MINMAX_TEST(3, MIN)
+      _TEMP_MIN_E(3);
     #endif
-
-    #if HOTENDS > 7 && THERMISTOR_HEATER_7 && THERMISTOR_HEATER_7 != 999 && THERMISTOR_HEATER_7 != 998
-      #ifdef HEATER_7_MINTEMP
-        _TEMP_MIN_E(7);
-      #endif
-      #ifdef HEATER_7_MAXTEMP
-        _TEMP_MAX_E(7);
-      #endif
+    #if _MINMAX_TEST(3, MAX)
+      _TEMP_MAX_E(3);
+    #endif
+    #if _MINMAX_TEST(4, MIN)
+      _TEMP_MIN_E(4);
+    #endif
+    #if _MINMAX_TEST(4, MAX)
+      _TEMP_MAX_E(4);
+    #endif
+    #if _MINMAX_TEST(5, MIN)
+      _TEMP_MIN_E(5);
+    #endif
+    #if _MINMAX_TEST(5, MAX)
+      _TEMP_MAX_E(5);
+    #endif
+    #if _MINMAX_TEST(6, MIN)
+      _TEMP_MIN_E(6);
+    #endif
+    #if _MINMAX_TEST(6, MAX)
+      _TEMP_MAX_E(6);
+    #endif
+    #if _MINMAX_TEST(7, MIN)
+      _TEMP_MIN_E(7);
+    #endif
+    #if _MINMAX_TEST(7, MAX)
+      _TEMP_MAX_E(7);
     #endif
 
   #endif // HAS_HOTEND


### PR DESCRIPTION
### Requirements

Use TEMP_SENSOR_{n}  type 998 or 999

### Description

Printer immediately goes into thermal runaway detection.   

### Benefits

Allows for thermistor types 998 and 999 

### Related Issues

Issue: https://github.com/MarlinFirmware/Marlin/issues/18525