### PR TITLE
Handle more pre-defined pins in pins_postprocess

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -30,10 +30,6 @@
 
 #include "MarlinCore.h"
 
-#if ENABLED(MARLIN_DEV_MODE)
-  #warning "WARNING! Disable MARLIN_DEV_MODE for the final build!"
-#endif
-
 #include "HAL/shared/Delay.h"
 #include "HAL/shared/esp_wifi.h"
 #include "HAL/shared/cpu_exception/exception_hook.h"

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1001,10 +1001,6 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   static_assert(WITHIN(npp_xyz.z, Z_MIN_POS, Z_MAX_POS), "NOZZLE_PARK_POINT.Z is out of bounds (Z_MIN_POS, Z_MAX_POS).");
 #endif
 
-#if !HAS_RESUME_CONTINUE && DISABLED(HOST_PROMPT_SUPPORT) && DISABLED(EXTENSIBLE_UI)
-  #warning "Your Configuration provides no method to acquire user feedback!"
-#endif
-
 /**
  * Instant Freeze
  */

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -1,0 +1,457 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * Warnings.cpp
+ * Test configuration values and give warnings at compile-time.
+ */
+
+#include "MarlinConfig.h"
+
+//
+// Warnings! Located here so they will appear just once in the build output.
+//
+
+#if ENABLED(MARLIN_DEV_MODE)
+  #warning "WARNING! Disable MARLIN_DEV_MODE for the final build!"
+#endif
+
+#if NONE(HAS_RESUME_CONTINUE, HOST_PROMPT_SUPPORT)
+  #warning "Your Configuration provides no method to acquire user feedback!"
+#endif
+
+#if AUTO_ASSIGNED_X2_STEPPER
+  #warning "Auto-assigned X2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
+#endif
+#if AUTO_ASSIGNED_X2_MS1
+  #warning "Auto-assigned X2_MS1_PIN to an unused En_MS1_PIN."
+#endif
+#if AUTO_ASSIGNED_X2_MS2
+  #warning "Auto-assigned X2_MS2_PIN to an unused En_MS2_PIN."
+#endif
+#if AUTO_ASSIGNED_X2_MS3
+  #warning "Auto-assigned X2_MS3_PIN to an unused En_MS3_PIN."
+#endif
+#if AUTO_ASSIGNED_X2_CS
+  #warning "Auto-assigned X2_CS_PIN to an unused En_CS_PIN."
+#endif
+#if AUTO_ASSIGNED_X2_DIAG
+  #if X2_USE_ENDSTOP == _XMIN_
+    #warning "Auto-assigned X2_DIAG_PIN to X_MIN_PIN."
+  #elif X2_USE_ENDSTOP == _XMAX_
+    #warning "Auto-assigned X2_DIAG_PIN to X_MAX_PIN."
+  #elif X2_USE_ENDSTOP == _YMIN_
+    #warning "Auto-assigned X2_DIAG_PIN to Y_MIN_PIN."
+  #elif X2_USE_ENDSTOP == _YMAX_
+    #warning "Auto-assigned X2_DIAG_PIN to Y_MAX_PIN."
+  #elif X2_USE_ENDSTOP == _ZMIN_
+    #warning "Auto-assigned X2_DIAG_PIN to Z_MIN_PIN."
+  #elif X2_USE_ENDSTOP == _ZMAX_
+    #warning "Auto-assigned X2_DIAG_PIN to Z_MAX_PIN."
+  #elif X2_USE_ENDSTOP == _XDIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to X_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _YDIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to Y_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _ZDIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to Z_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _E0DIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to E0_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _E1DIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to E1_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _E2DIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to E2_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _E3DIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to E3_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _E4DIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to E4_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _E5DIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to E5_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _E6DIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to E6_DIAG_PIN."
+  #elif X2_USE_ENDSTOP == _E7DIAG_
+    #warning "Auto-assigned X2_DIAG_PIN to E7_DIAG_PIN."
+  #endif
+#endif
+#if AUTO_ASSIGNED_Y2_STEPPER
+  #warning "Auto-assigned Y2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
+#endif
+#if AUTO_ASSIGNED_Y2_MS1
+  #warning "Auto-assigned Y2_MS1_PIN to an unused En_MS1_PIN."
+#endif
+#if AUTO_ASSIGNED_Y2_MS2
+  #warning "Auto-assigned Y2_MS2_PIN to an unused En_MS2_PIN."
+#endif
+#if AUTO_ASSIGNED_Y2_MS3
+  #warning "Auto-assigned Y2_MS3_PIN to an unused En_MS3_PIN."
+#endif
+#if AUTO_ASSIGNED_Y2_CS
+  #warning "Auto-assigned Y2_CS_PIN to an unused En_CS_PIN."
+#endif
+#if AUTO_ASSIGNED_Y2_DIAG
+  #if Y2_USE_ENDSTOP == _XMIN_
+    #warning "Auto-assigned Y2_DIAG_PIN to X_MIN_PIN."
+  #elif Y2_USE_ENDSTOP == _XMAX_
+    #warning "Auto-assigned Y2_DIAG_PIN to X_MAX_PIN."
+  #elif Y2_USE_ENDSTOP == _YMIN_
+    #warning "Auto-assigned Y2_DIAG_PIN to Y_MIN_PIN."
+  #elif Y2_USE_ENDSTOP == _YMAX_
+    #warning "Auto-assigned Y2_DIAG_PIN to Y_MAX_PIN."
+  #elif Y2_USE_ENDSTOP == _ZMIN_
+    #warning "Auto-assigned Y2_DIAG_PIN to Z_MIN_PIN."
+  #elif Y2_USE_ENDSTOP == _ZMAX_
+    #warning "Auto-assigned Y2_DIAG_PIN to Z_MAX_PIN."
+  #elif Y2_USE_ENDSTOP == _XDIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to X_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _YDIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to Y_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _ZDIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to Z_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _E0DIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to E0_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _E1DIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to E1_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _E2DIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to E2_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _E3DIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to E3_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _E4DIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to E4_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _E5DIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to E5_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _E6DIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to E6_DIAG_PIN."
+  #elif Y2_USE_ENDSTOP == _E7DIAG_
+    #warning "Auto-assigned Y2_DIAG_PIN to E7_DIAG_PIN."
+  #endif
+#endif
+#if AUTO_ASSIGNED_Z2_STEPPER
+  #warning "Auto-assigned Z2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
+#endif
+#if AUTO_ASSIGNED_Z2_MS1
+  #warning "Auto-assigned Z2_MS1_PIN to an unused En_MS1_PIN."
+#endif
+#if AUTO_ASSIGNED_Z2_MS2
+  #warning "Auto-assigned Z2_MS2_PIN to an unused En_MS2_PIN."
+#endif
+#if AUTO_ASSIGNED_Z2_MS3
+  #warning "Auto-assigned Z2_MS3_PIN to an unused En_MS3_PIN."
+#endif
+#if AUTO_ASSIGNED_Z2_CS
+  #warning "Auto-assigned Z2_CS_PIN to an unused En_CS_PIN."
+#endif
+#if AUTO_ASSIGNED_Z2_DIAG
+  #if Z2_USE_ENDSTOP == _XMIN_
+    #warning "Auto-assigned Z2_DIAG_PIN to X_MIN_PIN."
+  #elif Z2_USE_ENDSTOP == _XMAX_
+    #warning "Auto-assigned Z2_DIAG_PIN to X_MAX_PIN."
+  #elif Z2_USE_ENDSTOP == _YMIN_
+    #warning "Auto-assigned Z2_DIAG_PIN to Y_MIN_PIN."
+  #elif Z2_USE_ENDSTOP == _YMAX_
+    #warning "Auto-assigned Z2_DIAG_PIN to Y_MAX_PIN."
+  #elif Z2_USE_ENDSTOP == _ZMIN_
+    #warning "Auto-assigned Z2_DIAG_PIN to Z_MIN_PIN."
+  #elif Z2_USE_ENDSTOP == _ZMAX_
+    #warning "Auto-assigned Z2_DIAG_PIN to Z_MAX_PIN."
+  #elif Z2_USE_ENDSTOP == _XDIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to X_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _YDIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to Y_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _ZDIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to Z_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _E0DIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to E0_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _E1DIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to E1_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _E2DIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to E2_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _E3DIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to E3_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _E4DIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to E4_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _E5DIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to E5_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _E6DIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to E6_DIAG_PIN."
+  #elif Z2_USE_ENDSTOP == _E7DIAG_
+    #warning "Auto-assigned Z2_DIAG_PIN to E7_DIAG_PIN."
+  #endif
+#endif
+#if AUTO_ASSIGNED_Z3_STEPPER
+  #warning "Auto-assigned Z3 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
+#endif
+#if AUTO_ASSIGNED_Z3_CS
+  #warning "Auto-assigned Z3_CS_PIN to an unused En_CS_PIN."
+#endif
+#if AUTO_ASSIGNED_Z3_MS1
+  #warning "Auto-assigned Z3_MS1_PIN to an unused En_MS1_PIN."
+#endif
+#if AUTO_ASSIGNED_Z3_MS2
+  #warning "Auto-assigned Z3_MS2_PIN to an unused En_MS2_PIN."
+#endif
+#if AUTO_ASSIGNED_Z3_MS3
+  #warning "Auto-assigned Z3_MS3_PIN to an unused En_MS3_PIN."
+#endif
+#if AUTO_ASSIGNED_Z3_DIAG
+  #if Z3_USE_ENDSTOP == _XMIN_
+    #warning "Auto-assigned Z3_DIAG_PIN to X_MIN_PIN."
+  #elif Z3_USE_ENDSTOP == _XMAX_
+    #warning "Auto-assigned Z3_DIAG_PIN to X_MAX_PIN."
+  #elif Z3_USE_ENDSTOP == _YMIN_
+    #warning "Auto-assigned Z3_DIAG_PIN to Y_MIN_PIN."
+  #elif Z3_USE_ENDSTOP == _YMAX_
+    #warning "Auto-assigned Z3_DIAG_PIN to Y_MAX_PIN."
+  #elif Z3_USE_ENDSTOP == _ZMIN_
+    #warning "Auto-assigned Z3_DIAG_PIN to Z_MIN_PIN."
+  #elif Z3_USE_ENDSTOP == _ZMAX_
+    #warning "Auto-assigned Z3_DIAG_PIN to Z_MAX_PIN."
+  #elif Z3_USE_ENDSTOP == _XDIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to X_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _YDIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to Y_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _ZDIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to Z_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _E0DIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to E0_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _E1DIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to E1_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _E2DIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to E2_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _E3DIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to E3_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _E4DIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to E4_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _E5DIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to E5_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _E6DIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to E6_DIAG_PIN."
+  #elif Z3_USE_ENDSTOP == _E7DIAG_
+    #warning "Auto-assigned Z3_DIAG_PIN to E7_DIAG_PIN."
+  #endif
+#endif
+#if AUTO_ASSIGNED_Z4_STEPPER
+  #warning "Auto-assigned Z4 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
+#endif
+#if AUTO_ASSIGNED_Z4_CS
+  #warning "Auto-assigned Z4_CS_PIN to an unused En_CS_PIN."
+#endif
+#if AUTO_ASSIGNED_Z4_MS1
+  #warning "Auto-assigned Z4_MS1_PIN to an unused En_MS1_PIN."
+#endif
+#if AUTO_ASSIGNED_Z4_MS2
+  #warning "Auto-assigned Z4_MS2_PIN to an unused En_MS2_PIN."
+#endif
+#if AUTO_ASSIGNED_Z4_MS3
+  #warning "Auto-assigned Z4_MS3_PIN to an unused En_MS3_PIN."
+#endif
+#if AUTO_ASSIGNED_Z4_DIAG
+  #if Z4_USE_ENDSTOP == _XMIN_
+    #warning "Auto-assigned Z4_DIAG_PIN to X_MIN_PIN."
+  #elif Z4_USE_ENDSTOP == _XMAX_
+    #warning "Auto-assigned Z4_DIAG_PIN to X_MAX_PIN."
+  #elif Z4_USE_ENDSTOP == _YMIN_
+    #warning "Auto-assigned Z4_DIAG_PIN to Y_MIN_PIN."
+  #elif Z4_USE_ENDSTOP == _YMAX_
+    #warning "Auto-assigned Z4_DIAG_PIN to Y_MAX_PIN."
+  #elif Z4_USE_ENDSTOP == _ZMIN_
+    #warning "Auto-assigned Z4_DIAG_PIN to Z_MIN_PIN."
+  #elif Z4_USE_ENDSTOP == _ZMAX_
+    #warning "Auto-assigned Z4_DIAG_PIN to Z_MAX_PIN."
+  #elif Z4_USE_ENDSTOP == _XDIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to X_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _YDIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to Y_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _ZDIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to Z_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _E0DIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to E0_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _E1DIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to E1_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _E2DIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to E2_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _E3DIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to E3_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _E4DIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to E4_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _E5DIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to E5_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _E6DIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to E6_DIAG_PIN."
+  #elif Z4_USE_ENDSTOP == _E7DIAG_
+    #warning "Auto-assigned Z4_DIAG_PIN to E7_DIAG_PIN."
+  #endif
+#endif
+#if AUTO_ASSIGNED_I_STEPPER
+  #warning "Auto-assigned I STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
+#endif
+#if AUTO_ASSIGNED_I_CS
+  #warning "Auto-assigned I_CS_PIN to an unused En_CS_PIN."
+#endif
+#if AUTO_ASSIGNED_I_MS1
+  #warning "Auto-assigned I_MS1_PIN to an unused En_MS1_PIN."
+#endif
+#if AUTO_ASSIGNED_I_MS2
+  #warning "Auto-assigned I_MS2_PIN to an unused En_MS2_PIN."
+#endif
+#if AUTO_ASSIGNED_I_MS3
+  #warning "Auto-assigned I_MS3_PIN to an unused En_MS3_PIN."
+#endif
+#if AUTO_ASSIGNED_I_DIAG
+  #if I_USE_ENDSTOP == _XMIN_
+    #warning "Auto-assigned I_DIAG_PIN to X_MIN_PIN."
+  #elif I_USE_ENDSTOP == _XMAX_
+    #warning "Auto-assigned I_DIAG_PIN to X_MAX_PIN."
+  #elif I_USE_ENDSTOP == _YMIN_
+    #warning "Auto-assigned I_DIAG_PIN to Y_MIN_PIN."
+  #elif I_USE_ENDSTOP == _YMAX_
+    #warning "Auto-assigned I_DIAG_PIN to Y_MAX_PIN."
+  #elif I_USE_ENDSTOP == _ZMIN_
+    #warning "Auto-assigned I_DIAG_PIN to Z_MIN_PIN."
+  #elif I_USE_ENDSTOP == _ZMAX_
+    #warning "Auto-assigned I_DIAG_PIN to Z_MAX_PIN."
+  #elif I_USE_ENDSTOP == _XDIAG_
+    #warning "Auto-assigned I_DIAG_PIN to X_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _YDIAG_
+    #warning "Auto-assigned I_DIAG_PIN to Y_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _ZDIAG_
+    #warning "Auto-assigned I_DIAG_PIN to Z_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _E0DIAG_
+    #warning "Auto-assigned I_DIAG_PIN to E0_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _E1DIAG_
+    #warning "Auto-assigned I_DIAG_PIN to E1_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _E2DIAG_
+    #warning "Auto-assigned I_DIAG_PIN to E2_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _E3DIAG_
+    #warning "Auto-assigned I_DIAG_PIN to E3_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _E4DIAG_
+    #warning "Auto-assigned I_DIAG_PIN to E4_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _E5DIAG_
+    #warning "Auto-assigned I_DIAG_PIN to E5_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _E6DIAG_
+    #warning "Auto-assigned I_DIAG_PIN to E6_DIAG_PIN."
+  #elif I_USE_ENDSTOP == _E7DIAG_
+    #warning "Auto-assigned I_DIAG_PIN to E7_DIAG_PIN."
+  #endif
+#endif
+#if AUTO_ASSIGNED_J_STEPPER
+  #warning "Auto-assigned J STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
+#endif
+#if AUTO_ASSIGNED_J_CS
+  #warning "Auto-assigned J_CS_PIN to an unused En_CS_PIN."
+#endif
+#if AUTO_ASSIGNED_J_MS1
+  #warning "Auto-assigned J_MS1_PIN to an unused En_MS1_PIN."
+#endif
+#if AUTO_ASSIGNED_J_MS2
+  #warning "Auto-assigned J_MS2_PIN to an unused En_MS2_PIN."
+#endif
+#if AUTO_ASSIGNED_J_MS3
+  #warning "Auto-assigned J_MS3_PIN to an unused En_MS3_PIN."
+#endif
+#if AUTO_ASSIGNED_J_DIAG
+  #if J_USE_ENDSTOP == _XMIN_
+    #warning "Auto-assigned J_DIAG_PIN to X_MIN_PIN."
+  #elif J_USE_ENDSTOP == _XMAX_
+    #warning "Auto-assigned J_DIAG_PIN to X_MAX_PIN."
+  #elif J_USE_ENDSTOP == _YMIN_
+    #warning "Auto-assigned J_DIAG_PIN to Y_MIN_PIN."
+  #elif J_USE_ENDSTOP == _YMAX_
+    #warning "Auto-assigned J_DIAG_PIN to Y_MAX_PIN."
+  #elif J_USE_ENDSTOP == _ZMIN_
+    #warning "Auto-assigned J_DIAG_PIN to Z_MIN_PIN."
+  #elif J_USE_ENDSTOP == _ZMAX_
+    #warning "Auto-assigned J_DIAG_PIN to Z_MAX_PIN."
+  #elif J_USE_ENDSTOP == _XDIAG_
+    #warning "Auto-assigned J_DIAG_PIN to X_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _YDIAG_
+    #warning "Auto-assigned J_DIAG_PIN to Y_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _ZDIAG_
+    #warning "Auto-assigned J_DIAG_PIN to Z_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _E0DIAG_
+    #warning "Auto-assigned J_DIAG_PIN to E0_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _E1DIAG_
+    #warning "Auto-assigned J_DIAG_PIN to E1_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _E2DIAG_
+    #warning "Auto-assigned J_DIAG_PIN to E2_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _E3DIAG_
+    #warning "Auto-assigned J_DIAG_PIN to E3_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _E4DIAG_
+    #warning "Auto-assigned J_DIAG_PIN to E4_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _E5DIAG_
+    #warning "Auto-assigned J_DIAG_PIN to E5_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _E6DIAG_
+    #warning "Auto-assigned J_DIAG_PIN to E6_DIAG_PIN."
+  #elif J_USE_ENDSTOP == _E7DIAG_
+    #warning "Auto-assigned J_DIAG_PIN to E7_DIAG_PIN."
+  #endif
+#endif
+#if AUTO_ASSIGNED_K_STEPPER
+  #warning "Auto-assigned K STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
+#endif
+#if AUTO_ASSIGNED_K_CS
+  #warning "Auto-assigned K_CS_PIN to an unused En_CS_PIN."
+#endif
+#if AUTO_ASSIGNED_K_MS1
+  #warning "Auto-assigned K_MS1_PIN to an unused En_MS1_PIN."
+#endif
+#if AUTO_ASSIGNED_K_MS2
+  #warning "Auto-assigned K_MS2_PIN to an unused En_MS2_PIN."
+#endif
+#if AUTO_ASSIGNED_K_MS3
+  #warning "Auto-assigned K_MS3_PIN to an unused En_MS3_PIN."
+#endif
+#if AUTO_ASSIGNED_K_DIAG
+  #if K_USE_ENDSTOP == _XMIN_
+    #warning "Auto-assigned K_DIAG_PIN to X_MIN_PIN."
+  #elif K_USE_ENDSTOP == _XMAX_
+    #warning "Auto-assigned K_DIAG_PIN to X_MAX_PIN."
+  #elif K_USE_ENDSTOP == _YMIN_
+    #warning "Auto-assigned K_DIAG_PIN to Y_MIN_PIN."
+  #elif K_USE_ENDSTOP == _YMAX_
+    #warning "Auto-assigned K_DIAG_PIN to Y_MAX_PIN."
+  #elif K_USE_ENDSTOP == _ZMIN_
+    #warning "Auto-assigned K_DIAG_PIN to Z_MIN_PIN."
+  #elif K_USE_ENDSTOP == _ZMAX_
+    #warning "Auto-assigned K_DIAG_PIN to Z_MAX_PIN."
+  #elif K_USE_ENDSTOP == _XDIAG_
+    #warning "Auto-assigned K_DIAG_PIN to X_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _YDIAG_
+    #warning "Auto-assigned K_DIAG_PIN to Y_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _ZDIAG_
+    #warning "Auto-assigned K_DIAG_PIN to Z_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _E0DIAG_
+    #warning "Auto-assigned K_DIAG_PIN to E0_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _E1DIAG_
+    #warning "Auto-assigned K_DIAG_PIN to E1_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _E2DIAG_
+    #warning "Auto-assigned K_DIAG_PIN to E2_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _E3DIAG_
+    #warning "Auto-assigned K_DIAG_PIN to E3_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _E4DIAG_
+    #warning "Auto-assigned K_DIAG_PIN to E4_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _E5DIAG_
+    #warning "Auto-assigned K_DIAG_PIN to E5_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _E6DIAG_
+    #warning "Auto-assigned K_DIAG_PIN to E6_DIAG_PIN."
+  #elif K_USE_ENDSTOP == _E7DIAG_
+    #warning "Auto-assigned K_DIAG_PIN to E7_DIAG_PIN."
+  #endif
+#endif

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -542,6 +542,7 @@
 #define __EPIN(p,q) E##p##_##q##_PIN
 #define _EPIN(p,q) __EPIN(p,q)
 #define DIAG_REMAPPED(p,q) (PIN_EXISTS(q) && _EPIN(p##_E_INDEX, DIAG) == q##_PIN)
