### PR TITLE
12-bit ADC resolution for BIGTREE_SKR_PRO

### DIFF
--- a/buildroot/share/PlatformIO/variants/BIGTREE_SKR_PRO_1v1/variant.h
+++ b/buildroot/share/PlatformIO/variants/BIGTREE_SKR_PRO_1v1/variant.h
@@ -218,7 +218,7 @@ extern "C" {
 // Below ADC, DAC and PWM definitions already done in the core
 // Could be redefined here if needed
 // ADC resolution is 12bits
-//#define ADC_RESOLUTION          12
+#define ADC_RESOLUTION          12
 //#define DACC_RESOLUTION         12
 
 // PWM resolution


### PR DESCRIPTION
### Description

ADC_RESOLUTION defaults to 10 in stm32 arduino: https://github.com/stm32duino/Arduino_Core_STM32/blob/a4058ae1c9e6234b7411ae8214bbd12c99961cca/cores/arduino/pins_arduino.h#L343

BIGTREE_SKR_PRO can use 12-bit ADC (as per stm32f407zgt6 datasheet at https://www.st.com/resource/en/datasheet/dm00037051.pdf)

### Benefits

Better PID stability

### Configurations

None

### Related Issues

#20519, #20539