### PR TITLE
Cleanup ahead of MeatPack refactor

### DIFF
--- a/Marlin/src/HAL/AVR/HAL.cpp
+++ b/Marlin/src/HAL/AVR/HAL.cpp
@@ -25,7 +25,7 @@
 #include "HAL.h"
 
 #ifdef USBCON
-  DefaultSerial MSerial(false, Serial);
+  DefaultSerial1 MSerial0(false, Serial);
   #ifdef BLUETOOTH
     BTSerial btSerial(false, bluetoothSerial);
   #endif

--- a/Marlin/src/HAL/AVR/HAL.h
+++ b/Marlin/src/HAL/AVR/HAL.h
@@ -83,25 +83,25 @@ typedef int8_t pin_t;
 // Serial ports
 #ifdef USBCON
   #include "../../core/serial_hook.h"
-  typedef ForwardSerial0Type< decltype(Serial) > DefaultSerial;
-  extern DefaultSerial MSerial;
+  typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
+  extern DefaultSerial1 MSerial0;
   #ifdef BLUETOOTH
-    typedef ForwardSerial0Type< decltype(bluetoothSerial) > BTSerial;
+    typedef ForwardSerial1Class< decltype(bluetoothSerial) > BTSerial;
     extern BTSerial btSerial;
   #endif
 
-  #define MYSERIAL0 TERN(BLUETOOTH, btSerial, MSerial)
+  #define MYSERIAL1 TERN(BLUETOOTH, btSerial, MSerial0)
 #else
   #if !WITHIN(SERIAL_PORT, -1, 3)
     #error "SERIAL_PORT must be from -1 to 3. Please update your configuration."
   #endif
-  #define MYSERIAL0 customizedSerial1
+  #define MYSERIAL1 customizedSerial1
 
   #ifdef SERIAL_PORT_2
     #if !WITHIN(SERIAL_PORT_2, -1, 3)
       #error "SERIAL_PORT_2 must be from -1 to 3. Please update your configuration."
     #endif
-    #define MYSERIAL1 customizedSerial2
+    #define MYSERIAL2 customizedSerial2
   #endif
 #endif
 

--- a/Marlin/src/HAL/AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/AVR/MarlinSerial.h
@@ -238,11 +238,11 @@
     static constexpr bool MAX_RX_QUEUED     = ENABLED(SERIAL_STATS_MAX_RX_QUEUED);
   };
 
-  typedef Serial0Type< MarlinSerial< MarlinSerialCfg<SERIAL_PORT> > > MSerialT;
+  typedef Serial1Class< MarlinSerial< MarlinSerialCfg<SERIAL_PORT> > > MSerialT;
   extern MSerialT customizedSerial1;
 
   #ifdef SERIAL_PORT_2
-    typedef Serial0Type< MarlinSerial< MarlinSerialCfg<SERIAL_PORT_2> > > MSerialT2;
+    typedef Serial1Class< MarlinSerial< MarlinSerialCfg<SERIAL_PORT_2> > > MSerialT2;
     extern MSerialT2 customizedSerial2;
   #endif
 
@@ -262,7 +262,7 @@
     static constexpr bool RX_OVERRUNS       = false;
   };
 
-  typedef Serial0Type< MarlinSerial< MMU2SerialCfg<MMU2_SERIAL_PORT> > > MSerialT3;
+  typedef Serial1Class< MarlinSerial< MMU2SerialCfg<MMU2_SERIAL_PORT> > > MSerialT3;
   extern MSerialT3 mmuSerial;
 #endif
 
@@ -292,12 +292,12 @@
   };
 
 
-  typedef Serial0Type< MarlinSerial< LCDSerialCfg<LCD_SERIAL_PORT> > > MSerialT4;
+  typedef Serial1Class< MarlinSerial< LCDSerialCfg<LCD_SERIAL_PORT> > > MSerialT4;
   extern MSerialT4 lcdSerial;
 #endif
 
 // Use the UART for Bluetooth in AT90USB configurations
 #if defined(USBCON) && ENABLED(BLUETOOTH)
-  typedef Serial0Type<HardwareSerial> MSerialT5;
+  typedef Serial1Class<HardwareSerial> MSerialT5;
   extern MSerialT5 bluetoothSerial;
 #endif

--- a/Marlin/src/HAL/DUE/HAL.cpp
+++ b/Marlin/src/HAL/DUE/HAL.cpp
@@ -107,16 +107,16 @@ uint16_t HAL_adc_get_result() {
 
 // Forward the default serial ports
 #if ANY_SERIAL_IS(0)
-  DefaultSerial MSerial(false, Serial);
+  DefaultSerial1 MSerial0(false, Serial);
 #endif
 #if ANY_SERIAL_IS(1)
-  DefaultSerial1 MSerial1(false, Serial1);
+  DefaultSerial2 MSerial1(false, Serial1);
 #endif
 #if ANY_SERIAL_IS(2)
-  DefaultSerial2 MSerial2(false, Serial2);
+  DefaultSerial3 MSerial2(false, Serial2);
 #endif
 #if ANY_SERIAL_IS(3)
-  DefaultSerial3 MSerial3(false, Serial3);
+  DefaultSerial4 MSerial3(false, Serial3);
 #endif
 
 #endif // ARDUINO_ARCH_SAM

--- a/Marlin/src/HAL/DUE/HAL.h
+++ b/Marlin/src/HAL/DUE/HAL.h
@@ -38,33 +38,32 @@
 
 #include "../../core/serial_hook.h"
 
-typedef ForwardSerial0Type< decltype(Serial) > DefaultSerial;
-typedef ForwardSerial0Type< decltype(Serial1) > DefaultSerial1;
-typedef ForwardSerial0Type< decltype(Serial2) > DefaultSerial2;
-typedef ForwardSerial0Type< decltype(Serial3) > DefaultSerial3;
-extern DefaultSerial MSerial;
-extern DefaultSerial1 MSerial1;
-extern DefaultSerial2 MSerial2;
-extern DefaultSerial3 MSerial3;
+typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
+typedef ForwardSerial1Class< decltype(Serial1) > DefaultSerial2;
+typedef ForwardSerial1Class< decltype(Serial2) > DefaultSerial3;
+typedef ForwardSerial1Class< decltype(Serial3) > DefaultSerial4;
+extern DefaultSerial1 MSerial0;
+extern DefaultSerial2 MSerial1;
+extern DefaultSerial3 MSerial2;
+extern DefaultSerial4 MSerial3;
 
 #define _MSERIAL(X) MSerial##X
 #define MSERIAL(X) _MSERIAL(X)
-#define MSerial0 MSerial
 
-// Define MYSERIAL0/1 before MarlinSerial includes!
+// Define MYSERIAL1/2 before MarlinSerial includes!
 #if SERIAL_PORT == -1 || ENABLED(EMERGENCY_PARSER)
-  #define MYSERIAL0 customizedSerial1
+  #define MYSERIAL1 customizedSerial1
 #elif WITHIN(SERIAL_PORT, 0, 3)
-  #define MYSERIAL0 MSERIAL(SERIAL_PORT)
+  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #else
   #error "The required SERIAL_PORT must be from -1 to 3. Please update your configuration."
 #endif
 
 #ifdef SERIAL_PORT_2
   #if SERIAL_PORT_2 == -1 || ENABLED(EMERGENCY_PARSER)
-    #define MYSERIAL1 customizedSerial2
+    #define MYSERIAL2 customizedSerial2
   #elif WITHIN(SERIAL_PORT_2, 0, 3)
-    #define MYSERIAL1 MSERIAL(SERIAL_PORT_2)
+    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
   #else
     #error "SERIAL_PORT_2 must be from -1 to 3. Please update your configuration."
   #endif

--- a/Marlin/src/HAL/DUE/MarlinSerial.h
+++ b/Marlin/src/HAL/DUE/MarlinSerial.h
@@ -141,11 +141,11 @@ struct MarlinSerialCfg {
 };
 
 #if SERIAL_PORT >= 0
-  typedef Serial0Type< MarlinSerial< MarlinSerialCfg<SERIAL_PORT> > > MSerialT;
+  typedef Serial1Class< MarlinSerial< MarlinSerialCfg<SERIAL_PORT> > > MSerialT;
   extern MSerialT customizedSerial1;
 #endif
 
 #if defined(SERIAL_PORT_2) && SERIAL_PORT_2 >= 0
-  typedef Serial0Type< MarlinSerial< MarlinSerialCfg<SERIAL_PORT_2> > > MSerialT2;
+  typedef Serial1Class< MarlinSerial< MarlinSerialCfg<SERIAL_PORT_2> > > MSerialT2;
   extern MSerialT2 customizedSerial2;
 #endif

--- a/Marlin/src/HAL/DUE/MarlinSerialUSB.h
+++ b/Marlin/src/HAL/DUE/MarlinSerialUSB.h
@@ -50,7 +50,7 @@ struct MarlinSerialUSB {
     FORCE_INLINE int rxMaxEnqueued() { return 0; }
   #endif
 };
-typedef Serial0Type<MarlinSerialUSB> MSerialT;
+typedef Serial1Class<MarlinSerialUSB> MSerialT;
 
 #if SERIAL_PORT == -1
   extern MSerialT customizedSerial1;

--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.cpp
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.cpp
@@ -24,6 +24,6 @@
 
 #include "FlushableHardwareSerial.h"
 
-Serial0Type<FlushableHardwareSerial> flushableSerial(false, 0);
+Serial1Class<FlushableHardwareSerial> flushableSerial(false, 0);
 
 #endif

--- a/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
+++ b/Marlin/src/HAL/ESP32/FlushableHardwareSerial.h
@@ -31,4 +31,4 @@ public:
   FlushableHardwareSerial(int uart_nr) : HardwareSerial(uart_nr) {}
 };
 
