### PR TITLE
Add GD32F103RE_btt env (96 MHz)

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -514,7 +514,7 @@
 #elif MB(BTT_SKR_MINI_E3_V1_2)
   #include "stm32f1/pins_BTT_SKR_MINI_E3_V1_2.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple
 #elif MB(BTT_SKR_MINI_E3_V2_0)
-  #include "stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RE_btt env:STM32F103RE_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple env:STM32F103RE_btt_maple env:STM32F103RE_btt_USB_maple
+  #include "stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RE_btt env:STM32F103RE_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple env:STM32F103RE_btt_maple env:STM32F103RE_btt_USB_maple env:GD32F103RE_btt env:GD32F103RE_btt_USB
 #elif MB(BTT_SKR_MINI_MZ_V1_0)
   #include "stm32f1/pins_BTT_SKR_MINI_MZ_V1_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple
 #elif MB(BTT_SKR_E3_DIP)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -160,8 +160,10 @@ upload_protocol      = jlink
 #
 # BigTree SKR Mini E3 V2.0 & DIP / SKR CR6 (STM32F103RET6 ARM Cortex-M3)
 #
-#   STM32F103RE_btt ............. RET6
-#   STM32F103RE_btt_USB ......... RET6 (USB mass storage)
+#   STM32F103RE_btt ............. STM32F103RET6
+#   GD32F103RE_btt .............. GD32F103RET6
+#   STM32F103RE_btt_USB ......... STM32F103RET6 (USB mass storage)
+#   GD32F103RE_btt_USB .......... GD32F103RET6 (USB mass storage)
 #
 [env:STM32F103RE_btt]
 platform             = ${common_stm32.platform}
@@ -180,6 +182,11 @@ extra_scripts        = ${common_stm32.extra_scripts}
 debug_tool           = jlink
 upload_protocol      = jlink
 
+[env:GD32F103RE_btt]
+extends           = env:STM32F103RE_btt
+build_flags       = ${env:STM32F103RE_btt.build_flags} -DGD32F10x
+board_build.f_cpu = 96000000L
+
 [env:STM32F103RE_btt_USB]
 extends           = env:STM32F103RE_btt
 platform          = ${common_stm32.platform}
@@ -191,6 +198,11 @@ build_flags       = ${env:STM32F103RE_btt.build_flags} ${env:stm32_flash_drive.b
   -DUSBD_IRQ_PRIO=5
   -DUSBD_IRQ_SUBPRIO=6
   -DUSBD_USE_CDC_MSC
+
+[env:GD32F103RE_btt_USB]
+extends           = env:STM32F103RE_btt_USB
+build_flags       = ${env:STM32F103RE_btt_USB.build_flags} -DGD32F10x
+board_build.f_cpu = 96000000L
 
 #
 # FLSUN QQS Pro (STM32F103VET6)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -183,6 +183,7 @@ debug_tool           = jlink
 upload_protocol      = jlink
 
 [env:GD32F103RE_btt]
+platform          = ${common_stm32.platform}
 extends           = env:STM32F103RE_btt
 build_flags       = ${env:STM32F103RE_btt.build_flags} -DGD32F10x
 board_build.f_cpu = 96000000L
@@ -200,6 +201,7 @@ build_flags       = ${env:STM32F103RE_btt.build_flags} ${env:stm32_flash_drive.b
   -DUSBD_USE_CDC_MSC
 
 [env:GD32F103RE_btt_USB]
+platform          = ${common_stm32.platform}
 extends           = env:STM32F103RE_btt_USB
 build_flags       = ${env:STM32F103RE_btt_USB.build_flags} -DGD32F10x
 board_build.f_cpu = 96000000L


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

Recently I bought [BIGTREETECH SKR Mini E3 V2.0](https://www.biqu.equipment/products/bigtreetech-skr-mini-e3-v2-0-32-bit-control-board-integrated-tmc2209-uart-for-ender-3?variant=31995437744226) board to replace damaged Creality v4.2.2 (bed MOSFET released the [magic smoke](https://en.wikipedia.org/wiki/Magic_smoke)) on my Ender 3 V2 and I noticed that instead of usual STM32F103RET6 it came equipped with [GigaDevice GD32F103RET6](https://www.gigadevice.com/microcontroller/gd32f103ret6/). This chip is a clone of the STM, but not an exact one. It actually has a PLL capable of running the core at 108 MHz, that is **50% faster than the original**. I thought it would be a waste not to enable its full potential.

**EDIT**: Full speed 108 MHz is not compatible with USB support, max usable frequency is 96 MHz.

![BTT_SKR_Mini_V2_GD32F103RET6](https://user-images.githubusercontent.com/13185945/124304977-bbdd7f00-db64-11eb-86f6-c58fe4ab06cb.jpg)

Also I disabled the HSI clock as it was never used, all board use HSE for system clock.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

Any printer with BTT SKR Mini E3 V2.0 with GD32F103RET6 MCU. Could be extended to any board equipped with this MCU.

### Benefits

<!-- What does this PR fix or improve? -->

Thanks to ~~50%~~ 33% faster operation, in theory, this could allow more advanced operations to be performed by the CPU. Processing intensive operations like UI refreshing will execute faster.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

My full setup is descibed in following issue:

* https://github.com/MarlinFirmware/Configurations/issues/535
