### PR TITLE
Missing header for suicide() on LVGL UI

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_set.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_set.cpp
@@ -37,6 +37,10 @@
 #include "../../../../gcode/queue.h"
 #include "../../../../inc/MarlinConfig.h"
 
+#if HAS_SUICIDE
+  #include "../../../../MarlinCore.h"
+#endif
+
 static lv_obj_t *scr;
 extern lv_group_t*  g;
 


### PR DESCRIPTION
### Description

Fix missing header to use suicide() on LVGL_UI.

### Benefits

Fix: #20090

