### PR TITLE
Add DIGIPOT_I2C pin numbers to pins_SMOOTHIEBOARD.h

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -114,3 +114,22 @@
   #error "Marlin's Smoothieboard support cannot drive your LCD."
 
 #endif
+
+
+// I2C Digipots - MCP4451
+// Address 58 (2C << 1)
+// Set from 0 - 127 with stop bit.
+// (Ex. 3F << 1 | 1)
+//
+#define DIGIPOTS_I2C_SCL                      P0_0
+#define DIGIPOTS_I2C_SDA_X                    P0_04
+#define DIGIPOTS_I2C_SDA_Y                    P0_10
+#define DIGIPOTS_I2C_SDA_Z                    P0_19
+#define DIGIPOTS_I2C_SDA_E0                   P0_21
+#define DIGIPOTS_I2C_SDA_E1                   P4_29
+
+#ifndef DIGIPOT_I2C_ADDRESS_A
+  #define DIGIPOT_I2C_ADDRESS_A 0x2C              // unshifted slave address (58 <- 2C << 1)
+#endif
+
+

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -115,21 +115,19 @@
 
 #endif
 
-
-// I2C Digipots - MCP4451
-// Address 58 (2C << 1)
-// Set from 0 - 127 with stop bit.
-// (Ex. 3F << 1 | 1)
-//
-#define DIGIPOTS_I2C_SCL                      P0_0
-#define DIGIPOTS_I2C_SDA_X                    P0_04
-#define DIGIPOTS_I2C_SDA_Y                    P0_10
-#define DIGIPOTS_I2C_SDA_Z                    P0_19
-#define DIGIPOTS_I2C_SDA_E0                   P0_21
-#define DIGIPOTS_I2C_SDA_E1                   P4_29
+/**
+ * I2C Digipots - MCP4451
+ * Address 58 (2C << 1)
+ * Set from 0 - 127 with stop bit.
+ * (Ex. 3F << 1 | 1)
+ */
+#define DIGIPOTS_I2C_SCL                   P0_0
+#define DIGIPOTS_I2C_SDA_X                 P0_04
+#define DIGIPOTS_I2C_SDA_Y                 P0_10
+#define DIGIPOTS_I2C_SDA_Z                 P0_19
+#define DIGIPOTS_I2C_SDA_E0                P0_21
+#define DIGIPOTS_I2C_SDA_E1                P4_29
 
 #ifndef DIGIPOT_I2C_ADDRESS_A
-  #define DIGIPOT_I2C_ADDRESS_A 0x2C              // unshifted slave address (58 <- 2C << 1)
+  #define DIGIPOT_I2C_ADDRESS_A             0x2C  // unshifted slave address (58 <- 2C << 1)
 #endif
-
-


### PR DESCRIPTION
### Description

Added pins for DIGIPOTS control of motor current.

### Benefits

Adds current control for Smoothieboards

### Related Issues

http://smoothieware.github.io/Webif-pack/documentation/web/html/lpc1769-pin-usage.html