### PR TITLE
check for TOUCH_UI_FTDI_EVE, fixes arduino ide build 

### DIFF
--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/flash_storage.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/flash_storage.cpp
@@ -20,7 +20,7 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#include "../compat.h"
+#include "../config.h"
 
 #if ENABLED(TOUCH_UI_FTDI_EVE)
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/media_file_reader.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/media_file_reader.cpp
@@ -20,7 +20,7 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#include "../compat.h"
+#include "../config.h"
 
 #if ENABLED(TOUCH_UI_FTDI_EVE)
   #include "media_file_reader.h"

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/compat.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/compat.h
@@ -21,9 +21,6 @@
 
 #pragma once
 
-#include "../../../inc/MarlinConfigPre.h"
-#if ENABLED(TOUCH_UI_FTDI_EVE)
-
 /**
  * This following provides compatibility whether compiling
  * as a part of Marlin or outside it
@@ -54,5 +51,3 @@
 class __FlashStringHelper;
 typedef const __FlashStringHelper *progmem_str;
 extern const char G28_STR[];
-
-#endif  // TOUCH_UI_FTDI_EVE

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/compat.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/compat.h
@@ -21,6 +21,9 @@
 
 #pragma once
 
+#include "../../../inc/MarlinConfigPre.h"
+#if ENABLED(TOUCH_UI_FTDI_EVE)
+
 /**
  * This following provides compatibility whether compiling
  * as a part of Marlin or outside it
@@ -51,3 +54,5 @@
 class __FlashStringHelper;
 typedef const __FlashStringHelper *progmem_str;
 extern const char G28_STR[];
+
+#endif  // TOUCH_UI_FTDI_EVE

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/config.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/config.h
@@ -21,6 +21,10 @@
 
 #pragma once
 
+// Configure this display with options in Configuration_adv.h
+#include "../../../inc/MarlinConfigPre.h"
+#if ENABLED(TOUCH_UI_FTDI_EVE)
+
 #include "compat.h"
 
-// Configure this display with options in Configuration_adv.h
+#endif

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/screens.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/screens.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include "compat.h"
+#include "config.h"
 
 #if ENABLED(TOUCH_UI_FTDI_EVE)
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/theme/sounds.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/theme/sounds.cpp
@@ -20,7 +20,7 @@
  *   location: <https://www.gnu.org/licenses/>.                             *
  ****************************************************************************/
 
-#include "../compat.h"
+#include "../config.h"
 
 #if ENABLED(TOUCH_UI_FTDI_EVE)
 


### PR DESCRIPTION
### Description

Arduino ide failes to compile as it attempts to use Marlin/src/lcd/extui/ftdi_eve_touch_ui/compat.h  
Add a simple #if ENABLED(TOUCH_UI_FTDI_EVE) so this code is skipped unless needed.

### Requirements

Primitive non source filtering Arduino ide

### Benefits

Compiles as expected

### Configurations

Stock; Anet A8 V1.0

### Related Issues
Issue https://github.com/MarlinFirmware/Marlin/issues/22275