### PR TITLE
Marlin Color UI for STM32F1 (FSMC)

### DIFF
--- a/Marlin/src/HAL/STM32F1/inc/Conditionals_LCD.h
+++ b/Marlin/src/HAL/STM32F1/inc/Conditionals_LCD.h
@@ -26,7 +26,7 @@
   #undef SD_CHECK_AND_RETRY
 #endif
 
-#if EITHER(TFT_320x240_SPI, TFT_480x320_SPI)
+#if HAS_SPI_TFT
   #error "Sorry! SPI TFT displays are not available for HAL/STM32F1 (yet)."
 #endif
 

--- a/Marlin/src/HAL/STM32F1/inc/Conditionals_LCD.h
+++ b/Marlin/src/HAL/STM32F1/inc/Conditionals_LCD.h
@@ -31,7 +31,7 @@
 #endif
 
 // This platform has 'touch/xpt2046', not 'tft/xpt2046'
-#if ENABLED(TOUCH_SCREEN) && NONE(TFT_320x240, TFT_480x320)
+#if ENABLED(TOUCH_SCREEN) && !HAS_FSMC_TFT
   #undef TOUCH_SCREEN
   #undef TOUCH_SCREEN_CALIBRATION
   #define HAS_TOUCH_XPT2046 1

--- a/Marlin/src/HAL/STM32F1/inc/Conditionals_LCD.h
+++ b/Marlin/src/HAL/STM32F1/inc/Conditionals_LCD.h
@@ -26,12 +26,12 @@
   #undef SD_CHECK_AND_RETRY
 #endif
 
-#if HAS_GRAPHICAL_TFT
-  #error "Sorry! TFT displays are not available for HAL/STM32F1."
+#if EITHER(TFT_320x240_SPI, TFT_480x320_SPI)
+  #error "Sorry! SPI TFT displays are not available for HAL/STM32F1 (yet)."
 #endif
 
 // This platform has 'touch/xpt2046', not 'tft/xpt2046'
-#if ENABLED(TOUCH_SCREEN)
+#if ENABLED(TOUCH_SCREEN) && NONE(TFT_320x240, TFT_480x320)
   #undef TOUCH_SCREEN
   #undef TOUCH_SCREEN_CALIBRATION
   #define HAS_TOUCH_XPT2046 1

