### PR TITLE
MKS Robin TFT pins fixes for STM32 and STM32F1

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -174,7 +174,7 @@
   #define SCK_PIN                           PB13  // SPI2
   #define MISO_PIN                          PB14  // SPI2
   #define MOSI_PIN                          PB15  // SPI2
-  #define SD_DETECT_PIN                     PF12  // SD_CD
+  #define SD_DETECT_PIN                     -1    // SD_CD
 #else
   // SD as custom software SPI (SDIO pins)
   #define SCK_PIN                           PC12

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -165,11 +165,7 @@
 // SPI1(PA7) & SPI3(PB5) not available
 #define SPI_DEVICE                             2
 
-// STM32F1 do not support SW SPI on SD cards
-#ifdef ARDUINO_ARCH_STM32F1
-  #define SDIO_SUPPORT
-#endif
-
+#define SDIO_SUPPORT
 #if ENABLED(SDIO_SUPPORT)
   #define SCK_PIN                           PB13  // SPI2
   #define MISO_PIN                          PB14  // SPI2

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -23,7 +23,6 @@
 
 /**
  * MKS Robin (STM32F130ZET6) board pin assignments
- *
  * https://github.com/makerbase-mks/MKS-Robin/tree/master/MKS%20Robin/Hardware
  */
 
@@ -121,7 +120,7 @@
 #define PS_ON_PIN                           PA3   // PW_OFF
 #define FIL_RUNOUT_PIN                      PF11  // MT_DET
 
-#define BEEPER_PIN                        PC13
+#define BEEPER_PIN                          PC13
 #define LED_PIN                             PB2
 
 #if HAS_FSMC_TFT

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -128,11 +128,6 @@
 #endif
 #define LED_PIN                             PB2
 
-#if HAS_FSMC_TFT || HAS_GRAPHICAL_TFT
-  #define TFT_CS_PIN                        PG12  // NE4
-  #define TFT_RS_PIN                        PF0   // A0
-#endif
-
 #if HAS_FSMC_TFT
   /**
    * Note: MKS Robin TFT screens use various TFT controllers
@@ -140,21 +135,22 @@
    * ILI9488 is not supported
    * Define init sequences for other screens in u8g_dev_tft_320x240_upscale_from_128x64.cpp
    *
-   * If the screen stays white, disable 'LCD_RESET_PIN'
+   * If the screen stays white, disable 'TFT_RESET_PIN'
    * to let the bootloader init the screen.
    *
-   * Setting an 'LCD_RESET_PIN' may cause a flicker when entering the LCD menu
+   * Setting an 'TFT_RESET_PIN' may cause a flicker when entering the LCD menu
    * because Marlin uses the reset as a failsafe to revive a glitchy LCD.
    */
-  //#define LCD_RESET_PIN                   PF6
-  #define LCD_BACKLIGHT_PIN                 PG11
+  #define TFT_CS_PIN                        PG12  // NE4
+  #define TFT_RS_PIN                        PF0   // A0
+
   #define FSMC_CS_PIN                 TFT_CS_PIN
   #define FSMC_RS_PIN                 TFT_RS_PIN
 
   #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
   #define FSMC_DMA_DEV                      DMA2
   #define FSMC_DMA_CHANNEL               DMA_CH5
-#elif HAS_GRAPHICAL_TFT
+
   #define TFT_RESET_PIN                     PF6
   #define TFT_BACKLIGHT_PIN                 PG11
 #endif

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -153,6 +153,9 @@
 
   #define TFT_RESET_PIN                     PF6
   #define TFT_BACKLIGHT_PIN                 PG11
+
+  #define TOUCH_BUTTONS_HW_SPI
+  #define TOUCH_BUTTONS_HW_SPI_DEVICE          2
 #endif
 
 #if NEED_TOUCH_PINS

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -121,11 +121,7 @@
 #define PS_ON_PIN                           PA3   // PW_OFF
 #define FIL_RUNOUT_PIN                      PF11  // MT_DET
 
-#ifdef ARDUINO_ARCH_STM32F1
-  #define BEEPER_PIN                        PC13
-#else
-  #define BEEPER_PIN                        -1
-#endif
+#define BEEPER_PIN                        PC13
 #define LED_PIN                             PB2
 
 #if HAS_FSMC_TFT
@@ -168,6 +164,11 @@
 
 // SPI1(PA7) & SPI3(PB5) not available
 #define SPI_DEVICE                             2
+
+// STM32F1 do not support SW SPI on SD cards
+#ifdef ARDUINO_ARCH_STM32F1
+  #define SDIO_SUPPORT
+#endif
 
 #if ENABLED(SDIO_SUPPORT)
   #define SCK_PIN                           PB13  // SPI2

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -169,7 +169,18 @@
   #define SCK_PIN                           PB13  // SPI2
   #define MISO_PIN                          PB14  // SPI2
   #define MOSI_PIN                          PB15  // SPI2
-  #define SD_DETECT_PIN                     -1    // SD_CD
+  /**
+   * MKS Robin has a few hardware revisions
+   * https://github.com/makerbase-mks/MKS-Robin/tree/master/MKS%20Robin/Hardware
+   *
+   * MKS Robin less or equal to V2.3 don't have SD_DETECT_PIN.
+   *
+   * MKS Robin greater or equal to V2.4 have SD_DETECT_PIN at PF12.
+   *
+   * You can uncomment it here, or you can add it SD_DETECT_PIN to your Configuration.h
+   */
+  //#define SD_DETECT_PIN                   -1
+  //#define SD_DETECT_PIN                   PF12  // SD_CD
 #else
   // SD as custom software SPI (SDIO pins)
   #define SCK_PIN                           PC12

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -23,6 +23,7 @@
 
 /**
  * MKS Robin nano (STM32F130VET6) board pin assignments
+ * https://github.com/makerbase-mks/MKS-Robin-Nano-V1.X/tree/master/hardware
  */
 
 #if NOT_TARGET(STM32F1, STM32F1xx)

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -167,17 +167,13 @@
 
 /**
  * Note: MKS Robin TFT screens use various TFT controllers.
- * If the screen stays white, disable 'LCD_RESET_PIN'
+ * If the screen stays white, disable 'TFT_RESET_PIN'
  * to let the bootloader init the screen.
  */
-
 // Shared FSMC Configs
 #if HAS_FSMC_TFT
   #define DOGLCD_MOSI                       -1    // Prevent auto-define by Conditionals_post.h
   #define DOGLCD_SCK                        -1
-
-  #define FSMC_CS_PIN                       PD7   // NE4
-  #define FSMC_RS_PIN                       PD11  // A0
 
   #define TOUCH_CS_PIN                      PA7   // SPI2_NSS
   #define TOUCH_SCK_PIN                     PB13  // SPI2_SCK


### PR DESCRIPTION
### Description

Update the TFT pins for the MKS Robin board after the TFT refactoring.

Fixed a few more issues on this board, for STM32F1:

 - There's no SD_DETECT_PIN on MKS Robin V2.3 (Matt board). Only on > V2.4.
 - Fixed touch on STM32F1 too

### Benefits

Fix #20377
Fix #19274 

### Related Issues 

#15474

