### PR TITLE
[MKS_UI][FIX] Move on ID_M_STEP and ID_M_RETURN

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_move_motor.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_move_motor.cpp
@@ -54,14 +54,18 @@ enum {
 static void event_handler(lv_obj_t *obj, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
   if (queue.length <= (BUFSIZE - 3)) {
+    bool do_inject = true;
     float dist = uiCfg.move_dist;
     switch (obj->mks_obj_id) {
       case ID_M_X_N: dist *= -1; case ID_M_X_P: cur_label = 'X'; break;
       case ID_M_Y_N: dist *= -1; case ID_M_Y_P: cur_label = 'Y'; break;
       case ID_M_Z_N: dist *= -1; case ID_M_Z_P: cur_label = 'Z'; break;
+      default: do_inject = false;
     }
-    sprintf_P(public_buf_l, PSTR("G91\nG1 %c%3.1f F%d\nG90"), cur_label, dist, uiCfg.moveSpeed);
-    queue.inject(public_buf_l);
+    if (do_inject) {
+      sprintf_P(public_buf_l, PSTR("G91\nG1 %c%3.1f F%d\nG90"), cur_label, dist, uiCfg.moveSpeed);
+      queue.inject(public_buf_l);
+    }
   }
 
   switch (obj->mks_obj_id) {


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Since MKS_WIFI_MODULE has been merged, move UI is buggy. When clicking Change Step distance (0.1mm, 1mm, 10mm) or Back, the last moved axis moves.

```
> if (queue.length <= (BUFSIZE - 3)) {
>     float dist = uiCfg.move_dist;
>     switch (obj->mks_obj_id) {
>       case ID_M_X_N: dist *= -1; case ID_M_X_P: cur_label = 'X'; break;
>       case ID_M_Y_N: dist *= -1; case ID_M_Y_P: cur_label = 'Y'; break;
>       case ID_M_Z_N: dist *= -1; case ID_M_Z_P: cur_label = 'Z'; break;
>     }
>     sprintf_P(public_buf_l, PSTR("G91\nG1 %c%3.1f F%d\nG90"), cur_label, dist, uiCfg.moveSpeed);
>     queue.inject(public_buf_l);
>   }
```

queue.length can be  <= (BUFSIZE - 3) even if obj->mks_obj_id is not a move event.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
MKS_UI

### Benefits

No move when clicking on "Change step distance" and "Back"
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
