### PR TITLE
Unify BTT Motor Expansion Options

### DIFF
--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -279,7 +279,7 @@
     #undef SPEAKER
   #endif
 
-#elif HAS_WIRED_LCD && !HAS_BTT_EXP_MOT
+#elif HAS_WIRED_LCD && !BTT_MOTOR_EXPANSION
 
   #if ENABLED(ANET_FULL_GRAPHICS_LCD_ALT_WIRING)
     #error "CAUTION! ANET_FULL_GRAPHICS_LCD_ALT_WIRING requires wiring modifications. See 'pins_BTT_SKR_V1_4.h' for details. Comment out this line to continue."

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_common.h
@@ -23,11 +23,11 @@
 
 #include "env_validate.h"
 
-// If you have the Big tree tech driver expansion module, enable HAS_BTT_EXP_MOT
+// If you have the BigTreeTech driver expansion module, enable BTT_MOTOR_EXPANSION
 // https://github.com/bigtreetech/BTT-Expansion-module/tree/master/BTT%20EXP-MOT
-//#define HAS_BTT_EXP_MOT 1
+//#define BTT_MOTOR_EXPANSION
 
-#if BOTH(HAS_WIRED_LCD, HAS_BTT_EXP_MOT)
+#if BOTH(HAS_WIRED_LCD, BTT_MOTOR_EXPANSION)
   #if EITHER(CR10_STOCKDISPLAY, ENDER2_STOCKDISPLAY)
     #define EXP_MOT_USE_EXP2_ONLY 1
   #else
@@ -138,16 +138,16 @@
   #error "No custom SD drive cable defined for this board."
 #endif
 
-#if HAS_BTT_EXP_MOT
+#if ENABLED(BTT_MOTOR_EXPANSION)
 
-  /**              _____                                      _____
-   *           NC | · · | GND                             NC | · · | GND
-   *           NC | · · | 1.31 (M1EN)            (M2EN) 1.23 | · · | 1.22 (M3EN)
-   * (M1STP) 0.18 | · ·   3.25 (M1DIR)           (M1RX) 1.21 | · ·   1.20 (M1DIAG)
-   * (M2DIR) 0.16 | · · | 3.26 (M2STP)           (M2RX) 1.19 | · · | 1.18 (M2DIAG)
-   * (M3DIR) 0.15 | · · | 0.17 (M3STP)           (M3RX) 0.28 | · · | 1.30 (M3DIAG)
-   *               -----                                      -----
-   *               EXP2                                       EXP1
+  /**       _____                        _____
+   *    NC | 1 2 | GND               NC | 1 2 | GND
+   *    NC | 3 4 | M1EN            M2EN | 3 4 | M3EN
+   * M1STP | 5 6   M1DIR           M1RX | 5 6   M1DIAG
+   * M2DIR | 7 8 | M2STP           M2RX | 7 8 | M2DIAG
+   * M3DIR | 9 10| M3STP           M3RX | 9 10| M3DIAG
+   *        -----                        -----
+   *        EXP2                         EXP1
    *
    * NB In EXP_MOT_USE_EXP2_ONLY mode EXP1 is not used and M2EN and M3EN need to be jumpered to M1EN
    */
@@ -195,4 +195,4 @@
     #define E4_ENABLE_PIN            EXP2_04_PIN
   #endif
 
-#endif // HAS_BTT_EXP_MOT
+#endif // BTT_MOTOR_EXPANSION

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -23,11 +23,16 @@
 
 #include "env_validate.h"
 
-// BigTreeTech driver expansion module https://bit.ly/3ptRRoj
+// If you have the BigTreeTech driver expansion module, enable BTT_MOTOR_EXPANSION
+// https://github.com/bigtreetech/BTT-Expansion-module/tree/master/BTT%20EXP-MOT
 //#define BTT_MOTOR_EXPANSION
 
 #if BOTH(HAS_WIRED_LCD, BTT_MOTOR_EXPANSION)
