### PR TITLE
fix warnings related to fixed cmd array.

### DIFF
--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -138,8 +138,9 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
           SUBMENU_N_P(s, msg, []{ _menu_temp_filament_op(PAUSE_MODE_CHANGE_FILAMENT, MenuItemBase::itemIndex); });
         else {
           ACTION_ITEM_N_P(s, msg, []{
-            char cmd[13];
-            sprintf_P(cmd, PSTR("M600 B0 T%i"), int(MenuItemBase::itemIndex));
+            PGM_P const cmdpstr = PSTR("M600 B0 T%i");
+            char cmd[strlen_P(cmdpstr) + 3 + 1];
+            sprintf_P(cmd, cmdpstr, int(MenuItemBase::itemIndex));
             queue.inject(cmd);
           });
         }


### PR DESCRIPTION
### Requirements

E_STEPPERS > 1 and ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
menu capable LCD

### Description

The above combination produces a compiler warning 
Marlin/src/lcd/menu/menu_filament.cpp:142:33: warning: 'sprintf' may write a terminating nul past the end of the destination [-Wformat-overflow=]
  142 |             sprintf_P(cmd, PSTR("M600 B0 T%i"), int(MenuItemBase::itemIndex));

The warning is valid. If i > 99 the cmd array would overflow and the nul termination would be lost.

Taking inspiration from https://github.com/MarlinFirmware/Marlin/commit/e8dcbd8300680f0d0f2032065952181f51d52874
I have fixed this warning, Size of cmd array is determined mathematically vs a fixed length.  

### Benefits

Warning is gone.

### Configurations
Configs used to generate warning.
[configs.zip](https://github.com/MarlinFirmware/Marlin/files/5146364/configs.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/commit/e8dcbd8300680f0d0f2032065952181f51d52874