### PR TITLE
Clarify "not interrupt-capable" error message

### DIFF
--- a/Marlin/src/HAL/AVR/endstop_interrupts.h
+++ b/Marlin/src/HAL/AVR/endstop_interrupts.h
@@ -124,7 +124,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(X_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(X_MAX_PIN);
     #else
-      static_assert(digitalPinHasPCICR(X_MAX_PIN), "X_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(X_MAX_PIN), "X_MAX_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(X_MAX_PIN);
     #endif
   #endif
@@ -132,7 +132,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(X_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(X_MIN_PIN);
     #else
-      static_assert(digitalPinHasPCICR(X_MIN_PIN), "X_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(X_MIN_PIN), "X_MIN_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(X_MIN_PIN);
     #endif
   #endif
@@ -140,7 +140,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Y_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Y_MAX_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Y_MAX_PIN), "Y_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Y_MAX_PIN), "Y_MAX_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Y_MAX_PIN);
     #endif
   #endif
@@ -148,7 +148,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Y_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Y_MIN_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Y_MIN_PIN), "Y_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Y_MIN_PIN), "Y_MIN_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Y_MIN_PIN);
     #endif
   #endif
@@ -156,7 +156,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z_MAX_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z_MAX_PIN), "Z_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z_MAX_PIN), "Z_MAX_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z_MAX_PIN);
     #endif
   #endif
@@ -164,7 +164,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z_MIN_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z_MIN_PIN), "Z_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z_MIN_PIN), "Z_MIN_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z_MIN_PIN);
     #endif
   #endif
@@ -172,7 +172,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(X2_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(X2_MAX_PIN);
     #else
-      static_assert(digitalPinHasPCICR(X2_MAX_PIN), "X2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(X2_MAX_PIN), "X2_MAX_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(X2_MAX_PIN);
     #endif
   #endif
@@ -180,7 +180,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(X2_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(X2_MIN_PIN);
     #else
-      static_assert(digitalPinHasPCICR(X2_MIN_PIN), "X2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(X2_MIN_PIN), "X2_MIN_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(X2_MIN_PIN);
     #endif
   #endif
@@ -188,7 +188,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Y2_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Y2_MAX_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Y2_MAX_PIN), "Y2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Y2_MAX_PIN), "Y2_MAX_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Y2_MAX_PIN);
     #endif
   #endif
@@ -196,7 +196,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Y2_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Y2_MIN_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Y2_MIN_PIN), "Y2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Y2_MIN_PIN), "Y2_MIN_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Y2_MIN_PIN);
     #endif
   #endif
@@ -204,7 +204,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z2_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z2_MAX_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z2_MAX_PIN), "Z2_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z2_MAX_PIN), "Z2_MAX_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z2_MAX_PIN);
     #endif
   #endif
@@ -212,7 +212,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z2_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z2_MIN_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z2_MIN_PIN), "Z2_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z2_MIN_PIN), "Z2_MIN_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z2_MIN_PIN);
     #endif
   #endif
@@ -220,7 +220,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z3_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z3_MAX_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z3_MAX_PIN), "Z3_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z3_MAX_PIN), "Z3_MAX_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z3_MAX_PIN);
     #endif
   #endif
@@ -228,7 +228,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z3_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z3_MIN_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z3_MIN_PIN), "Z3_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z3_MIN_PIN), "Z3_MIN_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z3_MIN_PIN);
     #endif
   #endif
@@ -236,7 +236,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z4_MAX_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z4_MAX_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z4_MAX_PIN), "Z4_MAX_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z4_MAX_PIN), "Z4_MAX_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z4_MAX_PIN);
     #endif
   #endif
@@ -244,7 +244,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z4_MIN_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z4_MIN_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z4_MIN_PIN), "Z4_MIN_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z4_MIN_PIN), "Z4_MIN_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z4_MIN_PIN);
     #endif
   #endif
