### PR TITLE
Fix MKS UI SPI flash typo

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/SPIFlashStorage.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/SPIFlashStorage.cpp
@@ -221,7 +221,7 @@ void SPIFlashStorage::flushPage() {
   #if HAS_SPI_FLASH_COMPRESSION
     // Restart the compressed buffer, keep the pointers of the uncompressed buffer
     m_compressedDataUsed = 0;
-  #elif
+  #else
     m_pageDataUsed = 0;
   #endif
   m_currentPage++;


### PR DESCRIPTION
### Description

It wasn't breaking because the else was never taken, but its a typo and it was reported in #19407.

### Related Issues

#19407.
