### PR TITLE
Clean up / improve generate_version functionality

### DIFF
--- a/buildroot/bin/generate_version
+++ b/buildroot/bin/generate_version
@@ -4,6 +4,8 @@
 #
 # Make a Version.h file to accompany CUSTOM_VERSION_FILE
 #
+# Authors: jbrazio, thinkyhead, InsanityAutomation, rfinnie
+#
 
 set -e
 

--- a/buildroot/bin/generate_version
+++ b/buildroot/bin/generate_version
@@ -5,46 +5,32 @@
 # Make a Version.h file to accompany CUSTOM_VERSION_FILE
 #
 
-DIR=${1:-"Marlin"}
+set -e
 
-# MRCC3=$( git merge-base HEAD upstream/bugfix-2.0.x 2>/dev/null )
-# MRCC2=$( git merge-base HEAD upstream/bugfix-1.1.x 2>/dev/null )
-# MRCC1=$( git merge-base HEAD upstream/1.1.x 2>/dev/null )
+DIR="${1:-Marlin}"
+READ_FILE="${READ_FILE:-${DIR}/Version.h}"
+WRITE_FILE="${WRITE_FILE:-${READ_FILE}}"
 
-# BASE='?'
-# if [[ -n $MRCC3 && $MRCC3 != $MRCC2 ]]; then
-#   BASE=bugfix-2.0.x
-# elif [[ -n $MRCC2 ]]; then
-#   BASE=bugfix-1.1.x
-# elif [[ -n $MRCC1 ]]; then
-#   BASE=1.1.x
-# fi
+BRANCH="$(git -C "${DIR}" symbolic-ref -q --short HEAD 2>/dev/null || true)"
+VERSION="$(git -C "${DIR}" describe --tags --first-parent 2>/dev/null || true)"
 
-BUILDATE=$(date '+%s')
-DISTDATE=$(date '+%Y-%m-%d %H:%M')
-
-BRANCH=$(git -C "${DIR}" symbolic-ref -q --short HEAD)
-VERSION=$(git -C "${DIR}" describe --tags --first-parent 2>/dev/null)
-
-[ -z "${BRANCH}" ] && BRANCH=$(echo "${TRAVIS_BRANCH}")
-[ -z "${VERSION}" ] && VERSION=$(git -C "${DIR}" describe --tags --first-parent --always 2>/dev/null)
-
-SHORT_BUILD_VERSION=$(echo "${BRANCH}")
-DETAILED_BUILD_VERSION=$(echo "${BRANCH}-${VERSION}")
+STRING_DISTRIBUTION_DATE="${STRING_DISTRIBUTION_DATE:-$(date '+%Y-%m-%d %H:%M')}"
+SHORT_BUILD_VERSION="${SHORT_BUILD_VERSION:-${BRANCH}}"
+DETAILED_BUILD_VERSION="${DETAILED_BUILD_VERSION:-${BRANCH}-${VERSION}}"
 
 # Gets some misc options from their defaults
-DEFAULT_MACHINE_UUID=$(awk -F'"' \
-  '/#define DEFAULT_MACHINE_UUID/{ print $2 }' < "${DIR}/Version.h")
-MACHINE_NAME=$(awk -F'"' \
-  '/#define MACHINE_NAME/{ print $2 }' < "${DIR}/Version.h")
-PROTOCOL_VERSION=$(awk -F'"' \
-  '/#define PROTOCOL_VERSION/{ print $2 }' < "${DIR}/Version.h")
-SOURCE_CODE_URL=$(awk -F'"' \
-  '/#define SOURCE_CODE_URL/{ print $2 }' < "${DIR}/Version.h")
-WEBSITE_URL=$(awk -F'"' \
-  '/#define WEBSITE_URL/{ print $2 }' < "${DIR}/Version.h")
+DEFAULT_MACHINE_UUID="${DEFAULT_MACHINE_UUID:-$(awk -F'"' \
+  '/#define DEFAULT_MACHINE_UUID/{ print $2 }' < "${READ_FILE}")}"
+MACHINE_NAME="${MACHINE_NAME:-$(awk -F'"' \
+  '/#define MACHINE_NAME/{ print $2 }' < "${READ_FILE}")}"
+PROTOCOL_VERSION="${PROTOCOL_VERSION:-$(awk -F'"' \
+  '/#define PROTOCOL_VERSION/{ print $2 }' < "${READ_FILE}")}"
+SOURCE_CODE_URL="${SOURCE_CODE_URL:-$(awk -F'"' \
+  '/#define SOURCE_CODE_URL/{ print $2 }' < "${READ_FILE}")}"
+WEBSITE_URL="${WEBSITE_URL:-$(awk -F'"' \
+  '/#define WEBSITE_URL/{ print $2 }' < "${READ_FILE}")}"
 
-cat > "${DIR}/Version.h" <<EOF
+cat > "${WRITE_FILE}" <<EOF
 /**
  * Marlin 3D Printer Firmware
  * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
@@ -97,7 +83,7 @@ cat > "${DIR}/Version.h" <<EOF
   * version was tagged.
   */
 #ifndef STRING_DISTRIBUTION_DATE
-  #define STRING_DISTRIBUTION_DATE "${DISTDATE}"
+  #define STRING_DISTRIBUTION_DATE "${STRING_DISTRIBUTION_DATE}"
 #endif
 
 /**


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Clean up / improve generate_version functionality

- Separate reading/writing filenames into READ_FILE/WRITE_FILE
- Allow defines to be overridden via environment variables
- Add `set -e` (but guard against no git repository)
- Add additional double-quote protections
- Remove comments which referred to obsolete BASE variable
- Remove unused BUILDATE (which was also a typo)
- Remove obsolete TRAVIS_BRANCH pointer
- Remove duplicated VERSION `git describe`

All changes should be backwards compatible with current usage
invocations.

No warnings against default `shellcheck` lint.

### Requirements

N/A, not hardware-dependent.

### Benefits

- Allows creation of generated version file with a filename which matches a non-default Configuration.h CUSTOM_VERSION_FILE.
- Allows overriding generated defines (e.g., a build farm building per-machine firmware with a custom MACHINE_NAME), or bypassing the logic used to assemble SHORT_BUILD_VERSION / DETAILED_BUILD_VERSION).
- Fixes a few places where filenames with spaces would fail.
- Cleaner code, passes `shellcheck`.

### Configurations

Any test-platform from the GH CI workflow will do.

Example usage:

Marlin/Configuration.h:
```c++
#define CUSTOM_VERSION_FILE _Version.h
```

Generation:
```shell
env WRITE_FILE=Marlin/_Version.h buildroot/bin/generate_version
```

### Related Issues

None
