### PR TITLE
Remove FLYmaker FLY Mini Maple Environment Option

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -552,7 +552,7 @@
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro
 #elif MB(FLY_MINI)
-  #include "stm32f1/pins_FLY_MINI.h"            // STM32F1                                env:FLY_MINI env:FLY_MINI_maple
+  #include "stm32f1/pins_FLY_MINI.h"            // STM32F1                                env:FLY_MINI
 #elif MB(FLSUN_HISPEED)
   #include "stm32f1/pins_FLSUN_HISPEED.h"       // STM32F1                                env:flsun_hispeedv1
 #elif MB(BEAST)


### PR DESCRIPTION
### Description

The FLY Mini did not get a `*_maple` environment (https://github.com/MarlinFirmware/Marlin/pull/22355/commits/80ef74d2ba72976c8ed3d2f1e34b0b6cc16b5557), but the option was added in https://github.com/MarlinFirmware/Marlin/pull/22356.

### Benefits

Users will no longer be presented with an invalid environment when building for this board.

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/22355
https://github.com/MarlinFirmware/Marlin/pull/22356