### PR TITLE
Z2 stepper config for Chitu V6 Board

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -73,6 +73,10 @@
 #define Z_STEP_PIN                          PB9
 #define Z_DIR_PIN                           PE0
 
+#define Z2_ENABLE_PIN                       PF3
+#define Z2_STEP_PIN                         PF5
+#define Z2_DIR_PIN                          PF1
+
 #define E0_ENABLE_PIN                       PB8
 #define E0_STEP_PIN                         PB4
 #define E0_DIR_PIN                          PB5


### PR DESCRIPTION
### Description

Z2 stepper config for Chitu V6 Board

### Benefits

Tronxy X5SA-500 V6 users with two z steppe will be able to use Marlin.

### Related Issues

