### PR TITLE
Skip scripts during 'platformio init'

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -3,6 +3,12 @@
 # Convenience script to apply customizations to CPP flags
 #
 Import("env")
+
+# Detect that 'vscode init' is running
+from SCons.Script import COMMAND_LINE_TARGETS
+if "idedata" in COMMAND_LINE_TARGETS:
+    env.Exit(0)
+
 env.Append(CXXFLAGS=[
   "-Wno-register"
   #"-Wno-incompatible-pointer-types",

--- a/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
@@ -2,8 +2,13 @@
 # common-dependencies-post.py
 # Convenience script to add build flags for Marlin Enabled Features
 #
-
 Import("env")
+
+# Detect that 'vscode init' is running
+from SCons.Script import COMMAND_LINE_TARGETS
+if "idedata" in COMMAND_LINE_TARGETS:
+    env.Exit(0)
+
 Import("projenv")
 
 def apply_board_build_flags():

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -2,6 +2,15 @@
 # common-dependencies.py
 # Convenience script to check dependencies and add libs and sources for Marlin Enabled Features
 #
+Import("env")
+
+#print(env.Dump())
+
+# Detect that 'vscode init' is running
+from SCons.Script import COMMAND_LINE_TARGETS
+if "idedata" in COMMAND_LINE_TARGETS:
+    env.Exit(0)
+
 import subprocess,os,re
 
 PIO_VERSION_MIN = (5, 0, 3)
@@ -30,10 +39,6 @@ except:
 
 from platformio.package.meta import PackageSpec
 from platformio.project.config import ProjectConfig
-
-Import("env")
-
-#print(env.Dump())
 
 try:
 	verbose = int(env.GetProjectOption('custom_verbose'))

--- a/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
+++ b/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
@@ -1,6 +1,13 @@
 #
 # copy_marlin_variant_to_framework.py
 #
+Import("env")
+
+# Detect that 'vscode init' is running
+from SCons.Script import COMMAND_LINE_TARGETS
+if "idedata" in COMMAND_LINE_TARGETS:
+    env.Exit(0)
+
 import os,shutil
 from SCons.Script import DefaultEnvironment
 from platformio import util

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -2,8 +2,14 @@
 # preflight-checks.py
 # Check for common issues prior to compiling
 #
-import os,re,sys
 Import("env")
+
+# Detect that 'vscode init' is running
+from SCons.Script import COMMAND_LINE_TARGETS
+if "idedata" in COMMAND_LINE_TARGETS:
+    env.Exit(0)
+
+import os,re,sys
 
 def get_envs_for_board(board):
 	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:


### PR DESCRIPTION
Currently when you start / reload VSCode the PlatformIO IDE extension runs `platformio -c vscode init -t vscode` using the `default_env`. This results in a long error message appearing in the Javascript console, because one of Marlin’s scripts is responsible for validating the active build, returning a list of problems, and if necessary, canceling the build.

Since these messages may be confusing, and this behavior is likely to interfere with `platformio init`, this PR adds code to the scripts to detect the difference and only run during a `build`, `debug`, `upload`, etc.

cc: @ellensp