### PR TITLE
Quote compiler call to not break when compiler path have spaces

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -234,7 +234,7 @@ def load_marlin_features():
 	build_flags = env.ParseFlagsExtended(build_flags)
 
 	cxx = search_compiler()
-	cmd = [cxx]
+	cmd = ['"' + cxx + '"']
 
 	# Build flags from board.json
 	#if 'BOARD' in env:


### PR DESCRIPTION
### Description

Dep script call uses the full path now. But some users have spaces in the path where the pio is installed. This quote the compiler call.

### Benefits

Fix #19927 

### Related Issues

#19881 
