### PR TITLE
Wanhao One+ SD detect pin

### DIFF
--- a/Marlin/src/pins/mega/pins_WANHAO_ONEPLUS.h
+++ b/Marlin/src/pins/mega/pins_WANHAO_ONEPLUS.h
@@ -82,7 +82,7 @@
 //
 // SD Card
 //
-#define SD_DETECT_PIN                         -1
+#define SD_DETECT_PIN                         83
 #define SDSS                                  53
 
 //


### PR DESCRIPTION
### Description

Define SD_DETECT_PIN for Wanhao One+ board to enable SD card support.

### Benefits

Prior to this Marlin was not detecting SD card insertion on a Cocoon Create ModelMaker (a Wanhao Duplicator i3 Mini rebrand).

### Configurations

This allows Configuration.h's SDSUPPORT define to function as expected:

```
/**
 * SD CARD
 *
 * SD Card support is disabled by default. If your controller has an SD slot,
 * you must uncomment the following option or it won't work.
 */
#define SDSUPPORT
```

### Related Issues

* Wanhao Duplicator i3 Mini & Rebrands Support [#12425](https://github.com/MarlinFirmware/Marlin/issues/12425)
* Wanhao Duplicator i3 Mini & Rebrands Configuration [#14559](https://github.com/MarlinFirmware/Marlin/pull/14559)

### Additional Information

An old Cocoon Create ModelMaker joined the printer family this week. After backing up Marlin 1.1.4 and upgrading to 2.0.7.2 it was observed that the SD card was no longer working. Continuity probing showed the Card Detect connected to m2560 pin 49 which, in src/HAL/AVR/fastio/fastio_1280.h maps to Port D6/Logical Pin 83.