### PR TITLE
Fix LPC + TMC boot loop

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1053,6 +1053,10 @@ void setup() {
   #if HAS_FILAMENT_SENSOR
     SETUP_RUN(runout.setup());
   #endif
+  
+  #if HAS_TMC220x
+    SETUP_RUN(tmc_serial_begin());
+  #endif
 
   #if ENABLED(PSU_CONTROL)
     SETUP_LOG("PSU_CONTROL");
@@ -1066,10 +1070,6 @@ void setup() {
 
   #if HAS_L64XX
     SETUP_RUN(L64xxManager.init());  // Set up SPI, init drivers
-  #endif
-
-  #if HAS_TMC220x
-    SETUP_RUN(tmc_serial_begin());
   #endif
 
   #if HAS_STEPPER_RESET


### PR DESCRIPTION
This commit fixes a boot loop on some LPC1768 + TMC driver configurations

### Requirements

At least TMC drivers and probably a LPC176x MCU as well.

### Benefits

Marlin will boot normally

### Related Issues

 #21297
