### PR TITLE
Fix mismatched conditional and default override include order

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1045,11 +1045,6 @@
   #define INVERT_E_DIR false
 #endif
 
-// Fallback SPI Speed for SD
-#if ENABLED(SDSUPPORT) && !defined(SD_SPI_SPEED)
-  #define SD_SPI_SPEED SPI_FULL_SPEED
-#endif
-
 /**
  * This setting is also used by M109 when trying to calculate
  * a ballpark safe margin to prevent wait-forever situation.

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2708,6 +2708,11 @@
   #endif
 #endif
 
+// Fallback SPI Speed for SD
+#if ENABLED(SDSUPPORT) && !defined(SD_SPI_SPEED)
+  #define SD_SPI_SPEED SPI_FULL_SPEED
+#endif
+
 // Defined here to catch the above defines
 #if ENABLED(SDCARD_SORT_ALPHA) && (FOLDER_SORTING || ENABLED(SDSORT_GCODE))
   #define HAS_FOLDER_SORTING 1

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
@@ -21,7 +21,7 @@
 
 #include "../config.h"
 
-#if BOTH(TOUCH_UI_FTDI_EVE, AUTO_BED_LEVELING_UBL)
+#if BOTH(TOUCH_UI_FTDI_EVE, HAS_MESH)
 
 #include "screens.h"
 #include "screen_data.h"

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
@@ -309,17 +309,6 @@ void BedMeshScreen::onMeshUpdate(const int8_t, const int8_t, const float) {
     onRefresh();
 }
 
-bool BedMeshScreen::isMeshComplete(ExtUI::bed_mesh_t data) {
-  for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
-    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
-      if (isnan(data[x][y])) {
-        return false;
-      }
-    }
-  }
-  return true;
-}
-
 void BedMeshScreen::onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t state) {
   switch (state) {
     case ExtUI::MESH_START:
@@ -327,7 +316,7 @@ void BedMeshScreen::onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::pr
       screen_data.BedMesh.message = screen_data.BedMesh.MSG_NONE;
       break;
     case ExtUI::MESH_FINISH:
-      if (screen_data.BedMesh.count == GRID_MAX_POINTS && isMeshComplete(ExtUI::getMeshArray()))
+      if (screen_data.BedMesh.count == GRID_MAX_POINTS && ExtUI::getMeshValid())
         screen_data.BedMesh.message = screen_data.BedMesh.MSG_MESH_COMPLETE;
       else
         screen_data.BedMesh.message = screen_data.BedMesh.MSG_MESH_INCOMPLETE;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
@@ -539,7 +539,6 @@ class StepsScreen : public BaseNumericAdjustmentScreen, public CachedScreen<STEP
         static float getHightlightedValue();
         static void drawHighlightedPointValue();
         static void drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max = 0.1);
-        static bool isMeshComplete(ExtUI::bed_mesh_t data);
 
       public:
         static void onMeshUpdate(const int8_t x, const int8_t y, const float val);


### PR DESCRIPTION
When SD_SPI_SPEED  was set in config adv, conditionals lcd had already set it, so duplicate define messages bounded. When using Bilinear instead of UBL, touchscreen had calls to undefined functions.