### PR TITLE
scale filament runout dist lcd menu range

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -152,7 +152,7 @@ void menu_cancelobject();
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       editable.decimal = runout.runout_distance();
-      EDIT_ITEM(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, FILAMENT_RUNOUT_DISTANCE_MM*1.5,
+      EDIT_ITEM(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, float(FILAMENT_RUNOUT_DISTANCE_MM) * 1.5f,
         []{ runout.set_runout_distance(editable.decimal); }, true
       );
     #endif

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -152,7 +152,7 @@ void menu_cancelobject();
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       editable.decimal = runout.runout_distance();
-      EDIT_ITEM(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, 30,
+      EDIT_ITEM(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, FILAMENT_RUNOUT_DISTANCE_MM*1.5,
         []{ runout.set_runout_distance(editable.decimal); }, true
       );
     #endif


### PR DESCRIPTION
Requirements
Requires a filament runout sensor and FILAMENT_RUNOUT_DISTANCE_MM defined in Configuration.h

Description
This change scales the range of adjustment for the "Runout Dist mm" LCD menu option based on the FILAMENT_RUNOUT_LENGTH_MM value set in Configuration.h

Benefits
The previous maximum of 30 was insufficient for a sensor mounted at the end of a long feed tube. This change makes it easier to adjust to an optimal value starting from a measured length of the tube.

Related Issues
No known bugs or issues that this relates to