### PR TITLE
Fix arduino ide compile error, issue 22876

### DIFF
--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language.cpp
@@ -21,7 +21,7 @@
 
 
 #include "../../../../MarlinCore.h"
-
-#include "language.h"
-
-uint8_t lang = 0;
+#if ENABLED(TOUCH_UI_FTDI_EVE)
+  #include "language.h"
+  uint8_t lang = 0;
+#endif


### PR DESCRIPTION
### Description

Yet again Marlin doesn't compile under Arduino IDE
In this case Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language.cpp is always compiled 
Added a #if ENABLED(TOUCH_UI_FTDI_EVE) block

### Requirements

Arduino IDE

### Benefits

Users get to continue torturing themselves using Arduino IDE

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/22876