### PR TITLE
Configure TMC interpolation per driver.

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2282,7 +2282,7 @@
     #define X2_MICROSTEPS    16
     #define X2_RSENSE         0.11
     #define X2_CHAIN_POS     -1
-    //#define X2_INTERPOLATE true     // Use interpolation on X axis 
+    //#define X2_INTERPOLATE true     // Use interpolation on X2 axis 
   #endif
 
   #if AXIS_IS_TMC(Y)
@@ -2291,7 +2291,7 @@
     #define Y_MICROSTEPS     16
     #define Y_RSENSE          0.11
     #define Y_CHAIN_POS      -1
-    //#define Y_INTERPOLATE true      // Use interpolation on X axis 
+    //#define Y_INTERPOLATE true      // Use interpolation on Y axis 
   #endif
 
   #if AXIS_IS_TMC(Y2)
@@ -2300,7 +2300,7 @@
     #define Y2_MICROSTEPS    16
     #define Y2_RSENSE         0.11
     #define Y2_CHAIN_POS     -1
-    //#define Y2_INTERPOLATE true      // Use interpolation on X axis 
+    //#define Y2_INTERPOLATE true      // Use interpolation on Y2 axis 
   #endif
 
   #if AXIS_IS_TMC(Z)
@@ -2309,7 +2309,7 @@
     #define Z_MICROSTEPS     16
     #define Z_RSENSE          0.11
     #define Z_CHAIN_POS      -1
-    //#define Z_INTERPOLATE true      // Use interpolation on X axis 
+    //#define Z_INTERPOLATE true      // Use interpolation on Z axis 
   #endif
 
   #if AXIS_IS_TMC(Z2)
@@ -2318,7 +2318,7 @@
     #define Z2_MICROSTEPS    16
     #define Z2_RSENSE         0.11
     #define Z2_CHAIN_POS     -1
-    //#define Z2_INTERPOLATE true      // Use interpolation on X axis 
+    //#define Z2_INTERPOLATE true      // Use interpolation on Z2 axis 
   #endif
 
   #if AXIS_IS_TMC(Z3)
@@ -2327,7 +2327,7 @@
     #define Z3_MICROSTEPS    16
     #define Z3_RSENSE         0.11
     #define Z3_CHAIN_POS     -1
-    //#define Z3_INTERPOLATE true      // Use interpolation on X axis 
+    //#define Z3_INTERPOLATE true      // Use interpolation on Z3 axis 
   #endif
 
   #if AXIS_IS_TMC(Z4)
@@ -2336,7 +2336,7 @@
     #define Z4_MICROSTEPS    16
     #define Z4_RSENSE         0.11
     #define Z4_CHAIN_POS     -1
-    //#define Z4_INTERPOLATE true      // Use interpolation on X axis 
+    //#define Z4_INTERPOLATE true      // Use interpolation on Z4 axis 
   #endif
 
   #if AXIS_IS_TMC(E0)
@@ -2344,7 +2344,7 @@
     #define E0_MICROSTEPS    16
     #define E0_RSENSE         0.11
     #define E0_CHAIN_POS     -1
-    //#define E0_INTERPOLATE true      // Use interpolation on X axis 
+    //#define E0_INTERPOLATE true      // Use interpolation on E0 axis 
   #endif
 
   #if AXIS_IS_TMC(E1)
@@ -2352,7 +2352,7 @@
     #define E1_MICROSTEPS    16
     #define E1_RSENSE         0.11
     #define E1_CHAIN_POS     -1
-    //#define E1_INTERPOLATE true      // Use interpolation on X axis 
+    //#define E1_INTERPOLATE true      // Use interpolation on E1 axis 
   #endif
 
   #if AXIS_IS_TMC(E2)
@@ -2360,7 +2360,7 @@
     #define E2_MICROSTEPS    16
     #define E2_RSENSE         0.11
     #define E2_CHAIN_POS     -1
-    //#define E2_INTERPOLATE true      // Use interpolation on X axis 
+    //#define E2_INTERPOLATE true      // Use interpolation on E2 axis 
   #endif
 
   #if AXIS_IS_TMC(E3)
