### PR TITLE
Fix EP compilation error when using HW Serial for STM32

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -81,7 +81,9 @@ void HAL_init() {
 
   SetTimerInterruptPriorities();
 
-  TERN_(EMERGENCY_PARSER, USB_Hook_init());
+  #if ENABLED(EMERGENCY_PARSER) && USBD_USE_CDC
+    USB_Hook_init();
+  #endif
 }
 
 void HAL_clear_reset_source() { __HAL_RCC_CLEAR_RESET_FLAGS(); }

--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -130,8 +130,12 @@ uint16_t HAL_adc_get_result() { return HAL_adc_result; }
 void flashFirmware(const int16_t) { NVIC_SystemReset(); }
 
 // Maple Compatibility
+volatile uint32_t systick_uptime_millis = 0;
 systickCallback_t systick_user_callback;
 void systick_attach_callback(systickCallback_t cb) { systick_user_callback = cb; }
-void HAL_SYSTICK_Callback() { if (systick_user_callback) systick_user_callback(); }
+void HAL_SYSTICK_Callback() {
+  systick_uptime_millis++;
+  if (systick_user_callback) systick_user_callback();
+}
 
 #endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -184,3 +184,4 @@ void flashFirmware(const int16_t);
 typedef void (*systickCallback_t)(void);
 void systick_attach_callback(systickCallback_t cb);
 void HAL_SYSTICK_Callback();
+extern volatile uint32_t systick_uptime_millis;

--- a/Marlin/src/HAL/STM32/usb_serial.cpp
+++ b/Marlin/src/HAL/STM32/usb_serial.cpp
@@ -21,7 +21,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(EMERGENCY_PARSER)
+#if ENABLED(EMERGENCY_PARSER) && USBD_USE_CDC
 
 #include "usb_serial.h"
 #include "../../feature/e_parser.h"


### PR DESCRIPTION
### Description

We get compilation errors when using HW Serial with EP enabled on STM32.

This fix that and add one more lib maple compatibility.

### Benefits

As we are beginning to add more boards on STM32, we will need setup options to take care... This fix two..
