### PR TITLE
Single Touch Menu Navigation for Color UI

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2342,6 +2342,10 @@
   //#define XPT2046_Y_CALIBRATION -8981
   //#define XPT2046_X_OFFSET        -43
   //#define XPT2046_Y_OFFSET        257
+
+  #if ENABLED(TFT_COLOR_UI)
+    //#define SINGLE_TOUCH_NAVIGATION
+  #endif
 #endif
 
 //

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -203,7 +203,7 @@ void Touch::touch(touch_control_t *control) {
 
     case MENU_SCREEN: ui.goto_screen((screenFunc_t)control->data); break;
     case BACK: ui.goto_previous_screen(); break;
-    case CLICK: ui.lcd_clicked = true; break;
+    case CLICK: TERN_(SINGLE_TOUCH_NAVIGATION, ui.encoderPosition = control->data;) ui.lcd_clicked = true; break;
     #if HAS_RESUME_CONTINUE
       case RESUME_CONTINUE: extern bool wait_for_user; wait_for_user = false; break;
     #endif

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -203,7 +203,10 @@ void Touch::touch(touch_control_t *control) {
 
     case MENU_SCREEN: ui.goto_screen((screenFunc_t)control->data); break;
     case BACK: ui.goto_previous_screen(); break;
-    case CLICK: TERN_(SINGLE_TOUCH_NAVIGATION, ui.encoderPosition = control->data;) ui.lcd_clicked = true; break;
+    case CLICK:
+      TERN_(SINGLE_TOUCH_NAVIGATION, ui.encoderPosition = control->data);
+      ui.lcd_clicked = true;
+      break;
     #if HAS_RESUME_CONTINUE
       case RESUME_CONTINUE: extern bool wait_for_user; wait_for_user = false; break;
     #endif

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -647,7 +647,10 @@ void menu_item(const uint8_t row, bool sel ) {
   #endif
 
   menu_line(row, sel ? COLOR_SELECTION_BG : COLOR_BACKGROUND);
-  TERN_(TOUCH_SCREEN, touch.add_control(TERN(SINGLE_TOUCH_NAVIGATION, CLICK, sel ? CLICK : MENU_ITEM), 0, 2 + 34 * row, 320, 32, encoderTopLine + row));
+  #if ENABLED(TOUCH_SCREEN)
+    const TouchControlType tct = TERN(SINGLE_TOUCH_NAVIGATION, true, sel) ? CLICK : MENU_ITEM;
+    touch.add_control(tct, 0, 2 + 34 * row, 320, 32, encoderTopLine + row);
+  #endif
 }
 
 void MarlinUI::move_axis_screen() {

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -647,7 +647,7 @@ void menu_item(const uint8_t row, bool sel ) {
   #endif
 
   menu_line(row, sel ? COLOR_SELECTION_BG : COLOR_BACKGROUND);
-  TERN_(TOUCH_SCREEN, touch.add_control(sel ? CLICK : MENU_ITEM, 0, 2 + 34 * row, 320, 32, encoderTopLine + row));
+  TERN_(TOUCH_SCREEN, touch.add_control(TERN(SINGLE_TOUCH_NAVIGATION, CLICK, sel ? CLICK : MENU_ITEM), 0, 2 + 34 * row, 320, 32, encoderTopLine + row));
 }
 
 void MarlinUI::move_axis_screen() {

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -652,7 +652,10 @@ void menu_item(const uint8_t row, bool sel ) {
   #endif
 
   menu_line(row, sel ? COLOR_SELECTION_BG : COLOR_BACKGROUND);
-  TERN_(TOUCH_SCREEN, touch.add_control(TERN(SINGLE_TOUCH_NAVIGATION, CLICK, sel ? CLICK : MENU_ITEM), 0, 4 + 45 * row, TFT_WIDTH, 43, encoderTopLine + row));
+  #if ENABLED(TOUCH_SCREEN)
+    const TouchControlType tct = TERN(SINGLE_TOUCH_NAVIGATION, true, sel) ? CLICK : MENU_ITEM;
+    touch.add_control(tct, 0, 4 + 45 * row, TFT_WIDTH, 43, encoderTopLine + row);
+  #endif
 }
 
 #if ENABLED(BABYSTEP_ZPROBE_OFFSET)

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -652,7 +652,7 @@ void menu_item(const uint8_t row, bool sel ) {
   #endif
 
   menu_line(row, sel ? COLOR_SELECTION_BG : COLOR_BACKGROUND);
-  TERN_(TOUCH_SCREEN, touch.add_control(sel ? CLICK : MENU_ITEM, 0, 4 + 45 * row, TFT_WIDTH, 43, encoderTopLine + row));
+  TERN_(TOUCH_SCREEN, touch.add_control(TERN(SINGLE_TOUCH_NAVIGATION, CLICK, sel ? CLICK : MENU_ITEM), 0, 4 + 45 * row, TFT_WIDTH, 43, encoderTopLine + row));
 }
 
 #if ENABLED(BABYSTEP_ZPROBE_OFFSET)


### PR DESCRIPTION
### Description

Color UI need two touch to enter a menu: one to select plus one to enter. 

This PR add an option so the user can choose to use a single touch to enter the menu. 

### Benefits

Fast navigation.

### Configurations

New Config: `SINGLE_TOUCH_NAVIGATION`

### Related Issues


