### PR TITLE
DWIN support for platforms other than STM32F1

### DIFF
--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -109,8 +109,9 @@
   #else
     #error "LCD_SERIAL_PORT must be -1 or from 1 to 3. Please update your configuration."
   #endif
-
-  #define SERIAL_GET_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
+  #if HAS_DGUS_LCD
+    #define SERIAL_GET_TX_BUFFER_FREE() LCD_SERIAL.availableForWrite()
+  #endif
 #endif
 
 // Set interrupt grouping for this MCU

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -995,8 +995,9 @@ void setup() {
   #endif
 
   MYSERIAL0.begin(BAUDRATE);
-  uint32_t serial_connect_timeout = millis() + 1000UL;
+  millis_t serial_connect_timeout = millis() + 1000UL;
   while (!MYSERIAL0 && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+
   #if HAS_MULTI_SERIAL && !HAS_ETHERNET
     MYSERIAL1.begin(BAUDRATE);
     serial_connect_timeout = millis() + 1000UL;

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -651,6 +651,9 @@
 
 #if ENABLED(DWIN_CREALITY_LCD)
   #define SERIAL_CATCHALL 0
+  #ifndef LCD_SERIAL_PORT
+    #define LCD_SERIAL_PORT 3 // Creality 4.x board
+  #endif
 #endif
 
 /**

--- a/Marlin/src/lcd/dwin/dwin_lcd.cpp
+++ b/Marlin/src/lcd/dwin/dwin_lcd.cpp
@@ -40,6 +40,12 @@
 //#define DEBUG_OUT 1
 #include "../../core/debug_out.h"
 
+#ifdef LCD_SERIAL_PORT
+  #define DWIN_SERIAL  LCD_SERIAL
+#else
+  #define DWIN_SERIAL  MYSERIAL1
+#endif
+
 // Make sure DWIN_SendBuf is large enough to hold the largest string plus draw command and tail.
 // Assume the narrowest (6 pixel) font and 2-byte gb2312-encoded characters.
 uint8_t DWIN_SendBuf[11 + DWIN_WIDTH / 6 * 2] = { 0xAA };
@@ -82,20 +88,26 @@ inline void DWIN_String(size_t &i, const __FlashStringHelper * string) {
 // Send the data in the buffer and the packet end
 inline void DWIN_Send(size_t &i) {
   ++i;
-  LOOP_L_N(n, i) { MYSERIAL1.write(DWIN_SendBuf[n]); delayMicroseconds(1); }
-  LOOP_L_N(n, 4) { MYSERIAL1.write(DWIN_BufTail[n]); delayMicroseconds(1); }
+  LOOP_L_N(n, i) { DWIN_SERIAL.write(DWIN_SendBuf[n]); delayMicroseconds(1); }
+  LOOP_L_N(n, 4) { DWIN_SERIAL.write(DWIN_BufTail[n]); delayMicroseconds(1); }
 }
 
 /*-------------------------------------- System variable function --------------------------------------*/
 
 // Handshake (1: Success, 0: Fail)
 bool DWIN_Handshake(void) {
+  #ifdef LCD_SERIAL_PORT
+    LCD_SERIAL.begin(115200UL);
+    serial_connect_timeout = millis() + 1000UL;
+    while (!LCD_SERIAL && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+  #endif
+
   size_t i = 0;
   DWIN_Byte(i, 0x00);
   DWIN_Send(i);
 
-  while (MYSERIAL1.available() > 0 && recnum < (signed)sizeof(databuf)) {
-    databuf[recnum] = MYSERIAL1.read();
+  while (DWIN_SERIAL.available() > 0 && recnum < (signed)sizeof(databuf)) {
+    databuf[recnum] = DWIN_SERIAL.read();
     // ignore the invalid data
     if (databuf[0] != FHONE) { // prevent the program from running.
       if (recnum > 0) {

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -497,14 +497,21 @@ inline void Draw_Back_First(const bool is_sel=true) {
   if (is_sel) Draw_Menu_Cursor(0);
 }
 
-inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, auto &valref) {
-  if (encoder_diffState == ENCODER_DIFF_CW)
-    valref += EncoderRate.encoderMoveValue;
-  else if (encoder_diffState == ENCODER_DIFF_CCW)
-    valref -= EncoderRate.encoderMoveValue;
-  else if (encoder_diffState == ENCODER_DIFF_ENTER)
-    return true;
+#define APPLY_ENCODER_F \
+  if (encoder_diffState == ENCODER_DIFF_CW)          \
+    valref += EncoderRate.encoderMoveValue;          \
+  else if (encoder_diffState == ENCODER_DIFF_CCW)    \
+    valref -= EncoderRate.encoderMoveValue;          \
+  else if (encoder_diffState == ENCODER_DIFF_ENTER)  \
+    return true;                                     \
   return false;
+
+inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, int16_t &valref) {
+  APPLY_ENCODER_F
+}
+
+inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, float &valref) {
+  APPLY_ENCODER_F
 }
 
 //

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -249,10 +249,8 @@ typedef struct {
     float Move_E_scale    = 0;
   #endif
   float offset_value      = 0;
-  #if NOT_TARGET(__STM32F1__)
-    signed
-  #endif
-  char show_mode          = 0;    // -1: Temperature control    0: Printing temperature
+  TERN_(__STM32F1__, signed)
+  char show_mode          = 0; // -1: Temperature control    0: Printing temperature
 } HMI_value_t;
 
 #define DWIN_CHINESE 123

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -249,6 +249,9 @@ typedef struct {
     float Move_E_scale    = 0;
   #endif
   float offset_value      = 0;
+  #if NOT_TARGET(__STM32F1__)
+    signed
+  #endif
   char show_mode          = 0;    // -1: Temperature control    0: Printing temperature
 } HMI_value_t;
 

--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -592,15 +592,12 @@ void AnycubicTFTClass::GetCommandFromTFT() {
           } break;
 
           case 5: { // A5 GET CURRENT COORDINATE
-            float xPostition = ExtUI::getAxisPosition_mm(ExtUI::X);
-            float yPostition = ExtUI::getAxisPosition_mm(ExtUI::Y);
-            float zPostition = ExtUI::getAxisPosition_mm(ExtUI::Z);
-            SEND_PGM("A5V X: ");
-            LCD_SERIAL.print(xPostition);
-            SEND_PGM(" Y: ");
-            LCD_SERIAL.print(yPostition);
-            SEND_PGM(" Z: ");
-            LCD_SERIAL.print(zPostition);
+            const float xPosition = ExtUI::getAxisPosition_mm(ExtUI::X),
+                        yPosition = ExtUI::getAxisPosition_mm(ExtUI::Y),
+                        zPosition = ExtUI::getAxisPosition_mm(ExtUI::Z);
+            SEND_PGM("A5V X: "); LCD_SERIAL.print(xPosition);
+            SEND_PGM(   " Y: "); LCD_SERIAL.print(yPosition);
+            SEND_PGM(   " Z: "); LCD_SERIAL.print(zPosition);
             SENDLINE_PGM("");
           } break;
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/wifi_module.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/wifi_module.cpp
@@ -282,27 +282,24 @@ void esp_port_begin(uint8_t interrupt) {
     dma_init();
   }
   #endif
-  if (interrupt) {
-    #if ENABLED(MKS_WIFI_MODULE)
-      WIFISERIAL.end();
-      for (uint16_t i = 0; i < 65535; i++);
-      WIFISERIAL.begin(WIFI_BAUDRATE);
-      uint32_t serial_connect_timeout = millis() + 1000UL;
-        while (/*!WIFISERIAL && */PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
-      //for (uint8_t i=0;i<100;i++)WIFISERIAL.write(0x33);
-    #endif
-  }
-  else {
-    #if ENABLED(MKS_WIFI_MODULE)
-      WIFISERIAL.end();
-      for (uint16_t i = 0; i < 65535; i++);
-      WIFISERIAL.begin(WIFI_UPLOAD_BAUDRATE);
-      uint32_t serial_connect_timeout = millis() + 1000UL;
-        while (/*!WIFISERIAL && */PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
-      //for (uint16_t i=0;i<65535;i++);//WIFISERIAL.write(0x33);
-    #endif
-    dma_init();
-  }
+
+  #if ENABLED(MKS_WIFI_MODULE)
+    WIFISERIAL.end();
+    for (uint16_t i = 0; i < 65535; i++) { /*nada*/ }
+    WIFISERIAL.begin(interrupt ? WIFI_BAUDRATE : WIFI_UPLOAD_BAUDRATE);
+
+    const millis_t serial_connect_timeout = millis() + 1000UL;
+    while (/*!WIFISERIAL && */PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+
+    if (interrupt) {
+      //for (uint8_t i=0;i<100;i++) WIFISERIAL.write(0x33);
+    }
+    else {
+      //for (uint16_t i=0;i<65535;i++); //WIFISERIAL.write(0x33);
+    }
+  #endif
+
+  if (!interrupt) dma_init();
 }
 
 #if ENABLED(MKS_WIFI_MODULE)

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -50,10 +50,6 @@
 #include "stepper.h"
 #include "temperature.h"
 
-#if ENABLED(DWIN_CREALITY_LCD)
-  #include "../lcd/dwin/e3v2/dwin.h"
-#endif
-
 #include "../lcd/marlinui.h"
 #include "../libs/vector_3.h"   // for matrix_3x3
 #include "../gcode/gcode.h"

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -258,7 +258,20 @@
  *               EXP2                                              EXP1
  */
 
-#if HAS_WIRED_LCD && !HAS_BTT_EXP_MOT
+#if ENABLED(DWIN_CREALITY_LCD)
+
+  // RET6 DWIN ENCODER LCD
+  #define BTN_ENC                           P1_20
+  #define BTN_EN1                           P1_23
+  #define BTN_EN2                           P1_22
+
+  #ifndef BEEPER_PIN
+    #define BEEPER_PIN                      P1_21
+    #undef SPEAKER
+  #endif
+
+#elif HAS_WIRED_LCD && !HAS_BTT_EXP_MOT
+
   #if ENABLED(ANET_FULL_GRAPHICS_LCD_ALT_WIRING)
     #error "CAUTION! ANET_FULL_GRAPHICS_LCD_ALT_WIRING requires wiring modifications. See 'pins_BTT_SKR_V1_4.h' for details. Comment out this line to continue."
 


### PR DESCRIPTION
### Requirements

None, this change should be fully backward compatible with existing working implementations

### Description

I have a Ender 3 V2 and SKR1.4 Turbo.  [I was able to get it working](https://www.reddit.com/r/ender3/comments/jsiv0d/ender_3_v2_dwin_on_skr_boards/), but I'm hoping I won't need to repeatedly merge my changes back in.

If my changes are not according to standards, give me code review feedback and I can make the changes required :)

### Benefits

- Allows using LCD_SERIAL_PORT for Creality DWIN display
- Creality DWIN screen jumps from some screens to other without reason.  For example, setting the hotend temperature would jump inadvertently to the Print options screen. To resolve this, I fixed the *warnings*, namely that an unsigned was being compared to a signed value (ie. char).  That was probably what caused this issue.  However I also replaced *auto* because it doesn't appear to conform to the [*Do use modern C++11 features*](https://marlinfw.org/docs/development/coding_standards.html)

### Configurations

I used the standard Ender 3 v2 configuration.  Additionally I made the following change to **pins_BTT_SKR_V1_4.h**:
```pins_BTT_SKR_V1_4.h
#if ENABLED(DWIN_CREALITY_LCD)
  // RET6 DWIN ENCODER LCD
  #define BTN_ENC                           P1_20
  #define BTN_EN1                           P1_23
  #define BTN_EN2                           P1_22

  #ifndef BEEPER_PIN
    #define BEEPER_PIN                      P1_21
    #undef SPEAKER
  #endif
#endif
```

### Related Issues

Not fully aware of another issue