### PR TITLE
Fix SKR Pro Extra Tokens Warning

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -254,7 +254,7 @@
   #define TEMP_BED_PIN                      PF3   // T0 <-> Bed
 #endif
 
-#ifdef TEMP_SENSOR_PROBE && !defined(TEMP_PROBE_PIN)
+#if TEMP_SENSOR_PROBE && !defined(TEMP_PROBE_PIN)
   #if TEMP_SENSOR_PROBE_IS_AD8495 || TEMP_SENSOR_PROBE == 20
     #if HOTENDS == 2
       #define TEMP_PROBE_PIN                PF10


### PR DESCRIPTION
### Description

Fix wall of warnings due to extra tokens at end of #ifdef directive:

```prolog
Compiling .pio/build/BIGTREE_SKR_PRO/src/src/HAL/shared/backtrace/backtrace.cpp.o
In file included from Marlin/src/HAL/STM32/../../inc/../pins/stm32f4/pins_BTT_SKR_PRO_V1_1.h:30,
                 from Marlin/src/HAL/STM32/../../inc/../pins/pins.h:589,
                 from Marlin/src/HAL/STM32/../../inc/MarlinConfig.h:34,
                 from Marlin/src/HAL/STM32/eeprom_flash.cpp:25:
Marlin/src/HAL/STM32/../../inc/../pins/stm32f4/pins_BTT_SKR_PRO_common.h:257:26: warning: extra tokens at end of #ifdef directive
  257 | #ifdef TEMP_SENSOR_PROBE && !defined(TEMP_PROBE_PIN)
      |                          ^~
```

### Requirements

SKR Pro

### Benefits

No more wall of warnings

### Configurations

Any SKR Pro config

### Related Issues

Fixes https://github.com/MarlinFirmware/Marlin/issues/22437