### PR TITLE
Send all MIN/MAX temp error texts

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -458,6 +458,10 @@ namespace Language_en {
   PROGMEM Language_Str MSG_THERMAL_RUNAWAY_CHAMBER         = _UxGT("CHAMBER T. RUNAWAY");
   PROGMEM Language_Str MSG_ERR_MAXTEMP                     = _UxGT("Err: MAXTEMP");
   PROGMEM Language_Str MSG_ERR_MINTEMP                     = _UxGT("Err: MINTEMP");
+  PROGMEM Language_Str MSG_ERR_MAXTEMP_BED                 = _UxGT("Err: MAXTEMP BED");
+  PROGMEM Language_Str MSG_ERR_MINTEMP_BED                 = _UxGT("Err: MINTEMP BED");
+  PROGMEM Language_Str MSG_ERR_MAXTEMP_CHAMBER             = _UxGT("Err: MAXTEMP CHAMBER");
+  PROGMEM Language_Str MSG_ERR_MINTEMP_CHAMBER             = _UxGT("Err: MINTEMP CHAMBER");
   PROGMEM Language_Str MSG_HALTED                          = _UxGT("PRINTER HALTED");
   PROGMEM Language_Str MSG_PLEASE_RESET                    = _UxGT("Please Reset");
   PROGMEM Language_Str MSG_SHORT_DAY                       = _UxGT("d"); // One character only

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -817,13 +817,13 @@ void Temperature::max_temp_error(const heater_id_t heater_id) {
   #endif
   #if HAS_HEATED_BED
     if (H_BED == heater_ind_t) {
-      _temp_error(heater, PSTR(MSG_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_BED));
+      _temp_error(heater, PSTR(STR_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_BED));
       return;
     }
   #endif
   #if HAS_HEATED_CHAMBER
     if (H_CHAMBER == heater_ind_t) {
-      _temp_error(heater, PSTR(MSG_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_CHAMBER));
+      _temp_error(heater, PSTR(STR_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_CHAMBER));
       return;
     }
   #endif
@@ -836,13 +836,13 @@ void Temperature::min_temp_error(const heater_id_t heater_id) {
   #endif
   #if HAS_HEATED_BED
     if (H_BED == heater_ind_t) {
-      _temp_error(heater, PSTR(MSG_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP_BED));
+      _temp_error(heater, PSTR(STR_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP_BED));
       return;
     }
   #endif
   #if HAS_HEATED_CHAMBER
     if (H_CHAMBER == heater_ind_t) {
-      _temp_error(heater, PSTR(MSG_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP_CHAMBER));
+      _temp_error(heater, PSTR(STR_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP_CHAMBER));
       return;
     }
   #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -815,12 +815,36 @@ void Temperature::max_temp_error(const heater_id_t heater_id) {
   #if ENABLED(DWIN_CREALITY_LCD) && (HAS_HOTEND || HAS_HEATED_BED)
     DWIN_Popup_Temperature(1);
   #endif
+  #if HAS_HEATED_BED
+    if (H_BED == heater_ind_t) {
+      _temp_error(heater, PSTR(MSG_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_BED));
+      return;
+    }
+  #endif
+  #if HAS_HEATED_CHAMBER
+    if (H_CHAMBER == heater_ind_t) {
+      _temp_error(heater, PSTR(MSG_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_CHAMBER));
+      return;
+    }
+  #endif
   _temp_error(heater_id, PSTR(STR_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP));
 }
 
 void Temperature::min_temp_error(const heater_id_t heater_id) {
   #if ENABLED(DWIN_CREALITY_LCD) && (HAS_HOTEND || HAS_HEATED_BED)
     DWIN_Popup_Temperature(0);
+  #endif
+  #if HAS_HEATED_BED
+    if (H_BED == heater_ind_t) {
+      _temp_error(heater, PSTR(MSG_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP_BED));
+      return;
+    }
+  #endif
+  #if HAS_HEATED_CHAMBER
+    if (H_CHAMBER == heater_ind_t) {
+      _temp_error(heater, PSTR(MSG_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP_CHAMBER));
+      return;
+    }
   #endif
   _temp_error(heater_id, PSTR(STR_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP));
 }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -816,13 +816,13 @@ void Temperature::max_temp_error(const heater_id_t heater_id) {
     DWIN_Popup_Temperature(1);
   #endif
   #if HAS_HEATED_BED
-    if (H_BED == heater_ind_t) {
+    if (H_BED == heater_id) {
       _temp_error(heater, PSTR(STR_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_BED));
       return;
     }
   #endif
   #if HAS_HEATED_CHAMBER
-    if (H_CHAMBER == heater_ind_t) {
+    if (H_CHAMBER == heater_id) {
       _temp_error(heater, PSTR(STR_T_MAXTEMP), GET_TEXT(MSG_ERR_MAXTEMP_CHAMBER));
       return;
     }
@@ -835,13 +835,13 @@ void Temperature::min_temp_error(const heater_id_t heater_id) {
     DWIN_Popup_Temperature(0);
   #endif
   #if HAS_HEATED_BED
-    if (H_BED == heater_ind_t) {
+    if (H_BED == heater_id) {
       _temp_error(heater, PSTR(STR_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP_BED));
       return;
     }
   #endif
   #if HAS_HEATED_CHAMBER
-    if (H_CHAMBER == heater_ind_t) {
+    if (H_CHAMBER == heater_id) {
       _temp_error(heater, PSTR(STR_T_MINTEMP), GET_TEXT(MSG_ERR_MINTEMP_CHAMBER));
       return;
     }


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

If a MIN/MAX error is triggered you cannot distinguish between hotend, bed and chamber according to the text sent. This patch adds separate texts for these situations.

### Benefits

SW can distinguish if error occured in hotend, bed or chamber.

### Configurations

### Related Issues

This is a bug fix (texts were available previously but were not used and removed).