### PR TITLE
[FR] add ability to kill fan pins on M112 

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2838,7 +2838,7 @@
 //#define SPINDLE_FEATURE
 //#define LASER_FEATURE
 #if EITHER(SPINDLE_FEATURE, LASER_FEATURE)
-  #define USING_FAN_PIN                 fasle  // set if your actually using the fan_pin for spindle or laser control 
+  #define USING_FAN_PIN                 false  // set if your actually using the fan_pin for spindle or laser control 
   #define USING_FAN1_PIN                false  // set if your actually using the fan1_pin for spindle or laser control 
   #define SPINDLE_LASER_ACTIVE_HIGH     false  // Set to "true" if the on/off function is active HIGH
   #define SPINDLE_LASER_PWM             true   // Set to "true" if your controller supports setting the speed/power

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2838,6 +2838,8 @@
 //#define SPINDLE_FEATURE
 //#define LASER_FEATURE
 #if EITHER(SPINDLE_FEATURE, LASER_FEATURE)
+  #define USING_FAN_PIN                 fasle  // set if your actually using the fan_pin for spindle or laser control 
+  #define USING_FAN1_PIN                false  // set if your actually using the fan_pin for spindle or laser control 
   #define SPINDLE_LASER_ACTIVE_HIGH     false  // Set to "true" if the on/off function is active HIGH
   #define SPINDLE_LASER_PWM             true   // Set to "true" if your controller supports setting the speed/power
   #define SPINDLE_LASER_PWM_INVERT      false  // Set to "true" if the speed/power goes up when you want it to go slower

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2839,7 +2839,7 @@
 //#define LASER_FEATURE
 #if EITHER(SPINDLE_FEATURE, LASER_FEATURE)
   #define USING_FAN_PIN                 fasle  // set if your actually using the fan_pin for spindle or laser control 
-  #define USING_FAN1_PIN                false  // set if your actually using the fan_pin for spindle or laser control 
+  #define USING_FAN1_PIN                false  // set if your actually using the fan1_pin for spindle or laser control 
   #define SPINDLE_LASER_ACTIVE_HIGH     false  // Set to "true" if the on/off function is active HIGH
   #define SPINDLE_LASER_PWM             true   // Set to "true" if your controller supports setting the speed/power
   #define SPINDLE_LASER_PWM_INVERT      false  // Set to "true" if the speed/power goes up when you want it to go slower

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -767,6 +767,13 @@ void idle(TERN_(ADVANCED_PAUSE_FEATURE, bool no_stepper_sleep/*=false*/)) {
 void kill(PGM_P const lcd_error/*=nullptr*/, PGM_P const lcd_component/*=nullptr*/, const bool steppers_off/*=false*/) {
   thermalManager.disable_all_heaters();
 
+  #if PIN_EXISTS(FAN)
+    TERN_(USING_FAN_PIN, WRITE(FAN_PIN, 0));    // Kill fan_pin if requested.  
+  #endif
+  #if PIN_EXISTS(FAN1)
+    TERN_(USING_FAN1_PIN, WRITE(FAN1_PIN, 0));  // Kill fan1_pin if requested.  
+  #endif
+
   TERN_(HAS_CUTTER, cutter.kill()); // Full cutter shutdown including ISR control
 
   SERIAL_ERROR_MSG(STR_ERR_KILLED);
@@ -797,6 +804,13 @@ void minkill(const bool steppers_off/*=false*/) {
 
   // Reiterate heaters off
   thermalManager.disable_all_heaters();
+
+  #if PIN_EXISTS(FAN)
+    TERN_(USING_FAN_PIN, WRITE(FAN_PIN, 0));    // Reiterate Kill fan_pin if requested.  
+  #endif
+  #if PIN_EXISTS(FAN1)
+    TERN_(USING_FAN1_PIN, WRITE(FAN1_PIN, 0));  // Reiterate Kill fan1_pin if requested.  
+  #endif
 
   TERN_(HAS_CUTTER, cutter.kill());  // Reiterate cutter shutdown
 


### PR DESCRIPTION
### Requirements

#define SPINDLE_FEATURE or LASER_FEATURE
and either  #define USING_FAN_PIN                true   // set if your actually using the fan_pin for spindle or laser control 
or     #define USING_FAN1_PIN               true   // set if your actually using the fan1_pin for spindle or laser control 
or both

### Description

Dispute marlin having spindle and laser control features many laser and spindle users use m106 to control their their devices.
This as we know is fan control. 
The issue is that when M112 is called fan are not normally killed. leaving their lasers or spindles active. 

### Benefits

This gives the user the ability to kill either or both FAN and  FAN1 on m112. 

### Related Issues

Issue https://github.com/MarlinFirmware/Marlin/issues/17850
