### PR TITLE
Fixes issue #20085, POWER_LOSS_RECOVERY assumes fan exists 

### DIFF
--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -433,13 +433,15 @@ void PrintJobRecovery::resume() {
   #endif
 
   // Restore print cooling fan speeds
-  FANS_LOOP(i) {
-    uint8_t f = info.fan_speed[i];
-    if (f) {
-      sprintf_P(cmd, PSTR("M106 P%i S%i"), i, f);
-      gcode.process_subcommands_now(cmd);
+  #if HAS_FAN
+    FANS_LOOP(i) {
+      uint8_t f = info.fan_speed[i];
+      if (f) {
+        sprintf_P(cmd, PSTR("M106 P%i S%i"), i, f);
+        gcode.process_subcommands_now(cmd);
+      }
     }
-  }
+  #endif
 
   // Restore retract and hop state
   #if ENABLED(FWRETRACT)

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -435,7 +435,7 @@ void PrintJobRecovery::resume() {
   // Restore print cooling fan speeds
   #if HAS_FAN
     FANS_LOOP(i) {
-      uint8_t f = info.fan_speed[i];
+      const int f = info.fan_speed[i];
       if (f) {
         sprintf_P(cmd, PSTR("M106 P%i S%i"), i, f);
         gcode.process_subcommands_now(cmd);


### PR DESCRIPTION
### Requirements

enable POWER_LOSS_RECOVERY
enable SDSUPPORT needed by POWER_LOSS_RECOVERY
define FAN_PIN -1

### Description

This will fail to compile with the following error.
```
Marlin\src\feature\powerloss.cpp: In static member function 'static void PrintJobRecovery::resume()':
Marlin\src\feature\powerloss.cpp:436:13: error: 'i' was not declared in this scope
FANS_LOOP(i) {
^
Marlin\src\feature\powerloss.cpp:436:14: error: 'FANS_LOOP' was not declared in this scope
FANS_LOOP(i) {
```
Added a `#if HAS_FAN` block around offending code.

### Benefits

This compiles as expected

### Related Issues

Issue #20085 