### PR TITLE
Fix compiler search in non default PIO installs -  Fix #18959 

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -156,11 +156,11 @@ def search_compiler():
 	# Find the current platform compiler by searching the $PATH
 	if env['PLATFORM'] == 'win32':
 		path_separator = ';'
-		path_regex = r'platformio\\packages.*\\bin'
+		path_regex = re.escape(env['PROJECT_PACKAGES_DIR']) + r'.*\\bin'
 		gcc = "g++.exe"
 	else:
 		path_separator = ':'
-		path_regex = r'platformio/packages.*/bin'
+		path_regex = re.escape(env['PROJECT_PACKAGES_DIR']) + r'.*/bin'
 		gcc = "g++"
 
 	# Search for the compiler

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -165,7 +165,7 @@ def search_compiler():
 
 	# Search for the compiler
 	for path in env['ENV']['PATH'].split(path_separator):
-		if not re.search(path_regex, path):
+		if not re.search(path_regex, path, re.IGNORECASE):
 			continue
 		for file in os.listdir(path):
 			if not file.endswith(gcc):


### PR DESCRIPTION
### Description

Fix the search for the current gcc for non standard PIO installs

### Benefits

Less build broken
Fix #18959 

### Related Issues

#18959 
