### PR TITLE
Optional `M42`/`M226`; Add more features filters

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3560,6 +3560,11 @@
 //#define M100_FREE_MEMORY_WATCHER
 
 //
+// M42 - Set pin states
+//
+//#define DIRECT_PIN_CONTROL
+
+//
 // M43 - display pin status, toggle pins, watch pins, watch endstops & toggle LED, test servo probe
 //
 //#define PINS_DEBUGGING

--- a/Marlin/src/gcode/control/M226.cpp
+++ b/Marlin/src/gcode/control/M226.cpp
@@ -20,6 +20,10 @@
  *
  */
 
+#include "../../MarlinConfig.h"
+
+#if ENABLED(DIRECT_PIN_CONTROL)
+
 #include "../gcode.h"
 #include "../../MarlinCore.h" // for pin_is_protected and idle()
 #include "../../module/stepper.h"
@@ -50,3 +54,5 @@ void GcodeSuite::M226() {
     } // pin_state -1 0 1 && pin > -1
   } // parser.seen('P')
 }
+
+#endif // DIRECT_PIN_CONTROL

--- a/Marlin/src/gcode/control/M226.cpp
+++ b/Marlin/src/gcode/control/M226.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "../../MarlinConfig.h"
+#include "../../inc/MarlinConfig.h"
 
 #if ENABLED(DIRECT_PIN_CONTROL)
 

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -20,9 +20,12 @@
  *
  */
 
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(DIRECT_PIN_CONTROL)
+
 #include "../gcode.h"
 #include "../../MarlinCore.h" // for pin_is_protected
-#include "../../inc/MarlinConfig.h"
 
 #if HAS_FAN
   #include "../../module/temperature.h"
@@ -96,3 +99,5 @@ void GcodeSuite::M42() {
   extDigitalWrite(pin, pin_status);
   analogWrite(pin, pin_status);
 }
+
+#endif // DIRECT_PIN_CONTROL

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -445,7 +445,10 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       #endif // SDSUPPORT
 
       case 31: M31(); break;                                      // M31: Report time since the start of SD print or last M109
-      case 42: M42(); break;                                      // M42: Change pin state
+
+      #if ENABLED(DIRECT_PIN_CONTROL)
+        case 42: M42(); break;                                    // M42: Change pin state
+      #endif
 
       #if ENABLED(PINS_DEBUGGING)
         case 43: M43(); break;                                    // M43: Read pin state
@@ -620,7 +623,9 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
         case 221: M221(); break;                                  // M221: Set Flow Percentage
       #endif
 
-      case 226: M226(); break;                                    // M226: Wait until a pin reaches a state
+      #if ENABLED(DIRECT_PIN_CONTROL)
+        case 226: M226(); break;                                  // M226: Wait until a pin reaches a state
+      #endif
 
       #if HAS_SERVOS
         case 280: M280(); break;                                  // M280: Set servo position absolute

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -109,7 +109,7 @@
  *        The '#' is necessary when calling from within sd files, as it stops buffer prereading
  * M33  - Get the longname version of a path. (Requires LONG_FILENAME_HOST_SUPPORT)
  * M34  - Set SD Card sorting options. (Requires SDCARD_SORT_ALPHA)
- * M42  - Change pin status via gcode: M42 P<pin> S<value>. LED pin assumed if P is omitted.
+ * M42  - Change pin status via gcode: M42 P<pin> S<value>. LED pin assumed if P is omitted. (Requires DIRECT_PIN_CONTROL)
  * M43  - Display pin status, watch pins for changes, watch endstops & toggle LED, Z servo probe test, toggle pins
  * M48  - Measure Z Probe repeatability: M48 P<points> X<pos> Y<pos> V<level> E<engage> L<legs> S<chizoid>. (Requires Z_MIN_PROBE_REPEATABILITY_TEST)
  * M73  - Set the progress percentage. (Requires LCD_SET_PROGRESS_MANUALLY)
@@ -183,7 +183,7 @@
  * M220 - Set Feedrate Percentage: "M220 S<percent>" (i.e., "FR" on the LCD)
  *        Use "M220 B" to back up the Feedrate Percentage and "M220 R" to restore it. (Requires PRUSA_MMU2)
  * M221 - Set Flow Percentage: "M221 S<percent>"
