### PR TITLE
Fix BTT E3 RRF and SKR V2 Generic PIO Board

### DIFF
--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -181,7 +181,7 @@ build_flags       = ${stm_flash_drive.build_flags}
 [env:BIGTREE_E3_RRF]
 platform            = ${common_stm32.platform}
 extends             = common_stm32
-board               = genericSTM32F407VGT6
+board               = marlin_STM32F407VGT6_CCM
 board_build.variant = MARLIN_BIGTREE_E3_RRF
 build_flags         = ${common_stm32.build_flags}
   -DSTM32F407_5VX -DVECT_TAB_OFFSET=0x8000
@@ -234,7 +234,7 @@ extra_scripts     = ${common.extra_scripts}
 platform             = ${common_stm32.platform}
 platform_packages    = ${stm_flash_drive.platform_packages}
 extends              = common_stm32
-board                = genericSTM32F407VGT6
+board                = marlin_STM32F407VGT6_CCM
 board_build.core     = stm32
 board_build.variant  = MARLIN_F4x7Vx
 board_build.ldscript = ldscript.ld


### PR DESCRIPTION
### Description

Follow-up to https://github.com/MarlinFirmware/Marlin/pull/21655 to rename E3 RRF and SKR V2 env boards to match new name.

H/T to @rhapsodyv for finding it.

### Benefits

Boards will now boot.

### Related Issues

#21732
#21655