### PR TITLE
Add GLCD w/ SD support to pins_SMOOTHIEBOARD.h

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -144,7 +144,7 @@
     
     #define MISO_PIN                       P0_08  // EXP2 Pin 1 (PB3, SD_MISO)
     #define SCK_PIN                        P0_07  // EXP2 Pin 2 (SD_SCK)    
-    #define SS_PIN                         P0_28  // EXP2 Pin 4 (SD_CSEL, SD_CS) (Sometimes called SDSS) - CS used by Marlin
+    #define SS_PIN                         P0_28  // EXP2 Pin 4 (SD_CSEL, SD_CS)
     #define MOSI_PIN                       P0_09  // EXP2 Pin 6 (PB2, SD_MOSI)
     #define SD_DETECT_PIN                  P0_27  // EXP2 Pin 7 (SD_CD, SD_DET)
     

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -129,6 +129,24 @@
     //  EXP2 Pins 
     #define BTN_EN1                        P3_25  // EXP2 Pin 5
     #define BTN_EN2                        P3_26  // EXP2 Pin 3
+
+    /*  
+       SD Support
+    
+      For the RRD GLCD it CANNOT share the same SPI as the LCD so it must be 
+      hooked up to the onboard sdcard SPI and use a spare pin for the sdcs.
+      Also note that an external SDcard sharing the SPI port with the 
+      onboard/internal sdcard must be ejected before rebooting as the bootloader 
+      does not like the external card. NOTE Smoothie will not boot if the external 
+      sdcard is inserted in the RRD LCD sdcard slot at boot time, it must be 
+      inserted after it has booted.
+    */
+    #define SD_DETECT_PIN                  P0_27  // EXP2 Pin 7 (SD_CD, SD_DET)
+    #define SCK_PIN                        P0_07  // EXP2 Pin 2 (SD_SCK)
+    #define MISO_PIN                       P0_08  // EXP2 Pin 1 (PB3, SD_MISO)
+    #define MOSI_PIN                       P0_09  // EXP2 Pin 6 (PB2, SD_MOSI)
+    #define SS_PIN                         P0_28  // EXP2 Pin 4 (SD_CSEL, SD_CS) (Sometimes called SDSS) - CS used by Marlin
+
   #else
     #error "Marlin's Smoothieboard support cannot drive your LCD."
   #endif

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -129,6 +129,8 @@
     //  EXP2 Pins 
     #define BTN_EN1                        P3_25  // EXP2 Pin 5
     #define BTN_EN2                        P3_26  // EXP2 Pin 3
+  #else
+    #error "Marlin's Smoothieboard support cannot drive your LCD."
   #endif
 
 #endif

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -111,13 +111,14 @@
 
 #elif HAS_SPI_LCD
 
-  /*  The Smoothieboard supports the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER either
-      with a custom cable with breakouts to the pins indicated below or with RRD GLCD Adpater board
-      found at:    http://smoothieware.org/rrdglcdadapter
+  /*
+    The Smoothieboard supports the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER with either
+    a custom cable with breakouts to the pins indicated below or the RRD GLCD Adapter board
+    found at http://smoothieware.org/rrdglcdadapter
 
-      Other links to information about setting up a display panel with Smoothieboard
-      http://chibidibidiwah.wdfiles.com/local--files/panel/smoothieboard2sd.jpg
-      http://smoothieware.org/panel
+    Other links to information about setting up a display panel with Smoothieboard
+    http://chibidibidiwah.wdfiles.com/local--files/panel/smoothieboard2sd.jpg
+    http://smoothieware.org/panel
   */
 
   #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
@@ -131,17 +132,18 @@
     #define BTN_EN2                        P3_26  // EXP2 Pin 3
     #define BTN_EN1                        P3_25  // EXP2 Pin 5
     
-    /*  SD Support
+    /*
+      SD Support
     
-        For the RRD GLCD it CANNOT share the same SPI as the LCD so it must be 
-        hooked up to the onboard sdcard SPI and use a spare pin for the sdcs.
-        Also note that an external SDcard sharing the SPI port with the 
-        onboard/internal sdcard must be ejected before rebooting as the bootloader 
-        does not like the external card. NOTE Smoothie will not boot if the external 
-        sdcard is inserted in the RRD LCD sdcard slot at boot time, it must be 
-        inserted after it has booted.
+      For the RRD GLCD it CANNOT share the same SPI as the LCD so it must be
+      hooked up to the onboard SDCard SPI and use a spare pin for the SDCS.
+      Also note that an external SDCard sharing the SPI port with the
+      onboard/internal SDCard must be ejected before rebooting as the bootloader
+      does not like the external card. NOTE Smoothie will not boot if the external
+      sdcard is inserted in the RRD LCD sdcard slot at boot time, it must be
+      inserted after it has booted.
     */
-    
+
     #define MISO_PIN                       P0_08  // EXP2 Pin 1 (PB3, SD_MISO)
     #define SCK_PIN                        P0_07  // EXP2 Pin 2 (SD_SCK)    
     #define SS_PIN                         P0_28  // EXP2 Pin 4 (SD_CSEL, SD_CS)

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -111,6 +111,14 @@
 
 #elif HAS_SPI_LCD
 
