### PR TITLE
Keep HAL tasks running during PID Autotune

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -637,6 +637,10 @@ volatile bool Temperature::raw_temps_ready = false;
 
         goto EXIT_M303;
       }
+
+      // Run HAL idle tasks
+      TERN_(HAL_IDLETASK, HAL_idletask());
+      // Run UI update
       TERN(DWIN_CREALITY_LCD, DWIN_Update(), ui.update());
     }
     wait_for_heatup = false;

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -640,6 +640,7 @@ volatile bool Temperature::raw_temps_ready = false;
 
       // Run HAL idle tasks
       TERN_(HAL_IDLETASK, HAL_idletask());
+
       // Run UI update
       TERN(DWIN_CREALITY_LCD, DWIN_Update(), ui.update());
     }


### PR DESCRIPTION
### Description

Pid autotune is a closed loop, so it needs to call some important idle task to keep everything up. It already did ui update. 

This PR add the call to HAL_idletask(). The main reason is when board use MSC, we need to call msc idle task periodycally (that is done by HAL_idletask).

### Benefits

Fix #19187

### Configurations

None

### Related Issues

#19187
