### PR TITLE
Support Fysetc Mini 12864 + GT2560 A(+)

### DIFF
--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -117,7 +117,7 @@
       #define BTN_EN1                         40
       #define BTN_EN2                         42
     #elif ENABLED(FYSETC_MINI_12864)
-      //Disconnect 1,2 of EXP2, otherwise future firmware upload won't work.
+      // Disconnect EXP2-1 and EXP2-2, otherwise future firmware upload won't work.
       #define DOGLCD_A0                       20
       #define DOGLCD_CS                       17
 

--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -116,6 +116,20 @@
       #define DOGLCD_CS                       21
       #define BTN_EN1                         40
       #define BTN_EN2                         42
+    #elif ENABLED(FYSETC_MINI_12864)
+      //Disconnect 1,2 of EXP2, otherwise future firmware upload won't work.
+      #define DOGLCD_A0                       20
+      #define DOGLCD_CS                       17
+
+      #define NEOPIXEL_PIN                    21
+      #define BTN_EN1                         42
+      #define BTN_EN2                         40
+
+      #define LCD_RESET_PIN                   16
+
+      #define DEFAULT_LCD_CONTRAST           220
+
+      #define LCD_BACKLIGHT_PIN               -1
     #else
       #define LCD_PINS_RS                     20
       #define LCD_PINS_ENABLE                 17


### PR DESCRIPTION
### Description

Adds pins when using GT2560 A (+) motherboard with the Fysetc Mini12864 LCD.

### Benefits

Makes that combination usable.

### Configurations

Set motherboard to Geeetech GT2560 A or GT2560 A+ and enable define for Fysetc Mini12864 (any version)