@@ -2368,7 +2368,7 @@
     #define E3_MICROSTEPS    16
     #define E3_RSENSE         0.11
     #define E3_CHAIN_POS     -1
-    //#define E3_INTERPOLATE true      // Use interpolation on X axis 
+    //#define E3_INTERPOLATE true      // Use interpolation on E3 axis 
   #endif
 
   #if AXIS_IS_TMC(E4)
@@ -2376,7 +2376,7 @@
     #define E4_MICROSTEPS    16
     #define E4_RSENSE         0.11
     #define E4_CHAIN_POS     -1
-    //#define E4_INTERPOLATE true      // Use interpolation on X axis 
+    //#define E4_INTERPOLATE true      // Use interpolation on E4 axis 
   #endif
 
   #if AXIS_IS_TMC(E5)
@@ -2384,7 +2384,7 @@
     #define E5_MICROSTEPS    16
     #define E5_RSENSE         0.11
     #define E5_CHAIN_POS     -1
-    //#define E5_INTERPOLATE true      // Use interpolation on X axis 
+    //#define E5_INTERPOLATE true      // Use interpolation on E5 axis 
   #endif
 
   #if AXIS_IS_TMC(E6)
@@ -2392,7 +2392,7 @@
     #define E6_MICROSTEPS    16
     #define E6_RSENSE         0.11
     #define E6_CHAIN_POS     -1
-    //#define E6_INTERPOLATE true      // Use interpolation on X axis 
+    //#define E6_INTERPOLATE true      // Use interpolation on E6 axis 
   #endif
 
   #if AXIS_IS_TMC(E7)
@@ -2400,7 +2400,7 @@
     #define E7_MICROSTEPS    16
     #define E7_RSENSE         0.11
     #define E7_CHAIN_POS     -1
-    //#define E7_INTERPOLATE true      // Use interpolation on X axis 
+    //#define E7_INTERPOLATE true      // Use interpolation on E7 axis 
   #endif
 
   /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2266,7 +2266,7 @@
    * Interpolate microsteps to 256
    * Override for each driver with <driver>_INTERPOLATE settings below
    */
-  #define INTERPOLATE      true        // Interpolate X/Y/Z Microsteps to 256
+  #define INTERPOLATE      true
 
   #if AXIS_IS_TMC(X)
     #define X_CURRENT       800        // (mA) RMS current. Multiply by 1.414 for peak current.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2261,6 +2261,10 @@
 #if HAS_TRINAMIC_CONFIG
 
   #define HOLD_MULTIPLIER    0.5  // Scales down the holding current from run current
+  /*
+   * Interpolate microsteps to 256
+   * This can be overriden per driver with the <driver>_INTERPOLATE setting below
+   */
   #define INTERPOLATE       true  // Interpolate X/Y/Z_MICROSTEPS to 256
 
   #if AXIS_IS_TMC(X)
@@ -2269,6 +2273,7 @@
     #define X_MICROSTEPS     16    // 0..256
     #define X_RSENSE          0.11
     #define X_CHAIN_POS      -1    // <=0 : Not chained. 1 : MCU MOSI connected. 2 : Next in chain, ...
+    //#define X_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(X2)
@@ -2277,6 +2282,7 @@
     #define X2_MICROSTEPS    16
     #define X2_RSENSE         0.11
     #define X2_CHAIN_POS     -1
+    //#define X2_INTERPOLATE true     // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(Y)
@@ -2285,6 +2291,7 @@
     #define Y_MICROSTEPS     16
     #define Y_RSENSE          0.11
     #define Y_CHAIN_POS      -1
+    //#define Y_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(Y2)
@@ -2293,6 +2300,7 @@
     #define Y2_MICROSTEPS    16
     #define Y2_RSENSE         0.11
     #define Y2_CHAIN_POS     -1
+    //#define Y2_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(Z)
@@ -2301,6 +2309,7 @@
     #define Z_MICROSTEPS     16
     #define Z_RSENSE          0.11
     #define Z_CHAIN_POS      -1
+    //#define Z_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(Z2)
@@ -2309,6 +2318,7 @@
     #define Z2_MICROSTEPS    16
     #define Z2_RSENSE         0.11
     #define Z2_CHAIN_POS     -1
