### PR TITLE
Skip preflight checks only during PIO init

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-cxxflags.py
+++ b/buildroot/share/PlatformIO/scripts/common-cxxflags.py
@@ -3,12 +3,6 @@
 # Convenience script to apply customizations to CPP flags
 #
 Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 env.Append(CXXFLAGS=[
   "-Wno-register"
   #"-Wno-incompatible-pointer-types",

--- a/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies-post.py
@@ -2,13 +2,8 @@
 # common-dependencies-post.py
 # Convenience script to add build flags for Marlin Enabled Features
 #
+
 Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 Import("projenv")
 
 def apply_board_build_flags():

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -2,15 +2,6 @@
 # common-dependencies.py
 # Convenience script to check dependencies and add libs and sources for Marlin Enabled Features
 #
-Import("env")
-
-#print(env.Dump())
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 import subprocess,os,re
 
 PIO_VERSION_MIN = (5, 0, 3)
@@ -39,6 +30,10 @@ except:
 
 from platformio.package.meta import PackageSpec
 from platformio.project.config import ProjectConfig
+
+Import("env")
+
+#print(env.Dump())
 
 try:
 	verbose = int(env.GetProjectOption('custom_verbose'))

--- a/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
+++ b/buildroot/share/PlatformIO/scripts/copy_marlin_variant_to_framework.py
@@ -1,13 +1,6 @@
 #
 # copy_marlin_variant_to_framework.py
 #
-Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 import os,shutil
 from SCons.Script import DefaultEnvironment
 from platformio import util

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -2,14 +2,8 @@
 # preflight-checks.py
 # Check for common issues prior to compiling
 #
-Import("env")
-
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" in COMMAND_LINE_TARGETS:
-    env.Exit(0)
-
 import os,re,sys
+Import("env")
 
 def get_envs_for_board(board):
 	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:
@@ -50,44 +44,50 @@ def check_envs(build_env, board_envs, config):
 					return True
 	return False
 
-# Sanity checks:
-if 'PIOENV' not in env:
-	raise SystemExit("Error: PIOENV is not defined. This script is intended to be used with PlatformIO")
+def sanity_check_target():
+	# Sanity checks:
+	if 'PIOENV' not in env:
+		raise SystemExit("Error: PIOENV is not defined. This script is intended to be used with PlatformIO")
 
-if 'MARLIN_FEATURES' not in env:
-	raise SystemExit("Error: this script should be used after common Marlin scripts")
+	if 'MARLIN_FEATURES' not in env:
+		raise SystemExit("Error: this script should be used after common Marlin scripts")
 
-if 'MOTHERBOARD' not in env['MARLIN_FEATURES']:
-	raise SystemExit("Error: MOTHERBOARD is not defined in Configuration.h")
+	if 'MOTHERBOARD' not in env['MARLIN_FEATURES']:
+		raise SystemExit("Error: MOTHERBOARD is not defined in Configuration.h")
 
-build_env = env['PIOENV']
-motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']
-board_envs = get_envs_for_board(motherboard)
-config = env.GetProjectConfig()
-result = check_envs("env:"+build_env, board_envs, config)
+	build_env = env['PIOENV']
+	motherboard = env['MARLIN_FEATURES']['MOTHERBOARD']
+	board_envs = get_envs_for_board(motherboard)
+	config = env.GetProjectConfig()
+	result = check_envs("env:"+build_env, board_envs, config)
 
-if not result:
-	err = "Error: Build environment '%s' is incompatible with %s. Use one of these: %s" % \
-		  ( build_env, motherboard, ", ".join([ e[4:] for e in board_envs if e.startswith("env:") ]) )
-	raise SystemExit(err)
+	if not result:
+		err = "Error: Build environment '%s' is incompatible with %s. Use one of these: %s" % \
+			  ( build_env, motherboard, ", ".join([ e[4:] for e in board_envs if e.startswith("env:") ]) )
+		raise SystemExit(err)
 
-#
-# Check for Config files in two common incorrect places
-#
-for p in [ env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config") ]:
-	for f in [ "Configuration.h", "Configuration_adv.h" ]:
-		if os.path.isfile(os.path.join(p, f)):
-			err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p
-			raise SystemExit(err)
+	#
+	# Check for Config files in two common incorrect places
+	#
+	for p in [ env['PROJECT_DIR'], os.path.join(env['PROJECT_DIR'], "config") ]:
+		for f in [ "Configuration.h", "Configuration_adv.h" ]:
+			if os.path.isfile(os.path.join(p, f)):
+				err = "ERROR: Config files found in directory %s. Please move them into the Marlin subfolder." % p
+				raise SystemExit(err)
 
-#
-# Check for old files indicating an entangled Marlin (mixing old and new code)
-#
-mixedin = []
-for p in [ os.path.join(env['PROJECT_DIR'], "Marlin/src/lcd/dogm") ]:
-	for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
-		if os.path.isfile(os.path.join(p, f)):
-			mixedin += [ f ]
-if mixedin:
-	err = "ERROR: Old files fell into your Marlin folder. Remove %s and try again" % ", ".join(mixedin)
-	raise SystemExit(err)
+	#
+	# Check for old files indicating an entangled Marlin (mixing old and new code)
+	#
+	mixedin = []
+	for p in [ os.path.join(env['PROJECT_DIR'], "Marlin/src/lcd/dogm") ]:
+		for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
+			if os.path.isfile(os.path.join(p, f)):
+				mixedin += [ f ]
+	if mixedin:
+		err = "ERROR: Old files fell into your Marlin folder. Remove %s and try again" % ", ".join(mixedin)
+		raise SystemExit(err)
+
+# Detect that 'vscode init' is running
+from SCons.Script import COMMAND_LINE_TARGETS
+if "idedata" not in COMMAND_LINE_TARGETS:
+    sanity_check_target()


### PR DESCRIPTION
Skip preflight checks during `platformio init` but allow other scripts to run.

As suggested in #21657