### PR TITLE
Fix compact sensitive pins array

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -282,19 +282,22 @@ bool wait_for_heatup = true;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wnarrowing"
 
-#ifdef RUNTIME_ONLY_ANALOG_TO_DIGITAL
-  static const pin_t sensitive_pins[] PROGMEM = { SENSITIVE_PINS };
-#else
+#ifndef RUNTIME_ONLY_ANALOG_TO_DIGITAL
   template <pin_t ...D>
-  constexpr pin_t OnlyPins<-2, D...>::table[sizeof...(D)];
-  #define sensitive_pins OnlyPins<SENSITIVE_PINS>::table
+  constexpr pin_t OnlyPins<_SP_END, D...>::table[sizeof...(D)];
 #endif
 
 bool pin_is_protected(const pin_t pin) {
-  LOOP_L_N(i, COUNT(sensitive_pins)) {
-    pin_t sensitive_pin;
-    memcpy_P(&sensitive_pin, &sensitive_pins[i], sizeof(pin_t));
-    if (pin == sensitive_pin) return true;
+  #ifdef RUNTIME_ONLY_ANALOG_TO_DIGITAL
+    static const pin_t sensitive_pins[] PROGMEM = { SENSITIVE_PINS };
+    const size_t pincount = COUNT(sensitive_pins);
+  #else
+    static constexpr size_t pincount = OnlyPins<SENSITIVE_PINS>::size;
+    static const pin_t (&sensitive_pins)[pincount] PROGMEM = OnlyPins<SENSITIVE_PINS>::table;
+  #endif
+  LOOP_L_N(i, pincount) {
+    const pin_t * const pptr = &sensitive_pins[i];
+    if (pin == (sizeof(pin_t) == 2 ? (pin_t)pgm_read_word(pptr) : (pin_t)pgm_read_byte(pptr))) return true;
   }
   return false;
 }

--- a/Marlin/src/pins/sensitive_pins.h
+++ b/Marlin/src/pins/sensitive_pins.h
@@ -882,7 +882,7 @@
 
   // Remove -2 from the front, emit the rest, cease propagation
   template<pin_t ...D>
-  struct OnlyPins<_SP_END, D...> { static constexpr pin_t table[sizeof...(D)] PROGMEM = { D... }; };
+  struct OnlyPins<_SP_END, D...> { static constexpr size_t size = sizeof...(D); static constexpr pin_t table[sizeof...(D)] PROGMEM = { D... }; };
 #endif
 
 #define SENSITIVE_PINS \


### PR DESCRIPTION
The sensitive pins array is reduced to a minimum with some `constexpr` template structs. The code as it is has been tested and seems to work fine for me, but some reports indicate that the recent sensitive pins changes are leading to instability. So this PR reworks the sensitive pins code in the hopes that it will clear up the issue.