### PR TITLE
Allow Creality V4 SERVO0 and PROBE pin overrides

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -58,10 +58,12 @@
 //
 // Servos
 //
-#ifndef HAS_PIN_27_BOARD
-  #define SERVO0_PIN                        PB0   // BLTouch OUT
-#else
-  #define SERVO0_PIN                        PC6
+#ifndef SERVO0_PIN
+  #ifndef HAS_PIN_27_BOARD
+    #define SERVO0_PIN                      PB0   // BLTouch OUT
+  #else
+    #define SERVO0_PIN                      PC6
+  #endif
 #endif
 
 //
@@ -71,7 +73,9 @@
 #define Y_STOP_PIN                          PA6
 #define Z_STOP_PIN                          PA7
 
-#define Z_MIN_PROBE_PIN                     PB1   // BLTouch IN
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PB1   // BLTouch IN
+#endif
 
 //
 // Filament Runout Sensor


### PR DESCRIPTION

### Description

This adds a check that SERVO0_PIN and Z_MIN_PROBE_PIN haven't already been defined via the Configuration.h file for the Creality v4 boards, similar to other board configs.

### Requirements

This change is for the Creality v4 board series.

### Benefits

This is important as the standard PB1 (Z_MIN_PROBE_PIN) pin seems to blink at 20Hz for 1 second after a system reset from the kill(), and I need to be able to redefine these pins from the Configuration.h to be able to fully utilize all exposed pins on this board. Allowing it in upstream may come in handy for other people as well.
