### PR TITLE
Enable CI for 2.0.x branch

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -8,7 +8,7 @@ name: CI
 on:
   pull_request:
     branches:
-    - bugfix-2.0.x
+    - 2.0.x
     paths-ignore:
     - config/**
     - data/**
@@ -16,7 +16,7 @@ on:
     - '**/*.md'
   push:
     branches:
-    - bugfix-2.0.x
+    - 2.0.x
     paths-ignore:
     - config/**
     - data/**


### PR DESCRIPTION
### Description

CI is enabled correctly for `bugfix-2.0.x` ([here](https://github.com/MarlinFirmware/Marlin/blob/52edc543bd72bfacb4ac6eb47eae2e466dcce62d/.github/workflows/test-builds.yml)), but not the `2.0.x` branch.

### Benefits

CI will now run/check the `2.0.x` branch.