### PR TITLE
Fix indexed and edit menu items

### DIFF
--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -1032,13 +1032,12 @@ void MarlinUI::draw_status_screen() {
   // Low-level draw_edit_screen can be used to draw an edit screen from anyplace
   void MenuEditItemBase::draw_edit_screen(PGM_P const pstr, const char* const value/*=nullptr*/) {
     ui.encoder_direction_normal();
-
     uint8_t n = lcd_put_u8str_ind_P(0, 1, pstr, itemIndex, itemString, LCD_WIDTH - 1);
     if (value != nullptr) {
-      lcd_put_wchar(':');
-      int len = utf8_strlen(value);
-      const lcd_uint_t valrow = (n < len + 1) ? 2 : 1;          // Value on the next row if it won't fit
-      lcd_put_wchar((LCD_WIDTH - 1) - (len + 1), valrow, ' ');  // Right-justified, padded, leading space
+      lcd_put_wchar(':'); n--;
+      const uint8_t len = utf8_strlen(value) + 1;   // Plus one for a leading space
+      const lcd_uint_t valrow = n < len ? 2 : 1;    // Value on the next row if it won't fit
+      lcd_put_wchar(LCD_WIDTH - len, valrow, ' ');  // Right-justified, padded, leading space
       lcd_put_u8str(value);
     }
   }

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -309,11 +309,11 @@ namespace Language_en {
   PROGMEM Language_Str MSG_XY_FREQUENCY_LIMIT              = _UxGT("Frequency max");
   PROGMEM Language_Str MSG_XY_FREQUENCY_FEEDRATE           = _UxGT("Feed min");
   PROGMEM Language_Str MSG_STEPS_PER_MM                    = _UxGT("Steps/mm");
-  PROGMEM Language_Str MSG_A_STEPS                         = LCD_STR_A _UxGT("steps/mm");
-  PROGMEM Language_Str MSG_B_STEPS                         = LCD_STR_B _UxGT("steps/mm");
-  PROGMEM Language_Str MSG_C_STEPS                         = LCD_STR_C _UxGT("steps/mm");
-  PROGMEM Language_Str MSG_E_STEPS                         = _UxGT("Esteps/mm");
-  PROGMEM Language_Str MSG_EN_STEPS                        = _UxGT("*steps/mm");
+  PROGMEM Language_Str MSG_A_STEPS                         = LCD_STR_A _UxGT(" Steps/mm");
+  PROGMEM Language_Str MSG_B_STEPS                         = LCD_STR_B _UxGT(" Steps/mm");
+  PROGMEM Language_Str MSG_C_STEPS                         = LCD_STR_C _UxGT(" Steps/mm");
+  PROGMEM Language_Str MSG_E_STEPS                         = _UxGT("E steps/mm");
+  PROGMEM Language_Str MSG_EN_STEPS                        = _UxGT("* Steps/mm");
   PROGMEM Language_Str MSG_TEMPERATURE                     = _UxGT("Temperature");
   PROGMEM Language_Str MSG_MOTION                          = _UxGT("Motion");
   PROGMEM Language_Str MSG_FILAMENT                        = _UxGT("Filament");

--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -37,20 +37,18 @@
 lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const int8_t ind, PGM_P const inStr/*=nullptr*/, const lcd_uint_t maxlen/*=LCD_WIDTH*/) {
   uint8_t *p = (uint8_t*)pstr;
   int8_t n = maxlen;
-  for (; n > 0; n--) {
+  while (n > 0) {
     wchar_t ch;
     p = get_utf8_value_cb(p, read_byte_rom, &ch);
     if (!ch) break;
     if (ch == '=' || ch == '~' || ch == '*') {
-      // lcd_put_int(ind); n--; if (ind >= 10) n--;
       if (ind >= 0) {
         if (ch == '*') { lcd_put_wchar('E'); n--; }
         if (n) { lcd_put_wchar(ind + ((ch == '=') ? '0' : LCD_FIRST_TOOL)); n--; }
       }
       else {
         PGM_P const b = ind == -2 ? GET_TEXT(MSG_CHAMBER) : GET_TEXT(MSG_BED);
-        lcd_put_u8str_P(b);
-        n -= utf8_strlen_P(b);
+        n -= lcd_put_u8str_max_P(b, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
       }
       if (n) n -= lcd_put_u8str_max_P((PGM_P)p, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
       continue;
@@ -61,6 +59,7 @@ lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const int8_t ind, PGM_P const i
     }
 
     lcd_put_wchar(ch);
+    n--;
   }
   return n;
 }

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -186,6 +186,7 @@ DEFINE_MENU_EDIT_ITEM(float43);     // 1.234
 DEFINE_MENU_EDIT_ITEM(float5);      // 12345      right-justified
 DEFINE_MENU_EDIT_ITEM(float5_25);   // 12345      right-justified (25 increment)
 DEFINE_MENU_EDIT_ITEM(float51);     // 1234.5     right-justified
+DEFINE_MENU_EDIT_ITEM(float31sign); // +12.3
 DEFINE_MENU_EDIT_ITEM(float41sign); // +123.4
 DEFINE_MENU_EDIT_ITEM(float51sign); // +1234.5
 DEFINE_MENU_EDIT_ITEM(float52sign); // +123.45

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -296,6 +296,7 @@ DEFINE_MENU_EDIT_ITEM_TYPE(float43     ,float    ,ftostr43sign    ,1000     );  
 DEFINE_MENU_EDIT_ITEM_TYPE(float5      ,float    ,ftostr5rj       ,   1     );   // 12345      right-justified
 DEFINE_MENU_EDIT_ITEM_TYPE(float5_25   ,float    ,ftostr5rj       ,   0.04f );   // 12345      right-justified (25 increment)
 DEFINE_MENU_EDIT_ITEM_TYPE(float51     ,float    ,ftostr51rj      ,  10     );   // 1234.5     right-justified
+DEFINE_MENU_EDIT_ITEM_TYPE(float31sign ,float    ,ftostr31sign    ,  10     );   // +12.3
 DEFINE_MENU_EDIT_ITEM_TYPE(float41sign ,float    ,ftostr41sign    ,  10     );   // +123.4
 DEFINE_MENU_EDIT_ITEM_TYPE(float51sign ,float    ,ftostr51sign    ,  10     );   // +1234.5
 DEFINE_MENU_EDIT_ITEM_TYPE(float52sign ,float    ,ftostr52sign    , 100     );   // +123.45

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -479,8 +479,8 @@ void menu_cancelobject();
       START_MENU();
       BACK_ITEM(MSG_ADVANCED_SETTINGS);
       #if HAS_PROBE_XY_OFFSET
-        EDIT_ITEM(float51sign, MSG_ZPROBE_XOFFSET, &probe.offset.x, -(X_BED_SIZE), X_BED_SIZE);
-        EDIT_ITEM(float51sign, MSG_ZPROBE_YOFFSET, &probe.offset.y, -(Y_BED_SIZE), Y_BED_SIZE);
+        EDIT_ITEM(float31sign, MSG_ZPROBE_XOFFSET, &probe.offset.x, -(X_BED_SIZE), X_BED_SIZE);
+        EDIT_ITEM(float31sign, MSG_ZPROBE_YOFFSET, &probe.offset.y, -(Y_BED_SIZE), Y_BED_SIZE);
       #endif
       EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_ZPROBE_ZOFFSET, &probe.offset.z, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
       END_MENU();
@@ -500,7 +500,6 @@ void menu_advanced_steps_per_mm() {
   EDIT_QSTEPS(C);
 
   #if ENABLED(DISTINCT_E_FACTORS)
-    EDIT_ITEM_FAST(float51, MSG_E_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(active_extruder)], 5, 9999, []{ planner.refresh_positioning(); });
     LOOP_L_N(n, E_STEPPERS)
       EDIT_ITEM_FAST_N(float51, n, MSG_EN_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(n)], 5, 9999, []{ _planner_refresh_e_positioning(MenuItemBase::itemIndex); });
   #elif E_STEPPERS

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -435,19 +435,20 @@ void menu_cancelobject();
     END_MENU();
   }
 
-  // M205 Jerk
-  void menu_advanced_jerk() {
-    START_MENU();
-    BACK_ITEM(MSG_ADVANCED_SETTINGS);
+  #if HAS_CLASSIC_JERK
 
-    #if HAS_JUNCTION_DEVIATION
-      #if ENABLED(LIN_ADVANCE)
-        EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, 0.3f, planner.recalculate_max_e_jerk);
-      #else
-        EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, 0.5f);
+    void menu_advanced_jerk() {
+      START_MENU();
+      BACK_ITEM(MSG_ADVANCED_SETTINGS);
+
+      #if HAS_JUNCTION_DEVIATION
+        #if ENABLED(LIN_ADVANCE)
+          EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, 0.3f, planner.recalculate_max_e_jerk);
+        #else
+          EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, 0.5f);
+        #endif
       #endif
