### PR TITLE
Update MKS UI for no bed, extruder

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -160,18 +160,16 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
     case ID_P_ABS:
       if (uiCfg.curTempType == 0)
         thermalManager.setTargetHotend(PREHEAT_2_TEMP_HOTEND, 0);
-      #if HAS_HEATED_BED
-      else if (uiCfg.curTempType == 1)
-        thermalManager.setTargetBed(PREHEAT_2_TEMP_BED);
-      #endif  //HAS_HEATED_BED
+      else if (uiCfg.curTempType == 1) {
+        TERN_(HAS_HEATED_BED, thermalManager.setTargetBed(PREHEAT_2_TEMP_BED));
+      }
       break;
     case ID_P_PLA:
       if (uiCfg.curTempType == 0)
         thermalManager.setTargetHotend(PREHEAT_1_TEMP_HOTEND, 0);
-      #if HAS_HEATED_BED
-      else if (uiCfg.curTempType == 1)
-        thermalManager.setTargetBed(PREHEAT_1_TEMP_BED);
-      #endif  //HAS_HEATED_BED
+      else if (uiCfg.curTempType == 1) {
+        TERN_(HAS_HEATED_BED, thermalManager.setTargetBed(PREHEAT_1_TEMP_BED));
+      }
       break;
   }
 }

--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -160,14 +160,18 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
     case ID_P_ABS:
       if (uiCfg.curTempType == 0)
         thermalManager.setTargetHotend(PREHEAT_2_TEMP_HOTEND, 0);
+      #if HAS_HEATED_BED
       else if (uiCfg.curTempType == 1)
         thermalManager.setTargetBed(PREHEAT_2_TEMP_BED);
+      #endif  //HAS_HEATED_BED
       break;
     case ID_P_PLA:
       if (uiCfg.curTempType == 0)
         thermalManager.setTargetHotend(PREHEAT_1_TEMP_HOTEND, 0);
+      #if HAS_HEATED_BED
       else if (uiCfg.curTempType == 1)
         thermalManager.setTargetBed(PREHEAT_1_TEMP_BED);
+      #endif  //HAS_HEATED_BED
       break;
   }
 }

