### PR TITLE
enable sensorless homing in both directions

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -47,14 +47,53 @@
 #define PS_ON_PIN                           PH6
 
 //
+// Trinamic Stallguard pins
+//
+#define X_DIAG_PIN                          PF2   // X-
+#define Y_DIAG_PIN                          PC13  // Y-
+#define Z_DIAG_PIN                          PE0   // Z-
+#define E0_DIAG_PIN                         PG14  // X+
+#define E1_DIAG_PIN                         PG9   // Y+
+#define E2_DIAG_PIN                         PD3   // Z+
+
+//
 // Limit Switches
 //
-#define X_MIN_PIN                           PF2
-#define X_MAX_PIN                           PG14
-#define Y_MIN_PIN                           PC13
-#define Y_MAX_PIN                           PG9
-#define Z_MIN_PIN                           PE0
-#define Z_MAX_PIN                           PD3
+#ifdef X_STALL_SENSITIVITY
+  #define X_STOP_PIN                        X_DIAG_PIN
+  #if X_HOME_DIR < 0
+    #define X_MAX_PIN                       E0_DIAG_PIN  // X+
+  #else
+    #define X_MIN_PIN                       E0_DIAG_PIN  // X+
+  #endif
+#else
+  #define X_MIN_PIN                         X_DIAG_PIN   // X-
+  #define X_MAX_PIN                         E0_DIAG_PIN  // X+
+#endif
+
+#ifdef Y_STALL_SENSITIVITY
+  #define Y_STOP_PIN                        Y_DIAG_PIN
+  #if Y_HOME_DIR < 0
+    #define Y_MAX_PIN                       E1_DIAG_PIN  // Y+
+  #else
+    #define Y_MIN_PIN                       E1_DIAG_PIN  // Y+
+  #endif
+#else
+  #define Y_MIN_PIN                         Y_DIAG_PIN   // Y-
+  #define Y_MAX_PIN                         E1_DIAG_PIN  // Y+
+#endif
+
+#ifdef Z_STALL_SENSITIVITY
+  #define Z_STOP_PIN                        Z_DIAG_PIN
+  #if Z_HOME_DIR < 0
+    #define Z_MAX_PIN                       E2_DIAG_PIN  // Z+
+  #else
+    #define Z_MIN_PIN                       E2_DIAG_PIN  // Z+
+  #endif
+#else
+  #define Z_MIN_PIN                         Z_DIAG_PIN   // Z-
+  #define Z_MAX_PIN                         E2_DIAG_PIN  // Z+
+#endif
 
 //
 // Pins on the extender


### PR DESCRIPTION
### Requirements

BOARD_BTT_GTR_V1_0 and stepper drivers with DIAG pins
Enable sensor-less homing.

### Description

With homing direction -1 this works as expected.
But when homing direction is 1 on this board it will not work.
Currently Marlin looks at the end stop max pins which are attached to E0-E2 diag pins. These are not triggered when moving the X,Y or Z axis.
I updated pins_BTT_GTR_V1_0.h with DIAG_PIN and defining a single STOP_PIN when using sensor less homing.
Also enabled the unused stepper plug as min or max as needed.
Same tricks as skr 1.3 and skr 1.4 use to support homing in both directions.  

### Benefits

Can now use sensor-less homing in both homing directions.

### Related Issues
Raised by https://github.com/MarlinFirmware/Marlin/issues/20238
