### PR TITLE
Added condition #if HAS_BED_PROBE for DGUSScreenVariableHandler

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus/DGUSDisplay.cpp
@@ -852,14 +852,16 @@ void DGUSScreenVariableHandler::HandleStepPerMMExtruderChanged(DGUS_VP_Variable 
   }
 #endif
 
-void DGUSScreenVariableHandler::HandleProbeOffsetZChanged(DGUS_VP_Variable &var, void *val_ptr) {
-  DEBUG_ECHOLNPGM("HandleProbeOffsetZChanged");
+#if HAS_BED_PROBE
+    void DGUSScreenVariableHandler::HandleProbeOffsetZChanged(DGUS_VP_Variable &var, void *val_ptr) {
+      DEBUG_ECHOLNPGM("HandleProbeOffsetZChanged");
 
-  const float offset = float(int16_t(swap16(*(uint16_t*)val_ptr))) / 100.0f;
-  ExtUI::setZOffset_mm(offset);
-  ScreenHandler.skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
-  return;
-}
+      const float offset = float(int16_t(swap16(*(uint16_t*)val_ptr))) / 100.0f;
+      ExtUI::setZOffset_mm(offset);
+      ScreenHandler.skipVP = var.VP; // don't overwrite value the next update time as the display might autoincrement in parallel
+      return;
+    }
+#endif
 
 #if ENABLED(BABYSTEPPING)
   void DGUSScreenVariableHandler::HandleLiveAdjustZ(DGUS_VP_Variable &var, void *val_ptr) {


### PR DESCRIPTION
### Description
Added condition **#if HAS_BED_PROBE** for `DGUSScreenVariableHandler::HandleProbeOffsetZChanged`. In DGUSDisplay.h condition is included.

Without this condition compiler shows error.

```
sketch\src\lcd\extui\lib\dgus\DGUSDisplay.cpp:856:99: error: no 'void DGUSScreenVariableHandler::HandleProbeOffsetZChanged(DGUS_VP_Variable&, void*)' member function declared in class 'DGUSScreenVariableHandler'
     void DGUSScreenVariableHandler::HandleProbeOffsetZChanged(DGUS_VP_Variable &var, void *val_ptr) {
```


### Benefits
The compiler does not display a compilation error.

### Related Issues
N/A