### PR TITLE
Fix SKR 1.4 UART3 Environment

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -729,7 +729,7 @@ board    = nxp_lpc1769
 
 # BTT SKR 1.4 needs a UART3 tweak
 [env:LPC1768_btt_skr_v1_4]
-platform    = ${LPC1768.platform}
+platform    = ${env:LPC1768.platform}
 extends     = env:LPC1768
 build_flags = ${env:LPC1768.build_flags} -DLPC_PINCFG_UART3_P4_28
 


### PR DESCRIPTION
### Description

PR https://github.com/MarlinFirmware/Marlin/pull/21254 introduced some new warnings & build errors for the SKR 1.4, so this corrects the platform line so the new `LPC1768_btt_skr_v1_4` PIO environment compiles correctly.

H/T to @rhapsodyv for the fix.

### Requirements

SKR 1.4 with new `LPC1768_btt_skr_v1_4` PIO environment.

### Benefits

No more "_Can not remove temporary directory `/github/Marlin/.pio/build`. Please remove it manually to avoid build issues_" or  "_Error: Invalid '/github/Marlin/platformio.ini' (project configuration file): 'No section: 'LPC1768''_" warnings/errors.

### Configurations

Any `BOARD_BTT_SKR_V1_4` config.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/21259