### PR TITLE
Silence debug_current_on Warning

### DIFF
--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -865,9 +865,11 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
       #if HAS_CURRENT_HOME(Z)
         static int16_t saved_current_Z;
       #endif
-      auto debug_current_on = [](PGM_P const s, const int16_t a, const int16_t b) {
-        if (DEBUGGING(LEVELING)) { DEBUG_ECHOPGM_P(s); DEBUG_ECHOLNPAIR(" current: ", a, " -> ", b); }
-      };
+      #if ((ENABLED(DELTA) && (HAS_CURRENT_HOME(X) || HAS_CURRENT_HOME(Y))) || HAS_CURRENT_HOME(Z))
+        auto debug_current_on = [](PGM_P const s, const int16_t a, const int16_t b) {
+          if (DEBUGGING(LEVELING)) { DEBUG_ECHOPGM_P(s); DEBUG_ECHOLNPAIR(" current: ", a, " -> ", b); }
+        };
+      #endif
       if (onoff) {
         #if ENABLED(DELTA)
           #if HAS_CURRENT_HOME(X)


### PR DESCRIPTION
### Description

`debug_current_on` is defined when `HAS_CURRENT_HOME(X) || HAS_CURRENT_HOME(Y) || HAS_CURRENT_HOME(Z)`, but then is only used if you have a delta with `HAS_CURRENT_HOME(X) || HAS_CURRENT_HOME(Y)` *or any config* with `HAS_CURRENT_HOME(Z)`.

With a sensorless homing config like the [Prusa MK3S w/ BTT002](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Prusa/MK3S-BigTreeTech-BTT002) where X & Y's homing currents differ from their run currents, but Z run & home currents are the same, you get the following warning:


```prolog
Marlin/src/module/probe.cpp: In static member function 'static void Probe::set_homing_current(bool)':
Marlin/src/module/probe.cpp:870:14: warning: variable 'debug_current_on' set but not used [-Wunused-but-set-variable]
  870 |         auto debug_current_on = [](PGM_P const s, const int16_t a, const int16_t b) {
      |              ^~~~~~~~~~~~~~~~
```

I tried changing the main conditional to match this pattern, but you still need those `IMPROVE_HOMING_RELIABILITY` TERNs.

...or I didn't stare at it long enough and I'm missing an easier fix.


### Benefits

No more unused variable warning.

### Configurations

[Prusa MK3S BTT002](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Prusa/MK3S-BigTreeTech-BTT002)

### Related Issues

- PR #21899