### PR TITLE
Fix PIO warning about new `marlin` config

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -37,10 +37,10 @@ def load_config():
 			FEATURE_CONFIG[feature] = { 'lib_deps': [] }
 		add_to_feat_cnf(feature, key[1])
 
-	# Add options matching marlin.MY_OPTION to the pile
+	# Add options matching custom_marlin.MY_OPTION to the pile
 	all_opts = env.GetProjectOptions()
 	for n in all_opts:
-		mat = re.match(r'marlin\.(.+)', n[0])
+		mat = re.match(r'custom_marlin\.(.+)', n[0])
 		if mat:
 			try:
 				val = env.GetProjectOption(n[0])

--- a/platformio.ini
+++ b/platformio.ini
@@ -594,7 +594,7 @@ src_filter     = ${common.default_src_filter} +<src/HAL/SAMD51>
 lib_deps       = ${common.lib_deps}
   SoftwareSerialM
   Adafruit SPIFlash
-marlin.SDSUPPORT = SdFat - Adafruit Fork
+custom_marlin.SDSUPPORT = SdFat - Adafruit Fork
 debug_tool     = jlink
 
 #################################
@@ -616,8 +616,8 @@ extra_scripts     = ${common.extra_scripts}
 src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768>
 lib_deps          = ${common.lib_deps}
   Servo
-marlin.USES_LIQUIDCRYSTAL = LiquidCrystal@1.0.0
-marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/1.5.0.zip
+custom_marlin.USES_LIQUIDCRYSTAL = LiquidCrystal@1.0.0
+custom_marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/1.5.0.zip
 build_flags       = ${common.build_flags} -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g
   # debug options for backtrace
   #-funwind-tables
@@ -702,7 +702,7 @@ extra_scripts     = ${common.extra_scripts}
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM
   USBComposite for STM32F1@0.91
-marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/ccccmagicboy/Adafruit_NeoPixel#meeb_3dp_use
+custom_marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/ccccmagicboy/Adafruit_NeoPixel#meeb_3dp_use
 debug_tool        = stlink
 upload_protocol   = dfu
 


### PR DESCRIPTION
### Description

PIO warns about the new `marlin.` env config. To get rid of PIO warnings, we need to prefix the new config with `custom_`.

I really do like `marlin.`. But with `custom_marlin.` we get no warning.

Verified in the PIO source code: `~/.platformio/penv/python-xx/site-packages/platformio/project/config.py:170`
### Benefits

Fixes #18934

### Related Issues

#18934
#18919 
