### PR TITLE
Advanced pause compile without prevent cold extrusion #19463

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -132,8 +132,10 @@ static bool ensure_safe_temperature(const bool wait=true, const PauseMode mode=P
   DEBUG_SECTION(est, "ensure_safe_temperature", true);
   DEBUG_ECHOLNPAIR("... wait:", int(wait), " mode:", int(mode));
 
-  if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(active_extruder))
-    thermalManager.setTargetHotend(thermalManager.extrude_min_temp, active_extruder);
+  #if ENABLED(PREVENT_COLD_EXTRUSION)
+    if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(active_extruder))
+      thermalManager.setTargetHotend(thermalManager.extrude_min_temp, active_extruder);
+  #endif
 
   #if HAS_LCD_MENU
     lcd_pause_show_message(PAUSE_MESSAGE_HEATING, mode);


### PR DESCRIPTION
### Description
Added #if Enabled macro bracketing sensitive if statement that check non undeclared field ` thermalManager.targetTooColdToExtrude`
In [temerature.h](https://github.com/MarlinFirmware/Marlin/blob/8e1ea6a2fa1b90a58b4257eec9fbc2923adda680/Marlin/src/module/temperature.h#L320) field **extrude_min_temp** is declared conditionally in respect to **PREVENT_COLD_EXTRUSION**. This was not changed recently, yet how the **ensure_safe_temperature** handles this has changed:
[2.6.1](https://github.com/MarlinFirmware/Marlin/blob/ca194ca52ee63fe319305a79e396b8b013b4c935/Marlin/src/feature/pause.cpp#L122) no use of the field
2.0.7 and 2.0.x use that field:
[https://github.com/MarlinFirmware/Marlin/blob/da79674f84ef65cb014288a27d60f8709b1f0936/Marlin/src/feature/pause.cpp#L136](url)

### Benefits
Makes compilation working with Advanced Pause Feature enabled while Prevent Cold Extrusion disabled

### Related Issues

[#19463](https://github.com/MarlinFirmware/Marlin/issues/19463)
