### PR TITLE
Fix SAMD Serial name macro

### DIFF
--- a/Marlin/src/HAL/SAMD51/HAL.h
+++ b/Marlin/src/HAL/SAMD51/HAL.h
@@ -35,7 +35,8 @@
 
   // MYSERIAL0 required before MarlinSerial includes!
 
-  #define _MSERIAL(X) Serial##X
+  #define __MSERIAL(X) Serial##X
+  #define _MSERIAL(X) __MSERIAL(X)
   #define MSERIAL(X) _MSERIAL(INCREMENT(X))
 
   #if SERIAL_PORT == -1


### PR DESCRIPTION
### Description

Adds another layer to the serial name macro for the SAMD51 HAL, preventing this error:

`g:\avr\projekte\marlin2_207_agc\marlin-2.0.7\marlin\src\hal\samd51\hal.h:38:23: error: 'SerialINCREMENT' was not declared in this scope`

### Benefits

Gets past the serial error.
The build still fails for me due to something related to SdFat.h, but that is an unrelated issue.

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/5390136/Configuration.zip)
(Only changed board name and environment)

### Related Issues

#19729 - [BUG] SAMD51 Compile Error with Marlin 2.0.7
