### PR TITLE
Update pins_BTT_SKR_MINI_E3_V2_0.h

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -43,7 +43,7 @@
 
 #define FAN1_PIN                           PC7
 
-#ifndef CONTROLLER_FAN_PIN
+#if CONTROLLER_FAN_PIN
   #define CONTROLLER_FAN_PIN               FAN1_PIN
 #endif
 


### PR DESCRIPTION
Fixed the #if CONTROLLER_FAN_PIN there a was a typo where it was spelled #ifndef CONTROLLER_FAN_PIN and was not defining the pin when compiled.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
