### PR TITLE
Fix Change Filament Menu Actions

### DIFF
--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -91,7 +91,7 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
   BACK_ITEM(MSG_BACK);
   #if PREHEAT_COUNT
     LOOP_L_N(m, PREHEAT_COUNT)
-      ACTION_ITEM_N_S(extruder, ui.get_preheat_label(m), MSG_PREHEAT_M, _change_filament_with_preset);
+      ACTION_ITEM_N_S(m, ui.get_preheat_label(m), MSG_PREHEAT_M, _change_filament_with_preset);
   #endif
   EDIT_ITEM_FAST_N(int3, extruder, MSG_PREHEAT_CUSTOM, &thermalManager.temp_hotend[extruder].target,
     EXTRUDE_MINTEMP, thermalManager.heater_maxtemp[extruder] - HOTEND_OVERSHOOT,

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -98,6 +98,7 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
     _change_filament_with_custom
   );
   END_MENU();
+  MenuItemBase::itemIndex = extruder;
 }
 
 /**

--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -90,15 +90,16 @@ void _menu_temp_filament_op(const PauseMode mode, const int8_t extruder) {
   if (LCD_HEIGHT >= 4) STATIC_ITEM_P(change_filament_header(mode), SS_DEFAULT|SS_INVERT);
   BACK_ITEM(MSG_BACK);
   #if PREHEAT_COUNT
+    const int8_t old_index = MenuItemBase::itemIndex;
     LOOP_L_N(m, PREHEAT_COUNT)
       ACTION_ITEM_N_S(m, ui.get_preheat_label(m), MSG_PREHEAT_M, _change_filament_with_preset);
+    MenuItemBase::itemIndex = old_index;
   #endif
   EDIT_ITEM_FAST_N(int3, extruder, MSG_PREHEAT_CUSTOM, &thermalManager.temp_hotend[extruder].target,
     EXTRUDE_MINTEMP, thermalManager.heater_maxtemp[extruder] - HOTEND_OVERSHOOT,
     _change_filament_with_custom
   );
   END_MENU();
-  MenuItemBase::itemIndex = extruder;
 }
 
 /**


### PR DESCRIPTION
### Description

Change filament menu double uses MenuItem::index, leading to one menu level overwriting the other. I tried to fix it on #20201, but I broke the preheat material index.

I'm fixing both cases on this PR.

### Benefits

Fix #20553
Fix #20534
Fix #20154

