### PR TITLE
Fix MKS Robin Nano V3 I2C pins

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_F4x7Vx/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F4x7Vx/variant.h
@@ -143,8 +143,12 @@ extern "C" {
 #define PIN_SPI_SCK             PA5
 
 // I2C definitions
-#define PIN_WIRE_SDA            PB9
-#define PIN_WIRE_SCL            PB8
+#ifndef PIN_WIRE_SDA
+  #define PIN_WIRE_SDA          PB9
+#endif
+#ifndef PIN_WIRE_SCL
+  #define PIN_WIRE_SCL          PB8
+#endif
 
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin

--- a/platformio.ini
+++ b/platformio.ini
@@ -1486,7 +1486,7 @@ extra_scripts        = ${common.extra_scripts}
 [env:mks_robin_nano_v3]
 platform             = ${common_stm32.platform}
 extends              = common_stm32
-build_flags          = ${common_stm32.build_flags} -DHAL_PCD_MODULE_ENABLED -DUSBCON -DUSBD_USE_CDC
+build_flags          = ${common_stm32.build_flags} -DHAL_PCD_MODULE_ENABLED -DUSBCON -DUSBD_USE_CDC -DPIN_WIRE_SCL=PB6 -DPIN_WIRE_SDA=PB7
 board                = genericSTM32F407VGT6
 board_build.core     = stm32
 board_build.variant  = MARLIN_F4x7Vx
@@ -1509,6 +1509,7 @@ extra_scripts        = ${common.extra_scripts}
 extends           = env:mks_robin_nano_v3
 platform_packages = ${stm32_flash_drive.platform_packages}
 build_flags       = ${stm32_flash_drive.build_flags}
+  -DPIN_WIRE_SCL=PB6 -DPIN_WIRE_SDA=PB7
   -DUSBCON
   -DUSE_USBHOST_HS
   -DUSBD_IRQ_PRIO=5
@@ -1525,6 +1526,7 @@ extends           = env:mks_robin_nano_v3
 platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc.zip
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 build_flags       = ${stm32_flash_drive.build_flags}
+  -DPIN_WIRE_SCL=PB6 -DPIN_WIRE_SDA=PB7
   -DUSBCON
   -DUSE_USBHOST_HS
   -DUSBD_IRQ_PRIO=5


### PR DESCRIPTION
### Description

MKS Robin Nano V3 doesn't use the default variant I2C pins. This PR fix that.

### Benefits

Fix #21070

