### PR TITLE
Allow build flags per folder/files/any match

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -2,6 +2,9 @@
 # common-cxxflags.py
 # Convenience script to apply customizations to CPP flags
 #
+
+import re
+
 Import("env")
 env.Append(CXXFLAGS=[
   "-Wno-register"
@@ -10,3 +13,23 @@ env.Append(CXXFLAGS=[
   #"-Wno-maybe-uninitialized",
   #"-Wno-sign-compare"
 ])
+
+
+# We can use it to apply custom compilation flags for individual folders or files
+def ignore_lcd_warnings(node):
+	"""
+	`node.name` - a name of File System Node
+	`node.get_path()` - a relative path
+	`node.get_abspath()` - an absolute path
+	"""
+	mat = re.match(r'.*\/LiquidCrystal\/.*', node.get_path())
+	if not mat:
+		return node
+
+	#print(node.get_path())
+	return env.Object(
+        node,
+        CCFLAGS=env["CCFLAGS"] + ["-Wno-comment"]
+    )
+
+env.AddBuildMiddleware(ignore_lcd_warnings)


### PR DESCRIPTION
### Description

Script to allow build flags per any kind of match (folder, files, etc).

As start, added the -Wno-comment to remove the warning while compiling LiquidCrystal library.

Suggestion from @sjasonsmith 

### Benefits

Custom build per folder/file
