### PR TITLE
declare emergency_state variable to fix compile issues on SKR Pro

### DIFF
--- a/Marlin/src/HAL/STM32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSerial.cpp
@@ -66,6 +66,7 @@ void MarlinSerial::begin(unsigned long baud, uint8_t config) {
 void MarlinSerial::_rx_complete_irq(serial_t *obj) {
   // No Parity error, read byte and store it in the buffer if there is room
   unsigned char c;
+  static EmergencyParser::State emergency_state; // = EP_RESET
 
   if (uart_getc(obj, &c) == 0) {
 


### PR DESCRIPTION
### Description

7bbdbcf caused compile issues on SKR Pro if EMERGENCY_PARSER was used. This change declares the variable where needed.

### Requirements

SKR Pro

### Benefits

Compiling possible again

### Configurations

attached

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/20906
