### PR TITLE
Add Support for YHCB2004 & GT2560 V4.1B

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1956,13 +1956,10 @@
 //
 // GT2560 (YHCB2004) LCD Display
 //
-// Note: This controller requires Testato, Koepel softwarewire library
-//		and Andriy Golovnya LiquidCrystal_AIP31068 libray.
+// Requires Testato, Koepel softwarewire library and
+// Andriy Golovnya's LiquidCrystal_AIP31068 library.
 //
 //#define YHCB2004
-#if ENABLED (YHCB2004)
-  #define ULTIPANEL
-#endif
 
 //
 // Original RADDS LCD Display+Encoder+SDCardReader

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1959,7 +1959,7 @@
 // Note: This controller requires Testato, Koepel softwarewire library
 //		and Andriy Golovnya LiquidCrystal_AIP31068 libray.
 //
-#define YHCB2004
+//#define YHCB2004
 #if ENABLED (YHCB2004)
   #define ULTIPANEL
 #endif

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1954,6 +1954,17 @@
 //#define REPRAP_DISCOUNT_SMART_CONTROLLER
 
 //
+// GT2560 (YHCB2004) LCD Display
+//
+// Note: This controller requires Testato, Koepel softwarewire library
+//		and Andriy Golovnya LiquidCrystal_AIP31068 libray.
+//
+#define YHCB2004
+#if ENABLED (YHCB2004)
+  #define ULTIPANEL
+#endif
+
+//
 // Original RADDS LCD Display+Encoder+SDCardReader
 // http://doku.radds.org/dokumentation/lcd-display/
 //

--- a/Marlin/src/HAL/AVR/fastio/fastio_1280.h
+++ b/Marlin/src/HAL/AVR/fastio/fastio_1280.h
@@ -39,16 +39,9 @@
 #define TXD         DIO1
 
 // SPI
-#if ENABLED(YHCB2004)
-  #define SCK         5
-  #define MISO        21
-  #define MOSI        36
-#else
-  #define SCK         DIO52
-  #define MISO        DIO50
-  #define MOSI        DIO51
-#endif
-
+#define SCK         DIO52
+#define MISO        DIO50
+#define MOSI        DIO51
 #define SS          DIO53
 
 // TWI (I2C)

--- a/Marlin/src/HAL/AVR/fastio/fastio_1280.h
+++ b/Marlin/src/HAL/AVR/fastio/fastio_1280.h
@@ -39,14 +39,14 @@
 #define TXD         DIO1
 
 // SPI
-#ifndef YHCB2004
-  #define SCK         DIO52
-  #define MISO        DIO50
-  #define MOSI        DIO51
-#else
+#if ENABLED(YHCB2004)
   #define SCK         5
   #define MISO        21
   #define MOSI        36
+#else
+  #define SCK         DIO52
+  #define MISO        DIO50
+  #define MOSI        DIO51
 #endif
 
 #define SS          DIO53

--- a/Marlin/src/HAL/AVR/fastio/fastio_1280.h
+++ b/Marlin/src/HAL/AVR/fastio/fastio_1280.h
@@ -39,9 +39,16 @@
 #define TXD         DIO1
 
 // SPI
-#define SCK         DIO52
-#define MISO        DIO50
-#define MOSI        DIO51
+#ifndef YHCB2004
+  #define SCK         DIO52
+  #define MISO        DIO50
+  #define MOSI        DIO51
+#else
+  #define SCK         5
+  #define MISO        21
+  #define MOSI        36
+#endif
+
 #define SS          DIO53
 
 // TWI (I2C)

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -50,6 +50,10 @@
 
   #define MINIPANEL
 
+#elif ENABLED(YHCB2004)
+
+  #define IS_ULTIPANEL 1
+
 #elif ENABLED(CARTESIO_UI)
 
   #define DOGLCD

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2292,12 +2292,10 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 
 /**
  * Make sure only one display is enabled
- * had to remove   + ENABLED(ULTIPANEL) \
- */ 
+ */
 #if 1 < 0 \
   + ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) \
   + ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) \
