### PR TITLE
Z_SENSORLESS has confused error message

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2654,6 +2654,10 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #if ENABLED(SENSORLESS_PROBING)
   #if ENABLED(DELTA) && !(X_SENSORLESS && Y_SENSORLESS && Z_SENSORLESS)
     #error "SENSORLESS_PROBING for DELTA requires TMC stepper drivers with StallGuard on X, Y, and Z axes."
+  #elif !(Z_SENSORLESS) && ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+    #error "SENSORLESS_PROBING on Z axis cannot be used inconjunction with Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN or USE_PROBE_FOR_Z_HOMING (because Z-probes are obviously sensors)"
+  #elif !Z_SENSORLESS && ENABLED(USE_PROBE_FOR_Z_HOMING)
+    #error "SENSORLESS_PROBING on Z axis cannot be used inconjunction with USE_PROBE_FOR_Z_HOMING (because z-probes are obviously sensors!)"   
   #elif !Z_SENSORLESS
     #error "SENSORLESS_PROBING requires a TMC stepper driver with StallGuard on Z."
   #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2654,10 +2654,10 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #if ENABLED(SENSORLESS_PROBING)
   #if ENABLED(DELTA) && !(X_SENSORLESS && Y_SENSORLESS && Z_SENSORLESS)
     #error "SENSORLESS_PROBING for DELTA requires TMC stepper drivers with StallGuard on X, Y, and Z axes."
-  #elif !(Z_SENSORLESS) && ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
-    #error "SENSORLESS_PROBING on Z axis cannot be used inconjunction with Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN or USE_PROBE_FOR_Z_HOMING (because Z-probes are obviously sensors)"
-  #elif !Z_SENSORLESS && ENABLED(USE_PROBE_FOR_Z_HOMING)
-    #error "SENSORLESS_PROBING on Z axis cannot be used inconjunction with USE_PROBE_FOR_Z_HOMING (because z-probes are obviously sensors!)"   
+  #elif ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+    #error "SENSORLESS_PROBING cannot be used with Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN."
+  #elif ENABLED(USE_PROBE_FOR_Z_HOMING)
+    #error "SENSORLESS_PROBING cannot be used with USE_PROBE_FOR_Z_HOMING."   
   #elif !Z_SENSORLESS
     #error "SENSORLESS_PROBING requires a TMC stepper driver with StallGuard on Z."
   #endif


### PR DESCRIPTION
The default error message "SENSORLESS_PROBING requires a TMC stepper driver with StallGuard on Z."  is confusing. 

The error does not indicate the source of the problem (it implies something non-specific is amiss with the StallGuard configuration) ..
However it turns out that Z_SENSORLESS (which was defined) is being implicitly disabled by the USE_PROBE_FOR_Z_HOMING which is implicitly enabled by Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN 

Ashamed to admit how long it took me to figure out why the error was occurring.

### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

<!-- What does this fix or improve? -->

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
