### PR TITLE
Fix USB name conflict to use _USB F1 envs

### DIFF
--- a/Marlin/src/HAL/STM32/inc/Conditionals_adv.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_adv.h
@@ -21,7 +21,7 @@
  */
 #pragma once
 
-#if defined(USBD_USE_CDC_MSC) && DISABLED(NO_SD_HOST_DRIVE)
+#if BOTH(SDSUPPORT, USBD_USE_CDC_MSC) && DISABLED(NO_SD_HOST_DRIVE)
   #define HAS_SD_HOST_DRIVE 1
 #endif
 

--- a/buildroot/share/PlatformIO/scripts/generic_create_variant.py
+++ b/buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -28,7 +28,7 @@ if len(platform_packages) == 0:
 else:
     platform_name = PackageSpec(platform_packages[0]).name
 
-if platform_name in [ "usb-host-msc", "usb-host-msc-cdc-msc", "tool-stm32duino" ]:
+if platform_name in [ "usb-host-msc", "usb-host-msc-cdc-msc", "usb-host-msc-cdc-msc-2", "tool-stm32duino" ]:
     platform_name = "framework-arduinoststm32"
 
 FRAMEWORK_DIR = platform.get_package_dir(platform_name)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -69,7 +69,7 @@ board_upload.offset_address = 0x08007000
 [env:STM32F103RC_btt_USB]
 extends           = env:STM32F103RC_btt
 platform          = ${common_stm32.platform}
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/refs/heads/usb-host-msc-cdc-msc-2.zip
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 build_flags       = ${env:STM32F103RC_btt.build_flags} ${env:stm32_flash_drive.build_flags}
   -DUSBCON

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -69,7 +69,7 @@ board_upload.offset_address = 0x08007000
 [env:STM32F103RC_btt_USB]
 extends           = env:STM32F103RC_btt
 platform          = ${common_stm32.platform}
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/refs/heads/usb-host-msc-cdc-msc-2.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-2.zip
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 build_flags       = ${env:STM32F103RC_btt.build_flags} ${env:stm32_flash_drive.build_flags}
   -DUSBCON

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -146,7 +146,7 @@ debug_init_break  =
 # USB Flash Drive mix-ins for STM32
 #
 [stm_flash_drive]
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/refs/heads/usb-host-msc-cdc-msc-2.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-2.zip
 build_flags       = ${common_stm32.build_flags}
   -DHAL_PCD_MODULE_ENABLED -DHAL_HCD_MODULE_ENABLED
   -DUSBHOST -DUSBH_IRQ_PRIO=3 -DUSBH_IRQ_SUBPRIO=4
@@ -424,7 +424,7 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 [env:mks_robin_nano_v3_usb_flash_drive_msc]
 platform          = ${common_stm32.platform}
 extends           = env:mks_robin_nano_v3
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/refs/heads/usb-host-msc-cdc-msc-2.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-2.zip
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
   -DUSBCON

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -146,7 +146,7 @@ debug_init_break  =
 # USB Flash Drive mix-ins for STM32
 #
 [stm_flash_drive]
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/refs/heads/usb-host-msc-cdc-msc-2.zip
 build_flags       = ${common_stm32.build_flags}
   -DHAL_PCD_MODULE_ENABLED -DHAL_HCD_MODULE_ENABLED
   -DUSBHOST -DUSBH_IRQ_PRIO=3 -DUSBH_IRQ_SUBPRIO=4
@@ -424,7 +424,7 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 [env:mks_robin_nano_v3_usb_flash_drive_msc]
 platform          = ${common_stm32.platform}
 extends           = env:mks_robin_nano_v3
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/refs/heads/usb-host-msc-cdc-msc-2.zip
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
   -DUSBCON


### PR DESCRIPTION
### Description

This PR update the stm32duino repo link with a version that doesn't conflict the USB class name with the USB F1 peripheral define.

And fix `_USB` envs for STM32 and F1 boards

#21946 
#21488 
