### PR TITLE
Use development version of PlatformIO

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -105,7 +105,7 @@ jobs:
 
     - name: Install PlatformIO
       run: |
-        pip install -U https://github.com/platformio/platformio-core/archive/master.zip
+        pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
         platformio update
 
     - name: Check out the PR


### PR DESCRIPTION
We would be thankful if you use PlatformIO Core Dev for CI builds. Marlin is a very important project for the open-source community. We don't want to break it with new changes. So, please report us if PIO Core fails due to our issue. 

Thanks in advance!

P.S: PIO Core Dev is very stable. We use it for all our projects in CI.