### PR TITLE
Add probe & chamber pins to BTT SKR V2

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0.h
@@ -200,15 +200,35 @@
 #define TEMP_0_PIN                          PA2   // TH0
 #define TEMP_1_PIN                          PA3   // TH1
 
+#if HOTENDS == 1
+  #if TEMP_SENSOR_PROBE
+    #define TEMP_PROBE_PIN           TEMP_1_PIN
+  #elif TEMP_SENSOR_CHAMBER
+    #define TEMP_CHAMBER_PIN         TEMP_1_PIN
+  #endif
+#endif
+
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN                        PB3   // Heater0
-#define HEATER_1_PIN                        PB4   // Heater1
-#define HEATER_BED_PIN                      PD7   // Hotbed
-#define FAN_PIN                             PB7   // Fan0
-#define FAN1_PIN                            PB6   // Fan1
-#define FAN2_PIN                            PB5   // Fan2
+#ifndef HEATER_0_PIN
+  #define HEATER_0_PIN                      PB3   // Heater0
+#endif
+#ifndef HEATER_1_PIN
+  #define HEATER_1_PIN                      PB4   // Heater1
+#endif
+#ifndef HEATER_BED_PIN
+  #define HEATER_BED_PIN                    PD7   // Hotbed
+#endif
+#ifndef FAN_PIN
+  #define FAN_PIN                           PB7   // Fan0
+#endif
+#ifndef FAN1_PIN
+  #define FAN1_PIN                          PB6   // Fan1
+#endif
+#ifndef FAN2_PIN
+  #define FAN2_PIN                          PB5   // Fan2
+#endif
 
 //
 // Software SPI pins for TMC2130 stepper drivers


### PR DESCRIPTION
### Description

Add probe & chamber temperature sensor pins to BTT SKR V2 and allow for pins to be overridden like the previous SKR boards.

### Related Issues

None. Found while updating some SKR 1.3/1.4 builds that were using a PINDA V2 probe (with a thermistor).