### PR TITLE
Fix [XYZ]_ENABLE_PIN defines for sensitive pins

### DIFF
--- a/Marlin/src/pins/sensitive_pins.h
+++ b/Marlin/src/pins/sensitive_pins.h
@@ -55,8 +55,13 @@
 #else
   #define _X_MS3
 #endif
+#if AXIS_HAS_UART(X) && defined SOFTWARE_DRIVER_ENABLE
+  #define _X_ENABLE_PIN
+#else
+  #define _X_ENABLE_PIN X_ENABLE_PIN,
+#endif
 
-#define _X_PINS X_STEP_PIN, X_DIR_PIN, X_ENABLE_PIN, _X_MIN _X_MAX _X_MS1 _X_MS2 _X_MS3 _X_CS
+#define _X_PINS X_STEP_PIN, X_DIR_PIN, _X_ENABLE_PIN _X_MIN _X_MAX _X_MS1 _X_MS2 _X_MS3 _X_CS
 
 #if PIN_EXISTS(Y_MIN)
   #define _Y_MIN Y_MIN_PIN,
@@ -88,8 +93,13 @@
 #else
   #define _Y_MS3
 #endif
+#if AXIS_HAS_UART(Y) && defined SOFTWARE_DRIVER_ENABLE
+  #define _Y_ENABLE_PIN
+#else
+  #define _Y_ENABLE_PIN Y_ENABLE_PIN,
+#endif
 
-#define _Y_PINS Y_STEP_PIN, Y_DIR_PIN, Y_ENABLE_PIN, _Y_MIN _Y_MAX _Y_MS1 _Y_MS2 _Y_MS3 _Y_CS
+#define _Y_PINS Y_STEP_PIN, Y_DIR_PIN, _Y_ENABLE_PIN _Y_MIN _Y_MAX _Y_MS1 _Y_MS2 _Y_MS3 _Y_CS
 
 #if PIN_EXISTS(Z_MIN)
   #define _Z_MIN Z_MIN_PIN,
@@ -121,8 +131,13 @@
 #else
   #define _Z_MS3
 #endif
+#if AXIS_HAS_UART(Z) && defined SOFTWARE_DRIVER_ENABLE
+  #define _Z_ENABLE_PIN
+#else
+  #define _Z_ENABLE_PIN Z_ENABLE_PIN,
+#endif
 
-#define _Z_PINS Z_STEP_PIN, Z_DIR_PIN, Z_ENABLE_PIN, _Z_MIN _Z_MAX _Z_MS1 _Z_MS2 _Z_MS3 _Z_CS
+#define _Z_PINS Z_STEP_PIN, Z_DIR_PIN, _Z_ENABLE_PIN _Z_MIN _Z_MAX _Z_MS1 _Z_MS2 _Z_MS3 _Z_CS
 
 //
 // Extruder Chip Select, Digital Micro-steps

--- a/Marlin/src/pins/sensitive_pins.h
+++ b/Marlin/src/pins/sensitive_pins.h
@@ -55,10 +55,10 @@
 #else
   #define _X_MS3
 #endif
-#if AXIS_HAS_UART(X) && defined SOFTWARE_DRIVER_ENABLE
-  #define _X_ENABLE_PIN
-#else
+#if PIN_EXISTS(X_ENABLE)
   #define _X_ENABLE_PIN X_ENABLE_PIN,
+#else
+  #define _X_ENABLE_PIN
 #endif
 
 #define _X_PINS X_STEP_PIN, X_DIR_PIN, _X_ENABLE_PIN _X_MIN _X_MAX _X_MS1 _X_MS2 _X_MS3 _X_CS
@@ -93,10 +93,10 @@
 #else
   #define _Y_MS3
 #endif
-#if AXIS_HAS_UART(Y) && defined SOFTWARE_DRIVER_ENABLE
-  #define _Y_ENABLE_PIN
-#else
+#if PIN_EXISTS(Y_ENABLE)
   #define _Y_ENABLE_PIN Y_ENABLE_PIN,
+#else
+  #define _Y_ENABLE_PIN
 #endif
 
 #define _Y_PINS Y_STEP_PIN, Y_DIR_PIN, _Y_ENABLE_PIN _Y_MIN _Y_MAX _Y_MS1 _Y_MS2 _Y_MS3 _Y_CS
@@ -131,10 +131,10 @@
 #else
   #define _Z_MS3
 #endif
-#if AXIS_HAS_UART(Z) && defined SOFTWARE_DRIVER_ENABLE
-  #define _Z_ENABLE_PIN
-#else
+#if PIN_EXISTS(Z_ENABLE)
   #define _Z_ENABLE_PIN Z_ENABLE_PIN,
+#else
+  #define _Z_ENABLE_PIN
 #endif
 
 #define _Z_PINS Z_STEP_PIN, Z_DIR_PIN, _Z_ENABLE_PIN _Z_MIN _Z_MAX _Z_MS1 _Z_MS2 _Z_MS3 _Z_CS


### PR DESCRIPTION
…bled

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Marlin requires X, Y, and Z driver enable pins to be defined. At the same time some Trinamic drivers do not have EN pins and Marlin supports Enable over UART per the option SOFTWARE_DRIVER_ENABLE.

I want to control my TMC2209s and TMC2208s over UART, including Software Enable control, which allows me to re-use the GPIOs used for (hardware) EN as Software UART lines.

For this reason I disabled the requirement of having an EN pin for an axis defined if both conditions are met:
* The driver for the axis has UART control
* SOFTWARE_DRIVER_ENABLE is defined

### Requirements

./.

### Benefits

EN pins do not have to be defined if SOFTWARE_DRIVER_ENABLE is selected and the axis stepper driver has a UART interface, thus saving a GPIO pin that is not used.

### Configurations

./.

### Related Issues

./.
