### PR TITLE
fixes #21813

### DIFF
--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -81,7 +81,7 @@ void GcodeSuite::M125() {
   TERN_(POWER_LOSS_RECOVERY, if (recovery.enabled) recovery.save(true));
 
   if (pause_print(retract, park_point, show_lcd, 0)) {
-    if (ENABLED(EXTENSIBLE_UI) || !sd_printing || show_lcd) {
+    if (ENABLED(EXTENSIBLE_UI) || !sd_printing || show_lcd || ENABLED(M600_PURGE_MORE_RESUMABLE)) {
       wait_for_confirmation(false, 0);
       resume_print(0, 0, -retract, 0);
     }

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -51,7 +51,7 @@
  *    Y<pos>    = Override park position Y
  *    Z<linear> = Override Z raise
  *
- *  With an LCD menu:
+ *  With an LCD menu or both EMERGENCY_PARSER and HOST_PROMPT_SUPPORT:
  *    P<bool>   = Always show a prompt and await a response
  */
 void GcodeSuite::M125() {

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -81,7 +81,7 @@ void GcodeSuite::M125() {
   TERN_(POWER_LOSS_RECOVERY, if (recovery.enabled) recovery.save(true));
 
   if (pause_print(retract, park_point, show_lcd, 0)) {
-    if (ENABLED(EXTENSIBLE_UI) || !sd_printing || show_lcd || ENABLED(M600_PURGE_MORE_RESUMABLE)) {
+    if (EITHER(EXTENSIBLE_UI, M600_PURGE_MORE_RESUMABLE) || !sd_printing || show_lcd) {
       wait_for_confirmation(false, 0);
       resume_print(0, 0, -retract, 0);
     }

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -51,7 +51,7 @@
  *    Y<pos>    = Override park position Y
  *    Z<linear> = Override Z raise
  *
- *  With an LCD menu or both EMERGENCY_PARSER and HOST_PROMPT_SUPPORT:
+ *  With an LCD menu:
  *    P<bool>   = Always show a prompt and await a response
  */
 void GcodeSuite::M125() {

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -81,7 +81,7 @@ void GcodeSuite::M125() {
   TERN_(POWER_LOSS_RECOVERY, if (recovery.enabled) recovery.save(true));
 
   if (pause_print(retract, park_point, show_lcd, 0)) {
-    if (EITHER(EXTENSIBLE_UI, M600_PURGE_MORE_RESUMABLE) || !sd_printing || show_lcd) {
+    if (ENABLED(EXTENSIBLE_UI) || BOTH(EMERGENCY_PARSER, HOST_PROMPT_SUPPORT) || !sd_printing || show_lcd) {
       wait_for_confirmation(false, 0);
       resume_print(0, 0, -retract, 0);
     }


### PR DESCRIPTION
Fixes #21813 for M125 in case of LCD_MENU disabled but both EMERGENCY_PARSER and HOST_PROMPT_SUPPORT are enabled as it has been recently done for M600 by the merged PR #21671,