### PR TITLE
Fix renamed pin PROBE_ENABLE_PIN to PROBE_ACTIVATION_SWITCH_PIN

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
@@ -33,6 +33,6 @@
 #define HEATER_0_PIN                        PA1   // HEATER1
 #define HEATER_BED_PIN                      PA2   // HOT BED
 #define FAN_PIN                             PA0   // FAN
-#define PROBE_ENABLE_PIN                    PC6   // Optoswitch to Enable Z Probe
+#define PROBE_ACTIVATION_SWITCH_PIN         PC6   // Optoswitch to Enable Z Probe
 
 #include "pins_CREALITY_V45x.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V453.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V453.h
@@ -33,6 +33,6 @@
 #define HEATER_0_PIN                        PB14  // HEATER1
 #define HEATER_BED_PIN                      PB13  // HOT BED
 #define FAN_PIN                             PB15  // FAN
-#define PROBE_ENABLE_PIN                    PB2   // Optoswitch to Enable Z Probe
+#define PROBE_ACTIVATION_SWITCH_PIN         PB2   // Optoswitch to Enable Z Probe
 
 #include "pins_CREALITY_V45x.h"


### PR DESCRIPTION
### Description

`PROBE_ENABLE_PIN` has been renamed to `PROBE_ACTIVATION_SWITCH_PIN` but the pin files for the Creality CR-6 SE still use the old pin name. This PR fixes that.

### Benefits

Able to compile 😉

### Related Issues

#20379
#20468