### PR TITLE
Added tramming sanity checks

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -797,7 +797,7 @@
 //#define ASSISTED_TRAMMING
 #if ENABLED(ASSISTED_TRAMMING)
 
-  // Define positions for probing points, use the hotend as reference not the sensor.
+  // Define positions for probing points, use the sensor as reference.
   #define TRAMMING_POINT_XY { {  20, 20 }, { 200,  20 }, { 200, 200 }, { 20, 200 } }
 
   // Define positions names for probing points.

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -60,11 +60,14 @@ static PGM_P const tramming_point_name[] PROGMEM = {
 
 #define G35_PROBE_COUNT COUNT(screws_tilt_adjust_pos)
 
+static_assert(G35_PROBE_COUNT > 2, "TRAMMING_POINT_XY requires at least 3 XY positions.");
+static_assert(G35_PROBE_COUNT==COUNT(tramming_point_name), "TRAMMING_POINT_XY must have the same number of positions as TRAMMING_POINT_NAMES.");
+
 #if !WITHIN(TRAMMING_SCREW_THREAD, 30, 51) || TRAMMING_SCREW_THREAD % 10 > 1
   #error "TRAMMING_SCREW_THREAD must be equal to 30, 31, 40, 41, 50, or 51."
 #endif
 
-static_assert(G35_PROBE_COUNT > 2, "TRAMMING_POINT_XY requires at least 3 XY positions.");
+
 
 /**
  * G35: Read bed corners to help adjust bed screws

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2132,6 +2132,33 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
   #error "ASSISTED_TRAMMING requires a bed probe."
 #endif
 
+#if ENABLED(ASSISTED_TRAMMING) 
+  constexpr xy_pos_t sanity_tramming_points[] = TRAMMING_POINT_XY;
+  static_assert(COUNT(sanity_tramming_points) > 2, "TRAMMING_POINT_XY requires at least 3 XY positions.");
+
+  constexpr float sanity_tramming_nozzle_to_probe_offset[] = NOZZLE_TO_PROBE_OFFSET;
+  constexpr float sanity_tramming_x_min_pos=X_MIN_POS+sanity_tramming_nozzle_to_probe_offset[0];
+  constexpr float sanity_tramming_x_max_pos=X_MAX_POS+sanity_tramming_nozzle_to_probe_offset[0];
+  constexpr float sanity_tramming_y_min_pos=Y_MIN_POS+sanity_tramming_nozzle_to_probe_offset[1];
+  constexpr float sanity_tramming_y_max_pos=Y_MAX_POS+sanity_tramming_nozzle_to_probe_offset[1];
+
+  static_assert(WITHIN(sanity_tramming_points[0].x, sanity_tramming_x_min_pos, sanity_tramming_x_max_pos), "TRAMMING_POINT_1 is out of bounds (X_MIN_POS, X_MAX_POS).");
+  static_assert(WITHIN(sanity_tramming_points[0].x, sanity_tramming_y_min_pos, sanity_tramming_y_max_pos), "TRAMMING_POINT_1 is out of bounds (Y_MIN_POS, Y_MAX_POS).");
+  static_assert(WITHIN(sanity_tramming_points[1].x, sanity_tramming_x_min_pos, sanity_tramming_x_max_pos), "TRAMMING_POINT_2 is out of bounds (X_MIN_POS, X_MAX_POS).");
+  static_assert(WITHIN(sanity_tramming_points[1].x, sanity_tramming_y_min_pos, sanity_tramming_y_max_pos), "TRAMMING_POINT_2 is out of bounds (Y_MIN_POS, Y_MAX_POS).");
+  static_assert(WITHIN(sanity_tramming_points[2].x, sanity_tramming_x_min_pos, sanity_tramming_x_max_pos), "TRAMMING_POINT_3 is out of bounds (X_MIN_POS, X_MAX_POS).");
+  static_assert(WITHIN(sanity_tramming_points[2].x, sanity_tramming_y_min_pos, sanity_tramming_y_max_pos), "TRAMMING_POINT_3 is out of bounds (Y_MIN_POS, Y_MAX_POS).");
+  #ifdef TRAMMING_POINT_NAME_4
+    static_assert(WITHIN(sanity_tramming_points[3].x, sanity_tramming_x_min_pos, sanity_tramming_x_max_pos), "TRAMMING_POINT_4 is out of bounds (X_MIN_POS, X_MAX_POS).");
+    static_assert(WITHIN(sanity_tramming_points[3].x, sanity_tramming_y_min_pos, sanity_tramming_y_max_pos), "TRAMMING_POINT_4 is out of bounds (Y_MIN_POS, Y_MAX_POS).");
+    #ifdef TRAMMING_POINT_NAME_5
+      static_assert(WITHIN(sanity_tramming_points[4].x, sanity_tramming_x_min_pos, sanity_tramming_x_max_pos), "TRAMMING_POINT_5 is out of bounds (X_MIN_POS, X_MAX_POS).");
+      static_assert(WITHIN(sanity_tramming_points[4].x, sanity_tramming_y_min_pos, sanity_tramming_y_max_pos), "TRAMMING_POINT_5 is out of bounds (Y_MIN_POS, Y_MAX_POS).");
+    #endif
+  #endif
+#endif
+
+
 /**
  * G38 Probe Target
  */


### PR DESCRIPTION
### Description

- Corrected comment: tramming reference from nozzle to sensor. 
- Added sanity check for number of tramming point names versus tramming points
- Added sanity checks for tramming points

### Requirements

None

### Benefits

Corrected configuration comment and additional sanity checks. The sanity check will prevent users from entering wrong tramming coordinates, which otherwise would only be caught at run-time

### Configurations

#define ASSISTED_TRAMMING

### Related Issues

N/A
