### PR TITLE
Fix setDrvPct() in DAC stuff

### DIFF
--- a/Marlin/src/feature/dac/dac_mcp4728.cpp
+++ b/Marlin/src/feature/dac/dac_mcp4728.cpp
@@ -123,8 +123,8 @@ uint8_t MCP4728::getDrvPct(const uint8_t channel) { return uint8_t(100.0 * dac_v
  * Receives all Drive strengths as 0-100 percent values, updates
  * DAC Values array and calls fastwrite to update the DAC.
  */
-void MCP4728::setDrvPct(xyze_uint8_t &pct) {
-  dac_values *= pct.asFloat() * 0.01f * (DAC_STEPPER_MAX);
+void MCP4728::setDrvPct(xyze_uint_t &pct) {
+  dac_values = pct * (DAC_STEPPER_MAX * 0.01f);
   fastWrite();
 }
 

--- a/Marlin/src/feature/dac/dac_mcp4728.cpp
+++ b/Marlin/src/feature/dac/dac_mcp4728.cpp
@@ -124,7 +124,7 @@ uint8_t MCP4728::getDrvPct(const uint8_t channel) { return uint8_t(100.0 * dac_v
  * DAC Values array and calls fastwrite to update the DAC.
  */
 void MCP4728::setDrvPct(xyze_uint_t &pct) {
-  dac_values = pct * (DAC_STEPPER_MAX * 0.01f);
+  dac_values = pct * (DAC_STEPPER_MAX) * 0.01f;
   fastWrite();
 }
 

--- a/Marlin/src/feature/dac/dac_mcp4728.h
+++ b/Marlin/src/feature/dac/dac_mcp4728.h
@@ -76,7 +76,7 @@ public:
   static uint8_t  fastWrite();
   static uint8_t  simpleCommand(const byte simpleCommand);
   static uint8_t  getDrvPct(const uint8_t channel);
-  static void     setDrvPct(xyze_uint8_t &pct);
+  static void     setDrvPct(xyze_uint_t &pct);
 };
 
 extern MCP4728 mcp4728;

--- a/Marlin/src/feature/dac/stepper_dac.cpp
+++ b/Marlin/src/feature/dac/stepper_dac.cpp
@@ -73,7 +73,7 @@ void StepperDAC::set_current_percent(const uint8_t channel, float val) {
 }
 
 static float dac_perc(int8_t n) { return mcp4728.getDrvPct(dac_order[n]); }
-static float dac_amps(int8_t n) { return mcp4728.getValue(dac_order[n]) / 1000.0; }
+static float dac_amps(int8_t n) { return mcp4728.getValue(dac_order[n]) * 0.125 * RECIPROCAL(DAC_STEPPER_SENSE * 1000); }
 
 uint8_t StepperDAC::get_current_percent(const AxisEnum axis) { return mcp4728.getDrvPct(dac_order[axis]); }
 void StepperDAC::set_current_percents(xyze_uint8_t &pct) {

--- a/Marlin/src/feature/dac/stepper_dac.cpp
+++ b/Marlin/src/feature/dac/stepper_dac.cpp
@@ -33,7 +33,7 @@
 
 bool dac_present = false;
 constexpr xyze_uint8_t dac_order = DAC_STEPPER_ORDER;
-xyze_uint8_t dac_channel_pct = DAC_MOTOR_CURRENT_DEFAULT;
+xyze_uint_t dac_channel_pct = DAC_MOTOR_CURRENT_DEFAULT;
 
 StepperDAC stepper_dac;
 
@@ -72,8 +72,8 @@ void StepperDAC::set_current_percent(const uint8_t channel, float val) {
   set_current_value(channel, _MIN(val, 100.0f) * (DAC_STEPPER_MAX) / 100.0f);
 }
 
-static float dac_perc(int8_t n) { return 100.0 * mcp4728.getValue(dac_order[n]) * RECIPROCAL(DAC_STEPPER_MAX); }
-static float dac_amps(int8_t n) { return mcp4728.getDrvPct(dac_order[n]) * (DAC_STEPPER_MAX) * 0.125 * RECIPROCAL(DAC_STEPPER_SENSE); }
+static float dac_perc(int8_t n) { return mcp4728.getDrvPct(dac_order[n]); }
+static float dac_amps(int8_t n) { return mcp4728.getValue(dac_order[n]) / 1000.0; }
 
 uint8_t StepperDAC::get_current_percent(const AxisEnum axis) { return mcp4728.getDrvPct(dac_order[axis]); }
 void StepperDAC::set_current_percents(xyze_uint8_t &pct) {


### PR DESCRIPTION
Hi,

This PR fixes `setDrvPct()` and use the right methods at the right places to display values through **M909** (in percent and in Amps).
It leads to fix :
- dac initialization if no previous dac eeprom config.
- motor power in percent change from screen.

This is related to the issue #20116 .

_Note: In the issue description, i stated the way the initialization works is not what is expected . I was wrong as it must respect the previous dac eeprom config if any so no change on this part._

Regards,
Orel