### PR TITLE
Index Motherboard rev03

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -97,6 +97,7 @@ jobs:
         - REMRAM_V1
         - BTT_SKR_SE_BX
         - chitu_f103
+        - Index_Mobo_Rev03
 
         # Put lengthy tests last
 

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -394,6 +394,7 @@
 #define BOARD_ANET_ET4P               4230  // ANET ET4P V1.x (STM32F407VGT6)
 #define BOARD_FYSETC_CHEETAH_V20      4231  // FYSETC Cheetah V2.0
 #define BOARD_TH3D_EZBOARD_LITE_V2    4232  // TH3D EZBoard Lite v2.0
+#define BOARD_INDEX_REV03             4233  // Index PnP Controller REV03 (STM32F407VET6/VGT6)
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -644,7 +644,7 @@
 #elif MB(TH3D_EZBOARD_LITE_V2)
   #include "stm32f4/pins_TH3D_EZBOARD_LITE_V2.h" // STM32F4                               env:TH3D_EZBoard_Lite_V2
 #elif MB(INDEX_REV03)
-  #include "stm32f4/pins_INDEX_REV03.h"         // STM32F4
+  #include "stm32f4/pins_INDEX_REV03.h"         // STM32F4                                env:Index_Mobo_Rev03
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -643,6 +643,8 @@
   #include "stm32f4/pins_MKS_MONSTER8.h"        // STM32F4                                env:mks_monster8 env:mks_monster8_usb_flash_drive env:mks_monster8_usb_flash_drive_msc
 #elif MB(TH3D_EZBOARD_LITE_V2)
   #include "stm32f4/pins_TH3D_EZBOARD_LITE_V2.h" // STM32F4                               env:TH3D_EZBoard_Lite_V2
+#elif MB(INDEX_REV03)
+  #include "stm32f4/pins_INDEX_REV03.h"         // STM32F4
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -35,15 +35,21 @@
 
 #define DEFAULT_MACHINE_NAME "Index Pick and Place"
 
-//#define I2C_EEPROM
+/*
+By default, the extra stepper motor configuration is:
+  I = Left Head
+  J = Right Head
+  K = Auxiliary (Conveyor belt)
+*/
+
 #define SRAM_EEPROM_EMULATION
-#define MARLIN_EEPROM_SIZE                0x2000  // 8KB
+#define MARLIN_EEPROM_SIZE                  0x2000  // 8KB
 
 //
 // Servos
 //
-#define SERVO0_PIN                          PB6
-#define SERVO1_PIN                          PB7
+#define SERVO0_PIN                          PB10
+#define SERVO1_PIN                          PB11
 
 //
 // Limit Switches
@@ -54,12 +60,15 @@
 #define Y_MAX_PIN                           -1
 #define Z_MIN_PIN                           PD14
 #define Z_MAX_PIN                           -1
-#define I_MIN_PIN                           -1
-#define I_MAX_PIN                           -1
-#define J_MIN_PIN                           -1
-#define J_MAX_PIN                           -1
-#define K_MIN_PIN                           -1
-#define K_MAX_PIN                           -1
+
+// None of these require limit switches by default, so we leave these commented
+// here for your reference.
+// #define I_MIN_PIN                           PA8
+// #define I_MAX_PIN                           PA8
+// #define J_MIN_PIN                           PD13
+// #define J_MAX_PIN                           PD13
+// #define K_MIN_PIN                           PC9
+// #define K_MAX_PIN                           PC9
 
 //
 // Steppers
@@ -67,50 +76,88 @@
 #define X_STEP_PIN                          PB15
 #define X_DIR_PIN                           PB14
 #define X_ENABLE_PIN                        PD9
+#define X_SERIAL_TX_PIN                     PD8
+#define X_SERIAL_RX_PIN                     PD8
 
 #define Y_STEP_PIN                          PE15
 #define Y_DIR_PIN                           PE14
 #define Y_ENABLE_PIN                        PB13
+#define Y_SERIAL_TX_PIN                     PB12
+#define Y_SERIAL_RX_PIN                     PB12
 
 #define Z_STEP_PIN                          PE7
 #define Z_DIR_PIN                           PB1
 #define Z_ENABLE_PIN                        PE9
+#define Z_SERIAL_TX_PIN                     PE8
+#define Z_SERIAL_RX_PIN                     PE8
 
