### PR TITLE
Longer3D: fix firmware offset and builtin pins

### DIFF
--- a/buildroot/tests/STM32F103VE_longer_maple
+++ b/buildroot/tests/STM32F103VE_longer_maple
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Build tests for STM32F103VET6 (using maple STM32F1 framework)
+#
+
+# exit on first failure
+set -e
+
+use_example_configs Alfawise/U20
+opt_enable BAUD_RATE_GCODE
+exec_test $1 $2 "maple CLASSIC_UI U20 config" "$3"
+
+use_example_configs Alfawise/U20
+opt_enable BAUD_RATE_GCODE TFT_COLOR_UI
+opt_disable TFT_CLASSIC_UI CUSTOM_STATUS_SCREEN_IMAGE
+exec_test $1 $2 "maple COLOR_UI U20 config" "$3"
+
+use_example_configs Alfawise/U20-bltouch
+opt_enable BAUD_RATE_GCODE
+exec_test $1 $2 "maple BLTouch U20 config"
+
+# cleanup
+restore_configs

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -369,10 +369,13 @@ extends             = common_stm32
 board               = genericSTM32F103VE
 board_build.core    = stm32
 board_build.variant = MARLIN_F103Vx
-board_build.offset  = 0x1000
+board_build.offset  = 0x10000
 board_build.address = 0x08010000
 build_flags         = ${common_stm32.build_flags} -DMCU_STM32F103VE -DU20 -DTS_V12
-build_unflags       = ${common_stm32.build_unflags} -DUSBCON -DUSBD_USE_CDC
+  -DLED_BUILTIN=PC2 -UPIN_WIRE_SDA -UPIN_WIRE_SCL -DPIN_WIRE_SDA=PB11 -DPIN_WIRE_SCL=PB10
+  -DHAL_DAC_MODULE_DISABLED -DHAL_I2S_MODULE_DISABLED
+build_unflags       = ${common_stm32.build_unflags}
+  -DUSBCON -DUSBD_USE_CDC -DHAL_PCD_MODULE_ENABLED
 extra_scripts       = ${stm32f1_variant.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
 


### PR DESCRIPTION
Also disable a few unused arduinoststm32 modules
and re-enable tests on fully working maple framework
