### PR TITLE
Fix case light brightness save/load

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -138,7 +138,7 @@
   void M710_report(const bool forReplay);
 #endif
 
-#if ENABLED(CASE_LIGHT_MENU) && DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
+#if ENABLED(CASE_LIGHT_ENABLE) && DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
   #include "../feature/caselight.h"
   #define HAS_CASE_LIGHT_BRIGHTNESS 1
 #endif


### PR DESCRIPTION
### Description

Previously the case light brightness was only stored if there was an UltraLCD case light menu. However, there are other ways for a user to adjust the case light, even when not using UltraLCD. With this PR:

- A user can use M355 to adjust the case light
- A user can use an ExtUI to adjust case light
