### PR TITLE
Update PROBE_OFFSET_WIZARD in Configuration_adv.h

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1049,7 +1049,7 @@
 #if HAS_LCD_MENU
 
   // Add Probe Z Offset calibration to the Bed Leveling menu
-  #if HAS_BED_PROBE
+  #if BOTH(HAS_BED_PROBE, LCD_BED_LEVELING)
     //#define PROBE_OFFSET_WIZARD
     #if ENABLED(PROBE_OFFSET_WIZARD)
       #define PROBE_OFFSET_START -4.0   // Estimated nozzle-to-probe Z offset, plus a little extra

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1049,7 +1049,7 @@
 #if HAS_LCD_MENU
 
   // Add Probe Z Offset calibration to the Bed Leveling menu
-  #if BOTH(HAS_BED_PROBE, LCD_BED_LEVELING)
+  #if HAS_BED_PROBE && ENABLED(LCD_BED_LEVELING)
     //#define PROBE_OFFSET_WIZARD
     #if ENABLED(PROBE_OFFSET_WIZARD)
       #define PROBE_OFFSET_START -4.0   // Estimated nozzle-to-probe Z offset, plus a little extra


### PR DESCRIPTION
### Requirements

https://github.com/MarlinFirmware/Marlin/pull/18866

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Little tweak for `PROBE_OFFSET_WIZARD` in Configuration_adv.h, because `PROBE_OFFSET_WIZARD` can only be used if `LCD_BED_LEVELING` is also enabled

### Benefits

<!-- What does this fix or improve? -->
More obvious definition in Configuration_adv.h

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
Nothing else

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
None