-  + ENABLED(ULTRA_LCD) \
   + (ENABLED(U8GLIB_SSD1306) && DISABLED(IS_U8GLIB_SSD1306)) \
   + (ENABLED(MINIPANEL) && NONE(MKS_MINI_12864, ENDER2_STOCKDISPLAY)) \
   + (ENABLED(MKS_MINI_12864) && DISABLED(MKS_LCD12864)) \
@@ -2346,6 +2344,9 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
   + ENABLED(U8GLIB_SH1106_EINSTART) \
   + ENABLED(ULTI_CONTROLLER) \
   + ENABLED(ULTIMAKERCONTROLLER) \
+  + ENABLED(ULTIPANEL) \
+  + ENABLED(ULTRA_LCD) \
+  + ENABLED(YHCB2004) \
   + ENABLED(ZONESTAR_LCD)
   #error "Please select only one LCD controller option."
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2292,11 +2292,11 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 
 /**
  * Make sure only one display is enabled
- */
+ * had to remove   + ENABLED(ULTIPANEL) \
+ */ 
 #if 1 < 0 \
   + ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) \
   + ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER) \
-  + ENABLED(ULTIPANEL) \
   + ENABLED(ULTRA_LCD) \
   + (ENABLED(U8GLIB_SSD1306) && DISABLED(IS_U8GLIB_SSD1306)) \
   + (ENABLED(MINIPANEL) && NONE(MKS_MINI_12864, ENDER2_STOCKDISPLAY)) \

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -93,6 +93,10 @@
 
   LCD_CLASS lcd(0x27, 2, 1, 0, 4, 5, 6, 7, 3, POSITIVE);
 
+#elif ENABLED(YHCB2004)
+
+ LCD_CLASS lcd(5, 20, 4, 21, 36);//LCD spi ss pin, lcd cols, lcd rows, lcd sclk pin, lcd mosi pin, lcd miso pin  	
+
 #else
 
   // Standard direct-connected LCD implementations

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -95,7 +95,7 @@
 
 #elif ENABLED(YHCB2004)
 
- LCD_CLASS lcd(5, 20, 4, 21, 36); // spi ss pin, cols, rows, sclk pin, mosi pin, miso pin
+  LCD_CLASS lcd(YHCB2004_CLK, 20, 4, YHCB2004_MOSI, YHCB2004_MISO); // CLK, cols, rows, MOSI, MISO
 
 #else
 

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -95,7 +95,7 @@
 
 #elif ENABLED(YHCB2004)
 
- LCD_CLASS lcd(5, 20, 4, 21, 36);//LCD spi ss pin, lcd cols, lcd rows, lcd sclk pin, lcd mosi pin, lcd miso pin  	
+ LCD_CLASS lcd(5, 20, 4, 21, 36); // spi ss pin, cols, rows, sclk pin, mosi pin, miso pin
 
 #else
 

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.h
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.h
@@ -90,6 +90,11 @@
   #include <LiquidCrystal_I2C.h>
   #define LCD_CLASS LiquidCrystal_I2C
 
+#elif ENABLED(YHCB2004)
+
+  #include <LiquidCrystal_AIP31068_SPI.h>
+  #define LCD_CLASS LiquidCrystal_AIP31068_SPI 	
+
 #else
 
   // Standard directly connected LCD implementations

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.h
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.h
@@ -93,7 +93,7 @@
 #elif ENABLED(YHCB2004)
 
   #include <LiquidCrystal_AIP31068_SPI.h>
-  #define LCD_CLASS LiquidCrystal_AIP31068_SPI 	
+  #define LCD_CLASS LiquidCrystal_AIP31068_SPI
 
 #else
 

--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -156,7 +156,17 @@
 //
 #define BEEPER_PIN                            18
 
-#if HAS_GRAPHICAL_LCD
+#if ENABLED(YHCB2004)
+  #ifndef YHCB2004_MOSI
+    #define YHCB2004_MOSI                     21
+  #endif
+  #ifndef YHCB2004_SCK
+    #define YHCB2004_SCK                      5
+  #endif
+  #ifndef YHCB2004_MISO
+    #define YHCB2004_MISO                     36
+  #endif
+#elif HAS_WIRED_LCD
   #ifndef LCD_PINS_RS
     #define LCD_PINS_RS                       20
   #endif

