### PR TITLE
Reduce RAM usage for TFT Color UI on SGen-L V2

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -268,8 +268,12 @@
     #define LCD_PINS_ENABLE                -1
     #define LCD_PINS_RS                    -1
 
-    #define TFT_BUFFER_SIZE                 1200
-    #define TFT_QUEUE_SIZE                  6144
+    #ifndef TFT_BUFFER_SIZE
+      #define TFT_BUFFER_SIZE               1200
+    #endif
+    #ifndef TFT_QUEUE_SIZE
+      #define TFT_QUEUE_SIZE                6144
+    #endif
 
     #define BTN_EN1                        P3_25
     #define BTN_EN2                        P3_26

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -318,8 +318,12 @@
       #define LCD_PINS_ENABLE              -1
       #define LCD_PINS_RS                  -1
 
-      #define TFT_BUFFER_SIZE               1200
-      #define TFT_QUEUE_SIZE                6144
+      #ifndef TFT_BUFFER_SIZE
+        #define TFT_BUFFER_SIZE             1200
+      #endif
+      #ifndef TFT_QUEUE_SIZE
+        #define TFT_QUEUE_SIZE              6144
+      #endif
 
     #else                                         // !MKS_12864OLED_SSD1306
 

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -251,7 +251,7 @@
  *                _____                                            _____
  * (BEEPER) 1.31 | · · | 1.30 (BTN_ENC)               (MISO) 0.8  | · · | 0.7  (SD_SCK)
  * (LCD_EN) 0.18 | · · | 0.16 (LCD_RS)             (BTN_EN1) 3.25 | · · | 0.28 (SD_CS2)
- * (LCD_D4) 0.15 | · ·   0.17 (LCD_D5)             (BTN_EN2) 3.26 | · ·   0.9  (SD_MOSI)
+ * (LCD_D4) 0.15 | · · | 0.17 (LCD_D5)             (BTN_EN2) 3.26 | · · | 0.9  (SD_MOSI)
  * (LCD_D6)  1.0 | · · | 1.22 (LCD_D7)           (SD_DETECT) 0.27 | · · | RST
  *           GND | · · | 5V                                   GND | · · | NC
  *                -----                                            -----
@@ -318,7 +318,8 @@
       #define LCD_PINS_ENABLE              -1
       #define LCD_PINS_RS                  -1
 
-      #define TFT_BUFFER_SIZE               2400
+      #define TFT_BUFFER_SIZE               1200
+      #define TFT_QUEUE_SIZE                6144
 
     #else                                         // !MKS_12864OLED_SSD1306
 


### PR DESCRIPTION
### Description

Reduce RAM usage for TFT Color UI on SGen-L V2 too.

### Benefits

Users will be able to add more features on SGen-L V2 without going out of RAM.

### Related Issues

#20179
