### PR TITLE
Fix LED_CONTROL_MENU based on LED/NEO2_COLOR_PRESETS

### DIFF
--- a/Marlin/src/lcd/menu/menu_led.cpp
+++ b/Marlin/src/lcd/menu/menu_led.cpp
@@ -123,11 +123,15 @@ void menu_led() {
   #if ENABLED(LED_CONTROL_MENU)
     editable.state = leds.lights_on;
     EDIT_ITEM(bool, MSG_LEDS, &editable.state, leds.toggle);
-    ACTION_ITEM(MSG_SET_LEDS_DEFAULT, leds.set_default);
+    #if ENABLED(LED_COLOR_PRESETS)
+      ACTION_ITEM(MSG_SET_LEDS_DEFAULT, leds.set_default);
+    #endif
     #if ENABLED(NEOPIXEL2_SEPARATE)
       editable.state = leds2.lights_on;
       EDIT_ITEM(bool, MSG_LEDS2, &editable.state, leds2.toggle);
-      ACTION_ITEM(MSG_SET_LEDS_DEFAULT, leds2.set_default);
+      #if ENABLED(NEO2_COLOR_PRESETS)
+        ACTION_ITEM(MSG_SET_LEDS_DEFAULT, leds2.set_default);
+      #endif
     #endif
     #if ENABLED(LED_COLOR_PRESETS)
       SUBMENU(MSG_LED_PRESETS, menu_led_presets);


### PR DESCRIPTION
### Description

LED_CONTROL_MENU uses objects that only exists if LED_COLOR_PRESETS or NEO2_COLOR_PRESETS is enabled
This causes compile errors eg
```
error: 'class LEDLights2' has no member named 'set_default'
  130 |       ACTION_ITEM(MSG_SET_LEDS_DEFAULT, leds2.set_default);

```
Added ifdefs so that LED_CONTROL_MENU only uses LED_COLOR_PRESETS or NEO2_COLOR_PRESETS when they are defined.

### Requirements

A LCD with LED_CONTROL_MENU enabled
Either NEOPIXEL_LED enabled with LED_COLOR_PRESETS disabled
or NEOPIXEL_LED and NEOPIXEL2_SEPARATE enabled with NEO2_COLOR_PRESETS disabled

### Benefits

Compiles as expected

### Related Issues
Issue #20904