### PR TITLE
Allow Status Message without LCD

### DIFF
--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -77,7 +77,7 @@ void GcodeSuite::M303() {
     KEEPALIVE_STATE(NOT_BUSY);
   #endif
 
-  ui.set_status_P(GET_TEXT(MSG_PID_AUTOTUNE));
+  LCD_MESSAGEPGM(MSG_PID_AUTOTUNE);
   thermalManager.PID_autotune(temp, e, c, u);
   ui.reset_status();
 }

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -472,6 +472,10 @@
   #endif
 #endif
 
+#if EITHER(HAS_DISPLAY, GLOBAL_STATUS_MESSAGE)
+  #define HAS_STATUS_MESSAGE 1
+#endif
+
 #if IS_ULTIPANEL && DISABLED(NO_LCD_MENUS)
   #define HAS_LCD_MENU 1
 #endif

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1332,58 +1332,15 @@ void MarlinUI::update() {
 
 #endif // HAS_WIRED_LCD
 
-#if HAS_DISPLAY
+#if HAS_STATUS_MESSAGE
+
+  ////////////////////////////////////////////
+  ////////////// Status Message //////////////
+  ////////////////////////////////////////////
 
   #if ENABLED(EXTENSIBLE_UI)
     #include "extui/ui_api.h"
   #endif
-
-  ////////////////////////////////////////////
-  /////////////// Status Line ////////////////
-  ////////////////////////////////////////////
-
-  #if ENABLED(STATUS_MESSAGE_SCROLLING)
-    void MarlinUI::advance_status_scroll() {
-      // Advance by one UTF8 code-word
-      if (status_scroll_offset < utf8_strlen(status_message))
-        while (!START_OF_UTF8_CHAR(status_message[++status_scroll_offset]));
-      else
-        status_scroll_offset = 0;
-    }
-    char* MarlinUI::status_and_len(uint8_t &len) {
-      char *out = status_message + status_scroll_offset;
-      len = utf8_strlen(out);
-      return out;
-    }
-  #endif
-
-  void MarlinUI::finish_status(const bool persist) {
-
-    #if !(ENABLED(LCD_PROGRESS_BAR) && (PROGRESS_MSG_EXPIRE) > 0)
-      UNUSED(persist);
-    #endif
-
-    #if ENABLED(LCD_PROGRESS_BAR) || BOTH(FILAMENT_LCD_DISPLAY, SDSUPPORT)
-      const millis_t ms = millis();
-    #endif
-
-    #if ENABLED(LCD_PROGRESS_BAR) && !IS_TFTGLCD_PANEL
-      progress_bar_ms = ms;
-      #if PROGRESS_MSG_EXPIRE > 0
-        expire_status_ms = persist ? 0 : ms + PROGRESS_MSG_EXPIRE;
-      #endif
-    #endif
-
-    #if BOTH(FILAMENT_LCD_DISPLAY, SDSUPPORT)
-      next_filament_display = ms + 5000UL; // Show status message for 5s
-    #endif
-
-    #if BOTH(HAS_WIRED_LCD, STATUS_MESSAGE_SCROLLING)
-      status_scroll_offset = 0;
-    #endif
-
-    TERN_(EXTENSIBLE_UI, ExtUI::onStatusChanged(status_message));
-  }
 
   bool MarlinUI::has_status() { return (status_message[0] != '\0'); }
 
@@ -1414,16 +1371,45 @@ void MarlinUI::update() {
     finish_status(persist);
   }
 
-  #include <stdarg.h>
+  /**
+   * Reset the status message
+   */
+  void MarlinUI::reset_status(const bool no_welcome) {
+    #if SERVICE_INTERVAL_1 > 0
+      static PGMSTR(service1, "> " SERVICE_NAME_1 "!");
+    #endif
+    #if SERVICE_INTERVAL_2 > 0
+      static PGMSTR(service2, "> " SERVICE_NAME_2 "!");
+    #endif
+    #if SERVICE_INTERVAL_3 > 0
+      static PGMSTR(service3, "> " SERVICE_NAME_3 "!");
+    #endif
+    PGM_P msg;
+    if (printingIsPaused())
+      msg = GET_TEXT(MSG_PRINT_PAUSED);
+    #if ENABLED(SDSUPPORT)
+      else if (IS_SD_PRINTING())
+        return set_status(card.longest_filename(), true);
+    #endif
+    else if (print_job_timer.isRunning())
+      msg = GET_TEXT(MSG_PRINTING);
 
-  void MarlinUI::status_printf_P(const uint8_t level, PGM_P const fmt, ...) {
-    if (level < alert_level) return;
-    alert_level = level;
-    va_list args;
-    va_start(args, fmt);
-    vsnprintf_P(status_message, MAX_MESSAGE_LENGTH, fmt, args);
-    va_end(args);
-    finish_status(level > 0);
+    #if SERVICE_INTERVAL_1 > 0
+      else if (print_job_timer.needsService(1)) msg = service1;
+    #endif
+    #if SERVICE_INTERVAL_2 > 0
+      else if (print_job_timer.needsService(2)) msg = service2;
+    #endif
+    #if SERVICE_INTERVAL_3 > 0
+      else if (print_job_timer.needsService(3)) msg = service3;
+    #endif
+
+    else if (!no_welcome)
+      msg = GET_TEXT(WELCOME_MSG);
+    else
+      return;
+
+    set_status_P(msg, -1);
   }
 
   void MarlinUI::set_status_P(PGM_P const message, int8_t level) {
@@ -1459,50 +1445,75 @@ void MarlinUI::update() {
     TERN_(HAS_LCD_MENU, return_to_status());
   }
 
-  PGM_P print_paused = GET_TEXT(MSG_PRINT_PAUSED);
+  #include <stdarg.h>
 
-  /**
-   * Reset the status message
-   */
-  void MarlinUI::reset_status(const bool no_welcome) {
-    PGM_P printing = GET_TEXT(MSG_PRINTING);
-    PGM_P welcome  = GET_TEXT(WELCOME_MSG);
-    #if SERVICE_INTERVAL_1 > 0
-      static PGMSTR(service1, "> " SERVICE_NAME_1 "!");
-    #endif
-    #if SERVICE_INTERVAL_2 > 0
-      static PGMSTR(service2, "> " SERVICE_NAME_2 "!");
-    #endif
-    #if SERVICE_INTERVAL_3 > 0
-      static PGMSTR(service3, "> " SERVICE_NAME_3 "!");
-    #endif
-    PGM_P msg;
-    if (printingIsPaused())
-      msg = print_paused;
-    #if ENABLED(SDSUPPORT)
-      else if (IS_SD_PRINTING())
-        return set_status(card.longest_filename(), true);
-    #endif
-    else if (print_job_timer.isRunning())
-      msg = printing;
-
-    #if SERVICE_INTERVAL_1 > 0
-      else if (print_job_timer.needsService(1)) msg = service1;
-    #endif
-    #if SERVICE_INTERVAL_2 > 0
-      else if (print_job_timer.needsService(2)) msg = service2;
-    #endif
-    #if SERVICE_INTERVAL_3 > 0
-      else if (print_job_timer.needsService(3)) msg = service3;
-    #endif
-
-    else if (!no_welcome)
-      msg = welcome;
-    else
-      return;
-
-    set_status_P(msg, -1);
+  void MarlinUI::status_printf_P(const uint8_t level, PGM_P const fmt, ...) {
+    if (level < alert_level) return;
+    alert_level = level;
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf_P(status_message, MAX_MESSAGE_LENGTH, fmt, args);
+    va_end(args);
+    finish_status(level > 0);
   }
+
+  void MarlinUI::finish_status(const bool persist) {
+
+    #if HAS_SPI_LCD
+
+      #if !(ENABLED(LCD_PROGRESS_BAR) && (PROGRESS_MSG_EXPIRE) > 0)
+        UNUSED(persist);
+      #endif
+
+      #if ENABLED(LCD_PROGRESS_BAR) || BOTH(FILAMENT_LCD_DISPLAY, SDSUPPORT)
+        const millis_t ms = millis();
+      #endif
+
+      #if ENABLED(LCD_PROGRESS_BAR)
+        progress_bar_ms = ms;
+        #if PROGRESS_MSG_EXPIRE > 0
+          expire_status_ms = persist ? 0 : ms + PROGRESS_MSG_EXPIRE;
+        #endif
+      #endif
+
+      #if BOTH(FILAMENT_LCD_DISPLAY, SDSUPPORT)
+        next_filament_display = ms + 5000UL; // Show status message for 5s
+      #endif
+
+      #if ENABLED(STATUS_MESSAGE_SCROLLING)
+        status_scroll_offset = 0;
+      #endif
+
+    #endif
+
+    TERN_(EXTENSIBLE_UI, ExtUI::onStatusChanged(status_message));
+  }
+
+  #if ENABLED(STATUS_MESSAGE_SCROLLING)
+
+    void MarlinUI::advance_status_scroll() {
+      // Advance by one UTF8 code-word
+      if (status_scroll_offset < utf8_strlen(status_message))
+        while (!START_OF_UTF8_CHAR(status_message[++status_scroll_offset]));
+      else
+        status_scroll_offset = 0;
+    }
+
+    char* MarlinUI::status_and_len(uint8_t &len) {
+      char *out = status_message + status_scroll_offset;
+      len = utf8_strlen(out);
+      return out;
+    }
+
+  #endif
+
+#endif
+
+#if HAS_DISPLAY
+
+  #if ENABLED(SDSUPPORT)
+    extern bool wait_for_user, wait_for_heatup;
+  #endif
 
   void MarlinUI::abort_print() {
     #if ENABLED(SDSUPPORT)
@@ -1514,7 +1525,7 @@ void MarlinUI::update() {
     #endif
     TERN_(HOST_PROMPT_SUPPORT, host_prompt_open(PROMPT_INFO, PSTR("UI Aborted"), DISMISS_STR));
     print_job_timer.stop();
-    set_status_P(GET_TEXT(MSG_PRINT_ABORTED));
+    LCD_MESSAGEPGM(MSG_PRINT_ABORTED);
     TERN_(HAS_LCD_MENU, return_to_status());
   }
 
@@ -1530,7 +1541,7 @@ void MarlinUI::update() {
 
     TERN_(HOST_PROMPT_SUPPORT, host_prompt_open(PROMPT_PAUSE_RESUME, PSTR("UI Pause"), PSTR("Resume")));
 
-    set_status_P(print_paused);
+    LCD_MESSAGEPGM(MSG_PRINT_PAUSED);
 
     #if ENABLED(PARK_HEAD_ON_PAUSE)
       TERN_(HAS_WIRED_LCD, lcd_pause_show_message(PAUSE_MESSAGE_PARKING, PAUSE_MODE_PAUSE_PRINT)); // Show message immediately to let user know about pause in progress
@@ -1615,6 +1626,10 @@ void MarlinUI::update() {
 
 #if ENABLED(SDSUPPORT)
 
+  #if ENABLED(EXTENSIBLE_UI)
+    #include "extui/ui_api.h"
+  #endif
+
   void MarlinUI::media_changed(const uint8_t old_status, const uint8_t status) {
     if (old_status == status) {
       TERN_(EXTENSIBLE_UI, ExtUI::onMediaError()); // Failed to mount/unmount
@@ -1629,7 +1644,7 @@ void MarlinUI::update() {
           quick_feedback();
           goto_screen(MEDIA_MENU_GATEWAY);
         #else
-          set_status_P(GET_TEXT(MSG_MEDIA_INSERTED));
+          LCD_MESSAGEPGM(MSG_MEDIA_INSERTED);
         #endif
       }
     }
@@ -1637,7 +1652,7 @@ void MarlinUI::update() {
       if (old_status < 2) {
         TERN_(EXTENSIBLE_UI, ExtUI::onMediaRemoved()); // ExtUI response
         #if PIN_EXISTS(SD_DETECT)
-          set_status_P(GET_TEXT(MSG_MEDIA_REMOVED));
+          LCD_MESSAGEPGM(MSG_MEDIA_REMOVED);
           #if HAS_LCD_MENU
             if (!defer_return_to_status) return_to_status();
           #endif

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -373,23 +373,37 @@ public:
     static constexpr uint8_t get_progress_percent() { return 0; }
   #endif
 
-  #if HAS_DISPLAY
-
-    static void init();
-    static void update();
-    static void set_alert_status_P(PGM_P const message);
-
+  #if HAS_STATUS_MESSAGE
     static char status_message[];
-    static bool has_status();
-
     static uint8_t alert_level; // Higher levels block lower levels
-    static inline void reset_alert_level() { alert_level = 0; }
 
     #if ENABLED(STATUS_MESSAGE_SCROLLING)
       static uint8_t status_scroll_offset;
       static void advance_status_scroll();
       static char* status_and_len(uint8_t &len);
     #endif
+
+    static bool has_status();
+    static void reset_status(const bool no_welcome=false);
+    static void set_status(const char* const message, const bool persist=false);
+    static void set_status_P(PGM_P const message, const int8_t level=0);
+    static void status_printf_P(const uint8_t level, PGM_P const fmt, ...);
+    static void set_alert_status_P(PGM_P const message);
+    static inline void reset_alert_level() { alert_level = 0; }
+  #else
+    static constexpr bool has_status() { return false; }
+    static inline void reset_status(const bool=false) {}
+    static void set_status(const char* message, const bool=false);
+    static void set_status_P(PGM_P message, const int8_t=0);
+    static void status_printf_P(const uint8_t, PGM_P message, ...);
+    static inline void set_alert_status_P(PGM_P const) {}
+    static inline void reset_alert_level() {}
+  #endif
+
+  #if HAS_DISPLAY
+
+    static void init();
+    static void update();
 
     static void abort_print();
     static void pause_print();
@@ -481,25 +495,12 @@ public:
     static bool get_blink();
     static void kill_screen(PGM_P const lcd_error, PGM_P const lcd_component);
     static void draw_kill_screen();
-    static void set_status(const char* const message, const bool persist=false);
-    static void set_status_P(PGM_P const message, const int8_t level=0);
-    static void status_printf_P(const uint8_t level, PGM_P const fmt, ...);
-    static void reset_status(const bool no_welcome=false);
 
   #else // No LCD
-
-    // Send status to host as a notification
-    static void set_status(const char* message, const bool=false);
-    static void set_status_P(PGM_P message, const int8_t=0);
-    static void status_printf_P(const uint8_t, PGM_P message, ...);
 
     static inline void init() {}
     static inline void update() {}
     static inline void return_to_status() {}
-    static inline void set_alert_status_P(PGM_P const) {}
-    static inline void reset_status(const bool=false) {}
-    static inline void reset_alert_level() {}
-    static constexpr bool has_status() { return false; }
 
   #endif
 
@@ -702,7 +703,7 @@ public:
 
 private:
 
-  #if HAS_DISPLAY
+  #if HAS_STATUS_MESSAGE
     static void finish_status(const bool persist);
   #endif
 


### PR DESCRIPTION
### Description

The status message  doesn't really require an LCD and can exist separate from any particular implementation. Then the "latest status message" can be pulled by a host or an external serial controller for display in its user interface via a command like `M408`. This PR doesn't change any current behavior, but simply makes it possible to enable the status message separately for future controllers and other features.
