### PR TITLE
Fix for file sorting by recent first on Ender 3 V2

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -1690,7 +1690,7 @@ inline void Draw_SDItem(const uint16_t item, int16_t row=-1) {
     return;
   }
 
-  card.getfilename_sorted(item - is_subdir);
+  card.getfilename_sorted(SD_ORDER(item - is_subdir, card.get_num_Files()));
   char * const name = card.longest_filename();
 
   #if ENABLED(SCROLL_LONG_FILENAMES)


### PR DESCRIPTION


### Description

This fixes an issue I have been having when trying to display the Files from SD on the LCD on an Ender 3 V2, sorted by newest first.

Files now get Displayed correctly when activating "SDCARD_RATHERRECENTFIRST" and disabling "SDCARD_SORT_ALPHA".
Previously they would get displayed in the wrong order, but selected in the right, causing a different file than selected to print.

### Benefits

Fixes the Issue explained above.

### Configurations

Comment out 
`#define SDCARD_SORT_ALPHA` 
in Configuration_adv.h to reproduce the issue

### Related Issues

none