+#define _En_DIAG_(p) _E##p##_DIAG_
 
 // The E0/E1 steppers are always used for Dual E
 #if ENABLED(E_DUAL_STEPPER_DRIVERS)
@@ -566,19 +567,33 @@
     #define X2_ENABLE_PIN _EPIN(X2_E_INDEX, ENABLE)
     #if X2_E_INDEX >= MAX_E_STEPPERS || !PIN_EXISTS(X2_STEP)
       #error "No E stepper plug left for X2!"
+    #else
+      #define AUTO_ASSIGNED_X2_STEPPER 1
     #endif
   #endif
   #ifndef X2_MS1_PIN
     #define X2_MS1_PIN    _EPIN(X2_E_INDEX, MS1)
+    #if PIN_EXISTS(X2_MS1)
+      #define AUTO_ASSIGNED_X2_MS1 1
+    #endif
   #endif
   #ifndef X2_MS2_PIN
     #define X2_MS2_PIN    _EPIN(X2_E_INDEX, MS2)
+    #if PIN_EXISTS(X2_MS2)
+      #define AUTO_ASSIGNED_X2_MS2 1
+    #endif
   #endif
   #ifndef X2_MS3_PIN
     #define X2_MS3_PIN    _EPIN(X2_E_INDEX, MS3)
