### PR TITLE
Ignore NativeEthernet for at90usb1286 builds

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -39,6 +39,7 @@ jobs:
         - esp32
         - linux_native
         - mega2560
+        - at90usb1286_dfu
         - teensy31
         - teensy35
         - teensy41
@@ -95,7 +96,6 @@ jobs:
 
         # Non-working environment tests
         #- at90usb1286_cdc
-        #- at90usb1286_dfu
         #- STM32F103CB_malyan
         #- mks_robin_mini
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -560,7 +560,7 @@ build_unflags = -g -ggdb
 platform      = teensy
 extends       = common_avr8
 board         = at90usb1286
-lib_ignore    = ${env:common_avr8.lib_ignore} Teensy_ADC
+lib_ignore    = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
 
 #
 # AT90USB1286 boards using DFU bootloader


### PR DESCRIPTION
### Description

NativeEthernet was ignored for other pre-4.1 Teensy environments earlier, but at90usb environments were missed.

Enabled a test environment for at90usb1286_dfu, as these seem to break frequently when other changes are made.

### Benefits

Can build for at90usb.

### Configurations

Example:
Printrbot/Simple Metal RevD

### Related Issues

N/A
