### PR TITLE
Check filament runout at print job start

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -415,6 +415,7 @@ void startOrResumeJob() {
     #if BOTH(LCD_SET_PROGRESS_MANUALLY, USE_M73_REMAINING_TIME)
       ui.reset_remaining_time();
     #endif
+    TERN_(HAS_FILAMENT_SENSOR, runout.run(true));   // Check filament runout with no delay / distance
   }
   print_job_timer.start();
 }

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -99,14 +99,14 @@ class TFilamentMonitor : public FilamentMonitorBase {
     }
 
     // Give the response a chance to update its counter.
-    static inline void run() {
+    static inline void run(const bool no_delay=false) {
       if ( enabled && !filament_ran_out
         && (printingIsActive() || TERN0(ADVANCED_PAUSE_FEATURE, did_pause_print))
       ) {
         TERN_(HAS_FILAMENT_RUNOUT_DISTANCE, cli()); // Prevent RunoutResponseDelayed::block_completed from accumulating here
         response.run();
         sensor.run();
-        const bool ran_out = response.has_run_out();
+        const bool ran_out = response.has_run_out(no_delay);
         TERN_(HAS_FILAMENT_RUNOUT_DISTANCE, sei());
         if (ran_out) {
           filament_ran_out = true;
@@ -273,8 +273,8 @@ class FilamentSensorBase {
         #endif
       }
 
-      static inline bool has_run_out() {
-        return runout_mm_countdown[active_extruder] < 0;
+      static inline bool has_run_out(const bool no_delay=false) {
+        return no_delay || runout_mm_countdown[active_extruder] < 0;
       }
 
       static inline void filament_present(const uint8_t extruder) {
@@ -305,7 +305,7 @@ class FilamentSensorBase {
     public:
       static inline void reset()                                  { runout_count = runout_threshold; }
       static inline void run()                                    { if (runout_count >= 0) runout_count--; }
-      static inline bool has_run_out()                            { return runout_count < 0; }
+      static inline bool has_run_out(const bool no_delay)         { return no_delay || runout_count < 0; }
       static inline void block_completed(const block_t* const)    { }
       static inline void filament_present(const uint8_t)          { runout_count = runout_threshold; }
   };


### PR DESCRIPTION
The `FILAMENT_RUNOUT_DISTANCE_MM` option delays filament runout until some amount of filament has been extruded. This is undesirable if filament is out right at the start of a print job. This PR adds an extra filament runout check at the start of printing, which will trigger right away even if there is a `FILAMENT_RUNOUT_DISTANCE_MM` value set.