### PR TITLE
Added support for self-latching Power Supplies

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -367,6 +367,17 @@
 
 #if ENABLED(PSU_CONTROL)
   #define PSU_ACTIVE_STATE LOW      // Set 'LOW' for ATX, 'HIGH' for X-Box
+  //#define PSU_SELF_LATCHING         // Enable if your PSU is self-latching rather than digital-state
+
+  #if ENABLED(PSU_SELF_LATCHING)
+    #define PSU_LATCH_DELAY 200 // (ms) Latch signal delay
+
+    //#define PSU_RS_LATCH // Enable if your PSU latch is Reset/Set, Disable for a Toggle Latch.
+
+    #if ENABLED(PSU_RS_LATCH)
+      #define PS_OFF_PIN 0 // Pin number for the Latch-Reset signal. (Add to pins.h ?)
+    #endif
+  #endif
 
   //#define PSU_DEFAULT_OFF         // Keep power off until enabled directly with M80
   //#define PSU_POWERUP_DELAY 250   // (ms) Delay for the PSU to warm up to full power
@@ -374,7 +385,7 @@
   //#define PSU_POWERUP_GCODE  "M355 S1"  // G-code to run after power-on (e.g., case light on)
   //#define PSU_POWEROFF_GCODE "M355 S0"  // G-code to run before power-off (e.g., case light off)
 
-  //#define AUTO_POWER_CONTROL      // Enable automatic control of the PS_ON pin
+  #define AUTO_POWER_CONTROL      // Enable automatic control of the PS_ON pin
   #if ENABLED(AUTO_POWER_CONTROL)
     #define AUTO_POWER_FANS         // Turn on PSU if fans need power
     #define AUTO_POWER_E_FANS

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3458,7 +3458,23 @@ static_assert(   _ARR_TEST(3,0) && _ARR_TEST(3,1) && _ARR_TEST(3,2)
   #elif !PIN_EXISTS(PS_ON)
     #error "PSU_CONTROL requires PS_ON_PIN."
   #elif POWER_OFF_DELAY < 0
-    #error "POWER_OFF_DELAY must be a positive value."
+    #error "POWER_OFF_DELAY must be a positive value."   
+  #endif
+
+  #if ENABLED(PSU_SELF_LATCHING)
+    #ifndef PSU_LATCH_DELAY
+      #error "PSU_SELF_LATCHING requires PSU_LATCH_DELAY"
+    #elif PSU_LATCH_DELAY < 0
+      #error "PSU_LATCH_DELAY must be a positive value."
+    #endif
+
+    #if ENABLED(PSU_RS_LATCH) 
+      #ifndef PS_OFF_PIN
+        #error "PSU_RS_LATCH requires PS_OFF_PIN"
+      #elif PS_OFF_PIN < 0
+        #error "PS_OFF_PIN must be a valid pin."
+      #endif
+    #endif
   #endif
 #endif
 


### PR DESCRIPTION
### Description

Added support for self-latching power supplies.
supports both RS-Flip-Flop and T-Flip-Flop latches.

### Requirements

None.

### Benefits

<!-- What does this PR fix or improve? -->
Improves **PSU_CONTROL** by allowing a broader range of hardware possibilities;
Eg, large/custom machines require large/custom power supplies, including ones that aren't solid-state and/or don't require a constant input signal to remain operational.

### Configurations

[Marlin_Self-Latching_PSU_Configs.zip](https://github.com/MarlinFirmware/Marlin/files/7271090/Marlin_Self-Latching_PSU_Configs.zip)

### Reason

I built a HUGE custom machine with a 48v self-latching power supply.
I needed a way to wire the T-Flip-Flop to Marlin.
Then I added RS-Flip-Flop support just in case.
This pull request is so that anyone could benefit from this modification.

<!-- second attempt -->