--- a/Marlin/src/HAL/STM32F1/tft/tft_fsmc.cpp
+++ b/Marlin/src/HAL/STM32F1/tft/tft_fsmc.cpp
@@ -1,0 +1,236 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if HAS_FSMC_TFT
+
+#include "tft_fsmc.h"
+#include <libmaple/fsmc.h>
+#include <libmaple/gpio.h>
+#include <libmaple/dma.h>
+
+LCD_CONTROLLER_TypeDef *TFT_FSMC::LCD;
+
+/**
+ * FSMC LCD IO
+ */
+#define __ASM __asm
+#define __STATIC_INLINE static inline
+
+__attribute__((always_inline)) __STATIC_INLINE void __DSB() {
+  __ASM volatile ("dsb 0xF":::"memory");
+}
+
+#define FSMC_CS_NE1   PD7
+
+#if ENABLED(STM32_XL_DENSITY)
+  #define FSMC_CS_NE2 PG9
+  #define FSMC_CS_NE3 PG10
+  #define FSMC_CS_NE4 PG12
+
+  #define FSMC_RS_A0  PF0
+  #define FSMC_RS_A1  PF1
+  #define FSMC_RS_A2  PF2
+  #define FSMC_RS_A3  PF3
+  #define FSMC_RS_A4  PF4
+  #define FSMC_RS_A5  PF5
+  #define FSMC_RS_A6  PF12
+  #define FSMC_RS_A7  PF13
+  #define FSMC_RS_A8  PF14
+  #define FSMC_RS_A9  PF15
+  #define FSMC_RS_A10 PG0
+  #define FSMC_RS_A11 PG1
+  #define FSMC_RS_A12 PG2
+  #define FSMC_RS_A13 PG3
+  #define FSMC_RS_A14 PG4
+  #define FSMC_RS_A15 PG5
+#endif
+
+#define FSMC_RS_A16   PD11
+#define FSMC_RS_A17   PD12
+#define FSMC_RS_A18   PD13
+#define FSMC_RS_A19   PE3
+#define FSMC_RS_A20   PE4
+#define FSMC_RS_A21   PE5
+#define FSMC_RS_A22   PE6
+#define FSMC_RS_A23   PE2
+
+#if ENABLED(STM32_XL_DENSITY)
+  #define FSMC_RS_A24 PG13
+  #define FSMC_RS_A25 PG14
+#endif
+
+/* Timing configuration */
+#define FSMC_ADDRESS_SETUP_TIME   15  // AddressSetupTime
+#define FSMC_DATA_SETUP_TIME      15  // DataSetupTime
+
+static uint8_t fsmcInit = 0;
+void TFT_FSMC::Init() {
+  uint8_t cs = FSMC_CS_PIN, rs = FSMC_RS_PIN;
+  uint32_t controllerAddress;
+
+  #if PIN_EXISTS(TFT_RESET)
+    OUT_WRITE(TFT_RESET_PIN, HIGH);
+    delay(100);
+  #endif
+
+  #if PIN_EXISTS(TFT_BACKLIGHT)
+    OUT_WRITE(TFT_BACKLIGHT_PIN, HIGH);
+  #endif
+
+  struct fsmc_nor_psram_reg_map* fsmcPsramRegion;
+
+  if (fsmcInit) return;
+  fsmcInit = 1;
+
+  switch (cs) {
+    case FSMC_CS_NE1: controllerAddress = (uint32_t)FSMC_NOR_PSRAM_REGION1; fsmcPsramRegion = FSMC_NOR_PSRAM1_BASE; break;
+    #if ENABLED(STM32_XL_DENSITY)
+      case FSMC_CS_NE2: controllerAddress = (uint32_t)FSMC_NOR_PSRAM_REGION2; fsmcPsramRegion = FSMC_NOR_PSRAM2_BASE; break;
+      case FSMC_CS_NE3: controllerAddress = (uint32_t)FSMC_NOR_PSRAM_REGION3; fsmcPsramRegion = FSMC_NOR_PSRAM3_BASE; break;
+      case FSMC_CS_NE4: controllerAddress = (uint32_t)FSMC_NOR_PSRAM_REGION4; fsmcPsramRegion = FSMC_NOR_PSRAM4_BASE; break;
+    #endif
+    default: return;
+  }
+
+  #define _ORADDR(N) controllerAddress |= (_BV32(N) - 2)
+
+  switch (rs) {
+    #if ENABLED(STM32_XL_DENSITY)
+      case FSMC_RS_A0:  _ORADDR( 1); break;
+      case FSMC_RS_A1:  _ORADDR( 2); break;
+      case FSMC_RS_A2:  _ORADDR( 3); break;
+      case FSMC_RS_A3:  _ORADDR( 4); break;
+      case FSMC_RS_A4:  _ORADDR( 5); break;
+      case FSMC_RS_A5:  _ORADDR( 6); break;
+      case FSMC_RS_A6:  _ORADDR( 7); break;
+      case FSMC_RS_A7:  _ORADDR( 8); break;
+      case FSMC_RS_A8:  _ORADDR( 9); break;
+      case FSMC_RS_A9:  _ORADDR(10); break;
+      case FSMC_RS_A10: _ORADDR(11); break;
+      case FSMC_RS_A11: _ORADDR(12); break;
+      case FSMC_RS_A12: _ORADDR(13); break;
+      case FSMC_RS_A13: _ORADDR(14); break;
+      case FSMC_RS_A14: _ORADDR(15); break;
+      case FSMC_RS_A15: _ORADDR(16); break;
+    #endif
+    case FSMC_RS_A16: _ORADDR(17); break;
+    case FSMC_RS_A17: _ORADDR(18); break;
+    case FSMC_RS_A18: _ORADDR(19); break;
+    case FSMC_RS_A19: _ORADDR(20); break;
+    case FSMC_RS_A20: _ORADDR(21); break;
+    case FSMC_RS_A21: _ORADDR(22); break;
+    case FSMC_RS_A22: _ORADDR(23); break;
+    case FSMC_RS_A23: _ORADDR(24); break;
+    #if ENABLED(STM32_XL_DENSITY)
+      case FSMC_RS_A24: _ORADDR(25); break;
+      case FSMC_RS_A25: _ORADDR(26); break;
+    #endif
+    default: return;
+  }
+
+  rcc_clk_enable(RCC_FSMC);
+
+  gpio_set_mode(GPIOD, 14, GPIO_AF_OUTPUT_PP);  // FSMC_D00
+  gpio_set_mode(GPIOD, 15, GPIO_AF_OUTPUT_PP);  // FSMC_D01
+  gpio_set_mode(GPIOD,  0, GPIO_AF_OUTPUT_PP);  // FSMC_D02
+  gpio_set_mode(GPIOD,  1, GPIO_AF_OUTPUT_PP);  // FSMC_D03
+  gpio_set_mode(GPIOE,  7, GPIO_AF_OUTPUT_PP);  // FSMC_D04
+  gpio_set_mode(GPIOE,  8, GPIO_AF_OUTPUT_PP);  // FSMC_D05
+  gpio_set_mode(GPIOE,  9, GPIO_AF_OUTPUT_PP);  // FSMC_D06
+  gpio_set_mode(GPIOE, 10, GPIO_AF_OUTPUT_PP);  // FSMC_D07
+  gpio_set_mode(GPIOE, 11, GPIO_AF_OUTPUT_PP);  // FSMC_D08
+  gpio_set_mode(GPIOE, 12, GPIO_AF_OUTPUT_PP);  // FSMC_D09
+  gpio_set_mode(GPIOE, 13, GPIO_AF_OUTPUT_PP);  // FSMC_D10
+  gpio_set_mode(GPIOE, 14, GPIO_AF_OUTPUT_PP);  // FSMC_D11
+  gpio_set_mode(GPIOE, 15, GPIO_AF_OUTPUT_PP);  // FSMC_D12
+  gpio_set_mode(GPIOD,  8, GPIO_AF_OUTPUT_PP);  // FSMC_D13
+  gpio_set_mode(GPIOD,  9, GPIO_AF_OUTPUT_PP);  // FSMC_D14
+  gpio_set_mode(GPIOD, 10, GPIO_AF_OUTPUT_PP);  // FSMC_D15
+
+  gpio_set_mode(GPIOD,  4, GPIO_AF_OUTPUT_PP);  // FSMC_NOE
+  gpio_set_mode(GPIOD,  5, GPIO_AF_OUTPUT_PP);  // FSMC_NWE
+
+  gpio_set_mode(PIN_MAP[cs].gpio_device, PIN_MAP[cs].gpio_bit, GPIO_AF_OUTPUT_PP);  //FSMC_CS_NEx
+  gpio_set_mode(PIN_MAP[rs].gpio_device, PIN_MAP[rs].gpio_bit, GPIO_AF_OUTPUT_PP);  //FSMC_RS_Ax
+
+  fsmcPsramRegion->BCR = FSMC_BCR_WREN | FSMC_BCR_MTYP_SRAM | FSMC_BCR_MWID_16BITS | FSMC_BCR_MBKEN;
+  fsmcPsramRegion->BTR = (FSMC_DATA_SETUP_TIME << 8) | FSMC_ADDRESS_SETUP_TIME;
+
+  afio_remap(AFIO_REMAP_FSMC_NADV);
+
+  LCD = (LCD_CONTROLLER_TypeDef*)controllerAddress;
+}
+
+void TFT_FSMC::Transmit(uint16_t Data) {
+  LCD->RAM = Data;
+  __DSB();
+}
+
+void TFT_FSMC::WriteReg(uint16_t Reg) {
+  LCD->REG = Reg;
+  __DSB();
+}
+
+uint32_t TFT_FSMC::GetID() {
+  uint32_t id;
+  WriteReg(0x0000);
+  id = LCD->RAM;
+
+  if (id == 0)
+    id = ReadID(LCD_READ_ID);
+  if ((id & 0xFFFF) == 0 || (id & 0xFFFF) == 0xFFFF)
+    id = ReadID(LCD_READ_ID4);
+  return id;
+}
+
+ uint32_t TFT_FSMC::ReadID(uint16_t Reg) {
+   uint32_t id;
+   WriteReg(Reg);
+   id = LCD->RAM; // dummy read
+   id = Reg << 24;
+   id |= (LCD->RAM & 0x00FF) << 16;
+   id |= (LCD->RAM & 0x00FF) << 8;
+   id |= LCD->RAM & 0x00FF;
+   return id;
+ }
+
+bool TFT_FSMC::isBusy() {
+  return false;
+}
+
+void TFT_FSMC::Abort() {
+
+}
+
+void TFT_FSMC::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Count) {
+  dma_setup_transfer(FSMC_DMA_DEV, FSMC_DMA_CHANNEL, Data, DMA_SIZE_16BITS, &LCD->RAM, DMA_SIZE_16BITS, DMA_MEM_2_MEM | MemoryIncrease);
+  dma_set_num_transfers(FSMC_DMA_DEV, FSMC_DMA_CHANNEL, Count);
+  dma_clear_isr_bits(FSMC_DMA_DEV, FSMC_DMA_CHANNEL);
+  dma_enable(FSMC_DMA_DEV, FSMC_DMA_CHANNEL);
+
+  while ((dma_get_isr_bits(FSMC_DMA_DEV, FSMC_DMA_CHANNEL) & 0x0A) == 0) {};
+  dma_disable(FSMC_DMA_DEV, FSMC_DMA_CHANNEL);
+}
+
+#endif // HAS_FSMC_TFT

