### PR TITLE
Don't check for upload disk if not uploading.

### DIFF
--- a/Marlin/src/HAL/LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -13,6 +13,7 @@ import os,getpass,platform
 current_OS = platform.system()
 Import("env")
 
+
 def print_error(e):
 	print('\nUnable to find destination disk (%s)\n' \
 		  'Please select it in platformio.ini using the upload_port keyword ' \
@@ -20,101 +21,104 @@ def print_error(e):
 		  'or copy the firmware (.pio/build/%s/firmware.bin) manually to the appropriate disk\n' \
 		  %(e, env.get('PIOENV')))
 
-try:
-	#
-	# Find a disk for upload
-	#
-	upload_disk = 'Disk not found'
-	target_file_found = False
-	target_drive_found = False
-	if current_OS == 'Windows':
+def before_upload(source, target, env):
+	try:
 		#
-		# platformio.ini will accept this for a Windows upload port designation: 'upload_port = L:'
-		#   Windows - doesn't care about the disk's name, only cares about the drive letter
-		import subprocess,string
-		from ctypes import windll
+		# Find a disk for upload
+		#
+		upload_disk = 'Disk not found'
+		target_file_found = False
+		target_drive_found = False
+		if current_OS == 'Windows':
+			#
+			# platformio.ini will accept this for a Windows upload port designation: 'upload_port = L:'
+			#   Windows - doesn't care about the disk's name, only cares about the drive letter
+			import subprocess,string
+			from ctypes import windll
 
-		# getting list of drives
-		# https://stackoverflow.com/questions/827371/is-there-a-way-to-list-all-the-available-drive-letters-in-python
-		drives = []
-		bitmask = windll.kernel32.GetLogicalDrives()
-		for letter in string.ascii_uppercase:
-			if bitmask & 1:
-				drives.append(letter)
-			bitmask >>= 1
+			# getting list of drives
+			# https://stackoverflow.com/questions/827371/is-there-a-way-to-list-all-the-available-drive-letters-in-python
+			drives = []
+			bitmask = windll.kernel32.GetLogicalDrives()
+			for letter in string.ascii_uppercase:
+				if bitmask & 1:
+					drives.append(letter)
+				bitmask >>= 1
 
-		for drive in drives:
-			final_drive_name = drive + ':\\'
-			# print ('disc check: {}'.format(final_drive_name))
-			try:
-				volume_info = str(subprocess.check_output('cmd /C dir ' + final_drive_name, stderr=subprocess.STDOUT))
-			except Exception as e:
-				print ('error:{}'.format(e))
-				continue
-			else:
-				if target_drive in volume_info and not target_file_found:  # set upload if not found target file yet
-					target_drive_found = True
-					upload_disk = final_drive_name
-				if target_filename in volume_info:
-					if not target_file_found:
+			for drive in drives:
+				final_drive_name = drive + ':\\'
+				# print ('disc check: {}'.format(final_drive_name))
+				try:
+					volume_info = str(subprocess.check_output('cmd /C dir ' + final_drive_name, stderr=subprocess.STDOUT))
+				except Exception as e:
+					print ('error:{}'.format(e))
+					continue
+				else:
+					if target_drive in volume_info and not target_file_found:  # set upload if not found target file yet
+						target_drive_found = True
 						upload_disk = final_drive_name
-					target_file_found = True
+					if target_filename in volume_info:
+						if not target_file_found:
+							upload_disk = final_drive_name
+						target_file_found = True
 
