### PR TITLE
Add POWER_OFF_DELAY option

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -344,10 +344,10 @@
     #define AUTO_POWER_E_FANS
     #define AUTO_POWER_CONTROLLERFAN
     #define AUTO_POWER_CHAMBER_FAN
-    //#define AUTO_POWER_E_TEMP        50 // (°C) Turn on PSU over this temperature
-    //#define AUTO_POWER_CHAMBER_TEMP  30 // (°C) Turn on PSU over this temperature
-    #define POWER_TIMEOUT 30
-    //#define POWER_OFF_TIMEOUT 30    // (s) Delay for the shutoff of the PSU; for example used to let a cooling-fan run after print is finished
+    //#define AUTO_POWER_E_TEMP        50 // (°C) Turn on PSU if any extruder is over this temperature
+    //#define AUTO_POWER_CHAMBER_TEMP  30 // (°C) Turn on PSU if the chamber is over this temperature
+    #define POWER_TIMEOUT              30 // (s) Turn off power if the machine is idle for this duration
+    //#define POWER_OFF_TIMEOUT        60 // (s) Delay of poweroff after M81 command. Useful to let fans run for extra time.
   #endif
 #endif
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -338,6 +338,8 @@
   //#define PSU_POWERUP_GCODE  "M355 S1"  // G-code to run after power-on (e.g., case light on)
   //#define PSU_POWEROFF_GCODE "M355 S0"  // G-code to run before power-off (e.g., case light off)
 
+  //#define POWER_OFF_TIMEOUT 30    // (s) Delay for the shutoff of the PSU; for example used to let a cooling-fan run after print is finished
+
   //#define AUTO_POWER_CONTROL      // Enable automatic control of the PS_ON pin
   #if ENABLED(AUTO_POWER_CONTROL)
     #define AUTO_POWER_FANS         // Turn on PSU if fans need power

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -338,8 +338,6 @@
   //#define PSU_POWERUP_GCODE  "M355 S1"  // G-code to run after power-on (e.g., case light on)
   //#define PSU_POWEROFF_GCODE "M355 S0"  // G-code to run before power-off (e.g., case light off)
 
-  //#define POWER_OFF_TIMEOUT 30    // (s) Delay for the shutoff of the PSU; for example used to let a cooling-fan run after print is finished
-
   //#define AUTO_POWER_CONTROL      // Enable automatic control of the PS_ON pin
   #if ENABLED(AUTO_POWER_CONTROL)
     #define AUTO_POWER_FANS         // Turn on PSU if fans need power
@@ -349,6 +347,7 @@
     //#define AUTO_POWER_E_TEMP        50 // (°C) Turn on PSU over this temperature
     //#define AUTO_POWER_CHAMBER_TEMP  30 // (°C) Turn on PSU over this temperature
     #define POWER_TIMEOUT 30
+    //#define POWER_OFF_TIMEOUT 30    // (s) Delay for the shutoff of the PSU; for example used to let a cooling-fan run after print is finished
   #endif
 #endif
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -347,7 +347,7 @@
     //#define AUTO_POWER_E_TEMP        50 // (°C) Turn on PSU if any extruder is over this temperature
     //#define AUTO_POWER_CHAMBER_TEMP  30 // (°C) Turn on PSU if the chamber is over this temperature
     #define POWER_TIMEOUT              30 // (s) Turn off power if the machine is idle for this duration
-    //#define POWER_OFF_TIMEOUT        60 // (s) Delay of poweroff after M81 command. Useful to let fans run for extra time.
+    //#define POWER_OFF_DELAY          60 // (s) Delay of poweroff after M81 command. Useful to let fans run for extra time.
   #endif
 #endif
 

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -92,11 +92,13 @@ extern bool wait_for_heatup;
   #define PSU_PIN_ON()  do{ OUT_WRITE(PS_ON_PIN,  PSU_ACTIVE_STATE); powersupply_on = true;  }while(0)
   #define PSU_PIN_OFF() do{ OUT_WRITE(PS_ON_PIN, !PSU_ACTIVE_STATE); powersupply_on = false; }while(0)
   #if ENABLED(AUTO_POWER_CONTROL)
