### PR TITLE
Update Dagoma F5 board configuration

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -92,7 +92,7 @@
 #define BOARD_TRIGORILLA_14_11        1136  //   ... Rev 1.1 (new servo pin order)
 #define BOARD_RAMPS_ENDER_4           1137  // Creality: Ender-4, CR-8
 #define BOARD_RAMPS_CREALITY          1138  // Creality: CR10S, CR20, CR-X
-#define BOARD_RAMPS_DAGOMA            1139  // Dagoma F5
+#define BOARD_DAGOMA_F5               1139  // Dagoma F5
 #define BOARD_FYSETC_F6_13            1140  // FYSETC F6 1.3
 #define BOARD_FYSETC_F6_14            1141  // FYSETC F6 1.4
 #define BOARD_DUPLICATOR_I3_PLUS      1142  // Wanhao Duplicator i3 Plus

--- a/Marlin/src/module/thermistor/thermistor_17.h
+++ b/Marlin/src/module/thermistor/thermistor_17.h
@@ -1,0 +1,78 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+// Dagoma NTC 100k white thermistor
+const temp_entry_t temptable_17[] PROGMEM = {
+  { OV(  16),  309 },
+  { OV(  18),  307 },
+  { OV(  20),  300 },
+  { OV(  22),  293 },
+  { OV(  26),  284 },
+  { OV(  29),  272 },
+  { OV(  33),  266 },
+  { OV(  36),  260 },
+  { OV(  42),  252 },
+  { OV(  46),  247 },
+  { OV(  48),  244 },
+  { OV(  51),  241 },
+  { OV(  62),  231 },
+  { OV(  73),  222 },
+  { OV(  78),  219 },
+  { OV(  87),  212 },
+  { OV(  98),  207 },
+  { OV( 109),  201 },
+  { OV( 118),  197 },
+  { OV( 131),  191 },
+  { OV( 145),  186 },
+  { OV( 160),  181 },
+  { OV( 177),  175 },
+  { OV( 203),  169 },
+  { OV( 222),  164 },
+  { OV( 256),  156 },
+  { OV( 283),  151 },
+  { OV( 312),  145 },
+  { OV( 343),  140 },
+  { OV( 377),  131 },
+  { OV( 413),  125 },
+  { OV( 454),  119 },
+  { OV( 496),  113 },
+  { OV( 537),  108 },
+  { OV( 578),  102 },
+  { OV( 619),   97 },
+  { OV( 658),   92 },
+  { OV( 695),   87 },
+  { OV( 735),   81 },
+  { OV( 773),   75 },
+  { OV( 808),   70 },
+  { OV( 844),   64 },
+  { OV( 868),   59 },
+  { OV( 892),   54 },
+  { OV( 914),   49 },
+  { OV( 935),   42 },
+  { OV( 951),   38 },
+  { OV( 967),   32 },
+  { OV( 975),   28 },
+  { OV(1000),   20 },
+  { OV(1010),   10 },
+  { OV(1024), -273 } // for safety
+};

--- a/Marlin/src/module/thermistor/thermistors.h
+++ b/Marlin/src/module/thermistor/thermistors.h
@@ -105,6 +105,9 @@ typedef struct { int16_t value, celsius; } temp_entry_t;
 #if ANY_THERMISTOR_IS(15) // JGAurora A5 thermistor calibration
   #include "thermistor_15.h"
 #endif
+#if ANY_THERMISTOR_IS(17) // Dagoma NTC 100k white thermistor
+  #include "thermistor_17.h"
+#endif
 #if ANY_THERMISTOR_IS(18) // ATC Semitec 204GT-2 (4.7k pullup) Dagoma.Fr - MKS_Base_DKU001327
   #include "thermistor_18.h"
 #endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -713,6 +713,7 @@
   #define BOARD_BIGTREE_SKR_E3_DIP      -1017
   #define BOARD_RUMBA32                 -1018
   #define BOARD_RUMBA32_AUS3D           -1019
+  #define BOARD_RAMPS_DAGOMA            -1020
 
   #if MB(MKS_13)
     #error "BOARD_MKS_13 has been renamed BOARD_MKS_GEN_13. Please update your configuration."
@@ -756,6 +757,8 @@
     #error "BOARD_RUMBA32 is now BOARD_RUMBA32_MKS or BOARD_RUMBA32_V1_0. Please update your configuration."
   #elif MB(RUMBA32_AUS3D)
     #error "BOARD_RUMBA32_AUS3D is now BOARD_RUMBA32_V1_0. Please update your configuration."
