### PR TITLE
move power off sound to better place

### DIFF
--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -33,6 +33,10 @@
 #include "../module/stepper/indirection.h"
 #include "../MarlinCore.h"
 
+#if ENABLED(PS_OFF_SOUND)
+  #include "../libs/buzzer.h"
+#endif
+
 #if defined(PSU_POWERUP_GCODE) || defined(PSU_POWEROFF_GCODE)
   #include "../gcode/gcode.h"
 #endif
@@ -133,6 +137,11 @@ void Power::power_off() {
     #ifdef PSU_POWEROFF_GCODE
       GcodeSuite::process_subcommands_now_P(PSTR(PSU_POWEROFF_GCODE));
     #endif
+
+    #if ENABLED(PS_OFF_SOUND)
+      BUZZ(1000, 659);
+    #endif
+
     PSU_PIN_OFF();
   }
 }

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -101,10 +101,6 @@ void GcodeSuite::M81() {
     #endif
   #endif
 
-  #if ENABLED(PS_OFF_SOUND)
-    BUZZ(1000, 659);
-  #endif
-
   safe_delay(1000); // Wait 1 second before switching off
 
   #if HAS_SUICIDE


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

M80_M81.cpp is not a good place to play power off sound, move to power.cpp, then to auto power off can use this feature.


### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
