### PR TITLE
Pins file fix for K8800 controller.

### DIFF
--- a/Marlin/src/pins/ramps/pins_K8800.h
+++ b/Marlin/src/pins/ramps/pins_K8800.h
@@ -40,7 +40,12 @@
 #define X_STOP_PIN                             3
 #define Y_STOP_PIN                            14
 #define Z_STOP_PIN                            66
-#define Z_MIN_PIN                             68  // Used for bed leveling
+
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                     68
+#endif
+
+#define FIL_RUNOUT_PIN                        69  // PK7
 
 //
 // Steppers
@@ -76,36 +81,42 @@
 //
 // Misc. Functions
 //
-#define SDSS                                  25
-
-#define FIL_RUNOUT_PIN                        69  // PK7
 #define KILL_PIN                              20  // PD1
-
 #define CASE_LIGHT_PIN                         7
+
+//
+// SD Card
+//
+#define SDSS                                  25
+#define SD_DETECT_PIN                         21  // PD0
 
 //
 // LCD / Controller
 //
-#define SD_DETECT_PIN                         21  // PD0
-#define LCD_SDSS                              53
 #define BEEPER_PIN                             6
 
-#define DOGLCD_CS                             29
-#define DOGLCD_A0                             27
+#if HAS_SPI_LCD
 
-#define LCD_PINS_RS                           27
-#define LCD_PINS_ENABLE                       29
-#define LCD_PINS_D4                           37
-#define LCD_PINS_D5                           35
-#define LCD_PINS_D6                           33
-#define LCD_PINS_D7                           31
+  #define LCD_SDSS                            53
 
-#define LCD_CONTRAST_MIN                       0
-#define LCD_CONTRAST_MAX                     100
-#define DEFAULT_LCD_CONTRAST                  30
+  #define DOGLCD_CS                           29
+  #define DOGLCD_A0                           27
 
-#if ENABLED(NEWPANEL)
-  #define BTN_EN1                             17
-  #define BTN_EN2                             16
-  #define BTN_ENC                             23
-#endif
+  #define LCD_PINS_RS                         27
+  #define LCD_PINS_ENABLE                     29
+  #define LCD_PINS_D4                         37
+  #define LCD_PINS_D5                         35
+  #define LCD_PINS_D6                         33
+  #define LCD_PINS_D7                         31
+
+  #define LCD_CONTRAST_MIN                     0
+  #define LCD_CONTRAST_MAX                   100
+  #define DEFAULT_LCD_CONTRAST                30
+
+  #if ENABLED(NEWPANEL)
+    #define BTN_EN1                           17
+    #define BTN_EN2                           16
+    #define BTN_ENC                           23
+  #endif
+
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/ramps/pins_K8800.h
+++ b/Marlin/src/pins/ramps/pins_K8800.h
@@ -39,8 +39,8 @@
 //
 #define X_STOP_PIN                             3
 #define Y_STOP_PIN                            14
+#define Z_STOP_PIN                            66
 #define Z_MIN_PIN                             68  // Used for bed leveling
-#define Z_MAX_PIN                             66
 
 //
 // Steppers
@@ -60,10 +60,6 @@
 #define E0_STEP_PIN                           26
 #define E0_DIR_PIN                            28
 #define E0_ENABLE_PIN                         24
-
-#define E1_STEP_PIN                           32
-#define E1_DIR_PIN                            34
-#define E1_ENABLE_PIN                         30
 
 //
 // Temperature Sensors
@@ -85,6 +81,8 @@
 #define FIL_RUNOUT_PIN                        69  // PK7
 #define KILL_PIN                              20  // PD1
 
+#define CASE_LIGHT_PIN                         7
+
 //
 // LCD / Controller
 //
@@ -101,6 +99,10 @@
 #define LCD_PINS_D5                           35
 #define LCD_PINS_D6                           33
 #define LCD_PINS_D7                           31
+
+#define LCD_CONTRAST_MIN                       0
+#define LCD_CONTRAST_MAX                     100
+#define DEFAULT_LCD_CONTRAST                  30
 
 #if ENABLED(NEWPANEL)
   #define BTN_EN1                             17


### PR DESCRIPTION
### Description

During config migration to Marlin 2.0.x I've noticed that the pins file is incomplete for the Vertex Delta printer (missing case light pin). This fixes that issue and adds the proper LCD contrast values for the builtin LCD.
I've taken the liberty of cleaning the file up a little and removing the second extruder config which the printer does not have. The pins defined for it are on the expansion header according to [the schematic](https://www.velleman.eu/downloads/files/vertex-delta/schematics/K8800-schematic-V1.4.pdf).

### Benefits

Proper pins config in base repository.

### Configurations

Not applicable

### Related Issues

Didn't create any issues for it.
