### PR TITLE
Provide FYSETC F6 13 LCD pins for HD44780

### DIFF
--- a/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
+++ b/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
@@ -261,7 +261,7 @@
       #define NEOPIXEL_PIN                    25
     #endif
 
-  #elif HAS_MARLINUI_U8GLIB
+  #elif #elif EITHER(HAS_MARLINUI_U8GLIB, HAS_MARLINUI_HD44780)
 
     #define LCD_PINS_RS                       16
     #define LCD_PINS_ENABLE                   17

--- a/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
+++ b/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
@@ -261,7 +261,7 @@
       #define NEOPIXEL_PIN                    25
     #endif
 
-  #elif EITHER(HAS_MARLINUI_U8GLIB, HAS_MARLINUI_HD44780)
+  #elif HAS_MARLINUI_U8GLIB || HAS_MARLINUI_HD44780
 
     #define LCD_PINS_RS                       16
     #define LCD_PINS_ENABLE                   17

--- a/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
+++ b/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
@@ -261,7 +261,7 @@
       #define NEOPIXEL_PIN                    25
     #endif
 
-  #elif #elif EITHER(HAS_MARLINUI_U8GLIB, HAS_MARLINUI_HD44780)
+  #elif EITHER(HAS_MARLINUI_U8GLIB, HAS_MARLINUI_HD44780)
 
     #define LCD_PINS_RS                       16
     #define LCD_PINS_ENABLE                   17


### PR DESCRIPTION

### Description

 Compile Error occurs when using a REPRAP_DISCOUNT_SMART_CONTROLLER Display (2004LCD) on FYSETC F6 1.3 due to missing PIN definitions.
I solved the issue by changing Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
from
Line 264 #elif HAS_MARLINUI_U8GLIB
to
Line 264 #elif EITHER(HAS_MARLINUI_U8GLIB, HAS_MARLINUI_HD44780)

### Benefits

Fix compile error

### Configurations


[pins_FYSETC_F6_13.zip](https://github.com/MarlinFirmware/Marlin/files/5391528/pins_FYSETC_F6_13.zip)


### Related Issues

#19570
