### PR TITLE
Fix #19602

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -637,7 +637,7 @@ bool CardReader::fileExists(const char * const path) {
   if (fname) {
     diveDir->rewind();
     selectByName(*diveDir, fname);
-    diveDir->close();
+    //diveDir->close();
   }
   return !!fname;
 }


### PR DESCRIPTION
This change fix #19602 

Printing does not start because the M23 command cannot open the file.
One solution is to remount the sd card after the fileExists() function. Or just remove diveDir->close();.