### PR TITLE
Add PIN_27_BOARD support

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -48,20 +48,20 @@
 #endif
 
 #if ENABLED(IIC_BL24CXX_EEPROM)
-  #define IIC_EEPROM_SDA                  PA11
-  #define IIC_EEPROM_SCL                  PA12
-  #define MARLIN_EEPROM_SIZE             0x800  // 2Kb (24C16)
+  #define IIC_EEPROM_SDA                    PA11
+  #define IIC_EEPROM_SCL                    PA12
+  #define MARLIN_EEPROM_SIZE               0x800  // 2Kb (24C16)
 #elif ENABLED(SDCARD_EEPROM_EMULATION)
-  #define MARLIN_EEPROM_SIZE             0x800  // 2Kb
+  #define MARLIN_EEPROM_SIZE               0x800  // 2Kb
 #endif
 
 //
 // Servos
 //
 #ifndef HAS_PIN_27_BOARD
-  #define SERVO0_PIN                          PB0   // BLTouch OUT
+  #define SERVO0_PIN                        PB0   // BLTouch OUT
 #else 
-  #define SERVO0_PIN                          PC6
+  #define SERVO0_PIN                        PC6
 #endif
 
 //
@@ -161,7 +161,7 @@
   #define BTN_EN2                           PB14
 
   #ifndef HAS_PIN_27_BOARD
-    #define BEEPER_PIN                        PC6
+    #define BEEPER_PIN                      PC6
   #endif
 
 #elif ENABLED(VET6_12864_LCD)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -58,7 +58,11 @@
 //
 // Servos
 //
-#define SERVO0_PIN                          PB0   // BLTouch OUT
+#ifndef HAS_PIN_27_BOARD
+  #define SERVO0_PIN                          PB0   // BLTouch OUT
+#else 
+  #define SERVO0_PIN                          PC6
+#endif
 
 //
 // Limit Switches
@@ -156,7 +160,9 @@
   #define BTN_EN1                           PB10
   #define BTN_EN2                           PB14
 
-  #define BEEPER_PIN                        PC6
+  #ifndef HAS_PIN_27_BOARD
+    #define BEEPER_PIN                        PC6
+  #endif
 
 #elif ENABLED(VET6_12864_LCD)
 


### PR DESCRIPTION
### Requirements

Creality V422 or V427 controller with a Pin 27 board 
Eg the green pcb below <img src="https://cdn.discordapp.com/attachments/491165528295997450/787166219199053854/PXL_20201212_035503939.jpg">

### Description

With this combination of hardware the user has to manually change the servo0 pin and disable the the BEEPER_PIN
I've added a simple flag HAS_PIN_27_BOARD to do this for them.

### Benefits

When this is added to the example configs (todo after this has been merged). It will easily allow users to select how their Bltouch servo wire is connected.

### Related Issues
https://github.com/MarlinFirmware/Configurations/issues/355
