### PR TITLE
add missing pins to pins_CHITU3D_V9.h 

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -33,6 +33,12 @@
 
 #define _AXIS(A) (A##_AXIS)
 
+#define _XSTOP_  0x01
+#define _YSTOP_  0x02
+#define _ZSTOP_  0x03
+#define _ISTOP_  0x04
+#define _JSTOP_  0x05
+#define _KSTOP_  0x06
 #define _XMIN_   0x11
 #define _YMIN_   0x12
 #define _ZMIN_   0x13

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -769,19 +769,25 @@
         #define X2_MAX_ENDSTOP_INVERTING false
       #endif
     #endif
-    #ifndef X2_MAX_PIN
+    #if !defined(X2_MAX_PIN) && !defined(X2_STOP_PIN)
       #if X2_USE_ENDSTOP == _XMIN_
         #define X2_MAX_PIN X_MIN_PIN
       #elif X2_USE_ENDSTOP == _XMAX_
         #define X2_MAX_PIN X_MAX_PIN
+      #elif X2_USE_ENDSTOP == _XSTOP_
+        #define X2_MAX_PIN X_STOP_PIN
       #elif X2_USE_ENDSTOP == _YMIN_
         #define X2_MAX_PIN Y_MIN_PIN
       #elif X2_USE_ENDSTOP == _YMAX_
         #define X2_MAX_PIN Y_MAX_PIN
+      #elif X2_USE_ENDSTOP == _YSTOP_
+        #define X2_MAX_PIN Y_STOP_PIN
       #elif X2_USE_ENDSTOP == _ZMIN_
         #define X2_MAX_PIN Z_MIN_PIN
       #elif X2_USE_ENDSTOP == _ZMAX_
         #define X2_MAX_PIN Z_MAX_PIN
+      #elif X2_USE_ENDSTOP == _ZSTOP_
+        #define X2_MAX_PIN Z_STOP_PIN
       #elif X2_USE_ENDSTOP == _XDIAG_
         #define X2_MAX_PIN X_DIAG_PIN
       #elif X2_USE_ENDSTOP == _YDIAG_
@@ -827,19 +833,25 @@
         #define X2_MIN_ENDSTOP_INVERTING false
       #endif
     #endif
-    #ifndef X2_MIN_PIN
+    #if !defined(X2_MIN_PIN) && !defined(X2_STOP_PIN)
       #if X2_USE_ENDSTOP == _XMIN_
         #define X2_MIN_PIN X_MIN_PIN
       #elif X2_USE_ENDSTOP == _XMAX_
         #define X2_MIN_PIN X_MAX_PIN
+      #elif X2_USE_ENDSTOP == _XSTOP_
+        #define X2_MIN_PIN X_STOP_PIN
       #elif X2_USE_ENDSTOP == _YMIN_
         #define X2_MIN_PIN Y_MIN_PIN
       #elif X2_USE_ENDSTOP == _YMAX_
         #define X2_MIN_PIN Y_MAX_PIN
+      #elif X2_USE_ENDSTOP == _YSTOP_
+        #define X2_MIN_PIN Y_STOP_PIN
       #elif X2_USE_ENDSTOP == _ZMIN_
         #define X2_MIN_PIN Z_MIN_PIN
       #elif X2_USE_ENDSTOP == _ZMAX_
         #define X2_MIN_PIN Z_MAX_PIN
+      #elif X2_USE_ENDSTOP == _ZSTOP_
+        #define X2_MIN_PIN Z_STOP_PIN
       #elif X2_USE_ENDSTOP == _XDIAG_
         #define X2_MIN_PIN X_DIAG_PIN
       #elif X2_USE_ENDSTOP == _YDIAG_
@@ -892,19 +904,25 @@
         #define Y2_MAX_ENDSTOP_INVERTING false
       #endif
     #endif
-    #ifndef Y2_MAX_PIN
+    #if !defined(Y2_MAX_PIN) && !defined(Y2_STOP_PIN)
       #if Y2_USE_ENDSTOP == _XMIN_
         #define Y2_MAX_PIN X_MIN_PIN
       #elif Y2_USE_ENDSTOP == _XMAX_
         #define Y2_MAX_PIN X_MAX_PIN
+      #elif Y2_USE_ENDSTOP == _XSTOP_
+        #define Y2_MAX_PIN X_STOP_PIN
       #elif Y2_USE_ENDSTOP == _YMIN_
         #define Y2_MAX_PIN Y_MIN_PIN
       #elif Y2_USE_ENDSTOP == _YMAX_
         #define Y2_MAX_PIN Y_MAX_PIN
