### PR TITLE
Ask the PR authors to attach configuration

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ We must be able to understand your proposed change from this description. If we 
 
 ### Configurations
 
-<!-- Attach the Configuration.h/Configuration_adv.h/platformio.ini needed to compile/test your Pull Request -->
+<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
 
 ### Related Issues
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,10 @@ We must be able to understand your proposed change from this description. If we 
 
 <!-- What does this fix or improve? -->
 
+### Configurations
+
+<!-- Attach the Configuration.h/Configuration_adv.h/platformio.ini needed to compile/test your Pull Request -->
+
 ### Related Issues
 
 <!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->


### PR DESCRIPTION
### Description

Marlin have a lot of configurations options, and receive dozens of PR daily.

I think it would be easy to maintainers test (or at least compile) the PR, if the author attach its configs. So I added that instruction to the PR template.

### Benefits

- It will be easy to everyone test any PR
