### PR TITLE
Prevent magnetic switching toolhead collision

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1112,7 +1112,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
         #if ENABLED(MAGNETIC_SWITCHING_TOOLHEAD)
           // If the original position is within tool store area, go to X origin at once
           if (destination.y < SWITCHING_TOOLHEAD_Y_POS + SWITCHING_TOOLHEAD_Y_CLEAR) {
-            current_position.x = 0;
+            current_position.x = X_MIN_POS;
             planner.buffer_line(current_position, planner.settings.max_feedrate_mm_s[X_AXIS], new_tool);
             planner.synchronize();
           }


### PR DESCRIPTION
### Description

The sequence for switching magnetic toolheads moves the head to X origin, if the original position is within tool store area. The X origin in the code is simply defined as a 0, which results in a crash on systems, where the `X_MIN_POS` is greater than 0. 

### Requirements

No special requirements, only `MAGNETIC_SWITCHING_TOOLHEAD` enabled.

### Benefits

This quick fix redefines the X origin in the toolchanging sequence to `X_MIN_POS` to prevent crashing.

