### PR TITLE
 SKR E3 Turbo support Ender3 V2 Display 

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -202,20 +202,14 @@
 #define EXP1_10_PIN                        P2_08
 
 #if ENABLED(DWIN_CREALITY_LCD)
-//You have to rewire Displaycable, TX = P0_15, RX = P0_16 with LCD_SERIAL_PORT 1
+  #error "DWIN_CREALITY_LCD requires a custom cable with TX = P0_15, RX = P0_16, and LCD_SERIAL_PORT 1. Comment out this line to continue."
 
+  #define BEEPER_PIN                 EXP1_10_PIN
+  #define BTN_EN1                    EXP1_03_PIN
+  #define BTN_EN2                    EXP1_04_PIN
+  #define BTN_ENC                    EXP1_06_PIN
 
-    #define BEEPER_PIN               EXP1_10_PIN
-    #define BTN_EN1                  EXP1_03_PIN
-    #define BTN_EN2                  EXP1_04_PIN
-    #define BTN_ENC                  EXP1_06_PIN
-
-
-
-  #endif
-  
-
-#if HAS_WIRED_LCD
+#elif HAS_WIRED_LCD
 
   #if ENABLED(CR10_STOCKDISPLAY)
 

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -201,6 +201,20 @@
 #define EXP1_09_PIN                        P0_16
 #define EXP1_10_PIN                        P2_08
 
+#if ENABLED(DWIN_CREALITY_LCD)
+//You have to rewire Displaycable, TX = P0_15, RX = P0_16 with LCD_SERIAL_PORT 1
+
+
+    #define BEEPER_PIN               EXP1_10_PIN
+    #define BTN_EN1                  EXP1_03_PIN
+    #define BTN_EN2                  EXP1_04_PIN
+    #define BTN_ENC                  EXP1_06_PIN
+
+
+
+  #endif
+  
+
 #if HAS_WIRED_LCD
 
   #if ENABLED(CR10_STOCKDISPLAY)


### PR DESCRIPTION
 Hello
Here Pin update to support SKR E3 Turbo with original Ender3 v2 Display.
but you have still to rewire displaycable.
![20210618_201021](https://user-images.githubusercontent.com/57866234/123517613-4116ee80-d6a2-11eb-8bc8-5a6f495778d4.jpg)


i get a warning when compiling
`Marlin\src\lcd\dwin\e3v2\dwin.cpp:497:71: warning: use of 'auto' in parameter declaration only available with '-fconcepts' 497 | inline bool Apply_Encoder(const ENCODER_DiffState &encoder_diffState, auto &valref) { |`

maybe someone can fix