### PR TITLE
Fix issue with status displaying service prompt when not needed

### DIFF
--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -319,7 +319,7 @@ void PrintCounter::reset() {
   }
 
   bool PrintCounter::needsService(const int index) {
-    if ( !loaded ) loadStats();
+    if (!loaded) loadStats();
     switch (index) {
       #if SERVICE_INTERVAL_1 > 0
         case 1: return data.nextService1 == 0;

--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -319,6 +319,7 @@ void PrintCounter::reset() {
   }
 
   bool PrintCounter::needsService(const int index) {
+    if ( !loaded ) loadStats();
     switch (index) {
       #if SERVICE_INTERVAL_1 > 0
         case 1: return data.nextService1 == 0;


### PR DESCRIPTION
## Description

### Observed Behaviour
When print counters and service intervals are enabled, on boot-up the status line shows that SERVICE_NAME_1 needs servicing
### Expected Behaviour
Status line should show "3D Printer Ready"

## How to Reproduce
- Enable PRINTCOUNTER, HAS_SERVICE_INTERVALS, uncomment SERVICE_INTERVAL_1 and SERVICE_NAME_1
- Disable DWIN_CREALITY_LCD.
- Build and flash firmware
- On boot up, reset Service Interval 1
- reboot printer

Status line will indicate "> Service S!"

## Root Cause
In MarlinCore.cpp, in the setup() function, this block of code executes before the call to settings.first_load():
`  #if ENABLED(DWIN_CREALITY_LCD)`
`    delay(800);   // Required delay (since boot?)`
`    SERIAL_ECHOPGM("\nDWIN handshake ");`
`    if (DWIN_Handshake()) SERIAL_ECHOLNPGM("ok."); else SERIAL_ECHOLNPGM("error.");`
`    DWIN_Frame_SetDir(1); // Orientation 90°`
`    DWIN_UpdateLCD();     // Show bootscreen (first image)`
`  #else`
`    SETUP_RUN(ui.init());`
`    #if HAS_WIRED_LCD && ENABLED(SHOW_BOOTSCREEN)`
`      SETUP_RUN(ui.show_bootscreen());`
`    #endif`
`    SETUP_RUN(ui.reset_status());     // Load welcome message early. (Retained if no errors exist.)`
`  #endif`

The call to ui.reset_status() calls PrintCounter::needsService(). Since the EEPROM settings have not yet been loaded, all service intervals are set to 0, which means the needsService() function returns true. This causes the status line to indicate that the service interval has been exceeded, when it may not actually have been.

##Fix
in the function PrintCounter::needsService, if the stats have not been loaded call loadStats():
`   bool PrintCounter::needsService(const int index) {`
`    if ( !loaded ) loadStats();`
`    switch (index) {`

I was debating whether to call loadStats() or just to return false.

## Benefits

Status menu no longer displays false positives for service intervals.

## Configurations
Attached .zip file has Configuration.h and Configuration_adv.h

## Related Issues
Bug fix, no known issues found in searching the current issues.
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6332102/Configuration.zip)

