### PR TITLE
Overridable POWER_LOSS_PIN for MKS Robin Nano V3

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -190,7 +190,9 @@
   #define FIL_RUNOUT2_PIN               MT_DET_2
 #endif
 
-#define POWER_LOSS_PIN                    PW_DET
+#ifndef POWER_LOSS_PIN
+  #define POWER_LOSS_PIN                    PW_DET
+#endif
 #define PS_ON_PIN                         PW_OFF
 
 //

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -191,7 +191,7 @@
 #endif
 
 #ifndef POWER_LOSS_PIN
-  #define POWER_LOSS_PIN                    PW_DET
+  #define POWER_LOSS_PIN                  PW_DET
 #endif
 #define PS_ON_PIN                         PW_OFF
 


### PR DESCRIPTION
### Description

If POWER_LOSS_PIN is defined in Configuration_adv.h the compiler rises a warning about POWER_LOSS_PIN redefinition. This means that currently the POWER_LOSS_PIN configured is not able to override the default one.

The worst case is if the custom POWER_LOSS_PIN is set to -1. In that case the printer believes to be always in power loss condition,

### Benefits

This fixes the just mentioned issue.