### PR TITLE
Fix wait_for_user in the Color UI

### DIFF
--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -46,6 +46,10 @@
   #include "../../lcd/extui/ui_api.h"
 #endif
 
+#if HAS_RESUME_CONTINUE
+  #include "../../lcd/ultralcd.h"
+#endif
+
 #ifndef GET_PIN_MAP_PIN_M43
   #define GET_PIN_MAP_PIN_M43(Q) GET_PIN_MAP_PIN(Q)
 #endif
@@ -362,7 +366,10 @@ void GcodeSuite::M43() {
         }
       }
 
-      if (TERN0(HAS_RESUME_CONTINUE, !wait_for_user)) break;
+      #if HAS_RESUME_CONTINUE
+        ui.update();
+        if (!wait_for_user) break;
+      #endif
 
       safe_delay(200);
     }

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -50,6 +50,9 @@ touch_calibration_t Touch::calibration;
   calibrationState Touch::calibration_state = CALIBRATION_NONE;
   touch_calibration_point_t Touch::calibration_points[4];
 #endif
+#if HAS_RESUME_CONTINUE
+  extern bool wait_for_user;
+#endif
 
 void Touch::init() {
   calibration_reset();
@@ -80,6 +83,15 @@ void Touch::idle() {
   now = millis();
 
   if (get_point(&_x, &_y)) {
+    #if HAS_RESUME_CONTINUE
+      // UI is waiting for a click anywhere?
+      if (wait_for_user) {
+        touch_control_type = CLICK;
+        ui.lcd_clicked = true;
+        return;
+      }
+    #endif
+
     #if LCD_TIMEOUT_TO_STATUS
       ui.return_to_status_ms = now + LCD_TIMEOUT_TO_STATUS;
     #endif


### PR DESCRIPTION
### Description

Some marlin operations just wait for a encoder click, without any specific screen.

This PR makes the color ui handle it.

### Benefits

Fix #19627 

### Related Issues

#19627 
