### PR TITLE
fixes #21089 "BUTTON_CLICK" redefined warnings

### DIFF
--- a/Marlin/src/lcd/buttons.h
+++ b/Marlin/src/lcd/buttons.h
@@ -45,86 +45,6 @@
   #define ENCODER_PHASE_3 1
 #endif
 
-#if EITHER(HAS_DIGITAL_BUTTONS, DWIN_CREALITY_LCD)
-
-  // Wheel spin pins where BA is 00, 10, 11, 01 (1 bit always changes)
-  #define BLEN_A 0
-  #define BLEN_B 1
-
-  #define EN_A _BV(BLEN_A)
-  #define EN_B _BV(BLEN_B)
-
-  #define _BUTTON_PRESSED(BN) !READ(BTN_##BN)
-
-  #if BUTTON_EXISTS(ENC) || HAS_TOUCH_BUTTONS
-    #define BLEN_C 2
-    #define EN_C _BV(BLEN_C)
-  #endif
-
-  #if ENABLED(LCD_I2C_VIKI)
-
-    #include <LiquidTWI2.h>
-
-    #define B_I2C_BTN_OFFSET 3 // (the first three bit positions reserved for EN_A, EN_B, EN_C)
-
-    // button and encoder bit positions within 'buttons'
-    #define B_LE (BUTTON_LEFT   << B_I2C_BTN_OFFSET)      // The remaining normalized buttons are all read via I2C
-    #define B_UP (BUTTON_UP     << B_I2C_BTN_OFFSET)
-    #define B_MI (BUTTON_SELECT << B_I2C_BTN_OFFSET)
-    #define B_DW (BUTTON_DOWN   << B_I2C_BTN_OFFSET)
-    #define B_RI (BUTTON_RIGHT  << B_I2C_BTN_OFFSET)
-
-    #if BUTTON_EXISTS(ENC)                                // The pause/stop/restart button is connected to BTN_ENC when used
-      #define B_ST (EN_C)                                 // Map the pause/stop/resume button into its normalized functional name
-      #define BUTTON_CLICK() (buttons & (B_MI|B_RI|B_ST)) // Pause/stop also acts as click until a proper pause/stop is implemented.
-    #else
-      #define BUTTON_CLICK() (buttons & (B_MI|B_RI))
-    #endif
-
-    // I2C buttons take too long to read inside an interrupt context and so we read them during lcd_update
-
-  #elif ENABLED(LCD_I2C_PANELOLU2)
-
-    #if !BUTTON_EXISTS(ENC) // Use I2C if not directly connected to a pin
-
-      #define B_I2C_BTN_OFFSET 3 // (the first three bit positions reserved for EN_A, EN_B, EN_C)
-
-      #define B_MI (PANELOLU2_ENCODER_C << B_I2C_BTN_OFFSET) // requires LiquidTWI2 library v1.2.3 or later
-
-      #define BUTTON_CLICK() (buttons & B_MI)
-
-    #endif
-
-  #endif
-
-#else
-
-  #undef BUTTON_EXISTS
-  #define BUTTON_EXISTS(...) false
-
-  // Dummy button, never pressed
-  #define _BUTTON_PRESSED(BN) false
-
-  // Shift register bits correspond to buttons:
-  #define BL_LE 7   // Left
-  #define BL_UP 6   // Up
-  #define BL_MI 5   // Middle
-  #define BL_DW 4   // Down
-  #define BL_RI 3   // Right
-  #define BL_ST 2   // Red Button
-  #define B_LE _BV(BL_LE)
-  #define B_UP _BV(BL_UP)
-  #define B_MI _BV(BL_MI)
-  #define B_DW _BV(BL_DW)
-  #define B_RI _BV(BL_RI)
-  #define B_ST _BV(BL_ST)
-
-  #ifndef BUTTON_CLICK
-    #define BUTTON_CLICK() (buttons & (B_MI|B_ST))
-  #endif
-
-#endif
-
 #if IS_RRW_KEYPAD
   #define BTN_OFFSET          0 // Bit offset into buttons for shift register values
 
