### PR TITLE
Distinct Chopper Timing settings

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -30,7 +30,7 @@
  *
  * Basic settings can be found in Configuration.h
  */
-#define CONFIGURATION_ADV_H_VERSION 020008
+#define CONFIGURATION_ADV_H_VERSION 020007
 
 //===========================================================================
 //============================= Thermal Settings ============================
@@ -1048,10 +1048,10 @@
 
 // @section lcd
 
-#if EITHER(IS_ULTIPANEL, EXTENSIBLE_UI)
+#if EITHER(ULTIPANEL, EXTENSIBLE_UI)
   #define MANUAL_FEEDRATE { 50*60, 50*60, 4*60, 2*60 } // (mm/min) Feedrates for manual moves along X, Y, Z, E from panel
   #define SHORT_MANUAL_Z_MOVE 0.025 // (mm) Smallest manual Z move (< 0.1mm)
-  #if IS_ULTIPANEL
+  #if ENABLED(ULTIPANEL)
     #define MANUAL_E_MOVES_RELATIVE // Display extruder move distance rather than "position"
     #define ULTIPANEL_FEEDMULTIPLY  // Encoder sets the feedrate multiplier on the Status Screen
   #endif
@@ -2475,7 +2475,11 @@
    * { <off_time[1..15]>, <hysteresis_end[-3..12]>, hysteresis_start[1..8] }
    */
   #define CHOPPER_TIMING CHOPPER_DEFAULT_12V
-
+  //For different timings for each axis set below, otherwise default timings will be used
+  //#define CHOPPER_TIMING_Y CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_Z CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_E CHOPPER_DEFAULT_12V
+ 
   /**
    * Monitor Trinamic drivers
    * for error conditions like overtemperature and short to ground.
@@ -2958,7 +2962,7 @@
      * This allows the laser to keep in perfect sync with the planner and removes
      * the powerup/down delay since lasers require negligible time.
      */
-    //#define LASER_POWER_INLINE
+    #define LASER_POWER_INLINE
 
     #if ENABLED(LASER_POWER_INLINE)
       /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -30,7 +30,7 @@
  *
  * Basic settings can be found in Configuration.h
  */
-#define CONFIGURATION_ADV_H_VERSION 020007
+#define CONFIGURATION_ADV_H_VERSION 020008
 
 //===========================================================================
 //============================= Thermal Settings ============================
@@ -1048,10 +1048,10 @@
 
 // @section lcd
 
-#if EITHER(ULTIPANEL, EXTENSIBLE_UI)
+#if EITHER(IS_ULTIPANEL, EXTENSIBLE_UI)
   #define MANUAL_FEEDRATE { 50*60, 50*60, 4*60, 2*60 } // (mm/min) Feedrates for manual moves along X, Y, Z, E from panel
   #define SHORT_MANUAL_Z_MOVE 0.025 // (mm) Smallest manual Z move (< 0.1mm)
-  #if ENABLED(ULTIPANEL)
+  #if IS_ULTIPANEL
     #define MANUAL_E_MOVES_RELATIVE // Display extruder move distance rather than "position"
     #define ULTIPANEL_FEEDMULTIPLY  // Encoder sets the feedrate multiplier on the Status Screen
   #endif
@@ -2471,15 +2471,27 @@
    * CHOPPER_PRUSAMK3_24V // Imported parameters from the official Průša firmware for MK3 (24V)
    * CHOPPER_MARLIN_119   // Old defaults from Marlin v1.1.9
    *
-   * Define you own with
+   * Define your own with:
    * { <off_time[1..15]>, <hysteresis_end[-3..12]>, hysteresis_start[1..8] }
    */
-  #define CHOPPER_TIMING CHOPPER_DEFAULT_12V
-  //For different timings for each axis set below, otherwise default timings will be used
-  //#define CHOPPER_TIMING_Y CHOPPER_DEFAULT_12V
-  //#define CHOPPER_TIMING_Z CHOPPER_DEFAULT_12V
-  //#define CHOPPER_TIMING_E CHOPPER_DEFAULT_12V
- 
+  #define CHOPPER_TIMING CHOPPER_DEFAULT_12V        // All axes (override below)
+  //#define CHOPPER_TIMING_X  CHOPPER_DEFAULT_12V   // For X Axes (override below)
+  //#define CHOPPER_TIMING_X2 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_Y  CHOPPER_DEFAULT_12V   // For Y Axes (override below)
+  //#define CHOPPER_TIMING_Y2 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_Z  CHOPPER_DEFAULT_12V   // For Z Axes (override below)
+  //#define CHOPPER_TIMING_Z2 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_Z3 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_Z4 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_E  CHOPPER_DEFAULT_12V   // For Extruders (override below)
+  //#define CHOPPER_TIMING_E1 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_E2 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_E3 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_E4 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_E5 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_E6 CHOPPER_DEFAULT_12V
+  //#define CHOPPER_TIMING_E7 CHOPPER_DEFAULT_12V
+
   /**
    * Monitor Trinamic drivers
    * for error conditions like overtemperature and short to ground.
@@ -2962,7 +2974,7 @@
      * This allows the laser to keep in perfect sync with the planner and removes
      * the powerup/down delay since lasers require negligible time.
      */
