### PR TITLE
Fix Ender3V2 Dwin compile issues with manual mesh and host prompt

### DIFF
--- a/Marlin/src/lcd/dwin/dwin.cpp
+++ b/Marlin/src/lcd/dwin/dwin.cpp
@@ -53,6 +53,10 @@
 #include "../../module/motion.h"
 #include "../../module/planner.h"
 
+#if ENABLED(HOST_ACTION_COMMANDS)
+  #include "../../feature/host_actions.h"
+#endif
+
 #if HAS_LEVELING
   #include "../../feature/bedlevel/bedlevel.h"
 #endif
@@ -124,7 +128,7 @@ constexpr uint16_t TROWS = 6, MROWS = TROWS - 1,        // Total rows, and other
 
 #define MBASE(L) (49 + (L)*MLINE)
 
-#define BABY_Z_VAR TERN(HAS_LEVELING, probe.offset.z, zprobe_zoffset)
+#define BABY_Z_VAR TERN(HAS_BED_PROBE, probe.offset.z, zprobe_zoffset)
 
 /* Value Init */
 HMI_value_t HMI_ValueStruct;
@@ -1116,11 +1120,11 @@ void HMI_Zoffset(void) {
 
       if (HMI_ValueStruct.show_mode == -4) {
         checkkey = Prepare;
-        show_plus_or_minus(font8x16, Background_black, 2, 2, 202, MBASE(4 + MROWS - index_prepare), TERN(HAS_LEVELING, probe.offset.z * 100, HMI_ValueStruct.offset_value));
+        show_plus_or_minus(font8x16, Background_black, 2, 2, 202, MBASE(4 + MROWS - index_prepare), TERN(HAS_BED_PROBE, probe.offset.z * 100, HMI_ValueStruct.offset_value));
       }
       else {
         checkkey = Tune;
-        show_plus_or_minus(font8x16, Background_black, 2, 2, 202, MBASE(5 + MROWS - index_tune), TERN(HAS_LEVELING, probe.offset.z * 100, HMI_ValueStruct.offset_value));
+        show_plus_or_minus(font8x16, Background_black, 2, 2, 202, MBASE(5 + MROWS - index_tune), TERN(HAS_BED_PROBE, probe.offset.z * 100, HMI_ValueStruct.offset_value));
       }
       DWIN_UpdateLCD();
       return;
@@ -1484,7 +1488,7 @@ void update_variable(void) {
     DWIN_Draw_IntValue(true, true, 0, STAT_FONT, White, Background_black, 3, 33 + 2 * STAT_CHR_W, 429, feedrate_percentage);
     last_speed = feedrate_percentage;
   }
-  #if HAS_LEVELING
+  #if HAS_BED_PROBE
     if (last_probe_zoffset != probe.offset.z) {
       show_plus_or_minus(STAT_FONT, Background_black, 2, 2, 178 + STAT_CHR_W, 429, probe.offset.z * 100);
       last_probe_zoffset = probe.offset.z;
@@ -2188,7 +2192,7 @@ void HMI_Prepare(void) {
         Popup_Window_Home();
         break;
       case 4: // Z-offset
-        #if HAS_LEVELING
+        #if HAS_BED_PROBE
           checkkey = Homeoffset;
           HMI_ValueStruct.show_mode    = -4;
           HMI_ValueStruct.offset_value = probe.offset.z * 100;
@@ -3390,7 +3394,7 @@ void EachMomentUpdate(void) {
   else if (abort_flag && !HMI_flag.home_flag) { // Print Stop
     abort_flag = 0;
     HMI_ValueStruct.print_speed = feedrate_percentage = 100;
-    zprobe_zoffset = TERN(HAS_LEVELING, probe.offset.z, 0);
+    zprobe_zoffset = TERN(HAS_BED_PROBE, probe.offset.z, 0);
 
     planner.finish_and_disable();
 


### PR DESCRIPTION
Fix compile errors when manual mesh is used without a probe and host prompt to allow cancel message.