### PR TITLE
Limit lock-closed to issues newer than July 2017

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -22,7 +22,7 @@ jobs:
         github-token: ${{ github.token }}
         process-only: 'issues'
         issue-lock-inactive-days: '60'
-        issue-exclude-created-before: ''
+        issue-exclude-created-before: '2017-07-01T00:00:00Z'
         issue-exclude-labels: 'no-locking'
         issue-lock-labels: ''
         issue-lock-comment: >


### PR DESCRIPTION
### Description

I did some experimenting and found that early 2017 issues cannot be locked, but July 2017 can.

The lock-closed actions seems to stop as soon as it fails to lock an issue, so this prevents it from locking everything it can.

Until GitHub resolves the issue, I think we should limit the date range to avoid this problem.
This is an educated guess of an appropriate date. If we still encounter problems we can adjust as needed.

### Benefits

Enable the lock-closed action to get through more issues.

### Configurations

N/A

### Related Issues

N/A
