### PR TITLE
Swap Z_MIN and Z_MAX pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
@@ -55,8 +55,8 @@
 //
 #define X_MAX_PIN                           PG10
 #define Y_MAX_PIN                           PA12
-#define Z_MAX_PIN                           PA14
-#define Z_MIN_PIN                           PA13
+#define Z_MAX_PIN                           PA13
+#define Z_MIN_PIN                           PA14
 
 //
 // Steppers


### PR DESCRIPTION
### Description

as described in multiple issues, the pins for Z_MAX and Z_MIN are swapped on the trigorilla_pro board

### Requirements

a fix for trigorilla pro

### Benefits

it saves users (llike me) from a headache

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

#21090 #21095 