-    #endif
-    #if HAS_CLASSIC_JERK
+
       constexpr xyze_float_t max_jerk_edit =
         #ifdef MAX_JERK_EDIT_VALUES
           MAX_JERK_EDIT_VALUES
@@ -468,10 +469,11 @@ void menu_cancelobject();
       #if HAS_CLASSIC_E_JERK
         EDIT_ITEM_FAST(float52sign, MSG_VE_JERK, &planner.max_jerk.e, 0.1f, max_jerk_edit.e);
       #endif
-    #endif
 
-    END_MENU();
-  }
+      END_MENU();
+    }
+
+  #endif
 
   // M851 - Z Probe Offsets
   #if HAS_BED_PROBE
@@ -534,8 +536,16 @@ void menu_advanced_settings() {
     // M201 - Acceleration items
     SUBMENU(MSG_ACCELERATION, menu_advanced_acceleration);
 
-    // M205 - Max Jerk
-    SUBMENU(MSG_JERK, menu_advanced_jerk);
+    #if HAS_CLASSIC_JERK
+      // M205 - Max Jerk
+      SUBMENU(MSG_JERK, menu_advanced_jerk);
+    #elif HAS_JUNCTION_DEVIATION
+      EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, 0.3f
+        #if ENABLED(LIN_ADVANCE)
+          , planner.recalculate_max_e_jerk
+        #endif
+      );
+    #endif
 
     // M851 - Z Probe Offsets
     #if HAS_BED_PROBE

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -307,6 +307,7 @@ void menu_advanced_settings();
     #define MAXTEMP_ALL _MAX(REPEAT(HOTENDS, _MAXTEMP_ITEM) 0)
     const uint8_t m = MenuItemBase::itemIndex;
     START_MENU();
