### PR TITLE
Do not rely on probe settings when a probe is not present

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1127,8 +1127,7 @@ bool homing_needed_error(uint8_t axis_bits/*=0x07*/) {
  */
 feedRate_t get_homing_bump_feedrate(const AxisEnum axis) {
   #if HOMING_Z_WITH_PROBE
-    if (axis == Z_AXIS)
-      return MMM_TO_MMS(Z_PROBE_SPEED_SLOW);
+    if (axis == Z_AXIS) return MMM_TO_MMS(Z_PROBE_SPEED_SLOW);
   #endif
   static const uint8_t homing_bump_divisor[] PROGMEM = HOMING_BUMP_DIVISOR;
   uint8_t hbd = pgm_read_byte(&homing_bump_divisor[axis]);

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -510,12 +510,7 @@ void do_z_clearance(const float &zclear, const bool z_known/*=true*/, const bool
   const bool rel = raise_on_unknown && !z_known;
   float zdest = zclear + (rel ? current_position.z : 0.0f);
   if (!lower_allowed) NOLESS(zdest, current_position.z);
-  do_blocking_move_to_z(_MIN(zdest, Z_MAX_POS),
-  #if HAS_BED_PROBE
-    MMM_TO_MMS(Z_PROBE_SPEED_FAST));
-  #else
-    MMM_TO_MMS(HOMING_FEEDRATE_Z));
-  #endif
+  do_blocking_move_to_z(_MIN(zdest, Z_MAX_POS), MMM_TO_MMS(TERN(HAS_BED_PROBE, Z_PROBE_SPEED_FAST, HOMING_FEEDRATE_Z)));
 }
 
 //


### PR DESCRIPTION
### Description

Do not rely on `Z_PROBE_SPEED_SLOW` and `Z_PROBE_SPEED_FAST` when the configuration does not need a probe.

These are typically present even when there is no probe, but it is logical to anybody reading the Configuration file that they should not be necessary if the system has no probe. This removes the requirement that a probeless system must provide probe speeds.

### Benefits

Fixes ANET/A2 example compilation and any other configurations which don't define probe speeds.

### Configurations

ANET/A2 example

### Related Issues

N/A
