### PR TITLE
 Fixes #20923 error: 'G28_STR' was not declared in this scop, Ftdi_eve

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/compat.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/compat.h
@@ -50,3 +50,4 @@
 
 class __FlashStringHelper;
 typedef const __FlashStringHelper *progmem_str;
+extern const char G28_STR[];


### PR DESCRIPTION
### Description

Another undefined G28_STR error

Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stress_test_screen.cpp:123:24: error: 'G28_STR' was not declared in this scope; did you mean 'M24_STR'?

Added extern const char G28_STR[]; to src/lcd/extui/lib/ftdi_eve_touch_ui/compat.h

### Requirements

TOUCH_UI_DEVELOPER_MENU and a Ftdi_eve touch screen

### Benefits

Compiles without errors

### Related Issues

Issue #20923
