### PR TITLE
Fix PWM DC when SPINDLE_LASER_FREQUENCY is set

### DIFF
--- a/Marlin/src/feature/spindle_laser.cpp
+++ b/Marlin/src/feature/spindle_laser.cpp
@@ -66,6 +66,9 @@ void SpindleLaser::init() {
   void SpindleLaser::set_ocr(const uint8_t ocr) {
     WRITE(SPINDLE_LASER_ENA_PIN, SPINDLE_LASER_ACTIVE_HIGH);        // turn spindle on
     analogWrite(pin_t(SPINDLE_LASER_PWM_PIN), ocr ^ SPINDLE_LASER_PWM_OFF);
+    #if NEEDS_HARDWARE_PWM && SPINDLE_LASER_FREQUENCY
+      set_pwm_duty(pin_t(SPINDLE_LASER_PWM_PIN), ocr ^ SPINDLE_LASER_PWM_OFF);
+    #endif 
   }
   void SpindleLaser::ocr_off() {
     WRITE(SPINDLE_LASER_ENA_PIN, !SPINDLE_LASER_ACTIVE_HIGH);       // Turn spindle off


### PR DESCRIPTION
### Requirements

AVR or LPC176x hardware.
#define LASER_FEATURE 
#define SPINDLE_LASER_FREQUENCY       2500 

### Description

The above combination doesn't work correctly.
The PWM duty cycle is not updated when gcode M3 S{1-254} is given when SPINDLE_LASER_FREQUENCY is set
If SPINDLE_LASER_FREQUENCY is disabled it works as expected.

### Benefits
M3 S{1-254} gcode now works both with and without SPINDLE_LASER_FREQUENCY

### Related Issues
Issue #18848 