### PR TITLE
Fix at90usb1286 builds

### DIFF
--- a/Marlin/src/HAL/AVR/HAL.h
+++ b/Marlin/src/HAL/AVR/HAL.h
@@ -25,7 +25,7 @@
 #include "watchdog.h"
 #include "math.h"
 
-#ifdef USBCON
+#ifdef IS_AT90USB
   #include <HardwareSerial.h>
 #else
   #define HardwareSerial_h // Hack to prevent HardwareSerial.h header inclusion
@@ -81,7 +81,7 @@ typedef int8_t pin_t;
 //extern uint8_t MCUSR;
 
 // Serial ports
-#ifdef USBCON
+#ifdef IS_AT90USB
   #define MYSERIAL0 TERN(BLUETOOTH, bluetoothSerial, Serial)
 #else
   #if !WITHIN(SERIAL_PORT, -1, 3)

--- a/Marlin/src/HAL/AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/AVR/MarlinSerial.cpp
@@ -38,7 +38,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if !defined(USBCON) && (defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(UBRR2H) || defined(UBRR3H))
+#if !IS_AT90USB && (defined(UBRRH) || defined(UBRR0H) || defined(UBRR1H) || defined(UBRR2H) || defined(UBRR3H))
 
 #include "MarlinSerial.h"
 #include "../../MarlinCore.h"
@@ -792,10 +792,10 @@ MarlinSerial<MarlinSerialCfg<SERIAL_PORT>> customizedSerial1;
 
 #endif
 
-#endif // !USBCON && (UBRRH || UBRR0H || UBRR1H || UBRR2H || UBRR3H)
+#endif // !IS_AT90USB && (UBRRH || UBRR0H || UBRR1H || UBRR2H || UBRR3H)
 
 // For AT90USB targets use the UART for BT interfacing
-#if defined(USBCON) && ENABLED(BLUETOOTH)
+#if BOTH(IS_AT90USB, BLUETOOTH)
   HardwareSerial bluetoothSerial;
 #endif
 

--- a/Marlin/src/HAL/AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/AVR/MarlinSerial.h
@@ -327,6 +327,6 @@
 #endif
 
 // Use the UART for Bluetooth in AT90USB configurations
-#if defined(USBCON) && ENABLED(BLUETOOTH)
+#if BOTH(IS_AT90USB, BLUETOOTH)
   extern HardwareSerial bluetoothSerial;
 #endif

--- a/Marlin/src/HAL/STM32F1/dogm/u8g_com_stm32duino_swspi.cpp
+++ b/Marlin/src/HAL/STM32F1/dogm/u8g_com_stm32duino_swspi.cpp
@@ -22,7 +22,6 @@
 
 #if BOTH(HAS_MARLINUI_U8GLIB, FORCE_SOFT_SPI)
 
-#include "../HAL.h"
 #include <U8glib.h>
 
 #undef SPI_SPEED
@@ -161,5 +160,5 @@ uint8_t u8g_com_HAL_STM32F1_sw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, 
   return 1;
 }
 
-#endif // HAS_MARLINUI_U8GLIB
+#endif // HAS_MARLINUI_U8GLIB && FORCE_SOFT_SPI
 #endif // STM32F1

