### PR TITLE
Never Stop SPI on LPC

### DIFF
--- a/Marlin/src/HAL/LPC1768/HAL_SPI.cpp
+++ b/Marlin/src/HAL/LPC1768/HAL_SPI.cpp
@@ -263,8 +263,9 @@ uint16_t SPIClass::transfer16(const uint16_t data) {
 }
 
 void SPIClass::end() {
-  // SSP_Cmd(_currentSetting->spi_d, DISABLE);  // stop device or SSP_DeInit?
-  // SSP_DeInit(_currentSetting->spi_d);
+  // Neither is needed for Marlin
+  //SSP_Cmd(_currentSetting->spi_d, DISABLE);
+  //SSP_DeInit(_currentSetting->spi_d);
 }
 
 void SPIClass::send(uint8_t data) {

--- a/Marlin/src/HAL/LPC1768/HAL_SPI.cpp
+++ b/Marlin/src/HAL/LPC1768/HAL_SPI.cpp
@@ -264,7 +264,7 @@ uint16_t SPIClass::transfer16(const uint16_t data) {
 
 void SPIClass::end() {
   // SSP_Cmd(_currentSetting->spi_d, DISABLE);  // stop device or SSP_DeInit?
-  SSP_DeInit(_currentSetting->spi_d);
+  // SSP_DeInit(_currentSetting->spi_d);
 }
 
 void SPIClass::send(uint8_t data) {


### PR DESCRIPTION
### Description

LPC MSC code start and configure the SPI 1 when the SD is release (to be shared with the host). After that initialisation, it relies that the SPI 1 will be always enabled and with the right configuration.

It's work fine with boards that keep SPI 1 only for SD.

But, some boards, like MKS SGEN L V2, share SPI 1 for the SD and the LCD/TFT. This makes SPI 1 changes constantly.

This results in random things, like not being able to mount SD, or even shows the SD as corrupted in the HOST.

This is just a temporary (but OK) fix, until we check if the LPC framework can handle it. ~Maybe it will not be able to do so, if it use any async DMA..~. There’s no dma async in the SD, so as long the spi keep the same config for both devices, this fix will work. 
I just don't stop/end the SPI anymore...

I just found that the LPC framework have some hardcode SPI clock settings, that may not work for every board. It's the reason "disk not initialised" error.

### Benefits

Fix #19917 
Fix #19750 (maybe?) 

