### PR TITLE
announce to all ports that sd printing is complete

### DIFF
--- a/Marlin/src/gcode/sd/M1001.cpp
+++ b/Marlin/src/gcode/sd/M1001.cpp
@@ -75,6 +75,7 @@ void GcodeSuite::M1001() {
   TERN_(POWER_LOSS_RECOVERY, recovery.purge());
 
   // Announce SD file completion
+  PORT_REDIRECT(SERIAL_BOTH);
   SERIAL_ECHOLNPGM(STR_FILE_PRINTED);
 
   // Update the status LED color

--- a/Marlin/src/gcode/sd/M1001.cpp
+++ b/Marlin/src/gcode/sd/M1001.cpp
@@ -75,8 +75,10 @@ void GcodeSuite::M1001() {
   TERN_(POWER_LOSS_RECOVERY, recovery.purge());
 
   // Announce SD file completion
-  PORT_REDIRECT(SERIAL_BOTH);
-  SERIAL_ECHOLNPGM(STR_FILE_PRINTED);
+  {
+    PORT_REDIRECT(SERIAL_BOTH);
+    SERIAL_ECHOLNPGM(STR_FILE_PRINTED);
+  }
 
   // Update the status LED color
   #if HAS_LEDS_OFF_FLAG


### PR DESCRIPTION
### Requirements


### Description
announce to all ports that sd printing is complete
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
* Avoid that the serial port device (Serial Port TouchScreen)  can not get the printing status correctly  by M23 / M24 / M27
<!-- What does this fix or improve? -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
