### PR TITLE
Add a check that PIO env set to one of the options in pins.h

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -511,7 +511,7 @@
 #elif MB(BTT_SKR_E3_DIP)
   #include "stm32f1/pins_BTT_SKR_E3_DIP.h"      // STM32F1                                env:STM32F103RE_btt env:STM32F103RE_btt_USB env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(BTT_SKR_CR6)
-  #include "stm32f1/pins_BTT_SKR_CR6.h"         // STM32F1                                env:STM32F103RC_btt_512K_USB env:STM32F103RC_btt_USB
+  #include "stm32f1/pins_BTT_SKR_CR6.h"         // STM32F1                                env:STM32F103RC_btt_512K_USB env:STM32F103RE_btt_USB
 #elif MB(JGAURORA_A5S_A1)
   #include "stm32f1/pins_JGAURORA_A5S_A1.h"     // STM32F1                                env:jgaurora_a5s_a1
 #elif MB(FYSETC_AIO_II)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -511,7 +511,7 @@
 #elif MB(BTT_SKR_E3_DIP)
   #include "stm32f1/pins_BTT_SKR_E3_DIP.h"      // STM32F1                                env:STM32F103RE_btt env:STM32F103RE_btt_USB env:STM32F103RC_btt env:STM32F103RC_btt_512K env:STM32F103RC_btt_USB env:STM32F103RC_btt_512K_USB
 #elif MB(BTT_SKR_CR6)
-  #include "stm32f1/pins_BTT_SKR_CR6.h"         // STM32F1                                env:STM32F103RC_btt_512K_USB
+  #include "stm32f1/pins_BTT_SKR_CR6.h"         // STM32F1                                env:STM32F103RC_btt_512K_USB env:STM32F103RC_btt_USB
 #elif MB(JGAURORA_A5S_A1)
   #include "stm32f1/pins_JGAURORA_A5S_A1.h"     // STM32F1                                env:jgaurora_a5s_a1
 #elif MB(FYSETC_AIO_II)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -175,7 +175,7 @@
 #elif MB(Z_BOLT_X_SERIES)
   #include "ramps/pins_Z_BOLT_X_SERIES.h"       // ATmega2560                             env:mega2560
 #elif MB(TT_OSCAR)
-  #include "ramps/pins_TT_OSCAR.h"              // ATmega2560                             env:mega2560
+  #include "ramps/pins_TT_OSCAR.h"              // ATmega2560                             env:mega2560 env:mega1280
 #elif MB(TANGO)
   #include "ramps/pins_TANGO.h"                 // ATmega2560                             env:mega2560
 #elif MB(MKS_GEN_L_V2)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -479,9 +479,9 @@
 #elif MB(MKS_ROBIN_MINI)
   #include "stm32f1/pins_MKS_ROBIN_MINI.h"      // STM32F1                                env:mks_robin_mini
 #elif MB(MKS_ROBIN_NANO)
-  #include "stm32f1/pins_MKS_ROBIN_NANO.h"      // STM32F1                                env:mks_robin_nano35
+  #include "stm32f1/pins_MKS_ROBIN_NANO.h"      // STM32F1                                env:mks_robin_nano35 env:mks_robin_nano35_stm32
 #elif MB(MKS_ROBIN_NANO_V2)
-  #include "stm32f1/pins_MKS_ROBIN_NANO_V2.h"   // STM32F1                                env:mks_robin_nano35
+  #include "stm32f1/pins_MKS_ROBIN_NANO_V2.h"   // STM32F1                                env:mks_robin_nano35 env:mks_robin_nano35_stm32
 #elif MB(MKS_ROBIN_LITE)
   #include "stm32f1/pins_MKS_ROBIN_LITE.h"      // STM32F1                                env:mks_robin_lite
 #elif MB(MKS_ROBIN_LITE3)

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -377,7 +377,7 @@ def get_starting_env(board_name_full):
   env_B = ''
   env_C = ''
 
-  board_name = board_name_full[6:]  # only use the part after "BOARD_" since we're searching the pins.h file
+  board_name = '('+board_name_full[6:]+')'  # only use the part after "BOARD_" since we're searching the pins.h file
   pins_h = pins_h.split('\n')
   environment = ''
   board_line = ''

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -322,35 +322,7 @@ def check_configfile_locations():
 				err = 'ERROR: Config files found in directory ' + str(p) + '. Please move them into the Marlin subdirectory.'
 				raise SystemExit(err)
 
-# Get the board being built from the Configuration.h file
-#   return: board name
-def get_board_name():
-  board_name = ''
-  # get board name
-
-  with open('Marlin/Configuration.h', 'r') as myfile:
-    Configuration_h = myfile.read()
-
-  Configuration_h = Configuration_h.split('\n')
-  Marlin_ver = 0  # set version to invalid number
-  for lines in Configuration_h:
-    board = lines.find(' BOARD_') + 1
-    motherboard = lines.find(' MOTHERBOARD ') + 1
-    define = lines.find('#define ')
-    comment = lines.find('//')
-    if (comment == -1 or comment > board) and \
-      board > motherboard and \
-      motherboard > define and \
-      define >= 0 :
-      spaces = lines.find(' ', board)  # find the end of the board substring
-      if spaces == -1:
-        board_name = lines[board:]
-      else:
-        board_name = lines[board:spaces]
-      break
-
-  return board_name
-
+#
 # extract first environment name found after the start position
 #   return: environment name and position to start the next search from
 def get_env_from_line(line, start_position):
