### PR TITLE
Fix Creality RET6 board environment typo

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1065,7 +1065,7 @@ build_flags   = ${env:chitu_f103.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
 [env:STM32F103RET6_creality]
 platform        = ${common_stm32f1.platform}
 extends         = common_stm32f1
-board           = genericSTM32F103RC
+board           = genericSTM32F103RE
 build_flags     = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags} -std=gnu++14 -DSTM32_XL_DENSITY -DTEMP_TIMER_CHAN=4
 extra_scripts   = ${common.extra_scripts}


### PR DESCRIPTION
### Requirements

Crealtiy 4.2.x board with RET6 MCU

### Description

Use `genericSTM32F103RE`  board instead of `genericSTM32F103RC` for RET6.

### Benefits

Full 512k flash access instead of 256k.

### Related Issues

None. Found via discussion on Discord.
