### PR TITLE
Improve BLTouch reliability for STM32F1 boards

### DIFF
--- a/Marlin/src/HAL/STM32F1/Servo.cpp
+++ b/Marlin/src/HAL/STM32F1/Servo.cpp
@@ -74,6 +74,7 @@ void libServo::servoWrite(uint8_t inPin, uint16_t duty_cycle) {
 
 libServo::libServo() {
   servoIndex = ServoCount < MAX_SERVOS ? ServoCount++ : INVALID_SERVO;
+  timer_set_interrupt_priority(SERVO0_TIMER_NUM, SERVO0_TIMER_IRQ_PRIO);
 }
 
 bool libServo::attach(const int32_t inPin, const int32_t inMinAngle, const int32_t inMaxAngle) {

--- a/Marlin/src/HAL/STM32F1/timers.h
+++ b/Marlin/src/HAL/STM32F1/timers.h
@@ -91,8 +91,9 @@ typedef uint16_t hal_timer_t;
   #define SERVO0_TIMER_NUM 1  // SERVO0 or BLTOUCH
 #endif
 
-#define STEP_TIMER_IRQ_PRIO 1
-#define TEMP_TIMER_IRQ_PRIO 2
+#define STEP_TIMER_IRQ_PRIO 2
+#define TEMP_TIMER_IRQ_PRIO 3
+#define SERVO0_TIMER_IRQ_PRIO 1
 
 #define TEMP_TIMER_PRESCALE     1000 // prescaler for setting Temp timer, 72Khz
 #define TEMP_TIMER_FREQUENCY    1000 // temperature interrupt frequency
@@ -192,5 +193,7 @@ FORCE_INLINE static void HAL_timer_isr_prologue(const uint8_t timer_num) {
 FORCE_INLINE static void timer_no_ARR_preload_ARPE(timer_dev *dev) {
   bb_peri_set_bit(&(dev->regs).gen->CR1, TIMER_CR1_ARPE_BIT, 0);
 }
+
+void timer_set_interrupt_priority(uint_fast8_t timer_num, uint_fast8_t priority);
 
 #define TIMER_OC_NO_PRELOAD 0 // Need to disable preload also on compare registers.


### PR DESCRIPTION
### Description

There have been many reports of unreliable BLTouch probing on STM32F1 boards. This is caused by unstable PWM ouput on the servo line. It seems that when the BLTouch receives an invalid pulse, it will not trigger for 2-3 PWM cycles after the correct pulse width is restored.

HAL/STM32F1 relies on a hardware timer ISR to control the pulse width. When these ISRs happen to align with STEP and TEMP ISRs, the pulse width is corrupted.

This PR increases the priority of the timer interrupt used for PWM generation, to ensure it can output a stable signal.

The following image demonstrates the beginning of the servo pulse being delayed by ~20 microseconds by the other ISRs:

![image](https://user-images.githubusercontent.com/20053467/87324343-cda5bc80-c4e4-11ea-9a9d-d4f648ce5602.png)


### Benefits

Improves probing consistency, by ensuring the BLTouch is in the proper state when it hits the bed. It may also improve other BLTouch "randomness" such as dropped pins, but I have not explicitly tested for this.  The following chart shows the difference in probing consistency before and after this change, across 60 probes.

![image](https://user-images.githubusercontent.com/20053467/87324385-e0b88c80-c4e4-11ea-9e34-6ddf6eadcef4.png)


### Related Issues

#18598
Probably many others, I will need to finish filling in this list later when I have time to search for them.