--- a/Marlin/src/HAL/STM32F1/tft/tft_fsmc.h
+++ b/Marlin/src/HAL/STM32F1/tft/tft_fsmc.h
@@ -1,0 +1,64 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#ifndef LCD_READ_ID
+  #define LCD_READ_ID 0x04   // Read display identification information (0xD3 on ILI9341)
+#endif
+#ifndef LCD_READ_ID4
+  #define LCD_READ_ID4 0xD3   // Read display identification information (0xD3 on ILI9341)
+#endif
+
+#include <libmaple/dma.h>
+
+#define DATASIZE_8BIT    DMA_SIZE_8BITS
+#define DATASIZE_16BIT   DMA_SIZE_16BITS
+#define TFT_IO TFT_FSMC
+
+typedef struct {
+  __IO uint16_t REG;
+  __IO uint16_t RAM;
+} LCD_CONTROLLER_TypeDef;
+
+class TFT_FSMC {
+  private:
+    static LCD_CONTROLLER_TypeDef *LCD;
+
+    static uint32_t ReadID(uint16_t Reg);
+    static void Transmit(uint16_t Data);
+    static void TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Count);
+
+  public:
+    static void Init();
+    static uint32_t GetID();
+    static bool isBusy();
+    static void Abort();
+
+    static void DataTransferBegin(uint16_t DataWidth = DATASIZE_16BIT) {};
+    static void DataTransferEnd() {};
+
+    static void WriteData(uint16_t Data) { Transmit(Data); }
+    static void WriteReg(uint16_t Reg);
+
+    static void WriteSequence(uint16_t *Data, uint16_t Count) { TransmitDMA(DMA_PINC_MODE, Data, Count); }
+    static void WriteMultiple(uint16_t Color, uint16_t Count) { static uint16_t Data; Data = Color; TransmitDMA(DMA_CIRC_MODE, &Data, Count); }
+};

