### PR TITLE
Fix BLTouch PWM reliability in HAL/STM32

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -79,7 +79,7 @@ void HAL_init() {
     while (!LL_PWR_IsActiveFlag_BRR());   // Wait until backup regulator is initialized
   #endif
 
-  SetSoftwareSerialTimerInterruptPriority();
+  SetTimerInterruptPriorities();
 
   TERN_(EMERGENCY_PARSER, USB_Hook_init());
 }

--- a/Marlin/src/HAL/STM32/Servo.h
+++ b/Marlin/src/HAL/STM32/Servo.h
@@ -41,6 +41,7 @@ class libServo {
 
     static void pause_all_servos();
     static void resume_all_servos();
+    static void setInterruptPriority(uint32_t preemptPriority, uint32_t subPriority);
 
   private:
     Servo stm32_servo;

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -29,26 +29,41 @@
 
 #define NUM_HARDWARE_TIMERS 2
 
+// Default timer priorities. Override by specifying alternate priorities in the board pins file.
+// The TONE timer is not present here, as it currently cannot be set programmatically. It is set
+// by defining TIM_IRQ_PRIO in the variant.h or platformio.ini file, which adjusts the default
+// priority for STM32 HardwareTimer objects.
+#define SERVO_TIMER_IRQ_PRIO_DEFAULT     1 // Requires tight bit timing to communicate reliably with TMC drivers
+#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  1 // Requires tight PWM timing to control a BLTouch reliably
+#define STEP_TIMER_IRQ_PRIO_DEFAULT      2
+#define TEMP_TIMER_IRQ_PRIO_DEFAULT     14 // Low priority avoids interference with other hardware and timers
+
 #ifndef STEP_TIMER_IRQ_PRIO
-  #define STEP_TIMER_IRQ_PRIO 2
+  #define STEP_TIMER_IRQ_PRIO STEP_TIMER_IRQ_PRIO_DEFAULT
 #endif
 #ifndef TEMP_TIMER_IRQ_PRIO
-  #define TEMP_TIMER_IRQ_PRIO 14   // 14 = after hardware ISRs
+  #define TEMP_TIMER_IRQ_PRIO TEMP_TIMER_IRQ_PRIO_DEFAULT
 #endif
-
-// Ensure the default timer priority is somewhere between the STEP and TEMP priorities.
-// The STM32 framework defaults to interrupt 14 for all timers. This should be increased so that
-// timing-sensitive operations such as speaker output are note impacted by the long-running
-// temperature ISR. This must be defined in the platformio.ini file or the board's variant.h,
-// so that it will be consumed by framework code.
-#if !(TIM_IRQ_PRIO > STEP_TIMER_IRQ_PRIO && TIM_IRQ_PRIO < TEMP_TIMER_IRQ_PRIO)
-  #error "Default timer interrupt priority is unspecified or set to a value which may degrade performance."
-#endif
-
 #if HAS_TMC_SW_SERIAL
   #include <SoftwareSerial.h>
   #ifndef SWSERIAL_TIMER_IRQ_PRIO
-    #define SWSERIAL_TIMER_IRQ_PRIO 1
+    #define SWSERIAL_TIMER_IRQ_PRIO SWSERIAL_TIMER_IRQ_PRIO_DEFAULT
+  #endif
+#endif
+#if HAS_SERVOS
+  #include "Servo.h"
+  #ifndef SERVO_TIMER_IRQ_PRIO
+    #define SERVO_TIMER_IRQ_PRIO SERVO_TIMER_IRQ_PRIO_DEFAULT
+  #endif
+#endif
+#if ENABLED(SPEAKER)
+  // Ensure the default timer priority is somewhere between the STEP and TEMP priorities.
+  // The STM32 framework defaults to interrupt 14 for all timers. This should be increased so that
+  // timing-sensitive operations such as speaker output are not impacted by the long-running
+  // temperature ISR. This must be defined in the platformio.ini file or the board's variant.h,
+  // so that it will be consumed by framework code.
+  #if !(TIM_IRQ_PRIO > STEP_TIMER_IRQ_PRIO && TIM_IRQ_PRIO < TEMP_TIMER_IRQ_PRIO)
+    #error "Default timer interrupt priority is unspecified or set to a value which may degrade performance."
   #endif
 #endif
 
@@ -189,8 +204,9 @@ TIM_TypeDef * HAL_timer_device(const uint8_t timer_num) {
   return nullptr;
 }
 
-void SetSoftwareSerialTimerInterruptPriority() {
+void SetTimerInterruptPriorities() {
   TERN_(HAS_TMC_SW_SERIAL, SoftwareSerial::setInterruptPriority(SWSERIAL_TIMER_IRQ_PRIO, 0));
+  TERN_(HAS_SERVOS, libServo::setInterruptPriority(SERVO_TIMER_IRQ_PRIO, 0));
 }
 
 #endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -33,8 +33,8 @@
 // The TONE timer is not present here, as it currently cannot be set programmatically. It is set
 // by defining TIM_IRQ_PRIO in the variant.h or platformio.ini file, which adjusts the default
 // priority for STM32 HardwareTimer objects.
-#define SERVO_TIMER_IRQ_PRIO_DEFAULT     1 // Requires tight bit timing to communicate reliably with TMC drivers
-#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  1 // Requires tight PWM timing to control a BLTouch reliably
+#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  1 // Requires tight bit timing to communicate reliably with TMC drivers
+#define SERVO_TIMER_IRQ_PRIO_DEFAULT     1 // Requires tight PWM timing to control a BLTouch reliably
 #define STEP_TIMER_IRQ_PRIO_DEFAULT      2
 #define TEMP_TIMER_IRQ_PRIO_DEFAULT     14 // Low priority avoids interference with other hardware and timers
 

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -86,8 +86,9 @@ void HAL_timer_enable_interrupt(const uint8_t timer_num);
 void HAL_timer_disable_interrupt(const uint8_t timer_num);
 bool HAL_timer_interrupt_enabled(const uint8_t timer_num);
 
+// Configure timer priorities for peripherals such as Software Serial or Servos.
 // Exposed here to allow all timer priority information to reside in timers.cpp
-void SetSoftwareSerialTimerInterruptPriority();
+void SetTimerInterruptPriorities();
 
 //TIM_TypeDef* HAL_timer_device(const uint8_t timer_num); no need to be public for now. not public = not used externally
 


### PR DESCRIPTION
### Description

Increases the interrupt priority of Servo output PWM generation. Without this change I observed massive timing discrepancies in output PWM widths when testing with high CPU load.

To test this, I monitored the PWM output while perform arc movements. The arc movements provided a simple way to generate a gradient of step rates across two axis, ensuring CPU saturation due to `ADAPTIVE_STEP_SMOOTHING` was achieved.

I expected to see an output PWM with a pulse width of ~1473µs, which is the BLTouch "Stow" command. Values from 1453-1493µs should be valid, according to the +/-20µs range specified for a BLTouch.
![image](https://user-images.githubusercontent.com/20053467/87870139-3fa15a00-c95a-11ea-8218-bb834e724dcc.png)

When measuring, I found frequent excursions to +/-50µs, and in some cases saw pulses of only 1000µs! This could clearly explain a variety of unexpected BLTouch behavior.

### Benefits

Prevents sporadic 
Ensures stable PWM output for BLTouch control. While performing the same operations after this change I observe a pulse width which varies only by +/- 3µs.

I also verified with a logic analyzer that I can see the PWM output changing while the STEP ISR is still active, demonstrating that the SERVO timer interrupt is pre-empting the STEP ISR, as is required to accurately time the output.

![image](https://user-images.githubusercontent.com/20053467/87870269-0b7a6900-c95b-11ea-823f-ebfe792027c8.png)

### Related Issues

#18372
