### PR TITLE
tft: restore ILI9341 colors and reversed logic

### DIFF
--- a/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_320x240_upscale_from_128x64.cpp
@@ -366,7 +366,7 @@ static const uint16_t ili9328_init[] = {
 static const uint16_t ili9341_init[] = {
   ESC_REG(0x0010), ESC_DELAY(10),
   ESC_REG(0x0001), ESC_DELAY(200),
-  ESC_REG(0x0036), TERN(GRAPHICAL_TFT_ROTATE_180, 0x00E8, 0x0028),
+  ESC_REG(0x0036), TERN(GRAPHICAL_TFT_ROTATE_180, 0x0028, 0x00E8),
   ESC_REG(0x003A), 0x0055,
   ESC_REG(0x002A), 0x0000, 0x0000, 0x0001, 0x003F,
   ESC_REG(0x002B), 0x0000, 0x0000, 0x0000, 0x00EF,
@@ -658,6 +658,9 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
           setWindow = setWindow_ili9328;
           break;
         case 0x9341:   // ILI9341
+          WRITE_ESC_SEQUENCE(ili9341_init);
+          setWindow = setWindow_st7789v;
+          break;
         case 0x8066:   // Anycubic / TronXY TFTs (480x320)
           WRITE_ESC_SEQUENCE(ili9488_init);
           setWindow = setWindow_st7789v;

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -130,6 +130,12 @@
 #define DOGLCD_MOSI                         -1    // Prevent auto-define by Conditionals_post.h
 #define DOGLCD_SCK                          -1
 
+#define FSMC_UPSCALE                        2
+#define LCD_FULL_PIXEL_WIDTH                320
+#define LCD_FULL_PIXEL_HEIGHT               240
+#define LCD_PIXEL_OFFSET_X                  32
+#define LCD_PIXEL_OFFSET_Y                  32
+
 /**
  * Note: Alfawise U20/U30 boards DON'T use SPI2, as the hardware designer
  * mixed up MOSI and MISO pins. SPI is managed in SW, and needs pins

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -130,11 +130,11 @@
 #define DOGLCD_MOSI                         -1    // Prevent auto-define by Conditionals_post.h
 #define DOGLCD_SCK                          -1
 
-#define FSMC_UPSCALE                        2
-#define LCD_FULL_PIXEL_WIDTH                320
-#define LCD_FULL_PIXEL_HEIGHT               240
-#define LCD_PIXEL_OFFSET_X                  32
-#define LCD_PIXEL_OFFSET_Y                  32
+#define FSMC_UPSCALE                           2
+#define LCD_FULL_PIXEL_WIDTH                 320
+#define LCD_FULL_PIXEL_HEIGHT                240
+#define LCD_PIXEL_OFFSET_X                    32
+#define LCD_PIXEL_OFFSET_Y                    32
 
 /**
  * Note: Alfawise U20/U30 boards DON'T use SPI2, as the hardware designer


### PR DESCRIPTION
ILI9341 init code was recently changed to 9488 init (last 10 days)

This restore the right colors and the reversed display, like it was originally.

also, the X & Y offsets of the dogm UI are no more centered on 320x240 displays.... the dogm ui is touching the right border... 