### PR TITLE
Aesthetic M503 fix

### DIFF
--- a/Marlin/src/gcode/feature/runout/M412.cpp
+++ b/Marlin/src/gcode/feature/runout/M412.cpp
@@ -68,7 +68,7 @@ void GcodeSuite::M412() {
 
 void GcodeSuite::M412_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, PSTR(STR_FILAMENT_RUNOUT_SENSOR));
-  SERIAL_ECHOLNPGM(
+  SERIAL_ECHOPGM(
     "  M412 S", runout.enabled
     #if HAS_FILAMENT_RUNOUT_DISTANCE
       , " D", LINEAR_UNIT(runout.runout_distance())


### PR DESCRIPTION
Remove newline on M412 report, between 'sensor' and status text