### PR TITLE
Let boards set default TMC Slave Addresses

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2473,22 +2473,22 @@
    * Set *_SERIAL_TX_PIN and *_SERIAL_RX_PIN to match for all drivers
    * on the same serial port, either here or in your board's pins file.
    */
-  #define  X_SLAVE_ADDRESS 0
-  #define  Y_SLAVE_ADDRESS 0
-  #define  Z_SLAVE_ADDRESS 0
-  #define X2_SLAVE_ADDRESS 0
-  #define Y2_SLAVE_ADDRESS 0
-  #define Z2_SLAVE_ADDRESS 0
-  #define Z3_SLAVE_ADDRESS 0
-  #define Z4_SLAVE_ADDRESS 0
-  #define E0_SLAVE_ADDRESS 0
-  #define E1_SLAVE_ADDRESS 0
-  #define E2_SLAVE_ADDRESS 0
-  #define E3_SLAVE_ADDRESS 0
-  #define E4_SLAVE_ADDRESS 0
-  #define E5_SLAVE_ADDRESS 0
-  #define E6_SLAVE_ADDRESS 0
-  #define E7_SLAVE_ADDRESS 0
+  //#define  X_SLAVE_ADDRESS 0
+  //#define  Y_SLAVE_ADDRESS 0
+  //#define  Z_SLAVE_ADDRESS 0
+  //#define X2_SLAVE_ADDRESS 0
+  //#define Y2_SLAVE_ADDRESS 0
+  //#define Z2_SLAVE_ADDRESS 0
+  //#define Z3_SLAVE_ADDRESS 0
+  //#define Z4_SLAVE_ADDRESS 0
+  //#define E0_SLAVE_ADDRESS 0
+  //#define E1_SLAVE_ADDRESS 0
+  //#define E2_SLAVE_ADDRESS 0
+  //#define E3_SLAVE_ADDRESS 0
+  //#define E4_SLAVE_ADDRESS 0
+  //#define E5_SLAVE_ADDRESS 0
+  //#define E6_SLAVE_ADDRESS 0
+  //#define E7_SLAVE_ADDRESS 0
 
   /**
    * Software enable

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1647,6 +1647,54 @@
   #ifndef E7_INTERPOLATE
     #define E7_INTERPOLATE INTERPOLATE
   #endif
+  #ifndef X_SLAVE_ADDRESS
+    #define X_SLAVE_ADDRESS  0
+  #endif
+  #ifndef Y_SLAVE_ADDRESS
+    #define Y_SLAVE_ADDRESS  0
+  #endif
+  #ifndef Z_SLAVE_ADDRESS
+    #define Z_SLAVE_ADDRESS  0
+  #endif
+  #ifndef X2_SLAVE_ADDRESS
+    #define X2_SLAVE_ADDRESS 0
+  #endif
+  #ifndef Y2_SLAVE_ADDRESS
+    #define Y2_SLAVE_ADDRESS 0
+  #endif
+  #ifndef Z2_SLAVE_ADDRESS
+    #define Z2_SLAVE_ADDRESS 0
+  #endif
+  #ifndef Z3_SLAVE_ADDRESS
+    #define Z3_SLAVE_ADDRESS 0
+  #endif
+  #ifndef Z4_SLAVE_ADDRESS
+    #define Z4_SLAVE_ADDRESS 0
+  #endif
+  #ifndef E0_SLAVE_ADDRESS
+    #define E0_SLAVE_ADDRESS 0
+  #endif
+  #ifndef E1_SLAVE_ADDRESS
+    #define E1_SLAVE_ADDRESS 0
+  #endif
+  #ifndef E2_SLAVE_ADDRESS
+    #define E2_SLAVE_ADDRESS 0
+  #endif
+  #ifndef E3_SLAVE_ADDRESS
+    #define E3_SLAVE_ADDRESS 0
+  #endif
+  #ifndef E4_SLAVE_ADDRESS
+    #define E4_SLAVE_ADDRESS 0
+  #endif
+  #ifndef E5_SLAVE_ADDRESS
+    #define E5_SLAVE_ADDRESS 0
+  #endif
+  #ifndef E6_SLAVE_ADDRESS
+    #define E6_SLAVE_ADDRESS 0
+  #endif
+  #ifndef E7_SLAVE_ADDRESS
+    #define E7_SLAVE_ADDRESS 0
+  #endif
 #endif
 
 #if (HAS_E_DRIVER(TMC2660) \

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_0.h
@@ -35,16 +35,17 @@
   #define Z_HARDWARE_SERIAL  MSerial4
   #define E0_HARDWARE_SERIAL MSerial4
 
-  // Override default config TMC slave addresses
-  #undef X_SLAVE_ADDRESS
-  #define X_SLAVE_ADDRESS 0
-
-  #undef Y_SLAVE_ADDRESS
-  #define Y_SLAVE_ADDRESS 2
-
-  #undef Z_SLAVE_ADDRESS
-  #define Z_SLAVE_ADDRESS 1
-
-  #undef E0_SLAVE_ADDRESS
-  #define E0_SLAVE_ADDRESS 3
+  // Default TMC slave addresses
+  #ifndef X_SLAVE_ADDRESS
+    #define X_SLAVE_ADDRESS  0
+  #endif
+  #ifndef Y_SLAVE_ADDRESS
+    #define Y_SLAVE_ADDRESS  2
+  #endif
+  #ifndef Z_SLAVE_ADDRESS
+    #define Z_SLAVE_ADDRESS  1
+  #endif
+  #ifndef E0_SLAVE_ADDRESS
+    #define E0_SLAVE_ADDRESS 3
+  #endif
 #endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_0.h
@@ -34,4 +34,17 @@
   #define Y_HARDWARE_SERIAL  MSerial4
   #define Z_HARDWARE_SERIAL  MSerial4
   #define E0_HARDWARE_SERIAL MSerial4
+
+  // Override default config TMC slave addresses
+  #undef X_SLAVE_ADDRESS
+  #define X_SLAVE_ADDRESS 0
+
+  #undef Y_SLAVE_ADDRESS
+  #define Y_SLAVE_ADDRESS 2
+
+  #undef Z_SLAVE_ADDRESS
+  #define Z_SLAVE_ADDRESS 1
+
+  #undef E0_SLAVE_ADDRESS
+  #define E0_SLAVE_ADDRESS 3
 #endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -59,16 +59,17 @@
   #define Z_HARDWARE_SERIAL  MSerial4
   #define E0_HARDWARE_SERIAL MSerial4
 
-  // Override default config TMC slave addresses
-  #undef X_SLAVE_ADDRESS
-  #define X_SLAVE_ADDRESS 0
-
-  #undef Y_SLAVE_ADDRESS
-  #define Y_SLAVE_ADDRESS 2
-
-  #undef Z_SLAVE_ADDRESS
-  #define Z_SLAVE_ADDRESS 1
-
-  #undef E0_SLAVE_ADDRESS
-  #define E0_SLAVE_ADDRESS 3
+  // Default TMC slave addresses
+  #ifndef X_SLAVE_ADDRESS
+    #define X_SLAVE_ADDRESS  0
+  #endif
+  #ifndef Y_SLAVE_ADDRESS
+    #define Y_SLAVE_ADDRESS  2
+  #endif
+  #ifndef Z_SLAVE_ADDRESS
+    #define Z_SLAVE_ADDRESS  1
+  #endif
+  #ifndef E0_SLAVE_ADDRESS
+    #define E0_SLAVE_ADDRESS 3
+  #endif
 #endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -58,4 +58,17 @@
   #define Y_HARDWARE_SERIAL  MSerial4
   #define Z_HARDWARE_SERIAL  MSerial4
   #define E0_HARDWARE_SERIAL MSerial4
+
+  // Override default config TMC slave addresses
+  #undef X_SLAVE_ADDRESS
+  #define X_SLAVE_ADDRESS 0
+
+  #undef Y_SLAVE_ADDRESS
+  #define Y_SLAVE_ADDRESS 2
+
+  #undef Z_SLAVE_ADDRESS
+  #define Z_SLAVE_ADDRESS 1
+
+  #undef E0_SLAVE_ADDRESS
+  #define E0_SLAVE_ADDRESS 3
 #endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -49,11 +49,11 @@
   #define CONTROLLER_FAN_PIN               FAN1_PIN
 #endif
 
-/**
- * TMC220x stepper drivers
- * Hardware serial communication ports.
- */
 #if HAS_TMC_UART
