### PR TITLE
init max endstop pins if corresponding flag USE_MAX is enabled

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -61,6 +61,9 @@
     #define X_MIN_PIN                      P1_26  // E0DET
   #endif
 #else
+  #ifdef USE_XMAX_PLUG
+    #define X_MAX_PIN                      P1_26  // E0DET
+  #endif
   #define X_STOP_PIN                       P1_29  // X-STOP
 #endif
 
@@ -73,6 +76,9 @@
   #endif
 #else
   #define Y_STOP_PIN                       P1_28  // Y-STOP
+  #ifdef USE_YMAX_PLUG
+    #define Y_MAX_PIN                      P1_25  // E1DET
+  #endif
 #endif
 
 #ifdef Z_STALL_SENSITIVITY
@@ -83,6 +89,9 @@
     #define Z_MIN_PIN                      P1_00  // PWRDET
   #endif
 #else
+  #ifdef USE_ZMAX_PLUG
+    #define Z_MAX_PIN                      P1_00  // PWRDET
+  #endif
   #ifndef Z_STOP_PIN
     #define Z_STOP_PIN                     P1_27  // Z-STOP
   #endif


### PR DESCRIPTION


### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Added init max endstops for scenario when user wants to use `USE_XMAX_PLUG`, `USE_YMAX_PLUG` or `USE_ZMAX_PLUG` and doesn't have `SENSORLESS_HOMING` enabled (ie `STALL_SENSITIVITY` is undefined).

### Benefits

The use case is dual Z motors which require usage of one of those MAX plugs for the second Z_MIN endstop. If neither of MAX_PIN parameters defined compilation fails with a simiilar error

```
#error "Z2_USE_ENDSTOP has been assigned to a nonexistent endstop!"
```

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

Here is the related parameters
#### Configuration_adv.h
```c
// #define SENSORLESS_HOMING // StallGuard capable drivers only
...
#define NUM_Z_STEPPER_DRIVERS 2
....
#define Z2_USE_ENDSTOP          _YMAX_
```

#### Configuration.h
```c
#define USE_YMAX_PLUG
```

### Related Issues

I didn't see any related open issues.
