### PR TITLE
Fix build in some windows path edge case

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -97,19 +97,13 @@ def install_features_dependencies():
 def search_compiler():
 	if env['PLATFORM'] == 'win32':
 		# the first path have the compiler
-		compiler_path = None
 		for path in env['ENV']['PATH'].split(';'):
-			if re.search(r'platformio\\packages.*\\bin', path):
-				compiler_path = path
-				break
-		if compiler_path == None:
-			print("Could not find the g++ path")
-			return None
-		
-		print(compiler_path)
-		for file in os.listdir(compiler_path):
-			if file.endswith("g++.exe"):
-				return file
+			if not re.search(r'platformio\\packages.*\\bin', path):
+				continue			
+			#print(path)
+			for file in os.listdir(path):
+				if file.endswith("g++.exe"):
+					return file
 		print("Could not find the g++")
 		return None
 	else:


### PR DESCRIPTION
### Description

Fix a edge case when there're more than one platformio package bin folder in path, and the first isn't the compiler one...

Now it searchs for every platformio bin folders until it find the g++.

The pre script runs before the current platform entry point. So we don’t have all it’s info.
The post script runs after everything, so it’s late to add libs...
We just need a g++ compiler. Anyone will work, because we just use the preprocessor to discover the user configurations. 
In Mac and Linux, we have gcc on path. 
In Windows no. I just know what is in the PATH env var. I don't even know what is the toolchain that will run.

So, the fast and easier solution I found, is try the platformio bin folder in path searching for g++.
But I really didn’t handle the edge cases in the first PR.
But now I think I covered all.

### Related Issues

#18699 