### PR TITLE
User-configurable Temperature Offsets

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -428,6 +428,20 @@
 #define TEMP_SENSOR_PROBE 0
 #define TEMP_SENSOR_CHAMBER 0
 
+// Temperature offsets enable the user to make the reported room temperature readings match for all sensors
+#define TEMP_SENSOR_0_OFFSET 0
+#define TEMP_SENSOR_1_OFFSET 0
+#define TEMP_SENSOR_2_OFFSET 0
+#define TEMP_SENSOR_3_OFFSET 0
+#define TEMP_SENSOR_4_OFFSET 0
+#define TEMP_SENSOR_5_OFFSET 0
+#define TEMP_SENSOR_6_OFFSET 0
+#define TEMP_SENSOR_7_OFFSET 0
+#define TEMP_SENSOR_BED_OFFSET 0
+#define TEMP_SENSOR_PROBE_OFFSET 0
+#define TEMP_SENSOR_CHAMBER_OFFSET 0
+
+
 // Dummy thermistor constant temperature readings, for use with 998 and 999
 #define DUMMY_THERMISTOR_998_VALUE 25
 #define DUMMY_THERMISTOR_999_VALUE 100

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -428,7 +428,7 @@
 #define TEMP_SENSOR_PROBE 0
 #define TEMP_SENSOR_CHAMBER 0
 
-// Temperature offsets enable the user to make the reported room temperature readings match for all sensors
+// Adjust these until the reported room temperature readings match for all sensors
 #define TEMP_SENSOR_0_OFFSET 0
 #define TEMP_SENSOR_1_OFFSET 0
 #define TEMP_SENSOR_2_OFFSET 0
@@ -440,7 +440,6 @@
 #define TEMP_SENSOR_BED_OFFSET 0
 #define TEMP_SENSOR_PROBE_OFFSET 0
 #define TEMP_SENSOR_CHAMBER_OFFSET 0
-
 
 // Dummy thermistor constant temperature readings, for use with 998 and 999
 #define DUMMY_THERMISTOR_998_VALUE 25

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1744,71 +1744,70 @@
   #endif
 #endif
 
+// Temperature Sensors
+#if TEMP_SENSOR_0 && !defined(TEMP_SENSOR_0_OFFSET)
+  #define TEMP_SENSOR_0_OFFSET 0
+#endif
+#if TEMP_SENSOR_1 && !defined(TEMP_SENSOR_1_OFFSET)
+  #define TEMP_SENSOR_1_OFFSET 0
+#endif
+#if TEMP_SENSOR_2 && !defined(TEMP_SENSOR_2_OFFSET)
+  #define TEMP_SENSOR_2_OFFSET 0
+#endif
+#if TEMP_SENSOR_3 && !defined(TEMP_SENSOR_3_OFFSET)
+  #define TEMP_SENSOR_3_OFFSET 0
+#endif
+#if TEMP_SENSOR_4 && !defined(TEMP_SENSOR_4_OFFSET)
+  #define TEMP_SENSOR_4_OFFSET 0
+#endif
+#if TEMP_SENSOR_5 && !defined(TEMP_SENSOR_5_OFFSET)
+  #define TEMP_SENSOR_5_OFFSET 0
+#endif
+#if TEMP_SENSOR_6 && !defined(TEMP_SENSOR_6_OFFSET)
+  #define TEMP_SENSOR_6_OFFSET 0
+#endif
+#if TEMP_SENSOR_7 && !defined(TEMP_SENSOR_7_OFFSET)
+  #define TEMP_SENSOR_7_OFFSET 0
+#endif
+
 // Heaters
 #if PIN_EXISTS(HEATER_0)
   #define HAS_HEATER_0 1
-  #ifndef TEMP_SENSOR_0_OFFSET
-    #define TEMP_SENSOR_0_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_1)
   #define HAS_HEATER_1 1
-  #ifndef TEMP_SENSOR_1_OFFSET
-    #define TEMP_SENSOR_1_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_2)
   #define HAS_HEATER_2 1
-  #ifndef TEMP_SENSOR_2_OFFSET
-    #define TEMP_SENSOR_2_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_3)
   #define HAS_HEATER_3 1
-  #ifndef TEMP_SENSOR_3_OFFSET
-    #define TEMP_SENSOR_3_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_4)
   #define HAS_HEATER_4 1
-  #ifndef TEMP_SENSOR_4_OFFSET
-    #define TEMP_SENSOR_4_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_5)
   #define HAS_HEATER_5 1
-  #ifndef TEMP_SENSOR_5_OFFSET
-    #define TEMP_SENSOR_5_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_6)
   #define HAS_HEATER_6 1
-  #ifndef TEMP_SENSOR_6_OFFSET
-    #define TEMP_SENSOR_6_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_7)
   #define HAS_HEATER_7 1
-  #ifndef TEMP_SENSOR_7_OFFSET
-    #define TEMP_SENSOR_7_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_BED)
   #define HAS_HEATER_BED 1
