### PR TITLE
Return to correct file position after power loss

### DIFF
--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2019,7 +2019,7 @@ uint32_t Stepper::block_phase_isr() {
         cutter.apply_power(current_block->cutter_power);
       #endif
 
-      TERN_(POWER_LOSS_RECOVERY, recovery.info.sdpos = current_block->sdpos);
+      TERN_(POWER_LOSS_RECOVERY, recovery.info.sdpos = Planner::block_buffer[BLOCK_MOD(Planner::block_buffer_tail - 1)].sdpos);
 
       #if ENABLED(DIRECT_STEPPING)
         if (IS_PAGE(current_block)) {


### PR DESCRIPTION
### Description
`Planner::block_buffer[Planner::block_buffer_tail]` is the current block but printer is printing the previous block. This version resumes from the correct file position during power loss recovery.

### Requirements
Power loss feature (pin, trigger).

### Benefits
More precise return from power loss.

### Configurations
`POWER_LOSS_RECOVERY` must be enabled and set according to printer.
