### PR TITLE
Reduce float math library code size (by 3 1/2 kilobytes)

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -112,6 +112,9 @@
 #define SIGN(a) ({__typeof__(a) _a = (a); (_a>0)-(_a<0);})
 #define IS_POWER_OF_2(x) ((x) && !((x) & ((x) - 1)))
 
+#define MFNAN 999999.0f
+#define ISNAN(V) ((V) == MFNAN)
+
 // Macros to constrain values
 #ifdef __cplusplus
 

--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -43,7 +43,7 @@ bed_mesh_t z_values;
  * Extrapolate a single point from its neighbors
  */
 static void extrapolate_one_point(const uint8_t x, const uint8_t y, const int8_t xdir, const int8_t ydir) {
-  if (!isnan(z_values[x][y])) return;
+  if (!ISNAN(z_values[x][y])) return;
   if (DEBUGGING(LEVELING)) {
     DEBUG_ECHOPGM("Extrapolate [");
     if (x < 10) DEBUG_CHAR(' ');
@@ -63,12 +63,12 @@ static void extrapolate_one_point(const uint8_t x, const uint8_t y, const int8_t
         c1 = z_values[x1][y1], c2 = z_values[x2][y2];
 
   // Treat far unprobed points as zero, near as equal to far
-  if (isnan(a2)) a2 = 0.0;
-  if (isnan(a1)) a1 = a2;
-  if (isnan(b2)) b2 = 0.0;
-  if (isnan(b1)) b1 = b2;
-  if (isnan(c2)) c2 = 0.0;
-  if (isnan(c1)) c1 = c2;
+  if (ISNAN(a2)) a2 = 0.0;
+  if (ISNAN(a1)) a1 = a2;
+  if (ISNAN(b2)) b2 = 0.0;
+  if (ISNAN(b1)) b1 = b2;
+  if (ISNAN(c2)) c2 = 0.0;
+  if (ISNAN(c1)) c1 = c2;
 
   const float a = 2 * a1 - a2, b = 2 * b1 - b2, c = 2 * c1 - c2;
 

--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -132,7 +132,7 @@ void reset_bed_level() {
       bilinear_start.reset();
       bilinear_grid_spacing.reset();
       GRID_LOOP(x, y) {
-        z_values[x][y] = NAN;
+        z_values[x][y] = MFNAN;
         TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, 0));
       }
     #elif ABL_PLANAR
@@ -177,7 +177,7 @@ void reset_bed_level() {
       LOOP_L_N(x, sx) {
         SERIAL_CHAR(' ');
         const float offset = fn(x, y);
-        if (!isnan(offset)) {
+        if (!ISNAN(offset)) {
           if (offset >= 0) SERIAL_CHAR('+');
           SERIAL_ECHO_F(offset, int(precision));
         }

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
@@ -97,6 +97,7 @@ public:
   static inline xy_int8_t probe_indexes(const xy_pos_t &xy) { return probe_indexes(xy.x, xy.y); }
 
   static float calc_z0(const_float_t a0, const_float_t a1, const_float_t z1, const_float_t a2, const_float_t z2) {
+    if (ISNAN(a0) || ISNAN(a1) || ISNAN(z1) || ISNAN(a2) || ISNAN(z2)) return MFNAN;
     const float delta_z = (z2 - z1) / (a2 - a1),
                 delta_a = a0 - a1;
     return z1 + delta_a * delta_z;
@@ -114,9 +115,11 @@ public:
     const float x1 = index_to_xpos[ind.x], x2 = index_to_xpos[ind.x+1],
                 y1 = index_to_xpos[ind.y], y2 = index_to_xpos[ind.y+1],
                 z1 = calc_z0(pos.x, x1, z_values[ind.x][ind.y  ], x2, z_values[ind.x+1][ind.y  ]),
-                z2 = calc_z0(pos.x, x1, z_values[ind.x][ind.y+1], x2, z_values[ind.x+1][ind.y+1]);
+                z2 = calc_z0(pos.x, x1, z_values[ind.x][ind.y+1], x2, z_values[ind.x+1][ind.y+1]),
+                zf = calc_z0(pos.y, y1, z1, y2, z2);
 
-    return z_offset + calc_z0(pos.y, y1, z1, y2, z2) * factor;
+
+    return ISNAN(zf) ? zf : z_offset + zf * factor;
   }
 
   #if IS_CARTESIAN && DISABLED(SEGMENT_LEVELED_MOVES)

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -48,7 +48,7 @@ void unified_bed_leveling::report_current_mesh() {
   if (!leveling_is_valid()) return;
   SERIAL_ECHO_MSG("  G29 I999");
   GRID_LOOP(x, y)
-    if (!isnan(z_values[x][y])) {
+    if (!ISNAN(z_values[x][y])) {
       SERIAL_ECHO_START();
       SERIAL_ECHOPAIR("  M421 I", x, " J", y);
       SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, z_values[x][y], 4);
@@ -99,7 +99,7 @@ void unified_bed_leveling::reset() {
 
 void unified_bed_leveling::invalidate() {
   set_bed_leveling_enabled(false);
-  set_all_mesh_points_to_value(NAN);
+  set_all_mesh_points_to_value(MFNAN);
 }
 
 void unified_bed_leveling::set_all_mesh_points_to_value(const_float_t value) {
@@ -116,7 +116,7 @@ void unified_bed_leveling::set_all_mesh_points_to_value(const_float_t value) {
 
   void unified_bed_leveling::set_store_from_mesh(const bed_mesh_t &in_values, mesh_store_t &stored_values) {
     auto z_to_store = [](const_float_t z) {
-      if (isnan(z)) return Z_STEPS_NAN;
+      if (ISNAN(z)) return Z_STEPS_NAN;
       const int32_t z_scaled = TRUNC(z * mesh_store_scaling);
       if (z_scaled == Z_STEPS_NAN || !WITHIN(z_scaled, INT16_MIN, INT16_MAX))
         return Z_STEPS_NAN; // If Z is out of range, return our custom 'NaN'
@@ -127,7 +127,7 @@ void unified_bed_leveling::set_all_mesh_points_to_value(const_float_t value) {
 
   void unified_bed_leveling::set_mesh_from_store(const mesh_store_t &stored_values, bed_mesh_t &out_values) {
     auto store_to_z = [](const int16_t z_scaled) {
-      return z_scaled == Z_STEPS_NAN ? NAN : z_scaled / mesh_store_scaling;
+      return z_scaled == Z_STEPS_NAN ? MFNAN : z_scaled / mesh_store_scaling;
     };
     GRID_LOOP(x, y) out_values[x][y] = store_to_z(stored_values[x][y]);
   }
@@ -211,7 +211,7 @@ void unified_bed_leveling::display_map(const int map_type) {
       if (lcd) {
         // TODO: Display on Graphical LCD
       }
-      else if (isnan(f))
+      else if (ISNAN(f))
         SERIAL_ECHOPGM_P(human ? PSTR("  .   ") : PSTR("NAN"));
       else if (human || csv) {
         if (human && f >= 0.0) SERIAL_CHAR(f > 0 ? '+' : ' ');  // Display sign also for positive numbers (' ' for 0)

--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -85,7 +85,7 @@
 
       // Undefined parts of the Mesh in z_values[][] are NAN.
       // Replace NAN corrections with 0.0 to prevent NAN propagation.
-      if (!isnan(z0)) end.z += z0;
+      if (!ISNAN(z0)) end.z += z0;
       planner.buffer_segment(end, scaled_fr_mm_s, extruder);
       current_position = destination;
       return;
@@ -150,7 +150,7 @@
 
         // Undefined parts of the Mesh in z_values[][] are NAN.
         // Replace NAN corrections with 0.0 to prevent NAN propagation.
-        if (isnan(z0)) z0 = 0.0;
+        if (ISNAN(z0)) z0 = 0.0;
 
         const float ry = mesh_index_to_ypos(icell.y);
 
@@ -198,7 +198,7 @@
 
         // Undefined parts of the Mesh in z_values[][] are NAN.
         // Replace NAN corrections with 0.0 to prevent NAN propagation.
-        if (isnan(z0)) z0 = 0.0;
+        if (ISNAN(z0)) z0 = 0.0;
 
         /**
          * Without this check, it's possible to generate a zero length move, as in the case where
@@ -253,7 +253,7 @@
 
         // Undefined parts of the Mesh in z_values[][] are NAN.
         // Replace NAN corrections with 0.0 to prevent NAN propagation.
-        if (isnan(z0)) z0 = 0.0;
+        if (ISNAN(z0)) z0 = 0.0;
 
         if (!inf_normalized_flag) {
           on_axis_distance = use_x_dist ? rx - start.x : next_mesh_line_y - start.y;
@@ -276,7 +276,7 @@
 
         // Undefined parts of the Mesh in z_values[][] are NAN.
         // Replace NAN corrections with 0.0 to prevent NAN propagation.
-        if (isnan(z0)) z0 = 0.0;
+        if (ISNAN(z0)) z0 = 0.0;
 
         if (!inf_normalized_flag) {
           on_axis_distance = use_x_dist ? next_mesh_line_x - start.x : ry - start.y;
@@ -405,10 +405,10 @@
             z_x0y1 = z_values[icell.x  ][icell.y+1],  // z at lower right corner
             z_x1y1 = z_values[icell.x+1][icell.y+1];  // z at upper right corner
 
-      if (isnan(z_x0y0)) z_x0y0 = 0;              // ideally activating planner.leveling_active (G29 A)
-      if (isnan(z_x1y0)) z_x1y0 = 0;              //   should refuse if any invalid mesh points
-      if (isnan(z_x0y1)) z_x0y1 = 0;              //   in order to avoid isnan tests per cell,
-      if (isnan(z_x1y1)) z_x1y1 = 0;              //   thus guessing zero for undefined points
+      if (ISNAN(z_x0y0)) z_x0y0 = 0;              // ideally activating planner.leveling_active (G29 A)
+      if (ISNAN(z_x1y0)) z_x1y0 = 0;              //   should refuse if any invalid mesh points
+      if (ISNAN(z_x0y1)) z_x0y1 = 0;              //   in order to avoid ISNAN tests per cell,
+      if (ISNAN(z_x1y1)) z_x1y1 = 0;              //   thus guessing zero for undefined points
 
       const xy_pos_t pos = { mesh_index_to_xpos(icell.x), mesh_index_to_ypos(icell.y) };
       xy_pos_t cell = raw - pos;

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -105,7 +105,7 @@ void GcodeSuite::G35() {
     do_blocking_move_to_z(SUM_TERN(BLTOUCH_HS_MODE, Z_CLEARANCE_BETWEEN_PROBES, 7));
     const float z_probed_height = probe.probe_at_point(screws_tilt_adjust_pos[i], PROBE_PT_RAISE, 0, true);
 
-    if (isnan(z_probed_height)) {
+    if (ISNAN(z_probed_height)) {
       SERIAL_ECHOPAIR("G35 failed at point ", i, " (");
       SERIAL_ECHOPGM_P((char *)pgm_read_ptr(&tramming_point_name[i]));
       SERIAL_CHAR(')');

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -287,11 +287,11 @@ G29_TYPE GcodeSuite::G29() {
           G29_RETURN(false);
         }
 
-        const float rx = RAW_X_POSITION(parser.linearval('X', NAN)),
-                    ry = RAW_Y_POSITION(parser.linearval('Y', NAN));
+        const float rx = RAW_X_POSITION(parser.linearval('X', MFNAN)),
+                    ry = RAW_Y_POSITION(parser.linearval('Y', MFNAN));
         int8_t i = parser.byteval('I', -1), j = parser.byteval('J', -1);
 
-        if (!isnan(rx) && !isnan(ry)) {
+        if (!ISNAN(rx) && !ISNAN(ry)) {
           // Get nearest i / j from rx / ry
           i = (rx - bilinear_start.x + 0.5 * abl.gridSpacing.x) / abl.gridSpacing.x;
           j = (ry - bilinear_start.y + 0.5 * abl.gridSpacing.y) / abl.gridSpacing.y;
@@ -608,7 +608,7 @@ G29_TYPE GcodeSuite::G29() {
 
       // Outer loop is X with PROBE_Y_FIRST enabled
       // Outer loop is Y with PROBE_Y_FIRST disabled
-      for (PR_OUTER_VAR = 0; PR_OUTER_VAR < PR_OUTER_SIZE && !isnan(abl.measured_z); PR_OUTER_VAR++) {
+      for (PR_OUTER_VAR = 0; PR_OUTER_VAR < PR_OUTER_SIZE && !ISNAN(abl.measured_z); PR_OUTER_VAR++) {
 
         int8_t inStart, inStop, inInc;
 
@@ -644,7 +644,7 @@ G29_TYPE GcodeSuite::G29() {
 
           abl.measured_z = faux ? 0.001f * random(-100, 101) : probe.probe_at_point(abl.probePos, raise_after, abl.verbose_level);
 
-          if (isnan(abl.measured_z)) {
+          if (ISNAN(abl.measured_z)) {
             set_bed_leveling_enabled(abl.reenable);
             break; // Breaks out of both loops
           }
@@ -690,14 +690,14 @@ G29_TYPE GcodeSuite::G29() {
         // Retain the last probe position
         abl.probePos = points[i];
         abl.measured_z = faux ? 0.001 * random(-100, 101) : probe.probe_at_point(abl.probePos, raise_after, abl.verbose_level);
-        if (isnan(abl.measured_z)) {
+        if (ISNAN(abl.measured_z)) {
           set_bed_leveling_enabled(abl.reenable);
           break;
         }
         points[i].z = abl.measured_z;
       }
 
-      if (!abl.dryrun && !isnan(abl.measured_z)) {
+      if (!abl.dryrun && !ISNAN(abl.measured_z)) {
         vector_3 planeNormal = vector_3::cross(points[0] - points[1], points[2] - points[1]).get_normal();
         if (planeNormal.z < 0) planeNormal *= -1;
         planner.bed_level_matrix = matrix_3x3::create_look_at(planeNormal);
@@ -713,7 +713,7 @@ G29_TYPE GcodeSuite::G29() {
     // Stow the probe. No raise for FIX_MOUNTED_PROBE.
     if (probe.stow()) {
       set_bed_leveling_enabled(abl.reenable);
-      abl.measured_z = NAN;
+      abl.measured_z = MFNAN;
     }
   }
   #endif // !PROBE_MANUALLY
@@ -736,7 +736,7 @@ G29_TYPE GcodeSuite::G29() {
   #endif
 
   // Calculate leveling, print reports, correct the position
-  if (!isnan(abl.measured_z)) {
+  if (!ISNAN(abl.measured_z)) {
     #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
       if (!abl.dryrun) extrapolate_unprobed_bed_level();
@@ -873,7 +873,7 @@ G29_TYPE GcodeSuite::G29() {
 
     // Auto Bed Leveling is complete! Enable if possible.
     planner.leveling_active = !abl.dryrun || abl.reenable;
-  } // !isnan(abl.measured_z)
+  } // !ISNAN(abl.measured_z)
 
   // Restore state after probing
   if (!faux) restore_feedrate_and_scaling();
@@ -897,7 +897,7 @@ G29_TYPE GcodeSuite::G29() {
 
   report_current_position();
 
-  G29_RETURN(isnan(abl.measured_z));
+  G29_RETURN(ISNAN(abl.measured_z));
 }
 
 #endif // HAS_ABL_NOT_UBL

--- a/Marlin/src/gcode/bedlevel/ubl/M421.cpp
+++ b/Marlin/src/gcode/bedlevel/ubl/M421.cpp
@@ -62,7 +62,7 @@ void GcodeSuite::M421() {
     SERIAL_ERROR_MSG(STR_ERR_MESH_XY);
   else {
     float &zval = ubl.z_values[ij.x][ij.y];
-    zval = hasN ? NAN : parser.value_linear_units() + (hasQ ? zval : 0);
+    zval = hasN ? MFNAN : parser.value_linear_units() + (hasQ ? zval : 0);
     TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(ij.x, ij.y, zval));
   }
 }

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -212,7 +212,7 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
     if (!_7p_no_intermediates && !_7p_4_intermediates && !_7p_11_intermediates) { // probe the center
       const xy_pos_t center{0};
       z_pt[CEN] += calibration_probe(center, stow_after_each);
-      if (isnan(z_pt[CEN])) return false;
+      if (ISNAN(z_pt[CEN])) return false;
     }
 
     if (_7p_calibration) { // probe extra center points
@@ -223,7 +223,7 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
                     r = dcr * 0.1;
         const xy_pos_t vec = { cos(a), sin(a) };
         z_pt[CEN] += calibration_probe(vec * r, stow_after_each);
-        if (isnan(z_pt[CEN])) return false;
+        if (ISNAN(z_pt[CEN])) return false;
      }
       z_pt[CEN] /= float(_7p_2_intermediates ? 7 : probe_points);
     }
@@ -248,7 +248,7 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
                       interpol = FMOD(rad, 1);
           const xy_pos_t vec = { cos(a), sin(a) };
           const float z_temp = calibration_probe(vec * r, stow_after_each);
-          if (isnan(z_temp)) return false;
+          if (ISNAN(z_temp)) return false;
           // split probe point to neighbouring calibration points
           z_pt[uint8_t(LROUND(rad - interpol + NPP - 1)) % NPP + 1] += z_temp * sq(cos(RADIANS(interpol * 90)));
           z_pt[uint8_t(LROUND(rad - interpol))           % NPP + 1] += z_temp * sq(sin(RADIANS(interpol * 90)));

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -229,7 +229,7 @@ void GcodeSuite::G34() {
           // Probing sanity check is disabled, as it would trigger even in normal cases because
           // current_position.z has been manually altered in the "dirty trick" above.
           const float z_probed_height = probe.probe_at_point(z_stepper_align.xy[iprobe], raise_after, 0, true, false);
-          if (isnan(z_probed_height)) {
+          if (ISNAN(z_probed_height)) {
             SERIAL_ECHOLNPGM("Probing failed");
             LCD_MESSAGEPGM(MSG_LCD_PROBING_FAILED);
             err_break = true;

--- a/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
@@ -113,7 +113,7 @@ void GcodeSuite::G76() {
   auto g76_probe = [](const TempSensorID sid, uint16_t &targ, const xy_pos_t &nozpos) {
     do_z_clearance(5.0); // Raise nozzle before probing
     const float measured_z = probe.probe_at_point(nozpos, PROBE_PT_STOW, 0, false);  // verbose=0, probe_relative=false
-    if (isnan(measured_z))
+    if (ISNAN(measured_z))
       SERIAL_ECHOLNPGM("!Received NAN. Aborting.");
     else {
       SERIAL_ECHOLNPAIR_F("Measured: ", measured_z);
@@ -208,7 +208,7 @@ void GcodeSuite::G76() {
         report_temps(next_temp_report);
 
       const float measured_z = g76_probe(TSI_BED, target_bed, noz_pos_xyz);
-      if (isnan(measured_z) || target_bed > BED_MAX_TARGET) break;
+      if (ISNAN(measured_z) || target_bed > BED_MAX_TARGET) break;
     }
 
     SERIAL_ECHOLNPAIR("Retrieved measurements: ", temp_comp.get_index());
@@ -267,7 +267,7 @@ void GcodeSuite::G76() {
       if (timeout) break;
 
       const float measured_z = g76_probe(TSI_PROBE, target_probe, noz_pos_xyz);
-      if (isnan(measured_z) || target_probe > cali_info_init[TSI_PROBE].end_temp) break;
+      if (ISNAN(measured_z) || target_probe > cali_info_init[TSI_PROBE].end_temp) break;
     }
 
     SERIAL_ECHOLNPAIR("Retrieved measurements: ", temp_comp.get_index());

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -134,7 +134,7 @@ void GcodeSuite::M48() {
 
   // Move to the first point, deploy, and probe
   const float t = probe.probe_at_point(test_position, raise_after, verbose_level);
-  bool probing_good = !isnan(t);
+  bool probing_good = !ISNAN(t);
 
   if (probing_good) {
     randomSeed(millis());
@@ -219,7 +219,7 @@ void GcodeSuite::M48() {
       const float pz = probe.probe_at_point(test_position, raise_after, 0);
 
       // Break the loop if the probe fails
-      probing_good = !isnan(pz);
+      probing_good = !ISNAN(pz);
       if (!probing_good) break;
 
       // Store the new sample

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -52,7 +52,7 @@ void GcodeSuite::G30() {
 
   const ProbePtRaise raise_after = parser.boolval('E', true) ? PROBE_PT_STOW : PROBE_PT_NONE;
   const float measured_z = probe.probe_at_point(pos, raise_after, 1);
-  if (!isnan(measured_z))
+  if (!ISNAN(measured_z))
     SERIAL_ECHOLNPAIR("Bed X: ", pos.x, " Y: ", pos.y, " Z: ", measured_z);
 
   restore_feedrate_and_scaling();

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -1457,7 +1457,7 @@ void MarlinUI::draw_status_screen() {
          * Print Z values
          */
         _ZLABEL(_LCD_W_POS, 1);
-        if (!isnan(ubl.z_values[x_plot][y_plot]))
+        if (!ISNAN(ubl.z_values[x_plot][y_plot]))
           lcd_put_u8str(ftostr43sign(ubl.z_values[x_plot][y_plot]));
         else
           lcd_put_u8str_P(PSTR(" -----"));
@@ -1476,7 +1476,7 @@ void MarlinUI::draw_status_screen() {
          * Show the location value
          */
         _ZLABEL(_LCD_W_POS, 3);
-        if (!isnan(ubl.z_values[x_plot][y_plot]))
+        if (!ISNAN(ubl.z_values[x_plot][y_plot]))
           lcd_put_u8str(ftostr43sign(ubl.z_values[x_plot][y_plot]));
         else
           lcd_put_u8str_P(PSTR(" -----"));

--- a/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
+++ b/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
@@ -941,7 +941,7 @@ void MarlinUI::draw_status_screen() {
       // Show the location value
       lcd.setCursor(_LCD_W_POS, 3); lcd_put_u8str_P(PSTR("Z:"));
 
-      if (!isnan(ubl.z_values[x_plot][y_plot]))
+      if (!ISNAN(ubl.z_values[x_plot][y_plot]))
         lcd.print(ftostr43sign(ubl.z_values[x_plot][y_plot]));
       else
         lcd_put_u8str_P(PSTR(" -----"));

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -569,7 +569,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
         // Show the location value
         lcd_put_u8str_P(74, LCD_PIXEL_HEIGHT, Z_LBL);
-        if (!isnan(ubl.z_values[x_plot][y_plot]))
+        if (!ISNAN(ubl.z_values[x_plot][y_plot]))
           lcd_put_u8str(ftostr43sign(ubl.z_values[x_plot][y_plot]));
         else
           lcd_put_u8str_P(PSTR(" -----"));

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -835,13 +835,17 @@ void MarlinUI::draw_status_screen() {
             mix_label = PSTR("Mx");
           }
 
-        #pragma GCC diagnostic push
-        #pragma GCC diagnostic ignored "-Wformat-overflow"
+        #if GCC_VERSION <= 50000
+          #pragma GCC diagnostic push
+          #pragma GCC diagnostic ignored "-Wformat-overflow"
+        #endif
 
         sprintf_P(mixer_messages, PSTR(S_FMT " %d;%d%% "), mix_label, int(mixer.mix[0]), int(mixer.mix[1]));
         lcd_put_u8str(X_LABEL_POS, XYZ_BASELINE, mixer_messages);
 
-        #pragma GCC diagnostic pop
+        #if GCC_VERSION <= 50000
+          #pragma GCC diagnostic pop
+        #endif
 
       #else
 

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/adjuster_widget.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/ftdi_eve_lib/extended/adjuster_widget.cpp
@@ -32,7 +32,7 @@
 namespace FTDI {
   void draw_adjuster_value(CommandProcessor& cmd, int16_t x, int16_t y, int16_t w, int16_t h, float value, progmem_str units, int8_t width, uint8_t precision) {
     char str[width + precision + 10 + (units ? strlen_P((const char*) units) : 0)];
-    if (isnan(value))
+    if (ISNAN(value))
       strcpy_P(str, PSTR("-"));
     else
       dtostrf(value, width, precision, str);

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_base.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_base.cpp
@@ -31,7 +31,7 @@ void BedMeshBase::_drawMesh(CommandProcessor &cmd, int16_t x, int16_t y, int16_t
   constexpr uint8_t cols = GRID_MAX_POINTS_X;
 
   #define VALUE(X,Y)  (func ? func(X,Y,data) : 0)
-  #define ISVAL(X,Y)  (func ? !isnan(VALUE(X,Y)) : true)
+  #define ISVAL(X,Y)  (func ? !ISNAN(VALUE(X,Y)) : true)
   #define HEIGHT(X,Y) (ISVAL(X,Y) ? (VALUE(X,Y) - val_min) * scale_z : 0)
 
   // Compute the mean, min and max for the points

--- a/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_edit_screen.cpp
+++ b/Marlin/src/lcd/extui/lib/ftdi_eve_touch_ui/screens/bed_mesh_edit_screen.cpp
@@ -70,7 +70,7 @@ void BedMeshEditScreen::onEntry() {
 
 float BedMeshEditScreen::getHighlightedValue() {
   const float val = ExtUI::getMeshPoint(mydata.highlight);
-  return (isnan(val) ? 0 : val) + mydata.zAdjustment;
+  return (ISNAN(val) ? 0 : val) + mydata.zAdjustment;
 }
 
 void BedMeshEditScreen::setHighlightedValue(float value) {

--- a/Marlin/src/lcd/extui/ui_api.cpp
+++ b/Marlin/src/lcd/extui/ui_api.cpp
@@ -421,7 +421,7 @@ namespace ExtUI {
         #if AXIS_IS_TMC(Z2)
           case Z2: return stepperZ2.getMilliamps();
         #endif
-        default: return NAN;
+        default: return MFNAN;
       };
     }
 
@@ -451,7 +451,7 @@ namespace ExtUI {
         #if AXIS_IS_TMC(E7)
           case E7: return stepperE7.getMilliamps();
         #endif
-        default: return NAN;
+        default: return MFNAN;
       };
     }
 

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -54,7 +54,7 @@ static bool probe_single_point() {
   z_measured[tram_index] = z_probed_height;
   move_to_tramming_wait_pos();
 
-  return !isnan(z_probed_height);
+  return !ISNAN(z_probed_height);
 }
 
 static void _menu_single_probe(const uint8_t point) {

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -505,7 +505,7 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
     tft.set_background(COLOR_BACKGROUND);
     tft_string.set(Z_LBL);
     tft.add_text(0, MENU_TEXT_Y_OFFSET, COLOR_MENU_TEXT, tft_string);
-    tft_string.set(isnan(ubl.z_values[x_plot][y_plot]) ? "-----" : ftostr43sign(ubl.z_values[x_plot][y_plot]));
+    tft_string.set(ISNAN(ubl.z_values[x_plot][y_plot]) ? "-----" : ftostr43sign(ubl.z_values[x_plot][y_plot]));
     tft_string.trim();
     tft.add_text(120 - tft_string.width(), MENU_TEXT_Y_OFFSET, COLOR_MENU_VALUE, tft_string);
 

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -492,7 +492,7 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
     tft.set_background(COLOR_BACKGROUND);
     tft_string.set(Z_LBL);
     tft.add_text(0, MENU_TEXT_Y_OFFSET, COLOR_MENU_TEXT, tft_string);
-    tft_string.set(isnan(ubl.z_values[x_plot][y_plot]) ? "-----" : ftostr43sign(ubl.z_values[x_plot][y_plot]));
+    tft_string.set(ISNAN(ubl.z_values[x_plot][y_plot]) ? "-----" : ftostr43sign(ubl.z_values[x_plot][y_plot]));
     tft_string.trim();
     tft.add_text(96 - tft_string.width(), MENU_TEXT_Y_OFFSET, COLOR_MENU_VALUE, tft_string);
 

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -492,7 +492,7 @@ void MenuItem_confirm::draw_select_screen(PGM_P const yes, PGM_P const no, const
     tft.set_background(COLOR_BACKGROUND);
     tft_string.set(Z_LBL);
     tft.add_text(0, MENU_TEXT_Y_OFFSET, COLOR_MENU_TEXT, tft_string);
-    tft_string.set(isnan(ubl.z_values[x_plot][y_plot]) ? "-----" : ftostr43sign(ubl.z_values[x_plot][y_plot]));
+    tft_string.set(ISNAN(ubl.z_values[x_plot][y_plot]) ? "-----" : ftostr43sign(ubl.z_values[x_plot][y_plot]));
     tft_string.trim();
     tft.add_text(120 - tft_string.width(), MENU_TEXT_Y_OFFSET, COLOR_MENU_VALUE, tft_string);
 

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -583,7 +583,7 @@ bool Probe::probe_down_to_z(const_float_t z, const_feedRate_t fr_mm_s) {
  * @details Used by probe_at_point to get the bed Z height at the current XY.
  *          Leaves current_position.z at the height where the probe triggered.
  *
- * @return The Z position of the bed at the current XY or NAN on error.
+ * @return The Z position of the bed at the current XY or MFNAN on error.
  */
 float Probe::run_z_probe(const bool sanity_check/*=true*/) {
   DEBUG_SECTION(log_probe, "Probe::run_z_probe", DEBUGGING(LEVELING));
@@ -617,11 +617,11 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
   #if TOTAL_PROBING == 2
 
     // Attempt to tare the probe
-    if (TERN0(PROBE_TARE, tare())) return NAN;
+    if (TERN0(PROBE_TARE, tare())) return MFNAN;
 
     // Do a first probe at the fast speed
     if (try_to_probe(PSTR("FAST"), z_probe_low_point, z_probe_fast_mm_s,
-                     sanity_check, Z_CLEARANCE_BETWEEN_PROBES) ) return NAN;
+                     sanity_check, Z_CLEARANCE_BETWEEN_PROBES) ) return MFNAN;
 
     const float first_probe_z = current_position.z;
 
@@ -662,7 +662,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
 
       // Probe downward slowly to find the bed
       if (try_to_probe(PSTR("SLOW"), z_probe_low_point, MMM_TO_MMS(Z_PROBE_FEEDRATE_SLOW),
-                       sanity_check, Z_CLEARANCE_MULTI_PROBE) ) return NAN;
+                       sanity_check, Z_CLEARANCE_MULTI_PROBE) ) return MFNAN;
 
       TERN_(MEASURE_BACKLASH_WHEN_PROBING, backlash.measure_with_probe());
 
@@ -765,29 +765,29 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
   if (probe_relative) {                                     // The given position is in terms of the probe
     if (!can_reach(npos)) {
       if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Position Not Reachable");
-      return NAN;
+      return MFNAN;
     }
     npos -= offset_xy;                                      // Get the nozzle position
   }
-  else if (!position_is_reachable(npos)) return NAN;        // The given position is in terms of the nozzle
+  else if (!position_is_reachable(npos)) return MFNAN;      // The given position is in terms of the nozzle
 
   // Move the probe to the starting XYZ
   do_blocking_move_to(npos, feedRate_t(XY_PROBE_FEEDRATE_MM_S));
 
-  float measured_z = NAN;
+  float measured_z = MFNAN;
   if (!deploy()) measured_z = run_z_probe(sanity_check) + offset.z;
-  if (!isnan(measured_z)) {
+  if (!ISNAN(measured_z)) {
     const bool big_raise = raise_after == PROBE_PT_BIG_RAISE;
     if (big_raise || raise_after == PROBE_PT_RAISE)
       do_blocking_move_to_z(current_position.z + (big_raise ? 25 : Z_CLEARANCE_BETWEEN_PROBES), z_probe_fast_mm_s);
     else if (raise_after == PROBE_PT_STOW)
-      if (stow()) measured_z = NAN;   // Error on stow?
+      if (stow()) measured_z = MFNAN;   // Error on stow?
 
     if (verbose_level > 2)
       SERIAL_ECHOLNPAIR("Bed X: ", LOGICAL_X_POSITION(rx), " Y: ", LOGICAL_Y_POSITION(ry), " Z: ", measured_z);
   }
 
-  if (isnan(measured_z)) {
+  if (ISNAN(measured_z)) {
     stow();
     LCD_MESSAGEPGM(MSG_LCD_PROBING_FAILED);
     #if DISABLED(G29_RETRY_AND_RECOVER)

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -185,10 +185,10 @@ public:
       );
     }
 
-    static float min_x() { return _min_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x)); }
-    static float max_x() { return _max_x() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.x)); }
-    static float min_y() { return _min_y() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y)); }
-    static float max_y() { return _max_y() - TERN0(NOZZLE_AS_PROBE, TERN0(HAS_HOME_OFFSET, home_offset.y)); }
+    static float min_x() { return _min_x() TERN_(NOZZLE_AS_PROBE, TERN_(HAS_HOME_OFFSET, - home_offset.x)); }
+    static float max_x() { return _max_x() TERN_(NOZZLE_AS_PROBE, TERN_(HAS_HOME_OFFSET, - home_offset.x)); }
+    static float min_y() { return _min_y() TERN_(NOZZLE_AS_PROBE, TERN_(HAS_HOME_OFFSET, - home_offset.y)); }
+    static float max_y() { return _max_y() TERN_(NOZZLE_AS_PROBE, TERN_(HAS_HOME_OFFSET, - home_offset.y)); }
 
     // constexpr helpers used in build-time static_asserts, relying on default probe offsets.
     class build_time {

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -900,8 +900,8 @@ void MarlinSettings::postprocess() {
       HOTEND_LOOP() {
         PIDCF_t pidcf = {
           #if DISABLED(PIDTEMP)
-            NAN, NAN, NAN,
-            NAN, NAN
+            MFNAN, MFNAN, MFNAN,
+            MFNAN, MFNAN
           #else
                          PID_PARAM(Kp, e),
             unscalePID_i(PID_PARAM(Ki, e)),
@@ -928,7 +928,7 @@ void MarlinSettings::postprocess() {
 
       const PID_t bed_pid = {
         #if DISABLED(PIDTEMPBED)
-          NAN, NAN, NAN
+          MFNAN, MFNAN, MFNAN
         #else
           // Store the unscaled PID values
           thermalManager.temp_bed.pid.Kp,
@@ -947,7 +947,7 @@ void MarlinSettings::postprocess() {
 
       const PID_t chamber_pid = {
         #if DISABLED(PIDTEMPCHAMBER)
-          NAN, NAN, NAN
+          MFNAN, MFNAN, MFNAN
         #else
           // Store the unscaled PID values
           thermalManager.temp_chamber.pid.Kp,
@@ -1786,7 +1786,7 @@ void MarlinSettings::postprocess() {
           PIDCF_t pidcf;
           EEPROM_READ(pidcf);
           #if ENABLED(PIDTEMP)
-            if (!validating && !isnan(pidcf.Kp)) {
+            if (!validating && !ISNAN(pidcf.Kp)) {
               // Scale PID values since EEPROM values are unscaled
               PID_PARAM(Kp, e) = pidcf.Kp;
               PID_PARAM(Ki, e) = scalePID_i(pidcf.Ki);
@@ -1818,7 +1818,7 @@ void MarlinSettings::postprocess() {
         PID_t pid;
         EEPROM_READ(pid);
         #if ENABLED(PIDTEMPBED)
-          if (!validating && !isnan(pid.Kp)) {
+          if (!validating && !ISNAN(pid.Kp)) {
             // Scale PID values since EEPROM values are unscaled
             thermalManager.temp_bed.pid.Kp = pid.Kp;
             thermalManager.temp_bed.pid.Ki = scalePID_i(pid.Ki);
@@ -1834,7 +1834,7 @@ void MarlinSettings::postprocess() {
         PID_t pid;
         EEPROM_READ(pid);
         #if ENABLED(PIDTEMPCHAMBER)
-          if (!validating && !isnan(pid.Kp)) {
+          if (!validating && !ISNAN(pid.Kp)) {
             // Scale PID values since EEPROM values are unscaled
             thermalManager.temp_chamber.pid.Kp = pid.Kp;
             thermalManager.temp_chamber.pid.Ki = scalePID_i(pid.Ki);

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -74,9 +74,9 @@ hotend_pid_t;
 #endif
 
 #define PID_PARAM(F,H) _PID_##F(TERN(PID_PARAMS_PER_HOTEND, H, 0 & H)) // Always use 'H' to suppress warning
-#define _PID_Kp(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Kp, NAN)
-#define _PID_Ki(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Ki, NAN)
-#define _PID_Kd(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Kd, NAN)
+#define _PID_Kp(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Kp, MFNAN)
+#define _PID_Ki(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Ki, MFNAN)
+#define _PID_Kd(H) TERN(PIDTEMP, Temperature::temp_hotend[H].pid.Kd, MFNAN)
 #if ENABLED(PIDTEMP)
   #define _PID_Kc(H) TERN(PID_EXTRUSION_SCALING, Temperature::temp_hotend[H].pid.Kc, 1)
   #define _PID_Kf(H) TERN(PID_FAN_SCALING,       Temperature::temp_hotend[H].pid.Kf, 0)

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -565,7 +565,7 @@ void announceOpen(const uint8_t doing, const char * const path) {
 //   - 1 : (no file open) Opening a macro (M98).
 //   - 2 : Resuming from a sub-procedure
 //
-void CardReader::openFileRead(char * const path, const uint8_t subcall_type/*=0*/) {
+void CardReader::openFileRead(const char * const path, const uint8_t subcall_type/*=0*/) {
   if (!isMounted()) return;
 
   switch (subcall_type) {

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -102,7 +102,7 @@ public:
   #endif
 
   // Basic file ops
-  static void openFileRead(char * const path, const uint8_t subcall=0);
+  static void openFileRead(const char * const path, const uint8_t subcall=0);
   static void openFileWrite(const char * const path);
   static void closefile(const bool store_location=false);
   static bool fileExists(const char * const name);

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,6 +38,13 @@ extra_configs =
 # The 'common' values are used for most Marlin builds
 #
 [common]
+build_flags        = -fmax-errors=5 -g3 -D__MARLIN_FIRMWARE__ -fmerge-constants -fno-signed-zeros -ffinite-math-only
+extra_scripts      =
+  pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
+  pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
+  pre:buildroot/share/PlatformIO/scripts/preflight-checks.py
+  post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
+lib_deps           =
 default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/lcd/HD44780> -<src/lcd/TFTGLCD> -<src/lcd/dwin> -<src/lcd/dogm> -<src/lcd/tft> -<src/lcd/tft_io>
   -<src/HAL/STM32/tft> -<src/HAL/STM32F1/tft>
@@ -227,13 +234,6 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/module/scara.cpp> -<src/gcode/calibrate/M665.cpp>
   -<src/module/servo.cpp> -<src/gcode/control/M280.cpp>
   -<src/module/stepper/TMC26X.cpp>
-extra_scripts      =
-  pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
-  pre:buildroot/share/PlatformIO/scripts/common-cxxflags.py
-  pre:buildroot/share/PlatformIO/scripts/preflight-checks.py
-  post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
-build_flags        = -fmax-errors=5 -g3 -D__MARLIN_FIRMWARE__ -fmerge-constants
-lib_deps           =
 
 #
 # Default values apply to all 'env:' prefixed environments


### PR DESCRIPTION
Add compiler flags `-fno-signed-zeros` and `-ffinite-math-only` to reduce the size of float math library, recovering 3.4K of Flash space on space-starved AVR boards and a comparable amount of space on other platforms.

The caveat is that we can no longer use `NAN` or `isnan` to signify and test unset values. Instead, we must use our own custom `MFNAN` and `ISNAN` macros.