### PR TITLE
Small / Large Boot Screen option for TFT_COLOR_UI follow-up

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1140,7 +1140,7 @@
 
   #if ENABLED(SHOW_BOOTSCREEN)
     #define BOOTSCREEN_TIMEOUT 4000      // (ms) Total Duration to display the boot screen(s)
-    #if EITHER(HAS_MARLINUI_U8GLIB, TFT_COLOR_UI)
+    #if ANY(HAS_MARLINUI_U8GLIB, TFT_SCALED_DOGLCD, TFT_COLOR_UI)
       #define BOOT_MARLIN_LOGO_SMALL     // Show a smaller Marlin logo on the Boot Screen (saving lots of flash)
     #endif
   #endif


### PR DESCRIPTION
### Description

Quick follow-up so `TFT_CLASSIC_UI` (`TFT_SCALED_DOGLCD`) is also included in `BOOT_MARLIN_LOGO_SMALL` check.

### Benefits

The `BOOT_MARLIN_LOGO_SMALL` setting will now be honored when `TFT_CLASSIC_UI` is enabled. Simply comment it out to use the the old/large bootscreen.

Just to confirm that everything works as expected, I tested it with the following:

- A real `REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER`
- `TFT_CLASSIC_UI` (`TFT_SCALED_DOGLCD`)
- `TFT_COLOR_UI`

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/20578#issuecomment-751728286