+  /**
+   * TMC220x stepper drivers
+   * Hardware serial communication ports
+   */
   #define X_HARDWARE_SERIAL  MSerial4
   #define Y_HARDWARE_SERIAL  MSerial4
   #define Z_HARDWARE_SERIAL  MSerial4

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
@@ -113,6 +113,21 @@
 
 #endif
 
+#if HAS_TRINAMIC_CONFIG
+  #ifndef X_SLAVE_ADDRESS
+    #define X_SLAVE_ADDRESS  0
+  #endif
+  #ifndef Y_SLAVE_ADDRESS
+    #define Y_SLAVE_ADDRESS  1
+  #endif
+  #ifndef Z_SLAVE_ADDRESS
+    #define Z_SLAVE_ADDRESS  2
+  #endif
+  #ifndef E0_SLAVE_ADDRESS
+    #define E0_SLAVE_ADDRESS 3
+  #endif
+#endif
+
 //
 // Stepper current PWM
 //

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
@@ -87,29 +87,15 @@
 #define E0_ENABLE_PIN                       PC13
 
 #if HAS_TMC_UART
-
   /**
    * TMC2208/TMC2209 stepper drivers
    */
 
-  //
   // Hardware serial with switch
-  //
   #define X_HARDWARE_SERIAL  MSerial2
   #define Y_HARDWARE_SERIAL  MSerial2
   #define Z_HARDWARE_SERIAL  MSerial2
   #define E0_HARDWARE_SERIAL MSerial2
