### PR TITLE
MKS hardware test followup

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/mks_hardware.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/mks_hardware.cpp
@@ -127,77 +127,81 @@
     delay(100);
   }
 
-  void mks_gpio_test() {
-    init_test_gpio();
+  #if ENABLED(SDSUPPORT)
 
-    test_gpio_readlevel_L();
-    test_gpio_readlevel_H();
-    test_gpio_readlevel_L();
-    if (pw_det_sta && pw_off_sta && mt_det_sta
-      #if PIN_EXISTS(MT_DET_2)
-        && mt_det2_sta
-      #endif
-      #if ENABLED(MKS_HARDWARE_TEST_ONLY_E0)
-        && (READ(PA1) == LOW)
-        && (READ(PA3) == LOW)
-        && (READ(PC2) == LOW)
-        && (READ(PD8) == LOW)
-        && (READ(PE5) == LOW)
-        && (READ(PE6) == LOW)
-        && (READ(PE7) == LOW)
-      #endif
-    )
-      disp_det_ok();
-    else
-      disp_det_error();
+    void mks_gpio_test() {
+      init_test_gpio();
 
-    if (endstopx1_sta && endstopy1_sta && endstopz1_sta && endstopz2_sta)
-      disp_Limit_ok();
-    else
-      disp_Limit_error();
-  }
+      test_gpio_readlevel_L();
+      test_gpio_readlevel_H();
+      test_gpio_readlevel_L();
+      if (pw_det_sta && pw_off_sta && mt_det_sta
+        #if PIN_EXISTS(MT_DET_2)
+          && mt_det2_sta
+        #endif
+        #if ENABLED(MKS_HARDWARE_TEST_ONLY_E0)
+          && (READ(PA1) == LOW)
+          && (READ(PA3) == LOW)
+          && (READ(PC2) == LOW)
+          && (READ(PD8) == LOW)
+          && (READ(PE5) == LOW)
+          && (READ(PE6) == LOW)
+          && (READ(PE7) == LOW)
+        #endif
+      )
+        disp_det_ok();
+      else
+        disp_det_error();
 
-  void mks_hardware_test() {
-    if (millis() % 2000 < 1000) {
-      WRITE(X_DIR_PIN, LOW);
-      WRITE(Y_DIR_PIN, LOW);
-      WRITE(Z_DIR_PIN, LOW);
-      WRITE(E0_DIR_PIN, LOW);
-      #if DISABLED(MKS_HARDWARE_TEST_ONLY_E0)
-        WRITE(E1_DIR_PIN, LOW);
-      #endif
-      thermalManager.fan_speed[0] = 255;
-      #if DISABLED(MKS_HARDWARE_TEST_ONLY_E0)
-        WRITE(HEATER_1_PIN, HIGH); // HE1
-      #endif
-      WRITE(HEATER_0_PIN, HIGH); // HE0
-      WRITE(HEATER_BED_PIN, HIGH); // HOT-BED
-    }
-    else {
-      WRITE(X_DIR_PIN, HIGH);
-      WRITE(Y_DIR_PIN, HIGH);
-      WRITE(Z_DIR_PIN, HIGH);
-      WRITE(E0_DIR_PIN, HIGH);
-      #if DISABLED(MKS_HARDWARE_TEST_ONLY_E0)
-        WRITE(E1_DIR_PIN, HIGH);
-      #endif
-      thermalManager.fan_speed[0] = 0;
-      #if DISABLED(MKS_HARDWARE_TEST_ONLY_E0)
-        WRITE(HEATER_1_PIN, LOW); // HE1
-      #endif
-      WRITE(HEATER_0_PIN, LOW); // HE0
-      WRITE(HEATER_BED_PIN, LOW); // HOT-BED
+      if (endstopx1_sta && endstopy1_sta && endstopz1_sta && endstopz2_sta)
+        disp_Limit_ok();
+      else
+        disp_Limit_error();
     }
 
-    if (endstopx1_sta && endstopx2_sta && endstopy1_sta && endstopy2_sta && endstopz1_sta && endstopz2_sta) {
-      // nothing here
-    }
-    else {
+    void mks_hardware_test() {
+      if (millis() % 2000 < 1000) {
+        WRITE(X_DIR_PIN, LOW);
+        WRITE(Y_DIR_PIN, LOW);
+        WRITE(Z_DIR_PIN, LOW);
+        WRITE(E0_DIR_PIN, LOW);
+        #if DISABLED(MKS_HARDWARE_TEST_ONLY_E0)
+          WRITE(E1_DIR_PIN, LOW);
+        #endif
+        thermalManager.fan_speed[0] = 255;
+        #if DISABLED(MKS_HARDWARE_TEST_ONLY_E0)
+          WRITE(HEATER_1_PIN, HIGH); // HE1
+        #endif
+        WRITE(HEATER_0_PIN, HIGH); // HE0
+        WRITE(HEATER_BED_PIN, HIGH); // HOT-BED
+      }
+      else {
+        WRITE(X_DIR_PIN, HIGH);
+        WRITE(Y_DIR_PIN, HIGH);
+        WRITE(Z_DIR_PIN, HIGH);
+        WRITE(E0_DIR_PIN, HIGH);
+        #if DISABLED(MKS_HARDWARE_TEST_ONLY_E0)
+          WRITE(E1_DIR_PIN, HIGH);
+        #endif
+        thermalManager.fan_speed[0] = 0;
+        #if DISABLED(MKS_HARDWARE_TEST_ONLY_E0)
+          WRITE(HEATER_1_PIN, LOW); // HE1
+        #endif
+        WRITE(HEATER_0_PIN, LOW); // HE0
+        WRITE(HEATER_BED_PIN, LOW); // HOT-BED
+      }
+
+      if (endstopx1_sta && endstopx2_sta && endstopy1_sta && endstopy2_sta && endstopz1_sta && endstopz2_sta) {
+        // nothing here
+      }
+      else {
+      }
+
+      if (disp_state == PRINT_READY_UI)
+        mks_disp_test();
     }
 
-    if (disp_state == PRINT_READY_UI)
-      mks_disp_test();
-  }
+  #endif
 
 #endif // MKS_TEST
 
@@ -613,7 +617,7 @@ void disp_assets_update_progress(const char *msg) {
   disp_string(100, 165, buf, 0xFFFF, 0x0000);
 }
 
-#if ENABLED(SDSUPPORT)
+#if BOTH(MKS_TEST, SDSUPPORT)
   uint8_t mks_test_flag = 0;
   const char *MKSTestPath = "MKS_TEST";
   void mks_test_get() {

--- a/Marlin/src/lcd/extui/mks_ui/mks_hardware.h
+++ b/Marlin/src/lcd/extui/mks_ui/mks_hardware.h
@@ -26,17 +26,14 @@
 #include <lvgl.h>
 
 // Functions for MKS_TEST
-#if ENABLED(MKS_TEST)
-  void mks_gpio_test();
+#if BOTH(MKS_TEST, SDSUPPORT)
   void mks_hardware_test();
   void mks_test_get();
+  void mks_gpio_test();
+  extern uint8_t mks_test_flag;
 #endif
 
 // String display and assets
 void disp_string(uint16_t x, uint16_t y, const char * string, uint16_t charColor, uint16_t bkColor);
 void disp_assets_update();
 void disp_assets_update_progress(const char *msg);
-
-#if ENABLED(SDSUPPORT)
-  extern uint8_t mks_test_flag;
-#endif

--- a/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
@@ -139,6 +139,7 @@ void tft_lvgl_init() {
   #if ENABLED(SDSUPPORT)
     UpdateAssets();
     watchdog_refresh();   // LVGL init takes time
+    TERN_(MKS_TEST, mks_test_get());
   #endif
 
   touch.Init();

--- a/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
@@ -139,7 +139,6 @@ void tft_lvgl_init() {
   #if ENABLED(SDSUPPORT)
     UpdateAssets();
     watchdog_refresh();   // LVGL init takes time
-    mks_test_get();
   #endif
 
   touch.Init();


### PR DESCRIPTION
### Description

Compilation error after pull request https://github.com/MarlinFirmware/Marlin/issues/22387
I tested this fix on my robin nano v2, it works for me. But it's better to check, I'm not 100% sure of the correctness of this decision.

### Requirements

Board: MKS Robin nano v2

Platformio.ini:
```
default_envs = mks_robin_nano35_maple 
or 
default_envs = mks_robin_nano35
```

Configuration.h:
```
#define SERIAL_PORT 3
#define MOTHERBOARD BOARD_MKS_ROBIN_NANO_V2
#define SDSUPPORT
#define MKS_TS35_V2_0
#define TFT_LVGL_UI
#define TOUCH_SCREEN
```


### Benefits

fix compilation error:
Marlin\src\lcd\extui\mks_ui\tft_lvgl_configuration.cpp:142:5: error: 'mks_test_get' was not declared in this scope
     mks_test_get();


### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/6839476/Configuration.zip)

