### PR TITLE
Fix Host Keepalive serial output with multi-serial

### DIFF
--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
@@ -22,6 +22,8 @@
 #pragma once
 
 #include <HardwareSerial.h>
+
+#include "../shared/Marduino.h"
 #include "../../core/serial_hook.h"
 
 class FlushableHardwareSerial : public HardwareSerial {

--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
@@ -21,8 +21,7 @@
  */
 #pragma once
 
-#ifdef ARDUINO_ARCH_ESP32
-
+#include "../shared/serial_hook.h"
 #include <HardwareSerial.h>
 #include "../../core/serial_hook.h"
 
@@ -32,5 +31,3 @@ public:
 };
 
 extern Serial0Type<FlushableHardwareSerial> flushableSerial;
-
-#endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
@@ -21,7 +21,6 @@
  */
 #pragma once
 
-#include "../shared/serial_hook.h"
 #include <HardwareSerial.h>
 #include "../../core/serial_hook.h"
 

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -62,7 +62,7 @@ extern uint8_t marlin_debug_flags;
 //
 // Serial redirection
 //
-#define SERIAL_ALL 0x7F
+#define SERIAL_ALL 0xFF
 #if HAS_MULTI_SERIAL
   #define _PORT_REDIRECT(n,p)   REMEMBER(n,multiSerial.portMask,p)
   #define _PORT_RESTORE(n,p)    RESTORE(n)

--- a/Marlin/src/core/serial_hook.h
+++ b/Marlin/src/core/serial_hook.h
@@ -165,12 +165,12 @@ struct RuntimeSerial : public SerialBase< RuntimeSerial<SerialT> >, public Seria
   RuntimeSerial(const bool e, Args... args) : BaseClassT(e), SerialT(args...), writeHook(0), eofHook(0), userPointer(0) {}
 };
 
