### PR TITLE
Fix M166 Gradient Mix on delta printers

### DIFF
--- a/Marlin/src/feature/mixing.cpp
+++ b/Marlin/src/feature/mixing.cpp
@@ -180,7 +180,12 @@ void Mixer::refresh_collector(const float proportion/*=1.0*/, const uint8_t t/*=
   }
 
   void Mixer::update_gradient_for_planner_z() {
-    update_gradient_for_z(planner.get_axis_position_mm(Z_AXIS));
+    #if ENABLED(DELTA)
+      get_cartesian_from_steppers();
+      update_gradient_for_z(cartes.z);
+    #else
+      update_gradient_for_z(planner.get_axis_position_mm(Z_AXIS));
+    #endif
   }
 
 #endif // GRADIENT_MIX

--- a/Marlin/src/gcode/feature/mixing/M166.cpp
+++ b/Marlin/src/gcode/feature/mixing/M166.cpp
@@ -86,7 +86,11 @@ void GcodeSuite::M166() {
     echo_zt(mixer.gradient.end_vtool, mixer.gradient.end_z);
 
     mixer.update_mix_from_gradient();
-    SERIAL_ECHOPAIR(" ; Current Z", planner.get_axis_position_mm(Z_AXIS));
+    #if ENABLED(DELTA)
+      SERIAL_ECHOPAIR(" ; Current Z", cartes.z);
+    #else
+      SERIAL_ECHOPAIR(" ; Current Z", planner.get_axis_position_mm(Z_AXIS));
+    #endif
     echo_mix();
   }
 


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

The updates for M166 gradient mix on delta printers use the z tower stepper position instead of the toolhead cartesian z position. This leads to current gradient mix being constantly changing during a single layer as seen here and results in the gradient being rotated and offset.

Example:

![2020-09-06 12 34 46](https://user-images.githubusercontent.com/751209/92334012-d88d5100-f03e-11ea-9340-12a8057fa71c.jpg)

I am not sure if the fix I have made is the correct way to do it. I have been running with this patch and it does fix the issue. This likely creates additional cycles with having to call for a forward kinematics update more often, though a delta+mixing setup should already preclude 8-bit controllers.

### Benefits

Allows M166 to work as intended on delta printers.

### Configurations

[RGB_Delta.zip](https://github.com/MarlinFirmware/Marlin/files/5180702/RGB_Delta.zip)

### Related Issues

#18917 