- * M226 - Wait until a pin is in a given state: "M226 P<pin> S<state>"
+ * M226 - Wait until a pin is in a given state: "M226 P<pin> S<state>" (Requires DIRECT_PIN_CONTROL)
  * M240 - Trigger a camera to take a photograph. (Requires PHOTO_GCODE)
  * M250 - Set LCD contrast: "M250 C<contrast>" (0-63). (Requires LCD support)
  * M260 - i2c Send Data (Requires EXPERIMENTAL_I2CBUS)
@@ -541,8 +541,7 @@ private:
     #endif
   #endif
 
-  static void M42();
-
+  TERN_(DIRECT_PIN_CONTROL, static void M42());
   TERN_(PINS_DEBUGGING, static void M43());
 
   TERN_(Z_MIN_PROBE_REPEATABILITY_TEST, static void M48());
@@ -670,7 +669,7 @@ private:
     static void M221();
   #endif
 
-  static void M226();
+  TERN_(DIRECT_PIN_CONTROL, static void M226());
 
   TERN_(PHOTO_GCODE, static void M240());
 

--- a/Marlin/src/inc/MarlinConfig.h
+++ b/Marlin/src/inc/MarlinConfig.h
@@ -27,21 +27,31 @@
 
 #include "MarlinConfigPre.h"
 
-#include "../HAL/HAL.h"
+#ifndef __MARLIN_DEPS__
+  #include "../HAL/HAL.h"
+#endif
 
 #include "../pins/pins.h"
-#include HAL_PATH(../HAL, timers.h)
-#include HAL_PATH(../HAL, spi_pins.h)
+
+#ifndef __MARLIN_DEPS__
+  #include HAL_PATH(../HAL, timers.h)
+  #include HAL_PATH(../HAL, spi_pins.h)
+#endif
 
 #include "Conditionals_post.h"
-#include HAL_PATH(../HAL, inc/Conditionals_post.h)
 
-#include "../core/types.h"  // Ahead of sanity-checks
+#ifndef __MARLIN_DEPS__
 
-#include "SanityCheck.h"
-#include HAL_PATH(../HAL, inc/SanityCheck.h)
+  #include HAL_PATH(../HAL, inc/Conditionals_post.h)
 
-// Include all core headers
-#include "../core/language.h"
-#include "../core/utility.h"
-#include "../core/serial.h"
+  #include "../core/types.h"  // Ahead of sanity-checks
+
+  #include "SanityCheck.h"
+  #include HAL_PATH(../HAL, inc/SanityCheck.h)
+
+  // Include all core headers
+  #include "../core/language.h"
+  #include "../core/utility.h"
+  #include "../core/serial.h"
+
+#endif

--- a/Marlin/src/inc/MarlinConfigPre.h
+++ b/Marlin/src/inc/MarlinConfigPre.h
@@ -30,7 +30,9 @@
 //
 #include <stdint.h>
 
-#include "../HAL/platforms.h"
+#ifndef __MARLIN_DEPS__
+  #include "../HAL/platforms.h"
+#endif
 
 #include "../core/boards.h"
 #include "../core/macros.h"
@@ -45,10 +47,16 @@
 #include "Version.h"
 
 #include "Conditionals_LCD.h"
-#include HAL_PATH(../HAL, inc/Conditionals_LCD.h)
+
+#ifndef __MARLIN_DEPS__
+  #include HAL_PATH(../HAL, inc/Conditionals_LCD.h)
+#endif
 
 #include "../core/drivers.h"
 #include "../../Configuration_adv.h"
 
 #include "Conditionals_adv.h"
-#include HAL_PATH(../HAL, inc/Conditionals_adv.h)
+
+#ifndef __MARLIN_DEPS__
+  #include HAL_PATH(../HAL, inc/Conditionals_adv.h)
+#endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -52,7 +52,7 @@
 #define HAS_FREE_AUX2_PINS !(BOTH(ULTRA_LCD, NEWPANEL) && ANY(PANEL_ONE, VIKI2, miniVIKI, MINIPANEL, REPRAPWORLD_KEYPAD))
 
 // Test the target within the included pins file
-#ifdef __MARLIN_PREBUILD__
+#ifdef __MARLIN_DEPS__
   #define NOT_TARGET(V...) 0
 #else
   #define NOT_TARGET(V...) NONE(V)

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.h
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#pragma once
 
 /**
  * The purpose of this file is just include Marlin Configuration files,
@@ -27,44 +26,9 @@
  * Used by common-dependencies.py
  */
 
