### PR TITLE
add  BLTOUCH_SET_5V_MODE pin sanity test for stm32f103 

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1529,10 +1529,41 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #endif
 
   #if ENABLED(BLTOUCH)
+    //Check for coltrollers that we know about.
+    #define ENABLE_FT_CHECK ENABLED(STM32F1)
+
+    //What pin does probe use?
+    #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
+      #define PROBE_ON_PIN Z_MIN_PIN
+    #else
+      #define PROBE_ON_PIN Z_MIN_PROBE_PIN
+    #endif
+
+    #if ENABLED(STM32F1)
+      // List of pins that are 5 volt tolerant for stm32f103
+      #define CHECK_FT_PIN(FT) (\
+        FT == PA8 || FT == PA9 || FT == PA10 || FT == PA11 || FT == PA12 || FT == PA13 || FT == PA14 || FT == PA15 || \
+        FT == PB2 || FT == PB3 || FT == PB4  || FT == PB5  || FT == PB6  || FT == PB7  || FT == PB8  || FT == PB9  || FT == PB10 || FT == PB11 || FT == PB12 || FT == PB13 || FT == PB14 || FT == PB15 || \
+        FT == PC6 || FT == PC7 || FT == PC8  || FT == PC9  || FT == PC10 || FT == PC11 || FT == PC12 || \
+        FT == PD0 || FT == PD1 || FT == PD2  || FT == PD3  || FT == PD4  || FT == PD5  || FT == PD6  || FT == PD7  || FT == PD8  || FT == PD9  || FT == PD10 || FT == PD11 || FT == PD12 || FT == PD13 || FT == PD14 || FT == PD15 || \
+        FT == PE0 || FT == PE1 || FT == PE2  || FT == PE3  || FT == PE4  || FT == PE5  || FT == PE6  || FT == PE7  || FT == PE8  || FT == PE9  || FT == PE10 || FT == PE11 || FT == PE12 || FT == PE13 || FT == PE14 || FT == PE15 || \
+        FT == PF0 || FT == PF1 || FT == PF2  || FT == PF3  || FT == PF4  || FT == PF5  || FT == PF11 || FT == PF12 || FT == PF13 || FT == PF14 || FT == PF15 \
+      )
+    #endif
+
+    #if ENABLE_FT_CHECK
+      #define CHECK_BLTOUCH_PIN_IS_FIVE_VOLT_TOLERNT CHECK_FT_PIN(PROBE_ON_PIN)
+    #else
+      #define CHECK_BLTOUCH_PIN_IS_FIVE_VOLT_TOLERNT 1
+    #endif
+
     #if BLTOUCH_DELAY < 200
       #error "BLTOUCH_DELAY less than 200 is unsafe and is not supported."
     #elif DISABLED(BLTOUCH_SET_5V_MODE) && NONE(ONBOARD_ENDSTOPPULLUPS, ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN, ENDSTOPPULLUP_ZMIN_PROBE)
       #error "BLTOUCH without BLTOUCH_SET_5V_MODE requires ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN or ENDSTOPPULLUP_ZMIN_PROBE."
+    #endif
+    #if ENABLED(BLTOUCH_SET_5V_MODE) && !CHECK_BLTOUCH_PIN_IS_FIVE_VOLT_TOLERNT
+      #error "BLTOUCH_SET_5V_MODE is active but the pin is not 5V tolerant. Disable BLTOUCH_SET_5V_MODE"
     #endif
   #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1529,41 +1529,28 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #endif
 
   #if ENABLED(BLTOUCH)
