### PR TITLE
Use the proper pin on EXP1 connector Fysetc MINI12864 2.1 Neopixel-based backlight on BTT GTR 1.0

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -381,7 +381,7 @@
           #define RGB_LED_B_PIN             PG5
         #endif
       #elif ENABLED(FYSETC_MINI_12864_2_1)
-        #define NEOPIXEL_PIN                PF13
+        #define NEOPIXEL_PIN                PG7
       #endif
     #endif // !FYSETC_MINI_12864
 


### PR DESCRIPTION
### Description

This changes the pin used for Fysetc MINI12864 2.1 Neopixel-based backlight to the one on the EXT1 connector, instead of the one on GTR 1.0 Neopixel connector.

### Benefits

Working backlight!

### Configurations

1. Enable `FYSETC_MINI_12864_2_1` and `NEOPIXEL_LED` on BTT GTR 1.0.
2. Enjoy the thermonuclear explosion of colors.
