### PR TITLE
platformio: use jump relaxing for all AVR targets

### DIFF
--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -13,6 +13,7 @@
 # AVR (8-bit) Common Environment values
 #
 [common_avr8]
+build_flags       = ${common.build_flags} -Wl,--relax
 board_build.f_cpu = 16000000L
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 


### PR DESCRIPTION
### Description

This is a pretty straight-forward linker optimization that saves
program space and makes the code faster.

I know it's there in tuned_1284p, but it could be turned on by default for all AVRs.

### Benefits

This saves around 1 Kb of program space on my Anet A6.
