### PR TITLE
[New Feature] Mesh editor for the FTDI Eve Touch UI.

### DIFF
--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/grid_layout.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/grid_layout.h
@@ -87,6 +87,19 @@
     cmd.cmd(LINE_WIDTH(16)); \
   }
 
+// Routines for subdividing a grid within a box (x,y,w,h)
+
+#define SUB_GRID_W(W)     ((W)*w/SUB_COLS)
+#define SUB_GRID_H(H)     ((H)*h/SUB_ROWS)
+#define SUB_GRID_X(X)     (SUB_GRID_W((X)-1) + x)
+#define SUB_GRID_Y(Y)     (SUB_GRID_H((Y)-1) + y)
+#define SUB_X(X)          (SUB_GRID_X(X) + MARGIN_L)
+#define SUB_Y(Y)          (SUB_GRID_Y(Y) + MARGIN_T)
+#define SUB_W(W)          (SUB_GRID_W(W) - MARGIN_L - MARGIN_R)
+#define SUB_H(H)          (SUB_GRID_H(H) - MARGIN_T - MARGIN_B)
+#define SUB_POS(X,Y)      SUB_X(X), SUB_Y(Y)
+#define SUB_SIZE(W,H)     SUB_W(W), SUB_H(H)
+
 namespace FTDI {
   #if ENABLED(TOUCH_UI_PORTRAIT)
     constexpr uint16_t display_width  = Vsize;

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extras/adjuster_widget.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extras/adjuster_widget.cpp
@@ -1,0 +1,54 @@
+/***********************
+ * adjuster_widget.cpp *
+ ***********************/
+
+/****************************************************************************
+ *   Written By Marcio Teixeira 2021 - Cocoa Press                          *
+ *                                                                          *
+ *   This program is free software: you can redistribute it and/or modify   *
+ *   it under the terms of the GNU General Public License as published by   *
+ *   the Free Software Foundation, either version 3 of the License, or      *
+ *   (at your option) any later version.                                    *
+ *                                                                          *
+ *   This program is distributed in the hope that it will be useful,        *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU General Public License for more details.                           *
+ *                                                                          *
+ *   To view a copy of the GNU General Public License, go to the following  *
+ *   location: <https://www.gnu.org/licenses/>.                             *
+ ****************************************************************************/
+
+#include "../ftdi_eve_lib.h"
+#include "../extended/grid_layout.h"
+
+#include "adjuster_widget.h"
+
+#define SUB_COLS          9
+#define SUB_ROWS          1
+#define VAL_POS           SUB_POS(1,1), SUB_SIZE(5,1)
+#define INC_POS           SUB_POS(6,1), SUB_SIZE(2,1)
+#define DEC_POS           SUB_POS(8,1), SUB_SIZE(2,1)
+
+void draw_adjuster(CommandProcessor& cmd, int16_t x, int16_t y, int16_t w, int16_t h, uint8_t tag, float value, progmem_str units, int8_t width, uint8_t precision, draw_mode_t what) {
+    if (what & BACKGROUND)
+      cmd.tag(0).button(VAL_POS, F(""), FTDI::OPT_FLAT);
+
+    if (what & FOREGROUND) {
+      char str[width + precision + 10 + (units ? strlen_P((const char*) units) : 0)];
+      if (isnan(value))
+        strcpy_P(str, PSTR("-"));
+      else
+        dtostrf(value, width, precision, str);
+
+      if (units) {
+        strcat_P(str, PSTR(" "));
+        strcat_P(str, (const char*) units);
+      }
+
+      cmd.tag(0)
+         .text(VAL_POS, str)
+         .tag(tag  ).button(INC_POS, F("-"))
+         .tag(tag+1).button(DEC_POS, F("+"));
+    }
+}

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extras/adjuster_widget.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extras/adjuster_widget.h
@@ -1,0 +1,32 @@
+/*********************
+ * adjuster_widget.h *
+ *********************/
+
+/****************************************************************************
+ *   Written By Marcio Teixeira 2021 - Cocoa Press                          *
+ *                                                                          *
+ *   This program is free software: you can redistribute it and/or modify   *
+ *   it under the terms of the GNU General Public License as published by   *
+ *   the Free Software Foundation, either version 3 of the License, or      *
+ *   (at your option) any later version.                                    *
+ *                                                                          *
+ *   This program is distributed in the hope that it will be useful,        *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
+ *   GNU General Public License for more details.                           *
+ *                                                                          *
+ *   To view a copy of the GNU General Public License, go to the following  *
+ *   location: <https://www.gnu.org/licenses/>.                             *
+ ****************************************************************************/
+
+#pragma once
+#include "../extended/screen_types.h"
+
+void draw_adjuster(
+  CommandProcessor& cmd,
+  int16_t x, int16_t y, int16_t w, int16_t h,
+  uint8_t tag,
+  float value, progmem_str units = nullptr,
+  int8_t width = 5, uint8_t precision = 1,
+  draw_mode_t what = BOTH
+);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/language/language_en.h
@@ -144,7 +144,6 @@ namespace Language_en {
   PROGMEM Language_Str MSG_BED_MAPPING_DONE         = u8"Bed mapping finished";
   PROGMEM Language_Str MSG_BED_MAPPING_INCOMPLETE   = u8"Not all points probed";
   PROGMEM Language_Str MSG_LEVELING                 = u8"Leveling";
-  PROGMEM Language_Str MSG_SHOW_MESH                = u8"Show Bed Mesh";
 
   #if ENABLED(TOUCH_UI_LULZBOT_BIO)
     PROGMEM Language_Str MSG_MOVE_TO_HOME           = u8"Move to Home";

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.cpp
@@ -25,21 +25,24 @@
 
 #ifdef FTDI_BED_MESH_SCREEN
 
+#include "../ftdi_eve_lib/extras/adjuster_widget.h"
+
 using namespace FTDI;
 using namespace Theme;
 using namespace ExtUI;
 
 constexpr static BedMeshScreenData &mydata = screen_data.BedMeshScreen;
+constexpr static float gaugeThickness = 0.25;
 
 #if ENABLED(TOUCH_UI_PORTRAIT)
-  #define GRID_COLS 2
+  #define GRID_COLS 3
   #define GRID_ROWS 10
 
-  #define MESH_POS    BTN_POS(1, 2), BTN_SIZE(2,5)
-  #define MESSAGE_POS BTN_POS(1, 7), BTN_SIZE(2,1)
+  #define MESH_POS    BTN_POS(1, 2), BTN_SIZE(3,5)
+  #define MESSAGE_POS BTN_POS(1, 7), BTN_SIZE(3,1)
   #define Z_LABEL_POS BTN_POS(1, 8), BTN_SIZE(1,1)
-  #define Z_VALUE_POS BTN_POS(2, 8), BTN_SIZE(1,1)
-  #define OKAY_POS    BTN_POS(1,10), BTN_SIZE(2,1)
+  #define Z_VALUE_POS BTN_POS(2, 8), BTN_SIZE(2,1)
+  #define OKAY_POS    BTN_POS(1,10), BTN_SIZE(3,1)
 #else
   #define GRID_COLS 5
   #define GRID_ROWS 5
@@ -198,12 +201,12 @@ void BedMeshScreen::drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::
 
   if (opts & USE_HIGHLIGHT) {
     const uint8_t tag = mydata.highlightedTag;
-    uint8_t x, y;
-    if (tagToPoint(tag, x, y)) {
+    xy_uint8_t pt;
+    if (tagToPoint(tag, pt)) {
       cmd.cmd(COLOR_A(128))
          .cmd(POINT_SIZE(basePointSize * 6))
          .cmd(BEGIN(POINTS))
-         .tag(tag).cmd(VERTEX2F(TRANSFORM(x, y, HEIGHT(x, y))));
+         .tag(tag).cmd(VERTEX2F(TRANSFORM(pt.x, pt.y, HEIGHT(pt.x, pt.y))));
     }
   }
   cmd.cmd(END());
@@ -214,43 +217,68 @@ uint8_t BedMeshScreen::pointToTag(uint8_t x, uint8_t y) {
   return y * (GRID_MAX_POINTS_X) + x + 10;
 }
 
-bool BedMeshScreen::tagToPoint(uint8_t tag, uint8_t &x, uint8_t &y) {
+bool BedMeshScreen::tagToPoint(uint8_t tag, xy_uint8_t &pt) {
   if (tag < 10) return false;
-  x = (tag - 10) % (GRID_MAX_POINTS_X);
-  y = (tag - 10) / (GRID_MAX_POINTS_X);
+  pt.x = (tag - 10) % (GRID_MAX_POINTS_X);
+  pt.y = (tag - 10) / (GRID_MAX_POINTS_X);
   return true;
 }
 
 void BedMeshScreen::onEntry() {
   mydata.highlightedTag = 0;
+  mydata.zAdjustment = 0;
   mydata.count = GRID_MAX_POINTS;
   mydata.message = mydata.MSG_NONE;
   BaseScreen::onEntry();
 }
 
-float BedMeshScreen::getHightlightedValue() {
-  if (mydata.highlightedTag) {
-    xy_uint8_t pt;
-    tagToPoint(mydata.highlightedTag, pt.x, pt.y);
-    return ExtUI::getMeshPoint(pt);
+float BedMeshScreen::getHighlightedValue(bool nanAsZero) {
+  xy_uint8_t pt;
+  if (tagToPoint(mydata.highlightedTag, pt)) {
+    const float val = ExtUI::getMeshPoint(pt);
+    return (isnan(val) && nanAsZero) ? 0 : val;
   }
   return NAN;
 }
 
-void BedMeshScreen::drawHighlightedPointValue() {
-  char str[16];
-  const float val = getHightlightedValue();
-  const bool isGood = !isnan(val);
-  if (isGood)
-    dtostrf(val, 5, 3, str);
-  else
-    strcpy_P(str, PSTR("-"));
+void BedMeshScreen::setHighlightedValue(float value) {
+  xy_uint8_t pt;
+  if (tagToPoint(mydata.highlightedTag, pt))
+    ExtUI::setMeshPoint(pt, value);
+}
 
+void BedMeshScreen::moveToHighlightedValue() {
+  xy_uint8_t pt;
+  if (tagToPoint(mydata.highlightedTag, pt))
+    ExtUI::moveToMeshPoint(pt, gaugeThickness + mydata.zAdjustment);
+}
+
+void BedMeshScreen::adjustHighlightedValue(float increment) {
+  mydata.zAdjustment += increment;
+  moveToHighlightedValue();
+}
+
+void BedMeshScreen::saveAdjustedHighlightedValue() {
+  if(mydata.zAdjustment) {
+    BedMeshScreen::setHighlightedValue(BedMeshScreen::getHighlightedValue(true) + mydata.zAdjustment);
+    mydata.zAdjustment = 0;
+  }
+}
+
+void BedMeshScreen::changeHighlightedValue(uint8_t tag) {
+  saveAdjustedHighlightedValue();
+  mydata.highlightedTag = tag;
+  moveToHighlightedValue();
+}
+
+void BedMeshScreen::drawHighlightedPointValue() {
   CommandProcessor cmd;
   cmd.font(Theme::font_medium)
+     .colors(normal_btn)
      .text(Z_LABEL_POS, GET_TEXT_F(MSG_MESH_EDIT_Z))
-     .text(Z_VALUE_POS, str)
-     .colors(action_btn)
+     .font(font_small);
+  draw_adjuster(cmd, Z_VALUE_POS, 2, getHighlightedValue(true) + mydata.zAdjustment, GET_TEXT_F(MSG_UNITS_MM), 4, 3);
+  cmd.colors(action_btn)
      .tag(1).button(OKAY_POS, GET_TEXT_F(MSG_BUTTON_OKAY))
      .tag(0);
 
@@ -292,19 +320,23 @@ void BedMeshScreen::onRedraw(draw_mode_t what) {
   }
 }
 
-bool BedMeshScreen::onTouchStart(uint8_t tag) {
-  mydata.highlightedTag = tag;
-  return true;
-}
-
 bool BedMeshScreen::onTouchEnd(uint8_t tag) {
+  constexpr float increment = 0.01;
   switch (tag) {
     case 1:
+      saveAdjustedHighlightedValue();
+      injectCommands_P(PSTR("G29 S1"));
       GOTO_PREVIOUS();
       return true;
+    case 2: adjustHighlightedValue(-increment); break;
+    case 3: adjustHighlightedValue( increment); break;
     default:
-      return false;
+        if (tag >= 10)
+            changeHighlightedValue(tag);
+        else
+            return false;
   }
+  return true;
 }
 
 void BedMeshScreen::onMeshUpdate(const int8_t, const int8_t, const float) {
@@ -339,6 +371,13 @@ void BedMeshScreen::startMeshProbe() {
   GOTO_SCREEN(BedMeshScreen);
   mydata.count = 0;
   injectCommands_P(PSTR(BED_LEVELING_COMMANDS));
+}
+
+void BedMeshScreen::showMeshEditor() {
+  SpinnerDialogBox::enqueueAndWait_P(ExtUI::isMachineHomed() ? F("M420 S1") : F("G28\nM420 S1"));
+  // After the spinner, go to this screen.
+  current_screen.forget();
+  PUSH_SCREEN(BedMeshScreen);
 }
 
 #endif // FTDI_BED_MESH_SCREEN

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.h
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_screen.h
@@ -32,6 +32,7 @@ struct BedMeshScreenData {
   } message;
   uint8_t count;
   uint8_t highlightedTag;
+  float zAdjustment;
 };
 
 class BedMeshScreen : public BaseScreen, public CachedScreen<BED_MESH_SCREEN_CACHE> {
@@ -45,18 +46,22 @@ class BedMeshScreen : public BaseScreen, public CachedScreen<BED_MESH_SCREEN_CAC
     };
 
     static uint8_t pointToTag(uint8_t x, uint8_t y);
-    static bool tagToPoint(uint8_t tag, uint8_t &x, uint8_t &y);
-    static float getHightlightedValue();
+    static bool tagToPoint(uint8_t tag, xy_uint8_t &pt);
+    static float getHighlightedValue(bool nanAsZero);
+    static void setHighlightedValue(float value);
+    static void moveToHighlightedValue();
+    static void adjustHighlightedValue(float increment);
+    static void saveAdjustedHighlightedValue();
+    static void changeHighlightedValue(uint8_t tag);
     static void drawHighlightedPointValue();
     static void drawMesh(int16_t x, int16_t y, int16_t w, int16_t h, ExtUI::bed_mesh_t data, uint8_t opts, float autoscale_max = 0.1);
-
   public:
-    static void onMeshUpdate(const int8_t x, const int8_t y, const float &val);
+    static void onMeshUpdate(const int8_t x, const int8_t y, const float val);
     static void onMeshUpdate(const int8_t x, const int8_t y, const ExtUI::probe_state_t);
     static void onEntry();
     static void onRedraw(draw_mode_t);
-    static bool onTouchStart(uint8_t tag);
     static bool onTouchEnd(uint8_t tag);
 
     static void startMeshProbe();
+    static void showMeshEditor();
 };

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/leveling_menu.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/leveling_menu.cpp
@@ -39,7 +39,7 @@ using namespace Theme;
   #define TITLE_POS          BTN_POS(1,1), BTN_SIZE(2,1)
   #define LEVEL_AXIS_POS     BTN_POS(1,2), BTN_SIZE(2,1)
   #define LEVEL_BED_POS      BTN_POS(1,3), BTN_SIZE(2,1)
-  #define SHOW_MESH_POS      BTN_POS(1,4), BTN_SIZE(2,1)
+  #define EDIT_MESH_POS      BTN_POS(1,4), BTN_SIZE(2,1)
   #define BLTOUCH_TITLE_POS  BTN_POS(1,6), BTN_SIZE(2,1)
   #define BLTOUCH_RESET_POS  BTN_POS(1,7), BTN_SIZE(1,1)
   #define BLTOUCH_TEST_POS   BTN_POS(2,7), BTN_SIZE(1,1)
@@ -50,7 +50,7 @@ using namespace Theme;
   #define TITLE_POS          BTN_POS(1,1), BTN_SIZE(2,1)
   #define LEVEL_AXIS_POS     BTN_POS(1,2), BTN_SIZE(2,1)
   #define LEVEL_BED_POS      BTN_POS(1,3), BTN_SIZE(2,1)
-  #define SHOW_MESH_POS      BTN_POS(1,4), BTN_SIZE(2,1)
+  #define EDIT_MESH_POS      BTN_POS(1,4), BTN_SIZE(2,1)
   #define BLTOUCH_TITLE_POS  BTN_POS(1,5), BTN_SIZE(2,1)
   #define BLTOUCH_RESET_POS  BTN_POS(1,6), BTN_SIZE(1,1)
   #define BLTOUCH_TEST_POS   BTN_POS(2,6), BTN_SIZE(1,1)
@@ -79,7 +79,7 @@ void LevelingMenu::onRedraw(draw_mode_t what) {
     #endif
        .tag(3).button(LEVEL_BED_POS, GET_TEXT_F(MSG_LEVEL_BED))
        .enabled(ENABLED(HAS_MESH))
-       .tag(4).button(SHOW_MESH_POS, GET_TEXT_F(MSG_SHOW_MESH))
+       .tag(4).button(EDIT_MESH_POS, GET_TEXT_F(MSG_EDIT_MESH))
     #if ENABLED(BLTOUCH)
        .tag(5).button(BLTOUCH_RESET_POS, GET_TEXT_F(MSG_BLTOUCH_RESET))
        .tag(6).button(BLTOUCH_TEST_POS,  GET_TEXT_F(MSG_BLTOUCH_SELFTEST))
@@ -106,7 +106,7 @@ bool LevelingMenu::onTouchEnd(uint8_t tag) {
     #endif
     break;
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-    case 4: GOTO_SCREEN(BedMeshScreen); break;
+    case 4: BedMeshScreen::showMeshEditor(); break;
     #endif
     #if ENABLED(BLTOUCH)
     case 5: injectCommands_P(PSTR("M280 P0 S60")); break;

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -825,6 +825,26 @@ namespace ExtUI {
           TERN_(ABL_BILINEAR_SUBDIVISION, bed_level_virt_interpolate());
         }
       }
+      void moveToMeshPoint(const xy_uint8_t &pos, const float &z) {
+        #if EITHER(MESH_BED_LEVELING, AUTO_BED_LEVELING_UBL)
+          const feedRate_t old_feedrate = feedrate_mm_s;
+          feedrate_mm_s = Z_PROBE_FEEDRATE_FAST;
+          destination = current_position;
+          destination[Z_AXIS] = Z_CLEARANCE_BETWEEN_PROBES;
+          prepare_line_to_destination();
+          feedrate_mm_s = XY_PROBE_FEEDRATE;
+          destination[X_AXIS] = MESH_MIN_X + pos.x * MESH_X_DIST;
+          destination[Y_AXIS] = MESH_MIN_Y + pos.y * MESH_Y_DIST;
+          prepare_line_to_destination();
+          feedrate_mm_s = Z_PROBE_FEEDRATE_FAST;
+          destination[Z_AXIS] = z;
+          prepare_line_to_destination();
+          feedrate_mm_s = old_feedrate;
+        #else
+          UNUSED(pos);
+          UNUSED(z);
+        #endif
+      }
     #endif
   #endif
 

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -162,6 +162,7 @@ namespace ExtUI {
       bed_mesh_t& getMeshArray();
       float getMeshPoint(const xy_uint8_t &pos);
       void setMeshPoint(const xy_uint8_t &pos, const float &zval);
+      void moveToMeshPoint(const xy_uint8_t &pos, const float &z);
       void onMeshLevelingStart();
       void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval);
       inline void onMeshUpdate(const xy_int8_t &pos, const float &zval) { onMeshUpdate(pos.x, pos.y, zval); }


### PR DESCRIPTION
This PR adds a mesh editor the the FTDI Eve Touch UI. The editor allows you to click points on the mesh and move the nozzle closer or further from the bed using the "+" and "-" buttons, checking for proper clearance at each point using a business card.

![MeshEditor](https://user-images.githubusercontent.com/6752228/111840985-ddbb3a80-88c2-11eb-9986-7f94cfeafa7f.jpg)
