### PR TITLE
fix enable pins for SANGUINOLOLU boards < version 1.2

### DIFF
--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -106,10 +106,10 @@
 #else
 
   #define HEATER_BED_PIN                      14  // (bed)
-  #define X_ENABLE_PIN                        -1
-  #define Y_ENABLE_PIN                        -1
-  #define Z_ENABLE_PIN                        -1
-  #define E0_ENABLE_PIN                       -1
+  #define X_ENABLE_PIN                         4
+  #define Y_ENABLE_PIN                         4
+  #define Z_ENABLE_PIN                         4
+  #define E0_ENABLE_PIN                        4
 
 #endif
 


### PR DESCRIPTION
### Requirements

#define MOTHERBOARD BOARD_SANGUINOLOLU_11

### Description

This result in a compile error
#error "E0_STEP_PIN, E0_DIR_PIN, or E0_ENABLE_PIN not defined for this board."
This error is correct as all enable pin are incorrectly set to -1 on  SANGUINOLOLU boards < version 1.2

I have set  all enable pins back to 4 and checked for conflicts with other 1284p based boards.

### Benefits

MOTHERBOARD BOARD_SANGUINOLOLU_11 compiles as expected.

### Related Issues

None