### PR TITLE
🐛 Some ILI9328 / ILI9341 macros apply to all TFT drivers

### DIFF
--- a/Marlin/src/lcd/tft_io/tft_io.cpp
+++ b/Marlin/src/lcd/tft_io/tft_io.cpp
@@ -39,18 +39,15 @@
 #if TFT_DRIVER == R61505 || TFT_DRIVER == AUTO
   #include "r65105.h"
 #endif
-#if TFT_DRIVER == ILI9328 || TFT_DRIVER == AUTO
-  #include "ili9328.h"
-#endif
-#if TFT_DRIVER == ILI9341 || TFT_DRIVER == AUTO
-  #include "ili9341.h"
-#endif
 #if TFT_DRIVER == ILI9488 || TFT_DRIVER == ILI9488_ID1 || TFT_DRIVER == AUTO
   #include "ili9488.h"
 #endif
 #if TFT_DRIVER == SSD1963 || TFT_DRIVER == AUTO
   #include "ssd1963.h"
 #endif
+
+#include "ili9341.h"
+#include "ili9328.h"
 
 #define DEBUG_OUT ENABLED(DEBUG_GRAPHICAL_TFT)
 #include "../../core/debug_out.h"


### PR DESCRIPTION
### Description

Fix compilation error after #22031


### Related Issues

Fixes #22117
