### PR TITLE
Fix M420 / M851 reports

### DIFF
--- a/Marlin/src/gcode/bedlevel/M420.cpp
+++ b/Marlin/src/gcode/bedlevel/M420.cpp
@@ -251,7 +251,7 @@ void GcodeSuite::M420_report(const bool forReplay/*=true*/) {
     #if ENABLED(ENABLE_LEVELING_FADE_HEIGHT)
       , SP_Z_STR, LINEAR_UNIT(planner.z_fade_height)
     #endif
-    , " ; Leveling "
+    , PSTR(" ; Leveling ")
   );
   serialprintln_onoff(planner.leveling_active);
 }

--- a/Marlin/src/gcode/probe/M851.cpp
+++ b/Marlin/src/gcode/probe/M851.cpp
@@ -94,7 +94,7 @@ void GcodeSuite::M851_report(const bool forReplay/*=true*/) {
       PSTR("  M851 X0 Y0 Z")
     #endif
     , LINEAR_UNIT(probe.offset.z)
-    , " ;"
+    , PSTR(" ;")
   );
   say_units();
 }


### PR DESCRIPTION
### Description

Fix garbage characters being listed in the `M420` report from `M503`.

### Requirements

Marlin with ABL or MBL enabled

### Benefits

Fixes garbage characters instead of correct comment.

### Related Issues

No issue reported in Marlin issue tracker. The following was seen on the OctoPrint discord:

"I just compiled Marlin 2..0x bugfix for my ender 3 pro (8 bit board) - anyone know why these strange chars show up in the output of bed level commands:
```
; Auto Bed Leveling:
READ: echo:  M420 S0 Z10.00?ð?ð?ðàà?ð?ð?ðÀOFF
M420 S0 Z10.00?ð?ð?ðàà?ð?ð?ðÀOFF
echo:  M304 P108.93 I19.84 D398.60
READ: echo:; Z-Probe Offset:
; Z-Probe Offset:
READ: echo:  M851 X-44.00 Y-9.00 Z-2.80ÿ (mm)
M851 X-44.00 Y-9.00 Z-2.80ÿ (mm)
```
Everything seems to be working except for these strange chars in output"

Asked the user to make the change defined in this PR and it fixed the problem for them.
I note that the `M851` output also seems to have a single garbage character - same issue?

@LazeMSS can you post your config files?