### PR TITLE
SD Init Fail message only when we can detect the SD Card Insertion 

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -383,8 +383,10 @@ void CardReader::mount() {
 
   if (flag.mounted)
     cdroot();
-  else if (marlin_state != MF_INITIALIZING)
-    ui.set_status_P(GET_TEXT(MSG_SD_INIT_FAIL), -1);
+  #if ENABLED(USB_FLASH_DRIVE_SUPPORT) || PIN_EXISTS(SD_DETECT)
+    else if (marlin_state != MF_INITIALIZING)
+      ui.set_status_P(GET_TEXT(MSG_SD_INIT_FAIL), -1);
+  #endif
 
   ui.refresh();
 }


### PR DESCRIPTION
### Description

Only show sd init fail on card.mount if we can detect the card.

If we can't detect the sd card, the actual code shows "SD Init Fail" forever, because the card.mount is called in the marlin main loop always....

### Benefits


### Related Issues

#19064
#19226 
