### PR TITLE
Predefining the Z_MIN_PROBE_PIN as the default PC14

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -49,6 +49,10 @@
   #define PS_ON_PIN                        PC13  // Power Supply Control
 #endif
 
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                  PC14  // Z-Probe pin
+#endif
+
 #define FAN1_PIN                           PC7
 
 #ifndef CONTROLLER_FAN_PIN


### PR DESCRIPTION
### Description

The default z-probe pin is not defined yet for this board, if using the default Z-PROBE port available on the board:

https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3/blob/master/hardware/BTT%20SKR%20MINI%20E3%20V2.0/Hardware/BTT%20SKR%20MINI%20E3%20V2.0-PIN.pdf


### Requirements

Z-probe hardware connected to the default port for it.

### Benefits

Avoiding the need to configure manually the pin on each SKR Mini E3 V2.x board setup, on the 'configuration.h' file.

### Configurations

```
#define BLTOUCH 
//#define Z_MIN_PROBE_PIN 32 // Pin 32 is the RAMPS default
```

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
