### PR TITLE
Fix TFT LCD build (untested)

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2612,14 +2612,14 @@
   #ifndef LCD_WIDTH
     #if HAS_GRAPHICAL_LCD
       #define LCD_WIDTH 21
-    #elif HAS_CHARACTER_LCD
+    #else
       #define LCD_WIDTH TERN(ULTIPANEL, 20, 16)
     #endif
   #endif
   #ifndef LCD_HEIGHT
     #if HAS_GRAPHICAL_LCD
       #define LCD_HEIGHT 5
-    #elif HAS_CHARACTER_LCD
+    #else
       #define LCD_HEIGHT TERN(ULTIPANEL, 4, 2)
     #endif
   #endif

--- a/Marlin/src/lcd/lcdprint.h
+++ b/Marlin/src/lcd/lcdprint.h
@@ -79,7 +79,7 @@
   #define SETCURSOR(col, row)    lcd_moveto((col) * (MENU_FONT_WIDTH), ((row) + 1) * (MENU_FONT_HEIGHT))
   #define SETCURSOR_RJ(len, row) lcd_moveto(LCD_PIXEL_WIDTH - (len) * (MENU_FONT_WIDTH), ((row) + 1) * (MENU_FONT_HEIGHT))
 
-#elif HAS_CHARACTER_LCD
+#else
 
   #define _UxGT(a) a
   typedef uint8_t lcd_uint_t;


### PR DESCRIPTION
### Description

The changes in a445746a8b6dd752de725eb67d264153c3b393d7 broke TFT builds, including the `mks_robin_stm32` environment in CI. This reverts the portion of the change which broke the build.

### Benefits

Allows building with TFT enabled, and fixes CI.

I have not actually tested the change.

### Configurations

`use_example_configs Mks/Robin`

### Related Issues

N/A
