### PR TITLE
Clean up, optimize ExtUI/TFT code

### DIFF
--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -98,7 +98,7 @@ TemporaryBedLevelingState::TemporaryBedLevelingState(const bool enable) : saved(
 
 #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
 
-  void set_z_fade_height(const float zfh, const bool do_report/*=true*/) {
+  void set_z_fade_height(const float &zfh, const bool do_report/*=true*/) {
 
     if (planner.z_fade_height == zfh) return;
 

--- a/Marlin/src/feature/bedlevel/bedlevel.h
+++ b/Marlin/src/feature/bedlevel/bedlevel.h
@@ -38,7 +38,7 @@ void set_bed_leveling_enabled(const bool enable=true);
 void reset_bed_level();
 
 #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-  void set_z_fade_height(const float zfh, const bool do_report=true);
+  void set_z_fade_height(const float &zfh, const bool do_report=true);
 #endif
 
 #if EITHER(MESH_BED_LEVELING, PROBE_MANUALLY)

--- a/Marlin/src/lcd/extui/anycubic_chiron_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron_lcd.cpp
@@ -101,7 +101,7 @@ namespace ExtUI {
   #if HAS_MESH
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {
       // Called when any mesh points are updated
       //SERIAL_ECHOLNPAIR("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);
     }

--- a/Marlin/src/lcd/extui/anycubic_chiron_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron_lcd.cpp
@@ -74,7 +74,7 @@ namespace ExtUI {
     // into buff.
 
     // Example:
-    //  static_assert(sizeof(myDataStruct) <= ExtUI::eeprom_data_size);
+    //  static_assert(sizeof(myDataStruct) <= eeprom_data_size);
     //  memcpy(buff, &myDataStruct, sizeof(myDataStruct));
   }
 
@@ -84,7 +84,7 @@ namespace ExtUI {
     // from buff
 
     // Example:
-    //  static_assert(sizeof(myDataStruct) <= ExtUI::eeprom_data_size);
+    //  static_assert(sizeof(myDataStruct) <= eeprom_data_size);
     //  memcpy(&myDataStruct, buff, sizeof(myDataStruct));
   }
 
@@ -106,7 +106,7 @@ namespace ExtUI {
       //SERIAL_ECHOLNPAIR("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);
     }
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const probe_state_t state) {
       // Called to indicate a special condition
       //SERIAL_ECHOLNPAIR("onMeshUpdate() x:", xpos, " y:", ypos, " state:", state);
     }

--- a/Marlin/src/lcd/extui/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega_lcd.cpp
@@ -93,7 +93,7 @@ namespace ExtUI {
 
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {
       // Called when any mesh points are updated
     }
   #endif

--- a/Marlin/src/lcd/extui/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega_lcd.cpp
@@ -65,7 +65,7 @@ namespace ExtUI {
     // into buff.
 
     // Example:
-    //  static_assert(sizeof(myDataStruct) <= ExtUI::eeprom_data_size);
+    //  static_assert(sizeof(myDataStruct) <= eeprom_data_size);
     //  memcpy(buff, &myDataStruct, sizeof(myDataStruct));
   }
 
@@ -75,7 +75,7 @@ namespace ExtUI {
     // from buff
 
     // Example:
-    //  static_assert(sizeof(myDataStruct) <= ExtUI::eeprom_data_size);
+    //  static_assert(sizeof(myDataStruct) <= eeprom_data_size);
     //  memcpy(&myDataStruct, buff, sizeof(myDataStruct));
   }
 

--- a/Marlin/src/lcd/extui/dgus_lcd.cpp
+++ b/Marlin/src/lcd/extui/dgus_lcd.cpp
@@ -61,7 +61,7 @@ namespace ExtUI {
   void onUserConfirmRequired(const char * const msg) {
     if (msg) {
       ScreenHandler.sendinfoscreen(PSTR("Please confirm."), nullptr, msg, nullptr, true, true, false, true);
-      ScreenHandler.SetupConfirmAction(ExtUI::setUserConfirmed);
+      ScreenHandler.SetupConfirmAction(setUserConfirmed);
       ScreenHandler.GotoScreen(DGUSLCD_SCREEN_POPUP);
     }
     else if (ScreenHandler.getCurrentScreen() == DGUSLCD_SCREEN_POPUP ) {
@@ -84,7 +84,7 @@ namespace ExtUI {
     // into buff.
 
     // Example:
-    //  static_assert(sizeof(myDataStruct) <= ExtUI::eeprom_data_size);
+    //  static_assert(sizeof(myDataStruct) <= eeprom_data_size);
     //  memcpy(buff, &myDataStruct, sizeof(myDataStruct));
   }
 
@@ -94,7 +94,7 @@ namespace ExtUI {
     // from buff
 
     // Example:
-    //  static_assert(sizeof(myDataStruct) <= ExtUI::eeprom_data_size);
+    //  static_assert(sizeof(myDataStruct) <= eeprom_data_size);
     //  memcpy(&myDataStruct, buff, sizeof(myDataStruct));
   }
 
@@ -115,7 +115,7 @@ namespace ExtUI {
       // Called when any mesh points are updated
     }
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const probe_state_t state) {
       // Called to indicate a special condition
     }
   #endif

--- a/Marlin/src/lcd/extui/dgus_lcd.cpp
+++ b/Marlin/src/lcd/extui/dgus_lcd.cpp
@@ -111,7 +111,7 @@ namespace ExtUI {
   #if HAS_MESH
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {
       // Called when any mesh points are updated
     }
 

--- a/Marlin/src/lcd/extui/example.cpp
+++ b/Marlin/src/lcd/extui/example.cpp
@@ -70,7 +70,7 @@ namespace ExtUI {
     // into buff.
 
     // Example:
-    //  static_assert(sizeof(myDataStruct) <= ExtUI::eeprom_data_size);
+    //  static_assert(sizeof(myDataStruct) <= eeprom_data_size);
     //  memcpy(buff, &myDataStruct, sizeof(myDataStruct));
   }
 
@@ -80,7 +80,7 @@ namespace ExtUI {
     // from buff
 
     // Example:
-    //  static_assert(sizeof(myDataStruct) <= ExtUI::eeprom_data_size);
+    //  static_assert(sizeof(myDataStruct) <= eeprom_data_size);
     //  memcpy(&myDataStruct, buff, sizeof(myDataStruct));
   }
 
@@ -101,7 +101,7 @@ namespace ExtUI {
       // Called when any mesh points are updated
     }
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const probe_state_t state) {
       // Called to indicate a special condition
     }
   #endif

--- a/Marlin/src/lcd/extui/example.cpp
+++ b/Marlin/src/lcd/extui/example.cpp
@@ -97,7 +97,7 @@ namespace ExtUI {
   #if HAS_MESH
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {
       // Called when any mesh points are updated
     }
 

--- a/Marlin/src/lcd/extui/lib/anycubic_chiron/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_chiron/FileNavigator.cpp
@@ -73,7 +73,7 @@ namespace Anycubic {
     // Each time we change folder we reset the file index to 0 and keep track
     // of the current position as the TFT panel isnt aware of folders trees.
     if (index > 0) {
-      --currentindex; // go back a file to take account off the .. we added to the root.
+      --currentindex; // go back a file to take account of the .. added to the root.
       if (index > lastindex)
         currentindex += files;
       else

--- a/Marlin/src/lcd/extui/lib/anycubic_chiron/chiron_tft.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_chiron/chiron_tft.cpp
@@ -288,7 +288,7 @@ namespace Anycubic {
     SERIAL_ECHOLNPGM("Select SD file then press resume");
   }
 
-  void ChironTFT::SendtoTFT(PGM_P str) {  // A helper to print PROGMEN string to the panel
+  void ChironTFT::SendtoTFT(PGM_P str) {  // A helper to print PROGMEM string to the panel
     #if ACDEBUG(AC_SOME)
       SERIAL_ECHOPGM_P(str);
     #endif
@@ -880,6 +880,7 @@ namespace Anycubic {
       }  break;
     }
   }
-} // namespace
+
+} // Anycubic
 
 #endif // ANYCUBIC_LCD_CHIRON

--- a/Marlin/src/lcd/extui/lib/anycubic_chiron/chiron_tft.h
+++ b/Marlin/src/lcd/extui/lib/anycubic_chiron/chiron_tft.h
@@ -32,46 +32,49 @@
 #include "chiron_tft_defs.h"
 #include "../../../../inc/MarlinConfigPre.h"
 #include "../../ui_api.h"
+
 namespace Anycubic {
 
   class ChironTFT {
-    static printer_state_t  printer_state;
-    static paused_state_t   pause_state;
-    static heater_state_t   hotend_state;
-    static heater_state_t   hotbed_state;
-    static xy_uint8_t       selectedmeshpoint;
-    static char             panel_command[MAX_CMND_LEN];
-    static uint8_t          command_len;
-    static char             selectedfile[MAX_PATH_LEN];
-    static float            live_Zoffset;
-    static file_menu_t      file_menu;
+    private:
+      static printer_state_t  printer_state;
+      static paused_state_t   pause_state;
+      static heater_state_t   hotend_state;
+      static heater_state_t   hotbed_state;
+      static xy_uint8_t       selectedmeshpoint;
+      static char             panel_command[MAX_CMND_LEN];
+      static uint8_t          command_len;
+      static char             selectedfile[MAX_PATH_LEN];
+      static float            live_Zoffset;
+      static file_menu_t      file_menu;
+
     public:
       ChironTFT();
-      void Startup();
-      void IdleLoop();
-      void PrinterKilled(PGM_P,PGM_P);
-      void MediaEvent(media_event_t);
-      void TimerEvent(timer_event_t);
-      void FilamentRunout();
-      void ConfirmationRequest(const char * const );
-      void StatusChange(const char * const );
-      void PowerLossRecovery();
+      static void Startup();
+      static void IdleLoop();
+      static void PrinterKilled(PGM_P,PGM_P);
+      static void MediaEvent(media_event_t);
+      static void TimerEvent(timer_event_t);
+      static void FilamentRunout();
+      static void ConfirmationRequest(const char * const );
+      static void StatusChange(const char * const );
+      static void PowerLossRecovery();
 
     private:
-      void SendtoTFT(PGM_P);
-      void SendtoTFTLN(PGM_P);
-      bool ReadTFTCommand();
-      int8_t Findcmndpos(const char *, char);
-      void CheckHeaters();
-      void SendFileList(int8_t);
-      void SelectFile();
-      void InjectCommandandWait(PGM_P);
-      void ProcessPanelRequest();
-      void PanelInfo(uint8_t);
-      void PanelAction(uint8_t);
-      void PanelProcess(uint8_t);
+      static void SendtoTFT(PGM_P);
+      static void SendtoTFTLN(PGM_P);
+      static bool ReadTFTCommand();
+      static int8_t Findcmndpos(const char *, char);
+      static void CheckHeaters();
+      static void SendFileList(int8_t);
+      static void SelectFile();
+      static void InjectCommandandWait(PGM_P);
+      static void ProcessPanelRequest();
+      static void PanelInfo(uint8_t);
+      static void PanelAction(uint8_t);
+      static void PanelProcess(uint8_t);
   };
 
   extern ChironTFT Chiron;
 
-}
+} // Anycubic

--- a/Marlin/src/lcd/extui/lib/anycubic_chiron/chiron_tft_defs.h
+++ b/Marlin/src/lcd/extui/lib/anycubic_chiron/chiron_tft_defs.h
@@ -109,6 +109,7 @@
 #define AC_cmnd_power_loss_recovery    PSTR("G28XYR5\nG28Z")           // Lift, home X and Y then home Z when in 'safe' position
 
 namespace Anycubic {
+
   enum heater_state_t : uint8_t {
     AC_heater_off,
     AC_heater_temp_set,
@@ -148,4 +149,5 @@ namespace Anycubic {
     AC_menu_change_to_file,
     AC_menu_change_to_command
   };
-}
+
+} // Anycubic

--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -2,7 +2,7 @@
  * anycubic_i3mega_lcd.cpp  --- Support for Anycubic i3 Mega TFT
  * Created by Christian Hopp on 09.12.17.
  * Improved by David Ramiro
- * Converted to ext_iu by John BouAntoun 21 June 2020
+ * Converted to ExtUI by John BouAntoun 21 June 2020
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -32,44 +32,46 @@
 #include "../../../../inc/MarlinConfig.h"
 
 // command sending macro's with debugging capability
-#define SEND_PGM(x)                                 send_P(PSTR(x))
-#define SENDLINE_PGM(x)                             sendLine_P(PSTR(x))
-#define SEND_PGM_VAL(x,y)                           (send_P(PSTR(x)), sendLine(i16tostr3rj(y)))
-#define SEND(x)                                     send(x)
-#define SENDLINE(x)                                 sendLine(x)
+#define SEND_PGM(x)       send_P(PSTR(x))
+#define SENDLINE_PGM(x)   sendLine_P(PSTR(x))
+#define SEND_PGM_VAL(x,y) (send_P(PSTR(x)), sendLine(i16tostr3rj(y)))
+#define SEND(x)           send(x)
+#define SENDLINE(x)       sendLine(x)
 #if ENABLED(ANYCUBIC_LCD_DEBUG)
-  #define SENDLINE_DBG_PGM(x,y)                     (sendLine_P(PSTR(x)), SERIAL_ECHOLNPGM(y))
-  #define SENDLINE_DBG_PGM_VAL(x,y,z)               (sendLine_P(PSTR(x)), SERIAL_ECHOPGM(y), SERIAL_ECHOLN(z))
+  #define SENDLINE_DBG_PGM(x,y)       (sendLine_P(PSTR(x)), SERIAL_ECHOLNPGM(y))
+  #define SENDLINE_DBG_PGM_VAL(x,y,z) (sendLine_P(PSTR(x)), SERIAL_ECHOPGM(y), SERIAL_ECHOLN(z))
 #else
-  #define SENDLINE_DBG_PGM(x,y)                     sendLine_P(PSTR(x))
-  #define SENDLINE_DBG_PGM_VAL(x,y,z)               sendLine_P(PSTR(x))
+  #define SENDLINE_DBG_PGM(x,y)       sendLine_P(PSTR(x))
+  #define SENDLINE_DBG_PGM_VAL(x,y,z) sendLine_P(PSTR(x))
 #endif
 
 AnycubicTFTClass AnycubicTFT;
 
-static void sendNewLine(void) {
-  LCD_SERIAL.write('\r');
-  LCD_SERIAL.write('\n');
-}
+char AnycubicTFTClass::TFTcmdbuffer[TFTBUFSIZE][TFT_MAX_CMD_SIZE];
+int AnycubicTFTClass::TFTbuflen = 0,
+    AnycubicTFTClass::TFTbufindr = 0,
+    AnycubicTFTClass::TFTbufindw = 0;
+char AnycubicTFTClass::serial3_char;
+int AnycubicTFTClass::serial3_count = 0;
+char* AnycubicTFTClass::TFTstrchr_pointer;
+uint8_t AnycubicTFTClass::SpecialMenu = false;
+AnycubicMediaPrintState AnycubicTFTClass::mediaPrintingState = AMPRINTSTATE_NOT_PRINTING;
+AnycubicMediaPauseState AnycubicTFTClass::mediaPauseState = AMPAUSESTATE_NOT_PAUSED;
 
-static void send(const char *str) {
-  LCD_SERIAL.print(str);
-}
+char AnycubicTFTClass::SelectedDirectory[30];
+char AnycubicTFTClass::SelectedFile[FILENAME_LENGTH];
 
-static void sendLine(const char *str) {
-  send(str);
-  sendNewLine();
-}
-
+// Serial helpers
+static void sendNewLine(void) { LCD_SERIAL.write('\r'); LCD_SERIAL.write('\n'); }
+static void send(const char *str) { LCD_SERIAL.print(str); }
 static void send_P(PGM_P str) {
   while (const char c = pgm_read_byte(str++))
     LCD_SERIAL.write(c);
 }
+static void sendLine(const char *str) { send(str); sendNewLine(); }
+static void sendLine_P(PGM_P str) { send_P(str); sendNewLine(); }
 
-static void sendLine_P(PGM_P str) {
-  send_P(str);
-  sendNewLine();
-}
+using namespace ExtUI;
 
 AnycubicTFTClass::AnycubicTFTClass() {}
 
@@ -80,7 +82,7 @@ void AnycubicTFTClass::OnSetup() {
   LCD_SERIAL.begin(LCD_BAUDRATE);
 
   SENDLINE_DBG_PGM("J17", "TFT Serial Debug: Main board reset... J17"); // J17 Main board reset
-  ExtUI::delay_ms(10);
+  delay_ms(10);
 
   // initialise the state of the key pins running on the tft
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
@@ -95,13 +97,13 @@ void AnycubicTFTClass::OnSetup() {
 
   // DoSDCardStateCheck();
   SENDLINE_DBG_PGM("J12", "TFT Serial Debug: Ready... J12"); // J12 Ready
-  ExtUI::delay_ms(10);
+  delay_ms(10);
 
   DoFilamentRunoutCheck();
   SelectedFile[0] = 0;
 
   #if ENABLED(STARTUP_CHIME)
-    ExtUI::injectCommands_P(PSTR("M300 P250 S554\nM300 P250 S554\nM300 P250 S740\nM300 P250 S554\nM300 P250 S740\nM300 P250 S554\nM300 P500 S831"));
+    injectCommands_P(PSTR("M300 P250 S554\nM300 P250 S554\nM300 P250 S740\nM300 P250 S554\nM300 P250 S740\nM300 P250 S554\nM300 P500 S831"));
   #endif
   #if ENABLED(ANYCUBIC_LCD_DEBUG)
     SERIAL_ECHOLNPGM("TFT Serial Debug: Finished startup");
@@ -119,8 +121,8 @@ void AnycubicTFTClass::OnCommandScan() {
       #endif
       mediaPrintingState = AMPRINTSTATE_NOT_PRINTING;
       mediaPauseState = AMPAUSESTATE_NOT_PAUSED;
-      ExtUI::injectCommands_P(PSTR("M84\nM27")); // disable stepper motors and force report of SD status
-      ExtUI::delay_ms(200);
+      injectCommands_P(PSTR("M84\nM27")); // disable stepper motors and force report of SD status
+      delay_ms(200);
       // tell printer to release resources of print to indicate it is done
       SENDLINE_DBG_PGM("J14", "TFT Serial Debug: SD Print Stopped... J14");
     }
@@ -224,8 +226,8 @@ bool AnycubicTFTClass::CodeSeen(char code) {
 }
 
 bool AnycubicTFTClass::IsNozzleHomed() {
-  const float xPosition = ExtUI::getAxisPosition_mm((ExtUI::axis_t) ExtUI::X);
-  const float yPosition = ExtUI::getAxisPosition_mm((ExtUI::axis_t) ExtUI::Y);
+  const float xPosition = getAxisPosition_mm((axis_t) X);
+  const float yPosition = getAxisPosition_mm((axis_t) Y);
   return WITHIN(xPosition, X_MIN_POS - 0.1, X_MIN_POS + 0.1) &&
          WITHIN(yPosition, Y_MIN_POS - 0.1, Y_MIN_POS + 0.1);
 }
@@ -246,48 +248,48 @@ void AnycubicTFTClass::HandleSpecialMenu() {
             switch (SelectedDirectory[2]) {
               case '1': // "<01ZUp0.1>"
                 SERIAL_ECHOLNPGM("Special Menu: Z Up 0.1");
-                ExtUI::injectCommands_P(PSTR("G91\nG1 Z+0.1\nG90"));
+                injectCommands_P(PSTR("G91\nG1 Z+0.1\nG90"));
                 break;
 
               case '2': // "<02ZUp0.02>"
                 SERIAL_ECHOLNPGM("Special Menu: Z Up 0.02");
-                ExtUI::injectCommands_P(PSTR("G91\nG1 Z+0.02\nG90"));
+                injectCommands_P(PSTR("G91\nG1 Z+0.02\nG90"));
                 break;
 
               case '3': // "<03ZDn0.02>"
                 SERIAL_ECHOLNPGM("Special Menu: Z Down 0.02");
-                ExtUI::injectCommands_P(PSTR("G91\nG1 Z-0.02\nG90"));
+                injectCommands_P(PSTR("G91\nG1 Z-0.02\nG90"));
                 break;
 
               case '4': // "<04ZDn0.1>"
                 SERIAL_ECHOLNPGM("Special Menu: Z Down 0.1");
-                ExtUI::injectCommands_P(PSTR("G91\nG1 Z-0.1\nG90"));
+                injectCommands_P(PSTR("G91\nG1 Z-0.1\nG90"));
                 break;
 
               case '5': // "<05PrehtBed>"
                 SERIAL_ECHOLNPGM("Special Menu: Preheat Bed");
-                ExtUI::injectCommands_P(PSTR("M140 S65"));
+                injectCommands_P(PSTR("M140 S65"));
                 break;
 
               case '6': // "<06SMeshLvl>"
                 SERIAL_ECHOLNPGM("Special Menu: Start Mesh Leveling");
-                ExtUI::injectCommands_P(PSTR("G29S1"));
+                injectCommands_P(PSTR("G29S1"));
                 break;
 
               case '7': // "<07MeshNPnt>"
                 SERIAL_ECHOLNPGM("Special Menu: Next Mesh Point");
-                ExtUI::injectCommands_P(PSTR("G29S2"));
+                injectCommands_P(PSTR("G29S2"));
                 break;
 
               case '8': // "<08HtEndPID>"
                 SERIAL_ECHOLNPGM("Special Menu: Auto Tune Hotend PID");
                 // need to dwell for half a second to give the fan a chance to start before the pid tuning starts
-                ExtUI::injectCommands_P(PSTR("M106 S204\nG4 P500\nM303 E0 S215 C15 U1"));
+                injectCommands_P(PSTR("M106 S204\nG4 P500\nM303 E0 S215 C15 U1"));
                 break;
 
               case '9': // "<09HtBedPID>"
                 SERIAL_ECHOLNPGM("Special Menu: Auto Tune Hotbed Pid");
-                ExtUI::injectCommands_P(PSTR("M303 E-1 S65 C6 U1"));
+                injectCommands_P(PSTR("M303 E-1 S65 C6 U1"));
                 break;
 
               default:
@@ -299,12 +301,12 @@ void AnycubicTFTClass::HandleSpecialMenu() {
             switch (SelectedDirectory[2]) {
               case '0': // "<10FWDeflts>"
                 SERIAL_ECHOLNPGM("Special Menu: Load FW Defaults");
-                ExtUI::injectCommands_P(PSTR("M502\nM300 P105 S1661\nM300 P210 S1108"));
+                injectCommands_P(PSTR("M502\nM300 P105 S1661\nM300 P210 S1108"));
                 break;
 
               case '1': // "<11SvEEPROM>"
                 SERIAL_ECHOLNPGM("Special Menu: Save EEPROM");
-                ExtUI::injectCommands_P(PSTR("M500\nM300 P105 S1108\nM300 P210 S1661"));
+                injectCommands_P(PSTR("M500\nM300 P105 S1108\nM300 P210 S1661"));
                 break;
 
               default:
@@ -316,38 +318,38 @@ void AnycubicTFTClass::HandleSpecialMenu() {
             switch (SelectedDirectory[2]) {
               case '1': // "<01PrehtBed>"
                 SERIAL_ECHOLNPGM("Special Menu: Preheat Bed");
-                ExtUI::injectCommands_P(PSTR("M140 S65"));
+                injectCommands_P(PSTR("M140 S65"));
                 break;
 
               case '2': // "<02ABL>"
                 SERIAL_ECHOLNPGM("Special Menu: Auto Bed Leveling");
-                ExtUI::injectCommands_P(PSTR("G29N"));
+                injectCommands_P(PSTR("G29N"));
                 break;
 
               case '3': // "<03HtendPID>"
                 SERIAL_ECHOLNPGM("Special Menu: Auto Tune Hotend PID");
                 // need to dwell for half a second to give the fan a chance to start before the pid tuning starts
-                ExtUI::injectCommands_P(PSTR("M106 S204\nG4 P500\nM303 E0 S215 C15 U1"));
+                injectCommands_P(PSTR("M106 S204\nG4 P500\nM303 E0 S215 C15 U1"));
                 break;
 
               case '4': // "<04HtbedPID>"
                 SERIAL_ECHOLNPGM("Special Menu: Auto Tune Hotbed Pid");
-                ExtUI::injectCommands_P(PSTR("M303 E-1 S65 C6 U1"));
+                injectCommands_P(PSTR("M303 E-1 S65 C6 U1"));
                 break;
 
               case '5': // "<05FWDeflts>"
                 SERIAL_ECHOLNPGM("Special Menu: Load FW Defaults");
-                ExtUI::injectCommands_P(PSTR("M502\nM300 P105 S1661\nM300 P210 S1108"));
+                injectCommands_P(PSTR("M502\nM300 P105 S1661\nM300 P210 S1108"));
                 break;
 
               case '6': // "<06SvEEPROM>"
                 SERIAL_ECHOLNPGM("Special Menu: Save EEPROM");
-                ExtUI::injectCommands_P(PSTR("M500\nM300 P105 S1108\nM300 P210 S1661"));
+                injectCommands_P(PSTR("M500\nM300 P105 S1108\nM300 P210 S1661"));
                 break;
 
               case '7': // <07SendM108>
                 SERIAL_ECHOLNPGM("Special Menu: Send User Confirmation");
-                ExtUI::injectCommands_P(PSTR("M108"));
+                injectCommands_P(PSTR("M108"));
                 break;
 
               default:
@@ -373,11 +375,11 @@ void AnycubicTFTClass::RenderCurrentFileList() {
     uint16_t selectedNumber = 0;
     SelectedDirectory[0] = 0;
     SelectedFile[0] = 0;
-    ExtUI::FileList currentFileList;
+    FileList currentFileList;
 
     SENDLINE_PGM("FN "); // Filelist start
 
-    if (!ExtUI::isMediaInserted() && !SpecialMenu) {
+    if (!isMediaInserted() && !SpecialMenu) {
       SENDLINE_DBG_PGM("J02", "TFT Serial Debug: No SD Card mounted to render Current File List... J02");
 
       SENDLINE_PGM("<Special_Menu>");
@@ -462,7 +464,7 @@ void AnycubicTFTClass::RenderSpecialMenu(uint16_t selectedNumber) {
 }
 
 void AnycubicTFTClass::RenderCurrentFolder(uint16_t selectedNumber) {
-  ExtUI::FileList currentFileList;
+  FileList currentFileList;
   uint16_t cnt = selectedNumber;
   uint16_t max_files;
   uint16_t dir_files = currentFileList.count();
@@ -514,7 +516,7 @@ void AnycubicTFTClass::OnPrintTimerStarted() {
 
 void AnycubicTFTClass::OnPrintTimerPaused() {
   #if ENABLED(SDSUPPORT)
-    if (ExtUI::isPrintingFromMedia()) {
+    if (isPrintingFromMedia()) {
       mediaPrintingState = AMPRINTSTATE_PAUSED;
       mediaPauseState    = AMPAUSESTATE_PARKING;
     }
@@ -558,38 +560,38 @@ void AnycubicTFTClass::GetCommandFromTFT() {
 
         switch (a_command) {
           case 0: { // A0 GET HOTEND TEMP
-            float hotendActualTemp = ExtUI::getActualTemp_celsius((ExtUI::extruder_t) (ExtUI::extruder_t) ExtUI::E0);
+            float hotendActualTemp = getActualTemp_celsius((extruder_t) (extruder_t) E0);
             SEND_PGM_VAL("A0V ", int(hotendActualTemp + 0.5));
           }
           break;
 
           case 1: { // A1  GET HOTEND TARGET TEMP
-            float hotendTargetTemp = ExtUI::getTargetTemp_celsius((ExtUI::extruder_t) (ExtUI::extruder_t) ExtUI::E0);
+            float hotendTargetTemp = getTargetTemp_celsius((extruder_t) (extruder_t) E0);
             SEND_PGM_VAL("A1V ", int(hotendTargetTemp + 0.5));
           }
           break;
 
           case 2: { // A2 GET HOTBED TEMP
-            float heatedBedActualTemp = ExtUI::getActualTemp_celsius((ExtUI::heater_t) ExtUI::BED);
+            float heatedBedActualTemp = getActualTemp_celsius((heater_t) BED);
             SEND_PGM_VAL("A2V ", int(heatedBedActualTemp + 0.5));
           }
           break;
 
           case 3: { // A3 GET HOTBED TARGET TEMP
-            float heatedBedTargetTemp = ExtUI::getTargetTemp_celsius((ExtUI::heater_t) ExtUI::BED);
+            float heatedBedTargetTemp = getTargetTemp_celsius((heater_t) BED);
             SEND_PGM_VAL("A3V ", int(heatedBedTargetTemp + 0.5));
           } break;
 
           case 4: { // A4 GET FAN SPEED
-            float fanPercent = ExtUI::getActualFan_percent(ExtUI::FAN0);
+            float fanPercent = getActualFan_percent(FAN0);
             fanPercent = constrain(fanPercent, 0, 100);
             SEND_PGM_VAL("A4V ", int(fanPercent));
           } break;
 
           case 5: { // A5 GET CURRENT COORDINATE
-            const float xPosition = ExtUI::getAxisPosition_mm(ExtUI::X),
-                        yPosition = ExtUI::getAxisPosition_mm(ExtUI::Y),
-                        zPosition = ExtUI::getAxisPosition_mm(ExtUI::Z);
+            const float xPosition = getAxisPosition_mm(X),
+                        yPosition = getAxisPosition_mm(Y),
+                        zPosition = getAxisPosition_mm(Z);
             SEND_PGM("A5V X: "); LCD_SERIAL.print(xPosition);
             SEND_PGM(   " Y: "); LCD_SERIAL.print(yPosition);
             SEND_PGM(   " Z: "); LCD_SERIAL.print(zPosition);
@@ -598,10 +600,10 @@ void AnycubicTFTClass::GetCommandFromTFT() {
 
           case 6: // A6 GET SD CARD PRINTING STATUS
             #if ENABLED(SDSUPPORT)
-              if (ExtUI::isPrintingFromMedia()) {
+              if (isPrintingFromMedia()) {
                 SEND_PGM("A6V ");
-                if (ExtUI::isMediaInserted())
-                  SENDLINE(ui8tostr3rj(ExtUI::getProgress_percent()));
+                if (isMediaInserted())
+                  SENDLINE(ui8tostr3rj(getProgress_percent()));
                 else
                   SENDLINE_DBG_PGM("J02", "TFT Serial Debug: No SD Card mounted to return printing status... J02");
               }
@@ -611,7 +613,7 @@ void AnycubicTFTClass::GetCommandFromTFT() {
             break;
 
           case 7: { // A7 GET PRINTING TIME
-            const uint32_t elapsedSeconds = ExtUI::getProgress_seconds_elapsed();
+            const uint32_t elapsedSeconds = getProgress_seconds_elapsed();
             SEND_PGM("A7V ");
             if (elapsedSeconds != 0) {  // print time
               const uint32_t elapsedMinutes = elapsedSeconds / 60;
@@ -634,14 +636,14 @@ void AnycubicTFTClass::GetCommandFromTFT() {
 
           case 9: // A9 pause sd print
             #if ENABLED(SDSUPPORT)
-              if (ExtUI::isPrintingFromMedia())
+              if (isPrintingFromMedia())
                 PausePrint();
             #endif
             break;
 
           case 10: // A10 resume sd print
             #if ENABLED(SDSUPPORT)
-              if (ExtUI::isPrintingFromMediaPaused())
+              if (isPrintingFromMediaPaused())
                 ResumePrint();
             #endif
             break;
@@ -656,7 +658,7 @@ void AnycubicTFTClass::GetCommandFromTFT() {
 
           case 13: // A13 SELECTION FILE
             #if ENABLED(SDSUPPORT)
-              if (ExtUI::isMediaInserted()) {
+              if (isMediaInserted()) {
                 starpos = (strchr(TFTstrchr_pointer + 4, '*'));
                 if (TFTstrchr_pointer[4] == '/') {
                   strcpy(SelectedDirectory, TFTstrchr_pointer + 5);
@@ -685,7 +687,7 @@ void AnycubicTFTClass::GetCommandFromTFT() {
 
           case 14: // A14 START PRINTING
             #if ENABLED(SDSUPPORT)
-              if (!ExtUI::isPrinting() && strlen(SelectedFile) > 0)
+              if (!isPrinting() && strlen(SelectedFile) > 0)
                 StartPrint();
             #endif
             break;
@@ -698,13 +700,13 @@ void AnycubicTFTClass::GetCommandFromTFT() {
             unsigned int tempvalue;
             if (CodeSeen('S')) {
               tempvalue = constrain(CodeValue(), 0, 275);
-              ExtUI::setTargetTemp_celsius(tempvalue, (ExtUI::extruder_t) ExtUI::E0);
+              setTargetTemp_celsius(tempvalue, (extruder_t) E0);
             }
-            else if (CodeSeen('C') && !ExtUI::isPrinting()) {
-              if (ExtUI::getAxisPosition_mm(ExtUI::Z) < 10)
-                ExtUI::injectCommands_P(PSTR("G1 Z10")); // RASE Z AXIS
+            else if (CodeSeen('C') && !isPrinting()) {
+              if (getAxisPosition_mm(Z) < 10)
+                injectCommands_P(PSTR("G1 Z10")); // RASE Z AXIS
               tempvalue = constrain(CodeValue(), 0, 275);
-              ExtUI::setTargetTemp_celsius(tempvalue, (ExtUI::extruder_t) ExtUI::E0);
+              setTargetTemp_celsius(tempvalue, (extruder_t) E0);
             }
           }
           break;
@@ -713,7 +715,7 @@ void AnycubicTFTClass::GetCommandFromTFT() {
             unsigned int tempbed;
             if (CodeSeen('S')) {
               tempbed = constrain(CodeValue(), 0, 100);
-              ExtUI::setTargetTemp_celsius(tempbed, (ExtUI::heater_t)ExtUI::BED);
+              setTargetTemp_celsius(tempbed, (heater_t)BED);
             }
           }
           break;
@@ -723,18 +725,18 @@ void AnycubicTFTClass::GetCommandFromTFT() {
             if (CodeSeen('S')) {
               fanPercent = CodeValue();
               fanPercent = constrain(fanPercent, 0, 100);
-              ExtUI::setTargetFan_percent(fanPercent, ExtUI::FAN0);
+              setTargetFan_percent(fanPercent, FAN0);
             }
             else
               fanPercent = 100;
 
-            ExtUI::setTargetFan_percent(fanPercent, ExtUI::FAN0);
+            setTargetFan_percent(fanPercent, FAN0);
             SENDLINE_PGM("");
           }
           break;
 
           case 19: // A19 stop stepper drivers - sent on stop extrude command and on turn motors off command
-            if (!ExtUI::isPrinting()) {
+            if (!isPrinting()) {
               quickstop_stepper();
               disable_all_steppers();
             }
@@ -750,23 +752,23 @@ void AnycubicTFTClass::GetCommandFromTFT() {
             break;
 
           case 21: // A21 all home
-            if (!ExtUI::isPrinting() && !ExtUI::isPrintingFromMediaPaused()) {
+            if (!isPrinting() && !isPrintingFromMediaPaused()) {
               if (CodeSeen('X') || CodeSeen('Y') || CodeSeen('Z')) {
                 if (CodeSeen('X'))
-                  ExtUI::injectCommands_P(PSTR("G28X"));
+                  injectCommands_P(PSTR("G28X"));
                 if (CodeSeen('Y'))
-                  ExtUI::injectCommands_P(PSTR("G28Y"));
+                  injectCommands_P(PSTR("G28Y"));
                 if (CodeSeen('Z'))
-                  ExtUI::injectCommands_P(PSTR("G28Z"));
+                  injectCommands_P(PSTR("G28Z"));
               }
               else if (CodeSeen('C')) {
-                ExtUI::injectCommands_P(G28_STR);
+                injectCommands_P(G28_STR);
               }
             }
             break;
 
           case 22: // A22 move X/Y/Z or extrude
-            if (!ExtUI::isPrinting()) {
+            if (!isPrinting()) {
               float coorvalue;
               unsigned int movespeed = 0;
               char commandStr[30];
@@ -819,38 +821,38 @@ void AnycubicTFTClass::GetCommandFromTFT() {
                   SERIAL_ECHOPGM("TFT Serial Debug: A22 Move final request with gcode... ");
                   SERIAL_ECHOLN(fullCommandStr);
                 #endif
-                ExtUI::injectCommands(fullCommandStr);
+                injectCommands(fullCommandStr);
               }
             }
             SENDLINE_PGM("");
             break;
 
           case 23: // A23 preheat pla
-            if (!ExtUI::isPrinting()) {
-              if (ExtUI::getAxisPosition_mm(ExtUI::Z) < 10)
-                ExtUI::injectCommands_P(PSTR("G1 Z10")); // RASE Z AXIS
+            if (!isPrinting()) {
+              if (getAxisPosition_mm(Z) < 10)
+                injectCommands_P(PSTR("G1 Z10")); // RASE Z AXIS
 
-              ExtUI::setTargetTemp_celsius(PREHEAT_1_TEMP_BED, (ExtUI::heater_t) ExtUI::BED);
-              ExtUI::setTargetTemp_celsius(PREHEAT_1_TEMP_HOTEND, (ExtUI::extruder_t) ExtUI::E0);
+              setTargetTemp_celsius(PREHEAT_1_TEMP_BED, (heater_t) BED);
+              setTargetTemp_celsius(PREHEAT_1_TEMP_HOTEND, (extruder_t) E0);
               SENDLINE_PGM("OK");
             }
             break;
 
           case 24:// A24 preheat abs
-            if (!ExtUI::isPrinting()) {
-              if (ExtUI::getAxisPosition_mm(ExtUI::Z) < 10)
-                ExtUI::injectCommands_P(PSTR("G1 Z10")); // RASE Z AXIS
+            if (!isPrinting()) {
+              if (getAxisPosition_mm(Z) < 10)
+                injectCommands_P(PSTR("G1 Z10")); // RASE Z AXIS
 
-              ExtUI::setTargetTemp_celsius(PREHEAT_2_TEMP_BED, (ExtUI::heater_t) ExtUI::BED);
-              ExtUI::setTargetTemp_celsius(PREHEAT_2_TEMP_HOTEND, (ExtUI::extruder_t) ExtUI::E0);
+              setTargetTemp_celsius(PREHEAT_2_TEMP_BED, (heater_t) BED);
+              setTargetTemp_celsius(PREHEAT_2_TEMP_HOTEND, (extruder_t) E0);
               SENDLINE_PGM("OK");
             }
             break;
 
           case 25: // A25 cool down
-            if (!ExtUI::isPrinting()) {
-              ExtUI::setTargetTemp_celsius(0, (ExtUI::heater_t) ExtUI::BED);
-              ExtUI::setTargetTemp_celsius(0, (ExtUI::extruder_t) ExtUI::E0);
+            if (!isPrinting()) {
+              setTargetTemp_celsius(0, (heater_t) BED);
+              setTargetTemp_celsius(0, (extruder_t) E0);
 
               SENDLINE_DBG_PGM("J12", "TFT Serial Debug: Cooling down... J12"); // J12 cool down
             }
@@ -858,9 +860,9 @@ void AnycubicTFTClass::GetCommandFromTFT() {
 
           case 26: // A26 refresh SD
             #if ENABLED(SDSUPPORT)
-              if (ExtUI::isMediaInserted()) {
+              if (isMediaInserted()) {
                 if (strlen(SelectedDirectory) > 0) {
-                  ExtUI::FileList currentFileList;
+                  FileList currentFileList;
                   if ((SelectedDirectory[0] == '.') && (SelectedDirectory[1] == '.')) {
                     currentFileList.upDir();
                   }
@@ -914,7 +916,7 @@ void AnycubicTFTClass::GetCommandFromTFT() {
 
 void AnycubicTFTClass::DoSDCardStateCheck() {
   #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
-    bool isInserted = ExtUI::isMediaInserted();
+    bool isInserted = isMediaInserted();
     if (isInserted)
       SENDLINE_DBG_PGM("J00", "TFT Serial Debug: SD card state changed... isInserted");
     else
@@ -925,12 +927,12 @@ void AnycubicTFTClass::DoSDCardStateCheck() {
 
 void AnycubicTFTClass::DoFilamentRunoutCheck() {
   #if ENABLED(FILAMENT_RUNOUT_SENSOR)
-    // NOTE: ExtUI::getFilamentRunoutState() only returns the runout state if the job is printing
+    // NOTE: getFilamentRunoutState() only returns the runout state if the job is printing
     // we want to actually check the status of the pin here, regardless of printstate
     if (READ(FIL_RUNOUT1_PIN)) {
       if (mediaPrintingState == AMPRINTSTATE_PRINTING || mediaPrintingState == AMPRINTSTATE_PAUSED || mediaPrintingState == AMPRINTSTATE_PAUSE_REQUESTED) {
         // play tone to indicate filament is out
-        ExtUI::injectCommands_P(PSTR("\nM300 P200 S1567\nM300 P200 S1174\nM300 P200 S1567\nM300 P200 S1174\nM300 P2000 S1567"));
+        injectCommands_P(PSTR("\nM300 P200 S1567\nM300 P200 S1174\nM300 P200 S1567\nM300 P200 S1174\nM300 P2000 S1567"));
 
         // tell the user that the filament has run out and wait
         SENDLINE_DBG_PGM("J23", "TFT Serial Debug: Blocking filament prompt... J23");
@@ -944,30 +946,30 @@ void AnycubicTFTClass::DoFilamentRunoutCheck() {
 
 void AnycubicTFTClass::StartPrint() {
   #if ENABLED(SDSUPPORT)
-    if (!ExtUI::isPrinting() && strlen(SelectedFile) > 0) {
+    if (!isPrinting() && strlen(SelectedFile) > 0) {
       #if ENABLED(ANYCUBIC_LCD_DEBUG)
         SERIAL_ECHOPGM("TFT Serial Debug: About to print file ... ");
-        SERIAL_ECHO(ExtUI::isPrinting());
+        SERIAL_ECHO(isPrinting());
         SERIAL_ECHOPGM(" ");
         SERIAL_ECHOLN(SelectedFile);
       #endif
       mediaPrintingState = AMPRINTSTATE_PRINTING;
       mediaPauseState    = AMPAUSESTATE_NOT_PAUSED;
-      ExtUI::printFile(SelectedFile);
+      printFile(SelectedFile);
     }
   #endif // SDUPPORT
 }
 
 void AnycubicTFTClass::PausePrint() {
   #if ENABLED(SDSUPPORT)
-    if (ExtUI::isPrintingFromMedia() && mediaPrintingState != AMPRINTSTATE_STOP_REQUESTED && mediaPauseState == AMPAUSESTATE_NOT_PAUSED) {
+    if (isPrintingFromMedia() && mediaPrintingState != AMPRINTSTATE_STOP_REQUESTED && mediaPauseState == AMPAUSESTATE_NOT_PAUSED) {
       mediaPrintingState = AMPRINTSTATE_PAUSE_REQUESTED;
       mediaPauseState    = AMPAUSESTATE_NOT_PAUSED; // need the userconfirm method to update pause state
       SENDLINE_DBG_PGM("J05", "TFT Serial Debug: SD print pause started... J05"); // J05 printing pause
 
       // for some reason pausing the print doesn't retract the extruder so force a manual one here
-      ExtUI::injectCommands_P(PSTR("G91\nG1 E-2 F1800\nG90"));
-      ExtUI::pausePrint();
+      injectCommands_P(PSTR("G91\nG1 E-2 F1800\nG90"));
+      pausePrint();
     }
   #endif
 }
@@ -996,14 +998,14 @@ void AnycubicTFTClass::ResumePrint() {
       // SENDLINE_DBG_PGM("J05", "TFT Serial Debug: Resume called with heater timeout... J05"); // J05 printing pause
 
       // reheat the nozzle
-      ExtUI::setUserConfirmed();
+      setUserConfirmed();
     }
     else {
       mediaPrintingState = AMPRINTSTATE_PRINTING;
       mediaPauseState    = AMPAUSESTATE_NOT_PAUSED;
 
       SENDLINE_DBG_PGM("J04", "TFT Serial Debug: SD print resumed... J04"); // J04 printing form sd card now
-      ExtUI::resumePrint();
+      resumePrint();
     }
   #endif
 }
@@ -1015,8 +1017,8 @@ void AnycubicTFTClass::StopPrint() {
     SENDLINE_DBG_PGM("J16", "TFT Serial Debug: SD print stop called... J16");
 
     // for some reason stopping the print doesn't retract the extruder so force a manual one here
-    ExtUI::injectCommands_P(PSTR("G91\nG1 E-2 F1800\nG90"));
-    ExtUI::stopPrint();
+    injectCommands_P(PSTR("G91\nG1 E-2 F1800\nG90"));
+    stopPrint();
   #endif
 }
 

--- a/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.h
+++ b/Marlin/src/lcd/extui/lib/anycubic_i3mega/anycubic_i3mega_lcd.h
@@ -2,7 +2,7 @@
  * anycubic_i3mega_lcd.h  --- Support for Anycubic i3 Mega TFT
  * Created by Christian Hopp on 09.12.17.
  * Improved by David Ramiro
- * Converted to ext_iu by John BouAntoun 21 June 2020
+ * Converted to ExtUI by John BouAntoun 21 June 2020
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -48,49 +48,47 @@ enum AnycubicMediaPauseState {
 class AnycubicTFTClass {
 public:
   AnycubicTFTClass();
-  void OnSetup();
-  void OnCommandScan();
-  void OnKillTFT();
-  void OnSDCardStateChange(bool);
-  void OnSDCardError();
-  void OnFilamentRunout();
-  void OnUserConfirmRequired(const char *);
-  void OnPrintTimerStarted();
-  void OnPrintTimerPaused();
-  void OnPrintTimerStopped();
+  static void OnSetup();
+  static void OnCommandScan();
+  static void OnKillTFT();
+  static void OnSDCardStateChange(bool);
+  static void OnSDCardError();
+  static void OnFilamentRunout();
+  static void OnUserConfirmRequired(const char *);
+  static void OnPrintTimerStarted();
+  static void OnPrintTimerPaused();
+  static void OnPrintTimerStopped();
 
 private:
-  char TFTcmdbuffer[TFTBUFSIZE][TFT_MAX_CMD_SIZE];
-  int TFTbuflen=0;
-  int TFTbufindr = 0;
-  int TFTbufindw = 0;
-  char serial3_char;
-  int serial3_count = 0;
-  char *TFTstrchr_pointer;
-  uint8_t SpecialMenu = false;
-  AnycubicMediaPrintState mediaPrintingState = AMPRINTSTATE_NOT_PRINTING;
-  AnycubicMediaPauseState mediaPauseState = AMPAUSESTATE_NOT_PAUSED;
+  static char TFTcmdbuffer[TFTBUFSIZE][TFT_MAX_CMD_SIZE];
+  static int TFTbuflen, TFTbufindr, TFTbufindw;
+  static char serial3_char;
+  static int serial3_count;
+  static char *TFTstrchr_pointer;
+  static uint8_t SpecialMenu;
+  static AnycubicMediaPrintState mediaPrintingState;
+  static AnycubicMediaPauseState mediaPauseState;
 
-  float CodeValue();
-  bool CodeSeen(char);
-  bool IsNozzleHomed();
-  void RenderCurrentFileList();
-  void RenderSpecialMenu(uint16_t);
-  void RenderCurrentFolder(uint16_t);
-  void GetCommandFromTFT();
-  void CheckSDCardChange();
-  void CheckPauseState();
-  void CheckPrintCompletion();
-  void HandleSpecialMenu();
-  void DoSDCardStateCheck();
-  void DoFilamentRunoutCheck();
-  void StartPrint();
-  void PausePrint();
-  void ResumePrint();
-  void StopPrint();
+  static float CodeValue();
+  static bool CodeSeen(char);
+  static bool IsNozzleHomed();
+  static void RenderCurrentFileList();
+  static void RenderSpecialMenu(uint16_t);
+  static void RenderCurrentFolder(uint16_t);
+  static void GetCommandFromTFT();
+  static void CheckSDCardChange();
+  static void CheckPauseState();
+  static void CheckPrintCompletion();
+  static void HandleSpecialMenu();
+  static void DoSDCardStateCheck();
+  static void DoFilamentRunoutCheck();
+  static void StartPrint();
+  static void PausePrint();
+  static void ResumePrint();
+  static void StopPrint();
 
-  char SelectedDirectory[30];
-  char SelectedFile[FILENAME_LENGTH];
+  static char SelectedDirectory[30];
+  static char SelectedFile[FILENAME_LENGTH];
 };
 
 extern AnycubicTFTClass AnycubicTFT;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -140,7 +140,7 @@ namespace ExtUI {
   #if HAS_LEVELING && HAS_MESH
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t x, const int8_t y, const float val) {
+    void onMeshUpdate(const int8_t x, const int8_t y, const float &val) {
       BedMeshScreen::onMeshUpdate(x, y, val);
     }
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.h
@@ -51,7 +51,7 @@ class BedMeshScreen : public BaseScreen, public CachedScreen<BED_MESH_SCREEN_CAC
     static void drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max = 0.1);
 
   public:
-    static void onMeshUpdate(const int8_t x, const int8_t y, const float val);
+    static void onMeshUpdate(const int8_t x, const int8_t y, const float &val);
     static void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t);
     static void onEntry();
     static void onRedraw(draw_mode_t);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stress_test_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/stress_test_screen.cpp
@@ -97,9 +97,7 @@ void StressTestScreen::onEntry() {
   mydata.message = PSTR("Test 1: Stress testing...");
 
   // Turn off heaters.
-  setTargetTemp_celsius(0, E0);
-  setTargetTemp_celsius(0, E1);
-  setTargetTemp_celsius(0, BED);
+  coolDown();
 
   runTestOnBootup(true);
 }

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/temperature_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/temperature_screen.cpp
@@ -101,13 +101,8 @@ bool TemperatureScreen::onTouchHeld(uint8_t tag) {
       case 11: UI_INCREMENT(TargetFan_percent, FAN0); break;
     #endif
     case 30:
-      #define _HOTEND_OFF(N) setTargetTemp_celsius(0, E##N);
-      REPEAT(HOTENDS, _HOTEND_OFF);
-      TERN_(HAS_HEATED_BED, setTargetTemp_celsius(0, BED));
+      coolDown();
       TERN_(HAS_HEATED_CHAMBER, setTargetTemp_celsius(0, CHAMBER));
-      #if HAS_FAN
-        setTargetFan_percent(0, FAN0);
-      #endif
       break;
     default:
       return false;

--- a/Marlin/src/lcd/extui/malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui/malyan_lcd.cpp
@@ -528,7 +528,7 @@ namespace ExtUI {
 
   #if HAS_MESH
     void onMeshLevelingStart() {}
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {}
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {}
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {}
   #endif
 

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -959,11 +959,11 @@ namespace ExtUI {
 
   void printFile(const char *filename) {
     UNUSED(filename);
-    IFSD(card.openAndPrintFile(filename), NOOP);
+    TERN_(SDSUPPORT, card.openAndPrintFile(filename));
   }
 
   bool isPrintingFromMediaPaused() {
-    return IFSD(isPrintingFromMedia() && !IS_SD_PRINTING(), false);
+    return TERN0(SDSUPPORT, isPrintingFromMedia() && !IS_SD_PRINTING());
   }
 
   bool isPrintingFromMedia() {
@@ -978,16 +978,14 @@ namespace ExtUI {
   }
 
   bool isPrinting() {
-    return (commandsInQueue() || isPrintingFromMedia() || IFSD(IS_SD_PRINTING(), false)) || print_job_timer.isRunning() || print_job_timer.isPaused();
+    return (commandsInQueue() || isPrintingFromMedia() || TERN0(SDSUPPORT, IS_SD_PRINTING())) || print_job_timer.isRunning() || print_job_timer.isPaused();
   }
 
   bool isPrintingPaused() {
     return isPrinting() && (isPrintingFromMediaPaused() || print_job_timer.isPaused());
   }
 
-  bool isMediaInserted() {
-    return IFSD(IS_SD_INSERTED() && card.isMounted(), false);
-  }
+  bool isMediaInserted() { return TERN0(SDSUPPORT, IS_SD_INSERTED() && card.isMounted()); }
 
   void pausePrint() { ui.pause_print(); }
   void resumePrint() { ui.resume_print(); }
@@ -1022,27 +1020,27 @@ namespace ExtUI {
   }
 
   const char* FileList::filename() {
-    return IFSD(card.longest_filename(), "");
+    return TERN(SDSUPPORT, card.longest_filename(), "");
   }
 
   const char* FileList::shortFilename() {
-    return IFSD(card.filename, "");
+    return TERN(SDSUPPORT, card.filename, "");
   }
 
   const char* FileList::longFilename() {
-    return IFSD(card.longFilename, "");
+    return TERN(SDSUPPORT, card.longFilename, "");
   }
 
   bool FileList::isDir() {
-    return IFSD(card.flag.filenameIsDir, false);
+    return TERN0(SDSUPPORT, card.flag.filenameIsDir);
   }
 
   uint16_t FileList::count() {
-    return IFSD((num_files = (num_files == 0xFFFF ? card.get_num_Files() : num_files)), 0);
+    return TERN0(SDSUPPORT, (num_files = (num_files == 0xFFFF ? card.get_num_Files() : num_files)));
   }
 
   bool FileList::isAtRootDir() {
-    return IFSD(card.flag.workDirIsRoot, true);
+    return TERN1(SDSUPPORT, card.flag.workDirIsRoot);
   }
 
   void FileList::upDir() {

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -936,6 +936,14 @@ namespace ExtUI {
 
   void setFeedrate_percent(const float &value) { feedrate_percentage = constrain(value, 10, 500); }
 
+  void coolDown() {
+    #if HAS_HOTEND
+      HOTEND_LOOP() thermalManager.setTargetHotend(0, e);
+    #endif
+    TERN_(HAS_HEATED_BED, thermalManager.setTargetBed(0));
+    TERN_(HAS_FAN, thermalManager.zero_fan_speeds());
+  }
+
   bool awaitingUserConfirm() { return wait_for_user; }
 
   void setUserConfirmed() { TERN_(HAS_RESUME_CONTINUE, wait_for_user = false); }

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -305,7 +305,7 @@ namespace ExtUI {
     return epos;
   }
 
-  void setAxisPosition_mm(const float position, const axis_t axis, const feedRate_t feedrate/*=0*/) {
+  void setAxisPosition_mm(const float &position, const axis_t axis, const feedRate_t feedrate/*=0*/) {
     // Get motion limit from software endstops, if any
     float min, max;
     soft_endstop.get_manual_axis_limits((AxisEnum)axis, min, max);
@@ -323,7 +323,7 @@ namespace ExtUI {
     line_to_current_position(feedrate ?: manual_feedrate_mm_s[axis]);
   }
 
-  void setAxisPosition_mm(const float position, const extruder_t extruder, const feedRate_t feedrate/*=0*/) {
+  void setAxisPosition_mm(const float &position, const extruder_t extruder, const feedRate_t feedrate/*=0*/) {
     setActiveTool(extruder, true);
 
     current_position.e = position;
@@ -435,7 +435,7 @@ namespace ExtUI {
       };
     }
 
-    void  setAxisCurrent_mA(const float mA, const axis_t axis) {
+    void setAxisCurrent_mA(const float &mA, const axis_t axis) {
       switch (axis) {
         #if AXIS_IS_TMC(X)
           case X: stepperX.rms_current(constrain(mA, 400, 1500)); break;
@@ -459,7 +459,7 @@ namespace ExtUI {
       };
     }
 
-    void  setAxisCurrent_mA(const float mA, const extruder_t extruder) {
+    void setAxisCurrent_mA(const float &mA, const extruder_t extruder) {
       switch (extruder) {
         #if AXIS_IS_TMC(E0)
           case E0: stepperE0.rms_current(constrain(mA, 400, 1500)); break;
@@ -503,7 +503,7 @@ namespace ExtUI {
       }
     }
 
-    void setTMCBumpSensitivity(const float value, const axis_t axis) {
+    void setTMCBumpSensitivity(const float &value, const axis_t axis) {
       switch (axis) {
         #if X_SENSORLESS || Y_SENSORLESS || Z_SENSORLESS
           #if X_SENSORLESS
@@ -547,12 +547,12 @@ namespace ExtUI {
     return planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)];
   }
 
-  void setAxisSteps_per_mm(const float value, const axis_t axis) {
+  void setAxisSteps_per_mm(const float &value, const axis_t axis) {
     planner.settings.axis_steps_per_mm[axis] = value;
     planner.refresh_positioning();
   }
 
-  void setAxisSteps_per_mm(const float value, const extruder_t extruder) {
+  void setAxisSteps_per_mm(const float &value, const extruder_t extruder) {
     UNUSED_E(extruder);
     planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)] = value;
     planner.refresh_positioning();
@@ -585,12 +585,12 @@ namespace ExtUI {
     return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)];
   }
 
-  void setAxisMaxAcceleration_mm_s2(const float value, const axis_t axis) {
+  void setAxisMaxAcceleration_mm_s2(const float &value, const axis_t axis) {
     planner.set_max_acceleration(axis, value);
     planner.reset_acceleration_rates();
   }
 
-  void setAxisMaxAcceleration_mm_s2(const float value, const extruder_t extruder) {
+  void setAxisMaxAcceleration_mm_s2(const float &value, const extruder_t extruder) {
     UNUSED_E(extruder);
     planner.set_max_acceleration(E_AXIS_N(extruder - E0), value);
     planner.reset_acceleration_rates();
@@ -604,7 +604,7 @@ namespace ExtUI {
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       float getFilamentRunoutDistance_mm()                 { return runout.runout_distance(); }
-      void setFilamentRunoutDistance_mm(const float value) { runout.set_runout_distance(constrain(value, 0, 999)); }
+      void setFilamentRunoutDistance_mm(const float &value) { runout.set_runout_distance(constrain(value, 0, 999)); }
     #endif
   #endif
 
@@ -617,7 +617,7 @@ namespace ExtUI {
 
     #if CASELIGHT_USES_BRIGHTNESS
       float getCaseLightBrightness_percent()                 { return ui8_to_percent(caselight.brightness); }
-      void setCaseLightBrightness_percent(const float value) {
+      void setCaseLightBrightness_percent(const float &value) {
          caselight.brightness = map(constrain(value, 0, 100), 0, 100, 0, 255);
          caselight.update_brightness();
       }
@@ -629,7 +629,7 @@ namespace ExtUI {
       return (extruder < EXTRUDERS) ? planner.extruder_advance_K[extruder - E0] : 0;
     }
 
-    void setLinearAdvance_mm_mm_s(const float value, const extruder_t extruder) {
+    void setLinearAdvance_mm_mm_s(const float &value, const extruder_t extruder) {
       if (extruder < EXTRUDERS)
         planner.extruder_advance_K[extruder - E0] = constrain(value, 0, 10);
     }
@@ -641,28 +641,16 @@ namespace ExtUI {
       return planner.junction_deviation_mm;
     }
 
-    void setJunctionDeviation_mm(const float value) {
+    void setJunctionDeviation_mm(const float &value) {
       planner.junction_deviation_mm = constrain(value, 0.001, 0.3);
       TERN_(LIN_ADVANCE, planner.recalculate_max_e_jerk());
     }
 
   #else
-
-    float getAxisMaxJerk_mm_s(const axis_t axis) {
-      return planner.max_jerk[axis];
-    }
-
-    float getAxisMaxJerk_mm_s(const extruder_t) {
-      return planner.max_jerk.e;
-    }
-
-    void setAxisMaxJerk_mm_s(const float value, const axis_t axis) {
-      planner.set_max_jerk((AxisEnum)axis, value);
-    }
-
-    void setAxisMaxJerk_mm_s(const float value, const extruder_t) {
-      planner.set_max_jerk(E_AXIS, value);
-    }
+    float getAxisMaxJerk_mm_s(const axis_t axis) { return planner.max_jerk[axis]; }
+    float getAxisMaxJerk_mm_s(const extruder_t) { return planner.max_jerk.e; }
+    void setAxisMaxJerk_mm_s(const float &value, const axis_t axis) { planner.set_max_jerk((AxisEnum)axis, value); }
+    void setAxisMaxJerk_mm_s(const float &value, const extruder_t) { planner.set_max_jerk(E_AXIS, value); }
   #endif
 
   feedRate_t getFeedrate_mm_s()                       { return feedrate_mm_s; }
@@ -676,11 +664,12 @@ namespace ExtUI {
   void setFlow_percent(const int16_t flow, const extruder_t extr) { planner.set_flow(extr, flow); }
   void setMinFeedrate_mm_s(const feedRate_t fr)       { planner.settings.min_feedrate_mm_s = fr; }
   void setMinTravelFeedrate_mm_s(const feedRate_t fr) { planner.settings.min_travel_feedrate_mm_s = fr; }
-  void setPrintingAcceleration_mm_s2(const float acc) { planner.settings.acceleration = acc; }
-  void setRetractAcceleration_mm_s2(const float acc)  { planner.settings.retract_acceleration = acc; }
-  void setTravelAcceleration_mm_s2(const float acc)   { planner.settings.travel_acceleration = acc; }
+  void setPrintingAcceleration_mm_s2(const float &acc) { planner.settings.acceleration = acc; }
+  void setRetractAcceleration_mm_s2(const float &acc)  { planner.settings.retract_acceleration = acc; }
+  void setTravelAcceleration_mm_s2(const float &acc)   { planner.settings.travel_acceleration = acc; }
 
   #if ENABLED(BABYSTEPPING)
+
     bool babystepAxis_steps(const int16_t steps, const axis_t axis) {
       switch (axis) {
         #if ENABLED(BABYSTEP_XY)
@@ -738,11 +727,12 @@ namespace ExtUI {
      * Converts a mm displacement to a number of whole number of
      * steps that is at least mm long.
      */
-    int16_t mmToWholeSteps(const float mm, const axis_t axis) {
+    int16_t mmToWholeSteps(const float &mm, const axis_t axis) {
       const float steps = mm / planner.steps_to_mm[axis];
       return steps > 0 ? CEIL(steps) : FLOOR(steps);
     }
-  #endif
+
+  #endif // BABYSTEPPING
 
   float getZOffset_mm() {
     return (0.0f
@@ -754,7 +744,7 @@ namespace ExtUI {
     );
   }
 
-  void setZOffset_mm(const float value) {
+  void setZOffset_mm(const float &value) {
     #if HAS_BED_PROBE
       if (WITHIN(value, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX))
         probe.offset.z = value;
@@ -772,7 +762,7 @@ namespace ExtUI {
       return hotend_offset[extruder - E0][axis];
     }
 
-    void setNozzleOffset_mm(const float value, const axis_t axis, const extruder_t extruder) {
+    void setNozzleOffset_mm(const float &value, const axis_t axis, const extruder_t extruder) {
       if (extruder - E0 >= HOTENDS) return;
       hotend_offset[extruder - E0][axis] = value;
     }
@@ -790,25 +780,21 @@ namespace ExtUI {
   #endif // HAS_HOTEND_OFFSET
 
   #if HAS_BED_PROBE
-    float getProbeOffset_mm(const axis_t axis) {
-      return probe.offset.pos[axis];
-    }
-    void setProbeOffset_mm(const float val, const axis_t axis) {
-      probe.offset.pos[axis] = val;
-    }
+    float getProbeOffset_mm(const axis_t axis) { return probe.offset.pos[axis]; }
+    void setProbeOffset_mm(const float &val, const axis_t axis) { probe.offset.pos[axis] = val; }
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
     float getAxisBacklash_mm(const axis_t axis)       { return backlash.distance_mm[axis]; }
-    void setAxisBacklash_mm(const float value, const axis_t axis)
+    void setAxisBacklash_mm(const float &value, const axis_t axis)
                                                       { backlash.distance_mm[axis] = constrain(value,0,5); }
 
     float getBacklashCorrection_percent()             { return ui8_to_percent(backlash.correction); }
-    void setBacklashCorrection_percent(const float value) { backlash.correction = map(constrain(value, 0, 100), 0, 100, 0, 255); }
+    void setBacklashCorrection_percent(const float &value) { backlash.correction = map(constrain(value, 0, 100), 0, 100, 0, 255); }
 
     #ifdef BACKLASH_SMOOTHING_MM
       float getBacklashSmoothing_mm()                 { return backlash.smoothing_mm; }
-      void setBacklashSmoothing_mm(const float value) { backlash.smoothing_mm = constrain(value, 0, 999); }
+      void setBacklashSmoothing_mm(const float &value) { backlash.smoothing_mm = constrain(value, 0, 999); }
     #endif
   #endif
 
@@ -824,7 +810,7 @@ namespace ExtUI {
     #if HAS_MESH
       bed_mesh_t& getMeshArray() { return Z_VALUES_ARR; }
       float getMeshPoint(const xy_uint8_t &pos) { return Z_VALUES(pos.x, pos.y); }
-      void setMeshPoint(const xy_uint8_t &pos, const float zoff) {
+      void setMeshPoint(const xy_uint8_t &pos, const float &zoff) {
         if (WITHIN(pos.x, 0, GRID_MAX_POINTS_X) && WITHIN(pos.y, 0, GRID_MAX_POINTS_Y)) {
           Z_VALUES(pos.x, pos.y) = zoff;
           TERN_(ABL_BILINEAR_SUBDIVISION, bed_level_virt_interpolate());
@@ -838,6 +824,7 @@ namespace ExtUI {
   #endif
 
   #if ENABLED(PRINTCOUNTER)
+    char* getFailedPrints_str(char buffer[21])   { strcpy(buffer,i16tostr3left(print_job_timer.getStats().totalPrints - print_job_timer.getStats().finishedPrints)); return buffer; }
     char* getTotalPrints_str(char buffer[21])    { strcpy(buffer,i16tostr3left(print_job_timer.getStats().totalPrints));    return buffer; }
     char* getFinishedPrints_str(char buffer[21]) { strcpy(buffer,i16tostr3left(print_job_timer.getStats().finishedPrints)); return buffer; }
     char* getTotalPrintTime_str(char buffer[21]) { return duration_t(print_job_timer.getStats().printTime).toString(buffer); }
@@ -856,14 +843,14 @@ namespace ExtUI {
     float getPIDValues_Ki(const extruder_t tool) { return unscalePID_i(PID_PARAM(Ki, tool)); }
     float getPIDValues_Kd(const extruder_t tool) { return unscalePID_d(PID_PARAM(Kd, tool)); }
 
-    void setPIDValues(const float p, const float i, const float d, extruder_t tool) {
+    void setPIDValues(const float &p, const float &i, const float &d, extruder_t tool) {
       thermalManager.temp_hotend[tool].pid.Kp = p;
       thermalManager.temp_hotend[tool].pid.Ki = scalePID_i(i);
       thermalManager.temp_hotend[tool].pid.Kd = scalePID_d(d);
       thermalManager.updatePID();
     }
 
-    void startPIDTune(const float temp, extruder_t tool) {
+    void startPIDTune(const float &temp, extruder_t tool) {
       thermalManager.PID_autotune(temp, (heater_id_t)tool, 8, true);
     }
   #endif
@@ -873,14 +860,14 @@ namespace ExtUI {
     float getBedPIDValues_Ki() { return unscalePID_i(thermalManager.temp_bed.pid.Ki); }
     float getBedPIDValues_Kd() { return unscalePID_d(thermalManager.temp_bed.pid.Kd); }
 
-    void setBedPIDValues(const float p, const float i, const float d) {
+    void setBedPIDValues(const float &p, const float &i, const float &d) {
       thermalManager.temp_bed.pid.Kp = p;
       thermalManager.temp_bed.pid.Ki = scalePID_i(i);
       thermalManager.temp_bed.pid.Kd = scalePID_d(d);
       thermalManager.updatePID();
     }
 
-    void startBedPIDTune(const float temp) {
+    void startBedPIDTune(const float &temp) {
       thermalManager.PID_autotune(temp, H_BED, 4, true);
     }
   #endif
@@ -900,7 +887,8 @@ namespace ExtUI {
     return firmware_name;
   }
 
-  void setTargetTemp_celsius(float value, const heater_t heater) {
+  void setTargetTemp_celsius(const float &inval, const heater_t heater) {
+    float value = inval;
     #ifdef TOUCH_UI_LCD_TEMP_SCALING
       value *= TOUCH_UI_LCD_TEMP_SCALING;
     #endif
@@ -924,7 +912,8 @@ namespace ExtUI {
     }
   }
 
-  void setTargetTemp_celsius(float value, const extruder_t extruder) {
+  void setTargetTemp_celsius(const float &inval, const extruder_t extruder) {
+    float value = inval;
     #ifdef TOUCH_UI_LCD_TEMP_SCALING
       value *= TOUCH_UI_LCD_TEMP_SCALING;
     #endif
@@ -935,7 +924,7 @@ namespace ExtUI {
     #endif
   }
 
-  void setTargetFan_percent(const float value, const fan_t fan) {
+  void setTargetFan_percent(const float &value, const fan_t fan) {
     #if HAS_FAN
       if (fan < FAN_COUNT)
         thermalManager.set_fan_speed(fan - FAN0, map(constrain(value, 0, 100), 0, 100, 0, 255));
@@ -945,17 +934,11 @@ namespace ExtUI {
     #endif
   }
 
-  void setFeedrate_percent(const float value) {
-    feedrate_percentage = constrain(value, 10, 500);
-  }
+  void setFeedrate_percent(const float &value) { feedrate_percentage = constrain(value, 10, 500); }
 
-  bool awaitingUserConfirm() {
-    return wait_for_user;
-  }
+  bool awaitingUserConfirm() { return wait_for_user; }
 
-  void setUserConfirmed() {
-    TERN_(HAS_RESUME_CONTINUE, wait_for_user = false);
-  }
+  void setUserConfirmed() { TERN_(HAS_RESUME_CONTINUE, wait_for_user = false); }
 
   void printFile(const char *filename) {
     UNUSED(filename);

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -181,6 +181,7 @@ namespace ExtUI {
   void setTargetTemp_celsius(const float&, const heater_t);
   void setTargetTemp_celsius(const float&, const extruder_t);
   void setTargetFan_percent(const float&, const fan_t);
+  void coolDown();
   void setAxisPosition_mm(const float&, const axis_t, const feedRate_t=0);
   void setAxisPosition_mm(const float&, const extruder_t, const feedRate_t=0);
   void setAxisSteps_per_mm(const float&, const axis_t);

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -102,11 +102,11 @@ namespace ExtUI {
   #if HAS_TRINAMIC_CONFIG
     float getAxisCurrent_mA(const axis_t);
     float getAxisCurrent_mA(const extruder_t);
-    void  setAxisCurrent_mA(const float, const axis_t);
-    void  setAxisCurrent_mA(const float, const extruder_t);
+    void  setAxisCurrent_mA(const float&, const axis_t);
+    void  setAxisCurrent_mA(const float&, const extruder_t);
 
      int getTMCBumpSensitivity(const axis_t);
-    void setTMCBumpSensitivity(const float, const axis_t);
+    void setTMCBumpSensitivity(const float&, const axis_t);
   #endif
 
   float getActualTemp_celsius(const heater_t);
@@ -150,10 +150,10 @@ namespace ExtUI {
     #if HAS_MESH
       bed_mesh_t& getMeshArray();
       float getMeshPoint(const xy_uint8_t &pos);
-      void setMeshPoint(const xy_uint8_t &pos, const float zval);
+      void setMeshPoint(const xy_uint8_t &pos, const float &zval);
       void onMeshLevelingStart();
-      void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float zval);
-      inline void onMeshUpdate(const xy_int8_t &pos, const float zval) { onMeshUpdate(pos.x, pos.y, zval); }
+      void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval);
+      inline void onMeshUpdate(const xy_int8_t &pos, const float &zval) { onMeshUpdate(pos.x, pos.y, zval); }
 
       typedef enum : uint8_t {
         MESH_START,    // Prior to start of probe
@@ -178,41 +178,41 @@ namespace ExtUI {
     char* getFilamentUsed_str(char buffer[21]);
   #endif
 
-  void setTargetTemp_celsius(const float, const heater_t);
-  void setTargetTemp_celsius(const float, const extruder_t);
-  void setTargetFan_percent(const float, const fan_t);
-  void setAxisPosition_mm(const float, const axis_t, const feedRate_t=0);
-  void setAxisPosition_mm(const float, const extruder_t, const feedRate_t=0);
-  void setAxisSteps_per_mm(const float, const axis_t);
-  void setAxisSteps_per_mm(const float, const extruder_t);
+  void setTargetTemp_celsius(const float&, const heater_t);
+  void setTargetTemp_celsius(const float&, const extruder_t);
+  void setTargetFan_percent(const float&, const fan_t);
+  void setAxisPosition_mm(const float&, const axis_t, const feedRate_t=0);
+  void setAxisPosition_mm(const float&, const extruder_t, const feedRate_t=0);
+  void setAxisSteps_per_mm(const float&, const axis_t);
+  void setAxisSteps_per_mm(const float&, const extruder_t);
   void setAxisMaxFeedrate_mm_s(const feedRate_t, const axis_t);
   void setAxisMaxFeedrate_mm_s(const feedRate_t, const extruder_t);
-  void setAxisMaxAcceleration_mm_s2(const float, const axis_t);
-  void setAxisMaxAcceleration_mm_s2(const float, const extruder_t);
+  void setAxisMaxAcceleration_mm_s2(const float&, const axis_t);
+  void setAxisMaxAcceleration_mm_s2(const float&, const extruder_t);
   void setFeedrate_mm_s(const feedRate_t);
   void setMinFeedrate_mm_s(const feedRate_t);
   void setMinTravelFeedrate_mm_s(const feedRate_t);
-  void setPrintingAcceleration_mm_s2(const float);
-  void setRetractAcceleration_mm_s2(const float);
-  void setTravelAcceleration_mm_s2(const float);
-  void setFeedrate_percent(const float);
+  void setPrintingAcceleration_mm_s2(const float&);
+  void setRetractAcceleration_mm_s2(const float&);
+  void setTravelAcceleration_mm_s2(const float&);
+  void setFeedrate_percent(const float&);
   void setFlow_percent(const int16_t, const extruder_t);
   bool awaitingUserConfirm();
   void setUserConfirmed();
 
   #if ENABLED(LIN_ADVANCE)
     float getLinearAdvance_mm_mm_s(const extruder_t);
-    void setLinearAdvance_mm_mm_s(const float, const extruder_t);
+    void setLinearAdvance_mm_mm_s(const float&, const extruder_t);
   #endif
 
   #if HAS_JUNCTION_DEVIATION
     float getJunctionDeviation_mm();
-    void setJunctionDeviation_mm(const float);
+    void setJunctionDeviation_mm(const float&);
   #else
     float getAxisMaxJerk_mm_s(const axis_t);
     float getAxisMaxJerk_mm_s(const extruder_t);
-    void setAxisMaxJerk_mm_s(const float, const axis_t);
-    void setAxisMaxJerk_mm_s(const float, const extruder_t);
+    void setAxisMaxJerk_mm_s(const float&, const axis_t);
+    void setAxisMaxJerk_mm_s(const float&, const extruder_t);
   #endif
 
   extruder_t getTool(const uint8_t extruder);
@@ -220,7 +220,7 @@ namespace ExtUI {
   void setActiveTool(const extruder_t, bool no_move);
 
   #if ENABLED(BABYSTEPPING)
-    int16_t mmToWholeSteps(const float mm, const axis_t axis);
+    int16_t mmToWholeSteps(const float& mm, const axis_t axis);
 
     bool babystepAxis_steps(const int16_t steps, const axis_t axis);
     void smartAdjustAxis_steps(const int16_t steps, const axis_t axis, bool linked_nozzles);
@@ -228,28 +228,28 @@ namespace ExtUI {
 
   #if HAS_HOTEND_OFFSET
     float getNozzleOffset_mm(const axis_t, const extruder_t);
-    void setNozzleOffset_mm(const float, const axis_t, const extruder_t);
+    void setNozzleOffset_mm(const float&, const axis_t, const extruder_t);
     void normalizeNozzleOffset(const axis_t axis);
   #endif
 
   float getZOffset_mm();
-  void setZOffset_mm(const float);
+  void setZOffset_mm(const float&);
 
   #if HAS_BED_PROBE
     float getProbeOffset_mm(const axis_t);
-    void setProbeOffset_mm(const float, const axis_t);
+    void setProbeOffset_mm(const float&, const axis_t);
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
     float getAxisBacklash_mm(const axis_t);
-    void setAxisBacklash_mm(const float, const axis_t);
+    void setAxisBacklash_mm(const float&, const axis_t);
 
     float getBacklashCorrection_percent();
-    void setBacklashCorrection_percent(const float);
+    void setBacklashCorrection_percent(const float&);
 
     #ifdef BACKLASH_SMOOTHING_MM
       float getBacklashSmoothing_mm();
-      void setBacklashSmoothing_mm(const float);
+      void setBacklashSmoothing_mm(const float&);
     #endif
   #endif
 
@@ -261,7 +261,7 @@ namespace ExtUI {
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       float getFilamentRunoutDistance_mm();
-      void setFilamentRunoutDistance_mm(const float);
+      void setFilamentRunoutDistance_mm(const float&);
     #endif
   #endif
 
@@ -271,7 +271,7 @@ namespace ExtUI {
 
     #if DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
       float getCaseLightBrightness_percent();
-      void setCaseLightBrightness_percent(const float);
+      void setCaseLightBrightness_percent(const float&);
     #endif
   #endif
 
@@ -279,16 +279,16 @@ namespace ExtUI {
     float getPIDValues_Kp(const extruder_t);
     float getPIDValues_Ki(const extruder_t);
     float getPIDValues_Kd(const extruder_t);
-    void setPIDValues(const float, const float, const float, extruder_t);
-    void startPIDTune(const float, extruder_t);
+    void setPIDValues(const float&, const float&, const float&, extruder_t);
+    void startPIDTune(const float&, extruder_t);
   #endif
 
   #if ENABLED(PIDTEMPBED)
     float getBedPIDValues_Kp();
     float getBedPIDValues_Ki();
     float getBedPIDValues_Kd();
-    void setBedPIDValues(const float, const float, const float);
-    void startBedPIDTune(const float);
+    void setBedPIDValues(const float&, const float&, const float&);
+    void startBedPIDTune(const float&);
   #endif
 
   /**

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -23,8 +23,6 @@
 
 #include "../inc/MarlinConfig.h"
 
-#define IFSD(A,B) TERN(SDSUPPORT,A,B)
-
 #if ENABLED(SDSUPPORT)
 
 extern const char M23_STR[], M24_STR[];


### PR DESCRIPTION
- Add `static` to TFT class methods since `this` is not used.
- Use references for `float` parameters for the benefit of AVR.
- Add a shared `coolDown` method.
- Replace the extraneous `IFSD` macro with `TERN(SDSUPPORT, ...)`.