### PR TITLE
fix BFT corruption when using compressed data on STM32duino

### DIFF
--- a/Marlin/src/feature/binary_stream.h
+++ b/Marlin/src/feature/binary_stream.h
@@ -24,9 +24,11 @@
 #include "../inc/MarlinConfig.h"
 
 #define BINARY_STREAM_COMPRESSION
-
 #if ENABLED(BINARY_STREAM_COMPRESSION)
   #include "../libs/heatshrink/heatshrink_decoder.h"
+  // STM32 (and others?) require a word-aligned buffer for SD card transfers via DMA
+  static __attribute__((aligned(sizeof(size_t)))) uint8_t decode_buffer[512] = {};
+  static heatshrink_decoder hsd;
 #endif
 
 inline bool bs_serial_data_available(const serial_index_t index) {
@@ -36,16 +38,6 @@ inline bool bs_serial_data_available(const serial_index_t index) {
 inline int bs_read_serial(const serial_index_t index) {
   return SERIAL_IMPL.read(index);
 }
-
-#if ENABLED(BINARY_STREAM_COMPRESSION)
-  static heatshrink_decoder hsd;
-  #if ENABLED(SDIO_SUPPORT)
-    // STM32 requires a word-aligned buffer for SD card transfers via DMA
-    static __attribute__((aligned(sizeof(size_t)))) uint8_t decode_buffer[512] = {};
-  #else
-    static uint8_t decode_buffer[512] = {};
-  #endif
-#endif
 
 class SDFileTransferProtocol  {
 private:

--- a/Marlin/src/feature/binary_stream.h
+++ b/Marlin/src/feature/binary_stream.h
@@ -39,7 +39,7 @@ inline int bs_read_serial(const serial_index_t index) {
 
 #if ENABLED(BINARY_STREAM_COMPRESSION)
   static heatshrink_decoder hsd;
-  #if BOTH(ARDUINO_ARCH_STM32F1, SDIO_SUPPORT)
+  #if EITHER(ARDUINO_ARCH_STM32F1, STM32F1) && ENABLED(SDIO_SUPPORT)
     // STM32 requires a word-aligned buffer for SD card transfers via DMA
     static __attribute__((aligned(sizeof(size_t)))) uint8_t decode_buffer[512] = {};
   #else

--- a/Marlin/src/feature/binary_stream.h
+++ b/Marlin/src/feature/binary_stream.h
@@ -39,7 +39,7 @@ inline int bs_read_serial(const serial_index_t index) {
 
 #if ENABLED(BINARY_STREAM_COMPRESSION)
   static heatshrink_decoder hsd;
-  #if ENABLED(SDIO_SUPPORT) && EITHER(ARDUINO_ARCH_STM32F1, STM32F1)
+  #if ENABLED(SDIO_SUPPORT)
     // STM32 requires a word-aligned buffer for SD card transfers via DMA
     static __attribute__((aligned(sizeof(size_t)))) uint8_t decode_buffer[512] = {};
   #else

--- a/Marlin/src/feature/binary_stream.h
+++ b/Marlin/src/feature/binary_stream.h
@@ -39,7 +39,7 @@ inline int bs_read_serial(const serial_index_t index) {
 
 #if ENABLED(BINARY_STREAM_COMPRESSION)
   static heatshrink_decoder hsd;
-  #if EITHER(ARDUINO_ARCH_STM32F1, STM32F1) && ENABLED(SDIO_SUPPORT)
+  #if ENABLED(SDIO_SUPPORT) && EITHER(ARDUINO_ARCH_STM32F1, STM32F1)
     // STM32 requires a word-aligned buffer for SD card transfers via DMA
     static __attribute__((aligned(sizeof(size_t)))) uint8_t decode_buffer[512] = {};
   #else


### PR DESCRIPTION
### Description

Using compressed BINARY_FILE_TRANSFER on new STM32duino env corrupted the data.

### Requirements

STM32duino based controller
SDIO_SUPPORT
BINARY_FILE_TRANSFER
test upload script such as "python3 transfer.py  -p /dev/ttyUSB0 -b 250000 -x 5000 -c TEST.GCO"
Run a diff on the sent file and the file on sdcard and they differ. 

Code has conditional ARDUINO_ARCH_STM32F1 block, which is not set on STM32duino but is needed.
Now conditional block also checks for STM32F1

### Benefits

Works as expected

### Configurations

eg. Standard Marlin Configs https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/Creality/Ender-3%20V2 + enable BINARY_FILE_TRANSFER

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/22119
Thanks to @p3p for pointing us at this cause.
