### PR TITLE
Fix E3V2 Advanced Settings without powerloss recovery (#21534)

### DIFF
--- a/Marlin/src/lcd/dwin/e3v2/dwin.cpp
+++ b/Marlin/src/lcd/dwin/e3v2/dwin.cpp
@@ -2381,10 +2381,12 @@ void Draw_AdvSet_Menu() {
   #endif
   if (AVISI(ADVSET_CASE_HEPID)) Draw_Menu_Line(ASCROL(ADVSET_CASE_HEPID), ICON_PIDNozzle, "Hotend PID", false);  // Nozzle PID
   if (AVISI(ADVSET_CASE_BEDPID)) Draw_Menu_Line(ASCROL(ADVSET_CASE_BEDPID), ICON_PIDbed, "Bed PID", false);  // Bed PID
-  if (AVISI(ADVSET_CASE_PWRLOSSR)) {
-    Draw_Menu_Line(ASCROL(ADVSET_CASE_PWRLOSSR), ICON_Motion, "Power-loss recovery", false);  // Power-loss recovery
-    Draw_Chkb_Line(ASCROL(ADVSET_CASE_PWRLOSSR), recovery.enabled);
-  }
+  #if ENABLED(POWER_LOSS_RECOVERY)
+    if (AVISI(ADVSET_CASE_PWRLOSSR)) {
+      Draw_Menu_Line(ASCROL(ADVSET_CASE_PWRLOSSR), ICON_Motion, "Power-loss recovery", false);  // Power-loss recovery
+      Draw_Chkb_Line(ASCROL(ADVSET_CASE_PWRLOSSR), recovery.enabled);
+    }
+  #endif
   if (select_advset.now) Draw_Menu_Cursor(ASCROL(select_advset.now));
 }
 
@@ -3409,10 +3411,12 @@ void HMI_AdvSet() {
           break;
       #endif
 
-      case ADVSET_CASE_PWRLOSSR:  // Power-loss recovery
-        recovery.enable(!recovery.enabled);
-        Draw_Chkb_Line(ADVSET_CASE_PWRLOSSR + MROWS - index_advset, recovery.enabled);
-        break;
+      #if ENABLED(POWER_LOSS_RECOVERY)
+        case ADVSET_CASE_PWRLOSSR:  // Power-loss recovery
+          recovery.enable(!recovery.enabled);
+          Draw_Chkb_Line(ADVSET_CASE_PWRLOSSR + MROWS - index_advset, recovery.enabled);
+          break;
+      #endif
       default: break;
     }
   }


### PR DESCRIPTION
### Description

Follow-up commit to #21534 to support builds with "POWER_LOSS_RECOVERY" disabled in "Configuration_adv.h"

### Requirements

* Ender 3 V2 with the original DWIN display

### Benefits

* Fixes #21534 with `POWER_LOSS_RECOVERY` disabled

### Configurations

* Configuration_adv.h : `//#define POWER_LOSS_RECOVERY`

### Related Issues

* Fixes #21534
