### PR TITLE
Update platform STM32 to version 10, optimize build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -922,7 +922,6 @@ build_flags   = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSTM32F1xx -USERIAL_USB -DU20 -DTS_V12
 build_unflags = ${common_stm32f1.build_unflags}
   -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
-lib_ignore    = ${common_stm32f1.lib_ignore}
 
 #
 # MKS Robin Mini (STM32F103VET6)

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = mega2560
+default_envs = STM32F103RC_btt
 include_dir  = Marlin
 
 #
@@ -742,8 +742,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_ignore    = SPI
 lib_deps      = ${common.lib_deps}
   SoftwareSerialM
-# Reduce space usage by using a more recent version of arduinoststm32-maple than the one published on platformio
-platform_packages = framework-arduinoststm32-maple@https://github.com/mathiasvr/Arduino_STM32/archive/2020.11.29-dev.zip
+platform_packages = framework-arduinoststm32-maple@~3.10000
   tool-stm32duino
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,7 +18,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = STM32F103RC_btt
+default_envs = mega2560
 include_dir  = Marlin
 
 #
@@ -737,6 +737,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/b
 platform      = ststm32@~6.1
 build_flags   = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags}
+  -DARDUINO_ARCH_STM32
 build_unflags = -std=gnu11 -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_ignore    = SPI

--- a/platformio.ini
+++ b/platformio.ini
@@ -752,8 +752,6 @@ platform_packages = framework-arduinoststm32-maple@https://github.com/mathiasvr/
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
-platform_packages = ${common_stm32f1.platform_packages}
-  tool-stm32duino
 monitor_speed     = 115200
 
 #
@@ -763,8 +761,6 @@ monitor_speed     = 115200
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = MEEB_3DP
-platform_packages = ${common_stm32f1.platform_packages}
-  tool-stm32duino
 build_flags       = ${common_stm32f1.build_flags}
                     -DDEBUG_LEVEL=0
                     -DSS_TIMER=4
@@ -846,8 +842,6 @@ lib_deps          = ${env:STM32F103RC_btt_512K.lib_deps}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RE
-platform_packages = ${common_stm32f1.platform_packages}
-  tool-stm32duino
 monitor_speed     = 115200
 
 #
@@ -907,69 +901,64 @@ build_flags   = ${common_stm32.build_flags}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103VE
-platform_packages = ${common_stm32f1.platform_packages}
 build_flags       = ${common_stm32f1.build_flags}
   -ffunction-sections -fdata-sections -nostdlib -MMD
   -DMCU_STM32F103VE -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1 -DBOARD_generic_stm32f103v
   -DDEBUG_LEVEL=DEBUG_NONE -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DVECT_TAB_ADDR=0x8000000
   -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 upload_protocol   = serial
+
 #
 # Longer 3D board in Alfawise U20 (STM32F103VET6)
 #
 [env:STM32F103VE_longer]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103VE
-platform_packages = ${common_stm32f1.platform_packages}
-extra_scripts     = ${common.extra_scripts}
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = genericSTM32F103VE
+extra_scripts = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
-build_flags       = ${common_stm32f1.build_flags}
+build_flags   = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSTM32F1xx -USERIAL_USB -DU20 -DTS_V12
-build_unflags     = ${common_stm32f1.build_unflags}
+build_unflags = ${common_stm32f1.build_unflags}
   -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
-lib_ignore        = ${common_stm32f1.lib_ignore}
+lib_ignore    = ${common_stm32f1.lib_ignore}
 
 #
 # MKS Robin Mini (STM32F103VET6)
 #
 [env:mks_robin_mini]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103VE
-platform_packages = ${common_stm32f1.platform_packages}
-extra_scripts     = ${common.extra_scripts}
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = genericSTM32F103VE
+extra_scripts = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_mini.py
-build_flags       = ${common_stm32f1.build_flags}
+build_flags   = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE
 
 #
 # MKS Robin Nano (STM32F103VET6)
 #
 [env:mks_robin_nano35]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103VE
