### PR TITLE
Fix nextion compile error 

### DIFF
--- a/Marlin/src/lcd/extui/nextion/nextion_extui.cpp
+++ b/Marlin/src/lcd/extui/nextion/nextion_extui.cpp
@@ -26,12 +26,12 @@
  * Nextion TFT support for Marlin
  */
 
-#include "../../inc/MarlinConfigPre.h"
+#include "../../../inc/MarlinConfigPre.h"
 
 #if ENABLED(NEXTION_TFT)
 
-#include "ui_api.h"
-#include "lib/nextion/nextion_tft.h"
+#include "../ui_api.h"
+#include "nextion_tft.h"
 
 namespace ExtUI {
 

--- a/Marlin/src/lcd/extui/nextion/nextion_tft.cpp
+++ b/Marlin/src/lcd/extui/nextion/nextion_tft.cpp
@@ -723,9 +723,9 @@ void NextionTFT::UpdateOnChange() {
     last_homedZ = isAxisPositionKnown(Z);
   }
 
-  // tmppage IDEX Mode
-  static uint8_t last_IDEX_Mode = 99;
   #if ENABLED(DUAL_X_CARRIAGE)
+    // tmppage IDEX Mode
+    static uint8_t last_IDEX_Mode = 99;
     if (last_IDEX_Mode != getIDEX_Mode()) {
       SEND_VAL("tmppage.idexmode", getIDEX_Mode());
       last_IDEX_Mode = getIDEX_Mode();

--- a/Marlin/src/lcd/extui/nextion/nextion_tft.cpp
+++ b/Marlin/src/lcd/extui/nextion/nextion_tft.cpp
@@ -645,6 +645,9 @@ void NextionTFT::UpdateOnChange() {
     last_flow_speed = getFlow_percent(getActiveTool());
   }
 
+  // tmppage Axis
+  static float last_get_axis_position_mmX = 999, last_get_axis_position_mmY = 999, last_get_axis_position_mmZ = 999;
+
   // tmppage Progress + Layer + Time
   if (isPrinting()) {
 
@@ -678,9 +681,6 @@ void NextionTFT::UpdateOnChange() {
       SEND_VALasTXT("tmppage.layer", layer);
     }
   }
-
-  // tmppage Axis
-  static float last_get_axis_position_mmX = 999, last_get_axis_position_mmY = 999, last_get_axis_position_mmZ = 999;
 
   if (!WITHIN(last_get_axis_position_mmX - getAxisPosition_mm(X), -0.1, 0.1)) {
     if (ELAPSED(ms, next_event_ms)) {


### PR DESCRIPTION
### Description

Nextion tft will not compile. Has 3 include path errors and a issue of trying to use a variable before it is created.
Also addresses an unused variable warning. 
This fixes all of these.
 
### Requirements

#define NEXTION_TFT

### Benefits

Compiles as expected


### Related Issues
Originally reported in Discord by Japhei