### PR TITLE
Allow Mightyboard* envs on board MIGHTYBOARD_REVE

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -216,7 +216,7 @@
 #elif MB(CNCONTROLS_15)
   #include "mega/pins_CNCONTROLS_15.h"          // ATmega2560, ATmega1280                 env:mega2560 env:mega1280
 #elif MB(MIGHTYBOARD_REVE)
-  #include "mega/pins_MIGHTYBOARD_REVE.h"       // ATmega2560, ATmega1280                 env:mega2560ext env:mega1280
+  #include "mega/pins_MIGHTYBOARD_REVE.h"       // ATmega2560, ATmega1280                 env:mega2560ext env:mega1280 env:MightyBoard1280 env:MightyBoard2560
 #elif MB(CHEAPTRONIC)
   #include "mega/pins_CHEAPTRONIC.h"            // ATmega2560                             env:mega2560
 #elif MB(CHEAPTRONIC_V2)


### PR DESCRIPTION
The current pre-compile checks fail because the Mightyboard* envs are not listed under the MIGHTYBOARD_REVE board in the main pins.h file. This commit adds the appropriate envs to the list.

### Description
The MightyBoard1280 and MightyBoard2560 envs were previously added for easier compatibility with the MightyBoard-based printers. However, the code in its present state will not compile when the BOARD_MIGHTYBOARD_REVE motherboard is specified. This PR adds the missing envs to the compatibility list in the main pins.h file. 

### Requirements

This change only affects compiles specifying either MightyBoard* env and the BOARD_MIGHTYBOARD_REVE board.

### Benefits

This PR fixes an omission that would otherwise prevent compilation on the intended configuration.

### Related Issues

Fixes issue #22099
