### PR TITLE
Improve ST7920 timings for Rumba32 and Fysetc S6

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -273,7 +273,7 @@
       #define BOARD_ST7920_DELAY_2  DELAY_NS(48)
     #endif
     #ifndef BOARD_ST7920_DELAY_3
-      #define BOARD_ST7920_DELAY_3 DELAY_NS(600)
+      #define BOARD_ST7920_DELAY_3 DELAY_NS(640)
     #endif
   #endif
 

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
@@ -180,7 +180,7 @@
       #define BOARD_ST7920_DELAY_2 DELAY_NS(48)
     #endif
     #ifndef BOARD_ST7920_DELAY_3
-      #define BOARD_ST7920_DELAY_3 DELAY_NS(600)
+      #define BOARD_ST7920_DELAY_3 DELAY_NS(640)
     #endif
   #endif
 


### PR DESCRIPTION
### Description

RepRapDiscount Full Graphics displays show artifacts when used with a Rumba32. Increasing Delay 3 fixes this.

The old values were copied directly from the SKR Pro timings, but the SKR Pro uses a 168 MHz processor, and these boards use a 180 MHz processor. Increased delays are needed to account for the higher clock speed.

I had previously fixed this for the FYSETC S6, but it was reverted back in an update to the pins file. I am repeating the earlier fix here for the S6 as well.

### Benefits

Stable image on FullGraphics displays.

### Configurations

Rumba 32 with RepRapDiscount Full Graphics Smart Controller
[Configuration_adv.zip](https://github.com/MarlinFirmware/Marlin/files/5737834/Configuration_adv.zip)

### Related Issues

N/A
