### PR TITLE
add additional platformio source filters

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -61,6 +61,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/lcd/touch/touch_buttons.cpp>
   -<src/sd/usb_flashdrive/lib-uhs2> -<src/sd/usb_flashdrive/lib-uhs3>
   -<src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp>
+  -<src/sd/cardreader.cpp> -<src/sd/Sd2Card.cpp> -<src/sd/SdBaseFile.cpp> -<src/sd/SdFatUtil.cpp> -<src/sd/SdFile.cpp> -<src/sd/SdVolume.cpp> -<src/gcode/sd>
   -<src/HAL/shared/backtrace>
   -<src/feature/babystep.cpp>
   -<src/feature/backlash.cpp>
@@ -379,7 +380,7 @@ BABYSTEPPING            = src_filter=+<src/gcode/motion/M290.cpp> +<src/feature/
 Z_PROBE_SLED            = src_filter=+<src/gcode/probe/G31_G32.cpp>
 G38_PROBE_TARGET        = src_filter=+<src/gcode/probe/G38.cpp>
 MAGNETIC_PARKING_EXTRUDER = src_filter=+<src/gcode/probe/M951.cpp>
-SDSUPPORT               = src_filter=+<src/gcode/sd>
+SDSUPPORT               = src_filter=+<src/sd/cardreader.cpp> +<src/sd/Sd2Card.cpp> +<src/sd/SdBaseFile.cpp> +<src/sd/SdFatUtil.cpp> +<src/sd/SdFile.cpp> +<src/sd/SdVolume.cpp> +<src/gcode/sd>
 HAS_MEDIA_SUBCALLS      = src_filter=+<src/gcode/sd/M32.cpp>
 GCODE_REPEAT_MARKERS    = src_filter=+<src/feature/repeat.cpp> +<src/gcode/sd/M808.cpp>
 HAS_EXTRUDERS           = src_filter=+<src/gcode/temp/M104_M109.cpp> +<src/gcode/config/M221.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -203,7 +203,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/module/printcounter.cpp>
   -<src/module/probe.cpp>
   -<src/module/scara.cpp> -<src/gcode/calibrate/M665.cpp>
-  -<src/module/servo.cpp>
+  -<src/module/servo.cpp> -<src/gcode/control/M280.cpp>
   -<src/module/stepper/TMC26X.cpp>
 extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -401,7 +401,7 @@ BEZIER_CURVE_SUPPORT    = src_filter=+<src/module/planner_bezier.cpp> +<src/gcod
 PRINTCOUNTER            = src_filter=+<src/module/printcounter.cpp>
 HAS_BED_PROBE           = src_filter=+<src/module/probe.cpp> +<src/gcode/probe/G30.cpp> +<src/gcode/probe/M401_M402.cpp> +<src/gcode/probe/M851.cpp>
 IS_SCARA                = src_filter=+<src/module/scara.cpp>
-HAS_SERVOS              = src_filter=+<src/module/servo.cpp>
+HAS_SERVOS              = src_filter=+<src/module/servo.cpp> +<src/gcode/control/M280.cpp> 
 MORGAN_SCARA            = src_filter=+<src/gcode/scara>
 (ESP3D_)?WIFISUPPORT    = AsyncTCP, ESP Async WebServer
   ESP3DLib=https://github.com/luc-github/ESP3DLib.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -192,7 +192,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/units/G20_G21.cpp>
   -<src/gcode/units/M149.cpp>
   -<src/libs/BL24CXX.cpp> -<src/libs/W25Qxx.cpp>
-  -<src/libs/L64XX> -<src/module/stepper/L64xx.cpp>
+  -<src/libs/L64XX> -<src/module/stepper/L64xx.cpp> -<src/HAL/shared/HAL_spi_L6470.cpp>
   -<src/libs/hex_print.cpp>
   -<src/libs/least_squares_fit.cpp>
   -<src/libs/nozzle.cpp> -<src/gcode/feature/clean>
@@ -227,7 +227,7 @@ HAS_MOTOR_CURRENT_I2C   = SlowSoftI2CMaster
 HAS_TMC26X              = TMC26XStepper=https://github.com/trinamic/TMC26XStepper/archive/master.zip
                           src_filter=+<src/module/TMC26X.cpp>
 HAS_L64XX               = Arduino-L6470@0.8.0
