### PR TITLE
Option to current scale with VREF on TMC2208/9

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2425,26 +2425,11 @@
    */
   #define INTERPOLATE      true
 
-  /**
-   * Use the VREF input voltage as reference for TMC22xx currents.
-   * Any voltage under 2.5V limits the maximum current the driver will deliver
-   * with this enabled, and gives higher resolution steps for current control
-   * from within Marlin.
-   * 
-   * If not enabled, the default reference of 2.5V within the driver is used.
-   */
-  #if HAS_I_SCALE_ANALOG
-    //#define USE_VREF_FOR_SCALING
-  #endif
-
   #if AXIS_IS_TMC(X)
     #define X_CURRENT       800        // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_CURRENT_HOME  X_CURRENT  // (mA) RMS current for sensorless homing
     #define X_MICROSTEPS     16        // 0..256
     #define X_RSENSE          0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(X)
-      #define X_VREF          2.5
-    #endif
     #define X_CHAIN_POS      -1        // -1..0: Not chained. 1: MCU MOSI connected. 2: Next in chain, ...
     //#define X_INTERPOLATE  true      // Enable to override 'INTERPOLATE' for the X axis
   #endif
@@ -2454,9 +2439,6 @@
     #define X2_CURRENT_HOME X2_CURRENT
     #define X2_MICROSTEPS    X_MICROSTEPS
     #define X2_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(X2)
-      #define X2_VREF         2.5
-    #endif
     #define X2_CHAIN_POS     -1
     //#define X2_INTERPOLATE true
   #endif
@@ -2466,9 +2448,6 @@
     #define Y_CURRENT_HOME  Y_CURRENT
     #define Y_MICROSTEPS     16
     #define Y_RSENSE          0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(Y)
-      #define Y_VREF          2.5
-    #endif
     #define Y_CHAIN_POS      -1
     //#define Y_INTERPOLATE  true
   #endif
@@ -2478,9 +2457,6 @@
     #define Y2_CURRENT_HOME Y2_CURRENT
     #define Y2_MICROSTEPS    Y_MICROSTEPS
     #define Y2_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(Y2)
-      #define Y2_VREF         2.5
-    #endif
     #define Y2_CHAIN_POS     -1
     //#define Y2_INTERPOLATE true
   #endif
@@ -2490,9 +2466,6 @@
     #define Z_CURRENT_HOME  Z_CURRENT
     #define Z_MICROSTEPS     16
     #define Z_RSENSE          0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(Z)
-      #define Z_VREF          2.5
-    #endif
     #define Z_CHAIN_POS      -1
     //#define Z_INTERPOLATE  true
   #endif
@@ -2502,9 +2475,6 @@
     #define Z2_CURRENT_HOME Z2_CURRENT
     #define Z2_MICROSTEPS    Z_MICROSTEPS
     #define Z2_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(Z2)
-      #define Z2_VREF         2.5
-    #endif
     #define Z2_CHAIN_POS     -1
     //#define Z2_INTERPOLATE true
   #endif
@@ -2514,9 +2484,6 @@
     #define Z3_CURRENT_HOME Z3_CURRENT
     #define Z3_MICROSTEPS    Z_MICROSTEPS
     #define Z3_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(Z3)
-      #define Z3_VREF         2.5
-    #endif
     #define Z3_CHAIN_POS     -1
     //#define Z3_INTERPOLATE true
   #endif
@@ -2526,9 +2493,6 @@
     #define Z4_CURRENT_HOME Z4_CURRENT
     #define Z4_MICROSTEPS    Z_MICROSTEPS
     #define Z4_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(Z4)
-      #define Z4_VREF         2.5
-    #endif
     #define Z4_CHAIN_POS     -1
     //#define Z4_INTERPOLATE true
   #endif
@@ -2537,9 +2501,6 @@
     #define E0_CURRENT      800
     #define E0_MICROSTEPS    16
     #define E0_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(E0)
-      #define E0_VREF         2.5
-    #endif
     #define E0_CHAIN_POS     -1
     //#define E0_INTERPOLATE true
   #endif
@@ -2548,9 +2509,6 @@
     #define E1_CURRENT      800
     #define E1_MICROSTEPS   E0_MICROSTEPS
     #define E1_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(E1)
-      #define E1_VREF         2.5
-    #endif
     #define E1_CHAIN_POS     -1
     //#define E1_INTERPOLATE true
   #endif
@@ -2559,9 +2517,6 @@
     #define E2_CURRENT      800
     #define E2_MICROSTEPS   E0_MICROSTEPS
     #define E2_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(E2)
-      #define E2_VREF         2.5
-    #endif
     #define E2_CHAIN_POS     -1
     //#define E2_INTERPOLATE true
   #endif
