### PR TITLE
Add CR10_STOCKDISPLAY checks to pins_CREALITY_V4.h 

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -134,6 +134,10 @@
 #define ONBOARD_SD_CS_PIN                   PA4   // SDSS
 #define SDIO_SUPPORT
 
+#if ENABLED(CR10_STOCKDISPLAY) && !EITHER(RET6_12864_LCD,VET6_12864_LCD)
+  #error "Please enable #define RET6_12864_LCD or #define VET6_12864_LCD to select the pins for a CR10_STOCKDISPLAY on this controller."
+#endif
+
 #if ENABLED(RET6_12864_LCD)
 
   /* RET6 12864 LCD */

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -134,8 +134,8 @@
 #define ONBOARD_SD_CS_PIN                   PA4   // SDSS
 #define SDIO_SUPPORT
 
-#if ENABLED(CR10_STOCKDISPLAY) && !EITHER(RET6_12864_LCD,VET6_12864_LCD)
-  #error "Please enable #define RET6_12864_LCD or #define VET6_12864_LCD to select the pins for a CR10_STOCKDISPLAY on this controller."
+#if ENABLED(CR10_STOCKDISPLAY) && NONE(RET6_12864_LCD, VET6_12864_LCD)
+  #error "Define RET6_12864_LCD or VET6_12864_LCD to select pins for CR10_STOCKDISPLAY with the Creality V4 controller."
 #endif
 
 #if ENABLED(RET6_12864_LCD)
@@ -150,6 +150,7 @@
   #define BTN_EN2                           PB14
 
   #define BEEPER_PIN                        PC6
+
 #elif ENABLED(VET6_12864_LCD)
 
   /* VET6 12864 LCD */


### PR DESCRIPTION
### Requirements

CREALITY_V4 controller with a CR10_STOCKDISPLAY display

### Description

Creality seems to have started shipping CREALITY_V4 for everyone. (as ender 3 silent board upgrades for eg) 
Those selecting CR10_STOCKDISPLAY get compile errors as they need an additional #define they are not aware of. 
either #define RET6_12864_LCD or #define VET6_12864_LCD is needed. Depending on MPU version board comes with 

### Benefits

Marlin now warns users they need to set one of these defines if they enable  CR10_STOCKDISPLAY on this controller.

### Related Issues
Seen this asked on discord and now issue #19015  