### PR TITLE
add SAV_3DGLCD LCD conditionals

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -141,6 +141,13 @@
   #define IS_RRD_SC 1
   #define IS_U8GLIB_SSD1306
 
+#elif ENABLED(SAV_3DGLCD)
+
+  #ifdef U8GLIB_SSD1306
+    #define IS_U8GLIB_SSD1306
+  #endif
+  #define IS_NEWPANEL 1
+
 #elif ENABLED(FYSETC_242_OLED_12864)
 
   #define IS_RRD_SC 1


### PR DESCRIPTION
### Description

If you enable LCD SAV_3DGLCD Marlin will error with a 
`Marlin/src/HAL/AVR/../../inc/SanityCheck.h:2664:4: error: #error "Please select only one LCD controller option."`
This error is due to  SAV_3DGLCD also setting U8GLIB_SSD1306 which is counted as two different LCD's

Marlin also does not define the encoder pins (RAMPS) when SAV_3DGLCD  is defined with U8GLIB_SSD1306 selected. U8GLIB_SH1106 worked as expected.

### Requirements

In Configuation.h

```CPP
#define SAV_3DGLCD
#if ENABLED(SAV_3DGLCD)
  #define U8GLIB_SSD1306
  //#define U8GLIB_SH1106
#endif

```
### Benefits

Compiles and works as expected.
The sanity check now passes and the encoder pins are defined for both lcd options.

### Related Issues
Related to reprap forum post https://reprap.org/forum/read.php?1,885165
