### PR TITLE
Arduino DUE compilation fixes

### DIFF
--- a/Marlin/src/HAL/STM32/MarlinSPI.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSPI.cpp
@@ -20,6 +20,8 @@
  *
  */
 
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC)
+
 #include "MarlinSPI.h"
 
 static void spi_init(spi_t *obj, uint32_t speed, spi_mode_e mode, uint8_t msb, uint32_t dataSize) {
@@ -159,3 +161,5 @@ uint8_t MarlinSPI::dmaSend(const void * transmitBuf, uint16_t length, bool minc)
   HAL_DMA_DeInit(&_dmaTx);
   return 1;
 }
+
+#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -34,6 +34,8 @@ uint8_t ControllerFan::speed;
 
 #if ENABLED(CONTROLLER_FAN_EDITABLE)
   controllerFan_settings_t ControllerFan::settings; // {0}
+ #else
+   const controllerFan_settings_t &ControllerFan::settings = controllerFan_defaults;
 #endif
 
 void ControllerFan::setup() {

--- a/Marlin/src/feature/controllerfan.h
+++ b/Marlin/src/feature/controllerfan.h
@@ -58,7 +58,7 @@ class ControllerFan {
     #if ENABLED(CONTROLLER_FAN_EDITABLE)
       static controllerFan_settings_t settings;
     #else
-      static const controllerFan_settings_t constexpr &settings = controllerFan_defaults;
+      static const controllerFan_settings_t &settings;
     #endif
     static inline bool state() { return speed > 0; }
     static inline void init() { reset(); }


### PR DESCRIPTION
### Description

The DUE toolchain used in the Arduino IDE does not like the static constexpr definition of ControllerFan::settings. I moved this to be instantiated in the cpp file to satisfy the compiler.

While fixing this, I also realized we had a new file in HAL/STM32 without proper include protections, which interfered with Arduino IDE builds.

### Benefits

Allows building for DUE from Arduino IDE.

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/5504582/Configuration.zip)

### Related Issues

#19895 - Marlin 2.0.7.2 failed to compile with the feature of "controller fan" for arduino DUE
