### PR TITLE
Add Filament Out port for Creality V4 Board

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -80,6 +80,13 @@
 #define Z_PROBE_PIN                         PB1   // BLTouch IN
 
 //
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                    PA4   // "Pulled-high"
+#endif
+
+//
 // Steppers
 //
 #define X_ENABLE_PIN                        PC3


### PR DESCRIPTION
### Requirements

There is a filament port on the Creality V4 board.  

### Description

This is to fill in the blanks for the board pins.

### Benefits

Allow people to use the built in filament out port.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
