### PR TITLE
Support for Shared Media on STM32 - USB Mass Storage Device

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -42,6 +42,11 @@
   #endif
 #endif
 
+#if HAS_SD_HOST_DRIVE
+  #include "msc_sd.h"
+  #include "usbd_cdc_if.h"
+#endif
+
 // ------------------------
 // Public Variables
 // ------------------------
@@ -87,6 +92,19 @@ void HAL_init() {
 
   #if ENABLED(EMERGENCY_PARSER) && USBD_USE_CDC
     USB_Hook_init();
+  #endif
+
+  #if HAS_SD_HOST_DRIVE
+    MSC_SD_init();                         // Enable USB SD card access
+  #endif
+}
+
+// HAL idle task
+void HAL_idletask() {
+  #if HAS_SHARED_MEDIA
+    // Stm32duino currently doesn't have a "loop/idle" method
+    CDC_resume_receive();
+    CDC_continue_transmit();
   #endif
 }
 

--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -135,6 +135,8 @@ extern uint16_t HAL_adc_result;
 
 // Enable hooks into  setup for HAL
 void HAL_init();
+#define HAL_IDLETASK 1
+void HAL_idletask();
 
 // Clear reset reason
 void HAL_clear_reset_source();

--- a/Marlin/src/HAL/STM32/inc/Conditionals_adv.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_adv.h
@@ -21,6 +21,6 @@
  */
 #pragma once
 
-#if defined(USBD_USE_CDC_COMPOSITE) && DISABLED(NO_SD_HOST_DRIVE)
+#if defined(USBD_USE_CDC_MSC) && DISABLED(NO_SD_HOST_DRIVE)
   #define HAS_SD_HOST_DRIVE 1
 #endif

--- a/Marlin/src/HAL/STM32/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32/msc_sd.cpp
@@ -1,0 +1,105 @@
+/**
+ * Marlin 3D Printer Firmware
+ *
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2019 BigTreeTech [https://github.com/bigtreetech]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#include "../../inc/MarlinConfigPre.h"
+
+#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && HAS_SD_HOST_DRIVE
+
+#include "msc_sd.h"
+#include "../shared/Marduino.h"
+#include "usbd_core.h"
+#include <USB.h>
+#include <USBMscHandler.h>
+
+#define BLOCK_SIZE 512
+#define PRODUCT_ID 0x29
+
+#include "../../sd/cardreader.h"
+
+class Sd2CardUSBMscHandler : public USBMscHandler {
+public:
+  bool GetCapacity(uint32_t *pBlockNum, uint16_t *pBlockSize) {
+    *pBlockNum = card.getSd2Card().cardSize();
+    *pBlockSize = BLOCK_SIZE;
+    return true;
+  }
+
+  bool Write(uint8_t *pBuf, uint32_t blkAddr, uint16_t blkLen) {
+    auto sd2card = card.getSd2Card();
+    if (blkLen == 1) {
+      sd2card.writeBlock(blkAddr, pBuf);
+      return true;
+    }
+
+    sd2card.writeStart(blkAddr, blkLen);
+    while (blkLen--) {
+      sd2card.writeData(pBuf);
+      pBuf += BLOCK_SIZE;
+    }
+    sd2card.writeStop();
+    return true;
+  }
+
+  bool Read(uint8_t *pBuf, uint32_t blkAddr, uint16_t blkLen) {
+    auto sd2card = card.getSd2Card();
+    if (blkLen == 1) {
+      sd2card.readBlock(blkAddr, pBuf);
+      return true;
+    }
+
+    sd2card.readStart(blkAddr);
+    while (blkLen--) {
+      sd2card.readData(pBuf);
+      pBuf += BLOCK_SIZE;
+    }
+    sd2card.readStop();
+    return true;
+  }
+
+  bool IsReady() {
+    return card.isMounted();
+  }
+};
+
+Sd2CardUSBMscHandler usbMscHandler;
+
+/* USB Mass storage Standard Inquiry Data */
+uint8_t  Marlin_STORAGE_Inquirydata[] =  /* 36 */
+{
+  /* LUN 0 */
+  0x00,
+  0x80,
+  0x02,
+  0x02,
+  (STANDARD_INQUIRY_DATA_LEN - 5),
+  0x00,
+  0x00,
+  0x00,
+  'M', 'A', 'R', 'L', 'I', 'N', ' ', ' ', /* Manufacturer : 8 bytes */
+  'P', 'r', 'o', 'd', 'u', 'c', 't', ' ', /* Product      : 16 Bytes */
+  ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ',
+  '0', '.', '0', '1',                     /* Version      : 4 Bytes */
+};
+
+USBMscHandler *pSingleMscHandler = &usbMscHandler;
+
+void MSC_SD_init() {
+  USBDevice.end();
+  delay(200);
+  USBDevice.begin();
+  USBDevice.registerMscHandlers(1, &pSingleMscHandler, Marlin_STORAGE_Inquirydata);
+}
+
+#endif // __STM32F1__ && HAS_SD_HOST_DRIVE

