### PR TITLE
Go to File Browser on Media Insert (option)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1189,6 +1189,8 @@
 
   //#define MENU_ADDAUTOSTART               // Add a menu option to run auto#.g files
 
+  //#define SD_AUTOOPEN_MENU                // Automatically open sd card menu when inserted like Prusa Firmware
+
   #define EVENT_GCODE_SD_ABORT "G28XY"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
 
   #if ENABLED(PRINTER_EVENT_LEDS)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1189,7 +1189,7 @@
 
   //#define MENU_ADDAUTOSTART               // Add a menu option to run auto#.g files
 
-  //#define SD_AUTOOPEN_MENU                // Automatically open sd card menu when inserted like Prusa Firmware
+  //#define BROWSE_MEDIA_ON_INSERT          // Open the file browser when media is inserted
 
   #define EVENT_GCODE_SD_ABORT "G28XY"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
 

--- a/Marlin/src/feature/password/password.h
+++ b/Marlin/src/feature/password/password.h
@@ -47,7 +47,7 @@ public:
     static void start_over();
 
     static void digit_entered();
-    static void set_password_done();
+    static void set_password_done(const bool with_set=true);
     static void menu_password_report();
 
     static void remove_password();

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -769,12 +769,8 @@ private:
 
   #if ENABLED(PASSWORD_FEATURE)
     static void M510();
-    #if ENABLED(PASSWORD_UNLOCK_GCODE)
-      static void M511();
-    #endif
-    #if ENABLED(PASSWORD_CHANGE_GCODE)
-      static void M512();
-    #endif
+    TERN_(PASSWORD_UNLOCK_GCODE, static void M511());
+    TERN_(PASSWORD_CHANGE_GCODE, static void M512());
   #endif
 
   TERN_(SDSUPPORT, static void M524());

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2202,13 +2202,6 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #endif
 
 /**
- * Make sure PASSWORD_FEATURE is not enabled with SD_AUTOOPEN_MENU
- */
-#if BOTH(SD_AUTOOPEN_MENU, PASSWORD_FEATURE)
-  #error SD_AUTOOPEN_MENU might not work with PASSWORD_FEATURE
-#endif
-
-/**
  * Make sure only one display is enabled
  */
 #if 1 < 0 \

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2204,7 +2204,7 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 /**
  * Make sure PASSWORD_FEATURE is not enabled with SD_AUTOOPEN_MENU
  */
