### PR TITLE
fix PIN_EXISTS calls in PR 18389

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3376,7 +3376,7 @@
 //#define CUSTOM_USER_BUTTONS
 #if ENABLED(CUSTOM_USER_BUTTONS)
   //#define BUTTON1_PIN -1
-  #if PIN_EXISTS(BUTTON1_PIN)
+  #if PIN_EXISTS(BUTTON1)
     #define BUTTON1_HIT_STATE     LOW       // State of the triggered button. NC=LOW. NO=HIGH.
     #define BUTTON1_WHEN_PRINTING false     // Button allowed to trigger during printing?
     #define BUTTON1_GCODE         "G28"
@@ -3384,7 +3384,7 @@
   #endif
 
   //#define BUTTON2_PIN -1
-  #if PIN_EXISTS(BUTTON2_PIN)
+  #if PIN_EXISTS(BUTTON2)
     #define BUTTON2_HIT_STATE     LOW
     #define BUTTON2_WHEN_PRINTING false
     #define BUTTON2_GCODE         "M140 S" STRINGIFY(PREHEAT_1_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_1_TEMP_HOTEND)
@@ -3392,7 +3392,7 @@
   #endif
 
   //#define BUTTON3_PIN -1
-  #if PIN_EXISTS(BUTTON3_PIN)
+  #if PIN_EXISTS(BUTTON3)
     #define BUTTON3_HIT_STATE     LOW
     #define BUTTON3_WHEN_PRINTING false
     #define BUTTON3_GCODE         "M140 S" STRINGIFY(PREHEAT_2_TEMP_BED) "\nM104 S" STRINGIFY(PREHEAT_2_TEMP_HOTEND)


### PR DESCRIPTION
### Description

PIN_EXISTS macro appends "_PIN" automatically
In the current Configuration_adv.h that is with bugfix the following are incorrect
```cpp
#if PIN_EXISTS(BUTTON1_PIN)
#if PIN_EXISTS(BUTTON2_PIN)
#if PIN_EXISTS(BUTTON3_PIN)
```
Should be
```cpp
#if PIN_EXISTS(BUTTON1)
#if PIN_EXISTS(BUTTON2)
#if PIN_EXISTS(BUTTON3)
```

### Requirements

Current bugfix Configuration_adv.h file

### Benefits

Works as expected

### Related Issues
See comments at end of https://github.com/MarlinFirmware/Marlin/pull/18389
