### PR TITLE
Update FYSETC AIO II board pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
@@ -84,7 +84,7 @@
 #define E0_DIR_PIN                          PC14
 #define E0_ENABLE_PIN                       PC13
 
-#if HAS_TMC220x
+#if HAS_TMC_UART
 
   /**
    * TMC2208/TMC2209 stepper drivers
@@ -98,8 +98,8 @@
   #define Z_HARDWARE_SERIAL  Serial1
   #define E0_HARDWARE_SERIAL Serial1
 
-  // 4*TMC2209 module don't have serial multiplexer,
-  // And need to set *_SLAVE_ADDRESS in configuration_adv.h for X,Y,Z,E0
+  // The 4xTMC2209 module doesn't have a serial multiplexer and
+  // needs to set *_SLAVE_ADDRESS in Configuration_adv.h for X,Y,Z,E0
   #if HAS_DRIVER(TMC2208)
     #define TMC_SERIAL_MULTIPLEXER
     #define SERIAL_MUL_PIN1                 PB13

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
@@ -97,9 +97,14 @@
   #define Y_HARDWARE_SERIAL  Serial1
   #define Z_HARDWARE_SERIAL  Serial1
   #define E0_HARDWARE_SERIAL Serial1
-  #define TMC_SERIAL_MULTIPLEXER
-  #define SERIAL_MUL_PIN1                   PB13
-  #define SERIAL_MUL_PIN2                   PB12
+
+  // 4*TMC2209 module don't have serial multiplexer,
+  // And need to set *_SLAVE_ADDRESS in configuration_adv.h for X,Y,Z,E0
+  #if HAS_DRIVER(TMC2208)
+    #define TMC_SERIAL_MULTIPLEXER
+    #define SERIAL_MUL_PIN1                 PB13
+    #define SERIAL_MUL_PIN2                 PB12
+  #endif
 
 #endif
 


### PR DESCRIPTION
Update FYSETC AIO II board pins to support 4*TMC2209 module