### PR TITLE
fix STATUS_COMBINE_HEATERS

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -264,29 +264,31 @@ FORCE_INLINE void _draw_centered_temp(const celsius_t temp, const uint8_t tx, co
       #define HOTEND_BITMAP(N,S) status_hotend_a_bmp
     #endif
 
-    if (PAGE_CONTAINS(STATUS_HEATERS_Y, STATUS_HEATERS_BOT)) {
+    #if DISABLED(STATUS_COMBINE_HEATERS)
+      if (PAGE_CONTAINS(STATUS_HEATERS_Y, STATUS_HEATERS_BOT)) {
 
-      #define BAR_TALL (STATUS_HEATERS_HEIGHT - 2)
+        #define BAR_TALL (STATUS_HEATERS_HEIGHT - 2)
 
-      const float prop = target - 20,
-                  perc = prop > 0 && temp >= 20 ? (temp - 20) / prop : 0;
-      uint8_t tall = uint8_t(perc * BAR_TALL + 0.5f);
-      NOMORE(tall, BAR_TALL);
+        const float prop = target - 20,
+                    perc = prop > 0 && temp >= 20 ? (temp - 20) / prop : 0;
+        uint8_t tall = uint8_t(perc * BAR_TALL + 0.5f);
+        NOMORE(tall, BAR_TALL);
 
-      // Draw hotend bitmap, either whole or split by the heating percent
-      const uint8_t hx = STATUS_HOTEND_X(heater_id),
-                    bw = STATUS_HOTEND_BYTEWIDTH(heater_id);
-      #if ENABLED(STATUS_HEAT_PERCENT)
-        if (isHeat && tall <= BAR_TALL) {
-          const uint8_t ph = STATUS_HEATERS_HEIGHT - 1 - tall;
-          u8g.drawBitmapP(hx, STATUS_HEATERS_Y, bw, ph, HOTEND_BITMAP(TERN(HAS_MMU, active_extruder, heater_id), false));
-          u8g.drawBitmapP(hx, STATUS_HEATERS_Y + ph, bw, tall + 1, HOTEND_BITMAP(TERN(HAS_MMU, active_extruder, heater_id), true) + ph * bw);
-        }
-        else
-      #endif
-          u8g.drawBitmapP(hx, STATUS_HEATERS_Y, bw, STATUS_HEATERS_HEIGHT, HOTEND_BITMAP(TERN(HAS_MMU, active_extruder, heater_id), isHeat));
+        // Draw hotend bitmap, either whole or split by the heating percent
+        const uint8_t hx = STATUS_HOTEND_X(heater_id),
+                      bw = STATUS_HOTEND_BYTEWIDTH(heater_id);
+        #if ENABLED(STATUS_HEAT_PERCENT)
+          if (isHeat && tall <= BAR_TALL) {
+            const uint8_t ph = STATUS_HEATERS_HEIGHT - 1 - tall;
+            u8g.drawBitmapP(hx, STATUS_HEATERS_Y, bw, ph, HOTEND_BITMAP(TERN(HAS_MMU, active_extruder, heater_id), false));
+            u8g.drawBitmapP(hx, STATUS_HEATERS_Y + ph, bw, tall + 1, HOTEND_BITMAP(TERN(HAS_MMU, active_extruder, heater_id), true) + ph * bw);
+          }
+          else
+        #endif
+            u8g.drawBitmapP(hx, STATUS_HEATERS_Y, bw, STATUS_HEATERS_HEIGHT, HOTEND_BITMAP(TERN(HAS_MMU, active_extruder, heater_id), isHeat));
 
-    } // PAGE_CONTAINS
+      } // PAGE_CONTAINS
+    #endif
 
     if (PAGE_UNDER(7)) {
       #if HEATER_IDLE_HANDLER

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -265,6 +265,7 @@ FORCE_INLINE void _draw_centered_temp(const celsius_t temp, const uint8_t tx, co
     #endif
 
     #if DISABLED(STATUS_COMBINE_HEATERS)
+
       if (PAGE_CONTAINS(STATUS_HEATERS_Y, STATUS_HEATERS_BOT)) {
 
         #define BAR_TALL (STATUS_HEATERS_HEIGHT - 2)
@@ -288,7 +289,8 @@ FORCE_INLINE void _draw_centered_temp(const celsius_t temp, const uint8_t tx, co
             u8g.drawBitmapP(hx, STATUS_HEATERS_Y, bw, STATUS_HEATERS_HEIGHT, HOTEND_BITMAP(TERN(HAS_MMU, active_extruder, heater_id), isHeat));
 
       } // PAGE_CONTAINS
-    #endif
+
+    #endif // !STATUS_COMBINE_HEATERS
 
     if (PAGE_UNDER(7)) {
       #if HEATER_IDLE_HANDLER

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -36,7 +36,7 @@ USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7
 HAS_WIRED_LCD                          = src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780                   = src_filter=+<src/lcd/HD44780>
-HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@~0.5.0
+HAS_MARLINUI_U8GLIB                    = U8glib-HAL@~0.5.0
                                          src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT                = src_filter=+<src/HAL/STM32/tft> +<src/HAL/STM32F1/tft> +<src/lcd/tft_io>
 HAS_FSMC_TFT                           = src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp> +<src/HAL/STM32F1/tft/tft_fsmc.cpp>

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -36,7 +36,7 @@ USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7
 HAS_WIRED_LCD                          = src_filter=+<src/lcd/lcdprint.cpp>
 HAS_MARLINUI_HD44780                   = src_filter=+<src/lcd/HD44780>
-HAS_MARLINUI_U8GLIB                    = U8glib-HAL@~0.5.0
+HAS_MARLINUI_U8GLIB                    = marlinfirmware/U8glib-HAL@~0.5.0
                                          src_filter=+<src/lcd/dogm>
 HAS_(FSMC|SPI|LTDC)_TFT                = src_filter=+<src/HAL/STM32/tft> +<src/HAL/STM32F1/tft> +<src/lcd/tft_io>
 HAS_FSMC_TFT                           = src_filter=+<src/HAL/STM32/tft/tft_fsmc.cpp> +<src/HAL/STM32F1/tft/tft_fsmc.cpp>


### PR DESCRIPTION
### Description

Enabling STATUS_COMBINE_HEATERS on a ug8 based lcd fails to compile see issue https://github.com/MarlinFirmware/Marlin/issues/22397
Code in status_screen_DOGM.cpp presumes separate heater images and attempts to draw them regardless 
Wrapped that block in a `#if DISABLED(STATUS_COMBINE_HEATERS)` so it doesn't conflict.

I also explicitly defined which  U8glib-HAL lib to use to stop this annoying PIO warning
```
Library Manager: Warning! More than one package has been found by U8glib-HAL @ ~0.5.0 requirements:
 - marlinfirmware/U8glib-HAL @ 0.5.0
 - thinkyhead/U8glib-HAL @ 0.4.5
Library Manager: Please specify detailed REQUIREMENTS using package owner and version (showed above) to avoid name conflicts
``` 

### Requirements

REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
STATUS_COMBINE_HEATERS

### Benefits

Works as expected

### Related Issues
Issue https://github.com/MarlinFirmware/Marlin/issues/22397

