### PR TITLE
Make M220 B / R into a standard feature

### DIFF
--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -37,11 +37,9 @@
  */
 void GcodeSuite::M220() {
 
-  #if HAS_PRUSA_MMU2
-    static int16_t backup_feedrate_percentage = 100;
-    if (parser.seen('B')) backup_feedrate_percentage = feedrate_percentage;
-    if (parser.seen('R')) feedrate_percentage = backup_feedrate_percentage;
-  #endif
+  static int16_t backup_feedrate_percentage = 100;
+  if (parser.seen('B')) backup_feedrate_percentage = feedrate_percentage;
+  if (parser.seen('R')) feedrate_percentage = backup_feedrate_percentage;
 
   if (parser.seenval('S')) feedrate_percentage = parser.value_int();
 


### PR DESCRIPTION
### Description

This is a pull request for issue #20333, and a variation on PR #20345, modified to be based on bugfix-2.0.x.

The feedrate backup and restore feature for M220 is mentioned in [the documentation](https://marlinfw.org/docs/gcode/M220.html), but what is not mentioned is that it is gated behind the PRUSA_MMU2 macro.

### Benefits

This PR amends the code to match the documentation by enabling the backup and restore feature regardless of PRUSA_MMU2.

### Configurations

No special configuration required.

### Related Issues

#20333 by @thomaslai.
#20345 by @nb-rapidia

