### PR TITLE
Only compile TFT_COLOR_UI bootscreen if enabled

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1197,7 +1197,3 @@
     #define TOUCH_ORIENTATION    TOUCH_LANDSCAPE
   #endif
 #endif
-
-#if MB(ANET_ET4, ANET_ET4P)
-  #define IS_ANET_ET 1
-#endif

--- a/Marlin/src/lcd/tft/tft_image.cpp
+++ b/Marlin/src/lcd/tft/tft_image.cpp
@@ -25,12 +25,14 @@
 
 const tImage NoLogo                 = { nullptr, 0, 0, NOCOLORS };
 
-const tImage MarlinLogo112x38x1     = { (void *)marlin_logo_112x38x1, 112, 38, GREYSCALE1 };
-const tImage MarlinLogo228x255x2    = { (void *)marlin_logo_228x255x2, 228, 255, GREYSCALE2 };
-const tImage MarlinLogo228x255x4    = { (void *)marlin_logo_228x255x4, 228, 255, GREYSCALE4 };
-const tImage MarlinLogo195x59x16    = { (void *)marlin_logo_195x59x16,  195,  59, HIGHCOLOR };
-const tImage MarlinLogo320x240x16   = { (void *)marlin_logo_320x240x16, 320, 240, HIGHCOLOR };
-const tImage MarlinLogo480x320x16   = { (void *)marlin_logo_480x320x16, 480, 320, HIGHCOLOR };
+#if ENABLED(SHOW_BOOTSCREEN)
+  const tImage MarlinLogo112x38x1     = { (void *)marlin_logo_112x38x1, 112, 38, GREYSCALE1 };
+  const tImage MarlinLogo228x255x2    = { (void *)marlin_logo_228x255x2, 228, 255, GREYSCALE2 };
+  const tImage MarlinLogo228x255x4    = { (void *)marlin_logo_228x255x4, 228, 255, GREYSCALE4 };
+  const tImage MarlinLogo195x59x16    = { (void *)marlin_logo_195x59x16,  195,  59, HIGHCOLOR };
+  const tImage MarlinLogo320x240x16   = { (void *)marlin_logo_320x240x16, 320, 240, HIGHCOLOR };
+  const tImage MarlinLogo480x320x16   = { (void *)marlin_logo_480x320x16, 480, 320, HIGHCOLOR };
+#endif
 const tImage Background320x30x16    = { (void *)background_320x30x16, 320, 30, HIGHCOLOR };
 
 const tImage HotEnd_64x64x4         = { (void *)hotend_64x64x4, 64, 64, GREYSCALE4 };

--- a/Marlin/src/lcd/tft/tft_image.cpp
+++ b/Marlin/src/lcd/tft/tft_image.cpp
@@ -26,12 +26,12 @@
 const tImage NoLogo                 = { nullptr, 0, 0, NOCOLORS };
 
 #if ENABLED(SHOW_BOOTSCREEN)
-  const tImage MarlinLogo112x38x1     = { (void *)marlin_logo_112x38x1, 112, 38, GREYSCALE1 };
-  const tImage MarlinLogo228x255x2    = { (void *)marlin_logo_228x255x2, 228, 255, GREYSCALE2 };
-  const tImage MarlinLogo228x255x4    = { (void *)marlin_logo_228x255x4, 228, 255, GREYSCALE4 };
-  const tImage MarlinLogo195x59x16    = { (void *)marlin_logo_195x59x16,  195,  59, HIGHCOLOR };
-  const tImage MarlinLogo320x240x16   = { (void *)marlin_logo_320x240x16, 320, 240, HIGHCOLOR };
-  const tImage MarlinLogo480x320x16   = { (void *)marlin_logo_480x320x16, 480, 320, HIGHCOLOR };
+  const tImage MarlinLogo112x38x1   = { (void *)marlin_logo_112x38x1, 112, 38, GREYSCALE1 };
+  const tImage MarlinLogo228x255x2  = { (void *)marlin_logo_228x255x2, 228, 255, GREYSCALE2 };
+  const tImage MarlinLogo228x255x4  = { (void *)marlin_logo_228x255x4, 228, 255, GREYSCALE4 };
+  const tImage MarlinLogo195x59x16  = { (void *)marlin_logo_195x59x16,  195,  59, HIGHCOLOR };
+  const tImage MarlinLogo320x240x16 = { (void *)marlin_logo_320x240x16, 320, 240, HIGHCOLOR };
+  const tImage MarlinLogo480x320x16 = { (void *)marlin_logo_480x320x16, 480, 320, HIGHCOLOR };
 #endif
 const tImage Background320x30x16    = { (void *)background_320x30x16, 320, 30, HIGHCOLOR };
 

--- a/Marlin/src/lcd/tft/tft_image.h
+++ b/Marlin/src/lcd/tft/tft_image.h
@@ -24,7 +24,6 @@
 #include "stdint.h"
 #include "../../inc/MarlinConfigPre.h"
 
-
 extern const uint8_t marlin_logo_112x38x1[];
 extern const uint8_t marlin_logo_228x255x2[];
 extern const uint8_t marlin_logo_228x255x4[];

