### PR TITLE
Add MCP4451 Digipot Support for Azteeg X5 GT

### DIFF
--- a/Marlin/src/feature/digipot/digipot_mcp4451.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4451.cpp
@@ -40,6 +40,9 @@
 #elif MB(AZTEEG_X5_MINI, AZTEEG_X5_MINI_WIFI)
   #define DIGIPOT_I2C_FACTOR      113.5f
   #define DIGIPOT_I2C_MAX_CURRENT   2.0f
+#elif MB(AZTEEG_X5_GT)
+  #define DIGIPOT_I2C_FACTOR       51.0f
+  #define DIGIPOT_I2C_MAX_CURRENT   3.0f
 #else
   #define DIGIPOT_I2C_FACTOR      106.7f
   #define DIGIPOT_I2C_MAX_CURRENT   2.5f

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2846,7 +2846,7 @@ static_assert(hbm[Z_AXIS] >= 0, "HOMING_BUMP_MM.Z must be greater than or equal 
 #if HAS_MOTOR_CURRENT_I2C
   #if BOTH(DIGIPOT_MCP4018, DIGIPOT_MCP4451)
     #error "Enable only one of DIGIPOT_MCP4018 or DIGIPOT_MCP4451."
-  #elif !MB(MKS_SBASE) \
+#elif !MB(MKS_SBASE, AZTEEG_X5_GT, AZTEEG_X5_MINI, AZTEEG_X5_MINI_WIFI) \
     && (!defined(DIGIPOTS_I2C_SDA_X) || !defined(DIGIPOTS_I2C_SDA_Y) || !defined(DIGIPOTS_I2C_SDA_Z) || !defined(DIGIPOTS_I2C_SDA_E0) || !defined(DIGIPOTS_I2C_SDA_E1))
       #error "DIGIPOT_MCP4018/4451 requires DIGIPOTS_I2C_SDA_* pins to be defined."
   #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Allows use of the digipot stepper current controller on Azteeg X5 GT, Mini, and Mini Wifi boards, in particular the X5 GT (https://panucattdevices.freshdesk.com/support/solutions/folders/1000226597 + http://www.panucatt.com/azteeg_X5_GT_reprap_3d_printer_controller_p/ax5gt.htm) which was missing the required definitions.

### Requirements

Azteeg X5 GT or Mini series.

### Benefits

Sets the digipot factor and current limits for X5 GT, and fixes a bug where Mini and Mini+ (other LPC1769 boards in the same series) could not actually use the digipot despite having factor/limit defined because the check for software I2C pins did not correctly exempt the boards causing a build failure. This patch makes the Azteeg X5 GT board fully functional with Marlin 2.x.

### Configurations

Not sure if any config is needed? Just:

#define DIGIPOT_MCP4451 in Configuration_adv.h,  setting DIGIPOT_I2C_MOTOR_CURRENTS, and building for LPC1769. If you want a fully working config for the Azteeg X5 GT I can upload the config for my machine or whatever you need.

### Related Issues

n/a
