### PR TITLE
Allow LPC Upload Script Run without Admin Privileges on Windows

### DIFF
--- a/Marlin/src/HAL/LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -12,20 +12,8 @@ import os
 import getpass
 import platform
 
-
 current_OS = platform.system()
 Import("env")
-
-# getting from https://stackoverflow.com/questions/827371/is-there-a-way-to-list-all-the-available-drive-letters-in-python
-def get_drives():
-    drives = []
-    bitmask = windll.kernel32.GetLogicalDrives()
-    for letter in string.ascii_uppercase:
-        if bitmask & 1:
-            drives.append(letter)
-        bitmask >>= 1
-
-    return drives
 
 def print_error(e):
 	print('\nUnable to find destination disk (%s)\n' \
@@ -46,17 +34,24 @@ try:
 		import subprocess
 		from ctypes import windll
 		import string
+
 		# getting list of drives
-		drives = get_drives()
+		# https://stackoverflow.com/questions/827371/is-there-a-way-to-list-all-the-available-drive-letters-in-python
+		drives = []
+		bitmask = windll.kernel32.GetLogicalDrives()
+		for letter in string.ascii_uppercase:
+			if bitmask & 1:
+				drives.append(letter)
+			bitmask >>= 1
 
 		upload_disk = 'Disk not found'
 		target_file_found = False
 		target_drive_found = False
 		for drive in drives:
 			final_drive_name = drive + ':\\' 
-			print ('disc check: {}'.format(final_drive_name))
+			# print ('disc check: {}'.format(final_drive_name))
 			try:
-				volume_info = str(subprocess.check_output('cmd /C dir ' + final_drive_name, stderr=subprocess.STDOUT))				
+				volume_info = str(subprocess.check_output('cmd /C dir ' + final_drive_name, stderr=subprocess.STDOUT))
 			except Exception as e:
 				print ('error:{}'.format(e))
 				continue

--- a/Marlin/src/HAL/LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -11,8 +11,7 @@ target_drive = "REARM"
 import os
 import getpass
 import platform
-from ctypes import windll
-import string
+
 
 current_OS = platform.system()
 Import("env")
@@ -45,6 +44,8 @@ try:
 		# get all drives on this computer
 		#
 		import subprocess
+		from ctypes import windll
+		import string
 		# getting list of drives
 		drives = get_drives()
 

--- a/Marlin/src/HAL/LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -23,6 +23,9 @@ def print_error(e):
 		  %(e, env.get('PIOENV')))
 
 try:
+	#
+	# Find a disk for upload
+	#
 	upload_disk = 'Disk not found'
 	target_file_found = False
 	target_drive_found = False
@@ -30,9 +33,6 @@ try:
 		#
 		# platformio.ini will accept this for a Windows upload port designation: 'upload_port = L:'
 		#   Windows - doesn't care about the disk's name, only cares about the drive letter
-		#
-		# get all drives on this computer
-		#
 		import subprocess
 		from ctypes import windll
 		import string
@@ -55,11 +55,11 @@ try:
 				print ('error:{}'.format(e))
 				continue
 			else:
-				if target_drive in volume_info and target_file_found == False:  # set upload if not found target file yet
+				if target_drive in volume_info and not target_file_found:  # set upload if not found target file yet
 					target_drive_found = True
 					upload_disk = final_drive_name
 				if target_filename in volume_info:
-					if target_file_found == False:
+					if not target_file_found:
 						upload_disk = final_drive_name
 					target_file_found = True
 
@@ -96,7 +96,7 @@ try:
 		# platformio.ini will accept this for a OSX upload port designation: 'upload_port = /media/media_name/drive'
 		#
 		drives = os.listdir('/Volumes')  # human readable names
-		if target_drive in drives and target_file_found == False:  # set upload if not found target file yet
+		if target_drive in drives and not target_file_found:  # set upload if not found target file yet
 			target_drive_found = True
 			upload_disk = '/Volumes/' + target_drive + '/'
 		for drive in drives:
@@ -106,7 +106,7 @@ try:
 				continue
 			else:
 				if target_filename in filenames:
-					if target_file_found == False:
+					if not target_file_found:
 						upload_disk = '/Volumes/' + drive + '/'
 					target_file_found = True
 


### PR DESCRIPTION
### Description

The upload script that should define the drive to upload action is not worked. I saw the error message Command 'fsutil fsinfo drives' returned non-zero exit status 1.
After analysis, I found the problem in the  permissions to run fsutil. After that I change the method of getting the drives list.

### Benefits

Now upload command for LPC1786 works WO admin privileges.

### Configurations

Anything for LPC1786 

### Related Issues

Platform IO upload command for LPC1786  not works wo admin privileges, on win 7
