### PR TITLE
Fix and add DMA for SDIO on STM32

### DIFF
--- a/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
+++ b/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
@@ -36,9 +36,10 @@
 
   // use USB drivers
 
-  extern "C" { int8_t SD_MSC_Read(uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_t blk_len);
-               int8_t SD_MSC_Write(uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_t blk_len);
-               extern SD_HandleTypeDef hsd;
+  extern "C" {
+    int8_t SD_MSC_Read(uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_t blk_len);
+    int8_t SD_MSC_Write(uint8_t lun, uint8_t *buf, uint32_t blk_addr, uint16_t blk_len);
+    extern SD_HandleTypeDef hsd;
   }
 
   bool SDIO_Init() {
@@ -76,12 +77,12 @@
   #endif
 
   // Fixed
-  #define SDIO_D0_PIN                       PC8
-  #define SDIO_D1_PIN                       PC9
-  #define SDIO_D2_PIN                       PC10
-  #define SDIO_D3_PIN                       PC11
-  #define SDIO_CK_PIN                       PC12
-  #define SDIO_CMD_PIN                      PD2
+  #define SDIO_D0_PIN   PC8
+  #define SDIO_D1_PIN   PC9
+  #define SDIO_D2_PIN   PC10
+  #define SDIO_D3_PIN   PC11
+  #define SDIO_CK_PIN   PC12
+  #define SDIO_CMD_PIN  PD2
 
   SD_HandleTypeDef hsd;  // create SDIO structure
   // F4 support one dma for RX and another for TX.
@@ -107,12 +108,12 @@
 
   // Target Clock, configurable. Default is 18MHz, from STM32F1
   #ifndef SDIO_CLOCK
-    #define SDIO_CLOCK                         18000000       /* 18 MHz */
+    #define SDIO_CLOCK 18000000 // 18 MHz
   #endif
 
   // SDIO retries, configurable. Default is 3, from STM32F1
   #ifndef SDIO_READ_RETRIES
-    #define SDIO_READ_RETRIES                  3
+    #define SDIO_READ_RETRIES 3
   #endif
 
   // SDIO Max Clock (naming from STM Manual, don't change)
@@ -297,7 +298,7 @@
 
     uint32_t timeout = millis() + 500;
     // Wait the transfer
-    while(hsd.State != HAL_SD_STATE_READY) {
+    while (hsd.State != HAL_SD_STATE_READY) {
       if (millis() > timeout) {
         HAL_DMA_Abort_IT(&hdma_sdio);
         HAL_DMA_DeInit(&hdma_sdio);
@@ -305,17 +306,15 @@
       }
     }
 
-    while(__HAL_DMA_GET_FLAG(&hdma_sdio, __HAL_DMA_GET_TC_FLAG_INDEX(&hdma_sdio)) != 0 || __HAL_DMA_GET_FLAG(&hdma_sdio, __HAL_DMA_GET_TE_FLAG_INDEX(&hdma_sdio)) != 0) { /* nada */}
+    while (__HAL_DMA_GET_FLAG(&hdma_sdio, __HAL_DMA_GET_TC_FLAG_INDEX(&hdma_sdio)) != 0
+        || __HAL_DMA_GET_FLAG(&hdma_sdio, __HAL_DMA_GET_TE_FLAG_INDEX(&hdma_sdio)) != 0) { /* nada */ }
 
     HAL_DMA_Abort_IT(&hdma_sdio);
     HAL_DMA_DeInit(&hdma_sdio);
 
     timeout = millis() + 500;
-    while(HAL_SD_GetCardState(&hsd) != HAL_SD_CARD_TRANSFER) {
-      if (millis() > timeout) {
-        return false;
-      }
-    }
+    while (HAL_SD_GetCardState(&hsd) != HAL_SD_CARD_TRANSFER)
+      if (millis() > timeout) return false;
 
     return true;
   }

--- a/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
+++ b/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
@@ -332,17 +332,16 @@
     return false;
   }
 
-  extern "C" void SDIO_IRQHandler(void) {
-    HAL_SD_IRQHandler(&hsd);
-  }
-
   #if defined(STM32F1xx)
-    extern "C" void DMA2_Channel4_5_IRQHandler(void) {
+    #define DMA_IRQ_HANDLER DMA2_Channel4_5_IRQHandler
   #elif defined(STM32F4xx)
-    extern "C" void DMA2_Stream3_IRQHandler(void) {
+    #define DMA_IRQ_HANDLER DMA2_Stream3_IRQHandler
+  #else
+    #error "Unknown STM32 architecture."
   #endif
-      HAL_DMA_IRQHandler(&hdma_sdio);
-    }
+
+  extern "C" void SDIO_IRQHandler(void) { HAL_SD_IRQHandler(&hsd); }
+  extern "C" void DMA_IRQ_HANDLER(void) { HAL_DMA_IRQHandler(&hdma_sdio); }
 
 #endif // !USBD_USE_CDC_COMPOSITE
 #endif // SDIO_SUPPORT

--- a/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
+++ b/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
@@ -177,14 +177,18 @@
     // Setup DMA
     __HAL_RCC_DMA2_CLK_ENABLE();
     #if defined(STM32F1xx)
+      hdma_sdio.Init.Mode = DMA_NORMAL;
       hdma_sdio.Instance = DMA2_Channel4;
       HAL_NVIC_EnableIRQ(DMA2_Channel4_5_IRQn);
       HAL_NVIC_EnableIRQ(SDIO_IRQn);
     #elif defined(STM32F4xx)
+      hdma_sdio.Init.Mode = DMA_PFCTRL;
       hdma_sdio.Instance = DMA2_Stream3;
       hdma_sdio.Init.Channel = DMA_CHANNEL_4;
       hdma_sdio.Init.FIFOMode = DMA_FIFOMODE_ENABLE;
       hdma_sdio.Init.FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
+      hdma_sdio.Init.MemBurst = DMA_MBURST_INC4;
+      hdma_sdio.Init.PeriphBurst = DMA_PBURST_INC4;
       HAL_NVIC_EnableIRQ(DMA2_Stream3_IRQn);
       HAL_NVIC_EnableIRQ(SDMMC1_IRQn);
     #endif
@@ -192,7 +196,6 @@
     hdma_sdio.Init.MemInc = DMA_MINC_ENABLE;
     hdma_sdio.Init.PeriphDataAlignment = DMA_PDATAALIGN_WORD;
     hdma_sdio.Init.MemDataAlignment = DMA_MDATAALIGN_WORD;
-    hdma_sdio.Init.Mode = DMA_NORMAL;
     hdma_sdio.Init.Priority = DMA_PRIORITY_LOW;
     __HAL_LINKDMA(&hsd, hdmarx, hdma_sdio);
     __HAL_LINKDMA(&hsd, hdmatx, hdma_sdio);

--- a/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
+++ b/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
@@ -179,12 +179,14 @@
     #if defined(STM32F1xx)
       hdma_sdio.Instance = DMA2_Channel4;
       HAL_NVIC_EnableIRQ(DMA2_Channel4_5_IRQn);
+      HAL_NVIC_EnableIRQ(SDIO_IRQn);
     #elif defined(STM32F4xx)
       hdma_sdio.Instance = DMA2_Stream3;
       hdma_sdio.Init.Channel = DMA_CHANNEL_4;
       hdma_sdio.Init.FIFOMode = DMA_FIFOMODE_ENABLE;
       hdma_sdio.Init.FIFOThreshold = DMA_FIFO_THRESHOLD_FULL;
       HAL_NVIC_EnableIRQ(DMA2_Stream3_IRQn);
+      HAL_NVIC_EnableIRQ(SDMMC1_IRQn);
     #endif
     hdma_sdio.Init.PeriphInc = DMA_PINC_DISABLE;
     hdma_sdio.Init.MemInc = DMA_MINC_ENABLE;
@@ -192,7 +194,6 @@
     hdma_sdio.Init.MemDataAlignment = DMA_MDATAALIGN_WORD;
     hdma_sdio.Init.Mode = DMA_NORMAL;
     hdma_sdio.Init.Priority = DMA_PRIORITY_LOW;
-    HAL_NVIC_EnableIRQ(SDIO_IRQn);
     __HAL_LINKDMA(&hsd, hdmarx, hdma_sdio);
     __HAL_LINKDMA(&hsd, hdmatx, hdma_sdio);
 
@@ -322,9 +323,13 @@
     return false;
   }
 
-  extern "C" void SDIO_IRQHandler(void) {
-    HAL_SD_IRQHandler(&hsd);
-  }
+  #if defined(STM32F1xx)
+    extern "C" void SDIO_IRQHandler(void) {
+  #elif defined(STM32F4xx)
+    extern "C" void SDMMC1_IRQHandler(void) {
+  #endif
+      HAL_SD_IRQHandler(&hsd);
+    }
 
   #if defined(STM32F1xx)
     extern "C" void DMA2_Channel4_5_IRQHandler(void) {

--- a/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
+++ b/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
@@ -131,18 +131,16 @@
   }
 
   void go_to_transfer_speed() {
-    SD_InitTypeDef Init;
-
     /* Default SDIO peripheral configuration for SD card initialization */
-    Init.ClockEdge           = hsd.Init.ClockEdge;
-    Init.ClockBypass         = hsd.Init.ClockBypass;
-    Init.ClockPowerSave      = hsd.Init.ClockPowerSave;
-    Init.BusWide             = hsd.Init.BusWide;
-    Init.HardwareFlowControl = hsd.Init.HardwareFlowControl;
-    Init.ClockDiv            = clock_to_divider(SDIO_CLOCK);
+    hsd.Init.ClockEdge           = hsd.Init.ClockEdge;
+    hsd.Init.ClockBypass         = hsd.Init.ClockBypass;
+    hsd.Init.ClockPowerSave      = hsd.Init.ClockPowerSave;
+    hsd.Init.BusWide             = hsd.Init.BusWide;
+    hsd.Init.HardwareFlowControl = hsd.Init.HardwareFlowControl;
+    hsd.Init.ClockDiv            = clock_to_divider(SDIO_CLOCK);
 
     /* Initialize SDIO peripheral interface with default configuration */
-    SDIO_Init(hsd.Instance, Init);
+    SDIO_Init(hsd.Instance, hsd.Init);
   }
 
   void SD_LowLevel_Init(void) {
@@ -267,6 +265,7 @@
           if (!status) break;
           if (!--retry_Cnt) return false;   // return failing status if retries are exhausted
         }
+        go_to_transfer_speed();
       }
     #endif
 

--- a/Marlin/src/gcode/gcode_d.cpp
+++ b/Marlin/src/gcode/gcode_d.cpp
@@ -127,19 +127,19 @@
       #endif
 
       case 4: { // D4 Read / Write PIN
-        // const uint8_t pin = parser.byteval('P');
-        // const bool is_out = parser.boolval('F'),
-        //            val = parser.byteval('V', LOW);
+        //const bool is_out = parser.boolval('F');
+        //const uint8_t pin = parser.byteval('P'),
+        //              val = parser.byteval('V', LOW);
         if (parser.seenval('X')) {
           // TODO: Write the hex bytes after the X
           //while (len--) {
           //}
         }
         else {
-          // while (len--) {
-            // TODO: Read bytes from EEPROM
-            // print_hex_byte(eeprom_read_byte(*(adr++));
-          // }
+          //while (len--) {
+          //// TODO: Read bytes from EEPROM
+          //  print_hex_byte(eeprom_read_byte(adr++));
+          //}
           SERIAL_EOL();
         }
       } break;
@@ -156,10 +156,10 @@
           //while (len--) {}
         }
         else {
-          // while (len--) {
-            // TODO: Read bytes from EEPROM
-            // print_hex_byte(eeprom_read_byte(adr++));
-          // }
+          //while (len--) {
+          //// TODO: Read bytes from EEPROM
+          //  print_hex_byte(eeprom_read_byte(adr++));
+          //}
           SERIAL_EOL();
         }
       } break;
