### PR TITLE
More Hotend Idle Timeout fixes

### DIFF
--- a/Marlin/src/feature/hotend_idle.cpp
+++ b/Marlin/src/feature/hotend_idle.cpp
@@ -43,7 +43,7 @@ millis_t HotendIdleProtection::next_protect_ms = 0;
 void HotendIdleProtection::check_hotends(const millis_t &ms) {
   bool do_prot = false;
   HOTEND_LOOP() {
-    if (thermalManager.degHotendNear(e, HOTEND_IDLE_MIN_TRIGGER)) {
+    if (thermalManager.degHotend(active_extruder) >= HOTEND_IDLE_MIN_TRIGGER) {
       do_prot = true; break;
     }
   }


### PR DESCRIPTION
### Requirements

`HOTEND_IDLE_TIMEOUT`

### Description

Prior to this PR, Hotend Idle Timeout would only kick in if extruder temp was near `HOTEND_IDLE_MIN_TRIGGER` (within a few degrees) and not above that temperature range.

### Benefits

Hotend Idle Timeout will kick in at or above `HOTEND_IDLE_MIN_TRIGGER`.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/18650