### PR TITLE
SKR E3 Turbo custom cable documentation

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -205,17 +205,15 @@
   #error "DWIN_CREALITY_LCD requires a custom cable with TX = P0_15, RX = P0_16. Comment out this line to continue."
 
  /** 
- *       Ender 3 V2 display                         	 SKR E3 Turbo(EXP1)                     Ender 3 V2 display --> SKR E3 Turbo 
- *                _____                                     _____                                              8 --> 5
- *            5V | 1 2 | GND                            5V | 1 2 | GND                                         5 --> 10
- *   (BTN_E1) A  | 3 4 | B (BTN_E2)         (LCD_EN) P0_18 | 3 4 | P0_17 (LCD_RS)                              7 --> 9
- *          BEEP | 5 6   ENT (BTN_ENC)      (LCD_D4) P0_15 | 5 6   P0_20 (BTN_EN2)
- *  (SKR_RX1) TX | 7 8 | RX (SKR_TX1)                Reset | 7 8 | P0_19 (BTN_EN1)
- *            NC | 9 10| NC                (BTN_ENC) P0_16 | 9 10| P2_08 (BEEPER)
- *                -----					                            -----
- */
-
-
+  *          Ender 3 V2 display                       SKR E3 Turbo (EXP1)                Ender 3 V2 display --> SKR E3 Turbo 
+  *                ______                                     ______                                  RX  8 -->  5  P0_15
+  *            5V | 1  2 | GND                            5V | 1  2 | GND                             TX  7 -->  9  P0_16
+  *   (BTN_E1) A  | 3  4 | B   (BTN_E2)       (LCD_EN) P0_18 | 3  4 | P0_17 (LCD_RS)              BEEPER  5 --> 10  P2_08
+  *        BEEPER | 5  6   ENT (BTN_ENC)      (LCD_D4) P0_15 | 5  6   P0_20 (BTN_EN2)
+  *  (SKR_RX1) TX | 7  8 | RX  (SKR_TX1)               Reset | 7  8 | P0_19 (BTN_EN1)
+  *            NC | 9 10 | NC                (BTN_ENC) P0_16 | 9 10 | P2_08 (BEEPER)
+  *                ------					                            ------
+  */
   #define BEEPER_PIN                 EXP1_10_PIN
   #define BTN_EN1                    EXP1_03_PIN
   #define BTN_EN2                    EXP1_04_PIN

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -203,6 +203,7 @@
 
 #if ENABLED(DWIN_CREALITY_LCD)
   #error "DWIN_CREALITY_LCD requires a custom cable with TX = P0_15, RX = P0_16. Comment out this line to continue."
+  //Make custom cable: https://github.com/bigtreetech/BIGTREETECH-SKR-E3-Turbo/issues/40#issuecomment-866369883
 
   #define BEEPER_PIN                 EXP1_10_PIN
   #define BTN_EN1                    EXP1_03_PIN

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -203,7 +203,18 @@
 
 #if ENABLED(DWIN_CREALITY_LCD)
   #error "DWIN_CREALITY_LCD requires a custom cable with TX = P0_15, RX = P0_16. Comment out this line to continue."
-  //Make custom cable: https://github.com/bigtreetech/BIGTREETECH-SKR-E3-Turbo/issues/40#issuecomment-866369883
+
+ /** 
+ *       Ender 3 V2 display                         	 SKR E3 Turbo(EXP1)                     Ender 3 V2 display --> SKR E3 Turbo 
+ *                _____                                     _____                                              8 --> 5
+ *            5V | 1 2 | GND                            5V | 1 2 | GND                                         5 --> 10
+ *   (BTN_E1) A  | 3 4 | B (BTN_E2)         (LCD_EN) P0_18 | 3 4 | P0_17 (LCD_RS)                              7 --> 9
+ *          BEEP | 5 6   ENT (BTN_ENC)      (LCD_D4) P0_15 | 5 6   P0_20 (BTN_EN2)
+ *  (SKR_RX1) TX | 7 8 | RX (SKR_TX1)                Reset | 7 8 | P0_19 (BTN_EN1)
+ *            NC | 9 10| NC                (BTN_ENC) P0_16 | 9 10| P2_08 (BEEPER)
+ *                -----					                            -----
+ */
+
 
   #define BEEPER_PIN                 EXP1_10_PIN
   #define BTN_EN1                    EXP1_03_PIN

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -182,13 +182,13 @@
 #endif
 
 /**
- *                  _____
- *              5V | 1 2 | GND
- *  (LCD_EN) P0_18 | 3 4 | P0_17 (LCD_RS)
- *  (LCD_D4) P0_15 | 5 6   P0_20 (BTN_EN2)
- *           RESET | 7 8 | P0_19 (BTN_EN1)
- * (BTN_ENC) P0_16 | 9 10| P2_08 (BEEPER)
- *                  -----
+ *                  ______
+ *              5V | 1  2 | GND
+ *  (LCD_EN) P0_18 | 3  4 | P0_17 (LCD_RS)
+ *  (LCD_D4) P0_15 | 5  6   P0_20 (BTN_EN2)
+ *           RESET | 7  8 | P0_19 (BTN_EN1)
+ * (BTN_ENC) P0_16 | 9 10 | P2_08 (BEEPER)
+ *                  ------
  *                   EXP
  */
 
@@ -208,12 +208,13 @@
   *          Ender 3 V2 display                       SKR E3 Turbo (EXP1)                Ender 3 V2 display --> SKR E3 Turbo 
   *                ______                                     ______                                  RX  8 -->  5  P0_15
   *            5V | 1  2 | GND                            5V | 1  2 | GND                             TX  7 -->  9  P0_16
-  *   (BTN_E1) A  | 3  4 | B   (BTN_E2)       (LCD_EN) P0_18 | 3  4 | P0_17 (LCD_RS)              BEEPER  5 --> 10  P2_08
+  *   (BTN_E1)  A | 3  4 | B   (BTN_E2)       (LCD_EN) P0_18 | 3  4 | P0_17 (LCD_RS)              BEEPER  5 --> 10  P2_08
   *        BEEPER | 5  6   ENT (BTN_ENC)      (LCD_D4) P0_15 | 5  6   P0_20 (BTN_EN2)
   *  (SKR_RX1) TX | 7  8 | RX  (SKR_TX1)               Reset | 7  8 | P0_19 (BTN_EN1)
   *            NC | 9 10 | NC                (BTN_ENC) P0_16 | 9 10 | P2_08 (BEEPER)
   *                ------					                            ------
   */
+
   #define BEEPER_PIN                 EXP1_10_PIN
   #define BTN_EN1                    EXP1_03_PIN
   #define BTN_EN2                    EXP1_04_PIN


### PR DESCRIPTION
Can be useful to make a custom cable for E3 Turbo to use Ender3v2 Stock display.


