### PR TITLE
Fix mini12864 v2.1 + psu control + neopixel backlight

### DIFF
--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -147,8 +147,8 @@ void LEDLights::set_color(const LEDColor &incol
   millis_t LEDLights::led_off_time; // = 0
 
   void LEDLights::update_timeout(const bool power_on) {
-    const millis_t ms = millis();
     if (lights_on) {
+      const millis_t ms = millis();
       if (power_on)
         reset_timeout(ms);
       else if (ELAPSED(ms, led_off_time))

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -148,10 +148,12 @@ void LEDLights::set_color(const LEDColor &incol
 
   void LEDLights::update_timeout(const bool power_on) {
     const millis_t ms = millis();
-    if (power_on)
-      reset_timeout(ms);
-    else if (ELAPSED(ms, led_off_time))
-      set_off();
+    if (lights_on) {
+      if (power_on)
+        reset_timeout(ms);
+      else if (ELAPSED(ms, led_off_time))
+        set_off();
+    }
   }
 
 #endif

--- a/Marlin/src/feature/leds/leds.h
+++ b/Marlin/src/feature/leds/leds.h
@@ -203,7 +203,7 @@ public:
     public:
       static inline void reset_timeout(const millis_t &ms) {
         led_off_time = ms + LED_BACKLIGHT_TIMEOUT;
-        if (!lights_on) set_default();
+        if (!lights_on) update();
       }
       static void update_timeout(const bool power_on);
   #endif

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -994,7 +994,7 @@ void MarlinUI::update() {
         refresh(LCDVIEW_REDRAW_NOW);
 
         #ifdef LED_BACKLIGHT_TIMEOUT
-          leds.reset_timeout(ms);
+          if (!powersupply_on) leds.reset_timeout(ms);
         #endif
       }
 

--- a/Marlin/src/lcd/menu/menu_led.cpp
+++ b/Marlin/src/lcd/menu/menu_led.cpp
@@ -122,6 +122,10 @@ void menu_led() {
 
   #if ENABLED(LED_CONTROL_MENU)
     editable.state = leds.lights_on;
+    #if ENABLED(PSU_CONTROL)
+      extern bool powersupply_on;
+      if (powersupply_on)
+    #endif
     EDIT_ITEM(bool, MSG_LEDS, &editable.state, leds.toggle);
     #if ENABLED(LED_COLOR_PRESETS)
       ACTION_ITEM(MSG_SET_LEDS_DEFAULT, leds.set_default);

--- a/Marlin/src/lcd/menu/menu_led.cpp
+++ b/Marlin/src/lcd/menu/menu_led.cpp
@@ -121,15 +121,20 @@ void menu_led() {
   BACK_ITEM(MSG_MAIN);
 
   #if ENABLED(LED_CONTROL_MENU)
-    editable.state = leds.lights_on;
     #if ENABLED(PSU_CONTROL)
       extern bool powersupply_on;
-      if (powersupply_on)
+    #else
+      static constexpr bool powersupply_on = true;
     #endif
-    EDIT_ITEM(bool, MSG_LEDS, &editable.state, leds.toggle);
+    if (powersupply_on) {
+      editable.state = leds.lights_on;
+      EDIT_ITEM(bool, MSG_LEDS, &editable.state, leds.toggle);
+    }
+
     #if ENABLED(LED_COLOR_PRESETS)
       ACTION_ITEM(MSG_SET_LEDS_DEFAULT, leds.set_default);
     #endif
+
     #if ENABLED(NEOPIXEL2_SEPARATE)
       editable.state = leds2.lights_on;
       EDIT_ITEM(bool, MSG_LEDS2, &editable.state, leds2.toggle);

--- a/Marlin/src/lcd/menu/menu_led.cpp
+++ b/Marlin/src/lcd/menu/menu_led.cpp
@@ -124,7 +124,7 @@ void menu_led() {
     #if ENABLED(PSU_CONTROL)
       extern bool powersupply_on;
     #else
-      static constexpr bool powersupply_on = true;
+      constexpr bool powersupply_on = true;
     #endif
     if (powersupply_on) {
       editable.state = leds.lights_on;


### PR DESCRIPTION
### Description

With FYSETC_MINI_12864_2_1 and PSU_CONTROL  lights on/off doesn't behave as it should'

Firstly there is some confusion here.
When PSU_CONTROL is enabled and power supply is off, It activates a 10 second timer. If you turn lights off they instantly come back on with any encoder moves. In this mode I removed the light On/Off menu as it just caused confusion.
Also in this mode when you move the encoder to bring back the back light it came back on but in the default colour, not the colour you started with. This is also fixed. 

When PSU_CONTROL and the power supply is on, the timer is disabled and you can now turn the lights on and off as intended.

### Requirements

FYSETC_MINI_12864_2_1 and PSU_CONTROL 

### Benefits

Works as expected

### Related Issues

Issue #20916