### PR TITLE
Use 32-bit float constants in STM32F1 builds

### DIFF
--- a/Marlin/src/HAL/STM32F1/build_flags.py
+++ b/Marlin/src/HAL/STM32F1/build_flags.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
                     "-fsigned-char",
                     "-fno-move-loop-invariants",
                     "-fno-strict-aliasing",
+                    "-fsingle-precision-constant",
 
                     "--specs=nano.specs",
                     "--specs=nosys.specs",


### PR DESCRIPTION
By default all floating point constants are treated by GCC as double precision. As a result any math involving `float`'s and floating point constants results in unnecessary `float` to `double` promotions and then back to `float`.

Lets take this simple snippet as an example.

```c
// floats.c

float foo(float x) {
    return x * 3.14;
}
```

Function takes a `float`, does some floating point arithmetics involving a constant and returns a `float`.

Let's compile it and  disassemble, I use `-Os` to show that it doesn't help much:

```sh
arm-none-eabi-gcc -c -mcpu=cortex-m3 -Os -o floats_default.o floats.c
arm-none-eabi-objdump -d floats_default.o
```

Let's look at disassembly of the function `foo`:

```
00000000 <foo>:
   0:	b508      	push	{r3, lr}
   2:	f7ff fffe 	bl	0 <__aeabi_f2d>    ; float to double promotion
   6:	a304      	add	r3, pc, #16
   8:	e9d3 2300 	ldrd	r2, r3, [r3]
   c:	f7ff fffe 	bl	0 <__aeabi_dmul>   ; double multiplication
  10:	f7ff fffe 	bl	0 <__aeabi_d2f>    ; double to float convertion
  14:	bd08      	pop	{r3, pc}
  16:	bf00      	nop
  18:	51eb851f 	.word	0x51eb851f
  1c:	40091eb8 	.word	0x40091eb8
```

Fortunately GCC comes with a flag `-fsingle-precision-constant` which instructs compiler to treat all floating point constants as single precision.

```sh
arm-none-eabi-gcc -c -mcpu=cortex-m3 -Os -fsingle-precision-constant -o floats_spc.o floats.c
arm-none-eabi-objdump -d floats_spc.o
```

And result:

```
00000000 <foo>:
   0:	b508      	push	{r3, lr}
   2:	4902      	ldr	r1, [pc, #8]
   4:	f7ff fffe 	bl	0 <__aeabi_fmul>  ; float multiplication
   8:	bd08      	pop	{r3, pc}
   a:	bf00      	nop
   c:	4048f5c3 	.word	0x4048f5c3
```

This simple optimization can be very beneficial in some tight loops because even with `libnano` double precision operations are very expensive instruction-wise.

Also it is possible to use double-precision constants with this flag, such constant should be suffixed with `L` symbol, like so:

```c
float foo(float x) {
    return x * 3.14;
}

double bar(double x) {
    return x * 3.14L;
}
```

Disassembles to:

```
00000000 <foo>:
   0:	b508      	push	{r3, lr}
   2:	4902      	ldr	r1, [pc, #8]
   4:	f7ff fffe 	bl	0 <__aeabi_fmul>  ; float multiplication
   8:	bd08      	pop	{r3, pc}
   a:	bf00      	nop
   c:	4048f5c3 	.word	0x4048f5c3

00000010 <bar>:
  10:	b508      	push	{r3, lr}
  12:	a303      	add	r3, pc, #12
  14:	e9d3 2300 	ldrd	r2, r3, [r3]
  18:	f7ff fffe 	bl	0 <__aeabi_dmul>  ; double multiplication
  1c:	bd08      	pop	{r3, pc}
  1e:	bf00      	nop
  20:	51eb851f 	.word	0x51eb851f
  24:	40091eb8 	.word	0x40091eb8
```

For constrained systems it makes much more sense to use 32-bit floats by default though.

### Further reading

* [Semantics of Floating Point Math in GCC](https://gcc.gnu.org/wiki/FloatingPointMath)