### PR TITLE
Better co-existence of S_CURVE_ACCELERATION and LIN_ADVANCE

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1653,9 +1653,12 @@
 //#define LIN_ADVANCE
 #if ENABLED(LIN_ADVANCE)
   //#define EXTRA_LIN_ADVANCE_K // Enable for second linear advance constants
-  #define LIN_ADVANCE_K 0.22    // Unit: mm compression per 1mm/s extruder speed
+  #if ENABLED(S_CURVE_ACCELERATION)
+    #define LIN_ADVANCE_K 0     // Linear advance by default off if S-Curve enabled, set K value using M900
+  #else
+    #define LIN_ADVANCE_K 0.22  // Unit: mm compression per 1mm/s extruder speed
+  #endif
   //#define LA_DEBUG            // If enabled, this will generate debug information output over USB.
-  //#define EXPERIMENTAL_SCURVE // Enable this option to permit S-Curve Acceleration
 #endif
 
 // @section leveling

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1018,8 +1018,11 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     WITHIN(LIN_ADVANCE_K, 0, 10),
     "LIN_ADVANCE_K must be a value from 0 to 10 (Changed in LIN_ADVANCE v1.5, Marlin 1.1.9)."
   );
-  #if ENABLED(S_CURVE_ACCELERATION) && DISABLED(EXPERIMENTAL_SCURVE)
-    #error "LIN_ADVANCE and S_CURVE_ACCELERATION may not play well together! Enable EXPERIMENTAL_SCURVE to continue."
+  #if ENABLED(S_CURVE_ACCELERATION)
+    static_assert(
+      LIN_ADVANCE_K == 0,
+      "LIN_ADVANCE and S_CURVE_ACCELERATION may not play well together! Set LIN_ADVANCE_K to 0 to continue."
+    );
   #endif
 #endif
 


### PR DESCRIPTION
### Requirements

### Description

There are incompatibilities between `S_CURVE_ACCELERATION` and `LIN_ADVANCE`. Currently this is resolved by not allowing 
`LIN_ADVANCE`  if the user has enabled `S_CURVE_ACCELERATION`, unless the user sets a special flag `EXPERIMENTAL_SCURVE`. 

This is problematic because it discourages experimentation. The flag `EXPERIMENTAL_SCURVE` is also misleading, since SCURVE itself is not experimental.

### Benefits

This PR allows that have both `S_CURVE_ACCELERATION` and `LIN_ADVANCE` enabled. Both are enabled, but `LIN_ADVANCE` is by default off, that is `LIN_ADVANCE_K` is set to zero. The user can then experiment with different K values using M900.

### Configurations

As in PR.

### Related Issues

See [[BUG] Linear advance incompatible with S-Curve acceleration #14728](https://github.com/MarlinFirmware/Marlin/issues/14728) - this bug report was closed due to lack of activity. This PR should help people experiment with different K values when scurve is on, thus allowing more understanding about how much co-existence is possible.
