### PR TITLE
add a check that MOTHERBOARD is defined

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -37,6 +37,11 @@
 
 #define MAX_E_STEPPERS 8
 
+
+#ifndef MOTHERBOARD
+  #error "#define MOTHERBOARD has not been set in Configuration.h"
+#endif
+
 #if   MB(RAMPS_13_EFB, RAMPS_14_EFB, RAMPS_PLUS_EFB, RAMPS_14_RE_ARM_EFB, RAMPS_SMART_EFB, RAMPS_DUO_EFB, RAMPS4DUE_EFB)
   #define IS_RAMPS_EFB
 #elif MB(RAMPS_13_EEB, RAMPS_14_EEB, RAMPS_PLUS_EEB, RAMPS_14_RE_ARM_EEB, RAMPS_SMART_EEB, RAMPS_DUO_EEB, RAMPS4DUE_EEB)
@@ -763,7 +768,7 @@
     #error "BOARD_RAMPS_LONGER3D_LK4PRO is now BOARD_LONGER3D_LKx_PRO. Please update your configuration."
   #elif MB(BTT_SKR_V2_0)
     #error "BTT_SKR_V2_0 is now BTT_SKR_V2_0_REV_A or BTT_SKR_V2_0_REV_B. See https://bit.ly/3t5d9JQ for more information. Please update your configuration."
-  #else
+  #elif defined(MOTHERBOARD)
     #error "Unknown MOTHERBOARD value set in Configuration.h"
   #endif
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -715,9 +715,7 @@
   #define BOARD_RAMPS_LONGER3D_LK4PRO   -1021
   #define BOARD_BTT_SKR_V2_0            -1022
 
-  #ifndef MOTHERBOARD
-    #error "MOTHERBOARD not defined! Use '#define MOTHERBOARD BOARD_...' in Configuration.h."
-  #elif MB(MKS_13)
+  #if MB(MKS_13)
     #error "BOARD_MKS_13 has been renamed BOARD_MKS_GEN_13. Please update your configuration."
   #elif MB(TRIGORILLA)
     #error "BOARD_TRIGORILLA has been renamed BOARD_TRIGORILLA_13. Please update your configuration."
@@ -765,8 +763,10 @@
     #error "BOARD_RAMPS_LONGER3D_LK4PRO is now BOARD_LONGER3D_LKx_PRO. Please update your configuration."
   #elif MB(BTT_SKR_V2_0)
     #error "BTT_SKR_V2_0 is now BTT_SKR_V2_0_REV_A or BTT_SKR_V2_0_REV_B. See https://bit.ly/3t5d9JQ for more information. Please update your configuration."
+  #elif defined(MOTHERBOARD)
+    #error "Unknown MOTHERBOARD value set in Configuration.h."
   #else
-    #error "Unknown MOTHERBOARD value set in Configuration.h"
+    #error "MOTHERBOARD not defined! Use '#define MOTHERBOARD BOARD_...' in Configuration.h."
   #endif
 
   #undef BOARD_MKS_13

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -37,11 +37,6 @@
 
 #define MAX_E_STEPPERS 8
 
-
-#ifndef MOTHERBOARD
-  #error "#define MOTHERBOARD has not been set in Configuration.h"
-#endif
-
 #if   MB(RAMPS_13_EFB, RAMPS_14_EFB, RAMPS_PLUS_EFB, RAMPS_14_RE_ARM_EFB, RAMPS_SMART_EFB, RAMPS_DUO_EFB, RAMPS4DUE_EFB)
   #define IS_RAMPS_EFB
 #elif MB(RAMPS_13_EEB, RAMPS_14_EEB, RAMPS_PLUS_EEB, RAMPS_14_RE_ARM_EEB, RAMPS_SMART_EEB, RAMPS_DUO_EEB, RAMPS4DUE_EEB)
@@ -720,7 +715,9 @@
   #define BOARD_RAMPS_LONGER3D_LK4PRO   -1021
   #define BOARD_BTT_SKR_V2_0            -1022
 
-  #if MB(MKS_13)
+  #ifndef MOTHERBOARD
+    #error "MOTHERBOARD not defined! Use '#define MOTHERBOARD BOARD_...' in Configuration.h."
+  #elif MB(MKS_13)
     #error "BOARD_MKS_13 has been renamed BOARD_MKS_GEN_13. Please update your configuration."
   #elif MB(TRIGORILLA)
     #error "BOARD_TRIGORILLA has been renamed BOARD_TRIGORILLA_13. Please update your configuration."
@@ -768,7 +765,7 @@
     #error "BOARD_RAMPS_LONGER3D_LK4PRO is now BOARD_LONGER3D_LKx_PRO. Please update your configuration."
   #elif MB(BTT_SKR_V2_0)
     #error "BTT_SKR_V2_0 is now BTT_SKR_V2_0_REV_A or BTT_SKR_V2_0_REV_B. See https://bit.ly/3t5d9JQ for more information. Please update your configuration."
-  #elif defined(MOTHERBOARD)
+  #else
     #error "Unknown MOTHERBOARD value set in Configuration.h"
   #endif
 


### PR DESCRIPTION
### Description

I have seen a number of people struggling to set #define MOTHERBOARD BOARD_{their board type} correctly in their Configuration.h files.

They often lose the MOTHERBOARD keywords and are trying things like 
#define BOARD_{their board type} or #define MOTHERBOARD_{their board type}

Currently these result in the error "Unknown MOTHERBOARD value set in Configuration.h"
Which is not as accurate as it could be. 

I have added a test to check that MOTHERBOARD is actually defined and if not it gives the new error
"#define MOTHERBOARD has not been set in Configuration.h"

### Benefits
Less confused users

### Related Issues
Latest example  https://reprap.org/forum/read.php?415,885325
