### PR TITLE
Allow to redefine SERVO0_PIN on Creality Melzi

### DIFF
--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
@@ -68,8 +68,12 @@
 #define LCD_PINS_D4                           30  // ST9720 CLK
 
 #if ENABLED(BLTOUCH)
-  #define SERVO0_PIN                          27
-  #undef BEEPER_PIN
+  #ifndef SERVO0_PIN
+    #define SERVO0_PIN                        27
+  #endif
+  #if SERVO0_PIN == BEEPER_PIN
+    #undef BEEPER_PIN
+  #endif
 #elif ENABLED(FILAMENT_RUNOUT_SENSOR)
   #ifndef FIL_RUNOUT_PIN
     #define FIL_RUNOUT_PIN                    27


### PR DESCRIPTION
### Description

On Creality Melzi boards there is PIN-29 (aka Ext-A2) which can be also used to drive servos.
So, to get working bltouch and still be able to use beeper it should be ability to redefine `SERVO0_PIN` in config.

### Requirements


### Benefits

More flexibility for wiring bltouch.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
