### PR TITLE
Fix Teensy building bug

### DIFF
--- a/Marlin/src/HAL/TEENSY31_32/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY31_32/HAL.cpp
@@ -31,7 +31,11 @@
 
 #include <Wire.h>
 
-DefaultSerial1 MSerial0(false);
+#define _IMPLEMENT_SERIAL(X) DefaultSerial##X MSerial##X(false, Serial##X)
+#define IMPLEMENT_SERIAL(X)  _IMPLEMENT_SERIAL(X)
+#if WITHIN(SERIAL_PORT, 0, 3)
+  IMPLEMENT_SERIAL(SERIAL_PORT);
+#endif
 USBSerialType USBSerial(false, SerialUSB);
 
 uint16_t HAL_adc_result;

--- a/Marlin/src/HAL/TEENSY31_32/HAL.h
+++ b/Marlin/src/HAL/TEENSY31_32/HAL.h
@@ -51,8 +51,13 @@
 #endif
 
 #include "../../core/serial_hook.h"
-typedef Serial1Class<decltype(Serial)> DefaultSerial1;
-extern DefaultSerial1 MSerial0;
+
+#define Serial0 Serial
+#define _DECLARE_SERIAL(X) \
+  typedef ForwardSerial1Class<decltype(Serial##X)> DefaultSerial##X; \
+  extern DefaultSerial##X MSerial##X
+#define DECLARE_SERIAL(X) _DECLARE_SERIAL(X)
+
 typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
@@ -62,6 +67,7 @@ extern USBSerialType USBSerial;
 #if SERIAL_PORT == -1
   #define MYSERIAL1 USBSerial
 #elif WITHIN(SERIAL_PORT, 0, 3)
+  DECLARE_SERIAL(SERIAL_PORT);
   #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #endif
 

--- a/Marlin/src/HAL/TEENSY35_36/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.cpp
@@ -31,7 +31,7 @@
 
 #include <Wire.h>
 
-#define _IMPLEMENT_SERIAL(X) DefaultSerial##X MSerial##X(false)
+#define _IMPLEMENT_SERIAL(X) DefaultSerial##X MSerial##X(false, Serial##X)
 #define IMPLEMENT_SERIAL(X)  _IMPLEMENT_SERIAL(X)
 #if WITHIN(SERIAL_PORT, 0, 3)
   IMPLEMENT_SERIAL(SERIAL_PORT);

--- a/Marlin/src/HAL/TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.h
@@ -57,7 +57,7 @@
 
 #define Serial0 Serial
 #define _DECLARE_SERIAL(X) \
-  typedef Serial1Class<decltype(Serial##X)> DefaultSerial##X; \
+  typedef ForwardSerial1Class<decltype(Serial##X)> DefaultSerial##X; \
   extern DefaultSerial##X MSerial##X
 #define DECLARE_SERIAL(X) _DECLARE_SERIAL(X)
 

--- a/Marlin/src/HAL/TEENSY40_41/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.cpp
@@ -32,7 +32,11 @@
 
 #include <Wire.h>
 
-DefaultSerial1 MSerial0(false);
+#define _IMPLEMENT_SERIAL(X) DefaultSerial##X MSerial##X(false, Serial##X)
+#define IMPLEMENT_SERIAL(X)  _IMPLEMENT_SERIAL(X)
+#if WITHIN(SERIAL_PORT, 0, 3)
+  IMPLEMENT_SERIAL(SERIAL_PORT);
+#endif
 USBSerialType USBSerial(false, SerialUSB);
 
 uint16_t HAL_adc_result, HAL_adc_select;

--- a/Marlin/src/HAL/TEENSY40_41/HAL.h
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.h
@@ -56,8 +56,12 @@
 #endif
 
 #include "../../core/serial_hook.h"
-typedef Serial1Class<decltype(Serial)> DefaultSerial1;
-extern DefaultSerial1 MSerial0;
+#define Serial0 Serial
+#define _DECLARE_SERIAL(X) \
+  typedef ForwardSerial1Class<decltype(Serial##X)> DefaultSerial##X; \
+  extern DefaultSerial##X MSerial##X
+#define DECLARE_SERIAL(X) _DECLARE_SERIAL(X)
+
 typedef ForwardSerial1Class<decltype(SerialUSB)> USBSerialType;
 extern USBSerialType USBSerial;
 
@@ -67,6 +71,7 @@ extern USBSerialType USBSerial;
 #if SERIAL_PORT == -1
   #define MYSERIAL1 SerialUSB
 #elif WITHIN(SERIAL_PORT, 0, 8)
+  DECLARE_SERIAL(SERIAL_PORT);
   #define MYSERIAL1 MSERIAL(SERIAL_PORT)
 #else
   #error "The required SERIAL_PORT must be from -1 to 8. Please update your configuration."


### PR DESCRIPTION

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Follow up to fix missing definition of non-USB serial port's instance on Teensy

### Requirements

Teensy specific

### Benefits

Using SERIAL_PORT > 0 previously failed to build or did not work (even in official release it seems).
This should fix this.

### Configurations

N/A

### Related Issues

#21277 