### PR TITLE
Fix lerdge script.

### DIFF
--- a/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
+++ b/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
@@ -15,19 +15,6 @@ env = DefaultEnvironment()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 variant = board.get("build.variant")
-variant_dir = ' +<buildroot/share/PlatformIO/variants/' + variant + '>';
-src_filter = env.get("SRC_FILTER")
-print("Starting SRC Filter:", env.get("SRC_FILTER"))
-src_filter_value = src_filter[0];
-
-src_filter_value = src_filter_value + variant_dir
-src_filter[0] = src_filter_value;
-env["SRC_FILTER"] = src_filter
-
-print("Modified SRC Filter:", env.get("SRC_FILTER"))
-
-cxx_flags = env['CXXFLAGS']
-print("CXXFLAGS", cxx_flags)
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinoststm32")
 assert os.path.isdir(FRAMEWORK_DIR)

--- a/platformio.ini
+++ b/platformio.ini
@@ -846,7 +846,7 @@ extra_scripts      = ${common.extra_scripts}
 build_flags        = ${common_stm32.build_flags}
   -DSTM32F4 -DSTM32F4xx -DTARGET_STM32F4
   -DDISABLE_GENERIC_SERIALUSB -DARDUINO_ARCH_STM32 -DARDUINO_LERDGE
-  -DTRANSFER_CLOCK_DIV=8
+  -DTRANSFER_CLOCK_DIV=8 -DHAL_SRAM_MODULE_ENABLED
 build_unflags      = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
 
 #


### PR DESCRIPTION
### Description

The lerdge copy script contains some code I didn't mean to include, which fails, thanks to me accidentally including code from me testing setting src filter. Also, a -D for the SRAM module was needed.

### Benefits

Lerdge environments will compile correctly.

### Related Issues

When #18130 is checked in, Lerdge LCDs will just work when TFT_DRIVER is set correctly.