-#define I_STEP_PIN                         PC4
-#define I_DIR_PIN                          PA4
-#define I_ENABLE_PIN                       PB0
+#define I_STEP_PIN                          PC4
+#define I_DIR_PIN                           PA4
+#define I_ENABLE_PIN                        PB0
+#define I_SERIAL_TX_PIN                     PC5
+#define I_SERIAL_RX_PIN                     PC5
 
-#define J_STEP_PIN                         PE11
-#define J_DIR_PIN                          PE10
-#define J_ENABLE_PIN                       PE13
+#define J_STEP_PIN                          PE11
+#define J_DIR_PIN                           PE10
+#define J_ENABLE_PIN                        PE13
+#define J_SERIAL_TX_PIN                     PE12
+#define J_SERIAL_RX_PIN                     PE12
+#define K_SERIAL_TX_PIN                     PA2
+#define K_SERIAL_RX_PIN                     PA2
 
-#define K_STEP_PIN                         PC_15  // Not an Arduino pin, might need a new board config
-#define K_DIR_PIN                          PC_14  // Not an Arduino pin, might need a new board config
-#define K_ENABLE_PIN                       PA3
-
-#define X_SERIAL_TX_PIN                    PD8
-#define X_SERIAL_RX_PIN                    PD8
-#define Y_SERIAL_TX_PIN                    PB12
-#define Y_SERIAL_RX_PIN                    PB12
-#define Z_SERIAL_TX_PIN                    PE8
-#define Z_SERIAL_RX_PIN                    PE8
-#define I_SERIAL_TX_PIN                    PC5
-#define I_SERIAL_RX_PIN                    PC5
-#define J_SERIAL_TX_PIN                    PE12
-#define J_SERIAL_RX_PIN                    PE12
-#define K_SERIAL_TX_PIN                    PA2
-#define K_SERIAL_RX_PIN                    PA2
+#define K_STEP_PIN                          PD6
+#define K_DIR_PIN                           PD7
+#define K_ENABLE_PIN                        PA3
 
 // Reduce baud rate to improve software serial reliability
-#define TMC_BAUD_RATE                    19200
+#define TMC_BAUD_RATE                       19200
 
-#define TEMP_0_PIN  PD0 // Not required for this board, really
+// Not required for this board. Fails to compile otherwise.
+// PD0 is not connected on this board.
+#define TEMP_0_PIN  PD0
 
-#define MOSFET_A_PIN                       PE2
-#define MOSFET_B_PIN                       PE3
-#define MOSFET_C_PIN                       PE4
-#define MOSFET_D_PIN                       PE5
+// General use mosfets, useful for things like pumps and solenoids
+#define FAN_PIN                             PE2
+#define FAN1_PIN                            PE3
+#define FAN2_PIN                            PE4
+#define FAN3_PIN                            PE5
 
 // Neopixel Rings
 #define NEOPIXEL_PIN                        PC7
 #define NEOPIXEL2_PIN                       PC8
