### PR TITLE
Replace 'const float &' with 'const_float_t'

### DIFF
--- a/Marlin/src/HAL/AVR/fastio.cpp
+++ b/Marlin/src/HAL/AVR/fastio.cpp
@@ -241,7 +241,7 @@ uint8_t extDigitalRead(const int8_t pin) {
  *
  * DC values -1.0 to 1.0. Negative duty cycle inverts the pulse.
  */
-uint16_t set_pwm_frequency_hz(const float &hz, const float dca, const float dcb, const float dcc) {
+uint16_t set_pwm_frequency_hz(const_float_t hz, const float dca, const float dcb, const float dcc) {
   float count = 0;
   if (hz > 0 && (dca || dcb || dcc)) {
     count = float(F_CPU) / hz;            // 1x prescaler, TOP for 16MHz base freq.

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -607,9 +607,3 @@
 #define MAP0(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP1) (f, peek, __VA_ARGS__)
 #define MAP1(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP0) (f, peek, __VA_ARGS__)
 #define MAP(f, ...) EVAL512 (MAP1 (f, __VA_ARGS__, (), 0))
-
-#ifdef __AVR__
-  #define const_float_t const float &
-#else
-  #define const_float_t const float
-#endif

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -607,3 +607,9 @@
 #define MAP0(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP1) (f, peek, __VA_ARGS__)
 #define MAP1(f, x, peek, ...) f(x) MAP_NEXT (peek, MAP0) (f, peek, __VA_ARGS__)
 #define MAP(f, ...) EVAL512 (MAP1 (f, __VA_ARGS__, (), 0))
+
+#ifdef __AVR__
+  #define const_float_t const float &
+#else
+  #define const_float_t const float
+#endif

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -91,7 +91,7 @@ void print_bin(uint16_t val) {
   }
 }
 
-void print_xyz(const float &x, const float &y, const float &z, PGM_P const prefix/*=nullptr*/, PGM_P const suffix/*=nullptr*/) {
+void print_xyz(const_float_t x, const_float_t y, const_float_t z, PGM_P const prefix/*=nullptr*/, PGM_P const suffix/*=nullptr*/) {
   if (prefix) serialprintPGM(prefix);
   SERIAL_ECHOPAIR_P(SP_X_STR, x, SP_Y_STR, y, SP_Z_STR, z);
   if (suffix) serialprintPGM(suffix); else SERIAL_EOL();

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -387,7 +387,7 @@ void serialprint_truefalse(const bool tf);
 void serial_spaces(uint8_t count);
 
 void print_bin(const uint16_t val);
-void print_xyz(const float &x, const float &y, const float &z, PGM_P const prefix=nullptr, PGM_P const suffix=nullptr);
+void print_xyz(const_float_t x, const_float_t y, const_float_t z, PGM_P const prefix=nullptr, PGM_P const suffix=nullptr);
 
 inline void print_xyz(const xyz_pos_t &xyz, PGM_P const prefix=nullptr, PGM_P const suffix=nullptr) {
   print_xyz(xyz.x, xyz.y, xyz.z, prefix, suffix);

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -78,6 +78,16 @@ typedef float feedRate_t;
 //
 typedef int16_t celsius_t;
 
+//
+// On AVR pointers are only 2 bytes so use 'const float &' for 'const float'
+//
+#ifdef __AVR__
+  typedef const float & const_float_t;
+#else
+  typedef const float const_float_t;
+#endif
+typedef const_float_t const_feedRate_t;
+
 // Conversion macros
 #define MMM_TO_MMS(MM_M) feedRate_t(float(MM_M) / 60.0f)
 #define MMS_TO_MMM(MM_S) (float(MM_S) * 60.0f)

--- a/Marlin/src/feature/babystep.cpp
+++ b/Marlin/src/feature/babystep.cpp
@@ -50,7 +50,7 @@ void Babystep::step_axis(const AxisEnum axis) {
   }
 }
 
-void Babystep::add_mm(const AxisEnum axis, const float &mm) {
+void Babystep::add_mm(const AxisEnum axis, const_float_t mm) {
   add_steps(axis, mm * planner.settings.axis_steps_per_mm[axis]);
 }
 

--- a/Marlin/src/feature/babystep.h
+++ b/Marlin/src/feature/babystep.h
@@ -61,7 +61,7 @@ public:
   #endif
 
   static void add_steps(const AxisEnum axis, const int16_t distance);
-  static void add_mm(const AxisEnum axis, const float &mm);
+  static void add_mm(const AxisEnum axis, const_float_t mm);
 
   static inline bool has_steps() {
     return steps[BS_AXIS_IND(X_AXIS)] || steps[BS_AXIS_IND(Y_AXIS)] || steps[BS_AXIS_IND(Z_AXIS)];

--- a/Marlin/src/feature/backlash.h
+++ b/Marlin/src/feature/backlash.h
@@ -35,7 +35,7 @@ public:
       static float smoothing_mm;
     #endif
 
-    static inline void set_correction(const float &v) { correction = _MAX(0, _MIN(1.0, v)) * all_on; }
+    static inline void set_correction(const_float_t v) { correction = _MAX(0, _MIN(1.0, v)) * all_on; }
     static inline float get_correction() { return float(ui8_to_percent(correction)) / 100.0f; }
   #else
     static constexpr uint8_t correction = (BACKLASH_CORRECTION) * 0xFF;

--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -213,7 +213,7 @@ void print_bilinear_leveling_grid() {
     ) * 0.5f;
   }
 
-  static float bed_level_virt_2cmr(const uint8_t x, const uint8_t y, const float &tx, const float &ty) {
+  static float bed_level_virt_2cmr(const uint8_t x, const uint8_t y, const_float_t tx, const_float_t ty) {
     float row[4], column[4];
     LOOP_L_N(i, 4) {
       LOOP_L_N(j, 4) {
@@ -356,7 +356,7 @@ float bilinear_z_offset(const xy_pos_t &raw) {
    * Prepare a bilinear-leveled linear move on Cartesian,
    * splitting the move where it crosses grid borders.
    */
-  void bilinear_line_to_destination(const feedRate_t &scaled_fr_mm_s, uint16_t x_splits, uint16_t y_splits) {
+  void bilinear_line_to_destination(const_feedRate_t scaled_fr_mm_s, uint16_t x_splits, uint16_t y_splits) {
     // Get current and destination cells for this line
     xy_int_t c1 { CELL_INDEX(x, current_position.x), CELL_INDEX(y, current_position.y) },
              c2 { CELL_INDEX(x, destination.x), CELL_INDEX(y, destination.y) };

--- a/Marlin/src/feature/bedlevel/abl/abl.h
+++ b/Marlin/src/feature/bedlevel/abl/abl.h
@@ -37,7 +37,7 @@ void refresh_bed_level();
 #endif
 
 #if IS_CARTESIAN && DISABLED(SEGMENT_LEVELED_MOVES)
-  void bilinear_line_to_destination(const feedRate_t &scaled_fr_mm_s, uint16_t x_splits=0xFFFF, uint16_t y_splits=0xFFFF);
+  void bilinear_line_to_destination(const_feedRate_t scaled_fr_mm_s, uint16_t x_splits=0xFFFF, uint16_t y_splits=0xFFFF);
 #endif
 
 #define _GET_MESH_X(I) float(bilinear_start.x + (I) * bilinear_grid_spacing.x)

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -98,7 +98,7 @@ TemporaryBedLevelingState::TemporaryBedLevelingState(const bool enable) : saved(
 
 #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
 
-  void set_z_fade_height(const float &zfh, const bool do_report/*=true*/) {
+  void set_z_fade_height(const_float_t zfh, const bool do_report/*=true*/) {
 
     if (planner.z_fade_height == zfh) return;
 

--- a/Marlin/src/feature/bedlevel/bedlevel.h
+++ b/Marlin/src/feature/bedlevel/bedlevel.h
@@ -38,7 +38,7 @@ void set_bed_leveling_enabled(const bool enable=true);
 void reset_bed_level();
 
 #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-  void set_z_fade_height(const float &zfh, const bool do_report=true);
+  void set_z_fade_height(const_float_t zfh, const bool do_report=true);
 #endif
 
 #if EITHER(MESH_BED_LEVELING, PROBE_MANUALLY)

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.cpp
@@ -61,7 +61,7 @@
      * Prepare a mesh-leveled linear move in a Cartesian setup,
      * splitting the move where it crosses mesh borders.
      */
-    void mesh_bed_leveling::line_to_destination(const feedRate_t &scaled_fr_mm_s, uint8_t x_splits, uint8_t y_splits) {
+    void mesh_bed_leveling::line_to_destination(const_feedRate_t scaled_fr_mm_s, uint8_t x_splits, uint8_t y_splits) {
       // Get current and destination cells for this line
       xy_int8_t scel = cell_indexes(current_position), ecel = cell_indexes(destination);
       NOMORE(scel.x, GRID_MAX_POINTS_X - 2);

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
@@ -56,7 +56,7 @@ public:
     return false;
   }
 
-  static void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
+  static void set_z(const int8_t px, const int8_t py, const_float_t z) { z_values[px][py] = z; }
 
   static inline void zigzag(const int8_t index, int8_t &px, int8_t &py) {
     px = index % (GRID_MAX_POINTS_X);
@@ -64,39 +64,39 @@ public:
     if (py & 1) px = (GRID_MAX_POINTS_X - 1) - px; // Zig zag
   }
 
-  static void set_zigzag_z(const int8_t index, const float &z) {
+  static void set_zigzag_z(const int8_t index, const_float_t z) {
     int8_t px, py;
     zigzag(index, px, py);
     set_z(px, py, z);
   }
 
-  static int8_t cell_index_x(const float &x) {
+  static int8_t cell_index_x(const_float_t x) {
     int8_t cx = (x - (MESH_MIN_X)) * RECIPROCAL(MESH_X_DIST);
     return constrain(cx, 0, (GRID_MAX_POINTS_X) - 2);
   }
-  static int8_t cell_index_y(const float &y) {
+  static int8_t cell_index_y(const_float_t y) {
     int8_t cy = (y - (MESH_MIN_Y)) * RECIPROCAL(MESH_Y_DIST);
     return constrain(cy, 0, (GRID_MAX_POINTS_Y) - 2);
   }
-  static inline xy_int8_t cell_indexes(const float &x, const float &y) {
+  static inline xy_int8_t cell_indexes(const_float_t x, const_float_t y) {
     return { cell_index_x(x), cell_index_y(y) };
   }
   static inline xy_int8_t cell_indexes(const xy_pos_t &xy) { return cell_indexes(xy.x, xy.y); }
 
-  static int8_t probe_index_x(const float &x) {
+  static int8_t probe_index_x(const_float_t x) {
     int8_t px = (x - (MESH_MIN_X) + 0.5f * (MESH_X_DIST)) * RECIPROCAL(MESH_X_DIST);
     return WITHIN(px, 0, GRID_MAX_POINTS_X - 1) ? px : -1;
   }
-  static int8_t probe_index_y(const float &y) {
+  static int8_t probe_index_y(const_float_t y) {
     int8_t py = (y - (MESH_MIN_Y) + 0.5f * (MESH_Y_DIST)) * RECIPROCAL(MESH_Y_DIST);
     return WITHIN(py, 0, GRID_MAX_POINTS_Y - 1) ? py : -1;
   }
-  static inline xy_int8_t probe_indexes(const float &x, const float &y) {
+  static inline xy_int8_t probe_indexes(const_float_t x, const_float_t y) {
     return { probe_index_x(x), probe_index_y(y) };
   }
   static inline xy_int8_t probe_indexes(const xy_pos_t &xy) { return probe_indexes(xy.x, xy.y); }
 
-  static float calc_z0(const float &a0, const float &a1, const float &z1, const float &a2, const float &z2) {
+  static float calc_z0(const_float_t a0, const_float_t a1, const_float_t z1, const_float_t a2, const_float_t z2) {
     const float delta_z = (z2 - z1) / (a2 - a1),
                 delta_a = a0 - a1;
     return z1 + delta_a * delta_z;
@@ -104,7 +104,7 @@ public:
 
   static float get_z(const xy_pos_t &pos
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      , const float &factor=1.0f
+      , const_float_t factor=1.0f
     #endif
   ) {
     #if DISABLED(ENABLE_LEVELING_FADE_HEIGHT)
@@ -120,7 +120,7 @@ public:
   }
 
   #if IS_CARTESIAN && DISABLED(SEGMENT_LEVELED_MOVES)
-    static void line_to_destination(const feedRate_t &scaled_fr_mm_s, uint8_t x_splits=0xFF, uint8_t y_splits=0xFF);
+    static void line_to_destination(const_feedRate_t scaled_fr_mm_s, uint8_t x_splits=0xFF, uint8_t y_splits=0xFF);
   #endif
 };
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -102,7 +102,7 @@ void unified_bed_leveling::invalidate() {
   set_all_mesh_points_to_value(NAN);
 }
 
-void unified_bed_leveling::set_all_mesh_points_to_value(const float value) {
+void unified_bed_leveling::set_all_mesh_points_to_value(const_float_t value) {
   GRID_LOOP(x, y) {
     z_values[x][y] = value;
     TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, value));
@@ -115,7 +115,7 @@ void unified_bed_leveling::set_all_mesh_points_to_value(const float value) {
   constexpr int16_t Z_STEPS_NAN = INT16_MAX;
 
   void unified_bed_leveling::set_store_from_mesh(const bed_mesh_t &in_values, mesh_store_t &stored_values) {
-    auto z_to_store = [](const float &z) {
+    auto z_to_store = [](const_float_t z) {
       if (isnan(z)) return Z_STEPS_NAN;
       const int32_t z_scaled = TRUNC(z * mesh_store_scaling);
       if (z_scaled == Z_STEPS_NAN || !WITHIN(z_scaled, INT16_MIN, INT16_MAX))

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -67,17 +67,17 @@ private:
   static G29_parameters_t param;
 
   #if IS_NEWPANEL
-    static void move_z_with_encoder(const float &multiplier);
+    static void move_z_with_encoder(const_float_t multiplier);
     static float measure_point_with_encoder();
     static float measure_business_card_thickness();
-    static void manually_probe_remaining_mesh(const xy_pos_t&, const float&, const float&, const bool) _O0;
+    static void manually_probe_remaining_mesh(const xy_pos_t&, const_float_t , const_float_t , const bool) _O0;
     static void fine_tune_mesh(const xy_pos_t &pos, const bool do_ubl_mesh_map) _O0;
   #endif
 
   static bool G29_parse_parameters() _O0;
   static void shift_mesh_height();
   static void probe_entire_mesh(const xy_pos_t &near, const bool do_ubl_mesh_map, const bool stow_probe, const bool do_furthest) _O0;
-  static void tilt_mesh_based_on_3pts(const float &z1, const float &z2, const float &z3);
+  static void tilt_mesh_based_on_3pts(const_float_t z1, const_float_t z2, const_float_t z3);
   static void tilt_mesh_based_on_probed_grid(const bool do_ubl_mesh_map);
   static bool smart_fill_one(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir);
   static inline bool smart_fill_one(const xy_uint8_t &pos, const xy_uint8_t &dir) {
@@ -103,12 +103,12 @@ public:
   static mesh_index_pair find_furthest_invalid_mesh_point() _O0;
   static void reset();
   static void invalidate();
-  static void set_all_mesh_points_to_value(const float value);
-  static void adjust_mesh_to_mean(const bool cflag, const float value);
+  static void set_all_mesh_points_to_value(const_float_t value);
+  static void adjust_mesh_to_mean(const bool cflag, const_float_t value);
   static bool sanity_check();
 
   static void G29() _O0;                          // O0 for no optimization
-  static void smart_fill_wlsf(const float &) _O2; // O2 gives smaller code than Os on A2560
+  static void smart_fill_wlsf(const_float_t ) _O2; // O2 gives smaller code than Os on A2560
 
   static int8_t storage_slot;
 
@@ -131,42 +131,42 @@ public:
 
   unified_bed_leveling();
 
-  FORCE_INLINE static void set_z(const int8_t px, const int8_t py, const float &z) { z_values[px][py] = z; }
+  FORCE_INLINE static void set_z(const int8_t px, const int8_t py, const_float_t z) { z_values[px][py] = z; }
 
-  static int8_t cell_index_x_raw(const float &x) {
+  static int8_t cell_index_x_raw(const_float_t x) {
     return FLOOR((x - (MESH_MIN_X)) * RECIPROCAL(MESH_X_DIST));
   }
 
-  static int8_t cell_index_y_raw(const float &y) {
+  static int8_t cell_index_y_raw(const_float_t y) {
     return FLOOR((y - (MESH_MIN_Y)) * RECIPROCAL(MESH_Y_DIST));
   }
 
-  static int8_t cell_index_x_valid(const float &x) {
+  static int8_t cell_index_x_valid(const_float_t x) {
     return WITHIN(cell_index_x_raw(x), 0, (GRID_MAX_POINTS_X - 2));
   }
 
-  static int8_t cell_index_y_valid(const float &y) {
+  static int8_t cell_index_y_valid(const_float_t y) {
     return WITHIN(cell_index_y_raw(y), 0, (GRID_MAX_POINTS_Y - 2));
   }
 
-  static int8_t cell_index_x(const float &x) {
+  static int8_t cell_index_x(const_float_t x) {
     return constrain(cell_index_x_raw(x), 0, (GRID_MAX_POINTS_X) - 2);
   }
 
-  static int8_t cell_index_y(const float &y) {
+  static int8_t cell_index_y(const_float_t y) {
     return constrain(cell_index_y_raw(y), 0, (GRID_MAX_POINTS_Y) - 2);
   }
 
-  static inline xy_int8_t cell_indexes(const float &x, const float &y) {
+  static inline xy_int8_t cell_indexes(const_float_t x, const_float_t y) {
     return { cell_index_x(x), cell_index_y(y) };
   }
   static inline xy_int8_t cell_indexes(const xy_pos_t &xy) { return cell_indexes(xy.x, xy.y); }
 
-  static int8_t closest_x_index(const float &x) {
+  static int8_t closest_x_index(const_float_t x) {
     const int8_t px = (x - (MESH_MIN_X) + (MESH_X_DIST) * 0.5) * RECIPROCAL(MESH_X_DIST);
     return WITHIN(px, 0, GRID_MAX_POINTS_X - 1) ? px : -1;
   }
-  static int8_t closest_y_index(const float &y) {
+  static int8_t closest_y_index(const_float_t y) {
     const int8_t py = (y - (MESH_MIN_Y) + (MESH_Y_DIST) * 0.5) * RECIPROCAL(MESH_Y_DIST);
     return WITHIN(py, 0, GRID_MAX_POINTS_Y - 1) ? py : -1;
   }
@@ -189,7 +189,7 @@ public:
    *  It is fairly expensive with its 4 floating point additions and 2 floating point
    *  multiplications.
    */
-  FORCE_INLINE static float calc_z0(const float &a0, const float &a1, const float &z1, const float &a2, const float &z2) {
+  FORCE_INLINE static float calc_z0(const_float_t a0, const_float_t a1, const_float_t z1, const_float_t a2, const_float_t z2) {
     return z1 + (z2 - z1) * (a0 - a1) / (a2 - a1);
   }
 
@@ -203,7 +203,7 @@ public:
    * z_correction_for_x_on_horizontal_mesh_line is an optimization for
    * the case where the printer is making a vertical line that only crosses horizontal mesh lines.
    */
-  static inline float z_correction_for_x_on_horizontal_mesh_line(const float &rx0, const int x1_i, const int yi) {
+  static inline float z_correction_for_x_on_horizontal_mesh_line(const_float_t rx0, const int x1_i, const int yi) {
     if (!WITHIN(x1_i, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(yi, 0, GRID_MAX_POINTS_Y - 1)) {
 
       if (DEBUGGING(LEVELING)) {
@@ -226,7 +226,7 @@ public:
   //
   // See comments above for z_correction_for_x_on_horizontal_mesh_line
   //
-  static inline float z_correction_for_y_on_vertical_mesh_line(const float &ry0, const int xi, const int y1_i) {
+  static inline float z_correction_for_y_on_vertical_mesh_line(const_float_t ry0, const int xi, const int y1_i) {
     if (!WITHIN(xi, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(y1_i, 0, GRID_MAX_POINTS_Y - 1)) {
 
       if (DEBUGGING(LEVELING)) {
@@ -252,7 +252,7 @@ public:
    * Z-Height at both ends. Then it does a linear interpolation of these heights based
    * on the Y position within the cell.
    */
-  static float get_z_correction(const float &rx0, const float &ry0) {
+  static float get_z_correction(const_float_t rx0, const_float_t ry0) {
     const int8_t cx = cell_index_x(rx0), cy = cell_index_y(ry0); // return values are clamped
 
     /**
@@ -309,9 +309,9 @@ public:
   }
 
   #if UBL_SEGMENTED
-    static bool line_to_destination_segmented(const feedRate_t &scaled_fr_mm_s);
+    static bool line_to_destination_segmented(const_feedRate_t scaled_fr_mm_s);
   #else
-    static void line_to_destination_cartesian(const feedRate_t &scaled_fr_mm_s, const uint8_t e);
+    static void line_to_destination_cartesian(const_feedRate_t scaled_fr_mm_s, const uint8_t e);
   #endif
 
   static inline bool mesh_is_valid() {

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -672,7 +672,7 @@ void unified_bed_leveling::G29() {
  * G29 P5 C<value> : Adjust Mesh To Mean (and subtract the given offset).
  *                   Find the mean average and shift the mesh to center on that value.
  */
-void unified_bed_leveling::adjust_mesh_to_mean(const bool cflag, const float offset) {
+void unified_bed_leveling::adjust_mesh_to_mean(const bool cflag, const_float_t offset) {
   float sum = 0;
   int n = 0;
   GRID_LOOP(x, y)
@@ -821,7 +821,7 @@ void set_message_with_feedback(PGM_P const msg_P) {
     return false;
   }
 
-  void unified_bed_leveling::move_z_with_encoder(const float &multiplier) {
+  void unified_bed_leveling::move_z_with_encoder(const_float_t multiplier) {
     ui.wait_for_release();
     while (!ui.button_pressed()) {
       idle();
@@ -883,7 +883,7 @@ void set_message_with_feedback(PGM_P const msg_P) {
    *          Move to INVALID points and
    *          NOTE: Blocks the G-code queue and captures Marlin UI during use.
    */
-  void unified_bed_leveling::manually_probe_remaining_mesh(const xy_pos_t &pos, const float &z_clearance, const float &thick, const bool do_ubl_mesh_map) {
+  void unified_bed_leveling::manually_probe_remaining_mesh(const xy_pos_t &pos, const_float_t z_clearance, const_float_t thick, const bool do_ubl_mesh_map) {
     ui.capture();
 
     save_ubl_active_state_and_disable();  // No bed level correction so only raw data is obtained
@@ -1633,10 +1633,10 @@ void unified_bed_leveling::smart_fill_mesh() {
        */
       #ifdef VALIDATE_MESH_TILT
         auto d_from = []{ DEBUG_ECHOPGM("D from "); };
-        auto normed = [&](const xy_pos_t &pos, const float &zadd) {
+        auto normed = [&](const xy_pos_t &pos, const_float_t zadd) {
           return normal.x * pos.x + normal.y * pos.y + zadd;
         };
-        auto debug_pt = [](PGM_P const pre, const xy_pos_t &pos, const float &zadd) {
+        auto debug_pt = [](PGM_P const pre, const xy_pos_t &pos, const_float_t zadd) {
           d_from(); SERIAL_ECHOPGM_P(pre);
           DEBUG_ECHO_F(normed(pos, zadd), 6);
           DEBUG_ECHOLNPAIR_F("   Z error = ", zadd - get_z_correction(pos), 6);
@@ -1658,7 +1658,7 @@ void unified_bed_leveling::smart_fill_mesh() {
 #endif // HAS_BED_PROBE
 
 #if ENABLED(UBL_G29_P31)
-  void unified_bed_leveling::smart_fill_wlsf(const float &weight_factor) {
+  void unified_bed_leveling::smart_fill_wlsf(const_float_t weight_factor) {
 
     // For each undefined mesh point, compute a distance-weighted least squares fit
     // from all the originally populated mesh points, weighted toward the point

--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -37,7 +37,7 @@
 
 #if !UBL_SEGMENTED
 
-  void unified_bed_leveling::line_to_destination_cartesian(const feedRate_t &scaled_fr_mm_s, const uint8_t extruder) {
+  void unified_bed_leveling::line_to_destination_cartesian(const_feedRate_t scaled_fr_mm_s, const uint8_t extruder) {
     /**
      * Much of the nozzle movement will be within the same cell. So we will do as little computation
      * as possible to determine if this is the case. If this move is within the same cell, we will
@@ -323,7 +323,7 @@
    * Returns true if did NOT move, false if moved (requires current_position update).
    */
 
-  bool _O2 unified_bed_leveling::line_to_destination_segmented(const feedRate_t &scaled_fr_mm_s) {
+  bool _O2 unified_bed_leveling::line_to_destination_segmented(const_feedRate_t scaled_fr_mm_s) {
 
     if (!position_is_reachable(destination))  // fail if moving outside reachable boundary
       return true;                            // did not move, so current_position still accurate

--- a/Marlin/src/feature/encoder_i2c.h
+++ b/Marlin/src/feature/encoder_i2c.h
@@ -188,7 +188,7 @@ class I2CPositionEncoder {
     FORCE_INLINE void set_ec_method(const byte method) { ecMethod = method; }
 
     FORCE_INLINE float get_ec_threshold() { return ecThreshold; }
-    FORCE_INLINE void set_ec_threshold(const float newThreshold) { ecThreshold = newThreshold; }
+    FORCE_INLINE void set_ec_threshold(const_float_t newThreshold) { ecThreshold = newThreshold; }
 
     FORCE_INLINE int get_encoder_ticks_mm() {
       switch (type) {

--- a/Marlin/src/feature/filwidth.h
+++ b/Marlin/src/feature/filwidth.h
@@ -78,7 +78,7 @@ public:
   static inline void update_measured_mm() { measured_mm = raw_to_mm(); }
 
   // Update ring buffer used to delay filament measurements
-  static inline void advance_e(const float &e_move) {
+  static inline void advance_e(const_float_t e_move) {
 
     // Increment counters with the E distance
     e_count += e_move;

--- a/Marlin/src/feature/leds/printer_event_leds.cpp
+++ b/Marlin/src/feature/leds/printer_event_leds.cpp
@@ -40,7 +40,7 @@ PrinterEventLEDs printerEventLEDs;
 
   uint8_t PrinterEventLEDs::old_intensity = 0;
 
-  inline uint8_t pel_intensity(const float &start, const float &current, const float &target) {
+  inline uint8_t pel_intensity(const_float_t start, const_float_t current, const_float_t target) {
     if (uint16_t(start) == uint16_t(target)) return 255;
     return (uint8_t)map(constrain(current, start, target), start, target, 0.f, 255.f);
   }
@@ -58,7 +58,7 @@ PrinterEventLEDs printerEventLEDs;
 
 #if HAS_TEMP_HOTEND
 
-  void PrinterEventLEDs::onHotendHeating(const float &start, const float &current, const float &target) {
+  void PrinterEventLEDs::onHotendHeating(const_float_t start, const_float_t current, const_float_t target) {
     const uint8_t blue = pel_intensity(start, current, target);
     if (blue != old_intensity) {
       old_intensity = blue;
@@ -70,7 +70,7 @@ PrinterEventLEDs printerEventLEDs;
 
 #if HAS_HEATED_BED
 
-  void PrinterEventLEDs::onBedHeating(const float &start, const float &current, const float &target) {
+  void PrinterEventLEDs::onBedHeating(const_float_t start, const_float_t current, const_float_t target) {
     const uint8_t red = pel_intensity(start, current, target);
     if (red != old_intensity) {
       old_intensity = red;
@@ -82,7 +82,7 @@ PrinterEventLEDs printerEventLEDs;
 
 #if HAS_HEATED_CHAMBER
 
-  void PrinterEventLEDs::onChamberHeating(const float &start, const float &current, const float &target) {
+  void PrinterEventLEDs::onChamberHeating(const_float_t start, const_float_t current, const_float_t target) {
     const uint8_t green = pel_intensity(start, current, target);
     if (green != old_intensity) {
       old_intensity = green;

--- a/Marlin/src/feature/leds/printer_event_leds.h
+++ b/Marlin/src/feature/leds/printer_event_leds.h
@@ -47,17 +47,17 @@ private:
 public:
   #if HAS_TEMP_HOTEND
     static inline LEDColor onHotendHeatingStart() { old_intensity = 0; return leds.get_color(); }
-    static void onHotendHeating(const float &start, const float &current, const float &target);
+    static void onHotendHeating(const_float_t start, const_float_t current, const_float_t target);
   #endif
 
   #if HAS_HEATED_BED
     static inline LEDColor onBedHeatingStart() { old_intensity = 127; return leds.get_color(); }
-    static void onBedHeating(const float &start, const float &current, const float &target);
+    static void onBedHeating(const_float_t start, const_float_t current, const_float_t target);
   #endif
 
   #if HAS_HEATED_CHAMBER
     static inline LEDColor onChamberHeatingStart() { old_intensity = 127; return leds.get_color(); }
-    static void onChamberHeating(const float &start, const float &current, const float &target);
+    static void onChamberHeating(const_float_t start, const_float_t current, const_float_t target);
   #endif
 
   #if HAS_TEMP_HOTEND || HAS_HEATED_BED || HAS_HEATED_CHAMBER

--- a/Marlin/src/feature/max7219.cpp
+++ b/Marlin/src/feature/max7219.cpp
@@ -256,7 +256,7 @@ void Max7219::set(const uint8_t line, const uint8_t bits) {
   }
 
   // Draw a float with a decimal point and optional digits
-  void Max7219::print(const uint8_t start, const float value, const uint8_t pre_size, const uint8_t post_size, const bool leadzero=false) {
+  void Max7219::print(const uint8_t start, const_float_t value, const uint8_t pre_size, const uint8_t post_size, const bool leadzero=false) {
     if (pre_size) print(start, value, pre_size, leadzero, !!post_size);
     if (post_size) {
       const int16_t after = ABS(value) * (10 ^ post_size);

--- a/Marlin/src/feature/max7219.h
+++ b/Marlin/src/feature/max7219.h
@@ -100,6 +100,13 @@ public:
   // Update a single native line on just one unit
   static void refresh_unit_line(const uint8_t line);
 
+  #if ENABLED(MAX7219_NUMERIC)
+    // Draw an integer with optional leading zeros and optional decimal point
+    void print(const uint8_t start, int16_t value, uint8_t size, const bool leadzero=false, bool dec=false);
+    // Draw a float with a decimal point and optional digits
+    void print(const uint8_t start, const_float_t value, const uint8_t pre_size, const uint8_t post_size, const bool leadzero=false);
+  #endif
+
   // Set a single LED by XY coordinate
   static void led_set(const uint8_t x, const uint8_t y, const bool on);
   static void led_on(const uint8_t x, const uint8_t y);

--- a/Marlin/src/feature/mixing.cpp
+++ b/Marlin/src/feature/mixing.cpp
@@ -162,7 +162,7 @@ void Mixer::refresh_collector(const float proportion/*=1.0*/, const uint8_t t/*=
 
   float Mixer::prev_z; // = 0
 
-  void Mixer::update_gradient_for_z(const float z) {
+  void Mixer::update_gradient_for_z(const_float_t z) {
     if (z == prev_z) return;
     prev_z = z;
 

--- a/Marlin/src/feature/mixing.h
+++ b/Marlin/src/feature/mixing.h
@@ -180,9 +180,9 @@ class Mixer {
     static float prev_z;
 
     // Update the current mix from the gradient for a given Z
-    static void update_gradient_for_z(const float z);
+    static void update_gradient_for_z(const_float_t z);
     static void update_gradient_for_planner_z();
-    static inline void gradient_control(const float z) {
+    static inline void gradient_control(const_float_t z) {
       if (gradient.enabled) {
         if (z >= gradient.end_z)
           T(gradient.end_vtool);

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -170,7 +170,7 @@ static bool ensure_safe_temperature(const bool wait=true, const PauseMode mode=P
  *
  * Returns 'true' if load was completed, 'false' for abort
  */
-bool load_filament(const float &slow_load_length/*=0*/, const float &fast_load_length/*=0*/, const float &purge_length/*=0*/, const int8_t max_beep_count/*=0*/,
+bool load_filament(const_float_t slow_load_length/*=0*/, const_float_t fast_load_length/*=0*/, const_float_t purge_length/*=0*/, const int8_t max_beep_count/*=0*/,
                    const bool show_lcd/*=false*/, const bool pause_for_user/*=false*/,
                    const PauseMode mode/*=PAUSE_MODE_PAUSE_PRINT*/
                    DXC_ARGS
@@ -298,10 +298,10 @@ inline void disable_active_extruder() {
  *
  * Returns 'true' if unload was completed, 'false' for abort
  */
-bool unload_filament(const float &unload_length, const bool show_lcd/*=false*/,
+bool unload_filament(const_float_t unload_length, const bool show_lcd/*=false*/,
                      const PauseMode mode/*=PAUSE_MODE_PAUSE_PRINT*/
                      #if BOTH(FILAMENT_UNLOAD_ALL_EXTRUDERS, MIXING_EXTRUDER)
-                       , const float &mix_multiplier/*=1.0*/
+                       , const_float_t mix_multiplier/*=1.0*/
                      #endif
 ) {
   DEBUG_SECTION(uf, "unload_filament", true);
@@ -367,7 +367,7 @@ bool unload_filament(const float &unload_length, const bool show_lcd/*=false*/,
  */
 uint8_t did_pause_print = 0;
 
-bool pause_print(const float &retract, const xyz_pos_t &park_point, const float &unload_length/*=0*/, const bool show_lcd/*=false*/ DXC_ARGS) {
+bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const_float_t unload_length/*=0*/, const bool show_lcd/*=false*/ DXC_ARGS) {
   DEBUG_SECTION(pp, "pause_print", true);
   DEBUG_ECHOLNPAIR("... park.x:", park_point.x, " y:", park_point.y, " z:", park_point.z, " unloadlen:", unload_length, " showlcd:", show_lcd DXC_SAY);
 
@@ -555,7 +555,7 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
  * - Send host action for resume, if configured
  * - Resume the current SD print job, if any
  */
-void resume_print(const float &slow_load_length/*=0*/, const float &fast_load_length/*=0*/, const float &purge_length/*=ADVANCED_PAUSE_PURGE_LENGTH*/, const int8_t max_beep_count/*=0*/, const celsius_t targetTemp/*=0*/ DXC_ARGS) {
+void resume_print(const_float_t slow_load_length/*=0*/, const_float_t fast_load_length/*=0*/, const_float_t purge_length/*=ADVANCED_PAUSE_PURGE_LENGTH*/, const int8_t max_beep_count/*=0*/, const celsius_t targetTemp/*=0*/ DXC_ARGS) {
   DEBUG_SECTION(rp, "resume_print", true);
   DEBUG_ECHOLNPAIR("... slowlen:", slow_load_length, " fastlen:", fast_load_length, " purgelen:", purge_length, " maxbeep:", max_beep_count, " targetTemp:", targetTemp DXC_SAY);
 

--- a/Marlin/src/feature/pause.h
+++ b/Marlin/src/feature/pause.h
@@ -85,19 +85,19 @@ extern uint8_t did_pause_print;
   #define DXC_SAY
 #endif
 
-bool pause_print(const float &retract, const xyz_pos_t &park_point, const float &unload_length=0, const bool show_lcd=false DXC_PARAMS);
+bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const_float_t unload_length=0, const bool show_lcd=false DXC_PARAMS);
 
 void wait_for_confirmation(const bool is_reload=false, const int8_t max_beep_count=0 DXC_PARAMS);
 
-void resume_print(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=ADVANCED_PAUSE_PURGE_LENGTH,
+void resume_print(const_float_t slow_load_length=0, const_float_t fast_load_length=0, const_float_t extrude_length=ADVANCED_PAUSE_PURGE_LENGTH,
                     const int8_t max_beep_count=0, const celsius_t targetTemp=0 DXC_PARAMS);
 
-bool load_filament(const float &slow_load_length=0, const float &fast_load_length=0, const float &extrude_length=0, const int8_t max_beep_count=0,
+bool load_filament(const_float_t slow_load_length=0, const_float_t fast_load_length=0, const_float_t extrude_length=0, const int8_t max_beep_count=0,
                     const bool show_lcd=false, const bool pause_for_user=false, const PauseMode mode=PAUSE_MODE_PAUSE_PRINT DXC_PARAMS);
 
-bool unload_filament(const float &unload_length, const bool show_lcd=false, const PauseMode mode=PAUSE_MODE_PAUSE_PRINT
+bool unload_filament(const_float_t unload_length, const bool show_lcd=false, const PauseMode mode=PAUSE_MODE_PAUSE_PRINT
   #if BOTH(FILAMENT_UNLOAD_ALL_EXTRUDERS, MIXING_EXTRUDER)
-    , const float &mix_multiplier=1.0
+    , const_float_t mix_multiplier=1.0
   #endif
 );
 

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -240,7 +240,7 @@ void PrintJobRecovery::save(const bool force/*=false*/, const float zraise/*=0*/
 
   #if ENABLED(BACKUP_POWER_SUPPLY)
 
-    void PrintJobRecovery::retract_and_lift(const float &zraise) {
+    void PrintJobRecovery::retract_and_lift(const_float_t zraise) {
       #if POWER_LOSS_RETRACT_LEN || POWER_LOSS_ZRAISE
 
         gcode.set_relative_mode(true);  // Use relative coordinates

--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -199,7 +199,7 @@ class PrintJobRecovery {
     static void write();
 
     #if ENABLED(BACKUP_POWER_SUPPLY)
-      static void retract_and_lift(const float &zraise);
+      static void retract_and_lift(const_float_t zraise);
     #endif
 
     #if PIN_EXISTS(POWER_LOSS)

--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -88,12 +88,12 @@ void ProbeTempComp::print_offsets() {
   }
 }
 
-void ProbeTempComp::prepare_new_calibration(const float &init_meas_z) {
+void ProbeTempComp::prepare_new_calibration(const_float_t init_meas_z) {
   calib_idx = 0;
   init_measurement = init_meas_z;
 }
 
-void ProbeTempComp::push_back_new_measurement(const TempSensorID tsi, const float &meas_z) {
+void ProbeTempComp::push_back_new_measurement(const TempSensorID tsi, const_float_t meas_z) {
   switch (tsi) {
     case TSI_PROBE:
     case TSI_BED:
@@ -159,12 +159,12 @@ bool ProbeTempComp::finish_calibration(const TempSensorID tsi) {
   return true;
 }
 
-void ProbeTempComp::compensate_measurement(const TempSensorID tsi, const float &temp, float &meas_z) {
+void ProbeTempComp::compensate_measurement(const TempSensorID tsi, const_float_t temp, float &meas_z) {
   if (WITHIN(temp, cali_info[tsi].start_temp, cali_info[tsi].end_temp))
     meas_z -= get_offset_for_temperature(tsi, temp);
 }
 
-float ProbeTempComp::get_offset_for_temperature(const TempSensorID tsi, const float &temp) {
+float ProbeTempComp::get_offset_for_temperature(const TempSensorID tsi, const_float_t temp) {
   const uint8_t measurements = cali_info[tsi].measurements;
   const float start_temp = cali_info[tsi].start_temp,
                 res_temp = cali_info[tsi].temp_res;

--- a/Marlin/src/feature/probe_temp_comp.h
+++ b/Marlin/src/feature/probe_temp_comp.h
@@ -121,10 +121,10 @@ class ProbeTempComp {
     }
     static bool set_offset(const TempSensorID tsi, const uint8_t idx, const int16_t offset);
     static void print_offsets();
-    static void prepare_new_calibration(const float &init_meas_z);
-    static void push_back_new_measurement(const TempSensorID tsi, const float &meas_z);
+    static void prepare_new_calibration(const_float_t init_meas_z);
+    static void push_back_new_measurement(const TempSensorID tsi, const_float_t meas_z);
     static bool finish_calibration(const TempSensorID tsi);
-    static void compensate_measurement(const TempSensorID tsi, const float &temp, float &meas_z);
+    static void compensate_measurement(const TempSensorID tsi, const_float_t temp, float &meas_z);
 
   private:
     static uint8_t calib_idx;
@@ -135,7 +135,7 @@ class ProbeTempComp {
      */
     static float init_measurement;
 
-    static float get_offset_for_temperature(const TempSensorID tsi, const float &temp);
+    static float get_offset_for_temperature(const TempSensorID tsi, const_float_t temp);
 
     /**
      * Fit a linear function in measured temperature offsets

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -101,7 +101,7 @@ class TFilamentMonitor : public FilamentMonitorBase {
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       static inline float& runout_distance() { return response.runout_distance_mm; }
-      static inline void set_runout_distance(const float &mm) { response.runout_distance_mm = mm; }
+      static inline void set_runout_distance(const_float_t mm) { response.runout_distance_mm = mm; }
     #endif
 
     // Handle a block completion. RunoutResponseDelayed uses this to

--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -53,7 +53,7 @@ public:
     min_pct = TERN(CUTTER_POWER_RELATIVE, 0, TERN(SPINDLE_FEATURE, round(100.0f * (SPEED_POWER_MIN) / (SPEED_POWER_MAX)), SPEED_POWER_MIN)),
     max_pct = TERN(SPINDLE_FEATURE, 100, SPEED_POWER_MAX);
 
-  static const inline uint8_t pct_to_ocr(const float pct) { return uint8_t(PCT_TO_PWM(pct)); }
+  static const inline uint8_t pct_to_ocr(const_float_t pct) { return uint8_t(PCT_TO_PWM(pct)); }
 
   // cpower = configured values (e.g., SPEED_POWER_MAX)
 

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -212,7 +212,7 @@ mesh_index_pair find_closest_circle_to_print(const xy_pos_t &pos) {
   return out_point;
 }
 
-void move_to(const float &rx, const float &ry, const float &z, const float &e_delta) {
+void move_to(const_float_t rx, const_float_t ry, const_float_t z, const_float_t e_delta) {
   static float last_z = -999.99;
 
   const xy_pos_t dest = { rx, ry };
@@ -239,7 +239,7 @@ void move_to(const float &rx, const float &ry, const float &z, const float &e_de
   prepare_internal_move_to_destination(fr_mm_s);
 }
 
-FORCE_INLINE void move_to(const xyz_pos_t &where, const float &de) { move_to(where.x, where.y, where.z, de); }
+FORCE_INLINE void move_to(const xyz_pos_t &where, const_float_t de) { move_to(where.x, where.y, where.z, de); }
 
 void retract_filament(const xyz_pos_t &where) {
   if (!g26_retracted) { // Only retract if we are not already retracted!

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -93,7 +93,7 @@ void ac_cleanup(TERN_(HAS_MULTI_HOTEND, const uint8_t old_tool_index)) {
   TERN_(HAS_MULTI_HOTEND, tool_change(old_tool_index, true));
 }
 
-void print_signed_float(PGM_P const prefix, const float &f) {
+void print_signed_float(PGM_P const prefix, const_float_t f) {
   SERIAL_ECHOPGM("  ");
   SERIAL_ECHOPGM_P(prefix);
   SERIAL_CHAR(':');

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -312,7 +312,7 @@ void GcodeSuite::G34() {
           ui.set_status(msg);
         #endif
 
-        auto decreasing_accuracy = [](const float &v1, const float &v2){
+        auto decreasing_accuracy = [](const_float_t v1, const_float_t v2){
           if (v1 < v2 * 0.7f) {
             SERIAL_ECHOLNPGM("Decreasing Accuracy Detected.");
             LCD_MESSAGEPGM(MSG_DECREASING_ACCURACY);

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -117,7 +117,7 @@ void GcodeSuite::M48() {
         max = -99999.9, // Largest value sampled so far
         sample_set[n_samples];  // Storage for sampled values
 
-  auto dev_report = [](const bool verbose, const float &mean, const float &sigma, const float &min, const float &max, const bool final=false) {
+  auto dev_report = [](const bool verbose, const_float_t mean, const_float_t sigma, const_float_t min, const_float_t max, const bool final=false) {
     if (verbose) {
       SERIAL_ECHOPAIR_F("Mean: ", mean, 6);
       if (!final) SERIAL_ECHOPAIR_F(" Sigma: ", sigma, 6);

--- a/Marlin/src/gcode/feature/camera/M240.cpp
+++ b/Marlin/src/gcode/feature/camera/M240.cpp
@@ -47,7 +47,7 @@
   #endif
 
   #ifdef PHOTO_RETRACT_MM
-    inline void e_move_m240(const float length, const feedRate_t &fr_mm_s) {
+    inline void e_move_m240(const float length, const_feedRate_t fr_mm_s) {
       if (length && thermalManager.hotEnoughToExtrude(active_extruder))
         unscaled_e_move(length, fr_mm_s);
     }

--- a/Marlin/src/gcode/feature/mixing/M166.cpp
+++ b/Marlin/src/gcode/feature/mixing/M166.cpp
@@ -33,7 +33,7 @@ inline void echo_mix() {
   SERIAL_ECHOPAIR(" (", mixer.mix[0], "%|", mixer.mix[1], "%)");
 }
 
-inline void echo_zt(const int t, const float &z) {
+inline void echo_zt(const int t, const_float_t z) {
   mixer.update_mix_from_vtool(t);
   SERIAL_ECHOPAIR_P(SP_Z_STR, z, SP_T_STR, t);
   echo_mix();

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -39,7 +39,7 @@
 
 #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
 
-  FORCE_INLINE void mod_probe_offset(const float &offs) {
+  FORCE_INLINE void mod_probe_offset(const_float_t offs) {
     if (TERN1(BABYSTEP_HOTEND_Z_OFFSET, active_extruder == 0)) {
       probe.offset.z += offs;
       SERIAL_ECHO_MSG(STR_PROBE_OFFSET " " STR_Z, probe.offset.z);

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -282,8 +282,8 @@ public:
   // Units modes: Inches, Fahrenheit, Kelvin
 
   #if ENABLED(INCH_MODE_SUPPORT)
-    static inline float mm_to_linear_unit(const float mm)     { return mm / linear_unit_factor; }
-    static inline float mm_to_volumetric_unit(const float mm) { return mm / (volumetric_enabled ? volumetric_unit_factor : linear_unit_factor); }
+    static inline float mm_to_linear_unit(const_float_t mm)     { return mm / linear_unit_factor; }
+    static inline float mm_to_volumetric_unit(const_float_t mm) { return mm / (volumetric_enabled ? volumetric_unit_factor : linear_unit_factor); }
 
     // Init linear units by constructor
     GCodeParser() { set_input_linear_units(LINEARUNIT_MM); }
@@ -301,16 +301,16 @@ public:
       return (axis >= E_AXIS && volumetric_enabled ? volumetric_unit_factor : linear_unit_factor);
     }
 
-    static inline float linear_value_to_mm(const float v)                    { return v * linear_unit_factor; }
+    static inline float linear_value_to_mm(const_float_t v)                  { return v * linear_unit_factor; }
     static inline float axis_value_to_mm(const AxisEnum axis, const float v) { return v * axis_unit_factor(axis); }
     static inline float per_axis_value(const AxisEnum axis, const float v)   { return v / axis_unit_factor(axis); }
 
   #else
 
-    static inline float mm_to_linear_unit(const float mm)     { return mm; }
-    static inline float mm_to_volumetric_unit(const float mm) { return mm; }
+    static inline float mm_to_linear_unit(const_float_t mm)     { return mm; }
+    static inline float mm_to_volumetric_unit(const_float_t mm) { return mm; }
 
-    static inline float linear_value_to_mm(const float v)               { return v; }
+    static inline float linear_value_to_mm(const_float_t v)             { return v; }
     static inline float axis_value_to_mm(const AxisEnum, const float v) { return v; }
     static inline float per_axis_value(const AxisEnum, const float v)   { return v; }
 

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -669,7 +669,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
       B00001100,B00000000
     };
 
-    void _lcd_zoffset_overlay_gfx(const float zvalue) {
+    void _lcd_zoffset_overlay_gfx(const_float_t zvalue) {
       // Determine whether the user is raising or lowering the nozzle.
       static int8_t dir;
       static float old_zvalue;

--- a/Marlin/src/lcd/extui/anycubic_chiron_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron_lcd.cpp
@@ -101,7 +101,7 @@ namespace ExtUI {
   #if HAS_MESH
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
       //SERIAL_ECHOLNPAIR("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);
     }

--- a/Marlin/src/lcd/extui/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega_lcd.cpp
@@ -93,7 +93,7 @@ namespace ExtUI {
 
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
     }
   #endif

--- a/Marlin/src/lcd/extui/dgus_lcd.cpp
+++ b/Marlin/src/lcd/extui/dgus_lcd.cpp
@@ -111,7 +111,7 @@ namespace ExtUI {
   #if HAS_MESH
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
     }
 

--- a/Marlin/src/lcd/extui/example.cpp
+++ b/Marlin/src/lcd/extui/example.cpp
@@ -97,7 +97,7 @@ namespace ExtUI {
   #if HAS_MESH
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
     }
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/marlin_events.cpp
@@ -140,7 +140,7 @@ namespace ExtUI {
   #if HAS_LEVELING && HAS_MESH
     void onMeshLevelingStart() {}
 
-    void onMeshUpdate(const int8_t x, const int8_t y, const float &val) {
+    void onMeshUpdate(const int8_t x, const int8_t y, const_float_t val) {
       BedMeshScreen::onMeshUpdate(x, y, val);
     }
 

--- a/Marlin/src/lcd/extui/malyan_lcd.cpp
+++ b/Marlin/src/lcd/extui/malyan_lcd.cpp
@@ -528,7 +528,7 @@ namespace ExtUI {
 
   #if HAS_MESH
     void onMeshLevelingStart() {}
-    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval) {}
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {}
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const ExtUI::probe_state_t state) {}
   #endif
 

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -325,7 +325,7 @@ namespace ExtUI {
     return epos;
   }
 
-  void setAxisPosition_mm(const float &position, const axis_t axis, const feedRate_t feedrate/*=0*/) {
+  void setAxisPosition_mm(const_float_t position, const axis_t axis, const feedRate_t feedrate/*=0*/) {
     // Get motion limit from software endstops, if any
     float min, max;
     soft_endstop.get_manual_axis_limits((AxisEnum)axis, min, max);
@@ -343,7 +343,7 @@ namespace ExtUI {
     line_to_current_position(feedrate ?: manual_feedrate_mm_s[axis]);
   }
 
-  void setAxisPosition_mm(const float &position, const extruder_t extruder, const feedRate_t feedrate/*=0*/) {
+  void setAxisPosition_mm(const_float_t position, const extruder_t extruder, const feedRate_t feedrate/*=0*/) {
     setActiveTool(extruder, true);
 
     current_position.e = position;
@@ -455,7 +455,7 @@ namespace ExtUI {
       };
     }
 
-    void setAxisCurrent_mA(const float &mA, const axis_t axis) {
+    void setAxisCurrent_mA(const_float_t mA, const axis_t axis) {
       switch (axis) {
         #if AXIS_IS_TMC(X)
           case X: stepperX.rms_current(constrain(mA, 400, 1500)); break;
@@ -479,7 +479,7 @@ namespace ExtUI {
       };
     }
 
-    void setAxisCurrent_mA(const float &mA, const extruder_t extruder) {
+    void setAxisCurrent_mA(const_float_t mA, const extruder_t extruder) {
       switch (extruder) {
         #if AXIS_IS_TMC(E0)
           case E0: stepperE0.rms_current(constrain(mA, 400, 1500)); break;
@@ -539,7 +539,7 @@ namespace ExtUI {
       }
     }
 
-    void setTMCBumpSensitivity(const float &value, const axis_t axis) {
+    void setTMCBumpSensitivity(const_float_t value, const axis_t axis) {
       switch (axis) {
         #if X_SENSORLESS || Y_SENSORLESS || Z_SENSORLESS
           #if X_SENSORLESS
@@ -583,12 +583,12 @@ namespace ExtUI {
     return planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)];
   }
 
-  void setAxisSteps_per_mm(const float &value, const axis_t axis) {
+  void setAxisSteps_per_mm(const_float_t value, const axis_t axis) {
     planner.settings.axis_steps_per_mm[axis] = value;
     planner.refresh_positioning();
   }
 
-  void setAxisSteps_per_mm(const float &value, const extruder_t extruder) {
+  void setAxisSteps_per_mm(const_float_t value, const extruder_t extruder) {
     UNUSED_E(extruder);
     planner.settings.axis_steps_per_mm[E_AXIS_N(extruder - E0)] = value;
     planner.refresh_positioning();
@@ -621,11 +621,11 @@ namespace ExtUI {
     return planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(extruder - E0)];
   }
 
-  void setAxisMaxAcceleration_mm_s2(const float &value, const axis_t axis) {
+  void setAxisMaxAcceleration_mm_s2(const_float_t value, const axis_t axis) {
     planner.set_max_acceleration(axis, value);
   }
 
-  void setAxisMaxAcceleration_mm_s2(const float &value, const extruder_t extruder) {
+  void setAxisMaxAcceleration_mm_s2(const_float_t value, const extruder_t extruder) {
     UNUSED_E(extruder);
     planner.set_max_acceleration(E_AXIS_N(extruder - E0), value);
   }
@@ -638,7 +638,7 @@ namespace ExtUI {
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       float getFilamentRunoutDistance_mm()                 { return runout.runout_distance(); }
-      void setFilamentRunoutDistance_mm(const float &value) { runout.set_runout_distance(constrain(value, 0, 999)); }
+      void setFilamentRunoutDistance_mm(const_float_t value) { runout.set_runout_distance(constrain(value, 0, 999)); }
     #endif
   #endif
 
@@ -651,7 +651,7 @@ namespace ExtUI {
 
     #if CASELIGHT_USES_BRIGHTNESS
       float getCaseLightBrightness_percent()                 { return ui8_to_percent(caselight.brightness); }
-      void setCaseLightBrightness_percent(const float &value) {
+      void setCaseLightBrightness_percent(const_float_t value) {
          caselight.brightness = map(constrain(value, 0, 100), 0, 100, 0, 255);
          caselight.update_brightness();
       }
@@ -663,7 +663,7 @@ namespace ExtUI {
       return (extruder < EXTRUDERS) ? planner.extruder_advance_K[extruder - E0] : 0;
     }
 
-    void setLinearAdvance_mm_mm_s(const float &value, const extruder_t extruder) {
+    void setLinearAdvance_mm_mm_s(const_float_t value, const extruder_t extruder) {
       if (extruder < EXTRUDERS)
         planner.extruder_advance_K[extruder - E0] = constrain(value, 0, 10);
     }
@@ -675,7 +675,7 @@ namespace ExtUI {
       return planner.junction_deviation_mm;
     }
 
-    void setJunctionDeviation_mm(const float &value) {
+    void setJunctionDeviation_mm(const_float_t value) {
       planner.junction_deviation_mm = constrain(value, 0.001, 0.3);
       TERN_(LIN_ADVANCE, planner.recalculate_max_e_jerk());
     }
@@ -683,8 +683,8 @@ namespace ExtUI {
   #else
     float getAxisMaxJerk_mm_s(const axis_t axis) { return planner.max_jerk[axis]; }
     float getAxisMaxJerk_mm_s(const extruder_t) { return planner.max_jerk.e; }
-    void setAxisMaxJerk_mm_s(const float &value, const axis_t axis) { planner.set_max_jerk((AxisEnum)axis, value); }
-    void setAxisMaxJerk_mm_s(const float &value, const extruder_t) { planner.set_max_jerk(E_AXIS, value); }
+    void setAxisMaxJerk_mm_s(const_float_t value, const axis_t axis) { planner.set_max_jerk((AxisEnum)axis, value); }
+    void setAxisMaxJerk_mm_s(const_float_t value, const extruder_t) { planner.set_max_jerk(E_AXIS, value); }
   #endif
 
   #if ENABLED(DUAL_X_CARRIAGE)
@@ -709,9 +709,9 @@ namespace ExtUI {
   void setFlow_percent(const int16_t flow, const extruder_t extr) { planner.set_flow(extr, flow); }
   void setMinFeedrate_mm_s(const feedRate_t fr)       { planner.settings.min_feedrate_mm_s = fr; }
   void setMinTravelFeedrate_mm_s(const feedRate_t fr) { planner.settings.min_travel_feedrate_mm_s = fr; }
-  void setPrintingAcceleration_mm_s2(const float &acc) { planner.settings.acceleration = acc; }
-  void setRetractAcceleration_mm_s2(const float &acc) { planner.settings.retract_acceleration = acc; }
-  void setTravelAcceleration_mm_s2(const float &acc)  { planner.settings.travel_acceleration = acc; }
+  void setPrintingAcceleration_mm_s2(const_float_t acc) { planner.settings.acceleration = acc; }
+  void setRetractAcceleration_mm_s2(const_float_t acc) { planner.settings.retract_acceleration = acc; }
+  void setTravelAcceleration_mm_s2(const_float_t acc)  { planner.settings.travel_acceleration = acc; }
 
   #if ENABLED(BABYSTEPPING)
 
@@ -772,7 +772,7 @@ namespace ExtUI {
      * Converts a mm displacement to a number of whole number of
      * steps that is at least mm long.
      */
-    int16_t mmToWholeSteps(const float &mm, const axis_t axis) {
+    int16_t mmToWholeSteps(const_float_t mm, const axis_t axis) {
       const float steps = mm / planner.steps_to_mm[axis];
       return steps > 0 ? CEIL(steps) : FLOOR(steps);
     }
@@ -789,7 +789,7 @@ namespace ExtUI {
     );
   }
 
-  void setZOffset_mm(const float &value) {
+  void setZOffset_mm(const_float_t value) {
     #if HAS_BED_PROBE
       if (WITHIN(value, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX))
         probe.offset.z = value;
@@ -807,7 +807,7 @@ namespace ExtUI {
       return hotend_offset[extruder - E0][axis];
     }
 
-    void setNozzleOffset_mm(const float &value, const axis_t axis, const extruder_t extruder) {
+    void setNozzleOffset_mm(const_float_t value, const axis_t axis, const extruder_t extruder) {
       if (extruder - E0 >= HOTENDS) return;
       hotend_offset[extruder - E0][axis] = value;
     }
@@ -826,20 +826,20 @@ namespace ExtUI {
 
   #if HAS_BED_PROBE
     float getProbeOffset_mm(const axis_t axis) { return probe.offset.pos[axis]; }
-    void setProbeOffset_mm(const float &val, const axis_t axis) { probe.offset.pos[axis] = val; }
+    void setProbeOffset_mm(const_float_t val, const axis_t axis) { probe.offset.pos[axis] = val; }
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
     float getAxisBacklash_mm(const axis_t axis)       { return backlash.distance_mm[axis]; }
-    void setAxisBacklash_mm(const float &value, const axis_t axis)
+    void setAxisBacklash_mm(const_float_t value, const axis_t axis)
                                                       { backlash.distance_mm[axis] = constrain(value,0,5); }
 
     float getBacklashCorrection_percent()             { return ui8_to_percent(backlash.correction); }
-    void setBacklashCorrection_percent(const float &value) { backlash.correction = map(constrain(value, 0, 100), 0, 100, 0, 255); }
+    void setBacklashCorrection_percent(const_float_t value) { backlash.correction = map(constrain(value, 0, 100), 0, 100, 0, 255); }
 
     #ifdef BACKLASH_SMOOTHING_MM
       float getBacklashSmoothing_mm()                 { return backlash.smoothing_mm; }
-      void setBacklashSmoothing_mm(const float &value) { backlash.smoothing_mm = constrain(value, 0, 999); }
+      void setBacklashSmoothing_mm(const_float_t value) { backlash.smoothing_mm = constrain(value, 0, 999); }
     #endif
   #endif
 
@@ -858,14 +858,14 @@ namespace ExtUI {
 
       bed_mesh_t& getMeshArray() { return Z_VALUES_ARR; }
       float getMeshPoint(const xy_uint8_t &pos) { return Z_VALUES(pos.x, pos.y); }
-      void setMeshPoint(const xy_uint8_t &pos, const float &zoff) {
+      void setMeshPoint(const xy_uint8_t &pos, const_float_t zoff) {
         if (WITHIN(pos.x, 0, GRID_MAX_POINTS_X) && WITHIN(pos.y, 0, GRID_MAX_POINTS_Y)) {
           Z_VALUES(pos.x, pos.y) = zoff;
           TERN_(ABL_BILINEAR_SUBDIVISION, bed_level_virt_interpolate());
         }
       }
 
-      void moveToMeshPoint(const xy_uint8_t &pos, const float &z) {
+      void moveToMeshPoint(const xy_uint8_t &pos, const_float_t z) {
         #if EITHER(MESH_BED_LEVELING, AUTO_BED_LEVELING_UBL)
           const feedRate_t old_feedrate = feedrate_mm_s;
           const float x_target = MESH_MIN_X + pos.x * (MESH_X_DIST),
@@ -919,14 +919,14 @@ namespace ExtUI {
     float getPIDValues_Ki(const extruder_t tool) { return unscalePID_i(PID_PARAM(Ki, tool)); }
     float getPIDValues_Kd(const extruder_t tool) { return unscalePID_d(PID_PARAM(Kd, tool)); }
 
-    void setPIDValues(const float &p, const float &i, const float &d, extruder_t tool) {
+    void setPIDValues(const_float_t p, const_float_t i, const_float_t d, extruder_t tool) {
       thermalManager.temp_hotend[tool].pid.Kp = p;
       thermalManager.temp_hotend[tool].pid.Ki = scalePID_i(i);
       thermalManager.temp_hotend[tool].pid.Kd = scalePID_d(d);
       thermalManager.updatePID();
     }
 
-    void startPIDTune(const float &temp, extruder_t tool) {
+    void startPIDTune(const_float_t temp, extruder_t tool) {
       thermalManager.PID_autotune(temp, (heater_id_t)tool, 8, true);
     }
   #endif
@@ -936,14 +936,14 @@ namespace ExtUI {
     float getBedPIDValues_Ki() { return unscalePID_i(thermalManager.temp_bed.pid.Ki); }
     float getBedPIDValues_Kd() { return unscalePID_d(thermalManager.temp_bed.pid.Kd); }
 
-    void setBedPIDValues(const float &p, const float &i, const float &d) {
+    void setBedPIDValues(const_float_t p, const_float_t i, const_float_t d) {
       thermalManager.temp_bed.pid.Kp = p;
       thermalManager.temp_bed.pid.Ki = scalePID_i(i);
       thermalManager.temp_bed.pid.Kd = scalePID_d(d);
       thermalManager.updatePID();
     }
 
-    void startBedPIDTune(const float &temp) {
+    void startBedPIDTune(const_float_t temp) {
       thermalManager.PID_autotune(temp, H_BED, 4, true);
     }
   #endif
@@ -963,7 +963,7 @@ namespace ExtUI {
     return firmware_name;
   }
 
-  void setTargetTemp_celsius(const float &inval, const heater_t heater) {
+  void setTargetTemp_celsius(const_float_t inval, const heater_t heater) {
     float value = inval;
     #ifdef TOUCH_UI_LCD_TEMP_SCALING
       value *= TOUCH_UI_LCD_TEMP_SCALING;
@@ -988,7 +988,7 @@ namespace ExtUI {
     }
   }
 
-  void setTargetTemp_celsius(const float &inval, const extruder_t extruder) {
+  void setTargetTemp_celsius(const_float_t inval, const extruder_t extruder) {
     float value = inval;
     #ifdef TOUCH_UI_LCD_TEMP_SCALING
       value *= TOUCH_UI_LCD_TEMP_SCALING;
@@ -1000,7 +1000,7 @@ namespace ExtUI {
     #endif
   }
 
-  void setTargetFan_percent(const float &value, const fan_t fan) {
+  void setTargetFan_percent(const_float_t value, const fan_t fan) {
     #if HAS_FAN
       if (fan < FAN_COUNT)
         thermalManager.set_fan_speed(fan - FAN0, map(constrain(value, 0, 100), 0, 100, 0, 255));
@@ -1010,7 +1010,7 @@ namespace ExtUI {
     #endif
   }
 
-  void setFeedrate_percent(const float &value) { feedrate_percentage = constrain(value, 10, 500); }
+  void setFeedrate_percent(const_float_t value) { feedrate_percentage = constrain(value, 10, 500); }
 
   void coolDown() {
     #if HAS_HOTEND

--- a/Marlin/src/lcd/extui/ui_api.h
+++ b/Marlin/src/lcd/extui/ui_api.h
@@ -102,11 +102,11 @@ namespace ExtUI {
   #if HAS_TRINAMIC_CONFIG
     float getAxisCurrent_mA(const axis_t);
     float getAxisCurrent_mA(const extruder_t);
-    void  setAxisCurrent_mA(const float&, const axis_t);
-    void  setAxisCurrent_mA(const float&, const extruder_t);
+    void  setAxisCurrent_mA(const_float_t , const axis_t);
+    void  setAxisCurrent_mA(const_float_t , const extruder_t);
 
      int getTMCBumpSensitivity(const axis_t);
-    void setTMCBumpSensitivity(const float&, const axis_t);
+    void setTMCBumpSensitivity(const_float_t , const axis_t);
   #endif
 
   float getActualTemp_celsius(const heater_t);
@@ -161,11 +161,11 @@ namespace ExtUI {
     #if HAS_MESH
       bed_mesh_t& getMeshArray();
       float getMeshPoint(const xy_uint8_t &pos);
-      void setMeshPoint(const xy_uint8_t &pos, const float &zval);
-      void moveToMeshPoint(const xy_uint8_t &pos, const float &z);
+      void setMeshPoint(const xy_uint8_t &pos, const_float_t zval);
+      void moveToMeshPoint(const xy_uint8_t &pos, const_float_t z);
       void onMeshLevelingStart();
-      void onMeshUpdate(const int8_t xpos, const int8_t ypos, const float &zval);
-      inline void onMeshUpdate(const xy_int8_t &pos, const float &zval) { onMeshUpdate(pos.x, pos.y, zval); }
+      void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval);
+      inline void onMeshUpdate(const xy_int8_t &pos, const_float_t zval) { onMeshUpdate(pos.x, pos.y, zval); }
 
       typedef enum : uint8_t {
         MESH_START,    // Prior to start of probe
@@ -191,42 +191,42 @@ namespace ExtUI {
     char* getFilamentUsed_str(char buffer[21]);
   #endif
 
-  void setTargetTemp_celsius(const float&, const heater_t);
-  void setTargetTemp_celsius(const float&, const extruder_t);
-  void setTargetFan_percent(const float&, const fan_t);
+  void setTargetTemp_celsius(const_float_t , const heater_t);
+  void setTargetTemp_celsius(const_float_t , const extruder_t);
+  void setTargetFan_percent(const_float_t , const fan_t);
   void coolDown();
-  void setAxisPosition_mm(const float&, const axis_t, const feedRate_t=0);
-  void setAxisPosition_mm(const float&, const extruder_t, const feedRate_t=0);
-  void setAxisSteps_per_mm(const float&, const axis_t);
-  void setAxisSteps_per_mm(const float&, const extruder_t);
+  void setAxisPosition_mm(const_float_t , const axis_t, const feedRate_t=0);
+  void setAxisPosition_mm(const_float_t , const extruder_t, const feedRate_t=0);
+  void setAxisSteps_per_mm(const_float_t , const axis_t);
+  void setAxisSteps_per_mm(const_float_t , const extruder_t);
   void setAxisMaxFeedrate_mm_s(const feedRate_t, const axis_t);
   void setAxisMaxFeedrate_mm_s(const feedRate_t, const extruder_t);
-  void setAxisMaxAcceleration_mm_s2(const float&, const axis_t);
-  void setAxisMaxAcceleration_mm_s2(const float&, const extruder_t);
+  void setAxisMaxAcceleration_mm_s2(const_float_t , const axis_t);
+  void setAxisMaxAcceleration_mm_s2(const_float_t , const extruder_t);
   void setFeedrate_mm_s(const feedRate_t);
   void setMinFeedrate_mm_s(const feedRate_t);
   void setMinTravelFeedrate_mm_s(const feedRate_t);
-  void setPrintingAcceleration_mm_s2(const float&);
-  void setRetractAcceleration_mm_s2(const float&);
-  void setTravelAcceleration_mm_s2(const float&);
-  void setFeedrate_percent(const float&);
+  void setPrintingAcceleration_mm_s2(const_float_t );
+  void setRetractAcceleration_mm_s2(const_float_t );
+  void setTravelAcceleration_mm_s2(const_float_t );
+  void setFeedrate_percent(const_float_t );
   void setFlow_percent(const int16_t, const extruder_t);
   bool awaitingUserConfirm();
   void setUserConfirmed();
 
   #if ENABLED(LIN_ADVANCE)
     float getLinearAdvance_mm_mm_s(const extruder_t);
-    void setLinearAdvance_mm_mm_s(const float&, const extruder_t);
+    void setLinearAdvance_mm_mm_s(const_float_t , const extruder_t);
   #endif
 
   #if HAS_JUNCTION_DEVIATION
     float getJunctionDeviation_mm();
-    void setJunctionDeviation_mm(const float&);
+    void setJunctionDeviation_mm(const_float_t );
   #else
     float getAxisMaxJerk_mm_s(const axis_t);
     float getAxisMaxJerk_mm_s(const extruder_t);
-    void setAxisMaxJerk_mm_s(const float&, const axis_t);
-    void setAxisMaxJerk_mm_s(const float&, const extruder_t);
+    void setAxisMaxJerk_mm_s(const_float_t , const axis_t);
+    void setAxisMaxJerk_mm_s(const_float_t , const extruder_t);
   #endif
 
   extruder_t getTool(const uint8_t extruder);
@@ -234,7 +234,7 @@ namespace ExtUI {
   void setActiveTool(const extruder_t, bool no_move);
 
   #if ENABLED(BABYSTEPPING)
-    int16_t mmToWholeSteps(const float& mm, const axis_t axis);
+    int16_t mmToWholeSteps(const_float_t mm, const axis_t axis);
 
     bool babystepAxis_steps(const int16_t steps, const axis_t axis);
     void smartAdjustAxis_steps(const int16_t steps, const axis_t axis, bool linked_nozzles);
@@ -242,28 +242,28 @@ namespace ExtUI {
 
   #if HAS_HOTEND_OFFSET
     float getNozzleOffset_mm(const axis_t, const extruder_t);
-    void setNozzleOffset_mm(const float&, const axis_t, const extruder_t);
+    void setNozzleOffset_mm(const_float_t , const axis_t, const extruder_t);
     void normalizeNozzleOffset(const axis_t axis);
   #endif
 
   float getZOffset_mm();
-  void setZOffset_mm(const float&);
+  void setZOffset_mm(const_float_t );
 
   #if HAS_BED_PROBE
     float getProbeOffset_mm(const axis_t);
-    void setProbeOffset_mm(const float&, const axis_t);
+    void setProbeOffset_mm(const_float_t , const axis_t);
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
     float getAxisBacklash_mm(const axis_t);
-    void setAxisBacklash_mm(const float&, const axis_t);
+    void setAxisBacklash_mm(const_float_t , const axis_t);
 
     float getBacklashCorrection_percent();
-    void setBacklashCorrection_percent(const float&);
+    void setBacklashCorrection_percent(const_float_t );
 
     #ifdef BACKLASH_SMOOTHING_MM
       float getBacklashSmoothing_mm();
-      void setBacklashSmoothing_mm(const float&);
+      void setBacklashSmoothing_mm(const_float_t );
     #endif
   #endif
 
@@ -275,7 +275,7 @@ namespace ExtUI {
 
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       float getFilamentRunoutDistance_mm();
-      void setFilamentRunoutDistance_mm(const float&);
+      void setFilamentRunoutDistance_mm(const_float_t );
     #endif
   #endif
 
@@ -285,7 +285,7 @@ namespace ExtUI {
 
     #if DISABLED(CASE_LIGHT_NO_BRIGHTNESS)
       float getCaseLightBrightness_percent();
-      void setCaseLightBrightness_percent(const float&);
+      void setCaseLightBrightness_percent(const_float_t );
     #endif
   #endif
 
@@ -293,16 +293,16 @@ namespace ExtUI {
     float getPIDValues_Kp(const extruder_t);
     float getPIDValues_Ki(const extruder_t);
     float getPIDValues_Kd(const extruder_t);
-    void setPIDValues(const float&, const float&, const float&, extruder_t);
-    void startPIDTune(const float&, extruder_t);
+    void setPIDValues(const_float_t , const_float_t , const_float_t , extruder_t);
+    void startPIDTune(const_float_t , extruder_t);
   #endif
 
   #if ENABLED(PIDTEMPBED)
     float getBedPIDValues_Kp();
     float getBedPIDValues_Ki();
     float getBedPIDValues_Kd();
-    void setBedPIDValues(const float&, const float&, const float&);
-    void startBedPIDTune(const float&);
+    void setBedPIDValues(const_float_t , const_float_t , const_float_t );
+    void startBedPIDTune(const_float_t );
   #endif
 
   /**

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -501,7 +501,7 @@ public:
     #endif
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
-      static void ubl_mesh_edit_start(const float &initial);
+      static void ubl_mesh_edit_start(const_float_t initial);
       static float ubl_mesh_value();
     #endif
 

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -289,7 +289,7 @@ void scroll_screen(const uint8_t limit, const bool is_menu) {
 
 #if HAS_LINE_TO_Z
 
-  void line_to_z(const float &z) {
+  void line_to_z(const_float_t z) {
     current_position.z = z;
     line_to_current_position(manual_feedrate_mm_s.z);
   }

--- a/Marlin/src/lcd/menu/menu.h
+++ b/Marlin/src/lcd/menu/menu.h
@@ -40,7 +40,7 @@ typedef void (*selectFunc_t)();
 #define SS_DEFAULT SS_CENTER
 
 #if HAS_MARLINUI_U8GLIB && EITHER(BABYSTEP_ZPROBE_GFX_OVERLAY, MESH_EDIT_GFX_OVERLAY)
-  void _lcd_zoffset_overlay_gfx(const float zvalue);
+  void _lcd_zoffset_overlay_gfx(const_float_t zvalue);
 #endif
 
 #if ENABLED(BABYSTEP_ZPROBE_OFFSET) && Z_PROBE_OFFSET_RANGE_MIN >= -9 && Z_PROBE_OFFSET_RANGE_MAX <= 9
@@ -212,11 +212,7 @@ void _lcd_draw_homing();
 #define HAS_LINE_TO_Z ANY(DELTA, PROBE_MANUALLY, MESH_BED_LEVELING, LEVEL_BED_CORNERS)
 
 #if HAS_LINE_TO_Z
-  void line_to_z(const float &z);
-#endif
-
-#if HAS_MARLINUI_U8GLIB && EITHER(BABYSTEP_ZPROBE_GFX_OVERLAY, MESH_EDIT_GFX_OVERLAY)
-  void _lcd_zoffset_overlay_gfx(const float zvalue);
+  void line_to_z(const_float_t z);
 #endif
 
 #if ENABLED(PROBE_OFFSET_WIZARD)

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -86,7 +86,7 @@ void _man_probe_pt(const xy_pos_t &xy) {
     ui.goto_screen(_lcd_calibrate_homing);
   }
 
-  void _goto_tower_a(const float &a) {
+  void _goto_tower_a(const_float_t a) {
     xy_pos_t tower_vec = { cos(RADIANS(a)), sin(RADIANS(a)) };
     _man_probe_pt(tower_vec * delta_calibration_radius());
   }

--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -77,8 +77,8 @@ template<typename NAME>
 class TMenuEditItem : MenuEditItemBase {
   private:
     typedef typename NAME::type_t type_t;
-    static inline float scale(const float value)      { return NAME::scale(value);            }
-    static inline float unscale(const float value)    { return NAME::unscale(value);          }
+    static inline float scale(const_float_t value)    { return NAME::scale(value);            }
+    static inline float unscale(const_float_t value)  { return NAME::unscale(value);          }
     static const char* to_string(const int32_t value) { return NAME::strfunc(unscale(value)); }
     static void load(void *ptr, const int32_t value)  { *((type_t*)ptr) = unscale(value);     }
   public:
@@ -114,9 +114,9 @@ class TMenuEditItem : MenuEditItemBase {
 #define DEFINE_MENU_EDIT_ITEM_TYPE(NAME, TYPE, STRFUNC, SCALE, V...) \
   struct MenuEditItemInfo_##NAME { \
     typedef TYPE type_t; \
-    static inline float scale(const float value)   { return value * (SCALE) + (V+0); } \
-    static inline float unscale(const float value) { return value / (SCALE) + (V+0); } \
-    static inline const char* strfunc(const float value) { return STRFUNC(_DOFIX(TYPE,value)); } \
+    static inline float scale(const_float_t value)   { return value * (SCALE) + (V+0); } \
+    static inline float unscale(const_float_t value) { return value / (SCALE) + (V+0); } \
+    static inline const char* strfunc(const_float_t value) { return STRFUNC(_DOFIX(TYPE,value)); } \
   }; \
   typedef TMenuEditItem<MenuEditItemInfo_##NAME> MenuItem_##NAME
 

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -149,7 +149,7 @@ void lcd_move_z() { _lcd_move_xyz(GET_TEXT(MSG_MOVE_Z), Z_AXIS); }
 
 screenFunc_t _manual_move_func_ptr;
 
-void _goto_manual_move(const float scale) {
+void _goto_manual_move(const_float_t scale) {
   ui.defer_status_screen();
   ui.manual_move.menu_scale = scale;
   ui.goto_screen(_manual_move_func_ptr);

--- a/Marlin/src/lcd/menu/menu_probe_offset.cpp
+++ b/Marlin/src/lcd/menu/menu_probe_offset.cpp
@@ -58,14 +58,14 @@ inline void z_clearance_move() {
   );
 }
 
-void set_offset_and_go_back(const float &z) {
+void set_offset_and_go_back(const_float_t z) {
   probe.offset.z = z;
   SET_SOFT_ENDSTOP_LOOSE(false);
   TERN_(HAS_LEVELING, set_bed_leveling_enabled(leveling_was_active));
   ui.goto_previous_screen_no_defer();
 }
 
-void _goto_manual_move_z(const float scale) {
+void _goto_manual_move_z(const_float_t scale) {
   ui.manual_move.menu_scale = scale;
   ui.goto_screen(lcd_move_z);
 }

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -92,7 +92,7 @@ void _lcd_mesh_fine_tune(PGM_P const msg) {
 // Init mesh editing and go to the fine tuning screen (ubl.fine_tune_mesh)
 // To capture encoder events UBL will also call ui.capture and ui.release.
 //
-void MarlinUI::ubl_mesh_edit_start(const float &initial) {
+void MarlinUI::ubl_mesh_edit_start(const_float_t initial) {
   TERN_(HAS_GRAPHICAL_TFT, clear_lcd());
   mesh_edit_accumulator = initial;
   goto_screen([]{ _lcd_mesh_fine_tune(GET_TEXT(MSG_MESH_EDIT_Z)); });

--- a/Marlin/src/libs/L64XX/L64XX_Marlin.cpp
+++ b/Marlin/src/libs/L64XX/L64XX_Marlin.cpp
@@ -368,12 +368,12 @@ void L64XX_Marlin::set_param(const L64XX_axis_t axis, const uint8_t param, const
   }
 }
 
-inline void echo_min_max(const char a, const float &min, const float &max) {
+inline void echo_min_max(const char a, const_float_t min, const_float_t max) {
   DEBUG_CHAR(' '); DEBUG_CHAR(a);
   DEBUG_ECHOPAIR(" min = ", min);
   DEBUG_ECHOLNPAIR("  max = ", max);
 }
-inline void echo_oct_used(const float &oct, const uint8_t stall) {
+inline void echo_oct_used(const_float_t oct, const uint8_t stall) {
   DEBUG_ECHOPAIR("over_current_threshold used     : ", oct);
   DEBUG_ECHOPGM_P(stall ? PSTR("  (Stall") : PSTR("  (OCD"));
   DEBUG_ECHOLNPGM(" threshold)");

--- a/Marlin/src/libs/least_squares_fit.h
+++ b/Marlin/src/libs/least_squares_fit.h
@@ -47,7 +47,7 @@ inline void incremental_LSF_reset(struct linear_fit_data *lsf) {
   memset(lsf, 0, sizeof(linear_fit_data));
 }
 
-inline void incremental_WLSF(struct linear_fit_data *lsf, const float &x, const float &y, const float &z, const float &w) {
+inline void incremental_WLSF(struct linear_fit_data *lsf, const_float_t x, const_float_t y, const_float_t z, const_float_t w) {
   // weight each accumulator by factor w, including the "number" of samples
   // (analogous to calling inc_LSF twice with same values to weight it by 2X)
   const float wx = w * x, wy = w * y, wz = w * z;
@@ -63,11 +63,11 @@ inline void incremental_WLSF(struct linear_fit_data *lsf, const float &x, const 
   lsf->max_absx = _MAX(ABS(wx), lsf->max_absx);
   lsf->max_absy = _MAX(ABS(wy), lsf->max_absy);
 }
-inline void incremental_WLSF(struct linear_fit_data *lsf, const xy_pos_t &pos, const float &z, const float &w) {
+inline void incremental_WLSF(struct linear_fit_data *lsf, const xy_pos_t &pos, const_float_t z, const_float_t w) {
   incremental_WLSF(lsf, pos.x, pos.y, z, w);
 }
 
-inline void incremental_LSF(struct linear_fit_data *lsf, const float &x, const float &y, const float &z) {
+inline void incremental_LSF(struct linear_fit_data *lsf, const_float_t x, const_float_t y, const_float_t z) {
   lsf->xbar += x;
   lsf->ybar += y;
   lsf->zbar += z;
@@ -80,7 +80,7 @@ inline void incremental_LSF(struct linear_fit_data *lsf, const float &x, const f
   lsf->max_absy = _MAX(ABS(y), lsf->max_absy);
   lsf->N += 1.0;
 }
-inline void incremental_LSF(struct linear_fit_data *lsf, const xy_pos_t &pos, const float &z) {
+inline void incremental_LSF(struct linear_fit_data *lsf, const xy_pos_t &pos, const_float_t z) {
   incremental_LSF(lsf, pos.x, pos.y, z);
 }
 

--- a/Marlin/src/libs/nozzle.cpp
+++ b/Marlin/src/libs/nozzle.cpp
@@ -130,7 +130,7 @@ Nozzle nozzle;
    * @param strokes number of strokes to execute
    * @param radius radius of circle
    */
-  void Nozzle::circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t &strokes, const float &radius) {
+  void Nozzle::circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t &strokes, const_float_t radius) {
     if (strokes == 0) return;
 
     #if ENABLED(NOZZLE_CLEAN_GOBACK)
@@ -158,7 +158,7 @@ Nozzle nozzle;
    * @param pattern one of the available patterns
    * @param argument depends on the cleaning pattern
    */
-  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const uint8_t cleans) {
+  void Nozzle::clean(const uint8_t &pattern, const uint8_t &strokes, const_float_t radius, const uint8_t &objects, const uint8_t cleans) {
     xyz_pos_t start[HOTENDS] = NOZZLE_CLEAN_START_POINT, end[HOTENDS] = NOZZLE_CLEAN_END_POINT, middle[HOTENDS] = NOZZLE_CLEAN_CIRCLE_MIDDLE;
 
     const uint8_t arrPos = ANY(SINGLENOZZLE, MIXING_EXTRUDER) ? 0 : active_extruder;

--- a/Marlin/src/libs/nozzle.h
+++ b/Marlin/src/libs/nozzle.h
@@ -62,7 +62,7 @@ class Nozzle {
      * @param strokes number of strokes to execute
      * @param radius radius of circle
      */
-    static void circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t &strokes, const float &radius) _Os;
+    static void circle(const xyz_pos_t &start, const xyz_pos_t &middle, const uint8_t &strokes, const_float_t radius) _Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 
@@ -77,7 +77,7 @@ class Nozzle {
      * @param pattern one of the available patterns
      * @param argument depends on the cleaning pattern
      */
-    static void clean(const uint8_t &pattern, const uint8_t &strokes, const float &radius, const uint8_t &objects, const uint8_t cleans) _Os;
+    static void clean(const uint8_t &pattern, const uint8_t &strokes, const_float_t radius, const uint8_t &objects, const uint8_t cleans) _Os;
 
   #endif // NOZZLE_CLEAN_FEATURE
 

--- a/Marlin/src/libs/numtostr.cpp
+++ b/Marlin/src/libs/numtostr.cpp
@@ -178,7 +178,7 @@ const char* i16tostr4signrj(const int16_t i) {
 }
 
 // Convert unsigned float to string with 1.1 format
-const char* ftostr11ns(const float &f) {
+const char* ftostr11ns(const_float_t f) {
   const long i = UINTFLOAT(f, 1);
   conv[4] = DIGIMOD(i, 10);
   conv[5] = '.';
@@ -187,7 +187,7 @@ const char* ftostr11ns(const float &f) {
 }
 
 // Convert unsigned float to string with 1.23 format
-const char* ftostr12ns(const float &f) {
+const char* ftostr12ns(const_float_t f) {
   const long i = UINTFLOAT(f, 2);
   conv[3] = DIGIMOD(i, 100);
   conv[4] = '.';
@@ -197,7 +197,7 @@ const char* ftostr12ns(const float &f) {
 }
 
 // Convert unsigned float to string with 12.3 format
-const char* ftostr31ns(const float &f) {
+const char* ftostr31ns(const_float_t f) {
   const long i = UINTFLOAT(f, 1);
   conv[3] = DIGIMOD(i, 100);
   conv[4] = DIGIMOD(i, 10);
@@ -207,7 +207,7 @@ const char* ftostr31ns(const float &f) {
 }
 
 // Convert unsigned float to string with 123.4 format
-const char* ftostr41ns(const float &f) {
+const char* ftostr41ns(const_float_t f) {
   const long i = UINTFLOAT(f, 1);
   conv[2] = DIGIMOD(i, 1000);
   conv[3] = DIGIMOD(i, 100);
@@ -218,7 +218,7 @@ const char* ftostr41ns(const float &f) {
 }
 
 // Convert signed float to fixed-length string with 12.34 / _2.34 / -2.34 or -23.45 / 123.45 format
-const char* ftostr42_52(const float &f) {
+const char* ftostr42_52(const_float_t f) {
   if (f <= -10 || f >= 100) return ftostr52(f); // -23.45 / 123.45
   long i = INTFLOAT(f, 2);
   conv[2] = (f >= 0 && f < 10) ? ' ' : MINUSOR(i, DIGIMOD(i, 1000));
@@ -230,7 +230,7 @@ const char* ftostr42_52(const float &f) {
 }
 
 // Convert signed float to fixed-length string with 023.45 / -23.45 format
-const char* ftostr52(const float &f) {
+const char* ftostr52(const_float_t f) {
   long i = INTFLOAT(f, 2);
   conv[1] = MINUSOR(i, DIGIMOD(i, 10000));
   conv[2] = DIGIMOD(i, 1000);
@@ -242,7 +242,7 @@ const char* ftostr52(const float &f) {
 }
 
 // Convert signed float to fixed-length string with 12.345 / _2.345 / -2.345 or -23.45 / 123.45 format
-const char* ftostr53_63(const float &f) {
+const char* ftostr53_63(const_float_t f) {
   if (f <= -10 || f >= 100) return ftostr63(f); // -23.456 / 123.456
   long i = INTFLOAT(f, 3);
   conv[1] = (f >= 0 && f < 10) ? ' ' : MINUSOR(i, DIGIMOD(i, 10000));
@@ -255,7 +255,7 @@ const char* ftostr53_63(const float &f) {
 }
 
 // Convert signed float to fixed-length string with 023.456 / -23.456 format
-const char* ftostr63(const float &f) {
+const char* ftostr63(const_float_t f) {
   long i = INTFLOAT(f, 3);
   conv[0] = MINUSOR(i, DIGIMOD(i, 100000));
   conv[1] = DIGIMOD(i, 10000);
@@ -270,7 +270,7 @@ const char* ftostr63(const float &f) {
 #if ENABLED(LCD_DECIMAL_SMALL_XY)
 
   // Convert float to rj string with 1234, _123, -123, _-12, 12.3, _1.2, or -1.2 format
-  const char* ftostr4sign(const float &f) {
+  const char* ftostr4sign(const_float_t f) {
     const int i = INTFLOAT(f, 1);
     if (!WITHIN(i, -99, 999)) return i16tostr4signrj((int)f);
     const bool neg = i < 0;
@@ -285,7 +285,7 @@ const char* ftostr63(const float &f) {
 #endif
 
 // Convert float to fixed-length string with +12.3 / -12.3 format
-const char* ftostr31sign(const float &f) {
+const char* ftostr31sign(const_float_t f) {
   int i = INTFLOAT(f, 1);
   conv[2] = MINUSOR(i, '+');
   conv[3] = DIGIMOD(i, 100);
@@ -296,7 +296,7 @@ const char* ftostr31sign(const float &f) {
 }
 
 // Convert float to fixed-length string with +123.4 / -123.4 format
-const char* ftostr41sign(const float &f) {
+const char* ftostr41sign(const_float_t f) {
   int i = INTFLOAT(f, 1);
   conv[1] = MINUSOR(i, '+');
   conv[2] = DIGIMOD(i, 1000);
@@ -308,7 +308,7 @@ const char* ftostr41sign(const float &f) {
 }
 
 // Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
-const char* ftostr43sign(const float &f, char plus/*=' '*/) {
+const char* ftostr43sign(const_float_t f, char plus/*=' '*/) {
   long i = INTFLOAT(f, 3);
   conv[1] = i ? MINUSOR(i, plus) : ' ';
   conv[2] = DIGIMOD(i, 1000);
@@ -320,7 +320,7 @@ const char* ftostr43sign(const float &f, char plus/*=' '*/) {
 }
 
 // Convert signed float to string (5 digit) with -1.2345 / _0.0000 / +1.2345 format
-const char* ftostr54sign(const float &f, char plus/*=' '*/) {
+const char* ftostr54sign(const_float_t f, char plus/*=' '*/) {
   long i = INTFLOAT(f, 4);
   conv[0] = i ? MINUSOR(i, plus) : ' ';
   conv[1] = DIGIMOD(i, 10000);
@@ -333,13 +333,13 @@ const char* ftostr54sign(const float &f, char plus/*=' '*/) {
 }
 
 // Convert unsigned float to rj string with 12345 format
-const char* ftostr5rj(const float &f) {
+const char* ftostr5rj(const_float_t f) {
   const long i = UINTFLOAT(f, 0);
   return ui16tostr5rj(i);
 }
 
 // Convert signed float to string with +1234.5 format
-const char* ftostr51sign(const float &f) {
+const char* ftostr51sign(const_float_t f) {
   long i = INTFLOAT(f, 1);
   conv[0] = MINUSOR(i, '+');
   conv[1] = DIGIMOD(i, 10000);
@@ -352,7 +352,7 @@ const char* ftostr51sign(const float &f) {
 }
 
 // Convert signed float to string with +123.45 format
-const char* ftostr52sign(const float &f) {
+const char* ftostr52sign(const_float_t f) {
   long i = INTFLOAT(f, 2);
   conv[0] = MINUSOR(i, '+');
   conv[1] = DIGIMOD(i, 10000);
@@ -365,7 +365,7 @@ const char* ftostr52sign(const float &f) {
 }
 
 // Convert signed float to string with +12.345 format
-const char* ftostr53sign(const float &f) {
+const char* ftostr53sign(const_float_t f) {
   long i = INTFLOAT(f, 3);
   conv[0] = MINUSOR(i, '+');
   conv[1] = DIGIMOD(i, 10000);
@@ -378,7 +378,7 @@ const char* ftostr53sign(const float &f) {
 }
 
 // Convert unsigned float to string with ____4.5, __34.5, _234.5, 1234.5 format
-const char* ftostr51rj(const float &f) {
+const char* ftostr51rj(const_float_t f) {
   const long i = UINTFLOAT(f, 1);
   conv[0] = ' ';
   conv[1] = RJDIGIT(i, 10000);
@@ -391,7 +391,7 @@ const char* ftostr51rj(const float &f) {
 }
 
 // Convert signed float to space-padded string with -_23.4_ format
-const char* ftostr52sp(const float &f) {
+const char* ftostr52sp(const_float_t f) {
   long i = INTFLOAT(f, 2);
   uint8_t dig;
   conv[0] = MINUSOR(i, ' ');

--- a/Marlin/src/libs/numtostr.h
+++ b/Marlin/src/libs/numtostr.h
@@ -21,7 +21,8 @@
  */
 #pragma once
 
-#include <stdint.h>
+#include "../inc/MarlinConfigPre.h"
+#include "../core/types.h"
 
 // Format uint8_t (0-100) as rj string with 123% / _12% / __1% format
 const char* pcttostrpctrj(const uint8_t i);
@@ -62,70 +63,66 @@ const char* i16tostr3left(const int16_t xx);
 const char* i16tostr4signrj(const int16_t x);
 
 // Convert unsigned float to string with 1.2 format
-const char* ftostr11ns(const float &x);
+const char* ftostr11ns(const_float_t x);
 
 // Convert unsigned float to string with 1.23 format
-const char* ftostr12ns(const float &x);
+const char* ftostr12ns(const_float_t x);
 
 // Convert unsigned float to string with 12.3 format
-const char* ftostr31ns(const float &x);
+const char* ftostr31ns(const_float_t x);
 
 // Convert unsigned float to string with 123.4 format
-const char* ftostr41ns(const float &x);
+const char* ftostr41ns(const_float_t x);
 
 // Convert signed float to fixed-length string with 12.34 / _2.34 / -2.34 or -23.45 / 123.45 format
-const char* ftostr42_52(const float &x);
+const char* ftostr42_52(const_float_t x);
 
 // Convert signed float to fixed-length string with 023.45 / -23.45 format
-const char* ftostr52(const float &x);
+const char* ftostr52(const_float_t x);
 
 // Convert signed float to fixed-length string with 12.345 / -2.345 or 023.456 / -23.456 format
-const char* ftostr53_63(const float &x);
+const char* ftostr53_63(const_float_t x);
 
 // Convert signed float to fixed-length string with 023.456 / -23.456 format
-const char* ftostr63(const float &x);
+const char* ftostr63(const_float_t x);
 
 // Convert float to fixed-length string with +12.3 / -12.3 format
-const char* ftostr31sign(const float &x);
+const char* ftostr31sign(const_float_t x);
 
 // Convert float to fixed-length string with +123.4 / -123.4 format
-const char* ftostr41sign(const float &x);
+const char* ftostr41sign(const_float_t x);
 
 // Convert signed float to string (6 digit) with -1.234 / _0.000 / +1.234 format
-const char* ftostr43sign(const float &x, char plus=' ');
+const char* ftostr43sign(const_float_t x, char plus=' ');
 
 // Convert signed float to string (5 digit) with -1.2345 / _0.0000 / +1.2345 format
-const char* ftostr54sign(const float &x, char plus=' ');
+const char* ftostr54sign(const_float_t x, char plus=' ');
 
 // Convert unsigned float to rj string with 12345 format
-const char* ftostr5rj(const float &x);
+const char* ftostr5rj(const_float_t x);
 
 // Convert signed float to string with +1234.5 format
-const char* ftostr51sign(const float &x);
+const char* ftostr51sign(const_float_t x);
 
 // Convert signed float to space-padded string with -_23.4_ format
-const char* ftostr52sp(const float &x);
+const char* ftostr52sp(const_float_t x);
 
 // Convert signed float to string with +123.45 format
-const char* ftostr52sign(const float &x);
+const char* ftostr52sign(const_float_t x);
 
 // Convert signed float to string with +12.345 format
-const char* ftostr53sign(const float &f);
+const char* ftostr53sign(const_float_t f);
 
 // Convert unsigned float to string with 1234.5 format omitting trailing zeros
-const char* ftostr51rj(const float &x);
-
-#include "../core/macros.h"
+const char* ftostr51rj(const_float_t x);
 
 // Convert float to rj string with 123 or -12 format
-FORCE_INLINE const char* ftostr3(const float &x) { return i16tostr3rj(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
-
-#include "../inc/MarlinConfigPre.h"
+FORCE_INLINE const char* ftostr3(const_float_t x) { return i16tostr3rj(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
 
 #if ENABLED(LCD_DECIMAL_SMALL_XY)
   // Convert float to rj string with 1234, _123, 12.3, _1.2, -123, _-12, or -1.2 format
-  const char* ftostr4sign(const float &fx);
+  const char* ftostr4sign(const_float_t fx);
 #else
   // Convert float to rj string with 1234, _123, -123, __12, _-12, ___1, or __-1 format
-  FORCE_INLINE const char* ftostr4sign(const float &x) { return i16tostr4signrj(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
+  FORCE_INLINE const char* ftostr4sign(const_float_t x) { return i16tostr4signrj(int16_t(x + (x < 0 ? -0.5f : 0.5f))); }
 #endif

--- a/Marlin/src/libs/vector_3.h
+++ b/Marlin/src/libs/vector_3.h
@@ -45,7 +45,7 @@
 class matrix_3x3;
 
 struct vector_3 : xyz_float_t {
-  vector_3(const float &_x, const float &_y, const float &_z) { set(_x, _y, _z); }
+  vector_3(const_float_t _x, const_float_t _y, const_float_t _z) { set(_x, _y, _z); }
   vector_3(const xy_float_t   &in) { set(in.x, in.y); }
   vector_3(const xyz_float_t  &in) { set(in.x, in.y, in.z); }
   vector_3(const xyze_float_t &in) { set(in.x, in.y, in.z); }

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -177,7 +177,7 @@ float delta_safe_distance_from_top() {
  *
  * The result is stored in the cartes[] array.
  */
-void forward_kinematics(const float &z1, const float &z2, const float &z3) {
+void forward_kinematics(const_float_t z1, const_float_t z2, const_float_t z3) {
   // Create a vector in old coordinates along x axis of new coordinate
   const float p12[3] = { delta_tower[B_AXIS].x - delta_tower[A_AXIS].x, delta_tower[B_AXIS].y - delta_tower[A_AXIS].y, z2 - z1 },
 

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -120,7 +120,7 @@ float delta_safe_distance_from_top();
  *
  * The result is stored in the cartes[] array.
  */
-void forward_kinematics(const float &z1, const float &z2, const float &z3);
+void forward_kinematics(const_float_t z1, const_float_t z2, const_float_t z3);
 
 FORCE_INLINE void forward_kinematics(const abc_float_t &point) {
   forward_kinematics(point.a, point.b, point.c);

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -311,12 +311,12 @@ void set_current_from_steppers_for_axis(const AxisEnum axis) {
  * Move the planner to the current position from wherever it last moved
  * (or from wherever it has been told it is located).
  */
-void line_to_current_position(const feedRate_t &fr_mm_s/*=feedrate_mm_s*/) {
+void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
   planner.buffer_line(current_position, fr_mm_s, active_extruder);
 }
 
 #if EXTRUDERS
-  void unscaled_e_move(const float &length, const feedRate_t &fr_mm_s) {
+  void unscaled_e_move(const_float_t length, const_feedRate_t fr_mm_s) {
     TERN_(HAS_FILAMENT_SENSOR, runout.reset());
     current_position.e += length / planner.e_factor[active_extruder];
     line_to_current_position(fr_mm_s);
@@ -329,7 +329,7 @@ void line_to_current_position(const feedRate_t &fr_mm_s/*=feedrate_mm_s*/) {
   /**
    * Buffer a fast move without interpolation. Set current_position to destination
    */
-  void prepare_fast_move_to_destination(const feedRate_t &scaled_fr_mm_s/*=MMS_SCALED(feedrate_mm_s)*/) {
+  void prepare_fast_move_to_destination(const_feedRate_t scaled_fr_mm_s/*=MMS_SCALED(feedrate_mm_s)*/) {
     if (DEBUGGING(LEVELING)) DEBUG_POS("prepare_fast_move_to_destination", destination);
 
     #if UBL_SEGMENTED
@@ -351,7 +351,7 @@ void line_to_current_position(const feedRate_t &fr_mm_s/*=feedrate_mm_s*/) {
  *  - Move at normal speed regardless of feedrate percentage.
  *  - Extrude the specified length regardless of flow percentage.
  */
-void _internal_move_to_destination(const feedRate_t &fr_mm_s/*=0.0f*/
+void _internal_move_to_destination(const_feedRate_t fr_mm_s/*=0.0f*/
   #if IS_KINEMATIC
     , const bool is_fast/*=false*/
   #endif
@@ -384,7 +384,7 @@ void _internal_move_to_destination(const feedRate_t &fr_mm_s/*=0.0f*/
 /**
  * Plan a move to (X, Y, Z) and set the current_position
  */
-void do_blocking_move_to(const float rx, const float ry, const float rz, const feedRate_t &fr_mm_s/*=0.0*/) {
+void do_blocking_move_to(const float rx, const float ry, const float rz, const_feedRate_t fr_mm_s/*=0.0*/) {
   DEBUG_SECTION(log_move, "do_blocking_move_to", DEBUGGING(LEVELING));
   if (DEBUGGING(LEVELING)) DEBUG_XYZ("> ", rx, ry, rz);
 
@@ -473,38 +473,38 @@ void do_blocking_move_to(const float rx, const float ry, const float rz, const f
   planner.synchronize();
 }
 
-void do_blocking_move_to(const xy_pos_t &raw, const feedRate_t &fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to(const xy_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*/) {
   do_blocking_move_to(raw.x, raw.y, current_position.z, fr_mm_s);
 }
-void do_blocking_move_to(const xyz_pos_t &raw, const feedRate_t &fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to(const xyz_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*/) {
   do_blocking_move_to(raw.x, raw.y, raw.z, fr_mm_s);
 }
-void do_blocking_move_to(const xyze_pos_t &raw, const feedRate_t &fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*/) {
   do_blocking_move_to(raw.x, raw.y, raw.z, fr_mm_s);
 }
 
-void do_blocking_move_to_x(const float &rx, const feedRate_t &fr_mm_s/*=0.0*/) {
+void do_blocking_move_to_x(const_float_t rx, const_feedRate_t fr_mm_s/*=0.0*/) {
   do_blocking_move_to(rx, current_position.y, current_position.z, fr_mm_s);
 }
-void do_blocking_move_to_y(const float &ry, const feedRate_t &fr_mm_s/*=0.0*/) {
+void do_blocking_move_to_y(const_float_t ry, const_feedRate_t fr_mm_s/*=0.0*/) {
   do_blocking_move_to(current_position.x, ry, current_position.z, fr_mm_s);
 }
-void do_blocking_move_to_z(const float &rz, const feedRate_t &fr_mm_s/*=0.0*/) {
+void do_blocking_move_to_z(const_float_t rz, const_feedRate_t fr_mm_s/*=0.0*/) {
   do_blocking_move_to_xy_z(current_position, rz, fr_mm_s);
 }
 
-void do_blocking_move_to_xy(const float &rx, const float &ry, const feedRate_t &fr_mm_s/*=0.0*/) {
+void do_blocking_move_to_xy(const_float_t rx, const_float_t ry, const_feedRate_t fr_mm_s/*=0.0*/) {
   do_blocking_move_to(rx, ry, current_position.z, fr_mm_s);
 }
-void do_blocking_move_to_xy(const xy_pos_t &raw, const feedRate_t &fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to_xy(const xy_pos_t &raw, const_feedRate_t fr_mm_s/*=0.0f*/) {
   do_blocking_move_to_xy(raw.x, raw.y, fr_mm_s);
 }
 
-void do_blocking_move_to_xy_z(const xy_pos_t &raw, const float &z, const feedRate_t &fr_mm_s/*=0.0f*/) {
+void do_blocking_move_to_xy_z(const xy_pos_t &raw, const_float_t z, const_feedRate_t fr_mm_s/*=0.0f*/) {
   do_blocking_move_to(raw.x, raw.y, z, fr_mm_s);
 }
 
-void do_z_clearance(const float &zclear, const bool lower_allowed/*=false*/) {
+void do_z_clearance(const_float_t zclear, const bool lower_allowed/*=false*/) {
   float zdest = zclear;
   if (!lower_allowed) NOLESS(zdest, current_position.z);
   do_blocking_move_to_z(_MIN(zdest, Z_MAX_POS), TERN(HAS_BED_PROBE, z_probe_fast_mm_s, homing_feedrate(Z_AXIS)));
@@ -826,7 +826,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
      * small incremental moves. This allows the planner to
      * apply more detailed bed leveling to the full move.
      */
-    inline void segmented_line_to_destination(const feedRate_t &fr_mm_s, const float segment_size=LEVELED_SEGMENT_LENGTH) {
+    inline void segmented_line_to_destination(const_feedRate_t fr_mm_s, const float segment_size=LEVELED_SEGMENT_LENGTH) {
 
       const xyze_float_t diff = destination - current_position;
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -229,28 +229,28 @@ void sync_plan_position_e();
  * Move the planner to the current position from wherever it last moved
  * (or from wherever it has been told it is located).
  */
-void line_to_current_position(const feedRate_t &fr_mm_s=feedrate_mm_s);
+void line_to_current_position(const_feedRate_t fr_mm_s=feedrate_mm_s);
 
 #if EXTRUDERS
-  void unscaled_e_move(const float &length, const feedRate_t &fr_mm_s);
+  void unscaled_e_move(const_float_t length, const_feedRate_t fr_mm_s);
 #endif
 
 void prepare_line_to_destination();
 
-void _internal_move_to_destination(const feedRate_t &fr_mm_s=0.0f
+void _internal_move_to_destination(const_feedRate_t fr_mm_s=0.0f
   #if IS_KINEMATIC
     , const bool is_fast=false
   #endif
 );
 
-inline void prepare_internal_move_to_destination(const feedRate_t &fr_mm_s=0.0f) {
+inline void prepare_internal_move_to_destination(const_feedRate_t fr_mm_s=0.0f) {
   _internal_move_to_destination(fr_mm_s);
 }
 
 #if IS_KINEMATIC
-  void prepare_fast_move_to_destination(const feedRate_t &scaled_fr_mm_s=MMS_SCALED(feedrate_mm_s));
+  void prepare_fast_move_to_destination(const_feedRate_t scaled_fr_mm_s=MMS_SCALED(feedrate_mm_s));
 
-  inline void prepare_internal_fast_move_to_destination(const feedRate_t &fr_mm_s=0.0f) {
+  inline void prepare_internal_fast_move_to_destination(const_feedRate_t fr_mm_s=0.0f) {
     _internal_move_to_destination(fr_mm_s, true);
   }
 #endif
@@ -258,29 +258,29 @@ inline void prepare_internal_move_to_destination(const feedRate_t &fr_mm_s=0.0f)
 /**
  * Blocking movement and shorthand functions
  */
-void do_blocking_move_to(const float rx, const float ry, const float rz, const feedRate_t &fr_mm_s=0.0f);
-void do_blocking_move_to(const xy_pos_t &raw, const feedRate_t &fr_mm_s=0.0f);
-void do_blocking_move_to(const xyz_pos_t &raw, const feedRate_t &fr_mm_s=0.0f);
-void do_blocking_move_to(const xyze_pos_t &raw, const feedRate_t &fr_mm_s=0.0f);
+void do_blocking_move_to(const float rx, const float ry, const float rz, const_feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to(const xy_pos_t &raw, const_feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to(const xyz_pos_t &raw, const_feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to(const xyze_pos_t &raw, const_feedRate_t fr_mm_s=0.0f);
 
-void do_blocking_move_to_x(const float &rx, const feedRate_t &fr_mm_s=0.0f);
-void do_blocking_move_to_y(const float &ry, const feedRate_t &fr_mm_s=0.0f);
-void do_blocking_move_to_z(const float &rz, const feedRate_t &fr_mm_s=0.0f);
+void do_blocking_move_to_x(const_float_t rx, const_feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to_y(const_float_t ry, const_feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to_z(const_float_t rz, const_feedRate_t fr_mm_s=0.0f);
 
-void do_blocking_move_to_xy(const float &rx, const float &ry, const feedRate_t &fr_mm_s=0.0f);
-void do_blocking_move_to_xy(const xy_pos_t &raw, const feedRate_t &fr_mm_s=0.0f);
-FORCE_INLINE void do_blocking_move_to_xy(const xyz_pos_t &raw, const feedRate_t &fr_mm_s=0.0f)  { do_blocking_move_to_xy(xy_pos_t(raw), fr_mm_s); }
-FORCE_INLINE void do_blocking_move_to_xy(const xyze_pos_t &raw, const feedRate_t &fr_mm_s=0.0f) { do_blocking_move_to_xy(xy_pos_t(raw), fr_mm_s); }
+void do_blocking_move_to_xy(const_float_t rx, const_float_t ry, const_feedRate_t fr_mm_s=0.0f);
+void do_blocking_move_to_xy(const xy_pos_t &raw, const_feedRate_t fr_mm_s=0.0f);
+FORCE_INLINE void do_blocking_move_to_xy(const xyz_pos_t &raw, const_feedRate_t fr_mm_s=0.0f)  { do_blocking_move_to_xy(xy_pos_t(raw), fr_mm_s); }
+FORCE_INLINE void do_blocking_move_to_xy(const xyze_pos_t &raw, const_feedRate_t fr_mm_s=0.0f) { do_blocking_move_to_xy(xy_pos_t(raw), fr_mm_s); }
 
-void do_blocking_move_to_xy_z(const xy_pos_t &raw, const float &z, const feedRate_t &fr_mm_s=0.0f);
-FORCE_INLINE void do_blocking_move_to_xy_z(const xyz_pos_t &raw, const float &z, const feedRate_t &fr_mm_s=0.0f)  { do_blocking_move_to_xy_z(xy_pos_t(raw), z, fr_mm_s); }
-FORCE_INLINE void do_blocking_move_to_xy_z(const xyze_pos_t &raw, const float &z, const feedRate_t &fr_mm_s=0.0f) { do_blocking_move_to_xy_z(xy_pos_t(raw), z, fr_mm_s); }
+void do_blocking_move_to_xy_z(const xy_pos_t &raw, const_float_t z, const_feedRate_t fr_mm_s=0.0f);
+FORCE_INLINE void do_blocking_move_to_xy_z(const xyz_pos_t &raw, const_float_t z, const_feedRate_t fr_mm_s=0.0f)  { do_blocking_move_to_xy_z(xy_pos_t(raw), z, fr_mm_s); }
+FORCE_INLINE void do_blocking_move_to_xy_z(const xyze_pos_t &raw, const_float_t z, const_feedRate_t fr_mm_s=0.0f) { do_blocking_move_to_xy_z(xy_pos_t(raw), z, fr_mm_s); }
 
 void remember_feedrate_and_scaling();
 void remember_feedrate_scaling_off();
 void restore_feedrate_and_scaling();
 
-void do_z_clearance(const float &zclear, const bool lower_allowed=false);
+void do_z_clearance(const_float_t zclear, const bool lower_allowed=false);
 
 /**
  * Homing and Trusted Axes
@@ -393,7 +393,7 @@ FORCE_INLINE bool all_axes_trusted()                        { return xyz_bits ==
   #endif
 
   // Return true if the given point is within the printable area
-  inline bool position_is_reachable(const float &rx, const float &ry, const float inset=0) {
+  inline bool position_is_reachable(const_float_t rx, const_float_t ry, const float inset=0) {
     #if ENABLED(DELTA)
 
       return HYPOT2(rx, ry) <= sq(DELTA_PRINTABLE_RADIUS - inset + fslop);
@@ -428,7 +428,7 @@ FORCE_INLINE bool all_axes_trusted()                        { return xyz_bits ==
 #else // CARTESIAN
 
   // Return true if the given position is within the machine bounds.
-  inline bool position_is_reachable(const float &rx, const float &ry) {
+  inline bool position_is_reachable(const_float_t rx, const_float_t ry) {
     if (!COORDINATE_OKAY(ry, Y_MIN_POS - fslop, Y_MAX_POS + fslop)) return false;
     #if ENABLED(DUAL_X_CARRIAGE)
       if (active_extruder)

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -775,7 +775,7 @@ block_t* Planner::get_current_block() {
  * is not and will not use the block while we modify it, so it is safe to
  * alter its values.
  */
-void Planner::calculate_trapezoid_for_block(block_t * const block, const float &entry_factor, const float &exit_factor) {
+void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t entry_factor, const_float_t exit_factor) {
 
   uint32_t initial_rate = CEIL(block->nominal_rate * entry_factor),
            final_rate = CEIL(block->nominal_rate * exit_factor); // (steps per second)
@@ -1463,7 +1463,7 @@ void Planner::check_axes_activity() {
    * This is the reciprocal of the circular cross-section area.
    * Return 1.0 with volumetric off or a diameter of 0.0.
    */
-  inline float calculate_volumetric_multiplier(const float &diameter) {
+  inline float calculate_volumetric_multiplier(const_float_t diameter) {
     return (parser.volumetric_enabled && diameter) ? 1.0f / CIRCLE_AREA(diameter * 0.5f) : 1;
   }
 
@@ -1745,7 +1745,7 @@ bool Planner::_buffer_steps(const xyze_long_t &target
   #if HAS_DIST_MM_ARG
     , const xyze_float_t &cart_dist_mm
   #endif
-  , feedRate_t fr_mm_s, const uint8_t extruder, const float &millimeters
+  , feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters
 ) {
 
   // Wait for the next available block
@@ -1811,7 +1811,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
   #if HAS_DIST_MM_ARG
     , const xyze_float_t &cart_dist_mm
   #endif
-  , feedRate_t fr_mm_s, const uint8_t extruder, const float &millimeters/*=0.0*/
+  , feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters/*=0.0*/
 ) {
 
   const int32_t da = target.a - position.a,
@@ -2745,11 +2745,11 @@ void Planner::buffer_sync_block(TERN_(LASER_SYNCHRONOUS_M106_M107, uint8_t sync_
  *
  * Return 'false' if no segment was queued due to cleaning, cold extrusion, full queue, etc.
  */
-bool Planner::buffer_segment(const float &a, const float &b, const float &c, const float &e
+bool Planner::buffer_segment(const_float_t a, const_float_t b, const_float_t c, const_float_t e
   #if HAS_DIST_MM_ARG
     , const xyze_float_t &cart_dist_mm
   #endif
-  , const feedRate_t &fr_mm_s, const uint8_t extruder, const float &millimeters/*=0.0*/
+  , const_feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters/*=0.0*/
 ) {
 
   // If we are cleaning, do not accept queuing of movements
@@ -2839,9 +2839,9 @@ bool Planner::buffer_segment(const float &a, const float &b, const float &c, con
  *  millimeters  - the length of the movement, if known
  *  inv_duration - the reciprocal if the duration of the movement, if known (kinematic only if feeedrate scaling is enabled)
  */
-bool Planner::buffer_line(const float &rx, const float &ry, const float &rz, const float &e, const feedRate_t &fr_mm_s, const uint8_t extruder, const float millimeters
+bool Planner::buffer_line(const_float_t rx, const_float_t ry, const_float_t rz, const_float_t e, const_feedRate_t fr_mm_s, const uint8_t extruder, const float millimeters
   #if ENABLED(SCARA_FEEDRATE_SCALING)
-    , const float &inv_duration
+    , const_float_t inv_duration
   #endif
 ) {
   xyze_pos_t machine = { rx, ry, rz, e };
@@ -2960,7 +2960,7 @@ bool Planner::buffer_line(const float &rx, const float &ry, const float &rz, con
  * The provided ABC position is in machine units.
  */
 
-void Planner::set_machine_position_mm(const float &a, const float &b, const float &c, const float &e) {
+void Planner::set_machine_position_mm(const_float_t a, const_float_t b, const_float_t c, const_float_t e) {
   TERN_(DISTINCT_E_FACTORS, last_extruder = active_extruder);
   TERN_(HAS_POSITION_FLOAT, position_float.set(a, b, c, e));
   position.set(LROUND(a * settings.axis_steps_per_mm[A_AXIS]),
@@ -2976,7 +2976,7 @@ void Planner::set_machine_position_mm(const float &a, const float &b, const floa
     stepper.set_position(position);
 }
 
-void Planner::set_position_mm(const float &rx, const float &ry, const float &rz, const float &e) {
+void Planner::set_position_mm(const_float_t rx, const_float_t ry, const_float_t rz, const_float_t e) {
   xyze_pos_t machine = { rx, ry, rz, e };
   #if HAS_POSITION_MODIFIERS
     apply_modifiers(machine, true);
@@ -2993,7 +2993,7 @@ void Planner::set_position_mm(const float &rx, const float &ry, const float &rz,
 /**
  * Setters for planner position (also setting stepper position).
  */
-void Planner::set_e_position_mm(const float &e) {
+void Planner::set_e_position_mm(const_float_t e) {
   const uint8_t axis_index = E_AXIS_N(active_extruder);
   TERN_(DISTINCT_E_FACTORS, last_extruder = active_extruder);
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -491,7 +491,7 @@ class Planner {
     #if HAS_CLASSIC_JERK
       static void set_max_jerk(const AxisEnum axis, float inMaxJerkMMS);
     #else
-      static inline void set_max_jerk(const AxisEnum, const float&) {}
+      static inline void set_max_jerk(const AxisEnum, const_float_t ) {}
     #endif
 
     #if EXTRUDERS
@@ -541,7 +541,7 @@ class Planner {
         static void calculate_volumetric_extruder_limits();
       #endif
 
-      FORCE_INLINE static void set_filament_size(const uint8_t e, const float &v) {
+      FORCE_INLINE static void set_filament_size(const uint8_t e, const_float_t v) {
         filament_size[e] = v;
         if (v > 0) volumetric_area_nominal = CIRCLE_AREA(v * 0.5); //TODO: should it be per extruder
         // make sure all extruders have some sane value for the filament size
@@ -552,7 +552,7 @@ class Planner {
     #endif
 
     #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-      FORCE_INLINE static void set_volumetric_extruder_limit(const uint8_t e, const float &v) {
+      FORCE_INLINE static void set_volumetric_extruder_limit(const uint8_t e, const_float_t v) {
         volumetric_extruder_limit[e] = v;
         calculate_volumetric_extruder_limit(e);
       }
@@ -567,7 +567,7 @@ class Planner {
        *  Returns 1.0 if planner.z_fade_height is 0.0.
        *  Returns 0.0 if Z is past the specified 'Fade Height'.
        */
-      static inline float fade_scaling_factor_for_z(const float &rz) {
+      static inline float fade_scaling_factor_for_z(const_float_t rz) {
         static float z_fade_factor = 1;
         if (!z_fade_height) return 1;
         if (rz >= z_fade_height) return 0;
@@ -580,27 +580,27 @@ class Planner {
 
       FORCE_INLINE static void force_fade_recalc() { last_fade_z = -999.999f; }
 
-      FORCE_INLINE static void set_z_fade_height(const float &zfh) {
+      FORCE_INLINE static void set_z_fade_height(const_float_t zfh) {
         z_fade_height = zfh > 0 ? zfh : 0;
         inverse_z_fade_height = RECIPROCAL(z_fade_height);
         force_fade_recalc();
       }
 
-      FORCE_INLINE static bool leveling_active_at_z(const float &rz) {
+      FORCE_INLINE static bool leveling_active_at_z(const_float_t rz) {
         return !z_fade_height || rz < z_fade_height;
       }
 
     #else
 
-      FORCE_INLINE static float fade_scaling_factor_for_z(const float&) { return 1; }
+      FORCE_INLINE static float fade_scaling_factor_for_z(const_float_t ) { return 1; }
 
-      FORCE_INLINE static bool leveling_active_at_z(const float&) { return true; }
+      FORCE_INLINE static bool leveling_active_at_z(const_float_t ) { return true; }
 
     #endif
 
     #if ENABLED(SKEW_CORRECTION)
 
-      FORCE_INLINE static void skew(float &cx, float &cy, const float &cz) {
+      FORCE_INLINE static void skew(float &cx, float &cy, const_float_t cz) {
         if (COORDINATE_OKAY(cx, X_MIN_POS + 1, X_MAX_POS) && COORDINATE_OKAY(cy, Y_MIN_POS + 1, Y_MAX_POS)) {
           const float sx = cx - cy * skew_factor.xy - cz * (skew_factor.xz - (skew_factor.xy * skew_factor.yz)),
                       sy = cy - cz * skew_factor.yz;
@@ -611,7 +611,7 @@ class Planner {
       }
       FORCE_INLINE static void skew(xyz_pos_t &raw) { skew(raw.x, raw.y, raw.z); }
 
-      FORCE_INLINE static void unskew(float &cx, float &cy, const float &cz) {
+      FORCE_INLINE static void unskew(float &cx, float &cy, const_float_t cz) {
         if (COORDINATE_OKAY(cx, X_MIN_POS, X_MAX_POS) && COORDINATE_OKAY(cy, Y_MIN_POS, Y_MAX_POS)) {
           const float sx = cx + cy * skew_factor.xy + cz * skew_factor.xz,
                       sy = cy + cz * skew_factor.yz;
@@ -713,7 +713,7 @@ class Planner {
       #if HAS_DIST_MM_ARG
         , const xyze_float_t &cart_dist_mm
       #endif
-      , feedRate_t fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
+      , feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters=0.0
     );
 
     /**
@@ -736,7 +736,7 @@ class Planner {
       #if HAS_DIST_MM_ARG
         , const xyze_float_t &cart_dist_mm
       #endif
-      , feedRate_t fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
+      , feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters=0.0
     );
 
     /**
@@ -767,18 +767,18 @@ class Planner {
      *  extruder    - target extruder
      *  millimeters - the length of the movement, if known
      */
-    static bool buffer_segment(const float &a, const float &b, const float &c, const float &e
+    static bool buffer_segment(const_float_t a, const_float_t b, const_float_t c, const_float_t e
       #if HAS_DIST_MM_ARG
         , const xyze_float_t &cart_dist_mm
       #endif
-      , const feedRate_t &fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
+      , const_feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters=0.0
     );
 
     FORCE_INLINE static bool buffer_segment(abce_pos_t &abce
       #if HAS_DIST_MM_ARG
         , const xyze_float_t &cart_dist_mm
       #endif
-      , const feedRate_t &fr_mm_s, const uint8_t extruder, const float &millimeters=0.0
+      , const_feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters=0.0
     ) {
       return buffer_segment(abce.a, abce.b, abce.c, abce.e
         #if HAS_DIST_MM_ARG
@@ -800,15 +800,15 @@ class Planner {
      *  millimeters  - the length of the movement, if known
      *  inv_duration - the reciprocal if the duration of the movement, if known (kinematic only if feeedrate scaling is enabled)
      */
-    static bool buffer_line(const float &rx, const float &ry, const float &rz, const float &e, const feedRate_t &fr_mm_s, const uint8_t extruder, const float millimeters=0.0
+    static bool buffer_line(const_float_t rx, const_float_t ry, const_float_t rz, const_float_t e, const_feedRate_t fr_mm_s, const uint8_t extruder, const float millimeters=0.0
       #if ENABLED(SCARA_FEEDRATE_SCALING)
-        , const float &inv_duration=0.0
+        , const_float_t inv_duration=0.0
       #endif
     );
 
-    FORCE_INLINE static bool buffer_line(const xyze_pos_t &cart, const feedRate_t &fr_mm_s, const uint8_t extruder, const float millimeters=0.0
+    FORCE_INLINE static bool buffer_line(const xyze_pos_t &cart, const_feedRate_t fr_mm_s, const uint8_t extruder, const float millimeters=0.0
       #if ENABLED(SCARA_FEEDRATE_SCALING)
-        , const float &inv_duration=0.0
+        , const_float_t inv_duration=0.0
       #endif
     ) {
       return buffer_line(cart.x, cart.y, cart.z, cart.e, fr_mm_s, extruder, millimeters
@@ -835,9 +835,9 @@ class Planner {
      *
      * Clears previous speed values.
      */
-    static void set_position_mm(const float &rx, const float &ry, const float &rz, const float &e);
+    static void set_position_mm(const_float_t rx, const_float_t ry, const_float_t rz, const_float_t e);
     FORCE_INLINE static void set_position_mm(const xyze_pos_t &cart) { set_position_mm(cart.x, cart.y, cart.z, cart.e); }
-    static void set_e_position_mm(const float &e);
+    static void set_e_position_mm(const_float_t e);
 
     /**
      * Set the planner.position and individual stepper positions.
@@ -845,7 +845,7 @@ class Planner {
      * The supplied position is in machine space, and no additional
      * conversions are applied.
      */
-    static void set_machine_position_mm(const float &a, const float &b, const float &c, const float &e);
+    static void set_machine_position_mm(const_float_t a, const_float_t b, const_float_t c, const_float_t e);
     FORCE_INLINE static void set_machine_position_mm(const abce_pos_t &abce) { set_machine_position_mm(abce.a, abce.b, abce.c, abce.e); }
 
     /**
@@ -957,7 +957,7 @@ class Planner {
      * Calculate the distance (not time) it takes to accelerate
      * from initial_rate to target_rate using the given acceleration:
      */
-    static float estimate_acceleration_distance(const float &initial_rate, const float &target_rate, const float &accel) {
+    static float estimate_acceleration_distance(const_float_t initial_rate, const_float_t target_rate, const_float_t accel) {
       if (accel == 0) return 0; // accel was 0, set acceleration distance to 0
       return (sq(target_rate) - sq(initial_rate)) / (accel * 2);
     }
@@ -970,7 +970,7 @@ class Planner {
      * This is used to compute the intersection point between acceleration and deceleration
      * in cases where the "trapezoid" has no plateau (i.e., never reaches maximum speed)
      */
-    static float intersection_distance(const float &initial_rate, const float &final_rate, const float &accel, const float &distance) {
+    static float intersection_distance(const_float_t initial_rate, const_float_t final_rate, const_float_t accel, const_float_t distance) {
       if (accel == 0) return 0; // accel was 0, set intersection distance to 0
       return (accel * 2 * distance - sq(initial_rate) + sq(final_rate)) / (accel * 4);
     }
@@ -980,7 +980,7 @@ class Planner {
      * to reach 'target_velocity_sqr' using 'acceleration' within a given
      * 'distance'.
      */
-    static float max_allowable_speed_sqr(const float &accel, const float &target_velocity_sqr, const float &distance) {
+    static float max_allowable_speed_sqr(const_float_t accel, const_float_t target_velocity_sqr, const_float_t distance) {
       return target_velocity_sqr - 2 * accel * distance;
     }
 
@@ -988,12 +988,12 @@ class Planner {
       /**
        * Calculate the speed reached given initial speed, acceleration and distance
        */
-      static float final_speed(const float &initial_velocity, const float &accel, const float &distance) {
+      static float final_speed(const_float_t initial_velocity, const_float_t accel, const_float_t distance) {
         return SQRT(sq(initial_velocity) + 2 * accel * distance);
       }
     #endif
 
-    static void calculate_trapezoid_for_block(block_t * const block, const float &entry_factor, const float &exit_factor);
+    static void calculate_trapezoid_for_block(block_t * const block, const_float_t entry_factor, const_float_t exit_factor);
 
     static void reverse_pass_kernel(block_t * const current, const block_t * const next);
     static void forward_pass_kernel(const block_t * const previous, block_t * const current, uint8_t block_index);
@@ -1013,7 +1013,7 @@ class Planner {
         vector *= RSQRT(magnitude_sq);
       }
 
-      FORCE_INLINE static float limit_value_by_axis_maximum(const float &max_value, xyze_float_t &unit_vec) {
+      FORCE_INLINE static float limit_value_by_axis_maximum(const_float_t max_value, xyze_float_t &unit_vec) {
         float limit_value = max_value;
         LOOP_XYZE(idx) {
           if (unit_vec[idx]) {

--- a/Marlin/src/module/planner_bezier.cpp
+++ b/Marlin/src/module/planner_bezier.cpp
@@ -43,7 +43,7 @@
 #define SIGMA 0.1f
 
 // Compute the linear interpolation between two real numbers.
-static inline float interp(const float &a, const float &b, const float &t) { return (1 - t) * a + t * b; }
+static inline float interp(const_float_t a, const_float_t b, const_float_t t) { return (1 - t) * a + t * b; }
 
 /**
  * Compute a Bézier curve using the De Casteljau's algorithm (see
@@ -51,7 +51,7 @@ static inline float interp(const float &a, const float &b, const float &t) { ret
  * easy to code and has good numerical stability (very important,
  * since Arudino works with limited precision real numbers).
  */
-static inline float eval_bezier(const float &a, const float &b, const float &c, const float &d, const float &t) {
+static inline float eval_bezier(const_float_t a, const_float_t b, const_float_t c, const_float_t d, const_float_t t) {
   const float iab = interp(a, b, t),
               ibc = interp(b, c, t),
               icd = interp(c, d, t),
@@ -64,7 +64,7 @@ static inline float eval_bezier(const float &a, const float &b, const float &c, 
  * We approximate Euclidean distance with the sum of the coordinates
  * offset (so-called "norm 1"), which is quicker to compute.
  */
-static inline float dist1(const float &x1, const float &y1, const float &x2, const float &y2) { return ABS(x1 - x2) + ABS(y1 - y2); }
+static inline float dist1(const_float_t x1, const_float_t y1, const_float_t x2, const_float_t y2) { return ABS(x1 - x2) + ABS(y1 - y2); }
 
 /**
  * The algorithm for computing the step is loosely based on the one in Kig
@@ -109,7 +109,7 @@ void cubic_b_spline(
   const xyze_pos_t &position,       // current position
   const xyze_pos_t &target,         // target position
   const xy_pos_t (&offsets)[2],     // a pair of offsets
-  const feedRate_t &scaled_fr_mm_s, // mm/s scaled by feedrate %
+  const_feedRate_t scaled_fr_mm_s,  // mm/s scaled by feedrate %
   const uint8_t extruder
 ) {
   // Absolute first and second control points are recovered.

--- a/Marlin/src/module/planner_bezier.h
+++ b/Marlin/src/module/planner_bezier.h
@@ -33,6 +33,6 @@ void cubic_b_spline(
   const xyze_pos_t &position,       // current position
   const xyze_pos_t &target,         // target position
   const xy_pos_t (&offsets)[2],     // a pair of offsets
-  const feedRate_t &scaled_fr_mm_s, // mm/s scaled by feedrate %
+  const_feedRate_t scaled_fr_mm_s,  // mm/s scaled by feedrate %
   const uint8_t extruder
 );

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -475,7 +475,7 @@ bool Probe::set_deployed(const bool deploy) {
  *
  * @return TRUE if the probe failed to trigger.
  */
-bool Probe::probe_down_to_z(const float z, const feedRate_t fr_mm_s) {
+bool Probe::probe_down_to_z(const_float_t z, const_feedRate_t fr_mm_s) {
   DEBUG_SECTION(log_probe, "Probe::probe_down_to_z", DEBUGGING(LEVELING));
 
   #if BOTH(HAS_HEATED_BED, WAIT_FOR_BED_HEATER)
@@ -588,7 +588,7 @@ bool Probe::probe_down_to_z(const float z, const feedRate_t fr_mm_s) {
 float Probe::run_z_probe(const bool sanity_check/*=true*/) {
   DEBUG_SECTION(log_probe, "Probe::run_z_probe", DEBUGGING(LEVELING));
 
-  auto try_to_probe = [&](PGM_P const plbl, const float &z_probe_low_point, const feedRate_t fr_mm_s, const bool scheck, const float clearance) -> bool {
+  auto try_to_probe = [&](PGM_P const plbl, const_float_t z_probe_low_point, const feedRate_t fr_mm_s, const bool scheck, const float clearance) -> bool {
     // Tare the probe, if supported
     if (TERN0(PROBE_TARE, tare())) return true;
 
@@ -743,7 +743,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
  *   - Raise to the BETWEEN height
  * - Return the probed Z position
  */
-float Probe::probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after/*=PROBE_PT_NONE*/, const uint8_t verbose_level/*=0*/, const bool probe_relative/*=true*/, const bool sanity_check/*=true*/) {
+float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRaise raise_after/*=PROBE_PT_NONE*/, const uint8_t verbose_level/*=0*/, const bool probe_relative/*=true*/, const bool sanity_check/*=true*/) {
   DEBUG_SECTION(log_probe, "Probe::probe_at_point", DEBUGGING(LEVELING));
 
   if (DEBUGGING(LEVELING)) {

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -71,12 +71,12 @@ public:
       #if HAS_PROBE_XY_OFFSET
         // Return true if the both nozzle and the probe can reach the given point.
         // Note: This won't work on SCARA since the probe offset rotates with the arm.
-        static bool can_reach(const float &rx, const float &ry) {
+        static bool can_reach(const_float_t rx, const_float_t ry) {
           return position_is_reachable(rx - offset_xy.x, ry - offset_xy.y) // The nozzle can go where it needs to go?
               && position_is_reachable(rx, ry, ABS(PROBING_MARGIN));       // Can the nozzle also go near there?
         }
       #else
-        static bool can_reach(const float &rx, const float &ry) {
+        static bool can_reach(const_float_t rx, const_float_t ry) {
           return position_is_reachable(rx, ry, PROBING_MARGIN);
         }
       #endif
@@ -90,7 +90,7 @@ public:
        * Example: For a probe offset of -10,+10, then for the probe to reach 0,0 the
        *          nozzle must be be able to reach +10,-10.
        */
-      static bool can_reach(const float &rx, const float &ry) {
+      static bool can_reach(const_float_t rx, const_float_t ry) {
         return position_is_reachable(rx - offset_xy.x, ry - offset_xy.y)
             && COORDINATE_OKAY(rx, min_x() - fslop, max_x() + fslop)
             && COORDINATE_OKAY(ry, min_y() - fslop, max_y() + fslop);
@@ -103,7 +103,7 @@ public:
         do_z_clearance(Z_AFTER_PROBING, true); // Move down still permitted
       #endif
     }
-    static float probe_at_point(const float &rx, const float &ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true);
+    static float probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true);
     static float probe_at_point(const xy_pos_t &pos, const ProbePtRaise raise_after=PROBE_PT_NONE, const uint8_t verbose_level=0, const bool probe_relative=true, const bool sanity_check=true) {
       return probe_at_point(pos.x, pos.y, raise_after, verbose_level, probe_relative, sanity_check);
     }
@@ -114,7 +114,7 @@ public:
 
     static bool set_deployed(const bool) { return false; }
 
-    static bool can_reach(const float &rx, const float &ry) { return position_is_reachable(rx, ry); }
+    static bool can_reach(const_float_t rx, const_float_t ry) { return position_is_reachable(rx, ry); }
 
   #endif
 
@@ -257,7 +257,7 @@ public:
   #endif
 
 private:
-  static bool probe_down_to_z(const float z, const feedRate_t fr_mm_s);
+  static bool probe_down_to_z(const_float_t z, const_feedRate_t fr_mm_s);
   static void do_z_raise(const float z_raise);
   static float run_z_probe(const bool sanity_check=true);
 };

--- a/Marlin/src/module/scara.cpp
+++ b/Marlin/src/module/scara.cpp
@@ -48,7 +48,7 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
    * Maths and first version by QHARLEY.
    * Integrated into Marlin and slightly restructured by Joachim Cerny.
    */
-  void forward_kinematics(const float &a, const float &b) {
+  void forward_kinematics(const_float_t a, const_float_t b) {
     const float a_sin = sin(RADIANS(a)) * L1,
                 a_cos = cos(RADIANS(a)) * L1,
                 b_sin = sin(RADIANS(b + TERN0(MP_SCARA, a))) * L2,
@@ -197,7 +197,7 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
   }
 
   // Convert ABC inputs in degrees to XYZ outputs in mm
-  void forward_kinematics(const float &a, const float &b, const float &c) {
+  void forward_kinematics(const_float_t a, const_float_t b, const_float_t c) {
     const float w = c - b,
                 r = L1 * cos(RADIANS(b)) + L2 * sin(RADIANS(w - (90 - b))),
                 x = r  * cos(RADIANS(a)),

--- a/Marlin/src/module/scara.h
+++ b/Marlin/src/module/scara.h
@@ -35,7 +35,7 @@ extern float segments_per_second;
                   L1_2 = sq(float(L1)), L1_2_2 = 2.0 * L1_2,
                   L2_2 = sq(float(L2));
 
-  void forward_kinematics(const float &a, const float &b, const float &c);
+  void forward_kinematics(const_float_t a, const_float_t b, const_float_t c);
   void home_TPARA();
 
 #else
@@ -44,7 +44,7 @@ extern float segments_per_second;
                   L1_2 = sq(float(L1)), L1_2_2 = 2.0 * L1_2,
                   L2_2 = sq(float(L2));
 
-  void forward_kinematics(const float &a, const float &b);
+  void forward_kinematics(const_float_t a, const_float_t b);
 
 #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -499,7 +499,7 @@ volatile bool Temperature::raw_temps_ready = false;
    * Needs sufficient heater power to make some overshoot at target
    * temperature to succeed.
    */
-  void Temperature::PID_autotune(const float &target, const heater_id_t heater_id, const int8_t ncycles, const bool set_result/*=false*/) {
+  void Temperature::PID_autotune(const_float_t target, const heater_id_t heater_id, const int8_t ncycles, const bool set_result/*=false*/) {
     float current_temp = 0.0;
     int cycles = 0;
     bool heating = true;
@@ -2336,7 +2336,7 @@ void Temperature::init() {
    *
    * TODO: Embed the last 3 parameters during init, if not less optimal
    */
-  void Temperature::tr_state_machine_t::run(const float &current, const float &target, const heater_id_t heater_id, const uint16_t period_seconds, const celsius_t hysteresis_degc) {
+  void Temperature::tr_state_machine_t::run(const_float_t current, const_float_t target, const heater_id_t heater_id, const uint16_t period_seconds, const celsius_t hysteresis_degc) {
 
     #if HEATER_IDLE_HANDLER
       // Convert the given heater_id_t to an idle array index
@@ -3371,7 +3371,7 @@ void Temperature::tick() {
 
   #include "../gcode/gcode.h"
 
-  static void print_heater_state(const float &c, const float &t
+  static void print_heater_state(const_float_t c, const_float_t t
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       , const float r
     #endif
@@ -3804,7 +3804,7 @@ void Temperature::tick() {
       #define MIN_DELTA_SLOPE_TIME_PROBE 600
     #endif
 
-    bool Temperature::wait_for_probe(const float target_temp, bool no_wait_for_cooling/*=true*/) {
+    bool Temperature::wait_for_probe(const_float_t target_temp, bool no_wait_for_cooling/*=true*/) {
 
       const bool wants_to_cool = isProbeAboveTemp(target_temp);
       const bool will_wait = !(wants_to_cool && no_wait_for_cooling);

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -688,7 +688,7 @@ class Temperature {
         return degTargetHotend(e) > TEMP_HYSTERESIS && ABS(degHotend(e) - degTargetHotend(e)) > TEMP_HYSTERESIS;
       }
 
-      FORCE_INLINE static bool degHotendNear(const uint8_t e, const float &temp) {
+      FORCE_INLINE static bool degHotendNear(const uint8_t e, const_float_t temp) {
         return ABS(degHotend(e) - temp) < (TEMP_HYSTERESIS);
       }
 
@@ -724,7 +724,7 @@ class Temperature {
 
       static void wait_for_bed_heating();
 
-      FORCE_INLINE static bool degBedNear(const float &temp) {
+      FORCE_INLINE static bool degBedNear(const_float_t temp) {
         return ABS(degBed() - temp) < (TEMP_BED_HYSTERESIS);
       }
 
@@ -735,9 +735,9 @@ class Temperature {
         FORCE_INLINE static int16_t rawProbeTemp()    { return temp_probe.raw; }
       #endif
       FORCE_INLINE static float degProbe()            { return temp_probe.celsius; }
-      FORCE_INLINE static bool isProbeBelowTemp(const float target_temp) { return temp_probe.celsius < target_temp; }
-      FORCE_INLINE static bool isProbeAboveTemp(const float target_temp) { return temp_probe.celsius > target_temp; }
-      static bool wait_for_probe(const float target_temp, bool no_wait_for_cooling=true);
+      FORCE_INLINE static bool isProbeBelowTemp(const_float_t target_temp) { return temp_probe.celsius < target_temp; }
+      FORCE_INLINE static bool isProbeAboveTemp(const_float_t target_temp) { return temp_probe.celsius > target_temp; }
+      static bool wait_for_probe(const_float_t target_temp, bool no_wait_for_cooling=true);
     #endif
 
     #if WATCH_PROBE
@@ -825,7 +825,7 @@ class Temperature {
         static bool pid_debug_flag;
       #endif
 
-      static void PID_autotune(const float &target, const heater_id_t heater_id, const int8_t ncycles, const bool set_result=false);
+      static void PID_autotune(const_float_t target, const heater_id_t heater_id, const int8_t ncycles, const bool set_result=false);
 
       #if ENABLED(NO_FAN_SLOWING_IN_PID_TUNING)
         static bool adaptive_fan_slowing;
@@ -959,7 +959,7 @@ class Temperature {
         millis_t timer = 0;
         TRState state = TRInactive;
         float running_temp;
-        void run(const float &current, const float &target, const heater_id_t heater_id, const uint16_t period_seconds, const celsius_t hysteresis_degc);
+        void run(const_float_t current, const_float_t target, const heater_id_t heater_id, const uint16_t period_seconds, const celsius_t hysteresis_degc);
       } tr_state_machine_t;
 
       static tr_state_machine_t tr_state_machine[NR_HEATER_RUNAWAY];


### PR DESCRIPTION
On AVR it is smaller … and maybe faster … to pass `float` arguments as `const float &`. Since this is only useful for 8-bit (AVR) platforms, this PR replaces the explicit use of `const float &` with an adapting "type" macro, `const_float_t`. The same might be done for some `long` / `unsigned long` / `int32_t` / `uint32_t` types, but these aren't too common.