### PR TITLE
Allow BTT EXP-MOT be used with Displays that needs only EXP 1

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
@@ -36,8 +36,8 @@
 #if BOTH(HAS_WIRED_LCD,HAS_BTT_EXP_MOT)
   #if EITHER(CR10_STOCKDISPLAY,ENDER2_STOCKDISPLAY)
     #define EXP_MOT_USE_EXP2_ONLY
-  #else   
-    #ERROR "Having a LCD that uses both EXP1/EXP2 and a expanion motor module on EXP1/EXP2 is not possable."
+  #else
+    #error "Having a LCD that uses both EXP1/EXP2 and a expanion motor module on EXP1/EXP2 is not possible."
   #endif
 #endif
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
@@ -34,7 +34,11 @@
 //#define HAS_BTT_EXP_MOT 1
 
 #if BOTH(HAS_WIRED_LCD,HAS_BTT_EXP_MOT)
-  #ERROR "Having a LCD on EXP1/EXP2 and a expanion motor module on EXP1/EXP2 is not possable."
+  #if EITHER(CR10_STOCKDISPLAY,ENDER2_STOCKDISPLAY)
+    #define EXP_MOT_USE_EXP2_ONLY
+  #else   
+    #ERROR "Having a LCD that uses both EXP1/EXP2 and a expanion motor module on EXP1/EXP2 is not possable."
+  #endif
 #endif
 
 // Ignore temp readings during development.
@@ -133,36 +137,48 @@
  * (M3DIR) 0.15 | · · | 0.17 (M3STP)           (M3RX) 0.28 | · · | 1.30 (M3DIAG)
  *               -----                                      -----
  *               EXP2                                       EXP1
+ *
+ * NB In EXP_MOT_USE_EXP2_ONLY mode EXP1 is not used and M2EN and M3EN need to be jumpered to M1EN
  */
 
   // M1 on Driver Expansion Module
   #define E2_STEP_PIN                      EXPA2_05_PIN
   #define E2_DIR_PIN                       EXPA2_06_PIN
   #define E2_ENABLE_PIN                    EXPA2_04_PIN
-  #define E2_DIAG_PIN                      EXPA1_06_PIN
-  #define E2_CS_PIN                        EXPA1_05_PIN
-  #if HAS_TMC_UART
-    #define E2_SERIAL_TX_PIN               EXPA1_05_PIN
-    #define E2_SERIAL_RX_PIN               EXPA1_05_PIN
+  #ifndef EXP_MOT_USE_EXP2_ONLY
+    #define E2_DIAG_PIN                    EXPA1_06_PIN
+    #define E2_CS_PIN                      EXPA1_05_PIN
+    #if HAS_TMC_UART
+      #define E2_SERIAL_TX_PIN             EXPA1_05_PIN
+      #define E2_SERIAL_RX_PIN             EXPA1_05_PIN
+    #endif
   #endif
   // M2 on Driver Expansion Module
   #define E3_STEP_PIN                      EXPA2_08_PIN
   #define E3_DIR_PIN                       EXPA2_07_PIN
-  #define E3_ENABLE_PIN                    EXPA1_03_PIN
-  #define E3_DIAG_PIN                      EXPA1_08_PIN
-  #define E3_CS_PIN                        EXPA1_07_PIN
-  #if HAS_TMC_UART
-    #define E3_SERIAL_TX_PIN               EXPA1_07_PIN
-    #define E3_SERIAL_RX_PIN               EXPA1_07_PIN
+  #ifndef EXP_MOT_USE_EXP2_ONLY
+    #define E3_ENABLE_PIN                  EXPA1_03_PIN
+    #define E3_DIAG_PIN                    EXPA1_08_PIN
+    #define E3_CS_PIN                      EXPA1_07_PIN
+    #if HAS_TMC_UART
+      #define E3_SERIAL_TX_PIN             EXPA1_07_PIN
+      #define E3_SERIAL_RX_PIN             EXPA1_07_PIN
+    #endif
+  #else
+    #define E3_ENABLE_PIN                  EXPA2_04_PIN
   #endif
   // M3 on Driver Expansion Module
   #define E4_STEP_PIN                      EXPA2_10_PIN
   #define E4_DIR_PIN                       EXPA2_09_PIN
-  #define E4_ENABLE_PIN                    EXPA1_04_PIN
-  #define E4_DIAG_PIN                      EXPA1_10_PIN
-  #define E4_CS_PIN                        EXPA1_09_PIN
-  #if HAS_TMC_UART
-    #define E4_SERIAL_TX_PIN               EXPA1_09_PIN
-    #define E4_SERIAL_RX_PIN               EXPA1_09_PIN
+  #ifndef EXP_MOT_USE_EXP2_ONLY
+    #define E4_ENABLE_PIN                  EXPA1_04_PIN
+    #define E4_DIAG_PIN                    EXPA1_10_PIN
+    #define E4_CS_PIN                      EXPA1_09_PIN
+    #if HAS_TMC_UART
+      #define E4_SERIAL_TX_PIN             EXPA1_09_PIN
+      #define E4_SERIAL_RX_PIN             EXPA1_09_PIN
+    #endif
+  #else
+    #define E4_ENABLE_PIN                  EXPA2_04_PIN
   #endif
 #endif // HAS_BTT_EXP_MOT


### PR DESCRIPTION
### Requirements

A BTT EXP MOT module and a display that only uses EXP1 eg CR10_STOCKDISPLAY or ENDER2_STOCKDISPLAY
On a skr 1.4 or 1.3

### Description

The BTT EXP MOT supports a cut down mode that only uses EXP2. This PR adds that functionality to pins_BTT_SKR_common.h 

There are limitation to this mode.
You can only use Step/Direction stepper drivers, no UARTS,SPI or DIAG pins..   
All 3 Enable lines are combined into one IO pin. Using a jumper on the module.

I have updated pins_BTT_SKR_common to enables EXP_MOT_USE_EXP2_ONLY mode when a CR10_STOCKDISPLAY or ENDER2_STOCKDISPLAY is enabled.

### Benefits

CR10_STOCKDISPLAY or ENDER2_STOCKDISPLAY now work with the BTT EXP MOT expansion module.

### Related Issues

Was brought to my attention in issue https://github.com/MarlinFirmware/Marlin/issues/20394