### PR TITLE
Fix SKR Mini E3 V2 EEPROM

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -28,7 +28,10 @@
 // Onboard I2C EEPROM
 #if NO_EEPROM_SELECTED
   #define I2C_EEPROM
+  #define SOFT_I2C_EEPROM
   #define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
+  #define I2C_SDA_PIN                      SDA
+  #define I2C_SCL_PIN                      SCL
   #undef NO_EEPROM_SELECTED
 #endif
 


### PR DESCRIPTION
### Description

Fix sporadic EEPROM errors on the SKR Mini E3 V2.

### Requirements

SKR Mini E3 V2-based build.

### Benefits

Users won't have to disable the onboard EEPROM.

### Configurations

Any SKR Mini E3 V2-based build, but this will work: https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Creality/Ender-3/BigTreeTech%20SKR%20Mini%20E3%202.0

### Related Issues

#22524