### PR TITLE
Fix runout.h building error

### DIFF
--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -30,6 +30,7 @@
 #include "../module/planner.h"
 #include "../module/stepper.h" // for block_t
 #include "../gcode/queue.h"
+#include "../feature/pause.h"
 
 #include "../inc/MarlinConfig.h"
 

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -38,9 +38,9 @@
   #include "../lcd/extui/ui_api.h"
 #endif
 
-#if ENABLED(ADVANCED_PAUSE_FEATURE)
-  #include "pause.h"
-#endif
+//#if ENABLED(ADVANCED_PAUSE_FEATURE)
+//  #include "pause.h"
+//#endif
 
 //#define FILAMENT_RUNOUT_SENSOR_DEBUG
 #ifndef FILAMENT_RUNOUT_THRESHOLD


### PR DESCRIPTION
### Description
Fix runout.h 'did_pause_print' not declared in the scope.

```
In file included from Marlin\src\feature\runout.cpp:31:0:
Marlin\src\feature\runout.h: In static member function 'static void TFilamentMonitor<RESPONSE_T, SENSOR_T>::run()':
Marlin\src\feature\runout.h:121:66: error: 'did_pause_print' was not declared in this scope
       if (enabled && !filament_ran_out && (printingIsActive() || did_pause_print)) {
                                                                  ^~~~~~~~~~~~~~~
In file included from Marlin\src\feature\runout.cpp:31:0:
Marlin\src\feature\runout.h: In static member function 'static void RunoutResponseDelayed::block_completed(const block_t*)':
Marlin\src\feature\runout.h:344:55: error: 'did_pause_print' was not declared in this scope
         if (b->steps.x || b->steps.y || b->steps.z || did_pause_print) { // Allow pause purge move to re-trigger runout state
                                                       ^~~~~~~~~~~~~~~
*** [.pio\build\mks_robin_nano35\src\src\feature\runout.cpp.o] Error 1
```