### PR TITLE
Move stepper driver defaults to Conditionals_adv.h

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -788,31 +788,6 @@
 #ifndef Z_DRIVER_TYPE
   #define Z_DRIVER_TYPE A4988
 #endif
-#if NONE(DUAL_X_CARRIAGE, X_DUAL_STEPPER_DRIVERS)
-  #undef X2_DRIVER_TYPE
-#elif !defined(X2_DRIVER_TYPE)
-  #define X2_DRIVER_TYPE A4988
-#endif
-#if DISABLED(Y_DUAL_STEPPER_DRIVERS)
-  #undef Y2_DRIVER_TYPE
-#elif !defined(Y2_DRIVER_TYPE)
-  #define Y2_DRIVER_TYPE A4988
-#endif
-#if NUM_Z_STEPPER_DRIVERS < 2
-  #undef Z2_DRIVER_TYPE
-#elif !defined(Z2_DRIVER_TYPE)
-  #define Z2_DRIVER_TYPE A4988
-#endif
-#if NUM_Z_STEPPER_DRIVERS < 3
-  #undef Z3_DRIVER_TYPE
-#elif !defined(Z3_DRIVER_TYPE)
-  #define Z3_DRIVER_TYPE A4988
-#endif
-#if NUM_Z_STEPPER_DRIVERS < 4
-  #undef Z4_DRIVER_TYPE
-#elif !defined(Z4_DRIVER_TYPE)
-  #define Z4_DRIVER_TYPE A4988
-#endif
 #if E_STEPPERS < 1
   #undef E0_DRIVER_TYPE
 #elif !defined(E0_DRIVER_TYPE)

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -778,52 +778,67 @@
   #define HAS_USB_SERIAL 1
 #endif
 
-// Fallback Stepper Driver types
+// Fallback Stepper Driver types that don't depend on Configuration_adv.h
 #ifndef X_DRIVER_TYPE
-  #define X_DRIVER_TYPE A4988
+  #define X_DRIVER_TYPE  A4988
+#endif
+#ifndef X2_DRIVER_TYPE
+  #define X2_DRIVER_TYPE A4988
 #endif
 #ifndef Y_DRIVER_TYPE
-  #define Y_DRIVER_TYPE A4988
+  #define Y_DRIVER_TYPE  A4988
+#endif
+#ifndef Y2_DRIVER_TYPE
+  #define Y2_DRIVER_TYPE A4988
 #endif
 #ifndef Z_DRIVER_TYPE
-  #define Z_DRIVER_TYPE A4988
+  #define Z_DRIVER_TYPE  A4988
 #endif
-#if E_STEPPERS < 1
+#ifndef Z2_DRIVER_TYPE
+  #define Z2_DRIVER_TYPE A4988
+#endif
+#ifndef Z3_DRIVER_TYPE
+  #define Z3_DRIVER_TYPE A4988
+#endif
+#ifndef Z4_DRIVER_TYPE
+  #define Z4_DRIVER_TYPE A4988
+#endif
+#if E_STEPPERS <= 0
   #undef E0_DRIVER_TYPE
 #elif !defined(E0_DRIVER_TYPE)
   #define E0_DRIVER_TYPE A4988
 #endif
-#if E_STEPPERS < 2
+#if E_STEPPERS <= 1
   #undef E1_DRIVER_TYPE
 #elif !defined(E1_DRIVER_TYPE)
   #define E1_DRIVER_TYPE A4988
 #endif
-#if E_STEPPERS < 3
+#if E_STEPPERS <= 2
   #undef E2_DRIVER_TYPE
 #elif !defined(E2_DRIVER_TYPE)
   #define E2_DRIVER_TYPE A4988
 #endif
-#if E_STEPPERS < 4
+#if E_STEPPERS <= 3
   #undef E3_DRIVER_TYPE
 #elif !defined(E3_DRIVER_TYPE)
   #define E3_DRIVER_TYPE A4988
 #endif
-#if E_STEPPERS < 5
+#if E_STEPPERS <= 4
   #undef E4_DRIVER_TYPE
 #elif !defined(E4_DRIVER_TYPE)
   #define E4_DRIVER_TYPE A4988
 #endif
-#if E_STEPPERS < 6
+#if E_STEPPERS <= 5
   #undef E5_DRIVER_TYPE
 #elif !defined(E5_DRIVER_TYPE)
   #define E5_DRIVER_TYPE A4988
 #endif
-#if E_STEPPERS < 7
+#if E_STEPPERS <= 6
   #undef E6_DRIVER_TYPE
 #elif !defined(E6_DRIVER_TYPE)
   #define E6_DRIVER_TYPE A4988
 #endif
-#if E_STEPPERS < 8
+#if E_STEPPERS <= 7
   #undef E7_DRIVER_TYPE
 #elif !defined(E7_DRIVER_TYPE)
   #define E7_DRIVER_TYPE A4988

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -501,3 +501,30 @@
   #define USING_SERIAL_8 1
 #endif
 #undef ANY_SERIAL_IS
