### PR TITLE
Neopixel bugfix

### DIFF
--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -114,7 +114,6 @@ public:
       #if CONJOINED_NEOPIXEL
         adaneo2.show();
       #else
-        IF_DISABLED(NEOPIXEL2_SEPARATE, adaneo1.setPin(NEOPIXEL2_PIN));
         adaneo1.show();
         adaneo1.setPin(NEOPIXEL_PIN);
       #endif

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -55,57 +55,55 @@
 
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-  const uint8_t index = parser.intval('I', -1);
-#if ENABLED(NEOPIXEL2_SEPARATE)
-  uint8_t unit = -1;
-  uint8_t brightness = -1;
-  if (parser.seen('S'))
-  {
-    unit = parser.intval('S');
+    const uint8_t index = parser.intval('I', -1);
+    #if ENABLED(NEOPIXEL2_SEPARATE)
+      uint8_t unit = -1;
+      uint8_t brightness = -1;
+      if (parser.seen('S'))
+      {
+        unit = parser.intval('S');
+        if (unit  == 0){
+          brightness = neo.brightness();
+          neo.neoindex = index;
+        }
+        else if (unit == 1)
+        {
+          brightness = neo2.brightness();
+          neo2.neoindex = index;
+        }
+      }
+      else
+      {
+        brightness = neo.brightness();
+        neo.neoindex = neo2.neoindex = index;
+      }
+    #else
+      const uint8_t brightness = neo.brightness();
+      neo.neoindex = index;
+    #endif
+  #endif
+
+  const LEDColor color = LEDColor(
+      parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+      parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+      parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0 
+      OPTARG(HAS_WHITE_LED, parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0) 
+      OPTARG(NEOPIXEL_LED, parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : brightness));
+
+  #if ENABLED(NEOPIXEL2_SEPARATE)
     if (unit == 0)
     {
-      brightness = neo.brightness();
-      neo.neoindex = index;
+      leds.set_color(color);
+      return;
     }
     else if (unit == 1)
     {
-      brightness = neo2.brightness();
-      neo2.neoindex = index;
+      leds2.set_color(color);
+      return;
     }
-  }
-  else
-  {
-    brightness = neo.brightness();
-    neo.neoindex = neo2.neoindex = index;
-  }
-#else
-  const uint8_t brightness = neo.brightness();
-  neo.neoindex = index;
-#endif
-#endif
-  ndif
-#endif
 
-      const LEDColor color = LEDColor(
-          parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-          parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-          parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0 OPTARG(HAS_WHITE_LED, parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0) OPTARG(NEOPIXEL_LED, parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : brightness));
-
-#if ENABLED(NEOPIXEL2_SEPARATE)
-  if (unit == 0)
-  {
-    leds.set_color(color);
-    return;
-  }
-  else if (unit == 1)
-  {
-    leds2.set_color(color);
-    return;
-  }
-
-#endif
+  #endif
   //if S is not specified use both
-
   leds.set_color(color);
   leds2.set_color(color);
 }

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -55,30 +55,59 @@
 
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-    const uint8_t index = parser.intval('I', -1);
-    #if ENABLED(NEOPIXEL2_SEPARATE)
-      const uint8_t unit = parser.intval('S'),
-                    brightness = unit ? neo2.brightness() : neo.brightness();
-      *(unit ? &neo2.neoindex : &neo.neoindex) = index;
-    #else
-      const uint8_t brightness = neo.brightness();
+  const uint8_t index = parser.intval('I', -1);
+#if ENABLED(NEOPIXEL2_SEPARATE)
+  uint8_t unit = -1;
+  uint8_t brightness = -1;
+  if (parser.seen('S'))
+  {
+    unit = parser.intval('S');
+    if (unit == 0)
+    {
+      brightness = neo.brightness();
       neo.neoindex = index;
-    #endif
-  #endif
+    }
+    else if (unit == 1)
+    {
+      brightness = neo2.brightness();
+      neo2.neoindex = index;
+    }
+  }
+  else
+  {
+    brightness = neo.brightness();
+    neo.neoindex = neo2.neoindex = index;
+  }
+#else
+  const uint8_t brightness = neo.brightness();
+  neo.neoindex = index;
+#endif
+#endif
+  ndif
+#endif
 
-  const LEDColor color = LEDColor(
-    parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-    parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-    parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0
-    OPTARG(HAS_WHITE_LED, parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0)
-    OPTARG(NEOPIXEL_LED, parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : brightness)
-  );
+      const LEDColor color = LEDColor(
+          parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+          parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+          parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0 OPTARG(HAS_WHITE_LED, parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0) OPTARG(NEOPIXEL_LED, parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : brightness));
 