-#include <stdint.h>
+#define NUM_SERIAL 1 // Normally provided by HAL/HAL.h
 
-// Include platform headers
-//#include "../../../../Marlin/src/HAL/platforms.h"
-
-#include "../../../../Marlin/src/core/boards.h"
-#include "../../../../Marlin/src/core/macros.h"
-#include "../../../../Marlin/Configuration.h"
-
-#include "../../../../Marlin/Version.h"
-
-#include "../../../../Marlin/src/inc/Conditionals_LCD.h"
-
-#ifdef HAL_PATH
-  #include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_LCD.h)
-#endif
-
-#include "../../../../Marlin/src/core/drivers.h"
-#include "../../../../Marlin/Configuration_adv.h"
-
-#include "../../../../Marlin/src/inc/Conditionals_adv.h"
-
-#ifdef HAL_PATH
-  #include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_adv.h)
-#endif
-
-//#include "../../../../Marlin/src/pins/pins.h"
-
-#ifdef HAL_PATH
-  #include HAL_PATH(../../../../Marlin/src/HAL, timers.h)
-  #include HAL_PATH(../../../../Marlin/src/HAL, spi_pins.h)
-#endif
-
-#include "../../../../Marlin/src/inc/Conditionals_post.h"
-
-#ifdef HAL_PATH
-  #include HAL_PATH(../../../../Marlin/src/HAL, inc/Conditionals_post.h)
-#endif
+#include "../../../../Marlin/src/inc/MarlinConfig.h"
 
 //
 // Conditionals only used for [features]
@@ -87,6 +51,10 @@
 
 #if EXTRUDERS
   #define HAS_EXTRUDERS
+#endif
+
+#if ENABLED(DUET_SMART_EFFECTOR) && PIN_EXISTS(SMART_EFFECTOR_MOD)
+  #define HAS_SMART_EFF_MOD
 #endif
 
 #if HAS_LCD_MENU
@@ -145,6 +113,3 @@
     #define HAS_MENU_UBL
   #endif
 #endif
-
-// Include pins for the current board. Platform tests will be skipped. No HAL-defined pins.
-#include "../../../../Marlin/src/pins/pins.h"

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -39,6 +39,12 @@ def parse_pkg_uri(spec):
 FEATURE_CONFIG = {}
 
 def add_to_feat_cnf(feature, flines):
+
+	try:
+		feat = FEATURE_CONFIG[feature]
+	except:
+		FEATURE_CONFIG[feature] = {}
+
 	feat = FEATURE_CONFIG[feature]
 	atoms = re.sub(',\\s*', '\n', flines).strip().split('\n')
 	for dep in atoms:
@@ -238,7 +244,7 @@ def load_marlin_features():
 		else:
 			cmd += ['-D' + s]
 
-	cmd += ['-D__MARLIN_PREBUILD__ -w -dM -E -x c++ buildroot/share/PlatformIO/scripts/common-dependencies.h']
+	cmd += ['-D__MARLIN_DEPS__ -w -dM -E -x c++ buildroot/share/PlatformIO/scripts/common-dependencies.h']
 	cmd = ' '.join(cmd)
 	blab(cmd)
 	define_list = subprocess.check_output(cmd, shell=True).splitlines()

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,6 +27,7 @@ include_dir  = Marlin
 [common]
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/lcd/HD44780> -<src/lcd/TFTGLCD> -<src/lcd/dwin> -<src/lcd/dogm> -<src/lcd/tft>
+  -<src/HAL/STM32/tft> -<src/HAL/STM32F1/tft>
   -<src/lcd/menu>
   -<src/lcd/menu/game/game.cpp> -<src/lcd/menu/game/brickout.cpp> -<src/lcd/menu/game/invaders.cpp>
   -<src/lcd/menu/game/maze.cpp> -<src/lcd/menu/game/snake.cpp>
@@ -53,10 +54,13 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/lcd/extui/example.cpp>
   -<src/lcd/extui/malyan_lcd.cpp>
   -<src/lcd/extui/lib/ftdi_eve_touch_ui>
