### PR TITLE
Ensure that PWM frequency is not changed by AUTO_FAN

### DIFF
--- a/Marlin/src/HAL/AVR/HAL.h
+++ b/Marlin/src/HAL/AVR/HAL.h
@@ -221,7 +221,7 @@ void set_pwm_frequency(const pin_t pin, int f_desired);
 
 /**
  * set_pwm_duty
- *  Sets the PWM duty cycle of the provided pin to the provided value
+ *  Set the PWM duty cycle of the provided pin to the provided value
  *  Optionally allows inverting the duty cycle [default = false]
  *  Optionally allows changing the maximum size of the provided value to enable finer PWM duty control [default = 255]
  */

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -153,7 +153,7 @@ Timer get_pwm_timer(const pin_t pin) {
 
 void set_pwm_frequency(const pin_t pin, int f_desired) {
   Timer timer = get_pwm_timer(pin);
-  if (timer.n == 0) return; // Don't proceed if protected timer or not recognised
+  if (timer.n == 0) return; // Don't proceed if protected timer or not recognized
   uint16_t size;
   if (timer.n == 2) size = 255; else size = 65535;
 
@@ -252,7 +252,7 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
     digitalWrite(pin, !invert);
   else {
     Timer timer = get_pwm_timer(pin);
-    if (timer.n == 0) return; // Don't proceed if protected timer or not recognised
+    if (timer.n == 0) return; // Don't proceed if protected timer or not recognized
     // Set compare output mode to CLEAR -> SET or SET -> CLEAR (if inverted)
     _SET_COMnQ(timer.TCCRnQ, (timer.q
         #ifdef TCCR2
@@ -261,20 +261,8 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
       ), COM_CLEAR_SET + invert
     );
 
-    uint16_t top;
-    if (timer.n == 2) { // if TIMER2
-      top = (
-        #if ENABLED(USE_OCR2A_AS_TOP)
-          *timer.OCRnQ[0] // top = OCR2A
-        #else
-          255 // top = 0xFF (max)
-        #endif
-      );
-    }
-    else
-      top = *timer.ICRn; // top = ICRn
-
-    _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top) / float(v_size)); // Scale 8/16-bit v to top value
+    uint16_t top = (timer.n == 2) ? TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255) : *timer.ICRn;
+    _SET_OCRnQ(timer.OCRnQ, timer.q, (v * top + v_size / 2) / v_size); // Scale 8/16-bit v to top value
   }
 }
 

--- a/Marlin/src/HAL/DUE/HAL.h
+++ b/Marlin/src/HAL/DUE/HAL.h
@@ -145,6 +145,11 @@ void HAL_adc_start_conversion(const uint8_t ch);
 uint16_t HAL_adc_get_result();
 
 //
+// PWM
+//
+inline void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t=255, const bool=false) { analogWrite(pin, v); }
+
+//
 // Pin Map
 //
 #define GET_PIN_MAP_PIN(index) index

--- a/Marlin/src/HAL/ESP32/HAL.h
+++ b/Marlin/src/HAL/ESP32/HAL.h
@@ -129,6 +129,10 @@ void HAL_adc_init();
 
 void HAL_adc_start_conversion(const uint8_t adc_pin);
 
+// PWM
+inline void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t=255, const bool=false) { analogWrite(pin, v); }
+
+// Pin Map
 #define GET_PIN_MAP_PIN(index) index
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)

--- a/Marlin/src/HAL/LINUX/HAL.h
+++ b/Marlin/src/HAL/LINUX/HAL.h
@@ -101,6 +101,9 @@ void HAL_adc_enable_channel(const uint8_t ch);
 void HAL_adc_start_conversion(const uint8_t ch);
 uint16_t HAL_adc_get_result();
 
+// PWM
+inline void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t=255, const bool=false) { analogWrite(pin, v); }
+
 // Reset source
 inline void HAL_clear_reset_source(void) {}
 inline uint8_t HAL_get_reset_source(void) { return RST_POWER_ON; }

--- a/Marlin/src/HAL/LPC1768/fast_pwm.cpp
+++ b/Marlin/src/HAL/LPC1768/fast_pwm.cpp
@@ -23,17 +23,18 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if NEEDS_HARDWARE_PWM // Specific meta-flag for features that mandate PWM
-
 #include <pwm.h>
