### PR TITLE
Dependency Ordering Fix

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -10,3 +10,7 @@ env.Append(CXXFLAGS=[
   #"-Wno-maybe-uninitialized",
   #"-Wno-sign-compare"
 ])
+
+# to avoid ordering errors in linker
+env.Prepend(_LIBFLAGS="-Wl,--start-group ")
+env.Append(_LIBFLAGS=" -Wl,--end-group")

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
@@ -48,3 +48,4 @@
 #include "../../../../Marlin/Configuration_adv.h"
 
 #include "../../../../Marlin/src/inc/Conditionals_adv.h"
+#include "../../../../Marlin/src/inc/Conditionals_post.h"

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -191,3 +191,7 @@ env.AddMethod(MarlinFeatureIsEnabled)
 # install all dependencies for features enabled in Configuration.h
 install_features_dependencies()
 force_ignore_unused_libs()
+
+print("Final src_filter = ", env.GetProjectOption("src_filter"))
+print("Final lib_deps = ", env.GetProjectOption("lib_deps"))
+print("Final lib_ignore = ", env.GetProjectOption("lib_ignore"))

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -185,10 +185,10 @@ def MarlinFeatureIsEnabled(env, feature):
 	matches = list(filter(r.match, env["MARLIN_FEATURES"]))
 	return len(matches) > 0
 
-# add a method for others scripts to check if a feature is enabled
+# Add a method for others scripts to check if a feature is enabled
 env.AddMethod(MarlinFeatureIsEnabled)
 
-# install all dependencies for features enabled in Configuration.h
+# Install all dependencies for features enabled in Configuration.h
 install_features_dependencies()
 force_ignore_unused_libs()
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -686,7 +686,7 @@ src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
 platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = CHITU_F103
-extra_scripts = pre:buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+extra_scripts = ${common.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
   buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = ${common_stm32f1.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared> -<src/l
   -<src/lcd/menu> -<src/lcd/dwin> -<src/lcd/extui/lib/dgus> -<src/lcd/extui/lib/ftdi_eve_touch_ui> -<src/lcd/dogm>
 extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-features-dependencies.py
-  pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
+  post:buildroot/share/PlatformIO/scripts/common-cxxflags.py
 build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-all-constants
 lib_deps           =
 


### PR DESCRIPTION
### Description

When using TMC 2209 Uart, the lib `TMCStepper` depends on `SoftwareSerialM`. The problem is that no matter the way we send the dependencies to platformio lib_deps, it randomly send the libs in the wrong order to linker.

The linker needs: dependent first, dependency last. Because as it is compiling, it discards non used references (until the compiled file). So, if SoftwareSerialM appear before TMCStepper in the linker command line, all symbols in SoftwareSerialM will be discarded, because they aren't used yet. 

The correct order is: TMCStepper first, SoftwareSerialM last.

Both dependency graph puts the SoftwareSerialM before TMCStepper.... 
```
Dependency Graph
|-- <lvgl> 6.1.1
|-- <SoftwareSerialM> 1.0.0
|-- <TMCStepper> 0.7.1
|   |-- <SoftwareSerialM> 1.0.0
|-- <STM32ADC> 1.0
|-- <EEPROM>
|-- <USBComposite for STM32F1> 0.91
|-- <Wire> 1.0
|-- <FreeRTOS701>
|-- <Servo(STM32F1)> 1.1.2
```
Or
```
Dependency Graph
|-- <lvgl> 6.1.1
|-- <TMCStepper> 0.7.1
|   |-- <SoftwareSerialM> 1.0.0
|-- <SoftwareSerialM> 1.0.0
|-- <STM32ADC> 1.0
|-- <EEPROM>
|-- <USBComposite for STM32F1> 0.91
|-- <Wire> 1.0
|-- <FreeRTOS701>
|-- <Servo(STM32F1)> 1.1.2
```

To solve it, gcc have a link flag. This PR add that flag (`-Wl,--start-group`) to the build process. 


### Benefits

 - Fix dependency ordering issue
 - We won't be any more link ordering problem

### Related Issues

#18699 