### PR TITLE
Longer3D: early init of open drain pins with BOARD_PREINIT

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -871,8 +871,7 @@ inline void tmc_standby_setup() {
  */
 void setup() {
   #ifdef BOARD_PREINIT
-    // no serial yet...
-    BOARD_PREINIT();
+    BOARD_PREINIT(); // Low-level init (before serial init)
   #endif
 
   tmc_standby_setup();  // TMC Low Power Standby pins must be set early or they're not usable

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -870,6 +870,10 @@ inline void tmc_standby_setup() {
  *    • Max7219
  */
 void setup() {
+  #ifdef BOARD_PREINIT
+    // no serial yet...
+    BOARD_PREINIT();
+  #endif
 
   tmc_standby_setup();  // TMC Low Power Standby pins must be set early or they're not usable
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1749,7 +1749,7 @@ void Temperature::updateTemperaturesFromRawValues() {
 #endif
 
 // Init fans according to whether they're native PWM or Software PWM
-#ifdef ALFAWISE_UX0
+#ifdef BOARD_OPENDRAIN_MOSFETS
   #define _INIT_SOFT_FAN(P) OUT_WRITE_OD(P, FAN_INVERTING ? LOW : HIGH)
 #else
   #define _INIT_SOFT_FAN(P) OUT_WRITE(P, FAN_INVERTING ? LOW : HIGH)
@@ -1842,7 +1842,7 @@ void Temperature::init() {
   #endif
 
   #if HAS_HEATER_0
-    #ifdef ALFAWISE_UX0
+    #ifdef BOARD_OPENDRAIN_MOSFETS
       OUT_WRITE_OD(HEATER_0_PIN, HEATER_0_INVERTING);
     #else
       OUT_WRITE(HEATER_0_PIN, HEATER_0_INVERTING);
@@ -1872,7 +1872,7 @@ void Temperature::init() {
   #endif
 
   #if HAS_HEATED_BED
-    #ifdef ALFAWISE_UX0
+    #ifdef BOARD_OPENDRAIN_MOSFETS
       OUT_WRITE_OD(HEATER_BED_PIN, HEATER_BED_INVERTING);
     #else
       OUT_WRITE(HEATER_BED_PIN, HEATER_BED_INVERTING);

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -29,7 +29,6 @@
 #endif
 
 #define BOARD_INFO_NAME "Longer3D"
-#define ALFAWISE_UX0                              // Common to all Longer3D STM32F1 boards (used for Open drain mosfets)
 
 #define BOARD_NO_NATIVE_USB
 
@@ -98,10 +97,12 @@
 
 // Longer3D board mosfets are passing by default
 // Avoid nozzle heat and fan start before serial init
+#define BOARD_OPENDRAIN_MOSFETS
+
 #define BOARD_PREINIT() { \
-   OUT_WRITE_OD(HEATER_0_PIN, 0); \
-   OUT_WRITE_OD(HEATER_BED_PIN, 0); \
-   OUT_WRITE_OD(FAN_PIN, 0); \
+  OUT_WRITE_OD(HEATER_0_PIN, 0); \
+  OUT_WRITE_OD(HEATER_BED_PIN, 0); \
+  OUT_WRITE_OD(FAN_PIN, 0); \
 }
 
 //

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -92,9 +92,17 @@
 #define FAN_MAX_PWM                          255
 
 //#define BEEPER_PIN                        PD13  // pin 60 (Servo PWM output 5V/GND on Board V0G+) made for BL-Touch sensor
-                                 // Can drive a PC Buzzer, if connected between PWM and 5V pins
+                                                  // Can drive a PC Buzzer, if connected between PWM and 5V pins
 
 #define LED_PIN                             PC2   // pin 17
+
+// Longer3D board mosfets are passing by default
+// Avoid nozzle heat and fan start before serial init
+#define BOARD_PREINIT() { \
+   OUT_WRITE_OD(HEATER_0_PIN, 0); \
+   OUT_WRITE_OD(HEATER_BED_PIN, 0); \
+   OUT_WRITE_OD(FAN_PIN, 0); \
+}
 
 //
 // PWM for a servo probe


### PR DESCRIPTION
We dont want to wait serial and eeprom to stop the fan & nozzle heat on boot

Each second of nozzle heat can be dangerous and using the max of PSU power during the init is not very good neither...