### PR TITLE
Add K8800 board entry to the boards.h file

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -170,112 +170,114 @@ else ifeq ($(HARDWARE_MOTHERBOARD),1100)
 else ifeq ($(HARDWARE_MOTHERBOARD),1101)
 # Velleman K8400 Controller (derived from 3Drag Controller)
 else ifeq ($(HARDWARE_MOTHERBOARD),1102)
-# Velleman K8600 Controller (derived from 3Drag Controller)
+# Velleman K8600 Controller (Vertex Nano)
 else ifeq ($(HARDWARE_MOTHERBOARD),1103)
-# 2PrintBeta BAM&DICE with STK drivers
+# Velleman K8800 Controller (Vertex Delta)
 else ifeq ($(HARDWARE_MOTHERBOARD),1104)
-# 2PrintBeta BAM&DICE Due with STK drivers
+# 2PrintBeta BAM&DICE with STK drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1105)
-# MKS BASE v1.0
+# 2PrintBeta BAM&DICE Due with STK drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1106)
-# MKS v1.4 with A4982 stepper drivers
+# MKS BASE v1.0
 else ifeq ($(HARDWARE_MOTHERBOARD),1107)
-# MKS v1.5 with Allegro A4982 stepper drivers
+# MKS v1.4 with A4982 stepper drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1108)
-# MKS v1.6 with Allegro A4982 stepper drivers
+# MKS v1.5 with Allegro A4982 stepper drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1109)
-# MKS BASE 1.0 with Heroic HR4982 stepper drivers
+# MKS v1.6 with Allegro A4982 stepper drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1110)
-# MKS GEN v1.3 or 1.4
+# MKS BASE 1.0 with Heroic HR4982 stepper drivers
 else ifeq ($(HARDWARE_MOTHERBOARD),1111)
-# MKS GEN L
+# MKS GEN v1.3 or 1.4
 else ifeq ($(HARDWARE_MOTHERBOARD),1112)
-# zrib V2.0 control board (Chinese knock off RAMPS replica)
+# MKS GEN L
 else ifeq ($(HARDWARE_MOTHERBOARD),1113)
-# BigTreeTech or BIQU KFB2.0
+# zrib V2.0 control board (Chinese knock off RAMPS replica)
 else ifeq ($(HARDWARE_MOTHERBOARD),1114)
-# Felix 2.0+ Electronics Board (RAMPS like)
+# BigTreeTech or BIQU KFB2.0
 else ifeq ($(HARDWARE_MOTHERBOARD),1115)
-# Invent-A-Part RigidBoard
+# Felix 2.0+ Electronics Board (RAMPS like)
 else ifeq ($(HARDWARE_MOTHERBOARD),1116)
-# Invent-A-Part RigidBoard V2
+# Invent-A-Part RigidBoard
 else ifeq ($(HARDWARE_MOTHERBOARD),1117)
-# Sainsmart 2-in-1 board
+# Invent-A-Part RigidBoard V2
 else ifeq ($(HARDWARE_MOTHERBOARD),1118)
-# Ultimaker
+# Sainsmart 2-in-1 board
 else ifeq ($(HARDWARE_MOTHERBOARD),1119)
-# Ultimaker (Older electronics. Pre 1.5.4. This is rare)
+# Ultimaker
 else ifeq ($(HARDWARE_MOTHERBOARD),1120)
+# Ultimaker (Older electronics. Pre 1.5.4. This is rare)
+else ifeq ($(HARDWARE_MOTHERBOARD),1121)
   MCU ?= atmega1280
 
 # Azteeg X3
-else ifeq ($(HARDWARE_MOTHERBOARD),1121)
-# Azteeg X3 Pro
 else ifeq ($(HARDWARE_MOTHERBOARD),1122)
-# Ultimainboard 2.x (Uses TEMP_SENSOR 20)
+# Azteeg X3 Pro
 else ifeq ($(HARDWARE_MOTHERBOARD),1123)
-# Rumba
+# Ultimainboard 2.x (Uses TEMP_SENSOR 20)
 else ifeq ($(HARDWARE_MOTHERBOARD),1124)
