### PR TITLE
Allow COLOR_UI be used without TOUCH_SCREEN

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -169,7 +169,9 @@
     if (ui.should_draw()) {
       MenuItem_static::draw(1, GET_TEXT(MSG_LEVEL_BED_WAITING));
       // Color UI needs a control to detect a touch
-      TERN_(HAS_GRAPHICAL_TFT, touch.add_control(CLICK, 0, 0, TFT_WIDTH, TFT_HEIGHT));
+      #if BOTH(TOUCH_SCREEN, HAS_GRAPHICAL_TFT)
+        touch.add_control(CLICK, 0, 0, TFT_WIDTH, TFT_HEIGHT);
+      #endif
     }
     if (ui.use_click()) {
       manual_probe_index = 0;

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -49,7 +49,9 @@
   #error "Seriously? High resolution TFT screen without menu?"
 #endif
 
-static bool draw_menu_navigation = false;
+#if ENABLED(TOUCH_SCREEN)
+  static bool draw_menu_navigation = false;
+#endif
 
 void MarlinUI::tft_idle() {
   #if ENABLED(TOUCH_SCREEN)
@@ -897,35 +899,37 @@ static void z_minus() {
   moveAxis(Z_AXIS, -1);
 }
 
-static void e_select() {
-  motionAxisState.e_selection++;
-  if (motionAxisState.e_selection >= EXTRUDERS) {
-    motionAxisState.e_selection = 0;
+#if ENABLED(TOUCH_SCREEN)
+  static void e_select() {
+    motionAxisState.e_selection++;
+    if (motionAxisState.e_selection >= EXTRUDERS) {
+      motionAxisState.e_selection = 0;
+    }
+
+    quick_feedback();
+    drawCurESelection();
+    drawAxisValue(E_AXIS);
   }
 
-  quick_feedback();
-  drawCurESelection();
-  drawAxisValue(E_AXIS);
-}
+  static void do_home() {
+    quick_feedback();
+    drawMessage(GET_TEXT(MSG_LEVEL_BED_HOMING));
+    queue.inject_P(G28_STR);
+    // Disable touch until home is done
+    TERN_(HAS_TFT_XPT2046, touch.disable());
+    drawAxisValue(E_AXIS);
+    drawAxisValue(X_AXIS);
+    drawAxisValue(Y_AXIS);
+    drawAxisValue(Z_AXIS);
+  }
 
-static void do_home() {
-  quick_feedback();
-  drawMessage(GET_TEXT(MSG_LEVEL_BED_HOMING));
-  queue.inject_P(G28_STR);
-  // Disable touch until home is done
-  TERN_(HAS_TFT_XPT2046, touch.disable());
-  drawAxisValue(E_AXIS);
-  drawAxisValue(X_AXIS);
-  drawAxisValue(Y_AXIS);
-  drawAxisValue(Z_AXIS);
-}
-
-static void step_size() {
-  motionAxisState.currentStepSize = motionAxisState.currentStepSize / 10.0;
-  if (motionAxisState.currentStepSize < 0.0015) motionAxisState.currentStepSize = 10.0;
-  quick_feedback();
-  drawCurStepValue();
-}
+  static void step_size() {
+    motionAxisState.currentStepSize = motionAxisState.currentStepSize / 10.0;
+    if (motionAxisState.currentStepSize < 0.0015) motionAxisState.currentStepSize = 10.0;
+    quick_feedback();
+    drawCurStepValue();
+  }
+#endif
 
 #if HAS_BED_PROBE
   static void z_select() {
@@ -1021,7 +1025,7 @@ void MarlinUI::move_axis_screen() {
   motionAxisState.zTypePos.x = x;
   motionAxisState.zTypePos.y = y;
   drawCurZSelection();
-  #if HAS_BED_PROBE
+  #if BOTH(HAS_BED_PROBE, TOUCH_SCREEN)
     if (!busy) touch.add_control(BUTTON, x, y, BTN_WIDTH, 34 * 2, (intptr_t)z_select);
   #endif
 

--- a/buildroot/tests/mks_robin_nano35-tests
+++ b/buildroot/tests/mks_robin_nano35-tests
@@ -65,5 +65,14 @@ opt_set X_DRIVER_TYPE TMC2209
 opt_set Y_DRIVER_TYPE TMC2209
 exec_test $1 $2 "MKS Robin v2 nano LVGL SPI + TMC"
 
+#
+# MKS Robin v2 nano New Color UI 480x320 SPI Without Touch Screen
+#
+use_example_configs Mks/Robin
+opt_set MOTHERBOARD BOARD_MKS_ROBIN_NANO_V2
+opt_disable TFT_INTERFACE_FSMC TFT_RES_320x240 TOUCH_SCREEN
+opt_enable TFT_INTERFACE_SPI TFT_RES_480x320 TFT_COLOR_UI
+exec_test $1 $2 "MKS Robin v2 nano New Color UI 480x320 SPI without TOUCH_SCREEN"
+
 # cleanup
 restore_configs


### PR DESCRIPTION
### Description

Fix #20172, allowing Color UI to be used without TOUCH_SCREEN.

### Benefits

Fix #20172

