### PR TITLE
set SDCARD_CONNECTION to LCD only if a LCD is present (on skr lpc176x boards) 

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
@@ -52,6 +52,37 @@
 #define E0_DIR_PIN                         P2_13
 #define E0_ENABLE_PIN                      P2_12
 
+
+/**
+ *               _____                                   _____
+ *           NC | 1 2 | GND                          5V | 1 2 | GND
+ *        RESET | 3 4 | 1.31                         NC | 3 4 | NC
+ *         0.18 | 5 6   3.25                         NC | 5 6   0.15
+ *         1.23 | 7 8 | 3.26                       0.16 | 7 8 | 0.18
+ *         0.15 | 9 10| 0.17                       2.11 | 9 10| 1.30
+ *               -----                                   -----
+ *               EXP2                                    EXP1
+ */
+
+#define EXP1_03_PIN                        -1
+#define EXP1_04_PIN                        -1
+#define EXP1_05_PIN                        -1
+#define EXP1_06_PIN                        P0_15
+#define EXP1_07_PIN                        P0_16
+#define EXP1_08_PIN                        P0_18
+#define EXP1_09_PIN                        P2_11
+#define EXP1_10_PIN                        P1_30
+
+#define EXP2_03_PIN                        -1
+#define EXP2_04_PIN                        P1_31
+#define EXP2_05_PIN                        P0_18
+#define EXP2_06_PIN                        P3_25
+#define EXP2_07_PIN                        P1_23
+#define EXP2_08_PIN                        P3_26
+#define EXP2_09_PIN                        P0_15
+#define EXP2_10_PIN                        P0_17
+
+
 /**
  * LCD / Controller
  *
@@ -68,26 +99,23 @@
 #if IS_TFTGLCD_PANEL
 
   #if ENABLED(TFTGLCD_PANEL_SPI)
-    #define TFTGLCD_CS                     P3_26
+    #define TFTGLCD_CS               EXP2_08_PIN
   #endif
-
-  #define SD_DETECT_PIN                    P1_31
 
 #elif HAS_WIRED_LCD
 
-  #define BTN_EN1                          P3_26
-  #define BTN_EN2                          P3_25
-  #define BTN_ENC                          P2_11
+  #define BTN_EN1                    EXP2_08_PIN
+  #define BTN_EN2                    EXP2_06_PIN
+  #define BTN_ENC                    EXP1_09_PIN
 
-  #define SD_DETECT_PIN                    P1_31
-  #define LCD_SDSS                         P1_23
-  #define LCD_PINS_RS                      P0_16
-  #define LCD_PINS_ENABLE                  P0_18
-  #define LCD_PINS_D4                      P0_15
+  #define LCD_SDSS                   EXP2_07_PIN
+  #define LCD_PINS_RS                EXP1_07_PIN
+  #define LCD_PINS_ENABLE            EXP2_05_PIN
+  #define LCD_PINS_D4                EXP2_09_PIN
 
   #if ENABLED(MKS_MINI_12864)
     #define DOGLCD_CS                      P2_06
-    #define DOGLCD_A0                      P0_16
+    #define DOGLCD_A0                EXP1_07_PIN
   #endif
 
 #endif // HAS_WIRED_LCD
@@ -104,10 +132,6 @@
   #else
     #define SDCARD_CONNECTION            ONBOARD
   #endif
-#endif
-
-#if SD_CONNECTION_IS(LCD)
-  #define SD_SS_PIN                        P1_23
 #endif
 
 // Trinamic driver support
@@ -140,10 +164,10 @@
   // When using any TMC SPI-based drivers, software SPI is used
   // because pins may be shared with the display or SD card.
   #define TMC_USE_SW_SPI
-  #define TMC_SW_MOSI                      P0_18
-  #define TMC_SW_MISO                      P0_17
+  #define TMC_SW_MOSI                EXP2_05_PIN
+  #define TMC_SW_MISO                EXP2_10_PIN
   // To minimize pin usage use the same clock pin as the display/SD card reader. (May generate LCD noise.)
-  #define TMC_SW_SCK                       P0_15
+  #define TMC_SW_SCK                 EXP2_09_PIN
   // If pin 2_06 is unused, it can be used for the clock to avoid the LCD noise.
   //#define TMC_SW_SCK                     P2_06
 
@@ -186,14 +210,11 @@
     //            SDCARD_CONNECTION must not be 'LCD'. Nothing should be connected to EXP1/EXP2.
     //#define SKR_USE_LCD_PINS_FOR_CS
     #if ENABLED(SKR_USE_LCD_PINS_FOR_CS)
-      #if SD_CONNECTION_IS(LCD)
-        #error "SDCARD_CONNECTION must not be 'LCD' with SKR_USE_LCD_PINS_FOR_CS."
-      #endif
-      #define X_CS_PIN                     P1_23
-      #define Y_CS_PIN                     P3_26
-      #define Z_CS_PIN                     P2_11
-      #define E0_CS_PIN                    P3_25
-      #define E1_CS_PIN                    P1_31
+      #define X_CS_PIN               EXP2_07_PIN
+      #define Y_CS_PIN               EXP2_08_PIN
+      #define Z_CS_PIN               EXP1_09_PIN
+      #define E0_CS_PIN              EXP2_06_PIN
+      #define E1_CS_PIN              EXP2_04_PIN
     #endif
 
     // Example 2: A REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
@@ -201,19 +222,16 @@
     //            the pins will be in use. So SDCARD_CONNECTION must not be 'LCD'.
     //#define SKR_USE_LCD_SD_CARD_PINS_FOR_CS
     #if ENABLED(SKR_USE_LCD_SD_CARD_PINS_FOR_CS)
-      #if SD_CONNECTION_IS(LCD)
-        #error "SDCARD_CONNECTION must not be 'LCD' with SKR_USE_LCD_SD_CARD_PINS_FOR_CS."
-      #endif
       #define X_CS_PIN                     P0_02
       #define Y_CS_PIN                     P0_03
       #define Z_CS_PIN                     P2_06
       // We use SD_DETECT_PIN for E0
       #undef SD_DETECT_PIN
-      #define E0_CS_PIN                    P1_31
+      #define E0_CS_PIN              EXP2_04_PIN
       // We use LCD_SDSS pin for E1
       #undef LCD_SDSS
       #define LCD_SDSS                     -1
-      #define E1_CS_PIN                    P1_23
+      #define E1_CS_PIN              EXP2_07_PIN
     #endif
 
     // Example 3: Use the driver enable pins for chip-select.

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -372,7 +372,11 @@
 //
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION                  LCD
+  #if HAS_WIRED_LCD
+    #define SDCARD_CONNECTION                LCD
+  #else
+    #define SDCARD_CONNECTION            ONBOARD
+  #endif
 #endif
 
 #if SD_CONNECTION_IS(LCD)

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -367,22 +367,6 @@
 
 #endif // HAS_WIRED_LCD
 
-//
-// SD Support
-//
-
-#ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
-    #define SDCARD_CONNECTION                LCD
-  #else
-    #define SDCARD_CONNECTION            ONBOARD
-  #endif
-#endif
-
-#if SD_CONNECTION_IS(LCD)
-  #define SD_SS_PIN                  EXP2_07_PIN
-#endif
-
 /**
  * Special pins
  *   P1_30  (37) (NOT 5V tolerant)

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -35,7 +35,11 @@
 // SD Connection
 //
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION LCD
+  #if HAS_WIRED_LCD
+    #define SDCARD_CONNECTION                LCD
+  #else
+    #define SDCARD_CONNECTION            ONBOARD
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -32,17 +32,6 @@
 #endif
 
 //
-// SD Connection
-//
-#ifndef SDCARD_CONNECTION
-  #if HAS_WIRED_LCD
-    #define SDCARD_CONNECTION                LCD
-  #else
-    #define SDCARD_CONNECTION            ONBOARD
-  #endif
-#endif
-
-//
 // Servos
 //
 #define SERVO0_PIN                         P2_00
@@ -267,13 +256,6 @@
 #define EXP2_09_PIN                        P0_15
 #define EXP2_10_PIN                        P0_17
 
-//
-// SD Connection
-//
-#if SD_CONNECTION_IS(LCD)
-  #define SD_SS_PIN                  EXP2_07_PIN
-#endif
-
 /**
  *               _____                                             _____
  *           NC | · · | GND                                    5V | · · | GND
@@ -446,10 +428,6 @@
     #define LCD_PINS_D4              EXP1_06_PIN
 
     #define LCD_SDSS                 EXP2_07_PIN  // (16) J3-7 & AUX-4
-
-    #if SD_CONNECTION_IS(LCD)
-      #define SD_DETECT_PIN          EXP2_04_PIN  // (49) (NOT 5V tolerant)
-    #endif
 
     #if ENABLED(FYSETC_MINI_12864)
       #define DOGLCD_CS              EXP1_08_PIN

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
@@ -105,12 +105,28 @@
 //
 // SD Support
 //
+#ifndef SDCARD_CONNECTION
+  #if HAS_WIRED_LCD
+    #define SDCARD_CONNECTION                LCD
+  #else
+    #define SDCARD_CONNECTION            ONBOARD
+  #endif
+#endif
+
+
 #define ONBOARD_SD_CS_PIN                  P0_06  // Chip select for "System" SD card
+
+#if SD_CONNECTION_IS(LCD) && ENABLED(SKR_USE_LCD_SD_CARD_PINS_FOR_CS)
+  #error "SDCARD_CONNECTION must not be 'LCD' with SKR_USE_LCD_PINS_FOR_CS."
+#endif
 
 #if SD_CONNECTION_IS(LCD)
   #define SD_SCK_PIN                       P0_15
   #define SD_MISO_PIN                      P0_17
   #define SD_MOSI_PIN                      P0_18
+  #define SD_SS_PIN                  EXP2_07_PIN
+  #define SD_DETECT_PIN              EXP2_04_PIN
+
 #elif SD_CONNECTION_IS(ONBOARD)
   #undef SD_DETECT_PIN
   #define SD_DETECT_PIN                    P0_27


### PR DESCRIPTION
### Description

On a BTT SKR 1.3 or BTT SKR 1.4 when SDSUPPORT is enabled but you don't have a LCD. If you don't manually set SDCARD_CONNECTION it defaults to LCD. Even when you don't have an LCD.
This messes with pins P0_15 and P0_16 , making uart 1 unusable.
This would also interfere with a BTT_EXP_MOT module

I added the test that if HAS_WIRED_LCD is not enabled then SDCARD_CONNECTION defaults to ONBOARD not LCD 

### Requirements

BTT SKR 1.3 or BTT SKR 1.4
SDSUPPORT
no LCD enabled
SDCARD_CONNECTION undefined.

### Benefits

Works as expected without pin conflicts 

### Related Issues
Discussions with Marek.T on Discord, When they tried to enable uart 1 and it would not work. 
