### PR TITLE
[SAMD51] Fix extra serial compiling

### DIFF
--- a/Marlin/src/HAL/DUE/HAL.cpp
+++ b/Marlin/src/HAL/DUE/HAL.cpp
@@ -102,8 +102,10 @@ uint16_t HAL_adc_get_result() {
   return HAL_adc_result;
 }
 
-// Forward the default serial port
-DefaultSerial MSerial(false, Serial);
+// Forward the default serial ports
+#if ANY_SERIAL_IS(0)
+  DefaultSerial MSerial(false, Serial);
+#endif
 #if ANY_SERIAL_IS(1)
   DefaultSerial1 MSerial1(false, Serial1);
 #endif

--- a/Marlin/src/HAL/DUE/HAL.cpp
+++ b/Marlin/src/HAL/DUE/HAL.cpp
@@ -104,9 +104,14 @@ uint16_t HAL_adc_get_result() {
 
 // Forward the default serial port
 DefaultSerial MSerial(false, Serial);
-
-DefaultSerial1 MSerial1(false, Serial1);
-DefaultSerial2 MSerial2(false, Serial2);
-DefaultSerial3 MSerial3(false, Serial3);
+#if ANY_SERIAL_IS(1)
+  DefaultSerial1 MSerial1(false, Serial1);
+#endif
+#if ANY_SERIAL_IS(2)
+  DefaultSerial2 MSerial2(false, Serial2);
+#endif
+#if ANY_SERIAL_IS(3)
+  DefaultSerial3 MSerial3(false, Serial3);
+#endif
 
 #endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/HAL/DUE/HAL.h
+++ b/Marlin/src/HAL/DUE/HAL.h
@@ -37,12 +37,12 @@
 #include <stdint.h>
 
 #include "../../core/serial_hook.h"
-typedef ForwardSerial0Type< decltype(Serial) > DefaultSerial;
-extern DefaultSerial MSerial;
 
+typedef ForwardSerial0Type< decltype(Serial) > DefaultSerial;
 typedef ForwardSerial0Type< decltype(Serial1) > DefaultSerial1;
 typedef ForwardSerial0Type< decltype(Serial2) > DefaultSerial2;
 typedef ForwardSerial0Type< decltype(Serial3) > DefaultSerial3;
+extern DefaultSerial MSerial;
 extern DefaultSerial1 MSerial1;
 extern DefaultSerial2 MSerial2;
 extern DefaultSerial3 MSerial3;

--- a/Marlin/src/HAL/SAMD51/HAL.cpp
+++ b/Marlin/src/HAL/SAMD51/HAL.cpp
@@ -27,6 +27,15 @@
 #ifdef ADAFRUIT_GRAND_CENTRAL_M4
   DefaultSerial MSerial(false, Serial);
   DefaultSerial1 MSerial1(false, Serial1);
+  #if ANY_SERIAL_IS(1)
+    DefaultSerial2 MSerial2(false, Serial2);
+  #endif
+  #if ANY_SERIAL_IS(2)
+    DefaultSerial3 MSerial3(false, Serial3);
+  #endif
+  #if ANY_SERIAL_IS(3)
+    DefaultSerial4 MSerial4(false, Serial4);
+  #endif
 #endif
 
 // ------------------------

--- a/Marlin/src/HAL/SAMD51/HAL.cpp
+++ b/Marlin/src/HAL/SAMD51/HAL.cpp
@@ -25,8 +25,12 @@
 #include <wiring_private.h>
 
 #ifdef ADAFRUIT_GRAND_CENTRAL_M4
-  DefaultSerial MSerial(false, Serial);
-  DefaultSerial1 MSerial1(false, Serial1);
+  #if ANY_SERIAL_IS(-1)
+    DefaultSerial MSerial(false, Serial);
+  #endif
+  #if ANY_SERIAL_IS(0)
+    DefaultSerial1 MSerial1(false, Serial1);
+  #endif
   #if ANY_SERIAL_IS(1)
     DefaultSerial2 MSerial2(false, Serial2);
   #endif

--- a/Marlin/src/HAL/SAMD51/HAL.h
+++ b/Marlin/src/HAL/SAMD51/HAL.h
@@ -33,9 +33,15 @@
 
   // Serial ports
   typedef ForwardSerial0Type< decltype(Serial) > DefaultSerial;
-  extern DefaultSerial MSerial;
   typedef ForwardSerial0Type< decltype(Serial1) > DefaultSerial1;
+  typedef ForwardSerial0Type< decltype(Serial2) > DefaultSerial2;
+  typedef ForwardSerial0Type< decltype(Serial3) > DefaultSerial3;
+  typedef ForwardSerial0Type< decltype(Serial4) > DefaultSerial4;
+  extern DefaultSerial MSerial;
   extern DefaultSerial1 MSerial1;
+  extern DefaultSerial2 MSerial2;
+  extern DefaultSerial3 MSerial3;
+  extern DefaultSerial4 MSerial4;
 
   // MYSERIAL0 required before MarlinSerial includes!
 


### PR DESCRIPTION
This let compile Marlin with Serial 1, 2 and 3 not defined, by default, by framework to save H/W resources