### PR TITLE
fix  compile error with DWIN_CREALITY_LCD on SKR14

### DIFF
--- a/Marlin/src/lcd/dwin/dwin_lcd.cpp
+++ b/Marlin/src/lcd/dwin/dwin_lcd.cpp
@@ -95,7 +95,7 @@ bool DWIN_Handshake(void) {
   #endif
   LCD_SERIAL.begin(LCD_BAUDRATE);
   const millis_t serial_connect_timeout = millis() + 1000UL;
-  while (!LCD_SERIAL && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+  while (!LCD_SERIAL.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
 
   size_t i = 0;
   DWIN_Byte(i, 0x00);


### PR DESCRIPTION
### Description

At present enabling DWIN_CREALITY_LCD on a BOARD_BTT_SKR_V1_4_TURBO fails to compile.

```
Marlin/src/lcd/dwin/dwin_lcd.cpp:99:10: error: no match for 'operator!' (operand type is 'MSerialT' {aka 'ForwardSerial<MarlinSerial>'})
   99 |   while (!LCD_SERIAL && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
Marlin/src/lcd/dwin/dwin_lcd.cpp:99:10: note: candidate: 'operator!(bool)' <built-in>
Marlin/src/lcd/dwin/dwin_lcd.cpp:99:10: note:   no known conversion for argument 1 from 'MSerialT' {aka 'ForwardSerial<MarlinSerial>'} to 'bool'
```

### Requirements

enabling DWIN_CREALITY_LCD on a BOARD_BTT_SKR_V1_4_TURBO (or non turbo, or V1_3)
A custom cable, incompatible pinout and no serial ports on EXP1 on these boards.

### Benefits

Compiles as expected

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6095305/Configuration.zip)

### Related Issues
Was discussed with Omgpewpewpewlazer on Discord in Marlin-v2