### PR TITLE
⚡️ Optimize Sensitive Pins array

### DIFF
--- a/Marlin/src/HAL/AVR/HAL.h
+++ b/Marlin/src/HAL/AVR/HAL.h
@@ -186,7 +186,7 @@ inline void HAL_adc_init() {
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)
 
-#define HAL_SENSITIVE_PINS 0, 1
+#define HAL_SENSITIVE_PINS 0, 1,
 
 #ifdef __AVR_AT90USB1286__
   #define JTAG_DISABLE() do{ MCUCR = 0x80; MCUCR = 0x80; }while(0)

--- a/Marlin/src/HAL/LINUX/include/pinmapping.cpp
+++ b/Marlin/src/HAL/LINUX/include/pinmapping.cpp
@@ -25,43 +25,6 @@
 
 #include "../../../gcode/parser.h"
 
-uint8_t analog_offset = NUM_DIGITAL_PINS - NUM_ANALOG_INPUTS;
-
-// Get the digital pin for an analog index
-pin_t analogInputToDigitalPin(const int8_t p) {
-  return (WITHIN(p, 0, NUM_ANALOG_INPUTS) ? analog_offset + p : P_NC);
-}
-
-// Return the index of a pin number
-int16_t GET_PIN_MAP_INDEX(const pin_t pin) {
-  return pin;
-}
-
-// Test whether the pin is valid
-bool VALID_PIN(const pin_t p) {
-  return WITHIN(p, 0, NUM_DIGITAL_PINS);
-}
-
-// Get the analog index for a digital pin
-int8_t DIGITAL_PIN_TO_ANALOG_PIN(const pin_t p) {
-  return (WITHIN(p, analog_offset, NUM_DIGITAL_PINS) ? p - analog_offset : P_NC);
-}
-
-// Test whether the pin is PWM
-bool PWM_PIN(const pin_t p) {
-  return false;
-}
-
-// Test whether the pin is interruptable
-bool INTERRUPT_PIN(const pin_t p) {
-  return false;
-}
-
-// Get the pin number at the given index
-pin_t GET_PIN_MAP_PIN(const int16_t ind) {
-  return ind;
-}
-
 int16_t PARSED_PIN_INDEX(const char code, const int16_t dval) {
   return parser.intval(code, dval);
 }

--- a/Marlin/src/HAL/LINUX/include/pinmapping.h
+++ b/Marlin/src/HAL/LINUX/include/pinmapping.h
@@ -34,26 +34,32 @@ constexpr uint8_t NUM_ANALOG_INPUTS = 16;
 
 #define HAL_SENSITIVE_PINS
 
+constexpr uint8_t analog_offset = NUM_DIGITAL_PINS - NUM_ANALOG_INPUTS;
+
 // Get the digital pin for an analog index
-pin_t analogInputToDigitalPin(const int8_t p);
-
-// Return the index of a pin number
-int16_t GET_PIN_MAP_INDEX(const pin_t pin);
-
-// Test whether the pin is valid
-bool VALID_PIN(const pin_t p);
+constexpr pin_t analogInputToDigitalPin(const int8_t p) {
+  return (WITHIN(p, 0, NUM_ANALOG_INPUTS) ? analog_offset + p : P_NC);
+}
 
 // Get the analog index for a digital pin
-int8_t DIGITAL_PIN_TO_ANALOG_PIN(const pin_t p);
+constexpr int8_t DIGITAL_PIN_TO_ANALOG_PIN(const pin_t p) {
+  return (WITHIN(p, analog_offset, NUM_DIGITAL_PINS) ? p - analog_offset : P_NC);
+}
+
+// Return the index of a pin number
+constexpr int16_t GET_PIN_MAP_INDEX(const pin_t pin) { return pin; }
+
+// Test whether the pin is valid
+constexpr bool VALID_PIN(const pin_t p) { return WITHIN(p, 0, NUM_DIGITAL_PINS); }
 
 // Test whether the pin is PWM