-  -<src/lcd/extui/anycubic_chiron_lcd.cpp>
+  -<src/lcd/extui/anycubic_chiron_lcd.cpp> -<src/lcd/extui/lib/anycubic_chiron>
   -<src/lcd/extui/anycubic_i3mega_lcd.cpp> -<src/lcd/extui/lib/anycubic_i3mega>
   -<src/lcd/lcdprint.cpp>
+  -<src/lcd/touch/touch_buttons.cpp>
   -<src/sd/usb_flashdrive>
+  -<src/HAL/shared/backtrace>
+  -<src/feature/babystep.cpp>
   -<src/feature/backlash.cpp>
   -<src/feature/baricuda.cpp> -<src/gcode/feature/baricuda>
   -<src/feature/bedlevel/abl> -<src/gcode/bedlevel/abl>
@@ -65,7 +69,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/feature/binary_stream.cpp> -<src/libs/heatshrink>
   -<src/feature/bltouch.cpp>
   -<src/feature/cancel_object.cpp> -<src/gcode/feature/cancel>
-  -<src/feature/caselight> -<src/gcode/feature/caselight>
+  -<src/feature/caselight.cpp> -<src/gcode/feature/caselight>
   -<src/feature/closedloop.cpp>
   -<src/feature/controllerfan.cpp> -<src/gcode/feature/controllerfan>
   -<src/feature/dac> -<src/feature/digipot>
@@ -80,6 +84,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/feature/joystick.cpp>
   -<src/feature/leds/blinkm.cpp>
   -<src/feature/leds/leds.cpp>
+  -<src/feature/leds/neopixel.cpp>
   -<src/feature/leds/pca9533.cpp>
   -<src/feature/leds/pca9632.cpp>
   -<src/feature/leds/printer_event_leds.cpp>
@@ -95,7 +100,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/feature/probe_temp_comp.cpp>
   -<src/feature/runout.cpp> -<src/gcode/feature/runout>
   -<src/feature/snmm.cpp>
-  -<src/feature/solenoid.cpp>
+  -<src/feature/solenoid.cpp> -<src/gcode/control/M380_M381.cpp>
   -<src/feature/spindle_laser.cpp> -<src/gcode/control/M3-M5.cpp>
   -<src/feature/tmc_util.cpp> -<src/module/stepper/trinamic.cpp>
   -<src/feature/twibus.cpp>
@@ -106,7 +111,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/bedlevel/M420.cpp>
   -<src/gcode/calibrate/G33.cpp>
   -<src/gcode/calibrate/G34_M422.cpp>
-  -<src/gcode/calibrate/G76_M871.cpp>
+  -<src/gcode/calibrate/G76_M192_M871.cpp>
   -<src/gcode/calibrate/G425.cpp>
   -<src/gcode/calibrate/M12.cpp>
   -<src/gcode/calibrate/M48.cpp>
@@ -120,9 +125,13 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/config/M218.cpp>
   -<src/gcode/config/M221.cpp>
   -<src/gcode/config/M281.cpp>
+  -<src/gcode/config/M301.cpp>
   -<src/gcode/config/M302.cpp>
+  -<src/gcode/config/M304.cpp>
   -<src/gcode/config/M305.cpp>
   -<src/gcode/config/M540.cpp>
+  -<src/gcode/config/M575.cpp>
+  -<src/gcode/config/M672.cpp>
   -<src/gcode/control/M7-M9.cpp>
   -<src/gcode/control/M211.cpp>
   -<src/gcode/control/M605.cpp>
@@ -170,8 +179,10 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/scara>
   -<src/gcode/sd>
   -<src/gcode/temp/M104_M109.cpp>
+  -<src/gcode/temp/M155.cpp>
   -<src/gcode/units/G20_G21.cpp>
   -<src/gcode/units/M149.cpp>
+  -<src/libs/BL24CXX.cpp> -<src/libs/W25Qxx.cpp>
   -<src/libs/L64XX> -<src/module/stepper/L64xx.cpp>
   -<src/libs/hex_print.cpp>
   -<src/libs/least_squares_fit.cpp>
@@ -215,9 +226,13 @@ HAS_WIRED_LCD           = src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780    = src_filter=+<src/lcd/HD44780>
 HAS_MARLINUI_U8GLIB     = U8glib-HAL@~0.4.1
                           src_filter=+<src/lcd/dogm>
