### PR TITLE
Uniform 'G34' to 'G28 O' to decide when homing is required or not

### DIFF
--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -137,7 +137,7 @@ void GcodeSuite::G34() {
     );
 
     // Home before the alignment procedure
-    if (!all_axes_known()) home_all_axes();
+    if (homing_needed()) home_all_axes();
 
     // Move the Z coordinate realm towards the positive - dirty trick
     current_position.z += z_probe * 0.5f;


### PR DESCRIPTION
I think that G34 should behave like G28 O to decide when home is required or not.

If position change due to stepper de-energization is not considered to home axes, should not be considered as well for G34