### PR TITLE
New options for autotemp

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1035,7 +1035,7 @@
 #define Z_PROBE_OFFSET_RANGE_MIN -20
 #define Z_PROBE_OFFSET_RANGE_MAX 20
 
-// Enable the M48 repeatability test to test probe accuracy
+// Enable the M48 repeatability test to test probe accuracy. May consume a large amount of PROGMEM.
 //#define Z_MIN_PROBE_REPEATABILITY_TEST
 
 // Before deploy/stow pause for user confirmation
@@ -1260,7 +1260,7 @@
   #define LEVELED_SEGMENT_LENGTH 5.0 // (mm) Length of all segments (except the last one)
 
   /**
-   * Enable the G26 Mesh Validation Pattern tool.
+   * Enable the G26 Mesh Validation Pattern tool. May consume a large amount of PROGMEM.
    */
   //#define G26_MESH_VALIDATION
   #if ENABLED(G26_MESH_VALIDATION)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -287,17 +287,29 @@
  * Enable Autotemp Mode with M104/M109 F<factor> S<mintemp> B<maxtemp>.
  * Disable by sending M104/M109 with no F parameter (or F0 with AUTOTEMP_PROPORTIONAL).
  *
+ * AUTOTEMP_GRANULARITY makes autotemp calculate the target temperature in increments
+ * of this many degrees. The calculated target may exceed the maximum temperature, if
+ * the temperature range doesn't fit in whole increments.
+ *
+ * AUTOTEMP_MIN_Z_RAISE ensures that the target temperature will only be recalculated
+ * when Z is raised, ie, on layer changes. Ensure BLOCK_BUFFER_SIZE is large enough,
+ * because that's how many moves autotemp will be able to look at to calculate the
+ * target temperature for the entire layer(s) ahead. You may also want to configure
+ * your slicer to output features with high volumetric rate first, like infill.
+ *
  * With AUTOTEMP_FACTORLESS, target temperature will scale evenly across a range of
  * extruder speeds set with M104/M109 S<mintemp> B<maxtemp> N<minespeed> M<maxespeed>.
  * Extruder speeds can be calculated from a slicer's volumetric extrusion rate preview
  * in mm^3/s. This option is incompatible with AUTOTEMP_PROPORTIONAL. Setting minimum
  * or maximum temperature to 0 or both speeds to the same value disables autotemp.
+ *
  */
 #define AUTOTEMP
 #if ENABLED(AUTOTEMP)
   #define AUTOTEMP_OLDWEIGHT      0.98
-  //#define AUTOTEMP_GRANULARITY 10.0  // Target temperature will be calculated in increments of this many degrees
-  //#define AUTOTEMP_MIN_Z_RAISE  0.08 // To ensure temperature is only calculated at the beginning of a new layer
+  //#define AUTOTEMP_GRANULARITY  10.0
+  //#define AUTOTEMP_MIN_Z_RAISE  0.08
+  //#define AUTOTEMP_FACTORLESS
   // Turn on AUTOTEMP on M104/M109 by default using proportions set here
   //#define AUTOTEMP_PROPORTIONAL
   #if ENABLED(AUTOTEMP_PROPORTIONAL)
@@ -305,7 +317,7 @@
     #define AUTOTEMP_MAX_P      5 // (°C) Added to the target temperature
     #define AUTOTEMP_FACTOR_P   1 // Apply this F parameter by default (overridden by M104/M109 F)
   #endif
-  //#define AUTOTEMP_FACTORLESS
+  //#define AUTOTEMP_DEBUG // outputs info to serial when calculating target temperature
 #endif
 
 // Show Temperature ADC value

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -286,10 +286,18 @@
  *
  * Enable Autotemp Mode with M104/M109 F<factor> S<mintemp> B<maxtemp>.
  * Disable by sending M104/M109 with no F parameter (or F0 with AUTOTEMP_PROPORTIONAL).
