### PR TITLE
Remove CUSTOM_SPI_PINS

### DIFF
--- a/Marlin/src/HAL/STM32/HAL_SPI.cpp
+++ b/Marlin/src/HAL/STM32/HAL_SPI.cpp
@@ -163,11 +163,9 @@ static SPISettings spiConfig;
     }
     spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
 
-    #if ENABLED(CUSTOM_SPI_PINS)
-      SPI.setMISO(SD_MISO_PIN);
-      SPI.setMOSI(SD_MOSI_PIN);
-      SPI.setSCLK(SD_SCK_PIN);
-    #endif
+    SPI.setMISO(SD_MISO_PIN);
+    SPI.setMOSI(SD_MOSI_PIN);
+    SPI.setSCLK(SD_SCK_PIN);
 
     SPI.begin();
   }

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
@@ -276,6 +276,9 @@
 
 #if SD_CONNECTION_IS(ONBOARD)
   #define SD_DETECT_PIN                     PC4
+  #define SD_SCK_PIN                        PA5
+  #define SD_MISO_PIN                       PA6
+  #define SD_MOSI_PIN                       PA7
 #elif SD_CONNECTION_IS(LCD) && BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
   #define SD_DETECT_PIN                     PA15
   #define SD_SS_PIN                         PA10

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -280,11 +280,8 @@
 #define ONBOARD_SPI_DEVICE                     1  // SPI1 -> used only by HAL/STM32F1...
 #define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
 
-#define CUSTOM_SPI_PINS                           // TODO: needed because is the only way to set SPI for SD on STM32 (for now)
-#if ENABLED(CUSTOM_SPI_PINS)
-  #define ENABLE_SPI1
-  #define SDSS                              ONBOARD_SD_CS_PIN
-  #define SD_SCK_PIN                        PA5
-  #define SD_MISO_PIN                       PA6
-  #define SD_MOSI_PIN                       PA7
-#endif
+#define ENABLE_SPI1
+#define SDSS                   ONBOARD_SD_CS_PIN
+#define SD_SCK_PIN                          PA5
+#define SD_MISO_PIN                         PA6
+#define SD_MOSI_PIN                         PA7

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -186,7 +186,6 @@
 
 // TODO: This is the only way to set SPI for SD on STM32 (for now)
 #define ENABLE_SPI2
-#define CUSTOM_SPI_PINS
 #define SD_SCK_PIN                          PB13
 #define SD_MISO_PIN                         PB14
 #define SD_MOSI_PIN                         PB15

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -205,13 +205,10 @@
 #define EXP2_10_PIN                         PA6
 
 // HAL SPI1 pins
-#define CUSTOM_SPI_PINS
-#if ENABLED(CUSTOM_SPI_PINS)
-  #define SD_SCK_PIN                 EXP2_09_PIN  // SPI1 SCLK
-  #define SD_SS_PIN                  EXP2_07_PIN  // SPI1 SSEL
-  #define SD_MISO_PIN                EXP2_10_PIN  // SPI1 MISO
-  #define SD_MOSI_PIN                EXP2_05_PIN  // SPI1 MOSI
-#endif
+#define SD_SCK_PIN                   EXP2_09_PIN  // SPI1 SCLK
+#define SD_SS_PIN                    EXP2_07_PIN  // SPI1 SSEL
+#define SD_MISO_PIN                  EXP2_10_PIN  // SPI1 MISO
+#define SD_MOSI_PIN                  EXP2_05_PIN  // SPI1 MOSI
 
 #define SDSS                         EXP2_07_PIN
 

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -357,8 +357,6 @@
 
 #elif SD_CONNECTION_IS(ONBOARD)
 
-  // Instruct the STM32 HAL to override the default SPI pins from the variant.h file
-  #define CUSTOM_SPI_PINS
   #define SDSS                              PA4
   #define SD_SS_PIN                         SDSS
   #define SD_SCK_PIN                        PA5

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -356,7 +356,6 @@
   #define SD_DETECT_PIN                     PC14
 #elif SD_CONNECTION_IS(LCD)
 
-  #define CUSTOM_SPI_PINS
   #define SDSS                              PA4
   #define SD_SS_PIN                         SDSS
   #define SD_SCK_PIN                        PA5

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -348,7 +348,6 @@
 
 #elif SD_CONNECTION_IS(LCD)
 
-  #define CUSTOM_SPI_PINS
   #define SDSS                              PA4
   #define SD_SS_PIN                         SDSS
   #define SD_SCK_PIN                        PA5

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -217,31 +217,25 @@
 //
 // detect pin dont work when ONBOARD and NO_SD_HOST_DRIVE disabled
 #if SD_CONNECTION_IS(ONBOARD)
-  #define CUSTOM_SPI_PINS                         // TODO: needed because is the only way to set SPI3 for SD on STM32 (by now)
-  #if ENABLED(CUSTOM_SPI_PINS)
-    #define ENABLE_SPI3
-    #define SD_SS_PIN                       -1
-    #define SDSS                            PC9
-    #define SD_SCK_PIN                      PC10
-    #define SD_MISO_PIN                     PC11
-    #define SD_MOSI_PIN                     PC12
-    #define SD_DETECT_PIN                   PD12
-  #endif
+  #define ENABLE_SPI3
+  #define SD_SS_PIN                         -1
+  #define SDSS                              PC9
+  #define SD_SCK_PIN                        PC10
+  #define SD_MISO_PIN                       PC11
+  #define SD_MOSI_PIN                       PC12
+  #define SD_DETECT_PIN                     PD12
 #endif
 
 //
 // LCD SD
 //
 #if SD_CONNECTION_IS(LCD)
