### PR TITLE
Allow overriding servo pin for MKS Robin Mini

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_MINI.h
@@ -111,7 +111,9 @@
 #define POWER_LOSS_PIN                      PA2   // PW_DET
 #define PS_ON_PIN                           PA3   // PW_OFF
 
-#define SERVO0_PIN                          PA8   // Enable BLTOUCH support on IO0 (WIFI connector)
+#ifndef SERVO0_PIN
+  #define SERVO0_PIN                        PA8   // Enable BLTOUCH support on IO0 (WIFI connector)
+#endif
 
 #define MT_DET_1_PIN                        PA4
 #define MT_DET_PIN_INVERTING               false


### PR DESCRIPTION
### Description

Robin Mini does not have a dedicated Servo pin. The default config uses a pin on the wifi connector, precluding the use of BLTouch and Wifi together.

### Benefits

This allows users to override the default if they want to use both a BLTouch and Wifi. The referenced issue describes a good alternative.

### Configurations

N/A

### Related Issues

#19392 - Suggest to consider using PIN PB2 (Reserved Connector pin) instead of PA8 (WiFI IO0 pin) for BLTouch
