### PR TITLE
Creality v4.5.3 (CR-6 SE, CR-6 MAX)

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -330,10 +330,11 @@
 #define BOARD_CREALITY_V4             4037  // Creality v4.x (STM32F103RE)
 #define BOARD_CREALITY_V427           4038  // Creality v4.2.7 (STM32F103RE)
 #define BOARD_CREALITY_V452           4039  // Creality v4.5.2 (STM32F103RE)
-#define BOARD_TRIGORILLA_PRO          4040  // Trigorilla Pro (STM32F103ZET6)
-#define BOARD_FLY_MINI                4041  // FLY MINI (STM32F103RCT6)
-#define BOARD_FLSUN_HISPEED           4042  // FLSUN HiSpeedV1 (STM32F103VET6)
-#define BOARD_BEAST                   4043  // STM32F103RET6 Libmaple-based controller
+#define BOARD_CREALITY_V453           4040  // Creality v4.5.3 (STM32F103RE)
+#define BOARD_TRIGORILLA_PRO          4041  // Trigorilla Pro (STM32F103ZET6)
+#define BOARD_FLY_MINI                4042  // FLY MINI (STM32F103RCT6)
+#define BOARD_FLSUN_HISPEED           4043  // FLSUN HiSpeedV1 (STM32F103VET6)
+#define BOARD_BEAST                   4044  // STM32F103RET6 Libmaple-based controller
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -530,8 +530,8 @@
   #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality
 #elif MB(CREALITY_V427)
   #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality
-#elif MB(CREALITY_V452)
-  #include "stm32f1/pins_CREALITY_V452.h"       // STM32F1                                env:STM32F103RET6_creality
+#elif MB(CREALITY_V452, CREALITY_V453)
+  #include "stm32f1/pins_CREALITY_V45x.h"       // STM32F1                                env:STM32F103RET6_creality
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro
 #elif MB(FLY_MINI)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V45x.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V45x.h
@@ -21,7 +21,7 @@
  */
 
 /**
- * Creality v4.5.2 (STM32F103RET6) board pin assignments
+ * Creality v4.5.2 and v4.5.3 (STM32F103RET6) board pin assignments
  */
 
 #if NOT_TARGET(__STM32F1__)
@@ -30,7 +30,12 @@
   #error "CREALITY_V452 supports up to 1 hotends / E-steppers. Comment out this line to continue."
 #endif
 
-#define BOARD_NAME "Creality v4.5.2"
+#if MB(CREALITY_V452)
+  #define BOARD_NAME "Creality v4.5.2"
+#elif MB(CREALITY_V453)
+  #define BOARD_NAME "Creality v4.5.3"
+#endif
+
 #define DEFAULT_MACHINE_NAME "Creality3D"
 
 //
@@ -69,7 +74,12 @@
 // Probe
 //
 #define PROBE_TARE_PIN                      PA5
-#define PROBE_ENABLE_PIN                    PC6   // Optoswitch to Enable Z Probe
+
+#if MB(CREALITY_V452)
+  #define PROBE_ENABLE_PIN                    PC6   // Optoswitch to Enable Z Probe
+#elif MB(CREALITY_V453)
+  #define PROBE_ENABLE_PIN                    PB2   // Optoswitch to Enable Z Probe
+#endif
 
 //
 // Steppers
@@ -99,10 +109,18 @@
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN                        PA1   // HEATER1
-#define HEATER_BED_PIN                      PA2   // HOT BED
+#if MB(CREALITY_V452)
+  #define HEATER_0_PIN                        PA1   // HEATER1
+  #define HEATER_BED_PIN                      PA2   // HOT BED
 
-#define FAN_PIN                             PA0   // FAN
+  #define FAN_PIN                             PA0   // FAN
+#elif MB(CREALITY_V453)
+  #define HEATER_0_PIN                        PB14  // HEATER1
+  #define HEATER_BED_PIN                      PB13  // HOT BED
+
+  #define FAN_PIN                             PB15  // FAN
+#endif
+
 #define FAN_SOFT_PWM
 
 //


### PR DESCRIPTION
Creality has been distributing a new board to some of the CR-6 SE owners. The CR-6 MAX comes with this board by default. This pull request adds support for this new board. This is a follow-up for #20378.

![versus](https://user-images.githubusercontent.com/1426097/102132765-58a02f80-3e54-11eb-9856-bf3b526d4b3d.jpg)

Related: #20379
