### PR TITLE
reset echo:start back to start and default monitor_speed back to 250000

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -982,7 +982,7 @@ void setup() {
     serial_connect_timeout = millis() + 1000UL;
     while (!MYSERIAL1 && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
   #endif
-  SERIAL_ECHO_MSG("start");
+  SERIAL_ECHOLN("start");
 
   #if BOTH(HAS_TFT_LVGL_UI, MKS_WIFI_MODULE)
     mks_esp_wifi_init();

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -982,7 +982,7 @@ void setup() {
     serial_connect_timeout = millis() + 1000UL;
     while (!MYSERIAL1 && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
   #endif
-  SERIAL_ECHOLN("start");
+  SERIAL_ECHOLNPGM("start");
 
   #if BOTH(HAS_TFT_LVGL_UI, MKS_WIFI_MODULE)
     mks_esp_wifi_init();

--- a/platformio.ini
+++ b/platformio.ini
@@ -405,7 +405,7 @@ framework     = arduino
 extra_scripts = ${common.extra_scripts}
 build_flags   = ${common.build_flags}
 lib_deps      = ${common.lib_deps}
-monitor_speed = 115200
+monitor_speed = 250000
 monitor_flags =
   --quiet
   --echo


### PR DESCRIPTION
### Requirements

Current Marlin bugfix

### Description

In commit https://github.com/MarlinFirmware/Marlin/commit/5a5be7e287183e633ee3235ee1bcd79a72a1a1f5
"start" was changed to "echo:start"
This seems to be in conflict of being a control words as defined in https://reprap.org/wiki/G-code#Replies_from_the_RepRap_machine_to_the_host_computer
```
When the machine boots up it sends the string
start
```

Secondly platformio's default monitor_speed of 250000 was changed to 115200 in https://github.com/MarlinFirmware/Marlin/commit/b6a32500c401877e3ee1300fa613e81086bb31d3

Since the default BAUDRATE in marlin is still 250000 I believe this is in error and am reverting it.

### Benefits

start works as per the protocol description. 
platformio serial monitor starts in correct baudrate.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/20305
https://github.com/MarlinFirmware/Marlin/commit/b6a32500c401877e3ee1300fa613e81086bb31d3

### Concerns
Since "start" was changed to "echo:start" back in April 2020 in version 2.0.6 Changing "echo:start" back to "start" may break some clients that have been modified to now expect "echo:start"

One thought was to send both going forward?
