### PR TITLE
Fix "continuous" typo

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2842,7 +2842,7 @@
 
   /**
    * Enable M122 debugging command for TMC stepper drivers.
-   * M122 S0/1 will enable continous reporting.
+   * M122 S0/1 will enable continuous reporting.
    */
   //#define TMC_DEBUG
 

--- a/Marlin/src/HAL/STM32F1/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32F1/MarlinSerial.cpp
@@ -60,7 +60,7 @@ static inline __always_inline void my_usart_irq(ring_buffer *rb, ring_buffer *wb
   }
   else if (srflags & USART_SR_ORE) {
     // overrun and empty data, just do a dummy read to clear ORE
-    // and prevent a raise condition where a continous interrupt stream (due to ORE set) occurs
+    // and prevent a raise condition where a continuous interrupt stream (due to ORE set) occurs
     // (see chapter "Overrun error" ) in STM32 reference manual
     regs->DR;
   }

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -855,7 +855,7 @@ void MarlinUI::update() {
     static bool wait_for_unclick; // = false
 
     auto do_click = [&]{
-      wait_for_unclick = true;                        //  - Set debounce flag to ignore continous clicks
+      wait_for_unclick = true;                        //  - Set debounce flag to ignore continuous clicks
       lcd_clicked = !wait_for_user;                   //  - Keep the click if not waiting for a user-click
       wait_for_user = false;                          //  - Any click clears wait for user
       quick_feedback();                               //  - Always make a click sound


### PR DESCRIPTION
### Description

continous => continuous
