### PR TITLE
M42: Allow S0 & S1 analogWrite on PWM pins (STM32)

### DIFF
--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -127,7 +127,7 @@ void GcodeSuite::M42() {
 
   #ifdef ARDUINO_ARCH_STM32
     // A simple I/O will be set to 0 by analogWrite()
-    if (pin_status <= 1) return;
+    if (pin_status <= 1 && !PWM_PIN(pin)) return;
   #endif
   analogWrite(pin, pin_status);
 }


### PR DESCRIPTION
Handle the special case a pin is really PWM on STM32 (tested on TFT backlight)