### PR TITLE
check for LCD_SET_PROGRESS_MANUALLY when using USE_M73_REMAINING_TIME

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -713,6 +713,10 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #endif
 #endif
 
+#if ENABLED(USE_M73_REMAINING_TIME) && DISABLED(LCD_SET_PROGRESS_MANUALLY)
+  #error "USE_M73_REMAINING_TIME requires LCD_SET_PROGRESS_MANUALLY"
+#endif
+
 #if !HAS_LCD_MENU && ENABLED(SD_REPRINT_LAST_SELECTED_FILE)
   #error "SD_REPRINT_LAST_SELECTED_FILE currently requires a Marlin-native LCD menu."
 #endif


### PR DESCRIPTION
### Description

If you enable USE_M73_REMAINING_TIME and  SHOW_REMAINING_TIME and SDSUPPORT without enabling LCD_SET_PROGRESS_MANUALLY you get a compile error

marlinui_HD44780.cpp:711:35: error: 'class MarlinUI' has no member named 'get_remaining_time'
duration_t remaining = ui.get_remaining_time();

### Requirements

A LCD and USE_M73_REMAINING_TIME and SHOW_REMAINING_TIME and SDSUPPORT enabled.

### Benefits

Warns the user that  USE_M73_REMAINING_TIME  requires to enable LCD_SET_PROGRESS_MANUALLY  

### Related Issues

Was noticed in reprap forum https://reprap.org/forum/read.php?415,880392