### PR TITLE
Fix probe preheat lowering temperatures

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -818,22 +818,6 @@
       #define TOTAL_PROBING MULTIPLE_PROBING
     #endif
   #endif
-  #if ENABLED(PREHEAT_BEFORE_PROBING)
-    #ifndef PROBING_NOZZLE_TEMP
-      #define PROBING_NOZZLE_TEMP 0
-    #endif
-    #ifndef PROBING_BED_TEMP
-      #define PROBING_BED_TEMP 0
-    #endif
-  #endif
-  #if ENABLED(PREHEAT_BEFORE_LEVELING)
-    #ifndef LEVELING_NOZZLE_TEMP
-      #define LEVELING_NOZZLE_TEMP 0
-    #endif
-    #ifndef LEVELING_BED_TEMP
-      #define LEVELING_BED_TEMP 0
-    #endif
-  #endif
 #else
   // Clear probe pin settings when no probe is selected
   #undef Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -358,15 +358,15 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     #endif
 
     #if ENABLED(WAIT_FOR_NOZZLE_HEAT)
-      const bool input_over_e_temp = in_target_e > thermalManager.degHotend(0);
       const uint16_t hotendPreheat = in_target_e > thermalManager.degTargetHotend(0) ? in_target_e : 0;
+      if (hotendPreheat) thermalManager.setTargetHotend(hotendPreheat, 0);
     #else
       constexpr uint16_t hotendPreheat = 0;
     #endif
 
     #if ENABLED(WAIT_FOR_BED_HEAT)
-      const bool input_over_bed_temp = in_target_bed > thermalManager.degBed();
       const uint16_t bedPreheat = in_target_bed > thermalManager.degTargetBed() ? in_target_bed : 0;
+      if (bedPreheat) thermalManager.setTargetBed(bedPreheat);
     #else
       constexpr uint16_t bedPreheat = 0;
     #endif
@@ -379,10 +379,8 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     if (bedPreheat) DEBUG_ECHOPAIR("bed (", bedPreheat, ")");
     DEBUG_EOL();
 
-    TERN_(WAIT_FOR_NOZZLE_HEAT, if (hotendPreheat)       thermalManager.setTargetHotend(hotendPreheat, 0));
-    TERN_(WAIT_FOR_BED_HEAT,    if (bedPreheat)          thermalManager.setTargetBed(bedPreheat));
-    TERN_(WAIT_FOR_NOZZLE_HEAT, if (input_over_e_temp)   thermalManager.wait_for_hotend(0));
-    TERN_(WAIT_FOR_BED_HEAT,    if (input_over_bed_temp) thermalManager.wait_for_bed_heating());
+    TERN_(WAIT_FOR_NOZZLE_HEAT, if (in_target_e > thermalManager.degHotend(0)) thermalManager.wait_for_hotend(0));
+    TERN_(WAIT_FOR_BED_HEAT,    if (in_target_bed > thermalManager.degBed())   thermalManager.wait_for_bed_heating());
   }
 
 #endif

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -365,7 +365,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
         DEBUG_ECHOPAIR("hotend (", hotendPreheat, ")");
         thermalManager.setTargetHotend(hotendPreheat, 0);
       }
-    #else
+    #elif ENABLED(WAIT_FOR_BED_HEAT)
       constexpr uint16_t hotendPreheat = 0;
     #endif
 

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -357,26 +357,27 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
       #define WAIT_FOR_BED_HEAT
     #endif
 
+    DEBUG_ECHOPGM("Preheating ");
+
     #if ENABLED(WAIT_FOR_NOZZLE_HEAT)
       const uint16_t hotendPreheat = in_target_e > thermalManager.degTargetHotend(0) ? in_target_e : 0;
-      if (hotendPreheat) thermalManager.setTargetHotend(hotendPreheat, 0);
+      if (hotendPreheat) {
+        DEBUG_ECHOPAIR("hotend (", hotendPreheat, ")");
+        thermalManager.setTargetHotend(hotendPreheat, 0);
+      }
     #else
       constexpr uint16_t hotendPreheat = 0;
     #endif
 
     #if ENABLED(WAIT_FOR_BED_HEAT)
       const uint16_t bedPreheat = in_target_bed > thermalManager.degTargetBed() ? in_target_bed : 0;
-      if (bedPreheat) thermalManager.setTargetBed(bedPreheat);
-    #else
-      constexpr uint16_t bedPreheat = 0;
+      if (bedPreheat) {
+        if (hotendPreheat) DEBUG_ECHOPGM(" and ");
+        DEBUG_ECHOPAIR("bed (", bedPreheat, ")");
+        thermalManager.setTargetBed(bedPreheat);
+      }
     #endif
 
-    DEBUG_ECHOPGM("Preheating ");
-    if (hotendPreheat) {
-      DEBUG_ECHOPAIR("hotend (", hotendPreheat, ")");
-      if (bedPreheat) DEBUG_ECHOPGM(" and ");
-    }
-    if (bedPreheat) DEBUG_ECHOPAIR("bed (", bedPreheat, ")");
     DEBUG_EOL();
 
     TERN_(WAIT_FOR_NOZZLE_HEAT, if (in_target_e > thermalManager.degHotend(0)) thermalManager.wait_for_hotend(0));

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -347,8 +347,8 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     if (bedPreheat) DEBUG_ECHOPAIR("bed (", bedPreheat, ") ");
     DEBUG_EOL();
 
