### PR TITLE
MEGA 2560 can be used with SMART RAMPS 1.4

### DIFF
--- a/Marlin/src/pins/sam/pins_RAMPS_SMART.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_SMART.h
@@ -80,7 +80,7 @@
 #define EEPROM_PAGE_SIZE                      64  // page write buffer size
 #define EEPROM_PAGE_WRITE_TIME                 7  // page write time in milliseconds (docs say 5ms but that is too short)
 
-#define TWI_CLOCK_FREQ                       400000
+#define TWI_CLOCK_FREQ                    400000
 #define EEPROM_ADDRSZ_BYTES TWI_MMR_IADRSZ_2_BYTE // TWI_MMR_IADRSZ_1_BYTE for 1 byte, or TWI_MMR_IADRSZ_2_BYTE for 2 byte
 #define EEPROM_AVAILABLE              EEPROM_I2C
 

--- a/Marlin/src/pins/sam/pins_RAMPS_SMART.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_SMART.h
@@ -60,8 +60,8 @@
  * (Search the web for "Arduino DUE Board Pinout" to see the correct header.)
  */
 
-#if NOT_TARGET(__SAM3X8E__)
-  #error "Oops! Select 'Arduino Due' in 'Tools > Board.'"
+#if NOT_TARGET(__SAM3X8E__,__AVR_ATmega2560__)
+  #error "Oops! Select 'Arduino Due'  or 'Mega 2560' in 'Tools > Board.'"
 #endif
 
 #define BOARD_INFO_NAME "RAMPS-SMART"
@@ -71,6 +71,17 @@
 // I2C EEPROM with 4K of space
 #define I2C_EEPROM
 #define MARLIN_EEPROM_SIZE                0x1000
+
+#define SDA_PIN 			20
+#define SCL_PIN 			21
+// see eeprom device data sheet for the following values, these are for 24xx256
+#define EEPROM_SERIAL_ADDR      0x50   // 7 bit i2c address (without R/W bit)
+#define EEPROM_PAGE_SIZE        64     // page write buffer size
+#define EEPROM_PAGE_WRITE_TIME  7      // page write time in milliseconds (docs say 5ms but that is too short)
+// TWI_MMR_IADRSZ_1_BYTE for 1 byte, or TWI_MMR_IADRSZ_2_BYTE for 2 byte
+#define TWI_CLOCK_FREQ          400000
+#define EEPROM_ADDRSZ_BYTES     TWI_MMR_IADRSZ_2_BYTE
+#define EEPROM_AVAILABLE EEPROM_I2C
 
 #define RESET_PIN                             42  // Resets the board if the jumper is attached
 

--- a/Marlin/src/pins/sam/pins_RAMPS_SMART.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_SMART.h
@@ -79,9 +79,9 @@
 #define EEPROM_SERIAL_ADDR                  0x50  // 7 bit i2c address (without R/W bit)
 #define EEPROM_PAGE_SIZE                      64  // page write buffer size
 #define EEPROM_PAGE_WRITE_TIME                 7  // page write time in milliseconds (docs say 5ms but that is too short)
-// TWI_MMR_IADRSZ_1_BYTE for 1 byte, or TWI_MMR_IADRSZ_2_BYTE for 2 byte
+
 #define TWI_CLOCK_FREQ                       400000
-#define EEPROM_ADDRSZ_BYTESTWI_MMR_IADRSZ_2_BYTE
+#define EEPROM_ADDRSZ_BYTES TWI_MMR_IADRSZ_2_BYTE // TWI_MMR_IADRSZ_1_BYTE for 1 byte, or TWI_MMR_IADRSZ_2_BYTE for 2 byte
 #define EEPROM_AVAILABLE              EEPROM_I2C
 
 #define RESET_PIN                             42  // Resets the board if the jumper is attached

--- a/Marlin/src/pins/sam/pins_RAMPS_SMART.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_SMART.h
@@ -72,17 +72,17 @@
 #define I2C_EEPROM
 #define MARLIN_EEPROM_SIZE                0x1000
 
