### PR TITLE
Fix FTDI Bilinear build

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -141,11 +141,15 @@ namespace ExtUI {
     void onMeshLevelingStart() {}
 
     void onMeshUpdate(const int8_t x, const int8_t y, const float val) {
-      BedMeshScreen::onMeshUpdate(x, y, val);
+      #if ENABLED(AUTO_BED_LEVELING_UBL)
+        BedMeshScreen::onMeshUpdate(x, y, val);
+      #endif
     }
 
     void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t state) {
-      BedMeshScreen::onMeshUpdate(x, y, state);
+      #if ENABLED(AUTO_BED_LEVELING_UBL)
+        BedMeshScreen::onMeshUpdate(x, y, state);
+      #endif
     }
   #endif
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.cpp
@@ -70,7 +70,7 @@ SCREEN_TABLE {
     #if HAS_BED_PROBE
       DECL_SCREEN(ZOffsetScreen),
     #endif
-    #if HAS_MESH
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
       DECL_SCREEN(BedMeshScreen),
     #endif
   #endif


### PR DESCRIPTION
### Description

A recent commit made the FTDI bed level screen build only when UBL is enabled. This seemed to be intentional. Presumably the implementation is only UBL-compatible.
https://github.com/MarlinFirmware/Marlin/pull/20393

A few additional changes were needed to complete the removal of the screen.

### Benefits

Can build with FTDI enabled and BILINEAR instead of UBL.

### Configurations

I tested with configs from this issue:
https://github.com/MarlinFirmware/Marlin/issues/20582

### Related Issues

Fixes #20582 
