### PR TITLE
add ethernet.cpp src filter

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -77,6 +77,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/feature/direct_stepping.cpp> -<src/gcode/motion/G6.cpp>
   -<src/feature/e_parser.cpp>
   -<src/feature/encoder_i2c.cpp>
+  -<src/feature/ethernet.cpp>
   -<src/feature/fanmux.cpp>
   -<src/feature/filwidth.cpp> -<src/gcode/feature/filwidth>
   -<src/feature/fwretract.cpp> -<src/gcode/feature/fwretract>


### PR DESCRIPTION
### Requirements

Any board without ethernet

### Description

Although there is a test in platformio.ini to add in ethernet, 
`HAS_ETHERNET            = src_filter=+<src/feature/ethernet.cpp>`
the default was that ethernet was compiled everytime.  
All though it caused no harm, It wastes cpu cycles attempting to compile ethernet.cpp 
It also produces the warnings noted below

Added -<src/feature/ethernet.cpp> to default_src_filter

### Benefits
Quicker compile times, less warnings

### Related Issues
I noticed this as on a ramps as ethernet.cpp was generating this warning, when it shouldn't have even been compiled.  
```
Compiling .pio/build/mega2560/src/src/feature/ethernet.cpp.o
In file included from Marlin/src/module/printcounter.h:25:0,
                 from Marlin/src/MarlinCore.cpp:51:
Marlin/src/module/../libs/duration_t.h:110:34: warning: unknown option after '#pragma GCC diagnostic' kind [-Wpragmas]
   #pragma GCC diagnostic ignored "-Wformat-overflow"
```