### PR TITLE
Revert "🐛 Prevent ABL G29 setting a funky feedrate"

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -363,8 +363,6 @@ G29_TYPE GcodeSuite::G29() {
     #if ABL_USES_GRID
 
       xy_probe_feedrate_mm_s = MMM_TO_MMS(parser.linearval('S', XY_PROBE_FEEDRATE));
-      if (!xy_probe_feedrate_mm_s) xy_probe_feedrate_mm_s = PLANNER_XY_FEEDRATE();
-      NOLESS(xy_probe_feedrate_mm_s, planner.settings.min_feedrate_mm_s);
 
       const float x_min = probe.min_x(), x_max = probe.max_x(),
                   y_min = probe.min_y(), y_max = probe.max_y();

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -483,7 +483,7 @@ void do_blocking_move_to(LINEAR_AXIS_ARGS(const float), const_feedRate_t fr_mm_s
   DEBUG_SECTION(log_move, "do_blocking_move_to", DEBUGGING(LEVELING));
   if (DEBUGGING(LEVELING)) DEBUG_XYZ("> ", LINEAR_AXIS_ARGS());
 
-  const feedRate_t xy_feedrate = fr_mm_s ?: PLANNER_XY_FEEDRATE();
+  const feedRate_t xy_feedrate = fr_mm_s ?: feedRate_t(XY_PROBE_FEEDRATE_MM_S);
 
   #if HAS_Z_AXIS
     const feedRate_t z_feedrate = fr_mm_s ?: homing_feedrate(Z_AXIS);


### PR DESCRIPTION
### Description

This reverts commit 9130f58f3f553584278ec716c617005b9e03cb49 due to crazy X/Y Z Safe Homing moves: https://github.com/MarlinFirmware/Marlin/issues/22569 until a better solution can be found for https://github.com/MarlinFirmware/Marlin/issues/22472.

### Requirements

`Z_SAFE_HOMING`

### Benefits

X & Y won't try to move at an excessive rate.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/22569
- https://github.com/MarlinFirmware/Marlin/issues/22472