### PR TITLE
Fix compilation errors for UI on Native build (simulator)

### DIFF
--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
@@ -55,7 +55,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if HAS_MARLINUI_U8GLIB
+#if HAS_MARLINUI_U8GLIB && DISABLED(TFT_CLASSIC_UI)
 
 #include "HAL_LCD_com_defines.h"
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_language.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_language.cpp
@@ -181,7 +181,7 @@ static void disp_language(uint8_t language, uint8_t state) {
 
   strcat_P(public_buf_l, PSTR(".bin"));
 
-  lv_obj_set_event_cb_mks(obj, event_handler, id, nullptr, 0);
+  lv_obj_set_event_cb_mks(obj, event_handler, id, "", 0);
   lv_imgbtn_set_src_both(obj, public_buf_l);
 
   if (state == UNSELECTED) lv_obj_refresh_ext_draw_pad(obj);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_print_file.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_print_file.cpp
@@ -279,7 +279,7 @@ void disp_gcode_icon(uint8_t file_num) {
       cutFileName((char *)list_file.long_name[i], 16, 8, (char *)public_buf_m);
 
       if (list_file.IsFolder[i]) {
-        lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), nullptr, 0);
+        lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), "", 0);
         lv_imgbtn_set_src_both(buttonGcode[i], "F:/bmp_dir.bin");
         if (i < 3)
           lv_obj_set_pos(buttonGcode[i], BTN_X_PIXEL * i + INTERVAL_V * (i + 1), titleHeight);
@@ -298,7 +298,7 @@ void disp_gcode_icon(uint8_t file_num) {
           strcat(test_public_buf_l, list_file.file_name[i]);
           char *temp = strstr(test_public_buf_l, ".GCO");
           if (temp) strcpy(temp, ".bin");
-          lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), nullptr, 0);
+          lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), "", 0);
           lv_imgbtn_set_src_both(buttonGcode[i], test_public_buf_l);
           if (i < 3) {
             lv_obj_set_pos(buttonGcode[i], BTN_X_PIXEL * i + INTERVAL_V * (i + 1) + FILE_PRE_PIC_X_OFFSET, titleHeight + FILE_PRE_PIC_Y_OFFSET);
@@ -308,7 +308,7 @@ void disp_gcode_icon(uint8_t file_num) {
             lv_btn_use_label_style(buttonText[i]);
             lv_obj_clear_protect(buttonText[i], LV_PROTECT_FOLLOW);
             lv_btn_set_layout(buttonText[i], LV_LAYOUT_OFF);
-            //lv_obj_set_event_cb_mks(buttonText[i], event_handler,(i+10),nullptr, 0);
+            //lv_obj_set_event_cb_mks(buttonText[i], event_handler,(i+10),"", 0);
             lv_obj_set_pos(buttonText[i], BTN_X_PIXEL * i + INTERVAL_V * (i + 1) + FILE_PRE_PIC_X_OFFSET, titleHeight + FILE_PRE_PIC_Y_OFFSET + 100);
             lv_obj_set_size(buttonText[i], 100, 40);
           }
@@ -320,7 +320,7 @@ void disp_gcode_icon(uint8_t file_num) {
             lv_btn_use_label_style(buttonText[i]);
             lv_obj_clear_protect(buttonText[i], LV_PROTECT_FOLLOW);
             lv_btn_set_layout(buttonText[i], LV_LAYOUT_OFF);
-            //lv_obj_set_event_cb_mks(buttonText[i], event_handler,(i+10),nullptr, 0);
+            //lv_obj_set_event_cb_mks(buttonText[i], event_handler,(i+10),"", 0);
             lv_obj_set_pos(buttonText[i], BTN_X_PIXEL * (i - 3) + INTERVAL_V * ((i - 3) + 1) + FILE_PRE_PIC_X_OFFSET, BTN_Y_PIXEL + INTERVAL_H + titleHeight + FILE_PRE_PIC_Y_OFFSET + 100);
             lv_obj_set_size(buttonText[i], 100, 40);
           }
@@ -328,7 +328,7 @@ void disp_gcode_icon(uint8_t file_num) {
           lv_obj_align(labelPageUp[i], buttonText[i], LV_ALIGN_IN_BOTTOM_MID, 0, 0);
         }
         else {
-          lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), nullptr, 0);
+          lv_obj_set_event_cb_mks(buttonGcode[i], event_handler, (i + 1), "", 0);
           lv_imgbtn_set_src_both(buttonGcode[i], "F:/bmp_file.bin");
           if (i < 3)
             lv_obj_set_pos(buttonGcode[i], BTN_X_PIXEL * i + INTERVAL_V * (i + 1), titleHeight);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
