### PR TITLE
Update stm32f4.ini

### DIFF
--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -238,7 +238,7 @@ build_flags       = ${stm_flash_drive.build_flags}
 [env:BIGTREE_OCTOPUS_V1]
 platform          = ${common_stm32.platform}
 extends           = common_stm32
-board             = marlin_BigTree_octopus_v1
+board             = marlin_BigTree_Octopus_v1
 extra_scripts     = ${common.extra_scripts}
     pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
 build_flags       = ${common_stm32.build_flags}


### PR DESCRIPTION
board name and file name do not match and prevents building for Octopus.

### Description
Build for BIGTREE_OCTOPUS_V1 environments fail with 

```> Executing task: platformio run --environment BIGTREE_OCTOPUS_V1 <

Processing BIGTREE_OCTOPUS_V1 (platform: ststm32@~12.1; board: marlin_BigTree_octopus_v1; framework: arduino)
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Error: Unknown board ID 'marlin_BigTree_octopus_v1'
The terminal process "platformio 'run', '--environment', 'BIGTREE_OCTOPUS_V1'" terminated with exit code: 1.```
```
### Requirements

needs to be a BIGTREE_OCTOPUS_V1 board (usb or not extend on it)

### Benefits

Build continues as expected

### Configurations

defaults will do

### Related Issues

not that I am aware of