+      #elif Y2_USE_ENDSTOP == _YSTOP_
+        #define Y2_MAX_PIN Y_STOP_PIN
       #elif Y2_USE_ENDSTOP == _ZMIN_
         #define Y2_MAX_PIN Z_MIN_PIN
       #elif Y2_USE_ENDSTOP == _ZMAX_
         #define Y2_MAX_PIN Z_MAX_PIN
+      #elif Y2_USE_ENDSTOP == _ZSTOP_
+        #define Y2_MAX_PIN Z_STOP_PIN
       #elif Y2_USE_ENDSTOP == _XDIAG_
         #define Y2_MAX_PIN X_DIAG_PIN
       #elif Y2_USE_ENDSTOP == _YDIAG_
@@ -950,19 +968,25 @@
         #define Y2_MIN_ENDSTOP_INVERTING false
       #endif
     #endif
-    #ifndef Y2_MIN_PIN
+    #if !defined(Y2_MIN_PIN) && !defined(Y2_STOP_PIN)
       #if Y2_USE_ENDSTOP == _XMIN_
         #define Y2_MIN_PIN X_MIN_PIN
       #elif Y2_USE_ENDSTOP == _XMAX_
         #define Y2_MIN_PIN X_MAX_PIN
+      #elif Y2_USE_ENDSTOP == _XSTOP_
+        #define Y2_MIN_PIN X_STOP_PIN
       #elif Y2_USE_ENDSTOP == _YMIN_
         #define Y2_MIN_PIN Y_MIN_PIN
       #elif Y2_USE_ENDSTOP == _YMAX_
         #define Y2_MIN_PIN Y_MAX_PIN
+      #elif Y2_USE_ENDSTOP == _YSTOP_
+        #define Y2_MIN_PIN Y_STOP_PIN
       #elif Y2_USE_ENDSTOP == _ZMIN_
         #define Y2_MIN_PIN Z_MIN_PIN
       #elif Y2_USE_ENDSTOP == _ZMAX_
         #define Y2_MIN_PIN Z_MAX_PIN
+      #elif Y2_USE_ENDSTOP == _ZSTOP_
+        #define Y2_MIN_PIN Z_STOP_PIN
       #elif Y2_USE_ENDSTOP == _XDIAG_
         #define Y2_MIN_PIN X_DIAG_PIN
       #elif Y2_USE_ENDSTOP == _YDIAG_
@@ -1016,19 +1040,25 @@
         #define Z2_MAX_ENDSTOP_INVERTING false
       #endif
     #endif
-    #ifndef Z2_MAX_PIN
+    #if !defined(Z2_MAX_PIN) && !defined(Z2_STOP_PIN)
       #if Z2_USE_ENDSTOP == _XMIN_
         #define Z2_MAX_PIN X_MIN_PIN
       #elif Z2_USE_ENDSTOP == _XMAX_
         #define Z2_MAX_PIN X_MAX_PIN
+      #elif Z2_USE_ENDSTOP == _XSTOP_
+        #define Z2_MAX_PIN X_STOP_PIN
       #elif Z2_USE_ENDSTOP == _YMIN_
         #define Z2_MAX_PIN Y_MIN_PIN
       #elif Z2_USE_ENDSTOP == _YMAX_
         #define Z2_MAX_PIN Y_MAX_PIN
+      #elif Z2_USE_ENDSTOP == _YSTOP_
+        #define Z2_MAX_PIN Y_STOP_PIN
       #elif Z2_USE_ENDSTOP == _ZMIN_
         #define Z2_MAX_PIN Z_MIN_PIN
       #elif Z2_USE_ENDSTOP == _ZMAX_
         #define Z2_MAX_PIN Z_MAX_PIN
+      #elif Z2_USE_ENDSTOP == _ZSTOP_
+        #define Z2_MAX_PIN Z_STOP_PIN
       #elif Z2_USE_ENDSTOP == _XDIAG_
         #define Z2_MAX_PIN X_DIAG_PIN
       #elif Z2_USE_ENDSTOP == _YDIAG_
@@ -1079,14 +1109,20 @@
         #define Z2_MIN_PIN X_MIN_PIN
       #elif Z2_USE_ENDSTOP == _XMAX_
         #define Z2_MIN_PIN X_MAX_PIN
+      #elif Z2_USE_ENDSTOP == _XSTOP_
+        #define Z2_MIN_PIN X_STOP_PIN
       #elif Z2_USE_ENDSTOP == _YMIN_
         #define Z2_MIN_PIN Y_MIN_PIN
       #elif Z2_USE_ENDSTOP == _YMAX_
         #define Z2_MIN_PIN Y_MAX_PIN