-    #define LASER_POWER_INLINE
+    //#define LASER_POWER_INLINE
 
     #if ENABLED(LASER_POWER_INLINE)
       /**

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -17,7 +17,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
+ * 
  */
 
 /**
@@ -136,10 +136,10 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 1;
-    chopconf.toff = chopper_timing.toff;
+    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing.hend + 3;
-    chopconf.hstrt = chopper_timing.hstrt - 1;
+    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -171,10 +171,11 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 1;
-    chopconf.toff = chopper_timing.toff;
+    
+    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing.hend + 3;
-    chopconf.hstrt = chopper_timing.hstrt - 1;
+    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -495,10 +496,11 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     TMC2208_n::CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01; // blank_time = 24
-    chopconf.toff = chopper_timing.toff;
+    
+    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing.hend + 3;
-    chopconf.hstrt = chopper_timing.hstrt - 1;
+    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -537,10 +539,10 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     TMC2208_n::CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01; // blank_time = 24
-    chopconf.toff = chopper_timing.toff;
+    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing.hend + 3;
-    chopconf.hstrt = chopper_timing.hstrt - 1;
+    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -573,9 +575,11 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     TMC2660_n::CHOPCONF_t chopconf{0};
     chopconf.tbl = 1;
-    chopconf.toff = chopper_timing.toff;
-    chopconf.hend = chopper_timing.hend + 3;
-    chopconf.hstrt = chopper_timing.hstrt - 1;
+
+    
+    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
+    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
     st.CHOPCONF(chopconf.sr);
 
     st.sdoff(0);
@@ -595,10 +599,11 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 1;
-    chopconf.toff = chopper_timing.toff;
+    
+    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing.hend + 3;
-    chopconf.hstrt = chopper_timing.hstrt - 1;
+    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -630,10 +635,10 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 1;
-    chopconf.toff = chopper_timing.toff;
+    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing.hend + 3;
-    chopconf.hstrt = chopper_timing.hstrt - 1;
+    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -17,7 +17,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- * 
+ *
  */
 
 /**
@@ -129,17 +129,20 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
   #define TMC_BAUD_RATE TERN(HAS_TMC_SW_SERIAL, 57600, 115200)
 #endif
 
+// Chopper timings inits on a per-axis basis
+constexpr chopper_timing_t chopper_timing_init[XYZE] = { CHOPPER_TIMING_X, CHOPPER_TIMING_Y, CHOPPER_TIMING_Z, CHOPPER_TIMING_E };
+
 #if HAS_DRIVER(TMC2130)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
   void tmc_init(TMCMarlin<TMC2130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth) {
     st.begin();
 
     CHOPCONF_t chopconf{0};
-    chopconf.tbl = 1;
-    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
+    chopconf.tbl = 0b01;
+    chopconf.toff = chopper_timing_init[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
-    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
+    chopconf.hend = chopper_timing_init[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing_init[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -170,12 +173,11 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     st.begin();
 
     CHOPCONF_t chopconf{0};
-    chopconf.tbl = 1;
-    
-    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
+    chopconf.tbl = 0b01;
+    chopconf.toff = chopper_timing_init[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
-    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
+    chopconf.hend = chopper_timing_init[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing_init[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -496,11 +498,10 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     TMC2208_n::CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01; // blank_time = 24
-    
-    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
+    chopconf.toff = chopper_timing_init[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
-    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
+    chopconf.hend = chopper_timing_init[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing_init[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -539,10 +540,10 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
     TMC2208_n::CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01; // blank_time = 24
-    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
+    chopconf.toff = chopper_timing_init[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
-    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
+    chopconf.hend = chopper_timing_init[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing_init[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -574,12 +575,10 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     st.begin();
 
     TMC2660_n::CHOPCONF_t chopconf{0};
-    chopconf.tbl = 1;
-
-    
-    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
-    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
-    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
+    chopconf.tbl = 0b01;
+    chopconf.toff = chopper_timing_init[AXIS_ID%4].toff;
+    chopconf.hend = chopper_timing_init[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing_init[AXIS_ID%4].hstrt - 1;
     st.CHOPCONF(chopconf.sr);
 
     st.sdoff(0);
@@ -598,12 +597,11 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     st.begin();
 
     CHOPCONF_t chopconf{0};
-    chopconf.tbl = 1;
-    
-    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
+    chopconf.tbl = 0b01;
+    chopconf.toff = chopper_timing_init[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
-    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
+    chopconf.hend = chopper_timing_init[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing_init[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 
@@ -634,11 +632,11 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     st.begin();
 
     CHOPCONF_t chopconf{0};
-    chopconf.tbl = 1;
-    chopconf.toff = chopper_timing[AXIS_ID%4].toff;
+    chopconf.tbl = 0b01;
+    chopconf.toff = chopper_timing_init[AXIS_ID%4].toff;
     chopconf.intpol = INTERPOLATE;
-    chopconf.hend = chopper_timing[AXIS_ID%4].hend + 3;
-    chopconf.hstrt = chopper_timing[AXIS_ID%4].hstrt - 1;
+    chopconf.hend = chopper_timing_init[AXIS_ID%4].hend + 3;
+    chopconf.hstrt = chopper_timing_init[AXIS_ID%4].hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
     st.CHOPCONF(chopconf.sr);
 

--- a/Marlin/src/module/stepper/trinamic.h
+++ b/Marlin/src/module/stepper/trinamic.h
@@ -17,7 +17,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
+ * 
  */
 #pragma once
 
@@ -70,13 +70,23 @@
   #define TMC_CLASS_E(N) TMC_CLASS(E##N, E)
 #endif
 
-typedef struct {
-  uint8_t toff;
-  int8_t hend;
-  uint8_t hstrt;
-} chopper_timing_t;
+typedef struct {uint8_t toff; int8_t hend; uint8_t hstrt;} chopper_timing_axis;
 
-static constexpr chopper_timing_t chopper_timing = CHOPPER_TIMING;
+#ifndef CHOPPER_TIMING_X
+  #define CHOPPER_TIMING_X CHOPPER_TIMING
+#endif
+#ifndef CHOPPER_TIMING_Y
+  #define CHOPPER_TIMING_Y CHOPPER_TIMING
+#endif
+#ifndef CHOPPER_TIMING_Z
+  #define CHOPPER_TIMING_Z CHOPPER_TIMING
+#endif
+#ifndef CHOPPER_TIMING_E
+  #define CHOPPER_TIMING_E CHOPPER_TIMING
+#endif
+
+
+constexpr chopper_timing_axis chopper_timing[4] = {CHOPPER_TIMING_X, CHOPPER_TIMING_Y, CHOPPER_TIMING_Z,CHOPPER_TIMING_E};
 
 #if HAS_TMC220x
   void tmc_serial_begin();
@@ -92,7 +102,7 @@ void reset_trinamic_drivers();
   extern TMC_CLASS(X, X) stepperX;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define X_ENABLE_INIT() NOOP
-    #define X_ENABLE_WRITE(STATE) stepperX.toff((STATE)==X_ENABLE_ON ? chopper_timing.toff : 0)
+    #define X_ENABLE_WRITE(STATE) stepperX.toff((STATE)==X_ENABLE_ON ? chopper_timing.X.toff : 0)
     #define X_ENABLE_READ() stepperX.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(X)
@@ -105,7 +115,7 @@ void reset_trinamic_drivers();
   extern TMC_CLASS(Y, Y) stepperY;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Y_ENABLE_INIT() NOOP
