### PR TITLE
add missing preprocessor checks to Power::is_power_needed()

### DIFF
--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -62,11 +62,13 @@ bool Power::is_power_needed() {
     if (controllerFan.state()) return true;
   #endif
 
-  if (TERN0(AUTO_POWER_CHAMBER_FAN, thermalManager.chamberfan_speed))
-    return true;
+  #if ENABLED(AUTO_POWER_CHAMBER_FAN)
+    if (thermalManager.chamberfan_speed) return true;
+  #endif
 
-  if (TERN0(AUTO_POWER_COOLER_FAN, thermalManager.coolerfan_speed))
-    return true;
+  #if ENABLED(AUTO_POWER_COOLER_FAN)
+    if (thermalManager.coolerfan_speed) return true;
+  #endif
 
   // If any of the drivers or the bed are enabled...
   if (X_ENABLE_READ() == X_ENABLE_ON || Y_ENABLE_READ() == Y_ENABLE_ON || Z_ENABLE_READ() == Z_ENABLE_ON
@@ -85,18 +87,23 @@ bool Power::is_power_needed() {
     #endif
   ) return true;
 
-  HOTEND_LOOP() if (thermalManager.degTargetHotend(e) > 0 || thermalManager.temp_hotend[e].soft_pwm_amount > 0) return true;
-  if (TERN0(HAS_HEATED_BED, thermalManager.degTargetBed() > 0 || thermalManager.temp_bed.soft_pwm_amount > 0)) return true;
+  #if HAS_HOTEND
+    HOTEND_LOOP() if (thermalManager.degTargetHotend(e) > 0 || thermalManager.temp_hotend[e].soft_pwm_amount > 0) return true;
+  #endif
 
-  #if HAS_HOTEND && AUTO_POWER_E_TEMP
+  #if HAS_HEATED_BED
+  if (thermalManager.degTargetBed() > 0 || thermalManager.temp_bed.soft_pwm_amount > 0) return true;
+  #endif
+
+  #if HAS_HOTEND && ENABLED(AUTO_POWER_E_TEMP)
     HOTEND_LOOP() if (thermalManager.degHotend(e) >= (AUTO_POWER_E_TEMP)) return true;
   #endif
 
-  #if HAS_HEATED_CHAMBER && AUTO_POWER_CHAMBER_TEMP
+  #if HAS_HEATED_CHAMBER && ENABLED(AUTO_POWER_CHAMBER_TEMP)
     if (thermalManager.degChamber() >= (AUTO_POWER_CHAMBER_TEMP)) return true;
   #endif
 
-  #if HAS_COOLER && AUTO_POWER_COOLER_TEMP
+  #if HAS_COOLER && ENABLED(AUTO_POWER_COOLER_TEMP)
     if (thermalManager.degCooler() >= (AUTO_POWER_COOLER_TEMP)) return true;
   #endif
 

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -62,13 +62,11 @@ bool Power::is_power_needed() {
     if (controllerFan.state()) return true;
   #endif
 
-  #if ENABLED(AUTO_POWER_CHAMBER_FAN)
-    if (thermalManager.chamberfan_speed) return true;
-  #endif
+  if (TERN0(AUTO_POWER_CHAMBER_FAN, thermalManager.chamberfan_speed))
+    return true;
 
-  #if ENABLED(AUTO_POWER_COOLER_FAN)
-    if (thermalManager.coolerfan_speed) return true;
-  #endif
+  if (TERN0(AUTO_POWER_COOLER_FAN, thermalManager.coolerfan_speed))
+    return true;
 
   // If any of the drivers or the bed are enabled...
   if (X_ENABLE_READ() == X_ENABLE_ON || Y_ENABLE_READ() == Y_ENABLE_ON || Z_ENABLE_READ() == Z_ENABLE_ON
@@ -91,19 +89,17 @@ bool Power::is_power_needed() {
     HOTEND_LOOP() if (thermalManager.degTargetHotend(e) > 0 || thermalManager.temp_hotend[e].soft_pwm_amount > 0) return true;
   #endif
 
-  #if HAS_HEATED_BED
-  if (thermalManager.degTargetBed() > 0 || thermalManager.temp_bed.soft_pwm_amount > 0) return true;
-  #endif
+  if (TERN0(HAS_HEATED_BED, thermalManager.degTargetBed() > 0 || thermalManager.temp_bed.soft_pwm_amount > 0)) return true;
 
-  #if HAS_HOTEND && ENABLED(AUTO_POWER_E_TEMP)
+  #if HAS_HOTEND && AUTO_POWER_E_TEMP
     HOTEND_LOOP() if (thermalManager.degHotend(e) >= (AUTO_POWER_E_TEMP)) return true;
   #endif
 
-  #if HAS_HEATED_CHAMBER && ENABLED(AUTO_POWER_CHAMBER_TEMP)
+  #if HAS_HEATED_CHAMBER && AUTO_POWER_CHAMBER_TEMP
     if (thermalManager.degChamber() >= (AUTO_POWER_CHAMBER_TEMP)) return true;
   #endif
 
-  #if HAS_COOLER && ENABLED(AUTO_POWER_COOLER_TEMP)
+  #if HAS_COOLER && AUTO_POWER_COOLER_TEMP
     if (thermalManager.degCooler() >= (AUTO_POWER_COOLER_TEMP)) return true;
   #endif
 


### PR DESCRIPTION
### Description

Power::is_power_needed() fails compilation if `#define EXTRUDERS 0`; add check around `HOTEND_LOOP()` and normalize the rest of the checks.

### Requirements

AUTO_POWER_CONTROL without any hotends/extruders.

### Benefits

Fixes a bug.

### Configurations

<details>
<summary>Full config diff(s)</summary>

```diff
diff --git a/Marlin/Configuration.h b/Marlin/Configuration.h
index d3221f80de..326938a498 100644
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -102,7 +102,7 @@
  *
  * :[-1, 0, 1, 2, 3, 4, 5, 6, 7]
  */
-#define SERIAL_PORT 0
+#define SERIAL_PORT -1
 
 /**
  * Serial Port Baud Rate
@@ -115,7 +115,7 @@
  *
  * :[2400, 9600, 19200, 38400, 57600, 115200, 250000, 500000, 1000000]
  */
-#define BAUDRATE 250000
+#define BAUDRATE 115200
 //#define BAUD_RATE_GCODE     // Enable G-code M575 to set the baud rate
 
 /**
@@ -139,7 +139,7 @@
 
 // Choose the name from boards.h that matches your setup
 #ifndef MOTHERBOARD
-  #define MOTHERBOARD BOARD_RAMPS_14_EFB
+  #define MOTHERBOARD BOARD_BTT_SKR_V2_0_REV_B
 #endif
 
 // Name displayed in the LCD "Ready" message and Info menu
@@ -192,7 +192,7 @@
 
 // This defines the number of extruders
 // :[0, 1, 2, 3, 4, 5, 6, 7, 8]
-#define EXTRUDERS 1
+#define EXTRUDERS 0
 
 // Generally expected filament diameter (1.75, 2.85, 3.0, ...). Used for Volumetric, Filament Width Sensor, etc.
 #define DEFAULT_NOMINAL_FILAMENT_DIA 1.75
@@ -362,7 +362,7 @@
  * Enable and connect the power supply to the PS_ON_PIN.
  * Specify whether the power supply is active HIGH or active LOW.
  */
-//#define PSU_CONTROL
+#define PSU_CONTROL
 //#define PSU_NAME "Power Supply"
 
 #if ENABLED(PSU_CONTROL)
@@ -376,7 +376,7 @@
   //#define PSU_POWERUP_GCODE  "M355 S1"  // G-code to run after power-on (e.g., case light on)
   //#define PSU_POWEROFF_GCODE "M355 S0"  // G-code to run before power-off (e.g., case light off)
 
-  //#define AUTO_POWER_CONTROL      // Enable automatic control of the PS_ON pin
+  #define AUTO_POWER_CONTROL      // Enable automatic control of the PS_ON pin
   #if ENABLED(AUTO_POWER_CONTROL)
     #define AUTO_POWER_FANS         // Turn on PSU if fans need power
     #define AUTO_POWER_E_FANS
@@ -462,7 +462,7 @@
  *   998 : Dummy Table that ALWAYS reads 25°C or the temperature defined below.
  *   999 : Dummy Table that ALWAYS reads 100°C or the temperature defined below.
  */
-#define TEMP_SENSOR_0 1
+#define TEMP_SENSOR_0 0
 #define TEMP_SENSOR_1 0
 #define TEMP_SENSOR_2 0
 #define TEMP_SENSOR_3 0
@@ -473,7 +473,7 @@
 #define TEMP_SENSOR_BED 0
 #define TEMP_SENSOR_PROBE 0
 #define TEMP_SENSOR_CHAMBER 0
-#define TEMP_SENSOR_COOLER 0
+#define TEMP_SENSOR_COOLER 1
 #define TEMP_SENSOR_REDUNDANT 0
 
 // Dummy thermistor constant temperature readings, for use with 998 and 999
@@ -897,18 +897,18 @@
  * Override with M92
  *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400, 500 }
+#define DEFAULT_AXIS_STEPS_PER_UNIT   { 80, 80, 400 }
 
 /**
  * Default Max Feed Rate (mm/s)
  * Override with M203
  *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_FEEDRATE          { 300, 300, 5, 25 }
+#define DEFAULT_MAX_FEEDRATE          { 300, 300, 5 }
 
 //#define LIMITED_MAX_FR_EDITING        // Limit edit via M203 or LCD to DEFAULT_MAX_FEEDRATE * 2
 #if ENABLED(LIMITED_MAX_FR_EDITING)
-  #define MAX_FEEDRATE_EDIT_VALUES    { 600, 600, 10, 50 } // ...or, set your own edit limits
+  #define MAX_FEEDRATE_EDIT_VALUES    { 600, 600, 10 } // ...or, set your own edit limits
 #endif
 
 /**
@@ -917,11 +917,11 @@
  * Override with M201
  *                                      X, Y, Z [, I [, J [, K]]], E0 [, E1[, E2...]]
  */
-#define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 100, 10000 }
+#define DEFAULT_MAX_ACCELERATION      { 3000, 3000, 100 }
 
 //#define LIMITED_MAX_ACCEL_EDITING     // Limit edit via M201 or LCD to DEFAULT_MAX_ACCELERATION * 2
 #if ENABLED(LIMITED_MAX_ACCEL_EDITING)
-  #define MAX_ACCEL_EDIT_VALUES       { 6000, 6000, 200, 20000 } // ...or, set your own edit limits
+  #define MAX_ACCEL_EDIT_VALUES       { 6000, 6000, 200 } // ...or, set your own edit limits
 #endif
 
 /**
diff --git a/Marlin/Configuration_adv.h b/Marlin/Configuration_adv.h
index a13df514b0..74e4f2dc41 100644
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -926,7 +926,7 @@
 
 // @section motion
 
-#define AXIS_RELATIVE_MODES { false, false, false, false }
+#define AXIS_RELATIVE_MODES { false, false, false }
 
 // Add a Duplicate option for well-separated conjoined nozzles
 //#define MULTI_NOZZLE_DUPLICATION
@@ -3280,7 +3280,9 @@
  * See https://marlinfw.org/docs/configuration/laser_spindle.html for more config details.
  */
 //#define SPINDLE_FEATURE
-//#define LASER_FEATURE
+#define SPINDLE_LASER_ENA_PIN 11
+#define SPINDLE_LASER_PWM_PIN 12
+#define LASER_FEATURE
 #if EITHER(SPINDLE_FEATURE, LASER_FEATURE)
   #define SPINDLE_LASER_ACTIVE_STATE    LOW    // Set to "HIGH" if the on/off function is active HIGH
   #define SPINDLE_LASER_PWM             true   // Set to "true" if your controller supports setting the speed/power
diff --git a/platformio.ini b/platformio.ini
index f55f5f5a93..7849e1a5ed 100644
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = mega2560
+default_envs = BIGTREE_SKR_2
 include_dir  = Marlin
 extra_configs =
     ini/avr.ini
```
</details>

### Related Issues

Fixes #22235