### PR TITLE
Missing watchdog for LVGL

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/pic_manager.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/pic_manager.cpp
@@ -488,6 +488,7 @@ uint8_t public_buf[512];
   }
 
   void UpdateAssets() {
+    if (!card.isMounted()) return;
     SdFile dir, root = card.getroot();
     if (dir.open(&root, assetsPath, O_RDONLY)) {
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
@@ -116,18 +116,20 @@ void tft_lvgl_init() {
   ui_cfg_init();
   disp_language_init();
 
-  //init tft first!
-  watchdog_refresh();
+  watchdog_refresh();     // LVGL init takes time
+
+  // Init TFT first!
   SPI_TFT.spi_init(SPI_FULL_SPEED);
   SPI_TFT.LCD_init();
 
+  watchdog_refresh();     // LVGL init takes time
+
   //spi_flash_read_test();
   #if ENABLED(SDSUPPORT)
-    watchdog_refresh();
     UpdateAssets();
+    watchdog_refresh();   // LVGL init takes time
   #endif
 
-  watchdog_refresh();
   mks_test_get();
 
   touch.Init();
@@ -190,9 +192,11 @@ void tft_lvgl_init() {
 
   lv_encoder_pin_init();
 
+  bool ready = true;
   #if ENABLED(POWER_LOSS_RECOVERY)
     recovery.load();
     if (recovery.valid()) {
+      ready = false;
       if (gCfgItems.from_flash_pic)
         flash_preview_begin = true;
       else
@@ -202,14 +206,12 @@ void tft_lvgl_init() {
 
       strncpy(public_buf_m, recovery.info.sd_filename, sizeof(public_buf_m));
       card.printLongPath(public_buf_m);
-
       strncpy(list_file.long_name[sel_id], card.longFilename, sizeof(list_file.long_name[sel_id]));
-
       lv_draw_printing();
     }
-    else
   #endif
-    lv_draw_ready_print();
+
+  if (ready) lv_draw_ready_print();
 
   if (mks_test_flag == 0x1E)
     mks_gpio_test();

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
@@ -117,6 +117,7 @@ void tft_lvgl_init() {
   disp_language_init();
 
   //init tft first!
+  watchdog_refresh();
   SPI_TFT.spi_init(SPI_FULL_SPEED);
   SPI_TFT.LCD_init();
 


### PR DESCRIPTION
### Description

Missing a `watchdog_refresh` in the lcd init makes boards using lvgl reboot when not using sd.

### Benefits

Fix #19893 

