### PR TITLE
Fix stall sensitivity adjustment for FTDI screens

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stepper_bump_sensitivity_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stepper_bump_sensitivity_screen.cpp
@@ -43,12 +43,12 @@ void StepperBumpSensitivityScreen::onRedraw(draw_mode_t what) {
 bool StepperBumpSensitivityScreen::onTouchHeld(uint8_t tag) {
   const float increment = getIncrement();
   switch (tag) {
-    case  2: UI_DECREMENT(TMCBumpSensitivity, X  ); break;
-    case  3: UI_INCREMENT(TMCBumpSensitivity, X2 ); break;
-    case  4: UI_DECREMENT(TMCBumpSensitivity, Y  ); break;
-    case  5: UI_INCREMENT(TMCBumpSensitivity, Y2 ); break;
-    case  6: UI_DECREMENT(TMCBumpSensitivity, Z  ); break;
-    case  7: UI_INCREMENT(TMCBumpSensitivity, Z2 ); break;
+    case  2: UI_DECREMENT(TMCBumpSensitivity, X ); break;
+    case  3: UI_INCREMENT(TMCBumpSensitivity, X ); break;
+    case  4: UI_DECREMENT(TMCBumpSensitivity, Y ); break;
+    case  5: UI_INCREMENT(TMCBumpSensitivity, Y ); break;
+    case  6: UI_DECREMENT(TMCBumpSensitivity, Z ); break;
+    case  7: UI_INCREMENT(TMCBumpSensitivity, Z ); break;
     default:
       return false;
   }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stepper_bump_sensitivity_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stepper_bump_sensitivity_screen.cpp
@@ -43,12 +43,12 @@ void StepperBumpSensitivityScreen::onRedraw(draw_mode_t what) {
 bool StepperBumpSensitivityScreen::onTouchHeld(uint8_t tag) {
   const float increment = getIncrement();
   switch (tag) {
-    case  2: UI_DECREMENT(TMCBumpSensitivity, X ); break;
-    case  3: UI_INCREMENT(TMCBumpSensitivity, X ); break;
-    case  4: UI_DECREMENT(TMCBumpSensitivity, Y ); break;
-    case  5: UI_INCREMENT(TMCBumpSensitivity, Y ); break;
-    case  6: UI_DECREMENT(TMCBumpSensitivity, Z ); break;
-    case  7: UI_INCREMENT(TMCBumpSensitivity, Z ); break;
+    case  2: UI_DECREMENT(TMCBumpSensitivity, X); break;
+    case  3: UI_INCREMENT(TMCBumpSensitivity, X); break;
+    case  4: UI_DECREMENT(TMCBumpSensitivity, Y); break;
+    case  5: UI_INCREMENT(TMCBumpSensitivity, Y); break;
+    case  6: UI_DECREMENT(TMCBumpSensitivity, Z); break;
+    case  7: UI_INCREMENT(TMCBumpSensitivity, Z); break;
     default:
       return false;
   }


### PR DESCRIPTION
### Description

Remove incorrect `2` suffix on the increment buttons when adjusting TMC Stall Sensitivity

**I have not tested this. It seems correct, because no other menus refer to `X2`, `Y2`, and `Z2`. I need somebody else to test it for me.**

### Benefits

Allows increment and not only decrement

### Related Issues

#18499 - From the screen in the settings menu, you cannot increase the sensitivity without a sensor, only decrease it. t description)
#18497 - (Duplicate of same issue)
