### PR TITLE
Allow coreXY conf when only two axis are enabled

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2150,10 +2150,10 @@
 #if _HAS_STOP(Y,MAX)
   #define HAS_Y_MAX 1
 #endif
-#if _HAS_STOP(Z,MIN)
+#if HAS_Z_AXIS && _HAS_STOP(Z,MIN)
   #define HAS_Z_MIN 1
 #endif
-#if _HAS_STOP(Z,MAX)
+#if HAS_Z_AXIS && _HAS_STOP(Z,MAX)
   #define HAS_Z_MAX 1
 #endif
 #if _HAS_STOP(I,MIN)

--- a/Marlin/src/libs/vector_3.h
+++ b/Marlin/src/libs/vector_3.h
@@ -76,7 +76,9 @@ struct vector_3 {
   vector_3 operator*(const float &v)    { return vector_3(x * v, y * v, z * v); }
 
   operator xy_float_t() { return xy_float_t({ x, y }); }
+  #ifdef HAS_Z_AXIS
   operator xyz_float_t() { return xyz_float_t({ x, y, z }); }
+  #endif
 
   void debug(PGM_P const title);
 };

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1917,7 +1917,9 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
   #if CORE_IS_XY
     if (da < 0) SBI(dm, X_HEAD);                // Save the toolhead's true direction in X
     if (db < 0) SBI(dm, Y_HEAD);                // ...and Y
+    #if HAS_Z_AXIS
     if (dc < 0) SBI(dm, Z_AXIS);
+    #endif
     if (da + db < 0) SBI(dm, A_AXIS);           // Motor A direction
     if (CORESIGN(da - db) < 0) SBI(dm, B_AXIS); // Motor B direction
   #elif CORE_IS_XZ
@@ -2017,7 +2019,9 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
     #if CORE_IS_XY
       steps_dist_mm.head.x = da * mm_per_step[A_AXIS];
       steps_dist_mm.head.y = db * mm_per_step[B_AXIS];
+      #if HAS_Z_AXIS
       steps_dist_mm.z      = dc * mm_per_step[Z_AXIS];
+      #endif
       steps_dist_mm.a      = (da + db) * mm_per_step[A_AXIS];
       steps_dist_mm.b      = CORESIGN(da - db) * mm_per_step[B_AXIS];
     #elif CORE_IS_XZ
@@ -2163,7 +2167,7 @@ bool Planner::_populate_block(block_t * const block, bool split_move,
       stepper.enable_axis(X_AXIS);
       stepper.enable_axis(Y_AXIS);
     }
