### PR TITLE
LPC using HW SPI Class + Finish DMA transfer for LPC

### DIFF
--- a/Marlin/src/HAL/LPC1768/HAL_SPI.cpp
+++ b/Marlin/src/HAL/LPC1768/HAL_SPI.cpp
@@ -113,16 +113,7 @@
     SPI.setDataSize(DATA_SIZE_8BIT);
     SPI.setDataMode(SPI_MODE0);
 
-    // table to convert Marlin spiRates (0-5 plus default) into bit rates
-    uint32_t Marlin_speed[7]; // CPSR is always 2
-    Marlin_speed[0] = 8333333; //(SCR:  2)  desired: 8,000,000  actual: 8,333,333  +4.2%  SPI_FULL_SPEED
-    Marlin_speed[1] = 4166667; //(SCR:  5)  desired: 4,000,000  actual: 4,166,667  +4.2%  SPI_HALF_SPEED
-    Marlin_speed[2] = 2083333; //(SCR: 11)  desired: 2,000,000  actual: 2,083,333  +4.2%  SPI_QUARTER_SPEED
-    Marlin_speed[3] = 1000000; //(SCR: 24)  desired: 1,000,000  actual: 1,000,000         SPI_EIGHTH_SPEED
-    Marlin_speed[4] =  500000; //(SCR: 49)  desired:   500,000  actual:   500,000         SPI_SPEED_5
-    Marlin_speed[5] =  250000; //(SCR: 99)  desired:   250,000  actual:   250,000         SPI_SPEED_6
-    Marlin_speed[6] =  125000; //(SCR:199)  desired:   125,000  actual:   125,000         Default from HAL.h
-    SPI.setClock(Marlin_speed[_MIN(spiRate, 6)]);
+    SPI.setClock(SPISettings::spiRate2Clock(spiRate));
     SPI.begin();
   }
 

--- a/Marlin/src/HAL/LPC1768/inc/SanityCheck.h
+++ b/Marlin/src/HAL/LPC1768/inc/SanityCheck.h
@@ -24,7 +24,7 @@
 #if PIO_PLATFORM_VERSION < 1001
   #error "nxplpc-arduino-lpc176x package is out of date, Please update the PlatformIO platforms, frameworks and libraries. You may need to remove the platform and let it reinstall automatically."
 #endif
-#if PIO_FRAMEWORK_VERSION < 2002
+#if PIO_FRAMEWORK_VERSION < 2005
   #error "framework-arduino-lpc176x package is out of date, Please update the PlatformIO platforms, frameworks and libraries."
 #endif
 

--- a/Marlin/src/HAL/LPC1768/include/SPI.h
+++ b/Marlin/src/HAL/LPC1768/include/SPI.h
@@ -61,7 +61,7 @@
 
 class SPISettings {
 public:
-  SPISettings(uint32_t speed, int, int) : spi_speed(speed) {};
+  // SPISettings(uint32_t speed, int, int) : spi_speed(speed) {};
   SPISettings(uint32_t inClock, uint8_t inBitOrder, uint8_t inDataMode, uint32_t inDataSize) {
     if (__builtin_constant_p(inClock))
       init_AlwaysInline(inClock, inBitOrder, inDataMode, inDataSize);
@@ -72,7 +72,7 @@ public:
     init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0, DATA_SIZE_8BIT);
   }
 
-  uint32_t spiRate() const { return spi_speed; }
+  // uint32_t spiRate() const { return spi_speed; }
 
 private:
   void init_MightInline(uint32_t inClock, uint8_t inBitOrder, uint8_t inDataMode, uint32_t inDataSize) {
@@ -85,7 +85,7 @@ private:
     dataSize = inDataSize;
   }
 
-  uint32_t spi_speed;
+  // uint32_t spi_speed;
   uint32_t clock;
   uint32_t dataSize;
   //uint32_t clockDivider;

--- a/Marlin/src/HAL/LPC1768/include/SPI.h
+++ b/Marlin/src/HAL/LPC1768/include/SPI.h
@@ -63,7 +63,7 @@ class SPISettings {
 public:
   SPISettings(uint32_t spiRate, int inBitOrder, int inDataMode) {
     init_AlwaysInline(spiRate2Clock(spiRate), inBitOrder, inDataMode, DATA_SIZE_8BIT);
-  };
+  }
   SPISettings(uint32_t inClock, uint8_t inBitOrder, uint8_t inDataMode, uint32_t inDataSize) {
     if (__builtin_constant_p(inClock))
       init_AlwaysInline(inClock, inBitOrder, inDataMode, inDataSize);
@@ -74,7 +74,7 @@ public:
     init_AlwaysInline(4000000, MSBFIRST, SPI_MODE0, DATA_SIZE_8BIT);
   }
 
-  // uint32_t spiRate() const { return spi_speed; }
+  //uint32_t spiRate() const { return spi_speed; }
 
   static inline uint32_t spiRate2Clock(uint32_t spiRate) {
     uint32_t Marlin_speed[7]; // CPSR is always 2
@@ -99,7 +99,7 @@ private:
     dataSize = inDataSize;
   }
 
-  // uint32_t spi_speed;
+  //uint32_t spi_speed;
   uint32_t clock;
   uint32_t dataSize;
   //uint32_t clockDivider;
@@ -136,7 +136,7 @@ public:
   void end();
 
   void beginTransaction(const SPISettings&);
-  void endTransaction() {};
+  void endTransaction() {}
 
   // Transfer using 1 "Data Size"
   uint8_t transfer(uint16_t data);

