### PR TITLE
fix for dualx sudden layer shift (#19151)

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -221,8 +221,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
   #if ENABLED(DUAL_X_CARRIAGE)
     const int8_t saved_ext        = active_extruder;
     const bool saved_ext_dup_mode = extruder_duplication_enabled;
-    active_extruder = DXC_ext;
-    extruder_duplication_enabled = false;
+    set_duplication_enabled(false, DXC_ext);
   #endif
 
   // Slow Load filament
@@ -243,9 +242,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
   }
 
   #if ENABLED(DUAL_X_CARRIAGE)      // Tie the two extruders movement back together.
-    active_extruder = saved_ext;
-    extruder_duplication_enabled = saved_ext_dup_mode;
-    stepper.set_directions();
+    set_duplication_enabled(saved_ext_dup_mode, saved_ext);
   #endif
 
   #if ENABLED(ADVANCED_PAUSE_CONTINUOUS_PURGE)
@@ -437,17 +434,14 @@ bool pause_print(const float &retract, const xyz_pos_t &park_point, const float 
   #if ENABLED(DUAL_X_CARRIAGE)
     const int8_t saved_ext        = active_extruder;
     const bool saved_ext_dup_mode = extruder_duplication_enabled;
-    active_extruder = DXC_ext;
-    extruder_duplication_enabled = false;
+    set_duplication_enabled(false, DXC_ext);
   #endif
 
   if (unload_length)   // Unload the filament
     unload_filament(unload_length, show_lcd, PAUSE_MODE_CHANGE_FILAMENT);
 
   #if ENABLED(DUAL_X_CARRIAGE)
-    active_extruder = saved_ext;
-    extruder_duplication_enabled = saved_ext_dup_mode;
-    stepper.set_directions();
+    set_duplication_enabled(saved_ext_dup_mode, saved_ext);
   #endif
 
   return true;
@@ -493,8 +487,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
   #if ENABLED(DUAL_X_CARRIAGE)
     const int8_t saved_ext        = active_extruder;
     const bool saved_ext_dup_mode = extruder_duplication_enabled;
-    active_extruder = DXC_ext;
-    extruder_duplication_enabled = false;
+    set_duplication_enabled(false, DXC_ext);
   #endif
 
   // Wait for filament insert by user and press button
@@ -548,9 +541,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
     idle_no_sleep();
   }
   #if ENABLED(DUAL_X_CARRIAGE)
-    active_extruder = saved_ext;
-    extruder_duplication_enabled = saved_ext_dup_mode;
-    stepper.set_directions();
+    set_duplication_enabled(saved_ext_dup_mode, saved_ext);
   #endif
 }
 

