### PR TITLE
Controller Fan for SKR E3 Turbo (same as SKR mini E3)

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -173,6 +173,10 @@
 #define FAN_PIN                            P2_01
 #define FAN1_PIN                           P2_02
 
+#ifndef CONTROLLER_FAN_PIN
+  #define CONTROLLER_FAN_PIN               FAN1_PIN
+#endif
+
 /**
  *                  _____
  *              5V | 1 2 | GND


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Similarly to SKR mini E3, FAN1 can be used as controller fan.

### Benefits

Reduces needs to explicitly define CONTROLLER_FAN_PIN in config, similar to SKR mini E3 boards.

### Configurations

None. Just makes it more convenient.

### Related Issues
