### PR TITLE
Fix User Sensor 1000, reversed Pt100 / Pt1000

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1798,15 +1798,15 @@ void Temperature::init() {
   delay(250);
 
   #if HAS_HOTEND
-
+  
     #define _TEMP_MIN_E(NR) do{ \
-      const int16_t tmin = _MAX(HEATER_ ##NR## _MINTEMP, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MINTEMP_IND].celsius)); \
+      const int16_t tmin = THERMISTOR_HEATER_##NR != 1000 ?_MAX(HEATER_ ##NR## _MINTEMP, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MINTEMP_IND].celsius)):HEATER_ ##NR## _MINTEMP; \
       temp_range[NR].mintemp = tmin; \
       while (analog_to_celsius_hotend(temp_range[NR].raw_min, NR) < tmin) \
         temp_range[NR].raw_min += TEMPDIR(NR) * (OVERSAMPLENR); \
     }while(0)
     #define _TEMP_MAX_E(NR) do{ \
-      const int16_t tmax = _MIN(HEATER_ ##NR## _MAXTEMP, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MAXTEMP_IND].celsius) - 1); \
+      const int16_t tmax = THERMISTOR_HEATER_##NR != 1000 ? _MIN(HEATER_ ##NR## _MAXTEMP, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MAXTEMP_IND].celsius) - 1):HEATER_ ##NR## _MAXTEMP; \
       temp_range[NR].maxtemp = tmax; \
       while (analog_to_celsius_hotend(temp_range[NR].raw_max, NR) > tmax) \
         temp_range[NR].raw_max -= TEMPDIR(NR) * (OVERSAMPLENR); \

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1800,13 +1800,13 @@ void Temperature::init() {
   #if HAS_HOTEND
 
     #define _TEMP_MIN_E(NR) do{ \
-      const int16_t tmin = THERMISTOR_HEATER_##NR != 1000 ?_MAX(HEATER_ ##NR## _MINTEMP, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MINTEMP_IND].celsius)):HEATER_ ##NR## _MINTEMP; \
+      const int16_t tmin = _MAX(HEATER_ ##NR## _MINTEMP, TERN(HEATER_##NR##_USER_THERMISTOR, 0, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MINTEMP_IND].celsius))); \
       temp_range[NR].mintemp = tmin; \
       while (analog_to_celsius_hotend(temp_range[NR].raw_min, NR) < tmin) \
         temp_range[NR].raw_min += TEMPDIR(NR) * (OVERSAMPLENR); \
     }while(0)
     #define _TEMP_MAX_E(NR) do{ \
-      const int16_t tmax = THERMISTOR_HEATER_##NR != 1000 ? _MIN(HEATER_ ##NR## _MAXTEMP, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MAXTEMP_IND].celsius) - 1):HEATER_ ##NR## _MAXTEMP; \
+      const int16_t tmax = _MIN(HEATER_ ##NR## _MAXTEMP, TERN(HEATER_##NR##_USER_THERMISTOR, 2000, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MAXTEMP_IND].celsius) - 1)); \
       temp_range[NR].maxtemp = tmax; \
       while (analog_to_celsius_hotend(temp_range[NR].raw_max, NR) > tmax) \
         temp_range[NR].raw_max -= TEMPDIR(NR) * (OVERSAMPLENR); \

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1798,7 +1798,7 @@ void Temperature::init() {
   delay(250);
 
   #if HAS_HOTEND
-  
+
     #define _TEMP_MIN_E(NR) do{ \
       const int16_t tmin = THERMISTOR_HEATER_##NR != 1000 ?_MAX(HEATER_ ##NR## _MINTEMP, (int16_t)pgm_read_word(&HEATER_ ##NR## _TEMPTABLE[HEATER_ ##NR## _SENSOR_MINTEMP_IND].celsius)):HEATER_ ##NR## _MINTEMP; \
       temp_range[NR].mintemp = tmin; \

--- a/Marlin/src/module/thermistor/thermistor_1010.h
+++ b/Marlin/src/module/thermistor/thermistor_1010.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#define REVERSE_TEMP_SENSOR_RANGE_1010 1
+
 // Pt1000 with 1k0 pullup
 const temp_entry_t temptable_1010[] PROGMEM = {
   PtLine(  0, 1000, 1000),

--- a/Marlin/src/module/thermistor/thermistor_1047.h
+++ b/Marlin/src/module/thermistor/thermistor_1047.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#define REVERSE_TEMP_SENSOR_RANGE_1047 1
+
 // Pt1000 with 4k7 pullup
 const temp_entry_t temptable_1047[] PROGMEM = {
   // only a few values are needed as the curve is very flat

--- a/Marlin/src/module/thermistor/thermistor_110.h
+++ b/Marlin/src/module/thermistor/thermistor_110.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#define REVERSE_TEMP_SENSOR_RANGE_110 1
+
 // Pt100 with 1k0 pullup
 const temp_entry_t temptable_110[] PROGMEM = {
   // only a few values are needed as the curve is very flat

--- a/Marlin/src/module/thermistor/thermistor_147.h
+++ b/Marlin/src/module/thermistor/thermistor_147.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#define REVERSE_TEMP_SENSOR_RANGE_147 1
+
 // Pt100 with 4k7 pullup
 const temp_entry_t temptable_147[] PROGMEM = {
   // only a few values are needed as the curve is very flat


### PR DESCRIPTION
### Requirements

Set a thermistor to type 110 or 147 or 1000 or 1010 or 1047. Causes instant Thermal runaway error.

### Description

Thermistor tables 110, 147, 1010, 1047 are all PTC thermistors but none had the REVERSE_TEMP_SENSOR_RANGE define set. This resulted in the min and max tests setting min to max value and max to min value.

Thermistor table 1000 is calculated, not a real table. When code attempts to determine min and max temperature the code presumes a existing table. In this case min and max should just use the defined HEATER_ ##NR## _MINTEMP and HEATER_ ##NR## _MAXTEMP in configuration.h. 

### Benefits

thermistor of types 110, 147, 1000, 1010 and 1047 all work as expected.

### Related Issues
Issue: https://github.com/MarlinFirmware/Marlin/issues/18559
Commit: https://github.com/MarlinFirmware/Marlin/commit/c43bbcce152b4d3b4697e1e188d3bcada76a24a7 