### PR TITLE
Update probe.h for G35

### DIFF
--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -92,7 +92,7 @@ public:
       #endif
     }
     static float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true);
-    static inline float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true) {
+    static inline float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=false, const bool sanity_check=true) {
       return probe_at_point(pos.x, pos.y, raise_after, verbose_level, probe_relative, sanity_check);
     }
 


### PR DESCRIPTION
### Requirements

None

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
With this change I was able to make G35 to work with five points, and with the first point defined as the center of the bed, but I'm not sure what side effects that change would result in, so I made this as a Draft PR.

### Benefits

<!-- What does this fix or improve? -->
Fifth point can be defined with the center of the bed as the first measured point.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
Only the provided change is needed.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
No issues where opened, but I wasn't able to have a fifth point defined with the first one as the center of the bed.