### PR TITLE
LPC176x framework update

### DIFF
--- a/Marlin/src/HAL/LPC1768/HAL.h
+++ b/Marlin/src/HAL/LPC1768/HAL.h
@@ -47,9 +47,6 @@ extern "C" volatile uint32_t _millis;
 #include <pinmapping.h>
 #include <CDCSerial.h>
 
-// i2c uses 8-bit shifted address
-#define I2C_ADDRESS(A) uint8_t((A) << 1)
-
 //
 // Default graphical display delays
 //

--- a/Marlin/src/HAL/LPC1768/inc/SanityCheck.h
+++ b/Marlin/src/HAL/LPC1768/inc/SanityCheck.h
@@ -24,7 +24,7 @@
 #if PIO_PLATFORM_VERSION < 1001
   #error "nxplpc-arduino-lpc176x package is out of date, Please update the PlatformIO platforms, frameworks and libraries. You may need to remove the platform and let it reinstall automatically."
 #endif
-#if PIO_FRAMEWORK_VERSION < 2005
+#if PIO_FRAMEWORK_VERSION < 2006
   #error "framework-arduino-lpc176x package is out of date, Please update the PlatformIO platforms, frameworks and libraries."
 #endif
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -683,7 +683,7 @@ debug_tool     = jlink
 #
 [common_LPC]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.3.zip
-platform_packages = framework-arduino-lpc176x@^0.2.5
+platform_packages = framework-arduino-lpc176x@^0.2.6
 board             = nxp_lpc1768
 lib_ldf_mode      = off
 lib_compat_mode   = strict


### PR DESCRIPTION
Update the LPC176x framework requirement and remove the i2c address correction macro