### PR TITLE
Warn about incompatible BLTouch settings

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1340,6 +1340,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
       #error "BLTOUCH_DELAY less than 200 is unsafe and is not supported."
     #elif DISABLED(BLTOUCH_SET_5V_MODE) && NONE(ONBOARD_ENDSTOPPULLUPS, ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN, ENDSTOPPULLUP_ZMIN_PROBE)
       #error "BLTOUCH without BLTOUCH_SET_5V_MODE requires ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN or ENDSTOPPULLUP_ZMIN_PROBE."
+    #elif defined(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN) && defined(USE_PROBE_FOR_Z_HOMING) && (defined(Z_MIN_PROBE_PIN) && Z_MIN_PROBE_PIN != 32)
+      #warning "Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN and USE_PROBE_FOR_Z_HOMING both defined with non-standard Z_MIN_PROBE_PIN. Verify this is intentional."
     #endif
   #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1341,7 +1341,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #elif DISABLED(BLTOUCH_SET_5V_MODE) && NONE(ONBOARD_ENDSTOPPULLUPS, ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN, ENDSTOPPULLUP_ZMIN_PROBE)
       #error "BLTOUCH without BLTOUCH_SET_5V_MODE requires ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN or ENDSTOPPULLUP_ZMIN_PROBE."
     #elif defined(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN) && defined(USE_PROBE_FOR_Z_HOMING) && (defined(Z_MIN_PROBE_PIN) && Z_MIN_PROBE_PIN != 32)
-      #warning "Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN and USE_PROBE_FOR_Z_HOMING both defined with non-standard Z_MIN_PROBE_PIN. Verify this is intentional."
+      #error "Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN and USE_PROBE_FOR_Z_HOMING both defined with a non-standard Z_MIN_PROBE_PIN. Uncomment this line to continue anyway."
     #endif
   #endif
 


### PR DESCRIPTION
Add warning: potentially incompatible BLTouch settings defined.

Description: Create a warning in SanityCheck.h (lines 1343-1344) to alert the user that defining both `Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN` and `USE_PROBE_FOR_Z_HOMING`, combined with a `Z_MIN_PROBE_PIN` other than 32 can results in issues homing the Z axis. This warning it to simply alert the user that of this potential should they be inadvertently be defined.

Benefits: Prevent new users from building firmware that cannot home the Z axis due to conflicting configuration items.

Add: Lines 1343-1344
```cpp
 #elif defined(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN) && defined(USE_PROBE_FOR_Z_HOMING) && (defined(Z_MIN_PROBE_PIN) && Z_MIN_PROBE_PIN != 32)
      #warning "Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN and USE_PROBE_FOR_Z_HOMING both defined with non-standard Z_MIN_PROBE_PIN. Verify this is intentional."
```