-    #define Y_ENABLE_WRITE(STATE) stepperY.toff((STATE)==Y_ENABLE_ON ? chopper_timing.toff : 0)
+    #define Y_ENABLE_WRITE(STATE) stepperY.toff((STATE)==Y_ENABLE_ON ? chopper_timing.Y.toff : 0)
     #define Y_ENABLE_READ() stepperY.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Y)
@@ -118,7 +128,7 @@ void reset_trinamic_drivers();
   extern TMC_CLASS(Z, Z) stepperZ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Z_ENABLE_INIT() NOOP
-    #define Z_ENABLE_WRITE(STATE) stepperZ.toff((STATE)==Z_ENABLE_ON ? chopper_timing.toff : 0)
+    #define Z_ENABLE_WRITE(STATE) stepperZ.toff((STATE)==Z_ENABLE_ON ? chopper_timing.Z.toff : 0)
     #define Z_ENABLE_READ() stepperZ.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Z)
@@ -131,7 +141,7 @@ void reset_trinamic_drivers();
   extern TMC_CLASS(X2, X) stepperX2;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define X2_ENABLE_INIT() NOOP
-    #define X2_ENABLE_WRITE(STATE) stepperX2.toff((STATE)==X_ENABLE_ON ? chopper_timing.toff : 0)
+    #define X2_ENABLE_WRITE(STATE) stepperX2.toff((STATE)==X_ENABLE_ON ? chopper_timing.X2.toff : 0)
     #define X2_ENABLE_READ() stepperX2.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(X2)
@@ -142,9 +152,17 @@ void reset_trinamic_drivers();
 // Y2 Stepper
 #if HAS_Y2_ENABLE && AXIS_IS_TMC(Y2)
   extern TMC_CLASS(Y2, Y) stepperY2;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_y2;
+    static constexpr chopper_timing_t_y2 chopper_timing_y2 = CHOPPER_TIMING_Y2;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Y2_ENABLE_INIT() NOOP
-    #define Y2_ENABLE_WRITE(STATE) stepperY2.toff((STATE)==Y_ENABLE_ON ? chopper_timing.toff : 0)
+    #define Y2_ENABLE_WRITE(STATE) stepperY2.toff((STATE)==Y_ENABLE_ON ? chopper_timing_y2.toff : 0)
     #define Y2_ENABLE_READ() stepperY2.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Y2)
@@ -155,9 +173,17 @@ void reset_trinamic_drivers();
 // Z2 Stepper
 #if HAS_Z2_ENABLE && AXIS_IS_TMC(Z2)
   extern TMC_CLASS(Z2, Z) stepperZ2;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_z2;
+    static constexpr chopper_timing_t_z2 chopper_timing_z2 = CHOPPER_TIMING_Z2;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(Z2)
     #define Z2_ENABLE_INIT() NOOP
-    #define Z2_ENABLE_WRITE(STATE) stepperZ2.toff((STATE)==Z_ENABLE_ON ? chopper_timing.toff : 0)
+    #define Z2_ENABLE_WRITE(STATE) stepperZ2.toff((STATE)==Z_ENABLE_ON ? chopper_timing_z2.toff : 0)
     #define Z2_ENABLE_READ() stepperZ2.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Z2)
@@ -168,9 +194,17 @@ void reset_trinamic_drivers();
 // Z3 Stepper
 #if HAS_Z3_ENABLE && AXIS_IS_TMC(Z3)
   extern TMC_CLASS(Z3, Z) stepperZ3;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_z3;
+    static constexpr chopper_timing_t_z3 chopper_timing_z3 = CHOPPER_TIMING_Z3;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Z3_ENABLE_INIT() NOOP
-    #define Z3_ENABLE_WRITE(STATE) stepperZ3.toff((STATE)==Z_ENABLE_ON ? chopper_timing.toff : 0)
+    #define Z3_ENABLE_WRITE(STATE) stepperZ3.toff((STATE)==Z_ENABLE_ON ? chopper_timing_z3.toff : 0)
     #define Z3_ENABLE_READ() stepperZ3.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Z3)
@@ -181,9 +215,17 @@ void reset_trinamic_drivers();
 // Z4 Stepper
 #if HAS_Z4_ENABLE && AXIS_IS_TMC(Z4)
   extern TMC_CLASS(Z4, Z) stepperZ4;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_z4;
+    static constexpr chopper_timing_t_z4 chopper_timing_z4 = CHOPPER_TIMING_Z4;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Z4_ENABLE_INIT() NOOP
-    #define Z4_ENABLE_WRITE(STATE) stepperZ4.toff((STATE)==Z_ENABLE_ON ? chopper_timing.toff : 0)
+    #define Z4_ENABLE_WRITE(STATE) stepperZ4.toff((STATE)==Z_ENABLE_ON ? chopper_timing_z4.toff : 0)
     #define Z4_ENABLE_READ() stepperZ4.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Z4)
@@ -196,7 +238,7 @@ void reset_trinamic_drivers();
   extern TMC_CLASS_E(0) stepperE0;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E0)
     #define E0_ENABLE_INIT() NOOP
-    #define E0_ENABLE_WRITE(STATE) stepperE0.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
+    #define E0_ENABLE_WRITE(STATE) stepperE0.toff((STATE)==E_ENABLE_ON ? chopper_timing.E0.toff : 0)
     #define E0_ENABLE_READ() stepperE0.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E0)
@@ -207,9 +249,17 @@ void reset_trinamic_drivers();
 // E1 Stepper
 #if AXIS_IS_TMC(E1)
   extern TMC_CLASS_E(1) stepperE1;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_e1;
+    static constexpr chopper_timing_t_e1 chopper_timing_e1 = CHOPPER_TIMING_E1;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E1)
     #define E1_ENABLE_INIT() NOOP
-    #define E1_ENABLE_WRITE(STATE) stepperE1.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
+    #define E1_ENABLE_WRITE(STATE) stepperE1.toff((STATE)==E_ENABLE_ON ? chopper_timing_e1.toff : 0)
     #define E1_ENABLE_READ() stepperE1.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E1)
@@ -220,9 +270,17 @@ void reset_trinamic_drivers();
 // E2 Stepper
 #if AXIS_IS_TMC(E2)
   extern TMC_CLASS_E(2) stepperE2;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_e2;
+    static constexpr chopper_timing_t_e2 chopper_timing_e2 = CHOPPER_TIMING_E2;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E2)
     #define E2_ENABLE_INIT() NOOP
