### PR TITLE
Add RCT6 512K PIO environment warning

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -739,6 +739,11 @@ upload_protocol   = serial
 #   STM32F103RC_btt_512K ........ RCT6 with 512K
 #   STM32F103RC_btt_512K_USB .... RCT6 with 512K (USB mass storage)
 #
+# WARNING! If you have an SKR Mini v1.1 or an SKR Mini E3 1.0 / 1.2 / 2.0 / DIP
+# and experience a printer freeze, re-flash Marlin using the regular (non-512K)
+# build option. 256K chips may be re-branded 512K chips, but this means the
+# upper 256K is sketchy, and failure is very likely.
+#
 
 [env:STM32F103RC_btt]
 platform          = ${common_stm32f1.platform}


### PR DESCRIPTION
### Requirements

SKR Mini SKR Mini v1.1 or SKR Mini E3 1.0 / 1.2 / 2.0 / DIP with an `STM32F103RCT6` MCU (256k) & `_512K` environment.

### Description

Users may not have seen the warnings go out [over Twitter](https://twitter.com/thinkyhead/status/1240405516863655943) or [Marlin's Discord](https://discordapp.com/channels/461605380783472640/491006207822266399/693568579047653448), so I added the comment directly in `platformio.ini`.

### Benefits

Warn users of possible dangers using the `_512K` PIO environment on SKR Mini/Mini E3 builds.

### Related Issues

None.
