### PR TITLE
Slim down MKS UI code

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_about.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_about.cpp
@@ -65,27 +65,18 @@ void lv_draw_about(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t *title = lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  lv_obj_t *buttonBack = lv_imgbtn_create(scr, NULL);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_A_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-    #if HAS_ROTARY_ENCODER
-      if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
-    #endif
+  lv_obj_t *buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_A_RETURN);
+  #if HAS_ROTARY_ENCODER
+    if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif
 
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
   // Create a label on the image button
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Back, common_menu.text_back);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_about.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_about.cpp
@@ -53,7 +53,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 }
 
 void lv_draw_about(void) {
-  lv_obj_t *buttonBack, *label_Back;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != ABOUT_UI) {
     disp_state_stack._disp_index++;
     disp_state_stack._disp_state[disp_state_stack._disp_index] = ABOUT_UI;
@@ -66,22 +65,17 @@ void lv_draw_about(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  lv_obj_t *title = lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonBack = lv_imgbtn_create(scr, NULL);
+  lv_obj_t *buttonBack = lv_imgbtn_create(scr, NULL);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_A_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
     #endif
@@ -91,26 +85,20 @@ void lv_draw_about(void) {
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
 
   // Create a label on the image button
-  label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Back, common_menu.text_back);
     lv_obj_align(label_Back, buttonBack, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
   }
 
-  //fw_version = lv_label_create(scr, NULL);
-  //lv_obj_set_style(fw_version, &tft_style_label_rel);
-  //lv_label_set_text(fw_version, SHORT_BUILD_VERSION);
+  //fw_version = lv_label_create(scr, SHORT_BUILD_VERSION);
   //lv_obj_align(fw_version, NULL, LV_ALIGN_CENTER, 0, -60);
 
-  fw_type = lv_label_create(scr, NULL);
-  lv_obj_set_style(fw_type, &tft_style_label_rel);
-  lv_label_set_text(fw_type, "Firmware: Marlin " SHORT_BUILD_VERSION);
+  fw_type = lv_label_create(scr, "Firmware: Marlin " SHORT_BUILD_VERSION);
   lv_obj_align(fw_type, NULL, LV_ALIGN_CENTER, 0, -20);
 
-  board = lv_label_create(scr, NULL);
-  lv_obj_set_style(board, &tft_style_label_rel);
-  lv_label_set_text(board, "Board: " BOARD_INFO_NAME);
+  board = lv_label_create(scr, "Board: " BOARD_INFO_NAME);
   lv_obj_align(board, NULL, LV_ALIGN_CENTER, 0, -60);
 }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_acceleration_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_acceleration_settings.cpp
@@ -190,55 +190,37 @@ void lv_draw_acceleration_settings(void) {
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.PrintAcceleration);
 
-    buttonPrintValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonPrintValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonPrintValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonPrintValue, event_handler, ID_ACCE_PRINT, NULL, 0);
-    lv_btn_set_style_both(buttonPrintValue, &style_para_value);
-    labelPrintValue = lv_label_create(buttonPrintValue, NULL);
+    buttonPrintValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_ACCE_PRINT);
+    labelPrintValue = lv_label_create_empty(buttonPrintValue);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.RetractAcceleration);
 
-    buttonRetraValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonRetraValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonRetraValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonRetraValue, event_handler, ID_ACCE_RETRA, NULL, 0);
-    lv_btn_set_style_both(buttonRetraValue, &style_para_value);
-    labelRetraValue = lv_label_create(buttonRetraValue, NULL);
+    buttonRetraValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_ACCE_RETRA);
+    labelRetraValue = lv_label_create_empty(buttonRetraValue);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.TravelAcceleration);
 
-    buttonTravelValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonTravelValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonTravelValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonTravelValue, event_handler, ID_ACCE_TRAVEL, NULL, 0);
-    lv_btn_set_style_both(buttonTravelValue, &style_para_value);
-    labelTravelValue = lv_label_create(buttonTravelValue, NULL);
+    buttonTravelValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_ACCE_TRAVEL);
+    labelTravelValue = lv_label_create_empty(buttonTravelValue);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.X_Acceleration);
 
-    buttonXValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_ACCE_X, NULL, 0);
-    lv_btn_set_style_both(buttonXValue, &style_para_value);
-    labelXValue = lv_label_create(buttonXValue, NULL);
+    buttonXValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_ACCE_X);
+    labelXValue = lv_label_create_empty(buttonXValue);
 
     line4 = lv_line_create(scr, NULL);
     lv_ex_line(line4, line_points[3]);
 
-    buttonTurnPage = lv_btn_create(scr, NULL);
-    lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_ACCE_DOWN, NULL, 0);
-    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
+    buttonTurnPage = lv_btn_create_back(scr, event_handler, ID_ACCE_DOWN);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -253,25 +235,16 @@ void lv_draw_acceleration_settings(void) {
   else {
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.Y_Acceleration);
 
-    buttonYValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
-    lv_btn_set_style_both(buttonYValue, &style_para_value);
-    labelYValue = lv_label_create(buttonYValue, NULL);
+    buttonYValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_ACCE_Y);
+    labelYValue = lv_label_create_empty(buttonYValue);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Z_Acceleration);
 
-    buttonZValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
-    lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_ACCE_Z, NULL, 0);
-    lv_btn_set_style_both(buttonZValue, &style_para_value);
-    labelZValue = lv_label_create(buttonZValue, NULL);
+    buttonZValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_ACCE_Z);
+    labelZValue = lv_label_create_empty(buttonZValue);
 
 
     line2 = lv_line_create(scr, NULL);
@@ -279,13 +252,8 @@ void lv_draw_acceleration_settings(void) {
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.E0_Acceleration);
 
-    buttonE0Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonE0Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
-    lv_obj_set_event_cb_mks(buttonE0Value, event_handler, ID_ACCE_E0, NULL, 0);
-    lv_btn_set_style_both(buttonE0Value, &style_para_value);
-    labelE0Value = lv_label_create(buttonE0Value, NULL);
+    buttonE0Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_ACCE_E0);
+    labelE0Value = lv_label_create_empty(buttonE0Value);
 
 
     line3 = lv_line_create(scr, NULL);
@@ -293,23 +261,15 @@ void lv_draw_acceleration_settings(void) {
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E1_Acceleration);
 
-    buttonE1Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonE1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
-    lv_obj_set_event_cb_mks(buttonE1Value, event_handler, ID_ACCE_E1, NULL, 0);
-    lv_btn_set_style_both(buttonE1Value, &style_para_value);
-    labelE1Value = lv_label_create(buttonE1Value, NULL);
-
+    buttonE1Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_ACCE_E1);
+    labelE1Value = lv_label_create_empty(buttonE1Value);
 
     line4 = lv_line_create(scr, NULL);
     lv_ex_line(line4, line_points[3]);
 
-    buttonTurnPage = lv_btn_create(scr, NULL);
-    lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_ACCE_UP, NULL, 0);
+    buttonTurnPage = lv_btn_create_back(scr, event_handler, ID_ACCE_UP);
     //lv_imgbtn_set_src_both(buttonTurnPage, "F:/bmp_back70x40.bin");
     //lv_imgbtn_use_label_style(buttonTurnPage);
-    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -324,19 +284,15 @@ void lv_draw_acceleration_settings(void) {
 
   //lv_obj_set_pos(buttonTurnPage, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
   //lv_btn_set_layout(buttonTurnPage, LV_LAYOUT_OFF);
-  //labelTurnPage = lv_label_create(buttonTurnPage, NULL);
+  //labelTurnPage = lv_label_create_empty(buttonTurnPage);
   lv_obj_set_pos(buttonTurnPage, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
   lv_obj_set_size(buttonTurnPage, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  labelTurnPage = lv_label_create(buttonTurnPage, NULL);
+  labelTurnPage = lv_label_create_empty(buttonTurnPage);
 
-  buttonBack = lv_btn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_ACCE_RETURN, NULL, 0);
+  buttonBack = lv_btn_create_back(scr, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE, event_handler, ID_ACCE_RETURN);
   //lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
   //lv_imgbtn_use_label_style(buttonBack);
-  lv_btn_set_style_both(buttonBack, &style_para_back);
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_acceleration_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_acceleration_settings.cpp
@@ -161,14 +161,14 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_acceleration_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL, *buttonTurnPage = NULL, *labelTurnPage = NULL;
-  lv_obj_t *labelPrintText = NULL, *buttonPrintValue = NULL, *labelPrintValue = NULL;
-  lv_obj_t *labelRetraText = NULL, *buttonRetraValue = NULL, *labelRetraValue = NULL;
-  lv_obj_t *labelTravelText = NULL, *buttonTravelValue = NULL, *labelTravelValue = NULL;
-  lv_obj_t *labelXText = NULL, *buttonXValue = NULL, *labelXValue = NULL;
-  lv_obj_t *labelYText = NULL, *buttonYValue = NULL, *labelYValue = NULL;
-  lv_obj_t *labelZText = NULL, *buttonZValue = NULL, *labelZValue = NULL;
-  lv_obj_t *labelE0Text = NULL, *buttonE0Value = NULL, *labelE0Value = NULL;
-  lv_obj_t *labelE1Text = NULL, *buttonE1Value = NULL, *labelE1Value = NULL;
+  lv_obj_t *buttonPrintValue = NULL, *labelPrintValue = NULL;
+  lv_obj_t *buttonRetraValue = NULL, *labelRetraValue = NULL;
+  lv_obj_t *buttonTravelValue = NULL, *labelTravelValue = NULL;
+  lv_obj_t *buttonXValue = NULL, *labelXValue = NULL;
+  lv_obj_t *buttonYValue = NULL, *labelYValue = NULL;
+  lv_obj_t *buttonZValue = NULL, *labelZValue = NULL;
+  lv_obj_t *buttonE0Value = NULL, *labelE0Value = NULL;
+  lv_obj_t *buttonE1Value = NULL, *labelE1Value = NULL;
   lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL, * line4 = NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != ACCELERATION_UI) {
     disp_state_stack._disp_index++;
@@ -182,74 +182,55 @@ void lv_draw_acceleration_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.AccelerationConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.AccelerationConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   if (uiCfg.para_ui_page != 1) {
 
-    labelPrintText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelPrintText, &tft_style_label_rel);
-    lv_obj_set_pos(labelPrintText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelPrintText, machine_menu.PrintAcceleration);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.PrintAcceleration);
 
     buttonPrintValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonPrintValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonPrintValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonPrintValue, event_handler, ID_ACCE_PRINT, NULL, 0);
-    lv_btn_set_style(buttonPrintValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonPrintValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonPrintValue, &style_para_value);
     labelPrintValue = lv_label_create(buttonPrintValue, NULL);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    labelRetraText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelRetraText, &tft_style_label_rel);
-    lv_obj_set_pos(labelRetraText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-    lv_label_set_text(labelRetraText, machine_menu.RetractAcceleration);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.RetractAcceleration);
 
     buttonRetraValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonRetraValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonRetraValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonRetraValue, event_handler, ID_ACCE_RETRA, NULL, 0);
-    lv_btn_set_style(buttonRetraValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonRetraValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonRetraValue, &style_para_value);
     labelRetraValue = lv_label_create(buttonRetraValue, NULL);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    labelTravelText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelTravelText, &tft_style_label_rel);
-    lv_obj_set_pos(labelTravelText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-    lv_label_set_text(labelTravelText, machine_menu.TravelAcceleration);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.TravelAcceleration);
 
     buttonTravelValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonTravelValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonTravelValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonTravelValue, event_handler, ID_ACCE_TRAVEL, NULL, 0);
-    lv_btn_set_style(buttonTravelValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonTravelValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonTravelValue, &style_para_value);
     labelTravelValue = lv_label_create(buttonTravelValue, NULL);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    labelXText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelXText, &tft_style_label_rel);
-    lv_obj_set_pos(labelXText, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-    lv_label_set_text(labelXText, machine_menu.X_Acceleration);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.X_Acceleration);
 
     buttonXValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_ACCE_X, NULL, 0);
-    lv_btn_set_style(buttonXValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonXValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonXValue, &style_para_value);
     labelXValue = lv_label_create(buttonXValue, NULL);
 
     line4 = lv_line_create(scr, NULL);
@@ -257,8 +238,7 @@ void lv_draw_acceleration_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_ACCE_DOWN, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -271,67 +251,54 @@ void lv_draw_acceleration_settings(void) {
     #endif
   }
   else {
-    labelYText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelYText, &tft_style_label_rel);
-    lv_obj_set_pos(labelYText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelYText, machine_menu.Y_Acceleration);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.Y_Acceleration);
 
     buttonYValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
-    lv_btn_set_style(buttonYValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonYValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonYValue, &style_para_value);
     labelYValue = lv_label_create(buttonYValue, NULL);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    labelZText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelZText, &tft_style_label_rel);
-    lv_obj_set_pos(labelZText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-    lv_label_set_text(labelZText, machine_menu.Z_Acceleration);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Z_Acceleration);
 
     buttonZValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
+    lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
+    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
     lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_ACCE_Z, NULL, 0);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonZValue, &style_para_value);
     labelZValue = lv_label_create(buttonZValue, NULL);
 
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    labelE0Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelE0Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelE0Text, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-    lv_label_set_text(labelE0Text, machine_menu.E0_Acceleration);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.E0_Acceleration);
 
     buttonE0Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonE0Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
+    lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
+    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
     lv_obj_set_event_cb_mks(buttonE0Value, event_handler, ID_ACCE_E0, NULL, 0);
-    lv_btn_set_style(buttonE0Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonE0Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonE0Value, &style_para_value);
     labelE0Value = lv_label_create(buttonE0Value, NULL);
 
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    labelE1Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelE1Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelE1Text, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-    lv_label_set_text(labelE1Text, machine_menu.E1_Acceleration);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E1_Acceleration);
 
     buttonE1Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonE1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
+    lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
+    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_ACCE_Y, NULL, 0);
     lv_obj_set_event_cb_mks(buttonE1Value, event_handler, ID_ACCE_E1, NULL, 0);
-    lv_btn_set_style(buttonE1Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonE1Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonE1Value, &style_para_value);
     labelE1Value = lv_label_create(buttonE1Value, NULL);
 
 
@@ -340,12 +307,9 @@ void lv_draw_acceleration_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_ACCE_UP, NULL, 0);
-    //lv_imgbtn_set_src(buttonTurnPage, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-    //lv_imgbtn_set_src(buttonTurnPage, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-    //lv_imgbtn_set_style(buttonTurnPage, LV_BTN_STATE_PR, &tft_style_label_pre);
-    //lv_imgbtn_set_style(buttonTurnPage, LV_BTN_STATE_REL, &tft_style_label_rel);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    //lv_imgbtn_set_src_both(buttonTurnPage, "F:/bmp_back70x40.bin");
+    //lv_imgbtn_use_label_style(buttonTurnPage);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -367,12 +331,9 @@ void lv_draw_acceleration_settings(void) {
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_ACCE_RETURN, NULL, 0);
-  //lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  //lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  //lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  //lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  //lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  //lv_imgbtn_use_label_style(buttonBack);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   label_Back = lv_label_create(buttonBack, NULL);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_advance_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_advance_settings.cpp
@@ -137,10 +137,10 @@ void lv_draw_advance_settings(void) {
   lv_obj_t *buttonFilamentSettings, *labelFilamentSettings, *buttonFilamentSettingsNarrow;
   lv_obj_t * line1,* line2;
   #if ENABLED(USE_WIFI_FUNCTION)
-    lv_obj_t *buttonWifiSet,*labelWifiSet,*buttonWifiSetNarrow;
+    lv_obj_t *buttonWifiSet, *labelWifiSet, *buttonWifiSetNarrow;
   #endif
   #if HAS_ROTARY_ENCODER
-    lv_obj_t *buttonEcoder,*labelEcoder,*buttonEcoderNarrow;
+    lv_obj_t *buttonEncoder, *labelEncoder, *buttonEncoderNarrow;
   #endif
 
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != ADVANCED_UI) {
@@ -155,10 +155,7 @@ void lv_draw_advance_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.AdvancedConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.AdvancedConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -167,8 +164,7 @@ void lv_draw_advance_settings(void) {
   lv_obj_set_size(buttonPausePos, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);
   //lv_obj_set_event_cb(buttonMachine, event_handler);
   lv_obj_set_event_cb_mks(buttonPausePos, event_handler, ID_PAUSE_POS, NULL, 0);
-  lv_btn_set_style(buttonPausePos, LV_BTN_STYLE_REL, &tft_style_label_rel);
-  lv_btn_set_style(buttonPausePos, LV_BTN_STYLE_PR, &tft_style_label_pre);
+  lv_btn_use_label_style(buttonPausePos);
   lv_btn_set_layout(buttonPausePos, LV_LAYOUT_OFF);
   labelPausePos = lv_label_create(buttonPausePos, NULL);
   #if HAS_ROTARY_ENCODER
@@ -178,10 +174,8 @@ void lv_draw_advance_settings(void) {
   buttonPausePosNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonPausePosNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonPausePosNarrow, event_handler, ID_PAUSE_POS_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonPausePosNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonPausePosNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonPausePosNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonPausePosNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonPausePosNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonPausePosNarrow);
   lv_btn_set_layout(buttonPausePosNarrow, LV_LAYOUT_OFF);
 
   line1 = lv_line_create(lv_scr_act(), NULL);
@@ -191,8 +185,7 @@ void lv_draw_advance_settings(void) {
   lv_obj_set_pos(buttonFilamentSettings, PARA_UI_POS_X, PARA_UI_POS_Y*2);
   lv_obj_set_size(buttonFilamentSettings, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);
   lv_obj_set_event_cb_mks(buttonFilamentSettings, event_handler, ID_FILAMENT_SETTINGS, NULL, 0);
-  lv_btn_set_style(buttonFilamentSettings, LV_BTN_STYLE_REL, &tft_style_label_rel);
-  lv_btn_set_style(buttonFilamentSettings, LV_BTN_STYLE_PR, &tft_style_label_pre);
+  lv_btn_use_label_style(buttonFilamentSettings);
   lv_btn_set_layout(buttonFilamentSettings, LV_LAYOUT_OFF);
   labelFilamentSettings = lv_label_create(buttonFilamentSettings, NULL);
   #if HAS_ROTARY_ENCODER
@@ -202,10 +195,8 @@ void lv_draw_advance_settings(void) {
   buttonFilamentSettingsNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonFilamentSettingsNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y*2 + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonFilamentSettingsNarrow, event_handler, ID_FILAMENT_SETTINGS_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonFilamentSettingsNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonFilamentSettingsNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonFilamentSettingsNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonFilamentSettingsNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonFilamentSettingsNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonFilamentSettingsNarrow);
   lv_btn_set_layout(buttonFilamentSettingsNarrow, LV_LAYOUT_OFF);
 
   line2 = lv_line_create(lv_scr_act(), NULL);
@@ -216,9 +207,8 @@ void lv_draw_advance_settings(void) {
     buttonWifiSet = lv_btn_create(scr, NULL);     /*Add a button the current screen*/
     lv_obj_set_pos(buttonWifiSet, PARA_UI_POS_X,PARA_UI_POS_Y*3);
     lv_obj_set_size(buttonWifiSet, PARA_UI_SIZE_X,PARA_UI_SIZE_Y);
-    lv_obj_set_event_cb_mks(buttonWifiSet, event_handler,ID_WIFI_PARA,NULL,0);
-    lv_btn_set_style(buttonWifiSet, LV_BTN_STYLE_REL, &tft_style_label_rel);
-    lv_btn_set_style(buttonWifiSet, LV_BTN_STYLE_PR, &tft_style_label_pre);
+    lv_obj_set_event_cb_mks(buttonWifiSet, event_handler,ID_WIFI_PARA,NULL, 0);
+    lv_btn_use_label_style(buttonWifiSet);
     lv_btn_set_layout(buttonWifiSet, LV_LAYOUT_OFF);
     labelWifiSet = lv_label_create(buttonWifiSet, NULL);
     #if HAS_ROTARY_ENCODER
@@ -227,61 +217,53 @@ void lv_draw_advance_settings(void) {
 
     buttonWifiSetNarrow = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonWifiSetNarrow,PARA_UI_POS_X+PARA_UI_SIZE_X,PARA_UI_POS_Y*3+PARA_UI_ARROW_V);
-    lv_obj_set_event_cb_mks(buttonWifiSetNarrow, event_handler,ID_WIFI_PARA_ARROW, NULL,0);
-    lv_imgbtn_set_src(buttonWifiSetNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_src(buttonWifiSetNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_style(buttonWifiSetNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonWifiSetNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonWifiSetNarrow, event_handler,ID_WIFI_PARA_ARROW, NULL, 0);
+    lv_imgbtn_set_src_both(buttonWifiSetNarrow, "F:/bmp_arrow.bin");
+    lv_imgbtn_use_label_style(buttonWifiSetNarrow);
     lv_btn_set_layout(buttonWifiSetNarrow, LV_LAYOUT_OFF);
 
     lv_obj_t * line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3,line_points[2]);
 
     #if HAS_ROTARY_ENCODER
-      buttonEcoder = lv_btn_create(scr, NULL);     /*Add a button the current screen*/
-      lv_obj_set_pos(buttonEcoder, PARA_UI_POS_X,PARA_UI_POS_Y*4);
-      lv_obj_set_size(buttonEcoder, PARA_UI_SIZE_X,PARA_UI_SIZE_Y);
-      lv_obj_set_event_cb_mks(buttonEcoder, event_handler,ID_ENCODER_SETTINGS,NULL,0);
-      lv_btn_set_style(buttonEcoder, LV_BTN_STYLE_REL, &tft_style_label_rel);
-      lv_btn_set_style(buttonEcoder, LV_BTN_STYLE_PR, &tft_style_label_pre);
-      lv_btn_set_layout(buttonEcoder, LV_LAYOUT_OFF);
-      labelEcoder = lv_label_create(buttonEcoder, NULL);
+      buttonEncoder = lv_btn_create(scr, NULL);     /*Add a button the current screen*/
+      lv_obj_set_pos(buttonEncoder, PARA_UI_POS_X,PARA_UI_POS_Y*4);
+      lv_obj_set_size(buttonEncoder, PARA_UI_SIZE_X,PARA_UI_SIZE_Y);
+      lv_obj_set_event_cb_mks(buttonEncoder, event_handler,ID_ENCODER_SETTINGS,NULL, 0);
+      lv_btn_use_label_style(buttonEncoder);
+      lv_btn_set_layout(buttonEncoder, LV_LAYOUT_OFF);
+      labelEncoder = lv_label_create(buttonEncoder, NULL);
 
-      if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonEcoder);
+      if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonEncoder);
 
-      buttonEcoderNarrow = lv_imgbtn_create(scr, NULL);
-      lv_obj_set_pos(buttonEcoderNarrow,PARA_UI_POS_X+PARA_UI_SIZE_X,PARA_UI_POS_Y*4+PARA_UI_ARROW_V);
-      lv_obj_set_event_cb_mks(buttonEcoderNarrow, event_handler,ID_ENCODER_SETTINGS_ARROW, NULL,0);
-      lv_imgbtn_set_src(buttonEcoderNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-      lv_imgbtn_set_src(buttonEcoderNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-      lv_imgbtn_set_style(buttonEcoderNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonEcoderNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
-      lv_btn_set_layout(buttonEcoderNarrow, LV_LAYOUT_OFF);
+      buttonEncoderNarrow = lv_imgbtn_create(scr, NULL);
+      lv_obj_set_pos(buttonEncoderNarrow,PARA_UI_POS_X+PARA_UI_SIZE_X,PARA_UI_POS_Y*4+PARA_UI_ARROW_V);
+      lv_obj_set_event_cb_mks(buttonEncoderNarrow, event_handler,ID_ENCODER_SETTINGS_ARROW, NULL, 0);
+      lv_imgbtn_set_src_both(buttonEncoderNarrow, "F:/bmp_arrow.bin");
+      lv_imgbtn_use_label_style(buttonEncoderNarrow);
+      lv_btn_set_layout(buttonEncoderNarrow, LV_LAYOUT_OFF);
 
       lv_obj_t * line4 = lv_line_create(scr, NULL);
       lv_ex_line(line4,line_points[3]);
     #endif
 
   #elif HAS_ROTARY_ENCODER
-    buttonEcoder = lv_btn_create(scr, NULL);     /*Add a button the current screen*/
-    lv_obj_set_pos(buttonEcoder, PARA_UI_POS_X,PARA_UI_POS_Y*3);
-    lv_obj_set_size(buttonEcoder, PARA_UI_SIZE_X,PARA_UI_SIZE_Y);
-    lv_obj_set_event_cb_mks(buttonEcoder, event_handler,ID_ENCODER_SETTINGS,NULL,0);
-    lv_btn_set_style(buttonEcoder, LV_BTN_STYLE_REL, &tft_style_label_rel);
-    lv_btn_set_style(buttonEcoder, LV_BTN_STYLE_PR, &tft_style_label_pre);
-    lv_btn_set_layout(buttonEcoder, LV_LAYOUT_OFF);
-    labelEcoder = lv_label_create(buttonEcoder, NULL);
+    buttonEncoder = lv_btn_create(scr, NULL);     /*Add a button the current screen*/
+    lv_obj_set_pos(buttonEncoder, PARA_UI_POS_X,PARA_UI_POS_Y*3);
+    lv_obj_set_size(buttonEncoder, PARA_UI_SIZE_X,PARA_UI_SIZE_Y);
+    lv_obj_set_event_cb_mks(buttonEncoder, event_handler,ID_ENCODER_SETTINGS,NULL, 0);
+    lv_btn_use_label_style(buttonEncoder);
+    lv_btn_set_layout(buttonEncoder, LV_LAYOUT_OFF);
+    labelEncoder = lv_label_create(buttonEncoder, NULL);
 
-    if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonEcoder);
+    if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonEncoder);
 
-    buttonEcoderNarrow = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonEcoderNarrow,PARA_UI_POS_X+PARA_UI_SIZE_X,PARA_UI_POS_Y*3+PARA_UI_ARROW_V);
-    lv_obj_set_event_cb_mks(buttonEcoderNarrow, event_handler,ID_ENCODER_SETTINGS_ARROW, NULL,0);
-    lv_imgbtn_set_src(buttonEcoderNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_src(buttonEcoderNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_style(buttonEcoderNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonEcoderNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
-    lv_btn_set_layout(buttonEcoderNarrow, LV_LAYOUT_OFF);
+    buttonEncoderNarrow = lv_imgbtn_create(scr, NULL);
+    lv_obj_set_pos(buttonEncoderNarrow,PARA_UI_POS_X+PARA_UI_SIZE_X,PARA_UI_POS_Y*3+PARA_UI_ARROW_V);
+    lv_obj_set_event_cb_mks(buttonEncoderNarrow, event_handler,ID_ENCODER_SETTINGS_ARROW, NULL, 0);
+    lv_imgbtn_set_src_both(buttonEncoderNarrow, "F:/bmp_arrow.bin");
+    lv_imgbtn_use_label_style(buttonEncoderNarrow);
+    lv_btn_set_layout(buttonEncoderNarrow, LV_LAYOUT_OFF);
 
     lv_obj_t * line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3,line_points[2]);
@@ -289,10 +271,8 @@ void lv_draw_advance_settings(void) {
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_ADVANCE_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
@@ -317,8 +297,8 @@ void lv_draw_advance_settings(void) {
       lv_obj_align(labelWifiSet, buttonWifiSet, LV_ALIGN_IN_LEFT_MID,0, 0);
     #endif
     #if HAS_ROTARY_ENCODER
-      lv_label_set_text(labelEcoder, machine_menu.EncoderSettings);
-      lv_obj_align(labelEcoder, buttonEcoder, LV_ALIGN_IN_LEFT_MID,0, 0);
+      lv_label_set_text(labelEncoder, machine_menu.EncoderSettings);
+      lv_obj_align(labelEncoder, buttonEncoder, LV_ALIGN_IN_LEFT_MID,0, 0);
     #endif
   }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_advance_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_advance_settings.cpp
@@ -133,8 +133,8 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_advance_settings(void) {
   lv_obj_t *buttonBack, *label_Back;
-  lv_obj_t *buttonPausePos, *labelPausePos, *buttonPausePosNarrow;
-  lv_obj_t *buttonFilamentSettings, *labelFilamentSettings, *buttonFilamentSettingsNarrow;
+  lv_obj_t *buttonPausePos, *labelPausePos;
+  lv_obj_t *buttonFilamentSettings, *labelFilamentSettings;
   lv_obj_t * line1,* line2;
   #if ENABLED(USE_WIFI_FUNCTION)
     lv_obj_t *buttonWifiSet, *labelWifiSet, *buttonWifiSetNarrow;
@@ -166,17 +166,12 @@ void lv_draw_advance_settings(void) {
   lv_obj_set_event_cb_mks(buttonPausePos, event_handler, ID_PAUSE_POS, NULL, 0);
   lv_btn_use_label_style(buttonPausePos);
   lv_btn_set_layout(buttonPausePos, LV_LAYOUT_OFF);
-  labelPausePos = lv_label_create(buttonPausePos, NULL);
+  labelPausePos = lv_label_create_empty(buttonPausePos);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonPausePos);
   #endif
 
-  buttonPausePosNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonPausePosNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonPausePosNarrow, event_handler, ID_PAUSE_POS_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonPausePosNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonPausePosNarrow);
-  lv_btn_set_layout(buttonPausePosNarrow, LV_LAYOUT_OFF);
+  (void)lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V, event_handler, ID_PAUSE_POS_ARROW);
 
   line1 = lv_line_create(lv_scr_act(), NULL);
   lv_ex_line(line1, line_points[0]);
@@ -187,17 +182,12 @@ void lv_draw_advance_settings(void) {
   lv_obj_set_event_cb_mks(buttonFilamentSettings, event_handler, ID_FILAMENT_SETTINGS, NULL, 0);
   lv_btn_use_label_style(buttonFilamentSettings);
   lv_btn_set_layout(buttonFilamentSettings, LV_LAYOUT_OFF);
-  labelFilamentSettings = lv_label_create(buttonFilamentSettings, NULL);
+  labelFilamentSettings = lv_label_create_empty(buttonFilamentSettings);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonFilamentSettings);
   #endif
 
-  buttonFilamentSettingsNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonFilamentSettingsNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y*2 + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonFilamentSettingsNarrow, event_handler, ID_FILAMENT_SETTINGS_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonFilamentSettingsNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonFilamentSettingsNarrow);
-  lv_btn_set_layout(buttonFilamentSettingsNarrow, LV_LAYOUT_OFF);
+  (void)lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y*2 + PARA_UI_ARROW_V, event_handler, ID_FILAMENT_SETTINGS_ARROW);
 
   line2 = lv_line_create(lv_scr_act(), NULL);
   lv_ex_line(line2, line_points[1]);
@@ -210,17 +200,12 @@ void lv_draw_advance_settings(void) {
     lv_obj_set_event_cb_mks(buttonWifiSet, event_handler,ID_WIFI_PARA,NULL, 0);
     lv_btn_use_label_style(buttonWifiSet);
     lv_btn_set_layout(buttonWifiSet, LV_LAYOUT_OFF);
-    labelWifiSet = lv_label_create(buttonWifiSet, NULL);
+    labelWifiSet = lv_label_create_empty(buttonWifiSet);
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonWifiSet);
     #endif
 
-    buttonWifiSetNarrow = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonWifiSetNarrow,PARA_UI_POS_X+PARA_UI_SIZE_X,PARA_UI_POS_Y*3+PARA_UI_ARROW_V);
-    lv_obj_set_event_cb_mks(buttonWifiSetNarrow, event_handler,ID_WIFI_PARA_ARROW, NULL, 0);
-    lv_imgbtn_set_src_both(buttonWifiSetNarrow, "F:/bmp_arrow.bin");
-    lv_imgbtn_use_label_style(buttonWifiSetNarrow);
-    lv_btn_set_layout(buttonWifiSetNarrow, LV_LAYOUT_OFF);
+    buttonWifiSetNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V, event_handler, ID_WIFI_PARA_ARROW);
 
     lv_obj_t * line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3,line_points[2]);
@@ -232,16 +217,11 @@ void lv_draw_advance_settings(void) {
       lv_obj_set_event_cb_mks(buttonEncoder, event_handler,ID_ENCODER_SETTINGS,NULL, 0);
       lv_btn_use_label_style(buttonEncoder);
       lv_btn_set_layout(buttonEncoder, LV_LAYOUT_OFF);
-      labelEncoder = lv_label_create(buttonEncoder, NULL);
+      labelEncoder = lv_label_create_empty(buttonEncoder);
 
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonEncoder);
 
-      buttonEncoderNarrow = lv_imgbtn_create(scr, NULL);
-      lv_obj_set_pos(buttonEncoderNarrow,PARA_UI_POS_X+PARA_UI_SIZE_X,PARA_UI_POS_Y*4+PARA_UI_ARROW_V);
-      lv_obj_set_event_cb_mks(buttonEncoderNarrow, event_handler,ID_ENCODER_SETTINGS_ARROW, NULL, 0);
-      lv_imgbtn_set_src_both(buttonEncoderNarrow, "F:/bmp_arrow.bin");
-      lv_imgbtn_use_label_style(buttonEncoderNarrow);
-      lv_btn_set_layout(buttonEncoderNarrow, LV_LAYOUT_OFF);
+      buttonEncoderNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 4 + PARA_UI_ARROW_V, event_handler, ID_ENCODER_SETTINGS_ARROW);
 
       lv_obj_t * line4 = lv_line_create(scr, NULL);
       lv_ex_line(line4,line_points[3]);
@@ -254,33 +234,21 @@ void lv_draw_advance_settings(void) {
     lv_obj_set_event_cb_mks(buttonEncoder, event_handler,ID_ENCODER_SETTINGS,NULL, 0);
     lv_btn_use_label_style(buttonEncoder);
     lv_btn_set_layout(buttonEncoder, LV_LAYOUT_OFF);
-    labelEncoder = lv_label_create(buttonEncoder, NULL);
+    labelEncoder = lv_label_create_empty(buttonEncoder);
 
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonEncoder);
 
-    buttonEncoderNarrow = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonEncoderNarrow,PARA_UI_POS_X+PARA_UI_SIZE_X,PARA_UI_POS_Y*3+PARA_UI_ARROW_V);
-    lv_obj_set_event_cb_mks(buttonEncoderNarrow, event_handler,ID_ENCODER_SETTINGS_ARROW, NULL, 0);
-    lv_imgbtn_set_src_both(buttonEncoderNarrow, "F:/bmp_arrow.bin");
-    lv_imgbtn_use_label_style(buttonEncoderNarrow);
-    lv_btn_set_layout(buttonEncoderNarrow, LV_LAYOUT_OFF);
+    buttonEncoderNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V, event_handler, ID_ENCODER_SETTINGS_ARROW);
 
     lv_obj_t * line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3,line_points[2]);
   #endif
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_ADVANCE_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, event_handler, ID_ADVANCE_RETURN);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif
-
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Back, common_menu.text_back);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_auto_level_offset_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_auto_level_offset_settings.cpp
@@ -105,46 +105,30 @@ void lv_draw_auto_level_offset_settings(void) {
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.Xoffset);
 
-  buttonXValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
-  lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_OFFSET_X, NULL, 0);
-  lv_btn_set_style_both(buttonXValue, &style_para_value);
-  labelXValue = lv_label_create(buttonXValue, NULL);
+  buttonXValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_OFFSET_X);
+  labelXValue = lv_label_create_empty(buttonXValue);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
   lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Yoffset);
 
-  buttonYValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
-  lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_OFFSET_Y, NULL, 0);
-  lv_btn_set_style_both(buttonYValue, &style_para_value);
-  labelYValue = lv_label_create(buttonYValue, NULL);
+  buttonYValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_OFFSET_Y);
+  labelYValue = lv_label_create_empty(buttonYValue);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Zoffset);
 
-  buttonZValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
-  lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_OFFSET_Z, NULL, 0);
-  lv_btn_set_style_both(buttonZValue, &style_para_value);
-  labelZValue = lv_label_create(buttonZValue, NULL);
+  buttonZValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_OFFSET_Z);
+  labelZValue = lv_label_create_empty(buttonZValue);
 
   line3 = lv_line_create(scr, NULL);
   lv_ex_line(line3, line_points[2]);
 
-  buttonBack = lv_btn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_OFFSET_RETURN, NULL, 0);
-  lv_btn_set_style_both(buttonBack, &style_para_back);
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_btn_create_back(scr, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE, event_handler, ID_OFFSET_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_auto_level_offset_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_auto_level_offset_settings.cpp
@@ -83,9 +83,9 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_auto_level_offset_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL;
-  lv_obj_t *labelXText = NULL, *buttonXValue = NULL, *labelXValue = NULL;
-  lv_obj_t *labelYText = NULL, *buttonYValue = NULL, *labelYValue = NULL;
-  lv_obj_t *labelZText = NULL, *buttonZValue = NULL, *labelZValue = NULL;
+  lv_obj_t *buttonXValue = NULL, *labelXValue = NULL;
+  lv_obj_t *buttonYValue = NULL, *labelYValue = NULL;
+  lv_obj_t *buttonZValue = NULL, *labelZValue = NULL;
   lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != NOZZLE_PROBE_OFFSET_UI) {
     disp_state_stack._disp_index++;
@@ -99,56 +99,41 @@ void lv_draw_auto_level_offset_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.OffsetConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.OffsetConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  labelXText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelXText, &tft_style_label_rel);
-  lv_obj_set_pos(labelXText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-  lv_label_set_text(labelXText, machine_menu.Xoffset);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.Xoffset);
 
   buttonXValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
   lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_OFFSET_X, NULL, 0);
-  lv_btn_set_style(buttonXValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonXValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonXValue, &style_para_value);
   labelXValue = lv_label_create(buttonXValue, NULL);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
-  labelYText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelYText, &tft_style_label_rel);
-  lv_obj_set_pos(labelYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-  lv_label_set_text(labelYText, machine_menu.Yoffset);
+  lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Yoffset);
 
   buttonYValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
   lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_OFFSET_Y, NULL, 0);
-  lv_btn_set_style(buttonYValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonYValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonYValue, &style_para_value);
   labelYValue = lv_label_create(buttonYValue, NULL);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
-  labelZText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelZText, &tft_style_label_rel);
-  lv_obj_set_pos(labelZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-  lv_label_set_text(labelZText, machine_menu.Zoffset);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Zoffset);
 
   buttonZValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
   lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_OFFSET_Z, NULL, 0);
-  lv_btn_set_style(buttonZValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonZValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonZValue, &style_para_value);
   labelZValue = lv_label_create(buttonZValue, NULL);
 
   line3 = lv_line_create(scr, NULL);
@@ -156,8 +141,7 @@ void lv_draw_auto_level_offset_settings(void) {
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_OFFSET_RETURN, NULL, 0);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   label_Back = lv_label_create(buttonBack, NULL);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_baby_stepping.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_baby_stepping.cpp
@@ -30,6 +30,10 @@
 #include "../../../../gcode/gcode.h"
 #include "../../../../inc/MarlinConfig.h"
 
+#if ENABLED(EEPROM_SETTINGS)
+  #include "../../../../module/settings.h"
+#endif
+
 #if HAS_BED_PROBE
   #include "../../../../module/probe.h"
 #endif
@@ -141,7 +145,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         if (has_adjust_z == 1) {
-          gcode.process_subcommands_now_P(PSTR("M500"));
+          TERN_(EEPROM_SETTINGS, (void)settings.save());
           has_adjust_z = 0;
         }
         clear_cur_ui();
@@ -166,71 +170,50 @@ void lv_draw_baby_stepping(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonXI   = lv_imgbtn_create(scr, NULL);
-  buttonXD   = lv_imgbtn_create(scr, NULL);
-  buttonYI   = lv_imgbtn_create(scr, NULL);
-  buttonYD   = lv_imgbtn_create(scr, NULL);
-  buttonZI   = lv_imgbtn_create(scr, NULL);
-  buttonZD   = lv_imgbtn_create(scr, NULL);
-  buttonV    = lv_imgbtn_create(scr, NULL);
-  buttonBack = lv_imgbtn_create(scr, NULL);
-
+  buttonXI = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonXI, event_handler, ID_BABY_STEP_X_P, NULL, 0);
-  lv_imgbtn_set_src(buttonXI, LV_BTN_STATE_REL, "F:/bmp_xAdd.bin");
-  lv_imgbtn_set_src(buttonXI, LV_BTN_STATE_PR, "F:/bmp_xAdd.bin");
-  lv_imgbtn_set_style(buttonXI, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonXI, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonXI, "F:/bmp_xAdd.bin");
+  lv_imgbtn_use_label_style(buttonXI);
 
-  #if 1
-    lv_obj_set_event_cb_mks(buttonXD, event_handler, ID_BABY_STEP_X_N, NULL, 0);
-    lv_imgbtn_set_src(buttonXD, LV_BTN_STATE_REL, "F:/bmp_xDec.bin");
-    lv_imgbtn_set_src(buttonXD, LV_BTN_STATE_PR, "F:/bmp_xDec.bin");
-    lv_imgbtn_set_style(buttonXD, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonXD, LV_BTN_STATE_REL, &tft_style_label_rel);
+  buttonXD = lv_imgbtn_create(scr, NULL);
+  lv_obj_set_event_cb_mks(buttonXD, event_handler, ID_BABY_STEP_X_N, NULL, 0);
+  lv_imgbtn_set_src_both(buttonXD, "F:/bmp_xDec.bin");
+  lv_imgbtn_use_label_style(buttonXD);
 
-    lv_obj_set_event_cb_mks(buttonYI, event_handler, ID_BABY_STEP_Y_P, NULL, 0);
-    lv_imgbtn_set_src(buttonYI, LV_BTN_STATE_REL, "F:/bmp_yAdd.bin");
-    lv_imgbtn_set_src(buttonYI, LV_BTN_STATE_PR, "F:/bmp_yAdd.bin");
-    lv_imgbtn_set_style(buttonYI, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonYI, LV_BTN_STATE_REL, &tft_style_label_rel);
+  buttonYI = lv_imgbtn_create(scr, NULL);
+  lv_obj_set_event_cb_mks(buttonYI, event_handler, ID_BABY_STEP_Y_P, NULL, 0);
+  lv_imgbtn_set_src_both(buttonYI, "F:/bmp_yAdd.bin");
+  lv_imgbtn_use_label_style(buttonYI);
 
-    lv_obj_set_event_cb_mks(buttonYD, event_handler, ID_BABY_STEP_Y_N, NULL, 0);
-    lv_imgbtn_set_src(buttonYD, LV_BTN_STATE_REL, "F:/bmp_yDec.bin");
-    lv_imgbtn_set_src(buttonYD, LV_BTN_STATE_PR, "F:/bmp_yDec.bin");
-    lv_imgbtn_set_style(buttonYD, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonYD, LV_BTN_STATE_REL, &tft_style_label_rel);
+  buttonYD = lv_imgbtn_create(scr, NULL);
+  lv_obj_set_event_cb_mks(buttonYD, event_handler, ID_BABY_STEP_Y_N, NULL, 0);
+  lv_imgbtn_set_src_both(buttonYD, "F:/bmp_yDec.bin");
+  lv_imgbtn_use_label_style(buttonYD);
 
-    lv_obj_set_event_cb_mks(buttonZI, event_handler, ID_BABY_STEP_Z_P, NULL, 0);
-    lv_imgbtn_set_src(buttonZI, LV_BTN_STATE_REL, "F:/bmp_zAdd.bin");
-    lv_imgbtn_set_src(buttonZI, LV_BTN_STATE_PR, "F:/bmp_zAdd.bin");
-    lv_imgbtn_set_style(buttonZI, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonZI, LV_BTN_STATE_REL, &tft_style_label_rel);
+  buttonZI = lv_imgbtn_create(scr, NULL);
+  lv_obj_set_event_cb_mks(buttonZI, event_handler, ID_BABY_STEP_Z_P, NULL, 0);
+  lv_imgbtn_set_src_both(buttonZI, "F:/bmp_zAdd.bin");
+  lv_imgbtn_use_label_style(buttonZI);
 
-    lv_obj_set_event_cb_mks(buttonZD, event_handler, ID_BABY_STEP_Z_N, NULL, 0);
-    lv_imgbtn_set_src(buttonZD, LV_BTN_STATE_REL, "F:/bmp_zDec.bin");
-    lv_imgbtn_set_src(buttonZD, LV_BTN_STATE_PR, "F:/bmp_zDec.bin");
-    lv_imgbtn_set_style(buttonZD, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonZD, LV_BTN_STATE_REL, &tft_style_label_rel);
+  buttonZD = lv_imgbtn_create(scr, NULL);
+  lv_obj_set_event_cb_mks(buttonZD, event_handler, ID_BABY_STEP_Z_N, NULL, 0);
+  lv_imgbtn_set_src_both(buttonZD, "F:/bmp_zDec.bin");
+  lv_imgbtn_use_label_style(buttonZD);
 
-    lv_obj_set_event_cb_mks(buttonV, event_handler, ID_BABY_STEP_DIST, NULL, 0);
-    lv_imgbtn_set_style(buttonV, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonV, LV_BTN_STATE_REL, &tft_style_label_rel);
+  buttonV = lv_imgbtn_create(scr, NULL);
+  lv_obj_set_event_cb_mks(buttonV, event_handler, ID_BABY_STEP_DIST, NULL, 0);
+  lv_imgbtn_use_label_style(buttonV);
 
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_BABY_STEP_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  buttonBack = lv_imgbtn_create(scr, NULL);
+  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_BABY_STEP_RETURN, NULL, 0);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
-  #endif // if 1
   lv_obj_set_pos(buttonXI, INTERVAL_V, titleHeight);
   lv_obj_set_pos(buttonYI, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
   lv_obj_set_pos(buttonZI, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
@@ -297,9 +280,7 @@ void lv_draw_baby_stepping(void) {
 
   disp_baby_step_dist();
 
-  zOffsetText = lv_label_create(scr, NULL);
-  lv_obj_set_style(zOffsetText, &tft_style_label_rel);
-  lv_obj_set_pos(zOffsetText, 290, TITLE_YPOS);
+  zOffsetText = lv_label_create(scr, 290, TITLE_YPOS, NULL);
   disp_z_offset_value();
 }
 
@@ -307,16 +288,13 @@ void disp_baby_step_dist() {
   // char buf[30] = {0};
 
   if ((int)(100 * babystep_dist) == 1) {
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_REL, "F:/bmp_baby_move0_01.bin");
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_PR, "F:/bmp_baby_move0_01.bin");
+    lv_imgbtn_set_src_both(buttonV, "F:/bmp_baby_move0_01.bin");
   }
   else if ((int)(100 * babystep_dist) == 5) {
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_REL, "F:/bmp_baby_move0_05.bin");
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_PR, "F:/bmp_baby_move0_05.bin");
+    lv_imgbtn_set_src_both(buttonV, "F:/bmp_baby_move0_05.bin");
   }
   else if ((int)(100 * babystep_dist) == 10) {
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_REL, "F:/bmp_baby_move0_1.bin");
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_PR, "F:/bmp_baby_move0_1.bin");
+    lv_imgbtn_set_src_both(buttonV, "F:/bmp_baby_move0_1.bin");
   }
   if (gCfgItems.multiple_language) {
     if ((int)(100 * babystep_dist) == 1) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_baby_stepping.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_baby_stepping.cpp
@@ -63,7 +63,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
         // nothing to do
       }
       else if (event == LV_EVENT_RELEASED) {
-        ZERO(baby_buf);
         sprintf_P(baby_buf, PSTR("M290 X%.3f"),babystep_dist);
         gcode.process_subcommands_now_P(PSTR(baby_buf));
         has_adjust_z = 1;
@@ -74,7 +73,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
         // nothing to do
       }
       else if (event == LV_EVENT_RELEASED) {
-        ZERO(baby_buf);
         sprintf_P(baby_buf, PSTR("M290 X%.3f"),((float)0 - babystep_dist));
         gcode.process_subcommands_now_P(PSTR(baby_buf));
         has_adjust_z = 1;
@@ -85,7 +83,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
         // nothing to do
       }
       else if (event == LV_EVENT_RELEASED) {
-        ZERO(baby_buf);
         sprintf_P(baby_buf, PSTR("M290 Y%.3f"), babystep_dist);
         gcode.process_subcommands_now_P(PSTR(baby_buf));
         has_adjust_z = 1;
@@ -96,7 +93,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
         // nothing to do
       }
       else if (event == LV_EVENT_RELEASED) {
-        ZERO(baby_buf);
         sprintf_P(baby_buf, PSTR("M290 Y%.3f"),((float)0 - babystep_dist));
         gcode.process_subcommands_now_P(PSTR(baby_buf));
         has_adjust_z = 1;
@@ -107,7 +103,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
         // nothing to do
       }
       else if (event == LV_EVENT_RELEASED) {
-        ZERO(baby_buf);
         sprintf_P(baby_buf, PSTR("M290 Z%.3f"), babystep_dist);
         gcode.process_subcommands_now_P(PSTR(baby_buf));
         has_adjust_z = 1;
@@ -118,7 +113,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
         // nothing to do
       }
       else if (event == LV_EVENT_RELEASED) {
-        ZERO(baby_buf);
         sprintf_P(baby_buf, PSTR("M290 Z%.3f"),((float)0 - babystep_dist));
         gcode.process_subcommands_now_P(PSTR(baby_buf));
         has_adjust_z = 1;
@@ -156,8 +150,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 }
 
 void lv_draw_baby_stepping(void) {
-  lv_obj_t *buttonXI, *buttonXD, *buttonYI, *buttonYD, *buttonZI, *buttonZD, *buttonBack;
-
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != BABY_STEP_UI) {
     disp_state_stack._disp_index++;
     disp_state_stack._disp_state[disp_state_stack._disp_index] = BABY_STEP_UI;
@@ -175,72 +167,24 @@ void lv_draw_baby_stepping(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonXI = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonXI, event_handler, ID_BABY_STEP_X_P, NULL, 0);
-  lv_imgbtn_set_src_both(buttonXI, "F:/bmp_xAdd.bin");
-  lv_imgbtn_use_label_style(buttonXI);
-
-  buttonXD = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonXD, event_handler, ID_BABY_STEP_X_N, NULL, 0);
-  lv_imgbtn_set_src_both(buttonXD, "F:/bmp_xDec.bin");
-  lv_imgbtn_use_label_style(buttonXD);
-
-  buttonYI = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonYI, event_handler, ID_BABY_STEP_Y_P, NULL, 0);
-  lv_imgbtn_set_src_both(buttonYI, "F:/bmp_yAdd.bin");
-  lv_imgbtn_use_label_style(buttonYI);
-
-  buttonYD = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonYD, event_handler, ID_BABY_STEP_Y_N, NULL, 0);
-  lv_imgbtn_set_src_both(buttonYD, "F:/bmp_yDec.bin");
-  lv_imgbtn_use_label_style(buttonYD);
-
-  buttonZI = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonZI, event_handler, ID_BABY_STEP_Z_P, NULL, 0);
-  lv_imgbtn_set_src_both(buttonZI, "F:/bmp_zAdd.bin");
-  lv_imgbtn_use_label_style(buttonZI);
-
-  buttonZD = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonZD, event_handler, ID_BABY_STEP_Z_N, NULL, 0);
-  lv_imgbtn_set_src_both(buttonZD, "F:/bmp_zDec.bin");
-  lv_imgbtn_use_label_style(buttonZD);
-
-  buttonV = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonV, event_handler, ID_BABY_STEP_DIST, NULL, 0);
-  lv_imgbtn_use_label_style(buttonV);
-
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_BABY_STEP_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-
-  lv_obj_set_pos(buttonXI, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonYI, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
-  lv_obj_set_pos(buttonZI, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
-  lv_obj_set_pos(buttonV, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonXD, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonYD, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonZD, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  lv_obj_t *buttonXI = lv_imgbtn_create(scr, "F:/bmp_xAdd.bin", INTERVAL_V, titleHeight, event_handler, ID_BABY_STEP_X_P);
+  lv_obj_t *buttonXD = lv_imgbtn_create(scr, "F:/bmp_xDec.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_BABY_STEP_X_N);
+  lv_obj_t *buttonYI = lv_imgbtn_create(scr, "F:/bmp_yAdd.bin", BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_BABY_STEP_Y_P);
+  lv_obj_t *buttonYD = lv_imgbtn_create(scr, "F:/bmp_yDec.bin", BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_BABY_STEP_Y_N);
+  lv_obj_t *buttonZI = lv_imgbtn_create(scr, "F:/bmp_zAdd.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_BABY_STEP_Z_P);
+  lv_obj_t *buttonZD = lv_imgbtn_create(scr, "F:/bmp_zDec.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_BABY_STEP_Z_N);
+             buttonV = lv_imgbtn_create(scr, NULL, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_BABY_STEP_DIST);
+  lv_obj_t *buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_BABY_STEP_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonXI, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonXD, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonYI, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonYD, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonZI, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonZD, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonV, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelXI = lv_label_create(buttonXI, NULL);
-  lv_obj_t *labelXD = lv_label_create(buttonXD, NULL);
-  lv_obj_t *labelYI = lv_label_create(buttonYI, NULL);
-  lv_obj_t *labelYD = lv_label_create(buttonYD, NULL);
-  lv_obj_t *labelZI = lv_label_create(buttonZI, NULL);
-  lv_obj_t *labelZD = lv_label_create(buttonZD, NULL);
-  labelV = lv_label_create(buttonV, NULL);
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelXI = lv_label_create_empty(buttonXI);
+  lv_obj_t *labelXD = lv_label_create_empty(buttonXD);
+  lv_obj_t *labelYI = lv_label_create_empty(buttonYI);
+  lv_obj_t *labelYD = lv_label_create_empty(buttonYD);
+  lv_obj_t *labelZI = lv_label_create_empty(buttonZI);
+  lv_obj_t *labelZD = lv_label_create_empty(buttonZD);
+  labelV = lv_label_create_empty(buttonV);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelXI, move_menu.x_add);
@@ -286,16 +230,13 @@ void lv_draw_baby_stepping(void) {
 
 void disp_baby_step_dist() {
   // char buf[30] = {0};
-
-  if ((int)(100 * babystep_dist) == 1) {
+  if ((int)(100 * babystep_dist) == 1)
     lv_imgbtn_set_src_both(buttonV, "F:/bmp_baby_move0_01.bin");
-  }
-  else if ((int)(100 * babystep_dist) == 5) {
+  else if ((int)(100 * babystep_dist) == 5)
     lv_imgbtn_set_src_both(buttonV, "F:/bmp_baby_move0_05.bin");
-  }
-  else if ((int)(100 * babystep_dist) == 10) {
+  else if ((int)(100 * babystep_dist) == 10)
     lv_imgbtn_set_src_both(buttonV, "F:/bmp_baby_move0_1.bin");
-  }
+
   if (gCfgItems.multiple_language) {
     if ((int)(100 * babystep_dist) == 1) {
       lv_label_set_text(labelV, move_menu.step_001mm);
@@ -314,8 +255,6 @@ void disp_baby_step_dist() {
 
 void disp_z_offset_value() {
   char buf[20];
-
-  ZERO(buf);
   sprintf_P(buf, PSTR("offset Z: %.3f"), (double)TERN(HAS_BED_PROBE, probe.offset.z, 0));
   lv_label_set_text(zOffsetText, buf);
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_change_speed.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_change_speed.cpp
@@ -173,57 +173,20 @@ void lv_draw_change_speed(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonAdd  = lv_imgbtn_create(scr, NULL);
-  buttonDec  = lv_imgbtn_create(scr, NULL);
-  buttonMov  = lv_imgbtn_create(scr, NULL);
-  buttonExt  = lv_imgbtn_create(scr, NULL);
-  buttonStep = lv_imgbtn_create(scr, NULL);
-  buttonBack = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonAdd, event_handler, ID_C_ADD, NULL, 0);
-  lv_imgbtn_set_src_both(buttonAdd, "F:/bmp_Add.bin");
-  lv_imgbtn_use_label_style(buttonAdd);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonDec, event_handler, ID_C_DEC, NULL, 0);
-    lv_imgbtn_set_src_both(buttonDec, "F:/bmp_Dec.bin");
-    lv_imgbtn_use_label_style(buttonDec);
-
-    lv_obj_set_event_cb_mks(buttonMov, event_handler, ID_C_MOVE, NULL, 0);
-    lv_imgbtn_use_label_style(buttonMov);
-
-    lv_obj_set_event_cb_mks(buttonExt, event_handler, ID_C_EXT, NULL, 0);
-    lv_imgbtn_use_label_style(buttonExt);
-
-    lv_obj_set_event_cb_mks(buttonStep, event_handler, ID_C_STEP, NULL, 0);
-    lv_imgbtn_use_label_style(buttonStep);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_C_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-  #endif
-
-  lv_obj_set_pos(buttonAdd, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonDec, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonMov, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonExt, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonStep, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonAdd  = lv_imgbtn_create(scr, "F:/bmp_Add.bin", INTERVAL_V, titleHeight, event_handler, ID_C_ADD);
+  buttonDec  = lv_imgbtn_create(scr, "F:/bmp_Dec.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_C_DEC);
+  buttonMov  = lv_imgbtn_create(scr, NULL, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_C_MOVE);
+  buttonExt  = lv_imgbtn_create(scr, NULL, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_C_EXT);
+  buttonStep = lv_imgbtn_create(scr, NULL, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_C_STEP);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_C_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonAdd, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonDec, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonMov, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonExt, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonStep, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelAdd    = lv_label_create(buttonAdd, NULL);
-  lv_obj_t *labelDec    = lv_label_create(buttonDec, NULL);
-  labelMov              = lv_label_create(buttonMov, NULL);
-  labelExt              = lv_label_create(buttonExt, NULL);
-  labelStep             = lv_label_create(buttonStep, NULL);
-  lv_obj_t *label_Back  = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelAdd    = lv_label_create_empty(buttonAdd);
+  lv_obj_t *labelDec    = lv_label_create_empty(buttonDec);
+  labelMov              = lv_label_create_empty(buttonMov);
+  labelExt              = lv_label_create_empty(buttonExt);
+  labelStep             = lv_label_create_empty(buttonStep);
+  lv_obj_t *label_Back  = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelAdd, speed_menu.add);
@@ -249,20 +212,19 @@ void lv_draw_change_speed(void) {
   disp_speed_type();
   disp_speed_step();
 
-  printSpeedText = lv_label_create(scr);
+  printSpeedText = lv_label_create_empty(scr);
+  lv_obj_set_style(printSpeedText, &tft_style_label_rel);
   disp_print_speed();
 }
 
 void disp_speed_step() {
-  if (uiCfg.stepPrintSpeed == 1) {
+  if (uiCfg.stepPrintSpeed == 1)
     lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step1_percent.bin");
-  }
-  else if (uiCfg.stepPrintSpeed == 5) {
+  else if (uiCfg.stepPrintSpeed == 5)
     lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step5_percent.bin");
-  }
-  else if (uiCfg.stepPrintSpeed == 10) {
+  else if (uiCfg.stepPrintSpeed == 10)
     lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step10_percent.bin");
-  }
+
   if (gCfgItems.multiple_language) {
     if (uiCfg.stepPrintSpeed == 1) {
       lv_label_set_text(labelStep, speed_menu.step_1percent);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_change_speed.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_change_speed.cpp
@@ -168,13 +168,9 @@ void lv_draw_change_speed(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
-
 
   // Create an Image button
   buttonAdd  = lv_imgbtn_create(scr, NULL);
@@ -185,35 +181,26 @@ void lv_draw_change_speed(void) {
   buttonBack = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonAdd, event_handler, ID_C_ADD, NULL, 0);
-  lv_imgbtn_set_src(buttonAdd, LV_BTN_STATE_REL, "F:/bmp_Add.bin");
-  lv_imgbtn_set_src(buttonAdd, LV_BTN_STATE_PR, "F:/bmp_Add.bin");
-  lv_imgbtn_set_style(buttonAdd, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonAdd, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonAdd, "F:/bmp_Add.bin");
+  lv_imgbtn_use_label_style(buttonAdd);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonDec, event_handler, ID_C_DEC, NULL, 0);
-    lv_imgbtn_set_src(buttonDec, LV_BTN_STATE_REL, "F:/bmp_Dec.bin");
-    lv_imgbtn_set_src(buttonDec, LV_BTN_STATE_PR, "F:/bmp_Dec.bin");
-    lv_imgbtn_set_style(buttonDec, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonDec, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonDec, "F:/bmp_Dec.bin");
+    lv_imgbtn_use_label_style(buttonDec);
 
     lv_obj_set_event_cb_mks(buttonMov, event_handler, ID_C_MOVE, NULL, 0);
-    lv_imgbtn_set_style(buttonMov, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonMov, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonMov);
 
     lv_obj_set_event_cb_mks(buttonExt, event_handler, ID_C_EXT, NULL, 0);
-    lv_imgbtn_set_style(buttonExt, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonExt, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonExt);
 
     lv_obj_set_event_cb_mks(buttonStep, event_handler, ID_C_STEP, NULL, 0);
-    lv_imgbtn_set_style(buttonStep, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonStep, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonStep);
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_C_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
   #endif
 
   lv_obj_set_pos(buttonAdd, INTERVAL_V, titleHeight);
@@ -262,23 +249,19 @@ void lv_draw_change_speed(void) {
   disp_speed_type();
   disp_speed_step();
 
-  printSpeedText = lv_label_create(scr, NULL);
-  lv_obj_set_style(printSpeedText, &tft_style_label_rel);
+  printSpeedText = lv_label_create(scr);
   disp_print_speed();
 }
 
 void disp_speed_step() {
   if (uiCfg.stepPrintSpeed == 1) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step1_percent.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step1_percent.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step1_percent.bin");
   }
   else if (uiCfg.stepPrintSpeed == 5) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step5_percent.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step5_percent.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step5_percent.bin");
   }
   else if (uiCfg.stepPrintSpeed == 10) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step10_percent.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step10_percent.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step10_percent.bin");
   }
   if (gCfgItems.multiple_language) {
     if (uiCfg.stepPrintSpeed == 1) {
@@ -320,17 +303,13 @@ void disp_print_speed() {
 void disp_speed_type() {
   switch (speedType) {
     case 1:
-      lv_imgbtn_set_src(buttonMov, LV_BTN_STATE_REL, "F:/bmp_mov_changeSpeed.bin");
-      lv_imgbtn_set_src(buttonMov, LV_BTN_STATE_PR, "F:/bmp_mov_changeSpeed.bin");
-      lv_imgbtn_set_src(buttonExt, LV_BTN_STATE_REL, "F:/bmp_extruct_sel.bin");
-      lv_imgbtn_set_src(buttonExt, LV_BTN_STATE_PR, "F:/bmp_extruct_sel.bin");
+      lv_imgbtn_set_src_both(buttonMov, "F:/bmp_mov_changeSpeed.bin");
+      lv_imgbtn_set_src_both(buttonExt, "F:/bmp_extruct_sel.bin");
       break;
 
     default:
-      lv_imgbtn_set_src(buttonMov, LV_BTN_STATE_REL, "F:/bmp_mov_sel.bin");
-      lv_imgbtn_set_src(buttonMov, LV_BTN_STATE_PR, "F:/bmp_mov_sel.bin");
-      lv_imgbtn_set_src(buttonExt, LV_BTN_STATE_REL, "F:/bmp_speed_extruct.bin");
-      lv_imgbtn_set_src(buttonExt, LV_BTN_STATE_PR, "F:/bmp_speed_extruct.bin");
+      lv_imgbtn_set_src_both(buttonMov, "F:/bmp_mov_sel.bin");
+      lv_imgbtn_set_src_both(buttonExt, "F:/bmp_speed_extruct.bin");
       break;
   }
   lv_obj_refresh_ext_draw_pad(buttonExt);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_dialog.cpp
@@ -43,6 +43,10 @@
 #include "../../../../gcode/gcode.h"
 #include "../../../../inc/MarlinConfig.h"
 
+#if ENABLED(EEPROM_SETTINGS)
+  #include "../../../../module/settings.h"
+#endif
+
 #if ENABLED(POWER_LOSS_RECOVERY)
   #include "../../../../feature/powerloss.h"
 #endif
@@ -155,17 +159,17 @@ static void btn_ok_event_cb(lv_obj_t * btn, lv_event_t event) {
       }
     #endif
     else if (uiCfg.dialogType == DIALOG_STORE_EEPROM_TIPS) {
-      gcode.process_subcommands_now_P(PSTR("M500"));
+      TERN_(EEPROM_SETTINGS, (void)settings.save());
       clear_cur_ui();
       draw_return_ui();
     }
     else if (uiCfg.dialogType == DIALOG_READ_EEPROM_TIPS) {
-      gcode.process_subcommands_now_P(PSTR("M501"));
+      TERN_(EEPROM_SETTINGS, (void)settings.load());
       clear_cur_ui();
       draw_return_ui();
     }
     else if (uiCfg.dialogType == DIALOG_REVERT_EEPROM_TIPS) {
-      gcode.process_subcommands_now_P(PSTR("M502"));
+      TERN_(EEPROM_SETTINGS, (void)settings.reset());
       clear_cur_ui();
       draw_return_ui();
     }
@@ -199,7 +203,7 @@ static void btn_cancel_event_cb(lv_obj_t * btn, lv_event_t event) {
         pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT;
       #endif
     }
-    else if ((uiCfg.dialogType      == DIALOG_TYPE_FILAMENT_LOAD_HEAT)
+    else if ((uiCfg.dialogType == DIALOG_TYPE_FILAMENT_LOAD_HEAT)
           || (uiCfg.dialogType == DIALOG_TYPE_FILAMENT_UNLOAD_HEAT)
           || (uiCfg.dialogType == DIALOG_TYPE_FILAMENT_HEAT_LOAD_COMPLETED)
           || (uiCfg.dialogType == DIALOG_TYPE_FILAMENT_HEAT_UNLOAD_COMPLETED)
@@ -244,18 +248,13 @@ void lv_draw_dialog(uint8_t type) {
 
   scr = lv_obj_create(NULL, NULL);
 
-
   lv_obj_set_style(scr, &tft_style_scr);
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
-
 
   static lv_style_t style_btn_rel;                                 // A variable to store the released style
   lv_style_copy(&style_btn_rel, &lv_style_plain);                  // Initialize from a built-in style
@@ -278,16 +277,20 @@ void lv_draw_dialog(uint8_t type) {
   style_btn_pr.text.color        = lv_color_hex3(0xBCD);
   style_btn_pr.text.font         = &TERN(HAS_SPI_FLASH_FONT, gb2312_puhui32, lv_font_roboto_22);
 
-  lv_obj_t *labelDialog = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelDialog, &tft_style_label_rel);
+  // Set button styles for Released and Pressed
+  auto lv_btn_use_button_style = [&](lv_obj_t *btn) {
+    lv_btn_set_style(btn, LV_BTN_STYLE_REL, &style_btn_rel);
+    lv_btn_set_style(btn, LV_BTN_STYLE_PR,  &style_btn_pr);
+  };
+
+  lv_obj_t *labelDialog = lv_label_create(scr);
 
   if (uiCfg.dialogType == DIALOG_TYPE_FINISH_PRINT || uiCfg.dialogType == DIALOG_PAUSE_MESSAGE_RESUME) {
       btnOk = lv_btn_create(scr, NULL);                   // Add a button the current screen
       lv_obj_set_pos(btnOk, BTN_OK_X + 90, BTN_OK_Y);                // Set its position
       lv_obj_set_size(btnOk, 100, 50);                               // Set its size
       lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
-      lv_btn_set_style(btnOk, LV_BTN_STYLE_REL, &style_btn_rel);     // Set the button's released style
-      lv_btn_set_style(btnOk, LV_BTN_STYLE_PR, &style_btn_pr);       // Set the button's pressed style
+      lv_btn_use_button_style(btnOk);
       lv_obj_t *labelOk = lv_label_create(btnOk, NULL);             // Add a label to the button
       lv_label_set_text(labelOk, print_file_dialog_menu.confirm);    // Set the labels text
   }
@@ -299,8 +302,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_pos(btnOk, BTN_OK_X + 90, BTN_OK_Y);                // Set its position
     lv_obj_set_size(btnOk, 100, 50);                               // Set its size
     lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
-    lv_btn_set_style(btnOk, LV_BTN_STYLE_REL, &style_btn_rel);     // Set the button's released style
-    lv_btn_set_style(btnOk, LV_BTN_STYLE_PR, &style_btn_pr);       // Set the button's pressed style
+    lv_btn_use_button_style(btnOk);
     lv_obj_t *labelOk = lv_label_create(btnOk, NULL);             // Add a label to the button
     lv_label_set_text(labelOk, print_file_dialog_menu.confirm);    // Set the labels text
   }
@@ -319,8 +321,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_pos(btnCancel, BTN_OK_X+90, BTN_OK_Y);
     lv_obj_set_size(btnCancel, 100, 50);
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_REL, &style_btn_rel);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_PR, &style_btn_pr);
+    lv_btn_use_button_style(btnCancel);
     lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
     lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
   }
@@ -329,8 +330,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_pos(btnCancel, BTN_OK_X+90, BTN_OK_Y);
     lv_obj_set_size(btnCancel, 100, 50);
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_REL, &style_btn_rel);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_PR, &style_btn_pr);
+    lv_btn_use_button_style(btnCancel);
     lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
     lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
   }
@@ -341,8 +341,7 @@ void lv_draw_dialog(uint8_t type) {
         lv_obj_set_pos(btnCancel, BTN_OK_X+90, BTN_OK_Y);
         lv_obj_set_size(btnCancel, 100, 50);
         lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
-        lv_btn_set_style(btnCancel, LV_BTN_STYLE_REL, &style_btn_rel);
-        lv_btn_set_style(btnCancel, LV_BTN_STYLE_PR, &style_btn_pr);
+        lv_btn_use_button_style(btnCancel);
         lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
         lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
       }
@@ -351,8 +350,7 @@ void lv_draw_dialog(uint8_t type) {
         lv_obj_set_pos(btnOk, BTN_OK_X+90, BTN_OK_Y);
         lv_obj_set_size(btnOk, 100, 50);
         lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
-        lv_btn_set_style(btnOk, LV_BTN_STYLE_REL, &style_btn_rel);
-        lv_btn_set_style(btnOk, LV_BTN_STYLE_PR, &style_btn_pr);
+        lv_btn_use_button_style(btnOk);
         lv_obj_t *labelOk = lv_label_create(btnOk, NULL);
         lv_label_set_text(labelOk, print_file_dialog_menu.confirm);
       }
@@ -365,13 +363,11 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_pos(btnCancel, BTN_OK_X+90, BTN_OK_Y);
     lv_obj_set_size(btnCancel, 100, 50);
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_REL, &style_btn_rel);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_PR, &style_btn_pr);
+    lv_btn_use_button_style(btnCancel);
     lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
     lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
 
-    tempText1 = lv_label_create(scr, NULL);
-    lv_obj_set_style(tempText1, &tft_style_label_rel);
+    tempText1 = lv_label_create(scr);
     filament_sprayer_temp();
   }
   else if (uiCfg.dialogType == DIALOG_TYPE_FILAMENT_LOAD_COMPLETED
@@ -381,8 +377,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_pos(btnOk, BTN_OK_X+90, BTN_OK_Y);
     lv_obj_set_size(btnOk, 100, 50);
     lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
-    lv_btn_set_style(btnOk, LV_BTN_STYLE_REL, &style_btn_rel);
-    lv_btn_set_style(btnOk, LV_BTN_STYLE_PR, &style_btn_pr);
+    lv_btn_use_button_style(btnOk);
     lv_obj_t *labelOk = lv_label_create(btnOk, NULL);
     lv_label_set_text(labelOk, print_file_dialog_menu.confirm);
   }
@@ -393,8 +388,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_pos(btnCancel, BTN_OK_X+90, BTN_OK_Y);
     lv_obj_set_size(btnCancel, 100, 50);
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_REL, &style_btn_rel);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_PR, &style_btn_pr);
+    lv_btn_use_button_style(btnCancel);
     lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
     lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
 
@@ -410,16 +404,14 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_pos(btnOk, BTN_OK_X, BTN_OK_Y);                     // Set its position
     lv_obj_set_size(btnOk, 100, 50);                               // Set its size
     lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
-    lv_btn_set_style(btnOk, LV_BTN_STYLE_REL, &style_btn_rel);     // Set the button's released style
-    lv_btn_set_style(btnOk, LV_BTN_STYLE_PR, &style_btn_pr);       // Set the button's pressed style
+    lv_btn_use_button_style(btnOk);
     lv_obj_t *labelOk = lv_label_create(btnOk, NULL);             // Add a label to the button
 
     btnCancel = lv_btn_create(scr, NULL);               // Add a button the current screen
     lv_obj_set_pos(btnCancel, BTN_CANCEL_X, BTN_CANCEL_Y);         // Set its position
     lv_obj_set_size(btnCancel, 100, 50);                           // Set its size
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_REL, &style_btn_rel); // Set the button's released style
-    lv_btn_set_style(btnCancel, LV_BTN_STYLE_PR, &style_btn_pr);   // Set the button's pressed style
+    lv_btn_use_button_style(btnCancel);
     lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);     // Add a label to the button
 
     if (uiCfg.dialogType == DIALOG_PAUSE_MESSAGE_OPTION) {
@@ -435,10 +427,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_label_set_text(labelDialog, print_file_dialog_menu.print_file);
     lv_obj_align(labelDialog, NULL, LV_ALIGN_CENTER, 0, -20);
 
-    lv_obj_t *labelFile = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelFile, &tft_style_label_rel);
-
-    lv_label_set_text(labelFile, list_file.long_name[sel_id]);
+    lv_obj_t *labelFile = lv_label_create(scr, list_file.long_name[sel_id]);
     lv_obj_align(labelFile, NULL, LV_ALIGN_CENTER, 0, -60);
   }
   else if (uiCfg.dialogType == DIALOG_TYPE_STOP) {
@@ -558,7 +547,6 @@ void lv_draw_dialog(uint8_t type) {
 
         lv_label_set_text(labelDialog, buf);
         lv_obj_align(labelDialog, NULL, LV_ALIGN_CENTER, 0, -20);
-
       }
     }
   #endif //USE_WIFI_FUNCTION
@@ -634,10 +622,8 @@ void filament_dialog_handle() {
     planner.synchronize();
     uiCfg.filament_loading_time_flg = 1;
     uiCfg.filament_loading_time_cnt = 0;
-    ZERO(public_buf_m);
-    sprintf_P(public_buf_m,PSTR("T%d\nG91\nG1 E%d F%d\nG90"),uiCfg.curSprayerChoose,gCfgItems.filamentchange_load_length,gCfgItems.filamentchange_load_speed);
-    queue.inject_P(PSTR(public_buf_m));
-    //gcode.process_subcommands_now_P(PSTR(public_buf_m));
+    sprintf_P(public_buf_m, PSTR("T%d\nG91\nG1 E%d F%d\nG90"), uiCfg.curSprayerChoose, gCfgItems.filamentchange_load_length, gCfgItems.filamentchange_load_speed);
+    queue.inject(public_buf_m);
   }
   if (uiCfg.filament_heat_completed_unload == 1) {
     uiCfg.filament_heat_completed_unload = 0;
@@ -646,9 +632,8 @@ void filament_dialog_handle() {
     planner.synchronize();
     uiCfg.filament_unloading_time_flg = 1;
     uiCfg.filament_unloading_time_cnt = 0;
-    ZERO(public_buf_m);
-    sprintf_P(public_buf_m,PSTR("T%d\nG91\nG1 E-%d F%d\nG90"),uiCfg.curSprayerChoose,gCfgItems.filamentchange_unload_length,gCfgItems.filamentchange_unload_speed);
-    queue.inject_P(PSTR(public_buf_m));
+    sprintf_P(public_buf_m, PSTR("T%d\nG91\nG1 E-%d F%d\nG90"), uiCfg.curSprayerChoose, gCfgItems.filamentchange_unload_length, gCfgItems.filamentchange_unload_speed);
+    queue.inject(public_buf_m);
   }
 
   if (((abs((int)((int)thermalManager.temp_hotend[uiCfg.curSprayerChoose].celsius - gCfgItems.filament_limit_temper)) <= 1)

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_dialog.cpp
@@ -283,7 +283,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_btn_set_style(btn, LV_BTN_STYLE_PR,  &style_btn_pr);
   };
 
-  lv_obj_t *labelDialog = lv_label_create(scr);
+  lv_obj_t *labelDialog = lv_label_create_empty(scr);
 
   if (uiCfg.dialogType == DIALOG_TYPE_FINISH_PRINT || uiCfg.dialogType == DIALOG_PAUSE_MESSAGE_RESUME) {
       btnOk = lv_btn_create(scr, NULL);                   // Add a button the current screen
@@ -291,7 +291,7 @@ void lv_draw_dialog(uint8_t type) {
       lv_obj_set_size(btnOk, 100, 50);                               // Set its size
       lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
       lv_btn_use_button_style(btnOk);
-      lv_obj_t *labelOk = lv_label_create(btnOk, NULL);             // Add a label to the button
+      lv_obj_t *labelOk = lv_label_create_empty(btnOk);             // Add a label to the button
       lv_label_set_text(labelOk, print_file_dialog_menu.confirm);    // Set the labels text
   }
   else if (uiCfg.dialogType == DIALOG_PAUSE_MESSAGE_WAITING
@@ -303,7 +303,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_size(btnOk, 100, 50);                               // Set its size
     lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
     lv_btn_use_button_style(btnOk);
-    lv_obj_t *labelOk = lv_label_create(btnOk, NULL);             // Add a label to the button
+    lv_obj_t *labelOk = lv_label_create_empty(btnOk);             // Add a label to the button
     lv_label_set_text(labelOk, print_file_dialog_menu.confirm);    // Set the labels text
   }
   else if (uiCfg.dialogType == DIALOG_PAUSE_MESSAGE_PAUSING
@@ -322,7 +322,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_size(btnCancel, 100, 50);
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
     lv_btn_use_button_style(btnCancel);
-    lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
+    lv_obj_t *labelCancel = lv_label_create_empty(btnCancel);
     lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
   }
   else if (uiCfg.dialogType == DIALOG_TRANSFER_NO_DEVICE) {
@@ -331,7 +331,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_size(btnCancel, 100, 50);
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
     lv_btn_use_button_style(btnCancel);
-    lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
+    lv_obj_t *labelCancel = lv_label_create_empty(btnCancel);
     lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
   }
   #if ENABLED(USE_WIFI_FUNCTION)
@@ -342,7 +342,7 @@ void lv_draw_dialog(uint8_t type) {
         lv_obj_set_size(btnCancel, 100, 50);
         lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
         lv_btn_use_button_style(btnCancel);
-        lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
+        lv_obj_t *labelCancel = lv_label_create_empty(btnCancel);
         lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
       }
       else if (upload_result == 3) {
@@ -351,7 +351,7 @@ void lv_draw_dialog(uint8_t type) {
         lv_obj_set_size(btnOk, 100, 50);
         lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
         lv_btn_use_button_style(btnOk);
-        lv_obj_t *labelOk = lv_label_create(btnOk, NULL);
+        lv_obj_t *labelOk = lv_label_create_empty(btnOk);
         lv_label_set_text(labelOk, print_file_dialog_menu.confirm);
       }
     }
@@ -364,21 +364,21 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_size(btnCancel, 100, 50);
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
     lv_btn_use_button_style(btnCancel);
-    lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
+    lv_obj_t *labelCancel = lv_label_create_empty(btnCancel);
     lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
 
-    tempText1 = lv_label_create(scr);
+    tempText1 = lv_label_create_empty(scr);
     filament_sprayer_temp();
   }
   else if (uiCfg.dialogType == DIALOG_TYPE_FILAMENT_LOAD_COMPLETED
         || uiCfg.dialogType == DIALOG_TYPE_FILAMENT_UNLOAD_COMPLETED
   ) {
     btnOk = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(btnOk, BTN_OK_X+90, BTN_OK_Y);
+    lv_obj_set_pos(btnOk, BTN_OK_X + 90, BTN_OK_Y);
     lv_obj_set_size(btnOk, 100, 50);
     lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
     lv_btn_use_button_style(btnOk);
-    lv_obj_t *labelOk = lv_label_create(btnOk, NULL);
+    lv_obj_t *labelOk = lv_label_create_empty(btnOk);
     lv_label_set_text(labelOk, print_file_dialog_menu.confirm);
   }
   else if (uiCfg.dialogType == DIALOG_TYPE_FILAMENT_LOADING
@@ -389,7 +389,7 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_size(btnCancel, 100, 50);
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
     lv_btn_use_button_style(btnCancel);
-    lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);
+    lv_obj_t *labelCancel = lv_label_create_empty(btnCancel);
     lv_label_set_text(labelCancel, print_file_dialog_menu.cancle);
 
     filament_bar = lv_bar_create(scr, NULL);
@@ -405,14 +405,14 @@ void lv_draw_dialog(uint8_t type) {
     lv_obj_set_size(btnOk, 100, 50);                               // Set its size
     lv_obj_set_event_cb(btnOk, btn_ok_event_cb);
     lv_btn_use_button_style(btnOk);
-    lv_obj_t *labelOk = lv_label_create(btnOk, NULL);             // Add a label to the button
+    lv_obj_t *labelOk = lv_label_create_empty(btnOk);             // Add a label to the button
 
     btnCancel = lv_btn_create(scr, NULL);               // Add a button the current screen
     lv_obj_set_pos(btnCancel, BTN_CANCEL_X, BTN_CANCEL_Y);         // Set its position
     lv_obj_set_size(btnCancel, 100, 50);                           // Set its size
     lv_obj_set_event_cb(btnCancel, btn_cancel_event_cb);
     lv_btn_use_button_style(btnCancel);
-    lv_obj_t *labelCancel = lv_label_create(btnCancel, NULL);     // Add a label to the button
+    lv_obj_t *labelCancel = lv_label_create_empty(btnCancel);     // Add a label to the button
 
     if (uiCfg.dialogType == DIALOG_PAUSE_MESSAGE_OPTION) {
       lv_label_set_text(labelOk, pause_msg_menu.purgeMore);        // Set the labels text

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_eeprom_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_eeprom_settings.cpp
@@ -111,9 +111,9 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_eeprom_settings(void) {
   lv_obj_t *buttonBack, *label_Back;
-  lv_obj_t *buttonStore,*labelStore,*buttonStoreNarrow;
+  lv_obj_t *buttonStore, *labelStore;
   //lv_obj_t *buttonRead,*labelRead,*buttonReadNarrow;
-  lv_obj_t *buttonRevert, *labelRevert, *buttonRevertNarrow;
+  lv_obj_t *buttonRevert, *labelRevert;
   lv_obj_t * line1, * line2; //* line3;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != EEPROM_SETTINGS_UI) {
     disp_state_stack._disp_index++;
@@ -138,14 +138,9 @@ void lv_draw_eeprom_settings(void) {
   lv_obj_set_event_cb_mks(buttonRevert, event_handler, ID_EEPROM_REVERT, NULL, 0);
   lv_btn_use_label_style(buttonRevert);
   lv_btn_set_layout(buttonRevert, LV_LAYOUT_OFF);
-  labelRevert = lv_label_create(buttonRevert, NULL);        /*Add a label to the button*/
+  labelRevert = lv_label_create_empty(buttonRevert);        /*Add a label to the button*/
 
-  buttonRevertNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonRevertNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonRevertNarrow, event_handler, ID_EEPROM_REVERT_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonRevertNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonRevertNarrow);
-  lv_btn_set_layout(buttonRevertNarrow, LV_LAYOUT_OFF);
+  (void)lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V, event_handler, ID_EEPROM_REVERT_ARROW);
 
   //line3 = lv_line_create(scr, NULL);
   //lv_ex_line(line3,line_points[2]);
@@ -159,26 +154,15 @@ void lv_draw_eeprom_settings(void) {
   lv_obj_set_event_cb_mks(buttonStore, event_handler, ID_EEPROM_STORE, NULL, 0);
   lv_btn_use_label_style(buttonStore);
   lv_btn_set_layout(buttonStore, LV_LAYOUT_OFF);
-  labelStore = lv_label_create(buttonStore, NULL);        /*Add a label to the button*/
+  labelStore = lv_label_create_empty(buttonStore);        /*Add a label to the button*/
 
-  buttonStoreNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonStoreNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonStoreNarrow, event_handler, ID_EEPROM_STORE_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonStoreNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonStoreNarrow);
-  lv_btn_set_layout(buttonStoreNarrow, LV_LAYOUT_OFF);
+  (void)lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V, event_handler, ID_EEPROM_STORE_ARROW);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_EEPROM_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, event_handler, ID_EEPROM_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Back, common_menu.text_back);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_eeprom_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_eeprom_settings.cpp
@@ -127,10 +127,7 @@ void lv_draw_eeprom_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -139,18 +136,15 @@ void lv_draw_eeprom_settings(void) {
   lv_obj_set_size(buttonRevert, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);                       /*Set its size*/
   //lv_obj_set_event_cb(buttonMotor, event_handler);
   lv_obj_set_event_cb_mks(buttonRevert, event_handler, ID_EEPROM_REVERT, NULL, 0);
-  lv_btn_set_style(buttonRevert, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-  lv_btn_set_style(buttonRevert, LV_BTN_STYLE_PR, &tft_style_label_pre);    /*Set the button's pressed style*/
+  lv_btn_use_label_style(buttonRevert);
   lv_btn_set_layout(buttonRevert, LV_LAYOUT_OFF);
   labelRevert = lv_label_create(buttonRevert, NULL);        /*Add a label to the button*/
 
   buttonRevertNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonRevertNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonRevertNarrow, event_handler, ID_EEPROM_REVERT_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonRevertNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonRevertNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonRevertNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonRevertNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonRevertNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonRevertNarrow);
   lv_btn_set_layout(buttonRevertNarrow, LV_LAYOUT_OFF);
 
   //line3 = lv_line_create(scr, NULL);
@@ -163,18 +157,15 @@ void lv_draw_eeprom_settings(void) {
   lv_obj_set_size(buttonStore, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);                       /*Set its size*/
   //lv_obj_set_event_cb(buttonMotor, event_handler);
   lv_obj_set_event_cb_mks(buttonStore, event_handler, ID_EEPROM_STORE, NULL, 0);
-  lv_btn_set_style(buttonStore, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-  lv_btn_set_style(buttonStore, LV_BTN_STYLE_PR, &tft_style_label_pre);    /*Set the button's pressed style*/
+  lv_btn_use_label_style(buttonStore);
   lv_btn_set_layout(buttonStore, LV_LAYOUT_OFF);
   labelStore = lv_label_create(buttonStore, NULL);        /*Add a label to the button*/
 
   buttonStoreNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonStoreNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonStoreNarrow, event_handler, ID_EEPROM_STORE_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonStoreNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonStoreNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonStoreNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonStoreNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonStoreNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonStoreNarrow);
   lv_btn_set_layout(buttonStoreNarrow, LV_LAYOUT_OFF);
 
   line2 = lv_line_create(scr, NULL);
@@ -182,10 +173,8 @@ void lv_draw_eeprom_settings(void) {
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_EEPROM_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_encoder_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_encoder_settings.cpp
@@ -87,27 +87,14 @@ void lv_draw_encoder_settings(void) {
 
   labelEncoderTips = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.EncoderConfText);
 
-  buttonEncoderState = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonEncoderState, PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V);
-  lv_imgbtn_set_src_both(buttonEncoderState, gCfgItems.encoder_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
-
-  lv_obj_set_event_cb_mks(buttonEncoderState, event_handler, ID_ENCODER_STATE, NULL, 0);
-
-  lv_imgbtn_use_label_style(buttonEncoderState);
-  lv_btn_set_layout(buttonEncoderState, LV_LAYOUT_OFF);
-  labelEncoderState = lv_label_create(buttonEncoderState, NULL);
+  buttonEncoderState = lv_imgbtn_create(scr, gCfgItems.encoder_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin", PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V, event_handler, ID_ENCODER_STATE);
+  labelEncoderState = lv_label_create_empty(buttonEncoderState);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_ENCODER_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, event_handler, ID_ENCODER_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   lv_label_set_text(labelEncoderState, gCfgItems.encoder_enable ? machine_menu.enable : machine_menu.disable);
   lv_obj_align(labelEncoderState, buttonEncoderState, LV_ALIGN_CENTER, 0, 0);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_encoder_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_encoder_settings.cpp
@@ -55,8 +55,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         gCfgItems.encoder_enable ^= true;
-        lv_imgbtn_set_src(buttonEncoderState, LV_BTN_STATE_REL, gCfgItems.encoder_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
-        lv_imgbtn_set_src(buttonEncoderState, LV_BTN_STATE_PR, gCfgItems.encoder_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
+        lv_imgbtn_set_src_both(buttonEncoderState, gCfgItems.encoder_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
         lv_label_set_text(labelEncoderState, machine_menu.enable);
         update_spi_flash();
       }
@@ -82,27 +81,19 @@ void lv_draw_encoder_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.EncoderConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.EncoderConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  labelEncoderTips = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelEncoderTips, &tft_style_label_rel);
-  lv_obj_set_pos(labelEncoderTips, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-  lv_label_set_text(labelEncoderTips, machine_menu.EncoderConfText);
+  labelEncoderTips = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.EncoderConfText);
 
   buttonEncoderState = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonEncoderState, PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V);
-  lv_imgbtn_set_src(buttonEncoderState, LV_BTN_STATE_REL, gCfgItems.encoder_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
-  lv_imgbtn_set_src(buttonEncoderState, LV_BTN_STATE_PR, gCfgItems.encoder_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
+  lv_imgbtn_set_src_both(buttonEncoderState, gCfgItems.encoder_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
 
   lv_obj_set_event_cb_mks(buttonEncoderState, event_handler, ID_ENCODER_STATE, NULL, 0);
 
-  lv_imgbtn_set_style(buttonEncoderState, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonEncoderState, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_use_label_style(buttonEncoderState);
   lv_btn_set_layout(buttonEncoderState, LV_LAYOUT_OFF);
   labelEncoderState = lv_label_create(buttonEncoderState, NULL);
 
@@ -111,10 +102,8 @@ void lv_draw_encoder_settings(void) {
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_ENCODER_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_error_message.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_error_message.cpp
@@ -56,20 +56,14 @@ void lv_draw_error_message(PGM_P const msg) {
     lv_refr_now(lv_refr_get_disp_refreshing());
 
     if (msg) {
-      message = lv_label_create(scr, NULL);
-      lv_obj_set_style(message, &tft_style_label_rel);
-      lv_label_set_text(message, msg);
+      message = lv_label_create(scr, msg);
       lv_obj_align(message, NULL, LV_ALIGN_CENTER, 0, -50);
     }
 
-    kill_message = lv_label_create(scr, NULL);
-    lv_obj_set_style(kill_message, &tft_style_label_rel);
-    lv_label_set_text(kill_message, "PRINTER HALTED");
+    kill_message = lv_label_create(scr, "PRINTER HALTED");
     lv_obj_align(kill_message, NULL, LV_ALIGN_CENTER, 0, -10);
 
-    reset_tips = lv_label_create(scr, NULL);
-    lv_obj_set_style(reset_tips, &tft_style_label_rel);
-    lv_label_set_text(reset_tips, "Please Reset");
+    reset_tips = lv_label_create(scr, "Please Reset");
     lv_obj_align(reset_tips, NULL, LV_ALIGN_CENTER, 0, 30);
 
     lv_task_handler();

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_extrusion.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_extrusion.cpp
@@ -34,14 +34,14 @@
 #include "../../../../gcode/queue.h"
 #include "../../../../inc/MarlinConfig.h"
 
-static lv_obj_t * scr;
-extern lv_group_t*  g;
-static lv_obj_t * buttoType, *buttonStep, *buttonSpeed;
+static lv_obj_t *scr;
+extern lv_group_t *g;
+static lv_obj_t *buttonType, *buttonStep, *buttonSpeed;
 static lv_obj_t *labelType;
 static lv_obj_t *labelStep;
 static lv_obj_t *labelSpeed;
-static lv_obj_t * tempText;
-static lv_obj_t * ExtruText;
+static lv_obj_t *tempText;
+static lv_obj_t *ExtruText;
 
 #define ID_E_ADD    1
 #define ID_E_DEC    2
@@ -170,58 +170,22 @@ void lv_draw_extrusion(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create image buttons
-  buttonAdd   = lv_imgbtn_create(scr, NULL);
-  buttonDec   = lv_imgbtn_create(scr, NULL);
-  buttoType   = lv_imgbtn_create(scr, NULL);
-  buttonStep  = lv_imgbtn_create(scr, NULL);
-  buttonSpeed = lv_imgbtn_create(scr, NULL);
-  buttonBack  = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonAdd, event_handler, ID_E_ADD, NULL, 0);
-  lv_imgbtn_set_src_both(buttonAdd, "F:/bmp_in.bin");
-  lv_imgbtn_use_label_style(buttonAdd);
+  buttonAdd = lv_imgbtn_create(scr, "F:/bmp_in.bin", INTERVAL_V, titleHeight, event_handler, ID_E_ADD);
   lv_obj_clear_protect(buttonAdd, LV_PROTECT_FOLLOW);
 
-  #if 1
-    lv_obj_set_event_cb_mks(buttonDec, event_handler, ID_E_DEC, NULL, 0);
-    lv_imgbtn_set_src_both(buttonDec, "F:/bmp_out.bin");
-    lv_imgbtn_use_label_style(buttonDec);
-
-    lv_obj_set_event_cb_mks(buttoType, event_handler, ID_E_TYPE, NULL, 0);
-    lv_imgbtn_use_label_style(buttoType);
-
-    lv_obj_set_event_cb_mks(buttonStep, event_handler, ID_E_STEP, NULL, 0);
-    lv_imgbtn_use_label_style(buttonStep);
-
-    lv_obj_set_event_cb_mks(buttonSpeed, event_handler, ID_E_SPEED, NULL, 0);
-    lv_imgbtn_use_label_style(buttonSpeed);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_E_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-  #endif
-
-  lv_obj_set_pos(buttonAdd, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonDec, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttoType, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonStep, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonSpeed, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonDec = lv_imgbtn_create(scr, "F:/bmp_out.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_E_DEC);
+  buttonType = lv_imgbtn_create(scr, NULL, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_E_TYPE);
+  buttonStep = lv_imgbtn_create(scr, NULL, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_E_STEP);
+  buttonSpeed = lv_imgbtn_create(scr, NULL, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_E_SPEED);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_E_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonAdd, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonDec, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttoType, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonStep, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonSpeed, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelAdd   = lv_label_create(buttonAdd, NULL);
-  lv_obj_t *labelDec   = lv_label_create(buttonDec, NULL);
-  labelType             = lv_label_create(buttoType, NULL);
-  labelStep             = lv_label_create(buttonStep, NULL);
-  labelSpeed            = lv_label_create(buttonSpeed, NULL);
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelAdd   = lv_label_create_empty(buttonAdd);
+  lv_obj_t *labelDec   = lv_label_create_empty(buttonDec);
+  labelType             = lv_label_create_empty(buttonType);
+  labelStep             = lv_label_create_empty(buttonStep);
+  labelSpeed            = lv_label_create_empty(buttonSpeed);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelAdd, extrude_menu.in);
@@ -238,7 +202,7 @@ void lv_draw_extrusion(void) {
     if (gCfgItems.encoder_enable) {
       lv_group_add_obj(g, buttonAdd);
       lv_group_add_obj(g, buttonDec);
-      lv_group_add_obj(g, buttoType);
+      lv_group_add_obj(g, buttonType);
       lv_group_add_obj(g, buttonStep);
       lv_group_add_obj(g, buttonSpeed);
       lv_group_add_obj(g, buttonBack);
@@ -249,40 +213,39 @@ void lv_draw_extrusion(void) {
   disp_ext_step();
   disp_ext_speed();
 
-  tempText = lv_label_create(scr);
+  tempText = lv_label_create_empty(scr);
+  lv_obj_set_style(tempText, &tft_style_label_rel);
   disp_hotend_temp();
 
-  ExtruText = lv_label_create(scr);
+  ExtruText = lv_label_create_empty(scr);
+  lv_obj_set_style(ExtruText, &tft_style_label_rel);
   disp_extru_amount();
 }
 
 void disp_ext_type() {
   if (uiCfg.curSprayerChoose == 1) {
-    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru2.bin");
+    lv_imgbtn_set_src_both(buttonType, "F:/bmp_extru2.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, extrude_menu.ext2);
-      lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
+      lv_obj_align(labelType, buttonType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
   }
   else {
-    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru1.bin");
+    lv_imgbtn_set_src_both(buttonType, "F:/bmp_extru1.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, extrude_menu.ext1);
-      lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
+      lv_obj_align(labelType, buttonType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
   }
 }
 
 void disp_ext_speed() {
-  if (uiCfg.extruSpeed == 20) {
+  if (uiCfg.extruSpeed == 20)
     lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed_high.bin");
-  }
-  else if (uiCfg.extruSpeed == 1) {
-  lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed_slow.bin");
-  }
-  else {
-  lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed_normal.bin");
-  }
+  else if (uiCfg.extruSpeed == 1)
+    lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed_slow.bin");
+  else
+    lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed_normal.bin");
 
   if (gCfgItems.multiple_language) {
     if (uiCfg.extruSpeed == 20) {
@@ -304,7 +267,7 @@ void disp_hotend_temp() {
   char buf[20] = {0};
   public_buf_l[0] = '\0';
   strcat(public_buf_l, extrude_menu.temper_text);
-  sprintf(buf, extrude_menu.temp_value, (int)thermalManager.temp_hotend[uiCfg.curSprayerChoose].celsius,  (int)thermalManager.temp_hotend[uiCfg.curSprayerChoose].target);
+  sprintf(buf, extrude_menu.temp_value, (int)thermalManager.temp_hotend[uiCfg.curSprayerChoose].celsius, (int)thermalManager.temp_hotend[uiCfg.curSprayerChoose].target);
   strcat(public_buf_l, buf);
   lv_label_set_text(tempText, public_buf_l);
   lv_obj_align(tempText, NULL, LV_ALIGN_CENTER, 0, -50);
@@ -345,15 +308,12 @@ void disp_extru_amount() {
 }
 
 void disp_ext_step() {
-  if (uiCfg.extruStep == 1) {
+  if (uiCfg.extruStep == 1)
     lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step1_mm.bin");
-  }
-  else if (uiCfg.extruStep == 5) {
+  else if (uiCfg.extruStep == 5)
     lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step5_mm.bin");
-  }
-  else if (uiCfg.extruStep == 10) {
+  else if (uiCfg.extruStep == 10)
     lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step10_mm.bin");
-  }
 
   if (gCfgItems.multiple_language) {
     if (uiCfg.extruStep == 1) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_extrusion.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_extrusion.cpp
@@ -165,10 +165,7 @@ void lv_draw_extrusion(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -181,36 +178,27 @@ void lv_draw_extrusion(void) {
   buttonBack  = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonAdd, event_handler, ID_E_ADD, NULL, 0);
-  lv_imgbtn_set_src(buttonAdd, LV_BTN_STATE_REL, "F:/bmp_in.bin");
-  lv_imgbtn_set_src(buttonAdd, LV_BTN_STATE_PR, "F:/bmp_in.bin");
-  lv_imgbtn_set_style(buttonAdd, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonAdd, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonAdd, "F:/bmp_in.bin");
+  lv_imgbtn_use_label_style(buttonAdd);
   lv_obj_clear_protect(buttonAdd, LV_PROTECT_FOLLOW);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonDec, event_handler, ID_E_DEC, NULL, 0);
-    lv_imgbtn_set_src(buttonDec, LV_BTN_STATE_REL, "F:/bmp_out.bin");
-    lv_imgbtn_set_src(buttonDec, LV_BTN_STATE_PR, "F:/bmp_out.bin");
-    lv_imgbtn_set_style(buttonDec, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonDec, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonDec, "F:/bmp_out.bin");
+    lv_imgbtn_use_label_style(buttonDec);
 
     lv_obj_set_event_cb_mks(buttoType, event_handler, ID_E_TYPE, NULL, 0);
-    lv_imgbtn_set_style(buttoType, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttoType, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttoType);
 
     lv_obj_set_event_cb_mks(buttonStep, event_handler, ID_E_STEP, NULL, 0);
-    lv_imgbtn_set_style(buttonStep, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonStep, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonStep);
 
     lv_obj_set_event_cb_mks(buttonSpeed, event_handler, ID_E_SPEED, NULL, 0);
-    lv_imgbtn_set_style(buttonSpeed, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonSpeed, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonSpeed);
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_E_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
   #endif
 
   lv_obj_set_pos(buttonAdd, INTERVAL_V, titleHeight);
@@ -261,27 +249,23 @@ void lv_draw_extrusion(void) {
   disp_ext_step();
   disp_ext_speed();
 
-  tempText = lv_label_create(scr, NULL);
-  lv_obj_set_style(tempText, &tft_style_label_rel);
+  tempText = lv_label_create(scr);
   disp_hotend_temp();
 
-  ExtruText = lv_label_create(scr, NULL);
-  lv_obj_set_style(ExtruText, &tft_style_label_rel);
+  ExtruText = lv_label_create(scr);
   disp_extru_amount();
 }
 
 void disp_ext_type() {
   if (uiCfg.curSprayerChoose == 1) {
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_REL, "F:/bmp_extru2.bin");
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_PR, "F:/bmp_extru2.bin");
+    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru2.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, extrude_menu.ext2);
       lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
   }
   else {
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_REL, "F:/bmp_extru1.bin");
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_PR, "F:/bmp_extru1.bin");
+    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru1.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, extrude_menu.ext1);
       lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
@@ -291,16 +275,13 @@ void disp_ext_type() {
 
 void disp_ext_speed() {
   if (uiCfg.extruSpeed == 20) {
-    lv_imgbtn_set_src(buttonSpeed, LV_BTN_STATE_REL, "F:/bmp_speed_high.bin");
-    lv_imgbtn_set_src(buttonSpeed, LV_BTN_STATE_PR, "F:/bmp_speed_high.bin");
+    lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed_high.bin");
   }
   else if (uiCfg.extruSpeed == 1) {
-  lv_imgbtn_set_src(buttonSpeed, LV_BTN_STATE_REL, "F:/bmp_speed_slow.bin");
-    lv_imgbtn_set_src(buttonSpeed, LV_BTN_STATE_PR, "F:/bmp_speed_slow.bin");
+  lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed_slow.bin");
   }
   else {
-  lv_imgbtn_set_src(buttonSpeed, LV_BTN_STATE_REL, "F:/bmp_speed_normal.bin");
-    lv_imgbtn_set_src(buttonSpeed, LV_BTN_STATE_PR, "F:/bmp_speed_normal.bin");
+  lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed_normal.bin");
   }
 
   if (gCfgItems.multiple_language) {
@@ -365,16 +346,13 @@ void disp_extru_amount() {
 
 void disp_ext_step() {
   if (uiCfg.extruStep == 1) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step1_mm.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step1_mm.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step1_mm.bin");
   }
   else if (uiCfg.extruStep == 5) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step5_mm.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step5_mm.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step5_mm.bin");
   }
   else if (uiCfg.extruStep == 10) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step10_mm.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step10_mm.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step10_mm.bin");
   }
 
   if (gCfgItems.multiple_language) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
@@ -137,62 +137,22 @@ void lv_draw_fan(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonAdd  = lv_imgbtn_create(scr, NULL);
-  buttonDec  = lv_imgbtn_create(scr, NULL);
-  buttonHigh = lv_imgbtn_create(scr, NULL);
-  buttonMid  = lv_imgbtn_create(scr, NULL);
-  buttonOff  = lv_imgbtn_create(scr, NULL);
-  buttonBack = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonAdd, event_handler, ID_F_ADD, NULL, 0);
-  lv_imgbtn_set_src_both(buttonAdd, "F:/bmp_Add.bin");
-  lv_imgbtn_use_label_style(buttonAdd);
+  buttonAdd  = lv_imgbtn_create(scr, "F:/bmp_Add.bin", INTERVAL_V, titleHeight, event_handler, ID_F_ADD);
   lv_obj_clear_protect(buttonAdd, LV_PROTECT_FOLLOW);
 
-  #if 1
-    lv_obj_set_event_cb_mks(buttonDec, event_handler, ID_F_DEC, NULL, 0);
-    lv_imgbtn_set_src_both(buttonDec, "F:/bmp_Dec.bin");
-    lv_imgbtn_use_label_style(buttonDec);
-
-    lv_obj_set_event_cb_mks(buttonHigh, event_handler,ID_F_HIGH, NULL, 0);
-    lv_imgbtn_set_src_both(buttonHigh, "F:/bmp_speed255.bin");
-    lv_imgbtn_use_label_style(buttonHigh);
-
-    lv_obj_set_event_cb_mks(buttonMid, event_handler,ID_F_MID, NULL, 0);
-    lv_imgbtn_set_src_both(buttonMid, "F:/bmp_speed127.bin");
-    lv_imgbtn_use_label_style(buttonMid);
-
-    lv_obj_set_event_cb_mks(buttonOff, event_handler,ID_F_OFF, NULL, 0);
-    lv_imgbtn_set_src_both(buttonOff, "F:/bmp_speed0.bin");
-    lv_imgbtn_use_label_style(buttonOff);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_F_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-
-  #endif
-
-  lv_obj_set_pos(buttonAdd, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonDec, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonHigh, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonMid, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonOff, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonDec  = lv_imgbtn_create(scr, "F:/bmp_Dec.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_F_DEC);
+  buttonHigh = lv_imgbtn_create(scr, "F:/bmp_speed255.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_F_HIGH);
+  buttonMid  = lv_imgbtn_create(scr, "F:/bmp_speed127.bin", BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_F_MID);
+  buttonOff  = lv_imgbtn_create(scr, "F:/bmp_speed0.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_F_OFF);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_F_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonAdd, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonDec, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonHigh, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonMid, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonOff, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelAdd = lv_label_create(buttonAdd, NULL);
-  lv_obj_t *labelDec = lv_label_create(buttonDec, NULL);
-  lv_obj_t *labelHigh = lv_label_create(buttonHigh, NULL);
-  lv_obj_t *labelMid = lv_label_create(buttonMid, NULL);
-  lv_obj_t *labelOff = lv_label_create(buttonOff, NULL);
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelAdd = lv_label_create_empty(buttonAdd);
+  lv_obj_t *labelDec = lv_label_create_empty(buttonDec);
+  lv_obj_t *labelHigh = lv_label_create_empty(buttonHigh);
+  lv_obj_t *labelMid = lv_label_create_empty(buttonMid);
+  lv_obj_t *labelOff = lv_label_create_empty(buttonOff);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelAdd, fan_menu.add);
@@ -224,7 +184,8 @@ void lv_draw_fan(void) {
     }
   #endif
 
-  fanText = lv_label_create(scr);
+  fanText = lv_label_create_empty(scr);
+  lv_obj_set_style(fanText, &tft_style_label_rel);
   disp_fan_value();
 }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
@@ -132,10 +132,7 @@ void lv_draw_fan(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -148,42 +145,30 @@ void lv_draw_fan(void) {
   buttonBack = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonAdd, event_handler, ID_F_ADD, NULL, 0);
-  lv_imgbtn_set_src(buttonAdd, LV_BTN_STATE_REL, "F:/bmp_Add.bin");
-  lv_imgbtn_set_src(buttonAdd, LV_BTN_STATE_PR, "F:/bmp_Add.bin");
-  lv_imgbtn_set_style(buttonAdd, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonAdd, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonAdd, "F:/bmp_Add.bin");
+  lv_imgbtn_use_label_style(buttonAdd);
   lv_obj_clear_protect(buttonAdd, LV_PROTECT_FOLLOW);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonDec, event_handler, ID_F_DEC, NULL, 0);
-    lv_imgbtn_set_src(buttonDec, LV_BTN_STATE_REL, "F:/bmp_Dec.bin");
-    lv_imgbtn_set_src(buttonDec, LV_BTN_STATE_PR, "F:/bmp_Dec.bin");
-    lv_imgbtn_set_style(buttonDec, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonDec, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonDec, "F:/bmp_Dec.bin");
+    lv_imgbtn_use_label_style(buttonDec);
 
-    lv_obj_set_event_cb_mks(buttonHigh, event_handler,ID_F_HIGH, NULL,0);
-    lv_imgbtn_set_src(buttonHigh, LV_BTN_STATE_REL, "F:/bmp_speed255.bin");
-    lv_imgbtn_set_src(buttonHigh, LV_BTN_STATE_PR, "F:/bmp_speed255.bin");
-    lv_imgbtn_set_style(buttonHigh, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonHigh, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonHigh, event_handler,ID_F_HIGH, NULL, 0);
+    lv_imgbtn_set_src_both(buttonHigh, "F:/bmp_speed255.bin");
+    lv_imgbtn_use_label_style(buttonHigh);
 
-    lv_obj_set_event_cb_mks(buttonMid, event_handler,ID_F_MID, NULL,0);
-    lv_imgbtn_set_src(buttonMid, LV_BTN_STATE_REL, "F:/bmp_speed127.bin");
-    lv_imgbtn_set_src(buttonMid, LV_BTN_STATE_PR, "F:/bmp_speed127.bin");
-    lv_imgbtn_set_style(buttonMid, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonMid, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonMid, event_handler,ID_F_MID, NULL, 0);
+    lv_imgbtn_set_src_both(buttonMid, "F:/bmp_speed127.bin");
+    lv_imgbtn_use_label_style(buttonMid);
 
-    lv_obj_set_event_cb_mks(buttonOff, event_handler,ID_F_OFF, NULL,0);
-    lv_imgbtn_set_src(buttonOff, LV_BTN_STATE_REL, "F:/bmp_speed0.bin");
-    lv_imgbtn_set_src(buttonOff, LV_BTN_STATE_PR, "F:/bmp_speed0.bin");
-    lv_imgbtn_set_style(buttonOff, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonOff, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonOff, event_handler,ID_F_OFF, NULL, 0);
+    lv_imgbtn_set_src_both(buttonOff, "F:/bmp_speed0.bin");
+    lv_imgbtn_use_label_style(buttonOff);
 
-    lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_F_RETURN, NULL,0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_F_RETURN, NULL, 0);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
 
   #endif
 
@@ -239,8 +224,7 @@ void lv_draw_fan(void) {
     }
   #endif
 
-  fanText = lv_label_create(scr, NULL);
-  lv_obj_set_style(fanText, &tft_style_label_rel);
+  fanText = lv_label_create(scr);
   disp_fan_value();
 }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_filament_change.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_filament_change.cpp
@@ -32,11 +32,11 @@
 #include "../../../../module/planner.h"
 #include "../../../../inc/MarlinConfig.h"
 
-extern lv_group_t * g;
-static lv_obj_t * scr;
-static lv_obj_t *buttoType;
+extern lv_group_t *g;
+static lv_obj_t *scr;
+static lv_obj_t *buttonType;
 static lv_obj_t *labelType;
-static lv_obj_t * tempText1;
+static lv_obj_t *tempText1;
 
 #define ID_FILAMNT_IN     1
 #define ID_FILAMNT_OUT    2
@@ -149,42 +149,18 @@ void lv_draw_filament_change(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonIn   = lv_imgbtn_create(scr, NULL);
-  buttonOut  = lv_imgbtn_create(scr, NULL);
-  buttoType  = lv_imgbtn_create(scr, NULL);
-  buttonBack = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonIn, event_handler, ID_FILAMNT_IN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonIn, "F:/bmp_in.bin");
-  lv_imgbtn_use_label_style(buttonIn);
+  buttonIn = lv_imgbtn_create(scr, "F:/bmp_in.bin", INTERVAL_V, titleHeight, event_handler, ID_FILAMNT_IN);
   lv_obj_clear_protect(buttonIn, LV_PROTECT_FOLLOW);
 
-  lv_obj_set_event_cb_mks(buttonOut, event_handler, ID_FILAMNT_OUT, NULL, 0);
-  lv_imgbtn_set_src_both(buttonOut, "F:/bmp_out.bin");
-  lv_imgbtn_use_label_style(buttonOut);
-
-  lv_obj_set_event_cb_mks(buttoType, event_handler, ID_FILAMNT_TYPE, NULL, 0);
-  lv_imgbtn_use_label_style(buttoType);
-
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_FILAMNT_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-
-  lv_obj_set_pos(buttonIn, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonOut, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttoType, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonOut = lv_imgbtn_create(scr, "F:/bmp_out.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_FILAMNT_OUT);
+  buttonType = lv_imgbtn_create(scr, NULL, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_FILAMNT_TYPE);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_FILAMNT_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonIn, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonOut, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttoType, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelIn  = lv_label_create(buttonIn, NULL);
-  lv_obj_t *labelOut = lv_label_create(buttonOut, NULL);
-  labelType = lv_label_create(buttoType, NULL);
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelIn  = lv_label_create_empty(buttonIn);
+  lv_obj_t *labelOut = lv_label_create_empty(buttonOut);
+  labelType = lv_label_create_empty(buttonType);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelIn, filament_menu.in);
@@ -201,30 +177,31 @@ void lv_draw_filament_change(void) {
     if (gCfgItems.encoder_enable) {
       lv_group_add_obj(g, buttonIn);
       lv_group_add_obj(g, buttonOut);
-      lv_group_add_obj(g, buttoType);
+      lv_group_add_obj(g, buttonType);
       lv_group_add_obj(g, buttonBack);
     }
   #endif
 
   disp_filament_type();
 
-  tempText1 = lv_label_create(scr);
+  tempText1 = lv_label_create_empty(scr);
+  lv_obj_set_style(tempText1, &tft_style_label_rel);
   disp_filament_temp();
 }
 
 void disp_filament_type() {
   if (uiCfg.curSprayerChoose == 1) {
-    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru2.bin");
+    lv_imgbtn_set_src_both(buttonType, "F:/bmp_extru2.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, preheat_menu.ext2);
-      lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
+      lv_obj_align(labelType, buttonType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
   }
   else {
-    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru1.bin");
+    lv_imgbtn_set_src_both(buttonType, "F:/bmp_extru1.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, preheat_menu.ext1);
-      lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
+      lv_obj_align(labelType, buttonType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
   }
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_filament_change.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_filament_change.cpp
@@ -144,10 +144,7 @@ void lv_draw_filament_change(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -158,27 +155,20 @@ void lv_draw_filament_change(void) {
   buttonBack = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonIn, event_handler, ID_FILAMNT_IN, NULL, 0);
-  lv_imgbtn_set_src(buttonIn, LV_BTN_STATE_REL, "F:/bmp_in.bin");
-  lv_imgbtn_set_src(buttonIn, LV_BTN_STATE_PR, "F:/bmp_in.bin");
-  lv_imgbtn_set_style(buttonIn, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonIn, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonIn, "F:/bmp_in.bin");
+  lv_imgbtn_use_label_style(buttonIn);
   lv_obj_clear_protect(buttonIn, LV_PROTECT_FOLLOW);
 
   lv_obj_set_event_cb_mks(buttonOut, event_handler, ID_FILAMNT_OUT, NULL, 0);
-  lv_imgbtn_set_src(buttonOut, LV_BTN_STATE_REL, "F:/bmp_out.bin");
-  lv_imgbtn_set_src(buttonOut, LV_BTN_STATE_PR, "F:/bmp_out.bin");
-  lv_imgbtn_set_style(buttonOut, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonOut, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonOut, "F:/bmp_out.bin");
+  lv_imgbtn_use_label_style(buttonOut);
 
   lv_obj_set_event_cb_mks(buttoType, event_handler, ID_FILAMNT_TYPE, NULL, 0);
-  lv_imgbtn_set_style(buttoType, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttoType, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_use_label_style(buttoType);
 
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_FILAMNT_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
   lv_obj_set_pos(buttonIn, INTERVAL_V, titleHeight);
   lv_obj_set_pos(buttonOut, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
@@ -218,23 +208,20 @@ void lv_draw_filament_change(void) {
 
   disp_filament_type();
 
-  tempText1 = lv_label_create(scr, NULL);
-  lv_obj_set_style(tempText1, &tft_style_label_rel);
+  tempText1 = lv_label_create(scr);
   disp_filament_temp();
 }
 
 void disp_filament_type() {
   if (uiCfg.curSprayerChoose == 1) {
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_REL, "F:/bmp_extru2.bin");
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_PR, "F:/bmp_extru2.bin");
+    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru2.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, preheat_menu.ext2);
       lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
   }
   else {
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_REL, "F:/bmp_extru1.bin");
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_PR, "F:/bmp_extru1.bin");
+    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru1.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, preheat_menu.ext1);
       lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_filament_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_filament_settings.cpp
@@ -127,12 +127,12 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_filament_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL, *buttonTurnPage = NULL, *labelTurnPage = NULL;
-  lv_obj_t *labelInLengthText = NULL, *buttonInLengthValue = NULL, *labelInLengthValue = NULL;
-  lv_obj_t *labelInSpeedText = NULL, *buttonInSpeedValue = NULL, *labelInSpeedValue = NULL;
-  lv_obj_t *labelOutLengthText = NULL, *buttonOutLengthValue = NULL, *labelOutLengthValue = NULL;
-  lv_obj_t *labelOutSpeedText = NULL, *buttonOutSpeedValue = NULL, *labelOutSpeedValue = NULL;
-  lv_obj_t *labelTemperText = NULL, *buttonTemperValue = NULL, *labelTemperValue = NULL;
-  lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL, * line4 = NULL;
+  lv_obj_t *buttonInLengthValue = NULL, *labelInLengthValue = NULL;
+  lv_obj_t *buttonInSpeedValue = NULL, *labelInSpeedValue = NULL;
+  lv_obj_t *buttonOutLengthValue = NULL, *labelOutLengthValue = NULL;
+  lv_obj_t *buttonOutSpeedValue = NULL, *labelOutSpeedValue = NULL;
+  lv_obj_t *buttonTemperValue = NULL, *labelTemperValue = NULL;
+  lv_obj_t *line1 = NULL, *line2 = NULL, *line3 = NULL, *line4 = NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != FILAMENT_SETTINGS_UI) {
     disp_state_stack._disp_index++;
     disp_state_stack._disp_state[disp_state_stack._disp_index] = FILAMENT_SETTINGS_UI;
@@ -150,57 +150,39 @@ void lv_draw_filament_settings(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   if (uiCfg.para_ui_page != 1) {
-    labelInLengthText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.InLength);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.InLength);
 
-    buttonInLengthValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonInLengthValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonInLengthValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonInLengthValue, event_handler, ID_FILAMENT_SET_IN_LENGTH, NULL, 0);
-    lv_btn_set_style_both(buttonInLengthValue, &style_para_value);
-    labelInLengthValue = lv_label_create(buttonInLengthValue, NULL);
+    buttonInLengthValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FILAMENT_SET_IN_LENGTH);
+    labelInLengthValue = lv_label_create_empty(buttonInLengthValue);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    labelInSpeedText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.InSpeed);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.InSpeed);
 
-    buttonInSpeedValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonInSpeedValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonInSpeedValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonInSpeedValue, event_handler, ID_FILAMENT_SET_IN_SPEED, NULL, 0);
-    lv_btn_set_style_both(buttonInSpeedValue, &style_para_value);
-    labelInSpeedValue = lv_label_create(buttonInSpeedValue, NULL);
+    buttonInSpeedValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FILAMENT_SET_IN_SPEED);
+    labelInSpeedValue = lv_label_create_empty(buttonInSpeedValue);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    labelOutLengthText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 6, machine_menu.OutLength);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 6, machine_menu.OutLength);
 
-    buttonOutLengthValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonOutLengthValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonOutLengthValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonOutLengthValue, event_handler, ID_FILAMENT_SET_OUT_LENGTH, NULL, 0);
-    lv_btn_set_style_both(buttonOutLengthValue, &style_para_value);
-    labelOutLengthValue = lv_label_create(buttonOutLengthValue, NULL);
+    buttonOutLengthValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FILAMENT_SET_OUT_LENGTH);
+    labelOutLengthValue = lv_label_create_empty(buttonOutLengthValue);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    labelOutSpeedText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.OutSpeed);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.OutSpeed);
 
-    buttonOutSpeedValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonOutSpeedValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonOutSpeedValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonOutSpeedValue, event_handler, ID_FILAMENT_SET_OUT_SPEED, NULL, 0);
-    lv_btn_set_style_both(buttonOutSpeedValue, &style_para_value);
-    labelOutSpeedValue = lv_label_create(buttonOutSpeedValue, NULL);
+    buttonOutSpeedValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FILAMENT_SET_OUT_SPEED);
+    labelOutSpeedValue = lv_label_create_empty(buttonOutSpeedValue);
 
     line4 = lv_line_create(scr, NULL);
     lv_ex_line(line4, line_points[3]);
 
-    buttonTurnPage = lv_btn_create(scr, NULL);
-    lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_FILAMENT_SET_DOWN, NULL, 0);
-    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
+    buttonTurnPage = lv_btn_create_back(scr, event_handler, ID_FILAMENT_SET_DOWN);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -213,21 +195,15 @@ void lv_draw_filament_settings(void) {
     #endif
   }
   else {
-    labelTemperText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.FilamentTemperature);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.FilamentTemperature);
 
-    buttonTemperValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonTemperValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonTemperValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonTemperValue, event_handler, ID_FILAMENT_SET_TEMP, NULL, 0);
-    lv_btn_set_style_both(buttonTemperValue, &style_para_value);
-    labelTemperValue = lv_label_create(buttonTemperValue, NULL);
+    buttonTemperValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FILAMENT_SET_TEMP);
+    labelTemperValue = lv_label_create_empty(buttonTemperValue);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    buttonTurnPage = lv_btn_create(scr, NULL);
-    lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_FILAMENT_SET_UP, NULL, 0);
-    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
+    buttonTurnPage = lv_btn_create_back(scr, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE, event_handler, ID_FILAMENT_SET_UP);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -237,16 +213,10 @@ void lv_draw_filament_settings(void) {
     #endif
   }
 
-  lv_obj_set_pos(buttonTurnPage, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
-  lv_obj_set_size(buttonTurnPage, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  labelTurnPage = lv_label_create(buttonTurnPage, NULL);
+  labelTurnPage = lv_label_create_empty(buttonTurnPage);
 
-  buttonBack = lv_btn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_FILAMENT_SET_RETURN, NULL, 0);
-  lv_btn_set_style_both(buttonBack, &style_para_back);
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_btn_create_back(scr, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE, event_handler, ID_FILAMENT_SET_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_filament_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_filament_settings.cpp
@@ -145,73 +145,54 @@ void lv_draw_filament_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.FilamentConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.FilamentConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   if (uiCfg.para_ui_page != 1) {
-    labelInLengthText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelInLengthText, &tft_style_label_rel);
-    lv_obj_set_pos(labelInLengthText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelInLengthText, machine_menu.InLength);
+    labelInLengthText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.InLength);
 
     buttonInLengthValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonInLengthValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonInLengthValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonInLengthValue, event_handler, ID_FILAMENT_SET_IN_LENGTH, NULL, 0);
-    lv_btn_set_style(buttonInLengthValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonInLengthValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonInLengthValue, &style_para_value);
     labelInLengthValue = lv_label_create(buttonInLengthValue, NULL);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    labelInSpeedText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelInSpeedText, &tft_style_label_rel);
-    lv_obj_set_pos(labelInSpeedText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-    lv_label_set_text(labelInSpeedText, machine_menu.InSpeed);
+    labelInSpeedText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.InSpeed);
 
     buttonInSpeedValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonInSpeedValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonInSpeedValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonInSpeedValue, event_handler, ID_FILAMENT_SET_IN_SPEED, NULL, 0);
-    lv_btn_set_style(buttonInSpeedValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonInSpeedValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonInSpeedValue, &style_para_value);
     labelInSpeedValue = lv_label_create(buttonInSpeedValue, NULL);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    labelOutLengthText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelOutLengthText, &tft_style_label_rel);
-    lv_obj_set_pos(labelOutLengthText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 6);
-    lv_label_set_text(labelOutLengthText, machine_menu.OutLength);
+    labelOutLengthText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 6, machine_menu.OutLength);
 
     buttonOutLengthValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonOutLengthValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonOutLengthValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonOutLengthValue, event_handler, ID_FILAMENT_SET_OUT_LENGTH, NULL, 0);
-    lv_btn_set_style(buttonOutLengthValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonOutLengthValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonOutLengthValue, &style_para_value);
     labelOutLengthValue = lv_label_create(buttonOutLengthValue, NULL);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    labelOutSpeedText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelOutSpeedText, &tft_style_label_rel);
-    lv_obj_set_pos(labelOutSpeedText, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-    lv_label_set_text(labelOutSpeedText, machine_menu.OutSpeed);
+    labelOutSpeedText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.OutSpeed);
 
     buttonOutSpeedValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonOutSpeedValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonOutSpeedValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonOutSpeedValue, event_handler, ID_FILAMENT_SET_OUT_SPEED, NULL, 0);
-    lv_btn_set_style(buttonOutSpeedValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonOutSpeedValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonOutSpeedValue, &style_para_value);
     labelOutSpeedValue = lv_label_create(buttonOutSpeedValue, NULL);
 
     line4 = lv_line_create(scr, NULL);
@@ -219,8 +200,7 @@ void lv_draw_filament_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_FILAMENT_SET_DOWN, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -233,17 +213,13 @@ void lv_draw_filament_settings(void) {
     #endif
   }
   else {
-    labelTemperText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelTemperText, &tft_style_label_rel);
-    lv_obj_set_pos(labelTemperText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelTemperText, machine_menu.FilamentTemperature);
+    labelTemperText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.FilamentTemperature);
 
     buttonTemperValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonTemperValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonTemperValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonTemperValue, event_handler, ID_FILAMENT_SET_TEMP, NULL, 0);
-    lv_btn_set_style(buttonTemperValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonTemperValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonTemperValue, &style_para_value);
     labelTemperValue = lv_label_create(buttonTemperValue, NULL);
 
     line1 = lv_line_create(scr, NULL);
@@ -251,8 +227,7 @@ void lv_draw_filament_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_FILAMENT_SET_UP, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -268,8 +243,7 @@ void lv_draw_filament_settings(void) {
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_FILAMENT_SET_RETURN, NULL, 0);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   label_Back = lv_label_create(buttonBack, NULL);
@@ -280,22 +254,18 @@ void lv_draw_filament_settings(void) {
 
   if (gCfgItems.multiple_language) {
     if (uiCfg.para_ui_page != 1) {
-      ZERO(public_buf_l);
       sprintf_P(public_buf_l, PSTR("%d"), gCfgItems.filamentchange_load_length);
       lv_label_set_text(labelInLengthValue, public_buf_l);
       lv_obj_align(labelInLengthValue, buttonInLengthValue, LV_ALIGN_CENTER, 0, 0);
 
-      ZERO(public_buf_l);
       sprintf_P(public_buf_l, PSTR("%d"), gCfgItems.filamentchange_load_speed);
       lv_label_set_text(labelInSpeedValue, public_buf_l);
       lv_obj_align(labelInSpeedValue, buttonInSpeedValue, LV_ALIGN_CENTER, 0, 0);
 
-      ZERO(public_buf_l);
       sprintf_P(public_buf_l, PSTR("%d"), gCfgItems.filamentchange_unload_length);
       lv_label_set_text(labelOutLengthValue, public_buf_l);
       lv_obj_align(labelOutLengthValue, buttonOutLengthValue, LV_ALIGN_CENTER, 0, 0);
 
-      ZERO(public_buf_l);
       sprintf_P(public_buf_l, PSTR("%d"), gCfgItems.filamentchange_unload_speed);
       lv_label_set_text(labelOutSpeedValue, public_buf_l);
       lv_obj_align(labelOutSpeedValue, buttonOutSpeedValue, LV_ALIGN_CENTER, 0, 0);
@@ -304,7 +274,6 @@ void lv_draw_filament_settings(void) {
       lv_obj_align(labelTurnPage, buttonTurnPage, LV_ALIGN_CENTER, 0, 0);
     }
     else {
-      ZERO(public_buf_l);
       sprintf_P(public_buf_l, PSTR("%d"), gCfgItems.filament_limit_temper);
       lv_label_set_text(labelTemperValue, public_buf_l);
       lv_obj_align(labelTemperValue, buttonTemperValue, LV_ALIGN_CENTER, 0, 0);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
@@ -126,69 +126,23 @@ void lv_draw_home(void) {
 
   // Create image buttons
   //buttonWifi     = lv_imgbtn_create(scr, NULL);
-  buttonHomeAll    = lv_imgbtn_create(scr, NULL);
-  buttonHomeX      = lv_imgbtn_create(scr, NULL);
   //buttonContinue = lv_imgbtn_create(scr, NULL);
-  buttonHomeY      = lv_imgbtn_create(scr, NULL);
-  buttonHomeZ      = lv_imgbtn_create(scr, NULL);
-  buttonOffAll     = lv_imgbtn_create(scr, NULL);
-  buttonOffXY      = lv_imgbtn_create(scr, NULL);
-  buttonBack       = lv_imgbtn_create(scr, NULL);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonHomeAll, event_handler,ID_H_ALL, NULL, 0);
-    lv_imgbtn_set_src_both(buttonHomeAll, "F:/bmp_zeroAll.bin");
-    lv_imgbtn_use_label_style(buttonHomeAll);
-
-    lv_obj_set_event_cb_mks(buttonHomeX, event_handler, ID_H_X, NULL, 0);
-    lv_imgbtn_set_src_both(buttonHomeX, "F:/bmp_zeroX.bin");
-    lv_imgbtn_use_label_style(buttonHomeX);
-
-    lv_obj_set_event_cb_mks(buttonHomeY, event_handler, ID_H_Y, NULL, 0);
-    lv_imgbtn_set_src_both(buttonHomeY, "F:/bmp_zeroY.bin");
-    lv_imgbtn_use_label_style(buttonHomeY);
-
-    lv_obj_set_event_cb_mks(buttonHomeZ, event_handler, ID_H_Z, NULL, 0);
-    lv_imgbtn_set_src_both(buttonHomeZ, "F:/bmp_zeroZ.bin");
-    lv_imgbtn_use_label_style(buttonHomeZ);
-
-    lv_obj_set_event_cb_mks(buttonOffAll, event_handler,ID_H_OFF_ALL, NULL, 0);
-    lv_imgbtn_set_src_both(buttonOffAll, "F:/bmp_function1.bin");
-    lv_imgbtn_use_label_style(buttonOffAll);
-
-    lv_obj_set_event_cb_mks(buttonOffXY, event_handler,ID_H_OFF_XY, NULL, 0);
-    lv_imgbtn_set_src_both(buttonOffXY, "F:/bmp_function1.bin");
-    lv_imgbtn_use_label_style(buttonOffXY);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_H_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-  #endif
-
-  lv_obj_set_pos(buttonHomeAll, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonHomeX, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
-  lv_obj_set_pos(buttonHomeY, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
-  lv_obj_set_pos(buttonHomeZ, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonOffAll, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonOffXY, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonHomeAll = lv_imgbtn_create(scr, "F:/bmp_zeroAll.bin", INTERVAL_V, titleHeight, event_handler, ID_H_ALL);
+  buttonHomeX   = lv_imgbtn_create(scr, "F:/bmp_zeroX.bin", BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_H_X);
+  buttonHomeY   = lv_imgbtn_create(scr, "F:/bmp_zeroY.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_H_Y);
+  buttonHomeZ   = lv_imgbtn_create(scr, "F:/bmp_zeroZ.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_H_Z);
+  buttonOffAll  = lv_imgbtn_create(scr, "F:/bmp_function1.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_H_OFF_ALL);
+  buttonOffXY   = lv_imgbtn_create(scr, "F:/bmp_function1.bin", BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_H_OFF_XY);
+  buttonBack    = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_H_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonHomeAll, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonHomeX, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonHomeY, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonHomeZ, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonOffAll, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonOffXY, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelHomeAll = lv_label_create(buttonHomeAll, NULL);
-  lv_obj_t *labelHomeX = lv_label_create(buttonHomeX, NULL);
-  lv_obj_t *labelHomeY = lv_label_create(buttonHomeY, NULL);
-  lv_obj_t *labelHomeZ = lv_label_create(buttonHomeZ, NULL);
-  lv_obj_t *labelOffAll = lv_label_create(buttonOffAll, NULL);
-  lv_obj_t *labelOffXY = lv_label_create(buttonOffXY, NULL);
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelHomeAll = lv_label_create_empty(buttonHomeAll);
+  lv_obj_t *labelHomeX = lv_label_create_empty(buttonHomeX);
+  lv_obj_t *labelHomeY = lv_label_create_empty(buttonHomeY);
+  lv_obj_t *labelHomeZ = lv_label_create_empty(buttonHomeZ);
+  lv_obj_t *labelOffAll = lv_label_create_empty(buttonOffAll);
+  lv_obj_t *labelOffXY = lv_label_create_empty(buttonOffXY);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelHomeAll, home_menu.home_all);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
@@ -120,10 +120,7 @@ void lv_draw_home(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -139,47 +136,33 @@ void lv_draw_home(void) {
   buttonBack       = lv_imgbtn_create(scr, NULL);
 
   #if 1
-    lv_obj_set_event_cb_mks(buttonHomeAll, event_handler,ID_H_ALL, NULL,0);
-    lv_imgbtn_set_src(buttonHomeAll, LV_BTN_STATE_REL, "F:/bmp_zeroAll.bin");
-    lv_imgbtn_set_src(buttonHomeAll, LV_BTN_STATE_PR, "F:/bmp_zeroAll.bin");
-    lv_imgbtn_set_style(buttonHomeAll, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonHomeAll, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonHomeAll, event_handler,ID_H_ALL, NULL, 0);
+    lv_imgbtn_set_src_both(buttonHomeAll, "F:/bmp_zeroAll.bin");
+    lv_imgbtn_use_label_style(buttonHomeAll);
 
     lv_obj_set_event_cb_mks(buttonHomeX, event_handler, ID_H_X, NULL, 0);
-    lv_imgbtn_set_src(buttonHomeX, LV_BTN_STATE_REL, "F:/bmp_zeroX.bin");
-    lv_imgbtn_set_src(buttonHomeX, LV_BTN_STATE_PR, "F:/bmp_zeroX.bin");
-    lv_imgbtn_set_style(buttonHomeX, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonHomeX, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonHomeX, "F:/bmp_zeroX.bin");
+    lv_imgbtn_use_label_style(buttonHomeX);
 
     lv_obj_set_event_cb_mks(buttonHomeY, event_handler, ID_H_Y, NULL, 0);
-    lv_imgbtn_set_src(buttonHomeY, LV_BTN_STATE_REL, "F:/bmp_zeroY.bin");
-    lv_imgbtn_set_src(buttonHomeY, LV_BTN_STATE_PR, "F:/bmp_zeroY.bin");
-    lv_imgbtn_set_style(buttonHomeY, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonHomeY, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonHomeY, "F:/bmp_zeroY.bin");
+    lv_imgbtn_use_label_style(buttonHomeY);
 
     lv_obj_set_event_cb_mks(buttonHomeZ, event_handler, ID_H_Z, NULL, 0);
-    lv_imgbtn_set_src(buttonHomeZ, LV_BTN_STATE_REL, "F:/bmp_zeroZ.bin");
-    lv_imgbtn_set_src(buttonHomeZ, LV_BTN_STATE_PR, "F:/bmp_zeroZ.bin");
-    lv_imgbtn_set_style(buttonHomeZ, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonHomeZ, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonHomeZ, "F:/bmp_zeroZ.bin");
+    lv_imgbtn_use_label_style(buttonHomeZ);
 
-    lv_obj_set_event_cb_mks(buttonOffAll, event_handler,ID_H_OFF_ALL, NULL,0);
-    lv_imgbtn_set_src(buttonOffAll, LV_BTN_STATE_REL, "F:/bmp_function1.bin");
-    lv_imgbtn_set_src(buttonOffAll, LV_BTN_STATE_PR, "F:/bmp_function1.bin");
-    lv_imgbtn_set_style(buttonOffAll, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonOffAll, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonOffAll, event_handler,ID_H_OFF_ALL, NULL, 0);
+    lv_imgbtn_set_src_both(buttonOffAll, "F:/bmp_function1.bin");
+    lv_imgbtn_use_label_style(buttonOffAll);
 
-    lv_obj_set_event_cb_mks(buttonOffXY, event_handler,ID_H_OFF_XY, NULL,0);
-    lv_imgbtn_set_src(buttonOffXY, LV_BTN_STATE_REL, "F:/bmp_function1.bin");
-    lv_imgbtn_set_src(buttonOffXY, LV_BTN_STATE_PR, "F:/bmp_function1.bin");
-    lv_imgbtn_set_style(buttonOffXY, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonOffXY, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonOffXY, event_handler,ID_H_OFF_XY, NULL, 0);
+    lv_imgbtn_set_src_both(buttonOffXY, "F:/bmp_function1.bin");
+    lv_imgbtn_use_label_style(buttonOffXY);
 
-    lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_H_RETURN, NULL,0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_H_RETURN, NULL, 0);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
   #endif
 
   lv_obj_set_pos(buttonHomeAll, INTERVAL_V, titleHeight);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_homing_sensitivity_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_homing_sensitivity_settings.cpp
@@ -124,12 +124,8 @@ void lv_draw_homing_sensitivity_settings(void) {
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.X_Sensitivity);
 
-  buttonXValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
-  lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_SENSITIVITY_X, NULL, 0);
-  lv_btn_set_style_both(buttonXValue, &style_para_value);
-  labelXValue = lv_label_create(buttonXValue, NULL);
+  buttonXValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_SENSITIVITY_X);
+  labelXValue = lv_label_create_empty(buttonXValue);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonXValue);
@@ -140,12 +136,8 @@ void lv_draw_homing_sensitivity_settings(void) {
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Y_Sensitivity);
 
-  buttonYValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
-  lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_SENSITIVITY_Y, NULL, 0);
-  lv_btn_set_style_both(buttonYValue, &style_para_value);
-  labelYValue = lv_label_create(buttonYValue, NULL);
+  buttonYValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_SENSITIVITY_Y);
+  labelYValue = lv_label_create_empty(buttonYValue);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonYValue);
@@ -156,12 +148,8 @@ void lv_draw_homing_sensitivity_settings(void) {
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Z_Sensitivity);
 
-  buttonZValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
-  lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_SENSITIVITY_Z, NULL, 0);
-  lv_btn_set_style_both(buttonZValue, &style_para_value);
-  labelZValue = lv_label_create(buttonZValue, NULL);
+  buttonZValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_SENSITIVITY_Z);
+  labelZValue = lv_label_create_empty(buttonZValue);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable == true) lv_group_add_obj(g, buttonZValue);
@@ -173,12 +161,8 @@ void lv_draw_homing_sensitivity_settings(void) {
   #if Z2_SENSORLESS
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.Z2_Sensitivity);
 
-    buttonZ2Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonZ2Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonZ2Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonZ2Value, event_handler, ID_SENSITIVITY_Z2, NULL, 0);
-    lv_btn_set_style_both(buttonZ2Value, &style_para_value);
-    labelZ2Value = lv_label_create(buttonZ2Value, NULL);
+    buttonZ2Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_SENSITIVITY_Z2);
+    labelZ2Value = lv_label_create_empty(buttonZ2Value);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonZ2Value);
@@ -188,12 +172,8 @@ void lv_draw_homing_sensitivity_settings(void) {
     lv_ex_line(line4, line_points[3]);
   #endif
 
-  buttonBack = lv_btn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_SENSITIVITY_RETURN, NULL, 0);
-  lv_btn_set_style_both(buttonBack, &style_para_back);
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_btn_create_back(scr, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE, event_handler, ID_SENSITIVITY_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_homing_sensitivity_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_homing_sensitivity_settings.cpp
@@ -98,13 +98,13 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_homing_sensitivity_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL;
-  lv_obj_t *labelXText = NULL, *buttonXValue = NULL, *labelXValue = NULL;
-  lv_obj_t *labelYText = NULL, *buttonYValue = NULL, *labelYValue = NULL;
-  lv_obj_t *labelZText = NULL, *buttonZValue = NULL, *labelZValue = NULL;
+  lv_obj_t *buttonXValue = NULL, *labelXValue = NULL;
+  lv_obj_t *buttonYValue = NULL, *labelYValue = NULL;
+  lv_obj_t *buttonZValue = NULL, *labelZValue = NULL;
   lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL;
   #if Z2_SENSORLESS
-    lv_obj_t *labelZ2Text = NULL, *buttonZ2Value = NULL, *labelZ2Value = NULL;
-    lv_obj_t * line4 = NULL;
+    lv_obj_t *buttonZ2Value = NULL, *labelZ2Value = NULL;
+    lv_obj_t *line4 = NULL;
   #endif
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != HOMING_SENSITIVITY_UI) {
     disp_state_stack._disp_index++;
@@ -118,24 +118,17 @@ void lv_draw_homing_sensitivity_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.HomingSensitivityConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.HomingSensitivityConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  labelXText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelXText, &tft_style_label_rel);
-  lv_obj_set_pos(labelXText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-  lv_label_set_text(labelXText, machine_menu.X_Sensitivity);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.X_Sensitivity);
 
   buttonXValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
   lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_SENSITIVITY_X, NULL, 0);
-  lv_btn_set_style(buttonXValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonXValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonXValue, &style_para_value);
   labelXValue = lv_label_create(buttonXValue, NULL);
 
   #if HAS_ROTARY_ENCODER
@@ -145,17 +138,13 @@ void lv_draw_homing_sensitivity_settings(void) {
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
-  labelYText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelYText, &tft_style_label_rel);
-  lv_obj_set_pos(labelYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-  lv_label_set_text(labelYText, machine_menu.Y_Sensitivity);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Y_Sensitivity);
 
   buttonYValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
   lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_SENSITIVITY_Y, NULL, 0);
-  lv_btn_set_style(buttonYValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonYValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonYValue, &style_para_value);
   labelYValue = lv_label_create(buttonYValue, NULL);
 
   #if HAS_ROTARY_ENCODER
@@ -165,17 +154,13 @@ void lv_draw_homing_sensitivity_settings(void) {
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
-  labelZText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelZText, &tft_style_label_rel);
-  lv_obj_set_pos(labelZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-  lv_label_set_text(labelZText, machine_menu.Z_Sensitivity);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Z_Sensitivity);
 
   buttonZValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
   lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_SENSITIVITY_Z, NULL, 0);
-  lv_btn_set_style(buttonZValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonZValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonZValue, &style_para_value);
   labelZValue = lv_label_create(buttonZValue, NULL);
 
   #if HAS_ROTARY_ENCODER
@@ -186,17 +171,13 @@ void lv_draw_homing_sensitivity_settings(void) {
   lv_ex_line(line3, line_points[2]);
 
   #if Z2_SENSORLESS
-    labelZ2Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelZ2Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelZ2Text, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-    lv_label_set_text(labelZ2Text, machine_menu.Z2_Sensitivity);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.Z2_Sensitivity);
 
     buttonZ2Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonZ2Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonZ2Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonZ2Value, event_handler, ID_SENSITIVITY_Z2, NULL, 0);
-    lv_btn_set_style(buttonZ2Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonZ2Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonZ2Value, &style_para_value);
     labelZ2Value = lv_label_create(buttonZ2Value, NULL);
 
     #if HAS_ROTARY_ENCODER
@@ -209,8 +190,7 @@ void lv_draw_homing_sensitivity_settings(void) {
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_SENSITIVITY_RETURN, NULL, 0);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   label_Back = lv_label_create(buttonBack, NULL);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_jerk_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_jerk_settings.cpp
@@ -117,59 +117,38 @@ void lv_draw_jerk_settings(void) {
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.X_Jerk);
 
-  buttonXValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_JERK_X, NULL, 0);
-  lv_btn_set_style_both(buttonXValue, &style_para_value);
-  labelXValue = lv_label_create(buttonXValue, NULL);
+  buttonXValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_JERK_X);
+  labelXValue = lv_label_create_empty(buttonXValue);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Y_Jerk);
 
-  buttonYValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_JERK_Y, NULL, 0);
-  lv_btn_set_style_both(buttonYValue, &style_para_value);
-  labelYValue = lv_label_create(buttonYValue, NULL);
+  buttonYValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_JERK_Y);
+  labelYValue = lv_label_create_empty(buttonYValue);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Z_Jerk);
 
-  buttonZValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_JERK_Z, NULL, 0);
-  lv_btn_set_style_both(buttonZValue, &style_para_value);
-  labelZValue = lv_label_create(buttonZValue, NULL);
+  buttonZValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_JERK_Z);
+  labelZValue = lv_label_create_empty(buttonZValue);
 
   line3 = lv_line_create(scr, NULL);
   lv_ex_line(line3, line_points[2]);
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E_Jerk);
 
-  buttonEValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonEValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonEValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonEValue, event_handler, ID_JERK_E, NULL, 0);
-  lv_btn_set_style_both(buttonEValue, &style_para_value);
-  labelEValue = lv_label_create(buttonEValue, NULL);
+  buttonEValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_JERK_E);
+  labelEValue = lv_label_create_empty(buttonEValue);
 
   line4 = lv_line_create(scr, NULL);
   lv_ex_line(line4, line_points[3]);
 
-  buttonBack = lv_btn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_JERK_RETURN, NULL, 0);
-  lv_btn_set_style_both(buttonBack, &style_para_back);
-
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_btn_create_back(scr, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE, event_handler, ID_JERK_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable == true) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_jerk_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_jerk_settings.cpp
@@ -94,11 +94,11 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_jerk_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL;
-  lv_obj_t *labelXText = NULL, *buttonXValue = NULL, *labelXValue = NULL;
-  lv_obj_t *labelYText = NULL, *buttonYValue = NULL, *labelYValue = NULL;
-  lv_obj_t *labelZText = NULL, *buttonZValue = NULL, *labelZValue = NULL;
-  lv_obj_t *labelEText = NULL, *buttonEValue = NULL, *labelEValue = NULL;
-  lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL, * line4 = NULL;
+  lv_obj_t *buttonXValue = NULL, *labelXValue = NULL;
+  lv_obj_t *buttonYValue = NULL, *labelYValue = NULL;
+  lv_obj_t *buttonZValue = NULL, *labelZValue = NULL;
+  lv_obj_t *buttonEValue = NULL, *labelEValue = NULL;
+  lv_obj_t *line1 = NULL, *line2 = NULL, *line3 = NULL, *line4 = NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != JERK_UI) {
     disp_state_stack._disp_index++;
     disp_state_stack._disp_state[disp_state_stack._disp_index] = JERK_UI;
@@ -111,72 +111,53 @@ void lv_draw_jerk_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.JerkConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.JerkConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  labelXText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelXText, &tft_style_label_rel);
-  lv_obj_set_pos(labelXText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-  lv_label_set_text(labelXText, machine_menu.X_Jerk);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.X_Jerk);
 
   buttonXValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_JERK_X, NULL, 0);
-  lv_btn_set_style(buttonXValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonXValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonXValue, &style_para_value);
   labelXValue = lv_label_create(buttonXValue, NULL);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
-  labelYText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelYText, &tft_style_label_rel);
-  lv_obj_set_pos(labelYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-  lv_label_set_text(labelYText, machine_menu.Y_Jerk);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Y_Jerk);
 
   buttonYValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_JERK_Y, NULL, 0);
-  lv_btn_set_style(buttonYValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonYValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonYValue, &style_para_value);
   labelYValue = lv_label_create(buttonYValue, NULL);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
-  labelZText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelZText, &tft_style_label_rel);
-  lv_obj_set_pos(labelZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-  lv_label_set_text(labelZText, machine_menu.Z_Jerk);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Z_Jerk);
 
   buttonZValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_JERK_Z, NULL, 0);
-  lv_btn_set_style(buttonZValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonZValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonZValue, &style_para_value);
   labelZValue = lv_label_create(buttonZValue, NULL);
 
   line3 = lv_line_create(scr, NULL);
   lv_ex_line(line3, line_points[2]);
 
-  labelEText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelEText, &tft_style_label_rel);
-  lv_obj_set_pos(labelEText, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-  lv_label_set_text(labelEText, machine_menu.E_Jerk);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E_Jerk);
 
   buttonEValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonEValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonEValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonEValue, event_handler, ID_JERK_E, NULL, 0);
-  lv_btn_set_style(buttonEValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonEValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonEValue, &style_para_value);
   labelEValue = lv_label_create(buttonEValue, NULL);
 
   line4 = lv_line_create(scr, NULL);
@@ -184,8 +165,7 @@ void lv_draw_jerk_settings(void) {
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_JERK_RETURN, NULL, 0);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
 
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_language.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_language.cpp
@@ -62,8 +62,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         disp_language(gCfgItems.language, UNSELECTED);
-        lv_imgbtn_set_src(buttonCN, LV_BTN_STATE_REL, "F:/bmp_simplified_cn_sel.bin");
-        lv_imgbtn_set_src(buttonCN, LV_BTN_STATE_PR, "F:/bmp_simplified_cn_sel.bin");
+        lv_imgbtn_set_src_both(buttonCN, "F:/bmp_simplified_cn_sel.bin");
         lv_obj_refresh_ext_draw_pad(buttonCN);
         gCfgItems.language = LANG_SIMPLE_CHINESE;
         update_spi_flash();
@@ -76,8 +75,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         disp_language(gCfgItems.language, UNSELECTED);
-        lv_imgbtn_set_src(buttonT_CN, LV_BTN_STATE_REL, "F:/bmp_traditional_cn_sel.bin");
-        lv_imgbtn_set_src(buttonT_CN, LV_BTN_STATE_PR, "F:/bmp_traditional_cn_sel.bin");
+        lv_imgbtn_set_src_both(buttonT_CN, "F:/bmp_traditional_cn_sel.bin");
         lv_obj_refresh_ext_draw_pad(buttonT_CN);
         gCfgItems.language = LANG_COMPLEX_CHINESE;
         update_spi_flash();
@@ -90,8 +88,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         disp_language(gCfgItems.language, UNSELECTED);
-        lv_imgbtn_set_src(buttonEN, LV_BTN_STATE_REL, "F:/bmp_english_sel.bin");
-        lv_imgbtn_set_src(buttonEN, LV_BTN_STATE_PR, "F:/bmp_english_sel.bin");
+        lv_imgbtn_set_src_both(buttonEN, "F:/bmp_english_sel.bin");
         lv_obj_refresh_ext_draw_pad(buttonEN);
         gCfgItems.language = LANG_ENGLISH;
         update_spi_flash();
@@ -104,8 +101,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         disp_language(gCfgItems.language, UNSELECTED);
-        lv_imgbtn_set_src(buttonRU, LV_BTN_STATE_REL, "F:/bmp_russian_sel.bin");
-        lv_imgbtn_set_src(buttonRU, LV_BTN_STATE_PR, "F:/bmp_russian_sel.bin");
+        lv_imgbtn_set_src_both(buttonRU, "F:/bmp_russian_sel.bin");
         lv_obj_refresh_ext_draw_pad(buttonRU);
         gCfgItems.language = LANG_RUSSIAN;
         update_spi_flash();
@@ -118,8 +114,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         disp_language(gCfgItems.language, UNSELECTED);
-        lv_imgbtn_set_src(buttonES, LV_BTN_STATE_REL, "F:/bmp_spanish_sel.bin");
-        lv_imgbtn_set_src(buttonES, LV_BTN_STATE_PR, "F:/bmp_spanish_sel.bin");
+        lv_imgbtn_set_src_both(buttonES, "F:/bmp_spanish_sel.bin");
         lv_obj_refresh_ext_draw_pad(buttonES);
         gCfgItems.language = LANG_SPANISH;
         update_spi_flash();
@@ -132,8 +127,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         disp_language(gCfgItems.language, UNSELECTED);
-        lv_imgbtn_set_src(buttonFR, LV_BTN_STATE_REL, "F:/bmp_french_sel.bin");
-        lv_imgbtn_set_src(buttonFR, LV_BTN_STATE_PR, "F:/bmp_french_sel.bin");
+        lv_imgbtn_set_src_both(buttonFR, "F:/bmp_french_sel.bin");
         lv_obj_refresh_ext_draw_pad(buttonFR);
         gCfgItems.language = LANG_FRENCH;
         update_spi_flash();
@@ -146,8 +140,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       }
       else if (event == LV_EVENT_RELEASED) {
         disp_language(gCfgItems.language, UNSELECTED);
-        lv_imgbtn_set_src(buttonIT, LV_BTN_STATE_REL, "F:/bmp_italy_sel.bin");
-        lv_imgbtn_set_src(buttonIT, LV_BTN_STATE_PR, "F:/bmp_italy_sel.bin");
+        lv_imgbtn_set_src_both(buttonIT, "F:/bmp_italy_sel.bin");
         lv_obj_refresh_ext_draw_pad(buttonIT);
         gCfgItems.language = LANG_ITALY;
         update_spi_flash();
@@ -231,8 +224,7 @@ static void disp_language(uint8_t language, uint8_t state) {
   strcat_P(public_buf_l, PSTR(".bin"));
 
   lv_obj_set_event_cb_mks(obj, event_handler, id, NULL, 0);
-  lv_imgbtn_set_src(obj, LV_BTN_STATE_REL, public_buf_l);
-  lv_imgbtn_set_src(obj, LV_BTN_STATE_PR, public_buf_l);
+  lv_imgbtn_set_src_both(obj, public_buf_l);
 
   if (state == UNSELECTED) lv_obj_refresh_ext_draw_pad(obj);
 }
@@ -253,10 +245,7 @@ void lv_draw_language(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -271,54 +260,38 @@ void lv_draw_language(void) {
   buttonBack = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonCN, event_handler, ID_CN, NULL, 0);
-  lv_imgbtn_set_src(buttonCN, LV_BTN_STATE_REL, "F:/bmp_simplified_cn.bin");
-  lv_imgbtn_set_src(buttonCN, LV_BTN_STATE_PR, "F:/bmp_simplified_cn.bin");
-  lv_imgbtn_set_style(buttonCN, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonCN, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonCN, "F:/bmp_simplified_cn.bin");
+  lv_imgbtn_use_label_style(buttonCN);
   lv_obj_clear_protect(buttonCN, LV_PROTECT_FOLLOW);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonT_CN, event_handler, ID_T_CN, NULL, 0);
-    lv_imgbtn_set_src(buttonT_CN, LV_BTN_STATE_REL, "F:/bmp_traditional_cn.bin");
-    lv_imgbtn_set_src(buttonT_CN, LV_BTN_STATE_PR, "F:/bmp_traditional_cn.bin");
-    lv_imgbtn_set_style(buttonT_CN, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonT_CN, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonT_CN, "F:/bmp_traditional_cn.bin");
+    lv_imgbtn_use_label_style(buttonT_CN);
 
     lv_obj_set_event_cb_mks(buttonEN, event_handler, ID_EN, NULL, 0);
-    lv_imgbtn_set_src(buttonEN, LV_BTN_STATE_REL, "F:/bmp_english.bin");
-    lv_imgbtn_set_src(buttonEN, LV_BTN_STATE_PR, "F:/bmp_english.bin");
-    lv_imgbtn_set_style(buttonEN, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonEN, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonEN, "F:/bmp_english.bin");
+    lv_imgbtn_use_label_style(buttonEN);
 
     lv_obj_set_event_cb_mks(buttonRU, event_handler, ID_RU, NULL, 0);
-    lv_imgbtn_set_src(buttonRU, LV_BTN_STATE_REL, "F:/bmp_russian.bin");
-    lv_imgbtn_set_src(buttonRU, LV_BTN_STATE_PR, "F:/bmp_russian.bin");
-    lv_imgbtn_set_style(buttonRU, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonRU, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonRU, "F:/bmp_russian.bin");
+    lv_imgbtn_use_label_style(buttonRU);
 
     lv_obj_set_event_cb_mks(buttonES, event_handler, ID_ES, NULL, 0);
-    lv_imgbtn_set_src(buttonES, LV_BTN_STATE_REL, "F:/bmp_spanish.bin");
-    lv_imgbtn_set_src(buttonES, LV_BTN_STATE_PR, "F:/bmp_spanish.bin");
-    lv_imgbtn_set_style(buttonES, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonES, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonES, "F:/bmp_spanish.bin");
+    lv_imgbtn_use_label_style(buttonES);
 
     lv_obj_set_event_cb_mks(buttonFR, event_handler, ID_FR, NULL, 0);
-    lv_imgbtn_set_src(buttonFR, LV_BTN_STATE_REL, "F:/bmp_french.bin");
-    lv_imgbtn_set_src(buttonFR, LV_BTN_STATE_PR, "F:/bmp_french.bin");
-    lv_imgbtn_set_style(buttonFR, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonFR, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonFR, "F:/bmp_french.bin");
+    lv_imgbtn_use_label_style(buttonFR);
 
     lv_obj_set_event_cb_mks(buttonIT, event_handler, ID_IT, NULL, 0);
-    lv_imgbtn_set_src(buttonIT, LV_BTN_STATE_REL, "F:/bmp_italy.bin");
-    lv_imgbtn_set_src(buttonIT, LV_BTN_STATE_PR, "F:/bmp_italy.bin");
-    lv_imgbtn_set_style(buttonIT, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonIT, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonIT, "F:/bmp_italy.bin");
+    lv_imgbtn_use_label_style(buttonIT);
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_L_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
 
   #endif // if 1
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_language.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_language.cpp
@@ -152,7 +152,6 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
       }
       else if (event == LV_EVENT_RELEASED) {
-
         buttonCN   = NULL;
         buttonT_CN = NULL;
         buttonEN   = NULL;
@@ -250,78 +249,25 @@ void lv_draw_language(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create image buttons
-  buttonCN   = lv_imgbtn_create(scr, NULL);
-  buttonT_CN = lv_imgbtn_create(scr, NULL);
-  buttonEN   = lv_imgbtn_create(scr, NULL);
-  buttonRU   = lv_imgbtn_create(scr, NULL);
-  buttonES   = lv_imgbtn_create(scr, NULL);
-  buttonFR   = lv_imgbtn_create(scr, NULL);
-  buttonIT   = lv_imgbtn_create(scr, NULL);
-  buttonBack = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonCN, event_handler, ID_CN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonCN, "F:/bmp_simplified_cn.bin");
-  lv_imgbtn_use_label_style(buttonCN);
+  buttonCN = lv_imgbtn_create(scr, "F:/bmp_simplified_cn.bin", INTERVAL_V, titleHeight, event_handler, ID_CN);
   lv_obj_clear_protect(buttonCN, LV_PROTECT_FOLLOW);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonT_CN, event_handler, ID_T_CN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonT_CN, "F:/bmp_traditional_cn.bin");
-    lv_imgbtn_use_label_style(buttonT_CN);
-
-    lv_obj_set_event_cb_mks(buttonEN, event_handler, ID_EN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonEN, "F:/bmp_english.bin");
-    lv_imgbtn_use_label_style(buttonEN);
-
-    lv_obj_set_event_cb_mks(buttonRU, event_handler, ID_RU, NULL, 0);
-    lv_imgbtn_set_src_both(buttonRU, "F:/bmp_russian.bin");
-    lv_imgbtn_use_label_style(buttonRU);
-
-    lv_obj_set_event_cb_mks(buttonES, event_handler, ID_ES, NULL, 0);
-    lv_imgbtn_set_src_both(buttonES, "F:/bmp_spanish.bin");
-    lv_imgbtn_use_label_style(buttonES);
-
-    lv_obj_set_event_cb_mks(buttonFR, event_handler, ID_FR, NULL, 0);
-    lv_imgbtn_set_src_both(buttonFR, "F:/bmp_french.bin");
-    lv_imgbtn_use_label_style(buttonFR);
-
-    lv_obj_set_event_cb_mks(buttonIT, event_handler, ID_IT, NULL, 0);
-    lv_imgbtn_set_src_both(buttonIT, "F:/bmp_italy.bin");
-    lv_imgbtn_use_label_style(buttonIT);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_L_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-
-  #endif // if 1
-
-  lv_obj_set_pos(buttonCN, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonT_CN, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
-  lv_obj_set_pos(buttonEN, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
-  lv_obj_set_pos(buttonRU, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonES, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonFR, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonIT, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonT_CN = lv_imgbtn_create(scr, "F:/bmp_traditional_cn.bin", BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_T_CN);
+  buttonEN = lv_imgbtn_create(scr, "F:/bmp_english.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_EN);
+  buttonRU = lv_imgbtn_create(scr, "F:/bmp_russian.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_RU);
+  buttonES = lv_imgbtn_create(scr, "F:/bmp_spanish.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_ES);
+  buttonFR = lv_imgbtn_create(scr, "F:/bmp_french.bin", BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_FR);
+  buttonIT = lv_imgbtn_create(scr, "F:/bmp_italy.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_IT);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_L_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonCN, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonT_CN, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonEN, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonRU, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonES, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonFR, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonIT, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *label_CN   = lv_label_create(buttonCN, NULL);
-  lv_obj_t *label_T_CN = lv_label_create(buttonT_CN, NULL);
-  lv_obj_t *label_EN   = lv_label_create(buttonEN, NULL);
-  lv_obj_t *label_RU   = lv_label_create(buttonRU, NULL);
-  lv_obj_t *label_ES   = lv_label_create(buttonES, NULL);
-  lv_obj_t *label_FR   = lv_label_create(buttonFR, NULL);
-  lv_obj_t *label_IT   = lv_label_create(buttonIT, NULL);
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *label_CN   = lv_label_create_empty(buttonCN);
+  lv_obj_t *label_T_CN = lv_label_create_empty(buttonT_CN);
+  lv_obj_t *label_EN   = lv_label_create_empty(buttonEN);
+  lv_obj_t *label_RU   = lv_label_create_empty(buttonRU);
+  lv_obj_t *label_ES   = lv_label_create_empty(buttonES);
+  lv_obj_t *label_FR   = lv_label_create_empty(buttonFR);
+  lv_obj_t *label_IT   = lv_label_create_empty(buttonIT);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   disp_language(gCfgItems.language, SELECTED);
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_level_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_level_settings.cpp
@@ -144,17 +144,13 @@ void lv_draw_level_settings(void) {
   lv_obj_set_event_cb_mks(buttonPosition, event_handler, ID_LEVEL_POSITION, NULL, 0);
   lv_btn_use_label_style(buttonPosition);
   lv_btn_set_layout(buttonPosition, LV_LAYOUT_OFF);
-  labelPosition = lv_label_create(buttonPosition, NULL);                       /*Add a label to the button*/
+  labelPosition = lv_label_create_empty(buttonPosition);                       /*Add a label to the button*/
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonPosition);
   #endif
 
-  buttonPositionNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonPositionNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonPositionNarrow, event_handler, ID_LEVEL_POSITION_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonPositionNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonPositionNarrow);
+  buttonPositionNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V, event_handler, ID_LEVEL_POSITION_ARROW);
   lv_btn_set_layout(buttonPositionNarrow, LV_LAYOUT_OFF);
 
   line1 = lv_line_create(scr, NULL);
@@ -166,17 +162,13 @@ void lv_draw_level_settings(void) {
   lv_obj_set_event_cb_mks(buttonCommand, event_handler, ID_LEVEL_COMMAND, NULL, 0);
   lv_btn_use_label_style(buttonCommand);
   lv_btn_set_layout(buttonCommand, LV_LAYOUT_OFF);
-  labelCommand = lv_label_create(buttonCommand, NULL);
+  labelCommand = lv_label_create_empty(buttonCommand);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonCommand);
   #endif
 
-  buttonCommandNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonCommandNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonCommandNarrow, event_handler, ID_LEVEL_COMMAND_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonCommandNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonCommandNarrow);
+  buttonCommandNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V, event_handler, ID_LEVEL_COMMAND_ARROW);
   lv_btn_set_layout(buttonCommandNarrow, LV_LAYOUT_OFF);
 
   line2 = lv_line_create(scr, NULL);
@@ -184,23 +176,15 @@ void lv_draw_level_settings(void) {
 
   #if HAS_BED_PROBE
 
-    buttonZoffset = lv_btn_create(scr, NULL);                                 /*Add a button the current screen*/
-    lv_obj_set_pos(buttonZoffset, PARA_UI_POS_X, PARA_UI_POS_Y * 3);          /*Set its position*/
-    lv_obj_set_size(buttonZoffset, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
-    lv_obj_set_event_cb_mks(buttonZoffset, event_handler, ID_LEVEL_ZOFFSET, NULL, 0);
-    lv_btn_use_label_style(buttonZoffset);
+    buttonZoffset = lv_btn_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3, PARA_UI_SIZE_X, PARA_UI_SIZE_Y, event_handler, ID_LEVEL_ZOFFSET);
     lv_btn_set_layout(buttonZoffset, LV_LAYOUT_OFF);
-    labelZoffset = lv_label_create(buttonZoffset, NULL);                      /*Add a label to the button*/
+    labelZoffset = lv_label_create_empty(buttonZoffset);                      /*Add a label to the button*/
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonZoffset);
     #endif
 
-    buttonZoffsetNarrow = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonZoffsetNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V);
-    lv_obj_set_event_cb_mks(buttonZoffsetNarrow, event_handler, ID_LEVEL_ZOFFSET_ARROW, NULL, 0);
-    lv_imgbtn_set_src_both(buttonZoffsetNarrow, "F:/bmp_arrow.bin");
-    lv_imgbtn_use_label_style(buttonZoffsetNarrow);
+    buttonZoffsetNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V, event_handler, ID_LEVEL_ZOFFSET_ARROW);
     lv_btn_set_layout(buttonZoffsetNarrow, LV_LAYOUT_OFF);
 
     line3 = lv_line_create(scr, NULL);
@@ -208,17 +192,14 @@ void lv_draw_level_settings(void) {
 
   #endif // HAS_BED_PROBE
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_LEVEL_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", event_handler, ID_LEVEL_RETURN);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif
 
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Back, common_menu.text_back);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_level_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_level_settings.cpp
@@ -133,10 +133,7 @@ void lv_draw_level_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.LevelingParaConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.LevelingParaConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -145,8 +142,7 @@ void lv_draw_level_settings(void) {
   lv_obj_set_pos(buttonPosition, PARA_UI_POS_X, PARA_UI_POS_Y);                /*Set its position*/
   lv_obj_set_size(buttonPosition, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);             /*Set its size*/
   lv_obj_set_event_cb_mks(buttonPosition, event_handler, ID_LEVEL_POSITION, NULL, 0);
-  lv_btn_set_style(buttonPosition, LV_BTN_STYLE_REL, &tft_style_label_rel);    /*Set the button's released style*/
-  lv_btn_set_style(buttonPosition, LV_BTN_STYLE_PR, &tft_style_label_pre);     /*Set the button's pressed style*/
+  lv_btn_use_label_style(buttonPosition);
   lv_btn_set_layout(buttonPosition, LV_LAYOUT_OFF);
   labelPosition = lv_label_create(buttonPosition, NULL);                       /*Add a label to the button*/
 
@@ -157,10 +153,8 @@ void lv_draw_level_settings(void) {
   buttonPositionNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonPositionNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonPositionNarrow, event_handler, ID_LEVEL_POSITION_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonPositionNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonPositionNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonPositionNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonPositionNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonPositionNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonPositionNarrow);
   lv_btn_set_layout(buttonPositionNarrow, LV_LAYOUT_OFF);
 
   line1 = lv_line_create(scr, NULL);
@@ -170,8 +164,7 @@ void lv_draw_level_settings(void) {
   lv_obj_set_pos(buttonCommand, PARA_UI_POS_X, PARA_UI_POS_Y * 2);
   lv_obj_set_size(buttonCommand, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);
   lv_obj_set_event_cb_mks(buttonCommand, event_handler, ID_LEVEL_COMMAND, NULL, 0);
-  lv_btn_set_style(buttonCommand, LV_BTN_STYLE_REL, &tft_style_label_rel);
-  lv_btn_set_style(buttonCommand, LV_BTN_STYLE_PR, &tft_style_label_pre);
+  lv_btn_use_label_style(buttonCommand);
   lv_btn_set_layout(buttonCommand, LV_LAYOUT_OFF);
   labelCommand = lv_label_create(buttonCommand, NULL);
 
@@ -182,10 +175,8 @@ void lv_draw_level_settings(void) {
   buttonCommandNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonCommandNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonCommandNarrow, event_handler, ID_LEVEL_COMMAND_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonCommandNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonCommandNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonCommandNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonCommandNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonCommandNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonCommandNarrow);
   lv_btn_set_layout(buttonCommandNarrow, LV_LAYOUT_OFF);
 
   line2 = lv_line_create(scr, NULL);
@@ -197,8 +188,7 @@ void lv_draw_level_settings(void) {
     lv_obj_set_pos(buttonZoffset, PARA_UI_POS_X, PARA_UI_POS_Y * 3);          /*Set its position*/
     lv_obj_set_size(buttonZoffset, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
     lv_obj_set_event_cb_mks(buttonZoffset, event_handler, ID_LEVEL_ZOFFSET, NULL, 0);
-    lv_btn_set_style(buttonZoffset, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-    lv_btn_set_style(buttonZoffset, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+    lv_btn_use_label_style(buttonZoffset);
     lv_btn_set_layout(buttonZoffset, LV_LAYOUT_OFF);
     labelZoffset = lv_label_create(buttonZoffset, NULL);                      /*Add a label to the button*/
 
@@ -209,10 +199,8 @@ void lv_draw_level_settings(void) {
     buttonZoffsetNarrow = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonZoffsetNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V);
     lv_obj_set_event_cb_mks(buttonZoffsetNarrow, event_handler, ID_LEVEL_ZOFFSET_ARROW, NULL, 0);
-    lv_imgbtn_set_src(buttonZoffsetNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_src(buttonZoffsetNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_style(buttonZoffsetNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonZoffsetNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonZoffsetNarrow, "F:/bmp_arrow.bin");
+    lv_imgbtn_use_label_style(buttonZoffsetNarrow);
     lv_btn_set_layout(buttonZoffsetNarrow, LV_LAYOUT_OFF);
 
     line3 = lv_line_create(scr, NULL);
@@ -222,10 +210,8 @@ void lv_draw_level_settings(void) {
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_LEVEL_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_machine_para.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_machine_para.cpp
@@ -146,10 +146,7 @@ void lv_draw_machine_para(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -158,18 +155,15 @@ void lv_draw_machine_para(void) {
   lv_obj_set_size(buttonMachine, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
   //lv_obj_set_event_cb(buttonMachine, event_handler);
   lv_obj_set_event_cb_mks(buttonMachine, event_handler, ID_PARA_MACHINE, NULL, 0);
-  lv_btn_set_style(buttonMachine, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-  lv_btn_set_style(buttonMachine, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+  lv_btn_use_label_style(buttonMachine);
   lv_btn_set_layout(buttonMachine, LV_LAYOUT_OFF);
   labelMachine = lv_label_create(buttonMachine, NULL);                      /*Add a label to the button*/
 
   buttonMachineNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonMachineNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonMachineNarrow, event_handler, ID_PARA_MACHINE_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonMachineNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonMachineNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonMachineNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonMachineNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonMachineNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonMachineNarrow);
   lv_btn_set_layout(buttonMachineNarrow, LV_LAYOUT_OFF);
 
   line1 = lv_line_create(scr, NULL);
@@ -180,18 +174,15 @@ void lv_draw_machine_para(void) {
   lv_obj_set_size(buttonMotor, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);             /*Set its size*/
   //lv_obj_set_event_cb(buttonMotor, event_handler);
   lv_obj_set_event_cb_mks(buttonMotor, event_handler, ID_PARA_MOTOR, NULL, 0);
-  lv_btn_set_style(buttonMotor, LV_BTN_STYLE_REL, &tft_style_label_rel);    /*Set the button's released style*/
-  lv_btn_set_style(buttonMotor, LV_BTN_STYLE_PR, &tft_style_label_pre);     /*Set the button's pressed style*/
+  lv_btn_use_label_style(buttonMotor);
   lv_btn_set_layout(buttonMotor, LV_LAYOUT_OFF);
   labelMotor = lv_label_create(buttonMotor, NULL);                          /*Add a label to the button*/
 
   buttonMotorNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonMotorNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonMotorNarrow, event_handler, ID_PARA_MOTOR_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonMotorNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonMotorNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonMotorNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonMotorNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonMotorNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonMotorNarrow);
   lv_btn_set_layout(buttonMotorNarrow, LV_LAYOUT_OFF);
 
   line2 = lv_line_create(scr, NULL);
@@ -202,18 +193,15 @@ void lv_draw_machine_para(void) {
   lv_obj_set_size(buttonLevel, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
   //lv_obj_set_event_cb(buttonMotor, event_handler);
   lv_obj_set_event_cb_mks(buttonLevel, event_handler, ID_PARA_LEVEL, NULL, 0);
-  lv_btn_set_style(buttonLevel, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-  lv_btn_set_style(buttonLevel, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+  lv_btn_use_label_style(buttonLevel);
   lv_btn_set_layout(buttonLevel, LV_LAYOUT_OFF);
   labelLevel = lv_label_create(buttonLevel, NULL);                      /*Add a label to the button*/
 
   buttonLevelNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonLevelNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonLevelNarrow, event_handler, ID_PARA_LEVEL_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonLevelNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonLevelNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonLevelNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonLevelNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonLevelNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonLevelNarrow);
   lv_btn_set_layout(buttonLevelNarrow, LV_LAYOUT_OFF);
 
   line3 = lv_line_create(scr, NULL);
@@ -224,18 +212,15 @@ void lv_draw_machine_para(void) {
   lv_obj_set_size(buttonAdvance, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
   //lv_obj_set_event_cb(buttonMotor, event_handler);
   lv_obj_set_event_cb_mks(buttonAdvance, event_handler, ID_PARA_ADVANCE, NULL, 0);
-  lv_btn_set_style(buttonAdvance, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-  lv_btn_set_style(buttonAdvance, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+  lv_btn_use_label_style(buttonAdvance);
   lv_btn_set_layout(buttonAdvance, LV_LAYOUT_OFF);
   labelAdvance = lv_label_create(buttonAdvance, NULL);                      /*Add a label to the button*/
 
   buttonAdvanceNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonAdvanceNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 4 + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonAdvanceNarrow, event_handler, ID_PARA_ADVANCE_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonAdvanceNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonAdvanceNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonAdvanceNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonAdvanceNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonAdvanceNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonAdvanceNarrow);
   lv_btn_set_layout(buttonAdvanceNarrow, LV_LAYOUT_OFF);
 
   line4 = lv_line_create(scr, NULL);
@@ -243,10 +228,8 @@ void lv_draw_machine_para(void) {
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_PARA_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X + 10, PARA_UI_BACL_POS_Y);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_machine_para.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_machine_para.cpp
@@ -157,14 +157,9 @@ void lv_draw_machine_para(void) {
   lv_obj_set_event_cb_mks(buttonMachine, event_handler, ID_PARA_MACHINE, NULL, 0);
   lv_btn_use_label_style(buttonMachine);
   lv_btn_set_layout(buttonMachine, LV_LAYOUT_OFF);
-  labelMachine = lv_label_create(buttonMachine, NULL);                      /*Add a label to the button*/
+  labelMachine = lv_label_create_empty(buttonMachine);                      /*Add a label to the button*/
 
-  buttonMachineNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonMachineNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonMachineNarrow, event_handler, ID_PARA_MACHINE_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonMachineNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonMachineNarrow);
-  lv_btn_set_layout(buttonMachineNarrow, LV_LAYOUT_OFF);
+  buttonMachineNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V, event_handler, ID_PARA_MACHINE_ARROW);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
@@ -176,33 +171,19 @@ void lv_draw_machine_para(void) {
   lv_obj_set_event_cb_mks(buttonMotor, event_handler, ID_PARA_MOTOR, NULL, 0);
   lv_btn_use_label_style(buttonMotor);
   lv_btn_set_layout(buttonMotor, LV_LAYOUT_OFF);
-  labelMotor = lv_label_create(buttonMotor, NULL);                          /*Add a label to the button*/
+  labelMotor = lv_label_create_empty(buttonMotor);                          /*Add a label to the button*/
 
-  buttonMotorNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonMotorNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonMotorNarrow, event_handler, ID_PARA_MOTOR_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonMotorNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonMotorNarrow);
-  lv_btn_set_layout(buttonMotorNarrow, LV_LAYOUT_OFF);
+  buttonMotorNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V, event_handler, ID_PARA_MOTOR_ARROW);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
-  buttonLevel = lv_btn_create(scr, NULL);                                 /*Add a button the current screen*/
-  lv_obj_set_pos(buttonLevel, PARA_UI_POS_X, PARA_UI_POS_Y * 3);          /*Set its position*/
-  lv_obj_set_size(buttonLevel, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
+  buttonLevel = lv_btn_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3, PARA_UI_SIZE_X, PARA_UI_SIZE_Y, event_handler, ID_PARA_LEVEL);
   //lv_obj_set_event_cb(buttonMotor, event_handler);
-  lv_obj_set_event_cb_mks(buttonLevel, event_handler, ID_PARA_LEVEL, NULL, 0);
-  lv_btn_use_label_style(buttonLevel);
   lv_btn_set_layout(buttonLevel, LV_LAYOUT_OFF);
-  labelLevel = lv_label_create(buttonLevel, NULL);                      /*Add a label to the button*/
+  labelLevel = lv_label_create_empty(buttonLevel);                      /*Add a label to the button*/
 
-  buttonLevelNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonLevelNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonLevelNarrow, event_handler, ID_PARA_LEVEL_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonLevelNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonLevelNarrow);
-  lv_btn_set_layout(buttonLevelNarrow, LV_LAYOUT_OFF);
+  buttonLevelNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V, event_handler, ID_PARA_LEVEL_ARROW);
 
   line3 = lv_line_create(scr, NULL);
   lv_ex_line(line3, line_points[2]);
@@ -214,26 +195,16 @@ void lv_draw_machine_para(void) {
   lv_obj_set_event_cb_mks(buttonAdvance, event_handler, ID_PARA_ADVANCE, NULL, 0);
   lv_btn_use_label_style(buttonAdvance);
   lv_btn_set_layout(buttonAdvance, LV_LAYOUT_OFF);
-  labelAdvance = lv_label_create(buttonAdvance, NULL);                      /*Add a label to the button*/
+  labelAdvance = lv_label_create_empty(buttonAdvance);                      /*Add a label to the button*/
 
-  buttonAdvanceNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonAdvanceNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 4 + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonAdvanceNarrow, event_handler, ID_PARA_ADVANCE_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonAdvanceNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonAdvanceNarrow);
+  buttonAdvanceNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 4 + PARA_UI_ARROW_V, event_handler, ID_PARA_ADVANCE_ARROW);
   lv_btn_set_layout(buttonAdvanceNarrow, LV_LAYOUT_OFF);
 
   line4 = lv_line_create(scr, NULL);
   lv_ex_line(line4, line_points[3]);
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_PARA_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X + 10, PARA_UI_BACL_POS_Y);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", PARA_UI_BACL_POS_X + 10, PARA_UI_BACL_POS_Y, event_handler, ID_PARA_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Back, common_menu.text_back);
@@ -260,7 +231,6 @@ void lv_draw_machine_para(void) {
       lv_group_add_obj(g, buttonBack);
     }
   #endif
-
 }
 
 void lv_clear_machine_para() {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_machine_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_machine_settings.cpp
@@ -132,10 +132,7 @@ void lv_draw_machine_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.MachineConfigTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.MachineConfigTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -144,18 +141,15 @@ void lv_draw_machine_settings(void) {
   lv_obj_set_size(buttonAcceleration, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);          // Set its size
   //lv_obj_set_event_cb(buttonMachine, event_handler);
   lv_obj_set_event_cb_mks(buttonAcceleration, event_handler, ID_MACHINE_ACCELERATION, NULL, 0);
-  lv_btn_set_style(buttonAcceleration, LV_BTN_STYLE_REL, &tft_style_label_rel); // Set the button's released style
-  lv_btn_set_style(buttonAcceleration, LV_BTN_STYLE_PR, &tft_style_label_pre);  // Set the button's pressed style
+  lv_btn_use_label_style(buttonAcceleration);
   lv_btn_set_layout(buttonAcceleration, LV_LAYOUT_OFF);
   labelAcceleration = lv_label_create(buttonAcceleration, NULL);                // Add a label to the button
 
   buttonAccelerationNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonAccelerationNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonAccelerationNarrow, event_handler, ID_MACHINE_ACCELERATION_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonAccelerationNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonAccelerationNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonAccelerationNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonAccelerationNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonAccelerationNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonAccelerationNarrow);
   lv_btn_set_layout(buttonAccelerationNarrow, LV_LAYOUT_OFF);
 
   line1 = lv_line_create(lv_scr_act(), NULL);
@@ -166,18 +160,15 @@ void lv_draw_machine_settings(void) {
   lv_obj_set_size(buttonMaxFeedrate, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           // Set its size
   //lv_obj_set_event_cb(buttonMachine, event_handler);
   lv_obj_set_event_cb_mks(buttonMaxFeedrate, event_handler, ID_MACHINE_FEEDRATE, NULL, 0);
-  lv_btn_set_style(buttonMaxFeedrate, LV_BTN_STYLE_REL, &tft_style_label_rel);  // Set the button's released style
-  lv_btn_set_style(buttonMaxFeedrate, LV_BTN_STYLE_PR, &tft_style_label_pre);   // Set the button's pressed style
+  lv_btn_use_label_style(buttonMaxFeedrate);
   lv_btn_set_layout(buttonMaxFeedrate, LV_LAYOUT_OFF);
   labelMaxFeedrate = lv_label_create(buttonMaxFeedrate, NULL);                  // Add a label to the button
 
   buttonMaxFeedrateNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonMaxFeedrateNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonMaxFeedrateNarrow, event_handler, ID_MACHINE_FEEDRATE_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonMaxFeedrateNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonMaxFeedrateNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonMaxFeedrateNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonMaxFeedrateNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonMaxFeedrateNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonMaxFeedrateNarrow);
   lv_btn_set_layout(buttonMaxFeedrateNarrow, LV_LAYOUT_OFF);
 
   line2 = lv_line_create(lv_scr_act(), NULL);
@@ -189,18 +180,15 @@ void lv_draw_machine_settings(void) {
     lv_obj_set_size(buttonJerk, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);                // Set its size
     //lv_obj_set_event_cb(buttonMotor, event_handler);
     lv_obj_set_event_cb_mks(buttonJerk, event_handler, ID_MACHINE_JERK, NULL, 0);
-    lv_btn_set_style(buttonJerk, LV_BTN_STYLE_REL, &tft_style_label_rel);       // Set the button's released style
-    lv_btn_set_style(buttonJerk, LV_BTN_STYLE_PR, &tft_style_label_pre);        // Set the button's pressed style
+    lv_btn_use_label_style(buttonJerk);
     lv_btn_set_layout(buttonJerk, LV_LAYOUT_OFF);
     labelJerk = lv_label_create(buttonJerk, NULL);                              // Add a label to the button
 
     buttonJerkNarrow = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonJerkNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V);
     lv_obj_set_event_cb_mks(buttonJerkNarrow, event_handler, ID_MACHINE_JERK_ARROW, NULL, 0);
-    lv_imgbtn_set_src(buttonJerkNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_src(buttonJerkNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_style(buttonJerkNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonJerkNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonJerkNarrow, "F:/bmp_arrow.bin");
+    lv_imgbtn_use_label_style(buttonJerkNarrow);
     lv_btn_set_layout(buttonJerkNarrow, LV_LAYOUT_OFF);
 
     line3 = lv_line_create(lv_scr_act(), NULL);
@@ -209,10 +197,8 @@ void lv_draw_machine_settings(void) {
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_MACHINE_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_machine_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_machine_settings.cpp
@@ -143,14 +143,9 @@ void lv_draw_machine_settings(void) {
   lv_obj_set_event_cb_mks(buttonAcceleration, event_handler, ID_MACHINE_ACCELERATION, NULL, 0);
   lv_btn_use_label_style(buttonAcceleration);
   lv_btn_set_layout(buttonAcceleration, LV_LAYOUT_OFF);
-  labelAcceleration = lv_label_create(buttonAcceleration, NULL);                // Add a label to the button
+  labelAcceleration = lv_label_create_empty(buttonAcceleration);                // Add a label to the button
 
-  buttonAccelerationNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonAccelerationNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonAccelerationNarrow, event_handler, ID_MACHINE_ACCELERATION_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonAccelerationNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonAccelerationNarrow);
-  lv_btn_set_layout(buttonAccelerationNarrow, LV_LAYOUT_OFF);
+  buttonAccelerationNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V, event_handler, ID_MACHINE_ACCELERATION_ARROW);
 
   line1 = lv_line_create(lv_scr_act(), NULL);
   lv_ex_line(line1, line_points[0]);
@@ -162,14 +157,9 @@ void lv_draw_machine_settings(void) {
   lv_obj_set_event_cb_mks(buttonMaxFeedrate, event_handler, ID_MACHINE_FEEDRATE, NULL, 0);
   lv_btn_use_label_style(buttonMaxFeedrate);
   lv_btn_set_layout(buttonMaxFeedrate, LV_LAYOUT_OFF);
-  labelMaxFeedrate = lv_label_create(buttonMaxFeedrate, NULL);                  // Add a label to the button
+  labelMaxFeedrate = lv_label_create_empty(buttonMaxFeedrate);                  // Add a label to the button
 
-  buttonMaxFeedrateNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonMaxFeedrateNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonMaxFeedrateNarrow, event_handler, ID_MACHINE_FEEDRATE_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonMaxFeedrateNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonMaxFeedrateNarrow);
-  lv_btn_set_layout(buttonMaxFeedrateNarrow, LV_LAYOUT_OFF);
+  buttonMaxFeedrateNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V, event_handler, ID_MACHINE_FEEDRATE_ARROW);
 
   line2 = lv_line_create(lv_scr_act(), NULL);
   lv_ex_line(line2, line_points[1]);
@@ -182,27 +172,19 @@ void lv_draw_machine_settings(void) {
     lv_obj_set_event_cb_mks(buttonJerk, event_handler, ID_MACHINE_JERK, NULL, 0);
     lv_btn_use_label_style(buttonJerk);
     lv_btn_set_layout(buttonJerk, LV_LAYOUT_OFF);
-    labelJerk = lv_label_create(buttonJerk, NULL);                              // Add a label to the button
+    labelJerk = lv_label_create_empty(buttonJerk);                              // Add a label to the button
 
-    buttonJerkNarrow = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonJerkNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V);
-    lv_obj_set_event_cb_mks(buttonJerkNarrow, event_handler, ID_MACHINE_JERK_ARROW, NULL, 0);
-    lv_imgbtn_set_src_both(buttonJerkNarrow, "F:/bmp_arrow.bin");
-    lv_imgbtn_use_label_style(buttonJerkNarrow);
-    lv_btn_set_layout(buttonJerkNarrow, LV_LAYOUT_OFF);
+    buttonJerkNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 3 + PARA_UI_ARROW_V, event_handler, ID_MACHINE_JERK_ARROW);
 
     line3 = lv_line_create(lv_scr_act(), NULL);
     lv_ex_line(line3, line_points[2]);
   #endif
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_MACHINE_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", event_handler, ID_MACHINE_RETURN);
 
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Back, common_menu.text_back);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_manuaLevel.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_manuaLevel.cpp
@@ -183,61 +183,21 @@ void lv_draw_manualLevel(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonPoint1 = lv_imgbtn_create(scr, NULL);
-  buttonPoint2 = lv_imgbtn_create(scr, NULL);
-  buttonPoint3 = lv_imgbtn_create(scr, NULL);
-  buttonPoint4 = lv_imgbtn_create(scr, NULL);
-  buttonPoint5 = lv_imgbtn_create(scr, NULL);
-  buttonBack   = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonPoint1, event_handler, ID_M_POINT1, NULL, 0);
-  lv_imgbtn_set_src_both(buttonPoint1, "F:/bmp_leveling1.bin");
-  lv_imgbtn_use_label_style(buttonPoint1);
+  buttonPoint1 = lv_imgbtn_create(scr, "F:/bmp_leveling1.bin", INTERVAL_V, titleHeight, event_handler, ID_M_POINT1);
   lv_obj_clear_protect(buttonPoint1, LV_PROTECT_FOLLOW);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonPoint2, event_handler, ID_M_POINT2, NULL, 0);
-    lv_imgbtn_set_src_both(buttonPoint2, "F:/bmp_leveling2.bin");
-    lv_imgbtn_use_label_style(buttonPoint2);
-
-    lv_obj_set_event_cb_mks(buttonPoint3, event_handler, ID_M_POINT3, NULL, 0);
-    lv_imgbtn_set_src_both(buttonPoint3, "F:/bmp_leveling3.bin");
-    lv_imgbtn_use_label_style(buttonPoint3);
-
-    lv_obj_set_event_cb_mks(buttonPoint4, event_handler, ID_M_POINT4, NULL, 0);
-    lv_imgbtn_set_src_both(buttonPoint4, "F:/bmp_leveling4.bin");
-    lv_imgbtn_use_label_style(buttonPoint4);
-
-    lv_obj_set_event_cb_mks(buttonPoint5, event_handler, ID_M_POINT5, NULL, 0);
-    lv_imgbtn_set_src_both(buttonPoint5, "F:/bmp_leveling5.bin");
-    lv_imgbtn_use_label_style(buttonPoint5);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_MANUAL_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-  #endif
-
-  lv_obj_set_pos(buttonPoint1, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonPoint2, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
-  lv_obj_set_pos(buttonPoint3, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
-  lv_obj_set_pos(buttonPoint4, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonPoint5, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonPoint2 = lv_imgbtn_create(scr, "F:/bmp_leveling2.bin", BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_M_POINT2);
+  buttonPoint3 = lv_imgbtn_create(scr, "F:/bmp_leveling3.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_M_POINT3);
+  buttonPoint4 = lv_imgbtn_create(scr, "F:/bmp_leveling4.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_M_POINT4);
+  buttonPoint5 = lv_imgbtn_create(scr, "F:/bmp_leveling5.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_M_POINT5);
+  buttonBack   = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_MANUAL_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonPoint1, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonPoint2, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonPoint3, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonPoint4, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonPoint5, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *label_Point1 = lv_label_create(buttonPoint1, NULL);
-  lv_obj_t *label_Point2 = lv_label_create(buttonPoint2, NULL);
-  lv_obj_t *label_Point3 = lv_label_create(buttonPoint3, NULL);
-  lv_obj_t *label_Point4 = lv_label_create(buttonPoint4, NULL);
-  lv_obj_t *label_Point5 = lv_label_create(buttonPoint5, NULL);
-  lv_obj_t *label_Back   = lv_label_create(buttonBack, NULL);
+  lv_obj_t *label_Point1 = lv_label_create_empty(buttonPoint1);
+  lv_obj_t *label_Point2 = lv_label_create_empty(buttonPoint2);
+  lv_obj_t *label_Point3 = lv_label_create_empty(buttonPoint3);
+  lv_obj_t *label_Point4 = lv_label_create_empty(buttonPoint4);
+  lv_obj_t *label_Point5 = lv_label_create_empty(buttonPoint5);
+  lv_obj_t *label_Back   = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Point1, leveling_menu.position1);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_manuaLevel.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_manuaLevel.cpp
@@ -178,10 +178,7 @@ void lv_draw_manualLevel(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -194,42 +191,30 @@ void lv_draw_manualLevel(void) {
   buttonBack   = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonPoint1, event_handler, ID_M_POINT1, NULL, 0);
-  lv_imgbtn_set_src(buttonPoint1, LV_BTN_STATE_REL, "F:/bmp_leveling1.bin");
-  lv_imgbtn_set_src(buttonPoint1, LV_BTN_STATE_PR, "F:/bmp_leveling1.bin");
-  lv_imgbtn_set_style(buttonPoint1, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonPoint1, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonPoint1, "F:/bmp_leveling1.bin");
+  lv_imgbtn_use_label_style(buttonPoint1);
   lv_obj_clear_protect(buttonPoint1, LV_PROTECT_FOLLOW);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonPoint2, event_handler, ID_M_POINT2, NULL, 0);
-    lv_imgbtn_set_src(buttonPoint2, LV_BTN_STATE_REL, "F:/bmp_leveling2.bin");
-    lv_imgbtn_set_src(buttonPoint2, LV_BTN_STATE_PR, "F:/bmp_leveling2.bin");
-    lv_imgbtn_set_style(buttonPoint2, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonPoint2, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonPoint2, "F:/bmp_leveling2.bin");
+    lv_imgbtn_use_label_style(buttonPoint2);
 
     lv_obj_set_event_cb_mks(buttonPoint3, event_handler, ID_M_POINT3, NULL, 0);
-    lv_imgbtn_set_src(buttonPoint3, LV_BTN_STATE_REL, "F:/bmp_leveling3.bin");
-    lv_imgbtn_set_src(buttonPoint3, LV_BTN_STATE_PR, "F:/bmp_leveling3.bin");
-    lv_imgbtn_set_style(buttonPoint3, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonPoint3, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonPoint3, "F:/bmp_leveling3.bin");
+    lv_imgbtn_use_label_style(buttonPoint3);
 
     lv_obj_set_event_cb_mks(buttonPoint4, event_handler, ID_M_POINT4, NULL, 0);
-    lv_imgbtn_set_src(buttonPoint4, LV_BTN_STATE_REL, "F:/bmp_leveling4.bin");
-    lv_imgbtn_set_src(buttonPoint4, LV_BTN_STATE_PR, "F:/bmp_leveling4.bin");
-    lv_imgbtn_set_style(buttonPoint4, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonPoint4, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonPoint4, "F:/bmp_leveling4.bin");
+    lv_imgbtn_use_label_style(buttonPoint4);
 
     lv_obj_set_event_cb_mks(buttonPoint5, event_handler, ID_M_POINT5, NULL, 0);
-    lv_imgbtn_set_src(buttonPoint5, LV_BTN_STATE_REL, "F:/bmp_leveling5.bin");
-    lv_imgbtn_set_src(buttonPoint5, LV_BTN_STATE_PR, "F:/bmp_leveling5.bin");
-    lv_imgbtn_set_style(buttonPoint5, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonPoint5, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonPoint5, "F:/bmp_leveling5.bin");
+    lv_imgbtn_use_label_style(buttonPoint5);
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_MANUAL_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
   #endif
 
   lv_obj_set_pos(buttonPoint1, INTERVAL_V, titleHeight);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_manual_level_pos_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_manual_level_pos_settings.cpp
@@ -213,76 +213,44 @@ void lv_draw_manual_level_pos_settings(void) {
   if (uiCfg.para_ui_page != 1) {
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, leveling_menu.position1);
 
-    buttonX1Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonX1Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonX1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonX1Value, event_handler, ID_MANUAL_POS_X1, NULL, 0);
-    lv_btn_set_style_both(buttonX1Value, &style_para_value);
-    labelX1Value = lv_label_create(buttonX1Value, NULL);
+    buttonX1Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_X1);
+    labelX1Value = lv_label_create_empty(buttonX1Value);
 
-    buttonY1Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonY1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonY1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonY1Value, event_handler, ID_MANUAL_POS_Y1, NULL, 0);
-    lv_btn_set_style_both(buttonY1Value, &style_para_value);
-    labelY1Value = lv_label_create(buttonY1Value, NULL);
+    buttonY1Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_Y1);
+    labelY1Value = lv_label_create_empty(buttonY1Value);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, leveling_menu.position2);
 
-    buttonX2Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonX2Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonX2Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonX2Value, event_handler, ID_MANUAL_POS_X2, NULL, 0);
-    lv_btn_set_style_both(buttonX2Value, &style_para_value);
-    labelX2Value = lv_label_create(buttonX2Value, NULL);
+    buttonX2Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_X2);
+    labelX2Value = lv_label_create_empty(buttonX2Value);
 
-    buttonY2Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonY2Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonY2Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonY2Value, event_handler, ID_MANUAL_POS_Y2, NULL, 0);
-    lv_btn_set_style_both(buttonY2Value, &style_para_value);
-    labelY2Value = lv_label_create(buttonY2Value, NULL);
+    buttonY2Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_Y2);
+    labelY2Value = lv_label_create_empty(buttonY2Value);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, leveling_menu.position3);
 
-    buttonX3Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonX3Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonX3Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonX3Value, event_handler, ID_MANUAL_POS_X3, NULL, 0);
-    lv_btn_set_style_both(buttonX3Value, &style_para_value);
-    labelX3Value = lv_label_create(buttonX3Value, NULL);
+    buttonX3Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_X3);
+    labelX3Value = lv_label_create_empty(buttonX3Value);
 
-    buttonY3Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonY3Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonY3Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonY3Value, event_handler, ID_MANUAL_POS_Y3, NULL, 0);
-    lv_btn_set_style_both(buttonY3Value, &style_para_value);
-    labelY3Value = lv_label_create(buttonY3Value, NULL);
+    buttonY3Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_Y3);
+    labelY3Value = lv_label_create_empty(buttonY3Value);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, leveling_menu.position4);
 
-    buttonX4Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonX4Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonX4Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonX4Value, event_handler, ID_MANUAL_POS_X4, NULL, 0);
-    lv_btn_set_style_both(buttonX4Value, &style_para_value);
-    labelX4Value = lv_label_create(buttonX4Value, NULL);
+    buttonX4Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_X4);
+    labelX4Value = lv_label_create_empty(buttonX4Value);
 
-    buttonY4Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonY4Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonY4Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonY4Value, event_handler, ID_MANUAL_POS_Y4, NULL, 0);
-    lv_btn_set_style_both(buttonY4Value, &style_para_value);
-    labelY4Value = lv_label_create(buttonY4Value, NULL);
+    buttonY4Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_Y4);
+    labelY4Value = lv_label_create_empty(buttonY4Value);
 
     line4 = lv_line_create(scr, NULL);
     lv_ex_line(line4, line_points[3]);
@@ -308,19 +276,11 @@ void lv_draw_manual_level_pos_settings(void) {
   else {
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, leveling_menu.position5);
 
-    buttonX5Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonX5Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonX5Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonX5Value, event_handler, ID_MANUAL_POS_X5, NULL, 0);
-    lv_btn_set_style_both(buttonX5Value, &style_para_value);
-    labelX5Value = lv_label_create(buttonX5Value, NULL);
+    buttonX5Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_X5);
+    labelX5Value = lv_label_create_empty(buttonX5Value);
 
-    buttonY5Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonY5Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
-    lv_obj_set_size(buttonY5Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonY5Value, event_handler, ID_MANUAL_POS_Y5, NULL, 0);
-    lv_btn_set_style_both(buttonY5Value, &style_para_value);
-    labelY5Value = lv_label_create(buttonY5Value, NULL);
+    buttonY5Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_MANUAL_POS_Y5);
+    labelY5Value = lv_label_create_empty(buttonY5Value);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
@@ -340,14 +300,14 @@ void lv_draw_manual_level_pos_settings(void) {
 
   lv_obj_set_pos(buttonTurnPage, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
   lv_obj_set_size(buttonTurnPage, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  labelTurnPage = lv_label_create(buttonTurnPage, NULL);
+  labelTurnPage = lv_label_create_empty(buttonTurnPage);
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_MANUAL_POS_RETURN, NULL, 0);
   lv_btn_set_style_both(buttonBack, &style_para_back);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_manual_level_pos_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_manual_level_pos_settings.cpp
@@ -183,15 +183,15 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_manual_level_pos_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL, *buttonTurnPage = NULL, *labelTurnPage = NULL;
-  lv_obj_t *labelPoint1Text = NULL, *buttonX1Value = NULL, *labelX1Value = NULL;
+  lv_obj_t *buttonX1Value = NULL, *labelX1Value = NULL;
   lv_obj_t *buttonY1Value = NULL, *labelY1Value = NULL;
-  lv_obj_t *labelPoint2Text = NULL, *buttonX2Value = NULL, *labelX2Value = NULL;
+  lv_obj_t *buttonX2Value = NULL, *labelX2Value = NULL;
   lv_obj_t *buttonY2Value = NULL, *labelY2Value = NULL;
-  lv_obj_t *labelPoint3Text = NULL, *buttonX3Value = NULL, *labelX3Value = NULL;
+  lv_obj_t *buttonX3Value = NULL, *labelX3Value = NULL;
   lv_obj_t *buttonY3Value = NULL, *labelY3Value = NULL;
-  lv_obj_t *labelPoint4Text = NULL, *buttonX4Value = NULL, *labelX4Value = NULL;
+  lv_obj_t *buttonX4Value = NULL, *labelX4Value = NULL;
   lv_obj_t *buttonY4Value = NULL, *labelY4Value = NULL;
-  lv_obj_t *labelPoint5Text = NULL, *buttonX5Value = NULL, *labelX5Value = NULL;
+  lv_obj_t *buttonX5Value = NULL, *labelX5Value = NULL;
   lv_obj_t *buttonY5Value = NULL, *labelY5Value = NULL;
   lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL, * line4 = NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != MANUAL_LEVELING_POSIGION_UI) {
@@ -206,105 +206,82 @@ void lv_draw_manual_level_pos_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.LevelingParaConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.LevelingParaConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   if (uiCfg.para_ui_page != 1) {
-    labelPoint1Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelPoint1Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelPoint1Text, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelPoint1Text, leveling_menu.position1);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, leveling_menu.position1);
 
     buttonX1Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonX1Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonX1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonX1Value, event_handler, ID_MANUAL_POS_X1, NULL, 0);
-    lv_btn_set_style(buttonX1Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonX1Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonX1Value, &style_para_value);
     labelX1Value = lv_label_create(buttonX1Value, NULL);
 
     buttonY1Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonY1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonY1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonY1Value, event_handler, ID_MANUAL_POS_Y1, NULL, 0);
-    lv_btn_set_style(buttonY1Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonY1Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonY1Value, &style_para_value);
     labelY1Value = lv_label_create(buttonY1Value, NULL);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    labelPoint2Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelPoint2Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelPoint2Text, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-    lv_label_set_text(labelPoint2Text, leveling_menu.position2);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, leveling_menu.position2);
 
     buttonX2Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonX2Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonX2Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonX2Value, event_handler, ID_MANUAL_POS_X2, NULL, 0);
-    lv_btn_set_style(buttonX2Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonX2Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonX2Value, &style_para_value);
     labelX2Value = lv_label_create(buttonX2Value, NULL);
 
     buttonY2Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonY2Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonY2Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonY2Value, event_handler, ID_MANUAL_POS_Y2, NULL, 0);
-    lv_btn_set_style(buttonY2Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonY2Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonY2Value, &style_para_value);
     labelY2Value = lv_label_create(buttonY2Value, NULL);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    labelPoint3Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelPoint3Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelPoint3Text, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-    lv_label_set_text(labelPoint3Text, leveling_menu.position3);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, leveling_menu.position3);
 
     buttonX3Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonX3Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonX3Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonX3Value, event_handler, ID_MANUAL_POS_X3, NULL, 0);
-    lv_btn_set_style(buttonX3Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonX3Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonX3Value, &style_para_value);
     labelX3Value = lv_label_create(buttonX3Value, NULL);
 
     buttonY3Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonY3Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonY3Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonY3Value, event_handler, ID_MANUAL_POS_Y3, NULL, 0);
-    lv_btn_set_style(buttonY3Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonY3Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonY3Value, &style_para_value);
     labelY3Value = lv_label_create(buttonY3Value, NULL);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    labelPoint4Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelPoint4Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelPoint4Text, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-    lv_label_set_text(labelPoint4Text, leveling_menu.position4);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, leveling_menu.position4);
 
     buttonX4Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonX4Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonX4Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonX4Value, event_handler, ID_MANUAL_POS_X4, NULL, 0);
-    lv_btn_set_style(buttonX4Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonX4Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonX4Value, &style_para_value);
     labelX4Value = lv_label_create(buttonX4Value, NULL);
 
     buttonY4Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonY4Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonY4Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonY4Value, event_handler, ID_MANUAL_POS_Y4, NULL, 0);
-    lv_btn_set_style(buttonY4Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonY4Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonY4Value, &style_para_value);
     labelY4Value = lv_label_create(buttonY4Value, NULL);
 
     line4 = lv_line_create(scr, NULL);
@@ -312,8 +289,7 @@ void lv_draw_manual_level_pos_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_MANUAL_POS_DOWN, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -330,25 +306,20 @@ void lv_draw_manual_level_pos_settings(void) {
     #endif
   }
   else {
-    labelPoint5Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelPoint5Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelPoint5Text, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelPoint5Text, leveling_menu.position5);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, leveling_menu.position5);
 
     buttonX5Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonX5Value, PARA_UI_VALUE_POS_X_2, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonX5Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonX5Value, event_handler, ID_MANUAL_POS_X5, NULL, 0);
-    lv_btn_set_style(buttonX5Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonX5Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonX5Value, &style_para_value);
     labelX5Value = lv_label_create(buttonX5Value, NULL);
 
     buttonY5Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonY5Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V_2);
     lv_obj_set_size(buttonY5Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonY5Value, event_handler, ID_MANUAL_POS_Y5, NULL, 0);
-    lv_btn_set_style(buttonY5Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonY5Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonY5Value, &style_para_value);
     labelY5Value = lv_label_create(buttonY5Value, NULL);
 
     line1 = lv_line_create(scr, NULL);
@@ -356,8 +327,7 @@ void lv_draw_manual_level_pos_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_MANUAL_POS_UP, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -374,8 +344,7 @@ void lv_draw_manual_level_pos_settings(void) {
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_MANUAL_POS_RETURN, NULL, 0);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   label_Back = lv_label_create(buttonBack, NULL);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_max_feedrate_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_max_feedrate_settings.cpp
@@ -128,12 +128,12 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_max_feedrate_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL, *buttonTurnPage = NULL, *labelTurnPage = NULL;
-  lv_obj_t *labelXText = NULL, *buttonXValue = NULL, *labelXValue = NULL;
-  lv_obj_t *labelYText = NULL, *buttonYValue = NULL, *labelYValue = NULL;
-  lv_obj_t *labelZText = NULL, *buttonZValue = NULL, *labelZValue = NULL;
-  lv_obj_t *labelE0Text = NULL, *buttonE0Value = NULL, *labelE0Value = NULL;
-  lv_obj_t *labelE1Text = NULL, *buttonE1Value = NULL, *labelE1Value = NULL;
-  lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL, * line4 = NULL;
+  lv_obj_t *buttonXValue = NULL, *labelXValue = NULL;
+  lv_obj_t *buttonYValue = NULL, *labelYValue = NULL;
+  lv_obj_t *buttonZValue = NULL, *labelZValue = NULL;
+  lv_obj_t *buttonE0Value = NULL, *labelE0Value = NULL;
+  lv_obj_t *buttonE1Value = NULL, *labelE1Value = NULL;
+  lv_obj_t *line1 = NULL, *line2 = NULL, *line3 = NULL, *line4 = NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != MAXFEEDRATE_UI) {
     disp_state_stack._disp_index++;
     disp_state_stack._disp_state[disp_state_stack._disp_index] = MAXFEEDRATE_UI;
@@ -146,76 +146,57 @@ void lv_draw_max_feedrate_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.MaxFeedRateConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.MaxFeedRateConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   if (uiCfg.para_ui_page != 1) {
-    labelXText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelXText, &tft_style_label_rel);
-    lv_obj_set_pos(labelXText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelXText, machine_menu.XMaxFeedRate);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.XMaxFeedRate);
 
     buttonXValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_FEED_X, NULL, 0);
-    lv_btn_set_style(buttonXValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonXValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonXValue, &style_para_value);
     lv_btn_set_layout(buttonXValue, LV_LAYOUT_OFF);
     labelXValue = lv_label_create(buttonXValue, NULL);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    labelYText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelYText, &tft_style_label_rel);
-    lv_obj_set_pos(labelYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-    lv_label_set_text(labelYText, machine_menu.YMaxFeedRate);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.YMaxFeedRate);
 
     buttonYValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_FEED_Y, NULL, 0);
-    lv_btn_set_style(buttonYValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonYValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonYValue, &style_para_value);
     lv_btn_set_layout(buttonYValue, LV_LAYOUT_OFF);
     labelYValue = lv_label_create(buttonYValue, NULL);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    labelZText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelZText, &tft_style_label_rel);
-    lv_obj_set_pos(labelZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-    lv_label_set_text(labelZText, machine_menu.ZMaxFeedRate);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.ZMaxFeedRate);
 
     buttonZValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_FEED_Z, NULL, 0);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonZValue, &style_para_value);
     lv_btn_set_layout(buttonZValue, LV_LAYOUT_OFF);
     labelZValue = lv_label_create(buttonZValue, NULL);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    labelE0Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelE0Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelE0Text, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-    lv_label_set_text(labelE0Text, machine_menu.E0MaxFeedRate);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E0MaxFeedRate);
 
     buttonE0Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonE0Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonE0Value, event_handler, ID_FEED_E0, NULL, 0);
-    lv_btn_set_style(buttonE0Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonE0Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonE0Value, &style_para_value);
     lv_btn_set_layout(buttonE0Value, LV_LAYOUT_OFF);
     labelE0Value = lv_label_create(buttonE0Value, NULL);
 
@@ -224,8 +205,7 @@ void lv_draw_max_feedrate_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_FEED_DOWN, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -238,17 +218,13 @@ void lv_draw_max_feedrate_settings(void) {
     #endif
   }
   else {
-    labelE1Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelE1Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelE1Text, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelE1Text, machine_menu.E1MaxFeedRate);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.E1MaxFeedRate);
 
     buttonE1Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonE1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonE1Value, event_handler, ID_FEED_E1, NULL, 0);
-    lv_btn_set_style(buttonE1Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonE1Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonE1Value, &style_para_value);
     lv_btn_set_layout(buttonE1Value, LV_LAYOUT_OFF);
     labelE1Value = lv_label_create(buttonE1Value, NULL);
 
@@ -258,8 +234,7 @@ void lv_draw_max_feedrate_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_FEED_UP, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -277,8 +252,7 @@ void lv_draw_max_feedrate_settings(void) {
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_FEED_RETURN, NULL, 0);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
   label_Back = lv_label_create(buttonBack, NULL);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_max_feedrate_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_max_feedrate_settings.cpp
@@ -153,52 +153,36 @@ void lv_draw_max_feedrate_settings(void) {
   if (uiCfg.para_ui_page != 1) {
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.XMaxFeedRate);
 
-    buttonXValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_FEED_X, NULL, 0);
-    lv_btn_set_style_both(buttonXValue, &style_para_value);
+    buttonXValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FEED_X);
     lv_btn_set_layout(buttonXValue, LV_LAYOUT_OFF);
-    labelXValue = lv_label_create(buttonXValue, NULL);
+    labelXValue = lv_label_create_empty(buttonXValue);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.YMaxFeedRate);
 
-    buttonYValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_FEED_Y, NULL, 0);
-    lv_btn_set_style_both(buttonYValue, &style_para_value);
+    buttonYValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FEED_Y);
     lv_btn_set_layout(buttonYValue, LV_LAYOUT_OFF);
-    labelYValue = lv_label_create(buttonYValue, NULL);
+    labelYValue = lv_label_create_empty(buttonYValue);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.ZMaxFeedRate);
 
-    buttonZValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_FEED_Z, NULL, 0);
-    lv_btn_set_style_both(buttonZValue, &style_para_value);
+    buttonZValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FEED_Z);
     lv_btn_set_layout(buttonZValue, LV_LAYOUT_OFF);
-    labelZValue = lv_label_create(buttonZValue, NULL);
+    labelZValue = lv_label_create_empty(buttonZValue);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E0MaxFeedRate);
 
-    buttonE0Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonE0Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonE0Value, event_handler, ID_FEED_E0, NULL, 0);
-    lv_btn_set_style_both(buttonE0Value, &style_para_value);
+    buttonE0Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FEED_E0);
     lv_btn_set_layout(buttonE0Value, LV_LAYOUT_OFF);
-    labelE0Value = lv_label_create(buttonE0Value, NULL);
+    labelE0Value = lv_label_create_empty(buttonE0Value);
 
     line4 = lv_line_create(scr, NULL);
     lv_ex_line(line4, line_points[3]);
@@ -220,13 +204,9 @@ void lv_draw_max_feedrate_settings(void) {
   else {
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.E1MaxFeedRate);
 
-    buttonE1Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonE1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonE1Value, event_handler, ID_FEED_E1, NULL, 0);
-    lv_btn_set_style_both(buttonE1Value, &style_para_value);
+    buttonE1Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_FEED_E1);
     lv_btn_set_layout(buttonE1Value, LV_LAYOUT_OFF);
-    labelE1Value = lv_label_create(buttonE1Value, NULL);
+    labelE1Value = lv_label_create_empty(buttonE1Value);
 
 
     line1 = lv_line_create(scr, NULL);
@@ -246,14 +226,14 @@ void lv_draw_max_feedrate_settings(void) {
 
   lv_obj_set_pos(buttonTurnPage, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
   lv_obj_set_size(buttonTurnPage, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  labelTurnPage = lv_label_create(buttonTurnPage, NULL);
+  labelTurnPage = lv_label_create_empty(buttonTurnPage);
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_FEED_RETURN, NULL, 0);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   lv_btn_set_style_both(buttonBack, &style_para_back);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_motor_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_motor_settings.cpp
@@ -169,10 +169,7 @@ void lv_draw_motor_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.MotorConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.MotorConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -181,8 +178,7 @@ void lv_draw_motor_settings(void) {
   lv_obj_set_size(buttonSteps, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
   //lv_obj_set_event_cb(buttonMachine, event_handler);
   lv_obj_set_event_cb_mks(buttonSteps, event_handler, ID_MOTOR_STEPS, NULL, 0);
-  lv_btn_set_style(buttonSteps, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-  lv_btn_set_style(buttonSteps, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+  lv_btn_use_label_style(buttonSteps);
   lv_btn_set_layout(buttonSteps, LV_LAYOUT_OFF);
   labelSteps = lv_label_create(buttonSteps, NULL);                        /*Add a label to the button*/
 
@@ -193,10 +189,8 @@ void lv_draw_motor_settings(void) {
   buttonStepsNarrow = lv_imgbtn_create(scr, NULL);
   lv_obj_set_pos(buttonStepsNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
   lv_obj_set_event_cb_mks(buttonStepsNarrow, event_handler, ID_MOTOR_STEPS_ARROW, NULL, 0);
-  lv_imgbtn_set_src(buttonStepsNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_src(buttonStepsNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-  lv_imgbtn_set_style(buttonStepsNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonStepsNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonStepsNarrow, "F:/bmp_arrow.bin");
+  lv_imgbtn_use_label_style(buttonStepsNarrow);
   lv_btn_set_layout(buttonStepsNarrow, LV_LAYOUT_OFF);
 
   line1 = lv_line_create(scr, NULL);
@@ -208,8 +202,7 @@ void lv_draw_motor_settings(void) {
     lv_obj_set_size(buttonSensitivity, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
     //lv_obj_set_event_cb(buttonMachine, event_handler);
     lv_obj_set_event_cb_mks(buttonSensitivity, event_handler, ID_HOME_SENSE, NULL, 0);
-    lv_btn_set_style(buttonSensitivity, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-    lv_btn_set_style(buttonSensitivity, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+    lv_btn_use_label_style(buttonSensitivity);
     lv_btn_set_layout(buttonSensitivity, LV_LAYOUT_OFF);
     labelSensitivity = lv_label_create(buttonSensitivity, NULL);                  /*Add a label to the button*/
 
@@ -220,10 +213,8 @@ void lv_draw_motor_settings(void) {
     buttonSensitivityNarrow = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonSensitivityNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
     lv_obj_set_event_cb_mks(buttonSensitivityNarrow, event_handler, ID_HOME_SENSE_ARROW, NULL, 0);
-    lv_imgbtn_set_src(buttonSensitivityNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_src(buttonSensitivityNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_style(buttonSensitivityNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonSensitivityNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonSensitivityNarrow, "F:/bmp_arrow.bin");
+    lv_imgbtn_use_label_style(buttonSensitivityNarrow);
     lv_btn_set_layout(buttonSensitivityNarrow, LV_LAYOUT_OFF);
 
     line2 = lv_line_create(scr, NULL);
@@ -237,8 +228,7 @@ void lv_draw_motor_settings(void) {
     lv_obj_set_size(buttonTMCcurrent, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);          /*Set its size*/
     //lv_obj_set_event_cb(buttonMachine, event_handler);
     lv_obj_set_event_cb_mks(buttonTMCcurrent, event_handler, ID_MOTOR_TMC_CURRENT, NULL, 0);
-    lv_btn_set_style(buttonTMCcurrent, LV_BTN_STYLE_REL, &tft_style_label_rel); /*Set the button's released style*/
-    lv_btn_set_style(buttonTMCcurrent, LV_BTN_STYLE_PR, &tft_style_label_pre);  /*Set the button's pressed style*/
+    lv_btn_use_label_style(buttonTMCcurrent);
     lv_btn_set_layout(buttonTMCcurrent, LV_LAYOUT_OFF);
     labelTMCcurrent = lv_label_create(buttonTMCcurrent, NULL);                  /*Add a label to the button*/
     #if HAS_ROTARY_ENCODER
@@ -248,10 +238,8 @@ void lv_draw_motor_settings(void) {
     buttonTMCcurrentNarrow = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonTMCcurrentNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 3, PARA_UI_POS_Y * 2) + PARA_UI_ARROW_V);
     lv_obj_set_event_cb_mks(buttonTMCcurrentNarrow, event_handler, ID_MOTOR_TMC_CURRENT_ARROW, NULL, 0);
-    lv_imgbtn_set_src(buttonTMCcurrentNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_src(buttonTMCcurrentNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-    lv_imgbtn_set_style(buttonTMCcurrentNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonTMCcurrentNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonTMCcurrentNarrow, "F:/bmp_arrow.bin");
+    lv_imgbtn_use_label_style(buttonTMCcurrentNarrow);
     lv_btn_set_layout(buttonTMCcurrentNarrow, LV_LAYOUT_OFF);
     #if USE_SENSORLESS
       line3 = lv_line_create(scr, NULL);
@@ -266,8 +254,7 @@ void lv_draw_motor_settings(void) {
       lv_obj_set_pos(buttonStepMode, PARA_UI_POS_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 4, PARA_UI_POS_Y * 3));
       lv_obj_set_size(buttonStepMode, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);          /*Set its size*/
       lv_obj_set_event_cb_mks(buttonStepMode, event_handler, ID_MOTOR_STEP_MODE, NULL, 0);
-      lv_btn_set_style(buttonStepMode, LV_BTN_STYLE_REL, &tft_style_label_rel); /*Set the button's released style*/
-      lv_btn_set_style(buttonStepMode, LV_BTN_STYLE_PR, &tft_style_label_pre);  /*Set the button's pressed style*/
+      lv_btn_use_label_style(buttonStepMode);
       lv_btn_set_layout(buttonStepMode, LV_LAYOUT_OFF);
       labelStepMode = lv_label_create(buttonStepMode, NULL);                    /*Add a label to the button*/
 
@@ -278,10 +265,8 @@ void lv_draw_motor_settings(void) {
       buttonStepModeNarrow = lv_imgbtn_create(scr, NULL);
       lv_obj_set_pos(buttonStepModeNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 4, PARA_UI_POS_Y * 3) + PARA_UI_ARROW_V);
       lv_obj_set_event_cb_mks(buttonStepModeNarrow, event_handler, ID_MOTOR_STEP_MODE_ARROW, NULL, 0);
-      lv_imgbtn_set_src(buttonStepModeNarrow, LV_BTN_STATE_REL, "F:/bmp_arrow.bin");
-      lv_imgbtn_set_src(buttonStepModeNarrow, LV_BTN_STATE_PR, "F:/bmp_arrow.bin");
-      lv_imgbtn_set_style(buttonStepModeNarrow, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonStepModeNarrow, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonStepModeNarrow, "F:/bmp_arrow.bin");
+      lv_imgbtn_use_label_style(buttonStepModeNarrow);
       lv_btn_set_layout(buttonStepModeNarrow, LV_LAYOUT_OFF);
 
       #if USE_SENSORLESS
@@ -298,10 +283,8 @@ void lv_draw_motor_settings(void) {
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_MOTOR_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
   label_Back = lv_label_create(buttonBack, NULL);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_motor_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_motor_settings.cpp
@@ -180,42 +180,27 @@ void lv_draw_motor_settings(void) {
   lv_obj_set_event_cb_mks(buttonSteps, event_handler, ID_MOTOR_STEPS, NULL, 0);
   lv_btn_use_label_style(buttonSteps);
   lv_btn_set_layout(buttonSteps, LV_LAYOUT_OFF);
-  labelSteps = lv_label_create(buttonSteps, NULL);                        /*Add a label to the button*/
+  labelSteps = lv_label_create_empty(buttonSteps);                        /*Add a label to the button*/
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonSteps);
   #endif
 
-  buttonStepsNarrow = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonStepsNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V);
-  lv_obj_set_event_cb_mks(buttonStepsNarrow, event_handler, ID_MOTOR_STEPS_ARROW, NULL, 0);
-  lv_imgbtn_set_src_both(buttonStepsNarrow, "F:/bmp_arrow.bin");
-  lv_imgbtn_use_label_style(buttonStepsNarrow);
-  lv_btn_set_layout(buttonStepsNarrow, LV_LAYOUT_OFF);
+  buttonStepsNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y + PARA_UI_ARROW_V, event_handler, ID_MOTOR_STEPS_ARROW);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
   #if USE_SENSORLESS
-    buttonSensitivity = lv_btn_create(scr, NULL);                                 /*Add a button the current screen*/
-    lv_obj_set_pos(buttonSensitivity, PARA_UI_POS_X, PARA_UI_POS_Y * 2);          /*Set its position*/
-    lv_obj_set_size(buttonSensitivity, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);           /*Set its size*/
+    buttonSensitivity = lv_btn_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2, PARA_UI_SIZE_X, PARA_UI_SIZE_Y, event_handler, ID_HOME_SENSE);
     //lv_obj_set_event_cb(buttonMachine, event_handler);
-    lv_obj_set_event_cb_mks(buttonSensitivity, event_handler, ID_HOME_SENSE, NULL, 0);
-    lv_btn_use_label_style(buttonSensitivity);
-    lv_btn_set_layout(buttonSensitivity, LV_LAYOUT_OFF);
-    labelSensitivity = lv_label_create(buttonSensitivity, NULL);                  /*Add a label to the button*/
+    labelSensitivity = lv_label_create_empty(buttonSensitivity);                  /*Add a label to the button*/
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonSensitivity);
     #endif
 
-    buttonSensitivityNarrow = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonSensitivityNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V);
-    lv_obj_set_event_cb_mks(buttonSensitivityNarrow, event_handler, ID_HOME_SENSE_ARROW, NULL, 0);
-    lv_imgbtn_set_src_both(buttonSensitivityNarrow, "F:/bmp_arrow.bin");
-    lv_imgbtn_use_label_style(buttonSensitivityNarrow);
-    lv_btn_set_layout(buttonSensitivityNarrow, LV_LAYOUT_OFF);
+    buttonSensitivityNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, PARA_UI_POS_Y * 2 + PARA_UI_ARROW_V, event_handler, ID_HOME_SENSE_ARROW);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
@@ -230,17 +215,13 @@ void lv_draw_motor_settings(void) {
     lv_obj_set_event_cb_mks(buttonTMCcurrent, event_handler, ID_MOTOR_TMC_CURRENT, NULL, 0);
     lv_btn_use_label_style(buttonTMCcurrent);
     lv_btn_set_layout(buttonTMCcurrent, LV_LAYOUT_OFF);
-    labelTMCcurrent = lv_label_create(buttonTMCcurrent, NULL);                  /*Add a label to the button*/
+    labelTMCcurrent = lv_label_create_empty(buttonTMCcurrent);                  /*Add a label to the button*/
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonTMCcurrent);
     #endif
 
-    buttonTMCcurrentNarrow = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonTMCcurrentNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 3, PARA_UI_POS_Y * 2) + PARA_UI_ARROW_V);
-    lv_obj_set_event_cb_mks(buttonTMCcurrentNarrow, event_handler, ID_MOTOR_TMC_CURRENT_ARROW, NULL, 0);
-    lv_imgbtn_set_src_both(buttonTMCcurrentNarrow, "F:/bmp_arrow.bin");
-    lv_imgbtn_use_label_style(buttonTMCcurrentNarrow);
-    lv_btn_set_layout(buttonTMCcurrentNarrow, LV_LAYOUT_OFF);
+    buttonTMCcurrentNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 3, PARA_UI_POS_Y * 2) + PARA_UI_ARROW_V, event_handler, ID_MOTOR_TMC_CURRENT_ARROW);
+
     #if USE_SENSORLESS
       line3 = lv_line_create(scr, NULL);
       lv_ex_line(line3, line_points[2]);
@@ -250,24 +231,14 @@ void lv_draw_motor_settings(void) {
     #endif
 
     #if HAS_STEALTHCHOP
-      buttonStepMode = lv_btn_create(scr, NULL);                                /*Add a button the current screen*/
-      lv_obj_set_pos(buttonStepMode, PARA_UI_POS_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 4, PARA_UI_POS_Y * 3));
-      lv_obj_set_size(buttonStepMode, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);          /*Set its size*/
-      lv_obj_set_event_cb_mks(buttonStepMode, event_handler, ID_MOTOR_STEP_MODE, NULL, 0);
-      lv_btn_use_label_style(buttonStepMode);
-      lv_btn_set_layout(buttonStepMode, LV_LAYOUT_OFF);
-      labelStepMode = lv_label_create(buttonStepMode, NULL);                    /*Add a label to the button*/
+      buttonStepMode = lv_btn_create(scr, NULL, PARA_UI_POS_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 4, PARA_UI_POS_Y * 3), PARA_UI_SIZE_X, PARA_UI_SIZE_Y, event_handler, ID_MOTOR_STEP_MODE);
+      labelStepMode = lv_label_create_empty(buttonStepMode);                    /*Add a label to the button*/
 
       #if HAS_ROTARY_ENCODER
         if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonStepMode);
       #endif
 
-      buttonStepModeNarrow = lv_imgbtn_create(scr, NULL);
-      lv_obj_set_pos(buttonStepModeNarrow, PARA_UI_POS_X + PARA_UI_SIZE_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 4, PARA_UI_POS_Y * 3) + PARA_UI_ARROW_V);
-      lv_obj_set_event_cb_mks(buttonStepModeNarrow, event_handler, ID_MOTOR_STEP_MODE_ARROW, NULL, 0);
-      lv_imgbtn_set_src_both(buttonStepModeNarrow, "F:/bmp_arrow.bin");
-      lv_imgbtn_use_label_style(buttonStepModeNarrow);
-      lv_btn_set_layout(buttonStepModeNarrow, LV_LAYOUT_OFF);
+      buttonStepModeNarrow = lv_imgbtn_create(scr, "F:/bmp_arrow.bin", PARA_UI_POS_X + PARA_UI_SIZE_X, TERN(USE_SENSORLESS, PARA_UI_POS_Y * 4, PARA_UI_POS_Y * 3) + PARA_UI_ARROW_V, event_handler, ID_MOTOR_STEP_MODE_ARROW);
 
       #if USE_SENSORLESS
         line4 = lv_line_create(scr, NULL);
@@ -281,13 +252,8 @@ void lv_draw_motor_settings(void) {
 
   #endif // HAS_TRINAMIC_CONFIG
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_MOTOR_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, event_handler, ID_MOTOR_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_move_motor.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_move_motor.cpp
@@ -179,77 +179,28 @@ void lv_draw_move_motor(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonXI   = lv_imgbtn_create(scr, NULL);
-  buttonXD   = lv_imgbtn_create(scr, NULL);
-  buttonYI   = lv_imgbtn_create(scr, NULL);
-  buttonYD   = lv_imgbtn_create(scr, NULL);
-  buttonZI   = lv_imgbtn_create(scr, NULL);
-  buttonZD   = lv_imgbtn_create(scr, NULL);
-  buttonV    = lv_imgbtn_create(scr, NULL);
-  buttonBack = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonXI, event_handler, ID_M_X_P, NULL, 0);
-  lv_imgbtn_set_src_both(buttonXI, "F:/bmp_xAdd.bin");
-  lv_imgbtn_use_label_style(buttonXI);
+  buttonXI = lv_imgbtn_create(scr, "F:/bmp_xAdd.bin", INTERVAL_V, titleHeight, event_handler, ID_M_X_P);
   lv_obj_clear_protect(buttonXI, LV_PROTECT_FOLLOW);
+  buttonXD = lv_imgbtn_create(scr, "F:/bmp_xDec.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_M_X_N);
+  buttonYI = lv_imgbtn_create(scr, "F:/bmp_yAdd.bin", BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_M_Y_P);
+  buttonYD = lv_imgbtn_create(scr, "F:/bmp_yDec.bin", BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_M_Y_N);
+  buttonZI = lv_imgbtn_create(scr, "F:/bmp_zAdd.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_M_Z_P);
+  buttonZD = lv_imgbtn_create(scr, "F:/bmp_zDec.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_M_Z_N);
 
-  #if 1
-    lv_obj_set_event_cb_mks(buttonXD, event_handler, ID_M_X_N, NULL, 0);
-    lv_imgbtn_set_src_both(buttonXD, "F:/bmp_xDec.bin");
-    lv_imgbtn_use_label_style(buttonXD);
+  buttonV = lv_imgbtn_create(scr, NULL, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_M_STEP);
+  //lv_obj_set_event_cb_mks(buttonV, event_handler,ID_T_MORE,"bmp_More.bin",0);
 
-    lv_obj_set_event_cb_mks(buttonYI, event_handler, ID_M_Y_P, NULL, 0);
-    lv_imgbtn_set_src_both(buttonYI, "F:/bmp_yAdd.bin");
-    lv_imgbtn_use_label_style(buttonYI);
-
-    lv_obj_set_event_cb_mks(buttonYD, event_handler, ID_M_Y_N, NULL, 0);
-    lv_imgbtn_set_src_both(buttonYD, "F:/bmp_yDec.bin");
-    lv_imgbtn_use_label_style(buttonYD);
-
-    lv_obj_set_event_cb_mks(buttonZI, event_handler, ID_M_Z_P, NULL, 0);
-    lv_imgbtn_set_src_both(buttonZI, "F:/bmp_zAdd.bin");
-    lv_imgbtn_use_label_style(buttonZI);
-
-    lv_obj_set_event_cb_mks(buttonZD, event_handler, ID_M_Z_N, NULL, 0);
-    lv_imgbtn_set_src_both(buttonZD, "F:/bmp_zDec.bin");
-    lv_imgbtn_use_label_style(buttonZD);
-
-    //lv_obj_set_event_cb_mks(buttonV, event_handler,ID_T_MORE,"bmp_More.bin",0);
-    lv_obj_set_event_cb_mks(buttonV, event_handler, ID_M_STEP, NULL, 0);
-    lv_imgbtn_use_label_style(buttonV);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_M_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-  #endif // if 1
-
-  lv_obj_set_pos(buttonXI, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonYI, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
-  lv_obj_set_pos(buttonZI, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
-  lv_obj_set_pos(buttonV, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonXD, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonYD, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonZD, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_M_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonXI, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonXD, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonYI, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonYD, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonZI, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonZD, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonV, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelXI = lv_label_create(buttonXI, NULL);
-  lv_obj_t *labelXD = lv_label_create(buttonXD, NULL);
-  lv_obj_t *labelYI = lv_label_create(buttonYI, NULL);
-  lv_obj_t *labelYD = lv_label_create(buttonYD, NULL);
-  lv_obj_t *labelZI = lv_label_create(buttonZI, NULL);
-  lv_obj_t *labelZD = lv_label_create(buttonZD, NULL);
-  labelV = lv_label_create(buttonV, NULL);
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelXI = lv_label_create_empty(buttonXI);
+  lv_obj_t *labelXD = lv_label_create_empty(buttonXD);
+  lv_obj_t *labelYI = lv_label_create_empty(buttonYI);
+  lv_obj_t *labelYD = lv_label_create_empty(buttonYD);
+  lv_obj_t *labelZI = lv_label_create_empty(buttonZI);
+  lv_obj_t *labelZD = lv_label_create_empty(buttonZD);
+  labelV = lv_label_create_empty(buttonV);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelXI, move_menu.x_add);
@@ -292,15 +243,13 @@ void lv_draw_move_motor(void) {
 void disp_move_dist() {
   // char buf[30] = {0};
 
-  if ((int)(10 * uiCfg.move_dist) == 1) {
+  if ((int)(10 * uiCfg.move_dist) == 1)
     lv_imgbtn_set_src_both(buttonV, "F:/bmp_step_move0_1.bin");
-  }
-  else if ((int)(10 * uiCfg.move_dist) == 10) {
+  else if ((int)(10 * uiCfg.move_dist) == 10)
     lv_imgbtn_set_src_both(buttonV, "F:/bmp_step_move1.bin");
-  }
-  else if ((int)(10 * uiCfg.move_dist) == 100) {
+  else if ((int)(10 * uiCfg.move_dist) == 100)
     lv_imgbtn_set_src_both(buttonV, "F:/bmp_step_move10.bin");
-  }
+
   if (gCfgItems.multiple_language) {
     if ((int)(10 * uiCfg.move_dist) == 1) {
       lv_label_set_text(labelV, move_menu.step_01mm);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_move_motor.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_move_motor.cpp
@@ -174,10 +174,7 @@ void lv_draw_move_motor(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -192,53 +189,38 @@ void lv_draw_move_motor(void) {
   buttonBack = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonXI, event_handler, ID_M_X_P, NULL, 0);
-  lv_imgbtn_set_src(buttonXI, LV_BTN_STATE_REL, "F:/bmp_xAdd.bin");
-  lv_imgbtn_set_src(buttonXI, LV_BTN_STATE_PR, "F:/bmp_xAdd.bin");
-  lv_imgbtn_set_style(buttonXI, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonXI, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonXI, "F:/bmp_xAdd.bin");
+  lv_imgbtn_use_label_style(buttonXI);
   lv_obj_clear_protect(buttonXI, LV_PROTECT_FOLLOW);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonXD, event_handler, ID_M_X_N, NULL, 0);
-    lv_imgbtn_set_src(buttonXD, LV_BTN_STATE_REL, "F:/bmp_xDec.bin");
-    lv_imgbtn_set_src(buttonXD, LV_BTN_STATE_PR, "F:/bmp_xDec.bin");
-    lv_imgbtn_set_style(buttonXD, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonXD, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonXD, "F:/bmp_xDec.bin");
+    lv_imgbtn_use_label_style(buttonXD);
 
     lv_obj_set_event_cb_mks(buttonYI, event_handler, ID_M_Y_P, NULL, 0);
-    lv_imgbtn_set_src(buttonYI, LV_BTN_STATE_REL, "F:/bmp_yAdd.bin");
-    lv_imgbtn_set_src(buttonYI, LV_BTN_STATE_PR, "F:/bmp_yAdd.bin");
-    lv_imgbtn_set_style(buttonYI, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonYI, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonYI, "F:/bmp_yAdd.bin");
+    lv_imgbtn_use_label_style(buttonYI);
 
     lv_obj_set_event_cb_mks(buttonYD, event_handler, ID_M_Y_N, NULL, 0);
-    lv_imgbtn_set_src(buttonYD, LV_BTN_STATE_REL, "F:/bmp_yDec.bin");
-    lv_imgbtn_set_src(buttonYD, LV_BTN_STATE_PR, "F:/bmp_yDec.bin");
-    lv_imgbtn_set_style(buttonYD, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonYD, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonYD, "F:/bmp_yDec.bin");
+    lv_imgbtn_use_label_style(buttonYD);
 
     lv_obj_set_event_cb_mks(buttonZI, event_handler, ID_M_Z_P, NULL, 0);
-    lv_imgbtn_set_src(buttonZI, LV_BTN_STATE_REL, "F:/bmp_zAdd.bin");
-    lv_imgbtn_set_src(buttonZI, LV_BTN_STATE_PR, "F:/bmp_zAdd.bin");
-    lv_imgbtn_set_style(buttonZI, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonZI, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonZI, "F:/bmp_zAdd.bin");
+    lv_imgbtn_use_label_style(buttonZI);
 
     lv_obj_set_event_cb_mks(buttonZD, event_handler, ID_M_Z_N, NULL, 0);
-    lv_imgbtn_set_src(buttonZD, LV_BTN_STATE_REL, "F:/bmp_zDec.bin");
-    lv_imgbtn_set_src(buttonZD, LV_BTN_STATE_PR, "F:/bmp_zDec.bin");
-    lv_imgbtn_set_style(buttonZD, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonZD, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonZD, "F:/bmp_zDec.bin");
+    lv_imgbtn_use_label_style(buttonZD);
 
     //lv_obj_set_event_cb_mks(buttonV, event_handler,ID_T_MORE,"bmp_More.bin",0);
     lv_obj_set_event_cb_mks(buttonV, event_handler, ID_M_STEP, NULL, 0);
-    lv_imgbtn_set_style(buttonV, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonV, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonV);
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_M_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
   #endif // if 1
 
   lv_obj_set_pos(buttonXI, INTERVAL_V, titleHeight);
@@ -311,16 +293,13 @@ void disp_move_dist() {
   // char buf[30] = {0};
 
   if ((int)(10 * uiCfg.move_dist) == 1) {
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_REL, "F:/bmp_step_move0_1.bin");
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_PR, "F:/bmp_step_move0_1.bin");
+    lv_imgbtn_set_src_both(buttonV, "F:/bmp_step_move0_1.bin");
   }
   else if ((int)(10 * uiCfg.move_dist) == 10) {
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_REL, "F:/bmp_step_move1.bin");
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_PR, "F:/bmp_step_move1.bin");
+    lv_imgbtn_set_src_both(buttonV, "F:/bmp_step_move1.bin");
   }
   else if ((int)(10 * uiCfg.move_dist) == 100) {
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_REL, "F:/bmp_step_move10.bin");
-    lv_imgbtn_set_src(buttonV, LV_BTN_STATE_PR, "F:/bmp_step_move10.bin");
+    lv_imgbtn_set_src_both(buttonV, "F:/bmp_step_move10.bin");
   }
   if (gCfgItems.multiple_language) {
     if ((int)(10 * uiCfg.move_dist) == 1) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_number_key.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_number_key.cpp
@@ -776,7 +776,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(buttonValue, LV_BTN_STYLE_REL, &style_num_text);     /*Set the button's released style*/
   lv_btn_set_style(buttonValue, LV_BTN_STYLE_PR, &style_num_text);      /*Set the button's pressed style*/
   //lv_btn_set_layout(buttonValue, LV_LAYOUT_OFF);
-  labelValue = lv_label_create(buttonValue, NULL);                      /*Add a label to the button*/
+  labelValue = lv_label_create_empty(buttonValue);                      /*Add a label to the button*/
 
   NumberKey_1 = lv_btn_create(scr, NULL);                               /*Add a button the current screen*/
   lv_obj_set_pos(NumberKey_1, 92, 90);                                  /*Set its position*/
@@ -785,7 +785,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_1, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_1, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_1, LV_LAYOUT_OFF);
-  labelKey_1 = lv_label_create(NumberKey_1, NULL);                      /*Add a label to the button*/
+  labelKey_1 = lv_label_create_empty(NumberKey_1);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_1, machine_menu.key_1);
   lv_obj_align(labelKey_1, NumberKey_1, LV_ALIGN_CENTER, 0, 0);
 
@@ -796,7 +796,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_2, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_2, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_2, LV_LAYOUT_OFF);
-  labelKey_2 = lv_label_create(NumberKey_2, NULL);                      /*Add a label to the button*/
+  labelKey_2 = lv_label_create_empty(NumberKey_2);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_2, machine_menu.key_2);
   lv_obj_align(labelKey_2, NumberKey_2, LV_ALIGN_CENTER, 0, 0);
 
@@ -807,7 +807,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_3, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_3, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_3, LV_LAYOUT_OFF);
-  labelKey_3 = lv_label_create(NumberKey_3, NULL);                      /*Add a label to the button*/
+  labelKey_3 = lv_label_create_empty(NumberKey_3);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_3, machine_menu.key_3);
   lv_obj_align(labelKey_3, NumberKey_3, LV_ALIGN_CENTER, 0, 0);
 
@@ -818,7 +818,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_4, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_4, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_4, LV_LAYOUT_OFF);
-  labelKey_4 = lv_label_create(NumberKey_4, NULL);                      /*Add a label to the button*/
+  labelKey_4 = lv_label_create_empty(NumberKey_4);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_4, machine_menu.key_4);
   lv_obj_align(labelKey_4, NumberKey_4, LV_ALIGN_CENTER, 0, 0);
 
@@ -829,7 +829,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_5, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_5, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_5, LV_LAYOUT_OFF);
-  labelKey_5 = lv_label_create(NumberKey_5, NULL);                      /*Add a label to the button*/
+  labelKey_5 = lv_label_create_empty(NumberKey_5);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_5, machine_menu.key_5);
   lv_obj_align(labelKey_5, NumberKey_5, LV_ALIGN_CENTER, 0, 0);
 
@@ -840,7 +840,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_6, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_6, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_6, LV_LAYOUT_OFF);
-  labelKey_6 = lv_label_create(NumberKey_6, NULL);                      /*Add a label to the button*/
+  labelKey_6 = lv_label_create_empty(NumberKey_6);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_6, machine_menu.key_6);
   lv_obj_align(labelKey_6, NumberKey_6, LV_ALIGN_CENTER, 0, 0);
 
@@ -851,7 +851,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_7, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_7, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_7, LV_LAYOUT_OFF);
-  labelKey_7 = lv_label_create(NumberKey_7, NULL);                      /*Add a label to the button*/
+  labelKey_7 = lv_label_create_empty(NumberKey_7);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_7, machine_menu.key_7);
   lv_obj_align(labelKey_7, NumberKey_7, LV_ALIGN_CENTER, 0, 0);
 
@@ -862,7 +862,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_8, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_8, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_8, LV_LAYOUT_OFF);
-  labelKey_8 = lv_label_create(NumberKey_8, NULL);                      /*Add a label to the button*/
+  labelKey_8 = lv_label_create_empty(NumberKey_8);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_8, machine_menu.key_8);
   lv_obj_align(labelKey_8, NumberKey_8, LV_ALIGN_CENTER, 0, 0);
 
@@ -873,7 +873,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_9, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_9, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_9, LV_LAYOUT_OFF);
-  labelKey_9 = lv_label_create(NumberKey_9, NULL);                      /*Add a label to the button*/
+  labelKey_9 = lv_label_create_empty(NumberKey_9);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_9, machine_menu.key_9);
   lv_obj_align(labelKey_9, NumberKey_9, LV_ALIGN_CENTER, 0, 0);
 
@@ -884,7 +884,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(NumberKey_0, LV_BTN_STYLE_REL, &style_num_key_pre);  /*Set the button's released style*/
   lv_btn_set_style(NumberKey_0, LV_BTN_STYLE_PR, &style_num_key_rel);   /*Set the button's pressed style*/
   //lv_btn_set_layout(NumberKey_0, LV_LAYOUT_OFF);
-  labelKey_0 = lv_label_create(NumberKey_0, NULL);                      /*Add a label to the button*/
+  labelKey_0 = lv_label_create_empty(NumberKey_0);                      /*Add a label to the button*/
   lv_label_set_text(labelKey_0, machine_menu.key_0);
   lv_obj_align(labelKey_0, NumberKey_0, LV_ALIGN_CENTER, 0, 0);
 
@@ -895,7 +895,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(KeyBack, LV_BTN_STYLE_REL, &style_num_key_pre);      /*Set the button's released style*/
   lv_btn_set_style(KeyBack, LV_BTN_STYLE_PR, &style_num_key_rel);       /*Set the button's pressed style*/
   //lv_btn_set_layout(KeyBack, LV_LAYOUT_OFF);
-  labelKeyBack = lv_label_create(KeyBack, NULL);                        /*Add a label to the button*/
+  labelKeyBack = lv_label_create_empty(KeyBack);                        /*Add a label to the button*/
   lv_label_set_text(labelKeyBack, machine_menu.key_back);
   lv_obj_align(labelKeyBack, KeyBack, LV_ALIGN_CENTER, 0, 0);
 
@@ -906,7 +906,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(KeyReset, LV_BTN_STYLE_REL, &style_num_key_pre);     /*Set the button's released style*/
   lv_btn_set_style(KeyReset, LV_BTN_STYLE_PR, &style_num_key_rel);      /*Set the button's pressed style*/
   //lv_btn_set_layout(KeyReset, LV_LAYOUT_OFF);
-  labelKeyReset = lv_label_create(KeyReset, NULL);                      /*Add a label to the button*/
+  labelKeyReset = lv_label_create_empty(KeyReset);                      /*Add a label to the button*/
   lv_label_set_text(labelKeyReset, machine_menu.key_reset);
   lv_obj_align(labelKeyReset, KeyReset, LV_ALIGN_CENTER, 0, 0);
 
@@ -917,7 +917,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(KeyConfirm, LV_BTN_STYLE_REL, &style_num_key_pre);   /*Set the button's released style*/
   lv_btn_set_style(KeyConfirm, LV_BTN_STYLE_PR, &style_num_key_rel);    /*Set the button's pressed style*/
   //lv_btn_set_layout(KeyConfirm, LV_LAYOUT_OFF);
-  labelKeyConfirm = lv_label_create(KeyConfirm, NULL);                  /*Add a label to the button*/
+  labelKeyConfirm = lv_label_create_empty(KeyConfirm);                  /*Add a label to the button*/
   lv_label_set_text(labelKeyConfirm, machine_menu.key_confirm);
   lv_obj_align(labelKeyConfirm, KeyConfirm, LV_ALIGN_CENTER, 0, 0);
 
@@ -928,7 +928,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(KeyPoint, LV_BTN_STYLE_REL, &style_num_key_pre);     /*Set the button's released style*/
   lv_btn_set_style(KeyPoint, LV_BTN_STYLE_PR, &style_num_key_rel);      /*Set the button's pressed style*/
   //lv_btn_set_layout(KeyPoint, LV_LAYOUT_OFF);
-  labelKeyPoint = lv_label_create(KeyPoint, NULL);                      /*Add a label to the button*/
+  labelKeyPoint = lv_label_create_empty(KeyPoint);                      /*Add a label to the button*/
   lv_label_set_text(labelKeyPoint, machine_menu.key_point);
   lv_obj_align(labelKeyPoint, KeyPoint, LV_ALIGN_CENTER, 0, 0);
 
@@ -939,7 +939,7 @@ void lv_draw_number_key(void) {
   lv_btn_set_style(Minus, LV_BTN_STYLE_REL, &style_num_key_pre);        /*Set the button's released style*/
   lv_btn_set_style(Minus, LV_BTN_STYLE_PR, &style_num_key_rel);         /*Set the button's pressed style*/
   //lv_btn_set_layout(Minus, LV_LAYOUT_OFF);
-  labelMinus = lv_label_create(Minus, NULL);                            /*Add a label to the button*/
+  labelMinus = lv_label_create_empty(Minus);                            /*Add a label to the button*/
   lv_label_set_text(labelMinus, machine_menu.negative);
   lv_obj_align(labelMinus, Minus, LV_ALIGN_CENTER, 0, 0);
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_number_key.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_number_key.cpp
@@ -765,10 +765,7 @@ void lv_draw_number_key(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  //lv_obj_t * title = lv_label_create(scr, NULL);
-  //lv_obj_set_style(title, &tft_style_label_rel);
-  //lv_obj_set_pos(title,TITLE_XPOS,TITLE_YPOS);
-  //lv_label_set_text(title, creat_title_text());
+  //(void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_operation.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_operation.cpp
@@ -137,14 +137,12 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
       else if (event == LV_EVENT_RELEASED) {
         if (gCfgItems.finish_power_off) {
           gCfgItems.finish_power_off = false;
-          lv_imgbtn_set_src(buttonPowerOff, LV_BTN_STATE_REL, "F:/bmp_manual_off.bin");
-          lv_imgbtn_set_src(buttonPowerOff, LV_BTN_STATE_PR, "F:/bmp_manual_off.bin");
+          lv_imgbtn_set_src_both(buttonPowerOff, "F:/bmp_manual_off.bin");
           lv_label_set_text(label_PowerOff, printing_more_menu.manual);
         }
         else {
           gCfgItems.finish_power_off = true;
-          lv_imgbtn_set_src(buttonPowerOff, LV_BTN_STATE_REL, "F:/bmp_auto_off.bin");
-          lv_imgbtn_set_src(buttonPowerOff, LV_BTN_STATE_PR, "F:/bmp_auto_off.bin");
+          lv_imgbtn_set_src_both(buttonPowerOff, "F:/bmp_auto_off.bin");
           lv_label_set_text(label_PowerOff, printing_more_menu.auto_close);
         }
         lv_obj_align(label_PowerOff, buttonPowerOff, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
@@ -185,10 +183,7 @@ void lv_draw_operation(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -208,35 +203,26 @@ void lv_draw_operation(void) {
   buttonBack       = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonPreHeat, event_handler, ID_O_PRE_HEAT, NULL, 0);
-  lv_imgbtn_set_src(buttonPreHeat, LV_BTN_STATE_REL, "F:/bmp_temp.bin");
-  lv_imgbtn_set_src(buttonPreHeat, LV_BTN_STATE_PR, "F:/bmp_temp.bin");
-  lv_imgbtn_set_style(buttonPreHeat, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonPreHeat, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonPreHeat, "F:/bmp_temp.bin");
+  lv_imgbtn_use_label_style(buttonPreHeat);
 
   lv_obj_set_event_cb_mks(buttonFilament, event_handler, ID_O_FILAMENT, NULL, 0);
-  lv_imgbtn_set_src(buttonFilament, LV_BTN_STATE_REL, "F:/bmp_filamentchange.bin");
-  lv_imgbtn_set_src(buttonFilament, LV_BTN_STATE_PR, "F:/bmp_filamentchange.bin");
-  lv_imgbtn_set_style(buttonFilament, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonFilament, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonFilament, "F:/bmp_filamentchange.bin");
+  lv_imgbtn_use_label_style(buttonFilament);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonFan, event_handler, ID_O_FAN, NULL, 0);
-    lv_imgbtn_set_src(buttonFan, LV_BTN_STATE_REL, "F:/bmp_fan.bin");
-    lv_imgbtn_set_src(buttonFan, LV_BTN_STATE_PR, "F:/bmp_fan.bin");
-    lv_imgbtn_set_style(buttonFan, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonFan, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonFan, "F:/bmp_fan.bin");
+    lv_imgbtn_use_label_style(buttonFan);
 
     if (gCfgItems.finish_power_off) {
-      lv_imgbtn_set_src(buttonPowerOff, LV_BTN_STATE_REL, "F:/bmp_auto_off.bin");
-      lv_imgbtn_set_src(buttonPowerOff, LV_BTN_STATE_PR, "F:/bmp_auto_off.bin");
+      lv_imgbtn_set_src_both(buttonPowerOff, "F:/bmp_auto_off.bin");
     }
     else {
-      lv_imgbtn_set_src(buttonPowerOff, LV_BTN_STATE_REL, "F:/bmp_manual_off.bin");
-      lv_imgbtn_set_src(buttonPowerOff, LV_BTN_STATE_PR, "F:/bmp_manual_off.bin");
+      lv_imgbtn_set_src_both(buttonPowerOff, "F:/bmp_manual_off.bin");
     }
     lv_obj_set_event_cb_mks(buttonPowerOff, event_handler, ID_O_POWER_OFF, NULL, 0);
-    lv_imgbtn_set_style(buttonPowerOff, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonPowerOff, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonPowerOff);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -249,16 +235,12 @@ void lv_draw_operation(void) {
 
     if (uiCfg.print_state != WORKING) {
       lv_obj_set_event_cb_mks(buttonExtrusion, event_handler, ID_O_EXTRUCT, NULL, 0);
-      lv_imgbtn_set_src(buttonExtrusion, LV_BTN_STATE_REL, "F:/bmp_extrude_opr.bin");
-      lv_imgbtn_set_src(buttonExtrusion, LV_BTN_STATE_PR, "F:/bmp_extrude_opr.bin");
-      lv_imgbtn_set_style(buttonExtrusion, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonExtrusion, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonExtrusion, "F:/bmp_extrude_opr.bin");
+      lv_imgbtn_use_label_style(buttonExtrusion);
 
       lv_obj_set_event_cb_mks(buttonMove, event_handler, ID_O_MOV, NULL, 0);
-      lv_imgbtn_set_src(buttonMove, LV_BTN_STATE_REL, "F:/bmp_move_opr.bin");
-      lv_imgbtn_set_src(buttonMove, LV_BTN_STATE_PR, "F:/bmp_move_opr.bin");
-      lv_imgbtn_set_style(buttonMove, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonMove, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonMove, "F:/bmp_move_opr.bin");
+      lv_imgbtn_use_label_style(buttonMove);
 
       #if HAS_ROTARY_ENCODER
         if (gCfgItems.encoder_enable) {
@@ -269,16 +251,12 @@ void lv_draw_operation(void) {
     }
     else {
       lv_obj_set_event_cb_mks(buttonSpeed, event_handler, ID_O_SPEED, NULL, 0);
-      lv_imgbtn_set_src(buttonSpeed, LV_BTN_STATE_REL, "F:/bmp_speed.bin");
-      lv_imgbtn_set_src(buttonSpeed, LV_BTN_STATE_PR, "F:/bmp_speed.bin");
-      lv_imgbtn_set_style(buttonSpeed, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonSpeed, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed.bin");
+      lv_imgbtn_use_label_style(buttonSpeed);
 
       lv_obj_set_event_cb_mks(buttonBabyStep, event_handler, ID_O_BABY_STEP, NULL, 0);
-      lv_imgbtn_set_src(buttonBabyStep, LV_BTN_STATE_REL, "F:/bmp_mov.bin");
-      lv_imgbtn_set_src(buttonBabyStep, LV_BTN_STATE_PR, "F:/bmp_mov.bin");
-      lv_imgbtn_set_style(buttonBabyStep, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonBabyStep, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonBabyStep, "F:/bmp_mov.bin");
+      lv_imgbtn_use_label_style(buttonBabyStep);
 
       #if HAS_ROTARY_ENCODER
         if (gCfgItems.encoder_enable) {
@@ -289,10 +267,8 @@ void lv_draw_operation(void) {
     }
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_O_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
   #endif // if 1
 
   #if HAS_ROTARY_ENCODER

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_operation.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_operation.cpp
@@ -188,152 +188,66 @@ void lv_draw_operation(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create image buttons
-  buttonPreHeat     = lv_imgbtn_create(scr, NULL);
-  buttonFilament    = lv_imgbtn_create(scr, NULL);
-  buttonFan         = lv_imgbtn_create(scr, NULL);
-  buttonPowerOff    = lv_imgbtn_create(scr, NULL);
+  buttonPreHeat  = lv_imgbtn_create(scr, "F:/bmp_temp.bin", INTERVAL_V, titleHeight, event_handler, ID_O_PRE_HEAT);
+  buttonFilament = lv_imgbtn_create(scr, "F:/bmp_filamentchange.bin", BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_O_FILAMENT);
+  buttonFan      = lv_imgbtn_create(scr, "F:/bmp_fan.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_O_FAN);
+  buttonPowerOff = lv_imgbtn_create(scr, gCfgItems.finish_power_off ? "F:/bmp_auto_off.bin" : "F:/bmp_manual_off.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_O_POWER_OFF);
+
+  #if HAS_ROTARY_ENCODER
+    if (gCfgItems.encoder_enable) {
+      lv_group_add_obj(g, buttonPreHeat);
+      lv_group_add_obj(g, buttonFilament);
+      lv_group_add_obj(g, buttonFan);
+      lv_group_add_obj(g, buttonPowerOff);
+    }
+  #endif
+
   if (uiCfg.print_state != WORKING) {
-    buttonExtrusion = lv_imgbtn_create(scr, NULL);
-    buttonMove      = lv_imgbtn_create(scr, NULL);
-  }
-  else {
-    buttonSpeed    = lv_imgbtn_create(scr, NULL);
-    buttonBabyStep = lv_imgbtn_create(scr, NULL);
-  }
-  buttonBack       = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonPreHeat, event_handler, ID_O_PRE_HEAT, NULL, 0);
-  lv_imgbtn_set_src_both(buttonPreHeat, "F:/bmp_temp.bin");
-  lv_imgbtn_use_label_style(buttonPreHeat);
-
-  lv_obj_set_event_cb_mks(buttonFilament, event_handler, ID_O_FILAMENT, NULL, 0);
-  lv_imgbtn_set_src_both(buttonFilament, "F:/bmp_filamentchange.bin");
-  lv_imgbtn_use_label_style(buttonFilament);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonFan, event_handler, ID_O_FAN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonFan, "F:/bmp_fan.bin");
-    lv_imgbtn_use_label_style(buttonFan);
-
-    if (gCfgItems.finish_power_off) {
-      lv_imgbtn_set_src_both(buttonPowerOff, "F:/bmp_auto_off.bin");
-    }
-    else {
-      lv_imgbtn_set_src_both(buttonPowerOff, "F:/bmp_manual_off.bin");
-    }
-    lv_obj_set_event_cb_mks(buttonPowerOff, event_handler, ID_O_POWER_OFF, NULL, 0);
-    lv_imgbtn_use_label_style(buttonPowerOff);
-
+    buttonExtrusion = lv_imgbtn_create(scr, "F:/bmp_extrude_opr.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_O_EXTRUCT);
+    buttonMove      = lv_imgbtn_create(scr, "F:/bmp_move_opr.bin", BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_O_MOV);
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
-        lv_group_add_obj(g, buttonPreHeat);
-        lv_group_add_obj(g, buttonFilament);
-        lv_group_add_obj(g, buttonFan);
-        lv_group_add_obj(g, buttonPowerOff);
+        lv_group_add_obj(g, buttonExtrusion);
+        lv_group_add_obj(g, buttonMove);
       }
     #endif
+  }
+  else {
+    buttonSpeed    = lv_imgbtn_create(scr, "F:/bmp_speed.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_O_SPEED);
+    buttonBabyStep = lv_imgbtn_create(scr, "F:/bmp_mov.bin", BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_O_BABY_STEP);
+    #if HAS_ROTARY_ENCODER
+      if (gCfgItems.encoder_enable) {
+        lv_group_add_obj(g, buttonSpeed);
+        lv_group_add_obj(g, buttonBabyStep);
+      }
+    #endif
+  }
 
-    if (uiCfg.print_state != WORKING) {
-      lv_obj_set_event_cb_mks(buttonExtrusion, event_handler, ID_O_EXTRUCT, NULL, 0);
-      lv_imgbtn_set_src_both(buttonExtrusion, "F:/bmp_extrude_opr.bin");
-      lv_imgbtn_use_label_style(buttonExtrusion);
-
-      lv_obj_set_event_cb_mks(buttonMove, event_handler, ID_O_MOV, NULL, 0);
-      lv_imgbtn_set_src_both(buttonMove, "F:/bmp_move_opr.bin");
-      lv_imgbtn_use_label_style(buttonMove);
-
-      #if HAS_ROTARY_ENCODER
-        if (gCfgItems.encoder_enable) {
-          lv_group_add_obj(g, buttonExtrusion);
-          lv_group_add_obj(g, buttonMove);
-        }
-      #endif
-    }
-    else {
-      lv_obj_set_event_cb_mks(buttonSpeed, event_handler, ID_O_SPEED, NULL, 0);
-      lv_imgbtn_set_src_both(buttonSpeed, "F:/bmp_speed.bin");
-      lv_imgbtn_use_label_style(buttonSpeed);
-
-      lv_obj_set_event_cb_mks(buttonBabyStep, event_handler, ID_O_BABY_STEP, NULL, 0);
-      lv_imgbtn_set_src_both(buttonBabyStep, "F:/bmp_mov.bin");
-      lv_imgbtn_use_label_style(buttonBabyStep);
-
-      #if HAS_ROTARY_ENCODER
-        if (gCfgItems.encoder_enable) {
-          lv_group_add_obj(g, buttonSpeed);
-          lv_group_add_obj(g, buttonBabyStep);
-        }
-      #endif
-    }
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_O_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-  #endif // if 1
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_O_RETURN);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif
 
-  lv_obj_set_pos(buttonPreHeat, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonFilament, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
-  lv_obj_set_pos(buttonFan, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
-  lv_obj_set_pos(buttonPowerOff, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-
-  if (uiCfg.print_state != WORKING) {
-    /*
-      lv_obj_set_pos(buttonFilament,INTERVAL_V,BTN_Y_PIXEL+INTERVAL_H+titleHeight);
-    } else {
-    */
-    lv_obj_set_pos(buttonExtrusion, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-    lv_obj_set_pos(buttonMove, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  }
-  else {
-    lv_obj_set_pos(buttonSpeed, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-    lv_obj_set_pos(buttonBabyStep, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  }
-
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonPreHeat, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonFilament, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonFan, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonPowerOff, LV_LAYOUT_OFF);
+  labelPreHeat   = lv_label_create_empty(buttonPreHeat);
+  label_Filament = lv_label_create_empty(buttonFilament);
+  label_Fan      = lv_label_create_empty(buttonFan);
+  label_PowerOff = lv_label_create_empty(buttonPowerOff);
 
   if (uiCfg.print_state != WORKING) {
     /*
-      lv_btn_set_layout(buttonFilament, LV_LAYOUT_OFF);
+      label_Filament = lv_label_create_empty(buttonFilament);
     } else {
     */
-    lv_btn_set_layout(buttonExtrusion, LV_LAYOUT_OFF);
-    lv_btn_set_layout(buttonMove, LV_LAYOUT_OFF);
+    labelExtrusion = lv_label_create_empty(buttonExtrusion);
+    label_Move = lv_label_create_empty(buttonMove);
   }
   else {
-    lv_btn_set_layout(buttonSpeed, LV_LAYOUT_OFF);
-    lv_btn_set_layout(buttonBabyStep, LV_LAYOUT_OFF);
+    label_Speed = lv_label_create_empty(buttonSpeed);
+    label_BabyStep = lv_label_create_empty(buttonBabyStep);
   }
-
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  labelPreHeat   = lv_label_create(buttonPreHeat, NULL);
-  label_Filament = lv_label_create(buttonFilament, NULL);
-  label_Fan   = lv_label_create(buttonFan, NULL);
-  label_PowerOff = lv_label_create(buttonPowerOff, NULL);
-
-  if (uiCfg.print_state != WORKING) {
-    /*
-      label_Filament = lv_label_create(buttonFilament, NULL);
-    } else {
-    */
-    labelExtrusion = lv_label_create(buttonExtrusion, NULL);
-    label_Move = lv_label_create(buttonMove, NULL);
-  }
-  else {
-    label_Speed = lv_label_create(buttonSpeed, NULL);
-    label_BabyStep = lv_label_create(buttonBabyStep, NULL);
-  }
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelPreHeat, operation_menu.temp);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_pause_position.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_pause_position.cpp
@@ -106,46 +106,30 @@ void lv_draw_pause_position(void) {
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.xPos);
 
-  buttonXValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_btn_set_style_both(buttonXValue, &style_para_value);
-  lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_PAUSE_X, NULL, 0);
-  labelXValue = lv_label_create(buttonXValue, NULL);
+  buttonXValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_PAUSE_X);
+  labelXValue = lv_label_create_empty(buttonXValue);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.yPos);
 
-  buttonYValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_PAUSE_Y, NULL, 0);
-  lv_btn_set_style_both(buttonYValue, &style_para_value);
-  labelYValue = lv_label_create(buttonYValue, NULL);
+  buttonYValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_PAUSE_Y);
+  labelYValue = lv_label_create_empty(buttonYValue);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
   (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.zPos);
 
-  buttonZValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_PAUSE_Z, NULL, 0);
-  lv_btn_set_style_both(buttonZValue, &style_para_value);
-  labelZValue = lv_label_create(buttonZValue, NULL);
+  buttonZValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_PAUSE_Z);
+  labelZValue = lv_label_create_empty(buttonZValue);
 
   line3 = lv_line_create(scr, NULL);
   lv_ex_line(line3, line_points[2]);
 
-  buttonBack = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_PAUSE_RETURN, NULL, 0);
-  lv_btn_set_style_both(buttonBack, &style_para_back);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_btn_create_back(scr, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE, event_handler, ID_PAUSE_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     sprintf_P(public_buf_l, PSTR("%.1f"), gCfgItems.pausePosX);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_pause_position.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_pause_position.cpp
@@ -83,9 +83,9 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_pause_position(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL;
-  lv_obj_t *labelXText = NULL, *buttonXValue = NULL, *labelXValue = NULL;
-  lv_obj_t *labelYText = NULL, *buttonYValue = NULL, *labelYValue = NULL;
-  lv_obj_t *labelZText = NULL, *buttonZValue = NULL, *labelZValue = NULL;
+  lv_obj_t *buttonXValue = NULL, *labelXValue = NULL;
+  lv_obj_t *buttonYValue = NULL, *labelYValue = NULL;
+  lv_obj_t *buttonZValue = NULL, *labelZValue = NULL;
 
   lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != PAUSE_POS_UI) {
@@ -100,56 +100,41 @@ void lv_draw_pause_position(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.PausePosText);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.PausePosText);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  labelXText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelXText, &tft_style_label_rel);
-  lv_obj_set_pos(labelXText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-  lv_label_set_text(labelXText, machine_menu.xPos);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.xPos);
 
   buttonXValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_btn_set_style(buttonXValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonXValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonXValue, &style_para_value);
   lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_PAUSE_X, NULL, 0);
   labelXValue = lv_label_create(buttonXValue, NULL);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1, line_points[0]);
 
-  labelYText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelYText, &tft_style_label_rel);
-  lv_obj_set_pos(labelYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-  lv_label_set_text(labelYText, machine_menu.yPos);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.yPos);
 
   buttonYValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_PAUSE_Y, NULL, 0);
-  lv_btn_set_style(buttonYValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonYValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonYValue, &style_para_value);
   labelYValue = lv_label_create(buttonYValue, NULL);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2, line_points[1]);
 
-  labelZText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelZText, &tft_style_label_rel);
-  lv_obj_set_pos(labelZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-  lv_label_set_text(labelZText, machine_menu.zPos);
+  (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.zPos);
 
   buttonZValue = lv_btn_create(scr, NULL);
   lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_PAUSE_Z, NULL, 0);
-  lv_btn_set_style(buttonZValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_btn_set_style_both(buttonZValue, &style_para_value);
   labelZValue = lv_label_create(buttonZValue, NULL);
 
   line3 = lv_line_create(scr, NULL);
@@ -159,22 +144,18 @@ void lv_draw_pause_position(void) {
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_PAUSE_RETURN, NULL, 0);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
   label_Back = lv_label_create(buttonBack, NULL);
 
   if (gCfgItems.multiple_language) {
-    ZERO(public_buf_l);
     sprintf_P(public_buf_l, PSTR("%.1f"), gCfgItems.pausePosX);
     lv_label_set_text(labelXValue, public_buf_l);
     lv_obj_align(labelXValue, buttonXValue, LV_ALIGN_CENTER, 0, 0);
 
-    ZERO(public_buf_l);
     sprintf_P(public_buf_l, PSTR("%.1f"), gCfgItems.pausePosY);
     lv_label_set_text(labelYValue, public_buf_l);
     lv_obj_align(labelYValue, buttonYValue, LV_ALIGN_CENTER, 0, 0);
 
-    ZERO(public_buf_l);
     sprintf_P(public_buf_l, PSTR("%.1f"), gCfgItems.pausePosZ);
     lv_label_set_text(labelZValue, public_buf_l);
     lv_obj_align(labelZValue, buttonZValue, LV_ALIGN_CENTER, 0, 0);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_preHeat.cpp
@@ -35,7 +35,7 @@
 
 static lv_obj_t * scr;
 extern lv_group_t*  g;
-static lv_obj_t *buttoType, *buttonStep;
+static lv_obj_t *buttonType, *buttonStep;
 static lv_obj_t *labelType;
 static lv_obj_t *labelStep;
 static lv_obj_t * tempText1;
@@ -208,59 +208,21 @@ void lv_draw_preHeat(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create image buttons
-  buttonAdd  = lv_imgbtn_create(scr, NULL);
-  buttonDec  = lv_imgbtn_create(scr, NULL);
-  buttoType  = lv_imgbtn_create(scr, NULL);
-  buttonStep = lv_imgbtn_create(scr, NULL);
-  buttonOff  = lv_imgbtn_create(scr, NULL);
-  buttonBack = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonAdd, event_handler, ID_P_ADD, NULL, 0);
-  lv_imgbtn_set_src_both(buttonAdd, "F:/bmp_Add.bin");
-  lv_imgbtn_use_label_style(buttonAdd);
+  buttonAdd = lv_imgbtn_create(scr, "F:/bmp_Add.bin", INTERVAL_V, titleHeight, event_handler, ID_P_ADD);
   lv_obj_clear_protect(buttonAdd, LV_PROTECT_FOLLOW);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonDec, event_handler, ID_P_DEC, NULL, 0);
-    lv_imgbtn_set_src_both(buttonDec, "F:/bmp_Dec.bin");
-    lv_imgbtn_use_label_style(buttonDec);
-
-    lv_obj_set_event_cb_mks(buttoType, event_handler, ID_P_TYPE, NULL, 0);
-    lv_imgbtn_use_label_style(buttoType);
-
-    lv_obj_set_event_cb_mks(buttonStep, event_handler, ID_P_STEP, NULL, 0);
-    lv_imgbtn_use_label_style(buttonStep);
-
-    lv_obj_set_event_cb_mks(buttonOff, event_handler, ID_P_OFF, NULL, 0);
-    lv_imgbtn_set_src_both(buttonOff, "F:/bmp_speed0.bin");
-    lv_imgbtn_use_label_style(buttonOff);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_P_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-  #endif
-
-  lv_obj_set_pos(buttonAdd, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonDec, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttoType, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonStep, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonOff, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonDec = lv_imgbtn_create(scr, "F:/bmp_Dec.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_P_DEC);
+  buttonType = lv_imgbtn_create(scr, NULL, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_P_TYPE);
+  buttonStep = lv_imgbtn_create(scr, NULL, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_P_STEP);
+  buttonOff = lv_imgbtn_create(scr, "F:/bmp_speed0.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_P_OFF);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_P_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonAdd, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonDec, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttoType, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonStep, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonOff, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelAdd = lv_label_create(buttonAdd, NULL);
-  lv_obj_t *labelDec = lv_label_create(buttonDec, NULL);
-  labelType = lv_label_create(buttoType, NULL);
-  labelStep = lv_label_create(buttonStep, NULL);
-  lv_obj_t *labelOff   = lv_label_create(buttonOff, NULL);
-  lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelAdd = lv_label_create_empty(buttonAdd);
+  lv_obj_t *labelDec = lv_label_create_empty(buttonDec);
+  labelType = lv_label_create_empty(buttonType);
+  labelStep = lv_label_create_empty(buttonStep);
+  lv_obj_t *labelOff   = lv_label_create_empty(buttonOff);
+  lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelAdd, preheat_menu.add);
@@ -279,7 +241,7 @@ void lv_draw_preHeat(void) {
     if (gCfgItems.encoder_enable) {
       lv_group_add_obj(g, buttonAdd);
       lv_group_add_obj(g, buttonDec);
-      lv_group_add_obj(g, buttoType);
+      lv_group_add_obj(g, buttonType);
       lv_group_add_obj(g, buttonStep);
       lv_group_add_obj(g, buttonOff);
       lv_group_add_obj(g, buttonBack);
@@ -289,33 +251,34 @@ void lv_draw_preHeat(void) {
   disp_temp_type();
   disp_step_heat();
 
-  tempText1 = lv_label_create(scr);
+  tempText1 = lv_label_create_empty(scr);
+  lv_obj_set_style(tempText1, &tft_style_label_rel);
   disp_desire_temp();
 }
 
 void disp_temp_type() {
   if (uiCfg.curTempType == 0) {
     if (uiCfg.curSprayerChoose == 1) {
-    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru2.bin");
+    lv_imgbtn_set_src_both(buttonType, "F:/bmp_extru2.bin");
       if (gCfgItems.multiple_language) {
         lv_label_set_text(labelType, preheat_menu.ext2);
-        lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
+        lv_obj_align(labelType, buttonType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
       }
     }
     else {
-    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru1.bin");
+    lv_imgbtn_set_src_both(buttonType, "F:/bmp_extru1.bin");
       if (gCfgItems.multiple_language) {
         lv_label_set_text(labelType, preheat_menu.ext1);
-        lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
+        lv_obj_align(labelType, buttonType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
       }
     }
 
   }
   else {
-  lv_imgbtn_set_src_both(buttoType, "F:/bmp_bed.bin");
+  lv_imgbtn_set_src_both(buttonType, "F:/bmp_bed.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, preheat_menu.hotbed);
-      lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
+      lv_obj_align(labelType, buttonType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
   }
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_preHeat.cpp
@@ -203,10 +203,7 @@ void lv_draw_preHeat(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -219,38 +216,28 @@ void lv_draw_preHeat(void) {
   buttonBack = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonAdd, event_handler, ID_P_ADD, NULL, 0);
-  lv_imgbtn_set_src(buttonAdd, LV_BTN_STATE_REL, "F:/bmp_Add.bin");
-  lv_imgbtn_set_src(buttonAdd, LV_BTN_STATE_PR, "F:/bmp_Add.bin");
-  lv_imgbtn_set_style(buttonAdd, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonAdd, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonAdd, "F:/bmp_Add.bin");
+  lv_imgbtn_use_label_style(buttonAdd);
   lv_obj_clear_protect(buttonAdd, LV_PROTECT_FOLLOW);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonDec, event_handler, ID_P_DEC, NULL, 0);
-    lv_imgbtn_set_src(buttonDec, LV_BTN_STATE_REL, "F:/bmp_Dec.bin");
-    lv_imgbtn_set_src(buttonDec, LV_BTN_STATE_PR, "F:/bmp_Dec.bin");
-    lv_imgbtn_set_style(buttonDec, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonDec, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonDec, "F:/bmp_Dec.bin");
+    lv_imgbtn_use_label_style(buttonDec);
 
     lv_obj_set_event_cb_mks(buttoType, event_handler, ID_P_TYPE, NULL, 0);
-    lv_imgbtn_set_style(buttoType, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttoType, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttoType);
 
     lv_obj_set_event_cb_mks(buttonStep, event_handler, ID_P_STEP, NULL, 0);
-    lv_imgbtn_set_style(buttonStep, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonStep, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonStep);
 
     lv_obj_set_event_cb_mks(buttonOff, event_handler, ID_P_OFF, NULL, 0);
-    lv_imgbtn_set_src(buttonOff, LV_BTN_STATE_REL, "F:/bmp_speed0.bin");
-    lv_imgbtn_set_src(buttonOff, LV_BTN_STATE_PR, "F:/bmp_speed0.bin");
-    lv_imgbtn_set_style(buttonOff, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonOff, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonOff, "F:/bmp_speed0.bin");
+    lv_imgbtn_use_label_style(buttonOff);
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_P_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
   #endif
 
   lv_obj_set_pos(buttonAdd, INTERVAL_V, titleHeight);
@@ -302,24 +289,21 @@ void lv_draw_preHeat(void) {
   disp_temp_type();
   disp_step_heat();
 
-  tempText1 = lv_label_create(scr, NULL);
-  lv_obj_set_style(tempText1, &tft_style_label_rel);
+  tempText1 = lv_label_create(scr);
   disp_desire_temp();
 }
 
 void disp_temp_type() {
   if (uiCfg.curTempType == 0) {
     if (uiCfg.curSprayerChoose == 1) {
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_REL, "F:/bmp_extru2.bin");
-      lv_imgbtn_set_src(buttoType, LV_BTN_STATE_PR, "F:/bmp_extru2.bin");
+    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru2.bin");
       if (gCfgItems.multiple_language) {
         lv_label_set_text(labelType, preheat_menu.ext2);
         lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
       }
     }
     else {
-    lv_imgbtn_set_src(buttoType, LV_BTN_STATE_REL, "F:/bmp_extru1.bin");
-      lv_imgbtn_set_src(buttoType, LV_BTN_STATE_PR, "F:/bmp_extru1.bin");
+    lv_imgbtn_set_src_both(buttoType, "F:/bmp_extru1.bin");
       if (gCfgItems.multiple_language) {
         lv_label_set_text(labelType, preheat_menu.ext1);
         lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
@@ -328,8 +312,7 @@ void disp_temp_type() {
 
   }
   else {
-  lv_imgbtn_set_src(buttoType, LV_BTN_STATE_REL, "F:/bmp_bed.bin");
-      lv_imgbtn_set_src(buttoType, LV_BTN_STATE_PR, "F:/bmp_bed.bin");
+  lv_imgbtn_set_src_both(buttoType, "F:/bmp_bed.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, preheat_menu.hotbed);
       lv_obj_align(labelType, buttoType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
@@ -363,16 +346,13 @@ void disp_desire_temp() {
 
 void disp_step_heat() {
   if (uiCfg.stepHeat == 1) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step1_degree.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step1_degree.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step1_degree.bin");
   }
   else if (uiCfg.stepHeat == 5) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step5_degree.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step5_degree.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step5_degree.bin");
   }
   else if (uiCfg.stepHeat == 10) {
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_REL, "F:/bmp_step10_degree.bin");
-    lv_imgbtn_set_src(buttonStep, LV_BTN_STATE_PR, "F:/bmp_step10_degree.bin");
+    lv_imgbtn_set_src_both(buttonStep, "F:/bmp_step10_degree.bin");
   }
 
   if (gCfgItems.multiple_language) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_print_file.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_print_file.cpp
@@ -266,9 +266,9 @@ void lv_draw_print_file(void) {
   #endif
   disp_gcode_icon(file_count);
 
-  //lv_obj_t *labelPageUp = lv_label_create(buttonPageUp, NULL);
-  //lv_obj_t *labelPageDown = lv_label_create(buttonPageDown, NULL);
-  //lv_obj_t *label_Back = lv_label_create(buttonBack, NULL);
+  //lv_obj_t *labelPageUp = lv_label_create_empty(buttonPageUp);
+  //lv_obj_t *labelPageDown = lv_label_create_empty(buttonPageDown);
+  //lv_obj_t *label_Back = lv_label_create_empty(buttonBack);
 
   /*
   if (gCfgItems.multiple_language) {
@@ -300,33 +300,11 @@ void disp_gcode_icon(uint8_t file_num) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create image buttons
-  buttonPageUp   = lv_imgbtn_create(scr, NULL);
-  buttonPageDown = lv_imgbtn_create(scr, NULL);
-  buttonBack     = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonPageUp, event_handler, ID_P_UP, NULL, 0);
-  lv_imgbtn_set_src_both(buttonPageUp, "F:/bmp_pageUp.bin");
-  lv_imgbtn_use_label_style(buttonPageUp);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonPageDown, event_handler, ID_P_DOWN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonPageDown, "F:/bmp_pageDown.bin");
-    lv_imgbtn_use_label_style(buttonPageDown);
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_P_RETURN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-  #endif
-
-  lv_obj_set_pos(buttonPageUp, OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonPageDown, OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + OTHER_BTN_YPIEL + INTERVAL_H);
-  lv_obj_set_pos(buttonBack, OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + OTHER_BTN_YPIEL * 2 + INTERVAL_H * 2);
+  buttonPageUp   = lv_imgbtn_create(scr, "F:/bmp_pageUp.bin", OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_P_UP);
+  buttonPageDown = lv_imgbtn_create(scr, "F:/bmp_pageDown.bin", OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + OTHER_BTN_YPIEL + INTERVAL_H, event_handler, ID_P_DOWN);
+  buttonBack     = lv_imgbtn_create(scr, "F:/bmp_back.bin", OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + OTHER_BTN_YPIEL * 2 + INTERVAL_H * 2, event_handler, ID_P_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonPageUp, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonPageDown, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
   for (i = 0; i < FILE_BTN_CNT; i++) {
     /*
     if (seq) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_print_file.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_print_file.cpp
@@ -295,10 +295,7 @@ void disp_gcode_icon(uint8_t file_num) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -308,23 +305,17 @@ void disp_gcode_icon(uint8_t file_num) {
   buttonBack     = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonPageUp, event_handler, ID_P_UP, NULL, 0);
-  lv_imgbtn_set_src(buttonPageUp, LV_BTN_STATE_REL, "F:/bmp_pageUp.bin");
-  lv_imgbtn_set_src(buttonPageUp, LV_BTN_STATE_PR, "F:/bmp_pageUp.bin");
-  lv_imgbtn_set_style(buttonPageUp, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonPageUp, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonPageUp, "F:/bmp_pageUp.bin");
+  lv_imgbtn_use_label_style(buttonPageUp);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonPageDown, event_handler, ID_P_DOWN, NULL, 0);
-    lv_imgbtn_set_src(buttonPageDown, LV_BTN_STATE_REL, "F:/bmp_pageDown.bin");
-    lv_imgbtn_set_src(buttonPageDown, LV_BTN_STATE_PR, "F:/bmp_pageDown.bin");
-    lv_imgbtn_set_style(buttonPageDown, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonPageDown, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonPageDown, "F:/bmp_pageDown.bin");
+    lv_imgbtn_use_label_style(buttonPageDown);
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_P_RETURN, NULL, 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back.bin");
+    lv_imgbtn_use_label_style(buttonBack);
   #endif
 
   lv_obj_set_pos(buttonPageUp, OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight);
@@ -352,8 +343,7 @@ void disp_gcode_icon(uint8_t file_num) {
     #ifdef TFT35
       buttonGcode[i] = lv_imgbtn_create(scr, NULL);
 
-      lv_imgbtn_set_style(buttonGcode[i], LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonGcode[i], LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_use_label_style(buttonGcode[i]);
       lv_obj_clear_protect(buttonGcode[i], LV_PROTECT_FOLLOW);
       lv_btn_set_layout(buttonGcode[i], LV_LAYOUT_OFF);
 
@@ -362,16 +352,13 @@ void disp_gcode_icon(uint8_t file_num) {
 
       if (list_file.IsFolder[i] == 1) {
         lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), NULL, 0);
-        lv_imgbtn_set_src(buttonGcode[i], LV_BTN_STATE_REL, "F:/bmp_dir.bin");
-        lv_imgbtn_set_src(buttonGcode[i], LV_BTN_STATE_PR, "F:/bmp_dir.bin");
+        lv_imgbtn_set_src_both(buttonGcode[i], "F:/bmp_dir.bin");
         if (i < 3)
           lv_obj_set_pos(buttonGcode[i], BTN_X_PIXEL * i + INTERVAL_V * (i + 1), titleHeight);
         else
           lv_obj_set_pos(buttonGcode[i], BTN_X_PIXEL * (i - 3) + INTERVAL_V * ((i - 3) + 1), BTN_Y_PIXEL + INTERVAL_H + titleHeight);
 
-        labelPageUp[i] = lv_label_create(buttonGcode[i], NULL);
-        lv_obj_set_style(labelPageUp[i], &tft_style_label_rel);
-        lv_label_set_text(labelPageUp[i], public_buf_m);
+        labelPageUp[i] = lv_label_create(buttonGcode[i], public_buf_m);
         lv_obj_align(labelPageUp[i], buttonGcode[i], LV_ALIGN_IN_BOTTOM_MID, 0, -5);
       }
       else {
@@ -385,20 +372,16 @@ void disp_gcode_icon(uint8_t file_num) {
           char *temp = strstr(test_public_buf_l,".GCO");
           if (temp) { strcpy(temp,".bin"); }
           lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), NULL, 0);
-          lv_imgbtn_set_src(buttonGcode[i], LV_BTN_STATE_REL, test_public_buf_l);
-          lv_imgbtn_set_src(buttonGcode[i], LV_BTN_STATE_PR, test_public_buf_l);
+          lv_imgbtn_set_src_both(buttonGcode[i], test_public_buf_l);
           if (i < 3) {
             lv_obj_set_pos(buttonGcode[i], BTN_X_PIXEL * i + INTERVAL_V * (i + 1) + FILE_PRE_PIC_X_OFFSET, titleHeight + FILE_PRE_PIC_Y_OFFSET);
             buttonText[i] = lv_btn_create(scr, NULL);
             //lv_obj_set_event_cb(buttonText[i], event_handler);
 
-            lv_btn_set_style(buttonText[i], LV_BTN_STATE_PR, &tft_style_label_pre);
-            lv_btn_set_style(buttonText[i], LV_BTN_STATE_REL, &tft_style_label_rel);
-            //lv_obj_set_style(buttonText[i], &tft_style_label_pre);
-            //lv_obj_set_style(buttonText[i], &tft_style_label_rel);
+            lv_btn_use_label_style(buttonText[i]);
             lv_obj_clear_protect(buttonText[i], LV_PROTECT_FOLLOW);
             lv_btn_set_layout(buttonText[i], LV_LAYOUT_OFF);
-            //lv_obj_set_event_cb_mks(buttonText[i], event_handler,(i+10),NULL,0);
+            //lv_obj_set_event_cb_mks(buttonText[i], event_handler,(i+10),NULL, 0);
             lv_obj_set_pos(buttonText[i], BTN_X_PIXEL * i + INTERVAL_V * (i + 1) + FILE_PRE_PIC_X_OFFSET, titleHeight + FILE_PRE_PIC_Y_OFFSET + 100);
             lv_obj_set_size(buttonText[i], 100, 40);
           }
@@ -407,33 +390,25 @@ void disp_gcode_icon(uint8_t file_num) {
             buttonText[i] = lv_btn_create(scr, NULL);
             //lv_obj_set_event_cb(buttonText[i], event_handler);
 
-            lv_btn_set_style(buttonText[i], LV_BTN_STATE_PR, &tft_style_label_pre);
-            lv_btn_set_style(buttonText[i], LV_BTN_STATE_REL, &tft_style_label_rel);
-
-            //lv_imgbtn_set_style(buttonText[i], LV_BTN_STATE_REL, &tft_style_label_rel);
+            lv_btn_use_label_style(buttonText[i]);
             lv_obj_clear_protect(buttonText[i], LV_PROTECT_FOLLOW);
             lv_btn_set_layout(buttonText[i], LV_LAYOUT_OFF);
-            //lv_obj_set_event_cb_mks(buttonText[i], event_handler,(i+10),NULL,0);
+            //lv_obj_set_event_cb_mks(buttonText[i], event_handler,(i+10),NULL, 0);
             lv_obj_set_pos(buttonText[i], BTN_X_PIXEL * (i - 3) + INTERVAL_V * ((i - 3) + 1) + FILE_PRE_PIC_X_OFFSET, BTN_Y_PIXEL + INTERVAL_H + titleHeight + FILE_PRE_PIC_Y_OFFSET + 100);
             lv_obj_set_size(buttonText[i], 100, 40);
           }
-          labelPageUp[i] = lv_label_create(buttonText[i], NULL);
-          lv_obj_set_style(labelPageUp[i], &tft_style_label_rel);
-          lv_label_set_text(labelPageUp[i], public_buf_m);
+          labelPageUp[i] = lv_label_create(buttonText[i], public_buf_m);
           lv_obj_align(labelPageUp[i], buttonText[i], LV_ALIGN_IN_BOTTOM_MID, 0, 0);
         }
         else {
           lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), NULL, 0);
-          lv_imgbtn_set_src(buttonGcode[i], LV_BTN_STATE_REL, "F:/bmp_file.bin");
-          lv_imgbtn_set_src(buttonGcode[i], LV_BTN_STATE_PR, "F:/bmp_file.bin");
+          lv_imgbtn_set_src_both(buttonGcode[i], "F:/bmp_file.bin");
           if (i < 3)
             lv_obj_set_pos(buttonGcode[i], BTN_X_PIXEL * i + INTERVAL_V * (i + 1), titleHeight);
           else
             lv_obj_set_pos(buttonGcode[i], BTN_X_PIXEL * (i - 3) + INTERVAL_V * ((i - 3) + 1), BTN_Y_PIXEL + INTERVAL_H + titleHeight);
 
-          labelPageUp[i] = lv_label_create(buttonGcode[i], NULL);
-          lv_obj_set_style(labelPageUp[i], &tft_style_label_rel);
-          lv_label_set_text(labelPageUp[i], public_buf_m);
+          labelPageUp[i] = lv_label_create(buttonGcode[i], public_buf_m);
           lv_obj_align(labelPageUp[i], buttonGcode[i], LV_ALIGN_IN_BOTTOM_MID, 0, -5);
         }
       }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_printing.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_printing.cpp
@@ -156,47 +156,36 @@ void lv_draw_printing(void) {
 
   // Create image buttons
   lv_obj_t *buttonExt1 = lv_img_create(scr, NULL);
+  lv_img_set_src(buttonExt1, "F:/bmp_ext1_state.bin");
+  lv_obj_set_pos(buttonExt1, 205, 136);
+
   #if HAS_MULTI_EXTRUDER
     lv_obj_t *buttonExt2 = lv_img_create(scr, NULL);
+    lv_img_set_src(buttonExt2, "F:/bmp_ext2_state.bin");
+    lv_obj_set_pos(buttonExt2, 350, 136);
   #endif
+
   #if HAS_HEATED_BED
     lv_obj_t *buttonBedstate = lv_img_create(scr, NULL);
+    lv_img_set_src(buttonBedstate, "F:/bmp_bed_state.bin");
+    lv_obj_set_pos(buttonBedstate, 205, 186);
   #endif
+
   lv_obj_t *buttonFanstate = lv_img_create(scr, NULL);
-  lv_obj_t *buttonTime     = lv_img_create(scr, NULL);
-  lv_obj_t *buttonZpos     = lv_img_create(scr, NULL);
-  buttonPause    = lv_imgbtn_create(scr, NULL);
-  buttonStop     = lv_imgbtn_create(scr, NULL);
-  buttonOperat   = lv_imgbtn_create(scr, NULL);
+  lv_img_set_src(buttonFanstate, "F:/bmp_fan_state.bin");
+  lv_obj_set_pos(buttonFanstate, 350, 186);
 
-  lv_img_set_src(buttonExt1, "F:/bmp_ext1_state.bin");
-  #if 1
-    #if HAS_MULTI_EXTRUDER
-      lv_img_set_src(buttonExt2, "F:/bmp_ext2_state.bin");
-    #endif
-    #if HAS_HEATED_BED
-      lv_img_set_src(buttonBedstate, "F:/bmp_bed_state.bin");
-    #endif
+  lv_obj_t *buttonTime = lv_img_create(scr, NULL);
+  lv_img_set_src(buttonTime, "F:/bmp_time_state.bin");
+  lv_obj_set_pos(buttonTime, 205, 86);
 
-    lv_img_set_src(buttonFanstate, "F:/bmp_fan_state.bin");
+  lv_obj_t *buttonZpos = lv_img_create(scr, NULL);
+  lv_img_set_src(buttonZpos, "F:/bmp_zpos_state.bin");
+  lv_obj_set_pos(buttonZpos, 350, 86);
 
-    lv_img_set_src(buttonTime, "F:/bmp_time_state.bin");
-
-    lv_img_set_src(buttonZpos, "F:/bmp_zpos_state.bin");
-
-    lv_imgbtn_set_src_both(buttonPause, uiCfg.print_state == WORKING ? "F:/bmp_pause.bin" : "F:/bmp_resume.bin");
-    lv_obj_set_event_cb_mks(buttonPause, event_handler, ID_PAUSE, NULL, 0);
-    lv_imgbtn_use_label_style(buttonPause);
-
-    lv_obj_set_event_cb_mks(buttonStop, event_handler, ID_STOP, NULL, 0);
-    lv_imgbtn_set_src_both(buttonStop, "F:/bmp_stop.bin");
-    lv_imgbtn_use_label_style(buttonStop);
-
-    lv_obj_set_event_cb_mks(buttonOperat, event_handler, ID_OPTION, NULL, 0);
-    lv_imgbtn_set_src_both(buttonOperat, "F:/bmp_operate.bin");
-    lv_imgbtn_use_label_style(buttonOperat);
-
-  #endif // if 1
+  buttonPause = lv_imgbtn_create(scr, uiCfg.print_state == WORKING ? "F:/bmp_pause.bin" : "F:/bmp_resume.bin", 5, 240, event_handler, ID_PAUSE);
+  buttonStop = lv_imgbtn_create(scr, "F:/bmp_stop.bin", 165, 240, event_handler, ID_STOP);
+  buttonOperat = lv_imgbtn_create(scr, "F:/bmp_operate.bin", 325, 240, event_handler, ID_OPTION);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) {
@@ -205,23 +194,6 @@ void lv_draw_printing(void) {
       lv_group_add_obj(g, buttonOperat);
     }
   #endif
-
-  lv_obj_set_pos(buttonExt1, 205, 136);
-
-  #if HAS_MULTI_EXTRUDER
-    lv_obj_set_pos(buttonExt2, 350, 136);
-  #endif
-
-  #if HAS_HEATED_BED
-    lv_obj_set_pos(buttonBedstate, 205, 186);
-  #endif
-
-  lv_obj_set_pos(buttonFanstate, 350, 186);
-  lv_obj_set_pos(buttonTime, 205, 86);
-  lv_obj_set_pos(buttonZpos, 350, 86);
-  lv_obj_set_pos(buttonPause, 5, 240);
-  lv_obj_set_pos(buttonStop, 165, 240);
-  lv_obj_set_pos(buttonOperat, 325, 240);
 
   // Create labels on the image buttons
   //lv_btn_set_layout(buttonExt1, LV_LAYOUT_OFF);
@@ -236,9 +208,6 @@ void lv_draw_printing(void) {
   //lv_btn_set_layout(buttonFanstate, LV_LAYOUT_OFF);
   //lv_btn_set_layout(buttonTime, LV_LAYOUT_OFF);
   //lv_btn_set_layout(buttonZpos, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonPause, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonStop, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonOperat, LV_LAYOUT_OFF);
 
   labelExt1 = lv_label_create(scr, 250, 146, NULL);
 
@@ -254,9 +223,9 @@ void lv_draw_printing(void) {
   labelTime = lv_label_create(scr, 250, 96, NULL);
   labelZpos = lv_label_create(scr, 395, 96, NULL);
 
-  labelPause  = lv_label_create(buttonPause, NULL);
-  labelStop   = lv_label_create(buttonStop, NULL);
-  labelOperat = lv_label_create(buttonOperat, NULL);
+  labelPause  = lv_label_create_empty(buttonPause);
+  labelStop   = lv_label_create_empty(buttonStop);
+  labelOperat = lv_label_create_empty(buttonOperat);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelPause, uiCfg.print_state == WORKING ? printing_menu.pause : printing_menu.resume);
@@ -275,7 +244,7 @@ void lv_draw_printing(void) {
   lv_bar_set_style(bar1, LV_BAR_STYLE_INDIC, &lv_bar_style_indic);
   lv_bar_set_anim_time(bar1, 1000);
   lv_bar_set_value(bar1, 0, LV_ANIM_ON);
-  bar1ValueText  = lv_label_create(bar1, NULL);
+  bar1ValueText  = lv_label_create_empty(bar1);
   lv_label_set_text(bar1ValueText,"0%");
   lv_obj_align(bar1ValueText, bar1, LV_ALIGN_CENTER, 0, 0);
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_printing.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_printing.cpp
@@ -46,13 +46,14 @@
   #include "../../../marlinui.h"
 #endif
 
-extern lv_group_t * g;
-static lv_obj_t * scr;
-static lv_obj_t *labelExt1, * labelFan, * labelZpos, * labelTime;
-TERN_(HAS_MULTI_EXTRUDER, static lv_obj_t *labelExt2;)
-static lv_obj_t *labelPause, * labelStop, * labelOperat;
-static lv_obj_t * bar1, *bar1ValueText;
-static lv_obj_t * buttonPause, *buttonOperat, *buttonStop;
+extern lv_group_t *g;
+static lv_obj_t *scr;
+static lv_obj_t *labelExt1, *labelFan, *labelZpos, *labelTime;
+static lv_obj_t *labelPause, *labelStop, *labelOperat;
+static lv_obj_t *bar1, *bar1ValueText;
+static lv_obj_t *buttonPause, *buttonOperat, *buttonStop;
+
+TERN_(HAS_MULTI_EXTRUDER, static lv_obj_t *labelExt2);
 
 #if HAS_HEATED_BED
   static lv_obj_t* labelBed;
@@ -83,23 +84,20 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
               stop_print_time();
               uiCfg.print_state = PAUSING;
             #endif
-            lv_imgbtn_set_src(buttonPause, LV_BTN_STATE_REL, "F:/bmp_resume.bin");
-            lv_imgbtn_set_src(buttonPause, LV_BTN_STATE_PR, "F:/bmp_resume.bin");
+            lv_imgbtn_set_src_both(buttonPause, "F:/bmp_resume.bin");
             lv_label_set_text(labelPause, printing_menu.resume);
             lv_obj_align(labelPause, buttonPause, LV_ALIGN_CENTER, 30, 0);
           }
           else if (uiCfg.print_state == PAUSED) {
             uiCfg.print_state = RESUMING;
-            lv_imgbtn_set_src(obj, LV_BTN_STATE_REL, "F:/bmp_pause.bin");
-            lv_imgbtn_set_src(obj, LV_BTN_STATE_PR, "F:/bmp_pause.bin");
+            lv_imgbtn_set_src_both(obj, "F:/bmp_pause.bin");
             lv_label_set_text(labelPause, printing_menu.pause);
             lv_obj_align(labelPause, buttonPause, LV_ALIGN_CENTER, 30, 0);
           }
           #if ENABLED(POWER_LOSS_RECOVERY)
             else if (uiCfg.print_state == REPRINTING) {
               uiCfg.print_state = REPRINTED;
-              lv_imgbtn_set_src(obj, LV_BTN_STATE_REL, "F:/bmp_pause.bin");
-              lv_imgbtn_set_src(obj, LV_BTN_STATE_PR, "F:/bmp_pause.bin");
+              lv_imgbtn_set_src_both(obj, "F:/bmp_pause.bin");
               lv_label_set_text(labelPause, printing_menu.pause);
               lv_obj_align(labelPause, buttonPause, LV_ALIGN_CENTER, 30, 0);
               // recovery.resume();
@@ -152,10 +150,7 @@ void lv_draw_printing(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -189,30 +184,17 @@ void lv_draw_printing(void) {
 
     lv_img_set_src(buttonZpos, "F:/bmp_zpos_state.bin");
 
-    if (uiCfg.print_state == WORKING) {
-      lv_imgbtn_set_src(buttonPause, LV_BTN_STATE_REL, "F:/bmp_pause.bin");
-      lv_imgbtn_set_src(buttonPause, LV_BTN_STATE_PR, "F:/bmp_pause.bin");
-    }
-    else {
-      lv_imgbtn_set_src(buttonPause, LV_BTN_STATE_REL, "F:/bmp_resume.bin");
-      lv_imgbtn_set_src(buttonPause, LV_BTN_STATE_PR, "F:/bmp_resume.bin");
-    }
-
+    lv_imgbtn_set_src_both(buttonPause, uiCfg.print_state == WORKING ? "F:/bmp_pause.bin" : "F:/bmp_resume.bin");
     lv_obj_set_event_cb_mks(buttonPause, event_handler, ID_PAUSE, NULL, 0);
-    lv_imgbtn_set_style(buttonPause, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonPause, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonPause);
 
     lv_obj_set_event_cb_mks(buttonStop, event_handler, ID_STOP, NULL, 0);
-    lv_imgbtn_set_src(buttonStop, LV_BTN_STATE_REL, "F:/bmp_stop.bin");
-    lv_imgbtn_set_src(buttonStop, LV_BTN_STATE_PR, "F:/bmp_stop.bin");
-    lv_imgbtn_set_style(buttonStop, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonStop, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonStop, "F:/bmp_stop.bin");
+    lv_imgbtn_use_label_style(buttonStop);
 
     lv_obj_set_event_cb_mks(buttonOperat, event_handler, ID_OPTION, NULL, 0);
-    lv_imgbtn_set_src(buttonOperat, LV_BTN_STATE_REL, "F:/bmp_operate.bin");
-    lv_imgbtn_set_src(buttonOperat, LV_BTN_STATE_PR, "F:/bmp_operate.bin");
-    lv_imgbtn_set_style(buttonOperat, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonOperat, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonOperat, "F:/bmp_operate.bin");
+    lv_imgbtn_use_label_style(buttonOperat);
 
   #endif // if 1
 
@@ -244,11 +226,11 @@ void lv_draw_printing(void) {
   // Create labels on the image buttons
   //lv_btn_set_layout(buttonExt1, LV_LAYOUT_OFF);
   //#if HAS_MULTI_EXTRUDER
-    //lv_btn_set_layout(buttonExt2, LV_LAYOUT_OFF);
+  //  lv_btn_set_layout(buttonExt2, LV_LAYOUT_OFF);
   //#endif
 
   //#if HAS_HEATED_BED
-    //lv_btn_set_layout(buttonBedstate, LV_LAYOUT_OFF);
+  //  lv_btn_set_layout(buttonBedstate, LV_LAYOUT_OFF);
   //#endif
 
   //lv_btn_set_layout(buttonFanstate, LV_LAYOUT_OFF);
@@ -258,33 +240,19 @@ void lv_draw_printing(void) {
   lv_btn_set_layout(buttonStop, LV_LAYOUT_OFF);
   lv_btn_set_layout(buttonOperat, LV_LAYOUT_OFF);
 
-  labelExt1 = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelExt1, &tft_style_label_rel);
-  lv_obj_set_pos(labelExt1, 250, 146);
+  labelExt1 = lv_label_create(scr, 250, 146, NULL);
 
   #if HAS_MULTI_EXTRUDER
-    labelExt2 = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelExt2, &tft_style_label_rel);
-    lv_obj_set_pos(labelExt2, 395, 146);
+    labelExt2 = lv_label_create(scr, 395, 146, NULL);
   #endif
 
   #if HAS_HEATED_BED
-    labelBed = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelBed, &tft_style_label_rel);
-    lv_obj_set_pos(labelBed, 250, 196);
+    labelBed = lv_label_create(scr, 250, 196, NULL);
   #endif
 
-  labelFan = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelFan, &tft_style_label_rel);
-  lv_obj_set_pos(labelFan, 395, 196);
-
-  labelTime = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelTime, &tft_style_label_rel);
-  lv_obj_set_pos(labelTime, 250, 96);
-
-  labelZpos = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelZpos, &tft_style_label_rel);
-  lv_obj_set_pos(labelZpos, 395, 96);
+  labelFan = lv_label_create(scr, 395, 196, NULL);
+  labelTime = lv_label_create(scr, 250, 96, NULL);
+  labelZpos = lv_label_create(scr, 395, 96, NULL);
 
   labelPause  = lv_label_create(buttonPause, NULL);
   labelStop   = lv_label_create(buttonStop, NULL);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ready_print.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ready_print.cpp
@@ -112,7 +112,7 @@ void disp_det_error() {
 lv_obj_t *e1, *e2, *e3, *bed;
 void mks_disp_test() {
   char buf[30] = {0};
-  //lv_obj_t *label_tool2 = lv_label_create(scr, NULL);
+  //lv_obj_t *label_tool2 = lv_label_create_empty(scr);
   //lv_obj_set_pos(label_tool, 20, 50);
   ZERO(buf);
   sprintf_P(buf, PSTR("e1:%d"), (int)thermalManager.temp_hotend[0].celsius);
@@ -156,16 +156,11 @@ void lv_draw_ready_print(void) {
 
     // Create image buttons
     //buttonPrint = lv_imgbtn_create(scr, NULL);
-    buttonTool = lv_imgbtn_create(scr, NULL);
-    //buttonSet = lv_imgbtn_create(scr, NULL);
-
-    #if 1
-      lv_obj_set_event_cb_mks(buttonTool, event_handler, ID_TOOL, NULL, 0);
-      lv_imgbtn_set_src_both(buttonTool, "F:/bmp_tool.bin");
-      lv_imgbtn_use_label_style(buttonTool);
-    #endif
+    buttonTool = lv_imgbtn_create(scr, "F:/bmp_tool.bin", event_handler, ID_TOOL);
 
     lv_obj_set_pos(buttonTool, 360, 180);
+
+    //buttonSet = lv_imgbtn_create(scr, NULL);
     //lv_obj_set_pos(buttonSet, 180, 90);
     //lv_obj_set_pos(buttonPrint, 340, 90);
 
@@ -176,11 +171,10 @@ void lv_draw_ready_print(void) {
     // Create labels on the image buttons
     //lv_btn_set_layout(buttonPrint, LV_LAYOUT_OFF);
     //lv_btn_set_layout(buttonSet, LV_LAYOUT_OFF);
-    lv_btn_set_layout(buttonTool, LV_LAYOUT_OFF);
 
-    //lv_obj_t *label_print = lv_label_create(buttonPrint, NULL);
-    //lv_obj_t *label_set = lv_label_create(buttonSet, NULL);
-    lv_obj_t *label_tool = lv_label_create(buttonTool, NULL);
+    //lv_obj_t *label_print = lv_label_create_empty(buttonPrint);
+    //lv_obj_t *label_set = lv_label_create_empty(buttonSet);
+    lv_obj_t *label_tool = lv_label_create_empty(buttonTool);
     if (gCfgItems.multiple_language) {
       //lv_label_set_text(label_print, main_menu.print);
       //lv_obj_align(label_print, buttonPrint, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
@@ -195,30 +189,30 @@ void lv_draw_ready_print(void) {
     }
 
     #if 1
-      e1 = lv_label_create(scr, NULL);
+      e1 = lv_label_create_empty(scr);
       lv_obj_set_pos(e1, 20, 20);
       sprintf_P(buf, PSTR("e1:  %d"), (int)thermalManager.temp_hotend[0].celsius);
       lv_label_set_text(e1, buf);
       #if HAS_MULTI_HOTEND
-        e2 = lv_label_create(scr, NULL);
+        e2 = lv_label_create_empty(scr);
         lv_obj_set_pos(e2, 20, 45);
         sprintf_P(buf, PSTR("e1:  %d"), (int)thermalManager.temp_hotend[1].celsius);
         lv_label_set_text(e2, buf);
       #endif
 
-      //e3 = lv_label_create(scr, NULL);
+      //e3 = lv_label_create_empty(scr);
       //lv_obj_set_pos(e3, 20, 70);
       //sprintf_P(buf, PSTR("e1:  %d"), (int)thermalManager.temp_hotend[2].celsius);
       //lv_label_set_text(e3, buf);
 
       #if HAS_HEATED_BED
-        bed = lv_label_create(scr, NULL);
+        bed = lv_label_create_empty(scr);
         lv_obj_set_pos(bed, 20, 95);
         sprintf_P(buf, PSTR("bed:  %d"), (int)thermalManager.temp_bed.celsius);
         lv_label_set_text(bed, buf);
       #endif
 
-      limit_info = lv_label_create(scr, NULL);
+      limit_info = lv_label_create_empty(scr);
 
       lv_style_copy(&limit_style, &lv_style_scr);
       limit_style.body.main_color.full = 0X0000;
@@ -229,7 +223,7 @@ void lv_draw_ready_print(void) {
       lv_obj_set_pos(limit_info, 20, 120);
       lv_label_set_text(limit_info, " ");
 
-      det_info = lv_label_create(scr, NULL);
+      det_info = lv_label_create_empty(scr);
 
       lv_style_copy(&det_style, &lv_style_scr);
       det_style.body.main_color.full = 0X0000;
@@ -244,29 +238,14 @@ void lv_draw_ready_print(void) {
   }
   else {
     // Create an Image button
-    buttonTool = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonTool, 20, 90);
-    lv_obj_set_event_cb_mks(buttonTool, event_handler, ID_TOOL, NULL, 0);
-    lv_imgbtn_set_src_both(buttonTool, "F:/bmp_tool.bin");
-    lv_imgbtn_use_label_style(buttonTool);
-    lv_obj_t *label_tool  = lv_label_create(buttonTool, NULL);
-    lv_btn_set_layout(buttonTool, LV_LAYOUT_OFF);
+    buttonTool = lv_imgbtn_create(scr, "F:/bmp_tool.bin", 20, 90, event_handler, ID_TOOL);
+    lv_obj_t *label_tool = lv_label_create_empty(buttonTool);
 
-    buttonSet = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonSet, 180, 90);
-    lv_obj_set_event_cb_mks(buttonSet, event_handler, ID_SET, NULL, 0);
-    lv_imgbtn_set_src_both(buttonSet, "F:/bmp_set.bin");
-    lv_imgbtn_use_label_style(buttonSet);
-    lv_obj_t *label_set   = lv_label_create(buttonSet, NULL);
-    lv_btn_set_layout(buttonSet, LV_LAYOUT_OFF);
+    buttonSet = lv_imgbtn_create(scr, "F:/bmp_set.bin", 180, 90, event_handler, ID_SET);
+    lv_obj_t *label_set = lv_label_create_empty(buttonSet);
 
-    buttonPrint = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonPrint, 340, 90);
-    lv_obj_set_event_cb_mks(buttonPrint, event_handler, ID_PRINT, NULL, 0);
-    lv_imgbtn_set_src_both(buttonPrint, "F:/bmp_printing.bin");
-    lv_imgbtn_use_label_style(buttonPrint);
-    lv_obj_t *label_print = lv_label_create(buttonPrint, NULL);
-    lv_btn_set_layout(buttonPrint, LV_LAYOUT_OFF);
+    buttonPrint = lv_imgbtn_create(scr, "F:/bmp_printing.bin", 340, 90, event_handler, ID_PRINT);
+    lv_obj_t *label_print = lv_label_create_empty(buttonPrint);
 
     if (gCfgItems.multiple_language) {
       lv_label_set_text(label_print, main_menu.print);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ready_print.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ready_print.cpp
@@ -41,7 +41,7 @@
 
 #include <stdio.h>
 
-//static lv_obj_t *buttonPrint,*buttonTool,*buttonSet;
+//static lv_obj_t *buttonPrint, *buttonTool, *buttonSet;
 extern lv_group_t*  g;
 static lv_obj_t * scr;
 #if ENABLED(MKS_TEST)
@@ -113,7 +113,7 @@ lv_obj_t *e1, *e2, *e3, *bed;
 void mks_disp_test() {
   char buf[30] = {0};
   //lv_obj_t *label_tool2 = lv_label_create(scr, NULL);
-  //lv_obj_set_pos(label_tool,20,50);
+  //lv_obj_set_pos(label_tool, 20, 50);
   ZERO(buf);
   sprintf_P(buf, PSTR("e1:%d"), (int)thermalManager.temp_hotend[0].celsius);
   lv_label_set_text(e1, buf);
@@ -148,14 +148,11 @@ void lv_draw_ready_print(void) {
   lv_obj_set_style(scr, &tft_style_scr);
   lv_scr_load(scr);
   lv_obj_clean(scr);
-  //lv_obj_set_hidden(scr,true);
+  //lv_obj_set_hidden(scr, true);
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   if (mks_test_flag == 0x1E) {
-    //lv_obj_t * title = lv_label_create(scr, NULL);
-    //lv_obj_set_style(title, &tft_style_label_rel);
-    //lv_obj_set_pos(title,TITLE_XPOS,TITLE_YPOS);
-    //lv_label_set_text(title, creat_title_text());
+    //(void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
     // Create image buttons
     //buttonPrint = lv_imgbtn_create(scr, NULL);
@@ -164,19 +161,17 @@ void lv_draw_ready_print(void) {
 
     #if 1
       lv_obj_set_event_cb_mks(buttonTool, event_handler, ID_TOOL, NULL, 0);
-      lv_imgbtn_set_src(buttonTool, LV_BTN_STATE_REL, "F:/bmp_tool.bin");
-      lv_imgbtn_set_src(buttonTool, LV_BTN_STATE_PR, "F:/bmp_tool.bin");
-      lv_imgbtn_set_style(buttonTool, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonTool, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonTool, "F:/bmp_tool.bin");
+      lv_imgbtn_use_label_style(buttonTool);
     #endif
 
     lv_obj_set_pos(buttonTool, 360, 180);
-    //lv_obj_set_pos(buttonSet,180,90);
-    //lv_obj_set_pos(buttonPrint,340,90);
+    //lv_obj_set_pos(buttonSet, 180, 90);
+    //lv_obj_set_pos(buttonPrint, 340, 90);
 
-    //lv_obj_set_pos(buttonTool,SIMPLE_FIRST_PAGE_GRAP+1,(TFT_HEIGHT-BTN_Y_PIXEL)/2+2);
-    //lv_obj_set_pos(buttonSet,BTN_X_PIXEL+SIMPLE_FIRST_PAGE_GRAP*2+1,(TFT_HEIGHT-BTN_Y_PIXEL)/2+2);
-    //lv_obj_set_pos(buttonPrint,BTN_X_PIXEL*2+SIMPLE_FIRST_PAGE_GRAP*3+1,(TFT_HEIGHT-BTN_Y_PIXEL)/2+2);
+    //lv_obj_set_pos(buttonTool, SIMPLE_FIRST_PAGE_GRAP+1, (TFT_HEIGHT-BTN_Y_PIXEL)/2+2);
+    //lv_obj_set_pos(buttonSet, BTN_X_PIXEL+SIMPLE_FIRST_PAGE_GRAP*2+1, (TFT_HEIGHT-BTN_Y_PIXEL)/2+2);
+    //lv_obj_set_pos(buttonPrint, BTN_X_PIXEL*2+SIMPLE_FIRST_PAGE_GRAP*3+1, (TFT_HEIGHT-BTN_Y_PIXEL)/2+2);
 
     // Create labels on the image buttons
     //lv_btn_set_layout(buttonPrint, LV_LAYOUT_OFF);
@@ -188,13 +183,13 @@ void lv_draw_ready_print(void) {
     lv_obj_t *label_tool = lv_label_create(buttonTool, NULL);
     if (gCfgItems.multiple_language) {
       //lv_label_set_text(label_print, main_menu.print);
-      //lv_obj_align(label_print, buttonPrint, LV_ALIGN_IN_BOTTOM_MID,0, BUTTON_TEXT_Y_OFFSET);
+      //lv_obj_align(label_print, buttonPrint, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
 
       //lv_label_set_text(label_set, main_menu.set);
-      //lv_obj_align(label_set, buttonSet, LV_ALIGN_IN_BOTTOM_MID,0, BUTTON_TEXT_Y_OFFSET);
+      //lv_obj_align(label_set, buttonSet, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
 
-      //lv_label_set_style(label_tool,LV_BTN_STATE_PR,&tft_style_label_pre);
-      //lv_label_set_style(label_tool,LV_BTN_STATE_REL,&tft_style_label_rel);
+      //lv_label_set_style(label_tool, LV_BTN_STATE_PR, &tft_style_label_pre);
+      //lv_label_set_style(label_tool, LV_BTN_STATE_REL, &tft_style_label_rel);
       lv_label_set_text(label_tool, main_menu.tool);
       lv_obj_align(label_tool, buttonTool, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
@@ -212,7 +207,7 @@ void lv_draw_ready_print(void) {
       #endif
 
       //e3 = lv_label_create(scr, NULL);
-      //lv_obj_set_pos(e3,20,70);
+      //lv_obj_set_pos(e3, 20, 70);
       //sprintf_P(buf, PSTR("e1:  %d"), (int)thermalManager.temp_hotend[2].celsius);
       //lv_label_set_text(e3, buf);
 
@@ -252,30 +247,24 @@ void lv_draw_ready_print(void) {
     buttonTool = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonTool, 20, 90);
     lv_obj_set_event_cb_mks(buttonTool, event_handler, ID_TOOL, NULL, 0);
-    lv_imgbtn_set_src(buttonTool, LV_BTN_STATE_REL, "F:/bmp_tool.bin");
-    lv_imgbtn_set_src(buttonTool, LV_BTN_STATE_PR, "F:/bmp_tool.bin");
-    lv_imgbtn_set_style(buttonTool, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonTool, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonTool, "F:/bmp_tool.bin");
+    lv_imgbtn_use_label_style(buttonTool);
     lv_obj_t *label_tool  = lv_label_create(buttonTool, NULL);
     lv_btn_set_layout(buttonTool, LV_LAYOUT_OFF);
 
     buttonSet = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonSet, 180, 90);
     lv_obj_set_event_cb_mks(buttonSet, event_handler, ID_SET, NULL, 0);
-    lv_imgbtn_set_src(buttonSet, LV_BTN_STATE_REL, "F:/bmp_set.bin");
-    lv_imgbtn_set_src(buttonSet, LV_BTN_STATE_PR, "F:/bmp_set.bin");
-    lv_imgbtn_set_style(buttonSet, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonSet, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonSet, "F:/bmp_set.bin");
+    lv_imgbtn_use_label_style(buttonSet);
     lv_obj_t *label_set   = lv_label_create(buttonSet, NULL);
     lv_btn_set_layout(buttonSet, LV_LAYOUT_OFF);
 
     buttonPrint = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonPrint, 340, 90);
     lv_obj_set_event_cb_mks(buttonPrint, event_handler, ID_PRINT, NULL, 0);
-    lv_imgbtn_set_src(buttonPrint, LV_BTN_STATE_REL, "F:/bmp_printing.bin");
-    lv_imgbtn_set_src(buttonPrint, LV_BTN_STATE_PR, "F:/bmp_printing.bin");
-    lv_imgbtn_set_style(buttonPrint, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonPrint, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonPrint, "F:/bmp_printing.bin");
+    lv_imgbtn_use_label_style(buttonPrint);
     lv_obj_t *label_print = lv_label_create(buttonPrint, NULL);
     lv_btn_set_layout(buttonPrint, LV_LAYOUT_OFF);
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_set.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_set.cpp
@@ -194,10 +194,7 @@ void lv_draw_set(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -218,63 +215,46 @@ void lv_draw_set(void) {
   buttonBack        = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonEepromSet, event_handler, ID_S_EEPROM_SET, NULL, 0);
-  lv_imgbtn_set_src(buttonEepromSet, LV_BTN_STATE_REL, "F:/bmp_eeprom_settings.bin");
-  lv_imgbtn_set_src(buttonEepromSet, LV_BTN_STATE_PR, "F:/bmp_eeprom_settings.bin");
-  lv_imgbtn_set_style(buttonEepromSet, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonEepromSet, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonEepromSet, "F:/bmp_eeprom_settings.bin");
+  lv_imgbtn_use_label_style(buttonEepromSet);
 
   #if 1
     lv_obj_set_event_cb_mks(buttonFan, event_handler, ID_S_FAN, NULL, 0);
-    lv_imgbtn_set_src(buttonFan, LV_BTN_STATE_REL, "F:/bmp_fan.bin");
-    lv_imgbtn_set_src(buttonFan, LV_BTN_STATE_PR, "F:/bmp_fan.bin");
-    lv_imgbtn_set_style(buttonFan, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonFan, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonFan, "F:/bmp_fan.bin");
+    lv_imgbtn_use_label_style(buttonFan);
 
     lv_obj_set_event_cb_mks(buttonAbout, event_handler, ID_S_ABOUT, NULL, 0);
-    lv_imgbtn_set_src(buttonAbout, LV_BTN_STATE_REL, "F:/bmp_about.bin");
-    lv_imgbtn_set_src(buttonAbout, LV_BTN_STATE_PR, "F:/bmp_about.bin");
-    lv_imgbtn_set_style(buttonAbout, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonAbout, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonAbout, "F:/bmp_about.bin");
+    lv_imgbtn_use_label_style(buttonAbout);
 
     lv_obj_set_event_cb_mks(buMotorOff, event_handler, ID_S_MOTOR_OFF, NULL, 0);
 
     #if HAS_SUICIDE
-      lv_imgbtn_set_src(buMotorOff, LV_BTN_STATE_REL, "F:/bmp_manual_off.bin");
-      lv_imgbtn_set_src(buMotorOff, LV_BTN_STATE_PR, "F:/bmp_manual_off.bin");
+      lv_imgbtn_set_src_both(buMotorOff, "F:/bmp_manual_off.bin");
     #else
-      lv_imgbtn_set_src(buMotorOff, LV_BTN_STATE_REL, "F:/bmp_function1.bin");
-      lv_imgbtn_set_src(buMotorOff, LV_BTN_STATE_PR, "F:/bmp_function1.bin");
+      lv_imgbtn_set_src_both(buMotorOff, "F:/bmp_function1.bin");
     #endif
-    lv_imgbtn_set_style(buMotorOff, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buMotorOff, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buMotorOff);
 
     lv_obj_set_event_cb_mks(buttonMachinePara, event_handler, ID_S_MACHINE_PARA, NULL, 0);
-    lv_imgbtn_set_src(buttonMachinePara, LV_BTN_STATE_REL, "F:/bmp_machine_para.bin");
-    lv_imgbtn_set_src(buttonMachinePara, LV_BTN_STATE_PR, "F:/bmp_machine_para.bin");
-    lv_imgbtn_set_style(buttonMachinePara, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonMachinePara, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonMachinePara, "F:/bmp_machine_para.bin");
+    lv_imgbtn_use_label_style(buttonMachinePara);
 
     #if HAS_LANG_SELECT_SCREEN
       lv_obj_set_event_cb_mks(buttonLanguage, event_handler, ID_S_LANGUAGE, NULL, 0);
-      lv_imgbtn_set_src(buttonLanguage, LV_BTN_STATE_REL, "F:/bmp_language.bin");
-      lv_imgbtn_set_src(buttonLanguage, LV_BTN_STATE_PR, "F:/bmp_language.bin");
-      lv_imgbtn_set_style(buttonLanguage, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonLanguage, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonLanguage, "F:/bmp_language.bin");
+      lv_imgbtn_use_label_style(buttonLanguage);
     #endif
 
     #if ENABLED(USE_WIFI_FUNCTION)
-      lv_obj_set_event_cb_mks(buttonWifi, event_handler,ID_S_WIFI,NULL,0);
-      lv_imgbtn_set_src(buttonWifi, LV_BTN_STATE_REL, "F:/bmp_wifi.bin");
-      lv_imgbtn_set_src(buttonWifi, LV_BTN_STATE_PR, "F:/bmp_wifi.bin");
-      lv_imgbtn_set_style(buttonWifi, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonWifi, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_obj_set_event_cb_mks(buttonWifi, event_handler,ID_S_WIFI,NULL, 0);
+      lv_imgbtn_set_src_both(buttonWifi, "F:/bmp_wifi.bin");
+      lv_imgbtn_use_label_style(buttonWifi);
     #endif
 
     lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_S_RETURN,NULL , 0);
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-    lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+    lv_imgbtn_use_label_style(buttonBack);
 
   #endif // if 1
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_set.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_set.cpp
@@ -199,64 +199,20 @@ void lv_draw_set(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create image buttons
-  buttonEepromSet   = lv_imgbtn_create(scr, NULL);
-  //buttonWifi      = lv_imgbtn_create(scr, NULL);
-  buttonFan         = lv_imgbtn_create(scr, NULL);
-  buttonAbout       = lv_imgbtn_create(scr, NULL);
-  //buttonContinue  = lv_imgbtn_create(scr, NULL);
-  buMotorOff        = lv_imgbtn_create(scr, NULL);
-  buttonMachinePara = lv_imgbtn_create(scr, NULL);
+  buttonEepromSet = lv_imgbtn_create(scr, "F:/bmp_eeprom_settings.bin", INTERVAL_V, titleHeight, event_handler, ID_S_EEPROM_SET);
+  //buttonWifi = lv_imgbtn_create(scr, NULL);
+  buttonFan = lv_imgbtn_create(scr, "F:/bmp_fan.bin", BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_S_FAN);
+  buttonAbout = lv_imgbtn_create(scr, "F:/bmp_about.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_S_ABOUT);
+  //buttonContinue = lv_imgbtn_create(scr, NULL);
+  buMotorOff = lv_imgbtn_create(scr, ENABLED(HAS_SUICIDE) ? "F:/bmp_manual_off.bin" : "F:/bmp_function1.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_S_MOTOR_OFF);
+  buttonMachinePara = lv_imgbtn_create(scr, "F:/bmp_machine_para.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_S_MACHINE_PARA);
   #if HAS_LANG_SELECT_SCREEN
-    buttonLanguage  = lv_imgbtn_create(scr, NULL);
+    buttonLanguage = lv_imgbtn_create(scr, "F:/bmp_language.bin", BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_S_LANGUAGE);
   #endif
   #if ENABLED(USE_WIFI_FUNCTION)
-  buttonWifi        = lv_imgbtn_create(scr, NULL);
+    buttonWifi = lv_imgbtn_create(scr, "F:/bmp_wifi.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_S_WIFI);
   #endif
-  buttonBack        = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonEepromSet, event_handler, ID_S_EEPROM_SET, NULL, 0);
-  lv_imgbtn_set_src_both(buttonEepromSet, "F:/bmp_eeprom_settings.bin");
-  lv_imgbtn_use_label_style(buttonEepromSet);
-
-  #if 1
-    lv_obj_set_event_cb_mks(buttonFan, event_handler, ID_S_FAN, NULL, 0);
-    lv_imgbtn_set_src_both(buttonFan, "F:/bmp_fan.bin");
-    lv_imgbtn_use_label_style(buttonFan);
-
-    lv_obj_set_event_cb_mks(buttonAbout, event_handler, ID_S_ABOUT, NULL, 0);
-    lv_imgbtn_set_src_both(buttonAbout, "F:/bmp_about.bin");
-    lv_imgbtn_use_label_style(buttonAbout);
-
-    lv_obj_set_event_cb_mks(buMotorOff, event_handler, ID_S_MOTOR_OFF, NULL, 0);
-
-    #if HAS_SUICIDE
-      lv_imgbtn_set_src_both(buMotorOff, "F:/bmp_manual_off.bin");
-    #else
-      lv_imgbtn_set_src_both(buMotorOff, "F:/bmp_function1.bin");
-    #endif
-    lv_imgbtn_use_label_style(buMotorOff);
-
-    lv_obj_set_event_cb_mks(buttonMachinePara, event_handler, ID_S_MACHINE_PARA, NULL, 0);
-    lv_imgbtn_set_src_both(buttonMachinePara, "F:/bmp_machine_para.bin");
-    lv_imgbtn_use_label_style(buttonMachinePara);
-
-    #if HAS_LANG_SELECT_SCREEN
-      lv_obj_set_event_cb_mks(buttonLanguage, event_handler, ID_S_LANGUAGE, NULL, 0);
-      lv_imgbtn_set_src_both(buttonLanguage, "F:/bmp_language.bin");
-      lv_imgbtn_use_label_style(buttonLanguage);
-    #endif
-
-    #if ENABLED(USE_WIFI_FUNCTION)
-      lv_obj_set_event_cb_mks(buttonWifi, event_handler,ID_S_WIFI,NULL, 0);
-      lv_imgbtn_set_src_both(buttonWifi, "F:/bmp_wifi.bin");
-      lv_imgbtn_use_label_style(buttonWifi);
-    #endif
-
-    lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_S_RETURN,NULL , 0);
-    lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-    lv_imgbtn_use_label_style(buttonBack);
-
-  #endif // if 1
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_S_RETURN);
 
   /*lv_obj_set_pos(buttonWifi,INTERVAL_V,titleHeight);
   lv_obj_set_pos(buttonFan,BTN_X_PIXEL+INTERVAL_V*2,titleHeight);
@@ -267,51 +223,23 @@ void lv_draw_set(void) {
   lv_obj_set_pos(buttonBack,BTN_X_PIXEL*3+INTERVAL_V*4, BTN_Y_PIXEL+INTERVAL_H+titleHeight);*/
 
   //lv_obj_set_pos(buttonWifi,INTERVAL_V,titleHeight);
-  lv_obj_set_pos(buttonEepromSet, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonFan, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
-  lv_obj_set_pos(buttonAbout, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
   //lv_obj_set_pos(buttonContinue,BTN_X_PIXEL*3+INTERVAL_V*4,titleHeight);
-  lv_obj_set_pos(buMotorOff, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-
-  lv_obj_set_pos(buttonMachinePara, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  #if HAS_LANG_SELECT_SCREEN
-    lv_obj_set_pos(buttonLanguage, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  #endif
-  #if ENABLED(USE_WIFI_FUNCTION)
-    lv_obj_set_pos(buttonWifi,BTN_X_PIXEL*2+INTERVAL_V*3,BTN_Y_PIXEL+INTERVAL_H+titleHeight);
-  #endif
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
 
   /// Create labels on the buttons
-  //lv_btn_set_layout(buttonWifi, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonEepromSet, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonFan, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonAbout, LV_LAYOUT_OFF);
-  //lv_btn_set_layout(buttonContinue, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buMotorOff, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonMachinePara, LV_LAYOUT_OFF);
+  //lv_obj_t *labelWifi= lv_label_create_empty(buttonWifi);
+  lv_obj_t *label_EepromSet   = lv_label_create_empty(buttonEepromSet);
+  lv_obj_t *labelFan          = lv_label_create_empty(buttonFan);
+  lv_obj_t *label_About       = lv_label_create_empty(buttonAbout);
+  //lv_obj_t *label_Continue  = lv_label_create_empty(buttonContinue);
+  lv_obj_t *label_MotorOff    = lv_label_create_empty(buMotorOff);
+  lv_obj_t *label_MachinePara = lv_label_create_empty(buttonMachinePara);
   #if HAS_LANG_SELECT_SCREEN
-    lv_btn_set_layout(buttonLanguage, LV_LAYOUT_OFF);
+    lv_obj_t *label_Language  = lv_label_create_empty(buttonLanguage);
   #endif
   #if ENABLED(USE_WIFI_FUNCTION)
-    lv_btn_set_layout(buttonWifi, LV_LAYOUT_OFF);
+    lv_obj_t *label_Wifi      = lv_label_create_empty(buttonWifi);
   #endif
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  //lv_obj_t *labelWifi= lv_label_create(buttonWifi, NULL);
-  lv_obj_t *label_EepromSet   = lv_label_create(buttonEepromSet, NULL);
-  lv_obj_t *labelFan          = lv_label_create(buttonFan, NULL);
-  lv_obj_t *label_About       = lv_label_create(buttonAbout, NULL);
-  //lv_obj_t *label_Continue  = lv_label_create(buttonContinue, NULL);
-  lv_obj_t *label_MotorOff    = lv_label_create(buMotorOff, NULL);
-  lv_obj_t *label_MachinePara = lv_label_create(buttonMachinePara, NULL);
-  #if HAS_LANG_SELECT_SCREEN
-    lv_obj_t *label_Language  = lv_label_create(buttonLanguage, NULL);
-  #endif
-  #if ENABLED(USE_WIFI_FUNCTION)
-    lv_obj_t *label_Wifi      = lv_label_create(buttonWifi, NULL);
-  #endif
-  lv_obj_t *label_Back        = lv_label_create(buttonBack, NULL);
+  lv_obj_t *label_Back        = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_step_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_step_settings.cpp
@@ -153,55 +153,37 @@ void lv_draw_step_settings(void) {
   if (uiCfg.para_ui_page != 1) {
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.X_Steps);
 
-    buttonXValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_STEP_X, NULL, 0);
-    lv_btn_set_style_both(buttonXValue, &style_para_value);
-    labelXValue = lv_label_create(buttonXValue, NULL);
+    buttonXValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_STEP_X);
+    labelXValue = lv_label_create_empty(buttonXValue);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Y_Steps);
 
-    buttonYValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_STEP_Y, NULL, 0);
-    lv_btn_set_style_both(buttonYValue, &style_para_value);
-    labelYValue = lv_label_create(buttonYValue, NULL);
+    buttonYValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_STEP_Y);
+    labelYValue = lv_label_create_empty(buttonYValue);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Z_Steps);
 
-    buttonZValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_STEP_Z, NULL, 0);
-    lv_btn_set_style_both(buttonZValue, &style_para_value);
-    labelZValue = lv_label_create(buttonZValue, NULL);
+    buttonZValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_STEP_Z);
+    labelZValue = lv_label_create_empty(buttonZValue);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E0_Steps);
 
-    buttonE0Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonE0Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonE0Value, event_handler, ID_STEP_E0, NULL, 0);
-    lv_btn_set_style_both(buttonE0Value, &style_para_value);
-    labelE0Value = lv_label_create(buttonE0Value, NULL);
+    buttonE0Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_STEP_E0);
+    labelE0Value = lv_label_create_empty(buttonE0Value);
 
     line4 = lv_line_create(scr, NULL);
     lv_ex_line(line4, line_points[3]);
 
-    buttonTurnPage = lv_btn_create(scr, NULL);
-    lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_STEP_DOWN, NULL, 0);
-    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
+    buttonTurnPage = lv_btn_create(scr, event_handler, ID_STEP_DOWN);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -216,19 +198,13 @@ void lv_draw_step_settings(void) {
   else {
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.E1_Steps);
 
-    buttonE1Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonE1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonE1Value, event_handler, ID_STEP_E1, NULL, 0);
-    lv_btn_set_style_both(buttonE1Value, &style_para_value);
-    labelE1Value = lv_label_create(buttonE1Value, NULL);
+    buttonE1Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_STEP_E1);
+    labelE1Value = lv_label_create_empty(buttonE1Value);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    buttonTurnPage = lv_btn_create(scr, NULL);
-    lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_STEP_UP, NULL, 0);
-    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
+    buttonTurnPage = lv_btn_create(scr, event_handler, ID_STEP_UP);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -240,14 +216,14 @@ void lv_draw_step_settings(void) {
 
   lv_obj_set_pos(buttonTurnPage, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
   lv_obj_set_size(buttonTurnPage, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  labelTurnPage = lv_label_create(buttonTurnPage, NULL);
+  labelTurnPage = lv_label_create_empty(buttonTurnPage);
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_btn_set_style_both(buttonBack, &style_para_back);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_STEP_RETURN, NULL, 0);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_step_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_step_settings.cpp
@@ -128,12 +128,12 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_step_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL, *buttonTurnPage = NULL, *labelTurnPage = NULL;
-  lv_obj_t *labelXText = NULL, *buttonXValue = NULL, *labelXValue = NULL;
-  lv_obj_t *labelYText = NULL, *buttonYValue = NULL, *labelYValue = NULL;
-  lv_obj_t *labelZText = NULL, *buttonZValue = NULL, *labelZValue = NULL;
-  lv_obj_t *labelE0Text = NULL, *buttonE0Value = NULL, *labelE0Value = NULL;
-  lv_obj_t *labelE1Text = NULL, *buttonE1Value = NULL, *labelE1Value = NULL;
-  lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL, * line4 = NULL;
+  lv_obj_t *buttonXValue = NULL, *labelXValue = NULL;
+  lv_obj_t *buttonYValue = NULL, *labelYValue = NULL;
+  lv_obj_t *buttonZValue = NULL, *labelZValue = NULL;
+  lv_obj_t *buttonE0Value = NULL, *labelE0Value = NULL;
+  lv_obj_t *buttonE1Value = NULL, *labelE1Value = NULL;
+  lv_obj_t *line1 = NULL, *line2 = NULL, *line3 = NULL, *line4 = NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != STEPS_UI) {
     disp_state_stack._disp_index++;
     disp_state_stack._disp_state[disp_state_stack._disp_index] = STEPS_UI;
@@ -146,73 +146,54 @@ void lv_draw_step_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.StepsConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.StepsConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   if (uiCfg.para_ui_page != 1) {
-    labelXText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelXText, &tft_style_label_rel);
-    lv_obj_set_pos(labelXText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelXText, machine_menu.X_Steps);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.X_Steps);
 
     buttonXValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_STEP_X, NULL, 0);
-    lv_btn_set_style(buttonXValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonXValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonXValue, &style_para_value);
     labelXValue = lv_label_create(buttonXValue, NULL);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    labelYText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelYText, &tft_style_label_rel);
-    lv_obj_set_pos(labelYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-    lv_label_set_text(labelYText, machine_menu.Y_Steps);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Y_Steps);
 
     buttonYValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_STEP_Y, NULL, 0);
-    lv_btn_set_style(buttonYValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonYValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonYValue, &style_para_value);
     labelYValue = lv_label_create(buttonYValue, NULL);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    labelZText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelZText, &tft_style_label_rel);
-    lv_obj_set_pos(labelZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-    lv_label_set_text(labelZText, machine_menu.Z_Steps);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Z_Steps);
 
     buttonZValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_STEP_Z, NULL, 0);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonZValue, &style_para_value);
     labelZValue = lv_label_create(buttonZValue, NULL);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    labelE0Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelE0Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelE0Text, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-    lv_label_set_text(labelE0Text, machine_menu.E0_Steps);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E0_Steps);
 
     buttonE0Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonE0Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonE0Value, event_handler, ID_STEP_E0, NULL, 0);
-    lv_btn_set_style(buttonE0Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonE0Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonE0Value, &style_para_value);
     labelE0Value = lv_label_create(buttonE0Value, NULL);
 
     line4 = lv_line_create(scr, NULL);
@@ -220,8 +201,7 @@ void lv_draw_step_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_STEP_DOWN, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -234,17 +214,13 @@ void lv_draw_step_settings(void) {
     #endif
   }
   else {
-    labelE1Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelE1Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelE1Text, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelE1Text, machine_menu.E1_Steps);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.E1_Steps);
 
     buttonE1Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonE1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonE1Value, event_handler, ID_STEP_E1, NULL, 0);
-    lv_btn_set_style(buttonE1Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonE1Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonE1Value, &style_para_value);
     labelE1Value = lv_label_create(buttonE1Value, NULL);
 
     line1 = lv_line_create(scr, NULL);
@@ -252,8 +228,7 @@ void lv_draw_step_settings(void) {
 
     buttonTurnPage = lv_btn_create(scr, NULL);
     lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_STEP_UP, NULL, 0);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-    lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+    lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -268,8 +243,7 @@ void lv_draw_step_settings(void) {
   labelTurnPage = lv_label_create(buttonTurnPage, NULL);
 
   buttonBack = lv_btn_create(scr, NULL);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_STEP_RETURN, NULL, 0);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_tmc_current_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_tmc_current_settings.cpp
@@ -143,10 +143,10 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
 void lv_draw_tmc_current_settings(void) {
   lv_obj_t *buttonBack = NULL, *label_Back = NULL;
-  lv_obj_t *labelXText = NULL, *buttonXValue = NULL, *labelXValue = NULL;
-  lv_obj_t *labelYText = NULL, *buttonYValue = NULL, *labelYValue = NULL;
-  lv_obj_t *labelZText = NULL, *buttonZValue = NULL, *labelZValue = NULL;
-  lv_obj_t *labelE0Text = NULL, *buttonE0Value = NULL, *labelE0Value = NULL;
+  lv_obj_t *buttonXValue = NULL, *labelXValue = NULL;
+  lv_obj_t *buttonYValue = NULL, *labelYValue = NULL;
+  lv_obj_t *buttonZValue = NULL, *labelZValue = NULL;
+  lv_obj_t *buttonE0Value = NULL, *labelE0Value = NULL;
 
   lv_obj_t * line1 = NULL, * line2 = NULL, * line3 = NULL, * line4 = NULL;
   //#if AXIS_IS_TMC(E1)
@@ -167,73 +167,54 @@ void lv_draw_tmc_current_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.TmcCurrentConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.TmcCurrentConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   if (uiCfg.para_ui_page != 1) {
-    labelXText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelXText, &tft_style_label_rel);
-    lv_obj_set_pos(labelXText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-    lv_label_set_text(labelXText, machine_menu.X_Current);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.X_Current);
 
     buttonXValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_TMC_CURRENT_X, NULL, 0);
-    lv_btn_set_style(buttonXValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonXValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonXValue, &style_para_value);
     labelXValue = lv_label_create(buttonXValue, NULL);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    labelYText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelYText, &tft_style_label_rel);
-    lv_obj_set_pos(labelYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
-    lv_label_set_text(labelYText, machine_menu.Y_Current);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Y_Current);
 
     buttonYValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_TMC_CURRENT_Y, NULL, 0);
-    lv_btn_set_style(buttonYValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonYValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonYValue, &style_para_value);
     labelYValue = lv_label_create(buttonYValue, NULL);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    labelZText = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelZText, &tft_style_label_rel);
-    lv_obj_set_pos(labelZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
-    lv_label_set_text(labelZText, machine_menu.Z_Current);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Z_Current);
 
     buttonZValue = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_TMC_CURRENT_Z, NULL, 0);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonZValue, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonZValue, &style_para_value);
     labelZValue = lv_label_create(buttonZValue, NULL);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    labelE0Text = lv_label_create(scr, NULL);
-    lv_obj_set_style(labelE0Text, &tft_style_label_rel);
-    lv_obj_set_pos(labelE0Text, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-    lv_label_set_text(labelE0Text, machine_menu.E0_Current);
+    (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E0_Current);
 
     buttonE0Value = lv_btn_create(scr, NULL);
     lv_obj_set_pos(buttonE0Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
     lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
     lv_obj_set_event_cb_mks(buttonE0Value, event_handler, ID_TMC_CURRENT_E0, NULL, 0);
-    lv_btn_set_style(buttonE0Value, LV_BTN_STYLE_REL, &style_para_value);
-    lv_btn_set_style(buttonE0Value, LV_BTN_STYLE_PR, &style_para_value);
+    lv_btn_set_style_both(buttonE0Value, &style_para_value);
     labelE0Value = lv_label_create(buttonE0Value, NULL);
 
     #if HAS_ROTARY_ENCODER
@@ -251,8 +232,7 @@ void lv_draw_tmc_current_settings(void) {
     //#if AXIS_IS_TMC(E1)
       buttonTurnPage = lv_btn_create(scr, NULL);
       lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_TMC_CURRENT_DOWN, NULL, 0);
-      lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-      lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+      lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
       #if HAS_ROTARY_ENCODER
         if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonTurnPage);
@@ -261,17 +241,13 @@ void lv_draw_tmc_current_settings(void) {
   }
   else {
     //#if AXIS_IS_TMC(E1)
-      labelE1Text = lv_label_create(scr, NULL);
-      lv_obj_set_style(labelE1Text, &tft_style_label_rel);
-      lv_obj_set_pos(labelE1Text, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-      lv_label_set_text(labelE1Text, machine_menu.E1_Current);
+      labelE1Text = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.E1_Current);
 
       buttonE1Value = lv_btn_create(scr, NULL);
       lv_obj_set_pos(buttonE1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
       lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
       lv_obj_set_event_cb_mks(buttonE1Value, event_handler, ID_TMC_CURRENT_E1, NULL, 0);
-      lv_btn_set_style(buttonE1Value, LV_BTN_STYLE_REL, &style_para_value);
-      lv_btn_set_style(buttonE1Value, LV_BTN_STYLE_PR, &style_para_value);
+      lv_btn_set_style_both(buttonE1Value, &style_para_value);
       labelE1Value = lv_label_create(buttonE1Value, NULL);
 
       line1 = lv_line_create(scr, NULL);
@@ -279,8 +255,7 @@ void lv_draw_tmc_current_settings(void) {
 
       buttonTurnPage = lv_btn_create(scr, NULL);
       lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_TMC_CURRENT_UP, NULL, 0);
-      lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_REL, &style_para_back);
-      lv_btn_set_style(buttonTurnPage, LV_BTN_STYLE_PR, &style_para_back);
+      lv_btn_set_style_both(buttonTurnPage, &style_para_back);
 
       #if HAS_ROTARY_ENCODER
         if (gCfgItems.encoder_enable) {
@@ -298,8 +273,7 @@ void lv_draw_tmc_current_settings(void) {
 
   buttonBack = lv_btn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_TMC_CURRENT_RETURN, NULL, 0);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_REL, &style_para_back);
-  lv_btn_set_style(buttonBack, LV_BTN_STYLE_PR, &style_para_back);
+  lv_btn_set_style_both(buttonBack, &style_para_back);
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_tmc_current_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_tmc_current_settings.cpp
@@ -174,48 +174,32 @@ void lv_draw_tmc_current_settings(void) {
   if (uiCfg.para_ui_page != 1) {
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.X_Current);
 
-    buttonXValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonXValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonXValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonXValue, event_handler, ID_TMC_CURRENT_X, NULL, 0);
-    lv_btn_set_style_both(buttonXValue, &style_para_value);
-    labelXValue = lv_label_create(buttonXValue, NULL);
+    buttonXValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_TMC_CURRENT_X);
+    labelXValue = lv_label_create_empty(buttonXValue);
 
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, machine_menu.Y_Current);
 
-    buttonYValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonYValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonYValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonYValue, event_handler, ID_TMC_CURRENT_Y, NULL, 0);
-    lv_btn_set_style_both(buttonYValue, &style_para_value);
-    labelYValue = lv_label_create(buttonYValue, NULL);
+    buttonYValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_TMC_CURRENT_Y);
+    labelYValue = lv_label_create_empty(buttonYValue);
 
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, machine_menu.Z_Current);
 
-    buttonZValue = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonZValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonZValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonZValue, event_handler, ID_TMC_CURRENT_Z, NULL, 0);
-    lv_btn_set_style_both(buttonZValue, &style_para_value);
-    labelZValue = lv_label_create(buttonZValue, NULL);
+    buttonZValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_TMC_CURRENT_Z);
+    labelZValue = lv_label_create_empty(buttonZValue);
 
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
     (void)lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.E0_Current);
 
-    buttonE0Value = lv_btn_create(scr, NULL);
-    lv_obj_set_pos(buttonE0Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V);
-    lv_obj_set_size(buttonE0Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-    lv_obj_set_event_cb_mks(buttonE0Value, event_handler, ID_TMC_CURRENT_E0, NULL, 0);
-    lv_btn_set_style_both(buttonE0Value, &style_para_value);
-    labelE0Value = lv_label_create(buttonE0Value, NULL);
+    buttonE0Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_TMC_CURRENT_E0);
+    labelE0Value = lv_label_create_empty(buttonE0Value);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) {
@@ -243,12 +227,8 @@ void lv_draw_tmc_current_settings(void) {
     //#if AXIS_IS_TMC(E1)
       labelE1Text = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.E1_Current);
 
-      buttonE1Value = lv_btn_create(scr, NULL);
-      lv_obj_set_pos(buttonE1Value, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-      lv_obj_set_size(buttonE1Value, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-      lv_obj_set_event_cb_mks(buttonE1Value, event_handler, ID_TMC_CURRENT_E1, NULL, 0);
-      lv_btn_set_style_both(buttonE1Value, &style_para_value);
-      labelE1Value = lv_label_create(buttonE1Value, NULL);
+      buttonE1Value = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_TMC_CURRENT_E1);
+      labelE1Value = lv_label_create_empty(buttonE1Value);
 
       line1 = lv_line_create(scr, NULL);
       lv_ex_line(line1, line_points[0]);
@@ -268,7 +248,7 @@ void lv_draw_tmc_current_settings(void) {
   //#if AXIS_IS_TMC(E1)
     lv_obj_set_pos(buttonTurnPage, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
     lv_obj_set_size(buttonTurnPage, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-    labelTurnPage = lv_label_create(buttonTurnPage, NULL);
+    labelTurnPage = lv_label_create_empty(buttonTurnPage);
   //#endif
 
   buttonBack = lv_btn_create(scr, NULL);
@@ -281,7 +261,7 @@ void lv_draw_tmc_current_settings(void) {
 
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_obj_set_size(buttonBack, PARA_UI_BACK_BTN_X_SIZE, PARA_UI_BACK_BTN_Y_SIZE);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     if (uiCfg.para_ui_page != 1) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_tmc_step_mode_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_tmc_step_mode_settings.cpp
@@ -248,27 +248,11 @@ void lv_draw_tmc_step_mode_settings(void) {
   #endif
 
   if (uiCfg.para_ui_page != 1) {
-    buttonXText = lv_btn_create(scr, NULL);                                 /*Add a button the current screen*/
-    lv_obj_set_pos(buttonXText, PARA_UI_POS_X, PARA_UI_POS_Y);              /*Set its position*/
-    lv_obj_set_size(buttonXText, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);     /*Set its size*/
-    lv_obj_set_event_cb(buttonXText, event_handler);
-    lv_btn_use_label_style(buttonXText);
-    lv_btn_set_layout(buttonXText, LV_LAYOUT_OFF);
-    labelXText = lv_label_create(buttonXText, NULL);                        /*Add a label to the button*/
+    buttonXText = lv_btn_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y, event_handler, 0);
+    labelXText = lv_label_create_empty(buttonXText);                        /*Add a label to the button*/
 
-    buttonXState = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonXState, PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V);
-    if (stealth_X) {
-      lv_imgbtn_set_src_both(buttonXState, "F:/bmp_enable.bin");
-    }
-    else {
-      lv_imgbtn_set_src_both(buttonXState, "F:/bmp_disable.bin");
-    }
-    lv_obj_set_event_cb_mks(buttonXState, event_handler, ID_TMC_MODE_X, NULL, 0);
-
-    lv_imgbtn_use_label_style(buttonXState);
-    lv_btn_set_layout(buttonXState, LV_LAYOUT_OFF);
-    labelXState = lv_label_create(buttonXState, NULL);
+    buttonXState = lv_imgbtn_create(scr, stealth_X ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin", PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V, event_handler, ID_TMC_MODE_X);
+    labelXState = lv_label_create_empty(buttonXState);
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonXState);
     #endif
@@ -276,22 +260,11 @@ void lv_draw_tmc_step_mode_settings(void) {
     line1 = lv_line_create(scr, NULL);
     lv_ex_line(line1, line_points[0]);
 
-    buttonYText = lv_btn_create(scr, NULL);                                 /*Add a button the current screen*/
-    lv_obj_set_pos(buttonYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2);          /*Set its position*/
-    lv_obj_set_size(buttonYText, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);     /*Set its size*/
-    lv_obj_set_event_cb(buttonYText, event_handler);
-    lv_btn_use_label_style(buttonYText);
-    lv_btn_set_layout(buttonYText, LV_LAYOUT_OFF);
-    labelYText = lv_label_create(buttonYText, NULL);                        /*Add a label to the button*/
+    buttonYText = lv_btn_create(scr, NULL, PARA_UI_POS_X, PARA_UI_POS_Y * 2, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y, event_handler, 0);
+    labelYText = lv_label_create_empty(buttonYText);                        /*Add a label to the button*/
 
-    buttonYState = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonYState, PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_STATE_V);
-    lv_imgbtn_set_src_both(buttonYState, stealth_Y ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
-    lv_obj_set_event_cb_mks(buttonYState, event_handler, ID_TMC_MODE_Y, NULL, 0);
-
-    lv_imgbtn_use_label_style(buttonYState);
-    lv_btn_set_layout(buttonYState, LV_LAYOUT_OFF);
-    labelYState = lv_label_create(buttonYState, NULL);
+    buttonYState = lv_imgbtn_create(scr, stealth_Y ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin", PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_STATE_V, event_handler, ID_TMC_MODE_Y);
+    labelYState = lv_label_create_empty(buttonYState);
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonYState);
     #endif
@@ -299,21 +272,11 @@ void lv_draw_tmc_step_mode_settings(void) {
     line2 = lv_line_create(scr, NULL);
     lv_ex_line(line2, line_points[1]);
 
-    buttonZText = lv_btn_create(scr, NULL);                                 /*Add a button the current screen*/
-    lv_obj_set_pos(buttonZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3);          /*Set its position*/
-    lv_obj_set_size(buttonZText, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);     /*Set its size*/
-    lv_obj_set_event_cb(buttonZText, event_handler);
-    lv_btn_use_label_style(buttonZText);
-    lv_btn_set_layout(buttonZText, LV_LAYOUT_OFF);
-    labelZText = lv_label_create(buttonZText, NULL);                        /*Add a label to the button*/
+    buttonZText = lv_btn_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y, event_handler, 0);
+    labelZText = lv_label_create_empty(buttonZText);                        /*Add a label to the button*/
 
-    buttonZState = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonZState, PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_STATE_V);
-    lv_imgbtn_set_src_both(buttonZState, stealth_Z ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
-    lv_obj_set_event_cb_mks(buttonZState, event_handler, ID_TMC_MODE_Z, NULL, 0);
-    lv_imgbtn_use_label_style(buttonZState);
-    lv_btn_set_layout(buttonZState, LV_LAYOUT_OFF);
-    labelZState = lv_label_create(buttonZState, NULL);
+    buttonZState = lv_imgbtn_create(scr, stealth_Z ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin", PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_STATE_V, event_handler, ID_TMC_MODE_Z);
+    labelZState = lv_label_create_empty(buttonZState);
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonZState);
     #endif
@@ -321,34 +284,20 @@ void lv_draw_tmc_step_mode_settings(void) {
     line3 = lv_line_create(scr, NULL);
     lv_ex_line(line3, line_points[2]);
 
-    buttonE0Text = lv_btn_create(scr, NULL);                                /*Add a button the current screen*/
-    lv_obj_set_pos(buttonE0Text, PARA_UI_POS_X, PARA_UI_POS_Y * 4);         /*Set its position*/
-    lv_obj_set_size(buttonE0Text, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);    /*Set its size*/
-    lv_obj_set_event_cb(buttonE0Text, event_handler);
-    lv_btn_use_label_style(buttonE0Text);
-    lv_btn_set_layout(buttonE0Text, LV_LAYOUT_OFF);
-    labelE0Text = lv_label_create(buttonE0Text, NULL);                      /*Add a label to the button*/
+    buttonE0Text = lv_btn_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y, event_handler, 0);
+    labelE0Text = lv_label_create_empty(buttonE0Text);                      /*Add a label to the button*/
 
-    buttonE0State = lv_imgbtn_create(scr, NULL);
-    lv_obj_set_pos(buttonE0State, PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_STATE_V);
-    lv_imgbtn_set_src_both(buttonE0State, stealth_E0 ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
-    lv_obj_set_event_cb_mks(buttonE0State, event_handler, ID_TMC_MODE_E0, NULL, 0);
-    lv_imgbtn_use_label_style(buttonE0State);
-    lv_btn_set_layout(buttonE0State, LV_LAYOUT_OFF);
-    labelE0State = lv_label_create(buttonE0State, NULL);
+    buttonE0State = lv_imgbtn_create(scr, stealth_E0 ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin", PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_STATE_V, event_handler, ID_TMC_MODE_E0);
+    labelE0State = lv_label_create_empty(buttonE0State);
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonE0State);
     #endif
-
 
     line4 = lv_line_create(scr, NULL);
     lv_ex_line(line4, line_points[3]);
 
     //#if AXIS_HAS_STEALTHCHOP(E1)
-      buttonTurnPage = lv_imgbtn_create(scr, NULL);
-      lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_TMC_MODE_DOWN, NULL, 0);
-      lv_imgbtn_set_src_both(buttonTurnPage, "F:/bmp_back70x40.bin");
-      lv_imgbtn_use_label_style(buttonTurnPage);
+      buttonTurnPage = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", event_handler, ID_TMC_MODE_DOWN);
       #if HAS_ROTARY_ENCODER
         if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonTurnPage);
       #endif
@@ -356,21 +305,11 @@ void lv_draw_tmc_step_mode_settings(void) {
   }
   else {
     //#if AXIS_HAS_STEALTHCHOP(E1)
-      buttonE1Text = lv_btn_create(scr, NULL);                                /*Add a button the current screen*/
-      lv_obj_set_pos(buttonE1Text, PARA_UI_POS_X, PARA_UI_POS_Y);             /*Set its position*/
-      lv_obj_set_size(buttonE1Text, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);    /*Set its size*/
-      lv_obj_set_event_cb(buttonE1Text, event_handler);
-      lv_btn_use_label_style(buttonE1Text);
-      lv_btn_set_layout(buttonE1Text, LV_LAYOUT_OFF);
-      labelE1Text = lv_label_create(buttonE1Text, NULL);                      /*Add a label to the button*/
+      buttonE1Text = lv_btn_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y, event_handler, 0);
+      labelE1Text = lv_label_create_empty(buttonE1Text);                      /*Add a label to the button*/
 
-      buttonE1State = lv_imgbtn_create(scr, NULL);
-      lv_obj_set_pos(buttonE1State, PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V);
-      lv_imgbtn_set_src_both(buttonE1State, stealth_E1 ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
-      lv_obj_set_event_cb_mks(buttonE1State, event_handler, ID_TMC_MODE_E1, NULL, 0);
-      lv_imgbtn_use_label_style(buttonE1State);
-      lv_btn_set_layout(buttonE1State, LV_LAYOUT_OFF);
-      labelE1State = lv_label_create(buttonE1State, NULL);
+      buttonE1State = lv_imgbtn_create(scr, stealth_E1 ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin", PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V, event_handler, ID_TMC_MODE_E1);
+      labelE1State = lv_label_create_empty(buttonE1State);
       #if HAS_ROTARY_ENCODER
         if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonE1State);
       #endif
@@ -378,29 +317,20 @@ void lv_draw_tmc_step_mode_settings(void) {
       line1 = lv_line_create(scr, NULL);
       lv_ex_line(line1, line_points[0]);
 
-      buttonTurnPage = lv_imgbtn_create(scr, NULL);
-      lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_TMC_MODE_UP, NULL, 0);
-      lv_imgbtn_set_src_both(buttonTurnPage, "F:/bmp_back70x40.bin");
-      lv_imgbtn_use_label_style(buttonTurnPage);
+      buttonTurnPage = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", event_handler, ID_TMC_MODE_UP);
     //#endif
   }
   //#if AXIS_HAS_STEALTHCHOP(E1)
     lv_obj_set_pos(buttonTurnPage, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
     lv_btn_set_layout(buttonTurnPage, LV_LAYOUT_OFF);
-    labelTurnPage = lv_label_create(buttonTurnPage, NULL);
+    labelTurnPage = lv_label_create_empty(buttonTurnPage);
   //#endif
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_TMC_MODE_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, event_handler, ID_TMC_MODE_RETURN);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif
-
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     if (uiCfg.para_ui_page != 1) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_tmc_step_mode_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_tmc_step_mode_settings.cpp
@@ -28,8 +28,11 @@
 
 #include "../../../../module/stepper/indirection.h"
 #include "../../../../feature/tmc_util.h"
-#include "../../../../gcode/gcode.h"
 #include "../../../../inc/MarlinConfig.h"
+
+#if ENABLED(EEPROM_SETTINGS)
+  #include "../../../../module/settings.h"
+#endif
 
 extern lv_group_t * g;
 static lv_obj_t * scr;
@@ -69,24 +72,16 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
         }
         else if (event == LV_EVENT_RELEASED) {
-          if (stepperX.stored.stealthChop_enabled) {
-            stepperX.stored.stealthChop_enabled = false;
-            stepperX.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-            lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-            lv_label_set_text(labelXState, machine_menu.disable);
-            //lv_obj_align(labelXState, buttonE1State, LV_ALIGN_IN_LEFT_MID,0, 0);
-            // gcode.process_subcommands_now_P(PSTR("M500"));
+          if (stepperX.toggle_stepping_mode()) {
+            lv_imgbtn_set_src_both(buttonXState, "F:/bmp_enable.bin");
+            lv_label_set_text(labelXState, machine_menu.enable);
           }
           else {
-            stepperX.stored.stealthChop_enabled = true;
-            stepperX.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-            lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-            lv_label_set_text(labelXState, machine_menu.enable);
-            // gcode.process_subcommands_now_P(PSTR("M500"));
+            lv_imgbtn_set_src_both(buttonXState, "F:/bmp_disable.bin");
+            lv_label_set_text(labelXState, machine_menu.disable);
+            //lv_obj_align(labelXState, buttonE1State, LV_ALIGN_IN_LEFT_MID,0, 0);
           }
-          gcode.process_subcommands_now_P(PSTR("M500"));
+          TERN_(EEPROM_SETTINGS, (void)settings.save());
         }
         break;
     #endif // if AXIS_HAS_STEALTHCHOP(X)
@@ -97,22 +92,16 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
         }
         else if (event == LV_EVENT_RELEASED) {
-          if (stepperY.stored.stealthChop_enabled) {
-            stepperY.stored.stealthChop_enabled = false;
-            stepperY.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-            lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
+          if (stepperY.toggle_stepping_mode()) {
+            lv_imgbtn_set_src_both(buttonYState, "F:/bmp_enable.bin");
+            lv_label_set_text(labelYState, machine_menu.enable);
+          }
+          else {
+            lv_imgbtn_set_src_both(buttonYState, "F:/bmp_disable.bin");
             lv_label_set_text(labelYState, machine_menu.disable);
             //lv_obj_align(labelXState, buttonE1State, LV_ALIGN_IN_LEFT_MID,0, 0);
           }
-          else {
-            stepperY.stored.stealthChop_enabled = true;
-            stepperY.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-            lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-            lv_label_set_text(labelYState, machine_menu.enable);
-          }
-          gcode.process_subcommands_now_P(PSTR("M500"));
+          TERN_(EEPROM_SETTINGS, (void)settings.save());
         }
         break;
     #endif // if AXIS_HAS_STEALTHCHOP(Y)
@@ -123,22 +112,16 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
         }
         else if (event == LV_EVENT_RELEASED) {
-          if (stepperZ.stored.stealthChop_enabled) {
-            stepperZ.stored.stealthChop_enabled = false;
-            stepperZ.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-            lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
+          if (stepperZ.toggle_stepping_mode()) {
+            lv_imgbtn_set_src_both(buttonZState, "F:/bmp_enable.bin");
+            lv_label_set_text(labelZState, machine_menu.enable);
+          }
+          else {
+            lv_imgbtn_set_src_both(buttonZState, "F:/bmp_disable.bin");
             lv_label_set_text(labelZState, machine_menu.disable);
             //lv_obj_align(labelXState, buttonE1State, LV_ALIGN_IN_LEFT_MID,0, 0);
           }
-          else {
-            stepperZ.stored.stealthChop_enabled = true;
-            stepperZ.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-            lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-            lv_label_set_text(labelZState, machine_menu.enable);
-          }
-          gcode.process_subcommands_now_P(PSTR("M500"));
+          TERN_(EEPROM_SETTINGS, (void)settings.save());
         }
         break;
     #endif // if AXIS_HAS_STEALTHCHOP(Z)
@@ -149,22 +132,16 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
         }
         else if (event == LV_EVENT_RELEASED) {
-          if (stepperE0.stored.stealthChop_enabled) {
-            stepperE0.stored.stealthChop_enabled = false;
-            stepperE0.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-            lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
+          if (stepperE0.toggle_stepping_mode()) {
+            lv_imgbtn_set_src_both(buttonE0State, "F:/bmp_enable.bin");
+            lv_label_set_text(labelE0State, machine_menu.enable);
+          }
+          else {
+            lv_imgbtn_set_src_both(buttonE0State, "F:/bmp_disable.bin");
             lv_label_set_text(labelE0State, machine_menu.disable);
             //lv_obj_align(labelXState, buttonE1State, LV_ALIGN_IN_LEFT_MID,0, 0);
           }
-          else {
-            stepperE0.stored.stealthChop_enabled = true;
-            stepperE0.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-            lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-            lv_label_set_text(labelE0State, machine_menu.enable);
-          }
-          gcode.process_subcommands_now_P(PSTR("M500"));
+          TERN_(EEPROM_SETTINGS, (void)settings.save());
         }
         break;
     #endif // if AXIS_HAS_STEALTHCHOP(E0)
@@ -175,22 +152,16 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
         }
         else if (event == LV_EVENT_RELEASED) {
-          if (stepperE1.stored.stealthChop_enabled) {
-            stepperE1.stored.stealthChop_enabled = false;
-            stepperE1.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-            lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
+          if (stepperE1.toggle_stepping_mode()) {
+            lv_imgbtn_set_src_both(buttonE1State, "F:/bmp_enable.bin");
+            lv_label_set_text(labelE1State, machine_menu.enable);
+          }
+          else {
+            lv_imgbtn_set_src_both(buttonE1State, "F:/bmp_disable.bin");
             lv_label_set_text(labelE1State, machine_menu.disable);
             //lv_obj_align(labelXState, buttonE1State, LV_ALIGN_IN_LEFT_MID,0, 0);
           }
-          else {
-            stepperE1.stored.stealthChop_enabled = true;
-            stepperE1.refresh_stepping_mode();
-            lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-            lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-            lv_label_set_text(labelE1State, machine_menu.enable);
-          }
-          gcode.process_subcommands_now_P(PSTR("M500"));
+          TERN_(EEPROM_SETTINGS, (void)settings.save());
         }
         break;
     #endif // if AXIS_HAS_STEALTHCHOP(E1)
@@ -255,42 +226,47 @@ void lv_draw_tmc_step_mode_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.TmcStepModeConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.TmcStepModeConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
+
+  bool stealth_X = false, stealth_Y = false, stealth_Z = false, stealth_E0 = false, stealth_E1 = false;
+  #if AXIS_HAS_STEALTHCHOP(X)
+    stealth_X = stepperX.get_stealthChop_status();
+  #endif
+  #if AXIS_HAS_STEALTHCHOP(Y)
+    stealth_Y = stepperY.get_stealthChop_status();
+  #endif
+  #if AXIS_HAS_STEALTHCHOP(Z)
+    stealth_Z = stepperZ.get_stealthChop_status();
+  #endif
+  #if AXIS_HAS_STEALTHCHOP(E0)
+    stealth_E0 = stepperE0.get_stealthChop_status();
+  #endif
+  #if AXIS_HAS_STEALTHCHOP(E1)
+    stealth_E1 = stepperE1.get_stealthChop_status();
+  #endif
 
   if (uiCfg.para_ui_page != 1) {
     buttonXText = lv_btn_create(scr, NULL);                                 /*Add a button the current screen*/
     lv_obj_set_pos(buttonXText, PARA_UI_POS_X, PARA_UI_POS_Y);              /*Set its position*/
     lv_obj_set_size(buttonXText, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);     /*Set its size*/
     lv_obj_set_event_cb(buttonXText, event_handler);
-    lv_btn_set_style(buttonXText, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-    lv_btn_set_style(buttonXText, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+    lv_btn_use_label_style(buttonXText);
     lv_btn_set_layout(buttonXText, LV_LAYOUT_OFF);
     labelXText = lv_label_create(buttonXText, NULL);                        /*Add a label to the button*/
 
     buttonXState = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonXState, PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V);
-    #if AXIS_HAS_STEALTHCHOP(X)
-    if (stepperX.get_stealthChop_status()) {
-      lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-      lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
+    if (stealth_X) {
+      lv_imgbtn_set_src_both(buttonXState, "F:/bmp_enable.bin");
     }
     else {
-      lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-      lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
+      lv_imgbtn_set_src_both(buttonXState, "F:/bmp_disable.bin");
     }
-    #else
-      lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-      lv_imgbtn_set_src(buttonXState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-    #endif
     lv_obj_set_event_cb_mks(buttonXState, event_handler, ID_TMC_MODE_X, NULL, 0);
 
-    lv_imgbtn_set_style(buttonXState, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonXState, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonXState);
     lv_btn_set_layout(buttonXState, LV_LAYOUT_OFF);
     labelXState = lv_label_create(buttonXState, NULL);
     #if HAS_ROTARY_ENCODER
@@ -304,30 +280,16 @@ void lv_draw_tmc_step_mode_settings(void) {
     lv_obj_set_pos(buttonYText, PARA_UI_POS_X, PARA_UI_POS_Y * 2);          /*Set its position*/
     lv_obj_set_size(buttonYText, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);     /*Set its size*/
     lv_obj_set_event_cb(buttonYText, event_handler);
-    lv_btn_set_style(buttonYText, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-    lv_btn_set_style(buttonYText, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+    lv_btn_use_label_style(buttonYText);
     lv_btn_set_layout(buttonYText, LV_LAYOUT_OFF);
     labelYText = lv_label_create(buttonYText, NULL);                        /*Add a label to the button*/
 
     buttonYState = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonYState, PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_STATE_V);
-    #if AXIS_HAS_STEALTHCHOP(Y)
-      if (stepperY.get_stealthChop_status()) {
-        lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-        lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-      }
-      else {
-        lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-        lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-      }
-    #else
-      lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-      lv_imgbtn_set_src(buttonYState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-    #endif
+    lv_imgbtn_set_src_both(buttonYState, stealth_Y ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
     lv_obj_set_event_cb_mks(buttonYState, event_handler, ID_TMC_MODE_Y, NULL, 0);
 
-    lv_imgbtn_set_style(buttonYState, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonYState, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonYState);
     lv_btn_set_layout(buttonYState, LV_LAYOUT_OFF);
     labelYState = lv_label_create(buttonYState, NULL);
     #if HAS_ROTARY_ENCODER
@@ -341,29 +303,15 @@ void lv_draw_tmc_step_mode_settings(void) {
     lv_obj_set_pos(buttonZText, PARA_UI_POS_X, PARA_UI_POS_Y * 3);          /*Set its position*/
     lv_obj_set_size(buttonZText, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);     /*Set its size*/
     lv_obj_set_event_cb(buttonZText, event_handler);
-    lv_btn_set_style(buttonZText, LV_BTN_STYLE_REL, &tft_style_label_rel);  /*Set the button's released style*/
-    lv_btn_set_style(buttonZText, LV_BTN_STYLE_PR, &tft_style_label_pre);   /*Set the button's pressed style*/
+    lv_btn_use_label_style(buttonZText);
     lv_btn_set_layout(buttonZText, LV_LAYOUT_OFF);
     labelZText = lv_label_create(buttonZText, NULL);                        /*Add a label to the button*/
 
     buttonZState = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonZState, PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_STATE_V);
-    #if AXIS_HAS_STEALTHCHOP(Z)
-      if (stepperZ.get_stealthChop_status()) {
-        lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-        lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-      }
-      else {
-        lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-        lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-      }
-    #else
-      lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-      lv_imgbtn_set_src(buttonZState, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-    #endif
+    lv_imgbtn_set_src_both(buttonZState, stealth_Z ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
     lv_obj_set_event_cb_mks(buttonZState, event_handler, ID_TMC_MODE_Z, NULL, 0);
-    lv_imgbtn_set_style(buttonZState, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonZState, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonZState);
     lv_btn_set_layout(buttonZState, LV_LAYOUT_OFF);
     labelZState = lv_label_create(buttonZState, NULL);
     #if HAS_ROTARY_ENCODER
@@ -377,31 +325,15 @@ void lv_draw_tmc_step_mode_settings(void) {
     lv_obj_set_pos(buttonE0Text, PARA_UI_POS_X, PARA_UI_POS_Y * 4);         /*Set its position*/
     lv_obj_set_size(buttonE0Text, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);    /*Set its size*/
     lv_obj_set_event_cb(buttonE0Text, event_handler);
-    lv_btn_set_style(buttonE0Text, LV_BTN_STYLE_REL, &tft_style_label_rel); /*Set the button's released style*/
-    lv_btn_set_style(buttonE0Text, LV_BTN_STYLE_PR, &tft_style_label_pre);  /*Set the button's pressed style*/
+    lv_btn_use_label_style(buttonE0Text);
     lv_btn_set_layout(buttonE0Text, LV_LAYOUT_OFF);
     labelE0Text = lv_label_create(buttonE0Text, NULL);                      /*Add a label to the button*/
 
     buttonE0State = lv_imgbtn_create(scr, NULL);
     lv_obj_set_pos(buttonE0State, PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_STATE_V);
-    #if AXIS_HAS_STEALTHCHOP(E0)
-      if (stepperE0.get_stealthChop_status()) {
-        lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-        lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-      }
-      else {
-        lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-        lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-      }
-    #else
-      lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-      lv_imgbtn_set_src(buttonE0State, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-    #endif
-
+    lv_imgbtn_set_src_both(buttonE0State, stealth_E0 ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
     lv_obj_set_event_cb_mks(buttonE0State, event_handler, ID_TMC_MODE_E0, NULL, 0);
-
-    lv_imgbtn_set_style(buttonE0State, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonE0State, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_imgbtn_use_label_style(buttonE0State);
     lv_btn_set_layout(buttonE0State, LV_LAYOUT_OFF);
     labelE0State = lv_label_create(buttonE0State, NULL);
     #if HAS_ROTARY_ENCODER
@@ -415,10 +347,8 @@ void lv_draw_tmc_step_mode_settings(void) {
     //#if AXIS_HAS_STEALTHCHOP(E1)
       buttonTurnPage = lv_imgbtn_create(scr, NULL);
       lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_TMC_MODE_DOWN, NULL, 0);
-      lv_imgbtn_set_src(buttonTurnPage, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-      lv_imgbtn_set_src(buttonTurnPage, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-      lv_imgbtn_set_style(buttonTurnPage, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonTurnPage, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonTurnPage, "F:/bmp_back70x40.bin");
+      lv_imgbtn_use_label_style(buttonTurnPage);
       #if HAS_ROTARY_ENCODER
         if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonTurnPage);
       #endif
@@ -430,29 +360,15 @@ void lv_draw_tmc_step_mode_settings(void) {
       lv_obj_set_pos(buttonE1Text, PARA_UI_POS_X, PARA_UI_POS_Y);             /*Set its position*/
       lv_obj_set_size(buttonE1Text, PARA_UI_VALUE_SIZE_X, PARA_UI_SIZE_Y);    /*Set its size*/
       lv_obj_set_event_cb(buttonE1Text, event_handler);
-      lv_btn_set_style(buttonE1Text, LV_BTN_STYLE_REL, &tft_style_label_rel); /*Set the button's released style*/
-      lv_btn_set_style(buttonE1Text, LV_BTN_STYLE_PR, &tft_style_label_pre);  /*Set the button's pressed style*/
+      lv_btn_use_label_style(buttonE1Text);
       lv_btn_set_layout(buttonE1Text, LV_LAYOUT_OFF);
       labelE1Text = lv_label_create(buttonE1Text, NULL);                      /*Add a label to the button*/
 
       buttonE1State = lv_imgbtn_create(scr, NULL);
       lv_obj_set_pos(buttonE1State, PARA_UI_STATE_POS_X, PARA_UI_POS_Y + PARA_UI_STATE_V);
-      #if AXIS_HAS_STEALTHCHOP(E1)
-        if (stepperE1.get_stealthChop_status()) {
-          lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-          lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-          }
-        else {
-          lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-          lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-        }
-      #else
-        lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-        lv_imgbtn_set_src(buttonE1State, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-      #endif
+      lv_imgbtn_set_src_both(buttonE1State, stealth_E1 ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
       lv_obj_set_event_cb_mks(buttonE1State, event_handler, ID_TMC_MODE_E1, NULL, 0);
-      lv_imgbtn_set_style(buttonE1State, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonE1State, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_use_label_style(buttonE1State);
       lv_btn_set_layout(buttonE1State, LV_LAYOUT_OFF);
       labelE1State = lv_label_create(buttonE1State, NULL);
       #if HAS_ROTARY_ENCODER
@@ -464,10 +380,8 @@ void lv_draw_tmc_step_mode_settings(void) {
 
       buttonTurnPage = lv_imgbtn_create(scr, NULL);
       lv_obj_set_event_cb_mks(buttonTurnPage, event_handler, ID_TMC_MODE_UP, NULL, 0);
-      lv_imgbtn_set_src(buttonTurnPage, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-      lv_imgbtn_set_src(buttonTurnPage, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-      lv_imgbtn_set_style(buttonTurnPage, LV_BTN_STATE_PR, &tft_style_label_pre);
-      lv_imgbtn_set_style(buttonTurnPage, LV_BTN_STATE_REL, &tft_style_label_rel);
+      lv_imgbtn_set_src_both(buttonTurnPage, "F:/bmp_back70x40.bin");
+      lv_imgbtn_use_label_style(buttonTurnPage);
     //#endif
   }
   //#if AXIS_HAS_STEALTHCHOP(E1)
@@ -478,10 +392,8 @@ void lv_draw_tmc_step_mode_settings(void) {
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_TMC_MODE_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif
@@ -504,44 +416,16 @@ void lv_draw_tmc_step_mode_settings(void) {
       lv_label_set_text(labelE0Text, machine_menu.E0_StepMode);
       lv_obj_align(labelE0Text, buttonE0Text, LV_ALIGN_IN_LEFT_MID, 0, 0);
 
-      #if AXIS_HAS_STEALTHCHOP(X)
-      if (stepperX.get_stealthChop_status())
-        lv_label_set_text(labelXState, machine_menu.enable);
-      else
-        lv_label_set_text(labelXState, machine_menu.disable);
-      #else
-        lv_label_set_text(labelXState, machine_menu.disable);
-      #endif
+      lv_label_set_text(labelXState, stealth_X ? machine_menu.enable : machine_menu.disable);
       lv_obj_align(labelXState, buttonXState, LV_ALIGN_CENTER, 0, 0);
 
-      #if AXIS_HAS_STEALTHCHOP(Y)
-      if (stepperY.get_stealthChop_status())
-        lv_label_set_text(labelYState, machine_menu.enable);
-      else
-        lv_label_set_text(labelYState, machine_menu.disable);
-      #else
-        lv_label_set_text(labelYState, machine_menu.disable);
-      #endif
+      lv_label_set_text(labelYState, stealth_Y ? machine_menu.enable : machine_menu.disable);
       lv_obj_align(labelYState, buttonYState, LV_ALIGN_CENTER, 0, 0);
 
-      #if AXIS_HAS_STEALTHCHOP(Z)
-      if (stepperZ.get_stealthChop_status())
-        lv_label_set_text(labelZState, machine_menu.enable);
-      else
-        lv_label_set_text(labelZState, machine_menu.disable);
-      #else
-        lv_label_set_text(labelZState, machine_menu.disable);
-      #endif
+      lv_label_set_text(labelZState, stealth_Z ? machine_menu.enable : machine_menu.disable);
       lv_obj_align(labelZState, buttonZState, LV_ALIGN_CENTER, 0, 0);
 
-      #if AXIS_HAS_STEALTHCHOP(E0)
-      if (stepperE0.get_stealthChop_status())
-        lv_label_set_text(labelE0State, machine_menu.enable);
-      else
-        lv_label_set_text(labelE0State, machine_menu.disable);
-      #else
-        lv_label_set_text(labelE0State, machine_menu.disable);
-      #endif
+      lv_label_set_text(labelE0State, stealth_E0 ? machine_menu.enable : machine_menu.disable);
       lv_obj_align(labelE0State, buttonE0State, LV_ALIGN_CENTER, 0, 0);
 
       //#if AXIS_HAS_STEALTHCHOP(E1)
@@ -553,14 +437,7 @@ void lv_draw_tmc_step_mode_settings(void) {
       //#if AXIS_HAS_STEALTHCHOP(E1)
         lv_label_set_text(labelE1Text, machine_menu.E1_StepMode);
         lv_obj_align(labelE1Text, buttonE1Text, LV_ALIGN_IN_LEFT_MID, 0, 0);
-        #if AXIS_HAS_STEALTHCHOP(E1)
-        if (stepperE1.get_stealthChop_status())
-          lv_label_set_text(labelE1State, machine_menu.enable);
-        else
-          lv_label_set_text(labelE1State, machine_menu.disable);
-        #else
-          lv_label_set_text(labelE1State, machine_menu.disable);
-        #endif
+        lv_label_set_text(labelE1State, stealth_E1 ? machine_menu.enable : machine_menu.disable);
         lv_obj_align(labelE1State, buttonE1State, LV_ALIGN_CENTER, 0, 0);
 
         lv_label_set_text(labelTurnPage, machine_menu.previous);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_tool.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_tool.cpp
@@ -149,10 +149,7 @@ void lv_draw_tool(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title, TITLE_XPOS, TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -167,46 +164,32 @@ void lv_draw_tool(void) {
   buttonBack      = lv_imgbtn_create(scr, NULL);
 
   lv_obj_set_event_cb_mks(buttonPreHeat, event_handler, ID_T_PRE_HEAT, NULL, 0);
-  lv_imgbtn_set_src(buttonPreHeat, LV_BTN_STATE_REL, "F:/bmp_preHeat.bin");
-  lv_imgbtn_set_src(buttonPreHeat, LV_BTN_STATE_PR, "F:/bmp_preHeat.bin");
-  lv_imgbtn_set_style(buttonPreHeat, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonPreHeat, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonPreHeat, "F:/bmp_preHeat.bin");
+  lv_imgbtn_use_label_style(buttonPreHeat);
 
   lv_obj_set_event_cb_mks(buttonExtrusion, event_handler, ID_T_EXTRUCT, NULL, 0);
-  lv_imgbtn_set_src(buttonExtrusion, LV_BTN_STATE_REL, "F:/bmp_extruct.bin");
-  lv_imgbtn_set_src(buttonExtrusion, LV_BTN_STATE_PR, "F:/bmp_extruct.bin");
-  lv_imgbtn_set_style(buttonExtrusion, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonExtrusion, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonExtrusion, "F:/bmp_extruct.bin");
+  lv_imgbtn_use_label_style(buttonExtrusion);
 
   lv_obj_set_event_cb_mks(buttonMove, event_handler, ID_T_MOV, NULL, 0);
-  lv_imgbtn_set_src(buttonMove, LV_BTN_STATE_REL, "F:/bmp_mov.bin");
-  lv_imgbtn_set_src(buttonMove, LV_BTN_STATE_PR, "F:/bmp_mov.bin");
-  lv_imgbtn_set_style(buttonMove, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonMove, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonMove, "F:/bmp_mov.bin");
+  lv_imgbtn_use_label_style(buttonMove);
 
   lv_obj_set_event_cb_mks(buttonHome, event_handler, ID_T_HOME, NULL, 0);
-  lv_imgbtn_set_src(buttonHome, LV_BTN_STATE_REL, "F:/bmp_zero.bin");
-  lv_imgbtn_set_src(buttonHome, LV_BTN_STATE_PR, "F:/bmp_zero.bin");
-  lv_imgbtn_set_style(buttonHome, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonHome, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonHome, "F:/bmp_zero.bin");
+  lv_imgbtn_use_label_style(buttonHome);
 
   lv_obj_set_event_cb_mks(buttonLevel, event_handler, ID_T_LEVELING, NULL, 0);
-  lv_imgbtn_set_src(buttonLevel, LV_BTN_STATE_REL, "F:/bmp_leveling.bin");
-  lv_imgbtn_set_src(buttonLevel, LV_BTN_STATE_PR, "F:/bmp_leveling.bin");
-  lv_imgbtn_set_style(buttonLevel, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonLevel, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonLevel, "F:/bmp_leveling.bin");
+  lv_imgbtn_use_label_style(buttonLevel);
 
-  lv_obj_set_event_cb_mks(buttonFilament, event_handler,ID_T_FILAMENT,NULL,0);
-  lv_imgbtn_set_src(buttonFilament, LV_BTN_STATE_REL, "F:/bmp_filamentchange.bin");
-  lv_imgbtn_set_src(buttonFilament, LV_BTN_STATE_PR, "F:/bmp_filamentchange.bin");
-  lv_imgbtn_set_style(buttonFilament, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonFilament, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_obj_set_event_cb_mks(buttonFilament, event_handler,ID_T_FILAMENT,NULL, 0);
+  lv_imgbtn_set_src_both(buttonFilament, "F:/bmp_filamentchange.bin");
+  lv_imgbtn_use_label_style(buttonFilament);
 
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_T_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
   lv_obj_set_pos(buttonPreHeat, INTERVAL_V, titleHeight);
   lv_obj_set_pos(buttonExtrusion, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_tool.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_tool.cpp
@@ -154,70 +154,25 @@ void lv_draw_tool(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create image buttons
-  buttonPreHeat   = lv_imgbtn_create(scr, NULL);
-  buttonExtrusion = lv_imgbtn_create(scr, NULL);
-  buttonMove      = lv_imgbtn_create(scr, NULL);
-  buttonHome      = lv_imgbtn_create(scr, NULL);
-  buttonLevel     = lv_imgbtn_create(scr, NULL);
-  buttonFilament  = lv_imgbtn_create(scr, NULL);
-  //buttonMore    = lv_imgbtn_create(scr, NULL);
-  buttonBack      = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonPreHeat, event_handler, ID_T_PRE_HEAT, NULL, 0);
-  lv_imgbtn_set_src_both(buttonPreHeat, "F:/bmp_preHeat.bin");
-  lv_imgbtn_use_label_style(buttonPreHeat);
-
-  lv_obj_set_event_cb_mks(buttonExtrusion, event_handler, ID_T_EXTRUCT, NULL, 0);
-  lv_imgbtn_set_src_both(buttonExtrusion, "F:/bmp_extruct.bin");
-  lv_imgbtn_use_label_style(buttonExtrusion);
-
-  lv_obj_set_event_cb_mks(buttonMove, event_handler, ID_T_MOV, NULL, 0);
-  lv_imgbtn_set_src_both(buttonMove, "F:/bmp_mov.bin");
-  lv_imgbtn_use_label_style(buttonMove);
-
-  lv_obj_set_event_cb_mks(buttonHome, event_handler, ID_T_HOME, NULL, 0);
-  lv_imgbtn_set_src_both(buttonHome, "F:/bmp_zero.bin");
-  lv_imgbtn_use_label_style(buttonHome);
-
-  lv_obj_set_event_cb_mks(buttonLevel, event_handler, ID_T_LEVELING, NULL, 0);
-  lv_imgbtn_set_src_both(buttonLevel, "F:/bmp_leveling.bin");
-  lv_imgbtn_use_label_style(buttonLevel);
-
-  lv_obj_set_event_cb_mks(buttonFilament, event_handler,ID_T_FILAMENT,NULL, 0);
-  lv_imgbtn_set_src_both(buttonFilament, "F:/bmp_filamentchange.bin");
-  lv_imgbtn_use_label_style(buttonFilament);
-
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_T_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-
-  lv_obj_set_pos(buttonPreHeat, INTERVAL_V, titleHeight);
-  lv_obj_set_pos(buttonExtrusion, BTN_X_PIXEL + INTERVAL_V * 2, titleHeight);
-  lv_obj_set_pos(buttonMove, BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight);
-  lv_obj_set_pos(buttonHome, BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight);
-  lv_obj_set_pos(buttonLevel, INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
-  lv_obj_set_pos(buttonFilament,BTN_X_PIXEL+INTERVAL_V*2,BTN_Y_PIXEL+INTERVAL_H+titleHeight);
+  buttonPreHeat   = lv_imgbtn_create(scr, "F:/bmp_preHeat.bin", INTERVAL_V, titleHeight, event_handler, ID_T_PRE_HEAT);
+  buttonExtrusion = lv_imgbtn_create(scr, "F:/bmp_extruct.bin", BTN_X_PIXEL + INTERVAL_V * 2, titleHeight, event_handler, ID_T_EXTRUCT);
+  buttonMove      = lv_imgbtn_create(scr, "F:/bmp_mov.bin", BTN_X_PIXEL * 2 + INTERVAL_V * 3, titleHeight, event_handler, ID_T_MOV);
+  buttonHome      = lv_imgbtn_create(scr, "F:/bmp_zero.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, titleHeight, event_handler, ID_T_HOME);
+  buttonLevel     = lv_imgbtn_create(scr, "F:/bmp_leveling.bin", INTERVAL_V, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_T_LEVELING);
+  buttonFilament  = lv_imgbtn_create(scr, "F:/bmp_filamentchange.bin",BTN_X_PIXEL+INTERVAL_V*2,BTN_Y_PIXEL+INTERVAL_H+titleHeight, event_handler,ID_T_FILAMENT);
+  //buttonMore    = lv_imgbtn_createx(scr, NULL);
   //lv_obj_set_pos(buttonMore,BTN_X_PIXEL*2+INTERVAL_V*3, BTN_Y_PIXEL+INTERVAL_H+titleHeight);
-  lv_obj_set_pos(buttonBack, BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
+  buttonBack      = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_T_RETURN);
 
   // Create labels on the image buttons
-  lv_btn_set_layout(buttonPreHeat, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonExtrusion, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonMove, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonHome, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonLevel, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonFilament, LV_LAYOUT_OFF);
-  //lv_btn_set_layout(buttonMore, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-
-  lv_obj_t *labelPreHeat   = lv_label_create(buttonPreHeat, NULL);
-  lv_obj_t *labelExtrusion = lv_label_create(buttonExtrusion, NULL);
-  lv_obj_t *label_Move     = lv_label_create(buttonMove, NULL);
-  lv_obj_t *label_Home     = lv_label_create(buttonHome, NULL);
-  lv_obj_t *label_Level    = lv_label_create(buttonLevel, NULL);
-  lv_obj_t *label_Filament = lv_label_create(buttonFilament, NULL);
-  //lv_obj_t *label_More   = lv_label_create(buttonMore, NULL);
-  lv_obj_t *label_Back     = lv_label_create(buttonBack, NULL);
+  lv_obj_t *labelPreHeat   = lv_label_create_empty(buttonPreHeat);
+  lv_obj_t *labelExtrusion = lv_label_create_empty(buttonExtrusion);
+  lv_obj_t *label_Move     = lv_label_create_empty(buttonMove);
+  lv_obj_t *label_Home     = lv_label_create_empty(buttonHome);
+  lv_obj_t *label_Level    = lv_label_create_empty(buttonLevel);
+  lv_obj_t *label_Filament = lv_label_create_empty(buttonFilament);
+  //lv_obj_t *label_More   = lv_label_create_empty(buttonMore);
+  lv_obj_t *label_Back     = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(labelPreHeat, tool_menu.preheat);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
@@ -1601,33 +1601,78 @@ void lv_btn_set_style_both(lv_obj_t *btn, lv_style_t *style) {
   lv_btn_set_style(btn, LV_BTN_STYLE_PR,  style);
 }
 
-// Create a label with style
-lv_obj_t* lv_label_create(const lv_obj_t *par) {
-  lv_obj_t *label = lv_label_create(par, NULL);
-  lv_obj_set_style(label, &tft_style_label_rel);
-  return label;
+// Create an empty label
+lv_obj_t* lv_label_create_empty(lv_obj_t *par) {
+  return lv_label_create(par, (lv_obj_t*)NULL);
 }
 
 // Create a label with style and text
-lv_obj_t* lv_label_create(const lv_obj_t *par, const char *text) {
-  lv_obj_t *label = lv_label_create(par);
+lv_obj_t* lv_label_create(lv_obj_t *par, const char *text) {
+  lv_obj_t *label = lv_label_create_empty(par);
   if (text) lv_label_set_text(label, text);
   return label;
 }
 
 // Create a label with style, position, and text
-lv_obj_t* lv_label_create(const lv_obj_t *par, lv_coord_t x, lv_coord_t y, const char *text) {
+lv_obj_t* lv_label_create(lv_obj_t *par, lv_coord_t x, lv_coord_t y, const char *text) {
   lv_obj_t *label = lv_label_create(par, text);
   lv_obj_set_pos(label, x, y);
   return label;
 }
 
-lv_obj_t* lv_btn_create(const lv_obj_t *par, const char *text, lv_event_cb_t cb, int id, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h) {
+// Create a button with callback, ID, and Style.
+lv_obj_t* lv_btn_create(lv_obj_t *par, lv_event_cb_t cb, const int id, lv_style_t *style) {
   lv_obj_t *btn = lv_btn_create(par, NULL);
+  if (id)
+    lv_obj_set_event_cb_mks(btn, cb, id, NULL, 0);
+  else
+    lv_obj_set_event_cb(btn, cb);
+  lv_btn_set_style_both(btn, style);
+  return btn;
+}
+
+// Create a button with callback and ID. Style set to style_para_value.
+lv_obj_t* lv_btn_create(lv_obj_t *par, lv_event_cb_t cb, const int id) {
+  return lv_btn_create(par, cb, id, &style_para_value);
+}
+
+// Create a button with position, size, callback, and ID. Style set to style_para_value.
+lv_obj_t* lv_btn_create(lv_obj_t *par, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h, lv_event_cb_t cb, const int id) {
+  lv_obj_t *btn = lv_btn_create(par, cb, id);
   lv_obj_set_pos(btn, x, y);
   lv_obj_set_size(btn, w, h);
-  lv_obj_set_event_cb_mks(btn, cb, id, NULL, 0);
-  lv_btn_set_style_both(btn, &style_para_value);
+  return btn;
+}
+
+// Create a button with callback and ID. Style set to style_para_back.
+lv_obj_t* lv_btn_create_back(lv_obj_t *par, lv_event_cb_t cb, const int id) {
+  return lv_btn_create(par, cb, id, &style_para_back);
+}
+// Create a button with position, size, callback, and ID. Style set to style_para_back.
+lv_obj_t* lv_btn_create_back(lv_obj_t *par, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h, lv_event_cb_t cb, const int id) {
+  lv_obj_t *btn = lv_btn_create_back(par, cb, id);
+  lv_obj_set_pos(btn, x, y);
+  lv_obj_set_size(btn, w, h);
+  return btn;
+}
+
+// Create an image button with image, callback, and ID. Use label style.
+lv_obj_t* lv_imgbtn_create(lv_obj_t *par, const char *img, lv_event_cb_t cb, const int id) {
+  lv_obj_t *btn = lv_imgbtn_create(par, NULL);
+  if (img) lv_imgbtn_set_src_both(btn, img);
+  if (id)
+    lv_obj_set_event_cb_mks(btn, cb, id, NULL, 0);
+  else
+    lv_obj_set_event_cb(btn, cb);
+  lv_imgbtn_use_label_style(btn);
+  lv_btn_set_layout(btn, LV_LAYOUT_OFF);
+  return btn;
+}
+
+// Create an image button with image, position, callback, and ID. Use label style.
+lv_obj_t* lv_imgbtn_create(lv_obj_t *par, const char *img, lv_coord_t x, lv_coord_t y, lv_event_cb_t cb, const int id) {
+  lv_obj_t *btn = lv_imgbtn_create(par, img, cb, id);
+  lv_obj_set_pos(btn, x, y);
   return btn;
 }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
@@ -1577,6 +1577,60 @@ void draw_return_ui() {
   }
 }
 
+// Set the same image for both Released and Pressed
+void lv_imgbtn_set_src_both(lv_obj_t *imgbtn, const void *src) {
+  lv_imgbtn_set_src(imgbtn, LV_BTN_STATE_REL, src);
+  lv_imgbtn_set_src(imgbtn, LV_BTN_STATE_PR,  src);
+}
+
+// Use label style for the image button
+void lv_imgbtn_use_label_style(lv_obj_t *imgbtn) {
+  lv_imgbtn_set_style(imgbtn, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_style(imgbtn, LV_BTN_STATE_PR,  &tft_style_label_pre);
+}
+
+// Use label style for the image button
+void lv_btn_use_label_style(lv_obj_t *btn) {
+  lv_btn_set_style(btn, LV_BTN_STYLE_REL, &tft_style_label_rel);
+  lv_btn_set_style(btn, LV_BTN_STYLE_PR,  &tft_style_label_pre);
+}
+
+// Use a single style for both Released and Pressed
+void lv_btn_set_style_both(lv_obj_t *btn, lv_style_t *style) {
+  lv_btn_set_style(btn, LV_BTN_STYLE_REL, style);
+  lv_btn_set_style(btn, LV_BTN_STYLE_PR,  style);
+}
+
+// Create a label with style
+lv_obj_t* lv_label_create(const lv_obj_t *par) {
+  lv_obj_t *label = lv_label_create(par, NULL);
+  lv_obj_set_style(label, &tft_style_label_rel);
+  return label;
+}
+
+// Create a label with style and text
+lv_obj_t* lv_label_create(const lv_obj_t *par, const char *text) {
+  lv_obj_t *label = lv_label_create(par);
+  if (text) lv_label_set_text(label, text);
+  return label;
+}
+
+// Create a label with style, position, and text
+lv_obj_t* lv_label_create(const lv_obj_t *par, lv_coord_t x, lv_coord_t y, const char *text) {
+  lv_obj_t *label = lv_label_create(par, text);
+  lv_obj_set_pos(label, x, y);
+  return label;
+}
+
+lv_obj_t* lv_btn_create(const lv_obj_t *par, const char *text, lv_event_cb_t cb, int id, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h) {
+  lv_obj_t *btn = lv_btn_create(par, NULL);
+  lv_obj_set_pos(btn, x, y);
+  lv_obj_set_size(btn, w, h);
+  lv_obj_set_event_cb_mks(btn, cb, id, NULL, 0);
+  lv_btn_set_style_both(btn, &style_para_value);
+  return btn;
+}
+
 #if ENABLED(SDSUPPORT)
 
   void sd_detection() {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.h
@@ -176,14 +176,35 @@ void lv_btn_use_label_style(lv_obj_t *btn);
 // Set the same style for both Released and Pressed
 void lv_btn_set_style_both(lv_obj_t *btn, lv_style_t *style);
 
-// Create a label with style
-lv_obj_t* lv_label_create(const lv_obj_t *par);
+// Create an empty label
+lv_obj_t* lv_label_create_empty(lv_obj_t *par);
 
 // Create a label with style and text
-lv_obj_t* lv_label_create(const lv_obj_t *par, const char *text);
+lv_obj_t* lv_label_create(lv_obj_t *par, const char *text);
 
 // Create a label with style, position, and text
-lv_obj_t* lv_label_create(const lv_obj_t *par, lv_coord_t x, lv_coord_t y, const char *text);
+lv_obj_t* lv_label_create(lv_obj_t *par, lv_coord_t x, lv_coord_t y, const char *text);
+
+// Create a button with callback, ID, and Style.
+lv_obj_t* lv_btn_create(lv_obj_t *par, lv_event_cb_t cb, const int id, lv_style_t *style);
+
+// Create a button with callback and ID. Style set to style_para_value.
+lv_obj_t* lv_btn_create(lv_obj_t *par, lv_event_cb_t cb, const int id);
+
+// Create a button with position, size, callback, and ID. Style set to style_para_value.
+lv_obj_t* lv_btn_create(lv_obj_t *par, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h, lv_event_cb_t cb, const int id);
+
+// Create a button with callback and ID. Style set to style_para_back.
+lv_obj_t* lv_btn_create_back(lv_obj_t *par, lv_event_cb_t cb, const int id);
+
+// Create a button with position, size, callback, and ID. Style set to style_para_back.
+lv_obj_t* lv_btn_create_back(lv_obj_t *par, lv_coord_t x, lv_coord_t y, lv_coord_t w, lv_coord_t h, lv_event_cb_t cb, const int id);
+
+// Create an image button with image, callback, and ID. Use label style.
+lv_obj_t* lv_imgbtn_create(lv_obj_t *par, const char *img, lv_event_cb_t cb, const int id);
+
+// Create an image button with image, position, callback, and ID. Use label style.
+lv_obj_t* lv_imgbtn_create(lv_obj_t *par, const char *img, lv_coord_t x, lv_coord_t y, lv_event_cb_t cb, const int id);
 
 #ifdef __cplusplus
   extern "C" { /* C-declarations for C++ */

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.h
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.h
@@ -164,6 +164,27 @@
 
 #endif // ifdef TFT35
 
+// Set the same image for both Released and Pressed
+void lv_imgbtn_set_src_both(lv_obj_t *imgbtn, const void *src);
+
+// Set label styles for Released and Pressed
+void lv_imgbtn_use_label_style(lv_obj_t *imgbtn);
+
+// Set label styles for Released and Pressed
+void lv_btn_use_label_style(lv_obj_t *btn);
+
+// Set the same style for both Released and Pressed
+void lv_btn_set_style_both(lv_obj_t *btn, lv_style_t *style);
+
+// Create a label with style
+lv_obj_t* lv_label_create(const lv_obj_t *par);
+
+// Create a label with style and text
+lv_obj_t* lv_label_create(const lv_obj_t *par, const char *text);
+
+// Create a label with style, position, and text
+lv_obj_t* lv_label_create(const lv_obj_t *par, lv_coord_t x, lv_coord_t y, const char *text);
+
 #ifdef __cplusplus
   extern "C" { /* C-declarations for C++ */
 #endif

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi.cpp
@@ -90,21 +90,16 @@ void lv_draw_wifi(void) {
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   // Create an Image button
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  if (gCfgItems.wifi_mode_sel == STA_MODEL) {
-    //buttonCloud = lv_imgbtn_create(scr, NULL);
-    buttonReconnect = lv_imgbtn_create(scr, NULL);
-  }
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_return.bin", BTN_X_PIXEL * 3 + INTERVAL_V * 4, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_W_RETURN);
 
-  lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_W_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
-  lv_imgbtn_use_label_style(buttonBack);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif
 
-  lv_obj_set_pos(buttonBack,BTN_X_PIXEL*3+INTERVAL_V*4,  BTN_Y_PIXEL+INTERVAL_H+titleHeight);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
+  if (gCfgItems.wifi_mode_sel == STA_MODEL) {
+    //buttonCloud = lv_imgbtn_create(scr, NULL);
+    buttonReconnect = lv_imgbtn_create(scr, NULL);
+  }
 
   if (gCfgItems.wifi_mode_sel == STA_MODEL) {
 
@@ -120,11 +115,11 @@ void lv_draw_wifi(void) {
     lv_btn_set_layout(buttonReconnect, LV_LAYOUT_OFF);
   }
 
-  label_Back = lv_label_create(buttonBack, NULL);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.wifi_mode_sel == STA_MODEL) {
-    //label_Cloud = lv_label_create(buttonCloud, NULL);
-    label_Reconnect = lv_label_create(buttonReconnect, NULL);
+    //label_Cloud = lv_label_create_empty(buttonCloud);
+    label_Reconnect = lv_label_create_empty(buttonReconnect);
   }
 
   if (gCfgItems.multiple_language) {
@@ -140,10 +135,14 @@ void lv_draw_wifi(void) {
     }
   }
 
-  wifi_ip_text = lv_label_create(scr);
-  wifi_name_text = lv_label_create(scr);
-  wifi_key_text = lv_label_create(scr);
-  wifi_state_text = lv_label_create(scr);
+  wifi_ip_text = lv_label_create_empty(scr);
+  lv_obj_set_style(wifi_ip_text, &tft_style_label_rel);
+  wifi_name_text = lv_label_create_empty(scr);
+  lv_obj_set_style(wifi_name_text, &tft_style_label_rel);
+  wifi_key_text = lv_label_create_empty(scr);
+  lv_obj_set_style(wifi_key_text, &tft_style_label_rel);
+  wifi_state_text = lv_label_create_empty(scr);
+  lv_obj_set_style(wifi_state_text, &tft_style_label_rel);
 
   disp_wifi_state();
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi.cpp
@@ -70,9 +70,9 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 }
 
 void lv_draw_wifi(void) {
-  lv_obj_t *buttonBack=NULL,*label_Back=NULL;
-  lv_obj_t *buttonCloud=NULL,*label_Cloud=NULL;
-  lv_obj_t *buttonReconnect=NULL,*label_Reconnect=NULL;
+  lv_obj_t *buttonBack = NULL, *label_Back = NULL;
+  lv_obj_t *buttonCloud = NULL, *label_Cloud = NULL;
+  lv_obj_t *buttonReconnect = NULL, *label_Reconnect=NULL;
   if (disp_state_stack._disp_state[disp_state_stack._disp_index] != WIFI_UI) {
     disp_state_stack._disp_index++;
     disp_state_stack._disp_state[disp_state_stack._disp_index] = WIFI_UI;
@@ -85,10 +85,7 @@ void lv_draw_wifi(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title,TITLE_XPOS,TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
@@ -99,11 +96,9 @@ void lv_draw_wifi(void) {
     buttonReconnect = lv_imgbtn_create(scr, NULL);
   }
 
-  lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_W_RETURN, NULL,0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_return.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_return.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_W_RETURN, NULL, 0);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_return.bin");
+  lv_imgbtn_use_label_style(buttonBack);
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonBack);
   #endif
@@ -113,17 +108,15 @@ void lv_draw_wifi(void) {
 
   if (gCfgItems.wifi_mode_sel == STA_MODEL) {
 
-    lv_obj_set_event_cb_mks(buttonReconnect, event_handler,ID_W_RECONNECT, NULL,0);
-    lv_imgbtn_set_src(buttonReconnect, LV_BTN_STATE_REL, "F:/bmp_wifi.bin");
-    lv_imgbtn_set_src(buttonReconnect, LV_BTN_STATE_PR, "F:/bmp_wifi.bin");
-    lv_imgbtn_set_style(buttonReconnect, LV_BTN_STATE_PR, &tft_style_label_pre);
-    lv_imgbtn_set_style(buttonReconnect, LV_BTN_STATE_REL, &tft_style_label_rel);
+    lv_obj_set_event_cb_mks(buttonReconnect, event_handler,ID_W_RECONNECT, NULL, 0);
+    lv_imgbtn_set_src_both(buttonReconnect, "F:/bmp_wifi.bin");
+    lv_imgbtn_use_label_style(buttonReconnect);
 
     #if HAS_ROTARY_ENCODER
       if (gCfgItems.encoder_enable) lv_group_add_obj(g, buttonReconnect);
     #endif
 
-    lv_obj_set_pos(buttonReconnect,BTN_X_PIXEL*2+INTERVAL_V*3,  BTN_Y_PIXEL+INTERVAL_H+titleHeight);
+    lv_obj_set_pos(buttonReconnect, BTN_X_PIXEL * 2 + INTERVAL_V * 3, BTN_Y_PIXEL + INTERVAL_H + titleHeight);
     lv_btn_set_layout(buttonReconnect, LV_LAYOUT_OFF);
   }
 
@@ -136,28 +129,21 @@ void lv_draw_wifi(void) {
 
   if (gCfgItems.multiple_language) {
     lv_label_set_text(label_Back, common_menu.text_back);
-    lv_obj_align(label_Back, buttonBack, LV_ALIGN_IN_BOTTOM_MID,0, BUTTON_TEXT_Y_OFFSET);
+    lv_obj_align(label_Back, buttonBack, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
 
     if (gCfgItems.wifi_mode_sel == STA_MODEL) {
       //lv_label_set_text(label_Cloud, common_menu.text_back);
-      //lv_obj_align(label_Cloud, buttonCloud, LV_ALIGN_IN_BOTTOM_MID,0, BUTTON_TEXT_Y_OFFSET);
+      //lv_obj_align(label_Cloud, buttonCloud, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
 
       lv_label_set_text(label_Reconnect, wifi_menu.reconnect);
-      lv_obj_align(label_Reconnect, buttonReconnect, LV_ALIGN_IN_BOTTOM_MID,0, BUTTON_TEXT_Y_OFFSET);
+      lv_obj_align(label_Reconnect, buttonReconnect, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
     }
   }
 
-  wifi_ip_text = lv_label_create(scr, NULL);
-  lv_obj_set_style(wifi_ip_text, &tft_style_label_rel);
-
-  wifi_name_text = lv_label_create(scr, NULL);
-  lv_obj_set_style(wifi_name_text, &tft_style_label_rel);
-
-  wifi_key_text = lv_label_create(scr, NULL);
-  lv_obj_set_style(wifi_key_text, &tft_style_label_rel);
-
-  wifi_state_text = lv_label_create(scr, NULL);
-  lv_obj_set_style(wifi_state_text, &tft_style_label_rel);
+  wifi_ip_text = lv_label_create(scr);
+  wifi_name_text = lv_label_create(scr);
+  wifi_key_text = lv_label_create(scr);
+  wifi_state_text = lv_label_create(scr);
 
   disp_wifi_state();
 }
@@ -167,20 +153,20 @@ void disp_wifi_state() {
   strcpy(public_buf_m,wifi_menu.ip);
   strcat(public_buf_m,ipPara.ip_addr);
   lv_label_set_text(wifi_ip_text, public_buf_m);
-  lv_obj_align(wifi_ip_text, NULL, LV_ALIGN_CENTER,0, -100);
+  lv_obj_align(wifi_ip_text, NULL, LV_ALIGN_CENTER, 0, -100);
 
   memset(public_buf_m, 0, sizeof(public_buf_m));
   strcpy(public_buf_m,wifi_menu.wifi);
   strcat(public_buf_m,wifiPara.ap_name);
   lv_label_set_text(wifi_name_text, public_buf_m);
-  lv_obj_align(wifi_name_text, NULL, LV_ALIGN_CENTER,0, -70);
+  lv_obj_align(wifi_name_text, NULL, LV_ALIGN_CENTER, 0, -70);
 
   if (wifiPara.mode == AP_MODEL) {
     memset(public_buf_m, 0, sizeof(public_buf_m));
     strcpy(public_buf_m,wifi_menu.key);
     strcat(public_buf_m,wifiPara.keyCode);
     lv_label_set_text(wifi_key_text, public_buf_m);
-    lv_obj_align(wifi_key_text, NULL, LV_ALIGN_CENTER,0, -40);
+    lv_obj_align(wifi_key_text, NULL, LV_ALIGN_CENTER, 0, -40);
 
     memset(public_buf_m, 0, sizeof(public_buf_m));
     strcpy(public_buf_m,wifi_menu.state_ap);
@@ -191,7 +177,7 @@ void disp_wifi_state() {
     else
       strcat(public_buf_m,wifi_menu.exception);
     lv_label_set_text(wifi_state_text, public_buf_m);
-    lv_obj_align(wifi_state_text, NULL, LV_ALIGN_CENTER,0, -10);
+    lv_obj_align(wifi_state_text, NULL, LV_ALIGN_CENTER, 0, -10);
   }
   else {
     ZERO(public_buf_m);
@@ -203,10 +189,10 @@ void disp_wifi_state() {
     else
       strcat(public_buf_m, wifi_menu.exception);
     lv_label_set_text(wifi_state_text, public_buf_m);
-    lv_obj_align(wifi_state_text, NULL, LV_ALIGN_CENTER,0, -40);
+    lv_obj_align(wifi_state_text, NULL, LV_ALIGN_CENTER, 0, -40);
 
     lv_label_set_text(wifi_key_text, "");
-    lv_obj_align(wifi_key_text, NULL, LV_ALIGN_CENTER,0, -10);
+    lv_obj_align(wifi_key_text, NULL, LV_ALIGN_CENTER, 0, -10);
   }
 }
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_list.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_list.cpp
@@ -42,8 +42,8 @@ list_menu_def list_menu;
 extern lv_group_t * g;
 static lv_obj_t * scr;
 static lv_obj_t *buttonWifiN[NUMBER_OF_PAGE];
-static lv_obj_t *lableWifiText[NUMBER_OF_PAGE];
-static lv_obj_t *lablePageText;
+static lv_obj_t *labelWifiText[NUMBER_OF_PAGE];
+static lv_obj_t *labelPageText;
 
 #define ID_WL_RETURN      11
 #define ID_WL_DOWN        12
@@ -120,22 +120,8 @@ void lv_draw_wifi_list(void) {
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  buttonDown = lv_imgbtn_create(scr, NULL);
-  buttonBack = lv_imgbtn_create(scr, NULL);
-
-  lv_obj_set_event_cb_mks(buttonDown, event_handler, ID_WL_DOWN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonDown, "F:/bmp_pageDown.bin");
-  lv_imgbtn_use_label_style(buttonDown);
-
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_WL_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-
-  lv_obj_set_pos(buttonDown, OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + OTHER_BTN_YPIEL + INTERVAL_H);
-  lv_obj_set_pos(buttonBack, OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + (OTHER_BTN_YPIEL + INTERVAL_H) * 2);
-
-  lv_btn_set_layout(buttonDown, LV_LAYOUT_OFF);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
+  buttonDown = lv_imgbtn_create(scr, "F:/bmp_pageDown.bin", OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + OTHER_BTN_YPIEL + INTERVAL_H, event_handler, ID_WL_DOWN);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back.bin", OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + (OTHER_BTN_YPIEL + INTERVAL_H) * 2, event_handler, ID_WL_RETURN);
 
   for (uint8_t i = 0; i < NUMBER_OF_PAGE; i++) {
     buttonWifiN[i] = lv_btn_create(scr, NULL);     /*Add a button the current screen*/
@@ -144,7 +130,7 @@ void lv_draw_wifi_list(void) {
     lv_obj_set_event_cb_mks(buttonWifiN[i], event_handler, (i+1), NULL, 0);
     lv_btn_use_label_style(buttonWifiN[i]);
     lv_btn_set_layout(buttonWifiN[i], LV_LAYOUT_OFF);
-    lableWifiText[i] = lv_label_create(buttonWifiN[i], NULL);
+    labelWifiText[i] = lv_label_create_empty(buttonWifiN[i]);
     #if HAS_ROTARY_ENCODER
       uint8_t j = 0;
       if (gCfgItems.encoder_enable) {
@@ -154,7 +140,8 @@ void lv_draw_wifi_list(void) {
     #endif
   }
 
-  lablePageText = lv_label_create(scr);
+  labelPageText = lv_label_create_empty(scr);
+  lv_obj_set_style(labelPageText, &tft_style_label_rel);
 
   wifi_list.nameIndex = 0;
   wifi_list.currentWifipage = 1;
@@ -178,20 +165,20 @@ void disp_wifi_list(void) {
   uint8_t i, j;
 
   sprintf((char *)tmpStr, list_menu.file_pages, wifi_list.currentWifipage, wifi_list.getPage);
-  lv_label_set_text(lablePageText, (const char *)tmpStr);
-  lv_obj_align(lablePageText, NULL, LV_ALIGN_CENTER, 50, -100);
+  lv_label_set_text(labelPageText, (const char *)tmpStr);
+  lv_obj_align(labelPageText, NULL, LV_ALIGN_CENTER, 50, -100);
 
   for (i = 0; i < NUMBER_OF_PAGE; i++) {
     memset(tmpStr, 0, sizeof(tmpStr));
 
     j = wifi_list.nameIndex + i;
     if (j >= wifi_list.getNameNum) {
-      lv_label_set_text(lableWifiText[i], (const char *)tmpStr);
-      lv_obj_align(lableWifiText[i], buttonWifiN[i], LV_ALIGN_IN_LEFT_MID, 20, 0);
+      lv_label_set_text(labelWifiText[i], (const char *)tmpStr);
+      lv_obj_align(labelWifiText[i], buttonWifiN[i], LV_ALIGN_IN_LEFT_MID, 20, 0);
     }
     else {
-      lv_label_set_text(lableWifiText[i], (char const *)wifi_list.wifiName[j]);
-      lv_obj_align(lableWifiText[i], buttonWifiN[i], LV_ALIGN_IN_LEFT_MID, 20, 0);
+      lv_label_set_text(labelWifiText[i], (char const *)wifi_list.wifiName[j]);
+      lv_obj_align(labelWifiText[i], buttonWifiN[i], LV_ALIGN_IN_LEFT_MID, 20, 0);
 
       const bool btext = (wifi_link_state == WIFI_CONNECTED && strcmp((const char *)wifi_list.wifiConnectedName, (const char *)wifi_list.wifiName[j]) == 0);
       lv_btn_set_style(buttonWifiN[i], LV_BTN_STYLE_REL, btext ? &style_sel_text : &tft_style_label_rel);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_list.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_list.cpp
@@ -116,41 +116,33 @@ void lv_draw_wifi_list(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title,TITLE_XPOS,TITLE_YPOS);
-  lv_label_set_text(title, creat_title_text());
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, creat_title_text());
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
   buttonDown = lv_imgbtn_create(scr, NULL);
   buttonBack = lv_imgbtn_create(scr, NULL);
 
-  lv_obj_set_event_cb_mks(buttonDown, event_handler,ID_WL_DOWN,NULL,0);
-  lv_imgbtn_set_src(buttonDown, LV_BTN_STATE_REL, "F:/bmp_pageDown.bin");
-  lv_imgbtn_set_src(buttonDown, LV_BTN_STATE_PR, "F:/bmp_pageDown.bin");
-  lv_imgbtn_set_style(buttonDown, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonDown, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_obj_set_event_cb_mks(buttonDown, event_handler, ID_WL_DOWN, NULL, 0);
+  lv_imgbtn_set_src_both(buttonDown, "F:/bmp_pageDown.bin");
+  lv_imgbtn_use_label_style(buttonDown);
 
-  lv_obj_set_event_cb_mks(buttonBack, event_handler,ID_WL_RETURN,NULL,0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_WL_RETURN, NULL, 0);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back.bin");
+  lv_imgbtn_use_label_style(buttonBack);
 
-  lv_obj_set_pos(buttonDown,OTHER_BTN_XPIEL*3+INTERVAL_V*4,titleHeight+OTHER_BTN_YPIEL+INTERVAL_H);
-  lv_obj_set_pos(buttonBack,OTHER_BTN_XPIEL*3+INTERVAL_V*4,titleHeight+OTHER_BTN_YPIEL*2+INTERVAL_H*2);
+  lv_obj_set_pos(buttonDown, OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + OTHER_BTN_YPIEL + INTERVAL_H);
+  lv_obj_set_pos(buttonBack, OTHER_BTN_XPIEL * 3 + INTERVAL_V * 4, titleHeight + (OTHER_BTN_YPIEL + INTERVAL_H) * 2);
 
   lv_btn_set_layout(buttonDown, LV_LAYOUT_OFF);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
 
   for (uint8_t i = 0; i < NUMBER_OF_PAGE; i++) {
     buttonWifiN[i] = lv_btn_create(scr, NULL);     /*Add a button the current screen*/
-    lv_obj_set_pos(buttonWifiN[i], 0,NAME_BTN_Y*i+10+titleHeight);                            /*Set its position*/
-    lv_obj_set_size(buttonWifiN[i], NAME_BTN_X,NAME_BTN_Y);                          /*Set its size*/
-    lv_obj_set_event_cb_mks(buttonWifiN[i], event_handler,(i+1),NULL,0);
-    lv_btn_set_style(buttonWifiN[i], LV_BTN_STYLE_REL, &tft_style_label_rel);    /*Set the button's released style*/
-    lv_btn_set_style(buttonWifiN[i], LV_BTN_STYLE_PR, &tft_style_label_pre);      /*Set the button's pressed style*/
+    lv_obj_set_pos(buttonWifiN[i], 0, NAME_BTN_Y*i+10+titleHeight);                            /*Set its position*/
+    lv_obj_set_size(buttonWifiN[i], NAME_BTN_X, NAME_BTN_Y);                          /*Set its size*/
+    lv_obj_set_event_cb_mks(buttonWifiN[i], event_handler, (i+1), NULL, 0);
+    lv_btn_use_label_style(buttonWifiN[i]);
     lv_btn_set_layout(buttonWifiN[i], LV_LAYOUT_OFF);
     lableWifiText[i] = lv_label_create(buttonWifiN[i], NULL);
     #if HAS_ROTARY_ENCODER
@@ -162,8 +154,7 @@ void lv_draw_wifi_list(void) {
     #endif
   }
 
-  lablePageText = lv_label_create(scr, NULL);
-  lv_obj_set_style(lablePageText, &tft_style_label_rel);
+  lablePageText = lv_label_create(scr);
 
   wifi_list.nameIndex = 0;
   wifi_list.currentWifipage = 1;
@@ -202,12 +193,8 @@ void disp_wifi_list(void) {
       lv_label_set_text(lableWifiText[i], (char const *)wifi_list.wifiName[j]);
       lv_obj_align(lableWifiText[i], buttonWifiN[i], LV_ALIGN_IN_LEFT_MID, 20, 0);
 
-      if (wifi_link_state == WIFI_CONNECTED && strcmp((const char *)wifi_list.wifiConnectedName, (const char *)wifi_list.wifiName[j]) == 0) {
-        lv_btn_set_style(buttonWifiN[i], LV_BTN_STYLE_REL, &style_sel_text);
-      }
-      else {
-        lv_btn_set_style(buttonWifiN[i], LV_BTN_STYLE_REL, &tft_style_label_rel);
-      }
+      const bool btext = (wifi_link_state == WIFI_CONNECTED && strcmp((const char *)wifi_list.wifiConnectedName, (const char *)wifi_list.wifiName[j]) == 0);
+      lv_btn_set_style(buttonWifiN[i], LV_BTN_STYLE_REL, btext ? &style_sel_text : &tft_style_label_rel);
     }
   }
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_settings.cpp
@@ -146,69 +146,45 @@ void lv_draw_wifi_settings(void) {
   labelModelText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.wifiMode);
 
   buttonModelValue = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonModelValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
-  lv_obj_set_event_cb_mks(buttonModelValue, event_handler,ID_WIFI_MODEL, NULL, 0);
   lv_imgbtn_set_src_both(buttonModelValue, "F:/bmp_blank_sel.bin");
-  lv_imgbtn_set_style(buttonModelValue, LV_BTN_STATE_PR, &style_para_value_pre);
-  lv_imgbtn_set_style(buttonModelValue, LV_BTN_STATE_REL, &style_para_value_pre);
+  lv_obj_set_pos(buttonModelValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
+  lv_obj_set_event_cb_mks(buttonModelValue, event_handler, ID_WIFI_MODEL, NULL, 0);
+  lv_btn_set_style_both(buttonModelValue, &style_para_value_pre);
   lv_btn_set_layout(buttonModelValue, LV_LAYOUT_OFF);
-  labelModelValue = lv_label_create(buttonModelValue, NULL);
+  labelModelValue = lv_label_create_empty(buttonModelValue);
 
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1,line_points[0]);
 
   labelNameText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, NULL);
 
-  buttonNameValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonNameValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonNameValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonNameValue, event_handler,ID_WIFI_NAME, NULL, 0);
-  lv_btn_set_style_both(buttonNameValue, &style_para_value);
-  labelNameValue = lv_label_create(buttonNameValue, NULL);
+  buttonNameValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_WIFI_NAME);
+  labelNameValue = lv_label_create_empty(buttonNameValue);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2,line_points[1]);
 
   labelPassWordText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, NULL);
 
-  buttonPassWordValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonPassWordValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
-  lv_obj_set_size(buttonPassWordValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonPassWordValue, event_handler,ID_WIFI_PASSWORD, NULL, 0);
-  lv_btn_set_style_both(buttonPassWordValue, &style_para_value);
-  labelPassWordValue = lv_label_create(buttonPassWordValue, NULL);
+  buttonPassWordValue = lv_btn_create(scr, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE, event_handler, ID_WIFI_PASSWORD);
+  labelPassWordValue = lv_label_create_empty(buttonPassWordValue);
 
   line3 = lv_line_create(scr, NULL);
   lv_ex_line(line3,line_points[2]);
 
   labelCloudText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.wifiCloud);
 
-  buttonCloudValue = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonCloudValue, PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_STATE_V);
-  lv_imgbtn_set_src_both(buttonCloudValue, gCfgItems.cloud_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
-  lv_obj_set_event_cb_mks(buttonCloudValue, event_handler,ID_WIFI_CLOUD, NULL, 0);
-  lv_imgbtn_use_label_style(buttonCloudValue);
-  lv_btn_set_layout(buttonCloudValue, LV_LAYOUT_OFF);
-  labelCloudValue = lv_label_create(buttonCloudValue, NULL);
+  buttonCloudValue = lv_imgbtn_create(scr, gCfgItems.cloud_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin", PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_STATE_V, event_handler, ID_WIFI_CLOUD);
+  labelCloudValue = lv_label_create_empty(buttonCloudValue);
 
   line4 = lv_line_create(scr, NULL);
   lv_ex_line(line4,line_points[3]);
 
-  buttonConfig = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonConfig, event_handler,ID_WIFI_CONFIG, NULL, 0);
-  lv_imgbtn_set_src_both(buttonConfig, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonConfig);
-  lv_obj_set_pos(buttonConfig, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
-  lv_btn_set_layout(buttonConfig, LV_LAYOUT_OFF);
-  labelConfig = lv_label_create(buttonConfig, NULL);
+  buttonConfig = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y, event_handler, ID_WIFI_CONFIG);
+  labelConfig = lv_label_create_empty(buttonConfig);
 
-  buttonBack = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_WIFI_RETURN, NULL, 0);
-  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
-  lv_imgbtn_use_label_style(buttonBack);
-  lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
-  lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
-  label_Back = lv_label_create(buttonBack, NULL);
+  buttonBack = lv_imgbtn_create(scr, "F:/bmp_back70x40.bin", PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y, event_handler, ID_WIFI_RETURN);
+  label_Back = lv_label_create_empty(buttonBack);
 
   if (gCfgItems.multiple_language) {
     if (gCfgItems.wifi_mode_sel == AP_MODEL) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_settings.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_settings.cpp
@@ -59,13 +59,13 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
         if (gCfgItems.wifi_mode_sel == AP_MODEL) {
           gCfgItems.wifi_mode_sel = STA_MODEL;
           lv_label_set_text(labelModelValue, WIFI_STA_TEXT);
-          lv_obj_align(labelModelValue, buttonModelValue, LV_ALIGN_CENTER,0, 0);
+          lv_obj_align(labelModelValue, buttonModelValue, LV_ALIGN_CENTER, 0, 0);
           update_spi_flash();
         }
         else {
           gCfgItems.wifi_mode_sel = AP_MODEL;
           lv_label_set_text(labelModelValue, WIFI_AP_TEXT);
-          lv_obj_align(labelModelValue, buttonModelValue, LV_ALIGN_CENTER,0, 0);
+          lv_obj_align(labelModelValue, buttonModelValue, LV_ALIGN_CENTER, 0, 0);
           update_spi_flash();
         }
       }
@@ -85,7 +85,7 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
       }
       else if (event == LV_EVENT_RELEASED) {
-      keyboard_value=wifiPassWord;
+      keyboard_value = wifiPassWord;
         lv_clear_wifi_settings();
         lv_draw_keyboard();
       }
@@ -95,19 +95,18 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
 
       }
       else if (event == LV_EVENT_RELEASED) {
-      if (gCfgItems.cloud_enable) {
-        gCfgItems.cloud_enable = false;
-        lv_obj_set_event_cb_mks(obj, event_handler,ID_WIFI_CLOUD,"bmp_disable.bin",0);
-        lv_label_set_text(labelCloudValue, machine_menu.disable);
+        if (gCfgItems.cloud_enable) {
+          gCfgItems.cloud_enable = false;
+          lv_obj_set_event_cb_mks(obj, event_handler, ID_WIFI_CLOUD, "bmp_disable.bin", 0);
+          lv_label_set_text(labelCloudValue, machine_menu.disable);
+        }
+        else {
+          gCfgItems.cloud_enable = true;
+          lv_obj_set_event_cb_mks(obj, event_handler, ID_WIFI_CLOUD, "bmp_enable.bin", 0);
+          lv_label_set_text(labelCloudValue, machine_menu.enable);
+        }
         update_spi_flash();
       }
-      else {
-        gCfgItems.cloud_enable = true;
-        lv_obj_set_event_cb_mks(obj, event_handler,ID_WIFI_CLOUD,"bmp_enable.bin",0);
-        lv_label_set_text(labelCloudValue, machine_menu.enable);
-        update_spi_flash();
-      }
-    }
     break;
     case ID_WIFI_CONFIG:
       if (event == LV_EVENT_CLICKED) {
@@ -140,23 +139,16 @@ void lv_draw_wifi_settings(void) {
   lv_scr_load(scr);
   lv_obj_clean(scr);
 
-  lv_obj_t * title = lv_label_create(scr, NULL);
-  lv_obj_set_style(title, &tft_style_label_rel);
-  lv_obj_set_pos(title,TITLE_XPOS,TITLE_YPOS);
-  lv_label_set_text(title, machine_menu.WifiConfTitle);
+  (void)lv_label_create(scr, TITLE_XPOS, TITLE_YPOS, machine_menu.WifiConfTitle);
 
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  labelModelText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelModelText, &tft_style_label_rel);
-  lv_obj_set_pos(labelModelText, PARA_UI_POS_X, PARA_UI_POS_Y + 10);
-  lv_label_set_text(labelModelText, machine_menu.wifiMode);
+  labelModelText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y + 10, machine_menu.wifiMode);
 
   buttonModelValue = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonModelValue,PARA_UI_VALUE_POS_X,PARA_UI_POS_Y+PARA_UI_VALUE_V);
-  lv_obj_set_event_cb_mks(buttonModelValue, event_handler,ID_WIFI_MODEL, NULL,0);
-  lv_imgbtn_set_src(buttonModelValue, LV_BTN_STATE_REL, "F:/bmp_blank_sel.bin");
-  lv_imgbtn_set_src(buttonModelValue, LV_BTN_STATE_PR, "F:/bmp_blank_sel.bin");
+  lv_obj_set_pos(buttonModelValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y + PARA_UI_VALUE_V);
+  lv_obj_set_event_cb_mks(buttonModelValue, event_handler,ID_WIFI_MODEL, NULL, 0);
+  lv_imgbtn_set_src_both(buttonModelValue, "F:/bmp_blank_sel.bin");
   lv_imgbtn_set_style(buttonModelValue, LV_BTN_STATE_PR, &style_para_value_pre);
   lv_imgbtn_set_style(buttonModelValue, LV_BTN_STATE_REL, &style_para_value_pre);
   lv_btn_set_layout(buttonModelValue, LV_LAYOUT_OFF);
@@ -165,54 +157,37 @@ void lv_draw_wifi_settings(void) {
   line1 = lv_line_create(scr, NULL);
   lv_ex_line(line1,line_points[0]);
 
-  labelNameText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelNameText, &tft_style_label_rel);
-  lv_obj_set_pos(labelNameText, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10);
+  labelNameText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 2 + 10, NULL);
 
   buttonNameValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonNameValue,PARA_UI_VALUE_POS_X,PARA_UI_POS_Y*2+PARA_UI_VALUE_V);
+  lv_obj_set_pos(buttonNameValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 2 + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonNameValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonNameValue, event_handler,ID_WIFI_NAME, NULL,0);
-  lv_btn_set_style(buttonNameValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonNameValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_obj_set_event_cb_mks(buttonNameValue, event_handler,ID_WIFI_NAME, NULL, 0);
+  lv_btn_set_style_both(buttonNameValue, &style_para_value);
   labelNameValue = lv_label_create(buttonNameValue, NULL);
 
   line2 = lv_line_create(scr, NULL);
   lv_ex_line(line2,line_points[1]);
 
-  labelPassWordText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelPassWordText, &tft_style_label_rel);
-  lv_obj_set_pos(labelPassWordText, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10);
+  labelPassWordText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 3 + 10, NULL);
 
   buttonPassWordValue = lv_btn_create(scr, NULL);
-  lv_obj_set_pos(buttonPassWordValue,PARA_UI_VALUE_POS_X,PARA_UI_POS_Y*3+PARA_UI_VALUE_V);
+  lv_obj_set_pos(buttonPassWordValue, PARA_UI_VALUE_POS_X, PARA_UI_POS_Y * 3 + PARA_UI_VALUE_V);
   lv_obj_set_size(buttonPassWordValue, PARA_UI_VALUE_BTN_X_SIZE, PARA_UI_VALUE_BTN_Y_SIZE);
-  lv_obj_set_event_cb_mks(buttonPassWordValue, event_handler,ID_WIFI_PASSWORD, NULL,0);
-  lv_btn_set_style(buttonPassWordValue, LV_BTN_STYLE_REL, &style_para_value);
-  lv_btn_set_style(buttonPassWordValue, LV_BTN_STYLE_PR, &style_para_value);
+  lv_obj_set_event_cb_mks(buttonPassWordValue, event_handler,ID_WIFI_PASSWORD, NULL, 0);
+  lv_btn_set_style_both(buttonPassWordValue, &style_para_value);
   labelPassWordValue = lv_label_create(buttonPassWordValue, NULL);
 
   line3 = lv_line_create(scr, NULL);
   lv_ex_line(line3,line_points[2]);
 
-  labelCloudText = lv_label_create(scr, NULL);
-  lv_obj_set_style(labelCloudText, &tft_style_label_rel);
-  lv_obj_set_pos(labelCloudText, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10);
-  lv_label_set_text(labelCloudText, machine_menu.wifiCloud);
+  labelCloudText = lv_label_create(scr, PARA_UI_POS_X, PARA_UI_POS_Y * 4 + 10, machine_menu.wifiCloud);
 
   buttonCloudValue = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_pos(buttonCloudValue,PARA_UI_STATE_POS_X,PARA_UI_POS_Y*4+PARA_UI_STATE_V);
-  if (gCfgItems.cloud_enable) {
-    lv_imgbtn_set_src(buttonCloudValue, LV_BTN_STATE_REL, "F:/bmp_enable.bin");
-    lv_imgbtn_set_src(buttonCloudValue, LV_BTN_STATE_PR, "F:/bmp_enable.bin");
-  }
-  else {
-    lv_imgbtn_set_src(buttonCloudValue, LV_BTN_STATE_REL, "F:/bmp_disable.bin");
-    lv_imgbtn_set_src(buttonCloudValue, LV_BTN_STATE_PR, "F:/bmp_disable.bin");
-  }
-  lv_obj_set_event_cb_mks(buttonCloudValue, event_handler,ID_WIFI_CLOUD, NULL,0);
-  lv_imgbtn_set_style(buttonCloudValue, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonCloudValue, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_obj_set_pos(buttonCloudValue, PARA_UI_STATE_POS_X, PARA_UI_POS_Y * 4 + PARA_UI_STATE_V);
+  lv_imgbtn_set_src_both(buttonCloudValue, gCfgItems.cloud_enable ? "F:/bmp_enable.bin" : "F:/bmp_disable.bin");
+  lv_obj_set_event_cb_mks(buttonCloudValue, event_handler,ID_WIFI_CLOUD, NULL, 0);
+  lv_imgbtn_use_label_style(buttonCloudValue);
   lv_btn_set_layout(buttonCloudValue, LV_LAYOUT_OFF);
   labelCloudValue = lv_label_create(buttonCloudValue, NULL);
 
@@ -220,21 +195,17 @@ void lv_draw_wifi_settings(void) {
   lv_ex_line(line4,line_points[3]);
 
   buttonConfig = lv_imgbtn_create(scr, NULL);
-  lv_obj_set_event_cb_mks(buttonConfig, event_handler,ID_WIFI_CONFIG, NULL,0);
-    lv_imgbtn_set_src(buttonConfig, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonConfig, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonConfig, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonConfig, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_obj_set_event_cb_mks(buttonConfig, event_handler,ID_WIFI_CONFIG, NULL, 0);
+  lv_imgbtn_set_src_both(buttonConfig, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonConfig);
   lv_obj_set_pos(buttonConfig, PARA_UI_TURN_PAGE_POS_X, PARA_UI_TURN_PAGE_POS_Y);
   lv_btn_set_layout(buttonConfig, LV_LAYOUT_OFF);
   labelConfig = lv_label_create(buttonConfig, NULL);
 
   buttonBack = lv_imgbtn_create(scr, NULL);
   lv_obj_set_event_cb_mks(buttonBack, event_handler, ID_WIFI_RETURN, NULL, 0);
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_REL, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_src(buttonBack, LV_BTN_STATE_PR, "F:/bmp_back70x40.bin");
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_PR, &tft_style_label_pre);
-  lv_imgbtn_set_style(buttonBack, LV_BTN_STATE_REL, &tft_style_label_rel);
+  lv_imgbtn_set_src_both(buttonBack, "F:/bmp_back70x40.bin");
+  lv_imgbtn_use_label_style(buttonBack);
   lv_obj_set_pos(buttonBack, PARA_UI_BACL_POS_X, PARA_UI_BACL_POS_Y);
   lv_btn_set_layout(buttonBack, LV_LAYOUT_OFF);
   label_Back = lv_label_create(buttonBack, NULL);
@@ -242,11 +213,11 @@ void lv_draw_wifi_settings(void) {
   if (gCfgItems.multiple_language) {
     if (gCfgItems.wifi_mode_sel == AP_MODEL) {
       lv_label_set_text(labelModelValue, WIFI_AP_TEXT);
-      lv_obj_align(labelModelValue, buttonModelValue, LV_ALIGN_CENTER,0, 0);
+      lv_obj_align(labelModelValue, buttonModelValue, LV_ALIGN_CENTER, 0, 0);
     }
     else {
       lv_label_set_text(labelModelValue, WIFI_STA_TEXT);
-      lv_obj_align(labelModelValue, buttonModelValue, LV_ALIGN_CENTER,0, 0);
+      lv_obj_align(labelModelValue, buttonModelValue, LV_ALIGN_CENTER, 0, 0);
     }
     memset(public_buf_m,0,sizeof(public_buf_m));
     strcat(public_buf_m,machine_menu.wifiName);
@@ -254,7 +225,7 @@ void lv_draw_wifi_settings(void) {
     lv_label_set_text(labelNameText,public_buf_m);
 
     lv_label_set_text(labelNameValue,machine_menu.wifiEdit);
-    lv_obj_align(labelNameValue, buttonNameValue, LV_ALIGN_CENTER,0, 0);
+    lv_obj_align(labelNameValue, buttonNameValue, LV_ALIGN_CENTER, 0, 0);
 
     memset(public_buf_m,0,sizeof(public_buf_m));
     strcat(public_buf_m,machine_menu.wifiPassWord);
@@ -262,16 +233,16 @@ void lv_draw_wifi_settings(void) {
     lv_label_set_text(labelPassWordText,public_buf_m);
 
     lv_label_set_text(labelPassWordValue,machine_menu.wifiEdit);
-    lv_obj_align(labelPassWordValue, buttonPassWordValue, LV_ALIGN_CENTER,0, 0);
+    lv_obj_align(labelPassWordValue, buttonPassWordValue, LV_ALIGN_CENTER, 0, 0);
 
     lv_label_set_text(labelCloudValue, gCfgItems.cloud_enable ? machine_menu.enable : machine_menu.disable);
-    lv_obj_align(labelCloudValue, buttonCloudValue, LV_ALIGN_CENTER,0, 0);
+    lv_obj_align(labelCloudValue, buttonCloudValue, LV_ALIGN_CENTER, 0, 0);
 
     lv_label_set_text(labelConfig,machine_menu.wifiConfig);
-    lv_obj_align(labelConfig, buttonConfig, LV_ALIGN_CENTER,0, 0);
+    lv_obj_align(labelConfig, buttonConfig, LV_ALIGN_CENTER, 0, 0);
 
     lv_label_set_text(label_Back, common_menu.text_back);
-    lv_obj_align(label_Back, buttonBack, LV_ALIGN_CENTER,0, 0);
+    lv_obj_align(label_Back, buttonBack, LV_ALIGN_CENTER, 0, 0);
   }
 
   #if HAS_ROTARY_ENCODER

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_tips.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_tips.cpp
@@ -52,24 +52,22 @@ void lv_draw_wifi_tips(void) {
   lv_obj_clean(scr);
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  text_tips = lv_label_create(scr);
-  wifi_name = lv_label_create(scr, NULL);
+  wifi_name = lv_label_create(scr, (const char *)wifi_list.wifiName[wifi_list.nameIndex]);
+  lv_obj_align(wifi_name, NULL, LV_ALIGN_CENTER, 0, -20);
 
+  text_tips = lv_label_create_empty(scr);
   if (wifi_tips_type == TIPS_TYPE_JOINING) {
     lv_label_set_text(text_tips, tips_menu.joining);
-    lv_obj_align(text_tips, NULL, LV_ALIGN_CENTER,0, -60);
+    lv_obj_align(text_tips, NULL, LV_ALIGN_CENTER, 0, -60);
   }
   else if (wifi_tips_type == TIPS_TYPE_TAILED_JOIN) {
     lv_label_set_text(text_tips, tips_menu.failedJoin);
-    lv_obj_align(text_tips, NULL, LV_ALIGN_CENTER,0, -60);
+    lv_obj_align(text_tips, NULL, LV_ALIGN_CENTER, 0, -60);
   }
   else if (wifi_tips_type == TIPS_TYPE_WIFI_CONECTED) {
     lv_label_set_text(text_tips, tips_menu.wifiConected);
-    lv_obj_align(text_tips, NULL, LV_ALIGN_CENTER,0, -60);
+    lv_obj_align(text_tips, NULL, LV_ALIGN_CENTER, 0, -60);
   }
-
-  lv_label_set_text(wifi_name, (const char *)wifi_list.wifiName[wifi_list.nameIndex]);
-  lv_obj_align(wifi_name, NULL, LV_ALIGN_CENTER,0, -20);
 
   tips_disp.timer = TIPS_TIMER_START;
   tips_disp.timer_count = 0;

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_tips.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi_tips.cpp
@@ -52,11 +52,8 @@ void lv_draw_wifi_tips(void) {
   lv_obj_clean(scr);
   lv_refr_now(lv_refr_get_disp_refreshing());
 
-  text_tips = lv_label_create(scr, NULL);
-  lv_obj_set_style(text_tips, &tft_style_label_rel);
-
+  text_tips = lv_label_create(scr);
   wifi_name = lv_label_create(scr, NULL);
-  lv_obj_set_style(wifi_name, &tft_style_label_rel);
 
   if (wifi_tips_type == TIPS_TYPE_JOINING) {
     lv_label_set_text(text_tips, tips_menu.joining);


### PR DESCRIPTION
### Requirements

An MKS TFT display is required to test or use this set of changes.

### Description

The MKS UI code in `lcd/extui/lib/mks_ui` is a bit repetitious. This PR creates a few helper functions and applies them throughout the MKS UI code in an attempt to reduce the code size and improve general maintainability.

### Benefits

MKS UI code will use less Flash and possibly less SRAM.