-    #define E2_ENABLE_WRITE(STATE) stepperE2.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
+    #define E2_ENABLE_WRITE(STATE) stepperE2.toff((STATE)==E_ENABLE_ON ? chopper_timing_e2.toff : 0)
     #define E2_ENABLE_READ() stepperE2.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E2)
@@ -233,9 +291,17 @@ void reset_trinamic_drivers();
 // E3 Stepper
 #if AXIS_IS_TMC(E3)
   extern TMC_CLASS_E(3) stepperE3;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_e3;
+    static constexpr chopper_timing_t_e3 chopper_timing_e3 = CHOPPER_TIMING_E3;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E3)
     #define E3_ENABLE_INIT() NOOP
-    #define E3_ENABLE_WRITE(STATE) stepperE3.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
+    #define E3_ENABLE_WRITE(STATE) stepperE3.toff((STATE)==E_ENABLE_ON ? chopper_timing_e3.toff : 0)
     #define E3_ENABLE_READ() stepperE3.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E3)
@@ -246,9 +312,17 @@ void reset_trinamic_drivers();
 // E4 Stepper
 #if AXIS_IS_TMC(E4)
   extern TMC_CLASS_E(4) stepperE4;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_e4;
+    static constexpr chopper_timing_t_e4 chopper_timing_e4 = CHOPPER_TIMING_E4;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E4)
     #define E4_ENABLE_INIT() NOOP
-    #define E4_ENABLE_WRITE(STATE) stepperE4.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
+    #define E4_ENABLE_WRITE(STATE) stepperE4.toff((STATE)==E_ENABLE_ON ? chopper_timing_e4.toff : 0)
     #define E4_ENABLE_READ() stepperE4.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E4)
@@ -259,9 +333,17 @@ void reset_trinamic_drivers();
 // E5 Stepper
 #if AXIS_IS_TMC(E5)
   extern TMC_CLASS_E(5) stepperE5;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_e5;
+    static constexpr chopper_timing_t_e5 chopper_timing_e5 = CHOPPER_TIMING_E5;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E5)
     #define E5_ENABLE_INIT() NOOP
-    #define E5_ENABLE_WRITE(STATE) stepperE5.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
+    #define E5_ENABLE_WRITE(STATE) stepperE5.toff((STATE)==E_ENABLE_ON ? chopper_timing_e5.toff : 0)
     #define E5_ENABLE_READ() stepperE5.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E5)
@@ -272,9 +354,17 @@ void reset_trinamic_drivers();
 // E6 Stepper
 #if AXIS_IS_TMC(E6)
   extern TMC_CLASS_E(6) stepperE6;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_e6;
+    static constexpr chopper_timing_t_e6 chopper_timing_e6 = CHOPPER_TIMING_E6;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E6)
     #define E6_ENABLE_INIT() NOOP
-    #define E6_ENABLE_WRITE(STATE) stepperE6.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
+    #define E6_ENABLE_WRITE(STATE) stepperE6.toff((STATE)==E_ENABLE_ON ? chopper_timing_e6.toff : 0)
     #define E6_ENABLE_READ() stepperE6.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E6)
@@ -285,9 +375,17 @@ void reset_trinamic_drivers();
 // E7 Stepper
 #if AXIS_IS_TMC(E7)
   extern TMC_CLASS_E(7) stepperE7;
+  #if ENABLED(CHOPPER_TIMING_SEPARATE)
+    typedef struct {
+      uint8_t toff; 
+      int8_t hend; 
+      uint8_t hstrt;
+    } chopper_timing_t_e7;
+    static constexpr chopper_timing_t_e7 chopper_timing_e7 = CHOPPER_TIMING_E7;
+  #endif
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E7)
     #define E7_ENABLE_INIT() NOOP
-    #define E7_ENABLE_WRITE(STATE) stepperE7.toff((STATE)==E_ENABLE_ON ? chopper_timing.toff : 0)
+    #define E7_ENABLE_WRITE(STATE) stepperE7.toff((STATE)==E_ENABLE_ON ? chopper_timing_e7.toff : 0)
     #define E7_ENABLE_READ() stepperE7.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E7)

--- a/Marlin/src/module/stepper/trinamic.h
+++ b/Marlin/src/module/stepper/trinamic.h
@@ -17,7 +17,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- * 
+ *
  */
 #pragma once
 
@@ -70,7 +70,11 @@
   #define TMC_CLASS_E(N) TMC_CLASS(E##N, E)
 #endif
 
-typedef struct {uint8_t toff; int8_t hend; uint8_t hstrt;} chopper_timing_axis;
+typedef struct {
+  uint8_t toff;
+  int8_t hend;
+  uint8_t hstrt;
+} chopper_timing_t;
 
 #ifndef CHOPPER_TIMING_X
   #define CHOPPER_TIMING_X CHOPPER_TIMING
@@ -85,9 +89,6 @@ typedef struct {uint8_t toff; int8_t hend; uint8_t hstrt;} chopper_timing_axis;
   #define CHOPPER_TIMING_E CHOPPER_TIMING
 #endif
 
-
-constexpr chopper_timing_axis chopper_timing[4] = {CHOPPER_TIMING_X, CHOPPER_TIMING_Y, CHOPPER_TIMING_Z,CHOPPER_TIMING_E};
-
 #if HAS_TMC220x
   void tmc_serial_begin();
 #endif
@@ -100,9 +101,10 @@ void reset_trinamic_drivers();
 // X Stepper
 #if AXIS_IS_TMC(X)
   extern TMC_CLASS(X, X) stepperX;
+  static constexpr chopper_timing_t chopper_timing_X = CHOPPER_TIMING_X;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define X_ENABLE_INIT() NOOP
-    #define X_ENABLE_WRITE(STATE) stepperX.toff((STATE)==X_ENABLE_ON ? chopper_timing.X.toff : 0)
+    #define X_ENABLE_WRITE(STATE) stepperX.toff((STATE)==X_ENABLE_ON ? chopper_timing_X.toff : 0)
     #define X_ENABLE_READ() stepperX.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(X)
@@ -113,9 +115,10 @@ void reset_trinamic_drivers();
 // Y Stepper
 #if AXIS_IS_TMC(Y)
   extern TMC_CLASS(Y, Y) stepperY;
