### PR TITLE
Fix Menu Mixer for Color UI

### DIFF
--- a/Marlin/src/lcd/menu/menu_mixer.cpp
+++ b/Marlin/src/lcd/menu/menu_mixer.cpp
@@ -71,11 +71,9 @@
       mixer.refresh_gradient();
       ui.goto_previous_screen();
     }
-    #if HAS_GRAPHICAL_TFT
-      else {
-        tft.draw_edit_screen_buttons();
-      }
-    #endif
+    else {
+      TERN_(HAS_GRAPHICAL_TFT, tft.draw_edit_screen_buttons());
+    }
   }
 
   void lcd_mixer_edit_gradient_menu() {
@@ -164,9 +162,7 @@ void lcd_mixer_mix_edit() {
       ui.goto_previous_screen();
     }
 
-    #if HAS_GRAPHICAL_TFT
-      tft.draw_edit_screen_buttons();
-    #endif
+    TERN_(HAS_GRAPHICAL_TFT, tft.draw_edit_screen_buttons());
 
   #else
 

--- a/Marlin/src/lcd/menu/menu_mixer.cpp
+++ b/Marlin/src/lcd/menu/menu_mixer.cpp
@@ -33,6 +33,10 @@
 
 #include "../../feature/mixing.h"
 
+#if HAS_GRAPHICAL_TFT
+  #include "../tft/tft.h"
+#endif
+
 #define CHANNEL_MIX_EDITING !HAS_DUAL_MIXING
 
 #if ENABLED(GRADIENT_MIX)
@@ -67,6 +71,11 @@
       mixer.refresh_gradient();
       ui.goto_previous_screen();
     }
+    #if HAS_GRAPHICAL_TFT
+      else {
+        tft.draw_edit_screen_buttons();
+      }
+    #endif
   }
 
   void lcd_mixer_edit_gradient_menu() {
@@ -154,6 +163,10 @@ void lcd_mixer_mix_edit() {
       mixer.update_vtool_from_mix();
       ui.goto_previous_screen();
     }
+
+    #if HAS_GRAPHICAL_TFT
+      tft.draw_edit_screen_buttons();
+    #endif
 
   #else
 

--- a/Marlin/src/lcd/tft/tft.h
+++ b/Marlin/src/lcd/tft/tft.h
@@ -93,6 +93,7 @@ class TFT {
     static inline void add_image(int16_t x, int16_t y, MarlinImage image, uint16_t color_main = COLOR_WHITE, uint16_t color_background = COLOR_BACKGROUND, uint16_t color_shadow = COLOR_BLACK) { queue.add_image(x, y, image, color_main,  color_background, color_shadow); }
     static inline void add_bar(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint16_t color) { queue.add_bar(x, y, width, height, color); }
     static inline void add_rectangle(uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint16_t color) { queue.add_rectangle(x, y, width, height, color); }
+    static void draw_edit_screen_buttons();
 };
 
 extern TFT tft;

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -652,6 +652,23 @@ void menu_item(const uint8_t row, bool sel ) {
   #endif
 }
 
+void lcd_moveto(const lcd_uint_t col, const lcd_uint_t row) {
+  #define TFT_COL_WIDTH ((TFT_WIDTH) / (LCD_WIDTH))
+  tft.canvas(col * TFT_COL_WIDTH, 4 + 45 * row, TFT_WIDTH - (col * TFT_COL_WIDTH), 43);
+  tft.set_background(COLOR_BACKGROUND);
+}
+
+int lcd_put_u8str_max_P(PGM_P utf8_str_P, pixel_len_t max_length) {
+  tft_string.set(utf8_str_P);
+  tft_string.trim();
+  tft.add_text(MENU_TEXT_X_OFFSET, MENU_TEXT_Y_OFFSET, COLOR_MENU_TEXT, tft_string);
+  return tft_string.width();
+}
+
+int lcd_put_u8str_max(const char * utf8_str, pixel_len_t max_length) {
+  return lcd_put_u8str_max_P(utf8_str, max_length);
+}
+
 void MarlinUI::move_axis_screen() {
 }
 

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -437,9 +437,9 @@ void MenuEditItemBase::draw_edit_screen(PGM_P const pstr, const char* const valu
 
 void TFT::draw_edit_screen_buttons() {
   #if ENABLED(TOUCH_SCREEN)
-    add_control(64, 256, DECREASE, imgDecrease);
-    add_control(352, 256, INCREASE, imgIncrease);
-    add_control(208, 256, CLICK, imgConfirm);
+    add_control(32, 176, DECREASE, imgDecrease);
+    add_control(224, 176, INCREASE, imgIncrease);
+    add_control(128, 176, CLICK, imgConfirm);
   #endif
 }
 

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -432,10 +432,14 @@ void MenuEditItemBase::draw_edit_screen(PGM_P const pstr, const char* const valu
     #endif
   }
 
+  tft.draw_edit_screen_buttons();
+}
+
+void TFT::draw_edit_screen_buttons() {
   #if ENABLED(TOUCH_SCREEN)
-    add_control(32, 176, DECREASE, imgDecrease);
-    add_control(224, 176, INCREASE, imgIncrease);
-    add_control(128, 176, CLICK, imgConfirm);
+    add_control(64, 256, DECREASE, imgDecrease);
+    add_control(352, 256, INCREASE, imgIncrease);
+    add_control(208, 256, CLICK, imgConfirm);
   #endif
 }
 

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -659,6 +659,23 @@ void menu_item(const uint8_t row, bool sel ) {
   #endif
 }
 
+void lcd_moveto(const lcd_uint_t col, const lcd_uint_t row) {
+  #define TFT_COL_WIDTH ((TFT_WIDTH) / (LCD_WIDTH))
+  tft.canvas(col * TFT_COL_WIDTH, 4 + 45 * row, TFT_WIDTH - (col * TFT_COL_WIDTH), 43);
+  tft.set_background(COLOR_BACKGROUND);
+}
+
+int lcd_put_u8str_max_P(PGM_P utf8_str_P, pixel_len_t max_length) {
+  tft_string.set(utf8_str_P);
+  tft_string.trim();
+  tft.add_text(MENU_TEXT_X_OFFSET, MENU_TEXT_Y_OFFSET, COLOR_MENU_TEXT, tft_string);
+  return tft_string.width();
+}
+
+int lcd_put_u8str_max(const char * utf8_str, pixel_len_t max_length) {
+  return lcd_put_u8str_max_P(utf8_str, max_length);
+}
+
 #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
   #include "../../feature/babystep.h"
 #endif

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -439,6 +439,10 @@ void MenuEditItemBase::draw_edit_screen(PGM_P const pstr, const char* const valu
     #endif
   }
 
+  tft.draw_edit_screen_buttons();
+}
+
+void TFT::draw_edit_screen_buttons() {
   #if ENABLED(TOUCH_SCREEN)
     add_control(64, 256, DECREASE, imgDecrease);
     add_control(352, 256, INCREASE, imgIncrease);


### PR DESCRIPTION
### Description

This fix Menu Mixer for Color UI.

It add some glue code for Color UI works with `MENU_ITEM_ADDON`, so more screens could benefit from this. I added a task for my self to check all `MENU_ITEM_ADDON` later.

### Benefits

Fix #20023
