### PR TITLE
Read STM32 clock rates from framework

### DIFF
--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -81,6 +81,10 @@
   #define MCU_TEMP_TIMER 14           // TIM7 is consumed by Software Serial if used.
 #endif
 
+#ifndef HAL_TIMER_RATE
+  #define HAL_TIMER_RATE GetStepperTimerClkFreq()
+#endif
+
 #ifndef STEP_TIMER
   #define STEP_TIMER MCU_STEP_TIMER
 #endif
@@ -136,7 +140,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
          */
 
         timer_instance[timer_num]->setPrescaleFactor(STEPPER_TIMER_PRESCALE); //the -1 is done internally
-        timer_instance[timer_num]->setOverflow(_MIN(hal_timer_t(HAL_TIMER_TYPE_MAX), GetStepperTimerClkFreq() / (STEPPER_TIMER_PRESCALE) /* /frequency */), TICK_FORMAT);
+        timer_instance[timer_num]->setOverflow(_MIN(hal_timer_t(HAL_TIMER_TYPE_MAX), (HAL_TIMER_RATE) / (STEPPER_TIMER_PRESCALE) /* /frequency */), TICK_FORMAT);
         break;
       case TEMP_TIMER_NUM: // TEMP TIMER - any available 16bit timer
         timer_instance[timer_num] = new HardwareTimer(TEMP_TIMER_DEV);

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -57,7 +57,8 @@
 
 // TODO: get rid of manual rate/prescale/ticks/cycles taken for procedures in stepper.cpp
 #define STEPPER_TIMER_RATE 2000000 // 2 Mhz
-#define STEPPER_TIMER_PRESCALE ((HAL_TIMER_RATE)/(STEPPER_TIMER_RATE))
+extern uint32_t GetStepperTimerClkFreq();
+#define STEPPER_TIMER_PRESCALE (GetStepperTimerClkFreq() / STEPPER_TIMER_RATE)
 #define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
 
 #define PULSE_TIMER_RATE STEPPER_TIMER_RATE

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -58,7 +58,7 @@
 // TODO: get rid of manual rate/prescale/ticks/cycles taken for procedures in stepper.cpp
 #define STEPPER_TIMER_RATE 2000000 // 2 Mhz
 extern uint32_t GetStepperTimerClkFreq();
-#define STEPPER_TIMER_PRESCALE (GetStepperTimerClkFreq() / STEPPER_TIMER_RATE)
+#define STEPPER_TIMER_PRESCALE (GetStepperTimerClkFreq() / (STEPPER_TIMER_RATE))
 #define STEPPER_TIMER_TICKS_PER_US ((STEPPER_TIMER_RATE) / 1000000) // stepper timer ticks per µs
 
 #define PULSE_TIMER_RATE STEPPER_TIMER_RATE

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
@@ -47,7 +47,6 @@
 
 #define STEP_TIMER 10
 #define TEMP_TIMER 14
-#define HAL_TIMER_RATE                     F_CPU
 
 //
 // Limit Switches


### PR DESCRIPTION
### Description

STM32 timer clock rates are not always constant across a device. Depending on the timer they may be `F_CPU`, `F_CPU/2`, or maybe even other values (there are lots of STM32 devices, and I haven't read all their datasheets!).

This change reads the timer's clock rate from the framework, rather than assuming Marlin knows the correct value. This makes our code more generic and easier to implement across the wide range of devices that will be supported by the STM32 HAL.

This also removes the ability to override `HAL_TIMER_RATE`, which was added for the Rumba32. It is simply no longer necessary.

I tested this on an SKR Pro, by moving the STEP timer to TIMER 10, as does the Rumba32. I both reproduced the original "double step rate" issue seen on the Rumba, then verified that this PR fixes it.

### Benefits

- Eliminates the need to consider timer clock rate when selecting timer assignments.
- Fixes a babystepping compilation issue, where timers.h depends on a define from timers.cpp.

### Configurations

N/A

### Related Issues

Fixes: #18961
Replaces former solution for Rumba32: #18374
