### PR TITLE
Fix IJK axis references and E stepper indices

### DIFF
--- a/Marlin/src/feature/dac/stepper_dac.cpp
+++ b/Marlin/src/feature/dac/stepper_dac.cpp
@@ -88,7 +88,9 @@ void StepperDAC::print_values() {
   SERIAL_ECHOPAIR_P(  SP_X_LBL, dac_perc(X_AXIS), PSTR(" ("), dac_amps(X_AXIS), PSTR(")"));
   SERIAL_ECHOPAIR_P(  SP_Y_LBL, dac_perc(Y_AXIS), PSTR(" ("), dac_amps(Y_AXIS), PSTR(")"));
   SERIAL_ECHOPAIR_P(  SP_Z_LBL, dac_perc(Z_AXIS), PSTR(" ("), dac_amps(Z_AXIS), PSTR(")"));
-  SERIAL_ECHOLNPAIR_P(SP_E_LBL, dac_perc(E_AXIS), PSTR(" ("), dac_amps(E_AXIS), PSTR(")"));
+  #if HAS_EXTRUDERS
+    SERIAL_ECHOLNPAIR_P(SP_E_LBL, dac_perc(E_AXIS), PSTR(" ("), dac_amps(E_AXIS), PSTR(")"));
+  #endif
 }
 
 void StepperDAC::commit_eeprom() {

--- a/Marlin/src/feature/dac/stepper_dac.cpp
+++ b/Marlin/src/feature/dac/stepper_dac.cpp
@@ -85,9 +85,13 @@ void StepperDAC::print_values() {
   if (!dac_present) return;
   SERIAL_ECHO_MSG("Stepper current values in % (Amps):");
   SERIAL_ECHO_START();
-  SERIAL_ECHOPAIR_P(  SP_X_LBL, dac_perc(X_AXIS), PSTR(" ("), dac_amps(X_AXIS), PSTR(")"));
-  SERIAL_ECHOPAIR_P(  SP_Y_LBL, dac_perc(Y_AXIS), PSTR(" ("), dac_amps(Y_AXIS), PSTR(")"));
-  SERIAL_ECHOPAIR_P(  SP_Z_LBL, dac_perc(Z_AXIS), PSTR(" ("), dac_amps(Z_AXIS), PSTR(")"));
+  SERIAL_ECHOPAIR_P(SP_X_LBL, dac_perc(X_AXIS), PSTR(" ("), dac_amps(X_AXIS), PSTR(")"));
+  #if HAS_Y_AXIS
+    SERIAL_ECHOPAIR_P(SP_Y_LBL, dac_perc(Y_AXIS), PSTR(" ("), dac_amps(Y_AXIS), PSTR(")"));
+  #endif
+  #if HAS_Z_AXIS
+    SERIAL_ECHOPAIR_P(SP_Z_LBL, dac_perc(Z_AXIS), PSTR(" ("), dac_amps(Z_AXIS), PSTR(")"));
+  #endif
   #if HAS_EXTRUDERS
     SERIAL_ECHOLNPAIR_P(SP_E_LBL, dac_perc(E_AXIS), PSTR(" ("), dac_amps(E_AXIS), PSTR(")"));
   #endif

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -33,31 +33,6 @@
 #include "../../../core/debug_out.h"
 
 /**
- * M906: report or set KVAL_HOLD which sets the maximum effective voltage provided by the
- *       PWMs to the steppers
- *
- * On L6474 this sets the TVAL register (same address).
- *
- * I - select which driver(s) to change on multi-driver axis
- *     0 - (default) all drivers on the axis or E0
- *     1 - monitor only X, Y, Z or E1
- *     2 - monitor only X2, Y2, Z2 or E2
- *     3 - monitor only Z3 or E3
- *     4 - monitor only Z4 or E4
- *     5 - monitor only E5
- * Xxxx, Yxxx, Zxxx, Exxx - axis to change (optional)
- *     L6474 - current in mA (4A max)
- *     All others - 0-255
- */
-
-/**
- * Sets KVAL_HOLD wich affects the current being driven through the stepper.
- *
- * L6470 is used in the STEP-CLOCK mode.  KVAL_HOLD is the only KVAL_xxx
- * that affects the effective voltage seen by the stepper.
- */
-
-/**
  * MACRO to fetch information on the items associated with current limiting
  * and maximum voltage output.
  *
@@ -220,6 +195,28 @@ void L64XX_report_current(L64XX &motor, const L64XX_axis_t axis) {
   }
 }
 
+/**
+ * M906: report or set KVAL_HOLD which sets the maximum effective voltage provided by the
+ *       PWMs to the steppers
+ *
+ * On L6474 this sets the TVAL register (same address).
+ *
+ * I - select which driver(s) to change on multi-driver axis
+ *     0 - (default) all drivers on the axis or E0
+ *     1 - monitor only X, Y, Z or E1
+ *     2 - monitor only X2, Y2, Z2 or E2
+ *     3 - monitor only Z3 or E3
+ *     4 - monitor only Z4 or E4
+ *     5 - monitor only E5
+ * Xxxx, Yxxx, Zxxx, Exxx - axis to change (optional)
+ *     L6474 - current in mA (4A max)
+ *     All others - 0-255
+ *
+ * Sets KVAL_HOLD wich affects the current being driven through the stepper.
+ *
+ * L6470 is used in the STEP-CLOCK mode.  KVAL_HOLD is the only KVAL_xxx
+ * that affects the effective voltage seen by the stepper.
+ */
 void GcodeSuite::M906() {
 
   L64xxManager.pause_monitor(true); // Keep monitor_driver() from stealing status

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -281,7 +281,7 @@ void GcodeSuite::M906() {
           break;
       #endif
 
-      #if HAS_EXTRUDERS
+      #if E_STEPPERS
         case E_AXIS: {
           const int8_t target_extruder = get_target_extruder_from_command();
           if (target_extruder < 0) return;

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -283,9 +283,9 @@ void GcodeSuite::M906() {
 
       #if E_STEPPERS
         case E_AXIS: {
-          const int8_t target_extruder = get_target_extruder_from_command();
-          if (target_extruder < 0) return;
-          switch (target_extruder) {
+          const int8_t target_e_stepper = get_target_e_stepper_from_command();
+          if (target_e_stepper < 0) return;
+          switch (target_e_stepper) {
             #if AXIS_IS_L64XX(E0)
               case 0: L6470_SET_KVAL_HOLD(E0); break;
             #endif

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -56,7 +56,12 @@
  */
 void GcodeSuite::M125() {
   // Initial retract before move to filament change position
-  const float retract = -ABS(parser.axisunitsval('L', E_AXIS, PAUSE_PARK_RETRACT_LENGTH));
+  const float retract =
+    #if HAS_EXTRUDERS
+      -ABS(parser.axisunitsval('L', E_AXIS, PAUSE_PARK_RETRACT_LENGTH));
+    #else
+      0;
+    #endif
 
   xyz_pos_t park_point = NOZZLE_PARK_POINT;
 

--- a/Marlin/src/gcode/feature/pause/M125.cpp
+++ b/Marlin/src/gcode/feature/pause/M125.cpp
@@ -56,12 +56,7 @@
  */
 void GcodeSuite::M125() {
   // Initial retract before move to filament change position
-  const float retract =
-    #if HAS_EXTRUDERS
-      -ABS(parser.axisunitsval('L', E_AXIS, PAUSE_PARK_RETRACT_LENGTH));
-    #else
-      0;
-    #endif
+  const float retract = TERN0(HAS_EXTRUDERS, -ABS(parser.axisunitsval('L', E_AXIS, PAUSE_PARK_RETRACT_LENGTH)));
 
   xyz_pos_t park_point = NOZZLE_PARK_POINT;
 

--- a/Marlin/src/gcode/feature/trinamic/M569.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M569.cpp
@@ -40,7 +40,7 @@ void tmc_set_stealthChop(TMC &st, const bool enable) {
   st.refresh_stepping_mode();
 }
 
-static void set_stealth_status(const bool enable, const int8_t target_extruder) {
+static void set_stealth_status(const bool enable, const int8_t target_e_stepper) {
   #define TMC_SET_STEALTH(Q) tmc_set_stealthChop(stepper##Q, enable)
 
   #if    X_HAS_STEALTHCHOP  || Y_HAS_STEALTHCHOP  || Z_HAS_STEALTHCHOP \
@@ -84,8 +84,8 @@ static void set_stealth_status(const bool enable, const int8_t target_extruder) 
 
       #if E_STEPPERS
         case E_AXIS: {
-          if (target_extruder < 0) return;
-          switch (target_extruder) {
+          if (target_e_stepper < 0) return;
+          switch (target_e_stepper) {
             TERN_(E0_HAS_STEALTHCHOP, case 0: TMC_SET_STEALTH(E0); break;)
             TERN_(E1_HAS_STEALTHCHOP, case 1: TMC_SET_STEALTH(E1); break;)
             TERN_(E2_HAS_STEALTHCHOP, case 2: TMC_SET_STEALTH(E2); break;)
@@ -133,7 +133,7 @@ static void say_stealth_status() {
  */
 void GcodeSuite::M569() {
   if (parser.seen('S'))
-    set_stealth_status(parser.value_bool(), get_target_extruder_from_command());
+    set_stealth_status(parser.value_bool(), get_target_e_stepper_from_command());
   else
     say_stealth_status();
 }

--- a/Marlin/src/gcode/feature/trinamic/M569.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M569.cpp
@@ -82,17 +82,19 @@ static void set_stealth_status(const bool enable, const int8_t target_extruder) 
         case K_AXIS: TMC_SET_STEALTH(K); break;
       #endif
 
-      #if HAS_EXTRUDERS
+      #if E_STEPPERS
         case E_AXIS: {
           if (target_extruder < 0) return;
-          OPTCODE(E0_HAS_STEALTHCHOP, else if (target_extruder == 0) TMC_SET_STEALTH(E0))
-          OPTCODE(E1_HAS_STEALTHCHOP, else if (target_extruder == 1) TMC_SET_STEALTH(E1))
-          OPTCODE(E2_HAS_STEALTHCHOP, else if (target_extruder == 2) TMC_SET_STEALTH(E2))
-          OPTCODE(E3_HAS_STEALTHCHOP, else if (target_extruder == 3) TMC_SET_STEALTH(E3))
-          OPTCODE(E4_HAS_STEALTHCHOP, else if (target_extruder == 4) TMC_SET_STEALTH(E4))
-          OPTCODE(E5_HAS_STEALTHCHOP, else if (target_extruder == 5) TMC_SET_STEALTH(E5))
-          OPTCODE(E6_HAS_STEALTHCHOP, else if (target_extruder == 6) TMC_SET_STEALTH(E6))
-          OPTCODE(E7_HAS_STEALTHCHOP, else if (target_extruder == 7) TMC_SET_STEALTH(E7))
+          switch (target_extruder) {
+            TERN_(E0_HAS_STEALTHCHOP, case 0: TMC_SET_STEALTH(E0); break;)
+            TERN_(E1_HAS_STEALTHCHOP, case 1: TMC_SET_STEALTH(E1); break;)
+            TERN_(E2_HAS_STEALTHCHOP, case 2: TMC_SET_STEALTH(E2); break;)
+            TERN_(E3_HAS_STEALTHCHOP, case 3: TMC_SET_STEALTH(E3); break;)
+            TERN_(E4_HAS_STEALTHCHOP, case 4: TMC_SET_STEALTH(E4); break;)
+            TERN_(E5_HAS_STEALTHCHOP, case 5: TMC_SET_STEALTH(E5); break;)
+            TERN_(E6_HAS_STEALTHCHOP, case 6: TMC_SET_STEALTH(E6); break;)
+            TERN_(E7_HAS_STEALTHCHOP, case 7: TMC_SET_STEALTH(E7); break;)
+          }
         } break;
       #endif
     }

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -104,9 +104,9 @@ void GcodeSuite::M906() {
 
       #if E_STEPPERS
         case E_AXIS: {
-          const int8_t target_extruder = get_target_extruder_from_command();
-          if (target_extruder < 0) return;
-          switch (target_extruder) {
+          const int8_t target_e_stepper = get_target_e_stepper_from_command();
+          if (target_e_stepper < 0) return;
+          switch (target_e_stepper) {
             #if AXIS_IS_TMC(E0)
               case 0: TMC_SET_CURRENT(E0); break;
             #endif

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -102,7 +102,7 @@ void GcodeSuite::M906() {
         case K_AXIS: TMC_SET_CURRENT(K); break;
       #endif
 
-      #if HAS_EXTRUDERS
+      #if E_STEPPERS
         case E_AXIS: {
           const int8_t target_extruder = get_target_extruder_from_command();
           if (target_extruder < 0) return;

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -267,9 +267,9 @@
           break;
         #if E_STEPPERS
           case E_AXIS: {
-            const int8_t target_extruder = get_target_extruder_from_command();
-            if (target_extruder < 0) return;
-            switch (target_extruder) {
+            const int8_t target_e_stepper = get_target_e_stepper_from_command();
+            if (target_e_stepper < 0) return;
+            switch (target_e_stepper) {
               TERN_(E0_HAS_STEALTHCHOP, case 0: TMC_SET_PWMTHRS_E(0); break;)
               TERN_(E1_HAS_STEALTHCHOP, case 1: TMC_SET_PWMTHRS_E(1); break;)
               TERN_(E2_HAS_STEALTHCHOP, case 2: TMC_SET_PWMTHRS_E(2); break;)

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -265,20 +265,22 @@
           TERN_(Z3_HAS_STEALTCHOP, if (index == 0 || index == 3) TMC_SET_PWMTHRS(Z,Z3));
           TERN_(Z4_HAS_STEALTCHOP, if (index == 0 || index == 4) TMC_SET_PWMTHRS(Z,Z4));
           break;
-        case E_AXIS: {
-          #if E_STEPPERS
+        #if E_STEPPERS
+          case E_AXIS: {
             const int8_t target_extruder = get_target_extruder_from_command();
             if (target_extruder < 0) return;
-            TERN_(E0_HAS_STEALTHCHOP, else if (target_extruder == 0) TMC_SET_PWMTHRS_E(0));
-            TERN_(E1_HAS_STEALTHCHOP, else if (target_extruder == 1) TMC_SET_PWMTHRS_E(1));
-            TERN_(E2_HAS_STEALTHCHOP, else if (target_extruder == 2) TMC_SET_PWMTHRS_E(2));
-            TERN_(E3_HAS_STEALTHCHOP, else if (target_extruder == 3) TMC_SET_PWMTHRS_E(3));
-            TERN_(E4_HAS_STEALTHCHOP, else if (target_extruder == 4) TMC_SET_PWMTHRS_E(4));
-            TERN_(E5_HAS_STEALTHCHOP, else if (target_extruder == 5) TMC_SET_PWMTHRS_E(5));
-            TERN_(E6_HAS_STEALTHCHOP, else if (target_extruder == 6) TMC_SET_PWMTHRS_E(6));
-            TERN_(E7_HAS_STEALTHCHOP, else if (target_extruder == 7) TMC_SET_PWMTHRS_E(7));
-          #endif // E_STEPPERS
-        } break;
+            switch (target_extruder) {
+              TERN_(E0_HAS_STEALTHCHOP, case 0: TMC_SET_PWMTHRS_E(0); break;)
+              TERN_(E1_HAS_STEALTHCHOP, case 1: TMC_SET_PWMTHRS_E(1); break;)
+              TERN_(E2_HAS_STEALTHCHOP, case 2: TMC_SET_PWMTHRS_E(2); break;)
+              TERN_(E3_HAS_STEALTHCHOP, case 3: TMC_SET_PWMTHRS_E(3); break;)
+              TERN_(E4_HAS_STEALTHCHOP, case 4: TMC_SET_PWMTHRS_E(4); break;)
+              TERN_(E5_HAS_STEALTHCHOP, case 5: TMC_SET_PWMTHRS_E(5); break;)
+              TERN_(E6_HAS_STEALTHCHOP, case 6: TMC_SET_PWMTHRS_E(6); break;)
+              TERN_(E7_HAS_STEALTHCHOP, case 7: TMC_SET_PWMTHRS_E(7); break;)
+            }
+          } break;
+        #endif // E_STEPPERS
       }
     }
 

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -180,19 +180,11 @@
     SERIAL_ECHOPGM("FromStp:");
     get_cartesian_from_steppers();  // writes 'cartes' (with forward kinematics)
     xyze_pos_t from_steppers = LOGICAL_AXIS_ARRAY(
-      #if HAS_EXTRUDERS
-        planner.get_axis_position_mm(E_AXIS),
-      #endif
+      planner.get_axis_position_mm(E_AXIS),
       cartes.x, cartes.y, cartes.z,
-      #if LINEAR_AXES >= 4
-        planner.get_axis_position_mm(I_AXIS),
-      #endif
-      #if LINEAR_AXES >= 5
-        planner.get_axis_position_mm(J_AXIS),
-      #endif
-      #if LINEAR_AXES >= 6
-        planner.get_axis_position_mm(K_AXIS)
-      #endif
+      planner.get_axis_position_mm(I_AXIS),
+      planner.get_axis_position_mm(J_AXIS),
+      planner.get_axis_position_mm(K_AXIS)
     );
     report_all_axis_pos(from_steppers);
 

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -180,11 +180,19 @@
     SERIAL_ECHOPGM("FromStp:");
     get_cartesian_from_steppers();  // writes 'cartes' (with forward kinematics)
     xyze_pos_t from_steppers = LOGICAL_AXIS_ARRAY(
-      planner.get_axis_position_mm(E_AXIS),
+      #if HAS_EXTRUDERS
+        planner.get_axis_position_mm(E_AXIS),
+      #endif
       cartes.x, cartes.y, cartes.z,
-      planner.get_axis_position_mm(I_AXIS),
-      planner.get_axis_position_mm(J_AXIS),
-      planner.get_axis_position_mm(K_AXIS)
+      #if LINEAR_AXES >= 4
+        planner.get_axis_position_mm(I_AXIS),
+      #endif
+      #if LINEAR_AXES >= 5
+        planner.get_axis_position_mm(J_AXIS),
+      #endif
+      #if LINEAR_AXES >= 6
+        planner.get_axis_position_mm(K_AXIS)
+      #endif
     );
     report_all_axis_pos(from_steppers);
 
@@ -216,10 +224,12 @@ void GcodeSuite::M114() {
       report_current_position_detail();
       return;
     }
-    if (parser.seen_test('E')) {
-      SERIAL_ECHOLNPAIR("Count E:", stepper.position(E_AXIS));
-      return;
-    }
+    #if HAS_EXTRUDERS
+      if (parser.seen_test('E')) {
+        SERIAL_ECHOLNPAIR("Count E:", stepper.position(E_AXIS));
+        return;
+      }
+    #endif
   #endif
 
   #if ENABLED(M114_REALTIME)

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -311,7 +311,7 @@ public:
     }
 
     static inline float axis_unit_factor(const AxisEnum axis) {
-      return (axis >= E_AXIS && volumetric_enabled ? volumetric_unit_factor : linear_unit_factor);
+      return (TERN_(HAS_EXTRUDERS, axis >= E_AXIS && volumetric_enabled ? volumetric_unit_factor :) linear_unit_factor);
     }
 
     static inline float linear_value_to_mm(const_float_t v)                  { return v * linear_unit_factor; }

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -311,7 +311,13 @@ public:
     }
 
     static inline float axis_unit_factor(const AxisEnum axis) {
-      return (TERN_(HAS_EXTRUDERS, axis >= E_AXIS && volumetric_enabled ? volumetric_unit_factor :) linear_unit_factor);
+      return (
+        #if HAS_EXTRUDERS
+          axis >= E_AXIS && volumetric_enabled ? volumetric_unit_factor : linear_unit_factor
+        #else
+          linear_unit_factor
+        #endif
+      );
     }
 
     static inline float linear_value_to_mm(const_float_t v)                  { return v * linear_unit_factor; }

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -267,7 +267,13 @@ void report_current_position_projected() {
     get_cartesian_from_steppers();
     const xyz_pos_t lpos = cartes.asLogical();
     SERIAL_ECHOPAIR(
-      "X:", lpos.x, " Y:", lpos.y, " Z:", lpos.z
+      "X:", lpos.x
+      #if HAS_Y_AXIS
+        , " Y:", lpos.y
+      #endif
+      #if HAS_Z_AXIS
+        , " Z:", lpos.z
+      #endif
       #if HAS_EXTRUDERS
         , " E:", current_position.e
       #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -266,7 +266,12 @@ void report_current_position_projected() {
 
     get_cartesian_from_steppers();
     const xyz_pos_t lpos = cartes.asLogical();
-    SERIAL_ECHOPAIR("X:", lpos.x, " Y:", lpos.y, " Z:", lpos.z, " E:", current_position.e);
+    SERIAL_ECHOPAIR(
+      "X:", lpos.x, " Y:", lpos.y, " Z:", lpos.z
+      #if HAS_EXTRUDERS
+        , " E:", current_position.e
+      #endif
+    );
 
     stepper.report_positions();
     #if IS_SCARA
@@ -929,7 +934,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
     float cartesian_mm = diff.magnitude();
 
     // If the move is very short, check the E move distance
-    if (UNEAR_ZERO(cartesian_mm)) cartesian_mm = ABS(diff.e);
+    TERN_(HAS_EXTRUDERS, if (UNEAR_ZERO(cartesian_mm)) cartesian_mm = ABS(diff.e));
 
     // No E move either? Game over.
     if (UNEAR_ZERO(cartesian_mm)) return true;
@@ -1008,7 +1013,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
       // If the move is very short, check the E move distance
       // No E move either? Game over.
       float cartesian_mm = diff.magnitude();
-      if (UNEAR_ZERO(cartesian_mm)) cartesian_mm = ABS(diff.e);
+      TERN_(HAS_EXTRUDERS, if (UNEAR_ZERO(cartesian_mm)) cartesian_mm = ABS(diff.e));
       if (UNEAR_ZERO(cartesian_mm)) return;
 
       // The length divided by the segment size


### PR DESCRIPTION
### Description

Fixes some references to `E_AXIS` that break compilation with `#define EXTRUDERS 0`, as well as the new linear axes i/j/k.

Also includes some cleanup/standardization for multiple E steppers in M569, M906, and M911-914.

### Requirements

EXTRUDERS 0 for the E_AXIS stuff, LINEAR_AXES < 4.

### Benefits

Fixes some edge cases in compilation.

### Configurations

See #22143

### Related Issues

Fixes #22143