### PR TITLE
changes digitalPinToPort_DEBUG(p) for teensy to work with marlin 2.0.x

### DIFF
--- a/Marlin/src/HAL/AVR/pinsDebug.h
+++ b/Marlin/src/HAL/AVR/pinsDebug.h
@@ -38,7 +38,7 @@
   // portModeRegister takes a different argument
   #define digitalPinToTimer_DEBUG(p) digitalPinToTimer(p)
   #define digitalPinToBitMask_DEBUG(p) digitalPinToBitMask(p)
-  #define digitalPinToPort_DEBUG(p) digitalPinToPort_Teensy(p)
+  #define digitalPinToPort_DEBUG(p) digitalPinToPort(p)
   #define GET_PINMODE(pin) (*portModeRegister(pin) & digitalPinToBitMask_DEBUG(pin))
 
 #elif AVR_ATmega2560_FAMILY_PLUS_70   // So we can access/display all the pins on boards using more than 70


### PR DESCRIPTION
### Description

While trying to build Marlin 2.0.x, I needed to enable debug of pins for testing their behavior.

After enabling PINS_DEBUGGING, some definition errors came up.

By modifying the line in the PR, this error are corrected and pin debugging can be enabled.

### Requirements

teensy board, tested with a printrboard revD

### Benefits

Enables PINS_DEBUGGING in teensy based boards, like printrboard

### Configurations

Get the files from this repository for testing.

https://github.com/rngkll/Latest-Marlin-printrboard/tree/main/configurationFiles/printrboard_revD

	* Marlin/Configuration.h
	* Marlin/Configuration_adv.h

### Related Issues

No related issue found.
