### PR TITLE
Block hotend idle check if moves planned or waiting for the user

### DIFF
--- a/Marlin/src/feature/hotend_idle.cpp
+++ b/Marlin/src/feature/hotend_idle.cpp
@@ -44,7 +44,7 @@ millis_t HotendIdleProtection::next_protect_ms = 0;
 void HotendIdleProtection::check_hotends(const millis_t &ms) {
   bool do_prot = false;
   HOTEND_LOOP() {
-    static bool busy = (TERN0(HAS_RESUME_CONTINUE, wait_for_user) || planner.has_blocks_queued());
+    const bool busy = (TERN0(HAS_RESUME_CONTINUE, wait_for_user) || planner.has_blocks_queued());
     if (thermalManager.degHotend(e) >= HOTEND_IDLE_MIN_TRIGGER && !busy) {
       do_prot = true; break;
     }

--- a/Marlin/src/feature/hotend_idle.cpp
+++ b/Marlin/src/feature/hotend_idle.cpp
@@ -34,6 +34,7 @@
 
 #include "../module/temperature.h"
 #include "../module/motion.h"
+#include "../module/planner.h"
 #include "../lcd/marlinui.h"
 
 extern HotendIdleProtection hotend_idle;
@@ -43,7 +44,8 @@ millis_t HotendIdleProtection::next_protect_ms = 0;
 void HotendIdleProtection::check_hotends(const millis_t &ms) {
   bool do_prot = false;
   HOTEND_LOOP() {
-    if (thermalManager.degHotend(e) >= HOTEND_IDLE_MIN_TRIGGER) {
+    static bool busy = (TERN0(HAS_RESUME_CONTINUE, wait_for_user) || planner.has_blocks_queued());
+    if (thermalManager.degHotend(e) >= HOTEND_IDLE_MIN_TRIGGER && !busy) {
       do_prot = true; break;
     }
   }


### PR DESCRIPTION
Long operations such as `G29` on large mesh sizes as well as active waits such as `M600` had the possibility of having the idle timeout kill the task. When it set temps to 0, the job timer was also killed and any active print job aborted. This was able to abort prints waiting for filament reload after runout or during `G29` routines in many cases.

This adds conditions to make sure the machine is truly idle, not moving or waiting for the user prior to aborting.