### PR TITLE
Adds a Mesh Viewer to the DWIN Enhanced version

### DIFF
--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -78,7 +78,7 @@
   #include "../../../feature/powerloss.h"
 #endif
 
-#if HAS_LEVELING
+#if HAS_MESH
   #include "meshviewer.h"
 #endif
 
@@ -3201,7 +3201,7 @@ void Draw_AdvancedSettings_Menu() {
       ADDMENUITEM(ICON_Sound, F("Enable Sound"), onDrawEnableSound, SetEnableSound);
     #endif
     #if HAS_MESH
-      ADDMENUITEM(ICON_MeshViewer, F("Mesh Viewer"), onDrawSubMenu, DWIN_MeshViewer);
+      ADDMENUITEM(ICON_MeshViewer, F("View Mesh"), onDrawSubMenu, DWIN_MeshViewer);
     #endif
     ADDMENUITEM(ICON_Lock, F("Lock Screen"), onDrawMenuItem, Goto_LockScreen);
   }
@@ -3421,7 +3421,7 @@ void Draw_Motion_Menu() {
       ADDMENUITEM(ICON_ManualMesh, GET_TEXT_F(MSG_LEVEL_BED), onDrawMenuItem, ManualMeshStart);
       MMeshMoveZItem = ADDMENUITEM_P(ICON_Zoffset, GET_TEXT_F(MSG_MOVE_Z), onDrawMMeshMoveZ, SetMMeshMoveZ, &current_position.z);
       ADDMENUITEM(ICON_Axis, GET_TEXT_F(MSG_UBL_CONTINUE_MESH), onDrawMenuItem, ManualMeshContinue);
-      ADDMENUITEM(ICON_MeshViewer, F("Mesh Viewer"), onDrawSubMenu, DWIN_MeshViewer);
+      ADDMENUITEM(ICON_MeshViewer, F("View Mesh"), onDrawSubMenu, DWIN_MeshViewer);
       ADDMENUITEM(ICON_MeshSave, GET_TEXT_F(MSG_UBL_SAVE_MESH), onDrawMenuItem, ManualMeshSave);
     }
     CurrentMenu->draw();

--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -3201,7 +3201,7 @@ void Draw_AdvancedSettings_Menu() {
       ADDMENUITEM(ICON_Sound, F("Enable Sound"), onDrawEnableSound, SetEnableSound);
     #endif
     #if HAS_MESH
-      ADDMENUITEM(ICON_MeshViewer, F("View Mesh"), onDrawSubMenu, DWIN_MeshViewer);
+      ADDMENUITEM(ICON_MeshViewer, GET_TEXT_F(MSG_MESH_VIEW), onDrawSubMenu, DWIN_MeshViewer);
     #endif
     ADDMENUITEM(ICON_Lock, F("Lock Screen"), onDrawMenuItem, Goto_LockScreen);
   }
@@ -3421,7 +3421,7 @@ void Draw_Motion_Menu() {
       ADDMENUITEM(ICON_ManualMesh, GET_TEXT_F(MSG_LEVEL_BED), onDrawMenuItem, ManualMeshStart);
       MMeshMoveZItem = ADDMENUITEM_P(ICON_Zoffset, GET_TEXT_F(MSG_MOVE_Z), onDrawMMeshMoveZ, SetMMeshMoveZ, &current_position.z);
       ADDMENUITEM(ICON_Axis, GET_TEXT_F(MSG_UBL_CONTINUE_MESH), onDrawMenuItem, ManualMeshContinue);
-      ADDMENUITEM(ICON_MeshViewer, F("View Mesh"), onDrawSubMenu, DWIN_MeshViewer);
+      ADDMENUITEM(ICON_MeshViewer, GET_TEXT_F(MSG_MESH_VIEW), onDrawSubMenu, DWIN_MeshViewer);
       ADDMENUITEM(ICON_MeshSave, GET_TEXT_F(MSG_UBL_SAVE_MESH), onDrawMenuItem, ManualMeshSave);
     }
     CurrentMenu->draw();

--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -78,6 +78,10 @@
   #include "../../../feature/powerloss.h"
 #endif
 
+#if HAS_MESH
+  #include "meshviewer.h"
+#endif
+
 #include <WString.h>
 #include <stdio.h>
 #include <string.h>
@@ -1661,7 +1665,7 @@ void DWIN_MeshLevelingStart() {
   #endif
 }
 