+  static constexpr chopper_timing_t chopper_timing_Y = CHOPPER_TIMING_Y;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Y_ENABLE_INIT() NOOP
-    #define Y_ENABLE_WRITE(STATE) stepperY.toff((STATE)==Y_ENABLE_ON ? chopper_timing.Y.toff : 0)
+    #define Y_ENABLE_WRITE(STATE) stepperY.toff((STATE)==Y_ENABLE_ON ? chopper_timing_Y.toff : 0)
     #define Y_ENABLE_READ() stepperY.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Y)
@@ -126,9 +129,10 @@ void reset_trinamic_drivers();
 // Z Stepper
 #if AXIS_IS_TMC(Z)
   extern TMC_CLASS(Z, Z) stepperZ;
+  static constexpr chopper_timing_t chopper_timing_Z = CHOPPER_TIMING_Z;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Z_ENABLE_INIT() NOOP
-    #define Z_ENABLE_WRITE(STATE) stepperZ.toff((STATE)==Z_ENABLE_ON ? chopper_timing.Z.toff : 0)
+    #define Z_ENABLE_WRITE(STATE) stepperZ.toff((STATE)==Z_ENABLE_ON ? chopper_timing_Z.toff : 0)
     #define Z_ENABLE_READ() stepperZ.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Z)
@@ -139,9 +143,16 @@ void reset_trinamic_drivers();
 // X2 Stepper
 #if HAS_X2_ENABLE && AXIS_IS_TMC(X2)
   extern TMC_CLASS(X2, X) stepperX2;
+  static constexpr chopper_timing_t chopper_timing_X2 =
+    #ifdef CHOPPER_TIMING_X2
+      CHOPPER_TIMING_X2
+    #else
+      CHOPPER_TIMING_X
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define X2_ENABLE_INIT() NOOP
-    #define X2_ENABLE_WRITE(STATE) stepperX2.toff((STATE)==X_ENABLE_ON ? chopper_timing.X2.toff : 0)
+    #define X2_ENABLE_WRITE(STATE) stepperX2.toff((STATE)==X_ENABLE_ON ? chopper_timing_X2.toff : 0)
     #define X2_ENABLE_READ() stepperX2.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(X2)
@@ -152,17 +163,16 @@ void reset_trinamic_drivers();
 // Y2 Stepper
 #if HAS_Y2_ENABLE && AXIS_IS_TMC(Y2)
   extern TMC_CLASS(Y2, Y) stepperY2;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_y2;
-    static constexpr chopper_timing_t_y2 chopper_timing_y2 = CHOPPER_TIMING_Y2;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_Y2 =
+    #ifdef CHOPPER_TIMING_Y2
+      CHOPPER_TIMING_Y2
+    #else
+      CHOPPER_TIMING_Y
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Y2_ENABLE_INIT() NOOP
-    #define Y2_ENABLE_WRITE(STATE) stepperY2.toff((STATE)==Y_ENABLE_ON ? chopper_timing_y2.toff : 0)
+    #define Y2_ENABLE_WRITE(STATE) stepperY2.toff((STATE)==Y_ENABLE_ON ? chopper_timing_Y2.toff : 0)
     #define Y2_ENABLE_READ() stepperY2.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Y2)
@@ -173,17 +183,16 @@ void reset_trinamic_drivers();
 // Z2 Stepper
 #if HAS_Z2_ENABLE && AXIS_IS_TMC(Z2)
   extern TMC_CLASS(Z2, Z) stepperZ2;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_z2;
-    static constexpr chopper_timing_t_z2 chopper_timing_z2 = CHOPPER_TIMING_Z2;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_Z2 =
+    #ifdef CHOPPER_TIMING_Z2
+      CHOPPER_TIMING_Z2
+    #else
+      CHOPPER_TIMING_Z
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(Z2)
     #define Z2_ENABLE_INIT() NOOP
-    #define Z2_ENABLE_WRITE(STATE) stepperZ2.toff((STATE)==Z_ENABLE_ON ? chopper_timing_z2.toff : 0)
+    #define Z2_ENABLE_WRITE(STATE) stepperZ2.toff((STATE)==Z_ENABLE_ON ? chopper_timing_Z2.toff : 0)
     #define Z2_ENABLE_READ() stepperZ2.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Z2)
@@ -194,17 +203,16 @@ void reset_trinamic_drivers();
 // Z3 Stepper
 #if HAS_Z3_ENABLE && AXIS_IS_TMC(Z3)
   extern TMC_CLASS(Z3, Z) stepperZ3;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_z3;
-    static constexpr chopper_timing_t_z3 chopper_timing_z3 = CHOPPER_TIMING_Z3;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_Z3 =
+    #ifdef CHOPPER_TIMING_Z3
+      CHOPPER_TIMING_Z3
+    #else
+      CHOPPER_TIMING_Z
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Z3_ENABLE_INIT() NOOP
-    #define Z3_ENABLE_WRITE(STATE) stepperZ3.toff((STATE)==Z_ENABLE_ON ? chopper_timing_z3.toff : 0)
+    #define Z3_ENABLE_WRITE(STATE) stepperZ3.toff((STATE)==Z_ENABLE_ON ? chopper_timing_Z3.toff : 0)
     #define Z3_ENABLE_READ() stepperZ3.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Z3)
@@ -215,17 +223,16 @@ void reset_trinamic_drivers();
 // Z4 Stepper
 #if HAS_Z4_ENABLE && AXIS_IS_TMC(Z4)
   extern TMC_CLASS(Z4, Z) stepperZ4;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_z4;
-    static constexpr chopper_timing_t_z4 chopper_timing_z4 = CHOPPER_TIMING_Z4;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_Z4 =
+    #ifdef CHOPPER_TIMING_Z4
+      CHOPPER_TIMING_Z4
+    #else
+      CHOPPER_TIMING_Z
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Z4_ENABLE_INIT() NOOP
-    #define Z4_ENABLE_WRITE(STATE) stepperZ4.toff((STATE)==Z_ENABLE_ON ? chopper_timing_z4.toff : 0)
+    #define Z4_ENABLE_WRITE(STATE) stepperZ4.toff((STATE)==Z_ENABLE_ON ? chopper_timing_Z4.toff : 0)
     #define Z4_ENABLE_READ() stepperZ4.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(Z4)
@@ -236,9 +243,16 @@ void reset_trinamic_drivers();
 // E0 Stepper
 #if AXIS_IS_TMC(E0)
   extern TMC_CLASS_E(0) stepperE0;