+HAS_(FSMC|SPI)_TFT      = src_filter=+<src/HAL/STM32/tft> +<src/HAL/STM32F1/tft>
+HAS_FSMC_TFT            = src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp> +<src/HAL/STM32F1/tft/tft_fsmc.cpp>
+HAS_SPI_TFT             = src_filter=+<src/HAL/STM32/tft/tft_spi.cpp> +<src/HAL/STM32F1/tft/tft_spi.cpp>
 HAS_GRAPHICAL_TFT       = src_filter=+<src/lcd/tft>
 DWIN_CREALITY_LCD       = src_filter=+<src/lcd/dwin>
 IS_TFTGLCD_PANEL        = src_filter=+<src/lcd/TFTGLCD>
+HAS_TOUCH_XPT2046       = src_filter=+<src/lcd/touch/touch_buttons.cpp>
 HAS_LCD_MENU            = src_filter=+<src/lcd/menu>
 HAS_GAMES               = src_filter=+<src/lcd/menu/game/game.cpp>
 MARLIN_BRICKOUT         = src_filter=+<src/lcd/menu/game/brickout.cpp>
@@ -243,7 +258,7 @@ HAS_MENU_TEMPERATURE    = src_filter=+<src/lcd/menu/menu_temperature.cpp>
 HAS_MENU_TMC            = src_filter=+<src/lcd/menu/menu_tmc.cpp>
 HAS_MENU_TOUCH_SCREEN   = src_filter=+<src/lcd/menu/menu_touch_screen.cpp>
 HAS_MENU_UBL            = src_filter=+<src/lcd/menu/menu_ubl.cpp>
-ANYCUBIC_LCD_CHIRON     = src_filter=+<src/lcd/extui/anycubic_chiron_lcd.cpp>
+ANYCUBIC_LCD_CHIRON     = src_filter=+<src/lcd/extui/anycubic_chiron_lcd.cpp> +<src/lcd/extui/lib/anycubic_chiron>
 ANYCUBIC_LCD_I3MEGA     = src_filter=+<src/lcd/extui/anycubic_i3mega_lcd.cpp> +<src/lcd/extui/lib/anycubic_i3mega>
 HAS_DGUS_LCD            = src_filter=+<src/lcd/extui/lib/dgus> +<src/lcd/extui/dgus_lcd.cpp>
 TOUCH_UI_FTDI_EVE       = src_filter=+<src/lcd/extui/lib/ftdi_eve_touch_ui>
@@ -259,13 +274,15 @@ BARICUDA                = src_filter=+<src/feature/baricuda.cpp> +<src/gcode/fea
 BINARY_FILE_TRANSFER    = src_filter=+<src/feature/binary_stream.cpp> +<src/libs/heatshrink>
 BLTOUCH                 = src_filter=+<src/feature/bltouch.cpp>
 CANCEL_OBJECTS          = src_filter=+<src/feature/cancel_object.cpp> +<src/gcode/feature/cancel>
-CASE_LIGHT_ENABLE       = src_filter=+<src/feature/caselight> +<src/gcode/feature/caselight>
+CASE_LIGHT_ENABLE       = src_filter=+<src/feature/caselight.cpp> +<src/gcode/feature/caselight>
 EXTERNAL_CLOSED_LOOP_CONTROLLER = src_filter=+<src/feature/closedloop.cpp> +<src/gcode/calibrate/M12.cpp>
 USE_CONTROLLER_FAN      = src_filter=+<src/feature/controllerfan.cpp>
 DAC_STEPPER_CURRENT     = src_filter=+<src/feature/dac>
 DIRECT_STEPPING         = src_filter=+<src/feature/direct_stepping.cpp> +<src/gcode/motion/G6.cpp>
 EMERGENCY_PARSER        = src_filter=+<src/feature/e_parser.cpp> -<src/gcode/control/M108_*.cpp>
 I2C_POSITION_ENCODERS   = src_filter=+<src/feature/encoder_i2c.cpp>
+IIC_BL24CXX_EEPROM      = src_filter=+<src/libs/BL24CXX.cpp>
+HAS_SPI_FLASH           = src_filter=+<src/libs/W25Qxx.cpp>
 HAS_FANMUX              = src_filter=+<src/feature/fanmux.cpp>
 FILAMENT_WIDTH_SENSOR   = src_filter=+<src/feature/filwidth.cpp> +<src/gcode/feature/filwidth>
 FWRETRACT               = src_filter=+<src/feature/fwretract.cpp> +<src/gcode/feature/fwretract>
