### PR TITLE
Option to disable Watchdog Init call for STM32

### DIFF
--- a/Marlin/src/HAL/STM32/watchdog.cpp
+++ b/Marlin/src/HAL/STM32/watchdog.cpp
@@ -30,7 +30,11 @@
   #include "watchdog.h"
   #include <IWatchdog.h>
 
-  void watchdog_init() { IWatchdog.begin(4000000); } // 4 sec timeout
+  void watchdog_init() {
+    #if DISABLED(DISABLE_WATCHDOG_INIT)
+      IWatchdog.begin(4000000); // 4 sec timeout
+    #endif
+  }
 
   void HAL_watchdog_refresh() {
     IWatchdog.reload();

--- a/Marlin/src/HAL/STM32F1/watchdog.cpp
+++ b/Marlin/src/HAL/STM32F1/watchdog.cpp
@@ -52,7 +52,9 @@ void watchdogSetup() {
  * @details The watchdog clock is 40Khz. We need a 4 seconds interval, so use a /256 preescaler and 625 reload value (counts down to 0)
  */
 void watchdog_init() {
-  //iwdg_init(IWDG_PRE_256, STM32F1_WD_RELOAD);
+  #if DISABLED(DISABLE_WATCHDOG_INIT)
+    iwdg_init(IWDG_PRE_256, STM32F1_WD_RELOAD);
+  #endif
 }
 
 #endif // USE_WATCHDOG

--- a/Marlin/src/pins/stm32f1/pins_MALYAN_M200.h
+++ b/Marlin/src/pins/stm32f1/pins_MALYAN_M200.h
@@ -33,6 +33,9 @@
   #define BOARD_INFO_NAME "Malyan M200"
 #endif
 
+// Prevents hanging from an extra watchdog init
+#define DISABLE_WATCHDOG_INIT
+
 // Assume Flash EEPROM
 #if NO_EEPROM_SELECTED
   #define FLASH_EEPROM_EMULATION
@@ -90,5 +93,3 @@
 #define MALYAN_FAN2_PIN                     PB3   // FAN2 header on board - CONTROLLER FAN
 
 #define FAN1_PIN                 MALYAN_FAN2_PIN
-
-#define DISABLE_WATCHDOG_INIT

--- a/Marlin/src/pins/stm32f1/pins_MALYAN_M200.h
+++ b/Marlin/src/pins/stm32f1/pins_MALYAN_M200.h
@@ -90,3 +90,5 @@
 #define MALYAN_FAN2_PIN                     PB3   // FAN2 header on board - CONTROLLER FAN
 
 #define FAN1_PIN                 MALYAN_FAN2_PIN
+
+#define DISABLE_WATCHDOG_INIT


### PR DESCRIPTION
### Description

This re-enable watchdog for STM32F1 (that is disabled...) and add an option for the boards disable the init call.

Double init call hang the board. And some board have HW watchdog enabled, or even initialised by the bootloader.

The best approach would be detect it. But it seems fair complex. So this PR is a simple fix to allow we re-enabled watchdog in stm32f1 that is disabled for some time...

Added the option for Maylan M200 as a sample, as in the issue is said that it hangs.

### Benefits

Fix #18226

### Related Issues

#18226
