### PR TITLE
Fix BTT E3 Turbo SD Detection

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -271,5 +271,5 @@
   #define SD_MOSI_PIN                      P0_09
   #define SD_SS_PIN                        P0_06
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "SD CUSTOM_CABLE is not compatible with SKR E3 Turbo."
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board."
 #endif

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -264,6 +264,7 @@
 #endif
 
 #if SD_CONNECTION_IS(ONBOARD)
+  #define NO_SD_HOST_DRIVE
   #define SD_DETECT_PIN                    P2_00
   #define SD_SCK_PIN                       P0_07
   #define SD_MISO_PIN                      P0_08

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
@@ -283,7 +283,7 @@
   #define SD_DETECT_PIN                     PA15
   #define SD_SS_PIN                         PA10
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "SD CUSTOM_CABLE is not compatible with SKR E3 DIP."
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board."
 #endif
 
 #define ONBOARD_SPI_DEVICE                     1  // SPI1

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -296,7 +296,7 @@
   #define SD_DETECT_PIN                     PB5
   #define SD_SS_PIN                         PA10
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "SD CUSTOM_CABLE is not compatible with SKR Mini E3."
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board."
 #endif
 
 #define ONBOARD_SPI_DEVICE                     1  // SPI1 -> used only by HAL/STM32F1...

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -360,7 +360,7 @@
   //#define SDIO_CLOCK                  48000000
   #define SD_DETECT_PIN                     PC4
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "SD CUSTOM_CABLE is not compatible with BTT E3 RRF."
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board."
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -365,7 +365,7 @@
   #define SD_DETECT_PIN                     PC4
 
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board"
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board."
 #endif
 
 /**

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -364,7 +364,7 @@
   #define SD_DETECT_PIN                     PC15
 
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board"
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board."
 #endif
 
 #if ENABLED(BTT_MOTOR_EXPANSION)

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -312,7 +312,7 @@
   #define SD_DETECT_PIN                     PB11
 
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board"
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board."
 #endif
 
 #if ENABLED(BTT_MOTOR_EXPANSION)

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -356,7 +356,7 @@
   #define SD_DETECT_PIN                     PC4
 
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board"
+  #error "CUSTOM_CABLE is not a supported SDCARD_CONNECTION for this board."
 #endif
 
 #if ENABLED(BTT_MOTOR_EXPANSION)


### PR DESCRIPTION
### Description

[Similar to other boards](https://github.com/search?q=NO_SD_HOST_DRIVE+repo%3AMarlinFirmware%2FMarlin+path%3AMarlin%2Fsrc%2Fpins%2F&type=Code&ref=advsearch&l=&l=), mass storage interferes with SD detection on this board, so I've enabled `NO_SD_HOST_DRIVE`.

This is done silently in other pins files, but can easily be changed to alert the user of the required change.

### Requirements

BTT E3 Turbo

### Benefits

SD detection works.

### Configurations

[Ender-3/BigTreeTech SKR E3 Turbo](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Creality/Ender-3/BigTreeTech%20SKR%20E3%20Turbo)

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/21599