### PR TITLE
Fix handling of complex extends in platformio.ini

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -25,9 +25,12 @@ def check_envs(build_env, base_envs, config):
         return True
     ext = config.get(build_env, 'extends', default=None)
     if ext:
-        for ext_env in ext:
-            if check_envs(ext_env, base_envs, config):
-                return True
+        if isinstance(ext, str):
+            return check_envs(ext, base_envs, config)
+        elif isinstance(ext, list):
+            for ext_env in ext:
+                if check_envs(ext_env, base_envs, config):
+                    return True
     return False
 
 # Sanity checks:
@@ -55,8 +58,8 @@ if not result:
 #
 # Check for Config files in two common incorrect places
 #
-for p in [ env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config") ]:
-	for f in [ "Configuration.h", "Configuration_adv.h" ]:
-		if os.path.isfile(os.path.join(p, f)):
-			err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p
-			raise SystemExit(err)
+for p in [env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config")]:
+    for f in ["Configuration.h", "Configuration_adv.h"]:
+        if os.path.isfile(os.path.join(p, f)):
+            err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p
+            raise SystemExit(err)

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -1,6 +1,6 @@
 #
 # preflight-checks.py
-# Script to check for common issues prior to compiling
+# Check for common issues prior to compiling
 #
 import os
 import re
@@ -58,8 +58,8 @@ if not result:
 #
 # Check for Config files in two common incorrect places
 #
-for p in [env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config")]:
-    for f in ["Configuration.h", "Configuration_adv.h"]:
+for p in [ env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config") ]:
+    for f in [ "Configuration.h", "Configuration_adv.h" ]:
         if os.path.isfile(os.path.join(p, f)):
             err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p
             raise SystemExit(err)


### PR DESCRIPTION
### Description

This is minor follow-up for PR #21068. 

This PR fixes corner case when custom PlatformIO env section is referencing
a non-env section via 'extends' directive. In that case PlatformIO Config APIs will return single string instead of array, which needs to be handled differently.

It also fixes some of the Python formatting conventions (tabs vs spaces mix in single file).

### Requirements

### Benefits

Fixes corner case for advanced users.

### Configurations

example platformio.ini:

```ini
[melzi_custom_flags]
extends = env:melzi
build_flags = ${env:melzi.build_flags} -ffast-math

[env:my_custom_build_env]
extends = melzi_custom_flags
extra_scripts  = pre:buildroot/share/PlatformIO/scripts/custom_pre_hook.py
                 ${melzi_custom_flags.extra_scripts}

```


### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
