### PR TITLE
Add BTT SKR CR6 board

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -335,6 +335,7 @@
 #define BOARD_FLY_MINI                4042  // FLY MINI (STM32F103RCT6)
 #define BOARD_FLSUN_HISPEED           4043  // FLSUN HiSpeedV1 (STM32F103VET6)
 #define BOARD_BEAST                   4044  // STM32F103RET6 Libmaple-based controller
+#define BOARD_BTT_SKR_CR6             4045  // BigTreeTech SKR CR6 v1.0 (STM32F103RE)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -542,6 +542,8 @@
   #include "stm32f1/pins_FLSUN_HISPEED.h"       // STM32F1                                env:flsun_hispeed
 #elif MB(BEAST)
   #include "stm32f1/pins_BEAST.h"               // STM32F1                                env:STM32F103RE
+#elif MB(BTT_SKR_CR6)
+  #include "stm32f1/pins_BTT_SKR_CR6.h"         // STM32F1                                env:STM32F103RC_btt_512K_USB
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -32,7 +32,6 @@
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #endif
 
-
 //
 // EEPROM
 //
@@ -43,51 +42,50 @@
 
 /* I2C */
 #if ENABLED(I2C_EEPROM)
-  #define IIC_EEPROM_SDA       PB7
-  #define IIC_EEPROM_SCL       PB6
+  #define IIC_EEPROM_SDA                    PB7
+  #define IIC_EEPROM_SCL                    PB6
 
-  #define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+  #define MARLIN_EEPROM_SIZE              0x1000  // 4KB
 #elif ENABLED(SDCARD_EEPROM_EMULATION)
-  #define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+  #define MARLIN_EEPROM_SIZE              0x1000  // 4KB
 #endif
 
 #define E2END                (MARLIN_EEPROM_SIZE - 1) // 2KB
-
 
 //
 // Limit Switches
 //
 
-#define X_STOP_PIN          PC0
-#define Y_STOP_PIN          PC1
-#define Z_STOP_PIN          PC14
+#define X_STOP_PIN                          PC0
+#define Y_STOP_PIN                          PC1
+#define Z_STOP_PIN                          PC14
 
-#define FIL_RUNOUT_PIN      PC15
+#define FIL_RUNOUT_PIN                      PC15
 
 //
 // Probe
 //
-#define PROBE_TARE_PIN      PA1
-#define PROBE_ACTIVATION_SWITCH_PIN   PC2   // Optoswitch to Enable Z Probe
+#define PROBE_TARE_PIN                      PA1
+#define PROBE_ACTIVATION_SWITCH_PIN         PC2   // Optoswitch to Enable Z Probe
 
 //
 // Steppers
 //
-#define X_ENABLE_PIN        PB14
-#define X_STEP_PIN          PB13
-#define X_DIR_PIN           PB12
+#define X_ENABLE_PIN                        PB14
+#define X_STEP_PIN                          PB13
+#define X_DIR_PIN                           PB12
 
-#define Y_ENABLE_PIN        PB11
-#define Y_STEP_PIN          PB10
-#define Y_DIR_PIN           PB2
+#define Y_ENABLE_PIN                        PB11
+#define Y_STEP_PIN                          PB10
+#define Y_DIR_PIN                           PB2
 
-#define Z_ENABLE_PIN        PB1
-#define Z_STEP_PIN          PB0
-#define Z_DIR_PIN           PC5
+#define Z_ENABLE_PIN                        PB1
+#define Z_STEP_PIN                          PB0
+#define Z_DIR_PIN                           PC5
 
-#define E0_ENABLE_PIN       PD2
-#define E0_STEP_PIN         PB3
-#define E0_DIR_PIN          PB4
+#define E0_ENABLE_PIN                       PD2
+#define E0_STEP_PIN                         PB3
+#define E0_DIR_PIN                          PB4
 
 //
 // Release PB4 (Z_STEP_PIN) from JTAG NRST role
@@ -97,20 +95,20 @@
 //
 // Temperature Sensors
 //