--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -22,7 +22,7 @@
 #pragma once
 
 /**
- * GT2560 RevB + GT2560 V3.0 + GT2560 V3.1 + GT2560 V4.0 pin assignment
+ * GT2560 RevB + GT2560 V3.0 + GT2560 V3.1 + GT2560 V4.0 + GT2560 V4.1 pin assignment
  */
 
 #if NOT_TARGET(__AVR_ATmega1280__, __AVR_ATmega2560__)
@@ -30,7 +30,7 @@
 #endif
 
 #ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME "GT2560 V3.0"
+  #define BOARD_INFO_NAME "GT2560 RevB/V3-V4.1"
 #endif
 
 //
@@ -142,7 +142,10 @@
 #define SDSS                                  53
 #define LED_PIN                               13  // Use 6 (case light) for external LED. 13 is internal (yellow) LED.
 #define PS_ON_PIN                             12
-#define SUICIDE_PIN                           54  // This pin must be enabled at boot to keep power flowing
+
+#if NUM_RUNOUT_SENSORS < 3
+  #define SUICIDE_PIN                           54  // This pin must be enabled at boot to keep power flowing
+#endif
 
 #ifndef CASE_LIGHT_PIN
   #define CASE_LIGHT_PIN                       6  // 21
@@ -170,9 +173,19 @@
 #endif
 #ifndef LCD_PINS_D7
   #define LCD_PINS_D7                         36
-#endif
+  #endif
 
-#if IS_NEWPANEL
+#if ENABLED(YHCB2004)
+  #ifndef BTN_EN1
+    #define BTN_EN1                           16
+  #endif
+  #ifndef BTN_EN2
+    #define BTN_EN2                           17
+  #endif
+  #ifndef BTN_ENC
+    #define BTN_ENC                           19
+  #endif
+#elif IS_NEWPANEL
   #ifndef BTN_EN1
     #define BTN_EN1                           42
   #endif

--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -144,7 +144,7 @@
 #define PS_ON_PIN                             12
 
 #if NUM_RUNOUT_SENSORS < 3
-  #define SUICIDE_PIN                           54  // This pin must be enabled at boot to keep power flowing
+  #define SUICIDE_PIN                         54  // This pin must be enabled at boot to keep power flowing
 #endif
 
 #ifndef CASE_LIGHT_PIN

--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -22,7 +22,7 @@
 #pragma once
 
 /**
- * GT2560 RevB + GT2560 V3.0 + GT2560 V3.1 + GT2560 V4.0 + GT2560 V4.1 pin assignment
+ * Geeetech GT2560 RevB + GT2560 3.0/3.1 + GT2560 4.0/4.1 pin assignments
  */
 
 #if NOT_TARGET(__AVR_ATmega1280__, __AVR_ATmega2560__)
@@ -30,13 +30,13 @@
 #endif
 
 #ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME "GT2560 RevB/V3-V4.1"
+  #define BOARD_INFO_NAME "GT2560 RevB/3.x/4.x"
 #endif
 
 //
 // Servos
 //
-#define SERVO0_PIN                            11  //13 untested  3Dtouch
+#define SERVO0_PIN                            11  // 13 untested  3Dtouch
 
 //
 // Limit Switches
@@ -156,24 +156,26 @@
 //
 #define BEEPER_PIN                            18
 
-#ifndef LCD_PINS_RS
-  #define LCD_PINS_RS                         20
-#endif
-#ifndef LCD_PINS_ENABLE
-  #define LCD_PINS_ENABLE                     17
-#endif
-#ifndef LCD_PINS_D4
-  #define LCD_PINS_D4                         16
-#endif
-#ifndef LCD_PINS_D5
-  #define LCD_PINS_D5                         21
-#endif
-#ifndef LCD_PINS_D6
-  #define LCD_PINS_D6                          5
-#endif
-#ifndef LCD_PINS_D7
-  #define LCD_PINS_D7                         36
+#if HAS_GRAPHICAL_LCD
+  #ifndef LCD_PINS_RS
+    #define LCD_PINS_RS                       20
   #endif
