### PR TITLE
Fix build script for upcoming PIO 4.4

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: Install PlatformIO
       run: |
-        pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
+        pip install -U https://github.com/platformio/platformio-core/archive/master.zip
         platformio update
 
     - name: Check out the PR


### PR DESCRIPTION
### Description

CI are using PIO 4.4 and is breaking because a core class was removed. This PR updates the dependency script to work with both PIO versions.

I think this PR should be part of the upcoming 2.0.6.1, as PIO could release their new version anytime.

### Benefits

Fixes CI
Compatibility with PIO >= 4.4 and < 4.4

### Related Issues

#18699

