### PR TITLE
Check for Minimum PIO Version to Build Marlin

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -16,6 +16,29 @@ except ImportError:
 	# PIO >= 4.4
 	from platformio.package.meta import PackageSpec as PackageManager
 
+PIO_VERSION_MIN = (5, 0, 3)
+try:
+	from platformio import VERSION as PIO_VERSION
+	weights = (10000, 1000, 100)
+	version_min = sum([x[0] * x[1] for x in zip(weights, PIO_VERSION_MIN)])
+	version_cur = sum([x[0] * x[1] for x in zip(weights, PIO_VERSION)])
+	if version_cur < version_min:
+		print()
+		print("**************************************************")
+		print("******    Unsupported PlatformIO Version    ******")
+		print("******          for Building Marlin         ******")
+		print("******                                      ******")
+		print("******      Minimum version: ", PIO_VERSION_MIN, "    ******")
+		print("******      Current Version: ", PIO_VERSION, "    ******")
+		print("******                                      ******")
+		print("******           Please, update it          ******")
+		print("**************************************************")
+		print()
+		exit(1)
+except ImportError:
+	print("Can't detect PlatformIO Version")
+
+
 Import("env")
 
 #print(env.Dump())

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -25,19 +25,18 @@ try:
 	if version_cur < version_min:
 		print()
 		print("**************************************************")
-		print("******    Unsupported PlatformIO Version    ******")
-		print("******          for Building Marlin         ******")
+		print("******      An update to PlatformIO is      ******")
+		print("******  required to build Marlin Firmware.  ******")
 		print("******                                      ******")
 		print("******      Minimum version: ", PIO_VERSION_MIN, "    ******")
 		print("******      Current Version: ", PIO_VERSION, "    ******")
 		print("******                                      ******")
-		print("******           Please, update it          ******")
+		print("******   Update PlatformIO and try again.   ******")
 		print("**************************************************")
 		print()
 		exit(1)
 except:
 	print("Can't detect PlatformIO Version")
-
 
 Import("env")
 

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -35,6 +35,8 @@ try:
 		print("**************************************************")
 		print()
 		exit(1)
+except SystemExit:
+	exit(1)
 except:
 	print("Can't detect PlatformIO Version")
 

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -35,7 +35,7 @@ try:
 		print("**************************************************")
 		print()
 		exit(1)
-except ImportError:
+except:
 	print("Can't detect PlatformIO Version")
 
 

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -19,9 +19,9 @@ except ImportError:
 PIO_VERSION_MIN = (5, 0, 3)
 try:
 	from platformio import VERSION as PIO_VERSION
-	weights = (10000, 1000, 100)
-	version_min = sum([x[0] * x[1] for x in zip(weights, PIO_VERSION_MIN)])
-	version_cur = sum([x[0] * x[1] for x in zip(weights, PIO_VERSION)])
+	weights = (1000, 100, 1)
+	version_min = sum([x[0] * float(re.sub(r'[^0-9]', '.', str(x[1]))) for x in zip(weights, PIO_VERSION_MIN)])
+	version_cur = sum([x[0] * float(re.sub(r'[^0-9]', '.', str(x[1]))) for x in zip(weights, PIO_VERSION)])
 	if version_cur < version_min:
 		print()
 		print("**************************************************")


### PR DESCRIPTION
### Description

With recent update on STM32F1 dependencies, users need to update to PIO 5.0.3 to be able to build Marlin.

This PR add a minimum version check for your dependency script, and stop the build if the PIO version is too old.

Message:
```
**************************************************
******    Unsupported PlatformIO Version    ******
******          for Building Marlin         ******
******                                      ******
******      Minimum version:  (5, 0, 3)     ******
******      Current Version:  (5, 0, 1)     ******
******                                      ******
******           Please, update it          ******
**************************************************
```

We can remove the `exit(1)`, if we want just warn... 

### Benefits

Help users find out why their build is failing, with recent Marlin changes.

### Related Issues

#20325 
