### PR TITLE
Run Calibration Screen after Eeprom reset, when needed, for Classic and Color UI

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1652,7 +1652,13 @@ void MarlinUI::update() {
 #endif // SDSUPPORT
 
 #if HAS_LCD_MENU
-  void MarlinUI::reset_settings() { settings.reset(); completion_feedback(); }
+  void MarlinUI::reset_settings() {
+    settings.reset();
+    completion_feedback();
+    #if ENABLED(TOUCH_SCREEN_CALIBRATION)
+      if (touch_calibration.need_calibration()) ui.goto_screen(touch_screen_calibration);
+    #endif
+  }
 #endif
 
 #if ENABLED(EEPROM_SETTINGS)


### PR DESCRIPTION
### Description

When user has no touch calibration default values, if he reset eeprom, touch will stop working. This PR makes the classic and color ui run touch calibration screen if it's needed, after an eeprom reset.

Note: if the user send M502, he can send too M955.

### Benefits

Fix #20849

### Related Issues

#20849
