### PR TITLE
BTT Octopus: Prevent Potential Step/Tone Timer Conflict

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_0.h
@@ -36,6 +36,9 @@
 // USB Flash Drive support
 #define HAS_OTG_USB_HOST_SUPPORT
 
+// Avoid conflict with TIMER_TONE
+#define STEP_TIMER                            10
+
 //
 // Servos
 #define SERVO0_PIN                          PB6


### PR DESCRIPTION
### Description

Certain configs can cause step & tone timer conflicts, so this PR mitigates potential issues by specifying `STEP_TIMER`.

### Requirements

BTT Octopus

### Benefits

See above.

### Related Issues

None. Discovered while working through more config testing.