### PR TITLE
Fix no response on SERIAL* for SKR 1.3 / 1.4 / LPC176x with high BAUDRATE

### DIFF
--- a/Marlin/src/HAL/LPC1768/MarlinSerial.h
+++ b/Marlin/src/HAL/LPC1768/MarlinSerial.h
@@ -21,6 +21,7 @@
  */
 #pragma once
 
+#include <lpc17xx_clkpwr.h>
 #include <HardwareSerial.h>
 #include <WString.h>
 
@@ -42,7 +43,18 @@
 
 class MarlinSerial : public HardwareSerial<RX_BUFFER_SIZE, TX_BUFFER_SIZE> {
 public:
-  MarlinSerial(LPC_UART_TypeDef *UARTx) : HardwareSerial<RX_BUFFER_SIZE, TX_BUFFER_SIZE>(UARTx) { }
+  MarlinSerial(LPC_UART_TypeDef *UARTx) : HardwareSerial<RX_BUFFER_SIZE, TX_BUFFER_SIZE>(UARTx) {
+    // Fix no response if BAUDRATE > 250000 https://github.com/MarlinFirmware/Marlin/issues/22283
+    if (UARTx == LPC_UART0) {
+      CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_UART0, CLKPWR_PCLKSEL_CCLK_DIV_1);
+    } else if ((LPC_UART1_TypeDef *) UARTx == LPC_UART1) {
+      CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_UART1, CLKPWR_PCLKSEL_CCLK_DIV_1);
+    } else if (UARTx == LPC_UART2) {
+      CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_UART2, CLKPWR_PCLKSEL_CCLK_DIV_1);
+    } else if (UARTx == LPC_UART3) {
+      CLKPWR_SetPCLKDiv(CLKPWR_PCLKSEL_UART3, CLKPWR_PCLKSEL_CCLK_DIV_1);
+    }
+  }
 
   void end() {}
 


### PR DESCRIPTION
### Description

Fix no response on `SERIAL`* for SKR v1.3 / LPC1768 with `BAUDRATE > 250000`
Fix no response on `SERIAL`* for SKR v1.4 Turbo / LPC176x with `BAUDRATE >= 1000000`

### Requirements

Tested on SKR v1.3. After fix verified 57600, 115200, 250000, 460800, 500000, 921600 `BAUDRATE`s work on `SERIAL_PORT 0`.
Edit: Tested on SKR v1.4 Turbo which uses LPC1769. After fix verified 57600, 115200, 250000, 460800, 500000, 921600, 1000000, 2000000 `BAUDRATE`s work on `SERIAL_PORT 0`.

### Benefits

SKR v1.3 and v1.4 Turbo (likely many LPC176x) can now use high `BAUDRATE`s on `SERIAL_PORT`*.

### Related Issues

#22283
