### PR TITLE
Update LPC176x platform to 0.2.8

### DIFF
--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -14,7 +14,7 @@
 #
 [common_LPC]
 platform          = https://github.com/p3p/pio-nxplpc-arduino-lpc176x/archive/0.1.3.zip
-platform_packages = framework-arduino-lpc176x@^0.2.6
+platform_packages = framework-arduino-lpc176x@^0.2.8
 board             = nxp_lpc1768
 lib_ldf_mode      = off
 lib_compat_mode   = strict


### PR DESCRIPTION
Description
Update LPC176x library to 0.2.8

Requirements
LPC176x MPU

Benefits
Enables PWM Latching
Improves Serial Baud Accuracy

Configurations
N/A

Related Issues
This PR fixes multiple issues see:
#16171
#22283
#22284