### PR TITLE
Add rumba32_btt board

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -365,33 +365,34 @@
 #define BOARD_RUMBA32_V1_0            4201  // RUMBA32 STM32F446VET6 based controller from Aus3D
 #define BOARD_RUMBA32_V1_1            4202  // RUMBA32 STM32F446VET6 based controller from Aus3D
 #define BOARD_RUMBA32_MKS             4203  // RUMBA32 STM32F446VET6 based controller from Makerbase
-#define BOARD_BLACK_STM32F407VE       4204  // BLACK_STM32F407VE
-#define BOARD_BLACK_STM32F407ZE       4205  // BLACK_STM32F407ZE
-#define BOARD_STEVAL_3DP001V1         4206  // STEVAL-3DP001V1 3D PRINTER BOARD
-#define BOARD_BTT_SKR_PRO_V1_1        4207  // BigTreeTech SKR Pro v1.1 (STM32F407ZGT6)
-#define BOARD_BTT_SKR_PRO_V1_2        4208  // BigTreeTech SKR Pro v1.2 (STM32F407ZGT6)
-#define BOARD_BTT_BTT002_V1_0         4209  // BigTreeTech BTT002 v1.0 (STM32F407VGT6)
-#define BOARD_BTT_E3_RRF              4210  // BigTreeTech E3 RRF (STM32F407VGT6)
-#define BOARD_BTT_SKR_V2_0_REV_A      4211  // BigTreeTech SKR v2.0 Rev A (STM32F407VGT6)
-#define BOARD_BTT_SKR_V2_0_REV_B      4212  // BigTreeTech SKR v2.0 Rev B (STM32F407VGT6)
-#define BOARD_BTT_GTR_V1_0            4213  // BigTreeTech GTR v1.0 (STM32F407IGT)
-#define BOARD_BTT_OCTOPUS_V1_0        4214  // BigTreeTech Octopus v1.0 (STM32F446ZET6)
-#define BOARD_BTT_OCTOPUS_V1_1        4215  // BigTreeTech Octopus v1.1 (STM32F446ZET6)
-#define BOARD_LERDGE_K                4216  // Lerdge K (STM32F407ZG)
-#define BOARD_LERDGE_S                4217  // Lerdge S (STM32F407VE)
-#define BOARD_LERDGE_X                4218  // Lerdge X (STM32F407VE)
-#define BOARD_VAKE403D                4219  // VAkE 403D (STM32F446VET6)
-#define BOARD_FYSETC_S6               4220  // FYSETC S6 (STM32F446VET6)
-#define BOARD_FYSETC_S6_V2_0          4221  // FYSETC S6 v2.0 (STM32F446VET6)
-#define BOARD_FYSETC_SPIDER           4222  // FYSETC Spider (STM32F446VET6)
-#define BOARD_FLYF407ZG               4223  // FLYmaker FLYF407ZG (STM32F407ZG)
-#define BOARD_MKS_ROBIN2              4224  // MKS_ROBIN2 (STM32F407ZE)
-#define BOARD_MKS_ROBIN_PRO_V2        4225  // MKS Robin Pro V2 (STM32F407VE)
-#define BOARD_MKS_ROBIN_NANO_V3       4226  // MKS Robin Nano V3 (STM32F407VG)
-#define BOARD_MKS_MONSTER8            4227  // MKS Monster8 (STM32F407VGT6)
-#define BOARD_ANET_ET4                4228  // ANET ET4 V1.x (STM32F407VGT6)
-#define BOARD_ANET_ET4P               4229  // ANET ET4P V1.x (STM32F407VGT6)
-#define BOARD_FYSETC_CHEETAH_V20      4230  // FYSETC Cheetah V2.0
+#define BOARD_RUMBA32_BTT             4204  // RUMBA32 STM32F446VET6 based controller from BIGTREETECH
+#define BOARD_BLACK_STM32F407VE       4205  // BLACK_STM32F407VE
+#define BOARD_BLACK_STM32F407ZE       4206  // BLACK_STM32F407ZE
+#define BOARD_STEVAL_3DP001V1         4207  // STEVAL-3DP001V1 3D PRINTER BOARD
+#define BOARD_BTT_SKR_PRO_V1_1        4208  // BigTreeTech SKR Pro v1.1 (STM32F407ZGT6)
+#define BOARD_BTT_SKR_PRO_V1_2        4209  // BigTreeTech SKR Pro v1.2 (STM32F407ZGT6)
+#define BOARD_BTT_BTT002_V1_0         4210  // BigTreeTech BTT002 v1.0 (STM32F407VGT6)
+#define BOARD_BTT_E3_RRF              4211  // BigTreeTech E3 RRF (STM32F407VGT6)
+#define BOARD_BTT_SKR_V2_0_REV_A      4212  // BigTreeTech SKR v2.0 Rev A (STM32F407VGT6)
+#define BOARD_BTT_SKR_V2_0_REV_B      4213  // BigTreeTech SKR v2.0 Rev B (STM32F407VGT6)
+#define BOARD_BTT_GTR_V1_0            4214  // BigTreeTech GTR v1.0 (STM32F407IGT)
+#define BOARD_BTT_OCTOPUS_V1_0        4215  // BigTreeTech Octopus v1.0 (STM32F446ZET6)
+#define BOARD_BTT_OCTOPUS_V1_1        4216  // BigTreeTech Octopus v1.1 (STM32F446ZET6)
+#define BOARD_LERDGE_K                4217  // Lerdge K (STM32F407ZG)
+#define BOARD_LERDGE_S                4218  // Lerdge S (STM32F407VE)
+#define BOARD_LERDGE_X                4219  // Lerdge X (STM32F407VE)
+#define BOARD_VAKE403D                4220  // VAkE 403D (STM32F446VET6)
+#define BOARD_FYSETC_S6               4221  // FYSETC S6 (STM32F446VET6)
+#define BOARD_FYSETC_S6_V2_0          4222  // FYSETC S6 v2.0 (STM32F446VET6)
+#define BOARD_FYSETC_SPIDER           4223  // FYSETC Spider (STM32F446VET6)
+#define BOARD_FLYF407ZG               4224  // FLYmaker FLYF407ZG (STM32F407ZG)
+#define BOARD_MKS_ROBIN2              4225  // MKS_ROBIN2 (STM32F407ZE)
+#define BOARD_MKS_ROBIN_PRO_V2        4226  // MKS Robin Pro V2 (STM32F407VE)
+#define BOARD_MKS_ROBIN_NANO_V3       4227  // MKS Robin Nano V3 (STM32F407VG)
+#define BOARD_MKS_MONSTER8            4228  // MKS Monster8 (STM32F407VGT6)
+#define BOARD_ANET_ET4                4229  // ANET ET4 V1.x (STM32F407VGT6)
+#define BOARD_ANET_ET4P               4230  // ANET ET4P V1.x (STM32F407VGT6)
+#define BOARD_FYSETC_CHEETAH_V20      4231  // FYSETC Cheetah V2.0
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -587,6 +587,8 @@
   #include "stm32f4/pins_RUMBA32_AUS3D.h"       // STM32F4                                env:rumba32
 #elif MB(RUMBA32_MKS)
   #include "stm32f4/pins_RUMBA32_MKS.h"         // STM32F4                                env:rumba32