-    //Check for coltrollers that we know about.
-    #define ENABLE_FT_CHECK ENABLED(STM32F1)
-
-    //What pin does probe use?
-    #if ENABLED(Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)
-      #define PROBE_ON_PIN Z_MIN_PIN
-    #else
-      #define PROBE_ON_PIN Z_MIN_PROBE_PIN
+    #if ENABLED(BLTOUCH_SET_5V_MODE)
+      #define _5V(A,B) !WITHIN(FT,A,B)
+      #ifdef STM32F1            // STM32F103 5V-tolerant pins
+        #define _NOT_5V_PIN(FT) (_5V(PA8, PA15) && _5V(PB2, PB15) && _5V(PC6, PC12) && _5V(PD0, PD15) && _5V(PE0, PE15) && _5V(PF0, PF5) && _5V(PF11, PF15))
+      #else
+        #define _NOT_5V_PIN(FT) 0 // No more known controllers
+      #endif
+      #if USES_Z_MIN_PROBE_PIN && _NOT_5V_PIN(Z_MIN_PROBE_PIN)
+        #error "BLTOUCH_SET_5V_MODE is not compatible with the Z_MIN_PROBE_PIN."
+      #elif _NOT_5V_PIN(Z_MIN_PIN)
+        #error "BLTOUCH_SET_5V_MODE is not compatible with the Z_MIN_PIN."
+      #endif
+      #undef _NOT_5V_PIN
+      #undef _5V
     #endif
 
-    #if ENABLED(STM32F1)
-      // List of pins that are 5 volt tolerant for stm32f103
-      #define CHECK_FT_PIN(FT) (\
-        FT == PA8 || FT == PA9 || FT == PA10 || FT == PA11 || FT == PA12 || FT == PA13 || FT == PA14 || FT == PA15 || \
-        FT == PB2 || FT == PB3 || FT == PB4  || FT == PB5  || FT == PB6  || FT == PB7  || FT == PB8  || FT == PB9  || FT == PB10 || FT == PB11 || FT == PB12 || FT == PB13 || FT == PB14 || FT == PB15 || \
-        FT == PC6 || FT == PC7 || FT == PC8  || FT == PC9  || FT == PC10 || FT == PC11 || FT == PC12 || \
-        FT == PD0 || FT == PD1 || FT == PD2  || FT == PD3  || FT == PD4  || FT == PD5  || FT == PD6  || FT == PD7  || FT == PD8  || FT == PD9  || FT == PD10 || FT == PD11 || FT == PD12 || FT == PD13 || FT == PD14 || FT == PD15 || \
-        FT == PE0 || FT == PE1 || FT == PE2  || FT == PE3  || FT == PE4  || FT == PE5  || FT == PE6  || FT == PE7  || FT == PE8  || FT == PE9  || FT == PE10 || FT == PE11 || FT == PE12 || FT == PE13 || FT == PE14 || FT == PE15 || \
-        FT == PF0 || FT == PF1 || FT == PF2  || FT == PF3  || FT == PF4  || FT == PF5  || FT == PF11 || FT == PF12 || FT == PF13 || FT == PF14 || FT == PF15 \
-      )
-    #endif
-
-    #if ENABLE_FT_CHECK
-      #define CHECK_BLTOUCH_PIN_IS_FIVE_VOLT_TOLERNT CHECK_FT_PIN(PROBE_ON_PIN)
-    #else
-      #define CHECK_BLTOUCH_PIN_IS_FIVE_VOLT_TOLERNT 1
-    #endif
+    #undef _DO_FT_CHECK
 
     #if BLTOUCH_DELAY < 200
       #error "BLTOUCH_DELAY less than 200 is unsafe and is not supported."
     #elif DISABLED(BLTOUCH_SET_5V_MODE) && NONE(ONBOARD_ENDSTOPPULLUPS, ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN, ENDSTOPPULLUP_ZMIN_PROBE)
       #error "BLTOUCH without BLTOUCH_SET_5V_MODE requires ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN or ENDSTOPPULLUP_ZMIN_PROBE."
-    #endif
-    #if ENABLED(BLTOUCH_SET_5V_MODE) && !CHECK_BLTOUCH_PIN_IS_FIVE_VOLT_TOLERNT
-      #error "BLTOUCH_SET_5V_MODE is active but the pin is not 5V tolerant. Disable BLTOUCH_SET_5V_MODE"
     #endif
   #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -1529,28 +1529,34 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #endif
 
   #if ENABLED(BLTOUCH)
