### PR TITLE
Add sanity check to detect USE_ZMAX_PLUG / HOMING_Z_WITH_PROBE conflict

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1965,6 +1965,8 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 // Z homing direction and plug usage flags
 #if Z_HOME_DIR < 0 && NONE(USE_ZMIN_PLUG, HOMING_Z_WITH_PROBE)
   #error "Enable USE_ZMIN_PLUG when homing Z to MIN."
+#elif BOTH(USE_ZMAX_PLUG, HOMING_Z_WITH_PROBE)
+  #error "DISABLE_USE_ZMAX_PLUG when homing with the probe."
 #elif Z_HOME_DIR > 0 && ENABLED(USE_PROBE_FOR_Z_HOMING)
   #error "Z_HOME_DIR must be -1 when homing Z with the probe."
 #elif Z_HOME_DIR > 0 && DISABLED(USE_ZMAX_PLUG)


### PR DESCRIPTION
### Description

I have helped several users recently who have homing problems due to homing with a BLTOUCH, but having USE_ZMAX_PLUG enabled in their configuration files.

The extra plug definition causes some homing code to fall-through into a MAX code-path, even though the printer is configured to home to MIN.

### Benefits

Reduce support due to this apparently common misconfiguration.

### Configurations

N/A

### Related Issues

N/A