+      #elif Z2_USE_ENDSTOP == _YSTOP_
+        #define Z2_MIN_PIN Y_STOP_PIN
       #elif Z2_USE_ENDSTOP == _ZMIN_
         #define Z2_MIN_PIN Z_MIN_PIN
       #elif Z2_USE_ENDSTOP == _ZMAX_
         #define Z2_MIN_PIN Z_MAX_PIN
+      #elif Z2_USE_ENDSTOP == _ZSTOP_
+        #define Z2_MIN_PIN Z_STOP_PIN
       #elif Z2_USE_ENDSTOP == _XDIAG_
         #define Z2_MIN_PIN X_DIAG_PIN
       #elif Z2_USE_ENDSTOP == _YDIAG_
@@ -1140,14 +1176,20 @@
           #define Z3_MAX_PIN X_MIN_PIN
         #elif Z3_USE_ENDSTOP == _XMAX_
           #define Z3_MAX_PIN X_MAX_PIN
+        #elif Z3_USE_ENDSTOP == _XSTOP_
+          #define Z3_MAX_PIN X_STOP_PIN
         #elif Z3_USE_ENDSTOP == _YMIN_
           #define Z3_MAX_PIN Y_MIN_PIN
         #elif Z3_USE_ENDSTOP == _YMAX_
           #define Z3_MAX_PIN Y_MAX_PIN
+        #elif Z3_USE_ENDSTOP == _YSTOP_
+          #define Z3_MAX_PIN Y_STOP_PIN
         #elif Z3_USE_ENDSTOP == _ZMIN_
           #define Z3_MAX_PIN Z_MIN_PIN
         #elif Z3_USE_ENDSTOP == _ZMAX_
           #define Z3_MAX_PIN Z_MAX_PIN
+        #elif Z3_USE_ENDSTOP == _ZSTOP_
+          #define Z3_MAX_PIN Z_STOP_PIN
         #elif Z3_USE_ENDSTOP == _XDIAG_
           #define Z3_MAX_PIN X_DIAG_PIN
         #elif Z3_USE_ENDSTOP == _YDIAG_
@@ -1198,14 +1240,20 @@
           #define Z3_MIN_PIN X_MIN_PIN
         #elif Z3_USE_ENDSTOP == _XMAX_
           #define Z3_MIN_PIN X_MAX_PIN
+        #elif Z3_USE_ENDSTOP == _XSTOP_
+          #define Z3_MIN_PIN X_STOP_PIN
         #elif Z3_USE_ENDSTOP == _YMIN_
           #define Z3_MIN_PIN Y_MIN_PIN
         #elif Z3_USE_ENDSTOP == _YMAX_
           #define Z3_MIN_PIN Y_MAX_PIN
+        #elif Z3_USE_ENDSTOP == _YSTOP_
+          #define Z3_MIN_PIN Y_STOP_PIN
         #elif Z3_USE_ENDSTOP == _ZMIN_
           #define Z3_MIN_PIN Z_MIN_PIN
         #elif Z3_USE_ENDSTOP == _ZMAX_
           #define Z3_MIN_PIN Z_MAX_PIN
+        #elif Z3_USE_ENDSTOP == _ZSTOP_
+          #define Z3_MIN_PIN Z_STOP_PIN
         #elif Z3_USE_ENDSTOP == _XDIAG_
           #define Z3_MIN_PIN X_DIAG_PIN
         #elif Z3_USE_ENDSTOP == _YDIAG_
@@ -1260,14 +1308,20 @@
           #define Z4_MAX_PIN X_MIN_PIN
         #elif Z4_USE_ENDSTOP == _XMAX_
           #define Z4_MAX_PIN X_MAX_PIN
+        #elif Z4_USE_ENDSTOP == _XSTOP_
+          #define Z4_MAX_PIN X_STOP_PIN
         #elif Z4_USE_ENDSTOP == _YMIN_
           #define Z4_MAX_PIN Y_MIN_PIN
         #elif Z4_USE_ENDSTOP == _YMAX_
           #define Z4_MAX_PIN Y_MAX_PIN
+        #elif Z4_USE_ENDSTOP == _YSTOP_
+          #define Z4_MAX_PIN Y_STOP_PIN
         #elif Z4_USE_ENDSTOP == _ZMIN_
           #define Z4_MAX_PIN Z_MIN_PIN
         #elif Z4_USE_ENDSTOP == _ZMAX_
           #define Z4_MAX_PIN Z_MAX_PIN
