### PR TITLE
Fix misleading docstring

### DIFF
--- a/Marlin/src/libs/duration_t.h
+++ b/Marlin/src/libs/duration_t.h
@@ -115,7 +115,8 @@ struct duration_t {
    * @brief Formats the duration as a string
    * @details String will be formated using a "full" representation of duration
    *
-   * @param buffer The array pointed to must be able to accommodate 21 bytes
+   * @param buffer The array pointed to must be able to accommodate 22 bytes
+   *               (21 for the string, 1 more for the terminating nul)
    *
    * Output examples:
    *  123456789012345678901 (strlen)


### PR DESCRIPTION
### Description

In Marlin/src/libs/duration_t.h, fix docstring of duration_t::toString(), which incorrectly stated that the `buffer' array must be able to hold 21 bytes. It actually must be able to hold 22, or the terminating nul could overflow.

### Requirements

None

### Benefits

Improves correctness of docstrings.

### Configurations

Not applicable.

### Related Issues

None.