### PR TITLE
Update marlinui_DOGM.cpp to fix pin 0 configuration.

### DIFF
--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -216,6 +216,7 @@ bool MarlinUI::detected() { return true; }
     };
 
     auto draw_bootscreen_bmp = [&](const uint8_t *bitmap) {
+      u8g.getU8g()->pin_list[U8G_PI_A0_STATE] = U8G_PIN_NONE;
       u8g.firstPage(); do { _draw_bootscreen_bmp(bitmap); } while (u8g.nextPage());
     };
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Reset pin_list[U8G_PI_A0_STATE] to init state to prevent changing pin 0 pinMode.

There is a bug in u8glib on Arduino that's setting this pin (U8G_PI_A0_STATE) to 0 following initialization through the use of u8g_SetAddress() and using this pin to update the pin direction on subsequent initializations.
The U8G_CLASS constructor provides the first initialization which doesn't change the pin direction (U8G_PI_A0_STATE = U8G_PIN_NONE) but does change the U8G_PI_A0_STATE value to 0 immediately following the init.
Upon first call to u8g.firstPage(), a second initialization is called with the pin value changed to 0 which will override the pin 0 configuration.
Rewriting the pin value to U8G_PIN_NONE prior to u8g.firstPage() prevents changing of the pin config.

### Requirements

Presumably any board that uses pin 0 as any pin config except OUTPUT plus any DOGM LCD.

### Benefits

Pin 0 function will not be overridden using a DOGM LCD.

### Configurations

[config.zip](https://github.com/MarlinFirmware/Marlin/files/6185313/config.zip)

### Related Issues

#21277
