### PR TITLE
Force signed chars for all environments

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -212,7 +212,7 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
-build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-constants
+build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-constants -fsigned-char
 lib_deps           =
 
 #
@@ -910,7 +910,7 @@ platform      = ${common_stm32.platform}
 extends       = common_stm32
 board         = armed_v1
 build_flags   = ${common_stm32.build_flags}
-  -O2 -ffreestanding -fsigned-char -fno-move-loop-invariants -fno-strict-aliasing
+  -O2 -ffreestanding -fno-move-loop-invariants -fno-strict-aliasing
 
 #
 # Geeetech GTM32 (STM32F103VET6)
@@ -1100,7 +1100,7 @@ platform    = ${common_stm32.platform}
 extends     = common_stm32
 board       = malyanM200v2
 build_flags = ${common_stm32.build_flags} -DHAL_PCD_MODULE_ENABLED
-  -O2 -ffreestanding -fsigned-char -fno-move-loop-invariants -fno-strict-aliasing
+  -O2 -ffreestanding -fno-move-loop-invariants -fno-strict-aliasing
   -DCUSTOM_STARTUP_FILE
 
 #


### PR DESCRIPTION
If seems that signed char vs unsigned char definition may give some problem in Marlin.

Marlin uses loops with uint8_t variabled and require some serial numeric print (see G29 T) but on arms chars defaults to unsigned.
Since firmware needs char to be treated differently from uint8_t I think it's required to force chars as signed everywhere.