-  #if ENABLED(NEOPIXEL2_SEPARATE)
-    if (unit == 1) { leds2.set_color(color); return; }
-  #endif
+#if ENABLED(NEOPIXEL2_SEPARATE)
+  if (unit == 0)
+  {
+    leds.set_color(color);
+    return;
+  }
+  else if (unit == 1)
+  {
+    leds2.set_color(color);
+    return;
+  }
+
+#endif
+  //if S is not specified use both
 
   leds.set_color(color);
+  leds2.set_color(color);
 }
 
 #endif // HAS_COLOR_LEDS

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -52,30 +52,15 @@
  *   M150 I1 R       ; Set NEOPIXEL index 1 to red
  *   M150 S1 I1 R    ; Set SEPARATE index 1 to red
  */
-
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-    const uint8_t index = parser.intval('I', -1);
+    const int8_t index = parser.intval('I', -1);
     #if ENABLED(NEOPIXEL2_SEPARATE)
-      uint8_t unit = -1;
-      uint8_t brightness = -1;
-      if (parser.seen('S'))
-      {
-        unit = parser.intval('S');
-        if (unit  == 0){
-          brightness = neo.brightness();
-          neo.neoindex = index;
-        }
-        else if (unit == 1)
-        {
-          brightness = neo2.brightness();
-          neo2.neoindex = index;
-        }
-      }
-      else
-      {
-        brightness = neo.brightness();
-        neo.neoindex = neo2.neoindex = index;
+      int8_t brightness, unit = parser.intval('S', -1);
+      switch (unit) {
+        case -1: neo2.neoindex = index; // fall-thru
+        case  0:  neo.neoindex = index; brightness =  neo.brightness(); break;
+        case  1: neo2.neoindex = index; brightness = neo2.brightness(); break;
       }
     #else
       const uint8_t brightness = neo.brightness();
@@ -84,28 +69,23 @@ void GcodeSuite::M150() {
   #endif
 
   const LEDColor color = LEDColor(
-      parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-      parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-      parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0 
-      OPTARG(HAS_WHITE_LED, parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0) 
-      OPTARG(NEOPIXEL_LED, parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : brightness));
+    parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+    parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
+    parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0
+    OPTARG(HAS_WHITE_LED, parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0)
+    OPTARG(NEOPIXEL_LED, parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : brightness)
+  );
 
   #if ENABLED(NEOPIXEL2_SEPARATE)
-    if (unit == 0)
-    {
-      leds.set_color(color);
-      return;
+    switch (unit) {
+      case 0: leds.set_color(color); return;
+      case 1: leds2.set_color(color); return;
     }
-    else if (unit == 1)
-    {
-      leds2.set_color(color);
-      return;
-    }
-
   #endif
-  //if S is not specified use both
+
+  // If 'S' is not specified use both
   leds.set_color(color);
-  leds2.set_color(color);
+  TERN_(NEOPIXEL2_SEPARATE, leds2.set_color(color));
 }
 
 #endif // HAS_COLOR_LEDS


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
I had a need to control 2 separate LED/NeoPixel rings, so I tried using M150 S0 and M150 S1 to control them. But unfortunately, it did not work that great. I have made the changes so that they can now be controlled separately.

With **M150** you can control both(or in the future maybe all, if there are more). 
Example : 
**M150 R255** turns all on and red
**M150** turns all off

With **M150 S0** you can control the first LED/NeoPixel on its own
_Example :_ 
**M150 S0 R255** turns on ONLY the first LED/NeoPixel to red
**M150 S0** turns off ONLY the first LED/NeoPixel

With **M150 S1** you can control the first LED/NeoPixel on its own
_Example :_ 
**M150 S1 R255** turns on ONLY the second LED/NeoPixel to red
**M150 S1** turns off ONLY the second LED/NeoPixel

### Requirements

I am guessing any board that has more than one LED/NeoPixel pin exposed

### Benefits

This Fixes the issue where we had an 'S' parameter to control them separately but could not. So, now we can control both individually and extend it if we have the need in the future.

### Configurations

**_Specify your NeoPixel pins in your board pins.h file_**
#define NEOPIXEL_PIN                         PE11 // replace PE11 with your microcontroller pin used for LED 1
#define NEOPIXEL2_PIN                       PE12 // replace PE12 with your microcontroller pin used for LED 2
 
**_In Configuration.h_**
#define NEOPIXEL_LED
#define NEOPIXEL2_SEPARATE
