### PR TITLE
Update mmu.cpp to fix compilation errors.

### DIFF
--- a/Marlin/src/feature/mmu/mmu.cpp
+++ b/Marlin/src/feature/mmu/mmu.cpp
@@ -20,7 +20,7 @@
  *
  */
 
-#include "../inc/MarlinConfig.h"
+#include "../../inc/MarlinConfig.h"
 
 #if HAS_PRUSA_MMU1
 


### PR DESCRIPTION


### Requirements


Compiling on platform.io is failling because of wrong path. Similar to #15106 only in different file now.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Fixes compiling errors on the bugfix-2.0 branch

### Configurations

bug seems platform indepentent. Howver I used big tree tech GTR 1.0

### Related Issues

#15106
