### PR TITLE
🐛 Fix Serial+MSC for _USB envs

### DIFF
--- a/buildroot/share/PlatformIO/scripts/generic_create_variant.py
+++ b/buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -28,7 +28,7 @@ if len(platform_packages) == 0:
 else:
     platform_name = PackageSpec(platform_packages[0]).name
 
-if platform_name in [ "usb-host-msc", "usb-host-msc-cdc-msc", "usb-host-msc-cdc-msc-2", "tool-stm32duino" ]:
+if platform_name in [ "usb-host-msc", "usb-host-msc-cdc-msc", "usb-host-msc-cdc-msc-2", "usb-host-msc-cdc-msc-3", "tool-stm32duino" ]:
     platform_name = "framework-arduinoststm32"
 
 FRAMEWORK_DIR = platform.get_package_dir(platform_name)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -91,14 +91,13 @@ board_upload.offset_address = 0x08007000
 [env:STM32F103RC_btt_USB]
 extends           = env:STM32F103RC_btt
 platform          = ${common_stm32.platform}
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-2.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-3.zip
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 build_flags       = ${env:STM32F103RC_btt.build_flags} ${env:stm32_flash_drive.build_flags}
   -DUSBCON
-  -DUSE_USBHOST_HS
+  -DUSE_USB_FS
   -DUSBD_IRQ_PRIO=5
   -DUSBD_IRQ_SUBPRIO=6
-  -DUSE_USB_HS_IN_FS
   -DUSBD_USE_CDC_MSC
 
 #
@@ -192,14 +191,13 @@ upload_protocol      = jlink
 [env:STM32F103RE_btt_USB]
 extends           = env:STM32F103RE_btt
 platform          = ${common_stm32.platform}
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-2.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-3.zip
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 build_flags       = ${env:STM32F103RE_btt.build_flags} ${env:stm32_flash_drive.build_flags}
   -DUSBCON
-  -DUSE_USBHOST_HS
+  -DUSE_USB_FS
   -DUSBD_IRQ_PRIO=5
   -DUSBD_IRQ_SUBPRIO=6
-  -DUSE_USB_HS_IN_FS
   -DUSBD_USE_CDC_MSC
 
 #

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -146,7 +146,7 @@ debug_init_break  =
 # USB Flash Drive mix-ins for STM32
 #
 [stm_flash_drive]
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-2.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-3.zip
 build_flags       = ${common_stm32.build_flags}
   -DHAL_PCD_MODULE_ENABLED -DHAL_HCD_MODULE_ENABLED
   -DUSBHOST -DUSBH_IRQ_PRIO=3 -DUSBH_IRQ_SUBPRIO=4
@@ -424,7 +424,7 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 [env:mks_robin_nano_v3_usb_flash_drive_msc]
 platform          = ${common_stm32.platform}
 extends           = env:mks_robin_nano_v3
-platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-2.zip
+platform_packages = framework-arduinoststm32@https://github.com/rhapsodyv/Arduino_Core_STM32/archive/usb-host-msc-cdc-msc-3.zip
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
   -DUSBCON


### PR DESCRIPTION
### Description

This PR is a continuation of #22087.

It fixes the Usb Serial and the media share for F1 boards (using _USB env) for STM32 hal.

I had to change the framework link, because the framework was fixed too.

### Related Issues

#22087 
Fix the last issue of #22078 
