### PR TITLE
Fix print halted when using MiniUPS (#21730)

### DIFF
--- a/Marlin/src/feature/powerloss.h
+++ b/Marlin/src/feature/powerloss.h
@@ -42,6 +42,8 @@
   #define POWER_LOSS_STATE HIGH
 #endif
 
+#define OUTAGE_NOISE_THRESHOLD	2;	// POWER_LOSS_PIN read count to eliminate noise
+
 //#define DEBUG_POWER_LOSS_RECOVERY
 //#define SAVE_EACH_CMD_MODE
 //#define SAVE_INFO_INTERVAL_MS 0
@@ -179,8 +181,11 @@ class PrintJobRecovery {
 
     #if PIN_EXISTS(POWER_LOSS)
       static inline void outage() {
-        if (enabled && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE)
-          _outage();
+        if (enabled && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE) {
+		  uint8_t outage_poll_count = OUTAGE_NOISE_THRESHOLD;
+		  while (--outage_poll_count && READ(POWER_LOSS_PIN) == POWER_LOSS_STATE) safe_delay(1);
+          if (!outage_poll_count) _outage();
+		}
       }
     #endif
 


### PR DESCRIPTION
Fix print halted when using MiniUPS (#21730)

### Description

Anyone who has MiniUPS installed in the printer may have problems with a sudden halted of printing at a random moment.
With intensive printing, impulse short voltage dips may occur, which are recorded by the MiniUPS as a power failure. 
If it coincides with the time of reading the signal from POWER_LOSS_PIN, this leads to an abnormal print interruption.
The multimeter does not show the deviation of the power supply voltage and the impulse dips in the power supply are very short and do not affect the operation of the printer.
At the same time, there is no noise protection in the Marlin code.
All I had to do was fix the code in powerloss.h to fix the problem.

### Requirements

MiniUPS

### Benefits

Fix sudden print halted at a random moment.

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6444524/Configuration.zip)

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/21730
