### PR TITLE
Fix the reported unit in the delay test code

### DIFF
--- a/Marlin/src/HAL/shared/Delay.cpp
+++ b/Marlin/src/HAL/shared/Delay.cpp
@@ -108,10 +108,13 @@
   #if ENABLED(MARLIN_DEV_MODE)
     void dump_delay_accuracy_check()
     {
-      auto report_call_time = [](PGM_P const name, const uint32_t cycles, const uint32_t total, const bool do_flush=true) {
+      auto report_call_time = [](PGM_P const name, PGM_P const unit, const uint32_t cycles, const uint32_t total, const bool do_flush=true) {
         SERIAL_ECHOPGM("Calling ");
         serialprintPGM(name);
-        SERIAL_ECHOLNPAIR(" for ", cycles, "cycles took: ", total, "cycles");
+        SERIAL_ECHOLNPAIR(" for ", cycles);
+        serialprintPGM(unit);
+        SERIAL_ECHOLNPAIR(" took: ", total);
+        serialprintPGM(unit);
         if (do_flush) SERIAL_FLUSH();
       };
 
@@ -123,41 +126,41 @@
       constexpr uint32_t testValues[] = { 1, 5, 10, 20, 50, 100, 150, 200, 350, 500, 750, 1000 };
       for (auto i : testValues) {
         s = micros(); DELAY_US(i); e = micros();
-        report_call_time(PSTR("delay"), i, e - s);
+        report_call_time(PSTR("delay"), PSTR("us"), i, e - s);
       }
 
       if (HW_REG(_DWT_CTRL)) {
         for (auto i : testValues) {
           s = HW_REG(_DWT_CYCCNT); DELAY_CYCLES(i); e = HW_REG(_DWT_CYCCNT);
-          report_call_time(PSTR("delay"), i, e - s);
+          report_call_time(PSTR("runtime delay"), PSTR("cycles"), i, e - s);
         }
 
         // Measure the delay to call a real function compared to a function pointer
         s = HW_REG(_DWT_CYCCNT); delay_dwt(1); e = HW_REG(_DWT_CYCCNT);
-        report_call_time(PSTR("delay_dwt"), 1, e - s);
+        report_call_time(PSTR("delay_dwt"), PSTR("cycles"), 1, e - s);
 
         static PGMSTR(dcd, "DELAY_CYCLES directly ");
 
         s = HW_REG(_DWT_CYCCNT); DELAY_CYCLES( 1); e = HW_REG(_DWT_CYCCNT);
-        report_call_time(dcd,  1, e - s, false);
+        report_call_time(dcd, PSTR("cycles"),  1, e - s, false);
 
         s = HW_REG(_DWT_CYCCNT); DELAY_CYCLES( 5); e = HW_REG(_DWT_CYCCNT);
-        report_call_time(dcd,  5, e - s, false);
+        report_call_time(dcd, PSTR("cycles"),  5, e - s, false);
 
         s = HW_REG(_DWT_CYCCNT); DELAY_CYCLES(10); e = HW_REG(_DWT_CYCCNT);
-        report_call_time(dcd, 10, e - s, false);
+        report_call_time(dcd, PSTR("cycles"), 10, e - s, false);
 
         s = HW_REG(_DWT_CYCCNT); DELAY_CYCLES(20); e = HW_REG(_DWT_CYCCNT);
-        report_call_time(dcd, 20, e - s, false);
+        report_call_time(dcd, PSTR("cycles"), 20, e - s, false);
 
         s = HW_REG(_DWT_CYCCNT); DELAY_CYCLES(50); e = HW_REG(_DWT_CYCCNT);
-        report_call_time(dcd, 50, e - s, false);
+        report_call_time(dcd, PSTR("cycles"), 50, e - s, false);
 
         s = HW_REG(_DWT_CYCCNT); DELAY_CYCLES(100); e = HW_REG(_DWT_CYCCNT);
-        report_call_time(dcd, 100, e - s, false);
+        report_call_time(dcd, PSTR("cycles"), 100, e - s, false);
 
         s = HW_REG(_DWT_CYCCNT); DELAY_CYCLES(200); e = HW_REG(_DWT_CYCCNT);
-        report_call_time(dcd, 200, e - s, false);
+        report_call_time(dcd, PSTR("cycles"), 200, e - s, false);
       }
     }
   #endif // MARLIN_DEV_MODE

--- a/Marlin/src/HAL/shared/Delay.cpp
+++ b/Marlin/src/HAL/shared/Delay.cpp
@@ -106,8 +106,7 @@
   }
 
   #if ENABLED(MARLIN_DEV_MODE)
-    void dump_delay_accuracy_check()
-    {
+    void dump_delay_accuracy_check() {
       auto report_call_time = [](PGM_P const name, PGM_P const unit, const uint32_t cycles, const uint32_t total, const bool do_flush=true) {
         SERIAL_ECHOPGM("Calling ");
         serialprintPGM(name);


### PR DESCRIPTION
### Description

Just a simple fix so that reported unit in the delay dump report is correct (previously, it was reported as cycles, while some were µs). I'm also making a difference between runtime computed delay cycles and compile-time computed delays.


### Requirements

None
### Benefits

Being correct for what's displayed.

### Configurations

ARM board

### Related Issues

None