### PR TITLE
Added Optimised ENV for melzi with stock bootloader

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -308,7 +308,7 @@
 #elif MB(MELZI_MAKR3D)
   #include "sanguino/pins_MELZI_MAKR3D.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(MELZI_CREALITY)
-  #include "sanguino/pins_MELZI_CREALITY.h"     // ATmega1284P                            env:melzi env:melzi_optimized env:melzi_optiboot env:melzi_stock_optimized
+  #include "sanguino/pins_MELZI_CREALITY.h"     // ATmega1284P                            env:melzi env:melzi_optimized env:melzi_optiboot env:melzi_optiboot_optimized
 #elif MB(MELZI_MALYAN)
   #include "sanguino/pins_MELZI_MALYAN.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(MELZI_TRONXY)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -298,27 +298,27 @@
 //
 
 #elif MB(SANGUINOLOLU_11)
-  #include "sanguino/pins_SANGUINOLOLU_11.h"    // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_SANGUINOLOLU_11.h"    // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(SANGUINOLOLU_12)
-  #include "sanguino/pins_SANGUINOLOLU_12.h"    // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_SANGUINOLOLU_12.h"    // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(MELZI)
-  #include "sanguino/pins_MELZI.h"              // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_MELZI.h"              // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(MELZI_V2)
-  #include "sanguino/pins_MELZI_V2.h"           // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_MELZI_V2.h"           // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(MELZI_MAKR3D)
-  #include "sanguino/pins_MELZI_MAKR3D.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_MELZI_MAKR3D.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(MELZI_CREALITY)
-  #include "sanguino/pins_MELZI_CREALITY.h"     // ATmega1284P                            env:melzi env:melzi_optimized env:melzi_optiboot
+  #include "sanguino/pins_MELZI_CREALITY.h"     // ATmega1284P                            env:melzi env:melzi_optimized env:melzi_optiboot env:melzi_stock_optimized
 #elif MB(MELZI_MALYAN)
-  #include "sanguino/pins_MELZI_MALYAN.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_MELZI_MALYAN.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(MELZI_TRONXY)
-  #include "sanguino/pins_MELZI_TRONXY.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_MELZI_TRONXY.h"       // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(STB_11)
-  #include "sanguino/pins_STB_11.h"             // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_STB_11.h"             // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(AZTEEG_X1)
-  #include "sanguino/pins_AZTEEG_X1.h"          // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_AZTEEG_X1.h"          // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(ZMIB_V2)
-  #include "sanguino/pins_ZMIB_V2.h"            // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_ZMIB_V2.h"            // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 
 //
 // Other ATmega644P, ATmega644, ATmega1284P
@@ -327,27 +327,27 @@
 #elif MB(GEN3_MONOLITHIC)
   #include "sanguino/pins_GEN3_MONOLITHIC.h"    // ATmega644P                             env:sanguino644p
 #elif MB(GEN3_PLUS)
-  #include "sanguino/pins_GEN3_PLUS.h"          // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_GEN3_PLUS.h"          // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(GEN6)
-  #include "sanguino/pins_GEN6.h"               // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_GEN6.h"               // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(GEN6_DELUXE)
-  #include "sanguino/pins_GEN6_DELUXE.h"        // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_GEN6_DELUXE.h"        // ATmega644P, ATmega1284P                env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(GEN7_CUSTOM)
-  #include "sanguino/pins_GEN7_CUSTOM.h"        // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_GEN7_CUSTOM.h"        // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(GEN7_12)
-  #include "sanguino/pins_GEN7_12.h"            // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_GEN7_12.h"            // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(GEN7_13)
-  #include "sanguino/pins_GEN7_13.h"            // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_GEN7_13.h"            // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(GEN7_14)
-  #include "sanguino/pins_GEN7_14.h"            // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_GEN7_14.h"            // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(OMCA_A)
   #include "sanguino/pins_OMCA_A.h"             // ATmega644                              env:sanguino644p
 #elif MB(OMCA)
   #include "sanguino/pins_OMCA.h"               // ATmega644P, ATmega644                  env:sanguino644p
 #elif MB(ANET_10)
-  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:sanguino1284p
+  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:sanguino1284p env:sanguino1284p_optimized
 #elif MB(SETHI)