-                          src_filter=+<src/libs/L64XX> +<src/module/stepper/L64xx.cpp> +<src/gcode/feature/L6470>
+                          src_filter=+<src/libs/L64XX> +<src/module/stepper/L64xx.cpp> +<src/gcode/feature/L6470> +<src/HAL/shared/HAL_spi_L6470.cpp>
 NEOPIXEL_LED            = Adafruit NeoPixel@1.5.0
                           src_filter=+<src/feature/leds/neopixel.cpp>
 MAX6675_._IS_MAX31865   = Adafruit MAX31865 library@~1.1.0

--- a/platformio.ini
+++ b/platformio.ini
@@ -60,6 +60,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/lcd/lcdprint.cpp>
   -<src/lcd/touch/touch_buttons.cpp>
   -<src/sd/usb_flashdrive/lib-uhs2> -<src/sd/usb_flashdrive/lib-uhs3>
+  -<src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp>
   -<src/HAL/shared/backtrace>
   -<src/feature/babystep.cpp>
   -<src/feature/backlash.cpp>
@@ -77,7 +78,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/feature/direct_stepping.cpp> -<src/gcode/motion/G6.cpp>
   -<src/feature/e_parser.cpp>
   -<src/feature/encoder_i2c.cpp>
-  -<src/feature/ethernet.cpp>
+  -<src/feature/ethernet.cpp> -<src/gcode/feature/network/M552-M554.cpp>
   -<src/feature/fanmux.cpp>
   -<src/feature/filwidth.cpp> -<src/gcode/feature/filwidth>
   -<src/feature/fwretract.cpp> -<src/gcode/feature/fwretract>
@@ -112,7 +113,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/bedlevel/G26.cpp>
   -<src/gcode/bedlevel/G35.cpp>
   -<src/gcode/bedlevel/G42.cpp>
-  -<src/gcode/bedlevel/M420.cpp>
+  -<src/gcode/bedlevel/M420.cpp> -<src/feature/bedlevel/bedlevel.cpp>
   -<src/gcode/calibrate/G33.cpp>
   -<src/gcode/calibrate/G34.cpp>
   -<src/gcode/calibrate/G34_M422.cpp>
@@ -276,6 +277,7 @@ EXTUI_EXAMPLE           = src_filter=+<src/lcd/extui/example.cpp>
 MALYAN_LCD              = src_filter=+<src/lcd/extui/malyan_lcd.cpp>
 USE_UHS2_USB            = src_filter=+<src/sd/usb_flashdrive/lib-uhs2>
 USE_UHS3_USB            = src_filter=+<src/sd/usb_flashdrive/lib-uhs3>
+USB_FLASH_DRIVE_SUPPORT = src_filter=+<src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp>
 AUTO_BED_LEVELING_BILINEAR = src_filter=+<src/feature/bedlevel/abl>
 AUTO_BED_LEVELING_(3POINT|(BI)?LINEAR) = src_filter=+<src/gcode/bedlevel/abl>
 MESH_BED_LEVELING       = src_filter=+<src/feature/bedlevel/mbl> +<src/gcode/bedlevel/mbl>
@@ -294,7 +296,7 @@ EMERGENCY_PARSER        = src_filter=+<src/feature/e_parser.cpp> -<src/gcode/con
 I2C_POSITION_ENCODERS   = src_filter=+<src/feature/encoder_i2c.cpp>
 IIC_BL24CXX_EEPROM      = src_filter=+<src/libs/BL24CXX.cpp>
 HAS_SPI_FLASH           = src_filter=+<src/libs/W25Qxx.cpp>
-HAS_ETHERNET            = src_filter=+<src/feature/ethernet.cpp>
+HAS_ETHERNET            = src_filter=+<src/feature/ethernet.cpp> +<src/gcode/feature/network/M552-M554.cpp>
 HAS_FANMUX              = src_filter=+<src/feature/fanmux.cpp>
 FILAMENT_WIDTH_SENSOR   = src_filter=+<src/feature/filwidth.cpp> +<src/gcode/feature/filwidth>
 FWRETRACT               = src_filter=+<src/feature/fwretract.cpp> +<src/gcode/feature/fwretract>
@@ -327,7 +329,7 @@ Z_STEPPER_AUTO_ALIGN    = src_filter=+<src/feature/z_stepper_align.cpp> +<src/gc
 G26_MESH_VALIDATION     = src_filter=+<src/gcode/bedlevel/G26.cpp>
 ASSISTED_TRAMMING       = src_filter=+<src/feature/tramming.cpp> +<src/gcode/bedlevel/G35.cpp>
 HAS_MESH                = src_filter=+<src/gcode/bedlevel/G42.cpp>
