### PR TITLE
fixes #19566 add TEMP_ADC_PROBE support to stm32f1 HAL

### DIFF
--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -97,6 +97,9 @@ const uint8_t adc_pins[] = {
   #if HAS_TEMP_ADC_0
     TEMP_0_PIN,
   #endif
+  #if HAS_TEMP_ADC_PROBE
+    TEMP_PROBE_PIN,
+  #endif   
   #if HAS_HEATED_BED
     TEMP_BED_PIN,
   #endif
@@ -151,6 +154,9 @@ enum TempPinIndex : char {
   #if HAS_TEMP_ADC_0
     TEMP_0,
   #endif
+  #if HAS_TEMP_ADC_PROBE
+    TEMP_PROBE,
+  #endif   
   #if HAS_HEATED_BED
     TEMP_BED,
   #endif
@@ -341,6 +347,9 @@ void HAL_adc_start_conversion(const uint8_t adc_pin) {
     #if HAS_TEMP_ADC_0
       case TEMP_0_PIN: pin_index = TEMP_0; break;
     #endif
+    #if HAS_TEMP_ADC_PROBE
+      case TEMP_PROBE_PIN: pin_index = TEMP_PROBE; break;
+    #endif   
     #if HAS_HEATED_BED
       case TEMP_BED_PIN: pin_index = TEMP_BED; break;
     #endif


### PR DESCRIPTION
### Requirements

a controller using STM32F1 HAL
TEMP_SENSOR_PROBE

### Description

The current STM32F1 HAL doesn't look for TEMP_SENSOR_PROBE so it never sets up the ADC pin. 

### Benefits

TEMP_SENSOR_PROBE works on STM32F1 HAL

### Related Issues
Issue #19566 