### PR TITLE
MKS LVGL UI: Changed fan speed control in percent

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
@@ -32,8 +32,7 @@
 #include "../../../../inc/MarlinConfig.h"
 
 extern lv_group_t *g;
-static lv_obj_t *scr;
-static lv_obj_t *fanText;
+static lv_obj_t *scr, *fanText;
 
 enum {
   ID_F_ADD = 1,
@@ -44,27 +43,22 @@ enum {
   ID_F_RETURN
 };
 
-static uint8_t fanPercent;
-
 static void event_handler(lv_obj_t *obj, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
+  uint8_t fanSpeed = thermalManager.fan_speed[0], pct = map(fanSpeed, 0, 255, 0, 100);
   switch (obj->mks_obj_id) {
-    case ID_F_ADD: if (fanPercent < 100) fanPercent++; break;
-    case ID_F_DEC: if (fanPercent > 0) fanPercent--; break;
-    case ID_F_HIGH: fanPercent = 100; break;
-    case ID_F_MID:  fanPercent =  50; break;
-    case ID_F_OFF:  fanPercent =   0; break;
+    case ID_F_ADD: if (pct < 100) fanSpeed = map(pct + 1, 0, 100, 0, 255); break;
+    case ID_F_DEC: if (pct !=  0) fanSpeed = map(pct - 1, 0, 100, 0, 255); break;
+    case ID_F_HIGH: fanSpeed = 255; break;
+    case ID_F_MID:  fanSpeed = 128; break;
+    case ID_F_OFF:  fanSpeed =   0; break;
     case ID_F_RETURN: clear_cur_ui(); draw_return_ui(); return;
   }
-  thermalManager.set_fan_speed(0, map(fanPercent, 0, 100, 0, 255));
+  thermalManager.set_fan_speed(0, fanSpeed);
 }
 
 void lv_draw_fan() {
   lv_obj_t *buttonAdd;
-
-  #if HAS_FAN
-    fanPercent = map(thermalManager.fan_speed[0], 0, 255, 0, 100);
-  #endif
 
   scr = lv_screen_create(FAN_UI);
   // Create an Image button
@@ -82,7 +76,11 @@ void lv_draw_fan() {
 }
 
 void disp_fan_value() {
-  sprintf_P(public_buf_l, PSTR("%s: %3d%%"), fan_menu.state, fanPercent);
+  #if HAS_FAN
+    sprintf_P(public_buf_l, PSTR("%s: %3d%%"), fan_menu.state, (int)map(thermalManager.fan_speed[0], 0, 255, 0, 100));
+  #else
+    sprintf_P(public_buf_l, PSTR("%s: ---"), fan_menu.state);
+  #endif
   lv_label_set_text(fanText, public_buf_l);
   lv_obj_align(fanText, nullptr, LV_ALIGN_CENTER, 0, -65);
 }

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
@@ -45,16 +45,16 @@ enum {
 
 static void event_handler(lv_obj_t *obj, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
-  uint8_t fanSpeed = thermalManager.fan_speed[0], pct = map(fanSpeed, 0, 255, 0, 100);
+  uint8_t fanPercent = map(thermalManager.fan_speed[0], 0, 255, 0, 100);
   switch (obj->mks_obj_id) {
-    case ID_F_ADD: if (pct < 100) fanSpeed = map(pct + 1, 0, 100, 0, 255); break;
-    case ID_F_DEC: if (pct !=  0) fanSpeed = map(pct - 1, 0, 100, 0, 255); break;
-    case ID_F_HIGH: fanSpeed = 255; break;
-    case ID_F_MID:  fanSpeed = 128; break;
-    case ID_F_OFF:  fanSpeed =   0; break;
+    case ID_F_ADD: if (fanPercent < 100) fanPercent++; break;
+    case ID_F_DEC: if (fanPercent !=  0) fanPercent--; break;
+    case ID_F_HIGH: fanPercent = 100; break;
+    case ID_F_MID:  fanPercent =  50; break;
+    case ID_F_OFF:  fanPercent =   0; break;
     case ID_F_RETURN: clear_cur_ui(); draw_return_ui(); return;
   }
-  thermalManager.set_fan_speed(0, fanSpeed);
+  thermalManager.set_fan_speed(0, map(fanPercent, 0, 100, 0, 255));
 }
 
 void lv_draw_fan() {

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
@@ -51,10 +51,10 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
 
   switch (obj->mks_obj_id) {
     case ID_F_ADD:
-      if (fanSpeed < 254) fanSpeed++;
+      if (fanSpeed < 252) fanSpeed += 2.55;
       break;
     case ID_F_DEC:
-      if (fanSpeed > 0) fanSpeed--;
+      if (fanSpeed > 0) fanSpeed-=2.55;
       break;
     case ID_F_HIGH:
       fanSpeed = 255;
@@ -64,6 +64,7 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       break;
     case ID_F_OFF:
       gcode.process_subcommands_now_P(PSTR("M107"));
+      fanSpeed = 0;
       return;
     case ID_F_RETURN:
       clear_cur_ui();
@@ -101,7 +102,7 @@ void disp_fan_value() {
   public_buf_l[0] = '\0';
   strcat(public_buf_l, fan_menu.state);
   strcat_P(public_buf_l, PSTR(": "));
-  sprintf_P(buf1, PSTR("%3d"), thermalManager.fan_speed[0]);
+  sprintf_P(buf1, PSTR("%3d%%"),thermalManager.fanPercent(fanSpeed));
   strcat(public_buf_l, buf1);
   lv_label_set_text(fanText, public_buf_l);
   lv_obj_align(fanText, nullptr, LV_ALIGN_CENTER, 0, -65);

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
@@ -51,7 +51,7 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
 
   switch (obj->mks_obj_id) {
     case ID_F_ADD:
-      if (fanSpeed < 252) fanSpeed += 2.55;
+      if (fanSpeed < 252) fanSpeed+=2.55;
       break;
     case ID_F_DEC:
       if (fanSpeed > 0) fanSpeed-=2.55;

--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_fan.cpp
@@ -44,42 +44,26 @@ enum {
   ID_F_RETURN
 };
 
-static uint8_t fanSpeed;
+static uint8_t fanPercent;
 
 static void event_handler(lv_obj_t *obj, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
-
   switch (obj->mks_obj_id) {
-    case ID_F_ADD:
-      if (fanSpeed < 252) fanSpeed+=2.55;
-      break;
-    case ID_F_DEC:
-      if (fanSpeed > 0) fanSpeed-=2.55;
-      break;
-    case ID_F_HIGH:
-      fanSpeed = 255;
-      break;
-    case ID_F_MID:
-      fanSpeed = 127;
-      break;
-    case ID_F_OFF:
-      gcode.process_subcommands_now_P(PSTR("M107"));
-      fanSpeed = 0;
-      return;
-    case ID_F_RETURN:
-      clear_cur_ui();
-      draw_return_ui();
-      return;
+    case ID_F_ADD: if (fanPercent < 100) fanPercent++; break;
+    case ID_F_DEC: if (fanPercent > 0) fanPercent--; break;
+    case ID_F_HIGH: fanPercent = 100; break;
+    case ID_F_MID:  fanPercent =  50; break;
+    case ID_F_OFF:  fanPercent =   0; break;
+    case ID_F_RETURN: clear_cur_ui(); draw_return_ui(); return;
   }
-  sprintf_P(public_buf_l, PSTR("M106 S%d"), fanSpeed);
-  gcode.process_subcommands_now(public_buf_l);
+  thermalManager.set_fan_speed(0, map(fanPercent, 0, 100, 0, 255));
 }
 
 void lv_draw_fan() {
   lv_obj_t *buttonAdd;
 
   #if HAS_FAN
-    fanSpeed = thermalManager.fan_speed[0];
+    fanPercent = map(thermalManager.fan_speed[0], 0, 255, 0, 100);
   #endif
 
   scr = lv_screen_create(FAN_UI);
@@ -98,12 +82,7 @@ void lv_draw_fan() {
 }
 
 void disp_fan_value() {
-  char buf1[10] = {0};
-  public_buf_l[0] = '\0';
-  strcat(public_buf_l, fan_menu.state);
-  strcat_P(public_buf_l, PSTR(": "));
-  sprintf_P(buf1, PSTR("%3d%%"),thermalManager.fanPercent(fanSpeed));
-  strcat(public_buf_l, buf1);
+  sprintf_P(public_buf_l, PSTR("%s: %3d%%"), fan_menu.state, fanPercent);
   lv_label_set_text(fanText, public_buf_l);
   lv_obj_align(fanText, nullptr, LV_ALIGN_CENTER, 0, -65);
 }


### PR DESCRIPTION
### Description

Changed fan speed control to percentage speed (from 0 to 100%)

### Benefits

The fan is now controlled in percent (0 to 100%) rather than in PWM units (0 to 255). This option gives the user a better idea of the current fan speed. In addition, the percentage display matches better with any slicer where the blowing power is indicated in procents.

### Demo

https://youtu.be/06nCCx7eBhk