+
+// SPI
+#define MISO_PIN                            PB4
+#define MOSI_PIN                            PB5
+#define SCK_PIN                             PB3
+
+// I2C
+#define I2C_SDA_PIN                         PB7
+#define I2C_SCL_PIN                         PB6
+
+/*
+The index mobo rev03 has 3 aux ports. We define them here so they may be used
+in other places and to make sure someone doesn't have to go look up the pinout
+in the board files. Each 12 pin aux port has this pinout:
+
+VDC    1   2    GND
+3.3V   3   4    SCL  (I2C_SCL_PIN)
+PWM1   5   6    SDA  (I2C_SDA_PIN)
+PWM2   7   8    CIPO (MISO_PIN)
+A1     9  10    COPI (MOSI_PIN)
+A2     11 12    SCK  (SCK_PIN)
+*/
+#define INDEX_AUX1_PWM1                     PA15
+#define INDEX_AUX1_PWM2                     PA5
+#define INDEX_AUX1_A1                       PC0
+#define INDEX_AUX1_A2                       PC1
+
+#define INDEX_AUX2_PWM1                     PA6
+#define INDEX_AUX2_PWM2                     PA7
+#define INDEX_AUX2_A1                       PC2
+#define INDEX_AUX2_A2                       PC3
+
+#define INDEX_AUX3_PWM1                     PB8
+#define INDEX_AUX3_PWM2                     PB9
+#define INDEX_AUX3_A1                       PA0
+#define INDEX_AUX3_A2                       PA1

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -1,0 +1,164 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * STM32F407VET6 with RAMPS-like shield
+ * 'Black' STM32F407VET6 board - https://www.stm32duino.com/viewtopic.php?t=485
+ * Shield - https://github.com/jmz52/Hardware
+ */
+
+#define ALLOW_STM32DUINO
+#include "env_validate.h"
+
+#if HOTENDS > 2 || E_STEPPERS > 2
+  #error "Black STM32F4VET6 supports up to 2 hotends / E-steppers."
+#endif
+
+#ifndef BOARD_INFO_NAME
+  #define BOARD_INFO_NAME "Black STM32F4VET6"
+#endif
+
+#define DEFAULT_MACHINE_NAME "STM32F407VET6"
+
+//#define I2C_EEPROM
+#define SRAM_EEPROM_EMULATION
+#define MARLIN_EEPROM_SIZE                0x2000  // 8KB
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PC6
+#define SERVO1_PIN                          PC7
+
+//
+// Limit Switches
+//
+#define X_MIN_PIN                           PC13
+#define X_MAX_PIN                           PA15
+#define Y_MIN_PIN                           PA5
+#define Y_MAX_PIN                           PD12
+#define Z_MIN_PIN                           PD14
+#define Z_MAX_PIN                           PD15
+
+//
+// Steppers
+//
+#define X_STEP_PIN                          PC4
+#define X_DIR_PIN                           PA4
+#define X_ENABLE_PIN                        PE7
+
+#define Y_STEP_PIN                          PE5
+#define Y_DIR_PIN                           PE2
+#define Y_ENABLE_PIN                        PE6
+
+#define Z_STEP_PIN                          PD5
+#define Z_DIR_PIN                           PD3
+#define Z_ENABLE_PIN                        PD6
+
+#define E0_STEP_PIN                         PD7
+#define E0_DIR_PIN                          PD0
+#define E0_ENABLE_PIN                       PB9
+
+#define E1_STEP_PIN                         PE0
+#define E1_DIR_PIN                          PE1
+#define E1_ENABLE_PIN                       PB8
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN                          PC0   // T0
+#define TEMP_1_PIN                          PC1   // T1
+#define TEMP_BED_PIN                        PC2   // TB
+
+#ifndef TEMP_CHAMBER_PIN
+  #define TEMP_CHAMBER_PIN                  PC3   // TC
+#endif
+
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                        PA2   // Heater0
+#define HEATER_1_PIN                        PA3   // Heater1
+#define HEATER_BED_PIN                      PA1   // Hotbed
+
+#define FAN_PIN                             PE9   // Fan0
+#define FAN1_PIN                            PE11  // Fan1
+#define FAN2_PIN                            PE13  // Fan2
+#define FAN3_PIN                            PE14  // Fan3
+
+//
+// Misc. Functions
+//
+#define LED_PIN                             PA6
+//#define LED_PIN                           PA7
+#define KILL_PIN                            PB1
+
+//
+// LCD / Controller
+//
+//#define SD_DETECT_PIN                     PC5
+//#define SD_DETECT_PIN                     PA8   // SDIO SD_DETECT_PIN, external SDIO card reader only
+
+#define BEEPER_PIN                          PD10
+#define LCD_PINS_RS                         PE15
+#define LCD_PINS_ENABLE                     PD8
+#define LCD_PINS_D4                         PE10
+#define LCD_PINS_D5                         PE12
+#define LCD_PINS_D6                         PD1
+#define LCD_PINS_D7                         PE8
+#define BTN_ENC                             PD9
+#define BTN_EN1                             PD4
+#define BTN_EN2                             PD13
+
+#define DOGLCD_CS                    LCD_PINS_D5
+#define DOGLCD_A0                    LCD_PINS_D6
+
+#if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+  #define BTN_ENC_EN                 LCD_PINS_D7  // Detect the presence of the encoder
+#endif
+
+//
+// Onboard SD support
+//
+#define SDIO_D0_PIN                         PC8
+#define SDIO_D1_PIN                         PC9
+#define SDIO_D2_PIN                         PC10
+#define SDIO_D3_PIN                         PC11
+#define SDIO_CK_PIN                         PC12
+#define SDIO_CMD_PIN                        PD2
+
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION              ONBOARD
+#endif
+
+#if SD_CONNECTION_IS(ONBOARD)
+  #define SDIO_SUPPORT                            // Use SDIO for onboard SD
+
+  #ifndef SDIO_SUPPORT
+    #define SOFTWARE_SPI                          // Use soft SPI for onboard SD
+    #define SDSS                     SDIO_D3_PIN
+    #define SD_SCK_PIN               SDIO_CK_PIN
+    #define SD_MISO_PIN              SDIO_D0_PIN
+    #define SD_MOSI_PIN             SDIO_CMD_PIN
+  #endif
+#endif

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -22,23 +22,18 @@
 #pragma once
 
 /**
- * STM32F407VET6 with RAMPS-like shield
- * 'Black' STM32F407VET6 board - https://www.stm32duino.com/viewtopic.php?t=485
- * Shield - https://github.com/jmz52/Hardware
+ * STM32F407VET6 on Index PnP Mobo Rev03
+ * Website - https://indexmachines.io/
  */
 
 #define ALLOW_STM32DUINO
 #include "env_validate.h"
 