+        #elif Z4_USE_ENDSTOP == _ZSTOP_
+          #define Z4_MAX_PIN Z_STOP_PIN
         #elif Z4_USE_ENDSTOP == _XDIAG_
           #define Z4_MAX_PIN X_DIAG_PIN
         #elif Z4_USE_ENDSTOP == _YDIAG_
@@ -1318,14 +1372,20 @@
           #define Z4_MIN_PIN X_MIN_PIN
         #elif Z4_USE_ENDSTOP == _XMAX_
           #define Z4_MIN_PIN X_MAX_PIN
+        #elif Z4_USE_ENDSTOP == _XSTOP_
+          #define Z4_MIN_PIN X_STOP_PIN
         #elif Z4_USE_ENDSTOP == _YMIN_
           #define Z4_MIN_PIN Y_MIN_PIN
         #elif Z4_USE_ENDSTOP == _YMAX_
           #define Z4_MIN_PIN Y_MAX_PIN
+        #elif Z4_USE_ENDSTOP == _YSTOP_
+          #define Z4_MIN_PIN Y_STOP_PIN
         #elif Z4_USE_ENDSTOP == _ZMIN_
           #define Z4_MIN_PIN Z_MIN_PIN
         #elif Z4_USE_ENDSTOP == _ZMAX_
           #define Z4_MIN_PIN Z_MAX_PIN
+        #elif Z4_USE_ENDSTOP == _ZSTOP_
+          #define Z4_MIN_PIN Z_STOP_PIN
         #elif Z4_USE_ENDSTOP == _XDIAG_
           #define Z4_MIN_PIN X_DIAG_PIN
         #elif Z4_USE_ENDSTOP == _YDIAG_

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -59,14 +59,20 @@
     #warning "Auto-assigned X2_DIAG_PIN to X_MIN_PIN."
   #elif X2_USE_ENDSTOP == _XMAX_
     #warning "Auto-assigned X2_DIAG_PIN to X_MAX_PIN."
+  #elif X2_USE_ENDSTOP == _XSTOP_
+    #warning "Auto-assigned X2_DIAG_PIN to X_STOP_PIN."
   #elif X2_USE_ENDSTOP == _YMIN_
     #warning "Auto-assigned X2_DIAG_PIN to Y_MIN_PIN."
   #elif X2_USE_ENDSTOP == _YMAX_
     #warning "Auto-assigned X2_DIAG_PIN to Y_MAX_PIN."
+  #elif X2_USE_ENDSTOP == _YSTOP_
+    #warning "Auto-assigned X2_DIAG_PIN to Y_STOP_PIN."
   #elif X2_USE_ENDSTOP == _ZMIN_
     #warning "Auto-assigned X2_DIAG_PIN to Z_MIN_PIN."
   #elif X2_USE_ENDSTOP == _ZMAX_
     #warning "Auto-assigned X2_DIAG_PIN to Z_MAX_PIN."
+  #elif X2_USE_ENDSTOP == _ZSTOP_
+    #warning "Auto-assigned X2_DIAG_PIN to Z_STOP_PIN."
   #elif X2_USE_ENDSTOP == _XDIAG_
     #warning "Auto-assigned X2_DIAG_PIN to X_DIAG_PIN."
   #elif X2_USE_ENDSTOP == _YDIAG_
@@ -111,14 +117,20 @@
     #warning "Auto-assigned Y2_DIAG_PIN to X_MIN_PIN."
   #elif Y2_USE_ENDSTOP == _XMAX_
     #warning "Auto-assigned Y2_DIAG_PIN to X_MAX_PIN."
+  #elif Y2_USE_ENDSTOP == _XSTOP_
+    #warning "Auto-assigned Y2_DIAG_PIN to X_STOP_PIN."
   #elif Y2_USE_ENDSTOP == _YMIN_
     #warning "Auto-assigned Y2_DIAG_PIN to Y_MIN_PIN."
   #elif Y2_USE_ENDSTOP == _YMAX_
     #warning "Auto-assigned Y2_DIAG_PIN to Y_MAX_PIN."
+  #elif Y2_USE_ENDSTOP == _YSTOP_
+    #warning "Auto-assigned Y2_DIAG_PIN to Y_STOP_PIN."
   #elif Y2_USE_ENDSTOP == _ZMIN_
     #warning "Auto-assigned Y2_DIAG_PIN to Z_MIN_PIN."
   #elif Y2_USE_ENDSTOP == _ZMAX_
     #warning "Auto-assigned Y2_DIAG_PIN to Z_MAX_PIN."