-  #ifndef TEMP_SENSOR_BED_OFFSET
-    #define TEMP_SENSOR_BED_OFFSET 0
-  #endif
 #endif
 #if PIN_EXISTS(HEATER_CHAMBER)
   #define HAS_HEATER_CHAMBER 1
-  #ifndef TEMP_SENSOR_CHAMBER_OFFSET
-    #define TEMP_SENSOR_CHAMBER_OFFSET 0
-  #endif
 #endif
 
 // Shorthand for common combinations
 #if HAS_TEMP_BED && HAS_HEATER_BED
   #define HAS_HEATED_BED 1
+  #ifndef TEMP_SENSOR_BED_OFFSET
+    #define TEMP_SENSOR_BED_OFFSET 0
+  #endif
   #ifndef BED_OVERSHOOT
     #define BED_OVERSHOOT 10
   #endif
@@ -1822,6 +1821,9 @@
 #endif
 #if HAS_TEMP_CHAMBER && PIN_EXISTS(HEATER_CHAMBER)
   #define HAS_HEATED_CHAMBER 1
+  #ifndef TEMP_SENSOR_CHAMBER_OFFSET
+    #define TEMP_SENSOR_CHAMBER_OFFSET 0
+  #endif
 #endif
 
 // PID heating

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1747,30 +1747,63 @@
 // Heaters
 #if PIN_EXISTS(HEATER_0)
   #define HAS_HEATER_0 1
+  #ifndef TEMP_SENSOR_0_OFFSET
+    #define TEMP_SENSOR_0_OFFSET 0
+  #endif
 #endif
 #if PIN_EXISTS(HEATER_1)
   #define HAS_HEATER_1 1
+  #ifndef TEMP_SENSOR_1_OFFSET
+    #define TEMP_SENSOR_1_OFFSET 0
+  #endif
 #endif
 #if PIN_EXISTS(HEATER_2)
   #define HAS_HEATER_2 1
+  #ifndef TEMP_SENSOR_2_OFFSET
+    #define TEMP_SENSOR_2_OFFSET 0
+  #endif
 #endif
 #if PIN_EXISTS(HEATER_3)
   #define HAS_HEATER_3 1
+  #ifndef TEMP_SENSOR_3_OFFSET
+    #define TEMP_SENSOR_3_OFFSET 0
+  #endif
 #endif
 #if PIN_EXISTS(HEATER_4)
   #define HAS_HEATER_4 1
+  #ifndef TEMP_SENSOR_4_OFFSET
+    #define TEMP_SENSOR_4_OFFSET 0
+  #endif
 #endif
 #if PIN_EXISTS(HEATER_5)
   #define HAS_HEATER_5 1
+  #ifndef TEMP_SENSOR_5_OFFSET
+    #define TEMP_SENSOR_5_OFFSET 0
+  #endif
 #endif
 #if PIN_EXISTS(HEATER_6)
   #define HAS_HEATER_6 1
+  #ifndef TEMP_SENSOR_6_OFFSET
+    #define TEMP_SENSOR_6_OFFSET 0
+  #endif
 #endif
 #if PIN_EXISTS(HEATER_7)
   #define HAS_HEATER_7 1
+  #ifndef TEMP_SENSOR_7_OFFSET
+    #define TEMP_SENSOR_7_OFFSET 0
+  #endif
 #endif
 #if PIN_EXISTS(HEATER_BED)
   #define HAS_HEATER_BED 1
