### PR TITLE
Make Cancel Objects reporting optional

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3641,6 +3641,9 @@
  * Implement M486 to allow Marlin to skip objects
  */
 //#define CANCEL_OBJECTS
+#if ENABLED(CANCEL_OBJECTS)
+  #define CANCEL_OBJECTS_REPORTING // Emit the current object as a status message
+#endif
 
 /**
  * I2C position encoders for closed loop control.

--- a/Marlin/src/feature/cancel_object.cpp
+++ b/Marlin/src/feature/cancel_object.cpp
@@ -43,7 +43,7 @@ void CancelObject::set_active_object(const int8_t obj) {
   else
     skipping = false;
 
-  #if HAS_STATUS_MESSAGE
+  #if HAS_STATUS_MESSAGE && ENABLED(CANCEL_OBJECTS_REPORTING)
     if (active_object >= 0)
       ui.status_printf_P(0, PSTR(S_FMT " %i"), GET_TEXT(MSG_PRINTING_OBJECT), int(active_object));
     else

--- a/Marlin/src/feature/cancel_object.cpp
+++ b/Marlin/src/feature/cancel_object.cpp
@@ -43,7 +43,7 @@ void CancelObject::set_active_object(const int8_t obj) {
   else
     skipping = false;
 
-  #if HAS_STATUS_MESSAGE && ENABLED(CANCEL_OBJECTS_REPORTING)
+  #if BOTH(HAS_STATUS_MESSAGE, CANCEL_OBJECTS_REPORTING)
     if (active_object >= 0)
       ui.status_printf_P(0, PSTR(S_FMT " %i"), GET_TEXT(MSG_PRINTING_OBJECT), int(active_object));
     else


### PR DESCRIPTION
### Description

Cancel objects is an awesome feature, allowing to partially cancel prints. However, it also always reports the status in the status line. This might not always be desirable. This PR adds a flag in configuration `CANCEL_OBJECTS_REPORTING` to turning on (default) or off (when undefined) cancel object reporting.

### Requirements

- Compile with `CANCEL_OBJECTS` enabled.
- Needs LCD or ExtUI implementation with status line.

### Benefits

When you have a slicer, or Octoprint inserting a M117 line with information (current layer, time remaining, whatever), the cancel objects always overrides the M117 status. When you have an ExtUI implementation showing the current object, or Octoprint plugin reporting the current object (because the current object is emitted over serial), then the M117 line can be used for other purposes.

### Configurations

See PR.

- Compile with `CANCEL_OBJECTS` enabled
- Enable or disable `CANCEL_OBJECTS_REPORTING`

### Related Issues

None.
