### PR TITLE
fix bogus output in print_xyz()

### DIFF
--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -68,7 +68,7 @@ void print_bin(uint16_t val) {
 extern const char SP_X_STR[], SP_Y_STR[], SP_Z_STR[];
 
 void print_xyz(const float &x, const float &y, const float &z, PGM_P const prefix/*=nullptr*/, PGM_P const suffix/*=nullptr*/) {
-  serialprintPGM(prefix);
+  if (prefix) serialprintPGM(prefix);
   SERIAL_ECHOPAIR_P(SP_X_STR, x, SP_Y_STR, y, SP_Z_STR, z);
   if (suffix) serialprintPGM(suffix); else SERIAL_EOL();
 }


### PR DESCRIPTION
### Description

I observed that with some command there are lots of bogus messages on the serial monitor:
for example, turnning on debugging output and do a G28:
```
M111 S255
G28
```
which prints leveling debug info gives:
```
00:11:25.854 : N15 M111 S255*87
00:11:25.865 : echo:DEBUG:ECHO,INFO,ERRORS,DRYRUN,COMMUNICATION,LEVELING
00:11:25.865 : ok N15 P15 B3
00:11:30.518 : N17 G28*37
00:11:30.567 : echo:N17 G28*37
00:11:30.567 : >>> G28 ?J!?{!?{!?{!?{!?{!?{!?{!?{!
00:11:30.567 : ??s
00:11:30.567 : ??s
00:11:30.567 : ??s?{!????{!?{!?{!????{!?{!?{!?{!
00:11:30.567 : ??O
00:11:30.567 : ?
00:11:30.588 : u?{!?E?E?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?5?5?5?5?5666p6>6;696IEYEjEuE}E?E?E?E?E?E?E?EFF%F0F;FFFQF\F?F?F?F?FgF?F?F?F?F?F?FG GWGWGWGWG.GvG?G?G?G?G?G?G?GHHHH?G=HFHTH_HjHuH?H?H?H?H?H?H?H?H?H?H?H?H?H?H?H%I%I%I%I?HSIEJYIcImIwI?I?IEJ?IEJEJEJEJEJ?IEJ?I?I?I?I?IJJJ"J1JEJ;JdJ?KmJzJ?J?J?J?J?K?J?K?K?K?K?K?J?K?J?JK(K:KGKRK_KlK~K?K?K?K?L?K?K?K?K?K
00:11:30.588 : L?LL?L?L?L?L?L.L?L9LIL`LxL?L?L?L?L?L?L?L?LM?M
00:11:30.588 : MMM"M8MCM?MNM?M?M?M?M?MZM?MbMmM?M?M?M?M?M?M?M?M?M?M?M?N X0.0000 Y0.0000 Z300.0000
00:11:30.589 : Machine Type: Delta
00:11:30.589 : Probe: PROBE_MANUALLY
00:11:30.590 : X current: 800 -> 400
00:11:30.593 : Y current: 800 -> 400
00:11:30.639 : >>> home_delta ?J!?{!?{!?{!?{!?{!?{!?{!?{!
00:11:30.639 : ??s
00:11:30.640 : ??s
00:11:30.640 : ??s?{!????{!?{!?{!????{!?{!?{!?{!
00:11:30.640 : ??O
00:11:30.640 : ?
00:11:30.657 : u?{!?E?E?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?{!?5?5?5?5?5666p6>6;696IEYEjEuE}E?E?E?E?E?E?E?EFF%F0F;FFFQF\F?F?F?F?FgF?F?F?F?F?F?FG GWGWGWGWG.GvG?G?G?G?G?G?G?GHHHH?G=HFHTH_HjHuH?H?H?H?H?H?H?H?H?H?H?H?H?H?H?H%I%I%I%I?HSIEJYIcImIwI?I?IEJ?IEJEJEJEJEJ?IEJ?I?I?I?I?IJJJ"J1JEJ;JdJ?KmJzJ?J?J?J?J?K?J?K?K?K?K?K?J?K?J?JK(K:KGKRK_KlK~K?K?K?K?L?K?K?K?K?K
00:11:30.657 : L?LL?L?L?L?L?L.L?L9LIL`LxL?L?L?L?L?L?L?L?LM?M
00:11:30.657 : MMM"M8MCM?MNM?M?M?M?M?MZM?MbMmM?M?M?M?M?M?M?M?M?M?M?M?N X0.0000 Y0.0000 Z300.0000
00:11:30.658 : current_position= X0.0000 Y0.0000 Z0.0000 : sync_plan_position
```

digging into the code, I found that `print_xyz()` is printing prefix even when `prefix == nullptr`.
thus, add a guard to prevent `nullptr` from printing.

### Benefits

no more bogus messages:
```
00:15:31.370 : N18 M111 S255*90
00:15:31.381 : echo:N18 M111 S255*90
00:15:31.382 : echo:DEBUG:ECHO,INFO,ERRORS,DRYRUN,COMMUNICATION,LEVELING
00:15:31.382 : ok N18 P15 B3
00:15:37.955 : N20 G28*33
00:15:37.966 : echo:N20 G28*33
00:15:37.966 : >>> G28  X0.0000 Y0.0000 Z290.0000
00:15:37.966 : Machine Type: Delta
00:15:37.966 : Probe: PROBE_MANUALLY
00:15:37.971 : X current: 800 -> 400
00:15:37.971 : Y current: 800 -> 400
00:15:37.983 : >>> home_delta  X0.0000 Y0.0000 Z290.0000
00:15:37.983 : current_position= X0.0000 Y0.0000 Z0.0000 : sync_plan_position
```

### Related Issues
