### PR TITLE
Fix Buzzer Init 

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1048,6 +1048,9 @@ void setup() {
   SERIAL_ECHO_MSG("Compiled: " __DATE__);
   SERIAL_ECHO_MSG(STR_FREE_MEMORY, freeMemory(), STR_PLANNER_BUFFER_BYTES, (int)sizeof(block_t) * (BLOCK_BUFFER_SIZE));
 
+  // Init buzzer pins
+  TERN_(USE_BEEPER, buzzer.init());
+
   // Set up LEDs early
   #if HAS_COLOR_LEDS
     SETUP_RUN(leds.setup());

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1048,8 +1048,10 @@ void setup() {
   SERIAL_ECHO_MSG("Compiled: " __DATE__);
   SERIAL_ECHO_MSG(STR_FREE_MEMORY, freeMemory(), STR_PLANNER_BUFFER_BYTES, (int)sizeof(block_t) * (BLOCK_BUFFER_SIZE));
 
-  // Init buzzer pins
-  TERN_(USE_BEEPER, buzzer.init());
+  // Init buzzer pin(s)
+  #if USE_BEEPER
+    SETUP_RUN(buzzer.init());
+  #endif
 
   // Set up LEDs early
   #if HAS_COLOR_LEDS

--- a/Marlin/src/libs/buzzer.h
+++ b/Marlin/src/libs/buzzer.h
@@ -84,9 +84,9 @@
 
     public:
       /**
-       * @brief Class constructor
+       * @brief Init Buzzer
        */
-      Buzzer() {
+      static inline void init() {
         SET_OUTPUT(BEEPER_PIN);
         reset();
       }


### PR DESCRIPTION
### Description

Buzzer have a global var. That global var do some pins setup in the constructor. The problem is that in STM32, the fast io setup runs inside a function call. So, the buzzer init will run before the fast io is setup, crashing marlin on STM32.

In fact, no global object should do pins setup in the constructor. It will break STM32 hal.

### Benefits

Fix buzzer init.

### Related Issues

#19333
