### PR TITLE
Update Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -151,3 +151,7 @@ body:
         If you've made any other modifications to the firmware, please describe them in detail in the space provided.
 
         When pasting formatted text into the box below don't forget to put ` ``` ` (on its own line) before and after to make it readable.
+
+  - type: textarea
+    attributes:
+      label: Additional information & file uploads

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -38,9 +38,7 @@ body:
     validations:
       required: true
 
-  - type: markdown
+  - type: textarea
     attributes:
-      value: >
-        **Additional context**
-
-        Add any other context or screenshots about the feature request here.
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
### Description

Bring back text area at the bottom of the bug report & feature request templates.

The last required changes dropped the textarea box at the bottom of the issue templates so the form simply ends:

**Bug Report**|**Feature Request**
:-----:|:-----:
<img src="https://user-images.githubusercontent.com/13375512/116005170-9bb89f00-a5ba-11eb-86f8-e814db4665fb.png">|<img src="https://user-images.githubusercontent.com/13375512/116006088-a8d78d00-a5be-11eb-8525-3b0ba587522e.png">

### Benefits

- Users can upload configs & related files
- Cut down on config/related file requests for new issues.