### PR TITLE
Fix Neopixels

### DIFF
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -53,7 +53,7 @@ Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIX
 #endif
 
 void Marlin_NeoPixel::set_color(const uint32_t color) {
-  if (get_neo_index() < 0) { 
+  if (get_neo_index() >= 0) { 
     set_pixel_color(get_neo_index(), color);
     set_neo_index(-1);
   }


### PR DESCRIPTION


### Description

PR #18490 broke Neopixel ``PRINTER_EVENT_LEDS`` and ``M150`` functionality. This PR fixes the breakage.

### Benefits

Fix Neopixels.

### Related Issues

Fixes #18543
