### PR TITLE
Make WriteVariable respecting Endian

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus/DGUSDisplay.cpp
@@ -1180,6 +1180,10 @@ void DGUSDisplay::WriteVariable(uint16_t adr, const void* values, uint8_t values
   }
 }
 
+void DGUSDisplay::WriteVariable(uint16_t adr, uint16_t value) {
+  WriteVariable(adr, static_cast<const void*>(&value), sizeof(uint16_t));
+}
+
 void DGUSDisplay::WriteVariablePGM(uint16_t adr, const void* values, uint8_t valueslen, bool isstr) {
   const char* myvalues = static_cast<const char*>(values);
   bool strend = !myvalues;

--- a/Marlin/src/lcd/extui/lib/dgus/DGUSDisplay.h
+++ b/Marlin/src/lcd/extui/lib/dgus/DGUSDisplay.h
@@ -54,10 +54,7 @@ public:
   // Variable access.
   static void WriteVariable(uint16_t adr, const void* values, uint8_t valueslen, bool isstr=false);
   static void WriteVariablePGM(uint16_t adr, const void* values, uint8_t valueslen, bool isstr=false);
-  template<typename T>
-  static void WriteVariable(uint16_t adr, T value) {
-    WriteVariable(adr, static_cast<const void*>(&value), sizeof(T));
-  }
+  static void WriteVariable(uint16_t adr, uint16_t value);
 
   // Until now I did not need to actively read from the display. That's why there is no ReadVariable
   // (I extensively use the auto upload of the display)


### PR DESCRIPTION
### Description

Convert WriteVariable from a template function to a normal function.

### Benefits

For different input value type, WriteVariable must use different endian.
For example, uint16 must swap before sending.
Converting it normal function to allow customization for each type.