### PR TITLE
Fix multi-serial CRC error crash

### DIFF
--- a/Marlin/src/gcode/control/M999.cpp
+++ b/Marlin/src/gcode/control/M999.cpp
@@ -41,5 +41,5 @@ void GcodeSuite::M999() {
 
   if (parser.boolval('S')) return;
 
-  queue.flush_and_request_resend();
+  queue.flush_and_request_resend(queue.ring_buffer.command_port());
 }

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -396,10 +396,6 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
 
       case 92: G92(); break;                                      // G92: Set current axis position(s)
 
-      #if HAS_MESH
-        case 42: G42(); break;                                    // G42: Coordinated move to a mesh point
-      #endif
-
       #if ENABLED(CALIBRATION_GCODE)
         case 425: G425(); break;                                  // G425: Perform calibration with calibration cube
       #endif

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -262,8 +262,7 @@ void GCodeQueue::RingBuffer::ok_to_send() {
  * Send a "Resend: nnn" message to the host to
  * indicate that a command needs to be re-sent.
  */
-void GCodeQueue::flush_and_request_resend() {
-  const serial_index_t serial_ind = ring_buffer.command_port();
+void GCodeQueue::flush_and_request_resend(const serial_index_t& serial_ind) {
   #if HAS_MULTI_SERIAL
     if (serial_ind < 0) return;                   // Never mind. Command came from SD or Flash Drive
     PORT_REDIRECT(SERIAL_PORTMASK(serial_ind));   // Reply to the serial port that sent the command
@@ -301,12 +300,12 @@ inline bool serial_data_available(uint8_t index = SERIAL_ALL) {
 
 inline int read_serial(const uint8_t index) { return SERIAL_IMPL.read(index); }
 
-void GCodeQueue::gcode_line_error(PGM_P const err, const serial_index_t serial_ind) {
+void GCodeQueue::gcode_line_error(PGM_P const err, const serial_index_t& serial_ind) {
   PORT_REDIRECT(SERIAL_PORTMASK(serial_ind)); // Reply to the serial port that sent the command
   SERIAL_ERROR_START();
   SERIAL_ECHOLNPAIR_P(err, serial_state[serial_ind].last_N);
   while (read_serial(serial_ind) != -1) { /* nada */ } // Clear out the RX buffer. Why don't use flush here ?
-  flush_and_request_resend();
+  flush_and_request_resend(serial_ind);
   serial_state[serial_ind].count = 0;
 }
 

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -262,7 +262,7 @@ void GCodeQueue::RingBuffer::ok_to_send() {
  * Send a "Resend: nnn" message to the host to
  * indicate that a command needs to be re-sent.
  */
-void GCodeQueue::flush_and_request_resend(const serial_index_t& serial_ind) {
+void GCodeQueue::flush_and_request_resend(const serial_index_t serial_ind) {
   #if HAS_MULTI_SERIAL
     if (serial_ind < 0) return;                   // Never mind. Command came from SD or Flash Drive
     PORT_REDIRECT(SERIAL_PORTMASK(serial_ind));   // Reply to the serial port that sent the command
@@ -300,7 +300,7 @@ inline bool serial_data_available(uint8_t index = SERIAL_ALL) {
 
 inline int read_serial(const uint8_t index) { return SERIAL_IMPL.read(index); }
 
-void GCodeQueue::gcode_line_error(PGM_P const err, const serial_index_t& serial_ind) {
+void GCodeQueue::gcode_line_error(PGM_P const err, const serial_index_t serial_ind) {
   PORT_REDIRECT(SERIAL_PORTMASK(serial_ind)); // Reply to the serial port that sent the command
   SERIAL_ERROR_START();
   SERIAL_ECHOLNPAIR_P(err, serial_state[serial_ind].last_N);

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -185,7 +185,7 @@ public:
    * Clear the serial line and request a resend of
    * the next expected line number.
    */
-  static void flush_and_request_resend();
+  static void flush_and_request_resend(const serial_index_t& serial_ind);
 
   /**
    * (Re)Set the current line number for the last received command
@@ -212,7 +212,7 @@ private:
    */
   static bool enqueue_one(const char* cmd);
 
-  static void gcode_line_error(PGM_P const err, const serial_index_t serial_ind);
+  static void gcode_line_error(PGM_P const err, const serial_index_t& serial_ind);
 
   friend class GcodeSuite;
 };

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -185,7 +185,7 @@ public:
    * Clear the serial line and request a resend of
    * the next expected line number.
    */
-  static void flush_and_request_resend(const serial_index_t& serial_ind);
+  static void flush_and_request_resend(const serial_index_t serial_ind);
 
   /**
    * (Re)Set the current line number for the last received command
@@ -212,7 +212,7 @@ private:
    */
   static bool enqueue_one(const char* cmd);
 
-  static void gcode_line_error(PGM_P const err, const serial_index_t& serial_ind);
+  static void gcode_line_error(PGM_P const err, const serial_index_t serial_ind);
 
   friend class GcodeSuite;
 };


### PR DESCRIPTION
### Description

If we get a CRC error when using more than one serial, the old code inside `flush_and_request_resend` will get the wrong serial index from `ring_buffer.command_port()`, because the current command wasn't queue yet.
So I made it receive the index by parameter.

~~I was having another crash too, related with the parameter `const serial_index_t serial_ind`. For some strange reason, the compiler was optimising the array access `serial_state[serial_ind].last_N` using a non sense value for `serial_ind`. The issue vanished when I started to use reference as parameter.~~
~~Link the pictures showing the issue: https://github.com/MarlinFirmware/Marlin/issues/21010#issuecomment-790657773~~

~~Maybe it was a issue trigged by too many debugging sessions... or by wrong gcc optimisation... I don't know. If don't have pictures, I would not believe.~~
After a full build, it seems solved the const/ref issue..

I'm attaching a simple script that I used to test the serial.

### Benefits

More stable multi serial.
May fix #21010 and #21244 


[test-serial.py.txt](https://github.com/MarlinFirmware/Marlin/files/6085870/test-serial.py.txt)

