### PR TITLE
Definition for SoftSPI::softSPI MAX6675 

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1563,6 +1563,7 @@ void Temperature::updateTemperaturesFromRawValues() {
 }
 
 #if MAX6675_SEPARATE_SPI
+  template<uint8_t MisoPin, uint8_t MosiPin, uint8_t SckPin> SoftSPI<MisoPin, MosiPin, SckPin> SPIclass<MisoPin, MosiPin, SckPin>::softSPI;
   SPIclass<MAX6675_DO_PIN, MOSI_PIN, MAX6675_SCK_PIN> max6675_spi;
 #endif
 


### PR DESCRIPTION
### Description

It maybe Fix #19417 .... 

But, as it's look like a clear C++ error (static variable without definition), I'm making this PR Ready for Review and Merge.

I think no one ever used MAX6675 with DO/MISO pin.... 

### Related Issues

#19417