-HAS_LEVELING            = src_filter=+<src/gcode/bedlevel/M420.cpp>
+HAS_LEVELING            = src_filter=+<src/gcode/bedlevel/M420.cpp> +<src/feature/bedlevel/bedlevel.cpp>
 DELTA_AUTO_CALIBRATION  = src_filter=+<src/gcode/calibrate/G33.cpp>
 CALIBRATION_GCODE       = src_filter=+<src/gcode/calibrate/G425.cpp>
 Z_MIN_PROBE_REPEATABILITY_TEST = src_filter=+<src/gcode/calibrate/M48.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -63,6 +63,9 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp>
   -<src/sd/cardreader.cpp> -<src/sd/Sd2Card.cpp> -<src/sd/SdBaseFile.cpp> -<src/sd/SdFatUtil.cpp> -<src/sd/SdFile.cpp> -<src/sd/SdVolume.cpp> -<src/gcode/sd>
   -<src/HAL/shared/backtrace>
+  -<src/HAL/shared/eeprom_if_i2c.cpp>
+  -<src/HAL/shared/eeprom_if_spi.cpp>
+  -<src/HAL/shared/servo.cpp>
   -<src/feature/babystep.cpp>
   -<src/feature/backlash.cpp>
   -<src/feature/baricuda.cpp> -<src/gcode/feature/baricuda>
@@ -241,6 +244,8 @@ HAS_MARLINUI_U8GLIB     = U8glib-HAL@~0.4.1
 HAS_(FSMC|SPI)_TFT      = src_filter=+<src/HAL/STM32/tft> +<src/HAL/STM32F1/tft> +<src/lcd/tft_io>
 HAS_FSMC_TFT            = src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp> +<src/HAL/STM32F1/tft/tft_fsmc.cpp>
 HAS_SPI_TFT             = src_filter=+<src/HAL/STM32/tft/tft_spi.cpp> +<src/HAL/STM32F1/tft/tft_spi.cpp>
+I2C_EEPROM              = src_filter=+<src/HAL/shared/eeprom_if_i2c.cpp>
+SPI_EEPROM              = src_filter=+<src/HAL/shared/eeprom_if_spi.cpp>
 HAS_GRAPHICAL_TFT       = src_filter=+<src/lcd/tft>
 DWIN_CREALITY_LCD       = src_filter=+<src/lcd/dwin>
 IS_TFTGLCD_PANEL        = src_filter=+<src/lcd/TFTGLCD>
@@ -398,6 +403,7 @@ PRINTCOUNTER            = src_filter=+<src/module/printcounter.cpp>
 HAS_BED_PROBE           = src_filter=+<src/module/probe.cpp> +<src/gcode/probe/G30.cpp> +<src/gcode/probe/M401_M402.cpp> +<src/gcode/probe/M851.cpp>
 IS_SCARA                = src_filter=+<src/module/scara.cpp>
 HAS_SERVOS              = src_filter=+<src/module/servo.cpp>
+SHARED_SERVOS           = src_filter=+<src/HAL/shared/servo.cpp>
 MORGAN_SCARA            = src_filter=+<src/gcode/scara>
 (ESP3D_)?WIFISUPPORT    = AsyncTCP, ESP Async WebServer
   ESP3DLib=https://github.com/luc-github/ESP3DLib.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,7 +65,6 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/HAL/shared/backtrace>
   -<src/HAL/shared/eeprom_if_i2c.cpp>
   -<src/HAL/shared/eeprom_if_spi.cpp>
-  -<src/HAL/shared/servo.cpp>
   -<src/feature/babystep.cpp>
   -<src/feature/backlash.cpp>
   -<src/feature/baricuda.cpp> -<src/gcode/feature/baricuda>
@@ -403,7 +402,6 @@ PRINTCOUNTER            = src_filter=+<src/module/printcounter.cpp>
 HAS_BED_PROBE           = src_filter=+<src/module/probe.cpp> +<src/gcode/probe/G30.cpp> +<src/gcode/probe/M401_M402.cpp> +<src/gcode/probe/M851.cpp>
 IS_SCARA                = src_filter=+<src/module/scara.cpp>
 HAS_SERVOS              = src_filter=+<src/module/servo.cpp>
