### PR TITLE
Restore FLYmaker FLY Mini Environment

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -249,7 +249,7 @@
 #define BOARD_BTT_SKR_V1_4_TURBO      2508  // BigTreeTech SKR v1.4 TURBO (Power outputs: Hotend0, Hotend1, Fan, Bed)
 #define BOARD_MKS_SGEN_L_V2           2509  // MKS SGEN_L V2 (Power outputs: Hotend0, Hotend1, Bed, Fan)
 #define BOARD_BTT_SKR_E3_TURBO        2510  // BigTreeTech SKR E3 Turbo (Power outputs: Hotend0, Hotend1, Bed, Fan0, Fan1)
-#define BOARD_FLY_CDY                 2511  // FLY_CDY (Power outputs: Hotend0, Hotend1, Hotend2, Bed, Fan0, Fan1, Fan2)
+#define BOARD_FLY_CDY                 2511  // FLYmaker FLY CDY (Power outputs: Hotend0, Hotend1, Hotend2, Bed, Fan0, Fan1, Fan2)
 
 //
 // SAM3X8E ARM Cortex M3
@@ -340,7 +340,7 @@
 #define BOARD_CREALITY_V452           4042  // Creality v4.5.2 (STM32F103RE)
 #define BOARD_CREALITY_V453           4043  // Creality v4.5.3 (STM32F103RE)
 #define BOARD_TRIGORILLA_PRO          4044  // Trigorilla Pro (STM32F103ZET6)
-#define BOARD_FLY_MINI                4045  // FLY MINI (STM32F103RCT6)
+#define BOARD_FLY_MINI                4045  // FLYmaker FLY MINI (STM32F103RCT6)
 #define BOARD_FLSUN_HISPEED           4046  // FLSUN HiSpeedV1 (STM32F103VET6)
 #define BOARD_BEAST                   4047  // STM32F103RET6 Libmaple-based controller
 #define BOARD_MINGDA_MPX_ARM_MINI     4048  // STM32F103ZET6 Mingda MD-16
@@ -380,7 +380,7 @@
 #define BOARD_FYSETC_S6               4220  // FYSETC S6 (STM32F446VET6)
 #define BOARD_FYSETC_S6_V2_0          4221  // FYSETC S6 v2.0 (STM32F446VET6)
 #define BOARD_FYSETC_SPIDER           4222  // FYSETC Spider (STM32F446VET6)
-#define BOARD_FLYF407ZG               4223  // FLYF407ZG (STM32F407ZG)
+#define BOARD_FLYF407ZG               4223  // FLYmaker FLYF407ZG (STM32F407ZG)
 #define BOARD_MKS_ROBIN2              4224  // MKS_ROBIN2 (STM32F407ZE)
 #define BOARD_MKS_ROBIN_PRO_V2        4225  // MKS Robin Pro V2 (STM32F407VE)
 #define BOARD_MKS_ROBIN_NANO_V3       4226  // MKS Robin Nano V3 (STM32F407VG)

--- a/Marlin/src/pins/stm32f1/pins_FLY_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_FLY_MINI.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #define BOARD_INFO_NAME   "FLY_MINI"
-#define BOARD_WEBSITE_URL "github.com/FLYmaker"
+#define BOARD_WEBSITE_URL "github.com/FLYmaker/FLY-MINI"
 #define DISABLE_JTAG
 
 //

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -342,3 +342,17 @@ build_unflags = ${common_stm32f1.build_unflags}
 platform      = ${common_stm32f1.platform}
 extends       = env:chitu_f103
 build_flags   = ${env:chitu_f103.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
+
+#
+# FLYmaker FLY MINI (STM32F103RCT6)
+#
+[env:FLY_MINI]
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103RC
+board_build.address  = 0x08005000
+board_build.ldscript = fly_mini.ld
+extra_scripts     = ${common_stm32f1.extra_scripts}
+  buildroot/share/PlatformIO/scripts/custom_board.py
+build_flags       = ${common_stm32f1.build_flags}
+ -DDEBUG_LEVEL=0 -DSS_TIMER=4

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -342,17 +342,3 @@ build_unflags = ${common_stm32f1.build_unflags}
 platform      = ${common_stm32f1.platform}
 extends       = env:chitu_f103
 build_flags   = ${env:chitu_f103.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
-
-#
-# FLYmaker FLY MINI (STM32F103RCT6)
-#
-[env:FLY_MINI]
-platform          = ${common_stm32f1.platform}
-extends           = common_stm32f1
-board             = genericSTM32F103RC
-board_build.address  = 0x08005000
-board_build.ldscript = fly_mini.ld
-extra_scripts     = ${common_stm32f1.extra_scripts}
-  buildroot/share/PlatformIO/scripts/custom_board.py
-build_flags       = ${common_stm32f1.build_flags}
- -DDEBUG_LEVEL=0 -DSS_TIMER=4

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -271,7 +271,7 @@ board                = genericSTM32F103RC
 board_build.core     = stm32
 board_build.variant  = MARLIN_F103Rx
 board_build.offset   = 0x5000
-board_upload.offset_address  = 0x08005000
+board_upload.offset_address = 0x08005000
 extra_scripts        = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
   buildroot/share/PlatformIO/scripts/stm32_bootloader.py


### PR DESCRIPTION
### Description

Restore FLYmaker FLY Mini environment. Verified on a real FLYmaker FLY Mini.

### Benefits

FLYmaker Mini owners can compile for their board again.

### Related Issues

Found while discussing migrating boards out of maple on Discord. This board was incorrectly added under the STM32F4 section before being accidentally ~~migrated~~ removed in https://github.com/MarlinFirmware/Marlin/pull/21507
