### PR TITLE
Reduce serial hook binary footprint.

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -53,6 +53,7 @@
 
 #define _FORCE_INLINE_ __attribute__((__always_inline__)) __inline__
 #define  FORCE_INLINE  __attribute__((always_inline)) inline
+#define NO_INLINE      __attribute__((noinline))
 #define _UNUSED      __attribute__((unused))
 #define _O0          __attribute__((optimize("O0")))
 #define _Os          __attribute__((optimize("Os")))

--- a/Marlin/src/core/serial_base.h
+++ b/Marlin/src/core/serial_base.h
@@ -78,23 +78,23 @@ struct SerialBase {
   FORCE_INLINE void write(const char* str)                    { while (*str) write(*str++); }
   FORCE_INLINE void write(const uint8_t* buffer, size_t size) { while (size--) write(*buffer++); }
   FORCE_INLINE void print(const char* str)                    { write(str); }
-  FORCE_INLINE void print(char c, int base = 0)               { print((long)c, base); }
-  FORCE_INLINE void print(unsigned char c, int base = 0)      { print((unsigned long)c, base); }
-  FORCE_INLINE void print(int c, int base = DEC)              { print((long)c, base); }
-  FORCE_INLINE void print(unsigned int c, int base = DEC)     { print((unsigned long)c, base); }
+  NO_INLINE void print(char c, int base = 0)               { print((long)c, base); }
+  NO_INLINE void print(unsigned char c, int base = 0)      { print((unsigned long)c, base); }
+  NO_INLINE void print(int c, int base = DEC)              { print((long)c, base); }
+  NO_INLINE void print(unsigned int c, int base = DEC)     { print((unsigned long)c, base); }
   void print(long c, int base = DEC)            { if (!base) write(c); write((const uint8_t*)"-", c < 0); printNumber(c < 0 ? -c : c, base); }
   void print(unsigned long c, int base = DEC)   { printNumber(c, base); }
   void print(double c, int digits = 2)          { printFloat(c, digits); }
 
-  FORCE_INLINE void println(const char s[])                  { print(s); println(); }
-  FORCE_INLINE void println(char c, int base = 0)            { print(c, base); println(); }
-  FORCE_INLINE void println(unsigned char c, int base = 0)   { print(c, base); println(); }
-  FORCE_INLINE void println(int c, int base = DEC)           { print(c, base); println(); }
-  FORCE_INLINE void println(unsigned int c, int base = DEC)  { print(c, base); println(); }
-  FORCE_INLINE void println(long c, int base = DEC)          { print(c, base); println(); }
-  FORCE_INLINE void println(unsigned long c, int base = DEC) { print(c, base); println(); }
-  FORCE_INLINE void println(double c, int digits = 2)        { print(c, digits); println(); }
-  void println()                                { write("\r\n"); }
+  NO_INLINE void println(const char s[])                  { print(s); println(); }
+  NO_INLINE void println(char c, int base = 0)            { print(c, base); println(); }
+  NO_INLINE void println(unsigned char c, int base = 0)   { print(c, base); println(); }
+  NO_INLINE void println(int c, int base = DEC)           { print(c, base); println(); }
+  NO_INLINE void println(unsigned int c, int base = DEC)  { print(c, base); println(); }
+  NO_INLINE void println(long c, int base = DEC)          { print(c, base); println(); }
+  NO_INLINE void println(unsigned long c, int base = DEC) { print(c, base); println(); }
+  NO_INLINE void println(double c, int digits = 2)        { print(c, digits); println(); }
+  NO_INLINE void println()                                { write('\r'); write('\n'); }
 
   // Print a number with the given base
   void printNumber(unsigned long n, const uint8_t base) {


### PR DESCRIPTION


<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Reduce the binary size of my serial hooking code, as spotted by @thinkyhead .
Without this PR, I had:
```
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [========= ]  88.9% (used 58248 bytes from 65536 bytes)
Flash: [========= ]  86.9% (used 455740 bytes from 524288 bytes)
encrypt([".pio/build/mks_robin_nano35/debug/firmware.bin"], [".pio/build/mks_robin_nano35/debug/firmware.elf"])
```
After the PR, I now have:
```
Advanced Memory Usage is available via "PlatformIO Home > Project Inspect"
RAM:   [========= ]  88.9% (used 58248 bytes from 65536 bytes)
Flash: [========= ]  86.1% (used 451500 bytes from 524288 bytes)
encrypt([".pio/build/mks_robin_nano35/debug/firmware.bin"], [".pio/build/mks_robin_nano35/debug/firmware.elf"])

```
It also fix RuntimeHook connected call loop

### Requirements

None

### Benefits

Reduce binary flash size by 4.2kB on my system at the cost of a bit less inlining of the serial code's print and write functions.

### Configurations

None

### Related Issues

PR #20783  last comment from Scott.