### PR TITLE
Bugfix USB_CS_PIN in USB_FLASH_DRIVE_SUPPORT with SKR 1.4/1.4T

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1239,7 +1239,7 @@
    */
   //#define USB_FLASH_DRIVE_SUPPORT
   #if ENABLED(USB_FLASH_DRIVE_SUPPORT)
-    #define USB_CS_PIN    LCD_SDSS
+    #define USB_CS_PIN    SDSS
     #define USB_INTR_PIN  SD_DETECT_PIN
 
     /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1239,7 +1239,7 @@
    */
   //#define USB_FLASH_DRIVE_SUPPORT
   #if ENABLED(USB_FLASH_DRIVE_SUPPORT)
-    #define USB_CS_PIN    SDSS
+    #define USB_CS_PIN    LCD_SDSS
     #define USB_INTR_PIN  SD_DETECT_PIN
 
     /**

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -261,6 +261,7 @@
     #define LCD_PINS_D4                    P1_20
 
     #define LCD_SDSS                       P0_16  // (16) J3-7 & AUX-4
+    #define SDSS                           LCD_SDSS
 
     #if SD_CONNECTION_IS(LCD)
       #define SD_DETECT_PIN                P1_31  // (49) (NOT 5V tolerant)

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -261,10 +261,10 @@
     #define LCD_PINS_D4                    P1_20
 
     #define LCD_SDSS                       P0_16  // (16) J3-7 & AUX-4
-    #define SDSS                           LCD_SDSS
 
     #if SD_CONNECTION_IS(LCD)
       #define SD_DETECT_PIN                P1_31  // (49) (NOT 5V tolerant)
+      #define SDSS                         LCD_SDSS
     #endif
 
     #if ENABLED(FYSETC_MINI_12864)


### PR DESCRIPTION
In pin's files  SDSS changed to LCD_SDSS, but in adv conf used SDSS.

