### PR TITLE
Allow DWIN to use LCD_SERIAL_PORT

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1011,6 +1011,12 @@ void setup() {
     while (/*!WIFISERIAL && */PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
   #endif
 
+  #if defined(DWIN_CREALITY_LCD) && defined(LCD_SERIAL_PORT)
+    LCD_SERIAL.begin(115200UL);
+    serial_connect_timeout = millis() + 1000UL;
+    while (!LCD_SERIAL && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+  #endif
+
   SETUP_RUN(HAL_init());
 
   // Init and disable SPI thermocouples

--- a/Marlin/src/lcd/dwin/dwin_lcd.cpp
+++ b/Marlin/src/lcd/dwin/dwin_lcd.cpp
@@ -40,6 +40,12 @@
 //#define DEBUG_OUT 1
 #include "../../core/debug_out.h"
 
+#ifndef LCD_SERIAL_PORT
+  #define DWIN_SERIAL MYSERIAL1
+#else
+  #define DWIN_SERIAL LCD_SERIAL
+#endif
+
 // Make sure DWIN_SendBuf is large enough to hold the largest string plus draw command and tail.
 // Assume the narrowest (6 pixel) font and 2-byte gb2312-encoded characters.
 uint8_t DWIN_SendBuf[11 + DWIN_WIDTH / 6 * 2] = { 0xAA };
@@ -82,8 +88,8 @@ inline void DWIN_String(size_t &i, const __FlashStringHelper * string) {
 // Send the data in the buffer and the packet end
 inline void DWIN_Send(size_t &i) {
   ++i;
-  LOOP_L_N(n, i) { MYSERIAL1.write(DWIN_SendBuf[n]); delayMicroseconds(1); }
-  LOOP_L_N(n, 4) { MYSERIAL1.write(DWIN_BufTail[n]); delayMicroseconds(1); }
+  LOOP_L_N(n, i) { DWIN_SERIAL.write(DWIN_SendBuf[n]); delayMicroseconds(1); }
+  LOOP_L_N(n, 4) { DWIN_SERIAL.write(DWIN_BufTail[n]); delayMicroseconds(1); }
 }
 
 /*-------------------------------------- System variable function --------------------------------------*/
@@ -94,8 +100,8 @@ bool DWIN_Handshake(void) {
   DWIN_Byte(i, 0x00);
   DWIN_Send(i);
 
-  while (MYSERIAL1.available() > 0 && recnum < (signed)sizeof(databuf)) {
-    databuf[recnum] = MYSERIAL1.read();
+  while (DWIN_SERIAL.available() > 0 && recnum < (signed)sizeof(databuf)) {
+    databuf[recnum] = DWIN_SERIAL.read();
     // ignore the invalid data
     if (databuf[0] != FHONE) { // prevent the program from running.
       if (recnum > 0) {

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -497,14 +497,21 @@ inline void Draw_Back_First(const bool is_sel=true) {
   if (is_sel) Draw_Menu_Cursor(0);
 }
 
-inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, auto &valref) {
-  if (encoder_diffState == ENCODER_DIFF_CW)
-    valref += EncoderRate.encoderMoveValue;
-  else if (encoder_diffState == ENCODER_DIFF_CCW)
-    valref -= EncoderRate.encoderMoveValue;
-  else if (encoder_diffState == ENCODER_DIFF_ENTER)
+#define APPLY_ENCODER_F \
+  if (encoder_diffState == ENCODER_DIFF_CW)          \ 
+    valref += EncoderRate.encoderMoveValue;          \
+  else if (encoder_diffState == ENCODER_DIFF_CCW)    \
+    valref -= EncoderRate.encoderMoveValue;          \
+  else if (encoder_diffState == ENCODER_DIFF_ENTER)  \
     return true;
   return false;
+
+inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, int16_t &valref) {
+  APPLY_ENCODER_F
+}
+
+inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, float &valref) {
+  APPLY_ENCODER_F
 }
 
 //

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -249,6 +249,9 @@ typedef struct {
     float Move_E_scale    = 0;
   #endif
   float offset_value      = 0;
+  #if NOT_TARGET(__STM32F1__, STM32F1xx, STM32F0xx)
+    unsigned
+  #endif
   char show_mode          = 0;    // -1: Temperature control    0: Printing temperature
 } HMI_value_t;
 


### PR DESCRIPTION
### Requirements

None, backward compatible

### Description

I have an Ender 3 V2 using a DWIN display.  I'm using an SKR 1.4 Turbo and want the option of specifying the serial port for the DWIN display.  [I've tested this and it is running on an SKR 1.4](https://www.reddit.com/r/ender3/comments/jsiv0d/ender_3_v2_dwin_on_skr_boards/).

There are some other bugs I'd like to address around this display in the future, like the SKR 1.4 not being able to adjust the nozzle temperature in the control menu without breaking the flow of the menus and ending up in the print menu without being in a print job.  I'd like to address those as separate pull requests/code reviews

### Benefits

Allow DWIN display to use the desired serial port driven using the existing "LCD_SERIAL_PORT" configuration directive

### Configurations

Nothing new is required but allows the following on an SKR 1.4 for example:

Configuration.h
```configuration.h
//
// Ender-3 v2 OEM display. A DWIN display with Rotary Encoder.
//
#define DWIN_CREALITY_LCD
#define LCD_SERIAL_PORT 0
```

### Related Issues

I'm not sure if this addresses further feature requets.