### PR TITLE
Enable CI on Push (direct commits)

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -14,6 +14,14 @@ on:
     - data/**
     - docs/**
     - '**/*.md'
+  push:
+    branches:
+    - bugfix-2.0.x
+    paths-ignore:
+    - config/**
+    - data/**
+    - docs/**
+    - '**/*.md'
 
 jobs:
   test_builds:


### PR DESCRIPTION
### Description

Trigger CI on push events (direct commits) in addition to pull requests since not all changes come in via PRs.

### Benefits

More thorough CI testing which will make it easier to locate potential bugs when committing directly to `bugfix-2.0.x`.