### PR TITLE
ADC_RESOLUTION=12 on all STM32

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_S6/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_S6/variant.h
@@ -114,10 +114,10 @@ extern "C" {
 #define NUM_ANALOG_INPUTS       7
 #define NUM_ANALOG_FIRST        80
 
-// #define ADC_RESOLUTION          12
+//#define ADC_RESOLUTION          12
 
 // PWM resolution
-// #define PWM_RESOLUTION          12
+//#define PWM_RESOLUTION          12
 #define PWM_FREQUENCY           20000 // >= 20 Khz => inaudible noise for fans
 #define PWM_MAX_DUTY_CYCLE      255
 

--- a/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_S6/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_S6/variant.h
@@ -114,7 +114,7 @@ extern "C" {
 #define NUM_ANALOG_INPUTS       7
 #define NUM_ANALOG_FIRST        80
 
-#define ADC_RESOLUTION          12
+// #define ADC_RESOLUTION          12
 
 // PWM resolution
 // #define PWM_RESOLUTION          12

--- a/platformio.ini
+++ b/platformio.ini
@@ -725,6 +725,7 @@ build_flags   = ${common.build_flags}
   -std=gnu++14
   -DUSBCON -DUSBD_USE_CDC
   -DTIM_IRQ_PRIO=13
+  -DADC_RESOLUTION=12
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
 


### PR DESCRIPTION
### Description

All STM32 mcu support 12-bit adc resolution. Maple uses 12 bit too. This set 12 as default for all STM32 hal.

### Benefits

Better pid stability.

### Related Issues

Fix: #20539
#20558
