### PR TITLE
Fix filament load M701 not raising nozzle #21750

### DIFF
--- a/Marlin/src/gcode/feature/pause/M701_M702.cpp
+++ b/Marlin/src/gcode/feature/pause/M701_M702.cpp
@@ -97,7 +97,7 @@ void GcodeSuite::M701() {
   };
 
   // Raise the Z axis (with max limit)
-  const float park_raise = _MIN(0, park_point.z, (Z_MAX_POS) - current_position.z);
+  const float park_raise = _MIN(park_point.z, (Z_MAX_POS) - current_position.z);
   move_z_by(park_raise);
 
   // Load filament


### PR DESCRIPTION
### Description

This resolves the issue that the Z-axis is no longer raised during loading of filament.

### Requirements

Run M701, watch how the nozzle is now raised, then lowered.

### Benefits

It resolves the issue.

### Configurations

- `ADVANCED_PAUSE_FEATURE`
- `FILAMENT_LOAD_UNLOAD_GCODES`
- `NOZZLE_PARK_FEATURE`

### Related Issues

#21750
#21564
