### PR TITLE
Add ENDER2_STOCKDISPLAY support for BTT_SKR_V1_4 ( and Turbo) Board

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -263,16 +263,16 @@
      *                    EXP1
      */
 
-    #define BTN_EN1                 P1_18
-    #define BTN_EN2                 P1_20
-    #define BTN_ENC                 P0_28
+    #define BTN_EN1                        P1_18
+    #define BTN_EN2                        P1_20
+    #define BTN_ENC                        P0_28
 
-    #define DOGLCD_CS               P1_22
-    #define DOGLCD_A0               P1_21
-    #define DOGLCD_SCK              P1_30
-    #define DOGLCD_MOSI             P1_23
+    #define DOGLCD_CS                      P1_22
+    #define DOGLCD_A0                      P1_21
+    #define DOGLCD_SCK                     P1_30
+    #define DOGLCD_MOSI                    P1_23
     #define FORCE_SOFT_SPI
-    #define LCD_BACKLIGHT_PIN       -1
+    #define LCD_BACKLIGHT_PIN              -1
 
   #else
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -250,6 +250,30 @@
     #define LCD_PINS_ENABLE                P1_23
     #define LCD_PINS_D4                    P1_21
 
+  #elif ENABLED(ENDER2_STOCKDISPLAY)
+
+    /** Creality Ender-2 display pinout
+     *                   _____
+     *               5V | 1 2 | GND
+     *      (MOSI) 1.23 | 3 4 | 1.22 (LCD_RS)
+     *    (LCD_A0) 1.21 | 5 6 | 1.20 (BTN_EN2)
+     *       RESET 1.19 | 7 8 | 1.18 (BTN_EN1)
+     *   (BTN_ENC) 0.28 | 9 10| 1.30  (SCK)
+     *                   -----
+     *                    EXP1
+     */
+
+    #define BTN_EN1                 P1_18
+    #define BTN_EN2                 P1_20
+    #define BTN_ENC                 P0_28
+
+    #define DOGLCD_CS               P1_22
+    #define DOGLCD_A0               P1_21
+    #define DOGLCD_SCK              P1_30
+    #define DOGLCD_MOSI             P1_23
+    #define FORCE_SOFT_SPI
+    #define LCD_BACKLIGHT_PIN       -1
+
   #else
 
     #define BTN_ENC                        P0_28  // (58) open-drain


### PR DESCRIPTION
### Requirements

* Bigtreetech SKR board 1_4 
* Ender2 Display (MKS_MINI_12864 Variant)

### Description

Adds Support for Ender2 Stock display for bigtreetech skr 1_4 boards with LPC1708 and LPC1709 (Turbo) boards.
I've tested it with the Turbo board and it works fine.

### Benefits
- Adds Ender2 display support for the boards above

### Related Issues

found no related issue