### PR TITLE
Revert "Adding custom move feedrate for G26"

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1361,7 +1361,6 @@
     #define MESH_TEST_HOTEND_TEMP  205    // (°C) Default nozzle temperature for the G26 Mesh Validation Tool.
     #define MESH_TEST_BED_TEMP      60    // (°C) Default bed temperature for the G26 Mesh Validation Tool.
     #define G26_XY_FEEDRATE         20    // (mm/s) Feedrate for XY Moves for the G26 Mesh Validation Tool.
-    #define G26_XY_FEEDRATE_TRAVEL  100   // (mm/s) Feedrate for XY Moves without extrusion for the G26 Mesh Validation Tool
     #define G26_RETRACT_MULTIPLIER   1.0  // G26 Q (retraction) used by default between mesh test elements.
   #endif
 

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -128,10 +128,6 @@
   #define G26_XY_FEEDRATE (PLANNER_XY_FEEDRATE() / 3.0)
 #endif
 
-#ifndef G26_XY_FEEDRATE_TRAVEL
-  #define G26_XY_FEEDRATE_TRAVEL (PLANNER_XY_FEEDRATE() / 1.5)
-#endif
-
 #if CROSSHAIRS_SIZE >= INTERSECTION_CIRCLE_RADIUS
   #error "CROSSHAIRS_SIZE must be less than INTERSECTION_CIRCLE_RADIUS."
 #endif
@@ -217,8 +213,7 @@ void move_to(const float &rx, const float &ry, const float &z, const float &e_de
 
   const xy_pos_t dest = { rx, ry };
 
-  const bool has_xy_component = dest != current_position; // Check if X or Y is involved in the movement.  
-  const bool has_e_component = e_delta != 0.0;
+  const bool has_xy_component = dest != current_position; // Check if X or Y is involved in the movement.
 
   destination = current_position;
 
@@ -229,15 +224,10 @@ void move_to(const float &rx, const float &ry, const float &z, const float &e_de
     destination = current_position;
   }
 
-  // If X or Y in combination with E is involved do a 'normal' move. 
-  // If X or Y with no E is involved do a 'fast' move
-  // Otherwise retract/recover/hop.
+  // If X or Y is involved do a 'normal' move. Otherwise retract/recover/hop.
   destination = dest;
   destination.e += e_delta;
-  const feedRate_t feed_value = 
-    has_xy_component 
-    ? (has_e_component ? feedRate_t(G26_XY_FEEDRATE) : feedRate_t(G26_XY_FEEDRATE_TRAVEL)) 
-    : planner.settings.max_feedrate_mm_s[E_AXIS] * 0.666f;
+  const feedRate_t feed_value = has_xy_component ? feedRate_t(G26_XY_FEEDRATE) : planner.settings.max_feedrate_mm_s[E_AXIS] * 0.666f;
   prepare_internal_move_to_destination(feed_value);
   destination = current_position;
 }


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#20729

We need the Example Configuration.h files to have the same option added to them.
