### PR TITLE
Lower Ram Usage for Color UI on MKS S GEN L

### DIFF
--- a/Marlin/src/lcd/tft/tft_queue.cpp
+++ b/Marlin/src/lcd/tft/tft_queue.cpp
@@ -210,7 +210,7 @@ void TFT_Queue::set_background(uint16_t color) {
 #define QUEUE_SAFETY_FREE_SPACE 100
 
 void TFT_Queue::handle_queue_overflow(uint16_t sizeNeeded) {
-  if (uintptr_t(end_of_queue) + sizeNeeded + (QUEUE_SAFETY_FREE_SPACE) - uintptr_t(queue) >= QUEUE_SIZE) {
+  if (uintptr_t(end_of_queue) + sizeNeeded + (QUEUE_SAFETY_FREE_SPACE) - uintptr_t(queue) >= TFT_QUEUE_SIZE) {
     end_of_queue = queue;
     ((parametersCanvasText_t *)last_parameter)->nextParameter = end_of_queue;
   }

--- a/Marlin/src/lcd/tft/tft_queue.h
+++ b/Marlin/src/lcd/tft/tft_queue.h
@@ -25,7 +25,9 @@
 #include "tft_string.h"
 #include "tft_image.h"
 
-#define QUEUE_SIZE              8192
+#ifndef TFT_QUEUE_SIZE
+  #define TFT_QUEUE_SIZE              8192
+#endif
 
 enum QueueTaskType : uint8_t {
   TASK_END_OF_QUEUE = 0x00,
@@ -118,7 +120,7 @@ typedef struct __attribute__((__packed__)) {
 
 class TFT_Queue {
   private:
-    static uint8_t queue[QUEUE_SIZE];
+    static uint8_t queue[TFT_QUEUE_SIZE];
     static uint8_t *end_of_queue;
     static uint8_t *current_task;
     static uint8_t *last_task;

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -268,7 +268,8 @@
     #define LCD_PINS_ENABLE                -1
     #define LCD_PINS_RS                    -1
 
-    #define TFT_BUFFER_SIZE                 2400
+    #define TFT_BUFFER_SIZE                 1200
+    #define TFT_QUEUE_SIZE                  6144
 
     #define BTN_EN1                        P3_25
     #define BTN_EN2                        P3_26


### PR DESCRIPTION
### Description

When enabling a lot of features with Color UI on MKS S GEN L, it goes out of RAM. This PR add options to color ui uses less ram and configure S GEN L for that.

### Benefits

Less ram usage on MKS S GEN L.

### Related Issues

#20171 
