### PR TITLE
fixes #21275, rename missed DEBUG_PRINT_P to DEBUG_ECHOPGM_P

### DIFF
--- a/Marlin/src/core/debug_out.h
+++ b/Marlin/src/core/debug_out.h
@@ -27,7 +27,7 @@
 //
 
 #undef DEBUG_SECTION
-#undef DEBUG_PRINT_P
+#undef DEBUG_ECHOPGM_P
 #undef DEBUG_ECHO_START
 #undef DEBUG_ERROR_START
 #undef DEBUG_CHAR


### PR DESCRIPTION
### Description

Fixes issue #21275 
Marlin/src/core/debug_out.h has a left over DEBUG_PRINT_P should now be DEBUG_ECHOPGM_P since https://github.com/MarlinFirmware/Marlin/pull/21231 

### Requirements
Debugging. eg enable DEBUG_LEVELING_FEATURE

### Benefits

Stops all the "warning: "DEBUG_ECHOPGM_P" redefined" 

### Configurations

See issue #21275

### Related Issues
#21231 