### PR TITLE
MKS_ROBIN_NANO_V3 add MT_DET_PIN_INVERTING

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -180,6 +180,7 @@
 //
 #define MT_DET_1_PIN                        PA4
 #define MT_DET_2_PIN                        PE6
+#define MT_DET_PIN_INVERTING              false  // LVGL UI filament RUNOUT PIN STATE
 #define PW_DET                              PA13
 #define PW_OFF                              PB2
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -180,7 +180,7 @@
 //
 #define MT_DET_1_PIN                        PA4
 #define MT_DET_2_PIN                        PE6
-#define MT_DET_PIN_INVERTING              false  // LVGL UI filament RUNOUT PIN STATE
+#define MT_DET_PIN_INVERTING               false  // LVGL UI filament RUNOUT PIN STATE
 #define PW_DET                              PA13
 #define PW_OFF                              PB2
 


### PR DESCRIPTION
### Description

Follow up to https://github.com/MarlinFirmware/Marlin/pull/22109

When board has MT_DET_{N}_PIN code filament_check() expects MT_DET_PIN_INVERTING to be defined.

This is present in all boards pins files with MT_DET_{N}_PIN except Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h

Added it to Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h also.

### Requirements

BOARD_MKS_ROBIN_NANO_V3, MKS_TS35_V2_0, TFT_LVGL_UI

### Benefits

Doesn't error out with
```
Marlin/src/lcd/extui/mks_ui/printer_operation.cpp: In function 'void filament_check()':
Marlin/src/lcd/extui/mks_ui/printer_operation.cpp:166:31: error: 'MT_DET_PIN_INVERTING' was not declared in this scope; did you mean 'SUICIDE_PIN_INVERTING'?
  166 |     if (READ(MT_DET_1_PIN) == MT_DET_PIN_INVERTING)
 
```

### Configurations

messy config with a few weird defines to get around another issue ( see https://github.com/MarlinFirmware/Marlin/issues/22349 )
But demonstrates this issue.  
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6805968/Configuration.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/21069