### PR TITLE
Add BigTreeTech SKR Mini MZ V1

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -308,19 +308,20 @@
 #define BOARD_BTT_SKR_MINI_E3_V1_0    4022  // BigTreeTech SKR Mini E3 (STM32F103RC)
 #define BOARD_BTT_SKR_MINI_E3_V1_2    4023  // BigTreeTech SKR Mini E3 V1.2 (STM32F103RC)
 #define BOARD_BTT_SKR_MINI_E3_V2_0    4024  // BigTreeTech SKR Mini E3 V2.0 (STM32F103RC)
-#define BOARD_BTT_SKR_E3_DIP          4025  // BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE)
-#define BOARD_JGAURORA_A5S_A1         4026  // JGAurora A5S A1 (STM32F103ZET6)
-#define BOARD_FYSETC_AIO_II           4027  // FYSETC AIO_II
-#define BOARD_FYSETC_CHEETAH          4028  // FYSETC Cheetah
-#define BOARD_FYSETC_CHEETAH_V12      4029  // FYSETC Cheetah V1.2
-#define BOARD_LONGER3D_LK             4030  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
-#define BOARD_CCROBOT_MEEB_3DP        4031  // ccrobot-online.com MEEB_3DP (STM32F103RC)
-#define BOARD_CHITU3D_V5              4032  // Chitu3D TronXY X5SA V5 Board
-#define BOARD_CHITU3D_V6              4033  // Chitu3D TronXY X5SA V5 Board
-#define BOARD_CREALITY_V4             4034  // Creality v4.x (STM32F103RE)
-#define BOARD_CREALITY_V427           4035  // Creality v4.2.7 (STM32F103RE)
-#define BOARD_TRIGORILLA_PRO          4036  // Trigorilla Pro (STM32F103ZET6)
-#define BOARD_FLY_MINI                4037  // FLY MINI (STM32F103RCT6)
+#define BOARD_BTT_SKR_MINI_MZ_V1_0    4025  // BigTreeTech SKR Mini MZ V1.0 (STM32F103RC)
+#define BOARD_BTT_SKR_E3_DIP          4026  // BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE)
+#define BOARD_JGAURORA_A5S_A1         4027  // JGAurora A5S A1 (STM32F103ZET6)
+#define BOARD_FYSETC_AIO_II           4028  // FYSETC AIO_II
+#define BOARD_FYSETC_CHEETAH          4029  // FYSETC Cheetah
+#define BOARD_FYSETC_CHEETAH_V12      4030  // FYSETC Cheetah V1.2
+#define BOARD_LONGER3D_LK             4031  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
+#define BOARD_CCROBOT_MEEB_3DP        4032  // ccrobot-online.com MEEB_3DP (STM32F103RC)
+#define BOARD_CHITU3D_V5              4033  // Chitu3D TronXY X5SA V5 Board
+#define BOARD_CHITU3D_V6              4034  // Chitu3D TronXY X5SA V5 Board
+#define BOARD_CREALITY_V4             4035  // Creality v4.x (STM32F103RE)
+#define BOARD_CREALITY_V427           4036  // Creality v4.2.7 (STM32F103RE)
+#define BOARD_TRIGORILLA_PRO          4037  // Trigorilla Pro (STM32F103ZET6)
+#define BOARD_FLY_MINI                4038  // FLY MINI (STM32F103RCT6)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -547,6 +547,8 @@
   #include "stm32f1/pins_BTT_SKR_MINI_E3_V1_2.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(BTT_SKR_MINI_E3_V2_0)
   #include "stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
+#elif MB(BTT_SKR_MINI_MZ_V1_0)
+  #include "stm32f1/pins_BTT_SKR_MINI_MZ_V1_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(BTT_SKR_E3_DIP)
   #include "stm32f1/pins_BTT_SKR_E3_DIP.h"      // STM32F1                                env:STM32F103RE_btt env:STM32F103RE_btt_USB env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(JGAURORA_A5S_A1)

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -32,7 +32,9 @@
 
 #include "pins_BTT_SKR_MINI_E3_common.h"
 
-#define BOARD_INFO_NAME "BTT SKR Mini E3 V2.0"
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME "BTT SKR Mini E3 V2.0"
+#endif
 
 // Release PA13/PA14 (led, usb control) from SWD pins
 #define DISABLE_DEBUG

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_MZ_V1_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_MZ_V1_0.h
@@ -1,0 +1,27 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "pins_BTT_SKR_MINI_E3_V2_0.h"
+
+#undef BOARD_INFO_NAME
+#define BOARD_INFO_NAME "BTT SKR Mini MZ V1.0"

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_MZ_V1_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_MZ_V1_0.h
@@ -21,7 +21,6 @@
  */
 #pragma once
 
-#include "pins_BTT_SKR_MINI_E3_V2_0.h"
-
-#undef BOARD_INFO_NAME
 #define BOARD_INFO_NAME "BTT SKR Mini MZ V1.0"
+
+#include "pins_BTT_SKR_MINI_E3_V2_0.h"


### PR DESCRIPTION
### Description

Aftermarket board for the Anycubic Mega Zero. This board is basically an SKR Mini E3 V2 in a different layout.

### Benefits

SKR Mini MZ for the Anycubic Mega Zero support.

### Configurations

https://github.com/MarlinFirmware/Configurations/pull/276

### Related Issues

None.