### PR TITLE
Allow configuration of MAX31865 resistance values

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -432,6 +432,12 @@
 #define DUMMY_THERMISTOR_998_VALUE 25
 #define DUMMY_THERMISTOR_999_VALUE 100
 
+// Resistor values when using a MAX31865 (sensor -5)
+// Sensor value is typically 100 (PT100) or 1000 (PT1000)
+// Calibration value is typically 430 ohm for AdaFruit PT100 modules and 4300 ohm for AdaFruit PT1000 modules.
+//#define MAX31865_SENSOR_OHMS      100
+//#define MAX31865_CALIBRATION_OHMS 430
+
 // Use temp sensor 1 as a redundant sensor with sensor 0. If the readings
 // from the two sensors differ too much the print will be aborted.
 //#define TEMP_SENSOR_1_AS_REDUNDANT

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1845,6 +1845,10 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
   #error "TEMP_SENSOR_1 is required with TEMP_SENSOR_1_AS_REDUNDANT."
 #endif
 
+#if ENABLED(MAX6675_IS_MAX31865) && (!defined(MAX31865_SENSOR_OHMS) || !defined(MAX31865_CALIBRATION_OHMS))
+  #error "MAX31865_SENSOR_OHMS and MAX31865_CALIBRATION_OHMS must be set in Configuration.h when using a MAX31865 temperature sensor."
+#endif
+
 /**
  * Test Heater, Temp Sensor, and Extruder Pins
  */

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1461,7 +1461,7 @@ void Temperature::manage_heater() {
         #elif ENABLED(HEATER_0_USES_MAX6675)
           return (
             #if ENABLED(MAX6675_IS_MAX31865)
-              max31865.temperature(100, 400)  // 100 ohms = PT100 resistance. 400 ohms = calibration resistor
+              max31865.temperature(MAX31865_SENSOR_OHMS, MAX31865_CALIBRATION_OHMS)
             #else
               raw * 0.25
             #endif
@@ -2236,7 +2236,7 @@ void Temperature::disable_all_heaters() {
     next_max6675_ms[hindex] = ms + MAX6675_HEAT_INTERVAL;
 
     #if ENABLED(MAX6675_IS_MAX31865)
-      max6675_temp = int(max31865.temperature(100, 400)); // 100 ohms = PT100 resistance. 400 ohms = calibration resistor
+      max6675_temp = int(max31865.temperature(MAX31865_SENSOR_OHMS, MAX31865_CALIBRATION_OHMS));
     #endif
 
     //


### PR DESCRIPTION
### Description

MAX31865 Sensor and Calibration resistor values are currently hard-coded to 100 and 400 ohms, respectively. This corresponds to the datasheet reference resistance for a PT100.

Unfortunately, this hard-coded value does not match what is commonly used on readily available hardware, such as those from AdaFruit.

The problem could be solved for AdaFruit boards by simply changing the hard-coded values, but that risks changing behavior on every existing MAX31865 user without notice, and it is hard to know if some boards are actually using 400 ohm resistors.

**I have not tested this at all. I do not have this hardware, I am purely doing this to present one possible solution to an issue reported by several users. I would greatly appreciate input from @Bob-the-Kuhn or @AnHardt who seem to have past experience with these parts.**

### Benefits

1. Allows configuration of correct resistance values without having to dig through code to find the values to change.
2. Sanity check forces all existing users to uncomment and add the new settings, so they are aware that a change may have occurred.

### Configurations

As mentioned, I did not actually test this, since I do not have the hardware. I utilized configuration files from #18809, although those are excessively modified.

The only real change needed to build these in is to set a TEMP_SENSOR to -5.

### Related Issues

#18809 
