### PR TITLE
Fix Danish and Basque-Euskera languages

### DIFF
--- a/Marlin/src/lcd/language/language_da.h
+++ b/Marlin/src/lcd/language/language_da.h
@@ -52,7 +52,7 @@ namespace Language_da {
   #if PREHEAT_COUNT
     PROGMEM Language_Str MSG_PREHEAT_1                     = _UxGT("Forvarm ") PREHEAT_1_LABEL;
     PROGMEM Language_Str MSG_PREHEAT_1_H                   = _UxGT("Forvarm ") PREHEAT_1_LABEL " ~";
-    PROGMEM Language_Str MSG_PREHEAT_1_END                 = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" end")
+    PROGMEM Language_Str MSG_PREHEAT_1_END                 = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" end");
     PROGMEM Language_Str MSG_PREHEAT_1_END_E               = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" end ~");
     PROGMEM Language_Str MSG_PREHEAT_1_ALL                 = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" Alle");
     PROGMEM Language_Str MSG_PREHEAT_1_BEDONLY             = _UxGT("Forvarm ") PREHEAT_1_LABEL _UxGT(" Bed");
@@ -60,7 +60,7 @@ namespace Language_da {
 
     PROGMEM Language_Str MSG_PREHEAT_M                     = _UxGT("Forvarm $");
     PROGMEM Language_Str MSG_PREHEAT_M_H                   = _UxGT("Forvarm $ ~");
-    PROGMEM Language_Str MSG_PREHEAT_M_END                 = _UxGT("Forvarm $ end")
+    PROGMEM Language_Str MSG_PREHEAT_M_END                 = _UxGT("Forvarm $ end");
     PROGMEM Language_Str MSG_PREHEAT_M_END_E               = _UxGT("Forvarm $ end ~");
     PROGMEM Language_Str MSG_PREHEAT_M_ALL                 = _UxGT("Forvarm $ Alle");
     PROGMEM Language_Str MSG_PREHEAT_M_BEDONLY             = _UxGT("Forvarm $ Bed");

--- a/Marlin/src/lcd/language/language_eu.h
+++ b/Marlin/src/lcd/language/language_eu.h
@@ -278,8 +278,7 @@ namespace Language_eu {
   PROGMEM Language_Str MSG_INFO_BAUDRATE                   = _UxGT("Baudioak");
   PROGMEM Language_Str MSG_INFO_PROTOCOL                   = _UxGT("Protokoloa");
   PROGMEM Language_Str MSG_CASE_LIGHT                      = _UxGT("Kabina Argia");
-  PROGMEM Language_Str MSG_CASE_LIGHT_BRIGHTNESS
-  = ;
+  PROGMEM Language_Str MSG_CASE_LIGHT_BRIGHTNESS           = _UxGT("Argiaren Distira");
   #if LCD_WIDTH >= 20
     PROGMEM Language_Str MSG_INFO_PRINT_COUNT              = _UxGT("Inprim. Zenbaketa");
     PROGMEM Language_Str MSG_INFO_COMPLETED_PRINTS         = _UxGT("Burututa");


### PR DESCRIPTION
### Requirements

Enable `LCD_LANGUAGE da` (Danish) or `LCD_LANGUAGE eu` (Basque-Euskera) languages.

### Description

Compiling with the Danish language resulted in errors due to missing semicolons. I checked the other language files for similar issues and ran into an oddity with Basque-Euskera, so I fixed that too.

### Benefits

Users can compile with Danish/Basque-Euskera languages.

### Configurations

N/A

### Related Issues

None. Reported in [Marlin's Facebook group](https://www.facebook.com/groups/marlinfirmware/permalink/2644155442354105/).