### PR TITLE
MKSUI with CUSTOM_MENU_MAIN - fix compilation error 

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_more.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_more.cpp
@@ -61,22 +61,22 @@ static void event_handler(lv_obj_t * obj, lv_event_t event) {
   switch (obj->mks_obj_id) {
     case ID_GCODE: lv_clear_more(); lv_draw_gcode(true); break;
     #if HAS_USER_ITEM(1)
-      case ID_CUSTOM_1: queue.inject_P(PSTR(USER_GCODE_1)); break;
+      case ID_CUSTOM_1: queue.inject_P(PSTR(MAIN_MENU_ITEM_1_GCODE)); break;
     #endif
     #if HAS_USER_ITEM(2)
-      case ID_CUSTOM_2: queue.inject_P(PSTR(USER_GCODE_2)); break;
+      case ID_CUSTOM_2: queue.inject_P(PSTR(MAIN_MENU_ITEM_2_GCODE)); break;
     #endif
     #if HAS_USER_ITEM(3)
-      case ID_CUSTOM_3: queue.inject_P(PSTR(USER_GCODE_3)); break;
+      case ID_CUSTOM_3: queue.inject_P(PSTR(MAIN_MENU_ITEM_3_GCODE)); break;
     #endif
     #if HAS_USER_ITEM(4)
-      case ID_CUSTOM_4: queue.inject_P(PSTR(USER_GCODE_4)); break;
+      case ID_CUSTOM_4: queue.inject_P(PSTR(MAIN_MENU_ITEM_4_GCODE)); break;
     #endif
     #if HAS_USER_ITEM(5)
-      case ID_CUSTOM_5: queue.inject_P(PSTR(USER_GCODE_5)); break;
+      case ID_CUSTOM_5: queue.inject_P(PSTR(MAIN_MENU_ITEM_5_GCODE)); break;
     #endif
     #if HAS_USER_ITEM(6)
-      case ID_CUSTOM_6: queue.inject_P(PSTR(USER_GCODE_6)); break;
+      case ID_CUSTOM_6: queue.inject_P(PSTR(MAIN_MENU_ITEM_6_GCODE)); break;
     #endif
     case ID_M_RETURN:
       lv_clear_more();


### PR DESCRIPTION

### Description

With the mksui interface on the mks robin nano2 board, after https://github.com/MarlinFirmware/Marlin/commit/35b0083dfee0f5508d1ecfd4756ebcac8892b067 a compilation error appears with an active option #define CUSTOM_MENU_MAIN.

```
Marlin\src\lcd\extui\mks_ui\draw_more.cpp:64:45: error: 'USER_GCODE_1' was not declared in this scope
       case ID_CUSTOM_1: queue.inject_P(PSTR(USER_GCODE_1)); break;
```

### Benefits

Fix compilation error

### Configurations

[Configs.zip](https://github.com/MarlinFirmware/Marlin/files/6910821/Configs.zip)

