### PR TITLE
fixes issue 20862, missing semicolon 

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -953,7 +953,7 @@ void setup() {
   #endif
 
   #if HAS_SUICIDE
-    SETUP_LOG("SUICIDE_PIN")
+    SETUP_LOG("SUICIDE_PIN");
     OUT_WRITE(SUICIDE_PIN, !SUICIDE_PIN_INVERTING);
   #endif
 


### PR DESCRIPTION
### Description

With HAS_SUICIDE true you get a compile error due to a missing ;
Added in the ;

### Requirements

Latest Marlin Bugfix 
A board with SUICIDE_PIN defined 

### Benefits

Compiles as expected

### Related Issues

Fixes issue #20862 