### PR TITLE
Fix some utf8 issues in Color UI (for FR lang, for example)

### DIFF
--- a/Marlin/src/lcd/tft/tft_string.cpp
+++ b/Marlin/src/lcd/tft/tft_string.cpp
@@ -116,6 +116,17 @@ void TFT_String::add(uint8_t *string, int8_t index, uint8_t *itemString) {
   eol();
 }
 
+void TFT_String::add(uint8_t *string) {
+  wchar_t wchar;
+  while (*string) {
+    string = get_utf8_value_cb(string, read_byte, &wchar);
+    if (wchar > 255) wchar |= 0x0080;
+    uint8_t ch = uint8_t(wchar & 0x00FF);
+    add_character(ch);
+  }
+  eol();
+}
+
 void TFT_String::add_character(uint8_t character) {
   if (length < MAX_STRING_LENGTH) {
     data[length] = character;

--- a/Marlin/src/lcd/tft/tft_string.h
+++ b/Marlin/src/lcd/tft/tft_string.h
@@ -85,7 +85,7 @@ class TFT_String {
 
     static void set();
     static void add(uint8_t character) { add_character(character); eol(); }
-    static void add(uint8_t *string) { while (*string) { add_character(*string++); } eol(); }
+    static void add(uint8_t *string);
     static void add(uint8_t *string, int8_t index, uint8_t *itemString = NULL);
     static void set(uint8_t *string) { set(); add(string); };
     static void set(uint8_t *string, int8_t index, const char *itemString = NULL) { set(); add(string, index, (uint8_t *)itemString); };


### PR DESCRIPTION
### Description

It fix some string draws of color ui that aren't handling utf8. 

@tpruvot can you test it? To see if I forgot some other calls...

### Benefits

FR and others langs working with color ui.

