### PR TITLE
PID Autotune UI Return to Status

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -187,6 +187,7 @@ void menu_cancelobject();
       #endif
     );
     queue.inject(cmd);
+    ui.return_to_status();
   }
 
 #endif // PID_AUTOTUNE_MENU


### PR DESCRIPTION
Merely beeping when something has been initiated is far from ideal.

Even if a beeper is connected, it leaves many users wondering whether
something happened or not.

Particularly combined with c135db1c (#18408) this improves usability
of the PID Autotune significantly.