### PR TITLE
Add "I" option to reinitialize TMC

### DIFF
--- a/Marlin/src/gcode/feature/trinamic/M122.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M122.cpp
@@ -26,6 +26,7 @@
 
 #include "../../gcode.h"
 #include "../../../feature/tmc_util.h"
+#include "../../../module/stepper/indirection.h"
 
 /**
  * M122: Debug TMC drivers
@@ -36,6 +37,8 @@ void GcodeSuite::M122() {
   LOOP_XYZE(i) if (parser.seen(axis_codes[i])) { print_axis[i] = true; print_all = false; }
 
   if (print_all) LOOP_XYZE(i) print_axis[i] = true;
+
+  if (parser.seen('I')) restore_stepper_drivers();
 
   #if ENABLED(TMC_DEBUG)
     #if ENABLED(MONITOR_DRIVER_STATUS)

--- a/Marlin/src/gcode/feature/trinamic/M122.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M122.cpp
@@ -38,7 +38,7 @@ void GcodeSuite::M122() {
 
   if (print_all) LOOP_XYZE(i) print_axis[i] = true;
 
-  if (parser.seen('I')) restore_stepper_drivers();
+  if (parser.boolval('I')) restore_stepper_drivers();
 
   #if ENABLED(TMC_DEBUG)
     #if ENABLED(MONITOR_DRIVER_STATUS)


### PR DESCRIPTION
Adds a new "I" option to ``M122`` which will reinitialize the TMC drivers.

### Description
This adds a new ``I`` option to ``M122`` which will reinitialize TMC drivers (useful if the motherboard was booted over USB and ``PSU_CONTROL`` is not enabled)

### Benefits

Gives an option for users to be able to reinitialize TMC drivers after powering up the main PSU even without ``PSU_CONTROL`` enabled.

### Related Issues

#17965
