### PR TITLE
dogm: slow down touchscreen calibration

### DIFF
--- a/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_tft_upscale_from_128x64.cpp
@@ -525,6 +525,11 @@ U8G_PB_DEV(u8g_dev_tft_320x240_upscale_from_128x64, WIDTH, HEIGHT, PAGE_HEIGHT, 
       lcd_put_u8str(0, LCD_PIXEL_HEIGHT / 2, str);
     } while (u8g.nextPage());
     drawing_screen = false;
+    safe_delay(250);
+    if (calibration_stage == CALIBRATION_SUCCESS) {
+      safe_delay(500);
+      ui.goto_previous_screen();
+    }
   }
 
 #endif // TOUCH_SCREEN_CALIBRATION


### PR DESCRIPTION
let the time to the user to see the text string... (only a problem with TFT_CLASSIC_UI)

cf this video : https://drive.google.com/file/d/1Re5O9_lGIsez_4bVDim33zL4i_JfKYQv/view?usp=sharing