### PR TITLE
fixes #21036 Division by zero error in _calculated_remaining_time

### DIFF
--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -248,7 +248,7 @@ public:
         static inline uint32_t _calculated_remaining_time() {
           const duration_t elapsed = print_job_timer.duration();
           const progress_t progress = _get_progress();
-          return progress > 0 ? elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress : 0;
+          return progress ? elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress : 0;
         }
         #if ENABLED(USE_M73_REMAINING_TIME)
           static uint32_t remaining_time;

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -248,7 +248,7 @@ public:
         static inline uint32_t _calculated_remaining_time() {
           const duration_t elapsed = print_job_timer.duration();
           const progress_t progress = _get_progress();
-          return elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress;
+          return progress > 0 ? elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress : 0;
         }
         #if ENABLED(USE_M73_REMAINING_TIME)
           static uint32_t remaining_time;


### PR DESCRIPTION
### Description

On Marlin power up  with USE_M73_REMAINING_TIME enabled the main status screen displays remaining time as a very large number. This should be not display any Remaining time yet. 
Cause is a division by 0 error in _calculated_remaining_time.
 
### Requirements

An LCD, and enable SHOW_REMAINING_TIME, USE_M73_REMAINING_TIME and LCD_SET_PROGRESS_MANUALLY 

### Benefits

Fixes issue #21036

### Configurations

See issue, but all that is required is in Requirements.

### Related Issues
Issue #21036