@@ -1680,7 +1680,7 @@ lv_obj_t* lv_label_create(lv_obj_t *par, lv_coord_t x, lv_coord_t y, const char 
 lv_obj_t* lv_btn_create(lv_obj_t *par, lv_event_cb_t cb, const int id/*=0*/, lv_style_t *style/*=&style_para_value*/) {
   lv_obj_t *btn = lv_btn_create(par, nullptr);
   if (id)
-    lv_obj_set_event_cb_mks(btn, cb, id, nullptr, 0);
+    lv_obj_set_event_cb_mks(btn, cb, id, "", 0);
   else
     lv_obj_set_event_cb(btn, cb);
   lv_btn_set_style_both(btn, style);
@@ -1748,7 +1748,7 @@ lv_obj_t* lv_imgbtn_create(lv_obj_t *par, const char *img, lv_event_cb_t cb, con
   lv_obj_t *btn = lv_imgbtn_create(par, nullptr);
   if (img) lv_imgbtn_set_src_both(btn, img);
   if (id)
-    lv_obj_set_event_cb_mks(btn, cb, id, nullptr, 0);
+    lv_obj_set_event_cb_mks(btn, cb, id, "", 0);
   else
     lv_obj_set_event_cb(btn, cb);
   lv_imgbtn_use_label_style(btn);
@@ -1785,7 +1785,7 @@ lv_obj_t* lv_screen_menu_item(lv_obj_t *par, const char *text, lv_coord_t x, lv_
   lv_obj_t *btn = lv_btn_create(par, nullptr);   /*Add a button the current screen*/
   lv_obj_set_pos(btn, x, y);                         /*Set its position*/
   lv_obj_set_size(btn, PARA_UI_SIZE_X, PARA_UI_SIZE_Y);                       /*Set its size*/
-  if (id > -1) lv_obj_set_event_cb_mks(btn, cb, id, nullptr, 0);
+  if (id > -1) lv_obj_set_event_cb_mks(btn, cb, id, "", 0);
   lv_btn_use_label_style(btn);
   lv_btn_set_layout(btn, LV_LAYOUT_OFF);
   lv_obj_t *label = lv_label_create_empty(btn);        /*Add a label to the button*/

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_wifi.cpp
@@ -73,7 +73,7 @@ void lv_draw_wifi(void) {
 
     buttonReconnect = lv_imgbtn_create(scr, nullptr);
 
-    lv_obj_set_event_cb_mks(buttonReconnect, event_handler, ID_W_RECONNECT, nullptr, 0);
+    lv_obj_set_event_cb_mks(buttonReconnect, event_handler, ID_W_RECONNECT, "", 0);
     lv_imgbtn_set_src_both(buttonReconnect, "F:/bmp_wifi.bin");
     lv_imgbtn_use_label_style(buttonReconnect);
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/wifi_upload.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/wifi_upload.cpp
@@ -21,7 +21,7 @@
  */
 #include "../../../../inc/MarlinConfigPre.h"
 
-#if HAS_TFT_LVGL_UI
+#if HAS_TFT_LVGL_UI && ENABLED(USE_WIFI_FUNCTION)
 
 #include "draw_ui.h"
 #include "wifi_module.h"

--- a/Marlin/src/lcd/extui/lib/mks_ui/wifi_upload.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/wifi_upload.cpp
@@ -21,7 +21,7 @@
  */
 #include "../../../../inc/MarlinConfigPre.h"
 
-#if HAS_TFT_LVGL_UI && ENABLED(USE_WIFI_FUNCTION)
+#if BOTH(HAS_TFT_LVGL_UI, USE_WIFI_FUNCTION)
 
 #include "draw_ui.h"
 #include "wifi_module.h"
@@ -822,4 +822,4 @@ int32_t wifi_upload(int type) {
   return esp_upload.uploadResult == success ? 0 : -1;
 }
 
-#endif  // HAS_TFT_LVGL_UI
+#endif // HAS_TFT_LVGL_UI && USE_WIFI_FUNCTION

--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -26,7 +26,7 @@
 
 #include "../inc/MarlinConfigPre.h"
 
-#if HAS_WIRED_LCD
+#if HAS_WIRED_LCD && !HAS_GRAPHICAL_TFT
 
 #include "lcdprint.h"
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -262,67 +262,69 @@ millis_t MarlinUI::next_button_update_ms; // = 0
 
   #endif
 
-  void _wrap_string(uint8_t &col, uint8_t &row, const char * const string, read_byte_cb_t cb_read_byte, bool wordwrap/*=false*/) {
-    SETCURSOR(col, row);
-    if (!string) return;
+  #if !HAS_GRAPHICAL_TFT
+    void _wrap_string(uint8_t &col, uint8_t &row, const char * const string, read_byte_cb_t cb_read_byte, bool wordwrap/*=false*/) {
+      SETCURSOR(col, row);
+      if (!string) return;
 
-    auto _newline = [&col, &row]{
-      col = 0; row++;                 // Move col to string len (plus space)
-      SETCURSOR(0, row);              // Simulate carriage return
-    };
+      auto _newline = [&col, &row]{
+        col = 0; row++;                 // Move col to string len (plus space)
+        SETCURSOR(0, row);              // Simulate carriage return
+      };
 
-    uint8_t *p = (uint8_t*)string;
-    wchar_t ch;
-    if (wordwrap) {
-      uint8_t *wrd = nullptr, c = 0;
-      // find the end of the part
-      for (;;) {
-        if (!wrd) wrd = p;            // Get word start /before/ advancing
-        p = get_utf8_value_cb(p, cb_read_byte, &ch);
-        const bool eol = !ch;         // zero ends the string
-        // End or a break between phrases?
-        if (eol || ch == ' ' || ch == '-' || ch == '+' || ch == '.') {
-          if (!c && ch == ' ') { if (wrd) wrd++; continue; } // collapse extra spaces
-          // Past the right and the word is not too long?
-          if (col + c > LCD_WIDTH && col >= (LCD_WIDTH) / 4) _newline(); // should it wrap?
-          c += !eol;                  // +1 so the space will be printed
-          col += c;                   // advance col to new position
-          while (c) {                 // character countdown
-            --c;                      // count down to zero
-            wrd = get_utf8_value_cb(wrd, cb_read_byte, &ch); // get characters again
-            lcd_put_wchar(ch);        // character to the LCD
+      uint8_t *p = (uint8_t*)string;
+      wchar_t ch;
+      if (wordwrap) {
+        uint8_t *wrd = nullptr, c = 0;
+        // find the end of the part
+        for (;;) {
+          if (!wrd) wrd = p;            // Get word start /before/ advancing
+          p = get_utf8_value_cb(p, cb_read_byte, &ch);
+          const bool eol = !ch;         // zero ends the string
+          // End or a break between phrases?
+          if (eol || ch == ' ' || ch == '-' || ch == '+' || ch == '.') {
+            if (!c && ch == ' ') { if (wrd) wrd++; continue; } // collapse extra spaces
+            // Past the right and the word is not too long?
+            if (col + c > LCD_WIDTH && col >= (LCD_WIDTH) / 4) _newline(); // should it wrap?
+            c += !eol;                  // +1 so the space will be printed
+            col += c;                   // advance col to new position
+            while (c) {                 // character countdown
+              --c;                      // count down to zero
+              wrd = get_utf8_value_cb(wrd, cb_read_byte, &ch); // get characters again
+              lcd_put_wchar(ch);        // character to the LCD
+            }
+            if (eol) break;             // all done!
+            wrd = nullptr;              // set up for next word
           }
-          if (eol) break;             // all done!
-          wrd = nullptr;              // set up for next word
+          else c++;                     // count word characters
         }
-        else c++;                     // count word characters
+      }
+      else {
+        for (;;) {
+          p = get_utf8_value_cb(p, cb_read_byte, &ch);
+          if (!ch) break;
+          lcd_put_wchar(ch);
+          col++;
+          if (col >= LCD_WIDTH) _newline();
+        }
       }
     }
-    else {
-      for (;;) {
-        p = get_utf8_value_cb(p, cb_read_byte, &ch);
-        if (!ch) break;
-        lcd_put_wchar(ch);
-        col++;
-        if (col >= LCD_WIDTH) _newline();
-      }
-    }
-  }
 
-  void MarlinUI::draw_select_screen_prompt(PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
-    const uint8_t plen = utf8_strlen_P(pref), slen = suff ? utf8_strlen_P(suff) : 0;
-    uint8_t col = 0, row = 0;
-    if (!string && plen + slen <= LCD_WIDTH) {
-      col = (LCD_WIDTH - plen - slen) / 2;
-      row = LCD_HEIGHT > 3 ? 1 : 0;
+    void MarlinUI::draw_select_screen_prompt(PGM_P const pref, const char * const string/*=nullptr*/, PGM_P const suff/*=nullptr*/) {
+      const uint8_t plen = utf8_strlen_P(pref), slen = suff ? utf8_strlen_P(suff) : 0;
+      uint8_t col = 0, row = 0;
+      if (!string && plen + slen <= LCD_WIDTH) {
+        col = (LCD_WIDTH - plen - slen) / 2;
+        row = LCD_HEIGHT > 3 ? 1 : 0;
+      }
+      wrap_string_P(col, row, pref, true);
+      if (string) {
+        if (col) { col = 0; row++; } // Move to the start of the next line
+        wrap_string(col, row, string);
+      }
+      if (suff) wrap_string_P(col, row, suff);
     }
-    wrap_string_P(col, row, pref, true);
-    if (string) {
-      if (col) { col = 0; row++; } // Move to the start of the next line
-      wrap_string(col, row, string);
-    }
-    if (suff) wrap_string_P(col, row, suff);
-  }
+  #endif // !HAS_GRAPHICAL_TFT
 
 #endif // HAS_LCD_MENU
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -263,6 +263,7 @@ millis_t MarlinUI::next_button_update_ms; // = 0
   #endif
 
   #if !HAS_GRAPHICAL_TFT
+
     void _wrap_string(uint8_t &col, uint8_t &row, const char * const string, read_byte_cb_t cb_read_byte, bool wordwrap/*=false*/) {
       SETCURSOR(col, row);
       if (!string) return;
@@ -324,6 +325,7 @@ millis_t MarlinUI::next_button_update_ms; // = 0
       }
       if (suff) wrap_string_P(col, row, suff);
     }
+
   #endif // !HAS_GRAPHICAL_TFT
 
 #endif // HAS_LCD_MENU

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -80,12 +80,10 @@
 
     #include "lcdprint.h"
 
-    void _wrap_string(uint8_t &col, uint8_t &row, const char * const string, read_byte_cb_t cb_read_byte, const bool wordwrap=false);
-    inline void wrap_string_P(uint8_t &col, uint8_t &row, PGM_P const pstr, const bool wordwrap=false) { _wrap_string(col, row, pstr, read_byte_rom, wordwrap); }
-    inline void wrap_string(uint8_t &col, uint8_t &row, const char * const string, const bool wordwrap=false) { _wrap_string(col, row, string, read_byte_ram, wordwrap); }
-
-    #if ENABLED(SDSUPPORT)
-      #include "../sd/cardreader.h"
+    #if !HAS_GRAPHICAL_TFT
+      void _wrap_string(uint8_t &col, uint8_t &row, const char * const string, read_byte_cb_t cb_read_byte, const bool wordwrap=false);
+      inline void wrap_string_P(uint8_t &col, uint8_t &row, PGM_P const pstr, const bool wordwrap=false) { _wrap_string(col, row, pstr, read_byte_rom, wordwrap); }
+      inline void wrap_string(uint8_t &col, uint8_t &row, const char * const string, const bool wordwrap=false) { _wrap_string(col, row, string, read_byte_ram, wordwrap); }
     #endif
 
     typedef void (*screenFunc_t)();


### PR DESCRIPTION
### Description

TFT UI (color, classic and lvgl) fails to build on simulator because of the issues fixed here. Same are code that aren't used (but compiled), other a null pointer where it can't be. 
ARM gcc just drops the unused references. But native don't. I prefer to fix it here, that just hiding the problem making native gcc drop it too.

