### PR TITLE
Don't extrude while resuming from parked nozzle position after M600 filament change

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -598,7 +598,7 @@ void resume_print(const_float_t slow_load_length/*=0*/, const_float_t fast_load_
 
   if (!axes_should_home()) {
     // Move XY back to saved position
-    destination.set(resume_position.x, resume_position.y, current_position.z);
+    destination.set(resume_position.x, resume_position.y, current_position.z, current_position.e);
     prepare_internal_move_to_destination(NOZZLE_PARK_XY_FEEDRATE);
 
     // Move Z back to saved position


### PR DESCRIPTION
### Description

Current E-axis position was not taken into account.

### Benefits

Fixes #21669

### Configurations

ADVANCED_PAUSE_FEATURE with PARK_HEAD_ON_PAUSE

### Related Issues

#21669