+    //#define Z2_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(Z3)
@@ -2317,6 +2327,7 @@
     #define Z3_MICROSTEPS    16
     #define Z3_RSENSE         0.11
     #define Z3_CHAIN_POS     -1
+    //#define Z3_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(Z4)
@@ -2325,6 +2336,7 @@
     #define Z4_MICROSTEPS    16
     #define Z4_RSENSE         0.11
     #define Z4_CHAIN_POS     -1
+    //#define Z4_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(E0)
@@ -2332,6 +2344,7 @@
     #define E0_MICROSTEPS    16
     #define E0_RSENSE         0.11
     #define E0_CHAIN_POS     -1
+    //#define E0_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(E1)
@@ -2339,6 +2352,7 @@
     #define E1_MICROSTEPS    16
     #define E1_RSENSE         0.11
     #define E1_CHAIN_POS     -1
+    //#define E1_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(E2)
@@ -2346,6 +2360,7 @@
     #define E2_MICROSTEPS    16
     #define E2_RSENSE         0.11
     #define E2_CHAIN_POS     -1
+    //#define E2_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(E3)
@@ -2353,6 +2368,7 @@
     #define E3_MICROSTEPS    16
     #define E3_RSENSE         0.11
     #define E3_CHAIN_POS     -1
+    //#define E3_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(E4)
@@ -2360,6 +2376,7 @@
     #define E4_MICROSTEPS    16
     #define E4_RSENSE         0.11
     #define E4_CHAIN_POS     -1
+    //#define E4_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(E5)
@@ -2367,6 +2384,7 @@
     #define E5_MICROSTEPS    16
     #define E5_RSENSE         0.11
     #define E5_CHAIN_POS     -1
+    //#define E5_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(E6)
@@ -2374,6 +2392,7 @@
     #define E6_MICROSTEPS    16
     #define E6_RSENSE         0.11
     #define E6_CHAIN_POS     -1
+    //#define E6_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   #if AXIS_IS_TMC(E7)
@@ -2381,6 +2400,7 @@
     #define E7_MICROSTEPS    16
     #define E7_RSENSE         0.11
     #define E7_CHAIN_POS     -1
+    //#define E7_INTERPOLATE true      // Use interpolation on X axis 
   #endif
 
   /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2261,19 +2261,20 @@
 #if HAS_TRINAMIC_CONFIG
 
   #define HOLD_MULTIPLIER    0.5  // Scales down the holding current from run current
-  /*
+
+  /**
    * Interpolate microsteps to 256
-   * This can be overriden per driver with the <driver>_INTERPOLATE setting below
+   * Override for each driver with <driver>_INTERPOLATE settings below
    */
-  #define INTERPOLATE       true  // Interpolate X/Y/Z_MICROSTEPS to 256
+  #define INTERPOLATE      true        // Interpolate X/Y/Z Microsteps to 256
 
   #if AXIS_IS_TMC(X)
     #define X_CURRENT       800        // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_CURRENT_HOME  X_CURRENT  // (mA) RMS current for sensorless homing
-    #define X_MICROSTEPS     16    // 0..256
+    #define X_MICROSTEPS     16        // 0..256
     #define X_RSENSE          0.11
-    #define X_CHAIN_POS      -1    // <=0 : Not chained. 1 : MCU MOSI connected. 2 : Next in chain, ...
-    //#define X_INTERPOLATE true      // Use interpolation on X axis 
+    #define X_CHAIN_POS      -1        // -1..0: Not chained. 1: MCU MOSI connected. 2: Next in chain, ...
+    //#define X_INTERPOLATE  true      // Enable to override 'INTERPOLATE' for the X axis
   #endif
 
   #if AXIS_IS_TMC(X2)
@@ -2282,7 +2283,7 @@
     #define X2_MICROSTEPS    16
     #define X2_RSENSE         0.11
     #define X2_CHAIN_POS     -1
-    //#define X2_INTERPOLATE true     // Use interpolation on X2 axis 
+    //#define X2_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(Y)
@@ -2291,7 +2292,7 @@
     #define Y_MICROSTEPS     16
     #define Y_RSENSE          0.11
     #define Y_CHAIN_POS      -1
