### PR TITLE
ststm32 update from 10.0 to 11.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -738,7 +738,7 @@ board    = nxp_lpc1769
 # HAL/STM32 Base Environment values
 #
 [common_stm32]
-platform      = ststm32@~10.0
+platform      = ststm32@~11.0
 build_flags   = ${common.build_flags}
   -std=gnu++14
   -DUSBCON -DUSBD_USE_CDC
@@ -751,7 +751,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/b
 # HAL/STM32F1 Common Environment values
 #
 [common_stm32f1]
-platform          = ststm32@~10.0
+platform          = ststm32@~11.0
 board_build.core  = maple
 build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags}


### PR DESCRIPTION
### Description

platformio has updated their ststm32 environment from 10.0 to 11.0
this change leverages the update

### Requirements

applies to STM32 boards

### Benefits

Allows the user of the most current pio environment