### PR TITLE
fix duplicate FAN_PIN definition for einsy rambo

### DIFF
--- a/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
@@ -135,9 +135,9 @@
 
 #ifndef FAN1_PIN
   #ifdef MK3_FAN_PINS
-    #define FAN_PIN                           -1
+    #define FAN1_PIN                           -1
   #else
-    #define FAN_PIN                            6
+    #define FAN1_PIN                            6
   #endif
 #endif
 


### PR DESCRIPTION
### Description

Looks like some code was copy-pasted, but not updated completely. Duplicate FAN_PIN.

### Requirements

Running tests for rambo: `make tests-single-local TEST_TARGET=rambo`

### Benefits

Fixes the wall'o'warnings.

### Configurations

n/a

### Related Issues

none.