-  #include "sanguino/pins_SETHI.h"              // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p
+  #include "sanguino/pins_SETHI.h"              // ATmega644P, ATmega644, ATmega1284P     env:sanguino644p env:sanguino1284p env:sanguino1284p_optimized
 
 //
 // Teensyduino - AT90USB1286, AT90USB1286P

--- a/platformio.ini
+++ b/platformio.ini
@@ -523,6 +523,18 @@ board         = sanguino_atmega1284p
 board_upload.maximum_size = 126976
 
 #
+# Sanguinololu (ATmega1284p stock bootloader with tuned flags)
+#
+[env:sanguino1284p_optimized]
+platform      = atmelavr
+extends       = common_avr8
+board         = sanguino_atmega1284p
+board_upload.maximum_size = 126976
+upload_speed  = 57600
+build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
+build_unflags = -g -ggdb
+
+#
 # Melzi and clones (ATmega1284p)
 #
 [env:melzi]

--- a/platformio.ini
+++ b/platformio.ini
@@ -533,6 +533,18 @@ upload_speed  = 57600
 board_upload.maximum_size = 126976
 
 #
+# Melzi and clones (ATmega1284p stock bootloader with tuned flags)
+#
+[env:melzi_stock_optimized]
+platform      = atmelavr
+extends       = common_avr8
+board         = sanguino_atmega1284p
+upload_speed  = 57600
+board_upload.maximum_size = 126976
+build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
+build_unflags = -g -ggdb
+
+#
 # Melzi and clones (Optiboot bootloader)
 #
 [env:melzi_optiboot]

--- a/platformio.ini
+++ b/platformio.ini
@@ -434,9 +434,9 @@ src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 # ATmega2560
 #
 [env:mega2560]
-platform            = atmelavr
-extends             = common_avr8
-board               = megaatmega2560
+platform = atmelavr
+extends  = common_avr8
+board    = megaatmega2560
 
 #
 # ATmega2560 with extended pins 70-85 defined
@@ -457,9 +457,9 @@ extra_scripts       = ${common.extra_scripts}
 # ATmega1280
 #
 [env:mega1280]
-platform      = atmelavr
-extends       = common_avr8
-board         = megaatmega1280
+platform = atmelavr
+extends  = common_avr8
+board    = megaatmega1280
 
 #
 # MightyBoard ATmega2560 (MegaCore 100 pin boards variants)
@@ -533,13 +533,19 @@ upload_speed = 57600
 #
 # Sanguinololu (ATmega1284p stock bootloader with tuned flags)
 #
+
+[tuned_1284p]
+build_flags = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
+
 [env:sanguino1284p_optimized]
 platform    = atmelavr
 extends     = env:melzi
-build_flags = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
+build_flags = ${tuned_1284p.build_flags}
 
-# Melzi and clones (ATmega1284p stock bootloader with tuned flags)
-[env:melzi_stock_optimized]
+#
+# Melzi and clones (alias for sanguino1284p_optimized)
+#
+[env:melzi_optimized]
 platform = atmelavr
 extends  = env:sanguino1284p_optimized
 
@@ -547,18 +553,18 @@ extends  = env:sanguino1284p_optimized
 # Melzi and clones (Optiboot bootloader)
 #
 [env:melzi_optiboot]
-platform      = atmelavr
-extends       = common_avr8
-board         = sanguino_atmega1284p
-upload_speed  = 115200
+platform     = atmelavr
+extends      = common_avr8
+board        = sanguino_atmega1284p
+upload_speed = 115200
 
 #
 # Melzi and clones (Zonestar Melzi2 with tuned flags)
 #
-[env:melzi_optimized]
-platform      = atmelavr
-extends       = env:melzi_optiboot
-build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
+[env:melzi_optiboot_optimized]
+platform    = atmelavr
+extends     = env:melzi_optiboot
+build_flags = ${tuned_1284p.build_flags}
 
 #
 # AT90USB1286 boards using CDC bootloader
@@ -617,13 +623,13 @@ build_flags = ${common.build_flags}
 # Archim SAM
 #
 [common_DUE_archim]
