### PR TITLE
Board IDs for G2560 Rev B, G2560 v4, GTM32 VD

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -157,6 +157,8 @@
 #define BOARD_PICA_REVB               1322  // PICA Shield (original version)
 #define BOARD_PICA                    1323  // PICA Shield (rev C or later)
 #define BOARD_INTAMSYS40              1324  // Intamsys 4.0 (Funmat HT)
+#define BOARD_GT2560_V4               1325  // Geeetech GT2560 Rev B for A10(M/D)
+#define BOARD_GT2560_REV_B            1326  // Geeetech GT2560 Rev. A
 
 //
 // ATmega1281, ATmega2561
@@ -341,6 +343,7 @@
 #define BOARD_FLSUN_HISPEED           4046  // FLSUN HiSpeedV1 (STM32F103VET6)
 #define BOARD_BEAST                   4047  // STM32F103RET6 Libmaple-based controller
 #define BOARD_MINGDA_MPX_ARM_MINI     4048  // STM32F103ZET6 Mingda MD-16
+#define BOARD_GTM32_PRO_VD            4049  // STM32F103VET6 controller
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -146,19 +146,19 @@
 #define BOARD_ELEFU_3                 1311  // Elefu Ra Board (v3)
 #define BOARD_LEAPFROG                1312  // Leapfrog
 #define BOARD_MEGACONTROLLER          1313  // Mega controller
-#define BOARD_GT2560_REV_A            1314  // Geeetech GT2560 Rev. A
-#define BOARD_GT2560_REV_A_PLUS       1315  // Geeetech GT2560 Rev. A+ (with auto level probe)
-#define BOARD_GT2560_V3               1316  // Geeetech GT2560 Rev B for A10(M/D)
-#define BOARD_GT2560_V3_MC2           1317  // Geeetech GT2560 Rev B for Mecreator2
-#define BOARD_GT2560_V3_A20           1318  // Geeetech GT2560 Rev B for A20(M/D)
-#define BOARD_EINSTART_S              1319  // Einstart retrofit
-#define BOARD_WANHAO_ONEPLUS          1320  // Wanhao 0ne+ i3 Mini
-#define BOARD_LEAPFROG_XEED2015       1321  // Leapfrog Xeed 2015
-#define BOARD_PICA_REVB               1322  // PICA Shield (original version)
-#define BOARD_PICA                    1323  // PICA Shield (rev C or later)
-#define BOARD_INTAMSYS40              1324  // Intamsys 4.0 (Funmat HT)
-#define BOARD_GT2560_V4               1325  // Geeetech GT2560 Rev B for A10(M/D)
-#define BOARD_GT2560_REV_B            1326  // Geeetech GT2560 Rev. A
+#define BOARD_GT2560_REV_A            1314  // Geeetech GT2560 Rev A
+#define BOARD_GT2560_REV_A_PLUS       1315  // Geeetech GT2560 Rev A+ (with auto level probe)
+#define BOARD_GT2560_REV_B            1316  // Geeetech GT2560 Rev B
+#define BOARD_GT2560_V3               1317  // Geeetech GT2560 Rev B for A10(M/D)
+#define BOARD_GT2560_V4               1318  // Geeetech GT2560 Rev B for A10(M/D)
+#define BOARD_GT2560_V3_MC2           1319  // Geeetech GT2560 Rev B for Mecreator2
+#define BOARD_GT2560_V3_A20           1320  // Geeetech GT2560 Rev B for A20(M/D)
+#define BOARD_EINSTART_S              1321  // Einstart retrofit
+#define BOARD_WANHAO_ONEPLUS          1322  // Wanhao 0ne+ i3 Mini
+#define BOARD_LEAPFROG_XEED2015       1323  // Leapfrog Xeed 2015
+#define BOARD_PICA_REVB               1324  // PICA Shield (original version)
+#define BOARD_PICA                    1325  // PICA Shield (rev C or later)
+#define BOARD_INTAMSYS40              1326  // Intamsys 4.0 (Funmat HT)
 
 //
 // ATmega1281, ATmega2561

--- a/Marlin/src/pins/mega/pins_GT2560_REV_B.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_B.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm

