### PR TITLE
MAX31865 enhancements

### DIFF
--- a/Marlin/src/libs/MAX31865.h
+++ b/Marlin/src/libs/MAX31865.h
@@ -90,7 +90,9 @@ private:
   static SPISettings spiConfig;
 
   TERN(LARGE_PINMAP, uint32_t, uint8_t) _sclk, _miso, _mosi, _cs;
+#if defined(TARGET_LPC1768)
   uint8_t _spi_speed;
+#endif
   float Rzero, Rref;
 
   void setConfig(uint8_t config, bool enable);
@@ -101,9 +103,6 @@ private:
 
   void writeRegister8(uint8_t addr, uint8_t reg);
   uint8_t spixfer(uint8_t addr);
-
-  // Writes value to pin, also factoring in speed of SPI transmission
-  void write(pin_t pin, bool value);
 
 public:
   #ifdef LARGE_PINMAP

--- a/Marlin/src/libs/MAX31865.h
+++ b/Marlin/src/libs/MAX31865.h
@@ -90,9 +90,7 @@ private:
   static SPISettings spiConfig;
 
   TERN(LARGE_PINMAP, uint32_t, uint8_t) _sclk, _miso, _mosi, _cs;
-#if defined(TARGET_LPC1768)
   uint8_t _spi_speed;
-#endif
   float Rzero, Rref;
 
   void setConfig(uint8_t config, bool enable);

--- a/Marlin/src/libs/MAX31865.h
+++ b/Marlin/src/libs/MAX31865.h
@@ -90,6 +90,7 @@ private:
   static SPISettings spiConfig;
 
   TERN(LARGE_PINMAP, uint32_t, uint8_t) _sclk, _miso, _mosi, _cs;
+  uint8_t _spi_speed;
   float Rzero, Rref;
 
   void setConfig(uint8_t config, bool enable);
@@ -100,6 +101,9 @@ private:
 
   void writeRegister8(uint8_t addr, uint8_t reg);
   uint8_t spixfer(uint8_t addr);
+
+  // Writes value to pin, also factoring in speed of SPI transmission
+  void write(pin_t pin, bool value);
 
 public:
   #ifdef LARGE_PINMAP


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
- Fix SPI mode typo
- Use software SPI library for software SPI mode
- Added timings/delays for sck and cs signals to match SPI speed
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->
Software SPI now uses the `<SoftwareSPI.h>` dependency. Not quite sure which board is or is not compatible, but i assume it should be compatible with all

### Benefits

<!-- What does this PR fix or improve? -->
Using the software SPI library, SPI clock speed can now be regulated, hopefully this means more compatibility with boards of different speeds. So far this PR will work with SKR E3 Turbo

### Configurations

No additional configurations apart from the original settings to enable MAX31865

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
Might Fix #22526