-platform      = atmelsam
-extends       = env:DUE
-board         = archim
-build_flags   = ${common.build_flags}
+platform                 = atmelsam
+extends                  = env:DUE
+board                    = archim
+build_flags              = ${common.build_flags}
   -DARDUINO_SAM_ARCHIM -DARDUINO_ARCH_SAM -D__SAM3X8E__ -DUSBCON
 board_build.variants_dir = buildroot/share/PlatformIO/variants/
-extra_scripts = ${common.extra_scripts}
+extra_scripts            = ${common.extra_scripts}
   Marlin/src/HAL/DUE/upload_extra_script.py
 
 [env:DUE_archim]

--- a/platformio.ini
+++ b/platformio.ini
@@ -474,85 +474,74 @@ upload_speed  = 57600
 # MightyBoard ATmega2560 (MegaCore 100 pin boards variants)
 #
 [env:MightyBoard2560]
-platform      = atmelavr
-extends       = common_avr8
-board         = ATmega2560
-upload_protocol = wiring
-upload_speed  = 57600
+platform                  = atmelavr
+extends                   = common_avr8
+board                     = ATmega2560
+upload_protocol           = wiring
+upload_speed              = 57600
 board_upload.maximum_size = 253952
 
 #
 # RAMBo
 #
 [env:rambo]
-platform      = atmelavr
-extends       = common_avr8
-board         = reprap_rambo
+platform = atmelavr
+extends  = common_avr8
+board    = reprap_rambo
 
 #
 # FYSETC F6 V1.3
 #
 [env:FYSETC_F6_13]
-platform      = atmelavr
-extends       = common_avr8
-board         = fysetc_f6_13
+platform = atmelavr
+extends  = common_avr8
+board    = fysetc_f6_13
 
 #
 # FYSETC F6 V1.4
 #
 [env:FYSETC_F6_14]
-platform      = atmelavr
-extends       = common_avr8
-board         = fysetc_f6_14
+platform = atmelavr
+extends  = common_avr8
+board    = fysetc_f6_14
 
 #
 # Sanguinololu (ATmega644p)
 #
 [env:sanguino644p]
-platform      = atmelavr
-extends       = common_avr8
-board         = sanguino_atmega644p
+platform = atmelavr
+extends  = common_avr8
+board    = sanguino_atmega644p
 
 #
 # Sanguinololu (ATmega1284p)
 #
 [env:sanguino1284p]
-platform      = atmelavr
-extends       = common_avr8
-board         = sanguino_atmega1284p
+platform                  = atmelavr
+extends                   = common_avr8
+board                     = sanguino_atmega1284p
 board_upload.maximum_size = 126976
-
-#
-# Sanguinololu (ATmega1284p stock bootloader with tuned flags)
-#
-[env:sanguino1284p_optimized]
-platform      = atmelavr
-extends       = common_avr8
-board         = sanguino_atmega1284p
-board_upload.maximum_size = 126976
-upload_speed  = 57600
-build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
 
 #
 # Melzi and clones (ATmega1284p)
 #
 [env:melzi]
-platform      = atmelavr
-extends       = common_avr8
-board         = sanguino_atmega1284p
-upload_speed  = 57600
-board_upload.maximum_size = 126976
+platform     = atmelavr
+extends      = env:sanguino1284p
+upload_speed = 57600
 
 #
-# Melzi and clones (ATmega1284p stock bootloader with tuned flags)
+# Sanguinololu (ATmega1284p stock bootloader with tuned flags)
 #
+[env:sanguino1284p_optimized]
+platform    = atmelavr
+extends     = env:melzi
+build_flags = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
+
+# Melzi and clones (ATmega1284p stock bootloader with tuned flags)
 [env:melzi_stock_optimized]
-platform      = atmelavr
-extends       = common_avr8
-board         = sanguino_atmega1284p
-upload_speed  = 57600
-board_upload.maximum_size = 126976
-build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
+platform = atmelavr
+extends  = env:sanguino1284p_optimized
 
 #
 # Melzi and clones (Optiboot bootloader)
@@ -579,10 +568,10 @@ build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types
 # - TEENSYLU
 #
 [env:at90usb1286_cdc]
-platform      = teensy
-extends       = common_avr8
-board         = at90usb1286
-lib_ignore    = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
+platform   = teensy
+extends    = common_avr8
+board      = at90usb1286
+lib_ignore = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
 
 #
 # AT90USB1286 boards using DFU bootloader