-#define TEMP_0_PIN         PA0   // TH1
-#define TEMP_BED_PIN       PC3   // TB1
+#define TEMP_0_PIN                          PA0   // TH1
+#define TEMP_BED_PIN                        PC3   // TB1
 
 //
 // Heaters / Fans
 //
 
-#define HEATER_0_PIN       PC8   // HEATER1
-#define HEATER_BED_PIN     PC9   // HOT BED
+#define HEATER_0_PIN                        PC8   // HEATER1
+#define HEATER_BED_PIN                      PC9   // HOT BED
 
-#define FAN_PIN            PC6   // FAN
+#define FAN_PIN                             PC6   // FAN
 #define FAN_SOFT_PWM
 
-#define CONTROLLER_FAN_PIN  PC7
+#define CONTROLLER_FAN_PIN                  PC7
 
 //
 // Display
@@ -118,23 +116,23 @@
 
 #if ENABLED(CR10_STOCKDISPLAY)
 
-    #define BTN_ENC            PA15
-    #define BTN_EN1            PA9
-    #define BTN_EN2            PA10
+    #define BTN_ENC                         PA15
+    #define BTN_EN1                         PA9
+    #define BTN_EN2                         PA10
 
-    #define LCD_PINS_RS        PB8
-    #define LCD_PINS_ENABLE    PB15
-    #define LCD_PINS_D4        PB9
+    #define LCD_PINS_RS                     PB8
+    #define LCD_PINS_ENABLE                 PB15
+    #define LCD_PINS_D4                     PB9
 
-    #define BEEPER_PIN         PB5
+    #define BEEPER_PIN                      PB5
 
 #endif
 
 //
 // USB connect control
 //