@@ -286,10 +303,10 @@ ADVANCED_PAUSE_FEATURE  = src_filter=+<src/feature/pause.cpp> +<src/gcode/featur
 AUTO_POWER_CONTROL      = src_filter=+<src/feature/power.cpp>
 HAS_POWER_MONITOR       = src_filter=+<src/feature/power_monitor.cpp> +<src/gcode/feature/power_monitor>
 POWER_LOSS_RECOVERY     = src_filter=+<src/feature/powerloss.cpp> +<src/gcode/feature/powerloss>
-PROBE_TEMP_COMPENSATION = src_filter=+<src/feature/probe_temp_comp.cpp> +<src/gcode/calibrate/G76_M871.cpp>
+PROBE_TEMP_COMPENSATION = src_filter=+<src/feature/probe_temp_comp.cpp> +<src/gcode/calibrate/G76_M192_M871.cpp>
 HAS_FILAMENT_SENSOR     = src_filter=+<src/feature/runout.cpp> +<src/gcode/feature/runout>
 MK2_MULTIPLEXER         = src_filter=+<src/feature/snmm.cpp>
-EXT_SOLENOID|MANUAL_SOLENOID_CONTROL = src_filter=+<src/feature/solenoid.cpp>
+EXT_SOLENOID|MANUAL_SOLENOID_CONTROL = src_filter=+<src/feature/solenoid.cpp> +<src/gcode/control/M380_M381.cpp>
 HAS_CUTTER              = src_filter=+<src/feature/spindle_laser.cpp> +<src/gcode/control/M3-M5.cpp>
 EXPERIMENTAL_I2CBUS     = src_filter=+<src/feature/twibus.cpp> +<src/gcode/feature/i2c>
 Z_STEPPER_AUTO_ALIGN    = src_filter=+<src/feature/z_stepper_align.cpp> +<src/gcode/calibrate/G34_M422.cpp>
@@ -306,14 +323,18 @@ IS_KINEMATIC            = src_filter=+<src/gcode/calibrate/M665.cpp>
 HAS_EXTRA_ENDSTOPS      = src_filter=+<src/gcode/calibrate/M666.cpp>
 SKEW_CORRECTION_GCODE   = src_filter=+<src/gcode/calibrate/M852.cpp>
 DIRECT_PIN_CONTROL      = src_filter=+<src/gcode/control/M42.cpp> +<src/gcode/control/M226.cpp>
-PINS_DEBUGGING          = src_filter=-<src/gcode/config/M43.cpp>
+PINS_DEBUGGING          = src_filter=+<src/gcode/config/M43.cpp>
 NO_VOLUMETRICS          = src_filter=-<src/gcode/config/M200-M205.cpp>
 HAS_MULTI_EXTRUDER      = src_filter=+<src/gcode/config/M217.cpp>
 HAS_HOTEND_OFFSET       = src_filter=+<src/gcode/config/M218.cpp>
 EDITABLE_SERVO_ANGLES   = src_filter=+<src/gcode/config/M281.cpp>
+PIDTEMP                 = src_filter=+<src/gcode/config/M301.cpp>
 PREVENT_COLD_EXTRUSION  = src_filter=+<src/gcode/config/M302.cpp>
+PIDTEMPBED              = src_filter=+<src/gcode/config/M304.cpp>
 HAS_USER_THERMISTORS    = src_filter=+<src/gcode/config/M305.cpp>
 SD_ABORT_ON_ENDSTOP_HIT = src_filter=+<src/gcode/config/M540.cpp>
+BAUD_RATE_GCODE         = src_filter=+<src/gcode/config/M575.cpp>
+HAS_SMART_EFF_MOD       = src_filter=+<src/gcode/config/M672.cpp>
 COOLANT_CONTROL         = src_filter=+<src/gcode/control/M7-M9.cpp>
 HAS_SOFTWARE_ENDSTOPS   = src_filter=+<src/gcode/control/M211.cpp>
 HAS_DUPLICATION_MODE    = src_filter=+<src/gcode/control/M605.cpp>
@@ -338,12 +359,13 @@ LCD_SET_PROGRESS_MANUALLY = src_filter=+<src/gcode/lcd/M73.cpp>
 TOUCH_SCREEN_CALIBRATION = src_filter=+<src/gcode/lcd/M995.cpp>
 ARC_SUPPORT             = src_filter=+<src/gcode/motion/G2_G3.cpp>
 GCODE_MOTION_MODES      = src_filter=+<src/gcode/motion/G80.cpp>
