### PR TITLE
BTT GTR Fix LCD12864 timing

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -484,8 +484,8 @@
 
   // Alter timing for graphical display
   #if IS_U8GLIB_ST7920
-    #define BOARD_ST7920_DELAY_1              96
-    #define BOARD_ST7920_DELAY_2              48
+    #define BOARD_ST7920_DELAY_1             125
+    #define BOARD_ST7920_DELAY_2              90
     #define BOARD_ST7920_DELAY_3             600
   #endif
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

Fix LCD12864 timing, use the same as skr pro is working great

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

- BTT GTR 1.0
- LCD12864
- 
### Benefits

<!-- What does this PR fix or improve? -->

Fix Timing, No more flicker.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
Bug fix of the LCD display