### PR TITLE
G60-G61 added E position

### DIFF
--- a/Marlin/src/gcode/feature/pause/G60.cpp
+++ b/Marlin/src/gcode/feature/pause/G60.cpp
@@ -48,10 +48,11 @@ void GcodeSuite::G60() {
 
   #if ENABLED(SAVED_POSITIONS_DEBUG)
     const xyze_pos_t &pos = stored_position[slot];
-    DEBUG_ECHOPAIR_F(STR_SAVED_POS " S", slot);
+    DEBUG_ECHOPAIR(STR_SAVED_POS " S", (int)slot);
     DEBUG_ECHOPAIR_F(" : X", pos.x);
     DEBUG_ECHOPAIR_F_P(SP_Y_STR, pos.y);
-    DEBUG_ECHOLNPAIR_F_P(SP_Z_STR, pos.z);
+    DEBUG_ECHOPAIR_F_P(SP_Z_STR, pos.z);
+    DEBUG_ECHOLNPAIR_F_P(SP_E_STR, pos.e);
   #endif
 }
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -102,7 +102,7 @@ xyze_pos_t destination; // {0}
 // G60/G61 Position Save and Return
 #if SAVED_POSITIONS
   uint8_t saved_slots[(SAVED_POSITIONS + 7) >> 3];
-  xyz_pos_t stored_position[SAVED_POSITIONS];
+  xyze_pos_t stored_position[SAVED_POSITIONS];
 #endif
 
 // The active extruder (tool). Set with T<extruder> command.

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -45,7 +45,7 @@ extern xyze_pos_t current_position,  // High-level current tool position
 // G60/G61 Position Save and Return
 #if SAVED_POSITIONS
   extern uint8_t saved_slots[(SAVED_POSITIONS + 7) >> 3];
-  extern xyz_pos_t stored_position[SAVED_POSITIONS];
+  extern xyze_pos_t stored_position[SAVED_POSITIONS];
 #endif
 
 // Scratch space for a cartesian result


### PR DESCRIPTION
### Description
Adds E position to save point
Adds option for restoring E position
Adds default restore angorithm

### Problem
if using G60, G61 for pause action, if inside pause manipulate with filament (load unload with G1 code)
the position of filament will changed. After resume and G61 we have a confuse at first next line in printing file with G1 E...

### Benefits
This update provide a E option for restoring filament position, and short form G61 for default restoring.