--- a/Marlin/src/HAL/STM32F1/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/STM32F1/tft/xpt2046.cpp
@@ -1,0 +1,151 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if HAS_TFT_XPT2046
+
+#include "xpt2046.h"
+#include <SPI.h>
+
+uint16_t delta(uint16_t a, uint16_t b) { return a > b ? a - b : b - a; }
+
+#if ENABLED(TOUCH_BUTTONS_HW_SPI)
+  #include <SPI.h>
+
+  SPIClass XPT2046::SPIx(TOUCH_BUTTONS_HW_SPI_DEVICE);
+
+  static void touch_spi_init(uint8_t spiRate) {
+    /**
+     * STM32F1 APB2 = 72MHz, APB1 = 36MHz, max SPI speed of this MCU if 18Mhz
+     * STM32F1 has 3 SPI ports, SPI1 in APB2, SPI2/SPI3 in APB1
+     * so the minimum prescale of SPI1 is DIV4, SPI2/SPI3 is DIV2
+     */
+    uint8_t clock;
+    switch (spiRate) {
+      case SPI_FULL_SPEED:    clock = SPI_CLOCK_DIV4;  break;
+      case SPI_HALF_SPEED:    clock = SPI_CLOCK_DIV4; break;
+      case SPI_QUARTER_SPEED: clock = SPI_CLOCK_DIV8; break;
+      case SPI_EIGHTH_SPEED:  clock = SPI_CLOCK_DIV16; break;
+      case SPI_SPEED_5:       clock = SPI_CLOCK_DIV32; break;
+      case SPI_SPEED_6:       clock = SPI_CLOCK_DIV64; break;
+      default:                clock = SPI_CLOCK_DIV2;        // Default from the SPI library
+    }
+    XPT2046::SPIx.setModule(TOUCH_BUTTONS_HW_SPI_DEVICE);
+    XPT2046::SPIx.setClockDivider(clock);
+    XPT2046::SPIx.setBitOrder(MSBFIRST);
+    XPT2046::SPIx.setDataMode(SPI_MODE0);
+  }
+#endif // TOUCH_BUTTONS_HW_SPI
+
+void XPT2046::Init() {
+  SET_INPUT(TOUCH_MISO_PIN);
+  SET_OUTPUT(TOUCH_MOSI_PIN);
+  SET_OUTPUT(TOUCH_SCK_PIN);
+  OUT_WRITE(TOUCH_CS_PIN, HIGH);
+
+  #if PIN_EXISTS(TOUCH_INT)
+    // Optional Pendrive interrupt pin
+    SET_INPUT(TOUCH_INT_PIN);
+  #endif
+
+  #if ENABLED(TOUCH_BUTTONS_HW_SPI)
+    touch_spi_init(SPI_SPEED_6);
+  #endif
+
+  // Read once to enable pendrive status pin
+  getRawData(XPT2046_X);
+}
+
+bool XPT2046::isTouched() {
+  return isBusy() ? false : (
+    #if PIN_EXISTS(TOUCH_INT)
+      READ(TOUCH_INT_PIN) != HIGH
+    #else
+      getRawData(XPT2046_Z1) >= XPT2046_Z1_THRESHOLD
+    #endif
+  );
+}
+
+bool XPT2046::getRawPoint(int16_t *x, int16_t *y) {
+  if (isBusy()) return false;
+  if (!isTouched()) return false;
+  *x = getRawData(XPT2046_X);
+  *y = getRawData(XPT2046_Y);
+  return isTouched();
+}
+
+uint16_t XPT2046::getRawData(const XPTCoordinate coordinate) {
+    uint16_t data[3];
+
+  DataTransferBegin();
+
+  for (uint16_t i = 0; i < 3 ; i++) {
+    IO(coordinate);
+    data[i] = (IO() << 4) | (IO() >> 4);
+  }
+
+  DataTransferEnd();
+
+  uint16_t delta01 = delta(data[0], data[1]);
+  uint16_t delta02 = delta(data[0], data[2]);
+  uint16_t delta12 = delta(data[1], data[2]);
+
+  if (delta01 > delta02 || delta01 > delta12) {
+    if (delta02 > delta12)
+      data[0] = data[2];
+    else
+      data[1] = data[2];
+  }
+
+  return (data[0] + data[1]) >> 1;
+}
+
+uint16_t XPT2046::IO(uint16_t data) {
+  #if ENABLED(TOUCH_BUTTONS_HW_SPI)
+    return HardwareIO(data);
+  #else
+    return SoftwareIO(data);
+  #endif
+}
+
+#if ENABLED(TOUCH_BUTTONS_HW_SPI)
+  uint16_t XPT2046::HardwareIO(uint16_t data) {
+    SPIx.begin();
+    uint16_t result = SPIx.transfer(data);
+    SPIx.end();
+    return result;
+  }
+#endif
+
+uint16_t XPT2046::SoftwareIO(uint16_t data) {
+  uint16_t result = 0;
+
+  for (uint8_t j = 0x80; j; j >>= 1) {
+    WRITE(TOUCH_SCK_PIN, LOW);
+    WRITE(TOUCH_MOSI_PIN, data & j ? HIGH : LOW);
+    if (READ(TOUCH_MISO_PIN)) result |= j;
+    WRITE(TOUCH_SCK_PIN, HIGH);
+  }
+  WRITE(TOUCH_SCK_PIN, LOW);
+
+  return result;
+}
+
+#endif // HAS_TFT_XPT2046

