### PR TITLE
Warn of possible endstop/DIAG homing conflicts

### DIFF
--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -1109,7 +1109,7 @@ private:
       static void M913();
       static void M913_report(const bool forReplay=true);
     #endif
-    #if ENABLED(USE_SENSORLESS)
+    #if USE_SENSORLESS
       static void M914();
       static void M914_report(const bool forReplay=true);
     #endif

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -495,5 +495,5 @@
 #if !USE_SENSORLESS && ENABLED(USES_DIAG_JUMPERS)
   #warning "Motherboard DIAG jumpers must be removed when SENSORLESS_HOMING is disabled."
 #elif !USE_SENSORLESS && ENABLED(USES_DIAG_PINS)
-  #warning "Driver DIAG pins must be removed when SENSORLESS_HOMING is disabled."
+  #warning "Driver DIAG pins must be physically removed unless SENSORLESS_HOMING is enabled. (See https://bit.ly/2ZPRlt0)"
 #endif

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -492,10 +492,8 @@
 //
 // Warn users of potential endstop/DIAG pin conflicts to prevent homing issues when not using sensorless homing
 //
-#if ENABLED(USES_DIAG_JUMPERS) && DISABLED(USE_SENSORLESS)
-  #undef USES_DIAG_JUMPERS
+#if !USE_SENSORLESS && ENABLED(USES_DIAG_JUMPERS)
   #warning "Motherboard DIAG jumpers must be removed when SENSORLESS_HOMING is disabled."
-#elif ENABLED(USES_DIAG_PINS) && DISABLED(USE_SENSORLESS)
-  #undef USES_DIAG_PINS
+#elif !USE_SENSORLESS && ENABLED(USES_DIAG_PINS)
   #warning "Driver DIAG pins must be removed when SENSORLESS_HOMING is disabled."
 #endif

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -488,3 +488,14 @@
 #if HOMING_Z_WITH_PROBE && IS_CARTESIAN && DISABLED(Z_SAFE_HOMING)
   #error "Z_SAFE_HOMING is recommended when homing with a probe. Enable Z_SAFE_HOMING or comment out this line to continue."
 #endif
+
+//
+// Warn users of potential endstop/DIAG pin conflicts to prevent homing issues when not using sensorless homing
+//
+#if ENABLED(USES_DIAG_JUMPERS) && DISABLED(USE_SENSORLESS)
+  #undef USES_DIAG_JUMPERS
+  #warning "Motherboard DIAG jumpers must be removed when SENSORLESS_HOMING is disabled."
+#elif ENABLED(USES_DIAG_PINS) && DISABLED(USE_SENSORLESS)
+  #undef USES_DIAG_PINS
+  #warning "Driver DIAG pins must be removed when SENSORLESS_HOMING is disabled."
+#endif

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -26,9 +26,9 @@
  */
 
 #define BOARD_INFO_NAME "BTT SKR V1.3"
-#define LPC1768_IS_SKRV1_3 1
 
-#define USES_DIAG_JUMPERS 1
+#define LPC1768_IS_SKRV1_3
+#define USES_DIAG_JUMPERS
 
 //
 // Trinamic Stallguard pins

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -28,6 +28,8 @@
 #define BOARD_INFO_NAME "BTT SKR V1.3"
 #define LPC1768_IS_SKRV1_3 1
 
+#define USES_DIAG_JUMPERS 1
+
 //
 // Trinamic Stallguard pins
 //

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -27,6 +27,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_PINS 1
+
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "BTT SKR V1.4"
 #endif

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -27,8 +27,6 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_PINS 1
-
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "BTT SKR V1.4"
 #endif
@@ -36,6 +34,8 @@
 #ifndef BOARD_CUSTOM_BUILD_FLAGS
   #define BOARD_CUSTOM_BUILD_FLAGS -DLPC_PINCFG_UART3_P4_28
 #endif
