### PR TITLE
Remaining Time followup fixes USE_M73_REMAINING_TIME

### DIFF
--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -714,7 +714,7 @@ inline uint8_t draw_elapsed_or_remaining_time(uint8_t timepos, const bool blink)
     const bool show_remain = TERN1(ROTATE_PROGRESS_DISPLAY, blink) && (printingIsActive() || marlin_state == MF_SD_COMPLETE);
     if (show_remain) {
       #if ENABLED(USE_M73_REMAINING_TIME)
-        duration_t remaining = get_remaining_time();
+        duration_t remaining = ui.get_remaining_time();
       #else
         uint8_t progress = ui.get_progress_percent();
         uint32_t elapsed = print_job_timer.duration();


### PR DESCRIPTION
Follow up fix for USE_M73_REMAINING_TIME

need to add MarlinUI class to get_remaining_time() as ui.get_remaining_time()
to compile similar to the last followup fix

### Requirements

Requirements
#define REPRAP_DISCOUNT_SMART_CONTROLLER
#define SDSUPPORT
#define SHOW_REMAINING_TIME
#define ROTATE_PROGRESS_DISPLAY

**#define USE_M73_REMAINING_TIME**

### Description

fails to compile with USE_M73_REMAINING_TIME

![image](https://user-images.githubusercontent.com/2419987/100426709-49875680-30cc-11eb-957d-22e2d8b997ef.png)


### Benefits

Now compiles.

### Related Issues

#20195 
#20199 - most recent related fix
