### PR TITLE
ubl: Avoid near variable, reserved keyword in GCC 9.1

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -727,7 +727,7 @@
      * Probe all invalidated locations of the mesh that can be reached by the probe.
      * This attempts to fill in locations closest to the nozzle's start location first.
      */
-    void unified_bed_leveling::probe_entire_mesh(const xy_pos_t &near, const bool do_ubl_mesh_map, const bool stow_probe, const bool do_furthest) {
+    void unified_bed_leveling::probe_entire_mesh(const xy_pos_t &pos, const bool do_ubl_mesh_map, const bool stow_probe, const bool do_furthest) {
       probe.deploy(); // Deploy before ui.capture() to allow for PAUSE_BEFORE_DEPLOY_STOW
 
       TERN_(HAS_LCD_MENU, ui.capture());
@@ -758,7 +758,7 @@
 
         best = do_furthest
           ? find_furthest_invalid_mesh_point()
-          : find_closest_mesh_point_of_type(INVALID, near, true);
+          : find_closest_mesh_point_of_type(INVALID, pos, true);
 
         if (best.pos.x >= 0) {    // mesh point found and is reachable by probe
           TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(best.pos, ExtUI::PROBE_START));
@@ -788,8 +788,8 @@
       restore_ubl_active_state_and_leave();
 
       do_blocking_move_to_xy(
-        constrain(near.x - probe.offset_xy.x, MESH_MIN_X, MESH_MAX_X),
-        constrain(near.y - probe.offset_xy.y, MESH_MIN_Y, MESH_MAX_Y)
+        constrain(pos.x - probe.offset_xy.x, MESH_MIN_X, MESH_MAX_X),
+        constrain(pos.y - probe.offset_xy.y, MESH_MIN_Y, MESH_MAX_Y)
       );
     }
 
@@ -1206,7 +1206,7 @@
 
       found_a_NAN = true;
 
-      xy_int8_t near { -1, -1 };
+      xy_int8_t near_pos { -1, -1 };
       float d1, d2 = 99999.9f;
       GRID_LOOP(k, l) {
         if (isnan(z_values[k][l])) continue;
@@ -1221,7 +1221,7 @@
 
         if (d1 < d2) {    // Invalid mesh point (i,j) is closer to the defined point (k,l)
           d2 = d1;
-          near.set(i, j);
+          near_pos.set(i, j);
         }
       }
 
@@ -1229,8 +1229,8 @@
       // At this point d2 should have the near defined mesh point to invalid mesh point (i,j)
       //
 
-      if (found_a_real && near.x >= 0 && d2 > farthest.distance) {
-        farthest.pos = near;      // Found an invalid location farther from the defined mesh point
+      if (found_a_real && near_pos.x >= 0 && d2 > farthest.distance) {
+        farthest.pos = near_pos; // Found an invalid location farther from the defined mesh point
         farthest.distance = d2;
       }
     } // GRID_LOOP


### PR DESCRIPTION
Problem seen trying to build the simulator with mingw64....

