### PR TITLE
Preheating should be restored before the homing

### DIFF
--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -377,14 +377,11 @@ void PrintJobRecovery::resume() {
 
   #else // "G92.9 E0 ..."
 
-    // Set Z to 0, raise Z by info.zraise, and Home (XY only for Cartesian)
-    // with no raise. (Only do simulated homing in Marlin Dev Mode.)
-    sprintf_P(cmd, PSTR("G92.9 E0 "
-      TERN(BACKUP_POWER_SUPPLY, "Z%s", "Z0\nG1Z%s")), // Set Z if already raised, or do a raise now
-      dtostrf(info.zraise, 1, 3, str_1)
-    );
+    // If a Z raise occurred at outage restore Z, otherwise raise Z now
+    sprintf_P(cmd, PSTR("G92.9 E0 " TERN(BACKUP_POWER_SUPPLY, "Z%s", "Z0\nG1Z%s")), dtostrf(info.zraise, 1, 3, str_1));
     gcode.process_subcommands_now(cmd);
 
+    // Home safely with no Z raise
     gcode.process_subcommands_now_P(PSTR(
       "G28R0"                               // No raise during G28
       #if IS_CARTESIAN && DISABLED(POWER_LOSS_RECOVER_ZHOME)

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -341,7 +341,7 @@ void PrintJobRecovery::resume() {
     // Make sure leveling is off before any G92 and G28
     gcode.process_subcommands_now_P(PSTR("M420 S0 Z0"));
   #endif
-  
+
   #if HAS_HEATED_BED
     const int16_t bt = info.target_temperature_bed;
     if (bt) {
@@ -379,14 +379,8 @@ void PrintJobRecovery::resume() {
 
     // Set Z to 0, raise Z by info.zraise, and Home (XY only for Cartesian)
     // with no raise. (Only do simulated homing in Marlin Dev Mode.)
-
     sprintf_P(cmd, PSTR("G92.9 E0 "
-        #if ENABLED(BACKUP_POWER_SUPPLY)
-          "Z%s"                             // Z was already raised at outage
-        #else
-          "Z0\nG1Z%s"                       // Set Z=0 and Raise Z now
-        #endif
-      ),
+      TERN(BACKUP_POWER_SUPPLY, "Z%s", "Z0\nG1Z%s")), // Set Z if already raised, or do a raise now
       dtostrf(info.zraise, 1, 3, str_1)
     );
     gcode.process_subcommands_now(cmd);

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -341,6 +341,30 @@ void PrintJobRecovery::resume() {
     // Make sure leveling is off before any G92 and G28
     gcode.process_subcommands_now_P(PSTR("M420 S0 Z0"));
   #endif
+  
+  #if HAS_HEATED_BED
+    const int16_t bt = info.target_temperature_bed;
+    if (bt) {
+      // Restore the bed temperature
+      sprintf_P(cmd, PSTR("M190 S%i"), bt);
+      gcode.process_subcommands_now(cmd);
+    }
+  #endif
+
+  // Restore all hotend temperatures
+  #if HAS_HOTEND
+    HOTEND_LOOP() {
+      const int16_t et = info.target_temperature[e];
+      if (et) {
+        #if HAS_MULTI_HOTEND
+          sprintf_P(cmd, PSTR("T%i S"), e);
+          gcode.process_subcommands_now(cmd);
+        #endif
+        sprintf_P(cmd, PSTR("M109 S%i"), et);
+        gcode.process_subcommands_now(cmd);
+      }
+    }
+  #endif
 
   // Reset E, raise Z, home XY...
   #if Z_HOME_DIR > 0
@@ -402,30 +426,6 @@ void PrintJobRecovery::resume() {
         gcode.process_subcommands_now(cmd);
       }
     #endif
-  #endif
-
-  #if HAS_HEATED_BED
-    const int16_t bt = info.target_temperature_bed;
-    if (bt) {
-      // Restore the bed temperature
-      sprintf_P(cmd, PSTR("M190 S%i"), bt);
-      gcode.process_subcommands_now(cmd);
-    }
-  #endif
-
-  // Restore all hotend temperatures
-  #if HAS_HOTEND
-    HOTEND_LOOP() {
-      const int16_t et = info.target_temperature[e];
-      if (et) {
-        #if HAS_MULTI_HOTEND
-          sprintf_P(cmd, PSTR("T%i S"), e);
-          gcode.process_subcommands_now(cmd);
-        #endif
-        sprintf_P(cmd, PSTR("M109 S%i"), et);
-        gcode.process_subcommands_now(cmd);
-      }
-    }
   #endif
 
   // Select the previously active tool (with no_move)


### PR DESCRIPTION
### Description
This will prevent the model from being pulled out of bed. Tested on my Prusa i3 and Tronxy x5sa printers. After power is restored, if the printer heaters recover before the homing then the printed model remains in the bed.

### Benefits

The proposed change will prevent the incomplete model from coming off the bed. Especially when, after very long hours of printing it's important to save the print.

### Configurations

n/a
