### PR TITLE
Correct MKS Robin Nano v3 Fan pins

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -165,8 +165,8 @@
 #define HEATER_1_PIN                        PB0   // HEATER2
 #define HEATER_BED_PIN                      PA0   // HOT BED
 
-#define FAN_PIN                             PB1   // FAN
-#define FAN1_PIN                            PC14  // FAN1
+#define FAN_PIN                             PC14  // FAN
+#define FAN1_PIN                            PB1   // FAN1
 
 //
 // Thermocouples


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

According to [MKS Robin Nano V3.0 pinout](https://github.com/makerbase-mks/MKS-Robin-Nano-V3.X/blob/main/hardware/MKS%20Robin%20Nano%20V3.0_003/MKS%20Robin%20Nano%20V3.0_003%20PIN.pdf):
- Fan1 pin is PC14
- Fan2 pin is PB1

So to use Fan1 connector as default the correct values should be:
#define FAN_PIN PC14 // FAN
#define FAN1_PIN PB1 // FAN1

### Requirements

MKS Robin Nano 3 board

### Benefits

An ability to use Fan1 connector as default if only one fan is used.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6068034/Configuration.zip)

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

