### PR TITLE
Update display timing for SKR Pro

### DIFF
--- a/Marlin/src/pins/sanguino/pins_MELZI_V2.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_V2.h
@@ -29,7 +29,7 @@
     #define BOARD_ST7920_DELAY_1 DELAY_NS(0)
   #endif
   #ifndef BOARD_ST7920_DELAY_2
-    #define BOARD_ST7920_DELAY_2 DELAY_NS(188)
+    #define BOARD_ST7920_DELAY_2 DELAY_NS(400)
   #endif
   #ifndef BOARD_ST7920_DELAY_3
     #define BOARD_ST7920_DELAY_3 DELAY_NS(0)

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -441,10 +441,10 @@
 // Alter timing for graphical display
 #if HAS_MARLINUI_U8GLIB
   #ifndef BOARD_ST7920_DELAY_1
-    #define BOARD_ST7920_DELAY_1    DELAY_NS(96)
+    #define BOARD_ST7920_DELAY_1    DELAY_NS(125)
   #endif
   #ifndef BOARD_ST7920_DELAY_2
-    #define BOARD_ST7920_DELAY_2    DELAY_NS(48)
+    #define BOARD_ST7920_DELAY_2    DELAY_NS(90)
   #endif
   #ifndef BOARD_ST7920_DELAY_3
     #define BOARD_ST7920_DELAY_3   DELAY_NS(600)


### PR DESCRIPTION
### Description

This adresses timing problems and resulting garbled display output discussed in #21264. Problems were likely caused by improvements to the delay code in #20901, which probably made timing more precise and thereby revealed that the default timings are too tight. This PR is a work in progress because

- Changes to the The Melzi V2 board have only been tested by 1 board owner (@bill-orange) and are quite drastic (now 0/400/0, before 0/188/0). I am not sure that this change fits all Melzi V2 variants "in the wild" and it should be tested on more boards.
- Changes to the SKR Pro have only been tested by 1 board owner (@FanDjango) and should also be tested by one or two more owners.
- More boards might be affected and we could be getting more user reports in the coming days and maybe weeks.

I would suuggest to tag this as **needs-testing** and **work-in-progress**.

### Requirements

Affected board with over-ambitious display timings after recent changes to the delay handling.

### Benefits

Fixes garbled display output.

### Configurations

None. 

### Related Issues

Should fix #21264.
