### PR TITLE
Add STM32 HAL to MKS Robin E3

### DIFF
--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -31,9 +31,10 @@
 // The TONE timer is not present here, as it currently cannot be set programmatically. It is set
 // by defining TIM_IRQ_PRIO in the variant.h or platformio.ini file, which adjusts the default
 // priority for STM32 HardwareTimer objects.
-#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  1 // Requires tight bit timing to communicate reliably with TMC drivers
-#define SERVO_TIMER_IRQ_PRIO_DEFAULT     1 // Requires tight PWM timing to control a BLTouch reliably
-#define STEP_TIMER_IRQ_PRIO_DEFAULT      2
+// Let the serial interrupt have the highest priority (1) to avoid lost characters.
+#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  2 // Requires tight bit timing to communicate reliably with TMC drivers
+#define SERVO_TIMER_IRQ_PRIO_DEFAULT     2 // Requires tight PWM timing to control a BLTouch reliably
+#define STEP_TIMER_IRQ_PRIO_DEFAULT      8
 #define TEMP_TIMER_IRQ_PRIO_DEFAULT     14 // Low priority avoids interference with other hardware and timers
 
 #ifndef STEP_TIMER_IRQ_PRIO

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -31,10 +31,9 @@
 // The TONE timer is not present here, as it currently cannot be set programmatically. It is set
 // by defining TIM_IRQ_PRIO in the variant.h or platformio.ini file, which adjusts the default
 // priority for STM32 HardwareTimer objects.
-// Let the serial interrupt have the highest priority (1) to avoid lost characters.
-#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  2 // Requires tight bit timing to communicate reliably with TMC drivers
-#define SERVO_TIMER_IRQ_PRIO_DEFAULT     2 // Requires tight PWM timing to control a BLTouch reliably
-#define STEP_TIMER_IRQ_PRIO_DEFAULT      8
+#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  1 // Requires tight bit timing to communicate reliably with TMC drivers
+#define SERVO_TIMER_IRQ_PRIO_DEFAULT     1 // Requires tight PWM timing to control a BLTouch reliably
+#define STEP_TIMER_IRQ_PRIO_DEFAULT      2
 #define TEMP_TIMER_IRQ_PRIO_DEFAULT     14 // Low priority avoids interference with other hardware and timers
 
 #ifndef STEP_TIMER_IRQ_PRIO

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -503,7 +503,7 @@
 #elif MB(MKS_ROBIN_PRO)
   #include "stm32f1/pins_MKS_ROBIN_PRO.h"       // STM32F1                                env:mks_robin_pro
 #elif MB(MKS_ROBIN_E3)
-  #include "stm32f1/pins_MKS_ROBIN_E3.h"        // STM32F1                                env:mks_robin_e3
+  #include "stm32f1/pins_MKS_ROBIN_E3.h"        // STM32F1                                env:mks_robin_e3 env:mks_robin_e3_maple
 #elif MB(MKS_ROBIN_E3_V1_1)
   #include "stm32f1/pins_MKS_ROBIN_E3_V1_1.h"   // STM32F1                                env:mks_robin_e3
 #elif MB(MKS_ROBIN_E3D)

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -178,19 +178,19 @@
 //
 #define SPI_DEVICE                          2
 #define ONBOARD_SPI_DEVICE                  2
-#define SDSS                                SD_SS_PIN
-#define SDCARD_CONNECTION                   ONBOARD
+#define SDSS                           SD_SS_PIN
+#define SDCARD_CONNECTION                ONBOARD
 #define SD_DETECT_PIN                       PC10
+#define ONBOARD_SD_CS_PIN              SD_SS_PIN
+#define NO_SD_HOST_DRIVE
+
+// TODO: This is the only way to set SPI for SD on STM32 (for now)
+#define ENABLE_SPI2
+#define CUSTOM_SPI_PINS
 #define SD_SCK_PIN                          PB13
 #define SD_MISO_PIN                         PB14
 #define SD_MOSI_PIN                         PB15
 #define SD_SS_PIN                           PA15
-#define ONBOARD_SD_CS_PIN                   SD_SS_PIN
-#define NO_SD_HOST_DRIVE
-
-// TODO: needed because is the only way to set SPI for SD on STM32 (by now)
-#define CUSTOM_SPI_PINS
-#define ENABLE_SPI2
 
 #ifndef BOARD_ST7920_DELAY_1
   #define BOARD_ST7920_DELAY_1     DELAY_NS(125)

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -176,12 +176,21 @@
 //
 // SD Card
 //
