### PR TITLE
Fix missing SPI pins in Ultratronics Pro

### DIFF
--- a/Marlin/src/pins/sam/pins_ULTRATRONICS_PRO.h
+++ b/Marlin/src/pins/sam/pins_ULTRATRONICS_PRO.h
@@ -23,6 +23,7 @@
 
 /**
  * ReprapWorld ULTRATRONICS v1.0
+ * https://reprapworld.com/documentation/datasheet_ultratronics10_05.pdf
  */
 
 #ifndef ARDUINO_ARCH_SAM
@@ -145,6 +146,10 @@
 #define SPI_EEPROM1_CS                        -1
 #define SPI_EEPROM2_CS                        -1
 #define SPI_FLASH_CS                          -1
+
+#define SCK_PIN                               76
+#define MISO_PIN                              74
+#define MOSI_PIN                              75
 
 // SPI for Max6675 or Max31855 Thermocouple
 #define MAX6675_SS_PIN                        65


### PR DESCRIPTION
### Requirements

BOARD_ULTRATRONICS_PRO
SDSUPPORT

### Description

SDSUPPORT doesn't work as SPI pins are not defined 

### Benefits

SDSUPPORT works as expected

### Related Issues

Issue #19352
