### PR TITLE
Restore FLYmaker FLY Mini Maple Environment

### DIFF
--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -342,3 +342,17 @@ build_unflags = ${common_stm32f1.build_unflags}
 platform      = ${common_stm32f1.platform}
 extends       = env:chitu_f103
 build_flags   = ${env:chitu_f103.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
+
+#
+# FLYmaker FLY Mini (STM32F103RCT6)
+#
+[env:FLY_MINI_maple]
+platform          = ${common_stm32f1.platform}
+extends           = common_stm32f1
+board             = genericSTM32F103RC
+board_build.address  = 0x08005000
+board_build.ldscript = fly_mini.ld
+extra_scripts     = ${common_stm32f1.extra_scripts}
+  buildroot/share/PlatformIO/scripts/custom_board.py
+build_flags       = ${common_stm32f1.build_flags}
+ -DDEBUG_LEVEL=0 -DSS_TIMER=4

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -261,7 +261,7 @@ build_flags = ${common_stm32.build_flags}
 src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
 
 #
-# FLY Mini (STM32F103RCT6)
+# FLYmaker FLY Mini (STM32F103RCT6)
 #
 [env:FLY_MINI]
 platform             = ${common_stm32.platform}


### PR DESCRIPTION
### Description

Readdressing https://github.com/MarlinFirmware/Marlin/pull/22355: Restore FLYmaker FLY Mini environment. Verified on a real FLYmaker FLY Mini.

### Benefits

FLYmaker Mini owners can compile for their board under maple again.

### Related Issues

- Found while discussing migrating boards out of maple on Discord. This board was incorrectly added under the STM32F4 section before being accidentally ~~migrated~~ removed in https://github.com/MarlinFirmware/Marlin/pull/21507
- https://github.com/MarlinFirmware/Marlin/pull/22356
- https://github.com/MarlinFirmware/Marlin/pull/22359