+  /*  The Smoothieboard supports the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER either
+    with a custom cable with breakouts to the pins indicated below or with RRD GLCD Adpater board
+    found at:    http://smoothieware.org/rrdglcdadapter
+    
+    Other links to information about setting up a display panel with Smoothieboard
+    http://chibidibidiwah.wdfiles.com/local--files/panel/smoothieboard2sd.jpg
+    http://smoothieware.org/panel
+  */
   #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
     //  EXP1 Pins
     #define BEEPER_PIN                     P1_31  // EXP1 Pin 1

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -112,13 +112,14 @@
 #elif HAS_SPI_LCD
 
   /*  The Smoothieboard supports the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER either
-    with a custom cable with breakouts to the pins indicated below or with RRD GLCD Adpater board
-    found at:    http://smoothieware.org/rrdglcdadapter
-    
-    Other links to information about setting up a display panel with Smoothieboard
-    http://chibidibidiwah.wdfiles.com/local--files/panel/smoothieboard2sd.jpg
-    http://smoothieware.org/panel
+      with a custom cable with breakouts to the pins indicated below or with RRD GLCD Adpater board
+      found at:    http://smoothieware.org/rrdglcdadapter
+
+      Other links to information about setting up a display panel with Smoothieboard
+      http://chibidibidiwah.wdfiles.com/local--files/panel/smoothieboard2sd.jpg
+      http://smoothieware.org/panel
   */
+
   #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
     //  EXP1 Pins
     #define BEEPER_PIN                     P1_31  // EXP1 Pin 1
@@ -127,26 +128,26 @@
     #define LCD_PINS_RS                    P0_16  // EXP1 Pin 4 (CS)  
     #define LCD_PINS_D4                    P0_15  // EXP1 Pin 5 (SCK)
     //  EXP2 Pins 
-    #define BTN_EN1                        P3_25  // EXP2 Pin 5
     #define BTN_EN2                        P3_26  // EXP2 Pin 3
-
-    /*  
-       SD Support
+    #define BTN_EN1                        P3_25  // EXP2 Pin 5
     
-      For the RRD GLCD it CANNOT share the same SPI as the LCD so it must be 
-      hooked up to the onboard sdcard SPI and use a spare pin for the sdcs.
-      Also note that an external SDcard sharing the SPI port with the 
-      onboard/internal sdcard must be ejected before rebooting as the bootloader 
-      does not like the external card. NOTE Smoothie will not boot if the external 
-      sdcard is inserted in the RRD LCD sdcard slot at boot time, it must be 
-      inserted after it has booted.
+    /*  SD Support
+    
+        For the RRD GLCD it CANNOT share the same SPI as the LCD so it must be 
+        hooked up to the onboard sdcard SPI and use a spare pin for the sdcs.
+        Also note that an external SDcard sharing the SPI port with the 
+        onboard/internal sdcard must be ejected before rebooting as the bootloader 
+        does not like the external card. NOTE Smoothie will not boot if the external 
+        sdcard is inserted in the RRD LCD sdcard slot at boot time, it must be 
+        inserted after it has booted.
     */
-    #define SD_DETECT_PIN                  P0_27  // EXP2 Pin 7 (SD_CD, SD_DET)
-    #define SCK_PIN                        P0_07  // EXP2 Pin 2 (SD_SCK)
+    
     #define MISO_PIN                       P0_08  // EXP2 Pin 1 (PB3, SD_MISO)
-    #define MOSI_PIN                       P0_09  // EXP2 Pin 6 (PB2, SD_MOSI)
+    #define SCK_PIN                        P0_07  // EXP2 Pin 2 (SD_SCK)    
     #define SS_PIN                         P0_28  // EXP2 Pin 4 (SD_CSEL, SD_CS) (Sometimes called SDSS) - CS used by Marlin
-
+    #define MOSI_PIN                       P0_09  // EXP2 Pin 6 (PB2, SD_MOSI)
+    #define SD_DETECT_PIN                  P0_27  // EXP2 Pin 7 (SD_CD, SD_DET)
+    
   #else
     #error "Marlin's Smoothieboard support cannot drive your LCD."
   #endif

--- a/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
+++ b/Marlin/src/pins/lpc1769/pins_SMOOTHIEBOARD.h
@@ -111,7 +111,17 @@
 
 #elif HAS_SPI_LCD
 
-  #error "Marlin's Smoothieboard support cannot drive your LCD."
+  #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+    //  EXP1 Pins
+    #define BEEPER_PIN                     P1_31  // EXP1 Pin 1
+    #define BTN_ENC                        P1_30  // EXP1 Pin 2
+    #define LCD_PINS_ENABLE                P0_18  // EXP1 Pin 3 (MOSI) 
+    #define LCD_PINS_RS                    P0_16  // EXP1 Pin 4 (CS)  
+    #define LCD_PINS_D4                    P0_15  // EXP1 Pin 5 (SCK)
+    //  EXP2 Pins 
+    #define BTN_EN1                        P3_25  // EXP2 Pin 5
+    #define BTN_EN2                        P3_26  // EXP2 Pin 3
+  #endif
 
 #endif
 


### PR DESCRIPTION
### Description

Add pins to pins_SMOOTHIEBOARD.h to support the LCD and SD card on the REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER on the Smoothieboard.

### Benefits

See description.