### PR TITLE
G60-G61 E position support

### DIFF
--- a/Marlin/src/gcode/feature/pause/G60.cpp
+++ b/Marlin/src/gcode/feature/pause/G60.cpp
@@ -48,10 +48,11 @@ void GcodeSuite::G60() {
 
   #if ENABLED(SAVED_POSITIONS_DEBUG)
     const xyze_pos_t &pos = stored_position[slot];
-    DEBUG_ECHOPAIR_F(STR_SAVED_POS " S", slot);
+    DEBUG_ECHOPAIR(STR_SAVED_POS " S", (int)slot);
     DEBUG_ECHOPAIR_F(" : X", pos.x);
     DEBUG_ECHOPAIR_F_P(SP_Y_STR, pos.y);
-    DEBUG_ECHOLNPAIR_F_P(SP_Z_STR, pos.z);
+    DEBUG_ECHOPAIR_F_P(SP_Z_STR, pos.z);
+    DEBUG_ECHOLNPAIR_F_P(SP_E_STR, pos.e);
   #endif
 }
 

--- a/Marlin/src/gcode/feature/pause/G60.cpp
+++ b/Marlin/src/gcode/feature/pause/G60.cpp
@@ -48,7 +48,7 @@ void GcodeSuite::G60() {
 
   #if ENABLED(SAVED_POSITIONS_DEBUG)
     const xyze_pos_t &pos = stored_position[slot];
-    DEBUG_ECHOPAIR(STR_SAVED_POS " S", (int)slot);
+    DEBUG_ECHOPAIR(STR_SAVED_POS " S", slot);
     DEBUG_ECHOPAIR_F(" : X", pos.x);
     DEBUG_ECHOPAIR_F_P(SP_Y_STR, pos.y);
     DEBUG_ECHOPAIR_F_P(SP_Z_STR, pos.z);

--- a/Marlin/src/gcode/feature/pause/G61.cpp
+++ b/Marlin/src/gcode/feature/pause/G61.cpp
@@ -62,11 +62,12 @@ void GcodeSuite::G61(void) {
   if (fr > 0.0) feedrate_mm_s = MMM_TO_MMS(fr);
 
   if (!parser.seen_axis()) {
-    DEBUG_ECHOLN("Default position restoring");
+    DEBUG_ECHOLNPGM("Default position restoring");
     do_blocking_move_to_xy(stored_position[slot].x, stored_position[slot].y, feedrate_mm_s);
     do_blocking_move_to_z(stored_position[slot].z, feedrate_mm_s);
     SYNC_E(stored_position[slot].e);
-  } else {
+  }
+  else {
     if (parser.seen("XYZ")) {
       DEBUG_ECHOPAIR(STR_RESTORING_POS " S", slot);
       LOOP_XYZ(i) {

--- a/Marlin/src/gcode/feature/pause/G61.cpp
+++ b/Marlin/src/gcode/feature/pause/G61.cpp
@@ -27,6 +27,7 @@
 #include "../../../module/planner.h"
 #include "../../gcode.h"
 #include "../../../module/motion.h"
+#include "../../../module/planner.h"
 
 #define DEBUG_OUT ENABLED(SAVED_POSITIONS_DEBUG)
 #include "../../../core/debug_out.h"
@@ -42,6 +43,8 @@
 void GcodeSuite::G61(void) {
 
   const uint8_t slot = parser.byteval('S');
+
+  #define SYNC_E(POINT) planner.set_e_position_mm((destination.e = current_position.e = (POINT)))
 
   #if SAVED_POSITIONS < 256
     if (slot >= SAVED_POSITIONS) {
@@ -62,7 +65,7 @@ void GcodeSuite::G61(void) {
     DEBUG_ECHOLN("Default position restoring");
     do_blocking_move_to_xy(stored_position[slot].x, stored_position[slot].y, feedrate_mm_s);
     do_blocking_move_to_z(stored_position[slot].z, feedrate_mm_s);
-    current_position.e = stored_position[slot].e;
+    SYNC_E(stored_position[slot].e);
   } else {
     if (parser.seen("XYZ")) {
       DEBUG_ECHOPAIR(STR_RESTORING_POS " S", slot);
@@ -79,8 +82,7 @@ void GcodeSuite::G61(void) {
     }
     if (parser.seen_test('E')) {
       DEBUG_ECHOLNPAIR(STR_RESTORING_POS " S", slot, " E", current_position.e, "=>", stored_position[slot].e);
-      current_position.e = stored_position[slot].e;
-      destination.e = current_position.e;
+      SYNC_E(stored_position[slot].e);
     }
   }
 

--- a/Marlin/src/gcode/feature/pause/G61.cpp
+++ b/Marlin/src/gcode/feature/pause/G61.cpp
@@ -31,6 +31,7 @@
 
 #define DEBUG_OUT ENABLED(SAVED_POSITIONS_DEBUG)
 #include "../../../core/debug_out.h"
+
 /**
  * G61: Return to saved position
  *
@@ -38,7 +39,8 @@
  *   S<slot>  - Slot # (0-based) to restore from (default 0).
  *   X Y Z    - Axes to restore. At least one is required.
  *   E - Restore extruder position
- *   if no params XYZE sets - default position restoring: xy, then z, then e
+ *
+ *   If XYZE are not given, default restore uses the smart blocking move.
  */
 void GcodeSuite::G61(void) {
 
@@ -62,9 +64,8 @@ void GcodeSuite::G61(void) {
   if (fr > 0.0) feedrate_mm_s = MMM_TO_MMS(fr);
 
   if (!parser.seen_axis()) {
-    DEBUG_ECHOLNPGM("Default position restoring");
-    do_blocking_move_to_xy(stored_position[slot].x, stored_position[slot].y, feedrate_mm_s);
-    do_blocking_move_to_z(stored_position[slot].z, feedrate_mm_s);
+    DEBUG_ECHOLNPGM("Default position restore");
+    do_blocking_move_to(stored_position[slot], feedrate_mm_s);
     SYNC_E(stored_position[slot].e);
   }
   else {

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -102,7 +102,7 @@ xyze_pos_t destination; // {0}
 // G60/G61 Position Save and Return
 #if SAVED_POSITIONS
   uint8_t saved_slots[(SAVED_POSITIONS + 7) >> 3];
-  xyz_pos_t stored_position[SAVED_POSITIONS];
+  xyze_pos_t stored_position[SAVED_POSITIONS];
 #endif
 
 // The active extruder (tool). Set with T<extruder> command.

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -45,7 +45,7 @@ extern xyze_pos_t current_position,  // High-level current tool position
 // G60/G61 Position Save and Return
 #if SAVED_POSITIONS
   extern uint8_t saved_slots[(SAVED_POSITIONS + 7) >> 3];
-  extern xyz_pos_t stored_position[SAVED_POSITIONS];
+  extern xyze_pos_t stored_position[SAVED_POSITIONS];
 #endif
 
 // Scratch space for a cartesian result


### PR DESCRIPTION
### Description
Adds E position to save point
Adds option for restoring E position
Adds default restore algorithm

### Problem
if using G60, G61 for pause action, if inside pause manipulate with filament (load unload with G1 code)
the position of filament will changed. After resume and G61 we have a confuse at first next line in printing file with G1 E...

### Benefits
This update provide a E option for restoring filament position, and short form G61 for default restoring.