### PR TITLE
Disable Z axis after change probe offset

### DIFF
--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -56,6 +56,11 @@ void menu_advanced_settings();
   void menu_delta_calibrate();
 #endif
 
+#if HAS_BED_PROBE
+  #include "../../module/stepper/indirection.h"
+  void disable_axis_z() { DISABLE_AXIS_Z(); }
+#endif
+
 #if ENABLED(LCD_PROGRESS_BAR_TEST)
 
   #include "../lcdprint.h"
@@ -509,7 +514,7 @@ void menu_configuration() {
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
     SUBMENU(MSG_ZPROBE_ZOFFSET, lcd_babystep_zoffset);
   #elif HAS_BED_PROBE
-    EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_ZPROBE_ZOFFSET, &probe.offset.z, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
+    EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_ZPROBE_ZOFFSET, &probe.offset.z, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX, disable_axis_z);
   #endif
 
   //


### PR DESCRIPTION
### Description

Hi!

After getting a bad first layer, I stopped the print, changed the Z offset through configuration menu and restarted. After that, my printer didn't home the axes again with `G28 O` and started the print at the same height as before changing the Z offset. That happened because it was homed _before_ changing the offset, and the homed state wasn't cleared after the change, so `G28 O` didn't home again, then the printer started to print using the same coordinates (and offset) as before.

To reproduce this:

1. Set the Z axis offset, for example, to -10.0
2. `G28`
3. `G0 Z20`
4. `G0 Z30`
5. Change the printer offset to another value, for example, 0.0
6. `G28 O` (note that this does nothing, as the three axes are homed)
7. `G0 Z20` (the Z axis goes to the same position as the step 2)

This PR just adds a callback that **disables the Z axis** to the Z probe offset `EDIT_ITEM`, so everytime that the Z probe offset is changed through the configuration menu, the Z axis will need to be homed again.

After applying this patch, and doing the same 1-5 steps:
6. `G28 O` (now it homes again)
7. `G0 Z20` (goes to the Z20 position relative to the new offset, instead of the same position of the step 2)

### Benefits

This PR will be useful for those who use `G28 O`, find that the Z probe offset is wrong during the print, and change it before starting the print again. This change will ensure that `G28 O` will home again and the new print will start at the correct height.

It also might be useful for other cases, as the Z position is not reliable after changing the offset and before homing again.