@@ -183,37 +183,38 @@
       } break;
 
       #if ENABLED(SDSUPPORT)
-        case 101: { //D101 Test SD Write
+
+        case 101: { // D101 Test SD Write
           card.openFileWrite("test.gco");
           if (!card.isFileOpen()) {
             SERIAL_ECHOLNPAIR("Failed to open test.gco to write.");
             return;
           }
           __attribute__((aligned(sizeof(size_t)))) uint8_t buf[512];
+
           uint16_t c;
-          for (c = 0; c < COUNT(buf); c++) {
+          for (c = 0; c < COUNT(buf); c++)
             buf[c] = 'A' + (c % ('Z' - 'A'));
-          }
+
           c = 1024 * 4;
           while (c--) {
-            TERN_(USE_WATCHDOG, HAL_watchdog_refresh());
+            TERN_(USE_WATCHDOG, watchdog_refresh());
             card.write(buf, COUNT(buf));
           }
           SERIAL_ECHOLNPGM(" done");
           card.closefile();
         } break;
 
-        case 102: { //D102 Test SD Read
+        case 102: { // D102 Test SD Read
           card.openFileRead("test.gco");
           if (!card.isFileOpen()) {
             SERIAL_ECHOLNPAIR("Failed to open test.gco to read.");
             return;
           }
           __attribute__((aligned(sizeof(size_t)))) uint8_t buf[512];
-          uint16_t c;
-          c = 1024 * 4;
+          uint16_t c = 1024 * 4;
           while (c--) {
-            TERN_(USE_WATCHDOG, HAL_watchdog_refresh());
+            TERN_(USE_WATCHDOG, watchdog_refresh());
             card.read(buf, COUNT(buf));
             bool error = false;
             for (uint16_t i = 0; i < COUNT(buf); i++) {
@@ -230,24 +231,27 @@
           SERIAL_ECHOLNPGM(" done");
           card.closefile();
         } break;
-      #endif
+
+      #endif // SDSUPPORT
 
       #if ENABLED(POSTMORTEM_DEBUGGING)
-      case 451: { // Trigger all kind of faults to test exception catcher
-        SERIAL_ECHOLNPGM("Disabling heaters");
-        thermalManager.disable_all_heaters();
-        delay(1000); // Allow time to print
-        volatile uint8_t type[5] = { parser.byteval('T', 1) };
 
-        // The code below is obviously wrong and it's full of quirks to fool the compiler from optimizing away the code
-        switch (type[0]) {
-          case 1: default: *(int*)0 = 451; break; // Write at bad address
-          case 2: { volatile int a = 0; volatile int b = 452 / a; *(int*)&a = b; } break; // Divide by zero (some CPUs accept this, like ARM)
-          case 3: { *(uint32_t*)&type[1] = 453; volatile int a = *(int*)&type[1]; type[0] = a / 255; } break; // Unaligned access (some CPUs accept this)
-          case 4: { volatile void (*func)() = (volatile void (*)()) 0xE0000000; func(); } break; // Invalid instruction
+        case 451: { // Trigger all kind of faults to test exception catcher
+          SERIAL_ECHOLNPGM("Disabling heaters");
+          thermalManager.disable_all_heaters();
+          delay(1000); // Allow time to print
+          volatile uint8_t type[5] = { parser.byteval('T', 1) };
+
+          // The code below is obviously wrong and it's full of quirks to fool the compiler from optimizing away the code
+          switch (type[0]) {
+            case 1: default: *(int*)0 = 451; break; // Write at bad address
+            case 2: { volatile int a = 0; volatile int b = 452 / a; *(int*)&a = b; } break; // Divide by zero (some CPUs accept this, like ARM)
+            case 3: { *(uint32_t*)&type[1] = 453; volatile int a = *(int*)&type[1]; type[0] = a / 255; } break; // Unaligned access (some CPUs accept this)
+            case 4: { volatile void (*func)() = (volatile void (*)()) 0xE0000000; func(); } break; // Invalid instruction
+          }
+          break;
         }
-        break;
-      }
+
       #endif
     }
   }


### PR DESCRIPTION
### Description

MKS just discovered that write block on STM32 SDIO is not working.

While fixing it, I already added DMA support for it, as we have on STM32F1.

I'm using DMA with interrupts.

Add two debug codes, to test write and read.

`D101` will generate a file `TEST.GCO` with a long sequence of A-Z, with about 2.1MB. Test Write.
`D102` will read this file and check if the A-Z sequence is valid. Test Read.

### Requirements

F1 board with SDIO: Nano V2 
F4 board with SDIO

### Benefits

Faster and Stable SDIO
Fix #20662

### Related Issues

