### PR TITLE
Add Einsy Rambo filament runout pin

### DIFF
--- a/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
@@ -81,6 +81,13 @@
 #endif
 
 //
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                      62
+#endif
+
+//
 // Steppers
 //
 #define X_STEP_PIN                            37


### PR DESCRIPTION
### Requirements

`BOARD_EINSY_RAMBO`/Stock Prusa MK3S build

### Description

Add filament runout pin.

### Benefits

Allows the use of Prusa's stock MK3S filament runout sensor without needing to modify the pins file.

Expect a stock Prusa MK3S config in the Configurations repo soon 🙂

### Related Issues

None.
