### PR TITLE
remove need for HEATER_0_PIN if EXTRUDERS is 0

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1799,7 +1799,7 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 /**
  * Test Heater, Temp Sensor, and Extruder Pins
  */
-#if !HAS_HEATER_0
+#if !HAS_HEATER_0 && EXTRUDERS
   #error "HEATER_0_PIN not defined for this board."
 #elif !ANY_PIN(TEMP_0, MAX6675_SS)
   #error "TEMP_0_PIN not defined for this board."


### PR DESCRIPTION
### Requirements

If you are using Marlin for a non 3d printer SanityCheck.h requires a valid HEATER_0_PIN

### Description

I have modified the test so that if EXTRUDERS < 1 (ie no hot ends) you don't need a HEATER_0_PIN defined.

### Benefits

More CNC/Non 3d printer friendly

### Related Issues

Was raised on reprap forum https://reprap.org/forum/read.php?415,875542,875572
A user wanted to use D8,D9,D10 on his ramps for CNC things..   