### PR TITLE
Take an argument in the NOOP version of SET_SOFT_ENDSTOP_LOOSE

### DIFF
--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -198,7 +198,7 @@ inline float home_bump_mm(const AxisEnum axis) {
   extern soft_endstops_t soft_endstop;
   #define apply_motion_limits(V)        NOOP
   #define update_software_endstops(...) NOOP
-  #define SET_SOFT_ENDSTOP_LOOSE()      NOOP
+  #define SET_SOFT_ENDSTOP_LOOSE(V)     NOOP
 
 #endif // !HAS_SOFTWARE_ENDSTOPS
 


### PR DESCRIPTION
### Description

Accept an argument in the NOOP form of SET_SOFT_ENDSTOP_LOOSE.

### Benefits

Resolves compilation error.

### Configurations

This was mentioned in the PR linked below. I also ran into it when compiling one of the Marlin examples, but unfortunately did not record which one.

### Related Issues

#19681 (Issue was mentioned in this PR)
