### PR TITLE
Patch for thermistor_21.h - 3.3V INA826 PT100 temperature probe

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -416,7 +416,7 @@
  *   998 : Dummy Table that ALWAYS reads 25°C or the temperature defined below.
  *   999 : Dummy Table that ALWAYS reads 100°C or the temperature defined below.
  */
-#define TEMP_SENSOR_0 1
+#define TEMP_SENSOR_0 21
 #define TEMP_SENSOR_1 0
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_3 0

--- a/Marlin/src/module/thermistor/thermistor_21.h
+++ b/Marlin/src/module/thermistor/thermistor_21.h
@@ -23,10 +23,10 @@
 
 #define REVERSE_TEMP_SENSOR_RANGE_21 1
 
-#undef OV_SCALE
-#define OV_SCALE(N) (float((N) * 5) / 3.3f)
-
-// Pt100 with INA826 amp with 3.3v excitation based on "Pt100 with INA826 amp on Ultimaker v2.0 electronics"
+// Pt100 with INA826 amp with 3.3V excitation based on "Pt100 with INA826 amp on Ultimaker v2.0 electronics"
+// As the uC ADC reference voltage is 3.3V as well as the INA826 supply/reference, the same table as for 5V excitation is valid.
+// The ADC is referring his counts to the reference voltage as the IN826 opamp does scale the output voltage to the supply voltage in the analog domain.
+// Note, that the quantization error of this table in conjunction with rounding of the temperature reading can result in a few degrees error most noticeable between datapoints, e.g. 25°C, 35°C, etc.
 const temp_entry_t temptable_21[] PROGMEM = {
   { OV(  0),    0 },
   { OV(227),    1 },
@@ -73,5 +73,3 @@ const temp_entry_t temptable_21[] PROGMEM = {
   { OV(614),  500 }
 };
 
-#undef OV_SCALE
-#define OV_SCALE(N) (N)


### PR DESCRIPTION
**Description**
I removed the 5V to 3.3V table #define OV_SCALE conversion. In essence, thermistor_21.h has now the same code content as thermistor_20.h.

The conversion is leading to an erronous temperature reading, as e.g. a 1°C reading at room temperature (see issues #16561 and #19234)

The table provides temperature reference points in terms of ADC-counts. As long as the ADC reference voltage (LPC, STM normally 3.3V) and the INA826 supply voltage (here as well 3.3V) are identical, there is no theoretical difference in ADC counts between 5V and 3V3 setups (besides noise, etc.).

Little more background:
the ADC is providing counts in relation to his reference voltage and the INA826 opamp does the very same in the analog domain referring to its supply voltage. Therefore, same references on both ends cancel out for the look-up table.

I validated with an additional PT100 measurement for 100°C and room temperature.

Note, that the quantization error of the table in combination with rounding of the temperature reading might lead to a few degrees (seen up to 3°C) of error around the center between datapoints, e.g. 25°C, 35°C, etc.

**Benefits**
Temp Probe Nr. 21 is usable for INA826 PT100 in 3V3 environments. Currently Nr. 21 is greatly underestimating the hotend temperature.

**Configurations**
in any Configuration.h with INA826-PT100 and 3V3 board setup:
#define TEMP_SENSOR_0 21

(I cannot attach .h files here?!)
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/5168274/Configuration.zip)


**Related Issues**
#19234
#16561