### PR TITLE
fix M114 E & R broken by `LIN_ADVANCE`

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2285,14 +2285,26 @@ uint32_t Stepper::block_phase_isr() {
       // We don't know which steppers will be stepped because LA loop follows,
       // with potentially multiple steps. Set all.
       if (LA_steps > 0)
+      {
         MIXER_STEPPER_LOOP(j) NORM_E_DIR(j);
+        count_direction.e = 1;
+      }
       else if (LA_steps < 0)
+      {
         MIXER_STEPPER_LOOP(j) REV_E_DIR(j);
+        count_direction.e = -1;
+      }
     #else
       if (LA_steps > 0)
+      {
         NORM_E_DIR(stepper_extruder);
+        count_direction.e = 1;
+      }
       else if (LA_steps < 0)
+      {
         REV_E_DIR(stepper_extruder);
+        count_direction.e = -1;
+      }
     #endif
 
     DIR_WAIT_AFTER();
@@ -2305,8 +2317,6 @@ uint32_t Stepper::block_phase_isr() {
       USING_TIMED_PULSE();
     #endif
 
-    count_direction.e = LA_steps > 0 ? 1 : -1;
-
     while (LA_steps) {
       #if ISR_MULTI_STEPS
         if (firstStep)
@@ -2314,6 +2324,8 @@ uint32_t Stepper::block_phase_isr() {
         else
           AWAIT_LOW_PULSE();
       #endif
+
+      count_position.e += count_direction.e;
 
       // Set the STEP pulse ON
       #if ENABLED(MIXING_EXTRUDER)
@@ -2339,8 +2351,6 @@ uint32_t Stepper::block_phase_isr() {
       #else
         E_STEP_WRITE(stepper_extruder, INVERT_E_STEP_PIN);
       #endif
-
-      count_position.e += count_direction.e;
 
       // For minimum pulse time wait before looping
       // Just wait for the requested pulse duration

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -1697,7 +1697,6 @@ void Stepper::pulse_phase_isr() {
       #if EITHER(LIN_ADVANCE, MIXING_EXTRUDER)
         delta_error.e += advance_dividend.e;
         if (delta_error.e >= 0) {
-          // count_position.e += count_direction.e; // When enabled 'LIN_ADVANCE', 'count_position.e' should change in 'advance_isr()' not here
           #if ENABLED(LIN_ADVANCE)
             delta_error.e -= advance_divisor;
             // Don't step E here - But remember the number of steps to perform
@@ -2284,24 +2283,20 @@ uint32_t Stepper::block_phase_isr() {
     #if ENABLED(MIXING_EXTRUDER)
       // We don't know which steppers will be stepped because LA loop follows,
       // with potentially multiple steps. Set all.
-      if (LA_steps > 0)
-      {
+      if (LA_steps > 0) {
         MIXER_STEPPER_LOOP(j) NORM_E_DIR(j);
         count_direction.e = 1;
       }
-      else if (LA_steps < 0)
-      {
+      else if (LA_steps < 0) {
         MIXER_STEPPER_LOOP(j) REV_E_DIR(j);
         count_direction.e = -1;
       }
     #else
-      if (LA_steps > 0)
-      {
+      if (LA_steps > 0) {
         NORM_E_DIR(stepper_extruder);
         count_direction.e = 1;
       }
-      else if (LA_steps < 0)
-      {
+      else if (LA_steps < 0) {
         REV_E_DIR(stepper_extruder);
         count_direction.e = -1;
       }


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Now we can get the current realtime position of E-axis when enabled `LIN_ADVANCE`
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware/issues/1794
https://github.com/MarlinFirmware/Marlin/issues/20760
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
