### PR TITLE
Fail SD mounting with no SPI re-init

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -383,9 +383,9 @@ void CardReader::mount() {
 
   if (flag.mounted)
     cdroot();
-  else if (marlin_state != MF_INITIALIZING) {
+  else if (marlin_state != MF_INITIALIZING)
     ui.set_status_P(GET_TEXT(MSG_SD_INIT_FAIL), -1);
-  }
+
   ui.refresh();
 }
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -383,7 +383,7 @@ void CardReader::mount() {
 
   if (flag.mounted)
     cdroot();
-  else {
+  else if (marlin_state != MF_INITIALIZING) {
     ui.set_status_P(GET_TEXT(MSG_SD_INIT_FAIL), -1);
   }
   ui.refresh();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -140,7 +140,7 @@ CardReader::CardReader() {
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
     SET_INPUT_PULLUP(SD_DETECT_PIN);
   #endif
-  
+
   #if PIN_EXISTS(SDPOWER)
     OUT_WRITE(SDPOWER_PIN, HIGH); // Power the SD reader
   #endif
@@ -384,7 +384,6 @@ void CardReader::mount() {
   if (flag.mounted)
     cdroot();
   else {
-    spiInit(SPI_SPEED); // Return to base SPI speed
     ui.set_status_P(GET_TEXT(MSG_SD_INIT_FAIL), -1);
   }
   ui.refresh();


### PR DESCRIPTION
### Description

sd2card.init uses SPI_SD_INIT_RATE, not SPI_SPEED. The removed line set the spi speed to wrong velocity and the SD stop working. Even if correct, that spiInit dont need stay there, as is the calling code the responsability to put spi in the right state before the use.

### Benefits

Fixes #19223

It removes the false "SD Init Fail" when booting a printer without a SD card.

### Related Issues

#19223
