### PR TITLE
Correct FYSETC S6 I2C EEPROM size

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -50,7 +50,7 @@
   // 128 kB sector allocated for EEPROM emulation.
   #define FLASH_EEPROM_LEVELING
 #elif ENABLED(I2C_EEPROM)
-  #define MARLIN_EEPROM_SIZE              0x0800  // 2KB
+  #define MARLIN_EEPROM_SIZE              0x1000  // 4KB
 #endif
 
 //


### PR DESCRIPTION
Except the first S6 batch. The I2C EEPROM chip in S6/S6 2.0/Spider are 24lc32 , it has 4KB capacity.