### PR TITLE
FYSETC S6: Allow redefine pin functions, enable eeprom

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -644,12 +644,12 @@
   #include "stm32f4/pins_VAKE403D.h"            // STM32F4
 #elif MB(FYSETC_S6)
   #include "stm32f4/pins_FYSETC_S6.h"           // STM32F4                                env:FYSETC_S6
+#elif MB(FYSETC_S6_V2_0)
+  #include "stm32f4/pins_FYSETC_S6_V2_0.h"      // STM32F4                                env:FYSETC_S6
 #elif MB(FLYF407ZG)
   #include "stm32f4/pins_FLYF407ZG.h"           // STM32F4                                env:FLYF407ZG
 #elif MB(MKS_ROBIN2)
   #include "stm32f4/pins_MKS_ROBIN2.h"          // STM32F4                                env:MKS_ROBIN2
-#elif MB(FYSETC_S6_V2_0)
-  #include "stm32f4/pins_FYSETC_S6_V2_0.h"      // STM32F4                                env:FYSETC_S6
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -41,9 +41,9 @@
 // EEPROM Emulation
 //
 #if NO_EEPROM_SELECTED
-  #define FLASH_EEPROM_EMULATION
+  //#define FLASH_EEPROM_EMULATION
   //#define SRAM_EEPROM_EMULATION
-  //#define I2C_EEPROM
+  #define I2C_EEPROM
 #endif
 
 #if ENABLED(FLASH_EEPROM_EMULATION)
@@ -51,7 +51,7 @@
   // 128 kB sector allocated for EEPROM emulation.
   #define FLASH_EEPROM_LEVELING
 #elif ENABLED(I2C_EEPROM)
-  #define MARLIN_EEPROM_SIZE              0x1000  // 4KB
+  #define MARLIN_EEPROM_SIZE              0x0800  // 2KB
 #endif
 
 //
@@ -62,12 +62,24 @@
 //
 // Limit Switches
 //
-#define X_MIN_PIN                           PB14
-#define X_MAX_PIN                           PA1
-#define Y_MIN_PIN                           PB13
-#define Y_MAX_PIN                           PA2
-#define Z_MIN_PIN                           PA0
-#define Z_MAX_PIN                           PA3
+#ifndef X_MIN_PIN
+  #define X_MIN_PIN                         PB14
+#endif
+#ifndef X_MAX_PIN
+  #define X_MAX_PIN                         PA1
+#endif
+#ifndef Y_MIN_PIN
+  #define Y_MIN_PIN                         PB13
+#endif
+#ifndef Y_MAX_PIN
+  #define Y_MAX_PIN                         PA2
+#endif
+#ifndef Z_MIN_PIN
+  #define Z_MIN_PIN                         PA0
+#endif
+#ifndef Z_MAX_PIN
+  #define Z_MAX_PIN                         PA3
+#endif
 
 //
 // Filament Sensor
@@ -169,14 +181,28 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN                        PB3
-#define HEATER_1_PIN                        PB4
-#define HEATER_2_PIN                        PB15
-#define HEATER_BED_PIN                      PC8
+#ifndef HEATER_0_PIN
+  #define HEATER_0_PIN                      PB3
+#endif
+#ifndef HEATER_1_PIN
+  #define HEATER_1_PIN                      PB4
+#endif
+#ifndef HEATER_2_PIN
+  #define HEATER_2_PIN                      PB15
+#endif
+#ifndef HEATER_BED_PIN
+  #define HEATER_BED_PIN                    PC8
+#endif
 
-#define FAN_PIN                             PB0
-#define FAN1_PIN                            PB1
-#define FAN2_PIN                            PB2
+#ifndef FAN_PIN
+  #define FAN_PIN                           PB0
+#endif
+#ifndef FAN1_PIN
+  #define FAN1_PIN                          PB1
+#endif
+#ifndef FAN2_PIN
+  #define FAN2_PIN                          PB2
+#endif
 
 //
 // SPI

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -42,7 +42,6 @@
 //
 #if NO_EEPROM_SELECTED
   #define FLASH_EEPROM_EMULATION
-  //#define SRAM_EEPROM_EMULATION
   //#define I2C_EEPROM
 #endif
 

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -41,9 +41,9 @@
 // EEPROM Emulation
 //
 #if NO_EEPROM_SELECTED
-  //#define FLASH_EEPROM_EMULATION
+  #define FLASH_EEPROM_EMULATION
   //#define SRAM_EEPROM_EMULATION
-  #define I2C_EEPROM
+  //#define I2C_EEPROM
 #endif
 
 #if ENABLED(FLASH_EEPROM_EMULATION)
@@ -62,24 +62,12 @@
 //
 // Limit Switches
 //
-#ifndef X_MIN_PIN
-  #define X_MIN_PIN                         PB14
-#endif
-#ifndef X_MAX_PIN
-  #define X_MAX_PIN                         PA1
-#endif
-#ifndef Y_MIN_PIN
-  #define Y_MIN_PIN                         PB13
-#endif
-#ifndef Y_MAX_PIN
-  #define Y_MAX_PIN                         PA2
-#endif
-#ifndef Z_MIN_PIN
-  #define Z_MIN_PIN                         PA0
-#endif
-#ifndef Z_MAX_PIN
-  #define Z_MAX_PIN                         PA3
-#endif
+#define X_MIN_PIN                           PB14
+#define X_MAX_PIN                           PA1
+#define Y_MIN_PIN                           PB13
+#define Y_MAX_PIN                           PA2
+#define Z_MIN_PIN                           PA0
+#define Z_MAX_PIN                           PA3
 
 //
 // Filament Sensor
@@ -181,28 +169,14 @@
 //
 // Heaters / Fans
 //
-#ifndef HEATER_0_PIN
-  #define HEATER_0_PIN                      PB3
-#endif
-#ifndef HEATER_1_PIN
-  #define HEATER_1_PIN                      PB4
-#endif
-#ifndef HEATER_2_PIN
-  #define HEATER_2_PIN                      PB15
-#endif
-#ifndef HEATER_BED_PIN
-  #define HEATER_BED_PIN                    PC8
-#endif
+#define HEATER_0_PIN                        PB3
+#define HEATER_1_PIN                        PB4
+#define HEATER_2_PIN                        PB15
+#define HEATER_BED_PIN                      PC8
 
-#ifndef FAN_PIN
-  #define FAN_PIN                           PB0
-#endif
-#ifndef FAN1_PIN
-  #define FAN1_PIN                          PB1
-#endif
-#ifndef FAN2_PIN
-  #define FAN2_PIN                          PB2
-#endif
+#define FAN_PIN                             PB0
+#define FAN1_PIN                            PB1
+#define FAN2_PIN                            PB2
 
 //
 // SPI

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6_V2_0.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6_V2_0.h
@@ -29,7 +29,6 @@
 #if NO_EEPROM_SELECTED
   #undef NO_EEPROM_SELECTED
   //#define FLASH_EEPROM_EMULATION
-  //#define SRAM_EEPROM_EMULATION
   #define I2C_EEPROM
 #endif
 


### PR DESCRIPTION
### Description

FYSETC S6 pin file enhancements

### Benefits

- Allow override endstops, heaters and fans socket function in Configuration.h without redefinition warning
- S6 has i2c eeprom soldered onboard, enables it's support. Maybe not all boards have it soldered (board images on fysetc site shows not-soldered placeholder), but it present in schematic and my v1.2 have it soldered.

### Configurations

None special

### Related Issues

#18434 - Proper EEPROM support on Fysetc S6 _(added by sjasonsmith)_