-#define SDA_PIN 			20
-#define SCL_PIN 			21
+#define SDA_PIN                               20
+#define SCL_PIN                               21
 
 // See EEPROM device datasheet for the following values. These are for 24xx256
-#define EEPROM_SERIAL_ADDR      0x50   // 7 bit i2c address (without R/W bit)
-#define EEPROM_PAGE_SIZE        64     // page write buffer size
-#define EEPROM_PAGE_WRITE_TIME  7      // page write time in milliseconds (docs say 5ms but that is too short)
+#define EEPROM_SERIAL_ADDR                  0x50  // 7 bit i2c address (without R/W bit)
+#define EEPROM_PAGE_SIZE                      64  // page write buffer size
+#define EEPROM_PAGE_WRITE_TIME                 7  // page write time in milliseconds (docs say 5ms but that is too short)
 // TWI_MMR_IADRSZ_1_BYTE for 1 byte, or TWI_MMR_IADRSZ_2_BYTE for 2 byte
-#define TWI_CLOCK_FREQ          400000
-#define EEPROM_ADDRSZ_BYTES     TWI_MMR_IADRSZ_2_BYTE
-#define EEPROM_AVAILABLE EEPROM_I2C
+#define TWI_CLOCK_FREQ                       400000
+#define EEPROM_ADDRSZ_BYTESTWI_MMR_IADRSZ_2_BYTE
+#define EEPROM_AVAILABLE              EEPROM_I2C
 
 #define RESET_PIN                             42  // Resets the board if the jumper is attached
 
@@ -109,6 +109,7 @@
 //
 // LCD / Controller
 //
+
 // Support for AZSMZ 12864 LCD with SD Card 3D printer smart controller control panel
 #if ENABLED(AZSMZ_12864)
   #define BEEPER_PIN                          66  // Smart RAMPS 1.42 pinout diagram on RepRap WIKI erroneously says this should be pin 65

--- a/Marlin/src/pins/sam/pins_RAMPS_SMART.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_SMART.h
@@ -60,8 +60,8 @@
  * (Search the web for "Arduino DUE Board Pinout" to see the correct header.)
  */
 
-#if NOT_TARGET(__SAM3X8E__,__AVR_ATmega2560__)
-  #error "Oops! Select 'Arduino Due'  or 'Mega 2560' in 'Tools > Board.'"
+#if NOT_TARGET(__SAM3X8E__, __AVR_ATmega2560__)
+  #error "Oops! Select 'Arduino Due' or 'Mega 2560' in 'Tools > Board.'"
 #endif
 
 #define BOARD_INFO_NAME "RAMPS-SMART"
@@ -74,7 +74,8 @@
 
 #define SDA_PIN 			20
 #define SCL_PIN 			21
-// see eeprom device data sheet for the following values, these are for 24xx256
+
+// See EEPROM device datasheet for the following values. These are for 24xx256
 #define EEPROM_SERIAL_ADDR      0x50   // 7 bit i2c address (without R/W bit)
 #define EEPROM_PAGE_SIZE        64     // page write buffer size
 #define EEPROM_PAGE_WRITE_TIME  7      // page write time in milliseconds (docs say 5ms but that is too short)


### PR DESCRIPTION
### Description

The SMART RAMPS board works with both the Arduino DUE and Arduino MEGA 2560 boards.  The following PR enables that capability. 

### Requirements

Arduino MEGA 2560 (or equivalent clone), SMART Ramps + AZSMZ 12864 LCD (For Arduino Due Like RAMPS-FD or RADDS 3D print control panel control board.

### Benefits

The PR allows the use of the MEGA 2560 board with the SMART RAMPS board by removing the compiler directive that throws an pre-compiler exception.  It defines pins needed to use the EEPROM on the SMART RAMPS board.

### Configurations

The commit in this link has the configuration used in testing. https://github.com/kpishere/Marlin/tree/itopie400%2B

PS: Sorry for the prior one from wrong branch!