### PR TITLE
Fixes to FTDI Touch UI

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -120,7 +120,8 @@ bool MarlinUI::detected() { return true; }
         #if ENABLED(CUSTOM_BOOTSCREEN_ANIMATED)
           (u8g_pgm_uint8_t*)pgm_read_ptr(&custom_bootscreen_animation[frame])
         #else
-          custom_start_bmp
+          custom_start_bmp;
+          UNUSED(frame)
         #endif
       ;
       TERN(CUSTOM_BOOTSCREEN_ANIMATED,,UNUSED(frame));

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
@@ -91,9 +91,6 @@ namespace Language_en {
   PROGMEM Language_Str MSG_UNITS_STEP_MM            = u8"st/mm";
   PROGMEM Language_Str MSG_UNITS_PERCENT            = u8"%";
   PROGMEM Language_Str MSG_UNITS_C                  = DEGREE_SIGN u8"C";
-  PROGMEM Language_Str MSG_MATERIAL_PLA             = u8"PLA";
-  PROGMEM Language_Str MSG_MATERIAL_ABS             = u8"ABS";
-  PROGMEM Language_Str MSG_MATERIAL_HIGH_TEMP       = u8"High";
   PROGMEM Language_Str MSG_IDLE                     = u8"idle";
   PROGMEM Language_Str MSG_SET_MAXIMUM              = u8"Set Maximum";
   PROGMEM Language_Str MSG_PRINT_SPEED              = u8"Print Speed";

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -92,7 +92,7 @@ namespace ExtUI {
     char lcd_msg[30];
     sprintf_P(lcd_msg, PSTR("Extruder %d Filament Error"), extruder + 1);
     StatusScreen::setStatusMessage(lcd_msg);
-    InterfaceSoundsScreen::playEventSound(InterfaceSoundsScreen::PRINTING_FAILED);
+    InterfaceSoundsScreen::playEventSound(InterfaceSoundsScreen::PRINTING_FAILED, FTDI::PLAY_SYNCHRONOUS);
   }
 
   void onFactoryReset() {

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/about_screen.cpp
@@ -80,6 +80,7 @@ void AboutScreen::onRedraw(draw_mode_t) {
     #endif
     , OPT_CENTER, font_xlarge
   );
+  cmd.tag(3);
   draw_text_box(cmd, FW_VERS_POS,
   #ifdef TOUCH_UI_VERSION
     F(TOUCH_UI_VERSION)
@@ -87,6 +88,7 @@ void AboutScreen::onRedraw(draw_mode_t) {
     progmem_str(getFirmwareName_str())
   #endif
   , OPT_CENTER, font_medium);
+  cmd.tag(0);
   draw_text_box(cmd, FW_INFO_POS, about_str, OPT_CENTER, font_medium);
   draw_text_box(cmd, INSET_POS(LICENSE_POS), GET_TEXT_F(MSG_LICENSE), OPT_CENTER, font_tiny);
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_printing_dialog_box.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_printing_dialog_box.cpp
@@ -103,7 +103,7 @@ bool BioPrintingDialogBox::onTouchEnd(uint8_t tag) {
     case 2: GOTO_SCREEN(TuneMenu); break;
     case 3:
       if (isPrinting())
-        GOTO_SCREEN(ConfirmAbortPrintDialogBox);
+        GOTO_SCREEN(ConfirmAbortPrintDialogBox)
       else
         GOTO_SCREEN(StatusScreen);
       break;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/change_filament_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/change_filament_screen.cpp
@@ -207,13 +207,13 @@ void ChangeFilamentScreen::onRedraw(draw_mode_t what) {
     {
       char str[30];
 
-      format_temp_and_material(str, LOW_TEMP, GET_TEXT(MSG_MATERIAL_PLA));
+      format_temp(str, LOW_TEMP);
       cmd.tag(2) .TOG_STYLE(tog2) .button (BTN_POS(2,6), BTN_SIZE(1,1), str);
 
-      format_temp_and_material(str, MED_TEMP, GET_TEXT(MSG_MATERIAL_ABS));
+      format_temp(str, MED_TEMP);
       cmd.tag(3) .TOG_STYLE(tog3) .button (BTN_POS(2,5), BTN_SIZE(1,1), str);
 
-      format_temp_and_material(str, HIGH_TEMP, GET_TEXT(MSG_MATERIAL_HIGH_TEMP));
+      format_temp(str, HIGH_TEMP);
       cmd.tag(4) .TOG_STYLE(tog4) .button (BTN_POS(2,4), BTN_SIZE(1,1), str);
     }
     cmd.colors(normal_btn)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_auto_calibration_dialog_box.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_auto_calibration_dialog_box.cpp
@@ -38,7 +38,7 @@ bool ConfirmAutoCalibrationDialogBox::onTouchEnd(uint8_t tag) {
   switch (tag) {
     case 1:
       GOTO_SCREEN(StatusScreen);
-      injectCommands_P(PSTR(CALIBRATION_COMMANDS));
+      injectCommands_P(PSTR("G425"));
       return true;
     default:
       return DialogBoxBaseClass::onTouchEnd(tag);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/status_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/status_screen.cpp
@@ -97,7 +97,7 @@ void StatusScreen::draw_axis_position(draw_mode_t what) {
       strcpy_P(y_str, PSTR("?"));
 
     if (isAxisPositionKnown(Z))
-      format_position(z_str, getAxisPosition_mm(Z));
+      format_position(z_str, getAxisPosition_mm(Z), 2);
     else
       strcpy_P(z_str, PSTR("?"));
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/string_format.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/string_format.cpp
@@ -61,8 +61,8 @@ void format_temp_and_material(char *str, float t1, const char *material) {
 /**
  * Formats a position value (e.g. "10 mm")
  */
-void format_position(char *str, float p) {
-  dtostrf(p, 5, 1, str);
+void format_position(char *str, float p, uint8_t decimals) {
+  dtostrf(p, 4 + decimals, decimals, str);
   strcat_P(str, PSTR(" "));
   strcat_P(str, GET_TEXT(MSG_UNITS_MM));
 }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/string_format.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/string_format.h
@@ -25,5 +25,5 @@ void format_temp(char *str, float t1);
 void format_temp_and_idle(char *str, float t1);
 void format_temp_and_temp(char *str, float t1, float t2);
 void format_temp_and_material(char *str, float t1, const char *material);
-void format_position(char *str, float p);
+void format_position(char *str, float p, uint8_t decimals = 1);
 void format_position(char *str, float x, float y, float z);

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -647,7 +647,11 @@ namespace Language_en {
 
   PROGMEM Language_Str MSG_LEVEL_X_AXIS                    = _UxGT("Level X Axis");
   PROGMEM Language_Str MSG_AUTO_CALIBRATE                  = _UxGT("Auto Calibrate");
+  #if ENABLED(TOUCH_UI_FTDI_EVE)
+  PROGMEM Language_Str MSG_HEATER_TIMEOUT                  = _UxGT("Idle timeout, temperature decreased. Press Okay to reheat and again to resume.");
+  #else
   PROGMEM Language_Str MSG_HEATER_TIMEOUT                  = _UxGT("Heater Timeout");
+  #endif
   PROGMEM Language_Str MSG_REHEAT                          = _UxGT("Reheat");
   PROGMEM Language_Str MSG_REHEATING                       = _UxGT("Reheating...");
 }


### PR DESCRIPTION
### Description

- Fix unused variable warning
- Fix for filament runout sound
- Fix for developer menu access
- Fix compilation error when using CALIBRATION_GCODE
- Remove material labels in change filament screen
- Add decimals to status screen Z coordinate
- Add more descriptive message on heater timeout
