### PR TITLE
update anycubic_i3mega_lcd debug macros

### DIFF
--- a/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -38,8 +38,8 @@
 #define SEND(x)           send(x)
 #define SENDLINE(x)       sendLine(x)
 #if ENABLED(ANYCUBIC_LCD_DEBUG)
-  #define SENDLINE_DBG_PGM(x,y)       (sendLine_P(PSTR(x)), SERIAL_ECHOLNPGM(y))
-  #define SENDLINE_DBG_PGM_VAL(x,y,z) (sendLine_P(PSTR(x)), SERIAL_ECHOPGM(y), SERIAL_ECHOLN(z))
+  #define SENDLINE_DBG_PGM(x,y)       do{sendLine_P(PSTR(x)); SERIAL_ECHOLNPGM(y);}while(0)
+  #define SENDLINE_DBG_PGM_VAL(x,y,z) do{sendLine_P(PSTR(x)); SERIAL_ECHOPGM(y); SERIAL_ECHOLN(z);}while(0)
 #else
   #define SENDLINE_DBG_PGM(x,y)       sendLine_P(PSTR(x))
   #define SENDLINE_DBG_PGM_VAL(x,y,z) sendLine_P(PSTR(x))

--- a/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_i3mega_lcd.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_i3mega_lcd.cpp
@@ -38,8 +38,8 @@
 #define SEND(x)           send(x)
 #define SENDLINE(x)       sendLine(x)
 #if ENABLED(ANYCUBIC_LCD_DEBUG)
-  #define SENDLINE_DBG_PGM(x,y)       do{sendLine_P(PSTR(x)); SERIAL_ECHOLNPGM(y);}while(0)
-  #define SENDLINE_DBG_PGM_VAL(x,y,z) do{sendLine_P(PSTR(x)); SERIAL_ECHOPGM(y); SERIAL_ECHOLN(z);}while(0)
+  #define SENDLINE_DBG_PGM(x,y)       do{ sendLine_P(PSTR(x)); SERIAL_ECHOLNPGM(y); }while(0)
+  #define SENDLINE_DBG_PGM_VAL(x,y,z) do{ sendLine_P(PSTR(x)); SERIAL_ECHOLNPGM(y, z); }while(0)
 #else
   #define SENDLINE_DBG_PGM(x,y)       sendLine_P(PSTR(x))
   #define SENDLINE_DBG_PGM_VAL(x,y,z) sendLine_P(PSTR(x))


### PR DESCRIPTION
### Description

When you have #define ANYCUBIC_LCD_I3MEGA and  #define ANYCUBIC_LCD_DEBUG Marlin will give compile errors

```CPP
Marlin/src/lcd/extui/anycubic_i3mega/../../../sd/../inc/../core/serial.h:210:35: error: expected primary-expression before 'do'
 #define SERIAL_ECHOLNPGM(V...)    do{ EVAL(_SELP_N(TWO_ARGS(V),V)); }while(0)
                                   ^
Marlin/src/lcd/extui/anycubic_i3mega/anycubic_i3mega_lcd.cpp:41:61: note: in expansion of macro 'SERIAL_ECHOLNPGM'
   #define SENDLINE_DBG_PGM(x,y)       (sendLine_P(PSTR(x)), SERIAL_ECHOLNPGM(y))
                                                             ^~~~~~~~~~~~~~~~
Marlin/src/lcd/extui/anycubic_i3mega/anycubic_i3mega_lcd.cpp:84:3: note: in expansion of macro 'SENDLINE_DBG_PGM'
   SENDLINE_DBG_PGM("J17", "TFT Serial Debug: Main board reset... J17"); // J17 Main board reset
   ^~~~~~~~~~~~~~~~
```
Updated #define SENDLINE_DBG_PGM(x,y) and  #define SENDLINE_DBG_PGM_VAL(x,y,z) so it will actually compile.

### Requirements

ANYCUBIC_LCD_I3MEGA
ANYCUBIC_LCD_DEBUG

### Benefits

Compiles as expected

### Configurations
Marlin example config for AnyCubic i3 Mega
https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/AnyCubic/i3%20Mega

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/22818