### PR TITLE
Fix STATUS_MESSAGE_SCROLLING on DOGM

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -892,6 +892,10 @@ void MarlinUI::draw_status_message(const bool blink) {
     }
     else {
       // String is longer than the available space
+      if (blink != last_blink) {
+        last_blink = blink;
+        advance_status_scroll();
+      }
 
       // Get a pointer to the next valid UTF8 character
       // and the string remaining length
@@ -910,11 +914,6 @@ void MarlinUI::draw_status_message(const bool blink) {
             lcd_put_wchar(' ');
           }
         }
-      }
-
-      if (last_blink != blink) {
-        last_blink = blink;
-        advance_status_scroll();
       }
     }
 


### PR DESCRIPTION
### Description

The status line is draw in two u8glib page calls. If `blink` change between these calls, the top of the test will draw in one scroll offset, and bottom in another.

Video: https://www.youtube.com/watch?v=6Sn3ZFMHMNE&feature=youtu.be

This PR will fix it, making it draw always after a scroll offset update.

Because it depends on `blink` timing, maybe it only happen on CLASSIC_UI (emulated dogm).

### Benefits

Fix STATUS_MESSAGE_SCROLLING on DOGM 

### Configurations

```cpp
#define CUSTOM_MACHINE_NAME "Anet ET5X Testing"
#define STATUS_MESSAGE_SCROLLING
#define TFT_CLASSIC_UI
```
