### PR TITLE
BTT SKR V1.1, V1.3, V1.4, V1.4 Turbo - Added missing pins for E1 stepper and added definition of E1 as Z2 Stepper

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
@@ -52,6 +52,14 @@
 #define E0_DIR_PIN                         P2_13
 #define E0_ENABLE_PIN                      P2_12
 
+#define E1_STEP_PIN                        P0_01
+#define E1_DIR_PIN                         P0_00
+#define E1_ENABLE_PIN                      P0_10
+
+#define Z2_STEP_PIN                        P0_01 // Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
+#define Z2_DIR_PIN                         P0_00 // E1 as Z2
+#define Z2_ENABLE_PIN                      P0_10 // E1 as Z2
+
 /**
  * LCD / Controller
  *
@@ -166,6 +174,12 @@
       #undef E1_ENABLE_PIN
     #endif
 
+    #if AXIS_DRIVER_TYPE_Z2(TMC2130)              // Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
+      #define Z2_CS_PIN                    P0_10  // E1 as Z2
+      #undef Z2_ENABLE_PIN                        // E1 as Z2
+    #endif
+
+
   #else                                           // !SOFTWARE_DRIVER_ENABLE
 
     // A chip-select pin is needed for each driver.
@@ -184,6 +198,7 @@
       #define Z_CS_PIN                     P2_11
       #define E0_CS_PIN                    P3_25
       #define E1_CS_PIN                    P1_31
+      #define Z2_CS_PIN                    P1_31  // Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
     #endif
 
     // Example 2: A REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
@@ -204,6 +219,7 @@
       #undef LCD_SDSS
       #define LCD_SDSS                     -1
       #define E1_CS_PIN                    P1_23
+      #define Z2_CS_PIN                    P1_23  // Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
     #endif
 
     // Example 3: Use the driver enable pins for chip-select.
@@ -216,6 +232,7 @@
       #define Z_CS_PIN              Z_ENABLE_PIN
       #define E0_CS_PIN            E0_ENABLE_PIN
       #define E1_CS_PIN            E1_ENABLE_PIN
+      #define Z2_CS_PIN            Z2_ENABLE_PIN
     #endif
 
   #endif // SOFTWARE_DRIVER_ENABLE

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -31,6 +31,7 @@
 #define Z_DIAG_PIN                         P1_25  // Z-
 #define E0_DIAG_PIN                        P1_28  // X+
 #define E1_DIAG_PIN                        P1_26  // Y+
+#define Z2_DIAG_PIN                        P1_26  // Y+ - Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
 
 //
 // Limit Switches
@@ -125,9 +126,21 @@
   #define E0_CS_PIN                        P1_08
 #endif
 
+#define E1_STEP_PIN                        P0_01
+#define E1_DIR_PIN                         P0_00
+#define E1_ENABLE_PIN                      P0_10
 #ifndef E1_CS_PIN
   #define E1_CS_PIN                        P1_01
 #endif
+
+#define Z2_STEP_PIN                        P0_01 // Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
+#define Z2_DIR_PIN                         P0_00 // E1 as Z2
+#define Z2_ENABLE_PIN                      P0_10 // E1 as Z2
+#ifndef Z2_CS_PIN
+  #define Z2_CS_PIN                        P1_01 // E1 as Z2
+#endif
+
+
 
 //
 // Software SPI pins for TMC2130 stepper drivers
@@ -180,6 +193,9 @@
 
   #define E1_SERIAL_TX_PIN                 P1_04
   #define E1_SERIAL_RX_PIN                 P1_01
+
+  #define Z2_SERIAL_TX_PIN                 P1_04 // Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
+  #define Z2_SERIAL_RX_PIN                 P1_01 // E1 as Z2
 
   // Reduce baud rate to improve software serial reliability
   #define TMC_BAUD_RATE                    19200

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -45,6 +45,7 @@
 #define Z_DIAG_PIN                         P1_27  // Z-STOP
 #define E0_DIAG_PIN                        P1_26  // E0DET
 #define E1_DIAG_PIN                        P1_25  // E1DET
+#define Z2_DIAG_PIN                        P1_25  // E1DET - Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
 
 //
 // Limit Switches
@@ -149,6 +150,13 @@
   #define E1_CS_PIN                        P1_01
 #endif
 
+#define Z2_STEP_PIN                        P1_15  // Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
+#define Z2_DIR_PIN                         P1_14  // E1 as Z2
+#define Z2_ENABLE_PIN                      P1_16  // E1 as Z2
+#ifndef Z2_CS_PIN
+  #define Z2_CS_PIN                        P1_01  // E1 as Z2
+#endif
+
 #define TEMP_1_PIN                      P0_23_A0  // A2 (T2) - (69) - TEMP_1_PIN
 #define TEMP_BED_PIN                    P0_25_A2  // A0 (T0) - (67) - TEMP_BED_PIN
 
@@ -204,8 +212,8 @@
   #define E1_SERIAL_TX_PIN                 P1_01
   #define E1_SERIAL_RX_PIN                 P1_01
 
-  #define Z2_SERIAL_TX_PIN                 P1_01
-  #define Z2_SERIAL_RX_PIN                 P1_01
+  #define Z2_SERIAL_TX_PIN                 P1_01 // Reusing E1 Stepper Port as Z2 for Dual Z-Stepper
+  #define Z2_SERIAL_RX_PIN                 P1_01 // E1 as Z2
 
   // Reduce baud rate to improve software serial reliability
   #define TMC_BAUD_RATE                    19200


### PR DESCRIPTION

### Requirements

* It doesn't change anything for users who don't use E1 nor Z2, since the definitions are added. 

### Description

I saw some confusion of how to use the SKR V1.3 (and the same applies to V1.1 and V1.4/V1.4 Turbo) in a Dual Z-stepper setup. 

I investigated the src/pins/lpc176x/pins_BTT_SKR_V1_x.h definitions and figured out that the pin assignments for E1 stepper were just partial done or completly missing. 

I also added the definition of Z2 on the E1 pins, so the user can utilize the E1 Stepper for Dual-Z motors just by changing the corresponding Configuration_adv.h and not fiddling around with the SKR pin definitions. 

### Benefits

a) The user can finally use the E1 stepper without doing manual changes to the SKR pin descriptions. 
b) The user can utilize the E1 Stepper for Dual-Z motors just by changing the corresponding Configuration_adv.h and not fiddling around with the SKR pin definitions.

### Configurations

Basically just add a stepper driver of your choice on E1 and either add
#define E1_DRIVER_TYPE  
as usual 

or if you want to test dual z stepper setups: 
Configuration.h 
#define Z2_DRIVER_TYPE 
and 
Configuration_adv.h 
#define NUM_Z_STEPPER_DRIVERS 2 

to test Dual-Z stepper motor setups on BigTreeTech V1.1, V1.3, V1.4 and V1.4 Turbo 

### Related Issues

