### PR TITLE
Add vscode extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,11 +161,8 @@ __vm/
 vc-fileutils.settings
 
 #Visual Studio Code
-.vscode
-.vscode/.browse.c_cpp.db*
-.vscode/c_cpp_properties.json
-.vscode/launch.json
-.vscode/*.db
+.vscode/**
+!.vscode/extensions.json
 
 #cmake
 CMakeLists.txt

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide",
+        "MarlinFirmware.auto-build"
+    ]
+}


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

We wouldn't normally commit these files but because Marlin 2 is so dependent on platformio and the instructions also suggest the use of auto-build Marlin this change is helpful. When opening the Marlin folder for the first time, if the recommended plugins are not installed in vscode, then it will prompt the user to install. This way the user also knows they are getting the correct plugins.

### Benefits

<!-- What does this fix or improve? -->
This should make getting VSCode configured easier for newbies. 

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

To test this PR simply delete the plugins from your vscode then open the project (on this branch). You will get a VSCode prompt in the bottom right corner asking if you would like to install the recommended plugins.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
