### PR TITLE
[2.0.x] DELTA + TMC + sensorless homing + SPI endstops

### DIFF
--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -242,11 +242,9 @@ void home_delta() {
 
   // Disable stealthChop if used. Enable diag1 pin on driver.
   #if ENABLED(SENSORLESS_HOMING)
-    sensorless_t stealth_states {
-      tmc_enable_stallguard(stepperX),
-      tmc_enable_stallguard(stepperY),
-      tmc_enable_stallguard(stepperZ)
-    };
+  TERN_(X_SENSORLESS, sensorless_t stealth_states_x = start_sensorless_homing_per_axis(X_AXIS));
+  TERN_(Y_SENSORLESS, sensorless_t stealth_states_y = start_sensorless_homing_per_axis(Y_AXIS));
+  TERN_(Z_SENSORLESS, sensorless_t stealth_states_z = start_sensorless_homing_per_axis(Z_AXIS));
   #endif
 
   // Move all carriages together linearly until an endstop is hit.
@@ -256,9 +254,9 @@ void home_delta() {
 
   // Re-enable stealthChop if used. Disable diag1 pin on driver.
   #if ENABLED(SENSORLESS_HOMING)
-    tmc_disable_stallguard(stepperX, stealth_states.x);
-    tmc_disable_stallguard(stepperY, stealth_states.y);
-    tmc_disable_stallguard(stepperZ, stealth_states.z);
+  TERN_(X_SENSORLESS, end_sensorless_homing_per_axis(X_AXIS, stealth_states_x));
+  TERN_(Y_SENSORLESS, end_sensorless_homing_per_axis(Y_AXIS, stealth_states_y));
+  TERN_(Z_SENSORLESS, end_sensorless_homing_per_axis(Z_AXIS, stealth_states_z));
   #endif
 
   endstops.validate_homing_move();

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -398,7 +398,6 @@ void homeaxis(const AxisEnum axis);
 
 #if USE_SENSORLESS
   struct sensorless_t;
-
   sensorless_t start_sensorless_homing_per_axis(const AxisEnum axis);
   void end_sensorless_homing_per_axis(const AxisEnum axis, sensorless_t enable_stealth);
 #endif

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -395,3 +395,10 @@ void homeaxis(const AxisEnum axis);
 #if HAS_M206_COMMAND
   void set_home_offset(const AxisEnum axis, const float v);
 #endif
+
+#if USE_SENSORLESS
+  struct sensorless_t;
+
+  sensorless_t start_sensorless_homing_per_axis(const AxisEnum axis);
+  void end_sensorless_homing_per_axis(const AxisEnum axis, sensorless_t enable_stealth);
+#endif


### PR DESCRIPTION
### Description

TMC sensorless homing with SPI endstops didn't work on DELTA machines.
digging into the problem I found that `home_delta()` in `delta.cpp` is calling `tmc_enable_stallguard()` and `tmc_disable_stallguard()` directly, which doesn't handle SPI endstops like in `start_sensorless_homing_per_axis()` and `stop_sensorless_homing_per_axis()` in `motion.cpp`.

thus, just call these functions from `motion.cpp`......

### Benefits

DELTA setups with trinamic drivers can finally home correctly with SPI endstops!
