### PR TITLE
Endstops always on after G28

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -102,7 +102,7 @@
 
     current_position.set(0.0, 0.0);
 
-    #if ENABLED(SENSORLESS_HOMING)
+    #if ENABLED(SENSORLESS_HOMING) && DISABLED(ENDSTOPS_ALWAYS_ON_DEFAULT)
       tmc_disable_stallguard(stepperX, stealth_states.x);
       tmc_disable_stallguard(stepperY, stealth_states.y);
       #if AXIS_HAS_STALLGUARD(X2)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
User can turn endstops always on in configuration but in case of sensorless homing they were turned off after G28.
### Requirements
--
### Benefits
It will finally work.
### Configurations
--
### Related Issues
--