-  #error "It's not possible to have both LCD and motor expansion module on EXP1/EXP2."
+  #if EITHER(CR10_STOCKDISPLAY, ENDER2_STOCKDISPLAY)
+    #define EXP_MOT_USE_EXP2_ONLY 1
+  #else
+    #error "You can't use both an LCD and a Motor Expansion Module on EXP1/EXP2 at the same time."
+  #endif
 #endif
 
 // Use one of these or SDCard-based Emulation will be used
@@ -311,48 +316,59 @@
 #endif
 
 #if ENABLED(BTT_MOTOR_EXPANSION)
-  /**
-   *               _____                                      _____
-   *           NC | · · | GND                             NC | · · | GND
-   *           NC | · · | PF12 (M1EN)            (M2EN)  PG7 | · · | PG6  (M3EN)
-   * (M1STP) PB15 | · ·   PF11 (M1DIR)           (M1RX)  PG3 | · ·   PG2  (M1DIAG)
-   * (M2DIR) PB12 | · · | PG10 (M2STP)           (M2RX) PD10 | · · | PD11 (M2DIAG)
-   * (M3DIR) PB13 | · · | PB14 (M3STP)           (M3RX)  PA8 | · · | PG4  (M3DIAG)
-   *               -----                                      -----
-   *               EXP2                                       EXP1
+  /**       _____                        _____
+   *    NC | 1 2 | GND               NC | 1 2 | GND
+   *    NC | 3 4 | M1EN            M2EN | 3 4 | M3EN
+   * M1STP | 5 6   M1DIR           M1RX | 5 6   M1DIAG
+   * M2DIR | 7 8 | M2STP           M2RX | 7 8 | M2DIAG
+   * M3DIR | 9 10| M3STP           M3RX | 9 10| M3DIAG
+   *        -----                        -----
+   *        EXP2                         EXP1
+   *
+   * NB In EXP_MOT_USE_EXP2_ONLY mode EXP1 is not used and M2EN and M3EN need to be jumpered to M1EN
    */
 
   // M1 on Driver Expansion Module
   #define E3_STEP_PIN                EXP2_05_PIN
   #define E3_DIR_PIN                 EXP2_06_PIN
   #define E3_ENABLE_PIN              EXP2_04_PIN
-  #define E3_DIAG_PIN                EXP1_06_PIN
-  #define E3_CS_PIN                  EXP1_05_PIN
-  #if HAS_TMC_UART
-    #define E3_SERIAL_TX_PIN         EXP1_05_PIN
-    #define E3_SERIAL_RX_PIN         EXP1_05_PIN
+  #if !EXP_MOT_USE_EXP2_ONLY
+    #define E3_DIAG_PIN              EXP1_06_PIN
+    #define E3_CS_PIN                EXP1_05_PIN
+    #if HAS_TMC_UART
+      #define E3_SERIAL_TX_PIN       EXP1_05_PIN
+      #define E3_SERIAL_RX_PIN       EXP1_05_PIN
+    #endif
   #endif
 
   // M2 on Driver Expansion Module
   #define E4_STEP_PIN                EXP2_08_PIN
   #define E4_DIR_PIN                 EXP2_07_PIN
-  #define E4_ENABLE_PIN              EXP1_03_PIN
-  #define E4_DIAG_PIN                EXP1_08_PIN
-  #define E4_CS_PIN                  EXP1_07_PIN
-  #if HAS_TMC_UART
-    #define E4_SERIAL_TX_PIN         EXP1_07_PIN
-    #define E4_SERIAL_RX_PIN         EXP1_07_PIN
+  #if !EXP_MOT_USE_EXP2_ONLY
+    #define E4_ENABLE_PIN            EXP1_03_PIN
+    #define E4_DIAG_PIN              EXP1_08_PIN
+    #define E4_CS_PIN                EXP1_07_PIN
+    #if HAS_TMC_UART
+      #define E4_SERIAL_TX_PIN       EXP1_07_PIN
+      #define E4_SERIAL_RX_PIN       EXP1_07_PIN
+    #endif
+  #else
+    #define E4_ENABLE_PIN            EXP2_04_PIN
   #endif
 
   // M3 on Driver Expansion Module
   #define E5_STEP_PIN                EXP2_10_PIN
   #define E5_DIR_PIN                 EXP2_09_PIN
