### PR TITLE
Test probe points at build time

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -801,10 +801,10 @@
 //#define ASSISTED_TRAMMING
 #if ENABLED(ASSISTED_TRAMMING)
 
-  // Define positions for probing points, use the hotend as reference not the sensor.
-  #define TRAMMING_POINT_XY { {  20, 20 }, { 200,  20 }, { 200, 200 }, { 20, 200 } }
+  // Define positions for probe points.
+  #define TRAMMING_POINT_XY { {  20, 20 }, { 180,  20 }, { 180, 180 }, { 20, 180 } }
 
-  // Define positions names for probing points.
+  // Define positions names for probe points.
   #define TRAMMING_POINT_NAME_1 "Front-Left"
   #define TRAMMING_POINT_NAME_2 "Front-Right"
   #define TRAMMING_POINT_NAME_3 "Back-Right"

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -804,7 +804,7 @@
   // Define positions for probe points.
   #define TRAMMING_POINT_XY { {  20, 20 }, { 180,  20 }, { 180, 180 }, { 20, 180 } }
 
-  // Define positions names for probe points.
+  // Define position names for probe points.
   #define TRAMMING_POINT_NAME_1 "Front-Left"
   #define TRAMMING_POINT_NAME_2 "Front-Right"
   #define TRAMMING_POINT_NAME_3 "Back-Right"

--- a/Marlin/src/feature/tramming.h
+++ b/Marlin/src/feature/tramming.h
@@ -21,6 +21,7 @@
  */
 
 #include "../inc/MarlinConfigPre.h"
+#include "../module/probe.h"
 
 #if !WITHIN(TRAMMING_SCREW_THREAD, 30, 51) || TRAMMING_SCREW_THREAD % 10 > 1
   #error "TRAMMING_SCREW_THREAD must be equal to 30, 31, 40, 41, 50, or 51."

--- a/Marlin/src/feature/tramming.h
+++ b/Marlin/src/feature/tramming.h
@@ -31,6 +31,10 @@ constexpr xy_pos_t screws_tilt_adjust_pos[] = TRAMMING_POINT_XY;
 #define G35_PROBE_COUNT COUNT(screws_tilt_adjust_pos)
 static_assert(G35_PROBE_COUNT >= 3, "TRAMMING_POINT_XY requires at least 3 XY positions.");
 
+#define VALIDATE_TRAMMING_POINT(N) static_assert(N >= G35_PROBE_COUNT || Probe::build_time::can_reach(screws_tilt_adjust_pos[N]), \
+  "TRAMMING_POINT_XY point " STRINGIFY(N) " is not reachable with the default NOZZLE_TO_PROBE offset and PROBING_MARGIN.")
+VALIDATE_TRAMMING_POINT(0); VALIDATE_TRAMMING_POINT(1); VALIDATE_TRAMMING_POINT(2); VALIDATE_TRAMMING_POINT(3); VALIDATE_TRAMMING_POINT(4);
+
 extern const char point_name_1[], point_name_2[], point_name_3[]
   #ifdef TRAMMING_POINT_NAME_4
     , point_name_4[]

--- a/Marlin/src/feature/z_stepper_align.cpp
+++ b/Marlin/src/feature/z_stepper_align.cpp
@@ -54,25 +54,9 @@ void ZStepperAlign::reset_to_default() {
       #endif
     );
 
