### PR TITLE
🧱MULTI_VOLUME for Color UI and Marlin Menus

### DIFF
--- a/Marlin/src/HAL/STM32/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32/msc_sd.cpp
@@ -33,9 +33,9 @@ public:
   DiskIODriver* diskIODriver() {
     #if ENABLED(MULTI_VOLUME)
       #if SHARED_VOLUME_IS(SD_ONBOARD)
-        return &card.media_sd_spi;
+        return &card.media_driver_sdcard;
       #elif SHARED_VOLUME_IS(USB_FLASH_DRIVE)
-        return &card.media_usbFlashDrive;
+        return &card.media_driver_usbFlash;
       #endif
     #else
       return card.diskIODriver();

--- a/Marlin/src/lcd/extui/mks_ui/draw_media_select.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_media_select.cpp
@@ -46,8 +46,8 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
   if (event != LV_EVENT_RELEASED) return;
   lv_clear_media_select();
   switch (obj->mks_obj_id) {
-    case ID_T_USB_DISK: card.changeMedia(&card.media_usbFlashDrive); break;
-    case ID_T_SD_DISK:  card.changeMedia(&card.media_sd_spi); break;
+    case ID_T_USB_DISK: card.changeMedia(&card.media_driver_usbFlash); break;
+    case ID_T_SD_DISK:  card.changeMedia(&card.media_driver_sdcard); break;
     case ID_T_RETURN:
       TERN_(MKS_TEST, curent_disp_ui = 1);
       lv_draw_ready_print();

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -710,6 +710,9 @@ namespace Language_en {
   PROGMEM Language_Str MSG_CALIBRATION_FAILED              = _UxGT("Calibration Failed");
 
   PROGMEM Language_Str MSG_DRIVER_BACKWARD                 = _UxGT(" driver backward");
+
+  PROGMEM Language_Str MSG_SD_CARD                         = _UxGT("SD Card");
+  PROGMEM Language_Str MSG_USB_DISK                        = _UxGT("USB Disk");
 }
 
 #if FAN_COUNT == 1

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -116,7 +116,7 @@ void menu_media_filelist() {
 
   START_MENU();
   #if ENABLED(MULTI_VOLUME)
-    ACTION_ITEM_P(GET_TEXT(MSG_BACK), []{ ui.goto_screen(menu_media); });
+    ACTION_ITEM(MSG_BACK, []{ ui.goto_screen(menu_media); });
   #else
     BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
   #endif
@@ -147,10 +147,10 @@ void menu_media_filelist() {
     START_MENU();
     BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
     #if ENABLED(VOLUME_SD_ONBOARD)
-      ACTION_ITEM_P(GET_TEXT(MSG_SD_CARD), []{ card.changeMedia(&card.media_sd_spi); card.mount(); ui.goto_screen(menu_media_filelist); });
+      ACTION_ITEM(MSG_SD_CARD, []{ card.changeMedia(&card.media_sd_spi); card.mount(); ui.goto_screen(menu_media_filelist); });
     #endif
     #if ENABLED(VOLUME_USB_FLASH_DRIVE)
-      ACTION_ITEM_P(GET_TEXT(MSG_USB_DISK), []{ card.changeMedia(&card.media_usbFlashDrive); card.mount(); ui.goto_screen(menu_media_filelist); });
+      ACTION_ITEM(MSG_USB_DISK, []{ card.changeMedia(&card.media_usbFlashDrive); card.mount(); ui.goto_screen(menu_media_filelist); });
     #endif
     END_MENU();
   }

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -157,11 +157,7 @@ void menu_media_filelist() {
 #endif
 
 void menu_media() {
-  #if ENABLED(MULTI_VOLUME)
-    menu_media_select();
-  #else
-    menu_media_filelist();
-  #endif
+  TERN(MULTI_VOLUME, menu_media_select, menu_media_filelist)();
 }
 
 #endif // HAS_LCD_MENU && SDSUPPORT

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -147,10 +147,10 @@ void menu_media_filelist() {
     START_MENU();
     BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
     #if ENABLED(VOLUME_SD_ONBOARD)
-      ACTION_ITEM(MSG_SD_CARD, []{ card.changeMedia(&card.media_sd_spi); card.mount(); ui.goto_screen(menu_media_filelist); });
+      ACTION_ITEM(MSG_SD_CARD, []{ card.changeMedia(&card.media_driver_sdcard); card.mount(); ui.goto_screen(menu_media_filelist); });
     #endif
     #if ENABLED(VOLUME_USB_FLASH_DRIVE)
-      ACTION_ITEM(MSG_USB_DISK, []{ card.changeMedia(&card.media_usbFlashDrive); card.mount(); ui.goto_screen(menu_media_filelist); });
+      ACTION_ITEM(MSG_USB_DISK, []{ card.changeMedia(&card.media_driver_usbFlash); card.mount(); ui.goto_screen(menu_media_filelist); });
     #endif
     END_MENU();
   }

--- a/Marlin/src/lcd/menu/menu_media.cpp
+++ b/Marlin/src/lcd/menu/menu_media.cpp
@@ -104,7 +104,7 @@ class MenuItem_sdfolder : public MenuItem_sdbase {
     }
 };
 
-void menu_media() {
+void menu_media_filelist() {
   ui.encoder_direction_menus();
 
   #if HAS_MARLINUI_U8GLIB
@@ -115,7 +115,11 @@ void menu_media() {
   #endif
 
   START_MENU();
-  BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
+  #if ENABLED(MULTI_VOLUME)
+    ACTION_ITEM_P(GET_TEXT(MSG_BACK), []{ ui.goto_screen(menu_media); });
+  #else
+    BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
+  #endif
   if (card.flag.workDirIsRoot) {
     #if !PIN_EXISTS(SD_DETECT)
       ACTION_ITEM(MSG_REFRESH, []{ encoderTopLine = 0; card.mount(); });
@@ -136,6 +140,28 @@ void menu_media() {
       SKIP_ITEM();
   }
   END_MENU();
+}
+
+#if ENABLED(MULTI_VOLUME)
+  void menu_media_select() {
+    START_MENU();
+    BACK_ITEM_P(TERN1(BROWSE_MEDIA_ON_INSERT, screen_history_depth) ? GET_TEXT(MSG_MAIN) : GET_TEXT(MSG_BACK));
+    #if ENABLED(VOLUME_SD_ONBOARD)
+      ACTION_ITEM_P(GET_TEXT(MSG_SD_CARD), []{ card.changeMedia(&card.media_sd_spi); card.mount(); ui.goto_screen(menu_media_filelist); });
+    #endif
+    #if ENABLED(VOLUME_USB_FLASH_DRIVE)
+      ACTION_ITEM_P(GET_TEXT(MSG_USB_DISK), []{ card.changeMedia(&card.media_usbFlashDrive); card.mount(); ui.goto_screen(menu_media_filelist); });
+    #endif
+    END_MENU();
+  }
+#endif
+
+void menu_media() {
+  #if ENABLED(MULTI_VOLUME)
+    menu_media_select();
+  #else
+    menu_media_filelist();
+  #endif
 }
 
 #endif // HAS_LCD_MENU && SDSUPPORT

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -120,13 +120,12 @@ uint8_t CardReader::workDirDepth;
 
 #endif // SDCARD_SORT_ALPHA
 
-#if SHARED_VOLUME_IS(USB_FLASH_DRIVE) || ENABLED(USB_FLASH_DRIVE_SUPPORT)
-  DiskIODriver_USBFlash CardReader::media_usbFlashDrive;
+#if HAS_USB_FLASH_DRIVE
+  DiskIODriver_USBFlash CardReader::media_driver_usbFlash;
 #endif
-#if NEED_SD2CARD_SDIO
-  DiskIODriver_SDIO CardReader::media_sdio;
-#elif NEED_SD2CARD_SPI
-  DiskIODriver_SPI_SD CardReader::media_sd_spi;
+
+#if NEED_SD2CARD_SDIO || NEED_SD2CARD_SPI
+  CardReader::sdcard_driver_t CardReader::media_driver_sdcard;
 #endif
 
 DiskIODriver* CardReader::driver = nullptr;
@@ -143,12 +142,10 @@ uint32_t CardReader::filesize, CardReader::sdpos;
 
 CardReader::CardReader() {
   changeMedia(&
-    #if SHARED_VOLUME_IS(SD_ONBOARD)
-      TERN(SDIO_SUPPORT, media_sdio, media_sd_spi)
-    #elif SHARED_VOLUME_IS(USB_FLASH_DRIVE) || ENABLED(USB_FLASH_DRIVE_SUPPORT)
-      media_usbFlashDrive
+    #if HAS_USB_FLASH_DRIVE && !SHARED_VOLUME_IS(SD_ONBOARD)
+      media_driver_usbFlash
     #else
-      TERN(SDIO_SUPPORT, media_sdio, media_sd_spi)
+      media_driver_sdcard
     #endif
   );
 

--- a/Marlin/src/sd/cardreader.h
+++ b/Marlin/src/sd/cardreader.h
@@ -235,12 +235,13 @@ public:
   #endif
 
   #if SHARED_VOLUME_IS(USB_FLASH_DRIVE) || ENABLED(USB_FLASH_DRIVE_SUPPORT)
-    static DiskIODriver_USBFlash media_usbFlashDrive;
+    #define HAS_USB_FLASH_DRIVE 1
+    static DiskIODriver_USBFlash media_driver_usbFlash;
   #endif
-  #if NEED_SD2CARD_SDIO
-    static DiskIODriver_SDIO media_sdio;
-  #elif NEED_SD2CARD_SPI
-    static DiskIODriver_SPI_SD media_sd_spi;
+
+  #if NEED_SD2CARD_SDIO || NEED_SD2CARD_SPI
+    typedef TERN(NEED_SD2CARD_SDIO, DiskIODriver_SDIO, DiskIODriver_SPI_SD) sdcard_driver_t;
+    static sdcard_driver_t media_driver_sdcard;
   #endif
 
 private:


### PR DESCRIPTION
### Description

This PR add MULTI_VOLUME support for COLOR UI and Marlin Menus. As LVGL UI, when MULTI_VOLUME is enabled, it add a "media select screen", so the user can select which volume navigate.

### Requirements

Board with sd and usb disk support (like nano v3).

### Benefits

Color UI matching LVGL UI features.

### Configurations

MULTI_VOLUME

### Related Issues

#21344 
