### PR TITLE
Protoneer CNC-Shield 3.00

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -161,7 +161,7 @@
 #define BOARD_INTAMSYS40              1326  // Intamsys 4.0 (Funmat HT)
 #define BOARD_MALYAN_M180             1327  // Malyan M180 Mainboard Version 2 (no display function, direct gcode only)
 #define BOARD_GT2560_V4_A20           1328  // Geeetech GT2560 Rev B for A20(M/T/D)
-#define PROTONEER_CNC_SHIELD_V3       1329  // Mega controller & Protoneer CNC Shield V3.00
+#define BOARD_PROTONEER_CNC_SHIELD_V3 1329  // Mega controller & Protoneer CNC Shield V3.00
 
 //
 // ATmega1281, ATmega2561

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -161,6 +161,7 @@
 #define BOARD_INTAMSYS40              1326  // Intamsys 4.0 (Funmat HT)
 #define BOARD_MALYAN_M180             1327  // Malyan M180 Mainboard Version 2 (no display function, direct gcode only)
 #define BOARD_GT2560_V4_A20           1328  // Geeetech GT2560 Rev B for A20(M/T/D)
+#define PROTONEER_CNC_SHIELD_V3       1329  // Mega controller & Protoneer CNC Shield V3.00
 
 //
 // ATmega1281, ATmega2561

--- a/Marlin/src/pins/mega/pins_PROTONEER_CNC_SHIELD_V3.h
+++ b/Marlin/src/pins/mega/pins_PROTONEER_CNC_SHIELD_V3.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -24,8 +24,7 @@
 /**
  * Protoneer v3.00 pin assignments
  * 
- * The SNS shield has a UNO pinout and will fit 
- * anything that claims to be Arduino hardware compatible.
+ * The SNS shield has an UNO pinout and fits all Arduino-compatibles.
  * 
  * Referenced docs:
  * - https://blog.protoneer.co.nz/arduino-cnc-shield-v3-00-assembly-guide/
@@ -35,6 +34,7 @@
 #include "env_validate.h"
 
 #define BOARD_INFO_NAME "Protoneer CNC Shield v3.00"
+
 //
 // Limit Switches
 //
@@ -47,31 +47,31 @@
 //
 #define X_STEP_PIN                             2
 #define X_DIR_PIN                              5
-#define X_ENABLE_PIN                           8 // common enable pin
+#define X_ENABLE_PIN                           8  // Shared enable pin
 
 #define Y_STEP_PIN                             3
 #define Y_DIR_PIN                              6
-#define Y_ENABLE_PIN                           8 // common enable pin
+#define Y_ENABLE_PIN                 X_ENABLE_PIN
 
 #define Z_STEP_PIN                             4
 #define Z_DIR_PIN                              7
-#define Z_ENABLE_PIN                           8 // common enable pin
+#define Z_ENABLE_PIN                 X_ENABLE_PIN
 
 // Designated with letter "A" on BOARD
 #define E0_STEP_PIN                           12
 #define E0_DIR_PIN                            13
-#define E0_ENABLE_PIN                          8 // common enable pin
+#define E0_ENABLE_PIN                X_ENABLE_PIN
 
 //
 // Temperature sensors - These could be any analog output not hidden by board
 //
 #define TEMP_0_PIN                             8  // Analog Input
-// #define TEMP_1_PIN                             9  // Analog Input
-// #define TEMP_BED_PIN                          10  // Analog Input
+//#define TEMP_1_PIN                           9  // Analog Input
+//#define TEMP_BED_PIN                        10  // Analog Input
 
 //
 // Heaters / Fans - These could be any digital input not hidden by board
 //
-// #define HEATER_0_PIN                          22  // EXTRUDER 1
-// #define HEATER_1_PIN                          23  // EXTRUDER 2
-// #define HEATER_BED_PIN                        24
+//#define HEATER_0_PIN                        22  // EXTRUDER 1
+//#define HEATER_1_PIN                        23  // EXTRUDER 2
+//#define HEATER_BED_PIN                      24

--- a/Marlin/src/pins/mega/pins_PROTONEER_CNC_SHIELD_V3.h
+++ b/Marlin/src/pins/mega/pins_PROTONEER_CNC_SHIELD_V3.h
@@ -1,0 +1,77 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Protoneer v3.00 pin assignments
+ * 
+ * The SNS shield has a UNO pinout and will fit 
+ * anything that claims to be Arduino hardware compatible.
+ * 
+ * Referenced docs:
+ * - https://blog.protoneer.co.nz/arduino-cnc-shield-v3-00-assembly-guide/
+ * - https://blog.protoneer.co.nz/arduino-cnc-shield/
+ */
+
+#include "env_validate.h"
+
+#define BOARD_INFO_NAME "Protoneer CNC Shield v3.00"
+//
+// Limit Switches
+//
+#define X_STOP_PIN                             9
+#define Y_STOP_PIN                            10
+#define Z_STOP_PIN                            11
+
+//
+// Steppers
+//
+#define X_STEP_PIN                             2
+#define X_DIR_PIN                              5
+#define X_ENABLE_PIN                           8 // common enable pin
+
+#define Y_STEP_PIN                             3
+#define Y_DIR_PIN                              6
+#define Y_ENABLE_PIN                           8 // common enable pin
+
+#define Z_STEP_PIN                             4
+#define Z_DIR_PIN                              7
+#define Z_ENABLE_PIN                           8 // common enable pin
+
+// Designated with letter "A" on BOARD
+#define E0_STEP_PIN                           12
+#define E0_DIR_PIN                            13
+#define E0_ENABLE_PIN                          8 // common enable pin
+
+//
+// Temperature sensors - These could be any analog output not hidden by board
+//
+#define TEMP_0_PIN                             8  // Analog Input
+// #define TEMP_1_PIN                             9  // Analog Input
+// #define TEMP_BED_PIN                          10  // Analog Input
+
+//
+// Heaters / Fans - These could be any digital input not hidden by board
+//
+// #define HEATER_0_PIN                          22  // EXTRUDER 1
+// #define HEATER_1_PIN                          23  // EXTRUDER 2
+// #define HEATER_BED_PIN                        24