+#elif MB(RUMBA32_BTT)
+  #include "stm32f4/pins_RUMBA32_BTT.h"         // STM32F4                                env:rumba32
 #elif MB(BLACK_STM32F407VE)
   #include "stm32f4/pins_BLACK_STM32F407VE.h"   // STM32F4                                env:STM32F407VE_black
 #elif MB(STEVAL_3DP001V1)

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -198,7 +198,6 @@
 // Misc. Functions
 //
 //#define LED_PIN                           PB14
-//#define BTN_PIN                           PC10
 //#define PS_ON_PIN                         PE11
 //#define KILL_PIN                          PC5
 

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_AUS3D.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_AUS3D.h
@@ -51,7 +51,6 @@
 #if MB(RUMBA32_V1_1)
 
   #define SERVO0_PIN                        PA15
-  #undef BTN_PIN
 
   #if HAS_TMC_UART
     //

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
@@ -1,0 +1,68 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * No offical schematics have been found.
+ * But these differences where noted in https://github.com/bigtreetech/Rumba32/issues/1
+ */
+
+#pragma once
+
+#define BOARD_INFO_NAME "RUMBA32"
+
+#if NO_EEPROM_SELECTED
+  #define I2C_EEPROM
+  #define MARLIN_EEPROM_SIZE            0x2000  // 8KB (24LC64T-I/OT)
+#endif
+
+#if ENABLED(FLASH_EEPROM_EMULATION)
+  // Decrease delays and flash wear by spreading writes across the
+  // 128 kB sector allocated for EEPROM emulation.
+  #define FLASH_EEPROM_LEVELING
+#endif
+
+#include "pins_RUMBA32_common.h"
+
+#define SERVO0_PIN                        PA15 // Pin is not broken out, is a test point only.
+#undef BTN_PIN
+
+#if HAS_TMC_UART
+  //
+  // TMC2208/TMC2209 stepper drivers - Software Serial is used according to below pins
+  //
+  #define X_SERIAL_TX_PIN                 PC14 // BTT Rumba32 only uses 1 pin for uart
+  #define X_SERIAL_RX_PIN                 PC14
+  #define Y_SERIAL_TX_PIN                 PE4
+  #define Y_SERIAL_RX_PIN                 PE4
+
+  #define Z_SERIAL_TX_PIN                 PE0
+  #define Z_SERIAL_RX_PIN                 PE0
+
+  #define E0_SERIAL_TX_PIN                PC13
+  #define E0_SERIAL_RX_PIN                PC13
+
+  #define E1_SERIAL_TX_PIN                PD5
+  #define E1_SERIAL_RX_PIN                PD5
+
+  #define E2_SERIAL_TX_PIN                PD1
+  #define E2_SERIAL_RX_PIN                PD1
+#endif

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#define BOARD_INFO_NAME "RUMBA32"
+#define BOARD_INFO_NAME "RUMBA32 (BTT)"
 
 #if NO_EEPROM_SELECTED
   #define I2C_EEPROM
