### PR TITLE
Add nozzle wipe sequence commands

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1595,6 +1595,10 @@
 
   // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
+
+  // Explicit wipe Gcode script. Will run by default unless explicitly overridden by patter with R, S or T arguments
+  //#define WIPE_SEQUENCE_COMMANDS "G1 X-17 Y25 Z10 F4000\nG1 Z1\nM114\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 Z15\nM400\nG0 X-10.0 Y-9.0"
+
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1596,7 +1596,7 @@
   // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 
-  // Explicit wipe G-code script. Run by default on a G12 with no arguments.
+  // Explicit wipe G-code script applies to a G12 with no arguments.
   //#define WIPE_SEQUENCE_COMMANDS "G1 X-17 Y25 Z10 F4000\nG1 Z1\nM114\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 Z15\nM400\nG0 X-10.0 Y-9.0"
 
 #endif

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1596,7 +1596,7 @@
   // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 
-  // Explicit wipe Gcode script. Will run by default unless explicitly overridden by patter with R, S or T arguments
+  // Explicit wipe G-code script. Run by default on a G12 with no arguments.
   //#define WIPE_SEQUENCE_COMMANDS "G1 X-17 Y25 Z10 F4000\nG1 Z1\nM114\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 Z15\nM400\nG0 X-10.0 Y-9.0"
 
 #endif

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -47,6 +47,13 @@ void GcodeSuite::G12() {
   // Don't allow nozzle cleaning without homing first
   if (axis_unhomed_error()) return;
 
+  #if defined(WIPE_SEQUENCE_COMMANDS)
+    if(!parser.seen("SRT")) {
+      GcodeSuite::process_subcommands_now_P(PSTR(WIPE_SEQUENCE_COMMANDS));
+      return;
+    }
+  #endif
+
   const uint8_t pattern = parser.ushortval('P', 0),
                 strokes = parser.ushortval('S', NOZZLE_CLEAN_STROKES),
                 objects = parser.ushortval('T', NOZZLE_CLEAN_TRIANGLES);

--- a/Marlin/src/gcode/feature/clean/G12.cpp
+++ b/Marlin/src/gcode/feature/clean/G12.cpp
@@ -47,9 +47,9 @@ void GcodeSuite::G12() {
   // Don't allow nozzle cleaning without homing first
   if (axis_unhomed_error()) return;
 
-  #if defined(WIPE_SEQUENCE_COMMANDS)
-    if(!parser.seen("SRT")) {
-      GcodeSuite::process_subcommands_now_P(PSTR(WIPE_SEQUENCE_COMMANDS));
+  #ifdef WIPE_SEQUENCE_COMMANDS
+    if (!parser.seen_any()) {
+      gcode.process_subcommands_now_P(PSTR(WIPE_SEQUENCE_COMMANDS));
       return;
     }
   #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -290,7 +290,7 @@ build_unflags  = -std=gnu++11
 src_filter     = ${common.default_src_filter} +<src/HAL/SAMD51>
 lib_deps       = ${common.lib_deps}
   SoftwareSerialM
-  Adafruit_SPIFlash=https://github.com/adafruit/Adafruit_SPIFlash/archive/master.zip
+  Adafruit SPIFlash@3.2.1
 debug_tool     = jlink
 
 #################################

--- a/platformio.ini
+++ b/platformio.ini
@@ -290,7 +290,8 @@ build_unflags  = -std=gnu++11
 src_filter     = ${common.default_src_filter} +<src/HAL/SAMD51>
 lib_deps       = ${common.lib_deps}
   SoftwareSerialM
-  Adafruit SPIFlash@3.2.1
+  Adafruit SPIFlash
+  SdFat - Adafruit Fork
 debug_tool     = jlink
 
 #################################


### PR DESCRIPTION
Add option to define an explicit sequence for nozzle wipe. Deviates from original lulzbot implementation by allowing standard wipe patterns to be called if arguments are passed to G12.