### PR TITLE
Fix AXIS_CAN_CALIBRATE compiler error with COREXY

### DIFF
--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -56,7 +56,7 @@ void GcodeSuite::M425() {
   };
 
   LOOP_XYZ(a) {
-    if (AXIS_CAN_CALIBRATE(a) && parser.seen(XYZ_CHAR(a))) {
+    if (axis_can_calibrate(a) && parser.seen(XYZ_CHAR(a))) {
       planner.synchronize();
       backlash.distance_mm[a] = parser.has_value() ? parser.value_linear_units() : backlash.get_measurement(AxisEnum(a));
       noArgs = false;

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -162,7 +162,10 @@
     #define X_AXIS_INDEX 0
     #define Y_AXIS_INDEX 1
     #define Z_AXIS_INDEX 2
-    #define CAN_CALIBRATE(A,B) (A##_AXIS_INDEX == B##_INDEX)
+    #define A_AXIS_INDEX 0
+    #define B_AXIS_INDEX 1
+    #define C_AXIS_INDEX 2
+    #define CAN_CALIBRATE(A,B) (A##_AXIS_INDEX == B)
   #else
     #define CAN_CALIBRATE(A,B) 1
   #endif

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -159,13 +159,7 @@
 // Calibration codes only for non-core axes
 #if EITHER(BACKLASH_GCODE, CALIBRATION_GCODE)
   #if EITHER(IS_CORE, MARKFORGED_XY)
-    #define X_AXIS_INDEX 0
-    #define Y_AXIS_INDEX 1
-    #define Z_AXIS_INDEX 2
-    #define A_AXIS_INDEX 0
-    #define B_AXIS_INDEX 1
-    #define C_AXIS_INDEX 2
-    #define CAN_CALIBRATE(A,B) (A##_AXIS_INDEX == B)
+    #define CAN_CALIBRATE(A,B) (_AXIS(A) == B)
   #else
     #define CAN_CALIBRATE(A,B) 1
   #endif

--- a/Marlin/src/lcd/menu/menu_backlash.cpp
+++ b/Marlin/src/lcd/menu/menu_backlash.cpp
@@ -50,4 +50,4 @@ void menu_backlash() {
   END_MENU();
 }
 
-#endif // HAS_LCD_MENU && BACKLASH_COMPENSATION
+#endif // HAS_LCD_MENU && BACKLASH_GCODE


### PR DESCRIPTION
### Description

Fix compiler error with AXIS_CAN_CALIBRATE macro when using COREXY (or any other CORE* movement).

### Benefits

Allows calibration to be used on the axis not included in the CORE motion (e.g., the Z axis on a COREXY machine).

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
Configuration.h
 - #define COREXY
Configuration_adv.h
 - #define BACKLASH_COMPENSATION
 - #define BACKLASH_GCODE

### Related Issues

[BUG] CALIBRATION_GCODE compile unsuccessful #19092
