### PR TITLE
Fix BLTOUCH and FAN PWM conflicts on SKR E3 v2 boards

### DIFF
--- a/Marlin/src/HAL/STM32F1/timers.h
+++ b/Marlin/src/HAL/STM32F1/timers.h
@@ -80,7 +80,7 @@ typedef uint16_t hal_timer_t;
   //#define TEMP_TIMER_NUM      4  // 2->4, Timer 2 for Stepper Current PWM
 #endif
 
-#if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_E3_DIP, BTT_SKR_MINI_E3_V1_2, MKS_ROBIN_LITE)
+#if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_MINI_E3_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_DIP, MKS_ROBIN_LITE)
   // SKR Mini E3 boards use PA8 as FAN_PIN, so TIMER 1 is used for Fan PWM.
   #ifdef STM32_HIGH_DENSITY
     #define SERVO0_TIMER_NUM 8  // tone.cpp uses Timer 4


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description
Corrects the same issue as #15547 on the newer SKR Mini E3 v2 boards. Also re-ordered the conditions to put all the SKR Mini E3s together, though that has no functional benefit (though if someone knows how to wild-card the condition it could be more evident what needs to be included).
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
Prevents some Z probes (notably certain BLTouch clones) from deploying randomly when the PWM fan is triggered while using a newer BTT SKR Mini E3 v2 board. Prevents damage to both the print and probe. Tested for over an hour with zero random deployments mid-print.
<!-- What does this fix or improve? -->

### Configurations
N/A
<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues
None listed. Personal issue encountered during recent experiments which, given the previous issue, is likely to impact other users with similar configurations.
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
