### PR TITLE
Fix macros that call macros crashing

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -1048,8 +1048,8 @@ void GcodeSuite::process_subcommands_now(char * gcode) {
     char * const delim = strchr(gcode, '\n');         // Get address of next newline
     if (delim) *delim = '\0';                         // Replace with nul
     parser.parse(gcode);                              // Parse the current command
-    if (delim) *delim = '\n';                         // Put back the newline
     process_parsed_command(true);                     // Process it
+    if (delim) *delim = '\n';                         // Put back the newline
     if (!delim) break;                                // Last command?
     gcode = delim + 1;                                // Get the next command
   }


### PR DESCRIPTION
When macros call macros, the null termination should remain in place
until the macro is completed, and only then put back. Otherwise, the
macro handler interprets this as setting the macro called to a new
value.

### Description

**Macros that call macros**

This fix addresses the M810-M819 macros, and their behaviour if used to call other macros:

    M810 M118 Test message 1|G4 S10|M118 Test message 2

    M810

The above prints "Test message 1", dwells for 10 seconds, and prints "Test message 2" on the serial port.

The issue occurs when calling macros from within macros:

    G90 ; Absolute positioning
    G0 Z4.2
    G0 X10 Y10
    G92 E0
    G91 ; Relative positioning

    ; Macros:
    M810 G0 X-5|G0 Z-4 E5|G2 I5 E1.5|G0 Z4 E-5 ; Print a 10mm circle here
    M811 G0 X25|M810 ; Draw a circle 25mm along X
    M812 M810|M811|M811|M811 ; Draw a line of 4 circles along X

    M812
    G0 Y25
    M812

The above _should_ draw 2 series of 10mm circles. However, when M812 is called, the subcommand processor first finds the first command, null-terminates the string, and calls the parser. After the parser returns, _but before the command is processed_, the delimiter is replaced - as a newline in the case of how macros are current stored.

When the M810_819() method is called, it first determines the length of parser.string_arg. As this is no longer null-terminated at the delimiter, it understands this as a request to change the macro, rather than to run it.

This pull request addresses this issue.

(... your guidelines said you wanted detail.)

### Requirements

Macros enabled, nowt else.

### Benefits

Macros that call macros should cause less breakage.

### Configurations

Example code:

    ;FLAVOR:Marlin
    ; Heating: Bed 60, hotend 200.
    M140 S60
    M104 S200
    M105
    M190 S60
    M109 S200
    
    M201 X1500.00 Y1500.00 Z100.00 E5000.00 ;Setup machine max acceleration
    M203 X500.00 Y500.00 Z10.00 E50.00 ;Setup machine max feedrate
    M204 P750.00 R1000.00 T750.00 ;Setup Print/Retract/Travel acceleration
    M205 X10.00 Y10.00 Z0.40 E5.00 ;Setup Jerk
    
    ; Ender 3 Custom Start G-code
    G92 E0 ; Reset Extruder
    G28 ; Home all axes
    G90
    M83
    G0 X0 Y15 Z2.0 F3000 ; Move Z Axis up little to prevent scratching of Heat Bed
    
    G1 X10 E2 F1200 ; Extract 2mm filament across a 10mm distance
    G1 X20 Z0.3 E2 F1200 ; Extract a bit more while descending
    G1 X30 E2 F1800 ; Final extract
    G0 X40 F1800 ; Wipe
    G0 X50 Z2 E-5 F2400
    G4 M250 ; Dwell 250ms
    G0 Y15 F2500
    G0 X30 F5000
    G0 X10 F7500
    G0 X0 F2500
    G0 Y0 F1500
    G92 E0
    G4 M250 ; Dwell 250ms
    
    M812 G0 Z-4 F3000|G1 E5 F3000|M400|G1 X-5 E0.25 F1200 ; Move down, prime, move to circle start
    M813 G1 E-5 F3000|G0 X5 F1200|G0 Z4 F3000|M400        ; Retract, move to center and lift; Wait for planner.
    
    M814 G0 X50 F6000|M810 ; Move and draw circle
    
    M810 M812|G2 I5 E1.5708|M813 ; Draw a complete circle
    M811 M810|M814|M814|M814|G4 M100 ; Draw a complete row
    
    ; Start location
    
    G90
    G0 Z4 ; Base height offset
    G0 X40 Y40 ; Starting location
    G91 ; Incremental mode
    G0 Z0.2 ; Set layer height
    
    ; Draw the grid
    
    M811
    G0 X-150 Y50 F6000
    M811
    G0 X-150 Y50 F6000
    M811
    G0 X-150 Y50 F6000
    M811
    
    ; All done
    
    M104 S0 ;Turn-off hotend
    M140 S0 ;Turn-off bed
    M107 ; Fan off
    M106 S0 ;Fan speed 0
    G91 ;Relative positioning
    G1 E-2 F2700 ;Retract a bit
    G1 E-2 Z0.2 F2400 ;Retract and raise Z
    G1 X5 Y5 F3000 ;Wipe out
    G1 Z10 ;Raise Z more
    G90 ;Absolute positionning
    G1 X10 Y235 F1500 ;Present print
    M84 X Y E ;Disable all steppers but Z
    M82 ;absolute extrusion mode

### Related Issues

Looks like it's the issue in #20919