### PR TITLE
Fix E3V2 DWIN Jerk Menu

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -185,7 +185,6 @@ bool dwin_abort_flag = false; // Flag to reset feedrate, return to Home
 
 constexpr float default_max_feedrate[]        = DEFAULT_MAX_FEEDRATE;
 constexpr float default_max_acceleration[]    = DEFAULT_MAX_ACCELERATION;
-constexpr float default_max_jerk[]            = { DEFAULT_XJERK, DEFAULT_YJERK, DEFAULT_ZJERK, DEFAULT_EJERK };
 
 #if HAS_CLASSIC_JERK
   constexpr float default_max_jerk[]          = { DEFAULT_XJERK, DEFAULT_YJERK, DEFAULT_ZJERK, DEFAULT_EJERK };

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -1495,8 +1495,8 @@ void HMI_MaxAccelerationXYZE() {
       if (Apply_Encoder(encoder_diffState, HMI_ValueStruct.Max_Jerk)) {
         checkkey = MaxJerk;
         EncoderRate.enabled = false;
-        if (WITHIN(HMI_flag.step_axis, X_AXIS, E_AXIS))
-          planner.set_max_jerk(HMI_flag.step_axis, HMI_ValueStruct.Max_Jerk / 10);
+        if (WITHIN(HMI_flag.jerk_axis, X_AXIS, E_AXIS))
+          planner.set_max_jerk(HMI_flag.jerk_axis, HMI_ValueStruct.Max_Jerk / 10);
         DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(select_jerk.now), HMI_ValueStruct.Max_Jerk);
         return;
       }

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -187,6 +187,10 @@ constexpr float default_max_feedrate[]        = DEFAULT_MAX_FEEDRATE;
 constexpr float default_max_acceleration[]    = DEFAULT_MAX_ACCELERATION;
 constexpr float default_max_jerk[]            = { DEFAULT_XJERK, DEFAULT_YJERK, DEFAULT_ZJERK, DEFAULT_EJERK };
 
+#if HAS_CLASSIC_JERK
+  constexpr float default_max_jerk[]          = { DEFAULT_XJERK, DEFAULT_YJERK, DEFAULT_ZJERK, DEFAULT_EJERK };
+#endif
+
 uint8_t Percentrecord = 0;
 uint16_t remain_time = 0;
 
@@ -2955,75 +2959,77 @@ inline void Draw_Max_Accel_Menu() {
   #endif
 }
 
