### PR TITLE
Fix to FTDI Eve unicode routine and spinner dialog box

### DIFF
--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/unicode.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/unicode.cpp
@@ -68,15 +68,17 @@
 
   utf8_char_t FTDI::get_utf8_char_and_inc(const char *&c) {
     utf8_char_t val = *(uint8_t*)c++;
-    while ((*c & 0xC0) == 0x80)
-      val = (val << 8) | *(uint8_t*)c++;
+    if((val & 0xC0) == 0x80)
+      while ((*c & 0xC0) == 0x80)
+        val = (val << 8) | *(uint8_t*)c++;
     return val;
   }
 
   utf8_char_t FTDI::get_utf8_char_and_inc(char *&c) {
     utf8_char_t val = *(uint8_t*)c++;
-    while ((*c & 0xC0) == 0x80)
-      val = (val << 8) | *(uint8_t*)c++;
+    if((val & 0xC0) == 0x80)
+      while ((*c & 0xC0) == 0x80)
+        val = (val << 8) | *(uint8_t*)c++;
     return val;
   }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/unicode.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/unicode.cpp
@@ -68,7 +68,7 @@
 
   utf8_char_t FTDI::get_utf8_char_and_inc(const char *&c) {
     utf8_char_t val = *(uint8_t*)c++;
-    if((val & 0xC0) == 0x80)
+    if ((val & 0xC0) == 0x80)
       while ((*c & 0xC0) == 0x80)
         val = (val << 8) | *(uint8_t*)c++;
     return val;
@@ -76,7 +76,7 @@
 
   utf8_char_t FTDI::get_utf8_char_and_inc(char *&c) {
     utf8_char_t val = *(uint8_t*)c++;
-    if((val & 0xC0) == 0x80)
+    if ((val & 0xC0) == 0x80)
       while ((*c & 0xC0) == 0x80)
         val = (val << 8) | *(uint8_t*)c++;
     return val;

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.cpp
@@ -31,6 +31,10 @@ using namespace ExtUI;
 
 constexpr static SpinnerDialogBoxData &mydata = screen_data.SpinnerDialogBox;
 
+void SpinnerDialogBox::onEntry() {
+  mydata.auto_hide = true;
+}
+
 void SpinnerDialogBox::onRedraw(draw_mode_t) {
 }
 
@@ -38,6 +42,7 @@ void SpinnerDialogBox::show(progmem_str message) {
   drawMessage(message);
   drawSpinner();
   storeBackground();
+  GOTO_SCREEN(SpinnerDialogBox);
   mydata.auto_hide = false;
 }
 
@@ -48,16 +53,12 @@ void SpinnerDialogBox::hide() {
 
 void SpinnerDialogBox::enqueueAndWait(progmem_str message, progmem_str commands) {
   show(message);
-  GOTO_SCREEN(SpinnerDialogBox);
   ExtUI::injectCommands_P((const char*)commands);
-  mydata.auto_hide = true;
 }
 
 void SpinnerDialogBox::enqueueAndWait(progmem_str message, char *commands) {
   show(message);
-  GOTO_SCREEN(SpinnerDialogBox);
   ExtUI::injectCommands(commands);
-  mydata.auto_hide = true;
 }
 
 void SpinnerDialogBox::onIdle() {

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.h
@@ -31,6 +31,7 @@ struct SpinnerDialogBoxData {
 
 class SpinnerDialogBox : public DialogBoxBaseClass, public CachedScreen<SPINNER_CACHE,SPINNER_DL_SIZE> {
   public:
+    static void onEntry();
     static void onRedraw(draw_mode_t);
     static void onIdle();
 


### PR DESCRIPTION
- Fix a serious issue where the Unicode routines would sometimes read past a string's null termination.
- Allow the spinner dialog box to work with command strings with the M0 command.