### PR TITLE
[WIP] Fix melzi_optiboot board_upload.maximum_size

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -329,7 +329,7 @@
 #elif MB(OMCA)
   #include "sanguino/pins_OMCA.h"               // ATmega644P, ATmega644                  env:sanguino644p
 #elif MB(ANET_10)
-  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:sanguino1284p env:sanguino1284p_optimized
+  #include "sanguino/pins_ANET_10.h"            // ATmega1284P                            env:sanguino1284p env:sanguino1284p_optimized env:melzi_optiboot
 #elif MB(SETHI)
   #include "sanguino/pins_SETHI.h"              // ATmega644P, ATmega644, ATmega1284P     env:sanguino1284p_optimized env:sanguino1284p env:sanguino644p
 

--- a/Marlin/src/pins/sanguino/pins_ANET_10.h
+++ b/Marlin/src/pins/sanguino/pins_ANET_10.h
@@ -87,20 +87,20 @@
  */
 
 /**
- * Installation of Marlin
+ * OptiBoot Bootloader:
+ *   Optiboot is an alternative bootloader that can be flashed on the board to free up space for a larger firmware build.
+ *   See https://github.com/Optiboot/optiboot for more information.
  *
- *   For upload of Marlin onto the board with stock bootloader using the Arduino IDE, select 'Sanguino' in 
- *   'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.'
- *   For upload of Marlin onto the board with stock bootloader using Platformio, change the default_env in 
- *   platformio.ini to 'default_env = sanguino1284p' or 'default_env = sanguino1284p_optimized'.
  *
- *   optiboot is an alternative bootloader that can be burned onto the board to allow upload of larger firmware. 
- *   Information can be found at https://github.com/Optiboot/optiboot
- *   After burning the optiboot bootloader onto the board, Marlin can be uploaded onto the board as follows:
- *   For upload of Marlin onto the board with optiboot using the Arduino IDE, select 'Sanguino (Optiboot)' in 
- *   'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.'
- *   For upload of Marlin onto the board with optiboot using Platformio, change the default_env in platformio.ini 
- *   to 'default_env = melzi_optiboot'.
+ * Install Marlin with Arduino IDE:
+ *   For a board with the stock bootloader, select 'Sanguino' in 'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.'
+ *   For a board with OptiBoot, select 'Sanguino (Optiboot)' in 'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.'
+ *
+ * Install Marlin with PlatformIO IDE:
+ *   (NOTE: You can set a default build environment by editing the value of 'default_env' in 'platformio.ini'.
+ *          For the best user experience install the "Auto Build Marlin" extension.)
+ *   For a board with the stock bootloader use Build / Upload under the 'sanguino1284p' or 'sanguino1284p_optimized' target.
+ *   For a board with OptiBoot, use Build / Upload under the 'melzi_optiboot' target.
  */
 
 #if NOT_TARGET(__AVR_ATmega1284P__)

--- a/Marlin/src/pins/sanguino/pins_ANET_10.h
+++ b/Marlin/src/pins/sanguino/pins_ANET_10.h
@@ -86,8 +86,25 @@
  *   Many thanks to Hans Raaf (@oderwat) for developing the Anet-specific software and supporting the Anet community.
  */
 
+/**
+ * Installation of Marlin
+ *
+ *   For upload of Marlin onto the board with stock bootloader using the Arduino IDE, select 'Sanguino' in 
+ *   'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.'
+ *   For upload of Marlin onto the board with stock bootloader using Platformio, change the default_env in 
+ *   platformio.ini to 'default_env = sanguino1284p' or 'default_env = sanguino1284p_optimized'.
+ *
+ *   optiboot is an alternative bootloader that can be burned onto the board to allow upload of larger firmware. 
+ *   Information can be found at https://github.com/Optiboot/optiboot
+ *   After burning the optiboot bootloader onto the board, Marlin can be uploaded onto the board as follows:
+ *   For upload of Marlin onto the board with optiboot using the Arduino IDE, select 'Sanguino (Optiboot)' in 
+ *   'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.'
+ *   For upload of Marlin onto the board with optiboot using Platformio, change the default_env in platformio.ini 
+ *   to 'default_env = melzi_optiboot'.
+ */
+
 #if NOT_TARGET(__AVR_ATmega1284P__)
-  #error "Oops! Select 'Sanguino' in 'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.' (For PlatformIO, use 'melzi' or 'melzi_optiboot.')"
+  #error "Oops! Select 'Sanguino' in 'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.' (For PlatformIO, use 'sanguino1284p' or 'sanguino1284p_optimized'. With optiboot, use 'melzi_optiboot.')"
 #endif
 
 #define BOARD_INFO_NAME "Anet 1.0"

--- a/Marlin/src/pins/sanguino/pins_ANET_10.h
+++ b/Marlin/src/pins/sanguino/pins_ANET_10.h
@@ -91,7 +91,6 @@
  *   Optiboot is an alternative bootloader that can be flashed on the board to free up space for a larger firmware build.
  *   See https://github.com/Optiboot/optiboot for more information.
  *
- *
  * Install Marlin with Arduino IDE:
  *   For a board with the stock bootloader, select 'Sanguino' in 'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.'
  *   For a board with OptiBoot, select 'Sanguino (Optiboot)' in 'Tools > Board' and 'ATmega1284P' in 'Tools > Processor.'

--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -141,6 +141,7 @@ platform     = atmelavr
 extends      = common_avr8
 board        = sanguino_atmega1284p
 upload_speed = 115200
+board_upload.maximum_size = 130048
 
 #
 # Melzi and clones (Zonestar Melzi2 with tuned flags)


### PR DESCRIPTION
And allow melzi_optiboot for Anet V1.0 board with optiboot.

TODO: 
[ ] Test `env:melzi_optiboot` with different boards (needs help)

### Description

This explicitly sets `board_upload.maximum_size = 130048` for `env:melzi_optiboot` and allows compilation with ``default_envs= melzi_optiboot`. 

Background: Some time ago, board definition files in PlatformIO were changed to specify the complete flash size (maximumsize = 131072,). Since then, the melzi_optiboot environment was probably broken for all boards: We now need to have `board_upload.maximum_size = ...` in all `env`s to account for the bootloader size. 

### Requirements

Anet V1.0 board with optiboot bootloader

### Benefits

for melzi_optiboot, limit board_upload.maximum_size = 130048 to account for the optiboot bootloader size

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/22626