--- a/Marlin/src/pins/mega/pins_GT2560_REV_B.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_B.h
@@ -1,0 +1,29 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Geeetech GT2560 Rev B Pins
+ */
+
+
+#include "pins_GT2560_V3.h"

--- a/Marlin/src/pins/mega/pins_GT2560_REV_B.h
+++ b/Marlin/src/pins/mega/pins_GT2560_REV_B.h
@@ -25,5 +25,6 @@
  * Geeetech GT2560 Rev B Pins
  */
 
+#define BOARD_INFO_NAME "GT2560 Rev B"
 
 #include "pins_GT2560_V3.h"

--- a/Marlin/src/pins/mega/pins_GT2560_V3.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V3.h
@@ -22,14 +22,16 @@
 #pragma once
 
 /**
- * Geeetech GT2560 RevB + GT2560 3.0/3.1 + GT2560 4.0/4.1 pin assignments
+ * Geeetech GT2560 3.0/3.1 pin assignments
+ *
+ * Also GT2560 RevB and GT2560 4.0/4.1
  */
 
 #define ALLOW_MEGA1280
 #include "env_validate.h"
 
 #ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME "GT2560 RevB/3.x/4.x"
+  #define BOARD_INFO_NAME "GT2560 3.x"
 #endif
 
 //

--- a/Marlin/src/pins/mega/pins_GT2560_V4.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V4.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm

--- a/Marlin/src/pins/mega/pins_GT2560_V4.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V4.h
@@ -1,0 +1,29 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Geeetech GT2560 V4.X Pins
+ */
+
+
+#include "pins_GT2560_V3.h"

--- a/Marlin/src/pins/mega/pins_GT2560_V4.h
+++ b/Marlin/src/pins/mega/pins_GT2560_V4.h
@@ -25,5 +25,6 @@
  * Geeetech GT2560 V4.X Pins
  */
 
+#define BOARD_INFO_NAME "GT2560 4.x"
 
 #include "pins_GT2560_V3.h"

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -474,6 +474,8 @@
   #include "stm32f1/pins_STM3R_MINI.h"          // STM32F1                                env:STM32F103RE
 #elif MB(GTM32_PRO_VB)
   #include "stm32f1/pins_GTM32_PRO_VB.h"        // STM32F1                                env:STM32F103RE
+#elif MB(GTM32_PRO_VD)
+  #include "stm32f1/pins_GTM32_PRO_VD.h"        // STM32F1                                env:STM32F103RE  
 #elif MB(GTM32_MINI)
   #include "stm32f1/pins_GTM32_MINI.h"          // STM32F1                                env:STM32F103RE
 #elif MB(GTM32_MINI_A30)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -242,16 +242,16 @@
   #include "mega/pins_GT2560_REV_A.h"           // ATmega2560, ATmega1280                 env:mega2560 env:mega1280
 #elif MB(GT2560_REV_A_PLUS)
   #include "mega/pins_GT2560_REV_A_PLUS.h"      // ATmega2560, ATmega1280                 env:mega2560 env:mega1280
-#elif MB(GT2560_REV_B)
-  #include "mega/pins_GT2560_REV_B.h"           // ATmega2560                             env:mega2560
 #elif MB(GT2560_V3)
   #include "mega/pins_GT2560_V3.h"              // ATmega2560                             env:mega2560
+#elif MB(GT2560_REV_B)
+  #include "mega/pins_GT2560_REV_B.h"           // ATmega2560                             env:mega2560
+#elif MB(GT2560_V4)
+  #include "mega/pins_GT2560_V4.h"              // ATmega2560                             env:mega2560
 #elif MB(GT2560_V3_MC2)
   #include "mega/pins_GT2560_V3_MC2.h"          // ATmega2560                             env:mega2560
 #elif MB(GT2560_V3_A20)
   #include "mega/pins_GT2560_V3_A20.h"          // ATmega2560                             env:mega2560
-#elif MB(GT2560_V4)
-  #include "mega/pins_GT2560_V4.h"              // ATmega2560                             env:mega2560  
 #elif MB(EINSTART_S)
   #include "mega/pins_EINSTART-S.h"             // ATmega2560, ATmega1280                 env:mega2560ext env:mega1280
 #elif MB(WANHAO_ONEPLUS)
