### PR TITLE
G34 TouchMi bug fix

### DIFF
--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -412,7 +412,9 @@ void GcodeSuite::G34() {
 
       // Stow the probe, as the last call to probe.probe_at_point(...) left
       // the probe deployed if it was successful.
-      probe.stow();
+      #ifndef TOUCH_MI_PROBE
+        probe.stow();
+      #endif
 
       #if ENABLED(HOME_AFTER_G34)
         // After this operation the z position needs correction

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -410,11 +410,9 @@ void GcodeSuite::G34() {
         SERIAL_ECHOLNPAIR_F("Accuracy: ", z_maxdiff);
       }
 
-      // Stow the probe, as the last call to probe.probe_at_point(...) left
-      // the probe deployed if it was successful.
-      #ifndef TOUCH_MI_PROBE
-        probe.stow();
-      #endif
+      // Stow the probe because the last call to probe.probe_at_point(...)
+      // leaves the probe deployed when it's successful.
+      IF_DISABLED(TOUCH_MI_PROBE, probe.stow());
 
       #if ENABLED(HOME_AFTER_G34)
         // After this operation the z position needs correction


### PR DESCRIPTION
### Description
By the use of TouchMi probe  at the end of Z alignment the nozzle crash on the bed without z endstop or z software limit action, for TouchMi the probe.stow() call at this moment is responsible for this issue and is not necessary to be triggered.

### Requirements
At line 415 the call to probe.stow() by using the Touchmi probe stow function is moving the print head to crash on the bed. This call is for this type of probe not necessary and because the "curent_position" is altered during the G34. We have to deactivate this call when the configuration is set for TOUCH_MI_PROBE.

### Benefits
User with TouchMI could use the G34 to make Z alignment

### Configurations
n.a

### Related Issues
#21225 [G34 with TouchMi] (Nozzle crash on the bed at the end of G34)
#18888 touch-mi G34 after performing the operation, the Z drops lower than foreseen in the setting

