### PR TITLE
Fix compile MMU error when >5 colors

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1423,10 +1423,7 @@ void setup() {
   #endif
 
   #if HAS_PRUSA_MMU1
-    SETUP_LOG("Prusa MMU1");
-    SET_OUTPUT(E_MUX0_PIN);
-    SET_OUTPUT(E_MUX1_PIN);
-    SET_OUTPUT(E_MUX2_PIN);
+    SETUP_RUN(mmu_init());
   #endif
 
   #if HAS_FANMUX

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -317,7 +317,7 @@ void disable_e_steppers() {
 void disable_e_stepper(const uint8_t e) {
   #define _CASE_DIS_E(N) case N: DISABLE_AXIS_E##N(); break;
   switch (e) {
-    REPEAT(EXTRUDERS, _CASE_DIS_E)
+    REPEAT(E_STEPPERS, _CASE_DIS_E)
   }
 }
 

--- a/Marlin/src/feature/mmu/mmu.cpp
+++ b/Marlin/src/feature/mmu/mmu.cpp
@@ -24,7 +24,8 @@
 
 #if HAS_PRUSA_MMU1
 
-#include "../module/stepper.h"
+#include "../MarlinCore.h"
+#include "../module/planner.h"
 
 void mmu_init() {
   SET_OUTPUT(E_MUX0_PIN);

--- a/Marlin/src/feature/mmu/mmu.cpp
+++ b/Marlin/src/feature/mmu/mmu.cpp
@@ -26,6 +26,12 @@
 
 #include "../module/stepper.h"
 
+void mmu_init() {
+  SET_OUTPUT(E_MUX0_PIN);
+  SET_OUTPUT(E_MUX1_PIN);
+  SET_OUTPUT(E_MUX2_PIN);
+}
+
 void select_multiplexed_stepper(const uint8_t e) {
   planner.synchronize();
   disable_e_steppers();

--- a/Marlin/src/feature/mmu/mmu.h
+++ b/Marlin/src/feature/mmu/mmu.h
@@ -21,4 +21,5 @@
  */
 #pragma once
 
+void mmu_init();
 void select_multiplexed_stepper(const uint8_t e);

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -517,7 +517,7 @@
     #define HAS_PRUSA_MMU2 1
     #define HAS_PRUSA_MMU2S 1
   #endif
-  #if MMU_MODEL == EXTENDABLE_EMU_MMU2 || MMU_MODEL == EXTENDABLE_EMU_MMU2S
+  #if MMU_MODEL >= EXTENDABLE_EMU_MMU2
     #define HAS_EXTENDABLE_MMU 1
   #endif
 #endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -954,9 +954,11 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
  * Multi-Material-Unit 2 / EXTENDABLE_EMU_MMU2 requirements
  */
 #if HAS_PRUSA_MMU2
-  #if EXTRUDERS != 5 && !HAS_EXTENDABLE_MMU
+  #if !HAS_EXTENDABLE_MMU && EXTRUDERS != 5
     #undef SINGLENOZZLE
     #error "PRUSA_MMU2(S) requires exactly 5 EXTRUDERS. Please update your Configuration."
+  #elif HAS_EXTENDABLE_MMU && EXTRUDERS > MAX_E_STEPPERS
+    #error "Too many extruders for MMU(S) emulation mode. (Limited by MAX_E_STEPPERS)."
   #elif DISABLED(NOZZLE_PARK_FEATURE)
     #error "PRUSA_MMU2(S) requires NOZZLE_PARK_FEATURE. Enable it to continue."
   #elif HAS_PRUSA_MMU2S && DISABLED(FILAMENT_RUNOUT_SENSOR)
@@ -968,9 +970,6 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #elif DISABLED(ADVANCED_PAUSE_FEATURE)
     static_assert(nullptr == strstr(MMU2_FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with PRUSA_MMU2(S) / HAS_EXTENDABLE_MMU(S).");
   #endif
-#endif
-#if HAS_EXTENDABLE_MMU && EXTRUDERS > 15
-  #error "Too many extruders for MMU(S) emulation mode. (15 maximum)."
 #endif
 
 /**

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -954,7 +954,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
  * Multi-Material-Unit 2 / EXTENDABLE_EMU_MMU2 requirements
  */
 #if HAS_PRUSA_MMU2
-  #if EXTRUDERS != 5
+  #if EXTRUDERS != 5 && !HAS_EXTENDABLE_MMU
     #undef SINGLENOZZLE
     #error "PRUSA_MMU2(S) requires exactly 5 EXTRUDERS. Please update your Configuration."
   #elif DISABLED(NOZZLE_PARK_FEATURE)
@@ -978,7 +978,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
  */
 #if HAS_MULTI_EXTRUDER
 
-  #if EXTRUDERS > 8
+  #if EXTRUDERS > 8 && !HAS_EXTENDABLE_MMU
     #error "Marlin supports a maximum of 8 EXTRUDERS."
   #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -957,8 +957,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #if !HAS_EXTENDABLE_MMU && EXTRUDERS != 5
     #undef SINGLENOZZLE
     #error "PRUSA_MMU2(S) requires exactly 5 EXTRUDERS. Please update your Configuration."
-  #elif HAS_EXTENDABLE_MMU && EXTRUDERS > MAX_E_STEPPERS
-    #error "Too many extruders for MMU(S) emulation mode. (Limited by MAX_E_STEPPERS)."
+  #elif HAS_EXTENDABLE_MMU && EXTRUDERS > 15
+    #error "EXTRUDERS is too large for MMU(S) emulation mode. The maximum value is 15."
   #elif DISABLED(NOZZLE_PARK_FEATURE)
     #error "PRUSA_MMU2(S) requires NOZZLE_PARK_FEATURE. Enable it to continue."
   #elif HAS_PRUSA_MMU2S && DISABLED(FILAMENT_RUNOUT_SENSOR)
@@ -977,9 +977,13 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
  */
 #if HAS_MULTI_EXTRUDER
 
-  #if EXTRUDERS > 8 && !HAS_EXTENDABLE_MMU
-    #error "Marlin supports a maximum of 8 EXTRUDERS."
+  #if HAS_EXTENDABLE_MMU
+    #define MAX_EXTRUDERS 15
+  #else
+    #define MAX_EXTRUDERS  8
   #endif
+  sanity_check(EXTRUDERS <= MAX_EXTRUDERS, "Marlin supports a maximum of " STRINGIFY(MAX_EXTRUDERS) " EXTRUDERS.");
+  #undef MAX_EXTRUDERS
 
   #if ENABLED(HEATERS_PARALLEL)
     #error "EXTRUDERS must be 1 with HEATERS_PARALLEL."

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -982,7 +982,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #else
     #define MAX_EXTRUDERS  8
   #endif
-  sanity_check(EXTRUDERS <= MAX_EXTRUDERS, "Marlin supports a maximum of " STRINGIFY(MAX_EXTRUDERS) " EXTRUDERS.");
+  static_assert(EXTRUDERS <= MAX_EXTRUDERS, "Marlin supports a maximum of " STRINGIFY(MAX_EXTRUDERS) " EXTRUDERS.");
   #undef MAX_EXTRUDERS
 
   #if ENABLED(HEATERS_PARALLEL)

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -213,7 +213,7 @@ xyze_float_t Planner::previous_speed;
 float Planner::previous_nominal_speed_sqr;
 
 #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
-  last_move_t Planner::g_uc_extruder_last_move[EXTRUDERS] = { 0 };
+  last_move_t Planner::g_uc_extruder_last_move[E_STEPPERS] = { 0 };
 #endif
 
 #ifdef XY_FREQUENCY_LIMIT
@@ -2122,7 +2122,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
       #if ENABLED(DISABLE_INACTIVE_EXTRUDER) // Enable only the selected extruder
 
-        LOOP_L_N(i, EXTRUDERS)
+        LOOP_L_N(i, E_STEPPERS)
           if (g_uc_extruder_last_move[i]) g_uc_extruder_last_move[i]--;
 
         #define ENABLE_ONE_E(N) do{ \
@@ -2145,7 +2145,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
 
       #endif
 
-      REPEAT(EXTRUDERS, ENABLE_ONE_E); // (ENABLE_ONE_E must end with semicolon)
+      REPEAT(E_STEPPERS, ENABLE_ONE_E); // (ENABLE_ONE_E must end with semicolon)
     }
   #endif // EXTRUDERS
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2125,7 +2125,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
         LOOP_L_N(i, E_STEPPERS)
           if (g_uc_extruder_last_move[i]) g_uc_extruder_last_move[i]--;
 
-        #define E_STEPPER_INDEX(E) ((E) / TERN(SWITCHING_EXTRUDER, 2, 1))
+        #define E_STEPPER_INDEX(E) TERN(SWITCHING_EXTRUDER, (E) / 2, E)
 
         #define ENABLE_ONE_E(N) do{ \
           if (extruder == N) { \

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2128,9 +2128,9 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
         #define E_STEPPER_INDEX(E) TERN(SWITCHING_EXTRUDER, (E) / 2, E)
 
         #define ENABLE_ONE_E(N) do{ \
-          if (extruder == N) { \
+          if (E_STEPPER_INDEX(extruder) == N) { \
             ENABLE_AXIS_E##N(); \
-            g_uc_extruder_last_move[E_STEPPER_INDEX(N)] = (BLOCK_BUFFER_SIZE) * 2; \
+            g_uc_extruder_last_move[N] = (BLOCK_BUFFER_SIZE) * 2; \
             if ((N) == 0 && TERN0(HAS_DUPLICATION_MODE, extruder_duplication_enabled)) \
               ENABLE_AXIS_E1(); \
           } \

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -2125,10 +2125,12 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
         LOOP_L_N(i, E_STEPPERS)
           if (g_uc_extruder_last_move[i]) g_uc_extruder_last_move[i]--;
 
+        #define E_STEPPER_INDEX(E) ((E) / TERN(SWITCHING_EXTRUDER, 2, 1))
+
         #define ENABLE_ONE_E(N) do{ \
           if (extruder == N) { \
             ENABLE_AXIS_E##N(); \
-            g_uc_extruder_last_move[N] = (BLOCK_BUFFER_SIZE) * 2; \
+            g_uc_extruder_last_move[E_STEPPER_INDEX(N)] = (BLOCK_BUFFER_SIZE) * 2; \
             if ((N) == 0 && TERN0(HAS_DUPLICATION_MODE, extruder_duplication_enabled)) \
               ENABLE_AXIS_E1(); \
           } \

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -450,8 +450,8 @@ class Planner {
     #endif
 
     #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
-       // Counters to manage disabling inactive extruders
-      static last_move_t g_uc_extruder_last_move[EXTRUDERS];
+       // Counters to manage disabling inactive extruder steppers
+      static last_move_t g_uc_extruder_last_move[E_STEPPERS];
     #endif
 
     #if HAS_WIRED_LCD

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -450,7 +450,7 @@ class Planner {
     #endif
 
     #if ENABLED(DISABLE_INACTIVE_EXTRUDER)
-       // Counters to manage disabling inactive extruder steppers
+      // Counters to manage disabling inactive extruder steppers
       static last_move_t g_uc_extruder_last_move[E_STEPPERS];
     #endif
 

--- a/Marlin/src/module/stepper/indirection.h
+++ b/Marlin/src/module/stepper/indirection.h
@@ -418,7 +418,7 @@ void reset_stepper_drivers();    // Called by settings.load / settings.reset
     #define    REV_E_DIR(E)   do{ E0_DIR_WRITE(E ? !INVERT_E0_DIR :  INVERT_E0_DIR); }while(0)
   #endif
 
-#elif HAS_PRUSA_MMU2
+#elif HAS_PRUSA_MMU2  // One multiplexed stepper driver
 
   #define E_STEP_WRITE(E,V) E0_STEP_WRITE(V)
   #define   NORM_E_DIR(E)   E0_DIR_WRITE(!INVERT_E0_DIR)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -35,11 +35,6 @@
  *    These numbers are the same in any pin mapping.
  */
 
-#if HAS_EXTENDABLE_MMU
-  #define MAX_EXTRUDERS 15
-#else
-  #define MAX_EXTRUDERS 8
-#endif
 #define MAX_E_STEPPERS 8
 
 #if   MB(RAMPS_13_EFB, RAMPS_14_EFB, RAMPS_PLUS_EFB, RAMPS_14_RE_ARM_EFB, RAMPS_SMART_EFB, RAMPS_DUO_EFB, RAMPS4DUE_EFB)

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -23,10 +23,10 @@
 
 #include "env_validate.h"
 
-#if HOTENDS > 8 || E_STEPPERS > 8
-  #error "BIGTREE GTR V1.0 supports up to 8 hotends / E-steppers."
-#elif HOTENDS > MAX_E_STEPPERS || E_STEPPERS > MAX_E_STEPPERS
+#if E_STEPPERS > MAX_E_STEPPERS
   #error "Marlin extruder/hotends limit! Increase MAX_E_STEPPERS to continue."
+#elif HOTENDS > 8 || E_STEPPERS > 8
+  #error "BIGTREE GTR V1.0 supports up to 8 hotends / E-steppers."
 #endif
 
 #define BOARD_INFO_NAME "BTT GTR V1.0"


### PR DESCRIPTION
This allows users to compile with more than 5 colors on extendable mmu.
There seems to be some extruder vs e_stepper mix in code I'm not sure I really understood which difference is one or other.