### PR TITLE
Use safe_delay for PSU_POWERUP_DELAY

### DIFF
--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -29,6 +29,7 @@
 #if ENABLED(AUTO_POWER_CONTROL)
 
 #include "power.h"
+#include "../gcode/gcode.h"
 #include "../module/temperature.h"
 #include "../module/stepper/indirection.h"
 #include "../MarlinCore.h"
@@ -105,9 +106,9 @@ void Power::power_on() {
   lastPowerOn = millis();
   if (!powersupply_on) {
     PSU_PIN_ON();
-    delay(PSU_POWERUP_DELAY);
+    gcode.dwell(PSU_POWERUP_DELAY);
     restore_stepper_drivers();
-    TERN_(HAS_TRINAMIC_CONFIG, delay(PSU_POWERUP_DELAY));
+    TERN_(HAS_TRINAMIC_CONFIG, gcode.dwell(PSU_POWERUP_DELAY));
   }
 }
 

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -29,7 +29,6 @@
 #if ENABLED(AUTO_POWER_CONTROL)
 
 #include "power.h"
-#include "../gcode/gcode.h"
 #include "../module/temperature.h"
 #include "../module/stepper/indirection.h"
 #include "../MarlinCore.h"
@@ -106,9 +105,9 @@ void Power::power_on() {
   lastPowerOn = millis();
   if (!powersupply_on) {
     PSU_PIN_ON();
-    gcode.dwell(PSU_POWERUP_DELAY);
+    safe_delay(PSU_POWERUP_DELAY);
     restore_stepper_drivers();
-    TERN_(HAS_TRINAMIC_CONFIG, gcode.dwell(PSU_POWERUP_DELAY));
+    TERN_(HAS_TRINAMIC_CONFIG, safe_delay(PSU_POWERUP_DELAY));
   }
 }
 

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -72,9 +72,9 @@
     #endif
 
     #if DISABLED(AUTO_POWER_CONTROL)
-      delay(PSU_POWERUP_DELAY);
+      safe_delay(PSU_POWERUP_DELAY);
       restore_stepper_drivers();
-      TERN_(HAS_TRINAMIC_CONFIG, delay(PSU_POWERUP_DELAY));
+      TERN_(HAS_TRINAMIC_CONFIG, safe_delay(PSU_POWERUP_DELAY));
     #endif
 
     TERN_(HAS_LCD_MENU, ui.reset_status());


### PR DESCRIPTION
For long PSU_POWERUP_DELAY (I use 2500 ms) Marlin crashes when turning power on (at least on LPC1768 with TMC drivers).
I suspect because the inactivity is not managed and triggers some watchdog.

Using dwell instead seems to fix the problem.