### PR TITLE
 Tramming_Wizard Clearance

### DIFF
--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -120,8 +120,7 @@ void GcodeSuite::G35() {
     // In BLTOUCH HS mode, the probe travels in a deployed state.
     // Users of G35 might have a badly misaligned bed, so raise Z by the
     // length of the deployed pin (BLTOUCH stroke < 7mm)
-    current_position.z = (Z_CLEARANCE_BETWEEN_PROBES) + (7 * ENABLED(BLTOUCH_HS_MODE));
-
+    do_blocking_move_to_z((Z_CLEARANCE_BETWEEN_PROBES) + TERN0(BLTOUCH_HS_MODE, 7));
     const float z_probed_height = probe.probe_at_point(screws_tilt_adjust_pos[i], PROBE_PT_RAISE, 0, true);
 
     if (isnan(z_probed_height)) {

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -44,7 +44,7 @@ static uint8_t tram_index = 0;
 
 bool probe_single_point() {
   // In BLTOUCH HS mode, the probe travels in a deployed state.
-  // Users of G35 might have a badly misaligned bed, so raise Z by the
+  // Users of Tramming Wizard might have a badly misaligned bed, so raise Z by the
   // length of the deployed pin (BLTOUCH stroke < 7mm)
   current_position.z = (Z_CLEARANCE_BETWEEN_PROBES) + (7 * ENABLED(BLTOUCH_HS_MODE));
   const float z_probed_height = probe.probe_at_point(screws_tilt_adjust_pos[tram_index], PROBE_PT_RAISE, 0, true);

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -43,6 +43,10 @@ float z_measured[G35_PROBE_COUNT] = { 0 };
 static uint8_t tram_index = 0;
 
 bool probe_single_point() {
+  // In BLTOUCH HS mode, the probe travels in a deployed state.
+  // Users of G35 might have a badly misaligned bed, so raise Z by the
+  // length of the deployed pin (BLTOUCH stroke < 7mm)
+  current_position.z = (Z_CLEARANCE_BETWEEN_PROBES) + (7 * ENABLED(BLTOUCH_HS_MODE));
   const float z_probed_height = probe.probe_at_point(screws_tilt_adjust_pos[tram_index], PROBE_PT_RAISE, 0, true);
   DEBUG_ECHOLNPAIR("probe_single_point: ", z_probed_height, "mm");
   z_measured[tram_index] = z_probed_height;

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -46,7 +46,7 @@ bool probe_single_point() {
   // In BLTOUCH HS mode, the probe travels in a deployed state.
   // Users of Tramming Wizard might have a badly misaligned bed, so raise Z by the
   // length of the deployed pin (BLTOUCH stroke < 7mm)
-  current_position.z = (Z_CLEARANCE_BETWEEN_PROBES) + (7 * ENABLED(BLTOUCH_HS_MODE));
+  do_blocking_move_to_z((Z_CLEARANCE_BETWEEN_PROBES) + TERN0(BLTOUCH_HS_MODE, 7));
   const float z_probed_height = probe.probe_at_point(screws_tilt_adjust_pos[tram_index], PROBE_PT_RAISE, 0, true);
   DEBUG_ECHOLNPAIR("probe_single_point: ", z_probed_height, "mm");
   z_measured[tram_index] = z_probed_height;

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -667,8 +667,8 @@ float Probe::probe_at_point(const float &rx, const float &ry, const ProbePtRaise
     if (bltouch.triggered()) bltouch._reset();
   #endif
 
-  // TODO: Adapt for SCARA, where the offset rotates
-  xyz_pos_t npos = { rx, ry };
+  // On delta keep Z below clip height or do_blocking_move_to will abort
+  xyz_pos_t npos = { rx, ry, _MIN(TERN(DELTA, delta_clip_start_height, current_position.z), current_position.z) };
   if (probe_relative) {                                     // The given position is in terms of the probe
     if (!can_reach(npos)) {
       if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Position Not Reachable");
@@ -677,15 +677,6 @@ float Probe::probe_at_point(const float &rx, const float &ry, const ProbePtRaise
     npos -= offset_xy;                                      // Get the nozzle position
   }
   else if (!position_is_reachable(npos)) return NAN;        // The given position is in terms of the nozzle
-
-  npos.z =
-    #if ENABLED(DELTA)
-      // Move below clip height or xy move will be aborted by do_blocking_move_to
-      _MIN(current_position.z, delta_clip_start_height)
-    #else
-      current_position.z
-    #endif
-  ;
 
   const float old_feedrate_mm_s = feedrate_mm_s;
   feedrate_mm_s = XY_PROBE_FEEDRATE_MM_S;


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Add `Z_CLEARANCE_BETWEEN_PROBES` to `probe_single_point` travel moves and 7mm (BLTOUCH stroke < 7mm) for `BLTOUCH_HS_MODE`, because users might have a badly misaligned bed.

### Benefits

<!-- What does this fix or improve? -->
Can be used more safely even if the bed is badly misaligned.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
None.

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
https://github.com/MarlinFirmware/Marlin/pull/20000#issuecomment-720945367