### PR TITLE
📝 Spellcheck comments

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1109,7 +1109,7 @@
 #endif
 
 // Duet Smart Effector (for delta printers) - https://bit.ly/2ul5U7J
-// When the pin is defined you can use M672 to set/reset the probe sensivity.
+// When the pin is defined you can use M672 to set/reset the probe sensitivity.
 //#define DUET_SMART_EFFECTOR
 #if ENABLED(DUET_SMART_EFFECTOR)
   #define SMART_EFFECTOR_MOD_PIN  -1  // Connect a GPIO pin to the Smart Effector MOD pin

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3912,7 +3912,7 @@
    */
   #define I2CPE_MIN_UPD_TIME_MS     4                       // (ms) Minimum time between encoder checks.
 
-  // Use a rolling average to identify persistant errors that indicate skips, as opposed to vibration and noise.
+  // Use a rolling average to identify persistent errors that indicate skips, as opposed to vibration and noise.
   #define I2CPE_ERR_ROLLING_AVERAGE
 
 #endif // I2C_POSITION_ENCODERS

--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -110,7 +110,7 @@ LIQUID_TWI2        ?= 0
 WIRE               ?= 0
 
 # This defines if Tone is needed (i.e SPEAKER is defined in Configuration.h)
-# Disabling this (and SPEAKER) saves approximatively 350 bytes of memory.
+# Disabling this (and SPEAKER) saves approximately 350 bytes of memory.
 TONE               ?= 1
 
 # This defines if U8GLIB is needed (may require RELOC_WORKAROUND)

--- a/Marlin/src/HAL/AVR/fastio.h
+++ b/Marlin/src/HAL/AVR/fastio.h
@@ -284,7 +284,7 @@ enum ClockSource2 : char {
  * PWM availability macros
  */
 
-// Determine which harware PWMs are already in use
+// Determine which hardware PWMs are already in use
 #define _PWM_CHK_FAN_B(P) (P == E0_AUTO_FAN_PIN || P == E1_AUTO_FAN_PIN || P == E2_AUTO_FAN_PIN || P == E3_AUTO_FAN_PIN || P == E4_AUTO_FAN_PIN || P == E5_AUTO_FAN_PIN || P == E6_AUTO_FAN_PIN || P == E7_AUTO_FAN_PIN || P == CHAMBER_AUTO_FAN_PIN || P == COOLER_AUTO_FAN_PIN)
 #if PIN_EXISTS(CONTROLLER_FAN)
   #define PWM_CHK_FAN_B(P) (_PWM_CHK_FAN_B(P) || P == CONTROLLER_FAN_PIN)

--- a/Marlin/src/HAL/DUE/HAL_SPI.cpp
+++ b/Marlin/src/HAL/DUE/HAL_SPI.cpp
@@ -437,7 +437,7 @@
     } while (--todo);
   }
 
-  // Pointers to generic functions for block tranfers
+  // Pointers to generic functions for block transfers
   static pfnSpiTxBlock spiTxBlock = (pfnSpiTxBlock)spiTxBlockX;
   static pfnSpiRxBlock spiRxBlock = (pfnSpiRxBlock)spiRxBlockX;
 

--- a/Marlin/src/HAL/DUE/usb/arduino_due_x.h
+++ b/Marlin/src/HAL/DUE/usb/arduino_due_x.h
@@ -71,7 +71,7 @@
 /* ------------------------------------------------------------------------ */
 
 /**
- * \page arduino_due_x_board_info "Arduino Due/X - Board informations"
+ * \page arduino_due_x_board_info "Arduino Due/X - Board information"
  * This page lists several definition related to the board description.
  *
  */

