### PR TITLE
Update display timing defaults for AVR boards

### DIFF
--- a/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
+++ b/Marlin/src/lcd/dogm/ultralcd_st7920_u8glib_rrd_AVR.cpp
@@ -34,9 +34,9 @@
 #include "ultralcd_st7920_u8glib_rrd_AVR.h"
 
 #if F_CPU >= 20000000
-  #define CPU_ST7920_DELAY_1 DELAY_NS(0)
+  #define CPU_ST7920_DELAY_1 DELAY_NS(150)
   #define CPU_ST7920_DELAY_2 DELAY_NS(0)
-  #define CPU_ST7920_DELAY_3 DELAY_NS(50)
+  #define CPU_ST7920_DELAY_3 DELAY_NS(150)
 #elif MB(3DRAG, K8200, K8400)
   #define CPU_ST7920_DELAY_1 DELAY_NS(0)
   #define CPU_ST7920_DELAY_2 DELAY_NS(188)
@@ -58,9 +58,9 @@
   #define CPU_ST7920_DELAY_2 DELAY_NS(40)
   #define CPU_ST7920_DELAY_3 DELAY_NS(340)
 #elif F_CPU == 16000000
-  #define CPU_ST7920_DELAY_1 DELAY_NS(0)
+  #define CPU_ST7920_DELAY_1 DELAY_NS(125)
   #define CPU_ST7920_DELAY_2 DELAY_NS(0)
-  #define CPU_ST7920_DELAY_3 DELAY_NS(63)
+  #define CPU_ST7920_DELAY_3 DELAY_NS(125)
 #else
   #error "No valid condition for delays in 'ultralcd_st7920_u8glib_rrd_AVR.h'"
 #endif


### PR DESCRIPTION
### Description

Fixes garbled text caused by incorrect display timing on AVR boards. Most likely caused by [a compiler change](https://github.com/MarlinFirmware/Marlin/issues/21264#issuecomment-804458963) in the platformIO toolchain.

### Requirements

AVR board using `REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER` or another UltraLCD/ST7920 display unit relying on default timings. Changes for 16 MHz AVR tested on RAMPS 1.44, changes for 20+ MHz AVR are a best guess and untested.

### Benefits

Correct display output.

### Configurations

None.

### Related Issues

Fixes #21495
