### PR TITLE
Fix Octopus 12864 LCD Delays

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
@@ -489,13 +489,13 @@
 // Alter timing for graphical display
 #if HAS_MARLINUI_U8GLIB
   #ifndef BOARD_ST7920_DELAY_1
-    #define BOARD_ST7920_DELAY_1    DELAY_NS(96)
+    #define BOARD_ST7920_DELAY_1   DELAY_NS(120)  // DELAY_NS(96)
   #endif
   #ifndef BOARD_ST7920_DELAY_2
-    #define BOARD_ST7920_DELAY_2    DELAY_NS(48)
+    #define BOARD_ST7920_DELAY_2    DELAY_NS(80)  // DELAY_NS(48)
   #endif
   #ifndef BOARD_ST7920_DELAY_3
-    #define BOARD_ST7920_DELAY_3   DELAY_NS(600)
+    #define BOARD_ST7920_DELAY_3   DELAY_NS(580)  // DELAY_NS(600)
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
@@ -492,7 +492,7 @@
     #define BOARD_ST7920_DELAY_1   DELAY_NS(120)  // DELAY_NS(96)
   #endif
   #ifndef BOARD_ST7920_DELAY_2
-    #define BOARD_ST7920_DELAY_2    DELAY_NS(80)  // DELAY_NS(48)
+    #define BOARD_ST7920_DELAY_2   DELAY_NS(80)   // DELAY_NS(48)
   #endif
   #ifndef BOARD_ST7920_DELAY_3
     #define BOARD_ST7920_DELAY_3   DELAY_NS(580)  // DELAY_NS(600)


### PR DESCRIPTION
### Description

Related to #21778, LCD timings are still broken on many configs with 12864 LCDs, and the BTT Octopus is no different.

Ideally, all the previous delays will be adjusted, but myself & others are working through hardware as time allows, so this PR only corrects timings on the Octopus board for now.

Also: I left the previous timings but commented them out in the likely event we need to revisit this.

### Requirements

BTT Octopus + 12864 LCD.

### Benefits

No more garbled LCD when using a real 12864 LCD (TFTs with an emulated "Marlin Mode" are not affected).

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

Related to #21778, but this doesn't solve the overall issue.