### PR TITLE
add NOZZLE_CLEAN_NO_Y for brush attached to x axis

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1603,10 +1603,10 @@
   // Move the nozzle to the initial position after cleaning
   #define NOZZLE_CLEAN_GOBACK
 
-  // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
+  // For a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 
-  // Enable for a purge/clean station that is mounted on the x axis
+  // For a purge/clean station mounted on the X axis
   //#define NOZZLE_CLEAN_NO_Y
 
   // Explicit wipe G-code script applies to a G12 with no arguments.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1606,6 +1606,9 @@
   // Enable for a purge/clean station that's always at the gantry height (thus no Z move)
   //#define NOZZLE_CLEAN_NO_Z
 
+  // Enable for a purge/clean station that is mounted on the x axis
+  //#define NOZZLE_CLEAN_NO_Y
+
   // Explicit wipe G-code script applies to a G12 with no arguments.
   //#define WIPE_SEQUENCE_COMMANDS "G1 X-17 Y25 Z10 F4000\nG1 Z1\nM114\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 X-17 Y25\nG1 X-17 Y95\nG1 Z15\nM400\nG0 X-10.0 Y-9.0"
 

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -46,15 +46,24 @@ Nozzle nozzle;
 
     // Move to the starting point
     #if ENABLED(NOZZLE_CLEAN_NO_Z)
-      do_blocking_move_to_xy(start);
+      #if ENABLED(NOZZLE_CLEAN_NO_Y)
+        do_blocking_move_to_x(start.x);
+      #else
+        do_blocking_move_to_xy(start);
+      #endif
     #else
       do_blocking_move_to(start);
     #endif
 
     // Start the stroke pattern
     LOOP_L_N(i, strokes >> 1) {
-      do_blocking_move_to_xy(end);
-      do_blocking_move_to_xy(start);
+      #if ENABLED(NOZZLE_CLEAN_NO_Y)
+        do_blocking_move_to_x(end.x);
+        do_blocking_move_to_x(start.x);
+      #else
+        do_blocking_move_to_xy(end);
+        do_blocking_move_to_xy(start);
+      #endif
     }
 
     TERN_(NOZZLE_CLEAN_GOBACK, do_blocking_move_to(oldpos));


### PR DESCRIPTION

### Description

My brush is attached to the x-axis, so it rises and drops with the nozzle, to wipe it only needs to wipe 
with a x-axis movement. I noticed that Z-Axis was only one that was able to be disabled.

Added the define NOZZLE_CLEAN_NO_Y

### Benefits

Allows configuration of the nozzle clean so it only moves the nozzle on the the x axis.

This is something I have had setup on my printer for about 6 months. Works quite well.

