### PR TITLE
remove space from m118 host action response

### DIFF
--- a/Marlin/src/gcode/host/M118.cpp
+++ b/Marlin/src/gcode/host/M118.cpp
@@ -66,7 +66,7 @@ void GcodeSuite::M118() {
   #endif
 
   if (hasE) SERIAL_ECHO_START();
-  if (hasA) SERIAL_ECHOPGM("// ");
+  if (hasA) SERIAL_ECHOPGM("//");
   SERIAL_ECHOLN(p);
 
   TERN_(HAS_MULTI_SERIAL, serial_port_index = old_serial);


### PR DESCRIPTION
### Requirements

M118 P0 A1 text

### Description

Results in "// action:notification text" vs expected "//action:notification text"
This breaks octoprints severely deficient passer.
This removes extra space from response.

### Benefits

Works with octoprint and more uniform formatting.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/20594