### PR TITLE
Move some common strings

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -230,18 +230,7 @@
   #include "feature/password/password.h"
 #endif
 
-PGMSTR(NUL_STR, "");
 PGMSTR(M112_KILL_STR, "M112 Shutdown");
-PGMSTR(G28_STR, "G28");
-PGMSTR(M21_STR, "M21");
-PGMSTR(M23_STR, "M23 %s");
-PGMSTR(M24_STR, "M24");
-PGMSTR(SP_P_STR, " P");  PGMSTR(SP_T_STR, " T");
-PGMSTR(X_STR,     "X");  PGMSTR(Y_STR,     "Y");  PGMSTR(Z_STR,     "Z");  PGMSTR(E_STR,     "E");
-PGMSTR(X_LBL,     "X:"); PGMSTR(Y_LBL,     "Y:"); PGMSTR(Z_LBL,     "Z:"); PGMSTR(E_LBL,     "E:");
-PGMSTR(SP_A_STR, " A");  PGMSTR(SP_B_STR, " B");  PGMSTR(SP_C_STR, " C");
-PGMSTR(SP_X_STR, " X");  PGMSTR(SP_Y_STR, " Y");  PGMSTR(SP_Z_STR, " Z");  PGMSTR(SP_E_STR, " E");
-PGMSTR(SP_X_LBL, " X:"); PGMSTR(SP_Y_LBL, " Y:"); PGMSTR(SP_Z_LBL, " Z:"); PGMSTR(SP_E_LBL, " E:");
 
 MarlinState marlin_state = MF_INITIALIZING;
 

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -108,7 +108,4 @@ bool pin_is_protected(const pin_t pin);
   inline bool kill_state() { return READ(KILL_PIN) == KILL_PIN_STATE; }
 #endif
 
-extern const char NUL_STR[], M112_KILL_STR[], G28_STR[], M21_STR[], M23_STR[], M24_STR[],
-                  SP_A_STR[], SP_B_STR[], SP_C_STR[],
-                  SP_P_STR[], SP_T_STR[], SP_X_STR[], SP_Y_STR[], SP_Z_STR[], SP_E_STR[],
-                  X_LBL[], Y_LBL[], Z_LBL[], E_LBL[], SP_X_LBL[], SP_Y_LBL[], SP_Z_LBL[], SP_E_LBL[];
+extern const char M112_KILL_STR[];

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -25,8 +25,13 @@
 
 uint8_t marlin_debug_flags = MARLIN_DEBUG_NONE;
 
-static PGMSTR(errormagic, "Error:");
-static PGMSTR(echomagic, "echo:");
+// Commonly-used strings in serial output
+PGMSTR(NUL_STR,   "");   PGMSTR(SP_P_STR, " P");  PGMSTR(SP_T_STR, " T");
+PGMSTR(X_STR,     "X");  PGMSTR(Y_STR,     "Y");  PGMSTR(Z_STR,     "Z");  PGMSTR(E_STR,     "E");
+PGMSTR(X_LBL,     "X:"); PGMSTR(Y_LBL,     "Y:"); PGMSTR(Z_LBL,     "Z:"); PGMSTR(E_LBL,     "E:");
+PGMSTR(SP_A_STR, " A");  PGMSTR(SP_B_STR, " B");  PGMSTR(SP_C_STR, " C");
+PGMSTR(SP_X_STR, " X");  PGMSTR(SP_Y_STR, " Y");  PGMSTR(SP_Z_STR, " Z");  PGMSTR(SP_E_STR, " E");
+PGMSTR(SP_X_LBL, " X:"); PGMSTR(SP_Y_LBL, " Y:"); PGMSTR(SP_Z_LBL, " Z:"); PGMSTR(SP_E_LBL, " E:");
 
 #if HAS_MULTI_SERIAL
   int8_t serial_port_index = 0;
@@ -35,8 +40,9 @@ static PGMSTR(echomagic, "echo:");
 void serialprintPGM(PGM_P str) {
   while (const char c = pgm_read_byte(str++)) SERIAL_CHAR(c);
 }