-#define SPI_DEVICE                             2
+#define SPI_DEVICE                          2
+#define ONBOARD_SPI_DEVICE                  2
+#define SDSS                                SD_SS_PIN
+#define SDCARD_CONNECTION                   ONBOARD
 #define SD_DETECT_PIN                       PC10
 #define SD_SCK_PIN                          PB13
 #define SD_MISO_PIN                         PB14
 #define SD_MOSI_PIN                         PB15
 #define SD_SS_PIN                           PA15
+#define ONBOARD_SD_CS_PIN                   SD_SS_PIN
+#define NO_SD_HOST_DRIVE
+
+// TODO: needed because is the only way to set SPI for SD on STM32 (by now)
+#define CUSTOM_SPI_PINS
+#define ENABLE_SPI2
 
 #ifndef BOARD_ST7920_DELAY_1
   #define BOARD_ST7920_DELAY_1     DELAY_NS(125)

--- a/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
+++ b/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
@@ -3,7 +3,16 @@
 #
 Import("env")
 
-# Set the buffer size according to the configuration file or 64 if too small or absent.
+# Marlin has `RX_BUFFER_SIZE` and `TX_BUFFER_SIZE` to configure the
+# buffer size for receiving and transmitting data respectively.
+# Stm32duino uses another set of defines for the same purpose,
+# so we get the values from the Marlin configuration and set
+# them in `SERIAL_RX_BUFFER_SIZE` and `SERIAL_TX_BUFFER_SIZE`.
+# It is not possible to change the values at runtime, they must
+# be set with build flags.
+#
+# The script will set the value as the default one (64 bytes)
+# or the user-configured one, whichever is higher.
 mf = env["MARLIN_FEATURES"]
 rxBuf = str(max(64, int(mf["RX_BUFFER_SIZE"]) if "RX_BUFFER_SIZE" in mf else 0))
 txBuf = str(max(64, int(mf["TX_BUFFER_SIZE"]) if "TX_BUFFER_SIZE" in mf else 0))

--- a/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
+++ b/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
@@ -1,0 +1,19 @@
+#
+# stm32_serialbuffer.py
+#
+from os.path import join, isfile
+import shutil
+from pprint import pprint
+
+Import("env")
+
+# Set the buffer size according to the configuration file
+# or 64 if too small or absent.
+mf = env["MARLIN_FEATURES"]
+rxBuf = str(max(64, int(mf["RX_BUFFER_SIZE"]) if "RX_BUFFER_SIZE" in mf else 0))
+txBuf = str(max(64, int(mf["TX_BUFFER_SIZE"]) if "TX_BUFFER_SIZE" in mf else 0))
+
+build_flags = env.get('BUILD_FLAGS')
+build_flags.append("-DSERIAL_RX_BUFFER_SIZE=" + rxBuf)
+build_flags.append("-DSERIAL_TX_BUFFER_SIZE=" + txBuf)
+env.Replace(BUILD_FLAGS=build_flags)

--- a/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
+++ b/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
@@ -1,14 +1,9 @@
 #
 # stm32_serialbuffer.py
 #
-from os.path import join, isfile
-import shutil
-from pprint import pprint
-
 Import("env")
 
-# Set the buffer size according to the configuration file
-# or 64 if too small or absent.
+# Set the buffer size according to the configuration file or 64 if too small or absent.
 mf = env["MARLIN_FEATURES"]
 rxBuf = str(max(64, int(mf["RX_BUFFER_SIZE"]) if "RX_BUFFER_SIZE" in mf else 0))
 txBuf = str(max(64, int(mf["TX_BUFFER_SIZE"]) if "TX_BUFFER_SIZE" in mf else 0))

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -268,7 +268,7 @@ extra_scripts = ${common_stm32f1.extra_scripts}
 # MKS Robin E3D (STM32F103RCT6) and
 # MKS Robin E3 with TMC2209
 #
-[env:mks_robin_e3]
+[env:mks_robin_e3_maple]
 platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103RC

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -31,6 +31,8 @@ build_flags   = ${common.build_flags}
   -DADC_RESOLUTION=12
 build_unflags = -std=gnu++11
 src_filter    = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
