### PR TITLE
Permit pulldown setup of thermistors' pulling resistors

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1420,7 +1420,11 @@ void Temperature::manage_heater() {
               adc_raw = constrain(raw, 1, adc_max - 1); // constrain to prevent divide-by-zero
 
     const float adc_inverse = (adc_max - adc_raw) - 0.5f,
-                resistance = t.series_res * (adc_raw + 0.5f) / adc_inverse,
+                resistance = t.series_res > 0 ?
+                  // pullup
+                  t.series_res * (adc_raw + 0.5f) / adc_inverse :
+                  // pulldown
+                  (-t.series_res) * adc_inverse / (adc_raw + 0.5f),
                 log_resistance = logf(resistance);
 
     float value = t.sh_alpha;


### PR DESCRIPTION
### Description
Permit pulldown setup of thermistors' pulling resistors, encoded as negative resistance in the configuration files.

<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->

### Benefits
Allows using pulldown resistors with thermistors.
<!-- What does this fix or improve? -->

### Configurations
Something like that:
```
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -54,7 +54,7 @@
 // Custom Thermistor 1000 parameters
 //
 #if TEMP_SENSOR_0 == 1000
-  #define HOTEND0_PULLUP_RESISTOR_OHMS 4700    // Pullup resistor
+  #define HOTEND0_PULLUP_RESISTOR_OHMS -7890    // Pull resistor
   #define HOTEND0_RESISTANCE_25C_OHMS  100000  // Resistance at 25C
   #define HOTEND0_BETA                 3950    // Beta value
 #endif
@@ -102,7 +102,7 @@
 #endif
 
 #if TEMP_SENSOR_BED == 1000
-  #define BED_PULLUP_RESISTOR_OHMS     4700    // Pullup resistor
+  #define BED_PULLUP_RESISTOR_OHMS     -6940    // Pull resistor
   #define BED_RESISTANCE_25C_OHMS      100000  // Resistance at 25C
   #define BED_BETA                     3950    // Beta value
 #endif

```
<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->