### PR TITLE
Fix RESTORE_LEVELING_AFTER_G28

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -435,7 +435,7 @@ void GcodeSuite::G28() {
     do_blocking_move_to_z(delta_clip_start_height);
   #endif
 
-  TERN_(RESTORE_LEVELING_AFTER_G28, set_bed_leveling_enabled(leveling_was_active));
+  TERN_(RESTORE_LEVELING_AFTER_G28, set_bed_leveling_enabled(leveling_restore_state));
 
   restore_feedrate_and_scaling();
 


### PR DESCRIPTION
fix naming mismatch: leveling_was_active to leveling_restore_state


### Description

Fix naming mismatch.  `leveling_was_active`  needs to be `leveling_restore_state`

### Benefits

corrects compiler error.
