### PR TITLE
Fixes #20905 error: 'G28_STR' was not declared in this scope

### DIFF
--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.h
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.h
@@ -94,3 +94,4 @@ private:
 };
 
 extern AnycubicTFTClass AnycubicTFT;
+extern const char G28_STR[];


### PR DESCRIPTION

### Description

enabling ANYCUBIC_LCD_I3MEGA results in a compile error
```
Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp: In member function 'void AnycubicTFTClass::GetCommandFromTFT()':
Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp:768:41: error: 'G28_STR' was not declared in this scope
                 ExtUI::injectCommands_P(G28_STR);
```
This adds external reference to G28_STR so it can be resolved.

### Requirements

Current bugfix and enable ANYCUBIC_LCD_I3MEGA

### Benefits

Compiles as expected

### Related Issues
Issue #20905