### PR TITLE
Show remaining time in LIGHTWEIGHT_UI

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -591,16 +591,17 @@ void ST7920_Lite_Status_Screen::draw_fan_speed(const uint8_t value) {
   write_byte('%');
 }
 
-void ST7920_Lite_Status_Screen::draw_print_time(const duration_t &elapsed) {
+void ST7920_Lite_Status_Screen::draw_print_time(const duration_t &elapsed, char suffix) {
   #if HOTENDS == 1
     set_ddram_address(DDRAM_LINE_3);
   #else
     set_ddram_address(DDRAM_LINE_3 + 5);
   #endif
   char str[7];
-  str[elapsed.toDigital(str)] = ' ';
+  int str_length = elapsed.toDigital(str);
+  str[str_length++] = suffix;
   begin_data();
-  write_str(str, 6);
+  write_str(str, str_length);
 }
 
 void ST7920_Lite_Status_Screen::draw_feedrate_percentage(const uint16_t percentage) {
@@ -713,7 +714,8 @@ bool ST7920_Lite_Status_Screen::indicators_changed() {
 void ST7920_Lite_Status_Screen::update_indicators(const bool forceUpdate) {
   if (forceUpdate || indicators_changed()) {
     const bool       blink             = ui.get_blink();
-    const duration_t elapsed           = print_job_timer.duration();
+    const duration_t elapsed           = print_job_timer.duration(),
+                     remaining         = TERN0(USE_M73_REMAINING_TIME, ui.get_remaining_time());
     const uint16_t   feedrate_perc     = feedrate_percentage;
     const int16_t    extruder_1_temp   = thermalManager.degHotend(0),
                      extruder_1_target = thermalManager.degTargetHotend(0);
@@ -738,7 +740,10 @@ void ST7920_Lite_Status_Screen::update_indicators(const bool forceUpdate) {
     #endif
 
     draw_fan_speed(thermalManager.fanPercent(spd));
-    draw_print_time(elapsed);
+    if(ENABLED(SHOW_REMAINING_TIME) && (DISABLED(ROTATE_PROGRESS_DISPLAY) || blink) && remaining.second())
+      draw_print_time(remaining, 'R');
+    else
+      draw_print_time(elapsed);
     draw_feedrate_percentage(feedrate_perc);
 
     // Update the fan and bed animations

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -743,12 +743,12 @@ void ST7920_Lite_Status_Screen::update_indicators(const bool forceUpdate) {
 
     // Draw elapsed/remaining time
     const bool show_remaining = ENABLED(SHOW_REMAINING_TIME) && (DISABLED(ROTATE_PROGRESS_DISPLAY) || blink);
-    if(show_remaining && !remaining.second()) {
+    if (show_remaining && !remaining.second()) {
       const auto progress = ui.get_progress_percent();
-      if(progress)
+      if (progress)
         remaining = elapsed.second() * (100 - progress) / progress;
     }
-    if(show_remaining && remaining.second())
+    if (show_remaining && remaining.second())
       draw_print_time(remaining, 'R');
     else
       draw_print_time(elapsed);

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
@@ -84,7 +84,7 @@ class ST7920_Lite_Status_Screen {
     static void draw_extruder_2_temp(const int16_t temp, const int16_t target, bool forceUpdate = false);
     static void draw_bed_temp(const int16_t temp, const int16_t target, bool forceUpdate = false);
     static void draw_fan_speed(const uint8_t value);
-    static void draw_print_time(const duration_t &elapsed);
+    static void draw_print_time(const duration_t &elapsed, char suffix = ' ');
     static void draw_feedrate_percentage(const uint16_t percentage);
     static void draw_status_message();
     static void draw_position(const xyze_pos_t &pos, bool position_known = true);

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.h
@@ -80,14 +80,14 @@ class ST7920_Lite_Status_Screen {
     static void draw_fan_icon(const bool whichIcon);
     static void draw_heat_icon(const bool whichIcon, const bool heating);
     static void draw_temps(uint8_t line, const int16_t temp, const int16_t target, bool showTarget, bool targetStateChange);
-    static void draw_extruder_1_temp(const int16_t temp, const int16_t target, bool forceUpdate = false);
-    static void draw_extruder_2_temp(const int16_t temp, const int16_t target, bool forceUpdate = false);
-    static void draw_bed_temp(const int16_t temp, const int16_t target, bool forceUpdate = false);
+    static void draw_extruder_1_temp(const int16_t temp, const int16_t target, bool forceUpdate=false);
+    static void draw_extruder_2_temp(const int16_t temp, const int16_t target, bool forceUpdate=false);
+    static void draw_bed_temp(const int16_t temp, const int16_t target, bool forceUpdate=false);
     static void draw_fan_speed(const uint8_t value);
-    static void draw_print_time(const duration_t &elapsed, char suffix = ' ');
+    static void draw_print_time(const duration_t &elapsed, char suffix=' ');
     static void draw_feedrate_percentage(const uint16_t percentage);
     static void draw_status_message();
-    static void draw_position(const xyze_pos_t &pos, bool position_known = true);
+    static void draw_position(const xyze_pos_t &pos, bool position_known=true);
 
     static bool indicators_changed();
     static bool position_changed();


### PR DESCRIPTION
### Description

Shows remaining time instead of elapsed time on LCD if both LIGHTWEIGHT_UI and SHOW_REMAINING_TIME are enabled. 
If ROTATE_PROGRESS_DISPLAY is enabled also, rotates elapsed and remaining once per second.
This code seems to be optimized away if SHOW_REMAINING_TIME is disabled