-extern Serial0Type<FlushableHardwareSerial> flushableSerial;
+extern Serial1Class<FlushableHardwareSerial> flushableSerial;

--- a/Marlin/src/HAL/ESP32/HAL.cpp
+++ b/Marlin/src/HAL/ESP32/HAL.cpp
@@ -41,7 +41,7 @@
 #endif
 
 #if ENABLED(ESP3D_WIFISUPPORT)
-  DefaultSerial MSerial(false, Serial2Socket);
+  DefaultSerial1 MSerial0(false, Serial2Socket);
 #endif
 
 // ------------------------

--- a/Marlin/src/HAL/ESP32/HAL.h
+++ b/Marlin/src/HAL/ESP32/HAL.h
@@ -51,15 +51,15 @@
 
 extern portMUX_TYPE spinlock;
 
-#define MYSERIAL0 flushableSerial
+#define MYSERIAL1 flushableSerial
 
 #if EITHER(WIFISUPPORT, ESP3D_WIFISUPPORT)
   #if ENABLED(ESP3D_WIFISUPPORT)
-    typedef ForwardSerial0Type< decltype(Serial2Socket) > DefaultSerial;
-    extern DefaultSerial MSerial;
-    #define MYSERIAL1 MSerial
+    typedef ForwardSerial1Class< decltype(Serial2Socket) > DefaultSerial1;
+    extern DefaultSerial1 MSerial0;
+    #define MYSERIAL2 MSerial0
   #else
-    #define MYSERIAL1 webSocketSerial
+    #define MYSERIAL2 webSocketSerial
   #endif
 #endif
 

--- a/Marlin/src/HAL/ESP32/WebSocketSerial.h
+++ b/Marlin/src/HAL/ESP32/WebSocketSerial.h
@@ -81,5 +81,5 @@ public:
   #endif
 };
 
-typedef Serial0Type<WebSocketSerial> MSerialT;
+typedef Serial1Class<WebSocketSerial> MSerialT;
 extern MSerialT webSocketSerial;

--- a/Marlin/src/HAL/LINUX/HAL.h
+++ b/Marlin/src/HAL/LINUX/HAL.h
@@ -61,7 +61,7 @@ uint8_t _getc();
 #define SHARED_SERVOS HAS_SERVOS
 
 extern MSerialT usb_serial;
-#define MYSERIAL0 usb_serial
+#define MYSERIAL1 usb_serial
 
 #define ST7920_DELAY_1 DELAY_NS(600)
 #define ST7920_DELAY_2 DELAY_NS(750)

--- a/Marlin/src/HAL/LINUX/include/serial.h
+++ b/Marlin/src/HAL/LINUX/include/serial.h
@@ -115,4 +115,4 @@ struct HalSerial {
   volatile bool host_connected;
 };
 
-typedef Serial0Type<HalSerial> MSerialT;
+typedef Serial1Class<HalSerial> MSerialT;

