### PR TITLE
cast I2C_ADDRESS to uint8_t, to avoid ambiguous call warnings

### DIFF
--- a/Marlin/src/HAL/HAL.h
+++ b/Marlin/src/HAL/HAL.h
@@ -34,7 +34,7 @@
 #define HAL_ADC_RANGE _BV(HAL_ADC_RESOLUTION)
 
 #ifndef I2C_ADDRESS
-  #define I2C_ADDRESS(A) (A)
+  #define I2C_ADDRESS(A) uint8_t(A)
 #endif
 
 // Needed for AVR sprintf_P PROGMEM extension


### PR DESCRIPTION
### Description

When building some examples I encountered the following warnings related to ambiguous calls. When I examined the candidate functions I found that the `int` versions were simply casting to `uint8_t` and calling the `uint8_t` version, so I decided to force this to use `uint8_t` everywhere.

```
Marlin/src/feature/dac/dac_mcp4728.cpp: In function 'void mcp4728_init()':
Marlin/src/feature/dac/dac_mcp4728.cpp:46:61: warning: ISO C++ says that these are ambiguous, even though the worst conversion for the first is better than the worst conversion for the second:
   Wire.requestFrom(I2C_ADDRESS(DAC_DEV_ADDRESS), uint8_t(24));
                                                             ^
In file included from Marlin/src/feature/dac/dac_mcp4728.h:30:0,
                 from Marlin/src/feature/dac/dac_mcp4728.cpp:37:
/home/jassmith/.platformio/packages/framework-arduino-avr/libraries/Wire/src/Wire.h:64:13: note: candidate 1: uint8_t TwoWire::requestFrom(int, int)
     uint8_t requestFrom(int, int);
             ^
/home/jassmith/.platformio/packages/framework-arduino-avr/libraries/Wire/src/Wire.h:61:13: note: candidate 2: uint8_t TwoWire::requestFrom(uint8_t, uint8_t)
     uint8_t requestFrom(uint8_t, uint8_t);
             ^
```

### Benefits

Eliminate a fairly worrying looking warning.

### Configurations

I unfortunately did not record which example I was compiling when I encountered this, but it is not the first time I have happened upon it.

### Related Issues

This was mentioned in #18019, and a fix was applied but it only impacted the LPC1768 HAL at the time.
