### PR TITLE
Add ASSISTED_TRAMMING Z distance difference for each point

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -806,11 +806,9 @@
   #define TRAMMING_POINT_NAME_3 "Back-Right"
   #define TRAMMING_POINT_NAME_4 "Back-Left"
 
-  // Enable to restore leveling setup after operation
-  #define RESTORE_LEVELING_AFTER_G35
-
-  // Add a menu item for Assisted Tramming
-  //#define ASSISTED_TRAMMING_MENU_ITEM
+  #define RESTORE_LEVELING_AFTER_G35    // Enable to restore leveling setup after operation
+  //#define REPORT_TRAMMING_MM          // Report Z deviation (mm) for each point relative to the first
+  //#define ASSISTED_TRAMMING_MENU_ITEM // Add a menu item for Assisted Tramming
 
   /**
    * Screw thread:
@@ -819,10 +817,6 @@
    *   M5: 50 = Clockwise, 51 = Counter-Clockwise
    */
   #define TRAMMING_SCREW_THREAD 30
-
-  // Show Z distance (mm) difference for each point, compared to the first point
-  //#define TRAMMING_POINT_Z_DISTANCE
-
 #endif
 
 // @section motion

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -817,6 +817,7 @@
    *   M5: 50 = Clockwise, 51 = Counter-Clockwise
    */
   #define TRAMMING_SCREW_THREAD 30
+
 #endif
 
 // @section motion

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -820,6 +820,9 @@
    */
   #define TRAMMING_SCREW_THREAD 30
 
+  // Show Z distance (mm) difference for each point, compared to the first point
+  //#define TRAMMING_POINT_Z_DISTANCE
+
 #endif
 
 // @section motion

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -160,7 +160,7 @@ void GcodeSuite::G35() {
              " ", (screw_thread & 1) == (adjust > 0) ? "CCW" : "CW",
              " by ", abs(full_turns), " turns");
       if (minutes) SERIAL_ECHOPAIR(" and ", abs(minutes), " minutes");
-      if ENABLED(TRAMMING_POINT_Z_DISTANCE) SERIAL_ECHOPAIR(", Diff: ", (diff * -1));
+      if (ENABLED(TRAMMING_POINT_Z_DISTANCE)) SERIAL_ECHOPAIR(" (", -diff, "mm)");
       SERIAL_EOL();
     }
   }

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -160,6 +160,7 @@ void GcodeSuite::G35() {
              " ", (screw_thread & 1) == (adjust > 0) ? "CCW" : "CW",
              " by ", abs(full_turns), " turns");
       if (minutes) SERIAL_ECHOPAIR(" and ", abs(minutes), " minutes");
+      if ENABLED(TRAMMING_POINT_Z_DISTANCE) SERIAL_ECHOPAIR(", Diff: ", (diff * -1));
       SERIAL_EOL();
     }
   }

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -160,7 +160,7 @@ void GcodeSuite::G35() {
              " ", (screw_thread & 1) == (adjust > 0) ? "CCW" : "CW",
              " by ", abs(full_turns), " turns");
       if (minutes) SERIAL_ECHOPAIR(" and ", abs(minutes), " minutes");
-      if (ENABLED(TRAMMING_POINT_Z_DISTANCE)) SERIAL_ECHOPAIR(" (", -diff, "mm)");
+      if (ENABLED(REPORT_TRAMMING_MM)) SERIAL_ECHOPAIR(" (", -diff, "mm)");
       SERIAL_EOL();
     }
   }


### PR DESCRIPTION
### Requirements

None.

### Description

Adds `REPORT_TRAMMING_MM` to show Z distance (mm) difference for each point, compared to the first point.

### Benefits

Z distance (mm) difference can be seen, even if it shows 0 turn/minute, for more precise bed tramming.

### Configurations

Don't need anything else.

### Related Issues

None.