### PR TITLE
No mks_robin extra_scripts in Trigorilla build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -651,6 +651,7 @@ extra_scripts = ${common.extra_scripts}
 [env:trigorilla_pro]
 platform      = ${common_stm32f1.platform}
 extends       = env:mks_robin
+extra_scripts = ${common.extra_scripts}
 
 #
 # MKS Robin E3D (STM32F103RCT6) and


### PR DESCRIPTION
### Description

Trigorilla Pro Firmware was messed up during the build process, because the mks_robin.py was modifying it.