### PR TITLE
Generalize BTT SKR E3-DIP version string

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
@@ -25,7 +25,7 @@
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #endif
 
-#define BOARD_INFO_NAME "BTT SKR E3 DIP V1.0"
+#define BOARD_INFO_NAME "BTT SKR E3 DIP V1.x"
 
 // Release PB3/PB4 (TMC_SW Pins) from JTAG pins
 #define DISABLE_JTAG


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Firmware build for Creality Ender-3 with BigTreeTech SKR E3-DIP mainboard upgrade uses the same source files for board version 1.0 and 1.1. Meanwhile "About Printer" -> "Board Info" submenu shows string "BTT SKR E3 DIP V1.0".
This patch changes the string to "BTT SKR E3 DIP V1.x" which is more suitable for all board versions.

### Benefits

Display correct board information in "Board Info" submenu.

### Configurations

Config files used for compilation are:
[MarlinFirmware/Configurations]: config/examples/Creality/Ender-3/BigTreeTech SKR E3-DIP V1.1/Configuration.h
[MarlinFirmware/Configurations]: config/examples/Creality/Ender-3/BigTreeTech SKR E3-DIP V1.1/Configuration_adv.h

platformio.ini:

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = mega2560
+default_envs = STM32F103RE_btt_USB
 include_dir  = Marlin


### Related Issues

None.