+extra_scripts = ${common.extra_scripts}
+  pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
 
 #
 # BigTree SKR Mini V1.1 / SKR mini E3 / SKR E3 DIP (STM32F103RCT6 ARM Cortex-M3)
@@ -53,9 +55,8 @@ monitor_speed        = 115200
 board_build.core     = stm32
 board_build.variant  = MARLIN_F103Rx
 board_build.ldscript = ldscript.ld
-extra_scripts        = ${common.extra_scripts}
+extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
-  pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
 
 #
@@ -137,7 +138,7 @@ build_flags          = ${common_stm32.build_flags}
   -DENABLE_HWSERIAL3 -DTIMER_SERIAL=TIM5
 build_unflags        = ${common_stm32.build_unflags}
  -DUSBCON -DUSBD_USE_CDC
-extra_scripts        = ${common.extra_scripts}
+extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
   buildroot/share/PlatformIO/scripts/mks_encrypt.py
@@ -202,7 +203,7 @@ board_build.firmware = Robin_mini.bin
 board_build.encrypt  = Yes
 board_upload.offset_address = 0x08007000
 build_unflags        = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
-extra_scripts        = ${common.extra_scripts}
+extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
   buildroot/share/PlatformIO/scripts/mks_encrypt.py
@@ -225,7 +226,7 @@ board_upload.offset_address = 0x08007000
 build_unflags        = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
 debug_tool           = jlink
 upload_protocol      = jlink
-extra_scripts        = ${common.extra_scripts}
+extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
   buildroot/share/PlatformIO/scripts/mks_encrypt.py
@@ -243,6 +244,6 @@ board_build.ldscript = ldscript.ld
 board_build.offset   = 0x10000
 build_flags          = ${common_stm32.build_flags} -DENABLE_HWSERIAL3 -DTIMER_SERIAL=TIM5
 build_unflags        = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
-extra_scripts        = ${common.extra_scripts}
+extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -55,6 +55,7 @@ board_build.variant  = MARLIN_F103Rx
 board_build.ldscript = ldscript.ld
 extra_scripts        = ${common.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
+  pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
 
 #
@@ -141,6 +142,26 @@ extra_scripts        = ${common.extra_scripts}
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
   buildroot/share/PlatformIO/scripts/mks_encrypt.py
 lib_deps             =
+
+#
+#
+# MKS Robin E3D (STM32F103RCT6) and
+# MKS Robin E3 with TMC2209
+#
+[env:mks_robin_e3]
+platform                    = ${common_stm32.platform}
+extends                     = env:STM32F103RC_stm32
+build_flags                 = ${common_stm32.build_flags}
+  -DDEBUG_LEVEL=0 -DTIMER_SERVO=TIM5
+build_unflags               = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
+monitor_speed               = 115200
+board_build.offset          = 0x5000
+board_build.encrypt         = Yes
+board_build.firmware        = Robin_e3.bin
+board_upload.offset_address = 0x08005000
+debug_tool                  = stlink
+extra_scripts               = ${env:STM32F103RC.extra_scripts}
+  buildroot/share/PlatformIO/scripts/mks_encrypt.py
 
 #
 # Creality (STM32F103RET6)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -145,9 +145,7 @@ extra_scripts        = ${common_stm32.extra_scripts}
 lib_deps             =
 
 #
-#
-# MKS Robin E3D (STM32F103RCT6) and
-# MKS Robin E3 with TMC2209
+# MKS Robin E3/E3D (STM32F103RCT6) with TMC2209
 #
 [env:mks_robin_e3]
 platform                    = ${common_stm32.platform}

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -151,7 +151,7 @@ lib_deps             =
 #
 [env:mks_robin_e3]
 platform                    = ${common_stm32.platform}
-extends                     = env:STM32F103RC_stm32
+extends                     = common_STM32F103RC
 build_flags                 = ${common_stm32.build_flags}
   -DDEBUG_LEVEL=0 -DTIMER_SERVO=TIM5
 build_unflags               = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC


### PR DESCRIPTION
### Description

This PR adds the `mks_robin_e3_stm32` env that uses the STM32 HAL. I'm using this configuration for over a month and it's rock solid.

### Requirements

MKS Robin E3 board. Should work with E3D but I don't have one to test.

### Benefits

One step closer to fully removing libmaple.
