### PR TITLE
add missing LED pins to AZTEEG X5 mini

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_AZTEEG_X5_MINI.h
+++ b/Marlin/src/pins/lpc1769/pins_AZTEEG_X5_MINI.h
@@ -37,10 +37,10 @@
 //
 // LED
 //
-#define LED_PIN                             P1_18
-#define LED2_PIN                            P1_20
-#define LED3_PIN                            P1_19
-#define LED4_PIN                            P1_21
+#define LED_PIN                            P1_18
+#define LED2_PIN                           P1_20
+#define LED3_PIN                           P1_19
+#define LED4_PIN                           P1_21
 
 //
 // Servos
@@ -82,14 +82,13 @@
 #define E0_ENABLE_PIN                      P0_04
 
 //
-// DIGIPOT slave addresses
+// DIGIPOT slave addresses (7-bit unshifted)
 //
 #ifndef DIGIPOT_I2C_ADDRESS_A
-  #define DIGIPOT_I2C_ADDRESS_A             0x2C  // unshifted slave address for first DIGIPOT
+  #define DIGIPOT_I2C_ADDRESS_A             0x2C
 #endif
-
 #ifndef DIGIPOT_I2C_ADDRESS_B
-  #define DIGIPOT_I2C_ADDRESS_B             0x2E  // unshifted slave address for second DIGIPOT
+  #define DIGIPOT_I2C_ADDRESS_B             0x2E
 #endif
 
 //

--- a/Marlin/src/pins/lpc1769/pins_AZTEEG_X5_MINI.h
+++ b/Marlin/src/pins/lpc1769/pins_AZTEEG_X5_MINI.h
@@ -37,7 +37,10 @@
 //
 // LED
 //
-#define LED_PIN                            P1_18
+#define LED_PIN                             P1_18 //50
+#define LED2_PIN                            P1_20 //52
+#define LED3_PIN                            P1_19 //53
+#define LED4_PIN                            P1_21 //55
 
 //
 // Servos

--- a/Marlin/src/pins/lpc1769/pins_AZTEEG_X5_MINI.h
+++ b/Marlin/src/pins/lpc1769/pins_AZTEEG_X5_MINI.h
@@ -37,10 +37,10 @@
 //
 // LED
 //
-#define LED_PIN                             P1_18 //50
-#define LED2_PIN                            P1_20 //52
-#define LED3_PIN                            P1_19 //53
-#define LED4_PIN                            P1_21 //55
+#define LED_PIN                             P1_18
+#define LED2_PIN                            P1_20
+#define LED3_PIN                            P1_19
+#define LED4_PIN                            P1_21
 
 //
 // Servos


### PR DESCRIPTION
### Requirements

AZTEEG X5 mini Controller

### Description

This controller has 4 'user' LED's  LED1 - LED4 but only LED1 was defined in Marlin as LED_PIN
I have added the other 3 LED's in case someone should want to use them.

### Benefits

LEDs are in the pins file.

