### PR TITLE
Fix BTT002 and Einsy Rambo board thermistor pins & add TDK NTCG104LH104KT1 thermistor

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -451,6 +451,7 @@
  *    67 : 500kΩ  SliceEngineering 450°C Thermistor
  *    70 : 100kΩ  bq Hephestos 2
  *    75 : 100kΩ  Generic Silicon Heat Pad with NTC100K MGB18-104F39050L32
+ *  2000 : 100kΩ  Ultimachine Rambo TDK NTCG104LH104KT1 NTC100K motherboard Thermistor
  *
  *  Analog Thermistors - 1kΩ pullup - Atypical, and requires changing out the 4.7kΩ pullup for 1kΩ.
  *  -------                           (but gives greater accuracy and more stable PID)

--- a/Marlin/src/lcd/thermistornames.h
+++ b/Marlin/src/lcd/thermistornames.h
@@ -128,6 +128,8 @@
   #define THERMISTOR_NAME "Pt100 1K"
 #elif THERMISTOR_ID == 666
   #define THERMISTOR_NAME "Einstart S"
+#elif THERMISTOR_ID == 2000
+  #define THERMISTOR_NAME "TDK NTCG104LH104JT1"
 
 // High Temperature thermistors
 #elif THERMISTOR_ID == 61

--- a/Marlin/src/module/thermistor/thermistor_2000.h
+++ b/Marlin/src/module/thermistor/thermistor_2000.h
@@ -1,0 +1,60 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+// R25 = 100 KOhm, beta25 = 4550 K, 4.7 kOhm pull-up, TDK NTCG104LH104KT1 https://product.tdk.com/en/search/sensor/ntc/chip-ntc-thermistor/info?part_no=NTCG104LH104KT1
+constexpr temp_entry_t temptable_2000[] PROGMEM = {
+{ OV(313),   125 },
+{ OV(347),   120 },
+{ OV(383),   115 },
+{ OV(422),   110 },
+{ OV(463),   105 },
+{ OV(506),   100 },
+{ OV(549),   95 },
+{ OV(594),   90 },
+{ OV(638),   85 },
+{ OV(681),   80 },
+{ OV(722),   75 },
+{ OV(762),   70 },
+{ OV(799),   65 },
+{ OV(833),   60 },
+{ OV(863),   55 },
+{ OV(890),   50 },
+{ OV(914),   45 },
+{ OV(934),   40 },
+{ OV(951),   35 },
+{ OV(966),   30 },
+{ OV(978),   25 },
+{ OV(988),   20 },
+{ OV(996),   15 },
+{ OV(1002),  10 },
+{ OV(1007),   5 },
+{ OV(1012),   0 },
+{ OV(1015),  -5 },
+{ OV(1017), -10 },
+{ OV(1019), -15 },
+{ OV(1020), -20 },
+{ OV(1021), -25 },
+{ OV(1022), -30 },
+{ OV(1023), -35 },
+{ OV(1023), -40 }
+};

--- a/Marlin/src/module/thermistor/thermistors.h
+++ b/Marlin/src/module/thermistor/thermistors.h
@@ -201,6 +201,9 @@ typedef struct { int16_t value; celsius_t celsius; } temp_entry_t;
 #if ANY_THERMISTOR_IS(1047) // Pt1000 with 4k7 pullup
   #include "thermistor_1047.h"
 #endif
+#if ANY_THERMISTOR_IS(2000) // "Ultimachine Rambo TDK NTCG104LH104KT1 NTC100K motherboard Thermistor" https://product.tdk.com/en/search/sensor/ntc/chip-ntc-thermistor/info?part_no=NTCG104LH104KT1
+  #include "thermistor_2000.h"
+#endif
 #if ANY_THERMISTOR_IS(998) // User-defined table 1
   #include "thermistor_998.h"
 #endif

--- a/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
+++ b/Marlin/src/pins/rambo/pins_EINSY_RAMBO.h
@@ -116,7 +116,7 @@
 //
 #define TEMP_0_PIN                             0  // Analog Input, Header J2
 #define TEMP_1_PIN                             1  // Analog Input, Header J3
