### PR TITLE
UMW follow up

### DIFF
--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -643,7 +643,6 @@ void _menu_ubl_tools() {
     #endif
 
     ACTION_ITEM(MSG_INFO_SCREEN, ui.return_to_status);
-    
     END_MENU();
   }
 

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -627,11 +627,11 @@ void _menu_ubl_tools() {
     BACK_ITEM(MSG_UBL_LEVEL_BED);
 
     #if HAS_HOTEND
-      EDIT_ITEM(int3, MSG_UBL_HOTEND_TEMP_CUSTOM, &custom_hotend_temp, 25, thermalManager.hotend_max_target(0));
+      EDIT_ITEM(int3, MSG_UBL_HOTEND_TEMP_CUSTOM, &custom_hotend_temp, HEATER_0_MINTEMP + 20, thermalManager.hotend_max_target(0));
     #endif
 
     #if HAS_HEATED_BED
-      EDIT_ITEM(int3, MSG_UBL_BED_TEMP_CUSTOM, &custom_bed_temp, 25, BED_MAX_TARGET);
+      EDIT_ITEM(int3, MSG_UBL_BED_TEMP_CUSTOM, &custom_bed_temp, BED_MINTEMP + 20, BED_MAX_TARGET);
     #endif
 
     EDIT_ITEM(int3, MSG_UBL_STORAGE_SLOT, &ubl_storage_slot, 0, total_slots);

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -642,6 +642,8 @@ void _menu_ubl_tools() {
       SUBMENU(MSG_UBL_VALIDATE_MESH_MENU, _lcd_ubl_validate_mesh);
     #endif
 
+    ACTION_ITEM(MSG_INFO_SCREEN, ui.return_to_status);
+    
     END_MENU();
   }
 

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -626,11 +626,11 @@ void _menu_ubl_tools() {
     BACK_ITEM(MSG_UBL_LEVEL_BED);
 
     #if HAS_HOTEND
-      EDIT_ITEM(int3, MSG_UBL_HOTEND_TEMP_CUSTOM, &custom_hotend_temp, HEATER_0_MINTEMP, thermalManager.hotend_max_target(0));
+      EDIT_ITEM(int3, MSG_UBL_HOTEND_TEMP_CUSTOM, &custom_hotend_temp, 25, thermalManager.hotend_max_target(0));
     #endif
 
     #if HAS_HEATED_BED
-      EDIT_ITEM(int3, MSG_UBL_BED_TEMP_CUSTOM, &custom_bed_temp, BED_MINTEMP, BED_MAX_TARGET);
+      EDIT_ITEM(int3, MSG_UBL_BED_TEMP_CUSTOM, &custom_bed_temp, 25, BED_MAX_TARGET);
     #endif
 
     EDIT_ITEM(int3, MSG_UBL_STORAGE_SLOT, &ubl_storage_slot, 0, total_slots);

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -618,6 +618,7 @@ void _menu_ubl_tools() {
       sprintf_P(ubl_lcd_gcode, PSTR("M1004S%i"), ubl_storage_slot);
     #endif
     queue.inject(ubl_lcd_gcode);
+    ui.goto_previous_screen();
   }
 
   void _menu_ubl_mesh_wizard() {

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -618,7 +618,7 @@ void _menu_ubl_tools() {
       sprintf_P(ubl_lcd_gcode, PSTR("M1004S%i"), ubl_storage_slot);
     #endif
     queue.inject(ubl_lcd_gcode);
-    ui.goto_previous_screen();
+    ui.return_to_status
   }
 
   void _menu_ubl_mesh_wizard() {
@@ -642,7 +642,6 @@ void _menu_ubl_tools() {
       SUBMENU(MSG_UBL_VALIDATE_MESH_MENU, _lcd_ubl_validate_mesh);
     #endif
 
-    ACTION_ITEM(MSG_INFO_SCREEN, ui.return_to_status);
     END_MENU();
   }
 

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -618,7 +618,7 @@ void _menu_ubl_tools() {
       sprintf_P(ubl_lcd_gcode, PSTR("M1004S%i"), ubl_storage_slot);
     #endif
     queue.inject(ubl_lcd_gcode);
-    ui.return_to_status;
+    ui.goto_previous_screen();
   }
 
   void _menu_ubl_mesh_wizard() {

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -626,7 +626,7 @@ void _menu_ubl_tools() {
     BACK_ITEM(MSG_UBL_LEVEL_BED);
 
     #if HAS_HOTEND
-      EDIT_ITEM(int3, MSG_UBL_HOTEND_TEMP_CUSTOM, &custom_hotend_temp, EXTRUDE_MINTEMP, thermalManager.hotend_max_target(0));
+      EDIT_ITEM(int3, MSG_UBL_HOTEND_TEMP_CUSTOM, &custom_hotend_temp, HEATER_0_MINTEMP, thermalManager.hotend_max_target(0));
     #endif
 
     #if HAS_HEATED_BED

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -618,7 +618,7 @@ void _menu_ubl_tools() {
       sprintf_P(ubl_lcd_gcode, PSTR("M1004S%i"), ubl_storage_slot);
     #endif
     queue.inject(ubl_lcd_gcode);
-    ui.goto_previous_screen();
+    ui.return_to_status();
   }
 
   void _menu_ubl_mesh_wizard() {

--- a/Marlin/src/lcd/menu/menu_ubl.cpp
+++ b/Marlin/src/lcd/menu/menu_ubl.cpp
@@ -618,7 +618,7 @@ void _menu_ubl_tools() {
       sprintf_P(ubl_lcd_gcode, PSTR("M1004S%i"), ubl_storage_slot);
     #endif
     queue.inject(ubl_lcd_gcode);
-    ui.return_to_status
+    ui.return_to_status;
   }
 
   void _menu_ubl_mesh_wizard() {


### PR DESCRIPTION
UMW = UBL Mesh Wizard
adjust the min temp for UMW menu to account for setting a temp lower then room temp that cant be reached.
return to info menu when UMW is run to help user to understand UMW was run and is starting.