### PR TITLE
Update TMC SPI endstops comment

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2892,7 +2892,7 @@
    *
    * It is recommended to set HOMING_BUMP_MM to { 0, 0, 0 }.
    *
-   * SPI_ENDSTOPS  *** Beta feature! *** TMC2130 Only ***
+   * SPI_ENDSTOPS  *** Beta feature! *** TMC2130/TMC5160 Only ***
    * Poll the driver through SPI to determine load when homing.
    * Removes the need for a wire from DIAG1 to an endstop pin.
    *


### PR DESCRIPTION
### Description

SPI endstops work with TMC2130s and TMC5160s.

### Benefits

Clearer documentation.

### Related Issues

See https://github.com/MarlinFirmware/Configurations/pull/529 for the sister PR to update configs as well.