### PR TITLE
Respect MANUAL_PROBE_START_Z in UBL

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -62,7 +62,7 @@ class unified_bed_leveling {
     #if IS_NEWPANEL
       static void move_z_with_encoder(const float &multiplier);
       static float measure_point_with_encoder();
-      static float measure_business_card_thickness(float in_height);
+      static float measure_business_card_thickness();
       static void manually_probe_remaining_mesh(const xy_pos_t&, const float&, const float&, const bool) _O0;
       static void fine_tune_mesh(const xy_pos_t &pos, const bool do_ubl_mesh_map) _O0;
     #endif

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -484,7 +484,7 @@
             }
 
             if (parser.seen('B')) {
-              g29_card_thickness = parser.has_value() ? parser.value_float() : measure_business_card_thickness(float(Z_CLEARANCE_BETWEEN_PROBES));
+              g29_card_thickness = parser.has_value() ? parser.value_float() : measure_business_card_thickness();
               if (ABS(g29_card_thickness) > 1.5f) {
                 SERIAL_ECHOLNPGM("?Error in Business Card measurement.");
                 return;
@@ -837,11 +837,11 @@
 
     static void echo_and_take_a_measurement() { SERIAL_ECHOLNPGM(" and take a measurement."); }
 
-    float unified_bed_leveling::measure_business_card_thickness(float in_height) {
+    float unified_bed_leveling::measure_business_card_thickness() {
       ui.capture();
       save_ubl_active_state_and_disable();   // Disable bed level correction for probing
 
-      do_blocking_move_to(0.5f * (MESH_MAX_X - (MESH_MIN_X)), 0.5f * (MESH_MAX_Y - (MESH_MIN_Y)), in_height);
+      do_blocking_move_to(0.5f * (MESH_MAX_X - (MESH_MIN_X)), 0.5f * (MESH_MAX_Y - (MESH_MIN_Y)), MANUAL_PROBE_START_Z);
         //, _MIN(planner.settings.max_feedrate_mm_s[X_AXIS], planner.settings.max_feedrate_mm_s[Y_AXIS]) * 0.5f);
       planner.synchronize();
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2583,7 +2583,7 @@
 #endif
 
 #if !defined(MANUAL_PROBE_START_Z) && defined(Z_CLEARANCE_BETWEEN_PROBES)
-  #define MANUAL_PROBE_START_Z (Z_CLEARANCE_BETWEEN_PROBES)
+  #define MANUAL_PROBE_START_Z Z_CLEARANCE_BETWEEN_PROBES
 #endif
 
 #ifndef __SAM3X8E__ //todo: hal: broken hal encapsulation

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2582,6 +2582,10 @@
   #endif
 #endif
 
+#if !defined(MANUAL_PROBE_START_Z) && defined(Z_CLEARANCE_BETWEEN_PROBES)
+  #define MANUAL_PROBE_START_Z (Z_CLEARANCE_BETWEEN_PROBES)
+#endif
+
 #ifndef __SAM3X8E__ //todo: hal: broken hal encapsulation
   #undef UI_VOLTAGE_LEVEL
   #undef RADDS_DISPLAY


### PR DESCRIPTION
### Description

`PROBE_MANUALLY` and UBL have a complex relationship. Enabling UBL implicitly _disables_ `PROBE_MANUALLY`, because UBL has its own manual probing mechanism.

Unfortunately this also causes the `MANUAL_PROBE_START_Z` to be ignored, since it wasn't originally added to UBL.

This change modified UBL to use `MANUAL_PROBE_START_Z`, and falls back to `Z_CLEARANCE_BETWEEN_PROBES` if it is available.

### Benefits

Allows users to reduce the amount of time they spend spinning their encoder wheels!

### Configurations

The following configs are for use in the simulator. Real configs are available from the referenced issue.
[Marlin.zip](https://github.com/MarlinFirmware/Marlin/files/5545230/Marlin.zip)

### Related Issues

#19795 - UBL with PROBE_MANUALLY doesn't lower to MANUAL_PROBE_START_Z and stays at Z_CLEARANCE_BETWEEN_PROBES
