### PR TITLE
Macros for optional list items

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -195,6 +195,11 @@
 #define __TERN(T,V...)      ___TERN(_CAT(_NO,T),V)  // Prepend '_NO' to get '_NOT_0' or '_NOT_1'
 #define ___TERN(P,V...)     THIRD(P,V)              // If first argument has a comma, A. Else B.
 
+#define _OPTARG(A)          , A
+#define OPTARG(O,A)         TERN_(O,DEFER4(_OPTARG)(A))
+#define _OPTCODE(A)         A;
+#define OPTCODE(O,A)        TERN_(O,DEFER4(_OPTCODE)(A))
+
 // Macros to avoid 'f + 0.0' which is not always optimized away. Minus included for symmetry.
 // Compiler flags -fno-signed-zeros -ffinite-math-only also cover 'f * 1.0', 'f - f', etc.
 #define PLUS_TERN0(O,A)     _TERN(_ENA_1(O),,+ (A)) // OPTION ? '+ (A)' : '<nul>'

--- a/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
+++ b/Marlin/src/feature/bedlevel/mbl/mesh_bed_leveling.h
@@ -103,9 +103,7 @@ public:
   }
 
   static float get_z(const xy_pos_t &pos
-    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-      , const_float_t factor=1.0f
-    #endif
+    OPTARG(ENABLE_LEVELING_FADE_HEIGHT, const_float_t factor=1.0f)
   ) {
     #if DISABLED(ENABLE_LEVELING_FADE_HEIGHT)
       constexpr float factor = 1.0f;

--- a/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_motion.cpp
@@ -362,15 +362,11 @@
       while (--segments) {
         raw += diff;
         planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, segment_xyz_mm
-          #if ENABLED(SCARA_FEEDRATE_SCALING)
-            , inv_duration
-          #endif
+          OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)
         );
       }
       planner.buffer_line(destination, scaled_fr_mm_s, active_extruder, segment_xyz_mm
-        #if ENABLED(SCARA_FEEDRATE_SCALING)
-          , inv_duration
-        #endif
+        OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)
       );
       return false; // Did not set current from destination
     }

--- a/Marlin/src/feature/caselight.cpp
+++ b/Marlin/src/feature/caselight.cpp
@@ -41,7 +41,7 @@ bool CaseLight::on = CASE_LIGHT_DEFAULT_ON;
 #if CASE_LIGHT_IS_COLOR_LED
   #include "leds/leds.h"
   constexpr uint8_t init_case_light[] = CASE_LIGHT_DEFAULT_COLOR;