-#define USB_CONNECT_PIN    PA14
-#define USB_CONNECT_INVERTING false
+#define USB_CONNECT_PIN                     PA14
+#define USB_CONNECT_INVERTING              false
 
 /**
  * TMC2209 stepper drivers
@@ -149,16 +147,16 @@
 
   // Default TMC slave addresses
   #ifndef X_SLAVE_ADDRESS
-    #define X_SLAVE_ADDRESS  0
+    #define X_SLAVE_ADDRESS                    0
   #endif
   #ifndef Y_SLAVE_ADDRESS
-    #define Y_SLAVE_ADDRESS  1
+    #define Y_SLAVE_ADDRESS                    1
   #endif
   #ifndef Z_SLAVE_ADDRESS
-    #define Z_SLAVE_ADDRESS  2
+    #define Z_SLAVE_ADDRESS                    2
   #endif
   #ifndef E0_SLAVE_ADDRESS
-    #define E0_SLAVE_ADDRESS 3
+    #define E0_SLAVE_ADDRESS                   3
   #endif
 #endif
 
@@ -169,19 +167,19 @@
 #define HAS_ONBOARD_SD
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION ONBOARD
+  #define SDCARD_CONNECTION              ONBOARD
 #endif
 
 #if SD_CONNECTION_IS(ONBOARD)
-  #define SD_DETECT_PIN      PC4
+  #define SD_DETECT_PIN                     PC4
 
-  #define ON_BOARD_SPI_DEVICE 1    // SPI1
-  #define ONBOARD_SD_CS_PIN  PA4   // Chip select for "System" SD card
+  #define ON_BOARD_SPI_DEVICE                  1  // SPI1
+  #define ONBOARD_SD_CS_PIN                 PA4   // Chip select for "System" SD card
 #endif
 
 //
 // Misc. Functions
 //
 
-#define LED_CONTROL_PIN    PA13
-#define NEOPIXEL_PIN       PA8     
+#define LED_CONTROL_PIN                     PA13
+#define NEOPIXEL_PIN                        PA8

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -172,10 +172,12 @@
   #define SDCARD_CONNECTION ONBOARD
 #endif
 
-#define ON_BOARD_SPI_DEVICE 1    // SPI1
-#define ONBOARD_SD_CS_PIN  PA4   // Chip select for "System" SD card
+#if SD_CONNECTION_IS(ONBOARD)
+  #define SD_DETECT_PIN      PC4
 
-#define SD_DETECT_PIN      PC4
+  #define ON_BOARD_SPI_DEVICE 1    // SPI1
+  #define ONBOARD_SD_CS_PIN  PA4   // Chip select for "System" SD card
+#endif
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -146,6 +146,20 @@
   #define Y_HARDWARE_SERIAL  MSerial4
   #define Z_HARDWARE_SERIAL  MSerial4
   #define E0_HARDWARE_SERIAL MSerial4
+
+  // Default TMC slave addresses
+  #ifndef X_SLAVE_ADDRESS
+    #define X_SLAVE_ADDRESS  0
+  #endif
+  #ifndef Y_SLAVE_ADDRESS
+    #define Y_SLAVE_ADDRESS  1
+  #endif
+  #ifndef Z_SLAVE_ADDRESS
+    #define Z_SLAVE_ADDRESS  2
+  #endif
+  #ifndef E0_SLAVE_ADDRESS
+    #define E0_SLAVE_ADDRESS 3
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -1,0 +1,184 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * BigTreeTech SKR CR-6 (STM32F103RET6) board pin assignments
+ */
+
+#define DEFAULT_MACHINE_NAME "Creality3D"
+#define BOARD_INFO_NAME "BTT SKR CR-6"
+
+#if NOT_TARGET(__STM32F1__)
+  #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
+#endif
+
+
+//
+// EEPROM
+//
+
+#if NO_EEPROM_SELECTED
+  #define I2C_EEPROM
+#endif
+
+/* I2C */
+#if ENABLED(I2C_EEPROM)
+  #define IIC_EEPROM_SDA       PB7
+  #define IIC_EEPROM_SCL       PB6
+
+  #define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+#elif ENABLED(SDCARD_EEPROM_EMULATION)
+  #define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+#endif
+
+#define E2END                (MARLIN_EEPROM_SIZE - 1) // 2KB
+
+
+//
+// Limit Switches
+//
+
+#define X_STOP_PIN          PC0
+#define Y_STOP_PIN          PC1
+#define Z_STOP_PIN          PC14
+
+#define FIL_RUNOUT_PIN      PC15
+
+//
+// Probe
+//
+#define PROBE_TARE_PIN      PA1
+#define PROBE_ACTIVATION_SWITCH_PIN   PC2   // Optoswitch to Enable Z Probe
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN        PB14
+#define X_STEP_PIN          PB13
+#define X_DIR_PIN           PB12
+
+#define Y_ENABLE_PIN        PB11
+#define Y_STEP_PIN          PB10
+#define Y_DIR_PIN           PB2
+
+#define Z_ENABLE_PIN        PB1
+#define Z_STEP_PIN          PB0
+#define Z_DIR_PIN           PC5
+
+#define E0_ENABLE_PIN       PD2
+#define E0_STEP_PIN         PB3
+#define E0_DIR_PIN          PB4
+
+//
+// Release PB4 (Z_STEP_PIN) from JTAG NRST role
+//
+#define DISABLE_DEBUG
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN         PA0   // TH1
+#define TEMP_BED_PIN       PC3   // TB1
+
+//
+// Heaters / Fans
+//
+
+#define HEATER_0_PIN       PC8   // HEATER1
+#define HEATER_BED_PIN     PC9   // HOT BED
+
+#define FAN_PIN            PC6   // FAN
+#define FAN_SOFT_PWM
+
+#define CONTROLLER_FAN_PIN  PC7
+
+//
+// Display
+//
+
+#if ENABLED(CR10_STOCKDISPLAY)
+
+    #define BTN_ENC            PA15
+    #define BTN_EN1            PA9
+    #define BTN_EN2            PA10
+
+    #define LCD_PINS_RS        PB8
+    #define LCD_PINS_ENABLE    PB15
+    #define LCD_PINS_D4        PB9
+
+    #define BEEPER_PIN         PB5
+
+#endif
+
+//
+// USB connect control
+//
+#define USB_CONNECT_PIN    PA14
+#define USB_CONNECT_INVERTING false
+
+/**
+ * TMC2209 stepper drivers
+ * Hardware serial communication ports.
+ */
+#if HAS_TMC220x
+
+  //
+  // TMC2208 mode
+  //
+  // #define TMC2208_STANDALONE
+
+  #define X_HARDWARE_SERIAL  MSerial4
+  #define Y_HARDWARE_SERIAL  MSerial4
+  #define Z_HARDWARE_SERIAL  MSerial4
+  #define E0_HARDWARE_SERIAL MSerial4
+
+  //
+  // TMC2208 Software serial
+  //
+  // #define HAVE_SW_SERIAL
+
+  // Reduce baud rate to improve software serial reliability
+  // #define TMC_BAUD_RATE 19200
+
+#endif
+
+//
+// SD Card
+//
+#define HAS_ONBOARD_SD
+
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION ONBOARD
+#endif
+
+#define ON_BOARD_SPI_DEVICE 1    // SPI1
+#define ONBOARD_SD_CS_PIN  PA4   // Chip select for "System" SD card
+
+#define SD_DETECT_PIN      PC4
+
+//
+// Misc. Functions
+//
+
+#define LED_CONTROL_PIN    PA13
+#define NEOPIXEL_PIN       PA8     

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -140,31 +140,18 @@
  * TMC2209 stepper drivers
  * Hardware serial communication ports.
  */
