### PR TITLE
Permit touch calibration override follow up

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -306,13 +306,13 @@
       #ifndef XPT2046_X_CALIBRATION
         #define XPT2046_X_CALIBRATION    -11245
       #endif
-      #ifdef XPT2046_Y_CALIBRATION
+      #ifndef XPT2046_Y_CALIBRATION
         #define XPT2046_Y_CALIBRATION      8629
       #endif
-      #ifdef XPT2046_X_OFFSET
+      #ifndef XPT2046_X_OFFSET
         #define XPT2046_X_OFFSET            685
       #endif
-      #ifdef XPT2046_Y_OFFSET
+      #ifndef XPT2046_Y_OFFSET
         #define XPT2046_Y_OFFSET           -285
       #endif
     #endif


### PR DESCRIPTION
### Description

Use ifndefs instead of ifdefs to allow config overrides, which I believe was the original intent of https://github.com/MarlinFirmware/Marlin/commit/854af7a4bf682b2569ea9a3cc03cd930e9490f73.

### Benefits

Configs can override defaults.