### PR TITLE
if NO_MOTION_BEFORE_HOMING is set don't move Z up before homing. 

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -370,9 +370,11 @@ void GcodeSuite::G28() {
     const float z_homing_height = parser.seenval('R') ? parser.value_linear_units() : Z_HOMING_HEIGHT;
 
     if (z_homing_height && (LINEAR_AXIS_GANG(doX, || doY, || TERN0(Z_SAFE_HOMING, doZ), || doI, || doJ, || doK))) {
-      // Raise Z before homing any other axes and z is not already high enough (never lower z)
-      if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) by ", z_homing_height);
-      do_z_clearance(z_homing_height);
+      #if DISABLED(NO_MOTION_BEFORE_HOMING)
+        // Raise Z before homing any other axes and z is not already high enough (never lower z)
+        if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPAIR("Raise Z (before homing) by ", z_homing_height);
+        do_z_clearance(z_homing_height);
+      #endif
       TERN_(BLTOUCH, bltouch.init());
     }
 


### PR DESCRIPTION
### Description

NO_MOTION_BEFORE_HOMING should inhibit all moves of the axis that have not yet been homed.
But  G28 moves Z up before homing Z

This can cause issues with machines that move Z to max at the end of print (eg printers where the bed moves up and down)
At the end of print the gcode.end script often sends the bed to Z max to allow for easy access and removal of the print
The next G28 will then try and drive the bed past its max position.

### Requirements

A printer where you leave Z at z-max
NO_MOTION_BEFORE_HOMING

### Benefits

Stop the machine trying to damage itself.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/21853
