### PR TITLE
Fix compilation issues with HID_* changes, add redundant temp test

### DIFF
--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -127,7 +127,9 @@
 
 // Usurp a sensor to do redundant readings
 #if TEMP_SENSOR_REDUNDANT
-  #define REDUNDANT_TEMP_MATCH(M,N) (TEMP_SENSOR_REDUNDANT_##M == HID_##N)
+  #define _HEATER_ID(M) HID_##M
+  #define HEATER_ID(M)  _HEATER_ID(M)
+  #define REDUNDANT_TEMP_MATCH(M,N) (HEATER_ID(TEMP_SENSOR_REDUNDANT_##M) == _HEATER_ID(N))
 #else
   #define REDUNDANT_TEMP_MATCH(...) 0
 #endif

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -951,7 +951,7 @@ void Temperature::_temp_error(const heater_id_t heater_id, PGM_P const serial_ms
     #if HAS_TEMP_REDUNDANT
       if (heater_id == H_REDUNDANT) {
         SERIAL_ECHOPGM(STR_REDUNDANT); // print redundant and cascade to print target, too.
-        real_heater_id = (heater_id_t)TEMP_SENSOR_REDUNDANT_TARGET;
+        real_heater_id = (heater_id_t)HEATER_ID(TEMP_SENSOR_REDUNDANT_TARGET);
       }
     #endif
 
@@ -1323,7 +1323,7 @@ void Temperature::manage_heater() {
   #if HAS_TEMP_REDUNDANT
     // Make sure measured temperatures are close together
     if (ABS(degRedundantTarget() - degRedundant()) > TEMP_SENSOR_REDUNDANT_MAX_DIFF)
-      _temp_error((heater_id_t)TEMP_SENSOR_REDUNDANT_TARGET, PSTR(STR_REDUNDANCY), GET_TEXT(MSG_ERR_REDUNDANT_TEMP));
+      _temp_error((heater_id_t)HEATER_ID(TEMP_SENSOR_REDUNDANT_TARGET), PSTR(STR_REDUNDANCY), GET_TEXT(MSG_ERR_REDUNDANT_TEMP));
   #endif
 
   #if HAS_AUTO_FAN
@@ -2015,7 +2015,7 @@ void Temperature::updateTemperaturesFromRawValues() {
 
   TERN_(TEMP_SENSOR_0_IS_MAX_TC, temp_hotend[0].raw = READ_MAX_TC(0));
   TERN_(TEMP_SENSOR_1_IS_MAX_TC, temp_hotend[1].raw = READ_MAX_TC(1));
-  TERN_(TEMP_SENSOR_REDUNDANT_IS_MAX_TC, temp_redundant.raw = READ_MAX_TC(TEMP_SENSOR_REDUNDANT_SOURCE));
+  TERN_(TEMP_SENSOR_REDUNDANT_IS_MAX_TC, temp_redundant.raw = READ_MAX_TC(HEATER_ID(TEMP_SENSOR_REDUNDANT_SOURCE)));
 
   #if HAS_HOTEND
     HOTEND_LOOP() temp_hotend[e].celsius = analog_to_celsius_hotend(temp_hotend[e].raw, e);
@@ -2473,7 +2473,7 @@ void Temperature::init() {
       #elif REDUNDANT_TEMP_MATCH(TARGET, BED) && HAS_TEMP_BED
         temp_bed
       #else
-        temp_hotend[TEMP_SENSOR_REDUNDANT_TARGET]
+        temp_hotend[HEATER_ID(TEMP_SENSOR_REDUNDANT_TARGET)]
       #endif
     );
   #endif

--- a/buildroot/tests/mega2560
+++ b/buildroot/tests/mega2560
@@ -199,6 +199,17 @@ opt_enable REPRAP_DISCOUNT_SMART_CONTROLLER SDSUPPORT EEPROM_SETTINGS EEPROM_BOO
 exec_test $1 $2 "REPRAP MEGA2560 RAMPS | Laser Feature | Air Evacuation | Air Assist | Cooler | Flowmeter | 44780 LCD " "$3"
 
 #
+# Test redundant temperature sensors + MAX TC
+#
+restore_configs
+opt_set MOTHERBOARD BOARD_RAMPS_14_EFB EXTRUDERS 1 \
+        TEMP_SENSOR_0 -2 TEMP_SENSOR_REDUNDANT -2 \
+        TEMP_SENSOR_REDUNDANT_SOURCE E1 TEMP_SENSOR_REDUNDANT_TARGET E0 \
+        TEMP_0_CS_PIN 11 TEMP_1_CS_PIN 12
+
+exec_test $1 $2 "MEGA2560 RAMPS | Redundant temperature sensor | 2x MAX6675" "$3"
+
+#
 # Language files test with REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
 #
 #restore_configs


### PR DESCRIPTION
### Description

Compilation fails from some additions to the redundant temp fixups 2. It was previously assumed that TEMP_SENSOR_REDUNDANT_SOURCE/TARGET was a number directly corresponding to the heater type enum; now it's a partial identifier that needs to be prepended with `HID_` to be valid. This was breaking sanity checks & actual usage of the values in code.

### Requirements

Redundant temperature sensor enabled.

### Benefits

Fixes compilation.

### Configurations

`#define TEMP_SENSOR_REDUNDANT 1`

### Related Issues

#22196 