### PR TITLE
fix Creality v4.3.1 pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V431.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V431.h
@@ -31,10 +31,13 @@
 //
 // Steppers
 //
-#define X_STEP_PIN                        PB8
-#define X_DIR_PIN                         PB7
+#define X_STEP_PIN                        PC2
+#define X_DIR_PIN                         PB9
 
-#define Y_STEP_PIN                        PC2
-#define Y_DIR_PIN                         PB9
+#define Y_STEP_PIN                        PB8
+#define Y_DIR_PIN                         PB7
+
+#define E0_STEP_PIN                       PB3
+#define E0_DIR_PIN                        PB4
 
 #include "pins_CREALITY_V4.h"


### PR DESCRIPTION
### Description
fix Creality v4.3.1 pins

Pinout source from 
https://github.com/ginge/Ender6/blob/main/README.md
> https://docs.google.com/spreadsheets/d/1DYhh9fwLnvZzuNvMoBen9Dl68KN-4TWkbO94lJ4iwe4

tested by my own board

### Requirements
### Benefits
creality v4.3.1 board pins fix

### Configurations
### Related Issues