### PR TITLE
Always swap with PRIME_FIRST_USED disabled

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -928,7 +928,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     #endif
 
     // First tool priming. To prime again, reboot the machine.
-    #if BOTH(TOOLCHANGE_FS_PRIME_FIRST_USED)
+    #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
       static bool first_tool_is_primed = false;
       if (new_tool == old_tool && !first_tool_is_primed && enable_first_prime) {
         tool_change_prime();

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -933,10 +933,10 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       if (new_tool == old_tool && !first_tool_is_primed && enable_first_prime) {
         tool_change_prime();
         first_tool_is_primed = true;
-        #if ENABLED(TOOLCHANGE_FS_INIT_BEFORE_SWAP)
-          toolchange_extruder_ready[old_tool] = true; // Primed and initialized
-        #endif
+        TERN_(TOOLCHANGE_FS_INIT_BEFORE_SWAP, toolchange_extruder_ready[old_tool] = true); // Primed and initialized
       }
+    #else
+      constexpr bool first_tool_is_primed = true;
     #endif
 
     if (new_tool != old_tool || TERN0(PARKING_EXTRUDER, extruder_parked)) { // PARKING_EXTRUDER may need to attach old_tool when homing
@@ -972,15 +972,10 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
             if (ENABLED(SINGLENOZZLE)) { active_extruder = new_tool; return; }
           }
           else {
-            #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
-              // For first new tool, change without unloading the old. 'Just prime/init the new'
-              if (first_tool_is_primed) {
-            #endif
-                unscaled_e_move(-toolchange_settings.swap_length, MMM_TO_MMS(toolchange_settings.retract_speed));
-            #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
-              }
-              first_tool_is_primed = true; // The first new tool will be primed by toolchanging
-            #endif
+            // For first new tool, change without unloading the old. 'Just prime/init the new'
+            if (first_tool_is_primed)
+              unscaled_e_move(-toolchange_settings.swap_length, MMM_TO_MMS(toolchange_settings.retract_speed));
+            TERN_(TOOLCHANGE_FS_PRIME_FIRST_USED, first_tool_is_primed = true); // The first new tool will be primed by toolchanging
           }
         }
       #endif

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -928,7 +928,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
     #endif
 
     // First tool priming. To prime again, reboot the machine.
-    #if BOTH(TOOLCHANGE_FILAMENT_SWAP, TOOLCHANGE_FS_PRIME_FIRST_USED)
+    #if BOTH(TOOLCHANGE_FS_PRIME_FIRST_USED)
       static bool first_tool_is_primed = false;
       if (new_tool == old_tool && !first_tool_is_primed && enable_first_prime) {
         tool_change_prime();

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -933,7 +933,9 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       if (new_tool == old_tool && !first_tool_is_primed && enable_first_prime) {
         tool_change_prime();
         first_tool_is_primed = true;
-        toolchange_extruder_ready[old_tool] = true; // Primed and initialized
+        #if ENABLED(TOOLCHANGE_FS_INIT_BEFORE_SWAP)
+          toolchange_extruder_ready[old_tool] = true; // Primed and initialized
+        #endif
       }
     #endif
 
@@ -972,8 +974,11 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
           else {
             #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
               // For first new tool, change without unloading the old. 'Just prime/init the new'
-              if (first_tool_is_primed)
+              if (first_tool_is_primed) {
+            #endif
                 unscaled_e_move(-toolchange_settings.swap_length, MMM_TO_MMS(toolchange_settings.retract_speed));
+            #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
+              }
               first_tool_is_primed = true; // The first new tool will be primed by toolchanging
             #endif
           }


### PR DESCRIPTION
### Description

If `TOOLCHANGE_FS_PRIME_FIRST_USED` is deactivated, Filament will never retract, which will break a tool change with `TOOLCHANGE_FILAMENT_SWAP`.

Removed setting of `toolchange_extruder_ready` if `TOOLCHANGE_FS_INIT_BEFORE_SWAP` is not enabled.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

- Retracting Filament also if `TOOLCHANGE_FS_PRIME_FIRST_USED` is not enabled.
- Resolved `error: 'toolchange_extruder_ready' was not declared in this scope` when only using `TOOLCHANGE_FS_PRIME_FIRST_USED`

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

Closes #20652