@@ -475,7 +475,7 @@
 #elif MB(GTM32_PRO_VB)
   #include "stm32f1/pins_GTM32_PRO_VB.h"        // STM32F1                                env:STM32F103RE
 #elif MB(GTM32_PRO_VD)
-  #include "stm32f1/pins_GTM32_PRO_VD.h"        // STM32F1                                env:STM32F103RE  
+  #include "stm32f1/pins_GTM32_PRO_VD.h"        // STM32F1                                env:STM32F103RE
 #elif MB(GTM32_MINI)
   #include "stm32f1/pins_GTM32_MINI.h"          // STM32F1                                env:STM32F103RE
 #elif MB(GTM32_MINI_A30)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -250,7 +250,7 @@
   #include "mega/pins_GT2560_V3_MC2.h"          // ATmega2560                             env:mega2560
 #elif MB(GT2560_V3_A20)
   #include "mega/pins_GT2560_V3_A20.h"          // ATmega2560                             env:mega2560
-#elif MB(GT2560_V3)
+#elif MB(GT2560_V4)
   #include "mega/pins_GT2560_V4.h"              // ATmega2560                             env:mega2560  
 #elif MB(EINSTART_S)
   #include "mega/pins_EINSTART-S.h"             // ATmega2560, ATmega1280                 env:mega2560ext env:mega1280

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -242,12 +242,16 @@
   #include "mega/pins_GT2560_REV_A.h"           // ATmega2560, ATmega1280                 env:mega2560 env:mega1280
 #elif MB(GT2560_REV_A_PLUS)
   #include "mega/pins_GT2560_REV_A_PLUS.h"      // ATmega2560, ATmega1280                 env:mega2560 env:mega1280
+#elif MB(GT2560_REV_B)
+  #include "mega/pins_GT2560_REV_B.h"           // ATmega2560                             env:mega2560
 #elif MB(GT2560_V3)
   #include "mega/pins_GT2560_V3.h"              // ATmega2560                             env:mega2560
 #elif MB(GT2560_V3_MC2)
   #include "mega/pins_GT2560_V3_MC2.h"          // ATmega2560                             env:mega2560
 #elif MB(GT2560_V3_A20)
   #include "mega/pins_GT2560_V3_A20.h"          // ATmega2560                             env:mega2560
+#elif MB(GT2560_V3)
+  #include "mega/pins_GT2560_V4.h"              // ATmega2560                             env:mega2560  
 #elif MB(EINSTART_S)
   #include "mega/pins_EINSTART-S.h"             // ATmega2560, ATmega1280                 env:mega2560ext env:mega1280
 #elif MB(WANHAO_ONEPLUS)

--- a/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VB.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VB.h
@@ -22,13 +22,17 @@
 #pragma once
 
 /**
- * Geeetech GTM32 Pro VB/VD board pin assignments
+ * Geeetech GTM32 Pro VB board pin assignments
  * http://www.geeetech.com/wiki/index.php/File:Hardware_GTM32_PRO_VB.pdf
+ *
+ * Also applies to GTM32 Pro VD
  */
 
 #include "env_validate.h"
 
-#define BOARD_INFO_NAME      "GTM32 Pro VB/VD"
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME    "GTM32 Pro VB"
+#endif
 #define DEFAULT_MACHINE_NAME "STM32F103VET6"
 
 #define BOARD_NO_NATIVE_USB

--- a/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VD.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VD.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm

--- a/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VD.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VD.h
@@ -1,0 +1,32 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Geeetech GTM32 Pro VD board pin assignments
+ */
+
+#include "pins_GTM32_PRO_VB.h"
+
+
+
+

--- a/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VD.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VD.h
@@ -25,4 +25,6 @@
  * Geeetech GTM32 Pro VD board pin assignments
  */
 
+#define BOARD_INFO_NAME "GTM32 Pro VD"
+
 #include "pins_GTM32_PRO_VB.h"

--- a/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VD.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_PRO_VD.h
@@ -26,7 +26,3 @@
  */
 
 #include "pins_GTM32_PRO_VB.h"
-
-
-
-


### PR DESCRIPTION
add pins for gt2560 revb + v4 as well as the gtm32 pro vd
Real tired of trying to explain that the revb and v4 pins are the v3 pins as there all the same so lets just do this.
same goes for the gtm32 vb/vd.