### PR TITLE
M503 -> M907 output garbled by out of bounds index

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3728,9 +3728,10 @@ void MarlinSettings::reset() {
         SERIAL_ECHOPGM("  M907");
         LOOP_L_N(q, MOTOR_CURRENT_COUNT) {
           SERIAL_CHAR(' ');
-          SERIAL_CHAR(axis_codes[q]);
+          SERIAL_CHAR(axis_codes[_MIN(q, E_AXIS)]);
           SERIAL_ECHO(stepper.motor_current_setting[q]);
         }
+        SERIAL_EOL();
       #endif
     #endif
 

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3719,20 +3719,25 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_HEADING("Stepper motor currents:");
       CONFIG_ECHO_START();
       #if HAS_MOTOR_CURRENT_PWM
-        SERIAL_ECHOLNPAIR_P(
-            PSTR("  M907 X"), stepper.motor_current_setting[0]
-          , SP_Z_STR, stepper.motor_current_setting[1]
-          , SP_E_STR, stepper.motor_current_setting[2]
+        SERIAL_ECHOLNPAIR_P(                                   // PWM-based has 3 values:
+            PSTR("  M907 X"), stepper.motor_current_setting[0] // X and Y
+                  , SP_Z_STR, stepper.motor_current_setting[1] // Z
+                  , SP_E_STR, stepper.motor_current_setting[2] // E
         );
       #elif HAS_MOTOR_CURRENT_SPI
-        SERIAL_ECHOPGM("  M907");
-        LOOP_L_N(q, MOTOR_CURRENT_COUNT) {
-          SERIAL_CHAR(' ');
-          SERIAL_CHAR(axis_codes[_MIN(q, E_AXIS)]);
+        SERIAL_ECHOPGM("  M907");                              // SPI-based has 5 values:
+        LOOP_XYZE(q) {                                         // X Y Z E0 (by default)
+          SERIAL_CHAR(' ', axis_codes[q]);
           SERIAL_ECHO(stepper.motor_current_setting[q]);
         }
-        SERIAL_EOL();
+        SERIAL_CHAR(' ', 'B');                                 // B maps to E1 (by default)
+        SERIAL_ECHOLN(stepper.motor_current_setting[4]);
       #endif
+    #elif HAS_MOTOR_CURRENT_I2C                                // i2c-based has any number of values
+      // Values sent over i2c are not stored.
+      // Indexes map directly to drivers, not axes.
+    #elif HAS_MOTOR_CURRENT_DAC                                // DAC-based has 4 values, for X Y Z E
+      // Values sent over i2c are not stored. Uses indirect mapping.
     #endif
 
     /**

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3726,11 +3726,11 @@ void MarlinSettings::reset() {
         );
       #elif HAS_MOTOR_CURRENT_SPI
         SERIAL_ECHOPGM("  M907");                              // SPI-based has 5 values:
-        LOOP_XYZE(q) {                                         // X Y Z E0 (by default)
+        LOOP_XYZE(q) {                                         // X Y Z E (map to X Y Z E0 by default)
           SERIAL_CHAR(' ', axis_codes[q]);
           SERIAL_ECHO(stepper.motor_current_setting[q]);
         }
-        SERIAL_CHAR(' ', 'B');                                 // B maps to E1 (by default)
+        SERIAL_CHAR(' ', 'B');                                 // B (maps to E1 by default)
         SERIAL_ECHOLN(stepper.motor_current_setting[4]);
       #endif
     #elif HAS_MOTOR_CURRENT_I2C                                // i2c-based has any number of values

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2962,7 +2962,7 @@ void Stepper::report_positions() {
   #if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM
 
     void Stepper::set_digipot_current(const uint8_t driver, const int16_t current) {
-      if (WITHIN(driver, 0, COUNT(motor_current_setting) - 1))
+      if (WITHIN(driver, 0, MOTOR_CURRENT_COUNT - 1))
         motor_current_setting[driver] = current; // update motor_current_setting
 
       if (!initialized) return;

--- a/Marlin/src/pins/rambo/pins_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_RAMBO.h
@@ -112,7 +112,7 @@
 #define E1_MS2_PIN                            64
 
 #define DIGIPOTSS_PIN                         38
-#define DIGIPOT_CHANNELS  { 4,5,3,0,1 }           // X Y Z E0 E1 digipot channels to stepper driver mapping
+#define DIGIPOT_CHANNELS { 4, 5, 3, 0, 1 }        // X Y Z E0 E1 digipot channels to stepper driver mapping
 #ifndef DIGIPOT_MOTOR_CURRENT
   #define DIGIPOT_MOTOR_CURRENT { 135,135,135,135,135 }   // Values 0-255 (RAMBO 135 = ~0.75A, 185 = ~1A)
 #endif

--- a/Marlin/src/pins/rambo/pins_SCOOVO_X9H.h
+++ b/Marlin/src/pins/rambo/pins_SCOOVO_X9H.h
@@ -92,7 +92,7 @@
 #define E1_MS2_PIN                            64
 
 #define DIGIPOTSS_PIN                         38
-#define DIGIPOT_CHANNELS {4,5,3,0,1}              // X Y Z E0 E1 digipot channels to stepper driver mapping
+#define DIGIPOT_CHANNELS { 4, 5, 3, 0, 1 }        // X Y Z E0 E1 digipot channels to stepper driver mapping
 
 //
 // Temperature Sensors

--- a/Marlin/src/pins/ramps/pins_BQ_ZUM_MEGA_3D.h
+++ b/Marlin/src/pins/ramps/pins_BQ_ZUM_MEGA_3D.h
@@ -85,7 +85,7 @@
 // Steppers
 //
 #define DIGIPOTSS_PIN                         22
-#define DIGIPOT_CHANNELS   { 4, 5, 3, 0, 1 }
+#define DIGIPOT_CHANNELS { 4, 5, 3, 0, 1 }
 
 //
 // Temperature Sensors


### PR DESCRIPTION
### Description

Configurations with `HAS_MOTOR_CURRENT_SPI` defined, M503 will produce garbage output for M907.
The problem occurs when `MOTOR_CURRENT_COUNT` is higher than 4 and we're reading past the end of axis_codes array.

### Benefits

Fixes random charaters in output after issuing M503 and in the case of OctoPrint terminal, prevents the terminal becoming unresponsive.

Current:
```
Recv: echo:; Stepper motor currents:
M907 X135 Y135 Z135 E135 \x87135ok
```
Fixed:
```
Recv: echo:; Stepper motor currents:
Recv: echo:  M907 X135 Y135 Z135 E135 E135
Recv: ok
```

Caveat: Two E values at the end of the output might seem confusing. Maybe a more granular logic is needed here?

### Configurations

[configs.zip](https://github.com/MarlinFirmware/Marlin/files/5395040/configs.zip)

### Related Issues

#19775
