### PR TITLE
Allow SWD debugging for the Robin Nano board

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -36,7 +36,7 @@
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
 //
-#define DISABLE_DEBUG
+#define DISABLE_JTAG
 
 //
 // EEPROM

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -25,7 +25,7 @@
  * MKS Robin nano (STM32F130VET6) board pin assignments
  */
 
-#ifndef __STM32F1__
+#if !defined(STM32F1) && !defined(STM32F1xx)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #elif HOTENDS > 2 || E_STEPPERS > 2
   #error "MKS Robin nano supports up to 2 hotends / E-steppers. Comment out this line to continue."


### PR DESCRIPTION
The Robin Nano board has dedicated SWD pins, so they can stay available for SWD upload and debugging.

The old DISABLE_DEBUG disables both SWD and JTAG.
The new JTAG_DISABLE only disables JTAG and still allows SWD.

Note that since SWD debugging is disabled by default in original firmwares, the GDB debugger should have the following set to allow accessing the device at all by the debugger:
(gdb) monitor connect_srst enable