### PR TITLE
Close filament change dialog on host

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -271,6 +271,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
     } while (TERN0(HAS_LCD_MENU, show_lcd && pause_menu_response == PAUSE_RESPONSE_EXTRUDE_MORE));
 
   #endif
+  TERN_(HOST_PROMPT_SUPPORT, host_action_prompt_end());
 
   return true;
 }


### PR DESCRIPTION
### Description
If you use the Filament Change menu options on the LCD it also displays the "Purge More/Continue" dialog on any connected host (such as OctoPrint), but this dialog is not dismissed if you answer the prompt on the LCD because Marlin does not send any indication to the host that the prompt has been answered.
This PR makes Marlin send an ``//action:prompt_end`` at the end of the process to dismiss any host prompts that may remain.

### Benefits
Improves filament change dialog when using both an LCD and a host.
