### PR TITLE
Reduce waits during filament change

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -119,7 +119,7 @@ fil_change_settings_t fc_settings[EXTRUDERS];
  *
  * Returns 'true' if heating was completed, 'false' for abort
  */
-static bool ensure_safe_temperature(const PauseMode mode=PAUSE_MODE_SAME) {
+static bool ensure_safe_temperature( const bool wait=true, const PauseMode mode=PAUSE_MODE_SAME) {
 
   #if ENABLED(PREVENT_COLD_EXTRUSION)
     if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(active_extruder)) {
@@ -134,7 +134,15 @@ static bool ensure_safe_temperature(const PauseMode mode=PAUSE_MODE_SAME) {
     UNUSED(mode);
   #endif
 
-  return thermalManager.wait_for_hotend(active_extruder);
+  if(wait)
+    return thermalManager.wait_for_hotend(active_extruder);
+  else {
+    do{
+      idle();
+    }while (thermalManager.degHotend(active_extruder) < (thermalManager.degTargetHotend(active_extruder) - TEMP_WINDOW) || thermalManager.degHotend(active_extruder) > (thermalManager.degTargetHotend(active_extruder) + TEMP_WINDOW));
+    return true;
+  }
+
 }
 
 /**
@@ -156,7 +164,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
 ) {
   TERN(HAS_LCD_MENU,,UNUSED(show_lcd));
 
-  if (!ensure_safe_temperature(mode)) {
+  if (!ensure_safe_temperature(false, mode)) {
     #if HAS_LCD_MENU
       if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_STATUS, mode);
     #endif
@@ -291,7 +299,7 @@ bool unload_filament(const float &unload_length, const bool show_lcd/*=false*/,
     constexpr float mix_multiplier = 1.0;
   #endif
 
-  if (!ensure_safe_temperature(mode)) {
+  if (!ensure_safe_temperature(false, mode)) {
     #if HAS_LCD_MENU
       if (show_lcd) lcd_pause_show_message(PAUSE_MESSAGE_STATUS);
     #endif
@@ -498,7 +506,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
       HOTEND_LOOP() thermalManager.reset_hotend_idle_timer(e);
 
       // Wait for the heaters to reach the target temperatures
-      ensure_safe_temperature();
+      ensure_safe_temperature(false);
 
       // Show the prompt to continue
       show_continue_prompt(is_reload);
@@ -586,6 +594,8 @@ void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_le
 
   // Unretract
   unscaled_e_move(PAUSE_PARK_RETRACT_LENGTH, feedRate_t(PAUSE_PARK_RETRACT_FEEDRATE));
+
+  ensure_safe_temperature();
 
   // Intelligent resuming
   #if ENABLED(FWRETRACT)

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -134,15 +134,13 @@ static bool ensure_safe_temperature( const bool wait=true, const PauseMode mode=
     UNUSED(mode);
   #endif
 
-  if(wait)
+  if (wait)
     return thermalManager.wait_for_hotend(active_extruder);
-  else {
-    do{
-      idle();
-    }while (thermalManager.degHotend(active_extruder) < (thermalManager.degTargetHotend(active_extruder) - TEMP_WINDOW) || thermalManager.degHotend(active_extruder) > (thermalManager.degTargetHotend(active_extruder) + TEMP_WINDOW));
-    return true;
-  }
 
+  while (ABS(thermalManager.degHotend(active_extruder) - thermalManager.degTargetHotend(active_extruder)) > TEMP_WINDOW)
+    idle();
+
+  return true;
 }
 
 /**

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -119,7 +119,7 @@ fil_change_settings_t fc_settings[EXTRUDERS];
  *
  * Returns 'true' if heating was completed, 'false' for abort
  */
-static bool ensure_safe_temperature( const bool wait=true, const PauseMode mode=PAUSE_MODE_SAME) {
+static bool ensure_safe_temperature(const bool wait=true, const PauseMode mode=PAUSE_MODE_SAME) {
 
   #if ENABLED(PREVENT_COLD_EXTRUSION)
     if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(active_extruder)) {


### PR DESCRIPTION
Reduce multiple waits for stabilization during filament change. We really only care that its "close enough" for most operations so this drastically reduces user wait time.

I havnt tested this since the rebase to bring it current from when i put this together a couple months ago, but wanted to put it up for review.