### PR TITLE
Fix LINEAR_AXES > 3 compile/display, endstops consistency

### DIFF
--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -37,6 +37,7 @@ extern const char NUL_STR[],
                   SP_I_LBL[], SP_J_LBL[], SP_K_LBL[],
                   SP_P_STR[], SP_T_STR[],
                   X_STR[], Y_STR[], Z_STR[], E_STR[],
+                  I_STR[], J_STR[], K_STR[],
                   X_LBL[], Y_LBL[], Z_LBL[], E_LBL[],
                   I_LBL[], J_LBL[], K_LBL[];
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -1784,6 +1784,15 @@
   #if defined(Z4_STALL_SENSITIVITY) && AXIS_HAS_STALLGUARD(Z4)
     #define Z4_SENSORLESS 1
   #endif
+  #if defined(I_STALL_SENSITIVITY)  && AXIS_HAS_STALLGUARD(I)
+    #define I_SENSORLESS 1
+  #endif
+  #if defined(J_STALL_SENSITIVITY)  && AXIS_HAS_STALLGUARD(J)
+    #define J_SENSORLESS 1
+  #endif
+  #if defined(K_STALL_SENSITIVITY)  && AXIS_HAS_STALLGUARD(K)
+    #define K_SENSORLESS 1
+  #endif
 
   #if AXIS_HAS_STEALTHCHOP(X)
     #define X_HAS_STEALTHCHOP 1
@@ -1845,8 +1854,21 @@
 
   #if ENABLED(SPI_ENDSTOPS)
     #define X_SPI_SENSORLESS X_SENSORLESS
-    #define Y_SPI_SENSORLESS Y_SENSORLESS
-    #define Z_SPI_SENSORLESS Z_SENSORLESS
+    #if HAS_Y_AXIS
+      #define Y_SPI_SENSORLESS Y_SENSORLESS
+    #endif
+    #if HAS_Z_AXIS
+      #define Z_SPI_SENSORLESS Z_SENSORLESS
+    #endif
+    #if LINEAR_AXES >= 4
+      #define I_SPI_SENSORLESS I_SENSORLESS
+    #endif
+    #if LINEAR_AXES >= 5
+      #define J_SPI_SENSORLESS J_SENSORLESS
+    #endif
+    #if LINEAR_AXES >= 6
+      #define K_SPI_SENSORLESS K_SENSORLESS
+    #endif
   #endif
   #ifndef X_INTERPOLATE
     #define X_INTERPOLATE INTERPOLATE

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -357,13 +357,13 @@ void menu_motion() {
       GCODES_ITEM(MSG_AUTO_HOME_Z, PSTR("G28Z"));
     #endif
     #if LINEAR_AXES >= 4
-      GCODES_ITEM(MSG_AUTO_HOME_I, PSTR("G28" I_STR));
+      GCODES_ITEM(MSG_AUTO_HOME_I, PSTR("G28" AXIS4_STR));
     #endif
     #if LINEAR_AXES >= 5
-      GCODES_ITEM(MSG_AUTO_HOME_J, PSTR("G28" J_STR));
+      GCODES_ITEM(MSG_AUTO_HOME_J, PSTR("G28" AXIS5_STR));
     #endif
     #if LINEAR_AXES >= 6
-      GCODES_ITEM(MSG_AUTO_HOME_K, PSTR("G28" K_STR));
+      GCODES_ITEM(MSG_AUTO_HOME_K, PSTR("G28" AXIS6_STR));
     #endif
   #endif
 

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -754,7 +754,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_I_MIN
+  #if HAS_I_MIN && !I_SPI_SENSORLESS
     #if ENABLED(I_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(I, MIN);
       #if HAS_I2_MIN
@@ -767,7 +767,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_I_MAX
+  #if HAS_I_MAX && !I_SPI_SENSORLESS
     #if ENABLED(I_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(I, MAX);
       #if HAS_I2_MAX
@@ -780,7 +780,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_J_MIN
+  #if HAS_J_MIN && !J_SPI_SENSORLESS
     #if ENABLED(J_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(J, MIN);
       #if HAS_J2_MIN
@@ -793,7 +793,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_J_MAX
+  #if HAS_J_MAX && !J_SPI_SENSORLESS
     #if ENABLED(J_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(J, MAX);
       #if HAS_J2_MAX
@@ -806,7 +806,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_K_MIN
+  #if HAS_K_MIN && !K_SPI_SENSORLESS
     #if ENABLED(K_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(K, MIN);
       #if HAS_K2_MIN
@@ -819,7 +819,7 @@ void Endstops::update() {
     #endif
   #endif
 
-  #if HAS_K_MAX
+  #if HAS_K_MAX && !K_SPI_SENSORLESS
     #if ENABLED(K_DUAL_ENDSTOPS)
       UPDATE_ENDSTOP_BIT(K, MAX);
       #if HAS_K2_MAX

--- a/Marlin/src/module/endstops.h
+++ b/Marlin/src/module/endstops.h
@@ -84,6 +84,15 @@ enum EndstopEnum : char {
   #if HAS_Z_MIN || HAS_Z_MAX || HOMING_Z_WITH_PROBE
     , Z_ENDSTOP = TERN(Z_HOME_TO_MAX, Z_MAX, TERN(HOMING_Z_WITH_PROBE, Z_MIN_PROBE, Z_MIN))
   #endif
+  #if HAS_I_MIN || HAS_I_MAX
+    , I_ENDSTOP = TERN(I_HOME_TO_MAX, I_MAX, I_MIN)
+  #endif
+  #if HAS_J_MIN || HAS_J_MAX
+    , J_ENDSTOP = TERN(J_HOME_TO_MAX, J_MAX, J_MIN)
+  #endif
+  #if HAS_K_MIN || HAS_K_MAX
+    , K_ENDSTOP = TERN(K_HOME_TO_MAX, K_MAX, K_MIN)
+  #endif
 };
 
 #undef __ES_ITEM


### PR DESCRIPTION
### Description

This is my attemt to fix compilation with the combination `LINEAR_AXES` > 4 and a display (see issue https://github.com/DerAndere1/Marlin/issues/52)

Also, this makes code for endstops more consistent.


### Requirements

- LINEAR_AXES >= 4
- A display that relies on code in file lcd/menu/menu_motion.cpp

### Benefits

I hope this PR fixes compilation with the combination LINEAR_AXES > 4 and a display.
It should also make enstops for additional LINEAR_AXES (axes I, J, K) behave like endstops for axes X, Y, Z, especially with `SPI_I_SENSORLESS`.

### Configurations

to be done

### Related Issues

https://github.com/DerAndere1/Marlin/issues/52