--- a/Marlin/src/HAL/STM32F1/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/STM32F1/tft/xpt2046.cpp
@@ -92,7 +92,7 @@ bool XPT2046::getRawPoint(int16_t *x, int16_t *y) {
 }
 
 uint16_t XPT2046::getRawData(const XPTCoordinate coordinate) {
-    uint16_t data[3];
+  uint16_t data[3];
 
   DataTransferBegin();
 
@@ -103,26 +103,18 @@ uint16_t XPT2046::getRawData(const XPTCoordinate coordinate) {
 
   DataTransferEnd();
 
-  uint16_t delta01 = delta(data[0], data[1]);
-  uint16_t delta02 = delta(data[0], data[2]);
-  uint16_t delta12 = delta(data[1], data[2]);
+  uint16_t delta01 = delta(data[0], data[1]),
+           delta02 = delta(data[0], data[2]),
+           delta12 = delta(data[1], data[2]);
 
-  if (delta01 > delta02 || delta01 > delta12) {
-    if (delta02 > delta12)
-      data[0] = data[2];
-    else
-      data[1] = data[2];
-  }
+  if (delta01 > delta02 || delta01 > delta12)
+    data[delta02 > delta12 ? 0 : 1] = data[2];
 
   return (data[0] + data[1]) >> 1;
 }
 
 uint16_t XPT2046::IO(uint16_t data) {
-  #if ENABLED(TOUCH_BUTTONS_HW_SPI)
-    return HardwareIO(data);
-  #else
-    return SoftwareIO(data);
-  #endif
+  TERN(TOUCH_BUTTONS_HW_SPI, HardwareIO, SoftwareIO)(data);
 }
 
 #if ENABLED(TOUCH_BUTTONS_HW_SPI)

--- a/Marlin/src/HAL/STM32F1/tft/xpt2046.h
+++ b/Marlin/src/HAL/STM32F1/tft/xpt2046.h
@@ -1,0 +1,82 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "../../../inc/MarlinConfig.h"
+
+#if HAS_TFT_XPT2046
+
+#if ENABLED(TOUCH_BUTTONS_HW_SPI)
+  #include <SPI.h>
+#endif
+
+#if !PIN_EXISTS(TOUCH_MISO)
+  #error "TOUCH_MISO_PIN is not defined."
+#elif !PIN_EXISTS(TOUCH_MOSI)
+  #error "TOUCH_MOSI_PIN is not defined."
+#elif !PIN_EXISTS(TOUCH_SCK)
+  #error "TOUCH_SCK_PIN is not defined."
+#elif !PIN_EXISTS(TOUCH_CS)
+  #error "TOUCH_CS_PIN is not defined."
+#endif
+
+#ifndef TOUCH_INT_PIN
+  #define TOUCH_INT_PIN  -1
+#endif
+
+#define XPT2046_DFR_MODE        0x00
+#define XPT2046_SER_MODE        0x04
+#define XPT2046_CONTROL         0x80
+
+enum XPTCoordinate : uint8_t {
+  XPT2046_X  = 0x10 | XPT2046_CONTROL | XPT2046_DFR_MODE,
+  XPT2046_Y  = 0x50 | XPT2046_CONTROL | XPT2046_DFR_MODE,
+  XPT2046_Z1 = 0x30 | XPT2046_CONTROL | XPT2046_DFR_MODE,
+  XPT2046_Z2 = 0x40 | XPT2046_CONTROL | XPT2046_DFR_MODE,
+};
+
+#if !defined(XPT2046_Z1_THRESHOLD)
+  #define XPT2046_Z1_THRESHOLD 10
+#endif
+
+class XPT2046 {
+private:
+  static bool isBusy() { return false; }
+
+  static uint16_t getRawData(const XPTCoordinate coordinate);
+  static bool isTouched();
+
+  static inline void DataTransferBegin() { WRITE(TOUCH_CS_PIN, LOW); };
+  static inline void DataTransferEnd() { WRITE(TOUCH_CS_PIN, HIGH); };
+  #if ENABLED(TOUCH_BUTTONS_HW_SPI)
+    static uint16_t HardwareIO(uint16_t data);
+  #endif
+  static uint16_t SoftwareIO(uint16_t data);
+  static uint16_t IO(uint16_t data = 0);
+
+public:
+  #if ENABLED(TOUCH_BUTTONS_HW_SPI)
+    static SPIClass SPIx;
+  #endif
+
+  static void Init();
+  static bool getRawPoint(int16_t *x, int16_t *y);
+};
+
+#endif

--- a/Marlin/src/HAL/STM32F1/tft/xpt2046.h
+++ b/Marlin/src/HAL/STM32F1/tft/xpt2046.h
@@ -20,8 +20,6 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if HAS_TFT_XPT2046
-
 #if ENABLED(TOUCH_BUTTONS_HW_SPI)
   #include <SPI.h>
 #endif
@@ -78,5 +76,3 @@ public:
   static void Init();
   static bool getRawPoint(int16_t *x, int16_t *y);
 };
