### PR TITLE
Remove Configuration.h EOL whitespace

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -957,14 +957,14 @@
  * X and Y offset
  *   Use a caliper or ruler to measure the distance from the tip of
  *   the Nozzle to the center-point of the Probe in the X and Y axes.
- * 
+ *
  * Z offset
  * - For the Z offset use your best known value and adjust at runtime.
  * - Common probes trigger below the nozzle and have negative values for Z offset.
  * - Probes triggering above the nozzle height are uncommon but do exist. When using
  *   probes such as this, carefully set Z_CLEARANCE_DEPLOY_PROBE and Z_CLEARANCE_BETWEEN_PROBES
  *   to avoid collisions during probing.
- * 
+ *
  * Tune and Adjust
  * -  Probe Offsets can be tuned at runtime with 'M851', LCD menus, babystepping, etc.
  * -  PROBE_OFFSET_WIZARD (configuration_adv.h) can be used for setting the Z offset.


### PR DESCRIPTION
### Description

Remove some EOL whitespace. Found while rebasing configs.

### Benefits

Cleaner code.

### Configurations

Use default configs

### Related Issues

N/A
