### PR TITLE
Do not unnecessarily switch direction when using linear advance

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2277,14 +2277,14 @@ uint32_t Stepper::block_phase_isr() {
     #if ENABLED(MIXING_EXTRUDER)
       // We don't know which steppers will be stepped because LA loop follows,
       // with potentially multiple steps. Set all.
-      if (LA_steps >= 0)
+      if (LA_steps > 0)
         MIXER_STEPPER_LOOP(j) NORM_E_DIR(j);
-      else
+      else if (LA_steps < 0)
         MIXER_STEPPER_LOOP(j) REV_E_DIR(j);
     #else
-      if (LA_steps >= 0)
+      if (LA_steps > 0)
         NORM_E_DIR(stepper_extruder);
-      else
+      else if (LA_steps < 0)
         REV_E_DIR(stepper_extruder);
     #endif
 


### PR DESCRIPTION
### Description

When possible, linear advance retracts by skipping forward steps, rather than adding reverse steps.
When this occurs, the direction line is toggled to the forward direction anyway, even though no step will not be performed.

When debugging stepping operations this makes it very hard to look at line captures to make sense of what is happening.

Here is an example where the direction line is toggled high every time a step is skipped but it always toggled low before an actual step is performed. You ahve to look closely to determine the direction of each step when looking at this capture. It is not obvious at all that they are actually going the same direction.

![image](https://user-images.githubusercontent.com/20053467/88138738-20493d80-cba3-11ea-84bb-7395b2dbad90.png)


### Benefits

Eliminates noise in analyzer captures when debugging, making them easier to understand. There is probably no actual benefit to a typical user.

Here is a zoomed out view of the same move after making this change. Now the direction line is only toggled when the actual direction of movement needs to change. It is very clear in this capture that all steps were in the same direction.
![image](https://user-images.githubusercontent.com/20053467/88139035-c301bc00-cba3-11ea-88dc-936b654f691f.png)

### Related Issues

N/A, although I hope it makes debugging many of them easier.
