### PR TITLE
Fix blue in NEOPIXEL_STARTUP_TEST

### DIFF
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -89,6 +89,7 @@ void Marlin_NeoPixel::init() {
     set_color_startup(adaneo1.Color(0, 255, 0, 0));  // green
     safe_delay(500);
     set_color_startup(adaneo1.Color(0, 0, 255, 0));  // blue
+    safe_delay(500);
   #endif
 
   #ifdef NEOPIXEL_BKGD_LED_INDEX


### PR DESCRIPTION
### Requirements

A number of NeoPixel LEDS, and enable NEOPIXEL_STARTUP_TEST

### Description

Currently the RGB test at startup only displays Red and Green, Blue is missing.
The cause, Blue is being setup but is immediately being followed by setting a new colour; 
The setting a new colour is part of the LED_USER_PRESET_STARTUP block. it either sets the neopixels to the preset colour, or all neopixels off. In either case BLUE is overridden.

Added a simple delay so blue can be seen. 

### Benefits

NEOPIXEL_STARTUP_TEST works as expected.

### Related Issues

Noticed this while looking into https://github.com/MarlinFirmware/Marlin/issues/19154
