### PR TITLE
Abort print if media is removed while printing from SD

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -454,10 +454,17 @@ void CardReader::manage_media() {
     DEBUG_ECHOLNPGM("SD: No UI Detected.");
 }
 
+/**
+ * "Release" the media by clearing the 'mounted' flag.
+ * Used by M22, "Release Media", manage_media.
+ */
 void CardReader::release() {
   // Card removed while printing? Abort!
-  if (IS_SD_PRINTING()) card.flag.abort_sd_printing = true;
-  else endFilePrint();
+  if (IS_SD_PRINTING())
+    card.flag.abort_sd_printing = true;
+  else
+    endFilePrint();
+
   flag.mounted = false;
   flag.workDirIsRoot = true;
   #if ALL(SDCARD_SORT_ALPHA, SDSORT_USES_RAM, SDSORT_CACHE_NAMES)
@@ -465,6 +472,10 @@ void CardReader::release() {
   #endif
 }
 
+/**
+ * Open a G-code file and set Marlin to start processing it.
+ * Enqueues M23 and M24 commands to initiate a media print.
+ */
 void CardReader::openAndPrintFile(const char *name) {
   char cmd[4 + strlen(name) + 1]; // Room for "M23 ", filename, and null
   extern const char M23_STR[];
@@ -474,6 +485,12 @@ void CardReader::openAndPrintFile(const char *name) {
   queue.enqueue_now_P(M24_STR);
 }
 
+/**
+ * Start or resume a media print by setting the sdprinting flag.
+ * The file browser pre-sort is also purged to free up memory,
+ * since you cannot browse files during active printing.
+ * Used by M24 and anywhere Start / Resume applies.
+ */
 void CardReader::startFileprint() {
   if (isMounted()) {
     flag.sdprinting = true;
@@ -481,6 +498,9 @@ void CardReader::startFileprint() {
   }
 }
 
+//
+// Run tasks upon finishing or aborting a file print.
+//
 void CardReader::endFilePrint(TERN_(SD_RESORT, const bool re_sort/*=false*/)) {
   TERN_(ADVANCED_PAUSE_FEATURE, did_pause_print = 0);
   TERN_(DWIN_CREALITY_LCD, HMI_flag.print_finish = flag.sdprinting);

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -455,7 +455,9 @@ void CardReader::manage_media() {
 }
 
 void CardReader::release() {
-  endFilePrint();
+  // Card removed while printing? Abort!
+  if (IS_SD_PRINTING()) card.flag.abort_sd_printing = true;
+  else endFilePrint();
   flag.mounted = false;
   flag.workDirIsRoot = true;
   #if ALL(SDCARD_SORT_ALPHA, SDSORT_USES_RAM, SDSORT_CACHE_NAMES)


### PR DESCRIPTION
### Description

If you are printing from SD and get the media removed, marlin enter in an invalid state, half printing, halt not printing. It even keep heaters on.

This PR detect if the SD was removed during a SD printing, and abort correctly the printing, keeping marlin in a right state.

Another option would be just send the user to a kill screen with a message. But I think that just abort the current printing is enough.

### Benefits

Fix #15390 

### Related Issues

#15390 
#20186
#20168 
