### PR TITLE
TFT encoder pin for BTT GTR

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -411,6 +411,7 @@
   #define TOUCH_MOSI_PIN             EXP1_08_PIN
   #define TOUCH_SCK_PIN              EXP1_06_PIN
   #define TOUCH_CS_PIN               EXP1_07_PIN
+  #define BTN_ENC                    EXP1_09_PIN
   #define BTN_EN1                    EXP2_08_PIN
   #define BTN_EN2                    EXP2_06_PIN
 


### PR DESCRIPTION
### Description

Define TFT encoder pin for BTT GTR.

### Benefits

BTT GTR with a compatible TFT that runs `TFT_COLOR_UI`, `TFT_LVGL_UI`, or `TFT_CLASSIC_UI` can use an encoder.

### Related Issues

Fixes #22161