### PR TITLE
Add Chitu 3D V6 second filament runout pin

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -111,8 +111,13 @@
 #define BEEPER_PIN                          PB0
 //#define LED_PIN                           PD3
 //#define POWER_LOSS_PIN                    PG2   // PG4 PW_DET
-#define FIL_RUNOUT_PIN                      PA15  // MT_DET
-#define FIL_RUNOUT2_PIN                     PF13
+
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                    PA15  // MT_DET
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN                   PF13
+#endif
 
 //
 // TronXY TFT Support

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -112,6 +112,7 @@
 //#define LED_PIN                           PD3
 //#define POWER_LOSS_PIN                    PG2   // PG4 PW_DET
 #define FIL_RUNOUT_PIN                      PA15  // MT_DET
+#define FIL_RUNOUT2_PIN                     PF13
 
 //
 // TronXY TFT Support


### PR DESCRIPTION
### Description

Add second filament runout pin to Chitu 3D V6.

### Benefits

Allows use of second filament runout sensor.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/18921