### PR TITLE
Fix LiquidCrystal CI failures

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -236,7 +236,7 @@ HAS_L64XX               = Arduino-L6470@0.8.0
 NEOPIXEL_LED            = Adafruit NeoPixel@1.5.0
                           src_filter=+<src/feature/leds/neopixel.cpp>
 MAX6675_._IS_MAX31865   = Adafruit MAX31865 library@~1.1.0
-USES_LIQUIDCRYSTAL      = LiquidCrystal@1.5.0
+USES_LIQUIDCRYSTAL      = bitbucket-fmalpartida/LiquidCrystal@1.5.0
 USES_LIQUIDCRYSTAL_I2C  = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2         = LiquidTWI2@1.2.7
 HAS_WIRED_LCD           = src_filter=+<src/lcd/lcdprint.cpp>
@@ -708,7 +708,7 @@ extra_scripts     = ${common.extra_scripts}
 src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768> +<src/HAL/shared/backtrace>
 lib_deps          = ${common.lib_deps}
   Servo
-custom_marlin.USES_LIQUIDCRYSTAL = LiquidCrystal~1.0.7
+custom_marlin.USES_LIQUIDCRYSTAL = arduino-libraries/LiquidCrystal@~1.0.7
 custom_marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/1.5.0.zip
 build_flags       = ${common.build_flags} -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g
   # debug options for backtrace


### PR DESCRIPTION
### Description

Fix issues including the LiquidCrystal dependency.

1. Add missing `@` in the LPC section
2. Disambiguate the two LiquidCrystal libraries, which share the same name.

Note that `bitbucket-fmalpartida` is no longer hosted in BitBucket, and the repo links in the PIO repository is stale. The new source location is in GitHub. It doesn't seem to have any new improvements checked in beyond forking from the BitBucket repo, so there is no compelling reason to point to it directly.
https://github.com/fmalpartida/New-LiquidCrystal

### Requirements

N/A

### Benefits

Fixes LPC builds. Improves ability to understand the source code.

### Configurations

N/A

### Related Issues

N/A
