### PR TITLE
Define HAL_STM32 for HAL/STM32

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "HAL.h"
 #include "usb_serial.h"
@@ -165,4 +167,4 @@ void HAL_SYSTICK_Callback() {
   if (systick_user_callback) systick_user_callback();
 }
 
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/HAL_MinSerial.cpp
+++ b/Marlin/src/HAL/STM32/HAL_MinSerial.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfigPre.h"
 
@@ -149,4 +151,4 @@ extern "C" {
 #endif
 
 #endif // POSTMORTEM_DEBUGGING
-#endif // ARDUINO_ARCH_STM32
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/HAL_SPI.cpp
+++ b/Marlin/src/HAL/STM32/HAL_SPI.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -224,4 +226,4 @@ static SPISettings spiConfig;
 
 #endif // SOFTWARE_SPI
 
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/MarlinSPI.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSPI.cpp
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1) && !defined(STM32H7xx)
+#if defined(HAL_STM32) && !defined(STM32H7xx)
 
 #include "MarlinSPI.h"
 
@@ -165,4 +165,4 @@ uint8_t MarlinSPI::dmaSend(const void * transmitBuf, uint16_t length, bool minc)
   return 1;
 }
 
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1 && !STM32H7xx
+#endif // HAL_STM32 && !STM32H7xx