+
+#define USES_DIAG_PINS
 
 //
 // EEPROM

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -27,10 +27,10 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
-
 #define BOARD_INFO_NAME   "MKS SGen-L"
 #define BOARD_WEBSITE_URL "github.com/makerbase-mks/MKS-SGEN_L"
+
+#define USES_DIAG_JUMPERS
 
 //
 // Servos

--- a/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
+++ b/Marlin/src/pins/lpc1768/pins_MKS_SGEN_L.h
@@ -27,6 +27,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 #define BOARD_INFO_NAME   "MKS SGen-L"
 #define BOARD_WEBSITE_URL "github.com/makerbase-mks/MKS-SGEN_L"
 

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -27,11 +27,11 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
-
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "BTT SKR E3 Turbo"
 #endif
+
+#define USES_DIAG_JUMPERS
 
 // Onboard I2C EEPROM
 #define I2C_EEPROM

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -27,6 +27,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "BTT SKR E3 Turbo"
 #endif

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -27,10 +27,10 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
-
 #define BOARD_INFO_NAME   "MKS SGEN_L V2"
 #define BOARD_WEBSITE_URL "github.com/makerbase-mks"
+
+#define USES_DIAG_JUMPERS
 
 //
 // EEPROM, MKS SGEN_L V2.0 hardware has 4K EEPROM on the board

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -27,6 +27,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 #define BOARD_INFO_NAME   "MKS SGEN_L V2"
 #define BOARD_WEBSITE_URL "github.com/makerbase-mks"
 

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -23,6 +23,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 // Release PB3/PB4 (E0 STP/DIR) from JTAG pins
 #define DISABLE_JTAG
 

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -23,10 +23,10 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
-
 // Release PB3/PB4 (E0 STP/DIR) from JTAG pins
 #define DISABLE_JTAG
+
+#define USES_DIAG_JUMPERS
 
 // Ignore temp readings during development.
 //#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -29,6 +29,8 @@
 
 #define BOARD_NO_NATIVE_USB
 
+#define USES_DIAG_JUMPERS 1
+
 #define BOARD_WEBSITE_URL "github.com/makerbase-mks"
 
 //#define DISABLE_DEBUG

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -27,11 +27,10 @@
 
 #include "env_validate.h"
 
-#define BOARD_NO_NATIVE_USB
-
-#define USES_DIAG_JUMPERS 1
-
 #define BOARD_WEBSITE_URL "github.com/makerbase-mks"
+
+#define BOARD_NO_NATIVE_USB
+#define USES_DIAG_JUMPERS
 
 //#define DISABLE_DEBUG
 #define DISABLE_JTAG

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#define USES_DIAG_PINS 1
+
 /**
  * MKS Robin nano (STM32F103VET6) board pin assignments
  */

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -21,8 +21,6 @@
  */
 #pragma once
 
-#define USES_DIAG_PINS 1
-
 /**
  * MKS Robin nano (STM32F103VET6) board pin assignments
  */
@@ -38,6 +36,7 @@
 #define BOARD_INFO_NAME "MKS Robin nano V2.0"
 
 #define BOARD_NO_NATIVE_USB
+#define USES_DIAG_PINS
 
 // Avoid conflict with TIMER_SERVO when using the STM32 HAL
 #define TEMP_TIMER                             5

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -23,6 +23,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_PINS 1
+
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
   #error "BIGTREE BTT002 V1.0 only supports one hotend / E-stepper. Comment out this line to continue."
 #endif

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -23,13 +23,16 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_PINS 1
-
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
   #error "BIGTREE BTT002 V1.0 only supports one hotend / E-stepper. Comment out this line to continue."
 #endif
 
 #define BOARD_INFO_NAME "BTT BTT002 V1.0"
+
+#define USES_DIAG_PINS
+
+// Ignore temp readings during development.
+//#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
 
 // Use one of these or SDCard-based Emulation will be used
 #if NO_EEPROM_SELECTED