-// A class that's duplicating its output conditionally to 2 serial interface
+// A class that duplicates its output conditionally to 2 serial interfaces
 template <class Serial0T, class Serial1T, const uint8_t offset = 0, const uint8_t step = 1>
 struct MultiSerial : public SerialBase< MultiSerial<Serial0T, Serial1T, offset, step> > {
   typedef SerialBase< MultiSerial<Serial0T, Serial1T, offset, step> > BaseClassT;
 
-  uint8_t    portMask;
+  uint8_t    portMask = SERIAL_ALL;
   Serial0T & serial0;
   Serial1T & serial1;
 

--- a/Marlin/src/core/serial_hook.h
+++ b/Marlin/src/core/serial_hook.h
@@ -170,7 +170,7 @@ template <class Serial0T, class Serial1T, const uint8_t offset = 0, const uint8_
 struct MultiSerial : public SerialBase< MultiSerial<Serial0T, Serial1T, offset, step> > {
   typedef SerialBase< MultiSerial<Serial0T, Serial1T, offset, step> > BaseClassT;
 
-  uint8_t    portMask = 0xFF;
+  uint8_t    portMask;
   Serial0T & serial0;
   Serial1T & serial1;
 

--- a/Marlin/src/core/serial_hook.h
+++ b/Marlin/src/core/serial_hook.h
@@ -170,7 +170,7 @@ template <class Serial0T, class Serial1T, const uint8_t offset = 0, const uint8_
 struct MultiSerial : public SerialBase< MultiSerial<Serial0T, Serial1T, offset, step> > {
   typedef SerialBase< MultiSerial<Serial0T, Serial1T, offset, step> > BaseClassT;
 
-  uint8_t    portMask = SERIAL_ALL;
+  uint8_t    portMask = 0xFF;
   Serial0T & serial0;
   Serial1T & serial1;
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -1062,6 +1062,7 @@ void GcodeSuite::process_subcommands_now(char * gcode) {
     static millis_t next_busy_signal_ms = 0;
     if (!autoreport_paused && host_keepalive_interval && busy_state != NOT_BUSY) {
       if (PENDING(ms, next_busy_signal_ms)) return;
+      PORT_REDIRECT(SERIAL_ALL);
       switch (busy_state) {
         case IN_HANDLER:
         case IN_PROCESS:

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -272,7 +272,7 @@ void GCodeQueue::flush_and_request_resend(const serial_index_t serial_ind) {
   SERIAL_ECHOLN(serial_state[serial_ind].last_N + 1);
 }
 
-inline bool serial_data_available(int8_t index) {
+inline bool serial_data_available(uint8_t index) {
   const int a = SERIAL_IMPL.available(index);
   #if BOTH(RX_BUFFER_MONITOR, RX_BUFFER_SIZE)
     if (a > RX_BUFFER_SIZE - 2) {

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -272,21 +272,7 @@ void GCodeQueue::flush_and_request_resend(const serial_index_t serial_ind) {
   SERIAL_ECHOLN(serial_state[serial_ind].last_N + 1);
 }
 
-// Multiserial already handle the dispatch to/from multiple port by itself
-inline bool serial_data_available(uint8_t index = SERIAL_ALL) {
-  if (index == SERIAL_ALL) {
-    for (index = 0; index < NUM_SERIAL; index++) {
-      const int a = SERIAL_IMPL.available(index);
-      #if BOTH(RX_BUFFER_MONITOR, RX_BUFFER_SIZE)
-        if (a > RX_BUFFER_SIZE - 2) {
-          PORT_REDIRECT(SERIAL_PORTMASK(index));
-          SERIAL_ERROR_MSG("RX BUF overflow, increase RX_BUFFER_SIZE: ", a);
-        }
-      #endif
-      if (a > 0) return true;
-    }
-    return false;
-  }
+inline bool serial_data_available(int8_t index) {
   const int a = SERIAL_IMPL.available(index);
   #if BOTH(RX_BUFFER_MONITOR, RX_BUFFER_SIZE)
     if (a > RX_BUFFER_SIZE - 2) {
@@ -294,8 +280,14 @@ inline bool serial_data_available(uint8_t index = SERIAL_ALL) {
       SERIAL_ERROR_MSG("RX BUF overflow, increase RX_BUFFER_SIZE: ", a);
     }
   #endif
-
   return a > 0;
+}
+
+// Multiserial already handles dispatch to/from multiple ports
+inline bool any_serial_data_available() {
+  LOOP_L_N(p, NUM_SERIAL)
+    if (serial_data_available(p))
+      return true;
 }
 
 inline int read_serial(const uint8_t index) { return SERIAL_IMPL.read(index); }
@@ -409,7 +401,7 @@ void GCodeQueue::get_serial_commands() {
   // send "wait" to indicate Marlin is still waiting.
   #if NO_TIMEOUTS > 0
     const millis_t ms = millis();
-    if (ring_buffer.empty() && !serial_data_available() && ELAPSED(ms, last_command_time + NO_TIMEOUTS)) {
+    if (ring_buffer.empty() && !any_serial_data_available() && ELAPSED(ms, last_command_time + NO_TIMEOUTS)) {
       SERIAL_ECHOLNPGM(STR_WAIT);
       last_command_time = ms;
     }

--- a/platformio.ini
+++ b/platformio.ini
@@ -423,7 +423,7 @@ MORGAN_SCARA            = src_filter=+<src/gcode/scara>
 HAS_MICROSTEPS          = src_filter=+<src/gcode/control/M350_M351.cpp>
 (ESP3D_)?WIFISUPPORT    = AsyncTCP, ESP Async WebServer
   ESP3DLib=https://github.com/luc-github/ESP3DLib.git
-  arduinoWebSockets=https://github.com/Links2004/arduinoWebSockets/archive/2.3.4.zip
+  arduinoWebSockets=links2004/WebSockets@2.3.4
   ESP32SSDP=https://github.com/luc-github/ESP32SSDP.git
   lib_ignore=ESPAsyncTCP
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -422,9 +422,9 @@ HAS_SERVOS              = src_filter=+<src/module/servo.cpp> +<src/gcode/control
 MORGAN_SCARA            = src_filter=+<src/gcode/scara>
 HAS_MICROSTEPS          = src_filter=+<src/gcode/control/M350_M351.cpp>
 (ESP3D_)?WIFISUPPORT    = AsyncTCP, ESP Async WebServer
-  ESP3DLib=https://github.com/luc-github/ESP3DLib.git
+  ESP3DLib=https://github.com/luc-github/ESP3DLib/archive/master.zip
   arduinoWebSockets=links2004/WebSockets@2.3.4
-  ESP32SSDP=https://github.com/luc-github/ESP32SSDP.git
+  luc-github/ESP32SSDP@^1.1.1
   lib_ignore=ESPAsyncTCP
 
 #

--- a/platformio.ini
+++ b/platformio.ini
@@ -423,7 +423,7 @@ MORGAN_SCARA            = src_filter=+<src/gcode/scara>
 HAS_MICROSTEPS          = src_filter=+<src/gcode/control/M350_M351.cpp>
 (ESP3D_)?WIFISUPPORT    = AsyncTCP, ESP Async WebServer
   ESP3DLib=https://github.com/luc-github/ESP3DLib.git
-  arduinoWebSockets=https://github.com/Links2004/arduinoWebSockets.git
+  arduinoWebSockets=https://github.com/Links2004/arduinoWebSockets/archive/2.3.4.zip
   ESP32SSDP=https://github.com/luc-github/ESP32SSDP.git
   lib_ignore=ESPAsyncTCP
 


### PR DESCRIPTION
### Description

This is a continuation of the stress tests I'm doing on multi serial, to fix corner cases.

I found an issue that happens in a very specific combination of events, but that can happen very often on a real printing operation: multi serial + idle stacking (slow commands that call idle until finished) + keep alive code.

When marlin is executing some slow commands, it may stay in a loop waiting for it to complete. Inside that loop, marlin may call idle periodically. So, the idle will check for new serial commands (in the other serial) to enqueue. When it receive the command, it will reply "busy" (on keep alive function), but it send to the wrong serial port.

Call stack:
```
idle
  process_next_command
    Gxxx
       while(something)
          idle
            keepalive (sent to the current serial)
            other serial tries to send data, thinks it succeeds, but marlin simply doesn't reply (until the actual commands)
            data loss and wrong behavior on the first serial (it will cause resend on serial 1)
```

I could simulate resend commands on octoprint this way. And I fixed making the keep alive reply "busy" for all serial ports... 

That in fact it seems correct, because marlin will only handle one command at time, so the keep alive should warns all serial ports that marlin is busy, to avoid timeout or false-resend commands everywhere.

### Benefits

More robust multi serial.
May fix #21010 and #21244

### Related Issues

#21249 