--- a/Marlin/src/lcd/tft/tft_image.h
+++ b/Marlin/src/lcd/tft/tft_image.h
@@ -120,12 +120,14 @@ typedef struct __attribute__((__packed__)) {
 
 extern const tImage NoLogo;
 
-extern const tImage MarlinLogo112x38x1;
-extern const tImage MarlinLogo228x255x2;
-extern const tImage MarlinLogo228x255x4;
-extern const tImage MarlinLogo195x59x16;
-extern const tImage MarlinLogo320x240x16;
-extern const tImage MarlinLogo480x320x16;
+#if ENABLED(SHOW_BOOTSCREEN)
+  extern const tImage MarlinLogo112x38x1;
+  extern const tImage MarlinLogo228x255x2;
+  extern const tImage MarlinLogo228x255x4;
+  extern const tImage MarlinLogo195x59x16;
+  extern const tImage MarlinLogo320x240x16;
+  extern const tImage MarlinLogo480x320x16;
+#endif
 extern const tImage Background320x30x16;
 
 extern const tImage HotEnd_64x64x4;

--- a/Marlin/src/lcd/tft/tft_image.h
+++ b/Marlin/src/lcd/tft/tft_image.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "stdint.h"
+#include "../../inc/MarlinConfigPre.h"
 
 
 extern const uint8_t marlin_logo_112x38x1[];

--- a/Marlin/src/lcd/tft/ui_320x240.h
+++ b/Marlin/src/lcd/tft/ui_320x240.h
@@ -44,7 +44,11 @@ void menu_item(const uint8_t row, bool sel = false);
 #define ABSOLUTE_ZERO     -273.15
 
 const tImage Images[imgCount] = {
-  TERN(BOOT_MARLIN_LOGO_SMALL, MarlinLogo195x59x16, MarlinLogo320x240x16),
+  #if ENABLED(SHOW_BOOTSCREEN)
+    TERN(BOOT_MARLIN_LOGO_SMALL, MarlinLogo195x59x16, MarlinLogo320x240x16),
+  #else
+    NoLogo,
+  #endif
   HotEnd_64x64x4,
   Bed_64x64x4,
   Bed_Heated_64x64x4,

--- a/Marlin/src/lcd/tft/ui_320x240.h
+++ b/Marlin/src/lcd/tft/ui_320x240.h
@@ -44,11 +44,7 @@ void menu_item(const uint8_t row, bool sel = false);
 #define ABSOLUTE_ZERO     -273.15
 
 const tImage Images[imgCount] = {
-  #if ENABLED(SHOW_BOOTSCREEN)
-    TERN(BOOT_MARLIN_LOGO_SMALL, MarlinLogo195x59x16, MarlinLogo320x240x16),
-  #else
-    NoLogo,
-  #endif
+  TERN(SHOW_BOOTSCREEN, TERN(BOOT_MARLIN_LOGO_SMALL, MarlinLogo195x59x16, MarlinLogo320x240x16), NoLogo),
   HotEnd_64x64x4,
   Bed_64x64x4,
   Bed_Heated_64x64x4,

--- a/Marlin/src/lcd/tft/ui_480x320.h
+++ b/Marlin/src/lcd/tft/ui_480x320.h
@@ -44,7 +44,11 @@ void menu_item(const uint8_t row, bool sel = false);
 #define ABSOLUTE_ZERO     -273.15
 
 const tImage Images[imgCount] = {
-  TERN(BOOT_MARLIN_LOGO_SMALL, MarlinLogo195x59x16, MarlinLogo480x320x16),
+  #if ENABLED(SHOW_BOOTSCREEN)
+    TERN(BOOT_MARLIN_LOGO_SMALL, MarlinLogo195x59x16, MarlinLogo480x320x16),
+  #else
+    NoLogo,
+  #endif
   HotEnd_64x64x4,
   Bed_64x64x4,
   Bed_Heated_64x64x4,

--- a/Marlin/src/lcd/tft/ui_480x320.h
+++ b/Marlin/src/lcd/tft/ui_480x320.h
@@ -44,11 +44,7 @@ void menu_item(const uint8_t row, bool sel = false);
 #define ABSOLUTE_ZERO     -273.15
 
 const tImage Images[imgCount] = {
-  #if ENABLED(SHOW_BOOTSCREEN)
-    TERN(BOOT_MARLIN_LOGO_SMALL, MarlinLogo195x59x16, MarlinLogo480x320x16),
-  #else
-    NoLogo,
-  #endif
+  TERN(SHOW_BOOTSCREEN, TERN(BOOT_MARLIN_LOGO_SMALL, MarlinLogo195x59x16, MarlinLogo480x320x16), NoLogo),
   HotEnd_64x64x4,
   Bed_64x64x4,
   Bed_Heated_64x64x4,


### PR DESCRIPTION
### Description

Fix increased `TFT_COLOR_UI` build sizes after https://github.com/MarlinFirmware/Marlin/pull/20578 due to a two-fold bug:

1. `BOOT_MARLIN_LOGO_SMALL` is no longer checked (and thus "disabled") in this block when `SHOW_BOOTSCREEN` is disabled:
https://github.com/MarlinFirmware/Marlin/blob/a8c361c93bdda3110d147c5f47f96f57298c0a13/Marlin/Configuration_adv.h#L1141-L1146
2. `TFT_COLOR_UI` _always_ compiles in a bootscreen, which means the larger of the two bootscreens due to item 1 above.

### Benefits

Users can now disable `SHOW_BOOTSCREEN` with `TFT_COLOR_UI` and not have the build bloat up/become unbuildable for smaller boards.

### Configurations

[Robin Nano 1.2 - TFT_COLOR_UI.zip](https://github.com/MarlinFirmware/Marlin/files/5748027/Robin.Nano.1.2.-.TFT_COLOR_UI.zip)

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/20585

Originally reported by @th0m4sek: https://github.com/MarlinFirmware/Marlin/commit/cfcfc8047afb09bd3da8d3e7bb49f066a977e6d6#commitcomment-45465331.