### PR TITLE
add power off sound support without AUTO_POWER_CONTROL

### DIFF
--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -91,7 +91,11 @@ extern bool wait_for_heatup;
     #define PSU_OFF_SOON() powerManager.power_off_soon()
   #else
     #define PSU_ON()     PSU_PIN_ON()
-    #define PSU_OFF()    PSU_PIN_OFF()
+    #if ENABLED(PS_OFF_SOUND)
+      #define PSU_OFF()  do{ BUZZ(1000, 659); PSU_PIN_OFF(); } while(0)
+    #else
+      #define PSU_OFF()  PSU_PIN_OFF()
+    #endif
     #define PSU_OFF_SOON PSU_OFF
   #endif
 #endif

--- a/Marlin/src/MarlinCore.h
+++ b/Marlin/src/MarlinCore.h
@@ -92,7 +92,7 @@ extern bool wait_for_heatup;
   #else
     #define PSU_ON()     PSU_PIN_ON()
     #if ENABLED(PS_OFF_SOUND)
-      #define PSU_OFF()  do{ BUZZ(1000, 659); PSU_PIN_OFF(); } while(0)
+      #define PSU_OFF()  do{ BUZZ(1000, 659); PSU_PIN_OFF(); }while(0)
     #else
       #define PSU_OFF()  PSU_PIN_OFF()
     #endif


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

When AUTO_POWER_CONTROL not enabled, PSU_OFF_SOUND not working, this fix that issue.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
