### PR TITLE
Fix Chitu V5/V6 FAN2 pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -94,7 +94,7 @@
 //
 #define CONTROLLER_FAN_PIN                  PD6   // BOARD FAN
 #define FAN_PIN                             PG13  // FAN
-#define FAN_PIN_2                           PG14
+#define FAN2_PIN                            PG14
 
 //
 // Misc

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -103,7 +103,7 @@
 //
 #define CONTROLLER_FAN_PIN                  PD6   // BOARD FAN
 #define FAN_PIN                             PG13  // FAN
-#define FAN_PIN_2                           PG14
+#define FAN2_PIN                            PG14
 
 //
 // Misc


### PR DESCRIPTION
### Description

Fix Chitu V5/V6 FAN2 pins.

### Benefits

Use proper fan pin format.

### Configurations

https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Tronxy/X5SA

A PR was created for the affected config: https://github.com/MarlinFirmware/Configurations/pull/284

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/19873