-    #define PSU_ON()  powerManager.power_on()
-    #define PSU_OFF() powerManager.power_off()
+    #define PSU_ON()       powerManager.power_on()
+    #define PSU_OFF()      powerManager.power_off()
+    #define PSU_OFF_SOON() powerManager.power_off_soon()
   #else
-    #define PSU_ON()  PSU_PIN_ON()
-    #define PSU_OFF() PSU_PIN_OFF()
+    #define PSU_ON()     PSU_PIN_ON()
+    #define PSU_OFF()    PSU_PIN_OFF()
+    #define PSU_OFF_SOON PSU_OFF
   #endif
 #endif
 

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -91,7 +91,7 @@ extern bool wait_for_heatup;
   extern bool powersupply_on;
   #define PSU_PIN_ON()  do{ OUT_WRITE(PS_ON_PIN,  PSU_ACTIVE_STATE); powersupply_on = true;  }while(0)
   #define PSU_PIN_OFF() do{ OUT_WRITE(PS_ON_PIN, !PSU_ACTIVE_STATE); powersupply_on = false; }while(0)
-  #if (ENABLED(AUTO_POWER_CONTROL) || POWER_OFF_TIMEOUT > 0)
+  #if ENABLED(AUTO_POWER_CONTROL)
     #define PSU_ON()  powerManager.power_on()
     #define PSU_OFF() powerManager.power_off()
   #else

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -91,7 +91,7 @@ extern bool wait_for_heatup;
   extern bool powersupply_on;
   #define PSU_PIN_ON()  do{ OUT_WRITE(PS_ON_PIN,  PSU_ACTIVE_STATE); powersupply_on = true;  }while(0)
   #define PSU_PIN_OFF() do{ OUT_WRITE(PS_ON_PIN, !PSU_ACTIVE_STATE); powersupply_on = false; }while(0)
-  #if ENABLED(AUTO_POWER_CONTROL)
+  #if (ENABLED(AUTO_POWER_CONTROL) || POWER_OFF_TIMEOUT > 0)
     #define PSU_ON()  powerManager.power_on()
     #define PSU_OFF() powerManager.power_off()
   #else

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -122,6 +122,7 @@ void Power::power_off() {
     #ifdef PSU_POWEROFF_GCODE
       GcodeSuite::process_subcommands_now_P(PSTR(PSU_POWEROFF_GCODE));
     #endif
+    safe_delay(SEC_TO_MS(POWER_OFF_TIMEOUT));
   	PSU_PIN_OFF();
   }
 }

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -122,9 +122,16 @@ void Power::power_off() {
     #ifdef PSU_POWEROFF_GCODE
       GcodeSuite::process_subcommands_now_P(PSTR(PSU_POWEROFF_GCODE));
     #endif
-    safe_delay(SEC_TO_MS(POWER_OFF_TIMEOUT));
   	PSU_PIN_OFF();
   }