@@ -42,9 +45,6 @@
   // 128 kB sector allocated for EEPROM emulation.
   #define FLASH_EEPROM_LEVELING
 #endif
-
-// Ignore temp readings during development.
-//#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
 
 //
 // Limit Switches

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -21,8 +21,6 @@
  */
 #pragma once
 
-#define USES_DIAG_JUMPERS 1
-
 #if NOT_TARGET(STM32F4)
   #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
 #endif
@@ -30,6 +28,8 @@
 #ifndef BOARD_INFO_NAME
   #define BOARD_INFO_NAME "BTT E3 RRF"
 #endif
+
+#define USES_DIAG_JUMPERS
 
 // Add-on board for IDEX conversion
 //#define BTT_E3_RRF_IDEX_BOARD

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -21,6 +21,8 @@
  */
 #pragma once
 
+#define USES_DIAG_JUMPERS 1
+
 #if NOT_TARGET(STM32F4)
   #error "Oops! Select an STM32F4 board in 'Tools > Board.'"
 #endif

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -23,8 +23,6 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
-
 #if E_STEPPERS > MAX_E_STEPPERS
   #error "Marlin extruder/hotends limit! Increase MAX_E_STEPPERS to continue."
 #elif HOTENDS > 8 || E_STEPPERS > 8
@@ -33,14 +31,13 @@
 
 #define BOARD_INFO_NAME "BTT GTR V1.0"
 
+#define USES_DIAG_JUMPERS
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
+#define M5_EXTENDER                               // The M5 extender is attached
+
 // Onboard I2C EEPROM
 #define I2C_EEPROM
 #define MARLIN_EEPROM_SIZE                0x2000  // 8KB (24C64 ... 64Kb = 8KB)
-
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
-
-#define M5_EXTENDER                               // The M5 extender is attached
 
 //
 // Servos

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -23,6 +23,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 #if E_STEPPERS > MAX_E_STEPPERS
   #error "Marlin extruder/hotends limit! Increase MAX_E_STEPPERS to continue."
 #elif HOTENDS > 8 || E_STEPPERS > 8

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -23,6 +23,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 // Onboard I2C EEPROM
 #define I2C_EEPROM
 #define MARLIN_EEPROM_SIZE                0x8000  // 32KB (24C32A)

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -23,16 +23,14 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
+#define USES_DIAG_JUMPERS
 
 // Onboard I2C EEPROM
 #define I2C_EEPROM
 #define MARLIN_EEPROM_SIZE                0x8000  // 32KB (24C32A)
 #define I2C_SCL_PIN                         PB8
 #define I2C_SDA_PIN                         PB9
-
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
 
 // Avoid conflict with TIMER_TONE
 #define STEP_TIMER                            10

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -23,6 +23,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 // If you have the BigTreeTech driver expansion module, enable BTT_MOTOR_EXPANSION
 // https://github.com/bigtreetech/BTT-Expansion-module/tree/master/BTT%20EXP-MOT
 //#define BTT_MOTOR_EXPANSION

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -23,7 +23,7 @@
 
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
+#define USES_DIAG_JUMPERS
 
 // If you have the BigTreeTech driver expansion module, enable BTT_MOTOR_EXPANSION
 // https://github.com/bigtreetech/BTT-Expansion-module/tree/master/BTT%20EXP-MOT
