### PR TITLE
STATIC_ITEM_N not working as intended

### DIFF
--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -343,7 +343,7 @@ class MenuItem_bool : public MenuEditItemBase {
 #define PSTRING_ITEM(LABEL, V...)                     PSTRING_ITEM_P(GET_TEXT(LABEL), ##V)
 
 #define STATIC_ITEM(LABEL,   V...)                     STATIC_ITEM_P(GET_TEXT(LABEL), ##V)
-#define STATIC_ITEM_N(LABEL, V...)                   STATIC_ITEM_N_P(GET_TEXT(LABEL), ##V)
+#define STATIC_ITEM_N(LABEL, N, V...)                   STATIC_ITEM_N_P(GET_TEXT(LABEL), N, ##V)
 
 #define MENU_ITEM_N_S_P(TYPE, N, S, PLABEL, V...)   _MENU_ITEM_N_S_P(TYPE, N, S, false, PLABEL, ##V)
 #define MENU_ITEM_N_S(TYPE, N, S, LABEL, V...)       MENU_ITEM_N_S_P(TYPE, N, S, GET_TEXT(LABEL), ##V)

--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -342,8 +342,8 @@ class MenuItem_bool : public MenuEditItemBase {
 
 #define PSTRING_ITEM(LABEL, V...)                     PSTRING_ITEM_P(GET_TEXT(LABEL), ##V)
 
-#define STATIC_ITEM(LABEL,   V...)                     STATIC_ITEM_P(GET_TEXT(LABEL), ##V)
-#define STATIC_ITEM_N(LABEL, N, V...)                   STATIC_ITEM_N_P(GET_TEXT(LABEL), N, ##V)
+#define STATIC_ITEM(LABEL, V...)                       STATIC_ITEM_P(GET_TEXT(LABEL), ##V)
+#define STATIC_ITEM_N(LABEL, N, V...)                STATIC_ITEM_N_P(GET_TEXT(LABEL), N, ##V)
 
 #define MENU_ITEM_N_S_P(TYPE, N, S, PLABEL, V...)   _MENU_ITEM_N_S_P(TYPE, N, S, false, PLABEL, ##V)
 #define MENU_ITEM_N_S(TYPE, N, S, LABEL, V...)       MENU_ITEM_N_S_P(TYPE, N, S, GET_TEXT(LABEL), ##V)


### PR DESCRIPTION
### Description
im confused about the removal of the N in the `#define STATIC_ITEM_N(LABEL, V...) STATIC_ITEM_N_P(GET_TEXT(LABEL), ##V) `when #19303 was merged because N is still needed, right? 

```
 #define STATIC_ITEM_N_P(PLABEL, N, V...) do{ \
  if (_menuLineNr == _thisItemNr) {          \
    MenuItemBase::init(N);                   \
    STATIC_ITEM_INNER_P(PLABEL, ##V);        \
  }                                          \
  NEXT_ITEM();                               \
}while(0)
```
without "N"  `STATIC_ITEM_N` acts the same as `STATIC_ITEM`
