### PR TITLE
M106 / M107 duplicated mode handling

### DIFF
--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -81,6 +81,11 @@ void GcodeSuite::M106() {
 
     // Set speed, with constraint
     thermalManager.set_fan_speed(pfan, speed);
+
+    #if ENABLED(DUAL_X_CARRIAGE)
+      if (idex_is_duplicating())
+        thermalManager.set_fan_speed(1, speed);
+    #endif
   }
 }
 
@@ -90,6 +95,11 @@ void GcodeSuite::M106() {
 void GcodeSuite::M107() {
   const uint8_t p = parser.byteval('P', _ALT_P);
   thermalManager.set_fan_speed(p, 0);
+
+  #if ENABLED(DUAL_X_CARRIAGE)
+    if (idex_is_duplicating())
+      thermalManager.set_fan_speed(1, 0);
+  #endif
 }
 
 #endif // HAS_FAN

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -83,7 +83,7 @@ void GcodeSuite::M106() {
     thermalManager.set_fan_speed(pfan, speed);
 
     if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
-      thermalManager.set_fan_speed(1, speed);
+      thermalManager.set_fan_speed(1 - pfan, speed);
   }
 }
 
@@ -92,10 +92,12 @@ void GcodeSuite::M106() {
  */
 void GcodeSuite::M107() {
   const uint8_t pfan = parser.byteval('P', _ALT_P);
-  thermalManager.set_fan_speed(pfan, 0);
+  if (pfan < _CNT_P) {
+    thermalManager.set_fan_speed(pfan, 0);
 
-  if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
-    thermalManager.set_fan_speed(1, 0);
+    if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
+      thermalManager.set_fan_speed(1 - pfan, 0);
+  }
 }
 
 #endif // HAS_FAN

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -82,10 +82,8 @@ void GcodeSuite::M106() {
     // Set speed, with constraint
     thermalManager.set_fan_speed(pfan, speed);
 
-    #if ENABLED(DUAL_X_CARRIAGE)
-      if (idex_is_duplicating())
-        thermalManager.set_fan_speed(1, speed);
-    #endif
+    if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
+      thermalManager.set_fan_speed(1, speed);
   }
 }
 
@@ -93,13 +91,11 @@ void GcodeSuite::M106() {
  * M107: Fan Off
  */
 void GcodeSuite::M107() {
-  const uint8_t p = parser.byteval('P', _ALT_P);
-  thermalManager.set_fan_speed(p, 0);
+  const uint8_t pfan = parser.byteval('P', _ALT_P);
+  thermalManager.set_fan_speed(pfan, 0);
 
-  #if ENABLED(DUAL_X_CARRIAGE)
-    if (idex_is_duplicating())
-      thermalManager.set_fan_speed(1, 0);
-  #endif
+  if (TERN0(DUAL_X_CARRIAGE, idex_is_duplicating()))  // pfan == 0 when duplicating
+    thermalManager.set_fan_speed(1, 0);
 }
 
 #endif // HAS_FAN


### PR DESCRIPTION
### Description
As per request, I create this PR, it is my very first one, so please be indulgent.

### Benefits
Theses minor changes merely duplicate the fan speed to the second extruder while printing in duplicated mode (IDEX).
This will complete the Duplicated / Mirror implementation.

### Related Issues
This is the PR for the Issue #21206 
