### PR TITLE
Fix hang on temp_sensor_board with THERMAL_PROTECTION_BOARD

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1135,6 +1135,23 @@
   #endif
 #endif
 
+#if TEMP_SENSOR_BOARD == -4
+  #define TEMP_SENSOR_BOARD_IS_AD8495 1
+#elif TEMP_SENSOR_BOARD == -3
+  #error "MAX31855 Thermocouples (-3) not supported for TEMP_SENSOR_BOARD."
+#elif TEMP_SENSOR_BOARD == -2
+  #error "MAX6675 Thermocouples (-2) not supported for TEMP_SENSOR_BOARD."
+#elif TEMP_SENSOR_BOARD == -1
+  #define TEMP_SENSOR_BOARD_IS_AD595 1
+#elif TEMP_SENSOR_BOARD > 0
+  #define TEMP_SENSOR_BOARD_IS_THERMISTOR 1
+  #if TEMP_SENSOR_BOARD == 1000
+    #define TEMP_SENSOR_BOARD_IS_CUSTOM 1
+  #elif TEMP_SENSOR_BOARD == 998 || TEMP_SENSOR_BOARD == 999
+    #define TEMP_SENSOR_BOARD_IS_DUMMY 1
+  #endif
+#endif
+
 /**
  * X_DUAL_ENDSTOPS endstop reassignment
  */

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -440,7 +440,7 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
   board_info_t Temperature::temp_board; // = { 0 }
   #if ENABLED(THERMAL_PROTECTION_BOARD)
     int16_t Temperature::mintemp_raw_BOARD = TEMP_SENSOR_BOARD_RAW_LO_TEMP,
-            Temperature::maxtemp_raw_BOARD = TEMP_SENSOR_COOLER_RAW_HI_TEMP;
+            Temperature::maxtemp_raw_BOARD = TEMP_SENSOR_BOARD_RAW_HI_TEMP;
   #endif
 #endif
 
@@ -2455,9 +2455,9 @@ void Temperature::init() {
     while (analog_to_celsius_cooler(maxtemp_raw_COOLER) < COOLER_MAXTEMP) maxtemp_raw_COOLER -= TEMPDIR(COOLER) * (OVERSAMPLENR);
   #endif
 
-  #if HAS_TEMP_BOARD
-    while (analog_to_celsius_board(mintemp_raw_BOARD) > BOARD_MINTEMP) mintemp_raw_BOARD += TEMPDIR(BOARD) * (OVERSAMPLENR);
-    while (analog_to_celsius_board(maxtemp_raw_BOARD) < BOARD_MAXTEMP) maxtemp_raw_BOARD -= TEMPDIR(BOARD) * (OVERSAMPLENR);
+  #if BOTH(HAS_TEMP_BOARD, THERMAL_PROTECTION_BOARD)
+    while (analog_to_celsius_board(mintemp_raw_BOARD) < BOARD_MINTEMP) mintemp_raw_BOARD += TEMPDIR(BOARD) * (OVERSAMPLENR);
+    while (analog_to_celsius_board(maxtemp_raw_BOARD) > BOARD_MAXTEMP) maxtemp_raw_BOARD -= TEMPDIR(BOARD) * (OVERSAMPLENR);
   #endif
 
   #if HAS_TEMP_REDUNDANT

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -815,7 +815,7 @@ class Temperature {
         static inline int16_t rawBoardTemp()    { return temp_board.raw; }
       #endif
       static inline celsius_float_t degBoard()  { return temp_board.celsius; }
-      static inline celsius_t wholeDegBoard()   { return static_cast<celsius_t>(degBoard() + 0.5f); }
+      static inline celsius_t wholeDegBoard()   { return static_cast<celsius_t>(temp_board.celsius + 0.5f); }
     #endif
 
     #if HAS_TEMP_REDUNDANT


### PR DESCRIPTION
### Description

A few errors in the recent TEMP_SENSOR_BOARD were missed that causes a hang on boot when THERMAL_PROTECTION_BOARD is enabled.

### Requirements

TEMP_SENSOR_BOARD and THERMAL_PROTECTION_BOARD

### Benefits

Fixes the hang.

### Configurations

Any config w/ THERMAL_PROTECTION_BOARD & TEMP_SENSOR_BOARD

### Related Issues

#22279 #20175