### PR TITLE
[AVR] Let laser use some servo timers when they're not used

### DIFF
--- a/Marlin/src/HAL/AVR/ServoTimers.h
+++ b/Marlin/src/HAL/AVR/ServoTimers.h
@@ -60,9 +60,11 @@
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
   //#define _useTimer1
   #define _useTimer3
-  #define _useTimer4
-  #if !HAS_MOTOR_CURRENT_PWM
-    #define _useTimer5 // Timer 5 is used for motor current PWM and can't be used for servos.
+  #if NUM_SERVOS > SERVOS_PER_TIMER
+    #define _useTimer4
+    #if !HAS_MOTOR_CURRENT_PWM && SERVOS > 2 * SERVOS_PER_TIMER
+      #define _useTimer5 // Timer 5 is used for motor current PWM and can't be used for servos.
+    #endif
   #endif
 #elif defined(__AVR_ATmega32U4__)
   #define _useTimer3

--- a/Marlin/src/HAL/AVR/inc/SanityCheck.h
+++ b/Marlin/src/HAL/AVR/inc/SanityCheck.h
@@ -25,6 +25,8 @@
  * Test AVR-specific configuration values for errors at compile-time.
  */
 
+#include "../ServoTimers.h"   // Needed to properly check timer availability for laser spindle
+
 /**
  * Checks for FAST PWM
  */
@@ -38,7 +40,7 @@
 #if ENABLED(SPINDLE_LASER_PWM)
   #if SPINDLE_LASER_PWM_PIN == 4 || WITHIN(SPINDLE_LASER_PWM_PIN, 11, 13)
     #error "Counter/Timer for SPINDLE_LASER_PWM_PIN is used by a system interrupt."
-  #elif NUM_SERVOS > 0 && (WITHIN(SPINDLE_LASER_PWM_PIN, 2, 3) || SPINDLE_LASER_PWM_PIN == 5)
+  #elif NUM_SERVOS > 0 && defined(_useTimer3) && (WITHIN(SPINDLE_LASER_PWM_PIN, 2, 3) || SPINDLE_LASER_PWM_PIN == 5)
     #error "Counter/Timer for SPINDLE_LASER_PWM_PIN is used by the servo system."
   #endif
 #elif defined(SPINDLE_LASER_FREQUENCY)

--- a/Marlin/src/HAL/AVR/inc/SanityCheck.h
+++ b/Marlin/src/HAL/AVR/inc/SanityCheck.h
@@ -25,8 +25,6 @@
  * Test AVR-specific configuration values for errors at compile-time.
  */
 
-#include "../ServoTimers.h"   // Needed to properly check timer availability for laser spindle
-
 /**
  * Checks for FAST PWM
  */
@@ -38,6 +36,7 @@
  * Sanity checks for Spindle / Laser PWM
  */
 #if ENABLED(SPINDLE_LASER_PWM)
+  #include "../ServoTimers.h"   // Needed to check timer availability (_useTimer3)
   #if SPINDLE_LASER_PWM_PIN == 4 || WITHIN(SPINDLE_LASER_PWM_PIN, 11, 13)
     #error "Counter/Timer for SPINDLE_LASER_PWM_PIN is used by a system interrupt."
   #elif NUM_SERVOS > 0 && defined(_useTimer3) && (WITHIN(SPINDLE_LASER_PWM_PIN, 2, 3) || SPINDLE_LASER_PWM_PIN == 5)


### PR DESCRIPTION
Relax sanity check when, in some custom configurastions, servo timer is freed

Fix #18973