### PR TITLE
SDIO patch followup

### DIFF
--- a/Marlin/src/feature/binary_stream.h
+++ b/Marlin/src/feature/binary_stream.h
@@ -39,7 +39,7 @@ inline int bs_read_serial(const serial_index_t index) {
 
 #if ENABLED(BINARY_STREAM_COMPRESSION)
   static heatshrink_decoder hsd;
-  #ifdef BOTH(ARDUINO_ARCH_STM32F1, SDIO_SUPPORT)
+  #if BOTH(ARDUINO_ARCH_STM32F1, SDIO_SUPPORT)
     // STM32 requires a word-aligned buffer for SD card transfers via DMA
     static __attribute__((aligned(sizeof(size_t)))) uint8_t decode_buffer[512] = {};
   #else


### PR DESCRIPTION
### Description

The line is supposed to be `#if` instead of `#ifdef`.

### Benefits

The line is now properly disabled on boards that don't require it and fixes a compilation warning.
```
In file included from Marlin\src\gcode\queue.cpp:49:0:
Marlin\src\gcode\../feature/binary_stream.h:42:14: warning: extra tokens at end of #ifdef directive
   #ifdef BOTH(ARDUINO_ARCH_STM32F1, SDIO_SUPPORT)
              ^
```

### Related Issues

PR #21396
