### PR TITLE
MKS UI LVGL bed preheat presets

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -128,8 +128,6 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       else if (uiCfg.curTempType == 1) {
         uiCfg.extruderIndex = 0;
         uiCfg.curTempType = 0;
-//        disp_add_dec();
-//        disp_ext_heart();
       }
       disp_temp_type();
       break;

--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -192,6 +192,7 @@ void lv_draw_preHeat() {
   buttonStep = lv_imgbtn_create(scr, nullptr, BTN_X_PIXEL + INTERVAL_V * 2, BTN_Y_PIXEL + INTERVAL_H + titleHeight, event_handler, ID_P_STEP);
 
   if (uiCfg.curTempType == 0) disp_ext_heart();
+  if (uiCfg.curTempType == 1) disp_ext_heart();
 
   #if HAS_ROTARY_ENCODER
     if (gCfgItems.encoder_enable) {

--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -128,8 +128,8 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       else if (uiCfg.curTempType == 1) {
         uiCfg.extruderIndex = 0;
         uiCfg.curTempType = 0;
-        disp_add_dec();
-        disp_ext_heart();
+//        disp_add_dec();
+//        disp_ext_heart();
       }
       disp_temp_type();
       break;
@@ -160,10 +160,20 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       draw_return_ui();
       break;
     case ID_P_ABS:
+    if (uiCfg.curTempType == 0) {
       thermalManager.setTargetHotend(PREHEAT_2_TEMP_HOTEND, 0);
+      }
+      else if (uiCfg.curTempType == 1) {
+        thermalManager.setTargetBed(PREHEAT_2_TEMP_BED);
+      }
       break;
     case ID_P_PLA:
+    if (uiCfg.curTempType == 0) {
       thermalManager.setTargetHotend(PREHEAT_1_TEMP_HOTEND, 0);
+      }
+      else if (uiCfg.curTempType == 1) {
+        thermalManager.setTargetBed(PREHEAT_1_TEMP_BED);
+      }
       break;
   }
 }


### PR DESCRIPTION
### Description

Recently, presets have been added to the preheat menu in the msui lvgl interface, which are defined in the configuration.h file (only extruder).
This merge request adds a temperature preset to the preheat menu for the bed.

```
#define PREHEAT_1_LABEL       "PLA"
#define PREHEAT_1_TEMP_HOTEND 180
#define PREHEAT_1_TEMP_BED     70

#define PREHEAT_2_LABEL       "ABS"
#define PREHEAT_2_TEMP_HOTEND 240
#define PREHEAT_2_TEMP_BED    110
```

### Benefits

preset for bed in preheat menu for pla/abs
see demo video:
https://disk.yandex.ru/i/Dz8_3Y6BKsMppg

