### PR TITLE
Service watchdog during Creality 4.x EEPROM writes

### DIFF
--- a/Marlin/src/HAL/STM32F1/eeprom_bl24cxx.cpp
+++ b/Marlin/src/HAL/STM32F1/eeprom_bl24cxx.cpp
@@ -48,6 +48,8 @@ bool PersistentStore::access_start()  { eeprom_init(); return true; }
 bool PersistentStore::access_finish() { return true; }
 
 bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, uint16_t *crc) {
+  size_t written = 0;
+
   while (size--) {
     uint8_t v = *value;
     uint8_t * const p = (uint8_t * const)pos;
@@ -55,7 +57,10 @@ bool PersistentStore::write_data(int &pos, const uint8_t *value, size_t size, ui
     // so only write bytes that have changed!
     if (v != eeprom_read_byte(p)) {
       eeprom_write_byte(p, v);
-      delay(2);
+      if (++written % 128 == 0)
+        safe_delay(2); // Avoid triggering watchdog during long EEPROM writes
+      else
+        delay(2);
       if (eeprom_read_byte(p) != v) {
         SERIAL_ECHO_MSG(STR_ERR_EEPROM_WRITE);
         return true;


### PR DESCRIPTION
### Description

When storing large meshes to the EEPROM on Creality 4.x boards the watchdog can expire and reboot the board.
This calls `safe_delay()` every 128 bytes written, so that heaters can be services and the watchdog avoided.

### Benefits

M500 does not reboot the board.

### Configurations

Configuration for Creatlity 4.2.7 board with Ender 3 V2 DWIN display.

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/5615924/Configuration.zip)


### Related Issues

#20307