+}
+
+void Power::power_off_soon() {
+  #if POWER_OFF_TIMEOUT
+    lastPowerOn = millis() - SEC_TO_MS(POWER_TIMEOUT) + SEC_TO_MS(POWER_OFF_TIMEOUT);
+  #else
+    power_off();
+  #endif
 }
 
 #endif // AUTO_POWER_CONTROL

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -127,8 +127,8 @@ void Power::power_off() {
 }
 
 void Power::power_off_soon() {
-  #if POWER_OFF_TIMEOUT
-    lastPowerOn = millis() - SEC_TO_MS(POWER_TIMEOUT) + SEC_TO_MS(POWER_OFF_TIMEOUT);
+  #if POWER_OFF_DELAY
+    lastPowerOn = millis() - SEC_TO_MS(POWER_TIMEOUT) + SEC_TO_MS(POWER_OFF_DELAY);
   #else
     power_off();
   #endif

--- a/Marlin/src/feature/power.h
+++ b/Marlin/src/feature/power.h
@@ -32,6 +32,7 @@ class Power {
     static void check();
     static void power_on();
     static void power_off();
+    static void power_off_soon();
   private:
     static millis_t lastPowerOn;
     static bool is_power_needed();

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -105,7 +105,7 @@ void GcodeSuite::M81() {
   #if HAS_SUICIDE
     suicide();
   #elif ENABLED(PSU_CONTROL)
-    PSU_OFF();
+    PSU_OFF_SOON();
   #endif
 
   LCD_MESSAGEPGM_P(PSTR(MACHINE_NAME " " STR_OFF "."));

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -420,6 +420,10 @@
   #define PSU_POWERUP_DELAY 250
 #endif
 
+#if !defined(POWER_OFF_TIMEOUT) && ENABLED(PSU_CONTROL)
+  #define POWER_OFF_TIMEOUT 0
+#endif
+
 /**
  * Temp Sensor defines
  */

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -420,8 +420,8 @@
   #ifndef PSU_POWERUP_DELAY
     #define PSU_POWERUP_DELAY 250
   #endif
-  #ifndef POWER_OFF_TIMEOUT
-    #define POWER_OFF_TIMEOUT 0
+  #ifndef POWER_OFF_DELAY
+    #define POWER_OFF_DELAY   0
   #endif
 #endif
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -416,12 +416,13 @@
   #endif
 #endif
 
-#if !defined(PSU_POWERUP_DELAY) && ENABLED(PSU_CONTROL)
-  #define PSU_POWERUP_DELAY 250
-#endif
-
-#if !defined(POWER_OFF_TIMEOUT) && ENABLED(PSU_CONTROL)
-  #define POWER_OFF_TIMEOUT 0
+#if ENABLED(PSU_CONTROL)
+  #ifndef PSU_POWERUP_DELAY
+    #define PSU_POWERUP_DELAY 250
+  #endif
+  #ifndef POWER_OFF_TIMEOUT
+    #define POWER_OFF_TIMEOUT 0
+  #endif
 #endif
 
 /**

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2999,17 +2999,9 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
     #error "PSU_CONTROL requires PSU_ACTIVE_STATE to be defined as 'HIGH' or 'LOW'."
   #elif !PIN_EXISTS(PS_ON)
     #error "PSU_CONTROL requires PS_ON_PIN."
+  #elif POWER_OFF_TIMEOUT < 0
+    #error "POWER_OFF_TIMEOUT must be a positive value."
   #endif
-#elif ENABLED(AUTO_POWER_CONTROL)
-  #error "AUTO_POWER_CONTROL requires PSU_CONTROL."
-#endif
-
-#if POWER_OFF_TIMEOUT > 0
-  #if DISABLED(AUTO_POWER_CONTROL)
-    #error "POWER_OFF_TIMEOUT requires AUTO_POWER_CONTROL"
-  #endif
-#elif POWER_OFF_TIMEOUT < 0
-  #error "POWER_OFF_TIMEOUT must be greater or equal 0"
 #endif
 
 #if HAS_CUTTER

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2999,8 +2999,8 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
     #error "PSU_CONTROL requires PSU_ACTIVE_STATE to be defined as 'HIGH' or 'LOW'."
   #elif !PIN_EXISTS(PS_ON)
     #error "PSU_CONTROL requires PS_ON_PIN."
-  #elif POWER_OFF_TIMEOUT < 0
-    #error "POWER_OFF_TIMEOUT must be a positive value."
+  #elif POWER_OFF_DELAY < 0
+    #error "POWER_OFF_DELAY must be a positive value."
   #endif
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3004,6 +3004,14 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
   #error "AUTO_POWER_CONTROL requires PSU_CONTROL."
 #endif
 
+#if POWER_OFF_TIMEOUT > 0
+  #if DISABLED(AUTO_POWER_CONTROL)
+    #error "POWER_OFF_TIMEOUT requires AUTO_POWER_CONTROL"
+  #endif
+#elif POWER_OFF_TIMEOUT < 0
+  #error "POWER_OFF_TIMEOUT must be greater or equal 0"
+#endif
+
 #if HAS_CUTTER
   #ifndef CUTTER_POWER_UNIT
     #error "CUTTER_POWER_UNIT is required with a spindle or laser. Please update your Configuration_adv.h."


### PR DESCRIPTION
### Description

Added a power off timeout before the printer/mainboard is shut off to enable a cooldown fan or other appliances to be powered even if the print has finished. The delay can be given in seconds.

### Benefits

Power off delay not existing.

### Configurations

`POWER_OFF_DELAY` added in `Configuration.h` under `PSU_CONTROL` section.

### Related Issues

- none -
