### PR TITLE
Fix Ender-3 v2 language init

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1591,7 +1591,7 @@ void setup() {
   #if ENABLED(DWIN_CREALITY_LCD)
     Encoder_Configuration();
     HMI_Init();
-    DWIN_JPG_CacheTo1(Language_English);
+    HMI_SetLanguageCache();
     HMI_StartFrame(true);
     DWIN_StatusChanged_P(GET_TEXT(WELCOME_MSG));
   #endif

--- a/Marlin/src/lcd/e3v2/creality/dwin.h
+++ b/Marlin/src/lcd/e3v2/creality/dwin.h
@@ -215,6 +215,7 @@ void HMI_MaxFeedspeedXYZE();
 void HMI_MaxAccelerationXYZE();
 void HMI_MaxJerkXYZE();
 void HMI_StepXYZE();
+void HMI_SetLanguageCache();
 
 void update_variable();
 void DWIN_Draw_Signed_Float(uint8_t size, uint16_t bColor, uint8_t iNum, uint8_t fNum, uint16_t x, uint16_t y, long value);


### PR DESCRIPTION
### Description

Fix the Issue: https://github.com/MarlinFirmware/Marlin/issues/21871 Creality Ender 3 v2 cannot display Chinese language correctly

### Requirements

Creality Ender 3v2 with stock DWIN display

### Benefits

Chinese language is displayed correctly after turn on if it was previously selected.

### Related Issues

Fix: https://github.com/MarlinFirmware/Marlin/issues/21871