-inline void Draw_Max_Jerk_Menu() {
-  Clear_Main_Window();
+#if HAS_CLASSIC_JERK
+  inline void Draw_Max_Jerk_Menu() {
+    Clear_Main_Window();
 
-  if (HMI_IsChinese()) {
-    DWIN_Frame_TitleCopy(1, 1, 16, 28, 28); // "Jerk"
+    if (HMI_IsChinese()) {
+      DWIN_Frame_TitleCopy(1, 1, 16, 28, 28); // "Jerk"
 
-    DWIN_Frame_AreaCopy(1, 173, 133, 200, 147, LBLX     , MBASE(1));
-    DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(1) + 1);
-    DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(1));
-    DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 83, MBASE(1));        // Max Jerk speed X
-    DWIN_Frame_AreaCopy(1, 173, 133, 200, 147, LBLX     , MBASE(2));
-    DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(2) + 1);
-    DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(2));
-    DWIN_Frame_AreaCopy(1,   1, 150,   7, 160, LBLX + 83, MBASE(2) + 3);    // Max Jerk speed Y
-    DWIN_Frame_AreaCopy(1, 173, 133, 200, 147, LBLX     , MBASE(3));
-    DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(3) + 1);
-    DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(3));
-    DWIN_Frame_AreaCopy(1,   9, 150,  16, 160, LBLX + 83, MBASE(3) + 3);    // Max Jerk speed Z
+      DWIN_Frame_AreaCopy(1, 173, 133, 200, 147, LBLX     , MBASE(1));
+      DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(1) + 1);
+      DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(1));
+      DWIN_Frame_AreaCopy(1, 229, 133, 236, 147, LBLX + 83, MBASE(1));        // Max Jerk speed X
+      DWIN_Frame_AreaCopy(1, 173, 133, 200, 147, LBLX     , MBASE(2));
+      DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(2) + 1);
+      DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(2));
+      DWIN_Frame_AreaCopy(1,   1, 150,   7, 160, LBLX + 83, MBASE(2) + 3);    // Max Jerk speed Y
+      DWIN_Frame_AreaCopy(1, 173, 133, 200, 147, LBLX     , MBASE(3));
+      DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(3) + 1);
+      DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(3));
+      DWIN_Frame_AreaCopy(1,   9, 150,  16, 160, LBLX + 83, MBASE(3) + 3);    // Max Jerk speed Z
+      #if HAS_HOTEND
+        DWIN_Frame_AreaCopy(1, 173, 133, 200, 147, LBLX     , MBASE(4));
+        DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(4) + 1);
+        DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(4));
+        DWIN_Frame_AreaCopy(1,  18, 150,  25, 160, LBLX + 83, MBASE(4) + 3);  // Max Jerk speed E
+      #endif
+    }
+    else {
+      #ifdef USE_STRING_HEADINGS
+        Draw_Title(GET_TEXT_F(MSG_JERK));
+        DWIN_Draw_String(false, true, font8x16, Color_White, Color_Bg_Black, LBLX, MBASE(1), F("Max Jerk X"));
+        DWIN_Draw_String(false, true, font8x16, Color_White, Color_Bg_Black, LBLX, MBASE(2), F("Max Jerk Y"));
+        DWIN_Draw_String(false, true, font8x16, Color_White, Color_Bg_Black, LBLX, MBASE(3), F("Max Jerk Z"));
+        #if HAS_HOTEND
+          DWIN_Draw_String(false, true, font8x16, Color_White, Color_Bg_Black, LBLX, MBASE(4), F("Max Jerk E"));
+        #endif
+      #else
+        DWIN_Frame_TitleCopy(1, 144, 16, 189, 26); // "Jerk"
+        draw_max_en(MBASE(1));          // "Max"
+        draw_jerk_en(MBASE(1));         // "Jerk"
+        draw_speed_en(72, MBASE(1));    // "Speed"
+        say_x(115, MBASE(1));           // "X"
+
+        draw_max_en(MBASE(2));          // "Max"
+        draw_jerk_en(MBASE(2));         // "Jerk"
+        draw_speed_en(72, MBASE(2));    // "Speed"
+        say_y(115, MBASE(2));           // "Y"
+
+        draw_max_en(MBASE(3));          // "Max"
+        draw_jerk_en(MBASE(3));         // "Jerk"
+        draw_speed_en(72, MBASE(3));    // "Speed"
+        say_z(115, MBASE(3));           // "Z"
+
+        #if HAS_HOTEND
+          draw_max_en(MBASE(4));        // "Max"
+          draw_jerk_en(MBASE(4));       // "Jerk"
+          draw_speed_en(72, MBASE(4));  // "Speed"
+          say_e(115, MBASE(4));         // "E"
+        #endif
+      #endif
+    }
+
+    Draw_Back_First();
+    LOOP_L_N(i, 3 + ENABLED(HAS_HOTEND)) Draw_Menu_Line(i + 1, ICON_MaxSpeedJerkX + i);
+    DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(1), planner.max_jerk[X_AXIS] * MINUNITMULT);
+    DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(2), planner.max_jerk[Y_AXIS] * MINUNITMULT);
+    DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(3), planner.max_jerk[Z_AXIS] * MINUNITMULT);
     #if HAS_HOTEND
-      DWIN_Frame_AreaCopy(1, 173, 133, 200, 147, LBLX     , MBASE(4));
-      DWIN_Frame_AreaCopy(1,   1, 180,  28, 192, LBLX + 27, MBASE(4) + 1);
-      DWIN_Frame_AreaCopy(1, 202, 133, 228, 147, LBLX + 53, MBASE(4));
-      DWIN_Frame_AreaCopy(1,  18, 150,  25, 160, LBLX + 83, MBASE(4) + 3);  // Max Jerk speed E
+      DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(4), planner.max_jerk[E_AXIS] * MINUNITMULT);
     #endif
   }
