### PR TITLE
Add M207/8/9 (firmware retraction) reporting

### DIFF
--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -79,6 +79,15 @@ public:
       , bool swapping = false
     #endif
   );
+
+  static void M207();
+  static void M207_report(const bool forReplay=false);
+  static void M208();
+  static void M208_report(const bool forReplay=false);
+  #if ENABLED(FWRETRACT_AUTORETRACT)
+    static void M209();
+    static void M209_report(const bool forReplay=false);
+  #endif
 };
 
 extern FWRetract fwretract;

--- a/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
+++ b/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
@@ -29,46 +29,24 @@
 
 /**
  * M207: Set firmware retraction values
- *
- *   S[+units]    retract_length
- *   W[+units]    swap_retract_length (multi-extruder)
- *   F[units/min] retract_feedrate_mm_s
- *   Z[units]     retract_zraise
  */
-void GcodeSuite::M207() {
-  if (parser.seen('S')) fwretract.settings.retract_length = parser.value_axis_units(E_AXIS);
-  if (parser.seen('F')) fwretract.settings.retract_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-  if (parser.seen('Z')) fwretract.settings.retract_zraise = parser.value_linear_units();
-  if (parser.seen('W')) fwretract.settings.swap_retract_length = parser.value_axis_units(E_AXIS);
-}
+void GcodeSuite::M207() { fwretract.M207(); }
 
 /**
  * M208: Set firmware un-retraction values
- *
- *   S[+units]    retract_recover_extra (in addition to M207 S*)
- *   W[+units]    swap_retract_recover_extra (multi-extruder)
- *   F[units/min] retract_recover_feedrate_mm_s
- *   R[units/min] swap_retract_recover_feedrate_mm_s
  */
-void GcodeSuite::M208() {
-  if (parser.seen('S')) fwretract.settings.retract_recover_extra = parser.value_axis_units(E_AXIS);
-  if (parser.seen('F')) fwretract.settings.retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-  if (parser.seen('R')) fwretract.settings.swap_retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-  if (parser.seen('W')) fwretract.settings.swap_retract_recover_extra = parser.value_axis_units(E_AXIS);
-}
+void GcodeSuite::M208() { fwretract.M208(); }
 
 #if ENABLED(FWRETRACT_AUTORETRACT)
 
   /**
    * M209: Enable automatic retract (M209 S1)
-   *   For slicers that don't support G10/11, reversed extrude-only
-   *   moves will be classified as retraction.
+   *
+   *   For slicers that don't support G10/11, reversed
+   *   extruder-only moves can be classified as retraction.
    */
-  void GcodeSuite::M209() {
-    if (MIN_AUTORETRACT <= MAX_AUTORETRACT && parser.seen('S'))
-      fwretract.enable_autoretract(parser.value_bool());
-  }
+  void GcodeSuite::M209() { fwretract.M209(); }
 
-#endif // FWRETRACT_AUTORETRACT
+#endif
 
 #endif // FWRETRACT

--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -30,7 +30,7 @@
 #include "../../libs/buzzer.h"
 #include "../../MarlinCore.h"
 
-void m206_report() {
+void M206_report() {
   SERIAL_ECHOLNPAIR_P(PSTR("M206 X"), home_offset.x, SP_Y_STR, home_offset.y, SP_Z_STR, home_offset.z);
 }
 
@@ -52,7 +52,7 @@ void GcodeSuite::M206() {
   #endif
 
   if (!parser.seen("XYZ"))
-    m206_report();
+    M206_report();
   else
     report_current_position();
 }

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3466,29 +3466,10 @@ void MarlinSettings::reset() {
     #endif
 
     #if ENABLED(FWRETRACT)
-
-      CONFIG_ECHO_HEADING("Retract: S<length> F<units/m> Z<lift>");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-          PSTR("  M207 S"), LINEAR_UNIT(fwretract.settings.retract_length)
-        , PSTR(" W"), LINEAR_UNIT(fwretract.settings.swap_retract_length)
-        , PSTR(" F"), LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_feedrate_mm_s))
-        , SP_Z_STR, LINEAR_UNIT(fwretract.settings.retract_zraise)
-      );
-
-      CONFIG_ECHO_HEADING("Recover: S<length> F<units/m>");
-      CONFIG_ECHO_MSG(
-          "  M208 S", LINEAR_UNIT(fwretract.settings.retract_recover_extra)
-        , " W", LINEAR_UNIT(fwretract.settings.swap_retract_recover_extra)
-        , " F", LINEAR_UNIT(MMS_TO_MMM(fwretract.settings.retract_recover_feedrate_mm_s))
-      );
-
-      #if ENABLED(FWRETRACT_AUTORETRACT)
-        CONFIG_ECHO_HEADING("Auto-Retract: S=0 to disable, 1 to interpret E-only moves as retract/recover");
-        CONFIG_ECHO_MSG("  M209 S", fwretract.autoretract_enabled);
-      #endif
-
-    #endif // FWRETRACT
+      fwretract.M207_report(forReplay);
+      fwretract.M208_report(forReplay);
+      TERN_(FWRETRACT_AUTORETRACT, fwretract.M209_report(forReplay));
+    #endif
 
     /**
      * Probe Offset


### PR DESCRIPTION
With no parameters, report the current `M207`, `M208`, or `M209` settings.
Use the same methods when displaying output for `M503`.