### PR TITLE
Fix MKS 'USB Flash MSC' environments

### DIFF
--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -438,4 +438,3 @@ extends           = env:mks_monster8_usb_flash_drive
 build_flags       = ${env:mks_monster8_usb_flash_drive.build_flags}
                     -DUSBD_USE_CDC_MSC
 build_unflags     = -DUSBD_USE_CDC
-

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -435,5 +435,7 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1_CAN.build_flag
 [env:mks_monster8_usb_flash_drive_msc]
 platform          = ${common_stm32.platform}
 extends           = env:mks_monster8_usb_flash_drive
-build_flags       = ${env:mks_monster8_usb_flash_drive}
+build_flags       = ${env:mks_monster8_usb_flash_drive.build_flags}
                     -DUSBD_USE_CDC_MSC
+build_unflags     = -DUSBD_USE_CDC
+

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -388,8 +388,9 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 [env:mks_robin_nano_v3_usb_flash_drive_msc]
 platform          = ${common_stm32.platform}
 extends           = env:mks_robin_nano_v3_usb_flash_drive
-build_flags       = ${env:mks_robin_nano_v3_usb_flash_drive}
+build_flags       = ${env:mks_robin_nano_v3_usb_flash_drive.build_flags}
                     -DUSBD_USE_CDC_MSC
+build_unflags     = -DUSBD_USE_CDC
 
 #
 # This I2C1(PB8:I2C1_SCL PB9:I2C1_SDA) is used by MKS Monster8


### PR DESCRIPTION
### Description

env:mks_robin_nano_v3_usb_flash_drive_msc or env:mks_monster8_usb_flash_drive_msc wont build.
Fixed and verified by user (on mks_robin_nano_v3, same issue for mks_monster8) 

### Requirements

env:mks_robin_nano_v3_usb_flash_drive_msc or env:mks_monster8_usb_flash_drive_msc

### Benefits

Works as it should

### Related Issues
Issue #22491