### PR TITLE
Build fail on Docker without GCC

### DIFF
--- a/Marlin/src/HAL/platforms.h
+++ b/Marlin/src/HAL/platforms.h
@@ -39,7 +39,7 @@
   #define HAL_PATH(PATH, NAME) XSTR(PATH/STM32_F4_F7/NAME)
 #elif defined(ARDUINO_ARCH_STM32)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/STM32/NAME)
-#elif defined(ARDUINO_ARCH_ESP32)
+#elif defined(ARDUINO_ARCH_ESP32) || defined(__ELF__)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/ESP32/NAME)
 #elif defined(__PLAT_LINUX__)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/LINUX/NAME)

--- a/Marlin/src/HAL/platforms.h
+++ b/Marlin/src/HAL/platforms.h
@@ -39,12 +39,12 @@
   #define HAL_PATH(PATH, NAME) XSTR(PATH/STM32_F4_F7/NAME)
 #elif defined(ARDUINO_ARCH_STM32)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/STM32/NAME)
+#elif defined(ARDUINO_ARCH_ESP32)
+  #define HAL_PATH(PATH, NAME) XSTR(PATH/ESP32/NAME)
 #elif defined(__PLAT_LINUX__)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/LINUX/NAME)
 #elif defined(__SAMD51__)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/SAMD51/NAME)
-#elif defined(ARDUINO_ARCH_ESP32) || defined(__ELF__)
-  #define HAL_PATH(PATH, NAME) XSTR(PATH/ESP32/NAME)
 #else
   #error "Unsupported Platform!"
 #endif

--- a/Marlin/src/HAL/platforms.h
+++ b/Marlin/src/HAL/platforms.h
@@ -39,12 +39,12 @@
   #define HAL_PATH(PATH, NAME) XSTR(PATH/STM32_F4_F7/NAME)
 #elif defined(ARDUINO_ARCH_STM32)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/STM32/NAME)
-#elif defined(ARDUINO_ARCH_ESP32) || defined(__ELF__)
-  #define HAL_PATH(PATH, NAME) XSTR(PATH/ESP32/NAME)
 #elif defined(__PLAT_LINUX__)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/LINUX/NAME)
 #elif defined(__SAMD51__)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/SAMD51/NAME)
+#elif defined(ARDUINO_ARCH_ESP32) || defined(__ELF__)
+  #define HAL_PATH(PATH, NAME) XSTR(PATH/ESP32/NAME)
 #else
   #error "Unsupported Platform!"
 #endif

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
@@ -36,6 +36,8 @@
 //
 #include <stdint.h>
 
+#include "../../../../Marlin/src/HAL/platforms.h"
+
 #include "../../../../Marlin/src/core/boards.h"
 #include "../../../../Marlin/src/core/macros.h"
 #include "../../../../Marlin/Configuration.h"
@@ -43,8 +45,17 @@
 #include "../../../../Marlin/Version.h"
 
 #include "../../../../Marlin/src/inc/Conditionals_LCD.h"
+#include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_LCD.h)
 
 #include "../../../../Marlin/src/core/drivers.h"
 #include "../../../../Marlin/Configuration_adv.h"
 
 #include "../../../../Marlin/src/inc/Conditionals_adv.h"
+#include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_adv.h)
+
+//#include "../../../../Marlin/src/pins/pins.h"
+//#include HAL_PATH(../../../../Marlin/src/HAL, timers.h)
+//#include HAL_PATH(../../../../Marlin/src/HAL, spi_pins.h)
+
+#include "../../../../Marlin/src/inc/Conditionals_post.h"
+#include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_post.h)

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
@@ -45,17 +45,28 @@
 #include "../../../../Marlin/Version.h"
 
 #include "../../../../Marlin/src/inc/Conditionals_LCD.h"
-#include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_LCD.h)
+
+#ifdef HAL_PATH
+  #include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_LCD.h)
+#endif
 
 #include "../../../../Marlin/src/core/drivers.h"
 #include "../../../../Marlin/Configuration_adv.h"
 
 #include "../../../../Marlin/src/inc/Conditionals_adv.h"
-#include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_adv.h)
 
