### PR TITLE
Document some DGUS Extensible UI Display firmwares

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2539,7 +2539,7 @@
 //
 // Flash display with DGUS Displays for Marlin:
 //  - Format the SD card to FAT32 with a allocation size of 4k.
-//  - Download files as spesified for your type of display
+//  - Download files as specified for your type of display
 //  - Plug the microSD card into the back of the display.
 //  - Boot the display and wait for the update to complete.
 //

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2538,8 +2538,8 @@
 // MKS    : https://www.aliexpress.com/item/1005002008179262.html
 //
 // Flash display with DGUS Displays for Marlin:
-//  - Format the SD card to FAT32 with a allocation size of 4k.
-//  - Download files as specified for your type of display
+//  - Format the SD card to FAT32 with an allocation size of 4kb.
+//  - Download files as specified for your type of display.
 //  - Plug the microSD card into the back of the display.
 //  - Boot the display and wait for the update to complete.
 //

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2535,11 +2535,33 @@
 // DGUS Touch Display with DWIN OS. (Choose one.)
 // ORIGIN : https://www.aliexpress.com/item/32993409517.html
 // FYSETC : https://www.aliexpress.com/item/32961471929.html
+// MKS    : https://www.aliexpress.com/item/1005002008179262.html
+//
+// Flash display with DGUS Displays for Marlin:
+//  - Format the SD card to FAT32 with a allocation size of 4k.
+//  - Download files as spesified for your type of display
+//  - Plug the microSD card into the back of the display.
+//  - Boot the display and wait for the update to complete.
+//
+// ORIGIN (Marlin DWIN_SET)
+//  - Download https://github.com/coldtobi/Marlin_DGUS_Resources
+//  - Copy the downloaded DWIN_SET folder to the SD card.
+//
+// FYSETC (Supplier default)
+//  - Download https://github.com/FYSETC/FYSTLCD-2.0
+//  - Copy the downloaded SCREEN folder to the SD card.
+//
+// HIPRECY (Supplier default)
+//  - Download https://github.com/HiPrecy/Touch-Lcd-LEO
+//  - Copy the downloaded DWIN_SET folder to the SD card.
+//
+// MKS (MKS-H43) (Supplier default)
+//  - Download https://github.com/makerbase-mks/MKS-H43
+//  - Copy the downloaded DWIN_SET folder to the SD card.
 //
 //#define DGUS_LCD_UI_ORIGIN
 //#define DGUS_LCD_UI_FYSETC
 //#define DGUS_LCD_UI_HIPRECY
-
 //#define DGUS_LCD_UI_MKS
 #if ENABLED(DGUS_LCD_UI_MKS)
   #define USE_MKS_GREEN_UI


### PR DESCRIPTION
### Description

I am looking at various DGUS Extensible UI Displays, found it all rather confusing as everything said they use the Marlin
DWIN_SET. But this is not accurate

Added some details to the Configuration.h as to the actually DWIN_SET's each display uses. 
Not sure if you want there here, but is a starting point.  

### Benefits

Less Confusion (perhaps)

