### PR TITLE
TOUCH_UI: Add "Not all points probed" warning to Bed Mesh Screen.

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
@@ -145,6 +145,7 @@ namespace Language_en {
   PROGMEM Language_Str MSG_TOUCH_CALIBRATION_PROMPT = u8"Touch the dots to calibrate";
   PROGMEM Language_Str MSG_AUTOLEVEL_X_AXIS         = u8"Level X Axis";
   PROGMEM Language_Str MSG_BED_MAPPING_DONE         = u8"Bed mapping finished";
+  PROGMEM Language_Str MSG_BED_MAPPING_INCOMPLETE   = u8"Not all points probed";
   PROGMEM Language_Str MSG_LEVELING                 = u8"Leveling";
   PROGMEM Language_Str MSG_SHOW_MESH                = u8"Show Bed Mesh";
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
@@ -223,7 +223,7 @@ bool BedMeshScreen::tagToPoint(uint8_t tag, uint8_t &x, uint8_t &y) {
 void BedMeshScreen::onEntry() {
   screen_data.BedMeshScreen.highlightedTag = 0;
   screen_data.BedMeshScreen.count = GRID_MAX_POINTS;
-  screen_data.BedMeshScreen.showMappingDone = false;
+  screen_data.BedMeshScreen.message = screen_data.BedMeshScreen.MSG_NONE;
   BaseScreen::onEntry();
 }
 
@@ -253,8 +253,10 @@ void BedMeshScreen::drawHighlightedPointValue() {
      .tag(1).button( OKAY_POS, GET_TEXT_F(MSG_BUTTON_OKAY))
      .tag(0);
 
-  if (screen_data.BedMeshScreen.showMappingDone) {
-    cmd.text(MESSAGE_POS, GET_TEXT_F(MSG_BED_MAPPING_DONE));
+  switch(screen_data.BedMeshScreen.message) {
+    case screen_data.BedMeshScreen.MSG_MESH_COMPLETE:   cmd.text(MESSAGE_POS, GET_TEXT_F(MSG_BED_MAPPING_DONE)); break;
+    case screen_data.BedMeshScreen.MSG_MESH_INCOMPLETE: cmd.text(MESSAGE_POS, GET_TEXT_F(MSG_BED_MAPPING_INCOMPLETE)); break;
+    default: break;
   }
 }
 
@@ -307,15 +309,30 @@ void BedMeshScreen::onMeshUpdate(const int8_t, const int8_t, const float) {
     onRefresh();
 }
 
+bool BedMeshScreen::isMeshComplete(ExtUI::bed_mesh_t data) {
+  for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
+    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
+      if (isnan(data[x][y])) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 void BedMeshScreen::onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t state) {
   switch(state) {
     case ExtUI::MESH_START:
       screen_data.BedMeshScreen.count = 0;
-      screen_data.BedMeshScreen.showMappingDone = false;
+      screen_data.BedMeshScreen.message = screen_data.BedMeshScreen.MSG_NONE;
       break;
     case ExtUI::MESH_FINISH:
+      if(screen_data.BedMeshScreen.count == GRID_MAX_POINTS && isMeshComplete(ExtUI::getMeshArray())) {
+        screen_data.BedMeshScreen.message = screen_data.BedMeshScreen.MSG_MESH_COMPLETE;
+      } else {
+        screen_data.BedMeshScreen.message = screen_data.BedMeshScreen.MSG_MESH_INCOMPLETE;
+      }
       screen_data.BedMeshScreen.count = GRID_MAX_POINTS;
-      screen_data.BedMeshScreen.showMappingDone = true;
       break;
     case ExtUI::PROBE_START:
       screen_data.BedMeshScreen.highlightedTag = pointToTag(x, y);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screen_data.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screen_data.h
@@ -62,7 +62,11 @@ union screen_data_t {
   } MoveAxisScreen;
 #if HAS_MESH
   struct {
-    bool    showMappingDone;
+    enum : uint8_t {
+        MSG_NONE,
+        MSG_MESH_COMPLETE,
+        MSG_MESH_INCOMPLETE
+    } message;
     uint8_t count;
     uint8_t highlightedTag;
   } BedMeshScreen;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
@@ -533,6 +533,7 @@ class StepsScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEP
       static float getHightlightedValue();
       static void drawHighlightedPointValue();
       static void drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max = 0.1);
+      static bool isMeshComplete(ExtUI::bed_mesh_t data);
 
     public:
       static void onMeshUpdate(const int8_t x, const int8_t y, const float val);


### PR DESCRIPTION
- Modified the Mesh Bed Leveling screen so that a warning is shown if not all points were probed.