### PR TITLE
Allow Cold Unload/Load on FilamentChange with M302 P1

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -143,7 +143,11 @@ static bool ensure_safe_temperature(const bool wait=true, const PauseMode mode=P
   if (wait)
     return thermalManager.wait_for_hotend(active_extruder);
 
-  wait_for_heatup = true; // Allow interruption by Emergency Parser M108
+  #if ENABLED(PREVENT_COLD_EXTRUSION)
+    wait_for_heatup = !thermalManager.allow_cold_extrude;
+  #else
+    wait_for_heatup = true; // Allow interruption by Emergency Parser M108
+  #endif
   while (wait_for_heatup && ABS(thermalManager.degHotend(active_extruder) - thermalManager.degTargetHotend(active_extruder)) > TEMP_WINDOW)
     idle();
   wait_for_heatup = false;


### PR DESCRIPTION
### Description

The Filmanet Change (M600) does not allow a cold unload/load with M302 P1 anymore.

It checks if the Temperature is ok for the extrude if **PREVENT_COLD_EXTRUSION** is enabled.

### Benefits

Not to wait for 0°C

### Configurations

see related issue

### Related Issues

[#20249](https://github.com/MarlinFirmware/Marlin/issues/20249) [BUG] Filament Change (M600) with cold Hotend (M302 P1) not working anymore 
