### PR TITLE
make extruders optional under 6 axis

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -888,7 +888,7 @@
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
-  #define MAX_FEEDRATE_EDIT_VALUES    { 600, 600, 10, 50 } // ...or, set your own edit limits
+  #define MAX_FEEDRATE_EDIT_VALUES    { 600, 600, 10 OPTARG(EXTRUDERS, 50) } // ...or, set your own edit limits
 #endif
 
 /**
@@ -901,7 +901,7 @@
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)
-  #define MAX_ACCEL_EDIT_VALUES       { 6000, 6000, 200, 20000 } // ...or, set your own edit limits
+  #define MAX_ACCEL_EDIT_VALUES       { 6000, 6000, 200 OPTARG(EXTRUDERS, 20000) } // ...or, set your own edit limits
 #endif
 
 /**
@@ -937,7 +937,7 @@
 
   //#define LIMITED_JERK_EDITING        // Limit edit via M205 or LCD to DEFAULT_aJERK * 2
   #if ENABLED(LIMITED_JERK_EDITING)
-    #define MAX_JERK_EDIT_VALUES { 20, 20, 0.6, 10 } // ...or, set your own edit limits
+    #define MAX_JERK_EDIT_VALUES { 20, 20, 0.6 OPTARG(EXTRUDERS, 10) } // ...or, set your own edit limits
   #endif
 #endif
 

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -875,16 +875,16 @@
 /**
  * Default Axis Steps Per Unit (steps/mm)
  * Override with M92
- *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
+ *                                      X, Y, Z [, I [, J [, K]]], [E0 [, E1[, E2...]]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 500 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400 OPTARG(EXTRUDERS, 500) }
 
 /**
  * Default Max Feed Rate (mm/s)
  * Override with M203
- *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
+ *                                      X, Y, Z [, I [, J [, K]]], [E0 [, E1[, E2...]]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 300, 300, 5, 25 }
+#define DEFAULT_MAX_FEEDRATE          { 300, 300, 5 OPTARG(EXTRUDERS, 25) }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
@@ -895,9 +895,9 @@
  * Default Max Acceleration (change/s) change = mm/s
  * (Maximum start speed for accelerated moves)
  * Override with M201
- *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
+ *                                      X, Y, Z [, I [, J [, K]]], [E0 [, E1[, E2...]]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 100, 10000 }
+#define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 100 OPTARG(EXTRUDERS, 10000) }
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -909,7 +909,7 @@
 
 // @section motion
 
-#define AXIS_RELATIVE_MODES { false, false, false, false }
+#define AXIS_RELATIVE_MODES { false, false, false OPTARG(EXTRUDERS,false) }
 
 // Add a Duplicate option for well-separated conjoined nozzles
 //#define MULTI_NOZZLE_DUPLICATION

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -186,6 +186,13 @@
 
 #define _ISENA_     ~,1
 #define _ISENA_1    ~,1
+#define _ISENA_2    ~,1
+#define _ISENA_3    ~,1
+#define _ISENA_4    ~,1
+#define _ISENA_5    ~,1
+#define _ISENA_6    ~,1
+#define _ISENA_7    ~,1
+#define _ISENA_8    ~,1
 #define _ISENA_0x1  ~,1
 #define _ISENA_true ~,1
 #define _ISENA(V...)        IS_PROBE(V)


### PR DESCRIPTION
### Description

With the new 6 axis code various defines need correct number of elements. That number changes depending on what you disable or enable. In particular these defines.
 DEFAULT_AXIS_STEPS_PER_UNIT
 DEFAULT_MAX_FEEDRATE1
 DEFAULT_MAX_ACCELERATION
 AXIS_RELATIVE_MODES
 MAX_JERK_EDIT_VALUES
 MAX_FEEDRATE_EDIT_VALUES
 MAX_ACCEL_EDIT_VALUES

If you're adding an axis this is fine, You add element to each define, It is expected. 

But if you set EXTRUDERS 0 It also means you need to remove the E elements in all of these defines. (this is not how marlin behaved before, especially the #define AXIS_RELATIVE_MODES "hidden" in Configuration_adv.h)

I purpose that we implement OPTARG in Configuration.h and Configuration_adv.h So that the E elements are handled automatically.

To do this I extended _ISENA_*  so that _ISENA_2 through _ISENA_8 return as true.
I'm not sure this extension is a good idea or not... Thoughts?

But with this change OPTARG can use EXTRUDERS in Configuration.h to disable the E elements when they are not needed.

### Requirements

#define EXTRUDERS 0

### Benefits

#define EXTRUDERS 0 works as before without the other changes now needed
Much easier to setup machines without extruders.   

### Related Issues

None

### Discussion
Is this is a good idea, or do you hate it? 