-#if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Black STM32F4VET6 supports up to 2 hotends / E-steppers."
-#endif
-
 #ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME "Black STM32F4VET6"
+  #define BOARD_INFO_NAME "Index Mobo Rev03"
 #endif
 
-#define DEFAULT_MACHINE_NAME "STM32F407VET6"
+#define DEFAULT_MACHINE_NAME "Index Pick and Place"
 
 //#define I2C_EEPROM
 #define SRAM_EEPROM_EMULATION
@@ -47,118 +42,75 @@
 //
 // Servos
 //
-#define SERVO0_PIN                          PC6
-#define SERVO1_PIN                          PC7
+#define SERVO0_PIN                          PB6
+#define SERVO1_PIN                          PB7
 
 //
 // Limit Switches
 //
-#define X_MIN_PIN                           PC13
-#define X_MAX_PIN                           PA15
-#define Y_MIN_PIN                           PA5
-#define Y_MAX_PIN                           PD12
+#define X_MIN_PIN                           PC6
+#define X_MAX_PIN                           -1
+#define Y_MIN_PIN                           PD15
+#define Y_MAX_PIN                           -1
 #define Z_MIN_PIN                           PD14
-#define Z_MAX_PIN                           PD15
+#define Z_MAX_PIN                           -1
+#define I_MIN_PIN                           -1
+#define I_MAX_PIN                           -1
+#define J_MIN_PIN                           -1
+#define J_MAX_PIN                           -1
+#define K_MIN_PIN                           -1
+#define K_MAX_PIN                           -1
 
 //
 // Steppers
 //
-#define X_STEP_PIN                          PC4
-#define X_DIR_PIN                           PA4
-#define X_ENABLE_PIN                        PE7
+#define X_STEP_PIN                          PB15
+#define X_DIR_PIN                           PB14
+#define X_ENABLE_PIN                        PD9
 
-#define Y_STEP_PIN                          PE5
-#define Y_DIR_PIN                           PE2
-#define Y_ENABLE_PIN                        PE6
+#define Y_STEP_PIN                          PE15
+#define Y_DIR_PIN                           PE14
+#define Y_ENABLE_PIN                        PB13
 
-#define Z_STEP_PIN                          PD5
-#define Z_DIR_PIN                           PD3
-#define Z_ENABLE_PIN                        PD6
+#define Z_STEP_PIN                          PE7
+#define Z_DIR_PIN                           PB1
+#define Z_ENABLE_PIN                        PE9
 
-#define E0_STEP_PIN                         PD7
-#define E0_DIR_PIN                          PD0
-#define E0_ENABLE_PIN                       PB9
+#define I_STEP_PIN                         PC4
+#define I_DIR_PIN                          PA4
+#define I_ENABLE_PIN                       PB0
 
-#define E1_STEP_PIN                         PE0
-#define E1_DIR_PIN                          PE1
-#define E1_ENABLE_PIN                       PB8
+#define J_STEP_PIN                         PE11
+#define J_DIR_PIN                          PE10
+#define J_ENABLE_PIN                       PE13
 
