### PR TITLE
String interpolation for 2 digit numbers.

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -353,7 +353,7 @@
  *
  */
 #if ENABLED(NUMBER_TOOLS_FROM_0)
-  #define LCD_FIRST_TOOL '0'
+  #define LCD_FIRST_TOOL 0
   #define LCD_STR_N0 "0"
   #define LCD_STR_N1 "1"
   #define LCD_STR_N2 "2"
@@ -363,7 +363,7 @@
   #define LCD_STR_N6 "6"
   #define LCD_STR_N7 "7"
 #else
-  #define LCD_FIRST_TOOL '1'
+  #define LCD_FIRST_TOOL 1
   #define LCD_STR_N0 "1"
   #define LCD_STR_N1 "2"
   #define LCD_STR_N2 "3"

--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -44,22 +44,28 @@ lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const int8_t ind, PGM_P const i
     if (ch == '=' || ch == '~' || ch == '*') {
       if (ind >= 0) {
         if (ch == '*') { lcd_put_wchar('E'); n--; }
-        if (n) { lcd_put_wchar(ind + ((ch == '=') ? '0' : LCD_FIRST_TOOL)); n--; }
+        if (n) {
+          int8_t inum = ind + ((ch == '=') ? 0 : LCD_FIRST_TOOL);
+          if (inum >= 10) {
+            lcd_put_wchar('0' + (inum / 10)); n--;
+            inum %= 10;
+          }
+          if (n) { lcd_put_wchar('0' + inum); n--; }
+        }
       }
       else {
         PGM_P const b = ind == -2 ? GET_TEXT(MSG_CHAMBER) : GET_TEXT(MSG_BED);
         n -= lcd_put_u8str_max_P(b, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
       }
       if (n) n -= lcd_put_u8str_max_P((PGM_P)p, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
-      continue;
     }
     else if (ch == '$' && inStr) {
       n -= lcd_put_u8str_max_P(inStr, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
-      continue;
     }
-
-    lcd_put_wchar(ch);
-    n--;
+    else {
+      lcd_put_wchar(ch);
+      n--;
+    }
   }
   return n;
 }

--- a/Marlin/src/lcd/tft/tft_string.cpp
+++ b/Marlin/src/lcd/tft/tft_string.cpp
@@ -86,33 +86,32 @@ void TFT_String::set() {
 
 uint8_t read_byte(uint8_t *byte) { return *byte; }
 
-void TFT_String::add(uint8_t *string, uint8_t index, uint8_t *itemString) {
-  uint8_t character;
+void TFT_String::add(uint8_t *string, int8_t index, uint8_t *itemString) {
   wchar_t wchar;
 
   while (*string) {
     string = get_utf8_value_cb(string, read_byte, &wchar);
-    if (wchar > 255)
-      wchar |= 0x0080;
-    character = (uint8_t) (wchar & 0x00FF);
+    if (wchar > 255) wchar |= 0x0080;
+    uint8_t ch = uint8_t(wchar & 0x00FF);
 
-    if (character == '=' || character == '~' || character == '*') {
+    if (ch == '=' || ch == '~' || ch == '*') {
       if (index >= 0) {
-        if (character == '*')
-          add_character('E');
-        add_character(index + ((character == '=') ? '0' : LCD_FIRST_TOOL));
+        int8_t inum = index + ((ch == '=') ? 0 : LCD_FIRST_TOOL);
+        if (ch == '*') add_character('E');
+        if (inum >= 10) { add_character('0' + (inum / 10)); inum %= 10; }
+        add_character('0' + inum);
       }
       else {
         add(index == -2 ? GET_TEXT(MSG_CHAMBER) : GET_TEXT(MSG_BED));
       }
       continue;
     }
-    else if (character == '$' && itemString) {
+    else if (ch == '$' && itemString) {
       add(itemString);
       continue;
     }
 
-    add_character(character);
+    add_character(ch);
   }
   eol();
 }

--- a/Marlin/src/lcd/tft/tft_string.h
+++ b/Marlin/src/lcd/tft/tft_string.h
@@ -86,11 +86,11 @@ class TFT_String {
     static void set();
     static void add(uint8_t character) { add_character(character); eol(); }
     static void add(uint8_t *string) { while (*string) { add_character(*string++); } eol(); }
-    static void add(uint8_t *string, uint8_t index, uint8_t *itemString = NULL);
+    static void add(uint8_t *string, int8_t index, uint8_t *itemString = NULL);
     static void set(uint8_t *string) { set(); add(string); };
-    static void set(uint8_t *string, uint8_t index, const char *itemString = NULL) { set(); add(string, index, (uint8_t *)itemString); };
+    static void set(uint8_t *string, int8_t index, const char *itemString = NULL) { set(); add(string, index, (uint8_t *)itemString); };
     static inline void set(const char *string) { set((uint8_t *)string); }
-    static inline void set(const char *string, uint8_t index, const char *itemString = NULL) { set((uint8_t *)string, index, itemString); }
+    static inline void set(const char *string, int8_t index, const char *itemString = NULL) { set((uint8_t *)string, index, itemString); }
     static inline void add(const char *string) { add((uint8_t *)string); }
 
     static void trim(uint8_t character = 0x20);


### PR DESCRIPTION
String index interpolation only supports 1 digit. This PR extends this to 2 digits and fixes the TFT implementation of the same method so that it can display "Chamber" and "Bed" strings.

Closes #18932