+
+    // BLTouch can't run in 5V mode with a 3.3V probe pin
     #if ENABLED(BLTOUCH_SET_5V_MODE)
-      #define _5V(A,B) !WITHIN(FT,A,B)
+      #define _5V(P,A,B) WITHIN(P,A,B)
       #ifdef STM32F1            // STM32F103 5V-tolerant pins
-        #define _NOT_5V_PIN(FT) (_5V(PA8, PA15) && _5V(PB2, PB15) && _5V(PC6, PC12) && _5V(PD0, PD15) && _5V(PE0, PE15) && _5V(PF0, PF5) && _5V(PF11, PF15))
+        #define _IS_5V_TOLERANT(P) (_5V(P,PA8,PA15) || _5V(P,PB2,PB15) || _5V(P,PC6,PC12) || _5V(P,PD0,PD15) || _5V(P,PE0,PE15) || _5V(P,PF0,PF5) || _5V(P,PF11,PF15))
+      #elif defined(ARDUINO_ARCH_SAM)
+        #define _IS_5V_TOLERANT(P) 0 // Assume no 5V tolerance
       #else
-        #define _NOT_5V_PIN(FT) 0 // No more known controllers
+        #define _IS_5V_TOLERANT(P) 1 // Assume 5V tolerance
       #endif
-      #if USES_Z_MIN_PROBE_PIN && _NOT_5V_PIN(Z_MIN_PROBE_PIN)
+      #if USES_Z_MIN_PROBE_PIN && !_IS_5V_TOLERANT(Z_MIN_PROBE_PIN)
         #error "BLTOUCH_SET_5V_MODE is not compatible with the Z_MIN_PROBE_PIN."
-      #elif _NOT_5V_PIN(Z_MIN_PIN)
+      #elif !_IS_5V_TOLERANT(Z_MIN_PIN)
         #error "BLTOUCH_SET_5V_MODE is not compatible with the Z_MIN_PIN."
       #endif
-      #undef _NOT_5V_PIN
+      #undef _IS_5V_TOLERANT
       #undef _5V
+    #elif NONE(ONBOARD_ENDSTOPPULLUPS, ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN, ENDSTOPPULLUP_ZMIN_PROBE)
+      #if USES_Z_MIN_PROBE_PIN
+        #error "BLTOUCH on Z_MIN_PROBE_PIN requires ENDSTOPPULLUP_ZMIN_PROBE, ENDSTOPPULLUPS, or BLTOUCH_SET_5V_MODE."
+      #else
+        #error "BLTOUCH on Z_MIN_PIN requires ENDSTOPPULLUP_ZMIN, ENDSTOPPULLUPS, or BLTOUCH_SET_5V_MODE."
+      #endif
     #endif
-
-    #undef _DO_FT_CHECK
 
     #if BLTOUCH_DELAY < 200
       #error "BLTOUCH_DELAY less than 200 is unsafe and is not supported."
-    #elif DISABLED(BLTOUCH_SET_5V_MODE) && NONE(ONBOARD_ENDSTOPPULLUPS, ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN, ENDSTOPPULLUP_ZMIN_PROBE)
-      #error "BLTOUCH without BLTOUCH_SET_5V_MODE requires ENDSTOPPULLUPS, ENDSTOPPULLUP_ZMIN or ENDSTOPPULLUP_ZMIN_PROBE."
     #endif
   #endif
 


### PR DESCRIPTION
### Description

After recently finding Configs in the wild that had BLTOUCH_SET_5V_MODE enabled but the BLTOUCH input pin was not 5 volt tolerant, I've added a sanity check for STM32F103 that check the defined pin is 5volt tolerant, #error is given when this is found not to be the case.

There are probably other 3.3v platforms that should have this added. The code is written with this in mind, so looks a little redundant in parts. 

### Requirements

STM32F103 based controller
BLTOUCH
BLTOUCH_SET_5V_MODE

### Benefits

Wont allow BLTOUCH_SET_5V_MODE where the pin is not 5v tolerant

### Related Issues
https://github.com/MarlinFirmware/Configurations/issues/575