### PR TITLE
remove trailing space from  check_configfile_locations and fix DEBUG_ECHOLNPGM error in motion.cpp 

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1657,10 +1657,7 @@ void homeaxis(const AxisEnum axis) {
 
     // Slow move towards endstop until triggered
     const float rebump = bump * 2;
-    if (DEBUGGING(LEVELING)) {
-      DEBUG_ECHOPAIR_P("Re-bump: ", rebump);
-      DEBUG_ECHOLNPGM("mm");
-    }
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Re-bump: ", rebump, "mm");
     do_homing_move(axis, rebump, get_homing_bump_feedrate(axis));
 
     #if BOTH(HOMING_Z_WITH_PROBE, BLTOUCH)

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1657,7 +1657,10 @@ void homeaxis(const AxisEnum axis) {
 
     // Slow move towards endstop until triggered
     const float rebump = bump * 2;
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Re-bump: ", rebump, "mm");
+    if (DEBUGGING(LEVELING)) {
+      DEBUG_ECHOPAIR_P("Re-bump: ", rebump);
+      DEBUG_ECHOLNPGM("mm");
+    }
     do_homing_move(axis, rebump, get_homing_bump_feedrate(axis));
 
     #if BOTH(HOMING_Z_WITH_PROBE, BLTOUCH)

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -318,6 +318,6 @@ env.AddMethod(MarlinFeatureIsEnabled)
 #
 # Add dependencies for enabled Marlin features
 #
-check_configfile_locations() 
+check_configfile_locations()
 apply_features_config()
 force_ignore_unused_libs()


### PR DESCRIPTION
### Requirements

Current bugfix

### Description

A trailing space managed to slip past (almost) everyone with the calling of check_configfile_locations in common-dependencies.py
CI highlighted an error in some debugging in motion.cpp on this fix, so I fixed that too. 

### Benefits

Remove trailing space
Fix DEBUG_ECHOLNPGM in motion.cpp

### Related Issues
motion.cpp was broken here https://github.com/MarlinFirmware/Marlin/commit/a87e5197cfb2f302c3eea9271b4c25c49df3ab6b