### PR TITLE
Follow up for LVGL PR 19442

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.h
@@ -21,10 +21,6 @@
  */
 #pragma once
 
-#ifdef __cplusplus
-  extern "C" { /* C-declarations for C++ */
-#endif
-
 #include <lvgl.h>
 
 #include <stdint.h>
@@ -167,6 +163,10 @@
   #define TFT_HEIGHT    240
 
 #endif // ifdef TFT35
+
+#ifdef __cplusplus
+  extern "C" { /* C-declarations for C++ */
+#endif
 
 extern char public_buf_m[100];
 extern char public_buf_l[30];

--- a/Marlin/src/lcd/extui/lib/mks_ui/pic_manager.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/pic_manager.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#include "../../../../inc/MarlinConfigPre.h"
+#include "../../../../inc/MarlinConfig.h"
 
 #include "../../../../libs/W25Qxx.h"
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
@@ -408,7 +408,9 @@ void SysTick_Callback() {
       OUT_WRITE(LCD_BACKLIGHT_PIN, LOW);
       LCD_Clear(0x0000);
 
-      lcd_draw_logo();
+      #if HAS_LOGO_IN_FLASH
+        lcd_draw_logo();
+      #endif
 
       OUT_WRITE(LCD_BACKLIGHT_PIN, HIGH);
       delay(2000);
@@ -724,6 +726,7 @@ lv_fs_res_t sd_open_cb (lv_fs_drv_t * drv, void * file_p, const char * path, lv_
   if (temp) { strcpy(temp,".GCO"); }
   sd_read_base_addr = lv_open_gcode_file((char *)name_buf);
   sd_read_addr_offset = sd_read_base_addr;
+  if (sd_read_addr_offset == 0) return LV_FS_RES_NOT_EX;
   return LV_FS_RES_OK;
 }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
@@ -408,9 +408,7 @@ void SysTick_Callback() {
       OUT_WRITE(LCD_BACKLIGHT_PIN, LOW);
       LCD_Clear(0x0000);
 
-      #if HAS_LOGO_IN_FLASH
-        lcd_draw_logo();
-      #endif
+      TERN_(HAS_LOGO_IN_FLASH, lcd_draw_logo());
 
       OUT_WRITE(LCD_BACKLIGHT_PIN, HIGH);
       delay(2000);


### PR DESCRIPTION
### Description

This include the fixes:

 - Freeze when fail to open a gcode preview file
 - User right header to avoid macro redefinition and keep the correct macro values
 - Don't try to draw the logo if it's disabled 

### Benefits

Fixes LVGL issues

### Related Issues

#19442 
