### PR TITLE
Adds extruder stepper disable back to filament unload procedure

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -296,6 +296,18 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
 }
 
 /**
+ * For liberty: Disable E steppers for manual filament change, the
+ * procedure where the user yanks the filament, spins the E motor,
+ * and sends current back to their board, potentially frying it.
+ */
+inline void disable_active_extruder() {
+  #if HAS_E_STEPPER_ENABLE
+    disable_e_stepper(active_extruder);
+    safe_delay(100);
+  #endif
+}
+
+/**
  * Unload filament from the hotend
  *
  * - Fail if the a safe temperature was not reached
@@ -357,11 +369,8 @@ bool unload_filament(const float &unload_length, const bool show_lcd/*=false*/,
     planner.settings.retract_acceleration = saved_acceleration;
   #endif
 
-  // Disable E steppers for manual change
-  #if HAS_E_STEPPER_ENABLE
-    disable_e_stepper(active_extruder);
-    safe_delay(100);
-  #endif
+  // Disable the Extruder for manual change
+  disable_active_extruder();
 
   return true;
 }
@@ -447,11 +456,8 @@ bool pause_print(const float &retract, const xyz_pos_t &park_point, const float 
     set_duplication_enabled(saved_ext_dup_mode, saved_ext);
   #endif
 
-  // Disable E steppers
-  #if HAS_E_STEPPER_ENABLE
-    disable_e_stepper(active_extruder);
-    safe_delay(100);
-  #endif
+  // Disable the Extruder for manual change
+  disable_active_extruder();
 
   return true;
 }

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -296,9 +296,9 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
 }
 
 /**
- * For liberty: Disable E steppers for manual filament change, the
- * procedure where the user yanks the filament, spins the E motor,
- * and sends current back to their board, potentially frying it.
+ * Disabling E steppers for manual filament change should be fine
+ * as long as users don't spin the E motor ridiculously fast and
+ * send current back to their board, potentially frying it.
  */
 inline void disable_active_extruder() {
   #if HAS_E_STEPPER_ENABLE

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -447,6 +447,12 @@ bool pause_print(const float &retract, const xyz_pos_t &park_point, const float 
     set_duplication_enabled(saved_ext_dup_mode, saved_ext);
   #endif
 
+  // Disable E steppers
+  #if HAS_E_STEPPER_ENABLE
+    disable_e_stepper(active_extruder);
+    safe_delay(100);
+  #endif
+
   return true;
 }
 


### PR DESCRIPTION
This prevents the extruder from locking up and preventing manual filament advancement during filament change operations.

### Requirements

Marlin, individual stepper enable/disable pins

### Description

Prevents the extruder from locking up and preventing manual filament advancement during filament change operations.

### Benefits

This makes it much easier to do filament changes

### Configurations

Must include filament change operations, ADVANCED_PAUSE_FEATURE and NOZZLE_PARK_FEATURE

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/12190