### PR TITLE
Consider axes unhomed after M84

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -518,10 +518,10 @@ inline void manage_inactivity(const bool ignore_stepper_queue=false) {
       if (!already_shutdown_steppers) {
         already_shutdown_steppers = true;  // L6470 SPI will consume 99% of free time without this
 
-        // Individual axes will be disabled if configured
-        if (ENABLED(DISABLE_INACTIVE_X)) DISABLE_AXIS_X();
-        if (ENABLED(DISABLE_INACTIVE_Y)) DISABLE_AXIS_Y();
-        if (ENABLED(DISABLE_INACTIVE_Z)) DISABLE_AXIS_Z();
+        // Individual axes will be disabled and considered to be homed if configured
+        if (ENABLED(DISABLE_INACTIVE_X)) DISABLE_AXIS_X() set_axis_never_homed(X_AXIS);
+        if (ENABLED(DISABLE_INACTIVE_Y)) DISABLE_AXIS_Y() set_axis_never_homed(X_AXIS);
+        if (ENABLED(DISABLE_INACTIVE_Z)) DISABLE_AXIS_Z() set_axis_never_homed(X_AXIS);
         if (ENABLED(DISABLE_INACTIVE_E)) disable_e_steppers();
 
         TERN_(AUTO_BED_LEVELING_UBL, ubl.steppers_were_disabled());

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -518,7 +518,7 @@ inline void manage_inactivity(const bool ignore_stepper_queue=false) {
       if (!already_shutdown_steppers) {
         already_shutdown_steppers = true;  // L6470 SPI will consume 99% of free time without this
 
-        // Individual axes will be disabled and considered to be homed if configured
+        // Individual axes will be disabled and considered to be not homed if configured
         if (ENABLED(DISABLE_INACTIVE_X)) DISABLE_AXIS_X() set_axis_never_homed(X_AXIS);
         if (ENABLED(DISABLE_INACTIVE_Y)) DISABLE_AXIS_Y() set_axis_never_homed(X_AXIS);
         if (ENABLED(DISABLE_INACTIVE_Z)) DISABLE_AXIS_Z() set_axis_never_homed(X_AXIS);


### PR DESCRIPTION
When the steppers are released/disabled on a M84, after a stepper time-out or manual disable command. They should not be trusted anymore.

Example, when you do an auto bedleveling, wait after the timeout, move your bed and restart another auto bedleveling, you'll get in trouble without a new autohome.
After a M84, the Z axis also drops a bit and that alone should be untrusted.

The best place I could think of was in MarlinCore.cpp, I have tested this on a E3v2 and the result was as desired.

Result;

The auto bed-level code in Marlin starts with a G28O;
G28O does not autohome within 2 minutes timeout, after the timeout or manual disable, G28O does a new autohome on all axes when you request a new auto bedleveling.