+  static constexpr chopper_timing_t chopper_timing_E0 =
+    #ifdef CHOPPER_TIMING_E0
+      CHOPPER_TIMING_E0
+    #else
+      CHOPPER_TIMING_E
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E0)
     #define E0_ENABLE_INIT() NOOP
-    #define E0_ENABLE_WRITE(STATE) stepperE0.toff((STATE)==E_ENABLE_ON ? chopper_timing.E0.toff : 0)
+    #define E0_ENABLE_WRITE(STATE) stepperE0.toff((STATE)==E_ENABLE_ON ? chopper_timing_E0.toff : 0)
     #define E0_ENABLE_READ() stepperE0.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E0)
@@ -249,17 +263,16 @@ void reset_trinamic_drivers();
 // E1 Stepper
 #if AXIS_IS_TMC(E1)
   extern TMC_CLASS_E(1) stepperE1;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_e1;
-    static constexpr chopper_timing_t_e1 chopper_timing_e1 = CHOPPER_TIMING_E1;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_E1 =
+    #ifdef CHOPPER_TIMING_E1
+      CHOPPER_TIMING_E1
+    #else
+      CHOPPER_TIMING_E
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E1)
     #define E1_ENABLE_INIT() NOOP
-    #define E1_ENABLE_WRITE(STATE) stepperE1.toff((STATE)==E_ENABLE_ON ? chopper_timing_e1.toff : 0)
+    #define E1_ENABLE_WRITE(STATE) stepperE1.toff((STATE)==E_ENABLE_ON ? chopper_timing_E1.toff : 0)
     #define E1_ENABLE_READ() stepperE1.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E1)
@@ -270,17 +283,16 @@ void reset_trinamic_drivers();
 // E2 Stepper
 #if AXIS_IS_TMC(E2)
   extern TMC_CLASS_E(2) stepperE2;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_e2;
-    static constexpr chopper_timing_t_e2 chopper_timing_e2 = CHOPPER_TIMING_E2;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_E2 =
+    #ifdef CHOPPER_TIMING_E2
+      CHOPPER_TIMING_E2
+    #else
+      CHOPPER_TIMING_E
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E2)
     #define E2_ENABLE_INIT() NOOP
-    #define E2_ENABLE_WRITE(STATE) stepperE2.toff((STATE)==E_ENABLE_ON ? chopper_timing_e2.toff : 0)
+    #define E2_ENABLE_WRITE(STATE) stepperE2.toff((STATE)==E_ENABLE_ON ? chopper_timing_E2.toff : 0)
     #define E2_ENABLE_READ() stepperE2.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E2)
@@ -291,17 +303,16 @@ void reset_trinamic_drivers();
 // E3 Stepper
 #if AXIS_IS_TMC(E3)
   extern TMC_CLASS_E(3) stepperE3;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_e3;
-    static constexpr chopper_timing_t_e3 chopper_timing_e3 = CHOPPER_TIMING_E3;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_E3 =
+    #ifdef CHOPPER_TIMING_E3
+      CHOPPER_TIMING_E3
+    #else
+      CHOPPER_TIMING_E
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E3)
     #define E3_ENABLE_INIT() NOOP
-    #define E3_ENABLE_WRITE(STATE) stepperE3.toff((STATE)==E_ENABLE_ON ? chopper_timing_e3.toff : 0)
+    #define E3_ENABLE_WRITE(STATE) stepperE3.toff((STATE)==E_ENABLE_ON ? chopper_timing_E3.toff : 0)
     #define E3_ENABLE_READ() stepperE3.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E3)
@@ -312,17 +323,16 @@ void reset_trinamic_drivers();
 // E4 Stepper
 #if AXIS_IS_TMC(E4)
   extern TMC_CLASS_E(4) stepperE4;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_e4;
-    static constexpr chopper_timing_t_e4 chopper_timing_e4 = CHOPPER_TIMING_E4;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_E4 =
+    #ifdef CHOPPER_TIMING_E4
+      CHOPPER_TIMING_E4
+    #else
+      CHOPPER_TIMING_E
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E4)
     #define E4_ENABLE_INIT() NOOP
-    #define E4_ENABLE_WRITE(STATE) stepperE4.toff((STATE)==E_ENABLE_ON ? chopper_timing_e4.toff : 0)
+    #define E4_ENABLE_WRITE(STATE) stepperE4.toff((STATE)==E_ENABLE_ON ? chopper_timing_E4.toff : 0)
     #define E4_ENABLE_READ() stepperE4.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E4)
@@ -333,17 +343,16 @@ void reset_trinamic_drivers();
 // E5 Stepper
 #if AXIS_IS_TMC(E5)
   extern TMC_CLASS_E(5) stepperE5;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_e5;
-    static constexpr chopper_timing_t_e5 chopper_timing_e5 = CHOPPER_TIMING_E5;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_E5 =
+    #ifdef CHOPPER_TIMING_E5
+      CHOPPER_TIMING_E5
+    #else
+      CHOPPER_TIMING_E
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E5)
     #define E5_ENABLE_INIT() NOOP
-    #define E5_ENABLE_WRITE(STATE) stepperE5.toff((STATE)==E_ENABLE_ON ? chopper_timing_e5.toff : 0)
+    #define E5_ENABLE_WRITE(STATE) stepperE5.toff((STATE)==E_ENABLE_ON ? chopper_timing_E5.toff : 0)
     #define E5_ENABLE_READ() stepperE5.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E5)
@@ -354,17 +363,16 @@ void reset_trinamic_drivers();
 // E6 Stepper
 #if AXIS_IS_TMC(E6)
   extern TMC_CLASS_E(6) stepperE6;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_e6;
-    static constexpr chopper_timing_t_e6 chopper_timing_e6 = CHOPPER_TIMING_E6;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_E6 =
+    #ifdef CHOPPER_TIMING_E6
+      CHOPPER_TIMING_E6
+    #else
+      CHOPPER_TIMING_E
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E6)
     #define E6_ENABLE_INIT() NOOP
-    #define E6_ENABLE_WRITE(STATE) stepperE6.toff((STATE)==E_ENABLE_ON ? chopper_timing_e6.toff : 0)
+    #define E6_ENABLE_WRITE(STATE) stepperE6.toff((STATE)==E_ENABLE_ON ? chopper_timing_E6.toff : 0)
     #define E6_ENABLE_READ() stepperE6.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E6)
@@ -375,17 +383,16 @@ void reset_trinamic_drivers();
 // E7 Stepper
 #if AXIS_IS_TMC(E7)
   extern TMC_CLASS_E(7) stepperE7;
