### PR TITLE
M42: Prevent unwanted pin mode switch to output

### DIFF
--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -68,20 +68,12 @@ void GcodeSuite::M42() {
       case 0: pinMode(pin, INPUT); avoidWrite = true; break;
       case 1: pinMode(pin, OUTPUT); break;
       case 2: pinMode(pin, INPUT_PULLUP); avoidWrite = true; break;
-      case 3:
-        #ifdef INPUT_PULLDOWN
-          pinMode(pin, INPUT_PULLDOWN);
-          avoidWrite = true;
-        #endif
-        break;
-      case 4:
-        #ifdef INPUT_ANALOG // STM32
-          pinMode(pin, INPUT_ANALOG);
-        #elif defined(MAPLE_STM32F1)
-          _SET_MODE(pin, GPIO_INPUT_ANALOG);
-        #endif
-        avoidWrite = true;
-        break;
+      #ifdef INPUT_PULLDOWN
+        case 3: pinMode(pin, INPUT_PULLDOWN); avoidWrite = true; break;
+      #endif
+      #ifdef INPUT_ANALOG
+        case 4: pinMode(pin, INPUT_ANALOG); avoidWrite = true; break;
+      #endif
       #ifdef OUTPUT_OPEN_DRAIN
         case 5: pinMode(pin, OUTPUT_OPEN_DRAIN); break;
       #endif

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -52,10 +52,10 @@ void GcodeSuite::M42() {
   if (pin_index < 0) return;
 
   const pin_t pin = GET_PIN_MAP_PIN(pin_index);
-  bool avoidWrite = false;
 
   if (!parser.boolval('I') && pin_is_protected(pin)) return protected_pin_err();
 
+  bool avoidWrite = false;
   if (parser.seenval('M')) {
     switch (parser.value_byte()) {
       case 0: pinMode(pin, INPUT); avoidWrite = true; break;
@@ -107,8 +107,8 @@ void GcodeSuite::M42() {
   #endif
 
   if (avoidWrite) {
-     SERIAL_ECHOLNPGM("No value allowed for an input");
-     return;
+    SERIAL_ECHOLNPGM("?Cannot write to INPUT");
+    return;
   }
 
   // An OUTPUT_OPEN_DRAIN should not be changed to normal OUTPUT (STM32)

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -62,7 +62,7 @@ void GcodeSuite::M42() {
       case 1: pinMode(pin, OUTPUT); break;
       case 2: pinMode(pin, INPUT_PULLUP); avoidWrite = true; break;
       #ifdef INPUT_PULLDOWN
-        case 3: pinMode(pin, INPUT_PULLDOWN); break;
+        case 3: pinMode(pin, INPUT_PULLDOWN); avoidWrite = true; break;
       #endif
       #ifdef INPUT_ANALOG
         case 4: pinMode(pin, INPUT_ANALOG); avoidWrite = true; break;

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -31,6 +31,13 @@
   #include "../../module/temperature.h"
 #endif
 
+#ifdef MAPLE_STM32F1
+  // these are enums on the F1...
+  #define INPUT_PULLDOWN INPUT_PULLDOWN
+  #define INPUT_ANALOG INPUT_ANALOG
+  #define OUTPUT_OPEN_DRAIN OUTPUT_OPEN_DRAIN
+#endif
+
 void protected_pin_err() {
   SERIAL_ERROR_MSG(STR_ERR_PROTECTED_PIN);
 }

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -68,12 +68,20 @@ void GcodeSuite::M42() {
       case 0: pinMode(pin, INPUT); avoidWrite = true; break;
       case 1: pinMode(pin, OUTPUT); break;
       case 2: pinMode(pin, INPUT_PULLUP); avoidWrite = true; break;
-      #ifdef INPUT_PULLDOWN
-        case 3: pinMode(pin, INPUT_PULLDOWN); avoidWrite = true; break;
-      #endif
-      #ifdef INPUT_ANALOG
-        case 4: pinMode(pin, INPUT_ANALOG); avoidWrite = true; break;
-      #endif
+      case 3:
+        #ifdef INPUT_PULLDOWN
+          pinMode(pin, INPUT_PULLDOWN);
+          avoidWrite = true;
+        #endif
+        break;
+      case 4:
+        #ifdef INPUT_ANALOG // STM32
+          pinMode(pin, INPUT_ANALOG);
+        #elif defined(MAPLE_STM32F1)
+          _SET_MODE(pin, GPIO_INPUT_ANALOG);
+        #endif
+        avoidWrite = true;
+        break;
       #ifdef OUTPUT_OPEN_DRAIN
         case 5: pinMode(pin, OUTPUT_OPEN_DRAIN); break;
       #endif


### PR DESCRIPTION
Add several basic checks and fixes to M42 command (DIRECT_PIN_CONTROL)

Also, M42 S1 was never set on STM32 arch, if the led pin is a normal digital output
Value was reset to 0 on analogWrite call...

if we set M0/M2 or other input types, ignore S parameter (write)

For the documentation, add two pins modes M4 & M5 to handle common types (like input analog & Open Drain output mode on STM32)

It's also made to prevent switching automatically an output of this kind to a normal output

M4 is less important, could be removed, except to just set/reset the mode during tests. Need some ADC/Analog setup etc i think