+  #ifndef TEMP_SENSOR_BED_OFFSET
+    #define TEMP_SENSOR_BED_OFFSET 0
+  #endif
+#endif
+#if PIN_EXISTS(HEATER_CHAMBER)
+  #define HAS_HEATER_CHAMBER 1
+  #ifndef TEMP_SENSOR_CHAMBER_OFFSET
+    #define TEMP_SENSOR_CHAMBER_OFFSET 0
+  #endif
 #endif
 
 // Shorthand for common combinations

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1536,6 +1536,9 @@ void Temperature::manage_heater() {
  * as it would block the stepper routine.
  */
 void Temperature::updateTemperaturesFromRawValues() {
+  float temperature_offset[] = {TEMP_SENSOR_0_OFFSET, TEMP_SENSOR_1_OFFSET, TEMP_SENSOR_2_OFFSET,
+                                TEMP_SENSOR_3_OFFSET, TEMP_SENSOR_4_OFFSET, TEMP_SENSOR_5_OFFSET,
+                                TEMP_SENSOR_6_OFFSET, TEMP_SENSOR_7_OFFSET};
   #if ENABLED(HEATER_0_USES_MAX6675)
     temp_hotend[0].raw = READ_MAX6675(0);
   #endif
@@ -1543,13 +1546,13 @@ void Temperature::updateTemperaturesFromRawValues() {
     temp_hotend[1].raw = READ_MAX6675(1);
   #endif
   #if HAS_HOTEND
-    HOTEND_LOOP() temp_hotend[e].celsius = analog_to_celsius_hotend(temp_hotend[e].raw, e);
+    HOTEND_LOOP() temp_hotend[e].celsius = analog_to_celsius_hotend(temp_hotend[e].raw, e) + temperature_offset[e];
   #endif
 
-  TERN_(HAS_HEATED_BED, temp_bed.celsius = analog_to_celsius_bed(temp_bed.raw));
-  TERN_(HAS_TEMP_CHAMBER, temp_chamber.celsius = analog_to_celsius_chamber(temp_chamber.raw));
-  TERN_(HAS_TEMP_PROBE, temp_probe.celsius = analog_to_celsius_probe(temp_probe.raw));
-  TERN_(TEMP_SENSOR_1_AS_REDUNDANT, redundant_temperature = analog_to_celsius_hotend(redundant_temperature_raw, 1));
+  TERN_(HAS_HEATED_BED, temp_bed.celsius = analog_to_celsius_bed(temp_bed.raw) + TEMP_SENSOR_BED_OFFSET);
+  TERN_(HAS_TEMP_CHAMBER, temp_chamber.celsius = analog_to_celsius_chamber(temp_chamber.raw) + TEMP_SENSOR_CHAMBER_OFFSET);
+  TERN_(HAS_TEMP_PROBE, temp_probe.celsius = analog_to_celsius_probe(temp_probe.raw) + TEMP_SENSOR_PROBE_OFFSET);
+  TERN_(TEMP_SENSOR_1_AS_REDUNDANT, redundant_temperature = analog_to_celsius_hotend(redundant_temperature_raw, 1) + TEMP_SENSOR_1_OFFSET);
   TERN_(FILAMENT_WIDTH_SENSOR, filwidth.update_measured_mm());
   TERN_(HAS_POWER_MONITOR, power_monitor.capture_values());
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1543,7 +1543,7 @@ void Temperature::updateTemperaturesFromRawValues() {
     temp_hotend[1].raw = READ_MAX6675(1);
   #endif
   #if HAS_HOTEND
-    const uint8_t temperature_offset[] = ARRAY_BY_HOTENDS(
+    const int8_t temperature_offset[] = ARRAY_BY_HOTENDS(
       TEMP_SENSOR_0_OFFSET, TEMP_SENSOR_1_OFFSET, TEMP_SENSOR_2_OFFSET, TEMP_SENSOR_3_OFFSET,
       TEMP_SENSOR_4_OFFSET, TEMP_SENSOR_5_OFFSET, TEMP_SENSOR_6_OFFSET, TEMP_SENSOR_7_OFFSET
     );

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1536,9 +1536,6 @@ void Temperature::manage_heater() {
  * as it would block the stepper routine.
  */
 void Temperature::updateTemperaturesFromRawValues() {
-  float temperature_offset[] = {TEMP_SENSOR_0_OFFSET, TEMP_SENSOR_1_OFFSET, TEMP_SENSOR_2_OFFSET,
-                                TEMP_SENSOR_3_OFFSET, TEMP_SENSOR_4_OFFSET, TEMP_SENSOR_5_OFFSET,
-                                TEMP_SENSOR_6_OFFSET, TEMP_SENSOR_7_OFFSET};
   #if ENABLED(HEATER_0_USES_MAX6675)
     temp_hotend[0].raw = READ_MAX6675(0);
   #endif
@@ -1546,6 +1543,10 @@ void Temperature::updateTemperaturesFromRawValues() {
     temp_hotend[1].raw = READ_MAX6675(1);
   #endif
   #if HAS_HOTEND
+    const uint8_t temperature_offset[] = ARRAY_BY_HOTENDS(
+      TEMP_SENSOR_0_OFFSET, TEMP_SENSOR_1_OFFSET, TEMP_SENSOR_2_OFFSET, TEMP_SENSOR_3_OFFSET,
+      TEMP_SENSOR_4_OFFSET, TEMP_SENSOR_5_OFFSET, TEMP_SENSOR_6_OFFSET, TEMP_SENSOR_7_OFFSET
+    );
     HOTEND_LOOP() temp_hotend[e].celsius = analog_to_celsius_hotend(temp_hotend[e].raw, e) + temperature_offset[e];
   #endif
 


### PR DESCRIPTION
This is in response to Feature Request #16561

This PR add the option for the user to configure offsets for each of the temperature sensors.  This allows the user to make the sensors display properly at room temperature and/or make all the sensors display the same at room temperature.

---

**CHANGES:**


**Configuration.h** - add temperature offset defines


**temperature.cpp**:
 - **Temperature::updateTemperaturesFromRawValues()** - add array for the heater temperature offsets
 - **Temperature::updateTemperaturesFromRawValues()** - add in the offset every time **analog_to_celsius_XXX** is called

---

The offsets for the following have been tested:
- TEMP_SENSOR_0_OFFSET
- TEMP_SENSOR_1_OFFSET
- TEMP_SENSOR_BED_OFFSET
- TEMP_SENSOR_PROBE_OFFSET
- TEMP_SENSOR_CHAMBER_OFFSET
- TEMP_SENSOR_1_AS_REDUNDANT

~The offset for TEMP_SENSOR_1_AS_REDUNDANT has not been tested.~