### PR TITLE
NO_SD_DETECT option

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1395,8 +1395,8 @@
    */
   //#define SDCARD_CONNECTION LCD
 
-  // Enable this if you are using an extender cable in your sd card slot
-  //#define SDCARD_EXTENDER
+  // Enable if SD detect is rendered useless (e.g., by using an SD extender)
+  //#define NO_SD_DETECT
 
 #endif // SDSUPPORT
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1388,7 +1388,7 @@
    * Set this option to one of the following (or the board's defaults apply):
    *
    *           LCD - Use the SD drive in the external LCD controller.
-   *       ONBOARD - Use the SD drive on the control board. (No SD_DETECT_PIN. M21 to init.)
+   *       ONBOARD - Use the SD drive on the control board.
    *  CUSTOM_CABLE - Use a custom cable to access the SD (as defined in a pins file).
    *
    * :[ 'LCD', 'ONBOARD', 'CUSTOM_CABLE' ]

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1395,6 +1395,9 @@
    */
   //#define SDCARD_CONNECTION LCD
 
+  // Enable this if you are using an extender cable in your sd card slot
+  //#define SDCARD_EXTENDER
+
 #endif // SDSUPPORT
 
 /**

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -324,7 +324,7 @@
 #if ENABLED(SDSUPPORT)
 
   // Extender cable doesn't support SD_DETECT_PIN
-  #if ENABLED(SDCARD_EXTENDER)
+  #if ENABLED(NO_SD_DETECT)
     #undef SD_DETECT_PIN
   #endif
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -323,6 +323,11 @@
  */
 #if ENABLED(SDSUPPORT)
 
+  // Extender cable doesn't support SD_DETECT_PIN
+  #if ENABLED(SDCARD_EXTENDER)
+    #undef SD_DETECT_PIN
+  #endif
+
   #if HAS_SD_HOST_DRIVE && SD_CONNECTION_IS(ONBOARD)
     //
     // The external SD card is not used. Hardware SPI is used to access the card.


### PR DESCRIPTION
### Description

SD card extender cable doesn't support SD_DETECT_PIN. I choose to add a new option, because it will allow us to handle speed and another parameters, related with a extender cable.

I'm doing here because I can't push commits to #20708 

### Benefits

See  #20708 

### Related Issues

 #20708 
