### PR TITLE
longer3D: use new board_build.rename feature

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -333,6 +333,7 @@ platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
+board_build.rename          = project.bin
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
 build_flags                 = ${stm32_variant.build_flags}
@@ -342,7 +343,6 @@ build_flags                 = ${stm32_variant.build_flags}
 build_unflags               = ${stm32_variant.build_unflags}
                               -DUSBCON -DUSBD_USE_CDC -DHAL_PCD_MODULE_ENABLED
 extra_scripts               = ${stm32_variant.extra_scripts}
-                              buildroot/share/PlatformIO/scripts/STM32F103VE_longer.py
 
 #
 # TRIGORILLA PRO (STM32F103ZET6)
@@ -363,8 +363,6 @@ board_build.variant  = MARLIN_F103Zx
 build_flags          = ${stm32_variant.build_flags}
                        -DSTM32F1xx -DSTM32_XL_DENSITY
 build_unflags        = ${stm32_variant.build_unflags}
-                       -DCONFIG_MAPLE_MINI_NO_DISABLE_DEBUG=
-                       -DERROR_LED_PORT=GPIOE -DERROR_LED_PIN=6
 extra_scripts        = ${stm32_variant.extra_scripts}
                        buildroot/share/PlatformIO/scripts/chitu_crypt.py
 


### PR DESCRIPTION
STM32F103VE_longer.py script is still required for the maple env.

Also remove last maple specific unflags on the chitu...