-platform_packages = ${common_stm32f1.platform_packages}
-  tool-stm32duino
-extra_scripts     = ${common.extra_scripts}
+platform        = ${common_stm32f1.platform}
+extends         = common_stm32f1
+board           = genericSTM32F103VE
+extra_scripts   = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
-build_flags       = ${common_stm32f1.build_flags}
+build_flags     = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSS_TIMER=4
-debug_tool        = jlink
-upload_protocol   = jlink
+debug_tool      = jlink
+upload_protocol = jlink
 
 #
 # MKS Robin (STM32F103ZET6)
 #
 [env:mks_robin]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103ZE
-platform_packages = ${common_stm32f1.platform_packages}
-extra_scripts     = ${common.extra_scripts}
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = genericSTM32F103ZE
+extra_scripts = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin.py
-build_flags       = ${common_stm32f1.build_flags}
+build_flags   = ${common_stm32f1.build_flags}
   -DSS_TIMER=4 -DSTM32_XL_DENSITY
 
 # MKS Robin (STM32F103ZET6)
@@ -1016,14 +1005,13 @@ extra_scripts = ${common.extra_scripts}
 # MKS Robin E3 with TMC2209
 #
 [env:mks_robin_e3]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103RC
-platform_packages = ${common_stm32f1.platform_packages}
-  tool-stm32duino
-extra_scripts     = ${common.extra_scripts}
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = genericSTM32F103RC
+platform_packages = tool-stm32duino
+extra_scripts = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_e3.py
-build_flags       = ${common_stm32f1.build_flags}
+build_flags   = ${common_stm32f1.build_flags}
   -DDEBUG_LEVEL=0 -DSS_TIMER=4
 
 #
@@ -1031,65 +1019,59 @@ build_flags       = ${common_stm32f1.build_flags}
 #  - LVGL UI
 #
 [env:mks_robin_e3p]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103VE
-platform_packages = ${common_stm32f1.platform_packages}
-  tool-stm32duino
-extra_scripts     = ${common.extra_scripts}
+platform        = ${common_stm32f1.platform}
+extends         = common_stm32f1
+board           = genericSTM32F103VE
+extra_scripts   = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_e3p.py
-build_flags       = ${common_stm32f1.build_flags}
+build_flags     = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSS_TIMER=4
-debug_tool        = jlink
-upload_protocol   = jlink
+debug_tool      = jlink
+upload_protocol = jlink
 
 #
 # MKS Robin Lite/Lite2 (STM32F103RCT6)
 #
 [env:mks_robin_lite]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103RC
-platform_packages = ${common_stm32f1.platform_packages}
-extra_scripts     = ${common.extra_scripts}
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = genericSTM32F103RC
+extra_scripts = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_lite.py
 
 #
 # MKS ROBIN LITE3 (STM32F103RCT6)
 #
 [env:mks_robin_lite3]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103RC
-platform_packages = ${common_stm32f1.platform_packages}
-extra_scripts     = ${common.extra_scripts}
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = genericSTM32F103RC
+extra_scripts = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_lite3.py
 
 #
 # JGAurora A5S A1 (STM32F103ZET6)
 #
 [env:jgaurora_a5s_a1]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103ZE
-platform_packages = ${common_stm32f1.platform_packages}
-extra_scripts     = ${common.extra_scripts}
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = genericSTM32F103ZE
+extra_scripts = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
-build_flags       = ${common_stm32f1.build_flags}
+build_flags   = ${common_stm32f1.build_flags}
   -DSTM32F1xx -DSTM32_XL_DENSITY
 
 #
 # Malyan M200 (STM32F103CB)
 #
 [env:STM32F103CB_malyan]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = malyanM200
-platform_packages = ${common_stm32f1.platform_packages}
-build_flags       = ${common_stm32f1.build_flags}
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = malyanM200
+build_flags   = ${common_stm32f1.build_flags}
   -DMCU_STM32F103CB -D__STM32F1__=1 -std=c++1y -DSERIAL_USB -ffunction-sections -fdata-sections
   -Wl,--gc-sections -DDEBUG_LEVEL=0 -D__MARLIN_FIRMWARE__
-lib_ignore        = ${common_stm32f1.lib_ignore}
+lib_ignore    = ${common_stm32f1.lib_ignore}
   SoftwareSerialM
 
 #
@@ -1128,16 +1110,15 @@ src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
 #
 [env:chitu_f103]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = CHITU_F103
