### PR TITLE
Configuration_adv.h: disable LASER_POWER_INLINE

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2958,7 +2958,7 @@
      * This allows the laser to keep in perfect sync with the planner and removes
      * the powerup/down delay since lasers require negligible time.
      */
-    #define LASER_POWER_INLINE
+    //#define LASER_POWER_INLINE
 
     #if ENABLED(LASER_POWER_INLINE)
       /**


### PR DESCRIPTION
Attempt 2 at https://github.com/MarlinFirmware/Marlin/pull/19726

LASER_POWER_INLINE causes many laser cuter GCode generators to be none functional in 'marlin' mode. LightBurn in my case. #18965 #18965 (comment)

