### PR TITLE
Multi-Hotend Preheat Fixes

### DIFF
--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -108,9 +108,8 @@ void Temperature::lcd_preheat(const int16_t e, const int8_t indh, const int8_t i
 
         HOTEND_LOOP() PREHEAT_ITEMS(editable.int8, e);
         ACTION_ITEM_S(ui.get_preheat_label(m), MSG_PREHEAT_M_ALL, []() {
-          TERN_(HAS_HEATED_BED, []{ _preheat_bed(editable.int8); });
           HOTEND_LOOP() thermalManager.setTargetHotend(ui.material_preset[editable.int8].hotend_temp, e);
-          ui.return_to_status();
+          TERN(HAS_HEATED_BED, _preheat_bed(editable.int8), ui.return_to_status());
         });
 
       #endif

--- a/Marlin/src/lcd/menu/menu_temperature.cpp
+++ b/Marlin/src/lcd/menu/menu_temperature.cpp
@@ -110,6 +110,7 @@ void Temperature::lcd_preheat(const int16_t e, const int8_t indh, const int8_t i
         ACTION_ITEM_S(ui.get_preheat_label(m), MSG_PREHEAT_M_ALL, []() {
           TERN_(HAS_HEATED_BED, []{ _preheat_bed(editable.int8); });
           HOTEND_LOOP() thermalManager.setTargetHotend(ui.material_preset[editable.int8].hotend_temp, e);
+          ui.return_to_status();
         });
 
       #endif


### PR DESCRIPTION
### Description

Return to Status Screen after using "Preheat (material) All" menu on multi-hotend setups and fix bed preheat with @rhapsodyv's fix below.

### Benefits

Return to Status Screen similar to how preheating with a single extruder currently works and preheat the bed when selecting "Preheat (material) All".

### Configurations

Use configs from #20163/any multi-hotend setup.

### Related Issues

#20163
