### PR TITLE
Fix motion over soft. endstop after M84 #20264

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1099,8 +1099,8 @@
 
 // @section homing
 
-//#define NO_MOTION_BEFORE_HOMING // Inhibit movement until all axes have been homed. Enable HOME_AFTER_DEACTIVATE for extra safety.
-
+//#define NO_MOTION_BEFORE_HOMING // Inhibit movement until all axes have been homed. Also enable HOME_AFTER_DEACTIVATE for extra safety.
+//#define HOME_AFTER_DEACTIVATE   // Require rehoming after steppers are deactivated. Also enable NO_MOTION_BEFORE_HOMING for extra safety.
 //#define UNKNOWN_Z_NO_RAISE      // Don't raise Z (lower the bed) if Z is "unknown." For beds that fall when Z is powered off.
 
 //#define Z_HOMING_HEIGHT  4      // (mm) Minimal Z height before homing (G28) for Z clearance above the bed, clamps, ...

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1099,7 +1099,7 @@
 
 // @section homing
 
-//#define NO_MOTION_BEFORE_HOMING // Inhibit movement until all axes have been homed
+//#define NO_MOTION_BEFORE_HOMING // Inhibit movement until all axes have been homed. Enable HOME_AFTER_DEACTIVATE for extra safety.
 
 //#define UNKNOWN_Z_NO_RAISE      // Don't raise Z (lower the bed) if Z is "unknown." For beds that fall when Z is powered off.
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -854,7 +854,9 @@
 // If the Nozzle or Bed falls when the Z stepper is disabled, set its resting position here.
 //#define Z_AFTER_DEACTIVATE Z_HOME_POS
 
-//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated
+#if ENABLED(NO_MOTION_BEFORE_HOMING)  // from Configuration.h.
+  //#define HOME_AFTER_DEACTIVATE     // Inhibit movement and require rehoming after steppers are deactivated
+#endif
 
 // Default Minimum Feedrates for printing and travel moves
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // (mm/s) Minimum feedrate. Set with M205 S.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -854,8 +854,6 @@
 // If the Nozzle or Bed falls when the Z stepper is disabled, set its resting position here.
 //#define Z_AFTER_DEACTIVATE Z_HOME_POS
 
-//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated. Enable NO_MOTION_BEFORE_HOMING for extra safety.
-
 // Default Minimum Feedrates for printing and travel moves
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // (mm/s) Minimum feedrate. Set with M205 S.
 #define DEFAULT_MINTRAVELFEEDRATE     0.0     // (mm/s) Minimum travel feedrate. Set with M205 T.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -854,9 +854,7 @@
 // If the Nozzle or Bed falls when the Z stepper is disabled, set its resting position here.
 //#define Z_AFTER_DEACTIVATE Z_HOME_POS
 
-#if ENABLED(NO_MOTION_BEFORE_HOMING)  // from Configuration.h.
-  //#define HOME_AFTER_DEACTIVATE     // Inhibit movement and require rehoming after steppers are deactivated
-#endif
+//#define HOME_AFTER_DEACTIVATE  // Require rehoming after steppers are deactivated. Enable NO_MOTION_BEFORE_HOMING for extra safety.
 
 // Default Minimum Feedrates for printing and travel moves
 #define DEFAULT_MINIMUMFEEDRATE       0.0     // (mm/s) Minimum feedrate. Set with M205 S.

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1545,6 +1545,15 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #endif
 
 /**
+ * Make sure NO_MOTION_BEFORE_HOMING if NO_MOTION_BEFORE_HOMING enabled
+ */
+
+#if ENABLED(HOME_AFTER_DEACTIVATE) && DISABLED(NO_MOTION_BEFORE_HOMING)
+  #error "NO_MOTION_BEFORE_HOMING must be enabled for HOME_AFTER_DEACTIVATE"
+#endif
+
+
+/**
  * Filament Width Sensor
  */
 #if ENABLED(FILAMENT_WIDTH_SENSOR)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1545,15 +1545,6 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #endif
 
 /**
- * Make sure NO_MOTION_BEFORE_HOMING if NO_MOTION_BEFORE_HOMING enabled
- */
-
-#if ENABLED(HOME_AFTER_DEACTIVATE) && DISABLED(NO_MOTION_BEFORE_HOMING)
-  #error "NO_MOTION_BEFORE_HOMING must be enabled for HOME_AFTER_DEACTIVATE"
-#endif
-
-
-/**
  * Filament Width Sensor
  */
 #if ENABLED(FILAMENT_WIDTH_SENSOR)


### PR DESCRIPTION
What does this fix:
If HOME_AFTER_DEACTIVATE enabled, but NO_MOTION_BEFORE_HOMING disabled, after M84 (disable steppers) command restriction of software endstop does not work. Limits are calculated for homed axes only. In case of an incorrect start or finish g-code, this may result in damage hardware.

In the command handler G0_G1, movement restrictions are imposed only on the homed axes. M84 drops "homed" flag, and software endstops stop working. 

How it works:
Forces to enable option NO_MOTION_BEFORE_HOMING if option HOME_AFTER_DEACTIVATE is enabled. In this case, after the command M84, the axes cannot move until the command G28. G28 restore "homed" flag and software endstops start working again.

Related Issues #20264
