### PR TITLE
Correct E0 pins for Creality 4.3.1 board

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -339,17 +339,21 @@
 #define BOARD_CREALITY_V427           4040  // Creality v4.2.7 (STM32F103RE)
 #define BOARD_CREALITY_V4210          4041  // Creality v4.2.10 (STM32F103RE) as found in the CR-30
 #define BOARD_CREALITY_V431           4042  // Creality v4.3.1 (STM32F103RE)
-#define BOARD_CREALITY_V452           4043  // Creality v4.5.2 (STM32F103RE)
-#define BOARD_CREALITY_V453           4044  // Creality v4.5.3 (STM32F103RE)
-#define BOARD_TRIGORILLA_PRO          4045  // Trigorilla Pro (STM32F103ZET6)
-#define BOARD_FLY_MINI                4046  // FLYmaker FLY MINI (STM32F103RCT6)
-#define BOARD_FLSUN_HISPEED           4047  // FLSUN HiSpeedV1 (STM32F103VET6)
-#define BOARD_BEAST                   4048  // STM32F103RET6 Libmaple-based controller
-#define BOARD_MINGDA_MPX_ARM_MINI     4049  // STM32F103ZET6 Mingda MD-16
-#define BOARD_GTM32_PRO_VD            4050  // STM32F103VET6 controller
-#define BOARD_ZONESTAR_ZM3E2          4051  // Zonestar ZM3E2    (STM32F103RCT6)
-#define BOARD_ZONESTAR_ZM3E4          4052  // Zonestar ZM3E4 V1 (STM32F103VCT6)
-#define BOARD_ZONESTAR_ZM3E4V2        4053  // Zonestar ZM3E4 V2 (STM32F103VCT6)
+#define BOARD_CREALITY_V431_A         4043  // Creality v4.3.1a (STM32F103RE)
+#define BOARD_CREALITY_V431_B         4044  // Creality v4.3.1b (STM32F103RE)
+#define BOARD_CREALITY_V431_C         4045  // Creality v4.3.1c (STM32F103RE)
+#define BOARD_CREALITY_V431_D         4046  // Creality v4.3.1d (STM32F103RE)
+#define BOARD_CREALITY_V452           4047  // Creality v4.5.2 (STM32F103RE)
+#define BOARD_CREALITY_V453           4048  // Creality v4.5.3 (STM32F103RE)
+#define BOARD_TRIGORILLA_PRO          4049  // Trigorilla Pro (STM32F103ZET6)
+#define BOARD_FLY_MINI                4050  // FLYmaker FLY MINI (STM32F103RCT6)
+#define BOARD_FLSUN_HISPEED           4051  // FLSUN HiSpeedV1 (STM32F103VET6)
+#define BOARD_BEAST                   4052  // STM32F103RET6 Libmaple-based controller
+#define BOARD_MINGDA_MPX_ARM_MINI     4053  // STM32F103ZET6 Mingda MD-16
+#define BOARD_GTM32_PRO_VD            4054  // STM32F103VET6 controller
+#define BOARD_ZONESTAR_ZM3E2          4055  // Zonestar ZM3E2    (STM32F103RCT6)
+#define BOARD_ZONESTAR_ZM3E4          4056  // Zonestar ZM3E4 V1 (STM32F103VCT6)
+#define BOARD_ZONESTAR_ZM3E4V2        4057  // Zonestar ZM3E4 V2 (STM32F103VCT6)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -547,7 +547,7 @@
   #include "stm32f1/pins_CREALITY_V4210.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V427)
   #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
-#elif MB(CREALITY_V431)
+#elif MB(CREALITY_V431, CREALITY_V431_A, CREALITY_V431_B, CREALITY_V431_C, CREALITY_V431_D)
   #include "stm32f1/pins_CREALITY_V431.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V452)
   #include "stm32f1/pins_CREALITY_V452.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -88,37 +88,37 @@
 //
 // Steppers
 //
-#define X_ENABLE_PIN                        PC3
 #ifndef X_STEP_PIN
   #define X_STEP_PIN                        PC2
 #endif
 #ifndef X_DIR_PIN
   #define X_DIR_PIN                         PB9
 #endif
+#define X_ENABLE_PIN                        PC3   // Shared
 
-#define Y_ENABLE_PIN                        PC3
 #ifndef Y_STEP_PIN
   #define Y_STEP_PIN                        PB8
 #endif
 #ifndef Y_DIR_PIN
   #define Y_DIR_PIN                         PB7
 #endif
+#define Y_ENABLE_PIN                X_ENABLE_PIN
 
-#define Z_ENABLE_PIN                        PC3
 #ifndef Z_STEP_PIN
   #define Z_STEP_PIN                        PB6
 #endif
 #ifndef Z_DIR_PIN
   #define Z_DIR_PIN                         PB5
 #endif
+#define Z_ENABLE_PIN                X_ENABLE_PIN
 
-#define E0_ENABLE_PIN                       PC3
 #ifndef E0_STEP_PIN
   #define E0_STEP_PIN                       PB4
 #endif
 #ifndef E0_DIR_PIN
   #define E0_DIR_PIN                        PB3
 #endif
+#define E0_ENABLE_PIN               X_ENABLE_PIN
 
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V431.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V431.h
@@ -31,6 +31,12 @@
 //
 // Steppers
 //
+#define X_STEP_PIN                          PB8
+#define X_DIR_PIN                           PB7
+
+#define Y_STEP_PIN                          PC2
+#define Y_DIR_PIN                           PB9
+
 #define E0_STEP_PIN                         PB3
 #define E0_DIR_PIN                          PB4
 

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V431.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V431.h
@@ -31,13 +31,21 @@
 //
 // Steppers
 //
-#define X_STEP_PIN                          PB8
-#define X_DIR_PIN                           PB7
+#if MB(CREALITY_V431, CREALITY_V431_A, CREALITY_V431_B)
 
-#define Y_STEP_PIN                          PC2
-#define Y_DIR_PIN                           PB9
+  #define X_STEP_PIN                        PB8
+  #define X_DIR_PIN                         PB7
 
-#define E0_STEP_PIN                         PB3
-#define E0_DIR_PIN                          PB4
+  #define Y_STEP_PIN                        PC2
+  #define Y_DIR_PIN                         PB9
+
+#endif
+
+#if MB(CREALITY_V431_B, CREALITY_V431_C)
+
+  #define E0_STEP_PIN                       PB3
+  #define E0_DIR_PIN                        PB4
+
+#endif
 
 #include "pins_CREALITY_V4.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V431.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V431.h
@@ -31,10 +31,7 @@
 //
 // Steppers
 //
-#define X_STEP_PIN                        PB8
-#define X_DIR_PIN                         PB7
-
-#define Y_STEP_PIN                        PC2
-#define Y_DIR_PIN                         PB9
+#define E0_STEP_PIN                         PB3
+#define E0_DIR_PIN                          PB4
 
 #include "pins_CREALITY_V4.h"


### PR DESCRIPTION
As originally posted in #22703 by @Chicos123, with corrections according to [this spreadsheet](https://docs.google.com/spreadsheets/d/1DYhh9fwLnvZzuNvMoBen9Dl68KN-4TWkbO94lJ4iwe4/edit#gid=0).