### PR TITLE
Adjustable precision in M105 temperature report

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2999,7 +2999,7 @@ void Temperature::tick() {
       if (e >= 0) SERIAL_CHAR('0' + e);
     #endif
     SERIAL_CHAR(':');
-    SERIAL_DECIMAL(c);
+    SERIAL_PRINT(c, _MIN(SERIAL_FLOAT_PRECISION, 2))
     SERIAL_ECHOPAIR(" /" , t);
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       SERIAL_ECHOPAIR(" (", r * RECIPROCAL(OVERSAMPLENR));

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2998,8 +2998,7 @@ void Temperature::tick() {
     #if HAS_MULTI_HOTEND
       if (e >= 0) SERIAL_CHAR('0' + e);
     #endif
-    SERIAL_CHAR(':');
-    SERIAL_ECHO(c);
+    SERIAL_ECHOPAIR(":" , c);
     SERIAL_ECHOPAIR(" /" , t);
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       SERIAL_ECHOPAIR(" (", r * RECIPROCAL(OVERSAMPLENR));

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2999,8 +2999,9 @@ void Temperature::tick() {
       if (e >= 0) SERIAL_CHAR('0' + e);
     #endif
     SERIAL_CHAR(':');
-    SERIAL_PRINT(c, _MIN(SERIAL_FLOAT_PRECISION, 2))
-    SERIAL_ECHOPAIR(" /" , t);
+    SERIAL_PRINT(c, _MIN(SERIAL_FLOAT_PRECISION, 2));
+    SERIAL_ECHOPGM(" /");
+    SERIAL_PRINT(t, _MIN(SERIAL_FLOAT_PRECISION, 2));
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       SERIAL_ECHOPAIR(" (", r * RECIPROCAL(OVERSAMPLENR));
       SERIAL_CHAR(')');

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -2998,7 +2998,8 @@ void Temperature::tick() {
     #if HAS_MULTI_HOTEND
       if (e >= 0) SERIAL_CHAR('0' + e);
     #endif
-    SERIAL_ECHOPAIR(":" , c);
+    SERIAL_CHAR(':');
+    SERIAL_DECIMAL(c);
     SERIAL_ECHOPAIR(" /" , t);
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       SERIAL_ECHOPAIR(" (", r * RECIPROCAL(OVERSAMPLENR));


### PR DESCRIPTION
**This PR does not fix a bug. It is entirely cosmetic and low priority**

This concerns

```
// For serial echo, the number of digits after the decimal point
//#define SERIAL_FLOAT_PRECISION 4
```

When it is **enabled** by removing the comments, a possible problem ensues.

There are a few places in the code where `SERIAL_ECHO(...)` is used to display a value of type float.

Thus, for example, the temperature status messages look like this:

```
Recv:  T:21.17 /0.0000 B:21.04 /0.0000 @:0 B@:0
Recv:  T:21.00 /0.0000 B:20.82 /0.0000 @:0 B@:0
Recv:  T:21.07 /0.0000 B:20.96 /0.0000 @:0 B@:0
```

`SERIAL_ECHO` is pretty baseline and does not respect `SERIAL_FLOAT_PRECISION`.

I have not looked at the other (few) places where this constellation also exists.

Since there are only a few places, it seems simpler to recode them instead of messing with `serial.h` and overloading `SERIAL_ECHO` to handle floats correctly, just like `SERIAL_ECHOPAIR` and its brethren do.

So here is the proposed change to `temperature.cpp`, the first such occurence I have noticed.

The temperature message then looks like this:
```
Recv:  T:21.1523 /0.0000 B:20.9765 /0.0000 @:0 B@:0
Recv:  T:21.2695 /0.0000 B:21.2109 /0.0000 @:0 B@:0
Recv:  T:21.3281 /0.0000 B:21.0546 /0.0000 @:0 B@:0
```
