### PR TITLE
Fix BTC_SAMPLE_RES sanity check

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -623,7 +623,7 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
     static_assert(_test_btc_sample_start != 12.3f, "BTC_SAMPLE_START must be a whole number.");
   #endif
   #ifdef BTC_SAMPLE_RES
-    constexpr _btc_sample_res = BTC_SAMPLE_RES;
+    constexpr auto _btc_sample_res = BTC_SAMPLE_RES;
     constexpr decltype(_btc_sample_res) _test_btc_sample_res = 12.3f;
     static_assert(_test_btc_sample_res != 12.3f, "BTC_SAMPLE_RES must be a whole number.");
   #endif


### PR DESCRIPTION
### Description

A missing `auto` declaration for _btc_sample_res is breaking compilation if `PROBE_TEMP_COMPENSATION` is enabled.

### Requirements

`PROBE_TEMP_COMPENSATION` and `BTC_SAMPLE_RES` defined.

### Benefits

Fixes SanityCheck/compilation.

### Configurations

```diff
diff --git a/Marlin/Configuration.h b/Marlin/Configuration.h
index 4adc40a19f..9622460e1e 100644
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -493,8 +493,9 @@
 #define TEMP_SENSOR_5 0
 #define TEMP_SENSOR_6 0
 #define TEMP_SENSOR_7 0
-#define TEMP_SENSOR_BED 0
-#define TEMP_SENSOR_PROBE 0
+#define TEMP_SENSOR_BED 1
+#define TEMP_SENSOR_PROBE 1
+#define TEMP_PROBE_PIN 11
 #define TEMP_SENSOR_CHAMBER 0
 #define TEMP_SENSOR_COOLER 0
 #define TEMP_SENSOR_BOARD 0
@@ -1058,7 +1059,7 @@
  * A Fix-Mounted Probe either doesn't deploy or needs manual deployment.
  *   (e.g., an inductive probe or a nozzle-based probe-switch.)
  */
-//#define FIX_MOUNTED_PROBE
+#define FIX_MOUNTED_PROBE
 
 /**
  * Use the nozzle as the probe, as with a conductive
@@ -1725,7 +1726,7 @@
  * - Allows Z homing only when XY positions are known and trusted.
  * - If stepper drivers sleep, XY homing may be required again before Z homing.
  */
-//#define Z_SAFE_HOMING
+#define Z_SAFE_HOMING
 
 #if ENABLED(Z_SAFE_HOMING)
   #define Z_SAFE_HOMING_X_POINT X_CENTER  // X point for Z homing
diff --git a/Marlin/Configuration_adv.h b/Marlin/Configuration_adv.h
index e99e1f7c09..dd3b165f96 100644
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2007,15 +2007,15 @@
     // Probe temperature calibration generates a table of values starting at PTC_SAMPLE_START
     // (e.g., 30), in steps of PTC_SAMPLE_RES (e.g., 5) with PTC_SAMPLE_COUNT (e.g., 10) samples.
 
-    //#define PTC_SAMPLE_START  30  // (°C)
-    //#define PTC_SAMPLE_RES     5  // (°C)
-    //#define PTC_SAMPLE_COUNT  10
+    #define PTC_SAMPLE_START  30  // (°C)
+    #define PTC_SAMPLE_RES     5  // (°C)
+    #define PTC_SAMPLE_COUNT  10
 
     // Bed temperature calibration builds a similar table.
 
-    //#define BTC_SAMPLE_START  60  // (°C)
-    //#define BTC_SAMPLE_RES     5  // (°C)
-    //#define BTC_SAMPLE_COUNT  10
+    #define BTC_SAMPLE_START  60  // (°C)
+    #define BTC_SAMPLE_RES     5  // (°C)
+    #define BTC_SAMPLE_COUNT  10
 
     // The temperature the probe should be at while taking measurements during bed temperature
     // calibration.
```
### Related Issues

Fixes #22392
