### PR TITLE
Fix building issue with Meatpack defined only on the second serial port

### DIFF
--- a/Marlin/src/HAL/HAL.h
+++ b/Marlin/src/HAL/HAL.h
@@ -29,12 +29,6 @@
 
 #include HAL_PATH(.,HAL.h)
 
-#ifdef SERIAL_PORT_2
-  #define NUM_SERIAL 2
-#else
-  #define NUM_SERIAL 1
-#endif
-
 #define HAL_ADC_RANGE _BV(HAL_ADC_RESOLUTION)
 
 #ifndef I2C_ADDRESS

--- a/Marlin/src/feature/meatpack.cpp
+++ b/Marlin/src/feature/meatpack.cpp
@@ -42,7 +42,6 @@
 #if HAS_MEATPACK
 
 #include "meatpack.h"
-MeatPack meatpack;
 
 #define MeatPack_ProtocolVersion "PV01"
 //#define MP_DEBUG

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -948,8 +948,12 @@
 //
 #ifdef SERIAL_PORT_2
   #define NUM_SERIAL 2
-#else
+  #define HAS_MULTI_SERIAL 1
+#elif defined(SERIAL_PORT)
   #define NUM_SERIAL 1
+#else
+  #define NUM_SERIAL 0
+  #undef BAUD_RATE_GCODE
 #endif
 #if SERIAL_PORT == -1 || SERIAL_PORT_2 == -1
   #define HAS_USB_SERIAL 1

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -654,13 +654,6 @@
   #define UNUSED_E(E) UNUSED(E)
 #endif
 
-#if ENABLED(DWIN_CREALITY_LCD)
-  #define SERIAL_CATCHALL 0
-  #ifndef LCD_SERIAL_PORT
-    #define LCD_SERIAL_PORT 3 // Creality 4.x board
-  #endif
-#endif
-
 /**
  * The BLTouch Probe emulates a servo probe
  * and uses "special" angles for its state.
@@ -950,11 +943,26 @@
   #define HAS_CLASSIC_E_JERK 1
 #endif
 
+//
+// Serial Port Info
+//
+#ifdef SERIAL_PORT_2
+  #define NUM_SERIAL 2
+#else
+  #define NUM_SERIAL 1
+#endif
 #if SERIAL_PORT == -1 || SERIAL_PORT_2 == -1
   #define HAS_USB_SERIAL 1
 #endif
 #if SERIAL_PORT_2 == -2
   #define HAS_ETHERNET 1
+#endif
+
+#if ENABLED(DWIN_CREALITY_LCD)
+  #define SERIAL_CATCHALL 0
+  #ifndef LCD_SERIAL_PORT
+    #define LCD_SERIAL_PORT 3 // Creality 4.x board
+  #endif
 #endif
 
 // Fallback Stepper Driver types that don't depend on Configuration_adv.h

--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -542,3 +542,10 @@
 #else
   #define HAS_USER_ITEM(N) 0
 #endif
+
+#if !HAS_MULTI_SERIAL
+  #undef MEATPACK_ON_SERIAL_PORT_2
+#endif
+#if EITHER(MEATPACK_ON_SERIAL_PORT_1, MEATPACK_ON_SERIAL_PORT_2)
+  #define HAS_MEATPACK 1
+#endif

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2907,6 +2907,16 @@
   #define HAS_ROTARY_ENCODER 1
 #endif
 
+#if NUM_SERIAL == 1 && defined(SERIAL_PORT_2)
+  // There's a bug here while platform IO is computing the BUILD_FEATURES for its scripts. It's including
+  // common-dependencies.h that (force) defines NUM_SERIAL to 1
+  // In turn, because NUM_SERIAL is set to 1, the code below undefine MEATPACK
+  // if it's defined from MEATPACK_ON_SERIAL_PORT_2 and it's not build anymore (it fails at link step)
+
+  // When used for actually building the code, the macro NUM_SERIAL is set in HAL.h to the expected value anyway
+  #undef NUM_SERIAL
+  #define NUM_SERIAL 2
+#endif
 #if !NUM_SERIAL
   #undef BAUD_RATE_GCODE
 #elif NUM_SERIAL > 1

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2906,26 +2906,3 @@
 #if BUTTONS_EXIST(EN1, EN2, ENC)
   #define HAS_ROTARY_ENCODER 1
 #endif
-
-#if NUM_SERIAL == 1 && defined(SERIAL_PORT_2)
-  // There's a bug here while platform IO is computing the BUILD_FEATURES for its scripts. It's including
-  // common-dependencies.h that (force) defines NUM_SERIAL to 1
-  // In turn, because NUM_SERIAL is set to 1, the code below undefine MEATPACK
-  // if it's defined from MEATPACK_ON_SERIAL_PORT_2 and it's not build anymore (it fails at link step)
-
-  // When used for actually building the code, the macro NUM_SERIAL is set in HAL.h to the expected value anyway
-  #undef NUM_SERIAL
-  #define NUM_SERIAL 2
-#endif
-#if !NUM_SERIAL
-  #undef BAUD_RATE_GCODE
-#elif NUM_SERIAL > 1
-  #define HAS_MULTI_SERIAL 1
-#endif
-
-#if !HAS_MULTI_SERIAL
-  #undef MEATPACK_ON_SERIAL_PORT_2
-#endif
-#if EITHER(MEATPACK_ON_SERIAL_PORT_1, MEATPACK_ON_SERIAL_PORT_2)
-  #define HAS_MEATPACK 1
-#endif

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.h
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.h
@@ -26,8 +26,6 @@
  * Used by common-dependencies.py
  */
 
-#define NUM_SERIAL 1 // Normally provided by HAL/HAL.h
-
 #include "../../../../Marlin/src/inc/MarlinConfig.h"
 
 //


### PR DESCRIPTION


### Description

Fix building issue. Github fails to create the PR once, so I've lost my previous logorrhea. See code for description.

### Requirements

LPC1769

### Configurations

See #21010 

### Related Issues

See #21010 
