### PR TITLE
fix DOGLCD_MOSI pin on FYSETC_MINI_12864 LCD

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -337,7 +337,7 @@
         #define DOGLCD_CS                  P0_18
         #define DOGLCD_A0                  P0_16
         #define DOGLCD_SCK                 P0_07
-        #define DOGLCD_MOSI                P1_20
+        #define DOGLCD_MOSI                P0_09
 
         #define LCD_BACKLIGHT_PIN          -1
 


### PR DESCRIPTION
### Description

With MOTHERBOARD BOARD_MKS_SGEN_L_V2 and a FYSETC_MINI_12864_2_1 LCD 
The LCD does not work. On investigation It was found that DOGLCD_MOSI was incorrectly set to P1_20 when it is meant to be  P0_09   (P1_20 is a LED on main board for this controller)

### Requirements

a MKS_SGEN_L_V2 motherboard and a  FYSETC_MINI_12864_2_1 LCD

### Benefits

LCD works as expected

### Related Issues

See talks with Viperian on marlin discord in general