-  LEDColor CaseLight::color = { init_case_light[0], init_case_light[1], init_case_light[2], TERN_(HAS_WHITE_LED, init_case_light[3]) };
+  LEDColor CaseLight::color = { init_case_light[0], init_case_light[1], init_case_light[2] OPTARG(HAS_WHITE_LED, init_case_light[3]) };
 #endif
 
 void CaseLight::update(const bool sflag) {

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -91,11 +91,7 @@ void FWRetract::reset() {
  * Note: Auto-retract will apply the set Z hop in addition to any Z hop
  *       included in the G-code. Use M207 Z0 to to prevent double hop.
  */
-void FWRetract::retract(const bool retracting
-  #if HAS_MULTI_EXTRUDER
-    , bool swapping/*=false*/
-  #endif
-) {
+void FWRetract::retract(const bool retracting OPTARG(HAS_MULTI_EXTRUDER, bool swapping/*=false*/)) {
   // Prevent two retracts or recovers in a row
   if (retracted[active_extruder] == retracting) return;
 

--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -74,11 +74,7 @@ public:
     #endif
   }
 
-  static void retract(const bool retracting
-    #if HAS_MULTI_EXTRUDER
-      , bool swapping = false
-    #endif
-  );
+  static void retract(const bool retracting OPTARG(HAS_MULTI_EXTRUDER, bool swapping = false));
 
   static void M207();
   static void M207_report(const bool forReplay=false);

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -75,9 +75,7 @@ void LEDLights::setup() {
 }
 
 void LEDLights::set_color(const LEDColor &incol
-  #if ENABLED(NEOPIXEL_LED)
-    , bool isSequence/*=false*/
-  #endif
+  OPTARG(NEOPIXEL_LED, bool isSequence/*=false*/)
 ) {
 
   #if ENABLED(NEOPIXEL_LED)

--- a/Marlin/src/feature/leds/leds.h
+++ b/Marlin/src/feature/leds/leds.h
@@ -43,46 +43,21 @@
  */
 typedef struct LEDColor {
   uint8_t r, g, b
-    #if HAS_WHITE_LED
-      , w
-      #if ENABLED(NEOPIXEL_LED)
-        , i
-      #endif
-    #endif
+    OPTARG(HAS_WHITE_LED, w)
+    OPTARG(NEOPIXEL_LED, i)
   ;
 
   LEDColor() : r(255), g(255), b(255)
-    #if HAS_WHITE_LED
-      , w(255)
-      #if ENABLED(NEOPIXEL_LED)
-        , i(NEOPIXEL_BRIGHTNESS)
-      #endif
-    #endif
+    OPTARG(HAS_WHITE_LED, w(255))
+    OPTARG(NEOPIXEL_LED, i(NEOPIXEL_BRIGHTNESS))
   {}
 
-  LEDColor(uint8_t r, uint8_t g, uint8_t b
-    #if HAS_WHITE_LED
-      , uint8_t w=0
-      #if ENABLED(NEOPIXEL_LED)
-        , uint8_t i=NEOPIXEL_BRIGHTNESS
-      #endif
-    #endif
-    ) : r(r), g(g), b(b)
-    #if HAS_WHITE_LED
-      , w(w)
-      #if ENABLED(NEOPIXEL_LED)
-        , i(i)
-      #endif
-    #endif
-  {}
+  LEDColor(uint8_t r, uint8_t g, uint8_t b OPTARG(HAS_WHITE_LED, uint8_t w=0) OPTARG(NEOPIXEL_LED, uint8_t i=NEOPIXEL_BRIGHTNESS))
+    : r(r), g(g), b(b) OPTARG(HAS_WHITE_LED, w(w)) OPTARG(NEOPIXEL_LED, i(i)) {}
 
   LEDColor(const uint8_t (&rgbw)[4]) : r(rgbw[0]), g(rgbw[1]), b(rgbw[2])
-    #if HAS_WHITE_LED
-      , w(rgbw[3])
-      #if ENABLED(NEOPIXEL_LED)
-        , i(NEOPIXEL_BRIGHTNESS)
-      #endif
-    #endif
+    OPTARG(HAS_WHITE_LED, w(rgbw[3]))
+    OPTARG(NEOPIXEL_LED, i(NEOPIXEL_BRIGHTNESS))
   {}
 
   LEDColor& operator=(const uint8_t (&rgbw)[4]) {
@@ -111,15 +86,7 @@ typedef struct LEDColor {
 /**
  * Color helpers and presets
  */
-#if HAS_WHITE_LED
-  #if ENABLED(NEOPIXEL_LED)
-    #define MakeLEDColor(R,G,B,W,I) LEDColor(R, G, B, W, I)
-  #else
-    #define MakeLEDColor(R,G,B,W,I) LEDColor(R, G, B, W)
-  #endif
-#else
-  #define MakeLEDColor(R,G,B,W,I)   LEDColor(R, G, B)
-#endif
+#define MakeLEDColor(R,G,B,W,I)   LEDColor(R, G, B OPTARG(HAS_WHITE_LED, W) OPTARG(NEOPIXEL_LED, I))
 
 #define LEDColorOff()             LEDColor(  0,   0,   0)
 #define LEDColorRed()             LEDColor(255,   0,   0)
@@ -147,25 +114,15 @@ public:
   static void setup(); // init()
 
   static void set_color(const LEDColor &color
-    #if ENABLED(NEOPIXEL_LED)
-      , bool isSequence=false
-    #endif
+    OPTARG(NEOPIXEL_LED, bool isSequence=false)
   );
 
   static inline void set_color(uint8_t r, uint8_t g, uint8_t b
-    #if HAS_WHITE_LED
-      , uint8_t w=0
-    #endif
-    #if ENABLED(NEOPIXEL_LED)
-      , uint8_t i=NEOPIXEL_BRIGHTNESS
-      , bool isSequence=false
-    #endif
+    OPTARG(HAS_WHITE_LED, uint8_t w=0)
+    OPTARG(NEOPIXEL_LED, uint8_t i=NEOPIXEL_BRIGHTNESS)
+    OPTARG(NEOPIXEL_LED, bool isSequence=false)
   ) {
-    set_color(MakeLEDColor(r, g, b, w, i)
-      #if ENABLED(NEOPIXEL_LED)
-        , isSequence
-      #endif
-    );
+    set_color(MakeLEDColor(r, g, b, w, i) OPTARG(NEOPIXEL_LED, isSequence));
   }
 
   static inline void set_off()   { set_color(LEDColorOff()); }

--- a/Marlin/src/feature/leds/pca9632.cpp
+++ b/Marlin/src/feature/leds/pca9632.cpp
@@ -93,9 +93,7 @@ static void PCA9632_WriteRegister(const byte addr, const byte regadd, const byte
 }
 
 static void PCA9632_WriteAllRegisters(const byte addr, const byte regadd, const byte vr, const byte vg, const byte vb
-  #if ENABLED(PCA9632_RGBW)
-    , const byte vw
-  #endif
+  OPTARG(PCA9632_RGBW, const byte vw)
 ) {
   #if DISABLED(PCA9632_NO_AUTO_INC)
     uint8_t data[4];
@@ -143,9 +141,7 @@ void PCA9632_set_led_color(const LEDColor &color) {
                     ;
 
   PCA9632_WriteAllRegisters(PCA9632_ADDRESS,PCA9632_PWM0, color.r, color.g, color.b
-    #if ENABLED(PCA9632_RGBW)
-      , color.w
-    #endif
+    OPTARG(PCA9632_RGBW, color.w)
   );
   PCA9632_WriteRegister(PCA9632_ADDRESS,PCA9632_LEDOUT, LEDOUT);
 }

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -70,15 +70,9 @@ class TMCStorage {
     }
 
     struct {
-      #if ENABLED(HAS_STEALTHCHOP)
-        bool stealthChop_enabled = false;
-      #endif
-      #if ENABLED(HYBRID_THRESHOLD)
-        uint8_t hybrid_thrs = 0;
-      #endif
-      #if ENABLED(USE_SENSORLESS)
-        int16_t homing_thrs = 0;
-      #endif
+      OPTCODE(HAS_STEALTHCHOP,  bool stealthChop_enabled = false)
+      OPTCODE(HYBRID_THRESHOLD, uint8_t hybrid_thrs = 0)
+      OPTCODE(USE_SENSORLESS,   int16_t homing_thrs = 0)
     } stored;
 };
 

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -330,12 +330,8 @@ typedef struct {
         thermalManager.setTargetBed(bed_temp);
 
         // Wait for the temperature to stabilize
-        if (!thermalManager.wait_for_bed(true
-            #if G26_CLICK_CAN_CANCEL
-              , true
-            #endif
-          )
-        ) return G26_ERR;
+        if (!thermalManager.wait_for_bed(true OPTARG(G26_CLICK_CAN_CANCEL, true)))
+          return G26_ERR;
       }
 
     #else
@@ -352,11 +348,8 @@ typedef struct {
     thermalManager.setTargetHotend(hotend_temp, active_extruder);
 
     // Wait for the temperature to stabilize
-    if (!thermalManager.wait_for_hotend(active_extruder, true
-      #if G26_CLICK_CAN_CANCEL
-        , true
-      #endif
-    )) return G26_ERR;
+    if (!thermalManager.wait_for_hotend(active_extruder, true OPTARG(G26_CLICK_CAN_CANCEL, true)))
+      return G26_ERR;
 
     #if HAS_WIRED_LCD
       ui.reset_status();

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -249,9 +249,7 @@ void plan_arc(
     #endif
 
     if (!planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, 0
-      #if ENABLED(SCARA_FEEDRATE_SCALING)
-        , inv_duration
-      #endif
+      OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)
     )) break;
   }
 
@@ -266,9 +264,7 @@ void plan_arc(
   #endif
 
   planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, 0
-    #if ENABLED(SCARA_FEEDRATE_SCALING)
-      , inv_duration
-    #endif
+    OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)
   );
 
   TERN_(AUTO_BED_LEVELING_UBL, raw[l_axis] = start_L);

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -84,9 +84,7 @@ char GCodeQueue::injected_commands[64]; // = { 0 }
 
 
 void GCodeQueue::RingBuffer::commit_command(bool skip_ok
-  #if HAS_MULTI_SERIAL
-    , serial_index_t serial_ind/*=-1*/
-  #endif
+  OPTARG(HAS_MULTI_SERIAL, serial_index_t serial_ind/*=-1*/)
 ) {
   commands[index_w].skip_ok = skip_ok;
   TERN_(HAS_MULTI_SERIAL, commands[index_w].port = serial_ind);
@@ -100,9 +98,7 @@ void GCodeQueue::RingBuffer::commit_command(bool skip_ok
  * Return false for a full buffer, or if the 'command' is a comment.
  */
 bool GCodeQueue::RingBuffer::enqueue(const char *cmd, bool skip_ok/*=true*/
-  #if HAS_MULTI_SERIAL
-    , serial_index_t serial_ind/*=-1*/
-  #endif
+  OPTARG(HAS_MULTI_SERIAL, serial_index_t serial_ind/*=-1*/)
 ) {
   if (*cmd == ';' || length >= BUFSIZE) return false;
   strcpy(commands[index_w].buffer, cmd);

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -80,15 +80,11 @@ public:
     void advance_pos(uint8_t &p, const int inc) { if (++p >= BUFSIZE) p = 0; length += inc; }
 
     void commit_command(bool skip_ok
-      #if HAS_MULTI_SERIAL
-        , serial_index_t serial_ind = serial_index_t()
-      #endif
+      OPTARG(HAS_MULTI_SERIAL, serial_index_t serial_ind = serial_index_t())
     );
 
     bool enqueue(const char *cmd, bool skip_ok = true
-      #if HAS_MULTI_SERIAL
-        , serial_index_t serial_ind = serial_index_t()
-      #endif
+      OPTARG(HAS_MULTI_SERIAL, serial_index_t serial_ind = serial_index_t())
     );
 
     void ok_to_send();

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -758,9 +758,7 @@ void MarlinUI::quick_feedback(const bool clear_buttons/*=true*/) {
   // Tell ui.update() to start a move to current_position after a short delay.
   //
   void ManualMove::soon(const AxisEnum move_axis
-    #if MULTI_E_MANUAL
-      , const int8_t eindex/*=active_extruder*/
-    #endif
+    OPTARG(MULTI_E_MANUAL, const int8_t eindex/*=active_extruder*/)
   ) {
     TERN_(MULTI_E_MANUAL, if (move_axis == E_AXIS) e_index = eindex);
     start_time = millis() + (menu_scale < 0.99f ? 0UL : 250UL); // delay for bigger moves

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -759,12 +759,10 @@ void MarlinUI::quick_feedback(const bool clear_buttons/*=true*/) {
   //
   void ManualMove::soon(const AxisEnum move_axis
     #if MULTI_E_MANUAL
-      , const int8_t eindex/*=-1*/
+      , const int8_t eindex/*=active_extruder*/
     #endif
   ) {
-    #if MULTI_E_MANUAL
-      if (move_axis == E_AXIS) e_index = eindex >= 0 ? eindex : active_extruder;
-    #endif
+    TERN_(MULTI_E_MANUAL, if (move_axis == E_AXIS) e_index = eindex);
     start_time = millis() + (menu_scale < 0.99f ? 0UL : 250UL); // delay for bigger moves
     axis = move_axis;
     //SERIAL_ECHOLNPAIR("Post Move with Axis ", AS_CHAR(axis_codes[axis]), " soon.");

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -182,11 +182,7 @@
       static bool constexpr processing = false;
     #endif
     static void task();
-    static void soon(const AxisEnum axis
-      #if MULTI_E_MANUAL
-        , const int8_t eindex=active_extruder
-      #endif
-    );
+    static void soon(const AxisEnum axis OPTARG(MULTI_E_MANUAL, const int8_t eindex=active_extruder));
   };
 
 #endif

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -184,7 +184,7 @@
     static void task();
     static void soon(const AxisEnum axis
       #if MULTI_E_MANUAL
-        , const int8_t eindex=-1
+        , const int8_t eindex=active_extruder
       #endif
     );
   };

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -94,7 +94,7 @@ void lcd_move_z() { _lcd_move_xyz(GET_TEXT(MSG_MOVE_Z), Z_AXIS); }
 
 #if E_MANUAL
 
-  static void lcd_move_e(TERN_(MULTI_E_MANUAL, const int8_t eindex=-1)) {
+  static void lcd_move_e(TERN_(MULTI_E_MANUAL, const int8_t eindex=active_extruder)) {
     if (ui.use_click()) return ui.goto_previous_screen_no_defer();
     if (ui.encoderPosition) {
       if (!ui.manual_move.processing) {
@@ -139,7 +139,7 @@ void _goto_manual_move(const_float_t scale) {
   ui.goto_screen(_manual_move_func_ptr);
 }
 
-void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int8_t eindex=-1) {
+void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int8_t eindex=active_extruder) {
   _manual_move_func_ptr = func;
   START_MENU();
   if (LCD_HEIGHT >= 4) {
@@ -188,7 +188,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
 #if E_MANUAL
 
   inline void _goto_menu_move_distance_e() {
-    ui.goto_screen([]{ _menu_move_distance(E_AXIS, []{ lcd_move_e(TERN_(MULTI_E_MANUAL, active_extruder)); }, -1); });
+    ui.goto_screen([]{ _menu_move_distance(E_AXIS, []{ lcd_move_e(); }); });
   }
 
   inline void _menu_move_distance_e_maybe() {

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -100,11 +100,7 @@ void lcd_move_z() { _lcd_move_xyz(GET_TEXT(MSG_MOVE_Z), Z_AXIS); }
       if (!ui.manual_move.processing) {
         const float diff = float(int32_t(ui.encoderPosition)) * ui.manual_move.menu_scale;
         TERN(IS_KINEMATIC, ui.manual_move.offset, current_position.e) += diff;
-        ui.manual_move.soon(E_AXIS
-          #if MULTI_E_MANUAL
-            , eindex
-          #endif
-        );
+        ui.manual_move.soon(E_AXIS OPTARG(MULTI_E_MANUAL, eindex));
         ui.refresh(LCDVIEW_REDRAW_NOW);
       }
       ui.encoderPosition = 0;

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -724,11 +724,7 @@ static void moveAxis(const AxisEnum axis, const int8_t direction) {
       drawMessage(msg);
     #endif
 
-    ui.manual_move.soon(axis
-      #if MULTI_E_MANUAL
-        , motionAxisState.e_selection
-      #endif
-    );
+    ui.manual_move.soon(axis OPTARG(MULTI_E_MANUAL, motionAxisState.e_selection));
   }
 
   drawAxisValue(axis);

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -709,11 +709,7 @@ static void moveAxis(const AxisEnum axis, const int8_t direction) {
       drawMessage(msg);
     #endif
 
-    ui.manual_move.soon(axis
-      #if MULTI_E_MANUAL
-        , motionAxisState.e_selection
-      #endif
-    );
+    ui.manual_move.soon(axis OPTARG(MULTI_E_MANUAL, motionAxisState.e_selection));
   }
 
   drawAxisValue(axis);

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -711,11 +711,7 @@ static void moveAxis(const AxisEnum axis, const int8_t direction) {
       drawMessage(msg);
     #endif
 
-    ui.manual_move.soon(axis
-      #if MULTI_E_MANUAL
-        , motionAxisState.e_selection
-      #endif
-    );
+    ui.manual_move.soon(axis OPTARG(MULTI_E_MANUAL, motionAxisState.e_selection));
   }
 
   drawAxisValue(axis);

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -411,9 +411,7 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
  *  - Extrude the specified length regardless of flow percentage.
  */
 void _internal_move_to_destination(const_feedRate_t fr_mm_s/*=0.0f*/
-  #if IS_KINEMATIC
-    , const bool is_fast/*=false*/
-  #endif
+  OPTARG(IS_KINEMATIC, const bool is_fast/*=false*/)
 ) {
   const feedRate_t old_feedrate = feedrate_mm_s;
   if (fr_mm_s) feedrate_mm_s = fr_mm_s;
@@ -433,9 +431,7 @@ void _internal_move_to_destination(const_feedRate_t fr_mm_s/*=0.0f*/
 
   feedrate_mm_s = old_feedrate;
   feedrate_percentage = old_pct;
-  #if HAS_EXTRUDERS
-    planner.e_factor[active_extruder] = old_fac;
-  #endif
+  TERN_(HAS_EXTRUDERS, planner.e_factor[active_extruder] = old_fac);
 }
 
 /**
@@ -607,10 +603,8 @@ void restore_feedrate_and_scaling() {
    * at the same positions relative to the machine.
    */
   void update_software_endstops(const AxisEnum axis
-    #if HAS_HOTEND_OFFSET
-      , const uint8_t old_tool_index/*=0*/
-      , const uint8_t new_tool_index/*=0*/
-    #endif
+    OPTARG(HAS_HOTEND_OFFSET, const uint8_t old_tool_index/*=0*/)
+    OPTARG(HAS_HOTEND_OFFSET, const uint8_t new_tool_index/*=0*/)
   ) {
 
     #if ENABLED(DUAL_X_CARRIAGE)
@@ -858,17 +852,13 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
       segment_idle(next_idle_ms);
       raw += segment_distance;
       if (!planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, cartesian_segment_mm
-        #if ENABLED(SCARA_FEEDRATE_SCALING)
-          , inv_duration
-        #endif
+        OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)
       )) break;
     }
 
     // Ensure last segment arrives at target location.
     planner.buffer_line(destination, scaled_fr_mm_s, active_extruder, cartesian_segment_mm
-      #if ENABLED(SCARA_FEEDRATE_SCALING)
-        , inv_duration
-      #endif
+      OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)
     );
 
     return false; // caller will update current_position
@@ -929,9 +919,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
         segment_idle(next_idle_ms);
         raw += segment_distance;
         if (!planner.buffer_line(raw, fr_mm_s, active_extruder, cartesian_segment_mm
-          #if ENABLED(SCARA_FEEDRATE_SCALING)
-            , inv_duration
-          #endif
+          OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)
         )) break;
       }
 

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -278,11 +278,7 @@ void line_to_current_position(const_feedRate_t fr_mm_s=feedrate_mm_s);
 
 void prepare_line_to_destination();
 
-void _internal_move_to_destination(const_feedRate_t fr_mm_s=0.0f
-  #if IS_KINEMATIC
-    , const bool is_fast=false
-  #endif
-);
+void _internal_move_to_destination(const_feedRate_t fr_mm_s=0.0f OPTARG(IS_KINEMATIC, const bool is_fast=false));
 
 inline void prepare_internal_move_to_destination(const_feedRate_t fr_mm_s=0.0f) {
   _internal_move_to_destination(fr_mm_s);

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1757,12 +1757,8 @@ void Planner::synchronize() {
  * Returns true if movement was properly queued, false otherwise (if cleaning)
  */
 bool Planner::_buffer_steps(const xyze_long_t &target
-  #if HAS_POSITION_FLOAT
-    , const xyze_pos_t &target_float
-  #endif
-  #if HAS_DIST_MM_ARG
-    , const xyze_float_t &cart_dist_mm
-  #endif
+  OPTARG(HAS_POSITION_FLOAT, const xyze_pos_t &target_float)
+  OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
   , feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters
 ) {
 
@@ -1823,12 +1819,8 @@ bool Planner::_buffer_steps(const xyze_long_t &target
  */
 bool Planner::_populate_block(block_t * const block, bool split_move,
   const abce_long_t &target
-  #if HAS_POSITION_FLOAT
-    , const xyze_pos_t &target_float
-  #endif
-  #if HAS_DIST_MM_ARG
-    , const xyze_float_t &cart_dist_mm
-  #endif
+  OPTARG(HAS_POSITION_FLOAT, const xyze_pos_t &target_float)
+  OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
   , feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters/*=0.0*/
 ) {
 
@@ -2763,9 +2755,7 @@ void Planner::buffer_sync_block(TERN_(LASER_SYNCHRONOUS_M106_M107, uint8_t sync_
  * Return 'false' if no segment was queued due to cleaning, cold extrusion, full queue, etc.
  */
 bool Planner::buffer_segment(const_float_t a, const_float_t b, const_float_t c, const_float_t e
-  #if HAS_DIST_MM_ARG
-    , const xyze_float_t &cart_dist_mm
-  #endif
+  OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
   , const_feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters/*=0.0*/
 ) {
 
@@ -2857,9 +2847,7 @@ bool Planner::buffer_segment(const_float_t a, const_float_t b, const_float_t c, 
  *  inv_duration - the reciprocal if the duration of the movement, if known (kinematic only if feeedrate scaling is enabled)
  */
 bool Planner::buffer_line(const_float_t rx, const_float_t ry, const_float_t rz, const_float_t e, const_feedRate_t fr_mm_s, const uint8_t extruder, const float millimeters
-  #if ENABLED(SCARA_FEEDRATE_SCALING)
-    , const_float_t inv_duration
-  #endif
+  OPTARG(SCARA_FEEDRATE_SCALING, const_float_t inv_duration)
 ) {
   xyze_pos_t machine = { rx, ry, rz, e };
   TERN_(HAS_POSITION_MODIFIERS, apply_modifiers(machine));

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -707,12 +707,8 @@ class Planner {
      * Returns true if movement was buffered, false otherwise
      */
     static bool _buffer_steps(const xyze_long_t &target
-      #if HAS_POSITION_FLOAT
-        , const xyze_pos_t &target_float
-      #endif
-      #if HAS_DIST_MM_ARG
-        , const xyze_float_t &cart_dist_mm
-      #endif
+      OPTARG(HAS_POSITION_FLOAT, const xyze_pos_t &target_float)
+      OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
       , feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters=0.0
     );
 
@@ -728,14 +724,9 @@ class Planner {
      *
      * Returns true is movement is acceptable, false otherwise
      */
-    static bool _populate_block(block_t * const block, bool split_move,
-        const xyze_long_t &target
-      #if HAS_POSITION_FLOAT
-        , const xyze_pos_t &target_float
-      #endif
-      #if HAS_DIST_MM_ARG
-        , const xyze_float_t &cart_dist_mm
-      #endif
+    static bool _populate_block(block_t * const block, bool split_move, const xyze_long_t &target
+      OPTARG(HAS_POSITION_FLOAT, const xyze_pos_t &target_float)
+      OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
       , feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters=0.0
     );
 
@@ -768,22 +759,16 @@ class Planner {
      *  millimeters - the length of the movement, if known
      */
     static bool buffer_segment(const_float_t a, const_float_t b, const_float_t c, const_float_t e
-      #if HAS_DIST_MM_ARG
-        , const xyze_float_t &cart_dist_mm
-      #endif
+      OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
       , const_feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters=0.0
     );
 
     FORCE_INLINE static bool buffer_segment(abce_pos_t &abce
-      #if HAS_DIST_MM_ARG
-        , const xyze_float_t &cart_dist_mm
-      #endif
+      OPTARG(HAS_DIST_MM_ARG, const xyze_float_t &cart_dist_mm)
       , const_feedRate_t fr_mm_s, const uint8_t extruder, const_float_t millimeters=0.0
     ) {
       return buffer_segment(abce.a, abce.b, abce.c, abce.e
-        #if HAS_DIST_MM_ARG
-          , cart_dist_mm
-        #endif
+        OPTARG(HAS_DIST_MM_ARG, cart_dist_mm)
         , fr_mm_s, extruder, millimeters);
     }
 
@@ -801,20 +786,14 @@ class Planner {
      *  inv_duration - the reciprocal if the duration of the movement, if known (kinematic only if feeedrate scaling is enabled)
      */
     static bool buffer_line(const_float_t rx, const_float_t ry, const_float_t rz, const_float_t e, const_feedRate_t fr_mm_s, const uint8_t extruder, const float millimeters=0.0
-      #if ENABLED(SCARA_FEEDRATE_SCALING)
-        , const_float_t inv_duration=0.0
-      #endif
+      OPTARG(SCARA_FEEDRATE_SCALING, const_float_t inv_duration=0.0)
     );
 
     FORCE_INLINE static bool buffer_line(const xyze_pos_t &cart, const_feedRate_t fr_mm_s, const uint8_t extruder, const float millimeters=0.0
-      #if ENABLED(SCARA_FEEDRATE_SCALING)
-        , const_float_t inv_duration=0.0
-      #endif
+      OPTARG(SCARA_FEEDRATE_SCALING, const_float_t inv_duration=0.0)
     ) {
       return buffer_line(cart.x, cart.y, cart.z, cart.e, fr_mm_s, extruder, millimeters
-        #if ENABLED(SCARA_FEEDRATE_SCALING)
-          , inv_duration
-        #endif
+        OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)
       );
     }
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -3335,11 +3335,8 @@ void Temperature::isr() {
    *   Extruder: " T0:nnn.nn /nnn.nn"
    *   With ADC: " T0:nnn.nn /nnn.nn (nnn.nn)"
    */
-  static void print_heater_state(const_celsius_float_t c, const_celsius_float_t t
-    #if ENABLED(SHOW_TEMP_ADC_VALUES)
-      , const float r
-    #endif
-    , const heater_id_t e=INDEX_NONE
+  static void print_heater_state(const heater_id_t e, const_celsius_float_t c, const_celsius_float_t t
+    OPTARG(SHOW_TEMP_ADC_VALUES, const float r)
   ) {
     char k;
     switch (e) {
@@ -3385,64 +3382,28 @@ void Temperature::isr() {
   }
 
   void Temperature::print_heater_states(const uint8_t target_extruder
-    #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-      , const bool include_r/*=false*/
-    #endif
+    OPTARG(TEMP_SENSOR_1_AS_REDUNDANT, const bool include_r/*=false*/)
   ) {
     #if HAS_TEMP_HOTEND
-      print_heater_state(degHotend(target_extruder), degTargetHotend(target_extruder)
-        #if ENABLED(SHOW_TEMP_ADC_VALUES)
-          , rawHotendTemp(target_extruder)
-        #endif
-      );
+      print_heater_state(H_NONE, degHotend(target_extruder), degTargetHotend(target_extruder) OPTARG(SHOW_TEMP_ADC_VALUES, rawHotendTemp(target_extruder)));
       #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-        if (include_r) print_heater_state(degHotendRedundant(), degTargetHotend(0)
-          #if ENABLED(SHOW_TEMP_ADC_VALUES)
-            , rawHotendTempRedundant()
-          #endif
-          , H_REDUNDANT
-        );
+        if (include_r) print_heater_state(H_REDUNDANT, degHotendRedundant(), degTargetHotend(0) OPTARG(SHOW_TEMP_ADC_VALUES, rawHotendTempRedundant()));
       #endif
     #endif
     #if HAS_HEATED_BED
-      print_heater_state(degBed(), degTargetBed()
-        #if ENABLED(SHOW_TEMP_ADC_VALUES)
-          , rawBedTemp()
-        #endif
-        , H_BED
-      );
+      print_heater_state(H_BED, degBed(), degTargetBed() OPTARG(SHOW_TEMP_ADC_VALUES, rawBedTemp()));
     #endif
     #if HAS_TEMP_CHAMBER
-      print_heater_state(degChamber(), TERN0(HAS_HEATED_CHAMBER, degTargetChamber())
-        #if ENABLED(SHOW_TEMP_ADC_VALUES)
-          , rawChamberTemp()
-        #endif
-        , H_CHAMBER
-      );
-    #endif // HAS_TEMP_CHAMBER
+      print_heater_state(H_CHAMBER, degChamber(), TERN0(HAS_HEATED_CHAMBER, degTargetChamber()) OPTARG(SHOW_TEMP_ADC_VALUES, rawChamberTemp()));
+    #endif
     #if HAS_TEMP_COOLER
-      print_heater_state(degCooler(), TERN0(HAS_COOLER, degTargetCooler())
-        #if ENABLED(SHOW_TEMP_ADC_VALUES)
-          , rawCoolerTemp()
-        #endif
-        , H_COOLER
-      );
-    #endif // HAS_TEMP_COOLER
+      print_heater_state(H_COOLER, degCooler(), TERN0(HAS_COOLER, degTargetCooler()) OPTARG(SHOW_TEMP_ADC_VALUES, rawCoolerTemp()));
+    #endif
     #if HAS_TEMP_PROBE
-      print_heater_state(degProbe(), 0
-        #if ENABLED(SHOW_TEMP_ADC_VALUES)
-          , rawProbeTemp()
-        #endif
-        , H_PROBE
-      );
+      print_heater_state(H_PROBE, degProbe(), 0 OPTARG(SHOW_TEMP_ADC_VALUES, rawProbeTemp()) );
     #endif
     #if HAS_MULTI_HOTEND
-      HOTEND_LOOP() print_heater_state(degHotend(e), degTargetHotend(e)
-        #if ENABLED(SHOW_TEMP_ADC_VALUES)
-          , rawHotendTemp(e)
-        #endif
-        , (heater_id_t)e
-      );
+      HOTEND_LOOP() print_heater_state((heater_id_t)e, degHotend(e), degTargetHotend(e) OPTARG(SHOW_TEMP_ADC_VALUES, rawHotendTemp(e)));
     #endif
     SERIAL_ECHOPAIR(" @:", getHeaterPower((heater_id_t)target_extruder));
     #if HAS_HEATED_BED
@@ -3465,10 +3426,7 @@ void Temperature::isr() {
 
   #if ENABLED(AUTO_REPORT_TEMPERATURES)
     AutoReporter<Temperature::AutoReportTemp> Temperature::auto_reporter;
-    void Temperature::AutoReportTemp::report() {
-      print_heater_states(active_extruder);
-      SERIAL_EOL();
-    }
+    void Temperature::AutoReportTemp::report() { print_heater_states(active_extruder); SERIAL_EOL(); }
   #endif
 
   #if HAS_HOTEND && HAS_STATUS_MESSAGE
@@ -3495,11 +3453,8 @@ void Temperature::isr() {
     #endif
 
     bool Temperature::wait_for_hotend(const uint8_t target_extruder, const bool no_wait_for_cooling/*=true*/
-      #if G26_CLICK_CAN_CANCEL
-        , const bool click_to_cancel/*=false*/
-      #endif
+      OPTARG(G26_CLICK_CAN_CANCEL, const bool click_to_cancel/*=false*/)
     ) {
-
       #if ENABLED(AUTOTEMP)
         REMEMBER(1, planner.autotemp_enabled, false);
       #endif
@@ -3638,9 +3593,7 @@ void Temperature::isr() {
     #endif
 
     bool Temperature::wait_for_bed(const bool no_wait_for_cooling/*=true*/
-      #if G26_CLICK_CAN_CANCEL
-        , const bool click_to_cancel/*=false*/
-      #endif
+      OPTARG(G26_CLICK_CAN_CANCEL, const bool click_to_cancel/*=false*/)
     ) {
       #if TEMP_BED_RESIDENCY_TIME > 0
         millis_t residency_start_ms = 0;

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -46,9 +46,9 @@
 
 // Element identifiers. Positive values are hotends. Negative values are other heaters or coolers.
 typedef enum : int8_t {
-  INDEX_NONE = -6,
-  H_COOLER, H_PROBE, H_REDUNDANT, H_CHAMBER, H_BED,
-  H_E0, H_E1, H_E2, H_E3, H_E4, H_E5, H_E6, H_E7
+  H_NONE = -6,
+  H_COOLER = -5, H_PROBE = -4, H_REDUNDANT = -3, H_CHAMBER = -2, H_BED = -1,
+  H_E0 = 0, H_E1, H_E2, H_E3, H_E4, H_E5, H_E6, H_E7
 } heater_id_t;
 
 // PID storage
@@ -672,9 +672,7 @@ class Temperature {
 
       #if HAS_TEMP_HOTEND
         static bool wait_for_hotend(const uint8_t target_extruder, const bool no_wait_for_cooling=true
-          #if G26_CLICK_CAN_CANCEL
-            , const bool click_to_cancel=false
-          #endif
+          OPTARG(G26_CLICK_CAN_CANCEL, const bool click_to_cancel=false)
         );
 
         #if ENABLED(WAIT_FOR_HOTEND)
@@ -721,9 +719,7 @@ class Temperature {
       }
 
       static bool wait_for_bed(const bool no_wait_for_cooling=true
-        #if G26_CLICK_CAN_CANCEL
-          , const bool click_to_cancel=false
-        #endif
+        OPTARG(G26_CLICK_CAN_CANCEL, const bool click_to_cancel=false)
       );
 
       static void wait_for_bed_heating();
@@ -859,9 +855,7 @@ class Temperature {
 
     #if HAS_TEMP_SENSOR
       static void print_heater_states(const uint8_t target_extruder
-        #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
-          , const bool include_r=false
-        #endif
+        OPTARG(TEMP_SENSOR_1_AS_REDUNDANT, const bool include_r=false)
       );
       #if ENABLED(AUTO_REPORT_TEMPERATURES)
         struct AutoReportTemp { static void report(); };
@@ -925,35 +919,24 @@ class Temperature {
     #if HAS_THERMAL_PROTECTION
 
       // Indices and size for the tr_state_machine array. One for each protected heater.
-      #define _ENUM_FOR_E(N) RUNAWAY_IND_E##N,
-      enum RunawayIndex : uint8_t {
+      #define _ENUM_FOR_E(N) ,RUNAWAY_IND_E##N
+      enum RunawayIndex : int8_t {
+        _ = -1
         #if ENABLED(THERMAL_PROTECTION_HOTENDS)
           REPEAT(HOTENDS, _ENUM_FOR_E)
         #endif
-        #if ENABLED(HAS_THERMALLY_PROTECTED_BED)
-          RUNAWAY_IND_BED,
-        #endif
-        #if ENABLED(THERMAL_PROTECTION_CHAMBER)
-          RUNAWAY_IND_CHAMBER,
-        #endif
-        #if ENABLED(THERMAL_PROTECTION_COOLER)
-          RUNAWAY_IND_COOLER,
-        #endif
-        NR_HEATER_RUNAWAY
+        OPTARG(HAS_THERMALLY_PROTECTED_BED, RUNAWAY_IND_BED)
+        OPTARG(THERMAL_PROTECTION_CHAMBER, RUNAWAY_IND_CHAMBER)
+        OPTARG(THERMAL_PROTECTION_COOLER, RUNAWAY_IND_COOLER)
+        , NR_HEATER_RUNAWAY
       };
       #undef _ENUM_FOR_E
 
       // Convert the given heater_id_t to runaway state array index
       static inline RunawayIndex runaway_index_for_id(const int8_t heater_id) {
-        #if HAS_THERMALLY_PROTECTED_CHAMBER
-          if (heater_id == H_CHAMBER) return RUNAWAY_IND_CHAMBER;
-        #endif
-        #if HAS_THERMALLY_PROTECTED_CHAMBER
-          if (heater_id == H_COOLER) return RUNAWAY_IND_COOLER;
-        #endif
-        #if HAS_THERMALLY_PROTECTED_BED
-          if (heater_id == H_BED) return RUNAWAY_IND_BED;
-        #endif
+        TERN_(HAS_THERMALLY_PROTECTED_CHAMBER, if (heater_id == H_CHAMBER) return RUNAWAY_IND_CHAMBER);
+        TERN_(HAS_THERMALLY_PROTECTED_CHAMBER, if (heater_id == H_COOLER)  return RUNAWAY_IND_COOLER);
+        TERN_(HAS_THERMALLY_PROTECTED_BED,     if (heater_id == H_BED)     return RUNAWAY_IND_BED);
         return (RunawayIndex)_MAX(heater_id, 0);
       }
 

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.cpp
@@ -956,12 +956,6 @@ uint8_t BulkOnly::HandleUsbError(uint8_t error, uint8_t index) {
   return ((error && !count) ? MASS_ERR_GENERAL_USB_ERROR : MASS_ERR_SUCCESS);
 }
 
-#if MS_WANT_PARSER
-  uint8_t BulkOnly::Transaction(CommandBlockWrapper *pcbw, uint16_t buf_size, void *buf) {
-    return Transaction(CommandBlockWrapper *pcbw, uint16_t buf_size, void *buf, 0);
-  }
-#endif
-
 /**
  * For driver use only.
  *
@@ -972,9 +966,7 @@ uint8_t BulkOnly::HandleUsbError(uint8_t error, uint8_t index) {
  * @return
  */
 uint8_t BulkOnly::Transaction(CommandBlockWrapper *pcbw, uint16_t buf_size, void *buf
-  #if MS_WANT_PARSER
-    , uint8_t flags
-  #endif
+  OPTARG(MS_WANT_PARSER, uint8_t flags/*=0*/)
 ) {
   #if MS_WANT_PARSER
     uint16_t bytes = (pcbw->dCBWDataTransferLength > buf_size) ? buf_size : pcbw->dCBWDataTransferLength;

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/masstorage.h
@@ -553,10 +553,7 @@ private:
   bool IsValidCSW(CommandStatusWrapper *pcsw, CommandBlockWrapperBase *pcbw);
 
   uint8_t ClearEpHalt(uint8_t index);
-  #if MS_WANT_PARSER
-    uint8_t Transaction(CommandBlockWrapper *cbw, uint16_t bsize, void *buf, uint8_t flags);
-  #endif
-  uint8_t Transaction(CommandBlockWrapper *cbw, uint16_t bsize, void *buf);
+  uint8_t Transaction(CommandBlockWrapper *cbw, uint16_t bsize, void *buf OPTARG(MS_WANT_PARSER, uint8_t flags=0));
   uint8_t HandleUsbError(uint8_t error, uint8_t index);
   uint8_t HandleSCSIError(uint8_t status);
 };


### PR DESCRIPTION
Add `OPTARG` macro to insert optional arguments without `#ifdef` wrappers. Generally makes arguments in methods appear cleaner, but most likely continues the custom of messing with IntelliSense™.

An ultimate aim might be to adjust the code to take optional arguments all the time but mark them `UNUSED` when a feature is disabled, presuming the compiler doesn't waste any space on the unused arguments.