+  #ifndef LCD_PINS_ENABLE
+    #define LCD_PINS_ENABLE                   17
+  #endif
+  #ifndef LCD_PINS_D4
+    #define LCD_PINS_D4                       16
+  #endif
+  #ifndef LCD_PINS_D5
+    #define LCD_PINS_D5                       21
+  #endif
+  #ifndef LCD_PINS_D6
+    #define LCD_PINS_D6                        5
+  #endif
+  #ifndef LCD_PINS_D7
+    #define LCD_PINS_D7                       36
+  #endif
+#endif
 
 #if ENABLED(YHCB2004)
   #ifndef BTN_EN1

--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -157,11 +157,11 @@
 #define BEEPER_PIN                            18
 
 #if ENABLED(YHCB2004)
-  #ifndef YHCB2004_MOSI
-    #define YHCB2004_MOSI                     21
-  #endif
   #ifndef YHCB2004_SCK
     #define YHCB2004_SCK                      5
+  #endif
+  #ifndef YHCB2004_MOSI
+    #define YHCB2004_MOSI                     21
   #endif
   #ifndef YHCB2004_MISO
     #define YHCB2004_MISO                     36

--- a/Marlin/src/pins/mega/pins_GT2560_V3_A20.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3_A20.h
@@ -22,7 +22,7 @@
 #pragma once
 
 /**
- * Geeetech A20M pin assignment
+ * Geeetech A20M board pin assignments
  */
 
 #define LCD_PINS_RS                            5
@@ -30,7 +30,7 @@
 #define LCD_PINS_D4                           21
 #define LCD_PINS_D7                            6
 
-#define SPEAKER  // The speaker can produce tones
+#define SPEAKER                                  // The speaker can produce tones
 
 #if IS_NEWPANEL
   #define BTN_EN1                             16

--- a/Marlin/src/pins/mega/pins_GT2560_V3_MC2.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3_MC2.h
@@ -21,9 +21,9 @@
  */
 #pragma once
 
-/*****************************************************************
- * GT2560 V3.0 pin assignment (for Mecreator 2)
- *****************************************************************/
+/**
+ * Geeetech GT2560 V 3.0 board pin assignments (for Mecreator 2)
+ */
 
 #define BOARD_INFO_NAME "GT2560 V3.0 (MC2)"
 

--- a/Marlin/src/pins/mega/pins_HJC2560C_REV2.h
+++ b/Marlin/src/pins/mega/pins_HJC2560C_REV2.h
@@ -22,7 +22,7 @@
 #pragma once
 
 /**
- * HJC2560-C Rev2.x pin assignments
+ * Geeetech HJC2560-C Rev 2.x board pin assignments
  */
 
 #if NOT_TARGET(__AVR_ATmega2560__)

--- a/Marlin/src/pins/stm32f1/pins_GTM32_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_MINI.h
@@ -22,8 +22,7 @@
 #pragma once
 
 /**
- * 24 May 2018 - @chepo for STM32F103VET6
- * Schematic: https://github.com/chepo92/Smartto/blob/master/circuit_diagram/Rostock301/Hardware_GTM32_PRO_VB.pdf
+ * Geeetech GTM32 Mini board pin assignments
  */
 
 #if NOT_TARGET(__STM32F1__)

--- a/Marlin/src/pins/stm32f1/pins_GTM32_MINI_A30.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_MINI_A30.h
@@ -22,8 +22,7 @@
 #pragma once
 
 /**
- * 24 May 2018 - @chepo for STM32F103VET6
- * Schematic: https://github.com/chepo92/Smartto/blob/master/circuit_diagram/Rostock301/Hardware_GTM32_PRO_VB.pdf
+ * Geeetech GTM32 Mini A30 board pin assignments
  */
 
 #if NOT_TARGET(__STM32F1__)

--- a/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VB.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VB.h
@@ -22,15 +22,15 @@
 #pragma once
 
 /**
- * 24 May 2018 - @chepo for STM32F103VET6
- * Schematic: https://github.com/chepo92/Smartto/blob/master/circuit_diagram/Rostock301/Hardware_GTM32_PRO_VB.pdf
+ * Geeetech GTM32 Pro VB/VD board pin assignments
+ * http://www.geeetech.com/wiki/index.php/File:Hardware_GTM32_PRO_VB.pdf
  */
 
 #if NOT_TARGET(__STM32F1__)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #endif
 
