### PR TITLE
Fix RESTORE_LEVELING_AFTER_G28 leveling_restore_state

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -435,7 +435,9 @@ void GcodeSuite::G28() {
     do_blocking_move_to_z(delta_clip_start_height);
   #endif
 
-  TERN_(RESTORE_LEVELING_AFTER_G28, set_bed_leveling_enabled(leveling_restore_state));
+  #if EITHER(RESTORE_LEVELING_AFTER_G28, ENABLE_LEVELING_AFTER_G28)
+    set_bed_leveling_enabled(leveling_restore_state);
+  #endif
 
   restore_feedrate_and_scaling();
 


### PR DESCRIPTION
### Description

Fixes `unused variable 'leveling_restore_state'` warning when `RESTORE_LEVELING_AFTER_G28` is enabled.

I'm not 100% sure if this is a viable solution for the problem, but it's a start.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

`leveling_restore_state` is now used if `RESTORE_LEVELING_AFTER_G28` enabled.
<!-- What does this fix or improve? -->

### Related Issues

https://github.com/MarlinFirmware/Marlin/commit/1be16e3d8c44965f2e3f58b2845f9ac8ecdbc74b#commitcomment-45125726
<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
