### PR TITLE
Fix IS_ULTIPANEL checks

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2614,14 +2614,14 @@
     #if HAS_MARLINUI_U8GLIB
       #define LCD_WIDTH 21
     #else
-      #define LCD_WIDTH TERN(ULTIPANEL, 20, 16)
+      #define LCD_WIDTH TERN(IS_ULTIPANEL, 20, 16)
     #endif
   #endif
   #ifndef LCD_HEIGHT
     #if HAS_MARLINUI_U8GLIB
       #define LCD_HEIGHT 5
     #else
-      #define LCD_HEIGHT TERN(ULTIPANEL, 4, 2)
+      #define LCD_HEIGHT TERN(IS_ULTIPANEL, 4, 2)
     #endif
   #endif
 #endif


### PR DESCRIPTION
### Description

The `Prusa/MK3S-BigTreeTech-BTT002` failed to builds to to the following sanity check:

```
#if LCD_INFO_SCREEN_STYLE > 0
  #if HAS_MARLINUI_U8GLIB || LCD_WIDTH < 20 || LCD_HEIGHT < 4
    #error "Alternative LCD_INFO_SCREEN_STYLE requires 20x4 Character LCD."
```

This happened beacause width/height were not properly checking for `IS_ULTIPANEL`.

### Benefits

Can compile when using `REPRAP_DISCOUNT_SMART_CONTROLLER` with `#define LCD_INFO_SCREEN_STYLE 1`.

### Configurations

`Prusa/MK3S-BigTreeTech-BTT002` example

### Related Issues

N/A
