### PR TITLE
Fix HAL/STM32 FastIO macros

### DIFF
--- a/Marlin/src/HAL/STM32/fastio.h
+++ b/Marlin/src/HAL/STM32/fastio.h
@@ -51,15 +51,15 @@ void FastIO_init(); // Must be called before using fast io macros
 
 #if defined(STM32F0xx) || defined(STM32F1xx) || defined(STM32F3xx) || defined(STM32L0xx) || defined(STM32L4xx)
   #define _WRITE(IO, V) do { \
-    if (V) FastIOPortMap[STM_PORT(digitalPin[IO])]->BSRR = _BV32(digitalPinToPinName(IO) & 0x1F) ; \
-    else   FastIOPortMap[STM_PORT(digitalPin[IO])]->BRR  = _BV32(digitalPinToPinName(IO) & 0x1F) ; \
+    if (V) FastIOPortMap[STM_PORT(digitalPin[IO])]->BSRR = _BV32(STM_PIN(digitalPin[IO])) ; \
+    else   FastIOPortMap[STM_PORT(digitalPin[IO])]->BRR  = _BV32(STM_PIN(digitalPin[IO])) ; \
   }while(0)
 #else
-  #define _WRITE(IO, V) (FastIOPortMap[STM_PORT(digitalPin[IO])]->BSRR = _BV32(digitalPinToPinName(IO) + ((V) ? 0 : 16)))
+  #define _WRITE(IO, V) (FastIOPortMap[STM_PORT(digitalPin[IO])]->BSRR = _BV32(STM_PIN(digitalPin[IO]) + ((V) ? 0 : 16)))
 #endif
 
-#define _READ(IO)               bool(READ_BIT(FastIOPortMap[STM_PORT(digitalPin[IO])]->IDR, _BV32(digitalPinToPinName(IO) & 0x1F)))
-#define _TOGGLE(IO)             (FastIOPortMap[STM_PORT(digitalPin[IO])]->ODR ^= _BV32(digitalPinToPinName(IO) & 0x1F))
+#define _READ(IO)               bool(READ_BIT(FastIOPortMap[STM_PORT(digitalPin[IO])]->IDR, _BV32(STM_PIN(digitalPin[IO]))))
+#define _TOGGLE(IO)             (FastIOPortMap[STM_PORT(digitalPin[IO])]->ODR ^= _BV32(STM_PIN(digitalPin[IO])))
 
 #define _GET_MODE(IO)
 #define _SET_MODE(IO,M)         pinMode(IO, M)


### PR DESCRIPTION
### Description

Go back to the original correct code. In the STM documentation: 

High nibble = port number (FirstPort <= PortName <= LastPort)
Low nibble  = pin number. 

So it must be 0xF, no 0x1F.


### Benefits

Fix #19677

### Related Issues

#19677 
#19614