+
+#if NEEDS_HARDWARE_PWM // Specific meta-flag for features that mandate PWM
 
 void set_pwm_frequency(const pin_t pin, int f_desired) {
   LPC176x::pwm_set_frequency(pin, f_desired);
 }
 
+#endif // NEEDS_HARDWARE_PWM
+
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   LPC176x::pwm_write_ratio(pin, invert ? 1.0f - (float)v / v_size : (float)v / v_size);
 }
 
-#endif // NEEDS_HARDWARE_PWM
 #endif // TARGET_LPC1768

--- a/Marlin/src/HAL/LPC1768/fast_pwm.cpp
+++ b/Marlin/src/HAL/LPC1768/fast_pwm.cpp
@@ -22,19 +22,18 @@
 #ifdef TARGET_LPC1768
 
 #include "../../inc/MarlinConfigPre.h"
-
 #include <pwm.h>
-
-#if NEEDS_HARDWARE_PWM // Specific meta-flag for features that mandate PWM
-
-void set_pwm_frequency(const pin_t pin, int f_desired) {
-  LPC176x::pwm_set_frequency(pin, f_desired);
-}
-
-#endif // NEEDS_HARDWARE_PWM
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   LPC176x::pwm_write_ratio(pin, invert ? 1.0f - (float)v / v_size : (float)v / v_size);
 }
+
+#if NEEDS_HARDWARE_PWM // Specific meta-flag for features that mandate PWM
+
+  void set_pwm_frequency(const pin_t pin, int f_desired) {
+    LPC176x::pwm_set_frequency(pin, f_desired);
+  }
+
+#endif
 
 #endif // TARGET_LPC1768

--- a/Marlin/src/HAL/NATIVE_SIM/HAL.h
+++ b/Marlin/src/HAL/NATIVE_SIM/HAL.h
@@ -133,6 +133,9 @@ void HAL_adc_enable_channel(const uint8_t ch);
 void HAL_adc_start_conversion(const uint8_t ch);
 uint16_t HAL_adc_get_result();
 
+// PWM
+inline void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t=255, const bool=false) { analogWrite(pin, v); }
+
 // Reset source
 inline void HAL_clear_reset_source(void) {}
 inline uint8_t HAL_get_reset_source(void) { return RST_POWER_ON; }

--- a/Marlin/src/HAL/SAMD51/HAL.h
+++ b/Marlin/src/HAL/SAMD51/HAL.h
@@ -128,6 +128,11 @@ void HAL_adc_init();
 void HAL_adc_start_conversion(const uint8_t adc_pin);
 
 //
+// PWM
+//
+inline void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t=255, const bool=false) { analogWrite(pin, v); }
+
+//
 // Pin Map
 //
 #define GET_PIN_MAP_PIN(index) index

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -26,9 +26,10 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
+#include "HAL.h"
+
 #if NEEDS_HARDWARE_PWM
 
-#include "HAL.h"
 #include "timers.h"
 
 void set_pwm_frequency(const pin_t pin, int f_desired) {
@@ -44,6 +45,8 @@ void set_pwm_frequency(const pin_t pin, int f_desired) {
   pwm_start(pin_name, f_desired, 0, RESOLUTION_8B_COMPARE_FORMAT);
 }
 
+#endif // NEEDS_HARDWARE_PWM
+
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   PinName pin_name = digitalPinToPinName(pin);
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM);
@@ -58,5 +61,4 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
   }
 }
 
-#endif // NEEDS_HARDWARE_PWM
 #endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -24,9 +24,7 @@
 
 #ifdef HAL_STM32
 
-#include "../../inc/MarlinConfigPre.h"
-
-#include "HAL.h"
+#include "../../inc/MarlinConfig.h"
 #include "timers.h"
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -27,25 +27,7 @@
 #include "../../inc/MarlinConfigPre.h"
 
 #include "HAL.h"
-
-#if NEEDS_HARDWARE_PWM
-
 #include "timers.h"