+
+// Fallback Stepper Driver types
+#if NONE(DUAL_X_CARRIAGE, X_DUAL_STEPPER_DRIVERS)
+  #undef X2_DRIVER_TYPE
+#elif !defined(X2_DRIVER_TYPE)
+  #define X2_DRIVER_TYPE A4988
+#endif
+#if DISABLED(Y_DUAL_STEPPER_DRIVERS)
+  #undef Y2_DRIVER_TYPE
+#elif !defined(Y2_DRIVER_TYPE)
+  #define Y2_DRIVER_TYPE A4988
+#endif
+#if NUM_Z_STEPPER_DRIVERS < 2
+  #undef Z2_DRIVER_TYPE
+#elif !defined(Z2_DRIVER_TYPE)
+  #define Z2_DRIVER_TYPE A4988
+#endif
+#if NUM_Z_STEPPER_DRIVERS < 3
+  #undef Z3_DRIVER_TYPE
+#elif !defined(Z3_DRIVER_TYPE)
+  #define Z3_DRIVER_TYPE A4988
+#endif
+#if NUM_Z_STEPPER_DRIVERS < 4
+  #undef Z4_DRIVER_TYPE
+#elif !defined(Z4_DRIVER_TYPE)
+  #define Z4_DRIVER_TYPE A4988
+#endif

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -178,16 +178,35 @@
   #define HAS_MOTOR_CURRENT_I2C 1
 #endif
 
+#if ENABLED(Z_STEPPER_AUTO_ALIGN)
+  #if ENABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
+    #undef Z_STEPPER_ALIGN_AMP
+  #endif
+  #ifndef Z_STEPPER_ALIGN_AMP
+    #define Z_STEPPER_ALIGN_AMP 1.0
+  #endif
+#endif
+
 // Multiple Z steppers
 #ifndef NUM_Z_STEPPER_DRIVERS
   #define NUM_Z_STEPPER_DRIVERS 1
 #endif
 
-#if ENABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
-  #undef Z_STEPPER_ALIGN_AMP
+// Fallback Stepper Driver types that depend on Configuration_adv.h
+#if NONE(DUAL_X_CARRIAGE, X_DUAL_STEPPER_DRIVERS)
+  #undef X2_DRIVER_TYPE
 #endif
-#ifndef Z_STEPPER_ALIGN_AMP
-  #define Z_STEPPER_ALIGN_AMP 1.0
+#if DISABLED(Y_DUAL_STEPPER_DRIVERS)
+  #undef Y2_DRIVER_TYPE
+#endif
+#if NUM_Z_STEPPER_DRIVERS < 2
+  #undef Z2_DRIVER_TYPE
+#endif
+#if NUM_Z_STEPPER_DRIVERS < 3
+  #undef Z3_DRIVER_TYPE
+#endif
+#if NUM_Z_STEPPER_DRIVERS < 4
+  #undef Z4_DRIVER_TYPE
 #endif
 
 //
@@ -501,30 +520,3 @@
   #define USING_SERIAL_8 1
 #endif
 #undef ANY_SERIAL_IS
-
-// Fallback Stepper Driver types
-#if NONE(DUAL_X_CARRIAGE, X_DUAL_STEPPER_DRIVERS)
-  #undef X2_DRIVER_TYPE
-#elif !defined(X2_DRIVER_TYPE)
-  #define X2_DRIVER_TYPE A4988
-#endif
-#if DISABLED(Y_DUAL_STEPPER_DRIVERS)
-  #undef Y2_DRIVER_TYPE
-#elif !defined(Y2_DRIVER_TYPE)
-  #define Y2_DRIVER_TYPE A4988
-#endif
-#if NUM_Z_STEPPER_DRIVERS < 2
-  #undef Z2_DRIVER_TYPE
-#elif !defined(Z2_DRIVER_TYPE)
-  #define Z2_DRIVER_TYPE A4988
-#endif
-#if NUM_Z_STEPPER_DRIVERS < 3
-  #undef Z3_DRIVER_TYPE
-#elif !defined(Z3_DRIVER_TYPE)
-  #define Z3_DRIVER_TYPE A4988
-#endif
-#if NUM_Z_STEPPER_DRIVERS < 4
-  #undef Z4_DRIVER_TYPE
-#elif !defined(Z4_DRIVER_TYPE)
-  #define Z4_DRIVER_TYPE A4988
-#endif


### PR DESCRIPTION
### Description

Fixes issues with PR 19798
Test where introduced into Conditionals_LCD.h requiring unavailable setting from Configuration_adv.h   
Moved these tests to  Conditionals_adv.h

### Benefits

Works as expected

### Related Issues

PR #19798 