### PR TITLE
Fix reporting of TMC_S2VSA/B

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -604,8 +604,6 @@
         case TMC_PWM_OFS_AUTO: SERIAL_PRINT(st.pwm_ofs_auto(), DEC); break;
         case TMC_PWM_GRAD_AUTO: SERIAL_PRINT(st.pwm_grad_auto(), DEC); break;
         case TMC_STEALTHCHOP: serialprint_truefalse(st.stealth()); break;
-        case TMC_S2VSA: if (st.s2vsa()) SERIAL_CHAR('*'); break;
-        case TMC_S2VSB: if (st.s2vsb()) SERIAL_CHAR('*'); break;
         case TMC_INTERPOLATE: serialprint_truefalse(st.intpol()); break;
         default: break;
       }
@@ -631,6 +629,8 @@
         case TMC_T150: if (st.t150()) SERIAL_CHAR('*'); break;
         case TMC_T143: if (st.t143()) SERIAL_CHAR('*'); break;
         case TMC_T120: if (st.t120()) SERIAL_CHAR('*'); break;
+        case TMC_S2VSA: if(st.s2vsa()) SERIAL_CHAR('*'); break;
+        case TMC_S2VSB: if(st.s2vsb()) SERIAL_CHAR('*'); break;
         case TMC_DRV_CS_ACTUAL: SERIAL_PRINT(st.cs_actual(), DEC); break;
         default: break;
       }

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -629,8 +629,8 @@
         case TMC_T150: if (st.t150()) SERIAL_CHAR('*'); break;
         case TMC_T143: if (st.t143()) SERIAL_CHAR('*'); break;
         case TMC_T120: if (st.t120()) SERIAL_CHAR('*'); break;
-        case TMC_S2VSA: if(st.s2vsa()) SERIAL_CHAR('*'); break;
-        case TMC_S2VSB: if(st.s2vsb()) SERIAL_CHAR('*'); break;
+        case TMC_S2VSA: if (st.s2vsa()) SERIAL_CHAR('*'); break;
+        case TMC_S2VSB: if (st.s2vsb()) SERIAL_CHAR('*'); break;
         case TMC_DRV_CS_ACTUAL: SERIAL_PRINT(st.cs_actual(), DEC); break;
         default: break;
       }


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

During `tmc_report_all()`, the status of the `S2VSA` and `S2VSB` flags are reporting using `DRV_REPORT`.
https://github.com/MarlinFirmware/Marlin/blob/f74015b4e57677cd033e116dab2331478edbe2ec/Marlin/src/feature/tmc_util.cpp#L604

However the code to handle `TMC_S2VSA/B` is currently in `_tmc_status()` instead of `_tmc_parse_drv_status()`. This means that the `s2vsa`/`s2vsb` are never indicated.
```
Recv: DRVSTATUS	X	Y	Z	E
Recv: sg_result
Recv: stst
Recv: olb
Recv: ola
Recv: s2gb
Recv: s2ga
Recv: otpw
Recv: ot
Recv: 157C
Recv: 150C
Recv: 143C
Recv: 120C
Recv: s2vsa
Recv: s2vsb
Recv: Driver registers:
Recv: 		X	0xC0:0C:00:20
Recv: 		Y	0xC0:0C:00:00
Recv: 		Z	0xC0:0C:00:00
Recv: 		E	0xC0:0C:00:00
```
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->


### Benefits

`S2VSA` and `S2VSB` are now reported properly.
```
Recv: DRVSTATUS	X	Y	Z	E
Recv: sg_result
Recv: stst
Recv: olb
Recv: ola
Recv: s2gb
Recv: s2ga
Recv: otpw
Recv: ot
Recv: 157C
Recv: 150C
Recv: 143C
Recv: 120C
Recv: s2vsa
Recv: s2vsb		*
Recv: Driver registers:
Recv: 		X	0xC0:0C:00:20
Recv: 		Y	0xC0:0C:00:00
Recv: 		Z	0xC0:0C:00:00
Recv: 		E	0xC0:0C:00:00
```
### Configurations

Shouldn't need anything other and TMC220x drivers

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
