### PR TITLE
Use PIO-dev again on CI

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -106,7 +106,7 @@ jobs:
 
     - name: Install PlatformIO
       run: |
-        pip install -U https://github.com/platformio/platformio-core/archive/master.zip
+        pip install -U https://github.com/platformio/platformio-core/archive/develop.zip
         platformio update
 
     - name: Check out the PR


### PR DESCRIPTION
### Description

We need to be ready for the upcoming PIO release.


### Related Issues

#19041 
#19034

