### PR TITLE
Fix SDCARD_EEPROM_EMULATION hang on E3V2

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -216,7 +216,7 @@ void HMI_SetLanguageCache() {
 }
 
 void HMI_SetLanguage() {
-  #if ENABLED(EEPROM_SETTINGS)
+  #if BOTH(EEPROM_SETTINGS, IIC_BL24CXX_EEPROM)
     BL24CXX::read(DWIN_LANGUAGE_EEPROM_ADDRESS, (uint8_t*)&HMI_flag.language, sizeof(HMI_flag.language));
   #endif
   HMI_SetLanguageCache();
@@ -225,7 +225,7 @@ void HMI_SetLanguage() {
 void HMI_ToggleLanguage() {
   HMI_flag.language = HMI_IsChinese() ? DWIN_ENGLISH : DWIN_CHINESE;
   HMI_SetLanguageCache();
-  #if ENABLED(EEPROM_SETTINGS)
+  #if BOTH(EEPROM_SETTINGS, IIC_BL24CXX_EEPROM)
     BL24CXX::write(DWIN_LANGUAGE_EEPROM_ADDRESS, (uint8_t*)&HMI_flag.language, sizeof(HMI_flag.language));
   #endif
 }

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -43,30 +43,16 @@
 // EEPROM
 //
 #if NO_EEPROM_SELECTED
-  // FLASH
-  //#define FLASH_EEPROM_EMULATION
+  #define IIC_BL24CXX_EEPROM                      // EEPROM on I2C-0
+  //#define SDCARD_EEPROM_EMULATION
+#endif
 
-  // I2C
-  #define IIC_BL24CXX_EEPROM                      // EEPROM on I2C-0 used only for display settings
-  #if ENABLED(IIC_BL24CXX_EEPROM)
-    #define IIC_EEPROM_SDA                  PA11
-    #define IIC_EEPROM_SCL                  PA12
-    #define MARLIN_EEPROM_SIZE             0x800  // 2Kb (24C16)
-  #else
-    #define SDCARD_EEPROM_EMULATION               // SD EEPROM until all EEPROM is BL24CXX
-    #define MARLIN_EEPROM_SIZE             0x800  // 2Kb
-  #endif
-
-  // SPI
-  //#define SPI_EEPROM                            // EEPROM on SPI-0
-  //#define SPI_CHAN_EEPROM1  ?
-  //#define SPI_EEPROM1_CS    ?
-
-  // 2K EEPROM
-  //#define SPI_EEPROM2_CS    ?
-
-  // 32Mb FLASH
-  //#define SPI_FLASH_CS      ?
+#if ENABLED(IIC_BL24CXX_EEPROM)
+  #define IIC_EEPROM_SDA                  PA11
+  #define IIC_EEPROM_SCL                  PA12
+  #define MARLIN_EEPROM_SIZE             0x800  // 2Kb (24C16)
+#elif ENABLED(SDCARD_EEPROM_EMULATION)
+  #define MARLIN_EEPROM_SIZE             0x800  // 2Kb
 #endif
 
 //

--- a/buildroot/tests/STM32F103RET6_creality-tests
+++ b/buildroot/tests/STM32F103RET6_creality-tests
@@ -15,6 +15,7 @@ exec_test $1 $2 "Ender 3 v2" "$3"
 
 use_example_configs "Creality/Ender-3 V2"
 opt_disable CLASSIC_JERK
-exec_test $1 $2 "Ender 3 v2 w/o CLASSIC_JERK" "$3"
+opt_enable SDCARD_EEPROM_EMULATION
+exec_test $1 $2 "Ender 3 v2, SD EEPROM, w/o CLASSIC_JERK" "$3"
 
 restore_configs

--- a/buildroot/tests/STM32F103RET6_creality-tests
+++ b/buildroot/tests/STM32F103RET6_creality-tests
@@ -15,7 +15,7 @@ exec_test $1 $2 "Ender 3 v2" "$3"
 
 use_example_configs "Creality/Ender-3 V2"
 opt_disable CLASSIC_JERK
-opt_enable SDCARD_EEPROM_EMULATION
+opt_add SDCARD_EEPROM_EMULATION
 exec_test $1 $2 "Ender 3 v2, SD EEPROM, w/o CLASSIC_JERK" "$3"
 
 restore_configs


### PR DESCRIPTION
### Description

The E3V2 DWIN display code assumes it is using `IIC_BL24CXX_EEPROM` and tries to access it directly to store the screen's language setting. This caused hangs if users tried to override this and use SDCARD_EEPROM_EMULATION, and the EEPROM was accessed anyway to retrieve the screen's language setting.

This change resolves issues surrounding SDCARD_EEPROM_EMULATION, although the screen's language setting will not be stored.

### Benefits

Can use SD EEPROM if you really want to.

### Configurations

See included automated test change for the steps needed to generate a configuration.

### Related Issues

Fixes  #20272
