### PR TITLE
Adjust PID_PARAMS_PER_HOTEND comments

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -595,8 +595,8 @@
                                   // Set/get with gcode: M301 E[extruder number, 0-2]
 
   #if ENABLED(PID_PARAMS_PER_HOTEND)
-    // Specify between 1 and HOTENDS values per array.
-    // If fewer than HOTENDS values are provided, the last element will be repeated.
+    // Specify up to one value per hotend here, according to your setup.
+    // If there are fewer values, the last one applies to the remaining hotends.
     #define DEFAULT_Kp_LIST {  22.20,  22.20 }
     #define DEFAULT_Ki_LIST {   1.08,   1.08 }
     #define DEFAULT_Kd_LIST { 114.00, 114.00 }

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -596,7 +596,7 @@
 
   #if ENABLED(PID_PARAMS_PER_HOTEND)
     // Specify between 1 and HOTENDS values per array.
-    // If fewer than EXTRUDER values are provided, the last element will be repeated.
+    // If fewer than HOTENDS values are provided, the last element will be repeated.
     #define DEFAULT_Kp_LIST {  22.20,  22.20 }
     #define DEFAULT_Ki_LIST {   1.08,   1.08 }
     #define DEFAULT_Kd_LIST { 114.00, 114.00 }


### PR DESCRIPTION
### Description

This corrects a reference to the `HOTENDS` macro in a comment in `Configuration.h`. Previously the comment reference the `EXTRUDERS` macro.

### Requirements

None.

### Benefits

Minimal, just keeps the comment consistent with the comment above it.

### Configurations

N/A

### Related Issues

N/A