### PR TITLE
Skip preflight checks only during PIO init

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -3,12 +3,6 @@
 # Convenience script to apply customizations to CPP flags
 #
 Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 env.Append(CXXFLAGS=[
   "-Wno-register"
   #"-Wno-incompatible-pointer-types",

--- a/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
@@ -2,13 +2,8 @@
 # common-dependencies-post.py
 # Convenience script to add build flags for Marlin Enabled Features
 #
+
 Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 Import("projenv")
 
 def apply_board_build_flags():

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -2,15 +2,6 @@
 # common-dependencies.py
 # Convenience script to check dependencies and add libs and sources for Marlin Enabled Features
 #
-Import("env")
-
-#print(env.Dump())
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 import subprocess,os,re
 
 PIO_VERSION_MIN = (5, 0, 3)
@@ -39,6 +30,10 @@ except:
 
 from platformio.package.meta import PackageSpec
 from platformio.project.config import ProjectConfig
+
+Import("env")
+
+#print(env.Dump())
 
 try:
 	verbose = int(env.GetProjectOption('custom_verbose'))

--- a/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
+++ b/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
@@ -1,13 +1,6 @@
 #
 # copy_marlin_variant_to_framework.py
 #
-Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 import os,shutil
 from SCons.Script import DefaultEnvironment
 from platformio import util

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -2,14 +2,8 @@
 # preflight-checks.py
 # Check for common issues prior to compiling
 #
-Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 import os,re,sys
+Import("env")
 
 def get_envs_for_board(board):
 	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:


### PR DESCRIPTION
Reverts MarlinFirmware/Marlin#21643

#21643 doesn't skip scripts, it simply completely aborts the execution of `idedata` target, that is used for VSCode integration. Without `idedata`, debugging doesn't work anymore.

I don't have any issue with `pio init` or `pio build`. It seems the original issue is related with a specific machine or pio install, and not a general issue.

I can investigate more the origin of #21643, if I have more information.