### PR TITLE
Remove old G34 sanity check

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -3436,10 +3436,6 @@ static_assert(_PLUS_TEST(4), "HOMING_FEEDRATE_MM_M values must be positive.");
   #endif
 #endif
 
-#if BOTH(Z_STEPPER_AUTO_ALIGN, MECHANICAL_GANTRY_CALIBRATION)
-  #error "You cannot use Z_STEPPER_AUTO_ALIGN and MECHANICAL_GANTRY_CALIBRATION at the same time."
-#endif
-
 #if ENABLED(PRINTCOUNTER) && DISABLED(EEPROM_SETTINGS)
   #error "PRINTCOUNTER requires EEPROM_SETTINGS."
 #endif


### PR DESCRIPTION
### Description

Remove duplicate sanity check since it's now handled in the code block above it:

https://github.com/MarlinFirmware/Marlin/blob/90fa48ffd565ae28e8a0bfcf2d5f8b5a2de2e558/Marlin/src/inc/SanityCheck.h#L3431-L3432

### Related Issues

None. Found while [splitting up `G34` documentation](https://github.com/MarlinFirmware/MarlinDocumentation/pull/425).