### PR TITLE
Fix G5 IJ with Motion Mode

### DIFF
--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -216,10 +216,9 @@ void GCodeParser::parse(char *p) {
       break;
 
     #if ENABLED(GCODE_MOTION_MODES)
-      #if ENABLED(ARC_SUPPORT)
-        case 'I' ... 'J':
-          if (motion_mode_codenum != 2 && motion_mode_codenum != 3) return;
-      #endif
+      case 'I' ... 'J':
+        if (motion_mode_codenum != 5 && \
+            TERN1(ARC_SUPPORT, motion_mode_codenum != 2 && motion_mode_codenum != 3)) return;
       case 'Q':
         if (motion_mode_codenum != 5) return;
       case 'X' ... 'Z': case 'E' ... 'F':


### PR DESCRIPTION
### Description

G5 can optionally pass I and J, so an extra check to see if the code number is 5 should be added during the `GCODE_MOTION_MODES` logic during the main parser switch on `letter`

I noticed at the same time that a recent PR #21630 removed P and R from the case, not running this bit of logic (when it should)
```
if (motion_mode_codenum < 0) return;
command_letter = 'G';
codenum = motion_mode_codenum;
TERN_(USE_GCODE_SUBCODES, subcode = motion_mode_subcode);
p--; // Back up one character to use the current parameter
```
Is this a bug? Or maybe I'm missing some context?

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

Allow I and J to be passed for a repeated G5 if GCODE_MOTION_MODES enabled

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
