### PR TITLE
Add support mks mini12864 v3 for e3/e3d board

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -156,7 +156,6 @@
     #define DOGLCD_MOSI                     PB15
 
   #elif ENABLED(MKS_MINI_12864_V3)
-    #define ENABLE_SPI3
     #define DOGLCD_CS                       PA4
     #define DOGLCD_A0                       PA5
     #define LCD_PINS_DC                     DOGLCD_A0
@@ -165,7 +164,9 @@
     #define NEOPIXEL_PIN                    PA7
     #define DOGLCD_MOSI                     PB15
     #define DOGLCD_SCK                      PB13
-
+    #define FORCE_SOFT_SPI
+    #define SOFTWARE_SPI
+    
   #else
 
     #define LCD_PINS_D4                     PA6

--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/variant.h
@@ -101,24 +101,19 @@ extern "C" {
 #endif
 
 // Override default Arduino configuration
+
 // SPI Definitions
-#ifdef DEFAULT_SPI3 || DEFAULT_SPI2
-  //SPI3
-  #ifdef DEFAULT_SPI3
-	#define PIN_SPI_SS          PA15
-	#define PIN_SPI_MOSI        PB3
-	#define PIN_SPI_MISO        PB4
-	#define PIN_SPI_SCK         PB5
-  #endif
-  //SPI2
-  #ifdef DEFAULT_SPI2
-	#define PIN_SPI_SS          PB12
-	#define PIN_SPI_MOSI        PB13
-	#define PIN_SPI_MISO        PB14
-	#define PIN_SPI_SCK         PB15
-  #endif
+#ifdef DEFAULT_SPI3
+  #define PIN_SPI_SS            PA15
+  #define PIN_SPI_MOSI          PB3
+  #define PIN_SPI_MISO          PB4
+  #define PIN_SPI_SCK           PB5
+#elif defined(DEFAULT_SPI2)
+  #define PIN_SPI_SS            PB12
+  #define PIN_SPI_MOSI          PB13
+  #define PIN_SPI_MISO          PB14
+  #define PIN_SPI_SCK           PB15
 #else
-  //SPI1
   #define PIN_SPI_SS            PA4
   #define PIN_SPI_MOSI          PA7
   #define PIN_SPI_MISO          PA6
@@ -136,6 +131,7 @@ extern "C" {
 #ifndef TIMER_SERVO
   #define TIMER_SERVO           TIM2
 #endif
+
 // UART Definitions
 // Define here Serial instance number to map on Serial generic name
 #define SERIAL_UART_INSTANCE    1
@@ -144,7 +140,7 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
-/* Extra HAL modules */
+// Extra HAL modules
 #if defined(STM32F103xE) || defined(STM32F103xG)
 #define HAL_DAC_MODULE_ENABLED
 #endif

--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/variant.h
@@ -103,12 +103,12 @@ extern "C" {
 // Override default Arduino configuration
 
 // SPI Definitions
-#ifdef DEFAULT_SPI3
+#if DEFAULT_SPI == 3
   #define PIN_SPI_SS            PA15
   #define PIN_SPI_MOSI          PB3
   #define PIN_SPI_MISO          PB4
   #define PIN_SPI_SCK           PB5
-#elif defined(DEFAULT_SPI2)
+#elif DEFAULT_SPI == 2
   #define PIN_SPI_SS            PB12
   #define PIN_SPI_MOSI          PB13
   #define PIN_SPI_MISO          PB14

--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/variant.h
@@ -102,10 +102,28 @@ extern "C" {
 
 // Override default Arduino configuration
 // SPI Definitions
-#define PIN_SPI_SS              PA4
-#define PIN_SPI_MOSI            PA7
-#define PIN_SPI_MISO            PA6
-#define PIN_SPI_SCK             PA5
+#ifdef DEFAULT_SPI3 || DEFAULT_SPI2
+  //SPI3
+  #ifdef DEFAULT_SPI3
+	#define PIN_SPI_SS          PA15
+	#define PIN_SPI_MOSI        PB3
+	#define PIN_SPI_MISO        PB4
+	#define PIN_SPI_SCK         PB5
+  #endif
+  //SPI2
+  #ifdef DEFAULT_SPI2
+	#define PIN_SPI_SS          PB12
+	#define PIN_SPI_MOSI        PB13
+	#define PIN_SPI_MISO        PB14
+	#define PIN_SPI_SCK         PB15
+  #endif
+#else
+  //SPI1
+  #define PIN_SPI_SS            PA4
+  #define PIN_SPI_MOSI          PA7
+  #define PIN_SPI_MISO          PA6
+  #define PIN_SPI_SCK           PA5
+#endif
 
 // I2C Definitions
 #define PIN_WIRE_SDA            PB7

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -125,9 +125,7 @@ lib_deps             =
 [env:mks_robin_e3]
 platform                    = ${common_stm32.platform}
 extends                     = common_STM32F103RC
-build_flags                 = ${common_stm32.build_flags}
-  -DDEBUG_LEVEL=0 -DTIMER_SERVO=TIM5
-  -DDEFAULT_SPI3
+build_flags                 = ${common_stm32.build_flags} -DDEBUG_LEVEL=0 -DTIMER_SERVO=TIM5 -DDEFAULT_SPI3
 build_unflags               = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
 monitor_speed               = 115200
 board_build.offset          = 0x5000

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -127,6 +127,7 @@ platform                    = ${common_stm32.platform}
 extends                     = common_STM32F103RC
 build_flags                 = ${common_stm32.build_flags}
   -DDEBUG_LEVEL=0 -DTIMER_SERVO=TIM5
+  -DDEFAULT_SPI3
 build_unflags               = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
 monitor_speed               = 115200
 board_build.offset          = 0x5000

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -125,7 +125,7 @@ lib_deps             =
 [env:mks_robin_e3]
 platform                    = ${common_stm32.platform}
 extends                     = common_STM32F103RC
-build_flags                 = ${common_stm32.build_flags} -DDEBUG_LEVEL=0 -DTIMER_SERVO=TIM5 -DDEFAULT_SPI3
+build_flags                 = ${common_stm32.build_flags} -DDEBUG_LEVEL=0 -DTIMER_SERVO=TIM5 -DDEFAULT_SPI=3
 build_unflags               = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
 monitor_speed               = 115200
 board_build.offset          = 0x5000


### PR DESCRIPTION
### Description
Add support MKS MINI12864 V3.0 for MKS Robin E3/E3D board
- Fix screen freezes when read tf card file on  E3/E3D board
- Only use it on env: mks_robin_e3
- Because neopixel_pin is PA7, so, i has change SPI pin define to DEFAULT_SPI3
- My test：[MKS MINI12864  V3+E3 TEST.zip](https://github.com/MarlinFirmware/Marlin/files/6820829/MKS.MINI12864.V3%2BE3.TEST.zip)


### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/22285
