### PR TITLE
Add example event broadcaster and listener interfaces

### DIFF
--- a/Marlin/src/core/events.h
+++ b/Marlin/src/core/events.h
@@ -1,0 +1,166 @@
+/**
+ * Marlin 3D Printer Firmware
+ *
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2021 X-Ryl669 boite.pour.spam@gmail.com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+
+#if MoreThan32OrDynamicEvents
+
+  /** The event types */
+  typedef unsigned int EventType;
+  constexpr size_t EventTypeCount = 34;
+
+  /** An event listener. */
+  class EventListener
+  {
+    /** The next listener in the chained list */
+    EventListener * next;
+    #if ENABLED(MARLIN_DEV_MODE)
+      /** The listener name, used for debugging purpose */
+      const char * name;
+    #endif
+
+    // Interface
+  public:
+    /** The event listener unique callback that's called upon registered events are broadcasted */
+    virtual bool on(EventType event, void * parameter) = 0;
+
+    EventListener(const char * name = nullptr) : next(0)
+      #if ENABLED(MARLIN_DEV_MODE)
+        , name(name)
+      #endif
+    {}
+    virtual ~EventListener() {}
+
+    // Helpers
+  private:
+    /** Append another listener in the chain */
+    void linkWith(EventListener * listener) { EventListener * n = this; while (n->next) n = n->next; n->next = listener; }
+
+    friend struct EventBroadcaster;
+  };
+
+
+  /** The broadcaster singleton */
+  struct EventBroadcaster
+  {
+    // Register a listener for an event
+    void registerListener(EventType event, EventListener * listener) {
+      if (!listeners[event]) listeners[event] = listener;
+      else listeners[event]->linkWith(listener);
+    }
+    // Emit an event
+    static void emit(EventType event, void * parameter = nullptr) {
+      EventListener * listener = listeners[event];
+      while (listener) {
+        if (!listener->on(event, parameter)) break;
+        listener = listener->next;
+      }
+    }
+    #if ENABLED(MARLIN_DEV_MODE)
+      void dumpListeners() {
+        for (size_t i = 0; i < EventType::Count; i++) {
+          SERIAL_ECHOPAIR("Event: ", i);
+          EventListener * listener = listeners[i];
+          while (listener) {
+            SERIAL_ECHOPAIR(listener->name, ", ");
+            listener = listener->next;
+          }
+          SERIAL_ECHOLN();
+        }
+      }
+    #endif
+
+  private:
+    // First possibility: A table of possible listener
+    EventListener * listeners[EventTypeCount];
+  };
+
+  EventBroadcaster events;
+#elif EventTypeIsBitMask
+  /** The possible event to listen upon. */
+  enum class EventType
+  {
+    PrinterHalted     = 0x00000001,
+    PrinterConnected  = 0x00000002,
+    PrinterBurning    = 0x00000004,
+  };
+
+  ENUM_FLAGS(EventType); // See #21318, this adds the | & and other bit manipulation operators so we can treat the enum as an integer without casting
+
+  /** An event listener. */
+  class EventListener
+  {
+    /** The next listener in the chained list */
+    EventListener * next;
+    /** The event this listener is interested in */
+    uint32          eventMask;
+    #if ENABLED(MARLIN_DEV_MODE)
+      /** The listener name, used for debugging purpose */
+      const char * name;
+    #endif
+
+    // Interface
+  public:
+    /** The event listener unique callback that's called upon registered events are broadcasted */
+    virtual bool on(EventType event, void * parameter) = 0;
+
+    EventListener(const char * name = nullptr) : next(0), eventMask(0)
+      #if ENABLED(MARLIN_DEV_MODE)
+        , name(name)
+      #endif
+    {}
+    virtual ~EventListener() {}
+
+    // Helpers
+  private:
+    /** Append another listener in the chain */
+    void linkWith(EventListener * listener) { EventListener * n = this; while (n->next) n = n->next; n->next = listener; }
+
+    friend struct EventBroadcaster;
+  };
+
+
+  /** The broadcaster singleton */
+  struct EventBroadcaster
+  {
+    // Register a listener for an event
+    void registerListener(EventType event, EventListener * listener) {
+      listener->eventMask |= event;
+
+      if (!head) head = listener;
+      else head->linkWith(listener);
+    }
+    // Emit an event
+    static void emit(EventType event, void * parameter = nullptr) {
+      EventListener * listener = head;
+      while (listener) {
+        if ((listener->eventMask & event) && !listener->on(event, parameter)) break;
+        listener = listener->next;
+      }
+    }
+
+  private:
+    // First possibility: A table of possible listener
+    EventListener * head;
+  };
+
+  EventBroadcaster events;
+#endif


### PR DESCRIPTION
### Description

Following #21355, we've spotted that some UI code are relying on fragile (untranslated) string parsing to react to printer's event/status. 
We've concluded that this should be changed and instead such code should rely on printer's event.

@rhapsodyv asked for discussion about such architecture.

This is a proposal of 2 different architecture for event broadcasting and event listener in C++.

#### First implementation
**When it's good to use** 

If the number of events is not known beforehand or if it's greater than 32.

The broadcaster contains an array of listeners indexed by the event type. Upon emitting an event, it's finding the first listener for this event in the list, call its callback and then follow the chained list of listeners until it's done processing all listener.

**Pros**
O(1) for finding the listeners that are interested on an event, then O(N) to process the listener list for this event type (N will be very small since it's the number of listener for one event type, so it's almost no impact)

**Cons**
Takes SRAM memory to hold the table of listeners's chained list head pointer (even if no listener are present). The size is proportional to the number of possible event (`= 4 * EventTypeCount`) .


#### Second implementation
**When it's good to use**

If the number of event is limited and fixed (less than 32 possible events).

The broadcaster contains a single chained list of all registered listeners. Upon emitting an event, the list is parsed and each listener contains a mask of the events it's interested in. If the listener is interested in the event, it's called back.

**Pros**
Limited storage space in SRAM (a single pointer)

**Cons**
Each event emitted requires parsing all listeners O(N) with N being the number listeners for all event type.