+    #if PIN_EXISTS(X2_MS3)
+      #define AUTO_ASSIGNED_X2_MS3 1
+    #endif
   #endif
   #if AXIS_HAS_SPI(X2) && !defined(X2_CS_PIN)
     #define X2_CS_PIN     _EPIN(X2_E_INDEX, CS)
+    #if PIN_EXISTS(X2_CS)
+      #define AUTO_ASSIGNED_X2_CS 1
+    #endif
   #endif
   #if AXIS_HAS_UART(X2)
     #ifndef X2_SERIAL_TX_PIN
@@ -606,11 +621,11 @@
       #define X2_USE_ENDSTOP _YMAX_
     #elif DIAG_REMAPPED(X2, Z_MAX)
       #define X2_USE_ENDSTOP _ZMAX_
-    #else                               // Otherwise use the driver DIAG_PIN directly
-      #define _X2_USE_ENDSTOP(P) _E##P##_DIAG_
-      #define X2_USE_ENDSTOP _X2_USE_ENDSTOP(X2_E_INDEX)
+    #else                               // Otherwise pick the next free En_DIAG_PIN directly
+      #define X2_USE_ENDSTOP _En_DIAG_(X2_E_INDEX)
     #endif
-    #undef X2_DIAG_PIN
+    #define AUTO_ASSIGNED_X2_DIAG 1
+    #undef X2_DIAG_PIN // Defined in Conditionals_post.h based on X2_USE_ENDSTOP
   #endif
 #endif
 
