### PR TITLE
Fix Buffer Corruption

### DIFF
--- a/Marlin/src/lcd/dwin/dwin_lcd.cpp
+++ b/Marlin/src/lcd/dwin/dwin_lcd.cpp
@@ -39,7 +39,7 @@
 
 // Make sure DWIN_SendBuf is large enough to hold the largest
 // printed string plus the draw command and tail.
-uint8_t DWIN_SendBuf[11 + 24] = { 0xAA };
+uint8_t DWIN_SendBuf[11 + DWIN_WIDTH / 8] = { 0xAA };
 uint8_t DWIN_BufTail[4] = { 0xCC, 0x33, 0xC3, 0x3C };
 uint8_t databuf[26] = { 0 };
 uint8_t receivedType;
@@ -63,7 +63,7 @@ inline void DWIN_Long(size_t &i, const uint32_t lval) {
 }
 
 inline void DWIN_String(size_t &i, char * const string) {
-  const size_t len = strlen(string);
+  const size_t len = _MIN(sizeof(DWIN_SendBuf) - i, strlen(string));
   memcpy(&DWIN_SendBuf[i+1], string, len);
   i += len;
 }

--- a/Marlin/src/lcd/dwin/dwin_lcd.cpp
+++ b/Marlin/src/lcd/dwin/dwin_lcd.cpp
@@ -39,7 +39,7 @@
 
 // Make sure DWIN_SendBuf is large enough to hold the largest
 // printed string plus the draw command and tail.
-uint8_t DWIN_SendBuf[11 + DWIN_WIDTH / 8] = { 0xAA };
+uint8_t DWIN_SendBuf[11 + DWIN_WIDTH / 6 * 2] = { 0xAA };
 uint8_t DWIN_BufTail[4] = { 0xCC, 0x33, 0xC3, 0x3C };
 uint8_t databuf[26] = { 0 };
 uint8_t receivedType;

--- a/Marlin/src/lcd/dwin/dwin_lcd.cpp
+++ b/Marlin/src/lcd/dwin/dwin_lcd.cpp
@@ -37,8 +37,8 @@
 #include "dwin_lcd.h"
 #include <string.h> // for memset
 
-// Make sure DWIN_SendBuf is large enough to hold the largest
-// printed string plus the draw command and tail.
+// Make sure DWIN_SendBuf is large enough to hold the largest string plus draw command and tail.
+// Assume the narrowest (6 pixel) font and 2-byte gb2312-encoded characters.
 uint8_t DWIN_SendBuf[11 + DWIN_WIDTH / 6 * 2] = { 0xAA };
 uint8_t DWIN_BufTail[4] = { 0xCC, 0x33, 0xC3, 0x3C };
 uint8_t databuf[26] = { 0 };


### PR DESCRIPTION
### Description

Fixes files over 22 characters long in the DWIN screen for the ender3 V2.  Adjust buffer for size of the DWIN screen width.  Also Set of DWIN_Strings so the the string buffer is not longer than the string.

### Benefits
This fixes the over 22 character file name issue that caused buffer corruption.  This resolves the high speed and some of the crashes associated with this buffer corruption.

### Configurations

[configs.zip](https://github.com/MarlinFirmware/Marlin/files/5177768/configs.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/18790
