### PR TITLE
Fix EXTRUDER 0 warnings

### DIFF
--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -609,7 +609,7 @@ class Stepper {
       static void disable_e_steppers();
     #else
       static inline void enable_extruder() {}
-      static inline bool disable_extruder() {return true;}
+      static inline bool disable_extruder() { return true; }
       static inline void enable_e_steppers() {}
       static inline void disable_e_steppers() {}
     #endif

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -609,7 +609,7 @@ class Stepper {
       static void disable_e_steppers();
     #else
       static inline void enable_extruder() {}
-      static inline bool disable_extruder() {}
+      static inline bool disable_extruder() {return true;}
       static inline void enable_e_steppers() {}
       static inline void disable_e_steppers() {}
     #endif


### PR DESCRIPTION
### Description

With EXTRUDERS 0  Bugfix gives the following warning a number of times
```CPP
Marlin/src/module/stepper.h: In static member function 'static bool Stepper::disable_extruder()':
Marlin/src/module/stepper.h:612:46: warning: no return statement in function returning non-void [-Wreturn-type]
       static inline bool disable_extruder() {}
```
### Requirements

#define EXTRUDERS 0

### Benefits

Warnings are gone.

### Configurations
https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/linear_axes/RAMPS%205%20LINEAR_AXES

### Related Issues
Noticed this while looking at https://github.com/MarlinFirmware/Marlin/issues/22864
