### PR TITLE
Fix dependency script for debug in recent PIO changes

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -208,7 +208,8 @@ def search_compiler():
 		for filepath in os.listdir(pathdir):
 			if not filepath.endswith(gcc):
 				continue
-
+			# Use entire path to not rely on env PATH
+			filepath = os.path.sep.join([pathdir, filepath])
 			# Cache the g++ path to no search always
 			if os.path.exists(ENV_BUILD_PATH):
 				blab('Caching g++ for current env')


### PR DESCRIPTION
### Description

Some recenty PIO change(minor) break the debugging(jtag) when using our dependecy script. The reason is that PIO don't use system path while starting the debugger.

This PR makes the dependency script use the entire path to call the compiler.

### Benefits

More resilient script, and fix broken debug.
