### PR TITLE
passive thermal chamber temp fix

### DIFF
--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -100,7 +100,7 @@ const uint8_t adc_pins[] = {
   #if HAS_HEATED_BED
     TEMP_BED_PIN,
   #endif
-  #if HAS_HEATED_CHAMBER
+  #if HAS_TEMP_CHAMBER
     TEMP_CHAMBER_PIN,
   #endif
   #if HAS_TEMP_ADC_1
@@ -154,7 +154,7 @@ enum TempPinIndex : char {
   #if HAS_HEATED_BED
     TEMP_BED,
   #endif
-  #if HAS_HEATED_CHAMBER
+  #if HAS_TEMP_CHAMBER
     TEMP_CHAMBER,
   #endif
   #if HAS_TEMP_ADC_1
@@ -344,7 +344,7 @@ void HAL_adc_start_conversion(const uint8_t adc_pin) {
     #if HAS_HEATED_BED
       case TEMP_BED_PIN: pin_index = TEMP_BED; break;
     #endif
-    #if HAS_HEATED_CHAMBER
+    #if HAS_TEMP_CHAMBER
       case TEMP_CHAMBER_PIN: pin_index = TEMP_CHAMBER; break;
     #endif
     #if HAS_TEMP_ADC_1


### PR DESCRIPTION
In the case of a passive thermal chamber (without a heater), the ADC does not turn on due to a check for the presence of a heater (HAS_HEATED_CHAMBER). HAS_HEATED_CHAMBER requires a control pin HEATER_CHAMBER_PIN, which does not exist.

I changed the check for a temperature sensor HAS_TEMP_CHAMBER and now the temperature of the heat chamber is displayed without a heater. The display works on the LCD screen and in response to the M105 command.