### PR TITLE
Minor fix to avoid division by zero, when using the simulator

### DIFF
--- a/Marlin/src/feature/leds/printer_event_leds.cpp
+++ b/Marlin/src/feature/leds/printer_event_leds.cpp
@@ -41,6 +41,7 @@ PrinterEventLEDs printerEventLEDs;
   uint8_t PrinterEventLEDs::old_intensity = 0;
 
   inline uint8_t pel_intensity(const float &start, const float &current, const float &target) {
+    if (uint16_t(start) == uint16_t(target)) return 255;
     return (uint8_t)map(constrain(current, start, target), start, target, 0.f, 255.f);
   }
 


### PR DESCRIPTION
### Description

The simulator showed up a bug in printer leds events. If it's called when target temp is equal to start temp, it leads to a division by zero on arduino map function.
Seems it only happens on the simulator because of the temperature "stability", or the simulated print speed.

### Benefits

Fix a hidden bug.

