### PR TITLE
Default KILL_PIN_STATE for RAMBO

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -1761,11 +1761,6 @@ void unified_bed_leveling::smart_fill_mesh() {
     }
     SERIAL_EOL();
 
-    #if HAS_KILL
-      SERIAL_ECHOLNPAIR("Kill pin on :", KILL_PIN, "  state:", kill_state());
-    #endif
-
-    SERIAL_EOL();
     serial_delay(50);
 
     #if ENABLED(UBL_DEVEL_DEBUGGING)

--- a/Marlin/src/pins/rambo/pins_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_RAMBO.h
@@ -196,6 +196,9 @@
 #if HAS_WIRED_LCD || TOUCH_UI_ULTIPANEL
 
   #define KILL_PIN                            80
+  #ifndef KILL_PIN_STATE
+    #define KILL_PIN_STATE                  HIGH
+  #endif
 
   #if IS_ULTIPANEL || TOUCH_UI_ULTIPANEL
 


### PR DESCRIPTION
~~In reference to #21914…~~

~~A machine with RAMBO and LCD2004 is spontaneously rebooting due to an inverted KILL pin. Should the default KILL state for RAMBO be HIGH in all cases, or is this just one of those things that must be set based on the attached controller?~~