-    constexpr xyz_pos_t dpo = NOZZLE_TO_PROBE_OFFSET;
-
-    #define LTEST(N) (xy_init[N].x >= _MAX(X_MIN_BED + PROBING_MARGIN_LEFT,  X_MIN_POS + dpo.x) - 0.00001f)
-    #define RTEST(N) (xy_init[N].x <= _MIN(X_MAX_BED - PROBING_MARGIN_RIGHT, X_MAX_POS + dpo.x) + 0.00001f)
-    #define FTEST(N) (xy_init[N].y >= _MAX(Y_MIN_BED + PROBING_MARGIN_FRONT, Y_MIN_POS + dpo.y) - 0.00001f)
-    #define BTEST(N) (xy_init[N].y <= _MIN(Y_MAX_BED - PROBING_MARGIN_BACK,  Y_MAX_POS + dpo.y) + 0.00001f)
-
-    static_assert(LTEST(0) && RTEST(0), "The 1st Z_STEPPER_ALIGN_XY X is unreachable with the default probe X offset.");
-    static_assert(FTEST(0) && BTEST(0), "The 1st Z_STEPPER_ALIGN_XY Y is unreachable with the default probe Y offset.");
-    static_assert(LTEST(1) && RTEST(1), "The 2nd Z_STEPPER_ALIGN_XY X is unreachable with the default probe X offset.");
-    static_assert(FTEST(1) && BTEST(1), "The 2nd Z_STEPPER_ALIGN_XY Y is unreachable with the default probe Y offset.");
-    #if NUM_Z_STEPPER_DRIVERS >= 3
-      static_assert(LTEST(2) && RTEST(2), "The 3rd Z_STEPPER_ALIGN_XY X is unreachable with the default probe X offset.");
-      static_assert(FTEST(2) && BTEST(2), "The 3rd Z_STEPPER_ALIGN_XY Y is unreachable with the default probe Y offset.");
-      #if NUM_Z_STEPPER_DRIVERS >= 4
-        static_assert(LTEST(3) && RTEST(3), "The 4th Z_STEPPER_ALIGN_XY X is unreachable with the default probe X offset.");
-        static_assert(FTEST(3) && BTEST(3), "The 4th Z_STEPPER_ALIGN_XY Y is unreachable with the default probe Y offset.");
-      #endif
-    #endif
+    #define VALIDATE_ALIGN_POINT(N) static_assert(N >= NUM_Z_STEPPER_DRIVERS || Probe::build_time::can_reach(xy_init[N]), \
+      "Z_STEPPER_ALIGN_XY point " STRINGIFY(N) " is not reachable with the default NOZZLE_TO_PROBE offset and PROBING_MARGIN.")
+    VALIDATE_ALIGN_POINT(0); VALIDATE_ALIGN_POINT(1); VALIDATE_ALIGN_POINT(2); VALIDATE_ALIGN_POINT(3);
 
   #else // !defined(Z_STEPPER_ALIGN_XY)
 

--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -77,6 +77,11 @@ constexpr xy_pos_t lf { (X_MIN_BED) + inset_lfrb[0], (Y_MIN_BED) + inset_lfrb[1]
  */
 #if ENABLED(LEVEL_CORNERS_USE_PROBE)
 
+  #define VALIDATE_POINT(X, Y, STR) static_assert(Probe::build_time::can_reach((X), (Y)), \
+    "LEVEL_CORNERS_INSET_LFRB " STR " inset is not reachable with the default NOZZLE_TO_PROBE offset and PROBING_MARGIN.")
+  VALIDATE_POINT(lf.x, Y_CENTER, "left"); VALIDATE_POINT(X_CENTER, lf.y, "front");
+  VALIDATE_POINT(rb.x, Y_CENTER, "right"); VALIDATE_POINT(X_CENTER, rb.y, "back");
+
   void _lcd_draw_probing() {
     if (ui.should_draw()) MenuItem_static::draw((LCD_HEIGHT - 1) / 2, GET_TEXT(MSG_PROBING_MESH));
   }

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -112,7 +112,7 @@ public:
   static void move_z_after_homing() {
     #ifdef Z_AFTER_HOMING
       do_z_clearance(Z_AFTER_HOMING, true, true, true);
-    #elif BOTH(Z_AFTER_PROBING,HAS_BED_PROBE)
+    #elif BOTH(Z_AFTER_PROBING, HAS_BED_PROBE)
       move_z_after_probing();
     #endif
   }
