### PR TITLE
Fix PASSWORD_FEATURE not compiling without a LCD

### DIFF
--- a/Marlin/src/feature/password/password.h
+++ b/Marlin/src/feature/password/password.h
@@ -31,10 +31,10 @@ public:
   Password() { is_locked = false; }
 
   static void lock_machine();
+  static void authentication_check();
 
   #if HAS_LCD_MENU
     static void access_menu_password();
-    static void authentication_check();
     static void authentication_done();
     static void media_gatekeeper();
 


### PR DESCRIPTION
### Requirements

#define EEPROM_SETTINGS
#define PASSWORD_FEATURE

### Description

If you don't enable a LCD this will give a compile error 
Marlin\src\feature\password\password.cpp:49:37: error: no 'void Password::authentication_check()' member function declared in class 'Password'

A LCD is not actuality required to use this feature, can be locked and unlocked via g-code

Move the authentication_check out of #if HAS_LCD_MENU block so it is always defined

### Benefits

PASSWORD_FEATURE works without a LCD

### Related Issues

Issue https://github.com/MarlinFirmware/Marlin/issues/19884