### PR TITLE
Fix short circuit handling on TMC220x

### DIFF
--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -291,7 +291,7 @@
     bool should_step_down = false;
 
     if (need_update_error_counters) {
-      if (data.is_ot /* | data.s2ga | data.s2gb*/) st.error_count++;
+      if (data.is_ot | data.is_s2g) st.error_count++;
       else if (st.error_count > 0) st.error_count--;
 
       #if ENABLED(STOP_ON_ERROR)

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -147,7 +147,7 @@
 
     static TMC_driver_data get_driver_data(TMC2208Stepper &st) {
       constexpr uint8_t OTPW_bp = 0, OT_bp = 1;
-      constexpr uint8_t S2G_bm = 0b11110; // 2..5
+      constexpr uint8_t S2G_bm = 0b111100; // 2..5
       TMC_driver_data data;
       const auto ds = data.drv_status = st.DRV_STATUS();
       data.is_otpw = TEST(ds, OTPW_bp);


### PR DESCRIPTION
### Description

Currently with `STOP_ON_ERROR`, Marlin ignores short circuit conditions. However there is commented out code which checks `s2a` and `s2b`. I suspect the fact that it was not updated to use `is_s2g` as part of #13135 was simply an oversight.

In addition the short-circuit bitmask used for TMC220x drivers is incorrect. The bits we are interested in are 2..5 (which is reflected in the comment), but the current mask is actually for 1..4
### Benefits

- When `STOP_ON_ERROR` and `MONITOR_DRIVER_STATUS` are enabled, Marlin will halt on a TMC driver reporting a short circuit condition.

- Short circuit flags are properly identified for TMC220x drivers

### Configurations

requires a TMC220x driver, `STOP_ON_ERROR` and `MONITOR_DRIVER_STATUS`
