### PR TITLE
TFT32 screen support on MKS Robin Nano 1.2 board

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -249,6 +249,36 @@
   #define TFT_DRIVER                        ILI9488
   #define TFT_BUFFER_SIZE                   14400
   #define ILI9488_ORIENTATION               ILI9488_MADCTL_MX | ILI9488_MADCTL_MV
+
+#elif ENABLED(TFT_320x240) //TFT32/28
+  #define TFT_RESET_PIN                     PC6
+  #define TFT_BACKLIGHT_PIN                 PD13
+
+  #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
+  #define FSMC_CS_PIN                       PD7
+  #define FSMC_RS_PIN                       PD11
+  #define FSMC_DMA_DEV                      DMA2
+  #define FSMC_DMA_CHANNEL               DMA_CH5
+
+  #define XPT2046_X_CALIBRATION           -12246
+  #define XPT2046_Y_CALIBRATION             9453
+  #define XPT2046_X_OFFSET                   360
+  #define XPT2046_Y_OFFSET                   -22
+
+  #define TOUCH_CS_PIN                      PA7   // SPI2_NSS
+  #define TOUCH_SCK_PIN                     PB13  // SPI2_SCK
+  #define TOUCH_MISO_PIN                    PB14  // SPI2_MISO
+  #define TOUCH_MOSI_PIN                    PB15  // SPI2_MOSI
+
+  #define TFT_DRIVER                     ILI9341
+  #define TFT_BUFFER_SIZE                  14400
+ 
+  // YV for normal screen mounting
+  //#define ILI9341_ORIENTATION  ILI9341_MADCTL_MY | ILI9341_MADCTL_MV
+  // XV for 180° rotated screen mounting
+  #define ILI9341_ORIENTATION  ILI9341_MADCTL_MX | ILI9341_MADCTL_MV
+
+  #define ILI9341_COLOR_RGB
 #endif
 
 #define HAS_SPI_FLASH                       1


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
MKS Robin Nano 1.2. Board can come with TFT32 screen based on ILI9341, for example on Flsun Q5 3d printer. This changes in pins_MKS_ROBIN_NANO.h file will make new style UI work with this board with TFT32 screen. It will work if `#define TFT_320x240` is selected in configutation.h and board type is  `#define MOTHERBOARD BOARD_MKS_ROBIN_NANO`
### Benefits

<!-- What does this fix or improve? -->
An ability to use sew style UI on MKS Robin Nano 1.2 Board with TFT32 screen (320x240 screen resolution).

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->