### PR TITLE
Include 'H' value in M412 report

### DIFF
--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -55,6 +55,10 @@ void GcodeSuite::M412() {
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM("Filament runout ");
     serialprintln_onoff(runout.enabled);
+    #if ENABLED(HOST_ACTION_COMMANDS)
+      SERIAL_ECHOPGM("Host action commands ");
+      serialprintln_onoff(runout.host_handling);
+    #endif
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       SERIAL_ECHOLNPAIR("Filament runout distance (mm): ", runout.runout_distance());
     #endif

--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -54,14 +54,15 @@ void GcodeSuite::M412() {
   else {
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM("Filament runout ");
-    serialprintln_onoff(runout.enabled);
-    #if ENABLED(HOST_ACTION_COMMANDS)
-      SERIAL_ECHOPGM("Host action commands ");
-      serialprintln_onoff(runout.host_handling);
-    #endif
+    serialprint_onoff(runout.enabled);
     #if HAS_FILAMENT_RUNOUT_DISTANCE
-      SERIAL_ECHOLNPAIR("Filament runout distance (mm): ", runout.runout_distance());
+      SERIAL_ECHOPAIR(" ; Distance ", runout.runout_distance(), "mm");
     #endif
+    #if ENABLED(HOST_ACTION_COMMANDS)
+      SERIAL_ECHOPGM(" ; Host handling ");
+      serialprint_onoff(runout.host_handling);
+    #endif
+    SERIAL_EOL();
   }
 }
 


### PR DESCRIPTION
### Description

M412 has S, H, D parameters to (S) Enable/Disable filament runout sensor, (H) Enable/Disable host action commands, (D) set the runout distance.
If you execute M412 without parameter, only display the actual value of S and D parameters (D is shown only if FILAMENT_RUNOUT_DISTANCE_MM is defined). 

Example 
 1) M412 S1 H1 D25
 2)  M412
      Filament runout ON
      Filament runout distance (mm): 25 (if FILAMENT_RUNOUT_DISTANCE_MM is defined)

With this modification:
 1) M412 S1 H1 D25
 2)  M412
      Filament runout ON
      Host action command  ON
      Filament runout distance (mm): 25 (if FILAMENT_RUNOUT_DISTANCE_MM is defined)

### Requirements
N/A

### Benefits

Get complete information of the actual values of M412's parameters. 

### Configurations

N/A

### Related Issues

N/A
