### PR TITLE
GT2560_REV_A_PLUS update z_max_pin

### DIFF
--- a/Marlin/src/pins/mega/pins_GT2560_REV_A.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_A.h
@@ -47,10 +47,11 @@
 #if ENABLED(BLTOUCH)
   #if MB(GT2560_REV_A_PLUS)
     #define SERVO0_PIN                        11
+    #define Z_MAX_PIN                         32
   #else
     #define SERVO0_PIN                        32
+    #define Z_MAX_PIN                         -1
   #endif
-  #define Z_MAX_PIN                           -1
 #else
   #define Z_MAX_PIN                           32
 #endif


### PR DESCRIPTION
### Description

If you currently enable BLTOUCH on a GT2560_REV_A_PLUS or GT2560_REV_A the pins file disables Z_MAX_ENDSTOP
This should only be disabled on the GT2560_REV_A 
On a delta with a GT2560_REV_A_PLUS this is quite bad.
Modified  pins_GT2560_REV_A.h so Z_MAX_ENDSTOP is only disabled on GT2560_REV_A when BLTOUCH is enbaled.

### Requirements

GT2560_REV_A_PLUS and BLTOUCH on a delta

### Benefits

Works as expected

### Related Issues

Was raised on discord. user: edicsonm #marlin-v2