-platform_packages = ${common_stm32f1.platform_packages}
-extra_scripts     = pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
+platform      = ${common_stm32f1.platform}
+extends       = common_stm32f1
+board         = CHITU_F103
+extra_scripts = pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
   buildroot/share/PlatformIO/scripts/chitu_crypt.py
-build_flags       = ${common_stm32f1.build_flags}
+build_flags   = ${common_stm32f1.build_flags}
   -DSTM32F1xx -DSTM32_XL_DENSITY
-build_unflags     = ${common_stm32f1.build_unflags}
+build_unflags = ${common_stm32f1.build_unflags}
   -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG= -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 
 #
@@ -1169,7 +1150,6 @@ upload_protocol = jlink
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103VE
-platform_packages = tool-stm32duino
 extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_mini.py
   buildroot/share/PlatformIO/scripts/add_nanolib.py
@@ -1211,8 +1191,6 @@ extra_scripts     = ${common.extra_scripts}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
-platform_packages = ${common_stm32f1.platform_packages}
-  tool-stm32duino
 extra_scripts     = ${common.extra_scripts}
  buildroot/share/PlatformIO/scripts/fly_mini.py
 build_flags       = ${common_stm32f1.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -742,6 +742,8 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
 lib_ignore    = SPI
 lib_deps      = ${common.lib_deps}
   SoftwareSerialM
+# Reduce space usage by using a more recent version of arduinoststm32-maple than the one published on platformio
+platform_packages = framework-arduinoststm32-maple@https://github.com/mathiasvr/Arduino_STM32/archive/2020.11.29-dev.zip
 
 #
 # STM32F103RC
@@ -750,8 +752,8 @@ lib_deps      = ${common.lib_deps}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
-platform_packages = tool-stm32duino
-                    framework-arduinoststm32-maple @ https://github.com/mathiasvr/Arduino_STM32.git
+platform_packages = ${common_stm32f1.platform_packages}
+  tool-stm32duino
 monitor_speed     = 115200
 
 #
@@ -761,7 +763,8 @@ monitor_speed     = 115200
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = MEEB_3DP
-platform_packages = tool-stm32duino
+platform_packages = ${common_stm32f1.platform_packages}
+  tool-stm32duino
 build_flags       = ${common_stm32f1.build_flags}
                     -DDEBUG_LEVEL=0
                     -DSS_TIMER=4
@@ -843,7 +846,8 @@ lib_deps          = ${env:STM32F103RC_btt_512K.lib_deps}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RE
-platform_packages = tool-stm32duino
+platform_packages = ${common_stm32f1.platform_packages}
+  tool-stm32duino
 monitor_speed     = 115200
 
 #
@@ -903,65 +907,69 @@ build_flags   = ${common_stm32.build_flags}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103VE
+platform_packages = ${common_stm32f1.platform_packages}
 build_flags       = ${common_stm32f1.build_flags}
   -ffunction-sections -fdata-sections -nostdlib -MMD
   -DMCU_STM32F103VE -DARDUINO_GENERIC_STM32F103V -DARDUINO_ARCH_STM32F1 -DBOARD_generic_stm32f103v
   -DDEBUG_LEVEL=DEBUG_NONE -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DVECT_TAB_ADDR=0x8000000
   -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 upload_protocol   = serial
-
 #
 # Longer 3D board in Alfawise U20 (STM32F103VET6)
 #
 [env:STM32F103VE_longer]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = genericSTM32F103VE
-extra_scripts = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103VE
+platform_packages = ${common_stm32f1.platform_packages}
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
-build_flags   = ${common_stm32f1.build_flags}
+build_flags       = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSTM32F1xx -USERIAL_USB -DU20 -DTS_V12
-build_unflags = ${common_stm32f1.build_unflags}
+build_unflags     = ${common_stm32f1.build_unflags}
   -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
-lib_ignore    = ${common_stm32f1.lib_ignore}
+lib_ignore        = ${common_stm32f1.lib_ignore}
 
 #
 # MKS Robin Mini (STM32F103VET6)
 #
 [env:mks_robin_mini]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = genericSTM32F103VE
-extra_scripts = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103VE
+platform_packages = ${common_stm32f1.platform_packages}
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_mini.py
-build_flags   = ${common_stm32f1.build_flags}
+build_flags       = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE
 
 #
 # MKS Robin Nano (STM32F103VET6)
 #
 [env:mks_robin_nano35]
-platform        = ${common_stm32f1.platform}
-extends         = common_stm32f1
-board           = genericSTM32F103VE
-platform_packages = tool-stm32duino
-extra_scripts   = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103VE
+platform_packages = ${common_stm32f1.platform_packages}
+  tool-stm32duino
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
-build_flags     = ${common_stm32f1.build_flags}
+build_flags       = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSS_TIMER=4
-debug_tool      = jlink
-upload_protocol = jlink
+debug_tool        = jlink
+upload_protocol   = jlink
 
 #
 # MKS Robin (STM32F103ZET6)
 #
 [env:mks_robin]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = genericSTM32F103ZE
-extra_scripts = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103ZE
+platform_packages = ${common_stm32f1.platform_packages}
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin.py
-build_flags   = ${common_stm32f1.build_flags}
+build_flags       = ${common_stm32f1.build_flags}
   -DSS_TIMER=4 -DSTM32_XL_DENSITY
 
 # MKS Robin (STM32F103ZET6)
@@ -1008,13 +1016,14 @@ extra_scripts = ${common.extra_scripts}
 # MKS Robin E3 with TMC2209
 #
 [env:mks_robin_e3]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = genericSTM32F103RC
-platform_packages = tool-stm32duino
-extra_scripts = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103RC
+platform_packages = ${common_stm32f1.platform_packages}
+  tool-stm32duino
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_e3.py
-build_flags   = ${common_stm32f1.build_flags}
+build_flags       = ${common_stm32f1.build_flags}
   -DDEBUG_LEVEL=0 -DSS_TIMER=4
 
 #
@@ -1022,60 +1031,65 @@ build_flags   = ${common_stm32f1.build_flags}
 #  - LVGL UI
 #
 [env:mks_robin_e3p]
-platform        = ${common_stm32f1.platform}
-extends         = common_stm32f1
-board           = genericSTM32F103VE
-platform_packages = tool-stm32duino
-extra_scripts   = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103VE
+platform_packages = ${common_stm32f1.platform_packages}
+  tool-stm32duino
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_e3p.py
-build_flags     = ${common_stm32f1.build_flags}
+build_flags       = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSS_TIMER=4
-debug_tool      = jlink
-upload_protocol = jlink
+debug_tool        = jlink
+upload_protocol   = jlink
 
 #
 # MKS Robin Lite/Lite2 (STM32F103RCT6)
 #
 [env:mks_robin_lite]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = genericSTM32F103RC
-extra_scripts = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103RC
+platform_packages = ${common_stm32f1.platform_packages}
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_lite.py
 
 #
 # MKS ROBIN LITE3 (STM32F103RCT6)
 #
 [env:mks_robin_lite3]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = genericSTM32F103RC
-extra_scripts = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103RC
+platform_packages = ${common_stm32f1.platform_packages}
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_lite3.py
 
 #
 # JGAurora A5S A1 (STM32F103ZET6)
 #
 [env:jgaurora_a5s_a1]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = genericSTM32F103ZE
-extra_scripts = ${common.extra_scripts}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103ZE
+platform_packages = ${common_stm32f1.platform_packages}
+extra_scripts     = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
-build_flags   = ${common_stm32f1.build_flags}
+build_flags       = ${common_stm32f1.build_flags}
   -DSTM32F1xx -DSTM32_XL_DENSITY
 
 #
 # Malyan M200 (STM32F103CB)
 #
 [env:STM32F103CB_malyan]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = malyanM200
-build_flags   = ${common_stm32f1.build_flags}
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = malyanM200
+platform_packages = ${common_stm32f1.platform_packages}
+build_flags       = ${common_stm32f1.build_flags}
   -DMCU_STM32F103CB -D__STM32F1__=1 -std=c++1y -DSERIAL_USB -ffunction-sections -fdata-sections
   -Wl,--gc-sections -DDEBUG_LEVEL=0 -D__MARLIN_FIRMWARE__
-lib_ignore    = ${common_stm32f1.lib_ignore}
+lib_ignore        = ${common_stm32f1.lib_ignore}
   SoftwareSerialM
 
 #
@@ -1114,15 +1128,16 @@ src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
 #
 [env:chitu_f103]
-platform      = ${common_stm32f1.platform}
-extends       = common_stm32f1
-board         = CHITU_F103
-extra_scripts = pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = CHITU_F103
+platform_packages = ${common_stm32f1.platform_packages}
+extra_scripts     = pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
   buildroot/share/PlatformIO/scripts/chitu_crypt.py
-build_flags   = ${common_stm32f1.build_flags}
+build_flags       = ${common_stm32f1.build_flags}
   -DSTM32F1xx -DSTM32_XL_DENSITY
-build_unflags = ${common_stm32f1.build_unflags}
+build_unflags     = ${common_stm32f1.build_unflags}
   -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG= -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 
 #
@@ -1196,7 +1211,8 @@ extra_scripts     = ${common.extra_scripts}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
-platform_packages = tool-stm32duino
+platform_packages = ${common_stm32f1.platform_packages}
+  tool-stm32duino
 extra_scripts     = ${common.extra_scripts}
  buildroot/share/PlatformIO/scripts/fly_mini.py
 build_flags       = ${common_stm32f1.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -744,6 +744,7 @@ lib_deps      = ${common.lib_deps}
   SoftwareSerialM
 # Reduce space usage by using a more recent version of arduinoststm32-maple than the one published on platformio
 platform_packages = framework-arduinoststm32-maple@https://github.com/mathiasvr/Arduino_STM32/archive/2020.11.29-dev.zip
+  tool-stm32duino
 
 #
 # STM32F103RC

--- a/platformio.ini
+++ b/platformio.ini
@@ -751,6 +751,7 @@ platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
 platform_packages = tool-stm32duino
+                    framework-arduinoststm32-maple @ https://github.com/mathiasvr/Arduino_STM32.git
 monitor_speed     = 115200
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -741,7 +741,7 @@ build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   -DARDUINO_ARCH_STM32
 build_unflags     = -std=gnu11 -std=gnu++11
 src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
-lib_ignore        = SPI
+lib_ignore        = SPI, FreeRTOS701, FreeRTOS821
 lib_deps          = ${common.lib_deps}
   SoftwareSerialM
 platform_packages = tool-stm32duino

--- a/platformio.ini
+++ b/platformio.ini
@@ -722,7 +722,7 @@ board    = nxp_lpc1769
 # HAL/STM32 Base Environment values
 #
 [common_stm32]
-platform      = ststm32@~8.0
+platform      = ststm32@~10.0
 build_flags   = ${common.build_flags}
   -std=gnu++14
   -DUSBCON -DUSBD_USE_CDC
@@ -734,17 +734,17 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/b
 # HAL/STM32F1 Common Environment values
 #
 [common_stm32f1]
-platform      = ststm32@~6.1
-build_flags   = !python Marlin/src/HAL/STM32F1/build_flags.py
+platform          = ststm32@~10.0
+board_build.core  = maple
+build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags}
   -DARDUINO_ARCH_STM32
-build_unflags = -std=gnu11 -std=gnu++11
-src_filter    = ${common.default_src_filter} +<src/HAL/STM32F1>
-lib_ignore    = SPI
-lib_deps      = ${common.lib_deps}
+build_unflags     = -std=gnu11 -std=gnu++11
+src_filter        = ${common.default_src_filter} +<src/HAL/STM32F1>
+lib_ignore        = SPI
+lib_deps          = ${common.lib_deps}
   SoftwareSerialM
-platform_packages = framework-arduinoststm32-maple@~3.10000
-  tool-stm32duino
+platform_packages = tool-stm32duino
 
 #
 # STM32F103RC


### PR DESCRIPTION
### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

The platformio package `framework-arduinoststm32-maple` needed for the `common_stm32f1` boards is outdated and contains C++ demangling symbols that take up a significant amount of space of the firmware builds.

I have created a platformio supported fork with all the recent updates including removal of the demangling symbols.

### Benefits

<!-- What does this fix or improve? -->

`STM32F103RC` based boards can now enable most marlin features within their 256kb limit.

This fix can most likely also be applied to the `STM32F103RE` based boards, but since they have a 512kb limit it seemed less urgent. Let me know what you think.


