### PR TITLE
Drop buggy -fmerge-constants flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -36,7 +36,7 @@ extra_configs =
 # Remove '-fmax-errors=5' from build_flags below to see all.
 #
 [common]
-build_flags        = -g3 -D__MARLIN_FIRMWARE__ -DNDEBUG -fmerge-constants
+build_flags        = -g3 -D__MARLIN_FIRMWARE__ -DNDEBUG
                      -fmax-errors=5
 extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/common-dependencies.py


### PR DESCRIPTION
### Description

Some time ago, we drop `-fmerge-constants-all` because it's buggy. So, now we discovered that `-fmerge-constants` is also buggy.

This PR drops this buggy and not worthy flag.

See #20389 to details of the GCC issue...

### Benefits

More stable marlin.
Less hidden and hard to track bugs.

Fix #21358 

### Related Issues

#21358 
#20389