--- a/Marlin/src/HAL/LINUX/main.cpp
+++ b/Marlin/src/HAL/LINUX/main.cpp
@@ -105,8 +105,8 @@ int main() {
   std::thread write_serial (write_serial_thread);
   std::thread read_serial (read_serial_thread);
 
-  #ifdef MYSERIAL0
-    MYSERIAL0.begin(BAUDRATE);
+  #ifdef MYSERIAL1
+    MYSERIAL1.begin(BAUDRATE);
     SERIAL_ECHOLNPGM("x86_64 Initialized");
     SERIAL_FLUSHTX();
   #endif

--- a/Marlin/src/HAL/LPC1768/HAL.cpp
+++ b/Marlin/src/HAL/LPC1768/HAL.cpp
@@ -29,7 +29,7 @@
   #include "watchdog.h"
 #endif
 
-DefaultSerial USBSerial(false, UsbSerial);
+DefaultSerial1 USBSerial(false, UsbSerial);
 
 uint32_t HAL_adc_reading = 0;
 

--- a/Marlin/src/HAL/LPC1768/HAL.h
+++ b/Marlin/src/HAL/LPC1768/HAL.h
@@ -60,26 +60,25 @@ extern "C" volatile uint32_t _millis;
   #define ST7920_DELAY_3 DELAY_NS(750)
 #endif
 
-typedef ForwardSerial0Type< decltype(UsbSerial) > DefaultSerial;
-extern DefaultSerial USBSerial;
+typedef ForwardSerial1Class< decltype(UsbSerial) > DefaultSerial1;
+extern DefaultSerial1 USBSerial;
 
 #define _MSERIAL(X) MSerial##X
 #define MSERIAL(X) _MSERIAL(X)
-#define MSerial0 MSerial
 
 #if SERIAL_PORT == -1
-  #define MYSERIAL0 USBSerial
+  #define MYSERIAL1 USBSerial
 #elif WITHIN(SERIAL_PORT, 0, 3)
-  #define MYSERIAL0 MSERIAL(SERIAL_PORT)
+  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #else
   #error "SERIAL_PORT must be from -1 to 3. Please update your configuration."
 #endif
 
 #ifdef SERIAL_PORT_2
   #if SERIAL_PORT_2 == -1
-    #define MYSERIAL1 USBSerial
+    #define MYSERIAL2 USBSerial
   #elif WITHIN(SERIAL_PORT_2, 0, 3)
-    #define MYSERIAL1 MSERIAL(SERIAL_PORT_2)
+    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
   #else
     #error "SERIAL_PORT_2 must be from -1 to 3. Please update your configuration."
   #endif

--- a/Marlin/src/HAL/LPC1768/MarlinSerial.cpp
+++ b/Marlin/src/HAL/LPC1768/MarlinSerial.cpp
@@ -26,7 +26,7 @@
 
 #if ANY_SERIAL_IS(0)
   MarlinSerial _MSerial(LPC_UART0);
-  MSerialT MSerial(true, _MSerial);
+  MSerialT MSerial0(true, _MSerial);
   extern "C" void UART0_IRQHandler() { _MSerial.IRQHandler(); }
 #endif
 #if ANY_SERIAL_IS(1)
@@ -51,7 +51,7 @@
     // Need to figure out which serial port we are and react in consequence (Marlin does not have CONTAINER_OF macro)
     if (false) {}
     #if ANY_SERIAL_IS(0)
-      else if (this == &_MSerial) emergency_parser.update(MSerial.emergency_state, c);
+      else if (this == &_MSerial) emergency_parser.update(MSerial0.emergency_state, c);
     #endif
     #if ANY_SERIAL_IS(1)
       else if (this == &_MSerial1) emergency_parser.update(MSerial1.emergency_state, c);

--- a/Marlin/src/HAL/LPC1768/MarlinSerial.h
+++ b/Marlin/src/HAL/LPC1768/MarlinSerial.h
@@ -54,8 +54,8 @@ public:
 // On LPC176x framework, HardwareSerial does not implement the same interface as Arduino's Serial, so overloads
 // of 'available' and 'read' method are not used in this multiple inheritance scenario.
 // Instead, use a ForwardSerial here that adapts the interface.
-typedef ForwardSerial0Type<MarlinSerial> MSerialT;
-extern MSerialT MSerial;
+typedef ForwardSerial1Class<MarlinSerial> MSerialT;
+extern MSerialT MSerial0;
 extern MSerialT MSerial1;
 extern MSerialT MSerial2;
 extern MSerialT MSerial3;

--- a/Marlin/src/HAL/SAMD51/HAL.cpp
+++ b/Marlin/src/HAL/SAMD51/HAL.cpp
@@ -26,19 +26,19 @@
 
 #ifdef ADAFRUIT_GRAND_CENTRAL_M4
   #if ANY_SERIAL_IS(-1)
-    DefaultSerial MSerial(false, Serial);
+    DefaultSerial1 MSerial0(false, Serial);
   #endif
   #if ANY_SERIAL_IS(0)
-    DefaultSerial1 MSerial1(false, Serial1);
+    DefaultSerial2 MSerial1(false, Serial1);
   #endif
   #if ANY_SERIAL_IS(1)
-    DefaultSerial2 MSerial2(false, Serial2);
+    DefaultSerial3 MSerial2(false, Serial2);
   #endif
   #if ANY_SERIAL_IS(2)
-    DefaultSerial3 MSerial3(false, Serial3);
+    DefaultSerial4 MSerial3(false, Serial3);
   #endif
   #if ANY_SERIAL_IS(3)
-    DefaultSerial4 MSerial4(false, Serial4);
+    DefaultSerial5 MSerial4(false, Serial4);
   #endif
 #endif
 

--- a/Marlin/src/HAL/SAMD51/HAL.h
+++ b/Marlin/src/HAL/SAMD51/HAL.h
@@ -32,36 +32,36 @@
   #include "MarlinSerial_AGCM4.h"
 
   // Serial ports
-  typedef ForwardSerial0Type< decltype(Serial) > DefaultSerial;
-  typedef ForwardSerial0Type< decltype(Serial1) > DefaultSerial1;
-  typedef ForwardSerial0Type< decltype(Serial2) > DefaultSerial2;
-  typedef ForwardSerial0Type< decltype(Serial3) > DefaultSerial3;
-  typedef ForwardSerial0Type< decltype(Serial4) > DefaultSerial4;
-  extern DefaultSerial MSerial;
-  extern DefaultSerial1 MSerial1;
-  extern DefaultSerial2 MSerial2;
-  extern DefaultSerial3 MSerial3;
-  extern DefaultSerial4 MSerial4;
+  typedef ForwardSerial1Class< decltype(Serial) > DefaultSerial1;
+  typedef ForwardSerial1Class< decltype(Serial1) > DefaultSerial2;
+  typedef ForwardSerial1Class< decltype(Serial2) > DefaultSerial3;
+  typedef ForwardSerial1Class< decltype(Serial3) > DefaultSerial4;
+  typedef ForwardSerial1Class< decltype(Serial4) > DefaultSerial5;
+  extern DefaultSerial1 MSerial0;
+  extern DefaultSerial2 MSerial1;
+  extern DefaultSerial3 MSerial2;
+  extern DefaultSerial4 MSerial3;
+  extern DefaultSerial5 MSerial4;
 
-  // MYSERIAL0 required before MarlinSerial includes!
+  // MYSERIAL1 required before MarlinSerial includes!
 
   #define __MSERIAL(X) MSerial##X
   #define _MSERIAL(X) __MSERIAL(X)
   #define MSERIAL(X) _MSERIAL(INCREMENT(X))
 
   #if SERIAL_PORT == -1
-    #define MYSERIAL0 MSerial
+    #define MYSERIAL1 MSerial0
   #elif WITHIN(SERIAL_PORT, 0, 3)
-    #define MYSERIAL0 MSERIAL(SERIAL_PORT)
+    #define MYSERIAL1 MSERIAL(SERIAL_PORT)
   #else
     #error "SERIAL_PORT must be from -1 to 3. Please update your configuration."
   #endif
 
   #ifdef SERIAL_PORT_2
     #if SERIAL_PORT_2 == -1
-      #define MYSERIAL1 MSerial
+      #define MYSERIAL2 MSerial0
     #elif WITHIN(SERIAL_PORT_2, 0, 3)
-      #define MYSERIAL1 MSERIAL(SERIAL_PORT_2)
+      #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
     #else
       #error "SERIAL_PORT_2 must be from -1 to 3. Please update your configuration."
     #endif
@@ -69,7 +69,7 @@
 
   #ifdef MMU2_SERIAL_PORT
     #if MMU2_SERIAL_PORT == -1
-      #define MMU2_SERIAL MSerial
+      #define MMU2_SERIAL MSerial0
     #elif WITHIN(MMU2_SERIAL_PORT, 0, 3)
       #define MMU2_SERIAL MSERIAL(MMU2_SERIAL_PORT)
     #else
@@ -79,7 +79,7 @@
 
   #ifdef LCD_SERIAL_PORT
     #if LCD_SERIAL_PORT == -1
-      #define LCD_SERIAL MSerial
+      #define LCD_SERIAL MSerial0
     #elif WITHIN(LCD_SERIAL_PORT, 0, 3)
       #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
     #else

--- a/Marlin/src/HAL/SAMD51/MarlinSerial_AGCM4.h
+++ b/Marlin/src/HAL/SAMD51/MarlinSerial_AGCM4.h
@@ -22,7 +22,7 @@
 
 #include "../../core/serial_hook.h"
 
-typedef Serial0Type<Uart> UartT;
+typedef Serial1Class<Uart> UartT;
 
 extern UartT Serial2;
 extern UartT Serial3;

--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -29,7 +29,7 @@
 #include "../shared/Delay.h"
 
 #ifdef USBCON
-  DefaultSerial MSerial(false, SerialUSB);
+  DefaultSerial1 MSerial0(false, SerialUSB);
 #endif
 
 #if ENABLED(SRAM_EEPROM_EMULATION)

--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -40,8 +40,8 @@
 #ifdef USBCON
   #include <USBSerial.h>
   #include "../../core/serial_hook.h"
-  typedef ForwardSerial0Type< decltype(SerialUSB) > DefaultSerial;
-  extern DefaultSerial MSerial;
+  typedef ForwardSerial1Class< decltype(SerialUSB) > DefaultSerial1;
+  extern DefaultSerial1 MSerial0;
 #endif
 
 // ------------------------
@@ -51,18 +51,18 @@
 #define MSERIAL(X) _MSERIAL(X)
 
 #if SERIAL_PORT == -1
-  #define MYSERIAL0 MSerial
+  #define MYSERIAL1 MSerial0
 #elif WITHIN(SERIAL_PORT, 1, 6)
-  #define MYSERIAL0 MSERIAL(SERIAL_PORT)
+  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #else
   #error "SERIAL_PORT must be -1 or from 1 to 6. Please update your configuration."
 #endif
 
 #ifdef SERIAL_PORT_2
   #if SERIAL_PORT_2 == -1
-    #define MYSERIAL1 MSerial
+    #define MYSERIAL2 MSerial0
   #elif WITHIN(SERIAL_PORT_2, 1, 6)
-    #define MYSERIAL1 MSERIAL(SERIAL_PORT_2)
+    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
   #else
     #error "SERIAL_PORT_2 must be -1 or from 1 to 6. Please update your configuration."
   #endif
@@ -70,7 +70,7 @@
 
 #ifdef MMU2_SERIAL_PORT
   #if MMU2_SERIAL_PORT == -1
-    #define MMU2_SERIAL MSerial
+    #define MMU2_SERIAL MSerial0
   #elif WITHIN(MMU2_SERIAL_PORT, 1, 6)
     #define MMU2_SERIAL MSERIAL(MMU2_SERIAL_PORT)
   #else
@@ -80,7 +80,7 @@
 
 #ifdef LCD_SERIAL_PORT
   #if LCD_SERIAL_PORT == -1
-    #define LCD_SERIAL MSerial
+    #define LCD_SERIAL MSerial0
   #elif WITHIN(LCD_SERIAL_PORT, 1, 6)
     #define LCD_SERIAL MSERIAL(LCD_SERIAL_PORT)
   #else

--- a/Marlin/src/HAL/STM32/MarlinSerial.h
+++ b/Marlin/src/HAL/STM32/MarlinSerial.h
@@ -42,7 +42,7 @@ protected:
   usart_rx_callback_t _rx_callback;
 };
 
