### PR TITLE
Enable E3 Turbo Onboard Thermistor as Chamber Pin

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -161,7 +161,9 @@
 //
 #define TEMP_0_PIN                         P0_24
 #define TEMP_1_PIN                         P0_23
-//#define TEMP_2_PIN                       P1_30  // Onboard thermistor
+#ifdef TEMP_SENSOR_CHAMBER
+  #define TEMP_CHAMBER_PIN                 P1_30  // Onboard thermistor
+#endif
 #define TEMP_BED_PIN                       P0_25
 
 //

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -161,7 +161,7 @@
 //
 #define TEMP_0_PIN                         P0_24
 #define TEMP_1_PIN                         P0_23
-#ifdef TEMP_SENSOR_CHAMBER
+#if ENABLED(TEMP_SENSOR_CHAMBER)
   #define TEMP_CHAMBER_PIN                 P1_30  // Onboard thermistor
 #endif
 #define TEMP_BED_PIN                       P0_25


### PR DESCRIPTION
### Description

Enable the E3 Turbo's onboard thermistor as a chamber pin until onboard/motherboard-based thermistors are supported (See my feature request in https://github.com/MarlinFirmware/Marlin/issues/20175).

Enable `TEMP_SENSOR_CHAMBER` and set it to 1 to enable LCD readings of the onboard thermistor.

### Benefits

Interim support for onboard thermistor readings.

### Configurations

Any E3 Turbo config from [MarlinFirmware/Configurations/config/examples/Creality/Ender-3/BigTreeTech SKR E3 Turbo](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Creality/Ender-3/BigTreeTech%20SKR%20E3%20Turbo), but enable `TEMP_SENSOR_CHAMBER` and set it to 1.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/20175