@@ -591,8 +580,8 @@ lib_ignore    = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
 # - ? 5DPRINT ?
 #
 [env:at90usb1286_dfu]
-platform      = teensy
-extends       = env:at90usb1286_cdc
+platform = teensy
+extends  = env:at90usb1286_cdc
 
 #################################
 #                               #
@@ -607,20 +596,20 @@ extends       = env:at90usb1286_cdc
 #  - RADDS
 #
 [env:DUE]
-platform      = atmelsam
-board         = due
-src_filter    = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
+platform   = atmelsam
+board      = due
+src_filter = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
 
 [env:DUE_USB]
-platform      = atmelsam
-extends       = env:DUE
-board         = dueUSB
+platform = atmelsam
+extends  = env:DUE
+board    = dueUSB
 
 [env:DUE_debug]
 # Used when WATCHDOG_RESET_MANUAL is enabled
-platform      = atmelsam
-extends       = env:DUE
-build_flags   = ${common.build_flags}
+platform    = atmelsam
+extends     = env:DUE
+build_flags = ${common.build_flags}
   -funwind-tables
   -mpoke-function-name
 
@@ -638,14 +627,14 @@ extra_scripts = ${common.extra_scripts}
   Marlin/src/HAL/DUE/upload_extra_script.py
 
 [env:DUE_archim]
-platform      = ${common_DUE_archim.platform}
-extends       = common_DUE_archim
+platform = ${common_DUE_archim.platform}
+extends  = common_DUE_archim
 
 # Used when WATCHDOG_RESET_MANUAL is enabled
 [env:DUE_archim_debug]
-platform      = ${common_DUE_archim.platform}
-extends       = common_DUE_archim
-build_flags   = ${common_DUE_archim.build_flags} -funwind-tables -mpoke-function-name
+platform    = ${common_DUE_archim.platform}
+extends     = common_DUE_archim
+build_flags = ${common_DUE_archim.build_flags} -funwind-tables -mpoke-function-name
 
 #################################
 #                               #
@@ -699,14 +688,14 @@ build_flags       = ${common.build_flags} -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC17
 # NXP LPC176x ARM Cortex-M3
 #
 [env:LPC1768]
-platform  = ${common_LPC.platform}
-extends   = common_LPC
-board     = nxp_lpc1768
+platform = ${common_LPC.platform}
+extends  = common_LPC
+board    = nxp_lpc1768
 
 [env:LPC1769]
-platform  = ${common_LPC.platform}
-extends   = common_LPC
-board     = nxp_lpc1769
+platform = ${common_LPC.platform}
+extends  = common_LPC
+board    = nxp_lpc1769
 
 #################################
 #                               #

--- a/platformio.ini
+++ b/platformio.ini
@@ -532,7 +532,6 @@ board         = sanguino_atmega1284p
 board_upload.maximum_size = 126976
 upload_speed  = 57600
 build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
-build_unflags = -g -ggdb
 
 #
 # Melzi and clones (ATmega1284p)
@@ -554,7 +553,6 @@ board         = sanguino_atmega1284p
 upload_speed  = 57600
 board_upload.maximum_size = 126976
 build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
-build_unflags = -g -ggdb
 
 #
 # Melzi and clones (Optiboot bootloader)
@@ -572,7 +570,6 @@ upload_speed  = 115200
 platform      = atmelavr
 extends       = env:melzi_optiboot
 build_flags   = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
-build_unflags = -g -ggdb
 
 #
 # AT90USB1286 boards using CDC bootloader


### PR DESCRIPTION
Added Optimised ENV for melzi with stock bootloader

### Requirements

Stock bootloader melzi builds without any additional features run very close to the limit of progmem for many 1284p boards. The amount of progmem used by debug info needs to be trimmed.

### Description

Added a new env: block to platformio.ini which is a clone of the standard melzi block, with additional build flags and unflags to build an optimised version of melzi for use with stock bootloaders (non-optiboot), to free up a significant amount of progmem.

### Benefits

A stock build with a ender3 example config runs close to 99% progmem, and if bltouch or runout detection is added, this immediately goes over 100%. Adding these flags brings the stock build down to near 70% and a "full fat" build to around 98%.

Tested on an anet 1.5 board with a 1284p processor.

### Configurations

n/a

### Related Issues

n/a
