### PR TITLE
Emergency Parser for STM32F1 with USB_COMPOSITE

### DIFF
--- a/Marlin/src/HAL/STM32F1/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32F1/msc_sd.cpp
@@ -44,10 +44,8 @@ MarlinUSBCompositeSerial MarlinCompositeSerial;
   void my_rx_callback(void) {
     real_rx_callback();
     int len = MarlinCompositeSerial.available();
-    // > 0 because available() return int... and we may get a -1 here...
-    while(len-- > 0){
+    while (len-- > 0) // >0 because available() may return a negative value
       emergency_parser.update(MarlinCompositeSerial.emergency_state, MarlinCompositeSerial.peek());
-    }
   }
 #endif
 

--- a/Marlin/src/HAL/STM32F1/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32F1/msc_sd.cpp
@@ -21,7 +21,7 @@
 #define PRODUCT_ID 0x29
 
 USBMassStorage MarlinMSC;
-USBCompositeSerial MarlinCompositeSerial;
+MarlinUSBCompositeSerial MarlinCompositeSerial;
 
 #include "../../inc/MarlinConfig.h"
 
@@ -36,6 +36,19 @@ USBCompositeSerial MarlinCompositeSerial;
     return (disk_read(0, readbuff, startSector, numSectors) == RES_OK);
   }
 
+#endif
+
+#if ENABLED(EMERGENCY_PARSER)
+  void (*real_rx_callback)(void);
+
+  void my_rx_callback(void) {
+    real_rx_callback();
+    int len = MarlinCompositeSerial.available();
+    // > 0 because available() return int... and we may get a -1 here...
+    while(len-- > 0){
+      emergency_parser.update(MarlinCompositeSerial.emergency_state, MarlinCompositeSerial.peek());
+    }
+  }
 #endif
 
 void MSC_SD_init() {
@@ -59,6 +72,11 @@ void MSC_SD_init() {
   // Register composite Serial
   MarlinCompositeSerial.registerComponent();
   USBComposite.begin();
+  #if ENABLED(EMERGENCY_PARSER)
+    //rx is usbSerialPart.endpoints[2]
+    real_rx_callback = usbSerialPart.endpoints[2].callback;
+    usbSerialPart.endpoints[2].callback = my_rx_callback;
+  #endif
 }
 
 #endif // USE_USB_COMPOSITE

--- a/Marlin/src/HAL/STM32F1/msc_sd.h
+++ b/Marlin/src/HAL/STM32F1/msc_sd.h
@@ -17,7 +17,25 @@
 
 #include <USBComposite.h>
 
+#include "../../inc/MarlinConfigPre.h"
+#if ENABLED(EMERGENCY_PARSER)
+  #include "../../feature/e_parser.h"
+#endif
+
+class MarlinUSBCompositeSerial : public USBCompositeSerial {
+public:
+  MarlinUSBCompositeSerial() : USBCompositeSerial()
+    #if ENABLED(EMERGENCY_PARSER)
+      , emergency_state(EmergencyParser::State::EP_RESET)
+    #endif
+    { }
+
+  #if ENABLED(EMERGENCY_PARSER)
+    EmergencyParser::State emergency_state;
+  #endif
+};
+
 extern USBMassStorage MarlinMSC;
-extern USBCompositeSerial MarlinCompositeSerial;
+extern MarlinUSBCompositeSerial MarlinCompositeSerial;
 
 void MSC_SD_init();


### PR DESCRIPTION
### Description

Emergency Parser for STM32F1 when using USB_COMPOSITE.

@thisiskeithb tested and it works! ~is testing this PR, as I don't have a STM32F1 board with USB_COMPOSITE support~.

### Benefits

Emergency parser for _USB env/boards, like BOARD_BTT_SKR_MINI_E3_V2_0

### Related Issues

#19279 
