### PR TITLE
Added Malyan M180 pin board files and configurations

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -127,14 +127,14 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 
 // Enable the Bluetooth serial interface on AT90USB devices
 //#define BLUETOOTH
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_MALYAN_M180
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
@@ -416,7 +416,7 @@
  *   998 : Dummy Table that ALWAYS reads 25°C or the temperature defined below.
  *   999 : Dummy Table that ALWAYS reads 100°C or the temperature defined below.
  */
-#define TEMP_SENSOR_0 1
+#define TEMP_SENSOR_0 -2
 #define TEMP_SENSOR_1 0
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_3 0
@@ -424,7 +424,7 @@
 #define TEMP_SENSOR_5 0
 #define TEMP_SENSOR_6 0
 #define TEMP_SENSOR_7 0
-#define TEMP_SENSOR_BED 0
+#define TEMP_SENSOR_BED 4
 #define TEMP_SENSOR_PROBE 0
 #define TEMP_SENSOR_CHAMBER 0
 #define TEMP_SENSOR_COOLER 0
@@ -444,7 +444,7 @@
 //#define TEMP_SENSOR_1_AS_REDUNDANT
 #define MAX_REDUNDANT_TEMP_SENSOR_DIFF 10
 
-#define TEMP_RESIDENCY_TIME         10  // (seconds) Time to wait for hotend to "settle" in M109
+#define TEMP_RESIDENCY_TIME         30  // (seconds) Time to wait for hotend to "settle" in M109
 #define TEMP_WINDOW                  1  // (°C) Temperature proximity for the "temperature reached" timer
 #define TEMP_HYSTERESIS              3  // (°C) Temperature proximity considered "close enough" to the target
 
@@ -472,7 +472,7 @@
 // Above this temperature the heater will be switched off.
 // This can protect components from overheating, but NOT from shorts and failures.
 // (Use MINTEMP for thermistor short/failure protection.)
-#define HEATER_0_MAXTEMP 275
+#define HEATER_0_MAXTEMP 320
 #define HEATER_1_MAXTEMP 275
 #define HEATER_2_MAXTEMP 275
 #define HEATER_3_MAXTEMP 275
@@ -489,7 +489,7 @@
  * (especially before PID tuning). Setting the target temperature too close to MAXTEMP guarantees
  * a MAXTEMP shutdown! Use these values to forbid temperatures being set too close to MAXTEMP.
  */
-#define HOTEND_OVERSHOOT 15   // (°C) Forbid temperatures over MAXTEMP - OVERSHOOT
+#define HOTEND_OVERSHOOT 10   // (°C) Forbid temperatures over MAXTEMP - OVERSHOOT
 #define BED_OVERSHOOT    10   // (°C) Forbid temperatures over MAXTEMP - OVERSHOOT
 #define COOLER_OVERSHOOT  2   // (°C) Forbid temperatures closer than OVERSHOOT
 
@@ -752,7 +752,7 @@
 //#define Z3_DRIVER_TYPE A4988
 //#define Z4_DRIVER_TYPE A4988
 #define E0_DRIVER_TYPE A4988
-//#define E1_DRIVER_TYPE A4988
+#define E1_DRIVER_TYPE A4988
 //#define E2_DRIVER_TYPE A4988
 //#define E3_DRIVER_TYPE A4988
 //#define E4_DRIVER_TYPE A4988
@@ -806,14 +806,14 @@
  * Override with M92
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 500 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 93, 93, 1600, 406 }
 
 /**
  * Default Max Feed Rate (mm/s)
  * Override with M203
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 300, 300, 5, 25 }
+#define DEFAULT_MAX_FEEDRATE          { 167, 167, 5, 50 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
@@ -826,7 +826,7 @@
  * Override with M201
  *                                      X, Y, Z, E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 100, 10000 }
+#define DEFAULT_MAX_ACCELERATION      { 800, 800, 50, 10000 }
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)
@@ -841,9 +841,9 @@
  *   M204 R    Retract Acceleration
  *   M204 T    Travel Acceleration
  */
