### PR TITLE
Modify PIO debug build path

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -10,3 +10,13 @@ env.Append(CXXFLAGS=[
   #"-Wno-maybe-uninitialized",
   #"-Wno-sign-compare"
 ])
+
+# Useful for JTAG debugging
+#
+# It will separe release and debug build folders. 
+# It useful when we need keep two live versions: one debug, for debugging, 
+# other release, for flashing.
+# Without this, PIO will recompile everything twice for any small change.
+# 
+if env.GetBuildType() == "debug":
+	env['BUILD_DIR'] = '$PROJECT_BUILD_DIR/$PIOENV/debug'


### PR DESCRIPTION
### Description

Currently PIO have only one build folder. So, when you need to do some step-by-step debug with tools like jtag, PIO will compile a version in release for flash, and build again in debug for step-by-step debug.

Each change you do, PIO will do a full clean, and rebuild everything for release, so you can flash the update firmware, and again a full build to debug.

It's annoying and a waste of time.

This PR separate the build folders: one for release and one for debug. This way, keeping separated folders, the compiler will just compile the needed files for each type of build. It's how almost any build tool out there work.

Important note: it don't change the Release build folder, so no user or tool will be affected! 

### Benefits

Faster and less annoying debug.