@@ -640,19 +655,33 @@
     #define Y2_ENABLE_PIN _EPIN(Y2_E_INDEX, ENABLE)
     #if Y2_E_INDEX >= MAX_E_STEPPERS || !PIN_EXISTS(Y2_STEP)
       #error "No E stepper plug left for Y2!"
+    #else
+      #define AUTO_ASSIGNED_Y2_STEPPER 1
     #endif
   #endif
   #ifndef Y2_MS1_PIN
     #define Y2_MS1_PIN    _EPIN(Y2_E_INDEX, MS1)
+    #if PIN_EXISTS(Y2_MS1)
+      #define AUTO_ASSIGNED_Y2_MS1 1
+    #endif
   #endif
   #ifndef Y2_MS2_PIN
     #define Y2_MS2_PIN    _EPIN(Y2_E_INDEX, MS2)
+    #if PIN_EXISTS(Y2_MS2)
+      #define AUTO_ASSIGNED_Y2_MS2 1
+    #endif
   #endif
   #ifndef Y2_MS3_PIN
     #define Y2_MS3_PIN    _EPIN(Y2_E_INDEX, MS3)
+    #if PIN_EXISTS(Y2_MS3)
+      #define AUTO_ASSIGNED_Y2_MS3 1
+    #endif
   #endif
   #if AXIS_HAS_SPI(Y2) && !defined(Y2_CS_PIN)
     #define Y2_CS_PIN     _EPIN(Y2_E_INDEX, CS)
+    #if PIN_EXISTS(Y2_CS)
+      #define AUTO_ASSIGNED_Y2_CS 1
+    #endif
   #endif
   #if AXIS_HAS_UART(Y2)
     #ifndef Y2_SERIAL_TX_PIN
@@ -678,10 +707,10 @@
     #elif DIAG_REMAPPED(Y2, Z_MAX)
       #define Y2_USE_ENDSTOP _ZMAX_
     #else
-      #define _Y2_USE_ENDSTOP(P) _E##P##_DIAG_
-      #define Y2_USE_ENDSTOP _Y2_USE_ENDSTOP(Y2_E_INDEX)
+      #define Y2_USE_ENDSTOP _En_DIAG_(Y2_E_INDEX)
     #endif
-    #undef Y2_DIAG_PIN
+    #define AUTO_ASSIGNED_Y2_DIAG 1
+    #undef Y2_DIAG_PIN // Defined in Conditionals_post.h based on Y2_USE_ENDSTOP
   #endif
 #endif
 
@@ -711,19 +740,33 @@
     #define Z2_ENABLE_PIN _EPIN(Z2_E_INDEX, ENABLE)
     #if Z2_E_INDEX >= MAX_E_STEPPERS || !PIN_EXISTS(Z2_STEP)
       #error "No E stepper plug left for Z2!"
+    #else
+      #define AUTO_ASSIGNED_Z2_STEPPER 1
     #endif
   #endif
   #ifndef Z2_MS1_PIN
     #define Z2_MS1_PIN    _EPIN(Z2_E_INDEX, MS1)
+    #if PIN_EXISTS(Z2_MS1)
+      #define AUTO_ASSIGNED_Z2_MS1 1
+    #endif
   #endif
   #ifndef Z2_MS2_PIN
     #define Z2_MS2_PIN    _EPIN(Z2_E_INDEX, MS2)
+    #if PIN_EXISTS(Z2_MS2)
+      #define AUTO_ASSIGNED_Z2_MS2 1
+    #endif
   #endif
   #ifndef Z2_MS3_PIN
     #define Z2_MS3_PIN    _EPIN(Z2_E_INDEX, MS3)