@@ -152,6 +72,76 @@
     #define BUTTON_CLICK() ((buttons & EN_C) || RRK(EN_KEYPAD_MIDDLE))
   #else
     #define BUTTON_CLICK() RRK(EN_KEYPAD_MIDDLE)
+  #endif
+#endif
+
+#if EITHER(HAS_DIGITAL_BUTTONS, DWIN_CREALITY_LCD)
+  // Wheel spin pins where BA is 00, 10, 11, 01 (1 bit always changes)
+  #define BLEN_A 0
+  #define BLEN_B 1
+
+  #define EN_A _BV(BLEN_A)
+  #define EN_B _BV(BLEN_B)
+
+  #define _BUTTON_PRESSED(BN) !READ(BTN_##BN)
+
+  #if BUTTON_EXISTS(ENC) || HAS_TOUCH_BUTTONS
+    #define BLEN_C 2
+    #define EN_C _BV(BLEN_C)
+  #endif
+
+  #if ENABLED(LCD_I2C_VIKI)
+    #include <LiquidTWI2.h>
+    #define B_I2C_BTN_OFFSET 3 // (the first three bit positions reserved for EN_A, EN_B, EN_C)
+
+    // button and encoder bit positions within 'buttons'
+    #define B_LE (BUTTON_LEFT   << B_I2C_BTN_OFFSET)      // The remaining normalized buttons are all read via I2C
+    #define B_UP (BUTTON_UP     << B_I2C_BTN_OFFSET)
+    #define B_MI (BUTTON_SELECT << B_I2C_BTN_OFFSET)
+    #define B_DW (BUTTON_DOWN   << B_I2C_BTN_OFFSET)
+    #define B_RI (BUTTON_RIGHT  << B_I2C_BTN_OFFSET)
+
+    #if BUTTON_EXISTS(ENC)                                // The pause/stop/restart button is connected to BTN_ENC when used
+      #define B_ST (EN_C)                                 // Map the pause/stop/resume button into its normalized functional name
+      #define BUTTON_CLICK() (buttons & (B_MI|B_RI|B_ST)) // Pause/stop also acts as click until a proper pause/stop is implemented.
+    #else
+      #define BUTTON_CLICK() (buttons & (B_MI|B_RI))
+    #endif
+
+    // I2C buttons take too long to read inside an interrupt context and so we read them during lcd_update
+
+  #elif ENABLED(LCD_I2C_PANELOLU2)
+    #if !BUTTON_EXISTS(ENC) // Use I2C if not directly connected to a pin
+      #define B_I2C_BTN_OFFSET 3 // (the first three bit positions reserved for EN_A, EN_B, EN_C)
+
+      #define B_MI (PANELOLU2_ENCODER_C << B_I2C_BTN_OFFSET) // requires LiquidTWI2 library v1.2.3 or later
+
+      #define BUTTON_CLICK() (buttons & B_MI)
+    #endif
+  #endif
+#else
+  #undef BUTTON_EXISTS
+  #define BUTTON_EXISTS(...) false
+
+  // Dummy button, never pressed
+  #define _BUTTON_PRESSED(BN) false
+
+  // Shift register bits correspond to buttons:
+  #define BL_LE 7   // Left
+  #define BL_UP 6   // Up
+  #define BL_MI 5   // Middle
+  #define BL_DW 4   // Down
+  #define BL_RI 3   // Right
+  #define BL_ST 2   // Red Button
+  #define B_LE _BV(BL_LE)
+  #define B_UP _BV(BL_UP)
+  #define B_MI _BV(BL_MI)
+  #define B_DW _BV(BL_DW)
+  #define B_RI _BV(BL_RI)
+  #define B_ST _BV(BL_ST)
+
+  #ifndef BUTTON_CLICK
+    #define BUTTON_CLICK() (buttons & (B_MI|B_ST))
   #endif
 #endif
 


### PR DESCRIPTION
### Description

fixes #21089 "BUTTON_CLICK" redefined warnings
`#if IS_RRW_KEYPAD `code block is moved up to before `#if EITHER(HAS_DIGITAL_BUTTONS, DWIN_CREALITY_LCD)` code block, not after it. 

### Requirements

ZONESTAR_LCD (and compatible controller) 

### Benefits

No warnings

### Related Issues

Issue #21089