@@ -184,7 +184,7 @@ public:
     // constexpr helpers used in build-time static_asserts, relying on default probe offsets.
     class build_time {
       static constexpr xyz_pos_t default_probe_xyz_offset = TERN(HAS_BED_PROBE, NOZZLE_TO_PROBE_OFFSET, {0});
-      static constexpr xy_pos_t default_probe_xy_offset = default_probe_xyz_offset;
+      static constexpr xy_pos_t default_probe_xy_offset = { default_probe_xyz_offset.x,  default_probe_xyz_offset.y };
 
     public:
       static constexpr bool can_reach(float x, float y) {

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -62,12 +62,12 @@ public:
       #if HAS_PROBE_XY_OFFSET
         // Return true if the both nozzle and the probe can reach the given point.
         // Note: This won't work on SCARA since the probe offset rotates with the arm.
-        static inline bool can_reach(const float &rx, const float &ry) {
+        static bool can_reach(const float &rx, const float &ry) {
           return position_is_reachable(rx - offset_xy.x, ry - offset_xy.y) // The nozzle can go where it needs to go?
               && position_is_reachable(rx, ry, ABS(PROBING_MARGIN));       // Can the nozzle also go near there?
         }
       #else
-        FORCE_INLINE static bool can_reach(const float &rx, const float &ry) {
+        static bool can_reach(const float &rx, const float &ry) {
           return position_is_reachable(rx, ry, PROBING_MARGIN);
         }
       #endif
@@ -81,7 +81,7 @@ public:
        * Example: For a probe offset of -10,+10, then for the probe to reach 0,0 the
        *          nozzle must be be able to reach +10,-10.
        */
-      static inline bool can_reach(const float &rx, const float &ry) {
+      static bool can_reach(const float &rx, const float &ry) {
         return position_is_reachable(rx - offset_xy.x, ry - offset_xy.y)
             && WITHIN(rx, min_x() - fslop, max_x() + fslop)
             && WITHIN(ry, min_y() - fslop, max_y() + fslop);
@@ -89,13 +89,13 @@ public:
 
     #endif
 
-    static inline void move_z_after_probing() {
+    static void move_z_after_probing() {
       #ifdef Z_AFTER_PROBING
         do_z_clearance(Z_AFTER_PROBING, true, true, true); // Move down still permitted
       #endif
     }
     static float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true);
-    static inline float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true) {
+    static float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true) {
       return probe_at_point(pos.x, pos.y, raise_after, verbose_level, probe_relative, sanity_check);
     }
 
@@ -105,11 +105,11 @@ public:
 
     static bool set_deployed(const bool) { return false; }
 
-    FORCE_INLINE static bool can_reach(const float &rx, const float &ry) { return position_is_reachable(rx, ry); }
+    static bool can_reach(const float &rx, const float &ry) { return position_is_reachable(rx, ry); }
 
   #endif
 
-  static inline void move_z_after_homing() {
+  static void move_z_after_homing() {
     #ifdef Z_AFTER_HOMING
       do_z_clearance(Z_AFTER_HOMING, true, true, true);
     #elif BOTH(Z_AFTER_PROBING,HAS_BED_PROBE)
@@ -117,9 +117,9 @@ public:
     #endif
   }
 
-  FORCE_INLINE static bool can_reach(const xy_pos_t &pos) { return can_reach(pos.x, pos.y); }
+  static bool can_reach(const xy_pos_t &pos) { return can_reach(pos.x, pos.y); }
 
-  FORCE_INLINE static bool good_bounds(const xy_pos_t &lf, const xy_pos_t &rb) {
+  static bool good_bounds(const xy_pos_t &lf, const xy_pos_t &rb) {
     return (
       #if IS_KINEMATIC
         can_reach(lf.x, 0) && can_reach(rb.x, 0) && can_reach(0, lf.y) && can_reach(0, rb.y)
@@ -137,8 +137,8 @@ public:
     static constexpr xy_pos_t offset_xy = xy_pos_t({ 0, 0 });   // See #16767
   #endif
 
-  static inline bool deploy() { return set_deployed(true); }
-  static inline bool stow() { return set_deployed(false); }
+  static bool deploy() { return set_deployed(true); }
+  static bool stow() { return set_deployed(false); }
 
   #if HAS_BED_PROBE || HAS_LEVELING
     #if IS_KINEMATIC
@@ -146,41 +146,78 @@ public:
         TERN_(DELTA, DELTA_PRINTABLE_RADIUS)
         TERN_(IS_SCARA, SCARA_PRINTABLE_RADIUS)
       );
-      static inline float probe_radius() {
-        return printable_radius - _MAX(PROBING_MARGIN, HYPOT(offset_xy.x, offset_xy.y));
+      static constexpr float probe_radius(const xy_pos_t &probe_offset_xy = offset_xy) {
+        return printable_radius - _MAX(PROBING_MARGIN, HYPOT(probe_offset_xy.x, probe_offset_xy.y));
       }
     #endif
 
-    static inline float min_x() {
+    static constexpr float _min_x(const xy_pos_t &probe_offset_xy = offset_xy) {
       return TERN(IS_KINEMATIC,
-        (X_CENTER) - probe_radius(),
-        _MAX((X_MIN_BED) + (PROBING_MARGIN_LEFT), (X_MIN_POS) + offset_xy.x)
-      ) - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x));
+        (X_CENTER) - probe_radius(probe_offset_xy),
+        _MAX((X_MIN_BED) + (PROBING_MARGIN_LEFT), (X_MIN_POS) + probe_offset_xy.x)
+      );
     }
-    static inline float max_x() {
+    static constexpr float _max_x(const xy_pos_t &probe_offset_xy = offset_xy) {
       return TERN(IS_KINEMATIC,
-        (X_CENTER) + probe_radius(),
-        _MIN((X_MAX_BED) - (PROBING_MARGIN_RIGHT), (X_MAX_POS) + offset_xy.x)
-      ) - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x));
+        (X_CENTER) + probe_radius(probe_offset_xy),
+        _MIN((X_MAX_BED) - (PROBING_MARGIN_RIGHT), (X_MAX_POS) + probe_offset_xy.x)
+      );
     }
-    static inline float min_y() {
+    static constexpr float _min_y(const xy_pos_t &probe_offset_xy = offset_xy) {
       return TERN(IS_KINEMATIC,
-        (Y_CENTER) - probe_radius(),
-        _MAX((Y_MIN_BED) + (PROBING_MARGIN_FRONT), (Y_MIN_POS) + offset_xy.y)
-      ) - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y));
+        (Y_CENTER) - probe_radius(probe_offset_xy),
+        _MAX((Y_MIN_BED) + (PROBING_MARGIN_FRONT), (Y_MIN_POS) + probe_offset_xy.y)
+      );
     }
-    static inline float max_y() {
+    static constexpr float _max_y(const xy_pos_t &probe_offset_xy = offset_xy) {
       return TERN(IS_KINEMATIC,
-        (Y_CENTER) + probe_radius(),
-        _MIN((Y_MAX_BED) - (PROBING_MARGIN_BACK), (Y_MAX_POS) + offset_xy.y)
-      ) - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y));
+        (Y_CENTER) + probe_radius(probe_offset_xy),
+        _MIN((Y_MAX_BED) - (PROBING_MARGIN_BACK), (Y_MAX_POS) + probe_offset_xy.y)
+      );
     }
+
+    static float min_x() {
+      return _min_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x));
+    }
+    static float max_x() {
+      return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x));
+    }
+    static float min_y() {
+      return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y));
+    }
+    static float max_y() {
+      return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y));
+    }
+
+    // constexpr helpers used in build-time static_asserts, relying on default probe offsets.
+    class build_time {
+      static constexpr xyz_pos_t default_probe_xyz_offset =
+        #if HAS_BED_PROBE
+          NOZZLE_TO_PROBE_OFFSET;
+        #else
+          {0, 0, 0};
+        #endif
+      static constexpr xy_pos_t default_probe_xy_offset = {default_probe_xyz_offset.x, default_probe_xyz_offset.y};
+
+    public:
+      static constexpr bool can_reach(const xy_pos_t &point) {
+        #if IS_KINEMATIC
+          return HYPOT2(point.x, point.y) <= sq(probe_radius());
+        #else
+          return WITHIN(point.x, _min_x(default_probe_xy_offset) - fslop, _max_x(default_probe_xy_offset) + fslop)
+              && WITHIN(point.y, _min_y(default_probe_xy_offset) - fslop, _max_y(default_probe_xy_offset) + fslop);
+        #endif
+      }
+    };
 
     #if NEEDS_THREE_PROBE_POINTS
       // Retrieve three points to probe the bed. Any type exposing set(X,Y) may be used.
       template <typename T>
