### PR TITLE
Fix preflight motherboard target check

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -2,34 +2,33 @@
 # preflight-checks.py
 # Check for common issues prior to compiling
 #
-import os,re,sys
+import os,re
 Import("env")
 
-def get_envs_for_board(board, envregex):
-	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:
-		r = re.compile(r"if\s+MB\((.+)\)")
-		if board.startswith("BOARD_"):
-			board = board[6:]
-
-		for line in file:
+def get_envs_for_board(board):
+	if board.startswith("BOARD_"):
+		board = board[6:]
+	with open(os.path.join("Marlin", "src", "pins", "pins.h"),"r") as f:
+		board_found = ""
+		r=re.compile(r"if\s+MB\((.+)\)")
+		for line in f.readlines():
 			mbs = r.findall(line)
-			if mbs and board in re.split(r",\s*", mbs[0]):
-				line = file.readline()
-				found_envs = re.match(r"\s*#include .+" + envregex, line)
-				if found_envs:
-					return re.findall(envregex + r"(\w+)", line)
+			if mbs:
+				board_found = board if board in re.split(r",\s*", mbs[0]) else ""
+			if board_found and "#include " in line and "env:" in line:
+				return re.findall(r"env:\w+", line)
 	return []
 
-def check_envs(build_env, board_envs, config):
-	if build_env in board_envs:
+def check_envs(build_env, base_envs, config):
+	if build_env in base_envs:
 		return True
 	ext = config.get(build_env, 'extends', default=None)
 	if ext:
 		if isinstance(ext, str):
-			return check_envs(ext, board_envs, config)
+			return check_envs(ext, base_envs, config)
 		elif isinstance(ext, list):
 			for ext_env in ext:
-				if check_envs(ext_env, board_envs, config):
+				if check_envs(ext_env, base_envs, config):
 					return True
 	return False
 
@@ -43,24 +42,15 @@ if 'MARLIN_FEATURES' not in env:
 if 'MOTHERBOARD' not in env['MARLIN_FEATURES']:
 	raise SystemExit("Error: MOTHERBOARD is not defined in Configuration.h")
 
-if sys.platform == 'win32':
-	osregex = r"(?:env|win):"
-elif sys.platform == 'darwin':
-	osregex = r"(?:env|mac|uni):"
-elif sys.platform == 'linux':
-	osregex = r"(?:env|lin|uni):"
-else:
-	osregex = r"(?:env):"
-
 build_env = env['PIOENV']
 motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']
-board_envs = get_envs_for_board(motherboard, osregex)
+base_envs = get_envs_for_board(motherboard)
 config = env.GetProjectConfig()
-result = check_envs(build_env, board_envs, config)
+result = check_envs("env:"+build_env, base_envs, config)
 
 if not result:
 	err = "Error: Build environment '%s' is incompatible with %s. Use one of these: %s" % \
-		  (build_env, motherboard, ",".join([e[4:] for e in board_envs if re.match(r"^" + osregex, e)]))
+		  (build_env, motherboard, ",".join([e[4:] for e in base_envs if e.startswith("env:")]))
 	raise SystemExit(err)
 
 #

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -2,13 +2,13 @@
 # preflight-checks.py
 # Check for common issues prior to compiling
 #
-import os,re
+import os,re,sys
 Import("env")
 
 def get_envs_for_board(board):
 	if board.startswith("BOARD_"):
 		board = board[6:]
-	with open(os.path.join("Marlin", "src", "pins", "pins.h"),"r") as f:
+	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as f:
 		board_found = ""
 		r=re.compile(r"if\s+MB\((.+)\)")
 		for line in f.readlines():
@@ -19,16 +19,16 @@ def get_envs_for_board(board):
 				return re.findall(r"env:\w+", line)
 	return []
 
-def check_envs(build_env, base_envs, config):
-	if build_env in base_envs:
+def check_envs(build_env, board_envs, config):
+	if build_env in board_envs:
 		return True
 	ext = config.get(build_env, 'extends', default=None)
 	if ext:
 		if isinstance(ext, str):
-			return check_envs(ext, base_envs, config)
+			return check_envs(ext, board_envs, config)
 		elif isinstance(ext, list):
 			for ext_env in ext:
-				if check_envs(ext_env, base_envs, config):
+				if check_envs(ext_env, board_envs, config):
 					return True
 	return False
 
@@ -42,15 +42,24 @@ if 'MARLIN_FEATURES' not in env:
 if 'MOTHERBOARD' not in env['MARLIN_FEATURES']:
 	raise SystemExit("Error: MOTHERBOARD is not defined in Configuration.h")
 
+if sys.platform == 'win32':
+	osregex = r"(?:env|win):"
+elif sys.platform == 'darwin':
+	osregex = r"(?:env|mac|uni):"
+elif sys.platform == 'linux':
+	osregex = r"(?:env|lin|uni):"
+else:
+	osregex = r"(?:env):"
+
 build_env = env['PIOENV']
 motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']
