### PR TITLE
Fix #19350 Remove duplicate string on LCD when wildcard is present.

### DIFF
--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -61,6 +61,7 @@ lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const int8_t ind, PGM_P const i
         n -= lcd_put_u8str_max_P((PGM_P)p, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
         break;
       }
+    }
     else if (ch == '$' && inStr) {
       n -= lcd_put_u8str_max_P(inStr, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
     }

--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -57,8 +57,10 @@ lcd_uint_t lcd_put_u8str_ind_P(PGM_P const pstr, const int8_t ind, PGM_P const i
         PGM_P const b = ind == -2 ? GET_TEXT(MSG_CHAMBER) : GET_TEXT(MSG_BED);
         n -= lcd_put_u8str_max_P(b, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
       }
-      if (n) n -= lcd_put_u8str_max_P((PGM_P)p, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
-    }
+      if (n) {
+        n -= lcd_put_u8str_max_P((PGM_P)p, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
+        break;
+      }
     else if (ch == '$' && inStr) {
       n -= lcd_put_u8str_max_P(inStr, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);
     }


### PR DESCRIPTION
### Requirements

A 12864 glcd
a menu that substitutes * in  Language_Str  eg MSG_EN_STEPS  = _UxGT("* Steps/mm");

### Description

The code at present does the * substitution, and then prints the remaining string twice. 
First copy is printed with "lcd_put_u8str_max_P((PGM_P)p, n * (MENU_FONT_WIDTH)) / (MENU_FONT_WIDTH);"
Second copy is printed with "lcd_put_wchar(ch);" character by character.

Adding a break after the first copy of the string is printed solves this issue.

### Benefits

LCD menus using substituted * in the Language_Str  now works as expected. 
Fixes issue #19350

### Configurations

See user provided Configs in issue #19350

### Related Issues
issue #19350