--- a/Marlin/src/pins/mega/pins_PROTONEER_CNC_SHIELD_V3.h
+++ b/Marlin/src/pins/mega/pins_PROTONEER_CNC_SHIELD_V3.h
@@ -24,7 +24,7 @@
 /**
  * Protoneer v3.00 pin assignments
  * 
- * The SNS shield has an UNO pinout and fits all Arduino-compatibles.
+ * This CNC shield has an UNO pinout and fits all Arduino-compatibles.
  * 
  * Referenced docs:
  * - https://blog.protoneer.co.nz/arduino-cnc-shield-v3-00-assembly-guide/

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -269,6 +269,9 @@
   #include "mega/pins_INTAMSYS40.h"             // ATmega2560                             env:mega2560
 #elif MB(MALYAN_M180)
   #include "mega/pins_MALYAN_M180.h"            // ATmega2560                             env:mega2560
+#elif MB(PROTONEER_CNC_SHIELD_V3)
+  #include "mega/pins_PROTONEER_CNC_SHIELD_V3.h"// ATmega2560                             env:mega2560
+
 
 //
 // ATmega1281, ATmega2561

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -272,7 +272,6 @@
 #elif MB(PROTONEER_CNC_SHIELD_V3)
   #include "mega/pins_PROTONEER_CNC_SHIELD_V3.h"// ATmega2560                             env:mega2560
 
-
 //
 // ATmega1281, ATmega2561
 //


### PR DESCRIPTION
### Description

Add full 3D printer support for the [Protoneer CNC-Shield v3.00](http://info.protoneer.com/1) board, which was originally developed for GRBL on an Arduino UNO. The board will work with any Arduino board with enough memory, i.e. the MEGA 2560. Documentation of pin-out can be found [here](https://blog.protoneer.co.nz/arduino-cnc-shield/).

![Image of the Protoneer CNC-Shield v3.00](https://user-images.githubusercontent.com/527705/132117189-70058fd3-0fd8-4034-9f51-de0a1cfc1ec8.png)

### Requirements

Requires a Protoneer CNC-Shield v3.00 or clone, and any micro-controller with a pin-out identical to an Arduino UNO.

### Benefits

Adds support in Marlin 2.0 for yet another board.

### Configurations

`Configuration.h`
```
#define MOTHERBOARD BOARD_PROTONEER_CNC_SHIELD_V3
```

### Related Issues

A user posted a partially working implementation [here](https://github.com/MarlinFirmware/Marlin/issues/5375#issuecomment-265291485).