### PR TITLE
Fix mega2560ext

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -445,7 +445,7 @@ board               = megaatmega2560
 #
 [env:mega2560ext]
 platform            = atmelavr
-extends             = mega2560
+extends             = env:mega2560
 board               = megaatmega2560
 board_build.variant = megaextendedpins
 extra_scripts       = ${common.extra_scripts}


### PR DESCRIPTION
### Description

The mega2560ext environment was not properly extending from mega2560.
I noticed this because it was building all source files, causing linking to fail due to path lengths on Windows.

### Benefits

Utilizes shared configuration such as source filtering and dependency detection.

### Configurations

I noticed this when building the FlashForge/CreatorPro example, although any mega2560ext build was impacted.

### Related Issues

N/A
