### PR TITLE
STM32: remove platforms.h include where not needed

### DIFF
--- a/Marlin/src/HAL/STM32/HAL_MinSerial.cpp
+++ b/Marlin/src/HAL/STM32/HAL_MinSerial.cpp
@@ -20,13 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(POSTMORTEM_DEBUGGING)
+#if defined(HAL_STM32) && ENABLED(POSTMORTEM_DEBUGGING)
 
 #include "../shared/HAL_MinSerial.h"
 #include "watchdog.h"
@@ -150,5 +146,4 @@ extern "C" {
 }
 #endif
 
-#endif // POSTMORTEM_DEBUGGING
-#endif // HAL_STM32
+#endif // HAL_STM32 && POSTMORTEM_DEBUGGING

--- a/Marlin/src/HAL/STM32/HAL_SPI.cpp
+++ b/Marlin/src/HAL/STM32/HAL_SPI.cpp
@@ -20,11 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
+#include "../../inc/MarlinConfig.h"
 
 #ifdef HAL_STM32
-
-#include "../../inc/MarlinConfig.h"
 
 #include <SPI.h>
 

--- a/Marlin/src/HAL/STM32/MarlinSerial.cpp
+++ b/Marlin/src/HAL/STM32/MarlinSerial.cpp
@@ -16,11 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
+#include "../../inc/MarlinConfig.h"
 #ifdef HAL_STM32
 
-#include "../../inc/MarlinConfig.h"
 #include "MarlinSerial.h"
 
 #if ENABLED(EMERGENCY_PARSER)

--- a/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
+++ b/Marlin/src/HAL/STM32/Sd2Card_sdio_stm32duino.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(SDIO_SUPPORT)
+#if defined(HAL_STM32) && ENABLED(SDIO_SUPPORT)
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -321,5 +317,4 @@ uint32_t SDIO_GetCardSize() {
 extern "C" void SDIO_IRQHandler(void) { HAL_SD_IRQHandler(&hsd); }
 extern "C" void DMA_IRQ_HANDLER(void) { HAL_DMA_IRQHandler(&hdma_sdio); }
 
-#endif // SDIO_SUPPORT
-#endif // HAL_STM32
+#endif // HAL_STM32 && SDIO_SUPPORT

--- a/Marlin/src/HAL/STM32/Servo.cpp
+++ b/Marlin/src/HAL/STM32/Servo.cpp
@@ -20,13 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfig.h"
 
-#if HAS_SERVOS
+#if defined(HAL_STM32) && HAS_SERVOS
 
 #include "Servo.h"
 
@@ -108,5 +104,4 @@ void libServo::setInterruptPriority(uint32_t preemptPriority, uint32_t subPriori
   servo_interrupt_priority = NVIC_EncodePriority(NVIC_GetPriorityGrouping(), preemptPriority, subPriority);
 }
 
-#endif // HAS_SERVOS
-#endif // HAL_STM32
+#endif // HAL_STM32 && HAS_SERVOS

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -20,13 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(FLASH_EEPROM_EMULATION)
+#if defined(HAL_STM32) && ENABLED(FLASH_EEPROM_EMULATION)
 
 #include "../shared/eeprom_api.h"
 
@@ -273,5 +269,4 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, size_t size, uint16_t 
   return false;
 }
 
-#endif // FLASH_EEPROM_EMULATION
-#endif // HAL_STM32
+#endif // HAL_STM32 && FLASH_EEPROM_EMULATION

--- a/Marlin/src/HAL/STM32/eeprom_sdcard.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_sdcard.cpp
@@ -19,17 +19,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
+#include "../../inc/MarlinConfig.h"
 
-#ifdef HAL_STM32
+#if defined(HAL_STM32) && ENABLED(SDCARD_EEPROM_EMULATION)
 
 /**
  * Implementation of EEPROM settings in SD Card
  */
-
-#include "../../inc/MarlinConfig.h"
-
-#if ENABLED(SDCARD_EEPROM_EMULATION)
 
 #include "../shared/eeprom_api.h"
 #include "../../sd/cardreader.h"
@@ -89,5 +85,4 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, const size_t size, uin
   return false;
 }
 
-#endif // SDCARD_EEPROM_EMULATION
-#endif // HAL_STM32
+#endif // HAL_STM32 && SDCARD_EEPROM_EMULATION

--- a/Marlin/src/HAL/STM32/eeprom_sram.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_sram.cpp
@@ -20,13 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfig.h"
 
