### PR TITLE
Fix MESH_BED_LEVELING w/o SEGMENT_LEVELED_MOVES

### DIFF
--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -71,8 +71,8 @@
 
       // Start and end in the same cell? No split needed.
       if (scel == ecel) {
-        line_to_destination(scaled_fr_mm_s);
         current_position = destination;
+        line_to_current_position(scaled_fr_mm_s);
         return;
       }
 
@@ -104,8 +104,8 @@
       else {
         // Must already have been split on these border(s)
         // This should be a rare case.
-        line_to_destination(scaled_fr_mm_s);
         current_position = destination;
+        line_to_current_position(scaled_fr_mm_s);
         return;
       }
 


### PR DESCRIPTION
### Description

MESH_BED_LEVELING was hanging/crashing controllers when SEGMENT_LEVELED_MOVES is disabled, due to infinite recursion in `mesh_bed_leveling::line_to_destination`. This resolves the infinite recursion, and makes the MBL version of this function nearly (but not quite) identical to the ABL version.

### Benefits

Allows SEGMENT_LEVELED_MOVES to be disabled with MBL.

### Configurations

These are for use in the simulator. Any MBL setup could reproduce the problems by disabling SEGMENT_LEVELED_MOVES.
[Configuration_adv.zip](https://github.com/MarlinFirmware/Marlin/files/5634918/Configuration_adv.zip)

### Related Issues

Fixes #20275
