### PR TITLE
Use DELAY_NS for non-const SW SPI delay in DUE. (#22320)

### DIFF
--- a/Marlin/src/HAL/DUE/HAL_SPI.cpp
+++ b/Marlin/src/HAL/DUE/HAL_SPI.cpp
@@ -240,7 +240,7 @@
   }
 
   // all the others
-  static uint32_t spiDelayCyclesX4 = 4 * (F_CPU) / 1000000; // 4µs => 125khz
+  static uint16_t spiDelayNS = 400; // 400ns => 125khz
 
   static uint8_t spiTransferX(uint8_t b) { // using Mode 0
     int bits = 8;
@@ -249,12 +249,12 @@
       b <<= 1; // little setup time
 
       WRITE(SD_SCK_PIN, HIGH);
-      DELAY_CYCLES(spiDelayCyclesX4);
+      DELAY_NS(spiDelayNS);
 
       b |= (READ(SD_MISO_PIN) != 0);
 
       WRITE(SD_SCK_PIN, LOW);
-      DELAY_CYCLES(spiDelayCyclesX4);
+      DELAY_NS(spiDelayNS);
     } while (--bits);
     return b;
   }
@@ -510,7 +510,7 @@
         spiRxBlock = (pfnSpiRxBlock)spiRxBlockX;
         break;
       default:
-        spiDelayCyclesX4 = ((F_CPU) / 1000000) >> (6 - spiRate) << 2; // spiRate of 2 gives the maximum error with current CPU
+        spiDelayNS = (((F_CPU) / 1000000) >> (6 - spiRate) << 2) * 100; // spiRate of 2 gives the maximum error with current CPU
         spiTransferTx = (pfnSpiTransfer)spiTransferX;
         spiTransferRx = (pfnSpiTransfer)spiTransferX;
         spiTxBlock = (pfnSpiTxBlock)spiTxBlockX;

--- a/Marlin/src/HAL/DUE/HAL_SPI.cpp
+++ b/Marlin/src/HAL/DUE/HAL_SPI.cpp
@@ -240,7 +240,7 @@
   }
 
   // all the others
-  static uint16_t spiDelayNS = 400; // 400ns => 125khz
+  static uint16_t spiDelayNS = 4000; // 400ns => 125khz
 
   static uint8_t spiTransferX(uint8_t b) { // using Mode 0
     int bits = 8;
@@ -510,7 +510,7 @@
         spiRxBlock = (pfnSpiRxBlock)spiRxBlockX;
         break;
       default:
-        spiDelayNS = (((F_CPU) / 1000000) >> (6 - spiRate) << 2) * 100; // spiRate of 2 gives the maximum error with current CPU
+        spiDelayNS = 4000 >> (6 - spiRate); // spiRate of 2 gives the maximum error with current CPU
         spiTransferTx = (pfnSpiTransfer)spiTransferX;
         spiTransferRx = (pfnSpiTransfer)spiTransferX;
         spiTxBlock = (pfnSpiTxBlock)spiTxBlockX;

--- a/Marlin/src/HAL/DUE/HAL_SPI.cpp
+++ b/Marlin/src/HAL/DUE/HAL_SPI.cpp
@@ -240,7 +240,7 @@
   }
 
   // all the others
-  static uint16_t spiDelayNS = 4000; // 400ns => 125khz
+  static uint16_t spiDelayNS = 4000; // 4000ns => 125khz
 
   static uint8_t spiTransferX(uint8_t b) { // using Mode 0
     int bits = 8;


### PR DESCRIPTION
### Description

In DUE's HAL_SPI, a non-const integer is used with DELAY_CYCLES which causes an error on compilation. Instead of using cycles, use nanoseconds as used elsewhere in the file.

### Requirements

See #22320 for configs to reproduce.

### Benefits

Fixes bug in DUE SW SPI.

### Configurations

See #22320

### Related Issues

Resolves #22320