@@ -252,7 +252,7 @@ void setup_endstop_interrupts() {
     #if (digitalPinToInterrupt(Z_MIN_PROBE_PIN) != NOT_AN_INTERRUPT)
       _ATTACH(Z_MIN_PROBE_PIN);
     #else
-      static_assert(digitalPinHasPCICR(Z_MIN_PROBE_PIN), "Z_MIN_PROBE_PIN is not interrupt-capable");
+      static_assert(digitalPinHasPCICR(Z_MIN_PROBE_PIN), "Z_MIN_PROBE_PIN is not interrupt-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue.");
       pciSetup(Z_MIN_PROBE_PIN);
     #endif
   #endif

--- a/Marlin/src/HAL/LPC1768/endstop_interrupts.h
+++ b/Marlin/src/HAL/LPC1768/endstop_interrupts.h
@@ -46,79 +46,79 @@ void setup_endstop_interrupts() {
 
   #if HAS_X_MAX
     #if !LPC1768_PIN_INTERRUPT_M(X_MAX_PIN)
-      #error "X_MAX_PIN is not INTERRUPT-capable."
+      #error "X_MAX_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(X_MAX_PIN);
   #endif
   #if HAS_X_MIN
     #if !LPC1768_PIN_INTERRUPT_M(X_MIN_PIN)
-      #error "X_MIN_PIN is not INTERRUPT-capable."
+      #error "X_MIN_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(X_MIN_PIN);
   #endif
   #if HAS_Y_MAX
     #if !LPC1768_PIN_INTERRUPT_M(Y_MAX_PIN)
-      #error "Y_MAX_PIN is not INTERRUPT-capable."
+      #error "Y_MAX_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Y_MAX_PIN);
   #endif
   #if HAS_Y_MIN
     #if !LPC1768_PIN_INTERRUPT_M(Y_MIN_PIN)
-      #error "Y_MIN_PIN is not INTERRUPT-capable."
+      #error "Y_MIN_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Y_MIN_PIN);
   #endif
   #if HAS_Z_MAX
     #if !LPC1768_PIN_INTERRUPT_M(Z_MAX_PIN)
-      #error "Z_MAX_PIN is not INTERRUPT-capable."
+      #error "Z_MAX_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Z_MAX_PIN);
   #endif
   #if HAS_Z_MIN
     #if !LPC1768_PIN_INTERRUPT_M(Z_MIN_PIN)
-      #error "Z_MIN_PIN is not INTERRUPT-capable."
+      #error "Z_MIN_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
      _ATTACH(Z_MIN_PIN);
   #endif
   #if HAS_Z2_MAX
     #if !LPC1768_PIN_INTERRUPT_M(Z2_MAX_PIN)
-      #error "Z2_MAX_PIN is not INTERRUPT-capable."
+      #error "Z2_MAX_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Z2_MAX_PIN);
   #endif
   #if HAS_Z2_MIN
     #if !LPC1768_PIN_INTERRUPT_M(Z2_MIN_PIN)
-      #error "Z2_MIN_PIN is not INTERRUPT-capable."
+      #error "Z2_MIN_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Z2_MIN_PIN);
   #endif
   #if HAS_Z3_MAX
     #if !LPC1768_PIN_INTERRUPT_M(Z3_MAX_PIN)
-      #error "Z3_MIN_PIN is not INTERRUPT-capable."
+      #error "Z3_MIN_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Z3_MAX_PIN);
   #endif
   #if HAS_Z3_MIN
     #if !LPC1768_PIN_INTERRUPT_M(Z3_MIN_PIN)
-      #error "Z3_MIN_PIN is not INTERRUPT-capable."
+      #error "Z3_MIN_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Z3_MIN_PIN);
   #endif
   #if HAS_Z4_MAX
     #if !LPC1768_PIN_INTERRUPT_M(Z4_MAX_PIN)
-      #error "Z4_MIN_PIN is not INTERRUPT-capable."
+      #error "Z4_MIN_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Z4_MAX_PIN);
   #endif
   #if HAS_Z4_MIN
     #if !LPC1768_PIN_INTERRUPT_M(Z4_MIN_PIN)
-      #error "Z4_MIN_PIN is not INTERRUPT-capable."
+      #error "Z4_MIN_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Z4_MIN_PIN);
   #endif
   #if HAS_Z_MIN_PROBE_PIN
     #if !LPC1768_PIN_INTERRUPT_M(Z_MIN_PROBE_PIN)
-      #error "Z_MIN_PROBE_PIN is not INTERRUPT-capable."
+      #error "Z_MIN_PROBE_PIN is not INTERRUPT-capable. Disable ENDSTOP_INTERRUPTS_FEATURE to continue."
     #endif
     _ATTACH(Z_MIN_PROBE_PIN);
   #endif


### PR DESCRIPTION
### Description

Enhance error message to instruct users to disable `ENDSTOP_INTERRUPTS_FEATURE` on incompatible configs.

### Benefits

Clearer error message.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/20415