### PR TITLE
🍬Fix #22146 - mks_robin_e3 build issue

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -135,7 +135,7 @@ board_build.offset          = 0x5000
 board_build.encrypt         = Robin_e3.bin
 board_upload.offset_address = 0x08005000
 debug_tool                  = stlink
-extra_scripts               = ${env:STM32F103RC.extra_scripts}
+extra_scripts               = ${common_STM32F103RC.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_encrypt.py
 
 #


### PR DESCRIPTION
Fix #22146 - mks_robin_e3 build issue (pointing to the wrong base scripts).

The build fail because the right scripts aren't executed.