### PR TITLE
Fix serial buffer size for Maple and STSTM32

### DIFF
--- a/buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
+++ b/buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
@@ -30,15 +30,3 @@ if env.MarlinFeatureIsEnabled("POSTMORTEM_DEBUGGING"):
         print("Done patching exception handler")
 
     print("Libmaple modified and ready for post mortem debugging")
-
-mf = env["MARLIN_FEATURES"]
-rxBuf = mf["RX_BUFFER_SIZE"] if "RX_BUFFER_SIZE" in mf else "0"
-txBuf = mf["TX_BUFFER_SIZE"] if "TX_BUFFER_SIZE" in mf else "0"
-if int(rxBuf) < 64:
-	rxBuf = "64"
-if int(txBuf) < 64:
-	txBuf = "64"
-
-build_flags = env.get('BUILD_FLAGS')
-build_flags.append("-DUSART_RX_BUF_SIZE=" + rxBuf + " -DUSART_TX_BUF_SIZE=" + txBuf)
-env.Replace(BUILD_FLAGS=build_flags)

--- a/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
+++ b/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
@@ -13,11 +13,16 @@ Import("env")
 #
 # The script will set the value as the default one (64 bytes)
 # or the user-configured one, whichever is higher.
+#
+# Marlin has 128 and 32 as default values for RX_BUFFER_SIZE and
+# TX_BUFFER_SIZE respectively. We use the highest value.
 mf = env["MARLIN_FEATURES"]
-rxBuf = str(max(64, int(mf["RX_BUFFER_SIZE"]) if "RX_BUFFER_SIZE" in mf else 0))
+rxBuf = str(max(128, int(mf["RX_BUFFER_SIZE"]) if "RX_BUFFER_SIZE" in mf else 0))
 txBuf = str(max(64, int(mf["TX_BUFFER_SIZE"]) if "TX_BUFFER_SIZE" in mf else 0))
 
 build_flags = env.get('BUILD_FLAGS')
 build_flags.append("-DSERIAL_RX_BUFFER_SIZE=" + rxBuf)
 build_flags.append("-DSERIAL_TX_BUFFER_SIZE=" + txBuf)
+build_flags.append("-DUSART_RX_BUF_SIZE=" + rxBuf)
+build_flags.append("-DUSART_TX_BUF_SIZE=" + txBuf)
 env.Replace(BUILD_FLAGS=build_flags)

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -36,6 +36,7 @@ lib_deps          = ${common.lib_deps}
 platform_packages = tool-stm32duino
 extra_scripts     = ${common.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/fix_framework_weakness.py
+  pre:buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
 
 #
 # STM32F103RC
@@ -325,7 +326,8 @@ lib_ignore    = ${common_stm32f1.lib_ignore}
 platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = marlin_CHITU_F103
-extra_scripts = pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
+extra_scripts = ${common_stm32f1.extra_scripts}
+  pre:buildroot/share/PlatformIO/scripts/common-dependencies.py
   pre:buildroot/share/PlatformIO/scripts/STM32F1_create_variant.py
   buildroot/share/PlatformIO/scripts/chitu_crypt.py
 build_flags   = ${common_stm32f1.build_flags}

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -150,7 +150,7 @@ board_build.variant  = MARLIN_F103Rx
 board_build.offset   = 0x7000
 board_upload.offset_address = 0x08007000
 build_unflags        = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
-extra_scripts        = ${common.extra_scripts}
+extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   pre:buildroot/share/PlatformIO/scripts/random-bin.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
@@ -174,7 +174,7 @@ board_build.variant  = MARLIN_F103Rx
 board_build.offset   = 0x7000
 board_upload.offset_address = 0x08007000
 build_unflags        = ${common_stm32.build_unflags}
-extra_scripts        = ${common.extra_scripts}
+extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py
 debug_tool           = jlink


### PR DESCRIPTION
### Description

- Added the serial buffer script for the environments `common_stm32f1`, `chitu_f103`, `STM32F103RET6_creality`, and `STM32F103RE_btt`.
- Moved the Maple-specific fix from `fix_framework_weakness.py` to `stm32_serialbuffer.py`.
- Increased the RX buffer size to 128 to match Marlin's default and also to fix buffer overflows when using arc commands.

### Benefits

More consistent defaults and less issues related to serial buffer.

### Related Issues

FormerLurker/ArcWelderPlugin#30
https://github.com/FormerLurker/ArcWelderPlugin/issues/30#issuecomment-871827363
FormerLurker/ArcWelderPlugin#175
#21170