-  #if ENABLED(CHOPPER_TIMING_SEPARATE)
-    typedef struct {
-      uint8_t toff; 
-      int8_t hend; 
-      uint8_t hstrt;
-    } chopper_timing_t_e7;
-    static constexpr chopper_timing_t_e7 chopper_timing_e7 = CHOPPER_TIMING_E7;
-  #endif
+  static constexpr chopper_timing_t chopper_timing_E7 =
+    #ifdef CHOPPER_TIMING_E7
+      CHOPPER_TIMING_E7
+    #else
+      CHOPPER_TIMING_E
+    #endif
+  ;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E7)
     #define E7_ENABLE_INIT() NOOP
-    #define E7_ENABLE_WRITE(STATE) stepperE7.toff((STATE)==E_ENABLE_ON ? chopper_timing_e7.toff : 0)
+    #define E7_ENABLE_WRITE(STATE) stepperE7.toff((STATE)==E_ENABLE_ON ? chopper_timing_E7.toff : 0)
     #define E7_ENABLE_READ() stepperE7.isEnabled()
   #endif
   #if AXIS_HAS_SQUARE_WAVE(E7)

--- a/Marlin/src/module/stepper/trinamic.h
+++ b/Marlin/src/module/stepper/trinamic.h
@@ -143,13 +143,10 @@ void reset_trinamic_drivers();
 // X2 Stepper
 #if HAS_X2_ENABLE && AXIS_IS_TMC(X2)
   extern TMC_CLASS(X2, X) stepperX2;
-  static constexpr chopper_timing_t chopper_timing_X2 =
-    #ifdef CHOPPER_TIMING_X2
-      CHOPPER_TIMING_X2
-    #else
-      CHOPPER_TIMING_X
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_X2
+    #define CHOPPER_TIMING_X2 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_X2 = CHOPPER_TIMING_X2;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define X2_ENABLE_INIT() NOOP
     #define X2_ENABLE_WRITE(STATE) stepperX2.toff((STATE)==X_ENABLE_ON ? chopper_timing_X2.toff : 0)
@@ -163,13 +160,10 @@ void reset_trinamic_drivers();
 // Y2 Stepper
 #if HAS_Y2_ENABLE && AXIS_IS_TMC(Y2)
   extern TMC_CLASS(Y2, Y) stepperY2;
-  static constexpr chopper_timing_t chopper_timing_Y2 =
-    #ifdef CHOPPER_TIMING_Y2
-      CHOPPER_TIMING_Y2
-    #else
-      CHOPPER_TIMING_Y
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_Y2
+    #define CHOPPER_TIMING_Y2 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_Y2 = CHOPPER_TIMING_Y2;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Y2_ENABLE_INIT() NOOP
     #define Y2_ENABLE_WRITE(STATE) stepperY2.toff((STATE)==Y_ENABLE_ON ? chopper_timing_Y2.toff : 0)
@@ -183,13 +177,10 @@ void reset_trinamic_drivers();
 // Z2 Stepper
 #if HAS_Z2_ENABLE && AXIS_IS_TMC(Z2)
   extern TMC_CLASS(Z2, Z) stepperZ2;
-  static constexpr chopper_timing_t chopper_timing_Z2 =
-    #ifdef CHOPPER_TIMING_Z2
-      CHOPPER_TIMING_Z2
-    #else
-      CHOPPER_TIMING_Z
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_Z2
+    #define CHOPPER_TIMING_Z2 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_Z2 = CHOPPER_TIMING_Z2;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(Z2)
     #define Z2_ENABLE_INIT() NOOP
     #define Z2_ENABLE_WRITE(STATE) stepperZ2.toff((STATE)==Z_ENABLE_ON ? chopper_timing_Z2.toff : 0)
@@ -203,13 +194,10 @@ void reset_trinamic_drivers();
 // Z3 Stepper
 #if HAS_Z3_ENABLE && AXIS_IS_TMC(Z3)
   extern TMC_CLASS(Z3, Z) stepperZ3;
-  static constexpr chopper_timing_t chopper_timing_Z3 =
-    #ifdef CHOPPER_TIMING_Z3
-      CHOPPER_TIMING_Z3
-    #else
-      CHOPPER_TIMING_Z
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_Z3
+    #define CHOPPER_TIMING_Z3 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_Z3 = CHOPPER_TIMING_Z3;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Z3_ENABLE_INIT() NOOP
     #define Z3_ENABLE_WRITE(STATE) stepperZ3.toff((STATE)==Z_ENABLE_ON ? chopper_timing_Z3.toff : 0)
@@ -223,13 +211,10 @@ void reset_trinamic_drivers();
 // Z4 Stepper
 #if HAS_Z4_ENABLE && AXIS_IS_TMC(Z4)
   extern TMC_CLASS(Z4, Z) stepperZ4;
-  static constexpr chopper_timing_t chopper_timing_Z4 =
-    #ifdef CHOPPER_TIMING_Z4
-      CHOPPER_TIMING_Z4
-    #else
-      CHOPPER_TIMING_Z
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_Z4
+    #define CHOPPER_TIMING_Z4 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_Z4 = CHOPPER_TIMING_Z4;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE)
     #define Z4_ENABLE_INIT() NOOP
     #define Z4_ENABLE_WRITE(STATE) stepperZ4.toff((STATE)==Z_ENABLE_ON ? chopper_timing_Z4.toff : 0)
@@ -243,13 +228,10 @@ void reset_trinamic_drivers();
 // E0 Stepper
 #if AXIS_IS_TMC(E0)
   extern TMC_CLASS_E(0) stepperE0;
-  static constexpr chopper_timing_t chopper_timing_E0 =
-    #ifdef CHOPPER_TIMING_E0
-      CHOPPER_TIMING_E0
-    #else
-      CHOPPER_TIMING_E
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_E0
+    #define CHOPPER_TIMING_E0 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_E0 = CHOPPER_TIMING_E0;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E0)
     #define E0_ENABLE_INIT() NOOP
     #define E0_ENABLE_WRITE(STATE) stepperE0.toff((STATE)==E_ENABLE_ON ? chopper_timing_E0.toff : 0)
@@ -263,13 +245,10 @@ void reset_trinamic_drivers();
 // E1 Stepper
 #if AXIS_IS_TMC(E1)
   extern TMC_CLASS_E(1) stepperE1;
