### PR TITLE
Fix Color UI external_control, wait_for_release

### DIFF
--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -88,6 +88,7 @@ void Touch::idle() {
       if (wait_for_user) {
         touch_control_type = CLICK;
         ui.lcd_clicked = true;
+        if (ui.external_control) wait_for_user = false;
         return;
       }
     #endif

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -40,7 +40,7 @@ int16_t Touch::x, Touch::y;
 touch_control_t Touch::controls[];
 touch_control_t *Touch::current_control;
 uint16_t Touch::controls_count;
-millis_t Touch::now = 0;
+millis_t Touch::last_touch_ms = 0;
 millis_t Touch::time_to_hold;
 millis_t Touch::repeat_delay;
 millis_t Touch::touch_time;
@@ -79,8 +79,10 @@ void Touch::idle() {
 
   if (!enabled) return;
 
-  if (now == millis()) return;
-  now = millis();
+  // Return if Touch::idle is called within the same millisecond
+  const millis_t now = millis();
+  if (last_touch_ms == now) return;
+  last_touch_ms = now;
 
   if (get_point(&_x, &_y)) {
     #if HAS_RESUME_CONTINUE
@@ -94,19 +96,19 @@ void Touch::idle() {
     #endif
 
     #if LCD_TIMEOUT_TO_STATUS
-      ui.return_to_status_ms = now + LCD_TIMEOUT_TO_STATUS;
+      ui.return_to_status_ms = last_touch_ms + LCD_TIMEOUT_TO_STATUS;
     #endif
 
     if (touch_time) {
       #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-        if (touch_control_type == NONE && ELAPSED(now, touch_time + TOUCH_SCREEN_HOLD_TO_CALIBRATE_MS) && ui.on_status_screen())
+        if (touch_control_type == NONE && ELAPSED(last_touch_ms, touch_time + TOUCH_SCREEN_HOLD_TO_CALIBRATE_MS) && ui.on_status_screen())
           ui.goto_screen(touch_screen_calibration);
       #endif
       return;
     }
 
-    if (time_to_hold == 0) time_to_hold = now + MINIMUM_HOLD_TIME;
-    if (PENDING(now, time_to_hold)) return;
+    if (time_to_hold == 0) time_to_hold = last_touch_ms + MINIMUM_HOLD_TIME;
+    if (PENDING(last_touch_ms, time_to_hold)) return;
 
     if (x != 0 && y != 0) {
       if (current_control) {
@@ -132,7 +134,7 @@ void Touch::idle() {
       }
 
       if (current_control == NULL)
-        touch_time = now;
+        touch_time = last_touch_ms;
     }
     x = _x;
     y = _y;
@@ -285,7 +287,7 @@ void Touch::hold(touch_control_t *control, millis_t delay) {
   current_control = control;
   if (delay) {
     repeat_delay = delay > MIN_REPEAT_DELAY ? delay : MIN_REPEAT_DELAY;
-    time_to_hold = now + repeat_delay;
+    time_to_hold = last_touch_ms + repeat_delay;
   }
   ui.refresh();
 }

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -164,7 +164,13 @@ class Touch {
     static void reset() { controls_count = 0; touch_time = -1; current_control = NULL; }
     static void clear() { controls_count = 0; }
     static void idle();
-    static bool is_clicked() { return touch_control_type == CLICK; }
+    static bool is_clicked() {
+      if (touch_control_type == CLICK) {
+        touch_control_type = NONE;
+        return true;
+      };
+      return false;
+    }
     static void disable() { enabled = false; }
     static void enable() { enabled = true; }
 

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -168,7 +168,7 @@ class Touch {
       if (touch_control_type == CLICK) {
         touch_control_type = NONE;
         return true;
-      };
+      }
       return false;
     }
     static void disable() { enabled = false; }

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -819,8 +819,6 @@ void MarlinUI::update() {
     leds.update_timeout(powersupply_on);
   #endif
 
-  TERN_(HAS_GRAPHICAL_TFT, tft_idle());
-
   #if HAS_LCD_MENU
 
     // Handle any queued Move Axis motion
@@ -1082,6 +1080,8 @@ void MarlinUI::update() {
     } // switch
 
   } // ELAPSED(ms, next_lcd_update_ms)
+
+  TERN_(HAS_GRAPHICAL_TFT, tft_idle());
 }
 
 #if HAS_ADC_BUTTONS

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -251,9 +251,7 @@ millis_t MarlinUI::next_button_update_ms; // = 0
     bool MarlinUI::external_control; // = false
 
     void MarlinUI::wait_for_release() {
-      TERN_(TOUCH_SCREEN, wait_for_user = true);
       while (button_pressed()) safe_delay(50);
-      TERN_(TOUCH_SCREEN, wait_for_user = false);
       safe_delay(50);
     }
 
@@ -821,6 +819,8 @@ void MarlinUI::update() {
     leds.update_timeout(powersupply_on);
   #endif
 
+  TERN_(HAS_GRAPHICAL_TFT, tft_idle());
+
   #if HAS_LCD_MENU
 
     // Handle any queued Move Axis motion
@@ -1082,8 +1082,6 @@ void MarlinUI::update() {
     } // switch
 
   } // ELAPSED(ms, next_lcd_update_ms)
-
-  TERN_(HAS_GRAPHICAL_TFT, tft_idle());
 }
 
 #if HAS_ADC_BUTTONS

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -251,9 +251,9 @@ millis_t MarlinUI::next_button_update_ms; // = 0
     bool MarlinUI::external_control; // = false
 
     void MarlinUI::wait_for_release() {
-      wait_for_user = true;
+      TERN_(TOUCH_SCREEN, wait_for_user = true);
       while (button_pressed()) safe_delay(50);
-      wait_for_user = false;
+      TERN_(TOUCH_SCREEN, wait_for_user = false);
       safe_delay(50);
     }
 
@@ -1479,10 +1479,6 @@ void MarlinUI::update() {
 
     set_status_P(msg, -1);
   }
-
-  #if ENABLED(SDSUPPORT)
-    extern bool wait_for_user, wait_for_heatup;
-  #endif
 
   void MarlinUI::abort_print() {
     #if ENABLED(SDSUPPORT)

--- a/Marlin/src/lcd/ultralcd.cpp
+++ b/Marlin/src/lcd/ultralcd.cpp
@@ -251,7 +251,9 @@ millis_t MarlinUI::next_button_update_ms; // = 0
     bool MarlinUI::external_control; // = false
 
     void MarlinUI::wait_for_release() {
+      wait_for_user = true;
       while (button_pressed()) safe_delay(50);
+      wait_for_user = false;
       safe_delay(50);
     }
 

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -38,7 +38,7 @@
 #include "../gcode/gcode.h"
 #include "../lcd/ultralcd.h"
 
-#include "../MarlinCore.h" // for stop(), disable_e_steppers, wait_for_user
+#include "../MarlinCore.h" // for stop(), disable_e_steppers
 
 #if HAS_LEVELING
   #include "../feature/bedlevel/bedlevel.h"


### PR DESCRIPTION
### Description

~~`MarlinUI::wait_for_release()` didn't set the `wait_for_user` flag. It's needed for the color ui, to allow click anywhere in the screen.~~
Clean the internal click state of the color ui, after it is consumed, so it only gives one click command. It may solve the `MarlinUI::wait_for_release()` bug.

And it fixes the `wait_for_user` while `external_control` is set, for color ui.

This PR fix that.

### Benefits

Fix UBL for Color UI.
Fix #19758


### Related Issues

#19758