-#define DEFAULT_ACCELERATION          3000    // X, Y, Z and E acceleration for printing moves
-#define DEFAULT_RETRACT_ACCELERATION  3000    // E acceleration for retracts
-#define DEFAULT_TRAVEL_ACCELERATION   3000    // X, Y, Z acceleration for travel (non printing) moves
+#define DEFAULT_ACCELERATION          800    // X, Y, Z and E acceleration for printing moves
+#define DEFAULT_RETRACT_ACCELERATION  800    // E acceleration for retracts
+#define DEFAULT_TRAVEL_ACCELERATION   800    // X, Y, Z acceleration for travel (non printing) moves
 
 /**
  * Default Jerk limits (mm/s)
@@ -855,15 +855,15 @@
  */
 //#define CLASSIC_JERK
 #if ENABLED(CLASSIC_JERK)
-  #define DEFAULT_XJERK 10.0
-  #define DEFAULT_YJERK 10.0
-  #define DEFAULT_ZJERK  0.3
+  #define DEFAULT_XJERK 20.0
+  #define DEFAULT_YJERK 20.0
+  #define DEFAULT_ZJERK  0.4
 
   //#define TRAVEL_EXTRA_XYJERK 0.0     // Additional jerk allowance for all travel moves
 
   //#define LIMITED_JERK_EDITING        // Limit edit via M205 or LCD to DEFAULT_aJERK * 2
   #if ENABLED(LIMITED_JERK_EDITING)
-    #define MAX_JERK_EDIT_VALUES { 20, 20, 0.6, 10 } // ...or, set your own edit limits
+    #define MAX_JERK_EDIT_VALUES { 30, 30, 0.6, 10 } // ...or, set your own edit limits
   #endif
 #endif
 
@@ -1191,13 +1191,13 @@
 
 // Invert the stepper direction. Change (or reverse the motor connector) if an axis goes the wrong way.
 #define INVERT_X_DIR false
-#define INVERT_Y_DIR true
-#define INVERT_Z_DIR false
+#define INVERT_Y_DIR false
+#define INVERT_Z_DIR true
 
 // @section extruder
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
-#define INVERT_E0_DIR false
+#define INVERT_E0_DIR false // TODO Timo: Double check! This can't e true as Malya config is inconclusive
 #define INVERT_E1_DIR false
 #define INVERT_E2_DIR false
 #define INVERT_E3_DIR false
@@ -1232,8 +1232,8 @@
 // @section machine
 
 // The size of the printable area
-#define X_BED_SIZE 200
-#define Y_BED_SIZE 200
+#define X_BED_SIZE 260
+#define Y_BED_SIZE 155
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS 0
@@ -1241,7 +1241,7 @@
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
-#define Z_MAX_POS 200
+#define Z_MAX_POS 165
 
 /**
  * Software Endstops
@@ -1936,14 +1936,14 @@
  * SD Card support is disabled by default. If your controller has an SD slot,
  * you must uncomment the following option or it won't work.
  */
-//#define SDSUPPORT
+#define SDSUPPORT
 
 /**
  * SD CARD: ENABLE CRC
  *
  * Use CRC checks and retries on the SD communication.
  */
