### PR TITLE
Fix IDEX broken endstop test

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -96,7 +96,7 @@
       };
     #endif
 
-    do_blocking_move_to_xy(1.5 * mlx * x_axis_home_dir, 1.5 * mly * home_dir(Y_AXIS), fr_mm_s);
+    do_blocking_move_to_xy(1.5 * mlx * x_axis_home_dir, 1.5 * mly * Y_HOME_DIR, fr_mm_s);
 
     endstops.validate_homing_move();
 

--- a/Marlin/src/module/endstops.h
+++ b/Marlin/src/module/endstops.h
@@ -38,7 +38,7 @@ enum EndstopEnum : char {
   Z4_MIN, Z4_MAX
 };
 
-#define X_ENDSTOP (X_HOME_DIR < 0 ? X_MIN : X_MAX)
+#define X_ENDSTOP (x_home_dir(active_extruder) < 0 ? X_MIN : X_MAX)
 #define Y_ENDSTOP (Y_HOME_DIR < 0 ? Y_MIN : Y_MAX)
 #define Z_ENDSTOP (Z_HOME_DIR < 0 ? TERN(HOMING_Z_WITH_PROBE, Z_MIN, Z_MIN_PROBE) : Z_MAX)
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -450,7 +450,7 @@ FORCE_INLINE void set_all_unhomed()                       { axis_homed = axis_tr
     FORCE_INLINE void set_duplication_enabled(const bool dupe) { extruder_duplication_enabled = dupe; }
   #endif
 
-  FORCE_INLINE int x_home_dir(const uint8_t) { return home_dir(X_AXIS); }
+  FORCE_INLINE int x_home_dir(const uint8_t) { return X_HOME_DIR; }
 
 #endif
 


### PR DESCRIPTION
Addressing #21107 — The broken endstop test doesn't account for IDEX setups. This PR proposes to fix it by changing the definition of the `X_ENDSTOP` macro.
