### PR TITLE
Fix M503 report of M206 (for 6-axis)

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3163,7 +3163,7 @@ void MarlinSettings::reset() {
       CONFIG_ECHO_START();
       SERIAL_ECHOLNPAIR_P(
         #if IS_CARTESIAN
-          LIST_N(LINEAR_AXES,
+          LIST_N(DOUBLE(LINEAR_AXES),
             PSTR("  M206 X"), LINEAR_UNIT(home_offset.x),
             SP_Y_STR, LINEAR_UNIT(home_offset.y),
             SP_Z_STR, LINEAR_UNIT(home_offset.z),


### PR DESCRIPTION
### Description

This fixes a missing DOUBLE() that caused incomplete report of home offsets with M503  

### Requirements

None

### Benefits

fix issue 22098 

### Configurations

### Related Issues

fixes issue https://github.com/MarlinFirmware/Marlin/issues/22098