### PR TITLE
Fix resuming after powerloss on parked nozzle (with z-homing)

### DIFF
--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -78,8 +78,9 @@ void GcodeSuite::M125() {
   // If possible, show an LCD prompt with the 'P' flag
   const bool show_lcd = TERN0(HAS_LCD_MENU, parser.boolval('P'));
 
+  TERN_(POWER_LOSS_RECOVERY, if (recovery.enabled) recovery.save(true));
+
   if (pause_print(retract, park_point, 0, show_lcd)) {
-    TERN_(POWER_LOSS_RECOVERY, if (recovery.enabled) recovery.save(true));
     if (ENABLED(EXTENSIBLE_UI) || !sd_printing || show_lcd) {
       wait_for_confirmation(false, 0);
       resume_print(0, 0, -retract, 0);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This fixes resuming after having parked the nozzle (on pause), then turning off (power-loss), and resuming after power up.

With this fix it is possible to pause long-time prints safely, powering off the printer, and then resume the next day.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

It is required to enable some configuration:
* ADVANCED_PAUSE_FEATURE
  * PARK_HEAD_ON_PAUSE
* POWER_LOSS_RECOVERY
  * POWER_LOSS_MIN_Z_CHANGE with high value, e.g. 1000.0
  * POWER_LOSS_RECOVER_ZHOME
  * POWER_LOSS_ZHOME_POS

Tested on Creality Ender 3 with board 4.2.2.

### Benefits

Previously, on resuming, the printer first printed "in the air". Only when hitting the first GCODE with Z coordinates, started to turn down to (then false) Z coordinates.

The wrong coordinates have been saved: it was saved after parking, not before parking the nozzle. With this patch, the coordinates are saved correctly.

Assuming POWER_LOSS_MIN_Z_CHANGE has a very high value (which would never be reached), it is possible to pause the print (and turning off the printer) without wear leveling the SD card on machines without UPS.

When parking the nozzle, you can avoid filament blobs when the nozzle would park right on the piece you print.

### Configurations

Configurations for Ender 3:
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6407082/Configuration.zip)

See requirements.

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->

none

### Remark / Outlook

What I already have prepared, making this possible without z-homing, just after pause with nozzle parking turning off, then on power on resume correctly.