@@ -2570,9 +2525,6 @@
     #define E3_CURRENT      800
     #define E3_MICROSTEPS   E0_MICROSTEPS
     #define E3_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(E3)
-      #define E3_VREF         2.5
-    #endif
     #define E3_CHAIN_POS     -1
     //#define E3_INTERPOLATE true
   #endif
@@ -2581,9 +2533,6 @@
     #define E4_CURRENT      800
     #define E4_MICROSTEPS   E0_MICROSTEPS
     #define E4_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(E4)
-      #define E4_VREF         2.5
-    #endif
     #define E4_CHAIN_POS     -1
     //#define E4_INTERPOLATE true
   #endif
@@ -2592,9 +2541,6 @@
     #define E5_CURRENT      800
     #define E5_MICROSTEPS   E0_MICROSTEPS
     #define E5_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(E5)
-      #define E5_VREF         2.5
-    #endif
     #define E5_CHAIN_POS     -1
     //#define E5_INTERPOLATE true
   #endif
@@ -2603,9 +2549,6 @@
     #define E6_CURRENT      800
     #define E6_MICROSTEPS   E0_MICROSTEPS
     #define E6_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(E6)
-      #define E6_VREF         2.5
-    #endif
     #define E6_CHAIN_POS     -1
     //#define E6_INTERPOLATE true
   #endif
@@ -2614,9 +2557,6 @@
     #define E7_CURRENT      800
     #define E7_MICROSTEPS   E0_MICROSTEPS
     #define E7_RSENSE         0.11
-    #if AXIS_HAS_I_SCALE_ANALOG(E7)
-      #define E7_VREF         2.5
-    #endif
     #define E7_CHAIN_POS     -1
     //#define E7_INTERPOLATE true
   #endif
@@ -2687,6 +2627,39 @@
    * function through a communication line such as SPI or UART.
    */
   //#define SOFTWARE_DRIVER_ENABLE
+
+  /**
+   * VREF current scaling (TMC2208, TMC2209 only)
+   * 
+   * Use the VREF input voltage as reference for TMC22xx currents.
+   * Any voltage under 2.5V limits the maximum current the driver will deliver
+   * with this enabled, and gives higher resolution steps for current control
+   * from within Marlin.
+   * 
+   * If not enabled, the default reference of 2.5V within the driver is used.
+   */
+  #if HAS_I_SCALE_ANALOG
+    //#define USE_VREF_FOR_SCALING
+
+    #if ENABLED(USE_VREF_FOR_SCALING)
+      #define  X_VREF 2.5
+      #define  Y_VREF 2.5
+      #define  Z_VREF 2.5
+      #define X2_VREF 2.5
+      #define Y2_VREF 2.5
+      #define Z2_VREF 2.5
+      #define Z3_VREF 2.5
+      #define Z4_VREF 2.5
+      #define E0_VREF 2.5
+      #define E1_VREF 2.5
+      #define E2_VREF 2.5
+      #define E3_VREF 2.5
+      #define E4_VREF 2.5
+      #define E5_VREF 2.5
+      #define E6_VREF 2.5
+      #define E7_VREF 2.5
+    #endif
+  #endif
 
   /**
    * TMC2130, TMC2160, TMC2208, TMC2209, TMC5130 and TMC5160 only

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2425,11 +2425,26 @@
    */
   #define INTERPOLATE      true
 
+  /**
+   * Use the VREF input voltage as reference for TMC22xx currents.
+   * Any voltage under 2.5V limits the maximum current the driver will deliver
+   * with this enabled, and gives higher resolution steps for current control
+   * from within Marlin.
+   * 
+   * If not enabled, the default reference of 2.5V within the driver is used.
+   */
+  #if HAS_I_SCALE_ANALOG
+    //#define USE_VREF_FOR_SCALING
+  #endif
+
   #if AXIS_IS_TMC(X)
     #define X_CURRENT       800        // (mA) RMS current. Multiply by 1.414 for peak current.
     #define X_CURRENT_HOME  X_CURRENT  // (mA) RMS current for sensorless homing
     #define X_MICROSTEPS     16        // 0..256
     #define X_RSENSE          0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(X)
+      #define X_VREF          2.5
+    #endif
     #define X_CHAIN_POS      -1        // -1..0: Not chained. 1: MCU MOSI connected. 2: Next in chain, ...
     //#define X_INTERPOLATE  true      // Enable to override 'INTERPOLATE' for the X axis
   #endif
@@ -2439,6 +2454,9 @@
     #define X2_CURRENT_HOME X2_CURRENT
     #define X2_MICROSTEPS    X_MICROSTEPS
     #define X2_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(X2)
