### PR TITLE
Hacky Auto Updater for User Supplied Config Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,6 @@ __pycache__
 # Simulation / Native
 eeprom.dat
 imgui.ini
+
+# Config
+config/autoupdater

--- a/config/autoupdater/README.md
+++ b/config/autoupdater/README.md
@@ -1,0 +1,29 @@
+This is a total hacky script that may or may not work. It comes with no Guarantee so make sure to save backups of your configs in case things go wrong. 
+
+Use:
+Ensure old configs are present in Marlin/Marlin folder
+run autoupdater.sh script
++ ./autoupdater.sh
++ bash autoupdater.sh
+
+Your newly updated configs will now be present in the Marlin/Marlin folder. Your old config files have been overwritten so I hope you made your own backup. 
+In case you didn't, read below:
+
+Within the autoupdater folder, you will see two *_Config folders
+One says Current and that is where your old configs in case you didn't make backups exists
+One says Updated and is the same file that is located in the Marlin/Marlin folder
+
+If the script doesn't work for any reason, try deleting everything inside of autoupdater folder except for autoupdater.sh. The script will regenerate any missing folders and files it needs.
+
+Lastly AND MOST IMPORTANTLY,
+Open the newly updated Configs in your favorite mergetool or simply open it within Visual Studio Code, which has a built in merge tool, and resolve all conflicts manually by clicking to either accept the new change or the user change.
+
+
+Note to myself/future-devs:
+Future ToDo:
++ Ability to dynamically select the best base_dir/config_base depending on the Machine Name and Motherboard listed in the user supplied config files.
++ include a virtualenv-ed python module that has a better merge tool that can be programmatically activated. 
++ ask for user preferences throughout to ensure tool can be used in more ways than a single size fits all method
++ make the script less hacky and more "professional" looking. Ensure it works the same in all environments. Possibly make it into a dockerfile. 
++ Programmaticly autoresolve conflicts that are known to be irrelevant (i.e. if the only difference is a space or some non essential character)
++ better config file visualizer for the command line impaired. 

--- a/config/autoupdater/autoupdater.sh
+++ b/config/autoupdater/autoupdater.sh
@@ -1,0 +1,68 @@
+cd "$(dirname "$0")"
+
+rm -rf Updated_Config Current_Config
+
+mkdir Updated_Config Current_Config
+
+cp ../../Marlin/Configuration* Current_Config/
+
+CONFIG_VERSION=$(grep -E "CONFIGURATION_.*_VERSION" Current_Config/Configuration.h | xargs | tr -d ' ')
+
+if [ ! -d "Configurations" ]; then
+git clone https://github.com/MarlinFirmware/Configurations.git
+fi
+
+cd Configurations
+
+git fetch origin
+git checkout -f origin/import-2.0.x
+git branch -D autoupdater
+git reset --hard
+
+BASE_DIR=config/default
+
+I=0
+J=0
+
+declare -a COMMITS=($(git log --oneline $BASE_DIR/Configuration.h | cut -d' ' -f1))
+
+for commit in "${COMMITS[@]}"
+do
+I=$((I+1))
+VERSION=$(git show $commit:$BASE_DIR/Configuration.h | grep -E "CONFIGURATION_.*_VERSION" | xargs | tr -d ' ')
+if [ $CONFIG_VERSION = $VERSION ]; then
+J=$I
+elif [ $J -ne 0 ]; then
+break
+fi
+done
+
+BASE_COMMIT=${COMMITS[$J]}
+
+git checkout -f $BASE_COMMIT
+
+git checkout -b autoupdater
+
+cp ../Current_Config/* $BASE_DIR/
+
+git add .
+
+git commit -m "user changes"
+
+USER_COMMIT=$(git log --oneline | head -1 | cut -d' ' -f1)
+
+git rebase origin/import-2.0.x
+
+cp $BASE_DIR/* ../Updated_Config/
+
+git rebase --abort
+
+git checkout -f origin/import-2.0.x
+
+cd ..
+
+Green='\033[0;32m'
+NC='\033[0m' # No Color
+printf "${Green}Upgraded $(grep -E "CONFIGURATION_.*_VERSION" Current_Config/Configuration* | grep -oE "[0-9]+$" | sort | uniq) to $(grep -E "CONFIGURATION_.*_VERSION" Updated_Config/Configuration* | grep -oE "[0-9]+$" | sort | uniq)\n${NC}"
+
+cp Updated_Config/Configuration* ../../Marlin/


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
A hacky bash script to auto update user supplied config files. Both config files within Marlin/Marlin folder are rebased against the lastest default config file. The user can then open the files within their favorite mergetool or within VSCode and quickly resolve any conflicts that appear. 

Motivation for this was the number of users who didn't know how to update their config files and were thus afraid to/unwilling to update to the latest marlin because they didn't want to put in the work to update their files. There was this one guy in the discord chat who just refused to learn how to rebase his files and kept complaining/asking others to do it for him. So for people like that just refer them to this tool and then make it their problem to resolve any merge conflicts. Over time, as this script improves, it can encourage people to always use the latest marlin firmware and could reduce the burden on devs dealing with bugs/problems with people using older versions of Marlin. 
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
None. Just ensure config files are located where they normally are and the script just does the rest on its own. 

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
+ Encourage Users to use the latest Marlin
+ Reduce burden on devs dealing with user problems running on older versions of Marlin
+ Hopefully can provide a template for command line averse users on how to manually rebase and update their configs. 
<!-- What does this PR fix or improve? -->

The ultimate goal of this tool should be to reduce burden on devs dealing with user problems related to older versions of marlin and for users who don't know how to update their configs. If we can provide a tool that makes it easier to for users to always use the latest Marlin but keep their modifications for things like Bltouch/etc, then mission accomplished. 

### Configurations
Probably best to say this script only works for config files with versions > 2.0.5.0
Untested for prior. 
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
