### PR TITLE
Move DWIN_CompletedLeveling() to within the IF HAS_MESH

### DIFF
--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -1665,9 +1665,9 @@ void DWIN_MeshLevelingStart() {
   #endif
 }
 
-#if HAS_MESH
-  void DWIN_CompletedLeveling() { DWIN_MeshViewer(); }
+void DWIN_CompletedLeveling() { TERN_(HAS_MESH, DWIN_MeshViewer()); }
 
+#if HAS_MESH
   void DWIN_MeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
     char msg[33] = "";
     char str_1[6] = "";

--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -1665,9 +1665,9 @@ void DWIN_MeshLevelingStart() {
   #endif
 }
 
-void DWIN_CompletedLeveling() { DWIN_MeshViewer(); }
-
 #if HAS_MESH
+  void DWIN_CompletedLeveling() { DWIN_MeshViewer(); }
+
   void DWIN_MeshUpdate(const int8_t xpos, const int8_t ypos, const float zval) {
     char msg[33] = "";
     char str_1[6] = "";

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -3246,7 +3246,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW:
             if (draw)
-              Draw_Menu_Item(row, ICON_Mesh, GET_TEXT_F(MSG_MESH_VIEW), nullptr, true);
+              Draw_Menu_Item(row, ICON_Mesh, GET_TEXT(MSG_MESH_VIEW), nullptr, true);
             else {
               #if ENABLED(AUTO_BED_LEVELING_UBL)
                 if (ubl.storage_slot < 0) {
@@ -3319,7 +3319,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
             break;
           case LEVELING_VIEW_MESH:
             if (draw)
-              Draw_Menu_Item(row, ICON_PrintSize, GET_TEXT_F(MSG_MESH_VIEW), nullptr, true);
+              Draw_Menu_Item(row, ICON_PrintSize, GET_TEXT(MSG_MESH_VIEW), nullptr, true);
             else
               Draw_Menu(MeshViewer);
             break;
@@ -4070,9 +4070,9 @@ const char * CrealityDWINClass::Get_Menu_Title(uint8_t menu) {
     case InfoMain:          return "Info";
     #if HAS_MESH
       case Leveling:        return "Leveling";
-      case LevelView:       return GET_TEXT_F(MSG_MESH_VIEW);
+      case LevelView:       return GET_TEXT(MSG_MESH_VIEW);
       case LevelSettings:   return "Leveling Settings";
-      case MeshViewer:      return GET_TEXT_F(MSG_MESH_VIEW);
+      case MeshViewer:      return GET_TEXT(MSG_MESH_VIEW);
       case LevelManual:     return "Manual Tuning";
     #endif
     #if ENABLED(AUTO_BED_LEVELING_UBL) && !HAS_BED_PROBE


### PR DESCRIPTION
Should fix:

```
Marlin/src/lcd/e3v2/enhanced/dwin.cpp: In function 'void DWIN_CompletedLeveling()':
Marlin/src/lcd/e3v2/enhanced/dwin.cpp:1668:33: error: 'DWIN_MeshViewer' was not declared in this scope; did you mean 'ICON_MeshViewer'?
 1668 | void DWIN_CompletedLeveling() { DWIN_MeshViewer(); }
      |                                 ^~~~~~~~~~~~~~~
      |                                 ICON_MeshViewer
*** [.pio/build/STM32F103RET6_creality/src/src/lcd/e3v2/enhanced/dwin.cpp.o] Error 1
```

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
