### PR TITLE
add X_MAX_PIN when  DUAL_X_CARRIAGE is enabled on BTT OCTOPUS

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -72,7 +72,7 @@
   #else
     #define X_MIN_PIN                E0_DIAG_PIN  // E0DET
   #endif
-#elif ENABLED(X_DUAL_ENDSTOPS)
+#elif EITHER(X_DUAL_ENDSTOPS, DUAL_X_CARRIAGE)
   #ifndef X_MIN_PIN
     #define X_MIN_PIN                 X_DIAG_PIN  // X-STOP
   #endif


### PR DESCRIPTION
### Description

Fixes issue #22648 "error "DUAL_X_CARRIAGE requires USE_XMAX_PLUG and an X Max Endstop.""
On a BTT OCTOPUS controller define a X_MAX_PIN when DUAL_X_CARRIAGE is enabled.

### Requirements

Default config with these chnages
#define MOTHERBOARD BOARD_BTT_OCTOPUS_V1_0 // or BOARD_BTT_OCTOPUS_V1_1
#define SERIAL_PORT -1
#define EXTRUDERS 2
#define TEMP_SENSOR_1 1
#define USE_XMAX_PLUG
#define DUAL_X_CARRIAGE

### Benefits

Compiles as expected

### Related Issues
Issue  #22648