### PR TITLE
SPI TFT for F4 boards on STM32 Hal

### DIFF
--- a/Marlin/src/HAL/STM32/inc/SanityCheck.h
+++ b/Marlin/src/HAL/STM32/inc/SanityCheck.h
@@ -51,3 +51,7 @@
 #elif ENABLED(SERIAL_STATS_DROPPED_RX)
   #error "SERIAL_STATS_DROPPED_RX is not supported on this platform."
 #endif
+
+#if ANY(TFT_COLOR_UI, TFT_LVGL_UI, TFT_CLASSIC_UI) && NOT_TARGET(STM32F4xx, STM32F1xx)
+  #error "TFT_COLOR_UI, TFT_LVGL_UI and TFT_CLASSIC_U are currently only supported on STM32F4 and STM32F1 hardware."
+#endif

--- a/Marlin/src/HAL/STM32/pinsDebug.h
+++ b/Marlin/src/HAL/STM32/pinsDebug.h
@@ -137,32 +137,19 @@ const XrefInfo pin_xref[] PROGMEM = {
 #endif
 
 uint8_t get_pin_mode(const pin_t Ard_num) {
-  uint32_t mode_all = 0;
   const PinName dp = digitalPinToPinName(Ard_num);
-  switch (PORT_ALPHA(dp)) {
-    case 'A' : mode_all = GPIOA->MODER; break;
-    case 'B' : mode_all = GPIOB->MODER; break;
-    case 'C' : mode_all = GPIOC->MODER; break;
-    case 'D' : mode_all = GPIOD->MODER; break;
-    #ifdef PE_0
-      case 'E' : mode_all = GPIOE->MODER; break;
-    #elif defined(PF_0)
-      case 'F' : mode_all = GPIOF->MODER; break;
-    #elif defined(PG_0)
-      case 'G' : mode_all = GPIOG->MODER; break;
-    #elif defined(PH_0)
-      case 'H' : mode_all = GPIOH->MODER; break;
-    #elif defined(PI_0)
-      case 'I' : mode_all = GPIOI->MODER; break;
-    #elif defined(PJ_0)
-      case 'J' : mode_all = GPIOJ->MODER; break;
-    #elif defined(PK_0)
-      case 'K' : mode_all = GPIOK->MODER; break;
-    #elif defined(PL_0)
-      case 'L' : mode_all = GPIOL->MODER; break;
-    #endif
+  uint32_t ll_pin  = STM_LL_GPIO_PIN(dp);
+  GPIO_TypeDef *port = get_GPIO_Port(STM_PORT(dp));
+  uint32_t mode = LL_GPIO_GetPinMode(port, ll_pin);
+  switch (mode)
+  {
+    case LL_GPIO_MODE_ANALOG: return MODE_PIN_ANALOG;
+    case LL_GPIO_MODE_INPUT: return MODE_PIN_INPUT;
+    case LL_GPIO_MODE_OUTPUT: return MODE_PIN_OUTPUT;
+    case LL_GPIO_MODE_ALTERNATE: return MODE_PIN_ALT;
+    TERN_(STM32F1xx, case LL_GPIO_MODE_FLOATING:)
+    default: return 0;
   }
-  return (mode_all >> (2 * uint8_t(PIN_NUM(dp)))) & 0x03;
 }
 
 bool GET_PINMODE(const pin_t Ard_num) {
@@ -217,58 +204,62 @@ bool pwm_status(const pin_t Ard_num) {
 }
 
 void pwm_details(const pin_t Ard_num) {
-  if (pwm_status(Ard_num)) {
-    uint32_t alt_all = 0;
-    const PinName dp = digitalPinToPinName(Ard_num);
-    pin_t pin_number = uint8_t(PIN_NUM(dp));
-    const bool over_7 = pin_number >= 8;
-    const uint8_t ind = over_7 ? 1 : 0;
-    switch (PORT_ALPHA(dp)) {  // get alt function
-      case 'A' : alt_all = GPIOA->AFR[ind]; break;
-      case 'B' : alt_all = GPIOB->AFR[ind]; break;
-      case 'C' : alt_all = GPIOC->AFR[ind]; break;
-      case 'D' : alt_all = GPIOD->AFR[ind]; break;
-      #ifdef PE_0
-        case 'E' : alt_all = GPIOE->AFR[ind]; break;
-      #elif defined (PF_0)
-        case 'F' : alt_all = GPIOF->AFR[ind]; break;
-      #elif defined (PG_0)
-        case 'G' : alt_all = GPIOG->AFR[ind]; break;
-      #elif defined (PH_0)
-        case 'H' : alt_all = GPIOH->AFR[ind]; break;
-      #elif defined (PI_0)
-        case 'I' : alt_all = GPIOI->AFR[ind]; break;
-      #elif defined (PJ_0)
-        case 'J' : alt_all = GPIOJ->AFR[ind]; break;
-      #elif defined (PK_0)
-        case 'K' : alt_all = GPIOK->AFR[ind]; break;
-      #elif defined (PL_0)
-        case 'L' : alt_all = GPIOL->AFR[ind]; break;
-      #endif
-    }
-    if (over_7) pin_number -= 8;
+  #ifndef STM32F1xx
+    if (pwm_status(Ard_num)) {
+      uint32_t alt_all = 0;
+      const PinName dp = digitalPinToPinName(Ard_num);
+      pin_t pin_number = uint8_t(PIN_NUM(dp));
+      const bool over_7 = pin_number >= 8;
+      const uint8_t ind = over_7 ? 1 : 0;
+      switch (PORT_ALPHA(dp)) {  // get alt function
+        case 'A' : alt_all = GPIOA->AFR[ind]; break;
+        case 'B' : alt_all = GPIOB->AFR[ind]; break;
+        case 'C' : alt_all = GPIOC->AFR[ind]; break;
+        case 'D' : alt_all = GPIOD->AFR[ind]; break;
+        #ifdef PE_0
+          case 'E' : alt_all = GPIOE->AFR[ind]; break;
+        #elif defined (PF_0)
+          case 'F' : alt_all = GPIOF->AFR[ind]; break;
+        #elif defined (PG_0)
+          case 'G' : alt_all = GPIOG->AFR[ind]; break;
+        #elif defined (PH_0)
+          case 'H' : alt_all = GPIOH->AFR[ind]; break;
+        #elif defined (PI_0)
+          case 'I' : alt_all = GPIOI->AFR[ind]; break;
+        #elif defined (PJ_0)
+          case 'J' : alt_all = GPIOJ->AFR[ind]; break;
+        #elif defined (PK_0)
+          case 'K' : alt_all = GPIOK->AFR[ind]; break;
+        #elif defined (PL_0)
+          case 'L' : alt_all = GPIOL->AFR[ind]; break;
+        #endif
+      }
+      if (over_7) pin_number -= 8;
 
-    uint8_t alt_func = (alt_all >> (4 * pin_number)) & 0x0F;
-    SERIAL_ECHOPAIR("Alt Function: ", alt_func);
-    if (alt_func < 10) SERIAL_CHAR(' ');
-    SERIAL_ECHOPGM(" - ");
-    switch (alt_func) {
-      case  0 : SERIAL_ECHOPGM("system (misc. I/O)"); break;
-      case  1 : SERIAL_ECHOPGM("TIM1/TIM2 (probably PWM)"); break;
-      case  2 : SERIAL_ECHOPGM("TIM3..5 (probably PWM)"); break;
-      case  3 : SERIAL_ECHOPGM("TIM8..11 (probably PWM)"); break;
-      case  4 : SERIAL_ECHOPGM("I2C1..3"); break;
-      case  5 : SERIAL_ECHOPGM("SPI1/SPI2"); break;
-      case  6 : SERIAL_ECHOPGM("SPI3"); break;
-      case  7 : SERIAL_ECHOPGM("USART1..3"); break;
-      case  8 : SERIAL_ECHOPGM("USART4..6"); break;
-      case  9 : SERIAL_ECHOPGM("CAN1/CAN2, TIM12..14  (probably PWM)"); break;
-      case 10 : SERIAL_ECHOPGM("OTG"); break;
-      case 11 : SERIAL_ECHOPGM("ETH"); break;
-      case 12 : SERIAL_ECHOPGM("FSMC, SDIO, OTG"); break;
-      case 13 : SERIAL_ECHOPGM("DCMI"); break;
-      case 14 : SERIAL_ECHOPGM("unused (shouldn't see this)"); break;
-      case 15 : SERIAL_ECHOPGM("EVENTOUT"); break;
+      uint8_t alt_func = (alt_all >> (4 * pin_number)) & 0x0F;
+      SERIAL_ECHOPAIR("Alt Function: ", alt_func);
+      if (alt_func < 10) SERIAL_CHAR(' ');
+      SERIAL_ECHOPGM(" - ");
+      switch (alt_func) {
+        case  0 : SERIAL_ECHOPGM("system (misc. I/O)"); break;
+        case  1 : SERIAL_ECHOPGM("TIM1/TIM2 (probably PWM)"); break;
+        case  2 : SERIAL_ECHOPGM("TIM3..5 (probably PWM)"); break;
+        case  3 : SERIAL_ECHOPGM("TIM8..11 (probably PWM)"); break;
+        case  4 : SERIAL_ECHOPGM("I2C1..3"); break;
+        case  5 : SERIAL_ECHOPGM("SPI1/SPI2"); break;
+        case  6 : SERIAL_ECHOPGM("SPI3"); break;
+        case  7 : SERIAL_ECHOPGM("USART1..3"); break;
+        case  8 : SERIAL_ECHOPGM("USART4..6"); break;
+        case  9 : SERIAL_ECHOPGM("CAN1/CAN2, TIM12..14  (probably PWM)"); break;
+        case 10 : SERIAL_ECHOPGM("OTG"); break;
+        case 11 : SERIAL_ECHOPGM("ETH"); break;
+        case 12 : SERIAL_ECHOPGM("FSMC, SDIO, OTG"); break;
+        case 13 : SERIAL_ECHOPGM("DCMI"); break;
+        case 14 : SERIAL_ECHOPGM("unused (shouldn't see this)"); break;
+        case 15 : SERIAL_ECHOPGM("EVENTOUT"); break;
+      }
     }
-  }
+  #else
+    // TODO: F1 doesn't support changing pins function, so we need to check the function of the PIN and if it's enabled
+  #endif
 } // pwm_details

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -365,6 +365,7 @@
 #define BOARD_FYSETC_S6_V2_0          4216  // FYSETC S6 v2.0 board
 #define BOARD_FLYF407ZG               4217  // FLYF407ZG board (STM32F407ZG)
 #define BOARD_MKS_ROBIN2              4218  // MKS_ROBIN2 (STM32F407ZE)
+#define BOARD_MKS_ROBIN_PRO_V2        4219  // MKS Robin Pro V2 (STM32F407VE)
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -588,6 +588,8 @@
   #include "stm32f4/pins_FLYF407ZG.h"           // STM32F4                                env:FLYF407ZG
 #elif MB(MKS_ROBIN2)
   #include "stm32f4/pins_MKS_ROBIN2.h"          // STM32F4                                env:MKS_ROBIN2
+#elif MB(MKS_ROBIN_PRO_V2)
+  #include "stm32f4/pins_MKS_ROBIN_PRO_V2.h"    // STM32F4                                env:mks_robin_pro2
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -244,10 +244,10 @@
 #define SPI_DEVICE                             2
 #define SPI_FLASH_SIZE                 0x1000000
 #if ENABLED(SPI_FLASH)
-	#define W25QXX_CS_PIN                      PB12
-	#define W25QXX_MOSI_PIN                    PB15
-	#define W25QXX_MISO_PIN                    PB14
-	#define W25QXX_SCK_PIN                     PB13
+  #define W25QXX_CS_PIN                     PB12
+  #define W25QXX_MOSI_PIN                   PB15
+  #define W25QXX_MISO_PIN                   PB14
+  #define W25QXX_SCK_PIN                    PB13
 #endif
 
 /**
@@ -360,22 +360,22 @@
   #endif // !MKS_MINI_12864
 
 #elif ENABLED(SPI_GRAPHICAL_TFT)
-	#define SPI_TFT_CS_PIN                     PD11
-	#define SPI_TFT_SCK_PIN                    PA5
-	#define SPI_TFT_MISO_PIN                   PA6
-	#define SPI_TFT_MOSI_PIN                   PA7
-	#define SPI_TFT_DC_PIN                     PD10
-	#define SPI_TFT_RST_PIN                    PC6
+  #define SPI_TFT_CS_PIN                    PD11
+  #define SPI_TFT_SCK_PIN                   PA5
+  #define SPI_TFT_MISO_PIN                  PA6
+  #define SPI_TFT_MOSI_PIN                  PA7
+  #define SPI_TFT_DC_PIN                    PD10
+  #define SPI_TFT_RST_PIN                   PC6
 
-	#define LCD_BACKLIGHT_PIN                  PD13
+  #define LCD_BACKLIGHT_PIN                 PD13
 
-    #define TOUCH_CS_PIN                    PE14  // SPI1_NSS
-    #define TOUCH_SCK_PIN                   PA5   // SPI1_SCK
-    #define TOUCH_MISO_PIN                  PA6   // SPI1_MISO
-    #define TOUCH_MOSI_PIN                  PA7   // SPI1_MOSI
+  #define TOUCH_CS_PIN                      PE14  // SPI1_NSS
+  #define TOUCH_SCK_PIN                     PA5   // SPI1_SCK
+  #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
+  #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
 
-    #define BTN_EN1                         PE8
-    #define BTN_EN2                         PE11
-    #define BEEPER_PIN                      PC5
-    #define BTN_ENC                         PE13
+  #define BTN_EN1                           PE8
+  #define BTN_EN2                           PE11
+  #define BEEPER_PIN                        PC5
+  #define BTN_ENC                           PE13
 #endif // HAS_SPI_LCD

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -1,0 +1,384 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#if NOT_TARGET(STM32F4, STM32F4xx)
+  #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
+#elif HOTENDS > 2 || E_STEPPERS > 2
+  #error "MKS Robin Nano V3 supports up to 1 hotends / E-steppers."
+#endif
+
+#define BOARD_INFO_NAME "MKS Robin PRO V2"
+
+// Use one of these or SDCard-based Emulation will be used
+//#define SRAM_EEPROM_EMULATION                   // Use BackSRAM-based EEPROM emulation
+//#define FLASH_EEPROM_EMULATION                    // Use Flash-based EEPROM emulation
+#define I2C_EEPROM
+
+//
+// Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
+//
+
+//
+// Note: MKS Robin board is using SPI2 interface.
+//
+//#define SPI_MODULE 2
+
+//
+// Limit Switches
+//
+#define X_DIAG_PIN                         PA15
+#define Y_DIAG_PIN                         PA12
+#define Z_DIAG_PIN                         PA11
+#define E0_DIAG_PIN                        PC4
+#define E1_DIAG_PIN                        PE7
+
+//
+
+#define X_STOP_PIN                          PA15
+#define Y_STOP_PIN                          PA12
+#define Z_MIN_PIN                           PA11
+#define Z_MAX_PIN                           PC4
+
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                    PA4   // MT_DET
+#endif
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN                        PE4
+#define X_STEP_PIN                          PE3
+#define X_DIR_PIN                           PE2
+#ifndef X_CS_PIN
+  #define X_CS_PIN                          PD5
+#endif
+
+#define Y_ENABLE_PIN                        PE1
+#define Y_STEP_PIN                          PE0
+#define Y_DIR_PIN                           PB9
+#ifndef Y_CS_PIN
+  #define Y_CS_PIN                          PD7
+#endif
+
+#define Z_ENABLE_PIN                        PB8
+#define Z_STEP_PIN                          PB5
+#define Z_DIR_PIN                           PB4
+#ifndef Z_CS_PIN
+  #define Z_CS_PIN                          PD4
+#endif
+
+#define E0_ENABLE_PIN                       PB3
+#define E0_STEP_PIN                         PD6
+#define E0_DIR_PIN                          PD3
+#ifndef E0_CS_PIN
+  #define E0_CS_PIN                         PD9
+#endif
+
+#define E1_ENABLE_PIN                       PA3
+#define E1_STEP_PIN                         PD15
+#define E1_DIR_PIN                          PA1
+#ifndef E1_CS_PIN
+  #define E1_CS_PIN                         PD8
+#endif
+
+//
+// Software SPI pins for TMC2130 stepper drivers
+//
+#if ENABLED(TMC_USE_SW_SPI)
+  #ifndef TMC_SW_MOSI
+    #define TMC_SW_MOSI    PD14
+  #endif
+  #ifndef TMC_SW_MISO
+    #define TMC_SW_MISO    PD1
+  #endif
+  #ifndef TMC_SW_SCK
+    #define TMC_SW_SCK     PD0
+  #endif
+#endif
+
+#if HAS_TMC_UART
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  Serial1
+  //#define X2_HARDWARE_SERIAL Serial1
+  //#define Y_HARDWARE_SERIAL  Serial1
+  //#define Y2_HARDWARE_SERIAL Serial1
+  //#define Z_HARDWARE_SERIAL  Serial1
+  //#define Z2_HARDWARE_SERIAL Serial1
+  //#define E0_HARDWARE_SERIAL Serial1
+  //#define E1_HARDWARE_SERIAL Serial1
+  //#define E2_HARDWARE_SERIAL Serial1
+  //#define E3_HARDWARE_SERIAL Serial1
+  //#define E4_HARDWARE_SERIAL Serial1
+
+  //
+  // Software serial
+  //
+
+  #define X_SERIAL_TX_PIN                  PD5
+  #define X_SERIAL_RX_PIN                  PD5
+
+  #define Y_SERIAL_TX_PIN                  PD7
+  #define Y_SERIAL_RX_PIN                  PD7
+
+  #define Z_SERIAL_TX_PIN                  PD4
+  #define Z_SERIAL_RX_PIN                  PD4
+
+  #define E0_SERIAL_TX_PIN                 PD9
+  #define E0_SERIAL_RX_PIN                 PD9
+
+  #define E1_SERIAL_TX_PIN                 PD8
+  #define E1_SERIAL_RX_PIN                 PD8
+
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE 19200
+#endif // TMC2208 || TMC2209
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN                          PC1   // TH1
+#define TEMP_1_PIN                          PC2   // TH2
+#define TEMP_BED_PIN                        PC0   // TB1
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                        PC3   // HEATER1
+#define HEATER_1_PIN                        PB0   // HEATER2
+#define HEATER_BED_PIN                      PA0   // HOT BED
+
+#define FAN_PIN                             PB1   // FAN
+
+//
+// Thermocouples
+//
+//#define MAX6675_SS_PIN                    PE5   // TC1 - CS1
+//#define MAX6675_SS_PIN                    PE6   // TC2 - CS2
+
+//
+// Misc. Functions
+//
+// #define POWER_LOSS_PIN                      PA2   // PW_DET
+// #define PS_ON_PIN                           PA3   // PW_OFF
+// #define SUICIDE_PIN                         PB2     // Enable MKSPWC support
+// #define KILL_PIN                            PA2     // Enable MKSPWC support
+// #define KILL_PIN_INVERTING                  true     // Enable MKSPWC support
+#define SERVO0_PIN                          PA8   // Enable BLTOUCH support
+//#define LED_PIN                           PB2
+
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION                  ONBOARD
+#endif
+
+// #define USE_NEW_SPI_API 1
+
+//
+// Onboard SD card
+// NOT compatible with LCD
+//
+// detect pin dont work when ONBOARD and NO_SD_HOST_DRIVE disabled
+#if !defined(SDCARD_CONNECTION) || SDCARD_CONNECTION == ONBOARD
+  #define CUSTOM_SPI_PINS
+  #if ENABLED(CUSTOM_SPI_PINS)
+
+    #if USE_NEW_SPI_API
+      #define SD_SPI MARLIN_SPI(HardwareSPI3, PC9)
+    #else
+      #define ENABLE_SPI3
+      #define SS_PIN                            -1
+      #define SDSS                              PC9
+      #define SCK_PIN                           PC10
+      #define MISO_PIN                          PC11
+      #define MOSI_PIN                          PC12
+    #endif
+    #define SD_DETECT_PIN                     PD12
+  #endif
+#endif
+
+
+/*
+//
+// LCD SD
+//
+#if SDCARD_CONNECTION == LCD
+  #define CUSTOM_SPI_PINS
+  #if ENABLED(CUSTOM_SPI_PINS)
+    #define ENABLE_SPI1
+    #define SDSS                              PE10
+    #define SCK_PIN                           PA5
+    #define MISO_PIN                          PA6
+    #define MOSI_PIN                          PA7
+    #define SD_DETECT_PIN                     PE12
+  #endif
+#endif
+*/
+
+//
+// LCD / Controller
+#define SPI_FLASH
+// #define HAS_SPI_FLASH 1
+#define SPI_DEVICE 2
+#define SPI_FLASH_SIZE 0x1000000
+#if ENABLED(SPI_FLASH)
+	#define 	W25QXX_CS_PIN		PB12
+	#define 	W25QXX_MOSI_PIN		PB15
+	#define 	W25QXX_MISO_PIN		PB14
+	#define 	W25QXX_SCK_PIN		PB13
+#endif
+
+
+/**
+ *                _____                                             _____
+ *   (BEEPER)PC5 | · · | PE13(BTN_ENC)             (SPI1 MISO) PA6 | · · | PA5 (SPI1 SCK)
+ *  (LCD_EN)PD13 | · · | PC6(LCD_RS)                 (BTN_EN1) PE8 | · · | PE10 (SPI1 CS)
+ *  (LCD_D4)PE14 | · · | PE15(LCD_D5)               (BTN_EN2) PE11 | · · | PA7 (SPI1 MOSI)
+ *  (LCD_D6)PD11 | · · | PD10(LCD_D7)               (SPI DET) PE12 | · · | RESET
+ *           GND | · · | 5V                                    GND | · · | 3.3V
+ *                ￣￣￣                                             ￣￣￣
+ *                EXP1                                               EXP2
+ */
+
+#if EITHER(TFT_480x320_SPI, TFT_LVGL_UI_SPI)
+  #ifndef TOUCH_CALIBRATION_X
+    #define TOUCH_CALIBRATION_X         -17253
+  #endif
+  #ifndef TOUCH_CALIBRATION_Y
+    #define TOUCH_CALIBRATION_Y          11579
+  #endif
+  #ifndef TOUCH_OFFSET_X
+    #define TOUCH_OFFSET_X                 514
+  #endif
+  #ifndef TOUCH_OFFSET_Y
+    #define TOUCH_OFFSET_Y                 -24
+  #endif
+  #ifndef TOUCH_ORIENTATION
+    #define TOUCH_ORIENTATION   TOUCH_LANDSCAPE
+  #endif
+
+  #define TFT_CS_PIN                        PD11
+  #define TFT_SCK_PIN                       PA5
+  #define TFT_MISO_PIN                      PA6
+  #define TFT_MOSI_PIN                      PA7
+  #define TFT_DC_PIN                        PD10
+  #define TFT_RST_PIN                       PC6
+  #define TFT_A0_PIN                  TFT_DC_PIN
+
+  #define TFT_RESET_PIN                     PC6
+  #define TFT_BACKLIGHT_PIN                 PD13
+
+  #define TOUCH_BUTTONS_HW_SPI
+  #define TOUCH_BUTTONS_HW_SPI_DEVICE          1
+
+  #define LCD_BACKLIGHT_PIN   PD13
+  #ifndef TFT_WIDTH
+    #define TFT_WIDTH                        480
+  #endif
+  #ifndef TFT_HEIGHT
+    #define TFT_HEIGHT                       320
+  #endif
+
+  #define TOUCH_CS_PIN                      PE14  // SPI1_NSS
+  #define TOUCH_SCK_PIN                     PA5   // SPI1_SCK
+  #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
+  #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
+
+  #define BTN_EN1          PE8
+  #define BTN_EN2          PE11
+  #define BEEPER_PIN       PC5
+  #define BTN_ENC          PE13
+
+  #define LCD_READ_ID                       0xD3
+  #define LCD_USE_DMA_SPI
+
+  // #define TFT_DRIVER                      ST7796
+  #define TFT_BUFFER_SIZE                  14400
+
+#elif HAS_SPI_LCD
+  #define BEEPER_PIN       PC5
+  #define BTN_ENC          PE13
+  #define LCD_PINS_ENABLE  PD13
+  #define LCD_PINS_RS      PC6
+  #define BTN_EN1          PE8
+  #define BTN_EN2          PE11
+  #define LCD_BACKLIGHT_PIN -1
+
+  // MKS MINI12864 and MKS LCD12864B; If using MKS LCD12864A (Need to remove RPK2 resistor)
+  #if ENABLED(MKS_MINI_12864)
+    //#define LCD_BACKLIGHT_PIN -1
+    //#define LCD_RESET_PIN  -1
+    #define DOGLCD_A0      PD11
+    #define DOGLCD_CS      PE15
+    //#define DOGLCD_SCK     PA5
+    //#define DOGLCD_MOSI    PA7
+
+    // Required for MKS_MINI_12864 with this board
+    //#define MKS_LCD12864B
+    //#undef SHOW_BOOTSCREEN
+
+  #else // !MKS_MINI_12864
+
+    #define LCD_PINS_D4    PE14
+    #if ENABLED(ULTIPANEL)
+      #define LCD_PINS_D5  PE15
+      #define LCD_PINS_D6  PD11
+      #define LCD_PINS_D7  PD10
+    #endif
+
+    #ifndef ST7920_DELAY_1
+    #define ST7920_DELAY_1 DELAY_NS(96)
+    #endif
+    #ifndef ST7920_DELAY_2
+      #define ST7920_DELAY_2 DELAY_NS(48)
+    #endif
+    #ifndef ST7920_DELAY_3
+      #define ST7920_DELAY_3 DELAY_NS(600)
+    #endif
+
+  #endif // !MKS_MINI_12864
+
+#elif ENABLED(SPI_GRAPHICAL_TFT)
+	#define SPI_TFT_CS_PIN			PD11
+	#define SPI_TFT_SCK_PIN			PA5
+	#define SPI_TFT_MISO_PIN		PA6
+	#define SPI_TFT_MOSI_PIN		PA7
+	#define SPI_TFT_DC_PIN			PD10
+	#define SPI_TFT_RST_PIN			PC6
+
+	#define LCD_BACKLIGHT_PIN   PD13
+
+    #define TOUCH_CS_PIN                    PE14   	// SPI1_NSS
+    #define TOUCH_SCK_PIN                   PA5  	// SPI1_SCK
+    #define TOUCH_MISO_PIN                  PA6  	// SPI1_MISO
+    #define TOUCH_MOSI_PIN                  PA7  	// SPI1_MOSI
+
+    #define BTN_EN1          PE8
+    #define BTN_EN2          PE11
+    #define BEEPER_PIN       PC5
+    #define BTN_ENC          PE13
+#endif // HAS_SPI_LCD

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -31,7 +31,7 @@
 
 // Use one of these or SDCard-based Emulation will be used
 //#define SRAM_EEPROM_EMULATION                   // Use BackSRAM-based EEPROM emulation
-//#define FLASH_EEPROM_EMULATION                    // Use Flash-based EEPROM emulation
+//#define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation
 #define I2C_EEPROM
 
 //
@@ -41,16 +41,16 @@
 //
 // Note: MKS Robin board is using SPI2 interface.
 //
-//#define SPI_MODULE 2
+//#define SPI_MODULE                           2
 
 //
 // Limit Switches
 //
-#define X_DIAG_PIN                         PA15
-#define Y_DIAG_PIN                         PA12
-#define Z_DIAG_PIN                         PA11
-#define E0_DIAG_PIN                        PC4
-#define E1_DIAG_PIN                        PE7
+#define X_DIAG_PIN                          PA15
+#define Y_DIAG_PIN                          PA12
+#define Z_DIAG_PIN                          PA11
+#define E0_DIAG_PIN                         PC4
+#define E1_DIAG_PIN                         PE7
 
 //
 
@@ -106,13 +106,13 @@
 //
 #if ENABLED(TMC_USE_SW_SPI)
   #ifndef TMC_SW_MOSI
-    #define TMC_SW_MOSI    PD14
+    #define TMC_SW_MOSI                     PD14
   #endif
   #ifndef TMC_SW_MISO
-    #define TMC_SW_MISO    PD1
+    #define TMC_SW_MISO                     PD1
   #endif
   #ifndef TMC_SW_SCK
-    #define TMC_SW_SCK     PD0
+    #define TMC_SW_SCK                      PD0
   #endif
 #endif
 
@@ -139,24 +139,23 @@
   // Software serial
   //
 
-  #define X_SERIAL_TX_PIN                  PD5
-  #define X_SERIAL_RX_PIN                  PD5
+  #define X_SERIAL_TX_PIN                   PD5
+  #define X_SERIAL_RX_PIN                   PD5
 
-  #define Y_SERIAL_TX_PIN                  PD7
-  #define Y_SERIAL_RX_PIN                  PD7
+  #define Y_SERIAL_TX_PIN                   PD7
+  #define Y_SERIAL_RX_PIN                   PD7
 
-  #define Z_SERIAL_TX_PIN                  PD4
-  #define Z_SERIAL_RX_PIN                  PD4
+  #define Z_SERIAL_TX_PIN                   PD4
+  #define Z_SERIAL_RX_PIN                   PD4
 
-  #define E0_SERIAL_TX_PIN                 PD9
-  #define E0_SERIAL_RX_PIN                 PD9
+  #define E0_SERIAL_TX_PIN                  PD9
+  #define E0_SERIAL_RX_PIN                  PD9
 
-  #define E1_SERIAL_TX_PIN                 PD8
-  #define E1_SERIAL_RX_PIN                 PD8
-
+  #define E1_SERIAL_TX_PIN                  PD8
+  #define E1_SERIAL_RX_PIN                  PD8
 
   // Reduce baud rate to improve software serial reliability
-  #define TMC_BAUD_RATE 19200
+  #define TMC_BAUD_RATE                    19200
 #endif // TMC2208 || TMC2209
 
 //
@@ -193,7 +192,7 @@
 //#define LED_PIN                           PB2
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION                  ONBOARD
+  #define SDCARD_CONNECTION              ONBOARD
 #endif
 
 // #define USE_NEW_SPI_API 1
@@ -211,16 +210,15 @@
       #define SD_SPI MARLIN_SPI(HardwareSPI3, PC9)
     #else
       #define ENABLE_SPI3
-      #define SS_PIN                            -1
-      #define SDSS                              PC9
-      #define SCK_PIN                           PC10
-      #define MISO_PIN                          PC11
-      #define MOSI_PIN                          PC12
+      #define SS_PIN                        -1
+      #define SDSS                          PC9
+      #define SCK_PIN                       PC10
+      #define MISO_PIN                      PC11
+      #define MOSI_PIN                      PC12
     #endif
-    #define SD_DETECT_PIN                     PD12
+    #define SD_DETECT_PIN                   PD12
   #endif
 #endif
-
 
 /*
 //
@@ -230,11 +228,11 @@
   #define CUSTOM_SPI_PINS
   #if ENABLED(CUSTOM_SPI_PINS)
     #define ENABLE_SPI1
-    #define SDSS                              PE10
-    #define SCK_PIN                           PA5
-    #define MISO_PIN                          PA6
-    #define MOSI_PIN                          PA7
-    #define SD_DETECT_PIN                     PE12
+    #define SDSS                            PE10
+    #define SCK_PIN                         PA5
+    #define MISO_PIN                        PA6
+    #define MOSI_PIN                        PA7
+    #define SD_DETECT_PIN                   PE12
   #endif
 #endif
 */
@@ -243,15 +241,14 @@
 // LCD / Controller
 #define SPI_FLASH
 // #define HAS_SPI_FLASH 1
-#define SPI_DEVICE 2
-#define SPI_FLASH_SIZE 0x1000000
+#define SPI_DEVICE                             2
+#define SPI_FLASH_SIZE                 0x1000000
 #if ENABLED(SPI_FLASH)
-	#define 	W25QXX_CS_PIN		PB12
-	#define 	W25QXX_MOSI_PIN		PB15
-	#define 	W25QXX_MISO_PIN		PB14
-	#define 	W25QXX_SCK_PIN		PB13
+	#define W25QXX_CS_PIN                      PB12
+	#define W25QXX_MOSI_PIN                    PB15
+	#define W25QXX_MISO_PIN                    PB14
+	#define W25QXX_SCK_PIN                     PB13
 #endif
-
 
 /**
  *                _____                                             _____
@@ -266,19 +263,19 @@
 
 #if EITHER(TFT_480x320_SPI, TFT_LVGL_UI_SPI)
   #ifndef TOUCH_CALIBRATION_X
-    #define TOUCH_CALIBRATION_X         -17253
+    #define TOUCH_CALIBRATION_X           -17253
   #endif
   #ifndef TOUCH_CALIBRATION_Y
-    #define TOUCH_CALIBRATION_Y          11579
+    #define TOUCH_CALIBRATION_Y            11579
   #endif
   #ifndef TOUCH_OFFSET_X
-    #define TOUCH_OFFSET_X                 514
+    #define TOUCH_OFFSET_X                   514
   #endif
   #ifndef TOUCH_OFFSET_Y
-    #define TOUCH_OFFSET_Y                 -24
+    #define TOUCH_OFFSET_Y                   -24
   #endif
   #ifndef TOUCH_ORIENTATION
-    #define TOUCH_ORIENTATION   TOUCH_LANDSCAPE
+    #define TOUCH_ORIENTATION    TOUCH_LANDSCAPE
   #endif
 
   #define TFT_CS_PIN                        PD11
@@ -295,7 +292,7 @@
   #define TOUCH_BUTTONS_HW_SPI
   #define TOUCH_BUTTONS_HW_SPI_DEVICE          1
 
-  #define LCD_BACKLIGHT_PIN   PD13
+  #define LCD_BACKLIGHT_PIN                 PD13
   #ifndef TFT_WIDTH
     #define TFT_WIDTH                        480
   #endif
@@ -308,10 +305,10 @@
   #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
   #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
 
-  #define BTN_EN1          PE8
-  #define BTN_EN2          PE11
-  #define BEEPER_PIN       PC5
-  #define BTN_ENC          PE13
+  #define BTN_EN1                           PE8
+  #define BTN_EN2                           PE11
+  #define BEEPER_PIN                        PC5
+  #define BTN_ENC                           PE13
 
   #define LCD_READ_ID                       0xD3
   #define LCD_USE_DMA_SPI
@@ -320,65 +317,65 @@
   #define TFT_BUFFER_SIZE                  14400
 
 #elif HAS_SPI_LCD
-  #define BEEPER_PIN       PC5
-  #define BTN_ENC          PE13
-  #define LCD_PINS_ENABLE  PD13
-  #define LCD_PINS_RS      PC6
-  #define BTN_EN1          PE8
-  #define BTN_EN2          PE11
-  #define LCD_BACKLIGHT_PIN -1
+  #define BEEPER_PIN                        PC5
+  #define BTN_ENC                           PE13
+  #define LCD_PINS_ENABLE                   PD13
+  #define LCD_PINS_RS                       PC6
+  #define BTN_EN1                           PE8
+  #define BTN_EN2                           PE11
+  #define LCD_BACKLIGHT_PIN                 -1
 
   // MKS MINI12864 and MKS LCD12864B; If using MKS LCD12864A (Need to remove RPK2 resistor)
   #if ENABLED(MKS_MINI_12864)
-    //#define LCD_BACKLIGHT_PIN -1
-    //#define LCD_RESET_PIN  -1
-    #define DOGLCD_A0      PD11
-    #define DOGLCD_CS      PE15
-    //#define DOGLCD_SCK     PA5
-    //#define DOGLCD_MOSI    PA7
+    //#define LCD_BACKLIGHT_PIN             -1
+    //#define LCD_RESET_PIN                 -1
+    #define DOGLCD_A0                       PD11
+    #define DOGLCD_CS                       PE15
+    //#define DOGLCD_SCK                    PA5
+    //#define DOGLCD_MOSI                   PA7
 
     // Required for MKS_MINI_12864 with this board
     //#define MKS_LCD12864B
     //#undef SHOW_BOOTSCREEN
 
-  #else // !MKS_MINI_12864
+  #else                                           // !MKS_MINI_12864
 
-    #define LCD_PINS_D4    PE14
+    #define LCD_PINS_D4                     PE14
     #if ENABLED(ULTIPANEL)
-      #define LCD_PINS_D5  PE15
-      #define LCD_PINS_D6  PD11
-      #define LCD_PINS_D7  PD10
+      #define LCD_PINS_D5                   PE15
+      #define LCD_PINS_D6                   PD11
+      #define LCD_PINS_D7                   PD10
     #endif
 
     #ifndef ST7920_DELAY_1
-    #define ST7920_DELAY_1 DELAY_NS(96)
+    #define ST7920_DELAY_1          DELAY_NS(96)
     #endif
     #ifndef ST7920_DELAY_2
-      #define ST7920_DELAY_2 DELAY_NS(48)
+      #define ST7920_DELAY_2        DELAY_NS(48)
     #endif
     #ifndef ST7920_DELAY_3
-      #define ST7920_DELAY_3 DELAY_NS(600)
+      #define ST7920_DELAY_3       DELAY_NS(600)
     #endif
 
   #endif // !MKS_MINI_12864
 
 #elif ENABLED(SPI_GRAPHICAL_TFT)
-	#define SPI_TFT_CS_PIN			PD11
-	#define SPI_TFT_SCK_PIN			PA5
-	#define SPI_TFT_MISO_PIN		PA6
-	#define SPI_TFT_MOSI_PIN		PA7
-	#define SPI_TFT_DC_PIN			PD10
-	#define SPI_TFT_RST_PIN			PC6
+	#define SPI_TFT_CS_PIN                     PD11
+	#define SPI_TFT_SCK_PIN                    PA5
+	#define SPI_TFT_MISO_PIN                   PA6
+	#define SPI_TFT_MOSI_PIN                   PA7
+	#define SPI_TFT_DC_PIN                     PD10
+	#define SPI_TFT_RST_PIN                    PC6
 
-	#define LCD_BACKLIGHT_PIN   PD13
+	#define LCD_BACKLIGHT_PIN                  PD13
 
-    #define TOUCH_CS_PIN                    PE14   	// SPI1_NSS
-    #define TOUCH_SCK_PIN                   PA5  	// SPI1_SCK
-    #define TOUCH_MISO_PIN                  PA6  	// SPI1_MISO
-    #define TOUCH_MOSI_PIN                  PA7  	// SPI1_MOSI
+    #define TOUCH_CS_PIN                    PE14  // SPI1_NSS
+    #define TOUCH_SCK_PIN                   PA5   // SPI1_SCK
+    #define TOUCH_MISO_PIN                  PA6   // SPI1_MISO
+    #define TOUCH_MOSI_PIN                  PA7   // SPI1_MOSI
 
-    #define BTN_EN1          PE8
-    #define BTN_EN2          PE11
-    #define BEEPER_PIN       PC5
-    #define BTN_ENC          PE13
+    #define BTN_EN1                         PE8
+    #define BTN_EN2                         PE11
+    #define BEEPER_PIN                      PC5
+    #define BTN_ENC                         PE13
 #endif // HAS_SPI_LCD

--- a/platformio.ini
+++ b/platformio.ini
@@ -1351,6 +1351,26 @@ extra_scripts        = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
   buildroot/share/PlatformIO/scripts/mks_encrypt.py
 
+#
+# MKS Robin Pro V2
+#
+[env:mks_robin_pro2]
+platform      = ${common_stm32.platform}
+extends       = common_stm32
+build_flags   = ${common_stm32.build_flags} -DHAL_HCD_MODULE_ENABLED  -DUSBHOST -DARDUINO_BLACK_F407VE
+board         = genericSTM32F407VET6
+board_build.core     = stm32
+board_build.variant  = MARLIN_F407VE
+board_build.ldscript = ldscript.ld
+board_build.firmware = Robin_nano35.bin
+build_unflags        = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
+debug_tool           = jlink
+upload_protocol      = jlink
+extra_scripts        = ${common.extra_scripts}
+  pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
+  buildroot/share/PlatformIO/scripts/stm32_bootloader.py
+  buildroot/share/PlatformIO/scripts/mks_encrypt.py
+
 #################################
 #                               #
 #      Other Architectures      #


### PR DESCRIPTION
### Requirements

STM32 F4 and F1 boards with SPI TFT. And fix pinsDebug for F1.

### Description

This PR add support for SPI TFTs on STM32F4 boards for STM32 hal. 

### Tests Done

- [x] TFT_COLOR_UI on F1 with touch
- [x] TFT_COLOR_UI on F4 with touch 

### Benefits

SPI TFT for F4 boards

### Related Issues

#20280 
