### PR TITLE
Invalidate whole mesh.

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -48,7 +48,7 @@
 
   void unified_bed_leveling::report_current_mesh() {
     if (!leveling_is_valid()) return;
-    SERIAL_ECHO_MSG("  G29 I", int(GRID_MAX_POINTS));
+    SERIAL_ECHO_MSG("  G29 I999");
     GRID_LOOP(x, y)
       if (!isnan(z_values[x][y])) {
         SERIAL_ECHO_START();

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -48,7 +48,7 @@
 
   void unified_bed_leveling::report_current_mesh() {
     if (!leveling_is_valid()) return;
-    SERIAL_ECHO_MSG("  G29 I99");
+    SERIAL_ECHO_MSG("  G29 I", GRID_MAX_POINTS);
     GRID_LOOP(x, y)
       if (!isnan(z_values[x][y])) {
         SERIAL_ECHO_START();

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -48,7 +48,7 @@
 
   void unified_bed_leveling::report_current_mesh() {
     if (!leveling_is_valid()) return;
-    SERIAL_ECHO_MSG("  G29 I", GRID_MAX_POINTS);
+    SERIAL_ECHO_MSG("  G29 I", int(GRID_MAX_POINTS));
     GRID_LOOP(x, y)
       if (!isnan(z_values[x][y])) {
         SERIAL_ECHO_START();


### PR DESCRIPTION
### Description

When using ``G29 S-1`` to generate gcode to save a UBL mesh, the generated gcode starts with a ``G29 I99`` to invalidate the mesh. If the mesh is 10x10 or larger this is not sufficient. This PR uses the mesh size in the generated ``G29 I`` command.

### Benefits

Improves results of ``G29 S-1`` for large meshes.

### Configurations

[Configurations.zip](https://github.com/MarlinFirmware/Marlin/files/5159751/Configurations.zip)

### Related Issues

None.