### PR TITLE
Update BTT002 board variant with correct MMU2 serial pins

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_BTT002/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_BTT002/variant.h
@@ -264,6 +264,11 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
+// Serial Pins for the MMU2
+#define ENABLE_HWSERIAL4
+#define PIN_SERIAL4_RX          PC11
+#define PIN_SERIAL4_TX          PC10
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
The BigTreeTech BTT002 board doesn't explicitly define the correct serial port pins for the MMU2 expansion port. The pins for serial port 4 aren't set correctly for the STM32F407VGT6 microcontroller.

Explicitly define the TX and RX ports for serial port 4 in the BTT002 board variant.

### Requirements

BigTreeTech BTT002 controller board.

### Benefits

Enables the use of the MMU2 (original Prusa or the BigTreeTech MMU2-DIP controllers).

### Configurations

In Configuration.h

#define MOTHERBOARD BOARD_BTT_BTT002_V1_0

#define EXTRUDERS 5

#define MMU_MODEL PRUSA_MMU2 // or PRUSA_MMU2S

In Configuration_adv.h

#define MMU2_SERIAL_PORT 4


