### PR TITLE
Add author to M115, combine strings

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -233,6 +233,14 @@ PGMSTR(X_LBL,     "X:"); PGMSTR(Y_LBL,     "Y:"); PGMSTR(Z_LBL,     "Z:"); PGMST
 PGMSTR(SP_A_STR, " A");  PGMSTR(SP_B_STR, " B");  PGMSTR(SP_C_STR, " C");
 PGMSTR(SP_X_STR, " X");  PGMSTR(SP_Y_STR, " Y");  PGMSTR(SP_Z_STR, " Z");  PGMSTR(SP_E_STR, " E");
 PGMSTR(SP_X_LBL, " X:"); PGMSTR(SP_Y_LBL, " Y:"); PGMSTR(SP_Z_LBL, " Z:"); PGMSTR(SP_E_LBL, " E:");
+#ifdef STRING_DISTRIBUTION_DATE
+  PGMSTR(string_distribution_date, STRING_DISTRIBUTION_DATE);
+#endif
+#ifdef STRING_CONFIG_H_AUTHOR
+  PGMSTR(string_config_h_author, STRING_CONFIG_H_AUTHOR);
+#endif
+PGMSTR(marlin_website_url, MARLIN_WEBSITE_URL);
+PGMSTR(short_build_version, SHORT_BUILD_VERSION);
 
 MarlinState marlin_state = MF_INITIALIZING;
 
@@ -975,13 +983,15 @@ void setup() {
 
   serialprintPGM(GET_TEXT(MSG_MARLIN));
   SERIAL_CHAR(' ');
-  SERIAL_ECHOLNPGM(SHORT_BUILD_VERSION);
+  serialprintPGM(short_build_version);
+  SERIAL_EOL();
   SERIAL_EOL();
   #if defined(STRING_DISTRIBUTION_DATE) && defined(STRING_CONFIG_H_AUTHOR)
-    SERIAL_ECHO_MSG(
-      " Last Updated: " STRING_DISTRIBUTION_DATE
-      " | Author: " STRING_CONFIG_H_AUTHOR
-    );
+    SERIAL_ECHOPGM(" Last Updated: ");
+    serialprintPGM(string_distribution_date);
+    SERIAL_ECHOPGM(" | Author: ");
+    serialprintPGM(string_config_h_author);
+    SERIAL_EOL();
   #endif
   SERIAL_ECHO_MSG("Compiled: " __DATE__);
   SERIAL_ECHO_MSG(STR_FREE_MEMORY, freeMemory(), STR_PLANNER_BUFFER_BYTES, (int)sizeof(block_t) * (BLOCK_BUFFER_SIZE));

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -122,4 +122,11 @@ void protected_pin_err();
 extern const char NUL_STR[], M112_KILL_STR[], G28_STR[], M21_STR[], M23_STR[], M24_STR[],
                   SP_A_STR[], SP_B_STR[], SP_C_STR[],
                   SP_P_STR[], SP_T_STR[], SP_X_STR[], SP_Y_STR[], SP_Z_STR[], SP_E_STR[],
-                  X_LBL[], Y_LBL[], Z_LBL[], E_LBL[], SP_X_LBL[], SP_Y_LBL[], SP_Z_LBL[], SP_E_LBL[];
+                  X_LBL[], Y_LBL[], Z_LBL[], E_LBL[], SP_X_LBL[], SP_Y_LBL[], SP_Z_LBL[], SP_E_LBL[],
+                  #ifdef STRING_DISTRIBUTION_DATE
+                    string_distribution_date[],
+                  #endif
+                  #ifdef STRING_CONFIG_H_AUTHOR
+                    string_config_h_author[],
+                  #endif
+                  marlin_website_url[], short_build_version[];

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -51,6 +51,9 @@ void GcodeSuite::M115() {
     #ifdef MACHINE_UUID
       "UUID:" MACHINE_UUID
     #endif
+    #ifdef STRING_CONFIG_H_AUTHOR
+      "CONFIG_BY:" STRING_CONFIG_H_AUTHOR
+    #endif
   );
 
   #if ENABLED(EXTENDED_CAPABILITIES_REPORT)

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -36,13 +36,15 @@
   }
 #endif
 
