### PR TITLE
Fix erroneous maths in SpindleLaser::cpwr_to_pct()

### DIFF
--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -53,7 +53,7 @@ public:
 
   // cpower = configured values (ie SPEED_POWER_MAX)
   static const inline uint8_t cpwr_to_pct(const cutter_cpower_t cpwr) { // configured value to pct
-    return unitPower ? round(100 * (cpwr - SPEED_POWER_FLOOR) / (SPEED_POWER_MAX - SPEED_POWER_FLOOR)) : 0;
+    return unitPower ? round(100 * float(cpwr - SPEED_POWER_FLOOR) / (SPEED_POWER_MAX - SPEED_POWER_FLOOR)) : 0;
   }
 
   // Convert a configured value (cpower)(ie SPEED_POWER_STARTUP) to unit power (upwr, upower),


### PR DESCRIPTION
### Description

When using `#define CUTTER_POWER_UNIT RPM`, the values set to the spindle PWM pin are incorrect. For example, if I do `M3 S15000` the pulse width should be half of the period, but instead it is a ridiculous short peak.

This is due to a bug in `SpindleLaser::cpwr_to_pct()`.

This method is intended to convert a value in the range of `SPEED_POWER_MIN..SPEED_POWER_MAX` to a value in the range of `0..100` (percentage), later the percentage will be converted to an ocr value in the range `0..255` to be set on PWM pin.

This pull request fixes the bug and restore the expected behavior.

### Benefits

Without this fix :

```
*** DEBUG SpindleLaser::cpwr_to_pct(0) = 0
*** DEBUG SpindleLaser::cpwr_to_pct(5000) = 1
*** DEBUG SpindleLaser::cpwr_to_pct(10000) = 0
*** DEBUG SpindleLaser::cpwr_to_pct(15000) = 1
*** DEBUG SpindleLaser::cpwr_to_pct(20000) = 1
*** DEBUG SpindleLaser::cpwr_to_pct(25000) = 0
*** DEBUG SpindleLaser::cpwr_to_pct(30000) = 1
```

```
*** DEBUG SpindleLaser::cpwr_to_pct(0) = 0
*** DEBUG SpindleLaser::cpwr_to_pct(5000) = 17
*** DEBUG SpindleLaser::cpwr_to_pct(10000) = 33
*** DEBUG SpindleLaser::cpwr_to_pct(15000) = 50
*** DEBUG SpindleLaser::cpwr_to_pct(20000) = 67
*** DEBUG SpindleLaser::cpwr_to_pct(25000) = 83
*** DEBUG SpindleLaser::cpwr_to_pct(30000) = 100
```

### Configurations

Default configuration with:

```
#define SPINDLE_FEATURE
```

and

```
#define CUTTER_POWER_UNIT RPM
```


### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
