### PR TITLE
Fix Load Filament Wait for User

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -199,7 +199,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
     first_impatient_beep(max_beep_count);
 
     KEEPALIVE_STATE(PAUSED_FOR_USER);
-
+    wait_for_user = true;    // LCD click or M108 will clear this
     #if ENABLED(HOST_PROMPT_SUPPORT)
       const char tool = '0'
         #if NUM_RUNOUT_SENSORS > 1


### PR DESCRIPTION
### Description

PR #17315 did a lot of changes for "wait for user", but remove one `wait_for_user = true` that should not. This is clear typo, as right bellow the code have a while(wait_for_user).

This PR fix that, putting wait_for_user back where it was.

### Benefits

Fix #19455 

### Related Issues

#19455 
#17315
