### PR TITLE
Fix PTC/BTC float checks from #22130

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -593,24 +593,29 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
   #endif
 
   #ifdef PTC_SAMPLE_START
-    constexpr int _ptc_sample_start = PTC_SAMPLE_START;
-    static_assert(_test_ptc_sample_start != PTC_SAMPLE_START, "PTC_SAMPLE_START must be a whole number.");
+    constexpr auto _ptc_sample_start = PTC_SAMPLE_START;
+    constexpr decltype(_ptc_sample_start) _test_ptc_sample_start = 12.3f;
+    static_assert(_test_ptc_sample_start != 12.3f, "PTC_SAMPLE_START must be a whole number.");
   #endif
   #ifdef PTC_SAMPLE_RES
-    constexpr int _ptc_sample_res = PTC_SAMPLE_END;
-    static_assert(_test_ptc_sample_res != PTC_SAMPLE_END, "PTC_SAMPLE_RES must be a whole number.");
+    constexpr auto _ptc_sample_res = PTC_SAMPLE_RES;
+    constexpr decltype(_ptc_sample_res) _test_ptc_sample_res = 12.3f;
+    static_assert(_test_ptc_sample_res != 12.3f, "PTC_SAMPLE_RES must be a whole number.");
   #endif
   #ifdef BTC_SAMPLE_START
-    constexpr int _btc_sample_start = BTC_SAMPLE_START;
-    static_assert(_test_btc_sample_start != BTC_SAMPLE_START, "BTC_SAMPLE_START must be a whole number.");
+    constexpr auto _btc_sample_start = BTC_SAMPLE_START;
+    constexpr decltype(_btc_sample_start) _test_btc_sample_start = 12.3f;
+    static_assert(_test_btc_sample_start != 12.3f, "BTC_SAMPLE_START must be a whole number.");
   #endif
   #ifdef BTC_SAMPLE_RES
-    constexpr int _btc_sample_res = BTC_SAMPLE_END;
-    static_assert(_test_btc_sample_res != BTC_SAMPLE_END, "BTC_SAMPLE_RES must be a whole number.");
+    constexpr _btc_sample_res = BTC_SAMPLE_RES;
+    constexpr decltype(_btc_sample_res) _test_btc_sample_res = 12.3f;
+    static_assert(_test_btc_sample_res != 12.3f, "BTC_SAMPLE_RES must be a whole number.");
   #endif
   #ifdef BTC_PROBE_TEMP
-    constexpr int _btc_probe_temp = BTC_PROBE_TEMP;
-    static_assert(_test_btc_probe_temp != BTC_PROBE_TEMP, "BTC_PROBE_TEMP must be a whole number.");
+    constexpr auto _btc_probe_temp = BTC_PROBE_TEMP;
+    constexpr decltype(_btc_probe_temp) _test_btc_probe_temp = 12.3f;
+    static_assert(_test_btc_probe_temp != 12.3f, "BTC_PROBE_TEMP must be a whole number.");
   #endif
 #endif
 


### PR DESCRIPTION
### Description

The checks as-is are failing in a number of ways. First, some typos.. _test_*
variables no longer exist, PTC_SAMPLE_END should be PTC_SAMPLE_RES. After
fixing those, the checks are not actually working (floats are passed OK). This
brings back the 'auto' vars that would be float if the user used '30.0f' or
the like; the type from the auto var is copied to a known-float & ensured that
the known value doesn't stay a float (i.e. gets rounded to an int: 12).

Thanks @thisiskeithb for the tip.

### Requirements

PROBE_TEMP_COMPENSATION

### Benefits

Fixes sanity checks.

### Configurations

Tested with the BT002 example config: https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Prusa/MK3S-BigTreeTech-BTT002

### Related Issues

PR #22130