@@ -365,7 +337,9 @@ def get_env_from_line(line, start_position):
       env = line[env_position + 4:]  # at the end of the line
   return env, next_position
 
+#
 # scan pins.h for board name and return the environment(s) found
+#
 def get_starting_env(board_name_full):
   # get environment starting point
 
@@ -405,33 +379,12 @@ def get_starting_env(board_name_full):
       break
   return env_A, env_B, env_C
 
-def check_multiple_motherboards():
-  motherboard_count = 0
-  with open('Marlin/Configuration.h', 'r') as myfile:
-    Configuration_h = myfile.read()
-
-  Configuration_h = Configuration_h.split('\n')
-  for lines in Configuration_h:
-    board = lines.find(' BOARD_') + 1
-    motherboard = lines.find(' MOTHERBOARD ') + 1
-    define = lines.find('#define ')
-    comment = lines.find('//')
-    if (comment == -1 or comment > board) and \
-      board > motherboard and \
-      motherboard > define and \
-      define >= 0 :
-      motherboard_count += 1
-  if motherboard_count == 1: return False
-  else: return True
-
 def check_suitable_env():
-  board_name = ''
   env_A = ''
   env_B = ''
   env_C = ''
-  if check_multiple_motherboards():
-    return # abort when mutiple #define MOTHERBOARD is detected, to complicated
-  board_name = get_board_name()
+  load_marlin_features()
+  board_name = env['MARLIN_FEATURES']['MOTHERBOARD']
   env_A, env_B, env_C = get_starting_env(board_name)
 
   if env['PIOENV'] in [env_A, env_B, env_C]:

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -377,7 +377,7 @@ def get_starting_env(board_name_full):
   env_B = ''
   env_C = ''
 
-  board_name = '('+board_name_full[6:]+')'  # only use the part after "BOARD_" since we're searching the pins.h file
+  board_name = "[( ]"+board_name_full[6:]+"[,)]" # only use the part after "BOARD_" since we're searching the pins.h file
   pins_h = pins_h.split('\n')
   environment = ''
   board_line = ''
@@ -393,11 +393,10 @@ def get_starting_env(board_name_full):
       list_start_found = True
     if list_start_found == False:  # skip lines until find start of CPU list
       continue
-    board = lines.find(board_name)
     comment_start = lines.find('// ')
     cpu_A_loc = comment_start
     cpu_B_loc = 0
-    if board > 0:  # need to look at the next line for environment info
+    if re.search(board_name,lines):
       cpu_line = pins_h[i]
       comment_start = cpu_line.find('// ')
       env_A, next_position = get_env_from_line(cpu_line, comment_start)  # get name of environment & start of search for next

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -405,11 +405,32 @@ def get_starting_env(board_name_full):
       break
   return env_A, env_B, env_C
 
+def check_multiple_motherboards():
+  motherboard_count = 0
+  with open('Marlin/Configuration.h', 'r') as myfile:
+    Configuration_h = myfile.read()
+
+  Configuration_h = Configuration_h.split('\n')
+  for lines in Configuration_h:
+    board = lines.find(' BOARD_') + 1
+    motherboard = lines.find(' MOTHERBOARD ') + 1
+    define = lines.find('#define ')
+    comment = lines.find('//')
+    if (comment == -1 or comment > board) and \
+      board > motherboard and \
+      motherboard > define and \
+      define >= 0 :
+      motherboard_count += 1
+  if motherboard_count == 1: return False
+  else: return True
+
 def check_suitable_env():
   board_name = ''
   env_A = ''
   env_B = ''
   env_C = ''
+  if check_multiple_motherboards():
+    return # abort when mutiple #define MOTHERBOARD is detected, to complicated
   board_name = get_board_name()
   env_A, env_B, env_C = get_starting_env(board_name)
 


### PR DESCRIPTION
### Description

NB much code cloned from buildroot/share/vscode/auto_build.py

Add a routine check_suitable_env to common-dependencies.py 
The routine checks that the selected build environment (either in paltformio or via command line) 
is a valid option from the list of env's in pins.h for the selected motherboard.

EG if you select MOTHERBOARD BOARD_RAMBO, but leave the build env set to mega2560, this will build, but will not work correctly. With  check_suitable_env PlatformIO will now stop with the error
`You have MOTHERBOARD set to BOARD_RAMBO, please use default_envs = rambo
`

### Requirements

A invalid MOTHERBOARD and default_envs combination 

### Benefits

Less confused users

### Related Issues
Invalid bug report due to user error Issue: https://github.com/MarlinFirmware/Marlin/issues/21000
