### PR TITLE
fix M150 after c488070 broke it.

### DIFF
--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -50,7 +50,7 @@
  */
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-    neo.set_neo_index(parser.intval('I', -1));
+    neo.neoindex = parser.intval('I', -1);
   #endif
   leds.set_color(MakeLEDColor(
     parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,


### PR DESCRIPTION
This PR fixes the compile error introduced with c488070. M150.cpp depends on set_neo_index(). c488070 removed set_neo_index and made neoindex public.

Benefits
M150.cpp will compile again just fine