-#if ENABLED(SD_AUTOOPEN_MENU) && ENABLED(PASSWORD_FEATURE)
+#if BOTH(SD_AUTOOPEN_MENU, PASSWORD_FEATURE)
   #error SD_AUTOOPEN_MENU might not work with PASSWORD_FEATURE
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2202,6 +2202,13 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #endif
 
 /**
+ * Make sure PASSWORD_FEATURE is not enabled with SD_AUTOOPEN_MENU
+ */
+#if ENABLED(SD_AUTOOPEN_MENU) && ENABLED(PASSWORD_FEATURE)
+  #error SD_AUTOOPEN_MENU might not work with PASSWORD_FEATURE
+#endif
+
+/**
  * Make sure only one display is enabled
  */
 #if 1 < 0 \

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1620,7 +1620,12 @@ void MarlinUI::update() {
     if (status) {
       if (old_status < 2) {
         TERN_(EXTENSIBLE_UI, ExtUI::onMediaInserted()); // ExtUI response
-        set_status_P(GET_TEXT(MSG_MEDIA_INSERTED));
+        #if ENABLED(SD_AUTOOPEN_MENU)
+          quick_feedback();
+          goto_screen(menu_media);
+        #else
+          set_status_P(GET_TEXT(MSG_MEDIA_INSERTED));
+        #endif
       }
     }
     else {

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -30,6 +30,10 @@
   #include "../feature/host_actions.h"
 #endif
 
+#if ENABLED(PASSWORD_ON_SD_PRINT_MENU)
+  #include "../feature/password/password.h"
+#endif
+
 // All displays share the MarlinUI class
 #include "marlinui.h"
 MarlinUI ui;
@@ -1620,9 +1624,9 @@ void MarlinUI::update() {
     if (status) {
       if (old_status < 2) {
         TERN_(EXTENSIBLE_UI, ExtUI::onMediaInserted()); // ExtUI response
-        #if ENABLED(SD_AUTOOPEN_MENU)
+        #if ENABLED(BROWSE_MEDIA_ON_INSERT)
           quick_feedback();
-          goto_screen(menu_media);
+          goto_screen(TERN(PASSWORD_ON_SD_PRINT_MENU, password.media_gatekeeper, menu_media));
         #else
           set_status_P(GET_TEXT(MSG_MEDIA_INSERTED));
         #endif

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -30,7 +30,7 @@
   #include "../feature/host_actions.h"
 #endif
 
-#if ENABLED(PASSWORD_ON_SD_PRINT_MENU)
+#if ENABLED(BROWSE_MEDIA_ON_INSERT, PASSWORD_ON_SD_PRINT_MENU)
   #include "../feature/password/password.h"
 #endif
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1626,7 +1626,7 @@ void MarlinUI::update() {
         TERN_(EXTENSIBLE_UI, ExtUI::onMediaInserted()); // ExtUI response
         #if ENABLED(BROWSE_MEDIA_ON_INSERT)
           quick_feedback();
-          goto_screen(TERN(PASSWORD_ON_SD_PRINT_MENU, password.media_gatekeeper, menu_media));
+          goto_screen(MEDIA_MENU_GATEWAY);
         #else
           set_status_P(GET_TEXT(MSG_MEDIA_INSERTED));
         #endif

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -312,6 +312,7 @@ public:
   static void clear_lcd();
 
   #if ENABLED(SDSUPPORT)
+    #define MEDIA_MENU_GATEWAY TERN(PASSWORD_ON_SD_PRINT_MENU, password.media_gatekeeper, menu_media)
     static void media_changed(const uint8_t old_stat, const uint8_t stat);
   #endif
 

--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -354,6 +354,7 @@ class MenuItem_bool : public MenuEditItemBase {
 #define MENU_ITEM_P(TYPE, PLABEL, V...)                 _MENU_ITEM_P(TYPE, false, PLABEL, ##V)
 #define MENU_ITEM(TYPE, LABEL, V...)                     MENU_ITEM_P(TYPE, GET_TEXT(LABEL), ##V)
 
+#define BACK_ITEM_P(PLABEL)                              MENU_ITEM_P(back, PLABEL)
 #define BACK_ITEM(LABEL)                                   MENU_ITEM(back, LABEL)
 
 #define ACTION_ITEM_N_S_P(N, S, PLABEL, ACTION)      MENU_ITEM_N_S_P(function, N, S, PLABEL, ACTION)

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -141,7 +141,7 @@ void menu_main() {
 
       if (card_detected) {
         if (!card_open) {
-          SUBMENU(MSG_MEDIA_MENU, TERN(PASSWORD_ON_SD_PRINT_MENU, password.media_gatekeeper, menu_media));
+          SUBMENU(MSG_MEDIA_MENU, MEDIA_MENU_GATEWAY);
           #if PIN_EXISTS(SD_DETECT)
             GCODES_ITEM(MSG_CHANGE_MEDIA, M21_STR);
           #else
@@ -248,7 +248,7 @@ void menu_main() {
           #else
             GCODES_ITEM(MSG_RELEASE_MEDIA, PSTR("M22"));
           #endif
-          SUBMENU(MSG_MEDIA_MENU, TERN(PASSWORD_ON_SD_PRINT_MENU, password.media_gatekeeper, menu_media));
+          SUBMENU(MSG_MEDIA_MENU, MEDIA_MENU_GATEWAY);
         }
       }
       else {

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -104,6 +104,8 @@ class MenuItem_sdfolder : public MenuItem_sdbase {
     }
 };
 
+extern uint8_t screen_history_depth;
+
 void menu_media() {
   ui.encoder_direction_menus();
 
@@ -115,7 +117,7 @@ void menu_media() {
   #endif
 
   START_MENU();
-  BACK_ITEM(MSG_MAIN);
+  BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
   if (card.flag.workDirIsRoot) {
     #if !PIN_EXISTS(SD_DETECT)
       ACTION_ITEM(MSG_REFRESH, []{ encoderTopLine = 0; card.mount(); });

--- a/Marlin/src/lcd/menu/menu_password.cpp
+++ b/Marlin/src/lcd/menu/menu_password.cpp
@@ -152,19 +152,17 @@ void Password::menu_password_report() {
   END_SCREEN();
 }
 
-void Password::set_password_done() {
-  is_set = true;
+void Password::set_password_done(const bool with_set/*=true*/) {
+  is_set = with_set;
   value = value_entry;
   ui.completion_feedback(true);
   ui.goto_screen(menu_password_report);
 }
 
 void Password::remove_password() {
-  is_set = false;
   string[0] = '0';
   string[1] = '\0';
-  ui.completion_feedback(true);
-  ui.goto_screen(menu_password_report);
+  set_password_done(false);
 }
 
 //


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Added SD_AUTOOPEN_MENU to the Configuration_adv.h when plugged so you don't have to scroll all the way down for those using the old classic lcd screens when you plug an SD card and open Print from media. This has only been tested on a REPRAP_DISCOUNT_SMART_CONTROLLER type of lcd.

video here
https://youtu.be/HLcYCQ0gGkA

### Benefits

Better Quality of Life with SD card insert and ejection

### Configurations

Configuration.h
REPRAP_DISCOUNT_SMART_CONTROLLER

Configuration_adv.h
Enable SDSUPPORT
and uncomment
SD_AUTOOPEN_MENU

### Related Issues

This was a feature originally part of the prusa firmware and I just added a few lines to do the same function. I'm not sure if it might conflict with other features / lcds yet

EDIT: I don't think this should work with the SD card password feature. ~~I should make a sanity check soon.~~ Done.