+  #elif Y2_USE_ENDSTOP == _ZSTOP_
+    #warning "Auto-assigned Y2_DIAG_PIN to Z_STOP_PIN."
   #elif Y2_USE_ENDSTOP == _XDIAG_
     #warning "Auto-assigned Y2_DIAG_PIN to X_DIAG_PIN."
   #elif Y2_USE_ENDSTOP == _YDIAG_
@@ -163,14 +175,20 @@
     #warning "Auto-assigned Z2_DIAG_PIN to X_MIN_PIN."
   #elif Z2_USE_ENDSTOP == _XMAX_
     #warning "Auto-assigned Z2_DIAG_PIN to X_MAX_PIN."
+  #elif Z2_USE_ENDSTOP == _XSTOP_
+    #warning "Auto-assigned Z2_DIAG_PIN to X_STOP_PIN."
   #elif Z2_USE_ENDSTOP == _YMIN_
     #warning "Auto-assigned Z2_DIAG_PIN to Y_MIN_PIN."
   #elif Z2_USE_ENDSTOP == _YMAX_
     #warning "Auto-assigned Z2_DIAG_PIN to Y_MAX_PIN."
+  #elif Z2_USE_ENDSTOP == _YSTOP_
+    #warning "Auto-assigned Z2_DIAG_PIN to Y_STOP_PIN."
   #elif Z2_USE_ENDSTOP == _ZMIN_
     #warning "Auto-assigned Z2_DIAG_PIN to Z_MIN_PIN."
   #elif Z2_USE_ENDSTOP == _ZMAX_
     #warning "Auto-assigned Z2_DIAG_PIN to Z_MAX_PIN."
+  #elif Z2_USE_ENDSTOP == _ZSTOP_
+    #warning "Auto-assigned Z2_DIAG_PIN to Z_STOP_PIN."
   #elif Z2_USE_ENDSTOP == _XDIAG_
     #warning "Auto-assigned Z2_DIAG_PIN to X_DIAG_PIN."
   #elif Z2_USE_ENDSTOP == _YDIAG_
@@ -215,14 +233,20 @@
     #warning "Auto-assigned Z3_DIAG_PIN to X_MIN_PIN."
   #elif Z3_USE_ENDSTOP == _XMAX_
     #warning "Auto-assigned Z3_DIAG_PIN to X_MAX_PIN."
+  #elif Z3_USE_ENDSTOP == _XSTOP_
+    #warning "Auto-assigned Z3_DIAG_PIN to X_STOP_PIN."
   #elif Z3_USE_ENDSTOP == _YMIN_
     #warning "Auto-assigned Z3_DIAG_PIN to Y_MIN_PIN."
   #elif Z3_USE_ENDSTOP == _YMAX_
     #warning "Auto-assigned Z3_DIAG_PIN to Y_MAX_PIN."
+  #elif Z3_USE_ENDSTOP == _YSTOP_
+    #warning "Auto-assigned Z3_DIAG_PIN to Y_STOP_PIN."
   #elif Z3_USE_ENDSTOP == _ZMIN_
     #warning "Auto-assigned Z3_DIAG_PIN to Z_MIN_PIN."
   #elif Z3_USE_ENDSTOP == _ZMAX_
     #warning "Auto-assigned Z3_DIAG_PIN to Z_MAX_PIN."
+  #elif Z3_USE_ENDSTOP == _ZSTOP_
+    #warning "Auto-assigned Z3_DIAG_PIN to Z_STOP_PIN."
   #elif Z3_USE_ENDSTOP == _XDIAG_
     #warning "Auto-assigned Z3_DIAG_PIN to X_DIAG_PIN."
   #elif Z3_USE_ENDSTOP == _YDIAG_
@@ -267,14 +291,20 @@
     #warning "Auto-assigned Z4_DIAG_PIN to X_MIN_PIN."
   #elif Z4_USE_ENDSTOP == _XMAX_
     #warning "Auto-assigned Z4_DIAG_PIN to X_MAX_PIN."
+  #elif Z4_USE_ENDSTOP == _XSTOP_
+    #warning "Auto-assigned Z4_DIAG_PIN to X_STOP_PIN."
   #elif Z4_USE_ENDSTOP == _YMIN_
     #warning "Auto-assigned Z4_DIAG_PIN to Y_MIN_PIN."
   #elif Z4_USE_ENDSTOP == _YMAX_
     #warning "Auto-assigned Z4_DIAG_PIN to Y_MAX_PIN."
