### PR TITLE
Fixes  #18133 LCD contrast corruption after M504 

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1804,13 +1804,11 @@ void MarlinSettings::postprocess() {
       //
       {
         _FIELD_TEST(lcd_contrast);
-        #if HAS_LCD_CONTRAST
-          int16_t &lcd_contrast = ui.contrast;
-        #else
-          int16_t lcd_contrast;
-        #endif
+        int16_t lcd_contrast;
         EEPROM_READ(lcd_contrast);
-        TERN_(HAS_LCD_CONTRAST, ui.set_contrast(lcd_contrast));
+        if (!validating) {
+          TERN_(HAS_LCD_CONTRAST, ui.set_contrast(lcd_contrast));
+        }
       }
 
       //

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1804,8 +1804,11 @@ void MarlinSettings::postprocess() {
       //
       {
         _FIELD_TEST(lcd_contrast);
-
-        int16_t lcd_contrast;
+        #if HAS_LCD_CONTRAST
+          int16_t &lcd_contrast = ui.contrast;
+        #else
+          int16_t lcd_contrast;
+        #endif
         EEPROM_READ(lcd_contrast);
         TERN_(HAS_LCD_CONTRAST, ui.set_contrast(lcd_contrast));
       }


### PR DESCRIPTION
### Requirements

A LCD that has eeprom settable contrast

### Description

It was found that M504 was corrupting the contrast value. 
A simple test was devised using these gcodes.  M250, take note of the value, M504, M250 value has incorrectly changed. 

### Benefits

LCD contrast value no longer gets corrupted

### Configurations

See Issue #18133

### Related Issues
Issue #18133