-typedef Serial0Type<MarlinSerial> MSerialT;
+typedef Serial1Class<MarlinSerial> MSerialT;
 extern MSerialT MSerial1;
 extern MSerialT MSerial2;
 extern MSerialT MSerial3;

--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -84,7 +84,7 @@
 
 #if defined(SERIAL_USB) && !HAS_SD_HOST_DRIVE
   USBSerial SerialUSB;
-  DefaultSerial MSerial(true, SerialUSB);
+  DefaultSerial1 MSerial0(true, SerialUSB);
 
   #if ENABLED(EMERGENCY_PARSER)
     #include "../libmaple/usb/stm32f1/usb_reg_map.h"
@@ -107,7 +107,7 @@
       len = usb_cdcacm_peek(buf, total);
 
       for (uint32 i = 0; i < len; i++)
-        emergency_parser.update(MSerial.emergency_state, buf[i + total - len]);
+        emergency_parser.update(MSerial0.emergency_state, buf[i + total - len]);
     }
   #endif
 #endif

--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -61,11 +61,11 @@
 #endif
 
 #ifdef SERIAL_USB
-  typedef ForwardSerial0Type< USBSerial > DefaultSerial;
-  extern DefaultSerial MSerial;
+  typedef ForwardSerial1Class< USBSerial > DefaultSerial1;
+  extern DefaultSerial1 MSerial0;
 
   #if !HAS_SD_HOST_DRIVE
-    #define UsbSerial MSerial
+    #define UsbSerial MSerial0
   #else
     #define UsbSerial MarlinCompositeSerial
   #endif
@@ -81,9 +81,9 @@
 #endif
 
 #if SERIAL_PORT == -1
-  #define MYSERIAL0 UsbSerial
+  #define MYSERIAL1 UsbSerial
 #elif WITHIN(SERIAL_PORT, 1, NUM_UARTS)
-  #define MYSERIAL0 MSERIAL(SERIAL_PORT)
+  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #elif NUM_UARTS == 5
   #error "SERIAL_PORT must be -1 or from 1 to 5. Please update your configuration."
 #else
@@ -92,9 +92,9 @@
 
 #ifdef SERIAL_PORT_2
   #if SERIAL_PORT_2 == -1
-    #define MYSERIAL1 UsbSerial
+    #define MYSERIAL2 UsbSerial
   #elif WITHIN(SERIAL_PORT_2, 1, NUM_UARTS)
-    #define MYSERIAL1 MSERIAL(SERIAL_PORT_2)
+    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
   #elif NUM_UARTS == 5
     #error "SERIAL_PORT_2 must be -1 or from 1 to 5. Please update your configuration."
   #else