-SHARED_SERVOS           = src_filter=+<src/HAL/shared/servo.cpp>
 MORGAN_SCARA            = src_filter=+<src/gcode/scara>
 (ESP3D_)?WIFISUPPORT    = AsyncTCP, ESP Async WebServer
   ESP3DLib=https://github.com/luc-github/ESP3DLib.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -143,11 +143,11 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/config/M672.cpp>
   -<src/gcode/control/M7-M9.cpp>
   -<src/gcode/control/M211.cpp>
-  -<src/gcode/control/.cpp>
+  -<src/gcode/control/M350_M351.cpp>
   -<src/gcode/control/M605.cpp>
   -<src/gcode/feature/advance>
   -<src/gcode/feature/camera>
-  -<src/gM350_M351code/feature/i2c>
+  -<src/gcode/feature/i2c>
   -<src/gcode/feature/L6470>
   -<src/gcode/feature/leds/M150.cpp>
   -<src/gcode/feature/leds/M7219.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -143,10 +143,11 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/config/M672.cpp>
   -<src/gcode/control/M7-M9.cpp>
   -<src/gcode/control/M211.cpp>
+  -<src/gcode/control/.cpp>
   -<src/gcode/control/M605.cpp>
   -<src/gcode/feature/advance>
   -<src/gcode/feature/camera>
-  -<src/gcode/feature/i2c>
+  -<src/gM350_M351code/feature/i2c>
   -<src/gcode/feature/L6470>
   -<src/gcode/feature/leds/M150.cpp>
   -<src/gcode/feature/leds/M7219.cpp>
@@ -403,6 +404,7 @@ HAS_BED_PROBE           = src_filter=+<src/module/probe.cpp> +<src/gcode/probe/G
 IS_SCARA                = src_filter=+<src/module/scara.cpp>
 HAS_SERVOS              = src_filter=+<src/module/servo.cpp> +<src/gcode/control/M280.cpp> 
 MORGAN_SCARA            = src_filter=+<src/gcode/scara>
+HAS_MICROSTEPS          = src_filter=+<src/gcode/control/M350_M351.cpp>
 (ESP3D_)?WIFISUPPORT    = AsyncTCP, ESP Async WebServer
   ESP3DLib=https://github.com/luc-github/ESP3DLib.git
   arduinoWebSockets=https://github.com/Links2004/arduinoWebSockets.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -201,6 +201,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/module/printcounter.cpp>
   -<src/module/probe.cpp>
   -<src/module/scara.cpp> -<src/gcode/calibrate/M665.cpp>
+  -<src/module/servo.cpp>
   -<src/module/stepper/TMC26X.cpp>
 extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -396,6 +397,7 @@ BEZIER_CURVE_SUPPORT    = src_filter=+<src/module/planner_bezier.cpp> +<src/gcod
 PRINTCOUNTER            = src_filter=+<src/module/printcounter.cpp>
 HAS_BED_PROBE           = src_filter=+<src/module/probe.cpp> +<src/gcode/probe/G30.cpp> +<src/gcode/probe/M401_M402.cpp> +<src/gcode/probe/M851.cpp>
 IS_SCARA                = src_filter=+<src/module/scara.cpp>
+HAS_SERVOS              = src_filter=+<src/module/servo.cpp>
 MORGAN_SCARA            = src_filter=+<src/gcode/scara>
 (ESP3D_)?WIFISUPPORT    = AsyncTCP, ESP Async WebServer
   ESP3DLib=https://github.com/luc-github/ESP3DLib.git


### PR DESCRIPTION
### Description

Add source filters for:
src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
src/gcode/feature/network/M552-M554.cpp
src/sd/cardreader.cpp 
src/sd/Sd2Card.cpp 
src/sd/SdBaseFile.cpp 
src/sd/SdFatUtil.cpp 
src/sd/SdFile.cpp 
src/sd/SdVolume.cpp 
src/module/servo.cpp
src/HAL/shared/HAL_spi_L6470.cpp
src/HAL/shared/eeprom_if_i2c.cpp
src/HAL/shared/eeprom_if_spi.cpp
src/gcode/control/M280.cpp
gcode/control/M350_M351.cpp

and there are still more..  but this will do as a start


### Requirements

A severe lack of patience for compiling code that doesn't need looked at 

### Benefits

Faster compiles, less time wastage.

### Related Issues

None.

