### PR TITLE
Fix Linux GPIO logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,6 @@ cmake-build-*
 
 #Python
 __pycache__
+
+#IOLogger logs
+*_log.csv

--- a/Marlin/src/HAL/LINUX/main.cpp
+++ b/Marlin/src/HAL/LINUX/main.cpp
@@ -19,22 +19,22 @@
  */
 #ifdef __PLAT_LINUX__
 
-extern void setup();
-extern void loop();
-
-#include <thread>
-
-#include <iostream>
-#include <fstream>
+//#define GPIO_LOGGING // Full GPIO and Positional Logging
 
 #include "../../inc/MarlinConfig.h"
-#include <stdio.h>
-#include <stdarg.h>
 #include "../shared/Delay.h"
 #include "hardware/IOLoggerCSV.h"
 #include "hardware/Heater.h"
 #include "hardware/LinearAxis.h"
-#include "../../core/macros.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <thread>
+#include <iostream>
+#include <fstream>
+
+extern void setup();
+extern void loop();
 
 // simple stdout / stdin implementation for fake serial port
 void write_serial_thread() {
@@ -64,8 +64,6 @@ void simulation_loop() {
   LinearAxis y_axis(Y_ENABLE_PIN, Y_DIR_PIN, Y_STEP_PIN, Y_MIN_PIN, Y_MAX_PIN);
   LinearAxis z_axis(Z_ENABLE_PIN, Z_DIR_PIN, Z_STEP_PIN, Z_MIN_PIN, Z_MAX_PIN);
   LinearAxis extruder0(E0_ENABLE_PIN, E0_DIR_PIN, E0_STEP_PIN, P_NC, P_NC);
-
-  //#define GPIO_LOGGING // Full GPIO and Positional Logging
 
   #ifdef GPIO_LOGGING
     IOLoggerCSV logger("all_gpio_log.csv");

--- a/Marlin/src/HAL/LINUX/main.cpp
+++ b/Marlin/src/HAL/LINUX/main.cpp
@@ -34,6 +34,7 @@ extern void loop();
 #include "hardware/IOLoggerCSV.h"
 #include "hardware/Heater.h"
 #include "hardware/LinearAxis.h"
+#include "../../core/macros.h"
 
 // simple stdout / stdin implementation for fake serial port
 void write_serial_thread() {
@@ -88,7 +89,7 @@ void simulation_loop() {
 
     #ifdef GPIO_LOGGING
       if (x_axis.position != x || y_axis.position != y || z_axis.position != z) {
-        uint64_t update = MAX3(x_axis.last_update, y_axis.last_update, z_axis.last_update);
+        uint64_t update = _MAX(x_axis.last_update, y_axis.last_update, z_axis.last_update);
         position_log << update << ", " << x_axis.position << ", " << y_axis.position << ", " << z_axis.position << std::endl;
         position_log.flush();
         x = x_axis.position;


### PR DESCRIPTION
### Description

When enabling `GPIO_LOGGING`, a code that uses a deprecated version of a macro (`MAX3` vs `_MAX`) is used, that causes a compilation error.

Also updated `.gitignore` to ignore `*_log.csv` files in the top directory

### Benefits

Fixes GPIO logging

### Configurations

```cpp
#define MOTHERBOARD BOARD_LINUX_RAMPS
#define GPIO_LOGGING
```

I haven't added a test case, to not increase the duration of tests, but could easily add one
