### PR TITLE
Fix building issue with binary transfer and multiserial

### DIFF
--- a/Marlin/src/gcode/sd/M28_M29.cpp
+++ b/Marlin/src/gcode/sd/M28_M29.cpp
@@ -49,7 +49,7 @@ void GcodeSuite::M28() {
     // Binary transfer mode
     if ((card.flag.binary_mode = binary_mode)) {
       SERIAL_ECHO_MSG("Switching to Binary Protocol");
-      TERN_(HAS_MULTI_SERIAL, card.transfer_port_index = queue.port[queue.index_r]);
+      TERN_(HAS_MULTI_SERIAL, card.transfer_port_index = queue.ring_buffer.command_port());
     }
     else
       card.openFileWrite(p);


### PR DESCRIPTION

### Description

As the title say. I've missed this line of code in the previous Queue rework.

### Requirements

N/A

### Benefits

Builds when both binary transfer and multiserial is enabled.

### Configurations

N/A

### Related Issues

#21122 