-    #if DISABLED(Z_LATE_ENABLE)
+    #if DISABLED(Z_LATE_ENABLE) && HAS_Z_AXIS
       if (block->steps.z) stepper.enable_axis(Z_AXIS);
     #endif
   #elif CORE_IS_XZ

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -2804,7 +2804,11 @@ void Stepper::_set_position(const abce_long_t &spos) {
     #if CORE_IS_XY
       // corexy positioning
       // these equations follow the form of the dA and dB equations on https://www.corexy.com/theory.html
+      #if HAS_Z_AXIS
       count_position.set(spos.a + spos.b, CORESIGN(spos.a - spos.b), spos.c);
+      #else
+      count_position.set(spos.a + spos.b, CORESIGN(spos.a - spos.b));
+      #endif
     #elif CORE_IS_XZ
       // corexz planning
       count_position.set(spos.a + spos.c, spos.b, CORESIGN(spos.a - spos.c));


### PR DESCRIPTION
### Description
When setting the amount of axis to two (`#define LINEAR_AXES 2`)  have no extruder (`#define EXTRUDERS 0`) and using CoreXY (`#define COREXY`) the compilation fails because several parts of the code are not written in a way that they understand the missing z axis. The attached PR makes Marlin compile and work when setting those two options. The setup of not having an extruder and only two axis is typical for pen plotters, laser cutters and other drawing robots which only operate on two axis (typically with a servo for a partly third axis). 

An example minimal configuration is here:
https://gist.github.com/theomega/8f516532a1792e197beef984872106d7

Without this patch, you get the following compilation errors:
```
In file included from /Users/dominikbruhn/.platformio/packages/framework-arduino-avr/cores/arduino/Arduino.h:28:0,
                 from Marlin/src/module/../inc/../HAL/./AVR/../shared/Marduino.h:36,
                 from Marlin/src/module/../inc/../HAL/./AVR/HAL.h:22,
                 from Marlin/src/module/../inc/../HAL/HAL.h:30,
                 from Marlin/src/module/../inc/MarlinConfig.h:31,
                 from Marlin/src/module/endstops.h:28,
                 from Marlin/src/module/endstops.cpp:27:
Marlin/src/module/endstops.cpp: In static member function 'static void Endstops::report_states()':
Marlin/src/module/endstops.cpp:499:84: error: 'STR_Z_MIN' was not declared in this scope
   #define ES_REPORT(S) print_es_state(READ(S##_PIN) != S##_ENDSTOP_INVERTING, PSTR(STR_##S))
                                                                                    ^
Marlin/src/module/endstops.cpp:525:5: note: in expansion of macro 'ES_REPORT'
     ES_REPORT(Z_MIN);
     ^~~~~~~~~
Marlin/src/module/endstops.cpp:499:84: note: suggested alternative: 'STR_Y_MIN'
   #define ES_REPORT(S) print_es_state(READ(S##_PIN) != S##_ENDSTOP_INVERTING, PSTR(STR_##S))
                                                                                    ^
Marlin/src/module/endstops.cpp:525:5: note: in expansion of macro 'ES_REPORT'
     ES_REPORT(Z_MIN);
     ^~~~~~~~~
In file included from Marlin/src/module/settings.cpp:54:0:
Marlin/src/module/../libs/vector_3.h: In member function 'vector_3::operator xyz_float_t()':
Marlin/src/module/../libs/vector_3.h:79:58: error: no matching function for call to 'XYZval<float>::XYZval(<brace-enclosed initializer list>)'
   operator xyz_float_t() { return xyz_float_t({ x, y, z }); }
                                                          ^
In file included from Marlin/src/module/../inc/MarlinConfig.h:47:0,
                 from Marlin/src/module/settings.h:28,
                 from Marlin/src/module/settings.cpp:46:
Marlin/src/module/../inc/../core/types.h:389:8: note: candidate: XYZval<float>::XYZval()
 struct XYZval {
        ^~~~~~
Marlin/src/module/../inc/../core/types.h:389:8: note:   candidate expects 0 arguments, 1 provided
Marlin/src/module/../inc/../core/types.h:389:8: note: candidate: constexpr XYZval<float>::XYZval(const XYZval<float>&)
Marlin/src/module/../inc/../core/types.h:389:8: note:   no known conversion for argument 1 from '<brace-enclosed initializer list>' to 'const XYZval<float>&'
Marlin/src/module/../inc/../core/types.h:389:8: note: candidate: constexpr XYZval<float>::XYZval(XYZval<float>&&)
Marlin/src/module/../inc/../core/types.h:389:8: note:   no known conversion for argument 1 from '<brace-enclosed initializer list>' to 'XYZval<float>&&'
*** [.pio/build/mega2560/src/src/module/endstops.cpp.o] Error 1
Marlin/src/module/planner.cpp: In static member function 'static bool Planner::_populate_block(block_t*, bool, const abce_long_t&, feedRate_t, uint8_t, const_float_t)':
Marlin/src/module/planner.cpp:1920:9: error: 'dc' was not declared in this scope
     if (dc < 0) SBI(dm, Z_AXIS);
         ^~
Marlin/src/module/planner.cpp:1920:9: note: suggested alternative: 'dm'
     if (dc < 0) SBI(dm, Z_AXIS);
         ^~
         dm
In file included from Marlin/src/module/../inc/../HAL/./AVR/HAL.h:22:0,
                 from Marlin/src/module/../inc/../HAL/HAL.h:30,
                 from Marlin/src/module/../inc/MarlinConfig.h:31,
                 from Marlin/src/module/../MarlinCore.h:24,
                 from Marlin/src/module/planner.h:33,
                 from Marlin/src/module/planner.cpp:65:
Marlin/src/module/planner.cpp:1920:25: error: 'Z_AXIS' was not declared in this scope
     if (dc < 0) SBI(dm, Z_AXIS);
                         ^
Marlin/src/module/../inc/../HAL/./AVR/../shared/Marduino.h:42:25: note: in definition of macro '_BV'
 #define _BV(b) (1UL << (b))
                         ^
Marlin/src/module/planner.cpp:1920:17: note: in expansion of macro 'SBI'
     if (dc < 0) SBI(dm, Z_AXIS);
                 ^~~
Marlin/src/module/planner.cpp:1920:25: note: suggested alternative: 'B_AXIS'
     if (dc < 0) SBI(dm, Z_AXIS);
                         ^
Marlin/src/module/../inc/../HAL/./AVR/../shared/Marduino.h:42:25: note: in definition of macro '_BV'
 #define _BV(b) (1UL << (b))
                         ^
Marlin/src/module/planner.cpp:1920:17: note: in expansion of macro 'SBI'
     if (dc < 0) SBI(dm, Z_AXIS);
                 ^~~
Marlin/src/module/planner.cpp:2020:21: error: 'struct Planner::_populate_block(block_t*, bool, const abce_long_t&, feedRate_t, uint8_t, const_float_t)::DistanceMM' has no member named 'z'
       steps_dist_mm.z      = dc * mm_per_step[Z_AXIS];
                     ^
Marlin/src/module/planner.cpp:2020:30: error: 'dc' was not declared in this scope
       steps_dist_mm.z      = dc * mm_per_step[Z_AXIS];
                              ^~
Marlin/src/module/planner.cpp:2020:30: note: suggested alternative: 'dm'
       steps_dist_mm.z      = dc * mm_per_step[Z_AXIS];
                              ^~
                              dm
Marlin/src/module/planner.cpp:2020:47: error: 'Z_AXIS' was not declared in this scope
       steps_dist_mm.z      = dc * mm_per_step[Z_AXIS];
                                               ^~~~~~
Marlin/src/module/planner.cpp:2020:47: note: suggested alternative: 'B_AXIS'
       steps_dist_mm.z      = dc * mm_per_step[Z_AXIS];
                                               ^~~~~~
                                               B_AXIS
compilation terminated due to -fmax-errors=5.
*** [.pio/build/mega2560/src/src/module/settings.cpp.o] Error 1
*** [.pio/build/mega2560/src/src/module/planner.cpp.o] Error 1
Marlin/src/module/stepper.cpp: In static member function 'static void Stepper::_set_position(const abce_long_t&)':
Marlin/src/module/stepper.cpp:2807:75: error: 'const abce_long_t {aka const struct XYZEval<long int>}' has no member named 'c'
       count_position.set(spos.a + spos.b, CORESIGN(spos.a - spos.b), spos.c);
                                                                           ^
*** [.pio/build/mega2560/src/src/module/stepper.cpp.o] Error 1
```

### Requirements

This should work for all all platforms and boards.

### Benefits

See above, compilation does not fail if the user decides to only have two axis and no extruder.

### Configurations

This configuration fails without the patch but works with it:
https://gist.github.com/theomega/8f516532a1792e197beef984872106d7