### PR TITLE
Add STM32 HAL FAST_PWM feature

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -185,3 +185,22 @@ typedef void (*systickCallback_t)(void);
 void systick_attach_callback(systickCallback_t cb);
 void HAL_SYSTICK_Callback();
 extern volatile uint32_t systick_uptime_millis;
+
+
+
+#define HAL_CAN_SET_PWM_FREQ   // This HAL supports PWM Frequency adjustment
+
+/**
+ * set_pwm_frequency
+ *  Set the frequency of the timer corresponding to the provided pin
+ *  All Timer PWM pins run at the same frequency
+ */
+void set_pwm_frequency(const pin_t pin, int f_desired);
+
+/**
+ * set_pwm_duty
+ *  Set the PWM duty cycle of the provided pin to the provided value
+ *  Optionally allows inverting the duty cycle [default = false]
+ *  Optionally allows changing the maximum size of the provided value to enable finer PWM duty control [default = 255]
+ */
+void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size=255, const bool invert=false);

--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -186,8 +186,6 @@ void systick_attach_callback(systickCallback_t cb);
 void HAL_SYSTICK_Callback();
 extern volatile uint32_t systick_uptime_millis;
 
-
-
 #define HAL_CAN_SET_PWM_FREQ   // This HAL supports PWM Frequency adjustment
 
 /**

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -1,0 +1,73 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../inc/MarlinConfigPre.h"
+
+#if NEEDS_HARDWARE_PWM
+
+#include "HAL.h"
+#include "timers.h"
+
+
+void set_pwm_frequency(const pin_t pin, int f_desired) {
+  if (!PWM_PIN(pin)) return;                    // Don't proceed if no hardware timer
+
+  PinName pin_name = digitalPinToPinName(pin);
+  TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); //get HAL timer instance
+  
+  LOOP_S_L_N(i, 0, NUM_HARDWARE_TIMERS){  //protect used timers
+      if(timer_instance[i] != nullptr && timer_instance[i]->getHandle()->Instance == Instance)
+        return;    
+  }
+
+  pwm_start(pin_name, f_desired, 0, RESOLUTION_8B_COMPARE_FORMAT);
+}
+
+void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
+  PinName pin_name = digitalPinToPinName(pin); 
+  TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM);
+  uint16_t adj_val = Instance->ARR * v / v_size;
+  if (invert) adj_val = Instance->ARR - adj_val;
+
+  uint32_t channel = get_pwm_channel(pin_name);
+  switch (channel)
+  {
+  case TIM_CHANNEL_1:
+    LL_TIM_OC_SetCompareCH1(Instance, adj_val);
+    break;
+
+  case TIM_CHANNEL_2:
+    LL_TIM_OC_SetCompareCH2(Instance, adj_val);
+    break;
+    
+  case TIM_CHANNEL_3:
+    LL_TIM_OC_SetCompareCH3(Instance, adj_val);
+    break;
+    
+  case TIM_CHANNEL_4:
+    LL_TIM_OC_SetCompareCH4(Instance, adj_val);
+    break;
+  }
+
+}
+
+#endif // NEEDS_HARDWARE_PWM

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -27,47 +27,31 @@
 #include "HAL.h"
 #include "timers.h"
 
-
 void set_pwm_frequency(const pin_t pin, int f_desired) {
-  if (!PWM_PIN(pin)) return;                    // Don't proceed if no hardware timer
+  if (!PWM_PIN(pin)) return;            // Don't proceed if no hardware timer
 
   PinName pin_name = digitalPinToPinName(pin);
-  TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); //get HAL timer instance
+  TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); // Get HAL timer instance
   
-  LOOP_S_L_N(i, 0, NUM_HARDWARE_TIMERS){  //protect used timers
-      if(timer_instance[i] != nullptr && timer_instance[i]->getHandle()->Instance == Instance)
-        return;    
-  }
+  LOOP_S_L_N(i, 0, NUM_HARDWARE_TIMERS) // Protect used timers
+    if (timer_instance[i] && timer_instance[i]->getHandle()->Instance == Instance)
+      return;
 
   pwm_start(pin_name, f_desired, 0, RESOLUTION_8B_COMPARE_FORMAT);
 }
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
-  PinName pin_name = digitalPinToPinName(pin); 
+  PinName pin_name = digitalPinToPinName(pin);
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM);
   uint16_t adj_val = Instance->ARR * v / v_size;
   if (invert) adj_val = Instance->ARR - adj_val;
 
-  uint32_t channel = get_pwm_channel(pin_name);
-  switch (channel)
-  {
-  case TIM_CHANNEL_1:
-    LL_TIM_OC_SetCompareCH1(Instance, adj_val);
-    break;
-
-  case TIM_CHANNEL_2:
-    LL_TIM_OC_SetCompareCH2(Instance, adj_val);
-    break;
-    
-  case TIM_CHANNEL_3:
-    LL_TIM_OC_SetCompareCH3(Instance, adj_val);
-    break;
-    
-  case TIM_CHANNEL_4:
-    LL_TIM_OC_SetCompareCH4(Instance, adj_val);
-    break;
+  switch (get_pwm_channel(pin_name)) {
+    case TIM_CHANNEL_1: LL_TIM_OC_SetCompareCH1(Instance, adj_val); break;
+    case TIM_CHANNEL_2: LL_TIM_OC_SetCompareCH2(Instance, adj_val); break;
+    case TIM_CHANNEL_3: LL_TIM_OC_SetCompareCH3(Instance, adj_val); break;
+    case TIM_CHANNEL_4: LL_TIM_OC_SetCompareCH4(Instance, adj_val); break;
   }
-
 }
 
 #endif // NEEDS_HARDWARE_PWM

--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -28,9 +28,6 @@
 //  #error "SPINDLE_LASER_PWM_PIN must use SERVO0, SERVO1 or SERVO3 connector"
 //#endif
 
-#if ENABLED(FAST_PWM_FAN) || SPINDLE_LASER_FREQUENCY
-  #error "Features requiring Hardware PWM (FAST_PWM_FAN, SPINDLE_LASER_FREQUENCY) are not yet supported on STM32."
-#endif
 
 #if ENABLED(SDCARD_EEPROM_EMULATION) && DISABLED(SDSUPPORT)
   #undef SDCARD_EEPROM_EMULATION // Avoid additional error noise

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -27,7 +27,6 @@
 // Local defines
 // ------------------------
 
-#define NUM_HARDWARE_TIMERS 2
 
 // Default timer priorities. Override by specifying alternate priorities in the board pins file.
 // The TONE timer is not present here, as it currently cannot be set programmatically. It is set

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -43,6 +43,8 @@
 #define hal_timer_t uint32_t
 #define HAL_TIMER_TYPE_MAX UINT16_MAX
 
+#define NUM_HARDWARE_TIMERS 2
+
 #ifndef STEP_TIMER_NUM
   #define STEP_TIMER_NUM        0  // Timer Index for Stepper
 #endif


### PR DESCRIPTION
### Description
Add a fast_pwm feature to the STM32 HAL. Ported from STM32F1

### Benefits
Fast_pwm for generic STM32

### Configurations
Any with FAST_PWM enabled

### Related PR
#19952 

#### P.S.
Seems like the currently active task is timers organization. I've found, that `TimerConfig timerConfig[NUM_HARDWARE_TIMERS];
` is currently storing only "used" timers: stepper and temperature and `#define NUM_HARDWARE_TIMERS 2`. So, maybe better to reserve space for all available hardware timers and don't define extra timer's indexes 
`#ifndef STEP_TIMER_NUM`
`  #define STEP_TIMER_NUM        0  // Timer Index for Stepper`

`#ifndef STEP_TIMER`
`  #define STEP_TIMER MCU_STEP_TIMER`

`  #define MCU_STEP_TIMER  4`

(suggest to replace STEP_TIMER_NUM by STEP_TIMER)

#### P.S.S
Firstly, I wanted to create that array for tracking timers but was found the `pwm_start` function, that uses the framework's implicit array for that purpose. But for maintaining the highest level of abstraction and usage that function in `set_pwm_duty` we need to somewhere store desired frequencies. So. I have a dilemma: duplicate data (save another explicit HardwareTimer objects or have an array of frequencies) or duplicate the framework functionality (start_pwm function almost perfectly fits in `set_pwm_frequency` function with its timer storage and checks.
