### PR TITLE
add multi-language save option

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1534,9 +1534,8 @@
   //#define LCD_LANGUAGE_3 de
   //#define LCD_LANGUAGE_4 es
   //#define LCD_LANGUAGE_5 it
-
   #ifdef LCD_LANGUAGE_2
-    //#define DONT_AUTOSAVE_LANGUAGE // Don't save language selection to EEPROM
+    //#define LCD_LANGUAGE_AUTO_SAVE // Automatically save language to EEPROM on change
   #endif
 #endif
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1534,6 +1534,10 @@
   //#define LCD_LANGUAGE_3 de
   //#define LCD_LANGUAGE_4 es
   //#define LCD_LANGUAGE_5 it
+
+  #ifdef LCD_LANGUAGE_2
+    //#define DONT_AUTOSAVE_LANGUAGE // Don't save language selection to EEPROM
+  #endif
 #endif
 
 //

--- a/Marlin/src/lcd/menu/menu_language.cpp
+++ b/Marlin/src/lcd/menu/menu_language.cpp
@@ -34,7 +34,7 @@
 
 static void set_lcd_language(const uint8_t inlang) {
   ui.set_language(inlang);
-  (void)settings.save();
+  IF_DISABLED(DONT_AUTOSAVE_LANGUAGE, (void)settings.save())
 }
 
 void menu_language() {

--- a/Marlin/src/lcd/menu/menu_language.cpp
+++ b/Marlin/src/lcd/menu/menu_language.cpp
@@ -34,7 +34,7 @@
 
 static void set_lcd_language(const uint8_t inlang) {
   ui.set_language(inlang);
-  IF_DISABLED(DONT_AUTOSAVE_LANGUAGE, (void)settings.save())
+  IF_DISABLED(DONT_AUTOSAVE_LANGUAGE, (void)settings.save());
 }
 
 void menu_language() {

--- a/Marlin/src/lcd/menu/menu_language.cpp
+++ b/Marlin/src/lcd/menu/menu_language.cpp
@@ -34,7 +34,7 @@
 
 static void set_lcd_language(const uint8_t inlang) {
   ui.set_language(inlang);
-  IF_DISABLED(DONT_AUTOSAVE_LANGUAGE, (void)settings.save());
+  TERN_(LCD_LANGUAGE_AUTO_SAVE, (void)settings.save());
 }
 
 void menu_language() {


### PR DESCRIPTION
When changing language, the settings are automatically stored to EEPROM. This causes a problem for universities or makerspaces when unexperienced users suddenly have to navigate through a menu in a foreign language. Instead, it would be nice to have the base language reset after reboot.

This pull request gives the option to disable the automatic storing to EEPROM.

**One related issue** that I have, is that only the langdata file of the main `LCD_LANGUAGE` is used, including possibly the wrong character set.

**Example:**
`LCD_LANGUAGE en` uses `NOT_EXTENDED_ISO10646_1_5X7` and loads `langdata_en.h`, but 
`LCD_LANGUAGE_2 de` requires the extended character set and
`LCD_LANGUAGE_3 zh_CN` requires `langdata_zh_CN.h`.

I solved this specific issue with these 3 languages by "forcefully" disabling `NOT_EXTENDED_ISO10646_1_5X7` and loading `langdata_zh_CN.h`, which works fine but it's ugly.