+    STATIC_ITEM_P(ui.get_preheat_label(m), SS_CENTER|SS_INVERT);
     BACK_ITEM(MSG_CONFIGURATION);
     #if HAS_FAN
       editable.uint8 = uint8_t(ui.material_preset[m].fan_speed);

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -114,7 +114,7 @@ static void _lcd_move_xyz(PGM_P const name, const AxisEnum axis) {
       ui.manual_move.processing ? destination[axis] : current_position[axis] + TERN0(IS_KINEMATIC, ui.manual_move.offset),
       axis
     );
-    MenuEditItemBase::draw_edit_screen(name, ui.manual_move.menu_scale >= 0.1f ? ftostr41sign(pos) : ftostr43sign(pos));
+    MenuEditItemBase::draw_edit_screen(name, ui.manual_move.menu_scale >= 0.1f ? ftostr41sign(pos) : ftostr63(pos));
   }
 }
 void lcd_move_x() { _lcd_move_xyz(GET_TEXT(MSG_MOVE_X), X_AXIS); }

--- a/Marlin/src/libs/numtostr.cpp
+++ b/Marlin/src/libs/numtostr.cpp
@@ -31,6 +31,8 @@ char conv[8] = { 0 };
 #define DIGIMOD(n, f) DIGIT((n)/(f) % 10)
 #define RJDIGIT(n, f) ((n) >= (f) ? DIGIMOD(n, f) : ' ')
 #define MINUSOR(n, alt) (n >= 0 ? (alt) : (n = -n, '-'))
