### PR TITLE
Allow Cold Unload/Load on FilamentChange with M302 P1

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -145,7 +145,11 @@ static bool ensure_safe_temperature(const bool wait=true, const PauseMode mode=P
   if (wait)
     return thermalManager.wait_for_hotend(active_extruder);
 
-  wait_for_heatup = true; // Allow interruption by Emergency Parser M108
+  #if ENABLED(PREVENT_COLD_EXTRUSION)
+    wait_for_heatup = !thermalManager.allow_cold_extrude;
+  #else
+    wait_for_heatup = true; // Allow interruption by Emergency Parser M108
+  #endif
   while (wait_for_heatup && ABS(thermalManager.degHotend(active_extruder) - thermalManager.degTargetHotend(active_extruder)) > TEMP_WINDOW)
     idle();
   wait_for_heatup = false;

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -142,14 +142,10 @@ static bool ensure_safe_temperature(const bool wait=true, const PauseMode mode=P
   #endif
   UNUSED(mode);
 
-  if (wait)
-    return thermalManager.wait_for_hotend(active_extruder);
+  if (wait) return thermalManager.wait_for_hotend(active_extruder);
 
-  #if ENABLED(PREVENT_COLD_EXTRUSION)
-    wait_for_heatup = !thermalManager.allow_cold_extrude;
-  #else
-    wait_for_heatup = true; // Allow interruption by Emergency Parser M108
-  #endif
+  // Allow interruption by Emergency Parser M108
+  wait_for_heatup = TERN1(PREVENT_COLD_EXTRUSION, !thermalManager.allow_cold_extrude);
   while (wait_for_heatup && ABS(thermalManager.degHotend(active_extruder) - thermalManager.degTargetHotend(active_extruder)) > TEMP_WINDOW)
     idle();
   wait_for_heatup = false;


### PR DESCRIPTION
### Description

The Filmanet Change (M600) does not allow a cold unload/load with M302 P1 anymore.

It checks if the Temperature is ok for the extrude if **PREVENT_COLD_EXTRUSION** is enabled.

### Benefits

Not to wait for 0°C

### Configurations

see related issue

### Related Issues

[#20249](https://github.com/MarlinFirmware/Marlin/issues/20249) [BUG] Filament Change (M600) with cold Hotend (M302 P1) not working anymore 

_this time hopefully the right branch to PR to._