-//#define SD_CHECK_AND_RETRY
+#define SD_CHECK_AND_RETRY
 
 /**
  * LCD Menu Items

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -159,6 +159,7 @@
 #define BOARD_PICA_REVB               1324  // PICA Shield (original version)
 #define BOARD_PICA                    1325  // PICA Shield (rev C or later)
 #define BOARD_INTAMSYS40              1326  // Intamsys 4.0 (Funmat HT)
+#define BOARD_MALYAN_M180             1327  // Malyan M180 Mainboard Version 2 (no display function, direct gcode only)
 
 //
 // ATmega1281, ATmega2561

--- a/Marlin/src/pins/mega/pins_MALYAN_M180.h
+++ b/Marlin/src/pins/mega/pins_MALYAN_M180.h
@@ -1,0 +1,105 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ * 
+ * Malyan M180 configuration created by Timo Birnschein (timo.birnschein@microforge.de)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Malyan M180 pin assignments
+ */
+
+#include "env_validate.h"
+
+#define BOARD_INFO_NAME "Malyan M180 v.2"
+//
+// Limit Switches
+//
+#define X_MIN_PIN                             48
+#define X_MAX_PIN                             -1
+#define Y_MIN_PIN                             46
+#define Y_MAX_PIN                             -1
+#define Z_MIN_PIN                             42
+#define Z_MAX_PIN                             -1
+
+//
+// Z Probe (when not Z_MIN_PIN)
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                     -1
+#endif
+
+//
+// Steppers
+//
+#define X_STEP_PIN                            55
+#define X_DIR_PIN                             54
+#define X_ENABLE_PIN                          56
+
+#define Y_STEP_PIN                            59
+#define Y_DIR_PIN                             58
+#define Y_ENABLE_PIN                          60
+
+#define Z_STEP_PIN                            63
+#define Z_DIR_PIN                             62
+#define Z_ENABLE_PIN                          64
+
+#define E0_STEP_PIN                           25
+#define E0_DIR_PIN                            24
+#define E0_ENABLE_PIN                         26
+
+#define E1_STEP_PIN                           29
+#define E1_DIR_PIN                            28
+#define E1_ENABLE_PIN                         39
+
+//
+// Temperature Sensors
+//
+#define TEMP_BED_PIN                          15  // Analog Input
+
+// Extruder thermocouples 0 and 1 are read out by two separate ICs using
+// SPI for Max6675 Thermocouple
+// Uses a separate SPI bus
+#define THERMO_SCK_PIN                        78  // E2 - SCK
+#define THERMO_DO_PIN                          3  // E5 - DO
+#define THERMO_CS1_PIN                         5  // E3 - CS0
+#define THERMO_CS2_PIN                         2  // E4 - CS1
+
+#define MAX6675_SS_PIN            THERMO_CS1_PIN
+#define MAX6675_SS2_PIN           THERMO_CS2_PIN
+#define MAX6675_SCK_PIN           THERMO_SCK_PIN
+#define MAX6675_DO_PIN             THERMO_DO_PIN
+
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                           6
+#define HEATER_1_PIN                          11
+#define HEATER_BED_PIN                        45
+
+#ifndef FAN_PIN
+  #define FAN_PIN                              7  // M106 Sxxx command supported and tested. M107 as well.
+#endif
+
+#ifndef FAN_PIN1
+  #define FAN_PIN1                            12  // Currently Unsupported by Marlin
+#endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -270,6 +270,8 @@
   #include "mega/pins_PICAOLD.h"                // ATmega2560                             env:mega2560
 #elif MB(INTAMSYS40)
   #include "mega/pins_INTAMSYS40.h"             // ATmega2560                             env:mega2560
+#elif MB(MALYAN_M180)
+  #include "mega/pins_MALYAN_M180.h"            // ATmega2560                             env:mega2560
 
 //
 // ATmega1281, ATmega2561


### PR DESCRIPTION
Added Malyan M180 mainboard pin and configuration files.
Please note, my configuration is set to single extruder with 406 steps per mm because I converted to E3D Hemera extruder. Both the original M180 extruders need 92 steps per mm!

Example configuration included but mine is reduced to just one extruder. Temperature sensor for second extruder needs to be configured to type -2. Number of extruders must be set to 2. For Malyan standard dual extruder, please use max temperature of 275 degrees which is already too high for your PTFE tubes within the extruder nozzles. I changed a number of other things within the configuration file to be compatible to the M180 mainboard, step direction, and endstop configuration. for my printer, I changed the max feedrates to higher settings since I converted to single E3D Hemera Extruder.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Added Malyan M180 Dual Extruder Mainboard pins_MALYAN_M180.h, board.h and pins.h files to allow almost full compatibility with the M180 printer. I could not get the second extruder fan to work but I added the pin for it regardless. The original firmware can only control both at the same time and only 0% or 100% PWM. Marlin can control one fan with any duty cycle.

I also added an example Configuration.h that uses these new/changed files. Note, though, that I set the config to one extruder only (I did test the dual extruder setup using new files). My 3d printer now runs a single E3D Hemera. The changes should be easy to spot as there are not many.

LCD is NOT working. The Malyan M180 seems to be using a proprietary LCD. Needs work!

### Requirements

No requirements. Just install on Malyan M180 and feed with Octoprint or any other gcode sender like you would with a serial 3D printer.

### Benefits

Added Malyan M180 config which was not supported by Marlin so far. Allows full take-over of proprietary printer to set new feeds and speeds, new temperatures and accelerations and everything else Marlin supports. Original firmware is extremely limited and not updated by Malyan anymore.

### Configurations

None needed. Included in this pull-request.

### Related Issues

None.