### PR TITLE
Fix SKR 1.4 boot failure with UART3 enabled (MARLIN_DEV_MODE)

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -886,6 +886,17 @@ void setup() {
   #endif
   #define SETUP_RUN(C) do{ SETUP_LOG(STRINGIFY(C)); C; }while(0)
 
+  MYSERIAL0.begin(BAUDRATE);
+  millis_t serial_connect_timeout = millis() + 1000UL;
+  while (!MYSERIAL0.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+
+  #if HAS_MULTI_SERIAL && !HAS_ETHERNET
+    MYSERIAL1.begin(BAUDRATE);
+    serial_connect_timeout = millis() + 1000UL;
+    while (!MYSERIAL1.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+  #endif
+  SERIAL_ECHOLNPGM("start");
+
   // Set up these pins early to prevent suicide
   #if HAS_KILL
     SETUP_LOG("KILL_PIN");
@@ -917,17 +928,6 @@ void setup() {
       #error "DISABLE_(DEBUG|JTAG) is not supported for the selected MCU/Board."
     #endif
   #endif
-
-  MYSERIAL0.begin(BAUDRATE);
-  millis_t serial_connect_timeout = millis() + 1000UL;
-  while (!MYSERIAL0.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
-
-  #if HAS_MULTI_SERIAL && !HAS_ETHERNET
-    MYSERIAL1.begin(BAUDRATE);
-    serial_connect_timeout = millis() + 1000UL;
-    while (!MYSERIAL1.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
-  #endif
-  SERIAL_ECHOLNPGM("start");
 
   #if BOTH(HAS_TFT_LVGL_UI, MKS_WIFI_MODULE)
     mks_esp_wifi_init();


### PR DESCRIPTION
### Description

Invoking SETUP_LOG() before initializing serial ports will fail on an SKR 1.4 with UART3 enabled (either as SERIAL_PORT or SERIAL_PORT_2) and the board resets immediately.

### Configurations

#define SERIAL_PORT 3
...
  #define MOTHERBOARD BOARD_BTT_SKR_V1_4
...
#define PSU_CONTROL
...
#define MARLIN_DEV_MODE

the above defines will cause SETUP_LOG() to run before serial setup.

### Related Issues

#20933 #20810 

In relation to #20810, it appears that the related issue is a race condition rather than a deterministic behavior, so it's not a fix, but rather a speed improvement. If this solution breaks #20810 and serial ports must be setup after KILL_PIN, it would be a good idea to remove SETUP_LOG() from all the code before serial setup, to avoid the crash.

On the other hand, it might be worthwhile to investigate why UART3 crashes (while UART0 does not) when used uninitialized, and fix that issue, but I don't have the means to debug the issue at this level.
