### PR TITLE
Apply NO_MOTION_BEFORE_HOMING for joystick motion

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3443,10 +3443,9 @@
   #define JOY_X_LIMITS { 5600, 8190-100, 8190+100, 10800 } // min, deadzone start, deadzone end, max
   #define JOY_Y_LIMITS { 5600, 8250-100, 8250+100, 11000 }
   #define JOY_Z_LIMITS { 4800, 8080-100, 8080+100, 11550 }
-  //#define JOYSTICK_DEBUG
+  //#define JOYSTICK_DEBUG 
   
-  //ensure joystick axis are homed
-  #define JOY_NO_MOVE_BEFORE_HOME
+  #define JOY_NO_MOVE_BEFORE_HOME  //ensure joystick axis are homed
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3443,9 +3443,7 @@
   #define JOY_X_LIMITS { 5600, 8190-100, 8190+100, 10800 } // min, deadzone start, deadzone end, max
   #define JOY_Y_LIMITS { 5600, 8250-100, 8250+100, 11000 }
   #define JOY_Z_LIMITS { 4800, 8080-100, 8080+100, 11550 }
-  //#define JOYSTICK_DEBUG 
-  
-  #define JOY_NO_MOVE_BEFORE_HOME  //ensure joystick axis are homed
+  //#define JOYSTICK_DEBUG
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3444,6 +3444,9 @@
   #define JOY_Y_LIMITS { 5600, 8250-100, 8250+100, 11000 }
   #define JOY_Z_LIMITS { 4800, 8080-100, 8080+100, 11550 }
   //#define JOYSTICK_DEBUG
+  
+  //ensure joystick axis are homed
+  #define JOY_NO_MOVE_BEFORE_HOME
 #endif
 
 /**

--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -126,6 +126,15 @@ Joystick joystick;
     // Recursion barrier
     static bool injecting_now; // = false;
     if (injecting_now) return;
+    
+    if(ENABLED(JOY_NO_MOVE_BEFORE_HOME) && ( // if enabled 
+        !(                                   // Return true if any of the following returns false
+        (TEST(axis_homed, Y_AXIS) || ! ENABLED(HAS_JOY_ADC_X)) && // if x is homed OR x joy NOT enabled this axis is good 
+        (TEST(axis_homed, X_AXIS) || ! ENABLED(HAS_JOY_ADC_Y)) && // if y is homed OR y joy NOT enabled this axis is good 
+        (TEST(axis_homed, Z_AXIS) || ! ENABLED(HAS_JOY_ADC_Z))    // if z is homed OR z joy NOT enabled this axis is good
+        ))){
+      return;
+    }
 
     static constexpr int QUEUE_DEPTH = 5;                                // Insert up to this many movements
     static constexpr float target_lag = 0.25f,                           // Aim for 1/4 second lag

--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -126,15 +126,11 @@ Joystick joystick;
     // Recursion barrier
     static bool injecting_now; // = false;
     if (injecting_now) return;
-    
-    if(ENABLED(JOY_NO_MOVE_BEFORE_HOME) && ( // if enabled 
-        !(                                   // Return true if any of the following returns false
-        (TEST(axis_homed, Y_AXIS) || ! ENABLED(HAS_JOY_ADC_X)) && // if x is homed OR x joy NOT enabled this axis is good 
-        (TEST(axis_homed, X_AXIS) || ! ENABLED(HAS_JOY_ADC_Y)) && // if y is homed OR y joy NOT enabled this axis is good 
-        (TEST(axis_homed, Z_AXIS) || ! ENABLED(HAS_JOY_ADC_Z))    // if z is homed OR z joy NOT enabled this axis is good
-        ))){
-      return;
-    }
+
+    #if ENABLED(NO_MOTION_BEFORE_HOMING)
+      if (TERN0(HAS_JOY_ADC_X, axis_should_home(X_AXIS)) || TERN0(HAS_JOY_ADC_Y, axis_should_home(Y_AXIS)) || TERN0(HAS_JOY_ADC_Z, axis_should_home(Z_AXIS)))
+        return;
+    #endif
 
     static constexpr int QUEUE_DEPTH = 5;                                // Insert up to this many movements
     static constexpr float target_lag = 0.25f,                           // Aim for 1/4 second lag


### PR DESCRIPTION
### Description

Adds JOY_NO_MOVE_BEFORE_HOME define in config advanced
Adds if statement in joystick.cpp to return if not homed on joystick axis
JOY_NO_MOVE_BEFORE_HOME could be replaced with NO_MOTION_BEFORE_HOMING to avoid an extra define, as most users will probably want both.

### Benefits

Issue: joystick could move past software endstops when printer is not homed.
Solution: Disables joystick before homing

### Configurations

Only JOY_NO_MOVE_BEFORE_HOME in configuration_adv.h required 

### Related Issues

#19855 