+extern const char string_config_h_author[];
+
 /**
  * M115: Capabilities string and extended capabilities report
  *       If a capability is not reported, hosts should assume
  *       the capability is not present.
  */
 void GcodeSuite::M115() {
-  SERIAL_ECHOLNPGM(
+  SERIAL_ECHOPGM(
     "FIRMWARE_NAME:Marlin " DETAILED_BUILD_VERSION " (" __DATE__ " " __TIME__ ") "
     "SOURCE_CODE_URL:" SOURCE_CODE_URL " "
     "PROTOCOL_VERSION:" PROTOCOL_VERSION " "
@@ -51,10 +53,12 @@ void GcodeSuite::M115() {
     #ifdef MACHINE_UUID
       "UUID:" MACHINE_UUID
     #endif
-    #ifdef STRING_CONFIG_H_AUTHOR
-      "CONFIG_BY:" STRING_CONFIG_H_AUTHOR
-    #endif
   );
+  #ifdef STRING_CONFIG_H_AUTHOR
+    SERIAL_ECHOPGM("CONFIG_BY:");
+    serialprintPGM(string_config_h_author);
+  #endif
+  SERIAL_EOL();
 
   #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
 

--- a/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_DOGM.cpp
@@ -163,6 +163,8 @@ bool MarlinUI::detected() { return true; }
   // Two-part needed to display all info
   constexpr bool two_part = ((LCD_PIXEL_HEIGHT) - (START_BMPHEIGHT)) < ((MENU_FONT_ASCENT) * 2);
 
+  extern const char short_build_version[], marlin_website_url[];
+
   // Draw the static Marlin bootscreen from a u8g loop
   // or the animated boot screen within its own u8g loop
   void MarlinUI::draw_marlin_bootscreen(const bool line2/*=false*/) {
@@ -199,8 +201,8 @@ bool MarlinUI::detected() { return true; }
     auto _draw_bootscreen_bmp = [&](const uint8_t *bitmap) {
       u8g.drawBitmapP(offx, offy, START_BMP_BYTEWIDTH, START_BMPHEIGHT, bitmap);
       set_font(FONT_MENU);
-      if (!two_part || !line2) lcd_put_u8str_P(txt_offx_1, txt_base - (MENU_FONT_HEIGHT), PSTR(SHORT_BUILD_VERSION));
-      if (!two_part || line2) lcd_put_u8str_P(txt_offx_2, txt_base, PSTR(MARLIN_WEBSITE_URL));
+      if (!two_part || !line2) lcd_put_u8str_P(txt_offx_1, txt_base - (MENU_FONT_HEIGHT), short_build_version);
+      if (!two_part || line2) lcd_put_u8str_P(txt_offx_2, txt_base, marlin_website_url);
     };
 
     auto draw_bootscreen_bmp = [&](const uint8_t *bitmap) {

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -1737,7 +1737,7 @@ inline void Draw_Info_Menu() {
   Clear_Main_Window();
 
   DWIN_Draw_String(false, false, font8x16, White, Background_black, (DWIN_WIDTH - strlen(MACHINE_SIZE) * MENU_CHR_W) / 2, 122, (char*)MACHINE_SIZE);
-  DWIN_Draw_String(false, false, font8x16, White, Background_black, (DWIN_WIDTH - strlen(SHORT_BUILD_VERSION) * MENU_CHR_W) / 2, 195, (char*)SHORT_BUILD_VERSION);
+  DWIN_Draw_String(false, false, font8x16, White, Background_black, (DWIN_WIDTH - strlen_P(short_build_version) * MENU_CHR_W) / 2, 195, (const __FlashStringHelper *)short_build_version);
 
   if (HMI_flag.language_chinese) {
     DWIN_Frame_AreaCopy(1, 30, 17, 271 - 214, 479 - 450, 14, 8);

--- a/Marlin/src/lcd/extui/anycubic_chiron_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron_lcd.cpp
@@ -48,6 +48,8 @@
   #error ANYCUBIC CHIRON LCD does not currently support POWER_LOSS_RECOVERY
 #endif
 
+extern const char short_build_version[];
+
 static bool is_auto_leveling = false;
 static bool is_printing_from_sd = false;
 static bool is_out_of_filament = false;
@@ -143,9 +145,7 @@ namespace ExtUI {
     static char selectedFileShortName[8+1+3+1];
 
     if (rx[0] != 'A') {
-      SERIAL_ECHOPGM("Unexpected RX: ");
-      SERIAL_ECHOLN(rx);
-
+      SERIAL_ECHOLNPAIR("Unexpected RX: ", rx);
       return;
     }
 
@@ -397,7 +397,8 @@ namespace ExtUI {
       //case 32: // ?
       //  break;
       case 33: // Get Version Info
-        SENDLINE_PGM("J33 " SHORT_BUILD_VERSION);
+        SEND_PGM("J33 ");
+        sendLine_P(short_build_version);
         break;
       case 34: // Set Bed Autolevel Grid
         {

--- a/Marlin/src/lcd/extui/lib/dgus/fysetc/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus/fysetc/DGUSDisplayDef.cpp
@@ -314,7 +314,7 @@ const struct VPMapping VPMap[] PROGMEM = {
   { 0 , nullptr } // List is terminated with an nullptr as table entry.
 };
 
-const char MarlinVersion[] PROGMEM = SHORT_BUILD_VERSION;
+extern const char short_build_version[];
 
 // Helper to define a DGUS_VP_Variable for common use cases.
 #define VPHELPER(VPADR, VPADRVAR, RXFPTR, TXFPTR ) { .VP=VPADR, .memadr=VPADRVAR, .size=sizeof(VPADRVAR), \
@@ -361,7 +361,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
     VPHELPER(VP_Z_FIRST_LAYER_CAL, nullptr, &ScreenHandler.HandleFirstLayerCal, nullptr),
   #endif
 
-  { .VP = VP_MARLIN_VERSION, .memadr = (void*)MarlinVersion, .size = VP_MARLIN_VERSION_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
+  { .VP = VP_MARLIN_VERSION, .memadr = (void*)short_build_version, .size = VP_MARLIN_VERSION_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   // M117 LCD String (We don't need the string in memory but "just" push it to the display on demand, hence the nullptr
   { .VP = VP_M117, .memadr = nullptr, .size = VP_M117_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplay },
 

--- a/Marlin/src/lcd/extui/lib/dgus/hiprecy/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus/hiprecy/DGUSDisplayDef.cpp
@@ -317,7 +317,7 @@ const struct VPMapping VPMap[] PROGMEM = {
   { 0 , nullptr } // List is terminated with an nullptr as table entry.
 };
 
-const char MarlinVersion[] PROGMEM = SHORT_BUILD_VERSION;
+extern const char short_build_version[];
 
 // Helper to define a DGUS_VP_Variable for common use cases.
 #define VPHELPER(VPADR, VPADRVAR, RXFPTR, TXFPTR ) { .VP=VPADR, .memadr=VPADRVAR, .size=sizeof(VPADRVAR), \
@@ -364,7 +364,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
     VPHELPER(VP_Z_FIRST_LAYER_CAL, nullptr, &ScreenHandler.HandleFirstLayerCal, nullptr),
   #endif
 
-  { .VP = VP_MARLIN_VERSION, .memadr = (void*)MarlinVersion, .size = VP_MARLIN_VERSION_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
+  { .VP = VP_MARLIN_VERSION, .memadr = (void*)short_build_version, .size = VP_MARLIN_VERSION_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   // M117 LCD String (We don't need the string in memory but "just" push it to the display on demand, hence the nullptr
   { .VP = VP_M117, .memadr = nullptr, .size = VP_M117_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplay },
 

--- a/Marlin/src/lcd/extui/lib/dgus/origin/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus/origin/DGUSDisplayDef.cpp
@@ -144,7 +144,7 @@ const struct VPMapping VPMap[] PROGMEM = {
   { 0 , nullptr } // List is terminated with an nullptr as table entry.
 };
 
-const char MarlinVersion[] PROGMEM = SHORT_BUILD_VERSION;
+extern const char short_build_version[];
 
 // Helper to define a DGUS_VP_Variable for common use cases.
 #define VPHELPER(VPADR, VPADRVAR, RXFPTR, TXFPTR ) { .VP=VPADR, .memadr=VPADRVAR, .size=sizeof(VPADRVAR), \
@@ -186,7 +186,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
   #endif
   VPHELPER(VP_SETTINGS, nullptr, &ScreenHandler.HandleSettings, nullptr),
 
-  { .VP = VP_MARLIN_VERSION, .memadr = (void*)MarlinVersion, .size = VP_MARLIN_VERSION_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
+  { .VP = VP_MARLIN_VERSION, .memadr = (void*)short_build_version, .size = VP_MARLIN_VERSION_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   // M117 LCD String (We don't need the string in memory but "just" push it to the display on demand, hence the nullptr
   { .VP = VP_M117, .memadr = nullptr, .size = VP_M117_LEN, .set_by_display_handler = nullptr, .send_to_display_handler =&ScreenHandler.DGUSLCD_SendStringToDisplay },
 

--- a/Marlin/src/lcd/menu/menu_info.cpp
+++ b/Marlin/src/lcd/menu/menu_info.cpp
@@ -234,12 +234,14 @@ void menu_info_board() {
 
 #else
 
+  extern const char short_build_version[], string_distribution_date[];
+
   void menu_info_printer() {
     if (ui.use_click()) return ui.go_back();
     START_SCREEN();
     STATIC_ITEM(MSG_MARLIN, SS_DEFAULT|SS_INVERT);              // Marlin
-    STATIC_ITEM_P(PSTR(SHORT_BUILD_VERSION));                   // x.x.x-Branch
-    STATIC_ITEM_P(PSTR(STRING_DISTRIBUTION_DATE));              // YYYY-MM-DD HH:MM
+    STATIC_ITEM_P(short_build_version);                         // x.x.x-Branch
+    STATIC_ITEM_P(string_distribution_date);                    // YYYY-MM-DD HH:MM
     STATIC_ITEM_P(PSTR(MACHINE_NAME));                          // My3DPrinter
     STATIC_ITEM_P(PSTR(WEBSITE_URL));                           // www.my3dprinter.com
     PSTRING_ITEM(MSG_INFO_EXTRUDERS, STRINGIFY(EXTRUDERS), SS_CENTER); // Extruders: 2

--- a/Marlin/src/pins/stm32f4/pins_STEVAL_3DP001V1.h
+++ b/Marlin/src/pins/stm32f4/pins_STEVAL_3DP001V1.h
@@ -44,9 +44,7 @@
   #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
 #endif
 
-#ifndef MACHINE_NAME
-  #define MACHINE_NAME "STEVAL-3DP001V1"
-#endif
+#define DEFAULT_MACHINE_NAME "STEVAL-3DP001V1"
 
 //
 // Limit Switches


### PR DESCRIPTION
- Reduce string storage with a few info string constants.
- Add "`CONFIG_BY`:" entry to `M115` as a test case.
  Since it is redundant to the boot message, it may be dropped.
