### PR TITLE
Add external pin to control PSU state M80/M81

### DIFF
--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -98,6 +98,12 @@ extern bool wait_for_heatup;
     #define PSU_ON()  PSU_PIN_ON()
     #define PSU_OFF() PSU_PIN_OFF()
   #endif
+  #if PSU_EXT_PIN
+    #ifndef PSU_EXT_PIN_STATE
+      #define PSU_EXT_PIN_STATE LOW
+    #endif
+    inline bool psu_ext_state() { return READ(PSU_EXT_PIN) == PSU_EXT_PIN_STATE; }
+  #endif
 #endif
 
 bool pin_is_protected(const pin_t pin);

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -261,6 +261,11 @@
   #define PS_ON_PIN                           12
 #endif
 
+// External pin to control PSU state
+#ifndef PSU_EXT_PIN
+  #define PSU_EXT_PIN                         58
+#endif
+
 #if ENABLED(CASE_LIGHT_ENABLE) && !defined(CASE_LIGHT_PIN) && !defined(SPINDLE_LASER_ENA_PIN)
   #if NUM_SERVOS <= 1                             // Prefer the servo connector
     #define CASE_LIGHT_PIN                     6  // Hardware PWM


### PR DESCRIPTION
### Requirements

To enable Marlin to have an external way (physical pin) to change the Power Source Unit (PSU) state besides M80 and M81 G-code commands or the "Switch Power" option on LCD menu.

### Description

I enabled the PSU_CONTROL to switch my PSU using the PS_ON_PIN to enable power on/off through M80/M81.
But I thought of adding a button on my printer to have an option to turn on the PSU physically and not only by G-code commands or navigating through the LCD menu and have to locate the "Switch Power" option.

### Benefits

Add an option for the users of PSU_CONTROL to easy control the PSU state.

### Configurations

Just uncomment line with PSU_CONTROL definition:
#define PSU_CONTROL
The default PSU_EXT_PIN is set to 58 that is exposed in AUX-1 header of RAMPS 1.4.
When the PSU_EXT_PIN is set to PSU_EXT_PIN_STATE it will verify the actual on/off state of PSU and change it accordingly.

### Related Issues

There are no related problems, but it will correct the initial behavior that states that the printer was "Ready" when in reality it is still in "OFF" state.