-  #define E5_ENABLE_PIN              EXP1_04_PIN
-  #define E5_DIAG_PIN                EXP1_10_PIN
-  #define E5_CS_PIN                  EXP1_09_PIN
-  #if HAS_TMC_UART
-    #define E5_SERIAL_TX_PIN         EXP1_09_PIN
-    #define E5_SERIAL_RX_PIN         EXP1_09_PIN
+  #if !EXP_MOT_USE_EXP2_ONLY
+    #define E5_ENABLE_PIN            EXP1_04_PIN
+    #define E5_DIAG_PIN              EXP1_10_PIN
+    #define E5_CS_PIN                EXP1_09_PIN
+    #if HAS_TMC_UART
+      #define E5_SERIAL_TX_PIN       EXP1_09_PIN
+      #define E5_SERIAL_RX_PIN       EXP1_09_PIN
+    #endif
+  #else
+    #define E5_ENABLE_PIN            EXP2_04_PIN
   #endif
 
 #endif // BTT_MOTOR_EXPANSION

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0.h
@@ -25,6 +25,18 @@
 
 #define BOARD_INFO_NAME "BTT SKR V2.0"
 
+// If you have the BigTreeTech driver expansion module, enable BTT_MOTOR_EXPANSION
+// https://github.com/bigtreetech/BTT-Expansion-module/tree/master/BTT%20EXP-MOT
+//#define BTT_MOTOR_EXPANSION
+
+#if BOTH(HAS_WIRED_LCD, BTT_MOTOR_EXPANSION)
+  #if EITHER(CR10_STOCKDISPLAY, ENDER2_STOCKDISPLAY)
+    #define EXP_MOT_USE_EXP2_ONLY 1
+  #else
+    #error "You can't use both an LCD and a Motor Expansion Module on EXP1/EXP2 at the same time."
+  #endif
+#endif
+
 // Use one of these or SDCard-based Emulation will be used
 #if NO_EEPROM_SELECTED
   //#define SRAM_EEPROM_EMULATION                 // Use BackSRAM-based EEPROM emulation
@@ -351,48 +363,59 @@
 #endif
 
 #if ENABLED(BTT_MOTOR_EXPANSION)
-  /**
-   *               _____                                      _____
-   *           NC | · · | GND                             NC | · · | GND
-   *           NC | · · | PF12 (M1EN)            (M2EN)  PG7 | · · | PG6  (M3EN)
-   * (M1STP) PB15 | · ·   PF11 (M1DIR)           (M1RX)  PG3 | · ·   PG2  (M1DIAG)
-   * (M2DIR) PB12 | · · | PG10 (M2STP)           (M2RX) PD10 | · · | PD11 (M2DIAG)
-   * (M3DIR) PB13 | · · | PB14 (M3STP)           (M3RX)  PA8 | · · | PG4  (M3DIAG)
-   *               -----                                      -----
-   *               EXP2                                       EXP1
+  /**       _____                        _____
+   *    NC | 1 2 | GND               NC | 1 2 | GND
+   *    NC | 3 4 | M1EN            M2EN | 3 4 | M3EN
+   * M1STP | 5 6   M1DIR           M1RX | 5 6   M1DIAG
+   * M2DIR | 7 8 | M2STP           M2RX | 7 8 | M2DIAG
+   * M3DIR | 9 10| M3STP           M3RX | 9 10| M3DIAG
+   *        -----                        -----
+   *        EXP2                         EXP1
+   *
+   * NB In EXP_MOT_USE_EXP2_ONLY mode EXP1 is not used and M2EN and M3EN need to be jumpered to M1EN
    */
 
   // M1 on Driver Expansion Module
