### PR TITLE
Fixes issue  #21274 compile error with maple env.

### DIFF
--- a/Marlin/src/lcd/extui/dgus/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/DGUSScreenHandler.cpp
@@ -559,7 +559,7 @@ void DGUSScreenHandler::HandleStepPerMMExtruderChanged(DGUS_VP_Variable &var, vo
         #endif
         #if ENABLED(PIDTEMPBED)
           case VP_PID_AUTOTUNE_BED:
-            sprintf_P(buf, PSTR("M303 E-1 C5 S70 U1"));
+            sprintf_P(buf, PSTR("M303 E%d C5 S70 U1"),-1);
             break;
         #endif
     }

--- a/Marlin/src/lcd/extui/dgus/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/DGUSScreenHandler.cpp
@@ -559,7 +559,7 @@ void DGUSScreenHandler::HandleStepPerMMExtruderChanged(DGUS_VP_Variable &var, vo
         #endif
         #if ENABLED(PIDTEMPBED)
           case VP_PID_AUTOTUNE_BED:
-            sprintf_P(buf, PSTR("M303 E%d C5 S70 U1"),-1);
+            strcpy_P(buf, PSTR("M303 E-1 C5 S70 U1"));
             break;
         #endif
     }


### PR DESCRIPTION
### Description

Ender 6 example configs give a build error when using env:STM32F103RET6_creality_maple

"Marlin\src\lcd\extui\dgus\DGUSScreenHandler.cpp:562:13: note: in expansion of macro 'sprintf_P'
sprintf_P(buf, PSTR("M303 E-1 C5 S70 U1"));"
 
The maple implementation of  sprintf_P seems to expect a variable always. 
So changed code to use a variable ie ```sprintf_P(buf, PSTR("M303 E%d C5 S70 U1"),-1);```
 
### Requirements

Ender 6 Configs, env:STM32F103RET6_creality_maple

### Benefits

Now compiles on Env's

### Configurations

https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/Creality/Ender-6

### Related Issues

Issue https://github.com/MarlinFirmware/Marlin/issues/21274
