### PR TITLE
Fix for [BUG] Head crashes after Home and Z-Align #21520

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -121,8 +121,12 @@
   inline void home_z_safely() {
     DEBUG_SECTION(log_G28, "home_z_safely", DEBUGGING(LEVELING));
 
-    // Disallow Z homing if X or Y homing is needed
-    if (homing_needed_error(_BV(X_AXIS) | _BV(Y_AXIS))) return;
+    // Ensure X and Y homed before Z homing
+    homeaxis(X_AXIS);
+    
+    if (homing_needed_error(_BV(Y_AXIS))) {
+      homeaxis(Y_AXIS);
+    }
 
     sync_plan_position();
 


### PR DESCRIPTION
### Description

On any call to G28 a second time, the head crashes.  home(x) home(y) needs to be unconditional.

### Requirements

Tested on SMART RAMPS MEGA2560.  By way of summary, this configuration has safe homing enabled with Z-induction probe and Z-min end stop with induction probe.  So, after homing, the head is in the middle of the build plate, it isn't at position 0,0.

### Benefits

No head crash

### Configurations

In the referenced ticket #21520 

### Related Issues

#21520 