### PR TITLE
Lerdge K pins for TMC 2208/2209 UART

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
@@ -103,45 +103,45 @@
    */
 
   #ifndef X_SERIAL_TX_PIN
-    #define X_SERIAL_TX_PIN                PB2
+    #define X_SERIAL_TX_PIN                 PB2
   #endif
   #ifndef X_SERIAL_RX_PIN
-    #define X_SERIAL_RX_PIN                PB2
+    #define X_SERIAL_RX_PIN                 PB2
   #endif
 
   #ifndef Y_SERIAL_TX_PIN
-    #define Y_SERIAL_TX_PIN                PE2
+    #define Y_SERIAL_TX_PIN                 PE2
   #endif
   #ifndef Y_SERIAL_RX_PIN
-    #define Y_SERIAL_RX_PIN                PE2
+    #define Y_SERIAL_RX_PIN                 PE2
   #endif
 
   #ifndef Z_SERIAL_TX_PIN
-    #define Z_SERIAL_TX_PIN                PE3
+    #define Z_SERIAL_TX_PIN                 PE3
   #endif
   #ifndef Z_SERIAL_RX_PIN
-    #define Z_SERIAL_RX_PIN                PE3
+    #define Z_SERIAL_RX_PIN                 PE3
   #endif
 
   #ifndef E0_SERIAL_TX_PIN
-    #define E0_SERIAL_TX_PIN               PE4
+    #define E0_SERIAL_TX_PIN                PE4
   #endif
   #ifndef E0_SERIAL_RX_PIN
-    #define E0_SERIAL_RX_PIN               PE4
+    #define E0_SERIAL_RX_PIN                PE4
   #endif
 
   #ifndef E1_SERIAL_TX_PIN
-    #define E1_SERIAL_TX_PIN               PE1
+    #define E1_SERIAL_TX_PIN                PE1
   #endif
   #ifndef E1_SERIAL_RX_PIN
-    #define E1_SERIAL_RX_PIN               PE1
+    #define E1_SERIAL_RX_PIN                PE1
   #endif
 
   #ifndef EX_SERIAL_TX_PIN
-    #define E2_SERIAL_TX_PIN               PE0
+    #define E2_SERIAL_TX_PIN                PE0
   #endif
   #ifndef EX_SERIAL_RX_PIN
-    #define E2_SERIAL_RX_PIN               PE0
+    #define E2_SERIAL_RX_PIN                PE0
   #endif
 
   // Reduce baud rate to improve software serial reliability

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
@@ -96,6 +96,58 @@
 //  #define E1_CS_PIN                       PE4
 //#endif
 
+#if HAS_TMC_UART
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   *
+   */
+
+  #ifndef X_SERIAL_TX_PIN
+    #define X_SERIAL_TX_PIN                PB2
+  #endif
+  #ifndef X_SERIAL_RX_PIN
+    #define X_SERIAL_RX_PIN                PB2
+  #endif
+
+  #ifndef Y_SERIAL_TX_PIN
+    #define Y_SERIAL_TX_PIN                PE2
+  #endif
+  #ifndef Y_SERIAL_RX_PIN
+    #define Y_SERIAL_RX_PIN                PE2
+  #endif
+
+  #ifndef Z_SERIAL_TX_PIN
+    #define Z_SERIAL_TX_PIN                PE3
+  #endif
+  #ifndef Z_SERIAL_RX_PIN
+    #define Z_SERIAL_RX_PIN                PE3
+  #endif
+
+  #ifndef E0_SERIAL_TX_PIN
+    #define E0_SERIAL_TX_PIN               PE4
+  #endif
+  #ifndef E0_SERIAL_RX_PIN
+    #define E0_SERIAL_RX_PIN               PE4
+  #endif
+
+  #ifndef E1_SERIAL_TX_PIN
+    #define E1_SERIAL_TX_PIN               PE1
+  #endif
+  #ifndef E1_SERIAL_RX_PIN
+    #define E1_SERIAL_RX_PIN               PE1
+  #endif
+
+  #ifndef EX_SERIAL_TX_PIN
+    #define E2_SERIAL_TX_PIN               PE0
+  #endif
+  #ifndef EX_SERIAL_RX_PIN
+    #define E2_SERIAL_RX_PIN               PE0
+  #endif
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE                    19200
+#endif
+
 //
 // Temperature Sensors
 //

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
@@ -99,51 +99,43 @@
 #if HAS_TMC_UART
   /**
    * TMC2208/TMC2209 stepper drivers
-   *
    */
-
   #ifndef X_SERIAL_TX_PIN
     #define X_SERIAL_TX_PIN                 PB2
   #endif
   #ifndef X_SERIAL_RX_PIN
     #define X_SERIAL_RX_PIN                 PB2
   #endif
-
   #ifndef Y_SERIAL_TX_PIN
     #define Y_SERIAL_TX_PIN                 PE2
   #endif
   #ifndef Y_SERIAL_RX_PIN
     #define Y_SERIAL_RX_PIN                 PE2
   #endif
-
   #ifndef Z_SERIAL_TX_PIN
     #define Z_SERIAL_TX_PIN                 PE3
   #endif
   #ifndef Z_SERIAL_RX_PIN
     #define Z_SERIAL_RX_PIN                 PE3
   #endif
-
   #ifndef E0_SERIAL_TX_PIN
     #define E0_SERIAL_TX_PIN                PE4
   #endif
   #ifndef E0_SERIAL_RX_PIN
     #define E0_SERIAL_RX_PIN                PE4
   #endif
-
   #ifndef E1_SERIAL_TX_PIN
     #define E1_SERIAL_TX_PIN                PE1
   #endif
   #ifndef E1_SERIAL_RX_PIN
     #define E1_SERIAL_RX_PIN                PE1
   #endif
-
   #ifndef EX_SERIAL_TX_PIN
     #define E2_SERIAL_TX_PIN                PE0
   #endif
   #ifndef EX_SERIAL_RX_PIN
     #define E2_SERIAL_RX_PIN                PE0
   #endif
-
   // Reduce baud rate to improve software serial reliability
   #define TMC_BAUD_RATE                    19200
 #endif


### PR DESCRIPTION
Added *_SERIAL_RX_PIN and *_SERIAL_TX_PIN. for TMC2208/TMC2209 in UART Mode.
Tested with TMC2208. Working with UART now ! :)