### PR TITLE
Sort out SKR 1.4 controller options

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -261,6 +261,10 @@
     #define LCD_PINS_ENABLE         EXPA1_03_PIN
     #define LCD_PINS_D4             EXPA1_05_PIN
 
+  #elif HAS_ADC_BUTTONS
+
+    #error "ADC BUTTONS do not work unmodifed on SKR 1.3, The ADC ports cannot take more than 3.3v."
+
   #else                                           // !CR10_STOCKDISPLAY
 
     #define LCD_PINS_RS             EXPA1_07_PIN

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -316,6 +316,10 @@
 
     #error "ADC BUTTONS do not work unmodifed on SKR 1.4, The ADC ports cannot take more than 3.3v."
 
+  #elif HAS_CHARACTER_LCD
+
+    #error "Character LCD not yet supported for SKR 1.4."
+
   #endif
 
 #endif // HAS_SPI_LCD

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -312,11 +312,7 @@
 
     #endif // !FYSETC_MINI_12864
 
-  #elif HAS_CHARACTER_LCD
-
-    #error "Character LCD not yet supported for SKR 1.4."
-
-  #endif
+  #endif // HAS_GRAPHICAL_LCD
 
 #endif // HAS_SPI_LCD
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -312,10 +312,6 @@
 
     #endif // !FYSETC_MINI_12864
 
-  #elif HAS_ADC_BUTTONS
-
-    #error "ADC BUTTONS do not work unmodifed on SKR 1.4, The ADC ports cannot take more than 3.3v."
-
   #elif HAS_CHARACTER_LCD
 
     #error "Character LCD not yet supported for SKR 1.4."
@@ -323,6 +319,10 @@
   #endif
 
 #endif // HAS_SPI_LCD
+
+#if HAS_ADC_BUTTONS
+  #error "ADC BUTTONS do not work unmodifed on SKR 1.4, The ADC ports cannot take more than 3.3v."
+#endif
 
 //
 // Neopixel LED

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -312,9 +312,9 @@
 
     #endif // !FYSETC_MINI_12864
 
-  #elif HAS_CHARACTER_LCD
+  #elif ENABLED(ADC_KEYPAD)
 
-    #error "Character LCD not yet supported for SKR 1.4."
+    #error "ADC KEYPADs do not work unmodifed on SKR 1.4, The ADC ports cannot take more than 3.3v."
 
   #endif
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -312,9 +312,9 @@
 
     #endif // !FYSETC_MINI_12864
 
-  #elif ENABLED(ADC_KEYPAD)
+  #elif HAS_ADC_BUTTONS
 
-    #error "ADC KEYPADs do not work unmodifed on SKR 1.4, The ADC ports cannot take more than 3.3v."
+    #error "ADC BUTTONS do not work unmodifed on SKR 1.4, The ADC ports cannot take more than 3.3v."
 
   #endif
 


### PR DESCRIPTION
### Requirements

SKR 1.4 + lcd with ADC_KEYPAD

### Description

The above combination should be blocked. Not all char based displays 

### Benefits

All non ADC_KEYPAD based displayed are allowed

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/18665