### PR TITLE
Fix Touch UI compiliation error when not using Trinamic drivers; missing colors in theme.

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/screens.h
@@ -176,7 +176,6 @@ enum {
 #include "change_filament_screen.h"
 #include "move_axis_screen.h"
 #include "steps_screen.h"
-#include "stepper_current_screen.h"
 #include "feedrate_percent_screen.h"
 #include "max_velocity_screen.h"
 #include "max_acceleration_screen.h"

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/colors.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/theme/colors.h
@@ -85,6 +85,9 @@ namespace Theme {
     constexpr uint32_t logo_bg_rgb          = accent_color_1;
     constexpr uint32_t logo_fill_rgb        = accent_color_0;
     constexpr uint32_t logo_stroke_rgb      = accent_color_4;
+
+    constexpr uint32_t bed_mesh_lines_rgb   = 0xFFFFFF;
+    constexpr uint32_t bed_mesh_shadow_rgb  = 0x444444;
   #elif ANY(TOUCH_UI_COCOA_THEME, TOUCH_UI_FROZEN_THEME)
     constexpr uint32_t theme_darkest        = accent_color_1;
     constexpr uint32_t theme_dark           = accent_color_4;
@@ -102,6 +105,9 @@ namespace Theme {
     constexpr uint32_t logo_bg_rgb          = accent_color_5;
     constexpr uint32_t logo_fill_rgb        = accent_color_6;
     constexpr uint32_t logo_stroke_rgb      = accent_color_2;
+
+    constexpr uint32_t bed_mesh_lines_rgb   = accent_color_6;
+    constexpr uint32_t bed_mesh_shadow_rgb  = 0x444444;
   #else
     constexpr uint32_t theme_darkest        = gray_color_1;
     constexpr uint32_t theme_dark           = gray_color_2;
@@ -119,6 +125,9 @@ namespace Theme {
     constexpr uint32_t logo_bg_rgb          = accent_color_4;
     constexpr uint32_t logo_fill_rgb        = accent_color_3;
     constexpr uint32_t logo_stroke_rgb      = 0x000000;
+
+    constexpr uint32_t bed_mesh_lines_rgb   = 0xFFFFFF;
+    constexpr uint32_t bed_mesh_shadow_rgb  = 0x444444;
   #endif
 
   constexpr uint32_t shadow_rgb             = gray_color_6;


### PR DESCRIPTION
- This include file was present in two places. It needs to be inside the HAS_TRINAMIC_CONFIG conditional.
- Add colors that was left out from previous PR