### PR TITLE
Sanity-check mutually-exclusive G34 features

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2807,6 +2807,10 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
   #endif
 #endif
 
+#if BOTH(Z_STEPPER_AUTO_ALIGN, MECHANICAL_GANTRY_CALIBRATION)
+  #error "You cannot use Z_STEPPER_AUTO_ALIGN and MECHANICAL_GANTRY_CALIBRATION at the same time."
+#endif
+
 #if ENABLED(PRINTCOUNTER) && DISABLED(EEPROM_SETTINGS)
   #error "PRINTCOUNTER requires EEPROM_SETTINGS. Please update your Configuration."
 #endif


### PR DESCRIPTION
### Description

Create a sanity check for when `Z_STEPPER_AUTO_ALIGN` and `MECHANICAL_GANTRY_CALIBRATION` are enabled at the same time since they both use `G34` and are used for different hardware configs.

### Benefits

Marlin will compile correctly.

<!-- What does this fix or improve? -->

### Configurations

Enable `Z_STEPPER_AUTO_ALIGN` and `MECHANICAL_GANTRY_CALIBRATION`.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/19702