### PR TITLE
Improve the debug symbol generated so we have macro value too

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -212,7 +212,7 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
-build_flags        = -fmax-errors=5 -g -D__MARLIN_FIRMWARE__ -fmerge-constants
+build_flags        = -fmax-errors=5 -g3 -D__MARLIN_FIRMWARE__ -fmerge-constants
 lib_deps           =
 
 #


### PR DESCRIPTION
### Description

As the title say. `-g3` adds macro symbols to gdb, and Marlin makes use of a lot of those. This does not impact binary size.

### Requirements

None

### Benefits

```
$ EXTRA_CFLAGS="-g" make

(gdb) p/x MEMFAULT_EXAMPLE_MACRO
No symbol "MEMFAULT_EXAMPLE_MACRO" in current context.


$ EXTRA_CFLAGS="-g3" make

(gdb) p/x MEMFAULT_EXAMPLE_MACRO
$1 = 0x4d
```

### Configurations

None, should work with all gcc version used in Marlin

### Related Issues

None, but see [here](https://interrupt.memfault.com/blog/best-and-worst-gcc-clang-compiler-flags) for the idea