+#define INTFLOAT(V,N) (((V) * 10 * pow(10, N) + ((V) < 0 ? -5: 5)) / 10)      // pow10?
+#define UINTFLOAT(V,N) INTFLOAT((V) < 0 ? -(V) : (V), N)
 
 // Convert a full-range unsigned 8bit int to a percentage
 const char* ui8tostr4pctrj(const uint8_t i) {
@@ -166,7 +168,7 @@ const char* i16tostr4signrj(const int16_t i) {
 
 // Convert unsigned float to string with 1.23 format
 const char* ftostr12ns(const float &f) {
-  const long i = ((f < 0 ? -f : f) * 1000 + 5) / 10;
+  const long i = UINTFLOAT(f, 2);
   conv[3] = DIGIMOD(i, 100);
   conv[4] = '.';
   conv[5] = DIGIMOD(i, 10);
@@ -176,7 +178,7 @@ const char* ftostr12ns(const float &f) {
 
 // Convert unsigned float to string with 12.3 format
 const char* ftostr31ns(const float &f) {
-  const long i = ((f < 0 ? -f : f) * 100 + 5) / 10;
+  const long i = UINTFLOAT(f, 1);
   conv[3] = DIGIMOD(i, 100);
   conv[4] = DIGIMOD(i, 10);
   conv[5] = '.';
@@ -186,7 +188,7 @@ const char* ftostr31ns(const float &f) {
 
 // Convert unsigned float to string with 123.4 format
 const char* ftostr41ns(const float &f) {
-  const long i = ((f < 0 ? -f : f) * 100 + 5) / 10;
+  const long i = UINTFLOAT(f, 1);
   conv[2] = DIGIMOD(i, 1000);
   conv[3] = DIGIMOD(i, 100);
   conv[4] = DIGIMOD(i, 10);
@@ -198,7 +200,7 @@ const char* ftostr41ns(const float &f) {
 // Convert signed float to fixed-length string with 12.34 / _2.34 / -2.34 or -23.45 / 123.45 format
 const char* ftostr42_52(const float &f) {
   if (f <= -10 || f >= 100) return ftostr52(f); // -23.45 / 123.45
-  long i = (f * 1000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 2);
   conv[2] = (f >= 0 && f < 10) ? ' ' : MINUSOR(i, DIGIMOD(i, 1000));
   conv[3] = DIGIMOD(i, 100);
   conv[4] = '.';
@@ -209,7 +211,7 @@ const char* ftostr42_52(const float &f) {
 
 // Convert signed float to fixed-length string with 023.45 / -23.45 format
 const char* ftostr52(const float &f) {
-  long i = (f * 1000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 2);
   conv[1] = MINUSOR(i, DIGIMOD(i, 10000));
   conv[2] = DIGIMOD(i, 1000);
   conv[3] = DIGIMOD(i, 100);
@@ -222,7 +224,7 @@ const char* ftostr52(const float &f) {
 // Convert signed float to fixed-length string with 12.345 / _2.345 / -2.345 or -23.45 / 123.45 format
 const char* ftostr53_63(const float &f) {
   if (f <= -10 || f >= 100) return ftostr63(f); // -23.456 / 123.456
-  long i = (f * 10000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 3);
   conv[1] = (f >= 0 && f < 10) ? ' ' : MINUSOR(i, DIGIMOD(i, 10000));
   conv[2] = DIGIMOD(i, 1000);
   conv[3] = '.';
@@ -234,7 +236,7 @@ const char* ftostr53_63(const float &f) {
 
 // Convert signed float to fixed-length string with 023.456 / -23.456 format
 const char* ftostr63(const float &f) {
-  long i = (f * 10000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 3);
   conv[0] = MINUSOR(i, DIGIMOD(i, 100000));
   conv[1] = DIGIMOD(i, 10000);
   conv[2] = DIGIMOD(i, 1000);
@@ -249,7 +251,7 @@ const char* ftostr63(const float &f) {
 
   // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
   const char* ftostr4sign(const float &f) {
-    const int i = (f * 100 + (f < 0 ? -5: 5)) / 10;
+    const int i = INTFLOAT(f, 1);
     if (!WITHIN(i, -99, 999)) return i16tostr4signrj((int)f);
     const bool neg = i < 0;
     const int ii = neg ? -i : i;
@@ -262,9 +264,20 @@ const char* ftostr63(const float &f) {
 
 #endif
 
+// Convert float to fixed-length string with +12.3 / -12.3 format
+const char* ftostr31sign(const float &f) {
+  int i = INTFLOAT(f, 1);
+  conv[2] = MINUSOR(i, '+');
+  conv[3] = DIGIMOD(i, 100);
+  conv[4] = DIGIMOD(i, 10);
+  conv[5] = '.';
+  conv[6] = DIGIMOD(i, 1);
+  return &conv[2];
+}
+
 // Convert float to fixed-length string with +123.4 / -123.4 format
 const char* ftostr41sign(const float &f) {
-  int i = (f * 100 + (f < 0 ? -5: 5)) / 10;
+  int i = INTFLOAT(f, 1);
   conv[1] = MINUSOR(i, '+');
   conv[2] = DIGIMOD(i, 1000);
   conv[3] = DIGIMOD(i, 100);
@@ -276,7 +289,7 @@ const char* ftostr41sign(const float &f) {
 
 // Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
 const char* ftostr43sign(const float &f, char plus/*=' '*/) {
-  long i = (f * 10000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 3);
   conv[1] = i ? MINUSOR(i, plus) : ' ';
   conv[2] = DIGIMOD(i, 1000);
   conv[3] = '.';
@@ -288,7 +301,7 @@ const char* ftostr43sign(const float &f, char plus/*=' '*/) {
 
 // Convert signed float to string (5 digit) with -1.2345 / _0.0000 / +1.2345 format
 const char* ftostr54sign(const float &f, char plus/*=' '*/) {
-  long i = (f * 100000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 4);
   conv[0] = i ? MINUSOR(i, plus) : ' ';
   conv[1] = DIGIMOD(i, 10000);
   conv[2] = '.';
@@ -301,13 +314,13 @@ const char* ftostr54sign(const float &f, char plus/*=' '*/) {
 
 // Convert unsigned float to rj string with 12345 format
 const char* ftostr5rj(const float &f) {
-  const long i = ((f < 0 ? -f : f) * 10 + 5) / 10;
+  const long i = UINTFLOAT(f, 0);
   return ui16tostr5rj(i);
 }
 
 // Convert signed float to string with +1234.5 format
 const char* ftostr51sign(const float &f) {
-  long i = (f * 100 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 1);
   conv[0] = MINUSOR(i, '+');
   conv[1] = DIGIMOD(i, 10000);
   conv[2] = DIGIMOD(i, 1000);
@@ -320,7 +333,7 @@ const char* ftostr51sign(const float &f) {
 
 // Convert signed float to string with +123.45 format
 const char* ftostr52sign(const float &f) {
-  long i = (f * 1000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 2);
   conv[0] = MINUSOR(i, '+');
   conv[1] = DIGIMOD(i, 10000);
   conv[2] = DIGIMOD(i, 1000);
@@ -333,7 +346,7 @@ const char* ftostr52sign(const float &f) {
 
 // Convert signed float to string with +12.345 format
 const char* ftostr53sign(const float &f) {
-  long i = (f * 10000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 3);
   conv[0] = MINUSOR(i, '+');
   conv[1] = DIGIMOD(i, 10000);
   conv[2] = DIGIMOD(i, 1000);
@@ -346,7 +359,7 @@ const char* ftostr53sign(const float &f) {
 
 // Convert unsigned float to string with ____4.5, __34.5, _234.5, 1234.5 format
 const char* ftostr51rj(const float &f) {
-  const long i = ((f < 0 ? -f : f) * 100 + 5) / 10;
+  const long i = UINTFLOAT(f, 1);
   conv[0] = ' ';
   conv[1] = RJDIGIT(i, 10000);
   conv[2] = RJDIGIT(i, 1000);
@@ -359,7 +372,7 @@ const char* ftostr51rj(const float &f) {
 
 // Convert signed float to space-padded string with -_23.4_ format
 const char* ftostr52sp(const float &f) {
-  long i = (f * 1000 + (f < 0 ? -5: 5)) / 10;
+  long i = INTFLOAT(f, 2);
   uint8_t dig;
   conv[0] = MINUSOR(i, ' ');
   conv[1] = RJDIGIT(i, 10000);

--- a/Marlin/src/libs/numtostr.h
+++ b/Marlin/src/libs/numtostr.h
@@ -76,6 +76,9 @@ const char* ftostr53_63(const float &x);
 // Convert signed float to fixed-length string with 023.456 / -23.456 format
 const char* ftostr63(const float &x);
 
+// Convert float to fixed-length string with +12.3 / -12.3 format
+const char* ftostr31sign(const float &x);
+
 // Convert float to fixed-length string with +123.4 / -123.4 format
 const char* ftostr41sign(const float &x);
 

--- a/Marlin/src/module/configuration_store.cpp
+++ b/Marlin/src/module/configuration_store.cpp
@@ -148,7 +148,7 @@ typedef struct {  int16_t X, Y, Z, X2, Y2, Z2, Z3, Z4;                          
 typedef struct {     bool X, Y, Z, X2, Y2, Z2, Z3, Z4, E0, E1, E2, E3, E4, E5, E6, E7; } tmc_stealth_enabled_t;
 
 // Limit an index to an array size
-#define ALIM(I,ARR) _MIN(I, COUNT(ARR) - 1)
+#define ALIM(I,ARR) _MIN(I, signed(COUNT(ARR) - 1))
 
 // Defaults for reset / fill in on load
 static const uint32_t   _DMA[] PROGMEM = DEFAULT_MAX_ACCELERATION;


### PR DESCRIPTION
This PR fixes the following LCD menu issues:
- Edited values one space too far to the left.
- Z Move with 0.025 increment missing upper 2 digits. (#17515)
- String-substituting menu items drawn with incorrect alignment. (#17514)
- "Bed" and "Chamber" substitution buffer overrun.
- Add `float31sign` and use for Probe XY Offset editing.
- No "Jerk" submenu if only JD is enabled with no Jerk axes.
- Add a heading to the Edit Material Preset submenu.