### PR TITLE
Fix FYSETC S6 Timer Conflict

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -34,8 +34,8 @@
   #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
 #endif
 
-// Change the priority to 3. Priority 2 is for software serial.
-//#define TEMP_TIMER_IRQ_PRIO                  3
+// Avoid conflict with TIMER_TONE defined in variant
+#define STEP_TIMER 10
 
 //
 // EEPROM Emulation


### PR DESCRIPTION
### Description

Reassign the `TEMP` timer number to avoid conflicts with `SPEAKER` on the FYSETC S6.
This applies to both S6 boards, because V2 includes the V1 header.

### Benefits

Avoid timer conflict errors during compile.
I verified I could build when Speaker, TMC SoftwareSerial, and BLTouch were all enabled.

### Configurations

These are from the referenced issue, but modified enough to build with Bugfix, and to enable BLTOUCH.
[Configuration_adv.zip](https://github.com/MarlinFirmware/Marlin/files/5500098/Configuration_adv.zip)

### Related Issues

#20024 
