### PR TITLE
Remove UBL moves to Z0

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -989,6 +989,8 @@
 
         do_blocking_move_to(raw);                           // Move the nozzle to the edit point with probe clearance
 
+        TERN_(UBL_MESH_EDIT_MOVES_Z, do_blocking_move_to_z(h_offset)); // Move Z to the given 'H' offset before editing
+
         KEEPALIVE_STATE(PAUSED_FOR_USER);
 
         if (do_ubl_mesh_map) display_map(g29_map_type);     // Display the current point

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -949,7 +949,7 @@
         g29_repetition_cnt = 1;   // do exactly one mesh location. Otherwise use what the parser decided.
 
       #if ENABLED(UBL_MESH_EDIT_MOVES_Z)
-        const float h_offset = parser.seenval('H') ? parser.value_linear_units() : 0;
+        const float h_offset = parser.seenval('H') ? parser.value_linear_units() : MANUAL_PROBE_START_Z;
         if (!WITHIN(h_offset, 0, 10)) {
           SERIAL_ECHOLNPGM("Offset out of bounds. (0 to 10mm)\n");
           return;
@@ -970,8 +970,6 @@
 
       do_blocking_move_to_xy_z(pos, Z_CLEARANCE_BETWEEN_PROBES);  // Move to the given XY with probe clearance
 
-      TERN_(UBL_MESH_EDIT_MOVES_Z, do_blocking_move_to_z(h_offset));  // Move Z to the given 'H' offset
-
       MeshFlags done_flags{0};
       const xy_int8_t &lpos = location.pos;
       do {
@@ -990,8 +988,6 @@
         if (!position_is_reachable(raw)) break;             // SHOULD NOT OCCUR (find_closest_mesh_point_of_type only returns reachable)
 
         do_blocking_move_to(raw);                           // Move the nozzle to the edit point with probe clearance
-
-        TERN_(UBL_MESH_EDIT_MOVES_Z, do_blocking_move_to_z(h_offset)); // Move Z to the given 'H' offset before editing
 
         KEEPALIVE_STATE(PAUSED_FOR_USER);
 


### PR DESCRIPTION
### Description

When fine-tuning a mesh point, UBL used 0 as the default clearance height, and had two redundant moves to this height. This now uses `MANUAL_PROBE_START_Z` as the default height. If this is not specified it already defaults to `Z_CLEARANCE_BETWEEN_PROBES` IN `Conditionals_post.h`.

### Benefits

Reduces instances of smashing nozzle into bed when fine-tuning UBL meshes.

### Configurations

Configs used to test inside the simulator:
[Configuration_adv.zip](https://github.com/MarlinFirmware/Marlin/files/5579267/Configuration_adv.zip)

### Related Issues

#19804 - UBL with PROBE_MANUALLY can crash into the bed