--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -89,10 +89,11 @@ bool pause_print(const float &retract, const xyz_pos_t &park_point, const float 
 
 void wait_for_confirmation(const bool is_reload=false, const int8_t max_beep_count=0 DXC_PARAMS);
 
-void resume_print(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=ADVANCED_PAUSE_PURGE_LENGTH, const int8_t max_beep_count=0, int16_t targetTemp=0 DXC_PARAMS);
+void resume_print(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=ADVANCED_PAUSE_PURGE_LENGTH,
+                    const int8_t max_beep_count=0, int16_t targetTemp=0 DXC_PARAMS);
 
-bool load_filament(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=0, const int8_t max_beep_count=0, const bool show_lcd=false,
-                          const bool pause_for_user=false, const PauseMode mode=PAUSE_MODE_PAUSE_PRINT DXC_PARAMS);
+bool load_filament(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=0, const int8_t max_beep_count=0,
+                    const bool show_lcd=false, const bool pause_for_user=false, const PauseMode mode=PAUSE_MODE_PAUSE_PRINT DXC_PARAMS);
 
 bool unload_filament(const float &unload_length, const bool show_lcd=false, const PauseMode mode=PAUSE_MODE_PAUSE_PRINT
   #if BOTH(FILAMENT_UNLOAD_ALL_EXTRUDERS, MIXING_EXTRUDER)

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -237,7 +237,7 @@ class FilamentSensorBase {
         #if NUM_RUNOUT_SENSORS == 1
           UNUSED(extruder);
         #else
-          if ( !TERN0(DUAL_X_CARRIAGE, dxc_is_duplicating())
+          if ( !TERN0(DUAL_X_CARRIAGE, idex_is_duplicating())
             && !TERN0(MULTI_NOZZLE_DUPLICATION, extruder_duplication_enabled)
           ) return TEST(runout_states, extruder); // A specific extruder ran out
         #endif

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -110,9 +110,8 @@ void GcodeSuite::G35() {
     tool_change(0, true);
   #endif
 
-  #if HAS_DUPLICATION_MODE
-    extruder_duplication_enabled = false;
-  #endif
+  // Disable duplication mode on homing
+  TERN_(HAS_DUPLICATION_MODE, set_duplication_enabled(false));
 
   // Home all before this procedure
   home_all_axes();

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -134,8 +134,8 @@
 
       if (DEBUGGING(LEVELING)) DEBUG_POS("home_z_safely", destination);
 
-      // This causes the carriage on Dual X to unpark
-      TERN_(DUAL_X_CARRIAGE, active_extruder_parked = false);
+      // Free the active extruder for movement
+      TERN_(DUAL_X_CARRIAGE, idex_set_parked(false));
 
       TERN_(SENSORLESS_HOMING, safe_delay(500)); // Short delay needed to settle
 
@@ -342,16 +342,14 @@ void GcodeSuite::G28() {
         homeaxis(X_AXIS);
 
         // Remember this extruder's position for later tool change
-        inactive_extruder_x_pos = current_position.x;
+        inactive_extruder_x = current_position.x;
 
         // Home the 1st (left) extruder
         active_extruder = 0;
         homeaxis(X_AXIS);
 
-        // Consider the active extruder to be parked
-        raised_parked_position = current_position;
-        delayed_move_time = 0;
-        active_extruder_parked = true;
+        // Consider the active extruder to be in its "parked" position
+        idex_set_parked();
 
       #else
 
@@ -392,7 +390,7 @@ void GcodeSuite::G28() {
    */
   #if ENABLED(DUAL_X_CARRIAGE)
 
-    if (dxc_is_duplicating()) {
+    if (idex_is_duplicating()) {
 
       TERN_(IMPROVE_HOMING_RELIABILITY, slow_homing = begin_slow_homing());
 
@@ -401,16 +399,15 @@ void GcodeSuite::G28() {
       homeaxis(X_AXIS);
 
       // Remember this extruder's position for later tool change
-      inactive_extruder_x_pos = current_position.x;
+      inactive_extruder_x = current_position.x;
 
       // Home the 1st (left) extruder
       active_extruder = 0;
       homeaxis(X_AXIS);
 
       // Consider the active extruder to be parked
-      raised_parked_position = current_position;
-      delayed_move_time = 0;
-      active_extruder_parked = true;
+      idex_set_parked();
+
       dual_x_carriage_mode = IDEX_saved_mode;
       set_duplication_enabled(IDEX_saved_duplication_state);
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -282,7 +282,7 @@ void GcodeSuite::G28() {
     tool_change(0, true);
   #endif
 
-  TERN_(HAS_DUPLICATION_MODE, extruder_duplication_enabled = false);
+  TERN_(HAS_DUPLICATION_MODE, set_duplication_enabled(false));
 
   remember_feedrate_scaling_off();
 
@@ -411,9 +411,8 @@ void GcodeSuite::G28() {
       raised_parked_position = current_position;
       delayed_move_time = 0;
       active_extruder_parked = true;
-      extruder_duplication_enabled = IDEX_saved_duplication_state;
-      dual_x_carriage_mode         = IDEX_saved_mode;
-      stepper.set_directions();
+      dual_x_carriage_mode = IDEX_saved_mode;
+      set_duplication_enabled(IDEX_saved_duplication_state);
 
       TERN_(IMPROVE_HOMING_RELIABILITY, end_slow_homing(slow_homing));
     }

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -113,7 +113,7 @@ void GcodeSuite::G34() {
       tool_change(0, true);
     #endif
 
-    TERN_(HAS_DUPLICATION_MODE, extruder_duplication_enabled = false);
+    TERN_(HAS_DUPLICATION_MODE, set_duplication_enabled(false));
 
     // In BLTOUCH HS mode, the probe travels in a deployed state.
     // Users of G34 might have a badly misaligned bed, so raise Z by the

--- a/Marlin/src/gcode/control/M605.cpp
+++ b/Marlin/src/gcode/control/M605.cpp
@@ -68,7 +68,7 @@
       const DualXMode previous_mode = dual_x_carriage_mode;
 
       dual_x_carriage_mode = (DualXMode)parser.value_byte();
-      mirrored_duplication_mode = false;
+      idex_set_mirrored_mode(false);
 
       if (dual_x_carriage_mode == DXC_MIRRORED_MODE) {
         if (previous_mode != DXC_DUPLICATION_MODE) {
@@ -77,8 +77,7 @@
           dual_x_carriage_mode = DEFAULT_DUAL_X_CARRIAGE_MODE;
           return;
         }
-        mirrored_duplication_mode = true;
-        stepper.set_directions();
+        idex_set_mirrored_mode(true);
         float x_jog = current_position.x - .1;
         for (uint8_t i = 2; --i;) {
           planner.buffer_line(x_jog, current_position.y, current_position.z, current_position.e, feedrate_mm_s, 0);
@@ -103,8 +102,7 @@
           break;
       }
       active_extruder_parked = false;
-      extruder_duplication_enabled = false;
-      stepper.set_directions();
+      set_duplication_enabled(false);
       delayed_move_time = 0;
     }
     else if (!parser.seen('W'))  // if no S or W parameter, the DXC mode gets reset to the user's default
@@ -166,7 +164,7 @@
       if (parser.seenval('P')) duplication_e_mask = parser.value_int();   // Set the mask directly
       else if (parser.seenval('E')) duplication_e_mask = pow(2, parser.value_int() + 1) - 1; // Set the mask by E index
       ena = (2 == parser.intval('S', extruder_duplication_enabled ? 2 : 0));
-      extruder_duplication_enabled = ena && (duplication_e_mask >= 3);
+      set_duplication_enabled(ena && (duplication_e_mask >= 3));
     }
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM(STR_DUPLICATION_MODE);

--- a/Marlin/src/gcode/control/M605.cpp
+++ b/Marlin/src/gcode/control/M605.cpp
@@ -101,9 +101,8 @@
           dual_x_carriage_mode = DEFAULT_DUAL_X_CARRIAGE_MODE;
           break;
       }
-      active_extruder_parked = false;
+      idex_set_parked(false);
       set_duplication_enabled(false);
-      delayed_move_time = 0;
     }
     else if (!parser.seen('W'))  // if no S or W parameter, the DXC mode gets reset to the user's default
       dual_x_carriage_mode = DEFAULT_DUAL_X_CARRIAGE_MODE;
@@ -123,7 +122,7 @@
         if (!active_extruder_parked) DEBUG_ECHOPGM(" NOT ");
         DEBUG_ECHOPGM(" parked.");
         DEBUG_ECHOPAIR("\nactive_extruder_x_pos: ", current_position.x);
-        DEBUG_ECHOPAIR("\ninactive_extruder_x_pos: ", inactive_extruder_x_pos);
+        DEBUG_ECHOPAIR("\ninactive_extruder_x: ", inactive_extruder_x);
         DEBUG_ECHOPAIR("\nextruder_duplication_enabled: ", int(extruder_duplication_enabled));
         DEBUG_ECHOPAIR("\nduplicate_extruder_x_offset: ", duplicate_extruder_x_offset);
         DEBUG_ECHOPAIR("\nduplicate_extruder_temp_offset: ", duplicate_extruder_temp_offset);

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -87,7 +87,7 @@ void GcodeSuite::M600() {
     if (!parser.seen('T')) {  // If no tool index is specified, M600 was (probably) sent in response to filament runout.
                               // In this case, for duplicating modes set DXC_ext to the extruder that ran out.
       #if HAS_FILAMENT_SENSOR && NUM_RUNOUT_SENSORS > 1
-        if (dxc_is_duplicating())
+        if (idex_is_duplicating())
           DXC_ext = (READ(FIL_RUNOUT2_PIN) == FIL_RUNOUT_STATE) ? 1 : 0;
       #else
         DXC_ext = active_extruder;
@@ -108,7 +108,7 @@ void GcodeSuite::M600() {
   #if HAS_MULTI_EXTRUDER
     // Change toolhead if specified
     const uint8_t active_extruder_before_filament_change = active_extruder;
-    if (active_extruder != target_extruder && TERN1(DUAL_X_CARRIAGE, !dxc_is_duplicating()))
+    if (active_extruder != target_extruder && TERN1(DUAL_X_CARRIAGE, !idex_is_duplicating()))
       tool_change(target_extruder, false);
   #endif
 

--- a/Marlin/src/gcode/temp/M104_M109.cpp
+++ b/Marlin/src/gcode/temp/M104_M109.cpp
@@ -94,7 +94,7 @@ void GcodeSuite::M104() {
     thermalManager.setTargetHotend(temp, target_extruder);
 
     #if ENABLED(DUAL_X_CARRIAGE)
-      if (dxc_is_duplicating() && target_extruder == 0)
+      if (idex_is_duplicating() && target_extruder == 0)
         thermalManager.setTargetHotend(temp ? temp + duplicate_extruder_temp_offset : 0, 1);
     #endif
 
@@ -172,7 +172,7 @@ void GcodeSuite::M109() {
     thermalManager.setTargetHotend(temp, target_extruder);
 
     #if ENABLED(DUAL_X_CARRIAGE)
-      if (dxc_is_duplicating() && target_extruder == 0)
+      if (idex_is_duplicating() && target_extruder == 0)
         thermalManager.setTargetHotend(temp ? temp + duplicate_extruder_temp_offset : 0, 1);
     #endif
 

--- a/Marlin/src/libs/L64XX/L64XX_Marlin.cpp
+++ b/Marlin/src/libs/L64XX/L64XX_Marlin.cpp
@@ -62,11 +62,11 @@ const uint8_t L64XX_Marlin::index_to_dir[MAX_L64XX] = {
   INVERT_X_DIR, INVERT_Y_DIR, INVERT_Z_DIR
   , (INVERT_X_DIR)                            // X2
     #if ENABLED(X_DUAL_STEPPER_DRIVERS)
-      ^ (INVERT_X2_VS_X_DIR)
+      ^ ENABLED(INVERT_X2_VS_X_DIR)
     #endif
   , (INVERT_Y_DIR)                            // Y2
     #if ENABLED(Y_DUAL_STEPPER_DRIVERS)
-      ^ (INVERT_Y2_VS_Y_DIR)
+      ^ ENABLED(INVERT_Y2_VS_Y_DIR)
     #endif
   , INVERT_Z_DIR, INVERT_Z_DIR, INVERT_Z_DIR  // Z2,Z3,Z4
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -997,6 +997,8 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
             if (  planner.buffer_line(RAISED_X, RAISED_Y, RAISED_Z, CUR_E, planner.settings.max_feedrate_mm_s[Z_AXIS], active_extruder))
               if (planner.buffer_line(   CUR_X,    CUR_Y, RAISED_Z, CUR_E, PLANNER_XY_FEEDRATE(),             active_extruder))
                   line_to_current_position(planner.settings.max_feedrate_mm_s[Z_AXIS]);
+          planner.synchronize(); // paranoia
+          stepper.set_directions();
           delayed_move_time = 0;
           active_extruder_parked = false;
           if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Clear active_extruder_parked");
@@ -1015,6 +1017,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
             if (!planner.buffer_line(new_pos, planner.settings.max_feedrate_mm_s[X_AXIS], 1)) break;
             planner.synchronize();
             sync_plan_position();
+            stepper.set_directions();
             extruder_duplication_enabled = true;
             active_extruder_parked = false;
             if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Set extruder_duplication_enabled\nClear active_extruder_parked");
@@ -1023,7 +1026,6 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
           break;
       }
     }
-    stepper.set_directions();
     return false;
   }
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -384,8 +384,7 @@ bool homing_needed_error(uint8_t axis_bits=0x07);
  * Duplication mode
  */
 #if HAS_DUPLICATION_MODE
-  extern bool extruder_duplication_enabled,       // Used in Dual X mode 2
-              mirrored_duplication_mode;          // Used in Dual X mode 3
+  extern bool extruder_duplication_enabled;       // Used in Dual X mode 2
   #if ENABLED(MULTI_NOZZLE_DUPLICATION)
     extern uint8_t duplication_e_mask;
   #endif
@@ -410,6 +409,7 @@ bool homing_needed_error(uint8_t axis_bits=0x07);
   extern bool active_extruder_parked;             // Used in mode 1, 2 & 3
   extern millis_t delayed_move_time;              // Used in mode 1
   extern int16_t duplicate_extruder_temp_offset;  // Used in mode 2 & 3
+  extern bool idex_mirrored_mode;                 // Used in mode 3
 
   FORCE_INLINE bool dxc_is_duplicating() { return dual_x_carriage_mode >= DXC_DUPLICATION_MODE; }
 
@@ -417,10 +417,14 @@ bool homing_needed_error(uint8_t axis_bits=0x07);
 
   FORCE_INLINE int x_home_dir(const uint8_t extruder) { return extruder ? X2_HOME_DIR : X_HOME_DIR; }
 
+  void set_duplication_enabled(const bool dupe, const int8_t tool_index=-1);
+  void idex_set_mirrored_mode(const bool mirr);
+
 #else
 
   #if ENABLED(MULTI_NOZZLE_DUPLICATION)
     enum DualXMode : char { DXC_DUPLICATION_MODE = 2 };
+    FORCE_INLINE void set_duplication_enabled(const bool dupe) { extruder_duplication_enabled = dupe; }
   #endif
 
   FORCE_INLINE int x_home_dir(const uint8_t) { return home_dir(X_AXIS); }

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -403,7 +403,7 @@ bool homing_needed_error(uint8_t axis_bits=0x07);
   };
 
   extern DualXMode dual_x_carriage_mode;
-  extern float inactive_extruder_x_pos,           // Used in mode 0 & 1
+  extern float inactive_extruder_x,               // Used in mode 0 & 1
                duplicate_extruder_x_offset;       // Used in mode 2 & 3
   extern xyz_pos_t raised_parked_position;        // Used in mode 1
   extern bool active_extruder_parked;             // Used in mode 1, 2 & 3
@@ -411,7 +411,7 @@ bool homing_needed_error(uint8_t axis_bits=0x07);
   extern int16_t duplicate_extruder_temp_offset;  // Used in mode 2 & 3
   extern bool idex_mirrored_mode;                 // Used in mode 3
 
-  FORCE_INLINE bool dxc_is_duplicating() { return dual_x_carriage_mode >= DXC_DUPLICATION_MODE; }
+  FORCE_INLINE bool idex_is_duplicating() { return dual_x_carriage_mode >= DXC_DUPLICATION_MODE; }
 
   float x_home_pos(const uint8_t extruder);
 
@@ -419,6 +419,7 @@ bool homing_needed_error(uint8_t axis_bits=0x07);
 
   void set_duplication_enabled(const bool dupe, const int8_t tool_index=-1);
   void idex_set_mirrored_mode(const bool mirr);
+  void idex_set_parked(const bool park=true);
 
 #else
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -356,7 +356,7 @@ xyze_int8_t Stepper::count_direction{0};
   #endif
 #elif ENABLED(DUAL_X_CARRIAGE)
   #define X_APPLY_DIR(v,ALWAYS) do{ \
-    if (extruder_duplication_enabled || ALWAYS) { X_DIR_WRITE(v); X2_DIR_WRITE(mirrored_duplication_mode ? !(v) : v); } \
+    if (extruder_duplication_enabled || ALWAYS) { X_DIR_WRITE(v); X2_DIR_WRITE(idex_mirrored_mode ? !(v) : v); } \
     else if (last_moved_extruder) X2_DIR_WRITE(v); else X_DIR_WRITE(v); \
   }while(0)
   #define X_APPLY_STEP(v,ALWAYS) do{ \

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1605,10 +1605,9 @@ void Stepper::pulse_phase_isr() {
               PAGE_SEGMENT_UPDATE(Z, high >> 4);
               PAGE_SEGMENT_UPDATE(E, high & 0xF);
 
-              if (dm != last_direction_bits) {
-                last_direction_bits = dm;
-                set_directions();
-              }
+              if (dm != last_direction_bits)
+                set_directions(dm);
+
             } break;
 
             default: break;
@@ -2154,10 +2153,9 @@ uint32_t Stepper::block_phase_isr() {
         || current_block->direction_bits != last_direction_bits
         || TERN(MIXING_EXTRUDER, false, stepper_extruder != last_moved_extruder)
       ) {
-        last_direction_bits = current_block->direction_bits;
         TERN_(HAS_MULTI_EXTRUDER, last_moved_extruder = stepper_extruder);
         TERN_(HAS_L64XX, L64XX_OK_to_power_up = true);
-        set_directions();
+        set_directions(current_block->direction_bits);
       }
 
       #if ENABLED(LASER_POWER_INLINE)
@@ -2579,12 +2577,9 @@ void Stepper::init() {
   #endif
 
   // Init direction bits for first moves
-  last_direction_bits = 0
-    | (INVERT_X_DIR ? _BV(X_AXIS) : 0)
-    | (INVERT_Y_DIR ? _BV(Y_AXIS) : 0)
-    | (INVERT_Z_DIR ? _BV(Z_AXIS) : 0);
-
-  set_directions();
+  set_directions((INVERT_X_DIR ? _BV(X_AXIS) : 0)
+               | (INVERT_Y_DIR ? _BV(Y_AXIS) : 0)
+               | (INVERT_Z_DIR ? _BV(Z_AXIS) : 0));
 
   #if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM
     initialized = true;

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2154,6 +2154,7 @@ uint32_t Stepper::block_phase_isr() {
       if ( ENABLED(HAS_L64XX)  // Always set direction for L64xx (Also enables the chips)
         || current_block->direction_bits != last_direction_bits
         || TERN(MIXING_EXTRUDER, false, stepper_extruder != last_moved_extruder)
+        || ENABLED(DUAL_X_CARRIAGE) // For some reason, motion becomes jittery on small circles with dualx machines without this.
       ) {
         last_direction_bits = current_block->direction_bits;
         #if HAS_MULTI_EXTRUDER

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -514,8 +514,14 @@ class Stepper {
       static void refresh_motor_power();
     #endif
 
-    // Set direction bits for all steppers
+    // Update direction states for all steppers
     static void set_directions();
+
+    // Set direction bits and update all stepper DIR states
+    static void set_directions(const uint8_t bits) {
+      last_direction_bits = bits;
+      set_directions();
+    }
 
   private:
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -61,6 +61,10 @@
   #include "../gcode/gcode.h"
 #endif
 
+#if ENABLED(DUAL_X_CARRIAGE)
+  #include "stepper.h"
+#endif
+
 #if ANY(SWITCHING_EXTRUDER, SWITCHING_NOZZLE, SWITCHING_TOOLHEAD)
   #include "servo.h"
 #endif
@@ -701,6 +705,13 @@ inline void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_a
 
 #if ENABLED(DUAL_X_CARRIAGE)
 
+  /**
+   * @brief Dual X Tool Change
+   * @details Change tools, with extra behavior based on current mode
+   *
+   * @param new_tool Tool index to activate
+   * @param no_move Flag indicating no moves should take place
+   */
   inline void dualx_tool_change(const uint8_t new_tool, bool &no_move) {
 
     DEBUG_ECHOPGM("Dual X Carriage Mode ");
@@ -711,17 +722,16 @@ inline void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_a
       case DXC_MIRRORED_MODE:     DEBUG_ECHOLNPGM("MIRRORED");     break;
     }
 
+    // Get the home position of the currently-active tool
     const float xhome = x_home_pos(active_extruder);
-    if (dual_x_carriage_mode == DXC_AUTO_PARK_MODE
-        && IsRunning() && !no_move
-        && (delayed_move_time || current_position.x != xhome)
+
+    if (dual_x_carriage_mode == DXC_AUTO_PARK_MODE                  // If Auto-Park mode is enabled
+        && IsRunning() && !no_move                                  // ...and movement is permitted
+        && (delayed_move_time || current_position.x != xhome)       // ...and delayed_move_time is set OR not "already parked"...
     ) {
-
       DEBUG_ECHOLNPAIR("MoveX to ", xhome);
-
-      // Park old head
       current_position.x = xhome;
-      line_to_current_position(planner.settings.max_feedrate_mm_s[X_AXIS]);
+      line_to_current_position(planner.settings.max_feedrate_mm_s[X_AXIS]);   // Park the current head
       planner.synchronize();
     }
 
@@ -736,19 +746,20 @@ inline void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_a
     switch (dual_x_carriage_mode) {
       case DXC_FULL_CONTROL_MODE:
         // New current position is the position of the activated extruder
-        current_position.x = inactive_extruder_x_pos;
+        current_position.x = inactive_extruder_x;
         // Save the inactive extruder's position (from the old current_position)
-        inactive_extruder_x_pos = destination.x;
+        inactive_extruder_x = destination.x;
+        DEBUG_ECHOLNPAIR("DXC Full Control curr.x=", current_position.x, " dest.x=", destination.x);
         break;
       case DXC_AUTO_PARK_MODE:
-        // record current raised toolhead position for use by unpark
-        raised_parked_position = current_position;
-        active_extruder_parked = true;
-        delayed_move_time = 0;
+        idex_set_parked();
         break;
       default:
         break;
     }
+
+    // Ensure X axis DIR pertains to the correct carriage
+    stepper.set_directions();
 
     DEBUG_ECHOLNPAIR("Active extruder parked: ", active_extruder_parked ? "yes" : "no");
     DEBUG_POS("New extruder (parked)", current_position);
@@ -875,7 +886,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     planner.synchronize();
 
     #if ENABLED(DUAL_X_CARRIAGE)  // Only T0 allowed if the Printer is in DXC_DUPLICATION_MODE or DXC_MIRRORED_MODE
-      if (new_tool != 0 && dxc_is_duplicating())
+      if (new_tool != 0 && idex_is_duplicating())
          return invalid_extruder_error(new_tool);
     #endif
 
@@ -1151,7 +1162,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
           }
         #endif
 
-        TERN_(DUAL_X_CARRIAGE, active_extruder_parked = false);
+        TERN_(DUAL_X_CARRIAGE, idex_set_parked(false));
       }
 
       #if ENABLED(SWITCHING_NOZZLE)


### PR DESCRIPTION
### Description

As described in #19151, sometimes a "sudden layer shift" occurs when printing with DUAL_X_CARRIAGE enabled. After extensively debugging using an emulator, we identified that the cause was most likely related to the `stepper.set_directions()` call in `dual_x_carriage_unpark()` [in motion.cpp](https://github.com/MarlinFirmware/Marlin/compare/MarlinFirmware:f86c685...nb-rapidia:9299b90#diff-197a5fe8cad6b377cafdf69cac0cd393e6d07d6e5133f1df0f6450b2cdb90a27).

What's suspicious about this line is that it sets the directions even if no unpark operation occurs, meaning that the directions are set on every `g0`/`g1` command. Furthermore, the stepper ISR also invokes `set_directions`, meaning there is potentially some risk of a concurrency error (though admittedly it's hard to see exactly how.). This could be fixed by inserting `planner.synchronize()` before the call to `set_directions` in `dual_x_carriage_unpark()`, but this would essentially induce synchronous motion (due to this routine running every g0/g1 call.)

The fix implemented in this PR is to move `set_directions` into the switch statement, where it will only run if an actual unpark operation occurs. A `planner.synchronize()` call is inserted before `set_directions` in the `DXC_AUTO_PARK_MODE` case just in case it turns out that there is a potential concurrency issue here. (Perhaps somebody with more experience with this particular code can decide whether or not there is a risk and if this change would pose a problem.)

For some reason, this fix alone caused small circles to cause some jitter when printing small circles. It's not clear why this would be related, but we double-checked and confirmed that the jitter only occurs when this fix is used. Given that the change only affects the direction bits, we decided that (for reasons not fully understood), the most likely explanation is that the `count_direction` bits are somehow not being set correctly at the start of a move. So we force the directions to be set again at the start of each move [in stepper.cpp](https://github.com/MarlinFirmware/Marlin/compare/MarlinFirmware:f86c685...nb-rapidia:9299b90#diff-ddacdfeac95e2a001322f957bfdfe0a702d54d6728dd9aebdcb8b7a279d89260) regardless of whether or not it would otherwise be necessary.

We have so far run 10 prints using this fix, and we did not once see a layer shift occur. Our statistics (which we can elaborate on if needed) indicate that there is at least a 90% chance that this change did indeed resolve the sudden layer shift error. However, the exact cause of the sudden layer shift bug is still not fully understood, so **we'd greatly appreciate if somebody with a better understanding of the firmware could look at the proposed change and make a guess as to why it seems to resolve the problem.**

### Benefits

Likely fixes the sudden layer shift that is frequently observed when using dualx carriages. #19151 

### Configurations

The same configurations used as in #19151. ([Link](https://github.com/MarlinFirmware/Marlin/files/5126758/ConfigurationFiles.zip).)

### Related Issues

 #19151 