### PR TITLE
Allow M140 to stop print job timer with PRINTJOB_TIMER_AUTOSTART

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1824,11 +1824,20 @@
 /**
  * Print Job Timer
  *
- * Automatically start and stop the print job timer on M104/M109/M190.
+ * Automatically start and stop the print job timer on M104/M109/M140/M190/M141/M191.
+ * The print job timer will only be stopped if the bed/chamber target temp is
+ * below BED_MINTEMP/CHAMBER_MINTEMP.
  *
- *   M104 (hotend, no wait) - high temp = none,        low temp = stop timer
- *   M109 (hotend, wait)    - high temp = start timer, low temp = stop timer
- *   M190 (bed, wait)       - high temp = start timer, low temp = none
+ *   M104 (hotend, no wait)  - high temp = none,        low temp = stop timer
+ *   M109 (hotend, wait)     - high temp = start timer, low temp = stop timer
+ *   M140 (bed, no wait)     - high temp = none,        low temp = stop timer
+ *   M190 (bed, wait)        - high temp = start timer, low temp = none
+ *   M141 (chamber, no wait) - high temp = none,        low temp = stop timer
+ *   M191 (chamber, wait)    - high temp = start timer, low temp = none
+ *
+ * For M104/M109, high temp is anything over EXTRUDE_MINTEMP / 2.
+ * For M140/M190, high temp is anything over BED_MINTEMP.
+ * For M141/M191, high temp is anything over CHAMBER_MINTEMP.
  *
  * The timer can also be controlled with the following commands:
  *

--- a/Marlin/src/gcode/temp/M140_M190.cpp
+++ b/Marlin/src/gcode/temp/M140_M190.cpp
@@ -83,9 +83,10 @@ void GcodeSuite::M140_M190(const bool isM190) {
 
   thermalManager.setTargetBed(temp);
 
-  TERN_(PRINTJOB_TIMER_AUTOSTART, thermalManager.auto_job_check_timer(true, false));
-
   ui.set_status_P(thermalManager.isHeatingBed() ? GET_TEXT(MSG_BED_HEATING) : GET_TEXT(MSG_BED_COOLING));
+
+  // with PRINTJOB_TIMER_AUTOSTART, M190 can start the timer, and M140 can stop it
+  TERN_(PRINTJOB_TIMER_AUTOSTART, thermalManager.auto_job_check_timer(isM190, !isM190));
 
   if (isM190)
     thermalManager.wait_for_bed(no_wait_for_cooling);


### PR DESCRIPTION
### Description

This will restore the behavior of `PRINTJOB_TIMER_AUTOSTART` and clarify the comments in `Configuration.h`:
 - `M140` can again stop the print job timer as it did before aee971bcaf2d8b7157985f36f6705015ef334238
 - Add references to `M141` and `M191` which will also start/stop the print job timer if used (Chamber)

Note: I moved the call to `thermalManager.auto_job_check_timer` below the call to `ui.set_status_P` so that the final message on the LCD screen is '[Printer Name] Ready' and not 'Bed Cooling...'.

### Requirements

None

### Benefits

Fixes #22020 and restores previous behavior of `PRINTJOB_TIMER_AUTOSTART`.

### Configurations

Tested on my Ender 3 v2:
[ender3v2-config.zip](https://github.com/MarlinFirmware/Marlin/files/6599662/ender3v2-config.zip)

But this should function on anything with `PRINTJOB_TIMER_AUTOSTART` enabled.

### Related Issues

Fixes #22020
