### PR TITLE
Added Slim LCD menus and Probe Offset Wizard Sanity Check

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3589,10 +3589,10 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
 #endif
 
 /**
- * Sanity Check for Slim LCD Menus and Z probe wizard
+ * Sanity Check for Slim LCD Menus and Probe Offset Wizard
  */
-#if BOTH(SLIM_LCD_MENUS,PROBE_OFFSET_WIZARD)
-  #error "SLIM_LCD_MENUS disables the "Advance Settings->Probe Offsets" menu that the "Z probe Wizard" is under"
+#if BOTH(SLIM_LCD_MENUS, PROBE_OFFSET_WIZARD)
+  #error "SLIM_LCD_MENUS disables "Advanced Settings > Probe Offsets > PROBE_OFFSET_WIZARD."
 #endif
 
 /**

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3589,6 +3589,13 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
 #endif
 
 /**
+ * Sanity Check for Slim LCD Menus and Z probe wizard
+ */
+#if BOTH(SLIM_LCD_MENUS,PROBE_OFFSET_WIZARD)
+  #error "SLIM_LCD_MENUS disables the "Advance Settings->Probe Offsets" menu that the "Z probe Wizard" is under"
+#endif
+
+/**
  * Sanity check for unique start and stop values in NOZZLE_CLEAN_FEATURE
  */
 #if ENABLED(NOZZLE_CLEAN_FEATURE)


### PR DESCRIPTION

### Description

With "SLIM_LCD_MENUS" enabled the Z Probe Wizard is useless since its under 
"Configuration->Advance Settings-> Probe Offsets" that Slim LCD Menus removes

This Sanity check will error on build if both "Slim_LCD_MENUS" and "Probe_OFFSET_WIZARD" are enabled.

### Requirements

N/A

### Benefits

It would help anyone that is having issues With Z probe Wizard not showing up in the menus if they also have 
Slim_LCD_MENUS enabled not realizing it removed the menu that the wizard is under.

### Configurations

### Related Issues

