### PR TITLE
Fix Clean Closed Action

### DIFF
--- a/.github/workflows/clean-closed.yml
+++ b/.github/workflows/clean-closed.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Remove Labels
         uses: actions-ecosystem/action-remove-labels@v1
         with:
+          github_token: ${{ github.token }}
           labels: |
             S: Don't Merge
             S: Please Merge


### PR DESCRIPTION
### Description

Add required `github_token` parameter Clean Closed action.

I noticed the "Clean Closed" action [was silently failing](https://github.com/MarlinFirmware/Marlin/actions/runs/643148297) when closing [an issue](https://github.com/MarlinFirmware/Marlin/issues/21319) since `github_token` was still required, so labels were not being removed.



Tested & confirmed working in my dev repo:
<img src="https://user-images.githubusercontent.com/13375512/110813049-0006e580-823d-11eb-9af8-ca3d9e5d1d61.png" width="75%">

### Requirements

GitHub Actions

### Benefits

Action will run correctly & extraneous labels will be removed.

### Configurations

N/A

### Related Issues

Found while checking the Actions log/testing https://github.com/MarlinFirmware/Marlin/issues/21319.