### PR TITLE
check for tmc2209 slave address conflicts when on same serial port.

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2420,19 +2420,19 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
   #error "TMC2209 X and Z are on the same serial port, this requires unique driver slave address."
 #endif
 #if UNIQUE_SLAVE_ADDRESS(E0,X)
-  #error "TMC2209 E0 and Y are on the same serial port, this requires unique driver slave address."
+  #error "TMC2209 E0 and X are on the same serial port, this requires unique driver slave address."
 #endif
 #if UNIQUE_SLAVE_ADDRESS(E0,Y)
-  #error "TMC2209 E0 and Z are on the same serial port, this requires unique driver slave address."
+  #error "TMC2209 E0 and Y are on the same serial port, this requires unique driver slave address."
 #endif
 #if UNIQUE_SLAVE_ADDRESS(E0,Z)
   #error "TMC2209 E0 and Z are on the same serial port, this requires unique driver slave address."
 #endif
 #if UNIQUE_SLAVE_ADDRESS(E1,X)
-  #error "TMC2209 E1 and Y are on the same serial port, this requires unique driver slave address."
+  #error "TMC2209 E1 and X are on the same serial port, this requires unique driver slave address."
 #endif
 #if UNIQUE_SLAVE_ADDRESS(E1,Y)
-  #error "TMC2209 E1 and Z are on the same serial port, this requires unique driver slave address."
+  #error "TMC2209 E1 and Y are on the same serial port, this requires unique driver slave address."
 #endif
 #if UNIQUE_SLAVE_ADDRESS(E1,Z)
   #error "TMC2209 E1 and Z are on the same serial port, this requires unique driver slave address."

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2406,6 +2406,42 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #endif
 #undef INVALID_TMC_ADDRESS
 
+/**
+ * TMC2209 slave address conflicts with shared UARTS
+ */
+#define UNIQUE_SLAVE_ADDRESS(A,B) ((AXIS_DRIVER_TYPE_##A(TMC2209) && AXIS_DRIVER_TYPE_##B(TMC2209)) && (A##_SERIAL_TX_PIN == B##_SERIAL_TX_PIN) && (A##_SLAVE_ADDRESS == B##_SLAVE_ADDRESS)) 
+#if UNIQUE_SLAVE_ADDRESS(X,Y)
+  #error "TMC2209 X and Y are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(Y,Z)
+  #error "TMC2209 Y and Z are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(X,Z)
+  #error "TMC2209 X and Z are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(E0,X)
+  #error "TMC2209 E0 and Y are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(E0,Y)
+  #error "TMC2209 E0 and Z are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(E0,Z)
+  #error "TMC2209 E0 and Z are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(E1,X)
+  #error "TMC2209 E1 and Y are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(E1,Y)
+  #error "TMC2209 E1 and Z are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(E1,Z)
+  #error "TMC2209 E1 and Z are on the same serial port, this requires unique driver slave address."
+#endif
+#if UNIQUE_SLAVE_ADDRESS(E1,E0)
+  #error "TMC2209 E1 and E0 are on the same serial port, this requires unique driver slave address."
+#endif
+#undef UNIQUE_SLAVE_ADDRESS
+
 #define _TMC_MICROSTEP_IS_VALID(MS) (MS == 0 || MS == 2 || MS == 4 || MS == 8 || MS == 16 || MS == 32 || MS == 64 || MS == 128 || MS == 256)
 #define TMC_MICROSTEP_IS_VALID(M) (!AXIS_IS_TMC(M) || _TMC_MICROSTEP_IS_VALID(M##_MICROSTEPS))
 #define INVALID_TMC_MS(ST) static_assert(0, "Invalid " STRINGIFY(ST) "_MICROSTEPS. Valid values are 0, 2, 4, 8, 16, 32, 64, 128, and 256.")


### PR DESCRIPTION
### Requirements

A number of TMC2209 stepper drivers

### Description

The TMC2209 can be connected to UART's in a number of ways.
One way is for them to use the same UART's but this requires that each TMC2209 is setup with a unique slave address.
This catches when a user sets up shared UART's but doesn't set unique slave address

At this time I't is only comparing slaves addresses for the following combinations 
X != Y, Y != Z, X != Z,  E0 != X, E0 != Y, E0 != Z, E1 != X, E1 != Y, E1 != Z and E1 != E0   
 (should this be extended to other axis?)  

### Benefits

Users don't get caught out with not setting slave addresses when the TMC2209 is sharing UART's

### Related Issues
Myself and other users have been caught by this, since there are no errors and even M122 says everything is fine.
 