-
-void set_pwm_frequency(const pin_t pin, int f_desired) {
-  if (!PWM_PIN(pin)) return;            // Don't proceed if no hardware timer
-
-  PinName pin_name = digitalPinToPinName(pin);
-  TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); // Get HAL timer instance
-
-  LOOP_S_L_N(i, 0, NUM_HARDWARE_TIMERS) // Protect used timers
-    if (timer_instance[i] && timer_instance[i]->getHandle()->Instance == Instance)
-      return;
-
-  pwm_start(pin_name, f_desired, 0, RESOLUTION_8B_COMPARE_FORMAT);
-}
-
-#endif // NEEDS_HARDWARE_PWM
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   PinName pin_name = digitalPinToPinName(pin);
@@ -60,5 +42,22 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
     case TIM_CHANNEL_4: LL_TIM_OC_SetCompareCH4(Instance, adj_val); break;
   }
 }
+
+#if NEEDS_HARDWARE_PWM
+
+  void set_pwm_frequency(const pin_t pin, int f_desired) {
+    if (!PWM_PIN(pin)) return;            // Don't proceed if no hardware timer
+
+    PinName pin_name = digitalPinToPinName(pin);
+    TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); // Get HAL timer instance
+
+    LOOP_S_L_N(i, 0, NUM_HARDWARE_TIMERS) // Protect used timers
+      if (timer_instance[i] && timer_instance[i]->getHandle()->Instance == Instance)
+        return;
+
+    pwm_start(pin_name, f_desired, 0, RESOLUTION_8B_COMPARE_FORMAT);
+  }
+
+#endif
 
 #endif // HAL_STM32

--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -449,8 +449,7 @@ uint16_t analogRead(pin_t pin) {
 
 // Wrapper to maple unprotected analogWrite
 void analogWrite(pin_t pin, int pwm_val8) {
-  if (PWM_PIN(pin))
-    analogWrite(uint8_t(pin), pwm_val8);
+  if (PWM_PIN(pin)) analogWrite(uint8_t(pin), pwm_val8);
 }
 
 void HAL_reboot() { nvic_sys_reset(); }

--- a/Marlin/src/HAL/STM32F1/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32F1/fast_pwm.cpp
@@ -25,40 +25,7 @@
 
 #include <pwm.h>
 #include "HAL.h"
-
-#if NEEDS_HARDWARE_PWM
-
 #include "timers.h"
-
-void set_pwm_frequency(const pin_t pin, int f_desired) {
-  if (!PWM_PIN(pin)) return;                    // Don't proceed if no hardware timer
-
-  timer_dev *timer = PIN_MAP[pin].timer_device;
-  uint8_t channel = PIN_MAP[pin].timer_channel;
-
-  // Protect used timers
-  if (timer == get_timer_dev(TEMP_TIMER_NUM)) return;
-  if (timer == get_timer_dev(STEP_TIMER_NUM)) return;
-  #if PULSE_TIMER_NUM != STEP_TIMER_NUM
-    if (timer == get_timer_dev(PULSE_TIMER_NUM)) return;
-  #endif
-
-  if (!(timer->regs.bas->SR & TIMER_CR1_CEN))   // Ensure the timer is enabled
-    timer_init(timer);
-
-  timer_set_mode(timer, channel, TIMER_PWM);
-  uint16_t preload = 255;                       // Lock 255 PWM resolution for high frequencies
-  int32_t prescaler = (HAL_TIMER_RATE) / (preload + 1) / f_desired - 1;
-  if (prescaler > 65535) {                      // For low frequencies increase prescaler
-    prescaler = 65535;
-    preload = (HAL_TIMER_RATE) / (prescaler + 1) / f_desired - 1;
-  }
-  if (prescaler < 0) return;                    // Too high frequency
-  timer_set_reload(timer, preload);
-  timer_set_prescaler(timer, prescaler);
-}
-
-#endif // NEEDS_HARDWARE_PWM
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   timer_dev *timer = PIN_MAP[pin].timer_device;
@@ -67,4 +34,35 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
   pwmWrite(pin, max_val);
 }
 
