### PR TITLE
Add non maple STM32F103CB_malyan build env.

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -466,7 +466,7 @@
 #elif MB(STM32F103RE)
   #include "stm32f1/pins_STM32F1R.h"            // STM32F103RE                            env:STM32F103RE env:STM32F103RE_maple
 #elif MB(MALYAN_M200)
-  #include "stm32f1/pins_MALYAN_M200.h"         // STM32F103CB                            env:STM32F103CB_malyan
+  #include "stm32f1/pins_MALYAN_M200.h"         // STM32F103CB                            env:STM32F103CB_malyan env:STM32F103CB_malyan_maple
 #elif MB(STM3R_MINI)
   #include "stm32f1/pins_STM3R_MINI.h"          // STM32F103VE?                           env:STM32F103VE env:STM32F103RE_maple
 #elif MB(GTM32_PRO_VB)

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -330,7 +330,7 @@ build_flags   = ${common_stm32f1.build_flags}
 #
 # Malyan M200 (STM32F103CB)
 #
-[env:STM32F103CB_malyan]
+[env:STM32F103CB_malyan_maple]
 platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = marlin_malyanM200

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -282,3 +282,14 @@ build_unflags        = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
 extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
+
+#
+# Malyan M200 (STM32F103CB)
+#
+[env:STM32F103CB_malyan]
+platform    = ${common_stm32.platform}
+extends     = common_stm32
+board       = malyanm200_f103cb
+build_flags = ${common_stm32.build_flags}
+  -DHAL_PCD_MODULE_ENABLED -DDISABLE_GENERIC_SERIALUSB -DHAL_UART_MODULE_ENABLED
+src_filter  = ${common.default_src_filter} +<src/HAL/STM32>


### PR DESCRIPTION
### Description

Add non maple STM32F103CB_malyan

### Requirements

BOARD_MALYAN_M200

### Benefits

Less maple

### Notes
I can't get original maple STM32F103CB_malyan_maple to build at all, but have left it in there.
 

