### PR TITLE
add checks for tangled marlin (marlin source with old and new code) 

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -73,3 +73,12 @@ for p in [ env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config") ]:
 		if os.path.isfile(os.path.join(p, f)):
 			err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p
 			raise SystemExit(err)
+
+#
+# Check for old files indicating a tangled marlin (mix of old and new code)
+#
+for p in [ os.path.join(env['PROJECT_DIR'], "Marlin/src/lcd/dogm") ]:
+	for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
+		if os.path.isfile(os.path.join(p, f)):
+			err = "ERROR: Tangled Marlin detected. You have files from old and new Marlin in the same directory tree. Please remove all Marlin files and try again."
+			raise SystemExit(err)

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -75,10 +75,13 @@ for p in [ env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config") ]:
 			raise SystemExit(err)
 
 #
-# Check for old files indicating a tangled marlin (mix of old and new code)
+# Check for old files indicating an entangled Marlin (mixing old and new code)
 #
+mixedin = []
 for p in [ os.path.join(env['PROJECT_DIR'], "Marlin/src/lcd/dogm") ]:
 	for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
 		if os.path.isfile(os.path.join(p, f)):
-			err = "ERROR: Tangled Marlin detected. You have files from old and new Marlin in the same directory tree. Please remove all Marlin files and try again."
-			raise SystemExit(err)
+			mixedin += [ f ]
+if mixedin:
+	err = "ERROR: Old files fell into your Marlin folder. Remove %s and try again" % ", ".join(mixedin)
+	raise SystemExit(err)


### PR DESCRIPTION
### Description

Users using zip files for Marlin source have started to extract bugfix Marlin over their older Marlin resulting in a mix of new and old code, which unsurprisingly does not compile.

Results in a lot of redefinition warnings and multiple definition errors. 
Egs. warning: "LCD_BACK_CLICKED" redefined, 
warning: "LCD_UPDATE_INTERVAL" redefined,
error: multiple definition of 'enum LCDViewAction

For more examples see Related issue.

### Requirements

Marlin bugfix zip extracted over older Marlin directory.

### Benefits

Tells users that Marlin is tangled. 

### Related Issues

Latest example. https://reprap.org/forum/read.php?415,883164 
