### PR TITLE
Fix Issue/Feature Request Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: 🪲 Report a bug
 description: Create a bug report to help improve Marlin Firmware
 title: "[BUG] (bug summary)"
-issue_body: true
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,6 @@
 name: 🪲 Report a bug
 description: Create a bug report to help improve Marlin Firmware
+title: "[BUG] (bug summary)"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,5 @@
 name: 🪲 Report a bug
 description: Create a bug report to help improve Marlin Firmware
-title: "[BUG] (bug summary)"
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,6 @@ name: ✨ Request a feature
 description: Request a new Marlin Firmware feature
 title: "[FR] (feature summary)"
 labels: 'T: Feature Request'
-issue_body: true
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,5 @@
 name: ✨ Request a feature
 description: Request a new Marlin Firmware feature
-title: "[FR] (feature summary)"
 labels: 'T: Feature Request'
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,6 @@
 name: ✨ Request a feature
 description: Request a new Marlin Firmware feature
+title: "[FR] (feature summary)"
 labels: 'T: Feature Request'
 body:
   - type: markdown


### PR DESCRIPTION
### Description

Issues/Feature Requests no longer work and it while may be a temporary GitHub glitch, @ellensp found these warnings when looking at the templates:

<p align="center"><img src="https://user-images.githubusercontent.com/13375512/115533999-2d877b80-a24c-11eb-89bf-b525b978da18.png" width="50%"></p>

### Requirements

GitHub

### Benefits

May fix Issue/Feature Requests not showing up, but if not, the `issue_body` lines should probably be removed anyway.

### Configurations

N/A

### Related Issues

N/A. Discussed on Discord.
