### PR TITLE
STM32: Fix unused EEPROM variable warning

### DIFF
--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -104,6 +104,8 @@ size_t PersistentStore::capacity() { return MARLIN_EEPROM_SIZE; }
 
 bool PersistentStore::access_start() {
 
+  EEPROM.begin(); // Avoid STM32 EEPROM.h warning (do nothing)
+
   #if ENABLED(FLASH_EEPROM_LEVELING)
 
     if (current_slot == -1 || eeprom_data_written) {


### PR DESCRIPTION
Warning visible on most STM32 boards... if they store config on the flash memory.

EEPROM.begin() just returns 0... no code inside