### PR TITLE
Use env:mega2560ext for the relevant boards

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -148,7 +148,7 @@
 #elif MB(AZTEEG_X3_PRO)
   #include "ramps/pins_AZTEEG_X3_PRO.h"         // ATmega2560                             env:mega2560
 #elif MB(ULTIMAIN_2)
-  #include "ramps/pins_ULTIMAIN_2.h"            // ATmega2560                             env:mega2560
+  #include "ramps/pins_ULTIMAIN_2.h"            // ATmega2560                             env:mega2560ext
 #elif MB(FORMBOT_RAPTOR)
   #include "ramps/pins_FORMBOT_RAPTOR.h"        // ATmega2560                             env:mega2560
 #elif MB(FORMBOT_RAPTOR2)
@@ -164,7 +164,7 @@
 #elif MB(RL200)
   #include "ramps/pins_RL200.h"                 // ATmega2560                             env:mega2560
 #elif MB(BQ_ZUM_MEGA_3D)
-  #include "ramps/pins_BQ_ZUM_MEGA_3D.h"        // ATmega2560                             env:mega2560
+  #include "ramps/pins_BQ_ZUM_MEGA_3D.h"        // ATmega2560                             env:mega2560ext
 #elif MB(MAKEBOARD_MINI)
   #include "ramps/pins_MAKEBOARD_MINI.h"        // ATmega2560                             env:mega2560
 #elif MB(TRIGORILLA_13)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -232,7 +232,7 @@
 #elif MB(CNCONTROLS_15)
   #include "mega/pins_CNCONTROLS_15.h"          // ATmega1280, ATmega2560                 env:mega1280 env:mega2560
 #elif MB(MIGHTYBOARD_REVE)
-  #include "mega/pins_MIGHTYBOARD_REVE.h"       // ATmega1280, ATmega2560                 env:mega1280 env:mega2560
+  #include "mega/pins_MIGHTYBOARD_REVE.h"       // ATmega1280, ATmega2560                 env:mega1280 env:mega2560ext
 #elif MB(CHEAPTRONIC)
   #include "mega/pins_CHEAPTRONIC.h"            // ATmega2560                             env:mega2560
 #elif MB(CHEAPTRONIC_V2)
@@ -260,7 +260,7 @@
 #elif MB(GT2560_V3_A20)
   #include "mega/pins_GT2560_V3_A20.h"          // ATmega2560                             env:mega2560
 #elif MB(EINSTART_S)
-  #include "mega/pins_EINSTART-S.h"             // ATmega1280, ATmega2560                 env:mega1280 env:mega2560
+  #include "mega/pins_EINSTART-S.h"             // ATmega1280, ATmega2560                 env:mega1280 env:mega2560ext
 #elif MB(WANHAO_ONEPLUS)
   #include "mega/pins_WANHAO_ONEPLUS.h"         // ATmega2560                             env:mega2560
 #elif MB(OVERLORD)

--- a/platformio.ini
+++ b/platformio.ini
@@ -414,6 +414,8 @@ board               = megaatmega2560
 # ATmega2560 with extended pins 70-85 defined
 # BOARD_BQ_ZUM_MEGA_3D
 # BOARD_ULTIMAIN_2
+# BOARD_MIGHTYBOARD_REVE
+# BOARD_EINSTART_S
 #
 [env:mega2560ext]
 platform            = atmelavr

--- a/platformio.ini
+++ b/platformio.ini
@@ -412,6 +412,8 @@ board               = megaatmega2560
 
 #
 # ATmega2560 with extended pins 70-85 defined
+# BOARD_BQ_ZUM_MEGA_3D
+# BOARD_ULTIMAIN_2
 #
 [env:mega2560ext]
 platform            = atmelavr


### PR DESCRIPTION
### Requirements

Any of these controller boards
BOARD_BQ_ZUM_MEGA_3D
BOARD_ULTIMAIN_2
BOARD_MIGHTYBOARD_REVE
BOARD_EINSTART_S

### Description

All of these boards use the build env:mega2560, but their respective pins files use Arduino data pins > 69 when the highest defined pin in the env:mega2560 is D69. 
Moved these boards to env:mega2560ext which has all pins up to 85
Egs.  
BOARD_ULTIMAIN_2 has #define E0_AUTO_FAN_PIN 77
BOARD_BQ_ZUM_MEGA_3D has #define Z_ENABLE_PIN 77 and #define X_MAX_PIN 79
BOARD_MIGHTYBOARD_REVE has #define CUTOFF_SR_CHECK_PIN 70 and #define BTN_LFT 72
BOARD_EINSTART_S has #define Y_ENABLE_PIN 72 and #define X_ENABLE_PIN 73

### Benefits

These boards now work as expected.

### Related Issues
Continuation of https://github.com/MarlinFirmware/Marlin/pull/19022 