### PR TITLE
Let libmaple accept RX_BUFFER_SIZE and TX_BUFFER_SIZE

### DIFF
--- a/Marlin/src/HAL/STM32F1/build_flags.py
+++ b/Marlin/src/HAL/STM32F1/build_flags.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import sys
 
+
 #dynamic build flags for generic compile options
 if __name__ == "__main__":
   args = " ".join([ "-std=gnu++14",

--- a/Marlin/src/HAL/STM32F1/build_flags.py
+++ b/Marlin/src/HAL/STM32F1/build_flags.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import sys
 
-
 #dynamic build flags for generic compile options
 if __name__ == "__main__":
   args = " ".join([ "-std=gnu++14",

--- a/buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
+++ b/buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
@@ -27,3 +27,15 @@ if env.MarlinFeatureIsEnabled("POSTMORTEM_DEBUGGING"):
         print("Done patching exception handler")
 
     print("Libmaple modified and ready for post mortem debugging")
+
+rxBuf = env["MARLIN_FEATURES"]["RX_BUFFER_SIZE"] if "RX_BUFFER_SIZE" in env["MARLIN_FEATURES"] else "0"
+txBuf = env["MARLIN_FEATURES"]["TX_BUFFER_SIZE"] if "TX_BUFFER_SIZE" in env["MARLIN_FEATURES"] else "0"
+if int(rxBuf) < 64: 
+	rxBuf = "64"
+
+if int(txBuf) < 64:
+	txBuf = "64"
+
+build_flags = env.get('BUILD_FLAGS')
+build_flags.append("-DUSART_RX_BUF_SIZE="+rxBuf + " -DUSART_TX_BUF_SIZE="+txBuf)
+env.Replace(BUILD_FLAGS=build_flags)

--- a/buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
+++ b/buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
@@ -30,12 +30,12 @@ if env.MarlinFeatureIsEnabled("POSTMORTEM_DEBUGGING"):
 
 rxBuf = env["MARLIN_FEATURES"]["RX_BUFFER_SIZE"] if "RX_BUFFER_SIZE" in env["MARLIN_FEATURES"] else "0"
 txBuf = env["MARLIN_FEATURES"]["TX_BUFFER_SIZE"] if "TX_BUFFER_SIZE" in env["MARLIN_FEATURES"] else "0"
-if int(rxBuf) < 64: 
+if int(rxBuf) < 64:
 	rxBuf = "64"
 
 if int(txBuf) < 64:
 	txBuf = "64"
 
 build_flags = env.get('BUILD_FLAGS')
-build_flags.append("-DUSART_RX_BUF_SIZE="+rxBuf + " -DUSART_TX_BUF_SIZE="+txBuf)
+build_flags.append("-DUSART_RX_BUF_SIZE=" + rxBuf + " -DUSART_TX_BUF_SIZE=" + txBuf)
 env.Replace(BUILD_FLAGS=build_flags)

--- a/platformio.ini
+++ b/platformio.ini
@@ -753,7 +753,7 @@ lib_deps          = ${common.lib_deps}
   SoftwareSerialM
 platform_packages = tool-stm32duino
 extra_scripts     = ${common.extra_scripts}
-  buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
+  pre:buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
 
 #
 # STM32F103RC
@@ -795,7 +795,7 @@ upload_protocol   = dfu
 [env:STM32F103RC_fysetc]
 platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RC
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
 build_flags       = ${common_stm32f1.build_flags} -DDEBUG_LEVEL=0
 lib_ldf_mode      = chain
@@ -819,7 +819,7 @@ upload_protocol   = serial
 [env:STM32F103RC_btt]
 platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RC
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103RC_SKR_MINI.py
 build_flags       = ${common_stm32f1.build_flags}
   -DDEBUG_LEVEL=0 -DSS_TIMER=4
@@ -861,7 +861,7 @@ monitor_speed     = 115200
 [env:STM32F103RE_btt]
 platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RE
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103RE_SKR_E3_DIP.py
 build_flags       = ${common_stm32f1.build_flags} -DDEBUG_LEVEL=0 -DSS_TIMER=4
 debug_tool        = stlink
@@ -951,7 +951,7 @@ build_flags   = ${common_stm32f1.build_flags}
 platform        = ${common_stm32f1.platform}
 extends         = common_stm32f1
 board           = genericSTM32F103VE
-extra_scripts   = ${common.extra_scripts}
+extra_scripts   = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_nano35.py
 build_flags     = ${common_stm32f1.build_flags}
   -DMCU_STM32F103VE -DSS_TIMER=4
@@ -1019,7 +1019,7 @@ platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103RC
 platform_packages = tool-stm32duino
-extra_scripts = ${common.extra_scripts}
+extra_scripts = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_e3.py
 build_flags   = ${common_stm32f1.build_flags}
   -DDEBUG_LEVEL=0 -DSS_TIMER=4


### PR DESCRIPTION

### Description

Fix #21170 
As requested by @rhapsodyv I'm splitting the refactoring of the serial queue from small fixes I've identified while reworking the code. Here's a one of the fix.

### Requirements

libmaple

### Benefits

Allow to increase the low level serial buffer size so a complete line can be stored in the buffer before the queue's is able to consume it, instead of dropping it. Long lines are caused by arc command and are longer than the default's libmaple's 64 chars buffer.

### Configurations

N/A

### Related Issues

#21170 Tested and validated by @ldursw

