### PR TITLE
Fix LCD AZSMZ 12864 display freeze with SD card

### DIFF
--- a/Marlin/src/lcd/dogm/marlinui_DOGM.h
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.h
@@ -88,7 +88,8 @@
 
   #define SMART_RAMPS MB(RAMPS_SMART_EFB, RAMPS_SMART_EEB, RAMPS_SMART_EFF, RAMPS_SMART_EEF, RAMPS_SMART_SF)
   #define U8G_CLASS U8GLIB_64128N_2X_HAL                        // 4 stripes (HW-SPI)
-  #if (SMART_RAMPS && NOT_TARGET(__AVR_ATmega2560__)) || DOGLCD_SCK != SD_SCK_PIN || DOGLCD_MOSI != SD_MOSI_PIN
+
+  #if (SMART_RAMPS && defined(__SAM3X8E__)) || DOGLCD_SCK != SD_SCK_PIN || DOGLCD_MOSI != SD_MOSI_PIN
     #define FORCE_SOFT_SPI                                      // SW-SPI
   #endif
 

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.h
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.h
@@ -88,7 +88,7 @@
 
   #define SMART_RAMPS MB(RAMPS_SMART_EFB, RAMPS_SMART_EEB, RAMPS_SMART_EFF, RAMPS_SMART_EEF, RAMPS_SMART_SF)
   #define U8G_CLASS U8GLIB_64128N_2X_HAL                        // 4 stripes (HW-SPI)
-  #if SMART_RAMPS || DOGLCD_SCK != SD_SCK_PIN || DOGLCD_MOSI != SD_MOSI_PIN
+  #if (SMART_RAMPS && NOT_TARGET(__AVR_ATmega2560__)) || DOGLCD_SCK != SD_SCK_PIN || DOGLCD_MOSI != SD_MOSI_PIN
     #define FORCE_SOFT_SPI                                      // SW-SPI
   #endif
 


### PR DESCRIPTION
…- FIX

### Description

For reported bug #21112 ([BUG] LCD AZSMZ 12864 display freezes when SD card is present #21112) the following fixes a display problem that was specific to a SMART RAMPS board with an Arduino MEGA 2650 -- something that was only recently enabled.

### Requirements

It is specific to users of SMART RAMPS board with a MEGA 2560.

### Benefits

In the case of a SMART RAMPS board, pre-compiler directives were such that SPI was forced to be software emulated -- this was intended for the DUE.  However, for the MAGA 2560, there is hardware SPI support on the same pins configured.  Hence, adjust switches to allow use of hardware SPI for this case.  

With that, the display works nicely with the SD Card in use now.

### Configurations

[Archive.zip](https://github.com/MarlinFirmware/Marlin/files/6007375/Archive.zip)

### Related Issues

Fix for reported bug #21112 
