### PR TITLE
Fix M303 patch regression

### DIFF
--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -51,7 +51,7 @@ void GcodeSuite::M303() {
       thermalManager.pid_debug_flag ^= true;
       SERIAL_ECHO_START();
       SERIAL_ECHOPGM("PID Debug ");
-      serialprintln_onoff(pid_debug_flag);
+      serialprintln_onoff(thermalManager.pid_debug_flag);
       return;
     }
   #endif


### PR DESCRIPTION
### Description

error: 'pid_debug_flag' was not declared in this scope; 

Changed to thermalManager.pid_debug_flag
 
### Requirements

PID_DEBUG

### Benefits

Compiles as expected

### Configurations

See Issue #21280

### Related Issues

Issue #21280