-  #define E3_STEP_PIN                EXP2_05_PIN
-  #define E3_DIR_PIN                 EXP2_06_PIN
-  #define E3_ENABLE_PIN              EXP2_04_PIN
-  #define E3_DIAG_PIN                EXP1_06_PIN
-  #define E3_CS_PIN                  EXP1_05_PIN
-  #if HAS_TMC_UART
-    #define E3_SERIAL_TX_PIN         EXP1_05_PIN
-    #define E3_SERIAL_RX_PIN         EXP1_05_PIN
+  #define E2_STEP_PIN                EXP2_05_PIN
+  #define E2_DIR_PIN                 EXP2_06_PIN
+  #define E2_ENABLE_PIN              EXP2_04_PIN
+  #if !EXP_MOT_USE_EXP2_ONLY
+    #define E2_DIAG_PIN              EXP1_06_PIN
+    #define E2_CS_PIN                EXP1_05_PIN
+    #if HAS_TMC_UART
+      #define E2_SERIAL_TX_PIN       EXP1_05_PIN
+      #define E2_SERIAL_RX_PIN       EXP1_05_PIN
+    #endif
   #endif
 
   // M2 on Driver Expansion Module
-  #define E4_STEP_PIN                EXP2_08_PIN
-  #define E4_DIR_PIN                 EXP2_07_PIN
-  #define E4_ENABLE_PIN              EXP1_03_PIN
-  #define E4_DIAG_PIN                EXP1_08_PIN
-  #define E4_CS_PIN                  EXP1_07_PIN
-  #if HAS_TMC_UART
-    #define E4_SERIAL_TX_PIN         EXP1_07_PIN
-    #define E4_SERIAL_RX_PIN         EXP1_07_PIN
+  #define E3_STEP_PIN                EXP2_08_PIN
+  #define E3_DIR_PIN                 EXP2_07_PIN
+  #if !EXP_MOT_USE_EXP2_ONLY
+    #define E3_ENABLE_PIN            EXP1_03_PIN
+    #define E3_DIAG_PIN              EXP1_08_PIN
+    #define E3_CS_PIN                EXP1_07_PIN
+    #if HAS_TMC_UART
+      #define E3_SERIAL_TX_PIN       EXP1_07_PIN
+      #define E3_SERIAL_RX_PIN       EXP1_07_PIN
+    #endif
+  #else
+    #define E3_ENABLE_PIN            EXP2_04_PIN
   #endif
 
   // M3 on Driver Expansion Module
-  #define E5_STEP_PIN                EXP2_10_PIN
-  #define E5_DIR_PIN                 EXP2_09_PIN
-  #define E5_ENABLE_PIN              EXP1_04_PIN
-  #define E5_DIAG_PIN                EXP1_10_PIN
-  #define E5_CS_PIN                  EXP1_09_PIN
-  #if HAS_TMC_UART
-    #define E5_SERIAL_TX_PIN         EXP1_09_PIN
-    #define E5_SERIAL_RX_PIN         EXP1_09_PIN
+  #define E4_STEP_PIN                EXP2_10_PIN
+  #define E4_DIR_PIN                 EXP2_09_PIN
+  #if !EXP_MOT_USE_EXP2_ONLY
+    #define E4_ENABLE_PIN            EXP1_04_PIN
+    #define E4_DIAG_PIN              EXP1_10_PIN
+    #define E4_CS_PIN                EXP1_09_PIN
+    #if HAS_TMC_UART
+      #define E4_SERIAL_TX_PIN       EXP1_09_PIN
+      #define E4_SERIAL_RX_PIN       EXP1_09_PIN
+    #endif
+  #else
+    #define E4_ENABLE_PIN            EXP2_04_PIN
   #endif
 
 #endif // BTT_MOTOR_EXPANSION


### PR DESCRIPTION
### Description

`HAS_BTT_EXP_MOT` => `BTT_MOTOR_EXPANSION`.

Both options were added to Marlin within days of each other, but they should be a single option.

### Requirements

BigTreeTech motor expansion board.

### Benefits

Single option across boards.

### Configurations

Enable `BTT_MOTOR_EXPANSION` for the SKR 1.3, 1.4 or SKR Pro.

### Related Issues

None. Found while adding feature to additional boards.
