### PR TITLE
important notice to avoid false alarms of filament runout

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1170,6 +1170,11 @@
  * Filament Runout Sensors
  * Mechanical or opto endstops are used to check for the presence of filament.
  *
+ * IMPORTANT: Runout will only trigger if and only if one of this criteria are met:
+ *  1. You are printing from SD that Marlin is accessing (not from a serial TFT SD)
+ *  2. Your GCode have M75 - Start Print Job Timer
+ *  3. PRINTJOB_TIMER_AUTOSTART is enabled and your GCode have M109 or M191 (wait for temp)
+ *
  * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
  * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
  */

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1170,10 +1170,11 @@
  * Filament Runout Sensors
  * Mechanical or opto endstops are used to check for the presence of filament.
  *
- * IMPORTANT: Runout will only trigger if and only if one of this criteria are met:
- *  1. You are printing from SD that Marlin is accessing (not from a serial TFT SD)
- *  2. Your GCode have M75 - Start Print Job Timer
- *  3. PRINTJOB_TIMER_AUTOSTART is enabled and your GCode have M109 or M191 (wait for temp)
+ * IMPORTANT: Runout will only trigger if Marlin is aware that a print job is running.
+ * Marlin knows a print job is running when:
+ *  1. Running a print job from media started with M24.
+ *  2. The Print Job Timer has been started with M75.
+ *  3. The heaters were turned on and PRINTJOB_TIMER_AUTOSTART is enabled.
  *
  * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
  * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.


### PR DESCRIPTION
### Description

Just a important notice for filament runout sensor, to avoid false alarms.

### Benefits

Avoid this: #19969 and #19453 (more than 100 comments for a false alarm)..

