### PR TITLE
MMU2 menu fails to compile, idle not declared

### DIFF
--- a/Marlin/src/lcd/menu/menu_mmu2.cpp
+++ b/Marlin/src/lcd/menu/menu_mmu2.cpp
@@ -24,6 +24,7 @@
 
 #if BOTH(HAS_LCD_MENU, MMU2_MENUS)
 
+#include "../../MarlinCore.h
 #include "../../feature/mmu/mmu2.h"
 #include "menu_mmu2.h"
 #include "menu_item.h"

--- a/Marlin/src/lcd/menu/menu_mmu2.cpp
+++ b/Marlin/src/lcd/menu/menu_mmu2.cpp
@@ -24,7 +24,7 @@
 
 #if BOTH(HAS_LCD_MENU, MMU2_MENUS)
 
-#include "../../MarlinCore.h
+#include "../../MarlinCore.h"
 #include "../../feature/mmu/mmu2.h"
 #include "menu_mmu2.h"
 #include "menu_item.h"


### PR DESCRIPTION
### Description

MMU2 and lcd produces error: 'idle' was not declared in this scope
This fixes the issue

### Requirements

MMU2 and LCD

### Benefits

Compiles

### Related Issues
Issue #21795