### PR TITLE
Init pwm_thrs to 0 when HYBRID_THRESHOLD is off

### DIFF
--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -120,11 +120,14 @@ class TMCMarlin : public TMC, public TMCStorage<AXIS_LETTER, DRIVER_ID> {
       uint32_t get_pwm_thrs() {
         return _tmc_thrs(this->microsteps(), this->TPWMTHRS(), planner.settings.axis_steps_per_mm[AXIS_ID]);
       }
-      void set_pwm_thrs(const uint32_t thrs) {
-        TMC::TPWMTHRS(_tmc_thrs(this->microsteps(), thrs, planner.settings.axis_steps_per_mm[AXIS_ID]));
-        TERN_(HAS_LCD_MENU, this->stored.hybrid_thrs = thrs);
-      }
     #endif
+
+    void set_pwm_thrs(const uint32_t thrs) {
+      TMC::TPWMTHRS(_tmc_thrs(this->microsteps(), thrs, planner.settings.axis_steps_per_mm[AXIS_ID]));
+      #if BOTH(HYBRID_THRESHOLD, HAS_LCD_MENU)
+        this->stored.hybrid_thrs = thrs;
+      #endif
+    }
 
     #if USE_SENSORLESS
       inline int16_t homing_threshold() { return TMC::sgt(); }
@@ -185,19 +188,21 @@ class TMCMarlin<TMC2208Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC220
       inline bool toggle_stepping_mode()           { set_stealthChop(!this->stored.stealthChop_enabled); return get_stealthChop(); }
     #endif
 
+    void set_pwm_thrs(const uint32_t thrs) {
+      TMC2208Stepper::TPWMTHRS(_tmc_thrs(this->microsteps(), thrs, planner.settings.axis_steps_per_mm[AXIS_ID]));
+      #if BOTH(HYBRID_THRESHOLD, HAS_LCD_MENU)
+        this->stored.hybrid_thrs = thrs;
+      #endif
+    }
+
     #if ENABLED(HYBRID_THRESHOLD)
       uint32_t get_pwm_thrs() {
         return _tmc_thrs(this->microsteps(), this->TPWMTHRS(), planner.settings.axis_steps_per_mm[AXIS_ID]);
-      }
-      void set_pwm_thrs(const uint32_t thrs) {
-        TMC2208Stepper::TPWMTHRS(_tmc_thrs(this->microsteps(), thrs, planner.settings.axis_steps_per_mm[AXIS_ID]));
-        TERN_(HAS_LCD_MENU, this->stored.hybrid_thrs = thrs);
       }
     #endif
 
     #if HAS_LCD_MENU
       inline void refresh_stepper_current() { rms_current(this->val_mA); }
-
       #if ENABLED(HYBRID_THRESHOLD)
         inline void refresh_hybrid_thrs() { set_pwm_thrs(this->stored.hybrid_thrs); }
       #endif
@@ -237,11 +242,15 @@ class TMCMarlin<TMC2209Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC220
       uint32_t get_pwm_thrs() {
         return _tmc_thrs(this->microsteps(), this->TPWMTHRS(), planner.settings.axis_steps_per_mm[AXIS_ID]);
       }
-      void set_pwm_thrs(const uint32_t thrs) {
-        TMC2209Stepper::TPWMTHRS(_tmc_thrs(this->microsteps(), thrs, planner.settings.axis_steps_per_mm[AXIS_ID]));
-        TERN_(HAS_LCD_MENU, this->stored.hybrid_thrs = thrs);
-      }
     #endif
+
+    void set_pwm_thrs(const uint32_t thrs) {
+      TMC2209Stepper::TPWMTHRS(_tmc_thrs(this->microsteps(), thrs, planner.settings.axis_steps_per_mm[AXIS_ID]));
+      #if BOTH(HYBRID_THRESHOLD, HAS_LCD_MENU)
+        this->stored.hybrid_thrs = thrs;
+      #endif
+    }
+
     #if USE_SENSORLESS
       inline int16_t homing_threshold() { return TMC2209Stepper::SGTHRS(); }
       void homing_threshold(int16_t sgt_val) {

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -158,7 +158,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     pwmconf.pwm_ampl = 180;
     st.PWMCONF(pwmconf.sr);
 
-    TERN(HYBRID_THRESHOLD, st.set_pwm_thrs(hyb_thrs), UNUSED(hyb_thrs));
+    st.set_pwm_thrs(TERN0(HYBRID_THRESHOLD, hyb_thrs)); UNUSED(hyb_thrs);
 
     st.GSTAT(); // Clear GSTAT
   }
@@ -196,7 +196,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     pwmconf.pwm_ofs = 36;
     st.PWMCONF(pwmconf.sr);
 
-    TERN(HYBRID_THRESHOLD, st.set_pwm_thrs(hyb_thrs), UNUSED(hyb_thrs));
+    st.set_pwm_thrs(TERN0(HYBRID_THRESHOLD, hyb_thrs)); UNUSED(hyb_thrs);
 
     st.GSTAT(); // Clear GSTAT
   }
@@ -517,7 +517,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     pwmconf.pwm_ofs = 36;
     st.PWMCONF(pwmconf.sr);
 
-    TERN(HYBRID_THRESHOLD, st.set_pwm_thrs(hyb_thrs), UNUSED(hyb_thrs));
+    st.set_pwm_thrs(TERN0(HYBRID_THRESHOLD, hyb_thrs)); UNUSED(hyb_thrs);
 
     st.GSTAT(0b111); // Clear
     delay(200);
@@ -559,7 +559,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     pwmconf.pwm_ofs = 36;
     st.PWMCONF(pwmconf.sr);
 
-    TERN(HYBRID_THRESHOLD, st.set_pwm_thrs(hyb_thrs), UNUSED(hyb_thrs));
+    st.set_pwm_thrs(TERN0(HYBRID_THRESHOLD, hyb_thrs)); UNUSED(hyb_thrs);
 
     st.GSTAT(0b111); // Clear
     delay(200);
@@ -617,7 +617,7 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     pwmconf.pwm_ampl = 180;
     st.PWMCONF(pwmconf.sr);
 
-    TERN(HYBRID_THRESHOLD, st.set_pwm_thrs(hyb_thrs), UNUSED(hyb_thrs));
+    st.set_pwm_thrs(TERN0(HYBRID_THRESHOLD, hyb_thrs)); UNUSED(hyb_thrs);
 
     st.GSTAT(); // Clear GSTAT
   }
@@ -655,11 +655,8 @@ enum StealthIndex : uint8_t { STEALTH_AXIS_XY, STEALTH_AXIS_Z, STEALTH_AXIS_E };
     pwmconf.pwm_ofs = 36;
     st.PWMCONF(pwmconf.sr);
 
-    #if ENABLED(HYBRID_THRESHOLD)
-      st.set_pwm_thrs(hyb_thrs);
-    #else
-      UNUSED(hyb_thrs);
-    #endif
+    st.set_pwm_thrs(TERN0(HYBRID_THRESHOLD, hyb_thrs)); UNUSED(hyb_thrs);
+
     st.GSTAT(); // Clear GSTAT
   }
 #endif // TMC5160


### PR DESCRIPTION
Fixing #19050

In the rare case when `HYBRID_THRESHOLD` is turned off as part of a firmware update, the stepper drivers will retain their old threshold settings until the board is power-cycled. This PR modifies the TMC support code so the threshold will be initialized to 0 (OFF) when `HYBRID_THRESHOLD` disabled instead of leaving them in an undefined state.