### PR TITLE
Remove BLTouch initialization if not needed

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -151,10 +151,6 @@
 
       TERN_(SENSORLESS_HOMING, safe_delay(500)); // Short delay needed to settle
 
-      #if BOTH(BLTOUCH, HOMING_Z_WITH_PROBE)
-        bltouch.init(); // Called again by homeaxis(Z_AXIS), but for extra safety init (i.e., stow) the probe before XY move.
-      #endif
-
       do_blocking_move_to_xy(destination);
       homeaxis(Z_AXIS);
     }
@@ -338,6 +334,7 @@ void GcodeSuite::G28() {
       // Raise Z before homing any other axes and z is not already high enough (never lower z)
       if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) by ", z_homing_height);
       do_z_clearance(z_homing_height, axis_is_trusted(Z_AXIS), DISABLED(UNKNOWN_Z_NO_RAISE));
+      TERN_(BLTOUCH, bltouch.init());
     }
 
     #if ENABLED(QUICK_HOME)

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -126,10 +126,6 @@
 
     sync_plan_position();
 
-    #if BOTH(BLTOUCH, HOMING_Z_WITH_PROBE)
-      bltouch.init();
-    #endif
-
     /**
      * Move the Z probe (or just the nozzle) to the safe homing point
      * (Z is already at the right height)
@@ -154,6 +150,10 @@
       TERN_(DUAL_X_CARRIAGE, idex_set_parked(false));
 
       TERN_(SENSORLESS_HOMING, safe_delay(500)); // Short delay needed to settle
+
+      #if BOTH(BLTOUCH, HOMING_Z_WITH_PROBE)
+        bltouch.init();
+      #endif
 
       do_blocking_move_to_xy(destination);
       homeaxis(Z_AXIS);

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -386,7 +386,6 @@ void GcodeSuite::G28() {
           stepper.set_separate_multi_axis(false);
         #endif
 
-        TERN_(BLTOUCH, bltouch.init());
         TERN(Z_SAFE_HOMING, home_z_safely(), homeaxis(Z_AXIS));
         probe.move_z_after_homing();
       }

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -152,7 +152,7 @@
       TERN_(SENSORLESS_HOMING, safe_delay(500)); // Short delay needed to settle
 
       #if BOTH(BLTOUCH, HOMING_Z_WITH_PROBE)
-        bltouch.init();
+        bltouch.init(); // Called again by homeaxis(Z_AXIS), but for extra safety init (i.e., stow) the probe before XY move.
       #endif
 
       do_blocking_move_to_xy(destination);

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -126,6 +126,10 @@
 
     sync_plan_position();
 
+    #if BOTH(BLTOUCH, HOMING_Z_WITH_PROBE)
+      bltouch.init();
+    #endif
+
     /**
      * Move the Z probe (or just the nozzle) to the safe homing point
      * (Z is already at the right height)

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1579,13 +1579,11 @@ void homeaxis(const AxisEnum axis) {
   const int axis_home_dir = TERN0(DUAL_X_CARRIAGE, axis == X_AXIS)
               ? x_home_dir(active_extruder) : home_dir(axis);
 
-  #if HOMING_Z_WITH_PROBE
-    if (axis == Z_AXIS) {             // Homing Z with a probe?
-      TERN_(BLTOUCH, bltouch.init()); // For BLTouch init now (reset and stow)
-      if (probe.deploy())             // Raise Z (maybe) and deploy the Z probe
-        return;                       // Exit if the probe is unable to deploy
-    }
-  #endif
+  //
+  // Homing Z with a probe? Raise Z (maybe) and deploy the Z probe.
+  //
+  if (TERN0(HOMING_Z_WITH_PROBE, axis == Z_AXIS && probe.deploy()))
+    return;
 
   // Set flags for X, Y, Z motor locking
   #if HAS_EXTRA_ENDSTOPS

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1579,6 +1579,10 @@ void homeaxis(const AxisEnum axis) {
   const int axis_home_dir = TERN0(DUAL_X_CARRIAGE, axis == X_AXIS)
               ? x_home_dir(active_extruder) : home_dir(axis);
 
+  #if BOTH(BLTOUCH, HOMING_Z_WITH_PROBE)
+    if (axis == Z_AXIS) bltouch.init();
+  #endif
+
   //
   // Homing Z with a probe? Raise Z (maybe) and deploy the Z probe.
   //

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1579,15 +1579,13 @@ void homeaxis(const AxisEnum axis) {
   const int axis_home_dir = TERN0(DUAL_X_CARRIAGE, axis == X_AXIS)
               ? x_home_dir(active_extruder) : home_dir(axis);
 
-  #if BOTH(BLTOUCH, HOMING_Z_WITH_PROBE)
-    if (axis == Z_AXIS) bltouch.init();
+  #if HOMING_Z_WITH_PROBE
+    if (axis == Z_AXIS) {             // Homing Z with a probe?
+      TERN_(BLTOUCH, bltouch.init()); // For BLTouch init now (reset, stow, set mode)
+      if (probe.deploy())             // Raise Z (maybe) and deploy the Z probe
+        return;                       // Exit if the probe is unable to deploy
+    }
   #endif
-
-  //
-  // Homing Z with a probe? Raise Z (maybe) and deploy the Z probe.
-  //
-  if (TERN0(HOMING_Z_WITH_PROBE, axis == Z_AXIS && probe.deploy()))
-    return;
 
   // Set flags for X, Y, Z motor locking
   #if HAS_EXTRA_ENDSTOPS

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1581,7 +1581,7 @@ void homeaxis(const AxisEnum axis) {
 
   #if HOMING_Z_WITH_PROBE
     if (axis == Z_AXIS) {             // Homing Z with a probe?
-      TERN_(BLTOUCH, bltouch.init()); // For BLTouch init now (reset, stow, set mode)
+      TERN_(BLTOUCH, bltouch.init()); // For BLTouch init now (reset and stow)
       if (probe.deploy())             // Raise Z (maybe) and deploy the Z probe
         return;                       // Exit if the probe is unable to deploy
     }


### PR DESCRIPTION
### Description

When `BLTOUCH` is enabled and `Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN` is disabled the homing sequence will home XY, have a small pause, and home Z using the endstop switch. The delay can be removed if the BLTouch is initialized only if it is going to be used as a Z probe.

### Requirements

BLTouch and Z endstop switch.

### Benefits

This patch will make homing a little bit faster by removing a delay between homing XY and homing Z.
