### PR TITLE
fixes #20961 Compile error in host_response_handler

### DIFF
--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -182,7 +182,7 @@ void host_action(PGM_P const pstr, const bool eol) {
         break;
       case PROMPT_PAUSE_RESUME:
         msg = PSTR("LCD_PAUSE_RESUME");
-        #if BOTH(ADVANCED_PAUSE_FEATURE,SDSUPPORT)
+        #if BOTH(ADVANCED_PAUSE_FEATURE, SDSUPPORT)
           extern const char M24_STR[];
           queue.inject_P(M24_STR);
         #endif

--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -182,7 +182,7 @@ void host_action(PGM_P const pstr, const bool eol) {
         break;
       case PROMPT_PAUSE_RESUME:
         msg = PSTR("LCD_PAUSE_RESUME");
-        #if ENABLED(ADVANCED_PAUSE_FEATURE)
+        #if BOTH(ADVANCED_PAUSE_FEATURE,SDSUPPORT)
           extern const char M24_STR[];
           queue.inject_P(M24_STR);
         #endif


### PR DESCRIPTION
### Description

host_response_handler() will not compile if SDSUPPORT is disabled 
Uses the following without checking for SDSUPPORT and M24_STR is only defined when using SDSUPPORT
```
          extern const char M24_STR[];
          queue.inject_P(M24_STR);
```
Added a check for SDSUPPORT

### Requirements

ADVANCED_PAUSE_FEATURE and HOST_PROMPT_SUPPORT with SDSUPPORT disabled

### Benefits

Compiles as expected 

### Configurations

[https://github.com/MarlinFirmware/Marlin/files/5901201/Configurations.zip](https://github.com/MarlinFirmware/Marlin/files/5901201/Configurations.zip)

### Related Issues

Issue #20961