### PR TITLE
Add platformio filters for M117, M300 and M414

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -606,9 +606,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       case 114: M114(); break;                                    // M114: Report current position
       case 115: M115(); break;                                    // M115: Report capabilities
 
-      #if HAS_STATUS_MESSAGE
-        case 117: M117(); break;                                  // M117: Set LCD message text, if possible
-      #endif
+      case 117: TERN_(HAS_STATUS_MESSAGE, M117()); break;         // M117: Set LCD message text, if possible
 
       case 118: M118(); break;                                    // M118: Display a message in the host console
       case 119: M119(); break;                                    // M119: Report endstop states

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -605,7 +605,11 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       case 92: M92(); break;                                      // M92: Set the steps-per-unit for one or more axes
       case 114: M114(); break;                                    // M114: Report current position
       case 115: M115(); break;                                    // M115: Report capabilities
-      case 117: M117(); break;                                    // M117: Set LCD message text, if possible
+
+      #if HAS_STATUS_MESSAGE
+        case 117: M117(); break;                                  // M117: Set LCD message text, if possible
+      #endif
+
       case 118: M118(); break;                                    // M118: Display a message in the host console
       case 119: M119(); break;                                    // M119: Report endstop states
       case 120: M120(); break;                                    // M120: Enable endstops

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -678,7 +678,11 @@ private:
 
   static void M114();
   static void M115();
-  static void M117();
+
+  #if HAS_STATUS_MESSAGE
+    static void M117();
+  #endif
+
   static void M118();
   static void M119();
   static void M120();

--- a/Marlin/src/gcode/lcd/M117.cpp
+++ b/Marlin/src/gcode/lcd/M117.cpp
@@ -39,4 +39,4 @@ void GcodeSuite::M117() {
 
 }
 
-#endif
+#endif // HAS_STATUS_MESSAGE

--- a/Marlin/src/gcode/lcd/M117.cpp
+++ b/Marlin/src/gcode/lcd/M117.cpp
@@ -20,6 +20,10 @@
  *
  */
 
+#include "../../inc/MarlinConfig.h"
+
+#if HAS_STATUS_MESSAGE
+
 #include "../gcode.h"
 #include "../../lcd/marlinui.h"
 
@@ -34,3 +38,5 @@ void GcodeSuite::M117() {
     ui.reset_status();
 
 }
+
+#endif

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -61,7 +61,7 @@ HAS_MENU_DELTA_CALIBRATE               = src_filter=+<src/lcd/menu/menu_delta_ca
 HAS_MENU_FILAMENT                      = src_filter=+<src/lcd/menu/menu_filament.cpp>
 LCD_INFO_MENU                          = src_filter=+<src/lcd/menu/menu_info.cpp>
 HAS_MENU_JOB_RECOVERY                  = src_filter=+<src/lcd/menu/menu_job_recovery.cpp>
-HAS_MULTI_LANGUAGE                     = src_filter=+<src/lcd/menu/menu_language.cpp>
+HAS_MULTI_LANGUAGE                     = src_filter=+<src/lcd/menu/menu_language.cpp> +<src/gcode/lcd/M414.cpp>
 HAS_MENU_LED                           = src_filter=+<src/lcd/menu/menu_led.cpp>
 HAS_MENU_MEDIA                         = src_filter=+<src/lcd/menu/menu_media.cpp>
 HAS_MENU_MIXER                         = src_filter=+<src/lcd/menu/menu_mixer.cpp>
@@ -186,7 +186,9 @@ AUTO_REPORT_POSITION                   = src_filter=+<src/gcode/host/M154.cpp>
 REPETIER_GCODE_M360                    = src_filter=+<src/gcode/host/M360.cpp>
 HAS_GCODE_M876                         = src_filter=+<src/gcode/host/M876.cpp>
 HAS_RESUME_CONTINUE                    = src_filter=+<src/gcode/lcd/M0_M1.cpp>
+HAS_STATUS_MESSAGE                     = src_filter=+<src/gcode/lcd/M117.cpp>
 HAS_LCD_CONTRAST                       = src_filter=+<src/gcode/lcd/M250.cpp>
+HAS_BUZZER                             = src_filter=+<src/gcode/lcd/M300.cpp>
 LCD_SET_PROGRESS_MANUALLY              = src_filter=+<src/gcode/lcd/M73.cpp>
 TOUCH_SCREEN_CALIBRATION               = src_filter=+<src/gcode/lcd/M995.cpp>
 ARC_SUPPORT                            = src_filter=+<src/gcode/motion/G2_G3.cpp>

--- a/platformio.ini
+++ b/platformio.ini
@@ -202,7 +202,10 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/gcode/host/M360.cpp>
   -<src/gcode/host/M876.cpp>
   -<src/gcode/lcd/M0_M1.cpp>
+  -<src/gcode/lcd/M117.cpp>
   -<src/gcode/lcd/M250.cpp>
+  -<src/gcode/lcd/M300.cpp>
+  -<src/gcode/lcd/M414.cpp>
   -<src/gcode/lcd/M73.cpp>
   -<src/gcode/lcd/M995.cpp>
   -<src/gcode/motion/G2_G3.cpp>


### PR DESCRIPTION
### Description

Add filters for gcodes M117, M300 and M414
M117 Set LCD Message, was always added if you had a LCD or not
M300 Play Tone, was always compiled, even when not needed
M414 Set language by index, was always compiled, even when not needed

### Requirements

Platformio

### Benefits

Smaller code, faster compiles.

### Related Issues
None, 