### PR TITLE
Tramming Wizard wait position

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -811,6 +811,7 @@
 
   //#define ASSISTED_TRAMMING_MENU_ITEM // Add a menu item to run G35 Assisted Tramming (MarlinUI)
   //#define ASSISTED_TRAMMING_WIZARD    // Make the menu item open a Tramming Wizard sub-menu
+  //#define ASSISTED_TRAMMING_CLEAR_POSITION { X_CENTER, Y_CENTER, 30 } // Clear position for nozzle to reach bed screws
 
   /**
    * Screw thread:

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -811,7 +811,7 @@
 
   //#define ASSISTED_TRAMMING_MENU_ITEM // Add a menu item to run G35 Assisted Tramming (MarlinUI)
   //#define ASSISTED_TRAMMING_WIZARD    // Make the menu item open a Tramming Wizard sub-menu
-  //#define ASSISTED_TRAMMING_CLEAR_POSITION { X_CENTER, Y_CENTER, 30 } // Clear position for nozzle to reach bed screws
+  //#define ASSISTED_TRAMMING_SAFE_POSITION { X_CENTER, Y_CENTER, 30 } // Clear position for nozzle to reach bed screws
 
   /**
    * Screw thread:

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -811,7 +811,7 @@
 
   //#define ASSISTED_TRAMMING_MENU_ITEM // Add a menu item to run G35 Assisted Tramming (MarlinUI)
   //#define ASSISTED_TRAMMING_WIZARD    // Make the menu item open a Tramming Wizard sub-menu
-  //#define ASSISTED_TRAMMING_SAFE_POSITION { X_CENTER, Y_CENTER, 30 } // Clear position for nozzle to reach bed screws
+  //#define ASSISTED_TRAMMING_WAIT_POSITION { X_CENTER, Y_CENTER, 30 } // Move the nozzle out of the way for adjustment
 
   /**
    * Screw thread:

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -46,12 +46,14 @@ bool probe_single_point() {
   const float z_probed_height = probe.probe_at_point(screws_tilt_adjust_pos[tram_index], PROBE_PT_RAISE, 0, true);
   DEBUG_ECHOLNPAIR("probe_single_point: ", z_probed_height, "mm");
   z_measured[tram_index] = z_probed_height;
-  #ifdef ASSISTED_TRAMMING_SAFE_POSITION
+
+  #ifdef ASSISTED_TRAMMING_WAIT_POSITION
     // Move XY to safe position
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Clearing Probing Point");
-    const xyz_pos_t safe_pos = ASSISTED_TRAMMING_SAFE_POSITION;
-    do_blocking_move_to(safe_pos, XY_PROBE_FEEDRATE_MM_S);
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Moving away");
+    const xyz_pos_t wait_pos = ASSISTED_TRAMMING_WAIT_POSITION;
+    do_blocking_move_to(wait_pos, XY_PROBE_FEEDRATE_MM_S);
   #endif
+
   return !isnan(z_probed_height);
 }
 

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -46,10 +46,10 @@ bool probe_single_point() {
   const float z_probed_height = probe.probe_at_point(screws_tilt_adjust_pos[tram_index], PROBE_PT_RAISE, 0, true);
   DEBUG_ECHOLNPAIR("probe_single_point: ", z_probed_height, "mm");
   z_measured[tram_index] = z_probed_height;
-  #ifdef ASSISTED_TRAMMING_CLEAR_POSITION
+  #ifdef ASSISTED_TRAMMING_SAFE_POSITION
     // Move XY to safe position
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Clearing Probing Point");
-    const xyz_pos_t safe_pos = ASSISTED_TRAMMING_CLEAR_POSITION;
+    const xyz_pos_t safe_pos = ASSISTED_TRAMMING_SAFE_POSITION;
     do_blocking_move_to(safe_pos, XY_PROBE_FEEDRATE_MM_S);
   #endif
   return !isnan(z_probed_height);

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -50,7 +50,7 @@ bool probe_single_point() {
     // Move XY to safe position
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Clearing Probing Point");
     const xyz_pos_t safe_pos = ASSISTED_TRAMMING_CLEAR_POSITION;
-    do_blocking_move_to(safe_pos, MMM_TO_MMS(XY_PROBE_FEEDRATE_MM_S));
+    do_blocking_move_to(safe_pos, XY_PROBE_FEEDRATE_MM_S);
   #endif
   return !isnan(z_probed_height);
 }

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -46,6 +46,12 @@ bool probe_single_point() {
   const float z_probed_height = probe.probe_at_point(screws_tilt_adjust_pos[tram_index], PROBE_PT_RAISE, 0, true);
   DEBUG_ECHOLNPAIR("probe_single_point: ", z_probed_height, "mm");
   z_measured[tram_index] = z_probed_height;
+  #ifdef ASSISTED_TRAMMING_CLEAR_POSITION
+    // Move XY to safe position
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Clearing Probing Point");
+    const xyz_pos_t safe_pos = ASSISTED_TRAMMING_CLEAR_POSITION;
+    do_blocking_move_to(safe_pos, MMM_TO_MMS(XY_PROBE_FEEDRATE_MM_S));
+  #endif
   return !isnan(z_probed_height);
 }
 


### PR DESCRIPTION
### Description
Adding a Clearing Position after probing for beds with screws needed to access from the top.
If defined this moves the nozzle to a defined position (default center) to grant access to probe points.

Following FR in #20000 