-void DWIN_CompletedLeveling() { HMI_ReturnScreen(); }
+void DWIN_CompletedLeveling() { DWIN_MeshViewer(); }
 
 #if HAS_MESH
   void DWIN_MeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
@@ -1920,6 +1924,17 @@ void DWIN_Redraw_screen() {
   }
 
 #endif // ADVANCED_PAUSE_FEATURE
+
+#if HAS_MESH
+  void DWIN_MeshViewer() {
+    if (!leveling_is_valid()) {
+      DWIN_Popup_Continue(ICON_BLTouch, "Mesh viewer", "There isn't a valid mesh");
+    } else {
+      HMI_SaveProcessID(WaitResponse);
+      MeshViewer.Draw();
+    }
+  }
+#endif // HAS_MESH
 
 void HMI_LockScreen() {
   EncoderState encoder_diffState = get_encoder_state();
@@ -3185,6 +3200,9 @@ void Draw_AdvancedSettings_Menu() {
     #if ENABLED(SOUND_MENU_ITEM)
       ADDMENUITEM(ICON_Sound, F("Enable Sound"), onDrawEnableSound, SetEnableSound);
     #endif
+    #if HAS_MESH
+      ADDMENUITEM(ICON_MeshViewer, F("Mesh Viewer"), onDrawSubMenu, DWIN_MeshViewer);
+    #endif
     ADDMENUITEM(ICON_Lock, F("Lock Screen"), onDrawMenuItem, Goto_LockScreen);
   }
   CurrentMenu->draw();
@@ -3403,6 +3421,7 @@ void Draw_Motion_Menu() {
       ADDMENUITEM(ICON_ManualMesh, GET_TEXT_F(MSG_LEVEL_BED), onDrawMenuItem, ManualMeshStart);
       MMeshMoveZItem = ADDMENUITEM_P(ICON_Zoffset, GET_TEXT_F(MSG_MOVE_Z), onDrawMMeshMoveZ, SetMMeshMoveZ, &current_position.z);
       ADDMENUITEM(ICON_Axis, GET_TEXT_F(MSG_UBL_CONTINUE_MESH), onDrawMenuItem, ManualMeshContinue);
+      ADDMENUITEM(ICON_MeshViewer, F("Mesh Viewer"), onDrawSubMenu, DWIN_MeshViewer);
       ADDMENUITEM(ICON_MeshSave, GET_TEXT_F(MSG_UBL_SAVE_MESH), onDrawMenuItem, ManualMeshSave);
     }
     CurrentMenu->draw();

--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -78,7 +78,7 @@
   #include "../../../feature/powerloss.h"
 #endif
 
-#if HAS_MESH
+#if HAS_LEVELING
   #include "meshviewer.h"
 #endif
 
@@ -1925,7 +1925,7 @@ void DWIN_Redraw_screen() {
 
 #endif // ADVANCED_PAUSE_FEATURE
 
-#if HAS_MESH
+#if HAS_LEVELING
   void DWIN_MeshViewer() {
     if (!leveling_is_valid()) {
       DWIN_Popup_Continue(ICON_BLTouch, "Mesh viewer", "There isn't a valid mesh");
@@ -1934,7 +1934,7 @@ void DWIN_Redraw_screen() {
       MeshViewer.Draw();
     }
   }
-#endif // HAS_MESH
+#endif // HAS_LEVELING
 
 void HMI_LockScreen() {
   EncoderState encoder_diffState = get_encoder_state();
@@ -3200,7 +3200,7 @@ void Draw_AdvancedSettings_Menu() {
     #if ENABLED(SOUND_MENU_ITEM)
       ADDMENUITEM(ICON_Sound, F("Enable Sound"), onDrawEnableSound, SetEnableSound);
     #endif
-    #if HAS_MESH
+    #if HAS_LEVELING
       ADDMENUITEM(ICON_MeshViewer, F("Mesh Viewer"), onDrawSubMenu, DWIN_MeshViewer);
     #endif
     ADDMENUITEM(ICON_Lock, F("Lock Screen"), onDrawMenuItem, Goto_LockScreen);

--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -62,7 +62,7 @@
   #include "../../../feature/host_actions.h"
 #endif
 
-#if HAS_ONESTEP_LEVELING
+#if HAS_MESH || HAS_ONESTEP_LEVELING
   #include "../../../feature/bedlevel/bedlevel.h"
 #endif
 
@@ -1925,16 +1925,16 @@ void DWIN_Redraw_screen() {
 
 #endif // ADVANCED_PAUSE_FEATURE
 
-#if HAS_LEVELING
+#if HAS_MESH
   void DWIN_MeshViewer() {
-    if (!leveling_is_valid()) {
-      DWIN_Popup_Continue(ICON_BLTouch, "Mesh viewer", "There isn't a valid mesh");
-    } else {
+    if (!leveling_is_valid())
+      DWIN_Popup_Continue(ICON_BLTouch, "Mesh viewer", "No valid mesh");
+    else {
       HMI_SaveProcessID(WaitResponse);
       MeshViewer.Draw();
     }
   }
-#endif // HAS_LEVELING
+#endif
 
 void HMI_LockScreen() {
   EncoderState encoder_diffState = get_encoder_state();
@@ -3200,7 +3200,7 @@ void Draw_AdvancedSettings_Menu() {
     #if ENABLED(SOUND_MENU_ITEM)
       ADDMENUITEM(ICON_Sound, F("Enable Sound"), onDrawEnableSound, SetEnableSound);
     #endif
-    #if HAS_LEVELING
+    #if HAS_MESH
       ADDMENUITEM(ICON_MeshViewer, F("Mesh Viewer"), onDrawSubMenu, DWIN_MeshViewer);
     #endif
     ADDMENUITEM(ICON_Lock, F("Lock Screen"), onDrawMenuItem, Goto_LockScreen);

--- a/Marlin/src/lcd/e3v2/enhanced/dwin.h
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.h
@@ -222,6 +222,9 @@ void DWIN_RebootScreen();
 // Utility and extensions
 void HMI_LockScreen();
 void DWIN_LockScreen(const bool flag = true);
+#if HAS_MESH
+  void DWIN_MeshViewer();
+#endif
 
 // HMI user control functions
 void HMI_Menu();

--- a/Marlin/src/lcd/e3v2/enhanced/dwinui.h
+++ b/Marlin/src/lcd/e3v2/enhanced/dwinui.h
@@ -50,6 +50,7 @@
 #define ICON_ManualMesh           ICON_HotendTemp
 #define ICON_MeshNext             ICON_Axis
 #define ICON_MeshSave             ICON_WriteEEPROM
+#define ICON_MeshViewer           ICON_HotendTemp
 #define ICON_MoveZ0               ICON_HotendTemp
 #define ICON_Park                 ICON_Motion
 #define ICON_PIDcycles            ICON_ResumeEEPROM

--- a/Marlin/src/lcd/e3v2/enhanced/meshviewer.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/meshviewer.cpp
@@ -5,7 +5,7 @@
  * Date: 2021/09/27
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
+ * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
@@ -21,57 +21,55 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
-#if HAS_LEVELING
+#if BOTH(DWIN_CREALITY_LCD_ENHANCED, HAS_MESH)
+
+#include "meshviewer.h"
 
 #include "../../../core/types.h"
 #include "../../marlinui.h"
 #include "dwin_lcd.h"
 #include "dwinui.h"
 #include "dwin.h"
-#include "meshviewer.h"
 #include "../../../feature/bedlevel/bedlevel.h"
 
 MeshViewerClass MeshViewer;
 
 void MeshViewerClass::Draw() {
-  const int8_t mx = 30;  // Margins
-  const int8_t my = 30;
-  const int16_t stx = (DWIN_WIDTH - 2 * mx) / (GRID_MAX_POINTS_X - 1);  // Steps
-  const int16_t sty = (DWIN_WIDTH - 2 * my) / (GRID_MAX_POINTS_Y - 1);
-  int8_t zmesh[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
-  int8_t maxz =-127;
-  int8_t minz = 127;
-  #define px(xp) (mx + (xp)*stx)
-  #define py(yp) (30 + DWIN_WIDTH - my - (yp)*sty)
+  const int8_t mx = 30, my = 30;  // Margins
+  const int16_t stx = (DWIN_WIDTH - 2 * mx) / (GRID_MAX_POINTS_X - 1),  // Steps
+                sty = (DWIN_WIDTH - 2 * my) / (GRID_MAX_POINTS_Y - 1);
+  int8_t zmesh[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y], maxz =-127, minz = 127;
+  #define px(xp) (mx + (xp) * stx)
+  #define py(yp) (30 + DWIN_WIDTH - my - (yp) * sty)
   #define rm(z) ((((z) - minz) * 10 / _MAX(1, (maxz - minz))) + 10)
-  #define DrawMeshValue(xp, yp, zv)  DWINUI::Draw_Signed_Float(font6x12, 1, 2, px(xp) - 12, py(yp) - 6, zv);
+  #define DrawMeshValue(xp, yp, zv) DWINUI::Draw_Signed_Float(font6x12, 1, 2, px(xp) - 12, py(yp) - 6, zv)
   #define DrawMeshHLine(yp) DWIN_Draw_HLine(HMI_data.SplitLine_Color, px(0), py(yp), DWIN_WIDTH - 2 * mx)
   #define DrawMeshVLine(xp) DWIN_Draw_VLine(HMI_data.SplitLine_Color, px(xp), py(GRID_MAX_POINTS_Y - 1), DWIN_WIDTH - 2 * my)
-  for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
-    for (uint8_t y = 0; y < GRID_MAX_POINTS_X; y++) {
-      zmesh[x][y] = Z_VALUES(x,y) * 100;
-      maxz = _MAX(zmesh[x][y], maxz);
-      minz = _MIN(zmesh[x][y], minz);
-    }
+  GRID_LOOP(x, y) {
+    const float v = Z_VALUES(x,y) * 100;
+    zmesh[x][y] = v;
+    NOLESS(maxz, v);
+    NOMORE(minz, v);
   }
   Title.ShowCaption(F("Mesh viewer"));
   DWINUI::ClearMenuArea();
   DWINUI::Draw_Icon(ICON_Continue_E, 86, 305);
   DWIN_Draw_Rectangle(0, HMI_data.SplitLine_Color, px(0), py(0), px(GRID_MAX_POINTS_X - 1), py(GRID_MAX_POINTS_Y - 1));
-  for (uint8_t x = 1; x < GRID_MAX_POINTS_X - 1; x++) DrawMeshVLine(x);
-  for (uint8_t y = 1; y < GRID_MAX_POINTS_Y - 1; y++) DrawMeshHLine(y);
-  for (uint8_t y = 0; y < GRID_MAX_POINTS_X; y++) {
+  LOOP_S_L_N(x, 1, GRID_MAX_POINTS_X - 1) DrawMeshVLine(x);
+  LOOP_S_L_N(y, 1, GRID_MAX_POINTS_Y - 1) DrawMeshHLine(y);
+  LOOP_L_N(y, GRID_MAX_POINTS_Y) {
     watchdog_refresh();
-    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
+    LOOP_L_N(x, GRID_MAX_POINTS_X) {
       uint16_t color = DWINUI::RainbowInt(zmesh[x][y], _MIN(-5, minz), _MAX(5, maxz));
       DWINUI::Draw_FillCircle(color, px(x), py(y), rm(zmesh[x][y]));
       DrawMeshValue(x, y, Z_VALUES(x,y));
     }
   }
   char str_1[6], str_2[6] = "";
-  ui.status_printf_P(0,PSTR("Mesh minZ: %s, maxZ: %s"),
-    dtostrf((float)minz/100, 1, 2, str_1),
-    dtostrf((float)maxz/100, 1, 2, str_2));
+  ui.status_printf_P(0, PSTR("Mesh minZ: %s, maxZ: %s"),
+    dtostrf((float)minz / 100, 1, 2, str_1),
+    dtostrf((float)maxz / 100, 1, 2, str_2)
+  );
 }
 
-#endif // HAS_LEVELING
+#endif // DWIN_CREALITY_LCD_ENHANCED && HAS_MESH

--- a/Marlin/src/lcd/e3v2/enhanced/meshviewer.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/meshviewer.cpp
@@ -1,8 +1,8 @@
 /**
  * DWIN Mesh Viewer
  * Author: Miguel A. Risco-Castillo
- * version: 2.4
- * Date: 2021/09/08
+ * version: 2.5
+ * Date: 2021/09/27
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as 
@@ -20,59 +20,58 @@
  */
 
 #include "../../../inc/MarlinConfigPre.h"
+
+#if HAS_LEVELING
+
 #include "../../../core/types.h"
 #include "../../marlinui.h"
 #include "dwin_lcd.h"
 #include "dwinui.h"
 #include "dwin.h"
 #include "meshviewer.h"
-
-#if HAS_LEVELING
-  #include "../../../feature/bedlevel/bedlevel.h"
-#endif
+#include "../../../feature/bedlevel/bedlevel.h"
 
 MeshViewerClass MeshViewer;
 
-#if HAS_MESH
-  void MeshViewerClass::Draw() {
-    const int8_t mx = 30;  // Margins
-    const int8_t my = 30;
-    const int16_t stx = (DWIN_WIDTH - 2 * mx) / (GRID_MAX_POINTS_X - 1);  // Steps
-    const int16_t sty = (DWIN_WIDTH - 2 * my) / (GRID_MAX_POINTS_Y - 1);
-    int8_t zmesh[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
-    int8_t maxz =-127;
-    int8_t minz = 127;
-    #define px(xp) (mx + (xp)*stx)
-    #define py(yp) (30 + DWIN_WIDTH - my - (yp)*sty)
-    #define rm(z) ((((z) - minz) * 10 / _MAX(1, (maxz - minz))) + 10)
-    #define DrawMeshValue(xp, yp, zv)  DWINUI::Draw_Signed_Float(font6x12, 1, 2, px(xp) - 12, py(yp) - 6, zv);
-    #define DrawMeshHLine(yp) DWIN_Draw_HLine(HMI_data.SplitLine_Color, px(0), py(yp), DWIN_WIDTH - 2 * mx)
-    #define DrawMeshVLine(xp) DWIN_Draw_VLine(HMI_data.SplitLine_Color, px(xp), py(GRID_MAX_POINTS_Y - 1), DWIN_WIDTH - 2 * my)
-    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
-      for (uint8_t y = 0; y < GRID_MAX_POINTS_X; y++) {
-        zmesh[x][y] = Z_VALUES(x,y) * 100;
-        maxz = _MAX(zmesh[x][y], maxz);
-        minz = _MIN(zmesh[x][y], minz);
-      }
-    }
-    Title.ShowCaption(F("Mesh viewer"));
-    DWINUI::ClearMenuArea();
-    DWINUI::Draw_Icon(ICON_Continue_E, 86, 305);
-    DWIN_Draw_Rectangle(0, HMI_data.SplitLine_Color, px(0), py(0), px(GRID_MAX_POINTS_X - 1), py(GRID_MAX_POINTS_Y - 1));
-    for (uint8_t x = 1; x < GRID_MAX_POINTS_X - 1; x++) DrawMeshVLine(x);
-    for (uint8_t y = 1; y < GRID_MAX_POINTS_Y - 1; y++) DrawMeshHLine(y);
+void MeshViewerClass::Draw() {
+  const int8_t mx = 30;  // Margins
+  const int8_t my = 30;
+  const int16_t stx = (DWIN_WIDTH - 2 * mx) / (GRID_MAX_POINTS_X - 1);  // Steps
+  const int16_t sty = (DWIN_WIDTH - 2 * my) / (GRID_MAX_POINTS_Y - 1);
+  int8_t zmesh[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
+  int8_t maxz =-127;
+  int8_t minz = 127;
+  #define px(xp) (mx + (xp)*stx)
+  #define py(yp) (30 + DWIN_WIDTH - my - (yp)*sty)
+  #define rm(z) ((((z) - minz) * 10 / _MAX(1, (maxz - minz))) + 10)
+  #define DrawMeshValue(xp, yp, zv)  DWINUI::Draw_Signed_Float(font6x12, 1, 2, px(xp) - 12, py(yp) - 6, zv);
+  #define DrawMeshHLine(yp) DWIN_Draw_HLine(HMI_data.SplitLine_Color, px(0), py(yp), DWIN_WIDTH - 2 * mx)
+  #define DrawMeshVLine(xp) DWIN_Draw_VLine(HMI_data.SplitLine_Color, px(xp), py(GRID_MAX_POINTS_Y - 1), DWIN_WIDTH - 2 * my)
+  for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
     for (uint8_t y = 0; y < GRID_MAX_POINTS_X; y++) {
-      watchdog_refresh();
-      for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
-        uint16_t color = DWINUI::RainbowInt(zmesh[x][y], _MIN(-5, minz), _MAX(5, maxz));
-        DWINUI::Draw_FillCircle(color, px(x), py(y), rm(zmesh[x][y]));
-        DrawMeshValue(x, y, Z_VALUES(x,y));
-      }
+      zmesh[x][y] = Z_VALUES(x,y) * 100;
+      maxz = _MAX(zmesh[x][y], maxz);
+      minz = _MIN(zmesh[x][y], minz);
     }
-    char str_1[6], str_2[6] = "";
-    ui.status_printf_P(0,PSTR("Mesh minZ: %s, maxZ: %s"),
-      dtostrf((float)minz/100, 1, 2, str_1),
-      dtostrf((float)maxz/100, 1, 2, str_2));
   }
+  Title.ShowCaption(F("Mesh viewer"));
+  DWINUI::ClearMenuArea();
+  DWINUI::Draw_Icon(ICON_Continue_E, 86, 305);
+  DWIN_Draw_Rectangle(0, HMI_data.SplitLine_Color, px(0), py(0), px(GRID_MAX_POINTS_X - 1), py(GRID_MAX_POINTS_Y - 1));
+  for (uint8_t x = 1; x < GRID_MAX_POINTS_X - 1; x++) DrawMeshVLine(x);
+  for (uint8_t y = 1; y < GRID_MAX_POINTS_Y - 1; y++) DrawMeshHLine(y);
+  for (uint8_t y = 0; y < GRID_MAX_POINTS_X; y++) {
+    watchdog_refresh();
+    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
+      uint16_t color = DWINUI::RainbowInt(zmesh[x][y], _MIN(-5, minz), _MAX(5, maxz));
+      DWINUI::Draw_FillCircle(color, px(x), py(y), rm(zmesh[x][y]));
+      DrawMeshValue(x, y, Z_VALUES(x,y));
+    }
+  }
+  char str_1[6], str_2[6] = "";
+  ui.status_printf_P(0,PSTR("Mesh minZ: %s, maxZ: %s"),
+    dtostrf((float)minz/100, 1, 2, str_1),
+    dtostrf((float)maxz/100, 1, 2, str_2));
+}
 
-#endif // HAS_MESH
+#endif // HAS_LEVELING

--- a/Marlin/src/lcd/e3v2/enhanced/meshviewer.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/meshviewer.cpp
@@ -1,0 +1,78 @@
+/**
+ * DWIN Mesh Viewer
+ * Author: Miguel A. Risco-Castillo
+ * version: 2.4
+ * Date: 2021/09/08
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfigPre.h"
+#include "../../../core/types.h"
+#include "../../marlinui.h"
+#include "dwin_lcd.h"
+#include "dwinui.h"
+#include "dwin.h"
+#include "meshviewer.h"
+
+#if HAS_LEVELING
+  #include "../../../feature/bedlevel/bedlevel.h"
+#endif
+
+MeshViewerClass MeshViewer;
+
+#if HAS_MESH
+  void MeshViewerClass::Draw() {
+    const int8_t mx = 30;  // Margins
+    const int8_t my = 30;
+    const int16_t stx = (DWIN_WIDTH - 2 * mx) / (GRID_MAX_POINTS_X - 1);  // Steps
+    const int16_t sty = (DWIN_WIDTH - 2 * my) / (GRID_MAX_POINTS_Y - 1);
+    int8_t zmesh[GRID_MAX_POINTS_X][GRID_MAX_POINTS_Y];
+    int8_t maxz =-127;
+    int8_t minz = 127;
+    #define px(xp) (mx + (xp)*stx)
+    #define py(yp) (30 + DWIN_WIDTH - my - (yp)*sty)
+    #define rm(z) ((((z) - minz) * 10 / _MAX(1, (maxz - minz))) + 10)
+    #define DrawMeshValue(xp, yp, zv)  DWINUI::Draw_Signed_Float(font6x12, 1, 2, px(xp) - 12, py(yp) - 6, zv);
+    #define DrawMeshHLine(yp) DWIN_Draw_HLine(HMI_data.SplitLine_Color, px(0), py(yp), DWIN_WIDTH - 2 * mx)
+    #define DrawMeshVLine(xp) DWIN_Draw_VLine(HMI_data.SplitLine_Color, px(xp), py(GRID_MAX_POINTS_Y - 1), DWIN_WIDTH - 2 * my)
+    for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
+      for (uint8_t y = 0; y < GRID_MAX_POINTS_X; y++) {
+        zmesh[x][y] = Z_VALUES(x,y) * 100;
+        maxz = _MAX(zmesh[x][y], maxz);
+        minz = _MIN(zmesh[x][y], minz);
+      }
+    }
+    Title.ShowCaption(F("Mesh viewer"));
+    DWINUI::ClearMenuArea();
+    DWINUI::Draw_Icon(ICON_Continue_E, 86, 305);
+    DWIN_Draw_Rectangle(0, HMI_data.SplitLine_Color, px(0), py(0), px(GRID_MAX_POINTS_X - 1), py(GRID_MAX_POINTS_Y - 1));
+    for (uint8_t x = 1; x < GRID_MAX_POINTS_X - 1; x++) DrawMeshVLine(x);
+    for (uint8_t y = 1; y < GRID_MAX_POINTS_Y - 1; y++) DrawMeshHLine(y);
+    for (uint8_t y = 0; y < GRID_MAX_POINTS_X; y++) {
+      watchdog_refresh();
+      for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++) {
+        uint16_t color = DWINUI::RainbowInt(zmesh[x][y], _MIN(-5, minz), _MAX(5, maxz));
+        DWINUI::Draw_FillCircle(color, px(x), py(y), rm(zmesh[x][y]));
+        DrawMeshValue(x, y, Z_VALUES(x,y));
+      }
+    }
+    char str_1[6], str_2[6] = "";
+    ui.status_printf_P(0,PSTR("Mesh minZ: %s, maxZ: %s"),
+      dtostrf((float)minz/100, 1, 2, str_1),
+      dtostrf((float)maxz/100, 1, 2, str_2));
+  }
+
+#endif // HAS_MESH

--- a/Marlin/src/lcd/e3v2/enhanced/meshviewer.h
+++ b/Marlin/src/lcd/e3v2/enhanced/meshviewer.h
@@ -5,7 +5,7 @@
  * Date: 2021/09/27
  *
  * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as 
+ * it under the terms of the GNU Lesser General Public License as
  * published by the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
  *
@@ -18,7 +18,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  *
  */
-
 #pragma once
 
 class MeshViewerClass {
@@ -27,4 +26,3 @@ public:
 };
 
 extern MeshViewerClass MeshViewer;
-

--- a/Marlin/src/lcd/e3v2/enhanced/meshviewer.h
+++ b/Marlin/src/lcd/e3v2/enhanced/meshviewer.h
@@ -1,0 +1,30 @@
+/**
+ * DWIN Mesh Viewer
+ * Author: Miguel A. Risco-Castillo
+ * version: 2.3
+ * Date: 2021/07/12
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as 
+ * published by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+class MeshViewerClass {
+public:
+  void Draw();
+};
+
+extern MeshViewerClass MeshViewer;
+

--- a/Marlin/src/lcd/e3v2/enhanced/meshviewer.h
+++ b/Marlin/src/lcd/e3v2/enhanced/meshviewer.h
@@ -1,8 +1,8 @@
 /**
  * DWIN Mesh Viewer
  * Author: Miguel A. Risco-Castillo
- * version: 2.3
- * Date: 2021/07/12
+ * version: 2.5
+ * Date: 2021/09/27
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as 

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -3246,7 +3246,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW:
             if (draw)
-              Draw_Menu_Item(row, ICON_Mesh, "View Mesh", nullptr, true);
+              Draw_Menu_Item(row, ICON_Mesh, GET_TEXT_F(MSG_MESH_VIEW), nullptr, true);
             else {
               #if ENABLED(AUTO_BED_LEVELING_UBL)
                 if (ubl.storage_slot < 0) {
@@ -3319,7 +3319,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW_MESH:
             if (draw)
-              Draw_Menu_Item(row, ICON_PrintSize, "View Mesh", nullptr, true);
+              Draw_Menu_Item(row, ICON_PrintSize, GET_TEXT_F(MSG_MESH_VIEW), nullptr, true);
             else
               Draw_Menu(MeshViewer);
             break;
@@ -4070,9 +4070,9 @@ const char * CrealityDWINClass::Get_Menu_Title(uint8_t menu) {
     case InfoMain:          return "Info";
     #if HAS_MESH
       case Leveling:        return "Leveling";
-      case LevelView:       return "Mesh View";
+      case LevelView:       return GET_TEXT_F(MSG_MESH_VIEW);
       case LevelSettings:   return "Leveling Settings";
-      case MeshViewer:      return "View Mesh";
+      case MeshViewer:      return GET_TEXT_F(MSG_MESH_VIEW);
       case LevelManual:     return "Manual Tuning";
     #endif
     #if ENABLED(AUTO_BED_LEVELING_UBL) && !HAS_BED_PROBE

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -3246,7 +3246,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW:
             if (draw)
-              Draw_Menu_Item(row, ICON_Mesh, "Mesh Viewer", nullptr, true);
+              Draw_Menu_Item(row, ICON_Mesh, "View Mesh", nullptr, true);
             else {
               #if ENABLED(AUTO_BED_LEVELING_UBL)
                 if (ubl.storage_slot < 0) {
@@ -3319,7 +3319,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW_MESH:
             if (draw)
-              Draw_Menu_Item(row, ICON_PrintSize, "Mesh Viewer", nullptr, true);
+              Draw_Menu_Item(row, ICON_PrintSize, "View Mesh", nullptr, true);
             else
               Draw_Menu(MeshViewer);
             break;
@@ -4072,7 +4072,7 @@ const char * CrealityDWINClass::Get_Menu_Title(uint8_t menu) {
       case Leveling:        return "Leveling";
       case LevelView:       return "Mesh View";
       case LevelSettings:   return "Leveling Settings";
-      case MeshViewer:      return "Mesh Viewer";
+      case MeshViewer:      return "View Mesh";
       case LevelManual:     return "Manual Tuning";
     #endif
     #if ENABLED(AUTO_BED_LEVELING_UBL) && !HAS_BED_PROBE

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/cocoa_press/leveling_menu.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/cocoa_press/leveling_menu.cpp
@@ -61,7 +61,7 @@ void LevelingMenu::onRedraw(draw_mode_t what) {
        .font(font_medium).colors(normal_btn)
        .tag(2).button(PROBE_BED_POS, GET_TEXT_F(MSG_PROBE_BED))
        .enabled(ENABLED(HAS_MESH))
-       .tag(3).button(SHOW_MESH_POS, GET_TEXT_F(MSG_SHOW_MESH))
+       .tag(3).button(SHOW_MESH_POS, GET_TEXT_F(MSG_MESH_VIEW))
        .enabled(ENABLED(HAS_MESH))
        .tag(4).button(EDIT_MESH_POS, GET_TEXT_F(MSG_EDIT_MESH))
        #undef  GRID_COLS

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/leveling_menu.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/generic/leveling_menu.cpp
@@ -86,7 +86,7 @@ void LevelingMenu::onRedraw(draw_mode_t what) {
        .enabled(ENABLED(HAS_BED_PROBE))
        .tag(3).button(PROBE_BED_POS, GET_TEXT_F(MSG_PROBE_BED))
        .enabled(ENABLED(HAS_MESH))
-       .tag(4).button(SHOW_MESH_POS, GET_TEXT_F(MSG_SHOW_MESH))
+       .tag(4).button(SHOW_MESH_POS, GET_TEXT_F(MSG_MESH_VIEW))
        .enabled(ENABLED(HAS_MESH))
        .tag(5).button(EDIT_MESH_POS, GET_TEXT_F(MSG_EDIT_MESH))
        .enabled(ENABLED(G26_MESH_VALIDATION))

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language_en.h
@@ -145,7 +145,7 @@ namespace Language_en {
   PROGMEM Language_Str MSG_LEVELING                 = u8"Leveling";
   PROGMEM Language_Str MSG_AXIS_LEVELING            = u8"Axis Leveling";
   PROGMEM Language_Str MSG_PROBE_BED                = u8"Probe Mesh";
-  PROGMEM Language_Str MSG_SHOW_MESH                = u8"View Mesh";
+  PROGMEM Language_Str MSG_MESH_VIEW                = u8"View Mesh";
   PROGMEM Language_Str MSG_PRINT_TEST               = u8"Print Test (PLA)";
   PROGMEM Language_Str MSG_MOVE_Z_TO_TOP            = u8"Raise Z to Top";
 

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -157,6 +157,7 @@ namespace Language_en {
   LSTR MSG_NEXT_CORNER                    = _UxGT("Next Corner");
   LSTR MSG_MESH_EDITOR                    = _UxGT("Mesh Editor");
   LSTR MSG_EDIT_MESH                      = _UxGT("Edit Mesh");
+  LSTR MSG_MESH_VIEW                      = _UxGT("View Mesh");
   LSTR MSG_EDITING_STOPPED                = _UxGT("Mesh Editing Stopped");
   LSTR MSG_PROBING_POINT                  = _UxGT("Probing Point");
   LSTR MSG_MESH_X                         = _UxGT("Index X");


### PR DESCRIPTION
### Description

Adds a Mesh Viewer to the DWIN Enhanced version

### Requirements

Printer with DWIN Screen and Mesh support

### Benefits

Allows to see a mesh graphically  

![Mesh-Viewer](https://user-images.githubusercontent.com/2745567/134844240-31ba8520-dd71-4fe0-9094-a03eff6264de.jpg)


