### PR TITLE
Fix Linker Script Typo

### DIFF
--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -119,7 +119,7 @@ lib_deps          = ${env:STM32F103RC_btt_maple.lib_deps}
 [env:STM32F103RC_btt_512K_maple]
 platform                  = ${common_stm32f1.platform}
 extends                   = env:STM32F103RC_btt_maple
-board_build.ldscript      = STM32F103RC_SKR_MINI_512K.ld
+board_build.ldscript      = STM32F103RE_SKR_MINI_512K.ld
 board_upload.maximum_size = 524288
 build_flags               = ${env:STM32F103RC_btt_maple.build_flags} -DSTM32_FLASH_SIZE=512
 


### PR DESCRIPTION
### Description

Linker script was renamed, but this reference wasn't updated.

### Benefits

Marlin will compile for BTT 512K RCT environments.

### Related Issues

None. Found while testing some other issues.
