### PR TITLE
update FLSUN_HISPEED env to flsun_hispeedv1

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -551,7 +551,7 @@
 #elif MB(FLY_MINI)
   #include "stm32f1/pins_FLY_MINI.h"            // STM32F1                                env:FLY_MINI
 #elif MB(FLSUN_HISPEED)
-  #include "stm32f1/pins_FLSUN_HISPEED.h"       // STM32F1                                env:flsun_hispeed
+  #include "stm32f1/pins_FLSUN_HISPEED.h"       // STM32F1                                env:flsun_hispeedv1
 #elif MB(BEAST)
   #include "stm32f1/pins_BEAST.h"               // STM32F1                                env:STM32F103RE
 #elif MB(MINGDA_MPX_ARM_MINI)


### PR DESCRIPTION
### Description

https://github.com/MarlinFirmware/Marlin/pull/20354 renamed env:flsun_hispeed to env:flsun_hispeedv1 but did not update pins.h so preflight tests fail.

updated pins.h with new name

### Requirements

BOARD_FLSUN_HISPEED

### Benefits

Passes preflight tests 

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/21508