+      #define X2_VREF         2.5
+    #endif
     #define X2_CHAIN_POS     -1
     //#define X2_INTERPOLATE true
   #endif
@@ -2448,6 +2466,9 @@
     #define Y_CURRENT_HOME  Y_CURRENT
     #define Y_MICROSTEPS     16
     #define Y_RSENSE          0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(Y)
+      #define Y_VREF          2.5
+    #endif
     #define Y_CHAIN_POS      -1
     //#define Y_INTERPOLATE  true
   #endif
@@ -2457,6 +2478,9 @@
     #define Y2_CURRENT_HOME Y2_CURRENT
     #define Y2_MICROSTEPS    Y_MICROSTEPS
     #define Y2_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(Y2)
+      #define Y2_VREF         2.5
+    #endif
     #define Y2_CHAIN_POS     -1
     //#define Y2_INTERPOLATE true
   #endif
@@ -2466,6 +2490,9 @@
     #define Z_CURRENT_HOME  Z_CURRENT
     #define Z_MICROSTEPS     16
     #define Z_RSENSE          0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(Z)
+      #define Z_VREF          2.5
+    #endif
     #define Z_CHAIN_POS      -1
     //#define Z_INTERPOLATE  true
   #endif
@@ -2475,6 +2502,9 @@
     #define Z2_CURRENT_HOME Z2_CURRENT
     #define Z2_MICROSTEPS    Z_MICROSTEPS
     #define Z2_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(Z2)
+      #define Z2_VREF         2.5
+    #endif
     #define Z2_CHAIN_POS     -1
     //#define Z2_INTERPOLATE true
   #endif
@@ -2484,6 +2514,9 @@
     #define Z3_CURRENT_HOME Z3_CURRENT
     #define Z3_MICROSTEPS    Z_MICROSTEPS
     #define Z3_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(Z3)
+      #define Z3_VREF         2.5
+    #endif
     #define Z3_CHAIN_POS     -1
     //#define Z3_INTERPOLATE true
   #endif
@@ -2493,6 +2526,9 @@
     #define Z4_CURRENT_HOME Z4_CURRENT
     #define Z4_MICROSTEPS    Z_MICROSTEPS
     #define Z4_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(Z4)
+      #define Z4_VREF         2.5
+    #endif
     #define Z4_CHAIN_POS     -1
     //#define Z4_INTERPOLATE true
   #endif
@@ -2501,6 +2537,9 @@
     #define E0_CURRENT      800
     #define E0_MICROSTEPS    16
     #define E0_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(E0)
+      #define E0_VREF         2.5
+    #endif
     #define E0_CHAIN_POS     -1
     //#define E0_INTERPOLATE true
   #endif
@@ -2509,6 +2548,9 @@
     #define E1_CURRENT      800
     #define E1_MICROSTEPS   E0_MICROSTEPS
     #define E1_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(E1)
+      #define E1_VREF         2.5
+    #endif
     #define E1_CHAIN_POS     -1
     //#define E1_INTERPOLATE true
   #endif
@@ -2517,6 +2559,9 @@
     #define E2_CURRENT      800
     #define E2_MICROSTEPS   E0_MICROSTEPS
     #define E2_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(E2)
+      #define E2_VREF         2.5
+    #endif
     #define E2_CHAIN_POS     -1
     //#define E2_INTERPOLATE true
   #endif
@@ -2525,6 +2570,9 @@
     #define E3_CURRENT      800
     #define E3_MICROSTEPS   E0_MICROSTEPS
     #define E3_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(E3)
+      #define E3_VREF         2.5
+    #endif
     #define E3_CHAIN_POS     -1
     //#define E3_INTERPOLATE true
   #endif
@@ -2533,6 +2581,9 @@
     #define E4_CURRENT      800
     #define E4_MICROSTEPS   E0_MICROSTEPS
     #define E4_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(E4)
+      #define E4_VREF         2.5
+    #endif
     #define E4_CHAIN_POS     -1
     //#define E4_INTERPOLATE true
   #endif
@@ -2541,6 +2592,9 @@
     #define E5_CURRENT      800
     #define E5_MICROSTEPS   E0_MICROSTEPS
     #define E5_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(E5)
+      #define E5_VREF         2.5
+    #endif
     #define E5_CHAIN_POS     -1
     //#define E5_INTERPOLATE true
   #endif
@@ -2549,6 +2603,9 @@
     #define E6_CURRENT      800
     #define E6_MICROSTEPS   E0_MICROSTEPS
     #define E6_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(E6)
+      #define E6_VREF         2.5
+    #endif
     #define E6_CHAIN_POS     -1
     //#define E6_INTERPOLATE true
   #endif
