### PR TITLE
fix mmu1 compile errors

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -216,6 +216,10 @@
   #include "feature/controllerfan.h"
 #endif
 
+#if HAS_PRUSA_MMU1
+  #include "feature/mmu/mmu.h"
+#endif
+
 #if HAS_PRUSA_MMU2
   #include "feature/mmu/mmu2.h"
 #endif

--- a/Marlin/src/feature/mmu/mmu.cpp
+++ b/Marlin/src/feature/mmu/mmu.cpp
@@ -24,9 +24,9 @@
 
 #if HAS_PRUSA_MMU1
 
-#include "../MarlinCore.h"
-#include "../module/planner.h"
-#include "../module/stepper.h"
+#include "../../MarlinCore.h"
+#include "../../module/planner.h"
+#include "../../module/stepper.h"
 
 void mmu_init() {
   SET_OUTPUT(E_MUX0_PIN);


### PR DESCRIPTION
### Description

If you enable PRUSA_MMU1 Marlin fails to compile.

```
src\src\MarlinCore.cpp: In function 'void setup()':
src\src\MarlinCore.cpp:1464:15: error: 'mmu_init' was not declared in this scope
SETUP_RUN(mmu_init());
```
This fixes this issue

### Requirements

base ramps config 
#define EXTRUDERS 2
#define SINGLENOZZLE
#define MMU_MODEL PRUSA_MMU1

### Benefits

Compiles as expected

### Related Issues

In the completely wrong repository...  https://github.com/MarlinFirmware/Configurations/issues/590