### PR TITLE
feedrate_percentage not change in Anicubic I3 MEGA(S) with original screen

### DIFF
--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -413,6 +413,7 @@ void AnycubicTFTClass::RenderCurrentFileList() {
     uint16_t selectedNumber = 0;
     SelectedDirectory[0] = 0;
     SelectedFile[0] = 0;
+    ExtUI::FileList currentFileList;                                 
 
     SENDLINE_PGM("FN "); // Filelist start
 
@@ -428,7 +429,7 @@ void AnycubicTFTClass::RenderCurrentFileList() {
 
       if (SpecialMenu)
         RenderSpecialMenu(selectedNumber);
-      else
+      else if (selectedNumber <= currentFileList.count())
         RenderCurrentFolder(selectedNumber);
     }
     SENDLINE_PGM("END"); // Filelist stop

--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -28,6 +28,7 @@
 #include "../../../../inc/MarlinConfig.h"
 #include "../../ui_api.h"
 #include "../../../../MarlinCore.h" // for quickstop_stepper and disable_steppers
+#include "../../../../module/motion.h"	// for A20 read printing speed feedrate_percentage
 
 // command sending macro's with debugging capability
 #define SEND_PGM(x)                                 send_P(PSTR(x))
@@ -804,7 +805,6 @@ void AnycubicTFTClass::GetCommandFromTFT() {
             break;
 
           case 20: { // A20 read printing speed
-            int16_t feedrate_percentage = 100;
 
             if (CodeSeen('S'))
               feedrate_percentage = constrain(CodeValue(), 40, 999);


### PR DESCRIPTION
the feedrate_percentage is set to 100 alltime, this change remove this bug

### Requirements

Anycubic I3 MEGA (S) printer

### Description

<!--

cannot change the feedrate_percentage via the AI3M screen, the value does not change

-->

### Benefits

FIX
cannot change the feedrate_percentage via the AI3M screen, the value does not change
### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here.
[Marlin_AI3M_Stef_Ladefense.zip](https://github.com/MarlinFirmware/Marlin/files/5150482/Marlin_AI3M_Stef_Ladefense.zip)

 -->
