### PR TITLE
fix bootloop caused by liquidcrystal library

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -30,7 +30,7 @@ HAS_L64XX               = Arduino-L6470@0.8.0
 NEOPIXEL_LED            = Adafruit NeoPixel@1.5.0
                           src_filter=+<src/feature/leds/neopixel.cpp>
 TEMP_.+_IS_MAX31865     = Adafruit MAX31865 library@~1.1.0
-USES_LIQUIDCRYSTAL      = arduino-libraries/LiquidCrystal@^1.0.7
+USES_LIQUIDCRYSTAL      = fmalpartida/LiquidCrystal@1.3.4
 USES_LIQUIDCRYSTAL_I2C  = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2         = LiquidTWI2@1.2.7
 HAS_WIRED_LCD           = src_filter=+<src/lcd/lcdprint.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -30,7 +30,7 @@ HAS_L64XX               = Arduino-L6470@0.8.0
 NEOPIXEL_LED            = Adafruit NeoPixel@1.5.0
                           src_filter=+<src/feature/leds/neopixel.cpp>
 TEMP_.+_IS_MAX31865     = Adafruit MAX31865 library@~1.1.0
-USES_LIQUIDCRYSTAL      = fmalpartida/LiquidCrystal@1.3.4
+USES_LIQUIDCRYSTAL      = fmalpartida/LiquidCrystal@<=1.3.4
 USES_LIQUIDCRYSTAL_I2C  = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2         = LiquidTWI2@1.2.7
 HAS_WIRED_LCD           = src_filter=+<src/lcd/lcdprint.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -30,7 +30,7 @@ HAS_L64XX               = Arduino-L6470@0.8.0
 NEOPIXEL_LED            = Adafruit NeoPixel@1.5.0
                           src_filter=+<src/feature/leds/neopixel.cpp>
 TEMP_.+_IS_MAX31865     = Adafruit MAX31865 library@~1.1.0
-USES_LIQUIDCRYSTAL      = fmalpartida/LiquidCrystal@=1.5.0
+USES_LIQUIDCRYSTAL      = fmalpartida/LiquidCrystal@1.5.0
 USES_LIQUIDCRYSTAL_I2C  = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2         = LiquidTWI2@1.2.7
 HAS_WIRED_LCD           = src_filter=+<src/lcd/lcdprint.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -30,7 +30,7 @@ HAS_L64XX               = Arduino-L6470@0.8.0
 NEOPIXEL_LED            = Adafruit NeoPixel@1.5.0
                           src_filter=+<src/feature/leds/neopixel.cpp>
 TEMP_.+_IS_MAX31865     = Adafruit MAX31865 library@~1.1.0
-USES_LIQUIDCRYSTAL      = fmalpartida/LiquidCrystal@<=1.3.4
+USES_LIQUIDCRYSTAL      = fmalpartida/LiquidCrystal@=1.5.0
 USES_LIQUIDCRYSTAL_I2C  = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2         = LiquidTWI2@1.2.7
 HAS_WIRED_LCD           = src_filter=+<src/lcd/lcdprint.cpp>

--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -23,6 +23,7 @@ extra_scripts     = ${common.extra_scripts}
 src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768> +<src/HAL/shared/backtrace>
 lib_deps          = ${common.lib_deps}
   Servo
+custom_marlin.USES_LIQUIDCRYSTAL = fmalpartida/LiquidCrystal@1.3.4  
 custom_marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/1.5.0.zip
 build_flags       = ${common.build_flags} -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g
   # debug options for backtrace

--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -23,7 +23,7 @@ extra_scripts     = ${common.extra_scripts}
 src_filter        = ${common.default_src_filter} +<src/HAL/LPC1768> +<src/HAL/shared/backtrace>
 lib_deps          = ${common.lib_deps}
   Servo
-custom_marlin.USES_LIQUIDCRYSTAL = fmalpartida/LiquidCrystal@1.3.4  
+custom_marlin.USES_LIQUIDCRYSTAL =  arduino-libraries/LiquidCrystal@~1.0.7
 custom_marlin.NEOPIXEL_LED = Adafruit NeoPixel=https://github.com/p3p/Adafruit_NeoPixel/archive/1.5.0.zip
 build_flags       = ${common.build_flags} -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC1768/include -IMarlin/src/HAL/LPC1768/u8g
   # debug options for backtrace


### PR DESCRIPTION
fix bootloop caused by liquidcrystal 1.5.0 by reverting to 1.3.4