### PR TITLE
CJ-JD Leftover Code Cleanup

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -945,11 +945,9 @@
 #endif
 
 // This flag indicates some kind of jerk storage is needed
-#if EITHER(CLASSIC_JERK, IS_KINEMATIC)
+#if ENABLED(CLASSIC_JERK)
   #define HAS_CLASSIC_JERK 1
-#endif
-
-#if DISABLED(CLASSIC_JERK)
+#else
   #define HAS_JUNCTION_DEVIATION 1
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1244,7 +1244,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 /**
  * Junction deviation is incompatible with kinematic systems.
  */
-#if HAS_JUNCTION_DEVIATION && IS_KINEMATIC
+#if BOTH(HAS_JUNCTION_DEVIATION, IS_KINEMATIC)
   #error "CLASSIC_JERK is required for DELTA and SCARA."
 #endif
 

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -442,14 +442,6 @@ void menu_backlash();
       START_MENU();
       BACK_ITEM(MSG_ADVANCED_SETTINGS);
 
-      #if HAS_JUNCTION_DEVIATION
-        #if ENABLED(LIN_ADVANCE)
-          EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, 0.3f, planner.recalculate_max_e_jerk);
-        #else
-          EDIT_ITEM(float43, MSG_JUNCTION_DEVIATION, &planner.junction_deviation_mm, 0.001f, 0.5f);
-        #endif
-      #endif
-
       constexpr xyze_float_t max_jerk_edit =
         #ifdef MAX_JERK_EDIT_VALUES
           MAX_JERK_EDIT_VALUES

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1341,18 +1341,9 @@ void do_homing_move(const AxisEnum axis, const float distance, const feedRate_t 
     target[axis] = 0;                         // Set the single homing axis to 0
     planner.set_machine_position_mm(target);  // Update the machine position
 
-    #if HAS_DIST_MM_ARG
-      const xyze_float_t cart_dist_mm{0};
-    #endif
-
     // Set delta/cartesian axes directly
     target[axis] = distance;                  // The move will be towards the endstop
-    planner.buffer_segment(target
-      #if HAS_DIST_MM_ARG
-        , cart_dist_mm
-      #endif
-      , home_fr_mm_s, active_extruder
-    );
+    planner.buffer_segment(target, home_fr_mm_s, active_extruder);
   #endif
 
   planner.synchronize();

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -79,10 +79,6 @@
                             manual_feedrate_mm_s { _mf.x / 60.0f, _mf.y / 60.0f, _mf.z / 60.0f, _mf.e / 60.0f };
 #endif
 
-#if IS_KINEMATIC && HAS_JUNCTION_DEVIATION
-  #define HAS_DIST_MM_ARG 1
-#endif
-
 enum BlockFlagBit : char {
   // Recalculate trapezoids on entry junction. For optimization.
   BLOCK_BIT_RECALCULATE,
@@ -673,9 +669,6 @@ class Planner {
       #if HAS_POSITION_FLOAT
         , const xyze_pos_t &target_float
       #endif
-      #if HAS_DIST_MM_ARG
-        , const xyze_float_t &cart_dist_mm
-      #endif
       , feedRate_t fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
     );
 
@@ -695,9 +688,6 @@ class Planner {
         const xyze_long_t &target
       #if HAS_POSITION_FLOAT
         , const xyze_pos_t &target_float
-      #endif
-      #if HAS_DIST_MM_ARG
-        , const xyze_float_t &cart_dist_mm
       #endif
       , feedRate_t fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
     );
@@ -728,23 +718,13 @@ class Planner {
      *  millimeters - the length of the movement, if known
      */
     static bool buffer_segment(const float &a, const float &b, const float &c, const float &e
-      #if HAS_DIST_MM_ARG
-        , const xyze_float_t &cart_dist_mm
-      #endif
       , const feedRate_t &fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
     );
 
     FORCE_INLINE static bool buffer_segment(abce_pos_t &abce
-      #if HAS_DIST_MM_ARG
-        , const xyze_float_t &cart_dist_mm
-      #endif
       , const feedRate_t &fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
     ) {
-      return buffer_segment(abce.a, abce.b, abce.c, abce.e
-        #if HAS_DIST_MM_ARG
-          , cart_dist_mm
-        #endif
-        , fr_mm_s, extruder, millimeters);
+      return buffer_segment(abce.a, abce.b, abce.c, abce.e, fr_mm_s, extruder, millimeters);
     }
 
   public:


### PR DESCRIPTION
### Description

Leftover Classic Jerk and Junction Deviation code cleanup.

There might be more, but I wasn't able to find any.
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits

Less junk.
<!-- What does this fix or improve? -->

### Modification explanation

**Marlin/src/inc/Conditionals_LCD.h**
There is no need to check for `IS_KINEMATIC`:
https://github.com/qwewer0/Marlin/blob/c3350c1945f46c249b37b0431f25b3e197698625/Marlin/src/inc/SanityCheck.h#L1244-L1249

**Marlin/src/inc/SanityCheck.h**
Use `BOTH()` instead.

**Marlin/src/lcd/menu/menu_advanced.cpp, Marlin/src/module/planner.cpp**
Inside `HAS_CLASSIC_JERK` there is no need to check for `HAS_JUNCTION_DEVIATION`:
https://github.com/qwewer0/Marlin/blob/c3350c1945f46c249b37b0431f25b3e197698625/Marlin/src/inc/Conditionals_LCD.h#L948-L952

Removing HAS_DIST_MM_ARG:
**Marlin/src/module/motion.cpp, Marlin/src/module/planner.cpp, Marlin/src/module/planner.h**
`HAS_JUNCTION_DEVIATION` cannot be enabled with `IS_KINEMATIC`:
https://github.com/qwewer0/Marlin/blob/c3350c1945f46c249b37b0431f25b3e197698625/Marlin/src/inc/SanityCheck.h#L1244-L1249