### PR TITLE
Fix MKS Robin E3 & E3D Z Stop & Probe Pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -54,8 +54,14 @@
 //
 #define X_STOP_PIN                          PA12
 #define Y_STOP_PIN                          PA11
-#define Z_MIN_PIN                           PC6
-#define Z_MAX_PIN                           PB1
+#define Z_STOP_PIN                          PC6
+
+//
+// Z Probe
+//
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PB1
+#endif
 
 //
 // Steppers


### PR DESCRIPTION
### Description

MKS Robin E3 & E3D boards do not have Z min & max pins. They have a Z stop pin & a dedicated probe pin. Pin details for each board can be found in [MKS' E3 & E3D repo](https://github.com/makerbase-mks/MKS-Robin-E3-E3D/tree/master/hardware).

### Requirements

MKS Robin E3 & E3D boards.

### Related Issues

- None. Found while adding MKS E3 & E3D board support to my [Prusa AIO firmware](https://github.com/thisiskeithb/Marlin/tree/prusa-aio/bugfix-2.0.x).