### PR TITLE
Fix HAS_TOUCH_XPT2046 feature detection

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.h
@@ -113,3 +113,10 @@
     #define HAS_MENU_UBL
   #endif
 #endif
+
+// This is currently defined only in some HALs
+#if ENABLED(TOUCH_SCREEN) && !HAS_GRAPHICAL_TFT
+  #undef TOUCH_SCREEN
+  #undef TOUCH_SCREEN_CALIBRATION
+  #define HAS_TOUCH_XPT2046 1
+#endif


### PR DESCRIPTION
### Description

`HAS_TOUCH_XPT2046` was not set property during dependency detection, since it is set inside the HAL's Conditionals_LCD file.
This prevented the necessary CPP files from being compiled to successfully link firmware using this feature.

An alternate solution would be to move the definition of HAS_TOUCH_XPT2046 out of HAL-specific files, even though not all HALs support it.

### Benefits

Fixes building the Tronxy/X5SA example.

### Configurations

Tronxy/X5SA from Marlin examples

### Related Issues

N/A
