### PR TITLE
Update ST STM32 platform to version 12.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -734,7 +734,7 @@ board    = nxp_lpc1769
 # HAL/STM32 Base Environment values
 #
 [common_stm32]
-platform      = ststm32@~11.0
+platform      = ststm32@~12.0
 build_flags   = ${common.build_flags}
   -std=gnu++14
   -DUSBCON -DUSBD_USE_CDC
@@ -747,7 +747,7 @@ src_filter    = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/b
 # HAL/STM32F1 Common Environment values
 #
 [common_stm32f1]
-platform          = ststm32@~11.0
+platform          = ststm32@~12.0
 board_build.core  = maple
 build_flags       = !python Marlin/src/HAL/STM32F1/build_flags.py
   ${common.build_flags}


### PR DESCRIPTION
### Description

Update ststm32 package to version 12.0.

[Release notes](https://github.com/platformio/platform-ststm32/releases/tag/v12.0.0)

### Benefits

Keep the platform up-to-date.
