### PR TITLE
Fix stale ZMIB_V2 environment names

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -318,7 +318,7 @@
 #elif MB(AZTEEG_X1)
   #include "sanguino/pins_AZTEEG_X1.h"          // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
 #elif MB(ZMIB_V2)
-  #include "sanguino/pins_ZMIB_V2.h"            // ATmega644P, ATmega1284P                env:sanguino_atmega644p env:sanguino_atmega1284p
+  #include "sanguino/pins_ZMIB_V2.h"            // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
 
 //
 // Other ATmega644P, ATmega644, ATmega1284P


### PR DESCRIPTION
### Description

Fix stale environment names in pin.h for ZMIB_V2.

### Benefits

Provide valid env names for AutoBuild.

### Configurations

N/A

### Related Issues

N/A
