### PR TITLE
G33 R and O options

### DIFF
--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -69,6 +69,8 @@ enum CalEnum : char {                        // the 7 main calibration points - 
 
 float lcd_probe_pt(const xy_pos_t &xy);
 
+float dcr;
+
 void ac_home() {
   endstops.enable(true);
   TERN_(SENSORLESS_HOMING, probe.set_homing_current(true));
@@ -175,9 +177,9 @@ static float std_dev_points(float z_pt[NPP + 1], const bool _0p_cal, const bool 
 /**
  *  - Probe a point
  */
-static float calibration_probe(const xy_pos_t &xy, const bool stow) {
+static float calibration_probe(const xy_pos_t &xy, const bool stow, const bool probe_at_offset) {
   #if HAS_BED_PROBE
-    return probe.probe_at_point(xy, stow ? PROBE_PT_STOW : PROBE_PT_RAISE, 0, true, false);
+    return probe.probe_at_point(xy, stow ? PROBE_PT_STOW : PROBE_PT_RAISE, 0, true, probe_at_offset);
   #else
     UNUSED(stow);
     return lcd_probe_pt(xy);
@@ -187,7 +189,7 @@ static float calibration_probe(const xy_pos_t &xy, const bool stow) {
 /**
  *  - Probe a grid
  */
-static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_points, const bool towers_set, const bool stow_after_each) {
+static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_points, const bool towers_set, const bool stow_after_each, const bool probe_at_offset) {
   const bool _0p_calibration      = probe_points == 0,
              _1p_calibration      = probe_points == 1 || probe_points == -1,
              _4p_calibration      = probe_points == 2,
@@ -209,11 +211,9 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
 
   if (!_0p_calibration) {
 
-    const float dcr = delta_calibration_radius();
-
     if (!_7p_no_intermediates && !_7p_4_intermediates && !_7p_11_intermediates) { // probe the center
       const xy_pos_t center{0};
-      z_pt[CEN] += calibration_probe(center, stow_after_each);
+      z_pt[CEN] += calibration_probe(center, stow_after_each, probe_at_offset);
       if (isnan(z_pt[CEN])) return false;
     }
 
@@ -224,7 +224,7 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
         const float a = RADIANS(210 + (360 / NPP) *  (rad - 1)),
                     r = dcr * 0.1;
         const xy_pos_t vec = { cos(a), sin(a) };
-        z_pt[CEN] += calibration_probe(vec * r, stow_after_each);
+        z_pt[CEN] += calibration_probe(vec * r, stow_after_each, probe_at_offset);
         if (isnan(z_pt[CEN])) return false;
      }
       z_pt[CEN] /= float(_7p_2_intermediates ? 7 : probe_points);
@@ -249,7 +249,7 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
                       r = dcr * (1 - 0.1 * (zig_zag ? offset - circle : circle)),
                       interpol = FMOD(rad, 1);
           const xy_pos_t vec = { cos(a), sin(a) };
-          const float z_temp = calibration_probe(vec * r, stow_after_each);
+          const float z_temp = calibration_probe(vec * r, stow_after_each, probe_at_offset);
           if (isnan(z_temp)) return false;
           // split probe point to neighbouring calibration points
           z_pt[uint8_t(LROUND(rad - interpol + NPP - 1)) % NPP + 1] += z_temp * sq(cos(RADIANS(interpol * 90)));
@@ -276,7 +276,6 @@ static bool probe_calibration_points(float z_pt[NPP + 1], const int8_t probe_poi
 static void reverse_kinematics_probe_points(float z_pt[NPP + 1], abc_float_t mm_at_pt_axis[NPP + 1]) {
   xyz_pos_t pos{0};
 
-  const float dcr = delta_calibration_radius();
   LOOP_CAL_ALL(rad) {
     const float a = RADIANS(210 + (360 / NPP) *  (rad - 1)),
                 r = (rad == CEN ? 0.0f : dcr);
@@ -287,7 +286,7 @@ static void reverse_kinematics_probe_points(float z_pt[NPP + 1], abc_float_t mm_
 }
 
 static void forward_kinematics_probe_points(abc_float_t mm_at_pt_axis[NPP + 1], float z_pt[NPP + 1]) {
-  const float r_quot = delta_calibration_radius() / delta_radius;
+  const float r_quot = dcr / delta_radius;
 
   #define ZPP(N,I,A) (((1.0f + r_quot * (N)) / 3.0f) * mm_at_pt_axis[I].A)
   #define Z00(I, A) ZPP( 0, I, A)
@@ -328,7 +327,7 @@ static void calc_kinematics_diff_probe_points(float z_pt[NPP + 1], abc_float_t d
 }
 
 static float auto_tune_h() {
-  const float r_quot = delta_calibration_radius() / delta_radius;
+  const float r_quot = dcr / delta_radius;
   return RECIPROCAL(r_quot / (2.0f / 3.0f));  // (2/3)/CR
 }
 
@@ -373,6 +372,8 @@ static float auto_tune_a() {
  *      P3       Probe all positions: center, towers and opposite towers. Calibrate all.
  *      P4-P10   Probe all positions at different intermediate locations and average them.
  *
+ *   Rn.nn  override default calibration Radius
+ *
  *   T   Don't calibrate tower angle corrections
  *
  *   Cn.nn  Calibration precision; when omitted calibrates to maximum precision
@@ -386,6 +387,8 @@ static float auto_tune_a() {
  *      V3  Report settings and probe results
  *
  *   E   Engage the probe for each point
+ *
+ *   O   Probe at offset points (this is wrong but it seems to work)
  *
  * With SENSORLESS_PROBING:
  *   Use these flags to calibrate stall sensitivity: (e.g., `G33 P1 Y Z` to calibrate X only.)
@@ -404,6 +407,33 @@ void GcodeSuite::G33() {
   }
 
   const bool towers_set = !parser.seen_test('T');
+
+  const bool probe_at_offset = 
+  #if HAS_PROBE_XY_OFFSET
+    parser.seen_test('O');
+  #else
+    false;
+  #endif
+
+  dcr = DELTA_PRINTABLE_RADIUS;
+  float max_dcr = DELTA_PRINTABLE_RADIUS;
+  #if HAS_PROBE_XY_OFFSET
+    // for offset probes calibration radius is set to a safe but non-optimal value
+	dcr -= HYPOT(probe.offset_xy.x, probe.offset_xy.y);
+	if (probe_at_offset) {
+	// with probe positions both probe and nozzle need to be within the printable area
+      max_dcr -= HYPOT(probe.offset_xy.x, probe.offset_xy.y);
+	}
+	// else with nozzle positions there is a risk of the probe being outside the bed
+	// but as long the nozzle stays within the printable area there is no risk
+	// the effector crashes into the towers
+  #endif
+  ;
+  dcr = parser.floatval('R', dcr);
+  if (dcr < 0 || dcr > max_dcr) {
+    SERIAL_ECHOLNPGM("?calibration (R)adius implausible.");
+    return;
+  }
 
   const float calibration_precision = parser.floatval('C', 0.0f);
   if (calibration_precision < 0) {
@@ -453,18 +483,6 @@ void GcodeSuite::G33() {
 
   SERIAL_ECHOLNPGM("G33 Auto Calibrate");
 
-  const float dcr = delta_calibration_radius();
-
-  if (!_1p_calibration && !_0p_calibration) { // test if the outer radius is reachable
-    LOOP_CAL_RAD(axis) {
-      const float a = RADIANS(210 + (360 / NPP) *  (axis - 1));
-      if (!position_is_reachable(cos(a) * dcr, sin(a) * dcr)) {
-        SERIAL_ECHOLNPGM("?Bed calibration radius implausible.");
-        return;
-      }
-    }
-  }
-
   // Report settings
   PGM_P const checkingac = PSTR("Checking... AC");
   SERIAL_ECHOPGM_P(checkingac);
@@ -487,7 +505,7 @@ void GcodeSuite::G33() {
 
     // Probe the points
     zero_std_dev_old = zero_std_dev;
-    if (!probe_calibration_points(z_at_pt, probe_points, towers_set, stow_after_each)) {
+    if (!probe_calibration_points(z_at_pt, probe_points, towers_set, stow_after_each, probe_at_offset)) {
       SERIAL_ECHOLNPGM("Correct delta settings with M665 and M666");
       return ac_cleanup(TERN_(HAS_MULTI_HOTEND, old_tool_index));
     }
@@ -526,11 +544,11 @@ void GcodeSuite::G33() {
       #define Z0(I) ZP(0, I)
 
       // calculate factors
-      if (_7p_9_center) calibration_radius_factor = 0.9f;
+      if (_7p_9_center) dcr *= 0.9f;
       h_factor = auto_tune_h();
       r_factor = auto_tune_r();
       a_factor = auto_tune_a();
-      calibration_radius_factor = 1.0f;
+      dcr /= 0.9f;
 
       switch (probe_points) {
         case 0:

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -88,8 +88,9 @@ void _man_probe_pt(const xy_pos_t &xy) {
   }
 
   void _goto_tower_a(const_float_t a) {
+	const float dcr = DELTA_PRINTABLE_RADIUS;
     xy_pos_t tower_vec = { cos(RADIANS(a)), sin(RADIANS(a)) };
-    _man_probe_pt(tower_vec * delta_calibration_radius());
+    _man_probe_pt(tower_vec * dcr);
   }
   void _goto_tower_x() { _goto_tower_a(210); }
   void _goto_tower_y() { _goto_tower_a(330); }

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -88,7 +88,7 @@ void _man_probe_pt(const xy_pos_t &xy) {
   }
 
   void _goto_tower_a(const_float_t a) {
-	const float dcr = DELTA_PRINTABLE_RADIUS;
+    const float dcr = DELTA_PRINTABLE_RADIUS;
     xy_pos_t tower_vec = { cos(RADIANS(a)), sin(RADIANS(a)) };
     _man_probe_pt(tower_vec * dcr);
   }

--- a/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
+++ b/Marlin/src/lcd/menu/menu_delta_calibrate.cpp
@@ -88,7 +88,7 @@ void _man_probe_pt(const xy_pos_t &xy) {
   }
 
   void _goto_tower_a(const_float_t a) {
-    const float dcr = DELTA_PRINTABLE_RADIUS;
+    constexpr float dcr = DELTA_PRINTABLE_RADIUS;
     xy_pos_t tower_vec = { cos(RADIANS(a)), sin(RADIANS(a)) };
     _man_probe_pt(tower_vec * dcr);
   }

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -83,28 +83,6 @@ void recalc_delta_settings() {
 }
 
 /**
- * Get a safe radius for calibration
- */
-
-#if EITHER(DELTA_AUTO_CALIBRATION, DELTA_CALIBRATION_MENU)
-
-  #if ENABLED(DELTA_AUTO_CALIBRATION)
-    float calibration_radius_factor = 1;
-  #endif
-
-  float delta_calibration_radius() {
-    return calibration_radius_factor * (
-      #if HAS_BED_PROBE
-        FLOOR((DELTA_PRINTABLE_RADIUS) - _MAX(HYPOT(probe.offset_xy.x, probe.offset_xy.y), PROBING_MARGIN))
-      #else
-        DELTA_PRINTABLE_RADIUS
-      #endif
-    );
-  }
-
-#endif
-
-/**
  * Delta Inverse Kinematics
  *
  * Calculate the tower positions for a given machine

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -46,19 +46,6 @@ extern abc_float_t delta_diagonal_rod_trim;
 void recalc_delta_settings();
 
 /**
- * Get a safe radius for calibration
- */
-#if ENABLED(DELTA_AUTO_CALIBRATION)
-  extern float calibration_radius_factor;
-#else
-  constexpr float calibration_radius_factor = 1;
-#endif
-
-#if EITHER(DELTA_AUTO_CALIBRATION, DELTA_CALIBRATION_MENU)
-  float delta_calibration_radius();
-#endif
-
-/**
  * Delta Inverse Kinematics
  *
  * Calculate the tower positions for a given machine


### PR DESCRIPTION
Making that the default calculated `delta_calibration_radius()` can be overwritten by issuing the G33 Rn.nn option.

Restoring probing at the nozzle positions as default but with an option to override this to probe offset positions by issuing the G33 O option.

### Requirements

delta

### Benefits

restores the functionality that was lost

### Configurations

none

### Related Issues

#17729 and #19144