### PR TITLE
Fix error: 'ubl' was not declared in this scope

### DIFF
--- a/Marlin/src/gcode/control/M17_M18_M84.cpp
+++ b/Marlin/src/gcode/control/M17_M18_M84.cpp
@@ -25,7 +25,7 @@
 #include "../../lcd/ultralcd.h"
 #include "../../module/stepper.h"
 
-#if BOTH(AUTO_BED_LEVELING_UBL, ULTRA_LCD)
+#if ENABLED(AUTO_BED_LEVELING_UBL)
   #include "../../feature/bedlevel/bedlevel.h"
 #endif
 


### PR DESCRIPTION
### Description

At present there exists a bug which prevents Marlin from compiling when Unified Bed Leveling is enabled but no LCD screen is enabled. This is an issue because some non-standard graphical devices (such as the BigTreeTech TFT series) allow for Auto Bed Leveling configuration, but such devices do not require any LCD to be enabled in the configuration files.

### Benefits

Allow compile with UBL and no LCD.

### Related Issues

Not applicable.

### Notes

According to [this page](https://marlinfw.org/docs/features/unified_bed_leveling.html#ubl-without-an-lcd) it is intended for the user to be able to use UBL without an LCD.
