### PR TITLE
Fix preheat screen, mksui lvgl interface

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -158,20 +158,16 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       draw_return_ui();
       break;
     case ID_P_ABS:
-      if (uiCfg.curTempType == 0) {
+      if (uiCfg.curTempType == 0)
         thermalManager.setTargetHotend(PREHEAT_2_TEMP_HOTEND, 0);
-      }
-      else if (uiCfg.curTempType == 1) {
+      else if (uiCfg.curTempType == 1)
         thermalManager.setTargetBed(PREHEAT_2_TEMP_BED);
-      }
       break;
     case ID_P_PLA:
-      if (uiCfg.curTempType == 0) {
+      if (uiCfg.curTempType == 0)
         thermalManager.setTargetHotend(PREHEAT_1_TEMP_HOTEND, 0);
-      }
-      else if (uiCfg.curTempType == 1) {
+      else if (uiCfg.curTempType == 1)
         thermalManager.setTargetBed(PREHEAT_1_TEMP_BED);
-      }
       break;
   }
 }

--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -124,17 +124,25 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
         else if (uiCfg.extruderIndex == 0) {
           uiCfg.curTempType = TERN(HAS_HEATED_BED, 1, 0);
         }
-        lv_obj_del(btn_pla);
-        lv_obj_del(btn_abs);
       }
       else if (uiCfg.curTempType == 1) {
         uiCfg.extruderIndex = 0;
         uiCfg.curTempType = 0;
         lv_obj_del(buttonAdd);
         lv_obj_del(buttonDec);
+        disp_add_dec();
+        disp_ext_heart();
       }
-
       disp_temp_type();
+      break;
+    case ID_P_STEP:
+      switch (uiCfg.stepHeat) {
+        case  1: uiCfg.stepHeat =  5; break;
+        case  5: uiCfg.stepHeat = 10; break;
+        case 10: uiCfg.stepHeat =  1; break;
+        default: break;
+      }
+      disp_step_heat();
       break;
     case ID_P_OFF:
       if (uiCfg.curTempType == 0) {
@@ -154,16 +162,20 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       draw_return_ui();
       break;
     case ID_P_ABS:
-      if (uiCfg.curTempType == 0)
+      if (uiCfg.curTempType == 0) {
         thermalManager.setTargetHotend(PREHEAT_2_TEMP_HOTEND, 0);
-      else if (uiCfg.curTempType == 1)
+      }
+      else if (uiCfg.curTempType == 1) {
         thermalManager.setTargetBed(PREHEAT_2_TEMP_BED);
+      }
       break;
     case ID_P_PLA:
-      if (uiCfg.curTempType == 0)
+      if (uiCfg.curTempType == 0) {
         thermalManager.setTargetHotend(PREHEAT_1_TEMP_HOTEND, 0);
-      else if (uiCfg.curTempType == 1)
+      }
+      else if (uiCfg.curTempType == 1) {
         thermalManager.setTargetBed(PREHEAT_1_TEMP_BED);
+      }
       break;
   }
 }

--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -128,10 +128,6 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       else if (uiCfg.curTempType == 1) {
         uiCfg.extruderIndex = 0;
         uiCfg.curTempType = 0;
-        lv_obj_del(buttonAdd);
-        lv_obj_del(buttonDec);
-        disp_add_dec();
-        disp_ext_heart();
       }
       disp_temp_type();
       break;


### PR DESCRIPTION

### Description

Fix for the preheating screen of the lvgl mksui interface.
After https://github.com/MarlinFirmware/Marlin/pull/22848, the following bugs were found:
1. The step of changing the temperature is not selectable (previously it was 1, 5 or 10)
2. At multiple switching of the extruder / table mode, the "+", "-" icons and overheating resets disappear, until the printer is restarted.
