### PR TITLE
Remove -fmerge-all-constants due to GCC bug

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -203,7 +203,7 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
-build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-all-constants
+build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-constants
 lib_deps           =
 
 #


### PR DESCRIPTION
### Description

When the flag `-fmerge-all-constants` is enabled, gcc will ignore the variable storage when merging constants. For example: it will think that one const var stored on PROGMEM and another const variable *not* stored in PROGMEM are *equal*, joining the two in one, and storing in out of PROGMEM. But the code that reads a global var is different from the code that read a PROGMEM var. 

Sample:
```cpp
const MyType Foo PROGMEM = { 10, 20, 30};
....
....
another part of the code
....
const MyType Bar = { 10, 20, 30};
```

With that flag enabled, GCC will ignore that the first var is stored on PROGMEM and merge both, storing on global var area. But, to read `Foo`, we use `pgm_read_`, and the other no. It will lead to reading dirty on flash.
 
Result: subtle and hard to track bugs. 

We just found it today, because the recent additions of `M115_GEOMETRY_REPORT` added this const var:
```
      const xyz_pos_t dmin = { X_MIN_POS, Y_MIN_POS, Z_MIN_POS },
                      dmax = { X_MAX_POS, Y_MAX_POS, Z_MAX_POS };
```
That is merged with this, from soft endstops:
```
#define XYZ_DEFS(T, NAME, OPT) \
  inline T NAME(const AxisEnum axis) { \
    static const XYZval<T> NAME##_P DEFS_PROGMEM = { X_##OPT, Y_##OPT, Z_##OPT }; \
    return pgm_read_any(&NAME##_P[axis]); \
  }
XYZ_DEFS(float, base_min_pos,   MIN_POS);
XYZ_DEFS(float, base_max_pos,   MAX_POS);
XYZ_DEFS(float, base_home_pos,  HOME_POS);
XYZ_DEFS(float, max_length,     MAX_LENGTH);
```

Making the soft endstops don't work when using it with `M115_GEOMETRY_REPORT`.

I added some logging, to get the address of `dmin`, `dmax`, `base_min_pos_P`,  and  `base_max_pos_P`.
```
X
base_min_pos addr: 9503
base_max_pos addr: 727
Y
base_min_pos addr: 9507
base_max_pos addr: 731
Z
base_min_pos addr: 9511
base_max_pos addr: 735

Dmin addr: 9503, Dmax addr: 727
```
As you see, both point the the same address! But one we access directly, the other we try to read from PROGMEM. It leads to read PROGMEM on the address of a global var, making the code just read dirty.


A big thanks for @ellensp that found that M115_GEOMETRY_REPORT was messing up with soft endstops in the #20370 issue!! I would never think about that when testing!!
And another bug thanks for @coolcheat that patiently did a lot of tests for us!

The impact of this fix is minimal. With a very full featured config, it only increase 768 bytes of flash usage.

### Benefits

Fix #20370 
May fix a lot of subtle bugs and random behaviours that we aren't aware!

### Configurations

Easy reproducible on atmega 2560 with `M115_GEOMETRY_REPORT` and softendstops. Just boot and send a `M211` and you will see random values on soft end stop values.

The problem don't happen on STM32F1 (tested in nano v2 board).

