### PR TITLE
Correcting typo in menu_bed_corners.cpp

### DIFF
--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -179,7 +179,7 @@ static void _lcd_level_bed_corners_get_next_position() {
     // Display # of good points found vs total needed
     if (PAGE_CONTAINS(y - (MENU_FONT_HEIGHT), y)) {
       SETCURSOR(TERN(TFT_COLOR_UI, 2, 0), cy);
-      lcd_put_u8str_(GET_TEXT_F(MSG_BED_TRAMMING_GOOD_POINTS));
+      lcd_put_u8str(GET_TEXT_F(MSG_BED_TRAMMING_GOOD_POINTS));
       IF_ENABLED(TFT_COLOR_UI, lcd_moveto(12, cy));
       lcd_put_u8str(GOOD_POINTS_TO_STR(good_points));
       lcd_put_wchar('/');


### PR DESCRIPTION
Just fixing a build-blocking typo

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

This is a simple change to fix a typo introduced in #22837 that broke the build. I looked at other places `lcd_put_u8str` was changed and it's clear that this underscore was unintentional.

I've also made the change in my local branch and confirmed it works fine.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

None

### Benefits

This fixes a bug that otherwise prevents building in certain configurations

### Configurations

n/a

### Related Issues

#22891 
