### PR TITLE
Rebase of "Fix SDSUPPORT for SKR CR-6" (#22667)

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -165,6 +165,7 @@
 #if SD_CONNECTION_IS(ONBOARD)
   #define SD_DETECT_PIN                     PC4
   #define ONBOARD_SD_CS_PIN                 PA4   // Chip select for "System" SD card
+  #define SDSS                              ONBOARD_SD_CS_PIN
 #endif
 
 //


### PR DESCRIPTION
Because PRs from second-degree forks are broken, creating a clone of the original PR #22667.