### PR TITLE
Ender 3 V2: Inject G28 before G29

### DIFF
--- a/Marlin/src/lcd/dwin/dwin.cpp
+++ b/Marlin/src/lcd/dwin/dwin.cpp
@@ -2374,7 +2374,7 @@ void HMI_Control(void) {
 void HMI_Leveling(void) {
   Popup_Window_Leveling();
   DWIN_UpdateLCD();
-  queue.inject_P(PSTR("G29"));
+  queue.inject_P(PSTR("G28\nG29"));
 }
 
 /* Axis Move */

--- a/Marlin/src/lcd/dwin/dwin.cpp
+++ b/Marlin/src/lcd/dwin/dwin.cpp
@@ -2374,7 +2374,7 @@ void HMI_Control(void) {
 void HMI_Leveling(void) {
   Popup_Window_Leveling();
   DWIN_UpdateLCD();
-  queue.inject_P(PSTR("G28\nG29"));
+  queue.inject_P(PSTR("G28O\nG29"));
 }
 
 /* Axis Move */

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -80,6 +80,13 @@
 #define Z_PROBE_PIN                         PB1   // BLTouch IN
 
 //
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                    PA4   // "Pulled-high"
+#endif
+
+//
 // Steppers
 //
 #define X_ENABLE_PIN                        PC3


### PR DESCRIPTION
### Requirements

When the bed leveling option is selected on the controller, if there is no prior Autohoming is done, the machine will hang.

### Description

Forcefully inject G28 prior to G29 to ensure that the bed leveling function is performed and controller returns to normal.

### Benefits

Fixes #18733