-
-  // The 4xTMC2209 module doesn't have a serial multiplexer and
-  // needs to set *_SLAVE_ADDRESS in Configuration_adv.h for X,Y,Z,E0
-  #if HAS_DRIVER(TMC2208)
-    #define TMC_SERIAL_MULTIPLEXER
-    #define SERIAL_MUL_PIN1                 PB13
-    #define SERIAL_MUL_PIN2                 PB12
-  #endif
-
-  // Reduce baud rate to improve software serial reliability
-  #define TMC_BAUD_RATE                    19200
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
@@ -124,6 +110,17 @@
   #ifndef E0_SLAVE_ADDRESS
     #define E0_SLAVE_ADDRESS 3
   #endif
+
+  // The 4xTMC2209 module doesn't have a serial multiplexer and
+  // needs to set *_SLAVE_ADDRESS in Configuration_adv.h for X,Y,Z,E0
+  #if HAS_DRIVER(TMC2208)
+    #define TMC_SERIAL_MULTIPLEXER
+    #define SERIAL_MUL_PIN1                 PB13
+    #define SERIAL_MUL_PIN2                 PB12
+  #endif
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE                    19200
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_AIO_II.h
@@ -111,9 +111,7 @@
   // Reduce baud rate to improve software serial reliability
   #define TMC_BAUD_RATE                    19200
 
-#endif
-
-#if HAS_TRINAMIC_CONFIG
+  // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
     #define X_SLAVE_ADDRESS  0
   #endif

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
@@ -86,6 +86,7 @@
   #define Z_HARDWARE_SERIAL  MSerial2
   #define E0_HARDWARE_SERIAL MSerial2
 
+  // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
     #define X_SLAVE_ADDRESS  0
   #endif

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
@@ -80,12 +80,12 @@
 #define E0_DIR_PIN                          PC14
 #define E0_ENABLE_PIN                       PC13
 
-#define X_HARDWARE_SERIAL  MSerial2
-#define Y_HARDWARE_SERIAL  MSerial2
-#define Z_HARDWARE_SERIAL  MSerial2
-#define E0_HARDWARE_SERIAL MSerial2
+#if HAS_TMC_UART
+  #define X_HARDWARE_SERIAL  MSerial2
+  #define Y_HARDWARE_SERIAL  MSerial2
+  #define Z_HARDWARE_SERIAL  MSerial2
+  #define E0_HARDWARE_SERIAL MSerial2
 
-#if HAS_TRINAMIC_CONFIG
   #ifndef X_SLAVE_ADDRESS
     #define X_SLAVE_ADDRESS  0
   #endif

--- a/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
+++ b/Marlin/src/pins/stm32f1/pins_FYSETC_CHEETAH.h
@@ -85,6 +85,21 @@
 #define Z_HARDWARE_SERIAL  MSerial2
 #define E0_HARDWARE_SERIAL MSerial2
 
+#if HAS_TRINAMIC_CONFIG
+  #ifndef X_SLAVE_ADDRESS
+    #define X_SLAVE_ADDRESS  0
+  #endif
+  #ifndef Y_SLAVE_ADDRESS
+    #define Y_SLAVE_ADDRESS  1
+  #endif
+  #ifndef Z_SLAVE_ADDRESS
+    #define Z_SLAVE_ADDRESS  2
+  #endif
+  #ifndef E0_SLAVE_ADDRESS
+    #define E0_SLAVE_ADDRESS 3
+  #endif
+#endif
+
 //
 // Heaters / Fans
 //

--- a/buildroot/tests/STM32F103RC_btt-tests
+++ b/buildroot/tests/STM32F103RC_btt-tests
@@ -17,10 +17,6 @@ opt_set X_DRIVER_TYPE TMC2209
 opt_set Y_DRIVER_TYPE TMC2209
 opt_set Z_DRIVER_TYPE TMC2209
 opt_set E0_DRIVER_TYPE TMC2209
-opt_set X_SLAVE_ADDRESS 0
-opt_set Y_SLAVE_ADDRESS 1
-opt_set Z_SLAVE_ADDRESS 2
-opt_set E0_SLAVE_ADDRESS 3
 opt_enable PINS_DEBUGGING
 
 exec_test $1 $2 "BigTreeTech SKR Mini E3 1.0 - Basic Config with TMC2209 HW Serial" "$3"


### PR DESCRIPTION
### Description

Override default TMC slave addresses for SKR Mini E3 V1 & V2 boards to prevent sporadic printer behaviors due to mis-matched or invalid TMC slave address settings.

### Benefits

This will prevent future issues for:

- Users who upgrade their boards from a V1.2 to a V2 and recycle their config
- Users who don't use [Marlin's pre-built configs](https://github.com/MarlinFirmware/Configurations)
- Users who start with a blank config

### Configurations

Marlin's Ender-3 [BigTreeTech SKR Mini E3 1.0](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Creality/Ender-3/BigTreeTech%20SKR%20Mini%20E3%201.0) or [BigTreeTech SKR Mini E3 2.0](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Creality/Ender-3/BigTreeTech%20SKR%20Mini%20E3%202.0) configs.

### Related Issues

This has come up in the past in a couple issues here & BigTreeTech's forks but I don't have a link. I mostly run into it on Facebook & Discord.
