### PR TITLE
STM32 - Higher serial IRQ priority

### DIFF
--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -31,9 +31,10 @@
 // The TONE timer is not present here, as it currently cannot be set programmatically. It is set
 // by defining TIM_IRQ_PRIO in the variant.h or platformio.ini file, which adjusts the default
 // priority for STM32 HardwareTimer objects.
-#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  1 // Requires tight bit timing to communicate reliably with TMC drivers
-#define SERVO_TIMER_IRQ_PRIO_DEFAULT     1 // Requires tight PWM timing to control a BLTouch reliably
-#define STEP_TIMER_IRQ_PRIO_DEFAULT      2
+// Leave priority 1 for serial interrupt.
+#define SWSERIAL_TIMER_IRQ_PRIO_DEFAULT  2 // Requires tight bit timing to communicate reliably with TMC drivers
+#define SERVO_TIMER_IRQ_PRIO_DEFAULT     2 // Requires tight PWM timing to control a BLTouch reliably
+#define STEP_TIMER_IRQ_PRIO_DEFAULT      8
 #define TEMP_TIMER_IRQ_PRIO_DEFAULT     14 // Low priority avoids interference with other hardware and timers
 
 #ifndef STEP_TIMER_IRQ_PRIO


### PR DESCRIPTION
### Description

Increased interrupt priority for serial communications to reduce the chance of random characters being lost at higher baudrates. If checksum is enabled the firmware reliably detects the corruption and requests a resend, but no resend is better than a few resends.

I can print at 57600 with no issues using this patch. At 115200+ there are a few resends and becomes worse the higher the baudrate. At 921600 I get 120+ resends in less than a minute of printing.

This PR won't eliminate connection issues but mitigates them. To properly fix the issue a refactor in the STM32 HAL would be necessary to use DMA instead of interrupts for serial.

### Requirements

Board running on STM32 HAL.

### Related Issues

https://github.com/MarlinFirmware/Marlin/pull/21927#discussion_r633132913
