### PR TITLE
Add USE_TEMP_EXT_COMPENSATION options

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2006,7 +2006,7 @@
     #define PTC_PROBE_POS  { 90, 100 }
 
     // Enable additional compensation using hotend temperature
-    // Note: this values cannot be calibrated automatically but have to be set manually
+    // Note: this values cannot be calibrated automatically but have to be set manually via M871.
     //#define USE_TEMP_EXT_COMPENSATION
 
     // Probe temperature calibration generates a table of values starting at PTC_SAMPLE_START
@@ -2021,6 +2021,12 @@
     //#define BTC_SAMPLE_START  60  // (°C)
     //#define BTC_SAMPLE_RES     5  // (°C)
     //#define BTC_SAMPLE_COUNT  10
+
+    #if ENABLED(USE_TEMP_EXT_COMPENSATION)
+      //#define ETC_SAMPLE_START 180  // (°C)
+      //#define ETC_SAMPLE_RES     5  // (°C)
+      //#define ETC_SAMPLE_COUNT  20
+    #endif
 
     // The temperature the probe should be at while taking measurements during bed temperature
     // calibration.

--- a/Marlin/src/feature/probe_temp_comp.h
+++ b/Marlin/src/feature/probe_temp_comp.h
@@ -72,6 +72,20 @@ typedef struct {
 #endif
 #define BTC_SAMPLE_END (BTC_SAMPLE_START + (BTC_SAMPLE_COUNT) * BTC_SAMPLE_RES)
 
+// Extruder temperature calibration constants
+#if ENABLED(USE_TEMP_EXT_COMPENSATION)
+  #ifndef ETC_SAMPLE_COUNT
+    #define ETC_SAMPLE_COUNT 20
+  #endif
+  #ifndef ETC_SAMPLE_RES
+    #define ETC_SAMPLE_RES 5
+  #endif
+  #ifndef ETC_SAMPLE_START
+    #define ETC_SAMPLE_START 180
+  #endif
+  #define ETC_SAMPLE_END (ETC_SAMPLE_START + (ETC_SAMPLE_COUNT) * ETC_SAMPLE_RES)
+#endif
+
 #ifndef PTC_PROBE_HEATING_OFFSET
   #define PTC_PROBE_HEATING_OFFSET 0.5f
 #endif
@@ -81,10 +95,10 @@ typedef struct {
 #endif
 
 static constexpr temp_calib_t cali_info_init[TSI_COUNT] = {
-  { PTC_SAMPLE_COUNT, PTC_SAMPLE_RES, PTC_SAMPLE_START, PTC_SAMPLE_END }, // Probe
-  { BTC_SAMPLE_COUNT, BTC_SAMPLE_RES, BTC_SAMPLE_START, BTC_SAMPLE_END }, // Bed
+  { PTC_SAMPLE_COUNT, PTC_SAMPLE_RES, PTC_SAMPLE_START, PTC_SAMPLE_END },   // Probe
+  { BTC_SAMPLE_COUNT, BTC_SAMPLE_RES, BTC_SAMPLE_START, BTC_SAMPLE_END },   // Bed
   #if ENABLED(USE_TEMP_EXT_COMPENSATION)
-    { 20,  5, 180, 180 +  5 * 20 }                                        // Extruder
+    { ETC_SAMPLE_COUNT, ETC_SAMPLE_RES, ETC_SAMPLE_START, ETC_SAMPLE_END }, // Extruder
   #endif
 };
 

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -648,7 +648,7 @@ G29_TYPE GcodeSuite::G29() {
           #if ENABLED(PROBE_TEMP_COMPENSATION)
             temp_comp.compensate_measurement(TSI_BED, thermalManager.degBed(), abl.measured_z);
             temp_comp.compensate_measurement(TSI_PROBE, thermalManager.degProbe(), abl.measured_z);
-            TERN_(USE_TEMP_EXT_COMPENSATION, temp_comp.compensate_measurement(TSI_EXT, thermalManager.degHotend(), abl.measured_z));
+            TERN_(USE_TEMP_EXT_COMPENSATION, temp_comp.compensate_measurement(TSI_EXT, thermalManager.degHotend(0), abl.measured_z));
           #endif
 
           #if ENABLED(AUTO_BED_LEVELING_LINEAR)

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -648,6 +648,18 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
     constexpr decltype(_btc_probe_temp) _test_btc_probe_temp = 12.3f;
     static_assert(_test_btc_probe_temp != 12.3f, "BTC_PROBE_TEMP must be a whole number.");
   #endif
+  #if ENABLED(USE_TEMP_EXT_COMPENSATION)
+    #ifdef ETC_SAMPLE_START
+      constexpr auto _etc_sample_start = ETC_SAMPLE_START;
+      constexpr decltype(_etc_sample_start) _test_etc_sample_start = 12.3f;
+      static_assert(_test_etc_sample_start != 12.3f, "ETC_SAMPLE_START must be a whole number.");
+    #endif
+    #ifdef ETC_SAMPLE_RES
+      constexpr auto _etc_sample_res = ETC_SAMPLE_RES;
+      constexpr decltype(_etc_sample_res) _test_etc_sample_res = 12.3f;
+      static_assert(_test_etc_sample_res != 12.3f, "ETC_SAMPLE_RES must be a whole number.");
+    #endif
+  #endif
 
   #if ENABLED(USE_TEMP_EXT_COMPENSATION) && EXTRUDERS != 1
     #error "USE_TEMP_EXT_COMPENSATION only works with a single extruder."

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -648,6 +648,10 @@ static_assert(COUNT(arm) == LOGICAL_AXES, "AXIS_RELATIVE_MODES must contain " _L
     constexpr decltype(_btc_probe_temp) _test_btc_probe_temp = 12.3f;
     static_assert(_test_btc_probe_temp != 12.3f, "BTC_PROBE_TEMP must be a whole number.");
   #endif
+
+  #if ENABLED(USE_TEMP_EXT_COMPENSATION) && EXTRUDERS != 1
+    #error "USE_TEMP_EXT_COMPENSATION only works with a single extruder."
+  #endif
 #endif
 
 /**


### PR DESCRIPTION
### Description
If you have a Z probe with a temperature sensor, it is possible to compensate against probe, bed and extruder temperatures. However if you select extruder temperature with macro USE_TEMP_EXT_COMPENSATION, the compile fails.

### Requirements

Z probe and temperature sensor.

### Benefits

Allows more accurate probing that takes expansion of the heatblock into account when probing.

### Configurations

[configs.zip](https://github.com/MarlinFirmware/Marlin/files/7403391/configs.zip)

### Related Issues

Issue #23006
