### PR TITLE
Added TEMP_PROBE_PIN for Einsy Rambo

### DIFF
--- a/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
@@ -109,6 +109,7 @@
 #define TEMP_0_PIN                             0  // Analog Input
 #define TEMP_1_PIN                             1  // Analog Input
 #define TEMP_BED_PIN                           2  // Analog Input
+#define TEMP_PROBE_PIN                         3  // Analog Input
 
 //
 // Heaters / Fans


### PR DESCRIPTION
### Requirements

* Enable PINDA v2 temperature sensor on Einsy Rambo

### Description

Enables G76 command - Probe temperature compensation added by @tompe-proj in #16293 when using an Einsy Rambo board (Tested on Einsy Rambo 1.1a)

### Benefits

Adds support for G76 on Einsy Rambo

### Related Issues

None that I could find
