### PR TITLE
Fix Assisted Tramming with Multi Hotends

### DIFF
--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -29,6 +29,10 @@
 #include "../../module/probe.h"
 #include "../../feature/bedlevel/bedlevel.h"
 
+#if HAS_MULTI_HOTEND
+  #include "../../module/tool_change.h"
+#endif
+
 #define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
 #include "../../core/debug_out.h"
 


### PR DESCRIPTION
### Requirements

`ASSISTED_TRAMMING`, bed probe

### Description

Allow `G35`/Assisted Tramming to work with multiple hotends. Fix originally posted by @ellensp.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/19402, https://github.com/MarlinFirmware/Marlin/issues/19252