### PR TITLE
Fix 'pio vscode init' detection, Lerdge encrypt, MKS Assets URL

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -2,7 +2,12 @@
 # common-dependencies.py
 # Convenience script to check dependencies and add libs and sources for Marlin Enabled Features
 #
-import subprocess,os,re
+import subprocess,os,re,pioutil
+Import("env")
+
+# Detect that 'vscode init' is running
+if pioutil.is_vscode_init():
+	env.Exit(0)
 
 PIO_VERSION_MIN = (5, 0, 3)
 try:
@@ -30,8 +35,6 @@ except:
 
 from platformio.package.meta import PackageSpec
 from platformio.project.config import ProjectConfig
-
-Import("env")
 
 #print(env.Dump())
 

--- a/buildroot/share/PlatformIO/scripts/download_mks_assets.py
+++ b/buildroot/share/PlatformIO/scripts/download_mks_assets.py
@@ -3,10 +3,15 @@
 # Added by HAS_TFT_LVGL_UI to download assets from Makerbase repo
 #
 Import("env")
-import os,requests,zipfile,tempfile,shutil
+import os,requests,zipfile,tempfile,shutil,pioutil
 
-url = "https://github.com/makerbase-mks/Mks-Robin-Nano-Marlin2.0-Firmware/archive/master.zip"
-zip_path = os.path.join(env.Dictionary("PROJECT_LIBDEPS_DIR"), "mks-assets.zip")
+# Detect that 'vscode init' is running
+if pioutil.is_vscode_init():
+	env.Exit(0)
+
+url = "https://github.com/makerbase-mks/Mks-Robin-Nano-Marlin2.0-Firmware/archive/0263cdaccf.zip"
+deps_path = env.Dictionary("PROJECT_LIBDEPS_DIR")
+zip_path = os.path.join(deps_path, "mks-assets.zip")
 assets_path = os.path.join(env.Dictionary("PROJECT_BUILD_DIR"), env.Dictionary("PIOENV"), "assets")
 
 def download_mks_assets():
@@ -14,8 +19,8 @@ def download_mks_assets():
 	r = requests.get(url, stream=True)
 	# the user may have a very clean workspace,
 	# so create the PROJECT_LIBDEPS_DIR directory if not exits
-	if os.path.exists(env.Dictionary("PROJECT_LIBDEPS_DIR")) == False:
-		os.mkdir(env.Dictionary("PROJECT_LIBDEPS_DIR"))
+	if os.path.exists(deps_path) == False:
+		os.mkdir(deps_path)
 	with open(zip_path, 'wb') as fd:
 		for chunk in r.iter_content(chunk_size=128):
 			fd.write(chunk)

--- a/buildroot/share/PlatformIO/scripts/lerdge.py
+++ b/buildroot/share/PlatformIO/scripts/lerdge.py
@@ -12,37 +12,36 @@ from SCons.Script import DefaultEnvironment
 board = DefaultEnvironment().BoardConfig()
 
 def encryptByte(byte):
-    byte = 0xFF & ((byte << 6) | (byte >> 2))
-    i = 0x58 + byte
-    j = 0x05 + byte + (i >> 8)
-    byte = (0xF8 & i) | (0x07 & j)
-    return byte
+	byte = 0xFF & ((byte << 6) | (byte >> 2))
+	i = 0x58 + byte
+	j = 0x05 + byte + (i >> 8)
+	byte = (0xF8 & i) | (0x07 & j)
+	return byte
 
 def encrypt_file(input, output_file, file_length):
-    input_file = bytearray(input.read())
-    for i in range(len(input_file)):
-        result = encryptByte(input_file[i])
-        input_file[i] = result
-
-    output_file.write(input_file)
-    return
+	input_file = bytearray(input.read())
+	for i in range(len(input_file)):
+		input_file[i] = encryptByte(input_file[i])
+	output_file.write(input_file)
 
 # Encrypt ${PROGNAME}.bin and save it with the name given in build.encrypt
 def encrypt(source, target, env):
-    fwname = board.get("build.encrypt")
-    print("Encrypting %s to %s" % (target[0].path, fwname))
-    firmware = open(target[0].path, "rb")
-    renamed = open(target[0].dir.path + "/" + fwname, "wb")
-    length = os.path.getsize(target[0].path)
+	fwpath = target[0].path
+	enname = board.get("build.encrypt")
+	print("Encrypting %s to %s" % (fwpath, enname))
+	fwfile = open(fwpath, "rb")
+	enfile = open(target[0].dir.path + "/" + enname, "wb")
+	length = os.path.getsize(fwpath)
 
-    encrypt_file(firmware, renamed, length)
+	encrypt_file(fwfile, enfile, length)
 
-    firmware.close()
-    renamed.close()
+	fwfile.close()
+	enfile.close()
+	os.remove(fwpath)
 
 if 'encrypt' in board.get("build").keys():
