### PR TITLE
Fix TFT Typos

### DIFF
--- a/Marlin/src/HAL/STM32/tft/tft_ltdc.cpp
+++ b/Marlin/src/HAL/STM32/tft/tft_ltdc.cpp
@@ -183,7 +183,7 @@ void LTDC_Config() {
   hltdc_F.Init.AccumulatedVBP = (LTDC_LCD_VSYNC + LTDC_LCD_VBP - 1);
   hltdc_F.Init.AccumulatedActiveH = (TFT_HEIGHT + LTDC_LCD_VSYNC + LTDC_LCD_VBP - 1);
   hltdc_F.Init.AccumulatedActiveW = (TFT_WIDTH + LTDC_LCD_HSYNC + LTDC_LCD_HBP - 1);
-  hltdc_F.Init.TotalHeight = (TFT_HEIGHT + LTDC_LCD_VSYNC + LTDC_LCD_VBP + LTDC_LCD_VFP - 1);
+  hltdc_F.Init.TotalHeigh = (TFT_HEIGHT + LTDC_LCD_VSYNC + LTDC_LCD_VBP + LTDC_LCD_VFP - 1);
   hltdc_F.Init.TotalWidth = (TFT_WIDTH + LTDC_LCD_HSYNC + LTDC_LCD_HBP + LTDC_LCD_HFP - 1);
 
   /* Configure R,G,B component values for LCD background color : all black background */
@@ -205,7 +205,7 @@ void LTDC_Config() {
   pLayerCfg.PixelFormat = LTDC_PIXEL_FORMAT_RGB565;
 
   /* Start Address configuration : frame buffer is located at SDRAM memory */
-  pLayerCfg.FBStartAddress = (uint32_t)(FRAME_BUFFER_ADDRESS);
+  pLayerCfg.FBStartAdress = (uint32_t)(FRAME_BUFFER_ADDRESS);
 
   /* Alpha constant (255 == totally opaque) */
   pLayerCfg.Alpha = 255;


### PR DESCRIPTION
### Description

Partially reverts changes introduced by https://github.com/MarlinFirmware/Marlin/pull/22531 so you can now compile for the Biqu BX & other TFTs.

### Requirements

Native TFT like the one on the Biqu BX.

### Benefits

Users can compile

### Configurations

Biqu BX with `BIQU_BX_TFT70`, though this probably affected others.

### Related Issues

None. Issue reported by WillE on Biqu/BigTreeTech's Discord server.
