### PR TITLE
Fix bug where encoder acts also as enter

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -504,6 +504,7 @@ inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, auto &valr
     valref -= EncoderRate.encoderMoveValue;
   else if (encoder_diffState == ENCODER_DIFF_ENTER)
     return true;
+  return false;
 }
 
 //

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -502,9 +502,8 @@ inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, auto &valr
     valref += EncoderRate.encoderMoveValue;
   else if (encoder_diffState == ENCODER_DIFF_CCW)
     valref -= EncoderRate.encoderMoveValue;
-  else if (encoder_diffState == ENCODER_DIFF_ENTER)
-    return true;
-  return false;
+  else
+    return encoder_diffState == ENCODER_DIFF_ENTER;
 }
 
 //

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -502,8 +502,7 @@ inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, auto &valr
     valref += EncoderRate.encoderMoveValue;
   else if (encoder_diffState == ENCODER_DIFF_CCW)
     valref -= EncoderRate.encoderMoveValue;
-  else
-    return encoder_diffState == ENCODER_DIFF_ENTER;
+  return encoder_diffState == ENCODER_DIFF_ENTER;
 }
 
 //


### PR DESCRIPTION
Commit https://github.com/MarlinFirmware/Marlin/commit/4472ba2b6bc0835d0fcc039ad66d9dab40e13010 introduced an issue where rotating the encoder also acts as enter.

This commit fixes bug https://github.com/MarlinFirmware/Marlin/issues/20774

Tested on my e3v2.