### PR TITLE
[Bugfix] Disable DEBUG that affect Z DIR - Mks Robin Nano v2

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -37,7 +37,7 @@
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
 //
 
-//#define DISABLE_DEBUG
+#define DISABLE_DEBUG
 
 //
 // EEPROM


### PR DESCRIPTION
### Description

MKS Robin Nano V2 pins was sent to Marlin with a debug enabled.... and when it is enabled, it affects the Z direction, because it's the same PIN as Z_DIR...

Disabling it

### Benefits

- Right now, MKS Robin Nano v2 can't use Marlin 2.0.6.... 

### Related Issues


