### PR TITLE
No Pin Aliases for SKR Mini E3 V2 I2C EEPROM

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h
@@ -30,8 +30,8 @@
   #define I2C_EEPROM
   #define SOFT_I2C_EEPROM
   #define MARLIN_EEPROM_SIZE 0x1000                 // 4KB
-  #define I2C_SDA_PIN                      SDA
-  #define I2C_SCL_PIN                      SCL
+  #define I2C_SDA_PIN                      PB7
+  #define I2C_SCL_PIN                      PB6
   #undef NO_EEPROM_SELECTED
 #endif
 


### PR DESCRIPTION
### Description

SDA/SCL aliases do not work with maple environments.

### Benefits

SKR Mini E3 V2 configs compiled under maple environments will work.

### Related Issues

- #22952
- #22524
- #22919
- #21964