### PR TITLE
Fix, improve Power-Loss Recovery

### DIFF
--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -107,6 +107,12 @@ typedef struct {
   // Job elapsed time
   millis_t print_job_elapsed;
 
+  // Misc. Marlin flags
+  struct {
+    bool dryrun:1;                // M111 S8
+    bool allow_cold_extrusion:1;  // M302 P1
+  } flag;
+
   uint8_t valid_foot;
 
   bool valid() { return valid_head && valid_head == valid_foot; }
@@ -173,7 +179,10 @@ class PrintJobRecovery {
       }
     #endif
 
-    static inline bool valid() { return info.valid(); }
+    // The referenced file exists
+    static inline bool interrupted_file_exists() { return card.fileExists(info.sd_filename); }
+
+    static inline bool valid() { return info.valid() && interrupted_file_exists(); }
 
     #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
       static void debug(PGM_P const prefix);

--- a/Marlin/src/gcode/feature/powerloss/M1000.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M1000.cpp
@@ -62,6 +62,8 @@ void GcodeSuite::M1000() {
     if (parser.seen('S')) {
       #if HAS_LCD_MENU
         ui.goto_screen(menu_job_recovery);
+      #elif ENABLED(DWIN_CREALITY_LCD)
+        recovery.dwin_flag = true;
       #elif ENABLED(EXTENSIBLE_UI)
         ExtUI::onPowerLossResume();
       #else

--- a/Marlin/src/gcode/feature/powerloss/M413.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M413.cpp
@@ -50,6 +50,7 @@ void GcodeSuite::M413() {
     if (parser.seen("RL")) recovery.load();
     if (parser.seen('W')) recovery.save(true);
     if (parser.seen('P')) recovery.purge();
+    if (parser.seen('D')) recovery.debug(PSTR("M413"));
     #if PIN_EXISTS(POWER_LOSS)
       if (parser.seen('O')) recovery._outage();
     #endif


### PR DESCRIPTION
- Whenever a file is resumed make sure to enable Power-Loss Recovery.
- Check for the existence of the interrupted file before re-starting.
- Set the Ender 3 V2 DWIN flag inside of `M1000S`.
- Save the dry-run and cold extrusion states for easier testing.
- Add more debug output, and `M413 D` to report the last-saved or last-loaded PLR info.
- Do homing on print resume in "dev mode" for updated beta testing.
