### PR TITLE
LEVEL_BED_CORNERS: raise Z to LEVEL_CORNERS_Z_HOP when finishing leveling

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -248,7 +248,7 @@ static inline void _lcd_level_bed_corners_get_next_position() {
     wait_for_probe = true;
     ui.goto_screen(_lcd_draw_raise); // show raise screen
     ui.set_selection(true);
-    while (wait_for_probe && !probe_triggered) { //loop while waiting to bed raise and probe trigger
+    while (wait_for_probe && !probe_triggered) { // loop while waiting to bed raise and probe trigger
       probe_triggered = PROBE_TRIGGERED();
       if (probe_triggered) {
         endstops.hit_on_purpose();
@@ -269,7 +269,7 @@ static inline void _lcd_level_bed_corners_get_next_position() {
     ui.goto_screen(_lcd_draw_probing);
     do {
       ui.refresh(LCDVIEW_REDRAW_NOW);
-      _lcd_draw_probing();                                //update screen with # of good points
+      _lcd_draw_probing();                                             // update screen with # of good points
       do_blocking_move_to_z(current_position.z + LEVEL_CORNERS_Z_HOP); // clearance
 
       _lcd_level_bed_corners_get_next_position();         // Select next corner coordinates
@@ -330,6 +330,7 @@ static inline void _lcd_level_bed_corners_homing() {
           GET_TEXT(MSG_BUTTON_NEXT), GET_TEXT(MSG_BUTTON_DONE)
         , _lcd_goto_next_corner
         , []{
+            line_to_z(LEVEL_CORNERS_Z_HOP); // raise Z off the bed when finishing
             TERN_(HAS_LEVELING, set_bed_leveling_enabled(leveling_was_active));
             ui.goto_previous_screen_no_defer();
           }

--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -39,7 +39,6 @@
 #ifndef LEVEL_CORNERS_Z_HOP
   #define LEVEL_CORNERS_Z_HOP 4.0
 #endif
-
 #ifndef LEVEL_CORNERS_HEIGHT
   #define LEVEL_CORNERS_HEIGHT 0.0
 #endif
@@ -330,7 +329,7 @@ static inline void _lcd_level_bed_corners_homing() {
           GET_TEXT(MSG_BUTTON_NEXT), GET_TEXT(MSG_BUTTON_DONE)
         , _lcd_goto_next_corner
         , []{
-            line_to_z(LEVEL_CORNERS_Z_HOP); // raise Z off the bed when finishing
+            line_to_z(LEVEL_CORNERS_Z_HOP); // Raise Z off the bed when done
             TERN_(HAS_LEVELING, set_bed_leveling_enabled(leveling_was_active));
             ui.goto_previous_screen_no_defer();
           }


### PR DESCRIPTION
### Description

When using `LEVEL_BED_CORNERS` without a probe, the flow looks like this:

1. XYZ homed
2. X/Y moved to front-left corner & Z lowered to `LEVEL_CORNERS_HEIGHT`
3. User selects 'Next':
   a. Z raised to `LEVEL_CORNERS_Z_HOP`
   b. X/Y moved to next corner based on `LEVEL_CORNERS_LEVELING_ORDER`
   c. Z lowered to `LEVEL_CORNERS_HEIGHT`
4. User selects 'Done':
   a. Corner leveling exits immediately without any action or movement.

This leaves the nozzle/tool in contact with the bed. If one is leveling corner(s) with a hot nozzle, this can burn and/or dent the bed surface from prolonged contact or very close proximity.

This PR changes the 'Done' behavior to:

4. User selects 'Done':
   a. Z raised to `LEVEL_CORNERS_Z_HOP`
   b. Corner leveling exits.

### Requirements

This change should be universal. I tested it with my Ender 3 Pro, Creality v4.2.7 board, both with and without probe. Of note: `LEVEL_CORNERS_USE_PROBE` does not exhibit the same behavior, as the probing will return the Z axis to its original position - this change only affects normal `LEVEL_BED_CORNERS`.

### Benefits

Improves the `LEVEL_BED_CORNERS` routine and protects the bed from damage.

### Configurations

Simply enable `LEVEL_BED_CORNERS` in Configuration.h:

```diff
diff --git a/Marlin/Configuration.h b/Marlin/Configuration.h
index 4ec64f8659..cbee8e1fd4 100644
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1438,7 +1438,7 @@
 #endif
 
 // Add a menu item to move between bed corners for manual bed adjustment
-//#define LEVEL_BED_CORNERS
+#define LEVEL_BED_CORNERS
 
 #if ENABLED(LEVEL_BED_CORNERS)
   #define LEVEL_CORNERS_INSET_LFRB { 30, 30, 30, 30 } // (mm) Left, Front, Right, Back insets
```

### Related Issues
Fulfills #20816
