### PR TITLE
Touch Calibration Screen

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2338,10 +2338,10 @@
 
   #define TOUCH_SCREEN_CALIBRATION
 
-  //#define XPT2046_X_CALIBRATION 12316
-  //#define XPT2046_Y_CALIBRATION -8981
-  //#define XPT2046_X_OFFSET        -43
-  //#define XPT2046_Y_OFFSET        257
+  //#define TOUCH_CALIBRATION_X 12316
+  //#define TOUCH_CALIBRATION_Y -8981
+  //#define TOUCH_OFFSET_X        -43
+  //#define TOUCH_OFFSET_Y        257
 #endif
 
 //

--- a/Marlin/src/HAL/LPC1768/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/LPC1768/tft/xpt2046.cpp
@@ -19,7 +19,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if HAS_TFT_XPT2046 || HAS_TOUCH_XPT2046
+#if HAS_TFT_XPT2046 || HAS_TOUCH_BUTTONS
 
 #include "xpt2046.h"
 #include <SPI.h>

--- a/Marlin/src/HAL/STM32F1/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/STM32F1/tft/xpt2046.cpp
@@ -19,7 +19,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if HAS_TFT_XPT2046 || HAS_TOUCH_XPT2046
+#if HAS_TFT_XPT2046 || HAS_TOUCH_BUTTONS
 
 #include "xpt2046.h"
 #include <SPI.h>

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -60,7 +60,7 @@
 #include "sd/cardreader.h"
 
 #include "lcd/marlinui.h"
-#if HAS_TOUCH_XPT2046
+#if HAS_TOUCH_BUTTONS
   #include "lcd/touch/touch_buttons.h"
 #endif
 
