### PR TITLE
Fix indentation of M43 for multi-name pin assignments on LPC176x

### DIFF
--- a/Marlin/src/HAL/LPC1768/pinsDebug.h
+++ b/Marlin/src/HAL/LPC1768/pinsDebug.h
@@ -35,7 +35,7 @@
 #define PRINT_ARRAY_NAME(x) do{ sprintf_P(buffer, PSTR("%-" STRINGIFY(MAX_NAME_LENGTH) "s"), pin_array[x].name); SERIAL_ECHO(buffer); }while(0)
 #define PRINT_PIN(p) do{ sprintf_P(buffer, PSTR("P%d_%02d"), LPC176x::pin_port(p), LPC176x::pin_bit(p)); SERIAL_ECHO(buffer); }while(0)
 #define PRINT_PIN_ANALOG(p) do{ sprintf_P(buffer, PSTR("_A%d     "), LPC176x::pin_get_adc_channel(pin)); SERIAL_ECHO(buffer); }while(0)
-#define MULTI_NAME_PAD 16 // space needed to be pretty if not first name assigned to a pin
+#define MULTI_NAME_PAD 17 // space needed to be pretty if not first name assigned to a pin
 
 // pins that will cause hang/reset/disconnect in M43 Toggle and Watch utilities
 #ifndef M43_NEVER_TOUCH


### PR DESCRIPTION
### Description

This PR fixes the indentation of multi-name pin output for M43 on LPC176x.

Before:
```
PIN: P0_16        LCD_SDSS                               Output = 1
.                SDSS                                   Output = 1
```

After:
```
PIN: P0_16        LCD_SDSS                               Output = 1
.                 SDSS                                   Output = 1
```

### Requirements

Any board using LPC176x.

### Benefits

M43 output looks nicer. 😎 

### Configurations

No special config required, but `PINS_DEBUGGING` must be enabled.

### Related Issues

Pin output format was changed from `x.yy` to `Px_yy` in #22611, increasing the width by one.