### PR TITLE
Fix compile with DISTINCT_E_FACTORS + SLIM_LCD_MENUS

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -350,15 +350,13 @@ void menu_backlash();
 
 #if DISABLED(SLIM_LCD_MENUS)
 
-  #if ENABLED(DISTINCT_E_FACTORS)
-    inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
-    inline void _planner_refresh_e_positioning(const uint8_t e) {
-      if (e == active_extruder)
-        planner.refresh_positioning();
-      else
-        planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
-    }
-  #endif
+  inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
+  inline void _planner_refresh_e_positioning(const uint8_t e) {
+    if (e == active_extruder)
+      planner.refresh_positioning();
+    else
+      planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
+  }
 
   // M203 / M205 Velocity options
   void menu_advanced_velocity() {
@@ -515,17 +513,6 @@ void menu_backlash();
       END_MENU();
     }
   #endif
-
-#else  // !SLIM_LCD_MENUS           
-  #if ENABLED(DISTINCT_E_FACTORS)     
-    inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
-    inline void _planner_refresh_e_positioning(const uint8_t e) {
-      if (e == active_extruder)
-        planner.refresh_positioning();
-      else
-        planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
-    }
-  #endif 
 
 #endif // !SLIM_LCD_MENUS
 

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -350,14 +350,6 @@ void menu_backlash();
 
 #if DISABLED(SLIM_LCD_MENUS)
 
-  inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
-  inline void _planner_refresh_e_positioning(const uint8_t e) {
-    if (e == active_extruder)
-      planner.refresh_positioning();
-    else
-      planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
-  }
-
   // M203 / M205 Velocity options
   void menu_advanced_velocity() {
     // M203 Max Feedrate
@@ -441,7 +433,10 @@ void menu_backlash();
     #if ENABLED(DISTINCT_E_FACTORS)
       EDIT_ITEM_FAST(long5_25, MSG_AMAX_E, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(active_extruder)], 100, max_accel_edit_scaled.e, []{ planner.reset_acceleration_rates(); });
       LOOP_L_N(n, E_STEPPERS)
-        EDIT_ITEM_FAST_N(long5_25, n, MSG_AMAX_EN, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(n)], 100, max_accel_edit_scaled.e, []{ _reset_e_acceleration_rate(MenuItemBase::itemIndex); });
+        EDIT_ITEM_FAST_N(long5_25, n, MSG_AMAX_EN, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(n)], 100, max_accel_edit_scaled.e, []{
+          if (MenuItemBase::itemIndex == active_extruder)
+            planner.reset_acceleration_rates();
+       });
     #elif E_STEPPERS
       EDIT_ITEM_FAST(long5_25, MSG_AMAX_E, &planner.settings.max_acceleration_mm_per_s2[E_AXIS], 100, max_accel_edit_scaled.e, []{ planner.reset_acceleration_rates(); });
     #endif
@@ -528,7 +523,13 @@ void menu_advanced_steps_per_mm() {
 
   #if ENABLED(DISTINCT_E_FACTORS)
     LOOP_L_N(n, E_STEPPERS)
-      EDIT_ITEM_FAST_N(float51, n, MSG_EN_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(n)], 5, 9999, []{ _planner_refresh_e_positioning(MenuItemBase::itemIndex); });
+      EDIT_ITEM_FAST_N(float51, n, MSG_EN_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(n)], 5, 9999, []{
+        const uint8_t e = MenuItemBase::itemIndex;
+        if (e == active_extruder)
+          planner.refresh_positioning();
+        else
+          planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
+      });
   #elif E_STEPPERS
     EDIT_ITEM_FAST(float51, MSG_E_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS], 5, 9999, []{ planner.refresh_positioning(); });
   #endif

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -516,6 +516,17 @@ void menu_backlash();
     }
   #endif
 
+#else  // !SLIM_LCD_MENUS           
+  #if ENABLED(DISTINCT_E_FACTORS)     
+    inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
+    inline void _planner_refresh_e_positioning(const uint8_t e) {
+      if (e == active_extruder)
+        planner.refresh_positioning();
+      else
+        planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
+    }
+  #endif 
+
 #endif // !SLIM_LCD_MENUS
 
 // M92 Steps-per-mm


### PR DESCRIPTION
Solution to compilation error when DISTINCT_E_FACTORS and SLIM_LCD_MENUS are activated.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Hello.
When trying to free up space from PROGMEM, I turned on SLIM_LCD_MENUS. But the compilation fails with the following error.

![image](https://user-images.githubusercontent.com/83166168/116472303-03e6d980-a876-11eb-8126-ac8a8792fdd0.png)


I found that '_planner_refresh_e_positioning' is defined in the same file associated with the error, "menu_advanced.cpp", and that it was linked to the active DISTINCT_E_FACTORS. But it also depended on SLIM_LCD_MENUS being disabled. That is, as the original code is, either SLIM_LCD_MENUS is disabled, or it is not possible to define the function '_planner_refresh_e_positioning'.

![image](https://user-images.githubusercontent.com/83166168/116472322-0c3f1480-a876-11eb-834b-873b6ce07fd5.png)


As I needed both configurations, I added a '#else' to the '#if' associated with the SLIM_LCD_MENUS validation disabled to always define '_planner_refresh_e_positioning', like this;
![image](https://user-images.githubusercontent.com/83166168/116472337-13662280-a876-11eb-99e9-313bb7140dd4.png)

As a result, the compilation finishes OK, with both settings active.
There is mention of this same error in #18147, but no solution was provided.
I can assume there will be a more refined solution, but this seemed the fastest to me.


### Requirements

Double extruder, on 8-bit board. 

### Benefits

To be able to release PROGMEN, without losing the DISTINCT_E_FACTORS configuration.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

#21720