-//
-// Temperature Sensors
-//
-#define TEMP_0_PIN                          PC0   // T0
-#define TEMP_1_PIN                          PC1   // T1
-#define TEMP_BED_PIN                        PC2   // TB
+#define K_STEP_PIN                         PC_15  // Not an Arduino pin, might need a new board config
+#define K_DIR_PIN                          PC_14  // Not an Arduino pin, might need a new board config
+#define K_ENABLE_PIN                       PA3
 
-#ifndef TEMP_CHAMBER_PIN
-  #define TEMP_CHAMBER_PIN                  PC3   // TC
-#endif
+#define X_SERIAL_TX_PIN                    PD8
+#define X_SERIAL_RX_PIN                    PD8
+#define Y_SERIAL_TX_PIN                    PB12
+#define Y_SERIAL_RX_PIN                    PB12
+#define Z_SERIAL_TX_PIN                    PE8
+#define Z_SERIAL_RX_PIN                    PE8
+#define I_SERIAL_TX_PIN                    PC5
+#define I_SERIAL_RX_PIN                    PC5
+#define J_SERIAL_TX_PIN                    PE12
+#define J_SERIAL_RX_PIN                    PE12
+#define K_SERIAL_TX_PIN                    PA2
+#define K_SERIAL_RX_PIN                    PA2
 
-//
-// Heaters / Fans
-//
-#define HEATER_0_PIN                        PA2   // Heater0
-#define HEATER_1_PIN                        PA3   // Heater1
-#define HEATER_BED_PIN                      PA1   // Hotbed
+// Reduce baud rate to improve software serial reliability
+#define TMC_BAUD_RATE                    19200
 
-#define FAN_PIN                             PE9   // Fan0
-#define FAN1_PIN                            PE11  // Fan1
-#define FAN2_PIN                            PE13  // Fan2
-#define FAN3_PIN                            PE14  // Fan3
+#define TEMP_0_PIN  PD0 // Not required for this board, really
 
-//
-// Misc. Functions
-//
-#define LED_PIN                             PA6
-//#define LED_PIN                           PA7
-#define KILL_PIN                            PB1
+#define MOSFET_A_PIN                       PE2
+#define MOSFET_B_PIN                       PE3
+#define MOSFET_C_PIN                       PE4
+#define MOSFET_D_PIN                       PE5
 
-//
-// LCD / Controller
-//
-//#define SD_DETECT_PIN                     PC5
-//#define SD_DETECT_PIN                     PA8   // SDIO SD_DETECT_PIN, external SDIO card reader only
-
-#define BEEPER_PIN                          PD10
-#define LCD_PINS_RS                         PE15
-#define LCD_PINS_ENABLE                     PD8
-#define LCD_PINS_D4                         PE10
-#define LCD_PINS_D5                         PE12
-#define LCD_PINS_D6                         PD1
-#define LCD_PINS_D7                         PE8
-#define BTN_ENC                             PD9
-#define BTN_EN1                             PD4
-#define BTN_EN2                             PD13
-
-#define DOGLCD_CS                    LCD_PINS_D5
-#define DOGLCD_A0                    LCD_PINS_D6
-
-#if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
-  #define BTN_ENC_EN                 LCD_PINS_D7  // Detect the presence of the encoder
-#endif
-
-//
-// Onboard SD support
-//
-#define SDIO_D0_PIN                         PC8
-#define SDIO_D1_PIN                         PC9
-#define SDIO_D2_PIN                         PC10
-#define SDIO_D3_PIN                         PC11
-#define SDIO_CK_PIN                         PC12
-#define SDIO_CMD_PIN                        PD2
-
-#ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION              ONBOARD
-#endif
-
-#if SD_CONNECTION_IS(ONBOARD)
-  #define SDIO_SUPPORT                            // Use SDIO for onboard SD
-
-  #ifndef SDIO_SUPPORT
-    #define SOFTWARE_SPI                          // Use soft SPI for onboard SD
-    #define SDSS                     SDIO_D3_PIN
-    #define SD_SCK_PIN               SDIO_CK_PIN
-    #define SD_MISO_PIN              SDIO_D0_PIN
-    #define SD_MOSI_PIN             SDIO_CMD_PIN
-  #endif
-#endif
+// Neopixel Rings
+#define NEOPIXEL_PIN                        PC7
+#define NEOPIXEL2_PIN                       PC8

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -29,21 +29,18 @@
 #define ALLOW_STM32DUINO
 #include "env_validate.h"
 
