### PR TITLE
Automatically turn on LEDs on startup

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2722,6 +2722,7 @@
  */
 #if ANY(BLINKM, RGB_LED, RGBW_LED, PCA9632, PCA9533, NEOPIXEL_LED)
   #define PRINTER_EVENT_LEDS
+  #define AUTO_WHITE //Set to white on startup
 #endif
 
 /**

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1209,6 +1209,7 @@ void setup() {
   // Set up LEDs early
   #if HAS_COLOR_LEDS
     SETUP_RUN(leds.setup());
+    TERN_(AUTO_WHITE, leds.set_white());
   #endif
 
   #if ENABLED(NEOPIXEL2_SEPARATE)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Adds the option to have the case LEDs turn on automaticlly when the printer is turned on like Flashforge, Makerbot, Ultimaker, etc

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
LEDs
Tested on an SKR Pro inside a Creator Pro 2

<!-- Does this PR require a specific board, LCD, etc.? -->
