### PR TITLE
Apply FILAMENT_RUNOUT_SENSOR to MKS_UI

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/printer_operation.h
+++ b/Marlin/src/lcd/extui/mks_ui/printer_operation.h
@@ -28,7 +28,6 @@
 #define MIN_FILE_PRINTED   100 //5000
 
 void printer_state_polling();
-void filament_pin_setup();
 void filament_check();
 
 #ifdef __cplusplus

--- a/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
@@ -205,7 +205,6 @@ void tft_lvgl_init() {
   TERN_(HAS_SPI_FLASH_FONT, init_gb2312_font());
 
   tft_style_init();
-  filament_pin_setup();
 
   #if ENABLED(MKS_WIFI_MODULE)
     mks_esp_wifi_init();


### PR DESCRIPTION
Fixes #22591

Partially integrate MKS UI filament runout code with Marlin.

It would be better if it didn't reinvent the wheel and just used the methods in `features/runout.*`, allowing it to also respond to `M600`, park the carriage at a configured position, and so on.