### PR TITLE
fixes 21928, mks_encrypt.py not using env variable build.firmware to set filename

### DIFF
--- a/buildroot/share/PlatformIO/scripts/mks_encrypt.py
+++ b/buildroot/share/PlatformIO/scripts/mks_encrypt.py
@@ -17,7 +17,7 @@ if 'firmware' in board.get("build").keys():
 
 	# Encrypt ${PROGNAME}.bin and save it as build.firmware
 	def encrypt(source, target, env):
-		marlin.encrypt_mks(source, target, env, "build.firmware")
+		marlin.encrypt_mks(source, target, env, board.get("build.firmware"))
 
 	marlin.add_post_action(encrypt);
 


### PR DESCRIPTION
### Description

mks_encrypt.py saves files as "build.firmware" not as the name build.firmware env is set to. (Robin.bin,Robin_mini.bin or 
 Robin_nano35.bin)

### Requirements

Use one of these build environments and build the firmware
env:mks_robin_nano35_stm32
env:flsun_hispeedv1]
env:mks_robin_stm32

### Benefits

Correct .bin files is generated 

### Related Issues
Issue https://github.com/MarlinFirmware/Marlin/issues/21928