### PR TITLE
Fix STM32F1 SPI device init, MKS_LCD12864

### DIFF
--- a/Marlin/src/HAL/STM32F1/SPI.cpp
+++ b/Marlin/src/HAL/STM32F1/SPI.cpp
@@ -40,6 +40,9 @@
 #include <boards.h>
 #include <wirish.h>
 
+#include "../../inc/MarlinConfig.h"
+#include "spi_pins.h"
+
 /** Time in ms for DMA receive timeout */
 #define DMA_TIMEOUT 100
 
@@ -710,10 +713,6 @@ static spi_baud_rate determine_baud_rate(spi_dev *dev, uint32_t freq) {
   return baud_rates[i];
 }
 
-#if SPI_DEVICE == 1
-  SPIClass SPI(1);
-#else
-  SPIClass SPI(2);
-#endif
+SPIClass SPI(SPI_DEVICE);
 
 #endif // __STM32F1__

--- a/Marlin/src/HAL/STM32F1/SPI.cpp
+++ b/Marlin/src/HAL/STM32F1/SPI.cpp
@@ -710,6 +710,10 @@ static spi_baud_rate determine_baud_rate(spi_dev *dev, uint32_t freq) {
   return baud_rates[i];
 }
 
-SPIClass SPI(1);
+#if SPI_DEVICE == 1
+  SPIClass SPI(1);
+#else
+  SPIClass SPI(2);
+#endif
 
 #endif // __STM32F1__

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -53,7 +53,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../inc/MarlinConfigPre.h"
+#include "../../inc/MarlinConfig.h"
 
 #if HAS_GRAPHICAL_LCD
 
@@ -143,6 +143,7 @@ uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg,
     case U8G_DEV_MSG_INIT:
       u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_init_seq);
+      delay(150);
       break;
 
     case U8G_DEV_MSG_STOP: break;
@@ -172,6 +173,7 @@ uint8_t u8g_dev_uc1701_mini12864_HAL_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
     case U8G_DEV_MSG_INIT:
       u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_init_seq);
+      delay(150);
       break;
 
     case U8G_DEV_MSG_STOP: break;

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -112,7 +112,7 @@ static const uint8_t u8g_dev_uc1701_mini12864_HAL_init_seq[] PROGMEM = {
   U8G_ESC_CS(1),              // enable chip
   UC1701_ALL_PIX(0),          // normal display
   U8G_ESC_CS(0),              // disable chip
-  U8G_ESC_DLY(150),           // delay 150 ms before send any data
+  U8G_ESC_DLY(150),           // delay 150 ms before sending any data
   U8G_ESC_END                 // end of sequence
 };
 

--- a/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_uc1701_mini12864_HAL.cpp
@@ -53,7 +53,7 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "../../inc/MarlinConfig.h"
+#include "../../inc/MarlinConfigPre.h"
 
 #if HAS_GRAPHICAL_LCD
 
@@ -112,6 +112,7 @@ static const uint8_t u8g_dev_uc1701_mini12864_HAL_init_seq[] PROGMEM = {
   U8G_ESC_CS(1),              // enable chip
   UC1701_ALL_PIX(0),          // normal display
   U8G_ESC_CS(0),              // disable chip
+  U8G_ESC_DLY(150),           // delay 150 ms before send any data
   U8G_ESC_END                 // end of sequence
 };
 
@@ -143,7 +144,6 @@ uint8_t u8g_dev_uc1701_mini12864_HAL_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg,
     case U8G_DEV_MSG_INIT:
       u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_init_seq);
-      delay(150);
       break;
 
     case U8G_DEV_MSG_STOP: break;
@@ -173,7 +173,6 @@ uint8_t u8g_dev_uc1701_mini12864_HAL_2x_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t m
     case U8G_DEV_MSG_INIT:
       u8g_InitCom(u8g, dev, U8G_SPI_CLK_CYCLE_300NS);
       u8g_WriteEscSeqP(u8g, dev, u8g_dev_uc1701_mini12864_HAL_init_seq);