-      static inline void get_three_points(T points[3]) {
+      static void get_three_points(T points[3]) {
         #if HAS_FIXED_3POINT
+          #define VALIDATE_PROBE_PT(N) static_assert(Probe::build_time::can_reach(xy_pos_t{PROBE_PT_##N##_X, PROBE_PT_##N##_Y}), \
+            "PROBE_PT_" STRINGIFY(N) "_(X|Y) is unreachable using default NOZZLE_TO_PROBE_OFFSET and PROBING_MARGIN");
+          VALIDATE_PROBE_PT(1); VALIDATE_PROBE_PT(2); VALIDATE_PROBE_PT(3);
           points[0].set(PROBE_PT_1_X, PROBE_PT_1_Y);
           points[1].set(PROBE_PT_2_X, PROBE_PT_2_Y);
           points[2].set(PROBE_PT_3_X, PROBE_PT_3_Y);

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -178,8 +178,8 @@ public:
 
     static float min_x() { return _min_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x)); }
     static float max_x() { return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x)); }
-    static float min_y() { return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y)); }
-    static float max_y() { return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y)); }
+    static float min_y() { return _min_y() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y)); }
+    static float max_y() { return _max_y() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y)); }
 
     // constexpr helpers used in build-time static_asserts, relying on default probe offsets.
     class build_time {

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -138,7 +138,7 @@ public:
   #endif
 
   static bool deploy() { return set_deployed(true); }
-  static bool stow() { return set_deployed(false); }
+  static bool stow()   { return set_deployed(false); }
 
   #if HAS_BED_PROBE || HAS_LEVELING
     #if IS_KINEMATIC
@@ -176,28 +176,15 @@ public:
       );
     }
 
