### PR TITLE
Fix comparison between signed and unsigned integer expressions warning

### DIFF
--- a/Marlin/src/lcd/dogm/dogm_Statusscreen.h
+++ b/Marlin/src/lcd/dogm/dogm_Statusscreen.h
@@ -193,7 +193,7 @@
     #define STATUS_LOGO_HEIGHT (sizeof(status_logo_bmp) / (STATUS_LOGO_BYTEWIDTH))
   #endif
   #ifndef STATUS_LOGO_Y
-    #define STATUS_LOGO_Y _MAX(0L, (28L - _MIN(28L, STATUS_LOGO_HEIGHT)) / 2L)
+    #define STATUS_LOGO_Y _MAX(0U, (28U - _MIN(28U, STATUS_LOGO_HEIGHT)) / 2U)
   #endif
   static_assert(
     sizeof(status_logo_bmp) == (STATUS_LOGO_BYTEWIDTH) * (STATUS_LOGO_HEIGHT),


### PR DESCRIPTION
### Description

If user is using custom status screen logo, but don't define STATUS_LOGO_Y position, the calculation macro produces warnings like below:

```
Compiling .pio/build/melzi_optimized/src/src/lcd/dogm/status_screen_DOGM.cpp.o
In file included from Marlin/src/lcd/dogm/../../inc/../core/boards.h:24:0,
                 from Marlin/src/lcd/dogm/../../inc/MarlinConfigPre.h:37,
                 from Marlin/src/lcd/dogm/status_screen_DOGM.cpp:28:
Marlin/src/lcd/dogm/../../inc/../core/macros.h: In instantiation of 'constexpr decltype ((lhs + rhs)) _MIN(L, R) [with L = long int; R = unsigned int; decltype ((lhs + rhs)) = long unsigned int]':
Marlin/src/lcd/dogm/status_screen_DOGM.cpp:536:9:   required from here
Marlin/src/lcd/dogm/../../inc/../core/macros.h:304:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         return lhs < rhs ? lhs : rhs;
                ~~~~^~~~~
Marlin/src/lcd/dogm/../../inc/../core/macros.h: In instantiation of 'constexpr decltype ((lhs + rhs)) _MAX(L, R) [with L = long int; R = long unsigned int; decltype ((lhs + rhs)) = long unsigned int]':
Marlin/src/lcd/dogm/status_screen_DOGM.cpp:536:9:   required from here
Marlin/src/lcd/dogm/../../inc/../core/macros.h:307:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         return lhs > rhs ? lhs : rhs;
                ~~~~^~~~~
```

As we have in that equation STATUS_LOGO_HEIGHT as unsigned int, and result from MIN() will be always unsigned integer between 0 and 28, the rest of expression also can be unsigned.

### Requirements

### Benefits

less warnings during builds.

### Configurations

 - CUSTOM_STATUS_SCREEN_IMAGE enabled
 - status_logo_bmp defined
 - STATUS_LOGO_Y not defined.

### Related Issues

