### PR TITLE
Add Creality V4.2.7 controller. Issue #19029

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -313,7 +313,7 @@
 #define BOARD_CHITU3D_V5              4031  // Chitu3D TronXY X5SA V5 Board
 #define BOARD_CHITU3D_V6              4032  // Chitu3D TronXY X5SA V5 Board
 #define BOARD_CREALITY_V4             4033  // Creality v4.x (STM32F103RE)
-#define BOARD_CREALITY_V4_2_7         4034  // Creality v4.2.7 (STM32F103RE)
+#define BOARD_CREALITY_V427           4034  // Creality v4.2.7 (STM32F103RE)
 #define BOARD_TRIGORILLA_PRO          4035  // Trigorilla Pro (STM32F103ZET6)
 
 //

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -313,7 +313,8 @@
 #define BOARD_CHITU3D_V5              4031  // Chitu3D TronXY X5SA V5 Board
 #define BOARD_CHITU3D_V6              4032  // Chitu3D TronXY X5SA V5 Board
 #define BOARD_CREALITY_V4             4033  // Creality v4.x (STM32F103RE)
-#define BOARD_TRIGORILLA_PRO          4034  // Trigorilla Pro (STM32F103ZET6)
+#define BOARD_CREALITY_V4_2_7         4034  // Creality v4.2.7 (STM32F103RE)
+#define BOARD_TRIGORILLA_PRO          4035  // Trigorilla Pro (STM32F103ZET6)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -550,6 +550,8 @@
   #include "stm32f1/pins_CHITU3D_V6.h"          // STM32F1                                env:chitu_f103
 #elif MB(CREALITY_V4)
   #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality
+#elif MB(CREALITY_V4_2_7)
+  #include "stm32f1/pins_CREALITY_V4.2.7.h"     // STM32F1                                env:STM32F103RET6_creality
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -550,8 +550,8 @@
   #include "stm32f1/pins_CHITU3D_V6.h"          // STM32F1                                env:chitu_f103
 #elif MB(CREALITY_V4)
   #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality
-#elif MB(CREALITY_V4_2_7)
-  #include "stm32f1/pins_CREALITY_V4.2.7.h"     // STM32F1                                env:STM32F103RET6_creality
+#elif MB(CREALITY_V427)
+  #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro
 

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.2.7.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.2.7.h
@@ -29,9 +29,7 @@
 #endif
 
 #define BOARD_INFO_NAME      "CREALITY V4.2.7"
-#ifndef DEFAULT_MACHINE_NAME
-  #define DEFAULT_MACHINE_NAME "Ender 3"
-#endif
+#define DEFAULT_MACHINE_NAME "CREALITY"
 
 //
 // Steppers

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.2.7.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.2.7.h
@@ -1,0 +1,47 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * CREALITY V4.2.7 (STM32F103) board pin assignments
+ */
+
+#ifndef __STM32F1__
+  #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
+#endif
+
+#define BOARD_INFO_NAME      "CREALITY V4.2.7"
+#define DEFAULT_MACHINE_NAME "Ender 3"
+
+//
+// Steppers
+//
+#define X_STEP_PIN                          PB9
+#define X_DIR_PIN                           PC2
+#define Y_STEP_PIN                          PB7
+#define Y_DIR_PIN                           PB8
+#define Z_STEP_PIN                          PB5
+#define Z_DIR_PIN                           PB6
+#define E0_STEP_PIN                         PB3
+#define E0_DIR_PIN                          PB4
+
+#include "pins_CREALITY_V4.h"
+

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.2.7.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.2.7.h
@@ -29,7 +29,9 @@
 #endif
 
 #define BOARD_INFO_NAME      "CREALITY V4.2.7"
-#define DEFAULT_MACHINE_NAME "Ender 3"
+#ifndef DEFAULT_MACHINE_NAME
+  #define DEFAULT_MACHINE_NAME "Ender 3"
+#endif
 
 //
 // Steppers

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -32,8 +32,12 @@
   #error "CREALITY supports up to 1 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_INFO_NAME      "CREALITY V4"
-#define DEFAULT_MACHINE_NAME "Ender 3 V2"
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME      "CREALITY V4"
+#endif
+#ifndef DEFAULT_MACHINE_NAME
+  #define DEFAULT_MACHINE_NAME "Ender 3 V2"
+#endif
 
 //
 // EEPROM
@@ -90,20 +94,36 @@
 // Steppers
 //
 #define X_ENABLE_PIN                        PC3
-#define X_STEP_PIN                          PC2
-#define X_DIR_PIN                           PB9
+#ifndef X_STEP_PIN
+  #define X_STEP_PIN                        PC2
+#endif
+#ifndef X_DIR_PIN
+  #define X_DIR_PIN                         PB9
+#endif
 
 #define Y_ENABLE_PIN                        PC3
-#define Y_STEP_PIN                          PB8
-#define Y_DIR_PIN                           PB7
+#ifndef Y_STEP_PIN
+  #define Y_STEP_PIN                        PB8
+#endif
+#ifndef Y_DIR_PIN
+  #define Y_DIR_PIN                         PB7
+#endif
 
 #define Z_ENABLE_PIN                        PC3
-#define Z_STEP_PIN                          PB6
-#define Z_DIR_PIN                           PB5
+#ifndef Z_STEP_PIN
+  #define Z_STEP_PIN                        PB6
+#endif
+#ifndef Z_DIR_PIN
+  #define Z_DIR_PIN                         PB5
+#endif
 
 #define E0_ENABLE_PIN                       PC3
-#define E0_STEP_PIN                         PB4
-#define E0_DIR_PIN                          PB3
+#ifndef E0_STEP_PIN
+  #define E0_STEP_PIN                       PB4
+#endif
+#ifndef E0_DIR_PIN
+  #define E0_DIR_PIN                        PB3
+#endif
 
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -33,7 +33,7 @@
 #endif
 
 #ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME      "CREALITY V4"
+  #define BOARD_INFO_NAME      "Creality V4"
 #endif
 #ifndef DEFAULT_MACHINE_NAME
   #define DEFAULT_MACHINE_NAME "Ender 3 V2"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V427.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V427.h
@@ -21,15 +21,15 @@
  */
 
 /**
- * CREALITY V4.2.7 (STM32F103) board pin assignments
+ * CREALITY v4.2.7 (STM32F103) board pin assignments
  */
 
 #ifndef __STM32F1__
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #endif
 
-#define BOARD_INFO_NAME      "CREALITY V4.2.7"
-#define DEFAULT_MACHINE_NAME "CREALITY"
+#define BOARD_INFO_NAME      "Creality v4.2.7"
+#define DEFAULT_MACHINE_NAME "Creality3D"
 
 //
 // Steppers
@@ -37,11 +37,12 @@
 #define X_STEP_PIN                          PB9
 #define X_DIR_PIN                           PC2
 #define Y_STEP_PIN                          PB7
+
 #define Y_DIR_PIN                           PB8
 #define Z_STEP_PIN                          PB5
 #define Z_DIR_PIN                           PB6
+
 #define E0_STEP_PIN                         PB3
 #define E0_DIR_PIN                          PB4
 
 #include "pins_CREALITY_V4.h"
-


### PR DESCRIPTION
### Requirements

A Creality 32 bit motherboard V4.2.7   

### Description

The Creality 32 bit motherboard V4.2.7 is not compatible with the previous V4.2.2 
No Documentation from Creality at all.
With user provided Images and reverse engineering the creality provided firmware that was know to work. The differences have been identified. See Issue #19029 for full details.

### Benefits

Allows users with this new Controller to use Latest Marlin

### Related Issues
Issue #19029