### PR TITLE
Bugfix: Probe Temp Calibration compile error

### DIFF
--- a/Marlin/src/feature/probe_temp_comp.h
+++ b/Marlin/src/feature/probe_temp_comp.h
@@ -64,7 +64,7 @@ typedef struct {
 #ifndef BTC_SAMPLE_COUNT
   #define BTC_SAMPLE_COUNT 10U
 #endif
-#ifndef BTC_SAMPLE_STEP
+#ifndef BTC_SAMPLE_RES
   #define BTC_SAMPLE_RES 5
 #endif
 #ifndef BTC_SAMPLE_START


### PR DESCRIPTION
Define and check for the same macro: BTC_SAMPLE_RES, instead of BTC_SAMPLE_STEP

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Probe temperature calibration can be configured in Configuration_adv.h. probe_temp_comp.h defines defaults, for unconfigured options via #ifndef directives for example for BTC_SAMPLE_RES. However, the guard checks for BTC_SAMPLE_STEP and defines BTC_SAMPLE_RES, which will cause a redefinied warning:

```
In file included from Marlin/src/feature/probe_temp_comp.cpp:27:0:
Marlin/src/feature/probe_temp_comp.h:68:0: warning: "BTC_SAMPLE_RES" redefined
   #define BTC_SAMPLE_RES 5

In file included from Marlin/src/feature/../inc/MarlinConfigPre.h:56:0,
                 from Marlin/src/feature/probe_temp_comp.cpp:23:
Marlin/src/feature/../inc/../../Configuration_adv.h:1959:0: note: this is the location of the previous definition
     #define BTC_SAMPLE_RES    5.0f
```


### Requirements

Probe with temperature sensor.

### Benefits

Avoid warning for redefinied macro.

### Configurations

Occurs only if BTC_SAMPLE_RES is actually defined in Configuration_adv.h (commented out by default)

### Related Issues

Haven't found one.
