### PR TITLE
serial: remove return value on write()

### DIFF
--- a/Marlin/src/HAL/AVR/MarlinSerial.cpp
+++ b/Marlin/src/HAL/AVR/MarlinSerial.cpp
@@ -454,7 +454,7 @@ void MarlinSerial<Cfg>::flush() {
 }
 
 template<typename Cfg>
-size_t MarlinSerial<Cfg>::write(const uint8_t c) {
+void MarlinSerial<Cfg>::write(const uint8_t c) {
   if (Cfg::TX_SIZE == 0) {
 
     _written = true;
@@ -480,7 +480,7 @@ size_t MarlinSerial<Cfg>::write(const uint8_t c) {
       // location". This makes sure flush() won't return until the bytes
       // actually got written
       B_TXC = 1;
-      return 1;
+      return;
     }
 
     const uint8_t i = (tx_buffer.head + 1) & (Cfg::TX_SIZE - 1);
@@ -510,7 +510,6 @@ size_t MarlinSerial<Cfg>::write(const uint8_t c) {
     // Enable TX ISR - Non atomic, but it will eventually enable TX ISR
     B_UDRIE = 1;
   }
-  return 1;
 }
 
 template<typename Cfg>

--- a/Marlin/src/HAL/AVR/MarlinSerial.h
+++ b/Marlin/src/HAL/AVR/MarlinSerial.h
@@ -210,7 +210,7 @@
     static int read();
     static void flush();
     static ring_buffer_pos_t available();
-    static size_t write(const uint8_t c);
+    static void write(const uint8_t c);
     static void flushTX();
     #if HAS_DGUS_LCD
       static ring_buffer_pos_t get_tx_buffer_free();

--- a/Marlin/src/core/serial_base.h
+++ b/Marlin/src/core/serial_base.h
@@ -100,7 +100,7 @@ struct SerialBase {
 
   // Static dispatch methods below:
   // The most important method here is where it all ends to:
-  size_t write(uint8_t c)           { return SerialChild->write(c); }
+  void write(uint8_t c)             { SerialChild->write(c); }
 
   // Called when the parser finished processing an instruction, usually build to nothing
   void msgDone() const              { SerialChild->msgDone(); }


### PR DESCRIPTION
### Description

I don't know why the write() function returns a size_t. It's big and
it's never used anyways. Until we find an use for the return value I
suggest we remove it.

### Benefits

Saves a few bytes and a few cycles every time write() is called.
