### PR TITLE
Effectively remove the limit for menu-configurable range of filament runout distance

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -155,7 +155,7 @@ void menu_backlash();
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       editable.decimal = runout.runout_distance();
-      EDIT_ITEM(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, float(FILAMENT_RUNOUT_DISTANCE_MM) * 1.5f,
+      EDIT_ITEM(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, 999,
         []{ runout.set_runout_distance(editable.decimal); }, true
       );
     #endif

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -155,7 +155,7 @@ void menu_backlash();
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       editable.decimal = runout.runout_distance();
-      EDIT_ITEM(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, 999,
+      EDIT_ITEM_FAST(float3, MSG_RUNOUT_DISTANCE_MM, &editable.decimal, 1, 999,
         []{ runout.set_runout_distance(editable.decimal); }, true
       );
     #endif


### PR DESCRIPTION
### Description
Since `M412 D<linear>` has no limit, I think it would make sense to also allow the user to change the filament runout distance in the menus without the limit of `FILAMENT_RUNOUT_DISTANCE_MM * 1.5f`. This removes a limit which users have reported as being troublesome (#19071).

### Requirements

Requires `FILAMENT_RUNOUT_SENSOR` and all the things that requires (lcd, advanced_pause, etc).

### Benefits

Improves usability for users who are tinkering with their machine, which may include moving their filament runout sensor more than `FILAMENT_RUNOUT_DISTANCE_MM * 1.5f`mm, meaning they have to re-compile Marlin. Since the option to change the distance is available already, this simply lifts the arbitrary limit (well, raises it, anyways). The underlying field type is `float`, so it can handle the increased range.

There already exists a way to change this through gcode, with `M412 D<linear>` - that method has no such ` * 1.5f` limit and simply sets the distance to whatever is provided. This makes the menus mirror that. Additionally, I have added a PR to document the undocumented gcode params for M412: MarlinFirmware/MarlinDocumentation#368

### Configurations

An LCD configuration matching your machine is required, plus these changes to enable FILAMENT_RUNOUT_SENSOR:

```diff
diff --git a/Marlin/Configuration.h b/Marlin/Configuration.h
index 4ec64f8659..135043f43a 100644
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1209,7 +1209,7 @@
  * RAMPS-based boards use SERVO3_PIN for the first runout sensor.
  * For other boards you may need to define FIL_RUNOUT_PIN, FIL_RUNOUT2_PIN, etc.
  */
-//#define FILAMENT_RUNOUT_SENSOR
+#define FILAMENT_RUNOUT_SENSOR
 #if ENABLED(FILAMENT_RUNOUT_SENSOR)
   #define FIL_RUNOUT_ENABLED_DEFAULT true // Enable the sensor on startup. Override with M412 followed by M500.
   #define NUM_RUNOUT_SENSORS   1          // Number of sensors, up to one per extruder. Define a FIL_RUNOUT#_PIN for each.
@@ -1635,7 +1635,7 @@
  *    P1  Raise the nozzle always to Z-park height.
  *    P2  Raise the nozzle by Z-park amount, limited to Z_MAX_POS.
  */
-//#define NOZZLE_PARK_FEATURE
+#define NOZZLE_PARK_FEATURE
 
 #if ENABLED(NOZZLE_PARK_FEATURE)
   // Specify a park position as { X, Y, Z_raise }
diff --git a/Marlin/Configuration_adv.h b/Marlin/Configuration_adv.h
index d1b5c7f5ce..f0bd81de3b 100644
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2151,7 +2151,7 @@
  * Requires NOZZLE_PARK_FEATURE.
  * This feature is required for the default FILAMENT_RUNOUT_SCRIPT.
  */
-//#define ADVANCED_PAUSE_FEATURE
+#define ADVANCED_PAUSE_FEATURE
 #if ENABLED(ADVANCED_PAUSE_FEATURE)
   #define PAUSE_PARK_RETRACT_FEEDRATE         60  // (mm/s) Initial retract feedrate.
   #define PAUSE_PARK_RETRACT_LENGTH            2  // (mm) Initial retract.
```

Tested on an Ender 3 Pro, verified the menu behaves as expected.

### Related Issues

Resolves #19071