### PR TITLE
Override STM32 timer assignments to avoid conflicts

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
+++ b/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
@@ -40,6 +40,9 @@
 
 #define BOARD_NO_NATIVE_USB
 
+// Avoid conflict with TIMER_SERVO when using the STM32 HAL
+#define TEMP_TIMER 5
+
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
 //

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO.h
@@ -36,6 +36,9 @@
 
 #define BOARD_NO_NATIVE_USB
 
+// Avoid conflict with TIMER_SERVO when using the STM32 HAL
+#define TEMP_TIMER 5
+
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
 //

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -37,6 +37,9 @@
 
 #define BOARD_NO_NATIVE_USB
 
+// Avoid conflict with TIMER_SERVO when using the STM32 HAL
+#define TEMP_TIMER 5
+
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
 //

--- a/Marlin/src/pins/stm32f4/pins_FLYF407ZG.h
+++ b/Marlin/src/pins/stm32f4/pins_FLYF407ZG.h
@@ -31,6 +31,10 @@
 #define BOARD_WEBSITE_URL    "github.com/FLYmaker/FLYF407ZG"
 #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
 
+// Avoid conflict with fans and TIMER_TONE
+#define TEMP_TIMER 3
+#define STEP_TIMER 5
+
 //
 // EEPROM Emulation
 //

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -31,6 +31,9 @@
 
 #define BOARD_INFO_NAME "MKS Robin Nano V3"
 
+// Avoid conflict with TIMER_TONE
+#define STEP_TIMER 13
+
 // Use one of these or SDCard-based Emulation will be used
 //#define SRAM_EEPROM_EMULATION                   // Use BackSRAM-based EEPROM emulation
 //#define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -29,6 +29,9 @@
 
 #define BOARD_INFO_NAME "MKS Robin PRO V2"
 
+// Avoid conflict with TIMER_TONE
+#define STEP_TIMER 13
+
 // Use one of these or SDCard-based Emulation will be used
 //#define SRAM_EEPROM_EMULATION                   // Use BackSRAM-based EEPROM emulation
 //#define FLASH_EEPROM_EMULATION                  // Use Flash-based EEPROM emulation

--- a/platformio.ini
+++ b/platformio.ini
@@ -980,7 +980,7 @@ board_build.ldscript = ldscript.ld
 board_build.offset   = 0x7000
 board_build.firmware = Robin.bin
 build_flags          = ${common_stm32.build_flags}
-  -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8
+  -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8 -DTIMER_SERIAL=TIM5
 build_unflags        = ${common_stm32.build_unflags}
  -DUSBCON -DUSBD_USE_CDC
 extra_scripts        = ${common.extra_scripts}


### PR DESCRIPTION
### Description

Several STM32 boards had timer conflicts when enabling SPEAKER, BLTOUCH, and TMC2208 drivers with SoftwareSerial.
Override these timer settings in the pins file.
For one board the SoftwareSerial timer number was added in platformio.ini, prevent conflicting with other timers in variant.h.

I have not tested these on hardware, but I did review the PeripheralPins files to check for conflicts with fans.

### Benefits

Fewer complaints about timer conflicts when enabling extra features on boards.

### Configurations

See referenced issues

### Related Issues

Fixes #20387
Fixes #20527
