### PR TITLE
Remove M202

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -582,11 +582,6 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       #endif
 
       case 201: M201(); break;                                    // M201: Set max acceleration for print moves (units/s^2)
-
-      #if 0
-        case 202: M202(); break;                                  // M202: Not used for Sprinter/grbl gen6
-      #endif
-
       case 203: M203(); break;                                    // M203: Set max feedrate (units/sec)
       case 204: M204(); break;                                    // M204: Set acceleration
       case 205: M205(); break;                                    // M205: Set advanced settings

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -165,7 +165,6 @@
  *        R<temp> Wait for bed current temp to reach target temp. ** Wait for heating or cooling. **
  * M200 - Set filament diameter, D<diameter>, setting E axis units to cubic. (Use S0 to revert to linear units.)
  * M201 - Set max acceleration in units/s^2 for print moves: "M201 X<accel> Y<accel> Z<accel> E<accel>"
- * M202 - Set max acceleration in units/s^2 for travel moves: "M202 X<accel> Y<accel> Z<accel> E<accel>" ** UNUSED IN MARLIN! **
  * M203 - Set maximum feedrate: "M203 X<fr> Y<fr> Z<fr> E<fr>" in units/sec.
  * M204 - Set default acceleration in units/sec^2: P<printing> R<extruder_only> T<travel>
  * M205 - Set advanced settings. Current units apply:
@@ -647,11 +646,6 @@ private:
 
   static void M200();
   static void M201();
-
-  #if 0
-    static void M202(); // Not used for Sprinter/grbl gen6
-  #endif
-
   static void M203();
   static void M204();
   static void M205();


### PR DESCRIPTION
While [discussing](https://github.com/MarlinFirmware/MarlinDocumentation/issues/341) missing GCode documentation we stumbled upon **M202** which is not used in marlin, but still in code. 
_"Set max acceleration in units/s^2 for travel moves"_
If this functionality isn't used we should delete this. Or is this some kind of reminder/documentation to not implement this code

