### PR TITLE
Missing header to use HAS_SD_HOST_DRIVE

### DIFF
--- a/Marlin/src/HAL/STM32F1/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32F1/msc_sd.cpp
@@ -13,6 +13,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
+#include "../../inc/MarlinConfigPre.h"
+
 #if defined(__STM32F1__) && HAS_SD_HOST_DRIVE
 
 #include "msc_sd.h"


### PR DESCRIPTION
# Description

Follow up for #20176. Just a missing header to use the macro.

Fix `STM32F103RC_btt_512K_USB` with MSC, after #20176.

### Related Issues

#20176 

