### PR TITLE
Follow up fixes to FTDI Eve Touch UI

### DIFF
--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/unicode.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/unicode/unicode.cpp
@@ -68,7 +68,7 @@
 
   utf8_char_t FTDI::get_utf8_char_and_inc(const char *&c) {
     utf8_char_t val = *(uint8_t*)c++;
-    if ((val & 0xC0) == 0x80)
+    if ((val & 0xC0) == 0xC0)
       while ((*c & 0xC0) == 0x80)
         val = (val << 8) | *(uint8_t*)c++;
     return val;
@@ -76,7 +76,7 @@
 
   utf8_char_t FTDI::get_utf8_char_and_inc(char *&c) {
     utf8_char_t val = *(uint8_t*)c++;
-    if ((val & 0xC0) == 0x80)
+    if ((val & 0xC0) == 0xC0)
       while ((*c & 0xC0) == 0x80)
         val = (val << 8) | *(uint8_t*)c++;
     return val;

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.cpp
@@ -49,6 +49,7 @@ void SpinnerDialogBox::show(progmem_str message) {
 void SpinnerDialogBox::hide() {
   CommandProcessor cmd;
   cmd.stop().execute();
+  GOTO_PREVIOUS();
 }
 
 void SpinnerDialogBox::enqueueAndWait(progmem_str message, progmem_str commands) {
@@ -66,7 +67,6 @@ void SpinnerDialogBox::onIdle() {
   if (mydata.auto_hide && !commandsInQueue()) {
     mydata.auto_hide = false;
     hide();
-    GOTO_PREVIOUS();
   }
 }
 


### PR DESCRIPTION
- Correct interpretation of first byte in UTF8 encoding.
- Allow the SpinnerDialogBox to be manually hidden