-    if board.get("build.encrypt") != "":
-        marlin.add_post_action(encrypt)
+	if board.get("build.encrypt") != "":
+		marlin.add_post_action(encrypt)
 else:
-    print("LERDGE builds require output file via board_build.encrypt = 'filename' parameter")
-    exit(1)
+	print("LERDGE builds require output file via board_build.encrypt = 'filename' parameter")
+	exit(1)

--- a/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/buildroot/share/PlatformIO/scripts/marlin.py
@@ -48,22 +48,24 @@ def encrypt_mks(source, target, env, new_name):
 
 	key = [0xA3, 0xBD, 0xAD, 0x0D, 0x41, 0x11, 0xBB, 0x8D, 0xDC, 0x80, 0x2D, 0xD0, 0xD2, 0xC4, 0x9B, 0x1E, 0x26, 0xEB, 0xE3, 0x33, 0x4A, 0x15, 0xE4, 0x0A, 0xB3, 0xB1, 0x3C, 0x93, 0xBB, 0xAF, 0xF7, 0x3E]
 
-	firmware = open(target[0].path, "rb")
-	renamed = open(target[0].dir.path + "/" + new_name, "wb")
-	length = os.path.getsize(target[0].path)
+	fwpath = target[0].path
+	fwfile = open(fwpath, "rb")
+	enfile = open(target[0].dir.path + "/" + new_name, "wb")
+	length = os.path.getsize(fwpath)
 	position = 0
 	try:
 		while position < length:
-			byte = firmware.read(1)
+			byte = fwfile.read(1)
 			if position >= 320 and position < 31040:
 				byte = chr(ord(byte) ^ key[position & 31])
 				if sys.version_info[0] > 2:
 					byte = bytes(byte, 'latin1')
-			renamed.write(byte)
+			enfile.write(byte)
 			position += 1
 	finally:
-		firmware.close()
-		renamed.close()
+		fwfile.close()
+		enfile.close()
+		os.remove(fwpath)
 
 def add_post_action(action):
 	env.AddPostAction(join("$BUILD_DIR", "${PROGNAME}.bin"), action);

--- a/buildroot/share/PlatformIO/scripts/pioutil.py
+++ b/buildroot/share/PlatformIO/scripts/pioutil.py
@@ -1,0 +1,8 @@
+#
+# buildroot/share/PlatformIO/scripts/pioutil.py
+#
+
+# Detect that 'vscode init' is running
+def is_vscode_init():
+	from SCons.Script import COMMAND_LINE_TARGETS
+	return "idedata" in COMMAND_LINE_TARGETS or "_idedata" in COMMAND_LINE_TARGETS

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -2,8 +2,12 @@
 # preflight-checks.py
 # Check for common issues prior to compiling
 #
-import os,re,sys
+import os,re,sys,pioutil
 Import("env")
+
+# Detect that 'vscode init' is running
+if pioutil.is_vscode_init():
+	env.Exit(0)
 
 def get_envs_for_board(board):
 	with open(os.path.join("Marlin", "src", "pins", "pins.h"), "r") as file:
@@ -94,7 +98,4 @@ def sanity_check_target():
 		err = "ERROR: Old files fell into your Marlin folder. Remove %s and try again" % ", ".join(mixedin)
 		raise SystemExit(err)
 
-# Detect that 'vscode init' is running
-from SCons.Script import COMMAND_LINE_TARGETS
-if "idedata" not in COMMAND_LINE_TARGETS:
-	sanity_check_target()
+sanity_check_target()

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -263,13 +263,13 @@ platform            = ${common_stm32.platform}
 extends             = stm32_variant
 board               = marlin_STM32F407ZGT6
 board_build.variant = MARLIN_LERDGE
-board_build.encrypt = firmware.bin
 board_build.offset  = 0x10000
 build_flags         = ${stm32_variant.build_flags}
                       -DSTM32F4 -DSTM32F4xx -DTARGET_STM32F4
                       -DDISABLE_GENERIC_SERIALUSB -DARDUINO_ARCH_STM32 -DLERDGE_TFT35
 build_unflags       = ${stm32_variant.build_unflags} -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
-extra_scripts       = ${stm32_variant.extra_scripts}
+extra_scripts       = ${common_stm32.extra_scripts}
+                      pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
                       buildroot/share/PlatformIO/scripts/lerdge.py
 
 #


### PR DESCRIPTION
- PlatformIO IDE integration has been updated so the `idedata` field is now called `_idedata`. Add a single up-to-date utility function to check for `pio vscode init` and apply it where we now do `vscode init` detection.
- Ensure that the `lerdge.py` script replaces `offset_and_rename.py` under the `lerdge_common` environment, since they both do the same thing, and only the `lerdge.py` version of `encrypt` should be applied.
- The @makerbase-mks branch `Mks-Robin-Nano-Marlin2.0-Firmware` was updated, removing the `Firmware` subfolder which contains binary assets. The URL is updated to point to the last commit containing those assets.

CC: @tpruvot
