### PR TITLE
Correct build offset in trigorilla_pro environment.

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -352,7 +352,6 @@ platform             = ${stm32_variant.platform}
 extends              = stm32_variant
 board                = genericSTM32F103ZE
 board_build.variant  = MARLIN_F103Zx
-board_build.offset   = 0x7000
 build_flags          = ${stm32_variant.build_flags}
                        -DENABLE_HWSERIAL3 -DTIMER_SERIAL=TIM5
 build_unflags        = ${stm32_variant.build_unflags}


### PR DESCRIPTION
### Description

When building firmware for a BOARD_TRIGORILLA_PRO, if you use the trigorilla_pro environment it would not boot but 
trigorilla_pro_maple would boot.

A quick examination of the resulting binaries showed env:trigorilla_pro_maple built for 0x08000000 while 
env:trigorilla_pro  built for 0x08007000

Removing the  build offset for the trigorilla_pro environment put the firmware back at  0x08000000 and the firmware now boots.

### Requirements

BOARD_TRIGORILLA_PRO
env:trigorilla_pro

### Benefits

firmware is put at correct address and works as expected

### Configurations

https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/delta/Anycubic/Predator

### Related Issues
Issue https://github.com/MarlinFirmware/Marlin/issues/22708