-#ifndef BOARD_INFO_NAME
-  #define BOARD_INFO_NAME "Index Mobo Rev03"
-#endif
-
+#define BOARD_INFO_NAME      "Index Mobo Rev03"
 #define DEFAULT_MACHINE_NAME "Index Pick and Place"
 
-/*
-By default, the extra stepper motor configuration is:
-  I = Left Head
-  J = Right Head
-  K = Auxiliary (Conveyor belt)
-*/
+/**
+ * By default, the extra stepper motor configuration is:
+ * I = Left Head
+ * J = Right Head
+ * K = Auxiliary (Conveyor belt)
+ */
 
 #define SRAM_EEPROM_EMULATION
-#define MARLIN_EEPROM_SIZE                  0x2000  // 8KB
+#define MARLIN_EEPROM_SIZE                0x2000  // 8KB
 
 //
 // Servos
@@ -54,12 +51,9 @@ By default, the extra stepper motor configuration is:
 //
 // Limit Switches
 //
-#define X_MIN_PIN                           PC6
-#define X_MAX_PIN                           -1
-#define Y_MIN_PIN                           PD15
-#define Y_MAX_PIN                           -1
-#define Z_MIN_PIN                           PD14
-#define Z_MAX_PIN                           -1
+#define X_STOP_PIN                          PC6
+#define Y_STOP_PIN                          PD15
+#define Z_STOP_PIN                          PD14
 
 // None of these require limit switches by default, so we leave these commented
 // here for your reference.
@@ -110,11 +104,11 @@ By default, the extra stepper motor configuration is:
 #define K_ENABLE_PIN                        PA3
 
 // Reduce baud rate to improve software serial reliability
-#define TMC_BAUD_RATE                       19200
+#define TMC_BAUD_RATE                      19200
 
 // Not required for this board. Fails to compile otherwise.
 // PD0 is not connected on this board.
-#define TEMP_0_PIN  PD0
+#define TEMP_0_PIN                          PD0
 
 // General use mosfets, useful for things like pumps and solenoids
 #define FAN_PIN                             PE2
@@ -135,18 +129,18 @@ By default, the extra stepper motor configuration is:
 #define I2C_SDA_PIN                         PB7
 #define I2C_SCL_PIN                         PB6
 
-/*
-The index mobo rev03 has 3 aux ports. We define them here so they may be used
-in other places and to make sure someone doesn't have to go look up the pinout
-in the board files. Each 12 pin aux port has this pinout:
-
-VDC    1   2    GND
-3.3V   3   4    SCL  (I2C_SCL_PIN)
-PWM1   5   6    SDA  (I2C_SDA_PIN)
-PWM2   7   8    CIPO (MISO_PIN)
-A1     9  10    COPI (MOSI_PIN)
-A2     11 12    SCK  (SCK_PIN)
-*/
+/**
+ * The index mobo rev03 has 3 aux ports. We define them here so they may be used
+ * in other places and to make sure someone doesn't have to go look up the pinout
+ * in the board files. Each 12 pin aux port has this pinout:
+ *
+ * VDC    1   2    GND
+ * 3.3V   3   4    SCL  (I2C_SCL_PIN)
+ * PWM1   5   6    SDA  (I2C_SDA_PIN)
+ * PWM2   7   8    CIPO (MISO_PIN)
+ * A1     9  10    COPI (MOSI_PIN)
+ * A2     11 12    SCK  (SCK_PIN)
+ */
 #define INDEX_AUX1_PWM1                     PA15
 #define INDEX_AUX1_PWM2                     PA5
 #define INDEX_AUX1_A1                       PC0

--- a/buildroot/share/PlatformIO/boards/marlin_index_mobo_rev03.json
+++ b/buildroot/share/PlatformIO/boards/marlin_index_mobo_rev03.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32F407xx",
+    "f_cpu": "168000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x0483",
+        "0x3748"
+      ],
+      [
+        "0x0483",
+        "0xdf11"
+      ]
+    ],
+    "mcu": "stm32f407vet6",
+    "variant": "MARLIN_F407VE"
+  },
+  "debug": {
+    "jlink_device": "STM32F407VE",
+    "openocd_target": "stm32f4x",
+    "svd_path": "STM32F40x.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "stm32cube"
+  ],
+  "name": "STM32F407VE (192k RAM. 512k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 131072,
+    "maximum_size": 524288,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "dfu",
+      "jlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f407ve.html",
+  "vendor": "Generic"
+}

