### PR TITLE
Minor SPI fixes, systick_callback for STM32F1 HAL compatibility

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -63,7 +63,7 @@ uint16_t HAL_adc_result;
 void HAL_init() {
   FastIO_init();
 
-  #if ENABLED(SDSUPPORT) && DISABLED(SDIO_SUPPORT)
+  #if ENABLED(SDSUPPORT) && DISABLED(SDIO_SUPPORT) && SDSS != -1
     OUT_WRITE(SDSS, HIGH); // Try to set SDSS inactive before any other SPI users start up
   #endif
 
@@ -126,5 +126,17 @@ void HAL_adc_start_conversion(const uint8_t adc_pin) { HAL_adc_result = analogRe
 uint16_t HAL_adc_get_result() { return HAL_adc_result; }
 
 void flashFirmware(const int16_t) { NVIC_SystemReset(); }
+
+static void (*systick_user_callback)(void);
+
+void HAL_SYSTICK_Callback(void) {
+    if (systick_user_callback) {
+        systick_user_callback();
+    }
+}
+
+void systick_attach_callback(void (*callback)(void)) {
+  systick_user_callback = callback;
+}
 
 #endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -122,21 +122,14 @@ extern "C" {
 
 // TODO: Make sure this doesn't cause any delay
 void HAL_adc_start_conversion(const uint8_t adc_pin) { HAL_adc_result = analogRead(adc_pin); }
-
 uint16_t HAL_adc_get_result() { return HAL_adc_result; }
 
+// Reset the system (to initiate a firmware flash)
 void flashFirmware(const int16_t) { NVIC_SystemReset(); }
 
-static void (*systick_user_callback)(void);
-
-void HAL_SYSTICK_Callback(void) {
-    if (systick_user_callback) {
-        systick_user_callback();
-    }
-}
-
-void systick_attach_callback(void (*callback)(void)) {
-  systick_user_callback = callback;
-}
+// Maple Compatibility
+systickCallback_t systick_user_callback;
+void systick_attach_callback(systickCallback_t cb) { systick_user_callback = cb; }
+void HAL_SYSTICK_Callback() { if (systick_user_callback) systick_user_callback(); }
 
 #endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -63,7 +63,7 @@ uint16_t HAL_adc_result;
 void HAL_init() {
   FastIO_init();
 
-  #if ENABLED(SDSUPPORT) && DISABLED(SDIO_SUPPORT) && SDSS != -1
+  #if ENABLED(SDSUPPORT) && DISABLED(SDIO_SUPPORT) && (defined(SDSS) && SDSS != -1)
     OUT_WRITE(SDSS, HIGH); // Try to set SDSS inactive before any other SPI users start up
   #endif
 

--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -177,3 +177,8 @@ uint16_t HAL_adc_get_result();
 
 #define PLATFORM_M997_SUPPORT
 void flashFirmware(const int16_t);
+
+// Maple Compatibility
+void systick_attach_callback(void (*callback)(void));
+
+void HAL_SYSTICK_Callback(void);

--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -179,6 +179,6 @@ uint16_t HAL_adc_get_result();
 void flashFirmware(const int16_t);
 
 // Maple Compatibility
-void systick_attach_callback(void (*callback)(void));
-
-void HAL_SYSTICK_Callback(void);
+typedef void (*systickCallback_t)(void);
+void systick_attach_callback(systickCallback_t cb);
+void HAL_SYSTICK_Callback();

--- a/Marlin/src/HAL/STM32/HAL_SPI.cpp
+++ b/Marlin/src/HAL/STM32/HAL_SPI.cpp
@@ -132,11 +132,9 @@ static SPISettings spiConfig;
    * @details Only configures SS pin since stm32duino creates and initialize the SPI object
    */
   void spiBegin() {
-    #if !PIN_EXISTS(SS)
-      #error "SS_PIN not defined!"
+    #if PIN_EXISTS(SS)
+      OUT_WRITE(SS_PIN, HIGH);
     #endif
-
-    OUT_WRITE(SS_PIN, HIGH);
   }
 
   // Configure SPI for specified SPI speed
@@ -173,9 +171,7 @@ static SPISettings spiConfig;
    * @details
    */
   uint8_t spiRec() {
-    SPI.beginTransaction(spiConfig);
     uint8_t returnByte = SPI.transfer(0xFF);
-    SPI.endTransaction();
     return returnByte;
   }
 
@@ -191,9 +187,7 @@ static SPISettings spiConfig;
   void spiRead(uint8_t* buf, uint16_t nbyte) {
     if (nbyte == 0) return;
     memset(buf, 0xFF, nbyte);
-    SPI.beginTransaction(spiConfig);
     SPI.transfer(buf, nbyte);
-    SPI.endTransaction();
   }
 
   /**
@@ -204,9 +198,7 @@ static SPISettings spiConfig;
    * @details
    */
   void spiSend(uint8_t b) {
-    SPI.beginTransaction(spiConfig);
     SPI.transfer(b);
-    SPI.endTransaction();
   }
 
   /**
@@ -219,10 +211,8 @@ static SPISettings spiConfig;
    */
   void spiSendBlock(uint8_t token, const uint8_t* buf) {
     uint8_t rxBuf[512];
-    SPI.beginTransaction(spiConfig);
     SPI.transfer(token);
     SPI.transfer((uint8_t*)buf, &rxBuf, 512);
-    SPI.endTransaction();
   }
 
 #endif // SOFTWARE_SPI


### PR DESCRIPTION
### Description

Tested in a STM32F4 board. This fixes my SD issues.

The systick callback is for compatibility with Hal STM32F1. LVGL ui is using it.

### Benefits

Fixes for HW SPI and SD in SPI mode now works fine.

