### PR TITLE
STM32 HAL add missing eeprom include

### DIFF
--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -28,8 +28,8 @@
 
 #include "../shared/eeprom_api.h"
 
-// Better include is "utility/stm32_eeprom.h", but only after updating stm32duino to 2.0.0
-// Right now, we need to include EEPROM.h for compatiblity reasons.
+// Better: "utility/stm32_eeprom.h", but only after updating stm32duino to 2.0.0
+// Use EEPROM.h for compatibility, for now.
 #include <EEPROM.h> 
 
 /**

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -28,6 +28,8 @@
 
 #include "../shared/eeprom_api.h"
 
+#include <EEPROM.h>
+
 /**
  * The STM32 HAL supports chips that deal with "pages" and some with "sectors" and some that
  * even have multiple "banks" of flash.

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -28,7 +28,9 @@
 
 #include "../shared/eeprom_api.h"
 
-#include <EEPROM.h>
+// Better include is "utility/stm32_eeprom.h", but only after updating stm32duino to 2.0.0
+// Right now, we need to include EEPROM.h for compatiblity reasons.
+#include <EEPROM.h> 
 
 /**
  * The STM32 HAL supports chips that deal with "pages" and some with "sectors" and some that


### PR DESCRIPTION
### Description
The eeprom_flash.cpp in the STM32 HAL seems to miss an include.
I have attached a minimal [Configuration](https://github.com/MarlinFirmware/Marlin/files/6602652/ReproduceConfigs.zip) to trigger a compilation error (tested with STM32F103RC_btt_USB & STM32F103RE_btt_USB environments).
Without the added include I get the following compile error:

<details><summary>Log Output</summary>

```
Marlin\src\HAL\STM32\eeprom_flash.cpp: In static member function 'static bool PersistentStore::access_start()':
Marlin\src\HAL\STM32\eeprom_flash.cpp:136:5: error: 'eeprom_buffer_fill' was not declared in this scope
  136 |     eeprom_buffer_fill();
      |     ^~~~~~~~~~~~~~~~~~
Marlin\src\HAL\STM32\eeprom_flash.cpp: In static member function 'static bool PersistentStore::access_finish()':
Marlin\src\HAL\STM32\eeprom_flash.cpp:227:7: error: 'eeprom_buffer_flush' was not declared in this scope
  227 |       eeprom_buffer_flush();
      |       ^~~~~~~~~~~~~~~~~~~
Marlin\src\HAL\STM32\eeprom_flash.cpp: In static member function 'static bool PersistentStore::write_data(int&, const uint8_t*, size_t, uint16_t*)':
Marlin\src\HAL\STM32\eeprom_flash.cpp:247:16: error: 'eeprom_buffered_read_byte' was not declared in this scope
  247 |       if (v != eeprom_buffered_read_byte(pos)) {
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~
Marlin\src\HAL\STM32\eeprom_flash.cpp:248:9: error: 'eeprom_buffered_write_byte' was not declared in this scope
  248 |         eeprom_buffered_write_byte(pos, v);
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~
Compiling .pio\build\STM32F103RC_btt_USB\src\src\HAL\STM32\fast_pwm.cpp.o
In file included from Marlin\src\HAL\STM32\../../inc/MarlinConfigPre.h:37,
                 from Marlin\src\HAL\STM32\../../inc/MarlinConfig.h:28,
                 from Marlin\src\HAL\STM32\eeprom_flash.cpp:25:
Marlin\src\HAL\STM32\eeprom_flash.cpp: In static member function 'static bool PersistentStore::read_data(int&, uint8_t*, size_t, uint16_t*, bool)':
Marlin\src\HAL\STM32\eeprom_flash.cpp:261:68: error: 'eeprom_buffered_read_byte' was not declared in this scope
  261 |     const uint8_t c = TERN(FLASH_EEPROM_LEVELING, ram_eeprom[pos], eeprom_buffered_read_byte(pos));
      |                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
Marlin\src\HAL\STM32\../../inc/../core/macros.h:558:26: note: in definition of macro 'THIRD'
  558 | #define THIRD(a,b,c,...) c
      |                          ^
Marlin\src\HAL\STM32\../../inc/../core/macros.h:204:29: note: in expansion of macro '___TERN'
  204 | #define __TERN(T,V...)      ___TERN(_CAT(_NO,T),V)  // Prepend '_NO' to get '_NOT_0' or '_NOT_1'
      |                             ^~~~~~~
Marlin\src\HAL\STM32\../../inc/../core/macros.h:203:29: note: in expansion of macro '__TERN'
  203 | #define _TERN(E,V...)       __TERN(_CAT(T_,E),V)    // Prepend 'T_' to get 'T_0' or 'T_1'
      |                             ^~~~~~
Marlin\src\HAL\STM32\../../inc/../core/macros.h:199:29: note: in expansion of macro '_TERN'
  199 | #define TERN(O,A,B)         _TERN(_ENA_1(O),B,A)    // OPTION ? 'A' : 'B'
      |                             ^~~~~
Marlin\src\HAL\STM32\eeprom_flash.cpp:261:23: note: in expansion of macro 'TERN'
  261 |     const uint8_t c = TERN(FLASH_EEPROM_LEVELING, ram_eeprom[pos], eeprom_buffered_read_byte(pos));
      |                       ^~~~
```
</details>

### Requirements
EEPROM_SETTINGS enabled and an environment that uses the new STM32 HAL.

### Benefits
No longer compile errors when enabling EEPROM.
Note that I have only tested this with the above specified environments which use https://github.com/rhapsodyv/Arduino_Core_STM32/commits/usb-host-msc-cdc-msc-2 as framework and I do not have the knowledge if this change might affect other devices that use this HAL too. In fact I do not even know the list of devices using this HAL.
Downsides:
An additional compiler warning due to an unsed class in EEPROM.h:
```
warning: 'EEPROM' defined but not used [-Wunused-variable]
  250 | static EEPROMClass EEPROM;
      |                    ^~~~~~
```
There might be a better include which avoids this message, but I would expect the compiler to optimize the unused variable away, so no additional memory usage should be caused by this PR.

### Configurations
[Minimal Configuration to Reproduce](https://github.com/MarlinFirmware/Marlin/files/6602652/ReproduceConfigs.zip)

### Related Issues
None known