+#if NEEDS_HARDWARE_PWM
+
+  void set_pwm_frequency(const pin_t pin, int f_desired) {
+    if (!PWM_PIN(pin)) return;                    // Don't proceed if no hardware timer
+
+    timer_dev *timer = PIN_MAP[pin].timer_device;
+    uint8_t channel = PIN_MAP[pin].timer_channel;
+
+    // Protect used timers
+    if (timer == get_timer_dev(TEMP_TIMER_NUM)) return;
+    if (timer == get_timer_dev(STEP_TIMER_NUM)) return;
+    #if PULSE_TIMER_NUM != STEP_TIMER_NUM
+      if (timer == get_timer_dev(PULSE_TIMER_NUM)) return;
+    #endif
+
+    if (!(timer->regs.bas->SR & TIMER_CR1_CEN))   // Ensure the timer is enabled
+      timer_init(timer);
+
+    timer_set_mode(timer, channel, TIMER_PWM);
+    uint16_t preload = 255;                       // Lock 255 PWM resolution for high frequencies
+    int32_t prescaler = (HAL_TIMER_RATE) / (preload + 1) / f_desired - 1;
+    if (prescaler > 65535) {                      // For low frequencies increase prescaler
+      prescaler = 65535;
+      preload = (HAL_TIMER_RATE) / (prescaler + 1) / f_desired - 1;
+    }
+    if (prescaler < 0) return;                    // Too high frequency
+    timer_set_reload(timer, preload);
+    timer_set_prescaler(timer, prescaler);
+  }
+
+#endif // NEEDS_HARDWARE_PWM
 #endif // __STM32F1__

--- a/Marlin/src/HAL/STM32F1/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32F1/fast_pwm.cpp
@@ -23,10 +23,11 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if NEEDS_HARDWARE_PWM
-
 #include <pwm.h>
 #include "HAL.h"
+
+#if NEEDS_HARDWARE_PWM
+
 #include "timers.h"
 
 void set_pwm_frequency(const pin_t pin, int f_desired) {
@@ -57,6 +58,8 @@ void set_pwm_frequency(const pin_t pin, int f_desired) {
   timer_set_prescaler(timer, prescaler);
 }
 
+#endif // NEEDS_HARDWARE_PWM
+
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   timer_dev *timer = PIN_MAP[pin].timer_device;
   uint16_t max_val = timer->regs.bas->ARR * v / v_size;
@@ -64,5 +67,4 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
   pwmWrite(pin, max_val);
 }
 
-#endif // NEEDS_HARDWARE_PWM
 #endif // __STM32F1__

--- a/Marlin/src/HAL/TEENSY31_32/HAL.h
+++ b/Marlin/src/HAL/TEENSY31_32/HAL.h
@@ -122,6 +122,12 @@ void HAL_adc_init();
 void HAL_adc_start_conversion(const uint8_t adc_pin);
 uint16_t HAL_adc_get_result();
 
+// PWM
+
+inline void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t=255, const bool=false) { analogWrite(pin, v); }
+
+// Pin Map
+
 #define GET_PIN_MAP_PIN(index) index
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)

--- a/Marlin/src/HAL/TEENSY35_36/HAL.h
+++ b/Marlin/src/HAL/TEENSY35_36/HAL.h
@@ -129,6 +129,12 @@ void HAL_adc_init();
 void HAL_adc_start_conversion(const uint8_t adc_pin);
 uint16_t HAL_adc_get_result();
 
+// PWM
+
+inline void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t=255, const bool=false) { analogWrite(pin, v); }
+
+// Pin Map
+
 #define GET_PIN_MAP_PIN(index) index
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)

--- a/Marlin/src/HAL/TEENSY40_41/HAL.cpp
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.cpp
@@ -106,17 +106,17 @@ void HAL_adc_init() {
 void HAL_clear_reset_source() {
   uint32_t reset_source = SRC_SRSR;
   SRC_SRSR = reset_source;
- }
+}
 
 uint8_t HAL_get_reset_source() {
   switch (SRC_SRSR & 0xFF) {
     case 1: return RST_POWER_ON; break;
     case 2: return RST_SOFTWARE; break;
     case 4: return RST_EXTERNAL; break;
-    // case 8: return RST_BROWN_OUT; break;
+    //case 8: return RST_BROWN_OUT; break;
     case 16: return RST_WATCHDOG; break;
-     case 64: return RST_JTAG; break;
-    // case 128: return RST_OVERTEMP; break;
+    case 64: return RST_JTAG; break;
+    //case 128: return RST_OVERTEMP; break;
   }
   return 0;
 }
