### PR TITLE
fixes #21144 'LEVELING_NOZZLE_TEMP' was not declared

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -335,14 +335,6 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
       #define PROBING_BED_TEMP 0
     #endif
   #endif
-  #if ENABLED(PREHEAT_BEFORE_LEVELING)
-    #ifndef LEVELING_NOZZLE_TEMP
-      #define LEVELING_NOZZLE_TEMP 0
-    #endif
-    #ifndef LEVELING_BED_TEMP
-      #define LEVELING_BED_TEMP 0
-    #endif
-  #endif
 
   /**
    * Do preheating as required before leveling or probing.

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -44,6 +44,15 @@
   #define PROBE_TRIGGERED() (READ(Z_MIN_PIN) != Z_MIN_ENDSTOP_INVERTING)
 #endif
 
+#if ENABLED(PREHEAT_BEFORE_LEVELING)
+  #ifndef LEVELING_NOZZLE_TEMP
+    #define LEVELING_NOZZLE_TEMP 0
+  #endif
+  #ifndef LEVELING_BED_TEMP
+    #define LEVELING_BED_TEMP 0
+  #endif
+#endif
+
 class Probe {
 public:
 


### PR DESCRIPTION
### Description

If LEVELING_NOZZLE_TEMP or LEVELING_BED_TEMP is not defined when PREHEAT_BEFORE_LEVELING is enabled this results in a compile error.

There is a fix for this in probe.cpp
```
#if ENABLED(PREHEAT_BEFORE_LEVELING)
  #ifndef LEVELING_NOZZLE_TEMP
    #define LEVELING_NOZZLE_TEMP 0
  #endif
  #ifndef LEVELING_BED_TEMP
    #define LEVELING_BED_TEMP 0
  #endif
#endif
```
But this is also needed in G29.cpp

I moved this fix into probe.h so both probe.cpp and G29.cpp get it.

### Requirements

Some sort of prob. I used FIX_MOUNTED_PROBE 
AUTO_BED_LEVELING_BILINEAR
PREHEAT_BEFORE_LEVELING
disabled LEVELING_NOZZLE_TEMP and or disabled LEVELING_BED_TEMP

### Benefits

Compiles as expected

### Related Issues
Issue #21144