### PR TITLE
Fix Robin Nano V3 board X-diag pin define

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -59,7 +59,7 @@
 //
 // Limit Switches
 //
-#define X_DIAG_PIN                          PD15
+#define X_DIAG_PIN                          PA15
 #define Y_DIAG_PIN                          PD2
 #define Z_DIAG_PIN                          PC8
 #define E0_DIAG_PIN                         PC4


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
MKS Robin Nano V3.x board, X-diag is connect to X stop interface by jumper.
- #define X_DIAG_PIN    PA15// same as X_STOP_PIN
- Hardware pinmap: https://github.com/makerbase-mks/MKS-Robin-Nano-V3.X/blob/main/hardware/MKS%20Robin%20Nano%20V3.0_004/MKS%20Robin%20Nano%20V3.0_004%20PIN.pdf
![image](https://user-images.githubusercontent.com/16629551/125260699-2e074e00-e333-11eb-97af-22790afa7580.png)

