### PR TITLE
Let the "G28 O" command honor the HOME_AFTER_DEACTIVATE setting

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -227,7 +227,7 @@ void GcodeSuite::G28() {
   #endif
 
   // Home (O)nly if position is unknown
-  if (!homing_needed() && parser.boolval('O')) {
+  if (!axes_should_home() && parser.boolval('O')) {
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> homing not needed, skip");
     return;
   }


### PR DESCRIPTION
### Requirements

HOME_AFTER_DEACTIVATE

### Description

I compiled Marlin for my Ender 3 v2 to add support for a BLtouch probe and change some other settings. One of the settings I enabled was HOME_AFTER_DEACTIVATE. However, this doesn't work for the "G28 O" command. Since the bed leveling menu option of the LCD injects "G28O\nG29" it is very easy to accidentally run the hotend off the bed. This change fixes the problem for me.

### Benefits

It makes the G28O command honor the HOME_AFTER_DEACTIVATE setting.

### Configurations

#define HOME_AFTER_DEACTIVATE

### Related Issues

None