### PR TITLE
If needed, home before G34

### DIFF
--- a/Marlin/src/gcode/calibrate/G34.cpp
+++ b/Marlin/src/gcode/calibrate/G34.cpp
@@ -38,7 +38,8 @@
 
 void GcodeSuite::G34() {
 
-  if (homing_needed()) return;
+  // Home before the alignment procedure
+  if (!all_axes_known()) home_all_axes();
 
   SET_SOFT_ENDSTOP_LOOSE(true);
   TEMPORARY_BED_LEVELING_STATE(false);


### PR DESCRIPTION
### Description

If XYZ are unknown before `G34`, the calibration routine exits with no information sent to the LCD or serial (and `GANTRY_CALIBRATION_COMMANDS_PRE` isn't executed, so you can't include a `G28` there).

This will now home all before proceeding if not all axes are known, just like what's done in other bed leveling/calibration procedures.

Alternatively, you could achieve a similar outcome by changing the `G34` menu item in [`menu_motion.cpp`](https://github.com/MarlinFirmware/Marlin/blob/da79674f84ef65cb014288a27d60f8709b1f0936/Marlin/src/lcd/menu/menu_motion.cpp#L339-L344) to include a `G28 O`, but I wasn't sure which would be prefered since it's done a few different ways in the code & not everyone will be using an LCD to start the process.

### Benefits

Procedure will complete as expected.

### Configurations

Enable `Z_STEPPER_AUTO_ALIGN` or `MECHANICAL_GANTRY_CALIBRATION`.

### Related Issues

None.
