### PR TITLE
New "Leveling" menu in Touch UI; Assorted Fixes

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -736,6 +736,7 @@
       uint8_t count = GRID_MAX_POINTS;
 
       mesh_index_pair best;
+      TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(best.pos, ExtUI::MESH_START));
       do {
         if (do_ubl_mesh_map) display_map(g29_map_type);
 
@@ -774,6 +775,8 @@
         SERIAL_FLUSH(); // Prevent host M105 buffer overrun.
 
       } while (best.pos.x >= 0 && --count);
+
+      TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(best.pos, ExtUI::MESH_FINISH));
 
       // Release UI during stow to allow for PAUSE_BEFORE_DEPLOY_STOW
       TERN_(HAS_LCD_MENU, ui.release());

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extras/poly_ui.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extras/poly_ui.h
@@ -36,7 +36,7 @@
  *
  *   PolyReader r(data, N_ELEMENTS(data));
  *
- *   for(r.start();r.has_more(); r.next()) {
+ *   for (r.start();r.has_more(); r.next()) {
  *     uint16_t x = r.x;
  *     uint16_t y = r.y;
  *
@@ -107,8 +107,8 @@ class PolyReader {
       }
     }
 
-    bool has_more()       {return p != NULL;}
-    bool end_of_loop()    {return start_x == eol;}
+    bool has_more()       { return p != NULL; }
+    bool end_of_loop()    { return start_x == eol; }
 };
 
 /**
@@ -129,7 +129,7 @@ class TransformedPolyReader : public PolyReader {
      */
     static constexpr uint8_t fract_bits = 5;
     typedef int16_t fix_t;
-    fix_t makefix(float f) {return f * (1 << fract_bits);}
+    fix_t makefix(float f) { return f * (1 << fract_bits); }
 
     // First two rows of 3x3 transformation matrix
     fix_t a, b, c;
