### PR TITLE
Prevent ESP3D_WIFISUPPORT with non-ESP32 board

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3042,5 +3042,5 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
  * Sanity check for WIFI
  */
 #if ENABLED(ESP3D_WIFISUPPORT) && DISABLED(ARDUINO_ARCH_ESP32) 
-    #error "ESP3D_WIFISUPPORT library is only for ESP32 based controllers. Is not needed for standalone ESP3D modules."
+  #error "ESP3D_WIFISUPPORT requires an ESP32 controller. Use WIFISUPPORT for standalone ESP3D modules."
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3037,3 +3037,10 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
     #error "DIRECT_STEPPING is incompatible with LIN_ADVANCE. Enable in external planner if possible."
   #endif
 #endif
+
+/**
+ * Sanity check for WIFI
+ */
+#if ENABLED(ESP3D_WIFISUPPORT) && DISABLED(ARDUINO_ARCH_ESP32) 
+    #error "ESP3D_WIFISUPPORT library is only for ESP32 based controllers. Is not needed for standalone ESP3D modules."
+#endif


### PR DESCRIPTION
### Requirements

enable ESP3D_WIFISUPPORT on non ESP32 based controller.

### Description

This does not compile and it shouldn't. But it doesn't error gracefully.
Added an error to SanityCheck.h to advise what is going on.

Users seem to be getting confused between ESP32 standalone modules and this ESP3DLib that marlin on ESP32 uses for WIFI

### Benefits

Potentially less user confusion.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/18789