### PR TITLE
add support for 6 tramming points

### DIFF
--- a/Marlin/src/feature/tramming.cpp
+++ b/Marlin/src/feature/tramming.cpp
@@ -49,7 +49,7 @@ PGM_P const tramming_point_name[] PROGMEM = {
     #ifdef TRAMMING_POINT_NAME_5
       , point_name_5
       #ifdef TRAMMING_POINT_NAME_6
-      , point_name_6
+        , point_name_6
       #endif
     #endif
   #endif

--- a/Marlin/src/feature/tramming.cpp
+++ b/Marlin/src/feature/tramming.cpp
@@ -36,6 +36,9 @@ PGMSTR(point_name_3, TRAMMING_POINT_NAME_3);
   PGMSTR(point_name_4, TRAMMING_POINT_NAME_4);
   #ifdef TRAMMING_POINT_NAME_5
     PGMSTR(point_name_5, TRAMMING_POINT_NAME_5);
+    #ifdef TRAMMING_POINT_NAME_6
+      PGMSTR(point_name_6, TRAMMING_POINT_NAME_6);
+    #endif
   #endif
 #endif
 
@@ -45,6 +48,9 @@ PGM_P const tramming_point_name[] PROGMEM = {
     , point_name_4
     #ifdef TRAMMING_POINT_NAME_5
       , point_name_5
+      #ifdef TRAMMING_POINT_NAME_6
+      , point_name_6
+      #endif
     #endif
   #endif
 };

--- a/Marlin/src/feature/tramming.h
+++ b/Marlin/src/feature/tramming.h
@@ -32,16 +32,20 @@ constexpr xy_pos_t screws_tilt_adjust_pos[] = TRAMMING_POINT_XY;
 
 #define G35_PROBE_COUNT COUNT(screws_tilt_adjust_pos)
 static_assert(G35_PROBE_COUNT >= 3, "TRAMMING_POINT_XY requires at least 3 XY positions.");
+static_assert(G35_PROBE_COUNT > 6, "TRAMMING_POINT_XY can only handle 6 XY positions max.");
 
 #define VALIDATE_TRAMMING_POINT(N) static_assert(N >= G35_PROBE_COUNT || Probe::build_time::can_reach(screws_tilt_adjust_pos[N]), \
   "TRAMMING_POINT_XY point " STRINGIFY(N) " is not reachable with the default NOZZLE_TO_PROBE offset and PROBING_MARGIN.")
-VALIDATE_TRAMMING_POINT(0); VALIDATE_TRAMMING_POINT(1); VALIDATE_TRAMMING_POINT(2); VALIDATE_TRAMMING_POINT(3); VALIDATE_TRAMMING_POINT(4);
+VALIDATE_TRAMMING_POINT(0); VALIDATE_TRAMMING_POINT(1); VALIDATE_TRAMMING_POINT(2); VALIDATE_TRAMMING_POINT(3); VALIDATE_TRAMMING_POINT(4); VALIDATE_TRAMMING_POINT(5);
 
 extern const char point_name_1[], point_name_2[], point_name_3[]
   #ifdef TRAMMING_POINT_NAME_4
     , point_name_4[]
     #ifdef TRAMMING_POINT_NAME_5
       , point_name_5[]
+      #ifdef TRAMMING_POINT_NAME_6
+        , point_name_6[]
+      #endif
     #endif
   #endif
 ;
@@ -56,6 +60,10 @@ extern const char point_name_1[], point_name_2[], point_name_3[]
     #ifdef TRAMMING_POINT_NAME_5
       #undef _NR_TRAM_NAMES
       #define _NR_TRAM_NAMES 5
+      #ifdef TRAMMING_POINT_NAME_6
+        #undef _NR_TRAM_NAMES
+        #define _NR_TRAM_NAMES 6
+      #endif
     #endif
   #endif
 #endif

--- a/Marlin/src/feature/tramming.h
+++ b/Marlin/src/feature/tramming.h
@@ -32,7 +32,7 @@ constexpr xy_pos_t screws_tilt_adjust_pos[] = TRAMMING_POINT_XY;
 
 #define G35_PROBE_COUNT COUNT(screws_tilt_adjust_pos)
 static_assert(G35_PROBE_COUNT >= 3, "TRAMMING_POINT_XY requires at least 3 XY positions.");