@@ -168,7 +168,7 @@ uint16_t HAL_adc_get_result() {
   return 0;
 }
 
-bool is_output(uint8_t pin) {
+bool is_output(pin_t pin) {
   const struct digital_pin_bitband_and_config_table_struct *p;
   p = digital_pin_to_info_PGM + pin;
   return (*(p->reg + 1) & p->mask);

--- a/Marlin/src/HAL/TEENSY40_41/HAL.h
+++ b/Marlin/src/HAL/TEENSY40_41/HAL.h
@@ -150,8 +150,14 @@ void HAL_adc_init();
 void HAL_adc_start_conversion(const uint8_t adc_pin);
 uint16_t HAL_adc_get_result();
 
+// PWM
+
+inline void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t=255, const bool=false) { analogWrite(pin, v); }
+
+// Pin Map
+
 #define GET_PIN_MAP_PIN(index) index
 #define GET_PIN_MAP_INDEX(pin) pin
 #define PARSED_PIN_INDEX(code, dval) parser.intval(code, dval)
 
-bool is_output(uint8_t pin);
+bool is_output(pin_t pin);

--- a/Marlin/src/feature/caselight.cpp
+++ b/Marlin/src/feature/caselight.cpp
@@ -70,7 +70,7 @@ void CaseLight::update(const bool sflag) {
 
     #if CASELIGHT_USES_BRIGHTNESS
       if (pin_is_pwm())
-        analogWrite(pin_t(CASE_LIGHT_PIN), (
+        set_pwm_duty(pin_t(CASE_LIGHT_PIN), (
           #if CASE_LIGHT_MAX_PWM == 255
             n10ct
           #else

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -72,9 +72,10 @@ void ControllerFan::update() {
       ? settings.active_speed : settings.idle_speed
     );
 
-    // Allow digital or PWM fan output (see M42 handling)
-    WRITE(CONTROLLER_FAN_PIN, speed);
-    analogWrite(pin_t(CONTROLLER_FAN_PIN), speed);
+    if (PWM_PIN(CONTROLLER_FAN_PIN))
+      set_pwm_duty(pin_t(CONTROLLER_FAN_PIN), speed);
+    else
+      WRITE(CONTROLLER_FAN_PIN, speed);
   }
 }
 

--- a/Marlin/src/feature/leds/leds.cpp
+++ b/Marlin/src/feature/leds/leds.cpp
@@ -121,11 +121,11 @@ void LEDLights::set_color(const LEDColor &incol
 
     // This variant uses 3-4 separate pins for the RGB(W) components.
     // If the pins can do PWM then their intensity will be set.
-    #define _UPDATE_RGBW(C,c) do {                \
-      if (PWM_PIN(RGB_LED_##C##_PIN))             \
-        analogWrite(pin_t(RGB_LED_##C##_PIN), c); \
-      else                                        \
-        WRITE(RGB_LED_##C##_PIN, c ? HIGH : LOW); \
+    #define _UPDATE_RGBW(C,c) do {                 \
+      if (PWM_PIN(RGB_LED_##C##_PIN))              \
+        set_pwm_duty(pin_t(RGB_LED_##C##_PIN), c); \
+      else                                         \
+        WRITE(RGB_LED_##C##_PIN, c ? HIGH : LOW);  \
     }while(0)
     #define UPDATE_RGBW(C,c) _UPDATE_RGBW(C, TERN1(CASE_LIGHT_USE_RGB_LED, caselight.on) ? incol.c : 0)
     UPDATE_RGBW(R,r); UPDATE_RGBW(G,g); UPDATE_RGBW(B,b);

--- a/Marlin/src/feature/spindle_laser.cpp
+++ b/Marlin/src/feature/spindle_laser.cpp
@@ -66,7 +66,7 @@ void SpindleLaser::init() {
   #endif
   #if ENABLED(SPINDLE_LASER_USE_PWM)
     SET_PWM(SPINDLE_LASER_PWM_PIN);
-    analogWrite(pin_t(SPINDLE_LASER_PWM_PIN), SPINDLE_LASER_PWM_OFF); // Set to lowest speed
+    set_pwm_duty(pin_t(SPINDLE_LASER_PWM_PIN), SPINDLE_LASER_PWM_OFF); // Set to lowest speed
   #endif
   #if ENABLED(HAL_CAN_SET_PWM_FREQ) && defined(SPINDLE_LASER_FREQUENCY)
     set_pwm_frequency(pin_t(SPINDLE_LASER_PWM_PIN), SPINDLE_LASER_FREQUENCY);
@@ -92,10 +92,8 @@ void SpindleLaser::init() {
   void SpindleLaser::_set_ocr(const uint8_t ocr) {
     #if NEEDS_HARDWARE_PWM && SPINDLE_LASER_FREQUENCY
       set_pwm_frequency(pin_t(SPINDLE_LASER_PWM_PIN), TERN(MARLIN_DEV_MODE, frequency, SPINDLE_LASER_FREQUENCY));
-      set_pwm_duty(pin_t(SPINDLE_LASER_PWM_PIN), ocr ^ SPINDLE_LASER_PWM_OFF);
-    #else
-      analogWrite(pin_t(SPINDLE_LASER_PWM_PIN), ocr ^ SPINDLE_LASER_PWM_OFF);
     #endif
+    set_pwm_duty(pin_t(SPINDLE_LASER_PWM_PIN), ocr ^ SPINDLE_LASER_PWM_OFF);
   }
 
   void SpindleLaser::set_ocr(const uint8_t ocr) {

--- a/Marlin/src/gcode/control/M42.cpp
+++ b/Marlin/src/gcode/control/M42.cpp
@@ -126,10 +126,10 @@ void GcodeSuite::M42() {
   extDigitalWrite(pin, pin_status);
 
   #ifdef ARDUINO_ARCH_STM32
-    // A simple I/O will be set to 0 by analogWrite()
+    // A simple I/O will be set to 0 by set_pwm_duty()
     if (pin_status <= 1 && !PWM_PIN(pin)) return;
   #endif
-  analogWrite(pin, pin_status);
+  set_pwm_duty(pin, pin_status);
 }
 
 #endif // DIRECT_PIN_CONTROL

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -342,7 +342,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
   void MarlinUI::_set_brightness() {
     #if PIN_EXISTS(TFT_BACKLIGHT)
       if (PWM_PIN(TFT_BACKLIGHT_PIN))
-        analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+        set_pwm_duty(pin_t(TFT_BACKLIGHT_PIN), brightness);
     #endif
   }
 #endif

--- a/Marlin/src/lcd/tft/ui_common.cpp
+++ b/Marlin/src/lcd/tft/ui_common.cpp
@@ -213,7 +213,7 @@ void MarlinUI::clear_lcd() {
   void MarlinUI::_set_brightness() {
     #if PIN_EXISTS(TFT_BACKLIGHT)
       if (PWM_PIN(TFT_BACKLIGHT_PIN))
-        analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+        set_pwm_duty(pin_t(TFT_BACKLIGHT_PIN), brightness);
     #endif
   }
 #endif

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -1342,7 +1342,7 @@ void Endstops::update() {
         ES_REPORT_CHANGE(K_MAX);
       #endif
       SERIAL_ECHOLNPGM("\n");
-      analogWrite(pin_t(LED_PIN), local_LED_status);
+      set_pwm_duty(pin_t(LED_PIN), local_LED_status);
       local_LED_status ^= 255;
       old_live_state_local = live_state_local;
     }

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1270,7 +1270,7 @@ void Planner::recalculate() {
     #elif ENABLED(FAST_PWM_FAN)
       #define _FAN_SET(F) set_pwm_duty(FAN##F##_PIN, CALC_FAN_SPEED(F));
     #else
-      #define _FAN_SET(F) analogWrite(pin_t(FAN##F##_PIN), CALC_FAN_SPEED(F));
+      #define _FAN_SET(F) set_pwm_duty(pin_t(FAN##F##_PIN), CALC_FAN_SPEED(F));
     #endif
     #define FAN_SET(F) do{ kickstart_fan(fan_speed, ms, F); _FAN_SET(F); }while(0)
 
@@ -1393,8 +1393,8 @@ void Planner::check_axes_activity() {
   TERN_(AUTOTEMP, autotemp_task());
 
   #if ENABLED(BARICUDA)
-    TERN_(HAS_HEATER_1, analogWrite(pin_t(HEATER_1_PIN), tail_valve_pressure));
-    TERN_(HAS_HEATER_2, analogWrite(pin_t(HEATER_2_PIN), tail_e_to_p_pressure));
+    TERN_(HAS_HEATER_1, set_pwm_duty(pin_t(HEATER_1_PIN), tail_valve_pressure));
+    TERN_(HAS_HEATER_2, set_pwm_duty(pin_t(HEATER_2_PIN), tail_e_to_p_pressure));
   #endif
 }
 

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -3253,7 +3253,7 @@ void Stepper::report_positions() {
 
       #elif HAS_MOTOR_CURRENT_PWM
 
-        #define _WRITE_CURRENT_PWM(P) analogWrite(pin_t(MOTOR_CURRENT_PWM_## P ##_PIN), 255L * current / (MOTOR_CURRENT_PWM_RANGE))
+        #define _WRITE_CURRENT_PWM(P) set_pwm_duty(pin_t(MOTOR_CURRENT_PWM_## P ##_PIN), 255L * current / (MOTOR_CURRENT_PWM_RANGE))
         switch (driver) {
           case 0:
             #if PIN_EXISTS(MOTOR_CURRENT_PWM_X)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -889,7 +889,7 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
 
     #define _UPDATE_AUTO_FAN(P,D,A) do{                  \
       if (PWM_PIN(P##_AUTO_FAN_PIN) && A < 255)          \
-        analogWrite(pin_t(P##_AUTO_FAN_PIN), D ? A : 0); \
+        set_pwm_duty(pin_t(P##_AUTO_FAN_PIN), D ? A : 0);\
       else                                               \
         WRITE(P##_AUTO_FAN_PIN, D);                      \
     }while(0)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -887,11 +887,11 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
         SBI(fanState, pgm_read_byte(&fanBit[COOLER_FAN_INDEX]));
     #endif
 
-    #define _UPDATE_AUTO_FAN(P,D,A) do{                  \
-      if (PWM_PIN(P##_AUTO_FAN_PIN) && A < 255)          \
-        set_pwm_duty(pin_t(P##_AUTO_FAN_PIN), D ? A : 0);\
-      else                                               \
-        WRITE(P##_AUTO_FAN_PIN, D);                      \
+    #define _UPDATE_AUTO_FAN(P,D,A) do{                   \
+      if (PWM_PIN(P##_AUTO_FAN_PIN) && A < 255)           \
+        set_pwm_duty(pin_t(P##_AUTO_FAN_PIN), D ? A : 0); \
+      else                                                \
+        WRITE(P##_AUTO_FAN_PIN, D);                       \
     }while(0)
 
     uint8_t fanDone = 0;


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

Fix `_UPDATE_AUTO_FAN` (in temperature.cpp) so it will not change timer PWM frequency during updates when a configuration with `EXTRUDER_AUTO_FAN_SPEED < 255` is set.

In the STM32 HAL, `analogWrite` will forcefully set the timer on every use to `1khz`. Causing `FAST_PWM_FAN_FREQUENCY` configuration to be overridden.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

`AUTO_FAN` feature enabled with  `EXTRUDER_AUTO_FAN_SPEED < 255`.
Using `FAST_PWM_FAN` with a specific `FAST_PWM_FAN_FREQUENCY`.

### Benefits

<!-- What does this PR fix or improve? -->

`AUTO_FAN` feature will not interfere with `FAST_PWM_FAN_FREQUENCY` when  `EXTRUDER_AUTO_FAN_SPEED < 255`.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

To test we need `AUTO_FAN_PIN` is enabled and `EXTRUDER_AUTO_FAN_SPEED < 255`.

This was tested on a `BIGTREE_SKR_2` (STM32 HAL). Measuring the frequency with an oscilloscope verified the fix.
- Before: It was always 1khz
- After: It follows `FAST_PWM_FAN_FREQUENCY`

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
None
