### PR TITLE
Auto Save Option for Successful Touch Calibration

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2457,6 +2457,10 @@
   //#define TOUCH_OFFSET_Y        257
   //#define TOUCH_ORIENTATION TOUCH_LANDSCAPE
 
+  #if BOTH(TOUCH_SCREEN_CALIBRATION, EEPROM_SETTINGS)
+    #define TOUCH_CALIBRATION_AUTO_SAVE // Auto save successful calibration values to EEPROM
+  #endif
+
   #if ENABLED(TFT_COLOR_UI)
     //#define SINGLE_TOUCH_NAVIGATION
   #endif

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -28,6 +28,10 @@
 #define DEBUG_OUT ENABLED(DEBUG_TOUCH_CALIBRATION)
 #include "../../core/debug_out.h"
 
+#if ENABLED(TOUCH_CALIBRATION_AUTO_SAVE)
+  #include "../../module/settings.h"
+#endif
+
 TouchCalibration touch_calibration;
 
 touch_calibration_t TouchCalibration::calibration;
@@ -78,6 +82,7 @@ void TouchCalibration::validate_calibration() {
     SERIAL_ECHOLNPAIR("TOUCH_OFFSET_X ", calibration.offset_x);
     SERIAL_ECHOLNPAIR("TOUCH_OFFSET_Y ", calibration.offset_y);
     SERIAL_ECHO_TERNARY(calibration.orientation == TOUCH_LANDSCAPE, "TOUCH_ORIENTATION ", "TOUCH_LANDSCAPE", "TOUCH_PORTRAIT", "\n");
+    TERN_(TOUCH_CALIBRATION_AUTO_SAVE, settings.save());
   }
 }
 


### PR DESCRIPTION
### Description

New option, enabled by default, that will save to eeprom the calibration values of a successful calibration. 

### Benefits

Easy for users. 
Less support.

### Related Issues

#20970 
