### PR TITLE
Fix LCD Menu MBL Z-Offset Adjustment

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -278,13 +278,12 @@ void menu_bed_leveling() {
   // Mesh Bed Leveling Z-Offset
   //
   #if ENABLED(MESH_BED_LEVELING)
-    #if ( Z_PROBE_OFFSET_RANGE_MIN >= -9 && Z_PROBE_OFFSET_RANGE_MAX <= 9 )
+    #if WITHIN(Z_PROBE_OFFSET_RANGE_MIN, -9, 9)
       #define LCD_Z_OFFSET_TYPE float43    // Values from -9.000 to +9.000
     #else
       #define LCD_Z_OFFSET_TYPE float42_52 // Values from -99.99 to 99.99
     #endif
-    EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_BED_Z, &mbl.z_offset, Z_PROBE_OFFSET_RANGE_MIN,  
-      Z_PROBE_OFFSET_RANGE_MAX);
+    EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_BED_Z, &mbl.z_offset, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX);
   #endif
 
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)

--- a/Marlin/src/lcd/menu/menu_bed_leveling.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_leveling.cpp
@@ -278,7 +278,13 @@ void menu_bed_leveling() {
   // Mesh Bed Leveling Z-Offset
   //
   #if ENABLED(MESH_BED_LEVELING)
-    EDIT_ITEM(float43, MSG_BED_Z, &mbl.z_offset, -1, 1);
+    #if ( Z_PROBE_OFFSET_RANGE_MIN >= -9 && Z_PROBE_OFFSET_RANGE_MAX <= 9 )
+      #define LCD_Z_OFFSET_TYPE float43    // Values from -9.000 to +9.000
+    #else
+      #define LCD_Z_OFFSET_TYPE float42_52 // Values from -99.99 to 99.99
+    #endif
+    EDIT_ITEM(LCD_Z_OFFSET_TYPE, MSG_BED_Z, &mbl.z_offset, Z_PROBE_OFFSET_RANGE_MIN,  
+      Z_PROBE_OFFSET_RANGE_MAX);
   #endif
 
   #if ENABLED(BABYSTEP_ZPROBE_OFFSET)


### PR DESCRIPTION
Issue #21108 , proposed fix for LCD Menu manual (Mesh Bed Leveling) Z-Offset Adjustment Too Fine.

### Description

<!--

Best described in detail by Issue #21108.   Changes variable type from float43 to float42_52 when Z_PROBE_OFFSET_RANGE_MIN and Z_PROBE_OFFSET_RANGE_MAX values set in Configuration.h file are set from -99.99 to 99.99.

-->

### Requirements

Only applicable to Z-Offset adjustment on printers with Configuration.h file setup with Manual Mesh Bed Leveling.

### Benefits

Saves time wasted rotating encoder knob many times to arrive a suitable adjustment shown on LCD display.

### Configurations

none required

### Related Issues

none known