@@ -2557,6 +2614,9 @@
     #define E7_CURRENT      800
     #define E7_MICROSTEPS   E0_MICROSTEPS
     #define E7_RSENSE         0.11
+    #if AXIS_HAS_I_SCALE_ANALOG(E7)
+      #define E7_VREF         2.5
+    #endif
     #define E7_CHAIN_POS     -1
     //#define E7_INTERPOLATE true
   #endif

--- a/Marlin/src/core/drivers.h
+++ b/Marlin/src/core/drivers.h
@@ -134,6 +134,8 @@
 #define AXIS_HAS_HW_SERIAL(A) ( AXIS_HAS_UART(A) &&  defined(A##_HARDWARE_SERIAL) )
 #define AXIS_HAS_SW_SERIAL(A) ( AXIS_HAS_UART(A) && !defined(A##_HARDWARE_SERIAL) )
 
+#define AXIS_HAS_I_SCALE_ANALOG(A) ( AXIS_DRIVER_TYPE(A,TMC2208) || AXIS_DRIVER_TYPE(A,TMC2209) )
+
 #define AXIS_HAS_STALLGUARD(A)   (    AXIS_DRIVER_TYPE(A,TMC2130) || AXIS_DRIVER_TYPE(A,TMC2160) \
                                    || AXIS_DRIVER_TYPE(A,TMC2209) \
                                    || AXIS_DRIVER_TYPE(A,TMC2660) \
@@ -174,6 +176,9 @@
 #endif
 #if ANY_AXIS_HAS(SPI)
   #define HAS_TMC_SPI 1
+#endif
+#if ANY_AXIS_HAS(I_SCALE_ANALOG)
+  #define HAS_I_SCALE_ANALOG 1
 #endif
 
 //

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2775,6 +2775,8 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
   #error "SENSORLESS_PROBING requires TMC2130, TMC2160, TMC2209, TMC2660, or TMC5160 stepper drivers."
 #elif STEALTHCHOP_ENABLED && !HAS_STEALTHCHOP
   #error "STEALTHCHOP requires TMC2130, TMC2160, TMC2208, TMC2209, or TMC5160 stepper drivers."
+#elif ENABLED(USE_VREF_FOR_SCALING) && !HAS_I_SCALE_ANALOG
+  #error "I_SCALE_ANALOG requires TMC2208 or TMC2209 stepper drivers."
 #endif
 
 /**

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -45,7 +45,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
 // SWHW = SW/SH UART selection
 
 #if ENABLED(USE_VREF_FOR_SCALING) 
-  #define TMC_EFFECTIVE_RSENSE(ST) (2.5 / ST##_VREF) * (ST##_RSENSE + 0.02) - 0.02
+  #define TMC_EFFECTIVE_RSENSE(ST) (2.5 * RECIPROCAL(ST##_VREF)) * (ST##_RSENSE + 0.02) - 0.02
 #else
   #define TMC_EFFECTIVE_RSENSE(ST) ST##_RSENSE
 #endif


### PR DESCRIPTION
### Current-scaling using VREF for TMC2208 and TMC2209
This allows fine-grained control of current for boards whose designs allow high current, but where smaller steppers are used. It also allows limiting the maximum current in case of misconfiguration of IRUN/IHOLD, and for external analog scaling of the current directly at the driver IC.

### Description

The stepper drivers TMC2208 and TMC2209 are currently reasonably well-supported in Marlin using UART control. They do, however, offer many more options than are currently made available to users.  This pull-request is the first of maybe a couple that will attempt to address some of these options.

At hand is the option to use the VREF input to scale the set current for each driver. A common TMC2209 based board might have sense resistors of 100mOhm, allowing a maximum peak current of 2.7A, and an RMS current of 1.92A. This gives a step resolution of 59.8mA RMS per step, or ~85mA peak. 

A user wishing to drive a 1A limited standard NEMA17 40mm stepper at roughly 80% current, or 800mA, could do so comfortably by setting VREF at 1.25V, putting a current limit of 1.35A peak / 0.95A RMS on the driver, and increasing the resolution of the current steps to 29.9mA.

Fine tuning by external analogue circuits would also be possible, as would be simple safety devices such as a temperature sensitive voltage divider limiting the current before the chip overheats.

(Enough of my rambling: I just thought it'd be cool.)

### Requirements

Requires TMC2208/9 stepper drivers with UART control, and some form of adjustable
VREF input.

### Benefits

Adds fine-grained current control beyond the existing steps for TMC drivers.

### Configurations

(Might do this later, but for now I'm gonna go to bed.)

### Related Issues

No, just my own idea.