### PR TITLE
E3V2 dwin used signed char for STM32F1 also needed for LPC 

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -249,7 +249,7 @@ typedef struct {
     float Move_E_scale    = 0;
   #endif
   float offset_value      = 0;
-  #if ANY(__STM32F1__,TARGET_LPC1768)
+  #if EITHER(__STM32F1__, TARGET_LPC1768)
     #define USE_SIGNED_CHAR
   #endif
   TERN_(USE_SIGNED_CHAR, signed)

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -249,11 +249,7 @@ typedef struct {
     float Move_E_scale    = 0;
   #endif
   float offset_value      = 0;
-  #if EITHER(__STM32F1__, TARGET_LPC1768)
-    #define USE_SIGNED_CHAR
-  #endif
-  TERN_(USE_SIGNED_CHAR, signed)
-  char show_mode          = 0; // -1: Temperature control    0: Printing temperature
+  int8_t show_mode        = 0; // -1: Temperature control    0: Printing temperature
 } HMI_value_t;
 
 #define DWIN_CHINESE 123

--- a/Marlin/src/lcd/dwin/e3v2/dwin.h
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.h
@@ -249,7 +249,10 @@ typedef struct {
     float Move_E_scale    = 0;
   #endif
   float offset_value      = 0;
-  TERN_(__STM32F1__, signed)
+  #if ANY(__STM32F1__,TARGET_LPC1768)
+    #define USE_SIGNED_CHAR
+  #endif
+  TERN_(USE_SIGNED_CHAR, signed)
   char show_mode          = 0; // -1: Temperature control    0: Printing temperature
 } HMI_value_t;
 


### PR DESCRIPTION
### Description

Using a DWIN_CREALITY_LCD on a LPC176x based controller causes lots of warnings due to using signed values in a char.
<img src="https://i.postimg.cc/yNBxr3WY/Screen-Shot-2021-01-15-at-3-56-05-PM.png">

On __STM32F1__ the char is re-typed to a signed char. 
This extends the retyping of char to signed char on TARGET_LPC1768 also.

### Requirements

LPC176x based controller with a DWIN_CREALITY_LCD, eg a Ender 3 V2 with a BTT SKR 1.4 turbo controller.

### Benefits

Removes lots of warnings.

### Configurations

[Configs.zip](https://github.com/MarlinFirmware/Marlin/files/5823804/Configs.zip)

### Related Issues
https://reprap.org/forum/read.php?415,880561 