@@ -42,23 +42,30 @@
 
 #include "pins_RUMBA32_common.h"
 
-#define SERVO0_PIN                        PA15 // Pin is not broken out, is a test point only.
+#define X_MIN_PIN                           PB12
+
+#define SERVO0_PIN                          PA15  // Pin is not broken out, is a test point only.
 #undef BTN_PIN
 
 #if HAS_TMC_UART
   //
-  // TMC2208/TMC2209 stepper drivers - Software Serial is used according to below pins
+  // TMC2208/TMC2209 Software Serial
   //
-  #define X_SERIAL_TX_PIN                 PC14 // BTT Rumba32 only uses 1 pin for uart
-  #define X_SERIAL_RX_PIN                 PC14
-  #define Y_SERIAL_TX_PIN                 PE4
-  #define Y_SERIAL_RX_PIN                 PE4
-  #define Z_SERIAL_TX_PIN                 PE0
-  #define Z_SERIAL_RX_PIN                 PE0
-  #define E0_SERIAL_TX_PIN                PC13
-  #define E0_SERIAL_RX_PIN                PC13
-  #define E1_SERIAL_TX_PIN                PD5
-  #define E1_SERIAL_RX_PIN                PD5
-  #define E2_SERIAL_TX_PIN                PD1
-  #define E2_SERIAL_RX_PIN                PD1
+  #define X_SERIAL_TX_PIN                   PC14  // BTT Rumba32 only uses 1 pin for UART
+  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
+
+  #define Y_SERIAL_TX_PIN                   PE4
+  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
+
+  #define Z_SERIAL_TX_PIN                   PE0
+  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
+
+  #define E0_SERIAL_TX_PIN                  PC13
+  #define E0_SERIAL_RX_PIN      E0_SERIAL_TX_PIN
+
+  #define E1_SERIAL_TX_PIN                  PD5
+  #define E1_SERIAL_RX_PIN      E1_SERIAL_TX_PIN
+
+  #define E2_SERIAL_TX_PIN                  PD1
+  #define E2_SERIAL_RX_PIN      E2_SERIAL_TX_PIN
 #endif

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
@@ -42,10 +42,7 @@
 
 #include "pins_RUMBA32_common.h"
 
-#define X_MIN_PIN                           PB12
-
 #define SERVO0_PIN                          PA15  // Pin is not broken out, is a test point only.
-#undef BTN_PIN
 
 #if HAS_TMC_UART
   //

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
@@ -53,16 +53,12 @@
   #define X_SERIAL_RX_PIN                 PC14
   #define Y_SERIAL_TX_PIN                 PE4
   #define Y_SERIAL_RX_PIN                 PE4
-
   #define Z_SERIAL_TX_PIN                 PE0
   #define Z_SERIAL_RX_PIN                 PE0
-
   #define E0_SERIAL_TX_PIN                PC13
   #define E0_SERIAL_RX_PIN                PC13
-
   #define E1_SERIAL_TX_PIN                PD5
   #define E1_SERIAL_RX_PIN                PD5
-
   #define E2_SERIAL_TX_PIN                PD1
   #define E2_SERIAL_RX_PIN                PD1
 #endif

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
@@ -134,7 +134,6 @@
 // Misc. Functions
 //
 #define LED_PIN                             PB14
-#define BTN_PIN                             PC10
 #define PS_ON_PIN                           PE11
 #define KILL_PIN                            PC5
 


### PR DESCRIPTION
### Description

The BIGTREETECH RUMBA32 is not fully compatible with BOARD_RUMBA32_V1_1, 
Despite BTT guthub example config saying it uses this motherboard.
The TMC UART serial pins are different. As noted in this issue. https://github.com/bigtreetech/Rumba32/issues/1
 
So I've added motherboard  BOARD_RUMBA32_BTT 

### Requirements

A BTT RUMBA32 controller

### Benefits

Works as expected

### Configurations

#define MOTHERBOARD BOARD_RUMBA32_BTT

### Related Issues
https://github.com/bigtreetech/Rumba32/issues/1
I was helping out a user in Marlin Discord trinamic with "tmc connection error" on their btt rumba32
They confirmed these new pins fixes the issue.    