### PR TITLE
Fix CHAMBER_FAN_MODE 0 build (mising semi-colon)

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1234,7 +1234,7 @@ void Temperature::manage_heater() {
 
         #if ENABLED(CHAMBER_FAN)
           #if CHAMBER_FAN_MODE == 0
-            fan_chamber_pwm = CHAMBER_FAN_BASE
+            fan_chamber_pwm = CHAMBER_FAN_BASE;
           #elif CHAMBER_FAN_MODE == 1
             fan_chamber_pwm = (temp_chamber.celsius > temp_chamber.target) ? (CHAMBER_FAN_BASE) + (CHAMBER_FAN_FACTOR) * (temp_chamber.celsius - temp_chamber.target) : 0;
           #elif CHAMBER_FAN_MODE == 2


### PR DESCRIPTION
### Description

Missing semi-colon prevented caused compile error.

### Benefits

Builds.

### Configurations

Adapted from Issue 20619.
[Configuration_adv.zip](https://github.com/MarlinFirmware/Marlin/files/5758532/Configuration_adv.zip)

### Related Issues

Fixes #20619 