-//#include "../../../../Marlin/src/pins/pins.h"
-//#include HAL_PATH(../../../../Marlin/src/HAL, timers.h)
-//#include HAL_PATH(../../../../Marlin/src/HAL, spi_pins.h)
+#ifdef HAL_PATH
+  #include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_adv.h)
+#endif
+
+#include "../../../../Marlin/src/pins/pins.h"
+//#ifdef HAL_PATH
+//  #include HAL_PATH(../../../../Marlin/src/HAL, timers.h)
+//  #include HAL_PATH(../../../../Marlin/src/HAL, spi_pins.h)
+//#endif
 
 #include "../../../../Marlin/src/inc/Conditionals_post.h"
-#include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_post.h)
+
+#ifdef HAL_PATH
+  #include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_post.h)
+#endif

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
@@ -36,7 +36,8 @@
 //
 #include <stdint.h>
 
-#include "../../../../Marlin/src/HAL/platforms.h"
+// Include platform headers
+//#include "../../../../Marlin/src/HAL/platforms.h"
 
 #include "../../../../Marlin/src/core/boards.h"
 #include "../../../../Marlin/src/core/macros.h"
@@ -57,13 +58,12 @@
 
 #ifdef HAL_PATH
   #include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_adv.h)
-#endif
 
-#include "../../../../Marlin/src/pins/pins.h"
-//#ifdef HAL_PATH
-//  #include HAL_PATH(../../../../Marlin/src/HAL, timers.h)
-//  #include HAL_PATH(../../../../Marlin/src/HAL, spi_pins.h)
-//#endif
+  #include "../../../../Marlin/src/pins/pins.h"
+
+  #include HAL_PATH(../../../../Marlin/src/HAL, timers.h)
+  #include HAL_PATH(../../../../Marlin/src/HAL, spi_pins.h)
+#endif
 
 #include "../../../../Marlin/src/inc/Conditionals_post.h"
 

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.h
@@ -27,13 +27,6 @@
  * Used by common-features-dependencies.py
  */
 
-#ifndef __MARLIN_FIRMWARE__
-#define __MARLIN_FIRMWARE__
-#endif
-
-//
-// Prefix header to acquire configurations
-//
 #include <stdint.h>
 
 // Include platform headers
@@ -58,9 +51,11 @@
 
 #ifdef HAL_PATH
   #include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_adv.h)
+#endif
 
-  #include "../../../../Marlin/src/pins/pins.h"
+//#include "../../../../Marlin/src/pins/pins.h"
 
+#ifdef HAL_PATH
   #include HAL_PATH(../../../../Marlin/src/HAL, timers.h)
   #include HAL_PATH(../../../../Marlin/src/HAL, spi_pins.h)
 #endif

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -57,8 +57,8 @@ def get_all_env_libs():
 		env_libs.append(name)
 	return env_libs
 
-# All unused libs should be ignored so that if a library exists
-# in .pio/lib_deps it will not break compilation.
+# All unused libs should be ignored so that if a library
+# exists in .pio/lib_deps it will not break compilation.
 def force_ignore_unused_libs():
 	env_libs = get_all_env_libs()
 	known_libs = get_all_known_libs()

--- a/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-features-dependencies.py
@@ -30,12 +30,8 @@ def load_config():
 			parts = dep.split('=')
 			name = parts.pop(0)
 			rest = '='.join(parts)
-			if name == 'extra_scripts':
-				FEATURE_DEPENDENCIES[ukey]['extra_scripts'] = rest
-			elif name == 'src_filter':
-				FEATURE_DEPENDENCIES[ukey]['src_filter'] = rest
-			elif name == 'lib_ignore':
-				FEATURE_DEPENDENCIES[ukey]['lib_ignore'] = rest
+			if name in ['extra_scripts', 'src_filter', 'lib_ignore']:
+				FEATURE_DEPENDENCIES[ukey][name] = rest
 			else:
 				FEATURE_DEPENDENCIES[ukey]['lib_deps'] += [dep]
 
@@ -166,8 +162,7 @@ def search_compiler():
 
 			return file
 
-	cc = env.get('CC')
-	file = cc if cc != None else env.get('CXX')
+	file = env.get('CXX')
 	print("Couldn't find a compiler! Fallback to", file)
 	return file
 


### PR DESCRIPTION
### Description

A user reported the build is failing on Docker without gcc installed.

This fix the issue once for all... If there's no known gcc, it will look at the path, for linux, windows, Mac....

### Benefits

- Fix building Marlin inside Docker without gcc
- Cached gcc path in the current env dir, so it dont search in every build

### Related Issues

#18699 
