### PR TITLE
Fix broken POWER_LOSS_RECOVERY prompt

### DIFF
--- a/Marlin/src/HAL/LPC1768/main.cpp
+++ b/Marlin/src/HAL/LPC1768/main.cpp
@@ -122,7 +122,7 @@ void HAL_init() {
   delay(1000);                              // Give OS time to notice
   USB_Connect(TRUE);
 
-  #if !BOTH(SHARED_SD_CARD, INIT_SDCARD_ON_BOOT) && DISABLED(NO_SD_HOST_DRIVE)
+  #if DISABLED(NO_SD_HOST_DRIVE)
     MSC_SD_Init(0);                         // Enable USB SD card access
   #endif
 
@@ -140,7 +140,7 @@ void HAL_init() {
 
 // HAL idle task
 void HAL_idletask() {
-  #if ENABLED(SHARED_SD_CARD)
+  #if HAS_SHARED_MEDIA
     // If Marlin is using the SD card we need to lock it to prevent access from
     // a PC via USB.
     // Other HALs use IS_SD_PRINTING() and IS_SD_FILE_OPEN() to check for access but

--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -258,7 +258,7 @@ void HAL_init() {
 // HAL idle task
 void HAL_idletask() {
   #ifdef USE_USB_COMPOSITE
-    #if ENABLED(SHARED_SD_CARD)
+    #if HAS_SHARED_MEDIA
       // If Marlin is using the SD card we need to lock it to prevent access from
       // a PC via USB.
       // Other HALs use IS_SD_PRINTING() and IS_SD_FILE_OPEN() to check for access but
@@ -266,7 +266,7 @@ void HAL_idletask() {
       // the disk if Marlin has it mounted. Unfortunately there is currently no way
       // to unmount the disk from the LCD menu.
       // if (IS_SD_PRINTING() || IS_SD_FILE_OPEN())
-      /* copy from lpc1768 framework, should be fixed later for process SHARED_SD_CARD*/
+      /* copy from lpc1768 framework, should be fixed later for process HAS_SHARED_MEDIA*/
     #endif
     // process USB mass storage device class loop
     MarlinMSC.loop();

--- a/Marlin/src/HAL/STM32F1/onboard_sd.cpp
+++ b/Marlin/src/HAL/STM32F1/onboard_sd.cpp
@@ -20,7 +20,7 @@
 #include "SPI.h"
 #include "fastio.h"
 
-#if ENABLED(SHARED_SD_CARD)
+#if HAS_SHARED_MEDIA
   #ifndef ON_BOARD_SPI_DEVICE
     #define ON_BOARD_SPI_DEVICE SPI_DEVICE
   #endif

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -353,11 +353,7 @@
     // mount/unmount the card and refresh it. So we disable card detect.
     //
     #undef SD_DETECT_PIN
-    #define SHARED_SD_CARD
-  #endif
-
-  #if DISABLED(SHARED_SD_CARD)
-    #define INIT_SDCARD_ON_BOOT
+    #define HAS_SHARED_MEDIA 1
   #endif
 
   #if PIN_EXISTS(SD_DETECT)

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -389,7 +389,7 @@ void CardReader::mount() {
 #endif
 
 void CardReader::manage_media() {
-  static uint8_t prev_stat = TERN(INIT_SDCARD_ON_BOOT, 2, 0);
+  static uint8_t prev_stat = 2;       // First call, no prior state
   uint8_t stat = uint8_t(IS_SD_INSERTED());
   if (stat == prev_stat) return;
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -389,7 +389,7 @@ void CardReader::mount() {
 #endif
 
 void CardReader::manage_media() {
-  static uint8_t prev_stat = 2;       // First call, no prior state
+  static uint8_t prev_stat = 2;
   uint8_t stat = uint8_t(IS_SD_INSERTED());
   if (stat == prev_stat) return;
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -389,7 +389,7 @@ void CardReader::mount() {
 #endif
 
 void CardReader::manage_media() {
-  static uint8_t prev_stat = 2;
+  static uint8_t prev_stat = 2;       // First call, no prior state
   uint8_t stat = uint8_t(IS_SD_INSERTED());
   if (stat == prev_stat) return;
 


### PR DESCRIPTION
# Description

Do not depend on `INIT_SDCARD_ON_BOOT` when initializing the previous (unknown) state in `CardReader::manage_media`.
This constant may no longer serve any purpose. I considered removing it entirely but wanted to reduce churn just prior to the 2.0.6 release.

I tested this on an SKR 1.3.

### Benefits

Restores prompt on boot when using power-loss recovery.

### Related Issues

#17378
