### PR TITLE
Fix extra E move in toolchange (TOOLCHANGE_NO_RETURN)

### DIFF
--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -954,11 +954,11 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       #if ENABLED(TOOLCHANGE_PARK)
         if (ok) {
           #if ENABLED(TOOLCHANGE_NO_RETURN)
+            const float temp = destination.z;
             destination = current_position;
-            prepare_internal_move_to_destination(planner.settings.max_feedrate_mm_s[Z_AXIS]);
-          #else
-            prepare_internal_move_to_destination(MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE));
+            destination.z = temp.z;
           #endif
+          prepare_internal_move_to_destination(TERN(TOOLCHANGE_NO_RETURN, planner.settings.max_feedrate_mm_s[Z_AXIS], MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE)));
         }
       #endif
 

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -954,7 +954,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       #if ENABLED(TOOLCHANGE_PARK)
         if (ok) {
           #if ENABLED(TOOLCHANGE_NO_RETURN)
-            destination.set(current_position.x, current_position.y);
+            destination.set(current_position.x, current_position.y, current_position.z, current_position.e);
             prepare_internal_move_to_destination(planner.settings.max_feedrate_mm_s[Z_AXIS]);
           #else
             prepare_internal_move_to_destination(MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE));

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -954,7 +954,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       #if ENABLED(TOOLCHANGE_PARK)
         if (ok) {
           #if ENABLED(TOOLCHANGE_NO_RETURN)
-            destination.set(current_position.x, current_position.y, current_position.z, current_position.e);
+            destination = current_position;
             prepare_internal_move_to_destination(planner.settings.max_feedrate_mm_s[Z_AXIS]);
           #else
             prepare_internal_move_to_destination(MMM_TO_MMS(TOOLCHANGE_PARK_XY_FEEDRATE));


### PR DESCRIPTION
When "changing" tools with TOOLCHANGE_FS_PRIME_FIRST_USED enabled, an unexpected extruder move would happen at the end of the tool change. A similar issue was previously fixed in pause.cpp https://github.com/MarlinFirmware/Marlin/pull/21670

In order to test, the following must be enabled in the configuration, and then M217 V1 must be invoked prior to "changing" tools with T#.

TOOLCHANGE_PARK
TOOLCHANGE_NO_RETURN
TOOLCHANGE_FILAMENT_SWAP
TOOLCHANGE_FS_PRIME_FIRST_USED