### PR TITLE
Fix build fail on windows

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -93,6 +93,19 @@ def install_features_dependencies():
 			proj.set("env:" + env["PIOENV"], "src_filter", src_filter)
 			env.Replace(SRC_FILTER=src_filter)
 
+# search the current compiler, considering the OS
+def search_compiler():
+	if env['PLATFORM'] == 'win32':
+		# the first path have the compiler
+		compiler_path = env['ENV']['PATH'].split(';')[0]
+		print(compiler_path)
+		for file in os.listdir(compiler_path):
+			if file.endswith("g++.exe"):
+				return file
+	else:
+		return env.get('CXX')
+
+
 # load marlin features
 def load_marlin_features():
 	if "MARLIN_FEATURES" in env:
@@ -113,7 +126,8 @@ def load_marlin_features():
 			cmd += ['-D' + s]
 	# cmd += ['-w -dM -E -x c++ Marlin/src/inc/MarlinConfigPre.h']
 	cmd += ['-w -dM -E -x c++ buildroot/share/PlatformIO/scripts/common-features-dependencies.h']
-	cmd = [env.get('CXX')] + cmd
+	cxx = search_compiler()
+	cmd = [cxx] + cmd
 	cmd = ' '.join(cmd)
 	print(cmd)
 	define_list = subprocess.check_output(cmd, shell=True).splitlines()

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -99,7 +99,7 @@ def search_compiler():
 		# the first path have the compiler
 		compiler_path = None
 		for path in env['ENV']['PATH'].split(';'):
-			if 'platformio\\packages' in path:
+			if re.search(r'platformio\\packages.*\\bin', path):
 				compiler_path = path
 				break
 		if compiler_path == None:

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -97,11 +97,21 @@ def install_features_dependencies():
 def search_compiler():
 	if env['PLATFORM'] == 'win32':
 		# the first path have the compiler
-		compiler_path = env['ENV']['PATH'].split(';')[0]
+		compiler_path = None
+		for path in env['ENV']['PATH'].split(';'):
+			if 'platformio\\packages' in path:
+				compiler_path = path
+				break
+		if compiler_path == None:
+			print("Could not find the g++ path")
+			return None
+		
 		print(compiler_path)
 		for file in os.listdir(compiler_path):
 			if file.endswith("g++.exe"):
 				return file
+		print("Could not find the g++")
+		return None
 	else:
 		return env.get('CXX')
 

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -125,7 +125,10 @@ def load_marlin_features():
 	# print(env.Dump())
 	build_flags = env.get('BUILD_FLAGS')
 	build_flags = env.ParseFlagsExtended(build_flags)
-	cmd = []
+
+	cxx = search_compiler()
+	cmd = [cxx]
+
 	# build flags from board.json
 	# if 'BOARD' in env:
 	# 	cmd += [env.BoardConfig().get("build.extra_flags")]
@@ -136,8 +139,6 @@ def load_marlin_features():
 			cmd += ['-D' + s]
 	# cmd += ['-w -dM -E -x c++ Marlin/src/inc/MarlinConfigPre.h']
 	cmd += ['-w -dM -E -x c++ buildroot/share/PlatformIO/scripts/common-features-dependencies.h']
-	cxx = search_compiler()
-	cmd = [cxx] + cmd
 	cmd = ' '.join(cmd)
 	print(cmd)
 	define_list = subprocess.check_output(cmd, shell=True).splitlines()


### PR DESCRIPTION
### Description

PlatformIO points to a invalid compiler on startup, on Windows. I did a quick fix to find the current g++. We need to work more on that later.

Its a quick fix. We may work more on this windows issue later.

### Related Issues

#18720
#18699