+ *
+ * With AUTOTEMP_FACTORLESS, target temperature will scale evenly across a range of
+ * extruder speeds set with M104/M109 S<mintemp> B<maxtemp> N<minespeed> M<maxespeed>.
+ * Extruder speeds can be calculated from a slicer's volumetric extrusion rate preview
+ * in mm^3/s. This option is incompatible with AUTOTEMP_PROPORTIONAL. Setting minimum
+ * or maximum temperature to 0 or both speeds to the same value disables autotemp.
  */
 #define AUTOTEMP
 #if ENABLED(AUTOTEMP)
-  #define AUTOTEMP_OLDWEIGHT    0.98
+  #define AUTOTEMP_OLDWEIGHT      0.98
+  //#define AUTOTEMP_GRANULARITY 10.0  // Target temperature will be calculated in increments of this many degrees
+  //#define AUTOTEMP_MIN_Z_RAISE  0.08 // To ensure temperature is only calculated at the beginning of a new layer
   // Turn on AUTOTEMP on M104/M109 by default using proportions set here
   //#define AUTOTEMP_PROPORTIONAL
   #if ENABLED(AUTOTEMP_PROPORTIONAL)
@@ -297,6 +305,7 @@
     #define AUTOTEMP_MAX_P      5 // (°C) Added to the target temperature
     #define AUTOTEMP_FACTOR_P   1 // Apply this F parameter by default (overridden by M104/M109 F)
   #endif
+  //#define AUTOTEMP_FACTORLESS
 #endif
 
 // Show Temperature ADC value

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3051,5 +3051,12 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
   #error "ESP3D_WIFISUPPORT or WIFISUPPORT requires an ESP32 controller."
 #endif
 
