### PR TITLE
Optimize least_squares_fit

### DIFF
--- a/Marlin/src/libs/least_squares_fit.cpp
+++ b/Marlin/src/libs/least_squares_fit.cpp
@@ -46,23 +46,22 @@ int finish_incremental_LSF(struct linear_fit_data *lsf) {
   if (N == 0.0)
     return 1;
 
-  lsf->xbar /= N;
-  lsf->ybar /= N;
-  lsf->zbar /= N;
-  lsf->x2bar = lsf->x2bar / N - sq(lsf->xbar);
-  lsf->y2bar = lsf->y2bar / N - sq(lsf->ybar);
-  lsf->z2bar = lsf->z2bar / N - sq(lsf->zbar);
-  lsf->xybar = lsf->xybar / N - lsf->xbar * lsf->ybar;
-  lsf->yzbar = lsf->yzbar / N - lsf->ybar * lsf->zbar;
-  lsf->xzbar = lsf->xzbar / N - lsf->xbar * lsf->zbar;
-  const float DD = lsf->x2bar * lsf->y2bar - sq(lsf->xybar);
+  const float xbar = lsf->xbar / N;
+  const float ybar = lsf->ybar / N;
+  const float zbar = lsf->zbar / N;
+  const float x2bar = lsf->x2bar / N - sq(xbar);
+  const float y2bar = lsf->y2bar / N - sq(ybar);
+  const float xybar = lsf->xybar / N - xbar * ybar;
+  const float yzbar = lsf->yzbar / N - ybar * zbar;
+  const float xzbar = lsf->xzbar / N - xbar * zbar;
+  const float DD = x2bar * y2bar - sq(xybar);
 
   if (ABS(DD) <= 1e-10 * (lsf->max_absx + lsf->max_absy))
     return 1;
 
-  lsf->A = (lsf->yzbar * lsf->xybar - lsf->xzbar * lsf->y2bar) / DD;
-  lsf->B = (lsf->xzbar * lsf->xybar - lsf->yzbar * lsf->x2bar) / DD;
-  lsf->D = -(lsf->zbar + lsf->A * lsf->xbar + lsf->B * lsf->ybar);
+  lsf->A = (yzbar * xybar - xzbar * y2bar) / DD;
+  lsf->B = (xzbar * xybar - yzbar * x2bar) / DD;
+  lsf->D = -(zbar + lsf->A * xbar + lsf->B * ybar);
   return 0;
 }
 

--- a/Marlin/src/libs/least_squares_fit.cpp
+++ b/Marlin/src/libs/least_squares_fit.cpp
@@ -46,15 +46,15 @@ int finish_incremental_LSF(struct linear_fit_data *lsf) {
   if (N == 0.0)
     return 1;
 
-  const float xbar = lsf->xbar / N;
-  const float ybar = lsf->ybar / N;
-  const float zbar = lsf->zbar / N;
-  const float x2bar = lsf->x2bar / N - sq(xbar);
-  const float y2bar = lsf->y2bar / N - sq(ybar);
-  const float xybar = lsf->xybar / N - xbar * ybar;
-  const float yzbar = lsf->yzbar / N - ybar * zbar;
-  const float xzbar = lsf->xzbar / N - xbar * zbar;
-  const float DD = x2bar * y2bar - sq(xybar);
+  const float xbar = lsf->xbar / N,
+              ybar = lsf->ybar / N,
+              zbar = lsf->zbar / N,
+              x2bar = lsf->x2bar / N - sq(xbar),
+              y2bar = lsf->y2bar / N - sq(ybar),
+              xybar = lsf->xybar / N - xbar * ybar,
+              yzbar = lsf->yzbar / N - ybar * zbar,
+              xzbar = lsf->xzbar / N - xbar * zbar,
+              DD = x2bar * y2bar - sq(xybar);
 
   if (ABS(DD) <= 1e-10 * (lsf->max_absx + lsf->max_absy))
     return 1;

--- a/Marlin/src/libs/least_squares_fit.cpp
+++ b/Marlin/src/libs/least_squares_fit.cpp
@@ -46,14 +46,15 @@ int finish_incremental_LSF(struct linear_fit_data *lsf) {
   if (N == 0.0)
     return 1;
 
-  const float xbar = lsf->xbar / N,
-              ybar = lsf->ybar / N,
-              zbar = lsf->zbar / N,
-              x2bar = lsf->x2bar / N - sq(xbar),
-              y2bar = lsf->y2bar / N - sq(ybar),
-              xybar = lsf->xybar / N - xbar * ybar,
-              yzbar = lsf->yzbar / N - ybar * zbar,
-              xzbar = lsf->xzbar / N - xbar * zbar,
+  const float RN = 1.0f / N,
+              xbar = lsf->xbar * RN,
+              ybar = lsf->ybar * RN,
+              zbar = lsf->zbar * RN,
+              x2bar = lsf->x2bar * RN - sq(xbar),
+              y2bar = lsf->y2bar * RN - sq(ybar),
+              xybar = lsf->xybar * RN - xbar * ybar,
+              yzbar = lsf->yzbar * RN - ybar * zbar,
+              xzbar = lsf->xzbar * RN - xbar * zbar,
               DD = x2bar * y2bar - sq(xybar);
 
   if (ABS(DD) <= 1e-10 * (lsf->max_absx + lsf->max_absy))

--- a/Marlin/src/libs/least_squares_fit.h
+++ b/Marlin/src/libs/least_squares_fit.h
@@ -37,7 +37,7 @@
 
 struct linear_fit_data {
   float xbar, ybar, zbar,
-        x2bar, y2bar, z2bar,
+        x2bar, y2bar,
         xybar, xzbar, yzbar,
         max_absx, max_absy,
         A, B, D, N;
@@ -56,7 +56,6 @@ inline void incremental_WLSF(struct linear_fit_data *lsf, const float &x, const 
   lsf->zbar  += wz;
   lsf->x2bar += wx * x;
   lsf->y2bar += wy * y;
-  lsf->z2bar += wz * z;
   lsf->xybar += wx * y;
   lsf->xzbar += wx * z;
   lsf->yzbar += wy * z;
@@ -74,7 +73,6 @@ inline void incremental_LSF(struct linear_fit_data *lsf, const float &x, const f
   lsf->zbar += z;
   lsf->x2bar += sq(x);
   lsf->y2bar += sq(y);
-  lsf->z2bar += sq(z);
   lsf->xybar += x * y;
   lsf->xzbar += x * z;
   lsf->yzbar += y * z;


### PR DESCRIPTION
### Description

Remove the z2bar variable (which is unused) and don't bother storing
intermediate values back into the linear_fit_data struct in function
finish_incremental_LSF().

This function could be optimized for speed by calculating (1/N) once
and using multiplications instead of divisions, but this code is not
speed-critical and that would increase program memory by a few bytes.

### Requirements

Tested on my Anet V1.0.

### Benefits

Saves 232 bytes of program memory on AVR.