@@ -255,10 +255,10 @@ class GenericPolyUI {
 
   public:
     enum ButtonStyle : uint8_t {
-        FILL    = 1,
-        STROKE  = 2,
-        SHADOW  = 4,
-        REGULAR = 7
+      FILL    = 1,
+      STROKE  = 2,
+      SHADOW  = 4,
+      REGULAR = 7
     };
 
     typedef POLY_READER poly_reader_t;
@@ -283,7 +283,7 @@ class GenericPolyUI {
       Polygon p(cmd);
       p.begin_fill();
       p.begin_loop();
-      for(r.start();r.has_more();r.next()) {
+      for (r.start();r.has_more();r.next()) {
         p(r.x * 16, r.y * 16);
         if (r.end_of_loop()) {
           p.end_loop();
@@ -313,7 +313,7 @@ class GenericPolyUI {
       Polygon p(cmd);
       p.begin_stroke();
       p.begin_loop();
-      for(r.start();r.has_more(); r.next()) {
+      for (r.start();r.has_more(); r.next()) {
         p(r.x * 16, r.y * 16);
         if (r.end_of_loop()) {
           p.end_loop();
@@ -330,7 +330,7 @@ class GenericPolyUI {
       int16_t y_min = INT16_MAX;
       int16_t x_max = INT16_MIN;
       int16_t y_max = INT16_MIN;
-      for(r.start(); r.has_more(); r.next()) {
+      for (r.start(); r.has_more(); r.next()) {
         x_min = min(x_min, int16_t(r.x));
         x_max = max(x_max, int16_t(r.x));
         y_min = min(y_min, int16_t(r.y));
@@ -388,11 +388,11 @@ class GenericPolyUI {
         #endif
         // Draw the fill and stroke
         cmd.cmd(TAG(tag));
-        if(style & FILL) {
+        if (style & FILL) {
           cmd.cmd(COLOR_RGB(btn_fill_color));
           fill(r, false);
         }
-        if(style & STROKE) {
+        if (style & STROKE) {
           cmd.cmd(COLOR_RGB(btn_stroke_color));
           cmd.cmd(LINE_WIDTH(btn_stroke_width));
           stroke(r);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extras/poly_ui.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extras/poly_ui.h
@@ -16,7 +16,7 @@
  *   GNU General Public License for more details.                           *
  *                                                                          *
  *   To view a copy of the GNU General Public License, go to the following  *
- *   location: <https://www.gnu.org/licenses/>.                              *
+ *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
 #pragma once
@@ -254,6 +254,13 @@ class GenericPolyUI {
     draw_mode_t mode;
 
   public:
+    enum ButtonStyle : uint8_t {
+        FILL    = 1,
+        STROKE  = 2,
+        SHADOW  = 4,
+        REGULAR = 7
+    };
+
     typedef POLY_READER poly_reader_t;
 
     GenericPolyUI(CommandProcessor &c, draw_mode_t what = BOTH) : cmd(c), mode(what) {}
@@ -355,11 +362,11 @@ class GenericPolyUI {
       btn_shadow_depth = depth;
     }
 
-    void button(const uint8_t tag, poly_reader_t r) {
+    void button(const uint8_t tag, poly_reader_t r, uint8_t style = REGULAR) {
       using namespace FTDI;
       // Draw the shadow
       #if FTDI_API_LEVEL >= 810
-      if (mode & BACKGROUND) {
+      if (mode & BACKGROUND && style & SHADOW) {
         cmd.cmd(SAVE_CONTEXT());
         cmd.cmd(TAG(tag));
         cmd.cmd(VERTEX_TRANSLATE_X(btn_shadow_depth * 16));
@@ -381,11 +388,15 @@ class GenericPolyUI {
         #endif
         // Draw the fill and stroke
         cmd.cmd(TAG(tag));
-        cmd.cmd(COLOR_RGB(btn_fill_color));
-        fill(r, false);
-        cmd.cmd(COLOR_RGB(btn_stroke_color));
-        cmd.cmd(LINE_WIDTH(btn_stroke_width));
-        stroke(r);
+        if(style & FILL) {
+          cmd.cmd(COLOR_RGB(btn_fill_color));
+          fill(r, false);
+        }
+        if(style & STROKE) {
+          cmd.cmd(COLOR_RGB(btn_stroke_color));
+          cmd.cmd(LINE_WIDTH(btn_stroke_width));
+          stroke(r);
+        }
         cmd.cmd(RESTORE_CONTEXT());
       }
     }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
@@ -145,7 +145,8 @@ namespace Language_en {
   PROGMEM Language_Str MSG_TOUCH_CALIBRATION_PROMPT = u8"Touch the dots to calibrate";
   PROGMEM Language_Str MSG_AUTOLEVEL_X_AXIS         = u8"Level X Axis";
   PROGMEM Language_Str MSG_BED_MAPPING_DONE         = u8"Bed mapping finished";
-  PROGMEM Language_Str MSG_RESET_BLTOUCH            = u8"Reset BLTouch";
+  PROGMEM Language_Str MSG_LEVELING                 = u8"Leveling";
+  PROGMEM Language_Str MSG_SHOW_MESH                = u8"Show Bed Mesh";
 
   #ifdef TOUCH_UI_LULZBOT_BIO
     PROGMEM Language_Str MSG_MOVE_TO_HOME           = u8"Move to Home";

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/advanced_settings_menu.cpp
@@ -55,11 +55,11 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
       #define ACCELERATION_POS        BTN_POS(2,5), BTN_SIZE(1,1)
       #define ENDSTOPS_POS            BTN_POS(1,6), BTN_SIZE(1,1)
       #define JERK_POS                BTN_POS(2,6), BTN_SIZE(1,1)
-      #define OFFSETS_POS             BTN_POS(1,7), BTN_SIZE(1,1)
+      #define CASE_LIGHT_POS          BTN_POS(1,7), BTN_SIZE(1,1)
       #define BACKLASH_POS            BTN_POS(2,7), BTN_SIZE(1,1)
-      #define CASE_LIGHT_POS          BTN_POS(1,8), BTN_SIZE(1,1)
+      #define OFFSETS_POS             BTN_POS(1,8), BTN_SIZE(1,1)
       #define TMC_HOMING_THRS_POS     BTN_POS(2,8), BTN_SIZE(1,1)
-      #if EITHER(CASE_LIGHT_ENABLE, SENSORLESS_HOMING)
+      #if EITHER(HAS_MULTI_HOTEND, SENSORLESS_HOMING)
         #define BACK_POS              BTN_POS(1,9), BTN_SIZE(2,1)
       #else
         #define BACK_POS              BTN_POS(1,8), BTN_SIZE(2,1)
@@ -98,8 +98,8 @@ void AdvancedSettingsMenu::onRedraw(draw_mode_t what) {
       .tag(13).button( TMC_CURRENT_POS,        GET_TEXT_F(MSG_TMC_CURRENT))
       .enabled(ENABLED(SENSORLESS_HOMING))
       .tag(14).button( TMC_HOMING_THRS_POS,    GET_TEXT_F(MSG_TMC_HOMING_THRS))
-      .enabled(EITHER(HAS_MULTI_HOTEND, BLTOUCH))
-      .tag(4) .button( OFFSETS_POS,            GET_TEXT_F(TERN(HAS_MULTI_HOTEND, MSG_OFFSETS_MENU, MSG_RESET_BLTOUCH)))
+      .enabled(ENABLED(HAS_MULTI_HOTEND))
+      .tag(4) .button( OFFSETS_POS,            GET_TEXT_F(MSG_OFFSETS_MENU))
       .enabled(EITHER(LIN_ADVANCE, FILAMENT_RUNOUT_SENSOR))
       .tag(11).button( FILAMENT_POS,           GET_TEXT_F(MSG_FILAMENT))
       .tag(12).button( ENDSTOPS_POS,           GET_TEXT_F(MSG_LCD_ENDSTOPS))
@@ -123,13 +123,9 @@ bool AdvancedSettingsMenu::onTouchEnd(uint8_t tag) {
     case  2: GOTO_SCREEN(ZOffsetScreen);              break;
     #endif
     case  3: GOTO_SCREEN(StepsScreen);                break;
-    case  4:
-      #if HAS_MULTI_HOTEND
-        GOTO_SCREEN(NozzleOffsetScreen);
-      #elif ENABLED(BLTOUCH)
-        injectCommands_P(PSTR("M280 P0 S60"));
-      #endif
-      break;
+    #if ENABLED(HAS_MULTI_HOTEND)
+    case  4: GOTO_SCREEN(NozzleOffsetScreen);         break;
+    #endif
     case  5: GOTO_SCREEN(MaxVelocityScreen);          break;
     case  6: GOTO_SCREEN(DefaultAccelerationScreen);  break;
     case  7: GOTO_SCREEN(TERN(HAS_JUNCTION_DEVIATION, JunctionDeviationScreen, JerkScreen)); break;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
@@ -222,7 +222,8 @@ bool BedMeshScreen::tagToPoint(uint8_t tag, uint8_t &x, uint8_t &y) {
 
 void BedMeshScreen::onEntry() {
   screen_data.BedMeshScreen.highlightedTag = 0;
-  screen_data.BedMeshScreen.count = 0;
+  screen_data.BedMeshScreen.count = GRID_MAX_POINTS;
+  screen_data.BedMeshScreen.showMappingDone = false;
   BaseScreen::onEntry();
 }
 
@@ -251,6 +252,10 @@ void BedMeshScreen::drawHighlightedPointValue() {
      .colors(action_btn)
      .tag(1).button( OKAY_POS, GET_TEXT_F(MSG_BUTTON_OKAY))
      .tag(0);
+
+  if (screen_data.BedMeshScreen.showMappingDone) {
+    cmd.text(MESSAGE_POS, GET_TEXT_F(MSG_BED_MAPPING_DONE));
+  }
 }
 
 void BedMeshScreen::onRedraw(draw_mode_t what) {
@@ -270,17 +275,13 @@ void BedMeshScreen::onRedraw(draw_mode_t what) {
 
   if (what & FOREGROUND) {
     constexpr float autoscale_max_amplitude = 0.03;
-    const bool levelingFinished = screen_data.BedMeshScreen.count >= GRID_MAX_POINTS;
-    const float levelingProgress = sq(float(screen_data.BedMeshScreen.count) / GRID_MAX_POINTS);
-    if (levelingFinished) {
+    const bool gotAllPoints = screen_data.BedMeshScreen.count >= GRID_MAX_POINTS;
+    if (gotAllPoints) {
       drawHighlightedPointValue();
-      CommandProcessor cmd;
-      cmd.font(Theme::font_medium)
-         .text(MESSAGE_POS, GET_TEXT_F(MSG_BED_MAPPING_DONE));
     }
-
+    const float levelingProgress = sq(float(screen_data.BedMeshScreen.count) / GRID_MAX_POINTS);
     BedMeshScreen::drawMesh(INSET_POS(MESH_POS), ExtUI::getMeshArray(),
-      USE_POINTS | USE_HIGHLIGHT | USE_AUTOSCALE | (levelingFinished ? USE_COLORS : 0),
+      USE_POINTS | USE_HIGHLIGHT | USE_AUTOSCALE | (gotAllPoints ? USE_COLORS : 0),
       autoscale_max_amplitude * levelingProgress
     );
   }
@@ -307,11 +308,30 @@ void BedMeshScreen::onMeshUpdate(const int8_t, const int8_t, const float) {
 }
 
 void BedMeshScreen::onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t state) {
-  if (state == ExtUI::PROBE_FINISH) {
-    screen_data.BedMeshScreen.highlightedTag = pointToTag(x, y);
-    screen_data.BedMeshScreen.count++;
+  switch(state) {
+    case ExtUI::MESH_START:
+      screen_data.BedMeshScreen.count = 0;
+      screen_data.BedMeshScreen.showMappingDone = false;
+      break;
+    case ExtUI::MESH_FINISH:
+      screen_data.BedMeshScreen.count = GRID_MAX_POINTS;
+      screen_data.BedMeshScreen.showMappingDone = true;
+      break;
+    case ExtUI::PROBE_START:
+      screen_data.BedMeshScreen.highlightedTag = pointToTag(x, y);
+      break;
+    case ExtUI::PROBE_FINISH:
+      screen_data.BedMeshScreen.count++;
+      break;
   }
   BedMeshScreen::onMeshUpdate(x, y, 0);
 }
 
+void BedMeshScreen::startMeshProbe() {
+    GOTO_SCREEN(BedMeshScreen);
+    screen_data.BedMeshScreen.count = 0;
+    injectCommands_P(PSTR(BED_LEVELING_COMMANDS));
+}
+
 #endif // TOUCH_UI_FTDI_EVE && HAS_MESH
+ HAS_MESH

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
@@ -328,10 +328,9 @@ void BedMeshScreen::onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::pr
 }
 
 void BedMeshScreen::startMeshProbe() {
-    GOTO_SCREEN(BedMeshScreen);
-    screen_data.BedMeshScreen.count = 0;
-    injectCommands_P(PSTR(BED_LEVELING_COMMANDS));
+  GOTO_SCREEN(BedMeshScreen);
+  screen_data.BedMeshScreen.count = 0;
+  injectCommands_P(PSTR(BED_LEVELING_COMMANDS));
 }
 
 #endif // TOUCH_UI_FTDI_EVE && HAS_MESH
- HAS_MESH

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_status_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_status_screen.cpp
@@ -29,7 +29,9 @@
 
 #include "../ftdi_eve_lib/extras/poly_ui.h"
 
-#ifdef TOUCH_UI_PORTRAIT
+#if ENABLED(TOUCH_UI_COCOA_PRESS)
+  #include "cocoa_press_ui.h"
+#elif ENABLED(TOUCH_UI_PORTRAIT)
   #include "bio_printer_ui_portrait.h"
 #else
   #include "bio_printer_ui_landscape.h"
@@ -100,7 +102,7 @@ void StatusScreen::draw_temperature(draw_mode_t what) {
       // heating zones, but has no bed temperature
 
       cmd.cmd(COLOR_RGB(bg_text_enabled));
-      cmd.font(font_medium);
+      cmd.font(font_xsmall);
 
       ui.bounds(POLY(h0_label), x, y, h, v);
       cmd.text(x, y, h, v, GET_TEXT_F(MSG_ZONE_1));
@@ -221,7 +223,7 @@ void StatusScreen::draw_syringe(draw_mode_t what) {
     ui.color(syringe_rgb);
     ui.fill(POLY(syringe_outline));
 
-    ui.color(fill_rgb);
+    ui.color(fluid_rgb);
     ui.bounds(POLY(syringe_fluid), x, y, h, v);
     cmd.cmd(SAVE_CONTEXT());
     cmd.cmd(SCISSOR_XY(x,y + v * (1.0 - fill_level)));
@@ -245,23 +247,29 @@ void StatusScreen::draw_arrows(draw_mode_t what) {
   ui.button_stroke(stroke_rgb, 28);
   ui.button_shadow(shadow_rgb, shadow_depth);
 
+  #if ENABLED(TOUCH_UI_COCOA_PRESS)
+    constexpr uint8_t style = PolyUI::FILL | PolyUI::SHADOW;
+  #else
+    constexpr uint8_t style = PolyUI::REGULAR;
+  #endif
+
   if ((what & BACKGROUND) || jog_xy) {
-    ui.button(1, POLY(x_neg));
-    ui.button(2, POLY(x_pos));
-    ui.button(3, POLY(y_neg));
-    ui.button(4, POLY(y_pos));
+    ui.button(1, POLY(x_neg), style);
+    ui.button(2, POLY(x_pos), style);
+    ui.button(3, POLY(y_neg), style);
+    ui.button(4, POLY(y_pos), style);
   }
 
   if ((what & BACKGROUND) || z_homed) {
-    ui.button(5, POLY(z_neg));
-    ui.button(6, POLY(z_pos));
+    ui.button(5, POLY(z_neg), style);
+    ui.button(6, POLY(z_pos), style);
   }
 
   if ((what & BACKGROUND) || e_homed) {
     #if DISABLED(TOUCH_UI_COCOA_PRESS)
-      ui.button(7, POLY(e_neg));
+      ui.button(7, POLY(e_neg), style);
     #endif
-    ui.button(8, POLY(e_pos));
+    ui.button(8, POLY(e_pos), style);
   }
 }
 
@@ -300,13 +308,23 @@ void StatusScreen::draw_overlay_icons(draw_mode_t what) {
   PolyUI ui(cmd, what);
 
   if (what & FOREGROUND) {
-    ui.button_fill  (fill_rgb);
+    #if ENABLED(TOUCH_UI_COCOA_PRESS)
+      ui.button_fill  (stroke_rgb);
+    #else
+      ui.button_fill  (fill_rgb);
+    #endif
     ui.button_stroke(stroke_rgb, 28);
     ui.button_shadow(shadow_rgb, shadow_depth);
 
-    if (!jog_xy)  ui.button(12, POLY(padlock));
-    if (!e_homed) ui.button(13, POLY(home_e));
-    if (!z_homed) ui.button(14, POLY(home_z));
+    #if ENABLED(TOUCH_UI_COCOA_PRESS)
+      constexpr uint8_t style = PolyUI::FILL | PolyUI::SHADOW;
+    #else
+      constexpr uint8_t style = PolyUI::REGULAR;
+    #endif
+
+    if (!jog_xy)  ui.button(12, POLY(padlock), style);
+    if (!e_homed) ui.button(13, POLY(home_e), style);
+    if (!z_homed) ui.button(14, POLY(home_z), style);
   }
 }
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_status_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bio_status_screen.cpp
@@ -247,11 +247,7 @@ void StatusScreen::draw_arrows(draw_mode_t what) {
   ui.button_stroke(stroke_rgb, 28);
   ui.button_shadow(shadow_rgb, shadow_depth);
 
-  #if ENABLED(TOUCH_UI_COCOA_PRESS)
-    constexpr uint8_t style = PolyUI::FILL | PolyUI::SHADOW;
-  #else
-    constexpr uint8_t style = PolyUI::REGULAR;
-  #endif
+  constexpr uint8_t style = TERN(TOUCH_UI_COCOA_PRESS, PolyUI::FILL | PolyUI::SHADOW, PolyUI::REGULAR);
 
   if ((what & BACKGROUND) || jog_xy) {
     ui.button(1, POLY(x_neg), style);
@@ -308,20 +304,11 @@ void StatusScreen::draw_overlay_icons(draw_mode_t what) {
   PolyUI ui(cmd, what);
 
   if (what & FOREGROUND) {
-    #if ENABLED(TOUCH_UI_COCOA_PRESS)
-      ui.button_fill  (stroke_rgb);
-    #else
-      ui.button_fill  (fill_rgb);
-    #endif
+    ui.button_fill  (TERN(TOUCH_UI_COCOA_PRESS, stroke_rgb, fill_rgb);
     ui.button_stroke(stroke_rgb, 28);
     ui.button_shadow(shadow_rgb, shadow_depth);
 
-    #if ENABLED(TOUCH_UI_COCOA_PRESS)
-      constexpr uint8_t style = PolyUI::FILL | PolyUI::SHADOW;
-    #else
-      constexpr uint8_t style = PolyUI::REGULAR;
-    #endif
-
+    constexpr uint8_t style = TERN(TOUCH_UI_COCOA_PRESS, PolyUI::FILL | PolyUI::SHADOW, PolyUI::REGULAR);
     if (!jog_xy)  ui.button(12, POLY(padlock), style);
     if (!e_homed) ui.button(13, POLY(home_e), style);
     if (!z_homed) ui.button(14, POLY(home_z), style);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_menu.cpp
@@ -59,17 +59,9 @@ void FilamentMenu::onRedraw(draw_mode_t what) {
     cmd.font(font_large)
        .text(TITLE_POS, GET_TEXT_F(MSG_FILAMENT))
        .font(font_medium).colors(normal_btn)
-       .enabled(
-         #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-           1
-         #endif
-       )
+       .enabled(ENABLED(FILAMENT_RUNOUT_SENSOR))
        .tag(2).button(RUNOUT_SENSOR_POS, GET_TEXT_F(MSG_RUNOUT_SENSOR))
-       .enabled(
-         #if ENABLED(LIN_ADVANCE)
-           1
-         #endif
-       )
+       .enabled(ENABLED(LIN_ADVANCE))
        .tag(3).button(LIN_ADVANCE_POS, GET_TEXT_F(MSG_LINEAR_ADVANCE))
        .colors(action_btn)
        .tag(1).button(BACK_POS, GET_TEXT_F(MSG_BACK));

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_menu.cpp
@@ -30,6 +30,22 @@ using namespace FTDI;
 using namespace ExtUI;
 using namespace Theme;
 
+#ifdef TOUCH_UI_PORTRAIT
+  #define GRID_ROWS 9
+  #define GRID_COLS 2
+  #define TITLE_POS          BTN_POS(1,1), BTN_SIZE(2,1)
+  #define RUNOUT_SENSOR_POS  BTN_POS(1,2), BTN_SIZE(2,1)
+  #define LIN_ADVANCE_POS    BTN_POS(1,3), BTN_SIZE(2,1)
+  #define BACK_POS           BTN_POS(1,9), BTN_SIZE(2,1)
+#else
+  #define GRID_ROWS 6
+  #define GRID_COLS 2
+  #define TITLE_POS          BTN_POS(1,1), BTN_SIZE(2,1)
+  #define RUNOUT_SENSOR_POS  BTN_POS(1,2), BTN_SIZE(2,1)
+  #define LIN_ADVANCE_POS    BTN_POS(1,3), BTN_SIZE(2,1)
+  #define BACK_POS           BTN_POS(1,6), BTN_SIZE(2,1)
+#endif
+
 void FilamentMenu::onRedraw(draw_mode_t what) {
   if (what & BACKGROUND) {
     CommandProcessor cmd;
@@ -41,47 +57,22 @@ void FilamentMenu::onRedraw(draw_mode_t what) {
   if (what & FOREGROUND) {
     CommandProcessor cmd;
     cmd.font(font_large)
-    #ifdef TOUCH_UI_PORTRAIT
-      #define GRID_ROWS 9
-      #define GRID_COLS 2
-         .text  ( BTN_POS(1,1),      BTN_SIZE(2,1), GET_TEXT_F(MSG_FILAMENT))
-         .font(font_medium).colors(normal_btn)
-         .enabled(
-           #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-             1
-           #endif
-         )
-      .tag(2).button( BTN_POS(1,2),  BTN_SIZE(2,1), GET_TEXT_F(MSG_RUNOUT_SENSOR))
-      .enabled(
-        #if ENABLED(LIN_ADVANCE)
-          1
-        #endif
-      )
-      .tag(3).button( BTN_POS(1,3),  BTN_SIZE(2,1), GET_TEXT_F(MSG_LINEAR_ADVANCE))
-      .colors(action_btn)
-      .tag(1) .button( BTN_POS(1,9), BTN_SIZE(2,1), GET_TEXT_F(MSG_BACK));
-      #undef GRID_COLS
-      #undef GRID_ROWS
-    #else
-      #define GRID_ROWS 6
-      #define GRID_COLS 3
-         .text  ( BTN_POS(1,1),      BTN_SIZE(3,1), GET_TEXT_F(MSG_FILAMENT))
-         .font(font_medium).colors(normal_btn)
-         .enabled(
-           #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-             1
-           #endif
-         )
-      .tag(2).button( BTN_POS(1,2),  BTN_SIZE(3,1), GET_TEXT_F(MSG_RUNOUT_SENSOR))
-      .enabled(
-        #if ENABLED(LIN_ADVANCE)
-          1
-        #endif
-      )
-      .tag(3).button( BTN_POS(1,3),  BTN_SIZE(3,1), GET_TEXT_F(MSG_LINEAR_ADVANCE))
-      .colors(action_btn)
-      .tag(1) .button( BTN_POS(1,6), BTN_SIZE(3,1), GET_TEXT_F(MSG_BACK));
-    #endif
+       .text(TITLE_POS, GET_TEXT_F(MSG_FILAMENT))
+       .font(font_medium).colors(normal_btn)
+       .enabled(
+         #if ENABLED(FILAMENT_RUNOUT_SENSOR)
+           1
+         #endif
+       )
+       .tag(2).button(RUNOUT_SENSOR_POS, GET_TEXT_F(MSG_RUNOUT_SENSOR))
+       .enabled(
+         #if ENABLED(LIN_ADVANCE)
+           1
+         #endif
+       )
+       .tag(3).button(LIN_ADVANCE_POS, GET_TEXT_F(MSG_LINEAR_ADVANCE))
+       .colors(action_btn)
+       .tag(1).button(BACK_POS, GET_TEXT_F(MSG_BACK));
   }
 }
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/files_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/files_screen.cpp
@@ -22,7 +22,7 @@
 
 #include "../config.h"
 
-#if ENABLED(TOUCH_UI_FTDI_EVE)
+#if BOTH(TOUCH_UI_FTDI_EVE, SDSUPPORT)
 
 #include "screens.h"
 #include "screen_data.h"

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/main_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/main_menu.cpp
@@ -44,15 +44,14 @@ void MainMenu::onRedraw(draw_mode_t what) {
     #define ADVANCED_SETTINGS_POS BTN_POS(1,2), BTN_SIZE(2,1)
     #define FILAMENTCHANGE_POS    BTN_POS(1,3), BTN_SIZE(2,1)
     #define TEMPERATURE_POS       BTN_POS(1,4), BTN_SIZE(2,1)
-    #define MOVE_AXIS_POS         BTN_POS(1,5), BTN_SIZE(1,1)
-    #define DISABLE_STEPPERS_POS  BTN_POS(2,5), BTN_SIZE(1,1)
-    #define AUTO_HOME_POS         BTN_POS(1,6), BTN_SIZE(1,1)
-    #define CLEAN_NOZZLE_POS      BTN_POS(2,6), BTN_SIZE(1,1)
-    #define LEVEL_BED_POS         BTN_POS(1,7), BTN_SIZE(1,1)
-    #define LEVEL_AXIS_POS        BTN_POS(2,7), BTN_SIZE(1,1)
+    #define DISABLE_STEPPERS_POS  BTN_POS(1,5), BTN_SIZE(2,1)
+    #define MOVE_AXIS_POS         BTN_POS(1,6), BTN_SIZE(1,1)
+    #define LEVELING_POS          BTN_POS(2,6), BTN_SIZE(1,1)
+    #define AUTO_HOME_POS         BTN_POS(1,7), BTN_SIZE(1,1)
+    #define CLEAN_NOZZLE_POS      BTN_POS(2,7), BTN_SIZE(1,1)
     #define BACK_POS              BTN_POS(1,8), BTN_SIZE(2,1)
   #else
-    #define GRID_ROWS 6
+    #define GRID_ROWS 5
     #define GRID_COLS 2
     #define ADVANCED_SETTINGS_POS BTN_POS(1,1), BTN_SIZE(1,1)
     #define ABOUT_PRINTER_POS     BTN_POS(2,1), BTN_SIZE(1,1)
@@ -62,9 +61,8 @@ void MainMenu::onRedraw(draw_mode_t what) {
     #define DISABLE_STEPPERS_POS  BTN_POS(2,3), BTN_SIZE(1,1)
     #define TEMPERATURE_POS       BTN_POS(1,4), BTN_SIZE(1,1)
     #define FILAMENTCHANGE_POS    BTN_POS(2,4), BTN_SIZE(1,1)
-    #define LEVEL_BED_POS         BTN_POS(1,5), BTN_SIZE(1,1)
-    #define LEVEL_AXIS_POS        BTN_POS(2,5), BTN_SIZE(1,1)
-    #define BACK_POS              BTN_POS(1,6), BTN_SIZE(2,1)
+    #define LEVELING_POS          BTN_POS(1,5), BTN_SIZE(1,1)
+    #define BACK_POS              BTN_POS(2,5), BTN_SIZE(1,1)
   #endif
 
   if (what & FOREGROUND) {
@@ -101,23 +99,12 @@ void MainMenu::onRedraw(draw_mode_t what) {
         ))
        .tag(8).button( ADVANCED_SETTINGS_POS, GET_TEXT_F(MSG_ADVANCED_SETTINGS))
        .enabled(
-         #ifdef PRINTCOUNTER
-           1
-         #endif
-        )
-       .enabled(
-         #ifdef AXIS_LEVELING_COMMANDS
-           1
-         #endif
-        )
-       .tag(9).button( LEVEL_AXIS_POS, GET_TEXT_F(MSG_AUTOLEVEL_X_AXIS))
-       .enabled(
          #ifdef HAS_LEVELING
            1
          #endif
         )
-       .tag(10).button( LEVEL_BED_POS, GET_TEXT_F(MSG_LEVEL_BED))
-       .tag(11).button( ABOUT_PRINTER_POS, GET_TEXT_F(MSG_INFO_MENU))
+       .tag(9).button( LEVELING_POS, GET_TEXT_F(MSG_LEVELING))
+       .tag(10).button( ABOUT_PRINTER_POS, GET_TEXT_F(MSG_INFO_MENU))
        .colors(action_btn)
        .tag(1).button( BACK_POS, GET_TEXT_F(MSG_BACK));
   }
@@ -143,23 +130,10 @@ bool MainMenu::onTouchEnd(uint8_t tag) {
     case 7:  GOTO_SCREEN(ChangeFilamentScreen);                       break;
     #endif
     case 8:  GOTO_SCREEN(AdvancedSettingsMenu);                       break;
-    #ifdef AXIS_LEVELING_COMMANDS
-    case 9: SpinnerDialogBox::enqueueAndWait_P(F(AXIS_LEVELING_COMMANDS)); break;
+    #ifdef HAS_LEVELING
+    case 9: GOTO_SCREEN(LevelingMenu);                                break;
     #endif
-    #if HAS_LEVELING
-      case 10:
-        #ifndef BED_LEVELING_COMMANDS
-          #define BED_LEVELING_COMMANDS "G29"
-        #endif
-        #if HAS_MESH
-          GOTO_SCREEN(BedMeshScreen);
-          injectCommands_P(PSTR(BED_LEVELING_COMMANDS));
-        #else
-          SpinnerDialogBox::enqueueAndWait_P(F(BED_LEVELING_COMMANDS));
-        #endif
-        break;
-    #endif
-    case 11: GOTO_SCREEN(AboutScreen);                                break;
+    case 10: GOTO_SCREEN(AboutScreen);                                break;
     default:
       return false;
   }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screen_data.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screen_data.h
@@ -62,6 +62,7 @@ union screen_data_t {
   } MoveAxisScreen;
 #if HAS_MESH
   struct {
+    bool    showMappingDone;
     uint8_t count;
     uint8_t highlightedTag;
   } BedMeshScreen;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.cpp
@@ -56,17 +56,20 @@ SCREEN_TABLE {
 #if ENABLED(BABYSTEPPING)
   DECL_SCREEN(NudgeNozzleScreen),
 #endif
-#if HAS_MESH
-  DECL_SCREEN(BedMeshScreen),
-#endif
   DECL_SCREEN(MoveAxisScreen),
   DECL_SCREEN(StepsScreen),
 #if HAS_TRINAMIC_CONFIG
   DECL_SCREEN(StepperCurrentScreen),
   DECL_SCREEN(StepperBumpSensitivityScreen),
 #endif
-#if HAS_BED_PROBE
-  DECL_SCREEN(ZOffsetScreen),
+#if HAS_LEVELING
+  DECL_SCREEN(LevelingMenu),
+  #if HAS_BED_PROBE
+    DECL_SCREEN(ZOffsetScreen),
+  #endif
+  #if HAS_MESH
+    DECL_SCREEN(BedMeshScreen),
+  #endif
 #endif
 #if HAS_MULTI_HOTEND
   DECL_SCREEN(NozzleOffsetScreen),
@@ -100,7 +103,9 @@ SCREEN_TABLE {
   DECL_SCREEN(InterfaceSettingsScreen),
   DECL_SCREEN(InterfaceSoundsScreen),
   DECL_SCREEN(LockScreen),
+#if ENABLED(SDSUPPORT)
   DECL_SCREEN(FilesScreen),
+#endif
   DECL_SCREEN(EndstopStatesScreen),
 #if ENABLED(TOUCH_UI_LULZBOT_BIO)
   DECL_SCREEN(BioPrintingDialogBox),

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
@@ -39,24 +39,37 @@ enum {
   STATUS_SCREEN_CACHE,
   MENU_SCREEN_CACHE,
   TUNE_SCREEN_CACHE,
-  ADJUST_OFFSETS_SCREEN_CACHE,
   ALERT_BOX_CACHE,
   SPINNER_CACHE,
   ADVANCED_SETTINGS_SCREEN_CACHE,
   MOVE_AXIS_SCREEN_CACHE,
   TEMPERATURE_SCREEN_CACHE,
   STEPS_SCREEN_CACHE,
-  STEPPER_CURRENT_SCREEN_CACHE,
-  STEPPER_BUMP_SENSITIVITY_SCREEN_CACHE,
-  ZOFFSET_SCREEN_CACHE,
-  NOZZLE_OFFSET_SCREEN_CACHE,
-  BACKLASH_COMPENSATION_SCREEN_CACHE,
   MAX_FEEDRATE_SCREEN_CACHE,
   MAX_VELOCITY_SCREEN_CACHE,
   MAX_ACCELERATION_SCREEN_CACHE,
   DEFAULT_ACCELERATION_SCREEN_CACHE,
-#if HAS_MESH
-  BED_MESH_SCREEN_CACHE,
+#if HAS_LEVELING
+  LEVELING_SCREEN_CACHE,
+  #if HAS_BED_PROBE
+    ZOFFSET_SCREEN_CACHE,
+  #endif
+  #if HAS_MESH
+    BED_MESH_SCREEN_CACHE,
+  #endif
+#endif
+#if ENABLED(BABYSTEPPING)
+  ADJUST_OFFSETS_SCREEN_CACHE,
+#endif
+#if HAS_TRINAMIC_CONFIG
+  STEPPER_CURRENT_SCREEN_CACHE,
+  STEPPER_BUMP_SENSITIVITY_SCREEN_CACHE,
+#endif
+#if HAS_MULTI_HOTEND
+  NOZZLE_OFFSET_SCREEN_CACHE,
+#endif
+#if ENABLED(BACKLASH_GCODE)
+  BACKLASH_COMPENSATION_SCREEN_CACHE,
 #endif
 #if HAS_JUNCTION_DEVIATION
   JUNC_DEV_SCREEN_CACHE,
@@ -82,11 +95,13 @@ enum {
   PREHEAT_MENU_CACHE,
   PREHEAT_TIMER_SCREEN_CACHE,
 #endif
+#if ENABLED(SDSUPPORT)
+  FILES_SCREEN_CACHE,
+#endif
   CHANGE_FILAMENT_SCREEN_CACHE,
   INTERFACE_SETTINGS_SCREEN_CACHE,
   INTERFACE_SOUNDS_SCREEN_CACHE,
   LOCK_SCREEN_CACHE,
-  FILES_SCREEN_CACHE,
   DISPLAY_TIMINGS_SCREEN_CACHE
 };
 
@@ -132,33 +147,6 @@ class AboutScreen : public BaseScreen, public UncachedScreen {
     static void onRedraw(draw_mode_t);
     static bool onTouchEnd(uint8_t tag);
 };
-
-#if HAS_MESH
-class BedMeshScreen : public BaseScreen, public CachedScreen<BED_MESH_SCREEN_CACHE> {
-  private:
-    enum MeshOpts {
-      USE_POINTS    = 0x01,
-      USE_COLORS    = 0x02,
-      USE_TAGS      = 0x04,
-      USE_HIGHLIGHT = 0x08,
-      USE_AUTOSCALE = 0x10
-    };
-
-    static uint8_t pointToTag(uint8_t x, uint8_t y);
-    static bool tagToPoint(uint8_t tag, uint8_t &x, uint8_t &y);
-    static float getHightlightedValue();
-    static void drawHighlightedPointValue();
-    static void drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max = 0.1);
-
-  public:
-    static void onMeshUpdate(const int8_t x, const int8_t y, const float val);
-    static void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t);
-    static void onEntry();
-    static void onRedraw(draw_mode_t);
-    static bool onTouchStart(uint8_t tag);
-    static bool onTouchEnd(uint8_t tag);
-};
-#endif
 
 #if ENABLED(PRINTCOUNTER)
   class StatisticsScreen : public BaseScreen, public UncachedScreen {
@@ -505,14 +493,6 @@ class StepsScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEP
   };
 #endif
 
-#if HAS_BED_PROBE
-  class ZOffsetScreen : public BaseNumericAdjustmentScreen, public CachedScreen<ZOFFSET_SCREEN_CACHE> {
-    public:
-      static void onRedraw(draw_mode_t);
-      static bool onTouchHeld(uint8_t tag);
-  };
-#endif
-
 #if HAS_MULTI_HOTEND
   class NozzleOffsetScreen : public BaseNumericAdjustmentScreen, public CachedScreen<NOZZLE_OFFSET_SCREEN_CACHE> {
     public:
@@ -520,6 +500,51 @@ class StepsScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEP
       static void onRedraw(draw_mode_t);
       static bool onTouchHeld(uint8_t tag);
   };
+#endif
+
+#if HAS_LEVELING
+  class LevelingMenu : public BaseScreen, public CachedScreen<LEVELING_SCREEN_CACHE> {
+    public:
+      static void onRedraw(draw_mode_t);
+      static bool onTouchEnd(uint8_t tag);
+  };
+
+  #if HAS_BED_PROBE
+    class ZOffsetScreen : public BaseNumericAdjustmentScreen, public CachedScreen<ZOFFSET_SCREEN_CACHE> {
+      public:
+        static void onRedraw(draw_mode_t);
+        static bool onTouchHeld(uint8_t tag);
+    };
+  #endif
+
+  #if HAS_MESH
+  class BedMeshScreen : public BaseScreen, public CachedScreen<BED_MESH_SCREEN_CACHE> {
+    private:
+      enum MeshOpts {
+        USE_POINTS    = 0x01,
+        USE_COLORS    = 0x02,
+        USE_TAGS      = 0x04,
+        USE_HIGHLIGHT = 0x08,
+        USE_AUTOSCALE = 0x10
+      };
+
+      static uint8_t pointToTag(uint8_t x, uint8_t y);
+      static bool tagToPoint(uint8_t tag, uint8_t &x, uint8_t &y);
+      static float getHightlightedValue();
+      static void drawHighlightedPointValue();
+      static void drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max = 0.1);
+
+    public:
+      static void onMeshUpdate(const int8_t x, const int8_t y, const float val);
+      static void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t);
+      static void onEntry();
+      static void onRedraw(draw_mode_t);
+      static bool onTouchStart(uint8_t tag);
+      static bool onTouchEnd(uint8_t tag);
+
+      static void startMeshProbe();
+  };
+  #endif
 #endif
 
 #if ENABLED(BABYSTEPPING)
@@ -707,40 +732,42 @@ class LockScreen : public BaseScreen, public CachedScreen<LOCK_SCREEN_CACHE> {
     static bool onTouchEnd(uint8_t tag);
 };
 
-class FilesScreen : public BaseScreen, public CachedScreen<FILES_SCREEN_CACHE, FILE_SCREEN_DL_SIZE> {
-  private:
-    #ifdef TOUCH_UI_PORTRAIT
-      static constexpr uint8_t header_h       = 2;
-      static constexpr uint8_t footer_h       = 2;
-      static constexpr uint8_t files_per_page = 11;
-    #else
-      static constexpr uint8_t header_h       = 1;
-      static constexpr uint8_t footer_h       = 1;
-      static constexpr uint8_t files_per_page = 6;
-    #endif
+#if ENABLED(SDSUPPORT)
+  class FilesScreen : public BaseScreen, public CachedScreen<FILES_SCREEN_CACHE, FILE_SCREEN_DL_SIZE> {
+    private:
+      #ifdef TOUCH_UI_PORTRAIT
+        static constexpr uint8_t header_h       = 2;
+        static constexpr uint8_t footer_h       = 2;
+        static constexpr uint8_t files_per_page = 11;
+      #else
+        static constexpr uint8_t header_h       = 1;
+        static constexpr uint8_t footer_h       = 1;
+        static constexpr uint8_t files_per_page = 6;
+      #endif
 
-    static uint8_t  getTagForLine(uint8_t line) {return line + 2;}
-    static uint8_t  getLineForTag(uint8_t tag)  {return  tag - 2;}
-    static uint16_t getFileForTag(uint8_t tag);
-    static uint16_t getSelectedFileIndex();
+      static uint8_t  getTagForLine(uint8_t line) {return line + 2;}
+      static uint8_t  getLineForTag(uint8_t tag)  {return  tag - 2;}
+      static uint16_t getFileForTag(uint8_t tag);
+      static uint16_t getSelectedFileIndex();
 
-    inline static const char *getSelectedShortFilename() {return getSelectedFilename(false);}
-    inline static const char *getSelectedLongFilename()  {return getSelectedFilename(true);}
-    static const char *getSelectedFilename(bool longName);
+      inline static const char *getSelectedShortFilename() {return getSelectedFilename(false);}
+      inline static const char *getSelectedLongFilename()  {return getSelectedFilename(true);}
+      static const char *getSelectedFilename(bool longName);
 
-    static void drawFileButton(const char* filename, uint8_t tag, bool is_dir, bool is_highlighted);
-    static void drawFileList();
-    static void drawHeader();
-    static void drawFooter();
-    static void drawSelectedFile();
+      static void drawFileButton(const char* filename, uint8_t tag, bool is_dir, bool is_highlighted);
+      static void drawFileList();
+      static void drawHeader();
+      static void drawFooter();
+      static void drawSelectedFile();
 
-    static void gotoPage(uint8_t);
-  public:
-    static void onEntry();
-    static void onRedraw(draw_mode_t);
-    static bool onTouchEnd(uint8_t tag);
-    static void onIdle();
-};
+      static void gotoPage(uint8_t);
+    public:
+      static void onEntry();
+      static void onRedraw(draw_mode_t);
+      static bool onTouchEnd(uint8_t tag);
+      static void onIdle();
+  };
+#endif
 
 class EndstopStatesScreen : public BaseScreen, public UncachedScreen {
   public:

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/colors.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/colors.h
@@ -124,7 +124,13 @@ namespace Theme {
   constexpr uint32_t shadow_rgb             = gray_color_6;
   constexpr uint32_t stroke_rgb             = accent_color_1;
   constexpr uint32_t fill_rgb               = accent_color_3;
-  constexpr uint32_t syringe_rgb            = accent_color_5;
+  #if ENABLED(TOUCH_UI_COCOA_PRESS)
+    constexpr uint32_t syringe_rgb          = 0xFFFFFF;
+    constexpr uint32_t fluid_rgb            = accent_color_5;
+  #else                                    
+    constexpr uint32_t syringe_rgb          = accent_color_5;
+    constexpr uint32_t fluid_rgb            = accent_color_3;
+  #endif
 
   #if ENABLED(TOUCH_UI_ROYAL_THEME)
     constexpr uint32_t x_axis               = hsl_to_rgb(0,   1.00, 0.26);

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -544,11 +544,13 @@ namespace ExtUI {
 
   void setAxisSteps_per_mm(const float value, const axis_t axis) {
     planner.settings.axis_steps_per_mm[axis] = value;
+    planner.refresh_positioning();
   }
 
   void setAxisSteps_per_mm(const float value, const extruder_t extruder) {
     UNUSED_E(extruder);
     planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)] = value;
+    planner.refresh_positioning();
   }
 
   feedRate_t getAxisMaxFeedrate_mm_s(const axis_t axis) {
@@ -580,11 +582,13 @@ namespace ExtUI {
 
   void setAxisMaxAcceleration_mm_s2(const float value, const axis_t axis) {
     planner.set_max_acceleration(axis, value);
+    planner.reset_acceleration_rates();
   }
 
   void setAxisMaxAcceleration_mm_s2(const float value, const extruder_t extruder) {
     UNUSED_E(extruder);
     planner.set_max_acceleration(E_AXIS_N(extruder - E0), value);
+    planner.reset_acceleration_rates();
   }
 
   #if HAS_FILAMENT_SENSOR

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -1007,7 +1007,7 @@ namespace ExtUI {
   bool FileList::seek(const uint16_t pos, const bool skip_range_check) {
     #if ENABLED(SDSUPPORT)
       if (!skip_range_check && (pos + 1) > count()) return false;
-      card.getfilename_sorted(pos);
+      card.getfilename_sorted(SD_ORDER(pos, count()));
       return card.filename[0] != '\0';
     #else
       UNUSED(pos);

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -144,10 +144,10 @@ namespace ExtUI {
       inline void onMeshUpdate(const xy_int8_t &pos, const float zval) { onMeshUpdate(pos.x, pos.y, zval); }
 
       typedef enum : unsigned char {
-          MESH_START,    // Prior to start of probe
-          MESH_FINISH,   // Following probe of all points
-          PROBE_START,   // Beginning probe of grid location
-          PROBE_FINISH   // Finished probe of grid location
+        MESH_START,    // Prior to start of probe
+        MESH_FINISH,   // Following probe of all points
+        PROBE_START,   // Beginning probe of grid location
+        PROBE_FINISH   // Finished probe of grid location
       } probe_state_t;
       void onMeshUpdate(const int8_t xpos, const int8_t ypos, probe_state_t state);
       inline void onMeshUpdate(const xy_int8_t &pos, probe_state_t state) { onMeshUpdate(pos.x, pos.y, state); }

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -143,7 +143,12 @@ namespace ExtUI {
       void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval);
       inline void onMeshUpdate(const xy_int8_t &pos, const float zval) { onMeshUpdate(pos.x, pos.y, zval); }
 
-      typedef enum : unsigned char { PROBE_START, PROBE_FINISH } probe_state_t;
+      typedef enum : unsigned char {
+          MESH_START,    // Prior to start of probe
+          MESH_FINISH,   // Following probe of all points
+          PROBE_START,   // Beginning probe of grid location
+          PROBE_FINISH   // Finished probe of grid location
+      } probe_state_t;
       void onMeshUpdate(const int8_t xpos, const int8_t ypos, probe_state_t state);
       inline void onMeshUpdate(const xy_int8_t &pos, probe_state_t state) { onMeshUpdate(pos.x, pos.y, state); }
     #endif


### PR DESCRIPTION
### Description

- Added a new "Leveling" submenu with leveling options and BLTouch controls
- Added button to test the BLTouch
- Added button to review the Bed Mesh without rerunning the mesh probe
- Merged in some tweaks done to the status screen for CocoaPress
- Cleaned up code in the Filament Runout Menu to reduce code duplication
- Fix Bed Mesh screen so it updates correctly with partial meshes
- Fix Bed Mesh screen so it updates correctly if G29 is issued from serial port
- Fix bug where files display screen was disregarding user sorting preference
- Fix bug where changing steps/mm in the touch UI would not recompute planner variables
- Fix bug where changing accelerations in the touch UI would not recompute planner variables
