### PR TITLE
Makes Cancel Object Numbers on statusscreen and menu corresponding to each other

### DIFF
--- a/Marlin/src/feature/cancel_object.cpp
+++ b/Marlin/src/feature/cancel_object.cpp
@@ -45,7 +45,7 @@ void CancelObject::set_active_object(const int8_t obj) {
 
   #if HAS_DISPLAY
     if (active_object >= 0)
-      ui.status_printf_P(0, PSTR(S_FMT " %i"), GET_TEXT(MSG_PRINTING_OBJECT), int(active_object + 1));
+      ui.status_printf_P(0, PSTR(S_FMT " %i"), GET_TEXT(MSG_PRINTING_OBJECT), int(active_object));
     else
       ui.reset_status();
   #endif

--- a/Marlin/src/feature/cancel_object.cpp
+++ b/Marlin/src/feature/cancel_object.cpp
@@ -45,7 +45,7 @@ void CancelObject::set_active_object(const int8_t obj) {
 
   #if HAS_DISPLAY
     if (active_object >= 0)
-      ui.status_printf_P(0, PSTR(S_FMT " %i"), GET_TEXT(MSG_PRINTING_OBJECT), int(active_object));
+      ui.status_printf_P(0, PSTR(S_FMT " %i"), GET_TEXT(MSG_PRINTING_OBJECT), int(active_object + 1));
     else
       ui.reset_status();
   #endif

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -319,7 +319,7 @@ void GcodeSuite::G28() {
     if (z_homing_height && (doX || doY || (ENABLED(Z_SAFE_HOMING) && doZ))) {
       // Raise Z before homing any other axes and z is not already high enough (never lower z)
       if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) by ", z_homing_height);
-      do_z_clearance(z_homing_height, TEST(axis_known_position, Z_AXIS), DISABLED(UNKNOWN_Z_NO_RAISE));
+      do_z_clearance(z_homing_height, (TEST(axis_known_position, Z_AXIS) || current_position.z == z_homing_height), DISABLED(UNKNOWN_Z_NO_RAISE));
     }
 
     #if ENABLED(QUICK_HOME)

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -319,7 +319,7 @@ void GcodeSuite::G28() {
     if (z_homing_height && (doX || doY || (ENABLED(Z_SAFE_HOMING) && doZ))) {
       // Raise Z before homing any other axes and z is not already high enough (never lower z)
       if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) by ", z_homing_height);
-      do_z_clearance(z_homing_height, (TEST(axis_known_position, Z_AXIS) || current_position.z == z_homing_height), DISABLED(UNKNOWN_Z_NO_RAISE));
+      do_z_clearance(z_homing_height, TEST(axis_known_position, Z_AXIS), DISABLED(UNKNOWN_Z_NO_RAISE));
     }
 
     #if ENABLED(QUICK_HOME)


### PR DESCRIPTION
### Requirements

Change the file cancelobject.cpp

### Description

The Number on the statusscreen is one count higher than the one in the menu.
With the change the numbers will correspond to each other.

### Benefits

No more false canceled object.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/18461
