### PR TITLE
Touch UI long filenames fixes

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.h
@@ -133,6 +133,7 @@ class CLCD {
     static void set_brightness (uint8_t brightness);
     static uint8_t get_brightness();
     static void host_cmd (unsigned char host_command, unsigned char byte2);
+    static uint32_t dl_size() {return CLCD::mem_read_32(REG::CMD_DL) & 0x1FFF;}
 
     static void get_font_metrics (uint8_t font, struct FontMetrics &fm);
     static uint16_t get_text_width(const uint8_t font, const char *str);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/dl_cache.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/dl_cache.h
@@ -66,7 +66,7 @@ class DLCache {
     }
 
     bool has_data();
-    bool store(uint32_t num_bytes = 0);
+    bool store(uint32_t min_bytes = 0);
     void append();
 };
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/dl_cache.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/dl_cache.h
@@ -44,12 +44,16 @@ class DLCache {
     typedef FTDI::ftdi_registers  REG;
     typedef FTDI::ftdi_memory_map MAP;
 
-    uint8_t  dl_slot;
-    uint32_t dl_addr;
-    uint16_t dl_size;
+    uint8_t  dl_slot_indx;
+    uint32_t dl_slot_addr;
+    uint16_t dl_slot_size;
+    uint16_t dl_slot_used;
 
-    void load_slot();
-    static void save_slot(uint8_t dl_slot, uint32_t dl_addr, uint32_t dl_size);
+    void load_slot() {load_slot(dl_slot_indx, dl_slot_addr, dl_slot_size, dl_slot_used);}
+    void save_slot() {save_slot(dl_slot_indx, dl_slot_addr, dl_slot_size, dl_slot_used);}
+    
+    static void load_slot(uint8_t indx, uint32_t &addr, uint16_t &size, uint16_t &used);
+    static void save_slot(uint8_t indx, uint32_t  addr, uint16_t  size, uint16_t  used);
 
     bool wait_until_idle();
 
@@ -57,7 +61,7 @@ class DLCache {
     static void init();
 
     DLCache(uint8_t slot) {
-      dl_slot = slot;
+      dl_slot_indx = slot;
       load_slot();
     }
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.h
@@ -173,10 +173,21 @@ class UncachedScreen {
 template<uint8_t DL_SLOT,uint32_t DL_SIZE = 0>
 class CachedScreen {
   protected:
+    static void gfxError() {
+      using namespace FTDI;
+      CommandProcessor cmd;
+      cmd.cmd(CMD_DLSTART)
+         .cmd(CLEAR(true,true,true))
+         .font(30)
+         .text(0, 0, display_width, display_height, F("GFX MEM FULL"));
+    }
+
     static bool storeBackground() {
       DLCache dlcache(DL_SLOT);
       if (!dlcache.store(DL_SIZE)) {
         SERIAL_ECHO_MSG("CachedScreen::storeBackground() failed: not enough DL cache space");
+        gfxError(); // Try to cache a shorter error message instead.
+        dlcache.store(DL_SIZE);
         return false;
       }
       return true;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/text_ellipsis.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/text_ellipsis.cpp
@@ -1,0 +1,80 @@
+/*********************
+ * text_ellipsis.cpp *
+ *********************/
+
+/****************************************************************************
+ *   Written By Marcio Teixeira 2019 - Aleph Objects, Inc.                  *
+ *                                                                          *
+ *   This program is free software: you can redistribute it and/or modify   *
+ *   it under the terms of the GNU General Public License as published by   *
+ *   the Free Software Foundation, either version 3 of the License, or      *
+ *   (at your option) any later version.                                    *
+ *                                                                          *
+ *   This program is distributed in the hope that it will be useful,        *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU General Public License for more details.                           *
+ *                                                                          *
+ *   To view a copy of the GNU General Public License, go to the following  *
+ *   location: <https://www.gnu.org/licenses/>.                              *
+ ****************************************************************************/
+
+#include "ftdi_extended.h"
+
+#ifdef FTDI_EXTENDED
+
+namespace FTDI {
+
+  /**
+   * Helper function for drawing text with ellipses. The str buffer may be modified and should have space for up to two extra characters.
+   */
+  static void _draw_text_with_ellipsis(CommandProcessor& cmd, int16_t x, int16_t y, int16_t w, int16_t h, char *str, uint16_t options, uint8_t font) {
+    FontMetrics fm(font);
+    const uint16_t ellipsisWidth = fm.get_char_width('.') * 3;
+
+    // Compute the total line length, as well as
+    // the location in the string where it can
+    // split and still allow the ellipsis to fit.
+    uint16_t lineWidth = 0;
+    char *breakPoint   = str;
+    for(char* c = str; *c; c++) {
+      lineWidth += fm.get_char_width(*c);
+      if(lineWidth + ellipsisWidth < w)
+        breakPoint = c;
+    }
+
+    if(lineWidth > w) {
+      *breakPoint = '\0';
+      strcpy_P(breakPoint,PSTR("..."));
+    }
+
+    cmd.apply_text_alignment(x, y, w, h, options);
+    #ifdef TOUCH_UI_USE_UTF8
+      if (has_utf8_chars(str)) {
+        draw_utf8_text(cmd, x, y, str, font_size_t::from_romfont(font), options);
+      } else
+    #endif
+      {
+        cmd.CLCD::CommandFifo::text(x, y, font, options);
+        cmd.CLCD::CommandFifo::str(str);
+      }
+  }
+
+  /**
+    * These functions draws text inside a bounding box, truncating the text and
+    * adding ellipsis if the text does not fit.
+    */
+  void draw_text_with_ellipsis(CommandProcessor& cmd, int x, int y, int w, int h, const char *str, uint16_t options, uint8_t font) {
+    char tmp[strlen(str) + 3];
+    strcpy(tmp, str);
+    _draw_text_with_ellipsis(cmd, x, y, w, h, tmp, options, font);
+  }
+
+  void draw_text_with_ellipsis(CommandProcessor& cmd, int x, int y, int w, int h, progmem_str pstr, uint16_t options, uint8_t font) {
+    char tmp[strlen_P((const char*)pstr) + 3];
+    strcpy_P(tmp, (const char*)pstr);
+    _draw_text_with_ellipsis(cmd, x, y, w, h, tmp, options, font);
+  }
+} // namespace FTDI
+
+#endif // FTDI_EXTENDED

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/text_ellipsis.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/text_ellipsis.h
@@ -1,10 +1,9 @@
 /*******************
- * ftdi_extended.h *
+ * text_ellipsis.h *
  *******************/
 
 /****************************************************************************
- *   Written By Mark Pelletier  2019 - Aleph Objects, Inc.                  *
- *   Written By Marcio Teixeira 201( - Aleph Objects, Inc.                  *
+ *   Written By Marcio Teixeira 2020 - SynDaver Labs, Inc.                  *
  *                                                                          *
  *   This program is free software: you can redistribute it and/or modify   *
  *   it under the terms of the GNU General Public License as published by   *
@@ -22,30 +21,11 @@
 
 #pragma once
 
-#include "../compat.h"
-#include "../basic/ftdi_basic.h"
-
-#ifndef __MARLIN_FIRMWARE__
-  #define FTDI_EXTENDED
-#endif
-
-#ifdef FTDI_EXTENDED
-  #include "unicode/font_size_t.h"
-  #include "unicode/unicode.h"
-  #include "unicode/standard_char_set.h"
-  #include "unicode/western_char_set.h"
-  #include "unicode/font_bitmaps.h"
-  #include "rgb_t.h"
-  #include "bitmap_info.h"
-  #include "tiny_timer.h"
-  #include "grid_layout.h"
-  #include "dl_cache.h"
-  #include "event_loop.h"
-  #include "command_processor.h"
-  #include "screen_types.h"
-  #include "sound_player.h"
-  #include "sound_list.h"
-  #include "polygon.h"
-  #include "text_box.h"
-  #include "text_ellipsis.h"
-#endif
+/**
+ * This function draws text inside a bounding box, truncating the text and
+ * showing ellipsis if it does not fit.
+ */
+namespace FTDI {
+  void draw_text_with_ellipsis(class CommandProcessor& cmd, int x, int y, int w, int h, progmem_str str, uint16_t options = 0, uint8_t font = 31);
+  void draw_text_with_ellipsis(class CommandProcessor& cmd, int x, int y, int w, int h, const char *str, uint16_t options = 0, uint8_t font = 31);
+}

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/files_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/files_screen.cpp
@@ -83,15 +83,19 @@ void FilesScreen::drawFileButton(const char* filename, uint8_t tag, bool is_dir,
   cmd.font(font_medium)
      .rectangle( 0, BTN_Y(header_h+line), display_width, BTN_H(1));
   cmd.cmd(COLOR_RGB(is_highlighted ? normal_btn.rgb : bg_text_enabled));
+  constexpr uint16_t dim[2] = {BTN_SIZE(6,1)};
+  #define POS_AND_SHORTEN(SHORTEN) BTN_POS(1,header_h+line), dim[0] - (SHORTEN), dim[1]
+  #define POS_AND_SIZE             POS_AND_SHORTEN(0)
   #if ENABLED(SCROLL_LONG_FILENAMES)
     if (is_highlighted) {
       cmd.cmd(SAVE_CONTEXT());
       cmd.cmd(MACRO(0));
-    }
+      cmd.text(POS_AND_SIZE, filename, OPT_CENTERY | OPT_NOFIT);
+    } else
   #endif
-  cmd.text  (BTN_POS(1,header_h+line), BTN_SIZE(6,1), filename, OPT_CENTERY | TERN0(SCROLL_LONG_FILENAMES, OPT_NOFIT));
-  if (is_dir) {
-    cmd.text(BTN_POS(1,header_h+line), BTN_SIZE(6,1), F("> "),  OPT_CENTERY | OPT_RIGHTX);
+  draw_text_with_ellipsis(cmd, POS_AND_SHORTEN(is_dir ? 20 : 0), filename, OPT_CENTERY, font_medium);
+  if (is_dir && !is_highlighted) {
+    cmd.text(POS_AND_SIZE, F("> "),  OPT_CENTERY | OPT_RIGHTX);
   }
   #if ENABLED(SCROLL_LONG_FILENAMES)
     if (is_highlighted) {
@@ -102,7 +106,7 @@ void FilesScreen::drawFileButton(const char* filename, uint8_t tag, bool is_dir,
 
 void FilesScreen::drawFileList() {
   FileList files;
-  screen_data.FilesScreen.num_page = max(1,(ceil)(float(files.count()) / files_per_page));
+  screen_data.FilesScreen.num_page = max(1,ceil(float(files.count()) / files_per_page));
   screen_data.FilesScreen.cur_page = min(screen_data.FilesScreen.cur_page, screen_data.FilesScreen.num_page-1);
   screen_data.FilesScreen.flags.is_root  = files.isAtRootDir();
 
@@ -133,7 +137,6 @@ void FilesScreen::drawHeader() {
   char str[16];
   sprintf_P(str, PSTR("Page %d of %d"),
     screen_data.FilesScreen.cur_page + 1, screen_data.FilesScreen.num_page);
-
 
   CommandProcessor cmd;
   cmd.colors(normal_btn)

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
@@ -96,7 +96,7 @@ enum {
 #define STATUS_SCREEN_DL_SIZE        2048
 #define ALERT_BOX_DL_SIZE            3072
 #define SPINNER_DL_SIZE              3072
-#define FILE_SCREEN_DL_SIZE          3072
+#define FILE_SCREEN_DL_SIZE          4160
 #define PRINTING_SCREEN_DL_SIZE      2048
 
 /************************* MENU SCREEN DECLARATIONS *************************/


### PR DESCRIPTION
# Description

This PR improves the FTDI_EVE_TOUCH_UI's handling of long file names.

- Added routines for printing truncated strings with ellipsis ("...")
- Long file names are now truncated and followed by ellipsis ("...")
- Fix for long directory names overwriting the ">" indicator
- Fixed incorrect handling of graphics buffers.
- Added a visual error message when the graphics buffer is exceeded.
- Increased graphics buffer size to accommodate cases in which file names fill the screen.


### Benefits

Before, if the user had particularly long file names in their SD cards, the Files display screen would glitch out and stop working. This PR corrects this issue. This PR also improves error reporting so it is easier to see when some code is running out of graphics buffer space.
