### PR TITLE
[bugfix-2.0.x] Fix minor compilation errors in specific configurations

### DIFF
--- a/Marlin/src/HAL/STM32F1/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32F1/MarlinSerial.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#ifdef __STM32F1__
+
 #include "../../inc/MarlinConfigPre.h"
 #include "MarlinSerial.h"
 #include <libmaple/usart.h>
@@ -91,3 +93,5 @@ static inline __always_inline void my_usart_irq(ring_buffer *rb, ring_buffer *wb
 #if SERIAL_PORT == 5 || SERIAL_PORT_2 == 5 || DGUS_SERIAL_PORT == 5
   DEFINE_HWSERIAL_UART_MARLIN(MSerial5, 5);
 #endif
+
+#endif // __STM32F1__

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -61,7 +61,7 @@ namespace ExtUI {
     if (AT_SCREEN(StatusScreen) || isPrintingFromMedia())
       StatusScreen::setStatusMessage(GET_TEXT_F(MSG_MEDIA_REMOVED));
 
-    if (AT_SCREEN(FilesScreen)) GOTO_SCREEN(StatusScreen)
+    if (AT_SCREEN(FilesScreen)) GOTO_SCREEN(StatusScreen);
   }
 
   void onMediaError() {

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -1003,7 +1003,7 @@ namespace ExtUI {
   bool FileList::seek(const uint16_t pos, const bool skip_range_check) {
     #if ENABLED(SDSUPPORT)
       if (!skip_range_check && (pos + 1) > count()) return false;
-      card.getfilename_sorted(pos);
+      card.getfilename_sorted(SD_ORDER(pos, count()));
       return card.filename[0] != '\0';
     #else
       UNUSED(pos);


### PR DESCRIPTION
Two minor compilation errors that crop up in very specific configurations (and probably don't affect anyone other than me!)

- Fix compilation error when using Makefile by adding guard for STM32F1 code
- Fix compilation error when compiling touch UI for bio printer.

