### PR TITLE
Get E3V2 DWIN `MACHINE_SIZE` from config

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -86,7 +86,7 @@
 #endif
 
 #ifndef MACHINE_SIZE
-  #define MACHINE_SIZE "220x220x250"
+  #define MACHINE_SIZE STRINGIFY(X_BED_SIZE) "x" STRINGIFY(Y_BED_SIZE) "x" STRINGIFY(Z_MAX_POS)
 #endif
 #ifndef CORP_WEBSITE_C
   #define CORP_WEBSITE_C "www.cxsw3d.com"


### PR DESCRIPTION
### Requirements

Ender 3 v2

### Description

This is a cosmetic fix to automatically update the machine size as displayed on the info menu page when a custom bed size is used.

### Benefits

When you use a custom bed size, you don't have to overrule the MACHINE_SIZE macro anymore.

### Configurations

Non-standard values for X_BED_SIZE, Y_BED_SIZE or Z_MAX_POS.

### Related Issues

None