### PR TITLE
Allow E3V2 steps/mm to be adjusted up to 999.9

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -186,7 +186,6 @@ bool dwin_abort_flag = false; // Flag to reset feedrate, return to Home
 constexpr float default_max_feedrate[]        = DEFAULT_MAX_FEEDRATE;
 constexpr float default_max_acceleration[]    = DEFAULT_MAX_ACCELERATION;
 constexpr float default_max_jerk[]            = { DEFAULT_XJERK, DEFAULT_YJERK, DEFAULT_ZJERK, DEFAULT_EJERK };
-constexpr float default_axis_steps_per_unit[] = DEFAULT_AXIS_STEPS_PER_UNIT;
 
 uint8_t Percentrecord = 0;
 uint16_t remain_time = 0;
@@ -1523,7 +1522,7 @@ void HMI_StepXYZE() {
     }
     // Step limit
     if (WITHIN(HMI_flag.step_axis, X_AXIS, E_AXIS))
-      NOMORE(HMI_ValueStruct.Max_Step, default_axis_steps_per_unit[HMI_flag.step_axis] * 2 * MINUNITMULT);
+      NOMORE(HMI_ValueStruct.Max_Step, 999.9 * MINUNITMULT);
     NOLESS(HMI_ValueStruct.Max_Step, MIN_STEP);
     // Step value
     DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Select_Color, 3, 1, 210, MBASE(select_step.now), HMI_ValueStruct.Max_Step);


### PR DESCRIPTION
### Description

The Ender 3 V2 DWIN display defaulted to only allowing adjustment of steps up to 2x the default from Configuration.h. This was inadequate for changes such as switching to a geared extruder. I have removed this limit and increased it to a fixed 999.9 steps/mm, which is the largest number which can be displayed without requiring additional formatting/layout work in the UI.

### Benefits

Increases steps/mm flexibility for E3V2 DWIN users.

### Configurations

[E3V2_Example.zip](https://github.com/MarlinFirmware/Marlin/files/5612948/E3V2_Example.zip)

### Related Issues

#20310
