### PR TITLE
Fix ZoneStar LCD 2004 buttons

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -923,7 +923,7 @@ void MarlinUI::update() {
 
       TERN_(HAS_SLOW_BUTTONS, slow_buttons = read_slow_buttons()); // Buttons that take too long to read in interrupt context
 
-      if (TERN0(REPRAPWORLD_KEYPAD, handle_keypad()))
+      if (TERN0(IS_RRW_KEYPAD, handle_keypad()))
         RESET_STATUS_TIMEOUT();
 
       uint8_t abs_diff = ABS(encoderDiff);


### PR DESCRIPTION
### Requirements

A ZONESTAR LCD 2004. Enable ZONESTAR_LCD In Configuration.h

### Description

Using this diaplay, which has analog buttons, the buttons no longer worked since this commit.  https://github.com/MarlinFirmware/Marlin/commit/f6ffbe548c81abfeecc996c8f2bffd27cabe0014

The cause is using the wrong  test to enable  handle_keypad()
Used TERN0(REPRAPWORLD_KEYPAD but should have been (TERN0(IS_RRW_KEYPAD

### Benefits

The buttons now work again.

### Related Issues

The commit that broke it. https://github.com/MarlinFirmware/Marlin/commit/f6ffbe548c81abfeecc996c8f2bffd27cabe0014
Issue reporting it not working. https://github.com/MarlinFirmware/Marlin/issues/20436
