### PR TITLE
Corrected the comments on the thermistor input pins for the SKR 1.4

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -153,8 +153,8 @@
   #define E1_CS_PIN                        P1_01
 #endif
 
-#define TEMP_1_PIN                      P0_23_A0  // A2 (T2) - (69) - TEMP_1_PIN
-#define TEMP_BED_PIN                    P0_25_A2  // A0 (T0) - (67) - TEMP_BED_PIN
+#define TEMP_1_PIN                      P0_23_A0  // A0 (T0) - (67) - TEMP_1_PIN
+#define TEMP_BED_PIN                    P0_25_A2  // A2 (T2) - (69) - TEMP_BED_PIN
 
 //
 // Software SPI pins for TMC2130 stepper drivers


### PR DESCRIPTION
### Requirements

### Description

Comments on the thermistor pins for the SKR 1.4 board were incorrect. Most likely an inheritance from the earlier revision boards. This flips and corrects them.

### Benefits

Thermistors now have correct comments.

### Configurations

N/A
### Related Issues

N/A