-    TERN_(WAIT_FOR_NOZZLE_HEAT, if (hotendPreheat) thermalManager.setTargetHotend(hotendPreheat, 0));
-    TERN_(WAIT_FOR_BED_HEAT,    if (bedPreheat)    thermalManager.setTargetBed(bedPreheat));
+    TERN_(WAIT_FOR_NOZZLE_HEAT, if (hotendPreheat > thermalManager.degTargetHotend(0)) thermalManager.setTargetHotend(hotendPreheat, 0));
+    TERN_(WAIT_FOR_BED_HEAT,    if (bedPreheat > thermalManager.degTargetBed())        thermalManager.setTargetBed(bedPreheat));
     TERN_(WAIT_FOR_NOZZLE_HEAT, if (hotendPreheat) thermalManager.wait_for_hotend(0));
     TERN_(WAIT_FOR_BED_HEAT,    if (bedPreheat)    thermalManager.wait_for_bed_heating());
   }

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -349,7 +349,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
    *  - If a preheat input is higher than the current target, raise the target temperature.
    *  - If a preheat input is higher than the current temperature, wait for stabilization.
    */
-  void Probe::preheat_for_probing(const uint16_t in_target_e, const uint16_t in_target_bed) {
+  void Probe::preheat_for_probing(const uint16_t hotend_temp, const uint16_t bed_temp) {
     #if HAS_HOTEND && (PROBING_NOZZLE_TEMP || LEVELING_NOZZLE_TEMP)
       #define WAIT_FOR_NOZZLE_HEAT
     #endif
@@ -360,7 +360,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     DEBUG_ECHOPGM("Preheating ");
 
     #if ENABLED(WAIT_FOR_NOZZLE_HEAT)
-      const uint16_t hotendPreheat = in_target_e > thermalManager.degTargetHotend(0) ? in_target_e : 0;
+      const uint16_t hotendPreheat = hotend_temp > thermalManager.degTargetHotend(0) ? hotend_temp : 0;
       if (hotendPreheat) {
         DEBUG_ECHOPAIR("hotend (", hotendPreheat, ")");
         thermalManager.setTargetHotend(hotendPreheat, 0);
@@ -370,7 +370,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     #endif
 
     #if ENABLED(WAIT_FOR_BED_HEAT)
-      const uint16_t bedPreheat = in_target_bed > thermalManager.degTargetBed() ? in_target_bed : 0;
+      const uint16_t bedPreheat = bed_temp > thermalManager.degTargetBed() ? bed_temp : 0;
       if (bedPreheat) {
         if (hotendPreheat) DEBUG_ECHOPGM(" and ");
         DEBUG_ECHOPAIR("bed (", bedPreheat, ")");
@@ -380,8 +380,8 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
 
     DEBUG_EOL();
 
-    TERN_(WAIT_FOR_NOZZLE_HEAT, if (in_target_e > thermalManager.degHotend(0)) thermalManager.wait_for_hotend(0));
-    TERN_(WAIT_FOR_BED_HEAT,    if (in_target_bed > thermalManager.degBed())   thermalManager.wait_for_bed_heating());
+    TERN_(WAIT_FOR_NOZZLE_HEAT, if (hotend_temp > thermalManager.degHotend(0)) thermalManager.wait_for_hotend(0));
+    TERN_(WAIT_FOR_BED_HEAT,    if (bed_temp > thermalManager.degBed())        thermalManager.wait_for_bed_heating());
   }
 
 #endif

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -380,8 +380,8 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
 
     DEBUG_EOL();
 
-    TERN_(WAIT_FOR_NOZZLE_HEAT, if (hotend_temp > thermalManager.degHotend(0)) thermalManager.wait_for_hotend(0));
-    TERN_(WAIT_FOR_BED_HEAT,    if (bed_temp > thermalManager.degBed())        thermalManager.wait_for_bed_heating());
+    TERN_(WAIT_FOR_NOZZLE_HEAT, if (hotend_temp > thermalManager.degHotend(0) + (TEMP_WINDOW)) thermalManager.wait_for_hotend(0));
+    TERN_(WAIT_FOR_BED_HEAT,    if (bed_temp > thermalManager.degBed() + (TEMP_BED_WINDOW))    thermalManager.wait_for_bed_heating());
   }
 
 #endif


### PR DESCRIPTION
### Description

Only set nozzle & bed temperature for probe/level preheat higher, never lower.

### Requirements

`PREHEAT_BEFORE_LEVELING` or `PREHEAT_BEFORE_PROBING` enabled

### Benefits

Prevents temperature being lowered during a preheat for probing/levelling.

### Configurations

[Archive.zip](https://github.com/MarlinFirmware/Marlin/files/5953092/Archive.zip)

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/21030

-- Note, this is my first contribution, I tried to follow the contributing guidelines but if I made any mistakes do let me know!

Thanks