-  #define CUSTOM_SPI_PINS
-  #if ENABLED(CUSTOM_SPI_PINS)
-    #define ENABLE_SPI1
-    #define SDSS                            PE10
-    #define SD_SCK_PIN                      PA5
-    #define SD_MISO_PIN                     PA6
-    #define SD_MOSI_PIN                     PA7
-    #define SD_DETECT_PIN                   PE12
-  #endif
+  #define ENABLE_SPI1
+  #define SDSS                              PE10
+  #define SD_SCK_PIN                        PA5
+  #define SD_MISO_PIN                       PA6
+  #define SD_MOSI_PIN                       PA7
+  #define SD_DETECT_PIN                     PE12
 #endif
 
 //
@@ -345,7 +339,7 @@
     //#define MKS_LCD12864B
     //#undef SHOW_BOOTSCREEN
 
-  #else // !MKS_MINI_12864
+  #else                                           // !MKS_MINI_12864
 
     #define LCD_PINS_D4                     PE14
     #if ENABLED(ULTIPANEL)

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -241,7 +241,7 @@
 //
 // LCD / Controller
 #define SPI_FLASH
-#define HAS_SPI_FLASH                          1
+#define HAS_SPI_FLASH 1
 #define SPI_DEVICE                             2
 #define SPI_FLASH_SIZE                 0x1000000
 #if ENABLED(SPI_FLASH)
@@ -339,7 +339,7 @@
     //#define MKS_LCD12864B
     //#undef SHOW_BOOTSCREEN
 
-  #else                                           // !MKS_MINI_12864
+  #else // !MKS_MINI_12864
 
     #define LCD_PINS_D4                     PE14
     #if ENABLED(ULTIPANEL)

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -206,7 +206,7 @@
   #define SDCARD_CONNECTION              ONBOARD
 #endif
 
-//#define USE_NEW_SPI_API 1
+//#define USE_NEW_SPI_API                      1
 
 //
 // Onboard SD card
@@ -214,21 +214,17 @@
 //
 // detect pin dont work when ONBOARD and NO_SD_HOST_DRIVE disabled
 #if !defined(SDCARD_CONNECTION) || SDCARD_CONNECTION == ONBOARD
-  #define CUSTOM_SPI_PINS
-  #if ENABLED(CUSTOM_SPI_PINS)
-
-    #if USE_NEW_SPI_API
-      #define SD_SPI MARLIN_SPI(HardwareSPI3, PC9)
-    #else
-      #define ENABLE_SPI3
-      #define SD_SS_PIN                     -1
-      #define SDSS                          PC9
-      #define SD_SCK_PIN                    PC10
-      #define SD_MISO_PIN                   PC11
-      #define SD_MOSI_PIN                   PC12
-    #endif
-    #define SD_DETECT_PIN                   PD12
+  #if USE_NEW_SPI_API
+    #define SD_SPI MARLIN_SPI(HardwareSPI3, PC9)
+  #else
+    #define ENABLE_SPI3
+    #define SD_SS_PIN                       -1
+    #define SDSS                            PC9
+    #define SD_SCK_PIN                      PC10
+    #define SD_MISO_PIN                     PC11
+    #define SD_MOSI_PIN                     PC12
   #endif
+  #define SD_DETECT_PIN                     PD12
 #endif
 
 /*
@@ -236,15 +232,12 @@
 // LCD SD
 //
 #if SDCARD_CONNECTION == LCD
-  #define CUSTOM_SPI_PINS
-  #if ENABLED(CUSTOM_SPI_PINS)
-    #define ENABLE_SPI1
-    #define SDSS                            PE10
-    #define SD_SCK_PIN                      PA5
-    #define SD_MISO_PIN                     PA6
-    #define SD_MOSI_PIN                     PA7
-    #define SD_DETECT_PIN                   PE12
-  #endif
+  #define ENABLE_SPI1
+  #define SDSS                              PE10
+  #define SD_SCK_PIN                        PA5
+  #define SD_MISO_PIN                       PA6
+  #define SD_MOSI_PIN                       PA7
+  #define SD_DETECT_PIN                     PE12
 #endif
 */
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -31,7 +31,7 @@
 #define BOARD_INFO_NAME "MKS Robin PRO V2"
 
 // Avoid conflict with TIMER_TONE
-#define STEP_TIMER                            10
+#define STEP_TIMER 10
 
 // Use one of these or SDCard-based Emulation will be used
 //#define SRAM_EEPROM_EMULATION                   // Use BackSRAM-based EEPROM emulation
@@ -50,7 +50,7 @@
 //
 // Note: MKS Robin board is using SPI2 interface.
 //
-//#define SPI_MODULE                           2
+//#define SPI_MODULE 2
 
 //
 // Servos
@@ -203,10 +203,10 @@
 //#define LED_PIN                           PB2
 
 #ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION              ONBOARD
+  #define SDCARD_CONNECTION ONBOARD
 #endif
 
-//#define USE_NEW_SPI_API                      1
+//#define USE_NEW_SPI_API 1
 
 //
 // Onboard SD card
@@ -244,7 +244,7 @@
 //
 // LCD / Controller
 #define SPI_FLASH
-#define HAS_SPI_FLASH                          1
+#define HAS_SPI_FLASH 1
 #define SPI_DEVICE                             2
 #define SPI_FLASH_SIZE                 0x1000000
 #if ENABLED(SPI_FLASH)


### PR DESCRIPTION
### Description

`CUSTOM_SPI_PINS` doesn't make sense anymore. This PR removes it and add some missing SD_SPI pins for STM32.

And it will break the build if the pins for a STM32 board is missing the SD SPI pins, as it is mandatory now.