### PR TITLE
Prototype STM32 Auto Timer Selection

### DIFF
--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -146,12 +146,7 @@ static constexpr uintptr_t default_preferred_timers[] = {
 
 // mcu_preferred_timers allows a customized list of timers to be considered before the
 // default_preferred_timers above.
-#ifdef STM32F0xx
-  static constexpr uintptr_t mcu_preferred_timers[] = {
-      uintptr_t(TIM16),
-      uintptr_t(TIM17)
-  }
-#elif defined(STM32F1xx)
+#if defined(STM32F1xx)
   // Customized preferences for F1 chips
   // This defers to historic precedent, since these timers were most likely left without
   // usage by fans.
@@ -171,36 +166,39 @@ static constexpr uintptr_t default_preferred_timers[] = {
     #endif
     uintptr_t(TIM2),
     uintptr_t(TIM4),
-  };
-#elif defined(STM32F4xx) || defined(STM32F7xx)
+    };
+#elif defined(STM32F0xx) || defined(STM32F4xx) || defined(STM32F7xx)
   // default selection order is fine
   static constexpr uintptr_t mcu_preferred_timers[] = {0};
+#else
+  #error "MCU not yet supported in this HAL"A0
 #endif
 
 #define _TIMER_DEV(X) TIM##X
 #define TIMER_DEV(X) _TIMER_DEV(X)
 
 static constexpr uintptr_t timers_in_use[] = {
-  #if HAS_TMC_SW_SERIAL
-    uintptr_t(TIMER_SERIAL),  // Set in variant.h, or as a define in platformio.h if not present in variant.h
-  #endif
-  #if ENABLED(SPEAKER)
-    uintptr_t(TIMER_TONE),    // Set in variant.h, or as a define in platformio.h if not present in variant.h
-  #endif
-  #if HAS_SERVOS
-    uintptr_t(TIMER_SERVO),   // Set in variant.h, or as a define in platformio.h if not present in variant.h
-  #endif
-  #ifdef STEP_TIMER
-    uintptr_t(TIMER_DEV(STEP_TIMER)),
-  #endif
-  #ifdef TEMP_TIMER
-    uintptr_t(TIMER_DEV(TEMP_TIMER))
-  #endif
+    #if HAS_TMC_SW_SERIAL
+      uintptr_t(TIMER_SERIAL),  // Set in variant.h, or as a define in platformio.h if not present in variant.h
+    #endif
+    #if ENABLED(SPEAKER)
+      uintptr_t(TIMER_TONE),    // Set in variant.h, or as a define in platformio.h if not present in variant.h
+    #endif
+    #if HAS_SERVOS
+      uintptr_t(TIMER_SERVO),   // Set in variant.h, or as a define in platformio.h if not present in variant.h
+    #endif
+    #ifdef STEP_TIMER
+      uintptr_t(TIMER_DEV(STEP_TIMER)),
+    #endif
+    #ifdef TEMP_TIMER
+      uintptr_t(TIMER_DEV(TEMP_TIMER)),
+    #endif
+    0u
   };
 
 static constexpr bool is_timer_in_use(uintptr_t timer) {
   for (auto timer_in_use : timers_in_use)
-    if (timer_in_use == timer) return true;
+    if (timer_in_use && timer_in_use == timer) return true;
   return false;
 }
 

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -171,7 +171,7 @@ static constexpr uintptr_t default_preferred_timers[] = {
   // default selection order is fine
   static constexpr uintptr_t mcu_preferred_timers[] = {0};
 #else
-  #error "MCU not yet supported in this HAL"A0
+  #error "MCU not yet supported in this HAL"
 #endif
 
 #define _TIMER_DEV(X) TIM##X

--- a/Marlin/src/pins/stm32f0/pins_MALYAN_M300.h
+++ b/Marlin/src/pins/stm32f0/pins_MALYAN_M300.h
@@ -44,12 +44,6 @@
 #define SDSS                              SS_PIN
 
 //
-// Timers
-//
-#define STEP_TIMER                             6
-#define TEMP_TIMER                             7
-
-//
 // Limit Switches
 //
 #define X_MAX_PIN                           PC13

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -34,9 +34,6 @@
   #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
 #endif
 
-// Avoid conflict with TIMER_TONE defined in variant
-#define STEP_TIMER 10
-
 //
 // EEPROM Emulation
 //

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
@@ -27,9 +27,6 @@
 #define BOARD_INFO_NAME      "Lerdge S"
 #define DEFAULT_MACHINE_NAME "LERDGE"
 
-#define STEP_TIMER                             4
-#define TEMP_TIMER                             2
-
 //#define I2C_EEPROM
 
 //

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_X.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_X.h
@@ -27,9 +27,6 @@
 #define BOARD_INFO_NAME      "Lerdge X"
 #define DEFAULT_MACHINE_NAME "LERDGE"
 
-#define STEP_TIMER                             4
-#define TEMP_TIMER                             2
-
 #define I2C_EEPROM
 
 //

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
@@ -38,17 +38,6 @@
 #define FAN_SOFT_PWM
 
 //
-// Configure Timers
-// TIM6 is used for TONE
-// TIM7 is used for SERVO
-// TIMER_SERIAL defaults to TIM7 and must be overridden in the platformio.h file if SERVO will also be used.
-//              This will be difficult to solve from the Arduino IDE, without modifying the RUMBA32 variant
-//              included with the STM32 framework.
-
-#define STEP_TIMER 10
-#define TEMP_TIMER 14
-
-//
 // Limit Switches
 //
 #define X_MIN_PIN                           PB12

--- a/Marlin/src/pins/stm32f7/pins_NUCLEO_F767ZI.h
+++ b/Marlin/src/pins/stm32f7/pins_NUCLEO_F767ZI.h
@@ -40,27 +40,6 @@
 #endif
 
 /**
- * Timer assignments
- *
- * TIM1 -
- * TIM2 - Hardware PWM (Fan/Heater Pins)
- * TIM3 - Hardware PWM (Servo Pins)
- * TIM4 - STEP_TIMER (Marlin)
- * TIM5 -
- * TIM6 - TIMER_TONE (variant.h)
- * TIM7 - TIMER_SERVO (variant.h)
- * TIM9 - TIMER_SERIAL (platformio.ini)
- * TIM10 - For some reason trips Watchdog when used for SW Serial
- * TIM11 -
- * TIM12 -
- * TIM13 -
- * TIM14 - TEMP_TIMER (Marlin)
- *
- */
-#define STEP_TIMER                             4
-#define TEMP_TIMER                            14
-
-/**
  * These pin assignments are arbitrary and intending for testing purposes.
  * Assignments may not be ideal, and not every assignment has been tested.
  * Proceed at your own risk.

--- a/Marlin/src/pins/stm32f7/pins_REMRAM_V1.h
+++ b/Marlin/src/pins/stm32f7/pins_REMRAM_V1.h
@@ -129,9 +129,3 @@
 #define BTN_EN1                               54  // BTN_EN1
 #define BTN_EN2                               55  // BTN_EN2
 #define BTN_ENC                               47  // BTN_ENC
-
-//
-// Timers
-//
-
-#define STEP_TIMER                             2


### PR DESCRIPTION
### Description

**This is experimental. Not yet tested AT ALL.
I am posting it to see how the CI run goes. If that is successful and my own tests go well I will invite others to try it.**

STM32 timer conflicts are an ongoing issue. This is worsened as we move STM32F1 boards into the STM32 HAL, since the default timers used were not always the same between the two HALs. There is significant variety in timer selection in the STM32F1 variants, making selection of defaults difficult.

This change seeks to automatically select timers at build time. This considers enabled features, variant.h definitions, and pin-file overrides. Combining these with lists of _preferred timers_ for each MCU family allows unused timers to be selected.

If no available timers can be located in the MCU-specific preferred list, it falls back to a default preferred list. These are ordered loosely based on the likelihood of them being already used.

### Benefits

Reduce the occurrence of timer conflicts when features are enabled for new boards. Can likely eliminate existing overrides as well, but this will have to be done with care.

### Current drawbacks

Selection is all being done using the timer's base address as the unique identifier. This makes it hard when debugging to know which timer numbers they correlate to. I would like to see if I can rework this to make it easier to see the actual timer number, rather than a base address.

As with previous solutions, this does not factor in PWM outputs, such as fans, RGB LEDs, and lasers.

### Configurations

I posted some updated customer configs as a comment in #20387. These produced timer conflicts prior to this change, and now compile.

### Related Issues

This has come up multiple times, but this is the issue I am working with directly.
#20387
#20527
