### PR TITLE
Comments update pins_BTT_GTR_V1_0.h to label M5 expansion board devices/connectors.

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -59,11 +59,11 @@
 //
 // Pins on the extender
 //
-//#define X_MIN_PIN                         PI4
-//#define X2_MIN_PIN                        PF12
-//#define Y_MIN_PIN                         PF4
-//#define Y2_MIN_PIN                        PI7
-//#define Z_MIN_PIN                         PF6
+//#define X_MIN_PIN                         PI4   // M5 M1_STOP
+//#define X2_MIN_PIN                        PF12  // M5 M5_STOP
+//#define Y_MIN_PIN                         PF4   // M5 M2_STOP
+//#define Y2_MIN_PIN                        PI7   // M5 M4_STOP
+//#define Z_MIN_PIN                         PF6   // M5 M3_STOP
 
 #if ENABLED(TP) && !defined(Z_MIN_PROBE_PIN)
   #define Z_MIN_PROBE_PIN                   PH11  // Z Probe must be PH11
@@ -114,6 +114,7 @@
   #define E2_CS_PIN                         PC12
 #endif
 
+//M5 MOTOR 1
 #define E3_STEP_PIN                         PF3
 #define E3_DIR_PIN                          PG3
 #define E3_ENABLE_PIN                       PF8
@@ -121,6 +122,7 @@
   #define E3_CS_PIN                         PG4
 #endif
 
+//M5 MOTOR 2
 #define E4_STEP_PIN                         PD14
 #define E4_DIR_PIN                          PD11
 #define E4_ENABLE_PIN                       PG2
@@ -128,6 +130,7 @@
   #define E4_CS_PIN                         PE15
 #endif
 
+//M5 MOTOR 3
 #define E5_STEP_PIN                         PE12
 #define E5_DIR_PIN                          PE10
 #define E5_ENABLE_PIN                       PF14
@@ -135,6 +138,7 @@
   #define E5_CS_PIN                         PE7
 #endif
 
+//M5 MOTOR 4
 #define E6_STEP_PIN                         PG0
 #define E6_DIR_PIN                          PG1
 #define E6_ENABLE_PIN                       PE8
@@ -142,6 +146,7 @@
   #define E6_CS_PIN                         PF15
 #endif
 
+//M5 MOTOR 5
 #define E7_STEP_PIN                         PH12
 #define E7_DIR_PIN                          PH15
 #define E7_ENABLE_PIN                       PI0
@@ -180,11 +185,11 @@
   //#define E0_HARDWARE_SERIAL Serial1
   //#define E1_HARDWARE_SERIAL Serial1
   //#define E2_HARDWARE_SERIAL Serial1
-  //#define E3_HARDWARE_SERIAL Serial1
-  //#define E4_HARDWARE_SERIAL Serial1
-  //#define E5_HARDWARE_SERIAL Serial1
-  //#define E6_HARDWARE_SERIAL Serial1
-  //#define E7_HARDWARE_SERIAL Serial1
+  //#define E3_HARDWARE_SERIAL Serial1  //M5 MOTOR 1
+  //#define E4_HARDWARE_SERIAL Serial1  //M5 MOTOR 2
+  //#define E5_HARDWARE_SERIAL Serial1  //M5 MOTOR 3
+  //#define E6_HARDWARE_SERIAL Serial1  //M5 MOTOR 4
+  //#define E7_HARDWARE_SERIAL Serial1  //M5 MOTOR 5
 
   //
   // Software serial
@@ -207,18 +212,23 @@
   #define E2_SERIAL_TX_PIN                  PC12
   #define E2_SERIAL_RX_PIN                  PC12
 
+  //M5 MOTOR 1
   #define E3_SERIAL_TX_PIN                  PG4
   #define E3_SERIAL_RX_PIN                  PG4
 
+  //M5 MOTOR 2
   #define E4_SERIAL_TX_PIN                  PE15
   #define E4_SERIAL_RX_PIN                  PE15
 
+  //M5 MOTOR 3
   #define E5_SERIAL_TX_PIN                  PE7
   #define E5_SERIAL_RX_PIN                  PE7
 
