### PR TITLE
M410 out of the UART IQR

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -221,6 +221,10 @@
   #include "feature/password/password.h"
 #endif
 
+#if ENABLED(EMERGENCY_PARSER)
+  #include "feature/e_parser.h"
+#endif
+
 PGMSTR(NUL_STR, "");
 PGMSTR(M112_KILL_STR, "M112 Shutdown");
 PGMSTR(G28_STR, "G28");
@@ -775,6 +779,14 @@ void idle(TERN_(ADVANCED_PAUSE_FEATURE, bool no_stepper_sleep/*=false*/)) {
 
   #if HAS_TFT_LVGL_UI
     LV_TASK_HANDLER();
+  #endif
+
+  #if ENABLED(EMERGENCY_PARSER)
+    if (emergency_parser.quickstop_by_M410) {
+      // quickstop_stepper will call idle, so we must set it to false to avoid infinite loop
+      emergency_parser.quickstop_by_M410 = false;
+      quickstop_stepper();
+    }
   #endif
 }
 

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -221,10 +221,6 @@
   #include "feature/password/password.h"
 #endif
 
-#if ENABLED(EMERGENCY_PARSER)
-  #include "feature/e_parser.h"
-#endif
-
 PGMSTR(NUL_STR, "");
 PGMSTR(M112_KILL_STR, "M112 Shutdown");
 PGMSTR(G28_STR, "G28");
@@ -779,14 +775,6 @@ void idle(TERN_(ADVANCED_PAUSE_FEATURE, bool no_stepper_sleep/*=false*/)) {
 
   #if HAS_TFT_LVGL_UI
     LV_TASK_HANDLER();
-  #endif
-
-  #if ENABLED(EMERGENCY_PARSER)
-    if (emergency_parser.quickstop_by_M410) {
-      // quickstop_stepper will call idle, so we must set it to false to avoid infinite loop
-      emergency_parser.quickstop_by_M410 = false;
-      quickstop_stepper();
-    }
   #endif
 }
 

--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -32,6 +32,7 @@
 
 // Static data members
 bool EmergencyParser::killed_by_M112, // = false
+     EmergencyParser::quickstop_by_M410,
      EmergencyParser::enabled;
 
 #if ENABLED(HOST_PROMPT_SUPPORT)

--- a/Marlin/src/feature/e_parser.h
+++ b/Marlin/src/feature/e_parser.h
@@ -63,6 +63,7 @@ public:
   };
 
   static bool killed_by_M112;
+  static bool quickstop_by_M410;
 
   #if ENABLED(HOST_PROMPT_SUPPORT)
     static uint8_t M876_reason;
@@ -168,7 +169,7 @@ public:
           if (enabled) switch (state) {
             case EP_M108: wait_for_user = wait_for_heatup = false; break;
             case EP_M112: killed_by_M112 = true; break;
-            case EP_M410: quickstop_stepper(); break;
+            case EP_M410: quickstop_by_M410 = true; break;
             #if ENABLED(HOST_PROMPT_SUPPORT)
               case EP_M876SN: host_response_handler(M876_reason); break;
             #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1032,8 +1032,15 @@ void Temperature::manage_heater() {
     if (!inited) return watchdog_refresh();
   #endif
 
-  if (TERN0(EMERGENCY_PARSER, emergency_parser.killed_by_M112))
-    kill(M112_KILL_STR, nullptr, true);
+  #if ENABLED(EMERGENCY_PARSER)
+    if (emergency_parser.killed_by_M112) kill(M112_KILL_STR, nullptr, true);
+
+    if (emergency_parser.quickstop_by_M410) {
+      // quickstop_stepper will call idle, so we must set it to false to avoid infinite loop
+      emergency_parser.quickstop_by_M410 = false;
+      quickstop_stepper();
+    }
+  #endif
 
   if (!raw_temps_ready) return;
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1036,8 +1036,7 @@ void Temperature::manage_heater() {
     if (emergency_parser.killed_by_M112) kill(M112_KILL_STR, nullptr, true);
 
     if (emergency_parser.quickstop_by_M410) {
-      // quickstop_stepper will call idle, so we must set it to false to avoid infinite loop
-      emergency_parser.quickstop_by_M410 = false;
+      emergency_parser.quickstop_by_M410 = false; // quickstop_stepper may call idle so clear this now!
       quickstop_stepper();
     }
   #endif


### PR DESCRIPTION
### Description

The Emergency Parser run inside the UART IRQ. So, the others IRQ (like temperature timer) will only run when EP returns.

For this reason, EP cannot run any command that depends on other IRQ.

As `quickstop_stepper()`, that depends on temperature timer, to finish and return.

This PR makes M410 exec in a async way (moved to idle), as other EP commands. This will allow the `quickstop_stepper()` run, while keep all other IRQ enabled and running too.

### Benefits

Fix #19490

### Configurations

Any board with EP enabled.

### Related Issues

#19490
