### PR TITLE
public member access

### DIFF
--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -50,7 +50,7 @@
  */
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-    neo.set_neo_index(parser.intval('I', -1));
+    neo.neoindex = parser.intval('I', -1);
   #endif
   leds.set_color(MakeLEDColor(
     parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,


### PR DESCRIPTION
### Description
  Missing function member **set_neo_index**, When compile with NEOPIXEL_LED enable on my meeb3dp board see picture below. I found 
 that **set_neo_index** and **get_neo_index** are deleted and **neoindex** member move to public access in the neopixel class define.
So, use neo.neoindex public access to set the index to make M150 work.
![19FC6D12-A2A7-41c2-874C-6B6567B172E3](https://user-images.githubusercontent.com/4132539/91167217-25e7f500-e706-11ea-8c5f-e62b3bd6963b.png)


### Benefits



### Related Issues


