### PR TITLE
Interpret spread / stealth based on spread_en state

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -485,6 +485,7 @@
     TMC_PWM_OFS_AUTO,
     TMC_PWM_GRAD_AUTO,
     TMC_VSENSE,
+    TMC_SPREAD_EN,
     TMC_STEALTHCHOP,
     TMC_MICROSTEPS,
     TMC_TSTEP,
@@ -617,6 +618,7 @@
         switch (i) {
           case TMC_SGT:       SERIAL_PRINT(st.SGTHRS(), DEC); break;
           case TMC_UART_ADDR: SERIAL_PRINT(st.get_address(), DEC); break;
+          case TMC_SPREAD_EN: serialprint_truefalse(st.spread_en()); break;
           default:
             TMC2208Stepper *parent = &st;
             _tmc_status(*parent, i);
@@ -909,6 +911,9 @@
     TMC_REPORT("PWM scale",          TMC_PWM_SCALE);
     #if HAS_DRIVER(TMC2130) || HAS_DRIVER(TMC2224) || HAS_DRIVER(TMC2660) || HAS_TMC220x
       TMC_REPORT("vsense\t",         TMC_VSENSE);
+    #endif
+    #if HAS_DRIVER(TMC2209)
+      TMC_REPORT("spread_en\t",      TMC_SPREAD_EN);
     #endif
     TMC_REPORT("stealthChop",        TMC_STEALTHCHOP);
     TMC_REPORT("msteps\t",           TMC_MICROSTEPS);

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -222,7 +222,7 @@ class TMCMarlin<TMC2209Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC220
     #if HAS_STEALTHCHOP
       inline bool get_stealthChop()                { return !this->en_spreadCycle(); }
       inline bool get_stored_stealthChop()         { return this->stored.stealthChop_enabled; }
-      inline void refresh_stepping_mode()          { this->en_spreadCycle(!this->stored.stealthChop_enabled); }
+      inline void refresh_stepping_mode()          { this->en_spreadCycle((!this->stored.stealthChop_enabled) ^ this->spread_en()); } // If SPREAD_EN is HIGH the outcome is reversed
       inline void set_stealthChop(const bool stch) { this->stored.stealthChop_enabled = stch; refresh_stepping_mode(); }
       inline bool toggle_stepping_mode()           { set_stealthChop(!this->stored.stealthChop_enabled); return get_stealthChop(); }
     #endif

--- a/Marlin/src/gcode/feature/trinamic/M569.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M569.cpp
@@ -35,14 +35,9 @@ void tmc_say_stealth_status(TMC &st) {
   serialprintPGM(st.get_stealthChop() ? PSTR("stealthChop") : PSTR("spreadCycle"));
   SERIAL_EOL();
 }
-template<typename TMC>
-void tmc_set_stealthChop(TMC &st, const bool enable) {
-  st.stored.stealthChop_enabled = enable;
-  st.refresh_stepping_mode();
-}
 
 static void set_stealth_status(const bool enable, const int8_t target_extruder) {
-  #define TMC_SET_STEALTH(Q) tmc_set_stealthChop(stepper##Q, enable)
+  #define TMC_SET_STEALTH(Q) stepper##Q.set_stealthChop(enable)
 
   #if    AXIS_HAS_STEALTHCHOP(X)  || AXIS_HAS_STEALTHCHOP(X2) \
       || AXIS_HAS_STEALTHCHOP(Y)  || AXIS_HAS_STEALTHCHOP(Y2) \

--- a/Marlin/src/lcd/menu/menu_tmc.cpp
+++ b/Marlin/src/lcd/menu/menu_tmc.cpp
@@ -186,7 +186,10 @@ void menu_tmc_current() {
 
 #if HAS_STEALTHCHOP
 
-  #define TMC_EDIT_STEP_MODE(ST, STR) EDIT_ITEM_P(bool, PSTR(STR), &stepper##ST.stored.stealthChop_enabled, []{ stepper##ST.refresh_stepping_mode(); })
+  #define TMC_EDIT_STEP_MODE(ST, STR) do{ \
+    editable.state = stepper##ST.get_stored_stealthChop(); \
+    EDIT_ITEM_P(bool, PSTR(STR), &editable.state, []{ (void)stepper##ST.toggle_stepping_mode(); }); \
+  }while(0)
 
   void menu_tmc_step_mode() {
     START_MENU();

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2081,7 +2081,7 @@ void MarlinSettings::postprocess() {
 
         #if HAS_TRINAMIC_CONFIG
 
-          #define SET_STEPPING_MODE(ST) stepper##ST.stored.stealthChop_enabled = tmc_stealth_enabled.ST; stepper##ST.refresh_stepping_mode();
+          #define SET_STEPPING_MODE(ST) stepper##ST.set_stealthChop(tmc_stealth_enabled.ST)
           if (!validating) {
             #if AXIS_HAS_STEALTHCHOP(X)
               SET_STEPPING_MODE(X);


### PR DESCRIPTION
According to discussion in #19824 the status bit for stealth/spread is inverted if the stepper driver is hard-wired for SPREAD mode. This PR adds an option to interpret the bit differently if your drivers are hardwired in SPREAD mode. If needed, this PR can be extended to allow for a mix of drivers with and without the SPREAD pin connected.