-base_envs = get_envs_for_board(motherboard)
+board_envs = get_envs_for_board(motherboard)
 config = env.GetProjectConfig()
-result = check_envs("env:"+build_env, base_envs, config)
+result = check_envs("env:"+build_env, board_envs, config)
 
 if not result:
 	err = "Error: Build environment '%s' is incompatible with %s. Use one of these: %s" % \
-		  (build_env, motherboard, ",".join([e[4:] for e in base_envs if e.startswith("env:")]))
+		  (build_env, motherboard, ",".join([e[4:] for e in board_envs if e.startswith("env:")]))
 	raise SystemExit(err)
 
 #

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -5,8 +5,18 @@
 import os,re,sys
 Import("env")
 
-def get_envs_for_board(board, envregex):
+def get_envs_for_board(board):
 	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:
+
+		if sys.platform == 'win32':
+			envregex = r"(?:env|win):"
+		elif sys.platform == 'darwin':
+			envregex = r"(?:env|mac|uni):"
+		elif sys.platform == 'linux':
+			envregex = r"(?:env|lin|uni):"
+		else:
+			envregex = r"(?:env):"
+
 		r = re.compile(r"if\s+MB\((.+)\)")
 		if board.startswith("BOARD_"):
 			board = board[6:]
@@ -44,18 +54,9 @@ if 'MARLIN_FEATURES' not in env:
 if 'MOTHERBOARD' not in env['MARLIN_FEATURES']:
 	raise SystemExit("Error: MOTHERBOARD is not defined in Configuration.h")
 
-if sys.platform == 'win32':
-	osregex = r"(?:env|win):"
-elif sys.platform == 'darwin':
-	osregex = r"(?:env|mac|uni):"
-elif sys.platform == 'linux':
-	osregex = r"(?:env|lin|uni):"
-else:
-	osregex = r"(?:env):"
-
 build_env = env['PIOENV']
 motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']
-board_envs = get_envs_for_board(motherboard, osregex)
+board_envs = get_envs_for_board(motherboard)
 config = env.GetProjectConfig()
 result = check_envs("env:"+build_env, board_envs, config)
 

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -5,19 +5,20 @@
 import os,re,sys
 Import("env")
 
-def get_envs_for_board(board):
+def get_envs_for_board(board, envregex):
 	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:
 		r = re.compile(r"if\s+MB\((.+)\)")
 		if board.startswith("BOARD_"):
 			board = board[6:]
 
-		board_found = ""
 		for line in file:
 			mbs = r.findall(line)
-			if mbs:
-				board_found = board if board in re.split(r",\s*", mbs[0]) else ""
-			if board_found and "#include " in line and "env:" in line:
-				return re.findall(r"env:\w+", line)
+			if mbs and board in re.split(r",\s*", mbs[0]):
+				line = file.readline()
+				found_envs = re.match(r"\s*#include .+" + envregex, line)
+				if found_envs:
+					envlist = re.findall(envregex + r"(\w+)", line)
+					return [ "env:"+s for s in envlist ]
 	return []
 
 def check_envs(build_env, board_envs, config):
@@ -54,13 +55,13 @@ else:
 
 build_env = env['PIOENV']
 motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']
-board_envs = get_envs_for_board(motherboard)
+board_envs = get_envs_for_board(motherboard, osregex)
 config = env.GetProjectConfig()
 result = check_envs("env:"+build_env, board_envs, config)
 
 if not result:
 	err = "Error: Build environment '%s' is incompatible with %s. Use one of these: %s" % \
-		  (build_env, motherboard, ",".join([e[4:] for e in board_envs if e.startswith("env:")]))
+		  ( build_env, motherboard, ", ".join([ e[4:] for e in board_envs if e.startswith("env:") ]) )
 	raise SystemExit(err)
 
 #

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -6,12 +6,13 @@ import os,re,sys
 Import("env")
 
 def get_envs_for_board(board):
-	if board.startswith("BOARD_"):
-		board = board[6:]
-	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as f:
+	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:
+		r = re.compile(r"if\s+MB\((.+)\)")
+		if board.startswith("BOARD_"):
+			board = board[6:]
+
 		board_found = ""
-		r=re.compile(r"if\s+MB\((.+)\)")
-		for line in f.readlines():
+		for line in file:
 			mbs = r.findall(line)
 			if mbs:
 				board_found = board if board in re.split(r",\s*", mbs[0]) else ""


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#21361

This broke to many things. See https://github.com/MarlinFirmware/Marlin/pull/21361 

No list of valid options given and also broke extending of base environments.

Simple eg

add to platfomio.ini
[env:test]
platform    = atmelavr
extends     = env:mega2560

set default_envs = test
set #define MOTHERBOARD BOARD_RAMPS_14_EFB

This should pass preflight test. It fails after PR  21361