### PR TITLE
Fix M876 called from EP (STM32F103, et.al.)

### DIFF
--- a/Marlin/src/feature/host_actions.cpp
+++ b/Marlin/src/feature/host_actions.cpp
@@ -143,24 +143,16 @@ void host_action(PGM_P const pstr, const bool eol) {
   //  - Dismissal of info
   //
   void host_response_handler(const uint8_t response) {
-    #ifdef DEBUG_HOST_ACTIONS
-      static PGMSTR(m876_prefix, "M876 Handle Re");
-      serialprintPGM(m876_prefix); SERIAL_ECHOLNPAIR("ason: ", host_prompt_reason);
-      serialprintPGM(m876_prefix); SERIAL_ECHOLNPAIR("sponse: ", response);
-    #endif
-    PGM_P msg = PSTR("UNKNOWN STATE");
     const PromptReason hpr = host_prompt_reason;
     host_prompt_reason = PROMPT_NOT_DEFINED;  // Reset now ahead of logic
     switch (hpr) {
       case PROMPT_FILAMENT_RUNOUT:
-        msg = PSTR("FILAMENT_RUNOUT");
         switch (response) {
 
           case 0: // "Purge More" button
             #if BOTH(HAS_LCD_MENU, ADVANCED_PAUSE_FEATURE)
               pause_menu_response = PAUSE_RESPONSE_EXTRUDE_MORE;  // Simulate menu selection (menu exits, doesn't extrude more)
             #endif
-            filament_load_host_prompt();                          // Initiate another host prompt. (NOTE: The loop in load_filament may also do this!)
             break;
 
           case 1: // "Continue" / "Disable Runout" button
@@ -178,23 +170,17 @@ void host_action(PGM_P const pstr, const bool eol) {
         break;
       case PROMPT_USER_CONTINUE:
         TERN_(HAS_RESUME_CONTINUE, wait_for_user = false);
-        msg = PSTR("FILAMENT_RUNOUT_CONTINUE");
         break;
       case PROMPT_PAUSE_RESUME:
-        msg = PSTR("LCD_PAUSE_RESUME");
         #if BOTH(ADVANCED_PAUSE_FEATURE, SDSUPPORT)
           extern const char M24_STR[];
           queue.inject_P(M24_STR);
         #endif
         break;
       case PROMPT_INFO:
-        msg = PSTR("GCODE_INFO");
         break;
       default: break;
     }
-    SERIAL_ECHOPGM("M876 Responding PROMPT_");
-    serialprintPGM(msg);
-    SERIAL_EOL();
   }
 
 #endif // HOST_PROMPT_SUPPORT

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -259,7 +259,7 @@ bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_l
         unscaled_e_move(purge_length, ADVANCED_PAUSE_PURGE_FEEDRATE);
       }
 
-      TERN_(HOST_PROMPT_SUPPORT, filament_load_host_prompt()); // Initiate another host prompt. (NOTE: host_response_handler may also do this!)
+      TERN_(HOST_PROMPT_SUPPORT, filament_load_host_prompt()); // Initiate another host prompt.
 
       #if HAS_LCD_MENU
         if (show_lcd) {


### PR DESCRIPTION
### Description

This change fixes crashes on STM32F103 (and probably other platforms) with the mergency M876 parser.
The host_response_handler used for M876 is called on an interrupt routine for the emergency response handler. The original routine sent output to the serial port and this causes crashed on STM32F103.
The fix removes all serial output from the routine. This should not affect the essential functionality.

### Requirements

Crash can be reproduced on boards using STM32F103, like teh BigTreeTech SKR mini E3 v1.2. A simple "M876 S0" already caused the crash.

### Benefits

This change fixes crashes on STM32F103 (and probably other platforms) with the mergency M876 parser.

### Configurations

EMERGENCY_PARSER and HOST_ACTION_COMMANDS need to be enabled

### Related Issues

It might fix issues with confirmation via the screen, but I cannot test this myself:
https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/1528
https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/1571
https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/1590