+  #elif Z4_USE_ENDSTOP == _YSTOP_
+    #warning "Auto-assigned Z4_DIAG_PIN to Y_STOP_PIN."
   #elif Z4_USE_ENDSTOP == _ZMIN_
     #warning "Auto-assigned Z4_DIAG_PIN to Z_MIN_PIN."
   #elif Z4_USE_ENDSTOP == _ZMAX_
     #warning "Auto-assigned Z4_DIAG_PIN to Z_MAX_PIN."
+  #elif Z4_USE_ENDSTOP == _ZSTOP_
+    #warning "Auto-assigned Z4_DIAG_PIN to Z_STOP_PIN."
   #elif Z4_USE_ENDSTOP == _XDIAG_
     #warning "Auto-assigned Z4_DIAG_PIN to X_DIAG_PIN."
   #elif Z4_USE_ENDSTOP == _YDIAG_
@@ -319,14 +349,20 @@
     #warning "Auto-assigned I_DIAG_PIN to X_MIN_PIN."
   #elif I_USE_ENDSTOP == _XMAX_
     #warning "Auto-assigned I_DIAG_PIN to X_MAX_PIN."
+  #elif I_USE_ENDSTOP == _XSTOP_
+    #warning "Auto-assigned I_DIAG_PIN to X_STOP_PIN."
   #elif I_USE_ENDSTOP == _YMIN_
     #warning "Auto-assigned I_DIAG_PIN to Y_MIN_PIN."
   #elif I_USE_ENDSTOP == _YMAX_
     #warning "Auto-assigned I_DIAG_PIN to Y_MAX_PIN."
+  #elif I_USE_ENDSTOP == _YSTOP_
+    #warning "Auto-assigned I_DIAG_PIN to Y_STOP_PIN."
   #elif I_USE_ENDSTOP == _ZMIN_
     #warning "Auto-assigned I_DIAG_PIN to Z_MIN_PIN."
   #elif I_USE_ENDSTOP == _ZMAX_
     #warning "Auto-assigned I_DIAG_PIN to Z_MAX_PIN."
+  #elif I_USE_ENDSTOP == _ZSTOP_
+    #warning "Auto-assigned I_DIAG_PIN to Z_STOP_PIN."
   #elif I_USE_ENDSTOP == _XDIAG_
     #warning "Auto-assigned I_DIAG_PIN to X_DIAG_PIN."
   #elif I_USE_ENDSTOP == _YDIAG_
@@ -371,14 +407,20 @@
     #warning "Auto-assigned J_DIAG_PIN to X_MIN_PIN."
   #elif J_USE_ENDSTOP == _XMAX_
     #warning "Auto-assigned J_DIAG_PIN to X_MAX_PIN."
+  #elif J_USE_ENDSTOP == _XSTOP_
+    #warning "Auto-assigned J_DIAG_PIN to X_STOP_PIN."
   #elif J_USE_ENDSTOP == _YMIN_
     #warning "Auto-assigned J_DIAG_PIN to Y_MIN_PIN."
   #elif J_USE_ENDSTOP == _YMAX_
     #warning "Auto-assigned J_DIAG_PIN to Y_MAX_PIN."
+  #elif J_USE_ENDSTOP == _YSTOP_
+    #warning "Auto-assigned J_DIAG_PIN to Y_STOP_PIN."
   #elif J_USE_ENDSTOP == _ZMIN_
     #warning "Auto-assigned J_DIAG_PIN to Z_MIN_PIN."
   #elif J_USE_ENDSTOP == _ZMAX_
     #warning "Auto-assigned J_DIAG_PIN to Z_MAX_PIN."
+  #elif J_USE_ENDSTOP == _ZSTOP_
+    #warning "Auto-assigned J_DIAG_PIN to Z_STOP_PIN."
   #elif J_USE_ENDSTOP == _XDIAG_
     #warning "Auto-assigned J_DIAG_PIN to X_DIAG_PIN."
   #elif J_USE_ENDSTOP == _YDIAG_
@@ -423,14 +465,20 @@
     #warning "Auto-assigned K_DIAG_PIN to X_MIN_PIN."
   #elif K_USE_ENDSTOP == _XMAX_
     #warning "Auto-assigned K_DIAG_PIN to X_MAX_PIN."
