### PR TITLE
M569, M906 and M913 should default to E0 when T not specified

### DIFF
--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -280,7 +280,7 @@ void GcodeSuite::M906() {
 
       #if E_STEPPERS
         case E_AXIS: {
-          const int8_t target_e_stepper = get_target_e_stepper_from_command();
+          const int8_t target_e_stepper = get_target_e_stepper_from_command(0);
           if (target_e_stepper < 0) return;
           switch (target_e_stepper) {
             #if AXIS_IS_L64XX(E0)

--- a/Marlin/src/gcode/feature/trinamic/M569.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M569.cpp
@@ -133,7 +133,7 @@ static void say_stealth_status() {
  */
 void GcodeSuite::M569() {
   if (parser.seen('S'))
-    set_stealth_status(parser.value_bool(), get_target_e_stepper_from_command());
+    set_stealth_status(parser.value_bool(), get_target_e_stepper_from_command(0));
   else
     say_stealth_status();
 }

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -104,7 +104,7 @@ void GcodeSuite::M906() {
 
       #if E_STEPPERS
         case E_AXIS: {
-          const int8_t target_e_stepper = get_target_e_stepper_from_command();
+          const int8_t target_e_stepper = get_target_e_stepper_from_command(0);
           if (target_e_stepper < 0) return;
           switch (target_e_stepper) {
             #if AXIS_IS_TMC(E0)

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -268,7 +268,7 @@
           break;
         #if E_STEPPERS
           case E_AXIS: {
-            const int8_t target_e_stepper = get_target_e_stepper_from_command();
+            const int8_t target_e_stepper = get_target_e_stepper_from_command(0);
             if (target_e_stepper < 0) return;
             switch (target_e_stepper) {
               TERN_(E0_HAS_STEALTHCHOP, case 0: TMC_SET_PWMTHRS_E(0); break;)

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -138,10 +138,10 @@ int8_t GcodeSuite::get_target_extruder_from_command() {
 
 /**
  * Get the target e stepper from the T parameter
- * Return -1 if the T parameter is out of range or unspecified
+ * Return dval if the T parameter is out of range or unspecified
  */
-int8_t GcodeSuite::get_target_e_stepper_from_command() {
-  const int8_t e = parser.intval('T', -1);
+int8_t GcodeSuite::get_target_e_stepper_from_command(int8_t dval/* = -1*/) {
+  const int8_t e = parser.intval('T', dval);
   if (WITHIN(e, 0, E_STEPPERS - 1)) return e;
 
   SERIAL_ECHO_START();

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -137,10 +137,11 @@ int8_t GcodeSuite::get_target_extruder_from_command() {
 }
 
 /**
- * Get the target e stepper from the T parameter
- * Return dval if the T parameter is out of range or unspecified
+ * Get the target E stepper from the 'T' parameter.
+ * If there is no 'T' parameter then dval will be substituted.
+ * Returns -1 if the resulting E stepper index is out of range.
  */
-int8_t GcodeSuite::get_target_e_stepper_from_command(int8_t dval/* = -1*/) {
+int8_t GcodeSuite::get_target_e_stepper_from_command(const int8_t dval/*=-1*/) {
   const int8_t e = parser.intval('T', dval);
   if (WITHIN(e, 0, E_STEPPERS - 1)) return e;
 

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -390,7 +390,7 @@ public:
   static void say_units();
 
   static int8_t get_target_extruder_from_command();
-  static int8_t get_target_e_stepper_from_command();
+  static int8_t get_target_e_stepper_from_command(int8_t dval = -1);
   static void get_destination_from_command();
 
   static void process_parsed_command(const bool no_ok=false);

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -390,7 +390,7 @@ public:
   static void say_units();
 
   static int8_t get_target_extruder_from_command();
-  static int8_t get_target_e_stepper_from_command(int8_t dval = -1);
+  static int8_t get_target_e_stepper_from_command(const int8_t dval=-1);
   static void get_destination_from_command();
 
   static void process_parsed_command(const bool no_ok=false);


### PR DESCRIPTION
### Description

In the Marlin documentation for M569, M906 and M913, if there is no T parameter then the command is supposed to be applied to stepper 0. In commit aba330e372bb57bd1a39f493343d9e1ff69908a5, these gcodes switched to using GcodeSuite::get_target_e_stepper_from_command() which insists on a T parameter being present.

This PR restores the former behaviour for M569, M906 and M913 without affecting the other gcodes that use GcodeSuite::get_target_e_stepper_from_command().

Example of the bug:
```
>>> m569 s1 e
SENDING:M569 S1 E
echo:M569 E stepper not specified
```

### Requirements

A stepper that uses these gcodes (i.e. TMC steppers).

### Benefits

Restores the gcodes to their former (and documented) behaviour.

### Configurations

[configs.zip](https://github.com/MarlinFirmware/Marlin/files/7412815/configs.zip)

### Related Issues

Bug #22143
PR #22176
Commit aba330e372bb57bd1a39f493343d9e1ff69908a5