### PR TITLE
Fix E3 V2 extruder movement when moving other axis

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -2574,6 +2574,7 @@ void HMI_AxisMove() {
       if (encoder_diffState == ENCODER_DIFF_ENTER) {
         HMI_flag.ETempTooLow_flag = false;
         current_position.e = HMI_ValueStruct.Move_E_scale = 0;
+        sync_plan_position_e();
         Draw_Move_Menu();
         DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 216, MBASE(1), HMI_ValueStruct.Move_X_scale);
         DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 216, MBASE(2), HMI_ValueStruct.Move_Y_scale);

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -2321,9 +2321,9 @@ void HMI_Prepare() {
         DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 216, MBASE(2), current_position.y * MINUNITMULT);
         DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, 216, MBASE(3), current_position.z * MINUNITMULT);
         #if HAS_HOTEND
-          queue.inject_P(PSTR("G92 E0"));
-          current_position.e = HMI_ValueStruct.Move_E_scale = 0;
-          DWIN_Draw_Signed_Float(font8x16, Color_Bg_Black, 3, 1, 216, MBASE(4), 0);
+          current_position.e = HMI_ValueStruct.Move_E_scale = 0.0;
+          sync_plan_position_e();
+          DWIN_Draw_Signed_Float(font8x16, Color_Bg_Black, 3, 1, 216, MBASE(4), 0.0);
         #endif
         break;
       case PREPARE_CASE_DISA: // Disable steppers


### PR DESCRIPTION
### Description

The E3 DWIN Motion menu resets E to zero each time the menu is entered, so that extruder movement is relative from 0.0.

The code injected a `G92` command and immediately after set `current_position.e` to zero. This caused the `G92` code to optimize out any adjustment, since `current_position` already matched the adjusted position.

I've changed this to call `sync_plan_position_e` instead of injecting `G92`. This code already uses internal calls to perform moves, so it doesn't make sense to use g-code for this when we have an internal call it can easily use.

### Requirements

Ender 3 V2 DWIN display.

### Benefits

No more weird E movement when manually moving other axis.

### Configurations

Ender 3 V2 example.

### Related Issues

#19944
