### PR TITLE
Remove 1.1.x references

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -117,7 +117,7 @@ Unsure where to begin contributing to Marlin? You can start by looking through t
 
 ### Pull Requests
 
-Pull Requests should always be targeted to working branches (e.g., `bugfix-1.1.x` and/or `bugfix-2.0.x`) and never to release branches (e.g., `1.1.x`). If this is your first Pull Request, please read our [Guide to Pull Requests](https://marlinfw.org/docs/development/getting_started_pull_requests.html) and Github's [Pull Request](https://help.github.com/articles/creating-a-pull-request/) documentation.
+Pull Requests should always be targeted to working branches (e.g., `bugfix-2.0.x`) and never to release branches (e.g., `2.0.x`). If this is your first Pull Request, please read our [Guide to Pull Requests](https://marlinfw.org/docs/development/getting_started_pull_requests.html) and Github's [Pull Request](https://help.github.com/articles/creating-a-pull-request/) documentation.
 
 * Fill in [the required template](pull_request_template.md).
 * Don't include issue numbers in the PR title.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -4,7 +4,7 @@ Have you read Marlin's Code of Conduct? By filing an Issue, you are expected to 
 
 Do you want to ask a question? Are you looking for support? Please don't post here. Instead please use the Marlin Firmware forum at http://forums.reprap.org/list.php?415 or the Marlin Facebook Group https://www.facebook.com/groups/1049718498464482/ or the Marlin Discord Server https://discord.gg/n5NJ59y.
 
-Before filing an issue be sure to test the 1.1 and/or 2.0 "bugfix" branches to see whether the issue is already addressed.
+Before filing an issue be sure to test the "bugfix-2.0.x" branch https://github.com/MarlinFirmware/Marlin/tree/bugfix-2.0.x to see whether the issue is already addressed.
 
 -->
 


### PR DESCRIPTION
### Description

Since 1.1.x is EOL'd, let's remove references to it.

### Benefits

Clearer instructions for users looking to contribute/file bug reports.

### Related Issues

None.
