### PR TITLE
SanityCheck: G2 / G3 (ARC_SUPPORT) currently requires LINEAR_AXES <= 3

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1377,6 +1377,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #error "DIRECT_STEPPING currently requires LINEAR_AXES 3"
 #elif ENABLED(FOAMCUTTER_XYUV) && LINEAR_AXES < 5
   #error "FOAMCUTTER_XYUV requires LINEAR_AXES >= 5."
+#elif ENABLED(ARC_SUPPORT) && LINEAR_AXES > XYZ
+  #error "ARC_SUPPORT currently requires LINEAR_AXES <= 3"
 #endif
 
 /**


### PR DESCRIPTION
### Description

I currently do not have the time to expand `ARC_SUPPORT` to work with `LINEAR_AXES >= 4`
So I propose to add this sanity check.

### Requirements

`ARC_SUPPORT` && `LINEAR_AXES >= 4`

### Benefits

Fewer bug reports like https://github.com/MarlinFirmware/Marlin/issues/22260 and https://github.com/MarlinFirmware/Marlin/issues/22461

### Configurations

None

### Related Issues
work-around for issues
https://github.com/MarlinFirmware/Marlin/issues/22260
https://github.com/MarlinFirmware/Marlin/issues/22461