### PR TITLE
Fix digipot compilation

### DIFF
--- a/Marlin/src/feature/digipot/digipot.h
+++ b/Marlin/src/feature/digipot/digipot.h
@@ -30,4 +30,4 @@ public:
   static void set_current(const uint8_t channel, const float current);
 };
 
-DigipotI2C digipot_i2c;
+extern DigipotI2C digipot_i2c;

--- a/Marlin/src/feature/digipot/digipot_mcp4018.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4018.cpp
@@ -99,4 +99,6 @@ void DigipotI2C::init() {
     set_current(i, pgm_read_float(&digipot_motor_current[i]));
 }
 
+DigipotI2C digipot_i2c;
+
 #endif // DIGIPOT_MCP4018

--- a/Marlin/src/feature/digipot/digipot_mcp4451.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4451.cpp
@@ -95,4 +95,6 @@ void DigipotI2C::init() {
     set_current(i, pgm_read_float(&digipot_motor_current[i]));
 }
 
+DigipotI2C digipot_i2c;
+
 #endif // DIGIPOT_MCP4451


### PR DESCRIPTION
### Description

The DigipotI2C class was instantiated in a header, causing multiple instances to be present when linking.

I made this declaration extern, and moved the instantiation into both possible CPP files.

### Benefits

Link does not fail.

### Configurations

Found when compiling the FlashForge/CreatorPro example.

### Related Issues

#19719
