### PR TITLE
Reset calibration screen touch timer when click is consumed 

### DIFF
--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -61,7 +61,7 @@ void Touch::init() {
   enable();
 }
 
-void Touch::add_control(TouchControlType type, uint16_t x, uint16_t y, uint16_t width, uint16_t height, int32_t data) {
+void Touch::add_control(TouchControlType type, uint16_t x, uint16_t y, uint16_t width, uint16_t height, intptr_t data) {
   if (controls_count == MAX_CONTROLS) return;
 
   controls[controls_count].type = type;
@@ -94,6 +94,8 @@ void Touch::idle() {
         return;
       }
     #endif
+
+    SERIAL_ECHOLNPAIR("X: ", _x, ", Y: ", _y);
 
     #if LCD_TIMEOUT_TO_STATUS
       ui.return_to_status_ms = last_touch_ms + LCD_TIMEOUT_TO_STATUS;
@@ -306,7 +308,7 @@ bool MarlinUI::touch_pressed() {
   return touch.is_clicked();
 }
 
-void add_control(uint16_t x, uint16_t y, TouchControlType control_type, int32_t data, MarlinImage image, bool is_enabled, uint16_t color_enabled, uint16_t color_disabled) {
+void add_control(uint16_t x, uint16_t y, TouchControlType control_type, intptr_t data, MarlinImage image, bool is_enabled, uint16_t color_enabled, uint16_t color_disabled) {
   uint16_t width = Images[image].width;
   uint16_t height = Images[image].height;
   tft.canvas(x, y, width, height);

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -95,8 +95,6 @@ void Touch::idle() {
       }
     #endif
 
-    SERIAL_ECHOLNPAIR("X: ", _x, ", Y: ", _y);
-
     #if LCD_TIMEOUT_TO_STATUS
       ui.return_to_status_ms = last_touch_ms + LCD_TIMEOUT_TO_STATUS;
     #endif

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -158,13 +158,12 @@ class Touch {
 
   public:
     static void init();
-    static void reset() { controls_count = 0; touch_time = -1; current_control = NULL; }
+    static void reset() { controls_count = 0; touch_time = 0; current_control = NULL; }
     static void clear() { controls_count = 0; }
     static void idle();
     static bool is_clicked() {
       if (touch_control_type == CLICK) {
         touch_control_type = NONE;
-        touch_time = 0;
         return true;
       }
       return false;

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -85,9 +85,9 @@ enum TouchControlType : uint16_t {
 
 typedef void (*screenFunc_t)();
 
-void add_control(uint16_t x, uint16_t y, TouchControlType control_type, int32_t data, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED);
+void add_control(uint16_t x, uint16_t y, TouchControlType control_type, intptr_t data, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED);
 inline void add_control(uint16_t x, uint16_t y, TouchControlType control_type, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED) { add_control(x, y, control_type, 0, image, is_enabled, color_enabled, color_disabled); }
-inline void add_control(uint16_t x, uint16_t y, screenFunc_t screen, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED) { add_control(x, y, MENU_SCREEN, (int32_t)screen, image, is_enabled, color_enabled, color_disabled); }
+inline void add_control(uint16_t x, uint16_t y, screenFunc_t screen, MarlinImage image, bool is_enabled = true, uint16_t color_enabled = COLOR_CONTROL_ENABLED, uint16_t color_disabled = COLOR_CONTROL_DISABLED) { add_control(x, y, MENU_SCREEN, (intptr_t)screen, image, is_enabled, color_enabled, color_disabled); }
 
 typedef struct __attribute__((__packed__)) {
   TouchControlType type;
@@ -95,7 +95,7 @@ typedef struct __attribute__((__packed__)) {
   uint16_t y;
   uint16_t width;
   uint16_t height;
-  int32_t data;
+  intptr_t data;
 } touch_control_t;
 
 typedef struct __attribute__((__packed__)) {
@@ -171,7 +171,7 @@ class Touch {
     static void disable() { enabled = false; }
     static void enable() { enabled = true; }
 
-    static void add_control(TouchControlType type, uint16_t x, uint16_t y, uint16_t width, uint16_t height, int32_t data = 0);
+    static void add_control(TouchControlType type, uint16_t x, uint16_t y, uint16_t width, uint16_t height, intptr_t data = 0);
 
     static touch_calibration_t calibration;
     static void calibration_reset() { calibration = {TOUCH_CALIBRATION_X, TOUCH_CALIBRATION_Y, TOUCH_OFFSET_X, TOUCH_OFFSET_Y, TOUCH_ORIENTATION}; }

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -164,6 +164,7 @@ class Touch {
     static bool is_clicked() {
       if (touch_control_type == CLICK) {
         touch_control_type = NONE;
+        touch_time = 0;
         return true;
       }
       return false;


### PR DESCRIPTION
### Description

With recent changes to adapt color ui for `wait_for_release`, we may break a timer to start touch calibration screen if the touch is held for more than 2.5s. This PR fix that timer.

### Benefits

Fix: #19941 

### Related Issues

#19771 