+  #elif K_USE_ENDSTOP == _XSTOP_
+    #warning "Auto-assigned K_DIAG_PIN to X_STOP_PIN."
   #elif K_USE_ENDSTOP == _YMIN_
     #warning "Auto-assigned K_DIAG_PIN to Y_MIN_PIN."
   #elif K_USE_ENDSTOP == _YMAX_
     #warning "Auto-assigned K_DIAG_PIN to Y_MAX_PIN."
+  #elif K_USE_ENDSTOP == _YSTOP_
+    #warning "Auto-assigned K_DIAG_PIN to Y_STOP_PIN."
   #elif K_USE_ENDSTOP == _ZMIN_
     #warning "Auto-assigned K_DIAG_PIN to Z_MIN_PIN."
   #elif K_USE_ENDSTOP == _ZMAX_
     #warning "Auto-assigned K_DIAG_PIN to Z_MAX_PIN."
+  #elif K_USE_ENDSTOP == _ZSTOP_
+    #warning "Auto-assigned K_DIAG_PIN to Z_STOP_PIN."
   #elif K_USE_ENDSTOP == _XDIAG_
     #warning "Auto-assigned K_DIAG_PIN to X_DIAG_PIN."
   #elif K_USE_ENDSTOP == _YDIAG_

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -458,6 +458,21 @@
   #else
     #define Z_STOP_PIN Z_MAX_PIN
   #endif
+  #if ENABLED(Z_MULTI_ENDSTOPS)
+    #ifdef Z2_STOP_PIN
+      #if Z_HOME_TO_MIN
+        #define Z2_MIN_PIN Z2_STOP_PIN
+        #ifndef Z2_MAX_PIN
+          #define Z2_MAX_PIN -1
+        #endif
+      #else
+        #define Z2_MAX_PIN Z2_STOP_PIN
+        #ifndef Z2_MIN_PIN
+          #define Z2_MIN_PIN -1
+        #endif
+      #endif
+    #endif
+  #endif
 #endif
 
 #if LINEAR_AXES >= 4

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -419,6 +419,9 @@
 #else
   #define X_STOP_PIN X_MAX_PIN
 #endif
+#if !defined(X2_USE_ENDSTOP) && ENABLED(X_DUAL_ENDSTOPS) && PIN_EXISTS(X_STOP)
+  #define X2_USE_ENDSTOP _XSTOP_
+#endif
 
 #if HAS_Y_AXIS
   #ifdef Y_STOP_PIN
@@ -437,6 +440,9 @@
     #define Y_STOP_PIN Y_MIN_PIN
   #else
     #define Y_STOP_PIN Y_MAX_PIN
+  #endif
+  #if !defined(Y2_USE_ENDSTOP) && ENABLED(Y_DUAL_ENDSTOPS) && PIN_EXISTS(Y_STOP)
+    #define Y2_USE_ENDSTOP _YSTOP_
   #endif
 #endif
 
@@ -458,45 +464,15 @@
   #else
     #define Z_STOP_PIN Z_MAX_PIN
   #endif
-  #if ENABLED(Z_MULTI_ENDSTOPS)
-    #ifdef Z2_STOP_PIN
-      #if Z_HOME_TO_MIN
-        #define Z2_MIN_PIN Z2_STOP_PIN
-        #ifndef Z2_MAX_PIN
-          #define Z2_MAX_PIN -1
-        #endif
-      #else
-        #define Z2_MAX_PIN Z2_STOP_PIN
-        #ifndef Z2_MIN_PIN
-          #define Z2_MIN_PIN -1
-        #endif
-      #endif
+  #if ENABLED(Z_MULTI_ENDSTOPS) && PIN_EXISTS(Z_STOP)
+    #ifndef Z2_USE_ENDSTOP
+      #define Z2_USE_ENDSTOP _ZSTOP_
     #endif
-    #ifdef Z3_STOP_PIN
-      #if Z_HOME_TO_MIN
-        #define Z3_MIN_PIN Z3_STOP_PIN
-        #ifndef Z3_MAX_PIN
-          #define Z3_MAX_PIN -1
-        #endif
-      #else
-        #define Z3_MAX_PIN Z3_STOP_PIN
-        #ifndef Z3_MIN_PIN
-          #define Z3_MIN_PIN -1
-        #endif
-      #endif
+    #if NUM_Z_STEPPER_DRIVERS >= 3 && !defined(Z3_USE_ENDSTOP)
+      #define Z3_USE_ENDSTOP _ZSTOP_
     #endif
