### PR TITLE
Update STM32F1/HAL.h to allow ADC_RESOLUTION to be set with -DADC_RESOLUTION

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.h
+++ b/Marlin/src/HAL/STM32/HAL.h
@@ -183,8 +183,13 @@ static inline int freeMemory() {
 
 #define HAL_ANALOG_SELECT(pin) pinMode(pin, INPUT)
 
+#ifdef ADC_RESOLUTION
+  #define HAL_ADC_RESOLUTION ADC_RESOLUTION
+#else
+  #define HAL_ADC_RESOLUTION 12
+#endif
+
 #define HAL_ADC_VREF         3.3
-#define HAL_ADC_RESOLUTION  ADC_RESOLUTION // 12
 #define HAL_START_ADC(pin)  HAL_adc_start_conversion(pin)
 #define HAL_READ_ADC()      HAL_adc_result
 #define HAL_ADC_READY()     true

--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -238,7 +238,11 @@ static inline int freeMemory() {
 void HAL_adc_init();
 
 #define HAL_ADC_VREF         3.3
-#define HAL_ADC_RESOLUTION  10
+#ifndef ADC_RESOLUTION
+#define HAL_ADC_RESOLUTION 10
+#else
+#define HAL_ADC_RESOLUTION ADC_RESOLUTION
+#endif
 #define HAL_START_ADC(pin)  HAL_adc_start_conversion(pin)
 #define HAL_READ_ADC()      HAL_adc_result
 #define HAL_ADC_READY()     true

--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -237,12 +237,13 @@ static inline int freeMemory() {
 
 void HAL_adc_init();
 
-#define HAL_ADC_VREF         3.3
 #ifdef ADC_RESOLUTION
   #define HAL_ADC_RESOLUTION ADC_RESOLUTION
 #else
-  #define HAL_ADC_RESOLUTION 10
+  #define HAL_ADC_RESOLUTION 12
 #endif
+
+#define HAL_ADC_VREF         3.3
 #define HAL_START_ADC(pin)  HAL_adc_start_conversion(pin)
 #define HAL_READ_ADC()      HAL_adc_result
 #define HAL_ADC_READY()     true

--- a/Marlin/src/HAL/STM32F1/HAL.h
+++ b/Marlin/src/HAL/STM32F1/HAL.h
@@ -238,10 +238,10 @@ static inline int freeMemory() {
 void HAL_adc_init();
 
 #define HAL_ADC_VREF         3.3
-#ifndef ADC_RESOLUTION
-#define HAL_ADC_RESOLUTION 10
+#ifdef ADC_RESOLUTION
+  #define HAL_ADC_RESOLUTION ADC_RESOLUTION
 #else
-#define HAL_ADC_RESOLUTION ADC_RESOLUTION
+  #define HAL_ADC_RESOLUTION 10
 #endif
 #define HAL_START_ADC(pin)  HAL_adc_start_conversion(pin)
 #define HAL_READ_ADC()      HAL_adc_result

--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -16,7 +16,6 @@ build_flags      = ${common.build_flags}
                    -std=gnu++14 -DHAL_STM32
                    -DUSBCON -DUSBD_USE_CDC
                    -DTIM_IRQ_PRIO=13
-                   -DADC_RESOLUTION=12
 build_unflags    = -std=gnu++11
 src_filter       = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
 extra_scripts    = ${common.extra_scripts}


### PR DESCRIPTION
As per suggestion in #22767

### Description

Allows `-DADC_RESOLUTION` to be used from [common_stm32] and be applied to STM32F1.

### Related Issues

#22767 