### PR TITLE
Standardize G-code and M503 reporting

### DIFF
--- a/Marlin/src/HAL/AVR/fastio.cpp
+++ b/Marlin/src/HAL/AVR/fastio.cpp
@@ -267,11 +267,11 @@ uint16_t set_pwm_frequency_hz(const_float_t hz, const float dca, const float dcb
     SET_WGM(5, FAST_PWM_ICRn);            // Fast PWM with ICR5 as TOP
 
     //SERIAL_ECHOLNPGM("Timer 5 Settings:");
-    //SERIAL_ECHOLNPAIR("  Prescaler=", prescaler);
-    //SERIAL_ECHOLNPAIR("        TOP=", ICR5);
-    //SERIAL_ECHOLNPAIR("      OCR5A=", OCR5A);
-    //SERIAL_ECHOLNPAIR("      OCR5B=", OCR5B);
-    //SERIAL_ECHOLNPAIR("      OCR5C=", OCR5C);
+    //SERIAL_ECHOLNPGM("  Prescaler=", prescaler);
+    //SERIAL_ECHOLNPGM("        TOP=", ICR5);
+    //SERIAL_ECHOLNPGM("      OCR5A=", OCR5A);
+    //SERIAL_ECHOLNPGM("      OCR5B=", OCR5B);
+    //SERIAL_ECHOLNPGM("      OCR5C=", OCR5C);
   }
   else {
     // Restore the default for Timer 5

--- a/Marlin/src/HAL/AVR/pinsDebug.h
+++ b/Marlin/src/HAL/AVR/pinsDebug.h
@@ -235,7 +235,7 @@ static void print_is_also_tied() { SERIAL_ECHOPGM(" is also tied to this pin"); 
 
 inline void com_print(const uint8_t N, const uint8_t Z) {
   const uint8_t *TCCRA = (uint8_t*)TCCR_A(N);
-  SERIAL_ECHOPAIR("    COM", AS_CHAR('0' + N));
+  SERIAL_ECHOPAIR("    COM", AS_DIGIT(N));
   SERIAL_CHAR(Z);
   SERIAL_ECHOPAIR(": ", int((*TCCRA >> (6 - Z * 2)) & 0x03));
 }
@@ -247,7 +247,7 @@ void timer_prefix(uint8_t T, char L, uint8_t N) {  // T - timer    L - pwm  N - 
   uint8_t WGM = (((*TCCRB & _BV(WGM_2)) >> 1) | (*TCCRA & (_BV(WGM_0) | _BV(WGM_1))));
   if (N == 4) WGM |= ((*TCCRB & _BV(WGM_3)) >> 1);
 
-  SERIAL_ECHOPAIR("    TIMER", AS_CHAR(T + '0'));
+  SERIAL_ECHOPAIR("    TIMER", AS_DIGIT(T));
   SERIAL_CHAR(L);
   SERIAL_ECHO_SP(3);
 
@@ -262,11 +262,11 @@ void timer_prefix(uint8_t T, char L, uint8_t N) {  // T - timer    L - pwm  N - 
   SERIAL_ECHOPAIR("    WGM: ", WGM);
   com_print(T,L);
   SERIAL_ECHOPAIR("    CS: ", (*TCCRB & (_BV(CS_0) | _BV(CS_1) | _BV(CS_2)) ));
-  SERIAL_ECHOPAIR("    TCCR", AS_CHAR(T + '0'), "A: ", *TCCRA);
-  SERIAL_ECHOPAIR("    TCCR", AS_CHAR(T + '0'), "B: ", *TCCRB);
+  SERIAL_ECHOPAIR("    TCCR", AS_DIGIT(T), "A: ", *TCCRA);
+  SERIAL_ECHOPAIR("    TCCR", AS_DIGIT(T), "B: ", *TCCRB);
 
   const uint8_t *TMSK = (uint8_t*)TIMSK(T);
-  SERIAL_ECHOPAIR("    TIMSK", AS_CHAR(T + '0'), ": ", *TMSK);
+  SERIAL_ECHOPAIR("    TIMSK", AS_DIGIT(T), ": ", *TMSK);
 
   const uint8_t OCIE = L - 'A' + 1;
   if (N == 3) { if (WGM == 0 || WGM == 2 || WGM ==  4 || WGM ==  6) err_is_counter(); }

--- a/Marlin/src/HAL/AVR/pinsDebug.h
+++ b/Marlin/src/HAL/AVR/pinsDebug.h
@@ -235,9 +235,9 @@ static void print_is_also_tied() { SERIAL_ECHOPGM(" is also tied to this pin"); 
 
 inline void com_print(const uint8_t N, const uint8_t Z) {
   const uint8_t *TCCRA = (uint8_t*)TCCR_A(N);
-  SERIAL_ECHOPAIR("    COM", AS_DIGIT(N));
+  SERIAL_ECHOPGM("    COM", AS_DIGIT(N));
   SERIAL_CHAR(Z);
-  SERIAL_ECHOPAIR(": ", int((*TCCRA >> (6 - Z * 2)) & 0x03));
+  SERIAL_ECHOPGM(": ", int((*TCCRA >> (6 - Z * 2)) & 0x03));
 }
 
 void timer_prefix(uint8_t T, char L, uint8_t N) {  // T - timer    L - pwm  N - WGM bit layout
@@ -247,7 +247,7 @@ void timer_prefix(uint8_t T, char L, uint8_t N) {  // T - timer    L - pwm  N - 
   uint8_t WGM = (((*TCCRB & _BV(WGM_2)) >> 1) | (*TCCRA & (_BV(WGM_0) | _BV(WGM_1))));
   if (N == 4) WGM |= ((*TCCRB & _BV(WGM_3)) >> 1);
 
-  SERIAL_ECHOPAIR("    TIMER", AS_DIGIT(T));
+  SERIAL_ECHOPGM("    TIMER", AS_DIGIT(T));
   SERIAL_CHAR(L);
   SERIAL_ECHO_SP(3);
 
@@ -259,14 +259,14 @@ void timer_prefix(uint8_t T, char L, uint8_t N) {  // T - timer    L - pwm  N - 
     const uint16_t *OCRVAL16 = (uint16_t*)OCR_VAL(T, L - 'A');
     PWM_PRINT(*OCRVAL16);
   }
-  SERIAL_ECHOPAIR("    WGM: ", WGM);
+  SERIAL_ECHOPGM("    WGM: ", WGM);
   com_print(T,L);
-  SERIAL_ECHOPAIR("    CS: ", (*TCCRB & (_BV(CS_0) | _BV(CS_1) | _BV(CS_2)) ));
-  SERIAL_ECHOPAIR("    TCCR", AS_DIGIT(T), "A: ", *TCCRA);
-  SERIAL_ECHOPAIR("    TCCR", AS_DIGIT(T), "B: ", *TCCRB);
+  SERIAL_ECHOPGM("    CS: ", (*TCCRB & (_BV(CS_0) | _BV(CS_1) | _BV(CS_2)) ));
+  SERIAL_ECHOPGM("    TCCR", AS_DIGIT(T), "A: ", *TCCRA);
+  SERIAL_ECHOPGM("    TCCR", AS_DIGIT(T), "B: ", *TCCRB);
 
   const uint8_t *TMSK = (uint8_t*)TIMSK(T);
-  SERIAL_ECHOPAIR("    TIMSK", AS_DIGIT(T), ": ", *TMSK);
+  SERIAL_ECHOPGM("    TIMSK", AS_DIGIT(T), ": ", *TMSK);
 
   const uint8_t OCIE = L - 'A' + 1;
   if (N == 3) { if (WGM == 0 || WGM == 2 || WGM ==  4 || WGM ==  6) err_is_counter(); }

--- a/Marlin/src/HAL/DUE/eeprom_flash.cpp
+++ b/Marlin/src/HAL/DUE/eeprom_flash.cpp
@@ -200,9 +200,9 @@ static bool ee_PageWrite(uint16_t page, const void *data) {
     pageContents[i] = (((uint32_t*)data)[i]) | (~(pageContents[i] ^ ((uint32_t*)data)[i]));
 
   DEBUG_ECHO_START();
-  DEBUG_ECHOLNPAIR("EEPROM PageWrite   ", page);
-  DEBUG_ECHOLNPAIR(" in FLASH address ", (uint32_t)addrflash);
-  DEBUG_ECHOLNPAIR(" base address     ", (uint32_t)getFlashStorage(0));
+  DEBUG_ECHOLNPGM("EEPROM PageWrite   ", page);
+  DEBUG_ECHOLNPGM(" in FLASH address ", (uint32_t)addrflash);
+  DEBUG_ECHOLNPGM(" base address     ", (uint32_t)getFlashStorage(0));
   DEBUG_FLUSH();
 
   // Get the page relative to the start of the EFC controller, and the EFC controller to use
@@ -246,7 +246,7 @@ static bool ee_PageWrite(uint16_t page, const void *data) {
     __enable_irq();
 
     DEBUG_ECHO_START();
-    DEBUG_ECHOLNPAIR("EEPROM Unlock failure for page ", page);
+    DEBUG_ECHOLNPGM("EEPROM Unlock failure for page ", page);
     return false;
   }
 
@@ -271,7 +271,7 @@ static bool ee_PageWrite(uint16_t page, const void *data) {
     __enable_irq();
 
     DEBUG_ECHO_START();
-    DEBUG_ECHOLNPAIR("EEPROM Write failure for page ", page);
+    DEBUG_ECHOLNPGM("EEPROM Write failure for page ", page);
 
     return false;
   }
@@ -287,7 +287,7 @@ static bool ee_PageWrite(uint16_t page, const void *data) {
 
     #ifdef EE_EMU_DEBUG
       DEBUG_ECHO_START();
-      DEBUG_ECHOLNPAIR("EEPROM Verify Write failure for page ", page);
+      DEBUG_ECHOLNPGM("EEPROM Verify Write failure for page ", page);
 
       ee_Dump( page, (uint32_t *)addrflash);
       ee_Dump(-page, data);
@@ -306,7 +306,7 @@ static bool ee_PageWrite(uint16_t page, const void *data) {
           }
         }
       }
-      DEBUG_ECHOLNPAIR("--> Differing bits: ", count);
+      DEBUG_ECHOLNPGM("--> Differing bits: ", count);
     #endif
 
     return false;
@@ -326,9 +326,9 @@ static bool ee_PageErase(uint16_t page) {
   uint32_t addrflash = uint32_t(getFlashStorage(page));
 
   DEBUG_ECHO_START();
-  DEBUG_ECHOLNPAIR("EEPROM PageErase  ", page);
-  DEBUG_ECHOLNPAIR(" in FLASH address ", (uint32_t)addrflash);
-  DEBUG_ECHOLNPAIR(" base address     ", (uint32_t)getFlashStorage(0));
+  DEBUG_ECHOLNPGM("EEPROM PageErase  ", page);
+  DEBUG_ECHOLNPGM(" in FLASH address ", (uint32_t)addrflash);
+  DEBUG_ECHOLNPGM(" base address     ", (uint32_t)getFlashStorage(0));
   DEBUG_FLUSH();
 
   // Get the page relative to the start of the EFC controller, and the EFC controller to use
@@ -371,7 +371,7 @@ static bool ee_PageErase(uint16_t page) {
     __enable_irq();
 
     DEBUG_ECHO_START();
-    DEBUG_ECHOLNPAIR("EEPROM Unlock failure for page ",page);
+    DEBUG_ECHOLNPGM("EEPROM Unlock failure for page ",page);
 
     return false;
   }
@@ -395,7 +395,7 @@ static bool ee_PageErase(uint16_t page) {
     __enable_irq();
 
     DEBUG_ECHO_START();
-    DEBUG_ECHOLNPAIR("EEPROM Erase failure for page ",page);
+    DEBUG_ECHOLNPGM("EEPROM Erase failure for page ",page);
 
     return false;
   }
@@ -411,7 +411,7 @@ static bool ee_PageErase(uint16_t page) {
   for (i = 0; i < PageSize >> 2; i++) {
     if (*aligned_src++ != 0xFFFFFFFF) {
       DEBUG_ECHO_START();
-      DEBUG_ECHOLNPAIR("EEPROM Verify Erase failure for page ",page);
+      DEBUG_ECHOLNPGM("EEPROM Verify Erase failure for page ",page);
       ee_Dump(page, (uint32_t *)addrflash);
       return false;
     }
@@ -922,7 +922,7 @@ static void ee_Init() {
   if (curGroup >= GroupCount) curGroup = 0;
 
   DEBUG_ECHO_START();
-  DEBUG_ECHOLNPAIR("EEPROM Current Group: ",curGroup);
+  DEBUG_ECHOLNPGM("EEPROM Current Group: ",curGroup);
   DEBUG_FLUSH();
 
   // Now, validate that all the other group pages are empty
@@ -932,7 +932,7 @@ static void ee_Init() {
     for (int page = 0; page < PagesPerGroup; page++) {
       if (!ee_IsPageClean(grp * PagesPerGroup + page)) {
         DEBUG_ECHO_START();
-        DEBUG_ECHOLNPAIR("EEPROM Page ", page, " not clean on group ", grp);
+        DEBUG_ECHOLNPGM("EEPROM Page ", page, " not clean on group ", grp);
         DEBUG_FLUSH();
         ee_PageErase(grp * PagesPerGroup + page);
       }
@@ -949,14 +949,14 @@ static void ee_Init() {
   }
 
   DEBUG_ECHO_START();
-  DEBUG_ECHOLNPAIR("EEPROM Active page: ", curPage);
+  DEBUG_ECHOLNPGM("EEPROM Active page: ", curPage);
   DEBUG_FLUSH();
 
   // Make sure the pages following the first clean one are also clean
   for (int page = curPage + 1; page < PagesPerGroup; page++) {
     if (!ee_IsPageClean(curGroup * PagesPerGroup + page)) {
       DEBUG_ECHO_START();
-      DEBUG_ECHOLNPAIR("EEPROM Page ", page, " not clean on active group ", curGroup);
+      DEBUG_ECHOLNPGM("EEPROM Page ", page, " not clean on active group ", curGroup);
       DEBUG_FLUSH();
       ee_Dump(curGroup * PagesPerGroup + page, getFlashStorage(curGroup * PagesPerGroup + page));
       ee_PageErase(curGroup * PagesPerGroup + page);

--- a/Marlin/src/HAL/DUE/pinsDebug.h
+++ b/Marlin/src/HAL/DUE/pinsDebug.h
@@ -87,7 +87,7 @@ bool GET_PINMODE(int8_t pin) {  // 1: output, 0: input
 void pwm_details(int32_t pin) {
   if (pwm_status(pin)) {
     uint32_t chan = g_APinDescription[pin].ulPWMChannel;
-    SERIAL_ECHOPAIR("PWM = ", PWM_INTERFACE->PWM_CH_NUM[chan].PWM_CDTY);
+    SERIAL_ECHOPGM("PWM = ", PWM_INTERFACE->PWM_CH_NUM[chan].PWM_CDTY);
   }
 }
 

--- a/Marlin/src/HAL/ESP32/wifi.cpp
+++ b/Marlin/src/HAL/ESP32/wifi.cpp
@@ -59,7 +59,7 @@ void wifi_init() {
 
   MDNS.addService("http", "tcp", 80);
 
-  SERIAL_ECHOLNPAIR("Successfully connected to WiFi with SSID '" WIFI_SSID "', hostname: '" WIFI_HOSTNAME "', IP address: ", WiFi.localIP().toString().c_str());
+  SERIAL_ECHOLNPGM("Successfully connected to WiFi with SSID '" WIFI_SSID "', hostname: '" WIFI_HOSTNAME "', IP address: ", WiFi.localIP().toString().c_str());
 }
 
 #endif // WIFISUPPORT

--- a/Marlin/src/HAL/LPC1768/eeprom_sdcard.cpp
+++ b/Marlin/src/HAL/LPC1768/eeprom_sdcard.cpp
@@ -84,15 +84,15 @@ static void debug_rw(const bool write, int &pos, const uint8_t *value, const siz
   PGM_P const rw_str = write ? PSTR("write") : PSTR("read");
   SERIAL_CHAR(' ');
   SERIAL_ECHOPGM_P(rw_str);
-  SERIAL_ECHOLNPAIR("_data(", pos, ",", value, ",", size, ", ...)");
+  SERIAL_ECHOLNPGM("_data(", pos, ",", value, ",", size, ", ...)");
   if (total) {
     SERIAL_ECHOPGM(" f_");
     SERIAL_ECHOPGM_P(rw_str);
-    SERIAL_ECHOPAIR("()=", s, "\n size=", size, "\n bytes_");
-    SERIAL_ECHOLNPAIR_P(write ? PSTR("written=") : PSTR("read="), total);
+    SERIAL_ECHOPGM("()=", s, "\n size=", size, "\n bytes_");
+    SERIAL_ECHOLNPGM_P(write ? PSTR("written=") : PSTR("read="), total);
   }
   else
-    SERIAL_ECHOLNPAIR(" f_lseek()=", s);
+    SERIAL_ECHOLNPGM(" f_lseek()=", s);
 }
 
 // File function return codes for type FRESULT. This goes away soon, but

--- a/Marlin/src/HAL/SAMD51/pinsDebug.h
+++ b/Marlin/src/HAL/SAMD51/pinsDebug.h
@@ -48,7 +48,7 @@ bool GET_PINMODE(int8_t pin) {  // 1: output, 0: input
 void pwm_details(int32_t pin) {
   if (pwm_status(pin)) {
     //uint32_t chan = g_APinDescription[pin].ulPWMChannel TODO when fast pwm is operative;
-    //SERIAL_ECHOPAIR("PWM = ", duty);
+    //SERIAL_ECHOPGM("PWM = ", duty);
   }
 }
 

--- a/Marlin/src/HAL/STM32/eeprom_flash.cpp
+++ b/Marlin/src/HAL/STM32/eeprom_flash.cpp
@@ -133,7 +133,7 @@ bool PersistentStore::access_start() {
         // load current settings
         uint8_t *eeprom_data = (uint8_t *)SLOT_ADDRESS(current_slot);
         for (int i = 0; i < MARLIN_EEPROM_SIZE; i++) ram_eeprom[i] = eeprom_data[i];
-        DEBUG_ECHOLNPAIR("EEPROM loaded from slot ", current_slot, ".");
+        DEBUG_ECHOLNPGM("EEPROM loaded from slot ", current_slot, ".");
       }
       eeprom_data_written = false;
     }
@@ -179,9 +179,9 @@ bool PersistentStore::access_finish() {
         ENABLE_ISRS();
         TERN_(HAS_PAUSE_SERVO_OUTPUT, RESUME_SERVO_OUTPUT());
         if (status != HAL_OK) {
-          DEBUG_ECHOLNPAIR("HAL_FLASHEx_Erase=", status);
-          DEBUG_ECHOLNPAIR("GetError=", HAL_FLASH_GetError());
-          DEBUG_ECHOLNPAIR("SectorError=", SectorError);
+          DEBUG_ECHOLNPGM("HAL_FLASHEx_Erase=", status);
+          DEBUG_ECHOLNPGM("GetError=", HAL_FLASH_GetError());
+          DEBUG_ECHOLNPGM("SectorError=", SectorError);
           LOCK_FLASH();
           return false;
         }
@@ -204,9 +204,9 @@ bool PersistentStore::access_finish() {
           offset += sizeof(uint32_t);
         }
         else {
-          DEBUG_ECHOLNPAIR("HAL_FLASH_Program=", status);
-          DEBUG_ECHOLNPAIR("GetError=", HAL_FLASH_GetError());
-          DEBUG_ECHOLNPAIR("address=", address);
+          DEBUG_ECHOLNPGM("HAL_FLASH_Program=", status);
+          DEBUG_ECHOLNPGM("GetError=", HAL_FLASH_GetError());
+          DEBUG_ECHOLNPGM("address=", address);
           success = false;
           break;
         }
@@ -216,7 +216,7 @@ bool PersistentStore::access_finish() {
 
       if (success) {
         eeprom_data_written = false;
-        DEBUG_ECHOLNPAIR("EEPROM saved to slot ", current_slot, ".");
+        DEBUG_ECHOLNPGM("EEPROM saved to slot ", current_slot, ".");
       }
 
       return success;

--- a/Marlin/src/HAL/STM32/pinsDebug.h
+++ b/Marlin/src/HAL/STM32/pinsDebug.h
@@ -237,7 +237,7 @@ void pwm_details(const pin_t Ard_num) {
       if (over_7) pin_number -= 8;
 
       uint8_t alt_func = (alt_all >> (4 * pin_number)) & 0x0F;
-      SERIAL_ECHOPAIR("Alt Function: ", alt_func);
+      SERIAL_ECHOPGM("Alt Function: ", alt_func);
       if (alt_func < 10) SERIAL_CHAR(' ');
       SERIAL_ECHOPGM(" - ");
       switch (alt_func) {

--- a/Marlin/src/HAL/STM32/usb_host.cpp
+++ b/Marlin/src/HAL/STM32/usb_host.cpp
@@ -88,9 +88,9 @@ void USBHost::setUsbTaskState(uint8_t state) {
     capacity = info.capacity.block_nbr / 2000;
     block_size = info.capacity.block_size;
     block_count = info.capacity.block_nbr;
-    // SERIAL_ECHOLNPAIR("info.capacity.block_nbr : %ld\n", info.capacity.block_nbr);
-    // SERIAL_ECHOLNPAIR("info.capacity.block_size: %d\n", info.capacity.block_size);
-    // SERIAL_ECHOLNPAIR("capacity                : %d MB\n", capacity);
+    //SERIAL_ECHOLNPGM("info.capacity.block_nbr : %ld\n", info.capacity.block_nbr);
+    //SERIAL_ECHOLNPGM("info.capacity.block_size: %d\n", info.capacity.block_size);
+    //SERIAL_ECHOLNPGM("capacity                : %d MB\n", capacity);
   }
 };
 

--- a/Marlin/src/HAL/shared/Delay.cpp
+++ b/Marlin/src/HAL/shared/Delay.cpp
@@ -110,16 +110,16 @@
       auto report_call_time = [](PGM_P const name, PGM_P const unit, const uint32_t cycles, const uint32_t total, const bool do_flush=true) {
         SERIAL_ECHOPGM("Calling ");
         SERIAL_ECHOPGM_P(name);
-        SERIAL_ECHOLNPAIR(" for ", cycles);
+        SERIAL_ECHOLNPGM(" for ", cycles);
         SERIAL_ECHOPGM_P(unit);
-        SERIAL_ECHOLNPAIR(" took: ", total);
+        SERIAL_ECHOLNPGM(" took: ", total);
         SERIAL_ECHOPGM_P(unit);
         if (do_flush) SERIAL_FLUSHTX();
       };
 
       uint32_t s, e;
 
-      SERIAL_ECHOLNPAIR("Computed delay calibration value: ", ASM_CYCLES_PER_ITERATION);
+      SERIAL_ECHOLNPGM("Computed delay calibration value: ", ASM_CYCLES_PER_ITERATION);
       SERIAL_FLUSH();
       // Display the results of the calibration above
       constexpr uint32_t testValues[] = { 1, 5, 10, 20, 50, 100, 150, 200, 350, 500, 750, 1000 };

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -798,7 +798,7 @@ inline void manage_inactivity(const bool no_stepper_sleep=false) {
 void idle(bool no_stepper_sleep/*=false*/) {
   #if ENABLED(MARLIN_DEV_MODE)
     static uint16_t idle_depth = 0;
-    if (++idle_depth > 5) SERIAL_ECHOLNPAIR("idle() call depth: ", idle_depth);
+    if (++idle_depth > 5) SERIAL_ECHOLNPGM("idle() call depth: ", idle_depth);
   #endif
 
   // Core Marlin activities
@@ -1623,7 +1623,7 @@ void setup() {
   #if BOTH(HAS_WIRED_LCD, SHOW_BOOTSCREEN)
     const millis_t elapsed = millis() - bootscreen_ms;
     #if ENABLED(MARLIN_DEV_MODE)
-      SERIAL_ECHOLNPAIR("elapsed=", elapsed);
+      SERIAL_ECHOLNPGM("elapsed=", elapsed);
     #endif
     SETUP_RUN(ui.bootscreen_completion(elapsed));
   #endif

--- a/Marlin/src/core/bug_on.h
+++ b/Marlin/src/core/bug_on.h
@@ -20,19 +20,19 @@
  */
 #pragma once
 
-// We need SERIAL_ECHOPAIR and macros.h
+// We need SERIAL_ECHOPGM and macros.h
 #include "serial.h"
 
 #if ENABLED(POSTMORTEM_DEBUGGING)
   // Useful macro for stopping the CPU on an unexpected condition
-  // This is used like SERIAL_ECHOPAIR, that is: a key-value call of the local variables you want
+  // This is used like SERIAL_ECHOPGM, that is: a key-value call of the local variables you want
   // to dump to the serial port before stopping the CPU.
-                          // \/ Don't replace by SERIAL_ECHOPAIR since ONLY_FILENAME cannot be transformed to a PGM string on Arduino and it breaks building
-  #define BUG_ON(V...) do { SERIAL_ECHO(ONLY_FILENAME); SERIAL_ECHO(__LINE__); SERIAL_ECHOLNPGM(": "); SERIAL_ECHOLNPAIR(V); SERIAL_FLUSHTX(); *(char*)0 = 42; } while(0)
+                          // \/ Don't replace by SERIAL_ECHOPGM since ONLY_FILENAME cannot be transformed to a PGM string on Arduino and it breaks building
+  #define BUG_ON(V...) do { SERIAL_ECHO(ONLY_FILENAME); SERIAL_ECHO(__LINE__); SERIAL_ECHOLNPGM(": "); SERIAL_ECHOLNPGM(V); SERIAL_FLUSHTX(); *(char*)0 = 42; } while(0)
 #elif ENABLED(MARLIN_DEV_MODE)
   // Don't stop the CPU here, but at least dump the bug on the serial port
-                          // \/ Don't replace by SERIAL_ECHOPAIR since ONLY_FILENAME cannot be transformed to a PGM string on Arduino and it breaks building
-  #define BUG_ON(V...) do { SERIAL_ECHO(ONLY_FILENAME); SERIAL_ECHO(__LINE__); SERIAL_ECHOLNPGM(": BUG!"); SERIAL_ECHOLNPAIR(V); SERIAL_FLUSHTX(); } while(0)
+                          // \/ Don't replace by SERIAL_ECHOPGM since ONLY_FILENAME cannot be transformed to a PGM string on Arduino and it breaks building
+  #define BUG_ON(V...) do { SERIAL_ECHO(ONLY_FILENAME); SERIAL_ECHO(__LINE__); SERIAL_ECHOLNPGM(": BUG!"); SERIAL_ECHOLNPGM(V); SERIAL_FLUSHTX(); } while(0)
 #else
   // Release mode, let's ignore the bug
   #define BUG_ON(V...) NOOP

--- a/Marlin/src/core/debug_out.h
+++ b/Marlin/src/core/debug_out.h
@@ -27,7 +27,6 @@
 //
 
 #undef DEBUG_SECTION
-#undef DEBUG_ECHOPGM_P
 #undef DEBUG_ECHO_START
 #undef DEBUG_ERROR_START
 #undef DEBUG_CHAR
@@ -37,12 +36,10 @@
 #undef DEBUG_ECHOLN
 #undef DEBUG_ECHOPGM
 #undef DEBUG_ECHOLNPGM
-#undef DEBUG_ECHOPAIR
-#undef DEBUG_ECHOPAIR_P
+#undef DEBUG_ECHOPGM_P
+#undef DEBUG_ECHOLNPGM_P
 #undef DEBUG_ECHOPAIR_F
 #undef DEBUG_ECHOPAIR_F_P
-#undef DEBUG_ECHOLNPAIR
-#undef DEBUG_ECHOLNPAIR_P
 #undef DEBUG_ECHOLNPAIR_F
 #undef DEBUG_ECHOLNPAIR_F_P
 #undef DEBUG_ECHO_MSG
@@ -69,12 +66,12 @@
   #define DEBUG_ECHOLN            SERIAL_ECHOLN
   #define DEBUG_ECHOPGM           SERIAL_ECHOPGM
   #define DEBUG_ECHOLNPGM         SERIAL_ECHOLNPGM
-  #define DEBUG_ECHOPAIR          SERIAL_ECHOPAIR
-  #define DEBUG_ECHOPAIR_P        SERIAL_ECHOPAIR_P
+  #define DEBUG_ECHOPGM           SERIAL_ECHOPGM
+  #define DEBUG_ECHOPGM_P         SERIAL_ECHOPGM_P
   #define DEBUG_ECHOPAIR_F        SERIAL_ECHOPAIR_F
   #define DEBUG_ECHOPAIR_F_P      SERIAL_ECHOPAIR_F_P
-  #define DEBUG_ECHOLNPAIR        SERIAL_ECHOLNPAIR
-  #define DEBUG_ECHOLNPAIR_P      SERIAL_ECHOLNPAIR_P
+  #define DEBUG_ECHOLNPGM         SERIAL_ECHOLNPGM
+  #define DEBUG_ECHOLNPGM_P       SERIAL_ECHOLNPGM_P
   #define DEBUG_ECHOLNPAIR_F      SERIAL_ECHOLNPAIR_F
   #define DEBUG_ECHOLNPAIR_F_P    SERIAL_ECHOLNPAIR_F_P
   #define DEBUG_ECHO_MSG          SERIAL_ECHO_MSG
@@ -89,7 +86,6 @@
 #else
 
   #define DEBUG_SECTION(...)        NOOP
-  #define DEBUG_ECHOPGM_P(P)          NOOP
   #define DEBUG_ECHO_START()        NOOP
   #define DEBUG_ERROR_START()       NOOP
   #define DEBUG_CHAR(...)           NOOP
@@ -99,12 +95,10 @@
   #define DEBUG_ECHOLN(...)         NOOP
   #define DEBUG_ECHOPGM(...)        NOOP
   #define DEBUG_ECHOLNPGM(...)      NOOP
-  #define DEBUG_ECHOPAIR(...)       NOOP
-  #define DEBUG_ECHOPAIR_P(...)     NOOP
+  #define DEBUG_ECHOPGM_P(...)      NOOP
+  #define DEBUG_ECHOLNPGM_P(...)    NOOP
   #define DEBUG_ECHOPAIR_F(...)     NOOP
   #define DEBUG_ECHOPAIR_F_P(...)   NOOP
-  #define DEBUG_ECHOLNPAIR(...)     NOOP
-  #define DEBUG_ECHOLNPAIR_P(...)   NOOP
   #define DEBUG_ECHOLNPAIR_F(...)   NOOP
   #define DEBUG_ECHOLNPAIR_F_P(...) NOOP
   #define DEBUG_ECHO_MSG(...)       NOOP

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -158,9 +158,7 @@
 #define STR_OFF                             "OFF"
 #define STR_ENDSTOP_HIT                     "TRIGGERED"
 #define STR_ENDSTOP_OPEN                    "open"
-#define STR_HOTEND_OFFSET                   "Hotend offsets:"
 #define STR_DUPLICATION_MODE                "Duplication mode: "
-#define STR_SOFT_ENDSTOPS                   "Soft endstops: "
 #define STR_SOFT_MIN                        "  Min: "
 #define STR_SOFT_MAX                        "  Max: "
 
@@ -262,6 +260,49 @@
 #define STR_REMINDER_SAVE_SETTINGS          "Remember to save!"
 #define STR_PASSWORD_SET                    "Password is "
 
+// Settings Report Strings
+#define STR_Z_AUTO_ALIGN                    "Z Auto-Align"
+#define STR_BACKLASH_COMPENSATION           "Backlash compensation"
+#define STR_DELTA_SETTINGS                  "Delta settings (L<diagonal-rod> R<radius> H<height> S<segments-per-sec> XYZ<tower-angle-trim> ABC<rod-trim>)"
+#define STR_SCARA_SETTINGS                  "SCARA settings"
+#define STR_SCARA_S                         "S<seg-per-sec>"
+#define STR_SCARA_P_T_Z                     "P<theta-psi-offset> T<theta-offset> Z<home-offset>"
+#define STR_ENDSTOP_ADJUSTMENT              "Endstop adjustment"
+#define STR_SKEW_FACTOR                     "Skew Factor"
+#define STR_FILAMENT_SETTINGS               "Filament settings"
+#define STR_MAX_ACCELERATION                "Max Acceleration (units/s2)"
+#define STR_MAX_FEEDRATES                   "Max feedrates (units/s)"
+#define STR_ACCELERATION_P_R_T              "Acceleration (units/s2) (P<print-accel> R<retract-accel> T<travel-accel>)"
+#define STR_TOOL_CHANGING                   "Tool-changing"
+#define STR_HOTEND_OFFSETS                  "Hotend offsets"
+#define STR_SERVO_ANGLES                    "Servo Angles"
+#define STR_HOTEND_PID                      "Hotend PID"
+#define STR_BED_PID                         "Bed PID"
+#define STR_CHAMBER_PID                     "Chamber PID"
+#define STR_STEPS_PER_UNIT                  "Steps per unit"
+#define STR_LINEAR_ADVANCE                  "Linear Advance"
+#define STR_CONTROLLER_FAN                  "Controller Fan"
+#define STR_STEPPER_MOTOR_CURRENTS          "Stepper motor currents"
+#define STR_RETRACT_S_F_Z                   "Retract (S<length> F<feedrate> Z<lift>)"
+#define STR_RECOVER_S_F                     "Recover (S<length> F<feedrate>)"
+#define STR_AUTO_RETRACT_S                  "Auto-Retract (S<enable>)"
+#define STR_FILAMENT_LOAD_UNLOAD            "Filament load/unload"
+#define STR_POWER_LOSS_RECOVERY             "Power-loss recovery"
+#define STR_FILAMENT_RUNOUT_SENSOR          "Filament runout sensor"
+#define STR_DRIVER_STEPPING_MODE            "Driver stepping mode"
+#define STR_STEPPER_DRIVER_CURRENT          "Stepper driver current"
+#define STR_HYBRID_THRESHOLD                "Hybrid Threshold"
+#define STR_STALLGUARD_THRESHOLD            "StallGuard threshold"
+#define STR_HOME_OFFSET                     "Home offset"
+#define STR_SOFT_ENDSTOPS                   "Soft endstops"
+#define STR_MATERIAL_HEATUP                 "Material heatup parameters"
+#define STR_LCD_CONTRAST                    "LCD Contrast"
+#define STR_LCD_BRIGHTNESS                  "LCD Brightness"
+#define STR_UI_LANGUAGE                     "UI Language"
+#define STR_Z_PROBE_OFFSET                  "Z-Probe Offset"
+#define STR_TEMPERATURE_UNITS               "Temperature Units"
+#define STR_USER_THERMISTORS                "User thermistors"
+
 //
 // Endstop Names used by Endstops::report_states
 //
@@ -290,7 +331,7 @@
 
 #define STR_Z_PROBE                         "z_probe"
 #define STR_PROBE_EN                        "probe_en"
-#define STR_FILAMENT_RUNOUT_SENSOR          "filament"
+#define STR_FILAMENT                        "filament"
 
 // General axis names
 #define STR_X "X"

--- a/Marlin/src/core/serial.cpp
+++ b/Marlin/src/core/serial.cpp
@@ -96,7 +96,7 @@ void print_bin(uint16_t val) {
 
 void print_pos(LINEAR_AXIS_ARGS(const_float_t), PGM_P const prefix/*=nullptr*/, PGM_P const suffix/*=nullptr*/) {
   if (prefix) serialprintPGM(prefix);
-  SERIAL_ECHOPAIR_P(
+  SERIAL_ECHOPGM_P(
     LIST_N(DOUBLE(LINEAR_AXES), SP_X_STR, x, SP_Y_STR, y, SP_Z_STR, z, SP_I_STR, i, SP_J_STR, j, SP_K_STR, k)
   );
   if (suffix) serialprintPGM(suffix); else SERIAL_EOL();

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -188,44 +188,44 @@ inline void SERIAL_FLUSHTX()  { SERIAL_IMPL.flushTX(); }
 void serialprintPGM(PGM_P str);
 
 //
-// SERIAL_ECHOPAIR... macros are used to output string-value pairs.
+// SERIAL_ECHOPGM... macros are used to output string-value pairs.
 //
 
 // Print up to 20 pairs of values. Odd elements must be literal strings.
 #define __SEP_N(N,V...)           _SEP_##N(V)
 #define _SEP_N(N,V...)            __SEP_N(N,V)
 #define _SEP_N_REF()              _SEP_N
-#define _SEP_1(s)                 SERIAL_ECHOPGM(s);
+#define _SEP_1(s)                 serialprintPGM(PSTR(s));
 #define _SEP_2(s,v)               serial_echopair_PGM(PSTR(s),v);
 #define _SEP_3(s,v,V...)          _SEP_2(s,v); DEFER2(_SEP_N_REF)()(TWO_ARGS(V),V);
-#define SERIAL_ECHOPAIR(V...)     do{ EVAL(_SEP_N(TWO_ARGS(V),V)); }while(0)
+#define SERIAL_ECHOPGM(V...)      do{ EVAL(_SEP_N(TWO_ARGS(V),V)); }while(0)
 
 // Print up to 20 pairs of values followed by newline. Odd elements must be literal strings.
 #define __SELP_N(N,V...)          _SELP_##N(V)
 #define _SELP_N(N,V...)           __SELP_N(N,V)
 #define _SELP_N_REF()             _SELP_N
-#define _SELP_1(s)                SERIAL_ECHOLNPGM(s);
+#define _SELP_1(s)                serialprintPGM(PSTR(s "\n"));
 #define _SELP_2(s,v)              serial_echopair_PGM(PSTR(s),v); SERIAL_EOL();
 #define _SELP_3(s,v,V...)         _SEP_2(s,v); DEFER2(_SELP_N_REF)()(TWO_ARGS(V),V);
-#define SERIAL_ECHOLNPAIR(V...)   do{ EVAL(_SELP_N(TWO_ARGS(V),V)); }while(0)
+#define SERIAL_ECHOLNPGM(V...)    do{ EVAL(_SELP_N(TWO_ARGS(V),V)); }while(0)
 
 // Print up to 20 pairs of values. Odd elements must be PSTR pointers.
 #define __SEP_N_P(N,V...)         _SEP_##N##_P(V)
 #define _SEP_N_P(N,V...)          __SEP_N_P(N,V)
 #define _SEP_N_P_REF()            _SEP_N_P
-#define _SEP_1_P(s)               serialprintPGM(s);
-#define _SEP_2_P(s,v)             serial_echopair_PGM(s,v);
-#define _SEP_3_P(s,v,V...)        _SEP_2_P(s,v); DEFER2(_SEP_N_P_REF)()(TWO_ARGS(V),V);
-#define SERIAL_ECHOPAIR_P(V...)   do{ EVAL(_SEP_N_P(TWO_ARGS(V),V)); }while(0)
+#define _SEP_1_P(p)               serialprintPGM(p);
+#define _SEP_2_P(p,v)             serial_echopair_PGM(p,v);
+#define _SEP_3_P(p,v,V...)        _SEP_2_P(p,v); DEFER2(_SEP_N_P_REF)()(TWO_ARGS(V),V);
+#define SERIAL_ECHOPGM_P(V...)    do{ EVAL(_SEP_N_P(TWO_ARGS(V),V)); }while(0)
 
 // Print up to 20 pairs of values followed by newline. Odd elements must be PSTR pointers.
 #define __SELP_N_P(N,V...)        _SELP_##N##_P(V)
 #define _SELP_N_P(N,V...)         __SELP_N_P(N,V)
 #define _SELP_N_P_REF()           _SELP_N_P
-#define _SELP_1_P(s)              { serialprintPGM(s); SERIAL_EOL(); }
-#define _SELP_2_P(s,v)            { serial_echopair_PGM(s,v); SERIAL_EOL(); }
-#define _SELP_3_P(s,v,V...)       { _SEP_2_P(s,v); DEFER2(_SELP_N_P_REF)()(TWO_ARGS(V),V); }
-#define SERIAL_ECHOLNPAIR_P(V...) do{ EVAL(_SELP_N_P(TWO_ARGS(V),V)); }while(0)
+#define _SELP_1_P(p)              { serialprintPGM(p); SERIAL_EOL(); }
+#define _SELP_2_P(p,v)            { serial_echopair_PGM(p,v); SERIAL_EOL(); }
+#define _SELP_3_P(p,v,V...)       { _SEP_2_P(p,v); DEFER2(_SELP_N_P_REF)()(TWO_ARGS(V),V); }
+#define SERIAL_ECHOLNPGM_P(V...)  do{ EVAL(_SELP_N_P(TWO_ARGS(V),V)); }while(0)
 
 #ifdef AllowDifferentTypeInList
 
@@ -261,12 +261,6 @@ void serialprintPGM(PGM_P str);
 
 #endif
 
-#define SERIAL_ECHOPGM_P(P)         (serialprintPGM(P))
-#define SERIAL_ECHOLNPGM_P(P)       do{ serialprintPGM(P); SERIAL_EOL(); }while(0)
-
-#define SERIAL_ECHOPGM(S)           (serialprintPGM(PSTR(S)))
-#define SERIAL_ECHOLNPGM(S)         (serialprintPGM(PSTR(S "\n")))
-
 #define SERIAL_ECHOPAIR_F_P(P,V...) do{ serialprintPGM(P); SERIAL_ECHO_F(V); }while(0)
 #define SERIAL_ECHOLNPAIR_F_P(V...) do{ SERIAL_ECHOPAIR_F_P(V); SERIAL_EOL(); }while(0)
 
@@ -277,8 +271,8 @@ void serialprintPGM(PGM_P str);
 #define SERIAL_ERROR_START()        serial_error_start()
 #define SERIAL_EOL()                SERIAL_CHAR('\n')
 
-#define SERIAL_ECHO_MSG(V...)       do{ SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR(V); }while(0)
-#define SERIAL_ERROR_MSG(V...)      do{ SERIAL_ERROR_START(); SERIAL_ECHOLNPAIR(V); }while(0)
+#define SERIAL_ECHO_MSG(V...)       do{ SERIAL_ECHO_START();  SERIAL_ECHOLNPGM(V); }while(0)
+#define SERIAL_ERROR_MSG(V...)      do{ SERIAL_ERROR_START(); SERIAL_ECHOLNPGM(V); }while(0)
 
 #define SERIAL_ECHO_SP(C)           serial_spaces(C)
 

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -55,6 +55,8 @@ struct IF<true, L, R> { typedef L type; };
 #define LOGICAL_AXIS_ELEM(O)    LOGICAL_AXIS_LIST(O.e, O.x, O.y, O.z, O.i, O.j, O.k)
 #define LOGICAL_AXIS_DECL(T,V)  LOGICAL_AXIS_LIST(T e=V, T x=V, T y=V, T z=V, T i=V, T j=V, T k=V)
 
+#define LOGICAL_AXES_STRING LOGICAL_AXIS_GANG("E", "X", "Y", "Z", AXIS4_STR, AXIS5_STR, AXIS6_STR)
+
 #if HAS_EXTRUDERS
   #define LIST_ITEM_E(N) , N
   #define CODE_ITEM_E(N) ; N

--- a/Marlin/src/core/utility.cpp
+++ b/Marlin/src/core/utility.cpp
@@ -79,9 +79,9 @@ void safe_delay(millis_t ms) {
     #if HAS_BED_PROBE
 
       #if !HAS_PROBE_XY_OFFSET
-        SERIAL_ECHOPAIR("Probe Offset X0 Y0 Z", probe.offset.z, " (");
+        SERIAL_ECHOPGM("Probe Offset X0 Y0 Z", probe.offset.z, " (");
       #else
-        SERIAL_ECHOPAIR_P(PSTR("Probe Offset X"), probe.offset_xy.x, SP_Y_STR, probe.offset_xy.y, SP_Z_STR, probe.offset.z);
+        SERIAL_ECHOPGM_P(PSTR("Probe Offset X"), probe.offset_xy.x, SP_Y_STR, probe.offset_xy.y, SP_Z_STR, probe.offset.z);
         if (probe.offset_xy.x > 0)
           SERIAL_ECHOPGM(" (Right");
         else if (probe.offset_xy.x < 0)
@@ -119,7 +119,7 @@ void safe_delay(millis_t ms) {
         SERIAL_ECHOLNPGM(" (enabled)");
         #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
           if (planner.z_fade_height)
-            SERIAL_ECHOLNPAIR("Z Fade: ", planner.z_fade_height);
+            SERIAL_ECHOLNPGM("Z Fade: ", planner.z_fade_height);
         #endif
         #if ABL_PLANAR
           SERIAL_ECHOPGM("ABL Adjustment");
@@ -140,7 +140,7 @@ void safe_delay(millis_t ms) {
           SERIAL_ECHO(ftostr43sign(rz, '+'));
           #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
             if (planner.z_fade_height) {
-              SERIAL_ECHOPAIR(" (", ftostr43sign(rz * planner.fade_scaling_factor_for_z(current_position.z), '+'));
+              SERIAL_ECHOPGM(" (", ftostr43sign(rz * planner.fade_scaling_factor_for_z(current_position.z), '+'));
               SERIAL_CHAR(')');
             }
           #endif
@@ -156,10 +156,10 @@ void safe_delay(millis_t ms) {
       SERIAL_ECHOPGM("Mesh Bed Leveling");
       if (planner.leveling_active) {
         SERIAL_ECHOLNPGM(" (enabled)");
-        SERIAL_ECHOPAIR("MBL Adjustment Z", ftostr43sign(mbl.get_z(current_position), '+'));
+        SERIAL_ECHOPGM("MBL Adjustment Z", ftostr43sign(mbl.get_z(current_position), '+'));
         #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
           if (planner.z_fade_height) {
-            SERIAL_ECHOPAIR(" (", ftostr43sign(
+            SERIAL_ECHOPGM(" (", ftostr43sign(
               mbl.get_z(current_position, planner.fade_scaling_factor_for_z(current_position.z)), '+'
             ));
             SERIAL_CHAR(')');

--- a/Marlin/src/feature/backlash.cpp
+++ b/Marlin/src/feature/backlash.cpp
@@ -134,12 +134,12 @@ void Backlash::add_correction_steps(const int32_t &da, const int32_t &db, const 
           switch (axis) {
             case CORE_AXIS_1:
               //block->steps[CORE_AXIS_2] += influence_distance_mm[axis] * planner.settings.axis_steps_per_mm[CORE_AXIS_2];
-              //SERIAL_ECHOLNPAIR("CORE_AXIS_1 dir change. distance=", distance_mm[axis], " r.err=", residual_error[axis],
+              //SERIAL_ECHOLNPGM("CORE_AXIS_1 dir change. distance=", distance_mm[axis], " r.err=", residual_error[axis],
               //  " da=", da, " db=", db, " block->steps[axis]=", block->steps[axis], " err_corr=", error_correction);
               break;
             case CORE_AXIS_2:
               //block->steps[CORE_AXIS_1] += influence_distance_mm[axis] * planner.settings.axis_steps_per_mm[CORE_AXIS_1];;
-              //SERIAL_ECHOLNPAIR("CORE_AXIS_2 dir change. distance=", distance_mm[axis], " r.err=", residual_error[axis],
+              //SERIAL_ECHOLNPGM("CORE_AXIS_2 dir change. distance=", distance_mm[axis], " r.err=", residual_error[axis],
               //  " da=", da, " db=", db, " block->steps[axis]=", block->steps[axis], " err_corr=", error_correction);
               break;
             case NORMAL_AXIS: break;

--- a/Marlin/src/feature/bedlevel/abl/abl.cpp
+++ b/Marlin/src/feature/bedlevel/abl/abl.cpp
@@ -336,11 +336,11 @@ float bilinear_z_offset(const xy_pos_t &raw) {
   /*
   static float last_offset = 0;
   if (ABS(last_offset - offset) > 0.2) {
-    SERIAL_ECHOLNPAIR("Sudden Shift at x=", rel.x, " / ", bilinear_grid_spacing.x, " -> thisg.x=", thisg.x);
-    SERIAL_ECHOLNPAIR(" y=", rel.y, " / ", bilinear_grid_spacing.y, " -> thisg.y=", thisg.y);
-    SERIAL_ECHOLNPAIR(" ratio.x=", ratio.x, " ratio.y=", ratio.y);
-    SERIAL_ECHOLNPAIR(" z1=", z1, " z2=", z2, " z3=", z3, " z4=", z4);
-    SERIAL_ECHOLNPAIR(" L=", L, " R=", R, " offset=", offset);
+    SERIAL_ECHOLNPGM("Sudden Shift at x=", rel.x, " / ", bilinear_grid_spacing.x, " -> thisg.x=", thisg.x);
+    SERIAL_ECHOLNPGM(" y=", rel.y, " / ", bilinear_grid_spacing.y, " -> thisg.y=", thisg.y);
+    SERIAL_ECHOLNPGM(" ratio.x=", ratio.x, " ratio.y=", ratio.y);
+    SERIAL_ECHOLNPGM(" z1=", z1, " z2=", z2, " z3=", z3, " z4=", z4);
+    SERIAL_ECHOLNPGM(" L=", L, " R=", R, " offset=", offset);
   }
   last_offset = offset;
   //*/

--- a/Marlin/src/feature/bedlevel/ubl/ubl.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.cpp
@@ -51,7 +51,7 @@ void unified_bed_leveling::report_current_mesh() {
   GRID_LOOP(x, y)
     if (!isnan(z_values[x][y])) {
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR("  M421 I", x, " J", y);
+      SERIAL_ECHOPGM("  M421 I", x, " J", y);
       SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, z_values[x][y], 4);
       serial_delay(75); // Prevent Printrun from exploding
     }

--- a/Marlin/src/feature/bedlevel/ubl/ubl.h
+++ b/Marlin/src/feature/bedlevel/ubl/ubl.h
@@ -208,7 +208,7 @@ public:
 
       if (DEBUGGING(LEVELING)) {
         if (WITHIN(x1_i, 0, (GRID_MAX_POINTS_X) - 1)) DEBUG_ECHOPGM("yi"); else DEBUG_ECHOPGM("x1_i");
-        DEBUG_ECHOLNPAIR(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(rx0=", rx0, ",x1_i=", x1_i, ",yi=", yi, ")");
+        DEBUG_ECHOLNPGM(" out of bounds in z_correction_for_x_on_horizontal_mesh_line(rx0=", rx0, ",x1_i=", x1_i, ",yi=", yi, ")");
       }
 
       // The requested location is off the mesh. Return UBL_Z_RAISE_WHEN_OFF_MESH or NAN.
@@ -231,7 +231,7 @@ public:
 
       if (DEBUGGING(LEVELING)) {
         if (WITHIN(xi, 0, (GRID_MAX_POINTS_X) - 1)) DEBUG_ECHOPGM("y1_i"); else DEBUG_ECHOPGM("xi");
-        DEBUG_ECHOLNPAIR(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ry0=", ry0, ", xi=", xi, ", y1_i=", y1_i, ")");
+        DEBUG_ECHOLNPGM(" out of bounds in z_correction_for_y_on_vertical_mesh_line(ry0=", ry0, ", xi=", xi, ", y1_i=", y1_i, ")");
       }
 
       // The requested location is off the mesh. Return UBL_Z_RAISE_WHEN_OFF_MESH or NAN.
@@ -275,11 +275,11 @@ public:
                      // because part of the Mesh is undefined and we don't have the
                      // information we need to complete the height correction.
 
-      if (DEBUGGING(MESH_ADJUST)) DEBUG_ECHOLNPAIR("??? Yikes! NAN in ");
+      if (DEBUGGING(MESH_ADJUST)) DEBUG_ECHOLNPGM("??? Yikes! NAN in ");
     }
 
     if (DEBUGGING(MESH_ADJUST)) {
-      DEBUG_ECHOPAIR("get_z_correction(", rx0, ", ", ry0);
+      DEBUG_ECHOPGM("get_z_correction(", rx0, ", ", ry0);
       DEBUG_ECHOLNPAIR_F(") => ", z0, 6);
     }
 

--- a/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
+++ b/Marlin/src/feature/bedlevel/ubl/ubl_G29.cpp
@@ -428,7 +428,7 @@ void unified_bed_leveling::G29() {
             SERIAL_ECHOLNPGM("Mesh invalidated. Probing mesh.");
           }
           if (param.V_verbosity > 1) {
-            SERIAL_ECHOPAIR("Probing around (", param.XY_pos.x);
+            SERIAL_ECHOPGM("Probing around (", param.XY_pos.x);
             SERIAL_CHAR(',');
             SERIAL_DECIMAL(param.XY_pos.y);
             SERIAL_ECHOLNPGM(").\n");
@@ -602,7 +602,7 @@ void unified_bed_leveling::G29() {
     }
 
     if (!WITHIN(param.KLS_storage_slot, 0, a - 1)) {
-      SERIAL_ECHOLNPAIR("?Invalid storage slot.\n?Use 0 to ", a - 1);
+      SERIAL_ECHOLNPGM("?Invalid storage slot.\n?Use 0 to ", a - 1);
       return;
     }
 
@@ -630,7 +630,7 @@ void unified_bed_leveling::G29() {
     }
 
     if (!WITHIN(param.KLS_storage_slot, 0, a - 1)) {
-      SERIAL_ECHOLNPAIR("?Invalid storage slot.\n?Use 0 to ", a - 1);
+      SERIAL_ECHOLNPGM("?Invalid storage slot.\n?Use 0 to ", a - 1);
       goto LEAVE;
     }
 
@@ -653,7 +653,7 @@ void unified_bed_leveling::G29() {
   #endif
 
   #ifdef Z_PROBE_END_SCRIPT
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
     if (probe_deployed) {
       planner.synchronize();
       gcode.process_subcommands_now_P(PSTR(Z_PROBE_END_SCRIPT));
@@ -690,7 +690,7 @@ void unified_bed_leveling::adjust_mesh_to_mean(const bool cflag, const_float_t o
     if (!isnan(z_values[x][y]))
       sum_of_diff_squared += sq(z_values[x][y] - mean);
 
-  SERIAL_ECHOLNPAIR("# of samples: ", n);
+  SERIAL_ECHOLNPGM("# of samples: ", n);
   SERIAL_ECHOLNPAIR_F("Mean Mesh Height: ", mean, 6);
 
   const float sigma = SQRT(sum_of_diff_squared / (n + 1));
@@ -735,7 +735,7 @@ void unified_bed_leveling::shift_mesh_height() {
       if (do_ubl_mesh_map) display_map(param.T_map_type);
 
       const uint8_t point_num = (GRID_MAX_POINTS - count) + 1;
-      SERIAL_ECHOLNPAIR("Probing mesh point ", point_num, "/", GRID_MAX_POINTS, ".");
+      SERIAL_ECHOLNPGM("Probing mesh point ", point_num, "/", GRID_MAX_POINTS, ".");
       TERN_(HAS_STATUS_MESSAGE, ui.status_printf_P(0, PSTR(S_FMT " %i/%i"), GET_TEXT(MSG_PROBING_POINT), point_num, int(GRID_MAX_POINTS)));
 
       #if HAS_LCD_MENU
@@ -1450,7 +1450,7 @@ void unified_bed_leveling::smart_fill_mesh() {
         #endif
         if (param.V_verbosity > 3) {
           serial_spaces(16);
-          SERIAL_ECHOLNPAIR("Corrected_Z=", measured_z);
+          SERIAL_ECHOLNPGM("Corrected_Z=", measured_z);
         }
         incremental_LSF(&lsf_results, points[0], measured_z);
       }
@@ -1469,7 +1469,7 @@ void unified_bed_leveling::smart_fill_mesh() {
           measured_z -= get_z_correction(points[1]);
           if (param.V_verbosity > 3) {
             serial_spaces(16);
-            SERIAL_ECHOLNPAIR("Corrected_Z=", measured_z);
+            SERIAL_ECHOLNPGM("Corrected_Z=", measured_z);
           }
           incremental_LSF(&lsf_results, points[1], measured_z);
         }
@@ -1489,7 +1489,7 @@ void unified_bed_leveling::smart_fill_mesh() {
           measured_z -= get_z_correction(points[2]);
           if (param.V_verbosity > 3) {
             serial_spaces(16);
-            SERIAL_ECHOLNPAIR("Corrected_Z=", measured_z);
+            SERIAL_ECHOLNPGM("Corrected_Z=", measured_z);
           }
           incremental_LSF(&lsf_results, points[2], measured_z);
         }
@@ -1517,7 +1517,7 @@ void unified_bed_leveling::smart_fill_mesh() {
           rpos.y = y_min + dy * (zig_zag ? param.J_grid_size - 1 - iy : iy);
 
           if (!abort_flag) {
-            SERIAL_ECHOLNPAIR("Tilting mesh point ", point_num, "/", total_points, "\n");
+            SERIAL_ECHOLNPGM("Tilting mesh point ", point_num, "/", total_points, "\n");
             TERN_(HAS_STATUS_MESSAGE, ui.status_printf_P(0, PSTR(S_FMT " %i/%i"), GET_TEXT(MSG_LCD_TILTING_MESH), point_num, total_points));
 
             measured_z = probe.probe_at_point(rpos, parser.seen_test('E') ? PROBE_PT_STOW : PROBE_PT_RAISE, param.V_verbosity); // TODO: Needs error handling
@@ -1545,7 +1545,7 @@ void unified_bed_leveling::smart_fill_mesh() {
 
             if (param.V_verbosity > 3) {
               serial_spaces(16);
-              SERIAL_ECHOLNPAIR("Corrected_Z=", measured_z);
+              SERIAL_ECHOLNPGM("Corrected_Z=", measured_z);
             }
             incremental_LSF(&lsf_results, rpos, measured_z);
           }
@@ -1648,7 +1648,7 @@ void unified_bed_leveling::smart_fill_mesh() {
         DEBUG_ECHOLNPAIR_F("0 : ", normed(safe_homing_xy, 0), 6);
         d_from(); DEBUG_ECHOPGM("safe home with Z=");
         DEBUG_ECHOLNPAIR_F("mesh value ", normed(safe_homing_xy, get_z_correction(safe_homing_xy)), 6);
-        DEBUG_ECHOPAIR("   Z error = (", Z_SAFE_HOMING_X_POINT, ",", Z_SAFE_HOMING_Y_POINT);
+        DEBUG_ECHOPGM("   Z error = (", Z_SAFE_HOMING_X_POINT, ",", Z_SAFE_HOMING_Y_POINT);
         DEBUG_ECHOLNPAIR_F(") = ", get_z_correction(safe_homing_xy), 6);
       #endif
     } // DEBUGGING(LEVELING)
@@ -1722,7 +1722,7 @@ void unified_bed_leveling::smart_fill_mesh() {
     if (storage_slot == -1)
       SERIAL_ECHOPGM("No Mesh Loaded.");
     else
-      SERIAL_ECHOPAIR("Mesh ", storage_slot, " Loaded.");
+      SERIAL_ECHOPGM("Mesh ", storage_slot, " Loaded.");
     SERIAL_EOL();
     serial_delay(50);
 
@@ -1736,14 +1736,14 @@ void unified_bed_leveling::smart_fill_mesh() {
       SERIAL_ECHOLNPAIR_F("Probe Offset M851 Z", probe.offset.z, 7);
     #endif
 
-    SERIAL_ECHOLNPAIR("MESH_MIN_X  " STRINGIFY(MESH_MIN_X) "=", MESH_MIN_X); serial_delay(50);
-    SERIAL_ECHOLNPAIR("MESH_MIN_Y  " STRINGIFY(MESH_MIN_Y) "=", MESH_MIN_Y); serial_delay(50);
-    SERIAL_ECHOLNPAIR("MESH_MAX_X  " STRINGIFY(MESH_MAX_X) "=", MESH_MAX_X); serial_delay(50);
-    SERIAL_ECHOLNPAIR("MESH_MAX_Y  " STRINGIFY(MESH_MAX_Y) "=", MESH_MAX_Y); serial_delay(50);
-    SERIAL_ECHOLNPAIR("GRID_MAX_POINTS_X  ", GRID_MAX_POINTS_X);             serial_delay(50);
-    SERIAL_ECHOLNPAIR("GRID_MAX_POINTS_Y  ", GRID_MAX_POINTS_Y);             serial_delay(50);
-    SERIAL_ECHOLNPAIR("MESH_X_DIST  ", MESH_X_DIST);
-    SERIAL_ECHOLNPAIR("MESH_Y_DIST  ", MESH_Y_DIST);                         serial_delay(50);
+    SERIAL_ECHOLNPGM("MESH_MIN_X  " STRINGIFY(MESH_MIN_X) "=", MESH_MIN_X); serial_delay(50);
+    SERIAL_ECHOLNPGM("MESH_MIN_Y  " STRINGIFY(MESH_MIN_Y) "=", MESH_MIN_Y); serial_delay(50);
+    SERIAL_ECHOLNPGM("MESH_MAX_X  " STRINGIFY(MESH_MAX_X) "=", MESH_MAX_X); serial_delay(50);
+    SERIAL_ECHOLNPGM("MESH_MAX_Y  " STRINGIFY(MESH_MAX_Y) "=", MESH_MAX_Y); serial_delay(50);
+    SERIAL_ECHOLNPGM("GRID_MAX_POINTS_X  ", GRID_MAX_POINTS_X);             serial_delay(50);
+    SERIAL_ECHOLNPGM("GRID_MAX_POINTS_Y  ", GRID_MAX_POINTS_Y);             serial_delay(50);
+    SERIAL_ECHOLNPGM("MESH_X_DIST  ", MESH_X_DIST);
+    SERIAL_ECHOLNPGM("MESH_Y_DIST  ", MESH_Y_DIST);                         serial_delay(50);
 
     SERIAL_ECHOPGM("X-Axis Mesh Points at: ");
     LOOP_L_N(i, GRID_MAX_POINTS_X) {
@@ -1762,27 +1762,27 @@ void unified_bed_leveling::smart_fill_mesh() {
     SERIAL_EOL();
 
     #if HAS_KILL
-      SERIAL_ECHOLNPAIR("Kill pin on :", KILL_PIN, "  state:", kill_state());
+      SERIAL_ECHOLNPGM("Kill pin on :", KILL_PIN, "  state:", kill_state());
     #endif
 
     SERIAL_EOL();
     serial_delay(50);
 
     #if ENABLED(UBL_DEVEL_DEBUGGING)
-      SERIAL_ECHOLNPAIR("ubl_state_at_invocation :", ubl_state_at_invocation, "\nubl_state_recursion_chk :", ubl_state_recursion_chk);
+      SERIAL_ECHOLNPGM("ubl_state_at_invocation :", ubl_state_at_invocation, "\nubl_state_recursion_chk :", ubl_state_recursion_chk);
       serial_delay(50);
 
-      SERIAL_ECHOLNPAIR("Meshes go from ", hex_address((void*)settings.meshes_start_index()), " to ", hex_address((void*)settings.meshes_end_index()));
+      SERIAL_ECHOLNPGM("Meshes go from ", hex_address((void*)settings.meshes_start_index()), " to ", hex_address((void*)settings.meshes_end_index()));
       serial_delay(50);
 
-      SERIAL_ECHOLNPAIR("sizeof(ubl) :  ", sizeof(ubl));         SERIAL_EOL();
-      SERIAL_ECHOLNPAIR("z_value[][] size: ", sizeof(z_values)); SERIAL_EOL();
+      SERIAL_ECHOLNPGM("sizeof(ubl) :  ", sizeof(ubl));         SERIAL_EOL();
+      SERIAL_ECHOLNPGM("z_value[][] size: ", sizeof(z_values)); SERIAL_EOL();
       serial_delay(25);
 
-      SERIAL_ECHOLNPAIR("EEPROM free for UBL: ", hex_address((void*)(settings.meshes_end_index() - settings.meshes_start_index())));
+      SERIAL_ECHOLNPGM("EEPROM free for UBL: ", hex_address((void*)(settings.meshes_end_index() - settings.meshes_start_index())));
       serial_delay(50);
 
-      SERIAL_ECHOLNPAIR("EEPROM can hold ", settings.calc_num_meshes(), " meshes.\n");
+      SERIAL_ECHOLNPGM("EEPROM can hold ", settings.calc_num_meshes(), " meshes.\n");
       serial_delay(25);
     #endif // UBL_DEVEL_DEBUGGING
 
@@ -1829,7 +1829,7 @@ void unified_bed_leveling::smart_fill_mesh() {
     }
 
     if (!parser.has_value() || !WITHIN(parser.value_int(), 0, a - 1)) {
-      SERIAL_ECHOLNPAIR("?Invalid storage slot.\n?Use 0 to ", a - 1);
+      SERIAL_ECHOLNPGM("?Invalid storage slot.\n?Use 0 to ", a - 1);
       return;
     }
 
@@ -1838,7 +1838,7 @@ void unified_bed_leveling::smart_fill_mesh() {
     float tmp_z_values[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
     settings.load_mesh(param.KLS_storage_slot, &tmp_z_values);
 
-    SERIAL_ECHOLNPAIR("Subtracting mesh in slot ", param.KLS_storage_slot, " from current mesh.");
+    SERIAL_ECHOLNPGM("Subtracting mesh in slot ", param.KLS_storage_slot, " from current mesh.");
 
     GRID_LOOP(x, y) {
       z_values[x][y] -= tmp_z_values[x][y];

--- a/Marlin/src/feature/binary_stream.h
+++ b/Marlin/src/feature/binary_stream.h
@@ -146,9 +146,9 @@ public:
     transfer_timeout = millis() + TIMEOUT;
     switch (static_cast<FileTransfer>(packet_type)) {
       case FileTransfer::QUERY:
-        SERIAL_ECHOPAIR("PFT:version:", VERSION_MAJOR, ".", VERSION_MINOR, ".", VERSION_PATCH);
+        SERIAL_ECHOPGM("PFT:version:", VERSION_MAJOR, ".", VERSION_MINOR, ".", VERSION_PATCH);
         #if ENABLED(BINARY_STREAM_COMPRESSION)
-          SERIAL_ECHOLNPAIR(":compression:heatshrink,", HEATSHRINK_STATIC_WINDOW_BITS, ",", HEATSHRINK_STATIC_LOOKAHEAD_BITS);
+          SERIAL_ECHOLNPGM(":compression:heatshrink,", HEATSHRINK_STATIC_WINDOW_BITS, ",", HEATSHRINK_STATIC_LOOKAHEAD_BITS);
         #else
           SERIAL_ECHOLNPGM(":compression:none");
         #endif
@@ -322,7 +322,7 @@ public:
             if (packet.header.checksum == packet.header_checksum) {
               // The SYNC control packet is a special case in that it doesn't require the stream sync to be correct
               if (static_cast<Protocol>(packet.header.protocol()) == Protocol::CONTROL && static_cast<ProtocolControl>(packet.header.type()) == ProtocolControl::SYNC) {
-                  SERIAL_ECHOLNPAIR("ss", sync, ",", buffer_size, ",", VERSION_MAJOR, ".", VERSION_MINOR, ".", VERSION_PATCH);
+                  SERIAL_ECHOLNPGM("ss", sync, ",", buffer_size, ",", VERSION_MAJOR, ".", VERSION_MINOR, ".", VERSION_PATCH);
                   stream_state = StreamState::PACKET_RESET;
                   break;
               }
@@ -337,7 +337,7 @@ public:
                   stream_state = StreamState::PACKET_PROCESS;
               }
               else if (packet.header.sync == sync - 1) {           // ok response must have been lost
-                SERIAL_ECHOLNPAIR("ok", packet.header.sync);  // transmit valid packet received and drop the payload
+                SERIAL_ECHOLNPGM("ok", packet.header.sync);  // transmit valid packet received and drop the payload
                 stream_state = StreamState::PACKET_RESET;
               }
               else if (packet_retries) {
@@ -393,7 +393,7 @@ public:
           packet_retries = 0;
           bytes_received += packet.header.size;
 
-          SERIAL_ECHOLNPAIR("ok", packet.header.sync); // transmit valid packet received
+          SERIAL_ECHOLNPGM("ok", packet.header.sync); // transmit valid packet received
           dispatch();
           stream_state = StreamState::PACKET_RESET;
           break;
@@ -402,7 +402,7 @@ public:
             packet_retries++;
             stream_state = StreamState::PACKET_RESET;
             SERIAL_ECHO_MSG("Resend request ", packet_retries);
-            SERIAL_ECHOLNPAIR("rs", sync);
+            SERIAL_ECHOLNPGM("rs", sync);
           }
           else
             stream_state = StreamState::PACKET_ERROR;
@@ -412,7 +412,7 @@ public:
           stream_state = StreamState::PACKET_RESEND;
           break;
         case StreamState::PACKET_ERROR:
-          SERIAL_ECHOLNPAIR("fe", packet.header.sync);
+          SERIAL_ECHOLNPGM("fe", packet.header.sync);
           reset(); // reset everything, resync required
           stream_state = StreamState::PACKET_RESET;
           break;

--- a/Marlin/src/feature/bltouch.cpp
+++ b/Marlin/src/feature/bltouch.cpp
@@ -39,7 +39,7 @@ void stop();
 #include "../core/debug_out.h"
 
 bool BLTouch::command(const BLTCommand cmd, const millis_t &ms) {
-  if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPAIR("BLTouch Command :", cmd);
+  if (DEBUGGING(LEVELING)) SERIAL_ECHOLNPGM("BLTouch Command :", cmd);
   MOVE_SERVO(Z_PROBE_SERVO_NR, cmd);
   safe_delay(_MAX(ms, (uint32_t)BLTOUCH_DELAY)); // BLTOUCH_DELAY is also the *minimum* delay
   return triggered();
@@ -64,7 +64,7 @@ void BLTouch::init(const bool set_voltage/*=false*/) {
   #else
 
     if (DEBUGGING(LEVELING)) {
-      DEBUG_ECHOLNPAIR("last_written_mode - ", last_written_mode);
+      DEBUG_ECHOLNPGM("last_written_mode - ", last_written_mode);
       DEBUG_ECHOLNPGM("config mode - "
         #if ENABLED(BLTOUCH_SET_5V_MODE)
           "BLTOUCH_SET_5V_MODE"
@@ -175,7 +175,7 @@ bool BLTouch::status_proc() {
   _set_SW_mode();              // Incidentally, _set_SW_mode() will also RESET any active alarm
   const bool tr = triggered(); // If triggered in SW mode, the pin is up, it is STOWED
 
-  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("BLTouch is ", tr);
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("BLTouch is ", tr);
 
   if (tr) _stow(); else _deploy();  // Turn off SW mode, reset any trigger, honor pin state
   return !tr;
@@ -187,7 +187,7 @@ void BLTouch::mode_conv_proc(const bool M5V) {
    * BLTOUCH V3.0: This will set the mode (twice) and sadly, a STOW is needed at the end, because of the deploy
    * BLTOUCH V3.1: This will set the mode and store it in the eeprom. The STOW is not needed but does not hurt
    */
-  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("BLTouch Set Mode - ", M5V);
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("BLTouch Set Mode - ", M5V);
   _deploy();
   if (M5V) _set_5V_mode(); else _set_OD_mode();
   _mode_store();

--- a/Marlin/src/feature/dac/stepper_dac.cpp
+++ b/Marlin/src/feature/dac/stepper_dac.cpp
@@ -85,15 +85,15 @@ void StepperDAC::print_values() {
   if (!dac_present) return;
   SERIAL_ECHO_MSG("Stepper current values in % (Amps):");
   SERIAL_ECHO_START();
-  SERIAL_ECHOPAIR_P(SP_X_LBL, dac_perc(X_AXIS), PSTR(" ("), dac_amps(X_AXIS), PSTR(")"));
+  SERIAL_ECHOPGM_P(SP_X_LBL, dac_perc(X_AXIS), PSTR(" ("), dac_amps(X_AXIS), PSTR(")"));
   #if HAS_Y_AXIS
-    SERIAL_ECHOPAIR_P(SP_Y_LBL, dac_perc(Y_AXIS), PSTR(" ("), dac_amps(Y_AXIS), PSTR(")"));
+    SERIAL_ECHOPGM_P(SP_Y_LBL, dac_perc(Y_AXIS), PSTR(" ("), dac_amps(Y_AXIS), PSTR(")"));
   #endif
   #if HAS_Z_AXIS
-    SERIAL_ECHOPAIR_P(SP_Z_LBL, dac_perc(Z_AXIS), PSTR(" ("), dac_amps(Z_AXIS), PSTR(")"));
+    SERIAL_ECHOPGM_P(SP_Z_LBL, dac_perc(Z_AXIS), PSTR(" ("), dac_amps(Z_AXIS), PSTR(")"));
   #endif
   #if HAS_EXTRUDERS
-    SERIAL_ECHOLNPAIR_P(SP_E_LBL, dac_perc(E_AXIS), PSTR(" ("), dac_amps(E_AXIS), PSTR(")"));
+    SERIAL_ECHOLNPGM_P(SP_E_LBL, dac_perc(E_AXIS), PSTR(" ("), dac_amps(E_AXIS), PSTR(")"));
   #endif
 }
 

--- a/Marlin/src/feature/encoder_i2c.cpp
+++ b/Marlin/src/feature/encoder_i2c.cpp
@@ -49,7 +49,7 @@ void I2CPositionEncoder::init(const uint8_t address, const AxisEnum axis) {
 
   initialized = true;
 
-  SERIAL_ECHOLNPAIR("Setting up encoder on ", AS_CHAR(axis_codes[encoderAxis]), " axis, addr = ", address);
+  SERIAL_ECHOLNPGM("Setting up encoder on ", AS_CHAR(axis_codes[encoderAxis]), " axis, addr = ", address);
 
   position = get_position();
 }
@@ -67,7 +67,7 @@ void I2CPositionEncoder::update() {
     /*
     if (trusted) { //commented out as part of the note below
       trusted = false;
-      SERIAL_ECHOLNPAIR("Fault detected on ", AS_CHAR(axis_codes[encoderAxis]), " axis encoder. Disengaging error correction until module is trusted again.");
+      SERIAL_ECHOLNPGM("Fault detected on ", AS_CHAR(axis_codes[encoderAxis]), " axis encoder. Disengaging error correction until module is trusted again.");
     }
     */
     return;
@@ -92,7 +92,7 @@ void I2CPositionEncoder::update() {
       if (millis() - lastErrorTime > I2CPE_TIME_TRUSTED) {
         trusted = true;
 
-        SERIAL_ECHOLNPAIR("Untrusted encoder module on ", AS_CHAR(axis_codes[encoderAxis]), " axis has been fault-free for set duration, reinstating error correction.");
+        SERIAL_ECHOLNPGM("Untrusted encoder module on ", AS_CHAR(axis_codes[encoderAxis]), " axis has been fault-free for set duration, reinstating error correction.");
 
         //the encoder likely lost its place when the error occurred, so we'll reset and use the printer's
         //idea of where it the axis is to re-initialize
@@ -103,10 +103,10 @@ void I2CPositionEncoder::update() {
         zeroOffset -= (positionInTicks - get_position());
 
         #ifdef I2CPE_DEBUG
-          SERIAL_ECHOLNPAIR("Current position is ", pos);
-          SERIAL_ECHOLNPAIR("Position in encoder ticks is ", positionInTicks);
-          SERIAL_ECHOLNPAIR("New zero-offset of ", zeroOffset);
-          SERIAL_ECHOPAIR("New position reads as ", get_position());
+          SERIAL_ECHOLNPGM("Current position is ", pos);
+          SERIAL_ECHOLNPGM("Position in encoder ticks is ", positionInTicks);
+          SERIAL_ECHOLNPGM("New zero-offset of ", zeroOffset);
+          SERIAL_ECHOPGM("New position reads as ", get_position());
           SERIAL_CHAR('(');
           SERIAL_DECIMAL(mm_from_count(get_position()));
           SERIAL_ECHOLNPGM(")");
@@ -149,12 +149,12 @@ void I2CPositionEncoder::update() {
       const int32_t error = get_axis_error_steps(false);
     #endif
 
-    //SERIAL_ECHOLNPAIR("Axis error steps: ", error);
+    //SERIAL_ECHOLNPGM("Axis error steps: ", error);
 
     #ifdef I2CPE_ERR_THRESH_ABORT
       if (ABS(error) > I2CPE_ERR_THRESH_ABORT * planner.settings.axis_steps_per_mm[encoderAxis]) {
         //kill(PSTR("Significant Error"));
-        SERIAL_ECHOLNPAIR("Axis error over threshold, aborting!", error);
+        SERIAL_ECHOLNPGM("Axis error over threshold, aborting!", error);
         safe_delay(5000);
       }
     #endif
@@ -173,7 +173,7 @@ void I2CPositionEncoder::update() {
             LOOP_L_N(i, I2CPE_ERR_PRST_ARRAY_SIZE) sumP += errPrst[i];
             const int32_t errorP = int32_t(sumP * RECIPROCAL(I2CPE_ERR_PRST_ARRAY_SIZE));
             SERIAL_CHAR(axis_codes[encoderAxis]);
-            SERIAL_ECHOLNPAIR(" : CORRECT ERR ", errorP * planner.steps_to_mm[encoderAxis], "mm");
+            SERIAL_ECHOLNPGM(" : CORRECT ERR ", errorP * planner.steps_to_mm[encoderAxis], "mm");
             babystep.add_steps(encoderAxis, -LROUND(errorP));
             errPrstIdx = 0;
           }
@@ -193,7 +193,7 @@ void I2CPositionEncoder::update() {
       const millis_t ms = millis();
       if (ELAPSED(ms, nextErrorCountTime)) {
         SERIAL_CHAR(axis_codes[encoderAxis]);
-        SERIAL_ECHOLNPAIR(" : LARGE ERR ", error, "; diffSum=", diffSum);
+        SERIAL_ECHOLNPGM(" : LARGE ERR ", error, "; diffSum=", diffSum);
         errorCount++;
         nextErrorCountTime = ms + I2CPE_ERR_CNT_DEBOUNCE_MS;
       }
@@ -213,7 +213,7 @@ void I2CPositionEncoder::set_homed() {
 
     #ifdef I2CPE_DEBUG
       SERIAL_CHAR(axis_codes[encoderAxis]);
-      SERIAL_ECHOLNPAIR(" axis encoder homed, offset of ", zeroOffset, " ticks.");
+      SERIAL_ECHOLNPGM(" axis encoder homed, offset of ", zeroOffset, " ticks.");
     #endif
   }
 }
@@ -253,7 +253,7 @@ float I2CPositionEncoder::get_axis_error_mm(const bool report) {
 
   if (report) {
     SERIAL_CHAR(axis_codes[encoderAxis]);
-    SERIAL_ECHOLNPAIR(" axis target=", target, "mm; actual=", actual, "mm; err=", error, "mm");
+    SERIAL_ECHOLNPGM(" axis target=", target, "mm; actual=", actual, "mm; err=", error, "mm");
   }
 
   return error;
@@ -288,7 +288,7 @@ int32_t I2CPositionEncoder::get_axis_error_steps(const bool report) {
 
   if (report) {
     SERIAL_CHAR(axis_codes[encoderAxis]);
-    SERIAL_ECHOLNPAIR(" axis target=", target, "; actual=", encoderCountInStepperTicksScaled, "; err=", error);
+    SERIAL_ECHOLNPGM(" axis target=", target, "; actual=", encoderCountInStepperTicksScaled, "; err=", error);
   }
 
   if (suppressOutput) {
@@ -424,15 +424,15 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
 
     travelledDistance = mm_from_count(ABS(stopCount - startCount));
 
-    SERIAL_ECHOLNPAIR("Attempted travel: ", travelDistance, "mm");
-    SERIAL_ECHOLNPAIR("   Actual travel:  ", travelledDistance, "mm");
+    SERIAL_ECHOLNPGM("Attempted travel: ", travelDistance, "mm");
+    SERIAL_ECHOLNPGM("   Actual travel:  ", travelledDistance, "mm");
 
     //Calculate new axis steps per unit
     old_steps_mm = planner.settings.axis_steps_per_mm[encoderAxis];
     new_steps_mm = (old_steps_mm * travelDistance) / travelledDistance;
 
-    SERIAL_ECHOLNPAIR("Old steps/mm: ", old_steps_mm);
-    SERIAL_ECHOLNPAIR("New steps/mm: ", new_steps_mm);
+    SERIAL_ECHOLNPGM("Old steps/mm: ", old_steps_mm);
+    SERIAL_ECHOLNPGM("New steps/mm: ", new_steps_mm);
 
     //Save new value
     planner.settings.axis_steps_per_mm[encoderAxis] = new_steps_mm;
@@ -449,7 +449,7 @@ void I2CPositionEncoder::calibrate_steps_mm(const uint8_t iter) {
 
   if (iter > 1) {
     total /= (float)iter;
-    SERIAL_ECHOLNPAIR("Average steps/mm: ", total);
+    SERIAL_ECHOLNPGM("Average steps/mm: ", total);
   }
 
   ec = oldec;
@@ -675,18 +675,18 @@ void I2CPositionEncodersMgr::change_module_address(const uint8_t oldaddr, const 
   // First check 'new' address is not in use
   Wire.beginTransmission(I2C_ADDRESS(newaddr));
   if (!Wire.endTransmission()) {
-    SERIAL_ECHOLNPAIR("?There is already a device with that address on the I2C bus! (", newaddr, ")");
+    SERIAL_ECHOLNPGM("?There is already a device with that address on the I2C bus! (", newaddr, ")");
     return;
   }
 
   // Now check that we can find the module on the oldaddr address
   Wire.beginTransmission(I2C_ADDRESS(oldaddr));
   if (Wire.endTransmission()) {
-    SERIAL_ECHOLNPAIR("?No module detected at this address! (", oldaddr, ")");
+    SERIAL_ECHOLNPGM("?No module detected at this address! (", oldaddr, ")");
     return;
   }
 
-  SERIAL_ECHOLNPAIR("Module found at ", oldaddr, ", changing address to ", newaddr);
+  SERIAL_ECHOLNPGM("Module found at ", oldaddr, ", changing address to ", newaddr);
 
   // Change the modules address
   Wire.beginTransmission(I2C_ADDRESS(oldaddr));
@@ -722,11 +722,11 @@ void I2CPositionEncodersMgr::report_module_firmware(const uint8_t address) {
   // First check there is a module
   Wire.beginTransmission(I2C_ADDRESS(address));
   if (Wire.endTransmission()) {
-    SERIAL_ECHOLNPAIR("?No module detected at this address! (", address, ")");
+    SERIAL_ECHOLNPGM("?No module detected at this address! (", address, ")");
     return;
   }
 
-  SERIAL_ECHOLNPAIR("Requesting version info from module at address ", address, ":");
+  SERIAL_ECHOLNPGM("Requesting version info from module at address ", address, ":");
 
   Wire.beginTransmission(I2C_ADDRESS(address));
   Wire.write(I2CPE_SET_REPORT_MODE);
@@ -773,13 +773,13 @@ int8_t I2CPositionEncodersMgr::parse() {
   else if (parser.seenval('I')) {
 
     if (!parser.has_value()) {
-      SERIAL_ECHOLNPAIR("?I seen, but no index specified! [0-", I2CPE_ENCODER_CNT - 1, "]");
+      SERIAL_ECHOLNPGM("?I seen, but no index specified! [0-", I2CPE_ENCODER_CNT - 1, "]");
       return I2CPE_PARSE_ERR;
     };
 
     I2CPE_idx = parser.value_byte();
     if (I2CPE_idx >= I2CPE_ENCODER_CNT) {
-      SERIAL_ECHOLNPAIR("?Index out of range. [0-", I2CPE_ENCODER_CNT - 1, "]");
+      SERIAL_ECHOLNPGM("?Index out of range. [0-", I2CPE_ENCODER_CNT - 1, "]");
       return I2CPE_PARSE_ERR;
     }
 
@@ -954,7 +954,7 @@ void I2CPositionEncodersMgr::M864() {
     else return;
   }
 
-  SERIAL_ECHOLNPAIR("Changing module at address ", I2CPE_addr, " to address ", newAddress);
+  SERIAL_ECHOLNPGM("Changing module at address ", I2CPE_addr, " to address ", newAddress);
 
   change_module_address(I2CPE_addr, newAddress);
 }

--- a/Marlin/src/feature/encoder_i2c.h
+++ b/Marlin/src/feature/encoder_i2c.h
@@ -236,7 +236,7 @@ class I2CPositionEncodersMgr {
 
     static void report_status(const int8_t idx) {
       CHECK_IDX();
-      SERIAL_ECHOLNPAIR("Encoder ", idx, ": ");
+      SERIAL_ECHOLNPGM("Encoder ", idx, ": ");
       encoders[idx].get_raw_count();
       encoders[idx].passes_test(true);
     }
@@ -261,32 +261,32 @@ class I2CPositionEncodersMgr {
 
     static void report_error_count(const int8_t idx, const AxisEnum axis) {
       CHECK_IDX();
-      SERIAL_ECHOLNPAIR("Error count on ", AS_CHAR(axis_codes[axis]), " axis is ", encoders[idx].get_error_count());
+      SERIAL_ECHOLNPGM("Error count on ", AS_CHAR(axis_codes[axis]), " axis is ", encoders[idx].get_error_count());
     }
 
     static void reset_error_count(const int8_t idx, const AxisEnum axis) {
       CHECK_IDX();
       encoders[idx].set_error_count(0);
-      SERIAL_ECHOLNPAIR("Error count on ", AS_CHAR(axis_codes[axis]), " axis has been reset.");
+      SERIAL_ECHOLNPGM("Error count on ", AS_CHAR(axis_codes[axis]), " axis has been reset.");
     }
 
     static void enable_ec(const int8_t idx, const bool enabled, const AxisEnum axis) {
       CHECK_IDX();
       encoders[idx].set_ec_enabled(enabled);
-      SERIAL_ECHOPAIR("Error correction on ", AS_CHAR(axis_codes[axis]));
+      SERIAL_ECHOPGM("Error correction on ", AS_CHAR(axis_codes[axis]));
       SERIAL_ECHO_TERNARY(encoders[idx].get_ec_enabled(), " axis is ", "en", "dis", "abled.\n");
     }
 
     static void set_ec_threshold(const int8_t idx, const float newThreshold, const AxisEnum axis) {
       CHECK_IDX();
       encoders[idx].set_ec_threshold(newThreshold);
-      SERIAL_ECHOLNPAIR("Error correct threshold for ", AS_CHAR(axis_codes[axis]), " axis set to ", newThreshold, "mm.");
+      SERIAL_ECHOLNPGM("Error correct threshold for ", AS_CHAR(axis_codes[axis]), " axis set to ", newThreshold, "mm.");
     }
 
     static void get_ec_threshold(const int8_t idx, const AxisEnum axis) {
       CHECK_IDX();
       const float threshold = encoders[idx].get_ec_threshold();
-      SERIAL_ECHOLNPAIR("Error correct threshold for ", AS_CHAR(axis_codes[axis]), " axis is ", threshold, "mm.");
+      SERIAL_ECHOLNPGM("Error correct threshold for ", AS_CHAR(axis_codes[axis]), " axis is ", threshold, "mm.");
     }
 
     static int8_t idx_from_axis(const AxisEnum axis) {

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -106,20 +106,20 @@ void FWRetract::retract(const bool retracting OPTARG(HAS_MULTI_EXTRUDER, bool sw
   #endif
 
   /* // debugging
-    SERIAL_ECHOLNPAIR(
+    SERIAL_ECHOLNPGM(
       "retracting ", AS_DIGIT(retracting),
       " swapping ", swapping,
       " active extruder ", active_extruder
     );
     LOOP_L_N(i, EXTRUDERS) {
-      SERIAL_ECHOLNPAIR("retracted[", i, "] ", AS_DIGIT(retracted[i]));
+      SERIAL_ECHOLNPGM("retracted[", i, "] ", AS_DIGIT(retracted[i]));
       #if HAS_MULTI_EXTRUDER
-        SERIAL_ECHOLNPAIR("retracted_swap[", i, "] ", AS_DIGIT(retracted_swap[i]));
+        SERIAL_ECHOLNPGM("retracted_swap[", i, "] ", AS_DIGIT(retracted_swap[i]));
       #endif
     }
-    SERIAL_ECHOLNPAIR("current_position.z ", current_position.z);
-    SERIAL_ECHOLNPAIR("current_position.e ", current_position.e);
-    SERIAL_ECHOLNPAIR("current_hop ", current_hop);
+    SERIAL_ECHOLNPGM("current_position.z ", current_position.z);
+    SERIAL_ECHOLNPGM("current_position.e ", current_position.e);
+    SERIAL_ECHOLNPGM("current_hop ", current_hop);
   //*/
 
   const float base_retract = TERN1(RETRACT_SYNC_MIXING, (MIXING_STEPPERS))
@@ -181,18 +181,18 @@ void FWRetract::retract(const bool retracting OPTARG(HAS_MULTI_EXTRUDER, bool sw
   #endif
 
   /* // debugging
-    SERIAL_ECHOLNPAIR("retracting ", AS_DIGIT(retracting));
-    SERIAL_ECHOLNPAIR("swapping ", AS_DIGIT(swapping));
-    SERIAL_ECHOLNPAIR("active_extruder ", active_extruder);
+    SERIAL_ECHOLNPGM("retracting ", AS_DIGIT(retracting));
+    SERIAL_ECHOLNPGM("swapping ", AS_DIGIT(swapping));
+    SERIAL_ECHOLNPGM("active_extruder ", active_extruder);
     LOOP_L_N(i, EXTRUDERS) {
-      SERIAL_ECHOLNPAIR("retracted[", i, "] ", AS_DIGIT(retracted[i]));
+      SERIAL_ECHOLNPGM("retracted[", i, "] ", AS_DIGIT(retracted[i]));
       #if HAS_MULTI_EXTRUDER
-        SERIAL_ECHOLNPAIR("retracted_swap[", i, "] ", AS_DIGIT(retracted_swap[i]));
+        SERIAL_ECHOLNPGM("retracted_swap[", i, "] ", AS_DIGIT(retracted_swap[i]));
       #endif
     }
-    SERIAL_ECHOLNPAIR("current_position.z ", current_position.z);
-    SERIAL_ECHOLNPAIR("current_position.e ", current_position.e);
-    SERIAL_ECHOLNPAIR("current_hop ", current_hop);
+    SERIAL_ECHOLNPGM("current_position.z ", current_position.z);
+    SERIAL_ECHOLNPGM("current_position.e ", current_position.e);
+    SERIAL_ECHOLNPGM("current_hop ", current_hop);
   //*/
 }
 
@@ -215,7 +215,7 @@ void FWRetract::M207() {
 }
 
 void FWRetract::M207_report() {
-  SERIAL_ECHOLNPAIR_P(
+  SERIAL_ECHOLNPGM_P(
       PSTR("  M207 S"), LINEAR_UNIT(settings.retract_length)
     , PSTR(" W"), LINEAR_UNIT(settings.swap_retract_length)
     , PSTR(" F"), LINEAR_UNIT(MMS_TO_MMM(settings.retract_feedrate_mm_s))
@@ -240,7 +240,7 @@ void FWRetract::M208() {
 }
 
 void FWRetract::M208_report() {
-  SERIAL_ECHOLNPAIR(
+  SERIAL_ECHOLNPGM(
       "  M208 S", LINEAR_UNIT(settings.retract_recover_extra)
     , " W", LINEAR_UNIT(settings.swap_retract_recover_extra)
     , " F", LINEAR_UNIT(MMS_TO_MMM(settings.retract_recover_feedrate_mm_s))
@@ -261,7 +261,7 @@ void FWRetract::M208_report() {
   }
 
   void FWRetract::M209_report() {
-    SERIAL_ECHOLNPAIR("  M209 S", AS_DIGIT(autoretract_enabled));
+    SERIAL_ECHOLNPGM("  M209 S", AS_DIGIT(autoretract_enabled));
   }
 
 #endif // FWRETRACT_AUTORETRACT

--- a/Marlin/src/feature/fwretract.cpp
+++ b/Marlin/src/feature/fwretract.cpp
@@ -36,7 +36,7 @@ FWRetract fwretract; // Single instance - this calls the constructor
 #include "../module/planner.h"
 #include "../module/stepper.h"
 
-#include "../gcode/parser.h"
+#include "../gcode/gcode.h"
 
 #if ENABLED(RETRACT_SYNC_MIXING)
   #include "mixing.h"
@@ -214,8 +214,7 @@ void FWRetract::M207() {
   if (parser.seenval('W')) settings.swap_retract_length   = parser.value_axis_units(E_AXIS);
 }
 
-void FWRetract::M207_report(const bool forReplay/*=false*/) {
-  if (!forReplay) { SERIAL_ECHO_MSG("; Retract: S<length> F<units/m> Z<lift>"); SERIAL_ECHO_START(); }
+void FWRetract::M207_report() {
   SERIAL_ECHOLNPAIR_P(
       PSTR("  M207 S"), LINEAR_UNIT(settings.retract_length)
     , PSTR(" W"), LINEAR_UNIT(settings.swap_retract_length)
@@ -240,8 +239,7 @@ void FWRetract::M208() {
   if (parser.seen('W')) settings.swap_retract_recover_extra         = parser.value_axis_units(E_AXIS);
 }
 
-void FWRetract::M208_report(const bool forReplay/*=false*/) {
-  if (!forReplay) { SERIAL_ECHO_MSG("; Recover: S<length> F<units/m>"); SERIAL_ECHO_START(); }
+void FWRetract::M208_report() {
   SERIAL_ECHOLNPAIR(
       "  M208 S", LINEAR_UNIT(settings.retract_recover_extra)
     , " W", LINEAR_UNIT(settings.swap_retract_recover_extra)
@@ -262,8 +260,7 @@ void FWRetract::M208_report(const bool forReplay/*=false*/) {
       enable_autoretract(parser.value_bool());
   }
 
-  void FWRetract::M209_report(const bool forReplay/*=false*/) {
-    if (!forReplay) { SERIAL_ECHO_MSG("; Auto-Retract: S=0 to disable, 1 to interpret E-only moves as retract/recover"); SERIAL_ECHO_START(); }
+  void FWRetract::M209_report() {
     SERIAL_ECHOLNPAIR("  M209 S", AS_DIGIT(autoretract_enabled));
   }
 

--- a/Marlin/src/feature/fwretract.h
+++ b/Marlin/src/feature/fwretract.h
@@ -76,13 +76,13 @@ public:
 
   static void retract(const bool retracting OPTARG(HAS_MULTI_EXTRUDER, bool swapping = false));
 
+  static void M207_report();
   static void M207();
-  static void M207_report(const bool forReplay=false);
+  static void M208_report();
   static void M208();
-  static void M208_report(const bool forReplay=false);
   #if ENABLED(FWRETRACT_AUTORETRACT)
+    static void M209_report();
     static void M209();
-    static void M209_report(const bool forReplay=false);
   #endif
 };
 

--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -68,13 +68,13 @@ Joystick joystick;
   void Joystick::report() {
     SERIAL_ECHOPGM("Joystick");
     #if HAS_JOY_ADC_X
-      SERIAL_ECHOPAIR_P(SP_X_STR, JOY_X(x.raw));
+      SERIAL_ECHOPGM_P(SP_X_STR, JOY_X(x.raw));
     #endif
     #if HAS_JOY_ADC_Y
-      SERIAL_ECHOPAIR_P(SP_Y_STR, JOY_Y(y.raw));
+      SERIAL_ECHOPGM_P(SP_Y_STR, JOY_Y(y.raw));
     #endif
     #if HAS_JOY_ADC_Z
-      SERIAL_ECHOPAIR_P(SP_Z_STR, JOY_Z(z.raw));
+      SERIAL_ECHOPGM_P(SP_Z_STR, JOY_Z(z.raw));
     #endif
     #if HAS_JOY_ADC_EN
       SERIAL_ECHO_TERNARY(READ(JOY_EN_PIN), " EN=", "HIGH (dis", "LOW (en", "abled)");

--- a/Marlin/src/feature/max7219.cpp
+++ b/Marlin/src/feature/max7219.cpp
@@ -130,7 +130,7 @@ void Max7219::error(const char * const func, const int32_t v1, const int32_t v2/
     SERIAL_ECHOPGM_P(func);
     SERIAL_CHAR('(');
     SERIAL_ECHO(v1);
-    if (v2 > 0) SERIAL_ECHOPAIR(", ", v2);
+    if (v2 > 0) SERIAL_ECHOPGM(", ", v2);
     SERIAL_CHAR(')');
     SERIAL_EOL();
   #else

--- a/Marlin/src/feature/meatpack.cpp
+++ b/Marlin/src/feature/meatpack.cpp
@@ -140,7 +140,7 @@ void MeatPack::handle_output_char(const uint8_t c) {
   #if ENABLED(MP_DEBUG)
     if (chars_decoded < 1024) {
       ++chars_decoded;
-      DEBUG_ECHOLNPAIR("RB: ", AS_CHAR(c));
+      DEBUG_ECHOLNPGM("RB: ", AS_CHAR(c));
     }
   #endif
 }

--- a/Marlin/src/feature/mixing.cpp
+++ b/Marlin/src/feature/mixing.cpp
@@ -154,11 +154,11 @@ void Mixer::refresh_collector(const float proportion/*=1.0*/, const uint8_t t/*=
     cmax = _MAX(cmax, v);
     csum += v;
   }
-  //SERIAL_ECHOPAIR("Mixer::refresh_collector(", proportion, ", ", t, ") cmax=", cmax, "  csum=", csum, "  color");
+  //SERIAL_ECHOPGM("Mixer::refresh_collector(", proportion, ", ", t, ") cmax=", cmax, "  csum=", csum, "  color");
   const float inv_prop = proportion / csum;
   MIXER_STEPPER_LOOP(i) {
     c[i] = color[t][i] * inv_prop;
-    //SERIAL_ECHOPAIR(" [", t, "][", i, "] = ", color[t][i], " (", c[i], ")  ");
+    //SERIAL_ECHOPGM(" [", t, "][", i, "] = ", color[t][i], " (", c[i], ")  ");
   }
   //SERIAL_EOL();
 }

--- a/Marlin/src/feature/mixing.h
+++ b/Marlin/src/feature/mixing.h
@@ -152,7 +152,7 @@ class Mixer {
       MIXER_STEPPER_LOOP(i) mix[i] = mixer_perc_t(100.0f * color[j][i] / ctot);
 
       #ifdef MIXER_NORMALIZER_DEBUG
-        SERIAL_ECHOPAIR("V-tool ", j, " [ ");
+        SERIAL_ECHOPGM("V-tool ", j, " [ ");
         SERIAL_ECHOLIST_N(MIXING_STEPPERS, color[j][0], color[j][1], color[j][2], color[j][3], color[j][4], color[j][5]);
         SERIAL_ECHOPGM(" ] to Mix [ ");
         SERIAL_ECHOLIST_N(MIXING_STEPPERS, mix[0], mix[1], mix[2], mix[3], mix[4], mix[5]);

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -169,7 +169,7 @@ void MMU2::mmu_loop() {
       if (rx_ok()) {
         sscanf(rx_buffer, "%huok\n", &version);
 
-        DEBUG_ECHOLNPAIR("MMU => ", version, "\nMMU <= 'S2'");
+        DEBUG_ECHOLNPGM("MMU => ", version, "\nMMU <= 'S2'");
 
         MMU2_COMMAND("S2");   // Read Build Number
         state = -3;
@@ -180,7 +180,7 @@ void MMU2::mmu_loop() {
       if (rx_ok()) {
         sscanf(rx_buffer, "%huok\n", &buildnr);
 
-        DEBUG_ECHOLNPAIR("MMU => ", buildnr);
+        DEBUG_ECHOLNPGM("MMU => ", buildnr);
 
         check_version();
 
@@ -217,7 +217,7 @@ void MMU2::mmu_loop() {
       if (rx_ok()) {
         sscanf(rx_buffer, "%hhuok\n", &finda);
 
-        DEBUG_ECHOLNPAIR("MMU => ", finda, "\nMMU - ENABLED");
+        DEBUG_ECHOLNPGM("MMU => ", finda, "\nMMU - ENABLED");
 
         _enabled = true;
         state = 1;
@@ -230,7 +230,7 @@ void MMU2::mmu_loop() {
         if (WITHIN(cmd, MMU_CMD_T0, MMU_CMD_T0 + EXTRUDERS - 1)) {
           // tool change
           int filament = cmd - MMU_CMD_T0;
-          DEBUG_ECHOLNPAIR("MMU <= T", filament);
+          DEBUG_ECHOLNPGM("MMU <= T", filament);
           tx_printf_P(PSTR("T%d\n"), filament);
           TERN_(MMU_EXTRUDER_SENSOR, mmu_idl_sens = 1); // enable idler sensor, if any
           state = 3; // wait for response
@@ -238,7 +238,7 @@ void MMU2::mmu_loop() {
         else if (WITHIN(cmd, MMU_CMD_L0, MMU_CMD_L0 + EXTRUDERS - 1)) {
           // load
           int filament = cmd - MMU_CMD_L0;
-          DEBUG_ECHOLNPAIR("MMU <= L", filament);
+          DEBUG_ECHOLNPGM("MMU <= L", filament);
           tx_printf_P(PSTR("L%d\n"), filament);
           state = 3; // wait for response
         }
@@ -258,7 +258,7 @@ void MMU2::mmu_loop() {
         else if (WITHIN(cmd, MMU_CMD_E0, MMU_CMD_E0 + EXTRUDERS - 1)) {
           // eject filament
           int filament = cmd - MMU_CMD_E0;
-          DEBUG_ECHOLNPAIR("MMU <= E", filament);
+          DEBUG_ECHOLNPGM("MMU <= E", filament);
           tx_printf_P(PSTR("E%d\n"), filament);
           state = 3; // wait for response
         }
@@ -271,7 +271,7 @@ void MMU2::mmu_loop() {
         else if (WITHIN(cmd, MMU_CMD_F0, MMU_CMD_F0 + EXTRUDERS - 1)) {
           // filament type
           int filament = cmd - MMU_CMD_F0;
-          DEBUG_ECHOLNPAIR("MMU <= F", filament, " ", cmd_arg);
+          DEBUG_ECHOLNPGM("MMU <= F", filament, " ", cmd_arg);
           tx_printf_P(PSTR("F%d %d\n"), filament, cmd_arg);
           state = 3; // wait for response
         }
@@ -647,7 +647,7 @@ static void mmu2_not_responding() {
 
   void MMU2::mmu_continue_loading() {
     for (uint8_t i = 0; i < MMU_LOADING_ATTEMPTS_NR; i++) {
-      DEBUG_ECHOLNPAIR("Additional load attempt #", i);
+      DEBUG_ECHOLNPGM("Additional load attempt #", i);
       if (FILAMENT_PRESENT()) break;
       command(MMU_CMD_C0);
       manage_response(true, true);
@@ -1025,7 +1025,7 @@ void MMU2::execute_extruder_sequence(const E_Step * sequence, int steps) {
     const feedRate_t fr_mm_m = pgm_read_float(&(step->feedRate));
 
     DEBUG_ECHO_START();
-    DEBUG_ECHOLNPAIR("E step ", es, "/", fr_mm_m);
+    DEBUG_ECHOLNPGM("E step ", es, "/", fr_mm_m);
 
     current_position.e += es;
     line_to_current_position(MMM_TO_MMS(fr_mm_m));

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -132,7 +132,7 @@ fil_change_settings_t fc_settings[EXTRUDERS];
  */
 static bool ensure_safe_temperature(const bool wait=true, const PauseMode mode=PAUSE_MODE_SAME) {
   DEBUG_SECTION(est, "ensure_safe_temperature", true);
-  DEBUG_ECHOLNPAIR("... wait:", wait, " mode:", mode);
+  DEBUG_ECHOLNPGM("... wait:", wait, " mode:", mode);
 
   #if ENABLED(PREVENT_COLD_EXTRUSION)
     if (!DEBUGGING(DRYRUN) && thermalManager.targetTooColdToExtrude(active_extruder))
@@ -178,7 +178,7 @@ bool load_filament(const_float_t slow_load_length/*=0*/, const_float_t fast_load
                    DXC_ARGS
 ) {
   DEBUG_SECTION(lf, "load_filament", true);
-  DEBUG_ECHOLNPAIR("... slowlen:", slow_load_length, " fastlen:", fast_load_length, " purgelen:", purge_length, " maxbeep:", max_beep_count, " showlcd:", show_lcd, " pauseforuser:", pause_for_user, " pausemode:", mode DXC_SAY);
+  DEBUG_ECHOLNPGM("... slowlen:", slow_load_length, " fastlen:", fast_load_length, " purgelen:", purge_length, " maxbeep:", max_beep_count, " showlcd:", show_lcd, " pauseforuser:", pause_for_user, " pausemode:", mode DXC_SAY);
 
   if (!ensure_safe_temperature(false, mode)) {
     if (show_lcd) ui.pause_show_message(PAUSE_MESSAGE_STATUS, mode);
@@ -315,7 +315,7 @@ bool unload_filament(const_float_t unload_length, const bool show_lcd/*=false*/,
                      #endif
 ) {
   DEBUG_SECTION(uf, "unload_filament", true);
-  DEBUG_ECHOLNPAIR("... unloadlen:", unload_length, " showlcd:", show_lcd, " mode:", mode
+  DEBUG_ECHOLNPGM("... unloadlen:", unload_length, " showlcd:", show_lcd, " mode:", mode
     #if BOTH(FILAMENT_UNLOAD_ALL_EXTRUDERS, MIXING_EXTRUDER)
       , " mixmult:", mix_multiplier
     #endif
@@ -379,7 +379,7 @@ uint8_t did_pause_print = 0;
 
 bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const bool show_lcd/*=false*/, const_float_t unload_length/*=0*/ DXC_ARGS) {
   DEBUG_SECTION(pp, "pause_print", true);
-  DEBUG_ECHOLNPAIR("... park.x:", park_point.x, " y:", park_point.y, " z:", park_point.z, " unloadlen:", unload_length, " showlcd:", show_lcd DXC_SAY);
+  DEBUG_ECHOLNPGM("... park.x:", park_point.x, " y:", park_point.y, " z:", park_point.z, " unloadlen:", unload_length, " showlcd:", show_lcd DXC_SAY);
 
   UNUSED(show_lcd);
 
@@ -430,7 +430,7 @@ bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const bool 
 
   // Initial retract before move to filament change position
   if (retract && thermalManager.hotEnoughToExtrude(active_extruder)) {
-    DEBUG_ECHOLNPAIR("... retract:", retract);
+    DEBUG_ECHOLNPGM("... retract:", retract);
     unscaled_e_move(retract, PAUSE_PARK_RETRACT_FEEDRATE);
   }
 
@@ -472,7 +472,7 @@ bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const bool 
 
 void show_continue_prompt(const bool is_reload) {
   DEBUG_SECTION(scp, "pause_print", true);
-  DEBUG_ECHOLNPAIR("... is_reload:", is_reload);
+  DEBUG_ECHOLNPGM("... is_reload:", is_reload);
 
   ui.pause_show_message(is_reload ? PAUSE_MESSAGE_INSERT : PAUSE_MESSAGE_WAITING);
   SERIAL_ECHO_START();
@@ -481,7 +481,7 @@ void show_continue_prompt(const bool is_reload) {
 
 void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep_count/*=0*/ DXC_ARGS) {
   DEBUG_SECTION(wfc, "wait_for_confirmation", true);
-  DEBUG_ECHOLNPAIR("... is_reload:", is_reload, " maxbeep:", max_beep_count DXC_SAY);
+  DEBUG_ECHOLNPGM("... is_reload:", is_reload, " maxbeep:", max_beep_count DXC_SAY);
 
   bool nozzle_timed_out = false;
 
@@ -584,10 +584,10 @@ void wait_for_confirmation(const bool is_reload/*=false*/, const int8_t max_beep
  */
 void resume_print(const_float_t slow_load_length/*=0*/, const_float_t fast_load_length/*=0*/, const_float_t purge_length/*=ADVANCED_PAUSE_PURGE_LENGTH*/, const int8_t max_beep_count/*=0*/, const celsius_t targetTemp/*=0*/ DXC_ARGS) {
   DEBUG_SECTION(rp, "resume_print", true);
-  DEBUG_ECHOLNPAIR("... slowlen:", slow_load_length, " fastlen:", fast_load_length, " purgelen:", purge_length, " maxbeep:", max_beep_count, " targetTemp:", targetTemp DXC_SAY);
+  DEBUG_ECHOLNPGM("... slowlen:", slow_load_length, " fastlen:", fast_load_length, " purgelen:", purge_length, " maxbeep:", max_beep_count, " targetTemp:", targetTemp DXC_SAY);
 
   /*
-  SERIAL_ECHOLNPAIR(
+  SERIAL_ECHOLNPGM(
     "start of resume_print()\ndual_x_carriage_mode:", dual_x_carriage_mode,
     "\nextruder_duplication_enabled:", extruder_duplication_enabled,
     "\nactive_extruder:", active_extruder,

--- a/Marlin/src/feature/powerloss.cpp
+++ b/Marlin/src/feature/powerloss.cpp
@@ -577,7 +577,7 @@ void PrintJobRecovery::resume() {
 
   void PrintJobRecovery::debug(PGM_P const prefix) {
     DEBUG_ECHOPGM_P(prefix);
-    DEBUG_ECHOLNPAIR(" Job Recovery Info...\nvalid_head:", info.valid_head, " valid_foot:", info.valid_foot);
+    DEBUG_ECHOLNPGM(" Job Recovery Info...\nvalid_head:", info.valid_head, " valid_foot:", info.valid_foot);
     if (info.valid_head) {
       if (info.valid_head == info.valid_foot) {
         DEBUG_ECHOPGM("current_position: ");
@@ -587,14 +587,14 @@ void PrintJobRecovery::resume() {
         }
         DEBUG_EOL();
 
-        DEBUG_ECHOLNPAIR("feedrate: ", info.feedrate);
+        DEBUG_ECHOLNPGM("feedrate: ", info.feedrate);
 
-        DEBUG_ECHOLNPAIR("zraise: ", info.zraise, " ", info.flag.raised ? "(before)" : "");
+        DEBUG_ECHOLNPGM("zraise: ", info.zraise, " ", info.flag.raised ? "(before)" : "");
 
         #if ENABLED(GCODE_REPEAT_MARKERS)
-          DEBUG_ECHOLNPAIR("repeat index: ", info.stored_repeat.index);
+          DEBUG_ECHOLNPGM("repeat index: ", info.stored_repeat.index);
           LOOP_L_N(i, info.stored_repeat.index)
-            DEBUG_ECHOLNPAIR("..... sdpos: ", info.stored_repeat.marker.sdpos, " count: ", info.stored_repeat.marker.counter);
+            DEBUG_ECHOLNPGM("..... sdpos: ", info.stored_repeat.marker.sdpos, " count: ", info.stored_repeat.marker.counter);
         #endif
 
         #if HAS_HOME_OFFSET
@@ -616,12 +616,12 @@ void PrintJobRecovery::resume() {
         #endif
 
         #if HAS_MULTI_EXTRUDER
-          DEBUG_ECHOLNPAIR("active_extruder: ", info.active_extruder);
+          DEBUG_ECHOLNPGM("active_extruder: ", info.active_extruder);
         #endif
 
         #if DISABLED(NO_VOLUMETRICS)
           DEBUG_ECHOPGM("filament_size:");
-          LOOP_L_N(i, EXTRUDERS) DEBUG_ECHOLNPAIR(" ", info.filament_size[i]);
+          LOOP_L_N(i, EXTRUDERS) DEBUG_ECHOLNPGM(" ", info.filament_size[i]);
           DEBUG_EOL();
         #endif
 
@@ -635,7 +635,7 @@ void PrintJobRecovery::resume() {
         #endif
 
         #if HAS_HEATED_BED
-          DEBUG_ECHOLNPAIR("target_temperature_bed: ", info.target_temperature_bed);
+          DEBUG_ECHOLNPGM("target_temperature_bed: ", info.target_temperature_bed);
         #endif
 
         #if HAS_FAN
@@ -648,7 +648,7 @@ void PrintJobRecovery::resume() {
         #endif
 
         #if HAS_LEVELING
-          DEBUG_ECHOLNPAIR("leveling: ", info.flag.leveling ? "ON" : "OFF", "  fade: ", info.fade);
+          DEBUG_ECHOLNPGM("leveling: ", info.flag.leveling ? "ON" : "OFF", "  fade: ", info.fade);
         #endif
 
         #if ENABLED(FWRETRACT)
@@ -658,17 +658,17 @@ void PrintJobRecovery::resume() {
             if (e < EXTRUDERS - 1) DEBUG_CHAR(',');
           }
           DEBUG_EOL();
-          DEBUG_ECHOLNPAIR("retract_hop: ", info.retract_hop);
+          DEBUG_ECHOLNPGM("retract_hop: ", info.retract_hop);
         #endif
 
         // Mixing extruder and gradient
         #if BOTH(MIXING_EXTRUDER, GRADIENT_MIX)
-          DEBUG_ECHOLNPAIR("gradient: ", info.gradient.enabled ? "ON" : "OFF");
+          DEBUG_ECHOLNPGM("gradient: ", info.gradient.enabled ? "ON" : "OFF");
         #endif
 
-        DEBUG_ECHOLNPAIR("sd_filename: ", info.sd_filename);
-        DEBUG_ECHOLNPAIR("sdpos: ", info.sdpos);
-        DEBUG_ECHOLNPAIR("print_job_elapsed: ", info.print_job_elapsed);
+        DEBUG_ECHOLNPGM("sd_filename: ", info.sd_filename);
+        DEBUG_ECHOLNPGM("sdpos: ", info.sdpos);
+        DEBUG_ECHOLNPGM("print_job_elapsed: ", info.print_job_elapsed);
 
         DEBUG_ECHOPGM("axis_relative:");
         if (TEST(info.axis_relative, REL_X)) DEBUG_ECHOPGM(" REL_X");
@@ -679,9 +679,9 @@ void PrintJobRecovery::resume() {
         if (TEST(info.axis_relative, E_MODE_REL)) DEBUG_ECHOPGM(" E_MODE_REL");
         DEBUG_EOL();
 
-        DEBUG_ECHOLNPAIR("flag.dryrun: ", AS_DIGIT(info.flag.dryrun));
-        DEBUG_ECHOLNPAIR("flag.allow_cold_extrusion: ", AS_DIGIT(info.flag.allow_cold_extrusion));
-        DEBUG_ECHOLNPAIR("flag.volumetric_enabled: ", AS_DIGIT(info.flag.volumetric_enabled));
+        DEBUG_ECHOLNPGM("flag.dryrun: ", AS_DIGIT(info.flag.dryrun));
+        DEBUG_ECHOLNPGM("flag.allow_cold_extrusion: ", AS_DIGIT(info.flag.allow_cold_extrusion));
+        DEBUG_ECHOLNPGM("flag.volumetric_enabled: ", AS_DIGIT(info.flag.volumetric_enabled));
       }
       else
         DEBUG_ECHOLNPGM("INVALID DATA");

--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -75,7 +75,7 @@ void ProbeTempComp::print_offsets() {
         #endif
         PSTR("Probe")
       );
-      SERIAL_ECHOLNPAIR(
+      SERIAL_ECHOLNPGM(
         " temp: ", temp,
         "C; Offset: ", i < 0 ? 0.0f : sensor_z_offsets[s][i], " um"
       );
@@ -117,7 +117,7 @@ bool ProbeTempComp::finish_calibration(const TempSensorID tsi) {
   // Extrapolate
   float k, d;
   if (calib_idx < measurements) {
-    SERIAL_ECHOLNPAIR("Got ", calib_idx, " measurements. ");
+    SERIAL_ECHOLNPGM("Got ", calib_idx, " measurements. ");
     if (linear_regression(tsi, k, d)) {
       SERIAL_ECHOPGM("Applying linear extrapolation");
       calib_idx--;

--- a/Marlin/src/feature/repeat.cpp
+++ b/Marlin/src/feature/repeat.cpp
@@ -43,7 +43,7 @@ void Repeat::add_marker(const uint32_t sdpos, const uint16_t count) {
     marker[index].sdpos = sdpos;
     marker[index].counter = count ?: -1;
     index++;
-    DEBUG_ECHOLNPAIR("Add Marker ", index, " at ", sdpos, " (", count, ")");
+    DEBUG_ECHOLNPGM("Add Marker ", index, " at ", sdpos, " (", count, ")");
   }
 }
 
@@ -53,14 +53,14 @@ void Repeat::loop() {
   else {
     const uint8_t ind = index - 1;      // Active marker's index
     if (!marker[ind].counter) {         // Did its counter run out?
-      DEBUG_ECHOLNPAIR("Pass Marker ", index);
+      DEBUG_ECHOLNPGM("Pass Marker ", index);
       index--;                          //  Carry on. Previous marker on the next 'M808'.
     }
     else {
       card.setIndex(marker[ind].sdpos); // Loop back to the marker.
       if (marker[ind].counter > 0)      // Ignore a negative (or zero) counter.
         --marker[ind].counter;          // Decrement the counter. If zero this 'M808' will be skipped next time.
-      DEBUG_ECHOLNPAIR("Goto Marker ", index, " at ", marker[ind].sdpos, " (", marker[ind].counter, ")");
+      DEBUG_ECHOLNPGM("Goto Marker ", index, " at ", marker[ind].sdpos, " (", marker[ind].counter, ")");
     }
   }
 }
@@ -69,7 +69,7 @@ void Repeat::cancel() { LOOP_L_N(i, index) marker[i].counter = 0; }
 
 void Repeat::early_parse_M808(char * const cmd) {
   if (is_command_M808(cmd)) {
-    DEBUG_ECHOLNPAIR("Parsing \"", cmd, "\"");
+    DEBUG_ECHOLNPGM("Parsing \"", cmd, "\"");
     parser.parse(cmd);
     if (parser.seen('L'))
       add_marker(card.getIndex(), parser.value_ushort());

--- a/Marlin/src/feature/runout.cpp
+++ b/Marlin/src/feature/runout.cpp
@@ -132,7 +132,7 @@ void event_filament_runout(const uint8_t extruder) {
       char script[strlen(FILAMENT_RUNOUT_SCRIPT) + 1];
       sprintf_P(script, PSTR(FILAMENT_RUNOUT_SCRIPT), tool);
       #if ENABLED(FILAMENT_RUNOUT_SENSOR_DEBUG)
-        SERIAL_ECHOLNPAIR("Runout Command: ", script);
+        SERIAL_ECHOLNPGM("Runout Command: ", script);
       #endif
       queue.inject(script);
     #else

--- a/Marlin/src/feature/runout.h
+++ b/Marlin/src/feature/runout.h
@@ -145,7 +145,7 @@ class TFilamentMonitor : public FilamentMonitorBase {
           if (runout_flags) {
             SERIAL_ECHOPGM("Runout Sensors: ");
             LOOP_L_N(i, 8) SERIAL_ECHO('0' + TEST(runout_flags, i));
-            SERIAL_ECHOPAIR(" -> ", extruder);
+            SERIAL_ECHOPGM(" -> ", extruder);
             if (ran_out) SERIAL_ECHOPGM(" RUN OUT");
             SERIAL_EOL();
           }
@@ -317,7 +317,7 @@ class FilamentSensorBase {
             static uint8_t was_out; // = 0
             if (out != TEST(was_out, s)) {
               TBI(was_out, s);
-              SERIAL_ECHOLNPAIR_P(PSTR("Filament Sensor "), '0' + s, out ? PSTR(" OUT") : PSTR(" IN"));
+              SERIAL_ECHOLNPGM_P(PSTR("Filament Sensor "), '0' + s, out ? PSTR(" OUT") : PSTR(" IN"));
             }
           #endif
         }
@@ -352,7 +352,7 @@ class FilamentSensorBase {
           if (ELAPSED(ms, t)) {
             t = millis() + 1000UL;
             LOOP_L_N(i, NUM_RUNOUT_SENSORS)
-              SERIAL_ECHOPAIR_P(i ? PSTR(", ") : PSTR("Remaining mm: "), runout_mm_countdown[i]);
+              SERIAL_ECHOPGM_P(i ? PSTR(", ") : PSTR("Remaining mm: "), runout_mm_countdown[i]);
             SERIAL_EOL();
           }
         #endif

--- a/Marlin/src/feature/tmc_util.cpp
+++ b/Marlin/src/feature/tmc_util.cpp
@@ -226,7 +226,7 @@
     SERIAL_ECHO(timestamp);
     SERIAL_ECHOPGM(": ");
     st.printLabel();
-    SERIAL_ECHOLNPAIR(" driver overtemperature warning! (", st.getMilliamps(), "mA)");
+    SERIAL_ECHOLNPGM(" driver overtemperature warning! (", st.getMilliamps(), "mA)");
   }
 
   template<typename TMC>
@@ -271,7 +271,7 @@
           st.rms_current(I_rms);
           #if ENABLED(REPORT_CURRENT_CHANGE)
             st.printLabel();
-            SERIAL_ECHOLNPAIR(" current decreased to ", I_rms);
+            SERIAL_ECHOLNPGM(" current decreased to ", I_rms);
           #endif
         }
       }

--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -300,7 +300,7 @@ class TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC266
 template<typename TMC>
 void tmc_print_current(TMC &st) {
   st.printLabel();
-  SERIAL_ECHOLNPAIR(" driver current: ", st.getMilliamps());
+  SERIAL_ECHOLNPGM(" driver current: ", st.getMilliamps());
 }
 
 #if ENABLED(MONITOR_DRIVER_STATUS)
@@ -322,7 +322,7 @@ void tmc_print_current(TMC &st) {
   template<typename TMC>
   void tmc_print_pwmthrs(TMC &st) {
     st.printLabel();
-    SERIAL_ECHOLNPAIR(" stealthChop max speed: ", st.get_pwm_thrs());
+    SERIAL_ECHOLNPGM(" stealthChop max speed: ", st.get_pwm_thrs());
   }
 #endif
 #if USE_SENSORLESS

--- a/Marlin/src/feature/twibus.cpp
+++ b/Marlin/src/feature/twibus.cpp
@@ -84,7 +84,7 @@ void TWIBus::send() {
 void TWIBus::echoprefix(uint8_t bytes, const char pref[], uint8_t adr) {
   SERIAL_ECHO_START();
   SERIAL_ECHOPGM_P(pref);
-  SERIAL_ECHOPAIR(": from:", adr, " bytes:", bytes, " data:");
+  SERIAL_ECHOPGM(": from:", adr, " bytes:", bytes, " data:");
 }
 
 // static

--- a/Marlin/src/gcode/bedlevel/G26.cpp
+++ b/Marlin/src/gcode/bedlevel/G26.cpp
@@ -539,7 +539,7 @@ void GcodeSuite::G26() {
 
     if (bedtemp) {
       if (!WITHIN(bedtemp, 40, BED_MAX_TARGET)) {
-        SERIAL_ECHOLNPAIR("?Specified bed temperature not plausible (40-", BED_MAX_TARGET, "C).");
+        SERIAL_ECHOLNPGM("?Specified bed temperature not plausible (40-", BED_MAX_TARGET, "C).");
         return;
       }
       g26.bed_temp = bedtemp;

--- a/Marlin/src/gcode/bedlevel/G35.cpp
+++ b/Marlin/src/gcode/bedlevel/G35.cpp
@@ -106,19 +106,19 @@ void GcodeSuite::G35() {
     const float z_probed_height = probe.probe_at_point(tramming_points[i], PROBE_PT_RAISE, 0, true);
 
     if (isnan(z_probed_height)) {
-      SERIAL_ECHOPAIR("G35 failed at point ", i + 1, " (");
+      SERIAL_ECHOPGM("G35 failed at point ", i + 1, " (");
       SERIAL_ECHOPGM_P((char *)pgm_read_ptr(&tramming_point_name[i]));
       SERIAL_CHAR(')');
-      SERIAL_ECHOLNPAIR_P(SP_X_STR, tramming_points[i].x, SP_Y_STR, tramming_points[i].y);
+      SERIAL_ECHOLNPGM_P(SP_X_STR, tramming_points[i].x, SP_Y_STR, tramming_points[i].y);
       err_break = true;
       break;
     }
 
     if (DEBUGGING(LEVELING)) {
-      DEBUG_ECHOPAIR("Probing point ", i + 1, " (");
+      DEBUG_ECHOPGM("Probing point ", i + 1, " (");
       DEBUG_ECHOPGM_P((char *)pgm_read_ptr(&tramming_point_name[i]));
       DEBUG_CHAR(')');
-      DEBUG_ECHOLNPAIR_P(SP_X_STR, tramming_points[i].x, SP_Y_STR, tramming_points[i].y, SP_Z_STR, z_probed_height);
+      DEBUG_ECHOLNPGM_P(SP_X_STR, tramming_points[i].x, SP_Y_STR, tramming_points[i].y, SP_Z_STR, z_probed_height);
     }
 
     z_measured[i] = z_probed_height;
@@ -138,9 +138,9 @@ void GcodeSuite::G35() {
 
       SERIAL_ECHOPGM("Turn ");
       SERIAL_ECHOPGM_P((char *)pgm_read_ptr(&tramming_point_name[i]));
-      SERIAL_ECHOPAIR(" ", (screw_thread & 1) == (adjust > 0) ? "CCW" : "CW", " by ", ABS(full_turns), " turns");
-      if (minutes) SERIAL_ECHOPAIR(" and ", ABS(minutes), " minutes");
-      if (ENABLED(REPORT_TRAMMING_MM)) SERIAL_ECHOPAIR(" (", -diff, "mm)");
+      SERIAL_ECHOPGM(" ", (screw_thread & 1) == (adjust > 0) ? "CCW" : "CW", " by ", ABS(full_turns), " turns");
+      if (minutes) SERIAL_ECHOPGM(" and ", ABS(minutes), " minutes");
+      if (ENABLED(REPORT_TRAMMING_MM)) SERIAL_ECHOPGM(" (", -diff, "mm)");
       SERIAL_EOL();
     }
   }

--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -242,4 +242,18 @@ void GcodeSuite::M420() {
     report_current_position();
 }
 
+void GcodeSuite::M420_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(
+    TERN(MESH_BED_LEVELING, "Mesh Bed Leveling", TERN(AUTO_BED_LEVELING_UBL, "Unified Bed Leveling", "Auto Bed Leveling"))
+  ));
+  SERIAL_ECHOPAIR_P(
+    PSTR("  M420 S"), planner.leveling_active
+    #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
+      , SP_Z_STR, LINEAR_UNIT(planner.z_fade_height)
+    #endif
+    , " ; Leveling "
+  );
+  serialprintln_onoff(planner.leveling_active);
+}
+
 #endif // HAS_LEVELING

--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -76,9 +76,9 @@ void GcodeSuite::M420() {
         TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(x, y, Z_VALUES(x, y)));
       }
       SERIAL_ECHOPGM("Simulated " STRINGIFY(GRID_MAX_POINTS_X) "x" STRINGIFY(GRID_MAX_POINTS_Y) " mesh ");
-      SERIAL_ECHOPAIR(" (", x_min);
+      SERIAL_ECHOPGM(" (", x_min);
       SERIAL_CHAR(','); SERIAL_ECHO(y_min);
-      SERIAL_ECHOPAIR(")-(", x_max);
+      SERIAL_ECHOPGM(")-(", x_max);
       SERIAL_CHAR(','); SERIAL_ECHO(y_max);
       SERIAL_ECHOLNPGM(")");
     }
@@ -108,7 +108,7 @@ void GcodeSuite::M420() {
 
         if (!WITHIN(storage_slot, 0, a - 1)) {
           SERIAL_ECHOLNPGM("?Invalid storage slot.");
-          SERIAL_ECHOLNPAIR("?Use 0 to ", a - 1);
+          SERIAL_ECHOLNPGM("?Use 0 to ", a - 1);
           return;
         }
 
@@ -128,7 +128,7 @@ void GcodeSuite::M420() {
       ubl.display_map(parser.byteval('T'));
       SERIAL_ECHOPGM("Mesh is ");
       if (!ubl.mesh_is_valid()) SERIAL_ECHOPGM("in");
-      SERIAL_ECHOLNPAIR("valid\nStorage slot: ", ubl.storage_slot);
+      SERIAL_ECHOLNPGM("valid\nStorage slot: ", ubl.storage_slot);
     }
 
   #endif // AUTO_BED_LEVELING_UBL
@@ -246,7 +246,7 @@ void GcodeSuite::M420_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(
     TERN(MESH_BED_LEVELING, "Mesh Bed Leveling", TERN(AUTO_BED_LEVELING_UBL, "Unified Bed Leveling", "Auto Bed Leveling"))
   ));
-  SERIAL_ECHOPAIR_P(
+  SERIAL_ECHOPGM_P(
     PSTR("  M420 S"), planner.leveling_active
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       , SP_Z_STR, LINEAR_UNIT(planner.z_fade_height)

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -379,7 +379,7 @@ G29_TYPE GcodeSuite::G29() {
 
       if (!probe.good_bounds(abl.probe_position_lf, abl.probe_position_rb)) {
         if (DEBUGGING(LEVELING)) {
-          DEBUG_ECHOLNPAIR("G29 L", abl.probe_position_lf.x, " R", abl.probe_position_rb.x,
+          DEBUG_ECHOLNPGM("G29 L", abl.probe_position_lf.x, " R", abl.probe_position_rb.x,
                               " F", abl.probe_position_lf.y, " B", abl.probe_position_rb.y);
         }
         SERIAL_ECHOLNPGM("? (L,R,F,B) out of bounds.");
@@ -470,7 +470,7 @@ G29_TYPE GcodeSuite::G29() {
     if (abl.verbose_level || seenQ) {
       SERIAL_ECHOPGM("Manual G29 ");
       if (g29_in_progress)
-        SERIAL_ECHOLNPAIR("point ", _MIN(abl.abl_probe_index + 1, abl.abl_points), " of ", abl.abl_points);
+        SERIAL_ECHOLNPGM("point ", _MIN(abl.abl_probe_index + 1, abl.abl_points), " of ", abl.abl_points);
       else
         SERIAL_ECHOLNPGM("idle");
     }
@@ -513,7 +513,7 @@ G29_TYPE GcodeSuite::G29() {
         z_values[abl.meshCount.x][abl.meshCount.y] = newz;
         TERN_(EXTENSIBLE_UI, ExtUI::onMeshUpdate(abl.meshCount, newz));
 
-        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR_P(PSTR("Save X"), abl.meshCount.x, SP_Y_STR, abl.meshCount.y, SP_Z_STR, abl.measured_z + abl.Z_offset);
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM_P(PSTR("Save X"), abl.meshCount.x, SP_Y_STR, abl.meshCount.y, SP_Z_STR, abl.measured_z + abl.Z_offset);
 
       #endif
     }
@@ -635,7 +635,7 @@ G29_TYPE GcodeSuite::G29() {
           // Avoid probing outside the round or hexagonal area
           if (TERN0(IS_KINEMATIC, !probe.can_reach(abl.probePos))) continue;
 
-          if (abl.verbose_level) SERIAL_ECHOLNPAIR("Probing mesh point ", pt_index, "/", abl.abl_points, ".");
+          if (abl.verbose_level) SERIAL_ECHOLNPGM("Probing mesh point ", pt_index, "/", abl.abl_points, ".");
           TERN_(HAS_STATUS_MESSAGE, ui.status_printf_P(0, PSTR(S_FMT " %i/%i"), GET_TEXT(MSG_PROBING_POINT), int(pt_index), int(abl.abl_points)));
 
           abl.measured_z = faux ? 0.001f * random(-100, 101) : probe.probe_at_point(abl.probePos, raise_after, abl.verbose_level);
@@ -680,7 +680,7 @@ G29_TYPE GcodeSuite::G29() {
       // Probe at 3 arbitrary points
 
       LOOP_L_N(i, 3) {
-        if (abl.verbose_level) SERIAL_ECHOLNPAIR("Probing point ", i + 1, "/3.");
+        if (abl.verbose_level) SERIAL_ECHOLNPGM("Probing point ", i + 1, "/3.");
         TERN_(HAS_STATUS_MESSAGE, ui.status_printf_P(0, PSTR(S_FMT " %i/3"), GET_TEXT(MSG_PROBING_POINT), int(i + 1)));
 
         // Retain the last probe position
@@ -842,7 +842,7 @@ G29_TYPE GcodeSuite::G29() {
           && NEAR(current_position.y, abl.probePos.y - probe.offset_xy.y)
         ) {
           const float simple_z = current_position.z - abl.measured_z;
-          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Probed Z", simple_z, "  Matrix Z", converted.z, "  Discrepancy ", simple_z - converted.z);
+          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Probed Z", simple_z, "  Matrix Z", converted.z, "  Discrepancy ", simple_z - converted.z);
           converted.z = simple_z;
         }
 
@@ -855,14 +855,14 @@ G29_TYPE GcodeSuite::G29() {
     #elif ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
       if (!abl.dryrun) {
-        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("G29 uncorrected Z:", current_position.z);
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("G29 uncorrected Z:", current_position.z);
 
         // Unapply the offset because it is going to be immediately applied
         // and cause compensation movement in Z
         const float fade_scaling_factor = TERN(ENABLE_LEVELING_FADE_HEIGHT, planner.fade_scaling_factor_for_z(current_position.z), 1);
         current_position.z -= fade_scaling_factor * bilinear_z_offset(current_position);
 
-        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR(" corrected Z:", current_position.z);
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM(" corrected Z:", current_position.z);
       }
 
     #endif // ABL_PLANAR
@@ -880,7 +880,7 @@ G29_TYPE GcodeSuite::G29() {
   TERN_(HAS_BED_PROBE, probe.move_z_after_probing());
 
   #ifdef Z_PROBE_END_SCRIPT
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Z Probe End Script: ", Z_PROBE_END_SCRIPT);
     planner.synchronize();
     process_subcommands_now_P(PSTR(Z_PROBE_END_SCRIPT));
   #endif

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -173,7 +173,7 @@ void GcodeSuite::G29() {
       if (parser.seenval('I')) {
         ix = parser.value_int();
         if (!WITHIN(ix, 0, (GRID_MAX_POINTS_X) - 1)) {
-          SERIAL_ECHOLNPAIR("I out of range (0-", (GRID_MAX_POINTS_X) - 1, ")");
+          SERIAL_ECHOLNPGM("I out of range (0-", (GRID_MAX_POINTS_X) - 1, ")");
           return;
         }
       }
@@ -183,7 +183,7 @@ void GcodeSuite::G29() {
       if (parser.seenval('J')) {
         iy = parser.value_int();
         if (!WITHIN(iy, 0, (GRID_MAX_POINTS_Y) - 1)) {
-          SERIAL_ECHOLNPAIR("J out of range (0-", (GRID_MAX_POINTS_Y) - 1, ")");
+          SERIAL_ECHOLNPGM("J out of range (0-", (GRID_MAX_POINTS_Y) - 1, ")");
           return;
         }
       }
@@ -213,7 +213,7 @@ void GcodeSuite::G29() {
   } // switch(state)
 
   if (state == MeshNext) {
-    SERIAL_ECHOLNPAIR("MBL G29 point ", _MIN(mbl_probe_index, GRID_MAX_POINTS), " of ", GRID_MAX_POINTS);
+    SERIAL_ECHOLNPGM("MBL G29 point ", _MIN(mbl_probe_index, GRID_MAX_POINTS), " of ", GRID_MAX_POINTS);
     if (mbl_probe_index > 0) TERN_(HAS_STATUS_MESSAGE, ui.status_printf_P(0, PSTR(S_FMT " %i/%i"), GET_TEXT(MSG_PROBING_POINT), _MIN(mbl_probe_index, GRID_MAX_POINTS), int(GRID_MAX_POINTS)));
   }
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -270,7 +270,7 @@ void GcodeSuite::G28() {
 
   #if HAS_HOMING_CURRENT
     auto debug_current = [](PGM_P const s, const int16_t a, const int16_t b) {
-      DEBUG_ECHOPGM_P(s); DEBUG_ECHOLNPAIR(" current: ", a, " -> ", b);
+      DEBUG_ECHOPGM_P(s); DEBUG_ECHOLNPGM(" current: ", a, " -> ", b);
     };
     #if HAS_CURRENT_HOME(X)
       const int16_t tmc_save_current_X = stepperX.getMilliamps();
@@ -371,7 +371,7 @@ void GcodeSuite::G28() {
 
     if (z_homing_height && (LINEAR_AXIS_GANG(doX, || doY, || TERN0(Z_SAFE_HOMING, doZ), || doI, || doJ, || doK))) {
       // Raise Z before homing any other axes and z is not already high enough (never lower z)
-      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) by ", z_homing_height);
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Raise Z (before homing) by ", z_homing_height);
       do_z_clearance(z_homing_height);
       TERN_(BLTOUCH, bltouch.init());
     }

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -107,14 +107,14 @@ void print_signed_float(PGM_P const prefix, const_float_t f) {
  *  - Print the delta settings
  */
 static void print_calibration_settings(const bool end_stops, const bool tower_angles) {
-  SERIAL_ECHOPAIR(".Height:", delta_height);
+  SERIAL_ECHOPGM(".Height:", delta_height);
   if (end_stops) {
     print_signed_float(PSTR("Ex"), delta_endstop_adj.a);
     print_signed_float(PSTR("Ey"), delta_endstop_adj.b);
     print_signed_float(PSTR("Ez"), delta_endstop_adj.c);
   }
   if (end_stops && tower_angles) {
-    SERIAL_ECHOPAIR("  Radius:", delta_radius);
+    SERIAL_ECHOPGM("  Radius:", delta_radius);
     SERIAL_EOL();
     SERIAL_CHAR('.');
     SERIAL_ECHO_SP(13);
@@ -125,7 +125,7 @@ static void print_calibration_settings(const bool end_stops, const bool tower_an
     print_signed_float(PSTR("Tz"), delta_tower_angle_trim.c);
   }
   if ((!end_stops && tower_angles) || (end_stops && !tower_angles)) { // XOR
-    SERIAL_ECHOPAIR("  Radius:", delta_radius);
+    SERIAL_ECHOPGM("  Radius:", delta_radius);
   }
   SERIAL_EOL();
 }

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -201,7 +201,7 @@ void GcodeSuite::G34() {
         if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> probing all positions.");
 
         const int iter = iteration + 1;
-        SERIAL_ECHOLNPAIR("\nG34 Iteration: ", iter);
+        SERIAL_ECHOLNPGM("\nG34 Iteration: ", iter);
         #if HAS_STATUS_MESSAGE
           char str[iter_str_len + 2 + 1];
           sprintf_P(str, msg_iteration, iter);
@@ -221,7 +221,7 @@ void GcodeSuite::G34() {
           if ((iteration == 0 || i > 0) && z_probe > current_position.z) do_blocking_move_to_z(z_probe);
 
           if (DEBUGGING(LEVELING))
-            DEBUG_ECHOLNPAIR_P(PSTR("Probing X"), z_stepper_align.xy[iprobe].x, SP_Y_STR, z_stepper_align.xy[iprobe].y);
+            DEBUG_ECHOLNPGM_P(PSTR("Probing X"), z_stepper_align.xy[iprobe].x, SP_Y_STR, z_stepper_align.xy[iprobe].y);
 
           // Probe a Z height for each stepper.
           // Probing sanity check is disabled, as it would trigger even in normal cases because
@@ -238,7 +238,7 @@ void GcodeSuite::G34() {
           // the next iteration of probing. This allows adjustments to be made away from the bed.
           z_measured[iprobe] = z_probed_height + Z_CLEARANCE_BETWEEN_PROBES;
 
-          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", iprobe + 1, " measured position is ", z_measured[iprobe]);
+          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> Z", iprobe + 1, " measured position is ", z_measured[iprobe]);
 
           // Remember the minimum measurement to calculate the correction later on
           z_measured_min = _MIN(z_measured_min, z_measured[iprobe]);
@@ -267,7 +267,7 @@ void GcodeSuite::G34() {
           linear_fit_data lfd;
           incremental_LSF_reset(&lfd);
           LOOP_L_N(i, NUM_Z_STEPPER_DRIVERS) {
-            SERIAL_ECHOLNPAIR("PROBEPT_", i, ": ", z_measured[i]);
+            SERIAL_ECHOLNPGM("PROBEPT_", i, ": ", z_measured[i]);
             incremental_LSF(&lfd, z_stepper_align.xy[i], z_measured[i]);
           }
           finish_incremental_LSF(&lfd);
@@ -278,7 +278,7 @@ void GcodeSuite::G34() {
             z_measured_min = _MIN(z_measured_min, z_measured[i]);
           }
 
-          SERIAL_ECHOLNPAIR(
+          SERIAL_ECHOLNPGM(
             LIST_N(DOUBLE(NUM_Z_STEPPER_DRIVERS),
               "Calculated Z1=", z_measured[0],
                         " Z2=", z_measured[1],
@@ -288,7 +288,7 @@ void GcodeSuite::G34() {
           );
         #endif
 
-        SERIAL_ECHOLNPAIR("\n"
+        SERIAL_ECHOLNPGM("\n"
           "Z2-Z1=", ABS(z_measured[1] - z_measured[0])
           #if TRIPLE_Z
             , " Z3-Z2=", ABS(z_measured[2] - z_measured[1])
@@ -372,8 +372,8 @@ void GcodeSuite::G34() {
 
             // Check for less accuracy compared to last move
             if (decreasing_accuracy(last_z_align_move[zstepper], z_align_abs)) {
-              if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", zstepper + 1, " last_z_align_move = ", last_z_align_move[zstepper]);
-              if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", zstepper + 1, " z_align_abs = ", z_align_abs);
+              if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> Z", zstepper + 1, " last_z_align_move = ", last_z_align_move[zstepper]);
+              if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> Z", zstepper + 1, " z_align_abs = ", z_align_abs);
               adjustment_reverse = !adjustment_reverse;
             }
 
@@ -385,7 +385,7 @@ void GcodeSuite::G34() {
           // Stop early if all measured points achieve accuracy target
           if (z_align_abs > z_auto_align_accuracy) success_break = false;
 
-          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", zstepper + 1, " corrected by ", z_align_move);
+          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> Z", zstepper + 1, " corrected by ", z_align_move);
 
           // Lock all steppers except one
           stepper.set_all_z_lock(true, zstepper);
@@ -395,7 +395,7 @@ void GcodeSuite::G34() {
             // Will match reversed Z steppers on dual steppers. Triple will need more work to map.
             if (adjustment_reverse) {
               z_align_move = -z_align_move;
-              if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("> Z", zstepper + 1, " correction reversed to ", z_align_move);
+              if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("> Z", zstepper + 1, " correction reversed to ", z_align_move);
             }
           #endif
 
@@ -421,7 +421,7 @@ void GcodeSuite::G34() {
       if (err_break)
         SERIAL_ECHOLNPGM("G34 aborted.");
       else {
-        SERIAL_ECHOLNPAIR("Did ", iteration + (iteration != z_auto_align_iterations), " of ", z_auto_align_iterations);
+        SERIAL_ECHOLNPGM("Did ", iteration + (iteration != z_auto_align_iterations), " of ", z_auto_align_iterations);
         SERIAL_ECHOLNPAIR_F("Accuracy: ", z_maxdiff);
       }
 
@@ -541,7 +541,7 @@ void GcodeSuite::M422_report(const bool forReplay/*=true*/) {
   report_heading(forReplay, PSTR(STR_Z_AUTO_ALIGN));
   LOOP_L_N(i, NUM_Z_STEPPER_DRIVERS) {
     report_echo_start(forReplay);
-    SERIAL_ECHOLNPAIR_P(
+    SERIAL_ECHOLNPGM_P(
       PSTR("  M422 S"), i + 1,
       SP_X_STR, z_stepper_align.xy[i].x,
       SP_Y_STR, z_stepper_align.xy[i].y
@@ -550,7 +550,7 @@ void GcodeSuite::M422_report(const bool forReplay/*=true*/) {
   #if ENABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
     LOOP_L_N(i, NUM_Z_STEPPER_DRIVERS) {
       report_echo_start(forReplay);
-      SERIAL_ECHOLNPAIR_P(
+      SERIAL_ECHOLNPGM_P(
         PSTR("  M422 W"), i + 1,
         SP_X_STR, z_stepper_align.stepper_xy[i].x,
         SP_Y_STR, z_stepper_align.stepper_xy[i].y

--- a/Marlin/src/gcode/calibrate/G34_M422.cpp
+++ b/Marlin/src/gcode/calibrate/G34_M422.cpp
@@ -475,18 +475,10 @@ void GcodeSuite::G34() {
  */
 void GcodeSuite::M422() {
 
+  if (!parser.seen_any()) return M422_report();
+
   if (parser.seen('R')) {
     z_stepper_align.reset_to_default();
-    return;
-  }
-
-  if (!parser.seen_any()) {
-    LOOP_L_N(i, NUM_Z_STEPPER_DRIVERS)
-      SERIAL_ECHOLNPAIR_P(PSTR("M422 S"), i + 1, SP_X_STR, z_stepper_align.xy[i].x, SP_Y_STR, z_stepper_align.xy[i].y);
-    #if ENABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
-      LOOP_L_N(i, NUM_Z_STEPPER_DRIVERS)
-        SERIAL_ECHOLNPAIR_P(PSTR("M422 W"), i + 1, SP_X_STR, z_stepper_align.stepper_xy[i].x, SP_Y_STR, z_stepper_align.stepper_xy[i].y);
-    #endif
     return;
   }
 
@@ -543,6 +535,28 @@ void GcodeSuite::M422() {
   }
 
   pos_dest[position_index] = pos;
+}
+
+void GcodeSuite::M422_report(const bool forReplay/*=true*/) {
+  report_heading(forReplay, PSTR(STR_Z_AUTO_ALIGN));
+  LOOP_L_N(i, NUM_Z_STEPPER_DRIVERS) {
+    report_echo_start(forReplay);
+    SERIAL_ECHOLNPAIR_P(
+      PSTR("  M422 S"), i + 1,
+      SP_X_STR, z_stepper_align.xy[i].x,
+      SP_Y_STR, z_stepper_align.xy[i].y
+    );
+  }
+  #if ENABLED(Z_STEPPER_ALIGN_KNOWN_STEPPER_POSITIONS)
+    LOOP_L_N(i, NUM_Z_STEPPER_DRIVERS) {
+      report_echo_start(forReplay);
+      SERIAL_ECHOLNPAIR_P(
+        PSTR("  M422 W"), i + 1,
+        SP_X_STR, z_stepper_align.stepper_xy[i].x,
+        SP_Y_STR, z_stepper_align.stepper_xy[i].y
+      );
+    }
+  #endif
 }
 
 #endif // Z_STEPPER_AUTO_ALIGN

--- a/Marlin/src/gcode/calibrate/G425.cpp
+++ b/Marlin/src/gcode/calibrate/G425.cpp
@@ -354,44 +354,44 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
   inline void report_measured_faces(const measurements_t &m) {
     SERIAL_ECHOLNPGM("Sides:");
     #if HAS_Z_AXIS && AXIS_CAN_CALIBRATE(Z)
-      SERIAL_ECHOLNPAIR("  Top: ", m.obj_side[TOP]);
+      SERIAL_ECHOLNPGM("  Top: ", m.obj_side[TOP]);
     #endif
     #if ENABLED(CALIBRATION_MEASURE_LEFT)
-      SERIAL_ECHOLNPAIR("  Left: ", m.obj_side[LEFT]);
+      SERIAL_ECHOLNPGM("  Left: ", m.obj_side[LEFT]);
     #endif
     #if ENABLED(CALIBRATION_MEASURE_RIGHT)
-      SERIAL_ECHOLNPAIR("  Right: ", m.obj_side[RIGHT]);
+      SERIAL_ECHOLNPGM("  Right: ", m.obj_side[RIGHT]);
     #endif
     #if HAS_Y_AXIS
       #if ENABLED(CALIBRATION_MEASURE_FRONT)
-        SERIAL_ECHOLNPAIR("  Front: ", m.obj_side[FRONT]);
+        SERIAL_ECHOLNPGM("  Front: ", m.obj_side[FRONT]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_BACK)
-        SERIAL_ECHOLNPAIR("  Back: ", m.obj_side[BACK]);
+        SERIAL_ECHOLNPGM("  Back: ", m.obj_side[BACK]);
       #endif
     #endif
     #if LINEAR_AXES >= 4
       #if ENABLED(CALIBRATION_MEASURE_IMIN)
-        SERIAL_ECHOLNPAIR("  " STR_I_MIN ": ", m.obj_side[IMINIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_I_MIN ": ", m.obj_side[IMINIMUM]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_IMAX)
-        SERIAL_ECHOLNPAIR("  " STR_I_MAX ": ", m.obj_side[IMAXIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_I_MAX ": ", m.obj_side[IMAXIMUM]);
       #endif
     #endif
     #if LINEAR_AXES >= 5
       #if ENABLED(CALIBRATION_MEASURE_JMIN)
-        SERIAL_ECHOLNPAIR("  " STR_J_MIN ": ", m.obj_side[JMINIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_J_MIN ": ", m.obj_side[JMINIMUM]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_JMAX)
-        SERIAL_ECHOLNPAIR("  " STR_J_MAX ": ", m.obj_side[JMAXIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_J_MAX ": ", m.obj_side[JMAXIMUM]);
       #endif
     #endif
     #if LINEAR_AXES >= 6
       #if ENABLED(CALIBRATION_MEASURE_KMIN)
-        SERIAL_ECHOLNPAIR("  " STR_K_MIN ": ", m.obj_side[KMINIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_K_MIN ": ", m.obj_side[KMINIMUM]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_KMAX)
-        SERIAL_ECHOLNPAIR("  " STR_K_MAX ": ", m.obj_side[KMAXIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_K_MAX ": ", m.obj_side[KMAXIMUM]);
       #endif
     #endif
     SERIAL_EOL();
@@ -400,20 +400,20 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
   inline void report_measured_center(const measurements_t &m) {
     SERIAL_ECHOLNPGM("Center:");
     #if HAS_X_CENTER
-      SERIAL_ECHOLNPAIR_P(SP_X_STR, m.obj_center.x);
+      SERIAL_ECHOLNPGM_P(SP_X_STR, m.obj_center.x);
     #endif
     #if HAS_Y_CENTER
-      SERIAL_ECHOLNPAIR_P(SP_Y_STR, m.obj_center.y);
+      SERIAL_ECHOLNPGM_P(SP_Y_STR, m.obj_center.y);
     #endif
-    SERIAL_ECHOLNPAIR_P(SP_Z_STR, m.obj_center.z);
+    SERIAL_ECHOLNPGM_P(SP_Z_STR, m.obj_center.z);
     #if HAS_I_CENTER
-      SERIAL_ECHOLNPAIR_P(SP_I_STR, m.obj_center.i);
+      SERIAL_ECHOLNPGM_P(SP_I_STR, m.obj_center.i);
     #endif
     #if HAS_J_CENTER
-      SERIAL_ECHOLNPAIR_P(SP_J_STR, m.obj_center.j);
+      SERIAL_ECHOLNPGM_P(SP_J_STR, m.obj_center.j);
     #endif
     #if HAS_K_CENTER
-      SERIAL_ECHOLNPAIR_P(SP_K_STR, m.obj_center.k);
+      SERIAL_ECHOLNPGM_P(SP_K_STR, m.obj_center.k);
     #endif
     SERIAL_EOL();
   }
@@ -422,45 +422,45 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
     SERIAL_ECHOLNPGM("Backlash:");
     #if AXIS_CAN_CALIBRATE(X)
       #if ENABLED(CALIBRATION_MEASURE_LEFT)
-        SERIAL_ECHOLNPAIR("  Left: ", m.backlash[LEFT]);
+        SERIAL_ECHOLNPGM("  Left: ", m.backlash[LEFT]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_RIGHT)
-        SERIAL_ECHOLNPAIR("  Right: ", m.backlash[RIGHT]);
+        SERIAL_ECHOLNPGM("  Right: ", m.backlash[RIGHT]);
       #endif
     #endif
     #if HAS_Y_AXIS && AXIS_CAN_CALIBRATE(Y)
       #if ENABLED(CALIBRATION_MEASURE_FRONT)
-        SERIAL_ECHOLNPAIR("  Front: ", m.backlash[FRONT]);
+        SERIAL_ECHOLNPGM("  Front: ", m.backlash[FRONT]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_BACK)
-        SERIAL_ECHOLNPAIR("  Back: ", m.backlash[BACK]);
+        SERIAL_ECHOLNPGM("  Back: ", m.backlash[BACK]);
       #endif
     #endif
     #if HAS_Z_AXIS && AXIS_CAN_CALIBRATE(Z)
-      SERIAL_ECHOLNPAIR("  Top: ", m.backlash[TOP]);
+      SERIAL_ECHOLNPGM("  Top: ", m.backlash[TOP]);
     #endif
     #if LINEAR_AXES >= 4 && AXIS_CAN_CALIBRATE(I)
       #if ENABLED(CALIBRATION_MEASURE_IMIN)
-        SERIAL_ECHOLNPAIR("  " STR_I_MIN ": ", m.backlash[IMINIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_I_MIN ": ", m.backlash[IMINIMUM]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_IMAX)
-        SERIAL_ECHOLNPAIR("  " STR_I_MAX ": ", m.backlash[IMAXIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_I_MAX ": ", m.backlash[IMAXIMUM]);
       #endif
     #endif
     #if LINEAR_AXES >= 5 && AXIS_CAN_CALIBRATE(J)
       #if ENABLED(CALIBRATION_MEASURE_JMIN)
-        SERIAL_ECHOLNPAIR("  " STR_J_MIN ": ", m.backlash[JMINIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_J_MIN ": ", m.backlash[JMINIMUM]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_JMAX)
-        SERIAL_ECHOLNPAIR("  " STR_J_MAX ": ", m.backlash[JMAXIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_J_MAX ": ", m.backlash[JMAXIMUM]);
       #endif
     #endif
     #if LINEAR_AXES >= 6 && AXIS_CAN_CALIBRATE(K)
       #if ENABLED(CALIBRATION_MEASURE_KMIN)
-        SERIAL_ECHOLNPAIR("  " STR_K_MIN ": ", m.backlash[KMINIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_K_MIN ": ", m.backlash[KMINIMUM]);
       #endif
       #if ENABLED(CALIBRATION_MEASURE_KMAX)
-        SERIAL_ECHOLNPAIR("  " STR_K_MAX ": ", m.backlash[KMAXIMUM]);
+        SERIAL_ECHOLNPGM("  " STR_K_MAX ": ", m.backlash[KMAXIMUM]);
       #endif
     #endif
     SERIAL_EOL();
@@ -471,22 +471,22 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
     SERIAL_ECHO(active_extruder);
     SERIAL_ECHOLNPGM(" Positional Error:");
     #if HAS_X_CENTER && AXIS_CAN_CALIBRATE(X)
-      SERIAL_ECHOLNPAIR_P(SP_X_STR, m.pos_error.x);
+      SERIAL_ECHOLNPGM_P(SP_X_STR, m.pos_error.x);
     #endif
     #if HAS_Y_CENTER && AXIS_CAN_CALIBRATE(Y)
-      SERIAL_ECHOLNPAIR_P(SP_Y_STR, m.pos_error.y);
+      SERIAL_ECHOLNPGM_P(SP_Y_STR, m.pos_error.y);
     #endif
     #if HAS_Z_AXIS && AXIS_CAN_CALIBRATE(Z)
-      SERIAL_ECHOLNPAIR_P(SP_Z_STR, m.pos_error.z);
+      SERIAL_ECHOLNPGM_P(SP_Z_STR, m.pos_error.z);
     #endif
     #if HAS_I_CENTER && AXIS_CAN_CALIBRATE(I)
-      SERIAL_ECHOLNPAIR_P(SP_I_STR, m.pos_error.i);
+      SERIAL_ECHOLNPGM_P(SP_I_STR, m.pos_error.i);
     #endif
     #if HAS_J_CENTER && AXIS_CAN_CALIBRATE(J)
-      SERIAL_ECHOLNPAIR_P(SP_J_STR, m.pos_error.j);
+      SERIAL_ECHOLNPGM_P(SP_J_STR, m.pos_error.j);
     #endif
     #if HAS_K_CENTER && AXIS_CAN_CALIBRATE(K)
-      SERIAL_ECHOLNPAIR_P(SP_Z_STR, m.pos_error.z);
+      SERIAL_ECHOLNPGM_P(SP_Z_STR, m.pos_error.z);
     #endif
     SERIAL_EOL();
   }
@@ -494,10 +494,10 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
   inline void report_measured_nozzle_dimensions(const measurements_t &m) {
     SERIAL_ECHOLNPGM("Nozzle Tip Outer Dimensions:");
     #if HAS_X_CENTER
-      SERIAL_ECHOLNPAIR_P(SP_X_STR, m.nozzle_outer_dimension.x);
+      SERIAL_ECHOLNPGM_P(SP_X_STR, m.nozzle_outer_dimension.x);
     #endif
     #if HAS_Y_CENTER
-      SERIAL_ECHOLNPAIR_P(SP_Y_STR, m.nozzle_outer_dimension.y);
+      SERIAL_ECHOLNPGM_P(SP_Y_STR, m.nozzle_outer_dimension.y);
     #endif
     SERIAL_EOL();
     UNUSED(m);
@@ -509,7 +509,7 @@ inline void probe_sides(measurements_t &m, const float uncertainty) {
     //
     inline void report_hotend_offsets() {
       LOOP_S_L_N(e, 1, HOTENDS)
-        SERIAL_ECHOLNPAIR_P(PSTR("T"), e, PSTR(" Hotend Offset X"), hotend_offset[e].x, SP_Y_STR, hotend_offset[e].y, SP_Z_STR, hotend_offset[e].z);
+        SERIAL_ECHOLNPGM_P(PSTR("T"), e, PSTR(" Hotend Offset X"), hotend_offset[e].x, SP_Y_STR, hotend_offset[e].y, SP_Z_STR, hotend_offset[e].z);
     }
   #endif
 

--- a/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
@@ -171,7 +171,7 @@ void GcodeSuite::G76() {
   millis_t next_temp_report = millis() + 1000;
 
   auto report_targets = [&](const celsius_t tb, const celsius_t tp) {
-    SERIAL_ECHOLNPAIR("Target Bed:", tb, " Probe:", tp);
+    SERIAL_ECHOLNPGM("Target Bed:", tb, " Probe:", tp);
   };
 
   if (do_bed_cal) {
@@ -211,7 +211,7 @@ void GcodeSuite::G76() {
       if (isnan(measured_z) || target_bed > (BED_MAX_TARGET)) break;
     }
 
-    SERIAL_ECHOLNPAIR("Retrieved measurements: ", temp_comp.get_index());
+    SERIAL_ECHOLNPGM("Retrieved measurements: ", temp_comp.get_index());
     if (temp_comp.finish_calibration(TSI_BED)) {
       say_successfully_calibrated();
       SERIAL_ECHOLNPGM(" bed.");
@@ -255,7 +255,7 @@ void GcodeSuite::G76() {
       do_blocking_move_to(noz_pos_xyz);
 
       say_waiting_for_probe_heating();
-      SERIAL_ECHOLNPAIR(" Bed:", target_bed, " Probe:", target_probe);
+      SERIAL_ECHOLNPGM(" Bed:", target_bed, " Probe:", target_probe);
       const millis_t probe_timeout_ms = millis() + SEC_TO_MS(900UL);
       while (thermalManager.degProbe() < target_probe) {
         if (report_temps(next_temp_report, probe_timeout_ms)) {
@@ -270,7 +270,7 @@ void GcodeSuite::G76() {
       if (isnan(measured_z) || target_probe > cali_info_init[TSI_PROBE].end_temp) break;
     }
 
-    SERIAL_ECHOLNPAIR("Retrieved measurements: ", temp_comp.get_index());
+    SERIAL_ECHOLNPGM("Retrieved measurements: ", temp_comp.get_index());
     if (temp_comp.finish_calibration(TSI_PROBE))
       say_successfully_calibrated();
     else
@@ -325,7 +325,7 @@ void GcodeSuite::M871() {
                                 TSI_PROBE
                               );
     if (idx > 0 && temp_comp.set_offset(mod, idx - 1, offset_val))
-      SERIAL_ECHOLNPAIR("Set value: ", offset_val);
+      SERIAL_ECHOLNPGM("Set value: ", offset_val);
     else
       SERIAL_ECHOLNPGM("!Invalid index. Failed to set value (note: value at index 0 is constant).");
 

--- a/Marlin/src/gcode/calibrate/M100.cpp
+++ b/Marlin/src/gcode/calibrate/M100.cpp
@@ -202,7 +202,7 @@ inline int check_for_free_memory_corruption(PGM_P const title) {
   char *start_free_memory = free_memory_start, *end_free_memory = free_memory_end;
   int n = end_free_memory - start_free_memory;
 
-  SERIAL_ECHOLNPAIR("\nfmc() n=", n,
+  SERIAL_ECHOLNPGM("\nfmc() n=", n,
                     "\nfree_memory_start=", hex_address(free_memory_start),
                     "  end=", hex_address(end_free_memory));
 
@@ -227,15 +227,15 @@ inline int check_for_free_memory_corruption(PGM_P const title) {
     if (start_free_memory[i] == TEST_BYTE) {
       int32_t j = count_test_bytes(start_free_memory + i);
       if (j > 8) {
-        //SERIAL_ECHOPAIR("Found ", j);
-        //SERIAL_ECHOLNPAIR(" bytes free at ", hex_address(start_free_memory + i));
+        //SERIAL_ECHOPGM("Found ", j);
+        //SERIAL_ECHOLNPGM(" bytes free at ", hex_address(start_free_memory + i));
         i += j;
         block_cnt++;
-        SERIAL_ECHOLNPAIR(" (", block_cnt, ") found=", j);
+        SERIAL_ECHOLNPGM(" (", block_cnt, ") found=", j);
       }
     }
   }
-  SERIAL_ECHOPAIR("  block_found=", block_cnt);
+  SERIAL_ECHOPGM("  block_found=", block_cnt);
 
   if (block_cnt != 1)
     SERIAL_ECHOLNPGM("\nMemory Corruption detected in free memory area.");
@@ -267,7 +267,7 @@ inline void free_memory_pool_report(char * const start_free_memory, const int32_
     if (*addr == TEST_BYTE) {
       const int32_t j = count_test_bytes(addr);
       if (j > 8) {
-        SERIAL_ECHOLNPAIR("Found ", j, " bytes free at ", hex_address(addr));
+        SERIAL_ECHOLNPGM("Found ", j, " bytes free at ", hex_address(addr));
         if (j > max_cnt) {
           max_cnt  = j;
           max_addr = addr;
@@ -277,11 +277,11 @@ inline void free_memory_pool_report(char * const start_free_memory, const int32_
       }
     }
   }
-  if (block_cnt > 1) SERIAL_ECHOLNPAIR(
+  if (block_cnt > 1) SERIAL_ECHOLNPGM(
     "\nMemory Corruption detected in free memory area."
     "\nLargest free block is ", max_cnt, " bytes at ", hex_address(max_addr)
   );
-  SERIAL_ECHOLNPAIR("check_for_free_memory_corruption() = ", check_for_free_memory_corruption(PSTR("M100 F ")));
+  SERIAL_ECHOLNPGM("check_for_free_memory_corruption() = ", check_for_free_memory_corruption(PSTR("M100 F ")));
 }
 
 #if ENABLED(M100_FREE_MEMORY_CORRUPTOR)
@@ -299,7 +299,7 @@ inline void free_memory_pool_report(char * const start_free_memory, const int32_
     for (uint32_t i = 1; i <= size; i++) {
       char * const addr = start_free_memory + i * j;
       *addr = i;
-      SERIAL_ECHOPAIR("\nCorrupting address: ", hex_address(addr));
+      SERIAL_ECHOPGM("\nCorrupting address: ", hex_address(addr));
     }
     SERIAL_EOL();
   }
@@ -327,8 +327,8 @@ inline void init_free_memory(char *start_free_memory, int32_t size) {
 
   for (int32_t i = 0; i < size; i++) {
     if (start_free_memory[i] != TEST_BYTE) {
-      SERIAL_ECHOPAIR("? address : ", hex_address(start_free_memory + i));
-      SERIAL_ECHOLNPAIR("=", hex_byte(start_free_memory[i]));
+      SERIAL_ECHOPGM("? address : ", hex_address(start_free_memory + i));
+      SERIAL_ECHOLNPGM("=", hex_byte(start_free_memory[i]));
       SERIAL_EOL();
     }
   }
@@ -340,14 +340,14 @@ inline void init_free_memory(char *start_free_memory, int32_t size) {
 void GcodeSuite::M100() {
   char *sp = top_of_stack();
   if (!free_memory_end) free_memory_end = sp - MEMORY_END_CORRECTION;
-                  SERIAL_ECHOPAIR("\nbss_end               : ", hex_address(end_bss));
-  if (heaplimit)  SERIAL_ECHOPAIR("\n__heaplimit           : ", hex_address(heaplimit));
-                  SERIAL_ECHOPAIR("\nfree_memory_start     : ", hex_address(free_memory_start));
-  if (stacklimit) SERIAL_ECHOPAIR("\n__stacklimit          : ", hex_address(stacklimit));
-                  SERIAL_ECHOPAIR("\nfree_memory_end       : ", hex_address(free_memory_end));
+                  SERIAL_ECHOPGM("\nbss_end               : ", hex_address(end_bss));
+  if (heaplimit)  SERIAL_ECHOPGM("\n__heaplimit           : ", hex_address(heaplimit));
+                  SERIAL_ECHOPGM("\nfree_memory_start     : ", hex_address(free_memory_start));
+  if (stacklimit) SERIAL_ECHOPGM("\n__stacklimit          : ", hex_address(stacklimit));
+                  SERIAL_ECHOPGM("\nfree_memory_end       : ", hex_address(free_memory_end));
   if (MEMORY_END_CORRECTION)
-                  SERIAL_ECHOPAIR("\nMEMORY_END_CORRECTION : ", MEMORY_END_CORRECTION);
-                  SERIAL_ECHOLNPAIR("\nStack Pointer       : ", hex_address(sp));
+                  SERIAL_ECHOPGM("\nMEMORY_END_CORRECTION : ", MEMORY_END_CORRECTION);
+                  SERIAL_ECHOLNPGM("\nStack Pointer       : ", hex_address(sp));
 
   // Always init on the first invocation of M100
   static bool m100_not_initialized = true;

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -86,7 +86,7 @@ void GcodeSuite::M425() {
     SERIAL_ECHOPGM("Backlash Correction ");
     if (!backlash.correction) SERIAL_ECHOPGM("in");
     SERIAL_ECHOLNPGM("active:");
-    SERIAL_ECHOLNPAIR("  Correction Amount/Fade-out:     F", backlash.get_correction(), " (F1.0 = full, F0.0 = none)");
+    SERIAL_ECHOLNPGM("  Correction Amount/Fade-out:     F", backlash.get_correction(), " (F1.0 = full, F0.0 = none)");
     SERIAL_ECHOPGM("  Backlash Distance (mm):        ");
     LOOP_LINEAR_AXES(a) if (axis_can_calibrate(a)) {
       SERIAL_CHAR(' ', AXIS_CHAR(a));
@@ -95,7 +95,7 @@ void GcodeSuite::M425() {
     }
 
     #ifdef BACKLASH_SMOOTHING_MM
-      SERIAL_ECHOLNPAIR("  Smoothing (mm):                 S", backlash.smoothing_mm);
+      SERIAL_ECHOLNPGM("  Smoothing (mm):                 S", backlash.smoothing_mm);
     #endif
 
     #if ENABLED(MEASURE_BACKLASH_WHEN_PROBING)
@@ -115,7 +115,7 @@ void GcodeSuite::M425() {
 
 void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_BACKLASH_COMPENSATION));
-  SERIAL_ECHOLNPAIR_P(
+  SERIAL_ECHOLNPGM_P(
     PSTR("  M425 F"), backlash.get_correction()
     #ifdef BACKLASH_SMOOTHING_MM
       , PSTR(" S"), LINEAR_UNIT(backlash.smoothing_mm)

--- a/Marlin/src/gcode/calibrate/M425.cpp
+++ b/Marlin/src/gcode/calibrate/M425.cpp
@@ -113,4 +113,22 @@ void GcodeSuite::M425() {
   }
 }
 
+void GcodeSuite::M425_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_BACKLASH_COMPENSATION));
+  SERIAL_ECHOLNPAIR_P(
+    PSTR("  M425 F"), backlash.get_correction()
+    #ifdef BACKLASH_SMOOTHING_MM
+      , PSTR(" S"), LINEAR_UNIT(backlash.smoothing_mm)
+    #endif
+    , LIST_N(DOUBLE(LINEAR_AXES),
+        SP_X_STR, LINEAR_UNIT(backlash.distance_mm.x),
+        SP_Y_STR, LINEAR_UNIT(backlash.distance_mm.y),
+        SP_Z_STR, LINEAR_UNIT(backlash.distance_mm.z),
+        SP_I_STR, LINEAR_UNIT(backlash.distance_mm.i),
+        SP_J_STR, LINEAR_UNIT(backlash.distance_mm.j),
+        SP_K_STR, LINEAR_UNIT(backlash.distance_mm.k)
+      )
+  );
+}
+
 #endif // BACKLASH_GCODE

--- a/Marlin/src/gcode/calibrate/M48.cpp
+++ b/Marlin/src/gcode/calibrate/M48.cpp
@@ -162,7 +162,7 @@ void GcodeSuite::M48() {
           #endif
         );
         if (verbose_level > 3) {
-          SERIAL_ECHOPAIR("Start radius:", radius, " angle:", angle, " dir:");
+          SERIAL_ECHOPGM("Start radius:", radius, " angle:", angle, " dir:");
           if (dir > 0) SERIAL_CHAR('C');
           SERIAL_ECHOLNPGM("CW");
         }
@@ -200,7 +200,7 @@ void GcodeSuite::M48() {
             while (!probe.can_reach(next_pos)) {
               next_pos *= 0.8f;
               if (verbose_level > 3)
-                SERIAL_ECHOLNPAIR_P(PSTR("Moving inward: X"), next_pos.x, SP_Y_STR, next_pos.y);
+                SERIAL_ECHOLNPGM_P(PSTR("Moving inward: X"), next_pos.x, SP_Y_STR, next_pos.y);
             }
           #elif HAS_ENDSTOPS
             // For a rectangular bed just keep the probe in bounds
@@ -209,7 +209,7 @@ void GcodeSuite::M48() {
           #endif
 
           if (verbose_level > 3)
-            SERIAL_ECHOLNPAIR_P(PSTR("Going to: X"), next_pos.x, SP_Y_STR, next_pos.y);
+            SERIAL_ECHOLNPGM_P(PSTR("Going to: X"), next_pos.x, SP_Y_STR, next_pos.y);
 
           do_blocking_move_to_xy(next_pos);
         } // n_legs loop
@@ -241,7 +241,7 @@ void GcodeSuite::M48() {
 
       if (verbose_level > 1) {
         SERIAL_ECHO(n + 1);
-        SERIAL_ECHOPAIR(" of ", n_samples);
+        SERIAL_ECHOPGM(" of ", n_samples);
         SERIAL_ECHOPAIR_F(": z: ", pz, 3);
         SERIAL_CHAR(' ');
         dev_report(verbose_level > 2, mean, sigma, min, max);

--- a/Marlin/src/gcode/calibrate/M665.cpp
+++ b/Marlin/src/gcode/calibrate/M665.cpp
@@ -63,7 +63,7 @@
 
   void GcodeSuite::M665_report(const bool forReplay/*=true*/) {
     report_heading_etc(forReplay, PSTR(STR_DELTA_SETTINGS));
-    SERIAL_ECHOLNPAIR_P(
+    SERIAL_ECHOLNPGM_P(
         PSTR("  M665 L"), LINEAR_UNIT(delta_diagonal_rod)
       , PSTR(" R"), LINEAR_UNIT(delta_radius)
       , PSTR(" H"), LINEAR_UNIT(delta_height)
@@ -133,7 +133,7 @@
 
   void GcodeSuite::M665_report(const bool forReplay/*=true*/) {
     report_heading_etc(forReplay, PSTR(STR_SCARA_SETTINGS " (" STR_SCARA_S TERN_(HAS_SCARA_OFFSET, " " STR_SCARA_P_T_Z) ")"));
-    SERIAL_ECHOLNPAIR_P(
+    SERIAL_ECHOLNPGM_P(
       PSTR("  M665 S"), segments_per_second
       #if HAS_SCARA_OFFSET
         , SP_P_STR, scara_home_offset.a

--- a/Marlin/src/gcode/calibrate/M665.cpp
+++ b/Marlin/src/gcode/calibrate/M665.cpp
@@ -30,6 +30,7 @@
 #if ENABLED(DELTA)
 
   #include "../../module/delta.h"
+
   /**
    * M665: Set delta configurations
    *
@@ -45,6 +46,8 @@
    *    C = Gamma (Tower 3) diagonal rod trim
    */
   void GcodeSuite::M665() {
+    if (!parser.seen_any()) return M665_report();
+
     if (parser.seenval('H')) delta_height              = parser.value_linear_units();
     if (parser.seenval('L')) delta_diagonal_rod        = parser.value_linear_units();
     if (parser.seenval('R')) delta_radius              = parser.value_linear_units();
@@ -58,6 +61,22 @@
     recalc_delta_settings();
   }
 
+  void GcodeSuite::M665_report(const bool forReplay/*=true*/) {
+    report_heading_etc(forReplay, PSTR(STR_DELTA_SETTINGS));
+    SERIAL_ECHOLNPAIR_P(
+        PSTR("  M665 L"), LINEAR_UNIT(delta_diagonal_rod)
+      , PSTR(" R"), LINEAR_UNIT(delta_radius)
+      , PSTR(" H"), LINEAR_UNIT(delta_height)
+      , PSTR(" S"), segments_per_second
+      , SP_X_STR, LINEAR_UNIT(delta_tower_angle_trim.a)
+      , SP_Y_STR, LINEAR_UNIT(delta_tower_angle_trim.b)
+      , SP_Z_STR, LINEAR_UNIT(delta_tower_angle_trim.c)
+      , PSTR(" A"), LINEAR_UNIT(delta_diagonal_rod_trim.a)
+      , PSTR(" B"), LINEAR_UNIT(delta_diagonal_rod_trim.b)
+      , PSTR(" C"), LINEAR_UNIT(delta_diagonal_rod_trim.c)
+    );
+  }
+
 #elif IS_SCARA
 
   #include "../../module/scara.h"
@@ -68,6 +87,9 @@
    * Parameters:
    *
    *   S[segments-per-second] - Segments-per-second
+   *
+   * Without NO_WORKSPACE_OFFSETS:
+   *
    *   P[theta-psi-offset]    - Theta-Psi offset, added to the shoulder (A/X) angle
    *   T[theta-offset]        - Theta     offset, added to the elbow    (B/Y) angle
    *   Z[z-offset]            - Z offset, added to Z
@@ -76,6 +98,8 @@
    *   B, T, and Y are all aliases for the elbow angle
    */
   void GcodeSuite::M665() {
+    if (!parser.seen_any()) return M665_report();
+
     if (parser.seenval('S')) segments_per_second = parser.value_float();
 
     #if HAS_SCARA_OFFSET
@@ -105,6 +129,18 @@
       }
 
     #endif // HAS_SCARA_OFFSET
+  }
+
+  void GcodeSuite::M665_report(const bool forReplay/*=true*/) {
+    report_heading_etc(forReplay, PSTR(STR_SCARA_SETTINGS " (" STR_SCARA_S TERN_(HAS_SCARA_OFFSET, " " STR_SCARA_P_T_Z) ")"));
+    SERIAL_ECHOLNPAIR_P(
+      PSTR("  M665 S"), segments_per_second
+      #if HAS_SCARA_OFFSET
+        , SP_P_STR, scara_home_offset.a
+        , SP_T_STR, scara_home_offset.b
+        , SP_Z_STR, LINEAR_UNIT(scara_home_offset.z)
+      #endif
+    );
   }
 
 #endif

--- a/Marlin/src/gcode/calibrate/M666.cpp
+++ b/Marlin/src/gcode/calibrate/M666.cpp
@@ -36,38 +36,6 @@
 #define DEBUG_OUT ENABLED(DEBUG_LEVELING_FEATURE)
 #include "../../core/debug_out.h"
 
-void M666_report(const bool forReplay=true) {
-  if (!forReplay) { SERIAL_ECHOLNPGM("; Endstop adjustment:"); SERIAL_ECHO_START(); }
-  #if ENABLED(DELTA)
-    SERIAL_ECHOLNPAIR_P(
-        PSTR("  M666 X"), LINEAR_UNIT(delta_endstop_adj.a)
-      , SP_Y_STR, LINEAR_UNIT(delta_endstop_adj.b)
-      , SP_Z_STR, LINEAR_UNIT(delta_endstop_adj.c)
-    );
-  #else
-    SERIAL_ECHOPGM("  M666");
-    #if ENABLED(X_DUAL_ENDSTOPS)
-      SERIAL_ECHOLNPAIR_P(SP_X_STR, LINEAR_UNIT(endstops.x2_endstop_adj));
-    #endif
-    #if ENABLED(Y_DUAL_ENDSTOPS)
-      SERIAL_ECHOLNPAIR_P(SP_Y_STR, LINEAR_UNIT(endstops.y2_endstop_adj));
-    #endif
-    #if ENABLED(Z_MULTI_ENDSTOPS)
-      #if NUM_Z_STEPPER_DRIVERS >= 3
-        SERIAL_ECHOPAIR(" S2 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
-        if (!forReplay) SERIAL_ECHO_START();
-        SERIAL_ECHOPAIR("  M666 S3 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
-        #if NUM_Z_STEPPER_DRIVERS >= 4
-          if (!forReplay) SERIAL_ECHO_START();
-          SERIAL_ECHOPAIR("  M666 S4 Z", LINEAR_UNIT(endstops.z4_endstop_adj));
-        #endif
-      #else
-        SERIAL_ECHOLNPAIR_P(SP_Z_STR, LINEAR_UNIT(endstops.z2_endstop_adj));
-      #endif
-    #endif
-  #endif
-}
-
 #if ENABLED(DELTA)
 
   /**
@@ -92,6 +60,15 @@ void M666_report(const bool forReplay=true) {
     if (!is_set) M666_report();
   }
 
+  void GcodeSuite::M666_report(const bool forReplay/*=true*/) {
+    report_heading_etc(forReplay, PSTR(STR_ENDSTOP_ADJUSTMENT));
+    SERIAL_ECHOLNPAIR_P(
+        PSTR("  M666 X"), LINEAR_UNIT(delta_endstop_adj.a)
+      , SP_Y_STR, LINEAR_UNIT(delta_endstop_adj.b)
+      , SP_Z_STR, LINEAR_UNIT(delta_endstop_adj.c)
+    );
+  }
+
 #else
 
   /**
@@ -105,6 +82,8 @@ void M666_report(const bool forReplay=true) {
    *       Set All: M666 Z<offset>
    */
   void GcodeSuite::M666() {
+    if (!parser.seen_any()) return M666_report();
+
     #if ENABLED(X_DUAL_ENDSTOPS)
       if (parser.seenval('X')) endstops.x2_endstop_adj = parser.value_linear_units();
     #endif
@@ -123,7 +102,30 @@ void M666_report(const bool forReplay=true) {
         #endif
       }
     #endif
-    if (!parser.seen("XYZ")) M666_report();
+  }
+
+  void GcodeSuite::M666_report(const bool forReplay/*=true*/) {
+    report_heading_etc(forReplay, PSTR(STR_ENDSTOP_ADJUSTMENT));
+    SERIAL_ECHOPGM("  M666");
+    #if ENABLED(X_DUAL_ENDSTOPS)
+      SERIAL_ECHOLNPAIR_P(SP_X_STR, LINEAR_UNIT(endstops.x2_endstop_adj));
+    #endif
+    #if ENABLED(Y_DUAL_ENDSTOPS)
+      SERIAL_ECHOLNPAIR_P(SP_Y_STR, LINEAR_UNIT(endstops.y2_endstop_adj));
+    #endif
+    #if ENABLED(Z_MULTI_ENDSTOPS)
+      #if NUM_Z_STEPPER_DRIVERS >= 3
+        SERIAL_ECHOPAIR(" S2 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
+        report_echo_start(forReplay);
+        SERIAL_ECHOPAIR("  M666 S3 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
+        #if NUM_Z_STEPPER_DRIVERS >= 4
+          report_echo_start(forReplay);
+          SERIAL_ECHOPAIR("  M666 S4 Z", LINEAR_UNIT(endstops.z4_endstop_adj));
+        #endif
+      #else
+        SERIAL_ECHOLNPAIR_P(SP_Z_STR, LINEAR_UNIT(endstops.z2_endstop_adj));
+      #endif
+    #endif
   }
 
 #endif // HAS_EXTRA_ENDSTOPS

--- a/Marlin/src/gcode/calibrate/M666.cpp
+++ b/Marlin/src/gcode/calibrate/M666.cpp
@@ -52,17 +52,17 @@
           is_err = true;
         else {
           delta_endstop_adj[i] = v;
-          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("delta_endstop_adj[", AS_CHAR(AXIS_CHAR(i)), "] = ", v);
+          if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("delta_endstop_adj[", AS_CHAR(AXIS_CHAR(i)), "] = ", v);
         }
       }
     }
-    if (is_err) SERIAL_ECHOLNPAIR("?M666 offsets must be <= 0");
+    if (is_err) SERIAL_ECHOLNPGM("?M666 offsets must be <= 0");
     if (!is_set) M666_report();
   }
 
   void GcodeSuite::M666_report(const bool forReplay/*=true*/) {
     report_heading_etc(forReplay, PSTR(STR_ENDSTOP_ADJUSTMENT));
-    SERIAL_ECHOLNPAIR_P(
+    SERIAL_ECHOLNPGM_P(
         PSTR("  M666 X"), LINEAR_UNIT(delta_endstop_adj.a)
       , SP_Y_STR, LINEAR_UNIT(delta_endstop_adj.b)
       , SP_Z_STR, LINEAR_UNIT(delta_endstop_adj.c)
@@ -108,22 +108,22 @@
     report_heading_etc(forReplay, PSTR(STR_ENDSTOP_ADJUSTMENT));
     SERIAL_ECHOPGM("  M666");
     #if ENABLED(X_DUAL_ENDSTOPS)
-      SERIAL_ECHOLNPAIR_P(SP_X_STR, LINEAR_UNIT(endstops.x2_endstop_adj));
+      SERIAL_ECHOLNPGM_P(SP_X_STR, LINEAR_UNIT(endstops.x2_endstop_adj));
     #endif
     #if ENABLED(Y_DUAL_ENDSTOPS)
-      SERIAL_ECHOLNPAIR_P(SP_Y_STR, LINEAR_UNIT(endstops.y2_endstop_adj));
+      SERIAL_ECHOLNPGM_P(SP_Y_STR, LINEAR_UNIT(endstops.y2_endstop_adj));
     #endif
     #if ENABLED(Z_MULTI_ENDSTOPS)
       #if NUM_Z_STEPPER_DRIVERS >= 3
-        SERIAL_ECHOPAIR(" S2 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
+        SERIAL_ECHOPGM(" S2 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
         report_echo_start(forReplay);
-        SERIAL_ECHOPAIR("  M666 S3 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
+        SERIAL_ECHOPGM("  M666 S3 Z", LINEAR_UNIT(endstops.z3_endstop_adj));
         #if NUM_Z_STEPPER_DRIVERS >= 4
           report_echo_start(forReplay);
-          SERIAL_ECHOPAIR("  M666 S4 Z", LINEAR_UNIT(endstops.z4_endstop_adj));
+          SERIAL_ECHOPGM("  M666 S4 Z", LINEAR_UNIT(endstops.z4_endstop_adj));
         #endif
       #else
-        SERIAL_ECHOLNPAIR_P(SP_Z_STR, LINEAR_UNIT(endstops.z2_endstop_adj));
+        SERIAL_ECHOLNPGM_P(SP_Z_STR, LINEAR_UNIT(endstops.z2_endstop_adj));
       #endif
     #endif
   }

--- a/Marlin/src/gcode/calibrate/M852.cpp
+++ b/Marlin/src/gcode/calibrate/M852.cpp
@@ -36,10 +36,11 @@
  *  K[yz_factor] - New YZ skew factor
  */
 void GcodeSuite::M852() {
-  uint8_t ijk = 0, badval = 0, setval = 0;
+  if (!parser.seen("SIJK")) return M852_report();
 
-  if (parser.seen('I') || parser.seen('S')) {
-    ++ijk;
+  uint8_t badval = 0, setval = 0;
+
+  if (parser.seenval('I') || parser.seenval('S')) {
     const float value = parser.value_linear_units();
     if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX)) {
       if (planner.skew_factor.xy != value) {
@@ -53,8 +54,7 @@ void GcodeSuite::M852() {
 
   #if ENABLED(SKEW_CORRECTION_FOR_Z)
 
-    if (parser.seen('J')) {
-      ++ijk;
+    if (parser.seenval('J')) {
       const float value = parser.value_linear_units();
       if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX)) {
         if (planner.skew_factor.xz != value) {
@@ -66,8 +66,7 @@ void GcodeSuite::M852() {
         ++badval;
     }
 
-    if (parser.seen('K')) {
-      ++ijk;
+    if (parser.seenval('K')) {
       const float value = parser.value_linear_units();
       if (WITHIN(value, SKEW_FACTOR_MIN, SKEW_FACTOR_MAX)) {
         if (planner.skew_factor.yz != value) {
@@ -90,17 +89,18 @@ void GcodeSuite::M852() {
     sync_plan_position();
     report_current_position();
   }
+}
 
-  if (!ijk) {
-    SERIAL_ECHO_START();
-    SERIAL_ECHOPGM("Skew Factor");
-    SERIAL_ECHOPAIR_F(" XY: ", planner.skew_factor.xy, 6);
-    #if ENABLED(SKEW_CORRECTION_FOR_Z)
-      SERIAL_ECHOPAIR_F(" XZ: ", planner.skew_factor.xz, 6);
-      SERIAL_ECHOPAIR_F(" YZ: ", planner.skew_factor.yz, 6);
-    #endif
-    SERIAL_EOL();
-  }
+void GcodeSuite::M852_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_SKEW_FACTOR));
+  SERIAL_ECHOPAIR_F("  M851 I", planner.skew_factor.xy, 6);
+  #if ENABLED(SKEW_CORRECTION_FOR_Z)
+    SERIAL_ECHOPAIR_F(" J", planner.skew_factor.xz, 6);
+    SERIAL_ECHOPAIR_F(" K", planner.skew_factor.yz, 6);
+    SERIAL_ECHOLNPGM(" ; XY, XZ, YZ");
+  #else
+    SERIAL_ECHOLNPGM(" ; XY");
+  #endif
 }
 
 #endif // SKEW_CORRECTION_GCODE

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -32,9 +32,14 @@
    *    T<extruder> - Optional extruder number. Current extruder if omitted.
    *    D<linear>   - Set filament diameter and enable. D0 disables volumetric.
    *    S<bool>     - Turn volumetric ON or OFF.
+   *
+   * With VOLUMETRIC_EXTRUDER_LIMIT:
+   *
    *    L<float>    - Volumetric extruder limit (in mm^3/sec). L0 disables the limit.
    */
   void GcodeSuite::M200() {
+    if (!parser.seen("DST" TERN_(VOLUMETRIC_EXTRUDER_LIMIT, "L")))
+      return M200_report();
 
     const int8_t target_extruder = get_target_extruder_from_command();
     if (target_extruder < 0) return;
@@ -69,6 +74,37 @@
     planner.calculate_volumetric_multipliers();
   }
 
+  void GcodeSuite::M200_report(const bool forReplay/*=true*/) {
+    if (!forReplay) {
+      report_heading(forReplay, PSTR(STR_FILAMENT_SETTINGS), false);
+      if (!parser.volumetric_enabled) SERIAL_ECHOPGM(" (Disabled):");
+      SERIAL_EOL();
+      report_echo_start(forReplay);
+    }
+
+    #if EXTRUDERS == 1
+    {
+      SERIAL_ECHOLNPAIR(
+        "  M200 S", parser.volumetric_enabled, " D", LINEAR_UNIT(planner.filament_size[0])
+        #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
+          , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[0])
+        #endif
+      );
+    }
+    #else
+      SERIAL_ECHOLNPAIR("  M200 S", parser.volumetric_enabled);
+      LOOP_L_N(i, EXTRUDERS) {
+        report_echo_start(forReplay);
+        SERIAL_ECHOLNPAIR(
+          "  M200 T", i, " D", LINEAR_UNIT(planner.filament_size[i])
+          #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
+            , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[i])
+          #endif
+        );
+      }
+    #endif
+  }
+
 #endif // !NO_VOLUMETRICS
 
 /**
@@ -77,6 +113,8 @@
  *       With multiple extruders use T to specify which one.
  */
 void GcodeSuite::M201() {
+  if (!parser.seen("T" LOGICAL_AXES_STRING))
+    return M201_report();
 
   const int8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
@@ -94,12 +132,40 @@ void GcodeSuite::M201() {
   }
 }
 
+void GcodeSuite::M201_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_MAX_ACCELERATION));
+  SERIAL_ECHOLNPAIR_P(
+    LIST_N(DOUBLE(LINEAR_AXES),
+      PSTR("  M201 X"), LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS]),
+      SP_Y_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS]),
+      SP_Z_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Z_AXIS]),
+      SP_I_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[I_AXIS]),
+      SP_J_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[J_AXIS]),
+      SP_K_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[K_AXIS])
+    )
+    #if HAS_EXTRUDERS && DISABLED(DISTINCT_E_FACTORS)
+      , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS])
+    #endif
+  );
+  #if ENABLED(DISTINCT_E_FACTORS)
+    LOOP_L_N(i, E_STEPPERS) {
+      report_echo_start(forReplay);
+      SERIAL_ECHOLNPAIR_P(
+          PSTR("  M201 T"), i
+        , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)])
+      );
+    }
+  #endif
+}
+
 /**
  * M203: Set maximum feedrate that your machine can sustain (M203 X200 Y200 Z300 E10000) in units/sec
  *
  *       With multiple extruders use T to specify which one.
  */
 void GcodeSuite::M203() {
+  if (!parser.seen("T" LOGICAL_AXES_STRING))
+    return M203_report();
 
   const int8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
@@ -111,6 +177,32 @@ void GcodeSuite::M203() {
     }
 }
 
+void GcodeSuite::M203_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_MAX_FEEDRATES));
+  SERIAL_ECHOLNPAIR_P(
+    LIST_N(DOUBLE(LINEAR_AXES),
+      PSTR("  M203 X"), LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS]),
+      SP_Y_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS]),
+      SP_Z_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Z_AXIS]),
+      SP_I_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[I_AXIS]),
+      SP_J_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[J_AXIS]),
+      SP_K_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[K_AXIS])
+    )
+    #if HAS_EXTRUDERS && DISABLED(DISTINCT_E_FACTORS)
+      , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS])
+    #endif
+  );
+  #if ENABLED(DISTINCT_E_FACTORS)
+    LOOP_L_N(i, E_STEPPERS) {
+      SERIAL_ECHO_START();
+      SERIAL_ECHOLNPAIR_P(
+          PSTR("  M203 T"), i
+        , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)])
+      );
+    }
+  #endif
+}
+
 /**
  * M204: Set Accelerations in units/sec^2 (M204 P1200 R3000 T3000)
  *
@@ -119,11 +211,8 @@ void GcodeSuite::M203() {
  *    T = Travel (non printing) moves
  */
 void GcodeSuite::M204() {
-  if (!parser.seen("PRST")) {
-    SERIAL_ECHOPAIR("Acceleration: P", planner.settings.acceleration);
-    SERIAL_ECHOPAIR(" R", planner.settings.retract_acceleration);
-    SERIAL_ECHOLNPAIR_P(SP_T_STR, planner.settings.travel_acceleration);
-  }
+  if (!parser.seen("PRST"))
+    return M204_report();
   else {
     //planner.synchronize();
     // 'S' for legacy compatibility. Should NOT BE USED for new development
@@ -132,6 +221,15 @@ void GcodeSuite::M204() {
     if (parser.seenval('R')) planner.settings.retract_acceleration = parser.value_linear_units();
     if (parser.seenval('T')) planner.settings.travel_acceleration = parser.value_linear_units();
   }
+}
+
+void GcodeSuite::M204_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_ACCELERATION_P_R_T));
+  SERIAL_ECHOLNPAIR_P(
+      PSTR("  M204 P"), LINEAR_UNIT(planner.settings.acceleration)
+    , PSTR(" R"), LINEAR_UNIT(planner.settings.retract_acceleration)
+    , SP_T_STR, LINEAR_UNIT(planner.settings.travel_acceleration)
+  );
 }
 
 /**
@@ -147,7 +245,8 @@ void GcodeSuite::M204() {
  *    J = Junction Deviation (mm) (If not using CLASSIC_JERK)
  */
 void GcodeSuite::M205() {
-  if (!parser.seen("BST" TERN_(HAS_JUNCTION_DEVIATION, "J") TERN_(HAS_CLASSIC_JERK, "XYZE"))) return;
+  if (!parser.seen("BST" TERN_(HAS_JUNCTION_DEVIATION, "J") TERN_(HAS_CLASSIC_JERK, "XYZE")))
+    return M205_report();
 
   //planner.synchronize();
   if (parser.seenval('B')) planner.settings.min_segment_time_us = parser.value_ulong();
@@ -183,4 +282,35 @@ void GcodeSuite::M205() {
         SERIAL_ECHOLNPGM("WARNING! Low Z Jerk may lead to unwanted pauses.");
     #endif
   #endif // HAS_CLASSIC_JERK
+}
+
+void GcodeSuite::M205_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(
+    "Advanced (B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate>"
+    TERN_(HAS_JUNCTION_DEVIATION, " J<junc_dev>")
+    TERN_(HAS_CLASSIC_JERK, " X<max_x_jerk> Y<max_y_jerk> Z<max_z_jerk>")
+    TERN_(HAS_CLASSIC_E_JERK, " E<max_e_jerk>")
+    ")"
+  ));
+  SERIAL_ECHOLNPAIR_P(
+      PSTR("  M205 B"), LINEAR_UNIT(planner.settings.min_segment_time_us)
+    , PSTR(" S"), LINEAR_UNIT(planner.settings.min_feedrate_mm_s)
+    , SP_T_STR, LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s)
+    #if HAS_JUNCTION_DEVIATION
+      , PSTR(" J"), LINEAR_UNIT(planner.junction_deviation_mm)
+    #endif
+    #if HAS_CLASSIC_JERK
+      , LIST_N(DOUBLE(LINEAR_AXES),
+        SP_X_STR, LINEAR_UNIT(planner.max_jerk.x),
+        SP_Y_STR, LINEAR_UNIT(planner.max_jerk.y),
+        SP_Z_STR, LINEAR_UNIT(planner.max_jerk.z),
+        SP_I_STR, LINEAR_UNIT(planner.max_jerk.i),
+        SP_J_STR, LINEAR_UNIT(planner.max_jerk.j),
+        SP_K_STR, LINEAR_UNIT(planner.max_jerk.k)
+      )
+      #if HAS_CLASSIC_E_JERK
+        , SP_E_STR, LINEAR_UNIT(planner.max_jerk.e)
+      #endif
+    #endif
+  );
 }

--- a/Marlin/src/gcode/config/M200-M205.cpp
+++ b/Marlin/src/gcode/config/M200-M205.cpp
@@ -84,7 +84,7 @@
 
     #if EXTRUDERS == 1
     {
-      SERIAL_ECHOLNPAIR(
+      SERIAL_ECHOLNPGM(
         "  M200 S", parser.volumetric_enabled, " D", LINEAR_UNIT(planner.filament_size[0])
         #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
           , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[0])
@@ -92,10 +92,10 @@
       );
     }
     #else
-      SERIAL_ECHOLNPAIR("  M200 S", parser.volumetric_enabled);
+      SERIAL_ECHOLNPGM("  M200 S", parser.volumetric_enabled);
       LOOP_L_N(i, EXTRUDERS) {
         report_echo_start(forReplay);
-        SERIAL_ECHOLNPAIR(
+        SERIAL_ECHOLNPGM(
           "  M200 T", i, " D", LINEAR_UNIT(planner.filament_size[i])
           #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
             , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[i])
@@ -134,7 +134,7 @@ void GcodeSuite::M201() {
 
 void GcodeSuite::M201_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_MAX_ACCELERATION));
-  SERIAL_ECHOLNPAIR_P(
+  SERIAL_ECHOLNPGM_P(
     LIST_N(DOUBLE(LINEAR_AXES),
       PSTR("  M201 X"), LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS]),
       SP_Y_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS]),
@@ -150,7 +150,7 @@ void GcodeSuite::M201_report(const bool forReplay/*=true*/) {
   #if ENABLED(DISTINCT_E_FACTORS)
     LOOP_L_N(i, E_STEPPERS) {
       report_echo_start(forReplay);
-      SERIAL_ECHOLNPAIR_P(
+      SERIAL_ECHOLNPGM_P(
           PSTR("  M201 T"), i
         , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)])
       );
@@ -179,7 +179,7 @@ void GcodeSuite::M203() {
 
 void GcodeSuite::M203_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_MAX_FEEDRATES));
-  SERIAL_ECHOLNPAIR_P(
+  SERIAL_ECHOLNPGM_P(
     LIST_N(DOUBLE(LINEAR_AXES),
       PSTR("  M203 X"), LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS]),
       SP_Y_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS]),
@@ -195,7 +195,7 @@ void GcodeSuite::M203_report(const bool forReplay/*=true*/) {
   #if ENABLED(DISTINCT_E_FACTORS)
     LOOP_L_N(i, E_STEPPERS) {
       SERIAL_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
+      SERIAL_ECHOLNPGM_P(
           PSTR("  M203 T"), i
         , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)])
       );
@@ -225,7 +225,7 @@ void GcodeSuite::M204() {
 
 void GcodeSuite::M204_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_ACCELERATION_P_R_T));
-  SERIAL_ECHOLNPAIR_P(
+  SERIAL_ECHOLNPGM_P(
       PSTR("  M204 P"), LINEAR_UNIT(planner.settings.acceleration)
     , PSTR(" R"), LINEAR_UNIT(planner.settings.retract_acceleration)
     , SP_T_STR, LINEAR_UNIT(planner.settings.travel_acceleration)
@@ -292,7 +292,7 @@ void GcodeSuite::M205_report(const bool forReplay/*=true*/) {
     TERN_(HAS_CLASSIC_E_JERK, " E<max_e_jerk>")
     ")"
   ));
-  SERIAL_ECHOLNPAIR_P(
+  SERIAL_ECHOLNPGM_P(
       PSTR("  M205 B"), LINEAR_UNIT(planner.settings.min_segment_time_us)
     , PSTR(" S"), LINEAR_UNIT(planner.settings.min_feedrate_mm_s)
     , SP_T_STR, LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s)

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -136,33 +136,33 @@ void GcodeSuite::M217_report(const bool forReplay/*=true*/) {
   SERIAL_ECHOPGM("  M217");
 
   #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-    SERIAL_ECHOPAIR(" S", LINEAR_UNIT(toolchange_settings.swap_length));
-    SERIAL_ECHOPAIR_P(SP_B_STR, LINEAR_UNIT(toolchange_settings.extra_resume),
+    SERIAL_ECHOPGM(" S", LINEAR_UNIT(toolchange_settings.swap_length));
+    SERIAL_ECHOPGM_P(SP_B_STR, LINEAR_UNIT(toolchange_settings.extra_resume),
                       SP_E_STR, LINEAR_UNIT(toolchange_settings.extra_prime),
                       SP_P_STR, LINEAR_UNIT(toolchange_settings.prime_speed));
-    SERIAL_ECHOPAIR(" R", LINEAR_UNIT(toolchange_settings.retract_speed),
+    SERIAL_ECHOPGM(" R", LINEAR_UNIT(toolchange_settings.retract_speed),
                     " U", LINEAR_UNIT(toolchange_settings.unretract_speed),
                     " F", toolchange_settings.fan_speed,
                     " G", toolchange_settings.fan_time);
 
     #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
-      SERIAL_ECHOPAIR(" A", migration.automode);
-      SERIAL_ECHOPAIR(" L", LINEAR_UNIT(migration.last));
+      SERIAL_ECHOPGM(" A", migration.automode);
+      SERIAL_ECHOPGM(" L", LINEAR_UNIT(migration.last));
     #endif
 
     #if ENABLED(TOOLCHANGE_PARK)
-      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(toolchange_settings.enable_park));
-      SERIAL_ECHOPAIR_P(SP_X_STR, LINEAR_UNIT(toolchange_settings.change_point.x));
-      SERIAL_ECHOPAIR_P(SP_Y_STR, LINEAR_UNIT(toolchange_settings.change_point.y));
+      SERIAL_ECHOPGM(" W", LINEAR_UNIT(toolchange_settings.enable_park));
+      SERIAL_ECHOPGM_P(SP_X_STR, LINEAR_UNIT(toolchange_settings.change_point.x));
+      SERIAL_ECHOPGM_P(SP_Y_STR, LINEAR_UNIT(toolchange_settings.change_point.y));
     #endif
 
     #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
-      SERIAL_ECHOPAIR(" V", LINEAR_UNIT(enable_first_prime));
+      SERIAL_ECHOPGM(" V", LINEAR_UNIT(enable_first_prime));
     #endif
 
   #endif
 
-  SERIAL_ECHOLNPAIR_P(SP_Z_STR, LINEAR_UNIT(toolchange_settings.z_raise));
+  SERIAL_ECHOLNPGM_P(SP_Z_STR, LINEAR_UNIT(toolchange_settings.z_raise));
 }
 
 #endif // HAS_MULTI_EXTRUDER

--- a/Marlin/src/gcode/config/M217.cpp
+++ b/Marlin/src/gcode/config/M217.cpp
@@ -33,44 +33,6 @@
 
 #include "../../MarlinCore.h" // for SP_X_STR, etc.
 
-void M217_report(const bool eeprom=false) {
-
-  #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
-    SERIAL_ECHOPGM_P(eeprom ? PSTR("  M217") : PSTR("Toolchange:"));
-    SERIAL_ECHOPAIR(" S", LINEAR_UNIT(toolchange_settings.swap_length));
-    SERIAL_ECHOPAIR_P(SP_B_STR, LINEAR_UNIT(toolchange_settings.extra_resume),
-                      SP_E_STR, LINEAR_UNIT(toolchange_settings.extra_prime),
-                      SP_P_STR, LINEAR_UNIT(toolchange_settings.prime_speed));
-    SERIAL_ECHOPAIR(" R", LINEAR_UNIT(toolchange_settings.retract_speed),
-                    " U", LINEAR_UNIT(toolchange_settings.unretract_speed),
-                    " F", toolchange_settings.fan_speed,
-                    " G", toolchange_settings.fan_time);
-
-    #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
-      SERIAL_ECHOPAIR(" A", migration.automode);
-      SERIAL_ECHOPAIR(" L", LINEAR_UNIT(migration.last));
-    #endif
-
-    #if ENABLED(TOOLCHANGE_PARK)
-      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(toolchange_settings.enable_park));
-      SERIAL_ECHOPAIR_P(SP_X_STR, LINEAR_UNIT(toolchange_settings.change_point.x));
-      SERIAL_ECHOPAIR_P(SP_Y_STR, LINEAR_UNIT(toolchange_settings.change_point.y));
-    #endif
-
-    #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
-      SERIAL_ECHOPAIR(" V", LINEAR_UNIT(enable_first_prime));
-    #endif
-
-  #else
-
-    UNUSED(eeprom);
-
-  #endif
-
-  SERIAL_ECHOPAIR_P(SP_Z_STR, LINEAR_UNIT(toolchange_settings.z_raise));
-  SERIAL_EOL();
-}
-
 /**
  * M217 - Set SINGLENOZZLE toolchange parameters
  *
@@ -166,6 +128,41 @@ void GcodeSuite::M217() {
   #endif
 
   M217_report();
+}
+
+void GcodeSuite::M217_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_TOOL_CHANGING));
+
+  SERIAL_ECHOPGM("  M217");
+
+  #if ENABLED(TOOLCHANGE_FILAMENT_SWAP)
+    SERIAL_ECHOPAIR(" S", LINEAR_UNIT(toolchange_settings.swap_length));
+    SERIAL_ECHOPAIR_P(SP_B_STR, LINEAR_UNIT(toolchange_settings.extra_resume),
+                      SP_E_STR, LINEAR_UNIT(toolchange_settings.extra_prime),
+                      SP_P_STR, LINEAR_UNIT(toolchange_settings.prime_speed));
+    SERIAL_ECHOPAIR(" R", LINEAR_UNIT(toolchange_settings.retract_speed),
+                    " U", LINEAR_UNIT(toolchange_settings.unretract_speed),
+                    " F", toolchange_settings.fan_speed,
+                    " G", toolchange_settings.fan_time);
+
+    #if ENABLED(TOOLCHANGE_MIGRATION_FEATURE)
+      SERIAL_ECHOPAIR(" A", migration.automode);
+      SERIAL_ECHOPAIR(" L", LINEAR_UNIT(migration.last));
+    #endif
+
+    #if ENABLED(TOOLCHANGE_PARK)
+      SERIAL_ECHOPAIR(" W", LINEAR_UNIT(toolchange_settings.enable_park));
+      SERIAL_ECHOPAIR_P(SP_X_STR, LINEAR_UNIT(toolchange_settings.change_point.x));
+      SERIAL_ECHOPAIR_P(SP_Y_STR, LINEAR_UNIT(toolchange_settings.change_point.y));
+    #endif
+
+    #if ENABLED(TOOLCHANGE_FS_PRIME_FIRST_USED)
+      SERIAL_ECHOPAIR(" V", LINEAR_UNIT(enable_first_prime));
+    #endif
+
+  #endif
+
+  SERIAL_ECHOLNPAIR_P(SP_Z_STR, LINEAR_UNIT(toolchange_settings.z_raise));
 }
 
 #endif // HAS_MULTI_EXTRUDER

--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -41,6 +41,8 @@
  */
 void GcodeSuite::M218() {
 
+  if (!parser.seen_any()) return M218_report();
+
   const int8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
@@ -48,24 +50,23 @@ void GcodeSuite::M218() {
   if (parser.seenval('Y')) hotend_offset[target_extruder].y = parser.value_linear_units();
   if (parser.seenval('Z')) hotend_offset[target_extruder].z = parser.value_linear_units();
 
-  if (!parser.seen("XYZ")) {
-    SERIAL_ECHO_START();
-    SERIAL_ECHOPGM(STR_HOTEND_OFFSET);
-    HOTEND_LOOP() {
-      SERIAL_CHAR(' ');
-      SERIAL_ECHO(hotend_offset[e].x);
-      SERIAL_CHAR(',');
-      SERIAL_ECHO(hotend_offset[e].y);
-      SERIAL_CHAR(',');
-      SERIAL_ECHO_F(hotend_offset[e].z, 3);
-    }
-    SERIAL_EOL();
-  }
-
   #if ENABLED(DELTA)
     if (target_extruder == active_extruder)
       do_blocking_move_to_xy(current_position, planner.settings.max_feedrate_mm_s[X_AXIS]);
   #endif
+}
+
+void GcodeSuite::M218_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_HOTEND_OFFSETS));
+  LOOP_S_L_N(e, 1, HOTENDS) {
+    report_echo_start(forReplay);
+    SERIAL_ECHOPAIR_P(
+      PSTR("  M218 T"), e,
+      SP_X_STR, LINEAR_UNIT(hotend_offset[e].x),
+      SP_Y_STR, LINEAR_UNIT(hotend_offset[e].y)
+    );
+    SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(hotend_offset[e].z), 3);
+  }
 }
 
 #endif // HAS_HOTEND_OFFSET

--- a/Marlin/src/gcode/config/M218.cpp
+++ b/Marlin/src/gcode/config/M218.cpp
@@ -60,7 +60,7 @@ void GcodeSuite::M218_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_HOTEND_OFFSETS));
   LOOP_S_L_N(e, 1, HOTENDS) {
     report_echo_start(forReplay);
-    SERIAL_ECHOPAIR_P(
+    SERIAL_ECHOPGM_P(
       PSTR("  M218 T"), e,
       SP_X_STR, LINEAR_UNIT(hotend_offset[e].x),
       SP_Y_STR, LINEAR_UNIT(hotend_offset[e].y)

--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -44,7 +44,7 @@ void GcodeSuite::M220() {
   if (parser.seenval('S')) feedrate_percentage = parser.value_int();
 
   if (!parser.seen_any()) {
-    SERIAL_ECHOPAIR("FR:", feedrate_percentage);
+    SERIAL_ECHOPGM("FR:", feedrate_percentage);
     SERIAL_CHAR('%');
     SERIAL_EOL();
   }

--- a/Marlin/src/gcode/config/M221.cpp
+++ b/Marlin/src/gcode/config/M221.cpp
@@ -38,7 +38,7 @@ void GcodeSuite::M221() {
   else {
     SERIAL_ECHO_START();
     SERIAL_CHAR('E', '0' + target_extruder);
-    SERIAL_ECHOPAIR(" Flow: ", planner.flow_percentage[target_extruder]);
+    SERIAL_ECHOPGM(" Flow: ", planner.flow_percentage[target_extruder]);
     SERIAL_CHAR('%');
     SERIAL_EOL();
   }

--- a/Marlin/src/gcode/config/M281.cpp
+++ b/Marlin/src/gcode/config/M281.cpp
@@ -34,6 +34,7 @@
  *  U<angle> - Stowed Angle
  */
 void GcodeSuite::M281() {
+  if (!parser.seen_any()) return M281_report();
 
   if (!parser.seenval('P')) return;
 
@@ -45,24 +46,32 @@ void GcodeSuite::M281() {
         return;
       }
     #endif
-    bool angle_change = false;
-    if (parser.seen('L')) {
-      servo_angles[servo_index][0] = parser.value_int();
-      angle_change = true;
-    }
-    if (parser.seen('U')) {
-      servo_angles[servo_index][1] = parser.value_int();
-      angle_change = true;
-    }
-    if (!angle_change) {
-      SERIAL_ECHO_MSG(" Servo ", servo_index,
-                      " L", servo_angles[servo_index][0],
-                      " U", servo_angles[servo_index][1]);
-    }
+    if (parser.seen('L')) servo_angles[servo_index][0] = parser.value_int();
+    if (parser.seen('U')) servo_angles[servo_index][1] = parser.value_int();
   }
   else
     SERIAL_ERROR_MSG("Servo ", servo_index, " out of range");
+}
 
+void GcodeSuite::M281_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_SERVO_ANGLES));
+  LOOP_L_N(i, NUM_SERVOS) {
+    switch (i) {
+      default: break;
+      #if ENABLED(SWITCHING_EXTRUDER)
+        case SWITCHING_EXTRUDER_SERVO_NR:
+        #if EXTRUDERS > 3
+          case SWITCHING_EXTRUDER_E23_SERVO_NR:
+        #endif
+      #elif ENABLED(SWITCHING_NOZZLE)
+        case SWITCHING_NOZZLE_SERVO_NR:
+      #elif ENABLED(BLTOUCH) || (HAS_Z_SERVO_PROBE && defined(Z_SERVO_ANGLES))
+        case Z_PROBE_SERVO_NR:
+      #endif
+          report_echo_start(forReplay);
+          SERIAL_ECHOLNPAIR("  M281 P", i, " L", servo_angles[i][0], " U", servo_angles[i][1]);
+    }
+  }
 }
 
 #endif // EDITABLE_SERVO_ANGLES

--- a/Marlin/src/gcode/config/M281.cpp
+++ b/Marlin/src/gcode/config/M281.cpp
@@ -69,7 +69,7 @@ void GcodeSuite::M281_report(const bool forReplay/*=true*/) {
         case Z_PROBE_SERVO_NR:
       #endif
           report_echo_start(forReplay);
-          SERIAL_ECHOLNPAIR("  M281 P", i, " L", servo_angles[i][0], " U", servo_angles[i][1]);
+          SERIAL_ECHOLNPGM("  M281 P", i, " L", servo_angles[i][0], " U", servo_angles[i][1]);
     }
   }
 }

--- a/Marlin/src/gcode/config/M301.cpp
+++ b/Marlin/src/gcode/config/M301.cpp
@@ -46,46 +46,63 @@
  *   F[float] Kf term
  */
 void GcodeSuite::M301() {
-
   // multi-extruder PID patch: M301 updates or prints a single extruder's PID values
   // default behavior (omitting E parameter) is to update for extruder 0 only
-  const uint8_t e = parser.byteval('E'); // extruder being updated
+  int8_t e = parser.byteval('E', -1); // extruder being updated
+
+  if (!parser.seen("PID" TERN_(PID_EXTRUSION_SCALING, "CL") TERN_(PID_FAN_SCALING, "F")))
+    return M301_report(true, e);
+
+  if (e == -1) e = 0;
 
   if (e < HOTENDS) { // catch bad input value
-    if (parser.seen('P')) PID_PARAM(Kp, e) = parser.value_float();
-    if (parser.seen('I')) PID_PARAM(Ki, e) = scalePID_i(parser.value_float());
-    if (parser.seen('D')) PID_PARAM(Kd, e) = scalePID_d(parser.value_float());
+
+    if (parser.seenval('P')) PID_PARAM(Kp, e) = parser.value_float();
+    if (parser.seenval('I')) PID_PARAM(Ki, e) = scalePID_i(parser.value_float());
+    if (parser.seenval('D')) PID_PARAM(Kd, e) = scalePID_d(parser.value_float());
+
     #if ENABLED(PID_EXTRUSION_SCALING)
-      if (parser.seen('C')) PID_PARAM(Kc, e) = parser.value_float();
+      if (parser.seenval('C')) PID_PARAM(Kc, e) = parser.value_float();
       if (parser.seenval('L')) thermalManager.lpq_len = parser.value_int();
       NOMORE(thermalManager.lpq_len, LPQ_MAX_LEN);
       NOLESS(thermalManager.lpq_len, 0);
     #endif
 
     #if ENABLED(PID_FAN_SCALING)
-      if (parser.seen('F')) PID_PARAM(Kf, e) = parser.value_float();
+      if (parser.seenval('F')) PID_PARAM(Kf, e) = parser.value_float();
     #endif
 
     thermalManager.updatePID();
-
-    SERIAL_ECHO_START();
-    #if ENABLED(PID_PARAMS_PER_HOTEND)
-      SERIAL_ECHOPAIR(" e:", e); // specify extruder in serial output
-    #endif
-    SERIAL_ECHOPAIR(" p:", PID_PARAM(Kp, e),
-                    " i:", unscalePID_i(PID_PARAM(Ki, e)),
-                    " d:", unscalePID_d(PID_PARAM(Kd, e)));
-    #if ENABLED(PID_EXTRUSION_SCALING)
-      SERIAL_ECHOPAIR(" c:", PID_PARAM(Kc, e));
-    #endif
-    #if ENABLED(PID_FAN_SCALING)
-      SERIAL_ECHOPAIR(" f:", PID_PARAM(Kf, e));
-    #endif
-
-    SERIAL_EOL();
   }
   else
     SERIAL_ERROR_MSG(STR_INVALID_EXTRUDER);
+}
+
+void GcodeSuite::M301_report(const bool forReplay/*=true*/, const int8_t eindex/*=-1*/) {
+  report_heading(forReplay, PSTR(STR_HOTEND_PID));
+  HOTEND_LOOP() {
+    if (e == eindex || eindex == -1) {
+      report_echo_start(forReplay);
+      SERIAL_ECHOPAIR_P(
+        #if ENABLED(PID_PARAMS_PER_HOTEND)
+          PSTR("  M301 E"), e, SP_P_STR
+        #else
+          PSTR("  M301 P")
+        #endif
+        ,                          PID_PARAM(Kp, e)
+        , PSTR(" I"), unscalePID_i(PID_PARAM(Ki, e))
+        , PSTR(" D"), unscalePID_d(PID_PARAM(Kd, e))
+      );
+      #if ENABLED(PID_EXTRUSION_SCALING)
+        SERIAL_ECHOPAIR_P(SP_C_STR, PID_PARAM(Kc, e));
+        if (e == 0) SERIAL_ECHOPAIR(" L", thermalManager.lpq_len);
+      #endif
+      #if ENABLED(PID_FAN_SCALING)
+        SERIAL_ECHOPAIR(" F", PID_PARAM(Kf, e));
+      #endif
+      SERIAL_EOL();
+    }
+  }
 }
 
 #endif // PIDTEMP

--- a/Marlin/src/gcode/config/M301.cpp
+++ b/Marlin/src/gcode/config/M301.cpp
@@ -83,7 +83,7 @@ void GcodeSuite::M301_report(const bool forReplay/*=true*/, const int8_t eindex/
   HOTEND_LOOP() {
     if (e == eindex || eindex == -1) {
       report_echo_start(forReplay);
-      SERIAL_ECHOPAIR_P(
+      SERIAL_ECHOPGM_P(
         #if ENABLED(PID_PARAMS_PER_HOTEND)
           PSTR("  M301 E"), e, SP_P_STR
         #else
@@ -94,11 +94,11 @@ void GcodeSuite::M301_report(const bool forReplay/*=true*/, const int8_t eindex/
         , PSTR(" D"), unscalePID_d(PID_PARAM(Kd, e))
       );
       #if ENABLED(PID_EXTRUSION_SCALING)
-        SERIAL_ECHOPAIR_P(SP_C_STR, PID_PARAM(Kc, e));
-        if (e == 0) SERIAL_ECHOPAIR(" L", thermalManager.lpq_len);
+        SERIAL_ECHOPGM_P(SP_C_STR, PID_PARAM(Kc, e));
+        if (e == 0) SERIAL_ECHOPGM(" L", thermalManager.lpq_len);
       #endif
       #if ENABLED(PID_FAN_SCALING)
-        SERIAL_ECHOPAIR(" F", PID_PARAM(Kf, e));
+        SERIAL_ECHOPGM(" F", PID_PARAM(Kf, e));
       #endif
       SERIAL_EOL();
     }

--- a/Marlin/src/gcode/config/M302.cpp
+++ b/Marlin/src/gcode/config/M302.cpp
@@ -56,7 +56,7 @@ void GcodeSuite::M302() {
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM("Cold extrudes are ");
     SERIAL_ECHOPGM_P(thermalManager.allow_cold_extrude ? PSTR("en") : PSTR("dis"));
-    SERIAL_ECHOLNPAIR("abled (min temp ", thermalManager.extrude_min_temp, "C)");
+    SERIAL_ECHOLNPGM("abled (min temp ", thermalManager.extrude_min_temp, "C)");
   }
 }
 

--- a/Marlin/src/gcode/config/M304.cpp
+++ b/Marlin/src/gcode/config/M304.cpp
@@ -35,15 +35,19 @@
  *  D<dval> - Set the D value
  */
 void GcodeSuite::M304() {
-
+  if (!parser.seen("PID")) return M304_report();
   if (parser.seen('P')) thermalManager.temp_bed.pid.Kp = parser.value_float();
   if (parser.seen('I')) thermalManager.temp_bed.pid.Ki = scalePID_i(parser.value_float());
   if (parser.seen('D')) thermalManager.temp_bed.pid.Kd = scalePID_d(parser.value_float());
+}
 
-  SERIAL_ECHO_MSG(" p:", thermalManager.temp_bed.pid.Kp,
-                  " i:", unscalePID_i(thermalManager.temp_bed.pid.Ki),
-                  " d:", unscalePID_d(thermalManager.temp_bed.pid.Kd));
-
+void GcodeSuite::M304_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_BED_PID));
+  SERIAL_ECHO_MSG(
+      "  M304 P", thermalManager.temp_bed.pid.Kp
+    , " I", unscalePID_i(thermalManager.temp_bed.pid.Ki)
+    , " D", unscalePID_d(thermalManager.temp_bed.pid.Kd)
+  );
 }
 
 #endif // PIDTEMPBED

--- a/Marlin/src/gcode/config/M305.cpp
+++ b/Marlin/src/gcode/config/M305.cpp
@@ -70,10 +70,10 @@ void GcodeSuite::M305() {
   }                       // If not setting then report parameters
   else if (t_index < 0) { // ...all user thermistors
     LOOP_L_N(i, USER_THERMISTORS)
-      thermalManager.log_user_thermistor(i);
+      thermalManager.M305_report(i);
   }
   else                    // ...one user thermistor
-    thermalManager.log_user_thermistor(t_index);
+    thermalManager.M305_report(t_index);
 }
 
 #endif // HAS_USER_THERMISTORS

--- a/Marlin/src/gcode/config/M309.cpp
+++ b/Marlin/src/gcode/config/M309.cpp
@@ -35,14 +35,19 @@
  *  D<dval> - Set the D value
  */
 void GcodeSuite::M309() {
+  if (!parser.seen("PID")) return M309_report();
   if (parser.seen('P')) thermalManager.temp_chamber.pid.Kp = parser.value_float();
   if (parser.seen('I')) thermalManager.temp_chamber.pid.Ki = scalePID_i(parser.value_float());
   if (parser.seen('D')) thermalManager.temp_chamber.pid.Kd = scalePID_d(parser.value_float());
+}
 
-  SERIAL_ECHO_START();
-  SERIAL_ECHOLNPAIR(" p:", thermalManager.temp_chamber.pid.Kp,
-                    " i:", unscalePID_i(thermalManager.temp_chamber.pid.Ki),
-                    " d:", unscalePID_d(thermalManager.temp_chamber.pid.Kd));
+void GcodeSuite::M309_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_CHAMBER_PID));
+  SERIAL_ECHOLNPAIR(
+      "  M309 P", thermalManager.temp_chamber.pid.Kp
+    , " I", unscalePID_i(thermalManager.temp_chamber.pid.Ki)
+    , " D", unscalePID_d(thermalManager.temp_chamber.pid.Kd)
+  );
 }
 
 #endif // PIDTEMPCHAMBER

--- a/Marlin/src/gcode/config/M309.cpp
+++ b/Marlin/src/gcode/config/M309.cpp
@@ -43,7 +43,7 @@ void GcodeSuite::M309() {
 
 void GcodeSuite::M309_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_CHAMBER_PID));
-  SERIAL_ECHOLNPAIR(
+  SERIAL_ECHOLNPGM(
       "  M309 P", thermalManager.temp_chamber.pid.Kp
     , " I", unscalePID_i(thermalManager.temp_chamber.pid.Ki)
     , " D", unscalePID_d(thermalManager.temp_chamber.pid.Kd)

--- a/Marlin/src/gcode/config/M43.cpp
+++ b/Marlin/src/gcode/config/M43.cpp
@@ -130,7 +130,7 @@ inline void servo_probe_test() {
 
     const uint8_t probe_index = parser.byteval('P', Z_PROBE_SERVO_NR);
 
-    SERIAL_ECHOLNPAIR("Servo probe test\n"
+    SERIAL_ECHOLNPGM("Servo probe test\n"
                       ". using index:  ", probe_index,
                       ", deploy angle: ", servo_angles[probe_index][0],
                       ", stow angle:   ", servo_angles[probe_index][1]
@@ -143,7 +143,7 @@ inline void servo_probe_test() {
       #define PROBE_TEST_PIN Z_MIN_PIN
       constexpr bool probe_inverting = Z_MIN_ENDSTOP_INVERTING;
 
-      SERIAL_ECHOLNPAIR(". Probe Z_MIN_PIN: ", PROBE_TEST_PIN);
+      SERIAL_ECHOLNPGM(". Probe Z_MIN_PIN: ", PROBE_TEST_PIN);
       SERIAL_ECHOPGM(". Z_MIN_ENDSTOP_INVERTING: ");
 
     #else
@@ -151,7 +151,7 @@ inline void servo_probe_test() {
       #define PROBE_TEST_PIN Z_MIN_PROBE_PIN
       constexpr bool probe_inverting = Z_MIN_PROBE_ENDSTOP_INVERTING;
 
-      SERIAL_ECHOLNPAIR(". Probe Z_MIN_PROBE_PIN: ", PROBE_TEST_PIN);
+      SERIAL_ECHOLNPGM(". Probe Z_MIN_PROBE_PIN: ", PROBE_TEST_PIN);
       SERIAL_ECHOPGM(   ". Z_MIN_PROBE_ENDSTOP_INVERTING: ");
 
     #endif
@@ -211,11 +211,11 @@ inline void servo_probe_test() {
       if (deploy_state != stow_state) {
         SERIAL_ECHOLNPGM("= Mechanical Switch detected");
         if (deploy_state) {
-          SERIAL_ECHOLNPAIR("  DEPLOYED state: HIGH (logic 1)",
+          SERIAL_ECHOLNPGM("  DEPLOYED state: HIGH (logic 1)",
                             "  STOWED (triggered) state: LOW (logic 0)");
         }
         else {
-          SERIAL_ECHOLNPAIR("  DEPLOYED state: LOW (logic 0)",
+          SERIAL_ECHOLNPGM("  DEPLOYED state: LOW (logic 0)",
                             "  STOWED (triggered) state: HIGH (logic 1)");
         }
         #if ENABLED(BLTOUCH)
@@ -244,7 +244,7 @@ inline void servo_probe_test() {
         if (probe_counter == 15)
           SERIAL_ECHOLNPGM(": 30ms or more");
         else
-          SERIAL_ECHOLNPAIR(" (+/- 4ms): ", probe_counter * 2);
+          SERIAL_ECHOLNPGM(" (+/- 4ms): ", probe_counter * 2);
 
         if (probe_counter >= 4) {
           if (probe_counter == 15) {

--- a/Marlin/src/gcode/config/M575.cpp
+++ b/Marlin/src/gcode/config/M575.cpp
@@ -53,13 +53,13 @@ void GcodeSuite::M575() {
     case 115200: case 250000: case 500000: case 1000000: {
       const int8_t port = parser.intval('P', -99);
       const bool set1 = (port == -99 || port == 0);
-      if (set1) SERIAL_ECHO_MSG(" Serial ", AS_CHAR('0'), " baud rate set to ", baud);
+      if (set1) SERIAL_ECHO_MSG(" Serial ", AS_DIGIT(0), " baud rate set to ", baud);
       #if HAS_MULTI_SERIAL
         const bool set2 = (port == -99 || port == 1);
-        if (set2) SERIAL_ECHO_MSG(" Serial ", AS_CHAR('1'), " baud rate set to ", baud);
+        if (set2) SERIAL_ECHO_MSG(" Serial ", AS_DIGIT(1), " baud rate set to ", baud);
         #ifdef SERIAL_PORT_3
           const bool set3 = (port == -99 || port == 2);
-          if (set3) SERIAL_ECHO_MSG(" Serial ", AS_CHAR('2'), " baud rate set to ", baud);
+          if (set3) SERIAL_ECHO_MSG(" Serial ", AS_DIGIT(2), " baud rate set to ", baud);
         #endif
       #endif
 

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -78,10 +78,10 @@ void GcodeSuite::M92() {
                      micro_steps = argH ?: Z_MICROSTEPS;
       const float z_full_step_mm = micro_steps * planner.steps_to_mm[Z_AXIS];
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR("{ micro_steps:", micro_steps, ", z_full_step_mm:", z_full_step_mm);
+      SERIAL_ECHOPGM("{ micro_steps:", micro_steps, ", z_full_step_mm:", z_full_step_mm);
       if (wanted) {
         const float best = uint16_t(wanted / z_full_step_mm) * z_full_step_mm;
-        SERIAL_ECHOPAIR(", best:[", best);
+        SERIAL_ECHOPGM(", best:[", best);
         if (best != wanted) { SERIAL_CHAR(','); SERIAL_DECIMAL(best + z_full_step_mm); }
         SERIAL_CHAR(']');
       }
@@ -92,7 +92,7 @@ void GcodeSuite::M92() {
 
 void GcodeSuite::M92_report(const bool forReplay/*=true*/, const int8_t e/*=-1*/) {
   report_heading_etc(forReplay, PSTR(STR_STEPS_PER_UNIT));
-  SERIAL_ECHOPAIR_P(LIST_N(DOUBLE(LINEAR_AXES),
+  SERIAL_ECHOPGM_P(LIST_N(DOUBLE(LINEAR_AXES),
     PSTR("  M92 X"), LINEAR_UNIT(planner.settings.axis_steps_per_mm[X_AXIS]),
     SP_Y_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[Y_AXIS]),
     SP_Z_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[Z_AXIS]),
@@ -101,7 +101,7 @@ void GcodeSuite::M92_report(const bool forReplay/*=true*/, const int8_t e/*=-1*/
     SP_K_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[K_AXIS]))
   );
   #if HAS_EXTRUDERS && DISABLED(DISTINCT_E_FACTORS)
-    SERIAL_ECHOPAIR_P(SP_E_STR, VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
+    SERIAL_ECHOPGM_P(SP_E_STR, VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
   #endif
   SERIAL_EOL();
 
@@ -109,7 +109,7 @@ void GcodeSuite::M92_report(const bool forReplay/*=true*/, const int8_t e/*=-1*/
     LOOP_L_N(i, E_STEPPERS) {
       if (e >= 0 && i != e) continue;
       report_echo_start(forReplay);
-      SERIAL_ECHOLNPAIR_P(
+      SERIAL_ECHOLNPGM_P(
         PSTR("  M92 T"), i,
         SP_E_STR, VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS_N(i)])
       );

--- a/Marlin/src/gcode/config/M92.cpp
+++ b/Marlin/src/gcode/config/M92.cpp
@@ -23,33 +23,6 @@
 #include "../gcode.h"
 #include "../../module/planner.h"
 
-void report_M92(const bool echo=true, const int8_t e=-1) {
-  if (echo) SERIAL_ECHO_START(); else SERIAL_CHAR(' ');
-  SERIAL_ECHOPAIR_P(LIST_N(DOUBLE(LINEAR_AXES),
-    PSTR(" M92 X"), LINEAR_UNIT(planner.settings.axis_steps_per_mm[X_AXIS]),
-    SP_Y_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[Y_AXIS]),
-    SP_Z_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[Z_AXIS]),
-    SP_I_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[I_AXIS]),
-    SP_J_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[J_AXIS]),
-    SP_K_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[K_AXIS]))
-  );
-  #if HAS_EXTRUDERS && DISABLED(DISTINCT_E_FACTORS)
-    SERIAL_ECHOPAIR_P(SP_E_STR, VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
-  #endif
-  SERIAL_EOL();
-
-  #if ENABLED(DISTINCT_E_FACTORS)
-    LOOP_L_N(i, E_STEPPERS) {
-      if (e >= 0 && i != e) continue;
-      if (echo) SERIAL_ECHO_START(); else SERIAL_CHAR(' ');
-      SERIAL_ECHOLNPAIR_P(PSTR(" M92 T"), i,
-                        SP_E_STR, VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS_N(i)]));
-    }
-  #endif
-
-  UNUSED(e);
-}
-
 /**
  * M92: Set axis steps-per-unit for one or more axes, X, Y, Z, and E.
  *      (Follows the same syntax as G92)
@@ -58,10 +31,11 @@ void report_M92(const bool echo=true, const int8_t e=-1) {
  *
  *      If no argument is given print the current values.
  *
- *    With MAGIC_NUMBERS_GCODE:
- *      Use 'H' and/or 'L' to get ideal layer-height information.
- *      'H' specifies micro-steps to use. We guess if it's not supplied.
- *      'L' specifies a desired layer height. Nearest good heights are shown.
+ * With MAGIC_NUMBERS_GCODE:
+ *
+ *   Use 'H' and/or 'L' to get ideal layer-height information.
+ *   H<microsteps> - Specify micro-steps to use. Best guess if not supplied.
+ *   L<linear>     - Desired layer height in current units. Nearest good heights are shown.
  */
 void GcodeSuite::M92() {
 
@@ -69,10 +43,8 @@ void GcodeSuite::M92() {
   if (target_extruder < 0) return;
 
   // No arguments? Show M92 report.
-  if (!parser.seen(
-    LOGICAL_AXIS_GANG("E", "X", "Y", "Z", AXIS4_STR, AXIS5_STR, AXIS6_STR)
-    TERN_(MAGIC_NUMBERS_GCODE, "HL")
-  )) return report_M92(true, target_extruder);
+  if (!parser.seen(LOGICAL_AXES_STRING TERN_(MAGIC_NUMBERS_GCODE, "HL")))
+    return M92_report(true, target_extruder);
 
   LOOP_LOGICAL_AXES(i) {
     if (parser.seenval(axis_codes[i])) {
@@ -100,7 +72,7 @@ void GcodeSuite::M92() {
     #ifndef Z_MICROSTEPS
       #define Z_MICROSTEPS 16
     #endif
-    const float wanted = parser.floatval('L');
+    const float wanted = parser.linearval('L');
     if (parser.seen('H') || wanted) {
       const uint16_t argH = parser.ushortval('H'),
                      micro_steps = argH ?: Z_MICROSTEPS;
@@ -115,5 +87,34 @@ void GcodeSuite::M92() {
       }
       SERIAL_ECHOLNPGM(" }");
     }
+  #endif
+}
+
+void GcodeSuite::M92_report(const bool forReplay/*=true*/, const int8_t e/*=-1*/) {
+  report_heading_etc(forReplay, PSTR(STR_STEPS_PER_UNIT));
+  SERIAL_ECHOPAIR_P(LIST_N(DOUBLE(LINEAR_AXES),
+    PSTR("  M92 X"), LINEAR_UNIT(planner.settings.axis_steps_per_mm[X_AXIS]),
+    SP_Y_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[Y_AXIS]),
+    SP_Z_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[Z_AXIS]),
+    SP_I_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[I_AXIS]),
+    SP_J_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[J_AXIS]),
+    SP_K_STR, LINEAR_UNIT(planner.settings.axis_steps_per_mm[K_AXIS]))
+  );
+  #if HAS_EXTRUDERS && DISABLED(DISTINCT_E_FACTORS)
+    SERIAL_ECHOPAIR_P(SP_E_STR, VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS]));
+  #endif
+  SERIAL_EOL();
+
+  #if ENABLED(DISTINCT_E_FACTORS)
+    LOOP_L_N(i, E_STEPPERS) {
+      if (e >= 0 && i != e) continue;
+      report_echo_start(forReplay);
+      SERIAL_ECHOLNPAIR_P(
+        PSTR("  M92 T"), i,
+        SP_E_STR, VOLUMETRIC_UNIT(planner.settings.axis_steps_per_mm[E_AXIS_N(i)])
+      );
+    }
+  #else
+    UNUSED(e);
   #endif
 }

--- a/Marlin/src/gcode/control/M111.cpp
+++ b/Marlin/src/gcode/control/M111.cpp
@@ -57,19 +57,19 @@ void GcodeSuite::M111() {
     SERIAL_ECHOPGM(STR_DEBUG_OFF);
     #if !defined(__AVR__) || !defined(USBCON)
       #if ENABLED(SERIAL_STATS_RX_BUFFER_OVERRUNS)
-        SERIAL_ECHOPAIR("\nBuffer Overruns: ", MYSERIAL1.buffer_overruns());
+        SERIAL_ECHOPGM("\nBuffer Overruns: ", MYSERIAL1.buffer_overruns());
       #endif
 
       #if ENABLED(SERIAL_STATS_RX_FRAMING_ERRORS)
-        SERIAL_ECHOPAIR("\nFraming Errors: ", MYSERIAL1.framing_errors());
+        SERIAL_ECHOPGM("\nFraming Errors: ", MYSERIAL1.framing_errors());
       #endif
 
       #if ENABLED(SERIAL_STATS_DROPPED_RX)
-        SERIAL_ECHOPAIR("\nDropped bytes: ", MYSERIAL1.dropped());
+        SERIAL_ECHOPGM("\nDropped bytes: ", MYSERIAL1.dropped());
       #endif
 
       #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
-        SERIAL_ECHOPAIR("\nMax RX Queue Size: ", MYSERIAL1.rxMaxEnqueued());
+        SERIAL_ECHOPGM("\nMax RX Queue Size: ", MYSERIAL1.rxMaxEnqueued());
       #endif
     #endif // !__AVR__ || !USBCON
   }

--- a/Marlin/src/gcode/control/M17_M18_M84.cpp
+++ b/Marlin/src/gcode/control/M17_M18_M84.cpp
@@ -33,7 +33,7 @@
  * M17: Enable stepper motors
  */
 void GcodeSuite::M17() {
-  if (parser.seen(LOGICAL_AXIS_GANG("E", "X", "Y", "Z", AXIS4_STR, AXIS5_STR, AXIS6_STR))) {
+  if (parser.seen_axis()) {
     LOGICAL_AXIS_CODE(
       if (TERN0(HAS_E_STEPPER_ENABLE, parser.seen_test('E'))) enable_e_steppers(),
       if (parser.seen_test('X'))        ENABLE_AXIS_X(),
@@ -59,7 +59,7 @@ void GcodeSuite::M18_M84() {
     stepper_inactive_time = parser.value_millis_from_seconds();
   }
   else {
-    if (parser.seen(LOGICAL_AXIS_GANG("E", "X", "Y", "Z", AXIS4_STR, AXIS5_STR, AXIS6_STR))) {
+    if (parser.seen_axis()) {
       planner.synchronize();
       LOGICAL_AXIS_CODE(
         if (TERN0(HAS_E_STEPPER_ENABLE, parser.seen_test('E'))) disable_e_steppers(),

--- a/Marlin/src/gcode/control/M211.cpp
+++ b/Marlin/src/gcode/control/M211.cpp
@@ -41,7 +41,7 @@ void GcodeSuite::M211() {
 
 void GcodeSuite::M211_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_SOFT_ENDSTOPS));
-  SERIAL_ECHOPAIR("  M211 S", AS_DIGIT(soft_endstop._enabled), " ; ");
+  SERIAL_ECHOPGM("  M211 S", AS_DIGIT(soft_endstop._enabled), " ; ");
   serialprintln_onoff(soft_endstop._enabled);
 
   report_echo_start(forReplay);

--- a/Marlin/src/gcode/control/M211.cpp
+++ b/Marlin/src/gcode/control/M211.cpp
@@ -33,14 +33,22 @@
  * Usage: M211 S1 to enable, M211 S0 to disable, M211 alone for report
  */
 void GcodeSuite::M211() {
+  if (parser.seen('S'))
+    soft_endstop._enabled = parser.value_bool();
+  else
+    M211_report();
+}
+
+void GcodeSuite::M211_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_SOFT_ENDSTOPS));
+  SERIAL_ECHOPAIR("  M211 S", AS_DIGIT(soft_endstop._enabled), " ; ");
+  serialprintln_onoff(soft_endstop._enabled);
+
+  report_echo_start(forReplay);
   const xyz_pos_t l_soft_min = soft_endstop.min.asLogical(),
                   l_soft_max = soft_endstop.max.asLogical();
-  SERIAL_ECHO_START();
-  SERIAL_ECHOPGM(STR_SOFT_ENDSTOPS);
-  if (parser.seen('S')) soft_endstop._enabled = parser.value_bool();
-  serialprint_onoff(soft_endstop._enabled);
   print_pos(l_soft_min, PSTR(STR_SOFT_MIN), PSTR(" "));
   print_pos(l_soft_max, PSTR(STR_SOFT_MAX));
 }
 
-#endif
+#endif // HAS_SOFTWARE_ENDSTOPS

--- a/Marlin/src/gcode/control/M605.cpp
+++ b/Marlin/src/gcode/control/M605.cpp
@@ -127,26 +127,26 @@
           case DXC_DUPLICATION_MODE:  DEBUG_ECHOPGM("DUPLICATION");  break;
           case DXC_MIRRORED_MODE:     DEBUG_ECHOPGM("MIRRORED");     break;
         }
-        DEBUG_ECHOPAIR("\nActive Ext: ", active_extruder);
+        DEBUG_ECHOPGM("\nActive Ext: ", active_extruder);
         if (!active_extruder_parked) DEBUG_ECHOPGM(" NOT ");
         DEBUG_ECHOPGM(" parked.");
-        DEBUG_ECHOPAIR("\nactive_extruder_x_pos: ", current_position.x);
-        DEBUG_ECHOPAIR("\ninactive_extruder_x: ", inactive_extruder_x);
-        DEBUG_ECHOPAIR("\nextruder_duplication_enabled: ", extruder_duplication_enabled);
-        DEBUG_ECHOPAIR("\nduplicate_extruder_x_offset: ", duplicate_extruder_x_offset);
-        DEBUG_ECHOPAIR("\nduplicate_extruder_temp_offset: ", duplicate_extruder_temp_offset);
-        DEBUG_ECHOPAIR("\ndelayed_move_time: ", delayed_move_time);
-        DEBUG_ECHOPAIR("\nX1 Home X: ", x_home_pos(0), "\nX1_MIN_POS=", X1_MIN_POS, "\nX1_MAX_POS=", X1_MAX_POS);
-        DEBUG_ECHOPAIR("\nX2 Home X: ", x_home_pos(1), "\nX2_MIN_POS=", X2_MIN_POS, "\nX2_MAX_POS=", X2_MAX_POS);
-        DEBUG_ECHOPAIR("\nX2_HOME_DIR=", X2_HOME_DIR, "\nX2_HOME_POS=", X2_HOME_POS);
-        DEBUG_ECHOPAIR("\nDEFAULT_DUAL_X_CARRIAGE_MODE=", STRINGIFY(DEFAULT_DUAL_X_CARRIAGE_MODE));
-        DEBUG_ECHOPAIR("\toolchange_settings.z_raise=", toolchange_settings.z_raise);
-        DEBUG_ECHOPAIR("\nDEFAULT_DUPLICATION_X_OFFSET=", DEFAULT_DUPLICATION_X_OFFSET);
+        DEBUG_ECHOPGM("\nactive_extruder_x_pos: ", current_position.x);
+        DEBUG_ECHOPGM("\ninactive_extruder_x: ", inactive_extruder_x);
+        DEBUG_ECHOPGM("\nextruder_duplication_enabled: ", extruder_duplication_enabled);
+        DEBUG_ECHOPGM("\nduplicate_extruder_x_offset: ", duplicate_extruder_x_offset);
+        DEBUG_ECHOPGM("\nduplicate_extruder_temp_offset: ", duplicate_extruder_temp_offset);
+        DEBUG_ECHOPGM("\ndelayed_move_time: ", delayed_move_time);
+        DEBUG_ECHOPGM("\nX1 Home X: ", x_home_pos(0), "\nX1_MIN_POS=", X1_MIN_POS, "\nX1_MAX_POS=", X1_MAX_POS);
+        DEBUG_ECHOPGM("\nX2 Home X: ", x_home_pos(1), "\nX2_MIN_POS=", X2_MIN_POS, "\nX2_MAX_POS=", X2_MAX_POS);
+        DEBUG_ECHOPGM("\nX2_HOME_DIR=", X2_HOME_DIR, "\nX2_HOME_POS=", X2_HOME_POS);
+        DEBUG_ECHOPGM("\nDEFAULT_DUAL_X_CARRIAGE_MODE=", STRINGIFY(DEFAULT_DUAL_X_CARRIAGE_MODE));
+        DEBUG_ECHOPGM("\toolchange_settings.z_raise=", toolchange_settings.z_raise);
+        DEBUG_ECHOPGM("\nDEFAULT_DUPLICATION_X_OFFSET=", DEFAULT_DUPLICATION_X_OFFSET);
         DEBUG_EOL();
 
         HOTEND_LOOP() {
-          DEBUG_ECHOPAIR_P(SP_T_STR, e);
-          LOOP_LINEAR_AXES(a) DEBUG_ECHOPAIR("  hotend_offset[", e, "].", AS_CHAR(AXIS_CHAR(a) | 0x20), "=", hotend_offset[e][a]);
+          DEBUG_ECHOPGM_P(SP_T_STR, e);
+          LOOP_LINEAR_AXES(a) DEBUG_ECHOPGM("  hotend_offset[", e, "].", AS_CHAR(AXIS_CHAR(a) | 0x20), "=", hotend_offset[e][a]);
           DEBUG_EOL();
         }
         DEBUG_EOL();

--- a/Marlin/src/gcode/control/M993_M994.cpp
+++ b/Marlin/src/gcode/control/M993_M994.cpp
@@ -37,7 +37,7 @@ void GcodeSuite::M993() {
   char fname[] = "spiflash.bin";
   card.openFileWrite(fname);
   if (!card.isFileOpen()) {
-    SERIAL_ECHOLNPAIR("Failed to open ", fname, " to write.");
+    SERIAL_ECHOLNPGM("Failed to open ", fname, " to write.");
     return;
   }
 
@@ -65,7 +65,7 @@ void GcodeSuite::M994() {
   char fname[] = "spiflash.bin";
   card.openFileRead(fname);
   if (!card.isFileOpen()) {
-    SERIAL_ECHOLNPAIR("Failed to open ", fname, " to read.");
+    SERIAL_ECHOLNPGM("Failed to open ", fname, " to read.");
     return;
   }
 

--- a/Marlin/src/gcode/control/T.cpp
+++ b/Marlin/src/gcode/control/T.cpp
@@ -49,7 +49,7 @@
 void GcodeSuite::T(const int8_t tool_index) {
 
   DEBUG_SECTION(log_T, "T", DEBUGGING(LEVELING));
-  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("...(", tool_index, ")");
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("...(", tool_index, ")");
 
   // Count this command as movement / activity
   reset_stepper_timeout();

--- a/Marlin/src/gcode/eeprom/M500-M504.cpp
+++ b/Marlin/src/gcode/eeprom/M500-M504.cpp
@@ -75,14 +75,14 @@ void GcodeSuite::M502() {
         if (dowrite) {
           val = parser.byteval('V');
           persistentStore.write_data(addr, &val);
-          SERIAL_ECHOLNPAIR("Wrote address ", addr, " with ", val);
+          SERIAL_ECHOLNPGM("Wrote address ", addr, " with ", val);
         }
         else {
           if (parser.seenval('T')) {
             const int endaddr = parser.value_ushort();
             while (addr <= endaddr) {
               persistentStore.read_data(addr, &val);
-              SERIAL_ECHOLNPAIR("0x", hex_word(addr), ":", hex_byte(val));
+              SERIAL_ECHOLNPGM("0x", hex_word(addr), ":", hex_byte(val));
               addr++;
               safe_delay(10);
             }
@@ -90,7 +90,7 @@ void GcodeSuite::M502() {
           }
           else {
             persistentStore.read_data(addr, &val);
-            SERIAL_ECHOLNPAIR("Read address ", addr, " and got ", val);
+            SERIAL_ECHOLNPGM("Read address ", addr, " and got ", val);
           }
         }
         return;

--- a/Marlin/src/gcode/feature/L6470/M122.cpp
+++ b/Marlin/src/gcode/feature/L6470/M122.cpp
@@ -68,7 +68,7 @@ inline void L6470_say_status(const L64XX_axis_t axis) {
     if (!(sh.STATUS_AXIS & sh.STATUS_AXIS_WRONG_CMD)) SERIAL_ECHOPGM("IN");
     SERIAL_ECHOPGM("VALID    ");
     SERIAL_ECHOPGM_P(sh.STATUS_AXIS & sh.STATUS_AXIS_NOTPERF_CMD ?  PSTR("COMPLETED    ") : PSTR("Not PERFORMED"));
-    SERIAL_ECHOPAIR("\n...THERMAL: ", !(sh.STATUS_AXIS & sh.STATUS_AXIS_TH_SD) ? "SHUTDOWN       " : !(sh.STATUS_AXIS & sh.STATUS_AXIS_TH_WRN) ? "WARNING        " : "OK             ");
+    SERIAL_ECHOPGM("\n...THERMAL: ", !(sh.STATUS_AXIS & sh.STATUS_AXIS_TH_SD) ? "SHUTDOWN       " : !(sh.STATUS_AXIS & sh.STATUS_AXIS_TH_WRN) ? "WARNING        " : "OK             ");
   }
   SERIAL_ECHOPGM("   OVERCURRENT:"); echo_yes_no((sh.STATUS_AXIS & sh.STATUS_AXIS_OCD) == 0);
   if (sh.STATUS_AXIS_LAYOUT != L6474_STATUS_LAYOUT) {

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -63,7 +63,7 @@ void L64XX_report_current(L64XX &motor, const L64XX_axis_t axis) {
     #if ENABLED(L6470_CHITCHAT)
       char tmp[10];
       sprintf_P(tmp, PSTR("%4x   "), status);
-      DEBUG_ECHOPAIR("   status: ", tmp);
+      DEBUG_ECHOPGM("   status: ", tmp);
       print_bin(status);
     #else
       UNUSED(status);
@@ -104,13 +104,13 @@ void L64XX_report_current(L64XX &motor, const L64XX_axis_t axis) {
       }
       SERIAL_EOL();
 
-      SERIAL_ECHOPAIR("...MicroSteps: ", MicroSteps,
+      SERIAL_ECHOPGM("...MicroSteps: ", MicroSteps,
                       "   ADC_OUT: ", L6470_ADC_out);
       SERIAL_ECHOPGM("   Vs_compensation: ");
       SERIAL_ECHOPGM_P((motor.GetParam(sh.L6470_AXIS_CONFIG) & CONFIG_EN_VSCOMP) ? PSTR("ENABLED ") : PSTR("DISABLED"));
-      SERIAL_ECHOLNPAIR("   Compensation coefficient: ~", comp_coef * 0.01f);
+      SERIAL_ECHOLNPGM("   Compensation coefficient: ~", comp_coef * 0.01f);
 
-      SERIAL_ECHOPAIR("...KVAL_HOLD: ", motor.GetParam(L6470_KVAL_HOLD),
+      SERIAL_ECHOPGM("...KVAL_HOLD: ", motor.GetParam(L6470_KVAL_HOLD),
                       "   KVAL_RUN : ", motor.GetParam(L6470_KVAL_RUN),
                       "   KVAL_ACC: ", motor.GetParam(L6470_KVAL_ACC),
                       "   KVAL_DEC: ", motor.GetParam(L6470_KVAL_DEC),
@@ -168,7 +168,7 @@ void L64XX_report_current(L64XX &motor, const L64XX_axis_t axis) {
       SERIAL_ECHOLNPGM(" mA)   Motor Status: NA");
 
       const uint16_t MicroSteps = _BV(motor.GetParam(L6470_STEP_MODE) & 0x07); //NOMORE(MicroSteps, 16);
-      SERIAL_ECHOPAIR("...MicroSteps: ", MicroSteps,
+      SERIAL_ECHOPGM("...MicroSteps: ", MicroSteps,
                       "   ADC_OUT: ", L6470_ADC_out);
 
       SERIAL_ECHOLNPGM("   Vs_compensation: NA\n");
@@ -185,7 +185,7 @@ void L64XX_report_current(L64XX &motor, const L64XX_axis_t axis) {
           case 1:  DEBUG_ECHOLNPGM("75V/uS")  ; break;
           case 2:  DEBUG_ECHOLNPGM("110V/uS") ; break;
           case 3:  DEBUG_ECHOLNPGM("260V/uS") ; break;
-          default: DEBUG_ECHOLNPAIR("slew rate: ", (motor.GetParam(sh.L6470_AXIS_CONFIG) & CONFIG_POW_SR) >> CONFIG_POW_SR_BIT); break;
+          default: DEBUG_ECHOLNPGM("slew rate: ", (motor.GetParam(sh.L6470_AXIS_CONFIG) & CONFIG_POW_SR) >> CONFIG_POW_SR_BIT); break;
         }
       #endif
       SERIAL_EOL();

--- a/Marlin/src/gcode/feature/L6470/M916-918.cpp
+++ b/Marlin/src/gcode/feature/L6470/M916-918.cpp
@@ -96,7 +96,7 @@ void GcodeSuite::M916() {
   if (L64xxManager.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, OCD_TH_val, STALL_TH_val, over_current_threshold))
     return;  // quit if invalid user input
 
-  DEBUG_ECHOLNPAIR("feedrate = ", final_feedrate);
+  DEBUG_ECHOLNPGM("feedrate = ", final_feedrate);
 
   planner.synchronize();                             // wait for all current movement commands to complete
 
@@ -127,9 +127,9 @@ void GcodeSuite::M916() {
   do {
 
     if (sh.STATUS_AXIS_LAYOUT == L6474_STATUS_LAYOUT)
-      DEBUG_ECHOLNPAIR("TVAL current (mA) = ", (M91x_counter + 1) * sh.AXIS_STALL_CURRENT_CONSTANT_INV);        // report TVAL current for this run
+      DEBUG_ECHOLNPGM("TVAL current (mA) = ", (M91x_counter + 1) * sh.AXIS_STALL_CURRENT_CONSTANT_INV);        // report TVAL current for this run
     else
-      DEBUG_ECHOLNPAIR("kval_hold = ", M91x_counter);                                   // report KVAL_HOLD for this run
+      DEBUG_ECHOLNPGM("kval_hold = ", M91x_counter);                                   // report KVAL_HOLD for this run
 
     for (j = 0; j < driver_count; j++)
       L64xxManager.set_param(axis_index[j], L6470_KVAL_HOLD, M91x_counter);  //set KVAL_HOLD or TVAL (same register address)
@@ -236,7 +236,7 @@ void GcodeSuite::M917() {
   if (L64xxManager.get_user_input(driver_count, axis_index, axis_mon, position_max, position_min, final_feedrate, kval_hold, over_current_flag, OCD_TH_val, STALL_TH_val, over_current_threshold))
     return;  // quit if invalid user input
 
-  DEBUG_ECHOLNPAIR("feedrate = ", final_feedrate);
+  DEBUG_ECHOLNPGM("feedrate = ", final_feedrate);
 
   planner.synchronize();                             // wait for all current movement commands to complete
 
@@ -252,18 +252,18 @@ void GcodeSuite::M917() {
                                           // 2 - OCD finalized - decreasing STALL - exit when STALL warning happens
                                           // 3 - OCD finalized - increasing STALL - exit when STALL warning stop
                                           // 4 - all testing completed
-  DEBUG_ECHOPAIR(".\n.\n.\nover_current threshold : ", (OCD_TH_val + 1) * 375);   // first status display
-  DEBUG_ECHOPAIR("  (OCD_TH:  : ", OCD_TH_val);
+  DEBUG_ECHOPGM(".\n.\n.\nover_current threshold : ", (OCD_TH_val + 1) * 375);   // first status display
+  DEBUG_ECHOPGM("  (OCD_TH:  : ", OCD_TH_val);
   if (sh.STATUS_AXIS_LAYOUT != L6474_STATUS_LAYOUT) {
-    DEBUG_ECHOPAIR(")   Stall threshold: ", (STALL_TH_val + 1) * 31.25);
-    DEBUG_ECHOPAIR("  (STALL_TH: ", STALL_TH_val);
+    DEBUG_ECHOPGM(")   Stall threshold: ", (STALL_TH_val + 1) * 31.25);
+    DEBUG_ECHOPGM("  (STALL_TH: ", STALL_TH_val);
   }
   DEBUG_ECHOLNPGM(")");
 
   do {
 
-    if (sh.STATUS_AXIS_LAYOUT != L6474_STATUS_LAYOUT) DEBUG_ECHOPAIR("STALL threshold : ", (STALL_TH_val + 1) * 31.25);
-    DEBUG_ECHOLNPAIR("   OCD threshold : ", (OCD_TH_val + 1) * 375);
+    if (sh.STATUS_AXIS_LAYOUT != L6474_STATUS_LAYOUT) DEBUG_ECHOPGM("STALL threshold : ", (STALL_TH_val + 1) * 31.25);
+    DEBUG_ECHOLNPGM("   OCD threshold : ", (OCD_TH_val + 1) * 375);
 
     sprintf_P(gcode_string, PSTR("G0 %s%03d F%03d"), temp_axis_string, uint16_t(position_min), uint16_t(final_feedrate));
     gcode.process_subcommands_now_P(gcode_string);
@@ -303,7 +303,7 @@ void GcodeSuite::M917() {
         if (!(k % 4)) {
           kval_hold *= 0.95;
           DEBUG_EOL();
-          DEBUG_ECHOLNPAIR("Lowering KVAL_HOLD by about 5% to ", kval_hold);
+          DEBUG_ECHOLNPGM("Lowering KVAL_HOLD by about 5% to ", kval_hold);
           for (j = 0; j < driver_count; j++)
             L64xxManager.set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
         }
@@ -590,8 +590,8 @@ void GcodeSuite::M918() {
   }
   m_steps = L64xxManager.get_param(axis_index[0], L6470_STEP_MODE) & 0x07;   // get microsteps
 
-  DEBUG_ECHOLNPAIR("Microsteps = ", _BV(m_steps));
-  DEBUG_ECHOLNPAIR("target (maximum) feedrate = ", final_feedrate);
+  DEBUG_ECHOLNPGM("Microsteps = ", _BV(m_steps));
+  DEBUG_ECHOLNPGM("target (maximum) feedrate = ", final_feedrate);
 
   const float feedrate_inc = final_feedrate / 10,   // Start at 1/10 of max & go up by 1/10 per step
               fr_limit = final_feedrate * 0.99f;    // Rounding-safe comparison value
@@ -612,7 +612,7 @@ void GcodeSuite::M918() {
 
   do {
     current_feedrate += feedrate_inc;
-    DEBUG_ECHOLNPAIR("...feedrate = ", current_feedrate);
+    DEBUG_ECHOLNPGM("...feedrate = ", current_feedrate);
 
     sprintf_P(gcode_string, PSTR("G0 %s%03d F%03d"), temp_axis_string, uint16_t(position_min), uint16_t(current_feedrate));
     gcode.process_subcommands_now_P(gcode_string);

--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -144,4 +144,17 @@ void GcodeSuite::M900() {
 
 }
 
+void GcodeSuite::M900_report(const bool forReplay/*=true*/) {
+  report_heading(forReplay, PSTR(STR_LINEAR_ADVANCE));
+  #if EXTRUDERS < 2
+    report_echo_start(forReplay);
+    SERIAL_ECHOLNPAIR("  M900 K", planner.extruder_advance_K[0]);
+  #else
+    LOOP_L_N(i, EXTRUDERS) {
+      report_echo_start(forReplay);
+      SERIAL_ECHOLNPAIR("  M900 T", i, " K", planner.extruder_advance_K[i]);
+    }
+  #endif
+}
+
 #endif // LIN_ADVANCE

--- a/Marlin/src/gcode/feature/advance/M900.cpp
+++ b/Marlin/src/gcode/feature/advance/M900.cpp
@@ -115,11 +115,11 @@ void GcodeSuite::M900() {
     #if ENABLED(EXTRA_LIN_ADVANCE_K)
 
       #if EXTRUDERS < 2
-        SERIAL_ECHOLNPAIR("Advance S", new_slot, " K", kref, "(S", !new_slot, " K", lref, ")");
+        SERIAL_ECHOLNPGM("Advance S", new_slot, " K", kref, "(S", !new_slot, " K", lref, ")");
       #else
         LOOP_L_N(i, EXTRUDERS) {
           const bool slot = TEST(lin_adv_slot, i);
-          SERIAL_ECHOLNPAIR("Advance T", i, " S", slot, " K", planner.extruder_advance_K[i],
+          SERIAL_ECHOLNPGM("Advance T", i, " S", slot, " K", planner.extruder_advance_K[i],
                             "(S", !slot, " K", other_extruder_advance_K[i], ")");
           SERIAL_EOL();
         }
@@ -129,7 +129,7 @@ void GcodeSuite::M900() {
 
       SERIAL_ECHO_START();
       #if EXTRUDERS < 2
-        SERIAL_ECHOLNPAIR("Advance K=", planner.extruder_advance_K[0]);
+        SERIAL_ECHOLNPGM("Advance K=", planner.extruder_advance_K[0]);
       #else
         SERIAL_ECHOPGM("Advance K");
         LOOP_L_N(i, EXTRUDERS) {
@@ -148,11 +148,11 @@ void GcodeSuite::M900_report(const bool forReplay/*=true*/) {
   report_heading(forReplay, PSTR(STR_LINEAR_ADVANCE));
   #if EXTRUDERS < 2
     report_echo_start(forReplay);
-    SERIAL_ECHOLNPAIR("  M900 K", planner.extruder_advance_K[0]);
+    SERIAL_ECHOLNPGM("  M900 K", planner.extruder_advance_K[0]);
   #else
     LOOP_L_N(i, EXTRUDERS) {
       report_echo_start(forReplay);
-      SERIAL_ECHOLNPAIR("  M900 T", i, " K", planner.extruder_advance_K[i]);
+      SERIAL_ECHOLNPGM("  M900 T", i, " K", planner.extruder_advance_K[i]);
     }
   #endif
 }

--- a/Marlin/src/gcode/feature/controllerfan/M710.cpp
+++ b/Marlin/src/gcode/feature/controllerfan/M710.cpp
@@ -27,18 +27,6 @@
 #include "../../gcode.h"
 #include "../../../feature/controllerfan.h"
 
-void M710_report(const bool forReplay=true) {
-  if (!forReplay) { SERIAL_ECHOLNPGM("; Controller Fan"); SERIAL_ECHO_START(); }
-  SERIAL_ECHOLNPAIR("  M710"
-    " S", int(controllerFan.settings.active_speed),
-    " I", int(controllerFan.settings.idle_speed),
-    " A", int(controllerFan.settings.auto_mode),
-    " D", controllerFan.settings.duration,
-    " ; (", (int(controllerFan.settings.active_speed) * 100) / 255, "%"
-    " ", (int(controllerFan.settings.idle_speed) * 100) / 255, "%)"
-  );
-}
-
 /**
  * M710: Set controller fan settings
  *
@@ -76,6 +64,18 @@ void GcodeSuite::M710() {
 
   if (!(seenR || seenS || seenI || seenA || seenD))
     M710_report();
+}
+
+void GcodeSuite::M710_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_CONTROLLER_FAN));
+  SERIAL_ECHOLNPAIR("  M710"
+    " S", int(controllerFan.settings.active_speed),
+    " I", int(controllerFan.settings.idle_speed),
+    " A", int(controllerFan.settings.auto_mode),
+    " D", controllerFan.settings.duration,
+    " ; (", (int(controllerFan.settings.active_speed) * 100) / 255, "%"
+    " ", (int(controllerFan.settings.idle_speed) * 100) / 255, "%)"
+  );
 }
 
 #endif // CONTROLLER_FAN_EDITABLE

--- a/Marlin/src/gcode/feature/controllerfan/M710.cpp
+++ b/Marlin/src/gcode/feature/controllerfan/M710.cpp
@@ -68,7 +68,7 @@ void GcodeSuite::M710() {
 
 void GcodeSuite::M710_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_CONTROLLER_FAN));
-  SERIAL_ECHOLNPAIR("  M710"
+  SERIAL_ECHOLNPGM("  M710"
     " S", int(controllerFan.settings.active_speed),
     " I", int(controllerFan.settings.idle_speed),
     " A", int(controllerFan.settings.auto_mode),

--- a/Marlin/src/gcode/feature/digipot/M907-M910.cpp
+++ b/Marlin/src/gcode/feature/digipot/M907-M910.cpp
@@ -102,7 +102,7 @@ void GcodeSuite::M907() {
   void GcodeSuite::M907_report(const bool forReplay/*=true*/) {
     report_heading_etc(forReplay, PSTR(STR_STEPPER_MOTOR_CURRENTS));
     #if HAS_MOTOR_CURRENT_PWM
-      SERIAL_ECHOLNPAIR_P(                                    // PWM-based has 3 values:
+      SERIAL_ECHOLNPGM_P(                                    // PWM-based has 3 values:
           PSTR("  M907 X"), stepper.motor_current_setting[0]  // X and Y
         , SP_Z_STR,         stepper.motor_current_setting[1]  // Z
         , SP_E_STR,         stepper.motor_current_setting[2]  // E

--- a/Marlin/src/gcode/feature/digipot/M907-M910.cpp
+++ b/Marlin/src/gcode/feature/digipot/M907-M910.cpp
@@ -22,7 +22,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#if ANY(HAS_MOTOR_CURRENT_SPI, HAS_MOTOR_CURRENT_PWM, HAS_MOTOR_CURRENT_I2C, HAS_MOTOR_CURRENT_DAC)
+#if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM || HAS_MOTOR_CURRENT_I2C || HAS_MOTOR_CURRENT_DAC
 
 #include "../../gcode.h"
 
@@ -44,11 +44,26 @@
 void GcodeSuite::M907() {
   #if HAS_MOTOR_CURRENT_SPI
 
+    if (!parser.seen("BS" LOGICAL_AXES_STRING))
+      return M907_report();
+
     LOOP_LOGICAL_AXES(i) if (parser.seenval(axis_codes[i])) stepper.set_digipot_current(i, parser.value_int());
     if (parser.seenval('B')) stepper.set_digipot_current(4, parser.value_int());
     if (parser.seenval('S')) LOOP_LE_N(i, 4) stepper.set_digipot_current(i, parser.value_int());
 
   #elif HAS_MOTOR_CURRENT_PWM
+
+    if (!parser.seen(
+      #if ANY_PIN(MOTOR_CURRENT_PWM_X, MOTOR_CURRENT_PWM_Y, MOTOR_CURRENT_PWM_XY)
+        "XY"
+      #endif
+      #if PIN_EXISTS(MOTOR_CURRENT_PWM_Z)
+        "Z"
+      #endif
+      #if PIN_EXISTS(MOTOR_CURRENT_PWM_E)
+        "E"
+      #endif
+    )) return M907_report();
 
     #if ANY_PIN(MOTOR_CURRENT_PWM_X, MOTOR_CURRENT_PWM_Y, MOTOR_CURRENT_PWM_XY)
       if (parser.seenval('X') || parser.seenval('Y')) stepper.set_digipot_current(0, parser.value_int());
@@ -82,7 +97,30 @@ void GcodeSuite::M907() {
   #endif
 }
 
-#if EITHER(HAS_MOTOR_CURRENT_SPI, HAS_MOTOR_CURRENT_DAC)
+#if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM
+
+  void GcodeSuite::M907_report(const bool forReplay/*=true*/) {
+    report_heading_etc(forReplay, PSTR(STR_STEPPER_MOTOR_CURRENTS));
+    #if HAS_MOTOR_CURRENT_PWM
+      SERIAL_ECHOLNPAIR_P(                                    // PWM-based has 3 values:
+          PSTR("  M907 X"), stepper.motor_current_setting[0]  // X and Y
+        , SP_Z_STR,         stepper.motor_current_setting[1]  // Z
+        , SP_E_STR,         stepper.motor_current_setting[2]  // E
+      );
+    #elif HAS_MOTOR_CURRENT_SPI
+      SERIAL_ECHOPGM("  M907");                               // SPI-based has 5 values:
+      LOOP_LOGICAL_AXES(q) {                                  // X Y Z (I J K) E (map to X Y Z (I J K) E0 by default)
+        SERIAL_CHAR(' ', axis_codes[q]);
+        SERIAL_ECHO(stepper.motor_current_setting[q]);
+      }
+      SERIAL_CHAR(' ', 'B');                                  // B (maps to E1 by default)
+      SERIAL_ECHOLN(stepper.motor_current_setting[4]);
+    #endif
+  }
+
+#endif // HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM
+
+#if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_DAC
 
   /**
    * M908: Control digital trimpot directly (M908 P<pin> S<current>)

--- a/Marlin/src/gcode/feature/filwidth/M404-M407.cpp
+++ b/Marlin/src/gcode/feature/filwidth/M404-M407.cpp
@@ -38,7 +38,7 @@ void GcodeSuite::M404() {
     planner.volumetric_area_nominal = CIRCLE_AREA(filwidth.nominal_mm * 0.5);
   }
   else
-    SERIAL_ECHOLNPAIR("Filament dia (nominal mm):", filwidth.nominal_mm);
+    SERIAL_ECHOLNPGM("Filament dia (nominal mm):", filwidth.nominal_mm);
 }
 
 /**
@@ -65,7 +65,7 @@ void GcodeSuite::M406() {
  * M407: Get measured filament diameter on serial output
  */
 void GcodeSuite::M407() {
-  SERIAL_ECHOLNPAIR("Filament dia (measured mm):", filwidth.measured_mm);
+  SERIAL_ECHOLNPGM("Filament dia (measured mm):", filwidth.measured_mm);
 }
 
 #endif // FILAMENT_WIDTH_SENSOR

--- a/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
+++ b/Marlin/src/gcode/feature/fwretract/M207-M209.cpp
@@ -29,13 +29,33 @@
 
 /**
  * M207: Set firmware retraction values
+ *
+ *   S[+units]    retract_length
+ *   W[+units]    swap_retract_length (multi-extruder)
+ *   F[units/min] retract_feedrate_mm_s
+ *   Z[units]     retract_zraise
  */
 void GcodeSuite::M207() { fwretract.M207(); }
 
+void GcodeSuite::M207_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_RETRACT_S_F_Z));
+  fwretract.M207_report();
+}
+
 /**
  * M208: Set firmware un-retraction values
+ *
+ *   S[+units]    retract_recover_extra (in addition to M207 S*)
+ *   W[+units]    swap_retract_recover_extra (multi-extruder)
+ *   F[units/min] retract_recover_feedrate_mm_s
+ *   R[units/min] swap_retract_recover_feedrate_mm_s
  */
 void GcodeSuite::M208() { fwretract.M208(); }
+
+void GcodeSuite::M208_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_RECOVER_S_F));
+  fwretract.M208_report();
+}
 
 #if ENABLED(FWRETRACT_AUTORETRACT)
 
@@ -46,6 +66,11 @@ void GcodeSuite::M208() { fwretract.M208(); }
    *   extruder-only moves can be classified as retraction.
    */
   void GcodeSuite::M209() { fwretract.M209(); }
+
+  void GcodeSuite::M209_report(const bool forReplay/*=true*/) {
+    report_heading_etc(forReplay, PSTR(STR_AUTO_RETRACT_S));
+    fwretract.M209_report();
+  }
 
 #endif
 

--- a/Marlin/src/gcode/feature/mixing/M166.cpp
+++ b/Marlin/src/gcode/feature/mixing/M166.cpp
@@ -30,12 +30,12 @@
 #include "../../../feature/mixing.h"
 
 inline void echo_mix() {
-  SERIAL_ECHOPAIR(" (", mixer.mix[0], "%|", mixer.mix[1], "%)");
+  SERIAL_ECHOPGM(" (", mixer.mix[0], "%|", mixer.mix[1], "%)");
 }
 
 inline void echo_zt(const int t, const_float_t z) {
   mixer.update_mix_from_vtool(t);
-  SERIAL_ECHOPAIR_P(SP_Z_STR, z, SP_T_STR, t);
+  SERIAL_ECHOPGM_P(SP_Z_STR, z, SP_T_STR, t);
   echo_mix();
 }
 
@@ -74,7 +74,7 @@ void GcodeSuite::M166() {
 
     #if ENABLED(GRADIENT_VTOOL)
       if (mixer.gradient.vtool_index >= 0) {
-        SERIAL_ECHOPAIR(" (T", mixer.gradient.vtool_index);
+        SERIAL_ECHOPGM(" (T", mixer.gradient.vtool_index);
         SERIAL_CHAR(')');
       }
     #endif

--- a/Marlin/src/gcode/feature/network/M552-M554.cpp
+++ b/Marlin/src/gcode/feature/network/M552-M554.cpp
@@ -64,17 +64,7 @@ void ip_report(const uint16_t cmd, PGM_P const post, const IPAddress &ipo) {
     if (i < 3) SERIAL_CHAR('.');
   }
   SERIAL_ECHOPGM(" ; ");
-  SERIAL_ECHOPGM_P(post);
-  SERIAL_EOL();
-}
-void M552_report() {
-  ip_report(552, PSTR("ip address"), Ethernet.linkStatus() == LinkON ? Ethernet.localIP() : ethernet.ip);
-}
-void M553_report() {
-  ip_report(553, PSTR("subnet mask"), Ethernet.linkStatus() == LinkON ? Ethernet.subnetMask() : ethernet.subnet);
-}
-void M554_report() {
-  ip_report(554, PSTR("gateway"), Ethernet.linkStatus() == LinkON ? Ethernet.gatewayIP() : ethernet.gateway);
+  SERIAL_ECHOLNPGM_P(post);
 }
 
 /**
@@ -107,20 +97,36 @@ void GcodeSuite::M552() {
   if (nopar || seenP) M552_report();
 }
 
+void GcodeSuite::M552_report() {
+  ip_report(552, PSTR("ip address"), Ethernet.linkStatus() == LinkON ? Ethernet.localIP() : ethernet.ip);
+}
+
 /**
  * M553 Pnnn - Set netmask
  */
 void GcodeSuite::M553() {
-  if (parser.seenval('P')) ethernet.subnet.fromString(parser.value_string());
-  M553_report();
+  if (parser.seenval('P'))
+    ethernet.subnet.fromString(parser.value_string());
+  else
+    M553_report();
+}
+
+void GcodeSuite::M553_report() {
+  ip_report(553, PSTR("subnet mask"), Ethernet.linkStatus() == LinkON ? Ethernet.subnetMask() : ethernet.subnet);
 }
 
 /**
  * M554 Pnnn - Set Gateway
  */
 void GcodeSuite::M554() {
-  if (parser.seenval('P')) ethernet.gateway.fromString(parser.value_string());
-  M554_report();
+  if (parser.seenval('P'))
+    ethernet.gateway.fromString(parser.value_string());
+  else
+    M554_report();
+}
+
+void GcodeSuite::M554_report() {
+  ip_report(554, PSTR("gateway"), Ethernet.linkStatus() == LinkON ? Ethernet.gatewayIP() : ethernet.gateway);
 }
 
 #endif // HAS_ETHERNET

--- a/Marlin/src/gcode/feature/password/M510-M512.cpp
+++ b/Marlin/src/gcode/feature/password/M510-M512.cpp
@@ -66,7 +66,7 @@ void GcodeSuite::M510() {
       if (password.value_entry < CAT(1e, PASSWORD_LENGTH)) {
         password.is_set = true;
         password.value = password.value_entry;
-        SERIAL_ECHOLNPAIR(STR_PASSWORD_SET, password.value); // TODO: Update password.string
+        SERIAL_ECHOLNPGM(STR_PASSWORD_SET, password.value); // TODO: Update password.string
       }
       else
         SERIAL_ECHOLNPGM(STR_PASSWORD_TOO_LONG);

--- a/Marlin/src/gcode/feature/pause/G60.cpp
+++ b/Marlin/src/gcode/feature/pause/G60.cpp
@@ -47,7 +47,7 @@ void GcodeSuite::G60() {
   SBI(saved_slots[slot >> 3], slot & 0x07);
 
   #if ENABLED(SAVED_POSITIONS_DEBUG)
-    DEBUG_ECHOPAIR(STR_SAVED_POS " S", slot);
+    DEBUG_ECHOPGM(STR_SAVED_POS " S", slot);
     const xyze_pos_t &pos = stored_position[slot];
     DEBUG_ECHOLNPAIR_F_P(
       LIST_N(DOUBLE(LOGICAL_AXES), SP_E_STR, pos.e,

--- a/Marlin/src/gcode/feature/pause/G61.cpp
+++ b/Marlin/src/gcode/feature/pause/G61.cpp
@@ -69,7 +69,7 @@ void GcodeSuite::G61(void) {
   }
   else {
     if (parser.seen(LINEAR_AXIS_GANG("X", "Y", "Z", AXIS4_STR, AXIS5_STR, AXIS6_STR))) {
-      DEBUG_ECHOPAIR(STR_RESTORING_POS " S", slot);
+      DEBUG_ECHOPGM(STR_RESTORING_POS " S", slot);
       LOOP_LINEAR_AXES(i) {
         destination[i] = parser.seen(AXIS_CHAR(i))
           ? stored_position[slot][i] + parser.value_axis_units((AxisEnum)i)
@@ -83,7 +83,7 @@ void GcodeSuite::G61(void) {
     }
     #if HAS_EXTRUDERS
       if (parser.seen_test('E')) {
-        DEBUG_ECHOLNPAIR(STR_RESTORING_POS " S", slot, " E", current_position.e, "=>", stored_position[slot].e);
+        DEBUG_ECHOLNPGM(STR_RESTORING_POS " S", slot, " E", current_position.e, "=>", stored_position[slot].e);
         SYNC_E(stored_position[slot].e);
       }
     #endif

--- a/Marlin/src/gcode/feature/pause/M603.cpp
+++ b/Marlin/src/gcode/feature/pause/M603.cpp
@@ -69,12 +69,12 @@ void GcodeSuite::M603_report(const bool forReplay/*=true*/) {
 
   #if EXTRUDERS == 1
     report_echo_start(forReplay);
-    SERIAL_ECHOPAIR("  M603 L", LINEAR_UNIT(fc_settings[0].load_length), " U", LINEAR_UNIT(fc_settings[0].unload_length), " ;");
+    SERIAL_ECHOPGM("  M603 L", LINEAR_UNIT(fc_settings[0].load_length), " U", LINEAR_UNIT(fc_settings[0].unload_length), " ;");
     say_units();
   #else
     LOOP_L_N(e, EXTRUDERS) {
       report_echo_start(forReplay);
-      SERIAL_ECHOPAIR("  M603 T", e, " L", LINEAR_UNIT(fc_settings[e].load_length), " U", LINEAR_UNIT(fc_settings[e].unload_length), " ;");
+      SERIAL_ECHOPGM("  M603 T", e, " L", LINEAR_UNIT(fc_settings[e].load_length), " U", LINEAR_UNIT(fc_settings[e].unload_length), " ;");
       say_units();
     }
   #endif

--- a/Marlin/src/gcode/feature/pause/M603.cpp
+++ b/Marlin/src/gcode/feature/pause/M603.cpp
@@ -42,6 +42,8 @@
  */
 void GcodeSuite::M603() {
 
+  if (!parser.seen("TUL")) return M603_report();
+
   const int8_t target_extruder = get_target_extruder_from_command();
   if (target_extruder < 0) return;
 
@@ -60,6 +62,22 @@ void GcodeSuite::M603() {
       NOMORE(fc_settings[target_extruder].load_length, EXTRUDE_MAXLENGTH);
     #endif
   }
+}
+
+void GcodeSuite::M603_report(const bool forReplay/*=true*/) {
+  report_heading(forReplay, PSTR(STR_FILAMENT_LOAD_UNLOAD));
+
+  #if EXTRUDERS == 1
+    report_echo_start(forReplay);
+    SERIAL_ECHOPAIR("  M603 L", LINEAR_UNIT(fc_settings[0].load_length), " U", LINEAR_UNIT(fc_settings[0].unload_length), " ;");
+    say_units();
+  #else
+    LOOP_L_N(e, EXTRUDERS) {
+      report_echo_start(forReplay);
+      SERIAL_ECHOPAIR("  M603 T", e, " L", LINEAR_UNIT(fc_settings[e].load_length), " U", LINEAR_UNIT(fc_settings[e].unload_length), " ;");
+      say_units();
+    }
+  #endif
 }
 
 #endif // ADVANCED_PAUSE_FEATURE

--- a/Marlin/src/gcode/feature/power_monitor/M430.cpp
+++ b/Marlin/src/gcode/feature/power_monitor/M430.cpp
@@ -50,7 +50,7 @@ void GcodeSuite::M430() {
     #endif
   #endif
   if (do_report) {
-    SERIAL_ECHOLNPAIR(
+    SERIAL_ECHOLNPGM(
       #if ENABLED(POWER_MONITOR_CURRENT)
         "Current: ", power_monitor.getAmps(), "A"
         #if ENABLED(POWER_MONITOR_VOLTAGE)

--- a/Marlin/src/gcode/feature/powerloss/M413.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M413.cpp
@@ -40,11 +40,8 @@ void GcodeSuite::M413() {
 
   if (parser.seen('S'))
     recovery.enable(parser.value_bool());
-  else {
-    SERIAL_ECHO_START();
-    SERIAL_ECHOPGM("Power-loss recovery ");
-    serialprintln_onoff(recovery.enabled);
-  }
+  else
+    M413_report();
 
   #if ENABLED(DEBUG_POWER_LOSS_RECOVERY)
     if (parser.seen("RL")) recovery.load();
@@ -57,6 +54,12 @@ void GcodeSuite::M413() {
     if (parser.seen_test('E')) SERIAL_ECHOPGM_P(recovery.exists() ? PSTR("PLR Exists\n") : PSTR("No PLR\n"));
     if (parser.seen_test('V')) SERIAL_ECHOPGM_P(recovery.valid() ? PSTR("Valid\n") : PSTR("Invalid\n"));
   #endif
+}
+
+void GcodeSuite::M413_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_POWER_LOSS_RECOVERY));
+  SERIAL_ECHOPAIR("  M413 S", AS_DIGIT(recovery.enabled), " ; ");
+  serialprintln_onoff(recovery.enabled);
 }
 
 #endif // POWER_LOSS_RECOVERY

--- a/Marlin/src/gcode/feature/powerloss/M413.cpp
+++ b/Marlin/src/gcode/feature/powerloss/M413.cpp
@@ -58,7 +58,7 @@ void GcodeSuite::M413() {
 
 void GcodeSuite::M413_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_POWER_LOSS_RECOVERY));
-  SERIAL_ECHOPAIR("  M413 S", AS_DIGIT(recovery.enabled), " ; ");
+  SERIAL_ECHOPGM("  M413 S", AS_DIGIT(recovery.enabled), " ; ");
   serialprintln_onoff(recovery.enabled);
 }
 

--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -66,4 +66,16 @@ void GcodeSuite::M412() {
   }
 }
 
+void GcodeSuite::M412_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_FILAMENT_RUNOUT_SENSOR));
+  SERIAL_ECHOLNPAIR(
+    "  M412 S", runout.enabled
+    #if HAS_FILAMENT_RUNOUT_DISTANCE
+      , " D", LINEAR_UNIT(runout.runout_distance())
+    #endif
+    , " ; Sensor "
+  );
+  serialprintln_onoff(runout.enabled);
+}
+
 #endif // HAS_FILAMENT_SENSOR

--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -56,7 +56,7 @@ void GcodeSuite::M412() {
     SERIAL_ECHOPGM("Filament runout ");
     serialprint_onoff(runout.enabled);
     #if HAS_FILAMENT_RUNOUT_DISTANCE
-      SERIAL_ECHOPAIR(" ; Distance ", runout.runout_distance(), "mm");
+      SERIAL_ECHOPGM(" ; Distance ", runout.runout_distance(), "mm");
     #endif
     #if ENABLED(HOST_ACTION_COMMANDS)
       SERIAL_ECHOPGM(" ; Host handling ");
@@ -68,7 +68,7 @@ void GcodeSuite::M412() {
 
 void GcodeSuite::M412_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_FILAMENT_RUNOUT_SENSOR));
-  SERIAL_ECHOLNPAIR(
+  SERIAL_ECHOLNPGM(
     "  M412 S", runout.enabled
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       , " D", LINEAR_UNIT(runout.runout_distance())

--- a/Marlin/src/gcode/feature/trinamic/M569.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M569.cpp
@@ -138,4 +138,66 @@ void GcodeSuite::M569() {
     say_stealth_status();
 }
 
+void GcodeSuite::M569_report(const bool forReplay/*=true*/) {
+  report_heading(forReplay, PSTR(STR_DRIVER_STEPPING_MODE));
+
+  auto say_M569 = [](const bool forReplay, const char * const etc=nullptr, const bool eol=false) {
+    if (!forReplay) SERIAL_ECHO_START();
+    SERIAL_ECHOPGM("  M569 S1");
+    if (etc) {
+      SERIAL_CHAR(' ');
+      SERIAL_ECHOPGM_P(etc);
+    }
+    if (eol) SERIAL_EOL();
+  };
+
+  const bool chop_x = TERN0(X_HAS_STEALTHCHOP, stepperX.get_stored_stealthChop()),
+             chop_y = TERN0(Y_HAS_STEALTHCHOP, stepperY.get_stored_stealthChop()),
+             chop_z = TERN0(Z_HAS_STEALTHCHOP, stepperZ.get_stored_stealthChop()),
+             chop_i = TERN0(I_HAS_STEALTHCHOP, stepperI.get_stored_stealthChop()),
+             chop_j = TERN0(J_HAS_STEALTHCHOP, stepperJ.get_stored_stealthChop()),
+             chop_k = TERN0(K_HAS_STEALTHCHOP, stepperK.get_stored_stealthChop());
+
+  if (chop_x || chop_y || chop_z || chop_i || chop_j || chop_k) {
+    say_M569(forReplay);
+    LINEAR_AXIS_CODE(
+      if (chop_x) SERIAL_ECHOPGM_P(SP_X_STR),
+      if (chop_y) SERIAL_ECHOPGM_P(SP_Y_STR),
+      if (chop_z) SERIAL_ECHOPGM_P(SP_Z_STR),
+      if (chop_i) SERIAL_ECHOPGM_P(SP_I_STR),
+      if (chop_j) SERIAL_ECHOPGM_P(SP_J_STR),
+      if (chop_k) SERIAL_ECHOPGM_P(SP_K_STR)
+    );
+    SERIAL_EOL();
+  }
+
+  const bool chop_x2 = TERN0(X2_HAS_STEALTHCHOP, stepperX2.get_stored_stealthChop()),
+             chop_y2 = TERN0(Y2_HAS_STEALTHCHOP, stepperY2.get_stored_stealthChop()),
+             chop_z2 = TERN0(Z2_HAS_STEALTHCHOP, stepperZ2.get_stored_stealthChop());
+
+  if (chop_x2 || chop_y2 || chop_z2) {
+    say_M569(forReplay, PSTR("I1"));
+    if (chop_x2) SERIAL_ECHOPGM_P(SP_X_STR);
+    if (chop_y2) SERIAL_ECHOPGM_P(SP_Y_STR);
+    if (chop_z2) SERIAL_ECHOPGM_P(SP_Z_STR);
+    SERIAL_EOL();
+  }
+
+  if (TERN0(Z3_HAS_STEALTHCHOP, stepperZ3.get_stored_stealthChop())) { say_M569(forReplay, PSTR("I2 Z"), true); }
+  if (TERN0(Z4_HAS_STEALTHCHOP, stepperZ4.get_stored_stealthChop())) { say_M569(forReplay, PSTR("I3 Z"), true); }
+
+  if (TERN0( I_HAS_STEALTHCHOP, stepperI.get_stored_stealthChop()))  { say_M569(forReplay, SP_I_STR, true); }
+  if (TERN0( J_HAS_STEALTHCHOP, stepperJ.get_stored_stealthChop()))  { say_M569(forReplay, SP_J_STR, true); }
+  if (TERN0( K_HAS_STEALTHCHOP, stepperK.get_stored_stealthChop()))  { say_M569(forReplay, SP_K_STR, true); }
+
+  if (TERN0(E0_HAS_STEALTHCHOP, stepperE0.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T0 E"), true); }
+  if (TERN0(E1_HAS_STEALTHCHOP, stepperE1.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T1 E"), true); }
+  if (TERN0(E2_HAS_STEALTHCHOP, stepperE2.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T2 E"), true); }
+  if (TERN0(E3_HAS_STEALTHCHOP, stepperE3.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T3 E"), true); }
+  if (TERN0(E4_HAS_STEALTHCHOP, stepperE4.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T4 E"), true); }
+  if (TERN0(E5_HAS_STEALTHCHOP, stepperE5.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T5 E"), true); }
+  if (TERN0(E6_HAS_STEALTHCHOP, stepperE6.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T6 E"), true); }
+  if (TERN0(E7_HAS_STEALTHCHOP, stepperE7.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T7 E"), true); }
+}
+
 #endif // HAS_STEALTHCHOP

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -209,13 +209,13 @@ void GcodeSuite::M906_report(const bool forReplay/*=true*/) {
   #if AXIS_IS_TMC(X) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Z)
     say_M906(forReplay);
     #if AXIS_IS_TMC(X)
-      SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.getMilliamps());
+      SERIAL_ECHOPGM_P(SP_X_STR, stepperX.getMilliamps());
     #endif
     #if AXIS_IS_TMC(Y)
-      SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.getMilliamps());
+      SERIAL_ECHOPGM_P(SP_Y_STR, stepperY.getMilliamps());
     #endif
     #if AXIS_IS_TMC(Z)
-      SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.getMilliamps());
+      SERIAL_ECHOPGM_P(SP_Z_STR, stepperZ.getMilliamps());
     #endif
     SERIAL_EOL();
   #endif
@@ -224,71 +224,71 @@ void GcodeSuite::M906_report(const bool forReplay/*=true*/) {
     say_M906(forReplay);
     SERIAL_ECHOPGM(" I1");
     #if AXIS_IS_TMC(X2)
-      SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.getMilliamps());
+      SERIAL_ECHOPGM_P(SP_X_STR, stepperX2.getMilliamps());
     #endif
     #if AXIS_IS_TMC(Y2)
-      SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.getMilliamps());
+      SERIAL_ECHOPGM_P(SP_Y_STR, stepperY2.getMilliamps());
     #endif
     #if AXIS_IS_TMC(Z2)
-      SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.getMilliamps());
+      SERIAL_ECHOPGM_P(SP_Z_STR, stepperZ2.getMilliamps());
     #endif
     SERIAL_EOL();
   #endif
 
   #if AXIS_IS_TMC(Z3)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.getMilliamps());
+    SERIAL_ECHOLNPGM(" I2 Z", stepperZ3.getMilliamps());
   #endif
 
   #if AXIS_IS_TMC(Z4)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.getMilliamps());
+    SERIAL_ECHOLNPGM(" I3 Z", stepperZ4.getMilliamps());
   #endif
 
   #if AXIS_IS_TMC(I)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.getMilliamps());
+    SERIAL_ECHOLNPGM_P(SP_I_STR, stepperI.getMilliamps());
   #endif
   #if AXIS_IS_TMC(J)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.getMilliamps());
+    SERIAL_ECHOLNPGM_P(SP_J_STR, stepperJ.getMilliamps());
   #endif
   #if AXIS_IS_TMC(K)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.getMilliamps());
+    SERIAL_ECHOLNPGM_P(SP_K_STR, stepperK.getMilliamps());
   #endif
 
   #if AXIS_IS_TMC(E0)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" T0 E", stepperE0.getMilliamps());
+    SERIAL_ECHOLNPGM(" T0 E", stepperE0.getMilliamps());
   #endif
   #if AXIS_IS_TMC(E1)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" T1 E", stepperE1.getMilliamps());
+    SERIAL_ECHOLNPGM(" T1 E", stepperE1.getMilliamps());
   #endif
   #if AXIS_IS_TMC(E2)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" T2 E", stepperE2.getMilliamps());
+    SERIAL_ECHOLNPGM(" T2 E", stepperE2.getMilliamps());
   #endif
   #if AXIS_IS_TMC(E3)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" T3 E", stepperE3.getMilliamps());
+    SERIAL_ECHOLNPGM(" T3 E", stepperE3.getMilliamps());
   #endif
   #if AXIS_IS_TMC(E4)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" T4 E", stepperE4.getMilliamps());
+    SERIAL_ECHOLNPGM(" T4 E", stepperE4.getMilliamps());
   #endif
   #if AXIS_IS_TMC(E5)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" T5 E", stepperE5.getMilliamps());
+    SERIAL_ECHOLNPGM(" T5 E", stepperE5.getMilliamps());
   #endif
   #if AXIS_IS_TMC(E6)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" T6 E", stepperE6.getMilliamps());
+    SERIAL_ECHOLNPGM(" T6 E", stepperE6.getMilliamps());
   #endif
   #if AXIS_IS_TMC(E7)
     say_M906(forReplay);
-    SERIAL_ECHOLNPAIR(" T7 E", stepperE7.getMilliamps());
+    SERIAL_ECHOLNPGM(" T7 E", stepperE7.getMilliamps());
   #endif
   SERIAL_EOL();
 }

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -198,4 +198,99 @@ void GcodeSuite::M906() {
   }
 }
 
+void GcodeSuite::M906_report(const bool forReplay/*=true*/) {
+  report_heading(forReplay, PSTR(STR_STEPPER_DRIVER_CURRENT));
+
+  auto say_M906 = [](const bool forReplay) {
+    report_echo_start(forReplay);
+    SERIAL_ECHOPGM("  M906");
+  };
+
+  #if AXIS_IS_TMC(X) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Z)
+    say_M906(forReplay);
+    #if AXIS_IS_TMC(X)
+      SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.getMilliamps());
+    #endif
+    #if AXIS_IS_TMC(Y)
+      SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.getMilliamps());
+    #endif
+    #if AXIS_IS_TMC(Z)
+      SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.getMilliamps());
+    #endif
+    SERIAL_EOL();
+  #endif
+
+  #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2)
+    say_M906(forReplay);
+    SERIAL_ECHOPGM(" I1");
+    #if AXIS_IS_TMC(X2)
+      SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.getMilliamps());
+    #endif
+    #if AXIS_IS_TMC(Y2)
+      SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.getMilliamps());
+    #endif
+    #if AXIS_IS_TMC(Z2)
+      SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.getMilliamps());
+    #endif
+    SERIAL_EOL();
+  #endif
+
+  #if AXIS_IS_TMC(Z3)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.getMilliamps());
+  #endif
+
+  #if AXIS_IS_TMC(Z4)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.getMilliamps());
+  #endif
+
+  #if AXIS_IS_TMC(I)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(J)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(K)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.getMilliamps());
+  #endif
+
+  #if AXIS_IS_TMC(E0)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" T0 E", stepperE0.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(E1)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" T1 E", stepperE1.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(E2)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" T2 E", stepperE2.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(E3)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" T3 E", stepperE3.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(E4)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" T4 E", stepperE4.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(E5)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" T5 E", stepperE5.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(E6)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" T6 E", stepperE6.getMilliamps());
+  #endif
+  #if AXIS_IS_TMC(E7)
+    say_M906(forReplay);
+    SERIAL_ECHOLNPAIR(" T7 E", stepperE7.getMilliamps());
+  #endif
+  SERIAL_EOL();
+}
+
 #endif // HAS_TRINAMIC_CONFIG

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -227,6 +227,7 @@
  * M913: Set HYBRID_THRESHOLD speed.
  */
 #if ENABLED(HYBRID_THRESHOLD)
+
   void GcodeSuite::M913() {
     #define TMC_SAY_PWMTHRS(A,Q) tmc_print_pwmthrs(stepper##Q)
     #define TMC_SET_PWMTHRS(A,Q) stepper##Q.set_pwm_thrs(value)
@@ -308,12 +309,109 @@
       TERN_(E7_HAS_STEALTHCHOP, TMC_SAY_PWMTHRS_E(7));
     }
   }
+
+  void GcodeSuite::M913_report(const bool forReplay/*=true*/) {
+    report_heading(forReplay, PSTR(STR_HYBRID_THRESHOLD));
+
+    auto say_M913 = [](const bool forReplay) {
+      report_echo_start(forReplay);
+      SERIAL_ECHOPGM("  M913");
+    };
+
+    #if X_HAS_STEALTHCHOP || Y_HAS_STEALTHCHOP || Z_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      #if X_HAS_STEALTHCHOP
+        SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.get_pwm_thrs());
+      #endif
+      #if Y_HAS_STEALTHCHOP
+        SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.get_pwm_thrs());
+      #endif
+      #if Z_HAS_STEALTHCHOP
+        SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.get_pwm_thrs());
+      #endif
+      SERIAL_EOL();
+    #endif
+
+    #if X2_HAS_STEALTHCHOP || Y2_HAS_STEALTHCHOP || Z2_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOPGM(" I1");
+      #if X2_HAS_STEALTHCHOP
+        SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.get_pwm_thrs());
+      #endif
+      #if Y2_HAS_STEALTHCHOP
+        SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.get_pwm_thrs());
+      #endif
+      #if Z2_HAS_STEALTHCHOP
+        SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.get_pwm_thrs());
+      #endif
+      SERIAL_EOL();
+    #endif
+
+    #if Z3_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.get_pwm_thrs());
+    #endif
+
+    #if Z4_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.get_pwm_thrs());
+    #endif
+
+    #if I_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.get_pwm_thrs());
+    #endif
+    #if J_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.get_pwm_thrs());
+    #endif
+    #if K_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.get_pwm_thrs());
+    #endif
+
+    #if E0_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" T0 E", stepperE0.get_pwm_thrs());
+    #endif
+    #if E1_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" T1 E", stepperE1.get_pwm_thrs());
+    #endif
+    #if E2_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" T2 E", stepperE2.get_pwm_thrs());
+    #endif
+    #if E3_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" T3 E", stepperE3.get_pwm_thrs());
+    #endif
+    #if E4_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" T4 E", stepperE4.get_pwm_thrs());
+    #endif
+    #if E5_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" T5 E", stepperE5.get_pwm_thrs());
+    #endif
+    #if E6_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" T6 E", stepperE6.get_pwm_thrs());
+    #endif
+    #if E7_HAS_STEALTHCHOP
+      say_M913(forReplay);
+      SERIAL_ECHOLNPAIR(" T7 E", stepperE7.get_pwm_thrs());
+    #endif
+    SERIAL_EOL();
+  }
+
 #endif // HYBRID_THRESHOLD
 
 /**
  * M914: Set StallGuard sensitivity.
  */
 #if USE_SENSORLESS
+
   void GcodeSuite::M914() {
 
     bool report = true;
@@ -412,6 +510,68 @@
       #endif
     }
   }
+
+  void GcodeSuite::M914_report(const bool forReplay/*=true*/) {
+    report_heading(forReplay, PSTR(STR_STALLGUARD_THRESHOLD));
+
+    auto say_M914 = [](const bool forReplay) {
+      report_echo_start(forReplay);
+      SERIAL_ECHOPGM("  M914");
+    };
+
+    #if X_SENSORLESS || Y_SENSORLESS || Z_SENSORLESS
+      say_M914(forReplay);
+      #if X_SENSORLESS
+        SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.homing_threshold());
+      #endif
+      #if Y_SENSORLESS
+        SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.homing_threshold());
+      #endif
+      #if Z_SENSORLESS
+        SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.homing_threshold());
+      #endif
+      SERIAL_EOL();
+    #endif
+
+    #if X2_SENSORLESS || Y2_SENSORLESS || Z2_SENSORLESS
+      say_M914(forReplay);
+      SERIAL_ECHOPGM(" I1");
+      #if X2_SENSORLESS
+        SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.homing_threshold());
+      #endif
+      #if Y2_SENSORLESS
+        SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.homing_threshold());
+      #endif
+      #if Z2_SENSORLESS
+        SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.homing_threshold());
+      #endif
+      SERIAL_EOL();
+    #endif
+
+    #if Z3_SENSORLESS
+      say_M914(forReplay);
+      SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.homing_threshold());
+    #endif
+
+    #if Z4_SENSORLESS
+      say_M914(forReplay);
+      SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.homing_threshold());
+    #endif
+
+    #if I_SENSORLESS
+      say_M914(forReplay);
+      SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.homing_threshold());
+    #endif
+    #if J_SENSORLESS
+      say_M914(forReplay);
+      SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.homing_threshold());
+    #endif
+    #if K_SENSORLESS
+      say_M914(forReplay);
+      SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.homing_threshold());
+    #endif
+  }
+
 #endif // USE_SENSORLESS
 
 #endif // HAS_TRINAMIC_CONFIG

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -321,13 +321,13 @@
     #if X_HAS_STEALTHCHOP || Y_HAS_STEALTHCHOP || Z_HAS_STEALTHCHOP
       say_M913(forReplay);
       #if X_HAS_STEALTHCHOP
-        SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.get_pwm_thrs());
+        SERIAL_ECHOPGM_P(SP_X_STR, stepperX.get_pwm_thrs());
       #endif
       #if Y_HAS_STEALTHCHOP
-        SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.get_pwm_thrs());
+        SERIAL_ECHOPGM_P(SP_Y_STR, stepperY.get_pwm_thrs());
       #endif
       #if Z_HAS_STEALTHCHOP
-        SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.get_pwm_thrs());
+        SERIAL_ECHOPGM_P(SP_Z_STR, stepperZ.get_pwm_thrs());
       #endif
       SERIAL_EOL();
     #endif
@@ -336,71 +336,71 @@
       say_M913(forReplay);
       SERIAL_ECHOPGM(" I1");
       #if X2_HAS_STEALTHCHOP
-        SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.get_pwm_thrs());
+        SERIAL_ECHOPGM_P(SP_X_STR, stepperX2.get_pwm_thrs());
       #endif
       #if Y2_HAS_STEALTHCHOP
-        SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.get_pwm_thrs());
+        SERIAL_ECHOPGM_P(SP_Y_STR, stepperY2.get_pwm_thrs());
       #endif
       #if Z2_HAS_STEALTHCHOP
-        SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.get_pwm_thrs());
+        SERIAL_ECHOPGM_P(SP_Z_STR, stepperZ2.get_pwm_thrs());
       #endif
       SERIAL_EOL();
     #endif
 
     #if Z3_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" I2 Z", stepperZ3.get_pwm_thrs());
     #endif
 
     #if Z4_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" I3 Z", stepperZ4.get_pwm_thrs());
     #endif
 
     #if I_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.get_pwm_thrs());
+      SERIAL_ECHOLNPGM_P(SP_I_STR, stepperI.get_pwm_thrs());
     #endif
     #if J_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.get_pwm_thrs());
+      SERIAL_ECHOLNPGM_P(SP_J_STR, stepperJ.get_pwm_thrs());
     #endif
     #if K_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.get_pwm_thrs());
+      SERIAL_ECHOLNPGM_P(SP_K_STR, stepperK.get_pwm_thrs());
     #endif
 
     #if E0_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" T0 E", stepperE0.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" T0 E", stepperE0.get_pwm_thrs());
     #endif
     #if E1_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" T1 E", stepperE1.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" T1 E", stepperE1.get_pwm_thrs());
     #endif
     #if E2_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" T2 E", stepperE2.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" T2 E", stepperE2.get_pwm_thrs());
     #endif
     #if E3_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" T3 E", stepperE3.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" T3 E", stepperE3.get_pwm_thrs());
     #endif
     #if E4_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" T4 E", stepperE4.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" T4 E", stepperE4.get_pwm_thrs());
     #endif
     #if E5_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" T5 E", stepperE5.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" T5 E", stepperE5.get_pwm_thrs());
     #endif
     #if E6_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" T6 E", stepperE6.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" T6 E", stepperE6.get_pwm_thrs());
     #endif
     #if E7_HAS_STEALTHCHOP
       say_M913(forReplay);
-      SERIAL_ECHOLNPAIR(" T7 E", stepperE7.get_pwm_thrs());
+      SERIAL_ECHOLNPGM(" T7 E", stepperE7.get_pwm_thrs());
     #endif
     SERIAL_EOL();
   }
@@ -522,13 +522,13 @@
     #if X_SENSORLESS || Y_SENSORLESS || Z_SENSORLESS
       say_M914(forReplay);
       #if X_SENSORLESS
-        SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.homing_threshold());
+        SERIAL_ECHOPGM_P(SP_X_STR, stepperX.homing_threshold());
       #endif
       #if Y_SENSORLESS
-        SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.homing_threshold());
+        SERIAL_ECHOPGM_P(SP_Y_STR, stepperY.homing_threshold());
       #endif
       #if Z_SENSORLESS
-        SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.homing_threshold());
+        SERIAL_ECHOPGM_P(SP_Z_STR, stepperZ.homing_threshold());
       #endif
       SERIAL_EOL();
     #endif
@@ -537,38 +537,38 @@
       say_M914(forReplay);
       SERIAL_ECHOPGM(" I1");
       #if X2_SENSORLESS
-        SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.homing_threshold());
+        SERIAL_ECHOPGM_P(SP_X_STR, stepperX2.homing_threshold());
       #endif
       #if Y2_SENSORLESS
-        SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.homing_threshold());
+        SERIAL_ECHOPGM_P(SP_Y_STR, stepperY2.homing_threshold());
       #endif
       #if Z2_SENSORLESS
-        SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.homing_threshold());
+        SERIAL_ECHOPGM_P(SP_Z_STR, stepperZ2.homing_threshold());
       #endif
       SERIAL_EOL();
     #endif
 
     #if Z3_SENSORLESS
       say_M914(forReplay);
-      SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.homing_threshold());
+      SERIAL_ECHOLNPGM(" I2 Z", stepperZ3.homing_threshold());
     #endif
 
     #if Z4_SENSORLESS
       say_M914(forReplay);
-      SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.homing_threshold());
+      SERIAL_ECHOLNPGM(" I3 Z", stepperZ4.homing_threshold());
     #endif
 
     #if I_SENSORLESS
       say_M914(forReplay);
-      SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.homing_threshold());
+      SERIAL_ECHOLNPGM_P(SP_I_STR, stepperI.homing_threshold());
     #endif
     #if J_SENSORLESS
       say_M914(forReplay);
-      SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.homing_threshold());
+      SERIAL_ECHOLNPGM_P(SP_J_STR, stepperJ.homing_threshold());
     #endif
     #if K_SENSORLESS
       say_M914(forReplay);
-      SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.homing_threshold());
+      SERIAL_ECHOLNPGM_P(SP_K_STR, stepperK.homing_threshold());
     #endif
   }
 

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -102,6 +102,24 @@ uint8_t GcodeSuite::axis_relative = 0 LOGICAL_AXIS_GANG(
   xyz_pos_t GcodeSuite::coordinate_system[MAX_COORDINATE_SYSTEMS];
 #endif
 
+void GcodeSuite::report_echo_start(const bool forReplay) { if (!forReplay) SERIAL_ECHO_START(); }
+void GcodeSuite::report_heading(const bool forReplay, PGM_P const pstr, const bool eol/*=true*/) {
+  if (forReplay) return;
+  if (pstr) {
+    SERIAL_ECHO_START();
+    SERIAL_ECHOPGM("; ");
+    SERIAL_ECHOPGM_P(pstr);
+  }
+  if (eol) { SERIAL_CHAR(':'); SERIAL_EOL(); }
+}
+
+void GcodeSuite::say_units() {
+  SERIAL_ECHOLNPGM_P(
+    TERN_(INCH_MODE_SUPPORT, parser.linear_unit_factor != 1.0 ? PSTR(" (in)") :)
+    PSTR(" (mm)")
+  );
+}
+
 /**
  * Get the target extruder from the T parameter or the active_extruder
  * Return -1 if the T parameter is out of range
@@ -180,7 +198,7 @@ void GcodeSuite::get_destination_from_command() {
       recovery.save();
   #endif
 
-  if (parser.linearval('F') > 0)
+  if (parser.floatval('F') > 0)
     feedrate_mm_s = parser.value_feedrate();
 
   #if ENABLED(PRINTCOUNTER)

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -130,7 +130,7 @@ int8_t GcodeSuite::get_target_extruder_from_command() {
     if (e < EXTRUDERS) return e;
     SERIAL_ECHO_START();
     SERIAL_CHAR('M'); SERIAL_ECHO(parser.codenum);
-    SERIAL_ECHOLNPAIR(" " STR_INVALID_EXTRUDER " ", e);
+    SERIAL_ECHOLNPGM(" " STR_INVALID_EXTRUDER " ", e);
     return -1;
   }
   return active_extruder;
@@ -149,7 +149,7 @@ int8_t GcodeSuite::get_target_e_stepper_from_command() {
   if (e == -1)
     SERIAL_ECHOLNPGM(" " STR_E_STEPPER_NOT_SPECIFIED);
   else
-    SERIAL_ECHOLNPAIR(" " STR_INVALID_E_STEPPER " ", e);
+    SERIAL_ECHOLNPGM(" " STR_INVALID_E_STEPPER " ", e);
   return -1;
 }
 
@@ -1082,7 +1082,7 @@ void GcodeSuite::process_next_command() {
     SERIAL_ECHO_START();
     SERIAL_ECHOLN(command.buffer);
     #if ENABLED(M100_FREE_MEMORY_DUMPER)
-      SERIAL_ECHOPAIR("slot:", queue.ring_buffer.index_r);
+      SERIAL_ECHOPGM("slot:", queue.ring_buffer.index_r);
       M100_dump_routine(PSTR("   Command Queue:"), (const char*)&queue.ring_buffer, sizeof(queue.ring_buffer));
     #endif
   }

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -383,6 +383,14 @@ public:
     return ELAPSED(ms, previous_move_ms + stepper_inactive_time);
   }
 
+  static void report_echo_start(const bool forReplay);
+  static void report_heading(const bool forReplay, PGM_P const pstr, const bool eol=true);
+  static inline void report_heading_etc(const bool forReplay, PGM_P const pstr, const bool eol=true) {
+    report_heading(forReplay, pstr, eol);
+    report_echo_start(forReplay);
+  }
+  static void say_units();
+
   static int8_t get_target_extruder_from_command();
   static int8_t get_target_e_stepper_from_command();
   static void get_destination_from_command();
@@ -437,6 +445,8 @@ public:
   static void dwell(millis_t time);
 
 private:
+
+  friend class MarlinSettings;
 
   #if ENABLED(MARLIN_DEV_MODE)
     static void D(const int16_t dcode);
@@ -518,6 +528,7 @@ private:
 
   #if ENABLED(Z_STEPPER_AUTO_ALIGN)
     static void M422();
+    static void M422_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(ASSISTED_TRAMMING)
@@ -662,6 +673,7 @@ private:
 
   static void M85();
   static void M92();
+  static void M92_report(const bool forReplay=true, const int8_t e=-1);
 
   #if ENABLED(M100_FREE_MEMORY_WATCHER)
     static void M100();
@@ -741,10 +753,12 @@ private:
 
   #if PREHEAT_COUNT
     static void M145();
+    static void M145_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
     static void M149();
+    static void M149_report(const bool forReplay=true);
   #endif
 
   #if HAS_COLOR_LEDS
@@ -770,37 +784,51 @@ private:
     #endif
   #endif
 
-  static void M200();
+  #if DISABLED(NO_VOLUMETRICS)
+    static void M200();
+    static void M200_report(const bool forReplay=true);
+  #endif
   static void M201();
+  static void M201_report(const bool forReplay=true);
 
   #if 0
     static void M202(); // Not used for Sprinter/grbl gen6
   #endif
 
   static void M203();
+  static void M203_report(const bool forReplay=true);
   static void M204();
+  static void M204_report(const bool forReplay=true);
   static void M205();
+  static void M205_report(const bool forReplay=true);
 
   #if HAS_M206_COMMAND
     static void M206();
+    static void M206_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(FWRETRACT)
     static void M207();
+    static void M207_report(const bool forReplay=true);
     static void M208();
+    static void M208_report(const bool forReplay=true);
     #if ENABLED(FWRETRACT_AUTORETRACT)
       static void M209();
+      static void M209_report(const bool forReplay=true);
     #endif
   #endif
 
   static void M211();
+  static void M211_report(const bool forReplay=true);
 
   #if HAS_MULTI_EXTRUDER
     static void M217();
+    static void M217_report(const bool forReplay=true);
   #endif
 
   #if HAS_HOTEND_OFFSET
     static void M218();
+    static void M218_report(const bool forReplay=true);
   #endif
 
   static void M220();
@@ -819,10 +847,12 @@ private:
 
   #if HAS_LCD_CONTRAST
     static void M250();
+    static void M250_report(const bool forReplay=true);
   #endif
 
   #if HAS_LCD_BRIGHTNESS
     static void M256();
+    static void M256_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(EXPERIMENTAL_I2CBUS)
@@ -834,6 +864,7 @@ private:
     static void M280();
     #if ENABLED(EDITABLE_SERVO_ANGLES)
       static void M281();
+      static void M281_report(const bool forReplay=true);
     #endif
   #endif
 
@@ -847,6 +878,7 @@ private:
 
   #if ENABLED(PIDTEMP)
     static void M301();
+    static void M301_report(const bool forReplay=true, const int8_t eindex=-1);
   #endif
 
   #if ENABLED(PREVENT_COLD_EXTRUSION)
@@ -859,6 +891,7 @@ private:
 
   #if ENABLED(PIDTEMPBED)
     static void M304();
+    static void M304_report(const bool forReplay=true);
   #endif
 
   #if HAS_USER_THERMISTORS
@@ -867,6 +900,7 @@ private:
 
   #if ENABLED(PIDTEMPCHAMBER)
     static void M309();
+    static void M309_report(const bool forReplay=true);
   #endif
 
   #if HAS_MICROSTEPS
@@ -915,19 +949,23 @@ private:
 
   #if HAS_FILAMENT_SENSOR
     static void M412();
+    static void M412_report(const bool forReplay=true);
   #endif
 
   #if HAS_MULTI_LANGUAGE
     static void M414();
+    static void M414_report(const bool forReplay=true);
   #endif
 
   #if HAS_LEVELING
     static void M420();
+    static void M420_report(const bool forReplay=true);
     static void M421();
   #endif
 
   #if ENABLED(BACKLASH_GCODE)
     static void M425();
+    static void M425_report(const bool forReplay=true);
   #endif
 
   #if HAS_M206_COMMAND
@@ -972,8 +1010,16 @@ private:
 
   #if HAS_ETHERNET
     static void M552();
+    static void M552_report();
     static void M553();
+    static void M553_report();
     static void M554();
+    static void M554_report();
+  #endif
+
+  #if HAS_STEALTHCHOP
+    static void M569();
+    static void M569_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(BAUD_RATE_GCODE)
@@ -983,6 +1029,7 @@ private:
   #if ENABLED(ADVANCED_PAUSE_FEATURE)
     static void M600();
     static void M603();
+    static void M603_report(const bool forReplay=true);
   #endif
 
   #if HAS_DUPLICATION_MODE
@@ -991,10 +1038,12 @@ private:
 
   #if IS_KINEMATIC
     static void M665();
+    static void M665_report(const bool forReplay=true);
   #endif
 
-  #if ENABLED(DELTA) || HAS_EXTRA_ENDSTOPS
+  #if EITHER(DELTA, HAS_EXTRA_ENDSTOPS)
     static void M666();
+    static void M666_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(DUET_SMART_EFFECTOR) && PIN_EXISTS(SMART_EFFECTOR_MOD)
@@ -1016,10 +1065,12 @@ private:
 
   #if HAS_BED_PROBE
     static void M851();
+    static void M851_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(SKEW_CORRECTION_GCODE)
     static void M852();
+    static void M852_report(const bool forReplay=true);
   #endif
 
   #if ENABLED(I2C_POSITION_ENCODERS)
@@ -1042,23 +1093,24 @@ private:
 
   #if ENABLED(LIN_ADVANCE)
     static void M900();
+    static void M900_report(const bool forReplay=true);
   #endif
 
   #if HAS_TRINAMIC_CONFIG
     static void M122();
     static void M906();
-    #if HAS_STEALTHCHOP
-      static void M569();
-    #endif
+    static void M906_report(const bool forReplay=true);
     #if ENABLED(MONITOR_DRIVER_STATUS)
       static void M911();
       static void M912();
     #endif
     #if ENABLED(HYBRID_THRESHOLD)
       static void M913();
+      static void M913_report(const bool forReplay=true);
     #endif
     #if ENABLED(USE_SENSORLESS)
       static void M914();
+      static void M914_report(const bool forReplay=true);
     #endif
   #endif
 
@@ -1070,15 +1122,18 @@ private:
     static void M918();
   #endif
 
-  #if ANY(HAS_MOTOR_CURRENT_SPI, HAS_MOTOR_CURRENT_PWM, HAS_MOTOR_CURRENT_I2C, HAS_MOTOR_CURRENT_DAC)
+  #if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM || HAS_MOTOR_CURRENT_I2C || HAS_MOTOR_CURRENT_DAC
     static void M907();
-    #if EITHER(HAS_MOTOR_CURRENT_SPI, HAS_MOTOR_CURRENT_DAC)
-      static void M908();
-      #if HAS_MOTOR_CURRENT_DAC
-        static void M909();
-        static void M910();
-      #endif
+    #if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM
+      static void M907_report(const bool forReplay=true);
     #endif
+  #endif
+  #if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_DAC
+    static void M908();
+  #endif
+  #if HAS_MOTOR_CURRENT_DAC
+    static void M909();
+    static void M910();
   #endif
 
   #if ENABLED(SDSUPPORT)
@@ -1106,6 +1161,7 @@ private:
 
   #if ENABLED(POWER_LOSS_RECOVERY)
     static void M413();
+    static void M413_report(const bool forReplay=true);
     static void M1000();
   #endif
 
@@ -1127,6 +1183,7 @@ private:
 
   #if ENABLED(CONTROLLER_FAN_EDITABLE)
     static void M710();
+    static void M710_report(const bool forReplay=true);
   #endif
 
   static void T(const int8_t tool_index);

--- a/Marlin/src/gcode/gcode_d.cpp
+++ b/Marlin/src/gcode/gcode_d.cpp
@@ -179,7 +179,7 @@ void GcodeSuite::D(const int16_t dcode) {
       break;
 
     case 7: // D7 dump the current serial port type (hence configuration)
-      SERIAL_ECHOLNPAIR("Current serial configuration RX_BS:", RX_BUFFER_SIZE, ", TX_BS:", TX_BUFFER_SIZE);
+      SERIAL_ECHOLNPGM("Current serial configuration RX_BS:", RX_BUFFER_SIZE, ", TX_BS:", TX_BUFFER_SIZE);
       SERIAL_ECHOLN(gtn(&SERIAL_IMPL));
       break;
 
@@ -202,7 +202,7 @@ void GcodeSuite::D(const int16_t dcode) {
       case 101: { // D101 Test SD Write
         card.openFileWrite("test.gco");
         if (!card.isFileOpen()) {
-          SERIAL_ECHOLNPAIR("Failed to open test.gco to write.");
+          SERIAL_ECHOLNPGM("Failed to open test.gco to write.");
           return;
         }
         __attribute__((aligned(sizeof(size_t)))) uint8_t buf[512];
@@ -224,7 +224,7 @@ void GcodeSuite::D(const int16_t dcode) {
         char testfile[] = "test.gco";
         card.openFileRead(testfile);
         if (!card.isFileOpen()) {
-          SERIAL_ECHOLNPAIR("Failed to open test.gco to read.");
+          SERIAL_ECHOLNPGM("Failed to open test.gco to read.");
           return;
         }
         __attribute__((aligned(sizeof(size_t)))) uint8_t buf[512];

--- a/Marlin/src/gcode/geometry/G53-G59.cpp
+++ b/Marlin/src/gcode/geometry/G53-G59.cpp
@@ -69,7 +69,7 @@ void GcodeSuite::G53() {
     process_parsed_command(); // ...process the chained command
     select_coordinate_system(old_system);
     #ifdef DEBUG_M53
-      SERIAL_ECHOLNPAIR("Go back to workspace ", old_system);
+      SERIAL_ECHOLNPGM("Go back to workspace ", old_system);
       report_current_position();
     #endif
   }
@@ -87,7 +87,7 @@ void GcodeSuite::G53() {
 void G54_59(uint8_t subcode=0) {
   const int8_t _space = parser.codenum - 54 + subcode;
   if (gcode.select_coordinate_system(_space)) {
-    SERIAL_ECHOLNPAIR("Select workspace ", _space);
+    SERIAL_ECHOLNPGM("Select workspace ", _space);
     report_current_position();
   }
 }

--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -54,7 +54,7 @@ void GcodeSuite::M206() {
 
 void GcodeSuite::M206_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_HOME_OFFSET));
-  SERIAL_ECHOLNPAIR_P(
+  SERIAL_ECHOLNPGM_P(
     #if IS_CARTESIAN
       LIST_N(DOUBLE(LINEAR_AXES),
         PSTR("  M206 X"), LINEAR_UNIT(home_offset.x),

--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -30,19 +30,6 @@
 #include "../../libs/buzzer.h"
 #include "../../MarlinCore.h"
 
-void M206_report() {
-  SERIAL_ECHOLNPAIR_P(
-    LIST_N(DOUBLE(LINEAR_AXES),
-      PSTR("M206 X"), home_offset.x,
-      SP_Y_STR, home_offset.y,
-      SP_Z_STR, home_offset.z,
-      SP_I_STR, home_offset.i,
-      SP_J_STR, home_offset.j,
-      SP_K_STR, home_offset.k,
-    )
-  );
-}
-
 /**
  * M206: Set Additional Homing Offset (X Y Z). SCARA aliases T=X, P=Y
  *
@@ -51,6 +38,8 @@ void M206_report() {
  * ***              In the 2.0 release, it will simply be disabled by default.
  */
 void GcodeSuite::M206() {
+  if (!parser.seen_any()) return M206_report();
+
   LOOP_LINEAR_AXES(i)
     if (parser.seen(AXIS_CHAR(i)))
       set_home_offset((AxisEnum)i, parser.value_linear_units());
@@ -60,10 +49,25 @@ void GcodeSuite::M206() {
     if (parser.seen('P')) set_home_offset(B_AXIS, parser.value_float()); // Psi
   #endif
 
-  if (!parser.seen(LINEAR_AXIS_GANG("X", "Y", "Z", "I", "J", "K")))
-    M206_report();
-  else
-    report_current_position();
+  report_current_position();
+}
+
+void GcodeSuite::M206_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_HOME_OFFSET));
+  SERIAL_ECHOLNPAIR_P(
+    #if IS_CARTESIAN
+      LIST_N(DOUBLE(LINEAR_AXES),
+        PSTR("  M206 X"), LINEAR_UNIT(home_offset.x),
+        SP_Y_STR, LINEAR_UNIT(home_offset.y),
+        SP_Z_STR, LINEAR_UNIT(home_offset.z),
+        SP_I_STR, LINEAR_UNIT(home_offset.i),
+        SP_J_STR, LINEAR_UNIT(home_offset.j),
+        SP_K_STR, LINEAR_UNIT(home_offset.k)
+      )
+    #else
+      PSTR("  M206 Z"), LINEAR_UNIT(home_offset.z)
+    #endif
+  );
 }
 
 /**

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -218,7 +218,7 @@ void GcodeSuite::M114() {
     }
     #if HAS_EXTRUDERS
       if (parser.seen_test('E')) {
-        SERIAL_ECHOLNPAIR("Count E:", stepper.position(E_AXIS));
+        SERIAL_ECHOLNPGM("Count E:", stepper.position(E_AXIS));
         return;
       }
     #endif

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -175,7 +175,7 @@ void GcodeSuite::M115() {
       apply_motion_limits(cmax);
       const xyz_pos_t lmin = dmin.asLogical(), lmax = dmax.asLogical(),
                       wmin = cmin.asLogical(), wmax = cmax.asLogical();
-      SERIAL_ECHOLNPAIR(
+      SERIAL_ECHOLNPGM(
         "area:{"
           "full:{"
             "min:{x:", lmin.x, ",y:", lmin.y, ",z:", lmin.z, "},"

--- a/Marlin/src/gcode/host/M360.cpp
+++ b/Marlin/src/gcode/host/M360.cpp
@@ -36,7 +36,7 @@ static void config_prefix(PGM_P const name, PGM_P const pref=nullptr, const int8
   SERIAL_ECHOPGM("Config:");
   if (pref) SERIAL_ECHOPGM_P(pref);
   if (ind >= 0) { SERIAL_ECHO(ind); SERIAL_CHAR(':'); }
-  SERIAL_ECHOPAIR_P(name, AS_CHAR(':'));
+  SERIAL_ECHOPGM_P(name, AS_CHAR(':'));
 }
 static void config_line(PGM_P const name, const float val, PGM_P const pref=nullptr, const int8_t ind=-1) {
   config_prefix(name, pref, ind);

--- a/Marlin/src/gcode/lcd/M145.cpp
+++ b/Marlin/src/gcode/lcd/M145.cpp
@@ -60,4 +60,23 @@ void GcodeSuite::M145() {
   }
 }
 
+void GcodeSuite::M145_report(const bool forReplay/*=true*/) {
+  report_heading(forReplay, PSTR(STR_MATERIAL_HEATUP));
+  LOOP_L_N(i, PREHEAT_COUNT) {
+    report_echo_start(forReplay);
+    SERIAL_ECHOLNPAIR_P(
+      PSTR("  M145 S"), i
+      #if HAS_HOTEND
+        , PSTR(" H"), parser.to_temp_units(ui.material_preset[i].hotend_temp)
+      #endif
+      #if HAS_HEATED_BED
+        , SP_B_STR, parser.to_temp_units(ui.material_preset[i].bed_temp)
+      #endif
+      #if HAS_FAN
+        , PSTR(" F"), ui.material_preset[i].fan_speed
+      #endif
+    );
+  }
+}
+
 #endif // PREHEAT_COUNT

--- a/Marlin/src/gcode/lcd/M145.cpp
+++ b/Marlin/src/gcode/lcd/M145.cpp
@@ -64,7 +64,7 @@ void GcodeSuite::M145_report(const bool forReplay/*=true*/) {
   report_heading(forReplay, PSTR(STR_MATERIAL_HEATUP));
   LOOP_L_N(i, PREHEAT_COUNT) {
     report_echo_start(forReplay);
-    SERIAL_ECHOLNPAIR_P(
+    SERIAL_ECHOLNPGM_P(
       PSTR("  M145 S"), i
       #if HAS_HOTEND
         , PSTR(" H"), parser.to_temp_units(ui.material_preset[i].hotend_temp)

--- a/Marlin/src/gcode/lcd/M250.cpp
+++ b/Marlin/src/gcode/lcd/M250.cpp
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-
 #include "../../inc/MarlinConfig.h"
 
 #if HAS_LCD_CONTRAST
@@ -31,8 +30,15 @@
  * M250: Read and optionally set the LCD contrast
  */
 void GcodeSuite::M250() {
-  if (parser.seen('C')) ui.set_contrast(parser.value_int());
-  SERIAL_ECHOLNPAIR("LCD Contrast: ", ui.contrast);
+  if (parser.seenval('C'))
+    ui.set_contrast(parser.value_int());
+  else
+    M250_report();
+}
+
+void GcodeSuite::M250_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_LCD_CONTRAST));
+  SERIAL_ECHOLNPAIR("  M250 C", ui.contrast);
 }
 
 #endif // HAS_LCD_CONTRAST

--- a/Marlin/src/gcode/lcd/M250.cpp
+++ b/Marlin/src/gcode/lcd/M250.cpp
@@ -38,7 +38,7 @@ void GcodeSuite::M250() {
 
 void GcodeSuite::M250_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_LCD_CONTRAST));
-  SERIAL_ECHOLNPAIR("  M250 C", ui.contrast);
+  SERIAL_ECHOLNPGM("  M250 C", ui.contrast);
 }
 
 #endif // HAS_LCD_CONTRAST

--- a/Marlin/src/gcode/lcd/M256.cpp
+++ b/Marlin/src/gcode/lcd/M256.cpp
@@ -30,8 +30,15 @@
  * M256: Set the LCD brightness
  */
 void GcodeSuite::M256() {
-  if (parser.seenval('B')) ui.set_brightness(parser.value_int());
-  SERIAL_ECHOLNPAIR("LCD Brightness: ", ui.brightness);
+  if (parser.seenval('B'))
+    ui.set_brightness(parser.value_int());
+  else
+    M256_report();
+}
+
+void GcodeSuite::M256_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_LCD_BRIGHTNESS));
+  SERIAL_ECHOLNPAIR("  M256 B", ui.brightness);
 }
 
 #endif // HAS_LCD_BRIGHTNESS

--- a/Marlin/src/gcode/lcd/M256.cpp
+++ b/Marlin/src/gcode/lcd/M256.cpp
@@ -38,7 +38,7 @@ void GcodeSuite::M256() {
 
 void GcodeSuite::M256_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_LCD_BRIGHTNESS));
-  SERIAL_ECHOLNPAIR("  M256 B", ui.brightness);
+  SERIAL_ECHOLNPGM("  M256 B", ui.brightness);
 }
 
 #endif // HAS_LCD_BRIGHTNESS

--- a/Marlin/src/gcode/lcd/M414.cpp
+++ b/Marlin/src/gcode/lcd/M414.cpp
@@ -38,7 +38,14 @@ void GcodeSuite::M414() {
 
   if (parser.seenval('S'))
     ui.set_language(parser.value_byte());
+  else
+    M414_report();
 
+}
+
+void GcodeSuite::M414_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_UI_LANGUAGE));
+  SERIAL_ECHOLNPAIR("  M414 S", ui.language);
 }
 
 #endif // HAS_MULTI_LANGUAGE

--- a/Marlin/src/gcode/lcd/M414.cpp
+++ b/Marlin/src/gcode/lcd/M414.cpp
@@ -45,7 +45,7 @@ void GcodeSuite::M414() {
 
 void GcodeSuite::M414_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_UI_LANGUAGE));
-  SERIAL_ECHOLNPAIR("  M414 S", ui.language);
+  SERIAL_ECHOLNPGM("  M414 S", ui.language);
 }
 
 #endif // HAS_MULTI_LANGUAGE

--- a/Marlin/src/gcode/motion/M290.cpp
+++ b/Marlin/src/gcode/motion/M290.cpp
@@ -91,12 +91,12 @@ void GcodeSuite::M290() {
     SERIAL_ECHO_START();
 
     #if ENABLED(BABYSTEP_ZPROBE_OFFSET)
-      SERIAL_ECHOLNPAIR(STR_PROBE_OFFSET " " STR_Z, probe.offset.z);
+      SERIAL_ECHOLNPGM(STR_PROBE_OFFSET " " STR_Z, probe.offset.z);
     #endif
 
     #if ENABLED(BABYSTEP_HOTEND_Z_OFFSET)
     {
-      SERIAL_ECHOLNPAIR_P(
+      SERIAL_ECHOLNPGM_P(
         PSTR("Hotend "), active_extruder
         #if ENABLED(BABYSTEP_XY)
           , PSTR("Offset X"), hotend_offset[active_extruder].x
@@ -111,12 +111,12 @@ void GcodeSuite::M290() {
     #endif
 
     #if ENABLED(MESH_BED_LEVELING)
-      SERIAL_ECHOLNPAIR("MBL Adjust Z", mbl.z_offset);
+      SERIAL_ECHOLNPGM("MBL Adjust Z", mbl.z_offset);
     #endif
 
     #if ENABLED(BABYSTEP_DISPLAY_TOTAL)
     {
-      SERIAL_ECHOLNPAIR_P(
+      SERIAL_ECHOLNPGM_P(
         #if ENABLED(BABYSTEP_XY)
             PSTR("Babystep X"), babystep.axis_total[X_AXIS]
           , SP_Y_STR, babystep.axis_total[Y_AXIS]

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -333,7 +333,7 @@ void GCodeParser::parse(char *p) {
 
       #if ENABLED(DEBUG_GCODE_PARSER)
         if (debug) {
-          SERIAL_ECHOPAIR("Got param ", AS_CHAR(param), " at index ", p - command_ptr - 1);
+          SERIAL_ECHOPGM("Got param ", AS_CHAR(param), " at index ", p - command_ptr - 1);
           if (has_val) SERIAL_ECHOPGM(" (has_val)");
         }
       #endif
@@ -341,7 +341,7 @@ void GCodeParser::parse(char *p) {
       if (!has_val && !string_arg) {            // No value? First time, keep as string_arg
         string_arg = p - 1;
         #if ENABLED(DEBUG_GCODE_PARSER)
-          if (debug) SERIAL_ECHOPAIR(" string_arg: ", hex_address((void*)string_arg)); // DEBUG
+          if (debug) SERIAL_ECHOPGM(" string_arg: ", hex_address((void*)string_arg)); // DEBUG
         #endif
       }
 
@@ -352,7 +352,7 @@ void GCodeParser::parse(char *p) {
     else if (!string_arg) {                     // Not A-Z? First time, keep as the string_arg
       string_arg = p - 1;
       #if ENABLED(DEBUG_GCODE_PARSER)
-        if (debug) SERIAL_ECHOPAIR(" string_arg: ", hex_address((void*)string_arg)); // DEBUG
+        if (debug) SERIAL_ECHOPGM(" string_arg: ", hex_address((void*)string_arg)); // DEBUG
       #endif
     }
 
@@ -390,7 +390,7 @@ void GCodeParser::unknown_command_warning() {
 #if ENABLED(DEBUG_GCODE_PARSER)
 
   void GCodeParser::debug() {
-    SERIAL_ECHOPAIR("Command: ", command_ptr, " (", command_letter);
+    SERIAL_ECHOPGM("Command: ", command_ptr, " (", command_letter);
     SERIAL_ECHO(codenum);
     SERIAL_ECHOLNPGM(")");
     #if ENABLED(FASTER_GCODE_PARSER)
@@ -398,18 +398,18 @@ void GCodeParser::unknown_command_warning() {
       for (char c = 'A'; c <= 'Z'; ++c) if (seen(c)) SERIAL_CHAR(c, ' ');
       SERIAL_CHAR('}');
     #else
-      SERIAL_ECHOPAIR(" args: { ", command_args, " }");
+      SERIAL_ECHOPGM(" args: { ", command_args, " }");
     #endif
     if (string_arg) {
-      SERIAL_ECHOPAIR(" string: \"", string_arg);
+      SERIAL_ECHOPGM(" string: \"", string_arg);
       SERIAL_CHAR('"');
     }
     SERIAL_ECHOLNPGM("\n");
     for (char c = 'A'; c <= 'Z'; ++c) {
       if (seen(c)) {
-        SERIAL_ECHOPAIR("Code '", c); SERIAL_ECHOPGM("':");
+        SERIAL_ECHOPGM("Code '", c); SERIAL_ECHOPGM("':");
         if (has_value()) {
-          SERIAL_ECHOLNPAIR(
+          SERIAL_ECHOLNPGM(
             "\n    float: ", value_float(),
             "\n     long: ", value_long(),
             "\n    ulong: ", value_ulong(),

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -225,9 +225,7 @@ public:
   #endif // !FASTER_GCODE_PARSER
 
   // Seen any axis parameter
-  static inline bool seen_axis() {
-    return seen(LOGICAL_AXIS_GANG("E", "X", "Y", "Z", AXIS4_STR, AXIS5_STR, AXIS6_STR));
-  }
+  static inline bool seen_axis() { return seen(LOGICAL_AXES_STRING); }
 
   #if ENABLED(GCODE_QUOTED_STRINGS)
     static char* unescape_string(char* &src);
@@ -350,14 +348,15 @@ public:
 
     static inline void set_input_temp_units(const TempUnit units) { input_temp_units = units; }
 
+    static inline char temp_units_code() {
+      return input_temp_units == TEMPUNIT_K ? 'K' : input_temp_units == TEMPUNIT_F ? 'F' : 'C';
+    }
+    static inline PGM_P temp_units_name() {
+      return input_temp_units == TEMPUNIT_K ? PSTR("Kelvin") : input_temp_units == TEMPUNIT_F ? PSTR("Fahrenheit") : PSTR("Celsius");
+    }
+
     #if HAS_LCD_MENU && DISABLED(DISABLE_M503)
 
-      static inline char temp_units_code() {
-        return input_temp_units == TEMPUNIT_K ? 'K' : input_temp_units == TEMPUNIT_F ? 'F' : 'C';
-      }
-      static inline PGM_P temp_units_name() {
-        return input_temp_units == TEMPUNIT_K ? PSTR("Kelvin") : input_temp_units == TEMPUNIT_F ? PSTR("Fahrenheit") : PSTR("Celsius");
-      }
       static inline float to_temp_units(celsius_t c) {
         switch (input_temp_units) {
           default:

--- a/Marlin/src/gcode/parser.h
+++ b/Marlin/src/gcode/parser.h
@@ -133,9 +133,9 @@ public:
       param[ind] = ptr ? ptr - command_ptr : 0;  // parameter offset or 0
       #if ENABLED(DEBUG_GCODE_PARSER)
         if (codenum == 800) {
-          SERIAL_ECHOPAIR("Set bit ", ind, " of codebits (", hex_address((void*)(codebits >> 16)));
+          SERIAL_ECHOPGM("Set bit ", ind, " of codebits (", hex_address((void*)(codebits >> 16)));
           print_hex_word((uint16_t)(codebits & 0xFFFF));
-          SERIAL_ECHOLNPAIR(") | param = ", param[ind]);
+          SERIAL_ECHOLNPGM(") | param = ", param[ind]);
         }
       #endif
     }

--- a/Marlin/src/gcode/probe/G30.cpp
+++ b/Marlin/src/gcode/probe/G30.cpp
@@ -53,7 +53,7 @@ void GcodeSuite::G30() {
   const ProbePtRaise raise_after = parser.boolval('E', true) ? PROBE_PT_STOW : PROBE_PT_NONE;
   const float measured_z = probe.probe_at_point(pos, raise_after, 1);
   if (!isnan(measured_z))
-    SERIAL_ECHOLNPAIR("Bed X: ", pos.x, " Y: ", pos.y, " Z: ", measured_z);
+    SERIAL_ECHOLNPGM("Bed X: ", pos.x, " Y: ", pos.y, " Z: ", measured_z);
 
   restore_feedrate_and_scaling();
 

--- a/Marlin/src/gcode/probe/M851.cpp
+++ b/Marlin/src/gcode/probe/M851.cpp
@@ -47,11 +47,11 @@ void GcodeSuite::M851() {
       if (WITHIN(x, -(X_BED_SIZE), X_BED_SIZE))
         offs.x = x;
       else {
-        SERIAL_ECHOLNPAIR("?X out of range (-", X_BED_SIZE, " to ", X_BED_SIZE, ")");
+        SERIAL_ECHOLNPGM("?X out of range (-", X_BED_SIZE, " to ", X_BED_SIZE, ")");
         ok = false;
       }
     #else
-      if (x) SERIAL_ECHOLNPAIR("?X must be 0 (NOZZLE_AS_PROBE)."); // ...but let 'ok' stay true
+      if (x) SERIAL_ECHOLNPGM("?X must be 0 (NOZZLE_AS_PROBE)."); // ...but let 'ok' stay true
     #endif
   }
 
@@ -61,11 +61,11 @@ void GcodeSuite::M851() {
       if (WITHIN(y, -(Y_BED_SIZE), Y_BED_SIZE))
         offs.y = y;
       else {
-        SERIAL_ECHOLNPAIR("?Y out of range (-", Y_BED_SIZE, " to ", Y_BED_SIZE, ")");
+        SERIAL_ECHOLNPGM("?Y out of range (-", Y_BED_SIZE, " to ", Y_BED_SIZE, ")");
         ok = false;
       }
     #else
-      if (y) SERIAL_ECHOLNPAIR("?Y must be 0 (NOZZLE_AS_PROBE)."); // ...but let 'ok' stay true
+      if (y) SERIAL_ECHOLNPGM("?Y must be 0 (NOZZLE_AS_PROBE)."); // ...but let 'ok' stay true
     #endif
   }
 
@@ -74,7 +74,7 @@ void GcodeSuite::M851() {
     if (WITHIN(z, Z_PROBE_OFFSET_RANGE_MIN, Z_PROBE_OFFSET_RANGE_MAX))
       offs.z = z;
     else {
-      SERIAL_ECHOLNPAIR("?Z out of range (", Z_PROBE_OFFSET_RANGE_MIN, " to ", Z_PROBE_OFFSET_RANGE_MAX, ")");
+      SERIAL_ECHOLNPGM("?Z out of range (", Z_PROBE_OFFSET_RANGE_MIN, " to ", Z_PROBE_OFFSET_RANGE_MAX, ")");
       ok = false;
     }
   }
@@ -85,7 +85,7 @@ void GcodeSuite::M851() {
 
 void GcodeSuite::M851_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_Z_PROBE_OFFSET));
-  SERIAL_ECHOPAIR_P(
+  SERIAL_ECHOPGM_P(
     #if HAS_PROBE_XY_OFFSET
       PSTR("  M851 X"), LINEAR_UNIT(probe.offset_xy.x),
               SP_Y_STR, LINEAR_UNIT(probe.offset_xy.y),

--- a/Marlin/src/gcode/probe/M851.cpp
+++ b/Marlin/src/gcode/probe/M851.cpp
@@ -32,19 +32,8 @@
  * M851: Set the nozzle-to-probe offsets in current units
  */
 void GcodeSuite::M851() {
-
-  // Show usage with no parameters
-  if (!parser.seen("XYZ")) {
-    SERIAL_ECHOLNPAIR_P(
-      #if HAS_PROBE_XY_OFFSET
-        PSTR(STR_PROBE_OFFSET " X"), probe.offset_xy.x, SP_Y_STR, probe.offset_xy.y, SP_Z_STR
-      #else
-        PSTR(STR_PROBE_OFFSET " X0 Y0 Z")
-      #endif
-      , probe.offset.z
-    );
-    return;
-  }
+  // No parameters? Show current state.
+  if (!parser.seen("XYZ")) return M851_report();
 
   // Start with current offsets and modify
   xyz_pos_t offs = probe.offset;
@@ -92,6 +81,22 @@ void GcodeSuite::M851() {
 
   // Save the new offsets
   if (ok) probe.offset = offs;
+}
+
+void GcodeSuite::M851_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_Z_PROBE_OFFSET));
+  SERIAL_ECHOPAIR_P(
+    #if HAS_PROBE_XY_OFFSET
+      PSTR("  M851 X"), LINEAR_UNIT(probe.offset_xy.x),
+              SP_Y_STR, LINEAR_UNIT(probe.offset_xy.y),
+              SP_Z_STR
+    #else
+      PSTR("  M851 X0 Y0 Z")
+    #endif
+    , LINEAR_UNIT(probe.offset.z)
+    , " ;"
+  );
+  say_units();
 }
 
 #endif // HAS_BED_PROBE

--- a/Marlin/src/gcode/probe/M951.cpp
+++ b/Marlin/src/gcode/probe/M951.cpp
@@ -32,13 +32,13 @@ mpe_settings_t mpe_settings;
 
 inline void mpe_settings_report() {
   SERIAL_ECHO_MSG("Magnetic Parking Extruder");
-  SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("L: Left parking  :", mpe_settings.parking_xpos[0]);
-  SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("R: Right parking :", mpe_settings.parking_xpos[1]);
-  SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("I: Grab Offset   :", mpe_settings.grab_distance);
-  SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("J: Normal speed  :", long(MMS_TO_MMM(mpe_settings.slow_feedrate)));
-  SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("H: High speed    :", long(MMS_TO_MMM(mpe_settings.fast_feedrate)));
-  SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("D: Distance trav.:", mpe_settings.travel_distance);
-  SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("C: Compenstion   :", mpe_settings.compensation_factor);
+  SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("L: Left parking  :", mpe_settings.parking_xpos[0]);
+  SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("R: Right parking :", mpe_settings.parking_xpos[1]);
+  SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("I: Grab Offset   :", mpe_settings.grab_distance);
+  SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("J: Normal speed  :", long(MMS_TO_MMM(mpe_settings.slow_feedrate)));
+  SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("H: High speed    :", long(MMS_TO_MMM(mpe_settings.fast_feedrate)));
+  SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("D: Distance trav.:", mpe_settings.travel_distance);
+  SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("C: Compenstion   :", mpe_settings.compensation_factor);
 }
 
 void mpe_settings_init() {

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -127,7 +127,7 @@ bool GCodeQueue::RingBuffer::enqueue(const char *cmd, bool skip_ok/*=true*/
  * Return true if the command was consumed
  */
 bool GCodeQueue::enqueue_one(const char *cmd) {
-  //SERIAL_ECHOLNPAIR("enqueue_one(\"", cmd, "\")");
+  //SERIAL_ECHOLNPGM("enqueue_one(\"", cmd, "\")");
 
   if (*cmd == 0 || ISEOL(*cmd)) return true;
 
@@ -260,7 +260,7 @@ void GCodeQueue::RingBuffer::ok_to_send() {
       while (NUMERIC_SIGNED(*p))
         SERIAL_CHAR(*p++);
     }
-    SERIAL_ECHOPAIR_P(SP_P_STR, planner.moves_free(),
+    SERIAL_ECHOPGM_P(SP_P_STR, planner.moves_free(),
                       SP_B_STR, BUFSIZE - length);
   #endif
   SERIAL_EOL();
@@ -276,7 +276,7 @@ void GCodeQueue::flush_and_request_resend(const serial_index_t serial_ind) {
     PORT_REDIRECT(SERIAL_PORTMASK(serial_ind));   // Reply to the serial port that sent the command
   #endif
   SERIAL_FLUSH();
-  SERIAL_ECHOLNPAIR(STR_RESEND, serial_state[serial_ind.index].last_N + 1);
+  SERIAL_ECHOLNPGM(STR_RESEND, serial_state[serial_ind.index].last_N + 1);
   SERIAL_ECHOLNPGM(STR_OK);
 }
 
@@ -306,7 +306,7 @@ inline int read_serial(const serial_index_t index) { return SERIAL_IMPL.read(ind
 void GCodeQueue::gcode_line_error(PGM_P const err, const serial_index_t serial_ind) {
   PORT_REDIRECT(SERIAL_PORTMASK(serial_ind)); // Reply to the serial port that sent the command
   SERIAL_ERROR_START();
-  SERIAL_ECHOLNPAIR_P(err, serial_state[serial_ind.index].last_N);
+  SERIAL_ECHOLNPGM_P(err, serial_state[serial_ind.index].last_N);
   while (read_serial(serial_ind) != -1) { /* nada */ } // Clear out the RX buffer. Why don't use flush here ?
   flush_and_request_resend(serial_ind);
   serial_state[serial_ind.index].count = 0;
@@ -659,10 +659,10 @@ void GCodeQueue::advance() {
 
         #if !defined(__AVR__) || !defined(USBCON)
           #if ENABLED(SERIAL_STATS_DROPPED_RX)
-            SERIAL_ECHOLNPAIR("Dropped bytes: ", MYSERIAL1.dropped());
+            SERIAL_ECHOLNPGM("Dropped bytes: ", MYSERIAL1.dropped());
           #endif
           #if ENABLED(SERIAL_STATS_MAX_RX_QUEUED)
-            SERIAL_ECHOLNPAIR("Max RX Queue Size: ", MYSERIAL1.rxMaxEnqueued());
+            SERIAL_ECHOLNPGM("Max RX Queue Size: ", MYSERIAL1.rxMaxEnqueued());
           #endif
         #endif
 
@@ -693,7 +693,7 @@ void GCodeQueue::advance() {
 #if ENABLED(BUFFER_MONITORING)
 
   void GCodeQueue::report_buffer_statistics() {
-    SERIAL_ECHOLNPAIR("D576"
+    SERIAL_ECHOLNPGM("D576"
       " P:", planner.moves_free(),         " ", -queue.planner_buffer_underruns, " (", queue.max_planner_buffer_empty_duration, ")"
       " B:", BUFSIZE - ring_buffer.length, " ", -queue.command_buffer_underruns, " (", queue.max_command_buffer_empty_duration, ")"
     );

--- a/Marlin/src/gcode/units/M149.cpp
+++ b/Marlin/src/gcode/units/M149.cpp
@@ -33,6 +33,13 @@ void GcodeSuite::M149() {
        if (parser.seenval('C')) parser.set_input_temp_units(TEMPUNIT_C);
   else if (parser.seenval('K')) parser.set_input_temp_units(TEMPUNIT_K);
   else if (parser.seenval('F')) parser.set_input_temp_units(TEMPUNIT_F);
+  else M149_report();
+}
+
+void GcodeSuite::M149_report(const bool forReplay/*=true*/) {
+  report_heading_etc(forReplay, PSTR(STR_TEMPERATURE_UNITS));
+  SERIAL_ECHOPAIR("  M149 ", AS_CHAR(parser.temp_units_code()), " ; Units in ");
+  SERIAL_ECHOLNPGM_P(parser.temp_units_name());
 }
 
 #endif // TEMPERATURE_UNITS_SUPPORT

--- a/Marlin/src/gcode/units/M149.cpp
+++ b/Marlin/src/gcode/units/M149.cpp
@@ -38,7 +38,7 @@ void GcodeSuite::M149() {
 
 void GcodeSuite::M149_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_TEMPERATURE_UNITS));
-  SERIAL_ECHOPAIR("  M149 ", AS_CHAR(parser.temp_units_code()), " ; Units in ");
+  SERIAL_ECHOPGM("  M149 ", AS_CHAR(parser.temp_units_code()), " ; Units in ");
   SERIAL_ECHOLNPGM_P(parser.temp_units_name());
 }
 

--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -1923,7 +1923,7 @@ void HMI_SDCardUpdate() {
   if (HMI_flag.home_flag) return;
   if (DWIN_lcd_sd_status != card.isMounted()) {
     DWIN_lcd_sd_status = card.isMounted();
-    //SERIAL_ECHOLNPAIR("HMI_SDCardUpdate: ", DWIN_lcd_sd_status);
+    //SERIAL_ECHOLNPGM("HMI_SDCardUpdate: ", DWIN_lcd_sd_status);
     if (DWIN_lcd_sd_status) {
       if (checkkey == SelectFile)
         Redraw_SD_List();

--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -969,7 +969,7 @@ void HMI_SDCardUpdate() {
   if (HMI_flag.home_flag) return;
   if (DWIN_lcd_sd_status != card.isMounted()) {
     DWIN_lcd_sd_status = card.isMounted();
-    //SERIAL_ECHOLNPAIR("HMI_SDCardUpdate: ", DWIN_lcd_sd_status);
+    //SERIAL_ECHOLNPGM("HMI_SDCardUpdate: ", DWIN_lcd_sd_status);
     if (DWIN_lcd_sd_status) {
       if (checkkey == SelectFile)
         Redraw_SD_List();

--- a/Marlin/src/lcd/extui/anycubic_chiron/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/FileNavigator.cpp
@@ -86,7 +86,7 @@ void FileNavigator::refresh() { filelist.refresh(); }
 
 void FileNavigator::changeDIR(const char *folder) {
   if (currentfolderdepth >= MAX_FOLDER_DEPTH) return; // limit the folder depth
-  DEBUG_ECHOLNPAIR("FD:" , folderdepth, " FP:",currentindex, " currentfolder:", currentfoldername, " enter:", folder);
+  DEBUG_ECHOLNPGM("FD:" , folderdepth, " FP:",currentindex, " currentfolder:", currentfoldername, " enter:", folder);
   currentfolderindex[currentfolderdepth] = currentindex;
   strcat(currentfoldername, folder);
   strcat(currentfoldername, "/");
@@ -96,7 +96,7 @@ void FileNavigator::changeDIR(const char *folder) {
 }
 
 void FileNavigator::upDIR() {
-  DEBUG_ECHOLNPAIR("upDIR() from D:", currentfolderdepth, " N:", currentfoldername);
+  DEBUG_ECHOLNPGM("upDIR() from D:", currentfolderdepth, " N:", currentfoldername);
   if (!filelist.isAtRootDir()) {
     filelist.upDir();
     currentfolderdepth--;
@@ -117,7 +117,7 @@ void FileNavigator::skiptofileindex(uint16_t skip) {
   if (skip == 0) return;
   while (skip > 0) {
     if (filelist.seek(currentindex)) {
-      DEBUG_ECHOLNPAIR("CI:", currentindex, " FD:", currentfolderdepth, " N:", skip, " ", filelist.longFilename());
+      DEBUG_ECHOLNPGM("CI:", currentindex, " FD:", currentfolderdepth, " N:", skip, " ", filelist.longFilename());
       if (!filelist.isDir()) {
         skip--;
         currentindex++;
@@ -151,7 +151,7 @@ void FileNavigator::skiptofileindex(uint16_t skip) {
     }
     lastpanelindex = index;
 
-    DEBUG_ECHOLNPAIR("index=", index, " currentindex=", currentindex);
+    DEBUG_ECHOLNPGM("index=", index, " currentindex=", currentindex);
 
     if (currentindex == 0 && currentfolderdepth > 0) { // Add a link to go up a folder
       // The new panel ignores entries that don't end in .GCO or .gcode so add and pad them.
@@ -169,7 +169,7 @@ void FileNavigator::skiptofileindex(uint16_t skip) {
     for (uint16_t seek = currentindex; seek < currentindex + filesneeded; seek++) {
       if (filelist.seek(seek)) {
         sendFile(paneltype);
-        DEBUG_ECHOLNPAIR("-", seek, " '", filelist.longFilename(), "' '", currentfoldername, "", filelist.shortFilename(), "'");
+        DEBUG_ECHOLNPGM("-", seek, " '", filelist.longFilename(), "' '", currentfoldername, "", filelist.shortFilename(), "'");
       }
     }
   }
@@ -212,7 +212,7 @@ void FileNavigator::skiptofileindex(uint16_t skip) {
 #else // Flat file list
 
   void FileNavigator::getFiles(uint16_t index, panel_type_t paneltype, uint8_t filesneeded) {
-    DEBUG_ECHOLNPAIR("getFiles() I:", index," L:", lastpanelindex);
+    DEBUG_ECHOLNPGM("getFiles() I:", index," L:", lastpanelindex);
     // if we're searching backwards, jump back to start and search forward
     if (index < lastpanelindex) {
       reset();
@@ -248,7 +248,7 @@ void FileNavigator::skiptofileindex(uint16_t skip) {
     TFTSer.println(filelist.shortFilename());
     if (currentfolderdepth > 0) TFTSer.print(currentfoldername);
     TFTSer.println(filelist.longFilename());
-    DEBUG_ECHOLNPAIR("/", currentfoldername, "", filelist.shortFilename(), " ", filelist.longFilename());
+    DEBUG_ECHOLNPGM("/", currentfoldername, "", filelist.shortFilename(), " ", filelist.longFilename());
   }
 
 #endif // Flat file list

--- a/Marlin/src/lcd/extui/anycubic_chiron/chiron_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/chiron_extui.cpp
@@ -107,12 +107,12 @@ namespace ExtUI {
 
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const_float_t zval) {
       // Called when any mesh points are updated
-      //SERIAL_ECHOLNPAIR("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);
+      //SERIAL_ECHOLNPGM("onMeshUpdate() x:", xpos, " y:", ypos, " z:", zval);
     }
 
     void onMeshUpdate(const int8_t xpos, const int8_t ypos, const probe_state_t state) {
       // Called to indicate a special condition
-      //SERIAL_ECHOLNPAIR("onMeshUpdate() x:", xpos, " y:", ypos, " state:", state);
+      //SERIAL_ECHOLNPGM("onMeshUpdate() x:", xpos, " y:", ypos, " state:", state);
     }
   #endif
 

--- a/Marlin/src/lcd/extui/anycubic_chiron/chiron_tft.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/chiron_tft.cpp
@@ -104,7 +104,7 @@ void ChironTFT::Startup() {
   PlayTune(BEEPER_PIN, TERN(AC_DEFAULT_STARTUP_TUNE, Anycubic_PowerOn, GB_PowerOn), 1);
 
   #if ACDEBUGLEVEL
-    SERIAL_ECHOLNPAIR("AC Debug Level ", ACDEBUGLEVEL);
+    SERIAL_ECHOLNPGM("AC Debug Level ", ACDEBUGLEVEL);
   #endif
   SendtoTFTLN(AC_msg_ready);
 }
@@ -128,13 +128,13 @@ void ChironTFT::IdleLoop()  {
 void ChironTFT::PrinterKilled(PGM_P error,PGM_P component)  {
   SendtoTFTLN(AC_msg_kill_lcd);
   #if ACDEBUG(AC_MARLIN)
-    SERIAL_ECHOLNPAIR("PrinterKilled()\nerror: ", error , "\ncomponent: ", component);
+    SERIAL_ECHOLNPGM("PrinterKilled()\nerror: ", error , "\ncomponent: ", component);
   #endif
 }
 
 void ChironTFT::MediaEvent(media_event_t event)  {
   #if ACDEBUG(AC_MARLIN)
-    SERIAL_ECHOLNPAIR("ProcessMediaStatus() ", event);
+    SERIAL_ECHOLNPGM("ProcessMediaStatus() ", event);
   #endif
   switch (event) {
     case AC_media_inserted:
@@ -154,8 +154,8 @@ void ChironTFT::MediaEvent(media_event_t event)  {
 
 void ChironTFT::TimerEvent(timer_event_t event)  {
   #if ACDEBUG(AC_MARLIN)
-    SERIAL_ECHOLNPAIR("TimerEvent() ", event);
-    SERIAL_ECHOLNPAIR("Printer State: ", printer_state);
+    SERIAL_ECHOLNPGM("TimerEvent() ", event);
+    SERIAL_ECHOLNPGM("Printer State: ", printer_state);
   #endif
 
   switch (event) {
@@ -184,7 +184,7 @@ void ChironTFT::TimerEvent(timer_event_t event)  {
 
 void ChironTFT::FilamentRunout()  {
   #if ACDEBUG(AC_MARLIN)
-    SERIAL_ECHOLNPAIR("FilamentRunout() printer_state ", printer_state);
+    SERIAL_ECHOLNPGM("FilamentRunout() printer_state ", printer_state);
   #endif
   // 1 Signal filament out
   last_error = AC_error_filament_runout;
@@ -195,7 +195,7 @@ void ChironTFT::FilamentRunout()  {
 void ChironTFT::ConfirmationRequest(const char * const msg)  {
   // M108 continue
   #if ACDEBUG(AC_MARLIN)
-    SERIAL_ECHOLNPAIR("ConfirmationRequest() ", msg, " printer_state:", printer_state);
+    SERIAL_ECHOLNPGM("ConfirmationRequest() ", msg, " printer_state:", printer_state);
   #endif
   switch (printer_state) {
     case AC_printer_pausing: {
@@ -232,8 +232,8 @@ void ChironTFT::ConfirmationRequest(const char * const msg)  {
 
 void ChironTFT::StatusChange(const char * const msg)  {
   #if ACDEBUG(AC_MARLIN)
-    SERIAL_ECHOLNPAIR("StatusChange() ", msg);
-    SERIAL_ECHOLNPAIR("printer_state:", printer_state);
+    SERIAL_ECHOLNPGM("StatusChange() ", msg);
+    SERIAL_ECHOLNPGM("printer_state:", printer_state);
   #endif
   bool msg_matched = false;
   // The only way to get printer status is to parse messages
@@ -348,7 +348,7 @@ bool ChironTFT::ReadTFTCommand() {
   if (command_ready || command_len == MAX_CMND_LEN) {
     panel_command[command_len] = '\0';
     #if ACDEBUG(AC_ALL)
-      SERIAL_ECHOLNPAIR("len(",command_len,") < ", panel_command);
+      SERIAL_ECHOLNPGM("len(",command_len,") < ", panel_command);
     #endif
     command_ready = true;
   }
@@ -360,13 +360,13 @@ int8_t ChironTFT::FindToken(char c) {
   do {
     if (panel_command[pos] == c) {
       #if ACDEBUG(AC_INFO)
-        SERIAL_ECHOLNPAIR("Tpos:", pos, " ", c);
+        SERIAL_ECHOLNPGM("Tpos:", pos, " ", c);
       #endif
       return pos;
     }
   } while(++pos < command_len);
   #if ACDEBUG(AC_INFO)
-    SERIAL_ECHOLNPAIR("Not found: ", c);
+    SERIAL_ECHOLNPGM("Not found: ", c);
   #endif
   return -1;
 }
@@ -381,7 +381,7 @@ void ChironTFT::CheckHeaters() {
     if (faultDuration >= AC_HEATER_FAULT_VALIDATION_TIME) {
       SendtoTFTLN(AC_msg_nozzle_temp_abnormal);
       last_error = AC_error_abnormal_temp_t0;
-      SERIAL_ECHOLNPAIR("Extruder temp abnormal! : ", temp);
+      SERIAL_ECHOLNPGM("Extruder temp abnormal! : ", temp);
       break;
     }
     delay_ms(500);
@@ -396,7 +396,7 @@ void ChironTFT::CheckHeaters() {
     if (faultDuration >= AC_HEATER_FAULT_VALIDATION_TIME) {
       SendtoTFTLN(AC_msg_nozzle_temp_abnormal);
       last_error = AC_error_abnormal_temp_bed;
-      SERIAL_ECHOLNPAIR("Bed temp abnormal! : ", temp);
+      SERIAL_ECHOLNPGM("Bed temp abnormal! : ", temp);
       break;
     }
     delay_ms(500);
@@ -423,7 +423,7 @@ void ChironTFT::CheckHeaters() {
 void ChironTFT::SendFileList(int8_t startindex) {
   // Respond to panel request for 4 files starting at index
   #if ACDEBUG(AC_INFO)
-    SERIAL_ECHOLNPAIR("## SendFileList ## ", startindex);
+    SERIAL_ECHOLNPGM("## SendFileList ## ", startindex);
   #endif
   SendtoTFTLN(PSTR("FN "));
   filenavigator.getFiles(startindex, panel_type, 4);
@@ -440,7 +440,7 @@ void ChironTFT::SelectFile() {
     selectedfile[command_len - 5] = '\0';
   }
   #if ACDEBUG(AC_FILE)
-    SERIAL_ECHOLNPAIR(" Selected File: ",selectedfile);
+    SERIAL_ECHOLNPGM(" Selected File: ",selectedfile);
   #endif
   switch (selectedfile[0]) {
     case '/':   // Valid file selected
@@ -561,7 +561,7 @@ void ChironTFT::PanelInfo(uint8_t req) {
       TFTSer.print(ui8tostr2(time % 60));
       SendtoTFT(PSTR(" M"));
       #if ACDEBUG(AC_ALL)
-        SERIAL_ECHOLNPAIR("Print time ", ui8tostr2(time / 60), ":", ui8tostr2(time % 60));
+        SERIAL_ECHOLNPGM("Print time ", ui8tostr2(time / 60), ":", ui8tostr2(time % 60));
       #endif
     } break;
 
@@ -702,7 +702,7 @@ void ChironTFT::PanelAction(uint8_t req) {
         char MoveCmnd[30];
         sprintf_P(MoveCmnd, PSTR("G91\nG0%s\nG90"), panel_command + 3);
         #if ACDEBUG(AC_ACTION)
-          SERIAL_ECHOLNPAIR("Move: ", MoveCmnd);
+          SERIAL_ECHOLNPGM("Move: ", MoveCmnd);
         #endif
         setSoftEndstopState(true);  // enable endstops
         injectCommands(MoveCmnd);
@@ -781,7 +781,7 @@ void ChironTFT::PanelProcess(uint8_t req) {
 
           if (isPositionKnown()) {
             #if ACDEBUG(AC_INFO)
-              SERIAL_ECHOLNPAIR("Moving to mesh point at x: ", pos.x, " y: ", pos.y, " z: ", pos_z);
+              SERIAL_ECHOLNPGM("Moving to mesh point at x: ", pos.x, " y: ", pos.y, " z: ", pos_z);
             #endif
             // Go up before moving
             setAxisPosition_mm(3.0,Z);
@@ -790,7 +790,7 @@ void ChironTFT::PanelProcess(uint8_t req) {
             setAxisPosition_mm(20 + (93 * pos.y), Y);
             setAxisPosition_mm(0.0, Z);
             #if ACDEBUG(AC_INFO)
-              SERIAL_ECHOLNPAIR("Current Z: ", getAxisPosition_mm(Z));
+              SERIAL_ECHOLNPGM("Current Z: ", getAxisPosition_mm(Z));
             #endif
           }
         }
@@ -858,17 +858,17 @@ void ChironTFT::PanelProcess(uint8_t req) {
           // From the leveling panel use the all points UI to adjust the print pos.
           if (isPrinting()) {
             #if ACDEBUG(AC_INFO)
-              SERIAL_ECHOLNPAIR("Change Zoffset from:", live_Zoffset, " to ", live_Zoffset + Zshift);
+              SERIAL_ECHOLNPGM("Change Zoffset from:", live_Zoffset, " to ", live_Zoffset + Zshift);
             #endif
             if (isAxisPositionKnown(Z)) {
               #if ACDEBUG(AC_INFO)
                 const float currZpos = getAxisPosition_mm(Z);
-                SERIAL_ECHOLNPAIR("Nudge Z pos from ", currZpos, " to ", currZpos + constrain(Zshift, -0.05, 0.05));
+                SERIAL_ECHOLNPGM("Nudge Z pos from ", currZpos, " to ", currZpos + constrain(Zshift, -0.05, 0.05));
               #endif
               // Use babystepping to adjust the head position
               int16_t steps = mmToWholeSteps(constrain(Zshift,-0.05,0.05), Z);
               #if ACDEBUG(AC_INFO)
-                SERIAL_ECHOLNPAIR("Steps to move Z: ", steps);
+                SERIAL_ECHOLNPGM("Steps to move Z: ", steps);
               #endif
               babystepAxis_steps(steps, Z);
               live_Zoffset += Zshift;
@@ -882,12 +882,12 @@ void ChironTFT::PanelProcess(uint8_t req) {
               const float currval = getMeshPoint(pos);
               setMeshPoint(pos, constrain(currval + Zshift, AC_LOWEST_MESHPOINT_VAL, 2));
               #if ACDEBUG(AC_INFO)
-                SERIAL_ECHOLNPAIR("Change mesh point X", x," Y",y ," from ", currval, " to ", getMeshPoint(pos) );
+                SERIAL_ECHOLNPGM("Change mesh point X", x," Y",y ," from ", currval, " to ", getMeshPoint(pos) );
               #endif
             }
             const float currZOffset = getZOffset_mm();
             #if ACDEBUG(AC_INFO)
-              SERIAL_ECHOLNPAIR("Change probe offset from ", currZOffset, " to  ", currZOffset + Zshift);
+              SERIAL_ECHOLNPGM("Change probe offset from ", currZOffset, " to  ", currZOffset + Zshift);
             #endif
 
             setZOffset_mm(currZOffset + Zshift);
@@ -898,7 +898,7 @@ void ChironTFT::PanelProcess(uint8_t req) {
               // Move Z axis
               const float currZpos = getAxisPosition_mm(Z);
               #if ACDEBUG(AC_INFO)
-                SERIAL_ECHOLNPAIR("Move Z pos from ", currZpos, " to ", currZpos + constrain(Zshift, -0.05, 0.05));
+                SERIAL_ECHOLNPGM("Move Z pos from ", currZpos, " to ", currZpos + constrain(Zshift, -0.05, 0.05));
               #endif
               setAxisPosition_mm(currZpos+constrain(Zshift,-0.05,0.05),Z);
             }
@@ -930,8 +930,8 @@ void ChironTFT::PanelProcess(uint8_t req) {
         float currmesh = getMeshPoint(pos);
         float newval   = atof(&panel_command[11])/100;
         #if ACDEBUG(AC_INFO)
-          SERIAL_ECHOLNPAIR("Change mesh point x:", pos.x, " y:", pos.y);
-          SERIAL_ECHOLNPAIR("from ", currmesh, " to ", newval);
+          SERIAL_ECHOLNPGM("Change mesh point x:", pos.x, " y:", pos.y);
+          SERIAL_ECHOLNPGM("from ", currmesh, " to ", newval);
         #endif
         // Update Meshpoint
         setMeshPoint(pos,newval);
@@ -942,7 +942,7 @@ void ChironTFT::PanelProcess(uint8_t req) {
             setSoftEndstopState(false);
             float currZpos = getAxisPosition_mm(Z);
             #if ACDEBUG(AC_INFO)
-              SERIAL_ECHOLNPAIR("Move Z pos from ", currZpos, " to ", currZpos + constrain(newval - currmesh, -0.05, 0.05));
+              SERIAL_ECHOLNPGM("Move Z pos from ", currZpos, " to ", currZpos + constrain(newval - currmesh, -0.05, 0.05));
             #endif
             setAxisPosition_mm(currZpos + constrain(newval - currmesh, -0.05, 0.05), Z);
           }

--- a/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -143,7 +143,7 @@ void AnycubicTFTClass::OnKillTFT() {
 
 void AnycubicTFTClass::OnSDCardStateChange(bool isInserted) {
   #if ENABLED(ANYCUBIC_LCD_DEBUG)
-    SERIAL_ECHOLNPAIR("TFT Serial Debug: OnSDCardStateChange event triggered...", isInserted);
+    SERIAL_ECHOLNPGM("TFT Serial Debug: OnSDCardStateChange event triggered...", isInserted);
   #endif
   DoSDCardStateCheck();
 }
@@ -164,7 +164,7 @@ void AnycubicTFTClass::OnFilamentRunout() {
 
 void AnycubicTFTClass::OnUserConfirmRequired(const char * const msg) {
   #if ENABLED(ANYCUBIC_LCD_DEBUG)
-    SERIAL_ECHOLNPAIR("TFT Serial Debug: OnUserConfirmRequired triggered... ", msg);
+    SERIAL_ECHOLNPGM("TFT Serial Debug: OnUserConfirmRequired triggered... ", msg);
   #endif
 
   #if ENABLED(SDSUPPORT)
@@ -557,7 +557,7 @@ void AnycubicTFTClass::GetCommandFromTFT() {
 
         #if ENABLED(ANYCUBIC_LCD_DEBUG)
           if ((a_command > 7) && (a_command != 20))   // No debugging of status polls, please!
-            SERIAL_ECHOLNPAIR("TFT Serial Command: ", TFTcmdbuffer[TFTbufindw]);
+            SERIAL_ECHOLNPGM("TFT Serial Command: ", TFTcmdbuffer[TFTbufindw]);
         #endif
 
         switch (a_command) {

--- a/Marlin/src/lcd/extui/dgus/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/dgus/DGUSDisplay.cpp
@@ -154,19 +154,19 @@ void DGUSDisplay::ProcessRx() {
 
       case DGUS_IDLE: // Waiting for the first header byte
         receivedbyte = LCD_SERIAL.read();
-        //DEBUG_ECHOPAIR("< ",x);
+        //DEBUG_ECHOPGM("< ",x);
         if (DGUS_HEADER1 == receivedbyte) rx_datagram_state = DGUS_HEADER1_SEEN;
         break;
 
       case DGUS_HEADER1_SEEN: // Waiting for the second header byte
         receivedbyte = LCD_SERIAL.read();
-        //DEBUG_ECHOPAIR(" ",x);
+        //DEBUG_ECHOPGM(" ",x);
         rx_datagram_state = (DGUS_HEADER2 == receivedbyte) ? DGUS_HEADER2_SEEN : DGUS_IDLE;
         break;
 
       case DGUS_HEADER2_SEEN: // Waiting for the length byte
         rx_datagram_len = LCD_SERIAL.read();
-        DEBUG_ECHOPAIR(" (", rx_datagram_len, ") ");
+        DEBUG_ECHOPGM(" (", rx_datagram_len, ") ");
 
         // Telegram min len is 3 (command and one word of payload)
         rx_datagram_state = WITHIN(rx_datagram_len, 3, DGUS_RX_BUFFER_SIZE) ? DGUS_WAIT_TELEGRAM : DGUS_IDLE;
@@ -178,14 +178,14 @@ void DGUSDisplay::ProcessRx() {
         Initialized = true; // We've talked to it, so we defined it as initialized.
         uint8_t command = LCD_SERIAL.read();
 
-        DEBUG_ECHOPAIR("# ", command);
+        DEBUG_ECHOPGM("# ", command);
 
         uint8_t readlen = rx_datagram_len - 1;  // command is part of len.
         unsigned char tmp[rx_datagram_len - 1];
         unsigned char *ptmp = tmp;
         while (readlen--) {
           receivedbyte = LCD_SERIAL.read();
-          DEBUG_ECHOPAIR(" ", receivedbyte);
+          DEBUG_ECHOPGM(" ", receivedbyte);
           *ptmp++ = receivedbyte;
         }
         DEBUG_ECHOPGM(" # ");
@@ -206,7 +206,7 @@ void DGUSDisplay::ProcessRx() {
         if (command == DGUS_CMD_READVAR) {
           const uint16_t vp = tmp[0] << 8 | tmp[1];
           //const uint8_t dlen = tmp[2] << 1;  // Convert to Bytes. (Display works with words)
-          //DEBUG_ECHOPAIR(" vp=", vp, " dlen=", dlen);
+          //DEBUG_ECHOPGM(" vp=", vp, " dlen=", dlen);
           DGUS_VP_Variable ramcopy;
           if (populate_VPVar(vp, &ramcopy)) {
             if (ramcopy.set_by_display_handler)
@@ -215,7 +215,7 @@ void DGUSDisplay::ProcessRx() {
               DEBUG_ECHOLNPGM(" VPVar found, no handler.");
           }
           else
-            DEBUG_ECHOLNPAIR(" VPVar not found:", vp);
+            DEBUG_ECHOLNPGM(" VPVar not found:", vp);
 
           rx_datagram_state = DGUS_IDLE;
           break;
@@ -260,9 +260,9 @@ bool DGUSDisplay::no_reentrance = false;
 #define sw_barrier() asm volatile("": : :"memory");
 
 bool populate_VPVar(const uint16_t VP, DGUS_VP_Variable * const ramcopy) {
-  // DEBUG_ECHOPAIR("populate_VPVar ", VP);
+  // DEBUG_ECHOPGM("populate_VPVar ", VP);
   const DGUS_VP_Variable *pvp = DGUSLCD_FindVPVar(VP);
-  // DEBUG_ECHOLNPAIR(" pvp ", (uint16_t )pvp);
+  // DEBUG_ECHOLNPGM(" pvp ", (uint16_t )pvp);
   if (!pvp) return false;
   memcpy_P(ramcopy, pvp, sizeof(DGUS_VP_Variable));
   return true;

--- a/Marlin/src/lcd/extui/dgus/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/DGUSScreenHandler.cpp
@@ -110,8 +110,8 @@ void DGUSScreenHandler::setstatusmessagePGM(PGM_P const msg) {
 // Send an 8 bit or 16 bit value to the display.
 void DGUSScreenHandler::DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &var) {
   if (var.memadr) {
-    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", var.VP);
-    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)var.memadr);
+    //DEBUG_ECHOPGM(" DGUS_LCD_SendWordValueToDisplay ", var.VP);
+    //DEBUG_ECHOLNPGM(" data ", *(uint16_t *)var.memadr);
     if (var.size > 1)
       dgusdisplay.WriteVariable(var.VP, *(int16_t*)var.memadr);
     else
@@ -122,8 +122,8 @@ void DGUSScreenHandler::DGUSLCD_SendWordValueToDisplay(DGUS_VP_Variable &var) {
 // Send an uint8_t between 0 and 255 to the display, but scale to a percentage (0..100)
 void DGUSScreenHandler::DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &var) {
   if (var.memadr) {
-    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", var.VP);
-    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)var.memadr);
+    //DEBUG_ECHOPGM(" DGUS_LCD_SendWordValueToDisplay ", var.VP);
+    //DEBUG_ECHOLNPGM(" data ", *(uint16_t *)var.memadr);
     uint16_t tmp = *(uint8_t *) var.memadr + 1; // +1 -> avoid rounding issues for the display.
     tmp = map(tmp, 0, 255, 0, 100);
     dgusdisplay.WriteVariable(var.VP, tmp);
@@ -132,9 +132,9 @@ void DGUSScreenHandler::DGUSLCD_SendPercentageToDisplay(DGUS_VP_Variable &var) {
 
 // Send the current print progress to the display.
 void DGUSScreenHandler::DGUSLCD_SendPrintProgressToDisplay(DGUS_VP_Variable &var) {
-  //DEBUG_ECHOPAIR(" DGUSLCD_SendPrintProgressToDisplay ", var.VP);
+  //DEBUG_ECHOPGM(" DGUSLCD_SendPrintProgressToDisplay ", var.VP);
   uint16_t tmp = ExtUI::getProgress_percent();
-  //DEBUG_ECHOLNPAIR(" data ", tmp);
+  //DEBUG_ECHOLNPGM(" data ", tmp);
   dgusdisplay.WriteVariable(var.VP, tmp);
 }
 
@@ -151,9 +151,9 @@ void DGUSScreenHandler::DGUSLCD_SendPrintTimeToDisplay(DGUS_VP_Variable &var) {
 void DGUSScreenHandler::DGUSLCD_PercentageToUint8(DGUS_VP_Variable &var, void *val_ptr) {
   if (var.memadr) {
     uint16_t value = swap16(*(uint16_t*)val_ptr);
-    DEBUG_ECHOLNPAIR("FAN value get:", value);
+    DEBUG_ECHOLNPGM("FAN value get:", value);
     *(uint8_t*)var.memadr = map(constrain(value, 0, 100), 0, 100, 0, 255);
-    DEBUG_ECHOLNPAIR("FAN value change:", *(uint8_t*)var.memadr);
+    DEBUG_ECHOLNPGM("FAN value change:", *(uint8_t*)var.memadr);
   }
 }
 
@@ -234,8 +234,8 @@ void DGUSScreenHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable &var) {
 
   void DGUSScreenHandler::DGUSLCD_SendFanStatusToDisplay(DGUS_VP_Variable &var) {
     if (var.memadr) {
-      DEBUG_ECHOPAIR(" DGUSLCD_SendFanStatusToDisplay ", var.VP);
-      DEBUG_ECHOLNPAIR(" data ", *(uint8_t *)var.memadr);
+      DEBUG_ECHOPGM(" DGUSLCD_SendFanStatusToDisplay ", var.VP);
+      DEBUG_ECHOLNPGM(" data ", *(uint8_t *)var.memadr);
       uint16_t data_to_send = 0;
       if (*(uint8_t *) var.memadr) data_to_send = 1;
       dgusdisplay.WriteVariable(var.VP, data_to_send);
@@ -247,8 +247,8 @@ void DGUSScreenHandler::DGUSLCD_SendStringToDisplayPGM(DGUS_VP_Variable &var) {
 // Send heater status value to the display.
 void DGUSScreenHandler::DGUSLCD_SendHeaterStatusToDisplay(DGUS_VP_Variable &var) {
   if (var.memadr) {
-    DEBUG_ECHOPAIR(" DGUSLCD_SendHeaterStatusToDisplay ", var.VP);
-    DEBUG_ECHOLNPAIR(" data ", *(int16_t *)var.memadr);
+    DEBUG_ECHOPGM(" DGUSLCD_SendHeaterStatusToDisplay ", var.VP);
+    DEBUG_ECHOLNPGM(" data ", *(int16_t *)var.memadr);
     uint16_t data_to_send = 0;
     if (*(int16_t *) var.memadr) data_to_send = 1;
     dgusdisplay.WriteVariable(var.VP, data_to_send);
@@ -261,11 +261,11 @@ void DGUSScreenHandler::DGUSLCD_SendHeaterStatusToDisplay(DGUS_VP_Variable &var)
     // In FYSETC UI design there are 10 statuses to loop
     static uint16_t period = 0;
     static uint16_t index = 0;
-    //DEBUG_ECHOPAIR(" DGUSLCD_SendWaitingStatusToDisplay ", var.VP);
-    //DEBUG_ECHOLNPAIR(" data ", swap16(index));
+    //DEBUG_ECHOPGM(" DGUSLCD_SendWaitingStatusToDisplay ", var.VP);
+    //DEBUG_ECHOLNPGM(" data ", swap16(index));
     if (period++ > DGUS_UI_WAITING_STATUS_PERIOD) {
       dgusdisplay.WriteVariable(var.VP, index);
-      //DEBUG_ECHOLNPAIR(" data ", swap16(index));
+      //DEBUG_ECHOLNPGM(" data ", swap16(index));
       if (++index >= DGUS_UI_WAITING_STATUS) index = 0;
       period = 0;
     }
@@ -307,7 +307,7 @@ void DGUSScreenHandler::DGUSLCD_SendHeaterStatusToDisplay(DGUS_VP_Variable &var)
     const int16_t scroll = (int16_t)swap16(*(uint16_t*)val_ptr);
     if (scroll) {
       top_file += scroll;
-      DEBUG_ECHOPAIR("new topfile calculated:", top_file);
+      DEBUG_ECHOPGM("new topfile calculated:", top_file);
       if (top_file < 0) {
         top_file = 0;
         DEBUG_ECHOLNPGM("Top of filelist reached");
@@ -317,7 +317,7 @@ void DGUSScreenHandler::DGUSLCD_SendHeaterStatusToDisplay(DGUS_VP_Variable &var)
         NOLESS(max_top, 0);
         NOMORE(top_file, max_top);
       }
-      DEBUG_ECHOPAIR("new topfile adjusted:", top_file);
+      DEBUG_ECHOPGM("new topfile adjusted:", top_file);
     }
     else if (!filelist.isAtRootDir()) {
       IF_DISABLED(DGUS_LCD_UI_MKS, filelist.upDir());
@@ -371,7 +371,7 @@ const DGUS_VP_Variable* DGUSLCD_FindVPVar(const uint16_t vp) {
     ++ret;
   } while (1);
 
-  DEBUG_ECHOLNPAIR("FindVPVar NOT FOUND ", vp);
+  DEBUG_ECHOLNPGM("FindVPVar NOT FOUND ", vp);
   return nullptr;
 }
 
@@ -476,7 +476,7 @@ void DGUSScreenHandler::HandleMotorLockUnlock(DGUS_VP_Variable &var, void *val_p
   const int16_t lock = swap16(*(uint16_t*)val_ptr);
   strcpy_P(buf, lock ? PSTR("M18") : PSTR("M17"));
 
-  //DEBUG_ECHOPAIR(" ", buf);
+  //DEBUG_ECHOPGM(" ", buf);
   queue.enqueue_one_now(buf);
 }
 
@@ -499,7 +499,7 @@ void DGUSScreenHandler::HandleStepPerMMChanged(DGUS_VP_Variable &var, void *val_
   DEBUG_ECHOLNPGM("HandleStepPerMMChanged");
 
   uint16_t value_raw = swap16(*(uint16_t*)val_ptr);
-  DEBUG_ECHOLNPAIR("value_raw:", value_raw);
+  DEBUG_ECHOLNPGM("value_raw:", value_raw);
   float value = (float)value_raw / 10;
   ExtUI::axis_t axis;
   switch (var.VP) {
@@ -519,7 +519,7 @@ void DGUSScreenHandler::HandleStepPerMMExtruderChanged(DGUS_VP_Variable &var, vo
   DEBUG_ECHOLNPGM("HandleStepPerMMExtruderChanged");
 
   uint16_t value_raw = swap16(*(uint16_t*)val_ptr);
-  DEBUG_ECHOLNPAIR("value_raw:", value_raw);
+  DEBUG_ECHOLNPGM("value_raw:", value_raw);
   float value = (float)value_raw / 10;
   ExtUI::extruder_t extruder;
   switch (var.VP) {
@@ -696,7 +696,7 @@ void DGUSScreenHandler::HandleHeaterControl(DGUS_VP_Variable &var, void *val_ptr
 #endif
 
 void DGUSScreenHandler::UpdateNewScreen(DGUSLCD_Screens newscreen, bool popup) {
-  DEBUG_ECHOLNPAIR("SetNewScreen: ", newscreen);
+  DEBUG_ECHOLNPGM("SetNewScreen: ", newscreen);
   if (!popup) {
     memmove(&past_screens[1], &past_screens[0], sizeof(past_screens) - 1);
     past_screens[0] = current_screen;
@@ -707,18 +707,18 @@ void DGUSScreenHandler::UpdateNewScreen(DGUSLCD_Screens newscreen, bool popup) {
 }
 
 void DGUSScreenHandler::PopToOldScreen() {
-  DEBUG_ECHOLNPAIR("PopToOldScreen s=", past_screens[0]);
+  DEBUG_ECHOLNPGM("PopToOldScreen s=", past_screens[0]);
   GotoScreen(past_screens[0], true);
   memmove(&past_screens[0], &past_screens[1], sizeof(past_screens) - 1);
   past_screens[sizeof(past_screens) - 1] = DGUSLCD_SCREEN_MAIN;
 }
 
 void DGUSScreenHandler::UpdateScreenVPData() {
-  DEBUG_ECHOPAIR(" UpdateScreenVPData Screen: ", current_screen);
+  DEBUG_ECHOPGM(" UpdateScreenVPData Screen: ", current_screen);
 
   const uint16_t *VPList = DGUSLCD_FindScreenVPMapList(current_screen);
   if (!VPList) {
-    DEBUG_ECHOLNPAIR(" NO SCREEN FOR: ", current_screen);
+    DEBUG_ECHOLNPGM(" NO SCREEN FOR: ", current_screen);
     ScreenComplete = true;
     return; // nothing to do, likely a bug or boring screen.
   }
@@ -729,7 +729,7 @@ void DGUSScreenHandler::UpdateScreenVPData() {
   bool sent_one = false;
   do {
     uint16_t VP = pgm_read_word(VPList);
-    DEBUG_ECHOPAIR(" VP: ", VP);
+    DEBUG_ECHOPGM(" VP: ", VP);
     if (!VP) {
       update_ptr = 0;
       DEBUG_ECHOLNPGM(" UpdateScreenVPData done");
@@ -745,14 +745,14 @@ void DGUSScreenHandler::UpdateScreenVPData() {
       // Send the VP to the display, but try to avoid overrunning the Tx Buffer.
       // But send at least one VP, to avoid getting stalled.
       if (rcpy.send_to_display_handler && (!sent_one || expected_tx <= dgusdisplay.GetFreeTxBuffer())) {
-        //DEBUG_ECHOPAIR(" calling handler for ", rcpy.VP);
+        //DEBUG_ECHOPGM(" calling handler for ", rcpy.VP);
         sent_one = true;
         rcpy.send_to_display_handler(rcpy);
       }
       else {
         // auto x=dgusdisplay.GetFreeTxBuffer();
-        //DEBUG_ECHOLNPAIR(" tx almost full: ", x);
-        //DEBUG_ECHOPAIR(" update_ptr ", update_ptr);
+        //DEBUG_ECHOLNPGM(" tx almost full: ", x);
+        //DEBUG_ECHOPGM(" update_ptr ", update_ptr);
         ScreenComplete = false;
         return; // please call again!
       }
@@ -767,7 +767,7 @@ void DGUSScreenHandler::GotoScreen(DGUSLCD_Screens screen, bool ispopup) {
 }
 
 void DGUSDisplay::RequestScreen(DGUSLCD_Screens screen) {
-  DEBUG_ECHOLNPAIR("GotoScreen ", screen);
+  DEBUG_ECHOLNPGM("GotoScreen ", screen);
   const unsigned char gotoscreen[] = { 0x5A, 0x01, (unsigned char) (screen >> 8U), (unsigned char) (screen & 0xFFU) };
   WriteVariable(0x84, gotoscreen, sizeof(gotoscreen));
 }

--- a/Marlin/src/lcd/extui/dgus/fysetc/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/fysetc/DGUSScreenHandler.cpp
@@ -134,7 +134,7 @@ void DGUSScreenHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
   // meaning "return to previous screen"
   DGUSLCD_Screens target = (DGUSLCD_Screens)tmp[1];
 
-  DEBUG_ECHOLNPAIR("\n DEBUG target", target);
+  DEBUG_ECHOLNPGM("\n DEBUG target", target);
 
   if (target == DGUSLCD_SCREEN_POPUP) {
     // Special handling for popup is to return to previous menu
@@ -146,7 +146,7 @@ void DGUSScreenHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
   UpdateNewScreen(target);
 
   #ifdef DEBUG_DGUSLCD
-    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPAIR("WARNING: No screen Mapping found for ", target);
+    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPGM("WARNING: No screen Mapping found for ", target);
   #endif
 }
 
@@ -190,10 +190,10 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
 
   if (!movevalue) {
     // homing
-    DEBUG_ECHOPAIR(" homing ", AS_CHAR(axiscode));
+    DEBUG_ECHOPGM(" homing ", AS_CHAR(axiscode));
     char buf[6] = "G28 X";
     buf[4] = axiscode;
-    //DEBUG_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPGM(" ", buf);
     queue.enqueue_one_now(buf);
     //DEBUG_ECHOLNPGM(" ✓");
     ForceCompleteUpdate();
@@ -201,7 +201,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   }
   else {
     // movement
-    DEBUG_ECHOPAIR(" move ", AS_CHAR(axiscode));
+    DEBUG_ECHOPGM(" move ", AS_CHAR(axiscode));
     bool old_relative_mode = relative_mode;
     if (!relative_mode) {
       //DEBUG_ECHOPGM(" G91");
@@ -215,13 +215,13 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
     if (movevalue < 0) { value = -value; sign[0] = '-'; }
     int16_t fraction = ABS(movevalue) % 100;
     snprintf_P(buf, 32, PSTR("G0 %c%s%d.%02d F%d"), axiscode, sign, value, fraction, speed);
-    //DEBUG_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPGM(" ", buf);
     queue.enqueue_one_now(buf);
     //DEBUG_ECHOLNPGM(" ✓ ");
     if (backup_speed != speed) {
       snprintf_P(buf, 32, PSTR("G0 F%d"), backup_speed);
       queue.enqueue_one_now(buf);
-      //DEBUG_ECHOPAIR(" ", buf);
+      //DEBUG_ECHOPGM(" ", buf);
     }
     // while (!enqueue_and_echo_command(buf)) idle();
     //DEBUG_ECHOLNPGM(" ✓ ");
@@ -237,16 +237,16 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   return;
 
   cannotmove:
-    DEBUG_ECHOLNPAIR(" cannot move ", AS_CHAR(axiscode));
+    DEBUG_ECHOLNPGM(" cannot move ", AS_CHAR(axiscode));
     return;
 }
 
 #if HAS_PID_HEATING
   void DGUSScreenHandler::HandleTemperaturePIDChanged(DGUS_VP_Variable &var, void *val_ptr) {
     uint16_t rawvalue = swap16(*(uint16_t*)val_ptr);
-    DEBUG_ECHOLNPAIR("V1:", rawvalue);
+    DEBUG_ECHOLNPGM("V1:", rawvalue);
     float value = (float)rawvalue / 10;
-    DEBUG_ECHOLNPAIR("V2:", value);
+    DEBUG_ECHOLNPGM("V2:", value);
     float newvalue = 0;
 
     switch (var.VP) {

--- a/Marlin/src/lcd/extui/dgus/hiprecy/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/hiprecy/DGUSScreenHandler.cpp
@@ -134,7 +134,7 @@ void DGUSScreenHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
   // meaning "return to previous screen"
   DGUSLCD_Screens target = (DGUSLCD_Screens)tmp[1];
 
-  DEBUG_ECHOLNPAIR("\n DEBUG target", target);
+  DEBUG_ECHOLNPGM("\n DEBUG target", target);
 
   if (target == DGUSLCD_SCREEN_POPUP) {
     // Special handling for popup is to return to previous menu
@@ -146,7 +146,7 @@ void DGUSScreenHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
   UpdateNewScreen(target);
 
   #ifdef DEBUG_DGUSLCD
-    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPAIR("WARNING: No screen Mapping found for ", target);
+    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPGM("WARNING: No screen Mapping found for ", target);
   #endif
 }
 
@@ -190,10 +190,10 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
 
   if (!movevalue) {
     // homing
-    DEBUG_ECHOPAIR(" homing ", AS_CHAR(axiscode));
+    DEBUG_ECHOPGM(" homing ", AS_CHAR(axiscode));
     char buf[6] = "G28 X";
     buf[4] = axiscode;
-    //DEBUG_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPGM(" ", buf);
     queue.enqueue_one_now(buf);
     //DEBUG_ECHOLNPGM(" ✓");
     ForceCompleteUpdate();
@@ -201,7 +201,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   }
   else {
     // movement
-    DEBUG_ECHOPAIR(" move ", AS_CHAR(axiscode));
+    DEBUG_ECHOPGM(" move ", AS_CHAR(axiscode));
     bool old_relative_mode = relative_mode;
     if (!relative_mode) {
       //DEBUG_ECHOPGM(" G91");
@@ -215,13 +215,13 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
     if (movevalue < 0) { value = -value; sign[0] = '-'; }
     int16_t fraction = ABS(movevalue) % 100;
     snprintf_P(buf, 32, PSTR("G0 %c%s%d.%02d F%d"), axiscode, sign, value, fraction, speed);
-    //DEBUG_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPGM(" ", buf);
     queue.enqueue_one_now(buf);
     //DEBUG_ECHOLNPGM(" ✓ ");
     if (backup_speed != speed) {
       snprintf_P(buf, 32, PSTR("G0 F%d"), backup_speed);
       queue.enqueue_one_now(buf);
-      //DEBUG_ECHOPAIR(" ", buf);
+      //DEBUG_ECHOPGM(" ", buf);
     }
     // while (!enqueue_and_echo_command(buf)) idle();
     //DEBUG_ECHOLNPGM(" ✓ ");
@@ -237,16 +237,16 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   return;
 
   cannotmove:
-    DEBUG_ECHOLNPAIR(" cannot move ", AS_CHAR(axiscode));
+    DEBUG_ECHOLNPGM(" cannot move ", AS_CHAR(axiscode));
     return;
 }
 
 #if HAS_PID_HEATING
   void DGUSScreenHandler::HandleTemperaturePIDChanged(DGUS_VP_Variable &var, void *val_ptr) {
     uint16_t rawvalue = swap16(*(uint16_t*)val_ptr);
-    DEBUG_ECHOLNPAIR("V1:", rawvalue);
+    DEBUG_ECHOLNPGM("V1:", rawvalue);
     float value = (float)rawvalue / 10;
-    DEBUG_ECHOLNPAIR("V2:", value);
+    DEBUG_ECHOLNPGM("V2:", value);
     float newvalue = 0;
 
     switch (var.VP) {

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
@@ -83,8 +83,8 @@ void DGUSScreenHandler::sendinfoscreen_mks(const void *line1, const void *line2,
 
 void DGUSScreenHandler::DGUSLCD_SendFanToDisplay(DGUS_VP_Variable &var) {
   if (var.memadr) {
-    //DEBUG_ECHOPAIR(" DGUS_LCD_SendWordValueToDisplay ", var.VP);
-    //DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)var.memadr);
+    //DEBUG_ECHOPGM(" DGUS_LCD_SendWordValueToDisplay ", var.VP);
+    //DEBUG_ECHOLNPGM(" data ", *(uint16_t *)var.memadr);
     uint16_t tmp = *(uint8_t *) var.memadr; // +1 -> avoid rounding issues for the display.
     // tmp = map(tmp, 0, 255, 0, 100);
     dgusdisplay.WriteVariable(var.VP, tmp);
@@ -109,14 +109,14 @@ void DGUSScreenHandler::DGUSLCD_SendPrintTimeToDisplay_MKS(DGUS_VP_Variable &var
 void DGUSScreenHandler::DGUSLCD_SetUint8(DGUS_VP_Variable &var, void *val_ptr) {
   if (var.memadr) {
     const uint16_t value = swap16(*(uint16_t*)val_ptr);
-    DEBUG_ECHOLNPAIR("FAN value get:", value);
+    DEBUG_ECHOLNPGM("FAN value get:", value);
     *(uint8_t*)var.memadr = map(constrain(value, 0, 255), 0, 255, 0, 255);
-    DEBUG_ECHOLNPAIR("FAN value change:", *(uint8_t*)var.memadr);
+    DEBUG_ECHOLNPGM("FAN value change:", *(uint8_t*)var.memadr);
   }
 }
 
 void DGUSScreenHandler::DGUSLCD_SendGbkToDisplay(DGUS_VP_Variable &var) {
-  DEBUG_ECHOLNPAIR(" data ", *(uint16_t *)var.memadr);
+  DEBUG_ECHOLNPGM(" data ", *(uint16_t *)var.memadr);
   uint16_t *tmp = (uint16_t*) var.memadr;
   dgusdisplay.WriteVariable(var.VP, tmp, var.size, true);
 }
@@ -282,7 +282,7 @@ void DGUSScreenHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
   // meaning "return to previous screen"
   DGUSLCD_Screens target = (DGUSLCD_Screens)tmp[1];
 
-  DEBUG_ECHOLNPAIR("\n DEBUG target", target);
+  DEBUG_ECHOLNPGM("\n DEBUG target", target);
 
   // when the dgus had reboot, it will enter the DGUSLCD_SCREEN_MAIN page,
   // so user can change any page to use this function, an it will check
@@ -311,13 +311,13 @@ void DGUSScreenHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
   UpdateNewScreen(target);
 
   #ifdef DEBUG_DGUSLCD
-    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPAIR("WARNING: No screen Mapping found for ", target);
+    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPGM("WARNING: No screen Mapping found for ", target);
   #endif
 }
 
 void DGUSScreenHandler::ScreenBackChange(DGUS_VP_Variable &var, void *val_ptr) {
   const uint16_t target = swap16(*(uint16_t *)val_ptr);
-  DEBUG_ECHOLNPAIR(" back = 0x%x", target);
+  DEBUG_ECHOLNPGM(" back = 0x%x", target);
   switch (target) {
   }
 }
@@ -756,7 +756,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   else if (manualMoveStep == 0x02) manualMoveStep =  100;
   else if (manualMoveStep == 0x03) manualMoveStep = 1000;
 
-  DEBUG_ECHOLNPAIR("QUEUE LEN:", queue.length);
+  DEBUG_ECHOLNPGM("QUEUE LEN:", queue.length);
 
   if (!print_job_timer.isPaused() && !queue.ring_buffer.empty())
     return;
@@ -818,7 +818,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
       break;
   }
 
-  DEBUG_ECHOPAIR("movevalue = ", movevalue);
+  DEBUG_ECHOPGM("movevalue = ", movevalue);
   if (movevalue != 0 && movevalue != 5) { // get move distance
     switch (movevalue) {
       case 0x0001: movevalue =  manualMoveStep; break;
@@ -829,20 +829,20 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
 
   if (!movevalue) {
     // homing
-    DEBUG_ECHOPAIR(" homing ", AS_CHAR(axiscode));
+    DEBUG_ECHOPGM(" homing ", AS_CHAR(axiscode));
     // char buf[6] = "G28 X";
     // buf[4] = axiscode;
 
     char buf[6];
     sprintf(buf, "G28 %c", axiscode);
-    //DEBUG_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPGM(" ", buf);
     queue.enqueue_one_now(buf);
     //DEBUG_ECHOLNPGM(" ✓");
     ForceCompleteUpdate();
     return;
   }
   else if (movevalue == 5) {
-    DEBUG_ECHOPAIR("send M84");
+    DEBUG_ECHOPGM("send M84");
     char buf[6];
     snprintf_P(buf,6,PSTR("M84 %c"), axiscode);
     queue.enqueue_one_now(buf);
@@ -851,7 +851,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   }
   else {
     // movement
-    DEBUG_ECHOPAIR(" move ", AS_CHAR(axiscode));
+    DEBUG_ECHOPGM(" move ", AS_CHAR(axiscode));
     bool old_relative_mode = relative_mode;
 
     if (!relative_mode) {
@@ -871,7 +871,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
     //if (backup_speed != speed) {
     //  snprintf_P(buf, 32, PSTR("G0 F%d"), backup_speed);
     //  queue.enqueue_one_now(buf);
-    //  //DEBUG_ECHOPAIR(" ", buf);
+    //  //DEBUG_ECHOPGM(" ", buf);
     //}
 
     //while (!enqueue_and_echo_command(buf)) idle();
@@ -889,7 +889,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   return;
 
   cannotmove:
-    DEBUG_ECHOLNPAIR(" cannot move ", AS_CHAR(axiscode));
+    DEBUG_ECHOLNPGM(" cannot move ", AS_CHAR(axiscode));
     return;
 }
 
@@ -923,7 +923,7 @@ void DGUSScreenHandler::HandleStepPerMMChanged_MKS(DGUS_VP_Variable &var, void *
   const uint16_t value_raw = swap16(*(uint16_t*)val_ptr);
   const float value = (float)value_raw;
 
-  DEBUG_ECHOLNPAIR("value_raw:", value_raw);
+  DEBUG_ECHOLNPGM("value_raw:", value_raw);
   DEBUG_ECHOLNPAIR_F("value:", value);
 
   ExtUI::axis_t axis;
@@ -945,7 +945,7 @@ void DGUSScreenHandler::HandleStepPerMMExtruderChanged_MKS(DGUS_VP_Variable &var
   const uint16_t value_raw = swap16(*(uint16_t*)val_ptr);
   const float value = (float)value_raw;
 
-  DEBUG_ECHOLNPAIR("value_raw:", value_raw);
+  DEBUG_ECHOLNPGM("value_raw:", value_raw);
   DEBUG_ECHOLNPAIR_F("value:", value);
 
   ExtUI::extruder_t extruder;
@@ -970,7 +970,7 @@ void DGUSScreenHandler::HandleMaxSpeedChange_MKS(DGUS_VP_Variable &var, void *va
   const uint16_t value_raw = swap16(*(uint16_t*)val_ptr);
   const float value = (float)value_raw;
 
-  DEBUG_ECHOLNPAIR("value_raw:", value_raw);
+  DEBUG_ECHOLNPGM("value_raw:", value_raw);
   DEBUG_ECHOLNPAIR_F("value:", value);
 
   ExtUI::axis_t axis;
@@ -992,7 +992,7 @@ void DGUSScreenHandler::HandleExtruderMaxSpeedChange_MKS(DGUS_VP_Variable &var, 
   const uint16_t value_raw = swap16(*(uint16_t*)val_ptr);
   const float value = (float)value_raw;
 
-  DEBUG_ECHOLNPAIR("value_raw:", value_raw);
+  DEBUG_ECHOLNPGM("value_raw:", value_raw);
   DEBUG_ECHOLNPAIR_F("value:", value);
 
   ExtUI::extruder_t extruder;
@@ -1017,7 +1017,7 @@ void DGUSScreenHandler::HandleMaxAccChange_MKS(DGUS_VP_Variable &var, void *val_
   const uint16_t value_raw = swap16(*(uint16_t*)val_ptr);
   const float value = (float)value_raw;
 
-  DEBUG_ECHOLNPAIR("value_raw:", value_raw);
+  DEBUG_ECHOLNPGM("value_raw:", value_raw);
   DEBUG_ECHOLNPAIR_F("value:", value);
 
   ExtUI::axis_t axis;
@@ -1037,7 +1037,7 @@ void DGUSScreenHandler::HandleExtruderAccChange_MKS(DGUS_VP_Variable &var, void 
   DEBUG_ECHOLNPGM("HandleExtruderAccChange_MKS");
 
   uint16_t value_raw = swap16(*(uint16_t*)val_ptr);
-  DEBUG_ECHOLNPAIR("value_raw:", value_raw);
+  DEBUG_ECHOLNPGM("value_raw:", value_raw);
   float value = (float)value_raw;
   ExtUI::extruder_t extruder;
   switch (var.VP) {
@@ -1091,9 +1091,9 @@ void DGUSScreenHandler::HandleAccChange_MKS(DGUS_VP_Variable &var, void *val_ptr
 #if HAS_PID_HEATING
   void DGUSScreenHandler::HandleTemperaturePIDChanged(DGUS_VP_Variable &var, void *val_ptr) {
     const uint16_t rawvalue = swap16(*(uint16_t*)val_ptr);
-    DEBUG_ECHOLNPAIR("V1:", rawvalue);
+    DEBUG_ECHOLNPGM("V1:", rawvalue);
     const float value = 1.0f * rawvalue;
-    DEBUG_ECHOLNPAIR("V2:", value);
+    DEBUG_ECHOLNPGM("V2:", value);
     float newvalue = 0;
 
     switch (var.VP) {

--- a/Marlin/src/lcd/extui/dgus/origin/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/origin/DGUSScreenHandler.cpp
@@ -134,7 +134,7 @@ void DGUSScreenHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
   // meaning "return to previous screen"
   DGUSLCD_Screens target = (DGUSLCD_Screens)tmp[1];
 
-  DEBUG_ECHOLNPAIR("\n DEBUG target", target);
+  DEBUG_ECHOLNPGM("\n DEBUG target", target);
 
   if (target == DGUSLCD_SCREEN_POPUP) {
     // Special handling for popup is to return to previous menu
@@ -146,7 +146,7 @@ void DGUSScreenHandler::ScreenChangeHook(DGUS_VP_Variable &var, void *val_ptr) {
   UpdateNewScreen(target);
 
   #ifdef DEBUG_DGUSLCD
-    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPAIR("WARNING: No screen Mapping found for ", target);
+    if (!DGUSLCD_FindScreenVPMapList(target)) DEBUG_ECHOLNPGM("WARNING: No screen Mapping found for ", target);
   #endif
 }
 
@@ -190,10 +190,10 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
 
   if (!movevalue) {
     // homing
-    DEBUG_ECHOPAIR(" homing ", AS_CHAR(axiscode));
+    DEBUG_ECHOPGM(" homing ", AS_CHAR(axiscode));
     char buf[6] = "G28 X";
     buf[4] = axiscode;
-    //DEBUG_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPGM(" ", buf);
     queue.enqueue_one_now(buf);
     //DEBUG_ECHOLNPGM(" ✓");
     ForceCompleteUpdate();
@@ -201,7 +201,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   }
   else {
     // movement
-    DEBUG_ECHOPAIR(" move ", AS_CHAR(axiscode));
+    DEBUG_ECHOPGM(" move ", AS_CHAR(axiscode));
     bool old_relative_mode = relative_mode;
     if (!relative_mode) {
       //DEBUG_ECHOPGM(" G91");
@@ -215,13 +215,13 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
     if (movevalue < 0) { value = -value; sign[0] = '-'; }
     int16_t fraction = ABS(movevalue) % 100;
     snprintf_P(buf, 32, PSTR("G0 %c%s%d.%02d F%d"), axiscode, sign, value, fraction, speed);
-    //DEBUG_ECHOPAIR(" ", buf);
+    //DEBUG_ECHOPGM(" ", buf);
     queue.enqueue_one_now(buf);
     //DEBUG_ECHOLNPGM(" ✓ ");
     if (backup_speed != speed) {
       snprintf_P(buf, 32, PSTR("G0 F%d"), backup_speed);
       queue.enqueue_one_now(buf);
-      //DEBUG_ECHOPAIR(" ", buf);
+      //DEBUG_ECHOPGM(" ", buf);
     }
     // while (!enqueue_and_echo_command(buf)) idle();
     //DEBUG_ECHOLNPGM(" ✓ ");
@@ -237,16 +237,16 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   return;
 
   cannotmove:
-    DEBUG_ECHOLNPAIR(" cannot move ", AS_CHAR(axiscode));
+    DEBUG_ECHOLNPGM(" cannot move ", AS_CHAR(axiscode));
     return;
 }
 
 #if HAS_PID_HEATING
   void DGUSScreenHandler::HandleTemperaturePIDChanged(DGUS_VP_Variable &var, void *val_ptr) {
     uint16_t rawvalue = swap16(*(uint16_t*)val_ptr);
-    DEBUG_ECHOLNPAIR("V1:", rawvalue);
+    DEBUG_ECHOLNPGM("V1:", rawvalue);
     float value = (float)rawvalue / 10;
-    DEBUG_ECHOLNPAIR("V2:", value);
+    DEBUG_ECHOLNPGM("V2:", value);
     float newvalue = 0;
 
     switch (var.VP) {

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.cpp
@@ -159,7 +159,7 @@ void DGUSDisplay::WriteStringPGM(uint16_t addr, const void* data_ptr, uint8_t si
 }
 
 void DGUSDisplay::SwitchScreen(DGUS_Screen screen) {
-  DEBUG_ECHOLNPAIR("SwitchScreen ", (uint8_t)screen);
+  DEBUG_ECHOLNPGM("SwitchScreen ", (uint8_t)screen);
   const uint8_t command[] = { 0x5A, 0x01, 0x00, (uint8_t)screen };
   Write(0x84, command, sizeof(command));
 }
@@ -167,13 +167,13 @@ void DGUSDisplay::SwitchScreen(DGUS_Screen screen) {
 void DGUSDisplay::PlaySound(uint8_t start, uint8_t len, uint8_t volume) {
   if (volume == 0) volume = DGUSDisplay::volume;
   if (volume == 0) return;
-  DEBUG_ECHOLNPAIR("PlaySound ", start, ":", len, "\nVolume ", volume);
+  DEBUG_ECHOLNPGM("PlaySound ", start, ":", len, "\nVolume ", volume);
   const uint8_t command[] = { start, len, volume, 0x00 };
   Write(0xA0, command, sizeof(command));
 }
 
 void DGUSDisplay::EnableControl(DGUS_Screen screen, DGUS_ControlType type, DGUS_Control control) {
-  DEBUG_ECHOLNPAIR("EnableControl ", (uint8_t)control, "\nScreen ", (uint8_t)screen, "\nType ", (uint8_t)type);
+  DEBUG_ECHOLNPGM("EnableControl ", (uint8_t)control, "\nScreen ", (uint8_t)screen, "\nType ", (uint8_t)type);
 
   const uint8_t command[] = { 0x5A, 0xA5, 0x00, (uint8_t)screen, (uint8_t)control, type, 0x00, 0x01 };
   Write(0xB0, command, sizeof(command));
@@ -183,7 +183,7 @@ void DGUSDisplay::EnableControl(DGUS_Screen screen, DGUS_ControlType type, DGUS_
 }
 
 void DGUSDisplay::DisableControl(DGUS_Screen screen, DGUS_ControlType type, DGUS_Control control) {
-  DEBUG_ECHOLNPAIR("DisableControl ", (uint8_t)control, "\nScreen ", (uint8_t)screen, "\nType ", (uint8_t)type);
+  DEBUG_ECHOLNPGM("DisableControl ", (uint8_t)control, "\nScreen ", (uint8_t)screen, "\nType ", (uint8_t)type);
 
   const uint8_t command[] = { 0x5A, 0xA5, 0x00, (uint8_t)screen, (uint8_t)control, type, 0x00, 0x00 };
   Write(0xB0, command, sizeof(command));
@@ -203,14 +203,14 @@ uint8_t DGUSDisplay::GetVolume() {
 void DGUSDisplay::SetBrightness(uint8_t new_brightness) {
   brightness = constrain(new_brightness, 0, 100);
   new_brightness = map_precise(brightness, 0, 100, 5, 100);
-  DEBUG_ECHOLNPAIR("SetBrightness ", new_brightness);
+  DEBUG_ECHOLNPGM("SetBrightness ", new_brightness);
   const uint8_t command[] = { new_brightness, new_brightness };
   Write(0x82, command, sizeof(command));
 }
 
 void DGUSDisplay::SetVolume(uint8_t new_volume) {
   volume = map_precise(constrain(new_volume, 0, 100), 0, 100, 0, 255);
-  DEBUG_ECHOLNPAIR("SetVolume ", volume);
+  DEBUG_ECHOLNPGM("SetVolume ", volume);
   const uint8_t command[] = { volume, 0x00 };
   Write(0xA1, command, sizeof(command));
 }
@@ -234,19 +234,19 @@ void DGUSDisplay::ProcessRx() {
 
       case DGUS_IDLE: // Waiting for the first header byte
         receivedbyte = LCD_SERIAL.read();
-        DEBUG_ECHOPAIR("< ", receivedbyte);
+        DEBUG_ECHOPGM("< ", receivedbyte);
         if (DGUS_HEADER1 == receivedbyte) rx_datagram_state = DGUS_HEADER1_SEEN;
         break;
 
       case DGUS_HEADER1_SEEN: // Waiting for the second header byte
         receivedbyte = LCD_SERIAL.read();
-        DEBUG_ECHOPAIR(" ", receivedbyte);
+        DEBUG_ECHOPGM(" ", receivedbyte);
         rx_datagram_state = (DGUS_HEADER2 == receivedbyte) ? DGUS_HEADER2_SEEN : DGUS_IDLE;
         break;
 
       case DGUS_HEADER2_SEEN: // Waiting for the length byte
         rx_datagram_len = LCD_SERIAL.read();
-        DEBUG_ECHOPAIR(" (", rx_datagram_len, ") ");
+        DEBUG_ECHOPGM(" (", rx_datagram_len, ") ");
 
         // Telegram min len is 3 (command and one word of payload)
         rx_datagram_state = WITHIN(rx_datagram_len, 3, DGUS_RX_BUFFER_SIZE) ? DGUS_WAIT_TELEGRAM : DGUS_IDLE;
@@ -258,7 +258,7 @@ void DGUSDisplay::ProcessRx() {
         initialized = true; // We've talked to it, so we defined it as initialized.
         uint8_t command = LCD_SERIAL.read();
 
-        DEBUG_ECHOPAIR("# ", command);
+        DEBUG_ECHOPGM("# ", command);
 
         uint8_t readlen = rx_datagram_len - 1;  // command is part of len.
         unsigned char tmp[rx_datagram_len - 1];
@@ -266,7 +266,7 @@ void DGUSDisplay::ProcessRx() {
 
         while (readlen--) {
           receivedbyte = LCD_SERIAL.read();
-          DEBUG_ECHOPAIR(" ", receivedbyte);
+          DEBUG_ECHOPGM(" ", receivedbyte);
           *ptmp++ = receivedbyte;
         }
         DEBUG_ECHOPGM(" # ");
@@ -287,7 +287,7 @@ void DGUSDisplay::ProcessRx() {
         if (command == DGUS_READVAR) {
           const uint16_t addr = tmp[0] << 8 | tmp[1];
           const uint8_t dlen = tmp[2] << 1;  // Convert to Bytes. (Display works with words)
-          DEBUG_ECHOPAIR("addr=", addr, " dlen=", dlen, "> ");
+          DEBUG_ECHOPGM("addr=", addr, " dlen=", dlen, "> ");
 
           if (addr == DGUS_VERSION && dlen == 2) {
             DEBUG_ECHOLNPGM("VERSIONS");
@@ -400,7 +400,7 @@ bool DGUS_PopulateVP(const DGUS_Addr addr, DGUS_VP * const buffer) {
       return true;
     }
   } while (++ret);
-  DEBUG_ECHOLNPAIR("VP not found: ", (uint16_t)addr);
+  DEBUG_ECHOLNPGM("VP not found: ", (uint16_t)addr);
   return false;
 }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/flash_storage.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/archim2-flash/flash_storage.cpp
@@ -178,9 +178,9 @@ bool UIFlashStorage::is_present = false;
 
     if (!is_known) {
       SERIAL_ECHO_MSG("Unable to locate supported SPI Flash Memory.");
-      SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("  Manufacturer ID, got: ", manufacturer_id);
-      SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("  Device Type    , got: ", device_type);
-      SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("  Capacity       , got: ", capacity);
+      SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("  Manufacturer ID, got: ", manufacturer_id);
+      SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("  Device Type    , got: ", device_type);
+      SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("  Capacity       , got: ", capacity);
     }
 
     return is_known;
@@ -247,7 +247,7 @@ bool UIFlashStorage::is_present = false;
         case 0xFFFFFFFFul: return read_offset;
         case delimiter:    read_offset = offset; break;
         default:
-          SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("Invalid delimiter in Flash: ", delim);
+          SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("Invalid delimiter in Flash: ", delim);
           return -1;
       }
     }
@@ -325,7 +325,7 @@ bool UIFlashStorage::is_present = false;
     }
 
     SERIAL_ECHO_START();
-    SERIAL_ECHOPAIR("Writing UI settings to SPI Flash (offset ", write_addr);
+    SERIAL_ECHOPGM("Writing UI settings to SPI Flash (offset ", write_addr);
     SERIAL_ECHOPGM(")...");
 
     const uint32_t delim = delimiter;
@@ -509,7 +509,7 @@ bool UIFlashStorage::is_present = false;
 
     bytes_remaining = get_media_file_size(slot);
     if (bytes_remaining != 0xFFFFFFFFUL) {
-      SERIAL_ECHO_START(); SERIAL_ECHOLNPAIR("Boot media file size:", bytes_remaining);
+      SERIAL_ECHO_START(); SERIAL_ECHOLNPGM("Boot media file size:", bytes_remaining);
       addr = get_media_file_start(slot);
       return true;
     }

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
@@ -131,7 +131,7 @@ namespace ExtUI {
   #if HAS_PID_HEATING
     void onPidTuning(const result_t rst) {
       // Called for temperature PID tuning result
-      //SERIAL_ECHOLNPAIR("OnPidTuning:", rst);
+      //SERIAL_ECHOLNPGM("OnPidTuning:", rst);
       switch (rst) {
         case PID_STARTED:
           StatusScreen::setStatusMessage(GET_TEXT_F(MSG_PID_AUTOTUNE));

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/basic/commands.cpp
@@ -1025,8 +1025,8 @@ template <class T> bool CLCD::CommandFifo::write(T data, uint16_t len) {
   if (Command_Space < (len + padding)) {
     #if ENABLED(TOUCH_UI_DEBUG)
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR("Waiting for ", len + padding);
-      SERIAL_ECHOLNPAIR(" bytes in command queue, now free: ", Command_Space);
+      SERIAL_ECHOPGM("Waiting for ", len + padding);
+      SERIAL_ECHOLNPGM(" bytes in command queue, now free: ", Command_Space);
     #endif
     do {
       Command_Space = mem_read_32(REG::CMDB_SPACE) & 0x0FFF;

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/compat.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/compat.h
@@ -199,7 +199,7 @@
   #define _NUM_ARGS(_,Z,Y,X,W,V,U,T,S,R,Q,P,O,N,M,L,K,J,I,H,G,F,E,D,C,B,A,OUT,...) OUT
   #define NUM_ARGS(V...) _NUM_ARGS(0,V,26,25,24,23,22,21,20,19,18,17,16,15,14,13,12,11,10,9,8,7,6,5,4,3,2,1,0)
 
-  // SERIAL_ECHOPAIR / SERIAL_ECHOPAIR_P is used to output a key value pair. The key must be a string and the value can be anything
+  // SERIAL_ECHOPGM / SERIAL_ECHOPGM_P is used to output a key value pair. The key must be a string and the value can be anything
   // Print up to 12 pairs of values. Odd elements auto-wrapped in PSTR().
   #define __SEP_N(N,V...)   _SEP_##N(V)
   #define _SEP_N(N,V...)    __SEP_N(N,V)
@@ -218,9 +218,9 @@
   #define SERIAL_ECHO_START()
   #define SERIAL_ECHOLNPGM(str)       Serial.println(F(str))
   #define SERIAL_ECHOPGM(str)         Serial.print(F(str))
-  #define SERIAL_ECHO_MSG(V...)       SERIAL_ECHOLNPAIR(V)
-  #define SERIAL_ECHOLNPAIR(V...)     _SELP_N(NUM_ARGS(V),V)
-  #define SERIAL_ECHOPAIR(str, val)   do{ Serial.print(F(str)); Serial.print(val); }while(0)
+  #define SERIAL_ECHO_MSG(V...)       SERIAL_ECHOLNPGM(V)
+  #define SERIAL_ECHOLNPGM(V...)     _SELP_N(NUM_ARGS(V),V)
+  #define SERIAL_ECHOPGM(str, val)   do{ Serial.print(F(str)); Serial.print(val); }while(0)
 
   #define safe_delay delay
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/dl_cache.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/dl_cache.cpp
@@ -132,8 +132,8 @@ bool DLCache::store(uint32_t min_bytes /* = 0*/) {
     // Not enough memory to cache the display list.
     #if ENABLED(TOUCH_UI_DEBUG)
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR  ("Not enough space in GRAM to cache display list, free space: ", dl_slot_size);
-      SERIAL_ECHOLNPAIR(" Required: ", dl_size);
+      SERIAL_ECHOPGM  ("Not enough space in GRAM to cache display list, free space: ", dl_slot_size);
+      SERIAL_ECHOLNPGM(" Required: ", dl_size);
     #endif
     dl_slot_used = 0;
     save_slot();
@@ -142,8 +142,8 @@ bool DLCache::store(uint32_t min_bytes /* = 0*/) {
   else {
     #if ENABLED(TOUCH_UI_DEBUG)
       SERIAL_ECHO_START();
-      SERIAL_ECHOPAIR  ("Saving DL to RAMG cache, bytes: ", dl_slot_used);
-      SERIAL_ECHOLNPAIR(" Free space: ", dl_slot_size);
+      SERIAL_ECHOPGM  ("Saving DL to RAMG cache, bytes: ", dl_slot_used);
+      SERIAL_ECHOLNPGM(" Free space: ", dl_slot_size);
     #endif
     dl_slot_used = dl_size;
     save_slot();
@@ -172,8 +172,8 @@ void DLCache::append() {
     cmd.execute();
     wait_until_idle();
     SERIAL_ECHO_START();
-    SERIAL_ECHOPAIR  ("Appending to DL from RAMG cache, bytes: ", dl_slot_used);
-    SERIAL_ECHOLNPAIR(" REG_CMD_DL: ", CLCD::mem_read_32(REG::CMD_DL));
+    SERIAL_ECHOPGM  ("Appending to DL from RAMG cache, bytes: ", dl_slot_used);
+    SERIAL_ECHOLNPGM(" REG_CMD_DL: ", CLCD::mem_read_32(REG::CMD_DL));
   #endif
 }
 

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.cpp
@@ -33,7 +33,7 @@ uint8_t ScreenRef::lookupScreen(onRedraw_func_t onRedraw_ptr) {
   }
   #if ENABLED(TOUCH_UI_DEBUG)
     SERIAL_ECHO_START();
-    SERIAL_ECHOPAIR("Screen not found: ", (uintptr_t) onRedraw_ptr);
+    SERIAL_ECHOPGM("Screen not found: ", (uintptr_t) onRedraw_ptr);
   #endif
   return 0xFF;
 }

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_lib/extended/screen_types.h
@@ -237,7 +237,7 @@ class CachedScreen {
       cmd.cmd(CMD_SWAP);
       cmd.execute();
       #if ENABLED(TOUCH_UI_DEBUG)
-        SERIAL_ECHOLNPAIR("Time to draw screen (ms): ", millis() - start_time);
+        SERIAL_ECHOLNPGM("Time to draw screen (ms): ", millis() - start_time);
       #endif
     }
 };

--- a/Marlin/src/lcd/extui/malyan/malyan.cpp
+++ b/Marlin/src/lcd/extui/malyan/malyan.cpp
@@ -122,7 +122,7 @@ void set_lcd_error_P(PGM_P const error, PGM_P const component/*=nullptr*/) {
 void process_lcd_c_command(const char *command) {
   const int target_val = command[1] ? atoi(command + 1) : -1;
   if (target_val < 0) {
-    DEBUG_ECHOLNPAIR("UNKNOWN C COMMAND ", command);
+    DEBUG_ECHOLNPGM("UNKNOWN C COMMAND ", command);
     return;
   }
   switch (command[0]) {
@@ -143,7 +143,7 @@ void process_lcd_c_command(const char *command) {
       case 'P': ExtUI::setTargetTemp_celsius(target_val, ExtUI::heater_t::BED); break;
     #endif
 
-    default: DEBUG_ECHOLNPAIR("UNKNOWN C COMMAND ", command);
+    default: DEBUG_ECHOLNPGM("UNKNOWN C COMMAND ", command);
   }
 }
 
@@ -185,7 +185,7 @@ void process_lcd_eb_command(const char *command) {
       write_to_lcd(message_buffer);
     } break;
 
-    default: DEBUG_ECHOLNPAIR("UNKNOWN E/B COMMAND ", command);
+    default: DEBUG_ECHOLNPGM("UNKNOWN E/B COMMAND ", command);
   }
 }
 
@@ -212,7 +212,7 @@ void process_lcd_j_command(const char *command) {
     case 'Y': j_move_axis<ExtUI::axis_t>(command, ExtUI::axis_t::Y); break;
     case 'Z': j_move_axis<ExtUI::axis_t>(command, ExtUI::axis_t::Z); break;
     case 'X': j_move_axis<ExtUI::axis_t>(command, ExtUI::axis_t::X); break;
-    default: DEBUG_ECHOLNPAIR("UNKNOWN J COMMAND ", command);
+    default: DEBUG_ECHOLNPGM("UNKNOWN J COMMAND ", command);
   }
 }
 
@@ -336,7 +336,7 @@ void process_lcd_s_command(const char *command) {
       #endif
     } break;
 
-    default: DEBUG_ECHOLNPAIR("UNKNOWN S COMMAND ", command);
+    default: DEBUG_ECHOLNPGM("UNKNOWN S COMMAND ", command);
   }
 }
 
@@ -360,11 +360,11 @@ void process_lcd_command(const char *command) {
       case 'C': process_lcd_c_command(current); break;
       case 'B':
       case 'E': process_lcd_eb_command(current); break;
-      default: DEBUG_ECHOLNPAIR("UNKNOWN COMMAND ", command);
+      default: DEBUG_ECHOLNPGM("UNKNOWN COMMAND ", command);
     }
   }
   else
-    DEBUG_ECHOLNPAIR("UNKNOWN COMMAND FORMAT ", command);
+    DEBUG_ECHOLNPGM("UNKNOWN COMMAND FORMAT ", command);
 }
 
 //

--- a/Marlin/src/lcd/extui/malyan/malyan_extui.cpp
+++ b/Marlin/src/lcd/extui/malyan/malyan_extui.cpp
@@ -106,7 +106,7 @@ namespace ExtUI {
 
     void onPidTuning(const result_t rst) {
       // Called for temperature PID tuning result
-      //SERIAL_ECHOLNPAIR("OnPidTuning:", rst);
+      //SERIAL_ECHOLNPGM("OnPidTuning:", rst);
       switch (rst) {
         case PID_STARTED:
           set_lcd_error_P(GET_TEXT(MSG_PID_AUTOTUNE));

--- a/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/pic_manager.cpp
@@ -233,7 +233,7 @@ uint32_t lv_get_pic_addr(uint8_t *Pname) {
   currentFlashPage = 0;
 
   #if ENABLED(MARLIN_DEV_MODE)
-    SERIAL_ECHOLNPAIR("Getting picture SPI Flash Address: ", (const char*)Pname);
+    SERIAL_ECHOLNPGM("Getting picture SPI Flash Address: ", (const char*)Pname);
   #endif
 
   W25QXX.init(SPI_QUARTER_SPEED);
@@ -408,7 +408,7 @@ uint32_t Pic_Info_Write(uint8_t *P_name, uint32_t P_size) {
     createFilename(dosFilename, entry);
     if (!file.open(&dir, dosFilename, O_READ)) {
       #if ENABLED(MARLIN_DEV_MODE)
-        SERIAL_ECHOLNPAIR("Error opening Asset: ", fn);
+        SERIAL_ECHOLNPGM("Error opening Asset: ", fn);
       #endif
       return;
     }
@@ -463,7 +463,7 @@ uint32_t Pic_Info_Write(uint8_t *P_name, uint32_t P_size) {
         } while (pbr >= BMP_WRITE_BUF_LEN);
       #endif
       #if ENABLED(MARLIN_DEV_MODE)
-        SERIAL_ECHOLNPAIR("Space used: ", fn, " - ", (SPIFlash.getCurrentPage() + 1) * SPI_FLASH_PageSize / 1024, "KB");
+        SERIAL_ECHOLNPGM("Space used: ", fn, " - ", (SPIFlash.getCurrentPage() + 1) * SPI_FLASH_PageSize / 1024, "KB");
         totalCompressed += (SPIFlash.getCurrentPage() + 1) * SPI_FLASH_PageSize;
       #endif
       SPIFlash.endWrite();
@@ -481,7 +481,7 @@ uint32_t Pic_Info_Write(uint8_t *P_name, uint32_t P_size) {
     file.close();
 
     #if ENABLED(MARLIN_DEV_MODE)
-      SERIAL_ECHOLNPAIR("Asset added: ", fn);
+      SERIAL_ECHOLNPGM("Asset added: ", fn);
     #endif
   }
 
@@ -537,8 +537,8 @@ uint32_t Pic_Info_Write(uint8_t *P_name, uint32_t P_size) {
     #if ENABLED(MARLIN_DEV_MODE)
       uint8_t pic_counter = 0;
       W25QXX.SPI_FLASH_BufferRead(&pic_counter, PIC_COUNTER_ADDR, 1);
-      SERIAL_ECHOLNPAIR("Total assets loaded: ", pic_counter);
-      SERIAL_ECHOLNPAIR("Total Uncompressed: ", totalSizes, ", Compressed: ", totalCompressed);
+      SERIAL_ECHOLNPGM("Total assets loaded: ", pic_counter);
+      SERIAL_ECHOLNPGM("Total Uncompressed: ", totalSizes, ", Compressed: ", totalCompressed);
     #endif
   }
 

--- a/Marlin/src/lcd/extui/nextion/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/nextion/FileNavigator.cpp
@@ -79,7 +79,7 @@ void FileNavigator::getFiles(uint16_t index) {
   lastindex = index;
 
   #if NEXDEBUG(AC_FILE)
-    DEBUG_ECHOLNPAIR("index=", index, " currentindex=", currentindex);
+    DEBUG_ECHOLNPGM("index=", index, " currentindex=", currentindex);
   #endif
 
   if (currentindex == 0 && folderdepth > 0) { // Add a link to go up a folder
@@ -127,7 +127,7 @@ void FileNavigator::getFiles(uint16_t index) {
       fcnt++;
       fseek = seek;
       #if NEXDEBUG(AC_FILE)
-        DEBUG_ECHOLNPAIR("-", seek, " '", filelist.longFilename(), "' '", currentfoldername, "", filelist.shortFilename(), "'\n");
+        DEBUG_ECHOLNPGM("-", seek, " '", filelist.longFilename(), "' '", currentfoldername, "", filelist.shortFilename(), "'\n");
       #endif
     }
   }
@@ -137,7 +137,7 @@ void FileNavigator::getFiles(uint16_t index) {
 
 void FileNavigator::changeDIR(char *folder) {
   #if NEXDEBUG(AC_FILE)
-    DEBUG_ECHOLNPAIR("currentfolder: ", currentfoldername, "  New: ", folder);
+    DEBUG_ECHOLNPGM("currentfolder: ", currentfoldername, "  New: ", folder);
   #endif
   if (folderdepth >= MAX_FOLDER_DEPTH) return; // limit the folder depth
   strcat(currentfoldername, folder);
@@ -165,7 +165,7 @@ void FileNavigator::upDIR() {
     pos[1] = '\0';
   }
   #if NEXDEBUG(AC_FILE)
-    DEBUG_ECHOLNPAIR("depth: ", folderdepth, " currentfoldername: ", currentfoldername);
+    DEBUG_ECHOLNPGM("depth: ", folderdepth, " currentfoldername: ", currentfoldername);
   #endif
 }
 

--- a/Marlin/src/lcd/extui/nextion/nextion_tft.cpp
+++ b/Marlin/src/lcd/extui/nextion/nextion_tft.cpp
@@ -72,7 +72,7 @@ void NextionTFT::Startup() {
   SEND_VALasTXT("tmppage.bedy", Y_BED_SIZE);
   SEND_VALasTXT("tmppage.bedz", Z_MAX_POS);
 
-  DEBUG_ECHOLNPAIR("Nextion Debug Level ", NEXDEBUGLEVEL);
+  DEBUG_ECHOLNPGM("Nextion Debug Level ", NEXDEBUGLEVEL);
 }
 
 void NextionTFT::IdleLoop() {
@@ -98,13 +98,13 @@ void NextionTFT::PrintFinished() {
 void NextionTFT::ConfirmationRequest(const char * const msg) {
   SEND_VALasTXT("tmppage.M117", msg);
   #if NEXDEBUG(N_MARLIN)
-    DEBUG_ECHOLNPAIR("ConfirmationRequest() ", msg, " printer_state:", printer_state);
+    DEBUG_ECHOLNPGM("ConfirmationRequest() ", msg, " printer_state:", printer_state);
   #endif
 }
 
 void NextionTFT::StatusChange(const char * const msg) {
   #if NEXDEBUG(N_MARLIN)
-    DEBUG_ECHOLNPAIR("StatusChange() ", msg, "\nprinter_state:", printer_state);
+    DEBUG_ECHOLNPGM("StatusChange() ", msg, "\nprinter_state:", printer_state);
   #endif
   SEND_VALasTXT("tmppage.M117", msg);
 }
@@ -133,12 +133,12 @@ bool NextionTFT::ReadTFTCommand() {
     if (nextion_command[0] == 'G' || nextion_command[0] == 'M' || nextion_command[0] == 'T')
       injectCommands(nextion_command);
     #if NEXDEBUG(N_ALL)
-      DEBUG_ECHOLNPAIR("< ", nextion_command);
+      DEBUG_ECHOLNPGM("< ", nextion_command);
     #endif
     #if NEXDEBUG(N_SOME)
       uint8_t req = atoi(&nextion_command[1]);
       if (req > 7 && req != 20)
-        DEBUG_ECHOLNPAIR(  "> ", AS_CHAR(nextion_command[0]),
+        DEBUG_ECHOLNPGM(  "> ", AS_CHAR(nextion_command[0]),
                          "\n> ", AS_CHAR(nextion_command[1]),
                          "\n> ", AS_CHAR(nextion_command[2]),
                          "\n> ", AS_CHAR(nextion_command[3]),
@@ -151,7 +151,7 @@ bool NextionTFT::ReadTFTCommand() {
 void NextionTFT::SendFileList(int8_t startindex) {
   // respond to panel request for 7 files starting at index
   #if NEXDEBUG(N_INFO)
-    DEBUG_ECHOLNPAIR("## SendFileList ## ", startindex);
+    DEBUG_ECHOLNPGM("## SendFileList ## ", startindex);
   #endif
   filenavigator.getFiles(startindex);
 }

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -778,7 +778,7 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
             TERN_(MULTI_E_MANUAL, axis == E_AXIS ? e_index :) active_extruder
           );
 
-          //SERIAL_ECHOLNPAIR("Add planner.move with Axis ", AS_CHAR(axis_codes[axis]), " at FR ", fr_mm_s);
+          //SERIAL_ECHOLNPGM("Add planner.move with Axis ", AS_CHAR(axis_codes[axis]), " at FR ", fr_mm_s);
 
           axis = NO_AXIS_ENUM;
 
@@ -795,7 +795,7 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
       TERN_(MULTI_E_MANUAL, if (move_axis == E_AXIS) e_index = eindex);
       start_time = millis() + (menu_scale < 0.99f ? 0UL : 250UL); // delay for bigger moves
       axis = move_axis;
-      //SERIAL_ECHOLNPAIR("Post Move with Axis ", AS_CHAR(axis_codes[axis]), " soon.");
+      //SERIAL_ECHOLNPGM("Post Move with Axis ", AS_CHAR(axis_codes[axis]), " soon.");
     }
 
     #if ENABLED(AUTO_BED_LEVELING_UBL)
@@ -981,10 +981,10 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
                   //#define ENCODER_RATE_MULTIPLIER_DEBUG
                   #if ENABLED(ENCODER_RATE_MULTIPLIER_DEBUG)
                     SERIAL_ECHO_START();
-                    SERIAL_ECHOPAIR("Enc Step Rate: ", encoderStepRate);
-                    SERIAL_ECHOPAIR("  Multiplier: ", encoderMultiplier);
-                    SERIAL_ECHOPAIR("  ENCODER_10X_STEPS_PER_SEC: ", ENCODER_10X_STEPS_PER_SEC);
-                    SERIAL_ECHOPAIR("  ENCODER_100X_STEPS_PER_SEC: ", ENCODER_100X_STEPS_PER_SEC);
+                    SERIAL_ECHOPGM("Enc Step Rate: ", encoderStepRate);
+                    SERIAL_ECHOPGM("  Multiplier: ", encoderMultiplier);
+                    SERIAL_ECHOPGM("  ENCODER_10X_STEPS_PER_SEC: ", ENCODER_10X_STEPS_PER_SEC);
+                    SERIAL_ECHOPGM("  ENCODER_100X_STEPS_PER_SEC: ", ENCODER_100X_STEPS_PER_SEC);
                     SERIAL_EOL();
                   #endif
                 }

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -217,7 +217,7 @@ void menu_advanced_settings();
 
   #if ENABLED(BLTOUCH_LCD_VOLTAGE_MENU)
     void bltouch_report() {
-      SERIAL_ECHOLNPAIR("EEPROM Last BLTouch Mode - ", bltouch.last_written_mode);
+      SERIAL_ECHOLNPGM("EEPROM Last BLTouch Mode - ", bltouch.last_written_mode);
       SERIAL_ECHOLNPGM("Configuration BLTouch Mode - " TERN(BLTOUCH_SET_5V_MODE, "5V", "OD"));
       char mess[21];
       strcpy_P(mess, PSTR("BLTouch Mode - "));

--- a/Marlin/src/lcd/menu/menu_tramming.cpp
+++ b/Marlin/src/lcd/menu/menu_tramming.cpp
@@ -56,12 +56,12 @@ static bool probe_single_point() {
   if (reference_index < 0) reference_index = tram_index;
   move_to_tramming_wait_pos();
 
-  DEBUG_ECHOLNPAIR("probe_single_point(", tram_index, ") = ", z_probed_height, "mm");
+  DEBUG_ECHOLNPGM("probe_single_point(", tram_index, ") = ", z_probed_height, "mm");
   return (z_isvalid[tram_index] = !isnan(z_probed_height));
 }
 
 static void _menu_single_probe() {
-  DEBUG_ECHOLNPAIR("Screen: single probe screen Arg:", tram_index);
+  DEBUG_ECHOLNPGM("Screen: single probe screen Arg:", tram_index);
   START_MENU();
   STATIC_ITEM(MSG_BED_TRAMMING, SS_LEFT);
   STATIC_ITEM(MSG_LAST_VALUE_SP, SS_LEFT, z_isvalid[tram_index] ? ftostr42_52(z_measured[reference_index] - z_measured[tram_index]) : "---");
@@ -87,7 +87,7 @@ static void tramming_wizard_menu() {
 
 // Init the wizard and enter the submenu
 void goto_tramming_wizard() {
-  DEBUG_ECHOLNPAIR("Screen: goto_tramming_wizard", 1);
+  DEBUG_ECHOLNPGM("Screen: goto_tramming_wizard", 1);
   ui.defer_status_screen();
 
   // Initialize measured point flags

--- a/Marlin/src/lcd/tft/tft_string.cpp
+++ b/Marlin/src/lcd/tft/tft_string.cpp
@@ -45,21 +45,21 @@ void TFT_String::set_font(const uint8_t *font) {
 
   for (glyph = 0; glyph < 256; glyph++) glyphs[glyph] = nullptr;
 
-  DEBUG_ECHOLNPAIR("Format: ",            font_header->Format);
-  DEBUG_ECHOLNPAIR("BBXWidth: ",          font_header->BBXWidth);
-  DEBUG_ECHOLNPAIR("BBXHeight: ",         font_header->BBXHeight);
-  DEBUG_ECHOLNPAIR("BBXOffsetX: ",        font_header->BBXOffsetX);
-  DEBUG_ECHOLNPAIR("BBXOffsetY: ",        font_header->BBXOffsetY);
-  DEBUG_ECHOLNPAIR("CapitalAHeight: ",    font_header->CapitalAHeight);
-  DEBUG_ECHOLNPAIR("Encoding65Pos: ",     font_header->Encoding65Pos);
-  DEBUG_ECHOLNPAIR("Encoding97Pos: ",     font_header->Encoding97Pos);
-  DEBUG_ECHOLNPAIR("FontStartEncoding: ", font_header->FontStartEncoding);
-  DEBUG_ECHOLNPAIR("FontEndEncoding: ",   font_header->FontEndEncoding);
-  DEBUG_ECHOLNPAIR("LowerGDescent: ",     font_header->LowerGDescent);
-  DEBUG_ECHOLNPAIR("FontAscent: ",        font_header->FontAscent);
-  DEBUG_ECHOLNPAIR("FontDescent: ",       font_header->FontDescent);
-  DEBUG_ECHOLNPAIR("FontXAscent: ",       font_header->FontXAscent);
-  DEBUG_ECHOLNPAIR("FontXDescent: ",      font_header->FontXDescent);
+  DEBUG_ECHOLNPGM("Format: ",            font_header->Format);
+  DEBUG_ECHOLNPGM("BBXWidth: ",          font_header->BBXWidth);
+  DEBUG_ECHOLNPGM("BBXHeight: ",         font_header->BBXHeight);
+  DEBUG_ECHOLNPGM("BBXOffsetX: ",        font_header->BBXOffsetX);
+  DEBUG_ECHOLNPGM("BBXOffsetY: ",        font_header->BBXOffsetY);
+  DEBUG_ECHOLNPGM("CapitalAHeight: ",    font_header->CapitalAHeight);
+  DEBUG_ECHOLNPGM("Encoding65Pos: ",     font_header->Encoding65Pos);
+  DEBUG_ECHOLNPGM("Encoding97Pos: ",     font_header->Encoding97Pos);
+  DEBUG_ECHOLNPGM("FontStartEncoding: ", font_header->FontStartEncoding);
+  DEBUG_ECHOLNPGM("FontEndEncoding: ",   font_header->FontEndEncoding);
+  DEBUG_ECHOLNPGM("LowerGDescent: ",     font_header->LowerGDescent);
+  DEBUG_ECHOLNPGM("FontAscent: ",        font_header->FontAscent);
+  DEBUG_ECHOLNPGM("FontDescent: ",       font_header->FontDescent);
+  DEBUG_ECHOLNPGM("FontXAscent: ",       font_header->FontXAscent);
+  DEBUG_ECHOLNPGM("FontXDescent: ",      font_header->FontXDescent);
 
   add_glyphs(font);
 }

--- a/Marlin/src/lcd/tft_io/touch_calibration.cpp
+++ b/Marlin/src/lcd/tft_io/touch_calibration.cpp
@@ -77,10 +77,10 @@ void TouchCalibration::validate_calibration() {
 
   if (calibration_state == CALIBRATION_SUCCESS) {
     SERIAL_ECHOLNPGM("Touch screen calibration completed");
-    SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_X ", calibration.x);
-    SERIAL_ECHOLNPAIR("TOUCH_CALIBRATION_Y ", calibration.y);
-    SERIAL_ECHOLNPAIR("TOUCH_OFFSET_X ", calibration.offset_x);
-    SERIAL_ECHOLNPAIR("TOUCH_OFFSET_Y ", calibration.offset_y);
+    SERIAL_ECHOLNPGM("TOUCH_CALIBRATION_X ", calibration.x);
+    SERIAL_ECHOLNPGM("TOUCH_CALIBRATION_Y ", calibration.y);
+    SERIAL_ECHOLNPGM("TOUCH_OFFSET_X ", calibration.offset_x);
+    SERIAL_ECHOLNPGM("TOUCH_OFFSET_Y ", calibration.offset_y);
     SERIAL_ECHO_TERNARY(calibration.orientation == TOUCH_LANDSCAPE, "TOUCH_ORIENTATION ", "TOUCH_LANDSCAPE", "TOUCH_PORTRAIT", "\n");
     TERN_(TOUCH_CALIBRATION_AUTO_SAVE, settings.save());
   }
@@ -95,7 +95,7 @@ bool TouchCalibration::handleTouch(uint16_t x, uint16_t y) {
   if (calibration_state < CALIBRATION_SUCCESS) {
     calibration_points[calibration_state].raw_x = x;
     calibration_points[calibration_state].raw_y = y;
-    DEBUG_ECHOLNPAIR("TouchCalibration - State: ", calibration_state, ", x: ", calibration_points[calibration_state].x, ", raw_x: ", x, ", y: ", calibration_points[calibration_state].y, ", raw_y: ", y);
+    DEBUG_ECHOLNPGM("TouchCalibration - State: ", calibration_state, ", x: ", calibration_points[calibration_state].x, ", raw_x: ", x, ", y: ", calibration_points[calibration_state].y, ", raw_y: ", y);
   }
 
   switch (calibration_state) {

--- a/Marlin/src/libs/L64XX/L64XX_Marlin.cpp
+++ b/Marlin/src/libs/L64XX/L64XX_Marlin.cpp
@@ -388,10 +388,10 @@ void L64XX_Marlin::set_param(const L64XX_axis_t axis, const uint8_t param, const
 
 inline void echo_min_max(const char a, const_float_t min, const_float_t max) {
   DEBUG_CHAR(' '); DEBUG_CHAR(a);
-  DEBUG_ECHOLNPAIR(" min = ", min, "  max = ", max);
+  DEBUG_ECHOLNPGM(" min = ", min, "  max = ", max);
 }
 inline void echo_oct_used(const_float_t oct, const uint8_t stall) {
-  DEBUG_ECHOPAIR("over_current_threshold used     : ", oct);
+  DEBUG_ECHOPGM("over_current_threshold used     : ", oct);
   DEBUG_ECHOPGM_P(stall ? PSTR("  (Stall") : PSTR("  (OCD"));
   DEBUG_ECHOLNPGM(" threshold)");
 }
@@ -568,7 +568,7 @@ uint8_t L64XX_Marlin::get_user_input(uint8_t &driver_count, L64XX_axis_t axis_in
   }
 
   DEBUG_ECHOPGM("Monitoring:");
-  for (j = 0; j < driver_count; j++) DEBUG_ECHOPAIR("  ", axis_mon[j]);
+  for (j = 0; j < driver_count; j++) DEBUG_ECHOPGM("  ", axis_mon[j]);
   DEBUG_EOL();
 
   // now have a list of driver(s) to monitor
@@ -589,19 +589,19 @@ uint8_t L64XX_Marlin::get_user_input(uint8_t &driver_count, L64XX_axis_t axis_in
     }
     // only print the tval from one of the drivers
     kval_hold = get_param(axis_index[0], L6474_TVAL);
-    DEBUG_ECHOLNPAIR("TVAL current (mA) = ", (kval_hold + 1) * sh.AXIS_STALL_CURRENT_CONSTANT_INV);
+    DEBUG_ECHOLNPGM("TVAL current (mA) = ", (kval_hold + 1) * sh.AXIS_STALL_CURRENT_CONSTANT_INV);
   }
   else {
     kval_hold = parser.byteval('K');
     if (kval_hold) {
-      DEBUG_ECHOLNPAIR("kval_hold = ", kval_hold);
+      DEBUG_ECHOLNPGM("kval_hold = ", kval_hold);
       for (j = 0; j < driver_count; j++)
         set_param(axis_index[j], L6470_KVAL_HOLD, kval_hold);
     }
     else {
       // only print the KVAL_HOLD from one of the drivers
       kval_hold = get_param(axis_index[0], L6470_KVAL_HOLD);
-      DEBUG_ECHOLNPAIR("KVAL_HOLD = ", kval_hold);
+      DEBUG_ECHOLNPGM("KVAL_HOLD = ", kval_hold);
     }
   }
 
@@ -629,7 +629,7 @@ uint8_t L64XX_Marlin::get_user_input(uint8_t &driver_count, L64XX_axis_t axis_in
         OCD_TH_actual = (OCD_TH_val_local + 1) * 375;
       }
 
-      DEBUG_ECHOLNPAIR("over_current_threshold specified: ", over_current_threshold);
+      DEBUG_ECHOLNPGM("over_current_threshold specified: ", over_current_threshold);
       if (!(sh.STATUS_AXIS_LAYOUT == L6474_STATUS_LAYOUT)) echo_oct_used((STALL_TH_val_local + 1) * 31.25, true);
       echo_oct_used((OCD_TH_val_local + 1) * 375, false);
 

--- a/Marlin/src/libs/MAX31865.cpp
+++ b/Marlin/src/libs/MAX31865.cpp
@@ -177,14 +177,14 @@ void MAX31865::begin(max31865_numwires_t wires, float zero, float ref) {
 
   #ifdef MAX31865_DEBUG_SPI
     #ifndef LARGE_PINMAP
-      SERIAL_ECHOLNPAIR(
+      SERIAL_ECHOLNPGM(
         "Regular begin call with _cs: ", _cs,
         " _miso: ", _miso,
         " _sclk: ", _sclk,
         " _mosi: ", _mosi
       );
     #else
-      SERIAL_ECHOLNPAIR(
+      SERIAL_ECHOLNPGM(
         "LARGE_PINMAP begin call with _cs: ", _cs,
         " _miso: ", _miso,
         " _sclk: ", _sclk,
@@ -192,7 +192,7 @@ void MAX31865::begin(max31865_numwires_t wires, float zero, float ref) {
       );
     #endif // LARGE_PINMAP
 
-    SERIAL_ECHOLNPAIR("config: ", readRegister8(MAX31856_CONFIG_REG));
+    SERIAL_ECHOLNPGM("config: ", readRegister8(MAX31856_CONFIG_REG));
     SERIAL_EOL();
   #endif // MAX31865_DEBUG_SPI
 }
@@ -290,7 +290,7 @@ uint16_t MAX31865::readRaw() {
   uint16_t rtd = readRegister16(MAX31856_RTDMSB_REG);
 
   #ifdef MAX31865_DEBUG
-    SERIAL_ECHOLNPAIR("RTD MSB:", (rtd >> 8), "  RTD LSB:", (rtd & 0x00FF));
+    SERIAL_ECHOLNPGM("RTD MSB:", (rtd >> 8), "  RTD LSB:", (rtd & 0x00FF));
   #endif
 
   // Disable the bias to lower power dissipation between reads.
@@ -437,7 +437,7 @@ void MAX31865::readRegisterN(uint8_t addr, uint8_t buffer[], uint8_t n) {
   while (n--) {
     buffer[0] = spixfer(0xFF);
     #ifdef MAX31865_DEBUG_SPI
-      SERIAL_ECHOLNPAIR("buffer read ", n, " data: ", buffer[0]);
+      SERIAL_ECHOLNPGM("buffer read ", n, " data: ", buffer[0]);
     #endif
     buffer++;
   }

--- a/Marlin/src/libs/bresenham.h
+++ b/Marlin/src/libs/bresenham.h
@@ -120,11 +120,11 @@ public:
 
   static void report(const uint8_t index) {
     if (index < Cfg::SIZE) {
-      SERIAL_ECHOPAIR("bresenham ", index, " : (", dividend[index], "/", divisor, ") ");
+      SERIAL_ECHOPGM("bresenham ", index, " : (", dividend[index], "/", divisor, ") ");
       if (counter[index] >= 0) SERIAL_CHAR(' ');
       if (labs(counter[index]) < 100) { SERIAL_CHAR(' '); if (labs(counter[index]) < 10) SERIAL_CHAR(' '); }
       SERIAL_ECHO(counter[index]);
-      SERIAL_ECHOLNPAIR(" ... ", value[index]);
+      SERIAL_ECHOLNPGM(" ... ", value[index]);
     }
   }
 

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -121,8 +121,8 @@ void recalc_delta_settings() {
  */
 
 #define DELTA_DEBUG(VAR) do { \
-    SERIAL_ECHOLNPAIR_P(PSTR("Cartesian X"), VAR.x, SP_Y_STR, VAR.y, SP_Z_STR, VAR.z); \
-    SERIAL_ECHOLNPAIR_P(PSTR("Delta A"), delta.a, SP_B_STR, delta.b, SP_C_STR, delta.c); \
+    SERIAL_ECHOLNPGM_P(PSTR("Cartesian X"), VAR.x, SP_Y_STR, VAR.y, SP_Z_STR, VAR.z); \
+    SERIAL_ECHOLNPGM_P(PSTR("Delta A"), delta.a, SP_B_STR, delta.b, SP_C_STR, delta.c); \
   }while(0)
 
 void inverse_kinematics(const xyz_pos_t &raw) {

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -578,13 +578,13 @@ void _O2 Endstops::report_states() {
         default: continue;
         REPEAT_1(NUM_RUNOUT_SENSORS, _CASE_RUNOUT)
       }
-      SERIAL_ECHOPGM(STR_FILAMENT_RUNOUT_SENSOR);
+      SERIAL_ECHOPGM(STR_FILAMENT);
       if (i > 1) SERIAL_CHAR(' ', '0' + i);
       print_es_state(extDigitalRead(pin) != state);
     }
     #undef _CASE_RUNOUT
   #elif HAS_FILAMENT_SENSOR
-    print_es_state(READ(FIL_RUNOUT1_PIN) != FIL_RUNOUT1_STATE, PSTR(STR_FILAMENT_RUNOUT_SENSOR));
+    print_es_state(READ(FIL_RUNOUT1_PIN) != FIL_RUNOUT1_STATE, PSTR(STR_FILAMENT));
   #endif
 
   TERN_(BLTOUCH, bltouch._reset_SW_mode());

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -429,7 +429,7 @@ void Endstops::event_handler() {
     #endif
 
     #define _ENDSTOP_HIT_ECHO(A,C) do{ \
-      SERIAL_ECHOPAIR(" " STRINGIFY(A) ":", planner.triggered_position_mm(_AXIS(A))); _SET_STOP_CHAR(A,C); }while(0)
+      SERIAL_ECHOPGM(" " STRINGIFY(A) ":", planner.triggered_position_mm(_AXIS(A))); _SET_STOP_CHAR(A,C); }while(0)
 
     #define _ENDSTOP_HIT_TEST(A,C) \
       if (TERN0(HAS_##A##_MIN, TEST(hit_state, A##_MIN)) || TERN0(HAS_##A##_MAX, TEST(hit_state, A##_MAX))) \
@@ -1271,7 +1271,7 @@ void Endstops::update() {
     #endif
 
     uint16_t endstop_change = live_state_local ^ old_live_state_local;
-    #define ES_REPORT_CHANGE(S) if (TEST(endstop_change, S)) SERIAL_ECHOPAIR("  " STRINGIFY(S) ":", TEST(live_state_local, S))
+    #define ES_REPORT_CHANGE(S) if (TEST(endstop_change, S)) SERIAL_ECHOPGM("  " STRINGIFY(S) ":", TEST(live_state_local, S))
 
     if (endstop_change) {
       #if HAS_X_MIN

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -195,7 +195,7 @@ inline void report_more_positions() {
 // Report the logical position for a given machine position
 inline void report_logical_position(const xyze_pos_t &rpos) {
   const xyze_pos_t lpos = rpos.asLogical();
-  SERIAL_ECHOPAIR_P(
+  SERIAL_ECHOPGM_P(
     LIST_N(DOUBLE(LINEAR_AXES),
          X_LBL, lpos.x,
       SP_Y_LBL, lpos.y,
@@ -257,7 +257,7 @@ void report_current_position_projected() {
   /**
    * Output the current grbl compatible state to serial while moving
    */
-  void report_current_grblstate_moving() { SERIAL_ECHOLNPAIR("S_XYZ:", int(M_State_grbl)); }
+  void report_current_grblstate_moving() { SERIAL_ECHOLNPGM("S_XYZ:", int(M_State_grbl)); }
 
   /**
    * Output the current position (processed) to serial while moving
@@ -266,7 +266,7 @@ void report_current_position_projected() {
 
     get_cartesian_from_steppers();
     const xyz_pos_t lpos = cartes.asLogical();
-    SERIAL_ECHOPAIR(
+    SERIAL_ECHOPGM(
       "X:", lpos.x
       #if HAS_Y_AXIS
         , " Y:", lpos.y
@@ -774,7 +774,7 @@ void restore_feedrate_and_scaling() {
     #endif
 
     if (DEBUGGING(LEVELING))
-      SERIAL_ECHOLNPAIR("Axis ", AS_CHAR(AXIS_CHAR(axis)), " min:", soft_endstop.min[axis], " max:", soft_endstop.max[axis]);
+      SERIAL_ECHOLNPGM("Axis ", AS_CHAR(AXIS_CHAR(axis)), " min:", soft_endstop.min[axis], " max:", soft_endstop.max[axis]);
   }
 
   /**
@@ -969,10 +969,10 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
     #endif
 
     /*
-    SERIAL_ECHOPAIR("mm=", cartesian_mm);
-    SERIAL_ECHOPAIR(" seconds=", seconds);
-    SERIAL_ECHOPAIR(" segments=", segments);
-    SERIAL_ECHOPAIR(" segment_mm=", cartesian_segment_mm);
+    SERIAL_ECHOPGM("mm=", cartesian_mm);
+    SERIAL_ECHOPGM(" seconds=", seconds);
+    SERIAL_ECHOPGM(" segments=", segments);
+    SERIAL_ECHOPGM(" segment_mm=", cartesian_segment_mm);
     SERIAL_EOL();
     //*/
 
@@ -1035,9 +1035,9 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
         const float inv_duration = scaled_fr_mm_s / cartesian_segment_mm;
       #endif
 
-      // SERIAL_ECHOPAIR("mm=", cartesian_mm);
-      // SERIAL_ECHOLNPAIR(" segments=", segments);
-      // SERIAL_ECHOLNPAIR(" segment_mm=", cartesian_segment_mm);
+      //SERIAL_ECHOPGM("mm=", cartesian_mm);
+      //SERIAL_ECHOLNPGM(" segments=", segments);
+      //SERIAL_ECHOLNPGM(" segment_mm=", cartesian_segment_mm);
 
       // Get the raw current position as starting point
       xyze_pos_t raw = current_position;
@@ -1204,7 +1204,7 @@ FORCE_INLINE void segment_idle(millis_t &next_idle_ms) {
               new_pos.x += duplicate_extruder_x_offset;
 
             // Move duplicate extruder into the correct position
-            if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Set planner X", inactive_extruder_x, " ... Line to X", new_pos.x);
+            if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Set planner X", inactive_extruder_x, " ... Line to X", new_pos.x);
             if (!planner.buffer_line(new_pos, planner.settings.max_feedrate_mm_s[X_AXIS], 1)) break;
             planner.synchronize();
 
@@ -1515,11 +1515,11 @@ void prepare_line_to_destination() {
     const feedRate_t home_fr_mm_s = fr_mm_s ?: homing_feedrate(axis);
 
     if (DEBUGGING(LEVELING)) {
-      DEBUG_ECHOPAIR("...(", AS_CHAR(AXIS_CHAR(axis)), ", ", distance, ", ");
+      DEBUG_ECHOPGM("...(", AS_CHAR(AXIS_CHAR(axis)), ", ", distance, ", ");
       if (fr_mm_s)
         DEBUG_ECHO(fr_mm_s);
       else
-        DEBUG_ECHOPAIR("[", home_fr_mm_s, "]");
+        DEBUG_ECHOPGM("[", home_fr_mm_s, "]");
       DEBUG_ECHOLNPGM(")");
     }
 
@@ -1595,12 +1595,12 @@ void prepare_line_to_destination() {
    * "trusted" position).
    */
   void set_axis_never_homed(const AxisEnum axis) {
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR(">>> set_axis_never_homed(", AS_CHAR(AXIS_CHAR(axis)), ")");
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM(">>> set_axis_never_homed(", AS_CHAR(AXIS_CHAR(axis)), ")");
 
     set_axis_untrusted(axis);
     set_axis_unhomed(axis);
 
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("<<< set_axis_never_homed(", AS_CHAR(AXIS_CHAR(axis)), ")");
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< set_axis_never_homed(", AS_CHAR(AXIS_CHAR(axis)), ")");
 
     TERN_(I2C_POSITION_ENCODERS, I2CPEM.unhomed(axis));
   }
@@ -1683,7 +1683,7 @@ void prepare_line_to_destination() {
 
       // Check if home distance within endstop assumed repeatability noise of .05mm and warn.
       if (ABS(phaseDelta) * planner.steps_to_mm[axis] / phasePerUStep < 0.05f)
-        SERIAL_ECHOLNPAIR("Selected home phase ", home_phase[axis],
+        SERIAL_ECHOLNPGM("Selected home phase ", home_phase[axis],
                          " too close to endstop trigger phase ", phaseCurrent,
                          ". Pick a different phase for ", AS_CHAR(AXIS_CHAR(axis)));
 
@@ -1695,7 +1695,7 @@ void prepare_line_to_destination() {
 
       // Optional debug messages
       if (DEBUGGING(LEVELING)) {
-        DEBUG_ECHOLNPAIR(
+        DEBUG_ECHOLNPGM(
           "Endstop ", AS_CHAR(AXIS_CHAR(axis)), " hit at Phase:", phaseCurrent,
           " Delta:", phaseDelta, " Distance:", mmDelta
         );
@@ -1741,7 +1741,7 @@ void prepare_line_to_destination() {
       ) return;
     #endif
 
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR(">>> homeaxis(", AS_CHAR(AXIS_CHAR(axis)), ")");
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM(">>> homeaxis(", AS_CHAR(AXIS_CHAR(axis)), ")");
 
     const int axis_home_dir = TERN0(DUAL_X_CARRIAGE, axis == X_AXIS)
                 ? TOOL_X_HOME_DIR(active_extruder) : home_dir(axis);
@@ -1780,7 +1780,7 @@ void prepare_line_to_destination() {
       const xyz_float_t backoff = SENSORLESS_BACKOFF_MM;
       if ((TERN0(X_SENSORLESS, axis == X_AXIS) || TERN0(Y_SENSORLESS, axis == Y_AXIS) || TERN0(Z_SENSORLESS, axis == Z_AXIS) || TERN0(I_SENSORLESS, axis == I_AXIS) || TERN0(J_SENSORLESS, axis == J_AXIS) || TERN0(K_SENSORLESS, axis == K_AXIS)) && backoff[axis]) {
         const float backoff_length = -ABS(backoff[axis]) * axis_home_dir;
-        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Sensorless backoff: ", backoff_length, "mm");
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Sensorless backoff: ", backoff_length, "mm");
         do_homing_move(axis, backoff_length, homing_feedrate(axis));
       }
     #endif
@@ -1796,7 +1796,7 @@ void prepare_line_to_destination() {
     // Fast move towards endstop until triggered
     //
     const float move_length = 1.5f * max_length(TERN(DELTA, Z_AXIS, axis)) * axis_home_dir;
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Home Fast: ", move_length, "mm");
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Home Fast: ", move_length, "mm");
     do_homing_move(axis, move_length, 0.0, !use_probe_bump);
 
     #if BOTH(HOMING_Z_WITH_PROBE, BLTOUCH_SLOW_MODE)
@@ -1806,7 +1806,7 @@ void prepare_line_to_destination() {
     // If a second homing move is configured...
     if (bump) {
       // Move away from the endstop by the axis HOMING_BUMP_MM
-      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Move Away: ", -bump, "mm");
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Move Away: ", -bump, "mm");
       do_homing_move(axis, -bump, TERN(HOMING_Z_WITH_PROBE, (axis == Z_AXIS ? z_probe_fast_mm_s : 0), 0), false);
 
       #if ENABLED(DETECT_BROKEN_ENDSTOP)
@@ -1839,7 +1839,7 @@ void prepare_line_to_destination() {
 
       // Slow move towards endstop until triggered
       const float rebump = bump * 2;
-      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Re-bump: ", rebump, "mm");
+      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Re-bump: ", rebump, "mm");
       do_homing_move(axis, rebump, get_homing_bump_feedrate(axis), true);
 
       #if BOTH(HOMING_Z_WITH_PROBE, BLTOUCH)
@@ -2003,7 +2003,7 @@ void prepare_line_to_destination() {
 
       // Retrace by the amount specified in delta_endstop_adj if more than min steps.
       if (adjDistance * (Z_HOME_DIR) < 0 && ABS(adjDistance) > minDistance) { // away from endstop, more than min distance
-        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("adjDistance:", adjDistance);
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("adjDistance:", adjDistance);
         do_homing_move(axis, adjDistance, get_homing_bump_feedrate(axis));
       }
 
@@ -2050,7 +2050,7 @@ void prepare_line_to_destination() {
       if (axis == Z_AXIS) fwretract.current_hop = 0.0;
     #endif
 
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("<<< homeaxis(", AS_CHAR(AXIS_CHAR(axis)), ")");
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("<<< homeaxis(", AS_CHAR(AXIS_CHAR(axis)), ")");
 
   } // homeaxis()
 
@@ -2075,7 +2075,7 @@ void prepare_line_to_destination() {
  * Callers must sync the planner position after calling this!
  */
 void set_axis_is_at_home(const AxisEnum axis) {
-  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR(">>> set_axis_is_at_home(", AS_CHAR(AXIS_CHAR(axis)), ")");
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM(">>> set_axis_is_at_home(", AS_CHAR(AXIS_CHAR(axis)), ")");
 
   set_axis_trusted(axis);
   set_axis_homed(axis);
@@ -2104,7 +2104,7 @@ void set_axis_is_at_home(const AxisEnum axis) {
 
         current_position.z -= probe.offset.z;
 
-        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("*** Z HOMED WITH PROBE (Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN) ***\n> probe.offset.z = ", probe.offset.z);
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("*** Z HOMED WITH PROBE (Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN) ***\n> probe.offset.z = ", probe.offset.z);
 
       #else
 
@@ -2125,17 +2125,17 @@ void set_axis_is_at_home(const AxisEnum axis) {
 
   if (DEBUGGING(LEVELING)) {
     #if HAS_HOME_OFFSET
-      DEBUG_ECHOLNPAIR("> home_offset[", AS_CHAR(AXIS_CHAR(axis)), "] = ", home_offset[axis]);
+      DEBUG_ECHOLNPGM("> home_offset[", AS_CHAR(AXIS_CHAR(axis)), "] = ", home_offset[axis]);
     #endif
     DEBUG_POS("", current_position);
-    DEBUG_ECHOLNPAIR("<<< set_axis_is_at_home(", AS_CHAR(AXIS_CHAR(axis)), ")");
+    DEBUG_ECHOLNPGM("<<< set_axis_is_at_home(", AS_CHAR(AXIS_CHAR(axis)), ")");
   }
 }
 
 #if HAS_WORKSPACE_OFFSET
   void update_workspace_offset(const AxisEnum axis) {
     workspace_offset[axis] = home_offset[axis] + position_shift[axis];
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Axis ", AS_CHAR(AXIS_CHAR(axis)), " home_offset = ", home_offset[axis], " position_shift = ", position_shift[axis]);
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Axis ", AS_CHAR(AXIS_CHAR(axis)), " home_offset = ", home_offset[axis], " position_shift = ", position_shift[axis]);
   }
 #endif
 

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1858,7 +1858,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
   );
 
   /* <-- add a slash to enable
-    SERIAL_ECHOLNPAIR(
+    SERIAL_ECHOLNPGM(
       "  _populate_block FR:", fr_mm_s,
       " A:", target.a, " (", da, " steps)"
       " B:", target.b, " (", db, " steps)"
@@ -2331,10 +2331,10 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
           if (max_vfr > 0 && cs > max_vfr) {
             NOMORE(speed_factor, max_vfr / cs); // respect volumetric extruder limit (if any)
             /* <-- add a slash to enable
-            SERIAL_ECHOPAIR("volumetric extruder limit enforced: ", (cs * CIRCLE_AREA(filament_size[extruder] * 0.5f)));
-            SERIAL_ECHOPAIR(" mm^3/s (", cs);
-            SERIAL_ECHOPAIR(" mm/s) limited to ", (max_vfr * CIRCLE_AREA(filament_size[extruder] * 0.5f)));
-            SERIAL_ECHOPAIR(" mm^3/s (", max_vfr);
+            SERIAL_ECHOPGM("volumetric extruder limit enforced: ", (cs * CIRCLE_AREA(filament_size[extruder] * 0.5f)));
+            SERIAL_ECHOPGM(" mm^3/s (", cs);
+            SERIAL_ECHOPGM(" mm/s) limited to ", (max_vfr * CIRCLE_AREA(filament_size[extruder] * 0.5f)));
+            SERIAL_ECHOPGM(" mm^3/s (", max_vfr);
             SERIAL_ECHOLNPGM(" mm/s)");
             //*/
           }
@@ -2921,44 +2921,44 @@ bool Planner::buffer_segment(const abce_pos_t &abce
   #endif
 
   /* <-- add a slash to enable
-    SERIAL_ECHOPAIR("  buffer_segment FR:", fr_mm_s);
+    SERIAL_ECHOPGM("  buffer_segment FR:", fr_mm_s);
     #if IS_KINEMATIC
-      SERIAL_ECHOPAIR(" A:", abce.a, " (", position.a, "->", target.a, ") B:", abce.b);
+      SERIAL_ECHOPGM(" A:", abce.a, " (", position.a, "->", target.a, ") B:", abce.b);
     #else
-      SERIAL_ECHOPAIR_P(SP_X_LBL, abce.a);
-      SERIAL_ECHOPAIR(" (", position.x, "->", target.x);
+      SERIAL_ECHOPGM_P(SP_X_LBL, abce.a);
+      SERIAL_ECHOPGM(" (", position.x, "->", target.x);
       SERIAL_CHAR(')');
-      SERIAL_ECHOPAIR_P(SP_Y_LBL, abce.b);
+      SERIAL_ECHOPGM_P(SP_Y_LBL, abce.b);
     #endif
-    SERIAL_ECHOPAIR(" (", position.y, "->", target.y);
+    SERIAL_ECHOPGM(" (", position.y, "->", target.y);
     #if LINEAR_AXES >= ABC
       #if ENABLED(DELTA)
-        SERIAL_ECHOPAIR(") C:", abce.c);
+        SERIAL_ECHOPGM(") C:", abce.c);
       #else
         SERIAL_CHAR(')');
-        SERIAL_ECHOPAIR_P(SP_Z_LBL, abce.c);
+        SERIAL_ECHOPGM_P(SP_Z_LBL, abce.c);
       #endif
-      SERIAL_ECHOPAIR(" (", position.z, "->", target.z);
+      SERIAL_ECHOPGM(" (", position.z, "->", target.z);
       SERIAL_CHAR(')');
     #endif
     #if LINEAR_AXES >= 4
-      SERIAL_ECHOPAIR_P(SP_I_LBL, abce.i);
-      SERIAL_ECHOPAIR(" (", position.i, "->", target.i);
+      SERIAL_ECHOPGM_P(SP_I_LBL, abce.i);
+      SERIAL_ECHOPGM(" (", position.i, "->", target.i);
       SERIAL_CHAR(')');
     #endif
     #if LINEAR_AXES >= 5
-      SERIAL_ECHOPAIR_P(SP_J_LBL, abce.j);
-      SERIAL_ECHOPAIR(" (", position.j, "->", target.j);
+      SERIAL_ECHOPGM_P(SP_J_LBL, abce.j);
+      SERIAL_ECHOPGM(" (", position.j, "->", target.j);
       SERIAL_CHAR(')');
     #endif
     #if LINEAR_AXES >= 6
-      SERIAL_ECHOPAIR_P(SP_K_LBL, abce.k);
-      SERIAL_ECHOPAIR(" (", position.k, "->", target.k);
+      SERIAL_ECHOPGM_P(SP_K_LBL, abce.k);
+      SERIAL_ECHOPGM(" (", position.k, "->", target.k);
       SERIAL_CHAR(')');
     #endif
     #if HAS_EXTRUDERS
-      SERIAL_ECHOPAIR_P(SP_E_LBL, abce.e);
-      SERIAL_ECHOLNPAIR(" (", position.e, "->", target.e, ")");
+      SERIAL_ECHOPGM_P(SP_E_LBL, abce.e);
+      SERIAL_ECHOLNPGM(" (", position.e, "->", target.e, ")");
     #else
       SERIAL_EOL();
     #endif
@@ -3186,7 +3186,7 @@ inline void limit_and_warn(float &val, const uint8_t axis, PGM_P const setting_n
     SERIAL_CHAR(AXIS_CHAR(lim_axis));
     SERIAL_ECHOPGM(" Max ");
     SERIAL_ECHOPGM_P(setting_name);
-    SERIAL_ECHOLNPAIR(" limited to ", val);
+    SERIAL_ECHOLNPGM(" limited to ", val);
   }
 }
 

--- a/Marlin/src/module/printcounter.cpp
+++ b/Marlin/src/module/printcounter.cpp
@@ -179,7 +179,7 @@ void PrintCounter::saveStats() {
   inline void _service_when(char buffer[], const char * const msg, const uint32_t when) {
     SERIAL_ECHOPGM(STR_STATS);
     SERIAL_ECHOPGM_P(msg);
-    SERIAL_ECHOLNPAIR(" in ", duration_t(when).toString(buffer));
+    SERIAL_ECHOLNPGM(" in ", duration_t(when).toString(buffer));
   }
 #endif
 
@@ -187,7 +187,7 @@ void PrintCounter::showStats() {
   char buffer[22];
 
   SERIAL_ECHOPGM(STR_STATS);
-  SERIAL_ECHOLNPAIR(
+  SERIAL_ECHOLNPGM(
     "Prints: ", data.totalPrints,
     ", Finished: ", data.finishedPrints,
     ", Failed: ", data.totalPrints - data.finishedPrints
@@ -197,21 +197,21 @@ void PrintCounter::showStats() {
   SERIAL_ECHOPGM(STR_STATS);
   duration_t elapsed = data.printTime;
   elapsed.toString(buffer);
-  SERIAL_ECHOPAIR("Total time: ", buffer);
+  SERIAL_ECHOPGM("Total time: ", buffer);
   #if ENABLED(DEBUG_PRINTCOUNTER)
-    SERIAL_ECHOPAIR(" (", data.printTime);
+    SERIAL_ECHOPGM(" (", data.printTime);
     SERIAL_CHAR(')');
   #endif
 
   elapsed = data.longestPrint;
   elapsed.toString(buffer);
-  SERIAL_ECHOPAIR(", Longest job: ", buffer);
+  SERIAL_ECHOPGM(", Longest job: ", buffer);
   #if ENABLED(DEBUG_PRINTCOUNTER)
-    SERIAL_ECHOPAIR(" (", data.longestPrint);
+    SERIAL_ECHOPGM(" (", data.longestPrint);
     SERIAL_CHAR(')');
   #endif
 
-  SERIAL_ECHOPAIR("\n" STR_STATS "Filament used: ", data.filamentUsed / 1000);
+  SERIAL_ECHOPGM("\n" STR_STATS "Filament used: ", data.filamentUsed / 1000);
   SERIAL_CHAR('m');
   SERIAL_EOL();
 

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -111,7 +111,7 @@ xyz_pos_t Probe::offset; // Initialized by settings.load()
    *              If true, move to MAX_X and release the solenoid
    */
   static void dock_sled(const bool stow) {
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("dock_sled(", stow, ")");
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("dock_sled(", stow, ")");
 
     // Dock sled a bit closer to ensure proper capturing
     do_blocking_move_to_x(X_MAX_POS + SLED_DOCKING_OFFSET - ((stow) ? 1 : 0));
@@ -274,7 +274,7 @@ xyz_pos_t Probe::offset; // Initialized by settings.load()
  * Raise Z to a minimum height to make room for a probe to move
  */
 void Probe::do_z_raise(const float z_raise) {
-  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Probe::do_z_raise(", z_raise, ")");
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Probe::do_z_raise(", z_raise, ")");
   float z_dest = z_raise;
   if (offset.z < 0) z_dest -= offset.z;
   do_z_clearance(z_dest);
@@ -367,7 +367,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     #if ENABLED(WAIT_FOR_NOZZLE_HEAT)
       const celsius_t hotendPreheat = hotend_temp > thermalManager.degTargetHotend(0) ? hotend_temp : 0;
       if (hotendPreheat) {
-        DEBUG_ECHOPAIR("hotend (", hotendPreheat, ")");
+        DEBUG_ECHOPGM("hotend (", hotendPreheat, ")");
         thermalManager.setTargetHotend(hotendPreheat, 0);
       }
     #elif ENABLED(WAIT_FOR_BED_HEAT)
@@ -378,7 +378,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
       const celsius_t bedPreheat = bed_temp > thermalManager.degTargetBed() ? bed_temp : 0;
       if (bedPreheat) {
         if (hotendPreheat) DEBUG_ECHOPGM(" and ");
-        DEBUG_ECHOPAIR("bed (", bedPreheat, ")");
+        DEBUG_ECHOPGM("bed (", bedPreheat, ")");
         thermalManager.setTargetBed(bedPreheat);
       }
     #endif
@@ -400,7 +400,7 @@ bool Probe::set_deployed(const bool deploy) {
 
   if (DEBUGGING(LEVELING)) {
     DEBUG_POS("Probe::set_deployed", current_position);
-    DEBUG_ECHOLNPAIR("deploy: ", deploy);
+    DEBUG_ECHOLNPGM("deploy: ", deploy);
   }
 
   if (endstops.z_probe_enabled == deploy) return false;
@@ -629,7 +629,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
 
     const float first_probe_z = current_position.z;
 
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("1st Probe Z:", first_probe_z);
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("1st Probe Z:", first_probe_z);
 
     // Raise to give the probe clearance
     do_blocking_move_to_z(current_position.z + Z_CLEARANCE_MULTI_PROBE, z_probe_fast_mm_s);
@@ -723,7 +723,7 @@ float Probe::run_z_probe(const bool sanity_check/*=true*/) {
 
     const float z2 = current_position.z;
 
-    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("2nd Probe Z:", z2, " Discrepancy:", first_probe_z - z2);
+    if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("2nd Probe Z:", z2, " Discrepancy:", first_probe_z - z2);
 
     // Return a weighted average of the fast and slow probes
     const float measured_z = (z2 * 3.0 + first_probe_z * 2.0) * 0.2;
@@ -751,7 +751,7 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
   DEBUG_SECTION(log_probe, "Probe::probe_at_point", DEBUGGING(LEVELING));
 
   if (DEBUGGING(LEVELING)) {
-    DEBUG_ECHOLNPAIR(
+    DEBUG_ECHOLNPGM(
       "...(", LOGICAL_X_POSITION(rx), ", ", LOGICAL_Y_POSITION(ry),
       ", ", raise_after == PROBE_PT_RAISE ? "raise" : raise_after == PROBE_PT_LAST_STOW ? "stow (last)" : raise_after == PROBE_PT_STOW ? "stow" : "none",
       ", ", verbose_level,
@@ -788,7 +788,7 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
       if (stow()) measured_z = NAN;   // Error on stow?
 
     if (verbose_level > 2)
-      SERIAL_ECHOLNPAIR("Bed X: ", LOGICAL_X_POSITION(rx), " Y: ", LOGICAL_Y_POSITION(ry), " Z: ", measured_z);
+      SERIAL_ECHOLNPGM("Bed X: ", LOGICAL_X_POSITION(rx), " Y: ", LOGICAL_Y_POSITION(ry), " Z: ", measured_z);
   }
 
   if (isnan(measured_z)) {
@@ -864,7 +864,7 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
       #endif
       #if ((ENABLED(DELTA) && (HAS_CURRENT_HOME(X) || HAS_CURRENT_HOME(Y))) || HAS_CURRENT_HOME(Z))
         auto debug_current_on = [](PGM_P const s, const int16_t a, const int16_t b) {
-          if (DEBUGGING(LEVELING)) { DEBUG_ECHOPGM_P(s); DEBUG_ECHOLNPAIR(" current: ", a, " -> ", b); }
+          if (DEBUGGING(LEVELING)) { DEBUG_ECHOPGM_P(s); DEBUG_ECHOLNPGM(" current: ", a, " -> ", b); }
         };
       #endif
       if (onoff) {

--- a/Marlin/src/module/scara.cpp
+++ b/Marlin/src/module/scara.cpp
@@ -58,7 +58,7 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
     cartes.y = a_sin + b_sin + scara_offset.y;  // phi
 
     /*
-      DEBUG_ECHOLNPAIR(
+      DEBUG_ECHOLNPGM(
         "SCARA FK Angle a=", a,
         " b=", b,
         " a_sin=", a_sin,
@@ -66,7 +66,7 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
         " b_sin=", b_sin,
         " b_cos=", b_cos
       );
-      DEBUG_ECHOLNPAIR(" cartes (X,Y) = "(cartes.x, ", ", cartes.y, ")");
+      DEBUG_ECHOLNPGM(" cartes (X,Y) = "(cartes.x, ", ", cartes.y, ")");
     //*/
   }
 
@@ -80,13 +80,13 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
     else {
       // MORGAN_SCARA uses a Cartesian XY home position
       xyz_pos_t homeposition = { X_HOME_POS, Y_HOME_POS, Z_HOME_POS };
-      //DEBUG_ECHOLNPAIR_P(PSTR("homeposition X"), homeposition.x, SP_Y_LBL, homeposition.y);
+      //DEBUG_ECHOLNPGM_P(PSTR("homeposition X"), homeposition.x, SP_Y_LBL, homeposition.y);
 
       delta = homeposition;
       forward_kinematics(delta.a, delta.b);
       current_position[axis] = cartes[axis];
 
-      //DEBUG_ECHOLNPAIR_P(PSTR("Cartesian X"), current_position.x, SP_Y_LBL, current_position.y);
+      //DEBUG_ECHOLNPGM_P(PSTR("Cartesian X"), current_position.x, SP_Y_LBL, current_position.y);
       update_software_endstops(axis);
     }
   }
@@ -132,7 +132,7 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
     /*
       DEBUG_POS("SCARA IK", raw);
       DEBUG_POS("SCARA IK", delta);
-      DEBUG_ECHOLNPAIR("  SCARA (x,y) ", sx, ",", sy, " C2=", C2, " S2=", S2, " Theta=", THETA, " Psi=", PSI);
+      DEBUG_ECHOLNPGM("  SCARA (x,y) ", sx, ",", sy, " C2=", C2, " S2=", S2, " Theta=", THETA, " Psi=", PSI);
     //*/
   }
 
@@ -150,13 +150,13 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
         #define SCARA_OFFSET_THETA2 131 // degrees
       #endif
       ab_float_t homeposition = { SCARA_OFFSET_THETA1, SCARA_OFFSET_THETA2 };
-      //DEBUG_ECHOLNPAIR("homeposition A:", homeposition.a, " B:", homeposition.b);
+      //DEBUG_ECHOLNPGM("homeposition A:", homeposition.a, " B:", homeposition.b);
 
       inverse_kinematics(homeposition);
       forward_kinematics(delta.a, delta.b);
       current_position[axis] = cartes[axis];
 
-      //DEBUG_ECHOLNPAIR_P(PSTR("Cartesian X"), current_position.x, SP_Y_LBL, current_position.y);
+      //DEBUG_ECHOLNPGM_P(PSTR("Cartesian X"), current_position.x, SP_Y_LBL, current_position.y);
       update_software_endstops(axis);
     }
   }
@@ -172,7 +172,7 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
     /*
       DEBUG_POS("SCARA IK", raw);
       DEBUG_POS("SCARA IK", delta);
-      SERIAL_ECHOLNPAIR("  SCARA (x,y) ", x, ",", y," Theta1=", THETA1, " Theta2=", THETA2);
+      SERIAL_ECHOLNPGM("  SCARA (x,y) ", x, ",", y," Theta1=", THETA1, " Theta2=", THETA2);
     //*/
   }
 
@@ -185,13 +185,13 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
       current_position.z = Z_HOME_POS;
     else {
       xyz_pos_t homeposition = { X_HOME_POS, Y_HOME_POS, Z_HOME_POS };
-      //DEBUG_ECHOLNPAIR_P(PSTR("homeposition X"), homeposition.x, SP_Y_LBL, homeposition.y, SP_Z_LBL, homeposition.z);
+      //DEBUG_ECHOLNPGM_P(PSTR("homeposition X"), homeposition.x, SP_Y_LBL, homeposition.y, SP_Z_LBL, homeposition.z);
 
       inverse_kinematics(homeposition);
       forward_kinematics(delta.a, delta.b, delta.c);
       current_position[axis] = cartes[axis];
 
-      //DEBUG_ECHOLNPAIR_P(PSTR("Cartesian X"), current_position.x, SP_Y_LBL, current_position.y);
+      //DEBUG_ECHOLNPGM_P(PSTR("Cartesian X"), current_position.x, SP_Y_LBL, current_position.y);
       update_software_endstops(axis);
     }
   }
@@ -289,13 +289,13 @@ float segments_per_second = TERN(AXEL_TPARA, TPARA_SEGMENTS_PER_SECOND, SCARA_SE
 
     delta.set(DEGREES(THETA), DEGREES(PHI), DEGREES(PSI));
 
-    //SERIAL_ECHOLNPAIR(" SCARA (x,y,z) ", spos.x , ",", spos.y, ",", spos.z, " Rho=", RHO, " Rho2=", RHO2, " Theta=", THETA, " Phi=", PHI, " Psi=", PSI, " Gamma=", GAMMA);
+    //SERIAL_ECHOLNPGM(" SCARA (x,y,z) ", spos.x , ",", spos.y, ",", spos.z, " Rho=", RHO, " Rho2=", RHO2, " Theta=", THETA, " Phi=", PHI, " Psi=", PSI, " Gamma=", GAMMA);
   }
 
 #endif
 
 void scara_report_positions() {
-  SERIAL_ECHOLNPAIR("SCARA Theta:", planner.get_axis_position_degrees(A_AXIS)
+  SERIAL_ECHOLNPGM("SCARA Theta:", planner.get_axis_position_degrees(A_AXIS)
     #if ENABLED(AXEL_TPARA)
       , "  Phi:", planner.get_axis_position_degrees(B_AXIS)
       , "  Psi:", planner.get_axis_position_degrees(C_AXIS)

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -133,9 +133,6 @@
 #endif
 
 #include "../feature/controllerfan.h"
-#if ENABLED(CONTROLLER_FAN_EDITABLE)
-  void M710_report(const bool forReplay=true);
-#endif
 
 #if ENABLED(CASE_LIGHT_ENABLE)
   #include "../feature/caselight.h"
@@ -167,13 +164,6 @@
 #if HAS_ETHERNET
   void ETH0_report();
   void MAC_report();
-  void M552_report();
-  void M553_report();
-  void M554_report();
-#endif
-
-#if EITHER(DELTA, HAS_EXTRA_ENDSTOPS)
-  void M666_report(const bool forReplay=true);
 #endif
 
 #define _EN_ITEM(N) , E##N
@@ -3012,63 +3002,19 @@ void MarlinSettings::reset() {
 
   postprocess();
 
-  DEBUG_ECHO_START();
-  DEBUG_ECHOLNPGM("Hardcoded Default Settings Loaded");
+  DEBUG_ECHO_MSG("Hardcoded Default Settings Loaded");
 
   TERN_(EXTENSIBLE_UI, ExtUI::onFactoryReset());
 }
 
 #if DISABLED(DISABLE_M503)
 
-  static void config_heading(const bool repl, PGM_P const pstr, const bool eol=true) {
-    if (!repl) {
-      SERIAL_ECHO_START();
-      SERIAL_ECHOPGM("; ");
-      SERIAL_ECHOPGM_P(pstr);
-      if (eol) SERIAL_EOL();
-    }
-  }
-
-  #define CONFIG_ECHO_START()       do{ if (!forReplay) SERIAL_ECHO_START(); }while(0)
+  #define CONFIG_ECHO_START()       gcode.report_echo_start(forReplay)
   #define CONFIG_ECHO_MSG(V...)     do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPAIR(V); }while(0)
-  #define CONFIG_ECHO_HEADING(STR)  config_heading(forReplay, PSTR(STR))
+  #define CONFIG_ECHO_MSG_P(V...)   do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPAIR_P(V); }while(0)
+  #define CONFIG_ECHO_HEADING(STR)  gcode.report_heading(forReplay, PSTR(STR))
 
-  #if HAS_TRINAMIC_CONFIG
-    inline void say_M906(const bool forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOPGM("  M906"); }
-    #if HAS_STEALTHCHOP
-      void say_M569(const bool forReplay, const char * const etc=nullptr, const bool newLine = false) {
-        CONFIG_ECHO_START();
-        SERIAL_ECHOPGM("  M569 S1");
-        if (etc) {
-          SERIAL_CHAR(' ');
-          SERIAL_ECHOPGM_P(etc);
-        }
-        if (newLine) SERIAL_EOL();
-      }
-    #endif
-    #if ENABLED(HYBRID_THRESHOLD)
-      inline void say_M913(const bool forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOPGM("  M913"); }
-    #endif
-    #if USE_SENSORLESS
-      inline void say_M914() { SERIAL_ECHOPGM("  M914"); }
-    #endif
-  #endif
-
-  #if ENABLED(ADVANCED_PAUSE_FEATURE)
-    inline void say_M603(const bool forReplay) { CONFIG_ECHO_START(); SERIAL_ECHOPGM("  M603 "); }
-  #endif
-
-  inline void say_units(const bool colon) {
-    SERIAL_ECHOPGM_P(
-      #if ENABLED(INCH_MODE_SUPPORT)
-        parser.linear_unit_factor != 1.0 ? PSTR(" (in)") :
-      #endif
-      PSTR(" (mm)")
-    );
-    if (colon) SERIAL_ECHOLNPGM(":");
-  }
-
-  void report_M92(const bool echo=true, const int8_t e=-1);
+  void M92_report(const bool echo=true, const int8_t e=-1);
 
   /**
    * M503 - Report current settings in RAM
@@ -3076,228 +3022,73 @@ void MarlinSettings::reset() {
    * Unless specifically disabled, M503 is available even without EEPROM
    */
   void MarlinSettings::report(const bool forReplay) {
-    /**
-     * Announce current units, in case inches are being displayed
-     */
-    CONFIG_ECHO_START();
+    //
+    // Announce current units, in case inches are being displayed
+    //
+    CONFIG_ECHO_HEADING("Linear Units");
     #if ENABLED(INCH_MODE_SUPPORT)
-      SERIAL_ECHOPGM("  G2");
-      SERIAL_CHAR(parser.linear_unit_factor == 1.0 ? '1' : '0');
-      SERIAL_ECHOPGM(" ;");
-      say_units(false);
+      SERIAL_ECHOPAIR("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
     #else
-      SERIAL_ECHOPGM("  G21    ; Units in mm");
-      say_units(false);
+      SERIAL_ECHOPGM("  G21 ;");
     #endif
-    SERIAL_EOL();
+    gcode.say_units();
 
-    #if HAS_LCD_MENU
-
-      // Temperature units - for Ultipanel temperature options
-
-      CONFIG_ECHO_START();
-      #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
-        SERIAL_ECHOPGM("  M149 ");
-        SERIAL_CHAR(parser.temp_units_code());
-        SERIAL_ECHOPGM(" ; Units in ");
-        SERIAL_ECHOPGM_P(parser.temp_units_name());
-      #else
-        SERIAL_ECHOLNPGM("  M149 C ; Units in Celsius");
-      #endif
-
+    //
+    // M149 Temperature units
+    //
+    #if ENABLED(TEMPERATURE_UNITS_SUPPORT)
+      gcode.M149_report(forReplay);
+    #else
+      CONFIG_ECHO_HEADING(STR_TEMPERATURE_UNITS);
+      CONFIG_ECHO_MSG("  M149 C ; Units in Celsius");
     #endif
 
-    SERIAL_EOL();
+    //
+    // M200 Volumetric Extrusion
+    //
+    IF_DISABLED(NO_VOLUMETRICS, gcode.M200_report(forReplay));
 
-    #if EXTRUDERS && DISABLED(NO_VOLUMETRICS)
+    //
+    // M92 Steps per Unit
+    //
+    gcode.M92_report(forReplay);
 
-      /**
-       * Volumetric extrusion M200
-       */
-      if (!forReplay) {
-        config_heading(forReplay, PSTR("Filament settings:"), false);
-        if (parser.volumetric_enabled)
-          SERIAL_EOL();
-        else
-          SERIAL_ECHOLNPGM(" Disabled");
-      }
+    //
+    // M203 Maximum feedrates (units/s)
+    //
+    gcode.M203_report(forReplay);
 
-      #if EXTRUDERS == 1
-        CONFIG_ECHO_MSG("  M200 S", parser.volumetric_enabled
-                            , " D", LINEAR_UNIT(planner.filament_size[0])
-                            #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-                              , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[0])
-                            #endif
-                       );
-      #else
-        LOOP_L_N(i, EXTRUDERS) {
-          CONFIG_ECHO_MSG("  M200 T", i
-                              , " D", LINEAR_UNIT(planner.filament_size[i])
-                              #if ENABLED(VOLUMETRIC_EXTRUDER_LIMIT)
-                                , " L", LINEAR_UNIT(planner.volumetric_extruder_limit[i])
-                              #endif
-                         );
-        }
-        CONFIG_ECHO_MSG("  M200 S", parser.volumetric_enabled);
-      #endif
+    //
+    // M201 Maximum Acceleration (units/s2)
+    //
+    gcode.M201_report(forReplay);
 
-    #endif // EXTRUDERS && !NO_VOLUMETRICS
+    //
+    // M204 Acceleration (units/s2)
+    //
+    gcode.M204_report(forReplay);
 
-    CONFIG_ECHO_HEADING("Steps per unit:");
-    report_M92(!forReplay);
+    //
+    // M205 "Advanced" Settings
+    //
+    gcode.M205_report(forReplay);
 
-    CONFIG_ECHO_HEADING("Maximum feedrates (units/s):");
-    CONFIG_ECHO_START();
-    SERIAL_ECHOLNPAIR_P(
-      LIST_N(DOUBLE(LINEAR_AXES),
-        PSTR("  M203 X"), LINEAR_UNIT(planner.settings.max_feedrate_mm_s[X_AXIS]),
-        SP_Y_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Y_AXIS]),
-        SP_Z_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[Z_AXIS]),
-        SP_I_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[I_AXIS]),
-        SP_J_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[J_AXIS]),
-        SP_K_STR, LINEAR_UNIT(planner.settings.max_feedrate_mm_s[K_AXIS])
-      )
-      #if HAS_EXTRUDERS && DISABLED(DISTINCT_E_FACTORS)
-        , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS])
-      #endif
-    );
-    #if ENABLED(DISTINCT_E_FACTORS)
-      LOOP_L_N(i, E_STEPPERS) {
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR_P(
-            PSTR("  M203 T"), i
-          , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_feedrate_mm_s[E_AXIS_N(i)])
-        );
-      }
-    #endif
+    //
+    // M206 Home Offset
+    //
+    TERN_(HAS_M206_COMMAND, gcode.M206_report(forReplay));
 
-    CONFIG_ECHO_HEADING("Maximum Acceleration (units/s2):");
-    CONFIG_ECHO_START();
-    SERIAL_ECHOLNPAIR_P(
-      LIST_N(DOUBLE(LINEAR_AXES),
-        PSTR("  M201 X"), LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[X_AXIS]),
-        SP_Y_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Y_AXIS]),
-        SP_Z_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[Z_AXIS]),
-        SP_I_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[I_AXIS]),
-        SP_J_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[J_AXIS]),
-        SP_K_STR, LINEAR_UNIT(planner.settings.max_acceleration_mm_per_s2[K_AXIS])
-      )
-      #if HAS_EXTRUDERS && DISABLED(DISTINCT_E_FACTORS)
-        , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS])
-      #endif
-    );
-    #if ENABLED(DISTINCT_E_FACTORS)
-      LOOP_L_N(i, E_STEPPERS) {
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR_P(
-            PSTR("  M201 T"), i
-          , SP_E_STR, VOLUMETRIC_UNIT(planner.settings.max_acceleration_mm_per_s2[E_AXIS_N(i)])
-        );
-      }
-    #endif
+    //
+    // M218 Hotend offsets
+    //
+    TERN_(HAS_HOTEND_OFFSET, gcode.M218_report(forReplay));
 
-    CONFIG_ECHO_HEADING("Acceleration (units/s2): P<print_accel> R<retract_accel> T<travel_accel>");
-    CONFIG_ECHO_START();
-    SERIAL_ECHOLNPAIR_P(
-        PSTR("  M204 P"), LINEAR_UNIT(planner.settings.acceleration)
-      , PSTR(" R"), LINEAR_UNIT(planner.settings.retract_acceleration)
-      , SP_T_STR, LINEAR_UNIT(planner.settings.travel_acceleration)
-    );
-
-    CONFIG_ECHO_HEADING(
-      "Advanced: B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate>"
-      TERN_(HAS_JUNCTION_DEVIATION, " J<junc_dev>")
-      #if HAS_CLASSIC_JERK
-        " X<max_x_jerk> Y<max_y_jerk> Z<max_z_jerk>"
-        TERN_(HAS_CLASSIC_E_JERK, " E<max_e_jerk>")
-      #endif
-    );
-    CONFIG_ECHO_START();
-    SERIAL_ECHOLNPAIR_P(
-        PSTR("  M205 B"), LINEAR_UNIT(planner.settings.min_segment_time_us)
-      , PSTR(" S"), LINEAR_UNIT(planner.settings.min_feedrate_mm_s)
-      , SP_T_STR, LINEAR_UNIT(planner.settings.min_travel_feedrate_mm_s)
-      #if HAS_JUNCTION_DEVIATION
-        , PSTR(" J"), LINEAR_UNIT(planner.junction_deviation_mm)
-      #endif
-      #if HAS_CLASSIC_JERK
-        , LIST_N(DOUBLE(LINEAR_AXES),
-          SP_X_STR, LINEAR_UNIT(planner.max_jerk.x),
-          SP_Y_STR, LINEAR_UNIT(planner.max_jerk.y),
-          SP_Z_STR, LINEAR_UNIT(planner.max_jerk.z),
-          SP_I_STR, LINEAR_UNIT(planner.max_jerk.i),
-          SP_J_STR, LINEAR_UNIT(planner.max_jerk.j),
-          SP_K_STR, LINEAR_UNIT(planner.max_jerk.k)
-        )
-        #if HAS_CLASSIC_E_JERK
-          , SP_E_STR, LINEAR_UNIT(planner.max_jerk.e)
-        #endif
-      #endif
-    );
-
-    #if HAS_M206_COMMAND
-      CONFIG_ECHO_HEADING("Home offset:");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-        #if IS_CARTESIAN
-          LIST_N(DOUBLE(LINEAR_AXES),
-            PSTR("  M206 X"), LINEAR_UNIT(home_offset.x),
-            SP_Y_STR, LINEAR_UNIT(home_offset.y),
-            SP_Z_STR, LINEAR_UNIT(home_offset.z),
-            SP_I_STR, LINEAR_UNIT(home_offset.i),
-            SP_J_STR, LINEAR_UNIT(home_offset.j),
-            SP_K_STR, LINEAR_UNIT(home_offset.k)
-          )
-        #else
-          PSTR("  M206 Z"), LINEAR_UNIT(home_offset.z)
-        #endif
-      );
-    #endif
-
-    #if HAS_HOTEND_OFFSET
-      CONFIG_ECHO_HEADING("Hotend offsets:");
-      CONFIG_ECHO_START();
-      LOOP_S_L_N(e, 1, HOTENDS) {
-        SERIAL_ECHOPAIR_P(
-          PSTR("  M218 T"), e,
-          SP_X_STR, LINEAR_UNIT(hotend_offset[e].x),
-          SP_Y_STR, LINEAR_UNIT(hotend_offset[e].y)
-        );
-        SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(hotend_offset[e].z), 3);
-      }
-    #endif
-
-    /**
-     * Bed Leveling
-     */
+    //
+    // Bed Leveling
+    //
     #if HAS_LEVELING
 
-      #if ENABLED(MESH_BED_LEVELING)
-
-        CONFIG_ECHO_HEADING("Mesh Bed Leveling:");
-
-      #elif ENABLED(AUTO_BED_LEVELING_UBL)
-
-        config_heading(forReplay, NUL_STR, false);
-        if (!forReplay) {
-          ubl.echo_name();
-          SERIAL_CHAR(':');
-          SERIAL_EOL();
-        }
-
-      #elif HAS_ABL_OR_UBL
-
-        CONFIG_ECHO_HEADING("Auto Bed Leveling:");
-
-      #endif
-
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-        PSTR("  M420 S"), planner.leveling_active
-        #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
-          , SP_Z_STR, LINEAR_UNIT(planner.z_fade_height)
-        #endif
-      );
+      gcode.M420_report(forReplay);
 
       #if ENABLED(MESH_BED_LEVELING)
 
@@ -3318,11 +3109,8 @@ void MarlinSettings::reset() {
         if (!forReplay) {
           SERIAL_EOL();
           ubl.report_state();
-          config_heading(false, PSTR("Active Mesh Slot: "), false);
-          SERIAL_ECHOLN(ubl.storage_slot);
-          config_heading(false, PSTR("EEPROM can hold "), false);
-          SERIAL_ECHO(calc_num_meshes());
-          SERIAL_ECHOLNPGM(" meshes.\n");
+          SERIAL_ECHO_MSG("Active Mesh Slot ", ubl.storage_slot);
+          SERIAL_ECHO_MSG("EEPROM can hold ", calc_num_meshes(), " meshes.\n");
         }
 
        //ubl.report_current_mesh();   // This is too verbose for large meshes. A better (more terse)
@@ -3343,602 +3131,150 @@ void MarlinSettings::reset() {
 
     #endif // HAS_LEVELING
 
-    #if ENABLED(EDITABLE_SERVO_ANGLES)
+    //
+    // Editable Servo Angles
+    //
+    TERN_(EDITABLE_SERVO_ANGLES, gcode.M281_report(forReplay));
 
-      CONFIG_ECHO_HEADING("Servo Angles:");
-      LOOP_L_N(i, NUM_SERVOS) {
-        switch (i) {
-          #if ENABLED(SWITCHING_EXTRUDER)
-            case SWITCHING_EXTRUDER_SERVO_NR:
-            #if EXTRUDERS > 3
-              case SWITCHING_EXTRUDER_E23_SERVO_NR:
-            #endif
-          #elif ENABLED(SWITCHING_NOZZLE)
-            case SWITCHING_NOZZLE_SERVO_NR:
-          #elif ENABLED(BLTOUCH) || (HAS_Z_SERVO_PROBE && defined(Z_SERVO_ANGLES))
-            case Z_PROBE_SERVO_NR:
-          #endif
-            CONFIG_ECHO_MSG("  M281 P", i, " L", servo_angles[i][0], " U", servo_angles[i][1]);
-          default: break;
-        }
-      }
+    //
+    // Delta / SCARA Kinematics
+    //
+    TERN_(IS_KINEMATIC, gcode.M665_report(forReplay));
 
-    #endif // EDITABLE_SERVO_ANGLES
-
-    #if HAS_SCARA_OFFSET
-
-      CONFIG_ECHO_HEADING("SCARA settings: S<seg-per-sec> P<theta-psi-offset> T<theta-offset>");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-          PSTR("  M665 S"), segments_per_second
-        , SP_P_STR, scara_home_offset.a
-        , SP_T_STR, scara_home_offset.b
-        , SP_Z_STR, LINEAR_UNIT(scara_home_offset.z)
-      );
-
-    #elif ENABLED(DELTA)
-
-      CONFIG_ECHO_HEADING("Delta settings: L<diagonal rod> R<radius> H<height> S<segments per sec> XYZ<tower angle trim> ABC<rod trim>");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-          PSTR("  M665 L"), LINEAR_UNIT(delta_diagonal_rod)
-        , PSTR(" R"), LINEAR_UNIT(delta_radius)
-        , PSTR(" H"), LINEAR_UNIT(delta_height)
-        , PSTR(" S"), segments_per_second
-        , SP_X_STR, LINEAR_UNIT(delta_tower_angle_trim.a)
-        , SP_Y_STR, LINEAR_UNIT(delta_tower_angle_trim.b)
-        , SP_Z_STR, LINEAR_UNIT(delta_tower_angle_trim.c)
-        , PSTR(" A"), LINEAR_UNIT(delta_diagonal_rod_trim.a)
-        , PSTR(" B"), LINEAR_UNIT(delta_diagonal_rod_trim.b)
-        , PSTR(" C"), LINEAR_UNIT(delta_diagonal_rod_trim.c)
-      );
-
-    #endif
-
+    //
+    // M666 Endstops Adjustment
+    //
     #if EITHER(DELTA, HAS_EXTRA_ENDSTOPS)
-      M666_report(forReplay);
+      gcode.M666_report(forReplay);
     #endif
 
+    //
+    // Z Auto-Align
+    //
+    TERN_(Z_STEPPER_AUTO_ALIGN, gcode.M422_report(forReplay));
+
+    //
+    // LCD Preheat Settings
+    //
     #if PREHEAT_COUNT
-
-      CONFIG_ECHO_HEADING("Material heatup parameters:");
-      LOOP_L_N(i, PREHEAT_COUNT) {
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR_P(
-          PSTR("  M145 S"), i
-          #if HAS_HOTEND
-            , PSTR(" H"), parser.to_temp_units(ui.material_preset[i].hotend_temp)
-          #endif
-          #if HAS_HEATED_BED
-            , SP_B_STR, parser.to_temp_units(ui.material_preset[i].bed_temp)
-          #endif
-          #if HAS_FAN
-            , PSTR(" F"), ui.material_preset[i].fan_speed
-          #endif
-        );
-      }
-
+      gcode.M145_report(forReplay);
     #endif
 
-    #if HAS_PID_HEATING
-
-      CONFIG_ECHO_HEADING("PID settings:");
-
-      #if ENABLED(PIDTEMP)
-        HOTEND_LOOP() {
-          CONFIG_ECHO_START();
-          SERIAL_ECHOPAIR_P(
-            #if ENABLED(PID_PARAMS_PER_HOTEND)
-              PSTR("  M301 E"), e,
-              SP_P_STR
-            #else
-              PSTR("  M301 P")
-            #endif
-                        , PID_PARAM(Kp, e)
-            , PSTR(" I"), unscalePID_i(PID_PARAM(Ki, e))
-            , PSTR(" D"), unscalePID_d(PID_PARAM(Kd, e))
-          );
-          #if ENABLED(PID_EXTRUSION_SCALING)
-            SERIAL_ECHOPAIR_P(SP_C_STR, PID_PARAM(Kc, e));
-            if (e == 0) SERIAL_ECHOPAIR(" L", thermalManager.lpq_len);
-          #endif
-          #if ENABLED(PID_FAN_SCALING)
-            SERIAL_ECHOPAIR(" F", PID_PARAM(Kf, e));
-          #endif
-          SERIAL_EOL();
-        }
-      #endif // PIDTEMP
-
-      #if ENABLED(PIDTEMPBED)
-        CONFIG_ECHO_MSG(
-            "  M304 P", thermalManager.temp_bed.pid.Kp
-          , " I", unscalePID_i(thermalManager.temp_bed.pid.Ki)
-          , " D", unscalePID_d(thermalManager.temp_bed.pid.Kd)
-        );
-      #endif
-
-      #if ENABLED(PIDTEMPCHAMBER)
-        CONFIG_ECHO_START();
-        SERIAL_ECHOLNPAIR(
-            "  M309 P", thermalManager.temp_chamber.pid.Kp
-          , " I", unscalePID_i(thermalManager.temp_chamber.pid.Ki)
-          , " D", unscalePID_d(thermalManager.temp_chamber.pid.Kd)
-        );
-      #endif
-
-    #endif // PIDTEMP || PIDTEMPBED || PIDTEMPCHAMBER
+    //
+    // PID
+    //
+    TERN_(PIDTEMP,        gcode.M301_report(forReplay));
+    TERN_(PIDTEMPBED,     gcode.M304_report(forReplay));
+    TERN_(PIDTEMPCHAMBER, gcode.M309_report(forReplay));
 
     #if HAS_USER_THERMISTORS
-      CONFIG_ECHO_HEADING("User thermistors:");
       LOOP_L_N(i, USER_THERMISTORS)
-        thermalManager.log_user_thermistor(i, true);
+        thermalManager.M305_report(i, forReplay);
     #endif
 
-    #if HAS_LCD_CONTRAST
-      CONFIG_ECHO_HEADING("LCD Contrast:");
-      CONFIG_ECHO_MSG("  M250 C", ui.contrast);
-    #endif
+    //
+    // LCD Contrast
+    //
+    TERN_(HAS_LCD_CONTRAST, gcode.M250_report(forReplay));
 
-    #if HAS_LCD_BRIGHTNESS
-      CONFIG_ECHO_HEADING("LCD Brightness:");
-      CONFIG_ECHO_MSG("  M256 B", ui.brightness);
-    #endif
+    //
+    // LCD Brightness
+    //
+    TERN_(HAS_LCD_BRIGHTNESS, gcode.M256_report(forReplay));
 
-    TERN_(CONTROLLER_FAN_EDITABLE, M710_report(forReplay));
+    //
+    // Controller Fan
+    //
+    TERN_(CONTROLLER_FAN_EDITABLE, gcode.M710_report(forReplay));
 
-    #if ENABLED(POWER_LOSS_RECOVERY)
-      CONFIG_ECHO_HEADING("Power-Loss Recovery:");
-      CONFIG_ECHO_MSG("  M413 S", recovery.enabled);
-    #endif
+    //
+    // Power-Loss Recovery
+    //
+    TERN_(POWER_LOSS_RECOVERY, gcode.M413_report(forReplay));
 
+    //
+    // Firmware Retraction
+    //
     #if ENABLED(FWRETRACT)
-      fwretract.M207_report(forReplay);
-      fwretract.M208_report(forReplay);
-      TERN_(FWRETRACT_AUTORETRACT, fwretract.M209_report(forReplay));
+      gcode.M207_report(forReplay);
+      gcode.M208_report(forReplay);
+      TERN_(FWRETRACT_AUTORETRACT, gcode.M209_report(forReplay));
     #endif
 
-    /**
-     * Probe Offset
-     */
-    #if HAS_BED_PROBE
-      config_heading(forReplay, PSTR("Z-Probe Offset"), false);
-      if (!forReplay) say_units(true);
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-        #if HAS_PROBE_XY_OFFSET
-          PSTR("  M851 X"), LINEAR_UNIT(probe.offset_xy.x),
-                  SP_Y_STR, LINEAR_UNIT(probe.offset_xy.y),
-                  SP_Z_STR
-        #else
-          PSTR("  M851 X0 Y0 Z")
-        #endif
-        , LINEAR_UNIT(probe.offset.z)
-      );
-    #endif
+    //
+    // Probe Offset
+    //
+    TERN_(HAS_BED_PROBE, gcode.M851_report(forReplay));
 
-    /**
-     * Bed Skew Correction
-     */
-    #if ENABLED(SKEW_CORRECTION_GCODE)
-      CONFIG_ECHO_HEADING("Skew Factor: ");
-      CONFIG_ECHO_START();
-      #if ENABLED(SKEW_CORRECTION_FOR_Z)
-        SERIAL_ECHOPAIR_F("  M852 I", LINEAR_UNIT(planner.skew_factor.xy), 6);
-        SERIAL_ECHOPAIR_F(" J", LINEAR_UNIT(planner.skew_factor.xz), 6);
-        SERIAL_ECHOLNPAIR_F(" K", LINEAR_UNIT(planner.skew_factor.yz), 6);
-      #else
-        SERIAL_ECHOLNPAIR_F("  M852 S", LINEAR_UNIT(planner.skew_factor.xy), 6);
-      #endif
-    #endif
+    //
+    // Bed Skew Correction
+    //
+    TERN_(SKEW_CORRECTION_GCODE, gcode.M852_report(forReplay));
 
     #if HAS_TRINAMIC_CONFIG
+      //
+      // TMC Stepper driver current
+      //
+      gcode.M906_report(forReplay);
 
-      /**
-       * TMC stepper driver current
-       */
-      CONFIG_ECHO_HEADING("Stepper driver current:");
+      //
+      // TMC Hybrid Threshold
+      //
+      TERN_(HYBRID_THRESHOLD, gcode.M913_report(forReplay));
 
-      #if AXIS_IS_TMC(X) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Z)
-        say_M906(forReplay);
-        #if AXIS_IS_TMC(X)
-          SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.getMilliamps());
-        #endif
-        #if AXIS_IS_TMC(Y)
-          SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.getMilliamps());
-        #endif
-        #if AXIS_IS_TMC(Z)
-          SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.getMilliamps());
-        #endif
-        SERIAL_EOL();
-      #endif
-
-      #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2)
-        say_M906(forReplay);
-        SERIAL_ECHOPGM(" I1");
-        #if AXIS_IS_TMC(X2)
-          SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.getMilliamps());
-        #endif
-        #if AXIS_IS_TMC(Y2)
-          SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.getMilliamps());
-        #endif
-        #if AXIS_IS_TMC(Z2)
-          SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.getMilliamps());
-        #endif
-        SERIAL_EOL();
-      #endif
-
-      #if AXIS_IS_TMC(Z3)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.getMilliamps());
-      #endif
-
-      #if AXIS_IS_TMC(Z4)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.getMilliamps());
-      #endif
-
-      #if AXIS_IS_TMC(I)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(J)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(K)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.getMilliamps());
-      #endif
-
-      #if AXIS_IS_TMC(E0)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" T0 E", stepperE0.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(E1)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" T1 E", stepperE1.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(E2)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" T2 E", stepperE2.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(E3)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" T3 E", stepperE3.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(E4)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" T4 E", stepperE4.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(E5)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" T5 E", stepperE5.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(E6)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" T6 E", stepperE6.getMilliamps());
-      #endif
-      #if AXIS_IS_TMC(E7)
-        say_M906(forReplay);
-        SERIAL_ECHOLNPAIR(" T7 E", stepperE7.getMilliamps());
-      #endif
-      SERIAL_EOL();
-
-      /**
-       * TMC Hybrid Threshold
-       */
-      #if ENABLED(HYBRID_THRESHOLD)
-        CONFIG_ECHO_HEADING("Hybrid Threshold:");
-        #if X_HAS_STEALTHCHOP || Y_HAS_STEALTHCHOP || Z_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          #if X_HAS_STEALTHCHOP
-            SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.get_pwm_thrs());
-          #endif
-          #if Y_HAS_STEALTHCHOP
-            SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.get_pwm_thrs());
-          #endif
-          #if Z_HAS_STEALTHCHOP
-            SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.get_pwm_thrs());
-          #endif
-          SERIAL_EOL();
-        #endif
-
-        #if X2_HAS_STEALTHCHOP || Y2_HAS_STEALTHCHOP || Z2_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOPGM(" I1");
-          #if X2_HAS_STEALTHCHOP
-            SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.get_pwm_thrs());
-          #endif
-          #if Y2_HAS_STEALTHCHOP
-            SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.get_pwm_thrs());
-          #endif
-          #if Z2_HAS_STEALTHCHOP
-            SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.get_pwm_thrs());
-          #endif
-          SERIAL_EOL();
-        #endif
-
-        #if Z3_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.get_pwm_thrs());
-        #endif
-
-        #if Z4_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.get_pwm_thrs());
-        #endif
-
-        #if I_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.get_pwm_thrs());
-        #endif
-        #if J_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.get_pwm_thrs());
-        #endif
-        #if K_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.get_pwm_thrs());
-        #endif
-
-        #if E0_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" T0 E", stepperE0.get_pwm_thrs());
-        #endif
-        #if E1_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" T1 E", stepperE1.get_pwm_thrs());
-        #endif
-        #if E2_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" T2 E", stepperE2.get_pwm_thrs());
-        #endif
-        #if E3_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" T3 E", stepperE3.get_pwm_thrs());
-        #endif
-        #if E4_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" T4 E", stepperE4.get_pwm_thrs());
-        #endif
-        #if E5_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" T5 E", stepperE5.get_pwm_thrs());
-        #endif
-        #if E6_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" T6 E", stepperE6.get_pwm_thrs());
-        #endif
-        #if E7_HAS_STEALTHCHOP
-          say_M913(forReplay);
-          SERIAL_ECHOLNPAIR(" T7 E", stepperE7.get_pwm_thrs());
-        #endif
-        SERIAL_EOL();
-      #endif // HYBRID_THRESHOLD
-
-      /**
-       * TMC Sensorless homing thresholds
-       */
-      #if USE_SENSORLESS
-        CONFIG_ECHO_HEADING("StallGuard threshold:");
-        #if X_SENSORLESS || Y_SENSORLESS || Z_SENSORLESS
-          CONFIG_ECHO_START();
-          say_M914();
-          #if X_SENSORLESS
-            SERIAL_ECHOPAIR_P(SP_X_STR, stepperX.homing_threshold());
-          #endif
-          #if Y_SENSORLESS
-            SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY.homing_threshold());
-          #endif
-          #if Z_SENSORLESS
-            SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ.homing_threshold());
-          #endif
-          SERIAL_EOL();
-        #endif
-
-        #if X2_SENSORLESS || Y2_SENSORLESS || Z2_SENSORLESS
-          CONFIG_ECHO_START();
-          say_M914();
-          SERIAL_ECHOPGM(" I1");
-          #if X2_SENSORLESS
-            SERIAL_ECHOPAIR_P(SP_X_STR, stepperX2.homing_threshold());
-          #endif
-          #if Y2_SENSORLESS
-            SERIAL_ECHOPAIR_P(SP_Y_STR, stepperY2.homing_threshold());
-          #endif
-          #if Z2_SENSORLESS
-            SERIAL_ECHOPAIR_P(SP_Z_STR, stepperZ2.homing_threshold());
-          #endif
-          SERIAL_EOL();
-        #endif
-
-        #if Z3_SENSORLESS
-          CONFIG_ECHO_START();
-          say_M914();
-          SERIAL_ECHOLNPAIR(" I2 Z", stepperZ3.homing_threshold());
-        #endif
-
-        #if Z4_SENSORLESS
-          CONFIG_ECHO_START();
-          say_M914();
-          SERIAL_ECHOLNPAIR(" I3 Z", stepperZ4.homing_threshold());
-        #endif
-
-        #if I_SENSORLESS
-          CONFIG_ECHO_START();
-          say_M914();
-          SERIAL_ECHOLNPAIR_P(SP_I_STR, stepperI.homing_threshold());
-        #endif
-        #if J_SENSORLESS
-          CONFIG_ECHO_START();
-          say_M914();
-          SERIAL_ECHOLNPAIR_P(SP_J_STR, stepperJ.homing_threshold());
-        #endif
-        #if K_SENSORLESS
-          CONFIG_ECHO_START();
-          say_M914();
-          SERIAL_ECHOLNPAIR_P(SP_K_STR, stepperK.homing_threshold());
-        #endif
-
-      #endif // USE_SENSORLESS
-
-      /**
-       * TMC stepping mode
-       */
-      #if HAS_STEALTHCHOP
-        CONFIG_ECHO_HEADING("Driver stepping mode:");
-        const bool chop_x = TERN0(X_HAS_STEALTHCHOP, stepperX.get_stored_stealthChop()),
-                   chop_y = TERN0(Y_HAS_STEALTHCHOP, stepperY.get_stored_stealthChop()),
-                   chop_z = TERN0(Z_HAS_STEALTHCHOP, stepperZ.get_stored_stealthChop()),
-                   chop_i = TERN0(I_HAS_STEALTHCHOP, stepperI.get_stored_stealthChop()),
-                   chop_j = TERN0(J_HAS_STEALTHCHOP, stepperJ.get_stored_stealthChop()),
-                   chop_k = TERN0(K_HAS_STEALTHCHOP, stepperK.get_stored_stealthChop());
-
-        if (chop_x || chop_y || chop_z || chop_i || chop_j || chop_k) {
-          say_M569(forReplay);
-          LINEAR_AXIS_CODE(
-            if (chop_x) SERIAL_ECHOPGM_P(SP_X_STR),
-            if (chop_y) SERIAL_ECHOPGM_P(SP_Y_STR),
-            if (chop_z) SERIAL_ECHOPGM_P(SP_Z_STR),
-            if (chop_i) SERIAL_ECHOPGM_P(SP_I_STR),
-            if (chop_j) SERIAL_ECHOPGM_P(SP_J_STR),
-            if (chop_k) SERIAL_ECHOPGM_P(SP_K_STR)
-          );
-          SERIAL_EOL();
-        }
-
-        const bool chop_x2 = TERN0(X2_HAS_STEALTHCHOP, stepperX2.get_stored_stealthChop()),
-                   chop_y2 = TERN0(Y2_HAS_STEALTHCHOP, stepperY2.get_stored_stealthChop()),
-                   chop_z2 = TERN0(Z2_HAS_STEALTHCHOP, stepperZ2.get_stored_stealthChop());
-
-        if (chop_x2 || chop_y2 || chop_z2) {
-          say_M569(forReplay, PSTR("I1"));
-          if (chop_x2) SERIAL_ECHOPGM_P(SP_X_STR);
-          if (chop_y2) SERIAL_ECHOPGM_P(SP_Y_STR);
-          if (chop_z2) SERIAL_ECHOPGM_P(SP_Z_STR);
-          SERIAL_EOL();
-        }
-
-        if (TERN0(Z3_HAS_STEALTHCHOP, stepperZ3.get_stored_stealthChop())) { say_M569(forReplay, PSTR("I2 Z"), true); }
-        if (TERN0(Z4_HAS_STEALTHCHOP, stepperZ4.get_stored_stealthChop())) { say_M569(forReplay, PSTR("I3 Z"), true); }
-
-        if (TERN0( I_HAS_STEALTHCHOP, stepperI.get_stored_stealthChop()))  { say_M569(forReplay, SP_I_STR, true); }
-        if (TERN0( J_HAS_STEALTHCHOP, stepperJ.get_stored_stealthChop()))  { say_M569(forReplay, SP_J_STR, true); }
-        if (TERN0( K_HAS_STEALTHCHOP, stepperK.get_stored_stealthChop()))  { say_M569(forReplay, SP_K_STR, true); }
-
-        if (TERN0(E0_HAS_STEALTHCHOP, stepperE0.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T0 E"), true); }
-        if (TERN0(E1_HAS_STEALTHCHOP, stepperE1.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T1 E"), true); }
-        if (TERN0(E2_HAS_STEALTHCHOP, stepperE2.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T2 E"), true); }
-        if (TERN0(E3_HAS_STEALTHCHOP, stepperE3.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T3 E"), true); }
-        if (TERN0(E4_HAS_STEALTHCHOP, stepperE4.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T4 E"), true); }
-        if (TERN0(E5_HAS_STEALTHCHOP, stepperE5.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T5 E"), true); }
-        if (TERN0(E6_HAS_STEALTHCHOP, stepperE6.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T6 E"), true); }
-        if (TERN0(E7_HAS_STEALTHCHOP, stepperE7.get_stored_stealthChop())) { say_M569(forReplay, PSTR("T7 E"), true); }
-
-      #endif // HAS_STEALTHCHOP
-
-    #endif // HAS_TRINAMIC_CONFIG
-
-    /**
-     * Linear Advance
-     */
-    #if ENABLED(LIN_ADVANCE)
-      CONFIG_ECHO_HEADING("Linear Advance:");
-      #if EXTRUDERS < 2
-        CONFIG_ECHO_MSG("  M900 K", planner.extruder_advance_K[0]);
-      #else
-        LOOP_L_N(i, EXTRUDERS)
-          CONFIG_ECHO_MSG("  M900 T", i, " K", planner.extruder_advance_K[i]);
-      #endif
+      //
+      // TMC Sensorless homing thresholds
+      //
+      TERN_(USE_SENSORLESS, gcode.M914_report(forReplay));
     #endif
 
-    #if EITHER(HAS_MOTOR_CURRENT_SPI, HAS_MOTOR_CURRENT_PWM)
-      CONFIG_ECHO_HEADING("Stepper motor currents:");
-      CONFIG_ECHO_START();
-      #if HAS_MOTOR_CURRENT_PWM
-        SERIAL_ECHOLNPAIR_P(                                   // PWM-based has 3 values:
-            PSTR("  M907 X"), stepper.motor_current_setting[0] // X and Y
-                  , SP_Z_STR, stepper.motor_current_setting[1] // Z
-                  , SP_E_STR, stepper.motor_current_setting[2] // E
-        );
-      #elif HAS_MOTOR_CURRENT_SPI
-        SERIAL_ECHOPGM("  M907");                              // SPI-based has 5 values:
-        LOOP_LOGICAL_AXES(q) {                                 // X Y Z (I J K) E (map to X Y Z (I J K) E0 by default)
-          SERIAL_CHAR(' ', axis_codes[q]);
-          SERIAL_ECHO(stepper.motor_current_setting[q]);
-        }
-        SERIAL_CHAR(' ', 'B');                                 // B (maps to E1 by default)
-        SERIAL_ECHOLN(stepper.motor_current_setting[4]);
-      #endif
-    #elif HAS_MOTOR_CURRENT_I2C                                // i2c-based has any number of values
-      // Values sent over i2c are not stored.
-      // Indexes map directly to drivers, not axes.
-    #elif HAS_MOTOR_CURRENT_DAC                                // DAC-based has 4 values, for X Y Z (I J K) E
-      // Values sent over i2c are not stored. Uses indirect mapping.
+    //
+    // TMC stepping mode
+    //
+    TERN_(HAS_STEALTHCHOP, gcode.M569_report(forReplay));
+
+    //
+    // Linear Advance
+    //
+    TERN_(LIN_ADVANCE, gcode.M900_report(forReplay));
+
+    //
+    // Motor Current (SPI or PWM)
+    //
+    #if HAS_MOTOR_CURRENT_SPI || HAS_MOTOR_CURRENT_PWM
+      gcode.M907_report(forReplay);
     #endif
 
-    /**
-     * Advanced Pause filament load & unload lengths
-     */
-    #if ENABLED(ADVANCED_PAUSE_FEATURE)
-      CONFIG_ECHO_HEADING("Filament load/unload lengths:");
-      #if EXTRUDERS == 1
-        say_M603(forReplay);
-        SERIAL_ECHOLNPAIR("L", LINEAR_UNIT(fc_settings[0].load_length), " U", LINEAR_UNIT(fc_settings[0].unload_length));
-      #else
-        auto echo_603 = [](const bool f, const uint8_t n) { say_M603(f); SERIAL_ECHOLNPAIR("T", n, " L", LINEAR_UNIT(fc_settings[n].load_length), " U", LINEAR_UNIT(fc_settings[n].unload_length)); };
-        LOOP_L_N(i, EXTRUDERS) echo_603(forReplay, i);
-      #endif
-    #endif
+    //
+    // Advanced Pause filament load & unload lengths
+    //
+    TERN_(ADVANCED_PAUSE_FEATURE, gcode.M603_report(forReplay));
 
-    #if HAS_MULTI_EXTRUDER
-      CONFIG_ECHO_HEADING("Tool-changing:");
-      CONFIG_ECHO_START();
-      M217_report(true);
-    #endif
+    //
+    // Tool-changing Parameters
+    //
+    TERN_(HAS_MULTI_EXTRUDER, gcode.M217_report(forReplay));
 
-    #if ENABLED(BACKLASH_GCODE)
-      CONFIG_ECHO_HEADING("Backlash compensation:");
-      CONFIG_ECHO_START();
-      SERIAL_ECHOLNPAIR_P(
-          PSTR("  M425 F"), backlash.get_correction()
-        , LIST_N(DOUBLE(LINEAR_AXES),
-            SP_X_STR, LINEAR_UNIT(backlash.distance_mm.x),
-            SP_Y_STR, LINEAR_UNIT(backlash.distance_mm.y),
-            SP_Z_STR, LINEAR_UNIT(backlash.distance_mm.z),
-            SP_I_STR, LINEAR_UNIT(backlash.distance_mm.i),
-            SP_J_STR, LINEAR_UNIT(backlash.distance_mm.j),
-            SP_K_STR, LINEAR_UNIT(backlash.distance_mm.k)
-          )
-        #ifdef BACKLASH_SMOOTHING_MM
-          , PSTR(" S"), LINEAR_UNIT(backlash.smoothing_mm)
-        #endif
-      );
-    #endif
+    //
+    // Backlash Compensation
+    //
+    TERN_(BACKLASH_GCODE, gcode.M425_report(forReplay));
 
-    #if HAS_FILAMENT_SENSOR
-      CONFIG_ECHO_HEADING("Filament runout sensor:");
-      CONFIG_ECHO_MSG(
-        "  M412 S", runout.enabled
-        #if HAS_FILAMENT_RUNOUT_DISTANCE
-          , " D", LINEAR_UNIT(runout.runout_distance())
-        #endif
-      );
-    #endif
+    //
+    // Filament Runout Sensor
+    //
+    TERN_(HAS_FILAMENT_SENSOR, gcode.M412_report(forReplay));
 
     #if HAS_ETHERNET
-      CONFIG_ECHO_HEADING("Ethernet:");
-      if (!forReplay) { CONFIG_ECHO_START(); ETH0_report(); }
+      CONFIG_ECHO_HEADING("Ethernet");
+      if (!forReplay) ETH0_report();
       CONFIG_ECHO_START(); SERIAL_ECHO_SP(2); MAC_report();
-      CONFIG_ECHO_START(); SERIAL_ECHO_SP(2); M552_report();
-      CONFIG_ECHO_START(); SERIAL_ECHO_SP(2); M553_report();
-      CONFIG_ECHO_START(); SERIAL_ECHO_SP(2); M554_report();
+      CONFIG_ECHO_START(); SERIAL_ECHO_SP(2); gcode.M552_report();
+      CONFIG_ECHO_START(); SERIAL_ECHO_SP(2); gcode.M553_report();
+      CONFIG_ECHO_START(); SERIAL_ECHO_SP(2); gcode.M554_report();
     #endif
 
-    #if HAS_MULTI_LANGUAGE
-      CONFIG_ECHO_HEADING("UI Language:");
-      CONFIG_ECHO_MSG("  M414 S", ui.language);
-    #endif
+    TERN_(HAS_MULTI_LANGUAGE, gcode.M414_report(forReplay));
   }
 
 #endif // !DISABLE_M503

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2353,7 +2353,7 @@ void MarlinSettings::postprocess() {
       else if (!validating) {
         DEBUG_ECHO_START();
         DEBUG_ECHO(version);
-        DEBUG_ECHOLNPAIR(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET), " bytes; crc ", (uint32_t)working_crc, ")");
+        DEBUG_ECHOLNPGM(" stored settings retrieved (", eeprom_index - (EEPROM_OFFSET), " bytes; crc ", (uint32_t)working_crc, ")");
       }
 
       if (!validating && !eeprom_error) postprocess();
@@ -2380,7 +2380,7 @@ void MarlinSettings::postprocess() {
 
           if (ubl.storage_slot >= 0) {
             load_mesh(ubl.storage_slot);
-            DEBUG_ECHOLNPAIR("Mesh ", ubl.storage_slot, " loaded from storage.");
+            DEBUG_ECHOLNPGM("Mesh ", ubl.storage_slot, " loaded from storage.");
           }
           else {
             ubl.reset();
@@ -2436,7 +2436,7 @@ void MarlinSettings::postprocess() {
   #if ENABLED(AUTO_BED_LEVELING_UBL)
 
     inline void ubl_invalid_slot(const int s) {
-      DEBUG_ECHOLNPAIR("?Invalid slot.\n", s, " mesh slots available.");
+      DEBUG_ECHOLNPGM("?Invalid slot.\n", s, " mesh slots available.");
       UNUSED(s);
     }
 
@@ -2467,7 +2467,7 @@ void MarlinSettings::postprocess() {
         const int16_t a = calc_num_meshes();
         if (!WITHIN(slot, 0, a - 1)) {
           ubl_invalid_slot(a);
-          DEBUG_ECHOLNPAIR("E2END=", persistentStore.capacity() - 1, " meshes_end=", meshes_end, " slot=", slot);
+          DEBUG_ECHOLNPGM("E2END=", persistentStore.capacity() - 1, " meshes_end=", meshes_end, " slot=", slot);
           DEBUG_EOL();
           return;
         }
@@ -2489,7 +2489,7 @@ void MarlinSettings::postprocess() {
         persistentStore.access_finish();
 
         if (status) SERIAL_ECHOLNPGM("?Unable to save mesh data.");
-        else        DEBUG_ECHOLNPAIR("Mesh saved in slot ", slot);
+        else        DEBUG_ECHOLNPGM("Mesh saved in slot ", slot);
 
       #else
 
@@ -2533,7 +2533,7 @@ void MarlinSettings::postprocess() {
         #endif
 
         if (status) SERIAL_ECHOLNPGM("?Unable to load mesh data.");
-        else        DEBUG_ECHOLNPAIR("Mesh loaded from slot ", slot);
+        else        DEBUG_ECHOLNPGM("Mesh loaded from slot ", slot);
 
         EEPROM_FINISH();
 
@@ -3010,8 +3010,8 @@ void MarlinSettings::reset() {
 #if DISABLED(DISABLE_M503)
 
   #define CONFIG_ECHO_START()       gcode.report_echo_start(forReplay)
-  #define CONFIG_ECHO_MSG(V...)     do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPAIR(V); }while(0)
-  #define CONFIG_ECHO_MSG_P(V...)   do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPAIR_P(V); }while(0)
+  #define CONFIG_ECHO_MSG(V...)     do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPGM(V); }while(0)
+  #define CONFIG_ECHO_MSG_P(V...)   do{ CONFIG_ECHO_START(); SERIAL_ECHOLNPGM_P(V); }while(0)
   #define CONFIG_ECHO_HEADING(STR)  gcode.report_heading(forReplay, PSTR(STR))
 
   void M92_report(const bool echo=true, const int8_t e=-1);
@@ -3027,7 +3027,7 @@ void MarlinSettings::reset() {
     //
     CONFIG_ECHO_HEADING("Linear Units");
     #if ENABLED(INCH_MODE_SUPPORT)
-      SERIAL_ECHOPAIR("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
+      SERIAL_ECHOPGM("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
     #else
       SERIAL_ECHOPGM("  G21 ;");
     #endif
@@ -3096,7 +3096,7 @@ void MarlinSettings::reset() {
           LOOP_L_N(py, GRID_MAX_POINTS_Y) {
             LOOP_L_N(px, GRID_MAX_POINTS_X) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR("  G29 S3 I", px, " J", py);
+              SERIAL_ECHOPGM("  G29 S3 I", px, " J", py);
               SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(mbl.z_values[px][py]), 5);
             }
           }
@@ -3121,7 +3121,7 @@ void MarlinSettings::reset() {
           LOOP_L_N(py, GRID_MAX_POINTS_Y) {
             LOOP_L_N(px, GRID_MAX_POINTS_X) {
               CONFIG_ECHO_START();
-              SERIAL_ECHOPAIR("  G29 W I", px, " J", py);
+              SERIAL_ECHOPGM("  G29 W I", px, " J", py);
               SERIAL_ECHOLNPAIR_F_P(SP_Z_STR, LINEAR_UNIT(z_values[px][py]), 5);
             }
           }

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2845,7 +2845,7 @@ int32_t Stepper::triggered_position(const AxisEnum axis) {
 #endif
 
 void Stepper::report_a_position(const xyz_long_t &pos) {
-  SERIAL_ECHOLNPAIR_P(
+  SERIAL_ECHOLNPGM_P(
     LIST_N(DOUBLE(LINEAR_AXES),
       TERN(SAYS_A, PSTR(STR_COUNT_A), PSTR(STR_COUNT_X)), pos.x,
       TERN(SAYS_B, PSTR("B:"), SP_Y_LBL), pos.y,
@@ -3167,7 +3167,7 @@ void Stepper::report_positions() {
 
       #if HAS_MOTOR_CURRENT_SPI
 
-        //SERIAL_ECHOLNPAIR("Digipotss current ", current);
+        //SERIAL_ECHOLNPGM("Digipotss current ", current);
 
         const uint8_t digipot_ch[] = DIGIPOT_CHANNELS;
         set_digipot_value_spi(digipot_ch[driver], current);

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -394,7 +394,7 @@ const char str_t_thermal_runaway[] PROGMEM = STR_T_THERMAL_RUNAWAY,
     void Temperature::report_fan_speed(const uint8_t fan) {
       if (fan >= FAN_COUNT) return;
       PORT_REDIRECT(SerialMask::All);
-      SERIAL_ECHOLNPAIR("M106 P", fan, " S", fan_speed[fan]);
+      SERIAL_ECHOLNPGM("M106 P", fan, " S", fan_speed[fan]);
     }
   #endif
 
@@ -676,7 +676,7 @@ volatile bool Temperature::raw_temps_ready = false;
             LIMIT(bias, 20, max_pow - 20);
             d = (bias > max_pow >> 1) ? max_pow - 1 - bias : bias;
 
-            SERIAL_ECHOPAIR(STR_BIAS, bias, STR_D_COLON, d, STR_T_MIN, minT, STR_T_MAX, maxT);
+            SERIAL_ECHOPGM(STR_BIAS, bias, STR_D_COLON, d, STR_T_MIN, minT, STR_T_MAX, maxT);
             if (cycles > 2) {
               const float Ku = (4.0f * d) / (float(M_PI) * (maxT - minT) * 0.5f),
                           Tu = float(t_low + t_high) * 0.001f,
@@ -687,12 +687,12 @@ volatile bool Temperature::raw_temps_ready = false;
               tune_pid.Ki = tune_pid.Kp * 2.0f / Tu;
               tune_pid.Kd = tune_pid.Kp * Tu * df;
 
-              SERIAL_ECHOLNPAIR(STR_KU, Ku, STR_TU, Tu);
+              SERIAL_ECHOLNPGM(STR_KU, Ku, STR_TU, Tu);
               if (ischamber || isbed)
                 SERIAL_ECHOLNPGM(" No overshoot");
               else
                 SERIAL_ECHOLNPGM(STR_CLASSIC_PID);
-              SERIAL_ECHOLNPAIR(STR_KP, tune_pid.Kp, STR_KI, tune_pid.Ki, STR_KD, tune_pid.Kd);
+              SERIAL_ECHOLNPGM(STR_KP, tune_pid.Kp, STR_KI, tune_pid.Ki, STR_KD, tune_pid.Kd);
             }
           }
           SHV((bias + d) >> 1);
@@ -756,13 +756,13 @@ volatile bool Temperature::raw_temps_ready = false;
 
         #if EITHER(PIDTEMPBED, PIDTEMPCHAMBER)
           PGM_P const estring = GHV(PSTR("chamber"), PSTR("bed"), NUL_STR);
-          say_default_(); SERIAL_ECHOPGM_P(estring); SERIAL_ECHOLNPAIR("Kp ", tune_pid.Kp);
-          say_default_(); SERIAL_ECHOPGM_P(estring); SERIAL_ECHOLNPAIR("Ki ", tune_pid.Ki);
-          say_default_(); SERIAL_ECHOPGM_P(estring); SERIAL_ECHOLNPAIR("Kd ", tune_pid.Kd);
+          say_default_(); SERIAL_ECHOPGM_P(estring); SERIAL_ECHOLNPGM("Kp ", tune_pid.Kp);
+          say_default_(); SERIAL_ECHOPGM_P(estring); SERIAL_ECHOLNPGM("Ki ", tune_pid.Ki);
+          say_default_(); SERIAL_ECHOPGM_P(estring); SERIAL_ECHOLNPGM("Kd ", tune_pid.Kd);
         #else
-          say_default_(); SERIAL_ECHOLNPAIR("Kp ", tune_pid.Kp);
-          say_default_(); SERIAL_ECHOLNPAIR("Ki ", tune_pid.Ki);
-          say_default_(); SERIAL_ECHOLNPAIR("Kd ", tune_pid.Kd);
+          say_default_(); SERIAL_ECHOLNPGM("Kp ", tune_pid.Kp);
+          say_default_(); SERIAL_ECHOLNPGM("Ki ", tune_pid.Ki);
+          say_default_(); SERIAL_ECHOLNPGM("Kd ", tune_pid.Kd);
         #endif
 
         auto _set_hotend_pid = [](const uint8_t e, const PID_t &in_pid) {
@@ -996,7 +996,7 @@ void Temperature::_temp_error(const heater_id_t heater_id, PGM_P const serial_ms
       OPTCODE(HAS_TEMP_BED,     case H_BED:     SERIAL_ECHOPGM(STR_HEATER_BED);     break)
       default:
         if (real_heater_id >= 0)
-          SERIAL_ECHOLNPAIR("E", real_heater_id);
+          SERIAL_ECHOLNPGM("E", real_heater_id);
     }
     SERIAL_EOL();
   }
@@ -1728,7 +1728,7 @@ void Temperature::manage_heater() {
 
   void Temperature::M305_report(const uint8_t t_index, const bool forReplay/*=true*/) {
     gcode.report_heading_etc(forReplay, PSTR(STR_USER_THERMISTORS));
-    SERIAL_ECHOPAIR("  M305 P", AS_DIGIT(t_index));
+    SERIAL_ECHOPGM("  M305 P", AS_DIGIT(t_index));
 
     const user_thermistor_t &t = user_thermistor[t_index];
 
@@ -2535,7 +2535,7 @@ void Temperature::init() {
         case H_CHAMBER: SERIAL_ECHOPGM("chamber"); break;
         default:        SERIAL_ECHO(heater_id);
       }
-      SERIAL_ECHOLNPAIR(
+      SERIAL_ECHOLNPGM(
         " ; sizeof(running_temp):", sizeof(running_temp),
         " ;  State:", state, " ;  Timer:", timer, " ;  Temperature:", current, " ;  Target Temp:", target
         #if HEATER_IDLE_HANDLER
@@ -2813,7 +2813,7 @@ void Temperature::disable_all_heaters() {
         SERIAL_ERROR_START();
         SERIAL_ECHOPGM("Temp measurement error! ");
         #if HAS_MAX31855
-          SERIAL_ECHOPAIR("MAX31855 Fault: (", max_tc_temp & 0x7, ") >> ");
+          SERIAL_ECHOPGM("MAX31855 Fault: (", max_tc_temp & 0x7, ") >> ");
           if (max_tc_temp & 0x1)
             SERIAL_ECHOLNPGM("Open Circuit");
           else if (max_tc_temp & 0x2)
@@ -2825,7 +2825,7 @@ void Temperature::disable_all_heaters() {
           max865ref.clearFault();
           if (fault_31865) {
             SERIAL_EOL();
-            SERIAL_ECHOLNPAIR("\nMAX31865 Fault: (", fault_31865, ")  >>");
+            SERIAL_ECHOLNPGM("\nMAX31865 Fault: (", fault_31865, ")  >>");
             if (fault_31865 & MAX31865_FAULT_HIGHTHRESH)
               SERIAL_ECHOLNPGM("RTD High Threshold");
             if (fault_31865 & MAX31865_FAULT_LOWTHRESH)
@@ -3543,7 +3543,7 @@ void Temperature::isr() {
     SERIAL_PRINT(t, SFP);
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
       // Temperature MAX SPI boards do not have an OVERSAMPLENR defined
-      SERIAL_ECHOPAIR(" (", TERN(HAS_MAXTC_LIBRARIES, k == 'T', false) ? r : r * RECIPROCAL(OVERSAMPLENR));
+      SERIAL_ECHOPGM(" (", TERN(HAS_MAXTC_LIBRARIES, k == 'T', false) ? r : r * RECIPROCAL(OVERSAMPLENR));
       SERIAL_CHAR(')');
     #endif
     delay(2);
@@ -3576,19 +3576,19 @@ void Temperature::isr() {
     #if HAS_MULTI_HOTEND
       HOTEND_LOOP() print_heater_state((heater_id_t)e, degHotend(e), degTargetHotend(e) OPTARG(SHOW_TEMP_ADC_VALUES, rawHotendTemp(e)));
     #endif
-    SERIAL_ECHOPAIR(" @:", getHeaterPower((heater_id_t)target_extruder));
+    SERIAL_ECHOPGM(" @:", getHeaterPower((heater_id_t)target_extruder));
     #if HAS_HEATED_BED
-      SERIAL_ECHOPAIR(" B@:", getHeaterPower(H_BED));
+      SERIAL_ECHOPGM(" B@:", getHeaterPower(H_BED));
     #endif
     #if HAS_HEATED_CHAMBER
-      SERIAL_ECHOPAIR(" C@:", getHeaterPower(H_CHAMBER));
+      SERIAL_ECHOPGM(" C@:", getHeaterPower(H_CHAMBER));
     #endif
     #if HAS_COOLER
-      SERIAL_ECHOPAIR(" C@:", getHeaterPower(H_COOLER));
+      SERIAL_ECHOPGM(" C@:", getHeaterPower(H_COOLER));
     #endif
     #if HAS_MULTI_HOTEND
       HOTEND_LOOP() {
-        SERIAL_ECHOPAIR(" @", e);
+        SERIAL_ECHOPGM(" @", e);
         SERIAL_CHAR(':');
         SERIAL_ECHO(getHeaterPower((heater_id_t)e));
       }
@@ -3896,7 +3896,7 @@ void Temperature::isr() {
       const bool wants_to_cool = isProbeAboveTemp(target_temp),
                  will_wait = !(wants_to_cool && no_wait_for_cooling);
       if (will_wait)
-        SERIAL_ECHOLNPAIR("Waiting for probe to ", (wants_to_cool ? PSTR("cool down") : PSTR("heat up")), " to ", target_temp, " degrees.");
+        SERIAL_ECHOLNPGM("Waiting for probe to ", (wants_to_cool ? PSTR("cool down") : PSTR("heat up")), " to ", target_temp, " degrees.");
 
       #if DISABLED(BUSY_WHILE_HEATING) && ENABLED(HOST_KEEPALIVE_FEATURE)
         KEEPALIVE_STATE(NOT_BUSY);

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -527,7 +527,7 @@ class Temperature {
 
     #if HAS_USER_THERMISTORS
       static user_thermistor_t user_thermistor[USER_THERMISTORS];
-      static void log_user_thermistor(const uint8_t t_index, const bool eprom=false);
+      static void M305_report(const uint8_t t_index, const bool forReplay=true);
       static void reset_user_thermistors();
       static celsius_float_t user_thermistor_to_deg_c(const uint8_t t_index, const int16_t raw);
       static inline bool set_pull_up_res(int8_t t_index, float value) {

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -189,7 +189,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     current_position.x = mpe_settings.parking_xpos[new_tool] + offsetcompensation;
 
-    DEBUG_ECHOPAIR("(1) Move extruder ", new_tool);
+    DEBUG_ECHOPGM("(1) Move extruder ", new_tool);
     DEBUG_POS(" to new extruder ParkPos", current_position);
 
     planner.buffer_line(current_position, mpe_settings.fast_feedrate, new_tool);
@@ -199,7 +199,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     current_position.x = grabpos + offsetcompensation;
 
-    DEBUG_ECHOPAIR("(2) Couple extruder ", new_tool);
+    DEBUG_ECHOPGM("(2) Couple extruder ", new_tool);
     DEBUG_POS(" to new extruder GrabPos", current_position);
 
     planner.buffer_line(current_position, mpe_settings.slow_feedrate, new_tool);
@@ -212,7 +212,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     current_position.x = mpe_settings.parking_xpos[new_tool] + offsetcompensation;
 
-    DEBUG_ECHOPAIR("(3) Move extruder ", new_tool);
+    DEBUG_ECHOPGM("(3) Move extruder ", new_tool);
     DEBUG_POS(" back to new extruder ParkPos", current_position);
 
     planner.buffer_line(current_position, mpe_settings.slow_feedrate, new_tool);
@@ -222,7 +222,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     current_position.x = mpe_settings.parking_xpos[active_extruder] + (active_extruder == 0 ? MPE_TRAVEL_DISTANCE : -MPE_TRAVEL_DISTANCE) + offsetcompensation;
 
-    DEBUG_ECHOPAIR("(4) Move extruder ", new_tool);
+    DEBUG_ECHOPGM("(4) Move extruder ", new_tool);
     DEBUG_POS(" close to old extruder ParkPos", current_position);
 
     planner.buffer_line(current_position, mpe_settings.fast_feedrate, new_tool);
@@ -232,7 +232,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     current_position.x = mpe_settings.parking_xpos[active_extruder] + offsetcompensation;
 
-    DEBUG_ECHOPAIR("(5) Park extruder ", new_tool);
+    DEBUG_ECHOPGM("(5) Park extruder ", new_tool);
     DEBUG_POS(" at old extruder ParkPos", current_position);
 
     planner.buffer_line(current_position, mpe_settings.slow_feedrate, new_tool);
@@ -242,7 +242,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     current_position.x = oldx;
 
-    DEBUG_ECHOPAIR("(6) Move extruder ", new_tool);
+    DEBUG_ECHOPGM("(6) Move extruder ", new_tool);
     DEBUG_POS(" to starting position", current_position);
 
     planner.buffer_line(current_position, mpe_settings.fast_feedrate, new_tool);
@@ -277,9 +277,9 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     if (homed_towards_final_tool) {
       pe_solenoid_magnet_off(1 - final_tool);
-      DEBUG_ECHOLNPAIR("Disengage magnet", 1 - final_tool);
+      DEBUG_ECHOLNPGM("Disengage magnet", 1 - final_tool);
       pe_solenoid_magnet_on(final_tool);
-      DEBUG_ECHOLNPAIR("Engage magnet", final_tool);
+      DEBUG_ECHOLNPGM("Engage magnet", final_tool);
       parking_extruder_set_parked(false);
       return false;
     }
@@ -318,7 +318,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
       if (!extruder_parked) {
         current_position.x = parkingposx[active_extruder] + x_offset;
 
-        DEBUG_ECHOLNPAIR("(1) Park extruder ", active_extruder);
+        DEBUG_ECHOLNPGM("(1) Park extruder ", active_extruder);
         DEBUG_POS("Moving ParkPos", current_position);
 
         fast_line_to_current(X_AXIS);
@@ -521,7 +521,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     current_position.x = placexpos;
 
-    DEBUG_ECHOLNPAIR("(1) Place old tool ", active_extruder);
+    DEBUG_ECHOLNPGM("(1) Place old tool ", active_extruder);
     DEBUG_POS("Move X SwitchPos", current_position);
 
     fast_line_to_current(X_AXIS);
@@ -627,7 +627,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
 
     current_position.y = SWITCHING_TOOLHEAD_Y_POS + SWITCHING_TOOLHEAD_Y_CLEAR;
 
-    SERIAL_ECHOLNPAIR("(1) Place old tool ", active_extruder);
+    SERIAL_ECHOLNPGM("(1) Place old tool ", active_extruder);
     DEBUG_POS("Move Y SwitchPos + Security", current_position);
 
     fast_line_to_current(Y_AXIS);
@@ -759,7 +759,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
     // 2. Move to position near active extruder parking
 
     DEBUG_SYNCHRONIZE();
-    DEBUG_ECHOLNPAIR("(2) Move near active extruder parking", active_extruder);
+    DEBUG_ECHOLNPGM("(2) Move near active extruder parking", active_extruder);
     DEBUG_POS("Moving ParkPos", current_position);
 
     current_position.set(hoffs.x + placexpos,
@@ -769,7 +769,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
     // 3. Move gently to park position of active extruder
 
     DEBUG_SYNCHRONIZE();
-    SERIAL_ECHOLNPAIR("(3) Move gently to park position of active extruder", active_extruder);
+    SERIAL_ECHOLNPGM("(3) Move gently to park position of active extruder", active_extruder);
     DEBUG_POS("Moving ParkPos", current_position);
 
     current_position.y -= SWITCHING_TOOLHEAD_Y_CLEAR;
@@ -858,7 +858,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
         && IsRunning() && !no_move                                  // ...and movement is permitted
         && (delayed_move_time || current_position.x != xhome)       // ...and delayed_move_time is set OR not "already parked"...
     ) {
-      DEBUG_ECHOLNPAIR("MoveX to ", xhome);
+      DEBUG_ECHOLNPGM("MoveX to ", xhome);
       current_position.x = xhome;
       line_to_current_position(planner.settings.max_feedrate_mm_s[X_AXIS]);   // Park the current head
       planner.synchronize();
@@ -878,7 +878,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
         current_position.x = inactive_extruder_x;
         // Save the inactive extruder's position (from the old current_position)
         inactive_extruder_x = destination.x;
-        DEBUG_ECHOLNPAIR("DXC Full Control curr.x=", current_position.x, " dest.x=", destination.x);
+        DEBUG_ECHOLNPGM("DXC Full Control curr.x=", current_position.x, " dest.x=", destination.x);
         break;
       case DXC_AUTO_PARK_MODE:
         idex_set_parked();
@@ -890,7 +890,7 @@ void fast_line_to_current(const AxisEnum fr_axis) { _line_to_current(fr_axis, 0.
     // Ensure X axis DIR pertains to the correct carriage
     stepper.set_directions();
 
-    DEBUG_ECHOLNPAIR("Active extruder parked: ", active_extruder_parked ? "yes" : "no");
+    DEBUG_ECHOLNPGM("Active extruder parked: ", active_extruder_parked ? "yes" : "no");
     DEBUG_POS("New extruder (parked)", current_position);
   }
 
@@ -1170,7 +1170,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
       (void)check_tool_sensor_stats(active_extruder, true);
 
       // The newly-selected extruder XYZ is actually at...
-      DEBUG_ECHOLNPAIR("Offset Tool XYZ by { ", diff.x, ", ", diff.y, ", ", diff.z, " }");
+      DEBUG_ECHOLNPGM("Offset Tool XYZ by { ", diff.x, ", ", diff.y, ", ", diff.z, " }");
       current_position += diff;
 
       // Tell the planner the new "current position"

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -379,7 +379,7 @@ void CardReader::ls(TERN_(LONG_FILENAME_HOST_SUPPORT, bool includeLongNames/*=fa
       // Go to the next segment
       while (path[++i]) { }
 
-      //SERIAL_ECHOLNPAIR("Looking for segment: ", segment);
+      //SERIAL_ECHOLNPGM("Looking for segment: ", segment);
 
       // Find the item, setting the long filename
       diveDir.rewind();
@@ -399,7 +399,7 @@ void CardReader::ls(TERN_(LONG_FILENAME_HOST_SUPPORT, bool includeLongNames/*=fa
       if (!dir.open(&diveDir, segment, O_READ)) {
         SERIAL_EOL();
         SERIAL_ECHO_START();
-        SERIAL_ECHOPAIR(STR_SD_CANT_OPEN_SUBDIR, segment);
+        SERIAL_ECHOPGM(STR_SD_CANT_OPEN_SUBDIR, segment);
         break;
       }
 
@@ -475,7 +475,7 @@ void CardReader::manage_media() {
   uint8_t stat = uint8_t(IS_SD_INSERTED());
   if (stat == prev_stat) return;
 
-  DEBUG_ECHOLNPAIR("SD: Status changed from ", prev_stat, " to ", stat);
+  DEBUG_ECHOLNPGM("SD: Status changed from ", prev_stat, " to ", stat);
 
   flag.workDirIsRoot = true;          // Return to root on mount/release
 
@@ -606,7 +606,7 @@ void CardReader::getAbsFilenameInCWD(char *dst) {
 }
 
 void openFailed(const char * const fname) {
-  SERIAL_ECHOLNPAIR(STR_SD_OPEN_FILE_FAIL, fname, ".");
+  SERIAL_ECHOLNPGM(STR_SD_OPEN_FILE_FAIL, fname, ".");
 }
 
 void announceOpen(const uint8_t doing, const char * const path) {
@@ -615,7 +615,7 @@ void announceOpen(const uint8_t doing, const char * const path) {
     SERIAL_ECHO_START();
     SERIAL_ECHOPGM("Now ");
     SERIAL_ECHOPGM_P(doing == 1 ? PSTR("doing") : PSTR("fresh"));
-    SERIAL_ECHOLNPAIR(" file: ", path);
+    SERIAL_ECHOLNPGM(" file: ", path);
   }
 }
 
@@ -678,7 +678,7 @@ void CardReader::openFileRead(const char * const path, const uint8_t subcall_typ
 
     { // Don't remove this block, as the PORT_REDIRECT is a RAII
       PORT_REDIRECT(SerialMask::All);
-      SERIAL_ECHOLNPAIR(STR_SD_FILE_OPENED, fname, STR_SD_SIZE, filesize);
+      SERIAL_ECHOLNPGM(STR_SD_FILE_OPENED, fname, STR_SD_SIZE, filesize);
       SERIAL_ECHOLNPGM(STR_SD_FILE_SELECTED);
     }
 
@@ -690,7 +690,7 @@ void CardReader::openFileRead(const char * const path, const uint8_t subcall_typ
 }
 
 inline void echo_write_to_file(const char * const fname) {
-  SERIAL_ECHOLNPAIR(STR_SD_WRITE_TO_FILE, fname);
+  SERIAL_ECHOLNPGM(STR_SD_WRITE_TO_FILE, fname);
 }
 
 //
@@ -730,7 +730,7 @@ void CardReader::openFileWrite(const char * const path) {
 bool CardReader::fileExists(const char * const path) {
   if (!isMounted()) return false;
 
-  DEBUG_ECHOLNPAIR("fileExists: ", path);
+  DEBUG_ECHOLNPGM("fileExists: ", path);
 
   // Dive to the file's directory and get the base name
   SdFile *diveDir = nullptr;
@@ -762,21 +762,21 @@ void CardReader::removeFile(const char * const name) {
   if (!fname) return;
 
   #if ENABLED(SDCARD_READONLY)
-    SERIAL_ECHOLNPAIR("Deletion failed (read-only), File: ", fname, ".");
+    SERIAL_ECHOLNPGM("Deletion failed (read-only), File: ", fname, ".");
   #else
     if (file.remove(itsDirPtr, fname)) {
-      SERIAL_ECHOLNPAIR("File deleted:", fname);
+      SERIAL_ECHOLNPGM("File deleted:", fname);
       sdpos = 0;
       TERN_(SDCARD_SORT_ALPHA, presort());
     }
     else
-      SERIAL_ECHOLNPAIR("Deletion failed, File: ", fname, ".");
+      SERIAL_ECHOLNPGM("Deletion failed, File: ", fname, ".");
   #endif
 }
 
 void CardReader::report_status() {
   if (isPrinting()) {
-    SERIAL_ECHOPAIR(STR_SD_PRINTING_BYTE, sdpos);
+    SERIAL_ECHOPGM(STR_SD_PRINTING_BYTE, sdpos);
     SERIAL_CHAR('/');
     SERIAL_ECHOLN(filesize);
   }
@@ -924,12 +924,12 @@ const char* CardReader::diveToFile(const bool update_cwd, SdFile* &inDirPtr, con
   // Parsing the path string
   const char *atom_ptr = path;
 
-  DEBUG_ECHOLNPAIR(" path = '", path, "'");
+  DEBUG_ECHOLNPGM(" path = '", path, "'");
 
   if (path[0] == '/') {               // Starting at the root directory?
     inDirPtr = &root;
     atom_ptr++;
-    DEBUG_ECHOLNPAIR(" CWD to root: ", hex_address((void*)inDirPtr));
+    DEBUG_ECHOLNPGM(" CWD to root: ", hex_address((void*)inDirPtr));
     if (update_cwd) workDirDepth = 0; // The cwd can be updated for the benefit of sub-programs
   }
   else
@@ -937,7 +937,7 @@ const char* CardReader::diveToFile(const bool update_cwd, SdFile* &inDirPtr, con
 
   startDirPtr = inDirPtr;
 
-  DEBUG_ECHOLNPAIR(" startDirPtr = ", hex_address((void*)startDirPtr));
+  DEBUG_ECHOLNPGM(" startDirPtr = ", hex_address((void*)startDirPtr));
 
   while (atom_ptr) {
     // Find next subdirectory delimiter
@@ -954,7 +954,7 @@ const char* CardReader::diveToFile(const bool update_cwd, SdFile* &inDirPtr, con
 
     if (echo) SERIAL_ECHOLN(dosSubdirname);
 
-    DEBUG_ECHOLNPAIR(" sub = ", hex_address((void*)sub));
+    DEBUG_ECHOLNPGM(" sub = ", hex_address((void*)sub));
 
     // Open inDirPtr (closing first)
     sub->close();
@@ -966,24 +966,24 @@ const char* CardReader::diveToFile(const bool update_cwd, SdFile* &inDirPtr, con
 
     // Close inDirPtr if not at starting-point
     if (inDirPtr != startDirPtr) {
-      DEBUG_ECHOLNPAIR(" closing inDirPtr: ", hex_address((void*)inDirPtr));
+      DEBUG_ECHOLNPGM(" closing inDirPtr: ", hex_address((void*)inDirPtr));
       inDirPtr->close();
     }
 
     // inDirPtr now subDir
     inDirPtr = sub;
-    DEBUG_ECHOLNPAIR(" inDirPtr = sub: ", hex_address((void*)inDirPtr));
+    DEBUG_ECHOLNPGM(" inDirPtr = sub: ", hex_address((void*)inDirPtr));
 
     // Update workDirParents and workDirDepth
     if (update_cwd) {
-      DEBUG_ECHOLNPAIR(" update_cwd");
+      DEBUG_ECHOLNPGM(" update_cwd");
       if (workDirDepth < MAX_DIR_DEPTH)
         workDirParents[workDirDepth++] = *inDirPtr;
     }
 
     // Point sub at the other scratch object
     sub = (inDirPtr != &newDir1) ? &newDir1 : &newDir2;
-    DEBUG_ECHOLNPAIR(" swapping sub = ", hex_address((void*)sub));
+    DEBUG_ECHOLNPGM(" swapping sub = ", hex_address((void*)sub));
 
     // Next path atom address
     atom_ptr = name_end + 1;
@@ -991,12 +991,12 @@ const char* CardReader::diveToFile(const bool update_cwd, SdFile* &inDirPtr, con
 
   if (update_cwd) {
     workDir = *inDirPtr;
-    DEBUG_ECHOLNPAIR(" final workDir = ", hex_address((void*)inDirPtr));
+    DEBUG_ECHOLNPGM(" final workDir = ", hex_address((void*)inDirPtr));
     flag.workDirIsRoot = (workDirDepth == 0);
     TERN_(SDCARD_SORT_ALPHA, presort());
   }
 
-  DEBUG_ECHOLNPAIR(" returning string ", atom_ptr ?: "nullptr");
+  DEBUG_ECHOLNPGM(" returning string ", atom_ptr ?: "nullptr");
   return atom_ptr;
 }
 
@@ -1138,9 +1138,9 @@ void CardReader::cdroot() {
             selectFileByIndex(i);
             SET_SORTNAME(i);
             SET_SORTSHORT(i);
-            // char out[30];
-            // sprintf_P(out, PSTR("---- %i %s %s"), i, flag.filenameIsDir ? "D" : " ", sortnames[i]);
-            // SERIAL_ECHOLN(out);
+            //char out[30];
+            //sprintf_P(out, PSTR("---- %i %s %s"), i, flag.filenameIsDir ? "D" : " ", sortnames[i]);
+            //SERIAL_ECHOLN(out);
             #if HAS_FOLDER_SORTING
               const uint16_t bit = i & 0x07, ind = i >> 3;
               if (bit == 0) isDir[ind] = 0x00;

--- a/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
+++ b/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
@@ -34,9 +34,9 @@
 #define USB_STARTUP_DELAY 0
 
 // uncomment to get 'printf' console debugging. NOT FOR UNO!
-//#define HOST_DEBUG(...)     {char s[255]; sprintf(s,__VA_ARGS__); SERIAL_ECHOLNPAIR("UHS:",s);}
-//#define BS_HOST_DEBUG(...)  {char s[255]; sprintf(s,__VA_ARGS__); SERIAL_ECHOLNPAIR("UHS:",s);}
-//#define MAX_HOST_DEBUG(...) {char s[255]; sprintf(s,__VA_ARGS__); SERIAL_ECHOLNPAIR("UHS:",s);}
+//#define HOST_DEBUG(...)     {char s[255]; sprintf(s,__VA_ARGS__); SERIAL_ECHOLNPGM("UHS:",s);}
+//#define BS_HOST_DEBUG(...)  {char s[255]; sprintf(s,__VA_ARGS__); SERIAL_ECHOLNPGM("UHS:",s);}
+//#define MAX_HOST_DEBUG(...) {char s[255]; sprintf(s,__VA_ARGS__); SERIAL_ECHOLNPGM("UHS:",s);}
 
 #if ENABLED(USB_FLASH_DRIVE_SUPPORT)
 
@@ -170,7 +170,7 @@ void DiskIODriver_USBFlash::idle() {
           UHS_USB_DEBUG(CONFIGURING_DONE);
           UHS_USB_DEBUG(RUNNING);
           default:
-            SERIAL_ECHOLNPAIR("UHS_USB_HOST_STATE: ", task_state);
+            SERIAL_ECHOLNPGM("UHS_USB_HOST_STATE: ", task_state);
             break;
         }
       }
@@ -273,14 +273,14 @@ bool DiskIODriver_USBFlash::init(const uint8_t, const pin_t) {
   #if USB_DEBUG >= 1
   const uint32_t sectorSize = bulk.GetSectorSize(0);
   if (sectorSize != 512) {
-    SERIAL_ECHOLNPAIR("Expecting sector size of 512. Got: ", sectorSize);
+    SERIAL_ECHOLNPGM("Expecting sector size of 512. Got: ", sectorSize);
     return false;
   }
   #endif
 
   #if USB_DEBUG >= 3
     lun0_capacity = bulk.GetCapacity(0);
-    SERIAL_ECHOLNPAIR("LUN Capacity (in blocks): ", lun0_capacity);
+    SERIAL_ECHOLNPGM("LUN Capacity (in blocks): ", lun0_capacity);
   #endif
   return true;
 }
@@ -299,11 +299,11 @@ bool DiskIODriver_USBFlash::readBlock(uint32_t block, uint8_t *dst) {
   if (!isInserted()) return false;
   #if USB_DEBUG >= 3
     if (block >= lun0_capacity) {
-      SERIAL_ECHOLNPAIR("Attempt to read past end of LUN: ", block);
+      SERIAL_ECHOLNPGM("Attempt to read past end of LUN: ", block);
       return false;
     }
     #if USB_DEBUG >= 4
-      SERIAL_ECHOLNPAIR("Read block ", block);
+      SERIAL_ECHOLNPGM("Read block ", block);
     #endif
   #endif
   return bulk.Read(0, block, 512, 1, dst) == 0;
@@ -313,11 +313,11 @@ bool DiskIODriver_USBFlash::writeBlock(uint32_t block, const uint8_t *src) {
   if (!isInserted()) return false;
   #if USB_DEBUG >= 3
     if (block >= lun0_capacity) {
-      SERIAL_ECHOLNPAIR("Attempt to write past end of LUN: ", block);
+      SERIAL_ECHOLNPGM("Attempt to write past end of LUN: ", block);
       return false;
     }
     #if USB_DEBUG >= 4
-      SERIAL_ECHOLNPAIR("Write block ", block);
+      SERIAL_ECHOLNPGM("Write block ", block);
     #endif
   #endif
   return bulk.Write(0, block, 512, 1, src) == 0;

--- a/Marlin/src/sd/usb_flashdrive/lib-uhs2/usbhost.cpp
+++ b/Marlin/src/sd/usb_flashdrive/lib-uhs2/usbhost.cpp
@@ -121,7 +121,7 @@ bool MAX3421e::start() {
 
   const uint8_t revision = regRd(rREVISION);
   if (revision == 0x00 || revision == 0xFF) {
-    SERIAL_ECHOLNPAIR("Revision register appears incorrect on MAX3421e initialization. Got ", revision);
+    SERIAL_ECHOLNPGM("Revision register appears incorrect on MAX3421e initialization. Got ", revision);
     return false;
   }
 

--- a/docs/Serial.md
+++ b/docs/Serial.md
@@ -58,10 +58,10 @@ The following macros are defined (in `serial.h`) to output data to the serial po
 | `SERIAL_ECHO` | Any basic type is supported (`char`, `uint8_t`, `int16_t`, `int32_t`, `float`, `long`, `const char*`, ...). | For a numeric type it prints the number in decimal. A string is output as a string. | `uint8_t a = 123; SERIAL_ECHO(a); SERIAL_CHAR(' '); SERIAL_ECHO(' '); ` | `123 32` |
 | `SERIAL_ECHOLN` | Same as `SERIAL_ECHO` | Do `SERIAL_ECHO`, adding a newline | `int a = 456; SERIAL_ECHOLN(a);` | `456\n` |
 | `SERIAL_ECHO_F` | `float` or `double` | Print a decimal value with a given precision (default 2) | `float a = 3.1415; SERIAL_ECHO_F(a); SERIAL_CHAR(' '); SERIAL_ECHO_F(a, 4);` | `3.14 3.1415`|
-| `SERIAL_ECHOPAIR` | String / Value pairs | Print a series of string literals and values alternately | `SERIAL_ECHOPAIR("Bob", 34);` | `Bob34` |
-| `SERIAL_ECHOLNPAIR` | Same as `SERIAL_ECHOPAIR` | Do `SERIAL_ECHOPAIR`, adding a newline | `SERIAL_ECHOPAIR("Alice", 56);` | `alice56` |
-| `SERIAL_ECHOPAIR_P` | Like `SERIAL_ECHOPAIR` but takes PGM strings | Print a series of PGM strings and values alternately | `SERIAL_ECHOPAIR_P(GET_TEXT(MSG_HELLO), 123);` | `Hello123` |
-| `SERIAL_ECHOLNPAIR_P` | Same as `SERIAL_ECHOPAIR_P` | Do `SERIAL_ECHOPAIR_P`, adding a newline | `SERIAL_ECHOLNPAIR_P(PSTR("Alice"), 78);` | `alice78\n` |
+| `SERIAL_ECHOPGM` | String / Value pairs | Print a series of string literals and values alternately | `SERIAL_ECHOPGM("Bob", 34);` | `Bob34` |
+| `SERIAL_ECHOLNPGM` | Same as `SERIAL_ECHOPGM` | Do `SERIAL_ECHOPGM`, adding a newline | `SERIAL_ECHOPGM("Alice", 56);` | `alice56` |
+| `SERIAL_ECHOPGM_P` | Like `SERIAL_ECHOPGM` but takes PGM strings | Print a series of PGM strings and values alternately | `SERIAL_ECHOPGM_P(GET_TEXT(MSG_HELLO), 123);` | `Hello123` |
+| `SERIAL_ECHOLNPGM_P` | Same as `SERIAL_ECHOPGM_P` | Do `SERIAL_ECHOPGM_P`, adding a newline | `SERIAL_ECHOLNPGM_P(PSTR("Alice"), 78);` | `alice78\n` |
 | `SERIAL_ECHOLIST` | String literal, values | Print a string literal and a list of values | `SERIAL_ECHOLIST("Key ", 1, 2, 3);` | `Key 1, 2, 3` |
 | `SERIAL_ECHO_START` | None | Prefix an echo line | `SERIAL_ECHO_START();` | `echo:` |
 | `SERIAL_ECHO_MSG` | Same as `SERIAL_ECHOLN_PAIR` | Print a full echo line | `SERIAL_ECHO_MSG("Count is ", count);` | `echo:Count is 3` |


### PR DESCRIPTION
- Add reporting to G-code commands `M200` - `M205`.
- Add a standard G-code report heading method to the `GCodeSuite` class.
- Move all G-code reporting out of `settings.cpp` and into the G-code handler files.