### PR TITLE
Fix floats in `PTC_*`/`BTC_*` vars breaking compilation

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -202,7 +202,7 @@
   #define COOLER_MAXTEMP          26  // (°C)
   #define COOLER_DEFAULT_TEMP     16  // (°C)
   #define TEMP_COOLER_HYSTERESIS   1  // (°C) Temperature proximity considered "close enough" to the target
-  #define COOLER_PIN               8  // Laser cooler on/off pin used to control power to the cooling element e.g. TEC, External chiller via relay
+  #define COOLER_PIN               8  // Laser cooler on/off pin used to control power to the cooling element (e.g., TEC, External chiller via relay)
   #define COOLER_INVERTING     false
   #define TEMP_COOLER_PIN         15  // Laser/Cooler temperature sensor pin. ADC is required.
   #define COOLER_FAN                  // Enable a fan on the cooler, Fan# 0,1,2,3 etc.
@@ -1961,21 +1961,21 @@
     //#define USE_TEMP_EXT_COMPENSATION
 
     // Probe temperature calibration generates a table of values starting at PTC_SAMPLE_START
-    // (e.g. 30), in steps of PTC_SAMPLE_RES (e.g. 5) with PTC_SAMPLE_COUNT (e.g. 10) samples.
+    // (e.g., 30), in steps of PTC_SAMPLE_RES (e.g., 5) with PTC_SAMPLE_COUNT (e.g., 10) samples.
 
-    //#define PTC_SAMPLE_START  30
-    //#define PTC_SAMPLE_RES    5
+    //#define PTC_SAMPLE_START  30  // (°C)
+    //#define PTC_SAMPLE_RES     5  // (°C)
     //#define PTC_SAMPLE_COUNT  10
 
     // Bed temperature calibration builds a similar table.
 
-    //#define BTC_SAMPLE_START  60
-    //#define BTC_SAMPLE_RES    5
+    //#define BTC_SAMPLE_START  60  // (°C)
+    //#define BTC_SAMPLE_RES     5  // (°C)
     //#define BTC_SAMPLE_COUNT  10
 
     // The temperature the probe should be at while taking measurements during bed temperature
     // calibration.
-    //#define BTC_PROBE_TEMP 30
+    //#define BTC_PROBE_TEMP    30  // (°C)
 
     // Height above Z=0.0f to raise the nozzle. Lowering this can help the probe to heat faster.
     // Note: the Z=0.0f offset is determined by the probe offset which can be set using M851.
@@ -2099,7 +2099,7 @@
 // @section motion
 
 // The number of linear moves that can be in the planner at once.
-// The value of BLOCK_BUFFER_SIZE must be a power of 2 (e.g. 8, 16, 32)
+// The value of BLOCK_BUFFER_SIZE must be a power of 2 (e.g., 8, 16, 32)
 #if BOTH(SDSUPPORT, DIRECT_STEPPING)
   #define BLOCK_BUFFER_SIZE  8
 #elif ENABLED(SDSUPPORT)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1963,19 +1963,19 @@
     // Probe temperature calibration generates a table of values starting at PTC_SAMPLE_START
     // (e.g. 30), in steps of PTC_SAMPLE_RES (e.g. 5) with PTC_SAMPLE_COUNT (e.g. 10) samples.
 
-    //#define PTC_SAMPLE_START  30.0f
-    //#define PTC_SAMPLE_RES    5.0f
-    //#define PTC_SAMPLE_COUNT  10U
+    //#define PTC_SAMPLE_START  30
+    //#define PTC_SAMPLE_RES    5
+    //#define PTC_SAMPLE_COUNT  10
 
     // Bed temperature calibration builds a similar table.
 
-    //#define BTC_SAMPLE_START  60.0f
-    //#define BTC_SAMPLE_RES    5.0f
-    //#define BTC_SAMPLE_COUNT  10U
+    //#define BTC_SAMPLE_START  60
+    //#define BTC_SAMPLE_RES    5
+    //#define BTC_SAMPLE_COUNT  10
 
     // The temperature the probe should be at while taking measurements during bed temperature
     // calibration.
-    //#define BTC_PROBE_TEMP 30.0f
+    //#define BTC_PROBE_TEMP 30
 
     // Height above Z=0.0f to raise the nozzle. Lowering this can help the probe to heat faster.
     // Note: the Z=0.0f offset is determined by the probe offset which can be set using M851.
@@ -1984,7 +1984,7 @@
     // Height to raise the Z-probe between heating and taking the next measurement. Some probes
     // may fail to untrigger if they have been triggered for a long time, which can be solved by
     // increasing the height the probe is raised to.
-    //#define PTC_PROBE_RAISE 15U
+    //#define PTC_PROBE_RAISE 15
 
     // If the probe is outside of the defined range, use linear extrapolation using the closest
     // point and the PTC_LINEAR_EXTRAPOLATION'th next point. E.g. if set to 4 it will use data[0]