-  else {
-    #ifdef USE_STRING_HEADINGS
-      Draw_Title(GET_TEXT_F(MSG_JERK));
-      DWIN_Draw_String(false, true, font8x16, Color_White, Color_Bg_Black, LBLX, MBASE(1), F("Max Jerk X"));
-      DWIN_Draw_String(false, true, font8x16, Color_White, Color_Bg_Black, LBLX, MBASE(2), F("Max Jerk Y"));
-      DWIN_Draw_String(false, true, font8x16, Color_White, Color_Bg_Black, LBLX, MBASE(3), F("Max Jerk Z"));
-      #if HAS_HOTEND
-        DWIN_Draw_String(false, true, font8x16, Color_White, Color_Bg_Black, LBLX, MBASE(4), F("Max Jerk E"));
-      #endif
-    #else
-      DWIN_Frame_TitleCopy(1, 144, 16, 189, 26); // "Jerk"
-      draw_max_en(MBASE(1));          // "Max"
-      draw_jerk_en(MBASE(1));         // "Jerk"
-      draw_speed_en(72, MBASE(1));    // "Speed"
-      say_x(115, MBASE(1));           // "X"
-
-      draw_max_en(MBASE(2));          // "Max"
-      draw_jerk_en(MBASE(2));         // "Jerk"
-      draw_speed_en(72, MBASE(2));    // "Speed"
-      say_y(115, MBASE(2));           // "Y"
-
-      draw_max_en(MBASE(3));          // "Max"
-      draw_jerk_en(MBASE(3));         // "Jerk"
-      draw_speed_en(72, MBASE(3));    // "Speed"
-      say_z(115, MBASE(3));           // "Z"
-
-      #if HAS_HOTEND
-        draw_max_en(MBASE(4));        // "Max"
-        draw_jerk_en(MBASE(4));       // "Jerk"
-        draw_speed_en(72, MBASE(4));  // "Speed"
-        say_e(115, MBASE(4));         // "E"
-      #endif
-    #endif
-  }
-
-  Draw_Back_First();
-  LOOP_L_N(i, 3 + ENABLED(HAS_HOTEND)) Draw_Menu_Line(i + 1, ICON_MaxSpeedJerkX + i);
-  DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(1), planner.max_jerk[X_AXIS] * MINUNITMULT);
-  DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(2), planner.max_jerk[Y_AXIS] * MINUNITMULT);
-  DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(3), planner.max_jerk[Z_AXIS] * MINUNITMULT);
-  #if HAS_HOTEND
-    DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 210, MBASE(4), planner.max_jerk[E_AXIS] * MINUNITMULT);
-  #endif
-}
+#endif
 
 inline void Draw_Steps_Menu() {
   Clear_Main_Window();
@@ -3636,7 +3642,9 @@ void DWIN_HandleScreen() {
     #endif
     case MaxSpeed:        HMI_MaxSpeed(); break;
     case MaxAcceleration: HMI_MaxAcceleration(); break;
-    case MaxJerk:         HMI_MaxJerk(); break;
+    #if HAS_CLASSIC_JERK
+      case MaxJerk:       HMI_MaxJerk(); break;
+    #endif
     case Step:            HMI_Step(); break;
     case Move_X:          HMI_Move_X(); break;
     case Move_Y:          HMI_Move_Y(); break;
@@ -3657,7 +3665,9 @@ void DWIN_HandleScreen() {
     case PrintSpeed:      HMI_PrintSpeed(); break;
     case MaxSpeed_value:  HMI_MaxFeedspeedXYZE(); break;
     case MaxAcceleration_value: HMI_MaxAccelerationXYZE(); break;
-    case MaxJerk_value:   HMI_MaxJerkXYZE(); break;
+    #if HAS_CLASSIC_JERK
+      case MaxJerk_value: HMI_MaxJerkXYZE(); break;
+    #endif
     case Step_value:      HMI_StepXYZE(); break;
     default: break;
   }

--- a/buildroot/tests/STM32F103RET6_creality-tests
+++ b/buildroot/tests/STM32F103RET6_creality-tests
@@ -13,4 +13,8 @@ use_example_configs "Creality/Ender-3 V2"
 opt_enable MARLIN_DEV_MODE
 exec_test $1 $2 "Ender 3 v2" "$3"
 
+use_example_configs "Creality/Ender-3 V2"
+opt_disable CLASSIC_JERK
+exec_test $1 $2 "Ender 3 v2 w/o CLASSIC_JERK" "$3"
+
 restore_configs


### PR DESCRIPTION
### Description

Fixes two issues with the E3V2 DWIN Jerk Menu:
1. Could not compile with CLASSIC_JERK disabled
    This was already partially implemented, but incomplete.
2. Edited values were stored to incorrect axis index
    This was incorrectly using the axis that was most recently edited in the STEP menu.

The changes look bigger than they are. The large block of code was just an indent so it could be placed inside an `#if` condition.

### Benefits

Allows editing jerk from the LCD, as well as compiling without CLASSIC_JERK

### Configurations

E3 V2 example, with CLASSIC_JERK enabled or disabled, depending on which fix you want to test.

### Related Issues

N/A (Reported by @CRCinAU on Discord)
