### PR TITLE
remove BTN_ENC_EN from pins_ANET_10.h

### DIFF
--- a/Marlin/src/pins/sanguino/pins_ANET_10.h
+++ b/Marlin/src/pins/sanguino/pins_ANET_10.h
@@ -198,14 +198,12 @@
 
   #endif
 
-  #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
-    #define BTN_ENC_EN               LCD_PINS_D7  // Detect the presence of the encoder
-  #endif
-
 #else
-
   #define SERVO0_PIN                          27
+#endif
 
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN              SERVO0_PIN
 #endif
 
 /**

--- a/Marlin/src/pins/sanguino/pins_ANET_10.h
+++ b/Marlin/src/pins/sanguino/pins_ANET_10.h
@@ -208,10 +208,6 @@
 
 #endif
 
-#ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN              SERVO0_PIN
-#endif
-
 /**
  * ====================================================================
  * =============== Alternative RepRapDiscount Wiring ==================


### PR DESCRIPTION
### Requirements

BOARD_ANET_10 and  REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER

### Description

Fails to compile. 'DIOLCD_PINS_D7_DDR' was not declared in this scope

I removed the code block trying to setup BTN_ENC_EN.
As far as I can tell (online research only, no physical access to the board) It just doesn't have this pin.

### Benefits

Builds as expected

### Related Issues

Issue https://github.com/MarlinFirmware/Marlin/issues/20680