### PR TITLE
Add Creality Board 452 Support

### DIFF
--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -109,6 +109,8 @@
   #else
     #error "LCD_SERIAL_PORT must be -1 or from 1 to 3. Please update your configuration."
   #endif
+
+  #define SERIAL_GET_TX_BUFFER_FREE LCD_SERIAL.availableForWrite
 #endif
 
 // Set interrupt grouping for this MCU

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -329,6 +329,7 @@
 #define BOARD_CHITU3D_V6              4036  // Chitu3D TronXY X5SA V5 Board
 #define BOARD_CREALITY_V4             4037  // Creality v4.x (STM32F103RE)
 #define BOARD_CREALITY_V427           4038  // Creality v4.2.7 (STM32F103RE)
+#define BOARD_CREALITY_V452           4043  // Creality v4.5.2 (STM32F103RE)
 #define BOARD_TRIGORILLA_PRO          4039  // Trigorilla Pro (STM32F103ZET6)
 #define BOARD_FLY_MINI                4040  // FLY MINI (STM32F103RCT6)
 #define BOARD_FLSUN_HISPEED           4041  // FLSUN HiSpeedV1 (STM32F103VET6)

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -329,11 +329,11 @@
 #define BOARD_CHITU3D_V6              4036  // Chitu3D TronXY X5SA V5 Board
 #define BOARD_CREALITY_V4             4037  // Creality v4.x (STM32F103RE)
 #define BOARD_CREALITY_V427           4038  // Creality v4.2.7 (STM32F103RE)
-#define BOARD_CREALITY_V452           4043  // Creality v4.5.2 (STM32F103RE)
-#define BOARD_TRIGORILLA_PRO          4039  // Trigorilla Pro (STM32F103ZET6)
-#define BOARD_FLY_MINI                4040  // FLY MINI (STM32F103RCT6)
-#define BOARD_FLSUN_HISPEED           4041  // FLSUN HiSpeedV1 (STM32F103VET6)
-#define BOARD_BEAST                   4042  // STM32F103RET6 Libmaple-based controller
+#define BOARD_CREALITY_V452           4039  // Creality v4.5.2 (STM32F103RE)
+#define BOARD_TRIGORILLA_PRO          4040  // Trigorilla Pro (STM32F103ZET6)
+#define BOARD_FLY_MINI                4041  // FLY MINI (STM32F103RCT6)
+#define BOARD_FLSUN_HISPEED           4042  // FLSUN HiSpeedV1 (STM32F103VET6)
+#define BOARD_BEAST                   4043  // STM32F103RET6 Libmaple-based controller
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -530,6 +530,8 @@
   #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality
 #elif MB(CREALITY_V427)
   #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality
+#elif MB(CREALITY_V452)
+  #include "stm32f1/pins_CREALITY_V452.h"       // STM32F1                                env:STM32F103RET6_creality
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro
 #elif MB(FLY_MINI)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -21,7 +21,7 @@
  */
 
 /**
- * CREALITY (STM32F103) board pin assignments
+ * Creality 4.2.x (STM32F103RET6) board pin assignments
  */
 
 #if NOT_TARGET(__STM32F1__)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -27,7 +27,7 @@
 #if NOT_TARGET(__STM32F1__)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #elif HOTENDS > 1 || E_STEPPERS > 1
-  #error "Creality V4 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Creality_V4 only supports one hotend / E-stepper. Comment out this line to continue."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
@@ -1,0 +1,116 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Creality v4.5.2 (STM32F103) board pin assignments
+ */
+
+#ifndef __STM32F1__
+  #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
+#endif
+
+#if HOTENDS > 1 || E_STEPPERS > 1
+  #error "CREALITY supports up to 1 hotends / E-steppers. Comment out this line to continue."
+#endif
+
+#define BOARD_NAME "Creality v4.5.2"
+#define DEFAULT_MACHINE_NAME "Creality3D"
+
+//
+// EEPROM
+//
+#if NO_EEPROM_SELECTED
+  #define IIC_BL24CXX_EEPROM                      // EEPROM on I2C-0 used only for display settings
+  #if ENABLED(IIC_BL24CXX_EEPROM)
+    #define IIC_EEPROM_SDA                  PA11
+    #define IIC_EEPROM_SCL                  PA12
+    #define MARLIN_EEPROM_SIZE             0x800  // 2Kb (24C16)
+  #else
+    #define SDCARD_EEPROM_EMULATION               // SD EEPROM until all EEPROM is BL24CXX
+    #define MARLIN_EEPROM_SIZE             0x800  // 2Kb
+  #endif
+#endif
+
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN           PC4
+// #define X_MAX_PIN          PA7
+#define Y_MIN_PIN           PC5
+#define Z_MIN_PIN           PA4
+#define COM_PIN             PA5
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN        PC3
+#define X_STEP_PIN          PB8
+#define X_DIR_PIN           PB7
+
+#define Y_ENABLE_PIN        PC3
+#define Y_STEP_PIN          PB6
+#define Y_DIR_PIN           PB5
+
+#define Z_ENABLE_PIN        PC3
+#define Z_STEP_PIN          PB4
+#define Z_DIR_PIN           PB3
+
+#define E0_ENABLE_PIN       PC3
+#define E0_STEP_PIN         PC2
+#define E0_DIR_PIN          PB9
+
+
+//
+// Release PB4 (Z_STEP_PIN) from JTAG NRST role
+//
+#define DISABLE_DEBUG
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         PB1   // TH1
+#define TEMP_BED_PIN       PB0   // TB1
+
+//
+// Heaters / Fans
+
+#define HEATER_0_PIN       PA1   // HEATER1
+#define HEATER_BED_PIN     PA2   // HOT BED
+
+#define FAN_PIN            PA0   // FAN
+#define FAN_SOFT_PWM
+
+/* SD card detect */
+#define SD_DETECT_PIN      PC7
+#define NO_SD_HOST_DRIVE  // This board's SD is only seen by the printer
+
+#define SDIO_SUPPORT      // Extra added by Creality
+#define SDIO_CLOCK 6000000 // In original source code overridden by Creality in sdio.h
+
+#define CASE_LIGHT_PIN PA6
+
+#define FIL_RUNOUT_PIN PA7
+#define PROBE_ENABLE_PIN    PC6 // Optoswitch to Enable Z Probe
+
+
+#define TEMP_TIMER_CHAN 4 // Channel of the timer to use for compare and interrupts

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
@@ -21,10 +21,10 @@
  */
 
 /**
- * Creality v4.5.2 (STM32F103) board pin assignments
+ * Creality v4.5.2 (STM32F103RET6) board pin assignments
  */
 
