### PR TITLE
BugFix 2.0.x discount controller LCD Height

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -242,7 +242,9 @@
 #elif ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
 
   // RepRapDiscount LCD or Graphical LCD with rotary click encoder
-  #define IS_RRD_SC 1
+  #define LCD_HEIGHT 4
+  #define LCD_WIDTH  20
+  #define IS_RRD_SC  1
 
 #endif
 


### PR DESCRIPTION
### Description

Added LCD_HEIGHT and LCD_WIDTH to conditionals_LCD.h

```
#elif ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)

  // RepRapDiscount LCD or Graphical LCD with rotary click encoder
  #define LCD_HEIGHT 4
  #define LCD_WIDTH  20
  #define IS_RRD_SC  1

#endif
```

### Benefits

Fixes issue with REPRAP_DISCOUNT_SMART_CONTROLLER only showing 2 x rows of characters

### Configurations

[Archive.zip](https://github.com/MarlinFirmware/Marlin/files/5428606/Archive.zip)

### Related Issues

[Bug #19862](https://github.com/MarlinFirmware/Marlin/issues/19862)

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
