### PR TITLE
Fix unused freeMemory() warnings for STM32F1

### DIFF
--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -202,17 +202,9 @@ extern "C" {
 
 extern "C" char* _sbrk(int incr);
 
-/*
-static int freeMemory() {
-  volatile int top;
-  top = (int)((char*)&top - reinterpret_cast<char*>(_sbrk(0)));
-  return top;
-}
-*/
-
-static int freeMemory() {
+static inline int freeMemory() {
   volatile char top;
-  return &top - reinterpret_cast<char*>(_sbrk(0));
+  return &top - _sbrk(0);
 }
 
 #if GCC_VERSION <= 50000


### PR DESCRIPTION
### Description

STM32F1 builds have recently generated an `unused-function` warning from every file, due to the `freeMemory` function in HAL.h. This was most likley introduced due to changes to compiler arguments.

Declare this function as inline to prevent this warning, and remove a redundant cast while I'm touching the code.

### Benefits

Eliminates a massive number of compiler warnings.

### Configurations

Any STM32F1 will suffice. Here is the config I was using, although it has never been used in a printer.
[Configuration_adv.zip](https://github.com/MarlinFirmware/Marlin/files/5611701/Configuration_adv.zip)

### Related Issues

closes #20313 