@@ -49,8 +49,7 @@
   #define FLASH_EEPROM_LEVELING
 #endif
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 
 //
 // Servos

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -47,8 +47,7 @@
   #define FLASH_EEPROM_LEVELING
 #endif
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 
 // Avoid conflict with TIMER_TONE
 #define STEP_TIMER                            10

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
@@ -40,8 +40,7 @@
   #define MARLIN_EEPROM_SIZE             0x10000
 #endif
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 
 //
 // Servos

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
@@ -34,8 +34,7 @@
 #define STEP_TIMER                             4
 #define TEMP_TIMER                             2
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 
 //
 // Servos

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_X.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_X.h
@@ -39,8 +39,7 @@
 #define I2C_SDA_PIN                         PB9
 #define MARLIN_EEPROM_SIZE               0x10000  // FM24CL64 F-RAM 64K (8Kx8)
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 
 //
 // Servos

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
@@ -24,6 +24,8 @@
 #define ALLOW_STM32DUINO
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 #if HOTENDS > 3 || E_STEPPERS > 5
   #error "MKS Monster supports up to 3 hotends and 5 E-steppers."
 #elif HAS_FSMC_TFT

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
@@ -24,8 +24,6 @@
 #define ALLOW_STM32DUINO
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
-
 #if HOTENDS > 3 || E_STEPPERS > 5
   #error "MKS Monster supports up to 3 hotends and 5 E-steppers."
 #elif HAS_FSMC_TFT
@@ -34,8 +32,8 @@
 
 #define BOARD_INFO_NAME "MKS Monster8 V1.x"
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
+#define USES_DIAG_JUMPERS
 
 //#define DISABLE_DEBUG
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -24,8 +24,6 @@
 #define ALLOW_STM32DUINO
 #include "env_validate.h"
 
-#define USES_DIAG_JUMPERS 1
-
 #if HOTENDS > 2 || E_STEPPERS > 2
   #error "MKS Robin Nano V3 supports up to 2 hotends / E-steppers."
 #elif HAS_FSMC_TFT
@@ -34,22 +32,20 @@
 
 #define BOARD_INFO_NAME "MKS Robin Nano V3"
 
+#define USES_DIAG_JUMPERS
+
 #ifndef X_CS_PIN
   #define X_CS_PIN                          PD5
 #endif
-
 #ifndef Y_CS_PIN
   #define Y_CS_PIN                          PD7
 #endif
-
 #ifndef Z_CS_PIN
   #define Z_CS_PIN                          PD4
 #endif
-
 #ifndef E0_CS_PIN
   #define E0_CS_PIN                         PD9
 #endif
-
 #ifndef E1_CS_PIN
   #define E1_CS_PIN                         PD8
 #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -24,6 +24,8 @@
 #define ALLOW_STM32DUINO
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS 1
+
 #if HOTENDS > 2 || E_STEPPERS > 2
   #error "MKS Robin Nano V3 supports up to 2 hotends / E-steppers."
 #elif HAS_FSMC_TFT

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -26,8 +26,7 @@
 // MKS Robin Nano V3, MKS Eagle pinmap
 //
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 
 // Avoid conflict with TIMER_TONE
 #define STEP_TIMER                            10

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -39,8 +39,7 @@
 #define I2C_EEPROM
 #define MARLIN_EEPROM_SIZE                0x1000  // 4KB
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX.h
@@ -32,8 +32,7 @@
 #define I2C_EEPROM
 #define MARLIN_EEPROM_SIZE                0x1000  // 4KB (24C32 ... 32Kb = 4KB)
 
-// USB Flash Drive support
-#define HAS_OTG_USB_HOST_SUPPORT
+#define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 
 //
 // Limit Switches


### PR DESCRIPTION
### Description

It is *extremely common* to troubleshoot homing issues where users do not remove diag jumpers from the motherboard or do not remove diag pins from drivers when using real endstops, so this PR adds a warning to remind users to do so.

I split the warning into `USES_DIAG_PINS` and `USES_DIAG_JUMPERS` flags to provide a clearer warning, but they could just as easily be combined and more generalized.

### Benefits

Users will be alerted to potential homing issues when their motherboard supports sensorless homing via diag signal and they are using real endstops.

### Related Issues
- Many in this issue queue, on Facebook, and on Discord. Some direct links:
- https://github.com/MarlinFirmware/Marlin/issues/21757
- https://github.com/MarlinFirmware/Marlin/issues/20295
- https://github.com/MarlinFirmware/Marlin/issues/16696