### PR TITLE
Fix Fil. Change labels with Extruder > 1

### DIFF
--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -91,7 +91,7 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
   BACK_ITEM(MSG_BACK);
   #if PREHEAT_COUNT
     LOOP_L_N(m, PREHEAT_COUNT)
-      ACTION_ITEM_N_S(m, ui.get_preheat_label(m), MSG_PREHEAT_M, _change_filament_with_preset);
+      ACTION_ITEM_N_S(extruder, ui.get_preheat_label(m), MSG_PREHEAT_M, _change_filament_with_preset);
   #endif
   EDIT_ITEM_FAST_N(int3, extruder, MSG_PREHEAT_CUSTOM, &thermalManager.temp_hotend[extruder].target,
     EXTRUDE_MINTEMP, thermalManager.heater_maxtemp[extruder] - HOTEND_OVERSHOOT,


### PR DESCRIPTION
### Description

The code from this menu uses `MenuItemBase::itemIndex` to keep track of the current selected extruder. The problem is that it get overwritten `_menu_temp_filament_op` by this loop:
```cpp
    LOOP_L_N(m, PREHEAT_COUNT)
      ACTION_ITEM_N_S(extruder, ui.get_preheat_label(m), MSG_PREHEAT_M, _change_filament_with_preset);
```

If the screen is big enough to hold all the menu, it will not be a problem, because marlin um call `SUBMENU_N_P(s, msg, []{ _menu_temp_filament_op(` using the same parameters, and everything will be reseted to the right values.
But if the screen is smaller, as 20x4, it will get called with different parameters because of the next menu page.

The fix is simple (but hard to track down!!), we don't use `MenuItemBase::itemIndex` in the `ACTION_ITEM_N_S` loop, so we can just keep fixed it with the right extruder value.

### Benefits

Fix #20154 

### Related Issues

#20154