-    //#define Y_INTERPOLATE true      // Use interpolation on Y axis 
+    //#define Y_INTERPOLATE  true
   #endif
 
   #if AXIS_IS_TMC(Y2)
@@ -2300,7 +2301,7 @@
     #define Y2_MICROSTEPS    16
     #define Y2_RSENSE         0.11
     #define Y2_CHAIN_POS     -1
-    //#define Y2_INTERPOLATE true      // Use interpolation on Y2 axis 
+    //#define Y2_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(Z)
@@ -2309,7 +2310,7 @@
     #define Z_MICROSTEPS     16
     #define Z_RSENSE          0.11
     #define Z_CHAIN_POS      -1
-    //#define Z_INTERPOLATE true      // Use interpolation on Z axis 
+    //#define Z_INTERPOLATE  true
   #endif
 
   #if AXIS_IS_TMC(Z2)
@@ -2318,7 +2319,7 @@
     #define Z2_MICROSTEPS    16
     #define Z2_RSENSE         0.11
     #define Z2_CHAIN_POS     -1
-    //#define Z2_INTERPOLATE true      // Use interpolation on Z2 axis 
+    //#define Z2_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(Z3)
@@ -2327,7 +2328,7 @@
     #define Z3_MICROSTEPS    16
     #define Z3_RSENSE         0.11
     #define Z3_CHAIN_POS     -1
-    //#define Z3_INTERPOLATE true      // Use interpolation on Z3 axis 
+    //#define Z3_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(Z4)
@@ -2336,7 +2337,7 @@
     #define Z4_MICROSTEPS    16
     #define Z4_RSENSE         0.11
     #define Z4_CHAIN_POS     -1
-    //#define Z4_INTERPOLATE true      // Use interpolation on Z4 axis 
+    //#define Z4_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(E0)
@@ -2344,7 +2345,7 @@
     #define E0_MICROSTEPS    16
     #define E0_RSENSE         0.11
     #define E0_CHAIN_POS     -1
-    //#define E0_INTERPOLATE true      // Use interpolation on E0 axis 
+    //#define E0_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(E1)
@@ -2352,7 +2353,7 @@
     #define E1_MICROSTEPS    16
     #define E1_RSENSE         0.11
     #define E1_CHAIN_POS     -1
-    //#define E1_INTERPOLATE true      // Use interpolation on E1 axis 
+    //#define E1_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(E2)
@@ -2360,7 +2361,7 @@
     #define E2_MICROSTEPS    16
     #define E2_RSENSE         0.11
     #define E2_CHAIN_POS     -1
-    //#define E2_INTERPOLATE true      // Use interpolation on E2 axis 
+    //#define E2_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(E3)
@@ -2368,7 +2369,7 @@
     #define E3_MICROSTEPS    16
     #define E3_RSENSE         0.11
     #define E3_CHAIN_POS     -1
-    //#define E3_INTERPOLATE true      // Use interpolation on E3 axis 
+    //#define E3_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(E4)
@@ -2376,7 +2377,7 @@
     #define E4_MICROSTEPS    16
     #define E4_RSENSE         0.11
     #define E4_CHAIN_POS     -1
-    //#define E4_INTERPOLATE true      // Use interpolation on E4 axis 
+    //#define E4_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(E5)
@@ -2384,7 +2385,7 @@
     #define E5_MICROSTEPS    16
     #define E5_RSENSE         0.11
     #define E5_CHAIN_POS     -1
-    //#define E5_INTERPOLATE true      // Use interpolation on E5 axis 
+    //#define E5_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(E6)
@@ -2392,7 +2393,7 @@
     #define E6_MICROSTEPS    16
     #define E6_RSENSE         0.11
     #define E6_CHAIN_POS     -1
-    //#define E6_INTERPOLATE true      // Use interpolation on E6 axis 
+    //#define E6_INTERPOLATE true
   #endif
 
   #if AXIS_IS_TMC(E7)
@@ -2400,7 +2401,7 @@
     #define E7_MICROSTEPS    16
     #define E7_RSENSE         0.11
     #define E7_CHAIN_POS     -1
