### PR TITLE
Make u8g_outData and friends static

### DIFF
--- a/Marlin/src/HAL/AVR/u8g_com_HAL_AVR_sw_spi.cpp
+++ b/Marlin/src/HAL/AVR/u8g_com_HAL_AVR_sw_spi.cpp
@@ -64,8 +64,8 @@
 
 #include <U8glib-HAL.h>
 
-uint8_t u8g_bitData, u8g_bitNotData, u8g_bitClock, u8g_bitNotClock;
-volatile uint8_t *u8g_outData, *u8g_outClock;
+static uint8_t u8g_bitData, u8g_bitNotData, u8g_bitClock, u8g_bitNotClock;
+static volatile uint8_t *u8g_outData, *u8g_outClock;
 
 static void u8g_com_arduino_init_shift_out(uint8_t dataPin, uint8_t clockPin) {
   u8g_outData = portOutputRegister(digitalPinToPort(dataPin));


### PR DESCRIPTION
Avoids a duplicate symbol issue

### Description

Ran into the same issue as https://github.com/MarlinFirmware/Marlin/issues/18368 and the change there fixes it. Submitted [similar change to u8glib-hal](https://github.com/MarlinFirmware/U8glib-HAL/pull/28) as well.

### Requirements

See original issue

### Benefits

Avoids build issue

### Configurations

See original issue

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/18368