-	elif current_OS == 'Linux':
-		#
-		# platformio.ini will accept this for a Linux upload port designation: 'upload_port = /media/media_name/drive'
-		#
-		drives = os.listdir(os.path.join(os.sep, 'media', getpass.getuser()))
-		if target_drive in drives:  # If target drive is found, use it.
-			target_drive_found = True
-			upload_disk = os.path.join(os.sep, 'media', getpass.getuser(), target_drive) + os.sep
-		else:
+		elif current_OS == 'Linux':
+			#
+			# platformio.ini will accept this for a Linux upload port designation: 'upload_port = /media/media_name/drive'
+			#
+			drives = os.listdir(os.path.join(os.sep, 'media', getpass.getuser()))
+			if target_drive in drives:  # If target drive is found, use it.
+				target_drive_found = True
+				upload_disk = os.path.join(os.sep, 'media', getpass.getuser(), target_drive) + os.sep
+			else:
+				for drive in drives:
+					try:
+						files = os.listdir(os.path.join(os.sep, 'media', getpass.getuser(), drive))
+					except:
+						continue
+					else:
+						if target_filename in files:
+							upload_disk = os.path.join(os.sep, 'media', getpass.getuser(), drive) + os.sep
+							target_file_found = True
+							break
+			#
+			# set upload_port to drive if found
+			#
+
+			if target_file_found or target_drive_found:
+				env.Replace(
+					UPLOAD_FLAGS="-P$UPLOAD_PORT"
+				)
+
+		elif current_OS == 'Darwin':  # MAC
+			#
+			# platformio.ini will accept this for a OSX upload port designation: 'upload_port = /media/media_name/drive'
+			#
+			drives = os.listdir('/Volumes')  # human readable names
+			if target_drive in drives and not target_file_found:  # set upload if not found target file yet
+				target_drive_found = True
+				upload_disk = '/Volumes/' + target_drive + '/'
 			for drive in drives:
 				try:
-					files = os.listdir(os.path.join(os.sep, 'media', getpass.getuser(), drive))
+					filenames = os.listdir('/Volumes/' + drive + '/')   # will get an error if the drive is protected
 				except:
 					continue
 				else:
-					if target_filename in files:
-						upload_disk = os.path.join(os.sep, 'media', getpass.getuser(), drive) + os.sep
+					if target_filename in filenames:
+						if not target_file_found:
+							upload_disk = '/Volumes/' + drive + '/'
 						target_file_found = True
-						break
-		#
-		# set upload_port to drive if found
-		#
 
+		#
+		# Set upload_port to drive if found
+		#
 		if target_file_found or target_drive_found:
-			env.Replace(
-				UPLOAD_FLAGS="-P$UPLOAD_PORT"
-			)
+			env.Replace(UPLOAD_PORT=upload_disk)
+			print('\nUpload disk: ', upload_disk, '\n')
+		else:
+			print_error('Autodetect Error')
 
-	elif current_OS == 'Darwin':  # MAC
-		#
-		# platformio.ini will accept this for a OSX upload port designation: 'upload_port = /media/media_name/drive'
-		#
-		drives = os.listdir('/Volumes')  # human readable names
-		if target_drive in drives and not target_file_found:  # set upload if not found target file yet
-			target_drive_found = True
-			upload_disk = '/Volumes/' + target_drive + '/'
-		for drive in drives:
-			try:
-				filenames = os.listdir('/Volumes/' + drive + '/')   # will get an error if the drive is protected
-			except:
-				continue
-			else:
-				if target_filename in filenames:
-					if not target_file_found:
-						upload_disk = '/Volumes/' + drive + '/'
-					target_file_found = True
+	except Exception as e:
+		print_error(str(e))
 
-	#
-	# Set upload_port to drive if found
-	#
-	if target_file_found or target_drive_found:
-		env.Replace(UPLOAD_PORT=upload_disk)
-		print('\nUpload disk: ', upload_disk, '\n')
-	else:
-		print_error('Autodetect Error')
-
-except Exception as e:
-	print_error(str(e))
+env.AddPreAction("upload", before_upload)

--- a/Marlin/src/HAL/LPC1768/upload_extra_script.py
+++ b/Marlin/src/HAL/LPC1768/upload_extra_script.py
@@ -13,7 +13,6 @@ import os,getpass,platform
 current_OS = platform.system()
 Import("env")
 
-
 def print_error(e):
 	print('\nUnable to find destination disk (%s)\n' \
 		  'Please select it in platformio.ini using the upload_port keyword ' \


### PR DESCRIPTION
### Description

Don't check for an upload disk unless we actually want to upload.

### Requirements

LPC1768-based board

### Benefits

This makes the check for a disk to upload to only occur if selecting the upload option. Many users are now using third party solutions such as OctoPrint's Firmware Updater plugin instead of physically connecting their PCs to the machine running Marlin or using an SD card reader. This removes the extraneous "Unable to find destination disk (Autodetect Error)" message if just using the PlatformIO Build option instead of the Upload option. The "Upload" option will still correctly detect a valid upload location or present the error if not found.
Also this moves the error message to the end of the build log (just before the actual upload step) so it’s easier to see.  

### Configurations

Any configuration with LPC1768.
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6424619/Configuration.zip)