### PR TITLE
BABYSTEP_DISPLAY_TOTAL isn't supported by Color UI (yet)

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -789,6 +789,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #if ENABLED(BABYSTEP_XY)
       static_assert(BABYSTEP_MULTIPLICATOR_XY <= 0.25f, "BABYSTEP_MULTIPLICATOR_XY must be less than or equal to 0.25mm.");
     #endif
+  #elif ENABLED(BABYSTEP_DISPLAY_TOTAL) && ANY(TFT_320x240, TFT_320x240_SPI, TFT_480x320, TFT_480x320_SPI)
+    #error "New Color UI (TFT_320x240, TFT_320x240_SPI, TFT_480x320, TFT_480x320_SPI) does not support BABYSTEP_DISPLAY_TOTAL yet."
   #endif
 #endif
 


### PR DESCRIPTION
### Description

Some users are having issues with undefined references and marlin dying, with baby step and the new color ui. 

It's because the new color UI don't support BABYSTEP_DISPLAY_TOTAL (yet) and the user is not informed.

This PR just add a sanity check, until we have full support in the new UI (that can take some time)

### Benefits

??Fixes?? #19233

