### PR TITLE
FYSETC Cheetah v2.0 smaller bootloader and fix build bug

### DIFF
--- a/buildroot/share/PlatformIO/boards/marlin_FYSETC_CHEETAH_V20.json
+++ b/buildroot/share/PlatformIO/boards/marlin_FYSETC_CHEETAH_V20.json
@@ -14,7 +14,6 @@
         "0x3748"
       ]
     ],
-    "ldscript": "stm32f401rc.ld",
     "mcu": "stm32f401rct6",
     "variant": "MARLIN_FYSETC_CHEETAH_V20"
   },

--- a/buildroot/share/PlatformIO/boards/marlin_FYSETC_CHEETAH_V20.json
+++ b/buildroot/share/PlatformIO/boards/marlin_FYSETC_CHEETAH_V20.json
@@ -56,7 +56,7 @@
       "dfu",
       "jlink"
     ],
-	"offset_address": "0x800C000",
+	"offset_address": "0x8008000",
     "require_upload_port": true,
     "use_1200bps_touch": false,
     "wait_for_upload_port": false

--- a/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_CHEETAH_V20/ldscript.ld
+++ b/buildroot/share/PlatformIO/variants/MARLIN_FYSETC_CHEETAH_V20/ldscript.ld
@@ -61,7 +61,7 @@ _Min_Stack_Size = 0x400;; /* required amount of stack */
 /* Specify the memory areas */
 MEMORY
 {
-FLASH (rx)      : ORIGIN = 0x800C000, LENGTH = 256K
+FLASH (rx)      : ORIGIN = 0x8008000, LENGTH = 256K - 32K
 RAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 64K
 }
 

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -48,7 +48,7 @@ build_flags       = ${stm32_variant.build_flags}
 platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_FYSETC_CHEETAH_V20
-board_build.offset = 0xC000
+board_build.offset = 0x8000
 build_flags        = ${stm32_variant.build_flags} -DSTM32F401xC
 
 #


### PR DESCRIPTION
### Description

FYSETC Cheetah v2.0 don't have production yet, so it is free to change the boot offset to have a smaller bootloader flash consumption. And delete "ldscript": "stm32f401rc.ld" to fix the build error.
