### PR TITLE
Fixes preflight-checks.py  

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -20,8 +20,8 @@ def get_envs_for_board(board, envregex):
 					return re.findall(re.compile("%s\w+" % envregex), line)
 	return []
 
-def check_envs(build_env, board_envs, config):
-	if build_env in board_envs:
+def check_envs(build_env, board_envs, config, envregex):
+	if any((match := re.compile("%s%s" % (envregex,build_env)).match(x)) for x in board_envs):
 		return True
 	ext = config.get(build_env, 'extends', default=None)
 	if ext:
@@ -56,7 +56,7 @@ build_env = env['PIOENV']
 motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']
 board_envs = get_envs_for_board(motherboard, osregex)
 config = env.GetProjectConfig()
-result = check_envs(build_env, board_envs, config)
+result = check_envs(build_env, board_envs, config, osregex)
 
 if not result:
 	err = "Error: Build environment '%s' is incompatible with %s. Use one of these: %s" % \

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -17,7 +17,7 @@ def get_envs_for_board(board, envregex):
 				line = file.readline()
 				found_envs = re.match(r"\s*#include .+" + envregex, line)
 				if found_envs:
-					return re.findall(re.compile("%s\w+" % osregex), line)
+					return re.findall(re.compile("%s\w+" % envregex), line)
 	return []
 
 def check_envs(build_env, board_envs, config):

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -21,7 +21,7 @@ def get_envs_for_board(board, envregex):
 	return []
 
 def check_envs(build_env, board_envs, config, envregex):
-	if any((match := re.compile("%s%s" % (envregex,build_env)).match(x)) for x in board_envs):
+	if any((re.compile("%s%s" % (envregex,build_env)).match(x)) for x in board_envs):
 		return True
 	ext = config.get(build_env, 'extends', default=None)
 	if ext:

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -17,7 +17,7 @@ def get_envs_for_board(board, envregex):
 				line = file.readline()
 				found_envs = re.match(r"\s*#include .+" + envregex, line)
 				if found_envs:
-					return re.findall(envregex + r"(\w+)", line)
+					return re.findall(re.compile("%s\w+" % osregex), line)
 	return []
 
 def check_envs(build_env, board_envs, config):


### PR DESCRIPTION
### Description

After #21361 preflight-checks.py no longer advises of what env's to use. 

Function get_envs_for_boardents() in preflight-checks.py returns a list of  environment names but without the needed prefix, this resulted in  preflight-checks.py not listed available environments to use.
Function check_envs() updated to use osregex.

### Benefits

Works as was intended.

### Related Issues

issue https://github.com/MarlinFirmware/Marlin/issues/21363