### PR TITLE
Update stale issue message and parameters

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -20,8 +20,8 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue has had no activity in the last 30 days. Please add a comment if you are still impacted by this issue or are working on a patch. This issue will be automatically closed if no comments are added within 7 days.'
+        stale-issue-message: 'This issue has had no activity in the last 30 days. Please add a reply if you want to keep this issue active, otherwise it will be automatically closed within 7 days.'
         days-before-stale: 30
         days-before-close: 7
         stale-issue-label: 'stale-closing-soon'
-        exempt-issue-labels: 'T: Feature Request,Bug: Confirmed !,no-locking'
+        exempt-issue-labels: 'T: Feature Request,Bug: Confirmed !'

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -24,4 +24,4 @@ jobs:
         days-before-stale: 30
         days-before-close: 7
         stale-issue-label: 'stale-closing-soon'
-        exempt-issue-labels: 'T: Feature Request,Bug: Confirmed !'
+        exempt-issue-labels: 'T: Feature Request'

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -20,8 +20,8 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label / comment or this will be closed in 5 days.'
+        stale-issue-message: 'This issue has had no activity in the last 30 days. Please add a comment if you are still impacted by this issue or are working on a patch. This issue will be automatically closed if no comments are added within 7 days.'
         days-before-stale: 30
-        days-before-close: 5
+        days-before-close: 7
         stale-issue-label: 'stale-closing-soon'
-        exempt-issue-labels: 'T: Feature Request'
+        exempt-issue-labels: 'T: Feature Request,Bug: Confirmed !,no-locking'


### PR DESCRIPTION
### Description

It seems that people are ignoring the stale message warning, then act surprised when the issue is closed. These changes attempt to improve this by the following:

1. Reword the message to make it more obvious what they are expected to do.
2. Increase the grace period to 7 days, since some people may only be available on weekends, etc.
3. Add additional tags which will prevent the issue from becoming stale.
   - **Bug: Confirmed !** : 19 open issues
   - **no-locking** : 4 open issues

### Benefits

I hope to reduce instances where issues are closed by the stale-bot, then have to be re-opened shortly thereafter.

### Configurations

N/A

### Related Issues

N/A
