### PR TITLE
backup_feedrate_percentage no longer requires PRUSA_MMU2

### DIFF
--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -37,11 +37,9 @@
  */
 void GcodeSuite::M220() {
 
-  #if ENABLED(PRUSA_MMU2)
-    static int16_t backup_feedrate_percentage = 100;
-    if (parser.seen('B')) backup_feedrate_percentage = feedrate_percentage;
-    if (parser.seen('R')) feedrate_percentage = backup_feedrate_percentage;
-  #endif
+  static int16_t backup_feedrate_percentage = 100;
+  if (parser.seen('B')) backup_feedrate_percentage = feedrate_percentage;
+  if (parser.seen('R')) feedrate_percentage = backup_feedrate_percentage;
 
   if (parser.seenval('S')) feedrate_percentage = parser.value_int();
 


### PR DESCRIPTION
### Description

This is a pull request for issue #20333.

The feedrate backup and restore feature for M220 is mentioned in [the documentation](https://marlinfw.org/docs/gcode/M220.html), but what is not mentioned is that it is gated behind the PRUSA_MMU2 macro.

### Benefits

This PR amends the code to match the documentation by enabling the backup and restore feature regardless of PRUSA_MMU2. 

### Configurations

No special configuration required.

### Related Issues

#20333 by @thomaslai.