### PR TITLE
Prevent U8glib-HAL PIO Conflict

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -35,7 +35,7 @@ USES_LIQUIDCRYSTAL_I2C  = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2         = LiquidTWI2@1.2.7
 HAS_WIRED_LCD           = src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780    = src_filter=+<src/lcd/HD44780>
-HAS_MARLINUI_U8GLIB     = U8glib-HAL@~0.4.4
+HAS_MARLINUI_U8GLIB     = MarlinFirmware/U8glib-HAL@~0.4.4
                           src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT = src_filter=+<src/HAL/STM32/tft> +<src/HAL/STM32F1/tft> +<src/lcd/tft_io>
 HAS_FSMC_TFT            = src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp> +<src/HAL/STM32F1/tft/tft_fsmc.cpp>


### PR DESCRIPTION
### Description

Specify MarlinFirmware fork of U8glib-HAL to prevent PlatformIO from complaining about more than one package being found:

```log
Library Manager: Installing U8glib-HAL @ ~0.4.4
Library Manager: Warning! More than one package has been found by U8glib-HAL @ ~0.4.4 requirements:
 - marlinfirmware/U8glib-HAL @ 0.4.4
 - thinkyhead/U8glib-HAL @ 0.4.4
Library Manager: Please specify detailed REQUIREMENTS using package owner and version (showed above) to avoid name conflicts
```

### Requirements

Build with PlatformIO

### Benefits

Fewer warnings

### Configurations

Compile with a display that will enable the `HAS_MARLINUI_U8GLIB` flag (`REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER`, `CR10_STOCKDISPLAY`, etc.).

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/21647