### PR TITLE
add missing KILL and BEEPER pins to LCD_FOR_MELZI 

### DIFF
--- a/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
+++ b/Marlin/src/pins/sanguino/pins_SANGUINOLOLU_11.h
@@ -163,6 +163,8 @@
       #define LCD_PINS_RS                     17
       #define LCD_PINS_ENABLE                 16
       #define LCD_PINS_D4                     11
+      #define KILL_PIN                        10
+      #define BEEPER_PIN                      27
 
       #ifndef BOARD_ST7920_DELAY_1
         #define BOARD_ST7920_DELAY_1 DELAY_NS(0)


### PR DESCRIPTION

### Description

KILL and BEEPER on LCD_FOR_MELZI do not work.
The pins are not defined.
Added the pin definitions 

### Requirements

Melzi based controller with a LCD_FOR_MELZI

### Benefits

Beeper and kill switch on LCD works.

### Related Issues
Issue #20917