### PR TITLE
Probe offset wizard: STOW probe and loosen endstops when using PROBE_OFFSET_WIZARD_XY_POS

### DIFF
--- a/Marlin/src/lcd/menu/menu_probe_offset.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_offset.cpp
@@ -175,7 +175,6 @@ void goto_probe_offset_wizard() {
   ui.goto_screen([]{
     _lcd_draw_homing();
     if (all_axes_homed()) {
-      SET_SOFT_ENDSTOP_LOOSE(true); // Disable soft endstops for free Z movement
       z_offset_ref = 0;             // Set Z Value for Wizard Position to 0
       ui.goto_screen(prepare_for_probe_offset_wizard);
       ui.defer_status_screen();

--- a/Marlin/src/lcd/menu/menu_probe_offset.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_offset.cpp
@@ -133,10 +133,12 @@ void prepare_for_probe_offset_wizard() {
 
     // Probe for Z reference
     ui.wait_for_move = true;
-    z_offset_ref = probe.probe_at_point(wizard_pos, PROBE_PT_RAISE, 0, true);
+    z_offset_ref = probe.probe_at_point(wizard_pos, PROBE_PT_STOW, 0, true);
     ui.wait_for_move = false;
 
   #endif
+
+  SET_SOFT_ENDSTOP_LOOSE(true); // Disable soft endstops for free Z movement
 
   // Move Nozzle to Probing/Homing Position
   ui.wait_for_move = true;


### PR DESCRIPTION
### Description

When you enable the PROBE OFFSET WIZARD:

Defining `PROBE_OFFSET_WIZARD_XY_POS`, means the code will use a

`probe.probe_at_point(...)`

at that XY place, which, when complete, will need the software endstops to be "loosened" once again, otherwise manual movement of the nozzle towards the bed (using the wizard lcd menu) will be constrained at some point and in some cases.

The software endstops are already loosened at the beginning of the sequence, but this is then lost.

Therefore, "loosening" the software endstops should be performed later.

Also, it is cleaner to STOW the probe after this operation, although the code DOES alleviate the danger of leaving the probe deployed by raising far enough.

### Benefits

Defining `PROBE_OFFSET_WIZARD_XY_POS` can cause the probe wizard to fail otherwise.

