### PR TITLE
Reliable encoder wheel action when reversing direction

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -905,15 +905,18 @@ void MarlinUI::update() {
         // Also check if passed half the threshold. This will compensate for missed single steps.
         static int8_t lastEncoderDiff;
         // When not past threshold, and reversing... or past half the threshold
-        if (encoderDiff != 0 && abs_diff < (ENCODER_PULSES_PER_STEP)) {
-          if ((encoderDiff > 0 && lastEncoderDiff < 0) ||
-              (encoderDiff < 0 && lastEncoderDiff > 0) ||
-              (abs_diff > (ENCODER_PULSES_PER_STEP) / 2)) {
+        if ((encoderDiff != 0 && abs_diff < (ENCODER_PULSES_PER_STEP)) && // Not past threshold
+            (
+              abs_diff > (ENCODER_PULSES_PER_STEP) / 2 || // Passed half the threshold
+              (ABS(encoderDiff - lastEncoderDiff) >= (ENCODER_PULSES_PER_STEP) && ABS(lastEncoderDiff) < (ENCODER_PULSES_PER_STEP)) // Or direction change through zero
+            )) {
+            lastEncoderDiff = encoderDiff; // Store before updating encoderDiff, we want actual steps
             encoderDiff = (encoderDiff < 0 ? -1 : 1) * (ENCODER_PULSES_PER_STEP); // Treat as full step
             abs_diff = ENCODER_PULSES_PER_STEP;
-          }
         }
-        lastEncoderDiff = encoderDiff;
+        else {
+          lastEncoderDiff = encoderDiff;
+        }
       #endif
 
       const bool encoderPastThreshold = (abs_diff >= (ENCODER_PULSES_PER_STEP));

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -896,6 +896,23 @@ void MarlinUI::update() {
       if (TERN0(REPRAPWORLD_KEYPAD, handle_keypad()))
         RESET_STATUS_TIMEOUT();
 
+      #if ENCODER_PULSES_PER_STEP > 1
+        // When reversing the encoder direction, a movement step can be missed.
+        // This happens when ABS(encoderDiff) has a non-zero residual value.
+        // A user will perceive this as unreliable: a step without any update.
+        // The fix will treat this condition as a full step.
+        static int8_t lastEncoderDiff;
+        if (ABS(encoderDiff) < ENCODER_PULSES_PER_STEP) {     // Only when not past threshold
+          if (encoderDiff > 0 && lastEncoderDiff < 0) {       // Reversing to positive
+            encoderDiff = ENCODER_PULSES_PER_STEP;            // Treat as full postive step
+          }
+          else if (encoderDiff < 0 && lastEncoderDiff > 0) {  // Reversing to negative
+            encoderDiff = -ENCODER_PULSES_PER_STEP;           // Treat as full negative step
+          }
+        }
+        lastEncoderDiff = encoderDiff;
+      #endif
+
       const float abs_diff = ABS(encoderDiff);
       const bool encoderPastThreshold = (abs_diff >= (ENCODER_PULSES_PER_STEP));
       if (encoderPastThreshold || lcd_clicked) {

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -903,7 +903,7 @@ void MarlinUI::update() {
         // The fix will treat this condition as a full step.
         static int8_t lastEncoderDiff;
         if (ABS(encoderDiff) < (ENCODER_PULSES_PER_STEP)) {     // Only when not past threshold
-          if ((encoderDiff > 0) != (lastEncoderDiff < 0))       // Reversing
+          if ((encoderDiff > 0) != (lastEncoderDiff > 0))       // Reversing
             encoderDiff = (encoderDiff < 0 ? -1 : 1) * (ENCODER_PULSES_PER_STEP); // Treat as full step
         }
         lastEncoderDiff = encoderDiff;

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -915,8 +915,8 @@ void MarlinUI::update() {
                )
              )
         ) {
-          encoderDiff = (encoderDiff < 0 ? -1 : 1) * (ENCODER_PULSES_PER_STEP); // Treat as full step
           abs_diff = ENCODER_PULSES_PER_STEP;
+          encoderDiff = (encoderDiff < 0 ? -1 : 1) * abs_diff;  // Treat as full step
         }
       #endif
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -955,7 +955,7 @@ void MarlinUI::update() {
           #endif // ENCODER_RATE_MULTIPLIER
 
           encoderPosition += (encoderDiff * encoderMultiplier) / (ENCODER_PULSES_PER_STEP);
-          encoderDiff = 0;  // Move this and clear always?
+          encoderDiff = 0;
         }
 
         RESET_STATUS_TIMEOUT();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -911,7 +911,7 @@ void MarlinUI::update() {
         if (WITHIN(abs_diff, 1, (ENCODER_PULSES_PER_STEP) - 1)  // Not past threshold
           && (abs_diff > (ENCODER_PULSES_PER_STEP) / 2          // Passed half the threshold?
             || (ABS(encoderDiff - prevDiff) >= (ENCODER_PULSES_PER_STEP)  // Or a large change...
-                && ABS(prevDiff) < (ENCODER_PULSES_PER_STEP)    // ...starting from a partial step?
+                && ABS(prevDiff) < (ENCODER_PULSES_PER_STEP)    // ...starting from a partial or no step?
                )
              )
         ) {

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -902,13 +902,9 @@ void MarlinUI::update() {
         // A user will perceive this as unreliable: a step without any update.
         // The fix will treat this condition as a full step.
         static int8_t lastEncoderDiff;
-        if (ABS(encoderDiff) < ENCODER_PULSES_PER_STEP) {     // Only when not past threshold
-          if (encoderDiff > 0 && lastEncoderDiff < 0) {       // Reversing to positive
-            encoderDiff = ENCODER_PULSES_PER_STEP;            // Treat as full postive step
-          }
-          else if (encoderDiff < 0 && lastEncoderDiff > 0) {  // Reversing to negative
-            encoderDiff = -ENCODER_PULSES_PER_STEP;           // Treat as full negative step
-          }
+        if (ABS(encoderDiff) < (ENCODER_PULSES_PER_STEP)) {     // Only when not past threshold
+          if ((encoderDiff > 0) != (lastEncoderDiff < 0))       // Reversing
+            encoderDiff = (encoderDiff < 0 ? -1 : 1) * (ENCODER_PULSES_PER_STEP); // Treat as full step
         }
         lastEncoderDiff = encoderDiff;
       #endif

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -909,9 +909,9 @@ void MarlinUI::update() {
 
         // When not past threshold, and reversing... or past half the threshold
         if (WITHIN(abs_diff, 1, (ENCODER_PULSES_PER_STEP) - 1)  // Not past threshold
-          && (abs_diff > (ENCODER_PULSES_PER_STEP) / 2          // Passed half the threshold?
-            || (ABS(encoderDiff - prevDiff) >= (ENCODER_PULSES_PER_STEP)  // Or a large change...
-                && ABS(prevDiff) < (ENCODER_PULSES_PER_STEP)    // ...starting from a partial or no step?
+          && (abs_diff > (ENCODER_PULSES_PER_STEP) / 2          // Passed half the threshold? Done! Call it a full step.
+            || (ABS(encoderDiff - prevDiff) >= (ENCODER_PULSES_PER_STEP)  // A big change when abs_diff is small implies reverse
+                && ABS(prevDiff) < (ENCODER_PULSES_PER_STEP)    // ...especially when starting from a partial or no step.
                )
              )
         ) {

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -902,20 +902,21 @@ void MarlinUI::update() {
         // When reversing the encoder direction, a movement step can be missed because
         // encoderDiff has a non-zero residual value, making the controller unresponsive.
         // The fix clears the residual value when the encoder is reversed.
-        // Also check if passed half the threshold. This will compensate for missed single steps.
+        // Also check if past half the threshold to compensate for missed single steps.
         static int8_t lastEncoderDiff;
+        int8_t prevDiff = lastEncoderDiff;
+        lastEncoderDiff = encoderDiff;  // Store before updating encoderDiff to save actual steps
+
         // When not past threshold, and reversing... or past half the threshold
-        if ((encoderDiff != 0 && abs_diff < (ENCODER_PULSES_PER_STEP)) && // Not past threshold
-            (
-              abs_diff > (ENCODER_PULSES_PER_STEP) / 2 || // Passed half the threshold
-              (ABS(encoderDiff - lastEncoderDiff) >= (ENCODER_PULSES_PER_STEP) && ABS(lastEncoderDiff) < (ENCODER_PULSES_PER_STEP)) // Or direction change through zero
-            )) {
-            lastEncoderDiff = encoderDiff; // Store before updating encoderDiff, we want actual steps
-            encoderDiff = (encoderDiff < 0 ? -1 : 1) * (ENCODER_PULSES_PER_STEP); // Treat as full step
-            abs_diff = ENCODER_PULSES_PER_STEP;
-        }
-        else {
-          lastEncoderDiff = encoderDiff;
+        if (WITHIN(abs_diff, 1, (ENCODER_PULSES_PER_STEP) - 1)  // Not past threshold
+          && (abs_diff > (ENCODER_PULSES_PER_STEP) / 2          // Passed half the threshold?
+            || (ABS(encoderDiff - prevDiff) >= (ENCODER_PULSES_PER_STEP)  // Or a large change...
+                && ABS(prevDiff) < (ENCODER_PULSES_PER_STEP)    // ...starting from a partial step?
+               )
+             )
+        ) {
+          encoderDiff = (encoderDiff < 0 ? -1 : 1) * (ENCODER_PULSES_PER_STEP); // Treat as full step
+          abs_diff = ENCODER_PULSES_PER_STEP;
         }
       #endif
 

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -950,7 +950,7 @@ void MarlinUI::update() {
           #endif // ENCODER_RATE_MULTIPLIER
 
           encoderPosition += (encoderDiff * encoderMultiplier) / (ENCODER_PULSES_PER_STEP);
-          encoderDiff = 0;
+          encoderDiff = 0;  // Move this and clear always?
         }
 
         RESET_STATUS_TIMEOUT();

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -903,7 +903,7 @@ void MarlinUI::update() {
         // The fix will treat this condition as a full step.
         static int8_t lastEncoderDiff;
         if (ABS(encoderDiff) < (ENCODER_PULSES_PER_STEP)) {     // Only when not past threshold
-          if ((encoderDiff > 0) != (lastEncoderDiff > 0))       // Reversing
+          if ((encoderDiff > 0) == (lastEncoderDiff < 0))       // Reversing
             encoderDiff = (encoderDiff < 0 ? -1 : 1) * (ENCODER_PULSES_PER_STEP); // Treat as full step
         }
         lastEncoderDiff = encoderDiff;


### PR DESCRIPTION
### Description

This change will fix a reliability issue with the encoder wheel when reversing direction.
After a direction change the first step was randomly ignored.
This was caused by missed encoder inputs. In most situations this is unnoticed. But when reversing direction, this can lead to not registering the first step.

By detecting a direction change under strict conditions, this behavior has been corrected.

This fixes #18693

### Benefits

The user will have reliable encoder wheel action.
My personal reaction was that I thought I had faulty hardware. It turned out to be a software bug.