-
-#endif

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -22,7 +22,6 @@
 #if ENABLED(TOUCH_SCREEN)
 
 #include "touch.h"
-#include "pinconfig.h"
 
 #include "../ultralcd.h"
 #include "../menu/menu.h"

--- a/Marlin/src/libs/hex_print.cpp
+++ b/Marlin/src/libs/hex_print.cpp
@@ -78,7 +78,7 @@ void print_hex_byte(const uint8_t b)         { SERIAL_ECHO(hex_byte(b));    }
 void print_hex_word(const uint16_t w)        { SERIAL_ECHO(hex_word(w));    }
 void print_hex_address(const void * const w) { SERIAL_ECHO(hex_address(w)); }
 
-void print_hex_long(const uintptr_t w, const char delimiter) {
+void print_hex_long(const uint32_t w, const char delimiter) {
   SERIAL_ECHOPGM("0x");
   for (int B = 24; B >= 8; B -= 8){
     print_hex_byte(w >> B);

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -235,6 +235,8 @@
   #define TOUCH_SCK_PIN                     PA5   // SPI1_SCK
   #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
   #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
+
+  #define TFT_DRIVER                        ILI9488
 #endif
 
 // SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -148,8 +148,8 @@
 #endif
 
 // SPI Flash
-#define SPI_FLASH_SIZE                      0x200000  // 2MB
-#define HAS_SPI_FLASH                       1
+#define SPI_FLASH_SIZE                  0x200000  // 2MB
+#define HAS_SPI_FLASH                          1
 
 // SPI 2
 #define W25QXX_CS_PIN                       PB12
@@ -197,24 +197,24 @@
   #define LCD_PIXEL_OFFSET_X     48
   #define LCD_PIXEL_OFFSET_Y     48
 
-  #define XPT2046_X_CALIBRATION  -12316
-  #define XPT2046_Y_CALIBRATION   8981
-  #define XPT2046_X_OFFSET        340
-  #define XPT2046_Y_OFFSET        -20
+  #define XPT2046_X_CALIBRATION           -12316
+  #define XPT2046_Y_CALIBRATION             8981
+  #define XPT2046_X_OFFSET                   340
+  #define XPT2046_Y_OFFSET                   -20
 
   #define USE_XPT2046       1
   #define XPT2046_XY_SWAP   0
   #define XPT2046_X_INV     1
   #define XPT2046_Y_INV     0
 
-  #define XPT2046_HOR_RES   480
-  #define XPT2046_VER_RES   320
-  #define XPT2046_X_MIN     140
-  #define XPT2046_Y_MIN     200
+  #define XPT2046_HOR_RES    480
+  #define XPT2046_VER_RES    320
+  #define XPT2046_X_MIN      140
+  #define XPT2046_Y_MIN      200
   #define XPT2046_X_MAX     1900
   #define XPT2046_Y_MAX     1900
-  #define XPT2046_AVG       4
-  #define XPT2046_INV       0
+  #define XPT2046_AVG          4
+  #define XPT2046_INV          0
 
 #elif ENABLED(TFT_480x320)
   #define TFT_RESET_PIN                     PF11
@@ -226,18 +226,18 @@
   #define FSMC_DMA_DEV                      DMA2
   #define FSMC_DMA_CHANNEL               DMA_CH5
 
-  #define XPT2046_X_CALIBRATION             -17181
-  #define XPT2046_Y_CALIBRATION             11434
-  #define XPT2046_X_OFFSET                  501
-  #define XPT2046_Y_OFFSET                  -9
+  #define XPT2046_X_CALIBRATION           -17181
+  #define XPT2046_Y_CALIBRATION            11434
+  #define XPT2046_X_OFFSET                   501
+  #define XPT2046_Y_OFFSET                    -9
 
   #define TOUCH_CS_PIN                      PB7   // SPI1_NSS
   #define TOUCH_SCK_PIN                     PA5   // SPI1_SCK
   #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
   #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
 
-  #define TFT_DRIVER                        ILI9488
-  #define TFT_BUFFER_SIZE                   14400
+  #define TFT_DRIVER                     ILI9488
+  #define TFT_BUFFER_SIZE                  14400
 #endif
 
 // SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -215,6 +215,26 @@
   #define XPT2046_Y_MAX     1900
   #define XPT2046_AVG       4
   #define XPT2046_INV       0
+
+#elif ENABLED(TFT_480x320)
+  #define TFT_RESET_PIN                     PF11
+  #define TFT_BACKLIGHT_PIN                 PD13
+
+  #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
+  #define FSMC_CS_PIN                       PD7
+  #define FSMC_RS_PIN                       PD11
+  #define FSMC_DMA_DEV                      DMA2
+  #define FSMC_DMA_CHANNEL               DMA_CH5
+
+  #define XPT2046_X_CALIBRATION             -17181
+  #define XPT2046_Y_CALIBRATION             11434
+  #define XPT2046_X_OFFSET                  501
+  #define XPT2046_Y_OFFSET                  -9
+
+  #define TOUCH_CS_PIN                      PB7   // SPI1_NSS
+  #define TOUCH_SCK_PIN                     PA5   // SPI1_SCK
+  #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
+  #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
 #endif
 
 // SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -237,6 +237,7 @@
   #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
 
   #define TFT_DRIVER                        ILI9488
+  #define TFT_BUFFER_SIZE                   14400
 #endif
 
 // SPI1(PA7)=LCD & SPI3(PB5)=STUFF, are not available

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -167,10 +167,10 @@
   #define FSMC_DMA_DEV                      DMA2
   #define FSMC_DMA_CHANNEL               DMA_CH5
 
-  #define XPT2046_X_CALIBRATION             -17181
-  #define XPT2046_Y_CALIBRATION             11434
-  #define XPT2046_X_OFFSET                  501
-  #define XPT2046_Y_OFFSET                  -9
+  #define XPT2046_X_CALIBRATION           -17181
+  #define XPT2046_Y_CALIBRATION            11434
+  #define XPT2046_X_OFFSET                   501
+  #define XPT2046_Y_OFFSET                    -9
 
   #define TOUCH_CS_PIN                      PB7   // SPI1_NSS
   #define TOUCH_SCK_PIN                     PA5   // SPI1_SCK

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -177,6 +177,7 @@
   #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
   #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
 
+  #define TFT_DRIVER                        ILI9488
 #endif
 
 // SPI Flash

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -178,6 +178,7 @@
   #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
 
   #define TFT_DRIVER                        ILI9488
+  #define TFT_BUFFER_SIZE                   14400
 #endif
 
 // SPI Flash

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -156,6 +156,27 @@
       #define XPT2046_Y_OFFSET               -20
     #endif
   #endif
+
+#elif ENABLED(TFT_480x320)
+  #define TFT_RESET_PIN                     PF11
+  #define TFT_BACKLIGHT_PIN                 PD13
+
+  #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
+  #define FSMC_CS_PIN                       PD7
+  #define FSMC_RS_PIN                       PD11
+  #define FSMC_DMA_DEV                      DMA2
+  #define FSMC_DMA_CHANNEL               DMA_CH5
+
+  #define XPT2046_X_CALIBRATION             -17181
+  #define XPT2046_Y_CALIBRATION             11434
+  #define XPT2046_X_OFFSET                  501
+  #define XPT2046_Y_OFFSET                  -9
+
+  #define TOUCH_CS_PIN                      PB7   // SPI1_NSS
+  #define TOUCH_SCK_PIN                     PA5   // SPI1_SCK
+  #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
+  #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
+
 #endif
 
 // SPI Flash

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -225,10 +225,10 @@
   #define FSMC_DMA_DEV                      DMA2
   #define FSMC_DMA_CHANNEL               DMA_CH5
 
-  #define XPT2046_X_CALIBRATION             -17181
-  #define XPT2046_Y_CALIBRATION             11434
-  #define XPT2046_X_OFFSET                  501
-  #define XPT2046_Y_OFFSET                  -9
+  #define XPT2046_X_CALIBRATION           -17181
+  #define XPT2046_Y_CALIBRATION            11434
+  #define XPT2046_X_OFFSET                   501
+  #define XPT2046_Y_OFFSET                    -9
 
   #define TOUCH_CS_PIN                      PA7   // SPI2_NSS
   #define TOUCH_SCK_PIN                     PB13   // SPI2_SCK

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -236,6 +236,7 @@
   #define TOUCH_MOSI_PIN                    PB15   // SPI2_MOSI
 
   #define TFT_DRIVER                        ILI9488
+  #define TFT_BUFFER_SIZE                   14400
 #endif
 
 #define SPI_FLASH

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -235,6 +235,7 @@
   #define TOUCH_MISO_PIN                    PB14   // SPI2_MISO
   #define TOUCH_MOSI_PIN                    PB15   // SPI2_MOSI
 
+  #define TFT_DRIVER                        ILI9488
 #endif
 
 #define SPI_FLASH

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -215,6 +215,26 @@
     #define TOUCH_MOSI_PIN                  PB15  // SPI2_MOSI
   #endif
 
+#elif ENABLED(TFT_480x320)
+  #define TFT_RESET_PIN                     PC6
+  #define TFT_BACKLIGHT_PIN                 PD13
+
+  #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
+  #define FSMC_CS_PIN                       PD7
+  #define FSMC_RS_PIN                       PD11
+  #define FSMC_DMA_DEV                      DMA2
+  #define FSMC_DMA_CHANNEL               DMA_CH5
+
+  #define XPT2046_X_CALIBRATION             -17181
+  #define XPT2046_Y_CALIBRATION             11434
+  #define XPT2046_X_OFFSET                  501
+  #define XPT2046_Y_OFFSET                  -9
+
+  #define TOUCH_CS_PIN                      PA7   // SPI2_NSS
+  #define TOUCH_SCK_PIN                     PB13   // SPI2_SCK
+  #define TOUCH_MISO_PIN                    PB14   // SPI2_MISO
+  #define TOUCH_MOSI_PIN                    PB15   // SPI2_MOSI
+
 #endif
 
 #define SPI_FLASH


### PR DESCRIPTION
### Description

Democratization of Marlin UIs!!

This is a port of the new Marlin Color UI for STM32F1. Currently FSMC support.

Added support for Chitu and MKS Robin Nano v1.

I will send more two separated PR in the next days. One for SPI (is almost complete) and other that will centralize all TFT IO/XPT for STM32F1: All FSMC and SPI UI will use (LVGL, emulated dogm, color UI).

### Benefits

More users will be able to use the new Marlin Color UI.

### Related Issues

![IMG_9756](https://user-images.githubusercontent.com/81722/89700221-f1e99300-d902-11ea-8d9b-40e828d28172.jpg)


