### PR TITLE
error handling on TMC Stallguard Z_SENSORLESS

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2587,6 +2587,10 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #if ENABLED(SENSORLESS_PROBING)
   #if ENABLED(DELTA) && !(X_SENSORLESS && Y_SENSORLESS && Z_SENSORLESS)
     #error "SENSORLESS_PROBING for DELTA requires TMC stepper drivers with StallGuard on X, Y, and Z axes."
+  #elif !(Z_SENSORLESS) && ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+    #error "SENSORLESS_PROBING on Z axis cannot be used inconjunction with Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN or USE_PROBE_FOR_Z_HOMING (because Z-probes are obviously sensors)"
+  #elif !Z_SENSORLESS && ENABLED(USE_PROBE_FOR_Z_HOMING)
+    #error "SENSORLESS_PROBING on Z axis cannot be used inconjunction with USE_PROBE_FOR_Z_HOMING (because z-probes are obviously sensors!)"    
   #elif !Z_SENSORLESS
     #error "SENSORLESS_PROBING requires a TMC stepper driver with StallGuard on Z."
   #endif


### PR DESCRIPTION
I'm ashamed to admit how it took me to figure out that Z_SENSORLESS was being disabled by USE_PROBE_FOR_Z_HOMING which was being enabled by 
Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN 

The default error message implied that something is amiss with the TMC STALLGUARD setting (which wasn't the case at all)

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
