### PR TITLE
Default Filament Runout Sensor enabled state

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1178,6 +1178,7 @@
  */
 //#define FILAMENT_RUNOUT_SENSOR
 #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
   #define NUM_RUNOUT_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
   #define FIL_RUNOUT_STATE     LOW   // Pin state indicating that filament is NOT present.
   #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1179,10 +1179,10 @@
 //#define FILAMENT_RUNOUT_SENSOR
 #if ENABLED(FILAMENT_RUNOUT_SENSOR)
   #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
-  #define NUM_RUNOUT_SENSORS   1     // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
-  #define FIL_RUNOUT_STATE     LOW   // Pin state indicating that filament is NOT present.
-  #define FIL_RUNOUT_PULLUP          // Use internal pullup for filament runout pins.
-  //#define FIL_RUNOUT_PULLDOWN      // Use internal pulldown for filament runout pins.
+  #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
+  #define FIL_RUNOUT_STATE     LOW        // Pin state indicating that filament is NOT present.
+  #define FIL_RUNOUT_PULLUP               // Use internal pullup for filament runout pins.
+  //#define FIL_RUNOUT_PULLDOWN           // Use internal pulldown for filament runout pins.
 
   // Set one or more commands to execute on filament runout.
   // (After 'M412 H' Marlin will ask the host to handle the process.)

--- a/Marlin/src/feature/runout.cpp
+++ b/Marlin/src/feature/runout.cpp
@@ -44,14 +44,6 @@ bool FilamentMonitorBase::enabled = true,
   #include "../module/tool_change.h"
 #endif
 
-/**
- * Called by FilamentSensorSwitch::run when filament is detected.
- * Called by FilamentSensorEncoder::block_completed when motion is detected.
- */
-void FilamentSensorBase::filament_present(const uint8_t extruder) {
-  runout.filament_present(extruder); // calls response.filament_present(extruder)
-}
-
 #if HAS_FILAMENT_RUNOUT_DISTANCE
   float RunoutResponseDelayed::runout_distance_mm = FILAMENT_RUNOUT_DISTANCE_MM;
   volatile float RunoutResponseDelayed::runout_mm_countdown[EXTRUDERS];

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -48,6 +48,25 @@
 
 void event_filament_runout();
 
+class FilamentMonitorBase;
+class TFilamentMonitor;
+class FilamentSensorBase;
+class FilamentSensorEncoder;
+class FilamentSensorSwitch;
+class RunoutResponseDelayed;
+class RunoutResponseDebounced;
+
+/********************************* TEMPLATE SPECIALIZATION *********************************/
+
+typedef TFilamentMonitor<
+          TERN(HAS_FILAMENT_RUNOUT_DISTANCE, RunoutResponseDelayed, RunoutResponseDebounced),
+          TERN(FILAMENT_MOTION_SENSOR, FilamentSensorEncoder, FilamentSensorSwitch)
+        > FilamentMonitor;
+
+extern FilamentMonitor runout;
+
+/*******************************************************************************************/
+
 class FilamentMonitorBase {
   public:
     static bool enabled, filament_ran_out;
@@ -121,7 +140,13 @@ class TFilamentMonitor : public FilamentMonitorBase {
 
 class FilamentSensorBase {
   protected:
-    static void filament_present(const uint8_t extruder);
+    /**
+     * Called by FilamentSensorSwitch::run when filament is detected.
+     * Called by FilamentSensorEncoder::block_completed when motion is detected.
+     */
+    static inline void filament_present(const uint8_t extruder) {
+      runout.filament_present(extruder); // ...which calls response.filament_present(extruder)
+    }
 
   public:
     static inline void setup() {
@@ -311,12 +336,3 @@ class FilamentSensorBase {
   };
 
 #endif // !HAS_FILAMENT_RUNOUT_DISTANCE
-
-/********************************* TEMPLATE SPECIALIZATION *********************************/
-
-typedef TFilamentMonitor<
-          TERN(HAS_FILAMENT_RUNOUT_DISTANCE, RunoutResponseDelayed, RunoutResponseDebounced),
-          TERN(FILAMENT_MOTION_SENSOR, FilamentSensorEncoder, FilamentSensorSwitch)
-        > FilamentMonitor;
-
-extern FilamentMonitor runout;

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -46,6 +46,10 @@
   #define FILAMENT_RUNOUT_THRESHOLD 5
 #endif
 
+#ifndef FIL_RUNOUT_ENABLED_DEFAULT
+  #define FIL_RUNOUT_ENABLED_DEFAULT true
+#endif
+
 void event_filament_runout();
 
 template<class RESPONSE_T, class SENSOR_T>

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -48,9 +48,8 @@
 
 void event_filament_runout();
 
-class FilamentMonitorBase;
+template<class RESPONSE_T, class SENSOR_T>
 class TFilamentMonitor;
-class FilamentSensorBase;
 class FilamentSensorEncoder;
 class FilamentSensorSwitch;
 class RunoutResponseDelayed;

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -46,10 +46,6 @@
   #define FILAMENT_RUNOUT_THRESHOLD 5
 #endif
 
-#ifndef FIL_RUNOUT_ENABLED_DEFAULT
-  #define FIL_RUNOUT_ENABLED_DEFAULT true
-#endif
-
 void event_filament_runout();
 
 template<class RESPONSE_T, class SENSOR_T>

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -106,6 +106,9 @@
 
 #if HAS_FILAMENT_SENSOR
   #include "../feature/runout.h"
+  #ifndef FIL_RUNOUT_ENABLED_DEFAULT
+    #define FIL_RUNOUT_ENABLED_DEFAULT true
+  #endif
 #endif
 
 #if ENABLED(EXTRA_LIN_ADVANCE_K)

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -641,7 +641,7 @@ void MarlinSettings::postprocess() {
       #if HAS_FILAMENT_SENSOR
         const bool &runout_sensor_enabled = runout.enabled;
       #else
-        constexpr bool runout_sensor_enabled = true;
+        constexpr bool runout_sensor_enabled = false;
       #endif
       #if HAS_FILAMENT_RUNOUT_DISTANCE
         const float &runout_distance_mm = runout.runout_distance();
@@ -2469,7 +2469,7 @@ void MarlinSettings::reset() {
   //
 
   #if HAS_FILAMENT_SENSOR
-    runout.enabled = true;
+    runout.enabled = false;
     runout.reset();
     TERN_(HAS_FILAMENT_RUNOUT_DISTANCE, runout.set_runout_distance(FILAMENT_RUNOUT_DISTANCE_MM));
   #endif


### PR DESCRIPTION
### Requirements

When a binary is compiled without `FILAMENT_RUNOUT_SENSOR`, the structure in the EEPROM defaults to a value of 'true' - which maps back into `runout.enabled`. This means that if a firmware is loaded later that has `FILAMENT_RUNOUT_SENSOR` enabled as a build time option, the sensor is automatically enabled just because the build option was present.

This patch set the default to disabled when built without `FILAMENT_RUNOUT_SENSOR`, and upon a reset with `M502`, resets the value to false.

This allows firmware to be shipped with support for a filament runout sensor - but disabled by default - meaning an end user need only plug the sensor in, and then enable with `M412 S1`.

This is a more sane default than the inverse, which requires the user to turn the option off manually - or if a firmware is shipped, it needs to be shipped without `FILAMENT_RUNOUT_SENSOR` enabled and a second binary provided to enable the sensor.

From my understanding of how the defaults / settings part works, I believe these are the only two parts that require modification to achieve this goal.