-# Raise3D Rumba
+# Rumba
 else ifeq ($(HARDWARE_MOTHERBOARD),1125)
-# Rapide Lite RL200 Rumba
+# Raise3D Rumba
 else ifeq ($(HARDWARE_MOTHERBOARD),1126)
-# Formbot T-Rex 2 Plus
+# Rapide Lite RL200 Rumba
 else ifeq ($(HARDWARE_MOTHERBOARD),1127)
-# Formbot T-Rex 3
+# Formbot T-Rex 2 Plus
 else ifeq ($(HARDWARE_MOTHERBOARD),1128)
-# Formbot Raptor
+# Formbot T-Rex 3
 else ifeq ($(HARDWARE_MOTHERBOARD),1129)
-# Formbot Raptor 2
+# Formbot Raptor
 else ifeq ($(HARDWARE_MOTHERBOARD),1130)
-# bq ZUM Mega 3D
+# Formbot Raptor 2
 else ifeq ($(HARDWARE_MOTHERBOARD),1131)
-# MakeBoard Mini v2.1.2 is a control board sold by MicroMake
+# bq ZUM Mega 3D
 else ifeq ($(HARDWARE_MOTHERBOARD),1132)
-# TriGorilla Anycubic version 1.3 based on RAMPS EFB
+# MakeBoard Mini v2.1.2 is a control board sold by MicroMake
 else ifeq ($(HARDWARE_MOTHERBOARD),1133)
-# TriGorilla Anycubic version 1.4 based on RAMPS EFB
+# TriGorilla Anycubic version 1.3 based on RAMPS EFB
 else ifeq ($(HARDWARE_MOTHERBOARD),1134)
-# TriGorilla Anycubic version 1.4 Rev 1.1
+# TriGorilla Anycubic version 1.4 based on RAMPS EFB
 else ifeq ($(HARDWARE_MOTHERBOARD),1135)
-# Creality: Ender-4, CR-8
+# TriGorilla Anycubic version 1.4 Rev 1.1
 else ifeq ($(HARDWARE_MOTHERBOARD),1136)
-# Creality: CR10S, CR20, CR-X
+# Creality: Ender-4, CR-8
 else ifeq ($(HARDWARE_MOTHERBOARD),1137)
-# Dagoma F5
+# Creality: CR10S, CR20, CR-X
 else ifeq ($(HARDWARE_MOTHERBOARD),1138)
-# FYSETC F6 1.3
+# Dagoma F5
 else ifeq ($(HARDWARE_MOTHERBOARD),1139)
-# FYSETC F6 1.5
+# FYSETC F6 1.3
 else ifeq ($(HARDWARE_MOTHERBOARD),1140)
-# Duplicator i3 Plus
+# FYSETC F6 1.5
 else ifeq ($(HARDWARE_MOTHERBOARD),1141)
-# VORON
+# Duplicator i3 Plus
 else ifeq ($(HARDWARE_MOTHERBOARD),1142)
-# TRONXY V3 1.0
+# VORON
 else ifeq ($(HARDWARE_MOTHERBOARD),1143)
-# Z-Bolt X Series
+# TRONXY V3 1.0
 else ifeq ($(HARDWARE_MOTHERBOARD),1144)
-# TT OSCAR
+# Z-Bolt X Series
 else ifeq ($(HARDWARE_MOTHERBOARD),1145)
-# Overlord/Overlord Pro
+# TT OSCAR
 else ifeq ($(HARDWARE_MOTHERBOARD),1146)
-# ADIMLab Gantry v1
+# Overlord/Overlord Pro
 else ifeq ($(HARDWARE_MOTHERBOARD),1147)
-# ADIMLab Gantry v2
+# ADIMLab Gantry v1
 else ifeq ($(HARDWARE_MOTHERBOARD),1148)
-# BIQU Tango V1
+# ADIMLab Gantry v2
 else ifeq ($(HARDWARE_MOTHERBOARD),1149)
