### PR TITLE
600W silicone heater thermistor

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -397,6 +397,7 @@
  *    67 : 450C thermistor from SliceEngineering
  *    70 : the 100K thermistor found in the bq Hephestos 2
  *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
+ *    76 : unknown thermistor in 600W silicone pad
  *    99 : 100k thermistor with a 10K pull-up resistor (found on some Wanhao i3 machines)
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -397,7 +397,7 @@
  *    67 : 450C thermistor from SliceEngineering
  *    70 : the 100K thermistor found in the bq Hephestos 2
  *    75 : 100k Generic Silicon Heat Pad with NTC 100K MGB18-104F39050L32 thermistor
- *    76 : unknown thermistor in 600W silicone pad
+ *    76 : Unknown thermistor in 600W silicone pad
  *    99 : 100k thermistor with a 10K pull-up resistor (found on some Wanhao i3 machines)
  *
  *       1k ohm pullup tables - This is atypical, and requires changing out the 4.7k pullup for 1k.

--- a/Marlin/src/lcd/thermistornames.h
+++ b/Marlin/src/lcd/thermistornames.h
@@ -104,6 +104,8 @@
   #define THERMISTOR_NAME "Hephestos 2"
 #elif THERMISTOR_ID == 75
   #define THERMISTOR_NAME "MGB18"
+#elif THERMISTOR_ID == 76
+  #define THERMISTOR_NAME "unknown in 600W pad"
 #elif THERMISTOR_ID == 99
   #define THERMISTOR_NAME "100k with 10k pull-up"
 

--- a/Marlin/src/lcd/thermistornames.h
+++ b/Marlin/src/lcd/thermistornames.h
@@ -105,7 +105,7 @@
 #elif THERMISTOR_ID == 75
   #define THERMISTOR_NAME "MGB18"
 #elif THERMISTOR_ID == 76
-  #define THERMISTOR_NAME "unknown in 600W pad"
+  #define THERMISTOR_NAME "Unknown in 600W pad"
 #elif THERMISTOR_ID == 99
   #define THERMISTOR_NAME "100k with 10k pull-up"
 

--- a/Marlin/src/module/thermistor/thermistor_76.h
+++ b/Marlin/src/module/thermistor/thermistor_76.h
@@ -1,0 +1,65 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+// Unknown thermistor in 600W silicone heater pad
+// Ordered from https://www.aliexpress.com/item/32859679498.html
+
+// Values were determined by taping two type-5 thermistors to the printer bed:
+// a 12x12x1/4" slab of cast-aluminum tooling plate with the aforementioned
+// heater stuck underneath.  The thermistors were stuck to the side of the 
+// bed with some kapton tape.  One was plugged into an SKR Pro 1.1 running
+// Marlin.  The other type-5 thermistor and the unknown thermistor in the
+// bed heater were connected to an Arduino Nano, programmed to write the temperature
+// and raw ADC readings to its serial port once per second.  Readings were
+// logged with Minicom while the bed temperature was adjusted and allowed
+// to settle.
+//
+// All but the last two (0 and 10 degrees) were determined this way.  As
+// a result, temperatures below 25 may be inaccurate...but the coldest I
+// run my printer is 60 for PLA, so that shouldn't be an issue for this
+// application.
+
+const short temptable_76[][2] PROGMEM = {
+  { OV( 634), 120 },
+  { OV( 676), 115 },
+  { OV( 717), 110 },
+  { OV( 738), 105 },
+  { OV( 796), 100 },
+  { OV( 832),  95 },
+  { OV( 845),  90 },
+  { OV( 849),  85 },
+  { OV( 867),  80 },
+  { OV( 881),  75 },
+  { OV( 906),  70 },
+  { OV( 915),  65 },
+  { OV( 926),  60 },
+  { OV( 938),  55 },
+  { OV( 947),  50 },
+  { OV( 954),  45 },
+  { OV( 961),  40 },
+  { OV( 967),  35 },
+  { OV( 974),  30 },
+  { OV( 979),  25 },
+  { OV(1000),  10 },
+  { OV(1010),   0 }
+};

--- a/Marlin/src/module/thermistor/thermistor_76.h
+++ b/Marlin/src/module/thermistor/thermistor_76.h
@@ -39,7 +39,7 @@
 // run my printer is 60 for PLA, so that shouldn't be an issue for this
 // application.
 
-const short temptable_76[][2] PROGMEM = {
+const temp_entry_t temptable_76[] PROGMEM = {
   { OV( 634), 120 },
   { OV( 676), 115 },
   { OV( 717), 110 },

--- a/Marlin/src/module/thermistor/thermistor_76.h
+++ b/Marlin/src/module/thermistor/thermistor_76.h
@@ -16,7 +16,7 @@
  * GNU General Public License for more details.
  *
  * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
 #pragma once
@@ -26,7 +26,7 @@
 
 // Values were determined by taping two type-5 thermistors to the printer bed:
 // a 12x12x1/4" slab of cast-aluminum tooling plate with the aforementioned
-// heater stuck underneath.  The thermistors were stuck to the side of the 
+// heater stuck underneath.  The thermistors were stuck to the side of the
 // bed with some kapton tape.  One was plugged into an SKR Pro 1.1 running
 // Marlin.  The other type-5 thermistor and the unknown thermistor in the
 // bed heater were connected to an Arduino Nano, programmed to write the temperature

--- a/Marlin/src/module/thermistor/thermistors.h
+++ b/Marlin/src/module/thermistor/thermistors.h
@@ -150,6 +150,9 @@ typedef struct { int16_t value, celsius; } temp_entry_t;
 #if ANY_THERMISTOR_IS(75) // beta25 = 4100 K, R25 = 100 kOhm, Pull-up = 4.7 kOhm, "MGB18-104F39050L32 thermistor"
   #include "thermistor_75.h"
 #endif
+#if ANY_THERMISTOR_IS(76) // unknown thermistor in 600W pad
+  #include "thermistor_76.h"
+#endif
 #if ANY_THERMISTOR_IS(99) // 100k bed thermistor with a 10K pull-up resistor (on some Wanhao i3 models)
   #include "thermistor_99.h"
 #endif


### PR DESCRIPTION
### Description

(Revised...patch is against bugfix-2.0.x, not 2.0.x.)

A while back, I purchased this 600W silicone bed heater:

https://www.aliexpress.com/item/32859679498.html

The thermistor within doesn't seem to match any that Marlin knows about; no matter what I selected, it tended to read low. (I tried bringing it up to 85 one time, and it started to smoke a little bit!) I knocked together a rig to correlate the ADC readings for this thermistor with those from a known thermistor, and put the results in a new thermistor table.

### Benefits

It keeps my bed heater temperature where it should be, at least within the usual range (60-110) within which I'll run it.

### Related Issues

None that I know about.