### PR TITLE
Fix BUG G33 KO#21767

### DIFF
--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -350,15 +350,13 @@ void menu_backlash();
 
 #if DISABLED(SLIM_LCD_MENUS)
 
-  #if ENABLED(DISTINCT_E_FACTORS)
-    inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
-    inline void _planner_refresh_e_positioning(const uint8_t e) {
-      if (e == active_extruder)
-        planner.refresh_positioning();
-      else
-        planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
-    }
-  #endif
+  inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
+  inline void _planner_refresh_e_positioning(const uint8_t e) {
+    if (e == active_extruder)
+      planner.refresh_positioning();
+    else
+      planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
+  }
 
   // M203 / M205 Velocity options
   void menu_advanced_velocity() {
@@ -515,17 +513,6 @@ void menu_backlash();
       END_MENU();
     }
   #endif
-
-#else  // !SLIM_LCD_MENUS           
-  #if ENABLED(DISTINCT_E_FACTORS)     
-    inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
-    inline void _planner_refresh_e_positioning(const uint8_t e) {
-      if (e == active_extruder)
-        planner.refresh_positioning();
-      else
-        planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
-    }
-  #endif 
 
 #endif // !SLIM_LCD_MENUS
 

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -350,14 +350,6 @@ void menu_backlash();
 
 #if DISABLED(SLIM_LCD_MENUS)
 
-  inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
-  inline void _planner_refresh_e_positioning(const uint8_t e) {
-    if (e == active_extruder)
-      planner.refresh_positioning();
-    else
-      planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
-  }
-
   // M203 / M205 Velocity options
   void menu_advanced_velocity() {
     // M203 Max Feedrate
@@ -441,7 +433,10 @@ void menu_backlash();
     #if ENABLED(DISTINCT_E_FACTORS)
       EDIT_ITEM_FAST(long5_25, MSG_AMAX_E, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(active_extruder)], 100, max_accel_edit_scaled.e, []{ planner.reset_acceleration_rates(); });
       LOOP_L_N(n, E_STEPPERS)
-        EDIT_ITEM_FAST_N(long5_25, n, MSG_AMAX_EN, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(n)], 100, max_accel_edit_scaled.e, []{ _reset_e_acceleration_rate(MenuItemBase::itemIndex); });
+        EDIT_ITEM_FAST_N(long5_25, n, MSG_AMAX_EN, &planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(n)], 100, max_accel_edit_scaled.e, []{
+          if (MenuItemBase::itemIndex == active_extruder)
+            planner.reset_acceleration_rates();
+       });
     #elif E_STEPPERS
       EDIT_ITEM_FAST(long5_25, MSG_AMAX_E, &planner.settings.max_acceleration_mm_per_s2[E_AXIS], 100, max_accel_edit_scaled.e, []{ planner.reset_acceleration_rates(); });
     #endif
@@ -528,7 +523,13 @@ void menu_advanced_steps_per_mm() {
 
   #if ENABLED(DISTINCT_E_FACTORS)
     LOOP_L_N(n, E_STEPPERS)
-      EDIT_ITEM_FAST_N(float51, n, MSG_EN_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(n)], 5, 9999, []{ _planner_refresh_e_positioning(MenuItemBase::itemIndex); });
+      EDIT_ITEM_FAST_N(float51, n, MSG_EN_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS_N(n)], 5, 9999, []{
+        const uint8_t e = MenuItemBase::itemIndex;
+        if (e == active_extruder)
+          planner.refresh_positioning();
+        else
+          planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
+      });
   #elif E_STEPPERS
     EDIT_ITEM_FAST(float51, MSG_E_STEPS, &planner.settings.axis_steps_per_mm[E_AXIS], 5, 9999, []{ planner.refresh_positioning(); });
   #endif

--- a/Marlin/src/lcd/menu/menu_advanced.cpp
+++ b/Marlin/src/lcd/menu/menu_advanced.cpp
@@ -516,6 +516,17 @@ void menu_backlash();
     }
   #endif
 
+#else  // !SLIM_LCD_MENUS           
+  #if ENABLED(DISTINCT_E_FACTORS)     
+    inline void _reset_e_acceleration_rate(const uint8_t e) { if (e == active_extruder) planner.reset_acceleration_rates(); }
+    inline void _planner_refresh_e_positioning(const uint8_t e) {
+      if (e == active_extruder)
+        planner.refresh_positioning();
+      else
+        planner.steps_to_mm[E_AXIS_N(e)] = 1.0f / planner.settings.axis_steps_per_mm[E_AXIS_N(e)];
+    }
+  #endif 
+
 #endif // !SLIM_LCD_MENUS
 
 // M92 Steps-per-mm

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -424,11 +424,10 @@ void _internal_move_to_destination(const_feedRate_t fr_mm_s/*=0.0f*/
     const float old_fac = planner.e_factor[active_extruder];
     planner.e_factor[active_extruder] = 1.0f;
   #endif
+  
+  if (TERN0(IS_KINEMATIC, is_fast)) prepare_fast_move_to_destination();
 
-  if (TERN0(IS_KINEMATIC, is_fast))
-    TERN(IS_KINEMATIC, NOOP, prepare_line_to_destination());
-  else
-    prepare_line_to_destination();
+  prepare_line_to_destination();
 
   feedrate_mm_s = old_feedrate;
   feedrate_percentage = old_pct;

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -424,9 +424,9 @@ void _internal_move_to_destination(const_feedRate_t fr_mm_s/*=0.0f*/
     const float old_fac = planner.e_factor[active_extruder];
     planner.e_factor[active_extruder] = 1.0f;
   #endif
-  
-  if (TERN0(IS_KINEMATIC, is_fast)) prepare_fast_move_to_destination();
 
+  //if (TERN0(IS_KINEMATIC, is_fast)) prepare_fast_move_to_destination();
+  if (TERN0(IS_KINEMATIC, is_fast)) prepare_internal_move_to_destination();
   prepare_line_to_destination();
 
   feedrate_mm_s = old_feedrate;


### PR DESCRIPTION
### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->
With the latest changes to motion.cpp, autocalibration for deltas has stopped working. G33 fails with "Probing Failed" message.
I have located an error in the code, comparing with the previous version of 'bugfix 2.0.x' that if it worked.

I show you what my solution is.

![image](https://user-images.githubusercontent.com/83166168/116810865-65dd6280-ab46-11eb-8852-41943a6f777e.png)



### Requirements

Trigorilla V1. Mega2560.

### Benefits

Fix 'Probing Failed' error when executing G33.



### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->
I include .txt with log output with G33 OK and G33 KO in your current version of motion.cpp.
[Debuging_G33_KO.txt](https://github.com/MarlinFirmware/Marlin/files/6411205/Debuging_G33_KO.txt)
[Debuging_G33_OK_.txt](https://github.com/MarlinFirmware/Marlin/files/6411206/Debuging_G33_OK_.txt)
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6411202/Configuration.zip)



### Related Issues

#21767
