### PR TITLE
Optimize G-code flag parameters

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -306,7 +306,7 @@ void unified_bed_leveling::G29() {
   if (G29_parse_parameters()) return; // Abort on parameter error
 
   const int8_t p_val = parser.intval('P', -1);
-  const bool may_move = p_val == 1 || p_val == 2 || p_val == 4 || parser.seen('J');
+  const bool may_move = p_val == 1 || p_val == 2 || p_val == 4 || parser.seen_test('J');
   #if ENABLED(HAS_MULTI_HOTEND)
     const uint8_t old_tool_index = active_extruder;
   #endif
@@ -315,7 +315,7 @@ void unified_bed_leveling::G29() {
   if (may_move) {
     planner.synchronize();
     // Send 'N' to force homing before G29 (internal only)
-    if (axes_should_home() || parser.seen('N')) gcode.home_all_axes();
+    if (axes_should_home() || parser.seen_test('N')) gcode.home_all_axes();
     TERN_(HAS_MULTI_HOTEND, if (active_extruder) tool_change(0));
   }
 
@@ -380,7 +380,7 @@ void unified_bed_leveling::G29() {
         // Allow the user to specify the height because 10mm is a little extreme in some cases.
         for (uint8_t x = (GRID_MAX_POINTS_X) / 3; x < 2 * (GRID_MAX_POINTS_X) / 3; x++)     // Create a rectangular raised area in
           for (uint8_t y = (GRID_MAX_POINTS_Y) / 3; y < 2 * (GRID_MAX_POINTS_Y) / 3; y++) { // the center of the bed
-            z_values[x][y] += parser.seen('C') ? param.C_constant : 9.99f;
+            z_values[x][y] += parser.seen_test('C') ? param.C_constant : 9.99f;
             TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, z_values[x][y]));
           }
         break;
@@ -389,7 +389,7 @@ void unified_bed_leveling::G29() {
 
   #if HAS_BED_PROBE
 
-    if (parser.seen('J')) {
+    if (parser.seen_test('J')) {
       save_ubl_active_state_and_disable();
       tilt_mesh_based_on_probed_grid(param.J_grid_size == 0); // Zero size does 3-Point
       restore_ubl_active_state_and_leave();
@@ -402,7 +402,7 @@ void unified_bed_leveling::G29() {
 
   #endif // HAS_BED_PROBE
 
-  if (parser.seen('P')) {
+  if (parser.seen_test('P')) {
     if (WITHIN(param.P_phase, 0, 1) && storage_slot == -1) {
       storage_slot = 0;
       SERIAL_ECHOLNPGM("Default storage slot 0 selected.");
@@ -423,7 +423,7 @@ void unified_bed_leveling::G29() {
           //
           // Invalidate Entire Mesh and Automatically Probe Mesh in areas that can be reached by the probe
           //
-          if (!parser.seen('C')) {
+          if (!parser.seen_test('C')) {
             invalidate();
             SERIAL_ECHOLNPGM("Mesh invalidated. Probing mesh.");
           }
@@ -433,7 +433,7 @@ void unified_bed_leveling::G29() {
             SERIAL_DECIMAL(param.XY_pos.y);
             SERIAL_ECHOLNPGM(").\n");
           }
-          probe_entire_mesh(param.XY_pos, parser.seen('T'), parser.seen('E'), parser.seen('U'));
+          probe_entire_mesh(param.XY_pos, parser.seen_test('T'), parser.seen_test('E'), parser.seen_test('U'));
 
           report_current_position();
           probe_deployed = true;
@@ -449,7 +449,7 @@ void unified_bed_leveling::G29() {
           SERIAL_ECHOLNPGM("Manually probing unreachable points.");
           do_z_clearance(Z_CLEARANCE_BETWEEN_PROBES);
 
-          if (parser.seen('C') && !param.XY_seen) {
+          if (parser.seen_test('C') && !param.XY_seen) {
 
             /**
              * Use a good default location for the path.
@@ -483,7 +483,7 @@ void unified_bed_leveling::G29() {
           }
 
           const float height = parser.floatval('H', Z_CLEARANCE_BETWEEN_PROBES);
-          manually_probe_remaining_mesh(param.XY_pos, height, param.B_shim_thickness, parser.seen('T'));
+          manually_probe_remaining_mesh(param.XY_pos, height, param.B_shim_thickness, parser.seen_test('T'));
 
           SERIAL_ECHOLNPGM("G29 P2 finished.");
 
@@ -555,7 +555,7 @@ void unified_bed_leveling::G29() {
 
       case 4: // Fine Tune (i.e., Edit) the Mesh
         #if HAS_LCD_MENU
-          fine_tune_mesh(param.XY_pos, parser.seen('T'));
+          fine_tune_mesh(param.XY_pos, parser.seen_test('T'));
         #else
           SERIAL_ECHOLNPGM("?P4 is only available when an LCD is present.");
           return;
@@ -574,14 +574,14 @@ void unified_bed_leveling::G29() {
     // Much of the 'What?' command can be eliminated. But until we are fully debugged, it is
     // good to have the extra information. Soon... we prune this to just a few items
     //
-    if (parser.seen('W')) g29_what_command();
+    if (parser.seen_test('W')) g29_what_command();
 
     //
     // When we are fully debugged, this may go away. But there are some valid
     // use cases for the users. So we can wait and see what to do with it.
     //
 
-    if (parser.seen('K')) // Kompare Current Mesh Data to Specified Stored Mesh
+    if (parser.seen_test('K')) // Kompare Current Mesh Data to Specified Stored Mesh
       g29_compare_current_mesh_to_stored_mesh();
 
   #endif // UBL_DEVEL_DEBUGGING
@@ -640,7 +640,7 @@ void unified_bed_leveling::G29() {
     SERIAL_ECHOLNPGM("Done.");
   }
 
-  if (parser.seen('T'))
+  if (parser.seen_test('T'))
     display_map(param.T_map_type);
 
   LEAVE:
@@ -915,7 +915,7 @@ void set_message_with_feedback(PGM_P const msg_P) {
 
       if (do_ubl_mesh_map) display_map(param.T_map_type);   // Show user where we're probing
 
-      if (parser.seen('B')) {
+      if (parser.seen_test('B')) {
         SERIAL_ECHOPGM_P(GET_TEXT(MSG_UBL_BC_INSERT));
         LCD_MESSAGEPGM(MSG_UBL_BC_INSERT);
       }
@@ -954,7 +954,7 @@ void set_message_with_feedback(PGM_P const msg_P) {
    *          NOTE: Blocks the G-code queue and captures Marlin UI during use.
    */
   void unified_bed_leveling::fine_tune_mesh(const xy_pos_t &pos, const bool do_ubl_mesh_map) {
-    if (!parser.seen('R'))        // fine_tune_mesh() is special. If no repetition count flag is specified
+    if (!parser.seen_test('R')) // fine_tune_mesh() is special. If no repetition count flag is specified
       param.R_repetition = 1;   // do exactly one mesh location. Otherwise use what the parser decided.
 
     #if ENABLED(UBL_MESH_EDIT_MOVES_Z)
@@ -1091,7 +1091,7 @@ bool unified_bed_leveling::G29_parse_parameters() {
     }
   }
 
-  param.V_verbosity = parser.seen('V') ? parser.value_int() : 0;
+  param.V_verbosity = parser.intval('V');
   if (!WITHIN(param.V_verbosity, 0, 4)) {
     SERIAL_ECHOLNPGM("?(V)erbose level implausible (0-4).\n");
     err_flag = true;
@@ -1153,15 +1153,15 @@ bool unified_bed_leveling::G29_parse_parameters() {
    *       Leveling is being enabled here with old data, possibly
    *       none. Error handling should disable for safety...
    */
-  if (parser.seen('A')) {
-    if (parser.seen('D')) {
+  if (parser.seen_test('A')) {
+    if (parser.seen_test('D')) {
       SERIAL_ECHOLNPGM("?Can't activate and deactivate at the same time.\n");
       return UBL_ERR;
     }
     set_bed_leveling_enabled(true);
     report_state();
   }
-  else if (parser.seen('D')) {
+  else if (parser.seen_test('D')) {
     set_bed_leveling_enabled(false);
     report_state();
   }
@@ -1520,7 +1520,7 @@ void unified_bed_leveling::smart_fill_mesh() {
             SERIAL_ECHOLNPAIR("Tilting mesh point ", point_num, "/", total_points, "\n");
             TERN_(HAS_STATUS_MESSAGE, ui.status_printf_P(0, PSTR(S_FMT " %i/%i"), GET_TEXT(MSG_LCD_TILTING_MESH), point_num, total_points));
 
-            measured_z = probe.probe_at_point(rpos, parser.seen('E') ? PROBE_PT_STOW : PROBE_PT_RAISE, param.V_verbosity); // TODO: Needs error handling
+            measured_z = probe.probe_at_point(rpos, parser.seen_test('E') ? PROBE_PT_STOW : PROBE_PT_RAISE, param.V_verbosity); // TODO: Needs error handling
 
             abort_flag = isnan(measured_z);
 

--- a/Marlin/src/feature/encoder_i2c.cpp
+++ b/Marlin/src/feature/encoder_i2c.cpp
@@ -819,11 +819,11 @@ int8_t I2CPositionEncodersMgr::parse() {
 void I2CPositionEncodersMgr::M860() {
   if (parse()) return;
 
-  const bool hasU = parser.seen('U'), hasO = parser.seen('O');
+  const bool hasU = parser.seen_test('U'), hasO = parser.seen_test('O');
 
   if (I2CPE_idx == 0xFF) {
     LOOP_XYZE(i) {
-      if (!I2CPE_anyaxis || parser.seen(axis_codes[i])) {
+      if (!I2CPE_anyaxis || parser.seen_test(axis_codes[i])) {
         const uint8_t idx = idx_from_axis(AxisEnum(i));
         if ((int8_t)idx >= 0) report_position(idx, hasU, hasO);
       }
@@ -956,10 +956,10 @@ void I2CPositionEncodersMgr::M864() {
     return;
   }
   else {
-         if (parser.seen('X')) newAddress = I2CPE_PRESET_ADDR_X;
-    else if (parser.seen('Y')) newAddress = I2CPE_PRESET_ADDR_Y;
-    else if (parser.seen('Z')) newAddress = I2CPE_PRESET_ADDR_Z;
-    else if (parser.seen('E')) newAddress = I2CPE_PRESET_ADDR_E;
+         if (parser.seen_test('X')) newAddress = I2CPE_PRESET_ADDR_X;
+    else if (parser.seen_test('Y')) newAddress = I2CPE_PRESET_ADDR_Y;
+    else if (parser.seen_test('Z')) newAddress = I2CPE_PRESET_ADDR_Z;
+    else if (parser.seen_test('E')) newAddress = I2CPE_PRESET_ADDR_E;
     else return;
   }
 
@@ -1012,7 +1012,7 @@ void I2CPositionEncodersMgr::M865() {
 void I2CPositionEncodersMgr::M866() {
   if (parse()) return;
 
-  const bool hasR = parser.seen('R');
+  const bool hasR = parser.seen_test('R');
 
   if (I2CPE_idx == 0xFF) {
     LOOP_XYZE(i) {

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -212,10 +212,10 @@ void FWRetract::retract(const bool retracting
  */
 void FWRetract::M207() {
   if (!parser.seen("FSWZ")) return M207_report();
-  if (parser.seen('S')) settings.retract_length = parser.value_axis_units(E_AXIS);
-  if (parser.seen('F')) settings.retract_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-  if (parser.seen('Z')) settings.retract_zraise = parser.value_linear_units();
-  if (parser.seen('W')) settings.swap_retract_length = parser.value_axis_units(E_AXIS);
+  if (parser.seenval('S')) settings.retract_length        = parser.value_axis_units(E_AXIS);
+  if (parser.seenval('F')) settings.retract_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
+  if (parser.seenval('Z')) settings.retract_zraise        = parser.value_linear_units();
+  if (parser.seenval('W')) settings.swap_retract_length   = parser.value_axis_units(E_AXIS);
 }
 
 void FWRetract::M207_report(const bool forReplay/*=false*/) {
@@ -238,10 +238,10 @@ void FWRetract::M207_report(const bool forReplay/*=false*/) {
  */
 void FWRetract::M208() {
   if (!parser.seen("FSRW")) return M208_report();
-  if (parser.seen('S')) settings.retract_recover_extra = parser.value_axis_units(E_AXIS);
-  if (parser.seen('F')) settings.retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
+  if (parser.seen('S')) settings.retract_recover_extra              = parser.value_axis_units(E_AXIS);
+  if (parser.seen('F')) settings.retract_recover_feedrate_mm_s      = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
   if (parser.seen('R')) settings.swap_retract_recover_feedrate_mm_s = MMM_TO_MMS(parser.value_axis_units(E_AXIS));
-  if (parser.seen('W')) settings.swap_retract_recover_extra = parser.value_axis_units(E_AXIS);
+  if (parser.seen('W')) settings.swap_retract_recover_extra         = parser.value_axis_units(E_AXIS);
 }
 
 void FWRetract::M208_report(const bool forReplay/*=false*/) {

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -648,12 +648,12 @@ void GcodeSuite::G26() {
   #if HAS_LCD_MENU
     g26_repeats = parser.intval('R', GRID_MAX_POINTS + 1);
   #else
-    if (!parser.seen('R')) {
+    if (parser.seen('R'))
+      g26_repeats = parser.has_value() ? parser.value_int() : GRID_MAX_POINTS + 1;
+    else {
       SERIAL_ECHOLNPGM("?(R)epeat must be specified when not using an LCD.");
       return;
     }
-    else
-      g26_repeats = parser.has_value() ? parser.value_int() : GRID_MAX_POINTS + 1;
   #endif
   if (g26_repeats < 1) {
     SERIAL_ECHOLNPGM("?(R)epeat value not plausible; must be at least 1.");
@@ -671,7 +671,7 @@ void GcodeSuite::G26() {
   /**
    * Wait until all parameters are verified before altering the state!
    */
-  set_bed_leveling_enabled(!parser.seen('D'));
+  set_bed_leveling_enabled(!parser.seen_test('D'));
 
   do_z_clearance(Z_CLEARANCE_BETWEEN_PROBES);
 

--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -133,7 +133,7 @@ void GcodeSuite::M420() {
 
   #endif // AUTO_BED_LEVELING_UBL
 
-  const bool seenV = parser.seen('V');
+  const bool seenV = parser.seen_test('V');
 
   #if HAS_MESH
 

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -223,7 +223,7 @@ G29_TYPE GcodeSuite::G29() {
 
   reset_stepper_timeout();
 
-  const bool seenQ = EITHER(DEBUG_LEVELING_FEATURE, PROBE_MANUALLY) && parser.seen('Q');
+  const bool seenQ = EITHER(DEBUG_LEVELING_FEATURE, PROBE_MANUALLY) && parser.seen_test('Q');
 
   // G29 Q is also available if debugging
   #if ENABLED(DEBUG_LEVELING_FEATURE)
@@ -235,7 +235,7 @@ G29_TYPE GcodeSuite::G29() {
     if (DISABLED(PROBE_MANUALLY) && seenQ) G29_RETURN(false);
   #endif
 
-  const bool seenA = TERN0(PROBE_MANUALLY, parser.seen('A')),
+  const bool seenA = TERN0(PROBE_MANUALLY, parser.seen_test('A')),
          no_action = seenA || seenQ,
               faux = ENABLED(DEBUG_LEVELING_FEATURE) && DISABLED(PROBE_MANUALLY) ? parser.boolval('C') : no_action;
 
@@ -245,7 +245,7 @@ G29_TYPE GcodeSuite::G29() {
   }
 
   // Send 'N' to force homing before G29 (internal only)
-  if (parser.seen('N'))
+  if (parser.seen_test('N'))
     process_subcommands_now_P(TERN(G28_L0_ENSURES_LEVELING_OFF, PSTR("G28L0"), G28_STR));
 
   // Don't allow auto-leveling without homing first
@@ -275,7 +275,7 @@ G29_TYPE GcodeSuite::G29() {
 
     #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
-      const bool seen_w = parser.seen('W');
+      const bool seen_w = parser.seen_test('W');
       if (seen_w) {
         if (!leveling_is_valid()) {
           SERIAL_ERROR_MSG("No bilinear grid");
@@ -308,7 +308,7 @@ G29_TYPE GcodeSuite::G29() {
           if (abl.reenable) report_current_position();
         }
         G29_RETURN(false);
-      } // parser.seen('W')
+      } // parser.seen_test('W')
 
     #else
 
@@ -317,7 +317,7 @@ G29_TYPE GcodeSuite::G29() {
     #endif
 
     // Jettison bed leveling data
-    if (!seen_w && parser.seen('J')) {
+    if (!seen_w && parser.seen_test('J')) {
       reset_bed_level();
       G29_RETURN(false);
     }

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -87,7 +87,7 @@ void GcodeSuite::G29() {
       mbl.reset();
       mbl_probe_index = 0;
       if (!ui.wait_for_move) {
-        queue.inject_P(parser.seen('N') ? PSTR("G28" TERN(G28_L0_ENSURES_LEVELING_OFF, "L0", "") "\nG29S2") : PSTR("G29S2"));
+        queue.inject_P(parser.seen_test('N') ? PSTR("G28" TERN(G28_L0_ENSURES_LEVELING_OFF, "L0", "") "\nG29S2") : PSTR("G29S2"));
         return;
       }
       state = MeshNext;

--- a/Marlin/src/gcode/bedlevel/ubl/M421.cpp
+++ b/Marlin/src/gcode/bedlevel/ubl/M421.cpp
@@ -21,7 +21,7 @@
  */
 
 /**
- * unified.cpp - Unified Bed Leveling
+ * M421.cpp - Unified Bed Leveling
  */
 
 #include "../../../inc/MarlinConfig.h"
@@ -39,31 +39,34 @@
  * M421: Set a single Mesh Bed Leveling Z coordinate
  *
  * Usage:
- *   M421 I<xindex> J<yindex> Z<linear>
- *   M421 I<xindex> J<yindex> Q<offset>
- *   M421 I<xindex> J<yindex> N
- *   M421 C Z<linear>
- *   M421 C Q<offset>
+ *   M421 I<xindex> J<yindex> Z<linear>  : Set the Mesh Point IJ to the Z value
+ *   M421 I<xindex> J<yindex> Q<offset>  : Add the Q value to the Mesh Point IJ
+ *   M421 I<xindex> J<yindex> N          : Set the Mesh Point IJ to NAN (not set)
+ *   M421 C Z<linear>                    : Set the closest Mesh Point to the Z value
+ *   M421 C Q<offset>                    : Add the Q value to the closest Mesh Point
  */
 void GcodeSuite::M421() {
   xy_int8_t ij = { int8_t(parser.intval('I', -1)), int8_t(parser.intval('J', -1)) };
   const bool hasI = ij.x >= 0,
              hasJ = ij.y >= 0,
-             hasC = parser.seen('C'),
-             hasN = parser.seen('N'),
+             hasC = parser.seen_test('C'),
+             hasN = parser.seen_test('N'),
              hasZ = parser.seen('Z'),
              hasQ = !hasZ && parser.seen('Q');
 
   if (hasC) ij = ubl.find_closest_mesh_point_of_type(CLOSEST, current_position);
 
+  // Test for bad parameter combinations
   if (int(hasC) + int(hasI && hasJ) != 1 || !(hasZ || hasQ || hasN))
     SERIAL_ERROR_MSG(STR_ERR_M421_PARAMETERS);
+
+  // Test for I J out of range
   else if (!WITHIN(ij.x, 0, GRID_MAX_POINTS_X - 1) || !WITHIN(ij.y, 0, GRID_MAX_POINTS_Y - 1))
     SERIAL_ERROR_MSG(STR_ERR_MESH_XY);
   else {
-    float &zval = ubl.z_values[ij.x][ij.y];
-    zval = hasN ? NAN : parser.value_linear_units() + (hasQ ? zval : 0);
-    TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(ij.x, ij.y, zval));
+    float &zval = ubl.z_values[ij.x][ij.y];                               // Altering this Mesh Point
+    zval = hasN ? NAN : parser.value_linear_units() + (hasQ ? zval : 0);  // N=NAN, Z=NEWVAL, or Q=ADDVAL
+    TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(ij.x, ij.y, zval));          // Ping ExtUI in case it's showing the mesh
   }
 }
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -219,7 +219,7 @@ void GcodeSuite::G28() {
   #endif
 
   #if ENABLED(MARLIN_DEV_MODE)
-    if (parser.seen('S')) {
+    if (parser.seen_test('S')) {
       LOOP_XYZ(a) set_axis_is_at_home((AxisEnum)a);
       sync_plan_position();
       SERIAL_ECHOLNPGM("Simulated Homing");
@@ -321,10 +321,10 @@ void GcodeSuite::G28() {
 
   #else
 
-    const bool homeZ = parser.seen('Z'),
+    const bool homeZ = parser.seen_test('Z'),
                needX = homeZ && TERN0(Z_SAFE_HOMING, axes_should_home(_BV(X_AXIS))),
                needY = homeZ && TERN0(Z_SAFE_HOMING, axes_should_home(_BV(Y_AXIS))),
-               homeX = needX || parser.seen('X'), homeY = needY || parser.seen('Y'),
+               homeX = needX || parser.seen_test('X'), homeY = needY || parser.seen_test('Y'),
                home_all = homeX == homeY && homeX == homeZ, // All or None
                doX = home_all || homeX, doY = home_all || homeY, doZ = home_all || homeZ;
 

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -395,7 +395,7 @@ void GcodeSuite::G33() {
     return;
   }
 
-  const bool towers_set = !parser.seen('T');
+  const bool towers_set = !parser.seen_test('T');
 
   const float calibration_precision = parser.floatval('C', 0.0f);
   if (calibration_precision < 0) {
@@ -415,7 +415,7 @@ void GcodeSuite::G33() {
     return;
   }
 
-  const bool stow_after_each = parser.seen('E');
+  const bool stow_after_each = parser.seen_test('E');
 
   const bool _0p_calibration      = probe_points == 0,
              _1p_calibration      = probe_points == 1 || probe_points == -1,

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -56,7 +56,7 @@
  */
 void GcodeSuite::M125() {
   // Initial retract before move to filament change position
-  const float retract = -ABS(parser.seen('L') ? parser.value_axis_units(E_AXIS) : (PAUSE_PARK_RETRACT_LENGTH));
+  const float retract = -ABS(parser.axisunitsval('L', E_AXIS, PAUSE_PARK_RETRACT_LENGTH));
 
   xyz_pos_t park_point = NOZZLE_PARK_POINT;
 

--- a/Marlin/src/gcode/feature/pause/M600.cpp
+++ b/Marlin/src/gcode/feature/pause/M600.cpp
@@ -81,8 +81,8 @@ void GcodeSuite::M600() {
 
   #if ENABLED(DUAL_X_CARRIAGE)
     int8_t DXC_ext = target_extruder;
-    if (!parser.seen('T')) {  // If no tool index is specified, M600 was (probably) sent in response to filament runout.
-                              // In this case, for duplicating modes set DXC_ext to the extruder that ran out.
+    if (!parser.seen_test('T')) {  // If no tool index is specified, M600 was (probably) sent in response to filament runout.
+                                   // In this case, for duplicating modes set DXC_ext to the extruder that ran out.
       #if MULTI_FILAMENT_SENSOR
         if (idex_is_duplicating())
           DXC_ext = (READ(FIL_RUNOUT2_PIN) == FIL_RUNOUT2_STATE) ? 1 : 0;
@@ -110,7 +110,7 @@ void GcodeSuite::M600() {
   #endif
 
   // Initial retract before move to filament change position
-  const float retract = -ABS(parser.seen('E') ? parser.value_axis_units(E_AXIS) : (PAUSE_PARK_RETRACT_LENGTH));
+  const float retract = -ABS(parser.axisunitsval('E', E_AXIS, PAUSE_PARK_RETRACT_LENGTH));
 
   xyz_pos_t park_point NOZZLE_PARK_POINT;
 
@@ -132,15 +132,11 @@ void GcodeSuite::M600() {
                     fast_load_length = 0.0f;
   #else
     // Unload filament
-    const float unload_length = -ABS(parser.seen('U') ? parser.value_axis_units(E_AXIS)
-                                                      : fc_settings[active_extruder].unload_length);
-
+    const float unload_length = -ABS(parser.axisunitsval('U', E_AXIS, fc_settings[active_extruder].unload_length));
     // Slow load filament
     constexpr float slow_load_length = FILAMENT_CHANGE_SLOW_LOAD_LENGTH;
-
     // Fast load filament
-    const float fast_load_length = ABS(parser.seen('L') ? parser.value_axis_units(E_AXIS)
-                                                        : fc_settings[active_extruder].load_length);
+    const float fast_load_length = ABS(parser.axisunitsval('L', E_AXIS, fc_settings[active_extruder].load_length));
   #endif
 
   const int beep_count = parser.intval('B', -1

--- a/Marlin/src/gcode/feature/powerloss/M1000.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M1000.cpp
@@ -59,7 +59,7 @@ inline void plr_error(PGM_P const prefix) {
 void GcodeSuite::M1000() {
 
   if (recovery.valid()) {
-    if (parser.seen('S')) {
+    if (parser.seen_test('S')) {
       #if HAS_LCD_MENU
         ui.goto_screen(menu_job_recovery);
       #elif ENABLED(DWIN_CREALITY_LCD)
@@ -70,7 +70,7 @@ void GcodeSuite::M1000() {
         SERIAL_ECHO_MSG("Resume requires LCD.");
       #endif
     }
-    else if (parser.seen('C')) {
+    else if (parser.seen_test('C')) {
       #if HAS_LCD_MENU
         lcd_power_loss_recovery_cancel();
       #else

--- a/Marlin/src/gcode/feature/powerloss/M413.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M413.cpp
@@ -48,14 +48,14 @@ void GcodeSuite::M413() {
 
   #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
     if (parser.seen("RL")) recovery.load();
-    if (parser.seen('W')) recovery.save(true);
-    if (parser.seen('P')) recovery.purge();
-    if (parser.seen('D')) recovery.debug(PSTR("M413"));
+    if (parser.seen_test('W')) recovery.save(true);
+    if (parser.seen_test('P')) recovery.purge();
+    if (parser.seen_test('D')) recovery.debug(PSTR("M413"));
     #if PIN_EXISTS(POWER_LOSS)
-      if (parser.seen('O')) recovery._outage();
+      if (parser.seen_test('O')) recovery._outage();
     #endif
-    if (parser.seen('E')) SERIAL_ECHOPGM_P(recovery.exists() ? PSTR("PLR Exists\n") : PSTR("No PLR\n"));
-    if (parser.seen('V')) SERIAL_ECHOPGM_P(recovery.valid() ? PSTR("Valid\n") : PSTR("Invalid\n"));
+    if (parser.seen_test('E')) SERIAL_ECHOPGM_P(recovery.exists() ? PSTR("PLR Exists\n") : PSTR("No PLR\n"));
+    if (parser.seen_test('V')) SERIAL_ECHOPGM_P(recovery.valid() ? PSTR("Valid\n") : PSTR("Invalid\n"));
   #endif
 }
 

--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -44,7 +44,7 @@ void GcodeSuite::M412() {
     #if ENABLED(HOST_ACTION_COMMANDS)
       if (parser.seen('H')) runout.host_handling = parser.value_bool();
     #endif
-    const bool seenR = parser.seen('R'), seenS = parser.seen('S');
+    const bool seenR = parser.seen_test('R'), seenS = parser.seen('S');
     if (seenR || seenS) runout.reset();
     if (seenS) runout.enabled = parser.value_bool();
     #if HAS_FILAMENT_RUNOUT_DISTANCE

--- a/Marlin/src/gcode/feature/trinamic/M122.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M122.cpp
@@ -48,7 +48,7 @@ void GcodeSuite::M122() {
       tmc_set_report_interval(interval);
     #endif
 
-    if (parser.seen('V'))
+    if (parser.seen_test('V'))
       tmc_get_registers(print_axis.x, print_axis.y, print_axis.z, print_axis.e);
     else
       tmc_report_all(print_axis.x, print_axis.y, print_axis.z, print_axis.e);

--- a/Marlin/src/gcode/gcode_d.cpp
+++ b/Marlin/src/gcode/gcode_d.cpp
@@ -52,7 +52,7 @@
         break;
 
       case 10:
-        kill(PSTR("D10"), PSTR("KILL TEST"), parser.seen('P'));
+        kill(PSTR("D10"), PSTR("KILL TEST"), parser.seen_test('P'));
         break;
 
       case 1: {

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -193,7 +193,7 @@
 void GcodeSuite::M114() {
 
   #if ENABLED(M114_DETAIL)
-    if (parser.seen('D')) {
+    if (parser.seen_test('D')) {
       #if DISABLED(M114_LEGACY)
         planner.synchronize();
       #endif
@@ -201,14 +201,14 @@ void GcodeSuite::M114() {
       report_current_position_detail();
       return;
     }
-    if (parser.seen('E')) {
+    if (parser.seen_test('E')) {
       SERIAL_ECHOLNPAIR("Count E:", stepper.position(E_AXIS));
       return;
     }
   #endif
 
   #if ENABLED(M114_REALTIME)
-    if (parser.seen('R')) { report_real_position(); return; }
+    if (parser.seen_test('R')) { report_real_position(); return; }
   #endif
 
   TERN_(M114_LEGACY, planner.synchronize());

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -49,9 +49,9 @@ void GcodeSuite::G0_G1(TERN_(HAS_FAST_MOVES, const bool fast_move/*=false*/)) {
   if (IsRunning()
     #if ENABLED(NO_MOTION_BEFORE_HOMING)
       && !homing_needed_error(
-          (parser.seen('X') ? _BV(X_AXIS) : 0)
-        | (parser.seen('Y') ? _BV(Y_AXIS) : 0)
-        | (parser.seen('Z') ? _BV(Z_AXIS) : 0) )
+          (parser.seen_test('X') ? _BV(X_AXIS) : 0)
+        | (parser.seen_test('Y') ? _BV(Y_AXIS) : 0)
+        | (parser.seen_test('Z') ? _BV(Z_AXIS) : 0) )
     #endif
   ) {
     TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_RUNNING));

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -74,7 +74,7 @@ void GcodeSuite::M290() {
         const float offs = constrain(parser.value_axis_units((AxisEnum)a), -2, 2);
         babystep.add_mm((AxisEnum)a, offs);
         #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
-          if (a == Z_AXIS && (!parser.seen('P') || parser.value_bool())) mod_probe_offset(offs);
+          if (a == Z_AXIS && parser.boolval('P', true)) mod_probe_offset(offs);
         #endif
       }
   #else

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -408,6 +408,8 @@ public:
   static inline int32_t   longval(const char c, const int32_t dval=0)    { return seenval(c) ? value_long()         : dval; }
   static inline uint32_t  ulongval(const char c, const uint32_t dval=0)  { return seenval(c) ? value_ulong()        : dval; }
   static inline float     linearval(const char c, const float dval=0)    { return seenval(c) ? value_linear_units() : dval; }
+  static inline float     axisunitsval(const char c, const AxisEnum a, const float dval=0)
+                                                                         { return seenval(c) ? value_axis_units(a)  : dval; }
   static inline celsius_t celsiusval(const char c, const float dval=0)   { return seenval(c) ? value_celsius()      : dval; }
 
   #if ENABLED(MARLIN_DEV_MODE)

--- a/Marlin/src/gcode/sd/M27.cpp
+++ b/Marlin/src/gcode/sd/M27.cpp
@@ -33,7 +33,7 @@
  *      OR, with 'C' get the current filename.
  */
 void GcodeSuite::M27() {
-  if (parser.seen('C')) {
+  if (parser.seen_test('C')) {
     SERIAL_ECHOPGM("Current file: ");
     card.printSelectedFilename();
     return;

--- a/Marlin/src/gcode/sd/M808.cpp
+++ b/Marlin/src/gcode/sd/M808.cpp
@@ -44,7 +44,7 @@ void GcodeSuite::M808() {
   // Allowed to go into the queue for logging purposes.
 
   // M808 K sent from the host to cancel all loops
-  if (parser.seen('K')) repeat.cancel();
+  if (parser.seen_test('K')) repeat.cancel();
 
 }
 

--- a/Marlin/src/gcode/temp/M106_M107.cpp
+++ b/Marlin/src/gcode/temp/M106_M107.cpp
@@ -68,7 +68,7 @@ void GcodeSuite::M106() {
       if (t > 0) return thermalManager.set_temp_fan_speed(pfan, t);
     #endif
 
-    const uint16_t dspeed = parser.seen('A') ? thermalManager.fan_speed[active_extruder] : 255;
+    const uint16_t dspeed = parser.seen_test('A') ? thermalManager.fan_speed[active_extruder] : 255;
 
     uint16_t speed = dspeed;
 

--- a/Marlin/src/gcode/temp/M303.cpp
+++ b/Marlin/src/gcode/temp/M303.cpp
@@ -47,7 +47,7 @@
 void GcodeSuite::M303() {
 
   #if ANY(PID_DEBUG, PID_BED_DEBUG, PID_CHAMBER_DEBUG)
-    if (parser.seen('D')) {
+    if (parser.seen_test('D')) {
       thermalManager.pid_debug_flag ^= true;
       SERIAL_ECHO_START();
       SERIAL_ECHOPGM("PID Debug ");


### PR DESCRIPTION
Contrary to some G-code standards, Marlin doesn't require G-code parameters to have a value. Parameters without values are interpreted in one of two ways in Marlin G-code handlers:

- Some parameters are interpreted using `parser.boolval('Q')` (or `parser.seen('Q')` … `parser.value_bool()`). These are actual `bool` parameters, and a value of `0` is considered `false`.

- Some parameters are interpreted using `parser.seen_test('Q')` (or `parser.seen('Q')`). These are "flag" parameters and the value doesn't matter, so `Q0` is still considered `true`. So you might see `G28 X0 Y0 Z0` in G-code examples from time to time.

The call to `seen` is slightly more expensive because it sets a pointer to the parameter value as setup for `parser.value_linear()` or another value converter to be used immediately afterward. Since "flag" parameters never use the value pointer, this PR changes flag parameter tests from `seen` to the more basic `seen_test`.

- Other miscellaneous `parser` calls are also improved.
- Add and apply `parser.axisunitsval` accessor.