-bool PWM_PIN(const pin_t p);
+constexpr bool PWM_PIN(const pin_t p) { return false; }
 
 // Test whether the pin is interruptable
-bool INTERRUPT_PIN(const pin_t p);
+constexpr bool INTERRUPT_PIN(const pin_t p) { return false; }
 
 // Get the pin number at the given index
-pin_t GET_PIN_MAP_PIN(const int16_t ind);
+constexpr pin_t GET_PIN_MAP_PIN(const int16_t ind) { return ind; }
 
 // Parse a G-code word into a pin index
 int16_t PARSED_PIN_INDEX(const char code, const int16_t dval);

--- a/Marlin/src/HAL/LPC1768/HAL.h
+++ b/Marlin/src/HAL/LPC1768/HAL.h
@@ -198,7 +198,7 @@ constexpr pin_t GET_PIN_MAP_PIN(const int16_t index) {
 // Parse a G-code word into a pin index
 int16_t PARSED_PIN_INDEX(const char code, const int16_t dval);
 // P0.6 thru P0.9 are for the onboard SD card
-#define HAL_SENSITIVE_PINS P0_06, P0_07, P0_08, P0_09
+#define HAL_SENSITIVE_PINS P0_06, P0_07, P0_08, P0_09,
 
 #define HAL_IDLETASK 1
 void HAL_idletask();

--- a/Marlin/src/HAL/STM32/inc/Conditionals_adv.h
+++ b/Marlin/src/HAL/STM32/inc/Conditionals_adv.h
@@ -30,3 +30,6 @@
   #undef F_CPU
   #define F_CPU BOARD_F_CPU
 #endif
+
+// The Sensitive Pins array is not optimizable
+#define RUNTIME_ONLY_ANALOG_TO_DIGITAL

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -282,8 +282,15 @@ bool wait_for_heatup = true;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
 
+#ifdef RUNTIME_ONLY_ANALOG_TO_DIGITAL
+  static const pin_t sensitive_pins[] PROGMEM = { SENSITIVE_PINS };
+#else
+  template <pin_t ...D>
+  constexpr pin_t OnlyPins<-2, D...>::table[sizeof...(D)];
+  #define sensitive_pins OnlyPins<SENSITIVE_PINS>::table
+#endif
+
 bool pin_is_protected(const pin_t pin) {
-  static const pin_t sensitive_pins[] PROGMEM = SENSITIVE_PINS;
   LOOP_L_N(i, COUNT(sensitive_pins)) {
     pin_t sensitive_pin;
     memcpy_P(&sensitive_pin, &sensitive_pins[i], sizeof(pin_t));

--- a/Marlin/src/pins/sensitive_pins.h
+++ b/Marlin/src/pins/sensitive_pins.h
@@ -187,8 +187,13 @@
   #else
     #define _I_MS3
   #endif
+  #if PIN_EXISTS(I_ENABLE)
+    #define _I_ENABLE_PIN I_ENABLE_PIN,
+  #else
+    #define _I_ENABLE_PIN
+  #endif
 
-  #define _I_PINS I_STEP_PIN, I_DIR_PIN, I_ENABLE_PIN, _I_MIN _I_MAX _I_MS1 _I_MS2 _I_MS3 _I_CS
+  #define _I_PINS I_STEP_PIN, I_DIR_PIN, _I_ENABLE_PIN _I_MIN _I_MAX _I_MS1 _I_MS2 _I_MS3 _I_CS
 
 #else
 
@@ -228,8 +233,13 @@
   #else
     #define _J_MS3
   #endif
+  #if PIN_EXISTS(J_ENABLE)
+    #define _J_ENABLE_PIN J_ENABLE_PIN,
+  #else
+    #define _J_ENABLE_PIN
+  #endif
 
-  #define _J_PINS J_STEP_PIN, J_DIR_PIN, J_ENABLE_PIN, _J_MIN _J_MAX _J_MS1 _J_MS2 _J_MS3 _J_CS
+  #define _J_PINS J_STEP_PIN, J_DIR_PIN, _J_ENABLE_PIN _J_MIN _J_MAX _J_MS1 _J_MS2 _J_MS3 _J_CS
 
 #else
 
@@ -269,8 +279,13 @@
   #else
     #define _K_MS3
   #endif
+  #if PIN_EXISTS(K_ENABLE)
+    #define _K_ENABLE_PIN K_ENABLE_PIN,
+  #else
+    #define _K_ENABLE_PIN
+  #endif
 
-  #define _K_PINS K_STEP_PIN, K_DIR_PIN, K_ENABLE_PIN, _K_MIN _K_MAX _K_MS1 _K_MS2 _K_MS3 _K_CS
+  #define _K_PINS K_STEP_PIN, K_DIR_PIN, _K_ENABLE_PIN _K_MIN _K_MAX _K_MS1 _K_MS2 _K_MS3 _K_CS
 
 #else
 
@@ -577,30 +592,32 @@
 #define _H6_PINS
 #define _H7_PINS
 
+#define DIO_PIN(P) TERN(TARGET_LPC1768, P, analogInputToDigitalPin(P))
+
 #if HAS_HOTEND
   #undef _H0_PINS
-  #define _H0_PINS HEATER_0_PIN, E0_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_0_PIN),
+  #define _H0_PINS HEATER_0_PIN, E0_AUTO_FAN_PIN, DIO_PIN(TEMP_0_PIN),
   #if HAS_MULTI_HOTEND
     #undef _H1_PINS
-    #define _H1_PINS HEATER_1_PIN, E1_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_1_PIN),
+    #define _H1_PINS HEATER_1_PIN, E1_AUTO_FAN_PIN, DIO_PIN(TEMP_1_PIN),
     #if HOTENDS > 2
       #undef _H2_PINS
-      #define _H2_PINS HEATER_2_PIN, E2_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_2_PIN),
+      #define _H2_PINS HEATER_2_PIN, E2_AUTO_FAN_PIN, DIO_PIN(TEMP_2_PIN),
       #if HOTENDS > 3
         #undef _H3_PINS
-        #define _H3_PINS HEATER_3_PIN, E3_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_3_PIN),
+        #define _H3_PINS HEATER_3_PIN, E3_AUTO_FAN_PIN, DIO_PIN(TEMP_3_PIN),
         #if HOTENDS > 4
           #undef _H4_PINS
-          #define _H4_PINS HEATER_4_PIN, E4_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_4_PIN),
+          #define _H4_PINS HEATER_4_PIN, E4_AUTO_FAN_PIN, DIO_PIN(TEMP_4_PIN),
           #if HOTENDS > 5
             #undef _H5_PINS
-            #define _H5_PINS HEATER_5_PIN, E5_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_5_PIN),
+            #define _H5_PINS HEATER_5_PIN, E5_AUTO_FAN_PIN, DIO_PIN(TEMP_5_PIN),
             #if HOTENDS > 6
               #undef _H6_PINS
-              #define _H6_PINS HEATER_6_PIN, E6_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_6_PIN),
+              #define _H6_PINS HEATER_6_PIN, E6_AUTO_FAN_PIN, DIO_PIN(TEMP_6_PIN),
               #if HOTENDS > 7
                 #undef _H7_PINS
-                #define _H7_PINS HEATER_7_PIN, E7_AUTO_FAN_PIN, analogInputToDigitalPin(TEMP_7_PIN),
+                #define _H7_PINS HEATER_7_PIN, E7_AUTO_FAN_PIN, DIO_PIN(TEMP_7_PIN),
               #endif // HOTENDS > 7
             #endif // HOTENDS > 6
           #endif // HOTENDS > 5
@@ -809,13 +826,13 @@
 #endif
 
 #if TEMP_SENSOR_BED && PINS_EXIST(TEMP_BED, HEATER_BED)
-  #define _BED_PINS HEATER_BED_PIN, analogInputToDigitalPin(TEMP_BED_PIN),
+  #define _BED_PINS HEATER_BED_PIN, DIO_PIN(TEMP_BED_PIN),
 #else
   #define _BED_PINS
 #endif
 
 #if TEMP_SENSOR_CHAMBER && PIN_EXISTS(TEMP_CHAMBER)
-  #define _CHAMBER_TEMP analogInputToDigitalPin(TEMP_CHAMBER_PIN),
+  #define _CHAMBER_TEMP DIO_PIN(TEMP_CHAMBER_PIN),
 #else
   #define _CHAMBER_TEMP
 #endif
@@ -831,17 +848,15 @@
 #endif
 
 #if TEMP_SENSOR_COOLER && PIN_EXISTS(TEMP_COOLER)
-  #define _COOLER_TEMP analogInputToDigitalPin(TEMP_COOLER_PIN),
+  #define _COOLER_TEMP DIO_PIN(TEMP_COOLER_PIN),
 #else
   #define _COOLER_TEMP
 #endif
-
 #if TEMP_SENSOR_COOLER && PIN_EXISTS(COOLER)
   #define _COOLER COOLER_PIN,
 #else
   #define _COOLER
 #endif
-
 #if TEMP_SENSOR_COOLER && PINS_EXIST(TEMP_COOLER, COOLER_AUTO_FAN)
   #define _COOLER_FAN COOLER_AUTO_FAN_PIN,
 #else
@@ -852,11 +867,30 @@
   #define HAL_SENSITIVE_PINS
 #endif
 
-#define SENSITIVE_PINS { \
+#ifdef RUNTIME_ONLY_ANALOG_TO_DIGITAL
+  #define _SP_END
+#else
+  #define _SP_END -2
+
+  // Move a regular pin in front to the end
+  template<pin_t F, pin_t ...D>
+  struct OnlyPins : OnlyPins<D..., F> { };
+
+  // Remove a -1 from the front
+  template<pin_t ...D>
+  struct OnlyPins<-1, D...> : OnlyPins<D...> { };
+
+  // Remove -2 from the front, emit the rest, cease propagation
+  template<pin_t ...D>
+  struct OnlyPins<_SP_END, D...> { static constexpr pin_t table[sizeof...(D)] PROGMEM = { D... }; };
+#endif
+
+#define SENSITIVE_PINS \
   _X_PINS _Y_PINS _Z_PINS _I_PINS _J_PINS _K_PINS \
   _X2_PINS _Y2_PINS _Z2_PINS _Z3_PINS _Z4_PINS _Z_PROBE \
   _E0_PINS _E1_PINS _E2_PINS _E3_PINS _E4_PINS _E5_PINS _E6_PINS _E7_PINS \
   _H0_PINS _H1_PINS _H2_PINS _H3_PINS _H4_PINS _H5_PINS _H6_PINS _H7_PINS \
   _PS_ON _FAN0 _FAN1 _FAN2 _FAN3 _FAN4 _FAN5 _FAN6 _FAN7 _FANC \
-  _BED_PINS _COOLER _CHAMBER_TEMP _CHAMBER_HEATER _CHAMBER_FAN HAL_SENSITIVE_PINS \
-}
+  _BED_PINS _CHAMBER_TEMP _CHAMBER_HEATER _CHAMBER_FAN \
+  _COOLER_TEMP _COOLER _COOLER_FAN HAL_SENSITIVE_PINS \
+  _SP_END


### PR DESCRIPTION
Use templates to produce an array of pins with all the -1 entries stripped out. The pin numbers might not be unique, but the array will be shorter and the function to compare a value to the sensitive pins list will run more quickly.

CC: @ramiropolla

Unfortunately, at this time some platforms still use a runtime array to do the `analogInputToDigitalPin` pin conversion, so this optimization isn't possible right now for STM32.