### PR TITLE
Fix servo angle index for extruders 2/3

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -123,7 +123,7 @@
       if (e < EXTRUDERS - 1)
     #endif
     {
-      MOVE_SERVO(_SERVO_NR(e), servo_angles[_SERVO_NR(e)][e&1]);
+      MOVE_SERVO(_SERVO_NR(e), servo_angles[_SERVO_NR(e)][e & 1]);
       safe_delay(500);
     }
   }

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -123,7 +123,7 @@
       if (e < EXTRUDERS - 1)
     #endif
     {
-      MOVE_SERVO(_SERVO_NR(e), servo_angles[_SERVO_NR(e)][e]);
+      MOVE_SERVO(_SERVO_NR(e), servo_angles[_SERVO_NR(e)][e&1]);
       safe_delay(500);
     }
   }


### PR DESCRIPTION
### Description

Changing tools with two servos incorrectly indexed into the servo_angles array for extruders 2/3.
This is a 2-dimensional array, so the second index should always be 0/1, not 0/1/2/3 as it was using.

### Benefits

Uses proper angles for extruders 2/3.

### Configurations

[Configs.zip](https://github.com/MarlinFirmware/Marlin/files/5504597/Configs.zip)

### Related Issues

#19980 - SWITCHING_EXTRUDER_E23_SERVO_NR 2