-#define TEMP_BOARD_PIN                TEMP_1_PIN  // Analog Input, Header J3
+#define TEMP_BOARD_PIN                        91  // Onboard thermistor, 100k TDK NTCG104LH104JT1
 #define TEMP_BED_PIN                           2  // Analog Input, Header J6
 #define TEMP_PROBE_PIN                         3  // Analog Input, Header J15
 

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -161,7 +161,7 @@
 //
 #define TEMP_0_PIN                          PA2   // T0 <-> E0
 #define TEMP_1_PIN                          PA0   // T1 <-> E1
-#define TEMP_BOARD_PIN               TEMP_1_PIN   // Onboard sensor shared with T1
+#define TEMP_BOARD_PIN                      PC2   // Onboard thermistor, NTC100K
 #define TEMP_BED_PIN                        PA1   // T2 <-> Bed
 #define TEMP_PROBE_PIN                      PC3   // Shares J4 connector with PD1
 


### PR DESCRIPTION
### Description

Fix BTT002 & Einsy Rambo `TEMP_BOARD_PIN`. Verified on real hardware.

~~I also disabled `TEMP_BOARD_PIN` on the Einsy Rambo for now since `TEMP_1_PIN` is not correct. Schematics say PF6/ADC6/TDO/Pin 91, but that shows a constant 61°C, so I need to do more digging and will submit a separate PR.~~

~~Pin 91 is correct and it's just Marlin's lack of [TDK NTCG104LH104JT1 thermistor](https://github.com/prusa3d/Prusa-Firmware/blob/1279a6cf4b852287ba708ea7f76c7ebb49f80c1c/Firmware/thermistortables.h#L1215-L1290) support.~~

 Ultimachine Rambo TDK NTCG104LH104KT1 thermistor table has been ported over from Prusa's firmware. I'm still getting incorrect temps, but this warning could be a clue:

<details><summary>HAS_ANALOG_SELECT error:</summary>
<p>

```cpp
Compiling .pio/build/rambo/lib005/TMCStepper/source/SW_MODE.cpp.o
In file included from Marlin/src/module/../inc/../HAL/./AVR/HAL.h:22:0,
                 from Marlin/src/module/../inc/../HAL/HAL.h:30,
                 from Marlin/src/module/../inc/MarlinConfig.h:31,
                 from Marlin/src/module/../MarlinCore.h:24,
                 from Marlin/src/module/temperature.cpp:30:
Marlin/src/module/temperature.cpp: In member function 'void Temperature::init()':
Marlin/src/module/../inc/../HAL/./AVR/../shared/Marduino.h:42:26: warning: left shift count >= width of type [-Wshift-count-overflow]
 #define _BV(b) (1UL << (b))
                          ^
Marlin/src/module/../inc/../HAL/./AVR/../shared/Marduino.h:44:26: note: in expansion of macro '_BV'
   #define SBI(A,B) (A |= _BV(B))
                          ^~~
Marlin/src/module/../inc/../HAL/./AVR/HAL.h:160:51: note: in expansion of macro 'SBI'
   #define HAL_ANALOG_SELECT(ind) do{ if (ind < 8) SBI(DIDR0, ind); else SBI(DIDR2, ind & 0x07); }while(0)
                                                   ^~~
Marlin/src/module/temperature.cpp:2327:5: note: in expansion of macro 'HAL_ANALOG_SELECT'
     HAL_ANALOG_SELECT(TEMP_BOARD_PIN);
     ^~~~~~~~~~~~~~~~~
Compiling .pio/build/rambo/lib005/TMCStepper/source/SW_SPI.cpp.o
```

</p>
</details>

### Benefits

BTT002 owners can now monitor motherboard temperatures. Einsy Rambo users will need to wait for proper TDK NTCG104LH104JT1 thermistor support since temps are reading incorrectly, but it's a step in the right direction!

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/22343
https://github.com/MarlinFirmware/Marlin/pull/22279