### PR TITLE
Use 'H' value for UBL G29 z-clearance

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -910,7 +910,8 @@ void unified_bed_leveling::shift_mesh_height() {
       if (parser.seen('B')) {
         serialprintPGM(GET_TEXT(MSG_UBL_BC_INSERT));
         LCD_MESSAGEPGM(MSG_UBL_BC_INSERT);
-      } else {
+      }
+      else {
         serialprintPGM(GET_TEXT(MSG_UBL_BC_INSERT2));
         LCD_MESSAGEPGM(MSG_UBL_BC_INSERT2);
       }

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -892,7 +892,7 @@ void unified_bed_leveling::shift_mesh_height() {
       const xyz_pos_t ppos = {
         mesh_index_to_xpos(lpos.x),
         mesh_index_to_ypos(lpos.y),
-        Z_CLEARANCE_BETWEEN_PROBES
+        z_clearance
       };
 
       if (!position_is_reachable(ppos)) break; // SHOULD NOT OCCUR (find_closest_mesh_point only returns reachable points)
@@ -907,7 +907,13 @@ void unified_bed_leveling::shift_mesh_height() {
 
       if (do_ubl_mesh_map) display_map(g29_map_type);  // show user where we're probing
 
-      serialprintPGM(parser.seen('B') ? GET_TEXT(MSG_UBL_BC_INSERT) : GET_TEXT(MSG_UBL_BC_INSERT2));
+      if (parser.seen('B')) {
+        serialprintPGM(GET_TEXT(MSG_UBL_BC_INSERT));
+        LCD_MESSAGEPGM(MSG_UBL_BC_INSERT);
+      } else {
+        serialprintPGM(GET_TEXT(MSG_UBL_BC_INSERT2));
+        LCD_MESSAGEPGM(MSG_UBL_BC_INSERT2);
+      }
 
       const float z_step = 0.01f;                         // existing behavior: 0.01mm per click, occasionally step
       //const float z_step = planner.steps_to_mm[Z_AXIS]; // approx one step each click


### PR DESCRIPTION
### Description

Using UBL, `G29 P2` allows you to manually probe points on the bed; the `G29` command also accepts an `H` argument so that the user can specify the Z-height that the nozzle will be lowered/raised to between probes. Currently, specifying `H` does not work with P2 - it always goes back to the `Z_CLEARANCE_BETWEEN_PROBES`.

### Requirements

UBL enabled, LCD required.

### Benefits

Fixes the Z behavior in P2 to match the documentation, respecting the user-provided H value. Also outputs more clear instructions to the LCD screen (instead of staying on 'Moving to next point').

Existing behavior:
1. `G29 P2 H1 T`
2. Nozzle moves to an invalid mesh point
3. Nozzle is lowered to 1mm (from H)
4. Nozzle is re-raised to `Z_CLEARANCE_BETWEEN_PROBES` (5mm)
5. User is prompted on LCD with "Moving to next point"

Fixed Behavior:
1. `G29 P2 H1 T`
2. Nozzle moves to an invalid mesh point
3. Nozzle is lowered to 1mm
4. User us prompted with LCD message "Measure"

### Configurations
An example configuration would enable UBL, EEPROM_SETTINGS, and an LCD.

```diff
diff --git a/Marlin/Configuration.h b/Marlin/Configuration.h
index 428e899b33..3f4b2e6994 100644
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1313,7 +1313,7 @@
 //#define AUTO_BED_LEVELING_3POINT
 //#define AUTO_BED_LEVELING_LINEAR
 //#define AUTO_BED_LEVELING_BILINEAR
-//#define AUTO_BED_LEVELING_UBL
+#define AUTO_BED_LEVELING_UBL
 //#define MESH_BED_LEVELING
 
 /**
@@ -1588,7 +1588,7 @@
  *   M501 - Read settings from EEPROM. (i.e., Throw away unsaved changes)
  *   M502 - Revert settings to "factory" defaults. (Follow with M500 to init the EEPROM.)
  */
-//#define EEPROM_SETTINGS     // Persistent storage with M500 and M501
+#define EEPROM_SETTINGS     // Persistent storage with M500 and M501
 //#define DISABLE_M503        // Saves ~2700 bytes of PROGMEM. Disable for release!
 #define EEPROM_CHITCHAT       // Give feedback on EEPROM commands. Disable to save PROGMEM.
 #define EEPROM_BOOT_SILENT    // Keep M503 quiet and only give errors during first load
@@ -2187,7 +2187,7 @@
 // This is RAMPS-compatible using a single 10-pin connector.
 // (For CR-10 owners who want to replace the Melzi Creality board but retain the display)
 //
-//#define CR10_STOCKDISPLAY
+#define CR10_STOCKDISPLAY
 
 //
 // Ender-2 OEM display, a variant of the MKS_MINI_12864
```

### Related Issues
No issue open for this; fixed directly & made PR. Didn't see any matching open issues.