+    #if PIN_EXISTS(Z2_MS3)
+      #define AUTO_ASSIGNED_Z2_MS3 1
+    #endif
   #endif
   #if AXIS_HAS_SPI(Z2) && !defined(Z2_CS_PIN)
     #define Z2_CS_PIN     _EPIN(Z2_E_INDEX, CS)
+    #if PIN_EXISTS(Z2_CS)
+      #define AUTO_ASSIGNED_Z2_CS 1
+    #endif
   #endif
   #if AXIS_HAS_UART(Z2)
     #ifndef Z2_SERIAL_TX_PIN
@@ -749,10 +792,10 @@
     #elif DIAG_REMAPPED(Z2, Z_MAX)
       #define Z2_USE_ENDSTOP _ZMAX_
     #else
-      #define _Z2_USE_ENDSTOP(P) _E##P##_DIAG_
-      #define Z2_USE_ENDSTOP _Z2_USE_ENDSTOP(Z2_E_INDEX)
+      #define Z2_USE_ENDSTOP _En_DIAG_(Z2_E_INDEX)
     #endif
-    #undef Z2_DIAG_PIN
+    #define AUTO_ASSIGNED_Z2_DIAG 1
+    #undef Z2_DIAG_PIN // Defined in Conditionals_post.h based on Z2_USE_ENDSTOP
   #endif
 #endif
 
@@ -782,21 +825,33 @@
     #define Z3_ENABLE_PIN _EPIN(Z3_E_INDEX, ENABLE)
     #if Z3_E_INDEX >= MAX_E_STEPPERS || !PIN_EXISTS(Z3_STEP)
       #error "No E stepper plug left for Z3!"
+    #else
+      #define AUTO_ASSIGNED_Z3_STEPPER 1
     #endif
   #endif
-  #if AXIS_HAS_SPI(Z3)
-    #ifndef Z3_CS_PIN
-      #define Z3_CS_PIN   _EPIN(Z3_E_INDEX, CS)
+  #if AXIS_HAS_SPI(Z3) && !defined(Z3_CS_PIN)
+    #define Z3_CS_PIN     _EPIN(Z3_E_INDEX, CS)
+    #if PIN_EXISTS(Z3_CS)
+      #define AUTO_ASSIGNED_Z3_CS 1
     #endif
   #endif
   #ifndef Z3_MS1_PIN
     #define Z3_MS1_PIN    _EPIN(Z3_E_INDEX, MS1)
+    #if PIN_EXISTS(Z3_MS1)
+      #define AUTO_ASSIGNED_Z3_MS1 1
+    #endif
   #endif
   #ifndef Z3_MS2_PIN
     #define Z3_MS2_PIN    _EPIN(Z3_E_INDEX, MS2)
+    #if PIN_EXISTS(Z3_MS2)
+      #define AUTO_ASSIGNED_Z3_MS2 1
+    #endif
   #endif
   #ifndef Z3_MS3_PIN
     #define Z3_MS3_PIN    _EPIN(Z3_E_INDEX, MS3)
+    #if PIN_EXISTS(Z3_MS3)
+      #define AUTO_ASSIGNED_Z3_MS3 1
+    #endif
   #endif
   #if AXIS_HAS_UART(Z3)
     #ifndef Z3_SERIAL_TX_PIN
@@ -822,10 +877,10 @@
     #elif DIAG_REMAPPED(Z3, Z_MAX)
       #define Z3_USE_ENDSTOP _ZMAX_
     #else
-      #define _Z3_USE_ENDSTOP(P) _E##P##_DIAG_
-      #define Z3_USE_ENDSTOP _Z3_USE_ENDSTOP(Z3_E_INDEX)
+      #define Z3_USE_ENDSTOP _En_DIAG_(Z3_E_INDEX)
     #endif
-    #undef Z3_DIAG_PIN
+    #define AUTO_ASSIGNED_Z3_DIAG 1
+    #undef Z3_DIAG_PIN // Defined in Conditionals_post.h based on Z3_USE_ENDSTOP
   #endif
 #endif
 
@@ -855,21 +910,33 @@
     #define Z4_ENABLE_PIN _EPIN(Z4_E_INDEX, ENABLE)
     #if Z4_E_INDEX >= MAX_E_STEPPERS || !PIN_EXISTS(Z4_STEP)
       #error "No E stepper plug left for Z4!"
+    #else
+      #define AUTO_ASSIGNED_Z4_STEPPER 1
     #endif
   #endif
-  #if AXIS_HAS_SPI(Z4)
-    #ifndef Z4_CS_PIN
-      #define Z4_CS_PIN     _EPIN(Z4_E_INDEX, CS)
+  #if AXIS_HAS_SPI(Z4) && !defined(Z4_CS_PIN)
+    #define Z4_CS_PIN     _EPIN(Z4_E_INDEX, CS)
+    #if PIN_EXISTS(Z4_CS)
+      #define AUTO_ASSIGNED_Z4_CS 1
     #endif
   #endif
   #ifndef Z4_MS1_PIN
     #define Z4_MS1_PIN    _EPIN(Z4_E_INDEX, MS1)
+    #if PIN_EXISTS(Z4_MS1)
+      #define AUTO_ASSIGNED_Z4_MS1 1
+    #endif
   #endif
   #ifndef Z4_MS2_PIN
     #define Z4_MS2_PIN    _EPIN(Z4_E_INDEX, MS2)
+    #if PIN_EXISTS(Z4_MS2)
+      #define AUTO_ASSIGNED_Z4_MS2 1
+    #endif
   #endif
   #ifndef Z4_MS3_PIN
     #define Z4_MS3_PIN    _EPIN(Z4_E_INDEX, MS3)
+    #if PIN_EXISTS(Z4_MS3)
+      #define AUTO_ASSIGNED_Z4_MS3 1
+    #endif
   #endif
   #if AXIS_HAS_UART(Z4)
     #ifndef Z4_SERIAL_TX_PIN
@@ -895,10 +962,10 @@
     #elif DIAG_REMAPPED(Z4, Z_MAX)
       #define Z4_USE_ENDSTOP _ZMAX_
     #else
-      #define _Z4_USE_ENDSTOP(P) _E##P##_DIAG_
-      #define Z4_USE_ENDSTOP _Z4_USE_ENDSTOP(Z4_E_INDEX)
+      #define Z4_USE_ENDSTOP _En_DIAG_(Z4_E_INDEX)
     #endif
-    #undef Z4_DIAG_PIN
+    #define AUTO_ASSIGNED_Z4_DIAG 1
+    #undef Z4_DIAG_PIN // Defined in Conditionals_post.h based on Z4_USE_ENDSTOP
   #endif
 #endif
 
@@ -928,21 +995,33 @@
     #define I_ENABLE_PIN _EPIN(I_E_INDEX, ENABLE)
     #if I_E_INDEX >= MAX_E_STEPPERS || !PIN_EXISTS(I_STEP)
       #error "No E stepper plug left for I!"
+    #else
+      #define AUTO_ASSIGNED_I_STEPPER 1
     #endif
   #endif
