### PR TITLE
fixes #19579, Z_AFTER_HOMING ignored with no probe

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1097,9 +1097,6 @@
 #define INVERT_E7_DIR false
 
 // @section homing
-//=========================================================================== 
-//============================= Homing Options ============================= 
-//=========================================================================== 
 
 //#define NO_MOTION_BEFORE_HOMING // Inhibit movement until all axes have been homed
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1097,6 +1097,9 @@
 #define INVERT_E7_DIR false
 
 // @section homing
+//=========================================================================== 
+//============================= Homing Options ============================= 
+//=========================================================================== 
 
 //#define NO_MOTION_BEFORE_HOMING // Inhibit movement until all axes have been homed
 

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -84,21 +84,12 @@ public:
         do_z_clearance(Z_AFTER_PROBING, true, true, true); // Move down still permitted
       #endif
     }
-    static inline void move_z_after_homing() {
-      #ifdef Z_AFTER_HOMING
-        do_z_clearance(Z_AFTER_HOMING, true, true, true);
-      #elif defined(Z_AFTER_PROBING)
-        move_z_after_probing();
-      #endif
-    }
     static float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true);
     static inline float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true) {
       return probe_at_point(pos.x, pos.y, raise_after, verbose_level, probe_relative, sanity_check);
     }
 
   #else
-
-    FORCE_INLINE static void move_z_after_homing() {}
 
     static constexpr xyz_pos_t offset = xyz_pos_t({ 0, 0, 0 }); // See #16767
 
@@ -107,6 +98,14 @@ public:
     FORCE_INLINE static bool can_reach(const float &rx, const float &ry) { return position_is_reachable(rx, ry); }
 
   #endif
+
+  static inline void move_z_after_homing() {
+    #ifdef Z_AFTER_HOMING
+      do_z_clearance(Z_AFTER_HOMING, true, true, true);
+    #elif BOTH(Z_AFTER_PROBING,HAS_BED_PROBE)
+      move_z_after_probing();
+    #endif
+  }
 
   FORCE_INLINE static bool can_reach(const xy_pos_t &pos) { return can_reach(pos.x, pos.y); }
 


### PR DESCRIPTION
### Requirements

Set Z_AFTER_HOMING but have no probe setup.

### Description

With no probe the function move_z_after_homing is declared as empty, effectively disabling  Z_AFTER_HOMING.
Re-arranged code so that  move_z_after_homing is defined correctly with or without a probe. 

### Benefits

Z_AFTER_HOMING no works as expected.

### Related Issues

Issue #19579 