### PR TITLE
fix MISO and MOSI pin definitions

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
@@ -143,6 +143,6 @@
 //
 #define SPI_DEVICE                             2
 #define SD_SCK_PIN                          PB13
-#define SD_MISO_PIN                         P1B4
-#define SD_MOSI_PIN                         P1B5
+#define SD_MISO_PIN                         PB14
+#define SD_MOSI_PIN                         PB15
 #define SD_SS_PIN                           PA15


### PR DESCRIPTION




### Description

<!--

the port definitions for the sd card spi pins were typed in incorrectly

#define SD_MISO_PIN                         PB14 // was  P1B4
#define SD_MOSI_PIN                         PB15 // was P1B5
-->


### Benefits

this fixes pin debugging.

I was able to find the schematics on makerbase GitHub back in the history.

https://github.com/makerbase-mks/MKS-Robin/tree/8a4853988dca648e1ea851953aac2aa82ebc280f/MKS%20Robin%20Lite/hardware/MKS%20Robin%20Lite%20V1.1_002

