### PR TITLE
Fix MKS Robin undefined pins error

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -143,6 +143,8 @@
   #define LCD_BACKLIGHT_PIN                 PG11
   #define FSMC_CS_PIN                       PG12  // NE4
   #define FSMC_RS_PIN                       PF0   // A0
+  #define TFT_CS_PIN                        FSMC_CS_PIN
+  #define TFT_RS_PIN                        FSMC_RS_PIN
 
   #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
   #define FSMC_DMA_DEV                      DMA2

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -126,12 +126,7 @@
 #endif
 #define LED_PIN                             PB2
 
-#ifdef HAS_GRAPHICAL_TFT
-  #define TFT_RESET_PIN                     PF6
-  #define TFT_BACKLIGHT_PIN                 PG11
-  #define TFT_CS_PIN                        PG12  // NE4
-  #define TFT_RS_PIN                        PF0   // A0
-#else
+#ifdef HAS_FSMC_TFT
   /**
    * Note: MKS Robin TFT screens use various TFT controllers
    * Supported screens are based on the ILI9341, ST7789V and ILI9328 (320x240)
@@ -152,6 +147,11 @@
   #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
   #define FSMC_DMA_DEV                      DMA2
   #define FSMC_DMA_CHANNEL               DMA_CH5
+#elif HAS_GRAPHICAL_TFT
+  #define TFT_RESET_PIN                     PF6
+  #define TFT_BACKLIGHT_PIN                 PG11
+  #define TFT_CS_PIN                        PG12  // NE4
+  #define TFT_RS_PIN                        PF0   // A0
 #endif
 
 #if NEED_TOUCH_PINS

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -126,7 +126,7 @@
 #endif
 #define LED_PIN                             PB2
 
-#ifdef HAS_FSMC_TFT
+#if HAS_FSMC_TFT
   /**
    * Note: MKS Robin TFT screens use various TFT controllers
    * Supported screens are based on the ILI9341, ST7789V and ILI9328 (320x240)


### PR DESCRIPTION
### Requirements

Example mks Robin config files from Configurations.

### Description

Errors with error: 'FSMC_CS_PIN' was not declared in this scope
Rearranged pins_MKS_ROBIN.h so that FSMC_CS_PIN is defined if HAS_FSMC_TFT is set.

### Benefits

Compiles as expected.

### Configurations

https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Mks/Robin

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/19501
Just noticed https://github.com/MarlinFirmware/Marlin/pull/19333  but its been sitting for 15 days...