### PR TITLE
Remove unused toggle command in meatpack

### DIFF
--- a/Marlin/src/feature/meatpack.cpp
+++ b/Marlin/src/feature/meatpack.cpp
@@ -186,7 +186,6 @@ void MeatPack::handle_command(const MeatPack_Command c) {
   switch (c) {
     case MPCommand_EnablePacking:   SBI(state, MPConfig_Bit_Active);   DEBUG_ECHOLNPGM("[MPDBG] ENA REC");   break;
     case MPCommand_DisablePacking:  CBI(state, MPConfig_Bit_Active);   DEBUG_ECHOLNPGM("[MPDBG] DIS REC");   break;
-    case MPCommand_TogglePacking:   TBI(state, MPConfig_Bit_Active);   DEBUG_ECHOLNPGM("[MPDBG] TGL REC");   break;
     case MPCommand_ResetAll:        reset_state();                     DEBUG_ECHOLNPGM("[MPDBG] RESET REC"); break;
     case MPCommand_EnableNoSpaces:  SBI(state, MPConfig_Bit_NoSpaces); DEBUG_ECHOLNPGM("[MPDBG] ENA NSP");
                                     TERN_(USE_LOOKUP_TABLE, MeatPackLookupTbl[kSpaceCharIdx] = kSpaceCharReplace);

--- a/Marlin/src/feature/meatpack.h
+++ b/Marlin/src/feature/meatpack.h
@@ -64,7 +64,6 @@
  */
 enum MeatPack_Command : uint8_t {
   MPCommand_None            = 0,
-  MPCommand_TogglePacking   = 0xFD,
   MPCommand_EnablePacking   = 0xFB,
   MPCommand_DisablePacking  = 0xFA,
   MPCommand_ResetAll        = 0xF9,


### PR DESCRIPTION
### Description

Remove unused toggle command code in meatpack

### Requirements

#define MEATPACK

### Benefits

removes unused code.
