### PR TITLE
Fix MARLIN_LOGO_FULL_SIZE - 20861 follow up

### DIFF
--- a/Marlin/src/lcd/tft/tft_image.cpp
+++ b/Marlin/src/lcd/tft/tft_image.cpp
@@ -25,6 +25,7 @@
 #if HAS_GRAPHICAL_TFT
 
 #include "tft_image.h"
+#include "ui_common.h"
 
 const tImage NoLogo                 = { nullptr, 0, 0, NOCOLORS };
 


### PR DESCRIPTION
Needs ui_common.h for MARLIN_LOGO_FULL_SIZE

Follow up for #20861
