### PR TITLE
Fix for long filenames

### DIFF
--- a/Marlin/src/lcd/dwin/dwin_lcd.cpp
+++ b/Marlin/src/lcd/dwin/dwin_lcd.cpp
@@ -39,7 +39,7 @@
 
 // Make sure DWIN_SendBuf is large enough to hold the largest
 // printed string plus the draw command and tail.
-uint8_t DWIN_SendBuf[11 + 24] = { 0xAA };
+uint8_t DWIN_SendBuf[11 + DWIN_WIDTH / 8] = { 0xAA };
 uint8_t DWIN_BufTail[4] = { 0xCC, 0x33, 0xC3, 0x3C };
 uint8_t databuf[26] = { 0 };
 uint8_t receivedType;
@@ -63,7 +63,7 @@ inline void DWIN_Long(size_t &i, const uint32_t lval) {
 }
 
 inline void DWIN_String(size_t &i, char * const string) {
-  const size_t len = strlen(string);
+  const size_t len = _MIN(sizeof(DWIN_SendBuf) - i, strlen(string));
   memcpy(&DWIN_SendBuf[i+1], string, len);
   i += len;
 }


### PR DESCRIPTION
### Description


This is the fix to the file with long file names over 22 characters long causing high speeds and print crashes.
Changes the buffer to be the right size based on screen width.  Also adjust string buffer to be the length of the actual string to prevent too large a buffer.



### Benefits
This allows people to use large files names, stops issues with suddenly high, speed and some printer crashes.

### Configurations

[configs.zip](https://github.com/MarlinFirmware/Marlin/files/5177748/configs.zip)


### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/18790
