### PR TITLE
SINGLENOZZLE part fan fix when not using STANDBY

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -210,6 +210,8 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
         if (target < EXTRUDERS) singlenozzle_fan_speed[target] = speed;
         return;
       }
+    #endif
+    #if ENABLED(SINGLENOZZLE)
       target = 0; // Always use fan index 0 with SINGLENOZZLE
     #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -211,9 +211,8 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
         return;
       }
     #endif
-    #if ENABLED(SINGLENOZZLE)
-      target = 0; // Always use fan index 0 with SINGLENOZZLE
-    #endif
+
+    TERN_(SINGLENOZZLE, target = 0); // Always use fan index 0 with SINGLENOZZLE
 
     if (target >= FAN_COUNT) return;
 


### PR DESCRIPTION
### Description
Pull request  https://github.com/MarlinFirmware/Marlin/pull/17712 added improvements to SINGLENOZZLE behavior; however when not using the new flags it appears to have broken the part cooling fan behavior. See Issue #18142 

### Benefits

This change reinstates the use of Fan 0 regardless of tool in use when using the SINGLENOZZLE option for multiple extruders.

_note: I'm not sure I completely understand everything the referenced prior pull did, but I know that it borked my configuration, and this change fixes it._

### Related Issues

Fixes issue #18142