+
 #if HAS_TMC220x
-
-  //
-  // TMC2208 mode
-  //
-  // #define TMC2208_STANDALONE
-
   #define X_HARDWARE_SERIAL  MSerial4
   #define Y_HARDWARE_SERIAL  MSerial4
   #define Z_HARDWARE_SERIAL  MSerial4
   #define E0_HARDWARE_SERIAL MSerial4
-
-  //
-  // TMC2208 Software serial
-  //
-  // #define HAVE_SW_SERIAL
-
-  // Reduce baud rate to improve software serial reliability
-  // #define TMC_BAUD_RATE 19200
-
 #endif
 
 //
 // SD Card
 //
+
 #define HAS_ONBOARD_SD
 
 #ifndef SDCARD_CONNECTION

--- a/buildroot/tests/STM32F103RE_btt_USB-tests
+++ b/buildroot/tests/STM32F103RE_btt_USB-tests
@@ -15,5 +15,17 @@ opt_set SERIAL_PORT 1
 opt_set SERIAL_PORT_2 -1
 exec_test $1 $2 "BigTreeTech SKR E3 DIP v1.0 - Basic Configuration" "$3"
 
+restore_configs
+opt_set SERIAL_PORT -1
+opt_set SERIAL_PORT_2 2
+opt_set TEMP_SENSOR_BED 1
+opt_set MOTHERBOARD BOARD_BTT_SKR_CR6
+opt_disable NOZZLE_TO_PROBE_OFFSET
+opt_enable CR10_STOCKDISPLAY
+opt_enable PROBING_HEATERS_OFF PREHEAT_BEFORE_PROBING
+opt_enable NOZZLE_AS_PROBE Z_SAFE_HOMING Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN
+opt_enable PROBE_ACTIVATION_SWITCH PROBE_TARE PROBE_TARE_ONLY_WHILE_INACTIVE
+exec_test $1 $2 "BigTreeTech SKR CR6 PROBE_ACTIVATION_SWITCH, Probe Tare" "$3"
+
 # clean up
 restore_configs


### PR DESCRIPTION
### Requirements

- Creality CR-6 SE
- BTT SKR CR6 board
- BTT TFT

### Description

In conjunction with PR #20383 and #20379, this PR adds support for the BigTreeTech SKR CR6 replacement board for the Creality CR-6 SE printer.

For now the attached configuration files will only support the BTT SKR CR6 with BTT TFT combination. Support for the Creality stock TFT is yet to be implemented - we're refining this implementation in the Creality CR6 community firmware, and is done as well in PR #19958.

### Benefits

Adds support for the BTT SKR CR6 board. When this is merged, users will be able to enjoy upstream Marlin.

### Configurations

Platform.io: compile with `STM32F103RE_btt_USB` env,

[Configurations_h.zip](https://github.com/MarlinFirmware/Marlin/files/5721234/Configurations_h.zip)
