### PR TITLE
[menu] Fix wrong extruder stepper on filament change

### DIFF
--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -116,7 +116,7 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
       PGM_P const msg = GET_TEXT(MSG_FILAMENTCHANGE_E);
       for (uint8_t s = 0; s < E_STEPPERS; s++) {
         if (thermalManager.targetTooColdToExtrude(s))
-          SUBMENU_N_P(s, msg, []{ _menu_temp_filament_op(PAUSE_MODE_CHANGE_FILAMENT, MenuItemBase::itemIndex); });
+          SUBMENU_N_P(s, msg, []{ _menu_temp_filament_op(PAUSE_MODE_CHANGE_FILAMENT, MenuItemBase::itemIndex - 1); });
         else {
           ACTION_ITEM_N_P(s, msg, []{
             char cmd[12];


### PR DESCRIPTION
### Description

The "change filament" menu produces a wrong extruder parameter (`T` parameter) in some circumstances.
Conditions:
- Mixing extruder
- User is trying to change the filament from a cold hotend

### Benefits

The correct extruder is chosen according to the menu presented to the user.

Fixes #19911 

### Configurations

Tested on this branch here: https://github.com/fishcu/Marlin/tree/2.0.7.2-a10m

Which is based on tag 2.0.7.2. Tested on a Geeetech A10M printer with mixing extruder (2-in-1-out).

### Related Issues

Fixes #19911 