### PR TITLE
Silence unused parameter warnings; FTDI EVE Touch UI fixes.

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/compat.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/compat.h
@@ -206,6 +206,10 @@
 
   // Define macros for compatibility
 
+  // Use NUM_ARGS(__VA_ARGS__) to get the number of variadic arguments
+  #define _NUM_ARGS(_,Z,Y,X,W,V,U,T,S,R,Q,P,O,N,M,L,K,J,I,H,G,F,E,D,C,B,A,OUT,...) OUT
+  #define NUM_ARGS(V...) _NUM_ARGS(0,V,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0)
+
   #define _CAT(a,V...) a##V
   #define CAT(a,V...) _CAT(a,V)
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_user_request_alert_box.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/confirm_user_request_alert_box.cpp
@@ -36,8 +36,14 @@ void ConfirmUserRequestAlertBox::onRedraw(draw_mode_t mode) {
 bool ConfirmUserRequestAlertBox::onTouchEnd(uint8_t tag) {
   switch (tag) {
     case 1:
-      ExtUI::setUserConfirmed();
-      GOTO_PREVIOUS();
+      if(ExtUI::isPrintingPaused()) {
+          // The TuneMenu will call ExtUI::setUserConfirmed()
+          GOTO_SCREEN(TuneMenu);
+          current_screen.forget();
+      } else {
+          ExtUI::setUserConfirmed();
+          GOTO_PREVIOUS();
+      }
       return true;
     case 2: GOTO_PREVIOUS(); return true;
     default:                 return false;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/tune_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/tune_menu.cpp
@@ -143,7 +143,9 @@ void TuneMenu::pausePrint() {
 
 void TuneMenu::resumePrint() {
   sound.play(twinkle, PLAY_ASYNCHRONOUS);
-  if (ExtUI::isPrintingFromMedia())
+  if(ExtUI::awaitingUserConfirm())
+    ExtUI::setUserConfirmed();
+  else if (ExtUI::isPrintingFromMedia())
     ExtUI::resumePrint();
   #ifdef ACTION_ON_RESUME
     else host_action_resume();

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -943,6 +943,10 @@ namespace ExtUI {
     feedrate_percentage = constrain(value, 10, 500);
   }
 
+  bool awaitingUserConfirm() {
+      return wait_for_user;
+  }
+
   void setUserConfirmed() {
     TERN_(HAS_RESUME_CONTINUE, wait_for_user = false);
   }

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -197,6 +197,7 @@ namespace ExtUI {
   void setTravelAcceleration_mm_s2(const float);
   void setFeedrate_percent(const float);
   void setFlow_percent(const int16_t, const extruder_t);
+  bool awaitingUserConfirm();
   void setUserConfirmed();
 
   #if ENABLED(LIN_ADVANCE)

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1450,7 +1450,8 @@ void MarlinUI::update() {
       #if ENABLED(STATUS_MESSAGE_SCROLLING)
         status_scroll_offset = 0;
       #endif
-
+    #else // HAS_SPI_LCD
+      UNUSED(persist);
     #endif
 
     TERN_(EXTENSIBLE_UI, ExtUI::onStatusChanged(status_message));

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2363,7 +2363,7 @@ void MarlinSettings::postprocess() {
   #if ENABLED(AUTO_BED_LEVELING_UBL)
 
     inline void ubl_invalid_slot(const int s) {
-      #if ENABLED(EEPROM_CHITCHAT)
+      #if BOTH(EEPROM_CHITCHAT,DEBUG_OUT)
         DEBUG_ECHOLNPGM("?Invalid slot.");
         DEBUG_ECHO(s);
         DEBUG_ECHOLNPGM(" mesh slots available.");

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -69,7 +69,7 @@ hotend_pid_t;
   typedef IF<(LPQ_MAX_LEN > 255), uint16_t, uint8_t>::type lpq_ptr_t;
 #endif
 
-#define PID_PARAM(F,H) _PID_##F(TERN(PID_PARAMS_PER_HOTEND, H, 0))
+#define PID_PARAM(F,H) _PID_##F(TERN(PID_PARAMS_PER_HOTEND, H, 0 & H))
 #define _PID_Kp(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Kp, NAN)
 #define _PID_Ki(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Ki, NAN)
 #define _PID_Kd(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Kd, NAN)

--- a/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.h
+++ b/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.h
@@ -70,7 +70,7 @@ class Sd2Card {
     bool readBlock(uint32_t block, uint8_t* dst);
     bool writeBlock(uint32_t blockNumber, const uint8_t* src);
 
-    bool readCSD(csd_t* csd) { return true; };
+    bool readCSD(csd_t*)                                         { return true; }
 
     uint32_t cardSize();
     static bool isInserted();


### PR DESCRIPTION
### Benefits

- Silence warnings about intentionally unused variables.
- Added missing macro to compatibility file (for use when FTDI_EVE library code is compiled outside of Marlin)
- Improved filament runout handling in the FTDI_EVE interface. On filament runout, the user will be taken to the tune menu where they can change filament prior to resuming the print.