### PR TITLE
Restore Automatic Feature Request Labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,7 @@
 name: ✨ Request a feature
 description: Request a new Marlin Firmware feature
 title: "[FR] (feature summary)"
+labels: 'T: Feature Request'
 issue_body: true
 body:
   - type: markdown


### PR DESCRIPTION
### Description

Restore automatic Feature Request labeling. Found while reviewing issues in the queue.

### Requirements

N/A

### Benefits

New Feature Requests will be auto-labeled again.

### Configurations

N/A

### Related Issues

N/A