--- a/Marlin/src/HAL/STM32F1/HAL_MinSerial.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL_MinSerial.cpp
@@ -44,8 +44,8 @@ static void TXBegin() {
     #warning "Using POSTMORTEM_DEBUGGING requires a physical U(S)ART hardware in case of severe error."
     #warning "Disabling the severe error reporting feature currently because the used serial port is not a HW port."
   #else
-    // We use MYSERIAL0 here, so we need to figure out how to get the linked register
-    struct usart_dev* dev = MYSERIAL0.c_dev();
+    // We use MYSERIAL1 here, so we need to figure out how to get the linked register
+    struct usart_dev* dev = MYSERIAL1.c_dev();
 
     // Or use this if removing libmaple
     // int irq = dev->irq_num;
@@ -80,7 +80,7 @@ static void TXBegin() {
 #define sw_barrier() __asm__ volatile("": : :"memory");
 static void TX(char c) {
   #if WITHIN(SERIAL_PORT, 1, 6)
-    struct usart_dev* dev = MYSERIAL0.c_dev();
+    struct usart_dev* dev = MYSERIAL1.c_dev();
     while (!(dev->regs->SR & USART_SR_TXE)) {
       TERN_(USE_WATCHDOG, HAL_watchdog_refresh());
       sw_barrier();

--- a/Marlin/src/HAL/STM32F1/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32F1/MarlinSerial.cpp
@@ -134,11 +134,11 @@ constexpr bool IsSerialClassAllowed(const HardwareSerial&) { return false; }
 // If you encounter this error, replace SerialX with MSerialX, for example MSerial3.
 
 // Non-TMC ports were already validated in HAL.h, so do not require verbose error messages.
-#ifdef MYSERIAL0
-  CHECK_CFG_SERIAL(MYSERIAL0);
-#endif
 #ifdef MYSERIAL1
   CHECK_CFG_SERIAL(MYSERIAL1);
+#endif
+#ifdef MYSERIAL2
+  CHECK_CFG_SERIAL(MYSERIAL2);
 #endif
 #ifdef LCD_SERIAL
   CHECK_CFG_SERIAL(LCD_SERIAL);

--- a/Marlin/src/HAL/STM32F1/MarlinSerial.h
+++ b/Marlin/src/HAL/STM32F1/MarlinSerial.h
@@ -47,7 +47,7 @@ struct MarlinSerial : public HardwareSerial {
   #endif
 };
 
-typedef Serial0Type<MarlinSerial> MSerialT;
+typedef Serial1Class<MarlinSerial> MSerialT;
 
 extern MSerialT MSerial1;
 extern MSerialT MSerial2;

--- a/Marlin/src/HAL/STM32F1/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32F1/msc_sd.cpp
@@ -24,7 +24,7 @@
 #define PRODUCT_ID 0x29
 
 USBMassStorage MarlinMSC;
-Serial0Type<USBCompositeSerial> MarlinCompositeSerial(true);
+Serial1Class<USBCompositeSerial> MarlinCompositeSerial(true);
 
 #include "../../inc/MarlinConfig.h"
 

--- a/Marlin/src/HAL/STM32F1/msc_sd.h
+++ b/Marlin/src/HAL/STM32F1/msc_sd.h
@@ -21,6 +21,6 @@
 #include "../../core/serial_hook.h"
 
 extern USBMassStorage MarlinMSC;
-extern Serial0Type<USBCompositeSerial> MarlinCompositeSerial;
+extern Serial1Class<USBCompositeSerial> MarlinCompositeSerial;
 
 void MSC_SD_init();

--- a/Marlin/src/HAL/TEENSY31_32/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY31_32/HAL.cpp
@@ -31,7 +31,7 @@
 
 #include <Wire.h>
 
-DefaultSerial MSerial(false);
+DefaultSerial1 MSerial0(false);
 USBSerialType USBSerial(false, SerialUSB);
 
 uint16_t HAL_adc_result;

--- a/Marlin/src/HAL/TEENSY31_32/HAL.h
+++ b/Marlin/src/HAL/TEENSY31_32/HAL.h
@@ -51,19 +51,18 @@
 #endif
 
 #include "../../core/serial_hook.h"
-typedef Serial0Type<decltype(Serial)> DefaultSerial;
-extern DefaultSerial MSerial;
-typedef ForwardSerial0Type<decltype(SerialUSB)> USBSerialType;
+typedef Serial1Class<decltype(Serial)> DefaultSerial1;
+extern DefaultSerial1 MSerial0;
+typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
 #define _MSERIAL(X) MSerial##X
 #define MSERIAL(X) _MSERIAL(X)
-#define MSerial0 MSerial
 
 #if SERIAL_PORT == -1
-  #define MYSERIAL0 USBSerial
+  #define MYSERIAL1 USBSerial
 #elif WITHIN(SERIAL_PORT, 0, 3)
-  #define MYSERIAL0 MSERIAL(SERIAL_PORT)
+  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #endif
 
 #define HAL_SERVO_LIB libServo

--- a/Marlin/src/HAL/TEENSY35_36/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.cpp
@@ -31,7 +31,12 @@
 
 #include <Wire.h>
 
-DefaultSerial1 MSerial0(false);
+#define _IMPLEMENT_SERIAL(X) DefaultSerial##X MSerial##X(false)
+#define IMPLEMENT_SERIAL(X)  _IMPLEMENT_SERIAL(X)
+#if WITHIN(SERIAL_PORT, 0, 3)
+  IMPLEMENT_SERIAL(SERIAL_PORT);
+#endif
+
 USBSerialType USBSerial(false, SerialUSB);
 
 uint16_t HAL_adc_result, HAL_adc_select;

--- a/Marlin/src/HAL/TEENSY35_36/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.cpp
@@ -31,7 +31,7 @@
 
 #include <Wire.h>
 
-DefaultSerial MSerial(false);
+DefaultSerial1 MSerial0(false);
 USBSerialType USBSerial(false, SerialUSB);
 
 uint16_t HAL_adc_result, HAL_adc_select;

--- a/Marlin/src/HAL/TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.h
@@ -54,19 +54,18 @@
 #endif
 
 #include "../../core/serial_hook.h"
-typedef Serial0Type<decltype(Serial)> DefaultSerial;
-extern DefaultSerial MSerial;
-typedef ForwardSerial0Type<decltype(SerialUSB)> USBSerialType;
+typedef Serial1Class<decltype(Serial)> DefaultSerial1;
+extern DefaultSerial1 MSerial0;
+typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
 #define _MSERIAL(X) MSerial##X
 #define MSERIAL(X) _MSERIAL(X)
-#define MSerial0 MSerial
 
 #if SERIAL_PORT == -1
-  #define MYSERIAL0 USBSerial
+  #define MYSERIAL1 USBSerial
 #elif WITHIN(SERIAL_PORT, 0, 3)
-  #define MYSERIAL0 MSERIAL(SERIAL_PORT)
+  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #endif
 
 #define HAL_SERVO_LIB libServo

--- a/Marlin/src/HAL/TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.h
@@ -54,8 +54,13 @@
 #endif
 
 #include "../../core/serial_hook.h"
-typedef Serial1Class<decltype(Serial)> DefaultSerial1;
-extern DefaultSerial1 MSerial0;
+
+#define Serial0 Serial
+#define _DECLARE_SERIAL(X) \
+  typedef Serial1Class<decltype(Serial##X)> DefaultSerial##X; \
+  extern DefaultSerial##X MSerial##X
+#define DECLARE_SERIAL(X) _DECLARE_SERIAL(X)
+
 typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
@@ -66,6 +71,7 @@ extern USBSerialType USBSerial;
   #define MYSERIAL1 USBSerial
 #elif WITHIN(SERIAL_PORT, 0, 3)
   #define MYSERIAL1 MSERIAL(SERIAL_PORT)
+  DECLARE_SERIAL(SERIAL_PORT);
 #endif
 
 #define HAL_SERVO_LIB libServo

--- a/Marlin/src/HAL/TEENSY40_41/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.cpp
@@ -32,7 +32,7 @@
 
 #include <Wire.h>
 
-DefaultSerial MSerial(false);
+DefaultSerial1 MSerial0(false);
 USBSerialType USBSerial(false, SerialUSB);
 
 uint16_t HAL_adc_result, HAL_adc_select;

--- a/Marlin/src/HAL/TEENSY40_41/HAL.h
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.h
@@ -56,30 +56,29 @@
 #endif
 
 #include "../../core/serial_hook.h"
-typedef Serial0Type<decltype(Serial)> DefaultSerial;
-extern DefaultSerial MSerial;
-typedef ForwardSerial0Type<decltype(SerialUSB)> USBSerialType;
+typedef Serial1Class<decltype(Serial)> DefaultSerial1;
+extern DefaultSerial1 MSerial0;
+typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
 #define _MSERIAL(X) MSerial##X
 #define MSERIAL(X) _MSERIAL(X)
-#define MSerial0 MSerial
 
 #if SERIAL_PORT == -1
-  #define MYSERIAL0 SerialUSB
+  #define MYSERIAL1 SerialUSB
 #elif WITHIN(SERIAL_PORT, 0, 8)
-  #define MYSERIAL0 MSERIAL(SERIAL_PORT)
+  #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #else
   #error "The required SERIAL_PORT must be from -1 to 8. Please update your configuration."
 #endif
 
 #ifdef SERIAL_PORT_2
   #if SERIAL_PORT_2 == -1
-    #define MYSERIAL1 usbSerial
+    #define MYSERIAL2 usbSerial
   #elif SERIAL_PORT_2 == -2
-    #define MYSERIAL1 ethernet.telnetClient
+    #define MYSERIAL2 ethernet.telnetClient
   #elif WITHIN(SERIAL_PORT_2, 0, 8)
-    #define MYSERIAL1 MSERIAL(SERIAL_PORT_2)
+    #define MYSERIAL2 MSERIAL(SERIAL_PORT_2)
   #else
     #error "SERIAL_PORT_2 must be from -2 to 8. Please update your configuration."
   #endif

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -990,14 +990,14 @@ void setup() {
   #endif
   #define SETUP_RUN(C) do{ SETUP_LOG(STRINGIFY(C)); C; }while(0)
 
-  MYSERIAL0.begin(BAUDRATE);
+  MYSERIAL1.begin(BAUDRATE);
   millis_t serial_connect_timeout = millis() + 1000UL;
-  while (!MYSERIAL0.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+  while (!MYSERIAL1.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
 
   #if HAS_MULTI_SERIAL && !HAS_ETHERNET
-    MYSERIAL1.begin(BAUDRATE);
+    MYSERIAL2.begin(BAUDRATE);
     serial_connect_timeout = millis() + 1000UL;
-    while (!MYSERIAL1.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
+    while (!MYSERIAL2.connected() && PENDING(millis(), serial_connect_timeout)) { /*nada*/ }
   #endif
   SERIAL_ECHOLNPGM("start");
 
@@ -1053,7 +1053,7 @@ void setup() {
   #if HAS_FILAMENT_SENSOR
     SETUP_RUN(runout.setup());
   #endif
-  
+
   #if HAS_TMC220x
     SETUP_RUN(tmc_serial_begin());
   #endif

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -43,12 +43,12 @@ PGMSTR(SP_X_LBL, " X:"); PGMSTR(SP_Y_LBL, " Y:"); PGMSTR(SP_Z_LBL, " Z:"); PGMST
   #else
     #if HAS_ETHERNET
       // Runtime checking of the condition variable
-      ConditionalSerial<decltype(MYSERIAL1)> serialOut1(ethernet.have_telnet_client, MYSERIAL1, false); // Takes reference here
+      ConditionalSerial<decltype(MYSERIAL2)> serialOut2(ethernet.have_telnet_client, MYSERIAL2, false); // Takes reference here
     #else
       // Don't pay for runtime checking a true variable, instead use the output directly
-      #define serialOut1 MYSERIAL1
+      #define serialOut2 MYSERIAL2
     #endif
-    SerialOutputT multiSerial(MYSERIAL0, serialOut1);
+    SerialOutputT multiSerial(MYSERIAL1, serialOut2);
   #endif
 #endif
 

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -69,15 +69,15 @@ extern uint8_t marlin_debug_flags;
   #ifdef SERIAL_CATCHALL
     typedef MultiSerial<decltype(MYSERIAL), decltype(SERIAL_CATCHALL), 0> SerialOutputT;
   #else
-    typedef MultiSerial<decltype(MYSERIAL0), TERN(HAS_ETHERNET, ConditionalSerial<decltype(MYSERIAL1)>, decltype(MYSERIAL1)), 0> SerialOutputT;
+    typedef MultiSerial<decltype(MYSERIAL1), TERN(HAS_ETHERNET, ConditionalSerial<decltype(MYSERIAL2)>, decltype(MYSERIAL2)), 0> SerialOutputT;
   #endif
-  extern SerialOutputT        multiSerial;
-  #define _SERIAL_IMPL        multiSerial
+  extern SerialOutputT multiSerial;
+  #define _SERIAL_IMPL multiSerial
 #else
   #define _PORT_REDIRECT(n,p) NOOP
   #define _PORT_RESTORE(n)    NOOP
   #define SERIAL_ASSERT(P)    NOOP
-  #define _SERIAL_IMPL        MYSERIAL0
+  #define _SERIAL_IMPL MYSERIAL1
 #endif
 
 #if ENABLED(MEATPACK)

--- a/Marlin/src/core/serial_hook.h
+++ b/Marlin/src/core/serial_hook.h
@@ -257,8 +257,8 @@ struct MultiSerial : public SerialBase< MultiSerial<Serial0T, Serial1T, offset, 
 };
 
 // Build the actual serial object depending on current configuration
-#define Serial0Type TERN(SERIAL_RUNTIME_HOOK, RuntimeSerial, BaseSerial)
-#define ForwardSerial0Type TERN(SERIAL_RUNTIME_HOOK, RuntimeSerial, ForwardSerial)
+#define Serial1Class TERN(SERIAL_RUNTIME_HOOK, RuntimeSerial, BaseSerial)
+#define ForwardSerial1Class TERN(SERIAL_RUNTIME_HOOK, RuntimeSerial, ForwardSerial)
 #ifdef HAS_MULTI_SERIAL
-  #define Serial1Type ConditionalSerial
+  #define Serial2Class ConditionalSerial
 #endif

--- a/Marlin/src/feature/binary_stream.h
+++ b/Marlin/src/feature/binary_stream.h
@@ -29,11 +29,11 @@
   #include "../libs/heatshrink/heatshrink_decoder.h"
 #endif
 
-inline bool bs_serial_data_available(const uint8_t index) {
+inline bool bs_serial_data_available(const serial_index_t index) {
   return SERIAL_IMPL.available(index);
 }
 
-inline int bs_read_serial(const uint8_t index) {
+inline int bs_read_serial(const serial_index_t index) {
   return SERIAL_IMPL.read(index);
 }
 

--- a/Marlin/src/feature/ethernet.cpp
+++ b/Marlin/src/feature/ethernet.cpp
@@ -124,7 +124,7 @@ void MarlinEthernet::check() {
       if (!Ethernet.localIP()) break;
 
       SERIAL_ECHOPGM("Successfully started telnet server with IP ");
-      MYSERIAL0.println(Ethernet.localIP());
+      MYSERIAL1.println(Ethernet.localIP());
 
       linkState = LINKED;
       break;

--- a/Marlin/src/gcode/config/M575.cpp
+++ b/Marlin/src/gcode/config/M575.cpp
@@ -61,10 +61,10 @@ void GcodeSuite::M575() {
 
       SERIAL_FLUSH();
 
-      if (set0) { MYSERIAL0.end(); MYSERIAL0.begin(baud); }
+      if (set0) { MYSERIAL1.end(); MYSERIAL1.begin(baud); }
 
       #if HAS_MULTI_SERIAL
-        if (set1) { MYSERIAL1.end(); MYSERIAL1.begin(baud); }
+        if (set1) { MYSERIAL2.end(); MYSERIAL2.begin(baud); }
       #endif
 
     } break;

--- a/Marlin/src/gcode/control/M111.cpp
+++ b/Marlin/src/gcode/control/M111.cpp
@@ -57,19 +57,19 @@ void GcodeSuite::M111() {
     SERIAL_ECHOPGM(STR_DEBUG_OFF);
     #if !defined(__AVR__) || !defined(USBCON)
       #if ENABLED(SERIAL_STATS_RX_BUFFER_OVERRUNS)
-        SERIAL_ECHOPAIR("\nBuffer Overruns: ", MYSERIAL0.buffer_overruns());
+        SERIAL_ECHOPAIR("\nBuffer Overruns: ", MYSERIAL1.buffer_overruns());
       #endif
 
       #if ENABLED(SERIAL_STATS_RX_FRAMING_ERRORS)
-        SERIAL_ECHOPAIR("\nFraming Errors: ", MYSERIAL0.framing_errors());
+        SERIAL_ECHOPAIR("\nFraming Errors: ", MYSERIAL1.framing_errors());
       #endif
 
       #if ENABLED(SERIAL_STATS_DROPPED_RX)
-        SERIAL_ECHOPAIR("\nDropped bytes: ", MYSERIAL0.dropped());
+        SERIAL_ECHOPAIR("\nDropped bytes: ", MYSERIAL1.dropped());
       #endif
 
       #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
-        SERIAL_ECHOPAIR("\nMax RX Queue Size: ", MYSERIAL0.rxMaxEnqueued());
+        SERIAL_ECHOPAIR("\nMax RX Queue Size: ", MYSERIAL1.rxMaxEnqueued());
       #endif
     #endif // !__AVR__ || !USBCON
   }

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -144,7 +144,7 @@ void GcodeSuite::M115() {
     // COOLER_TEMPERATURE (M143, M193)
     cap_line(PSTR("COOLER_TEMPERATURE"), ENABLED(HAS_COOLER));
 
-    // MEATPACK Compresson
+    // MEATPACK Compression
     cap_line(PSTR("MEATPACK"), ENABLED(MEATPACK));
 
     // Machine Geometry

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -272,7 +272,7 @@ void GCodeQueue::flush_and_request_resend(const serial_index_t serial_ind) {
   SERIAL_ECHOLN(serial_state[serial_ind.index].last_N + 1);
 }
 
-inline bool serial_data_available(serial_index_t index) {
+static bool serial_data_available(serial_index_t index) {
   const int a = SERIAL_IMPL.available(index);
   #if BOTH(RX_BUFFER_MONITOR, RX_BUFFER_SIZE)
     if (a > RX_BUFFER_SIZE - 2) {
@@ -283,13 +283,15 @@ inline bool serial_data_available(serial_index_t index) {
   return a > 0;
 }
 
-// Multiserial already handles dispatch to/from multiple ports
-inline bool any_serial_data_available() {
-  LOOP_L_N(p, NUM_SERIAL)
-    if (serial_data_available(p))
-      return true;
-  return false;
-}
+#if NO_TIMEOUTS > 0
+  // Multiserial already handles dispatch to/from multiple ports
+  static bool any_serial_data_available() {
+    LOOP_L_N(p, NUM_SERIAL)
+      if (serial_data_available(p))
+        return true;
+    return false;
+  }
+#endif
 
 inline int read_serial(const serial_index_t index) { return SERIAL_IMPL.read(index); }
 

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -393,7 +393,7 @@ void GCodeQueue::get_serial_commands() {
        * receive buffer (which limits the packet size to MAX_CMD_SIZE).
        * The receive buffer also limits the packet size for reliable transmission.
        */
-      binaryStream[card.transfer_port_index].receive(serial_state[card.transfer_port_index].line_buffer);
+      binaryStream[card.transfer_port_index.index].receive(serial_state[card.transfer_port_index.index].line_buffer);
       return;
     }
   #endif

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -635,10 +635,10 @@ void GCodeQueue::advance() {
 
         #if !defined(__AVR__) || !defined(USBCON)
           #if ENABLED(SERIAL_STATS_DROPPED_RX)
-            SERIAL_ECHOLNPAIR("Dropped bytes: ", MYSERIAL0.dropped());
+            SERIAL_ECHOLNPAIR("Dropped bytes: ", MYSERIAL1.dropped());
           #endif
           #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
-            SERIAL_ECHOLNPAIR("Max RX Queue Size: ", MYSERIAL0.rxMaxEnqueued());
+            SERIAL_ECHOLNPAIR("Max RX Queue Size: ", MYSERIAL1.rxMaxEnqueued());
           #endif
         #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3337,12 +3337,11 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
   #endif
 #endif
 
-
 /**
  * Sanity Check for MEATPACK and BINARY_FILE_TRANSFER Features
  */
 #if BOTH(MEATPACK, BINARY_FILE_TRANSFER)
-  #error "Either enable MEATPACK or enable BINARY_FILE_TRANSFER."
+  #error "Either enable MEATPACK or BINARY_FILE_TRANSFER, not both."
 #endif
 
 /**

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_gcode.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_gcode.cpp
@@ -80,7 +80,7 @@ void lv_serial_capt_hook(void * userPointer, uint8_t c)
 void lv_eom_hook(void *)
 {
   // Message is done, let's remove the hook now
-  MYSERIAL0.setHook();
+  MYSERIAL1.setHook();
   // We are back from the keyboard, so let's redraw ourselves
   draw_return_ui();
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_keyboard.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_keyboard.cpp
@@ -164,7 +164,7 @@ static void lv_kb_event_cb(lv_obj_t *kb, lv_event_t event) {
         case GCodeCommand:
           if (!queue.ring_buffer.full(3)) {
             // Hook anything that goes to the serial port
-            MYSERIAL0.setHook(lv_serial_capt_hook, lv_eom_hook, 0);
+            MYSERIAL1.setHook(lv_serial_capt_hook, lv_eom_hook, 0);
             queue.enqueue_one_now(ret_ta_txt);
           }
           lv_clear_keyboard();

--- a/Marlin/src/lcd/extui/malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui/malyan_lcd.cpp
@@ -414,8 +414,8 @@ void update_usb_status(const bool forceUpdate) {
   // This is mildly different than stock, which
   // appears to use the usb discovery status.
   // This is more logical.
-  if (last_usb_connected_status != MYSERIAL0.connected() || forceUpdate) {
-    last_usb_connected_status = MYSERIAL0.connected();
+  if (last_usb_connected_status != MYSERIAL1.connected() || forceUpdate) {
+    last_usb_connected_status = MYSERIAL1.connected();
     write_to_lcd_P(last_usb_connected_status ? PSTR("{R:UC}\r\n") : PSTR("{R:UD}\r\n"));
   }
 }

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -237,7 +237,7 @@
    * This board does not have dedicated TMC UART pins. Custom wiring is needed.
    * You may uncomment one of the options below, or add it to your Configuration.h.
    *
-   * When using up to four TMC2209 drivers, hardware serial is recommented on
+   * When using up to four TMC2209 drivers, hardware serial is recommended on
    * MSerial0 or MSerial1.
    *
    * When using TMC2208 or more than four drivers, SoftwareSerial will be needed,
@@ -246,14 +246,14 @@
 
   //#define TMC_HARDWARE_SERIAL
   #if ENABLED(TMC_HARDWARE_SERIAL)
-    #define X_HARDWARE_SERIAL            MSerial0
-    #define X2_HARDWARE_SERIAL           MSerial0
-    #define Y_HARDWARE_SERIAL            MSerial0
-    #define Y2_HARDWARE_SERIAL           MSerial0
-    #define Z_HARDWARE_SERIAL            MSerial0
-    #define Z2_HARDWARE_SERIAL           MSerial0
-    #define E0_HARDWARE_SERIAL           MSerial0
-    #define E1_HARDWARE_SERIAL           MSerial0
+    #define X_HARDWARE_SERIAL  MSerial0
+    #define X2_HARDWARE_SERIAL MSerial0
+    #define Y_HARDWARE_SERIAL  MSerial0
+    #define Y2_HARDWARE_SERIAL MSerial0
+    #define Z_HARDWARE_SERIAL  MSerial0
+    #define Z2_HARDWARE_SERIAL MSerial0
+    #define E0_HARDWARE_SERIAL MSerial0
+    #define E1_HARDWARE_SERIAL MSerial0
   #endif
 
   //#define TMC_SOFTWARE_SERIAL

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -70,7 +70,7 @@ char CardReader::filename[FILENAME_LENGTH], CardReader::longFilename[LONG_FILENA
 IF_DISABLED(NO_SD_AUTOSTART, uint8_t CardReader::autofile_index); // = 0
 
 #if BOTH(HAS_MULTI_SERIAL, BINARY_FILE_TRANSFER)
-  int8_t CardReader::transfer_port_index;
+  serial_index_t CardReader::transfer_port_index;
 #endif
 
 // private:

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -72,9 +72,9 @@ public:
   // Fast! binary file transfer
   #if ENABLED(BINARY_FILE_TRANSFER)
     #if HAS_MULTI_SERIAL
-      static int8_t transfer_port_index;
+      static serial_index_t transfer_port_index;
     #else
-      static constexpr int8_t transfer_port_index = 0;
+      static constexpr serial_index_t transfer_port_index = 0;
     #endif
   #endif
 

--- a/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
+++ b/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
@@ -54,7 +54,7 @@
   #define UHS_DEVICE_WINDOWS_USB_SPEC_VIOLATION_DESCRIPTOR_DEVICE 1
   #define UHS_HOST_MAX_INTERFACE_DRIVERS 2
   #define MASS_MAX_SUPPORTED_LUN 1
-  #define USB_HOST_SERIAL MYSERIAL0
+  #define USB_HOST_SERIAL MYSERIAL1
 
   // Workaround for certain issues with UHS3
   #define SKIP_PAGE3F // Required for IOGEAR media adapter

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/settings.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/settings.h
@@ -66,7 +66,7 @@
  * For example Serial3.
  */
 #if ENABLED(USB_FLASH_DRIVE_SUPPORT)
-  #define USB_HOST_SERIAL MYSERIAL0
+  #define USB_HOST_SERIAL MYSERIAL1
 #endif
 
 #ifndef USB_HOST_SERIAL

--- a/buildroot/tests/FYSETC_S6
+++ b/buildroot/tests/FYSETC_S6
@@ -9,7 +9,7 @@ set -e
 # Build examples
 restore_configs
 use_example_configs FYSETC/S6
-opt_enable MEATPACK
+opt_enable MEATPACK_ON_SERIAL_PORT_1
 opt_set Y_DRIVER_TYPE TMC2209 Z_DRIVER_TYPE TMC2130
 exec_test $1 $2 "FYSETC S6 Example" "$3"
 

--- a/buildroot/tests/mks_robin_nano35
+++ b/buildroot/tests/mks_robin_nano35
@@ -42,7 +42,8 @@ use_example_configs Mks/Robin
 opt_set MOTHERBOARD BOARD_MKS_ROBIN_NANO_V2
 opt_disable TFT_INTERFACE_FSMC TFT_RES_320x240
 opt_enable TFT_INTERFACE_SPI TFT_RES_480x320
-exec_test $1 $2 "MKS Robin v2 nano New Color UI 480x320 SPI" "$3"
+opt_enable BINARY_FILE_TRANSFER
+exec_test $1 $2 "MKS Robin v2 nano New Color UI 480x320 SPI + BINARY_FILE_TRANSFER" "$3"
 
 #
 # MKS Robin v2 nano LVGL SPI + TMC

--- a/docs/Serial.md
+++ b/docs/Serial.md
@@ -32,12 +32,12 @@ This is easily done via type definition of the feature.
 
 For example, to create a single serial interface with 2 serial outputs (one enabled at runtime and the other switchable):
 ```cpp
-typedef MultiSerial< RuntimeSerial<Serial>, ConditionalSerial<TelnetClient> > Serial0Type;
+typedef MultiSerial< RuntimeSerial<Serial>, ConditionalSerial<TelnetClient> > Serial1Class;
 ```
 
 To send the same output to 4 serial ports you could nest `MultiSerial` like this:
 ```cpp
-typedef MultiSerial< MultiSerial< BaseSerial<Serial>, BaseSerial<Serial1> >, MultiSerial< BaseSerial<Serial2>, BaseSerial<Serial3>, 2, 1>, 0, 2> Serial0Type;
+typedef MultiSerial< MultiSerial< BaseSerial<Serial>, BaseSerial<Serial1> >, MultiSerial< BaseSerial<Serial2>, BaseSerial<Serial3>, 2, 1>, 0, 2> Serial1Class;
 ```
 The magical numbers here are the step and offset for computing the serial port. Simplifying the above monster a bit:
 ```cpp


### PR DESCRIPTION
The boring parts of #21306…

- Add binary transfer test
- Fix serial index types
- Update `MEATPACK` test for changed configuration.
- Number serial things from 1 to better correspond to `SERIAL_PORT` (1) / `SERIAL_PORT_2`.
  Platform-based low-level serial port wrappers and hardware may index from 0.
  That's fine. Marlin's serial wrapper things are de facto 1-based … and can go to eleven.
- General cleanup