### PR TITLE
Fix compile error of M150 due to missing set_neo_index()

### DIFF
--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -73,6 +73,8 @@ public:
   static void set_color_startup(const uint32_t c);
 
   static void set_color(const uint32_t c);
+  
+  FORCE_INLINE static void set_neo_index(const int8_t neoIndex) { neoindex = neoIndex; }
 
   #ifdef NEOPIXEL_BKGD_LED_INDEX
     static void set_color_background();


### PR DESCRIPTION
This commit fixes the compile error introduced with c488070859c1995fe957938b1b6302c4eeef1ea3. M150.cpp depends on set_neo_index().

### Benefits

M150.cpp will compile again just fine


