### PR TITLE
error: pasting ENA_ and ( does not give a valid preprocessing token

### DIFF
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -60,7 +60,7 @@ void Marlin_NeoPixel::set_color(const uint32_t color) {
   else {
     for (uint16_t i = 0; i < pixels(); ++i) {
       #ifdef NEOPIXEL_BKGD_LED_INDEX
-        if (i == NEOPIXEL_BKGD_LED_INDEX && TERN(ENABLED(NEOPIXEL_BKGD_ALWAYS_ON), true, color != 0x000000)) {
+        if (i == NEOPIXEL_BKGD_LED_INDEX && TERN(NEOPIXEL_BKGD_ALWAYS_ON, true, color != 0x000000)) {
           set_color_background();
           continue;
         }


### PR DESCRIPTION
### Description

I do get a compile error:
```
error: pasting "ENA_" and "(" does not give a valid preprocessing token
on line 63 of Marlin/src/feature/leds/neopixels.cpp
```
I did solve with
```patch
diff --git a/Marlin/src/feature/leds/neopixel.cpp b/Marlin/src/feature/leds/neopixel.cpp
index bdd22837ad..6f5ea0540a 100644
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -60,7 +60,7 @@ void Marlin_NeoPixel::set_color(const uint32_t color) {
   else {
     for (uint16_t i = 0; i < pixels(); ++i) {
       #ifdef NEOPIXEL_BKGD_LED_INDEX
-        if (i == NEOPIXEL_BKGD_LED_INDEX && TERN(NEOPIXEL_BKGD_ALWAYS_ON, true, color != 0x000000)) {
+        if (i == NEOPIXEL_BKGD_LED_INDEX && TERN(ENABLED(NEOPIXEL_BKGD_ALWAYS_ON), true, color != 0x000000)) {
           set_color_background();
           continue;
         }
```
### Configurations
Relevant parts:
Configuration.h
```cpp
#define NEOPIXEL_LED
#if ENABLED(NEOPIXEL_LED)
  #define NEOPIXEL_TYPE   NEO_GRB  // NEO_GRBW / NEO_GRB - four/three channel driver type (defined in Adafruit_NeoPixel.h)
  #define NEOPIXEL_PIN    PF13       // LED driving pin
  //#define NEOPIXEL2_TYPE NEOPIXEL_TYPE
  //#define NEOPIXEL2_PIN    5
  #define NEOPIXEL_PIXELS 9        // Number of LEDs in the strip. (Longest strip when NEOPIXEL2_SEPARATE is disabled.)
  #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
  #define NEOPIXEL_BRIGHTNESS 127  // Initial brightness (0-255)
  #define NEOPIXEL_STARTUP_TEST  // Cycle through colors at startup

  // Support for second Adafruit NeoPixel LED driver controlled with M150 S1 ...
  //#define NEOPIXEL2_SEPARATE
  #if ENABLED(NEOPIXEL2_SEPARATE)
    #define NEOPIXEL2_PIXELS      15  // Number of LEDs in the second strip
    #define NEOPIXEL2_BRIGHTNESS 127  // Initial brightness (0-255)
    #define NEOPIXEL2_STARTUP_TEST    // Cycle through colors at startup
  #else
    //#define NEOPIXEL2_INSERIES      // Default behavior is NeoPixel 2 in parallel
  #endif

  // Use a single NeoPixel LED for static (background) lighting
  #define NEOPIXEL_BKGD_LED_INDEX  8               // Index of the LED to use
  #define NEOPIXEL_BKGD_COLOR { 255, 255, 255} // R, G, B, W
  #define NEOPIXEL_BKGD_ALWAYS_ON                  // Keep the backlight on when other NeoPixels are off
#endif
```
Configuration_adv.h
```cpp
#define CASE_LIGHT_ENABLE
#if ENABLED(CASE_LIGHT_ENABLE)
  #define CASE_LIGHT_PIN NEOPIXEL_PIN         // Override the default pin if needed
  #define INVERT_CASE_LIGHT false             // Set true if Case Light is ON when pin is LOW
  #define CASE_LIGHT_DEFAULT_ON true          // Set default power-up state on
  #define CASE_LIGHT_DEFAULT_BRIGHTNESS 105   // Set default power-up brightness (0-255, requires PWM pin)
  //#define CASE_LIGHT_NO_BRIGHTNESS          // Disable brightness control. Enable for non-PWM lighting.
  //#define CASE_LIGHT_MAX_PWM 128            // Limit PWM duty cycle (0-255)
  #define CASE_LIGHT_MENU                   // Add Case Light options to the LCD menu
  #if ENABLED(NEOPIXEL_LED)
    #define CASE_LIGHT_USE_NEOPIXEL         // Use NeoPixel LED as case light
  #endif
  #if EITHER(RGB_LED, RGBW_LED)
    //#define CASE_LIGHT_USE_RGB_LED          // Use RGB / RGBW LED as case light
  #endif
  #if EITHER(CASE_LIGHT_USE_NEOPIXEL, CASE_LIGHT_USE_RGB_LED)
    #define CASE_LIGHT_DEFAULT_COLOR { 255, 255, 255 } // { Red, Green, Blue, White }
  #endif
#endif
```
### Related Issues

#20341 