### PR TITLE
TFT: backlight PWM/brightness

### DIFF
--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -338,6 +338,13 @@ void MarlinUI::draw_kill_screen() {
 
 void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
+#if HAS_LCD_BRIGHTNESS
+  void MarlinUI::_set_brightness() {
+    if (PWM_PIN(TFT_BACKLIGHT_PIN))
+      analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+  }
+#endif
+
 #if HAS_LCD_MENU
 
   #include "../menu/menu.h"

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -340,8 +340,10 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
 #if HAS_LCD_BRIGHTNESS
   void MarlinUI::_set_brightness() {
-    if (PWM_PIN(TFT_BACKLIGHT_PIN))
-      analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+    #if PIN_EXISTS(TFT_BACKLIGHT)
+      if (PWM_PIN(TFT_BACKLIGHT_PIN))
+        analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+    #endif
   }
 #endif
 

--- a/Marlin/src/lcd/language/language_fr.h
+++ b/Marlin/src/lcd/language/language_fr.h
@@ -336,6 +336,7 @@ namespace Language_fr {
   LSTR MSG_FILAMENT_LOAD                  = _UxGT("Charger mm");
   LSTR MSG_ADVANCE_K                      = _UxGT("Avance K");
   LSTR MSG_ADVANCE_K_E                    = _UxGT("Avance K *");
+  LSTR MSG_BRIGHTNESS                     = _UxGT("Luminosité LCD");
   LSTR MSG_CONTRAST                       = _UxGT("Contraste LCD");
   LSTR MSG_STORE_EEPROM                   = _UxGT("Enregistrer config.");
   LSTR MSG_LOAD_EEPROM                    = _UxGT("Charger config.");

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -294,7 +294,9 @@ bool Touch::get_point(int16_t *x, int16_t *y) {
   }
   void Touch::wakeUp() {
     if (isSleeping()) {
-      #if PIN_EXISTS(TFT_BACKLIGHT)
+      #if HAS_LCD_BRIGHTNESS
+        ui._set_brightness();
+      #elif PIN_EXISTS(TFT_BACKLIGHT)
         WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif
     }

--- a/Marlin/src/lcd/tft/ui_common.cpp
+++ b/Marlin/src/lcd/tft/ui_common.cpp
@@ -210,6 +210,15 @@ void MarlinUI::clear_lcd() {
   cursor.set(0, 0);
 }
 
+#if HAS_LCD_BRIGHTNESS
+  void MarlinUI::_set_brightness() {
+    #if PIN_EXISTS(TFT_BACKLIGHT)
+      if (PWM_PIN(TFT_BACKLIGHT_PIN))
+        analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+    #endif
+  }
+#endif
+
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
 
   void MarlinUI::touch_calibration_screen() {
@@ -263,12 +272,5 @@ void MarlinUI::clear_lcd() {
   }
 
 #endif // TOUCH_SCREEN_CALIBRATION
-
-#if HAS_LCD_BRIGHTNESS
-  void MarlinUI::_set_brightness() {
-    if (PWM_PIN(TFT_BACKLIGHT_PIN))
-      analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
-  }
-#endif
 
 #endif // HAS_GRAPHICAL_TFT

--- a/Marlin/src/lcd/tft/ui_common.cpp
+++ b/Marlin/src/lcd/tft/ui_common.cpp
@@ -264,4 +264,11 @@ void MarlinUI::clear_lcd() {
 
 #endif // TOUCH_SCREEN_CALIBRATION
 
+#if HAS_LCD_BRIGHTNESS
+  void MarlinUI::_set_brightness() {
+    if (PWM_PIN(TFT_BACKLIGHT_PIN))
+      analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+  }
+#endif
+
 #endif // HAS_GRAPHICAL_TFT

--- a/Marlin/src/lcd/tft_io/tft_io.cpp
+++ b/Marlin/src/lcd/tft_io/tft_io.cpp
@@ -49,6 +49,8 @@
 #include "ili9341.h"
 #include "ili9328.h"
 
+#include "../marlinui.h"
+
 #define DEBUG_OUT ENABLED(DEBUG_GRAPHICAL_TFT)
 #include "../../core/debug_out.h"
 
@@ -72,6 +74,9 @@ if (lcd_id != 0xFFFFFFFF) return;
 
   #if PIN_EXISTS(TFT_BACKLIGHT)
     WRITE(TFT_BACKLIGHT_PIN, DISABLED(DELAYED_BACKLIGHT_INIT));
+    #if HAS_LCD_BRIGHTNESS && DISABLED(DELAYED_BACKLIGHT_INIT)
+      ui._set_brightness();
+    #endif
   #endif
 
   // io.Init();
@@ -146,6 +151,9 @@ if (lcd_id != 0xFFFFFFFF) return;
 
   #if PIN_EXISTS(TFT_BACKLIGHT) && ENABLED(DELAYED_BACKLIGHT_INIT)
     WRITE(TFT_BACKLIGHT_PIN, HIGH);
+    #if HAS_LCD_BRIGHTNESS
+      ui._set_brightness();
+    #endif
   #endif
 }
 

--- a/Marlin/src/lcd/tft_io/tft_io.cpp
+++ b/Marlin/src/lcd/tft_io/tft_io.cpp
@@ -49,7 +49,9 @@
 #include "ili9341.h"
 #include "ili9328.h"
 
-#include "../marlinui.h"
+#if HAS_LCD_BRIGHTNESS
+  #include "../marlinui.h"
+#endif
 
 #define DEBUG_OUT ENABLED(DEBUG_GRAPHICAL_TFT)
 #include "../../core/debug_out.h"
@@ -146,14 +148,12 @@ if (lcd_id != 0xFFFFFFFF) return;
         lcd_id = 0;
     }
   #else
-    #error Unsupported TFT driver
+    #error "Unsupported TFT driver"
   #endif
 
   #if PIN_EXISTS(TFT_BACKLIGHT) && ENABLED(DELAYED_BACKLIGHT_INIT)
     WRITE(TFT_BACKLIGHT_PIN, HIGH);
-    #if HAS_LCD_BRIGHTNESS
-      ui._set_brightness();
-    #endif
+    TERN_(HAS_LCD_BRIGHTNESS, ui._set_brightness());
   #endif
 }
 

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -122,7 +122,9 @@ uint8_t TouchButtons::read_buttons() {
   }
   void TouchButtons::wakeUp() {
     if (isSleeping()) {
-      #if PIN_EXISTS(TFT_BACKLIGHT)
+      #if HAS_LCD_BRIGHTNESS
+        ui._set_brightness();
+      #elif PIN_EXISTS(TFT_BACKLIGHT)
         WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif
     }

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -135,12 +135,18 @@
 
   #define TFT_RESET_PIN                     PC4   // pin 33
   #define TFT_BACKLIGHT_PIN                 PD12  // pin 59
+  #define TFT_BACKLIGHT_PWM                 150   // Brightness with alt. TIM4 chan 1 (1-255)
 
   #define DOGLCD_MOSI                       -1    // Prevent auto-define by Conditionals_post.h
   #define DOGLCD_SCK                        -1
 
   // Buffer for Color UI
   #define TFT_BUFFER_SIZE                   3200
+#endif
+
+#if defined(TFT_BACKLIGHT_PWM) && !defined(MAPLE_STM32F1)
+  #define HAS_LCD_BRIGHTNESS 1
+  #define DEFAULT_LCD_BRIGHTNESS TFT_BACKLIGHT_PWM
 #endif
 
 #if ENABLED(SDIO_SUPPORT)


### PR DESCRIPTION
Note for the Longer3D LK Board :
 Libmaple generic board variant is not compatible, timer4 alt function is not set
 and afio_remap(AFIO_REMAP_TIM4) may brick the stlink upload ability

Tested ok on CLASSIC_UI & COLOR_UI, allow M256 B[1-255] and add the LCD brightness in config menu.

To note B0 seems ignored and doesn't turn off the backlight..

```
M256 B100
16:05:29.943 > ok
M256
16:05:33.551 >   M256 B100
16:05:33.552 > ok
M256 B0
16:05:36.012 > ok
M256
16:05:38.504 >   M256 B100
16:05:38.504 > ok
```
