### PR TITLE
No extra folder for stlink/jlink upload

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -22,10 +22,9 @@ def add_cpu_freq():
 #
 # It will separe release and debug build folders.
 # It useful when we need keep two live versions: one debug, for debugging,
-# other release, for flashing.
+# other release, for flashing (when upload is not done automatically by jlink/stlink).
 # Without this, PIO will recompile everything twice for any small change.
-#
-if env.GetBuildType() == "debug":
+if env.GetBuildType() == "debug" and env.get('UPLOAD_PROTOCOL') not in ['jlink', 'stlink']:
 	env['BUILD_DIR'] = '$PROJECT_BUILD_DIR/$PIOENV/debug'
 
 # On some platform, F_CPU is a runtime variable. Since it's used to convert from ns


### PR DESCRIPTION
If the upload is don't by jlink, we can just work with debug version while debugging, so we don't need two folders. 

`env.get` is used to avoid key error exception, if there's no `UPLOAD_PROTOCOL` key. It returns `None`, by default, when the key is not found.