### PR TITLE
Add override for serial buffer size

### DIFF
--- a/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
+++ b/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
@@ -3,26 +3,25 @@
 #
 Import("env")
 
-# Marlin has `RX_BUFFER_SIZE` and `TX_BUFFER_SIZE` to configure the
-# buffer size for receiving and transmitting data respectively.
-# Stm32duino uses another set of defines for the same purpose,
-# so we get the values from the Marlin configuration and set
-# them in `SERIAL_RX_BUFFER_SIZE` and `SERIAL_TX_BUFFER_SIZE`.
-# It is not possible to change the values at runtime, they must
-# be set with build flags.
+# Marlin uses the `RX_BUFFER_SIZE` \ `TX_BUFFER_SIZE` options to
+# configure buffer sizes for receiving \ transmitting serial data.
+# Stm32duino uses another set of defines for the same purpose, so this
+# script gets the values from the configuration and uses them to define
+# `SERIAL_RX_BUFFER_SIZE` and `SERIAL_TX_BUFFER_SIZE` as global build
+# flags so they are available for use by the platform.
 #
 # The script will set the value as the default one (64 bytes)
 # or the user-configured one, whichever is higher.
 #
-# Marlin has 128 and 32 as default values for RX_BUFFER_SIZE and
-# TX_BUFFER_SIZE respectively. We use the highest value (128/64).
+# Marlin's default buffer sizes are 128 for RX and 32 for TX.
+# The highest value is taken (128/64).
 #
-# If the specific flags SERIAL_*X_BUFFER_SIZE, USART_*X_BUF_SIZE,
-# or MF_*X_BUFFER_SIZE are set, then the script will use these
-# values as minimum.
+# If MF_*_BUFFER_SIZE, SERIAL_*_BUFFER_SIZE, USART_*_BUF_SIZE, are
+# defined, the first of these values will be used as the minimum.
 build_flags = env.ParseFlags(env.get('BUILD_FLAGS'))["CPPDEFINES"]
 mf = env["MARLIN_FEATURES"]
 
+# Get a build flag's value or None
 def getBuildFlagValue(name):
 	for flag in build_flags:
 		if isinstance(flag, list) and flag[0] == name:
@@ -30,26 +29,30 @@ def getBuildFlagValue(name):
 
 	return None
 
+# Get an overriding buffer size for RX or TX from the build flags
 def getInternalSize(side):
-	return getBuildFlagValue(f"MF_{side}_BUFFER_SIZE") or \
-		getBuildFlagValue(f"SERIAL_{side}_BUFFER_SIZE") or \
-		getBuildFlagValue(f"USART_{side}_BUF_SIZE")
+	return	getBuildFlagValue(f"MF_{side}_BUFFER_SIZE") or \
+			getBuildFlagValue(f"SERIAL_{side}_BUFFER_SIZE") or \
+			getBuildFlagValue(f"USART_{side}_BUF_SIZE")
 
+# Get the largest defined buffer size for RX or TX
 def getBufferSize(side, default):
+	# Get a build flag value or fall back to the given default
 	internal = int(getInternalSize(side) or default)
 	flag = side + "_BUFFER_SIZE"
-	if flag in mf:
-		return max(int(mf[flag]), internal)
-	else:
-		return internal
+	# Return the largest value
+	return max(int(mf[flag]), internal) if flag in mf else internal
 
+# Add a build flag if it's not already defined
 def tryAddFlag(name, value):
 	if getBuildFlagValue(name) is None:
 		env.Append(BUILD_FLAGS=[f"-D{name}={value}"])
 
+# Get the largest defined buffer sizes for RX or TX, using defaults for undefined
 rxBuf = getBufferSize("RX", 128)
-txBuf = getBufferSize("TX", 64)
+txBuf = getBufferSize("TX",  64)
 
+# Provide serial buffer sizes to the stm32duino platform
 tryAddFlag("SERIAL_RX_BUFFER_SIZE", rxBuf)
 tryAddFlag("SERIAL_TX_BUFFER_SIZE", txBuf)
 tryAddFlag("USART_RX_BUF_SIZE", rxBuf)

--- a/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
+++ b/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
@@ -15,14 +15,44 @@ Import("env")
 # or the user-configured one, whichever is higher.
 #
 # Marlin has 128 and 32 as default values for RX_BUFFER_SIZE and