+  #elif MB(RAMPS_DAGOMA)
+    #error "BOARD_RAMPS_DAGOMA is now BOARD_DAGOMA_F5. Please update your configuration."
   #else
     #error "Unknown MOTHERBOARD value set in Configuration.h"
   #endif
@@ -780,6 +783,7 @@
   #undef BOARD_BIGTREE_SKR_E3_DIP
   #undef BOARD_RUMBA32
   #undef BOARD_RUMBA32_AUS3D
+  #undef BOARD_RAMPS_DAGOMA
 
 #endif
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -179,8 +179,8 @@
   #include "ramps/pins_RAMPS_ENDER_4.h"         // ATmega2560                             env:mega2560
 #elif MB(RAMPS_CREALITY)
   #include "ramps/pins_RAMPS_CREALITY.h"        // ATmega2560                             env:mega2560
-#elif MB(RAMPS_DAGOMA)
-  #include "ramps/pins_RAMPS_DAGOMA.h"          // ATmega2560                             env:mega2560
+#elif MB(DAGOMA_F5)
+  #include "ramps/pins_DAGOMA_F5.h"             // ATmega2560                             env:mega2560
 #elif MB(FYSETC_F6_13)
   #include "ramps/pins_FYSETC_F6_13.h"          // ATmega2560                             env:FYSETC_F6_13
 #elif MB(FYSETC_F6_14)

--- a/Marlin/src/pins/ramps/pins_DAGOMA_F5.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_F5.h
@@ -22,21 +22,44 @@
 #pragma once
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Dagoma3D F5 RAMPS supports only 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Dagoma3D F5 supports only 2 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_INFO_NAME "Dagoma3D F5 RAMPS"
+#define BOARD_INFO_NAME "Dagoma3D F5"
 
+//
+// Endstops
+//
 #define X_STOP_PIN                            2
 #define Y_STOP_PIN                            3
 #define Z_STOP_PIN                           15
 #define FIL_RUNOUT_PIN                       39
-
-#ifndef E0_AUTO_FAN_PIN
-  #define E0_AUTO_FAN_PIN                     7
+#if EXTRUDERS > 1
+  #define FIL_RUNOUT2_PIN                    14
 #endif
 
 //
-// Import RAMPS 1.4 pins
+// LCD delays
+//
+#define BOARD_ST7920_DELAY_1 DELAY_NS(0)
+#define BOARD_ST7920_DELAY_2 DELAY_NS(250)
+#define BOARD_ST7920_DELAY_3 DELAY_NS(250)
+
+//
+// DAC steppers
+//
+#define HAS_MOTOR_CURRENT_DAC
+
+#define DAC_STEPPER_ORDER { 0, 1, 2, 3 }
+
+#define DAC_STEPPER_SENSE    0.11
+#define DAC_STEPPER_ADDRESS  0
+#define DAC_STEPPER_MAX      4096
+#define DAC_STEPPER_VREF     1
+#define DAC_STEPPER_GAIN     0
+#define DAC_OR_ADDRESS       0x00
+
+//
+// Import default RAMPS 1.4 pins
 //
 #include "pins_RAMPS.h"

--- a/Marlin/src/pins/ramps/pins_DAGOMA_F5.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_F5.h
@@ -33,6 +33,7 @@
 #define X_STOP_PIN                            2
 #define Y_STOP_PIN                            3
 #define Z_STOP_PIN                           15
+
 #define FIL_RUNOUT_PIN                       39
 #if EXTRUDERS > 1
   #define FIL_RUNOUT2_PIN                    14
@@ -41,9 +42,11 @@
 //
 // LCD delays
 //
-#define BOARD_ST7920_DELAY_1 DELAY_NS(0)
-#define BOARD_ST7920_DELAY_2 DELAY_NS(250)
-#define BOARD_ST7920_DELAY_3 DELAY_NS(250)
+#if HAS_MARLINUI_U8GLIB
+  #define BOARD_ST7920_DELAY_1 DELAY_NS(0)
+  #define BOARD_ST7920_DELAY_2 DELAY_NS(250)
+  #define BOARD_ST7920_DELAY_3 DELAY_NS(250)
+#endif
 
 //
 // DAC steppers


### PR DESCRIPTION
Hi,

This PR updates the Dagoma F5 board pins configuration.
It comes with an update of the related printer configuration in a [PR submitted](https://github.com/MarlinFirmware/Configurations/pull/300) on the **Configurations** repository.

Regards,
Orel