### PR TITLE
Set "lcd_move_e" index to fix the label

### DIFF
--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -192,7 +192,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
 #if E_MANUAL
 
   inline void _goto_menu_move_distance_e() {
-    ui.goto_screen([]{ _menu_move_distance(E_AXIS, []{ lcd_move_e(active_extruder); }, -1); });
+    ui.goto_screen([]{ _menu_move_distance(E_AXIS, []{ lcd_move_e(TERN_(MULTI_MANUAL,active_extruder)); }, -1); });
   }
 
   inline void _menu_move_distance_e_maybe() {

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -192,7 +192,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
 #if E_MANUAL
 
   inline void _goto_menu_move_distance_e() {
-    ui.goto_screen([]{ _menu_move_distance(E_AXIS, []{ lcd_move_e(TERN_(MULTI_MANUAL,active_extruder)); }, -1); });
+    ui.goto_screen([]{ _menu_move_distance(E_AXIS, []{ lcd_move_e(TERN_(MULTI_MANUAL, active_extruder)); }, -1); });
   }
 
   inline void _menu_move_distance_e_maybe() {

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -192,7 +192,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
 #if E_MANUAL
 
   inline void _goto_menu_move_distance_e() {
-    ui.goto_screen([]{ _menu_move_distance(E_AXIS, []{ lcd_move_e(); }, -1); });
+    ui.goto_screen([]{ _menu_move_distance(E_AXIS, []{ lcd_move_e(active_extruder); }, -1); });
   }
 
   inline void _menu_move_distance_e_maybe() {


### PR DESCRIPTION
### Requirements

extruders > 1  and a 128x64 LCD   (or Sim)  

### Description

Currently in bugfix when you have extruders > 1 the edit menu in Motion|Move Axis|Extruder|Move [N]mm changes name. 
It should say "Extruder E1:" or "Extruder E2:" etc depending on the active tool.
But currently it displays "Extruder Bed:"
Eg
![IMG_20201124_204254](https://user-images.githubusercontent.com/530024/100065622-e1046380-2e98-11eb-9640-45abf803b3f0.jpg)

### Benefits

This fIx changes the display to the correct heater display, ie E1, E2 etc

### Configurations

This config will produce this display error.
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/5588291/Configuration.zip)

### Related Issues
I noticed this when Helping on Discord with a user who was confused with move Extruder vs move Extruder E1 etc 