--- a/Marlin/src/gcode/control/M111.cpp
+++ b/Marlin/src/gcode/control/M111.cpp
@@ -55,7 +55,7 @@ void GcodeSuite::M111() {
   }
   else {
     SERIAL_ECHOPGM(STR_DEBUG_OFF);
-    #if !defined(__AVR__) || !defined(USBCON)
+    #if !IS_AT90USB
       #if ENABLED(SERIAL_STATS_RX_BUFFER_OVERRUNS)
         SERIAL_ECHOPAIR("\nBuffer Overruns: ", MYSERIAL0.buffer_overruns());
       #endif
@@ -71,7 +71,7 @@ void GcodeSuite::M111() {
       #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
         SERIAL_ECHOPAIR("\nMax RX Queue Size: ", MYSERIAL0.rxMaxEnqueued());
       #endif
-    #endif //  !defined(__AVR__) || !defined(USBCON)
+    #endif // !IS_AT90USB
   }
   SERIAL_EOL();
 }

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -624,7 +624,7 @@ void GCodeQueue::advance() {
         card.closefile();
         SERIAL_ECHOLNPGM(STR_FILE_SAVED);
 
-        #if !defined(__AVR__) || !defined(USBCON)
+        #if !IS_AT90USB
           #if ENABLED(SERIAL_STATS_DROPPED_RX)
             SERIAL_ECHOLNPAIR("Dropped bytes: ", MYSERIAL0.dropped());
           #endif

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -208,7 +208,10 @@
   #define NEEDS_HARDWARE_PWM 1
 #endif
 
-#if !defined(__AVR__) || !defined(USBCON)
+#if defined(__AVR__) && defined(USBCON)
+  #define IS_AT90USB 1
+  #undef SERIAL_XON_XOFF // Not supported on USB-native devices
+#else
   // Define constants and variables for buffering serial data.
   // Use only 0 or powers of 2 greater than 1
   // : [0, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, ...]
@@ -220,9 +223,6 @@
   #ifndef TX_BUFFER_SIZE
     #define TX_BUFFER_SIZE 32
   #endif
-#else
-  // SERIAL_XON_XOFF not supported on USB-native devices
-  #undef SERIAL_XON_XOFF
 #endif
 
 #if ENABLED(HOST_ACTION_COMMANDS)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -582,7 +582,7 @@
 /**
  * Serial
  */
-#if !(defined(__AVR__) && defined(USBCON))
+#if !IS_AT90USB
   #if ENABLED(SERIAL_XON_XOFF) && RX_BUFFER_SIZE < 1024
     #error "SERIAL_XON_XOFF requires RX_BUFFER_SIZE >= 1024 for reliable transfers without drops."
   #elif RX_BUFFER_SIZE && (RX_BUFFER_SIZE < 2 || !IS_POWER_OF_2(RX_BUFFER_SIZE))
@@ -2104,9 +2104,9 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #endif
 
 /**
- * emergency-command parser
+ * Emergency Command Parser
  */
-#if ENABLED(EMERGENCY_PARSER) && defined(__AVR__) && defined(USBCON)
+#if BOTH(IS_AT90USB, EMERGENCY_PARSER)
   #error "EMERGENCY_PARSER does not work on boards with AT90USB processors (USBCON)."
 #endif
 

--- a/Marlin/src/pins/teensy2/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/src/pins/teensy2/pins_PRINTRBOARD_REVF.h
@@ -67,6 +67,10 @@
   #error "Oops! Select 'Teensy++ 2.0' or 'Printrboard' in 'Tools > Board.'"
 #endif
 
+#if !defined(__MARLIN_DEPS__) && !defined(USBCON)
+  #error "USBCON should be defined by the platform for this board."
+#endif
+
 #define BOARD_INFO_NAME "Printrboard Rev.F"
 
 // Disable JTAG pins so EXP1 pins work correctly

--- a/Marlin/src/pins/teensy2/pins_PRINTRBOARD_REVF.h
+++ b/Marlin/src/pins/teensy2/pins_PRINTRBOARD_REVF.h
@@ -67,10 +67,6 @@
   #error "Oops! Select 'Teensy++ 2.0' or 'Printrboard' in 'Tools > Board.'"
 #endif
 
-#ifndef USBCON
-  #error "USBCON should be defined by the platform for this board."
-#endif
-
 #define BOARD_INFO_NAME "Printrboard Rev.F"
 
 // Disable JTAG pins so EXP1 pins work correctly

--- a/platformio.ini
+++ b/platformio.ini
@@ -557,6 +557,7 @@ build_unflags = -g -ggdb
 platform      = teensy
 extends       = common_avr8
 board         = at90usb1286
+lib_ignore    = ${env:common_avr8.lib_ignore} Teensy_ADC
 
 #
 # AT90USB1286 boards using DFU bootloader


### PR DESCRIPTION
### Description

Fix two issues impacting at90usb1286 builds:

1. The test for `USBCON` in the pins file. This caused problems with the new code added in #19468, and didn't really seem to be important for the pins file. As far as I can tell `USBCON` is actually a framework resource, and not a flag to be turned on or off.

2. Ignore the Teensy_ADC library, which cannot compile for these boards. This is being detected as a dependency when building in VS Code on Windows, but not when building from Linux. I don't really have an explanation for this, but it happened even after I cleared out all PIO resources and reinstalled.

I have not actually tested these myself beyond building.

### Benefits

Allows building for Printerboard and other at90usb1286 bpards.

### Configurations

Refer to attached bug report.

### Related Issues

#19592 
