### PR TITLE
Require TMCStepper 0.7.1 or higher

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ extra_scripts      = pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
 build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-all-constants
 lib_deps           =
   LiquidCrystal@1.5.0
-  TMCStepper@~0.7.0
+  TMCStepper@~0.7.1
   Adafruit MAX31865 library@~1.1.0
   Adafruit NeoPixel@1.5.0
   U8glib-HAL@0.4.1
@@ -294,7 +294,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768>
 lib_deps          = Servo
   LiquidCrystal@1.0.0
   U8glib-HAL@0.4.1
-  TMCStepper@~0.7.0
+  TMCStepper@~0.7.1
   Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/1.5.0.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip
 build_flags       = -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g ${common.build_flags}
@@ -381,7 +381,7 @@ build_flags       = ${common_stm32f1.build_flags}
 extra_scripts     = pre:buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
     buildroot/share/PlatformIO/scripts/STM32F103RC_MEEB_3DP.py
 lib_deps          =
-  TMCStepper@~0.7.0
+  TMCStepper@~0.7.1
   Adafruit MAX31865 library@~1.1.0
   U8glib-HAL@0.4.1
   Arduino-L6470@0.8.0


### PR DESCRIPTION
### Description

Require TMCStepper 0.7.1

### Benefits

The attached issue reports that TMCStepper 0.7.0 introduced some issues controlling drivers, most specifically for sensorless homing. The single commit was important enough for @teemuatlut to release a 0.7.1, so this appears to be an important upgrade.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/18563

There are some other open sensorless homing issues, so perhaps this is related to those as well. I will reply to any I can find asking them to test with TMCStepper 0.7.1.