### PR TITLE
Revert MAX31865 recent changes

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -755,13 +755,13 @@
   // to select a USER library for MAX6675, MAX31855, MAX31865
   //
   #if BOTH(HAS_MAX6675, LIB_MAX6675)
-    #define LIB_USR_MAX6675 1
+    #define USE_LIB_MAX6675 1
   #endif
   #if BOTH(HAS_MAX31855, LIB_MAX31855)
-    #define LIB_USR_MAX31855 1
+    #define USE_ADAFRUIT_MAX31855 1
   #endif
   #if BOTH(HAS_MAX31865, LIB_MAX31865)
-    #define LIB_USR_MAX31865 1
+    #define USE_ADAFRUIT_MAX31865 1
   #elif HAS_MAX31865
     #define LIB_INTERNAL_MAX31865 1
   #endif

--- a/Marlin/src/libs/MAX31865.cpp
+++ b/Marlin/src/libs/MAX31865.cpp
@@ -46,7 +46,7 @@
 
 #include "../inc/MarlinConfig.h"
 
-#if HAS_MAX31865 && !LIB_USR_MAX31865
+#if HAS_MAX31865 && !USE_ADAFRUIT_MAX31865
 
 #include <SoftwareSPI.h>
 #include "MAX31865.h"
@@ -488,4 +488,4 @@ uint8_t MAX31865::spixfer(uint8_t x) {
   return swSpiTransfer(x, _spi_speed, _sclk, _miso, _mosi);
 }
 
-#endif // HAS_MAX31865 && !LIB_USR_MAX31865
+#endif // HAS_MAX31865 && !USE_ADAFRUIT_MAX31865

--- a/Marlin/src/libs/MAX31865.cpp
+++ b/Marlin/src/libs/MAX31865.cpp
@@ -48,7 +48,7 @@
 
 #if HAS_MAX31865 && !USE_ADAFRUIT_MAX31865
 
-#include <SoftwareSPI.h>
+//#include <SoftwareSPI.h> // TODO: switch to SPIclass/SoftSPI
 #include "MAX31865.h"
 
 // The maximum speed the MAX31865 can do is 5 MHz
@@ -61,7 +61,7 @@ SPISettings MAX31865::spiConfig = SPISettings(
     500000
   #endif
   , MSBFIRST
-  , SPI_MODE1 // CPOL0 CPHA1
+  , SPI_MODE_1 // CPOL0 CPHA1
 );
 
 #ifndef LARGE_PINMAP
@@ -152,24 +152,23 @@ void MAX31865::begin(max31865_numwires_t wires, float zero, float ref) {
   OUT_WRITE(_cs, HIGH);
 
   if (_sclk != TERN(LARGE_PINMAP, -1UL, -1)) {
-    // define pin modes for Software SPI
+    // Define pin modes for Software SPI
     #ifdef MAX31865_DEBUG
       SERIAL_ECHOLN("Initializing MAX31865 Software SPI");
     #endif
 
-    swSpiBegin(_sclk, _miso, _mosi);
-
-  } else {
-    // start and configure hardware SPI
+    OUT_WRITE(_sclk, LOW);
+    SET_OUTPUT(_mosi);
+    SET_INPUT(_miso);
+  }
+  else {
+    // Start and configure hardware SPI
     #ifdef MAX31865_DEBUG
       SERIAL_ECHOLN("Initializing MAX31865 Hardware SPI");
     #endif
 
     SPI.begin();
   }
-
-  // SPI Begin must be called first, then init
-  _spi_speed = swSpiInit(SPI_QUARTER_SPEED, _sclk, _mosi);
 
   setWires(wires);
   enableBias(false);
@@ -485,7 +484,17 @@ uint8_t MAX31865::spixfer(uint8_t x) {
   if (_sclk == TERN(LARGE_PINMAP, -1UL, -1))
     return SPI.transfer(x);
 
-  return swSpiTransfer(x, _spi_speed, _sclk, _miso, _mosi);
+  uint8_t reply = 0;
+  for (int i = 7; i >= 0; i--) {
+    reply <<= 1;
+    WRITE(_sclk, HIGH);
+    WRITE(_mosi, x & (1 << i));
+    WRITE(_sclk, LOW);
+    if (READ(_miso))
+      reply |= 1;
+  }
+
+  return reply;
 }
 
 #endif // HAS_MAX31865 && !USE_ADAFRUIT_MAX31865

--- a/Marlin/src/libs/MAX31865.cpp
+++ b/Marlin/src/libs/MAX31865.cpp
@@ -44,12 +44,11 @@
 //#define MAX31865_DEBUG
 //#define MAX31865_DEBUG_SPI
 
-#include <SoftwareSPI.h>
-
 #include "../inc/MarlinConfig.h"
 
 #if HAS_MAX31865 && !LIB_USR_MAX31865
 
+#include <SoftwareSPI.h>
 #include "MAX31865.h"
 
 // The maximum speed the MAX31865 can do is 5 MHz
@@ -157,9 +156,9 @@ void MAX31865::begin(max31865_numwires_t wires, float zero, float ref) {
     #ifdef MAX31865_DEBUG
       SERIAL_ECHOLN("Initializing MAX31865 Software SPI");
     #endif
-    
+
     swSpiBegin(_sclk, _miso, _mosi);
-    
+
   } else {
     // start and configure hardware SPI
     #ifdef MAX31865_DEBUG

--- a/Marlin/src/libs/MAX31865.h
+++ b/Marlin/src/libs/MAX31865.h
@@ -90,7 +90,6 @@ private:
   static SPISettings spiConfig;
 
   TERN(LARGE_PINMAP, uint32_t, uint8_t) _sclk, _miso, _mosi, _cs;
-  uint8_t _spi_speed;
   float Rzero, Rref;
 
   void setConfig(uint8_t config, bool enable);

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -63,21 +63,21 @@
 
 // LIB_MAX6675 can be added to the build_flags in platformio.ini to use a user-defined library
 // If LIB_MAX6675 is not on the build_flags then raw SPI reads will be used.
-#if HAS_MAX6675 && LIB_USR_MAX6675
+#if HAS_MAX6675 && USE_LIB_MAX6675
   #include <max6675.h>
   #define HAS_MAX6675_LIBRARY 1
 #endif
 
 // LIB_MAX31855 can be added to the build_flags in platformio.ini to use a user-defined library.
 // If LIB_MAX31855 is not on the build_flags then raw SPI reads will be used.
-#if HAS_MAX31855 && LIB_USR_MAX31855
+#if HAS_MAX31855 && USE_ADAFRUIT_MAX31855
   #include <Adafruit_MAX31855.h>
   #define HAS_MAX31855_LIBRARY 1
   typedef Adafruit_MAX31855 MAX31855;
 #endif
 
 #if HAS_MAX31865
-  #if LIB_USR_MAX31865
+  #if USE_ADAFRUIT_MAX31865
     #include <Adafruit_MAX31865.h>
     typedef Adafruit_MAX31865 MAX31865;
   #else


### PR DESCRIPTION
### Description

Currently libs/MAX31865.cpp always includes SoftwareSPI.h
This breaks building on arduino IDE unless you install the library, even when not needed

Moved the include to after the test that it needed

This just fixes compiling under Arduino IDE when MAX31865 is not used., There are much larger issues with MAX3186 support on 8 bit machines..

### Requirements

Any build on arduino iIDE

### Benefits

Compiles as expected without always needing SoftwareSPI

### Related Issues
Was raised o Discord user Celifreo