### PR TITLE
Allow to redefine NEOPIXEL pins on BTT SKR boards

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -70,7 +70,9 @@
 #endif
 
 // LED driving pin
-#define NEOPIXEL_PIN                       P1_24
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                     P1_24
+#endif
 
 //
 // Power Loss Detection

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -177,4 +177,7 @@
 // Misc. Functions
 //
 #define LED_CONTROL_PIN                     PA13
-#define NEOPIXEL_PIN                        PA8
+
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA8
+#endif

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_2.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V1_2.h
@@ -25,7 +25,9 @@
 
 #define BOARD_INFO_NAME "BTT SKR Mini E3 V1.2"
 
-#define NEOPIXEL_PIN                        PC7   // LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PC7   // LED driving pin
+#endif
 
 /**
  * TMC2208/TMC2209 stepper drivers

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -39,9 +39,13 @@
 // Release PA13/PA14 (led, usb control) from SWD pins
 #define DISABLE_DEBUG
 
-#define NEOPIXEL_PIN                       PA8   // LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                     PA8   // LED driving pin
+#endif
 
-#define PS_ON_PIN                          PC13  // Power Supply Control
+#ifndef PS_ON_PIN
+  #define PS_ON_PIN                        PC13  // Power Supply Control
+#endif
 
 #define FAN1_PIN                           PC7
 


### PR DESCRIPTION
### Description

Users might want to have main NeoPixel output on some other pin than
originally defined by vendor.

### Requirements


### Benefits

BTT SKR boards are known to use buffer chips 74LVC1G125 on BTT SKR board on NeoPixel output.
Those chips are very easy to fry or being faulty from factory. It is good to have ability to re-assign main NeoPixel pin to another pin.

### Configurations


### Related Issues