--- a/Marlin/src/HAL/LPC1768/include/SPI.h
+++ b/Marlin/src/HAL/LPC1768/include/SPI.h
@@ -61,7 +61,9 @@
 
 class SPISettings {
 public:
-  // SPISettings(uint32_t speed, int, int) : spi_speed(speed) {};
+  SPISettings(uint32_t spiRate, int inBitOrder, int inDataMode) {
+    init_AlwaysInline(spiRate2Clock(spiRate), inBitOrder, inDataMode, DATA_SIZE_8BIT);
+  };
   SPISettings(uint32_t inClock, uint8_t inBitOrder, uint8_t inDataMode, uint32_t inDataSize) {
     if (__builtin_constant_p(inClock))
       init_AlwaysInline(inClock, inBitOrder, inDataMode, inDataSize);
@@ -73,6 +75,18 @@ public:
   }
 
   // uint32_t spiRate() const { return spi_speed; }
+
+  static inline uint32_t spiRate2Clock(uint32_t spiRate) {
+    uint32_t Marlin_speed[7]; // CPSR is always 2
+    Marlin_speed[0] = 8333333; //(SCR:  2)  desired: 8,000,000  actual: 8,333,333  +4.2%  SPI_FULL_SPEED
+    Marlin_speed[1] = 4166667; //(SCR:  5)  desired: 4,000,000  actual: 4,166,667  +4.2%  SPI_HALF_SPEED
+    Marlin_speed[2] = 2083333; //(SCR: 11)  desired: 2,000,000  actual: 2,083,333  +4.2%  SPI_QUARTER_SPEED
+    Marlin_speed[3] = 1000000; //(SCR: 24)  desired: 1,000,000  actual: 1,000,000         SPI_EIGHTH_SPEED
+    Marlin_speed[4] =  500000; //(SCR: 49)  desired:   500,000  actual:   500,000         SPI_SPEED_5
+    Marlin_speed[5] =  250000; //(SCR: 99)  desired:   250,000  actual:   250,000         SPI_SPEED_6
+    Marlin_speed[6] =  125000; //(SCR:199)  desired:   125,000  actual:   125,000         Default from HAL.h
+    return Marlin_speed[spiRate > 6 ? 6 : spiRate];
+  }
 
 private:
   void init_MightInline(uint32_t inClock, uint8_t inBitOrder, uint8_t inDataMode, uint32_t inDataSize) {

--- a/Marlin/src/HAL/LPC1768/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/LPC1768/tft/xpt2046.cpp
@@ -72,7 +72,6 @@ bool XPT2046::getRawPoint(int16_t *x, int16_t *y) {
   if (!isTouched()) return false;
   *x = getRawData(XPT2046_X);
   *y = getRawData(XPT2046_Y);
-  SERIAL_ECHOLNPAIR("X: ", *x, ", Y: ", *y);
   return isTouched();
 }
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -275,9 +275,6 @@
     #define LCD_BACKLIGHT_PIN              -1
 
   #elif HAS_SPI_TFT                               // Config for Classic UI (emulated DOGM) and Color UI
-    #define SS_PIN                         -1
-    //#define ONBOARD_SD_CS_PIN            -1
-
     #define TFT_CS_PIN                     P1_22
     #define TFT_A0_PIN                     P1_23
     #define TFT_DC_PIN                     P1_23
@@ -285,7 +282,6 @@
     #define TFT_BACKLIGHT_PIN              P1_18
     #define TFT_RESET_PIN                  P1_19
 
-    #define LPC_HW_SPI_DEV                     0
     #define LCD_USE_DMA_SPI
 
     #define TOUCH_INT_PIN                  P1_21
@@ -297,14 +293,17 @@
       #define GRAPHICAL_TFT_UPSCALE            3
     #endif
 
-    // SPI 1
-    #define SCK_PIN                        P0_15
-    #define MISO_PIN                       P0_17
-    #define MOSI_PIN                       P0_18
-
     // Disable any LCD related PINs config
     #define LCD_PINS_ENABLE                -1
     #define LCD_PINS_RS                    -1
+
+    // Emulated DOGM have xpt calibration values independent of display resolution
+    #if ENABLED(SPI_GRAPHICAL_TFT)
+      #define XPT2046_X_CALIBRATION      -11245
+      #define XPT2046_Y_CALIBRATION        8629
+      #define XPT2046_X_OFFSET              685
+      #define XPT2046_Y_OFFSET             -285
+    #endif
 
   #else
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -623,6 +623,7 @@ debug_tool     = jlink
 #
 [common_LPC]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.3.zip
+platform_packages = framework-arduino-lpc176x@^0.2.5
 board             = nxp_lpc1768
 lib_ldf_mode      = off
 lib_compat_mode   = strict


### PR DESCRIPTION
### Description

This finished the work started in #19139 

- [x] Fix DMA transfer for repeat mode
- [x] Touch + TFT + Onboard SD = fully working sharing the same Hardware SPI class - Tested in SKR 1.4 Turbo
- [x] LCD + LCD SD = fully working sharing the same Hardware SPI class - Tested in SKR 1.4 Turbo

It depends on this PR for the lpc framework: https://github.com/p3p/pio-framework-arduino-lpc176x/pull/43
That PR needs to be merged before this one. 

@p3p, Marlin CI will break until the LPC framework get updated :-)

I think I'm done with LPC! ✅ 🚀 

### Benefits

- Fully DMA for LPC
- Fully HW SPI for LPC

### Configurations

For TFT + TOUCH + ONBOARD SD
```
TFT_480x320_SPI ou SPI_GRAPHICAL_TFT
TOUCH_SCREEN
SDSUPPORT
SDCARD_CONNECTION ONBOARD
BOARD_BTT_SKR_V1_4_TURBO
```

For LCD + LCD SD
```
REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
SDSUPPORT
BOARD_BTT_SKR_V1_4_TURBO
```

### Related Issues

#19139 
https://github.com/p3p/pio-framework-arduino-lpc176x/pull/43
