### PR TITLE
[AVR] Give timer4 priority over timer 3 (#19011 followup)

### DIFF
--- a/Marlin/src/HAL/AVR/ServoTimers.h
+++ b/Marlin/src/HAL/AVR/ServoTimers.h
@@ -59,9 +59,9 @@
 // Say which 16 bit timers can be used and in what order
 #if defined(__AVR_ATmega1280__) || defined(__AVR_ATmega2560__)
   //#define _useTimer1
-  #define _useTimer3
+  #define _useTimer4
   #if NUM_SERVOS > SERVOS_PER_TIMER
-    #define _useTimer4
+    #define _useTimer3
     #if !HAS_MOTOR_CURRENT_PWM && SERVOS > 2 * SERVOS_PER_TIMER
       #define _useTimer5 // Timer 5 is used for motor current PWM and can't be used for servos.
     #endif


### PR DESCRIPTION
timer 4 preference over timer 3, this is required to use spindle laser when servos are installed