-BABYSTEPPING            = src_filter=+<src/gcode/motion/M290.cpp>
+BABYSTEPPING            = src_filter=+<src/gcode/motion/M290.cpp> +<src/feature/babystep.cpp>
 Z_PROBE_SLED            = src_filter=+<src/gcode/probe/G31_G32.cpp>
 G38_PROBE_TARGET        = src_filter=+<src/gcode/probe/G38.cpp>
 MAGNETIC_PARKING_EXTRUDER = src_filter=+<src/gcode/probe/M951.cpp>
 SDSUPPORT               = src_filter=+<src/gcode/sd>
 HAS_EXTRUDERS           = src_filter=+<src/gcode/temp/M104_M109.cpp> +<src/gcode/config/M221.cpp>
+AUTO_REPORT_TEMPERATURES = src_filter=+<src/gcode/temp/M155.cpp>
 INCH_MODE_SUPPORT       = src_filter=+<src/gcode/units/G20_G21.cpp>
 TEMPERATURE_UNITS_SUPPORT = src_filter=+<src/gcode/units/M149.cpp>
 NEED_HEX_PRINT          = src_filter=+<src/libs/hex_print.cpp>
@@ -561,7 +583,7 @@ extends       = env:at90usb1286_cdc
 [env:DUE]
 platform      = atmelsam
 board         = due
-src_filter    = ${common.default_src_filter} +<src/HAL/DUE>
+src_filter    = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
 
 [env:DUE_USB]
 platform      = atmelsam
@@ -637,7 +659,7 @@ lib_ldf_mode      = off
 lib_compat_mode   = strict
 extra_scripts     = ${common.extra_scripts}
   Marlin/src/HAL/LPC1768/upload_extra_script.py
-src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768>
+src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768> +<src/HAL/shared/backtrace>
 lib_deps          = ${common.lib_deps}
   Servo
 custom_marlin.USES_LIQUIDCRYSTAL = LiquidCrystal@1.0.0
@@ -676,7 +698,7 @@ build_flags   = ${common.build_flags}
   -DUSBCON -DUSBD_USE_CDC
   -DTIM_IRQ_PRIO=13
 build_unflags = -std=gnu++11
-src_filter    = ${common.default_src_filter} +<src/HAL/STM32>
+src_filter    = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
 
 #
 # HAL/STM32F1 Common Environment values

--- a/platformio.ini
+++ b/platformio.ini
@@ -114,6 +114,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/calibrate/M425.cpp>
   -<src/gcode/calibrate/M666.cpp>
   -<src/gcode/calibrate/M852.cpp>
+  -<src/gcode/control/M42.cpp> -<src/gcode/control/M226.cpp>
   -<src/gcode/config/M43.cpp>
   -<src/gcode/config/M217.cpp>
   -<src/gcode/config/M218.cpp>
@@ -304,6 +305,7 @@ BACKLASH_GCODE          = src_filter=+<src/gcode/calibrate/M425.cpp>
 IS_KINEMATIC            = src_filter=+<src/gcode/calibrate/M665.cpp>
 HAS_EXTRA_ENDSTOPS      = src_filter=+<src/gcode/calibrate/M666.cpp>
 SKEW_CORRECTION_GCODE   = src_filter=+<src/gcode/calibrate/M852.cpp>
+DIRECT_PIN_CONTROL      = src_filter=+<src/gcode/control/M42.cpp> +<src/gcode/control/M226.cpp>
 PINS_DEBUGGING          = src_filter=-<src/gcode/config/M43.cpp>
 NO_VOLUMETRICS          = src_filter=-<src/gcode/config/M200-M205.cpp>
 HAS_MULTI_EXTRUDER      = src_filter=+<src/gcode/config/M217.cpp>


### PR DESCRIPTION
- Modify `inc/MarlinConfig*` files for use by `common-dependencies.h`.
- Fix handling of dependencies first mentioned in sub-environments.
- Fix `PINS_DEBUGGING` and `CASE_LIGHT_ENABLE` deps filters.
- Fix dependency filters for `anycubic_chiron` and `G76_M192_M871.cpp`.
- Add more dependency filters.
- Make `M42` / `M226` into optional features.
