### PR TITLE
Add probing margins to output of M503

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3440,6 +3440,21 @@ void MarlinSettings::reset() {
         #endif
         , LINEAR_UNIT(probe.offset.z)
       );
+
+
+      #ifdef PROBING_MARGIN
+        config_heading(forReplay, PSTR("Z-Probe Probing Margins"), false);
+        if (!forReplay) say_units(true);
+        CONFIG_ECHO_START();
+        SERIAL_ECHOLNPAIR_P(
+            PSTR("  L"), LINEAR_UNIT(PROBING_MARGIN_LEFT),
+            PSTR(" R"), LINEAR_UNIT(PROBING_MARGIN_RIGHT),
+            PSTR(" F"), LINEAR_UNIT(PROBING_MARGIN_FRONT),
+            PSTR(" B"), LINEAR_UNIT(PROBING_MARGIN_BACK)
+        );
+      #endif
+
+
     #endif
 
     /**


### PR DESCRIPTION
### Description

Sending the M503 command will now include probing margins in received output.

[Configurations.h](https://i.imgur.com/5lGgnl9.jpg)

[Configurations_adv.h](https://i.imgur.com/WrbBYVD.jpg)

[M503 Output](https://i.imgur.com/pf2uMCb.jpg)

### Requirements

A bed probe, related functionality defined in your marlin build, and a defined probing margin.

### Benefits

Allows users to review probing margin values (used when determining reachable probing points during probed bed leveling) along with other useful information output by the M503 command.

### Configurations

Any config with bed probe functionality and PROBING_MARGIN defined should work.

### Related Issues

None.
