### PR TITLE
Fix probe temp compensation maths

### DIFF
--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -156,11 +156,6 @@ bool ProbeTempComp::finish_calibration(const TempSensorID tsi) {
 }
 
 void ProbeTempComp::compensate_measurement(const TempSensorID tsi, const celsius_t temp, float &meas_z) {
-  if (WITHIN(temp, cali_info[tsi].start_temp, cali_info[tsi].end_temp))
-    meas_z -= get_offset_for_temperature(tsi, temp);
-}
-
-float ProbeTempComp::get_offset_for_temperature(const TempSensorID tsi, const celsius_t temp) {
   const uint8_t measurements = cali_info[tsi].measurements;
   const celsius_t start_temp = cali_info[tsi].start_temp,
                     res_temp = cali_info[tsi].temp_res;
@@ -194,8 +189,8 @@ float ProbeTempComp::get_offset_for_temperature(const TempSensorID tsi, const ce
     else
       offset = linear_interp(temp, point(idx), point(idx + 1));
 
-  // return offset in mm
-  return offset / 1000.0f;
+  // convert offset to mm and apply it
+  meas_z -= offset / 1000.0f;
 }
 
 bool ProbeTempComp::linear_regression(const TempSensorID tsi, float &k, float &d) {

--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -166,7 +166,7 @@ void ProbeTempComp::compensate_measurement(const TempSensorID tsi, const celsius
   };
 
   auto linear_interp = [](const_float_t x, xy_float_t p1, xy_float_t p2) {
-    return (p2.y - p1.y) / (p2.x - p2.y) * (x - p1.x) + p1.y;
+    return (p2.y - p1.y) / (p2.x - p1.x) * (x - p1.x) + p1.y;
   };
 
   // Linear interpolation

--- a/Marlin/src/feature/probe_temp_comp.cpp
+++ b/Marlin/src/feature/probe_temp_comp.cpp
@@ -174,7 +174,7 @@ void ProbeTempComp::compensate_measurement(const TempSensorID tsi, const celsius
 
   // Given a data index, return { celsius, zoffset } in the form { x, y }
   auto tpoint = [&](uint8_t i) -> xy_float_t {
-    return xy_float_t({ static_cast<float>(start_temp) + i * res_temp, TERN(i == 0, 0.0f, static_cast<float>(data[i - 1])) });
+    return xy_float_t({ static_cast<float>(start_temp) + i * res_temp, i ? static_cast<float>(data[i - 1]) : 0.0f });
   };
 
   // Interpolate Z based on a temperature being within a given range

--- a/Marlin/src/feature/probe_temp_comp.h
+++ b/Marlin/src/feature/probe_temp_comp.h
@@ -135,8 +135,6 @@ class ProbeTempComp {
      */
     static float init_measurement;
 
-    static float get_offset_for_temperature(const TempSensorID tsi, const celsius_t temp);
-
     /**
      * Fit a linear function in measured temperature offsets
      * to allow generating values of higher temperatures.

--- a/Marlin/src/feature/probe_temp_comp.h
+++ b/Marlin/src/feature/probe_temp_comp.h
@@ -33,9 +33,9 @@ enum TempSensorID : uint8_t {
 };
 
 typedef struct {
-  uint8_t measurements; // Max. number of measurements to be stored (35 - 80°C)
-  celsius_t temp_res,   // Resolution in °C between measurements
-            start_temp, // Base measurement; z-offset == 0
+  uint8_t measurements;       // Max. number of measurements to be stored (35 - 80°C)
+  celsius_t temp_resolution,  // Resolution in °C between measurements
+            start_temp,       // Base measurement; z-offset == 0
             end_temp;
 } temp_calib_t;
 

--- a/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M192_M871.cpp
@@ -121,7 +121,7 @@ void GcodeSuite::G76() {
         temp_comp.prepare_new_calibration(measured_z);
       else
         temp_comp.push_back_new_measurement(sid, measured_z);
-      targ += cali_info_init[sid].temp_res;
+      targ += cali_info_init[sid].temp_resolution;
     }
     return measured_z;
   };


### PR DESCRIPTION
### Description

Fixed 4 small bugs in the same section of the probe temperature compensation code. This code interpolates between z offsets which have been measured at different probe and bed temperatures and applies a correction to the measured bed height when levelling. There were 4 errors in this code which resulted in incorrect offsets being calculated.

### Requirements

A probe with a built-in temperature sensor such as PINDA v2.

Send the following gcode:
```gcode
m871 p i1 v1000
m871 p i2 v2000
m871 p i3 v3000
m871 p i4 v4000
m871 p i5 v5000
m871 p i6 v6000
m871 p i7 v7000
m871 p i8 v8000
m871 p i9 v9000
m871 p i10 v11000
m871
```
the debug statements I have added to probe_temp_comp.cpp (in the zip file below) will give the wrong results.

### Benefits

Better bed levelling.

### Configurations

[23002files.zip](https://github.com/MarlinFirmware/Marlin/files/7400876/23002files.zip)

### Related Issues

Issue #23002. 