--- a/Marlin/src/HAL/STM32/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32/msc_sd.cpp
@@ -38,13 +38,17 @@ public:
 
   bool Write(uint8_t *pBuf, uint32_t blkAddr, uint16_t blkLen) {
     auto sd2card = card.getSd2Card();
+    // single block
     if (blkLen == 1) {
+      watchdog_refresh();
       sd2card.writeBlock(blkAddr, pBuf);
       return true;
     }
 
+    // multi block optmization
     sd2card.writeStart(blkAddr, blkLen);
     while (blkLen--) {
+      watchdog_refresh();
       sd2card.writeData(pBuf);
       pBuf += BLOCK_SIZE;
     }
@@ -54,13 +58,17 @@ public:
 
   bool Read(uint8_t *pBuf, uint32_t blkAddr, uint16_t blkLen) {
     auto sd2card = card.getSd2Card();
+    // single block
     if (blkLen == 1) {
+      watchdog_refresh();
       sd2card.readBlock(blkAddr, pBuf);
       return true;
     }
 
+    // multi block optmization
     sd2card.readStart(blkAddr);
     while (blkLen--) {
+      watchdog_refresh();
       sd2card.readData(pBuf);
       pBuf += BLOCK_SIZE;
     }

--- a/Marlin/src/HAL/STM32/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32/msc_sd.cpp
@@ -1,7 +1,7 @@
 /**
  * Marlin 3D Printer Firmware
  *
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  * Copyright (c) 2019 BigTreeTech [https://github.com/bigtreetech]
  *
  * This program is free software: you can redistribute it and/or modify
@@ -84,8 +84,7 @@ public:
 Sd2CardUSBMscHandler usbMscHandler;
 
 /* USB Mass storage Standard Inquiry Data */
-uint8_t  Marlin_STORAGE_Inquirydata[] =  /* 36 */
-{
+uint8_t  Marlin_STORAGE_Inquirydata[] = { /* 36 */
   /* LUN 0 */
   0x00,
   0x80,

--- a/Marlin/src/HAL/STM32/msc_sd.h
+++ b/Marlin/src/HAL/STM32/msc_sd.h
@@ -1,0 +1,20 @@
+/**
+ * Marlin 3D Printer Firmware
+ *
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2019 BigTreeTech [https://github.com/bigtreetech]
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "../../inc/MarlinConfigPre.h"
+
+void MSC_SD_init();

--- a/Marlin/src/HAL/STM32/msc_sd.h
+++ b/Marlin/src/HAL/STM32/msc_sd.h
@@ -1,7 +1,7 @@
 /**
  * Marlin 3D Printer Firmware
  *
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  * Copyright (c) 2019 BigTreeTech [https://github.com/bigtreetech]
  *
  * This program is free software: you can redistribute it and/or modify
@@ -14,7 +14,5 @@
  *
  */
 #pragma once
-
-#include "../../inc/MarlinConfigPre.h"
 
 void MSC_SD_init();

--- a/platformio.ini
+++ b/platformio.ini
@@ -1525,6 +1525,22 @@ build_flags       = ${stm32_flash_drive.build_flags}
   -DUSBD_USE_CDC
 
 #
+# MKS Robin Nano V3 with USB Flash Drive Support and Shared Media
+# Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
+#
+[env:mks_robin_nano_v3_usb_flash_drive_msc]
+extends           = env:mks_robin_nano_v3
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc.zip
+build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
+build_flags       = ${stm32_flash_drive.build_flags}
+  -DUSBCON
+  -DUSE_USBHOST_HS
+  -DUSBD_IRQ_PRIO=5
+  -DUSBD_IRQ_SUBPRIO=6
+  -DUSE_USB_HS_IN_FS
+  -DUSBD_USE_CDC_MSC
+
+#
 # Mingda MPX_ARM_MINI
 #
 


### PR DESCRIPTION
### Description

This PR add support for shared media for STM32. The current work is experimental because it uses some code not merged on stm32duino yet.

The current version support any marlin accessible media to be shared with the computer: SD and even USB Flash Drive.

Note: in the current version, the media is mounted on Marlin and on Host. I didn't added a mutual exclusive access yet.

There's no big changes or anything that will break with this PR, so it can be merged with no risk.

### Requirements

Board with usb serial using stm32. I tested with nano v3, a F4 board.

Works with normal `SDSUPPORT` and `USB_FLASH_DRIVE_SUPPORT`

### Benefits

Migrating more features from STM32F1 to STM32.

### Related Issues


