### PR TITLE
Add MESH_EDIT_MENU sanity check

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1,4 +1,3 @@
-//wake up CI
 /**
  * Marlin 3D Printer Firmware
  * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1,3 +1,4 @@
+//wake up CI
 /**
  * Marlin 3D Printer Firmware
  * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1582,6 +1582,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #error "LCD_BED_LEVELING requires a programmable LCD controller."
   #elif !(ENABLED(MESH_BED_LEVELING) || HAS_ABL_NOT_UBL)
     #error "LCD_BED_LEVELING requires MESH_BED_LEVELING or AUTO_BED_LEVELING."
+  #elif ENABLED(MESH_EDIT_MENU) && !HAS_MESH
+    #error "MESH_EDIT_MENU requires MESH_BED_LEVELING, AUTO_BED_LEVELING_BILINEAR or AUTO_BED_LEVELING_UBL."
   #endif
 #endif
 


### PR DESCRIPTION
### Description

User are enabling MESH_EDIT_MENU when they are not using a meshed based levelling system.
This result in Compilation error (as expected)

### Requirements

MESH_EDIT_MENU and an appropriate LCD with an inappropriate bed levelling system ( AUTO_BED_LEVELING_3POINT or AUTO_BED_LEVELING_LINEAR)

### Benefits

Less confused users

### Related Issues
issue https://github.com/MarlinFirmware/Marlin/issues/21908