### PR TITLE
Fix Ender 3 V2 Power Loss Recovery

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -991,15 +991,15 @@ void Popup_Window_Resume() {
   if (HMI_IsChinese()) {
     DWIN_Frame_AreaCopy(1, 160, 338, 235, 354, 98, 135);
     DWIN_Frame_AreaCopy(1, 103, 321, 271, 335, 52, 192);
-    DWIN_ICON_Show(ICON, ICON_Continue_C, 26, 307);
-    DWIN_ICON_Show(ICON, ICON_Cancel_C, 146, 307);
+    DWIN_ICON_Show(ICON, ICON_Cancel_C,    26, 307);
+    DWIN_ICON_Show(ICON, ICON_Continue_C, 146, 307);
   }
   else {
     DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Window, (272 - 8 * 14) / 2, 115, F("Continue Print"));
     DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Window, (272 - 8 * 22) / 2, 192, F("It looks like the last"));
     DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Window, (272 - 8 * 22) / 2, 212, F("file was interrupted."));
-    DWIN_ICON_Show(ICON, ICON_Continue_E, 26, 307);
-    DWIN_ICON_Show(ICON, ICON_Cancel_E, 146, 307);
+    DWIN_ICON_Show(ICON, ICON_Cancel_E,    26, 307);
+    DWIN_ICON_Show(ICON, ICON_Continue_E, 146, 307);
   }
 }
 
@@ -3597,45 +3597,30 @@ void EachMomentUpdate() {
   #if ENABLED(POWER_LOSS_RECOVERY)
     else if (DWIN_lcd_sd_status && recovery.dwin_flag) { // resume print before power off
       static bool recovery_flag = false;
+
       recovery.dwin_flag = false;
-
-      recovery.load();
-      if (!recovery.valid()) return recovery.purge();
-
-      auto draw_first_option = [](const bool sel) {
-        const uint16_t c1 = sel ? Color_Bg_Window : Select_Color;
-        DWIN_Draw_Rectangle(0, c1, 25, 306, 126, 345);
-        DWIN_Draw_Rectangle(0, c1, 24, 305, 127, 346);
-      };
+      recovery_flag = true;
 
       auto update_selection = [&](const bool sel) {
         HMI_flag.select_flag = sel;
-        draw_first_option(sel);
+        const uint16_t c1 = sel ? Color_Bg_Window : Select_Color;
+        DWIN_Draw_Rectangle(0, c1, 25, 306, 126, 345);
+        DWIN_Draw_Rectangle(0, c1, 24, 305, 127, 346);
         const uint16_t c2 = sel ? Select_Color : Color_Bg_Window;
         DWIN_Draw_Rectangle(0, c2, 145, 306, 246, 345);
         DWIN_Draw_Rectangle(0, c2, 144, 305, 247, 346);
       };
 
-      const uint16_t fileCnt = card.get_num_Files();
-      for (uint16_t i = 0; i < fileCnt; i++) {
-        // TODO: Resume print via M1000 then update the UI
-        // with the active filename which can come from CardReader.
-        card.getfilename_sorted(SD_ORDER(i, fileCnt));
-        if (!strcmp(card.filename, &recovery.info.sd_filename[1])) { // Resume print before power failure while have the same file
-          recovery_flag = true;
-          HMI_flag.select_flag = true;
-          Popup_Window_Resume();
-          draw_first_option(false);
-          char * const name = card.longest_filename();
-          const int8_t npos = _MAX(0, DWIN_WIDTH - strlen(name) * (MENU_CHR_W)) / 2;
-          DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Window, npos, 252, name);
-          DWIN_UpdateLCD();
-          break;
-        }
-      }
+      Popup_Window_Resume();
+      update_selection(true);
 
-      // if hasn't resumable G-code file
-      if (!recovery_flag) return;
+      // TODO: Get the name of the current file from someplace
+      //
+      //(void)recovery.interrupted_file_exists();
+      char * const name = card.longest_filename();
+      const int8_t npos = _MAX(0U, DWIN_WIDTH - strlen(name) * (MENU_CHR_W)) / 2;
+      DWIN_Draw_String(false, true, font8x16, Popup_Text_Color, Color_Bg_Window, npos, 252, name);
+      DWIN_UpdateLCD();
 
       while (recovery_flag) {
         ENCODER_DiffState encoder_diffState = Encoder_ReceiveAnalyze();
@@ -3643,12 +3628,12 @@ void EachMomentUpdate() {
           if (encoder_diffState == ENCODER_DIFF_ENTER) {
             recovery_flag = false;
             if (HMI_flag.select_flag) break;
-            TERN_(POWER_LOSS_RECOVERY, recovery.cancel());
+            TERN_(POWER_LOSS_RECOVERY, queue.inject_P(PSTR("M1000C")));
             HMI_StartFrame(true);
             return;
           }
           else
-            update_selection(encoder_diffState == ENCODER_DIFF_CCW);
+            update_selection(encoder_diffState == ENCODER_DIFF_CW);
 
           DWIN_UpdateLCD();
         }
@@ -3656,9 +3641,9 @@ void EachMomentUpdate() {
 
       select_print.set(0);
       HMI_ValueStruct.show_mode = 0;
-      HMI_StartFrame(false);
-      recovery.resume();
-      return;
+      queue.inject_P(PSTR("M1000"));
+      Goto_PrintProcess();
+      Draw_Status_Area(true);
     }
   #endif
   DWIN_UpdateLCD();

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -628,11 +628,17 @@ void CardReader::openFileWrite(char * const path) {
 
 //
 // Check if a file exists by absolute or workDir-relative path
+// If the file exists, the long name can also be fetched.
 //
 bool CardReader::fileExists(const char * const path) {
   if (!isMounted()) return false;
   SdFile *diveDir = nullptr;
   const char * const fname = diveToFile(false, diveDir, path);
+  if (fname) {
+    diveDir->rewind();
+    selectByName(*diveDir, fname);
+    diveDir->close();
+  }
   return fname != nullptr;
 }
 


### PR DESCRIPTION
Ender 3 V2 user interface code is still a work-in-progress. This PR fixes issues with Power-Loss Recovery and brings it up to date with support for SD card sub-folders.

- Fix an issue where files in sub-folders were prevented from resuming.
- Set the long filename in response to `card.fileExists()` so the correct name displays on the "Resume" screen.
- Update the UI to put "Cancel" on the left, "Continue" on the right, with counter-clockwise selecting "Cancel."
- Re-draw the Status Area and go to the Printing Screen when a print is resumed.
- Add extra debugging to help diagnose future `diveToFile` issues.
- Use "M1000C" instead of `recovery.cancel()` to send a host notification, etc.

---
- A related issue was fixed in #19539 where `CardReader::diveToFile` would fail with an open dir object.
