### PR TITLE
Chitu v6 board fix for lvgl

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -112,9 +112,6 @@
 //
 // TronXY TFT Support
 //
-#define FSMC_GRAPHICAL_TFT
-#define TOUCH_BUTTONS
-
 #if ENABLED(FSMC_GRAPHICAL_TFT)
   #define FSMC_UPSCALE 3
   #define LCD_FULL_PIXEL_WIDTH 480


### PR DESCRIPTION
### Description

two forgotten lines that breaks chitu v6 board when using the new lvgl ui...

It conflicts with the configuration.h defines.