### PR TITLE
Fix compile error (typo)

### DIFF
--- a/Marlin/src/gcode/feature/trinamic/M122.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M122.cpp
@@ -32,7 +32,7 @@
  * M122: Debug TMC drivers
  */
 void GcodeSuite::M122() {
-  xyze_bool_t print_axis = ARRAY_N_1(NUM_AXIS, false);
+  xyze_bool_t print_axis = ARRAY_N_1(XYZE, false);
 
   bool print_all = true;
   LOOP_XYZE(i) if (parser.seen(axis_codes[i])) { print_axis[i] = true; print_all = false; }


### PR DESCRIPTION
### Description

Commit 390878e broke M122 
error: 'LIST_NUM_AXIS' was not declared in this scope

@rhapsodyv found the fix,  no one seems to have created a pr, so I did.

### Requirements

TMC stepper drivers 

### Benefits

Compiles as expected

### Related Issues
Issue #21874