### PR TITLE
Fix int overflow in DELAY_US on AVR platform (closes #22256)

### DIFF
--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -97,18 +97,60 @@ void calibrate_delay_loop();
   #define DELAY_US(x) DelayCycleFnc((x) * ((F_CPU) / 1000000UL))
 
 #elif defined(__AVR__)
+  FORCE_INLINE static void __delay_up_to_3c(uint8_t cycles) {
+    switch (cycles) {
+      case 3:
+        __asm__ __volatile__(A("RJMP .+0") A("NOP"));
+        break;
+      case 2:
+        __asm__ __volatile__(A("RJMP .+0"));
+        break;
+      case 1:
+        __asm__ __volatile__(A("NOP"));
+        break;
+    }
+  }
 
   // Delay in cycles
   FORCE_INLINE static void DELAY_CYCLES(uint16_t cycles) {
     if (__builtin_constant_p(cycles)) {
-      __builtin_avr_delay_cycles(cycles);
+      if (cycles <= 3) {
+        __delay_up_to_3c(cycles);
+      }
+      else if (cycles == 4) {
+        __delay_up_to_3c(2);
+        __delay_up_to_3c(2);
+      }
+      else {
+        cycles -= 1 + 4; // Compensate for the first LDI (1) and the first round (4)
+        __delay_up_to_3c(cycles % 4);
+
+        cycles /= 4;
+        // The following code burns [1 + 4 * (rounds+1)] cycles
+        uint16_t dummy;
+        __asm__ __volatile__(
+          // "manualy" load counter from constants, otherwise the compiler may optimize this part away
+          A("LDI %A[rounds], %[l]") // 1c
+          A("LDI %B[rounds], %[h]") // 1c (compensating the non branching BRCC)
+          L("1")
+          A("SBIW %[rounds], 1")    // 2c
+          A("BRCC 1b")              // 2c when branching, else 1c (end of loop)
+          : // Outputs ...
+          [rounds] "=w" (dummy) // Restrict to a wo (=) 16 bit register pair (w)
+          : // Inputs ...
+          [l] "M" (cycles%256), // Restrict to 0..255 constant (M)
+          [h] "M" (cycles/256)  // Restrict to 0..255 constant (M)
+          :// Clobbers ...
+          "cc"                  // Indicate we are modifying flags like Carry (cc)
+        );
+      }
     }
     else {
       __asm__ __volatile__(
-        L("loop")
-        A("sbiw %[cycles],4")    // 2 cycles
-        A("brcc loop")           // 2 cycles when branching, else 1 cycle
-        : [cycles] "+w" (cycles) // output: Restrict to a r/w (+) 16 bit register pair (w)
+        L("1")
+        A("SBIW %[cycles], 4")   // 2c
+        A("BRCC 1b")             // 2c when branching, else 1c (end of loop)
+        : [cycles] "+w" (cycles) // output: Restrict to a rw (+) 16 bit register pair (w)
         :                        // input: -
         : "cc"                   // clobbers: We are modifying flags like Carry (cc)
       );

--- a/Marlin/src/HAL/shared/Delay.h
+++ b/Marlin/src/HAL/shared/Delay.h
@@ -129,7 +129,7 @@ void calibrate_delay_loop();
         // The following code burns [1 + 4 * (rounds+1)] cycles
         uint16_t dummy;
         __asm__ __volatile__(
-          // "manualy" load counter from constants, otherwise the compiler may optimize this part away
+          // "manually" load counter from constants, otherwise the compiler may optimize this part away
           A("LDI %A[rounds], %[l]") // 1c
           A("LDI %B[rounds], %[h]") // 1c (compensating the non branching BRCC)
           L("1")


### PR DESCRIPTION
### Description

Complete rewrite of `DELAY_CYCLES(x)` for AVR platform. This in first place fixes an integer overflow (described in #22256) and uses a <del>GCC intrinsic for the compile time branch</del>16 bit version of the delay loop and an simpler inline ASM function with less overhead for the runtime branch.

### Requirements

  * AVR Platform (e.g. ATmega2560)

### Benefits
Fixes integer overflow in `DELAY_US(x)` on AVR platforms for x > 64

### Configurations
tested in `MARLIN_DEV_MODE` with the following code in `gcode_d.cpp` and an oscilloscope
```c

      case 42: {// D42 test busy waiting delay
        const pin_t pin = GET_PIN_MAP_PIN(11);
        if (pin_is_protected(pin)) {
          SERIAL_ERROR_MSG(STR_ERR_PROTECTED_PIN);
          break;
        }

        pinMode(pin, OUTPUT);
        extDigitalWrite(pin, 0);
        delay(1000UL);

        if (parser.seenval('D')) {
          uint16_t delay_us = parser.value_ushort();
          DISABLE_ISRS();
          PORTB |= _BV(PINB5);
          DELAY_CYCLES(delay_us);
          PORTB &= ~_BV(PINB5);
          ENABLE_ISRS();
        }
        else if (parser.seenval('C')) {
          #define switch_constant_delay(x) \
            case x: \
              DISABLE_ISRS(); \
              __asm__ __volatile__(L("MARKER_delay_" # x)); \
              PORTB |= _BV(PINB5); \
              DELAY_CYCLES(x); \
              PORTB &= ~_BV(PINB5); \
              __asm__ __volatile__(L("MARKER_delay_" # x "_END")); \
              ENABLE_ISRS(); \
              break;

          switch (parser.value_ushort()) {
            switch_constant_delay(0)
            switch_constant_delay(1)
            switch_constant_delay(2)
            switch_constant_delay(3)
            switch_constant_delay(4)
            switch_constant_delay(5)
            switch_constant_delay(6)
            switch_constant_delay(7)
            switch_constant_delay(8)
            switch_constant_delay(9)
            switch_constant_delay(1600UL)
            switch_constant_delay(1601UL)
            switch_constant_delay(1602UL)
            switch_constant_delay(1603UL)
            switch_constant_delay(1604UL)
            switch_constant_delay(3200UL)
            switch_constant_delay(8000UL)
            switch_constant_delay(16000UL)
          }

          #undef switch_constant_delay
        }
      } break;
```

For 0 to 9 cycle delays I could verify 1 cycle accurate delays (<5% error). For the greater delays, the scope sample length wasn't big enough, but the delay was still in the expected us range.

The generated ASM for the compile time delays is:
```ASM
00012b9a <MARKER_delay_0>:

00012ba2 <MARKER_delay_1>:
   12ba4:	00 00       	nop

00012ac2 <MARKER_delay_2>:
   12ac4:	00 c0       	rjmp	.+0      	; 0x12ac6 <MARKER_delay_2+0x4>

00012bac <MARKER_delay_3>:
   12bae:	00 c0       	rjmp	.+0      	; 0x12bb0 <MARKER_delay_3+0x4>
   12bb0:	00 00       	nop

00012bb8 <MARKER_delay_4>:
   12bba:	00 c0       	rjmp	.+0      	; 0x12bbc <MARKER_delay_4+0x4>
   12bbc:	00 c0       	rjmp	.+0      	; 0x12bbe <MARKER_delay_4+0x6>

00012bc4 <MARKER_delay_5>:
   12bc6:	80 e0       	ldi	r24, 0x00	; 0
   12bc8:	90 e0       	ldi	r25, 0x00	; 0
   12bca:	01 97       	sbiw	r24, 0x01	; 1
   12bcc:	f0 f7       	brcc	.-4      	; 0x12bca <MARKER_delay_5+0x6>

00012bd4 <MARKER_delay_6>:
   12bd6:	00 00       	nop
   12bd8:	80 e0       	ldi	r24, 0x00	; 0
   12bda:	90 e0       	ldi	r25, 0x00	; 0
   12bdc:	01 97       	sbiw	r24, 0x01	; 1
   12bde:	f0 f7       	brcc	.-4      	; 0x12bdc <MARKER_delay_6+0x8>

00012ae6 <MARKER_delay_7>:
   12ae8:	00 c0       	rjmp	.+0      	; 0x12aea <MARKER_delay_7+0x4>
   12aea:	80 e0       	ldi	r24, 0x00	; 0
   12aec:	90 e0       	ldi	r25, 0x00	; 0
   12aee:	01 97       	sbiw	r24, 0x01	; 1
   12af0:	f0 f7       	brcc	.-4      	; 0x12aee <MARKER_delay_7+0x8>

00012be6 <MARKER_delay_8>:
   12be8:	00 c0       	rjmp	.+0      	; 0x12bea <MARKER_delay_8+0x4>
   12bea:	00 00       	nop
   12bec:	80 e0       	ldi	r24, 0x00	; 0
   12bee:	90 e0       	ldi	r25, 0x00	; 0
   12bf0:	01 97       	sbiw	r24, 0x01	; 1
   12bf2:	f0 f7       	brcc	.-4      	; 0x12bf0 <MARKER_delay_8+0xa>

00012b18 <MARKER_delay_9>:
   12b1a:	81 e0       	ldi	r24, 0x01	; 1
   12b1c:	90 e0       	ldi	r25, 0x00	; 0
   12b1e:	01 97       	sbiw	r24, 0x01	; 1
   12b20:	f0 f7       	brcc	.-4      	; 0x12b1e <MARKER_delay_9+0x6>

00012bfa <MARKER_delay_1600UL>:
   12bfc:	00 c0       	rjmp	.+0      	; 0x12bfe <MARKER_delay_1600UL+0x4>
   12bfe:	00 00       	nop
   12c00:	8e e8       	ldi	r24, 0x8E	; 142
   12c02:	91 e0       	ldi	r25, 0x01	; 1
   12c04:	01 97       	sbiw	r24, 0x01	; 1
   12c06:	f0 f7       	brcc	.-4      	; 0x12c04 <MARKER_delay_1600UL+0xa>

00012c0e <MARKER_delay_1601UL>:
   12c10:	8f e8       	ldi	r24, 0x8F	; 143
   12c12:	91 e0       	ldi	r25, 0x01	; 1
   12c14:	01 97       	sbiw	r24, 0x01	; 1
   12c16:	f0 f7       	brcc	.-4      	; 0x12c14 <MARKER_delay_1601UL+0x6>

00012b3a <MARKER_delay_1602UL>:
   12b3c:	00 00       	nop
   12b3e:	8f e8       	ldi	r24, 0x8F	; 143
   12b40:	91 e0       	ldi	r25, 0x01	; 1
   12b42:	01 97       	sbiw	r24, 0x01	; 1
   12b44:	f0 f7       	brcc	.-4      	; 0x12b42 <MARKER_delay_1602UL+0x8>

00012c1e <MARKER_delay_1603UL>:
   12c20:	00 c0       	rjmp	.+0      	; 0x12c22 <MARKER_delay_1603UL+0x4>
   12c22:	8f e8       	ldi	r24, 0x8F	; 143
   12c24:	91 e0       	ldi	r25, 0x01	; 1
   12c26:	01 97       	sbiw	r24, 0x01	; 1
   12c28:	f0 f7       	brcc	.-4      	; 0x12c26 <MARKER_delay_1603UL+0x8>

00012b60 <MARKER_delay_1604UL>:
   12b62:	00 c0       	rjmp	.+0      	; 0x12b64 <MARKER_delay_1604UL+0x4>
   12b64:	00 00       	nop
   12b66:	8f e8       	ldi	r24, 0x8F	; 143
   12b68:	91 e0       	ldi	r25, 0x01	; 1
   12b6a:	01 97       	sbiw	r24, 0x01	; 1
   12b6c:	f0 f7       	brcc	.-4      	; 0x12b6a <MARKER_delay_1604UL+0xa>

00012c30 <MARKER_delay_3200UL>:
   12c32:	00 c0       	rjmp	.+0      	; 0x12c34 <MARKER_delay_3200UL+0x4>
   12c34:	00 00       	nop
   12c36:	8e e1       	ldi	r24, 0x1E	; 30
   12c38:	93 e0       	ldi	r25, 0x03	; 3
   12c3a:	01 97       	sbiw	r24, 0x01	; 1
   12c3c:	f0 f7       	brcc	.-4      	; 0x12c3a <MARKER_delay_3200UL+0xa>

00012c44 <MARKER_delay_8000UL>:
   12c46:	00 c0       	rjmp	.+0      	; 0x12c48 <MARKER_delay_8000UL+0x4>
   12c48:	00 00       	nop
   12c4a:	8e ec       	ldi	r24, 0xCE	; 206
   12c4c:	97 e0       	ldi	r25, 0x07	; 7
   12c4e:	01 97       	sbiw	r24, 0x01	; 1
   12c50:	f0 f7       	brcc	.-4      	; 0x12c4e <MARKER_delay_8000UL+0xa>

00012b86 <MARKER_delay_16000UL>:
   12b88:	00 c0       	rjmp	.+0      	; 0x12b8a <MARKER_delay_16000UL+0x4>
   12b8a:	00 00       	nop
   12b8c:	8e e9       	ldi	r24, 0x9E	; 158
   12b8e:	9f e0       	ldi	r25, 0x0F	; 15
   12b90:	01 97       	sbiw	r24, 0x01	; 1
   12b92:	f0 f7       	brcc	.-4      	; 0x12b90 <MARKER_delay_16000UL+0xa>
```

### Related Issues
Fixes #22256