-static_assert(G35_PROBE_COUNT > 6, "TRAMMING_POINT_XY can only handle 6 XY positions max.");
+static_assert(G35_PROBE_COUNT <= 6, "TRAMMING_POINT_XY can only handle 6 XY positions max.");
 
 #define VALIDATE_TRAMMING_POINT(N) static_assert(N >= G35_PROBE_COUNT || Probe::build_time::can_reach(screws_tilt_adjust_pos[N]), \
   "TRAMMING_POINT_XY point " STRINGIFY(N) " is not reachable with the default NOZZLE_TO_PROBE offset and PROBING_MARGIN.")

--- a/Marlin/src/feature/tramming.h
+++ b/Marlin/src/feature/tramming.h
@@ -31,8 +31,7 @@
 constexpr xy_pos_t screws_tilt_adjust_pos[] = TRAMMING_POINT_XY;
 
 #define G35_PROBE_COUNT COUNT(screws_tilt_adjust_pos)
-static_assert(G35_PROBE_COUNT >= 3, "TRAMMING_POINT_XY requires at least 3 XY positions.");
-static_assert(G35_PROBE_COUNT <= 6, "TRAMMING_POINT_XY can only handle 6 XY positions max.");
+static_assert(WITHIN(G35_PROBE_COUNT, 3, 6), "TRAMMING_POINT_XY requires between 3 and 6 XY positions.");
 
 #define VALIDATE_TRAMMING_POINT(N) static_assert(N >= G35_PROBE_COUNT || Probe::build_time::can_reach(screws_tilt_adjust_pos[N]), \
   "TRAMMING_POINT_XY point " STRINGIFY(N) " is not reachable with the default NOZZLE_TO_PROBE offset and PROBING_MARGIN.")


### PR DESCRIPTION
add assert if to many points are configured

### Benefits

bump maximum tramming points handled form 5 to 6.
this is for example needed for a tronxy x5sa pro which has 6 points to adjust.

add check if to many points a configured, this is needed since if too many points a configured the firmware crashes since its tryes to print binary data as string.
array out of index access for `tramming_point_name` at the end of the G35 run in the result printing code.



### Configurations

```cpp

//
// Add the G35 command to read bed corners to help adjust screws. Requires a bed probe.
//
#define ASSISTED_TRAMMING
#if ENABLED(ASSISTED_TRAMMING)

  // Define positions for probing points, use the hotend as reference not the sensor.
  #define TRAMMING_POINT_XY { { 20, 20 }, { 165, 20 }, { 285, 20 }, { 285, 308 }, { 165, 308 }, { 20, 308 } }

  // Define positions names for probing points.
  #define TRAMMING_POINT_NAME_1 "Front-Left"
  #define TRAMMING_POINT_NAME_2 "Front-Mid"
  #define TRAMMING_POINT_NAME_3 "Front-Right"
  #define TRAMMING_POINT_NAME_4 "Back-Right"
  #define TRAMMING_POINT_NAME_5 "Back-Mid"
  #define TRAMMING_POINT_NAME_6 "Back-Left"

  #define RESTORE_LEVELING_AFTER_G35    // Enable to restore leveling setup after operation
  #define REPORT_TRAMMING_MM            // Report Z deviation (mm) for each point relative to the first

  #define ASSISTED_TRAMMING_WIZARD    // Add a Tramming Wizard to the LCD menu

  //#define ASSISTED_TRAMMING_WAIT_POSITION { X_CENTER, Y_CENTER, 30 } // Move the nozzle out of the way for adjustment

  /**
   * Screw thread:
   *   M3: 30 = Clockwise, 31 = Counter-Clockwise
   *   M4: 40 = Clockwise, 41 = Counter-Clockwise
   *   M5: 50 = Clockwise, 51 = Counter-Clockwise
   */
  #define TRAMMING_SCREW_THREAD 30

#endif

```

### Related Issues

never searched,I simply fixed the code ;)