-      delay(150);
       break;
 
     case U8G_DEV_MSG_STOP: break;

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -240,39 +240,35 @@ bool MarlinUI::detected() { return true; }
 
 // Initialize or re-initialize the LCD
 void MarlinUI::init_lcd() {
-  #if DISABLED(MKS_LCD12864)
+  #if PIN_EXISTS(LCD_BACKLIGHT)
+    OUT_WRITE(LCD_BACKLIGHT_PIN, DISABLED(DELAYED_BACKLIGHT_INIT)); // Illuminate after reset or right away
+  #endif
 
-    #if PIN_EXISTS(LCD_BACKLIGHT)
-      OUT_WRITE(LCD_BACKLIGHT_PIN, DISABLED(DELAYED_BACKLIGHT_INIT)); // Illuminate after reset or right away
+  #if ANY(MKS_12864OLED, MKS_12864OLED_SSD1306, FYSETC_242_OLED_12864, ZONESTAR_12864OLED)
+    SET_OUTPUT(LCD_PINS_DC);
+    #ifndef LCD_RESET_PIN
+      #define LCD_RESET_PIN LCD_PINS_RS
     #endif
+  #endif
 
-    #if ANY(MKS_12864OLED, MKS_12864OLED_SSD1306, FYSETC_242_OLED_12864, ZONESTAR_12864OLED)
-      SET_OUTPUT(LCD_PINS_DC);
-      #ifndef LCD_RESET_PIN
-        #define LCD_RESET_PIN LCD_PINS_RS
-      #endif
-    #endif
+  #if PIN_EXISTS(LCD_RESET)
+    // Perform a clean hardware reset with needed delays
+    OUT_WRITE(LCD_RESET_PIN, LOW);
+    _delay_ms(5);
+    WRITE(LCD_RESET_PIN, HIGH);
+    _delay_ms(5);
+    u8g.begin();
+  #endif
 
-    #if PIN_EXISTS(LCD_RESET)
-      // Perform a clean hardware reset with needed delays
-      OUT_WRITE(LCD_RESET_PIN, LOW);
-      _delay_ms(5);
-      WRITE(LCD_RESET_PIN, HIGH);
-      _delay_ms(5);
-      u8g.begin();
-    #endif
+  #if PIN_EXISTS(LCD_BACKLIGHT) && ENABLED(DELAYED_BACKLIGHT_INIT)
+    WRITE(LCD_BACKLIGHT_PIN, HIGH);
+  #endif
 
-    #if PIN_EXISTS(LCD_BACKLIGHT) && ENABLED(DELAYED_BACKLIGHT_INIT)
-      WRITE(LCD_BACKLIGHT_PIN, HIGH);
-    #endif
+  TERN_(HAS_LCD_CONTRAST, refresh_contrast());
 
-    TERN_(HAS_LCD_CONTRAST, refresh_contrast());
-
-    TERN_(LCD_SCREEN_ROT_90, u8g.setRot90());
-    TERN_(LCD_SCREEN_ROT_180, u8g.setRot180());
-    TERN_(LCD_SCREEN_ROT_270, u8g.setRot270());
-
-  #endif // !MKS_LCD12864
+  TERN_(LCD_SCREEN_ROT_90, u8g.setRot90());
+  TERN_(LCD_SCREEN_ROT_180, u8g.setRot180());
+  TERN_(LCD_SCREEN_ROT_270, u8g.setRot270());
 
   uxg_SetUtf8Fonts(g_fontinfo, COUNT(g_fontinfo));
 }

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -152,8 +152,6 @@
     #define DOGLCD_SCK                      PB13
     #define DOGLCD_MOSI                     PB15
 
-    #undef SHOW_BOOTSCREEN
-
   #else
 
     #define LCD_PINS_D4                     PA6

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -33,7 +33,6 @@
 
 //#define DISABLE_DEBUG
 #define DISABLE_JTAG
-#define ENABLE_SPI2
 
 //
 // EEPROM

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE3.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE3.h
@@ -115,8 +115,6 @@
     #define DOGLCD_SCK                      PB13
     #define DOGLCD_MOSI                     PB15
 
-    #undef SHOW_BOOTSCREEN
-
   #else                                           // !MKS_MINI_12864
 
     #define LCD_PINS_D4                     PA6

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -351,9 +351,6 @@
     #define DOGLCD_SCK                      PA5
     #define DOGLCD_MOSI                     PA7
 
-    // Required for MKS_MINI_12864 with this board
-    #define MKS_LCD12864B
-
   #else                                           // !MKS_MINI_12864
 
     #define LCD_PINS_D4                     PE14

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -353,7 +353,6 @@
 
     // Required for MKS_MINI_12864 with this board
     #define MKS_LCD12864B
-    #undef SHOW_BOOTSCREEN
 
   #else                                           // !MKS_MINI_12864
 


### PR DESCRIPTION
### Description

Some PINs file have `ENABLE_SPI2`, to select the SPI 2 as the main device. But the current code start the SPI object with the SPI 1.
If any code try to use SPI before calling `spiInit` function (that set it according to board pins), the SPI will not work.

And this is the problem with #19269 . The LCD code in u8glib don't call `spiInit`, it rely on the current SPI selected from the global SPI object.

The MKS fix call SD card mount in the init of marlin code. The SD mount code call `spiInit`, putting the SPI to the right device, so its the reason why LCD works after the sd card mount. That SD mount just hide the real problem.

This fix start the SPI object with according with the board definition. It solves the problem in the root cause.

@thisiskeithb tested it and solved the LCD problem.

~But it generate other issue: a very long boot time, that I'm looking for and `SD Init Fail error`~. We check and that issue always happens, even with the old and mks pr. It's a boot loader issue. The delay happens before marlin ever starts.

### Benefits

- Fix STM32F1 HAL SPI default device
- Fix #19159

### Configurations



### Related Issues

#19269 
#19159