### PR TITLE
Follow up for Allow Zero Endstops #21120

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1393,7 +1393,7 @@ void prepare_line_to_destination() {
     TERN_(I2C_POSITION_ENCODERS, I2CPEM.unhomed(axis));
   }
 
-  #if defined(TMC_HOME_PHASE)
+  #ifdef TMC_HOME_PHASE
     /**
      * Move the axis back to its home_phase if set and driver is capable (TMC)
      *

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -1393,7 +1393,7 @@ void prepare_line_to_destination() {
     TERN_(I2C_POSITION_ENCODERS, I2CPEM.unhomed(axis));
   }
 
-  #if ENABLED(TMC_HOME_PHASE)
+  #if defined(TMC_HOME_PHASE)
     /**
      * Move the axis back to its home_phase if set and driver is capable (TMC)
      *


### PR DESCRIPTION
### Description

Fix compilation error when TMC_HOME_PHASE is defined. 

### Benefits

Fix #21187

### Configurations

TMC_2208 / TMC_2209

### Related Issues

#21187