-    static float min_x() {
-      return _min_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x));
-    }
-    static float max_x() {
-      return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x));
-    }
-    static float min_y() {
-      return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y));
-    }
-    static float max_y() {
-      return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y));
-    }
+    static float min_x() { return _min_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x)); }
+    static float max_x() { return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x)); }
+    static float min_y() { return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y)); }
+    static float max_y() { return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y)); }
 
     // constexpr helpers used in build-time static_asserts, relying on default probe offsets.
     class build_time {
-      static constexpr xyz_pos_t default_probe_xyz_offset =
-        #if HAS_BED_PROBE
-          NOZZLE_TO_PROBE_OFFSET;
-        #else
-          {0, 0, 0};
-        #endif
-      static constexpr xy_pos_t default_probe_xy_offset = {default_probe_xyz_offset.x, default_probe_xyz_offset.y};
+      static constexpr xyz_pos_t default_probe_xyz_offset = TERN(HAS_BED_PROBE, NOZZLE_TO_PROBE_OFFSET, {0});
+      static constexpr xy_pos_t default_probe_xy_offset = default_probe_xyz_offset;
 
     public:
       static constexpr bool can_reach(float x, float y) {
@@ -209,9 +196,7 @@ public:
         #endif
       }
 
-      static constexpr bool can_reach(const xy_pos_t &point) {
-        return can_reach(point.x, point.y);
-      }
+      static constexpr bool can_reach(const xy_pos_t &point) { return can_reach(point.x, point.y); }
     };
 
     #if NEEDS_THREE_PROBE_POINTS

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -202,7 +202,7 @@ public:
     public:
       static constexpr bool can_reach(const xy_pos_t &point) {
         #if IS_KINEMATIC
-          return HYPOT2(point.x, point.y) <= sq(probe_radius());
+          return HYPOT2(point.x, point.y) <= sq(probe_radius(default_probe_xy_offset));
         #else
           return WITHIN(point.x, _min_x(default_probe_xy_offset) - fslop, _max_x(default_probe_xy_offset) + fslop)
               && WITHIN(point.y, _min_y(default_probe_xy_offset) - fslop, _max_y(default_probe_xy_offset) + fslop);

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -183,7 +183,13 @@ public:
 
     // constexpr helpers used in build-time static_asserts, relying on default probe offsets.
     class build_time {
-      static constexpr xyz_pos_t default_probe_xyz_offset = TERN(HAS_BED_PROBE, NOZZLE_TO_PROBE_OFFSET, {0});
+      static constexpr xyz_pos_t default_probe_xyz_offset =
+        #if HAS_BED_PROBE
+          NOZZLE_TO_PROBE_OFFSET
+        #else
+          { 0 }
+        #endif
+      ;
       static constexpr xy_pos_t default_probe_xy_offset = { default_probe_xyz_offset.x,  default_probe_xyz_offset.y };
 
     public:

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -200,13 +200,17 @@ public:
       static constexpr xy_pos_t default_probe_xy_offset = {default_probe_xyz_offset.x, default_probe_xyz_offset.y};
 
     public:
-      static constexpr bool can_reach(const xy_pos_t &point) {
+      static constexpr bool can_reach(float x, float y) {
         #if IS_KINEMATIC
-          return HYPOT2(point.x, point.y) <= sq(probe_radius(default_probe_xy_offset));
+          return HYPOT2(x, y) <= sq(probe_radius(default_probe_xy_offset));
         #else
-          return WITHIN(point.x, _min_x(default_probe_xy_offset) - fslop, _max_x(default_probe_xy_offset) + fslop)
-              && WITHIN(point.y, _min_y(default_probe_xy_offset) - fslop, _max_y(default_probe_xy_offset) + fslop);
+          return WITHIN(x, _min_x(default_probe_xy_offset) - fslop, _max_x(default_probe_xy_offset) + fslop)
+              && WITHIN(y, _min_y(default_probe_xy_offset) - fslop, _max_y(default_probe_xy_offset) + fslop);
         #endif
+      }
+
+      static constexpr bool can_reach(const xy_pos_t &point) {
+        return can_reach(point.x, point.y);
       }
     };
 


### PR DESCRIPTION
### Description

Users frequently experience G35 failures because their selected probe points are outside the area reachable by the bed probe. It would benefit from build-time tests to make sure probe points can be reached, as is done for G34.

This is not a perfect solution, since probe offsets can be modified and stored to the EEPROM at runtime. This will at least identify misconfigurations with default settings.

This changes several things:

1. Update configuration_adv.h sample tramming points so they will work with the default bed size and probe offset.
2. Slight wording change in Configuration_adv, to remove "relative to probe" that confused some users.
3. Extract the portion of probe.h min/max functions relevant to build-time checks. Make these constexpr, and add Probe::build_time helpers for use in static_asserts.
4. Remove `inline` and `FORCE_INLINE` attributes from all probe.h functions. These should not be performance critical, and reduce flash usage.
5. Refactors G34 build-time checks to use these helpers.
6. Adds build-time checks for G35 tramming points.
7. Adds build-time checks for custom 3-point PROBE_PT values.
8. Adds build-time checks for LEVEL_CORNERS_USE_PROBE insets

### Benefits

- More users detect issues at build-time, reducing support burden.
- Reduced flash usage by 336 bytes on my AVR test config.

### Configurations

[Configuration_adv.zip](https://github.com/MarlinFirmware/Marlin/files/5742834/Configuration_adv.zip)


### Related Issues

#20412