-  #if AXIS_HAS_SPI(I)
-    #ifndef I_CS_PIN
-      #define I_CS_PIN   _EPIN(I_E_INDEX, CS)
+  #if AXIS_HAS_SPI(I) && !defined(I_CS_PIN)
+    #define I_CS_PIN     _EPIN(I_E_INDEX, CS)
+    #if PIN_EXISTS(I_CS)
+      #define AUTO_ASSIGNED_I_CS 1
     #endif
   #endif
   #ifndef I_MS1_PIN
     #define I_MS1_PIN    _EPIN(I_E_INDEX, MS1)
+    #if PIN_EXISTS(I_MS1)
+      #define AUTO_ASSIGNED_I_MS1 1
+    #endif
   #endif
   #ifndef I_MS2_PIN
     #define I_MS2_PIN    _EPIN(I_E_INDEX, MS2)
+    #if PIN_EXISTS(I_MS2)
+      #define AUTO_ASSIGNED_I_MS2 1
+    #endif
   #endif
   #ifndef I_MS3_PIN
     #define I_MS3_PIN    _EPIN(I_E_INDEX, MS3)
+    #if PIN_EXISTS(I_MS3)
+      #define AUTO_ASSIGNED_I_MS3 1
+    #endif
   #endif
   #if AXIS_HAS_UART(I)
     #ifndef I_SERIAL_TX_PIN
@@ -968,10 +1047,10 @@
     #elif DIAG_REMAPPED(I, Z_MAX)
       #define I_USE_ENDSTOP _ZMAX_
     #else
-      #define _I_USE_ENDSTOP(P) _E##P##_DIAG_
-      #define I_USE_ENDSTOP _I_USE_ENDSTOP(I_E_INDEX)
+      #define I_USE_ENDSTOP _En_DIAG_(I_E_INDEX)
     #endif
-    #undef I_DIAG_PIN
+    #define AUTO_ASSIGNED_I_DIAG 1
+    #undef I_DIAG_PIN // Defined in Conditionals_post.h based on I_USE_ENDSTOP
   #endif
 #endif
 
@@ -1001,21 +1080,33 @@
     #define J_ENABLE_PIN _EPIN(J_E_INDEX, ENABLE)
     #if I_E_INDEX >= MAX_E_STEPPERS || !PIN_EXISTS(J_STEP)
       #error "No E stepper plug left for J!"
+    #else
+      #define AUTO_ASSIGNED_J_STEPPER 1
     #endif
   #endif
-  #if AXIS_HAS_SPI(J)
-    #ifndef J_CS_PIN
-      #define J_CS_PIN   _EPIN(J_E_INDEX, CS)
+  #if AXIS_HAS_SPI(J) && !defined(J_CS_PIN)
+    #define J_CS_PIN     _EPIN(J_E_INDEX, CS)
+    #if PIN_EXISTS(J_CS)
+      #define AUTO_ASSIGNED_J_CS 1
     #endif
   #endif
   #ifndef J_MS1_PIN
     #define J_MS1_PIN    _EPIN(J_E_INDEX, MS1)
+    #if PIN_EXISTS(J_MS1)
+      #define AUTO_ASSIGNED_J_MS1 1
+    #endif
   #endif
   #ifndef J_MS2_PIN
     #define J_MS2_PIN    _EPIN(J_E_INDEX, MS2)
+    #if PIN_EXISTS(J_MS2)
+      #define AUTO_ASSIGNED_J_MS2 1
+    #endif
   #endif
   #ifndef J_MS3_PIN
     #define J_MS3_PIN    _EPIN(J_E_INDEX, MS3)
+    #if PIN_EXISTS(J_MS3)
+      #define AUTO_ASSIGNED_J_MS3 1
+    #endif
   #endif
   #if AXIS_HAS_UART(J)
     #ifndef J_SERIAL_TX_PIN
@@ -1041,10 +1132,10 @@
     #elif DIAG_REMAPPED(I, Z_MAX)
       #define J_USE_ENDSTOP _ZMAX_
     #else
-      #define _J_USE_ENDSTOP(P) _E##P##_DIAG_
-      #define J_USE_ENDSTOP _J_USE_ENDSTOP(J_E_INDEX)
+      #define J_USE_ENDSTOP _En_DIAG_(J_E_INDEX)
     #endif
-    #undef J_DIAG_PIN
+    #define AUTO_ASSIGNED_J_DIAG 1
+    #undef J_DIAG_PIN // Defined in Conditionals_post.h based on J_USE_ENDSTOP
   #endif
 #endif
 
@@ -1069,21 +1160,33 @@
     #define K_ENABLE_PIN _EPIN(K_E_INDEX, ENABLE)
     #if K_E_INDEX >= MAX_E_STEPPERS || !PIN_EXISTS(K_STEP)
       #error "No E stepper plug left for K!"
+    #else
+      #define AUTO_ASSIGNED_K_STEPPER 1
     #endif
   #endif
-  #if AXIS_HAS_SPI(K)
-    #ifndef K_CS_PIN
-      #define K_CS_PIN   _EPIN(K_E_INDEX, CS)
+  #if AXIS_HAS_SPI(K) && !defined(K_CS_PIN)
+    #define K_CS_PIN     _EPIN(K_E_INDEX, CS)
+    #if PIN_EXISTS(K_CS)
+      #define AUTO_ASSIGNED_K_CS 1
     #endif
   #endif
   #ifndef K_MS1_PIN
     #define K_MS1_PIN    _EPIN(K_E_INDEX, MS1)
+    #if PIN_EXISTS(K_MS1)
+      #define AUTO_ASSIGNED_K_MS1 1
+    #endif
   #endif
   #ifndef K_MS2_PIN
     #define K_MS2_PIN    _EPIN(K_E_INDEX, MS2)
+    #if PIN_EXISTS(K_MS2)
+      #define AUTO_ASSIGNED_K_MS2 1
+    #endif
   #endif
   #ifndef K_MS3_PIN
     #define K_MS3_PIN    _EPIN(K_E_INDEX, MS3)
+    #if PIN_EXISTS(K_MS3)
+      #define AUTO_ASSIGNED_K_MS3 1
+    #endif
   #endif
   #if AXIS_HAS_UART(K)
     #ifndef K_SERIAL_TX_PIN
@@ -1109,10 +1212,10 @@
     #elif DIAG_REMAPPED(K, Z_MAX)
       #define K_USE_ENDSTOP _ZMAX_
     #else
-      #define _K_USE_ENDSTOP(P) _E##P##_DIAG_
-      #define K_USE_ENDSTOP _K_USE_ENDSTOP(K_E_INDEX)
+      #define K_USE_ENDSTOP _En_DIAG_(K_E_INDEX)
     #endif
-    #undef K_DIAG_PIN
+    #define AUTO_ASSIGNED_K_DIAG 1
+    #undef K_DIAG_PIN // Defined in Conditionals_post.h based on K_USE_ENDSTOP
   #endif
 #endif
 

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -554,6 +554,11 @@
 #endif
 
 // The X2 axis, if any, should be the next open extruder port
