### PR TITLE
Fix SKR E3 DIP pin CLCD_SPI_CS

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
@@ -264,7 +264,7 @@
   #define BEEPER_PIN                        PB6
 
   #define CLCD_MOD_RESET                    PA9
-  #define CLCD_SPI_CS                       PA8
+  #define CLCD_SPI_CS                       PB8
 
 #endif // TOUCH_UI_FTDI_EVE && LCD_FYSETC_TFT81050
 


### PR DESCRIPTION


### Requirements

BTT SKR E3 DIP

### Description

<!--

fix typo in CLCD_SPI_CS:  PA8 should be  PB8
-->

### Benefits

fix CLCD_SPI_CS define

