### PR TITLE
Fix "autotune" LCD message

### DIFF
--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -77,7 +77,7 @@ void GcodeSuite::M303() {
     KEEPALIVE_STATE(NOT_BUSY);
   #endif
 
-  ui.set_status(GET_TEXT(MSG_PID_AUTOTUNE));
+  ui.set_status_P(GET_TEXT(MSG_PID_AUTOTUNE));
   thermalManager.PID_autotune(temp, e, c, u);
   ui.reset_status();
 }


### PR DESCRIPTION
M303 was not printing PID Autotune to LCD
#20108

> Line 80 in the M303.cpp file should be ui.set_status_P not ui.set_status. Tested with 2.0.7.2 Marlin.
> 
> See commit on my branch that fixes it: th3dstudio@58630ee
> 
> This bug is also present in bugfix-2.0.x branch: https://github.com/MarlinFirmware/Marlin/blob/bugfix-2.0.x/Marlin/src/gcode/temp/M303.cpp