### PR TITLE
tweak SKR2 pins

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -154,13 +154,6 @@
 #endif
 
 //
-// NeoPixel LED
-//
-#ifndef NEOPIXEL_PIN
-  #define NEOPIXEL_PIN                      PE6
-#endif
-
-//
 // Control pin of driver/heater/fan power supply
 //
 #define SAFE_POWER_PIN                      PC13
@@ -509,6 +502,13 @@
   #ifndef BOARD_ST7920_DELAY_3
     #define BOARD_ST7920_DELAY_3   DELAY_NS(580)
   #endif
+#endif
+
+//
+// NeoPixel LED
+//
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PE6
 #endif
 
 //

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -207,6 +207,7 @@ build_flags                 = ${stm_flash_drive.build_flags}
                               -DUSE_USBHOST_HS -DUSE_USB_HS_IN_FS
                               -DUSBD_IRQ_PRIO=5 -DUSBD_IRQ_SUBPRIO=6
                               -DHSE_VALUE=8000000U -DHAL_SD_MODULE_ENABLED
+                              -DPIN_SERIAL3_RX=PD_9 -DPIN_SERIAL3_TX=PD_8
 
 #
 # BigTreeTech SKR V2.0 (STM32F407VGT6 ARM Cortex-M4) with USB Media Share Support


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
* Specify the USART3 `TX = PD_8` `RX = PD_9`  for SKR-2 motherboard wifi port (Because the default pins of USART3 in `MARLIN_F4x7Vx` variant are `PB_10` and `PB_11`)
* 
* Move the define of `NEOPIXEL_PIN`  below `FYSETC_MINI_12864_2_1`, because when the LCD is set to `FYSETC_MINI_12864_2_1`, `NEOPIXEL_PIN` will be defined as the `EXP1_05_PIN` pin, and a warning of repeated definition will appear during compilation.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

