### PR TITLE
Note (MarlinUI) limit on Preheat Settings

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1614,9 +1614,8 @@
 
 // @section temperature
 
-// Preheat Constants
 //
-// You can set PREHEAT_1 through PREHEAT_5
+// Preheat Constants - Up to 5 are supported without changes
 //
 #define PREHEAT_1_LABEL       "PLA"
 #define PREHEAT_1_TEMP_HOTEND 180

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1615,6 +1615,9 @@
 // @section temperature
 
 // Preheat Constants
+//
+// You can set PREHEAT_1 though PREHEAT_5
+//
 #define PREHEAT_1_LABEL       "PLA"
 #define PREHEAT_1_TEMP_HOTEND 180
 #define PREHEAT_1_TEMP_BED     70

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1616,7 +1616,7 @@
 
 // Preheat Constants
 //
-// You can set PREHEAT_1 though PREHEAT_5
+// You can set PREHEAT_1 through PREHEAT_5
 //
 #define PREHEAT_1_LABEL       "PLA"
 #define PREHEAT_1_TEMP_HOTEND 180


### PR DESCRIPTION
### Description

There is no documentation that says you can have more than 2 PREHEAT Constants
When the code shows you can have up to 5

### Requirements

Reading the Config file

### Benefits

Less confused users

### Related Issues

Issue #20964