### PR TITLE
Fix MKS Robin Pro 1.0 LCD reset pin

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_PRO.h
@@ -237,7 +237,7 @@
   #define TFT_CS_PIN                 FSMC_CS_PIN
   #define TFT_RS_PIN                 FSMC_RS_PIN
 
-  #define LCD_RESET_PIN                     PF6
+  #define LCD_RESET_PIN                     PC6
   #define LCD_BACKLIGHT_PIN                 PD13
 
   #define TFT_BUFFER_SIZE                  14400


### PR DESCRIPTION
### Description

Fix incorrect MKS Robin Pro 1.0 LCD reset pin. Edit: This was fixed [two years ago in MKS' repo](https://github.com/makerbase-mks/MKS-Robin-Pro/commit/b9d6f91a50d76ad802dbeaad01533598deb74806). Oops.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/22931