### PR TITLE
Fix bug of negative target temperature in visu screen Anycubic I3 MEGA serie

### DIFF
--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -34,7 +34,7 @@
 // command sending macro's with debugging capability
 #define SEND_PGM(x)                                 send_P(PSTR(x))
 #define SENDLINE_PGM(x)                             sendLine_P(PSTR(x))
-#define SEND_PGM_VAL(x,y)                           (send_P(PSTR(x)), sendLine(ui16tostr3rj(y)))
+#define SEND_PGM_VAL(x,y)                           (send_P(PSTR(x)), sendLine(i16tostr3rj(y)))
 #define SEND(x)                                     send(x)
 #define SENDLINE(x)                                 sendLine(x)
 #if ENABLED(ANYCUBIC_LCD_DEBUG)

--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -496,12 +496,12 @@ void AnycubicTFTClass::RenderCurrentFolder(uint16_t selectedNumber) {
         SEND_PGM("/");
         SENDLINE(currentFileList.shortFilename());
         SEND_PGM("/");
-        SENDLINE(currentFileList.longFilename());
+        SENDLINE(currentFileList.filename());
 
       }
       else {
         SENDLINE(currentFileList.shortFilename());
-        SENDLINE(currentFileList.longFilename());
+        SENDLINE(currentFileList.filename());
       }
     }
   }

--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -34,7 +34,7 @@
 // command sending macro's with debugging capability
 #define SEND_PGM(x)                                 send_P(PSTR(x))
 #define SENDLINE_PGM(x)                             sendLine_P(PSTR(x))
-#define SEND_PGM_VAL(x,y)                           (send_P(PSTR(x)), sendLine(i8tostr3rj(y)))
+#define SEND_PGM_VAL(x,y)                           (send_P(PSTR(x)), sendLine(ui8tostr3rj(y)))
 #define SEND(x)                                     send(x)
 #define SENDLINE(x)                                 sendLine(x)
 #if ENABLED(ANYCUBIC_LCD_DEBUG)

--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -34,7 +34,7 @@
 // command sending macro's with debugging capability
 #define SEND_PGM(x)                                 send_P(PSTR(x))
 #define SENDLINE_PGM(x)                             sendLine_P(PSTR(x))
-#define SEND_PGM_VAL(x,y)                           (send_P(PSTR(x)), sendLine(ui8tostr3rj(y)))
+#define SEND_PGM_VAL(x,y)                           (send_P(PSTR(x)), sendLine(ui16tostr3rj(y)))
 #define SEND(x)                                     send(x)
 #define SENDLINE(x)                                 sendLine(x)
 #if ENABLED(ANYCUBIC_LCD_DEBUG)


### PR DESCRIPTION
the target temperature is positive, the convertion is unsigned.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

the display is incorrect with the requested temperature values. it displays in the form -xx when it exceeds 128 ° C because the conversion used is signed.

-->

### Benefits

<!-- fix with unsigned conversion
[stb.zip](https://github.com/MarlinFirmware/Marlin/files/5312831/stb.zip)
 -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
