### PR TITLE
expose hidden BLTOUCH setting changes

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -713,14 +713,24 @@
   #ifndef Z_PROBE_SERVO_NR
     #define Z_PROBE_SERVO_NR 0
   #endif
-  #undef DEACTIVATE_SERVOS_AFTER_MOVE
+  #ifdef DEACTIVATE_SERVOS_AFTER_MOVE
+    #warning "BLTOUCH requires DEACTIVATE_SERVOS_AFTER_MOVE to be to disabled. Undefining DEACTIVATE_SERVOS_AFTER_MOVE. Please update your Configuration.h file."
+    #undef DEACTIVATE_SERVOS_AFTER_MOVE
+  #endif
 
   // Always disable probe pin inverting for BLTouch
-  #undef Z_MIN_PROBE_ENDSTOP_INVERTING
-  #define Z_MIN_PROBE_ENDSTOP_INVERTING false
+  #if Z_MIN_PROBE_ENDSTOP_INVERTING
+    #warning "BLTOUCH requires Z_MIN_PROBE_ENDSTOP_INVERTING set to false. Resetting Z_MIN_PROBE_ENDSTOP_INVERTING to false. Please update your Configuration.h file."
+    #undef Z_MIN_PROBE_ENDSTOP_INVERTING1
+    #define Z_MIN_PROBE_ENDSTOP_INVERTING false
+  #endif
+
   #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
-    #undef Z_MIN_ENDSTOP_INVERTING
-    #define Z_MIN_ENDSTOP_INVERTING false
+    #if Z_MIN_ENDSTOP_INVERTING
+      #warning "BLTOUCH requires Z_MIN_ENDSTOP_INVERTING set to false. Resetting Z_MIN_ENDSTOP_INVERTING to false. Please update your Configuration.h file."
+      #undef Z_MIN_ENDSTOP_INVERTING
+      #define Z_MIN_ENDSTOP_INVERTING false
+    #endif
   #endif
 #endif
 

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -721,7 +721,7 @@
   // Always disable probe pin inverting for BLTouch
   #if Z_MIN_PROBE_ENDSTOP_INVERTING
     #warning "BLTOUCH requires Z_MIN_PROBE_ENDSTOP_INVERTING set to false. Resetting Z_MIN_PROBE_ENDSTOP_INVERTING to false. Please update your Configuration.h file."
-    #undef Z_MIN_PROBE_ENDSTOP_INVERTING1
+    #undef Z_MIN_PROBE_ENDSTOP_INVERTING
     #define Z_MIN_PROBE_ENDSTOP_INVERTING false
   #endif
 


### PR DESCRIPTION
### Description

When you enable BLTOUCH, Marlin quietly resets  DEACTIVATE_SERVOS_AFTER_MOVE, Z_MIN_PROBE_ENDSTOP_INVERTING and Z_MIN_ENDSTOP_INVERTING to what is needed by the BLTOUCH.

This leads to many user arguments along the lines of "I have Z_MIN_ENDSTOP_INVERTING set true, and BLTOUCH works for me" Immediately followed by a second user says the opposite "I have Z_MIN_ENDSTOP_INVERTING set false, and BLTOUCH works for me" and on and  on...

This exposes that Marlin is resetting these defines to what is actually needed by BLTOUCH 

### Requirements

BLTOUCH and various combinations of DEACTIVATE_SERVOS_AFTER_MOVE, Z_MIN_ENDSTOP_INVERTING and Z_MIN_PROBE_ENDSTOP_INVERTING

### Benefits

Less confused users, cleaner Config files that have correct settings.