-    #ifdef Z4_STOP_PIN
-      #if Z_HOME_TO_MIN
-        #define Z4_MIN_PIN Z4_STOP_PIN
-        #ifndef Z4_MAX_PIN
-          #define Z4_MAX_PIN -1
-        #endif
-      #else
-        #define Z4_MAX_PIN Z4_STOP_PIN
-        #ifndef Z4_MIN_PIN
-          #define Z4_MIN_PIN -1
-        #endif
-      #endif
+    #if NUM_Z_STEPPER_DRIVERS >= 4 && !defined(Z4_USE_ENDSTOP)
+      #define Z4_USE_ENDSTOP _ZSTOP_
     #endif
   #endif
 #endif
@@ -842,7 +818,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(Z2_DIAG_PIN) && !defined(Z2_USE_ENDSTOP) && defined(Z2_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 2 && _PEXI(Z2_E_INDEX, DIAG)
+  #if !defined(Z2_DIAG_PIN) && !defined(Z2_USE_ENDSTOP) && defined(Z2_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && _PEXI(Z2_E_INDEX, DIAG)
     #define Z2_DIAG_PIN _EPIN(Z2_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(Z2, X_MIN)
       #define Z2_USE_ENDSTOP _XMIN_
@@ -927,7 +903,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(Z3_DIAG_PIN) && !defined(Z3_USE_ENDSTOP) && defined(Z3_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 3 && _PEXI(Z3_E_INDEX, DIAG)
+  #if !defined(Z3_DIAG_PIN) && !defined(Z3_USE_ENDSTOP) && defined(Z3_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && _PEXI(Z3_E_INDEX, DIAG)
     #define Z3_DIAG_PIN _EPIN(Z3_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(Z3, X_MIN)
       #define Z3_USE_ENDSTOP _XMIN_
@@ -1012,7 +988,7 @@
     #endif
   #endif
   // Auto-assign pins for stallGuard sensorless homing
-  #if !defined(Z4_DIAG_PIN) && !defined(Z4_USE_ENDSTOP) && defined(Z4_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && NUM_Z_STEPPER_DRIVERS >= 4 && _PEXI(Z4_E_INDEX, DIAG)
+  #if !defined(Z4_DIAG_PIN) && !defined(Z4_USE_ENDSTOP) && defined(Z4_STALL_SENSITIVITY) && ENABLED(Z_MULTI_ENDSTOPS) && _PEXI(Z4_E_INDEX, DIAG)
     #define Z4_DIAG_PIN _EPIN(Z4_E_INDEX, DIAG)
     #if   DIAG_REMAPPED(Z4, X_MIN)
       #define Z4_USE_ENDSTOP _XMIN_

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -472,6 +472,32 @@
         #endif
       #endif
     #endif
+    #ifdef Z3_STOP_PIN
+      #if Z_HOME_TO_MIN
+        #define Z3_MIN_PIN Z3_STOP_PIN
+        #ifndef Z3_MAX_PIN
+          #define Z3_MAX_PIN -1
+        #endif
+      #else
+        #define Z3_MAX_PIN Z3_STOP_PIN
+        #ifndef Z3_MIN_PIN
+          #define Z3_MIN_PIN -1
+        #endif
+      #endif
+    #endif
+    #ifdef Z4_STOP_PIN
+      #if Z_HOME_TO_MIN
+        #define Z4_MIN_PIN Z4_STOP_PIN
+        #ifndef Z4_MAX_PIN
+          #define Z4_MAX_PIN -1
+        #endif
+      #else
+        #define Z4_MAX_PIN Z4_STOP_PIN
+        #ifndef Z4_MIN_PIN
+          #define Z4_MIN_PIN -1
+        #endif
+      #endif
+    #endif
   #endif
 #endif
 

--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V9.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V9.h
@@ -28,7 +28,11 @@
 #define Z2_ENABLE_PIN                       PF3
 #define Z2_STEP_PIN                         PF5
 #define Z2_DIR_PIN                          PF1
+#define Z2_STOP_PIN                         PA13
 
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PG9
+#endif
 #ifndef FIL_RUNOUT2_PIN
   #define FIL_RUNOUT2_PIN                   PF13
 #endif


### PR DESCRIPTION
### Description

In https://github.com/MarlinFirmware/Marlin/pull/22401 two pins where lost in the commit shuffle.
#define Z2_STOP_PIN                         PA13
#define Z_MIN_PROBE_PIN                   PG9

This adds them back

Support for Z2_STOP_PIN, Z3_STOP_PIN and Z4_STOP_PIN was also missing. Added this also

### Requirements

#define MOTHERBOARD BOARD_CHITU3D_V9

### Benefits

Z2_STOP_PIN and Z_MIN_PROBE_PIN work as expected 

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/22401