-# TX_BUFFER_SIZE respectively. We use the highest value.
+# TX_BUFFER_SIZE respectively. We use the highest value (128/64).
+#
+# If the specific flags SERIAL_*X_BUFFER_SIZE, USART_*X_BUF_SIZE,
+# or MF_*X_BUFFER_SIZE are set, then the script will use these
+# values as minimum.
+build_flags = env.ParseFlags(env.get('BUILD_FLAGS'))["CPPDEFINES"]
 mf = env["MARLIN_FEATURES"]
-rxBuf = str(max(128, int(mf["RX_BUFFER_SIZE"]) if "RX_BUFFER_SIZE" in mf else 0))
-txBuf = str(max(64, int(mf["TX_BUFFER_SIZE"]) if "TX_BUFFER_SIZE" in mf else 0))
 
-build_flags = env.get('BUILD_FLAGS')
-build_flags.append("-DSERIAL_RX_BUFFER_SIZE=" + rxBuf)
-build_flags.append("-DSERIAL_TX_BUFFER_SIZE=" + txBuf)
-build_flags.append("-DUSART_RX_BUF_SIZE=" + rxBuf)
-build_flags.append("-DUSART_TX_BUF_SIZE=" + txBuf)
-env.Replace(BUILD_FLAGS=build_flags)
+def getBuildFlagValue(name):
+	for flag in build_flags:
+		if isinstance(flag, list) and flag[0] == name:
+			return flag[1]
+
+	return None
+
+def getInternalSize(side):
+	return getBuildFlagValue(f"MF_{side}_BUFFER_SIZE") or \
+		getBuildFlagValue(f"SERIAL_{side}_BUFFER_SIZE") or \
+		getBuildFlagValue(f"USART_{side}_BUF_SIZE")
+
+def getBufferSize(side, default):
+	internal = int(getInternalSize(side) or default)
+	flag = side + "_BUFFER_SIZE"
+	if flag in mf:
+		return max(int(mf[flag]), internal)
+	else:
+		return internal
+
+def tryAddFlag(name, value):
+	if getBuildFlagValue(name) is not None:
+		return
+
+	env.Append(BUILD_FLAGS=[f"-D{name}={value}"])
+
+rxBuf = getBufferSize("RX", 128)
+txBuf = getBufferSize("TX", 64)
+
+tryAddFlag("SERIAL_RX_BUFFER_SIZE", rxBuf)
+tryAddFlag("SERIAL_TX_BUFFER_SIZE", txBuf)
+tryAddFlag("USART_RX_BUF_SIZE", rxBuf)
+tryAddFlag("USART_TX_BUF_SIZE", txBuf)

--- a/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
+++ b/buildroot/share/PlatformIO/scripts/stm32_serialbuffer.py
@@ -44,10 +44,8 @@ def getBufferSize(side, default):
 		return internal
 
 def tryAddFlag(name, value):
-	if getBuildFlagValue(name) is not None:
-		return
-
-	env.Append(BUILD_FLAGS=[f"-D{name}={value}"])
+	if getBuildFlagValue(name) is None:
+		env.Append(BUILD_FLAGS=[f"-D{name}={value}"])
 
 rxBuf = getBufferSize("RX", 128)
 txBuf = getBufferSize("TX", 64)

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -152,11 +152,10 @@ extends             = stm32_variant
 board               = marlin_STM32F407VGT6_CCM
 board_build.variant = MARLIN_BIGTREE_E3_RRF
 board_build.offset  = 0x8000
-extra_scripts       = ${common.extra_scripts}
 build_flags         = ${stm32_variant.build_flags}
                       -DSTM32F407_5VX
-                      -DSERIAL_RX_BUFFER_SIZE=255
-                      -DSERIAL_TX_BUFFER_SIZE=255
+                      -DMF_RX_BUFFER_SIZE=255
+                      -DMF_TX_BUFFER_SIZE=255
 
 #
 # Bigtreetech GTR V1.0 (STM32F407IGT6 ARM Cortex-M4)


### PR DESCRIPTION
### Description
Add `MF_RX_BUFFER_SIZE` and `MF_TX_BUFFER_SIZE` to override the default values.

### Requirements
Environment `BIGTREE_E3_RRF`, board `BOARD_BTT_E3_RRF`.

### Benefits
More consistent support for a special case.

### Related Issues
#22466
