### PR TITLE
UBL: remove extra lines on settings load/report

### DIFF
--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -59,7 +59,7 @@ void unified_bed_leveling::report_current_mesh() {
 
 void unified_bed_leveling::report_state() {
   echo_name();
-  SERIAL_ECHO_TERNARY(planner.leveling_active, " System v" UBL_VERSION " ", "", "in", "active");
+  SERIAL_ECHO_TERNARY(planner.leveling_active, " System v" UBL_VERSION " ", "", "in", "active\n");
   serial_delay(50);
 }
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -59,7 +59,7 @@ void unified_bed_leveling::report_current_mesh() {
 
 void unified_bed_leveling::report_state() {
   echo_name();
-  SERIAL_ECHO_TERNARY(planner.leveling_active, " System v" UBL_VERSION " ", "", "in", "active\n");
+  SERIAL_ECHO_TERNARY(planner.leveling_active, " System v" UBL_VERSION " ", "", "in", "active");
   serial_delay(50);
 }
 

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2320,7 +2320,6 @@ void MarlinSettings::postprocess() {
           ubl.report_state();
 
           if (!ubl.sanity_check()) {
-            SERIAL_EOL();
             #if BOTH(EEPROM_CHITCHAT, DEBUG_LEVELING_FEATURE)
               ubl.echo_name();
               DEBUG_ECHOLNPGM(" initialized.\n");
@@ -3266,7 +3265,6 @@ void MarlinSettings::reset() {
         if (!forReplay) {
           SERIAL_EOL();
           ubl.report_state();
-          SERIAL_EOL();
           config_heading(false, PSTR("Active Mesh Slot: "), false);
           SERIAL_ECHOLN(ubl.storage_slot);
           config_heading(false, PSTR("EEPROM can hold "), false);

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3884,7 +3884,7 @@ void MarlinSettings::reset() {
 
     #if HAS_MULTI_LANGUAGE
       CONFIG_ECHO_HEADING("UI Language:");
-      SERIAL_ECHO_MSG("  M414 S", ui.language);
+      CONFIG_ECHO_MSG("  M414 S", ui.language);
     #endif
   }
 


### PR DESCRIPTION
Sample output before :

```
17:11:33.764 > echo: Last Updated: 2021-08-11
17:11:33.765 > echo:Compiled: Aug 12 2021
17:11:33.766 > echo: Free Memory: 49139  PlannerBufferBytes: 2816
17:11:34.159 > echo:V84 stored settings retrieved (636 bytes; crc 7431)
17:11:34.161 > Unified Bed Leveling System v1.01 inactive
17:11:34.212 >
17:11:34.212 > Mesh loaded from slot 0
17:11:34.212 > Mesh 0 loaded from storage.
17:11:38.669 > echo:SD card ok
```

SERIAL_EOL() is already present in the two places where report_state() is used in settings... G29 code use it a lot too, so keep the "\n" and remove SERIAL_EOL on settings load/report...

Small question:  Is "echo:" prefix required ? 
Also "Compiled:" line may need a space prefix...