### PR TITLE
Use goto_screen for Change Filament preheat menu

### DIFF
--- a/Marlin/src/lcd/menu/menu_filament.cpp
+++ b/Marlin/src/lcd/menu/menu_filament.cpp
@@ -211,7 +211,7 @@ void menu_change_filament() {
     if (thermalManager.targetHotEnoughToExtrude(active_extruder))
       queue.inject_P(PSTR("M600B0"));
     else
-      _menu_temp_filament_op(PAUSE_MODE_CHANGE_FILAMENT, 0);
+      ui.goto_screen([]{ _menu_temp_filament_op(PAUSE_MODE_CHANGE_FILAMENT, 0); });
 
   #endif
 }


### PR DESCRIPTION
### Description

The Change Filament menu item shows a preheat menu when the nozzle is not heated. When `FILAMENT_LOAD_UNLOAD_GCODES` is **not** enabled, the preheat menu isn't properly shown. See #22360

This fixes that issue.

### Requirements

Any MarlinUI LCD with `ADVANCED_PAUSE_FEATURE` enabled and `FILAMENT_LOAD_UNLOAD_GCODES` **not** enabled.

### Benefits

Fixes #22360

### Configurations

[Ender 3 pro v427.zip](https://github.com/MarlinFirmware/Marlin/files/6824152/Ender.3.pro.v427.zip)

### Related Issues

#22360

### Additional Notes

I noticed while fixing this that the menu items created when `FILAMENT_LOAD_UNLOAD_GCODES` is enabled do not have a confirmation screen like Change Filament does when it is not enabled. This inconsistency isn't addressed here.