### PR TITLE
Fix RGB parameter typo

### DIFF
--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -28,7 +28,7 @@
 #include "../../../feature/leds/leds.h"
 
 /**
- * M150: Set Status LED Color - Use R-U-B-W for R-G-B-W
+ * M150: Set Status LED Color - Use R-G-B-W
  *       and Brightness       - Use P (for NEOPIXEL only)
  *
  * Always sets all 3 or 4 components. If a component is left out, set to 0.
@@ -43,9 +43,9 @@
  * Examples:
  *
  *   M150 R255       ; Turn LED red
- *   M150 R255 U127  ; Turn LED orange (PWM only)
+ *   M150 R255 G127  ; Turn LED orange (PWM only)
  *   M150            ; Turn LED off
- *   M150 R U B      ; Turn LED white
+ *   M150 R G B      ; Turn LED white
  *   M150 W          ; Turn LED white using a white LED
  *   M150 P127       ; Set LED 50% brightness
  *   M150 P          ; Set LED full brightness
@@ -68,7 +68,7 @@ void GcodeSuite::M150() {
 
   const LEDColor color = MakeLEDColor(
     parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-    parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+    parser.seen('G') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
     parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
     parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
     parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : brightness


### PR DESCRIPTION
### Description

Fixed the usage of "U" instead of "G" for setting the green component of a RGB light.

### Benefits

More logical usage of parameters when setting RGB colors

### Configurations

configuration.h must have an RGB light enabled and pins for controlling it set