-#ifndef __STM32F1__
+#if NOT_TARGET(__STM32F1__)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #endif
 
@@ -35,21 +35,23 @@
 #define BOARD_NAME "Creality v4.5.2"
 #define DEFAULT_MACHINE_NAME "Creality3D"
 
+#define BOARD_NO_NATIVE_USB
+
 //
 // EEPROM
 //
 #if NO_EEPROM_SELECTED
-  #define IIC_BL24CXX_EEPROM                      // EEPROM on I2C-0 used only for display settings
-  #if ENABLED(IIC_BL24CXX_EEPROM)
-    #define IIC_EEPROM_SDA                  PA11
-    #define IIC_EEPROM_SCL                  PA12
-    #define MARLIN_EEPROM_SIZE             0x800  // 2Kb (24C16)
-  #else
-    #define SDCARD_EEPROM_EMULATION               // SD EEPROM until all EEPROM is BL24CXX
-    #define MARLIN_EEPROM_SIZE             0x800  // 2Kb
-  #endif
+  #define IIC_BL24CXX_EEPROM                      // EEPROM on I2C-0
+  //#define SDCARD_EEPROM_EMULATION
 #endif
 
+#if ENABLED(IIC_BL24CXX_EEPROM)
+  #define IIC_EEPROM_SDA                  PA11
+  #define IIC_EEPROM_SCL                  PA12
+  #define MARLIN_EEPROM_SIZE             0x800  // 2Kb (24C16)
+#elif ENABLED(SDCARD_EEPROM_EMULATION)
+  #define MARLIN_EEPROM_SIZE             0x800  // 2Kb
+#endif
 
 //
 // Limit Switches
@@ -58,7 +60,7 @@
 // #define X_MAX_PIN          PA7
 #define Y_MIN_PIN           PC5
 #define Z_MIN_PIN           PA4
-#define COM_PIN             PA5
+#define PROBE_TARE_PIN      PA5
 
 //
 // Steppers
@@ -111,6 +113,3 @@
 
 #define FIL_RUNOUT_PIN PA7
 #define PROBE_ENABLE_PIN    PC6 // Optoswitch to Enable Z Probe
-
-
-#define TEMP_TIMER_CHAN 4 // Channel of the timer to use for compare and interrupts

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
@@ -26,10 +26,8 @@
 
 #if NOT_TARGET(__STM32F1__)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
-#endif
-
-#if HOTENDS > 1 || E_STEPPERS > 1
-  #error "CREALITY supports up to 1 hotends / E-steppers. Comment out this line to continue."
+#elif HOTENDS > 1 || E_STEPPERS > 1
+  #error "CREALITY_V452 supports up to 1 hotends / E-steppers. Comment out this line to continue."
 #endif
 
 #define BOARD_NAME "Creality v4.5.2"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (C) 2016 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (C) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
@@ -39,7 +39,7 @@
 // EEPROM
 //
 #if NO_EEPROM_SELECTED
-  #define IIC_BL24CXX_EEPROM                      // EEPROM on I2C-0
+  #define IIC_BL24CXX_EEPROM                    // EEPROM on I2C-0
   //#define SDCARD_EEPROM_EMULATION
 #endif
 
@@ -102,12 +102,12 @@
 
 /* SD card detect */
 #define SD_DETECT_PIN      PC7
-#define NO_SD_HOST_DRIVE  // This board's SD is only seen by the printer
+#define NO_SD_HOST_DRIVE       // SD is only seen by the printer
 
-#define SDIO_SUPPORT      // Extra added by Creality
-#define SDIO_CLOCK 6000000 // In original source code overridden by Creality in sdio.h
+#define SDIO_SUPPORT           // Extra added by Creality
+#define SDIO_CLOCK     6000000 // In original source code overridden by Creality in sdio.h
 
-#define CASE_LIGHT_PIN PA6
+#define CASE_LIGHT_PIN     PA6
 
-#define FIL_RUNOUT_PIN PA7
-#define PROBE_ENABLE_PIN    PC6 // Optoswitch to Enable Z Probe
+#define FIL_RUNOUT_PIN     PA7
+#define PROBE_ENABLE_PIN   PC6 // Optoswitch to Enable Z Probe


### PR DESCRIPTION
Following work by @Sebazzz on the Creality CR6 printer, this breaks out the motherboard support to give a path to support in chunks, minimizing rebase work and potential conflicts as LCD code evolves.

Probes with explicit enable pin coming up next followed by ExtUI is homing extensions.