### PR TITLE
Add option EVENT_GCODE_TOOLCHANGE_ALWAYS_RUN

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2314,6 +2314,8 @@
   //#define EVENT_GCODE_TOOLCHANGE_T0 "G28 A\nG1 A0" // Extra G-code to run while executing tool-change command T0
   //#define EVENT_GCODE_TOOLCHANGE_T1 "G1 A10"       // Extra G-code to run while executing tool-change command T1
 
+  //#define EVENT_GCODE_TOOLCHANGE_ALWAYS_RUN        // Force Event Gcode sequences above to always be executed. Use with caution!
+
   /**
    * Tool Sensors detect when tools have been picked up or dropped.
    * Requires the pins TOOL_SENSOR1_PIN, TOOL_SENSOR2_PIN, etc.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2313,8 +2313,7 @@
    */
   //#define EVENT_GCODE_TOOLCHANGE_T0 "G28 A\nG1 A0" // Extra G-code to run while executing tool-change command T0
   //#define EVENT_GCODE_TOOLCHANGE_T1 "G1 A10"       // Extra G-code to run while executing tool-change command T1
-
-  //#define EVENT_GCODE_TOOLCHANGE_ALWAYS_RUN        // Force Event Gcode sequences above to always be executed. Use with caution!
+  //#define EVENT_GCODE_TOOLCHANGE_ALWAYS_RUN        // Always execute above G-code sequences. Use with caution!
 
   /**
    * Tool Sensors detect when tools have been picked up or dropped.

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1307,7 +1307,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
 
     TERN_(HAS_FANMUX, fanmux_switch(active_extruder));
 
-    if (!no_move || TERN0(EVENT_GCODE_TOOLCHANGE_ALWAYS_RUN, true)) {
+    if (ENABLED(EVENT_GCODE_TOOLCHANGE_ALWAYS_RUN) || !no_move) {
       #ifdef EVENT_GCODE_TOOLCHANGE_T0
         if (new_tool == 0)
           gcode.process_subcommands_now(F(EVENT_GCODE_TOOLCHANGE_T0));

--- a/Marlin/src/module/tool_change.cpp
+++ b/Marlin/src/module/tool_change.cpp
@@ -1307,7 +1307,7 @@ void tool_change(const uint8_t new_tool, bool no_move/*=false*/) {
 
     TERN_(HAS_FANMUX, fanmux_switch(active_extruder));
 
-    if (!no_move) {
+    if (!no_move || TERN0(EVENT_GCODE_TOOLCHANGE_ALWAYS_RUN, true)) {
       #ifdef EVENT_GCODE_TOOLCHANGE_T0
         if (new_tool == 0)
           gcode.process_subcommands_now(F(EVENT_GCODE_TOOLCHANGE_T0));


### PR DESCRIPTION
Implements request in #22957 and allows tool change event GCode to be forced to run regardless of no_move. May be required if setting servo angles or other commands not involving stepper motion.