### PR TITLE
Archim1 Platform.io windows fix.

### DIFF
--- a/Marlin/src/HAL/DUE/upload_extra_script.py
+++ b/Marlin/src/HAL/DUE/upload_extra_script.py
@@ -14,5 +14,5 @@ if current_OS == 'Windows':
 
 	# Use bossac.exe on Windows
 	env.Replace(
-	    UPLOADCMD="bossac --info --unlock --write --verify --reset --erase -U false --boot"
+	    UPLOADCMD="bossac --info --unlock --write --verify --reset --erase -U false --boot $SOURCE"
 	)


### PR DESCRIPTION
Adding this allows for a successful upload using a windows machine to an Archim1 board using Platform.io in VS Code.