+#if EITHER(DUAL_X_CARRIAGE, X_DUAL_STEPPER_DRIVERS) && !defined(X2_DIAG_PIN) && !defined(X2_STEP_PIN) && !PIN_EXISTS(X2_CS_PIN)
+  #define Y2_E_INDEX INCREMENT(X2_E_INDEX)
+#else
+  #define Y2_E_INDEX X2_E_INDEX
+#endif
 #if EITHER(DUAL_X_CARRIAGE, X_DUAL_STEPPER_DRIVERS)
   #ifndef X2_STEP_PIN
     #define X2_STEP_PIN   _EPIN(X2_E_INDEX, STEP)
@@ -587,7 +592,7 @@
   //
   // Auto-assign pins for stallGuard sensorless homing
   //
-  #if !defined(X2_USE_ENDSTOP) && defined(X2_STALL_SENSITIVITY) && ENABLED(X_DUAL_ENDSTOPS) && _PEXI(X2_E_INDEX, DIAG)
+  #if !defined(X2_DIAG_PIN) && !defined(X2_USE_ENDSTOP) && defined(X2_STALL_SENSITIVITY) && ENABLED(X_DUAL_ENDSTOPS) && _PEXI(X2_E_INDEX, DIAG)
     #define X2_DIAG_PIN _EPIN(X2_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(X2, X_MIN)      // If already remapped in the pins file...
       #define X2_USE_ENDSTOP _XMIN_
@@ -607,10 +612,6 @@
     #endif
     #undef X2_DIAG_PIN
   #endif
-
-  #define Y2_E_INDEX INCREMENT(X2_E_INDEX)
-#else
-  #define Y2_E_INDEX X2_E_INDEX
 #endif
 
 #ifndef X2_CS_PIN
@@ -627,6 +628,11 @@
 #endif
 
 // The Y2 axis, if any, should be the next open extruder port
+#if ENABLED(Y_DUAL_STEPPER_DRIVERS) && !defined(Y2_DIAG_PIN) && !defined(Y2_STEP_PIN) && !PIN_EXISTS(Y2_CS_PIN)
+  #define Z2_E_INDEX INCREMENT(Y2_E_INDEX)
+#else
+  #define Z2_E_INDEX Y2_E_INDEX
+#endif
 #if ENABLED(Y_DUAL_STEPPER_DRIVERS)
   #ifndef Y2_STEP_PIN
     #define Y2_STEP_PIN   _EPIN(Y2_E_INDEX, STEP)
@@ -657,7 +663,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(Y2_USE_ENDSTOP) && defined(Y2_STALL_SENSITIVITY) && ENABLED(Y_DUAL_ENDSTOPS) && _PEXI(Y2_E_INDEX, DIAG)
+  #if !defined(Y2_DIAG_PIN) && !defined(Y2_USE_ENDSTOP) && defined(Y2_STALL_SENSITIVITY) && ENABLED(Y_DUAL_ENDSTOPS) && _PEXI(Y2_E_INDEX, DIAG)
     #define Y2_DIAG_PIN _EPIN(Y2_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(Y2, X_MIN)
       #define Y2_USE_ENDSTOP _XMIN_
@@ -677,9 +683,6 @@
     #endif
     #undef Y2_DIAG_PIN
   #endif
-  #define Z2_E_INDEX INCREMENT(Y2_E_INDEX)
-#else
-  #define Z2_E_INDEX Y2_E_INDEX
 #endif
 
 #ifndef Y2_CS_PIN
@@ -696,6 +699,11 @@
 #endif
 
 // The Z2 axis, if any, should be the next open extruder port
+#if NUM_Z_STEPPER_DRIVERS >= 2 && !defined(Z2_DIAG_PIN) && !defined(Z2_STEP_PIN) && !PIN_EXISTS(Z2_CS_PIN)
+  #define Z3_E_INDEX INCREMENT(Z2_E_INDEX)
+#else
+  #define Z3_E_INDEX Z2_E_INDEX
+#endif
 #if NUM_Z_STEPPER_DRIVERS >= 2
   #ifndef Z2_STEP_PIN
     #define Z2_STEP_PIN   _EPIN(Z2_E_INDEX, STEP)
