### PR TITLE
Corrections to FTDI Eve Touch UI

### DIFF
--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/adjuster_widget.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/adjuster_widget.cpp
@@ -42,7 +42,7 @@ namespace FTDI {
       strcat_P(str, (const char*) units);
     }
 
-    cmd.text(VAL_POS, str);
+    cmd.tag(0).text(VAL_POS, str);
   }
 
   void draw_adjuster(CommandProcessor& cmd, int16_t x, int16_t y, int16_t w, int16_t h, uint8_t tag, float value, progmem_str units, int8_t width, uint8_t precision, draw_mode_t what) {

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.cpp
@@ -36,6 +36,7 @@ using namespace Theme;
 constexpr static SpinnerDialogBoxData &mydata = screen_data.SpinnerDialogBox;
 
 void SpinnerDialogBox::onEntry() {
+  UIScreen::onEntry();
   mydata.auto_hide = true;
 }
 
@@ -98,7 +99,7 @@ void SpinnerDialogBox::enqueueAndWait(progmem_str message, char *commands) {
 }
 
 void SpinnerDialogBox::onIdle() {
-  if (mydata.auto_hide && !commandsInQueue()) {
+  if (mydata.auto_hide && !commandsInQueue() && TERN1(HOST_KEEPALIVE_FEATURE, GcodeSuite::busy_state == GcodeSuite::NOT_BUSY)) {
     mydata.auto_hide = false;
     hide();
   }

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/spinner_dialog_box.h
@@ -29,7 +29,7 @@ struct SpinnerDialogBoxData {
   bool auto_hide;
 };
 
-class SpinnerDialogBox : public BaseScreen {
+class SpinnerDialogBox : public UIScreen {
   public:
     static void onEntry();
     static void onExit();


### PR DESCRIPTION
- Improve detection of when printer is actively executing a command.
- Fix situations where spinner would not get drawn
- Make non-clickable text non-clickable