### PR TITLE
fixes #19575 Cant compile with PRUSA_MMU2_S_MODE disabled

### DIFF
--- a/Marlin/src/feature/mmu2/mmu2.cpp
+++ b/Marlin/src/feature/mmu2/mmu2.cpp
@@ -342,15 +342,15 @@ void MMU2::mmu_loop() {
       if (rx_ok()) {
         // response to C0 mmu command in PRUSA_MMU2_S_MODE
         bool can_reset = true;
-        if (ENABLED(PRUSA_MMU2_S_MODE) && last_cmd == MMU_CMD_C0) {
-          if (!mmu2s_triggered) {
+        #if ENABLED(PRUSA_MMU2_S_MODE)
+          if ((last_cmd == MMU_CMD_C0) && !mmu2s_triggered) {
             can_reset = false;
             // MMU ok received but filament sensor not triggered, retrying...
             DEBUG_ECHOLNPGM("MMU => 'ok' (filament not present in gears)");
             DEBUG_ECHOLNPGM("MMU <= 'C0' (keep trying)");
             MMU2_COMMAND("C0");
           }
-        }
+        #endif
         if (can_reset) {
           DEBUG_ECHOLNPGM("MMU => 'ok'");
           ready = true;

--- a/Marlin/src/feature/mmu2/mmu2.cpp
+++ b/Marlin/src/feature/mmu2/mmu2.cpp
@@ -340,10 +340,10 @@ void MMU2::mmu_loop() {
       #endif
 
       if (rx_ok()) {
-        // response to C0 mmu command in PRUSA_MMU2_S_MODE
+        // Response to C0 mmu command in PRUSA_MMU2_S_MODE
         bool can_reset = true;
         #if ENABLED(PRUSA_MMU2_S_MODE)
-          if ((last_cmd == MMU_CMD_C0) && !mmu2s_triggered) {
+          if (!mmu2s_triggered && last_cmd == MMU_CMD_C0) {
             can_reset = false;
             // MMU ok received but filament sensor not triggered, retrying...
             DEBUG_ECHOLNPGM("MMU => 'ok' (filament not present in gears)");


### PR DESCRIPTION
### Requirements

PRUSA_MMU2_S_MODE disabled but with PRUSA_MMU2 enabled

### Description

Will not compile, gives error
```
Marlin\src\feature\mmu2\mmu2.cpp:346:16: error: 'mmu2s_triggered' was not declared in this scope
if (!mmu2s_triggered) {
^~~~~~~~~~~~~~~
Marlin\src\feature\mmu2\mmu2.cpp:346:16: note: suggested alternative: 'adc_trigger_t'
if (!mmu2s_triggered) {
^~~~~~~~~~~~~~~
adc_trigger_t
```

### Benefits

Compiles as expected

### Related Issues

issue #19575