### PR TITLE
Fix emergency parser for stm32f1

### DIFF
--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -84,7 +84,32 @@
 
 #if defined(SERIAL_USB) && !HAS_SD_HOST_DRIVE
   USBSerial SerialUSB;
-  DefaultSerial MSerial(false, SerialUSB);
+  DefaultSerial MSerial(true, SerialUSB);
+
+  #if ENABLED(EMERGENCY_PARSER)
+    #include "../libmaple/usb/stm32f1/usb_reg_map.h"
+    #include "libmaple/usb_cdcacm.h"
+    // The original callback is not called (no way to retrieve address).
+    // That callback detects a special STM32 reset sequence: this functionality is not essential
+    // as M997 achieves the same.
+    void my_rx_callback(unsigned int, void*) {
+      // max length of 16 is enough to contain all emergency commands
+      uint8 buf[16];
+
+      //rx is usbSerialPart.endpoints[2]
+      uint16 len = usb_get_ep_rx_count(USB_CDCACM_RX_ENDP);
+      uint32 total = usb_cdcacm_data_available();
+
+      if (len == 0 || total == 0 || total < len || total > sizeof(buf)/sizeof(buf[0]))
+        return;
+
+      // cannot get character by character due to bug in composite_cdcacm_peek_ex
+      len = usb_cdcacm_peek(buf, total);
+
+      for (uint32 i = 0; i < len; i++)
+        emergency_parser.update(MSerial.emergency_state, buf[i+total-len]);
+    }
+  #endif
 #endif
 
 uint16_t HAL_adc_result;
@@ -254,6 +279,10 @@ void HAL_init() {
   #endif
   #if HAS_SD_HOST_DRIVE
     MSC_SD_init();
+  #else 
+    #if ALL(SERIAL_USB, EMERGENCY_PARSER)
+        usb_cdcacm_set_hooks(USB_CDCACM_HOOK_RX, my_rx_callback);
+    #endif
   #endif
   #if PIN_EXISTS(USB_CONNECT)
     OUT_WRITE(USB_CONNECT_PIN, !USB_CONNECT_INVERTING);  // USB clear connection

--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -279,10 +279,8 @@ void HAL_init() {
   #endif
   #if HAS_SD_HOST_DRIVE
     MSC_SD_init();
-  #else 
-    #if ALL(SERIAL_USB, EMERGENCY_PARSER)
-        usb_cdcacm_set_hooks(USB_CDCACM_HOOK_RX, my_rx_callback);
-    #endif
+  #elif BOTH(SERIAL_USB, EMERGENCY_PARSER)
+    usb_cdcacm_set_hooks(USB_CDCACM_HOOK_RX, my_rx_callback);
   #endif
   #if PIN_EXISTS(USB_CONNECT)
     OUT_WRITE(USB_CONNECT_PIN, !USB_CONNECT_INVERTING);  // USB clear connection

--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -100,14 +100,14 @@
       uint16 len = usb_get_ep_rx_count(USB_CDCACM_RX_ENDP);
       uint32 total = usb_cdcacm_data_available();
 
-      if (len == 0 || total == 0 || total < len || total > sizeof(buf)/sizeof(buf[0]))
+      if (len == 0 || total == 0 || !WITHIN(total, len, COUNT(buf)))
         return;
 
       // cannot get character by character due to bug in composite_cdcacm_peek_ex
       len = usb_cdcacm_peek(buf, total);
 
       for (uint32 i = 0; i < len; i++)
-        emergency_parser.update(MSerial.emergency_state, buf[i+total-len]);
+        emergency_parser.update(MSerial.emergency_state, buf[i + total - len]);
     }
   #endif
 #endif

--- a/Marlin/src/HAL/STM32F1/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32F1/msc_sd.cpp
@@ -19,6 +19,7 @@
 
 #include "msc_sd.h"
 #include "SPI.h"
+#include "usb_reg_map.h"
 
 #define PRODUCT_ID 0x29
 
@@ -41,14 +42,27 @@ Serial0Type<USBCompositeSerial> MarlinCompositeSerial(true);
 #endif
 
 #if ENABLED(EMERGENCY_PARSER)
-  void (*real_rx_callback)(void);
 
-  void my_rx_callback(void) {
-    real_rx_callback();
-    int len = MarlinCompositeSerial.available();
-    while (len-- > 0) // >0 because available() may return a negative value
-      emergency_parser.update(MarlinCompositeSerial.emergency_state, MarlinCompositeSerial.peek());
-  }
+// The original callback is not called (no way to retrieve address).
+// That callback detects a special STM32 reset sequence: this functionality is not essential
+// as M997 achieves the same.
+void my_rx_callback(unsigned int, void*) {
+  // max length of 16 is enough to contain all emergency commands
+  uint8 buf[16];
+
+  //rx is usbSerialPart.endpoints[2]
+  uint16 len = usb_get_ep_rx_count(usbSerialPart.endpoints[2].address);
+  uint32 total = composite_cdcacm_data_available();
+
+  if (len == 0 || total == 0 || total < len || total > sizeof(buf)/sizeof(buf[0]))
+    return;
+
+  // cannot get character by character due to bug in composite_cdcacm_peek_ex
+  len = composite_cdcacm_peek(buf, total);
+
+  for (uint32 i = 0; i < len; i++)
+    emergency_parser.update(MarlinCompositeSerial.emergency_state, buf[i+total-len]);
+}
 #endif
 
 void MSC_SD_init() {
@@ -73,9 +87,7 @@ void MSC_SD_init() {
   MarlinCompositeSerial.registerComponent();
   USBComposite.begin();
   #if ENABLED(EMERGENCY_PARSER)
-    //rx is usbSerialPart.endpoints[2]
-    real_rx_callback = usbSerialPart.endpoints[2].callback;
-    usbSerialPart.endpoints[2].callback = my_rx_callback;
+  	composite_cdcacm_set_hooks(USBHID_CDCACM_HOOK_RX, my_rx_callback);
   #endif
 }
 

--- a/Marlin/src/HAL/STM32F1/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32F1/msc_sd.cpp
@@ -54,7 +54,7 @@ void my_rx_callback(unsigned int, void*) {
   uint16 len = usb_get_ep_rx_count(usbSerialPart.endpoints[2].address);
   uint32 total = composite_cdcacm_data_available();
 
-  if (len == 0 || total == 0 || total < len || total > sizeof(buf)/sizeof(buf[0]))
+  if (len == 0 || total == 0 || !WITHIN(total, len, COUNT(buf)))
     return;
 
   // cannot get character by character due to bug in composite_cdcacm_peek_ex


### PR DESCRIPTION
### Description

Fixes emergency parser support for stm32f1 when using USB Composite Serial and adds emergency parser support when using USB Serial.

### Requirements

Board using stm32f1. (Tested using Bigtreetech SKR Mini-E3 v1.2 with both USB Composite Serial and USB Serial.)

### Benefits

Adds support for emergency parser when using USB Serial and fixes support for USB Composite Serial.
The original changes (#19279, #19281) do not work (for me). The function ```MarlinCompositeSerial.peek()``` return multiple times the same character in: https://github.com/MarlinFirmware/Marlin/blob/5ee1087959f88dc60386ff3caa21e75d9e20b128/Marlin/src/HAL/STM32F1/msc_sd.cpp#L48

### Configurations

Use SKR Mini-E3 v1.2 example config

```#define EMERGENCY_PARSER```

For USB Composite Serial:
```#define USE_USB_COMPOSITE```


### Related Issues

Original implementation: #19279, #19281, Related issues: #19623
