### PR TITLE
Fix for MKS nano LVGL wifi maple test

### DIFF
--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -149,6 +149,12 @@ public:
   static bool enqueue_one(FSTR_P const fgcode);
 
   /**
+   * Enqueue with Serial Echo
+   * Return true on success
+   */
+  static bool enqueue_one(const char *cmd);
+
+  /**
    * Enqueue from program memory and return only when commands are actually enqueued
    */
   static void enqueue_now_P(PGM_P const pcmd);
@@ -252,12 +258,6 @@ private:
 
   // Process the next "immediate" command (SRAM)
   static bool process_injected_command();
-
-  /**
-   * Enqueue with Serial Echo
-   * Return true on success
-   */
-  static bool enqueue_one(const char *cmd);
 
   static void gcode_line_error(FSTR_P const ferr, const serial_index_t serial_ind);
 


### PR DESCRIPTION
Allow to build/pass mks_robin_nano35_maple LVGL test. Detected on my fork which still do this test in github CI.

cf https://github.com/tpruvot/Marlin/runs/3805080340?check_suite_focus=true

May not be the best way to fix it, but seems to build fine, moved this second enqueue_one() method to public section...