### PR TITLE
Enable Fullscreen Bootscreen on 480x320 TFT Color UI

### DIFF
--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -90,9 +90,6 @@ void MarlinUI::clear_lcd() {
 }
 
 #if ENABLED(SHOW_BOOTSCREEN)
-  #undef BOOTSCREEN_TIMEOUT
-  #define BOOTSCREEN_TIMEOUT 5000
-
   void MarlinUI::show_bootscreen() {
     tft.queue.reset();
 

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -97,11 +97,10 @@ void MarlinUI::clear_lcd() {
     tft.queue.reset();
 
     tft.canvas(0, 0, TFT_WIDTH, TFT_HEIGHT);
-    tft.set_background(COLOR_BACKGROUND);
-    tft.add_image(142, 130, imgBootScreen);  // MarlinLogo195x59x16
+    tft.add_image(0, 0, imgBootScreen);  // MarlinLogo480x320x16
 
     #ifdef WEBSITE_URL
-      tft.add_text(8, 250, COLOR_WEBSITE_URL, WEBSITE_URL);
+      tft.add_text(8, 230, COLOR_WEBSITE_URL, WEBSITE_URL);
     #endif
 
     tft.queue.sync();

--- a/Marlin/src/lcd/tft/ui_480x320.h
+++ b/Marlin/src/lcd/tft/ui_480x320.h
@@ -44,7 +44,7 @@ void menu_item(const uint8_t row, bool sel = false);
 #define ABSOLUTE_ZERO     -273.15
 
 const tImage Images[imgCount] = {
-  MarlinLogo195x59x16,
+  MarlinLogo480x320x16,
   HotEnd_64x64x4,
   Bed_64x64x4,
   Bed_Heated_64x64x4,


### PR DESCRIPTION
### Description

Enable fullscreen bootscreen for 480x320 TFTs running Color UI to match the 320x240 Color UI. I removed the bootscreen timeout override since it didn't make sense & wasn't done for the 320x240 Color UI.

Tested on an Anet ET5X with Anet TFT35.

### Benefits

No more small Marlin logo.

### Configurations

[Any of the default ET5 configs](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Anet).

### Related Issues

None.