-# MKS GEN L V2
+# BIQU Tango V1
 else ifeq ($(HARDWARE_MOTHERBOARD),1150)
-# MKS GEN L V2.1
+# MKS GEN L V2
 else ifeq ($(HARDWARE_MOTHERBOARD),1151)
-# Copymaster 3D
+# MKS GEN L V2.1
 else ifeq ($(HARDWARE_MOTHERBOARD),1152)
-# Ortur 4
+# Copymaster 3D
 else ifeq ($(HARDWARE_MOTHERBOARD),1153)
-# Tenlog D3 Hero
+# Ortur 4
 else ifeq ($(HARDWARE_MOTHERBOARD),1154)
+# Tenlog D3 Hero
+else ifeq ($(HARDWARE_MOTHERBOARD),1155)
 
 #
 # RAMBo and derivatives

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -57,57 +57,58 @@
 #define BOARD_K8200                   1101  // Velleman K8200 Controller (derived from 3Drag Controller)
 #define BOARD_K8400                   1102  // Velleman K8400 Controller (derived from 3Drag Controller)
 #define BOARD_K8600                   1103  // Velleman K8600 Controller (Vertex Nano)
-#define BOARD_BAM_DICE                1104  // 2PrintBeta BAM&DICE with STK drivers
-#define BOARD_BAM_DICE_DUE            1105  // 2PrintBeta BAM&DICE Due with STK drivers
-#define BOARD_MKS_BASE                1106  // MKS BASE v1.0
-#define BOARD_MKS_BASE_14             1107  // MKS BASE v1.4 with Allegro A4982 stepper drivers
-#define BOARD_MKS_BASE_15             1108  // MKS BASE v1.5 with Allegro A4982 stepper drivers
-#define BOARD_MKS_BASE_16             1109  // MKS BASE v1.6 with Allegro A4982 stepper drivers
-#define BOARD_MKS_BASE_HEROIC         1110  // MKS BASE 1.0 with Heroic HR4982 stepper drivers
-#define BOARD_MKS_GEN_13              1111  // MKS GEN v1.3 or 1.4
-#define BOARD_MKS_GEN_L               1112  // MKS GEN L
-#define BOARD_KFB_2                   1113  // BigTreeTech or BIQU KFB2.0
-#define BOARD_ZRIB_V20                1114  // zrib V2.0 control board (Chinese knock off RAMPS replica)
-#define BOARD_FELIX2                  1115  // Felix 2.0+ Electronics Board (RAMPS like)
-#define BOARD_RIGIDBOARD              1116  // Invent-A-Part RigidBoard
-#define BOARD_RIGIDBOARD_V2           1117  // Invent-A-Part RigidBoard V2
-#define BOARD_SAINSMART_2IN1          1118  // Sainsmart 2-in-1 board
-#define BOARD_ULTIMAKER               1119  // Ultimaker
-#define BOARD_ULTIMAKER_OLD           1120  // Ultimaker (Older electronics. Pre 1.5.4. This is rare)
-#define BOARD_AZTEEG_X3               1121  // Azteeg X3
-#define BOARD_AZTEEG_X3_PRO           1122  // Azteeg X3 Pro
-#define BOARD_ULTIMAIN_2              1123  // Ultimainboard 2.x (Uses TEMP_SENSOR 20)
-#define BOARD_RUMBA                   1124  // Rumba
-#define BOARD_RUMBA_RAISE3D           1125  // Raise3D N series Rumba derivative
-#define BOARD_RL200                   1126  // Rapide Lite 200 (v1, low-cost RUMBA clone with drv)
-#define BOARD_FORMBOT_TREX2PLUS       1127  // Formbot T-Rex 2 Plus
-#define BOARD_FORMBOT_TREX3           1128  // Formbot T-Rex 3
-#define BOARD_FORMBOT_RAPTOR          1129  // Formbot Raptor
-#define BOARD_FORMBOT_RAPTOR2         1130  // Formbot Raptor 2
-#define BOARD_BQ_ZUM_MEGA_3D          1131  // bq ZUM Mega 3D
-#define BOARD_MAKEBOARD_MINI          1132  // MakeBoard Mini v2.1.2 is a control board sold by MicroMake
-#define BOARD_TRIGORILLA_13           1133  // TriGorilla Anycubic version 1.3-based on RAMPS EFB
-#define BOARD_TRIGORILLA_14           1134  //   ... Ver 1.4
-#define BOARD_TRIGORILLA_14_11        1135  //   ... Rev 1.1 (new servo pin order)
-#define BOARD_RAMPS_ENDER_4           1136  // Creality: Ender-4, CR-8
-#define BOARD_RAMPS_CREALITY          1137  // Creality: CR10S, CR20, CR-X
-#define BOARD_RAMPS_DAGOMA            1138  // Dagoma F5
-#define BOARD_FYSETC_F6_13            1139  // FYSETC F6 1.3
-#define BOARD_FYSETC_F6_14            1140  // FYSETC F6 1.4
-#define BOARD_DUPLICATOR_I3_PLUS      1141  // Wanhao Duplicator i3 Plus
-#define BOARD_VORON                   1142  // VORON Design
-#define BOARD_TRONXY_V3_1_0           1143  // Tronxy TRONXY-V3-1.0
-#define BOARD_Z_BOLT_X_SERIES         1144  // Z-Bolt X Series
-#define BOARD_TT_OSCAR                1145  // TT OSCAR
-#define BOARD_OVERLORD                1146  // Overlord/Overlord Pro
-#define BOARD_HJC2560C_REV1           1147  // ADIMLab Gantry v1
-#define BOARD_HJC2560C_REV2           1148  // ADIMLab Gantry v2
-#define BOARD_TANGO                   1149  // BIQU Tango V1
-#define BOARD_MKS_GEN_L_V2            1150  // MKS GEN L V2
-#define BOARD_MKS_GEN_L_V21           1151  // MKS GEN L V2.1
-#define BOARD_COPYMASTER_3D           1152  // Copymaster 3D
-#define BOARD_ORTUR_4                 1153  // Ortur 4
-#define BOARD_TENLOG_D3_HERO          1154  // Tenlog D3 Hero IDEX printer
+#define BOARD_K8800                   1104  // Velleman K8800 Controller (Vertex Delta)
+#define BOARD_BAM_DICE                1105  // 2PrintBeta BAM&DICE with STK drivers
+#define BOARD_BAM_DICE_DUE            1106  // 2PrintBeta BAM&DICE Due with STK drivers
+#define BOARD_MKS_BASE                1107  // MKS BASE v1.0
+#define BOARD_MKS_BASE_14             1108  // MKS BASE v1.4 with Allegro A4982 stepper drivers
+#define BOARD_MKS_BASE_15             1109  // MKS BASE v1.5 with Allegro A4982 stepper drivers
+#define BOARD_MKS_BASE_16             1110  // MKS BASE v1.6 with Allegro A4982 stepper drivers
+#define BOARD_MKS_BASE_HEROIC         1111  // MKS BASE 1.0 with Heroic HR4982 stepper drivers
+#define BOARD_MKS_GEN_13              1112  // MKS GEN v1.3 or 1.4
+#define BOARD_MKS_GEN_L               1113  // MKS GEN L
+#define BOARD_KFB_2                   1114  // BigTreeTech or BIQU KFB2.0
+#define BOARD_ZRIB_V20                1115  // zrib V2.0 control board (Chinese knock off RAMPS replica)
+#define BOARD_FELIX2                  1116  // Felix 2.0+ Electronics Board (RAMPS like)
+#define BOARD_RIGIDBOARD              1117  // Invent-A-Part RigidBoard
+#define BOARD_RIGIDBOARD_V2           1118  // Invent-A-Part RigidBoard V2
+#define BOARD_SAINSMART_2IN1          1119  // Sainsmart 2-in-1 board
+#define BOARD_ULTIMAKER               1120  // Ultimaker
+#define BOARD_ULTIMAKER_OLD           1121  // Ultimaker (Older electronics. Pre 1.5.4. This is rare)
+#define BOARD_AZTEEG_X3               1122  // Azteeg X3
+#define BOARD_AZTEEG_X3_PRO           1123  // Azteeg X3 Pro
+#define BOARD_ULTIMAIN_2              1124  // Ultimainboard 2.x (Uses TEMP_SENSOR 20)
+#define BOARD_RUMBA                   1125  // Rumba
+#define BOARD_RUMBA_RAISE3D           1126  // Raise3D N series Rumba derivative
+#define BOARD_RL200                   1127  // Rapide Lite 200 (v1, low-cost RUMBA clone with drv)
+#define BOARD_FORMBOT_TREX2PLUS       1128  // Formbot T-Rex 2 Plus
+#define BOARD_FORMBOT_TREX3           1129  // Formbot T-Rex 3
+#define BOARD_FORMBOT_RAPTOR          1130  // Formbot Raptor
+#define BOARD_FORMBOT_RAPTOR2         1131  // Formbot Raptor 2
+#define BOARD_BQ_ZUM_MEGA_3D          1132  // bq ZUM Mega 3D
+#define BOARD_MAKEBOARD_MINI          1133  // MakeBoard Mini v2.1.2 is a control board sold by MicroMake
+#define BOARD_TRIGORILLA_13           1134  // TriGorilla Anycubic version 1.3-based on RAMPS EFB
+#define BOARD_TRIGORILLA_14           1135  //   ... Ver 1.4
+#define BOARD_TRIGORILLA_14_11        1136  //   ... Rev 1.1 (new servo pin order)
+#define BOARD_RAMPS_ENDER_4           1137  // Creality: Ender-4, CR-8
+#define BOARD_RAMPS_CREALITY          1138  // Creality: CR10S, CR20, CR-X
+#define BOARD_RAMPS_DAGOMA            1139  // Dagoma F5
+#define BOARD_FYSETC_F6_13            1140  // FYSETC F6 1.3
+#define BOARD_FYSETC_F6_14            1141  // FYSETC F6 1.4
+#define BOARD_DUPLICATOR_I3_PLUS      1142  // Wanhao Duplicator i3 Plus
+#define BOARD_VORON                   1143  // VORON Design
+#define BOARD_TRONXY_V3_1_0           1144  // Tronxy TRONXY-V3-1.0
+#define BOARD_Z_BOLT_X_SERIES         1145  // Z-Bolt X Series
+#define BOARD_TT_OSCAR                1146  // TT OSCAR
+#define BOARD_OVERLORD                1147  // Overlord/Overlord Pro
+#define BOARD_HJC2560C_REV1           1148  // ADIMLab Gantry v1
+#define BOARD_HJC2560C_REV2           1149  // ADIMLab Gantry v2
+#define BOARD_TANGO                   1150  // BIQU Tango V1
+#define BOARD_MKS_GEN_L_V2            1151  // MKS GEN L V2
+#define BOARD_MKS_GEN_L_V21           1152  // MKS GEN L V2.1
+#define BOARD_COPYMASTER_3D           1153  // Copymaster 3D
+#define BOARD_ORTUR_4                 1154  // Ortur 4
+#define BOARD_TENLOG_D3_HERO          1155  // Tenlog D3 Hero IDEX printer
 
 //
 // RAMBo and derivatives


### PR DESCRIPTION
# Description

Add K8800 (Velleman Vertex Delta) controller to the `boards.h` file.
The board has its respective `pins_K8800.h` file which is properly included in `pins.h`.
All of the siblings of the Vertex Delta (K8200, K8400, K8600) are already in `boards.h` so it seems this is a slip of hand while writing the file.

The board is sadly almost at the top of the list so the numbers need to be changed for most boards.
If you think this part is going to cause problems maybe I should add this entry at the end, this would hovewer be less nice.

### Benefits

"Completeness" of the file and gives me less effort to prepare my own branch which supports this printer fully.
I want to be able to have this branch easily updatable and the boards file would be one less hassle.

### Configurations

not applicable

### Related Issues

I didn't create a FR for this.
