### PR TITLE
replace HAS_CHARACTER_LCD with HAS_MARLINUI_HD44780

### DIFF
--- a/Marlin/src/lcd/menu/menu_probe_offset.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_offset.cpp
@@ -94,7 +94,7 @@ void probe_offset_wizard_menu() {
   if ((SHORT_MANUAL_Z_MOVE) > 0.0f && (SHORT_MANUAL_Z_MOVE) < 0.1f) {
     extern const char NUL_STR[];
     SUBMENU_P(NUL_STR, []{ _goto_manual_move_z(float(SHORT_MANUAL_Z_MOVE)); });
-    MENU_ITEM_ADDON_START(0 + ENABLED(HAS_CHARACTER_LCD));
+    MENU_ITEM_ADDON_START(0 + ENABLED(HAS_MARLINUI_HD44780));
       char tmp[20], numstr[10];
       // Determine digits needed right of decimal
       const uint8_t digs = !UNEAR_ZERO((SHORT_MANUAL_Z_MOVE) * 1000 - int((SHORT_MANUAL_Z_MOVE) * 1000)) ? 4 :


### PR DESCRIPTION
### Requirements

A HAS_MARLINUI_HD44780 based display

### Description

replace a missed/regressed HAS_CHARACTER_LCD with HAS_MARLINUI_HD44780

### Benefits

Code should do as it is meant to for HAS_MARLINUI_HD44780 displays

### Related Issues

Initial PR that renamed this https://github.com/MarlinFirmware/Marlin/pull/19533 