### PR TITLE
Fix Allen key probe build

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -270,7 +270,11 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
   #if ENABLED(PAUSE_BEFORE_DEPLOY_STOW)
     do {
       #if ENABLED(PAUSE_PROBE_DEPLOY_WHEN_TRIGGERED)
-        if (deploy == (READ(Z_MIN_PROBE_PIN) == Z_MIN_PROBE_ENDSTOP_INVERTING)) break;
+        #if HAS_CUSTOM_PROBE_PIN
+          if (deploy == (READ(Z_MIN_PROBE_PIN) == Z_MIN_PROBE_ENDSTOP_INVERTING)) break;
+        #else
+          if (deploy == (READ(Z_MIN_PIN) == Z_MIN_ENDSTOP_INVERTING)) break;
+        #endif
       #endif
 
       BUZZ(100, 659);

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -270,11 +270,13 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
   #if ENABLED(PAUSE_BEFORE_DEPLOY_STOW)
     do {
       #if ENABLED(PAUSE_PROBE_DEPLOY_WHEN_TRIGGERED)
-        #if HAS_CUSTOM_PROBE_PIN
-          if (deploy == (READ(Z_MIN_PROBE_PIN) == Z_MIN_PROBE_ENDSTOP_INVERTING)) break;
-        #else
-          if (deploy == (READ(Z_MIN_PIN) == Z_MIN_ENDSTOP_INVERTING)) break;
-        #endif
+        if (deploy == (
+          #if HAS_CUSTOM_PROBE_PIN
+            READ(Z_MIN_PROBE_PIN) == Z_MIN_PROBE_ENDSTOP_INVERTING
+          #else
+            READ(Z_MIN_PIN) == Z_MIN_ENDSTOP_INVERTING
+          #endif
+        )) break;
       #endif
 
       BUZZ(100, 659);


### PR DESCRIPTION
Fix Allen key probe build

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Compilation would fail because Z_MIN_PROBE_PIN is unset for Allen key probe on Z endstop pin. To reproduce the issue define
Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
FIX_MOUNTED_PROBE
PAUSE_BEFORE_DEPLOY_STOW
PAUSE_PROBE_DEPLOY_WHEN_TRIGGERED
