### PR TITLE
lock teensy @4.12.0 for now, CI failing teensy tests  

### DIFF
--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -10,6 +10,15 @@
 #################################
 
 #
+# Teensy++ 2.0
+#
+[env:teensy20]
+platform   = teensy
+extends    = common_avr8
+board      = teensy2pp
+lib_ignore = ${env:common_avr8.lib_ignore}, NativeEthernet
+
+#
 # Teensy 3.1 / 3.2 (ARM Cortex-M4)
 #
 [env:teensy31]

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -13,7 +13,7 @@
 # Teensy 3.1 / 3.2 (ARM Cortex-M4)
 #
 [env:teensy31]
-platform      = teensy
+platform      = teensy@4.12.0
 board         = teensy31
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY31_32>
 lib_ignore    = NativeEthernet
@@ -22,13 +22,13 @@ lib_ignore    = NativeEthernet
 # Teensy 3.5 / 3.6 (ARM Cortex-M4)
 #
 [env:teensy35]
-platform      = teensy
+platform      = teensy@4.12.0
 board         = teensy35
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
 lib_ignore    = NativeEthernet
 
 [env:teensy36]
-platform      = teensy
+platform      = teensy@4.12.0
 board         = teensy36
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
 lib_ignore    = NativeEthernet
@@ -37,6 +37,6 @@ lib_ignore    = NativeEthernet
 # Teensy 4.0 / 4.1 (ARM Cortex-M7)
 #
 [env:teensy41]
-platform      = teensy
+platform      = teensy@4.12.0
 board         = teensy41
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY40_41>

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -22,7 +22,7 @@ lib_ignore = ${env:common_avr8.lib_ignore}, NativeEthernet
 # Teensy 3.1 / 3.2 (ARM Cortex-M4)
 #
 [env:teensy31]
-platform      = teensy@4.12.0
+platform      = teensy@~4.12.0
 board         = teensy31
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY31_32>
 lib_ignore    = NativeEthernet
@@ -31,13 +31,13 @@ lib_ignore    = NativeEthernet
 # Teensy 3.5 / 3.6 (ARM Cortex-M4)
 #
 [env:teensy35]
-platform      = teensy@4.12.0
+platform      = teensy@~4.12.0
 board         = teensy35
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
 lib_ignore    = NativeEthernet
 
 [env:teensy36]
-platform      = teensy@4.12.0
+platform      = teensy@~4.12.0
 board         = teensy36
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
 lib_ignore    = NativeEthernet
@@ -46,6 +46,6 @@ lib_ignore    = NativeEthernet
 # Teensy 4.0 / 4.1 (ARM Cortex-M7)
 #
 [env:teensy41]
-platform      = teensy@4.12.0
+platform      = teensy@~4.12.0
 board         = teensy41
 src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY40_41>


### PR DESCRIPTION
### Description

Platform teensy has been upgraded to 4.13.0  see https://github.com/platformio/platform-teensy/releases
This included Teensyduino to v1.54 which breaks how marlin does SD on teensy (missing include files) 

For now I recommend we lock Marlin to using 4.12.0 until someone gets time to look at the SD changes.

### Requirements

BOARD_TEENSY31_32 or BOARD_TEENSY35_36 or BOARD_TEENSY41 with SDSUPPORT

### Benefits

Builds as expected

### Related Issues
Is causing CI  to fail on New PR's egs 
https://github.com/MarlinFirmware/Marlin/pull/22447
https://github.com/MarlinFirmware/Marlin/pull/22443
