### PR TITLE
Fix smaller and larger I2C EEPROM support

### DIFF
--- a/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
+++ b/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
@@ -61,23 +61,24 @@ static constexpr uint8_t eeprom_device_address = I2C_ADDRESS(EEPROM_DEVICE_ADDRE
 // Public functions
 // ------------------------
 
+#define SMALL_EEPROM (MARLIN_EEPROM_SIZE <= 2048)
+
+// Combine Address high bits into the device address on <=16Kbit (2K) and >512Kbit (64K) EEPROMs.
+// Note: MARLIN_EEPROM_SIZE is specified in bytes, whereas EEPROM model numbers refer to bits.
+//       e.g., The "16" in BL24C16 indicates a 16Kbit (2KB) size.
 static uint8_t _eeprom_calc_device_address(uint8_t * const pos) {
   const unsigned eeprom_address = (unsigned)pos;
-  // Note: MARLIN_EEPROM_SIZE is specified in bytes, whereas most EEPROMs advertise bits
-  if (MARLIN_EEPROM_SIZE <= 2048 || MARLIN_EEPROM_SIZE > 65536) {
-    // Address high bits are stuffed into device address on <=16Kbit and >512Kbit EEPROMs
-    return uint8_t(eeprom_device_address | ((eeprom_address >> (MARLIN_EEPROM_SIZE <= 2048 ? 8 : 16)) & 0x07));
-  }
-  return eeprom_device_address;
+  return (SMALL_EEPROM || MARLIN_EEPROM_SIZE > 65536)
+    ? uint8_t(eeprom_device_address | ((eeprom_address >> (SMALL_EEPROM ? 8 : 16)) & 0x07))
+    : eeprom_device_address;
 }
 
 static void _eeprom_begin(uint8_t * const pos) {
   const unsigned eeprom_address = (unsigned)pos;
   Wire.beginTransmission(_eeprom_calc_device_address(pos));
-  if (MARLIN_EEPROM_SIZE > 2048) {
-    Wire.write(uint8_t((eeprom_address >> 8) & 0xFF)); // Address High, if needed
-  }
-  Wire.write(uint8_t(eeprom_address & 0xFF)); // Address Low
+  if (!SMALL_EEPROM)
+    Wire.write(uint8_t((eeprom_address >> 8) & 0xFF));  // Address High, if needed
+  Wire.write(uint8_t(eeprom_address & 0xFF));           // Address Low
 }
 
 void eeprom_write_byte(uint8_t *pos, uint8_t value) {

--- a/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
+++ b/Marlin/src/HAL/shared/eeprom_if_i2c.cpp
@@ -61,11 +61,23 @@ static constexpr uint8_t eeprom_device_address = I2C_ADDRESS(EEPROM_DEVICE_ADDRE
 // Public functions
 // ------------------------
 
+static uint8_t _eeprom_calc_device_address(uint8_t * const pos) {
+  const unsigned eeprom_address = (unsigned)pos;
+  // Note: MARLIN_EEPROM_SIZE is specified in bytes, whereas most EEPROMs advertise bits
+  if (MARLIN_EEPROM_SIZE <= 2048 || MARLIN_EEPROM_SIZE > 65536) {
+    // Address high bits are stuffed into device address on <=16Kbit and >512Kbit EEPROMs
+    return uint8_t(eeprom_device_address | ((eeprom_address >> (MARLIN_EEPROM_SIZE <= 2048 ? 8 : 16)) & 0x07));
+  }
+  return eeprom_device_address;
+}
+
 static void _eeprom_begin(uint8_t * const pos) {
   const unsigned eeprom_address = (unsigned)pos;
-  Wire.beginTransmission(eeprom_device_address);
-  Wire.write(int(eeprom_address >> 8));   // Address High
-  Wire.write(int(eeprom_address & 0xFF)); // Address Low
+  Wire.beginTransmission(_eeprom_calc_device_address(pos));
+  if (MARLIN_EEPROM_SIZE > 2048) {
+    Wire.write(uint8_t((eeprom_address >> 8) & 0xFF)); // Address High, if needed
+  }
+  Wire.write(uint8_t(eeprom_address & 0xFF)); // Address Low
 }
 
 void eeprom_write_byte(uint8_t *pos, uint8_t value) {
@@ -81,7 +93,7 @@ void eeprom_write_byte(uint8_t *pos, uint8_t value) {
 uint8_t eeprom_read_byte(uint8_t *pos) {
   _eeprom_begin(pos);
   Wire.endTransmission();
-  Wire.requestFrom(eeprom_device_address, (byte)1);
+  Wire.requestFrom(_eeprom_calc_device_address(pos), (byte)1);
   return Wire.available() ? Wire.read() : 0xFF;
 }
 


### PR DESCRIPTION
### Description

Currently, I2C EEPROMs that use 1 byte addressing or stuff upper address bits into the device address are unsupported by the shared EEPROM library.

### Requirements

Any board with I2C EEPROM.

If a board does not _properly define_ MARLIN_EEPROM_SIZE it may stop working with this PR. eeprom_wired differs from platform to platform on whether or not MARLIN_EEPROM_SIZE must be defined (hard error if not) or if it will try to guess a value for you. It may be wise to move any attempt to auto-define or require-to-be-defined MARLIN_EEPROM_SIZE into SanityCheck.h, I'll leave this to discussion first though.

### Benefits

This allows more boards with EEPROMs to make use of I2C_EEPROM, such as Robin Nano v1. (I plan to submit this for a future PR, for whatever reason it requires SOFT_I2C_EEPROM to work right now).

This also probably allows removal of IIC_BL24CXX_EEPROM, used by a few devices such as Creality V4 that have 2KB EEPROMs which were presumably unsupported by the simple built-in library until this PR.

### Related Issues

#21330 and the related PR attempted to fix this, but the comparison being made was "MARLIN_EEPROM_SIZE > 0x4000"; the value they were looking for was 2048, or 0x800.
