### PR TITLE
Fix babystep overlay on MarlinUI-DWIN

### DIFF
--- a/Marlin/src/lcd/e3v2/common/dwin_api.cpp
+++ b/Marlin/src/lcd/e3v2/common/dwin_api.cpp
@@ -23,11 +23,6 @@
 
 #if EITHER(HAS_DWIN_E3V2, IS_DWIN_MARLINUI)
 
-#if ENABLED(DWIN_MARLINUI_LANDSCAPE)
-  #define DWIN_WIDTH  480
-  #define DWIN_HEIGHT 272
-#endif
-
 #include "dwin_api.h"
 #include "dwin_set.h"
 

--- a/Marlin/src/lcd/e3v2/common/dwin_api.cpp
+++ b/Marlin/src/lcd/e3v2/common/dwin_api.cpp
@@ -23,6 +23,11 @@
 
 #if EITHER(HAS_DWIN_E3V2, IS_DWIN_MARLINUI)
 
+#if ENABLED(DWIN_MARLINUI_LANDSCAPE)
+  #define DWIN_WIDTH  480
+  #define DWIN_HEIGHT 272
+#endif
+
 #include "dwin_api.h"
 #include "dwin_set.h"
 

--- a/Marlin/src/lcd/e3v2/common/dwin_api.h
+++ b/Marlin/src/lcd/e3v2/common/dwin_api.h
@@ -23,10 +23,11 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#ifndef DWIN_WIDTH
+#if ENABLED(DWIN_MARLINUI_LANDSCAPE)
+  #define DWIN_WIDTH  480
+  #define DWIN_HEIGHT 272
+#else
   #define DWIN_WIDTH  272
-#endif
-#ifndef DWIN_HEIGHT
   #define DWIN_HEIGHT 480
 #endif
 

--- a/Marlin/src/lcd/e3v2/creality/dwin_lcd.h
+++ b/Marlin/src/lcd/e3v2/creality/dwin_lcd.h
@@ -29,9 +29,6 @@
  * @brief    迪文屏控制操作函数
  ********************************************************************************/
 
-#define DWIN_WIDTH  272
-#define DWIN_HEIGHT 480
-
 #include "../common/dwin_api.h"
 #include "../common/dwin_set.h"
 #include "../common/dwin_font.h"

--- a/Marlin/src/lcd/e3v2/marlinui/dwin_lcd.h
+++ b/Marlin/src/lcd/e3v2/marlinui/dwin_lcd.h
@@ -28,11 +28,6 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
-#if ENABLED(DWIN_MARLINUI_LANDSCAPE)
-  #define DWIN_WIDTH  480
-  #define DWIN_HEIGHT 272
-#endif
-
 #include "../common/dwin_api.h"
 
 // Picture ID


### PR DESCRIPTION
### Description

The icon positions of the BABYSTEP_ZPROBE_GFX_OVERLAY under DWIN_MARLINUI_LANDSCAPE  for the right hand side are not in the correct position.

dwin_api.cpp doesnt check for DWIN_MARLINUI_LANDSCAPE  then it includes 
dwin_api.h in PORTRAIT mode.

All icon positions that goes through DWIN_ICON_Show, the macro 
  NOMORE(x, DWIN_WIDTH - 1);

truncates x to 272 pixels when it should be 400.

### Requirements

Ender3v2 DWN LCD

### Benefits

Fixes issue #22969
Icons on right hand side like intended. 

### Configurations
Stock ender3v2 
Enable FIX_MOUNTED_PROBE
Enable Z_SAFE_HOMING
Enable DWIN_MARLINUI_LANDSCAPE.
Enable BABYSTEP_ZPROBE_GFX_OVERLAY.

### Related Issues
More info can be found in https://github.com/MarlinFirmware/Marlin/issues/22969

### NOTE
This only fixes DWIN_MARLINUI_LANDSCAPE, DWIN_MARLINUI_PORTRAIT need a bit more work.