### PR TITLE
Allow disable of currently-required POWER_TIMEOUT

### DIFF
--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -99,6 +99,10 @@ bool Power::is_power_needed() {
   return false;
 }
 
+#ifndef POWER_TIMEOUT
+  #define POWER_TIMEOUT 0
+#endif
+
 void Power::check() {
   static millis_t nextPowerCheck = 0;
   millis_t ms = millis();
@@ -106,12 +110,8 @@ void Power::check() {
     nextPowerCheck = ms + 2500UL;
     if (is_power_needed())
       power_on();
-    else if (!lastPowerOn)
+    else if (!lastPowerOn || (POWER_TIMEOUT > 0 && ELAPSED(ms, lastPowerOn + SEC_TO_MS(POWER_TIMEOUT))))
       power_off();
-    #ifdef POWER_TIMEOUT
-      else if (ELAPSED(ms, lastPowerOn + SEC_TO_MS(POWER_TIMEOUT)))
-        power_off();
-    #endif
   }
 }
 
@@ -139,11 +139,7 @@ void Power::power_off() {
 
 void Power::power_off_soon() {
   #if POWER_OFF_DELAY
-    #ifdef POWER_TIMEOUT
-      lastPowerOn = millis() - SEC_TO_MS(POWER_TIMEOUT) + SEC_TO_MS(POWER_OFF_DELAY);
-    #else
-      lastPowerOn = millis() + SEC_TO_MS(POWER_OFF_DELAY);
-    #endif
+    lastPowerOn = millis() - SEC_TO_MS(POWER_TIMEOUT) + SEC_TO_MS(POWER_OFF_DELAY);
   #else
     power_off();
   #endif

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -106,8 +106,12 @@ void Power::check() {
     nextPowerCheck = ms + 2500UL;
     if (is_power_needed())
       power_on();
-    else if (!lastPowerOn || ELAPSED(ms, lastPowerOn + SEC_TO_MS(POWER_TIMEOUT)))
+    else if (!lastPowerOn)
       power_off();
+    #ifdef POWER_TIMEOUT
+      else if (ELAPSED(ms, lastPowerOn + SEC_TO_MS(POWER_TIMEOUT)))
+        power_off();
+    #endif
   }
 }
 
@@ -135,7 +139,11 @@ void Power::power_off() {
 
 void Power::power_off_soon() {
   #if POWER_OFF_DELAY
-    lastPowerOn = millis() - SEC_TO_MS(POWER_TIMEOUT) + SEC_TO_MS(POWER_OFF_DELAY);
+    #ifdef POWER_TIMEOUT
+      lastPowerOn = millis() - SEC_TO_MS(POWER_TIMEOUT) + SEC_TO_MS(POWER_OFF_DELAY);
+    #else
+      lastPowerOn = millis() + SEC_TO_MS(POWER_OFF_DELAY);
+    #endif
   #else
     power_off();
   #endif


### PR DESCRIPTION
### Description

The value of`POWER_TIMEOUT` is used by the `powerManager` object in `Marlin/src/feature/power.cpp` to calculate `lastPowerOn` and whether or not the PSU should be turned off. This PR fixes the calculation of `lastPowerOn` to not use that value and the conditional turning off of the PSU is disabled.

### Requirements

A printer using automatic power on/off

### Benefits

Configs with `AUTO_POWER_CONTROL` defined without defining `POWER_TIMEOUT`  can be built. Result will be that `Power::check` won't call `power_off` after a certain period of time anymore whenever `manage_inactivity` is called so the printer won't turn off.

### Configurations

[Configurations.zip](https://github.com/MarlinFirmware/Marlin/files/6410831/Configurations.zip)

Configurations are pretty much stock from [here](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Anet/E16/BTT%20SKR%201.3). All I did was add a line defining `PS_ON_PIN`, uncommented `#define AUTO_POWER_CONTROL` and commented out `#define POWER_TIMEOUT`.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/21475
