### PR TITLE
Move JOYSTICK_DEBUG from joystick.h to Configuration_adv.h

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3323,9 +3323,6 @@
  */
 //#define JOYSTICK
 #if ENABLED(JOYSTICK)
-  // Use M119 with JOYSTICK_DEBUG to find reasonable values after connecting:
-  //#define JOYSTICK_DEBUG
-
   #define JOY_X_PIN    5  // RAMPS: Suggested pin A5  on AUX2
   #define JOY_Y_PIN   10  // RAMPS: Suggested pin A10 on AUX2
   #define JOY_Z_PIN   12  // RAMPS: Suggested pin A12 on AUX2
@@ -3335,9 +3332,11 @@
   //#define INVERT_JOY_Y  // Enable if Y direction is reversed
   //#define INVERT_JOY_Z  // Enable if Z direction is reversed
 
+  // Use M119 with JOYSTICK_DEBUG to find reasonable values after connecting:
   #define JOY_X_LIMITS { 5600, 8190-100, 8190+100, 10800 } // min, deadzone start, deadzone end, max
   #define JOY_Y_LIMITS { 5600, 8250-100, 8250+100, 11000 }
   #define JOY_Z_LIMITS { 4800, 8080-100, 8080+100, 11550 }
+  //#define JOYSTICK_DEBUG
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3323,6 +3323,9 @@
  */
 //#define JOYSTICK
 #if ENABLED(JOYSTICK)
+  // Use M119 with JOYSTICK_DEBUG to find reasonable values after connecting:
+  //#define JOYSTICK_DEBUG
+
   #define JOY_X_PIN    5  // RAMPS: Suggested pin A5  on AUX2
   #define JOY_Y_PIN   10  // RAMPS: Suggested pin A10 on AUX2
   #define JOY_Z_PIN   12  // RAMPS: Suggested pin A12 on AUX2
@@ -3332,7 +3335,6 @@
   //#define INVERT_JOY_Y  // Enable if Y direction is reversed
   //#define INVERT_JOY_Z  // Enable if Z direction is reversed
 
-  // Use M119 with JOYSTICK_DEBUG to find reasonable values after connecting:
   #define JOY_X_LIMITS { 5600, 8190-100, 8190+100, 10800 } // min, deadzone start, deadzone end, max
   #define JOY_Y_LIMITS { 5600, 8250-100, 8250+100, 11000 }
   #define JOY_Z_LIMITS { 4800, 8080-100, 8080+100, 11550 }

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3514,14 +3514,6 @@
   //#define SERVICE_INTERVAL_3    1 // print hours
 #endif
 
-// @section homing
-/**
- * Turn off probe z sanity checks
- * If you are using a CNC and you get Probe::probe_down_to_z SLOW Probe fail! errors,
- * setting this value to false will prevent the error by disabling the probe sanity check.
- */
-//#define PROBE_SANITY_CHECK false
-
 // @section develop
 
 //

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3514,6 +3514,14 @@
   //#define SERVICE_INTERVAL_3    1 // print hours
 #endif
 
+// @section homing
+/**
+ * Turn off probe z sanity checks
+ * If you are using a CNC and you get Probe::probe_down_to_z SLOW Probe fail! errors,
+ * setting this value to false will prevent the error by disabling the probe sanity check.
+ */
+//#define PROBE_SANITY_CHECK false
+
 // @section develop
 
 //

--- a/Marlin/src/feature/joystick.h
+++ b/Marlin/src/feature/joystick.h
@@ -30,8 +30,6 @@
 #include "../core/macros.h"
 #include "../module/temperature.h"
 
-
-
 class Joystick {
   friend class Temperature;
   private:

--- a/Marlin/src/feature/joystick.h
+++ b/Marlin/src/feature/joystick.h
@@ -30,7 +30,7 @@
 #include "../core/macros.h"
 #include "../module/temperature.h"
 
-//#define JOYSTICK_DEBUG
+
 
 class Joystick {
   friend class Temperature;

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -29,6 +29,11 @@
 
 #include "motion.h"
 
+// check and define probe sanity check
+#ifndef PROBE_SANITY_CHECK
+  #define PROBE_SANITY_CHECK true
+#endif
+
 #if HAS_BED_PROBE
   enum ProbePtRaise : uint8_t {
     PROBE_PT_NONE,      // No raise or stow after run_z_probe
@@ -91,8 +96,8 @@ public:
         move_z_after_probing();
       #endif
     }
-    static float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true);
-    static inline float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true) {
+    static float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=PROBE_SANITY_CHECK);
+    static inline float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=PROBE_SANITY_CHECK) {
       return probe_at_point(pos.x, pos.y, raise_after, verbose_level, probe_relative, sanity_check);
     }
 
@@ -220,7 +225,7 @@ public:
 private:
   static bool probe_down_to_z(const float z, const feedRate_t fr_mm_s);
   static void do_z_raise(const float z_raise);
-  static float run_z_probe(const bool sanity_check=true);
+  static float run_z_probe(const bool sanity_check=PROBE_SANITY_CHECK);
 };
 
 extern Probe probe;

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -29,11 +29,6 @@
 
 #include "motion.h"
 
-// check and define probe sanity check
-#ifndef PROBE_SANITY_CHECK
-  #define PROBE_SANITY_CHECK true
-#endif
-
 #if HAS_BED_PROBE
   enum ProbePtRaise : uint8_t {
     PROBE_PT_NONE,      // No raise or stow after run_z_probe
@@ -96,8 +91,8 @@ public:
         move_z_after_probing();
       #endif
     }
-    static float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=PROBE_SANITY_CHECK);
-    static inline float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=PROBE_SANITY_CHECK) {
+    static float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true);
+    static inline float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true) {
       return probe_at_point(pos.x, pos.y, raise_after, verbose_level, probe_relative, sanity_check);
     }
 
@@ -225,7 +220,7 @@ public:
 private:
   static bool probe_down_to_z(const float z, const feedRate_t fr_mm_s);
   static void do_z_raise(const float z_raise);
-  static float run_z_probe(const bool sanity_check=PROBE_SANITY_CHECK);
+  static float run_z_probe(const bool sanity_check=true);
 };
 
 extern Probe probe;


### PR DESCRIPTION
This is my first ever pull request for anything on github, please let me know what I need to change.

### Description

While setting up joystick jogging, I was unable to find #define JOYSTICK_DEBUG, which was in joystick.h.  It should just be in Configuration_adv.h with the other joystick settings.

### Benefits

Consolidate joystick configuration into one place.
