### PR TITLE
Fix typo: 'Automaticaly' to 'Automatically'

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -993,5 +993,5 @@ clean:
 
 .PHONY: all build elf hex eep lss sym program coff extcoff clean depend sizebefore sizeafter
 
-# Automaticaly include the dependency files created by gcc
+# Automatically include the dependency files created by gcc
 -include ${patsubst %.o, %.d, ${OBJ}}


### PR DESCRIPTION
### Description

Fix typo in comment in `Marlin/Makefile`: "Automaticaly" → "Automatically"

Comment changed only; no functional changes.

### Requirements

None.

### Benefits

Improves readability/correctness of comments.

### Configurations

None.

### Related Issues

None.