### PR TITLE
Remaining Time for Prusa-style LCD layout

### DIFF
--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -966,13 +966,42 @@ void MarlinUI::draw_status_screen() {
     #if HAS_PRINT_PROGRESS && !defined(DREW_PRINT_PROGRESS)
       _draw_print_progress();
     #else
-      duration_t elapsed = print_job_timer.duration();
-      char buffer[14];
-      (void)elapsed.toDigital(buffer);
-      lcd_put_wchar(LCD_STR_CLOCK[0]);
-      lcd_put_u8str(buffer);
-    #endif
 
+    /// CUSTOM TO ADD REMAINING TIME TO PRUSA SCREEN - copied most of it from classic screen
+    {
+      #if ENABLED(SHOW_REMAINING_TIME)
+        char buffer[14];
+        uint8_t timepos = 0; 
+        const bool show_remain = TERN1(ROTATE_PROGRESS_DISPLAY, blink) && (printingIsActive() || marlin_state == MF_SD_COMPLETE);
+        if (show_remain) {
+          #if ENABLED(USE_M73_REMAINING_TIME)
+            duration_t remaining = get_remaining_time();
+          #else
+            uint8_t progress = get_progress_percent();
+            uint32_t elapsed = print_job_timer.duration();
+            duration_t remaining = (progress > 0) ? ((elapsed * 25600 / progress) >> 8) - elapsed : 0;
+          #endif
+          const uint8_t len = remaining.toDigital(buffer);
+          timepos = LCD_WIDTH - 4 - len;
+          lcd_put_wchar(timepos, 2, 'R');
+        }
+        if (!show_remain) { 
+          duration_t elapsed = print_job_timer.duration();
+          const uint8_t len = elapsed.toDigital(buffer);
+          timepos = LCD_WIDTH - 4 - len;
+          lcd_put_wchar(timepos, 2, LCD_STR_CLOCK[0]);
+        }
+        lcd_put_u8str(buffer);
+
+      #else // original block
+        duration_t elapsed = print_job_timer.duration();
+        char buffer[14];
+        (void)elapsed.toDigital(buffer);
+        lcd_put_wchar(LCD_STR_CLOCK[0]);
+        lcd_put_u8str(buffer);
+      #endif
+    }
+    #endif
   #endif // LCD_INFO_SCREEN_STYLE 1
 
   // ========= Last Line ========

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -707,6 +707,35 @@ void MarlinUI::draw_status_message(const bool blink) {
  *  |01234567890123456789|
  */
 
+inline uint8_t draw_elapsed_or_remaining_time(uint8_t timepos) {
+  char buffer[14];
+
+  #if ENABLED(SHOW_REMAINING_TIME)
+    const bool show_remain = TERN1(ROTATE_PROGRESS_DISPLAY, blink) && (printingIsActive() || marlin_state == MF_SD_COMPLETE);
+    if (show_remain) {
+      #if ENABLED(USE_M73_REMAINING_TIME)
+        duration_t remaining = get_remaining_time();
+      #else
+        uint8_t progress = get_progress_percent();
+        uint32_t elapsed = print_job_timer.duration();
+        duration_t remaining = (progress > 0) ? ((elapsed * 25600 / progress) >> 8) - elapsed : 0;
+      #endif
+      timepos -= remaining.toDigital(buffer);
+      lcd_put_wchar(timepos, 2, 'R');
+    }
+  #else
+    constexpr bool show_remain = false;
+  #endif
+
+  if (!show_remain) {
+    duration_t elapsed = print_job_timer.duration();
+    timepos -= elapsed.toDigital(buffer);
+    lcd_put_wchar(timepos, 2, LCD_STR_CLOCK[0]);
+  }
+  lcd_put_u8str(buffer);
+  return timepos;
+}
+
 void MarlinUI::draw_status_screen() {
 
   const bool blink = get_blink();
@@ -845,33 +874,7 @@ void MarlinUI::draw_status_screen() {
       lcd_put_u8str(i16tostr3rj(feedrate_percentage));
       lcd_put_wchar('%');
 
-      char buffer[14];
-      uint8_t timepos = 0;
-      #if ENABLED(SHOW_REMAINING_TIME)
-        const bool show_remain = TERN1(ROTATE_PROGRESS_DISPLAY, blink) && (printingIsActive() || marlin_state == MF_SD_COMPLETE);
-        if (show_remain) {
-          #if ENABLED(USE_M73_REMAINING_TIME)
-            duration_t remaining = get_remaining_time();
-          #else
-            uint8_t progress = get_progress_percent();
-            uint32_t elapsed = print_job_timer.duration();
-            duration_t remaining = (progress > 0) ? ((elapsed * 25600 / progress) >> 8) - elapsed : 0;
-          #endif
-          const uint8_t len = remaining.toDigital(buffer);
-          timepos = LCD_WIDTH - 1 - len;
-          lcd_put_wchar(timepos, 2, 'R');
-        }
-      #else
-        constexpr bool show_remain = false;
-      #endif
-
-      if (!show_remain) {
-        duration_t elapsed = print_job_timer.duration();
-        const uint8_t len = elapsed.toDigital(buffer);
-        timepos = LCD_WIDTH - 1 - len;
-        lcd_put_wchar(timepos, 2, LCD_STR_CLOCK[0]);
-      }
-      lcd_put_u8str(buffer);
+      const uint8_t timepos = draw_elapsed_or_remaining_time(LCD_WIDTH - 1);
 
       #if LCD_WIDTH >= 20
         lcd_moveto(timepos - 7, 2);
@@ -955,7 +958,7 @@ void MarlinUI::draw_status_screen() {
     #elif HAS_MULTI_HOTEND && HAS_HEATED_BED
       _draw_bed_status(blink);
     #elif HAS_PRINT_PROGRESS
-      #define DREW_PRINT_PROGRESS
+      #define DREW_PRINT_PROGRESS 1
       _draw_print_progress();
     #endif
 
@@ -963,45 +966,17 @@ void MarlinUI::draw_status_screen() {
     // Elapsed Time or SD Percent
     //
     lcd_moveto(LCD_WIDTH - 9, 2);
-    #if HAS_PRINT_PROGRESS && !defined(DREW_PRINT_PROGRESS)
+
+    #if HAS_PRINT_PROGRESS && !DREW_PRINT_PROGRESS
+
       _draw_print_progress();
+
     #else
 
-    /// CUSTOM TO ADD REMAINING TIME TO PRUSA SCREEN - copied most of it from classic screen
-    {
-      #if ENABLED(SHOW_REMAINING_TIME)
-        char buffer[14];
-        uint8_t timepos = 0; 
-        const bool show_remain = TERN1(ROTATE_PROGRESS_DISPLAY, blink) && (printingIsActive() || marlin_state == MF_SD_COMPLETE);
-        if (show_remain) {
-          #if ENABLED(USE_M73_REMAINING_TIME)
-            duration_t remaining = get_remaining_time();
-          #else
-            uint8_t progress = get_progress_percent();
-            uint32_t elapsed = print_job_timer.duration();
-            duration_t remaining = (progress > 0) ? ((elapsed * 25600 / progress) >> 8) - elapsed : 0;
-          #endif
-          const uint8_t len = remaining.toDigital(buffer);
-          timepos = LCD_WIDTH - 4 - len;
-          lcd_put_wchar(timepos, 2, 'R');
-        }
-        if (!show_remain) { 
-          duration_t elapsed = print_job_timer.duration();
-          const uint8_t len = elapsed.toDigital(buffer);
-          timepos = LCD_WIDTH - 4 - len;
-          lcd_put_wchar(timepos, 2, LCD_STR_CLOCK[0]);
-        }
-        lcd_put_u8str(buffer);
+      (void)draw_elapsed_or_remaining_time(LCD_WIDTH - 4);
 
-      #else // original block
-        duration_t elapsed = print_job_timer.duration();
-        char buffer[14];
-        (void)elapsed.toDigital(buffer);
-        lcd_put_wchar(LCD_STR_CLOCK[0]);
-        lcd_put_u8str(buffer);
-      #endif
-    }
     #endif
+
   #endif // LCD_INFO_SCREEN_STYLE 1
 
   // ========= Last Line ========


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Prusa style LCD for marlin didn't have conditional statements for SHOW_REMAINING_TIME nor USE_M73_REMAINING_TIME

I modified the specific block from the classic screen and adjusted the "timepos = LCD_WIDTH - 4 - len;" to keep it aligned.

### Benefits

This is to bring features for show remaining time and use m73 for those who prefer using the Prusa Screen layout. There weren't conditional statements set to enable this, but it's already part of the classic screen

### Configurations

depending on your setup, just enable
SHOW_REMAINING_TIME 
USE_M73_REMAINING_TIME

### Related Issues

none at the moment, since the section of the code is copied from the stable classic mode
