### PR TITLE
Added SDCARD_CONNECTION handler to LONGER3D_LKx_PRO board

### DIFF
--- a/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
+++ b/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
@@ -87,9 +87,21 @@
 #define Z_MIN_PROBE_PIN                       -1
 
 //
+// SD Support
+//
+#if SD_CONNECTION_IS(LCD)
+  #error "SD LCD is not compatible with LONGER3D_LKx_PRO"
+#elif SD_CONNECTION_IS(ONBOARD)
+  #define SD_DETECT_PIN                       -1
+#elif SD_CONNECTION_IS(LCD)
+  #error "SD CUSTOM_CABLE is not compatible with LONGER3D_LKx_PRO"
+#else
+  #define SD_DETECT_PIN                       49
+#endif
+
+//
 // Misc. Functions
 //
-#define SD_DETECT_PIN                         49
 #define FIL_RUNOUT_PIN                         2
 
 //


### PR DESCRIPTION
### Description

With this commit the board is able to handle SDCARD_CONNECTION option

### Benefits

LONGER3D_LKx_PRO board improvement

### Question
Due to the comment at this line: https://github.com/MarlinFirmware/Marlin/blob/f74015b4e57677cd033e116dab2331478edbe2ec/Marlin/Configuration_adv.h#L1336

I understood that if the board has SD_DETECT_PIN, but SDCARD_CONNECTION ONBOARD is selected, the SD_DETECT_PIN must be put to -1. Did i understood well?

The doubt come because a lot of boards put ONBOARD as default SDCARD_CONNECTION, setting the real SD_DETECT_PIN.

E.g. https://github.com/MarlinFirmware/Marlin/blob/f74015b4e57677cd033e116dab2331478edbe2ec/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h#L243-L258