--- a/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_preHeat.cpp
@@ -60,18 +60,20 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
   switch (obj->mks_obj_id) {
     case ID_P_ADD: {
       if (uiCfg.curTempType == 0) {
-        int16_t max_target;
-        thermalManager.temp_hotend[uiCfg.extruderIndex].target += uiCfg.stepHeat;
-        if (uiCfg.extruderIndex == 0)
-          max_target = HEATER_0_MAXTEMP - (WATCH_TEMP_INCREASE + TEMP_HYSTERESIS + 1);
-        else {
-          #if HAS_MULTI_HOTEND
-            max_target = HEATER_1_MAXTEMP - (WATCH_TEMP_INCREASE + TEMP_HYSTERESIS + 1);
-          #endif
-        }
-        if (thermalManager.degTargetHotend(uiCfg.extruderIndex) > max_target)
-          thermalManager.setTargetHotend(max_target, uiCfg.extruderIndex);
-        thermalManager.start_watching_hotend(uiCfg.extruderIndex);
+        #if HAS_HOTEND
+          int16_t max_target;
+          thermalManager.temp_hotend[uiCfg.extruderIndex].target += uiCfg.stepHeat;
+          if (uiCfg.extruderIndex == 0)
+            max_target = HEATER_0_MAXTEMP - (WATCH_TEMP_INCREASE + TEMP_HYSTERESIS + 1);
+          else {
+            #if HAS_MULTI_HOTEND
+              max_target = HEATER_1_MAXTEMP - (WATCH_TEMP_INCREASE + TEMP_HYSTERESIS + 1);
+            #endif
+          }
+          if (thermalManager.degTargetHotend(uiCfg.extruderIndex) > max_target)
+            thermalManager.setTargetHotend(max_target, uiCfg.extruderIndex);
+          thermalManager.start_watching_hotend(uiCfg.extruderIndex);
+        #endif
       }
       else {
         #if HAS_HEATED_BED
@@ -87,11 +89,13 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
 
     case ID_P_DEC:
       if (uiCfg.curTempType == 0) {
-        if (thermalManager.degTargetHotend(uiCfg.extruderIndex) > uiCfg.stepHeat)
-          thermalManager.temp_hotend[uiCfg.extruderIndex].target -= uiCfg.stepHeat;
-        else
-          thermalManager.setTargetHotend(0, uiCfg.extruderIndex);
-        thermalManager.start_watching_hotend(uiCfg.extruderIndex);
+        #if HAS_HOTEND
+          if (thermalManager.degTargetHotend(uiCfg.extruderIndex) > uiCfg.stepHeat)
+            thermalManager.temp_hotend[uiCfg.extruderIndex].target -= uiCfg.stepHeat;
+          else
+            thermalManager.setTargetHotend(0, uiCfg.extruderIndex);
+          thermalManager.start_watching_hotend(uiCfg.extruderIndex);
+        #endif
       }
       else {
         #if HAS_HEATED_BED
@@ -99,7 +103,6 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
             thermalManager.temp_bed.target -= uiCfg.stepHeat;
           else
             thermalManager.setTargetBed(0);
-
           thermalManager.start_watching_bed();
         #endif
       }
@@ -142,8 +145,10 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       break;
     case ID_P_OFF:
       if (uiCfg.curTempType == 0) {
-        thermalManager.setTargetHotend(0, uiCfg.extruderIndex);
-        thermalManager.start_watching_hotend(uiCfg.extruderIndex);
+        #if HAS_HOTEND
+          thermalManager.setTargetHotend(0, uiCfg.extruderIndex);
+          thermalManager.start_watching_hotend(uiCfg.extruderIndex);
+        #endif
       }
       else {
         #if HAS_HEATED_BED
@@ -158,15 +163,17 @@ static void event_handler(lv_obj_t *obj, lv_event_t event) {
       draw_return_ui();
       break;
     case ID_P_ABS:
-      if (uiCfg.curTempType == 0)
-        thermalManager.setTargetHotend(PREHEAT_2_TEMP_HOTEND, 0);
+      if (uiCfg.curTempType == 0) {
+        TERN_(HAS_HOTEND, thermalManager.setTargetHotend(PREHEAT_2_TEMP_HOTEND, 0));
+      }
       else if (uiCfg.curTempType == 1) {
         TERN_(HAS_HEATED_BED, thermalManager.setTargetBed(PREHEAT_2_TEMP_BED));
       }
       break;
     case ID_P_PLA:
-      if (uiCfg.curTempType == 0)
-        thermalManager.setTargetHotend(PREHEAT_1_TEMP_HOTEND, 0);
+      if (uiCfg.curTempType == 0) {
+        TERN_(HAS_HOTEND, thermalManager.setTargetHotend(PREHEAT_1_TEMP_HOTEND, 0));
+      }
       else if (uiCfg.curTempType == 1) {
         TERN_(HAS_HEATED_BED, thermalManager.setTargetBed(PREHEAT_1_TEMP_BED));
       }
@@ -229,14 +236,14 @@ void disp_ext_heart() {
 
 void disp_temp_type() {
   if (uiCfg.curTempType == 0) {
-    if (uiCfg.extruderIndex == 1) {
+    if (TERN0(HAS_MULTI_EXTRUDER, uiCfg.extruderIndex == 1)) {
       lv_imgbtn_set_src_both(buttonType, "F:/bmp_extru2.bin");
       if (gCfgItems.multiple_language) {
         lv_label_set_text(labelType, preheat_menu.ext2);
         lv_obj_align(labelType, buttonType, LV_ALIGN_IN_BOTTOM_MID, 0, BUTTON_TEXT_Y_OFFSET);
       }
     }
-    else {
+    else if (ENABLED(HAS_HOTEND)) {
       lv_imgbtn_set_src_both(buttonType, "F:/bmp_extru1.bin");
       if (gCfgItems.multiple_language) {
         lv_label_set_text(labelType, preheat_menu.ext1);
@@ -244,7 +251,7 @@ void disp_temp_type() {
       }
     }
   }
-  else {
+  else if (ENABLED(HAS_HEATED_BED)) {
     lv_imgbtn_set_src_both(buttonType, "F:/bmp_bed.bin");
     if (gCfgItems.multiple_language) {
       lv_label_set_text(labelType, preheat_menu.hotbed);
@@ -258,8 +265,10 @@ void disp_desire_temp() {
   public_buf_l[0] = '\0';
 
   if (uiCfg.curTempType == 0) {
-    strcat(public_buf_l, uiCfg.extruderIndex < 1 ? preheat_menu.ext1 : preheat_menu.ext2);
-    sprintf(buf, preheat_menu.value_state, thermalManager.wholeDegHotend(uiCfg.extruderIndex), thermalManager.degTargetHotend(uiCfg.extruderIndex));
+    #if HAS_HOTEND
+      strcat(public_buf_l, uiCfg.extruderIndex < 1 ? preheat_menu.ext1 : preheat_menu.ext2);
+      sprintf(buf, preheat_menu.value_state, thermalManager.wholeDegHotend(uiCfg.extruderIndex), thermalManager.degTargetHotend(uiCfg.extruderIndex));
+    #endif
   }
   else {
     #if HAS_HEATED_BED


### PR DESCRIPTION
### Description

With my configuration (with no heat bed) I'm getting compilation error. This changes fixes it by moving undefined function `thermalManager.setTargetBed(...)` inside conditional macro, which will be included to build only if heat bed exists.

Error:
```
Compiling .pio\build\mks_robin_nano35\src\src\lcd\extui\mks_ui\draw_preHeat.cpp.o
Marlin\src\lcd\extui\mks_ui\draw_preHeat.cpp: In function 'void event_handler(lv_obj_t*, lv_event_t)':
Marlin\src\lcd\extui\mks_ui\draw_preHeat.cpp:164:24: error: 'class Temperature' has no member named 'setTargetBed'; did you mean 'setTargetHotend'?
  164 |         thermalManager.setTargetBed(PREHEAT_2_TEMP_BED);
      |                        ^~~~~~~~~~~~
      |                        setTargetHotend
Marlin\src\lcd\extui\mks_ui\draw_preHeat.cpp:170:24: error: 'class Temperature' has no member named 'setTargetBed'; did you mean 'setTargetHotend'?
  170 |         thermalManager.setTargetBed(PREHEAT_1_TEMP_BED);
      |                        ^~~~~~~~~~~~
      |                        setTargetHotend
*** [.pio\build\mks_robin_nano35\src\src\lcd\extui\mks_ui\draw_preHeat.cpp.o] Error 1
```

This error started to appear after setting '#define TEMP_SENSOR_BED 0' in config file.

### Requirements

To check that compilation fails you don't need anything except my config files. I tested my solution on MKS robin nano 1.2 with display:
 
![image](https://user-images.githubusercontent.com/22222390/136863252-6524a844-7f38-45b4-82c9-ebb82af8ab9e.png)


### Benefits

Resolve compilation error

### Configurations

[configs.zip](https://github.com/saloid/Marlin/files/7325634/configs.zip)

