### PR TITLE
Show 'Hotend Idle Timeout' message only when it really timed out

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -346,7 +346,7 @@
  * Hotend Idle Timeout
  * Prevent filament in the nozzle from charring and causing a critical jam.
  */
-//#define HOTEND_IDLE_TIMEOUT
+#define HOTEND_IDLE_TIMEOUT
 #if ENABLED(HOTEND_IDLE_TIMEOUT)
   #define HOTEND_IDLE_TIMEOUT_SEC (5*60)    // (seconds) Time without extruder movement to trigger protection
   #define HOTEND_IDLE_MIN_TRIGGER   180     // (°C) Minimum temperature to enable hotend protection

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -346,7 +346,7 @@
  * Hotend Idle Timeout
  * Prevent filament in the nozzle from charring and causing a critical jam.
  */
-#define HOTEND_IDLE_TIMEOUT
+//#define HOTEND_IDLE_TIMEOUT
 #if ENABLED(HOTEND_IDLE_TIMEOUT)
   #define HOTEND_IDLE_TIMEOUT_SEC (5*60)    // (seconds) Time without extruder movement to trigger protection
   #define HOTEND_IDLE_MIN_TRIGGER   180     // (°C) Minimum temperature to enable hotend protection

--- a/Marlin/src/feature/hotend_idle.cpp
+++ b/Marlin/src/feature/hotend_idle.cpp
@@ -74,16 +74,25 @@ void HotendIdleProtection::check() {
 // Lower (but don't raise) hotend / bed temperatures
 void HotendIdleProtection::timed_out() {
   next_protect_ms = 0;
-  SERIAL_ECHOLNPGM("Hotend Idle Timeout");
-  LCD_MESSAGEPGM(MSG_HOTEND_IDLE_TIMEOUT);
+  bool actually_timed_out = false;
+
   HOTEND_LOOP() {
-    if ((HOTEND_IDLE_NOZZLE_TARGET) < thermalManager.degTargetHotend(e))
+    if ((HOTEND_IDLE_NOZZLE_TARGET) < thermalManager.degTargetHotend(e)) {
       thermalManager.setTargetHotend(HOTEND_IDLE_NOZZLE_TARGET, e);
+      actually_timed_out = true;
+    }
   }
   #if HAS_HEATED_BED
-    if ((HOTEND_IDLE_BED_TARGET) < thermalManager.degTargetBed())
+    if ((HOTEND_IDLE_BED_TARGET) < thermalManager.degTargetBed()) {
       thermalManager.setTargetBed(HOTEND_IDLE_BED_TARGET);
+      actually_timed_out = true;
+    }
   #endif
+
+  if (actually_timed_out) {
+    SERIAL_ECHOLNPGM("Hotend Idle Timeout");
+    LCD_MESSAGEPGM(MSG_HOTEND_IDLE_TIMEOUT);
+  }
 }
 
 #endif // HOTEND_IDLE_TIMEOUT


### PR DESCRIPTION
### Description
I was annoyed by the 'Hotend Idle Timeout' message after a successful print, even it target E and HB temperature set to 0. This PR makes this message appear only if target temperature was changed to either HB hot E.

### Benefits
minor UX improvement

### Configurations
Only need to enable HOTEND_IDLE_TIMEOUT

### Related Issues
no