### PR TITLE
Shared AutoReport class for Temperature, Cardreader

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -687,8 +687,8 @@ void idle(TERN_(ADVANCED_PAUSE_FEATURE, bool no_stepper_sleep/*=false*/)) {
   // Auto-report Temperatures / SD Status
   #if HAS_AUTO_REPORTING
     if (!gcode.autoreport_paused) {
-      TERN_(AUTO_REPORT_TEMPERATURES, thermalManager.auto_report_temperatures());
-      TERN_(AUTO_REPORT_SD_STATUS, card.auto_report_sd_status());
+      TERN_(AUTO_REPORT_TEMPERATURES, thermalManager.auto_reporter.tick());
+      TERN_(AUTO_REPORT_SD_STATUS, card.auto_reporter.tick());
     }
   #endif
 

--- a/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
@@ -267,7 +267,7 @@ void GcodeSuite::G76() {
 
       say_waiting_for_probe_heating();
       SERIAL_ECHOLNPAIR(" Bed:", target_bed, " Probe:", target_probe);
-      const millis_t probe_timeout_ms = millis() + 900UL * 1000UL;
+      const millis_t probe_timeout_ms = millis() + SEC_TO_MS(900UL);
       while (thermalManager.degProbe() < target_probe) {
         if (report_temps(next_temp_report, probe_timeout_ms)) {
           SERIAL_ECHOLNPGM("!Probe heating timed out.");

--- a/Marlin/src/gcode/sd/M1001.cpp
+++ b/Marlin/src/gcode/sd/M1001.cpp
@@ -92,7 +92,7 @@ void GcodeSuite::M1001() {
       printerEventLEDs.onPrintCompleted();
       TERN_(EXTENSIBLE_UI, ExtUI::onUserConfirmRequired_P(GET_TEXT(MSG_PRINT_DONE)));
       TERN_(HOST_PROMPT_SUPPORT, host_prompt_do(PROMPT_USER_CONTINUE, GET_TEXT(MSG_PRINT_DONE), CONTINUE_STR));
-      wait_for_user_response(1000UL * TERN(HAS_LCD_MENU, PE_LEDS_COMPLETED_TIME, 30));
+      wait_for_user_response(SEC_TO_MS(TERN(HAS_LCD_MENU, PE_LEDS_COMPLETED_TIME, 30)));
       printerEventLEDs.onResumeAfterWait();
     }
   #endif

--- a/Marlin/src/gcode/sd/M27.cpp
+++ b/Marlin/src/gcode/sd/M27.cpp
@@ -36,15 +36,17 @@ void GcodeSuite::M27() {
   if (parser.seen('C')) {
     SERIAL_ECHOPGM("Current file: ");
     card.printFilename();
+    return;
   }
 
   #if ENABLED(AUTO_REPORT_SD_STATUS)
-    else if (parser.seenval('S'))
-      card.set_auto_report_interval(parser.value_byte());
+    if (parser.seenval('S')) {
+      card.auto_reporter.set_interval(parser.value_byte());
+      return;
+    }
   #endif
 
-  else
-    card.report_status();
+  card.report_status();
 }
 
 #endif // SDSUPPORT

--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -3553,7 +3553,7 @@ void EachMomentUpdate() {
     static millis_t next_remain_time_update = 0;
     if (Percentrecord > 1 && ELAPSED(ms, next_remain_time_update) && !HMI_flag.heat_flag) {
       remain_time = (elapsed.value - dwin_heat_time) / (Percentrecord * 0.01f) - (elapsed.value - dwin_heat_time);
-      next_remain_time_update += 20 * 1000UL;
+      next_remain_time_update += SEC_TO_MS(20);
       Draw_Print_ProgressRemain();
     }
   }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/compat.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/compat.h
@@ -43,8 +43,8 @@
   #define min(a,b) ((a)<(b)?(a):(b))
 #else
   namespace UI {
-    static inline uint32_t safe_millis() {return millis();};
-    static inline void     yield()       {};
+    static inline uint32_t safe_millis() { return millis(); }
+    static inline void     yield()       {}
   };
 #endif
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ui.cpp
@@ -889,7 +889,7 @@ void GUI_RefreshPage() {
               lv_draw_wifi_tips();
 
             }
-            if (tips_disp.timer_count >= 30 * 1000) {
+            if (tips_disp.timer_count >= SEC_TO_MS(30)) {
               tips_disp.timer = TIPS_TIMER_STOP;
               tips_disp.timer_count = 0;
               lv_clear_wifi_tips();
@@ -898,7 +898,7 @@ void GUI_RefreshPage() {
             }
             break;
           case TIPS_TYPE_TAILED_JOIN:
-            if (tips_disp.timer_count >= 3 * 1000) {
+            if (tips_disp.timer_count >= SEC_TO_MS(3)) {
               tips_disp.timer = TIPS_TIMER_STOP;
               tips_disp.timer_count = 0;
 
@@ -908,7 +908,7 @@ void GUI_RefreshPage() {
             }
             break;
           case TIPS_TYPE_WIFI_CONECTED:
-            if (tips_disp.timer_count >= 3 * 1000) {
+            if (tips_disp.timer_count >= SEC_TO_MS(3)) {
               tips_disp.timer = TIPS_TIMER_STOP;
               tips_disp.timer_count = 0;
 

--- a/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/tft_lvgl_configuration.cpp
@@ -89,8 +89,8 @@ void SysTick_Callback() {
   #endif
   if (uiCfg.filament_loading_time_flg) {
     uiCfg.filament_loading_time_cnt++;
-    uiCfg.filament_rate = (uint32_t)(((uiCfg.filament_loading_time_cnt / (uiCfg.filament_loading_time * 1000.0)) * 100.0) + 0.5);
-    if (uiCfg.filament_loading_time_cnt >= (uiCfg.filament_loading_time * 1000)) {
+    uiCfg.filament_rate = uint32_t(100.0f * uiCfg.filament_loading_time_cnt / SEC_TO_MS(uiCfg.filament_loading_time) + 0.5f);
+    if (uiCfg.filament_loading_time_cnt >= SEC_TO_MS(uiCfg.filament_loading_time)) {
       uiCfg.filament_loading_time_cnt  = 0;
       uiCfg.filament_loading_time_flg  = false;
       uiCfg.filament_loading_completed = true;
@@ -98,8 +98,8 @@ void SysTick_Callback() {
   }
   if (uiCfg.filament_unloading_time_flg) {
     uiCfg.filament_unloading_time_cnt++;
-    uiCfg.filament_rate = (uint32_t)(((uiCfg.filament_unloading_time_cnt / (uiCfg.filament_unloading_time * 1000.0)) * 100.0) + 0.5);
-    if (uiCfg.filament_unloading_time_cnt >= (uiCfg.filament_unloading_time * 1000)) {
+    uiCfg.filament_rate = uint32_t(100.0f * uiCfg.filament_unloading_time_cnt / SEC_TO_MS(uiCfg.filament_unloading_time) + 0.5f);
+    if (uiCfg.filament_unloading_time_cnt >= SEC_TO_MS(uiCfg.filament_unloading_time)) {
       uiCfg.filament_unloading_time_cnt  = 0;
       uiCfg.filament_unloading_time_flg  = false;
       uiCfg.filament_unloading_completed = true;

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -123,7 +123,7 @@ namespace ExtUI {
       // Machine was killed, reinit SysTick so we are able to compute time without ISRs
       if (currTimeHI == 0) {
         // Get the last time the Arduino time computed (from CMSIS) and convert it to SysTick
-        currTimeHI = (uint32_t)((GetTickCount() * (uint64_t)(F_CPU / 8000)) >> 24);
+        currTimeHI = uint32_t((GetTickCount() * uint64_t(F_CPU / 8000)) >> 24);
 
         // Reinit the SysTick timer to maximize its period
         SysTick->LOAD  = SysTick_LOAD_RELOAD_Msk;                    // get the full range for the systick timer
@@ -148,9 +148,9 @@ namespace ExtUI {
     }
   #endif // __SAM3X8E__
 
-  void delay_us(unsigned long us) { DELAY_US(us); }
+  void delay_us(uint32_t us) { DELAY_US(us); }
 
-  void delay_ms(unsigned long ms) {
+  void delay_ms(uint32_t ms) {
     if (flags.printer_killed)
       DELAY_US(ms * 1000);
     else

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -155,7 +155,7 @@ namespace ExtUI {
       void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval);
       inline void onMeshUpdate(const xy_int8_t &pos, const float zval) { onMeshUpdate(pos.x, pos.y, zval); }
 
-      typedef enum : unsigned char {
+      typedef enum : uint8_t {
         MESH_START,    // Prior to start of probe
         MESH_FINISH,   // Following probe of all points
         PROBE_START,   // Beginning probe of grid location
@@ -302,8 +302,8 @@ namespace ExtUI {
     FORCE_INLINE uint32_t safe_millis() { return millis(); } // TODO: Implement for AVR
   #endif
 
-  void delay_us(unsigned long us);
-  void delay_ms(unsigned long ms);
+  void delay_us(uint32_t us);
+  void delay_ms(uint32_t ms);
   void yield();
 
   /**

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1276,7 +1276,7 @@ void Temperature::manage_heater() {
             // temperature didn't drop at least MIN_COOLING_SLOPE_DEG_CHAMBER_VENT
             if (next_cool_check_ms_2 == 0 || ELAPSED(ms, next_cool_check_ms_2)) {
               if (old_temp - temp_chamber.celsius < float(MIN_COOLING_SLOPE_DEG_CHAMBER_VENT)) flag_chamber_excess_heat = true; //the bed is heating the chamber too much
-              next_cool_check_ms_2 = ms + 1000UL * MIN_COOLING_SLOPE_TIME_CHAMBER_VENT;
+              next_cool_check_ms_2 = ms + SEC_TO_MS(MIN_COOLING_SLOPE_TIME_CHAMBER_VENT);
               old_temp = temp_chamber.celsius;
             }
           }
@@ -3129,7 +3129,7 @@ void Temperature::tick() {
 
     void Temperature::auto_report_temperatures() {
       if (auto_report_temp_interval && ELAPSED(millis(), next_temp_report_ms)) {
-        next_temp_report_ms = millis() + 1000UL * auto_report_temp_interval;
+        next_temp_report_ms = millis() + SEC_TO_MS(auto_report_temp_interval);
         PORT_REDIRECT(SERIAL_ALL);
         print_heater_states(active_extruder);
         SERIAL_EOL();
@@ -3252,7 +3252,7 @@ void Temperature::tick() {
           // if the temperature did not drop at least MIN_COOLING_SLOPE_DEG
           if (!next_cool_check_ms || ELAPSED(now, next_cool_check_ms)) {
             if (old_temp - temp < float(MIN_COOLING_SLOPE_DEG)) break;
-            next_cool_check_ms = now + 1000UL * MIN_COOLING_SLOPE_TIME;
+            next_cool_check_ms = now + SEC_TO_MS(MIN_COOLING_SLOPE_TIME);
             old_temp = temp;
           }
         }
@@ -3377,7 +3377,7 @@ void Temperature::tick() {
           // if the temperature did not drop at least MIN_COOLING_SLOPE_DEG_BED
           if (!next_cool_check_ms || ELAPSED(now, next_cool_check_ms)) {
             if (old_temp - temp < float(MIN_COOLING_SLOPE_DEG_BED)) break;
-            next_cool_check_ms = now + 1000UL * MIN_COOLING_SLOPE_TIME_BED;
+            next_cool_check_ms = now + SEC_TO_MS(MIN_COOLING_SLOPE_TIME_BED);
             old_temp = temp;
           }
         }
@@ -3461,7 +3461,7 @@ void Temperature::tick() {
             SERIAL_ECHOLNPGM("Timed out waiting for probe temperature.");
             break;
           }
-          next_delta_check_ms = now + 1000UL * MIN_DELTA_SLOPE_TIME_PROBE;
+          next_delta_check_ms = now + SEC_TO_MS(MIN_DELTA_SLOPE_TIME_PROBE);
           old_temp = temp;
         }
 
@@ -3566,7 +3566,7 @@ void Temperature::tick() {
           // if the temperature did not drop at least MIN_COOLING_SLOPE_DEG_CHAMBER
           if (!next_cool_check_ms || ELAPSED(now, next_cool_check_ms)) {
             if (old_temp - temp < float(MIN_COOLING_SLOPE_DEG_CHAMBER)) break;
-            next_cool_check_ms = now + 1000UL * MIN_COOLING_SLOPE_TIME_CHAMBER;
+            next_cool_check_ms = now + SEC_TO_MS(MIN_COOLING_SLOPE_TIME_CHAMBER);
             old_temp = temp;
           }
         }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -3123,20 +3123,12 @@ void Temperature::tick() {
   }
 
   #if ENABLED(AUTO_REPORT_TEMPERATURES)
-
-    uint8_t Temperature::auto_report_temp_interval;
-    millis_t Temperature::next_temp_report_ms;
-
-    void Temperature::auto_report_temperatures() {
-      if (auto_report_temp_interval && ELAPSED(millis(), next_temp_report_ms)) {
-        next_temp_report_ms = millis() + SEC_TO_MS(auto_report_temp_interval);
-        PORT_REDIRECT(SERIAL_ALL);
-        print_heater_states(active_extruder);
-        SERIAL_EOL();
-      }
+    Temperature::AutoReportTemp Temperature::auto_reporter;
+    void Temperature::AutoReportTemp::auto_report() {
+      print_heater_states(active_extruder);
+      SERIAL_EOL();
     }
-
-  #endif // AUTO_REPORT_TEMPERATURES
+  #endif
 
   #if HAS_HOTEND && HAS_DISPLAY
     void Temperature::set_heating_message(const uint8_t e) {

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -33,6 +33,10 @@
   #include "../feature/power.h"
 #endif
 
+#if ENABLED(AUTO_REPORT_TEMPERATURES)
+  #include "../libs/autoreport.h"
+#endif
+
 #ifndef SOFT_PWM_SCALE
   #define SOFT_PWM_SCALE 0
 #endif
@@ -794,14 +798,8 @@ class Temperature {
         #endif
       );
       #if ENABLED(AUTO_REPORT_TEMPERATURES)
-        static uint8_t auto_report_temp_interval;
-        static millis_t next_temp_report_ms;
-        static void auto_report_temperatures();
-        static inline void set_auto_report_interval(uint8_t seconds) {
-          NOMORE(seconds, 60);
-          auto_report_temp_interval = seconds;
-          next_temp_report_ms = millis() + SEC_TO_MS(seconds);
-        }
+        class AutoReportTemp : public AutoReporter<SERIAL_ALL> { void auto_report(); };
+        static AutoReportTemp auto_reporter;
       #endif
     #endif
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -797,10 +797,10 @@ class Temperature {
         static uint8_t auto_report_temp_interval;
         static millis_t next_temp_report_ms;
         static void auto_report_temperatures();
-        static inline void set_auto_report_interval(uint8_t v) {
-          NOMORE(v, 60);
-          auto_report_temp_interval = v;
-          next_temp_report_ms = millis() + 1000UL * v;
+        static inline void set_auto_report_interval(uint8_t seconds) {
+          NOMORE(seconds, 60);
+          auto_report_temp_interval = seconds;
+          next_temp_report_ms = millis() + SEC_TO_MS(seconds);
         }
       #endif
     #endif

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1235,7 +1235,7 @@ void CardReader::fileHasFinished() {
   void CardReader::auto_report_sd_status() {
     millis_t current_ms = millis();
     if (auto_report_sd_interval && ELAPSED(current_ms, next_sd_report_ms)) {
-      next_sd_report_ms = current_ms + 1000UL * auto_report_sd_interval;
+      next_sd_report_ms = current_ms + SEC_TO_MS(auto_report_sd_interval);
       PORT_REDIRECT(auto_report_port);
       report_status();
     }

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -1226,21 +1226,10 @@ void CardReader::fileHasFinished() {
 }
 
 #if ENABLED(AUTO_REPORT_SD_STATUS)
-  uint8_t CardReader::auto_report_sd_interval = 0;
-  millis_t CardReader::next_sd_report_ms;
-  #if HAS_MULTI_SERIAL
-    serial_index_t CardReader::auto_report_port;
-  #endif
-
-  void CardReader::auto_report_sd_status() {
-    millis_t current_ms = millis();
-    if (auto_report_sd_interval && ELAPSED(current_ms, next_sd_report_ms)) {
-      next_sd_report_ms = current_ms + SEC_TO_MS(auto_report_sd_interval);
-      PORT_REDIRECT(auto_report_port);
-      report_status();
-    }
-  }
-#endif // AUTO_REPORT_SD_STATUS
+  TERN_(HAS_MULTI_SERIAL, serial_index_t CardReader::auto_report_port);
+  CardReader::AutoReportSD CardReader::auto_reporter;
+  void CardReader::AutoReportSD::auto_report() { report_status(); }
+#endif
 
 #if ENABLED(POWER_LOSS_RECOVERY)
 

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -59,6 +59,10 @@ typedef struct {
     ;
 } card_flags_t;
 
+#if ENABLED(AUTO_REPORT_SD_STATUS)
+  #include "../libs/autoreport.h"
+#endif
+
 class CardReader {
 public:
   static card_flags_t flag;                         // Flags (above)
@@ -172,13 +176,16 @@ public:
   static Sd2Card& getSd2Card() { return sd2card; }
 
   #if ENABLED(AUTO_REPORT_SD_STATUS)
-    static void auto_report_sd_status();
-    static inline void set_auto_report_interval(uint8_t seconds) {
-      TERN_(HAS_MULTI_SERIAL, auto_report_port = multiSerial.portMask);
-      NOMORE(seconds, 60);
-      auto_report_sd_interval = seconds;
-      next_sd_report_ms = millis() + SEC_TO_MS(seconds);
-    }
+    //
+    // SD Auto Reporting
+    //
+    #if HAS_MULTI_SERIAL
+      static serial_index_t auto_report_port;
+    #else
+      static constexpr serial_index_t auto_report_port = 0;
+    #endif
+    class AutoReportSD : public AutoReporter<auto_report_port> { void auto_report(); };
+    static AutoReportSD auto_reporter;
   #endif
 
 private:
@@ -258,17 +265,6 @@ private:
     static uint8_t file_subcall_ctr;
     static uint32_t filespos[SD_PROCEDURE_DEPTH];
     static char proc_filenames[SD_PROCEDURE_DEPTH][MAXPATHNAMELENGTH];
-  #endif
-
-  //
-  // SD Auto Reporting
-  //
-  #if ENABLED(AUTO_REPORT_SD_STATUS)
-    static uint8_t auto_report_sd_interval;
-    static millis_t next_sd_report_ms;
-    #if HAS_MULTI_SERIAL
-      static serial_index_t auto_report_port;
-    #endif
   #endif
 
   //

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -173,11 +173,11 @@ public:
 
   #if ENABLED(AUTO_REPORT_SD_STATUS)
     static void auto_report_sd_status();
-    static inline void set_auto_report_interval(uint8_t v) {
+    static inline void set_auto_report_interval(uint8_t seconds) {
       TERN_(HAS_MULTI_SERIAL, auto_report_port = multiSerial.portMask);
-      NOMORE(v, 60);
-      auto_report_sd_interval = v;
-      next_sd_report_ms = millis() + 1000UL * v;
+      NOMORE(seconds, 60);
+      auto_report_sd_interval = seconds;
+      next_sd_report_ms = millis() + SEC_TO_MS(seconds);
     }
   #endif
 


### PR DESCRIPTION
- Auto-report is a common paradigm in Marlin, so encapsulate this behavior as a simple template class.
- Also apply macros like `SEC_TO_MS` where contextually-appropriate.