### PR TITLE
Longer3D board is a VE variant

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Vx/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Vx/variant.h
@@ -132,8 +132,12 @@ extern "C" {
 
 // Timer Definitions (optional)
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
-#define TIMER_TONE              TIM3
-#define TIMER_SERVO             TIM2
+#ifndef TIMER_TONE
+  #define TIMER_TONE            TIM6
+#endif
+#ifndef TIMER_SERVO
+  #define TIMER_SERVO           TIM7
+#endif
 
 // UART Definitions
 // Define here Serial instance number to map on Serial generic name

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -372,10 +372,8 @@ board_build.core    = stm32
 board_build.variant = MARLIN_F103Vx
 board_build.offset  = 0x1000
 board_build.address = 0x08010000
-build_flags         = ${common_stm32.build_flags}
-  -DMCU_STM32F103VE -DU20 -DTS_V12
-build_unflags       = ${common_stm32.build_unflags}
-  -DUSBCON -DUSBD_USE_CDC
+build_flags         = ${common_stm32.build_flags} -DMCU_STM32F103VE -DU20 -DTS_V12
+build_unflags       = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
 extra_scripts       = ${stm32f1_variant.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
 

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -373,7 +373,7 @@ board_build.variant = MARLIN_F103Vx
 board_build.offset  = 0x1000
 board_build.address = 0x08010000
 build_flags         = ${common_stm32.build_flags}
-  -DMCU_STM32F103VE -DU20 -DTS_V12
+  -DMCU_STM32F103VE -DU20 -DTS_V12 -DTIMER_SERVO=TIM7
 build_unflags       = ${common_stm32.build_unflags}
   -DUSBCON -DUSBD_USE_CDC
 extra_scripts       = ${stm32f1_variant.extra_scripts}

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -373,8 +373,9 @@ board_build.variant = MARLIN_F103Vx
 board_build.offset  = 0x1000
 board_build.address = 0x08010000
 build_flags         = ${common_stm32.build_flags}
-  -DMCU_STM32F103VE -DSTM32F1xx -USERIAL_USB -DU20 -DTS_V12
+  -DMCU_STM32F103VE -DU20 -DTS_V12
 build_unflags       = ${common_stm32.build_unflags}
+  -DUSBCON -DUSBD_USE_CDC
 extra_scripts       = ${stm32f1_variant.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
 

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -194,7 +194,7 @@ build_flags       = ${env:STM32F103RE_btt.build_flags} ${env:stm32_flash_drive.b
 [env:flsun_hispeedv1]
 platform             = ${common_stm32.platform}
 extends              = common_stm32
-build_flags          = ${common_stm32.build_flags} -DMCU_STM32F103VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
+build_flags          = ${common_stm32.build_flags} -DMCU_STM32F103VE -DSS_TIMER=4 -DENABLE_HWSERIAL3 -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
 board                = genericSTM32F103VE
 board_build.core     = stm32
 board_build.variant  = MARLIN_F103Vx
@@ -210,7 +210,7 @@ extra_scripts        = ${stm32f1_variant.extra_scripts}
 [env:mks_robin_nano35]
 platform             = ${common_stm32.platform}
 extends              = common_stm32
-build_flags          = ${common_stm32.build_flags} -DMCU_STM32F103VE -DSS_TIMER=4 -DENABLE_HWSERIAL3
+build_flags          = ${common_stm32.build_flags} -DMCU_STM32F103VE -DSS_TIMER=4 -DENABLE_HWSERIAL3 -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
 board                = genericSTM32F103VE
 board_build.core     = stm32
 board_build.variant  = MARLIN_F103Vx

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -369,13 +369,12 @@ platform            = ${common_stm32.platform}
 extends             = common_stm32
 board               = genericSTM32F103VE
 board_build.core    = stm32
-board_build.variant = MARLIN_F103Zx
+board_build.variant = MARLIN_F103Vx
 board_build.offset  = 0x1000
 board_build.address = 0x08010000
 build_flags         = ${common_stm32.build_flags}
   -DMCU_STM32F103VE -DSTM32F1xx -USERIAL_USB -DU20 -DTS_V12
 build_unflags       = ${common_stm32.build_unflags}
-  -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=1 -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 extra_scripts       = ${stm32f1_variant.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
 

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -272,7 +272,7 @@ board_build.core    = stm32
 board_build.variant = MARLIN_F103Vx
 board_build.offset  = 0x7000
 board_build.encrypt = Robin_mini.bin
-build_flags         = ${common_stm32.build_flags} -DMCU_STM32F103VE
+build_flags         = ${common_stm32.build_flags} -DMCU_STM32F103VE -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
 board_upload.offset_address = 0x08007000
 extra_scripts       = ${stm32f1_variant.extra_scripts}
 
@@ -326,7 +326,7 @@ board_build.core    = stm32
 board_build.variant = MARLIN_F103Vx
 board_build.offset  = 0x7000
 board_build.encrypt = Robin_e3p.bin
-build_flags         = ${common_stm32.build_flags} -DMCU_STM32F103VE -DSS_TIMER=4
+build_flags         = ${common_stm32.build_flags} -DMCU_STM32F103VE -DSS_TIMER=4 -DTIMER_TONE=TIM3 -DTIMER_SERVO=TIM2
 board_upload.offset_address = 0x08007000
 extra_scripts       = ${stm32f1_variant.extra_scripts}
 debug_tool          = jlink

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -373,7 +373,7 @@ board_build.variant = MARLIN_F103Vx
 board_build.offset  = 0x1000
 board_build.address = 0x08010000
 build_flags         = ${common_stm32.build_flags}
-  -DMCU_STM32F103VE -DU20 -DTS_V12 -DTIMER_SERVO=TIM7
+  -DMCU_STM32F103VE -DU20 -DTS_V12
 build_unflags       = ${common_stm32.build_unflags}
   -DUSBCON -DUSBD_USE_CDC
 extra_scripts       = ${stm32f1_variant.extra_scripts}


### PR DESCRIPTION
Also remove unflags/cleanup defines which were generated by maple framework

To note, i cant build it for now due to a timers_in_use problem... maybe related to the bltouch.. to dig

edit: yes, its related to the software servo only available in STM32F1 HAL... SERVO0_TIMER_NUM