### PR TITLE
Always Invert Octopus Onboard SD Detect Pin

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
@@ -349,6 +349,7 @@
 //
 #if SD_CONNECTION_IS(ONBOARD)
   #define SDIO_SUPPORT                            // Use SDIO for onboard SD
+  #undef SD_DETECT_STATE
   #define SD_DETECT_STATE                   HIGH
   #define SD_DETECT_PIN                     PC14
 #elif SD_CONNECTION_IS(LCD)

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
@@ -349,6 +349,7 @@
 //
 #if SD_CONNECTION_IS(ONBOARD)
   #define SDIO_SUPPORT                            // Use SDIO for onboard SD
+  #define SD_DETECT_STATE                   HIGH
   #define SD_DETECT_PIN                     PC14
 #elif SD_CONNECTION_IS(LCD)
 


### PR DESCRIPTION
### Description

Always invert `SD_DETECT_STATE` using the pins file instead of relying on a proper config.

### Requirements

BTT Octopus with `SD_CONNECTION_IS` set to `ONBOARD`.

### Benefits

Onboard SD detection will work correctly, even if `SD_DETECT_STATE` is not set in the config.