### PR TITLE
Improve and simplify encoder wheel handling

### DIFF
--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -49,6 +49,8 @@ MarlinUI ui;
   bool MarlinUI::wait_for_move; // = false
 #endif
 
+constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
+
 #if HAS_SPI_LCD
   #if ENABLED(STATUS_MESSAGE_SCROLLING)
     uint8_t MarlinUI::status_scroll_offset; // = 0
@@ -440,13 +442,13 @@ bool MarlinUI::get_blink() {
           #endif
           {
             #if HAS_LCD_MENU
-                   if (RRK(EN_KEYPAD_UP))     encoderPosition -= ENCODER_PULSES_PER_STEP;
-              else if (RRK(EN_KEYPAD_DOWN))   encoderPosition += ENCODER_PULSES_PER_STEP;
+                   if (RRK(EN_KEYPAD_UP))     encoderPosition -= epps;
+              else if (RRK(EN_KEYPAD_DOWN))   encoderPosition += epps;
               else if (RRK(EN_KEYPAD_LEFT))   { MenuItem_back::action(); quick_feedback(); }
               else if (RRK(EN_KEYPAD_RIGHT))  encoderPosition = 0;
             #else
-                   if (RRK(EN_KEYPAD_UP)   || RRK(EN_KEYPAD_LEFT))  encoderPosition -= ENCODER_PULSES_PER_STEP;
-              else if (RRK(EN_KEYPAD_DOWN) || RRK(EN_KEYPAD_RIGHT)) encoderPosition += ENCODER_PULSES_PER_STEP;
+                   if (RRK(EN_KEYPAD_UP)   || RRK(EN_KEYPAD_LEFT))  encoderPosition -= epps;
+              else if (RRK(EN_KEYPAD_DOWN) || RRK(EN_KEYPAD_RIGHT)) encoderPosition += epps;
             #endif
           }
         #endif
@@ -841,7 +843,7 @@ void MarlinUI::update() {
         RESET_STATUS_TIMEOUT();
         if (touch_buttons & (EN_A | EN_B)) {              // Menu arrows, in priority
           if (ELAPSED(ms, next_button_update_ms)) {
-            encoderDiff = (ENCODER_STEPS_PER_MENU_ITEM) * (ENCODER_PULSES_PER_STEP) * encoderDirection;
+            encoderDiff = (ENCODER_STEPS_PER_MENU_ITEM) * epps * encoderDirection;
             if (touch_buttons & EN_A) encoderDiff *= -1;
             TERN_(AUTO_BED_LEVELING_UBL, external_encoder());
             next_button_update_ms = ms + repeat_delay;    // Assume the repeat delay
@@ -906,18 +908,16 @@ void MarlinUI::update() {
         static int8_t lastEncoderDiff;
 
         // Timeout? No decoder change since last check. 10 or 20 times per second.
-        if (encoderDiff == lastEncoderDiff && abs_diff <= (ENCODER_PULSES_PER_STEP) / 2 ) {
-          encoderDiff = 0;  // Clear residual value
-        } else
-        // Passed half the threshold?
-        if (WITHIN(abs_diff, (ENCODER_PULSES_PER_STEP) / 2 + 1, (ENCODER_PULSES_PER_STEP) - 1)) {
-          abs_diff = ENCODER_PULSES_PER_STEP;
-          encoderDiff = (encoderDiff < 0 ? -1 : 1) * abs_diff;  // Treat as full step
+        if (encoderDiff == lastEncoderDiff && abs_diff <= epps / 2)   // Same direction & size but not over a half-step?
+          encoderDiff = 0;                                            // Clear residual pulses.
+        else if (WITHIN(abs_diff, epps / 2 + 1, epps - 1)) {          // Past half of threshold?
+          abs_diff = epps;                                            // Treat as a full step size
+          encoderDiff = (encoderDiff < 0 ? -1 : 1) * abs_diff;        // ...in the spin direction.
         }
         lastEncoderDiff = encoderDiff;
       #endif
 
-      const bool encoderPastThreshold = (abs_diff >= (ENCODER_PULSES_PER_STEP));
+      const bool encoderPastThreshold = (abs_diff >= epps);
       if (encoderPastThreshold || lcd_clicked) {
         if (encoderPastThreshold) {
 
@@ -926,7 +926,7 @@ void MarlinUI::update() {
             int32_t encoderMultiplier = 1;
 
             if (encoderRateMultiplierEnabled) {
-              const float encoderMovementSteps = float(abs_diff) / (ENCODER_PULSES_PER_STEP);
+              const float encoderMovementSteps = float(abs_diff) / epps;
 
               if (lastEncoderMovementMillis) {
                 // Note that the rate is always calculated between two passes through the
@@ -955,7 +955,7 @@ void MarlinUI::update() {
 
           #endif // ENCODER_RATE_MULTIPLIER
 
-          encoderPosition += (encoderDiff * encoderMultiplier) / (ENCODER_PULSES_PER_STEP);
+          encoderPosition += (encoderDiff * encoderMultiplier) / epps;
           encoderDiff = 0;
         }
 
@@ -1188,7 +1188,7 @@ void MarlinUI::update() {
         //
         #if ANY_BUTTON(UP, DWN, LFT, RT)
 
-          const int8_t pulses = (ENCODER_PULSES_PER_STEP) * encoderDirection;
+          const int8_t pulses = epps * encoderDirection;
 
           if (false) {
             // for the else-ifs below
@@ -1544,17 +1544,17 @@ void MarlinUI::update() {
       const int8_t xdir = col < (LCD_WIDTH ) / 2 ? -1 : 1,
                    ydir = row < (LCD_HEIGHT) / 2 ? -1 : 1;
       if (on_edit_screen)
-        encoderDiff = (ENCODER_PULSES_PER_STEP) * ydir;
+        encoderDiff = epps * ydir;
       else if (screen_items > 0) {
         // Last 3 cols act as a scroll :-)
         if (col > (LCD_WIDTH) - 5)
           // 2 * LCD_HEIGHT to scroll to bottom of next page. (LCD_HEIGHT would only go 1 item down.)
-          encoderDiff = (ENCODER_PULSES_PER_STEP) * (encoderLine - encoderTopLine + 2 * (LCD_HEIGHT)) * ydir;
+          encoderDiff = epps * (encoderLine - encoderTopLine + 2 * (LCD_HEIGHT)) * ydir;
         else
-          encoderDiff = (ENCODER_PULSES_PER_STEP) * (row - encoderPosition + encoderTopLine);
+          encoderDiff = epps * (row - encoderPosition + encoderTopLine);
       }
       else if (!on_status_screen())
-        encoderDiff = (ENCODER_PULSES_PER_STEP) * xdir;
+        encoderDiff = epps * xdir;
     }
 
   #endif


### PR DESCRIPTION
### Description
This change will properly 'timeout' the residual encoder step value, and therefor obsoletes the complex 'reversal' check.

### Benefits
It simplifies the code and actually improves the behavior of the encoder wheel handling.

### Related Issues
This fixes #18693 
