### PR TITLE
fix multiple issues in password feature 

### DIFF
--- a/Marlin/src/feature/password/password.cpp
+++ b/Marlin/src/feature/password/password.cpp
@@ -31,7 +31,7 @@
 Password password;
 
 // public:
-bool     Password::is_set, Password::is_locked, Password::first_run;
+bool     Password::is_set, Password::is_locked, Password::did_first_run; // = false
 uint32_t Password::value, Password::value_entry;
 
 //
@@ -49,7 +49,7 @@ void Password::lock_machine() {
 void Password::authentication_check() {
   if (value_entry == value) {
     is_locked = false;
-    first_run = false;
+    did_first_run = true;
   }
   else {
     is_locked = true;

--- a/Marlin/src/feature/password/password.cpp
+++ b/Marlin/src/feature/password/password.cpp
@@ -31,7 +31,7 @@
 Password password;
 
 // public:
-bool     Password::is_set, Password::is_locked;
+bool     Password::is_set, Password::is_locked, Password::first_run;
 uint32_t Password::value, Password::value_entry;
 
 //
@@ -47,11 +47,14 @@ void Password::lock_machine() {
 // Authentication check
 //
 void Password::authentication_check() {
-  if (value_entry == value)
+  if (value_entry == value) {
     is_locked = false;
-  else
+    first_run = false;
+  }
+  else {
+    is_locked = true;
     SERIAL_ECHOLNPGM(STR_WRONG_PASSWORD);
-
+  }
   TERN_(HAS_LCD_MENU, authentication_done());
 }
 

--- a/Marlin/src/feature/password/password.h
+++ b/Marlin/src/feature/password/password.h
@@ -25,10 +25,10 @@
 
 class Password {
 public:
-  static bool is_set, is_locked;
+  static bool is_set, is_locked, first_run;
   static uint32_t value, value_entry;
 
-  Password() { is_locked = false; }
+  Password() { is_locked = false, first_run = true; }
 
   static void lock_machine();
   static void authentication_check();

--- a/Marlin/src/feature/password/password.h
+++ b/Marlin/src/feature/password/password.h
@@ -28,7 +28,7 @@ public:
   static bool is_set, is_locked, did_first_run;
   static uint32_t value, value_entry;
 
-  Password() : is_set(false), is_locked(false), did_first_run(false); {}
+  Password() {}
 
   static void lock_machine();
   static void authentication_check();

--- a/Marlin/src/feature/password/password.h
+++ b/Marlin/src/feature/password/password.h
@@ -25,10 +25,10 @@
 
 class Password {
 public:
-  static bool is_set, is_locked, first_run;
+  static bool is_set, is_locked, did_first_run;
   static uint32_t value, value_entry;
 
-  Password() { is_locked = false, first_run = true; }
+  Password() : is_set(false), is_locked(false), did_first_run(false); {}
 
   static void lock_machine();
   static void authentication_check();

--- a/Marlin/src/lcd/menu/menu_password.cpp
+++ b/Marlin/src/lcd/menu/menu_password.cpp
@@ -44,12 +44,17 @@ static uint8_t digit_no;
 // Screen for both editing and setting the password
 //
 void Password::menu_password_entry() {
+  if (password.first_run) ui.defer_status_screen();
   START_MENU();
 
   // "Login" or "New Code"
   STATIC_ITEM_P(authenticating ? GET_TEXT(MSG_LOGIN_REQUIRED) : GET_TEXT(MSG_EDIT_PASSWORD), SS_CENTER|SS_INVERT);
 
-  STATIC_ITEM_P(NUL_STR, SS_CENTER|SS_INVERT, string);
+  STATIC_ITEM_P(NUL_STR, SS_CENTER, string);
+
+  #if HAS_MARLINUI_U8GLIB
+    STATIC_ITEM_P(NUL_STR, SS_CENTER, "");
+  #endif
 
   // Make the digit edit item look like a sub-menu
   PGM_P const label = GET_TEXT(MSG_ENTER_DIGIT);
@@ -57,7 +62,7 @@ void Password::menu_password_entry() {
   MENU_ITEM_ADDON_START(utf8_strlen_P(label) + 1);
     lcd_put_wchar(' ');
     lcd_put_wchar('1' + digit_no);
-    SETCURSOR_X(LCD_WIDTH - 1);
+    SETCURSOR_X(LCD_WIDTH - 2);
     lcd_put_wchar('>');
   MENU_ITEM_ADDON_END();
 
@@ -104,7 +109,7 @@ void Password::screen_password_entry() {
   value_entry = 0;
   digit_no = 0;
   editable.uint8 = 0;
-  memset(string, '-', PASSWORD_LENGTH);
+  memset(string, '_', PASSWORD_LENGTH);
   string[PASSWORD_LENGTH] = '\0';
   menu_password_entry();
 }
@@ -120,7 +125,6 @@ void Password::authenticate_user(const screenFunc_t in_succ_scr, const screenFun
   if (is_set) {
     authenticating = true;
     ui.goto_screen(screen_password_entry);
-    ui.defer_status_screen();
     ui.update();
   }
   else {

--- a/Marlin/src/lcd/menu/menu_password.cpp
+++ b/Marlin/src/lcd/menu/menu_password.cpp
@@ -44,7 +44,8 @@ static uint8_t digit_no;
 // Screen for both editing and setting the password
 //
 void Password::menu_password_entry() {
-  if (!did_first_run) ui.defer_status_screen();
+  ui.defer_status_screen(!did_first_run); // No timeout to status before first auth
+
   START_MENU();
 
   // "Login" or "New Code"

--- a/Marlin/src/lcd/menu/menu_password.cpp
+++ b/Marlin/src/lcd/menu/menu_password.cpp
@@ -44,7 +44,7 @@ static uint8_t digit_no;
 // Screen for both editing and setting the password
 //
 void Password::menu_password_entry() {
-  if (password.first_run) ui.defer_status_screen();
+  if (!did_first_run) ui.defer_status_screen();
   START_MENU();
 
   // "Login" or "New Code"


### PR DESCRIPTION
### Description

The password feature screen has multiple issues:
1) On startup if you select "Start Over" and wait. The LCD_TIMEOUT_TO_STATUS is activated and on timeout the password prompt is bypassed and the status screen is displayed.
2) In password settings it first prompts you for a password to confirm you are authorised to change the password. But it accepts any password while logging password failed.
3) On the login required screen the last two characters on the "Enter Digits" line are printed on top of each other (on 128x64 lcd)

I have updated the code so that until the correct password is entered ui.defer_status_screen() is called so that it never times out to status screen. Later when changing password the menu  is allowed to time out back to status screen on the timer.
I have also fixed the bug that allowed anyone to change the password.
Further I have fixed the characters over writing and made a few cosmetic changes.
The passwood prompt was - characters, now _ character.
On GLCD's I have added a empty line between the password prompt and the menus
Lastly I removed the SS_INVERT from printing the login prompt, it just made things confusing. 

### Requirements

A 20x4 or 128x64 LCD, PASSWORD_FEATURE and a PASSWORD_DEFAULT_VALUE set.

### Benefits

Cleaned up and works as expected 

### Related Issues
more info can be found in Issue: #21293
