### PR TITLE
Fix STATIC_ITEM bugs

### DIFF
--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -21,7 +21,7 @@
  */
 
 /**
- * power_loss_recovery.cpp - Resume an SD print after power-loss
+ * feature/powerloss.cpp - Resume an SD print after power-loss
  */
 
 #include "../inc/MarlinConfigPre.h"

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -22,7 +22,7 @@
 #pragma once
 
 /**
- * power_loss_recovery.h - Resume an SD print after power-loss
+ * feature/powerloss.h - Resume an SD print after power-loss
  */
 
 #include "../sd/cardreader.h"

--- a/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/ultralcd_HD44780.cpp
@@ -997,15 +997,17 @@ void MarlinUI::draw_status_screen() {
   #endif // ADVANCED_PAUSE_FEATURE
 
   // Draw a static item with no left-right margin required. Centered by default.
-  void MenuItem_static::draw(const uint8_t row, PGM_P const pstr, const uint8_t style/*=SS_DEFAULT*/, const char * const valstr/*=nullptr*/) {
+  void MenuItem_static::draw(const uint8_t row, PGM_P const pstr, const uint8_t style/*=SS_DEFAULT*/, const char * const vstr/*=nullptr*/) {
     int8_t n = LCD_WIDTH;
     lcd_moveto(0, row);
-    if ((style & SS_CENTER) && !valstr) {
-      int8_t pad = (LCD_WIDTH - utf8_strlen_P(pstr)) / 2;
+    const int8_t plen = pstr ? utf8_strlen_P(pstr) : 0,
+                 vlen = vstr ? utf8_strlen(vstr) : 0;
+    if (style & SS_CENTER) {
+      int8_t pad = (LCD_WIDTH - plen - vlen) / 2;
       while (--pad >= 0) { lcd_put_wchar(' '); n--; }
     }
-    n = lcd_put_u8str_ind_P(pstr, itemIndex, itemString, n);
-    if (valstr) n -= lcd_put_u8str_max(valstr, n);
+    if (plen) n = lcd_put_u8str_ind_P(pstr, itemIndex, itemString, n);
+    if (vlen) n -= lcd_put_u8str_max(vstr, n);
     for (; n > 0; --n) lcd_put_wchar(' ');
   }
 

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -347,20 +347,21 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
   }
 
   // Draw a static line of text in the same idiom as a menu item
-  void MenuItem_static::draw(const uint8_t row, PGM_P const pstr, const uint8_t style/*=SS_DEFAULT*/, const char * const valstr/*=nullptr*/) {
+  void MenuItem_static::draw(const uint8_t row, PGM_P const pstr, const uint8_t style/*=SS_DEFAULT*/, const char * const vstr/*=nullptr*/) {
 
     if (mark_as_selected(row, style & SS_INVERT)) {
 
       pixel_len_t n = LCD_PIXEL_WIDTH; // pixel width of string allowed
 
-      if ((style & SS_CENTER) && !valstr)
-        for (int8_t pad = (LCD_WIDTH - utf8_strlen_P(pstr)) / 2; pad > 0; --pad) {
-          lcd_put_wchar(' ');
-          n -= MENU_FONT_WIDTH;
-        }
+      const int8_t plen = pstr ? utf8_strlen_P(pstr) : 0,
+                   vlen = vstr ? utf8_strlen(vstr) : 0;
+      if (style & SS_CENTER) {
+        int8_t pad = (LCD_WIDTH - plen - vlen) / 2;
+        while (--pad >= 0) n -= lcd_put_wchar(' ');
+      }
 
-      n = lcd_put_u8str_ind_P(pstr, itemIndex, itemString, n / (MENU_FONT_WIDTH)) * (MENU_FONT_WIDTH);
-      if (valstr) n -= lcd_put_u8str_max(valstr, n);
+      if (plen) n = lcd_put_u8str_ind_P(pstr, itemIndex, itemString, n / (MENU_FONT_WIDTH)) * (MENU_FONT_WIDTH);
+      if (vlen) n -= lcd_put_u8str_max(vstr, n);
       while (n > MENU_FONT_WIDTH) n -= lcd_put_wchar(' ');
     }
   }

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -504,7 +504,7 @@ namespace Language_en {
   #if LCD_WIDTH >= 20
     PROGMEM Language_Str MSG_INFO_PRINT_COUNT              = _UxGT("Print Count");
     PROGMEM Language_Str MSG_INFO_COMPLETED_PRINTS         = _UxGT("Completed");
-    PROGMEM Language_Str MSG_INFO_PRINT_TIME               = _UxGT("Total Print time");
+    PROGMEM Language_Str MSG_INFO_PRINT_TIME               = _UxGT("Total Print Time");
     PROGMEM Language_Str MSG_INFO_PRINT_LONGEST            = _UxGT("Longest Job Time");
     PROGMEM Language_Str MSG_INFO_PRINT_FILAMENT           = _UxGT("Extruded Total");
   #else

--- a/Marlin/src/lcd/lcdprint.h
+++ b/Marlin/src/lcd/lcdprint.h
@@ -99,6 +99,7 @@
 
 #endif
 
+#define SETCURSOR_X(col) SETCURSOR(col, _lcdLineNr)
 #define START_OF_UTF8_CHAR(C) (((C) & 0xC0u) != 0x80u)
 
 int lcd_glyph_height();

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -83,7 +83,7 @@ class MenuItemBase {
 
 class MenuItem_static : public MenuItemBase {
   public:
-    static void draw(const uint8_t row, PGM_P const pstr, const uint8_t style=SS_DEFAULT, const char * const valstr=nullptr);
+    static void draw(const uint8_t row, PGM_P const pstr, const uint8_t style=SS_DEFAULT, const char * const vstr=nullptr);
 };
 
 // CONFIRM_ITEM(LABEL,Y,N,FY,FN,V...),
@@ -418,16 +418,17 @@ class MenuItem_bool : public MenuEditItemBase {
 }while(0)
 
 #define _MENU_ITEM_P(TYPE, V...) do { \
-  _skipStatic = false;                \
-  if (_menuLineNr == _thisItemNr)     \
+  if (_menuLineNr == _thisItemNr) {   \
+    _skipStatic = false;              \
     _MENU_INNER_P(TYPE, ##V);         \
+  }                                   \
   NEXT_ITEM();                        \
 }while(0)
 
 // Indexed items set a global index value and optional data
 #define _MENU_ITEM_N_S_P(TYPE, N, S, V...) do{ \
-  _skipStatic = false;                         \
   if (_menuLineNr == _thisItemNr) {            \
+    _skipStatic = false;                       \
     MenuItemBase::init(N, S);                  \
     _MENU_INNER_P(TYPE, ##V);                  \
   }                                            \
@@ -436,8 +437,8 @@ class MenuItem_bool : public MenuEditItemBase {
 
 // Indexed items set a global index value
 #define _MENU_ITEM_N_P(TYPE, N, V...) do{ \
-  _skipStatic = false;                    \
   if (_menuLineNr == _thisItemNr) {       \
+    _skipStatic = false;                  \
     MenuItemBase::itemIndex = N;          \
     _MENU_INNER_P(TYPE, ##V);             \
   }                                       \
@@ -446,8 +447,8 @@ class MenuItem_bool : public MenuEditItemBase {
 
 // Items with a unique string
 #define _MENU_ITEM_S_P(TYPE, S, V...) do{ \
-  _skipStatic = false;                    \
   if (_menuLineNr == _thisItemNr) {       \
+    _skipStatic = false;                  \
     MenuItemBase::itemString = S;         \
     _MENU_INNER_P(TYPE, ##V);             \
   }                                       \
@@ -550,16 +551,17 @@ class MenuItem_bool : public MenuEditItemBase {
 
 // Indexed items set a global index value and optional data
 #define _CONFIRM_ITEM_P(PLABEL, V...) do { \
-  _skipStatic = false;                     \
-  if (_menuLineNr == _thisItemNr)          \
+  if (_menuLineNr == _thisItemNr) {        \
+    _skipStatic = false;                   \
     _CONFIRM_ITEM_INNER_P(PLABEL, ##V);    \
+  }                                        \
   NEXT_ITEM();                             \
 }while(0)
 
 // Indexed items set a global index value
 #define _CONFIRM_ITEM_N_S_P(N, S, V...) do{ \
-  _skipStatic = false;                      \
   if (_menuLineNr == _thisItemNr) {         \
+    _skipStatic = false;                    \
     MenuItemBase::init(N, S);               \
     _CONFIRM_ITEM_INNER_P(TYPE, ##V);       \
   }                                         \

--- a/Marlin/src/lcd/menu/menu_addon.h
+++ b/Marlin/src/lcd/menu/menu_addon.h
@@ -25,6 +25,6 @@
 
 #define MENU_ITEM_ADDON_START(X) do{ \
   if (ui.should_draw() && _menuLineNr == _thisItemNr - 1) { \
-    SETCURSOR(X, _lcdLineNr)
+    SETCURSOR_X(X)
 
 #define MENU_ITEM_ADDON_END() } }while(0)

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -66,7 +66,7 @@ void menu_advanced_settings();
     bar_percent += (int8_t)ui.encoderPosition;
     LIMIT(bar_percent, 0, 100);
     ui.encoderPosition = 0;
-    MenuItem_static::draw(0, GET_TEXT(MSG_PROGRESS_BAR_TEST), SS_CENTER|SS_INVERT);
+    MenuItem_static::draw(0, GET_TEXT(MSG_PROGRESS_BAR_TEST), SS_DEFAULT|SS_INVERT);
     lcd_put_int((LCD_WIDTH) / 2 - 2, LCD_HEIGHT - 2, bar_percent); lcd_put_wchar('%');
     lcd_moveto(0, LCD_HEIGHT - 1); ui.draw_progress_bar(bar_percent);
   }
@@ -307,7 +307,7 @@ void menu_advanced_settings();
     #define MAXTEMP_ALL _MAX(REPEAT(HOTENDS, _MAXTEMP_ITEM) 0)
     const uint8_t m = MenuItemBase::itemIndex;
     START_MENU();
-    STATIC_ITEM_P(ui.get_preheat_label(m), SS_CENTER|SS_INVERT);
+    STATIC_ITEM_P(ui.get_preheat_label(m), SS_DEFAULT|SS_INVERT);
     BACK_ITEM(MSG_CONFIGURATION);
     #if HAS_FAN
       editable.uint8 = uint8_t(ui.material_preset[m].fan_speed);

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -87,7 +87,7 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
   _change_filament_mode = mode;
   _change_filament_extruder = extruder;
   START_MENU();
-  if (LCD_HEIGHT >= 4) STATIC_ITEM_P(change_filament_header(mode), SS_CENTER|SS_INVERT);
+  if (LCD_HEIGHT >= 4) STATIC_ITEM_P(change_filament_header(mode), SS_DEFAULT|SS_INVERT);
   BACK_ITEM(MSG_BACK);
   #if PREHEAT_COUNT
     LOOP_L_N(m, PREHEAT_COUNT)
@@ -266,7 +266,7 @@ void _lcd_pause_message(PGM_P const msg) {
              skip1 = !has2 && (LCD_HEIGHT) >= 5;
 
   START_SCREEN();
-  STATIC_ITEM_P(pause_header(), SS_CENTER|SS_INVERT);           // 1: Header
+  STATIC_ITEM_P(pause_header(), SS_DEFAULT|SS_INVERT);          // 1: Header
   if (skip1) SKIP_ITEM();                                       // Move a single-line message down
   STATIC_ITEM_P(msg1);                                          // 2: Message Line 1
   if (has2) STATIC_ITEM_P(msg2);                                // 3: Message Line 2

--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -205,7 +205,7 @@ void menu_info_board() {
   if (ui.use_click()) return ui.go_back();
 
   START_SCREEN();
-  STATIC_ITEM_P(PSTR(BOARD_INFO_NAME), SS_CENTER|SS_INVERT);       // MyPrinterController
+  STATIC_ITEM_P(PSTR(BOARD_INFO_NAME), SS_DEFAULT|SS_INVERT);      // MyPrinterController
   #ifdef BOARD_WEBSITE_URL
     STATIC_ITEM_P(PSTR(BOARD_WEBSITE_URL), SS_LEFT);               // www.my3dprinter.com
   #endif
@@ -237,7 +237,7 @@ void menu_info_board() {
   void menu_info_printer() {
     if (ui.use_click()) return ui.go_back();
     START_SCREEN();
-    STATIC_ITEM(MSG_MARLIN, SS_CENTER|SS_INVERT);               // Marlin
+    STATIC_ITEM(MSG_MARLIN, SS_DEFAULT|SS_INVERT);              // Marlin
     STATIC_ITEM_P(PSTR(SHORT_BUILD_VERSION));                   // x.x.x-Branch
     STATIC_ITEM_P(PSTR(STRING_DISTRIBUTION_DATE));              // YYYY-MM-DD HH:MM
     STATIC_ITEM_P(PSTR(MACHINE_NAME));                          // My3DPrinter

--- a/Marlin/src/lcd/menu/menu_led.cpp
+++ b/Marlin/src/lcd/menu/menu_led.cpp
@@ -37,7 +37,7 @@
     void menu_led_presets() {
       START_MENU();
       #if LCD_HEIGHT > 2
-        STATIC_ITEM(MSG_LED_PRESETS, SS_CENTER|SS_INVERT);
+        STATIC_ITEM(MSG_LED_PRESETS, SS_DEFAULT|SS_INVERT);
       #endif
       BACK_ITEM(MSG_LED_CONTROL);
       ACTION_ITEM(MSG_SET_LEDS_WHITE, leds.set_white);

--- a/Marlin/src/lcd/menu/menu_mmu2.cpp
+++ b/Marlin/src/lcd/menu/menu_mmu2.cpp
@@ -131,7 +131,7 @@ inline void action_mmu2_choose(const uint8_t tool) {
 void menu_mmu2_choose_filament() {
   START_MENU();
   #if LCD_HEIGHT > 2
-    STATIC_ITEM(MSG_MMU2_CHOOSE_FILAMENT_HEADER, SS_CENTER|SS_INVERT);
+    STATIC_ITEM(MSG_MMU2_CHOOSE_FILAMENT_HEADER, SS_DEFAULT|SS_INVERT);
   #endif
   LOOP_L_N(i, 5) ACTION_ITEM_N(i, MSG_MMU2_FILAMENT_N, []{ action_mmu2_choose(MenuItemBase::itemIndex); });
   END_MENU();
@@ -145,7 +145,7 @@ void menu_mmu2_pause() {
   currentTool = mmu2.get_current_tool();
   START_MENU();
   #if LCD_HEIGHT > 2
-    STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, SS_CENTER|SS_INVERT);
+    STATIC_ITEM(MSG_FILAMENT_CHANGE_HEADER, SS_DEFAULT|SS_INVERT);
   #endif
   ACTION_ITEM(MSG_MMU2_RESUME, []{ mmuMenuWait = false; });
   ACTION_ITEM(MSG_MMU2_UNLOAD_FILAMENT, []{ mmu2.unload(); });

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -178,12 +178,12 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
   START_MENU();
   if (LCD_HEIGHT >= 4) {
     switch (axis) {
-      case X_AXIS: STATIC_ITEM(MSG_MOVE_X, SS_CENTER|SS_INVERT); break;
-      case Y_AXIS: STATIC_ITEM(MSG_MOVE_Y, SS_CENTER|SS_INVERT); break;
-      case Z_AXIS: STATIC_ITEM(MSG_MOVE_Z, SS_CENTER|SS_INVERT); break;
+      case X_AXIS: STATIC_ITEM(MSG_MOVE_X, SS_DEFAULT|SS_INVERT); break;
+      case Y_AXIS: STATIC_ITEM(MSG_MOVE_Y, SS_DEFAULT|SS_INVERT); break;
+      case Z_AXIS: STATIC_ITEM(MSG_MOVE_Z, SS_DEFAULT|SS_INVERT); break;
       default:
         TERN_(MANUAL_E_MOVES_RELATIVE, manual_move_e_origin = current_position.e);
-        STATIC_ITEM(MSG_MOVE_E, SS_CENTER|SS_INVERT);
+        STATIC_ITEM(MSG_MOVE_E, SS_DEFAULT|SS_INVERT);
         break;
     }
   }

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -341,11 +341,11 @@ void MarlinUI::draw_status_screen() {
 }
 
 // Draw a static item with no left-right margin required. Centered by default.
-void MenuItem_static::draw(const uint8_t row, PGM_P const pstr, const uint8_t style/*=SS_DEFAULT*/, const char * const valstr/*=nullptr*/) {
+void MenuItem_static::draw(const uint8_t row, PGM_P const pstr, const uint8_t style/*=SS_DEFAULT*/, const char * const vstr/*=nullptr*/) {
   menu_item(row);
   tft_string.set(pstr, itemIndex, itemString);
-  if (valstr)
-    tft_string.add(valstr);
+  if (vstr)
+    tft_string.add(vstr);
   tft.add_text(tft_string.center(TFT_WIDTH), MENU_TEXT_Y_OFFSET, COLOR_YELLOW, tft_string);
 }
 

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -345,11 +345,11 @@ void MarlinUI::draw_status_screen() {
 }
 
 // Draw a static item with no left-right margin required. Centered by default.
-void MenuItem_static::draw(const uint8_t row, PGM_P const pstr, const uint8_t style/*=SS_DEFAULT*/, const char * const valstr/*=nullptr*/) {
+void MenuItem_static::draw(const uint8_t row, PGM_P const pstr, const uint8_t style/*=SS_DEFAULT*/, const char * const vstr/*=nullptr*/) {
   menu_item(row);
   tft_string.set(pstr, itemIndex, itemString);
-  if (valstr)
-    tft_string.add(valstr);
+  if (vstr)
+    tft_string.add(vstr);
   tft.add_text(tft_string.center(TFT_WIDTH), MENU_TEXT_Y_OFFSET, COLOR_YELLOW, tft_string);
 }
 


### PR DESCRIPTION
Fixes:
- second and subsequent static items failed to push the selection down
- incorrect centering of static items with an empty label and value

Also:
- Use `SS_DEFAULT` in place of `SS_CENTER` for headings