--- a/Marlin/src/feature/probe_temp_comp.h
+++ b/Marlin/src/feature/probe_temp_comp.h
@@ -47,7 +47,7 @@ typedef struct {
 
 // Probe temperature calibration constants
 #ifndef PTC_SAMPLE_COUNT
-  #define PTC_SAMPLE_COUNT 10U
+  #define PTC_SAMPLE_COUNT 10
 #endif
 #ifndef PTC_SAMPLE_RES
   #define PTC_SAMPLE_RES 5
@@ -55,14 +55,14 @@ typedef struct {
 #ifndef PTC_SAMPLE_START
   #define PTC_SAMPLE_START 30
 #endif
-#define PTC_SAMPLE_END ((PTC_SAMPLE_START) + (PTC_SAMPLE_COUNT) * (PTC_SAMPLE_RES))
+#define PTC_SAMPLE_END (PTC_SAMPLE_START + (PTC_SAMPLE_COUNT) * PTC_SAMPLE_RES)
 
 // Bed temperature calibration constants
 #ifndef BTC_PROBE_TEMP
   #define BTC_PROBE_TEMP 30
 #endif
 #ifndef BTC_SAMPLE_COUNT
-  #define BTC_SAMPLE_COUNT 10U
+  #define BTC_SAMPLE_COUNT 10
 #endif
 #ifndef BTC_SAMPLE_RES
   #define BTC_SAMPLE_RES 5
@@ -70,7 +70,7 @@ typedef struct {
 #ifndef BTC_SAMPLE_START
   #define BTC_SAMPLE_START 60
 #endif
-#define BTC_SAMPLE_END ((BTC_SAMPLE_START) + (BTC_SAMPLE_COUNT) * (BTC_SAMPLE_RES))
+#define BTC_SAMPLE_END (BTC_SAMPLE_START + (BTC_SAMPLE_COUNT) * BTC_SAMPLE_RES)
 
 #ifndef PTC_PROBE_HEATING_OFFSET
   #define PTC_PROBE_HEATING_OFFSET 0.5f

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -577,39 +577,10 @@
 constexpr float arm[] = AXIS_RELATIVE_MODES;
 static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _LOGICAL_AXES_STR "elements.");
 
-#ifdef PTC_SAMPLE_START
-  auto _ptc_sample_start = PTC_SAMPLE_START;
-  constexpr decltype(_ptc_sample_start) _test_ptc_sample_start = 12.3f;
-  static_assert( _test_ptc_sample_start != 12.3f , "PTC_SAMPLE_START should not be a float; use whole numbers only.");
-#endif
-
-#ifdef PTC_SAMPLE_RES
-  auto _ptc_sample_res = PTC_SAMPLE_END;
-  constexpr decltype(_ptc_sample_res) _test_ptc_sample_res = 12.3f;
-  static_assert( _test_ptc_sample_res != 12.3f , "PTC_SAMPLE_RES should not be a float; use whole numbers only.");
-#endif
-
-#ifdef BTC_SAMPLE_START
-  auto _btc_sample_start = BTC_SAMPLE_START;
-  constexpr decltype(_btc_sample_start) _test_btc_sample_start = 12.3f;
-  static_assert( _test_btc_sample_start != 12.3f , "BTC_SAMPLE_START should not be a float; use whole numbers only.");
-#endif
-
-#ifdef BTC_SAMPLE_RES
-  auto _btc_sample_res = BTC_SAMPLE_END;
-  constexpr decltype(_btc_sample_res) _test_btc_sample_res = 12.3f;
-  static_assert( _test_btc_sample_res != 12.3f , "BTC_SAMPLE_RES should not be a float; use whole numbers only.");
-#endif
-
-#ifdef BTC_PROBE_TEMP
-  auto _btc_probe_temp = BTC_PROBE_TEMP;
-  constexpr decltype(_btc_probe_temp) _test_btc_probe_temp = 12.3f;
-  static_assert( _test_btc_probe_temp != 12.3f , "BTC_SAMPLE_RES should not be a float; use whole numbers only.");
-#endif
-
 /**
  * Probe temp compensation requirements
  */
+
 #if ENABLED(PROBE_TEMP_COMPENSATION)
   #if defined(PTC_PARK_POS_X) || defined(PTC_PARK_POS_Y) || defined(PTC_PARK_POS_Z)
     #error "PTC_PARK_POS_[XYZ] is now PTC_PARK_POS (array)."
@@ -619,6 +590,27 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
     #error "PTC_PROBE_POS_[XY] is now PTC_PROBE_POS (array)."
   #elif !defined(PTC_PROBE_POS)
     #error "PROBE_TEMP_COMPENSATION requires PTC_PROBE_POS."
+  #endif
+
+  #ifdef PTC_SAMPLE_START
+    constexpr int _ptc_sample_start = PTC_SAMPLE_START;
+    static_assert(_test_ptc_sample_start != PTC_SAMPLE_START, "PTC_SAMPLE_START must be a whole number.");
+  #endif
+  #ifdef PTC_SAMPLE_RES
+    constexpr int _ptc_sample_res = PTC_SAMPLE_END;
+    static_assert(_test_ptc_sample_res != PTC_SAMPLE_END, "PTC_SAMPLE_RES must be a whole number.");
+  #endif
+  #ifdef BTC_SAMPLE_START
+    constexpr int _btc_sample_start = BTC_SAMPLE_START;
+    static_assert(_test_btc_sample_start != BTC_SAMPLE_START, "BTC_SAMPLE_START must be a whole number.");
+  #endif
+  #ifdef BTC_SAMPLE_RES
+    constexpr int _btc_sample_res = BTC_SAMPLE_END;
+    static_assert(_test_btc_sample_res != BTC_SAMPLE_END, "BTC_SAMPLE_RES must be a whole number.");
+  #endif
+  #ifdef BTC_PROBE_TEMP
+    constexpr int _btc_probe_temp = BTC_PROBE_TEMP;
+    static_assert(_test_btc_probe_temp != BTC_PROBE_TEMP, "BTC_PROBE_TEMP must be a whole number.");
   #endif
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -577,6 +577,36 @@
 constexpr float arm[] = AXIS_RELATIVE_MODES;
 static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _LOGICAL_AXES_STR "elements.");
 
+#ifdef PTC_SAMPLE_START
+  auto _ptc_sample_start = PTC_SAMPLE_START;
+  constexpr decltype(_ptc_sample_start) _test_ptc_sample_start = 12.3f;
+  static_assert( _test_ptc_sample_start != 12.3f , "PTC_SAMPLE_START should not be a float; use whole numbers only.");
+#endif
+
+#ifdef PTC_SAMPLE_RES
+  auto _ptc_sample_res = PTC_SAMPLE_END;
+  constexpr decltype(_ptc_sample_res) _test_ptc_sample_res = 12.3f;
+  static_assert( _test_ptc_sample_res != 12.3f , "PTC_SAMPLE_RES should not be a float; use whole numbers only.");
+#endif
+
+#ifdef BTC_SAMPLE_START
+  auto _btc_sample_start = BTC_SAMPLE_START;
+  constexpr decltype(_btc_sample_start) _test_btc_sample_start = 12.3f;
+  static_assert( _test_btc_sample_start != 12.3f , "BTC_SAMPLE_START should not be a float; use whole numbers only.");
+#endif
+
+#ifdef BTC_SAMPLE_RES
+  auto _btc_sample_res = BTC_SAMPLE_END;
+  constexpr decltype(_btc_sample_res) _test_btc_sample_res = 12.3f;
+  static_assert( _test_btc_sample_res != 12.3f , "BTC_SAMPLE_RES should not be a float; use whole numbers only.");
+#endif
+
+#ifdef BTC_PROBE_TEMP
+  auto _btc_probe_temp = BTC_PROBE_TEMP;
+  constexpr decltype(_btc_probe_temp) _test_btc_probe_temp = 12.3f;
+  static_assert( _test_btc_probe_temp != 12.3f , "BTC_SAMPLE_RES should not be a float; use whole numbers only.");
+#endif
+
 /**
  * Probe temp compensation requirements
  */

--- a/buildroot/tests/BIGTREE_BTT002
+++ b/buildroot/tests/BIGTREE_BTT002
@@ -16,5 +16,11 @@ opt_set MOTHERBOARD BOARD_BTT_BTT002_V1_0 \
         Y_DRIVER_TYPE TMC2130
 exec_test $1 $2 "BigTreeTech BTT002 Default Configuration plus TMC steppers" "$3"
 
+#
+# A test with Probe Temperature Compensation enabled
+#
+use_example_configs Prusa/MK3S-BigTreeTech-BTT002
+exec_test $1 $2 "BigTreeTech BTT002 with Prusa MK3S and related options" "$3"
+
 # clean up
 restore_configs


### PR DESCRIPTION
### Description

The 'probe_temp_compenation' feature was moved to `celsius_t` at some point in the last few months, but the default config was not updated, and users previously using float vals in `BTC_SAMPLE_START`, `BTC_SAMPLE_RES`, `PTC_SAMPLE_START`, `PTC_SAMPLE_RES`, etc are being met with narrowing conbversion errors that break compilation.


### Requirements

Probe, probe temp sensor, PROBE_TEMP_COMPENSATION


### Benefits

Fixes up the default config from the replacement of `float` with `celsius_t` in probe_temp_compensation.h, and adds new sanity checks for floats which will warn users with old configs.


### Configurations

```
#define BLTOUCH //or some other probe
#define TEMP_SENSOR_PROBE 1
#define PROBE_TEMP_COMPENSATION
#define BTC_SAMPLE_START 30.0f
```

### Related Issues

Resolves #22044
MarlinFirmware/Configurations#519