### PR TITLE
Improvements to Touch Calibration Screen

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_dialog.cpp
@@ -55,6 +55,11 @@
   #include "../../../../feature/pause.h"
 #endif
 
+#if ENABLED(TOUCH_SCREEN_CALIBRATION)
+  #include "../../../tft_io/touch_calibration.h"
+  #include "draw_touch_calibration.h"
+#endif
+
 extern lv_group_t *g;
 static lv_obj_t *scr, *tempText1, *filament_bar;
 
@@ -161,6 +166,13 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
   else if (DIALOG_IS(REVERT_EEPROM_TIPS)) {
     TERN_(EEPROM_SETTINGS, (void)settings.reset());
     clear_cur_ui();
+    #if ENABLED(TOUCH_SCREEN_CALIBRATION)
+      if (touch_calibration.need_calibration()) {
+        disp_state_stack._disp_index--; // We are asynchronous from the dialog, so let's remove the dialog from the stack
+        lv_draw_touch_calibration_screen();
+      }
+      else
+    #endif
     draw_return_ui();
   }
   else if (DIALOG_IS(WIFI_CONFIG_TIPS)) {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_dialog.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_dialog.cpp
@@ -167,13 +167,15 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
     TERN_(EEPROM_SETTINGS, (void)settings.reset());
     clear_cur_ui();
     #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-      if (touch_calibration.need_calibration()) {
+      const bool do_draw_cal = touch_calibration.need_calibration();
+      if (do_draw_cal) {
         disp_state_stack._disp_index--; // We are asynchronous from the dialog, so let's remove the dialog from the stack
         lv_draw_touch_calibration_screen();
       }
-      else
+    #else
+      constexpr bool do_draw_cal = false;
     #endif
-    draw_return_ui();
+    if (!do_draw_cal) draw_return_ui();
   }
   else if (DIALOG_IS(WIFI_CONFIG_TIPS)) {
     uiCfg.configWifi = 1;
@@ -193,9 +195,7 @@ static void btn_ok_event_cb(lv_obj_t *btn, lv_event_t event) {
 static void btn_cancel_event_cb(lv_obj_t *btn, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
   if (DIALOG_IS(PAUSE_MESSAGE_OPTION)) {
-    #if ENABLED(ADVANCED_PAUSE_FEATURE)
-      pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT;
-    #endif
+    TERN_(ADVANCED_PAUSE_FEATURE, pause_menu_response = PAUSE_RESPONSE_RESUME_PRINT);
   }
   else if (DIALOG_IS(TYPE_FILAMENT_LOAD_HEAT, TYPE_FILAMENT_UNLOAD_HEAT, TYPE_FILAMENT_HEAT_LOAD_COMPLETED, TYPE_FILAMENT_HEAT_UNLOAD_COMPLETED)) {
     thermalManager.temp_hotend[uiCfg.curSprayerChoose].target= uiCfg.desireSprayerTempBak;

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ready_print.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ready_print.cpp
@@ -39,6 +39,11 @@
 #include "../../../../module/temperature.h"
 #include "../../../../inc/MarlinConfig.h"
 
+#if ENABLED(TOUCH_SCREEN_CALIBRATION)
+  #include "../../../tft_io/touch_calibration.h"
+  #include "draw_touch_calibration.h"
+#endif
+
 #include <stdio.h>
 
 //static lv_obj_t *buttonPrint, *buttonTool, *buttonSet;
@@ -215,6 +220,14 @@ void lv_draw_ready_print(void) {
     lv_big_button_create(scr, "F:/bmp_set.bin", main_menu.set, 180, 90, event_handler, ID_SET);
     lv_big_button_create(scr, "F:/bmp_printing.bin", main_menu.print, 340, 90, event_handler, ID_PRINT);
   }
+
+  #if ENABLED(TOUCH_SCREEN_CALIBRATION)
+    // If calibration is required, let's trigger it now, handles the case when there is default value in configuration files
+    if (!touch_calibration.calibration_loaded()) {
+      lv_clear_ready_print();
+      lv_draw_touch_calibration_screen();
+    }
+  #endif
 }
 
 void lv_clear_ready_print() {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_touch_calibration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_touch_calibration.cpp
@@ -95,14 +95,14 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
     case ID_TC_RETURN:
       TERN_(MKS_TEST, curent_disp_ui = 1);
       lv_clear_touch_calibration_screen();
-      lv_draw_ready_print();
+      draw_return_ui();
       break;
   }
 }
 
 void lv_draw_touch_calibration_screen() {
-  disp_state_stack._disp_index = 0;
-  ZERO(disp_state_stack._disp_state);
+//  disp_state_stack._disp_index = 0;
+//  ZERO(disp_state_stack._disp_state);
   scr = lv_screen_create(TOUCH_CALIBRATION_UI, "");
 
   status_label = lv_label_create(scr, "");

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_touch_calibration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_touch_calibration.cpp
@@ -101,8 +101,6 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
 }
 
 void lv_draw_touch_calibration_screen() {
-//  disp_state_stack._disp_index = 0;
-//  ZERO(disp_state_stack._disp_state);
   scr = lv_screen_create(TOUCH_CALIBRATION_UI, "");
 
   status_label = lv_label_create(scr, "");

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
@@ -217,12 +217,7 @@ void tft_lvgl_init() {
   #endif
 
   if (ready) {
-    #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-      if (touch_calibration.need_calibration()) lv_draw_touch_calibration_screen();
-      else lv_draw_ready_print();
-    #else
-      lv_draw_ready_print();
-    #endif
+    lv_draw_ready_print();
   }
 
   if (mks_test_flag == 0x1E)

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -28,6 +28,7 @@ TouchCalibration touch_calibration;
 touch_calibration_t TouchCalibration::calibration;
 calibrationState TouchCalibration::calibration_state = CALIBRATION_NONE;
 touch_calibration_point_t TouchCalibration::calibration_points[4];
+uint8_t TouchCalibration::failed_count;
 
 void TouchCalibration::validate_calibration() {
   const bool landscape = validate_precision_x(0, 1) && validate_precision_x(2, 3) && validate_precision_y(0, 2) && validate_precision_y(1, 3);
@@ -44,6 +45,8 @@ void TouchCalibration::validate_calibration() {
   else {
     calibration_state = CALIBRATION_FAIL;
     calibration_reset();
+    // If we fails, let's retry up to 5 times before reporting the failure
+    if (need_calibration() && failed_count++ < 5) calibration_state = CALIBRATION_TOP_LEFT;
   }
 
   if (calibration_state == CALIBRATION_SUCCESS) {

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -45,7 +45,7 @@ void TouchCalibration::validate_calibration() {
   else {
     calibration_state = CALIBRATION_FAIL;
     calibration_reset();
-    // If we fails, let's retry up to 5 times before reporting the failure
+    // Retry up to 5 times before reporting the failure
     if (need_calibration() && failed_count++ < 5) calibration_state = CALIBRATION_TOP_LEFT;
   }
 

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -61,7 +61,13 @@ public:
   static void validate_calibration();
 
   static touch_calibration_t calibration;
+  static uint8_t             failed_count;
   static void calibration_reset() { calibration = { TOUCH_CALIBRATION_X, TOUCH_CALIBRATION_Y, TOUCH_OFFSET_X, TOUCH_OFFSET_Y, TOUCH_ORIENTATION }; }
+  // Don't nuke the current touchscreen calibration if it'll be replaced by invalid values, else it'll make navigation in the printer unusable
+  static void calibration_smart_reset() { 
+    if (need_calibration() && (TOUCH_CALIBRATION_X || TOUCH_CALIBRATION_Y || TOUCH_OFFSET_X || TOUCH_OFFSET_Y)) calibration_reset(); 
+    else failed_count = (uint8_t)(-1); // Remember a reset was asked so we can substitute the value with a zeroed area if queried to save in EEPROM
+  }
   static bool need_calibration() { return !calibration.offset_x && !calibration.offset_y && !calibration.x && !calibration.y; }
 
   static calibrationState calibration_start() {
@@ -75,10 +81,12 @@ public:
     calibration_points[CALIBRATION_TOP_RIGHT].y = 30;
     calibration_points[CALIBRATION_BOTTOM_RIGHT].x = TFT_WIDTH - 31;
     calibration_points[CALIBRATION_BOTTOM_RIGHT].y = TFT_HEIGHT - 31;
+    failed_count = 0;
     return calibration_state;
   }
   static void calibration_end() { calibration_state = CALIBRATION_NONE; }
   static calibrationState get_calibration_state() { return calibration_state; }
+  static void calibration_loaded() { if (need_calibration()) calibration_reset(); }
 
   static bool handleTouch(uint16_t x, uint16_t y);
 };

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -81,7 +81,10 @@ public:
   }
   static void calibration_end() { calibration_state = CALIBRATION_NONE; }
   static calibrationState get_calibration_state() { return calibration_state; }
-  static bool calibration_loaded() { if (!need_calibration()) return true; calibration_reset(); return !need_calibration(); }
+  static bool calibration_loaded() {
+    if (need_calibration()) calibration_reset();
+    return !need_calibration();
+  }
 
   static bool handleTouch(uint16_t x, uint16_t y);
 };

--- a/Marlin/src/lcd/tft_io/touch_calibration.h
+++ b/Marlin/src/lcd/tft_io/touch_calibration.h
@@ -63,11 +63,6 @@ public:
   static touch_calibration_t calibration;
   static uint8_t             failed_count;
   static void calibration_reset() { calibration = { TOUCH_CALIBRATION_X, TOUCH_CALIBRATION_Y, TOUCH_OFFSET_X, TOUCH_OFFSET_Y, TOUCH_ORIENTATION }; }
-  // Don't nuke the current touchscreen calibration if it'll be replaced by invalid values, else it'll make navigation in the printer unusable
-  static void calibration_smart_reset() { 
-    if (need_calibration() && (TOUCH_CALIBRATION_X || TOUCH_CALIBRATION_Y || TOUCH_OFFSET_X || TOUCH_OFFSET_Y)) calibration_reset(); 
-    else failed_count = (uint8_t)(-1); // Remember a reset was asked so we can substitute the value with a zeroed area if queried to save in EEPROM
-  }
   static bool need_calibration() { return !calibration.offset_x && !calibration.offset_y && !calibration.x && !calibration.y; }
 
   static calibrationState calibration_start() {
@@ -86,7 +81,7 @@ public:
   }
   static void calibration_end() { calibration_state = CALIBRATION_NONE; }
   static calibrationState get_calibration_state() { return calibration_state; }
-  static void calibration_loaded() { if (need_calibration()) calibration_reset(); }
+  static bool calibration_loaded() { if (!need_calibration()) return true; calibration_reset(); return !need_calibration(); }
 
   static bool handleTouch(uint16_t x, uint16_t y);
 };

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1357,7 +1357,12 @@ void MarlinSettings::postprocess() {
     // TOUCH_SCREEN_CALIBRATION
     //
     #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-      EEPROM_WRITE(touch_calibration.calibration);
+      if (touch_calibration.failed_count != (uint8_t)-1) EEPROM_WRITE(touch_calibration.calibration);
+      else {
+        // Calibration should have been restored to a zero'd default yet it's in use (so it's not zero), so let's write zeros instead
+        for (uint8_t c = 0, t = 0; t < sizeof(touch_calibration.calibration); t++)
+          EEPROM_WRITE(c);
+      }
     #endif
 
     //
@@ -2242,6 +2247,7 @@ void MarlinSettings::postprocess() {
       #if ENABLED(TOUCH_SCREEN_CALIBRATION)
         _FIELD_TEST(touch_calibration_data);
         EEPROM_READ(touch_calibration.calibration);
+        touch_calibration.calibration_loaded();
       #endif
 
       //
@@ -2573,7 +2579,7 @@ void MarlinSettings::reset() {
   //
   // TOUCH_SCREEN_CALIBRATION
   //
-  TERN_(TOUCH_SCREEN_CALIBRATION, touch_calibration.calibration_reset());
+  TERN_(TOUCH_SCREEN_CALIBRATION, touch_calibration.calibration_smart_reset());
 
   //
   // Buzzer enable/disable

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1357,12 +1357,7 @@ void MarlinSettings::postprocess() {
     // TOUCH_SCREEN_CALIBRATION
     //
     #if ENABLED(TOUCH_SCREEN_CALIBRATION)
-      if (touch_calibration.failed_count != (uint8_t)-1) EEPROM_WRITE(touch_calibration.calibration);
-      else {
-        // Calibration should have been restored to a zero'd default yet it's in use (so it's not zero), so let's write zeros instead
-        for (uint8_t c = 0, t = 0; t < sizeof(touch_calibration.calibration); t++)
-          EEPROM_WRITE(c);
-      }
+      EEPROM_WRITE(touch_calibration.calibration);
     #endif
 
     //
@@ -2247,7 +2242,6 @@ void MarlinSettings::postprocess() {
       #if ENABLED(TOUCH_SCREEN_CALIBRATION)
         _FIELD_TEST(touch_calibration_data);
         EEPROM_READ(touch_calibration.calibration);
-        touch_calibration.calibration_loaded();
       #endif
 
       //
@@ -2579,7 +2573,7 @@ void MarlinSettings::reset() {
   //
   // TOUCH_SCREEN_CALIBRATION
   //
-  TERN_(TOUCH_SCREEN_CALIBRATION, touch_calibration.calibration_smart_reset());
+  TERN_(TOUCH_SCREEN_CALIBRATION, touch_calibration.calibration_reset());
 
   //
   // Buzzer enable/disable


### PR DESCRIPTION
Fix touchscreen calibration issue leading to printer locking if no default provided in Configuration

Fix touchscreen calibration calibration failing loop

### Requirements

A Configuration.h with TOUCH_SCREEN_CALIBRATION enabled but no TOUCH_CALIBRATION_X set up.
Typically, the default configuration in `bugfix-2.0.x` with this single addition:
`#define TOUCH_SCREEN` 

### Description

Please refer to #20506 for detailed bug description.
In short, if you don't have default value in for calibration, then there are 3 behaviors that are problematic;
1. Failing touch screen calibration locks up the printer (or at least, it appears locked from user point of view). This PR adds 5 more attempts to succeed calibration
2. Restoring EEPROM to factory default locks up the printer (or at least, it appears locked from user point of view). This PR separate the restoring of factory EEPROM from the currently used touch screen calibration values. It's still safe to save the EEPROM after restoring, zero will be written in the touch screen calibration places as if the calibration was reset, yet the screen is still working.
3. Loading the EEPROM with all zero does not overwrite the default touch screen calibration value if provided, so the touch screen will work in that case.

### Benefits

It improves user experience of using the printer. It allows using the printer without default touch screen calibration set up in Configuration.h

### Configurations

Default configuration should work. Mine are: 
[Marlin.zip](https://github.com/MarlinFirmware/Marlin/files/5721313/Marlin.zip)
Beware: There is no touch screen calibration default in my file.


### Related Issues

Should fix #20506 