-void serial_echo_start()  { serialprintPGM(echomagic); }
-void serial_error_start() { serialprintPGM(errormagic); }
+
+void serial_echo_start()  { static PGMSTR(echomagic, "echo:"); serialprintPGM(echomagic); }
+void serial_error_start() { static PGMSTR(errormagic, "Error:"); serialprintPGM(errormagic); }
 
 void serial_echopair_PGM(PGM_P const s_P, const char *v)   { serialprintPGM(s_P); SERIAL_ECHO(v); }
 void serial_echopair_PGM(PGM_P const s_P, char v)          { serialprintPGM(s_P); SERIAL_CHAR(v); }
@@ -64,8 +70,6 @@ void print_bin(uint16_t val) {
     if (!(i & 0x3) && i) SERIAL_CHAR(' ');
   }
 }
-
-extern const char SP_X_STR[], SP_Y_STR[], SP_Z_STR[];
 
 void print_xyz(const float &x, const float &y, const float &z, PGM_P const prefix/*=nullptr*/, PGM_P const suffix/*=nullptr*/) {
   if (prefix) serialprintPGM(prefix);

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -27,9 +27,17 @@
   #include "../feature/ethernet.h"
 #endif
 
-/**
- * Define debug bit-masks
- */
+// Commonly-used strings in serial output
+extern const char NUL_STR[], SP_P_STR[], SP_T_STR[],
+                  X_STR[], Y_STR[], Z_STR[], E_STR[],
+                  X_LBL[], Y_LBL[], Z_LBL[], E_LBL[],
+                  SP_A_STR[], SP_B_STR[], SP_C_STR[],
+                  SP_X_STR[], SP_Y_STR[], SP_Z_STR[], SP_E_STR[],
+                  SP_X_LBL[], SP_Y_LBL[], SP_Z_LBL[], SP_E_LBL[];
+
+//
+// Debugging flags for use by M111
+//
 enum MarlinDebugFlags : uint8_t {
   MARLIN_DEBUG_NONE          = 0,
   MARLIN_DEBUG_ECHO          = _BV(0), ///< Echo commands in order as they are processed
@@ -50,6 +58,9 @@ enum MarlinDebugFlags : uint8_t {
 extern uint8_t marlin_debug_flags;
 #define DEBUGGING(F) (marlin_debug_flags & (MARLIN_DEBUG_## F))
 
+//
+// Serial redirection
+//
 #define SERIAL_BOTH 0x7F
 #if HAS_MULTI_SERIAL
   extern int8_t serial_port_index;

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -520,7 +520,6 @@ void PrintJobRecovery::resume() {
 
   // Resume the SD file from the last position
   char *fn = info.sd_filename;
-  extern const char M23_STR[];
   sprintf_P(cmd, M23_STR, fn);
   gcode.process_subcommands_now(cmd);
   sprintf_P(cmd, PSTR("M24 S%ld T%ld"), resume_sdpos, info.print_job_elapsed);

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -188,7 +188,7 @@ G29_TYPE GcodeSuite::G29() {
 
   // Send 'N' to force homing before G29 (internal only)
   if (parser.seen('N'))
-    gcode.process_subcommands_now_P(TERN(G28_L0_ENSURES_LEVELING_OFF, PSTR("G28L0"), G28_STR));
+    process_subcommands_now_P(TERN(G28_L0_ENSURES_LEVELING_OFF, PSTR("G28L0"), G28_STR));
 
   // Don't allow auto-leveling without homing first
   if (homing_needed_error()) G29_RETURN(false);

--- a/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
@@ -38,7 +38,7 @@
 #include "../../feature/probe_temp_comp.h"
 
 #include "../../lcd/marlinui.h"
-#include "../../MarlinCore.h" // for wait_for_heatup, idle(), G28_STR
+#include "../../MarlinCore.h" // for wait_for_heatup, idle()
 
 #if ENABLED(PRINTJOB_TIMER_AUTOSTART)
   #include "../../module/printcounter.h"

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -51,8 +51,6 @@
  * This function requires the machine to be homed before invocation.
  */
 
-extern const char SP_Y_STR[];
-
 void GcodeSuite::M48() {
 
   if (homing_needed_error()) return;

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -33,8 +33,6 @@
 
 #include "../../MarlinCore.h" // for SP_X_STR, etc.
 
-extern const char SP_X_STR[], SP_Y_STR[], SP_Z_STR[];
-
 void M217_report(const bool eeprom=false) {
 
   #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)

--- a/Marlin/src/gcode/control/M108_M112_M410.cpp
+++ b/Marlin/src/gcode/control/M108_M112_M410.cpp
@@ -25,7 +25,7 @@
 #if DISABLED(EMERGENCY_PARSER)
 
 #include "../gcode.h"
-#include "../../MarlinCore.h" // for wait_for_heatup, kill
+#include "../../MarlinCore.h" // for wait_for_heatup, kill, M112_KILL_STR
 #include "../../module/motion.h" // for quickstop_stepper
 
 /**

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -310,6 +310,8 @@
 
 enum AxisRelative : uint8_t { REL_X, REL_Y, REL_Z, REL_E, E_MODE_ABS, E_MODE_REL };
 
+extern const char G28_STR[];
+
 class GcodeSuite {
 public:
 
@@ -371,7 +373,6 @@ public:
   static void process_subcommands_now(char * gcode);
 
   static inline void home_all_axes(const bool keep_leveling=false) {
-    extern const char G28_STR[];
     process_subcommands_now_P(keep_leveling ? G28_STR : TERN(G28_L0_ENSURES_LEVELING_OFF, PSTR("G28L0"), G28_STR));
   }
 

--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -30,8 +30,6 @@
 #include "../../libs/buzzer.h"
 #include "../../MarlinCore.h"
 
-extern const char SP_Y_STR[], SP_Z_STR[];
-
 void m206_report() {
   SERIAL_ECHOLNPAIR_P(PSTR("M206 X"), home_offset.x, SP_Y_STR, home_offset.y, SP_Z_STR, home_offset.z);
 }

--- a/Marlin/src/gcode/probe/M851.cpp
+++ b/Marlin/src/gcode/probe/M851.cpp
@@ -28,8 +28,6 @@
 #include "../../feature/bedlevel/bedlevel.h"
 #include "../../module/probe.h"
 
-extern const char SP_Y_STR[], SP_Z_STR[];
-
 /**
  * M851: Set the nozzle-to-probe offsets in current units
  */

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -56,6 +56,9 @@ GCodeQueue queue;
   #include "../feature/repeat.h"
 #endif
 
+// Frequently used G-code strings
+PGMSTR(G28_STR, "G28");
+
 /**
  * GCode line number handling. Hosts may opt to include line numbers when
  * sending commands to Marlin, and lines will be checked for sequentiality.

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -186,3 +186,5 @@ private:
 };
 
 extern GCodeQueue queue;
+
+extern const char G28_STR[];

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -471,7 +471,6 @@ void MarlinUI::clear_lcd() { lcd.clear(); }
       // Show the Marlin logo and short build version
       // After a delay show the website URL
       //
-      extern const char NUL_STR[];
       logo_lines(NUL_STR);
       CENTER_OR_SCROLL(SHORT_BUILD_VERSION, 1500);
       CENTER_OR_SCROLL(MARLIN_WEBSITE_URL, 1500);

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -544,8 +544,6 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
       // Put Relevant Text on Display
 
-      extern const char X_LBL[], Y_LBL[], Z_LBL[];
-
       // Show X and Y positions at top of screen
       u8g.setColorIndex(1);
       if (PAGE_UNDER(7)) {

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -703,7 +703,6 @@ void MarlinUI::draw_status_screen() {
           lcd_put_u8str(estimation_x_pos, EXTRAS_BASELINE, estimation_string);
         }
         else if (elapsed_string[0]) {
-          extern const char E_LBL[];
           lcd_put_u8str_P(PROGRESS_BAR_X, EXTRAS_BASELINE, E_LBL);
           lcd_put_u8str(elapsed_x_pos, EXTRAS_BASELINE, elapsed_string);
         }

--- a/Marlin/src/lcd/extui/dgus_lcd.cpp
+++ b/Marlin/src/lcd/extui/dgus_lcd.cpp
@@ -35,8 +35,6 @@
 #include "lib/dgus/DGUSDisplayDef.h"
 #include "lib/dgus/DGUSScreenHandler.h"
 
-extern const char NUL_STR[];
-
 namespace ExtUI {
 
   void onStartup() {

--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -28,7 +28,7 @@
 
 #include "../../../../libs/numtostr.h"
 #include "../../../../module/motion.h"  // for quickstop_stepper, A20 read printing speed, feedrate_percentage
-#include "../../../../MarlinCore.h"     // for disable_steppers, G28_STR
+#include "../../../../MarlinCore.h"     // for disable_steppers
 #include "../../../../inc/MarlinConfig.h"
 
 // command sending macro's with debugging capability

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_runout_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/filament_runout_screen.cpp
@@ -36,7 +36,6 @@ void FilamentRunoutScreen::onRedraw(draw_mode_t what) {
   w.toggle( 2, GET_TEXT_F(MSG_RUNOUT_SENSOR), getFilamentRunoutEnabled());
 
   #if HAS_FILAMENT_RUNOUT_DISTANCE
-    extern const char NUL_STR[];
     w.heading(GET_TEXT_F(MSG_RUNOUT_DISTANCE_MM));
     w.units(GET_TEXT_F(MSG_UNITS_MM));
     w.precision(0);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stress_test_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stress_test_screen.cpp
@@ -120,7 +120,6 @@ void StressTestScreen::onIdle() {
 
   if (!commandsInQueue()) {
     if (!isPositionKnown()) {
-      extern const char G28_STR[];
       injectCommands_P(G28_STR);
     }
     else {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_home.cpp
@@ -31,8 +31,6 @@
 #include "../../../../gcode/queue.h"
 #include "../../../../inc/MarlinConfig.h"
 
-extern const char G28_STR[];
-
 extern lv_group_t *g;
 static lv_obj_t *scr;
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_manuaLevel.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_manuaLevel.cpp
@@ -29,8 +29,6 @@
 #include "../../../../gcode/queue.h"
 #include "../../../../inc/MarlinConfig.h"
 
-extern const char G28_STR[];
-
 extern lv_group_t *g;
 static lv_obj_t *scr;
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/wifi_module.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/wifi_module.cpp
@@ -21,14 +21,12 @@
  */
 #include "../../../../inc/MarlinConfigPre.h"
 
-#if HAS_TFT_LVGL_UI
+#if BOTH(HAS_TFT_LVGL_UI, MKS_WIFI_MODULE)
 
 #include "draw_ui.h"
 #include "wifi_module.h"
 #include "wifi_upload.h"
 #include "SPI_TFT.h"
-
-#if ENABLED(MKS_WIFI_MODULE)
 
 #include "../../../../MarlinCore.h"
 #include "../../../../module/temperature.h"
@@ -459,7 +457,6 @@ int package_to_wifi(WIFI_RET_TYPE type, uint8_t *buf, int len) {
   return 1;
 }
 
-
 #define SEND_OK_TO_WIFI send_to_wifi((uint8_t *)"ok\r\n", strlen("ok\r\n"))
 int send_to_wifi(uint8_t *buf, int len) { return package_to_wifi(WIFI_TRANS_INF, buf, len); }
 
@@ -552,7 +549,6 @@ typedef struct {
   uint8_t *data;
   uint8_t tail;
 } ESP_PROTOC_FRAME;
-
 
 static int cut_msg_head(uint8_t *msg, uint16_t msgLen, uint16_t cutLen) {
   if (msgLen < cutLen) return 0;
@@ -1707,7 +1703,6 @@ void mks_esp_wifi_init() {
   wifi_link_state = WIFI_NOT_CONFIG;
 }
 
-
 void mks_wifi_firmware_update() {
   card.openFileRead((char *)ESP_FIRMWARE_FILE);
 
@@ -1826,5 +1821,4 @@ int readWifiBuf(int8_t *buf, int32_t len) {
   return i;
 }
 
-#endif // MKS_WIFI_MODULE
-#endif // HAS_TFT_LVGL_UI
+#endif // HAS_TFT_LVGL_UI && MKS_WIFI_MODULE

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1528,7 +1528,7 @@ void MarlinUI::update() {
   void MarlinUI::resume_print() {
     reset_status();
     TERN_(PARK_HEAD_ON_PAUSE, wait_for_heatup = wait_for_user = false);
-    if (IS_SD_PAUSED()) queue.inject_P(M24_STR);
+    TERN_(SDSUPPORT, if (IS_SD_PAUSED()) queue.inject_P(M24_STR));
     #ifdef ACTION_ON_RESUME
       host_action_resume();
     #endif

--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -66,8 +66,6 @@
 
 static_assert(LEVEL_CORNERS_Z_HOP >= 0, "LEVEL_CORNERS_Z_HOP must be >= 0. Please update your configuration.");
 
-extern const char G28_STR[];
-
 #if HAS_LEVELING
   static bool leveling_was_active = false;
 #endif
@@ -205,7 +203,7 @@ static inline void _lcd_level_bed_corners_get_next_position() {
       , []{ corner_probing_done = true; wait_for_probe = false; }
       , []{ wait_for_probe = false; }
       , GET_TEXT(MSG_LEVEL_CORNERS_RAISE)
-      , (const char*)nullptr, PSTR("")
+      , (const char*)nullptr, NUL_STR
     );
   }
 

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -161,8 +161,6 @@ void menu_advanced_settings();
   #include "../../module/motion.h"
   #include "../../gcode/queue.h"
 
-  extern const char G28_STR[];
-
   void menu_tool_offsets() {
 
     auto _recalc_offsets = []{

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -82,7 +82,6 @@ void _man_probe_pt(const xy_pos_t &xy) {
   }
 
   void _lcd_delta_calibrate_home() {
-    extern const char G28_STR[];
     queue.inject_P(G28_STR);
     ui.goto_screen(_lcd_calibrate_homing);
   }

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -101,8 +101,6 @@ void menu_configuration();
   void menu_language();
 #endif
 
-extern const char M21_STR[];
-
 void menu_main() {
   const bool busy = printingIsActive()
     #if ENABLED(SDSUPPORT)
@@ -156,7 +154,7 @@ void menu_main() {
         if (!card_open) {
           SUBMENU(MSG_MEDIA_MENU, MEDIA_MENU_GATEWAY);
           #if PIN_EXISTS(SD_DETECT)
-            GCODES_ITEM(MSG_CHANGE_MEDIA, M21_STR);
+            GCODES_ITEM(MSG_CHANGE_MEDIA, PSTR("M21"));
           #else
             GCODES_ITEM(MSG_RELEASE_MEDIA, PSTR("M22"));
           #endif
@@ -166,7 +164,7 @@ void menu_main() {
         #if PIN_EXISTS(SD_DETECT)
           ACTION_ITEM(MSG_NO_MEDIA, nullptr);
         #else
-          GCODES_ITEM(MSG_ATTACH_MEDIA, M21_STR);
+          GCODES_ITEM(MSG_ATTACH_MEDIA, PSTR("M21"));
         #endif
       }
 
@@ -257,7 +255,7 @@ void menu_main() {
       if (card_detected) {
         if (!card_open) {
           #if PIN_EXISTS(SD_DETECT)
-            GCODES_ITEM(MSG_CHANGE_MEDIA, M21_STR);
+            GCODES_ITEM(MSG_CHANGE_MEDIA, PSTR("M21"));
           #else
             GCODES_ITEM(MSG_RELEASE_MEDIA, PSTR("M22"));
           #endif
@@ -268,7 +266,7 @@ void menu_main() {
         #if PIN_EXISTS(SD_DETECT)
           ACTION_ITEM(MSG_NO_MEDIA, nullptr);
         #else
-          GCODES_ITEM(MSG_ATTACH_MEDIA, M21_STR);
+          GCODES_ITEM(MSG_ATTACH_MEDIA, PSTR("M21"));
         #endif
       }
     }

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -51,8 +51,6 @@
   float manual_move_e_origin = 0;
 #endif
 
-extern const char G28_STR[];
-
 //
 // "Motion" > "Move Axis" submenu
 //
@@ -191,7 +189,6 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
       sprintf_P(tmp, label, dtostrf(FINE_MANUAL_MOVE, 1, digs, numstr));
 
       #if DISABLED(HAS_GRAPHICAL_TFT)
-        extern const char NUL_STR[];
         SUBMENU_P(NUL_STR, []{ _goto_manual_move(float(FINE_MANUAL_MOVE)); });
         MENU_ITEM_ADDON_START(0 + ENABLED(HAS_MARLINUI_HD44780));
         lcd_put_u8str(tmp);

--- a/Marlin/src/lcd/menu/menu_password.cpp
+++ b/Marlin/src/lcd/menu/menu_password.cpp
@@ -49,7 +49,7 @@ void Password::menu_password_entry() {
   // "Login" or "New Code"
   STATIC_ITEM_P(authenticating ? GET_TEXT(MSG_LOGIN_REQUIRED) : GET_TEXT(MSG_EDIT_PASSWORD), SS_CENTER|SS_INVERT);
 
-  STATIC_ITEM_P(PSTR(""), SS_CENTER|SS_INVERT, string);
+  STATIC_ITEM_P(NUL_STR, SS_CENTER|SS_INVERT, string);
 
   // Make the digit edit item look like a sub-menu
   PGM_P const label = GET_TEXT(MSG_ENTER_DIGIT);

--- a/Marlin/src/lcd/menu/menu_probe_offset.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_offset.cpp
@@ -88,7 +88,6 @@ void probe_offset_wizard_menu() {
                          !UNEAR_ZERO((FINE_MANUAL_MOVE) *  100 - int((FINE_MANUAL_MOVE) *  100)) ? 3 : 2;
     sprintf_P(tmp, GET_TEXT(MSG_MOVE_N_MM), dtostrf(FINE_MANUAL_MOVE, 1, digs, numstr));
     #if DISABLED(HAS_GRAPHICAL_TFT)
-      extern const char NUL_STR[];
       SUBMENU_P(NUL_STR, []{ _goto_manual_move_z(float(FINE_MANUAL_MOVE)); });
       MENU_ITEM_ADDON_START(0 + ENABLED(HAS_MARLINUI_HD44780));
       lcd_put_u8str(tmp);

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -867,7 +867,7 @@ static void moveAxis(AxisEnum axis, const int8_t direction) {
         NOMORE(ui.manual_move.offset, max - current_position[axis]);
     #else
       current_position[axis] += diff;
-      const char *msg = PSTR(""); // clear the error
+      const char *msg = NUL_STR; // clear the error
       if (direction < 0 && current_position[axis] < min) {
         current_position[axis] = min;
         msg = GET_TEXT(MSG_LCD_SOFT_ENDSTOPS);

--- a/Marlin/src/libs/vector_3.cpp
+++ b/Marlin/src/libs/vector_3.cpp
@@ -76,8 +76,6 @@ void vector_3::apply_rotation(const matrix_3x3 &matrix) {
             matrix.vectors[0][2] * _x + matrix.vectors[1][2] * _y + matrix.vectors[2][2] * _z };
 }
 
-extern const char SP_X_STR[], SP_Y_STR[], SP_Z_STR[];
-
 void vector_3::debug(PGM_P const title) {
   serialprintPGM(title);
   SERIAL_ECHOPAIR_F_P(SP_X_STR, x, 6);

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -176,8 +176,6 @@ static const uint32_t   _DMA[] PROGMEM = DEFAULT_MAX_ACCELERATION;
 static const float     _DASU[] PROGMEM = DEFAULT_AXIS_STEPS_PER_UNIT;
 static const feedRate_t _DMF[] PROGMEM = DEFAULT_MAX_FEEDRATE;
 
-extern const char SP_X_STR[], SP_Y_STR[], SP_Z_STR[], SP_E_STR[];
-
 /**
  * Current EEPROM Layout
  *
@@ -3181,7 +3179,7 @@ void MarlinSettings::reset() {
 
       #elif ENABLED(AUTO_BED_LEVELING_UBL)
 
-        config_heading(forReplay, PSTR(""), false);
+        config_heading(forReplay, NUL_STR, false);
         if (!forReplay) {
           ubl.echo_name();
           SERIAL_CHAR(':');

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -57,6 +57,11 @@
 #include "../core/debug_out.h"
 #include "../libs/hex_print.h"
 
+// extern
+
+PGMSTR(M23_STR, "M23 %s");
+PGMSTR(M24_STR, "M24");
+
 // public:
 
 card_flags_t CardReader::flag;
@@ -481,7 +486,6 @@ void CardReader::release() {
  */
 void CardReader::openAndPrintFile(const char *name) {
   char cmd[4 + strlen(name) + 1 + 3 + 1]; // Room for "M23 ", filename, "\n", "M24", and null
-  extern const char M23_STR[];
   sprintf_P(cmd, M23_STR, name);
   for (char *c = &cmd[4]; *c; c++) *c = tolower(*c);
   strcat_P(cmd, PSTR("\nM24"));

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -27,6 +27,8 @@
 
 #if ENABLED(SDSUPPORT)
 
+extern const char M23_STR[], M24_STR[];
+
 #if BOTH(SDCARD_SORT_ALPHA, SDSORT_DYNAMIC_RAM)
   #define SD_RESORT 1
 #endif


### PR DESCRIPTION
- Most predefined label strings are used in serial output, so move them to `serial.*`.
- G-code strings are enqueued or parsed in place, so move them over to the gcode suite.
- `M23` and `M24` are used for SD printing so they are moved to `cardreader.*`.