### PR TITLE
Decrease ADAPTIVE_STEP_SMOOTHING target to 50% CPU usage

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2099,11 +2099,11 @@ uint32_t Stepper::block_phase_isr() {
       #if ENABLED(ADAPTIVE_STEP_SMOOTHING)
         uint8_t oversampling = 0;                           // Assume no axis smoothing (via oversampling)
         // Decide if axis smoothing is possible
-        uint32_t max_rate = current_block->nominal_rate;    // Get the maximum rate (maximum event speed)
+        uint32_t max_rate = current_block->nominal_rate;    // Get the step event rate
         while (max_rate < MIN_STEP_ISR_FREQUENCY) {         // As long as more ISRs are possible...
           max_rate <<= 1;                                   // Try to double the rate
-          if (max_rate >= MAX_STEP_ISR_FREQUENCY_1X) break; // Don't exceed the estimated ISR limit
-          ++oversampling;                                   // Increase the oversampling (used for left-shift)
+          if (max_rate < MIN_STEP_ISR_FREQUENCY)            // Don't exceed the estimated ISR limit
+            ++oversampling;                                 // Increase the oversampling (used for left-shift)
         }
         oversampling_factor = oversampling;                 // For all timer interval calculations
       #else

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -229,8 +229,10 @@
 #define MAX_STEP_ISR_FREQUENCY_2X   ((F_CPU) / ISR_EXECUTION_CYCLES(2))
 #define MAX_STEP_ISR_FREQUENCY_1X   ((F_CPU) / ISR_EXECUTION_CYCLES(1))
 
-// The minimum allowable frequency for step smoothing will be 1/10 of the maximum nominal frequency (in Hz)
-#define MIN_STEP_ISR_FREQUENCY MAX_STEP_ISR_FREQUENCY_1X
+// The minimum step ISR rate used by ADAPTIVE_STEP_SMOOTHING to target 50% CPU usage
+// This does not account for the possibility of multi-stepping.
+// Perhaps DISABLE_MULTI_STEPPING should be required with ADAPTIVE_STEP_SMOOTHING.
+#define MIN_STEP_ISR_FREQUENCY (MAX_STEP_ISR_FREQUENCY_1X / 2)
 
 //
 // Stepper class definition


### PR DESCRIPTION
### Description

ADAPTIVE_STEP_SMOOTHING had comments indicating it would use 10% of the CPU, but it was actually targeting 100%. This caused all sorts of timing problems for BLTouch users, and could completely starve out timer ISRs and idle tasks.

This decreases the target to 50%. I have verified on a logic analyzer that STEP ISRs performed during a G28 on my printer have absolutely become more spread out, compared to the earlier code where they were right on top of one another.

This is based on a recommendation from @AnHardt: https://github.com/MarlinFirmware/Marlin/issues/18598#issuecomment-657451656
I will happily drop this PR if they post a more extensive solution. This just seems to be causing enough issues that we need to get _something_ in quickly.

### Benefits

Decreases overall CPU usage, allowing time for other ISRs and idle tasks.

### Related Issues

#18598