@@ -1101,7 +1101,7 @@ void setup() {
     SETUP_RUN(ethernet.init());
   #endif
 
-  #if HAS_TOUCH_XPT2046
+  #if HAS_TOUCH_BUTTONS
     SETUP_RUN(touch.init());
   #endif
 

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -405,7 +405,7 @@ inline bool turn_on_heaters() {
 inline bool prime_nozzle() {
 
   const feedRate_t fr_slow_e = planner.settings.max_feedrate_mm_s[E_AXIS] / 15.0f;
-  #if HAS_LCD_MENU && !HAS_TOUCH_XPT2046 // ui.button_pressed issue with touchscreen
+  #if HAS_LCD_MENU && !HAS_TOUCH_BUTTONS // ui.button_pressed issue with touchscreen
     #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
       float Total_Prime = 0.0;
     #endif

--- a/Marlin/src/gcode/lcd/M995.cpp
+++ b/Marlin/src/gcode/lcd/M995.cpp
@@ -25,15 +25,19 @@
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
 
 #include "../gcode.h"
-#include "../../lcd/menu/menu.h"
+#if DISABLED(TFT_LVGL_UI)
+  #include "../../lcd/menu/menu.h"
+#endif
 
 /**
  * M995: Touch screen calibration for TFT display
  */
 void GcodeSuite::M995() {
-
-  ui.goto_screen(touch_screen_calibration);
-
+  #if DISABLED(TFT_LVGL_UI)
+    ui.goto_screen(touch_screen_calibration);
+  #else
+    //TODO: show LVGL UI calibration screen
+  #endif
 }
 
 #endif // TOUCH_SCREEN_CALIBRATION

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1001,3 +1001,20 @@
     #define HAS_TOUCH_BUTTONS 1
   #endif
 #endif
+
+// XPT2046_** Compatibility
+#if !(defined(TOUCH_CALIBRATION_X) || defined(TOUCH_CALIBRATION_Y) || defined(TOUCH_OFFSET_X) || defined(TOUCH_OFFSET_Y) || defined(TOUCH_ORIENTATION))
+  #if defined(XPT2046_X_CALIBRATION) && defined(XPT2046_Y_CALIBRATION) && defined(XPT2046_X_OFFSET) && defined(XPT2046_Y_OFFSET)
+    #define TOUCH_CALIBRATION_X  XPT2046_X_CALIBRATION
+    #define TOUCH_CALIBRATION_Y  XPT2046_Y_CALIBRATION
+    #define TOUCH_OFFSET_X       XPT2046_X_OFFSET
+    #define TOUCH_OFFSET_Y       XPT2046_Y_OFFSET
+    #define TOUCH_ORIENTATION    TOUCH_LANDSCAPE
+  #else
+    #define TOUCH_CALIBRATION_X  0
+    #define TOUCH_CALIBRATION_Y  0
+    #define TOUCH_OFFSET_X       0
+    #define TOUCH_OFFSET_Y       0
+    #define TOUCH_ORIENTATION    TOUCH_ORIENTATION_NONE
+  #endif
+#endif

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -998,6 +998,6 @@
 #if ENABLED(TOUCH_SCREEN) && !HAS_GRAPHICAL_TFT
   #undef TOUCH_SCREEN
   #if !HAS_TFT_LVGL_UI
-    #define HAS_TOUCH_XPT2046 1
+    #define HAS_TOUCH_BUTTONS 1
   #endif
 #endif

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -997,7 +997,6 @@
 // This emulated DOGM has 'touch/xpt2046', not 'tft/xpt2046'
 #if ENABLED(TOUCH_SCREEN) && !HAS_GRAPHICAL_TFT
   #undef TOUCH_SCREEN
-  #undef TOUCH_SCREEN_CALIBRATION
   #if !HAS_TFT_LVGL_UI
     #define HAS_TOUCH_XPT2046 1
   #endif

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -360,7 +360,7 @@
 
 // Touch Screen or "Touch Buttons" need XPT2046 pins
 // but they use different components
-#if EITHER(HAS_TFT_XPT2046, HAS_TOUCH_XPT2046)
+#if EITHER(HAS_TFT_XPT2046, HAS_TOUCH_BUTTONS)
   #define NEED_TOUCH_PINS 1
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3147,17 +3147,17 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
  * Touch Buttons
  */
 #if ENABLED(TOUCH_SCREEN)
-  #ifndef XPT2046_X_CALIBRATION
-    #error "XPT2046_X_CALIBRATION must be defined with TOUCH_SCREEN."
+  #ifndef TOUCH_CALIBRATION_X
+    #error "TOUCH_CALIBRATION_X must be defined with TOUCH_SCREEN."
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #error "XPT2046_Y_CALIBRATION must be defined with TOUCH_SCREEN."
+  #ifndef TOUCH_CALIBRATION_Y
+    #error "TOUCH_CALIBRATION_Y must be defined with TOUCH_SCREEN."
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #error "XPT2046_X_OFFSET must be defined with TOUCH_SCREEN."
+  #ifndef TOUCH_OFFSET_X
+    #error "TOUCH_OFFSET_X must be defined with TOUCH_SCREEN."
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #error "XPT2046_Y_OFFSET must be defined with TOUCH_SCREEN."
+  #ifndef TOUCH_OFFSET_Y
+    #error "TOUCH_OFFSET_Y must be defined with TOUCH_SCREEN."
   #endif
 #endif
 

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
@@ -75,6 +75,11 @@ TFT_IO tftio;
 
 #include "../touch/touch_buttons.h"
 
+#if ENABLED(TOUCH_SCREEN_CALIBRATION)
+  #include "../tft_io/touch_calibration.h"
+  #include "../marlinui.h"
+#endif
+
 #define X_HI (UPSCALE(TFT_PIXEL_OFFSET_X, WIDTH) - 1)
 #define Y_HI (UPSCALE(TFT_PIXEL_OFFSET_Y, HEIGHT) - 1)
 
@@ -313,6 +318,29 @@ inline void memset2(const void *ptr, uint16_t fill, size_t cnt) {
 static bool preinit = true;
 static uint8_t page;
 
+#if HAS_TOUCH_XPT2046
+  static bool redrawTouchButtons = true;
+  static void drawTouchButtons(u8g_t *u8g, u8g_dev_t *dev) {
+    if (!redrawTouchButtons) {
+      return;
+    }
+    redrawTouchButtons = false;
+    // Bottom buttons
+
+    setWindow(u8g, dev, BUTTOND_X_LO, BUTTON_Y_LO, BUTTOND_X_HI, BUTTON_Y_HI);
+    drawImage(buttonD, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTCANCEL_COLOR);
+
+    setWindow(u8g, dev, BUTTONA_X_LO, BUTTON_Y_LO, BUTTONA_X_HI, BUTTON_Y_HI);
+    drawImage(buttonA, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTARROWS_COLOR);
+
+    setWindow(u8g, dev, BUTTONB_X_LO, BUTTON_Y_LO, BUTTONB_X_HI, BUTTON_Y_HI);
+    drawImage(buttonB, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTARROWS_COLOR);
+
+    setWindow(u8g, dev, BUTTONC_X_LO, BUTTON_Y_LO, BUTTONC_X_HI, BUTTON_Y_HI);
+    drawImage(buttonC, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTOKMENU_COLOR);
+  }
+#endif // HAS_TOUCH_XPT2046
+
 uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
   u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
 
@@ -343,28 +371,13 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
         for (uint16_t i = 0; i < (TFT_HEIGHT) * sq(GRAPHICAL_TFT_UPSCALE); i++)
           u8g_WriteSequence(u8g, dev, (TFT_WIDTH) / 2, (uint8_t *)buffer);
       #endif
-
-      // Bottom buttons
-      #if HAS_TOUCH_XPT2046
-        setWindow(u8g, dev, BUTTOND_X_LO, BUTTON_Y_LO, BUTTOND_X_HI, BUTTON_Y_HI);
-        drawImage(buttonD, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTCANCEL_COLOR);
-
-        setWindow(u8g, dev, BUTTONA_X_LO, BUTTON_Y_LO, BUTTONA_X_HI, BUTTON_Y_HI);
-        drawImage(buttonA, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTARROWS_COLOR);
-
-        setWindow(u8g, dev, BUTTONB_X_LO, BUTTON_Y_LO, BUTTONB_X_HI, BUTTON_Y_HI);
-        drawImage(buttonB, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTARROWS_COLOR);
-
-        setWindow(u8g, dev, BUTTONC_X_LO, BUTTON_Y_LO, BUTTONC_X_HI, BUTTON_Y_HI);
-        drawImage(buttonC, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTOKMENU_COLOR);
-      #endif // HAS_TOUCH_XPT2046
-
       return 0;
 
     case U8G_DEV_MSG_STOP: preinit = true; break;
 
     case U8G_DEV_MSG_PAGE_FIRST:
       page = 0;
+      TERN_(HAS_TOUCH_XPT2046, drawTouchButtons(u8g, dev));
       setWindow(u8g, dev, TFT_PIXEL_OFFSET_X, TFT_PIXEL_OFFSET_Y, X_HI, Y_HI);
       break;
 
@@ -455,5 +468,65 @@ uint8_t u8g_com_hal_tft_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_p
 }
 
 U8G_PB_DEV(u8g_dev_tft_320x240_upscale_from_128x64, WIDTH, HEIGHT, PAGE_HEIGHT, u8g_dev_tft_320x240_upscale_from_128x64_fn, U8G_COM_HAL_TFT_FN);
+
+#if ENABLED(TOUCH_SCREEN_CALIBRATION)
+
+  static void drawCross(uint16_t x, uint16_t y, uint16_t color) {
+    tftio.set_window(x - 15, y, x + 15, y);
+    tftio.WriteMultiple(color, 31);
+    tftio.set_window(x, y - 15, x, y + 15);
+    tftio.WriteMultiple(color, 31);
+  }
+
+  void MarlinUI::touch_calibration_screen() {
+    uint16_t x, y;
+    calibrationState calibration_stage = touch_calibration.get_calibration_state();
+
+    if (calibration_stage == CALIBRATION_NONE) {
+      // start and clear screen
+      defer_status_screen(true);
+      calibration_stage = touch_calibration.calibration_start();
+      tftio.set_window(0, 0, (TFT_WIDTH) - 1, (TFT_HEIGHT) - 1);
+      tftio.WriteMultiple(TFT_MARLINBG_COLOR, uint32_t(TFT_WIDTH) * (TFT_HEIGHT));
+    }
+    else {
+      // clear last cross
+      x = touch_calibration.calibration_points[_MIN(calibration_stage - 1, CALIBRATION_BOTTOM_RIGHT)].x;
+      y = touch_calibration.calibration_points[_MIN(calibration_stage - 1, CALIBRATION_BOTTOM_RIGHT)].y;
+      drawCross(x, y, TFT_MARLINBG_COLOR);
+    }
+
+    const char *str = nullptr;
+    if (calibration_stage < CALIBRATION_SUCCESS) {
+      // handle current state
+      switch (calibration_stage) {
+        case CALIBRATION_TOP_LEFT: str = "Top Left"; break;
+        case CALIBRATION_BOTTOM_LEFT: str = "Bottom Left"; break;
+        case CALIBRATION_TOP_RIGHT:  str = "Top Right"; break;
+        case CALIBRATION_BOTTOM_RIGHT: str = "Bottom Right"; break;
+        default: break;
+      }
+
+      x = touch_calibration.calibration_points[calibration_stage].x;
+      y = touch_calibration.calibration_points[calibration_stage].y;
+      drawCross(x, y, TFT_MARLINUI_COLOR);
+    }
+    else {
+      // end calibration
+      str = calibration_stage == CALIBRATION_SUCCESS ? "Calibration Completed" : "Calibration Failed";
+      defer_status_screen(false);
+      touch_calibration.calibration_end();
+      TERN_(HAS_TOUCH_XPT2046, redrawTouchButtons = true);
+    }
+
+    // draw current message
+    tftio.set_window(TFT_PIXEL_OFFSET_X, TFT_PIXEL_OFFSET_Y, X_HI, Y_HI);
+    do {
+      set_font(FONT_MENU);
+      lcd_put_u8str(0, LCD_PIXEL_HEIGHT / 2, str);
+    } while (u8g.nextPage());
+    drawing_screen = false;
+  }
+#endif // TOUCH_SCREEN_CALIBRATION
 
 #endif // HAS_MARLINUI_U8GLIB && (FSMC_CS_PIN || HAS_SPI_GRAPHICAL_TFT)

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
@@ -134,7 +134,7 @@ static void setWindow(u8g_t *u8g, u8g_dev_t *dev, uint16_t Xmin, uint16_t Ymin, 
   tftio.set_window(Xmin, Ymin, Xmax, Ymax);
 }
 
-#if HAS_TOUCH_XPT2046
+#if HAS_TOUCH_BUTTONS
 
   static const uint8_t buttonD[] = {
     B01111111,B11111111,B11111111,B11111110,
@@ -307,7 +307,7 @@ static void setWindow(u8g_t *u8g, u8g_dev_t *dev, uint16_t Xmin, uint16_t Ymin, 
     }
   }
 
-#endif // HAS_TOUCH_XPT2046
+#endif // HAS_TOUCH_BUTTONS
 
 // Used to fill RGB565 (16bits) background
 inline void memset2(const void *ptr, uint16_t fill, size_t cnt) {
@@ -318,7 +318,7 @@ inline void memset2(const void *ptr, uint16_t fill, size_t cnt) {
 static bool preinit = true;
 static uint8_t page;
 
-#if HAS_TOUCH_XPT2046
+#if HAS_TOUCH_BUTTONS
   static bool redrawTouchButtons = true;
   static void drawTouchButtons(u8g_t *u8g, u8g_dev_t *dev) {
     if (!redrawTouchButtons) {
@@ -339,7 +339,7 @@ static uint8_t page;
     setWindow(u8g, dev, BUTTONC_X_LO, BUTTON_Y_LO, BUTTONC_X_HI, BUTTON_Y_HI);
     drawImage(buttonC, u8g, dev, BUTTON_DRAW_WIDTH, BUTTON_DRAW_HEIGHT, TFT_BTOKMENU_COLOR);
   }
-#endif // HAS_TOUCH_XPT2046
+#endif // HAS_TOUCH_BUTTONS
 
 uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, uint8_t msg, void *arg) {
   u8g_pb_t *pb = (u8g_pb_t *)(dev->dev_mem);
@@ -378,7 +378,7 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
 
     case U8G_DEV_MSG_PAGE_FIRST:
       page = 0;
-      TERN_(HAS_TOUCH_XPT2046, drawTouchButtons(u8g, dev));
+      TERN_(HAS_TOUCH_BUTTONS, drawTouchButtons(u8g, dev));
       setWindow(u8g, dev, TFT_PIXEL_OFFSET_X, TFT_PIXEL_OFFSET_Y, X_HI, Y_HI);
       break;
 
@@ -516,7 +516,7 @@ U8G_PB_DEV(u8g_dev_tft_320x240_upscale_from_128x64, WIDTH, HEIGHT, PAGE_HEIGHT, 
       str = calibration_stage == CALIBRATION_SUCCESS ? "Calibration Completed" : "Calibration Failed";
       defer_status_screen(false);
       touch_calibration.calibration_end();
-      TERN_(HAS_TOUCH_XPT2046, redrawTouchButtons = true);
+      TERN_(HAS_TOUCH_BUTTONS, redrawTouchButtons = true);
     }
 
     // draw current message

--- a/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
@@ -356,6 +356,7 @@ uint8_t u8g_dev_tft_320x240_upscale_from_128x64_fn(u8g_t *u8g, u8g_dev_t *dev, u
       dev->com_fn(u8g, U8G_COM_MSG_INIT, U8G_SPI_CLK_CYCLE_NONE, nullptr);
       tftio.Init();
       tftio.InitTFT();
+      TERN_(TOUCH_SCREEN_CALIBRATION, touch_calibration.calibration_reset());
 
       if (preinit) {
         preinit = false;
@@ -470,7 +471,6 @@ uint8_t u8g_com_hal_tft_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_p
 U8G_PB_DEV(u8g_dev_tft_320x240_upscale_from_128x64, WIDTH, HEIGHT, PAGE_HEIGHT, u8g_dev_tft_320x240_upscale_from_128x64_fn, U8G_COM_HAL_TFT_FN);
 
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-
   static void drawCross(uint16_t x, uint16_t y, uint16_t color) {
     tftio.set_window(x - 15, y, x + 15, y);
     tftio.WriteMultiple(color, 31);

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
@@ -241,8 +241,8 @@ static bool get_point(int16_t *x, int16_t *y) {
   bool is_touched = touch.getRawPoint(x, y);
 
   if (is_touched) {
-    *x = int16_t((int32_t(*x) * XPT2046_X_CALIBRATION) >> 16) + XPT2046_X_OFFSET;
-    *y = int16_t((int32_t(*y) * XPT2046_Y_CALIBRATION) >> 16) + XPT2046_Y_OFFSET;
+    *x = int16_t((int32_t(*x) * TOUCH_CALIBRATION_X) >> 16) + TOUCH_OFFSET_X;
+    *y = int16_t((int32_t(*y) * TOUCH_CALIBRATION_Y) >> 16) + TOUCH_OFFSET_Y;
   }
 
   #if (TFT_ROTATION & TFT_ROTATE_180)

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -158,7 +158,7 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
   #if HAS_SLOW_BUTTONS
     volatile uint8_t MarlinUI::slow_buttons;
   #endif
-  #if HAS_TOUCH_XPT2046
+  #if HAS_TOUCH_BUTTONS
     #include "touch/touch_buttons.h"
     bool MarlinUI::on_edit_screen = false;
   #endif
@@ -238,7 +238,7 @@ millis_t MarlinUI::next_button_update_ms; // = 0
     int8_t MarlinUI::encoderDirection = ENCODERBASE;
   #endif
 
-  #if HAS_TOUCH_XPT2046
+  #if HAS_TOUCH_BUTTONS
     uint8_t MarlinUI::touch_buttons;
     uint8_t MarlinUI::repeat_delay;
   #endif
@@ -855,7 +855,7 @@ void MarlinUI::update() {
       quick_feedback();                               //  - Always make a click sound
     };
 
-    #if HAS_TOUCH_XPT2046
+    #if HAS_TOUCH_BUTTONS
       if (touch_buttons) {
         RESET_STATUS_TIMEOUT();
         if (touch_buttons & (EN_A | EN_B)) {              // Menu arrows, in priority
@@ -876,7 +876,7 @@ void MarlinUI::update() {
       }
       else // keep wait_for_unclick value
 
-    #endif // HAS_TOUCH_XPT2046
+    #endif // HAS_TOUCH_BUTTONS
 
       {
         // Integrated LCD click handling via button_pressed
@@ -898,7 +898,7 @@ void MarlinUI::update() {
 
     next_lcd_update_ms = ms + LCD_UPDATE_INTERVAL;
 
-    #if HAS_TOUCH_XPT2046
+    #if HAS_TOUCH_BUTTONS
 
       if (on_status_screen()) next_lcd_update_ms += (LCD_UPDATE_INTERVAL) * 2;
 
@@ -1246,7 +1246,7 @@ void MarlinUI::update() {
           #if HAS_SLOW_BUTTONS
             | slow_buttons
           #endif
-          #if BOTH(HAS_TOUCH_XPT2046, HAS_ENCODER_ACTION)
+          #if BOTH(HAS_TOUCH_BUTTONS, HAS_ENCODER_ACTION)
             | (touch_buttons & TERN(HAS_ENCODER_WHEEL, ~(EN_A | EN_B), 0xFF))
           #endif
         );
@@ -1557,7 +1557,7 @@ void MarlinUI::update() {
 
   #endif
 
-  #if HAS_TOUCH_XPT2046
+  #if HAS_TOUCH_BUTTONS
 
     //
     // Screen Click

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -74,7 +74,7 @@
     uint8_t get_ADC_keyValue();
   #endif
 
-  #define LCD_UPDATE_INTERVAL TERN(HAS_TOUCH_XPT2046, 50, 100)
+  #define LCD_UPDATE_INTERVAL TERN(HAS_TOUCH_BUTTONS, 50, 100)
 
   #if HAS_LCD_MENU
 
@@ -148,7 +148,7 @@
 
   #define BUTTON_PRESSED(BN) !READ(BTN_## BN)
 
-  #if BUTTON_EXISTS(ENC) || HAS_TOUCH_XPT2046
+  #if BUTTON_EXISTS(ENC) || HAS_TOUCH_BUTTONS
     #define BLEN_C 2
     #define EN_C _BV(BLEN_C)
   #endif
@@ -214,7 +214,7 @@
 
 #endif
 
-#if BUTTON_EXISTS(BACK) || EITHER(HAS_TOUCH_XPT2046, IS_TFTGLCD_PANEL)
+#if BUTTON_EXISTS(BACK) || EITHER(HAS_TOUCH_BUTTONS, IS_TFTGLCD_PANEL)
   #define BLEN_D 3
   #define EN_D _BV(BLEN_D)
   #define LCD_BACK_CLICKED() (buttons & EN_D)
@@ -454,7 +454,7 @@ public:
         static void draw_hotend_status(const uint8_t row, const uint8_t extruder);
       #endif
 
-      #if HAS_TOUCH_XPT2046
+      #if HAS_TOUCH_BUTTONS
         static bool on_edit_screen;
         static void screen_click(const uint8_t row, const uint8_t col, const uint8_t x, const uint8_t y);
       #endif
@@ -514,7 +514,7 @@ public:
       static millis_t return_to_status_ms;
     #endif
 
-    #if HAS_TOUCH_XPT2046
+    #if HAS_TOUCH_BUTTONS
       static uint8_t touch_buttons;
       static uint8_t repeat_delay;
     #endif

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -684,7 +684,7 @@ public:
   #endif
 
   #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-    static void touch_calibration();
+    static void touch_calibration_screen();
   #endif
 
   #if HAS_GRAPHICAL_TFT

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -82,7 +82,7 @@ void MarlinUI::save_previous_screen() {
 
 void MarlinUI::_goto_previous_screen(TERN_(TURBO_BACK_MENU_ITEM, const bool is_back/*=false*/)) {
   TERN(TURBO_BACK_MENU_ITEM,,constexpr bool is_back = false);
-  TERN_(HAS_TOUCH_XPT2046, on_edit_screen = false);
+  TERN_(HAS_TOUCH_BUTTONS, on_edit_screen = false);
   if (screen_history_depth > 0) {
     menuPosition &sh = screen_history[--screen_history_depth];
     goto_screen(sh.menu_function,
@@ -123,7 +123,7 @@ void MarlinUI::_goto_previous_screen(TERN_(TURBO_BACK_MENU_ITEM, const bool is_b
  *       MenuItem_int3::draw(encoderLine == _thisItemNr, _lcdLineNr, plabel, &feedrate_percentage, 10, 999)
  */
 void MenuEditItemBase::edit_screen(strfunc_t strfunc, loadfunc_t loadfunc) {
-  TERN_(HAS_TOUCH_XPT2046, ui.repeat_delay = BUTTON_DELAY_EDIT);
+  TERN_(HAS_TOUCH_BUTTONS, ui.repeat_delay = BUTTON_DELAY_EDIT);
   if (int32_t(ui.encoderPosition) < 0) ui.encoderPosition = 0;
   if (int32_t(ui.encoderPosition) > maxEditValue) ui.encoderPosition = maxEditValue;
   if (ui.should_draw())
@@ -145,7 +145,7 @@ void MenuEditItemBase::goto_edit_screen(
   const screenFunc_t cb,  // Callback after edit
   const bool le           // Flag to call cb() during editing
 ) {
-  TERN_(HAS_TOUCH_XPT2046, ui.on_edit_screen = true);
+  TERN_(HAS_TOUCH_BUTTONS, ui.on_edit_screen = true);
   ui.screen_changed = true;
   ui.save_previous_screen();
   ui.refresh();
@@ -175,7 +175,7 @@ bool printer_busy() {
 void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, const uint8_t top/*=0*/, const uint8_t items/*=0*/) {
   if (currentScreen != screen) {
 
-    TERN_(HAS_TOUCH_XPT2046, repeat_delay = BUTTON_DELAY_MENU);
+    TERN_(HAS_TOUCH_BUTTONS, repeat_delay = BUTTON_DELAY_MENU);
 
     TERN_(LCD_SET_PROGRESS_MANUALLY, progress_reset());
 

--- a/Marlin/src/lcd/menu/menu_touch_screen.cpp
+++ b/Marlin/src/lcd/menu/menu_touch_screen.cpp
@@ -29,7 +29,7 @@
 
 void touch_screen_calibration() {
 
-  ui.touch_calibration();
+  ui.touch_calibration_screen();
 
 }
 

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -45,17 +45,12 @@ millis_t Touch::last_touch_ms = 0,
          Touch::repeat_delay,
          Touch::touch_time;
 TouchControlType  Touch::touch_control_type = NONE;
-touch_calibration_t Touch::calibration;
-#if ENABLED(TOUCH_SCREEN_CALIBRATION)
-  calibrationState Touch::calibration_state = CALIBRATION_NONE;
-  touch_calibration_point_t Touch::calibration_points[4];
-#endif
 #if HAS_RESUME_CONTINUE
   extern bool wait_for_user;
 #endif
 
 void Touch::init() {
-  calibration_reset();
+  touch_calibration.calibration_reset();
   reset();
   io.Init();
   enable();
@@ -152,52 +147,7 @@ void Touch::touch(touch_control_t *control) {
   switch (control->type) {
     #if ENABLED(TOUCH_SCREEN_CALIBRATION)
       case CALIBRATE:
-        ui.refresh();
-
-        if (calibration_state < CALIBRATION_SUCCESS) {
-          calibration_points[calibration_state].x = int16_t(control->data >> 16);
-          calibration_points[calibration_state].y = int16_t(control->data & 0xFFFF);
-          calibration_points[calibration_state].raw_x = x;
-          calibration_points[calibration_state].raw_y = y;
-        }
-
-        switch (calibration_state) {
-          case CALIBRATION_POINT_1: calibration_state = CALIBRATION_POINT_2; break;
-          case CALIBRATION_POINT_2: calibration_state = CALIBRATION_POINT_3; break;
-          case CALIBRATION_POINT_3: calibration_state = CALIBRATION_POINT_4; break;
-          case CALIBRATION_POINT_4:
-            if (validate_precision_x(0, 1) && validate_precision_x(2, 3) && validate_precision_y(0, 2) && validate_precision_y(1, 3)) {
-              calibration_state = CALIBRATION_SUCCESS;
-              calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_x + calibration_points[2].raw_x - calibration_points[1].raw_x - calibration_points[0].raw_x);
-              calibration.y = ((calibration_points[1].y - calibration_points[0].y) << 17) / (calibration_points[3].raw_y - calibration_points[2].raw_y + calibration_points[1].raw_y - calibration_points[0].raw_y);
-              calibration.offset_x = calibration_points[0].x - int16_t(((calibration_points[0].raw_x + calibration_points[1].raw_x) * calibration.x) >> 17);
-              calibration.offset_y = calibration_points[0].y - int16_t(((calibration_points[0].raw_y + calibration_points[2].raw_y) * calibration.y) >> 17);
-              calibration.orientation = TOUCH_LANDSCAPE;
-            }
-            else if (validate_precision_y(0, 1) && validate_precision_y(2, 3) && validate_precision_x(0, 2) && validate_precision_x(1, 3)) {
-              calibration_state = CALIBRATION_SUCCESS;
-              calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_y + calibration_points[2].raw_y - calibration_points[1].raw_y - calibration_points[0].raw_y);
-              calibration.y = ((calibration_points[1].y - calibration_points[0].y) << 17) / (calibration_points[3].raw_x - calibration_points[2].raw_x + calibration_points[1].raw_x - calibration_points[0].raw_x);
-              calibration.offset_x = calibration_points[0].x - int16_t(((calibration_points[0].raw_y + calibration_points[1].raw_y) * calibration.x) >> 17);
-              calibration.offset_y = calibration_points[0].y - int16_t(((calibration_points[0].raw_x + calibration_points[2].raw_x) * calibration.y) >> 17);
-              calibration.orientation = TOUCH_PORTRAIT;
-            }
-            else {
-              calibration_state = CALIBRATION_FAIL;
-              calibration_reset();
-            }
-
-            if (calibration_state == CALIBRATION_SUCCESS) {
-              SERIAL_ECHOLNPGM("Touch screen calibration completed");
-              SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_X ", calibration.x);
-              SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_Y ", calibration.y);
-              SERIAL_ECHOLNPAIR("TOUCH_OFFSET_X ", calibration.offset_x);
-              SERIAL_ECHOLNPAIR("TOUCH_OFFSET_Y ", calibration.offset_y);
-              SERIAL_ECHOPGM("TOUCH_ORIENTATION "); if (calibration.orientation == TOUCH_LANDSCAPE) SERIAL_ECHOLNPGM("TOUCH_LANDSCAPE"); else SERIAL_ECHOLNPGM("TOUCH_PORTRAIT");
-            }
-            break;
-          default: break;
-        }
+        if (touch_calibration.handleTouch(x, y)) ui.refresh();
         break;
     #endif // TOUCH_SCREEN_CALIBRATION
 
@@ -292,11 +242,11 @@ void Touch::hold(touch_control_t *control, millis_t delay) {
 }
 
 bool Touch::get_point(int16_t *x, int16_t *y) {
-  bool is_touched = (calibration.orientation == TOUCH_PORTRAIT ? io.getRawPoint(y, x) : io.getRawPoint(x, y));
+  bool is_touched = (touch_calibration.calibration.orientation == TOUCH_PORTRAIT ? io.getRawPoint(y, x) : io.getRawPoint(x, y));
 
-  if (is_touched && calibration.orientation != TOUCH_ORIENTATION_NONE) {
-    *x = int16_t((int32_t(*x) * calibration.x) >> 16) + calibration.offset_x;
-    *y = int16_t((int32_t(*y) * calibration.y) >> 16) + calibration.offset_y;
+  if (is_touched && touch_calibration.calibration.orientation != TOUCH_ORIENTATION_NONE) {
+    *x = int16_t((int32_t(*x) * touch_calibration.calibration.x) >> 16) + touch_calibration.calibration.offset_x;
+    *y = int16_t((int32_t(*y) * touch_calibration.calibration.y) >> 16) + touch_calibration.calibration.offset_y;
   }
   return is_touched;
 }

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -251,8 +251,8 @@ bool Touch::get_point(int16_t *x, int16_t *y) {
     }
   #else
     bool is_touched = (TOUCH_ORIENTATION == TOUCH_PORTRAIT ? io.getRawPoint(y, x) : io.getRawPoint(x, y));
-    *x = uint16_t((uint32_t(*x) * XPT2046_X_CALIBRATION) >> 16) + XPT2046_X_OFFSET;
-    *y = uint16_t((uint32_t(*y) * XPT2046_Y_CALIBRATION) >> 16) + XPT2046_Y_OFFSET;
+    *x = uint16_t((uint32_t(*x) * TOUCH_CALIBRATION_X) >> 16) + TOUCH_OFFSET_X;
+    *y = uint16_t((uint32_t(*y) * TOUCH_CALIBRATION_Y) >> 16) + TOUCH_OFFSET_Y;
   #endif
   return is_touched;
 }

--- a/Marlin/src/lcd/tft/touch.h
+++ b/Marlin/src/lcd/tft/touch.h
@@ -24,37 +24,10 @@
 
 #include "tft_color.h"
 #include "tft_image.h"
+#include "../tft_io/touch_calibration.h"
 
 #include HAL_PATH(../../HAL, tft/xpt2046.h)
 #define TOUCH_DRIVER XPT2046
-
-#ifndef TOUCH_SCREEN_CALIBRATION_PRECISION
-  #define TOUCH_SCREEN_CALIBRATION_PRECISION  80
-#endif
-
-#ifndef TOUCH_SCREEN_HOLD_TO_CALIBRATE_MS
-  #define TOUCH_SCREEN_HOLD_TO_CALIBRATE_MS   2500
-#endif
-
-#define TOUCH_ORIENTATION_NONE  0
-#define TOUCH_LANDSCAPE         1
-#define TOUCH_PORTRAIT          2
-
-#if !(defined(TOUCH_CALIBRATION_X) || defined(TOUCH_CALIBRATION_Y) || defined(TOUCH_OFFSET_X) || defined(TOUCH_OFFSET_Y) || defined(TOUCH_ORIENTATION))
-  #if defined(XPT2046_X_CALIBRATION) && defined(XPT2046_Y_CALIBRATION) && defined(XPT2046_X_OFFSET) && defined(XPT2046_Y_OFFSET)
-    #define TOUCH_CALIBRATION_X  XPT2046_X_CALIBRATION
-    #define TOUCH_CALIBRATION_Y  XPT2046_Y_CALIBRATION
-    #define TOUCH_OFFSET_X       XPT2046_X_OFFSET
-    #define TOUCH_OFFSET_Y       XPT2046_Y_OFFSET
-    #define TOUCH_ORIENTATION    TOUCH_LANDSCAPE
-  #else
-    #define TOUCH_CALIBRATION_X  0
-    #define TOUCH_CALIBRATION_Y  0
-    #define TOUCH_OFFSET_X       0
-    #define TOUCH_OFFSET_Y       0
-    #define TOUCH_ORIENTATION    TOUCH_ORIENTATION_NONE
-  #endif
-#endif
 
 // Menu Navigation
 extern int8_t encoderTopLine, encoderLine, screen_items;
@@ -98,31 +71,6 @@ typedef struct __attribute__((__packed__)) {
   intptr_t data;
 } touch_control_t;
 
-typedef struct __attribute__((__packed__)) {
-  int32_t x;
-  int32_t y;
-  int16_t offset_x;
-  int16_t offset_y;
-  uint8_t orientation;
-} touch_calibration_t;
-
-typedef struct __attribute__((__packed__)) {
-  uint16_t x;
-  uint16_t y;
-  int16_t raw_x;
-  int16_t raw_y;
-} touch_calibration_point_t;
-
-enum calibrationState : uint8_t {
-  CALIBRATION_POINT_1 = 0x00,
-  CALIBRATION_POINT_2,
-  CALIBRATION_POINT_3,
-  CALIBRATION_POINT_4,
-  CALIBRATION_SUCCESS,
-  CALIBRATION_FAIL,
-  CALIBRATION_NONE,
-};
-
 #define MAX_CONTROLS        16
 #define MINIMUM_HOLD_TIME   15
 #define TOUCH_REPEAT_DELAY  75
@@ -147,15 +95,6 @@ class Touch {
     static void touch(touch_control_t *control);
     static void hold(touch_control_t *control, millis_t delay = 0);
 
-    #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-      static calibrationState calibration_state;
-      static touch_calibration_point_t calibration_points[4];
-
-      static bool validate_precision(int32_t a, int32_t b) { return (a > b ? (100 * b) / a :  (100 * a) / b) > TOUCH_SCREEN_CALIBRATION_PRECISION; }
-      static bool validate_precision_x(uint8_t a, uint8_t b) { return validate_precision(calibration_points[a].raw_x, calibration_points[b].raw_x); }
-      static bool validate_precision_y(uint8_t a, uint8_t b) { return validate_precision(calibration_points[a].raw_y, calibration_points[b].raw_y); }
-    #endif // TOUCH_SCREEN_CALIBRATION
-
   public:
     static void init();
     static void reset() { controls_count = 0; touch_time = 0; current_control = NULL; }
@@ -172,15 +111,6 @@ class Touch {
     static void enable() { enabled = true; }
 
     static void add_control(TouchControlType type, uint16_t x, uint16_t y, uint16_t width, uint16_t height, intptr_t data = 0);
-
-    static touch_calibration_t calibration;
-    static void calibration_reset() { calibration = {TOUCH_CALIBRATION_X, TOUCH_CALIBRATION_Y, TOUCH_OFFSET_X, TOUCH_OFFSET_Y, TOUCH_ORIENTATION}; }
-
-    #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-      static calibrationState calibration_start() { calibration = {0, 0, 0, 0, TOUCH_ORIENTATION_NONE}; return calibration_state = CALIBRATION_POINT_1; }
-      static void calibration_end() { calibration_state = CALIBRATION_NONE; }
-      static calibrationState get_calibration_state() { return calibration_state; }
-    #endif // TOUCH_SCREEN_CALIBRATION
 };
 
 extern Touch touch;

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -584,15 +584,15 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
 #endif // AUTO_BED_LEVELING_UBL
 
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-  void MarlinUI::touch_calibration() {
+  void MarlinUI::touch_calibration_screen() {
     static uint16_t x, y;
 
-    calibrationState calibration_stage = touch.get_calibration_state();
+    calibrationState calibration_stage = touch_calibration.get_calibration_state();
 
     if (calibration_stage == CALIBRATION_NONE) {
       defer_status_screen(true);
       clear_lcd();
-      calibration_stage = touch.calibration_start();
+      calibration_stage = touch_calibration.calibration_start();
     }
     else {
       tft.canvas(x - 15, y - 15, 31, 31);
@@ -604,10 +604,10 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
 
     if (calibration_stage < CALIBRATION_SUCCESS) {
       switch (calibration_stage) {
-        case CALIBRATION_POINT_1: tft_string.set("Top Left"); break;
-        case CALIBRATION_POINT_2: y = TFT_HEIGHT - 21; tft_string.set("Bottom Left"); break;
-        case CALIBRATION_POINT_3: x = TFT_WIDTH  - 21; tft_string.set("Top Right"); break;
-        case CALIBRATION_POINT_4: x = TFT_WIDTH  - 21; y = TFT_HEIGHT - 21; tft_string.set("Bottom Right"); break;
+        case CALIBRATION_TOP_LEFT: tft_string.set("Top Left"); break;
+        case CALIBRATION_BOTTOM_LEFT: y = TFT_HEIGHT - 21; tft_string.set("Bottom Left"); break;
+        case CALIBRATION_TOP_RIGHT: x = TFT_WIDTH  - 21; tft_string.set("Top Right"); break;
+        case CALIBRATION_BOTTOM_RIGHT: x = TFT_WIDTH  - 21; y = TFT_HEIGHT - 21; tft_string.set("Bottom Right"); break;
         default: break;
       }
 
@@ -621,7 +621,7 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
     else {
       tft_string.set(calibration_stage == CALIBRATION_SUCCESS ? "Calibration Completed" : "Calibration Failed");
       defer_status_screen(false);
-      touch.calibration_end();
+      touch_calibration.calibration_end();
       touch.add_control(BACK, 0, 0, TFT_WIDTH, TFT_HEIGHT);
     }
 

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -589,15 +589,15 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
 #endif // AUTO_BED_LEVELING_UBL
 
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-  void MarlinUI::touch_calibration() {
+  void MarlinUI::touch_calibration_screen() {
     static uint16_t x, y;
 
-    calibrationState calibration_stage = touch.get_calibration_state();
+    calibrationState calibration_stage = touch_calibration.get_calibration_state();
 
     if (calibration_stage == CALIBRATION_NONE) {
       defer_status_screen(true);
       clear_lcd();
-      calibration_stage = touch.calibration_start();
+      calibration_stage = touch_calibration.calibration_start();
     }
     else {
       tft.canvas(x - 15, y - 15, 31, 31);
@@ -609,10 +609,10 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
 
     if (calibration_stage < CALIBRATION_SUCCESS) {
       switch (calibration_stage) {
-        case CALIBRATION_POINT_1: tft_string.set("Top Left"); break;
-        case CALIBRATION_POINT_2: y = TFT_HEIGHT - 21; tft_string.set("Bottom Left"); break;
-        case CALIBRATION_POINT_3: x = TFT_WIDTH  - 21; tft_string.set("Top Right"); break;
-        case CALIBRATION_POINT_4: x = TFT_WIDTH  - 21; y = TFT_HEIGHT - 21; tft_string.set("Bottom Right"); break;
+        case CALIBRATION_TOP_LEFT: tft_string.set("Top Left"); break;
+        case CALIBRATION_BOTTOM_LEFT: y = TFT_HEIGHT - 21; tft_string.set("Bottom Left"); break;
+        case CALIBRATION_TOP_RIGHT: x = TFT_WIDTH  - 21; tft_string.set("Top Right"); break;
+        case CALIBRATION_BOTTOM_RIGHT: x = TFT_WIDTH  - 21; y = TFT_HEIGHT - 21; tft_string.set("Bottom Right"); break;
         default: break;
       }
 
@@ -626,7 +626,7 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
     else {
       tft_string.set(calibration_stage == CALIBRATION_SUCCESS ? "Calibration Completed" : "Calibration Failed");
       defer_status_screen(false);
-      touch.calibration_end();
+      touch_calibration.calibration_end();
       touch.add_control(BACK, 0, 0, TFT_WIDTH, TFT_HEIGHT);
     }
 

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -21,13 +21,60 @@
 
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
 
-#include "../../inc/MarlinConfig.h"
-
-TouchCalibration touch_calibration;
-
 touch_calibration_t TouchCalibration::calibration;
 calibrationState TouchCalibration::calibration_state = CALIBRATION_NONE;
 touch_calibration_point_t TouchCalibration::calibration_points[4];
+TouchCalibration touch_calibration;
+
+bool TouchCalibration::validate_precision(int32_t a, int32_t b) { return (a > b ? (100 * b) / a :  (100 * a) / b) > TOUCH_SCREEN_CALIBRATION_PRECISION; }
+
+void TouchCalibration::validate_calibration() {
+  if (validate_precision_x(0, 1) && validate_precision_x(2, 3) && validate_precision_y(0, 2) && validate_precision_y(1, 3)) {
+    calibration_state = CALIBRATION_SUCCESS;
+    calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_x + calibration_points[2].raw_x - calibration_points[1].raw_x - calibration_points[0].raw_x);
+    calibration.y = ((calibration_points[1].y - calibration_points[0].y) << 17) / (calibration_points[3].raw_y - calibration_points[2].raw_y + calibration_points[1].raw_y - calibration_points[0].raw_y);
+    calibration.offset_x = calibration_points[0].x - int16_t(((calibration_points[0].raw_x + calibration_points[1].raw_x) * calibration.x) >> 17);
+    calibration.offset_y = calibration_points[0].y - int16_t(((calibration_points[0].raw_y + calibration_points[2].raw_y) * calibration.y) >> 17);
+    calibration.orientation = TOUCH_LANDSCAPE;
+  }
+  else if (validate_precision_y(0, 1) && validate_precision_y(2, 3) && validate_precision_x(0, 2) && validate_precision_x(1, 3)) {
+    calibration_state = CALIBRATION_SUCCESS;
+    calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_y + calibration_points[2].raw_y - calibration_points[1].raw_y - calibration_points[0].raw_y);
+    calibration.y = ((calibration_points[1].y - calibration_points[0].y) << 17) / (calibration_points[3].raw_x - calibration_points[2].raw_x + calibration_points[1].raw_x - calibration_points[0].raw_x);
+    calibration.offset_x = calibration_points[0].x - int16_t(((calibration_points[0].raw_y + calibration_points[1].raw_y) * calibration.x) >> 17);
+    calibration.offset_y = calibration_points[0].y - int16_t(((calibration_points[0].raw_x + calibration_points[2].raw_x) * calibration.y) >> 17);
+    calibration.orientation = TOUCH_PORTRAIT;
+  }
+  else {
+    calibration_state = CALIBRATION_FAIL;
+    calibration_reset();
+  }
+}
+
+static void logValues() {
+  if (touch_calibration.calibration_state == CALIBRATION_SUCCESS) {
+    SERIAL_ECHOLNPGM("Touch screen calibration completed");
+    SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_X ", touch_calibration.calibration.x);
+    SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_Y ", touch_calibration.calibration.y);
+    SERIAL_ECHOLNPAIR("TOUCH_OFFSET_X ", touch_calibration.calibration.offset_x);
+    SERIAL_ECHOLNPAIR("TOUCH_OFFSET_Y ", touch_calibration.calibration.offset_y);
+    SERIAL_ECHOPGM("TOUCH_ORIENTATION "); if (touch_calibration.calibration.orientation == TOUCH_LANDSCAPE) SERIAL_ECHOLNPGM("TOUCH_LANDSCAPE"); else SERIAL_ECHOLNPGM("TOUCH_PORTRAIT");
+  }
+}
+
+calibrationState TouchCalibration::calibration_start() {
+  calibration = {0, 0, 0, 0, TOUCH_ORIENTATION_NONE};
+  calibration_state = CALIBRATION_TOP_LEFT;
+  calibration_points[CALIBRATION_TOP_LEFT].x = 20;
+  calibration_points[CALIBRATION_TOP_LEFT].y = 20;
+  calibration_points[CALIBRATION_BOTTOM_LEFT].x = 20;
+  calibration_points[CALIBRATION_BOTTOM_LEFT].y = TFT_HEIGHT - 21;
+  calibration_points[CALIBRATION_TOP_RIGHT].x = TFT_WIDTH - 21;
+  calibration_points[CALIBRATION_TOP_RIGHT].y = 20;
+  calibration_points[CALIBRATION_BOTTOM_RIGHT].x = TFT_WIDTH - 21;
+  calibration_points[CALIBRATION_BOTTOM_RIGHT].y = TFT_HEIGHT - 21;
+  return calibration_state;
+}
 
 bool TouchCalibration::handleTouch(uint16_t x, uint16_t y) {
   static millis_t next_button_update_ms = 0;
@@ -40,44 +87,20 @@ bool TouchCalibration::handleTouch(uint16_t x, uint16_t y) {
     calibration_points[calibration_state].raw_y = y;
   }
 
-  switch (calibration_state) {
-    case CALIBRATION_TOP_LEFT: calibration_state = CALIBRATION_BOTTOM_LEFT; break;
-    case CALIBRATION_BOTTOM_LEFT: calibration_state = CALIBRATION_TOP_RIGHT; break;
-    case CALIBRATION_TOP_RIGHT: calibration_state = CALIBRATION_BOTTOM_RIGHT; break;
-    case CALIBRATION_BOTTOM_RIGHT: {
-      if (validate_precision_x(0, 1) && validate_precision_x(2, 3) && validate_precision_y(0, 2) && validate_precision_y(1, 3)) {
-        calibration_state = CALIBRATION_SUCCESS;
-        calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_x + calibration_points[2].raw_x - calibration_points[1].raw_x - calibration_points[0].raw_x);
-        calibration.y = ((calibration_points[1].y - calibration_points[0].y) << 17) / (calibration_points[3].raw_y - calibration_points[2].raw_y + calibration_points[1].raw_y - calibration_points[0].raw_y);
-        calibration.offset_x = calibration_points[0].x - int16_t(((calibration_points[0].raw_x + calibration_points[1].raw_x) * calibration.x) >> 17);
-        calibration.offset_y = calibration_points[0].y - int16_t(((calibration_points[0].raw_y + calibration_points[2].raw_y) * calibration.y) >> 17);
-        calibration.orientation = TOUCH_LANDSCAPE;
-      }
-      else if (validate_precision_y(0, 1) && validate_precision_y(2, 3) && validate_precision_x(0, 2) && validate_precision_x(1, 3)) {
-        calibration_state = CALIBRATION_SUCCESS;
-        calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_y + calibration_points[2].raw_y - calibration_points[1].raw_y - calibration_points[0].raw_y);
-        calibration.y = ((calibration_points[1].y - calibration_points[0].y) << 17) / (calibration_points[3].raw_x - calibration_points[2].raw_x + calibration_points[1].raw_x - calibration_points[0].raw_x);
-        calibration.offset_x = calibration_points[0].x - int16_t(((calibration_points[0].raw_y + calibration_points[1].raw_y) * calibration.x) >> 17);
-        calibration.offset_y = calibration_points[0].y - int16_t(((calibration_points[0].raw_x + calibration_points[2].raw_x) * calibration.y) >> 17);
-        calibration.orientation = TOUCH_PORTRAIT;
-      }
-      else {
-        calibration_state = CALIBRATION_FAIL;
-        calibration_reset();
-      }
+  if (calibration_state == CALIBRATION_TOP_LEFT) calibration_state = CALIBRATION_BOTTOM_LEFT;
+  else if (calibration_state == CALIBRATION_BOTTOM_LEFT) calibration_state = CALIBRATION_TOP_RIGHT;
+  else if (calibration_state == CALIBRATION_TOP_RIGHT) calibration_state = CALIBRATION_BOTTOM_RIGHT;
+  else if (calibration_state == CALIBRATION_BOTTOM_RIGHT) validate_calibration();
 
-      if (calibration_state == CALIBRATION_SUCCESS) {
-        SERIAL_ECHOLNPGM("Touch screen calibration completed");
-        SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_X ", calibration.x);
-        SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_Y ", calibration.y);
-        SERIAL_ECHOLNPAIR("TOUCH_OFFSET_X ", calibration.offset_x);
-        SERIAL_ECHOLNPAIR("TOUCH_OFFSET_Y ", calibration.offset_y);
-        SERIAL_ECHOPGM("TOUCH_ORIENTATION "); if (calibration.orientation == TOUCH_LANDSCAPE) SERIAL_ECHOLNPGM("TOUCH_LANDSCAPE"); else SERIAL_ECHOLNPGM("TOUCH_PORTRAIT");
-      }
-    break; }
-    default: break;
-  }
+  // switch (calibration_state) {
+  //   case CALIBRATION_TOP_LEFT: calibration_state = CALIBRATION_BOTTOM_LEFT; break;
+  //   case CALIBRATION_BOTTOM_LEFT: calibration_state = CALIBRATION_TOP_RIGHT; break;
+  //   case CALIBRATION_TOP_RIGHT: calibration_state = CALIBRATION_BOTTOM_RIGHT; break;
+  //   case CALIBRATION_BOTTOM_RIGHT: validate_calibration(); break;
+  //   default: return true;
+  // }
 
+  logValues();
   return true;
 }
 

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -44,7 +44,7 @@ bool TouchCalibration::handleTouch(uint16_t x, uint16_t y) {
     case CALIBRATION_TOP_LEFT: calibration_state = CALIBRATION_BOTTOM_LEFT; break;
     case CALIBRATION_BOTTOM_LEFT: calibration_state = CALIBRATION_TOP_RIGHT; break;
     case CALIBRATION_TOP_RIGHT: calibration_state = CALIBRATION_BOTTOM_RIGHT; break;
-    case CALIBRATION_BOTTOM_RIGHT:
+    case CALIBRATION_BOTTOM_RIGHT: {
       if (validate_precision_x(0, 1) && validate_precision_x(2, 3) && validate_precision_y(0, 2) && validate_precision_y(1, 3)) {
         calibration_state = CALIBRATION_SUCCESS;
         calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_x + calibration_points[2].raw_x - calibration_points[1].raw_x - calibration_points[0].raw_x);
@@ -74,7 +74,7 @@ bool TouchCalibration::handleTouch(uint16_t x, uint16_t y) {
         SERIAL_ECHOLNPAIR("TOUCH_OFFSET_Y ", calibration.offset_y);
         SERIAL_ECHOPGM("TOUCH_ORIENTATION "); if (calibration.orientation == TOUCH_LANDSCAPE) SERIAL_ECHOLNPGM("TOUCH_LANDSCAPE"); else SERIAL_ECHOLNPGM("TOUCH_PORTRAIT");
       }
-      break;
+    break; }
     default: break;
   }
 

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -1,0 +1,84 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "touch_calibration.h"
+
+#if ENABLED(TOUCH_SCREEN_CALIBRATION)
+
+#include "../../inc/MarlinConfig.h"
+
+TouchCalibration touch_calibration;
+
+touch_calibration_t TouchCalibration::calibration;
+calibrationState TouchCalibration::calibration_state = CALIBRATION_NONE;
+touch_calibration_point_t TouchCalibration::calibration_points[4];
+
+bool TouchCalibration::handleTouch(uint16_t x, uint16_t y) {
+  static millis_t next_button_update_ms = 0;
+  const millis_t now = millis();
+  if (PENDING(now, next_button_update_ms)) return false;
+  next_button_update_ms = now + BUTTON_DELAY_MENU;
+
+  if (calibration_state < CALIBRATION_SUCCESS) {
+    calibration_points[calibration_state].raw_x = x;
+    calibration_points[calibration_state].raw_y = y;
+  }
+
+  switch (calibration_state) {
+    case CALIBRATION_TOP_LEFT: calibration_state = CALIBRATION_BOTTOM_LEFT; break;
+    case CALIBRATION_BOTTOM_LEFT: calibration_state = CALIBRATION_TOP_RIGHT; break;
+    case CALIBRATION_TOP_RIGHT: calibration_state = CALIBRATION_BOTTOM_RIGHT; break;
+    case CALIBRATION_BOTTOM_RIGHT:
+      if (validate_precision_x(0, 1) && validate_precision_x(2, 3) && validate_precision_y(0, 2) && validate_precision_y(1, 3)) {
+        calibration_state = CALIBRATION_SUCCESS;
+        calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_x + calibration_points[2].raw_x - calibration_points[1].raw_x - calibration_points[0].raw_x);
+        calibration.y = ((calibration_points[1].y - calibration_points[0].y) << 17) / (calibration_points[3].raw_y - calibration_points[2].raw_y + calibration_points[1].raw_y - calibration_points[0].raw_y);
+        calibration.offset_x = calibration_points[0].x - int16_t(((calibration_points[0].raw_x + calibration_points[1].raw_x) * calibration.x) >> 17);
+        calibration.offset_y = calibration_points[0].y - int16_t(((calibration_points[0].raw_y + calibration_points[2].raw_y) * calibration.y) >> 17);
+        calibration.orientation = TOUCH_LANDSCAPE;
+      }
+      else if (validate_precision_y(0, 1) && validate_precision_y(2, 3) && validate_precision_x(0, 2) && validate_precision_x(1, 3)) {
+        calibration_state = CALIBRATION_SUCCESS;
+        calibration.x = ((calibration_points[2].x - calibration_points[0].x) << 17) / (calibration_points[3].raw_y + calibration_points[2].raw_y - calibration_points[1].raw_y - calibration_points[0].raw_y);
+        calibration.y = ((calibration_points[1].y - calibration_points[0].y) << 17) / (calibration_points[3].raw_x - calibration_points[2].raw_x + calibration_points[1].raw_x - calibration_points[0].raw_x);
+        calibration.offset_x = calibration_points[0].x - int16_t(((calibration_points[0].raw_y + calibration_points[1].raw_y) * calibration.x) >> 17);
+        calibration.offset_y = calibration_points[0].y - int16_t(((calibration_points[0].raw_x + calibration_points[2].raw_x) * calibration.y) >> 17);
+        calibration.orientation = TOUCH_PORTRAIT;
+      }
+      else {
+        calibration_state = CALIBRATION_FAIL;
+        calibration_reset();
+      }
+
+      if (calibration_state == CALIBRATION_SUCCESS) {
+        SERIAL_ECHOLNPGM("Touch screen calibration completed");
+        SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_X ", calibration.x);
+        SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_Y ", calibration.y);
+        SERIAL_ECHOLNPAIR("TOUCH_OFFSET_X ", calibration.offset_x);
+        SERIAL_ECHOLNPAIR("TOUCH_OFFSET_Y ", calibration.offset_y);
+        SERIAL_ECHOPGM("TOUCH_ORIENTATION "); if (calibration.orientation == TOUCH_LANDSCAPE) SERIAL_ECHOLNPGM("TOUCH_LANDSCAPE"); else SERIAL_ECHOLNPGM("TOUCH_PORTRAIT");
+      }
+      break;
+    default: break;
+  }
+
+  return true;
+}
+
+#endif // ENABLED(TOUCH_SCREEN_CALIBRATION)

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -18,7 +18,7 @@
  */
 #pragma once
 
-#include "../../inc/MarlinConfigPre.h"
+#include "../../inc/MarlinConfig.h"
 
 #ifndef TOUCH_SCREEN_CALIBRATION_PRECISION
   #define TOUCH_SCREEN_CALIBRATION_PRECISION  80
@@ -53,7 +53,7 @@ typedef struct __attribute__((__packed__)) {
   int16_t raw_y;
 } touch_calibration_point_t;
 
-enum calibrationState : uint8_t {
+enum calibrationState {
   CALIBRATION_TOP_LEFT = 0x00,
   CALIBRATION_BOTTOM_LEFT,
   CALIBRATION_TOP_RIGHT,
@@ -68,26 +68,15 @@ public:
   static calibrationState calibration_state;
   static touch_calibration_point_t calibration_points[4];
 
-  static bool validate_precision(int32_t a, int32_t b) { return (a > b ? (100 * b) / a :  (100 * a) / b) > TOUCH_SCREEN_CALIBRATION_PRECISION; }
+  static bool validate_precision(int32_t a, int32_t b);
   static bool validate_precision_x(uint8_t a, uint8_t b) { return validate_precision(calibration_points[a].raw_x, calibration_points[b].raw_x); }
   static bool validate_precision_y(uint8_t a, uint8_t b) { return validate_precision(calibration_points[a].raw_y, calibration_points[b].raw_y); }
+  static void validate_calibration();
 
   static touch_calibration_t calibration;
   static void calibration_reset() { calibration = {TOUCH_CALIBRATION_X, TOUCH_CALIBRATION_Y, TOUCH_OFFSET_X, TOUCH_OFFSET_Y, TOUCH_ORIENTATION}; }
 
-  static calibrationState calibration_start() {
-    calibration = {0, 0, 0, 0, TOUCH_ORIENTATION_NONE};
-    calibration_state = CALIBRATION_TOP_LEFT;
-    calibration_points[CALIBRATION_TOP_LEFT].x = 20;
-    calibration_points[CALIBRATION_TOP_LEFT].y = 20;
-    calibration_points[CALIBRATION_BOTTOM_LEFT].x = 20;
-    calibration_points[CALIBRATION_BOTTOM_LEFT].y = TFT_HEIGHT - 21;
-    calibration_points[CALIBRATION_TOP_RIGHT].x = TFT_WIDTH - 21;
-    calibration_points[CALIBRATION_TOP_RIGHT].y = 20;
-    calibration_points[CALIBRATION_BOTTOM_RIGHT].x = TFT_WIDTH - 21;
-    calibration_points[CALIBRATION_BOTTOM_RIGHT].y = TFT_HEIGHT - 21;
-    return calibration_state;
-  }
+  static calibrationState calibration_start();
   static void calibration_end() { calibration_state = CALIBRATION_NONE; }
   static calibrationState get_calibration_state() { return calibration_state; }
 

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -1,0 +1,111 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2019 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "../../inc/MarlinConfigPre.h"
+
+#if ENABLED(TOUCH_SCREEN_CALIBRATION)
+
+#ifndef TOUCH_SCREEN_CALIBRATION_PRECISION
+  #define TOUCH_SCREEN_CALIBRATION_PRECISION  80
+#endif
+
+#ifndef TOUCH_SCREEN_HOLD_TO_CALIBRATE_MS
+  #define TOUCH_SCREEN_HOLD_TO_CALIBRATE_MS   2500
+#endif
+
+#define TOUCH_ORIENTATION_NONE  0
+#define TOUCH_LANDSCAPE         1
+#define TOUCH_PORTRAIT          2
+
+#if !(defined(TOUCH_CALIBRATION_X) || defined(TOUCH_CALIBRATION_Y) || defined(TOUCH_OFFSET_X) || defined(TOUCH_OFFSET_Y) || defined(TOUCH_ORIENTATION))
+  #if defined(XPT2046_X_CALIBRATION) && defined(XPT2046_Y_CALIBRATION) && defined(XPT2046_X_OFFSET) && defined(XPT2046_Y_OFFSET)
+    #define TOUCH_CALIBRATION_X  XPT2046_X_CALIBRATION
+    #define TOUCH_CALIBRATION_Y  XPT2046_Y_CALIBRATION
+    #define TOUCH_OFFSET_X       XPT2046_X_OFFSET
+    #define TOUCH_OFFSET_Y       XPT2046_Y_OFFSET
+    #define TOUCH_ORIENTATION    TOUCH_LANDSCAPE
+  #else
+    #define TOUCH_CALIBRATION_X  0
+    #define TOUCH_CALIBRATION_Y  0
+    #define TOUCH_OFFSET_X       0
+    #define TOUCH_OFFSET_Y       0
+    #define TOUCH_ORIENTATION    TOUCH_ORIENTATION_NONE
+  #endif
+#endif
+
+typedef struct __attribute__((__packed__)) {
+  int32_t x;
+  int32_t y;
+  int16_t offset_x;
+  int16_t offset_y;
+  uint8_t orientation;
+} touch_calibration_t;
+
+typedef struct __attribute__((__packed__)) {
+  uint16_t x;
+  uint16_t y;
+  int16_t raw_x;
+  int16_t raw_y;
+} touch_calibration_point_t;
+
+enum calibrationState : uint8_t {
+  CALIBRATION_TOP_LEFT = 0x00,
+  CALIBRATION_BOTTOM_LEFT,
+  CALIBRATION_TOP_RIGHT,
+  CALIBRATION_BOTTOM_RIGHT,
+  CALIBRATION_SUCCESS,
+  CALIBRATION_FAIL,
+  CALIBRATION_NONE,
+};
+
+class TouchCalibration {
+public:
+  static calibrationState calibration_state;
+  static touch_calibration_point_t calibration_points[4];
+
+  static bool validate_precision(int32_t a, int32_t b) { return (a > b ? (100 * b) / a :  (100 * a) / b) > TOUCH_SCREEN_CALIBRATION_PRECISION; }
+  static bool validate_precision_x(uint8_t a, uint8_t b) { return validate_precision(calibration_points[a].raw_x, calibration_points[b].raw_x); }
+  static bool validate_precision_y(uint8_t a, uint8_t b) { return validate_precision(calibration_points[a].raw_y, calibration_points[b].raw_y); }
+
+  static touch_calibration_t calibration;
+  static void calibration_reset() { calibration = {TOUCH_CALIBRATION_X, TOUCH_CALIBRATION_Y, TOUCH_OFFSET_X, TOUCH_OFFSET_Y, TOUCH_ORIENTATION}; }
+
+  static calibrationState calibration_start() {
+    calibration = {0, 0, 0, 0, TOUCH_ORIENTATION_NONE};
+    calibration_state = CALIBRATION_TOP_LEFT;
+    calibration_points[CALIBRATION_TOP_LEFT].x = 20;
+    calibration_points[CALIBRATION_TOP_LEFT].y = 20;
+    calibration_points[CALIBRATION_BOTTOM_LEFT].x = 20;
+    calibration_points[CALIBRATION_BOTTOM_LEFT].y = TFT_HEIGHT - 21;
+    calibration_points[CALIBRATION_TOP_RIGHT].x = TFT_WIDTH - 21;
+    calibration_points[CALIBRATION_TOP_RIGHT].y = 20;
+    calibration_points[CALIBRATION_BOTTOM_RIGHT].x = TFT_WIDTH - 21;
+    calibration_points[CALIBRATION_BOTTOM_RIGHT].y = TFT_HEIGHT - 21;
+    return calibration_state;
+  }
+  static void calibration_end() { calibration_state = CALIBRATION_NONE; }
+  static calibrationState get_calibration_state() { return calibration_state; }
+
+  static bool handleTouch(uint16_t x, uint16_t y);
+};
+
+extern TouchCalibration touch_calibration;
+
+#endif

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -32,22 +32,6 @@
 #define TOUCH_LANDSCAPE         1
 #define TOUCH_PORTRAIT          2
 
-#if !(defined(TOUCH_CALIBRATION_X) || defined(TOUCH_CALIBRATION_Y) || defined(TOUCH_OFFSET_X) || defined(TOUCH_OFFSET_Y) || defined(TOUCH_ORIENTATION))
-  #if defined(XPT2046_X_CALIBRATION) && defined(XPT2046_Y_CALIBRATION) && defined(XPT2046_X_OFFSET) && defined(XPT2046_Y_OFFSET)
-    #define TOUCH_CALIBRATION_X  XPT2046_X_CALIBRATION
-    #define TOUCH_CALIBRATION_Y  XPT2046_Y_CALIBRATION
-    #define TOUCH_OFFSET_X       XPT2046_X_OFFSET
-    #define TOUCH_OFFSET_Y       XPT2046_Y_OFFSET
-    #define TOUCH_ORIENTATION    TOUCH_LANDSCAPE
-  #else
-    #define TOUCH_CALIBRATION_X  0
-    #define TOUCH_CALIBRATION_Y  0
-    #define TOUCH_OFFSET_X       0
-    #define TOUCH_OFFSET_Y       0
-    #define TOUCH_ORIENTATION    TOUCH_ORIENTATION_NONE
-  #endif
-#endif
-
 #ifndef TOUCH_ORIENTATION
   #define TOUCH_ORIENTATION    TOUCH_LANDSCAPE
 #endif

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -48,6 +48,10 @@
   #endif
 #endif
 
+#ifndef TOUCH_ORIENTATION
+  #define TOUCH_ORIENTATION    TOUCH_LANDSCAPE
+#endif
+
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
 
 typedef struct __attribute__((__packed__)) {

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -20,8 +20,6 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(TOUCH_SCREEN_CALIBRATION)
-
 #ifndef TOUCH_SCREEN_CALIBRATION_PRECISION
   #define TOUCH_SCREEN_CALIBRATION_PRECISION  80
 #endif
@@ -49,6 +47,8 @@
     #define TOUCH_ORIENTATION    TOUCH_ORIENTATION_NONE
   #endif
 #endif
+
+#if ENABLED(TOUCH_SCREEN_CALIBRATION)
 
 typedef struct __attribute__((__packed__)) {
   int32_t x;

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -60,8 +60,8 @@ uint8_t TouchButtons::read_buttons() {
       x = int16_t((int32_t(x) * touch_calibration.calibration.x) >> 16) + touch_calibration.calibration.offset_x;
       y = int16_t((int32_t(y) * touch_calibration.calibration.y) >> 16) + touch_calibration.calibration.offset_y;
     #else
-      x = uint16_t((uint32_t(x) * XPT2046_X_CALIBRATION) >> 16) + XPT2046_X_OFFSET;
-      y = uint16_t((uint32_t(y) * XPT2046_Y_CALIBRATION) >> 16) + XPT2046_Y_OFFSET;
+      x = uint16_t((uint32_t(x) * TOUCH_CALIBRATION_X) >> 16) + TOUCH_OFFSET_X;
+      y = uint16_t((uint32_t(y) * TOUCH_CALIBRATION_Y) >> 16) + TOUCH_OFFSET_Y;
     #endif
 
 

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -19,7 +19,7 @@
 
 #include "../../inc/MarlinConfig.h"
 
-#if HAS_TOUCH_XPT2046
+#if HAS_TOUCH_BUTTONS
 
 #include "touch_buttons.h"
 #include "../scaled_tft.h"
@@ -87,4 +87,4 @@ uint8_t TouchButtons::read_buttons() {
   return 0;
 }
 
-#endif // HAS_TOUCH_XPT2046
+#endif // HAS_TOUCH_BUTTONS

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -59,8 +59,8 @@ uint8_t TouchButtons::read_buttons() {
       }
     #endif
 
-    x = uint16_t((uint32_t(x) * XPT2046_X_CALIBRATION) >> 16) + XPT2046_X_OFFSET;
-    y = uint16_t((uint32_t(y) * XPT2046_Y_CALIBRATION) >> 16) + XPT2046_Y_OFFSET;
+    x = int16_t((int32_t(x) * touch_calibration.calibration.x) >> 16) + touch_calibration.calibration.offset_x;
+    y = int16_t((int32_t(y) * touch_calibration.calibration.y) >> 16) + touch_calibration.calibration.offset_y;
 
     // Touch within the button area simulates an encoder button
     if (y > BUTTON_AREA_TOP && y < BUTTON_AREA_BOT)

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -57,10 +57,13 @@ uint8_t TouchButtons::read_buttons() {
         if (touch_calibration.handleTouch(x, y)) ui.refresh();
         return 0;
       }
+      x = int16_t((int32_t(x) * touch_calibration.calibration.x) >> 16) + touch_calibration.calibration.offset_x;
+      y = int16_t((int32_t(y) * touch_calibration.calibration.y) >> 16) + touch_calibration.calibration.offset_y;
+    #else
+      x = uint16_t((uint32_t(x) * XPT2046_X_CALIBRATION) >> 16) + XPT2046_X_OFFSET;
+      y = uint16_t((uint32_t(y) * XPT2046_Y_CALIBRATION) >> 16) + XPT2046_Y_OFFSET;
     #endif
 
-    x = int16_t((int32_t(x) * touch_calibration.calibration.x) >> 16) + touch_calibration.calibration.offset_x;
-    y = int16_t((int32_t(y) * touch_calibration.calibration.y) >> 16) + touch_calibration.calibration.offset_y;
 
     // Touch within the button area simulates an encoder button
     if (y > BUTTON_AREA_TOP && y < BUTTON_AREA_BOT)

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -443,7 +443,7 @@ typedef struct SettingsDataStruct {
   // TOUCH_SCREEN_CALIBRATION
   //
   #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-    touch_calibration_t touch_calibration;
+    touch_calibration_t touch_calibration_data;
   #endif
 
   // Ethernet settings
@@ -1410,7 +1410,7 @@ void MarlinSettings::postprocess() {
     // TOUCH_SCREEN_CALIBRATION
     //
     #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-      EEPROM_WRITE(touch.calibration);
+      EEPROM_WRITE(touch_calibration.calibration);
     #endif
 
     //
@@ -2293,8 +2293,8 @@ void MarlinSettings::postprocess() {
       // TOUCH_SCREEN_CALIBRATION
       //
       #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-        _FIELD_TEST(touch.calibration);
-        EEPROM_READ(touch.calibration);
+        _FIELD_TEST(touch_calibration_data);
+        EEPROM_READ(touch_calibration.calibration);
       #endif
 
       //

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -146,7 +146,7 @@
 #endif
 
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-  #include "../lcd/tft/touch.h"
+  #include "../lcd/tft_io/touch_calibration.h"
 #endif
 
 #if HAS_ETHERNET
@@ -2626,7 +2626,7 @@ void MarlinSettings::reset() {
   //
   // TOUCH_SCREEN_CALIBRATION
   //
-  TERN_(TOUCH_SCREEN_CALIBRATION, touch.calibration_reset());
+  TERN_(TOUCH_SCREEN_CALIBRATION, touch_calibration.calibration_reset());
 
   //
   // Buzzer enable/disable

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -304,30 +304,30 @@
 
     // XPT2046 Touch Screen calibration
     #if ENABLED(TFT_CLASSIC_UI)
-      #ifndef XPT2046_X_CALIBRATION
-        #define XPT2046_X_CALIBRATION     -11245
+      #ifndef TOUCH_CALIBRATION_X
+        #define TOUCH_CALIBRATION_X     -11245
       #endif
-      #ifndef XPT2046_Y_CALIBRATION
-        #define XPT2046_Y_CALIBRATION       8629
+      #ifndef TOUCH_CALIBRATION_Y
+        #define TOUCH_CALIBRATION_Y       8629
       #endif
-      #ifndef XPT2046_X_OFFSET
-        #define XPT2046_X_OFFSET             685
+      #ifndef TOUCH_OFFSET_X
+        #define TOUCH_OFFSET_X             685
       #endif
-      #ifndef XPT2046_Y_OFFSET
-        #define XPT2046_Y_OFFSET            -285
+      #ifndef TOUCH_OFFSET_Y
+        #define TOUCH_OFFSET_Y            -285
       #endif
     #elif ENABLED(TFT_480x320_SPI)
-      #ifndef XPT2046_X_CALIBRATION
-        #define XPT2046_X_CALIBRATION     -17232
+      #ifndef TOUCH_CALIBRATION_X
+        #define TOUCH_CALIBRATION_X     -17232
       #endif
-      #ifndef XPT2046_Y_CALIBRATION
-        #define XPT2046_Y_CALIBRATION      11196
+      #ifndef TOUCH_CALIBRATION_Y
+        #define TOUCH_CALIBRATION_Y      11196
       #endif
-      #ifndef XPT2046_X_OFFSET
-        #define XPT2046_X_OFFSET            1047
+      #ifndef TOUCH_OFFSET_X
+        #define TOUCH_OFFSET_X            1047
       #endif
-      #ifndef XPT2046_Y_OFFSET
-        #define XPT2046_Y_OFFSET            -358
+      #ifndef TOUCH_OFFSET_Y
+        #define TOUCH_OFFSET_Y            -358
       #endif
 
       #define TFT_BUFFER_SIZE               2400

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -270,30 +270,30 @@
 
     // XPT2046 Touch Screen calibration
     #if ENABLED(TFT_CLASSIC_UI)
-      #ifndef XPT2046_X_CALIBRATION
-        #define XPT2046_X_CALIBRATION     -11386
+      #ifndef TOUCH_CALIBRATION_X
+        #define TOUCH_CALIBRATION_X     -11386
       #endif
-      #ifndef XPT2046_Y_CALIBRATION
-        #define XPT2046_Y_CALIBRATION       8684
+      #ifndef TOUCH_CALIBRATION_Y
+        #define TOUCH_CALIBRATION_Y       8684
       #endif
-      #ifndef XPT2046_X_OFFSET
-        #define XPT2046_X_OFFSET             689
+      #ifndef TOUCH_OFFSET_X
+        #define TOUCH_OFFSET_X             689
       #endif
-      #ifndef XPT2046_Y_OFFSET
-        #define XPT2046_Y_OFFSET            -273
+      #ifndef TOUCH_OFFSET_Y
+        #define TOUCH_OFFSET_Y            -273
       #endif
     #elif ENABLED(TFT_COLOR_UI)
-      #ifndef XPT2046_X_CALIBRATION
-        #define XPT2046_X_CALIBRATION     -16741
+      #ifndef TOUCH_CALIBRATION_X
+        #define TOUCH_CALIBRATION_X     -16741
       #endif
-      #ifndef XPT2046_Y_CALIBRATION
-        #define XPT2046_Y_CALIBRATION      11258
+      #ifndef TOUCH_CALIBRATION_Y
+        #define TOUCH_CALIBRATION_Y      11258
       #endif
-      #ifndef XPT2046_X_OFFSET
-        #define XPT2046_X_OFFSET            1024
+      #ifndef TOUCH_OFFSET_X
+        #define TOUCH_OFFSET_X            1024
       #endif
-      #ifndef XPT2046_Y_OFFSET
-        #define XPT2046_Y_OFFSET            -367
+      #ifndef TOUCH_OFFSET_Y
+        #define TOUCH_OFFSET_Y            -367
       #endif
 
       #define TFT_BUFFER_SIZE               2400

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -320,30 +320,30 @@
 
       // XPT2046 Touch Screen calibration
       #if ENABLED(TFT_CLASSIC_UI)
-        #ifndef XPT2046_X_CALIBRATION
-          #define XPT2046_X_CALIBRATION   -11386
+        #ifndef TOUCH_CALIBRATION_X
+          #define TOUCH_CALIBRATION_X   -11386
         #endif
-        #ifndef XPT2046_Y_CALIBRATION
-          #define XPT2046_Y_CALIBRATION     8684
+        #ifndef TOUCH_CALIBRATION_Y
+          #define TOUCH_CALIBRATION_Y     8684
         #endif
-        #ifndef XPT2046_X_OFFSET
-          #define XPT2046_X_OFFSET           689
+        #ifndef TOUCH_OFFSET_X
+          #define TOUCH_OFFSET_X           689
         #endif
-        #ifndef XPT2046_Y_OFFSET
-          #define XPT2046_Y_OFFSET          -273
+        #ifndef TOUCH_OFFSET_Y
+          #define TOUCH_OFFSET_Y          -273
         #endif
       #elif ENABLED(TFT_COLOR_UI)
-        #ifndef XPT2046_X_CALIBRATION
-          #define XPT2046_X_CALIBRATION   -17089
+        #ifndef TOUCH_CALIBRATION_X
+          #define TOUCH_CALIBRATION_X   -17089
         #endif
-        #ifndef XPT2046_Y_CALIBRATION
-          #define XPT2046_Y_CALIBRATION    11424
+        #ifndef TOUCH_CALIBRATION_Y
+          #define TOUCH_CALIBRATION_Y    11424
         #endif
-        #ifndef XPT2046_X_OFFSET
-          #define XPT2046_X_OFFSET          1044
+        #ifndef TOUCH_OFFSET_X
+          #define TOUCH_OFFSET_X          1044
         #endif
-        #ifndef XPT2046_Y_OFFSET
-          #define XPT2046_Y_OFFSET          -365
+        #ifndef TOUCH_OFFSET_Y
+          #define TOUCH_OFFSET_Y          -365
         #endif
 
         #define TFT_BUFFER_SIZE             2400

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -156,17 +156,17 @@
 
 // XPT2046 Touch Screen calibration
 #if ANY(TFT_LVGL_UI, TFT_COLOR_UI, TFT_CLASSIC_UI)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION         -17181
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X         -17181
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION          11434
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          11434
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 501
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 501
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                  -9
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                  -9
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V6.h
@@ -171,17 +171,17 @@
 
 // XPT2046 Touch Screen calibration
 #if ANY(TFT_LVGL_UI, TFT_COLOR_UI, TFT_CLASSIC_UI)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION         -17181
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X         -17181
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION          11434
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          11434
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 501
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 501
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                  -9
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                  -9
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
+++ b/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
@@ -284,22 +284,22 @@
 
 // MKS Robin TFT v2.0 with ILI9341
 // Read display identification information (0xD3 on ILI9341)
-//#define XPT2046_X_CALIBRATION            12013
-//#define XPT2046_Y_CALIBRATION            -8711
-//#define XPT2046_X_OFFSET                   -32
-//#define XPT2046_Y_OFFSET                   256
+//#define TOUCH_CALIBRATION_X            12013
+//#define TOUCH_CALIBRATION_Y            -8711
+//#define TOUCH_OFFSET_X                   -32
+//#define TOUCH_OFFSET_Y                   256
 
 // MKS Robin TFT v1.1 with ILI9328
-//#define XPT2046_X_CALIBRATION           -11792
-//#define XPT2046_Y_CALIBRATION             8947
-//#define XPT2046_X_OFFSET                   342
-//#define XPT2046_Y_OFFSET                   -19
+//#define TOUCH_CALIBRATION_X           -11792
+//#define TOUCH_CALIBRATION_Y             8947
+//#define TOUCH_OFFSET_X                   342
+//#define TOUCH_OFFSET_Y                   -19
 
 // MKS Robin TFT v1.1 with R61505
-//#define XPT2046_X_CALIBRATION            12489
-//#define XPT2046_Y_CALIBRATION             9210
-//#define XPT2046_X_OFFSET                   -52
-//#define XPT2046_Y_OFFSET                   -17
+//#define TOUCH_CALIBRATION_X            12489
+//#define TOUCH_CALIBRATION_Y             9210
+//#define TOUCH_OFFSET_X                   -52
+//#define TOUCH_OFFSET_Y                   -17
 
 // QQS-Pro uses MKS Robin TFT v2.0
 
@@ -326,31 +326,31 @@
 #if EITHER(TFT_LVGL_UI_FSMC, TFT_COLOR_UI)
   #define TFT_BUFFER_SIZE                  14400
 
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION          12218
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X          12218
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION          -8814
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          -8814
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 -35
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 -35
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                 256
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                 256
   #endif
 
 #elif ENABLED(TFT_CLASSIC_UI)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION          12149
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X          12149
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION          -8746
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          -8746
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 -35
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 -35
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                 256
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                 256
   #endif
 
   #define TFT_MARLINUI_COLOR              0xFFFF  // White

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -282,30 +282,30 @@
 
 // XPT2046 Touch Screen calibration
 #if EITHER(HAS_TFT_LVGL_UI, TFT_480x320_SPI)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION         -17253
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X         -17253
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION          11579
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          11579
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 514
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 514
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                 -24
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                 -24
   #endif
 #elif HAS_SPI_GRAPHICAL_TFT
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION         -11386
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X         -11386
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION           8684
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y           8684
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 339
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 339
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                 -18
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                 -18
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_MINI.h
@@ -169,17 +169,17 @@
 #endif
 
 #if ENABLED(TOUCH_SCREEN)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION          12033
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X          12033
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION          -9047
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          -9047
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 -30
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 -30
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                 254
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                 254
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -199,30 +199,30 @@
 
 // XPT2046 Touch Screen calibration
 #if ANY(HAS_TFT_LVGL_UI_FSMC, TFT_COLOR_UI, TFT_CLASSIC_UI) && ENABLED(TFT_RES_480x320)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION          17880
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X          17880
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION         -12234
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y         -12234
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 -45
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 -45
   #endif
-  #ifndef XPT2046_Y_OFFSET
-   #define XPT2046_Y_OFFSET                  349
+  #ifndef TOUCH_OFFSET_Y
+   #define TOUCH_OFFSET_Y                  349
   #endif
 #elif EITHER(TFT_COLOR_UI, TFT_CLASSIC_UI) && ENABLED(TFT_RES_320x240)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION         -12246
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X         -12246
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION           9453
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y           9453
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 360
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 360
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                 -22
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                 -22
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -285,17 +285,17 @@
 
 // XPT2046 Touch Screen calibration
 #if ANY(TFT_LVGL_UI, TFT_COLOR_UI, TFT_CLASSIC_UI)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION         -17253
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X         -17253
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION          11579
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          11579
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 514
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 514
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                 -24
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                 -24
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
@@ -138,17 +138,17 @@
 
 // XPT2046 Touch Screen calibration
 #if ANY(TFT_COLOR_UI, TFT_LVGL_UI, TFT_CLASSIC_UI)
-  #ifndef XPT2046_X_CALIBRATION
-    #define XPT2046_X_CALIBRATION         -17181
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X         -17181
   #endif
-  #ifndef XPT2046_Y_CALIBRATION
-    #define XPT2046_Y_CALIBRATION          11434
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          11434
   #endif
-  #ifndef XPT2046_X_OFFSET
-    #define XPT2046_X_OFFSET                 501
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 501
   #endif
-  #ifndef XPT2046_Y_OFFSET
-    #define XPT2046_Y_OFFSET                  -9
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                  -9
   #endif
 #endif
 


### PR DESCRIPTION
### Description

This PR add a touch calibration screen for all 3 marlin TFT UI.

Todo List:
 - [x] Class to control touch calibration logic
 - [x] Classic UI support
 - [x] Color UI support
 - [ ] LVGL UI support 
 - [x] Remove duplicated `XPT2046_**` defines for the new `TOUCH_**`
 - [ ] Remove XPT configuration from the board pins when the board uses SPI display

This PR closes the series for TFT changes I have done. TFT is not perfect yet, but now it will be fully usable and configurable by the users.

### Benefits

Without a calibration screen is nearly impossible to get the xpt calibration values. It's a lot of trial and error.

### Configurations

Any TFT UI with TOUCH_SCREEN_CALIBRATION

