### PR TITLE
Fix PORT_RESTORE

### DIFF
--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -87,7 +87,7 @@ extern uint8_t marlin_debug_flags;
 //         interface with the ability to output to multiple serial ports.
 #if HAS_MULTI_SERIAL
   #define _PORT_REDIRECT(n,p) REMEMBER(n,multiSerial.portMask,p)
-  #define _PORT_RESTORE(n)  RESTORE(n)
+  #define _PORT_RESTORE(n)    RESTORE(n)
   #define SERIAL_ASSERT(P)    if (multiSerial.portMask!=(P)) { debugger(); }
   // If we have a catchall, use that directly
   #ifdef SERIAL_CATCHALL

--- a/Marlin/src/core/serial.h
+++ b/Marlin/src/core/serial.h
@@ -87,7 +87,7 @@ extern uint8_t marlin_debug_flags;
 //         interface with the ability to output to multiple serial ports.
 #if HAS_MULTI_SERIAL
   #define _PORT_REDIRECT(n,p) REMEMBER(n,multiSerial.portMask,p)
-  #define _PORT_RESTORE(n,p)  RESTORE(n)
+  #define _PORT_RESTORE(n)  RESTORE(n)
   #define SERIAL_ASSERT(P)    if (multiSerial.portMask!=(P)) { debugger(); }
   // If we have a catchall, use that directly
   #ifdef SERIAL_CATCHALL

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -719,7 +719,7 @@ void GCodeQueue::advance() {
 
     if (auto_buffer_report_interval && ELAPSED(ms, next_buffer_report_ms)) {
       next_buffer_report_ms = ms + 1000UL * auto_buffer_report_interval;
-      PORT_REDIRECT(SERIAL_BOTH);
+      PORT_REDIRECT(SerialMask::All);
       report_buffer_statistics();
       PORT_RESTORE();
     }

--- a/Marlin/src/libs/autoreport.h
+++ b/Marlin/src/libs/autoreport.h
@@ -44,7 +44,7 @@ struct AutoReporter {
       next_report_ms = ms + SEC_TO_MS(report_interval);
       PORT_REDIRECT(report_port_mask);
       Helper::report();
-      //PORT_RESTORE();
+      PORT_RESTORE();
     }
   }
 };


### PR DESCRIPTION
Fixing refactoring that uses different argument counts depending on HAS_MULTI_SERIAL being defined, re-enabled PORT_RESTORE usage.

### Description
Someone changed the macro PORT_RESTORE when refactoring serial headers.

- When HAS_MULTI_SERIAL is defined, PORT_RESTORE(n, p) is expected. _PORT_RESTORE(n) doesn't want p.
- It looks like a copy paste error. PORT_RESTORE(n) is expected.

### Requirements

N/A, core code.

### Benefits

PORT_RESTORE works.

### Configurations

I found the problem while promoting BUFFER_MONITORING from D576 to M599 (avoiding the various risks introduced in MARLIN_DEV_MODE while I use the printer for regular operations).