--- a/buildroot/share/PlatformIO/boards/marlin_index_mobo_rev03.json
+++ b/buildroot/share/PlatformIO/boards/marlin_index_mobo_rev03.json
@@ -39,7 +39,8 @@
     "protocols": [
       "stlink",
       "dfu",
-      "jlink"
+      "jlink",
+      "blackmagic"
     ],
     "require_upload_port": true,
     "use_1200bps_touch": false,

--- a/buildroot/tests/Index_Mobo_Rev03
+++ b/buildroot/tests/Index_Mobo_Rev03
@@ -6,8 +6,8 @@
 # exit on first failure
 set -e
 
-restore_configs
-exec_test $1 $2 "Index_Mobo_Rev03" "$3"
+use_example_configs Index/REV_03
+exec_test $1 $2 "Index REV03 Pick and Place" "$3"
 
 # cleanup
 restore_configs

--- a/buildroot/tests/Index_Mobo_Rev03
+++ b/buildroot/tests/Index_Mobo_Rev03
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# Build tests for Index_Mobo_Rev03
+#
+
+# exit on first failure
+set -e
+
+restore_configs
+exec_test $1 $2 "Index_Mobo_Rev03" "$3"
+
+# cleanup
+restore_configs

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -100,6 +100,18 @@ build_flags       = ${stm32_variant.build_flags}
                     -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
 
 #
+# STM32F407VET6 Index Mobo Rev 03
+#
+[env:Index_Mobo_Rev03]
+platform          = ${common_stm32.platform}
+extends           = common_stm32
+board             = marlin_index_mobo_rev03
+build_flags       = ${common_stm32.build_flags}
+  -DARDUINO_BLACK_F407VE
+  -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
+extra_scripts     = ${common.extra_scripts}
+
+#
 # Anet ET4-MB_V1.x/ET4P-MB_V1.x (STM32F407VGT6 ARM Cortex-M4)
 # For use with with davidtgbe's OpenBLT bootloader https://github.com/davidtgbe/openblt/releases
 # Comment out board_build.offset = 0x10000 if you don't plan to use OpenBLT/flashing directly to 0x08000000.

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -104,12 +104,12 @@ build_flags       = ${stm32_variant.build_flags}
 #
 [env:Index_Mobo_Rev03]
 platform          = ${common_stm32.platform}
-extends           = common_stm32
+extends           = stm32_variant
 board             = marlin_index_mobo_rev03
-build_flags       = ${common_stm32.build_flags}
+build_flags       = ${stm32_variant.build_flags}
   -DARDUINO_BLACK_F407VE
   -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
-extra_scripts     = ${common.extra_scripts}
+extra_scripts     = ${stm32_variant.extra_scripts}
 
 #
 # Anet ET4-MB_V1.x/ET4P-MB_V1.x (STM32F407VGT6 ARM Cortex-M4)


### PR DESCRIPTION
### Description
The Index Pick and Place project by Stephen Hawes is an open source project used to assemble circuit boards. It's designed to be low cost and open source. The project decided to go with a custom motherboard based on the STM32F407VET6 chipset. This is one of a couple of diffs we would like to submit, the other big one being RS485 support for things like MODBUS and our custom protocol. For now, we wanted to get the board definition merged in mainline Marlin.

YouTube playlist: https://www.youtube.com/playlist?list=PLIeJXmcg1baLBz3x0nCDqkYpKs2IWGHk4
Website: https://indexmachines.io/

### Requirements
This PR is to add a new board, so yes it does require some custom hardware. That board is defined [here](https://github.com/index-machines/index/tree/mobo-rev03/pnp/pcb/mobo) and will eventually be for sale.

### Benefits
As far as I'm aware, this is the first time Marlin has been used on a custom pick and place board.

### Configurations
A work in progress configuration is available [here](https://github.com/index-machines/Marlin-Configurations/tree/index_config/config/examples/Index).

### Related Issues
No related issues.
