### PR TITLE
Restore board-based build flags

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -27,6 +27,10 @@
   #define BOARD_INFO_NAME "BTT SKR V1.4"
 #endif
 
+#ifndef BOARD_CUSTOM_BUILD_FLAGS
+  #define BOARD_CUSTOM_BUILD_FLAGS -DLPC_PINCFG_UART3_P4_28
+#endif
+
 //
 // SD Connection
 //

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -401,7 +401,7 @@
 #elif MB(TH3D_EZBOARD)
   #include "lpc1769/pins_TH3D_EZBOARD.h"        // LPC1769                                env:LPC1769
 #elif MB(BTT_SKR_V1_4_TURBO)
-  #include "lpc1769/pins_BTT_SKR_V1_4_TURBO.h"  // LPC1769                                env:LPC1769
+  #include "lpc1769/pins_BTT_SKR_V1_4_TURBO.h"  // LPC1769                                env:LPC1769_btt_skr_v1_4_turbo
 #elif MB(MKS_SGEN_L_V2)
   #include "lpc1769/pins_MKS_SGEN_L_V2.h"       // LPC1769                                env:LPC1769
 #elif MB(BTT_SKR_E3_TURBO)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -401,7 +401,7 @@
 #elif MB(TH3D_EZBOARD)
   #include "lpc1769/pins_TH3D_EZBOARD.h"        // LPC1769                                env:LPC1769
 #elif MB(BTT_SKR_V1_4_TURBO)
-  #include "lpc1769/pins_BTT_SKR_V1_4_TURBO.h"  // LPC1769                                env:LPC1769_btt_skr_v1_4_turbo
+  #include "lpc1769/pins_BTT_SKR_V1_4_TURBO.h"  // LPC1769                                env:LPC1769
 #elif MB(MKS_SGEN_L_V2)
   #include "lpc1769/pins_MKS_SGEN_L_V2.h"       // LPC1769                                env:LPC1769
 #elif MB(BTT_SKR_E3_TURBO)

--- a/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
+++ b/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
@@ -43,6 +43,9 @@
   #warning "Serial 3 is originally reserved to Y limit switches. Hardware changes are required to use it."
 #endif
 
+// Custom flags and defines for the build
+//#define BOARD_CUSTOM_BUILD_FLAGS -D__FOO__
+
 #define BOARD_INFO_NAME "LGT KIT V1.0"
 
 //

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -47,6 +47,9 @@
 
 #include "env_validate.h"
 
+// Custom flags and defines for the build
+//#define BOARD_CUSTOM_BUILD_FLAGS -D__FOO__
+
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "RAMPS 1.4"
 #endif

--- a/Marlin/src/pins/ramps/pins_RAMPS_S_12.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_S_12.h
@@ -36,6 +36,9 @@
 
 #include "env_validate.h"
 
+// Custom flags and defines for the build
+//#define BOARD_CUSTOM_BUILD_FLAGS -D__FOO__
+
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "RAMPS S 1.2"
 #endif

--- a/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
@@ -1,0 +1,16 @@
+#
+# common-dependencies-post.py
+# Convenience script to add build flags for Marlin Enabled Features
+#
+
+Import("env")
+Import("projenv")
+
+def apply_board_build_flags():
+	if not 'BOARD_CUSTOM_BUILD_FLAGS' in env['MARLIN_FEATURES']:
+		return
+	projenv.Append(CCFLAGS=env['MARLIN_FEATURES']['BOARD_CUSTOM_BUILD_FLAGS'].split())
+
+# We need to add the board build flags in a post script
+# so the platform build script doesn't overwrite the custom CCFLAGS
+apply_board_build_flags()

--- a/platformio.ini
+++ b/platformio.ini
@@ -215,6 +215,7 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
   pre:buildroot/share/PlatformIO/scripts/preflight-checks.py
+  post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
 build_flags        = -fmax-errors=5 -g3 -D__MARLIN_FIRMWARE__ -fmerge-constants
 lib_deps           =
 
@@ -726,18 +727,6 @@ board    = nxp_lpc1768
 platform = ${common_LPC.platform}
 extends  = common_LPC
 board    = nxp_lpc1769
-
-# BTT SKR 1.4 needs a UART3 tweak
-[env:LPC1768_btt_skr_v1_4]
-platform    = ${env:LPC1768.platform}
-extends     = env:LPC1768
-build_flags = ${env:LPC1768.build_flags} -DLPC_PINCFG_UART3_P4_28
-
-# BTT SKR 1.4 Turbo needs a UART3 tweak
-[env:LPC1769_btt_skr_v1_4_turbo]
-platform    = ${env:LPC1769.platform}
-extends     = env:LPC1769
-build_flags = ${env:LPC1769.build_flags} -DLPC_PINCFG_UART3_P4_28
 
 #################################
 #                               #

--- a/platformio.ini
+++ b/platformio.ini
@@ -733,6 +733,12 @@ platform    = ${env:LPC1768.platform}
 extends     = env:LPC1768
 build_flags = ${env:LPC1768.build_flags} -DLPC_PINCFG_UART3_P4_28
 
+# BTT SKR 1.4 Turbo needs a UART3 tweak
+[env:LPC1769_btt_skr_v1_4_turbo]
+platform    = ${env:LPC1769.platform}
+extends     = env:LPC1769
+build_flags = ${env:LPC1769.build_flags} -DLPC_PINCFG_UART3_P4_28
+
 #################################
 #                               #
 #      STM32 Architecture       #


### PR DESCRIPTION
### Description

The SKR 1.4 & 1.4 Turbo are identical boards except for the MCU. The regular 1.4 has an LPC1768 and the Turbo has an upgraded LPC1769.

### Requirements

Any SKR 1.4 Turbo config.

### Benefits

Adds an SKR 1.4 Turbo (LPC1769) PIO environment to accompany the new SKR 1.4 (LPC1768) PIO environment.

### Configurations

Any base config with `BOARD_BTT_SKR_V1_4_TURBO`.

### Related Issues

None, but has been brought up a couple times in previous PRs & something I ran into with the Prusa SKR Bear project.