### PR TITLE
Fix typo in M913 Z axis handling

### DIFF
--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -260,10 +260,10 @@
         #endif
 
         case Z_AXIS:
-          TERN_(Z_HAS_STEALTCHOP, if (index < 2) TMC_SET_PWMTHRS(Z,Z));
-          TERN_(Z2_HAS_STEALTCHOP, if (index == 0 || index == 2) TMC_SET_PWMTHRS(Z,Z2));
-          TERN_(Z3_HAS_STEALTCHOP, if (index == 0 || index == 3) TMC_SET_PWMTHRS(Z,Z3));
-          TERN_(Z4_HAS_STEALTCHOP, if (index == 0 || index == 4) TMC_SET_PWMTHRS(Z,Z4));
+          TERN_(Z_HAS_STEALTHCHOP, if (index < 2) TMC_SET_PWMTHRS(Z,Z));
+          TERN_(Z2_HAS_STEALTHCHOP, if (index == 0 || index == 2) TMC_SET_PWMTHRS(Z,Z2));
+          TERN_(Z3_HAS_STEALTHCHOP, if (index == 0 || index == 3) TMC_SET_PWMTHRS(Z,Z3));
+          TERN_(Z4_HAS_STEALTHCHOP, if (index == 0 || index == 4) TMC_SET_PWMTHRS(Z,Z4));
           break;
         #if E_STEPPERS
           case E_AXIS: {


### PR DESCRIPTION


<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

These spelling typos prevent Z parameters from having any effect in M913.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
N/A

### Benefits

<!-- What does this PR fix or improve? -->
M913 Z parameters don't work at HEAD of 2.0.x, this fixes them

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->
HYBRID_THRESHOLD enabled for the M913

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
fixes a bug