### PR TITLE
Fix Custom Menu audio and return

### DIFF
--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -105,8 +105,8 @@ void menu_configuration();
 
   void _lcd_custom_menu_main_gcode(PGM_P const cmd) {
     queue.inject_P(cmd);
-    TERN_(MAIN_MENU_ITEM_SCRIPT_AUDIBLE_FEEDBACK, ui.completion_feedback());
-    TERN_(MAIN_MENU_ITEM_SCRIPT_RETURN, ui.return_to_status());
+    TERN_(CUSTOM_MENU_MAIN_SCRIPT_AUDIBLE_FEEDBACK, ui.completion_feedback());
+    TERN_(CUSTOM_MENU_MAIN_SCRIPT_RETURN, ui.return_to_status());
   }
 
   void custom_menus_main() {


### PR DESCRIPTION
When I use "`#define CUSTOM_MENU_ITEM`" in `Configuration_adv.h` (last 2.0.x bugfix) and enable…
```cpp
#define CUSTOM_MENU_MAIN_SCRIPT_AUDIBLE_FEEDBACK

#define CUSTOM_MENU_MAIN_SCRIPT_RETURN
```
…nothing happens (LCD doesn't return to the main menu after script execution and no sound is played).

SOLUTION:
I found a mismatch in menu_main.cpp at line pulled where the function:

```cpp
#if ENABLED(CUSTOM_MENU_MAIN)
  void lcd_custom_menu_main_gcode(PGM_P const cmd) {
    queue.inject_P(cmd);
    TERN(MAIN_MENU_ITEM_SCRIPT_AUDIBLE_FEEDBACK, ui.completion_feedback());
    TERN_(MAIN_MENU_ITEM_SCRIPT_RETURN, ui.return_to_status());
  }

```
…contains another variable defined (not CUSTOM_etc but MAIN_etc).

### Related Issues
#21613 

This fix a bug without changes in template/actual configuration_adv.h
