### PR TITLE
STM32: No compile-time check for PWM_PIN

### DIFF
--- a/Marlin/src/HAL/STM32/fastio.h
+++ b/Marlin/src/HAL/STM32/fastio.h
@@ -80,7 +80,8 @@ void FastIO_init(); // Must be called before using fast io macros
 #define IS_INPUT(IO)
 #define IS_OUTPUT(IO)
 
-#define PWM_PIN(P)              true //digitalPinHasPWM(P) this has to be changed to pass sanity checks for PWM on Extruder Auto Fans
+#define PWM_PIN(P)              digitalPinHasPWM(P)
+#define NO_COMPILE_TIME_PWM
 
 // digitalRead/Write wrappers
 #define extDigitalRead(IO)    digitalRead(IO)

--- a/Marlin/src/HAL/STM32/fastio.h
+++ b/Marlin/src/HAL/STM32/fastio.h
@@ -80,7 +80,7 @@ void FastIO_init(); // Must be called before using fast io macros
 #define IS_INPUT(IO)
 #define IS_OUTPUT(IO)
 
-#define PWM_PIN(P)              digitalPinHasPWM(P)
+#define PWM_PIN(P)              true //digitalPinHasPWM(P) this has to be changed to pass sanity checks for PWM on Extruder Auto Fans
 
 // digitalRead/Write wrappers
 #define extDigitalRead(IO)    digitalRead(IO)


### PR DESCRIPTION
### Description

STM32 (on my SKR Pro V1.1) fails to compile failing a sanity check when Extruder Auto Fans is enabled and the pin is treated as PWM (speed less than 255)

### Benefits

This seems to be the previous way it worked before we started unifying the STM32 platform
It now works properly and compiles solving these errors

This fixes https://github.com/MarlinFirmware/Marlin/issues/15858

```error: non-constant condition for static assertion
  254 | #define digitalPinHasPWM(p)         (pin_in_pinmap(digitalPinToPinName(p), PinMap_PWM))
      |                                     ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Marlin\src\HAL\STM32\fastio.h:83:33: note: in expansion of macro 'digitalPinHasPWM'
   83 | #define PWM_PIN(P)              digitalPinHasPWM(P)
      |                                 ^~~~~~~~~~~~~~~~
Marlin\src\HAL\STM32\../../inc/SanityCheck.h:2091:19: note: in expansion of macro 'PWM_PIN'
 2091 |     static_assert(PWM_PIN(E0_AUTO_FAN_PIN), "E0" AF_ERR_SUFF);```


