### PR TITLE
Fix Software SPI when TEMP_n_MOSI_PIN is not defined

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -107,6 +107,27 @@
 #if (TEMP_SENSOR_0_USES_SW_SPI || TEMP_SENSOR_1_USES_SW_SPI) && !HAS_MAXTC_LIBRARIES
   #include "../libs/private_spi.h"
   #define HAS_MAXTC_SW_SPI 1
+
+  // determine the pins to use
+  #if TEMP_SENSOR_0_USES_SW_SPI
+    #define SW_SPI_SCK_PIN  TEMP_0_SCK_PIN
+    #define SW_SPI_MISO_PIN TEMP_0_MISO_PIN
+
+    #if PIN_EXISTS(TEMP_0_MOSI)
+      #define SW_SPI_MOSI_PIN TEMP_0_MOSI_PIN
+    #else
+      #define SW_SPI_MOSI_PIN SD_MOSI_PIN
+    #endif
+  #else
+    #define SW_SPI_SCK_PIN  TEMP_1_SCK_PIN
+    #define SW_SPI_MISO_PIN TEMP_1_MISO_PIN
+
+    #if PIN_EXISTS(TEMP_1_MOSI)
+      #define SW_SPI_MOSI_PIN TEMP_1_MOSI_PIN
+    #else
+      #define SW_SPI_MOSI_PIN SD_MOSI_PIN
+    #endif
+  #endif
 #endif
 
 #if ENABLED(PID_EXTRUSION_SCALING)
@@ -198,7 +219,8 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
     // Initialize SoftSPI for non-lib Software SPI; Libraries take care of it themselves.
     template<uint8_t MisoPin, uint8_t MosiPin, uint8_t SckPin>
       SoftSPI<MisoPin, MosiPin, SckPin> SPIclass<MisoPin, MosiPin, SckPin>::softSPI;
-    SPIclass<TEMP_0_MISO_PIN, TEMP_0_MOSI_PIN, TEMP_0_SCK_PIN> max_tc_spi;
+    SPIclass<SW_SPI_MISO_PIN, SW_SPI_MOSI_PIN, SW_SPI_SCK_PIN> max_tc_spi;
+
   #endif
 
   #define MAXTC_INIT(n, M) \

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -108,20 +108,18 @@
   #include "../libs/private_spi.h"
   #define HAS_MAXTC_SW_SPI 1
 
-  // determine the pins to use
+  // Define pins for SPI-based sensors
   #if TEMP_SENSOR_0_USES_SW_SPI
-    #define SW_SPI_SCK_PIN  TEMP_0_SCK_PIN
-    #define SW_SPI_MISO_PIN TEMP_0_MISO_PIN
-
+    #define SW_SPI_SCK_PIN    TEMP_0_SCK_PIN
+    #define SW_SPI_MISO_PIN   TEMP_0_MISO_PIN
     #if PIN_EXISTS(TEMP_0_MOSI)
       #define SW_SPI_MOSI_PIN TEMP_0_MOSI_PIN
     #else
       #define SW_SPI_MOSI_PIN SD_MOSI_PIN
     #endif
   #else
-    #define SW_SPI_SCK_PIN  TEMP_1_SCK_PIN
-    #define SW_SPI_MISO_PIN TEMP_1_MISO_PIN
-
+    #define SW_SPI_SCK_PIN    TEMP_1_SCK_PIN
+    #define SW_SPI_MISO_PIN   TEMP_1_MISO_PIN
     #if PIN_EXISTS(TEMP_1_MOSI)
       #define SW_SPI_MOSI_PIN TEMP_1_MOSI_PIN
     #else

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -114,17 +114,16 @@
     #define SW_SPI_MISO_PIN   TEMP_0_MISO_PIN
     #if PIN_EXISTS(TEMP_0_MOSI)
       #define SW_SPI_MOSI_PIN TEMP_0_MOSI_PIN
-    #else
-      #define SW_SPI_MOSI_PIN SD_MOSI_PIN
     #endif
   #else
     #define SW_SPI_SCK_PIN    TEMP_1_SCK_PIN
     #define SW_SPI_MISO_PIN   TEMP_1_MISO_PIN
     #if PIN_EXISTS(TEMP_1_MOSI)
       #define SW_SPI_MOSI_PIN TEMP_1_MOSI_PIN
-    #else
-      #define SW_SPI_MOSI_PIN SD_MOSI_PIN
     #endif
+  #endif
+  #ifndef SW_SPI_MOSI_PIN
+    #define SW_SPI_MOSI_PIN   SD_MOSI_PIN
   #endif
 #endif
 


### PR DESCRIPTION
### Description

From the temperature.cpp changes in the last month or so, a bug was introduced with Software SPI. If a MAX TC is used which does not have a MOSI pin, and thus a MOSI pin is not defined, SW SPI breaks compilation. This will default back to the old way - using SD_MOSI_PIN - even if MOSI is never used.

### Requirements

MAX31855, using software SPI, with only MISO, SCK, and SS defined.

### Benefits

Fixes a bug.

### Configurations

See 22346

### Related Issues

Fixes #22346