### PR TITLE
SanityCheck: Adafruit NeoPixel is not supported in STM32F1

### DIFF
--- a/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
@@ -51,3 +51,7 @@
 #elif ENABLED(SERIAL_STATS_DROPPED_RX)
   #error "SERIAL_STATS_DROPPED_RX is not supported on this platform."
 #endif
+
+#if ENABLED(NEOPIXEL_LED)
+  #error "NEOPIXEL_LED (Adafruit NeoPixel) is not supported for this platform."
+#endif

--- a/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
@@ -53,5 +53,5 @@
 #endif
 
 #if ENABLED(NEOPIXEL_LED)
-  #error "NEOPIXEL_LED (Adafruit NeoPixel) is not supported for this platform."
+  #error "NEOPIXEL_LED (Adafruit NeoPixel) is not supported for this platform. To proceed at their own risk, comment out this line to continue."
 #endif

--- a/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
@@ -53,5 +53,5 @@
 #endif
 
 #if ENABLED(NEOPIXEL_LED)
-  #error "NEOPIXEL_LED (Adafruit NeoPixel) is not supported for this platform. To proceed at their own risk, comment out this line to continue."
+  #error "NEOPIXEL_LED (Adafruit NeoPixel) is not supported for HAL/STM32F1. Comment out this line to proceed at your own risk!"
 #endif


### PR DESCRIPTION
### Description

Users are getting build error when using NEOPIXEL_LED in STM32F1.

### Benefits

- Inform users that its not supported.

### Related Issues

#18829 
