### PR TITLE
BTT SKR mini MZ / E3 2.0: PWR-DET

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -43,10 +43,6 @@
 
 #define PS_ON_PIN                          PC13  // Power Supply Control
 
-#ifndef POWER_LOSS_PIN
-  #define POWER_LOSS_PIN                   PC12  // Power Loss Detection: PWR-DET
-#endif
-
 #define FAN1_PIN                           PC7
 
 #ifndef CONTROLLER_FAN_PIN

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -43,6 +43,10 @@
 
 #define PS_ON_PIN                          PC13  // Power Supply Control
 
+#ifndef POWER_LOSS_PIN
+  #define POWER_LOSS_PIN                   PC12  // Power Loss Detection: PWR-DET
+#endif
+
 #define FAN1_PIN                           PC7
 
 #ifndef CONTROLLER_FAN_PIN

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -63,6 +63,13 @@
 #endif
 
 //
+// Power-loss Detection
+//
+#ifndef POWER_LOSS_PIN
+  #define POWER_LOSS_PIN                    PC12  // Power Loss Detection: PWR-DET
+#endif
+
+//
 // Steppers
 //
 #define X_ENABLE_PIN                        PB14


### PR DESCRIPTION
### Description

Define Power Loss Detection pin on BigTreeTech SKR mini E3 2.0 and MZ boards.

### Benefits

At least one define less for end-user to change in Configuration_adv.h. Better to use vendor pin definitions.

### Configurations

Based on BTT's UPS modules v1.0/24V and v2.0/12V: https://github.com/bigtreetech/BIGTREETECH-MINI-UPS-V2.0

```C
  #define POWER_LOSS_RECOVERY
  #if ENABLED(POWER_LOSS_RECOVERY)
    #define PLR_ENABLED_DEFAULT   false // Power Loss Recovery enabled by default. (Set with 'M413 Sn' & M500)
    #define BACKUP_POWER_SUPPLY       // Backup power / UPS to move the steppers on power loss
    //#define POWER_LOSS_RECOVER_ZHOME  // Z homing is needed for proper recovery. 99.9% of the time this should be disabled!
    #define POWER_LOSS_ZRAISE       2 // (mm) Z axis raise on resume (on power loss with UPS)
    // PIN defined in board file:
    //#define POWER_LOSS_PIN         44 // Pin to detect power loss. Set to -1 to disable default pin on boards without module.
    #define POWER_LOSS_STATE     HIGH // State of pin indicating power loss
    #define POWER_LOSS_PULL           // Set pullup / pulldown as appropriate
    #define POWER_LOSS_PURGE_LEN   20 // (mm) Length of filament to purge on resume
    #define POWER_LOSS_RETRACT_LEN 10 // (mm) Length of filament to retract on fail. Requires backup power.

    // Without a POWER_LOSS_PIN the following option helps reduce wear on the SD card,
    // especially with "vase mode" printing. Set too high and vases cannot be continued.
    #define POWER_LOSS_MIN_Z_CHANGE 0.05 // (mm) Minimum Z change before saving power-loss data
  #endif
```


### Related Issues