--- a/Marlin/src/HAL/STM32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSerial.cpp
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 #include "MarlinSerial.h"
@@ -101,4 +103,4 @@ void MarlinSerial::_rx_complete_irq(serial_t *obj) {
   }
 }
 
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
+++ b/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -320,4 +322,4 @@ extern "C" void SDIO_IRQHandler(void) { HAL_SD_IRQHandler(&hsd); }
 extern "C" void DMA_IRQ_HANDLER(void) { HAL_DMA_IRQHandler(&hdma_sdio); }
 
 #endif // SDIO_SUPPORT
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/Servo.cpp
+++ b/Marlin/src/HAL/STM32/Servo.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -107,4 +109,4 @@ void libServo::setInterruptPriority(uint32_t preemptPriority, uint32_t subPriori
 }
 
 #endif // HAS_SERVOS
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -272,4 +274,4 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, size_t size, uint16_t 
 }
 
 #endif // FLASH_EEPROM_EMULATION
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/eeprom_sdcard.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_sdcard.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 /**
  * Implementation of EEPROM settings in SD Card
@@ -88,4 +90,4 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, const size_t size, uin
 }
 
 #endif // SDCARD_EEPROM_EMULATION
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/eeprom_sram.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_sram.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -65,4 +67,4 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, size_t size, uint16_t 
 }
 
 #endif // SRAM_EEPROM_EMULATION
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/eeprom_wired.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_wired.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -75,4 +77,4 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, size_t size, uint16_t 
 }
 
 #endif // USE_WIRED_EEPROM
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfigPre.h"
 
@@ -56,4 +58,4 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
 }
 
 #endif // NEEDS_HARDWARE_PWM
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/fastio.cpp
+++ b/Marlin/src/HAL/STM32/fastio.cpp
@@ -20,7 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -31,4 +33,4 @@ void FastIO_init() {
     FastIOPortMap[STM_PORT(digitalPin[i])] = get_GPIO_Port(STM_PORT(digitalPin[i]));
 }
 
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32/msc_sd.cpp
@@ -13,7 +13,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfigPre.h"
 
@@ -125,4 +127,4 @@ void MSC_SD_init() {
 }
 
 #endif // HAS_SD_HOST_DRIVE
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/tft/gt911.cpp
+++ b/Marlin/src/HAL/STM32/tft/gt911.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../../inc/MarlinConfig.h"
 
@@ -199,4 +201,4 @@ bool GT911::getPoint(int16_t *x, int16_t *y) {
 }
 
 #endif // TFT_TOUCH_DEVICE_GT911
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/tft/tft_fsmc.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_fsmc.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../../inc/MarlinConfig.h"
 
@@ -178,4 +180,4 @@ void TFT_FSMC::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Cou
 }
 
 #endif // HAS_FSMC_TFT
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/tft/tft_ltdc.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_ltdc.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../../inc/MarlinConfig.h"
 
@@ -384,4 +386,4 @@ void TFT_LTDC::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Cou
 }
 
 #endif // HAS_LTDC_TFT
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_spi.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../../inc/MarlinConfig.h"
 
@@ -240,4 +242,4 @@ void TFT_SPI::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Coun
 }
 
 #endif // HAS_SPI_TFT
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/STM32/tft/xpt2046.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../../inc/MarlinConfig.h"
 
@@ -167,4 +169,4 @@ uint16_t XPT2046::SoftwareIO(uint16_t data) {
 }
 
 #endif // HAS_TFT_XPT2046
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -319,4 +321,4 @@ static constexpr bool verify_no_timer_conflicts() {
 // when hovering over it, making it easy to identify the conflicting timers.
 static_assert(verify_no_timer_conflicts(), "One or more timer conflict detected. Examine \"timers_in_use\" to help identify conflict.");
 
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/usb_host.cpp
+++ b/Marlin/src/HAL/STM32/usb_host.cpp
@@ -19,8 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
+#include "../platforms.h"
 
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
 
@@ -114,4 +115,4 @@ uint8_t BulkStorage::Write(uint8_t lun, uint32_t addr, uint16_t bsize, uint8_t b
 }
 
 #endif // USE_OTG_USB_HOST && USBHOST
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/usb_serial.cpp
+++ b/Marlin/src/HAL/STM32/usb_serial.cpp
@@ -16,7 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfigPre.h"
 
@@ -51,4 +53,4 @@ void USB_Hook_init() {
 }
 
 #endif // EMERGENCY_PARSER && USBD_USE_CDC
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/watchdog.cpp
+++ b/Marlin/src/HAL/STM32/watchdog.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../inc/MarlinConfigPre.h"
 
@@ -46,4 +48,4 @@ void HAL_watchdog_refresh() {
 }
 
 #endif // USE_WATCHDOG
-#endif // ARDUINO_ARCH_STM32 && !STM32GENERIC && !MAPLE_STM32F1
+#endif // HAL_STM32

--- a/Marlin/src/HAL/platforms.h
+++ b/Marlin/src/HAL/platforms.h
@@ -38,6 +38,9 @@
 #elif defined(__STM32F1__) || defined(TARGET_STM32F1)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/STM32F1/NAME)
 #elif defined(ARDUINO_ARCH_STM32)
+  #ifndef HAL_STM32
+    #define HAL_STM32
+  #endif
   #define HAL_PATH(PATH, NAME) XSTR(PATH/STM32/NAME)
 #elif defined(ARDUINO_ARCH_ESP32)
   #define HAL_PATH(PATH, NAME) XSTR(PATH/ESP32/NAME)

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/compat.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/compat.h
@@ -288,7 +288,7 @@
 
   // Remove compiler warning on an unused variable
   #ifndef UNUSED
-    #if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+    #ifdef HAL_STM32
       #define UNUSED(X) (void)X
     #else
       #define UNUSED(x) ((void)(x))

--- a/Marlin/src/lcd/extui/mks_ui/wifiSerial_STM32.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/wifiSerial_STM32.cpp
@@ -19,7 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#if defined(ARDUINO_ARCH_STM32) && !defined(STM32GENERIC) && !defined(MAPLE_STM32F1)
+#include "../../../HAL/platforms.h"
+
+#ifdef HAL_STM32
 
 #include "../../../inc/MarlinConfigPre.h"
 
@@ -349,4 +351,4 @@ int WifiSerial::write(uint8_t c) {
 }
 
 #endif // HAS_TFT_LVGL_UI && MKS_WIFI_MODULE
-#endif // !__STM32F1__
+#endif // HAL_STM32

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -31,7 +31,7 @@ LIB_INTERNAL_MAX31865                  = src_filter=+<src/libs/MAX31865.cpp>
 NEOPIXEL_LED                           = adafruit/Adafruit NeoPixel@~1.8.0
                                          src_filter=+<src/feature/leds/neopixel.cpp>
 I2C_AMMETER                            = peterus/INA226Lib@1.1.2
-USES_LIQUIDCRYSTAL                     = fmalpartida/LiquidCrystal@1.5.0
+USES_LIQUIDCRYSTAL                     = LiquidCrystal=https://github.com/MarlinFirmware/New-LiquidCrystal/archive/1.5.1.zip
 USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7
 HAS_WIRED_LCD                          = src_filter=+<src/lcd/lcdprint.cpp>

--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -13,7 +13,7 @@
 platform         = ststm32@~12.1
 board_build.core = stm32
 build_flags      = ${common.build_flags}
-                   -std=gnu++14
+                   -std=gnu++14 -DHAL_STM32
                    -DUSBCON -DUSBD_USE_CDC
                    -DTIM_IRQ_PRIO=13
                    -DADC_RESOLUTION=12

--- a/ini/stm32f0.ini
+++ b/ini/stm32f0.ini
@@ -10,7 +10,7 @@
 # Naming Example: STM32F070CBT6
 #
 #   F : Foundation
-#   0 : Cortex M0 core
+#   0 : Cortex M0 core (0:M0, 1-2:M3, 3-4:M4, 7:M7)
 #  70 : Line/Features
 #   C : 48 pins  (R:64 or 66, F:20)
 #   B : 128KB Flash-memory  (C:256KB, D:384KB, E:512KB, G:1024KB)

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -10,7 +10,7 @@
 # Naming Example: STM32F103RCT6
 #
 #   F : Foundation (sometimes High Performance F2/F4)
-#   1 : Cortex M1 core
+#   1 : Cortex M3 core (0:M0, 1-2:M3, 3-4:M4, 7:M7)
 #  03 : Line/Features
 #   R : 64 or 66 pins  (V:100, Z:144, I:176)
 #   C : 256KB Flash-memory  (D:384KB, E:512KB, G:1024KB)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -10,7 +10,7 @@
 # Naming Example: STM32F103RCT6
 #
 #   F : Foundation (sometimes High Performance F2/F4)
-#   1 : Cortex M3 core
+#   1 : Cortex M3 core (0:M0, 1-2:M3, 3-4:M4, 7:M7)
 #  03 : Line/Features
 #   R : 64 or 66 pins  (T:36, C:48, V:100, Z:144, I:176)
 #   C : 256KB Flash-memory  (B: 128KB, D:384KB, E:512KB, G:1024KB)

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -10,7 +10,7 @@
 # Naming Example: STM32F401RGT6
 #
 #   F : Foundation (sometimes High Performance F2/F4)
-#   4 : Cortex M4 core
+#   4 : Cortex M4 core (0:M0, 1-2:M3, 3-4:M4, 7:M7)
 #  01 : Line/Features
 #   R : 64 or 66 pins  (T:36, C:48 or 49, M:81, V:100, Z:144, I:176)
 #   G : 1024KB Flash-memory  (B:128KB, C:256KB, D:384KB, E:512KB)

--- a/ini/stm32f7.ini
+++ b/ini/stm32f7.ini
@@ -10,7 +10,7 @@
 # Naming Example: STM32F767ZIT6
 #
 #   F : Foundation (sometimes High Performance F2/F4)
-#   7 : Cortex M7 core
+#   7 : Cortex M7 core (0:M0, 1-2:M3, 3-4:M4, 7:M7)
 #  67 : Line/Features
 #   Z : 144 pins
 #   I : 4096KB Flash-memory

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -10,7 +10,7 @@
 # Naming Example: STM32H743IIT6
 #
 #   H : High Performance
-#   7 : Cortex M7 core
+#   7 : Cortex M7 core (0:M0, 1-2:M3, 3-4:M4, 7:M7)
 #  43 : Line/Features
 #   I : 176 pins
 #   I : 2048KB Flash-memory


### PR DESCRIPTION
- Simplify the condition designating HAL/STM32 so it can be changed in fewer locations. (From #22508)
- Use `MarlinFirmware/New-LiquidCrystal` (1.5.1) instead of `LiquidCrystal@1.5.0`.
