### PR TITLE
Add missing onMeshUpdate in  anycubic_i3mega_lcd.cpp

### DIFF
--- a/Marlin/src/lcd/extui/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega_lcd.cpp
@@ -100,6 +100,10 @@ namespace ExtUI {
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
     }
+
+    void onMeshUpdate(const int8_t xpos, const int8_t ypos, probe_state_t state) {
+      // Called when any mesh points are updated
+    }
   #endif
 
   #if ENABLED(POWER_LOSS_RECOVERY)


### PR DESCRIPTION
### Description

Fix issue #21761
undefined reference to `ExtUI::onMeshUpdate(signed char, signed char, ExtUI::probe_state_t)'
Created missing definition 

### Requirements

ANYCUBIC_LCD_I3MEGA and MESH_BED_LEVELING

### Benefits

Compiles as expected

### Configurations
Stock AnyCubic/i3 Mega
https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/AnyCubic/i3%20Mega

### Related Issues

issue #21761