### PR TITLE
Fix E3V2 (CrealityUI) position display

### DIFF
--- a/Marlin/src/lcd/e3v2/creality/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/creality/dwin.cpp
@@ -1659,7 +1659,7 @@ void _update_axis_value(const AxisEnum axis, const uint16_t x, const uint16_t y,
     else if (blink && draw_empty)
       DWIN_Draw_String(true, font8x16, Color_White, Color_Bg_Black, x, y, F("     "));
     else
-      DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, x, y, p * 10);
+      DWIN_Draw_FloatValue(true, true, 0, font8x16, Color_White, Color_Bg_Black, 3, 1, x, y, p);
   }
 }
 
@@ -1769,11 +1769,11 @@ void update_variable() {
   if (BABY_Z_VAR != _offset) {
     _offset = BABY_Z_VAR;
     if (BABY_Z_VAR < 0) {
-      Draw_Stat_Float(207, 417, -_offset * 100);
+      Draw_Stat_Float(207, 417, -_offset);
       DWIN_Draw_String(true, font8x16, Color_White, Color_Bg_Black, 205, 419, F("-"));
     }
     else {
-      Draw_Stat_Float(207, 417, _offset * 100);
+      Draw_Stat_Float(207, 417, _offset);
       DWIN_Draw_String(true, font8x16, Color_White, Color_Bg_Black, 205, 419, F(" "));
     }
   }


### PR DESCRIPTION
Hello 
here is the fix for current position and offset in status area (bottom on display)

related issue: https://github.com/MarlinFirmware/Marlin/issues/22831

have still a issue to set the Z-offset on LCD.
i set offset to -27.6 but the value show correct in the bottom -2.76

Followup to #23005