-#define BOARD_INFO_NAME      "GTM32 Pro VB" // works on VD revision also
+#define BOARD_INFO_NAME      "GTM32 Pro VB/VD"
 #define DEFAULT_MACHINE_NAME "STM32F103VET6"
 
 #define BOARD_NO_NATIVE_USB

--- a/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VB.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VB.h
@@ -30,7 +30,7 @@
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #endif
 
-#define BOARD_INFO_NAME      "GTM32 Pro VB"
+#define BOARD_INFO_NAME      "GTM32 Pro VB" // works on VD revision also
 #define DEFAULT_MACHINE_NAME "STM32F103VET6"
 
 #define BOARD_NO_NATIVE_USB

--- a/Marlin/src/pins/stm32f1/pins_GTM32_REV_B.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_REV_B.h
@@ -22,15 +22,14 @@
 #pragma once
 
 /**
- * 24 May 2018 - @chepo for STM32F103VET6
- * Schematic: https://github.com/chepo92/Smartto/blob/master/circuit_diagram/Rostock301/Hardware_GTM32_PRO_VB.pdf
+ * Geeetech GTM32 Rev. B board pin assignments
  */
 
 #if NOT_TARGET(__STM32F1__)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #endif
 
-#define BOARD_INFO_NAME      "GTM32 Pro VB"
+#define BOARD_INFO_NAME      "GTM32 Rev B"
 #define DEFAULT_MACHINE_NAME "M201"
 
 #define BOARD_NO_NATIVE_USB

--- a/platformio.ini
+++ b/platformio.ini
@@ -219,7 +219,7 @@ lib_deps           =
 # Feature Dependencies
 #
 [features]
-YHCB2004                = red-scorp/LiquidCrystal_AIP31068 @ ^1.0.4, red-scorp/SoftSPIB @ ^1.1.1
+YHCB2004                = red-scorp/LiquidCrystal_AIP31068@^1.0.4, red-scorp/SoftSPIB@^1.1.1
 HAS_TFT_LVGL_UI         = lvgl=https://github.com/makerbase-mks/LVGL-6.1.1-MKS/archive/master.zip
                           src_filter=+<src/lcd/extui/lib/mks_ui>
                           extra_scripts=download_mks_assets.py

--- a/platformio.ini
+++ b/platformio.ini
@@ -213,7 +213,7 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
 build_flags        = -fmax-errors=5 -g3 -D__MARLIN_FIRMWARE__ -fmerge-constants
-lib_deps           =
+lib_deps           = red-scorp/LiquidCrystal_AIP31068 @ ^1.0.4, red-scorp/SoftSPIB @ ^1.1.1
 
 #
 # Feature Dependencies

--- a/platformio.ini
+++ b/platformio.ini
@@ -213,12 +213,13 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
 build_flags        = -fmax-errors=5 -g3 -D__MARLIN_FIRMWARE__ -fmerge-constants
-lib_deps           = red-scorp/LiquidCrystal_AIP31068 @ ^1.0.4, red-scorp/SoftSPIB @ ^1.1.1
+lib_deps           =
 
 #
 # Feature Dependencies
 #
 [features]
+YHCB2004                = red-scorp/LiquidCrystal_AIP31068 @ ^1.0.4, red-scorp/SoftSPIB @ ^1.1.1
 HAS_TFT_LVGL_UI         = lvgl=https://github.com/makerbase-mks/LVGL-6.1.1-MKS/archive/master.zip
                           src_filter=+<src/lcd/extui/lib/mks_ui>
                           extra_scripts=download_mks_assets.py


### PR DESCRIPTION
Add Support for YHCB2004 lcd screen found on newer gt2560 V4.1b boards from geeetech.
also adjust pins file to reflect V4.1B support.
i plan to add examples to the configuration repo for these models at a later date once hardware changes are supported upstream.
i have confirmed with users that have the hardware this code functions as intended.
this code has been ported from official geeetech code.
i feel this code is functional and ready to head upstream if could likely be improved should you see fit.
