### PR TITLE
Update ESP32 Wifi Sanity Check Wording

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3102,7 +3102,7 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
  * Sanity check for WIFI
  */
 #if EITHER(ESP3D_WIFISUPPORT, WIFISUPPORT) && DISABLED(ARDUINO_ARCH_ESP32)
-  #error "ESP3D_WIFISUPPORT or WIFISUPPORT requires an ESP32 controller."
+  #error "ESP3D_WIFISUPPORT or WIFISUPPORT requires an ESP32 MOTHERBOARD."
 #endif
 
 /**


### PR DESCRIPTION
### Description

The wording in the ESP32 sanity check was _still_ confusing for some users, so hopefully it's now clear that you need an ESP32-based motherboard to enable `ESP3D_WIFISUPPORT` or `WIFISUPPORT`.

### Benefits

Clearer error?

### Configurations

N/A

### Related Issues

None. Found on Facebook.