-  static constexpr chopper_timing_t chopper_timing_E1 =
-    #ifdef CHOPPER_TIMING_E1
-      CHOPPER_TIMING_E1
-    #else
-      CHOPPER_TIMING_E
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_E1
+    #define CHOPPER_TIMING_E1 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_E1 = CHOPPER_TIMING_E1;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E1)
     #define E1_ENABLE_INIT() NOOP
     #define E1_ENABLE_WRITE(STATE) stepperE1.toff((STATE)==E_ENABLE_ON ? chopper_timing_E1.toff : 0)
@@ -283,13 +262,10 @@ void reset_trinamic_drivers();
 // E2 Stepper
 #if AXIS_IS_TMC(E2)
   extern TMC_CLASS_E(2) stepperE2;
-  static constexpr chopper_timing_t chopper_timing_E2 =
-    #ifdef CHOPPER_TIMING_E2
-      CHOPPER_TIMING_E2
-    #else
-      CHOPPER_TIMING_E
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_E2
+    #define CHOPPER_TIMING_E2 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_E2 = CHOPPER_TIMING_E2;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E2)
     #define E2_ENABLE_INIT() NOOP
     #define E2_ENABLE_WRITE(STATE) stepperE2.toff((STATE)==E_ENABLE_ON ? chopper_timing_E2.toff : 0)
@@ -303,13 +279,10 @@ void reset_trinamic_drivers();
 // E3 Stepper
 #if AXIS_IS_TMC(E3)
   extern TMC_CLASS_E(3) stepperE3;
-  static constexpr chopper_timing_t chopper_timing_E3 =
-    #ifdef CHOPPER_TIMING_E3
-      CHOPPER_TIMING_E3
-    #else
-      CHOPPER_TIMING_E
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_E3
+    #define CHOPPER_TIMING_E3 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_E3 = CHOPPER_TIMING_E3;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E3)
     #define E3_ENABLE_INIT() NOOP
     #define E3_ENABLE_WRITE(STATE) stepperE3.toff((STATE)==E_ENABLE_ON ? chopper_timing_E3.toff : 0)
@@ -323,13 +296,10 @@ void reset_trinamic_drivers();
 // E4 Stepper
 #if AXIS_IS_TMC(E4)
   extern TMC_CLASS_E(4) stepperE4;
-  static constexpr chopper_timing_t chopper_timing_E4 =
-    #ifdef CHOPPER_TIMING_E4
-      CHOPPER_TIMING_E4
-    #else
-      CHOPPER_TIMING_E
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_E4
+    #define CHOPPER_TIMING_E4 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_E4 = CHOPPER_TIMING_E4;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E4)
     #define E4_ENABLE_INIT() NOOP
     #define E4_ENABLE_WRITE(STATE) stepperE4.toff((STATE)==E_ENABLE_ON ? chopper_timing_E4.toff : 0)
@@ -343,13 +313,10 @@ void reset_trinamic_drivers();
 // E5 Stepper
 #if AXIS_IS_TMC(E5)
   extern TMC_CLASS_E(5) stepperE5;
-  static constexpr chopper_timing_t chopper_timing_E5 =
-    #ifdef CHOPPER_TIMING_E5
-      CHOPPER_TIMING_E5
-    #else
-      CHOPPER_TIMING_E
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_E5
+    #define CHOPPER_TIMING_E5 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_E5 = CHOPPER_TIMING_E5;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E5)
     #define E5_ENABLE_INIT() NOOP
     #define E5_ENABLE_WRITE(STATE) stepperE5.toff((STATE)==E_ENABLE_ON ? chopper_timing_E5.toff : 0)
@@ -363,13 +330,10 @@ void reset_trinamic_drivers();
 // E6 Stepper
 #if AXIS_IS_TMC(E6)
   extern TMC_CLASS_E(6) stepperE6;
-  static constexpr chopper_timing_t chopper_timing_E6 =
-    #ifdef CHOPPER_TIMING_E6
-      CHOPPER_TIMING_E6
-    #else
-      CHOPPER_TIMING_E
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_E6
+    #define CHOPPER_TIMING_E6 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_E6 = CHOPPER_TIMING_E6;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E6)
     #define E6_ENABLE_INIT() NOOP
     #define E6_ENABLE_WRITE(STATE) stepperE6.toff((STATE)==E_ENABLE_ON ? chopper_timing_E6.toff : 0)
@@ -383,13 +347,10 @@ void reset_trinamic_drivers();
 // E7 Stepper
 #if AXIS_IS_TMC(E7)
   extern TMC_CLASS_E(7) stepperE7;
-  static constexpr chopper_timing_t chopper_timing_E7 =
-    #ifdef CHOPPER_TIMING_E7
-      CHOPPER_TIMING_E7
-    #else
-      CHOPPER_TIMING_E
-    #endif
-  ;
+  #ifndef CHOPPER_TIMING_E7
+    #define CHOPPER_TIMING_E7 CHOPPER_TIMING_E
+  #endif
+  static constexpr chopper_timing_t chopper_timing_E7 = CHOPPER_TIMING_E7;
   #if ENABLED(SOFTWARE_DRIVER_ENABLE) && AXIS_IS_TMC(E7)
     #define E7_ENABLE_INIT() NOOP
     #define E7_ENABLE_WRITE(STATE) stepperE7.toff((STATE)==E_ENABLE_ON ? chopper_timing_E7.toff : 0)


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Issue [#18667](https://github.com/MarlinFirmware/Marlin/issues/18667) requests for the chopper timing for stealth chop to be able to be set independently to allow it to work properly when axis have different steppers.

### Benefits

This adds this functionality allowing each one to be set in the same way as the default one is set.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
Similar to setting stepper drivers this is configured by defining a timing for each axis, or if no timing is set the default is used.

Uncomment and change the configurations for each axis below in Configuration_adv.h to enable for each axis, setting their values as with the old default one.
```
  #define CHOPPER_TIMING CHOPPER_DEFAULT_12V
  //For different timings for each axis set below, otherwise default timings will be used
  //#define CHOPPER_TIMING_Y CHOPPER_DEFAULT_12V
  //#define CHOPPER_TIMING_Z CHOPPER_DEFAULT_12V
  //#define CHOPPER_TIMING_E CHOPPER_DEFAULT_12V   
```

### Related Issues

Issue [#18667](https://github.com/MarlinFirmware/Marlin/issues/18667)
