### PR TITLE
Startup: tweak/clean serial heading message

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1279,14 +1279,13 @@ void setup() {
   HAL_clear_reset_source();
 
   SERIAL_ECHOLNPGM("Marlin " SHORT_BUILD_VERSION);
-  SERIAL_EOL();
   #if defined(STRING_DISTRIBUTION_DATE) && defined(STRING_CONFIG_H_AUTHOR)
     SERIAL_ECHO_MSG(
       " Last Updated: " STRING_DISTRIBUTION_DATE
       " | Author: " STRING_CONFIG_H_AUTHOR
     );
   #endif
-  SERIAL_ECHO_MSG("Compiled: " __DATE__);
+  SERIAL_ECHO_MSG(" Compiled: " __DATE__);
   SERIAL_ECHO_MSG(STR_FREE_MEMORY, freeMemory(), STR_PLANNER_BUFFER_BYTES, sizeof(block_t) * (BLOCK_BUFFER_SIZE));
 
   // Some HAL need precise delay adjustment

--- a/Marlin/src/feature/ethernet.cpp
+++ b/Marlin/src/feature/ethernet.cpp
@@ -147,7 +147,7 @@ void MarlinEthernet::check() {
           " | Author: " STRING_CONFIG_H_AUTHOR
         );
       #endif
-      telnetClient.println("Compiled: " __DATE__);
+      telnetClient.println(" Compiled: " __DATE__);
 
       SERIAL_ECHOLNPGM("Client connected");
       have_telnet_client = true;


### PR DESCRIPTION
Keep same indentation for "Last Updated:" and "Compiled:"
and remove the extra EOL after the version.

Sorry to bug you with such things :p i guess the extra space was put to show details about the version...