### PR TITLE
Fix IS_PROBE_PIN macro

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1622,7 +1622,7 @@
 //
 
 // Is an endstop plug used for extra Z endstops or the probe?
-#define IS_PROBE_PIN(A,M) (HAS_CUSTOM_PROBE_PIN && Z_MIN_PROBE_PIN == P)
+#define IS_PROBE_PIN(A,M) (HAS_CUSTOM_PROBE_PIN && Z_MIN_PROBE_PIN == A##_##M##_PIN)
 #define IS_X2_ENDSTOP(A,M) (ENABLED(X_DUAL_ENDSTOPS) && X2_USE_ENDSTOP == _##A##M##_)
 #define IS_Y2_ENDSTOP(A,M) (ENABLED(Y_DUAL_ENDSTOPS) && Y2_USE_ENDSTOP == _##A##M##_)
 #define IS_Z2_ENDSTOP(A,M) (ENABLED(Z_MULTI_ENDSTOPS) && Z2_USE_ENDSTOP == _##A##M##_)


### PR DESCRIPTION
### Requirements

`HAS_CUSTOM_PROBE_PIN` defined (`Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN` disabled)
(optional Sensorless Homing)

### Description

In Conditionals_post.h, the line
`#define IS_PROBE_PIN(A,M) (HAS_CUSTOM_PROBE_PIN && Z_MIN_PROBE_PIN == P)`
was not working as intended, because `(A,M)` (e.g. X, MIN) was given, but `P` was expected.

That lead to endstop flags as HAS_X_MIN not being defined, so the FW thinks that the endstop does not exist, which ultimately resulted in G28 bumping into the endstop (or, in my case, the machine frame, as I use sensorless homing).

The fix is to replace the line with
`#define IS_PROBE_PIN(A,M) (HAS_CUSTOM_PROBE_PIN && Z_MIN_PROBE_PIN == A##_##M##_PIN)`

### Benefits

Endstops are recognized / the bug is fixed.

### Related Issues

Personal investigation
