### PR TITLE
Use Warning instead of Error for LA + DEFAULT_EJERK < 10

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1224,8 +1224,6 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
     #error "LIN_ADVANCE and S_CURVE_ACCELERATION may not play well together! Enable EXPERIMENTAL_SCURVE to continue."
   #elif ENABLED(DIRECT_STEPPING)
     #error "DIRECT_STEPPING is incompatible with LIN_ADVANCE. Enable in external planner if possible."
-  #elif !HAS_JUNCTION_DEVIATION && defined(DEFAULT_EJERK)
-    static_assert(DEFAULT_EJERK >= 10, "It is strongly recommended to set DEFAULT_EJERK >= 10 when using LIN_ADVANCE.");
   #endif
 #endif
 

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -455,3 +455,12 @@
     #warning "Auto-assigned K_DIAG_PIN to E7_DIAG_PIN."
   #endif
 #endif
+
+/**
+ * Linear Advance 1.5 - Warn for LIN_ADVANCE + low DEFAULT_EJERK
+ */
+#if ENABLED(LIN_ADVANCE) && defined(DEFAULT_EJERK)
+  #if !HAS_JUNCTION_DEVIATION && DEFAULT_EJERK < 10
+    #warning "It is strongly recommended to set DEFAULT_EJERK >= 10 when using LIN_ADVANCE."
+  #endif
+#endif


### PR DESCRIPTION
### Description

A `DEFAULT_EJERK` of < 10 is a perfectly valid combination, particularly for direct drive hotends like those found on the Prusa MK3/S, or printers upgraded with direct drive BMGs or Orbiter extruders.

### Requirements

Direct drive hotend

### Benefits

Less stringent rules for valid hardware combos

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/22785
- [Sanity-check DEFAULT_EJERK with LIN_ADVANCE](https://github.com/MarlinFirmware/Marlin/commit/22ae09ace498e735c216bbb726f2c3f39d5d714a) (22ae09a)
- https://github.com/MarlinFirmware/Marlin/issues/20649