### PR TITLE
Fix Creality v4 servo timer

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -121,7 +121,8 @@ lib_deps             =
 [env:STM32F103RET6_creality]
 platform             = ${common_stm32.platform}
 extends              = common_stm32
-build_flags          = ${common_stm32.build_flags} -DMCU_STM32F103RE -DHAL_SD_MODULE_ENABLED -DSS_TIMER=4 -DTIMER_SERVO=TIM5 -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8board                = genericSTM32F103RE
+build_flags          = ${common_stm32.build_flags} -DMCU_STM32F103RE -DHAL_SD_MODULE_ENABLED -DSS_TIMER=4 -DTIMER_SERVO=TIM5 -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8
+board                = genericSTM32F103RE
 monitor_speed        = 115200
 board_build.core     = stm32
 board_build.variant  = MARLIN_F103Rx

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -121,8 +121,7 @@ lib_deps             =
 [env:STM32F103RET6_creality]
 platform             = ${common_stm32.platform}
 extends              = common_stm32
-build_flags          = ${common_stm32.build_flags} -DMCU_STM32F103RE -DHAL_SD_MODULE_ENABLED -DSS_TIMER=4 -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8
-board                = genericSTM32F103RE
+build_flags          = ${common_stm32.build_flags} -DMCU_STM32F103RE -DHAL_SD_MODULE_ENABLED -DSS_TIMER=4 -DTIMER_SERVO=TIM5 -DENABLE_HWSERIAL3 -DTRANSFER_CLOCK_DIV=8board                = genericSTM32F103RE
 monitor_speed        = 115200
 board_build.core     = stm32
 board_build.variant  = MARLIN_F103Rx


### PR DESCRIPTION
### Description

If you enable bltouch on new env:STM32F103RET6_creality, you get a error: static assertion failed: One or more timer conflict detected. Examine "timers_in_use" to help identify conflict.

### Requirements

env:STM32F103RET6_creality with bltouch

### Benefits

Compiles as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/21999
User flodejr on discord found this issue and tested this fix for me. 