@@ -726,7 +734,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(Z2_USE_ENDSTOP) && defined(Z2_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 2 && _PEXI(Z2_E_INDEX, DIAG)
+  #if !defined(Z2_DIAG_PIN) && !defined(Z2_USE_ENDSTOP) && defined(Z2_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 2 && _PEXI(Z2_E_INDEX, DIAG)
     #define Z2_DIAG_PIN _EPIN(Z2_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(Z2, X_MIN)
       #define Z2_USE_ENDSTOP _XMIN_
@@ -746,9 +754,6 @@
     #endif
     #undef Z2_DIAG_PIN
   #endif
-  #define Z3_E_INDEX INCREMENT(Z2_E_INDEX)
-#else
-  #define Z3_E_INDEX Z2_E_INDEX
 #endif
 
 #ifndef Z2_CS_PIN
@@ -764,6 +769,12 @@
   #define Z2_MS3_PIN -1
 #endif
 
+// The Z3 axis, if any, should be the next open extruder port
+#if NUM_Z_STEPPER_DRIVERS >= 3 && !defined(Z3_DIAG_PIN) && !defined(Z3_STEP_PIN) && !PIN_EXISTS(Z3_CS_PIN)
+  #define Z4_E_INDEX INCREMENT(Z3_E_INDEX)
+#else
+  #define Z4_E_INDEX Z3_E_INDEX
+#endif
 #if NUM_Z_STEPPER_DRIVERS >= 3
   #ifndef Z3_STEP_PIN
     #define Z3_STEP_PIN   _EPIN(Z3_E_INDEX, STEP)
@@ -796,7 +807,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(Z3_USE_ENDSTOP) && defined(Z3_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 3 && _PEXI(Z3_E_INDEX, DIAG)
+  #if !defined(Z3_DIAG_PIN) && !defined(Z3_USE_ENDSTOP) && defined(Z3_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 3 && _PEXI(Z3_E_INDEX, DIAG)
     #define Z3_DIAG_PIN _EPIN(Z3_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(Z3, X_MIN)
       #define Z3_USE_ENDSTOP _XMIN_
@@ -816,9 +827,6 @@
     #endif
     #undef Z3_DIAG_PIN
   #endif
-  #define Z4_E_INDEX INCREMENT(Z3_E_INDEX)
-#else
-  #define Z4_E_INDEX Z3_E_INDEX
 #endif
 
 #ifndef Z3_CS_PIN
@@ -834,6 +842,12 @@
   #define Z3_MS3_PIN -1
 #endif
 
+// The Z4 axis, if any, should be the next open extruder port
+#if NUM_Z_STEPPER_DRIVERS >= 4 && !defined(Z4_DIAG_PIN) && !defined(Z4_STEP_PIN) && !PIN_EXISTS(Z4_CS_PIN)
+  #define I_E_INDEX INCREMENT(Z4_E_INDEX)
+#else
+  #define I_E_INDEX Z4_E_INDEX
+#endif
 #if NUM_Z_STEPPER_DRIVERS >= 4
   #ifndef Z4_STEP_PIN
     #define Z4_STEP_PIN   _EPIN(Z4_E_INDEX, STEP)
@@ -866,7 +880,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(Z4_USE_ENDSTOP) && defined(Z4_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 4 && _PEXI(Z4_E_INDEX, DIAG)
+  #if !defined(Z4_DIAG_PIN) && !defined(Z4_USE_ENDSTOP) && defined(Z4_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 4 && _PEXI(Z4_E_INDEX, DIAG)
     #define Z4_DIAG_PIN _EPIN(Z4_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(Z4, X_MIN)
       #define Z4_USE_ENDSTOP _XMIN_
@@ -886,9 +900,6 @@
     #endif
     #undef Z4_DIAG_PIN
   #endif
-  #define I_E_INDEX INCREMENT(Z4_E_INDEX)
-#else
-  #define I_E_INDEX Z4_E_INDEX
 #endif
 
 #ifndef Z4_CS_PIN
@@ -904,6 +915,12 @@
   #define Z4_MS3_PIN -1
 #endif
 
+// The I axis, if any, should be the next open extruder port
+#if LINEAR_AXES >= 4 && !defined(I_DIAG_PIN) && !defined(I_STEP_PIN) && !PIN_EXISTS(I_CS_PIN)
+  #define J_E_INDEX INCREMENT(I_E_INDEX)
+#else
+  #define J_E_INDEX I_E_INDEX
+#endif
 #if LINEAR_AXES >= 4
   #ifndef I_STEP_PIN
     #define I_STEP_PIN   _EPIN(I_E_INDEX, STEP)
@@ -936,7 +953,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(I_USE_ENDSTOP) && defined(I_STALL_SENSITIVITY) && _PEXI(I_E_INDEX, DIAG)
+  #if !defined(I_DIAG_PIN) && !defined(I_USE_ENDSTOP) && defined(I_STALL_SENSITIVITY) && _PEXI(I_E_INDEX, DIAG)
     #define I_DIAG_PIN _EPIN(I_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(I, X_MIN)
       #define I_USE_ENDSTOP _XMIN_
@@ -956,9 +973,6 @@
     #endif
     #undef I_DIAG_PIN
   #endif
-  #define J_E_INDEX INCREMENT(I_E_INDEX)
-#else
-  #define J_E_INDEX I_E_INDEX
 #endif
 
 #ifndef I_CS_PIN
@@ -974,6 +988,12 @@
   #define I_MS3_PIN -1
 #endif
 
+// The J axis, if any, should be the next open extruder port
+#if LINEAR_AXES >= 5 && !defined(J_DIAG_PIN) && !defined(J_STEP_PIN) && !PIN_EXISTS(J_CS_PIN)
+  #define K_E_INDEX INCREMENT(J_E_INDEX)
+#else
+  #define K_E_INDEX J_E_INDEX
+#endif
 #if LINEAR_AXES >= 5
   #ifndef J_STEP_PIN
     #define J_STEP_PIN   _EPIN(J_E_INDEX, STEP)
@@ -1006,7 +1026,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(J_USE_ENDSTOP) && defined(J_STALL_SENSITIVITY) && _PEXI(J_E_INDEX, DIAG)
+  #if !defined(J_DIAG_PIN) && !defined(J_USE_ENDSTOP) && defined(J_STALL_SENSITIVITY) && _PEXI(J_E_INDEX, DIAG)
     #define J_DIAG_PIN _EPIN(J_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(J, X_MIN)
       #define J_USE_ENDSTOP _XMIN_
@@ -1026,9 +1046,6 @@
     #endif
     #undef J_DIAG_PIN
   #endif
-  #define K_E_INDEX INCREMENT(J_E_INDEX)
-#else
-  #define K_E_INDEX J_E_INDEX
 #endif
 
 #ifndef J_CS_PIN
@@ -1044,6 +1061,7 @@
   #define J_MS3_PIN -1
 #endif
 
+// The K axis, if any, should be the next open extruder port
 #if LINEAR_AXES >= 6
   #ifndef K_STEP_PIN
     #define K_STEP_PIN   _EPIN(K_E_INDEX, STEP)
@@ -1076,7 +1094,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(K_USE_ENDSTOP) && defined(K_STALL_SENSITIVITY) && _PEXI(K_E_INDEX, DIAG)
+  #if !defined(K_DIAG_PIN) && !defined(K_USE_ENDSTOP) && defined(K_STALL_SENSITIVITY) && _PEXI(K_E_INDEX, DIAG)
     #define K_DIAG_PIN _EPIN(K_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(K, X_MIN)
       #define K_USE_ENDSTOP _XMIN_

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -76,13 +76,20 @@ def sanity_check_target():
 				raise SystemExit(err)
 
 	#
+	# Give warnings on every build
+	#
+	warnfile = os.path.join(env['PROJECT_BUILD_DIR'], build_env, "src", "src", "inc", "Warnings.cpp.o")
+	if os.path.exists(warnfile):
+		os.remove(warnfile)
+
+	#
 	# Check for old files indicating an entangled Marlin (mixing old and new code)
 	#
 	mixedin = []
-	for p in [ os.path.join(env['PROJECT_DIR'], "Marlin/src/lcd/dogm") ]:
-		for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
-			if os.path.isfile(os.path.join(p, f)):
-				mixedin += [ f ]
+	p = os.path.join(env['PROJECT_DIR'], "Marlin", "src", "lcd", "dogm")
+	for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
+		if os.path.isfile(os.path.join(p, f)):
+			mixedin += [ f ]
 	if mixedin:
 		err = "ERROR: Old files fell into your Marlin folder. Remove %s and try again" % ", ".join(mixedin)
 		raise SystemExit(err)
@@ -90,4 +97,4 @@ def sanity_check_target():
 # Detect that 'vscode init' is running
 from SCons.Script import COMMAND_LINE_TARGETS
 if "idedata" not in COMMAND_LINE_TARGETS:
-    sanity_check_target()
+	sanity_check_target()


### PR DESCRIPTION
### Description

The Octopus controller has Z2 in Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h this breaks pins postprocess when re allocating unused extruders.

eg
Steppers:   X | Y | Z | Z2 | E0 | E1 | E2 | E3    (default 8 stepper drivers)
You should be able to set DualX X, EXTRUDERS 2 and NUM_Z_STEPPER_DRIVERS 3
becomes:  X | Y | Z | Z2 | E0 | E1 | X2 | Z3   
But this errors with "No E stepper plug left for Z3"

This issue is that parts of the code presumes Z2 wont exist and always consumes a un allocated E 

I've re-ordred  pins postprocess so that if Z2 already exists, it doesn't try and re-allocate a un allocated E foe Z2

### Requirements

default_envs = BIGTREE_OCTOPUS_V1
#define SERIAL_PORT -1
#define MOTHERBOARD BOARD_BTT_OCTOPUS_V1_1
#define EXTRUDERS 2
#define TEMP_SENSOR_1 1
#define USE_XMAX_PLUG
#define NUM_Z_STEPPER_DRIVERS 3
#define DUAL_X_CARRIAGE

### Benefits

Works as expected

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/7161344/Configuration.zip)

### Related Issues

Issue https://github.com/MarlinFirmware/Marlin/issues/22714