+/**
+ * Sanity check for autotemp
+ */
+#if BOTH(AUTOTEMP_PROPORTIONAL, AUTOTEMP_FACTORLESS)
+  #error "AUTOTEMP_FACTORLESS is incompatible with AUTOTEMP_PROPORTIONAL."
+#endif
+
 // Misc. Cleanup
 #undef _TEST_PWM

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -263,8 +263,8 @@ namespace Language_en {
   PROGMEM Language_Str MSG_MIN                             = " " LCD_STR_THERMOMETER _UxGT(" Min");
   PROGMEM Language_Str MSG_MAX                             = " " LCD_STR_THERMOMETER _UxGT(" Max");
   PROGMEM Language_Str MSG_FACTOR                          = " " LCD_STR_THERMOMETER _UxGT(" Fact");
-  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Min e-speed");
-  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Max e-speed");
+  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Min E speed");
+  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Max E speed");
   PROGMEM Language_Str MSG_AUTOTEMP                        = _UxGT("Autotemp");
   PROGMEM Language_Str MSG_LCD_ON                          = _UxGT("On");
   PROGMEM Language_Str MSG_LCD_OFF                         = _UxGT("Off");

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -263,6 +263,8 @@ namespace Language_en {
   PROGMEM Language_Str MSG_MIN                             = " " LCD_STR_THERMOMETER _UxGT(" Min");
   PROGMEM Language_Str MSG_MAX                             = " " LCD_STR_THERMOMETER _UxGT(" Max");
   PROGMEM Language_Str MSG_FACTOR                          = " " LCD_STR_THERMOMETER _UxGT(" Fact");
+  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Min e-speed");
+  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Max e-speed");
   PROGMEM Language_Str MSG_AUTOTEMP                        = _UxGT("Autotemp");
   PROGMEM Language_Str MSG_LCD_ON                          = _UxGT("On");
   PROGMEM Language_Str MSG_LCD_OFF                         = _UxGT("Off");

--- a/Marlin/src/lcd/language/language_es.h
+++ b/Marlin/src/lcd/language/language_es.h
@@ -259,8 +259,8 @@ namespace Language_es {
   PROGMEM Language_Str MSG_MIN                             = " " LCD_STR_THERMOMETER _UxGT(" Min");
   PROGMEM Language_Str MSG_MAX                             = " " LCD_STR_THERMOMETER _UxGT(" Max");
   PROGMEM Language_Str MSG_FACTOR                          = " " LCD_STR_THERMOMETER _UxGT(" Factor");
-  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidad min e");
-  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidad Max e");
+  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidad min E");
+  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidad max E");
   PROGMEM Language_Str MSG_AUTOTEMP                        = _UxGT("Temp. Autom.");
   PROGMEM Language_Str MSG_LCD_ON                          = _UxGT("Enc");
   PROGMEM Language_Str MSG_LCD_OFF                         = _UxGT("Apg");

--- a/Marlin/src/lcd/language/language_es.h
+++ b/Marlin/src/lcd/language/language_es.h
@@ -259,6 +259,8 @@ namespace Language_es {
   PROGMEM Language_Str MSG_MIN                             = " " LCD_STR_THERMOMETER _UxGT(" Min");
   PROGMEM Language_Str MSG_MAX                             = " " LCD_STR_THERMOMETER _UxGT(" Max");
   PROGMEM Language_Str MSG_FACTOR                          = " " LCD_STR_THERMOMETER _UxGT(" Factor");
+  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidad min e");
+  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidad Max e");
   PROGMEM Language_Str MSG_AUTOTEMP                        = _UxGT("Temp. Autom.");
   PROGMEM Language_Str MSG_LCD_ON                          = _UxGT("Enc");
   PROGMEM Language_Str MSG_LCD_OFF                         = _UxGT("Apg");

--- a/Marlin/src/lcd/language/language_pt.h
+++ b/Marlin/src/lcd/language/language_pt.h
@@ -99,8 +99,8 @@ namespace Language_pt {
   PROGMEM Language_Str MSG_MIN                             = " " LCD_STR_THERMOMETER _UxGT(" Min");
   PROGMEM Language_Str MSG_MAX                             = " " LCD_STR_THERMOMETER _UxGT(" Max");
   PROGMEM Language_Str MSG_FACTOR                          = " " LCD_STR_THERMOMETER _UxGT(" Fact");
-  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade min e");
-  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade max e");
+  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade min E");
+  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade max E");
   PROGMEM Language_Str MSG_A_RETRACT                       = _UxGT("A-retracção");
   PROGMEM Language_Str MSG_A_TRAVEL                        = _UxGT("A-movimento");
   PROGMEM Language_Str MSG_STEPS_PER_MM                    = _UxGT("Passo/mm");

--- a/Marlin/src/lcd/language/language_pt.h
+++ b/Marlin/src/lcd/language/language_pt.h
@@ -99,6 +99,8 @@ namespace Language_pt {
   PROGMEM Language_Str MSG_MIN                             = " " LCD_STR_THERMOMETER _UxGT(" Min");
   PROGMEM Language_Str MSG_MAX                             = " " LCD_STR_THERMOMETER _UxGT(" Max");
   PROGMEM Language_Str MSG_FACTOR                          = " " LCD_STR_THERMOMETER _UxGT(" Fact");
+  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade min e");
+  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade max e");
   PROGMEM Language_Str MSG_A_RETRACT                       = _UxGT("A-retracção");
   PROGMEM Language_Str MSG_A_TRAVEL                        = _UxGT("A-movimento");
   PROGMEM Language_Str MSG_STEPS_PER_MM                    = _UxGT("Passo/mm");

--- a/Marlin/src/lcd/language/language_pt_br.h
+++ b/Marlin/src/lcd/language/language_pt_br.h
@@ -234,6 +234,8 @@ namespace Language_pt_br {
   PROGMEM Language_Str MSG_MIN                             = " " LCD_STR_THERMOMETER _UxGT(" Min");
   PROGMEM Language_Str MSG_MAX                             = " " LCD_STR_THERMOMETER _UxGT(" Máx");
   PROGMEM Language_Str MSG_FACTOR                          = " " LCD_STR_THERMOMETER _UxGT(" Fator");
+  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade min e");
+  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade máx e");
   PROGMEM Language_Str MSG_AUTOTEMP                        = _UxGT("Temp. Automática");
   PROGMEM Language_Str MSG_LCD_ON                          = _UxGT("Ligado");
   PROGMEM Language_Str MSG_LCD_OFF                         = _UxGT("Desligado");

--- a/Marlin/src/lcd/language/language_pt_br.h
+++ b/Marlin/src/lcd/language/language_pt_br.h
@@ -234,8 +234,8 @@ namespace Language_pt_br {
   PROGMEM Language_Str MSG_MIN                             = " " LCD_STR_THERMOMETER _UxGT(" Min");
   PROGMEM Language_Str MSG_MAX                             = " " LCD_STR_THERMOMETER _UxGT(" Máx");
   PROGMEM Language_Str MSG_FACTOR                          = " " LCD_STR_THERMOMETER _UxGT(" Fator");
-  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade min e");
-  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade máx e");
+  PROGMEM Language_Str MSG_MIN_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade min E");
+  PROGMEM Language_Str MSG_MAX_E_SPEED                     = " " LCD_STR_THERMOMETER _UxGT(" Velocidade máx E");
   PROGMEM Language_Str MSG_AUTOTEMP                        = _UxGT("Temp. Automática");
   PROGMEM Language_Str MSG_LCD_ON                          = _UxGT("Ligado");
   PROGMEM Language_Str MSG_LCD_OFF                         = _UxGT("Desligado");

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -252,7 +252,13 @@ void menu_backlash();
       EDIT_ITEM(bool, MSG_AUTOTEMP, &planner.autotemp_enabled);
       EDIT_ITEM(float3, MSG_MIN, &planner.autotemp_min, 0, float(HEATER_0_MAXTEMP) - HOTEND_OVERSHOOT);
       EDIT_ITEM(float3, MSG_MAX, &planner.autotemp_max, 0, float(HEATER_0_MAXTEMP) - HOTEND_OVERSHOOT);
-      EDIT_ITEM(float42_52, MSG_FACTOR, &planner.autotemp_factor, 0, 10);
+
+      #if ENABLED(AUTOTEMP_FACTORLESS)
+        EDIT_ITEM(float42_52, MSG_MIN_E_SPEED, &planner.autotemp_min_e_speed, 0, planner.settings.max_feedrate_mm_s[E_AXIS]);
+        EDIT_ITEM(float42_52, MSG_MAX_E_SPEED, &planner.autotemp_max_e_speed, planner.autotemp_min_e_speed, planner.settings.max_feedrate_mm_s[E_AXIS]);
+      #else
+        EDIT_ITEM(float42_52, MSG_FACTOR, &planner.autotemp_factor, 0, 10);
+      #endif
     #endif
 
     //

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1277,7 +1277,7 @@ void Planner::recalculate() {
 
     #if ENABLED(AUTOTEMP_DEBUG)
       unsigned blocks = 0;
-	#endif
+    #endif
 
     float high = 0.0;
     for (uint8_t b = block_buffer_tail; b != block_buffer_head; b = next_block_index(b)) {
@@ -3112,8 +3112,8 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
 
       #if ENABLED(AUTOTEMP_DEBUG)
         SERIAL_ECHO_START();
-	    SERIAL_ECHOPAIR("AUTOTEMP_PROPORTIONAL min: ", autotemp_min, "\n");
-	    SERIAL_ECHOPAIR("AUTOTEMP_PROPORTIONAL max: ", autotemp_max, "\n");
+        SERIAL_ECHOPAIR("AUTOTEMP_PROPORTIONAL min: ", autotemp_min, "\n");
+        SERIAL_ECHOPAIR("AUTOTEMP_PROPORTIONAL max: ", autotemp_max, "\n");
       #endif
     #endif
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -197,13 +197,13 @@ float Planner::steps_to_mm[XYZE_N];             // (mm) Millimeters per step
 skew_factor_t Planner::skew_factor; // Initialized by settings.load()
 
 #if ENABLED(AUTOTEMP)
-  float Planner::autotemp_max = 210,
-        Planner::autotemp_min = 190,
+  float Planner::autotemp_max = PREHEAT_1_TEMP_HOTEND + 10,
+        Planner::autotemp_min = PREHEAT_1_TEMP_HOTEND - 10,
         Planner::autotemp_oldtemp = 0.0f;
 
   #if ENABLED(AUTOTEMP_FACTORLESS)
     float Planner::autotemp_min_e_speed = 1.33f,
-          Planner::autotemp_max_e_speed = 3.33f;
+          Planner::autotemp_max_e_speed = 4.0f;
   #else
     float Planner::autotemp_factor = 0.1f;
   #endif
@@ -3079,7 +3079,13 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
       autotemp_enabled = autotemp_factor != 0;
     #endif
 
-    if (!autotemp_enabled) autotemp_oldtemp = 0.0f;
+    if (!autotemp_enabled) {
+      autotemp_oldtemp = 0.0f;
+
+      #ifdef AUTOTEMP_MIN_Z_RAISE
+        autotemp_last_z = 0.0f;
+      #endif
+    }
   }
 
   void Planner::autotemp_M104_M109() {
@@ -3112,10 +3118,11 @@ void Planner::set_max_jerk(const AxisEnum axis, float targetValue) {
       autotemp_enabled = autotemp_factor != 0;
     #endif
 
-    #ifdef AUTOTEMP_MIN_Z_RAISE
-      if (!autotemp_enabled) autotemp_last_z = 0.0f;
-    #endif
-
-    if (!autotemp_enabled) autotemp_oldtemp = 0.0f;
+    if (!autotemp_enabled) {
+      autotemp_oldtemp = 0.0f;
+      #ifdef AUTOTEMP_MIN_Z_RAISE
+        autotemp_last_z = 0.0f;
+      #endif
+    }
   }
 #endif

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -877,7 +877,7 @@ class Planner {
     #endif
 
     #if ENABLED(AUTOTEMP)
-      static float autotemp_min, autotemp_max;
+      static float autotemp_min, autotemp_max, autotemp_oldtemp;
 
       #if ENABLED(AUTOTEMP_FACTORLESS)
         static float autotemp_min_e_speed, autotemp_max_e_speed;

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -877,7 +877,18 @@ class Planner {
     #endif
 
     #if ENABLED(AUTOTEMP)
-      static float autotemp_min, autotemp_max, autotemp_factor;
+      static float autotemp_min, autotemp_max;
+
+      #if ENABLED(AUTOTEMP_FACTORLESS)
+        static float autotemp_min_e_speed, autotemp_max_e_speed;
+      #else
+        static float autotemp_factor;
+      #endif
+
+      #ifdef AUTOTEMP_MIN_Z_RAISE
+        static float autotemp_last_z;
+      #endif
+
       static bool autotemp_enabled;
       static void getHighESpeed();
       static void autotemp_M104_M109();


### PR DESCRIPTION
### Description

`AUTOTEMP_GRANULARITY` makes the target temperature 'snap' to increments of this many degrees.

`AUTOTEMP_MIN_Z_RAISE` ensures that the target temperature is only recalculated when Z is raised, ie, on layer changes. It's important to use large BLOCK_BUFFER_SIZE and to put high volumetric rate features, like infill, first when using this.

`AUTOTEMP_FACTORLESS` makes the target temperature scale evenly across a range of extruder speeds set with `M104/M109 S<mintemp> B<maxtemp> N<minespeed> M<maxespeed>`. Appropriate values for the extruder speeds can be calculated from a slicer's volumetric extrusion rate preview and from filament diameter.

It might be necessary to add a couple of lines to each of the language files, but I already took care of the languages I understand. Documentation might also need to be updated, if this is accepted.

I believe autotemp would be best done in the slicer, where entire layers can be analyzed, but since Marlin already has this feature, and my testing shows that this actually works well enough to use, I decided to make this pull request.

### Benefits

This allows me to actually use autotemp to deal with fine details (printed slow and cool), without sacrificing speed in the larger parts of my prints and without manual tweaks or multiple profiles in my slicer. Before this, autotemp would be very unpredictable, even after calculating an ideal factor from the volumetric rates seen in the slicer's preview, and tweaking it manually. It would adjust temperature too often and layer lines would be horribly visible.

### Related Issues

This is the result of the work I've been doing since opening issue #19007
