### PR TITLE
Add `ok_to_send()` to gcode.cpp

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -252,6 +252,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
   #if ENABLED(PASSWORD_FEATURE)
     if (password.is_locked && !parser.is_command('M', 511)) {
       SERIAL_ECHO_MSG(STR_PRINTER_LOCKED);
+      ok_to_send();
       return;
     }
   #endif

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -252,7 +252,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
   #if ENABLED(PASSWORD_FEATURE)
     if (password.is_locked && !parser.is_command('M', 511)) {
       SERIAL_ECHO_MSG(STR_PRINTER_LOCKED);
-      ok_to_send();
+      if (!no_ok) queue.ok_to_send();
       return;
     }
   #endif


### PR DESCRIPTION
Add `ok_to_send();` to prevent host from timing out when machine is locked

https://github.com/MarlinFirmware/Marlin/issues/20301