-#if ENABLED(SRAM_EEPROM_EMULATION)
+#if defined(HAL_STM32) && ENABLED(SRAM_EEPROM_EMULATION)
 
 #include "../shared/eeprom_if.h"
 #include "../shared/eeprom_api.h"
@@ -66,5 +62,4 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, size_t size, uint16_t 
   return false;
 }
 
-#endif // SRAM_EEPROM_EMULATION
-#endif // HAL_STM32
+#endif // HAL_STM32 && SRAM_EEPROM_EMULATION

--- a/Marlin/src/HAL/STM32/eeprom_wired.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_wired.cpp
@@ -20,13 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfig.h"
 
-#if USE_WIRED_EEPROM
+#if defined(HAL_STM32) && USE_WIRED_EEPROM
 
 /**
  * PersistentStore for Arduino-style EEPROM interface
@@ -76,5 +72,4 @@ bool PersistentStore::read_data(int &pos, uint8_t *value, size_t size, uint16_t 
   return false;
 }
 
-#endif // USE_WIRED_EEPROM
-#endif // HAL_STM32
+#endif // HAL_STM32 && USE_WIRED_EEPROM

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfigPre.h"
 
-#if NEEDS_HARDWARE_PWM
+#if defined(HAL_STM32) && NEEDS_HARDWARE_PWM
 
 #include "HAL.h"
 #include "timers.h"
@@ -57,5 +53,4 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
   }
 }
 
-#endif // NEEDS_HARDWARE_PWM
-#endif // HAL_STM32
+#endif // HAL_STM32 && NEEDS_HARDWARE_PWM

--- a/Marlin/src/HAL/STM32/fastio.cpp
+++ b/Marlin/src/HAL/STM32/fastio.cpp
@@ -20,11 +20,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
+#include "../../inc/MarlinConfig.h"
 
 #ifdef HAL_STM32
-
-#include "../../inc/MarlinConfig.h"
 
 GPIO_TypeDef* FastIOPortMap[LastPort + 1] = { 0 };
 

--- a/Marlin/src/HAL/STM32/msc_sd.cpp
+++ b/Marlin/src/HAL/STM32/msc_sd.cpp
@@ -13,13 +13,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfigPre.h"
 
-#if HAS_SD_HOST_DRIVE
+#if defined(HAL_STM32) && HAS_SD_HOST_DRIVE
 
 #include "../shared/Marduino.h"
 #include "msc_sd.h"
@@ -126,5 +122,4 @@ void MSC_SD_init() {
   USBDevice.begin();
 }
 
-#endif // HAS_SD_HOST_DRIVE
-#endif // HAL_STM32
+#endif // HAL_STM32 && HAS_SD_HOST_DRIVE

--- a/Marlin/src/HAL/STM32/tft/gt911.cpp
+++ b/Marlin/src/HAL/STM32/tft/gt911.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../../inc/MarlinConfig.h"
 
-#if ENABLED(TFT_TOUCH_DEVICE_GT911)
+#if defined(HAL_STM32) && ENABLED(TFT_TOUCH_DEVICE_GT911)
 
 #include "gt911.h"
 #include "pinconfig.h"
@@ -200,5 +196,4 @@ bool GT911::getPoint(int16_t *x, int16_t *y) {
   return touched;
 }
 
-#endif // TFT_TOUCH_DEVICE_GT911
-#endif // HAL_STM32
+#endif // HAL_STM32 && TFT_TOUCH_DEVICE_GT911

--- a/Marlin/src/HAL/STM32/tft/tft_fsmc.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_fsmc.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../../inc/MarlinConfig.h"
 
-#if HAS_FSMC_TFT
+#if defined(HAL_STM32) && HAS_FSMC_TFT
 
 #include "tft_fsmc.h"
 #include "pinconfig.h"
@@ -179,5 +175,4 @@ void TFT_FSMC::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Cou
   Abort();
 }
 
-#endif // HAS_FSMC_TFT
-#endif // HAL_STM32
+#endif // HAL_STM32 && HAS_FSMC_TFT

--- a/Marlin/src/HAL/STM32/tft/tft_ltdc.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_ltdc.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../../inc/MarlinConfig.h"
 
-#if HAS_LTDC_TFT
+#if defined(HAL_STM32) && HAS_LTDC_TFT
 
 #include "tft_ltdc.h"
 #include "pinconfig.h"
@@ -385,5 +381,4 @@ void TFT_LTDC::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Cou
   }
 }
 
-#endif // HAS_LTDC_TFT
-#endif // HAL_STM32
+#endif // HAL_STM32 && HAS_LTDC_TFT

--- a/Marlin/src/HAL/STM32/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_spi.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../../inc/MarlinConfig.h"
 
-#if HAS_SPI_TFT
+#if defined(HAL_STM32) && HAS_SPI_TFT
 
 #include "tft_spi.h"
 #include "pinconfig.h"
@@ -241,5 +237,4 @@ void TFT_SPI::TransmitDMA(uint32_t MemoryIncrease, uint16_t *Data, uint16_t Coun
   Abort();
 }
 
-#endif // HAS_SPI_TFT
-#endif // HAL_STM32
+#endif // HAL_STM32 && HAS_SPI_TFT

--- a/Marlin/src/HAL/STM32/tft/xpt2046.cpp
+++ b/Marlin/src/HAL/STM32/tft/xpt2046.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../../inc/MarlinConfig.h"
 
-#if HAS_TFT_XPT2046 || HAS_RES_TOUCH_BUTTONS
+#if defined(HAL_STM32) && (HAS_TFT_XPT2046 || HAS_RES_TOUCH_BUTTONS)
 
 #include "xpt2046.h"
 #include "pinconfig.h"
@@ -168,5 +164,4 @@ uint16_t XPT2046::SoftwareIO(uint16_t data) {
   return result;
 }
 
-#endif // HAS_TFT_XPT2046
-#endif // HAL_STM32
+#endif // HAL_STM32 && HAS_TFT_XPT2046 | HAS_RES_TOUCH_BUTTONS

--- a/Marlin/src/HAL/STM32/timers.cpp
+++ b/Marlin/src/HAL/STM32/timers.cpp
@@ -19,11 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
+#include "../../inc/MarlinConfig.h"
 
 #ifdef HAL_STM32
-
-#include "../../inc/MarlinConfig.h"
 
 // ------------------------
 // Local defines

--- a/Marlin/src/HAL/STM32/usb_host.cpp
+++ b/Marlin/src/HAL/STM32/usb_host.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfig.h"
 
-#if BOTH(USE_OTG_USB_HOST, USBHOST)
+#if defined(HAL_STM32) && BOTH(USE_OTG_USB_HOST, USBHOST)
 
 #include "usb_host.h"
 #include "../shared/Marduino.h"
@@ -114,5 +110,4 @@ uint8_t BulkStorage::Write(uint8_t lun, uint32_t addr, uint16_t bsize, uint8_t b
   return USBH_MSC_Write(&hUsbHost, lun, addr, const_cast<uint8_t*>(buf), blocks) != USBH_OK;
 }
 
-#endif // USE_OTG_USB_HOST && USBHOST
-#endif // HAL_STM32
+#endif // HAL_STM32 && USE_OTG_USB_HOST && USBHOST

--- a/Marlin/src/HAL/STM32/usb_serial.cpp
+++ b/Marlin/src/HAL/STM32/usb_serial.cpp
@@ -16,13 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(EMERGENCY_PARSER) && USBD_USE_CDC
+#if defined(HAL_STM32) && ENABLED(EMERGENCY_PARSER) && USBD_USE_CDC
 
 #include "usb_serial.h"
 #include "../../feature/e_parser.h"
@@ -52,5 +48,4 @@ void USB_Hook_init() {
   USBD_CDC_fops.Receive = USBD_CDC_Receive_hook;
 }
 
-#endif // EMERGENCY_PARSER && USBD_USE_CDC
-#endif // HAL_STM32
+#endif // HAL_STM32 && EMERGENCY_PARSER && USBD_USE_CDC

--- a/Marlin/src/HAL/STM32/watchdog.cpp
+++ b/Marlin/src/HAL/STM32/watchdog.cpp
@@ -19,13 +19,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-#include "../platforms.h"
-
-#ifdef HAL_STM32
-
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(USE_WATCHDOG)
+#if defined(HAL_STM32) && ENABLED(USE_WATCHDOG)
 
 #define WDT_TIMEOUT_US TERN(WATCHDOG_DURATION_8S, 8000000, 4000000) // 4 or 8 second timeout
 
@@ -47,5 +43,4 @@ void HAL_watchdog_refresh() {
   #endif
 }
 
-#endif // USE_WATCHDOG
-#endif // HAL_STM32
+#endif // HAL_STM32 && USE_WATCHDOG


### PR DESCRIPTION
MarlinConfigPre.h & MarlinConfig.h already include it...

Tested locally with & without -DHAL_STM32 in ini/stm32-common.ini but my travis currently doesnt allow me to test that on all boards... (also out of OSS Credits)

@thinkyhead could you try it with your Arduino IDE env ? I left one in STM32/HAL.cpp, may be deleted too