### PR TITLE
Fix compilation failure in M1001

### DIFF
--- a/Marlin/src/gcode/sd/M1001.cpp
+++ b/Marlin/src/gcode/sd/M1001.cpp
@@ -27,10 +27,7 @@
 #include "../gcode.h"
 #include "../../module/planner.h"
 #include "../../module/printcounter.h"
-
-#if DISABLED(NO_SD_AUTOSTART)
-  #include "../../sd/cardreader.h"
-#endif
+#include "../../sd/cardreader.h"
 
 #ifdef SD_FINISHED_RELEASECOMMAND
   #include "../queue.h"


### PR DESCRIPTION
### Description

Fixes undeclared reference to card in M1001 introduced by PR#21840

### Requirements

`NO_SD_AUTOSTART` enabled.

### Benefits

Fix build failure.

```
Marlin/src/gcode/sd/M1001.cpp: In static member function 'static void GcodeSuite::M1001()':
Marlin/src/gcode/sd/M1001.cpp:71:3: error: 'card' was not declared in this scope
   card.flag.sdprinting = card.flag.sdprintdone = false;
   ^~~~
Marlin/src/gcode/sd/M1001.cpp:71:3: note: suggested alternative: 'word'
   card.flag.sdprinting = card.flag.sdprintdone = false;
   ^~~~
   word
*** [.pio/build/anycubic_mega_zero_melzi_bl_zmin/src/src/gcode/sd/M1001.cpp.o] Error 1
```

### Configurations

`#define NO_SD_AUTOSTART` (saving space in BLTouch config on Melzi board). 

### Related Issues

Fixes: #21850

