### PR TITLE
Fix harmless compiler warning

### DIFF
--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -70,7 +70,8 @@ void GcodeSuite::G29() {
     return;
   }
 
-  int8_t ix, iy = 0;
+  int8_t ix, iy;
+  ix = iy = 0;
 
   switch (state) {
     case MeshReport:


### PR DESCRIPTION
FIXED:

G29.cpp: In static member function 'static void GcodeSuite::G29()':
G29.cpp:113:49: warning: 'ix' may be used uninitialized in this function [-Wmaybe-uninitialized]
