### PR TITLE
fix building error when LCD_SHOW_E_TOTAL is defined

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -40,6 +40,10 @@
 
 #include "../../gcode/parser.h" // for units (and volumetric)
 
+#if ENABLED(LCD_SHOW_E_TOTAL)
+  #include "../../MarlinCore.h" // for printingIsActive(), marlin_state and MF_SD_COMPLETE
+#endif
+
 #if ENABLED(FILAMENT_LCD_DISPLAY)
   #include "../../feature/filwidth.h"
   #include "../../module/planner.h"


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Build fails with 3 errors if LCD_SHOW_E_TOTAL is defined:
```
Marlin\src\lcd\dogm\status_screen_DOGM.cpp:433:70: error: 'printingIsActive' was not declared in this scope
Marlin\src\lcd\dogm\status_screen_DOGM.cpp:433:75: error: 'marlin_state' was not declared in this 
scope
Marlin\src\lcd\dogm\status_screen_DOGM.cpp:433:91: error: 'MF_SD_COMPLETE' was not declared in this scope
```
importing MarlinCore.h in the same file solves these errors

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Configurations
[config.zip](https://github.com/MarlinFirmware/Marlin/files/5863214/config.zip)
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->