-    //#define E7_INTERPOLATE true      // Use interpolation on E7 axis 
+    //#define E7_INTERPOLATE true
   #endif
 
   /**

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -554,13 +554,7 @@
         case TMC_PWM_SCALE: SERIAL_PRINT(st.PWM_SCALE(), DEC); break;
         case TMC_SGT: SERIAL_PRINT(st.sgt(), DEC); break;
         case TMC_STEALTHCHOP: serialprint_truefalse(st.en_pwm_mode()); break;
-        case TMC_INTERPOLATE:
-          {
-            CHOPCONF_t r{0};
-            r.sr = st.CHOPCONF();
-            serialprint_truefalse(r.intpol);
-          }
-          break;
+        case TMC_INTERPOLATE: serialprint_truefalse(st.intpol()); break;
         default: break;
       }
     }
@@ -596,13 +590,7 @@
             SERIAL_ECHOPGM("/256");
           }
           break;
-        case TMC_INTERPOLATE:
-          {
-            CHOPCONF_t r{0};
-            r.sr = st.CHOPCONF();
-            serialprint_truefalse(r.intpol);
-          }
-          break;
+        case TMC_INTERPOLATE: serialprint_truefalse(st.intpol()); break;
         default: break;
       }
     }
@@ -618,13 +606,7 @@
         case TMC_STEALTHCHOP: serialprint_truefalse(st.stealth()); break;
         case TMC_S2VSA: if (st.s2vsa()) SERIAL_CHAR('*'); break;
         case TMC_S2VSB: if (st.s2vsb()) SERIAL_CHAR('*'); break;
-        case TMC_INTERPOLATE:
-          {
-            CHOPCONF_t r{0};
-            r.sr = st.CHOPCONF();
-            serialprint_truefalse(r.intpol);
-          }
-          break;
+        case TMC_INTERPOLATE: serialprint_truefalse(st.intpol()); break;
         default: break;
       }
     }

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -648,7 +648,7 @@
 
   #if HAS_DRIVER(TMC2660)
     static void _tmc_parse_drv_status(TMC2660Stepper, const TMC_drv_status_enum) { }
-    static void _tmc_status(TMC2208Stepper &st, const TMC_debug_enum i) {
+    static void _tmc_status(TMC2660Stepper &st, const TMC_debug_enum i) {
       switch (i) {
         case TMC_INTERPOLATE: serialprint_truefalse(st.intpol()); break;
         default: break;

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -497,7 +497,8 @@
     TMC_HEND,
     TMC_HSTRT,
     TMC_SGT,
-    TMC_MSCNT
+    TMC_MSCNT,
+    TMC_INTERPOLATE
   };
   enum TMC_drv_status_enum : char {
     TMC_DRV_CODES,
@@ -553,6 +554,13 @@
         case TMC_PWM_SCALE: SERIAL_PRINT(st.PWM_SCALE(), DEC); break;
         case TMC_SGT: SERIAL_PRINT(st.sgt(), DEC); break;
         case TMC_STEALTHCHOP: serialprint_truefalse(st.en_pwm_mode()); break;
+        case TMC_INTERPOLATE:
+          {
+            CHOPCONF_t r{0};
+            r.sr = st.CHOPCONF();
+            serialprint_truefalse(r.intpol);
+          }
+          break;
         default: break;
       }
     }
@@ -588,6 +596,13 @@
             SERIAL_ECHOPGM("/256");
           }
           break;
+        case TMC_INTERPOLATE:
+          {
+            CHOPCONF_t r{0};
+            r.sr = st.CHOPCONF();
+            serialprint_truefalse(r.intpol);
+          }
+          break;
         default: break;
       }
     }
@@ -603,6 +618,13 @@
         case TMC_STEALTHCHOP: serialprint_truefalse(st.stealth()); break;
         case TMC_S2VSA: if (st.s2vsa()) SERIAL_CHAR('*'); break;
         case TMC_S2VSB: if (st.s2vsb()) SERIAL_CHAR('*'); break;
+        case TMC_INTERPOLATE:
+          {
+            CHOPCONF_t r{0};
+            r.sr = st.CHOPCONF();
+            serialprint_truefalse(r.intpol);
+          }
+          break;
         default: break;
       }
     }
@@ -644,6 +666,12 @@
 
   #if HAS_DRIVER(TMC2660)
     static void _tmc_parse_drv_status(TMC2660Stepper, const TMC_drv_status_enum) { }
+    static void _tmc_status(TMC2208Stepper &st, const TMC_debug_enum i) {
+      switch (i) {
+        case TMC_INTERPOLATE: serialprint_truefalse(st.intpol()); break;
+        default: break;
+      }
+    }
   #endif
 
   template <typename TMC>
@@ -902,6 +930,7 @@
     #endif
     TMC_REPORT("stealthChop",        TMC_STEALTHCHOP);
     TMC_REPORT("msteps\t",           TMC_MICROSTEPS);
+    TMC_REPORT("interp\t",           TMC_INTERPOLATE);
     TMC_REPORT("tstep\t",            TMC_TSTEP);
     TMC_REPORT("PWM thresh.",        TMC_TPWMTHRS);
     TMC_REPORT("[mm/s]\t",           TMC_TPWMTHRS_MMS);

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1608,6 +1608,54 @@
     #define Y_SPI_SENSORLESS Y_SENSORLESS
     #define Z_SPI_SENSORLESS Z_SENSORLESS
   #endif
+  #ifndef X_INTERPOLATE
+    #define X_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef X2_INTERPOLATE
+    #define X2_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef Y_INTERPOLATE
+    #define Y_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef Y2_INTERPOLATE
+    #define Y2_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef Z_INTERPOLATE
+    #define Z_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef Z2_INTERPOLATE
+    #define Z2_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef Z3_INTERPOLATE
+    #define Z3_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef Z4_INTERPOLATE
+    #define Z4_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef E0_INTERPOLATE
+    #define E0_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef E1_INTERPOLATE
+    #define E1_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef E2_INTERPOLATE
+    #define E2_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef E3_INTERPOLATE
+    #define E3_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef E4_INTERPOLATE
+    #define E4_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef E5_INTERPOLATE
+    #define E5_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef E6_INTERPOLATE
+    #define E6_INTERPOLATE INTERPOLATE
+  #endif
+  #ifndef E7_INTERPOLATE
+    #define E7_INTERPOLATE INTERPOLATE
+  #endif
 #endif
 
 #if (HAS_E_DRIVER(TMC2660) \

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -36,7 +36,7 @@
 #include <SPI.h>
 
 enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
-#define TMC_INIT(ST, STEALTH_INDEX) tmc_init(stepper##ST, ST##_CURRENT, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, stealthchop_by_axis[STEALTH_INDEX], chopper_timing_##ST)
+#define TMC_INIT(ST, STEALTH_INDEX) tmc_init(stepper##ST, ST##_CURRENT, ST##_MICROSTEPS, ST##_HYBRID_THRESHOLD, stealthchop_by_axis[STEALTH_INDEX], chopper_timing_##ST, ST##_INTERPOLATE)
 
 //   IC = TMC model number
 //   ST = Stepper object letter
@@ -131,13 +131,13 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
 #if HAS_DRIVER(TMC2130)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
-  void tmc_init(TMCMarlin<TMC2130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init) {
+  void tmc_init(TMCMarlin<TMC2130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init, const bool interpolate) {
     st.begin();
 
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01;
     chopconf.toff = chop_init.toff;
-    chopconf.intpol = INTERPOLATE;
+    chopconf.intpol = interpolate;
     chopconf.hend = chop_init.hend + 3;
     chopconf.hstrt = chop_init.hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
@@ -166,13 +166,13 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
 #if HAS_DRIVER(TMC2160)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
-  void tmc_init(TMCMarlin<TMC2160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init) {
+  void tmc_init(TMCMarlin<TMC2160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init, const bool interpolate) {
     st.begin();
 
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01;
     chopconf.toff = chop_init.toff;
-    chopconf.intpol = INTERPOLATE;
+    chopconf.intpol = interpolate;
     chopconf.hend = chop_init.hend + 3;
     chopconf.hstrt = chop_init.hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
@@ -484,7 +484,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
 #if HAS_DRIVER(TMC2208)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
-  void tmc_init(TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init) {
+  void tmc_init(TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init, const bool interpolate) {
     TMC2208_n::GCONF_t gconf{0};
     gconf.pdn_disable = true; // Use UART
     gconf.mstep_reg_select = true; // Select microsteps with UART
@@ -496,7 +496,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     TMC2208_n::CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01; // blank_time = 24
     chopconf.toff = chop_init.toff;
-    chopconf.intpol = INTERPOLATE;
+    chopconf.intpol = interpolate;
     chopconf.hend = chop_init.hend + 3;
     chopconf.hstrt = chop_init.hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
@@ -526,7 +526,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
 #if HAS_DRIVER(TMC2209)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
-  void tmc_init(TMCMarlin<TMC2209Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init) {
+  void tmc_init(TMCMarlin<TMC2209Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init, const bool interpolate) {
     TMC2208_n::GCONF_t gconf{0};
     gconf.pdn_disable = true; // Use UART
     gconf.mstep_reg_select = true; // Select microsteps with UART
@@ -538,7 +538,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     TMC2208_n::CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01; // blank_time = 24
     chopconf.toff = chop_init.toff;
-    chopconf.intpol = INTERPOLATE;
+    chopconf.intpol = interpolate;
     chopconf.hend = chop_init.hend + 3;
     chopconf.hstrt = chop_init.hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
@@ -568,7 +568,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
 #if HAS_DRIVER(TMC2660)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
-  void tmc_init(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t, const bool, const chopper_timing_t &chop_init) {
+  void tmc_init(TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t, const bool, const chopper_timing_t &chop_init, const bool interpolate) {
     st.begin();
 
     TMC2660_n::CHOPCONF_t chopconf{0};
@@ -582,7 +582,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     st.rms_current(mA);
     st.microsteps(microsteps);
     TERN_(SQUARE_WAVE_STEPPING, st.dedge(true));
-    st.intpol(INTERPOLATE);
+    st.intpol(interpolate);
     st.diss2g(true); // Disable short to ground protection. Too many false readings?
     TERN_(TMC_DEBUG, st.rdsel(0b01));
   }
@@ -590,13 +590,13 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
 #if HAS_DRIVER(TMC5130)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
-  void tmc_init(TMCMarlin<TMC5130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init) {
+  void tmc_init(TMCMarlin<TMC5130Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init, const bool interpolate) {
     st.begin();
 
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01;
     chopconf.toff = chop_init.toff;
-    chopconf.intpol = INTERPOLATE;
+    chopconf.intpol = interpolate;
     chopconf.hend = chop_init.hend + 3;
     chopconf.hstrt = chop_init.hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);
@@ -625,13 +625,13 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 
 #if HAS_DRIVER(TMC5160)
   template<char AXIS_LETTER, char DRIVER_ID, AxisEnum AXIS_ID>
-  void tmc_init(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init) {
+  void tmc_init(TMCMarlin<TMC5160Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> &st, const uint16_t mA, const uint16_t microsteps, const uint32_t hyb_thrs, const bool stealth, const chopper_timing_t &chop_init, const bool interpolate) {
     st.begin();
 
     CHOPCONF_t chopconf{0};
     chopconf.tbl = 0b01;
     chopconf.toff = chop_init.toff;
-    chopconf.intpol = INTERPOLATE;
+    chopconf.intpol = interpolate;
     chopconf.hend = chop_init.hend + 3;
     chopconf.hstrt = chop_init.hstrt - 1;
     TERN_(SQUARE_WAVE_STEPPING, chopconf.dedge = true);


### PR DESCRIPTION
### Description
Allow enabling/disabling TMC driver interpolation on a per-driver basis.
### Benefits
Allows using interpolation on some drivers (such as X/Y) while disabling it on others (probably most useful for E).
### Configurations
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/5412515/Configuration.zip)

I have tested this with TMC 2209 drivers on a Re-ARM. It would be a good idea to have tests done on other TMC drivers before this is merged.
