### PR TITLE
Fix software reset button press logic for HAS_KILL && SOFT_RESET_ON_KILL

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -890,11 +890,11 @@ void minkill(const bool steppers_off/*=false*/) {
   #if EITHER(HAS_KILL, SOFT_RESET_ON_KILL)
 
     // Wait for both KILL and ENC to be released
-    while (TERN0(HAS_KILL, !kill_state()) || TERN0(SOFT_RESET_ON_KILL, !ui.button_pressed()))
+    while (TERN0(HAS_KILL, kill_state()) || TERN0(SOFT_RESET_ON_KILL, ui.button_pressed()))
       watchdog_refresh();
 
-    // Wait for either KILL or ENC press
-    while (TERN1(HAS_KILL, kill_state()) && TERN1(SOFT_RESET_ON_KILL, ui.button_pressed()))
+    // Wait for either KILL or ENC to be pressed again
+    while (TERN1(HAS_KILL, !kill_state()) && TERN1(SOFT_RESET_ON_KILL, !ui.button_pressed()))
       watchdog_refresh();
 
     // Reboot the board


### PR DESCRIPTION
### Description

The issue (or the possibility to have this issue) was introduced with PR #21652. This added the `SOFT_RESET_ON_KILL` configuration option to reset the board after kill() with the select button of the UI.

When `SOFT_RESET_ON_KILL` is enabled on a printer which has also a kill switch on `KILL_PIN`, the software reset by pressing either one of those two buttons does not work. The workaround is to press both buttons at once (which is not clearly intuitive and I guess not intended) or a full power cycle.

The bug was introduced by a simple logic error and can be fixed as simple as moving negations to the right step.

_A small remark_: When holding the reset button the second time for too long, the board will immediately get killed after it restarts. If holding the select button for to long, the menu starts to flicker after restart. This could be easy fixed copying line 893 as a third step. But i guess this user error is not worth the extra valuable program space.

### Requirements

* A UI with a select button
* A kill button

### Benefits

Fixes an unexpected behaviour

### Configurations

Enable `SOFT_RESET_ON_KILL`

### Related Issues

None
