### PR TITLE
Fix SetFlow issue in DWIN Enhanced

### DIFF
--- a/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwin.cpp
@@ -2341,7 +2341,8 @@ void SetSpeed() { SetPIntOnClick(MIN_PRINT_SPEED, MAX_PRINT_SPEED); }
 
 #endif // ADVANCED_PAUSE_FEATURE
 
-void SetFlow() { SetPIntOnClick(MIN_PRINT_FLOW, MAX_PRINT_FLOW); }
+void ApplyFlow() { planner.refresh_e_factor(0); }
+void SetFlow() { SetPIntOnClick(MIN_PRINT_FLOW, MAX_PRINT_FLOW, ApplyFlow); }
 
 // Leveling Bed Corners
 void LevBed(uint8_t point) {


### PR DESCRIPTION
### Description
This PR fix the bug found by @Tom2199 at https://github.com/mriscoc/Marlin_Ender3v2/issues/136 :

The setting of the flow rate on the display within the tune menu has no effect on the actual flow rate. The flow rate changes on the display but the print doesn't.

### Steps to Reproduce
1. Start a print
2. Change Flow setting on the display
3. Observe no change in flowrate

**Expected behavior:** A change of the flowrate

**Actual behavior:** No change of the flowrate