### PR TITLE
Fix Trigorilla Pro STOP pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
@@ -56,8 +56,8 @@
 //
 // Limit Switches
 //
-#define X_MAX_PIN                           PG10
-#define Y_MAX_PIN                           PA12
+#define X_STOP_PIN                          PG10
+#define Y_STOP_PIN                          PA12
 #define Z_MAX_PIN                           PA14
 #define Z_MIN_PIN                           PA13
 


### PR DESCRIPTION
### Description

In pins_TRIGORILLA_PRO.h is 
#define X_MAX_PIN                           PG10
#define Y_MAX_PIN                           PA12
This seem to be have been hard coded to max for the Anycubic Predator  (delta)
Renamed to more useful 
#define X_STOP_PIN                          PG10
#define Y_STOP_PIN                          PA12
So marlin can move them to MIN or MAX as needed

This is a requirement before releasing Configuration files for newer Anycubic I3 Mega machines that ship with or are upgraded to the  TRIGORILLA_PRO controller.

### Requirements

TRIGORILLA_PRO controller

### Benefits

Controller board can be used for more than just delta's

### Related Issues

See mammoth 8 hour (and on going) session  trying to talk ibbu1426 though setting up his Anycubic I3 Mega with TRIGORILLA_PRO on discord.  (almost there)