### PR TITLE
fix regression on MEGA2560 with SMART_RAMPS, missed SWITCH in RENAMEING

### DIFF
--- a/Marlin/src/pins/ramps/env_validate.h
+++ b/Marlin/src/pins/ramps/env_validate.h
@@ -31,5 +31,4 @@
   #error "Oops! Select 'Arduino/Genuino Mega or Mega 2560 or 1280' in 'Tools > Board.'"
 #endif
 
-#undef ALLOW_SAM3X8E
 #undef REQUIRE_MEGA2560

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -720,7 +720,7 @@
     #elif ENABLED(AZSMZ_12864)
 
       // Pins only defined for RAMPS_SMART currently
-      #if DISABLED(IS_RAMPS_SMART)
+      #if DISABLED(ALLOW_SAM3X8E)
         #error "No pins defined for RAMPS with AZSMZ_12864."
       #endif
 


### PR DESCRIPTION
### Description

SMART_RAMPS board also works with MEGA2560.  There was a renaming of a precompiler switch that was missed.  This change applies that missed name change.

### Requirements

SMART_RAMPS board and MEGA2560

### Benefits

Allows use of MEGA2650 on SMART_RAMPS -- this is restoring that capability.