--- a/Marlin/src/HAL/DUE/usb/udd.h
+++ b/Marlin/src/HAL/DUE/usb/udd.h
@@ -90,7 +90,7 @@ typedef struct {
 	//! This buffer must be word align for DATA IN phase (use prefix COMPILER_WORD_ALIGNED for buffer)
 	uint8_t *payload;
 
-	//! Size of buffer to send or fill, and content the number of byte transfered
+	//! Size of buffer to send or fill, and content the number of byte transferred
 	uint16_t payload_size;
 
 	//! Callback called after reception of ZLP from setup request
@@ -132,7 +132,7 @@ typedef void (*udd_callback_halt_cleared_t)(void);
  *
  * \param status     UDD_EP_TRANSFER_OK, if transfer is complete
  * \param status     UDD_EP_TRANSFER_ABORT, if transfer is aborted
- * \param n          number of data transfered
+ * \param n          number of data transferred
  */
 typedef void (*udd_callback_trans_t) (udd_ep_status_t status,
 		iram_size_t nb_transfered, udd_ep_id_t ep);
@@ -303,7 +303,7 @@ bool udd_ep_wait_stall_clear(udd_ep_id_t ep,
  * The driver uses a specific DMA USB to transfer data
  * from internal RAM to endpoint, if this one is available.
  * When the transfer is finished or aborted (stall, reset, ...), the \a callback is called.
- * The \a callback returns the transfer status and eventually the number of byte transfered.
+ * The \a callback returns the transfer status and eventually the number of byte transferred.
  * Note: The control endpoint is not authorized.
  *
  * \param ep            The ID of the endpoint to use

--- a/Marlin/src/HAL/DUE/usb/udi_cdc.c
+++ b/Marlin/src/HAL/DUE/usb/udi_cdc.c
@@ -162,7 +162,7 @@ static void udi_cdc_ctrl_state_notify(uint8_t port, udd_ep_id_t ep);
  *
  * \param status     UDD_EP_TRANSFER_OK, if transfer finished
  * \param status     UDD_EP_TRANSFER_ABORT, if transfer aborted
- * \param n          number of data transfered
+ * \param n          number of data transferred
  */
 static void udi_cdc_serial_state_msg_sent(udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep);
 
@@ -200,7 +200,7 @@ static void udi_cdc_data_received(udd_ep_status_t status, iram_size_t n, udd_ep_
  *
  * \param status     UDD_EP_TRANSFER_OK, if transfer finished
  * \param status     UDD_EP_TRANSFER_ABORT, if transfer aborted
- * \param n          number of data transfered
+ * \param n          number of data transferred
  */
 static void udi_cdc_data_sent(udd_ep_status_t status, iram_size_t n, udd_ep_id_t ep);
 

--- a/Marlin/src/HAL/DUE/usb/udi_cdc_conf.h
+++ b/Marlin/src/HAL/DUE/usb/udi_cdc_conf.h
@@ -106,7 +106,7 @@ extern "C" {
  */
 //@{
 #  if UDI_CDC_PORT_NB > 2
-#    error USBB, UDP, UDPHS and UOTGHS interfaces have not enought endpoints.
+#    error USBB, UDP, UDPHS and UOTGHS interfaces have not enough endpoints.
 #  endif
 #define  UDI_CDC_DATA_EP_IN_0          (1 | USB_EP_DIR_IN)  // TX
 #define  UDI_CDC_DATA_EP_OUT_0         (2 | USB_EP_DIR_OUT) // RX

--- a/Marlin/src/HAL/DUE/usb/udi_msc.c
+++ b/Marlin/src/HAL/DUE/usb/udi_msc.c
@@ -173,7 +173,7 @@ static void udi_msc_cbw_wait(void);
  *
  * \param status       UDD_EP_TRANSFER_OK, if transfer is finished
  * \param status       UDD_EP_TRANSFER_ABORT, if transfer is aborted
- * \param nb_received  number of data transfered
+ * \param nb_received  number of data transferred
  */
 static void udi_msc_cbw_received(udd_ep_status_t status,
     iram_size_t nb_received, udd_ep_id_t ep);
@@ -211,7 +211,7 @@ static void udi_msc_data_send(uint8_t * buffer, uint8_t buf_size);
  *
  * \param status     UDD_EP_TRANSFER_OK, if transfer finish
  * \param status     UDD_EP_TRANSFER_ABORT, if transfer aborted
- * \param nb_sent    number of data transfered
+ * \param nb_sent    number of data transferred
  */
 static void udi_msc_data_sent(udd_ep_status_t status, iram_size_t nb_sent,
     udd_ep_id_t ep);
@@ -244,7 +244,7 @@ void udi_msc_csw_send(void);
  *
  * \param status     UDD_EP_TRANSFER_OK, if transfer is finished
  * \param status     UDD_EP_TRANSFER_ABORT, if transfer is aborted
- * \param nb_sent    number of data transfered
+ * \param nb_sent    number of data transferred
  */
 static void udi_msc_csw_sent(udd_ep_status_t status, iram_size_t nb_sent,
     udd_ep_id_t ep);
@@ -463,7 +463,7 @@ uint8_t udi_msc_getsetting(void)
 static void udi_msc_cbw_invalid(void)
 {
   if (!udi_msc_b_cbw_invalid)
-    return; // Don't re-stall endpoint if error reseted by setup
+    return; // Don't re-stall endpoint if error reset by setup
   udd_ep_set_halt(UDI_MSC_EP_OUT);
   // If stall cleared then re-stall it. Only Setup MSC Reset can clear it
   udd_ep_wait_stall_clear(UDI_MSC_EP_OUT, udi_msc_cbw_invalid);
@@ -472,7 +472,7 @@ static void udi_msc_cbw_invalid(void)
 static void udi_msc_csw_invalid(void)
 {
   if (!udi_msc_b_cbw_invalid)
-    return; // Don't re-stall endpoint if error reseted by setup
+    return; // Don't re-stall endpoint if error reset by setup
   udd_ep_set_halt(UDI_MSC_EP_IN);
   // If stall cleared then re-stall it. Only Setup MSC Reset can clear it
   udd_ep_wait_stall_clear(UDI_MSC_EP_IN, udi_msc_csw_invalid);

--- a/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
+++ b/Marlin/src/HAL/DUE/usb/uotghs_device_due.c
@@ -325,7 +325,7 @@ static void udd_sleep_mode(bool b_idle)
 /**
  * \name Control endpoint low level management routine.
  *
- * This function performs control endpoint mangement.
+ * This function performs control endpoint management.
  * It handle the SETUP/DATA/HANDSHAKE phases of a control transaction.
  */
 //@{
@@ -397,9 +397,9 @@ static void udd_ctrl_endofrequest(void);
 /**
  * \brief Main interrupt routine for control endpoint
  *
- * This switchs control endpoint events to correct sub function.
+ * This switches control endpoint events to correct sub function.
  *
- * \return \c 1 if an event about control endpoint is occured, otherwise \c 0.
+ * \return \c 1 if an event about control endpoint is occurred, otherwise \c 0.
  */
 static bool udd_ctrl_interrupt(void);
 
@@ -410,7 +410,7 @@ static bool udd_ctrl_interrupt(void);
  * \name Management of bulk/interrupt/isochronous endpoints
  *
  * The UDD manages the data transfer on endpoints:
- * - Start data tranfer on endpoint with USB Device DMA
+ * - Start data transfer on endpoint with USB Device DMA
  * - Send a ZLP packet if requested
  * - Call callback registered to signal end of transfer
  * The transfer abort and stall feature are supported.
@@ -431,7 +431,7 @@ typedef struct {
 	uint8_t *buf;
 	//! Size of buffer to send or fill
 	iram_size_t buf_size;
-	//!< Size of data transfered
+	//!< Size of data transferred
 	iram_size_t buf_cnt;
 	//!< Size of data loaded (or prepared for DMA) last time
 	iram_size_t buf_load;
@@ -486,7 +486,7 @@ static void udd_ep_finish_job(udd_ep_job_t * ptr_job, bool b_abort, uint8_t ep_n
 
 #ifdef UDD_EP_DMA_SUPPORTED
 	/**
-	 * \brief Start the next transfer if necessary or complet the job associated.
+	 * \brief Start the next transfer if necessary or complete the job associated.
 	 *
 	 * \param ep endpoint number without direction flag
 	 */
@@ -496,9 +496,9 @@ static void udd_ep_finish_job(udd_ep_job_t * ptr_job, bool b_abort, uint8_t ep_n
 /**
  * \brief Main interrupt routine for bulk/interrupt/isochronous endpoints
  *
- * This switchs endpoint events to correct sub function.
+ * This switches endpoint events to correct sub function.
  *
- * \return \c 1 if an event about bulk/interrupt/isochronous endpoints has occured, otherwise \c 0.
+ * \return \c 1 if an event about bulk/interrupt/isochronous endpoints has occurred, otherwise \c 0.
  */
 static bool udd_ep_interrupt(void);
 
@@ -520,7 +520,7 @@ static bool udd_ep_interrupt(void);
  *
  * Note:
  * Here, the global interrupt mask is not clear when an USB interrupt is enabled
- * because this one can not be occured during the USB ISR (=during INTX is masked).
+ * because this one can not be occurred during the USB ISR (=during INTX is masked).
  * See Technical reference $3.8.3 Masking interrupt requests in peripheral modules.
  */
 #ifdef UHD_ENABLE
@@ -787,7 +787,7 @@ void udd_attach(void)
 	udd_sleep_mode(true);
 	otg_unfreeze_clock();
 
-	// This section of clock check can be improved with a chek of
+	// This section of clock check can be improved with a check of
 	// USB clock source via sysclk()
 	// Check USB clock because the source can be a PLL
 	while (!Is_otg_clock_usable());
@@ -803,7 +803,7 @@ void udd_attach(void)
 #ifdef USB_DEVICE_HS_SUPPORT
 	udd_enable_msof_interrupt();
 #endif
-	// Reset following interupts flag
+	// Reset following interrupts flag
 	udd_ack_reset();
 	udd_ack_sof();
 	udd_ack_msof();
@@ -902,7 +902,7 @@ bool udd_ep_alloc(udd_ep_id_t ep, uint8_t bmAttributes,
 	}
 	dbg_print("alloc(%x, %d) ", ep, MaxEndpointSize);
 
-	// Bank choise
+	// Bank choice
 	switch (bmAttributes & USB_EP_TYPE_MASK) {
 	case USB_EP_TYPE_ISOCHRONOUS:
 		nb_bank = UDD_ISOCHRONOUS_NB_BANK(ep);
@@ -1228,7 +1228,7 @@ bool udd_ep_wait_stall_clear(udd_ep_id_t ep,
 
 	if (Is_udd_endpoint_stall_requested(ep)
 			|| ptr_job->stall_requested) {
-		// Endpoint halted then registes the callback
+		// Endpoint halted then registers the callback
 		ptr_job->busy = true;
 		ptr_job->call_nohalt = callback;
 	} else {
@@ -1386,7 +1386,7 @@ static void udd_ctrl_setup_received(void)
 
 	// Decode setup request
 	if (udc_process_setup() == false) {
-		// Setup request unknow then stall it
+		// Setup request unknown then stall it
 		udd_ctrl_stall_data();
 		udd_ack_setup_received(0);
 		return;
@@ -1447,7 +1447,7 @@ static void udd_ctrl_in_sent(void)
 		udd_ctrl_prev_payload_buf_cnt += udd_ctrl_payload_buf_cnt;
 		if ((udd_g_ctrlreq.req.wLength == udd_ctrl_prev_payload_buf_cnt)
 					|| b_shortpacket) {
-			// All data requested are transfered or a short packet has been sent
+			// All data requested are transferred or a short packet has been sent
 			// then it is the end of data phase.
 			// Generate an OUT ZLP for handshake phase.
 			udd_ctrl_send_zlp_out();
@@ -1516,7 +1516,7 @@ static void udd_ctrl_out_received(void)
 			// End of SETUP request:
 			// - Data IN Phase aborted,
 			// - or last Data IN Phase hidden by ZLP OUT sending quiclky,
-			// - or ZLP OUT received normaly.
+			// - or ZLP OUT received normally.
 			udd_ctrl_endofrequest();
 		} else {
 			// Protocol error during SETUP request
@@ -1544,7 +1544,7 @@ static void udd_ctrl_out_received(void)
 					(udd_ctrl_prev_payload_buf_cnt +
 							udd_ctrl_payload_buf_cnt))) {
 		// End of reception because it is a short packet
-		// Before send ZLP, call intermediat calback
+		// Before send ZLP, call intermediate callback
 		// in case of data receiv generate a stall
 		udd_g_ctrlreq.payload_size = udd_ctrl_payload_buf_cnt;
 		if (NULL != udd_g_ctrlreq.over_under_run) {
@@ -1565,7 +1565,7 @@ static void udd_ctrl_out_received(void)
 	if (udd_g_ctrlreq.payload_size == udd_ctrl_payload_buf_cnt) {
 		// Overrun then request a new payload buffer
 		if (!udd_g_ctrlreq.over_under_run) {
-			// No callback availabled to request a new payload buffer
+			// No callback available to request a new payload buffer
 			udd_ctrl_stall_data();
 			// Ack reception of OUT to replace NAK by a STALL
 			udd_ack_out_received(0);
@@ -1805,7 +1805,7 @@ static void udd_ep_trans_done(udd_ep_id_t ep)
 			// transfer size of UDD_ENDPOINT_MAX_TRANS Bytes
 			next_trans = UDD_ENDPOINT_MAX_TRANS;
 
-			// Set 0 to tranfer the maximum
+			// Set 0 to transfer the maximum
 			udd_dma_ctrl = UOTGHS_DEVDMACONTROL_BUFF_LENGTH(0);
 		} else {
 			udd_dma_ctrl = UOTGHS_DEVDMACONTROL_BUFF_LENGTH(next_trans);
@@ -1850,7 +1850,7 @@ static void udd_ep_trans_done(udd_ep_id_t ep)
 		}
 		cpu_irq_restore(flags);
 
-		// Here a ZLP has been recieved
+		// Here a ZLP has been received
 		// and the DMA transfer must be not started.
 		// It is the end of transfer
 		ptr_job->buf_size = ptr_job->buf_cnt;
@@ -1991,13 +1991,13 @@ static bool udd_ep_interrupt(void)
 			}
 			dbg_print("dma%x: ", ep);
 			udd_disable_endpoint_dma_interrupt(ep);
-			// Save number of data no transfered
+			// Save number of data no transferred
 			nb_remaining = (udd_endpoint_dma_get_status(ep) &
 					UOTGHS_DEVDMASTATUS_BUFF_COUNT_Msk)
 					>> UOTGHS_DEVDMASTATUS_BUFF_COUNT_Pos;
 			if (nb_remaining) {
 				// Transfer no complete (short packet or ZLP) then:
-				// Update number of data transfered
+				// Update number of data transferred
 				ptr_job->buf_cnt -= nb_remaining;
 				// Set transfer complete to stop the transfer
 				ptr_job->buf_size = ptr_job->buf_cnt;
@@ -2056,7 +2056,7 @@ static bool udd_ep_interrupt(void)
 				udd_disable_endpoint_interrupt(ep);
 
 				Assert(ptr_job->stall_requested);
-				// A stall has been requested during backgound transfer
+				// A stall has been requested during background transfer
 				ptr_job->stall_requested = false;
 				udd_disable_endpoint_bank_autoswitch(ep);
 				udd_enable_stall_handshake(ep);

--- a/Marlin/src/HAL/DUE/usb/usb_protocol_msc.h
+++ b/Marlin/src/HAL/DUE/usb/usb_protocol_msc.h
@@ -130,7 +130,7 @@ struct usb_msc_cbw {
 struct usb_msc_csw {
 	le32_t dCSWSignature;	//!< Must contain 'USBS'
 	le32_t dCSWTag;	//!< Same as dCBWTag
-	le32_t dCSWDataResidue;	//!< Number of bytes not transfered
+	le32_t dCSWDataResidue;	//!< Number of bytes not transferred
 	uint8_t bCSWStatus;	//!< Status code
 };
 

--- a/Marlin/src/HAL/LINUX/hardware/Heater.cpp
+++ b/Marlin/src/HAL/LINUX/hardware/Heater.cpp
@@ -54,7 +54,7 @@ void Heater::update() {
 }
 
 void Heater::interrupt(GpioEvent ev) {
-  // ununsed
+  // unused
 }
 
 #endif // __PLAT_LINUX__

--- a/Marlin/src/HAL/LINUX/include/pinmapping.h
+++ b/Marlin/src/HAL/LINUX/include/pinmapping.h
@@ -55,7 +55,7 @@ constexpr bool VALID_PIN(const pin_t p) { return WITHIN(p, 0, NUM_DIGITAL_PINS);
 // Test whether the pin is PWM
 constexpr bool PWM_PIN(const pin_t p) { return false; }
 
-// Test whether the pin is interruptable
+// Test whether the pin is interruptible
 constexpr bool INTERRUPT_PIN(const pin_t p) { return false; }
 
 // Get the pin number at the given index

--- a/Marlin/src/HAL/SAMD51/HAL.cpp
+++ b/Marlin/src/HAL/SAMD51/HAL.cpp
@@ -98,7 +98,7 @@
   // Struct must be 32 bits aligned because of DMA accesses but fields needs to be 8 bits packed
   typedef struct  __attribute__((aligned(4), packed)) {
     ADC_INPUTCTRL_Type INPUTCTRL;
-  } HAL_DMA_DAC_Registers;    // DMA transfered registers
+  } HAL_DMA_DAC_Registers;    // DMA transferred registers
 
 #endif
 

--- a/Marlin/src/HAL/SAMD51/fastio.h
+++ b/Marlin/src/HAL/SAMD51/fastio.h
@@ -131,7 +131,7 @@
    */
   #define PWM_PIN(P)        (WITHIN(P, 2, 13) || WITHIN(P, 22, 23) || WITHIN(P, 44, 45) || P == 48)
 
-  // Return fullfilled ADCx->INPUTCTRL.reg
+  // Return fulfilled ADCx->INPUTCTRL.reg
   #define PIN_TO_INPUTCTRL(P)     (  (PIN_TO_AIN(P) == 0) ? ADC_INPUTCTRL_MUXPOS_AIN0   \
                                    : (PIN_TO_AIN(P) == 1) ? ADC_INPUTCTRL_MUXPOS_AIN1   \
                                    : (PIN_TO_AIN(P) == 2) ? ADC_INPUTCTRL_MUXPOS_AIN2   \

--- a/Marlin/src/HAL/SAMD51/timers.cpp
+++ b/Marlin/src/HAL/SAMD51/timers.cpp
@@ -107,7 +107,7 @@ void HAL_timer_start(const uint8_t timer_num, const uint32_t frequency) {
     tc->COUNT32.INTENCLR.reg = TC_INTENCLR_OVF; // disable overflow interrupt
 
     // TCn clock setup
-    const uint8_t clockID = GCLK_CLKCTRL_IDs[TCC_INST_NUM + timer_num];   // TC clock are preceeded by TCC ones
+    const uint8_t clockID = GCLK_CLKCTRL_IDs[TCC_INST_NUM + timer_num];   // TC clock are preceded by TCC ones
     GCLK->PCHCTRL[clockID].bit.CHEN = false;
     SYNC(GCLK->PCHCTRL[clockID].bit.CHEN);
     GCLK->PCHCTRL[clockID].reg = GCLK_PCHCTRL_GEN_GCLK0 | GCLK_PCHCTRL_CHEN;   // 120MHz startup code programmed

--- a/Marlin/src/HAL/STM32/HAL_MinSerial.cpp
+++ b/Marlin/src/HAL/STM32/HAL_MinSerial.cpp
@@ -123,7 +123,7 @@ static void TX(char c) {
     }
     regs->DR = c;
   #else
-    // Let's hope a mystical guru will fix this, one day by writting interrupt-free USB CDC ACM code (or, at least, by polling the registers since interrupt will be queued but will never trigger)
+    // Let's hope a mystical guru will fix this, one day by writing interrupt-free USB CDC ACM code (or, at least, by polling the registers since interrupt will be queued but will never trigger)
     // For now, it's completely lost to oblivion.
   #endif
 }

--- a/Marlin/src/HAL/STM32/Servo.cpp
+++ b/Marlin/src/HAL/STM32/Servo.cpp
@@ -37,7 +37,7 @@ static_assert(COUNT(servoDelay) == NUM_SERVOS, "SERVO_DELAY must be an array NUM
 // This allows all timer interrupt priorities to be managed from a single location in the HAL.
 static uint32_t servo_interrupt_priority = NVIC_EncodePriority(NVIC_GetPriorityGrouping(), TIM_IRQ_PRIO, TIM_IRQ_SUBPRIO);
 
-// This must be called after the STM32 Servo class has intialized the timer.
+// This must be called after the STM32 Servo class has initialized the timer.
 // It may only be needed after the first call to attach(), but it is possible
 // that is is necessary after every detach() call. To be safe this is currently
 // called after every call to attach().

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -121,7 +121,7 @@ bool PersistentStore::access_start() {
         address += sizeof(uint32_t);
       }
       if (current_slot == -1) {
-        // We didn't find anything, so we'll just intialize to empty
+        // We didn't find anything, so we'll just initialize to empty
         for (int i = 0; i < MARLIN_EEPROM_SIZE; i++) ram_eeprom[i] = EMPTY_UINT8;
         current_slot = EEPROM_SLOTS;
       }

--- a/Marlin/src/HAL/STM32/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32/msc_sd.cpp
@@ -60,7 +60,7 @@ public:
       return true;
     }
 
-    // multi block optmization
+    // multi block optimization
     sd2card->writeStart(blkAddr, blkLen);
     while (blkLen--) {
       watchdog_refresh();
@@ -80,7 +80,7 @@ public:
       return true;
     }
 
-    // multi block optmization
+    // multi block optimization
     sd2card->readStart(blkAddr);
     while (blkLen--) {
       watchdog_refresh();

--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -253,7 +253,7 @@ static void NVIC_SetPriorityGrouping(uint32_t PriorityGroup) {
   reg_value &= ~(SCB_AIRCR_VECTKEY_Msk | SCB_AIRCR_PRIGROUP_Msk);             /* clear bits to change               */
   reg_value  =  (reg_value                                 |
                 ((uint32_t)0x5FA << SCB_AIRCR_VECTKEY_Pos) |
-                (PriorityGroupTmp << 8));                                     /* Insert write key and priorty group */
+                (PriorityGroupTmp << 8));                                     /* Insert write key & priority group  */
   SCB->AIRCR =  reg_value;
 }
 

--- a/Marlin/src/HAL/STM32F1/SPI.cpp
+++ b/Marlin/src/HAL/STM32F1/SPI.cpp
@@ -363,8 +363,8 @@ uint16_t SPIClass::transfer16(uint16_t data) const {
 /**
  * Roger Clark and Victor Perez, 2015
  * Performs a DMA SPI transfer with at least a receive buffer.
- * If a TX buffer is not provided, FF is sent over and over for the lenght of the transfer.
- * On exit TX buffer is not modified, and RX buffer cotains the received data.
+ * If a TX buffer is not provided, FF is sent over and over for the length of the transfer.
+ * On exit TX buffer is not modified, and RX buffer contains the received data.
  * Still in progress.
  */
 void SPIClass::dmaTransferSet(const void *transmitBuf, void *receiveBuf) {

--- a/Marlin/src/HAL/STM32F1/onboard_sd.h
+++ b/Marlin/src/HAL/STM32F1/onboard_sd.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #define _DISKIO_WRITE   1   /* 1: Enable disk_write function */
-#define _DISKIO_IOCTL   1   /* 1: Enable disk_ioctl fucntion */
-#define _DISKIO_ISDIO   0   /* 1: Enable iSDIO control fucntion */
+#define _DISKIO_IOCTL   1   /* 1: Enable disk_ioctl function */
+#define _DISKIO_ISDIO   0   /* 1: Enable iSDIO control function */
 
 typedef unsigned char BYTE;
 typedef unsigned short WORD;
@@ -56,7 +56,7 @@ DRESULT disk_read(BYTE pdrv, BYTE* buff, DWORD sector, UINT count);
 #define STA_NODISK      0x02    /* No medium in the drive */
 #define STA_PROTECT     0x04    /* Write protected */
 
-/* Command code for disk_ioctrl fucntion */
+/* Command code for disk_ioctrl function */
 
 /* Generic command (Used by FatFs) */
 #define CTRL_SYNC        0  /* Complete pending write process (needed at _FS_READONLY == 0) */

--- a/Marlin/src/HAL/STM32F1/timers.h
+++ b/Marlin/src/HAL/STM32F1/timers.h
@@ -166,7 +166,7 @@ FORCE_INLINE static void HAL_timer_set_compare(const uint8_t timer_num, const ha
   case STEP_TIMER_NUM:
     // NOTE: WE have set ARPE = 0, which means the Auto reload register is not preloaded
     // and there is no need to use any compare, as in the timer mode used, setting ARR to the compare value
-    // will result in exactly the same effect, ie trigerring an interrupt, and on top, set counter to 0
+    // will result in exactly the same effect, ie triggering an interrupt, and on top, set counter to 0
     timer_set_reload(STEP_TIMER_DEV, compare); // We reload direct ARR as needed during counting up
     break;
   case TEMP_TIMER_NUM:

--- a/Marlin/src/HAL/TEENSY31_32/HAL_SPI.cpp
+++ b/Marlin/src/HAL/TEENSY31_32/HAL_SPI.cpp
@@ -65,7 +65,7 @@ void spiInit(uint8_t spiRate) {
     case SPI_EIGHTH_SPEED:  clock =  1250000; break;
     case SPI_SPEED_5:       clock =   625000; break;
     case SPI_SPEED_6:       clock =   312500; break;
-    default:                clock = 4000000; // Default from the SPI libarary
+    default:                clock = 4000000; // Default from the SPI library
   }
   spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
   SPI.begin();

--- a/Marlin/src/HAL/TEENSY35_36/HAL_SPI.cpp
+++ b/Marlin/src/HAL/TEENSY35_36/HAL_SPI.cpp
@@ -65,7 +65,7 @@ void spiInit(uint8_t spiRate) {
   case SPI_SPEED_5:       clock =   625000; break;
   case SPI_SPEED_6:       clock =   312500; break;
   default:
-    clock = 4000000; // Default from the SPI libarary
+    clock = 4000000; // Default from the SPI library
   }
   spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
   SPI.begin();

--- a/Marlin/src/HAL/TEENSY40_41/HAL_SPI.cpp
+++ b/Marlin/src/HAL/TEENSY40_41/HAL_SPI.cpp
@@ -82,7 +82,7 @@ void spiInit(uint8_t spiRate) {
   case SPI_SPEED_5:       clock =   625000; break;
   case SPI_SPEED_6:       clock =   312500; break;
   default:
-    clock = 4000000; // Default from the SPI libarary
+    clock = 4000000; // Default from the SPI library
   }
   spiConfig = SPISettings(clock, MSBFIRST, SPI_MODE0);
   SPI.begin();

--- a/Marlin/src/HAL/shared/backtrace/unwarm.h
+++ b/Marlin/src/HAL/shared/backtrace/unwarm.h
@@ -4,7 +4,7 @@
  * This program is PUBLIC DOMAIN.
  * This means that there is no copyright and anyone is able to take a copy
  * for free and use it as they wish, with or without modifications, and in
- * any context, commerically or otherwise. The only limitation is that I
+ * any context, commercially or otherwise. The only limitation is that I
  * don't guarantee that the software is fit for any purpose or accept any
  * liability for its use or misuse - this software is without warranty.
  ***************************************************************************

--- a/Marlin/src/HAL/shared/backtrace/unwarmbytab.h
+++ b/Marlin/src/HAL/shared/backtrace/unwarmbytab.h
@@ -5,7 +5,7 @@
  * This program is PUBLIC DOMAIN.
  * This means that there is no copyright and anyone is able to take a copy
  * for free and use it as they wish, with or without modifications, and in
- * any context, commerically or otherwise. The only limitation is that I
+ * any context, commercially or otherwise. The only limitation is that I
  * don't guarantee that the software is fit for any purpose or accept any
  * liability for its use or misuse - this software is without warranty.
  ***************************************************************************

--- a/Marlin/src/HAL/shared/backtrace/unwarmmem.cpp
+++ b/Marlin/src/HAL/shared/backtrace/unwarmmem.cpp
@@ -5,7 +5,7 @@
  * This program is PUBLIC DOMAIN.
  * This means that there is no copyright and anyone is able to take a copy
  * for free and use it as they wish, with or without modifications, and in
- * any context, commerically or otherwise. The only limitation is that I
+ * any context, commercially or otherwise. The only limitation is that I
  * don't guarantee that the software is fit for any purpose or accept any
  * liability for its use or misuse - this software is without warranty.
  ***************************************************************************

--- a/Marlin/src/HAL/shared/backtrace/unwarmmem.h
+++ b/Marlin/src/HAL/shared/backtrace/unwarmmem.h
@@ -5,7 +5,7 @@
  * This program is PUBLIC DOMAIN.
  * This means that there is no copyright and anyone is able to take a copy
  * for free and use it as they wish, with or without modifications, and in
- * any context, commerically or otherwise. The only limitation is that I
+ * any context, commercially or otherwise. The only limitation is that I
  * don't guarantee that the software is fit for any purpose or accept any
  * liability for its use or misuse - this software is without warranty.
  ***************************************************************************

--- a/Marlin/src/HAL/shared/backtrace/unwinder.cpp
+++ b/Marlin/src/HAL/shared/backtrace/unwinder.cpp
@@ -28,7 +28,7 @@ extern "C" const UnwTabEntry __exidx_end[];
 
 // Detect if unwind information is present or not
 static int HasUnwindTableInfo() {
-  // > 16 because there are default entries we can't supress
+  // > 16 because there are default entries we can't suppress
   return ((char*)(&__exidx_end) - (char*)(&__exidx_start)) > 16 ? 1 : 0;
 }
 

--- a/Marlin/src/HAL/shared/backtrace/unwinder.h
+++ b/Marlin/src/HAL/shared/backtrace/unwinder.h
@@ -5,7 +5,7 @@
  * This program is PUBLIC DOMAIN.
  * This means that there is no copyright and anyone is able to take a copy
  * for free and use it as they wish, with or without modifications, and in
- * any context, commerically or otherwise. The only limitation is that I
+ * any context, commercially or otherwise. The only limitation is that I
  * don't guarantee that the software is fit for any purpose or accept any
  * liability for its use or misuse - this software is without warranty.
  **************************************************************************/

--- a/Marlin/src/HAL/shared/backtrace/unwmemaccess.h
+++ b/Marlin/src/HAL/shared/backtrace/unwmemaccess.h
@@ -5,7 +5,7 @@
  * This program is PUBLIC DOMAIN.
  * This means that there is no copyright and anyone is able to take a copy
  * for free and use it as they wish, with or without modifications, and in
- * any context, commerically or otherwise. The only limitation is that I
+ * any context, commercially or otherwise. The only limitation is that I
  * don't guarantee that the software is fit for any purpose or accept any
  * liability for its use or misuse - this software is without warranty.
  ***************************************************************************

--- a/Marlin/src/HAL/shared/cpu_exception/exception_arm.cpp
+++ b/Marlin/src/HAL/shared/cpu_exception/exception_arm.cpp
@@ -345,7 +345,7 @@ void hook_cpu_exceptions() {
       // We failed to find a valid vector table size, let's abort hooking up
       if (vec_size == VECTOR_TABLE_SENTINEL) return;
       // Poor method that's wasting RAM here, but allocating with malloc and alignment would be worst
-      // 128 bytes alignement is required for writing the VTOR register
+      // 128 bytes alignment is required for writing the VTOR register
       alignas(128) static unsigned long vectable[VECTOR_TABLE_SENTINEL];
 
       SERIAL_ECHOPGM("Detected vector table size: ");

--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -399,7 +399,7 @@
     template <typename T, typename ... Args> struct first_type_of { typedef T type; };
     template <typename T> struct first_type_of<T> { typedef T type; };
   }
-  // C++11 solution using SFINAE to detect the existance of a member in a class at compile time.
+  // C++11 solution using SFINAE to detect the existence of a member in a class at compile time.
   // It creates a HasMember<Type> structure containing 'value' set to true if the member exists
   #define HAS_MEMBER_IMPL(Member) \
     namespace Private { \

--- a/Marlin/src/core/serial_hook.h
+++ b/Marlin/src/core/serial_hook.h
@@ -109,7 +109,7 @@ struct ConditionalSerial : public SerialBase< ConditionalSerial<SerialT> > {
   ConditionalSerial(bool & conditionVariable, SerialT & out, const bool e) : BaseClassT(e), condition(conditionVariable), out(out) {}
 };
 
-// A simple foward class that taking a reference to an existing serial instance (likely created in their respective framework)
+// A simple forward class that taking a reference to an existing serial instance (likely created in their respective framework)
 template <class SerialT>
 struct ForwardSerial : public SerialBase< ForwardSerial<SerialT> > {
   typedef SerialBase< ForwardSerial<SerialT> > BaseClassT;

--- a/Marlin/src/feature/bedlevel/hilbert_curve.cpp
+++ b/Marlin/src/feature/bedlevel/hilbert_curve.cpp
@@ -35,7 +35,7 @@ constexpr uint8_t dim = _BV(ord);
 
 static inline bool eval_candidate(int8_t x, int8_t y, hilbert_curve::callback_ptr func, void *data) {
   // The print bed likely has fewer points than the full Hilbert
-  // curve, so cull unecessary points
+  // curve, so cull unnecessary points
   return x < (GRID_MAX_POINTS_X) && y < (GRID_MAX_POINTS_Y) ? func(x, y, data) : false;
 }
 

--- a/Marlin/src/feature/dac/dac_mcp4728.cpp
+++ b/Marlin/src/feature/dac/dac_mcp4728.cpp
@@ -81,7 +81,7 @@ uint8_t MCP4728::eepromWrite() {
 }
 
 /**
- * Write Voltage reference setting to all input regiters
+ * Write Voltage reference setting to all input registers
  */
 uint8_t MCP4728::setVref_all(const uint8_t value) {
   Wire.beginTransmission(I2C_ADDRESS(DAC_DEV_ADDRESS));
@@ -89,7 +89,7 @@ uint8_t MCP4728::setVref_all(const uint8_t value) {
   return Wire.endTransmission();
 }
 /**
- * Write Gain setting to all input regiters
+ * Write Gain setting to all input registers
  */
 uint8_t MCP4728::setGain_all(const uint8_t value) {
   Wire.beginTransmission(I2C_ADDRESS(DAC_DEV_ADDRESS));
@@ -129,7 +129,7 @@ void MCP4728::setDrvPct(xyze_uint_t &pct) {
 }
 
 /**
- * FastWrite input register values - All DAC ouput update. refer to DATASHEET 5.6.1
+ * FastWrite input register values - All DAC output update. refer to DATASHEET 5.6.1
  * DAC Input and PowerDown bits update.
  * No EEPROM update
  */

--- a/Marlin/src/feature/encoder_i2c.cpp
+++ b/Marlin/src/feature/encoder_i2c.cpp
@@ -94,7 +94,7 @@ void I2CPositionEncoder::update() {
 
         SERIAL_ECHOLNPAIR("Untrusted encoder module on ", AS_CHAR(axis_codes[encoderAxis]), " axis has been fault-free for set duration, reinstating error correction.");
 
-        //the encoder likely lost its place when the error occured, so we'll reset and use the printer's
+        //the encoder likely lost its place when the error occurred, so we'll reset and use the printer's
         //idea of where it the axis is to re-initialize
         const float pos = planner.get_axis_position_mm(encoderAxis);
         int32_t positionInTicks = pos * get_ticks_unit();

--- a/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
@@ -47,7 +47,7 @@
  *    Compensation values are deltas to first probe measurement at bed temp. = 60°C.
  *  - The hotend will not be heated at any time.
  *  - On my Průša MK3S clone I put a piece of paper between the probe and the hotend
- *    so the hotend fan would not cool my probe constantly. Alternativly you could just
+ *    so the hotend fan would not cool my probe constantly. Alternatively you could just
  *    make sure the fan is not running while running the calibration process.
  *
  *  Probe calibration:

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -288,8 +288,8 @@ inline void servo_probe_test() {
  *                  S<pin>  - Start Pin number.   If not given, will default to 0
  *                  L<pin>  - End Pin number.   If not given, will default to last pin defined for this board
  *                  I<bool> - Flag to ignore Marlin's pin protection.   Use with caution!!!!
- *                  R       - Repeat pulses on each pin this number of times before continueing to next pin
- *                  W       - Wait time (in miliseconds) between pulses.  If not given will default to 500
+ *                  R       - Repeat pulses on each pin this number of times before continuing to next pin
+ *                  W       - Wait time (in milliseconds) between pulses.  If not given will default to 500
  *
  *  M43 S       - Servo probe test
  *                  P<index> - Probe index (optional - defaults to 0

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -212,7 +212,7 @@ void L64XX_report_current(L64XX &motor, const L64XX_axis_t axis) {
  *     L6474 - current in mA (4A max)
  *     All others - 0-255
  *
- * Sets KVAL_HOLD wich affects the current being driven through the stepper.
+ * Sets KVAL_HOLD which affects the current being driven through the stepper.
  *
  * L6470 is used in the STEP-CLOCK mode.  KVAL_HOLD is the only KVAL_xxx
  * that affects the effective voltage seen by the stepper.

--- a/Marlin/src/gcode/feature/L6470/M916-918.cpp
+++ b/Marlin/src/gcode/feature/L6470/M916-918.cpp
@@ -177,7 +177,7 @@ void GcodeSuite::M916() {
   if ((status_composite & (sh.STATUS_AXIS_TH_WRN | sh.STATUS_AXIS_TH_SD)))
     DEBUG_ECHOLNPGM(".\n.\nTest completed normally - Thermal warning/shutdown has occurred");
   else if (status_composite)
-    DEBUG_ECHOLNPGM(".\n.\nTest completed abnormally - non-thermal error has occured");
+    DEBUG_ECHOLNPGM(".\n.\nTest completed abnormally - non-thermal error has occurred");
   else
     DEBUG_ECHOLNPGM(".\n.\nTest completed normally - Unable to get to thermal warning/shutdown");
 

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -220,7 +220,7 @@
     #define LCD_PROGRESS_BAR
   #endif
   #if ENABLED(TFTGLCD_PANEL_I2C)
-    #define LCD_I2C_ADDRESS           0x33  // Must be 0x33 for STM32 main boards and equal to panel's I2C slave addres
+    #define LCD_I2C_ADDRESS           0x33  // Must be 0x33 for STM32 main boards and equal to panel's I2C slave address
   #endif
   #define LCD_USE_I2C_BUZZER                // Enable buzzer on LCD, used for both I2C and SPI buses (LiquidTWI2 not required)
   #define STD_ENCODER_PULSES_PER_STEP 2

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -1321,7 +1321,7 @@ void MarlinUI::draw_status_screen() {
         y_map_pixels = pixels_per_y_mesh_pnt * (GRID_MAX_POINTS_Y);         // Directions fit nicely
 
         right_edge   = pixels_per_x_mesh_pnt * (GRID_MAX_POINTS_X) + 1;     // Find location of right edge within the character cell
-        bottom_line  = pixels_per_y_mesh_pnt * (GRID_MAX_POINTS_Y) + 1;     // Find location of bottome line within the character cell
+        bottom_line  = pixels_per_y_mesh_pnt * (GRID_MAX_POINTS_Y) + 1;     // Find location of bottom line within the character cell
 
         n_rows = bottom_line / (HD44780_CHAR_HEIGHT) + 1;
         n_cols = right_edge / (HD44780_CHAR_WIDTH) + 1;

--- a/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
+++ b/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
@@ -98,7 +98,7 @@ TFTGLCD lcd;
 #define COLOR_EDIT      '#'
 #define COLOR_ERROR     '!'
 
-#ifdef CONVERT_TO_EXT_ASCII   //use standart pseudographic symbols in ASCII table
+#ifdef CONVERT_TO_EXT_ASCII   //use standard pseudographic symbols in ASCII table
   #define LR            179   //vertical line
   #define TRC           191   //top right corner
   #define BLC           192   //bottom left corner
@@ -401,7 +401,7 @@ static void center_text_P(PGM_P pstart, uint8_t y) {
     //
     uint8_t indent = (LCD_WIDTH - 8) / 2;
     // symbols 217 (bottom right corner) and 218 (top left corner) are using for letters in some languages
-    // and they should be moved to begining ASCII table as spetial symbols
+    // and they should be moved to beginning ASCII table as special symbols
     lcd.setCursor(indent, 0); lcd.write(TLC); lcd_put_u8str_P(PSTR("------"));  lcd.write(TRC);
     lcd.setCursor(indent, 1); lcd.write(LR);  lcd_put_u8str_P(PSTR("Marlin"));  lcd.write(LR);
     lcd.setCursor(indent, 2); lcd.write(BLC); lcd_put_u8str_P(PSTR("------"));  lcd.write(BRC);
@@ -733,7 +733,7 @@ Equal to 20x10 text LCD
 |                    |
 |  HE  BED  FAN      |
 | ttc  ttc   %       | ttc - current temperature
-| tts  tts  %%%      | tts - setted temperature, %%% - percent for FAN
+| tts  tts  %%%      | tts - set temperature, %%% - percent for FAN
 | ICO  ICO  ICO  ICO | ICO - icon 48x48, placed in 2 text lines
 | ICO  ICO  ICO  ICO | ICO
 

--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -447,7 +447,7 @@ void ST7920_Lite_Status_Screen::draw_static_elements() {
  * data buffer (DDRAM) to be used in conjunction with the graphics
  * bitmap buffer (CGRAM). The contents of the graphics buffer is
  * XORed with the data from the character generator. This allows
- * us to make the progess bar out of graphical data (the bar) and
+ * us to make the progress bar out of graphical data (the bar) and
  * text data (the percentage).
  */
 void ST7920_Lite_Status_Screen::draw_progress_bar(const uint8_t value) {

--- a/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
+++ b/Marlin/src/lcd/dogm/u8g_dev_st7920_128x64_HAL.cpp
@@ -73,7 +73,7 @@ static const uint8_t u8g_dev_st7920_128x64_HAL_init_seq[] PROGMEM = {
   0x038,              // 8 Bit interface (DL=1), basic instruction set (RE=0)
   0x00C,              // display on, cursor & blink off; 0x08: all off
   0x006,              // Entry mode: Cursor move to right, DDRAM address counter (AC) plus 1, no shift
-  0x002,              // disable scroll, enable CGRAM adress
+  0x002,              // disable scroll, enable CGRAM address
   0x001,              // clear RAM, needs 1.6 ms
   U8G_ESC_DLY(100),   // delay 100 ms
 

--- a/Marlin/src/lcd/extui/anycubic_chiron/chiron_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/chiron_tft.cpp
@@ -208,7 +208,7 @@ void ChironTFT::ConfirmationRequest(const char * const msg)  {
     case AC_printer_resuming_from_power_outage:
     case AC_printer_printing:
     case AC_printer_paused: {
-      // Heater timout, send acknowledgement
+      // Heater timeout, send acknowledgement
       if (strcmp_P(msg, MARLIN_msg_heater_timeout) == 0) {
         pause_state = AC_paused_heater_timed_out;
         SendtoTFTLN(AC_msg_paused); // enable continue button
@@ -248,7 +248,7 @@ void ChironTFT::StatusChange(const char * const msg)  {
         printer_state = AC_printer_idle;
         msg_matched = true;
       }
-      // If probing fails dont save the mesh raise the probe above the bad point
+      // If probing fails don't save the mesh raise the probe above the bad point
       if (strcmp_P(msg, MARLIN_msg_probing_failed) == 0) {
         PlayTune(BEEPER_PIN, BeepBeepBeeep, 1);
         injectCommands_P(PSTR("G1 Z50 F500"));
@@ -622,7 +622,7 @@ void ChironTFT::PanelAction(uint8_t req) {
       break;
 
     case 14: { // A14 Start Printing
-      // Allows printer to restart the job if we dont want to recover
+      // Allows printer to restart the job if we don't want to recover
       if (printer_state == AC_printer_resuming_from_power_outage) {
         injectCommands_P(PSTR("M1000 C")); // Cancel recovery
         printer_state = AC_printer_idle;

--- a/Marlin/src/lcd/extui/dgus/DGUSDisplay.h
+++ b/Marlin/src/lcd/extui/dgus/DGUSDisplay.h
@@ -93,7 +93,7 @@ public:
   // Helper for users of this class to estimate if an interaction would be blocking.
   static size_t GetFreeTxBuffer();
 
-  // Checks two things: Can we confirm the presence of the display and has we initiliazed it.
+  // Checks two things: Can we confirm the presence of the display and has we initialized it.
   // (both boils down that the display answered to our chatting)
   static inline bool isInitialized() { return Initialized; }
 

--- a/Marlin/src/lcd/extui/dgus/fysetc/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/dgus/fysetc/DGUSDisplayDef.cpp
@@ -466,7 +466,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
     VPHELPER(VP_WAITING_STATUS, nullptr, nullptr, ScreenHandler.DGUSLCD_SendWaitingStatusToDisplay),
   #endif
 
-  // Messages for the User, shared by the popup and the kill screen. They cant be autouploaded as we do not buffer content.
+  // Messages for the User, shared by the popup and the kill screen. They can't be autouploaded as we do not buffer content.
   { .VP = VP_MSGSTR1, .memadr = nullptr, .size = VP_MSGSTR1_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   { .VP = VP_MSGSTR2, .memadr = nullptr, .size = VP_MSGSTR2_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   { .VP = VP_MSGSTR3, .memadr = nullptr, .size = VP_MSGSTR3_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },

--- a/Marlin/src/lcd/extui/dgus/fysetc/DGUSDisplayDef.h
+++ b/Marlin/src/lcd/extui/dgus/fysetc/DGUSDisplayDef.h
@@ -282,7 +282,7 @@ constexpr uint16_t VP_BED_PID_P = 0x3710;
 constexpr uint16_t VP_BED_PID_I = 0x3712;
 constexpr uint16_t VP_BED_PID_D = 0x3714;
 
-// Wating screen status
+// Waiting screen status
 constexpr uint16_t VP_WAITING_STATUS = 0x3800;
 
 // SPs for certain variables...

--- a/Marlin/src/lcd/extui/dgus/fysetc/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/fysetc/DGUSScreenHandler.cpp
@@ -161,7 +161,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
     }
   #endif
   char axiscode;
-  unsigned int speed = 1500; // FIXME: get default feedrate for manual moves, dont hardcode.
+  unsigned int speed = 1500; // FIXME: get default feedrate for manual moves, don't hardcode.
 
   switch (var.VP) {
     default: return;

--- a/Marlin/src/lcd/extui/dgus/fysetc/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus/fysetc/DGUSScreenHandler.h
@@ -36,7 +36,7 @@ public:
   static bool loop();
 
   // Send all 4 strings that are displayed on the infoscreen, confirmation screen and kill screen
-  // The bools specifing whether the strings are in RAM or FLASH.
+  // The bools specifying whether the strings are in RAM or FLASH.
   static void sendinfoscreen(const char *line1, const char *line2, const char *line3, const char *line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);
 
   static void HandleUserConfirmationPopUp(uint16_t ConfirmVP, const char *line1, const char *line2, const char *line3, const char *line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);

--- a/Marlin/src/lcd/extui/dgus/hiprecy/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/dgus/hiprecy/DGUSDisplayDef.cpp
@@ -465,7 +465,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
     VPHELPER(VP_WAITING_STATUS, nullptr, nullptr, ScreenHandler.DGUSLCD_SendWaitingStatusToDisplay),
   #endif
 
-  // Messages for the User, shared by the popup and the kill screen. They cant be autouploaded as we do not buffer content.
+  // Messages for the User, shared by the popup and the kill screen. They can't be autouploaded as we do not buffer content.
   { .VP = VP_MSGSTR1, .memadr = nullptr, .size = VP_MSGSTR1_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   { .VP = VP_MSGSTR2, .memadr = nullptr, .size = VP_MSGSTR2_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   { .VP = VP_MSGSTR3, .memadr = nullptr, .size = VP_MSGSTR3_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },

--- a/Marlin/src/lcd/extui/dgus/hiprecy/DGUSDisplayDef.h
+++ b/Marlin/src/lcd/extui/dgus/hiprecy/DGUSDisplayDef.h
@@ -278,7 +278,7 @@ constexpr uint16_t VP_BED_PID_P = 0x3710;
 constexpr uint16_t VP_BED_PID_I = 0x3712;
 constexpr uint16_t VP_BED_PID_D = 0x3714;
 
-// Wating screen status
+// Waiting screen status
 constexpr uint16_t VP_WAITING_STATUS = 0x3800;
 
 // SPs for certain variables...

--- a/Marlin/src/lcd/extui/dgus/hiprecy/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/hiprecy/DGUSScreenHandler.cpp
@@ -161,7 +161,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
     }
   #endif
   char axiscode;
-  unsigned int speed = 1500; // FIXME: get default feedrate for manual moves, dont hardcode.
+  unsigned int speed = 1500; // FIXME: get default feedrate for manual moves, don't hardcode.
 
   switch (var.VP) {
     default: return;

--- a/Marlin/src/lcd/extui/dgus/hiprecy/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus/hiprecy/DGUSScreenHandler.h
@@ -36,7 +36,7 @@ public:
   static bool loop();
 
   // Send all 4 strings that are displayed on the infoscreen, confirmation screen and kill screen
-  // The bools specifing whether the strings are in RAM or FLASH.
+  // The bools specifying whether the strings are in RAM or FLASH.
   static void sendinfoscreen(const char *line1, const char *line2, const char *line3, const char *line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);
 
   static void HandleUserConfirmationPopUp(uint16_t ConfirmVP, const char *line1, const char *line2, const char *line3, const char *line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSDisplayDef.cpp
@@ -785,7 +785,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
     VPHELPER(VP_WAITING_STATUS, nullptr, nullptr, ScreenHandler.DGUSLCD_SendWaitingStatusToDisplay),
   #endif
 
-  // Messages for the User, shared by the popup and the kill screen. They cant be autouploaded as we do not buffer content.
+  // Messages for the User, shared by the popup and the kill screen. They can't be autouploaded as we do not buffer content.
   //{.VP = VP_MSGSTR1, .memadr = nullptr, .size = VP_MSGSTR1_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM},
   //{.VP = VP_MSGSTR2, .memadr = nullptr, .size = VP_MSGSTR2_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM},
   //{.VP = VP_MSGSTR3, .memadr = nullptr, .size = VP_MSGSTR3_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM},

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSDisplayDef.h
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSDisplayDef.h
@@ -266,7 +266,7 @@ constexpr uint16_t VP_MOVE_OPTION = 0x3500;
 // constexpr uint16_t VP_BED_PID_I = 0x3712;
 // constexpr uint16_t VP_BED_PID_D = 0x3714;
 
-// Wating screen status
+// Waiting screen status
 constexpr uint16_t VP_WAITING_STATUS = 0x3800;
 
 // SPs for certain variables...

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
@@ -762,7 +762,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
     return;
 
   char axiscode;
-  unsigned int speed = 1500; // FIXME: get default feedrate for manual moves, dont hardcode.
+  unsigned int speed = 1500; // FIXME: get default feedrate for manual moves, don't hardcode.
 
   switch (var.VP) { // switch X Y Z or Home
     default: return;

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.h
@@ -36,7 +36,7 @@ public:
   static bool loop();
 
   // Send all 4 strings that are displayed on the infoscreen, confirmation screen and kill screen
-  // The bools specifing whether the strings are in RAM or FLASH.
+  // The bools specifying whether the strings are in RAM or FLASH.
   static void sendinfoscreen(const char *line1, const char *line2, const char *line3, const char *line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);
 
   static void HandleUserConfirmationPopUp(uint16_t ConfirmVP, const char *line1, const char *line2, const char *line3, const char *line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);

--- a/Marlin/src/lcd/extui/dgus/origin/DGUSDisplayDef.cpp
+++ b/Marlin/src/lcd/extui/dgus/origin/DGUSDisplayDef.cpp
@@ -267,7 +267,7 @@ const struct DGUS_VP_Variable ListOfVP[] PROGMEM = {
     VPHELPER(VP_WAITING_STATUS, nullptr, nullptr, ScreenHandler.DGUSLCD_SendWaitingStatusToDisplay),
   #endif
 
-  // Messages for the User, shared by the popup and the kill screen. They cant be autouploaded as we do not buffer content.
+  // Messages for the User, shared by the popup and the kill screen. They can't be autouploaded as we do not buffer content.
   { .VP = VP_MSGSTR1, .memadr = nullptr, .size = VP_MSGSTR1_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   { .VP = VP_MSGSTR2, .memadr = nullptr, .size = VP_MSGSTR2_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },
   { .VP = VP_MSGSTR3, .memadr = nullptr, .size = VP_MSGSTR3_LEN, .set_by_display_handler = nullptr, .send_to_display_handler = ScreenHandler.DGUSLCD_SendStringToDisplayPGM },

--- a/Marlin/src/lcd/extui/dgus/origin/DGUSDisplayDef.h
+++ b/Marlin/src/lcd/extui/dgus/origin/DGUSDisplayDef.h
@@ -268,7 +268,7 @@ constexpr uint16_t VP_BED_PID_P = 0x3710;
 constexpr uint16_t VP_BED_PID_I = 0x3712;
 constexpr uint16_t VP_BED_PID_D = 0x3714;
 
-// Wating screen status
+// Waiting screen status
 constexpr uint16_t VP_WAITING_STATUS = 0x3800;
 
 // SPs for certain variables...

--- a/Marlin/src/lcd/extui/dgus/origin/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/origin/DGUSScreenHandler.cpp
@@ -161,7 +161,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
     }
   #endif
   char axiscode;
-  unsigned int speed = 1500; // FIXME: get default feedrate for manual moves, dont hardcode.
+  unsigned int speed = 1500; // FIXME: get default feedrate for manual moves, don't hardcode.
 
   switch (var.VP) {
     default: return;

--- a/Marlin/src/lcd/extui/dgus/origin/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus/origin/DGUSScreenHandler.h
@@ -36,7 +36,7 @@ public:
   static bool loop();
 
   // Send all 4 strings that are displayed on the infoscreen, confirmation screen and kill screen
-  // The bools specifing whether the strings are in RAM or FLASH.
+  // The bools specifying whether the strings are in RAM or FLASH.
   static void sendinfoscreen(const char *line1, const char *line2, const char *line3, const char *line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);
 
   static void HandleUserConfirmationPopUp(uint16_t ConfirmVP, const char *line1, const char *line2, const char *line3, const char *line4, bool l1inflash, bool l2inflash, bool l3inflash, bool liinflash);

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/flash_storage.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/flash_storage.cpp
@@ -206,7 +206,7 @@ bool UIFlashStorage::is_present = false;
 
   /* In order to provide some degree of wear leveling, each data write to the
    * SPI Flash chip is appended to data that was already written before, until
-   * the data storage area is completely filled. New data is written preceeded
+   * the data storage area is completely filled. New data is written preceded
    * with a 32-bit delimiter 'LULZ', so that we can distinguish written and
    * unwritten data:
    *

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
@@ -1079,7 +1079,7 @@ void CLCD::CommandFifo::str(progmem_str data) {
 
 void CLCD::init() {
   spi_init();                                  // Set Up I/O Lines for SPI and FT800/810 Control
-  ftdi_reset();                                // Power down/up the FT8xx with the apropriate delays
+  ftdi_reset();                                // Power down/up the FT8xx with the appropriate delays
 
   host_cmd(Use_Crystal ? CLKEXT : CLKINT, 0);
   host_cmd(FTDI::ACTIVE, 0);                        // Activate the System Clock

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.h
@@ -70,7 +70,7 @@
   *
   * CommandFifo::fgcolor               Set Graphic Item Foreground Color      *
   * CommandFifo::bgcolor               Set Graphic Item Background Color      *
-  * CommandFifo::begin()               Begin Drawing a Primative              *
+  * CommandFifo::begin()               Begin Drawing a Primitive              *
   * CommandFifo::mem_copy()            Copy a Block of Memory                 *
   * CommandFifo::append()              Append Commands to Current DL          *
   * CommandFifo::gradient_color()      Set 3D Button Highlight Color          *

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/command_processor.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/command_processor.h
@@ -65,7 +65,7 @@ class CommandProcessor : public CLCD::CommandFifo {
     uint8_t _style = 0;
 
   protected:
-    // Returns the cannonical thickness of a widget (i.e. the height of a toggle element)
+    // Returns the canonical thickness of a widget (i.e. the height of a toggle element)
     uint16_t widget_thickness() {
       CLCD::FontMetrics fm(_font);
       return fm.height * 20.0/16;
@@ -251,7 +251,7 @@ class CommandProcessor : public CLCD::CommandFifo {
       return toggle(x, y, w, h, text, state, options);
     }
 
-    // Contrained drawing routines. These constrain the widget inside a box for easier layout.
+    // Constrained drawing routines. These constrain the widget inside a box for easier layout.
     // The FORCEDINLINE ensures that the code is inlined so that all the math is done at compile time.
 
     FORCEDINLINE CommandProcessor& track_linear(int16_t x, int16_t y, int16_t w, int16_t h, int16_t tag) {

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/event_loop.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/event_loop.cpp
@@ -108,7 +108,7 @@ namespace FTDI {
    *  - Dispatches onTouchStart and onTouchEnd events to the active screen.
    *  - Handles auto-repetition by sending onTouchHeld to the active screen periodically.
    *  - Plays touch feedback "click" sounds when appropriate.
-   *  - Performs debouncing to supress spurious touch events.
+   *  - Performs debouncing to suppress spurious touch events.
    */
   void EventLoop::process_events() {
     // If the LCD is processing commands, don't check

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/poly_ui.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/poly_ui.h
@@ -272,7 +272,7 @@ class GenericPolyUI {
       if (clip) {
         // Clipping reduces the number of pixels that are
         // filled, allowing more complex shapes to be drawn
-        // in the alloted time.
+        // in the allotted time.
         bounds(r, x, y, w, h);
         cmd.cmd(SAVE_CONTEXT());
         cmd.cmd(SCISSOR_XY(x, y));

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/polygon.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/polygon.h
@@ -41,7 +41,7 @@
  *        ...
  *   p.end_fill();
  *
- * Based on the example from "Applicaton Note AN_334, FT801 Polygon Application":
+ * Based on the example from "Application Note AN_334, FT801 Polygon Application":
  *
  *   https://brtchip.com/wp-content/uploads/Support/Documentation/Application_Notes/ICs/EVE/AN_334-FT801_Polygon_Application.pdf
  */

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.h
@@ -152,7 +152,7 @@ class UIScreen {
 #define AT_SCREEN(screen)     (current_screen.getType() == current_screen.lookupScreen(screen::onRedraw))
 #define IS_PARENT_SCREEN(screen) (current_screen.peek() == current_screen.lookupScreen(screen::onRedraw))
 
-/************************** CACHED VS UNCHACHED SCREENS ***************************/
+/************************** CACHED VS UNCACHED SCREENS ***************************/
 
 class UncachedScreen {
   public:

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/tiny_timer.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/tiny_timer.h
@@ -28,7 +28,7 @@
 
 /* tiny_interval_t downsamples a 32-bit millis() value
    into a 8-bit value which can record periods of
-   a few seconds with a rougly 1/16th of second
+   a few seconds with a roughly 1/16th of second
    resolution. This allows us to measure small
    intervals without needing to use four-byte counters.
  */

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/scripts/svg2cpp.py
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/scripts/svg2cpp.py
@@ -164,7 +164,7 @@ class Parser:
 
   def process_svg_path_data_cmd(self, id, cmd, a, b):
     """Converts the various types of moves into L or M commands
-    and dispatches to process_svg_path_L_or_M for futher processing."""
+    and dispatches to process_svg_path_L_or_M for further processing."""
     if cmd == "Z" or cmd == "z":
       self.process_svg_path_L_or_M("L", self.initial_x, self.initial_y)
     elif cmd == "H":

--- a/Marlin/src/lcd/extui/mks_ui/SPIFlashStorage.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/SPIFlashStorage.cpp
@@ -204,7 +204,7 @@ void SPIFlashStorage::flushPage() {
       return;
     }
 
-    // Part of the m_pageData was compressed, so ajust the pointers, freeing what was processed, shift the buffer
+    // Part of the m_pageData was compressed, so adjust the pointers, freeing what was processed, shift the buffer
     // TODO: To avoid this copy, use a circular buffer
     memmove(m_pageData, m_pageData + inputProcessed, m_pageDataUsed - inputProcessed);
     m_pageDataUsed -= inputProcessed;

--- a/Marlin/src/lcd/extui/mks_ui/SPIFlashStorage.h
+++ b/Marlin/src/lcd/extui/mks_ui/SPIFlashStorage.h
@@ -55,7 +55,7 @@
  *
  * When reading, it loads a full page from SPI Flash at once and
  * keeps it in a private SRAM buffer. Data is loaded as needed to
- * fullfill requests. Sequential reads are optimal.
+ * fulfill requests. Sequential reads are optimal.
  *
  *    SPIFlashStorage.beginRead(myStartAddress);
  *    while (there is data to read)

--- a/Marlin/src/lcd/extui/mks_ui/draw_ui.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_ui.cpp
@@ -237,7 +237,7 @@ void update_spi_flash() {
   uint8_t command_buf[512];
 
   W25QXX.init(SPI_QUARTER_SPEED);
-  //read back the gcode command befor erase spi flash
+  //read back the gcode command before erase spi flash
   W25QXX.SPI_FLASH_BufferRead((uint8_t *)&command_buf, GCODE_COMMAND_ADDR, sizeof(command_buf));
   W25QXX.SPI_FLASH_SectorErase(VAR_INF_ADDR);
   W25QXX.SPI_FLASH_BufferWrite((uint8_t *)&gCfgItems, VAR_INF_ADDR, sizeof(gCfgItems));
@@ -248,7 +248,7 @@ void update_gcode_command(int addr,uint8_t *s) {
   uint8_t command_buf[512];
 
   W25QXX.init(SPI_QUARTER_SPEED);
-  //read back the gcode command befor erase spi flash
+  //read back the gcode command before erase spi flash
   W25QXX.SPI_FLASH_BufferRead((uint8_t *)&command_buf, GCODE_COMMAND_ADDR, sizeof(command_buf));
   W25QXX.SPI_FLASH_SectorErase(VAR_INF_ADDR);
   W25QXX.SPI_FLASH_BufferWrite((uint8_t *)&gCfgItems, VAR_INF_ADDR, sizeof(gCfgItems));

--- a/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
@@ -503,7 +503,7 @@ uint32_t Pic_Info_Write(uint8_t *P_name, uint32_t P_size) {
       disp_assets_update_progress("Reading files...");
       dir_t d;
       while (dir.readDir(&d, card.longFilename) > 0) {
-        // If we dont get a long name, but gets a short one, try it
+        // If we don't get a long name, but gets a short one, try it
         if (card.longFilename[0] == 0 && d.name[0] != 0)
           dosName2LongName((const char*)d.name, card.longFilename);
         if (card.longFilename[0] == 0) continue;

--- a/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/printer_operation.cpp
@@ -54,7 +54,7 @@ void printer_state_polling() {
 
         gcode.process_subcommands_now_P(PSTR("M25"));
 
-        //save the positon
+        //save the position
         uiCfg.current_x_position_bak = current_position.x;
         uiCfg.current_y_position_bak = current_position.y;
         uiCfg.current_z_position_bak = current_position.z;

--- a/Marlin/src/lcd/extui/mks_ui/wifiSerial_STM32.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/wifiSerial_STM32.cpp
@@ -198,7 +198,7 @@ void WifiSerial::flush() {
     // nop, the interrupt handler will free up space for us
   }
   // If we get here, nothing is queued anymore (DRIE is disabled) and
-  // the hardware finished tranmission (TXC is set).
+  // the hardware finished transmission (TXC is set).
 }
 
 bool WifiSerial::isHalfDuplex() const { return _serial.pin_rx == NC; }

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -716,7 +716,7 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
      *     This is used to achieve more rapid stepping on kinematic machines.
      *
      * Currently used by the _lcd_move_xyz function in menu_motion.cpp
-     * and the ubl_map_move_to_xy funtion in menu_ubl.cpp.
+     * and the ubl_map_move_to_xy function in menu_ubl.cpp.
      */
     void ManualMove::task() {
 

--- a/Marlin/src/lcd/tft/canvas.cpp
+++ b/Marlin/src/lcd/tft/canvas.cpp
@@ -50,7 +50,7 @@ bool CANVAS::ToScreen() {
 }
 
 void CANVAS::SetBackground(uint16_t color) {
-  /* TODO: test and optimize perfomance */
+  /* TODO: test and optimize performance */
   /*
   uint32_t count = (endLine - startLine) * width;
   uint16_t *pixel = buffer;

--- a/Marlin/src/libs/MAX31865.cpp
+++ b/Marlin/src/libs/MAX31865.cpp
@@ -257,7 +257,7 @@ void MAX31865::oneShot() {
   // From the datasheet:
   // Note that a single conversion requires approximately 52ms in 60Hz filter
   // mode or 62.5ms in 50Hz filter mode to complete. 1-Shot is a self-clearing bit.
-  // TODO: switch this out depeding on the filter mode.
+  // TODO: switch this out depending on the filter mode.
   DELAY_US(65000); // 65ms
 }
 
@@ -301,7 +301,7 @@ uint16_t MAX31865::readRaw() {
 }
 
 /**
- * Calulate and return the resistance value of the connected RTD.
+ * Calculate and return the resistance value of the connected RTD.
  *
  * @param  refResistor The value of the matching reference resistor, usually 430 or 4300
  * @return             The raw RTD resistance value, NOT temperature!

--- a/Marlin/src/libs/MAX31865.h
+++ b/Marlin/src/libs/MAX31865.h
@@ -72,7 +72,7 @@
 #define MAX31865_FAULT_OVUV 0x04        // D2
 
 // http://www.analog.com/media/en/technical-documentation/application-notes/AN709_0.pdf
-// constants for calulating temperature from the measured RTD resistance.
+// constants for calculating temperature from the measured RTD resistance.
 #define RTD_Z1 -0.0039083
 #define RTD_Z2 0.00001758480889
 #define RTD_Z3 -0.0000000231

--- a/Marlin/src/libs/W25Qxx.cpp
+++ b/Marlin/src/libs/W25Qxx.cpp
@@ -157,8 +157,8 @@ void W25QXXFlash::SPI_FLASH_WriteEnable(void) {
 /*******************************************************************************
 * Function Name  : SPI_FLASH_WaitForWriteEnd
 * Description    : Polls the status of the Write In Progress (WIP) flag in the
-*                  FLASH's status  register  and  loop  until write  opertaion
-*                  has completed.
+*                  FLASH's status register and loop until write operation has
+*                  completed.
 * Input          : None
 * Output         : None
 * Return         : None

--- a/Marlin/src/libs/buzzer.h
+++ b/Marlin/src/libs/buzzer.h
@@ -56,7 +56,7 @@
       static CircularQueue<tone_t, TONE_QUEUE_LENGTH> buffer;
 
       /**
-       * @brief Inverts the sate of a digital PIN
+       * @brief Inverts the state of a digital PIN
        * @details This will invert the current state of an digital IO pin.
        */
       FORCE_INLINE static void invert() { TOGGLE(BEEPER_PIN); }

--- a/Marlin/src/libs/duration_t.h
+++ b/Marlin/src/libs/duration_t.h
@@ -113,7 +113,7 @@ struct duration_t {
 
   /**
    * @brief Formats the duration as a string
-   * @details String will be formated using a "full" representation of duration
+   * @details String will be formatted using a "full" representation of duration
    *
    * @param buffer The array pointed to must be able to accommodate 22 bytes
    *               (21 for the string, 1 more for the terminating nul)
@@ -143,7 +143,7 @@ struct duration_t {
 
   /**
    * @brief Formats the duration as a string
-   * @details String will be formated using a "digital" representation of duration
+   * @details String will be formatted using a "digital" representation of duration
    *
    * @param buffer The array pointed to must be able to accommodate 10 bytes
    *

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -884,7 +884,7 @@ void Endstops::update() {
     const byte dual_hit = TEST_ENDSTOP(_ENDSTOP(A, MINMAX)) | (TEST_ENDSTOP(_ENDSTOP(A##2, MINMAX)) << 1); \
     if (dual_hit) { \
       _ENDSTOP_HIT(A, MINMAX); \
-      /* if not performing home or if both endstops were trigged during homing... */ \
+      /* if not performing home or if both endstops were triggered during homing... */ \
       if (!stepper.separate_multi_axis || dual_hit == 0b11) \
         planner.endstop_triggered(_AXIS(A)); \
     } \
@@ -894,7 +894,7 @@ void Endstops::update() {
     const byte triple_hit = TEST_ENDSTOP(_ENDSTOP(A, MINMAX)) | (TEST_ENDSTOP(_ENDSTOP(A##2, MINMAX)) << 1) | (TEST_ENDSTOP(_ENDSTOP(A##3, MINMAX)) << 2); \
     if (triple_hit) { \
       _ENDSTOP_HIT(A, MINMAX); \
-      /* if not performing home or if both endstops were trigged during homing... */ \
+      /* if not performing home or if both endstops were triggered during homing... */ \
       if (!stepper.separate_multi_axis || triple_hit == 0b111) \
         planner.endstop_triggered(_AXIS(A)); \
     } \
@@ -904,7 +904,7 @@ void Endstops::update() {
     const byte quad_hit = TEST_ENDSTOP(_ENDSTOP(A, MINMAX)) | (TEST_ENDSTOP(_ENDSTOP(A##2, MINMAX)) << 1) | (TEST_ENDSTOP(_ENDSTOP(A##3, MINMAX)) << 2) | (TEST_ENDSTOP(_ENDSTOP(A##4, MINMAX)) << 3); \
     if (quad_hit) { \
       _ENDSTOP_HIT(A, MINMAX); \
-      /* if not performing home or if both endstops were trigged during homing... */ \
+      /* if not performing home or if both endstops were triggered during homing... */ \
       if (!stepper.separate_multi_axis || quad_hit == 0b1111) \
         planner.endstop_triggered(_AXIS(A)); \
     } \

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -857,7 +857,7 @@ class Planner {
       static void quick_resume();
     #endif
 
-    // Called when an endstop is triggered. Causes the machine to stop inmediately
+    // Called when an endstop is triggered. Causes the machine to stop immediately
     static void endstop_triggered(const AxisEnum axis);
 
     // Triggered position of an axis in mm (not core-savvy)

--- a/Marlin/src/module/stepper/trinamic.cpp
+++ b/Marlin/src/module/stepper/trinamic.cpp
@@ -955,7 +955,7 @@ void reset_trinamic_drivers() {
 // TMC Slave Address Conflict Detection
 //
 // Conflict detection is performed in the following way. Similar methods are used for
-// hardware and software serial, but the implementations are indepenent.
+// hardware and software serial, but the implementations are independent.
 //
 // 1. Populate a data structure with UART parameters and addresses for all possible axis.
 //      If an axis is not in use, populate it with recognizable placeholder data.

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1522,7 +1522,7 @@ void Temperature::manage_heater() {
     #endif
 
     #if ENABLED(PIDTEMPCHAMBER)
-      // PIDTEMPCHAMBER doens't support a CHAMBER_VENT yet.
+      // PIDTEMPCHAMBER doesn't support a CHAMBER_VENT yet.
       temp_chamber.soft_pwm_amount = WITHIN(temp_chamber.celsius, CHAMBER_MINTEMP, CHAMBER_MAXTEMP) ? (int)get_pid_output_chamber() >> 1 : 0;
     #else
       if (ELAPSED(ms, next_chamber_check_ms)) {

--- a/Marlin/src/module/thermistor/thermistor_61.h
+++ b/Marlin/src/module/thermistor/thermistor_61.h
@@ -31,7 +31,7 @@
 // B Value             3950K at 25/50 deg. C
 // B Value Tolerance         + / - 1%
 constexpr temp_entry_t temptable_61[] PROGMEM = {
-  { OV(   2.00), 420 }, // Guestimate to ensure we dont lose a reading and drop temps to -50 when over
+  { OV(   2.00), 420 }, // Guestimate to ensure we don't lose a reading and drop temps to -50 when over
   { OV(  12.07), 350 },
   { OV(  12.79), 345 },
   { OV(  13.59), 340 },

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_1.h
@@ -140,7 +140,7 @@
   // Using TMC devices in intelligent mode requires extra connections to each device. Unfortunately
   // the SKR does not have many free pins (especially if a display is in use). The SPI-based devices
   // will require 3 connections (clock, mosi, miso), plus a chip select line (CS) for each driver.
-  // The UART-based devices require 2 pis per deriver (one of which must be interrupt capable).
+  // The UART-based devices require 2 pis per driver (one of which must be interrupt capable).
   // The same SPI pins can be shared with the display/SD card reader, meaning SPI-based devices are
   // probably a good choice for this board.
   //

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -265,7 +265,7 @@
 
   #elif HAS_ADC_BUTTONS
 
-    #error "ADC BUTTONS do not work unmodifed on SKR 1.3, The ADC ports cannot take more than 3.3v."
+    #error "ADC BUTTONS do not work unmodified on SKR 1.3, The ADC ports cannot take more than 3.3v."
 
   #elif HAS_SPI_TFT                               // Config for Classic UI (emulated DOGM) and Color UI
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -494,7 +494,7 @@
 #endif // HAS_WIRED_LCD
 
 #if HAS_ADC_BUTTONS
-  #error "ADC BUTTONS do not work unmodifed on SKR 1.4, The ADC ports cannot take more than 3.3v."
+  #error "ADC BUTTONS do not work unmodified on SKR 1.4, The ADC ports cannot take more than 3.3v."
 #endif
 
 //

--- a/Marlin/src/pins/lpc1768/pins_GMARSH_X6_REV1.h
+++ b/Marlin/src/pins/lpc1768/pins_GMARSH_X6_REV1.h
@@ -25,7 +25,7 @@
 
 #define BOARD_INFO_NAME "GMARSH X6 REV1"
 
-// Ignore temp readings during develpment.
+// Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
 
 //

--- a/Marlin/src/pins/ramps/pins_TENLOG_D3_HERO.h
+++ b/Marlin/src/pins/ramps/pins_TENLOG_D3_HERO.h
@@ -138,7 +138,7 @@
 #define HEATER_BED_PIN                         8
 
 #define FAN_PIN                                9
-#define FAN1_PIN                               5  // Normall this would be a servo pin
+#define FAN1_PIN                               5  // Normally this would be a servo pin
 
 // XXX Runout support unknown?
 //#define NUM_RUNOUT_SENSORS                   0

--- a/Marlin/src/pins/sam/pins_ADSK.h
+++ b/Marlin/src/pins/sam/pins_ADSK.h
@@ -47,10 +47,10 @@ A stepper for E0 extruder
                                       Vcc (now "5V" on the board but actual 3.3V because of jumper))
 (Hold)&(GND) - Bed thermistor (also require pullup resistor 4.7K between "Hold" and
                                  Vcc (now "5V" on the board but actual 3.3V because of jumper))
-(CoolEn) - 3.3v signal to controll extruder heater MOSFET
+(CoolEn) - 3.3v signal to control extruder heater MOSFET
 (Resume) - 3.3v signal to control heatbed MOSFET
-(SDA) - 3.3v signal to controll extruder fan
-(SCL) - 3.3v signal to controll extruder cooling fan
+(SDA) - 3.3v signal to control extruder fan
+(SCL) - 3.3v signal to control extruder cooling fan
 */
 
 /* CNC Shield pinout
@@ -137,7 +137,7 @@ A stepper for E0 extruder
    * The 2004 LCD should be powered with 5V.
    * The next LCD pins RS,D4,D5,D6,D7 have internal pull-ups to 5V and as result the 5V will be on these pins.
    * Luckily these internal pull-ups have really high resistance and adding 33K pull-down resistors will create
-   * simple voltage divider that will bring the voltage down just slightly bellow 3.3V.
+   * simple voltage divider that will bring the voltage down just slightly below 3.3V.
    *
    * This LCD also has buttons that connected to the same ADC pin with different voltage divider combinations.
    * On the LCD panel there is internal pull-up resistor of the 4.7K connected to 5V.
@@ -175,7 +175,7 @@ A stepper for E0 extruder
 
   #define ADC_BUTTONS_VALUE_SCALE         (5.0/AREF_VOLTS) // The LCD module pullup voltage is 5.0V but ADC reference voltage is 3.3V
 
-  #define ADC_BUTTONS_R_PULLDOWN          4.7     // Moves voltage down to be bellow 3.3V instead of 5V
+  #define ADC_BUTTONS_R_PULLDOWN          4.7     // Moves voltage down to be below 3.3V instead of 5V
   // the resistors values will be scaled because of 4.7K pulldown parallel resistor
   #define _ADC_BUTTONS_R_SCALED(R)        ((R) * (ADC_BUTTONS_R_PULLDOWN) / ((R) + ADC_BUTTONS_R_PULLDOWN))
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
@@ -235,7 +235,7 @@
 //
 // Onboard SD card
 //
-// detect pin dont work when ONBOARD and NO_SD_HOST_DRIVE disabled
+// detect pin doesn't work when ONBOARD and NO_SD_HOST_DRIVE disabled
 #if SD_CONNECTION_IS(ONBOARD)
   #define ENABLE_SPI3
   #define SD_SS_PIN                         -1

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -229,7 +229,7 @@
 //
 // Onboard SD card
 //
-// detect pin dont work when ONBOARD and NO_SD_HOST_DRIVE disabled
+// detect pin doesn't work when ONBOARD and NO_SD_HOST_DRIVE disabled
 #if SD_CONNECTION_IS(ONBOARD)
   #define ENABLE_SPI3
   #define SD_SS_PIN                         -1

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -212,7 +212,7 @@
 // Onboard SD card
 // NOT compatible with LCD
 //
-// detect pin dont work when ONBOARD and NO_SD_HOST_DRIVE disabled
+// detect pin doesn't work when ONBOARD and NO_SD_HOST_DRIVE disabled
 #if !defined(SDCARD_CONNECTION) || SDCARD_CONNECTION == ONBOARD
   #if USE_NEW_SPI_API
     #define SD_SPI MARLIN_SPI(HardwareSPI3, PC9)

--- a/Marlin/src/sd/disk_io_driver.h
+++ b/Marlin/src/sd/disk_io_driver.h
@@ -24,7 +24,7 @@
 #include <stdint.h>
 
 /**
- * DiskIO Interace
+ * DiskIO Interface
  *
  * Interface for low level disk io
  */

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/UsbCore.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/UsbCore.h
@@ -114,7 +114,7 @@ typedef MAX3421e<P10, P9> MAX3421E; // Official Arduinos (UNO, Duemilanove, Mega
 
 #define USB_NUMDEVICES          16      //number of USB devices
 //#define HUB_MAX_HUBS          7       // maximum number of hubs that can be attached to the host controller
-#define HUB_PORT_RESET_DELAY    20      // hub port reset delay 10 ms recomended, can be up to 20 ms
+#define HUB_PORT_RESET_DELAY    20      // hub port reset delay 10 ms recommended, can be up to 20 ms
 
 /* USB state machine states */
 #define USB_STATE_MASK                                      0xF0

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/confdescparser.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/confdescparser.h
@@ -57,7 +57,7 @@ class ConfigDescParser : public USBReadParser {
   uint8_t dscrLen; // Descriptor length
   uint8_t dscrType; // Descriptor type
 
-  bool isGoodInterface; // Apropriate interface flag
+  bool isGoodInterface; // Appropriate interface flag
   uint8_t confValue; // Configuration value
   uint8_t protoValue; // Protocol value
   uint8_t ifaceNumber; // Interface number

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_UsbCore.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_UsbCore.h
@@ -248,7 +248,7 @@ e-mail   :  support@circuitsathome.com
 #define                      UHS_HOST_TRANSFER_MAX_MS 10000 // USB transfer timeout in ms, per section 9.2.6.1 of USB 2.0 spec
 #define               UHS_HOST_TRANSFER_RETRY_MAXIMUM 3     // 3 retry limit for a transfer
 #define                    UHS_HOST_DEBOUNCE_DELAY_MS 500   // settle delay in milliseconds
-#define                        UHS_HUB_RESET_DELAY_MS 20    // hub port reset delay, 10ms recomended, but can be up to 20ms
+#define                        UHS_HUB_RESET_DELAY_MS 20    // hub port reset delay, 10ms recommended, but can be up to 20ms
 
 //
 // We only provide the minimum needed information for enumeration.

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_macros.h
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs3/UHS_host/UHS_macros.h
@@ -150,7 +150,7 @@ e-mail   :  support@circuitsathome.com
 // HANDY MACROS
 ////////////////////////////////////////////////////////////////////////////////
 
-// Atmoically set/clear single bits using bitbands.
+// Atomically set/clear single bits using bitbands.
 // Believe it or not, this boils down to a constant,
 // and is less code than using |= &= operators.
 // Bonus, it makes code easier to read too.

--- a/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_BTT002/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_BTT002/ldscript.ld
@@ -169,7 +169,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_E3_RRF/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_E3_RRF/ldscript.ld
@@ -169,7 +169,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_GTR_V1/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_GTR_V1/ldscript.ld
@@ -169,7 +169,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_GTR_V1/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_GTR_V1/variant.h
@@ -280,7 +280,7 @@ extern "C" {
 #define PIN_SERIAL_TX           PA9
 
 // Optional PIN_SERIALn_RX and PIN_SERIALn_TX where 'n' is the U(S)ART number
-// Used when user instanciate a hardware Serial using its peripheral name.
+// Used when user instantiate a hardware Serial using its peripheral name.
 // Example: HardwareSerial mySerial(USART3);
 // will use PIN_SERIAL3_RX and PIN_SERIAL3_TX if defined.
 #define PIN_SERIAL1_RX          PA10

--- a/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_OCTOPUS_V1/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_OCTOPUS_V1/ldscript.ld
@@ -150,7 +150,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_SKR_PRO_11/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_SKR_PRO_11/ldscript.ld
@@ -169,7 +169,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_SKR_PRO_11/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BIGTREE_SKR_PRO_11/variant.h
@@ -280,7 +280,7 @@ extern "C" {
 #define PIN_SERIAL_TX           PA9
 
 // Optional PIN_SERIALn_RX and PIN_SERIALn_TX where 'n' is the U(S)ART number
-// Used when user instanciate a hardware Serial using its peripheral name.
+// Used when user instantiate a hardware Serial using its peripheral name.
 // Example: HardwareSerial mySerial(USART3);
 // will use PIN_SERIAL3_RX and PIN_SERIAL3_TX if defined.
 #define PIN_SERIAL1_RX          PA10

--- a/buildroot/share/PlatformIO/variants/MARLIN_BTT_SKR_SE_BX/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_BTT_SKR_SE_BX/ldscript.ld
@@ -173,7 +173,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Rx/ldscript.ld
@@ -162,7 +162,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Vx/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Vx/ldscript.ld
@@ -162,7 +162,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_F103Zx/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F103Zx/ldscript.ld
@@ -162,7 +162,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_F407VE/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F407VE/ldscript.ld
@@ -169,7 +169,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_F446VE/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F446VE/ldscript.ld
@@ -149,7 +149,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_F4x7Vx/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_F4x7Vx/ldscript.ld
@@ -167,7 +167,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_FLY_F407ZG/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FLY_F407ZG/ldscript.ld
@@ -169,7 +169,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_CHEETAH_V20/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_CHEETAH_V20/ldscript.ld
@@ -150,7 +150,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_CHEETAH_V20/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_CHEETAH_V20/variant.h
@@ -112,7 +112,7 @@ extern "C" {
 #define PIN_SERIAL_RX           PA10
 #define PIN_SERIAL_TX           PA9
 
-// Used when user instanciate a hardware Serial using its peripheral name.
+// Used when user instantiate a hardware Serial using its peripheral name.
 // Example: HardwareSerial mySerial(USART3);
 // will use PIN_SERIAL3_RX and PIN_SERIAL3_TX if defined.
 #define PIN_SERIAL1_RX          PA10

--- a/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_S6/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_S6/ldscript.ld
@@ -150,7 +150,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_LERDGE/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_LERDGE/ldscript.ld
@@ -149,7 +149,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/MARLIN_STEVAL_F401VE/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_STEVAL_F401VE/ldscript.ld
@@ -148,7 +148,7 @@ SECTIONS
   . = ALIGN(4);
   .bss :
   {
-    /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
     *(.bss)

--- a/buildroot/share/PlatformIO/variants/marlin_CHITU_F103/wirish/boards.cpp
+++ b/buildroot/share/PlatformIO/variants/marlin_CHITU_F103/wirish/boards.cpp
@@ -156,7 +156,7 @@ static void setup_nvic(void) {
 
 nvic_init((uint32)VECT_TAB_ADDR, 0);
 
-/* Roger Clark. We now control nvic vector table in boards.txt using the build.vect paramater
+/* Roger Clark. We now control nvic vector table in boards.txt using the build.vect parameter
 #ifdef VECT_TAB_FLASH
     nvic_init(USER_ADDR_ROM, 0);
 #elif defined VECT_TAB_RAM

--- a/buildroot/share/PlatformIO/variants/marlin_MEEB_3DP/wirish/boards.cpp
+++ b/buildroot/share/PlatformIO/variants/marlin_MEEB_3DP/wirish/boards.cpp
@@ -156,7 +156,7 @@ static void setup_nvic(void) {
 
 nvic_init((uint32)VECT_TAB_ADDR, 0);
 
-/* Roger Clark. We now control nvic vector table in boards.txt using the build.vect paramater
+/* Roger Clark. We now control nvic vector table in boards.txt using the build.vect parameter
 #ifdef VECT_TAB_FLASH
     nvic_init(USER_ADDR_ROM, 0);
 #elif defined VECT_TAB_RAM

--- a/buildroot/share/scripts/createTemperatureLookupMarlin.py
+++ b/buildroot/share/scripts/createTemperatureLookupMarlin.py
@@ -73,7 +73,7 @@ class Thermistor:
         return r
 
     def temp(self, adc):
-        "Convert ADC reading into a temperature in Celcius"
+        "Convert ADC reading into a temperature in Celsius"
         l = log(self.resist(adc))
         Tinv = self.c1 + self.c2*l + self.c3* l**3 # inverse temperature
         return (1/Tinv) - ZERO              # temperature

--- a/buildroot/share/scripts/g29_auto.py
+++ b/buildroot/share/scripts/g29_auto.py
@@ -119,7 +119,7 @@ def z_parse(gcode, start_at_line=0, end_at_line=0):
         # last_z = z
         last_i = i
         if 0 < end_at_line <= i or temp_line >= min_g1:
-            # print('break at line {} at heigth {}'.format(i, z))
+            # print('break at line {} at height {}'.format(i, z))
             break
 
     line_between_z = line_between_z[1:]

--- a/buildroot/tests/mega2560
+++ b/buildroot/tests/mega2560
@@ -127,7 +127,7 @@ exec_test $1 $2 "Azteeg X3 | Mixing Extruder (x5) | Gradient Mix | Greek" "$3"
 #
 # REPRAPWORLD_KEYPAD
 #
-# Cant find configuration details to get it to compile
+# Can't find configuration details to get it to compile
 #restore_configs
 #opt_enable ULTRA_LCD REPRAPWORLD_KEYPAD REPRAPWORLD_KEYPAD_MOVE_STEP
 #exec_test $1 $2 "Stuff" "$3"


### PR DESCRIPTION
### Description

Typos found throughout codebase. Most are trivial source comments. Found via `codespell -q 3 --builtin=clear,rare,informal,code -S ./Marlin/src/lcd/language -L alo,amin,endcode,stdio,uint`

### Benefits

Better readability of source code. Avoiding any potential bugs.

### Configurations

N/A

### Related Issues

N/A