+  //M5 MOTOR 4
   #define E6_SERIAL_TX_PIN                  PF15
   #define E6_SERIAL_RX_PIN                  PF15
 
+  //M5 MOTOR 5
   #define E7_SERIAL_TX_PIN                  PH14
   #define E7_SERIAL_RX_PIN                  PH14
 
@@ -233,11 +243,11 @@
 #define TEMP_1_PIN                          PC2   // T2 <-> E1
 #define TEMP_2_PIN                          PC3   // T3 <-> E2
 
-#define TEMP_3_PIN                          PA3   // T4 <-> E3
-#define TEMP_4_PIN                          PF9   // T5 <-> E4
-#define TEMP_5_PIN                          PF10  // T6 <-> E5
-#define TEMP_6_PIN                          PF7   // T7 <-> E6
-#define TEMP_7_PIN                          PF5   // T8 <-> E7
+#define TEMP_3_PIN                          PA3   // M5 TEMP1
+#define TEMP_4_PIN                          PF9   // M5 TEMP2
+#define TEMP_5_PIN                          PF10  // M5 TEMP3
+#define TEMP_6_PIN                          PF7   // M5 TEMP4
+#define TEMP_7_PIN                          PF5   // M5 TEMP5
 
 #define TEMP_BED_PIN                        PC0   // T0 <-> Bed
 
@@ -247,8 +257,8 @@
 
 #define THERMO_SCK_PIN                      PI1   // SCK
 #define THERMO_DO_PIN                       PI2   // MISO
-#define THERMO_CS1_PIN                      PH9   // CS1
-#define THERMO_CS2_PIN                      PH2   // CS2
+#define THERMO_CS1_PIN                      PH9   // GTR K-TEMP
+#define THERMO_CS2_PIN                      PH2   // M5 K-TEMP
 
 #define MAX6675_SS_PIN            THERMO_CS1_PIN
 #define MAX6675_SS2_PIN           THERMO_CS2_PIN
@@ -262,11 +272,11 @@
 #define HEATER_1_PIN                        PA1   // Heater1
 #define HEATER_2_PIN                        PB0   // Heater2
 
-#define HEATER_3_PIN                        PD15  // Heater3
-#define HEATER_4_PIN                        PD13  // Heater4
-#define HEATER_5_PIN                        PD12  // Heater5
-#define HEATER_6_PIN                        PE13  // Heater6
-#define HEATER_7_PIN                        PI6   // Heater7
+#define HEATER_3_PIN                        PD15  // M5 HEAT1
+#define HEATER_4_PIN                        PD13  // M5 HEAT2
+#define HEATER_5_PIN                        PD12  // M5 HEAT3
+#define HEATER_6_PIN                        PE13  // M5 HEAT4
+#define HEATER_7_PIN                        PI6   // M5 HEAT5
 
 #define HEATER_BED_PIN                      PA2   // Hotbed
 
@@ -274,11 +284,11 @@
 #define FAN1_PIN                            PE6   // Fan1
 #define FAN2_PIN                            PC8   // Fan2
 
-#define FAN3_PIN                            PI5   // Fan3
-#define FAN4_PIN                            PE9   // Fan4
-#define FAN5_PIN                            PE11  // Fan5
-//#define FAN6_PIN                          PC9   // Fan6
-//#define FAN7_PIN                          PE14  // Fan7
+#define FAN3_PIN                            PI5   // M5 FAN1
+#define FAN4_PIN                            PE9   // M5 FAN2
+#define FAN5_PIN                            PE11  // M5 FAN3
+//#define FAN6_PIN                          PC9   // M5 FAN4
+//#define FAN7_PIN                          PE14  // M5 FAN5
 
 #ifndef SDCARD_CONNECTION
   #define SDCARD_CONNECTION ONBOARD


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions, so please be patient during the review.

-->

### Description

The current pins file was unclear on devices & connectors on the M5 expansion board.

### Requirements

No requirements.

### Benefits

When using the M5 expansion board, this more understandable since the device & connector names don't match the defined elements.

### Configurations

No supporting configurations are required.

### Related Issues

No other PR or Feature Request
