### PR TITLE
Add feature PSU POWER Action gcode

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -334,6 +334,9 @@
 
   //#define PSU_DEFAULT_OFF         // Keep power off until enabled directly with M80
   //#define PSU_POWERUP_DELAY 250   // (ms) Delay for the PSU to warm up to full power
+  
+  //#define PSU_POWERUP_GCODE "M355 S1"   // gcode to run on powerup (i.e. case light on)
+  //#define PSU_POWEROFF_GCODE "M355 S0"  //gcode to run on poweroff (i.e. case light off)
 
   //#define AUTO_POWER_CONTROL      // Enable automatic control of the PS_ON pin
   #if ENABLED(AUTO_POWER_CONTROL)

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -334,9 +334,9 @@
 
   //#define PSU_DEFAULT_OFF         // Keep power off until enabled directly with M80
   //#define PSU_POWERUP_DELAY 250   // (ms) Delay for the PSU to warm up to full power
-  
-  //#define PSU_POWERUP_GCODE "M355 S1"   // gcode to run on powerup (i.e. case light on)
-  //#define PSU_POWEROFF_GCODE "M355 S0"  //gcode to run on poweroff (i.e. case light off)
+
+  //#define PSU_POWERUP_GCODE  "M355 S1"  // G-code to run after power-on (e.g., case light on)
+  //#define PSU_POWEROFF_GCODE "M355 S0"  // G-code to run before power-off (e.g., case light off)
 
   //#define AUTO_POWER_CONTROL      // Enable automatic control of the PS_ON pin
   #if ENABLED(AUTO_POWER_CONTROL)

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -119,10 +119,10 @@ void Power::power_on() {
 
 void Power::power_off() {
   if (powersupply_on) {
-  	PSU_PIN_OFF();
     #ifdef PSU_POWEROFF_GCODE
       GcodeSuite::process_subcommands_now_P(PSTR(PSU_POWEROFF_GCODE));
     #endif
+  	PSU_PIN_OFF();
   }
 }
 

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -33,6 +33,10 @@
 #include "../module/stepper/indirection.h"
 #include "../MarlinCore.h"
 
+#if defined(PSU_POWERUP_GCODE) || defined(PSU_POWEROFF_GCODE)
+  #include "../gcode/gcode.h"
+#endif
+
 #if BOTH(USE_CONTROLLER_FAN, AUTO_POWER_CONTROLLERFAN)
   #include "controllerfan.h"
 #endif
@@ -107,11 +111,19 @@ void Power::power_on() {
     safe_delay(PSU_POWERUP_DELAY);
     restore_stepper_drivers();
     TERN_(HAS_TRINAMIC_CONFIG, safe_delay(PSU_POWERUP_DELAY));
+    #ifdef PSU_POWERUP_GCODE
+      GcodeSuite::process_subcommands_now_P(PSTR(PSU_POWERUP_GCODE));
+    #endif
   }
 }
 
 void Power::power_off() {
-  if (powersupply_on) PSU_PIN_OFF();
+  if (powersupply_on) {
+  	PSU_PIN_OFF();
+    #ifdef PSU_POWEROFF_GCODE
+      GcodeSuite::process_subcommands_now_P(PSTR(PSU_POWEROFF_GCODE));
+    #endif
+  }
 }
 
 #endif // AUTO_POWER_CONTROL


### PR DESCRIPTION
Recreation of uneditable #19831 by @senseisimple so it can be cleaned up for merge.

---
### Description

Adds `PSU_POWERUP_GCODE` and `PSU_POWEROFF_GCODE` definitions to the PSU_CONTROL block which enables running gcode as part of the PS_ON/OFF (M80/M81) switching (manual, auto on, and timeout) routines. 

An example use is to turn on separately controlled case lights on/off (M355) as part of power on/off.

### Benefits

Allow running gcode as part of the PS_ON/OFF (M80/M81) action which implicitly benefits from the related functionality of the AUTO_POWER_CONTROL and POWER_TIMEOUT controls.

### Configurations

Stock Configuration.h is included in the commit with the two new definition entries `PSU_POWERUP_GCODE` and `PSU_POWEROFF_GCODE` commented.

### Related Issues
A relevant feature request is open (this adds a more generic approach than those suggested): 
https://github.com/MarlinFirmware/Marlin/issues/13318
