### PR TITLE
bug: Invalid PlatformIO option for memory offset

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -114,7 +114,7 @@ upload_protocol   = serial
 [env:STM32F103RC_btt]
 platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RC
-board_build.address  = 0x08007000
+board_upload.offset_address  = 0x08007000
 board_build.ldscript = STM32F103RC_SKR_MINI_256K.ld
 extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/custom_board.py
@@ -209,7 +209,7 @@ monitor_speed     = 115200
 [env:STM32F103RE_btt]
 platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RE
-board_build.address  = 0x08007000
+board_upload.offset_address  = 0x08007000
 board_build.ldscript = STM32F103RE_SKR_E3_DIP.ld
 extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/custom_board.py
@@ -245,7 +245,7 @@ upload_protocol = serial
 platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103VE
-board_build.address  = 0x08010000
+board_upload.offset_address  = 0x08010000
 board_build.ldscript = STM32F103VE_longer.ld
 extra_scripts = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/custom_board.py
@@ -388,7 +388,7 @@ extra_scripts = ${common_stm32f1.extra_scripts}
 platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103ZE
-board_build.address  = 0x0800A000
+board_upload.offset_address  = 0x0800A000
 board_build.ldscript = jgaurora_a5s_a1.ld
 extra_scripts = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/custom_board.py
@@ -440,7 +440,7 @@ build_flags   = ${env:chitu_f103.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
 platform        = ${env:STM32F103RE.platform}
 extends         = env:STM32F103RE
 build_flags     = ${env:STM32F103RE.build_flags} -DTEMP_TIMER_CHAN=4
-board_build.address  = 0x08007000
+board_upload.offset_address  = 0x08007000
 board_build.ldscript = creality.ld
 extra_scripts   = ${env:STM32F103RE.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/random-bin.py

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -75,7 +75,7 @@ extra_scripts       = ${common.extra_scripts}
 platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
-board_build.address  = 0x08005000
+board_upload.offset_address  = 0x08005000
 board_build.ldscript = fly_mini.ld
 extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/custom_board.py


### PR DESCRIPTION

### Description

A subset of STM32F1 & STM32F4 board definitions are using the option
`board_build.address` to specifying the memory location for firmware.

The correct option to be used is `board_upload.offset_address`, which
was added in [platformio/platform-ststm32#853208d1][1].  PR #21488
(recently submitted) uses the correct option for some _newly_ added
hardware abstractions, but left this in place for existing hardware.

Using this option presently overwrites the bootloader when using
`openocd` and an STLinkV2.

For example: https://ask.csdn.net/questions/4185515

This is occurring because the option gets ignored and the default vector
table location of `0x08000000` gets used (which is the location of the
bootloader).

NOTE: All changes were made using the following mechanism

```bash
sed -i 's/board_build.address/board_upload\.offset_address/g' ini/stm32f{1,4}.ini
```

No other changes to spacing or validation beyond verification on the
STM32F103RE_btt board.  This is confirmed operational with the offset
previously used with the invalid option, `0x08007000`.

[1]: https://github.com/platformio/platform-ststm32/commit/853208d1

### Requirements

STM32

### Benefits

Users with conforming boards should be able to upload directly using OpenOCD without obliterating their bootloader (though it seems this should, long term, really be added to the processor definition as opposed to individual boards).

### Related Issues

Affects: 
 - #21279
 
