### PR TITLE
fixes #20231 Thermistors 998/9 make heated bed disappear from LCD

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1776,7 +1776,7 @@
 //
 // ADC Temp Sensors (Thermistor or Thermocouple with amplifier ADC interface)
 //
-#define HAS_ADC_TEST(P) (PIN_EXISTS(TEMP_##P) && TEMP_SENSOR_##P != 0 && NONE(HEATER_##P##_USES_MAX6675, HEATER_##P##_DUMMY_THERMISTOR))
+#define HAS_ADC_TEST(P) ((PIN_EXISTS(TEMP_##P) || ENABLED(HEATER_##P##_DUMMY_THERMISTOR)) && TEMP_SENSOR_##P != 0 && DISABLED(HEATER_##P##_USES_MAX6675))
 #if HAS_ADC_TEST(0)
   #define HAS_TEMP_ADC_0 1
 #endif


### PR DESCRIPTION
### Requirements

#define TEMP_SENSOR_BED 998 and 128x64 or 20x4 LCD

### Description

With this combination the Heated bed section of LCD is disabled.
The logic seems wrong.

### Benefits

Heated bed section of LCD is enabled

### Related Issues

Introduced here https://github.com/MarlinFirmware/Marlin/pull/20159
brought to attention here https://github.com/MarlinFirmware/Marlin/issues/20231 