### PR TITLE
Sanity check for unsupported emergency parser config

### DIFF
--- a/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32F1/inc/SanityCheck.h
@@ -51,3 +51,10 @@
 #if ENABLED(NEOPIXEL_LED)
   #error "NEOPIXEL_LED (Adafruit NeoPixel) is not supported for HAL/STM32F1. Comment out this line to proceed at your own risk!"
 #endif
+
+// Emergency Parser needs at least one serial with HardwareSerial or USBComposite.
+// The USBSerial maple don't allow any hook to implement EMERGENCY_PARSER.
+// And copy all USBSerial code to marlin space to support EMERGENCY_PARSER, when we have another options, don't worth it.
+#if ENABLED(EMERGENCY_PARSER) && !defined(USE_USB_COMPOSITE) && ((SERIAL_PORT == -1 && !defined(SERIAL_PORT_2)) || (SERIAL_PORT_2 == -1 && !defined(SERIAL_PORT)))
+  #error "EMERGENCY_PARSER is only supported by HardwareSerial or USBComposite in HAL/STM32F1."
+#endif


### PR DESCRIPTION
### Description

STM32F1 have:
 - HardwareSerial
 - USBSerial
 - USBComponsite 

Of these 3 class, HardwareSerial and USBComponsite already have support for Emergency Parser. But USBSerial not. 

This PR add a sanity check for that.

### Benefits

Avoid users using a invalid config.

### Related Issues

