### PR TITLE
Fix PlatformIO Ledger Env to avoid breaking PIO clean

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1385,7 +1385,7 @@ board_build.firmware = Lerdge_X_firmware_force.bin
 # Lerdge X with USB Flash Drive Support
 #
 [env:LERDGEX_usb_flash_drive]
-platform          = ${LERDGEX.platform}
+platform          = ${env:LERDGEX.platform}
 extends           = LERDGEX
 platform_packages = ${stm32_flash_drive.platform_packages}
 build_flags       = ${stm32_flash_drive.build_flags}
@@ -1402,7 +1402,7 @@ board_build.firmware = Lerdge_firmware_force.bin
 # Lerdge S with USB Flash Drive Support
 #
 [env:LERDGES_usb_flash_drive]
-platform          = ${LERDGES.platform}
+platform          = ${env:LERDGES.platform}
 extends           = LERDGES
 platform_packages = ${stm32_flash_drive.platform_packages}
 build_flags       = ${stm32_flash_drive.build_flags}
@@ -1421,7 +1421,7 @@ build_flags          = ${lerdge_common.build_flags}
 # Lerdge K with USB Flash Drive Support
 #
 [env:LERDGEK_usb_flash_drive]
-platform          = ${LERDGEK.platform}
+platform          = ${env:LERDGEK.platform}
 extends           = LERDGEK
 platform_packages = ${stm32_flash_drive.platform_packages}
 build_flags       = ${stm32_flash_drive.build_flags}


### PR DESCRIPTION
### Description

Invalid env or configs on `platformio.ini` is breaking pio clean routine.

See #21203 

This PR fix that.
