### PR TITLE
Fix MKS SGEN_L pin assignment on EXP2

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -229,7 +229,7 @@
  *                _____                                            _____
  * (BEEPER) 1.31 | · · | 1.30 (BTN_ENC)          (MISO)       0.8 | · · | 0.7  (SD_SCK)
  * (LCD_EN) 0.18 | · · | 0.16 (LCD_RS)           (BTN_EN1)   3.25 | · · | 0.28 (SD_CS2)
- * (LCD_D4) 0.15 | · · | 0.17 (LCD_D5)           (BTN_EN2)   3.26 | · · | 1.20 (SD_MOSI)
+ * (LCD_D4) 0.15 | · · | 0.17 (LCD_D5)           (BTN_EN2)   3.26 | · · | 0.9  (SD_MOSI)
  * (LCD_D6)  1.0 | · · | 1.22 (LCD_D7)           (SD_DETECT) 0.27 | · · | RST
  *           GND | · · | 5V                                   GND | · · | NC
  *                -----                                            -----
@@ -279,7 +279,7 @@
         #define DOGLCD_CS                  P0_18
         #define DOGLCD_A0                  P0_16
         #define DOGLCD_SCK                 P0_07
-        #define DOGLCD_MOSI                P1_20
+        #define DOGLCD_MOSI                P0_09
 
         #define LCD_BACKLIGHT_PIN          -1
 


### PR DESCRIPTION
### Description

Fix incorrect pin assignment on the EXP2 connector on MKS SGEN_L 1.0 boards

### Benefits

Allows the pin to be properly used. This currently only seems to impact FYSETC Mini displays.
The FYSETC Mini still does not work, due to another another issue related to recent SPI changes. I will report an issue to track that.

### Configurations

Minimal configuration. Nothing more than the board and the display specified.
This can be used to reproduce the problem, but unfortunately you cannot verify the fix with it, without further modifying SPI classes elsewhere in the HAL.
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/5213431/Configuration.zip)


### Related Issues

SGEN_L issues with FYSETC Mini was mentioned by @nvumnov in a comment on #19346, but does not have an issue of its own.
