### PR TITLE
BROWSE_MEDIA_ON_INSERT - "Back" and "Main"

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1625,6 +1625,7 @@ void MarlinUI::update() {
       if (old_status < 2) {
         TERN_(EXTENSIBLE_UI, ExtUI::onMediaInserted()); // ExtUI response
         #if ENABLED(BROWSE_MEDIA_ON_INSERT)
+          clear_menu_history();
           quick_feedback();
           goto_screen(MEDIA_MENU_GATEWAY);
         #else

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -206,8 +206,8 @@ void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, co
     screen_items = items;
     if (on_status_screen()) {
       defer_status_screen(false);
+      clear_menu_history();
       TERN_(AUTO_BED_LEVELING_UBL, ubl.lcd_map_control = false);
-      screen_history_depth = 0;
     }
 
     clear_lcd();

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -249,3 +249,6 @@ void _lcd_draw_homing();
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
   void touch_screen_calibration();
 #endif
+
+extern uint8_t screen_history_depth;
+inline void clear_menu_history() { screen_history_depth = 0; }

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -104,8 +104,6 @@ class MenuItem_sdfolder : public MenuItem_sdbase {
     }
 };
 
-extern uint8_t screen_history_depth;
-
 void menu_media() {
   ui.encoder_direction_menus();
 
@@ -117,7 +115,7 @@ void menu_media() {
   #endif
 
   START_MENU();
-  BACK_ITEM_P(TERN0(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_BACK) : GET_TEXT(MSG_MAIN));
+  BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
   if (card.flag.workDirIsRoot) {
     #if !PIN_EXISTS(SD_DETECT)
       ACTION_ITEM(MSG_REFRESH, []{ encoderTopLine = 0; card.mount(); });

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -117,7 +117,7 @@ void menu_media() {
   #endif
 
   START_MENU();
-  BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
+  BACK_ITEM_P(TERN0(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_BACK) : GET_TEXT(MSG_MAIN));
   if (card.flag.workDirIsRoot) {
     #if !PIN_EXISTS(SD_DETECT)
       ACTION_ITEM(MSG_REFRESH, []{ encoderTopLine = 0; card.mount(); });


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

At the moment, if  the last item in the nav. history is the main menu screen (screen_history_depth = 0), the back menu item shows "Back" instead of "Main", this PR switch it as it should be, https://github.com/MarlinFirmware/Marlin/pull/20151#issuecomment-729391001.

Could have been done by just adding `screen_history_depth = 0`, but I'm not sure if that would have been the best apprach.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

If the back menu item is "Main" now it will take to the main menu or status screen.
<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/20151#issuecomment-729470158
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
