### PR TITLE
correct Y_SERIAL_RX_PIN in pins_FYSETC_S6.h

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -128,7 +128,7 @@
     #define Y_SERIAL_TX_PIN                 PE14
   #endif
   #ifndef Y_SERIAL_RX_PIN
-    #define Y_SERIAL_RX_PIN                 PE13
+    #define Y_SERIAL_RX_PIN                 PC4
   #endif
   #ifndef Z_SERIAL_TX_PIN
     #define Z_SERIAL_TX_PIN                 PD11


### PR DESCRIPTION
### Description

With MOTHERBOARD FYSETC_S6_V2_0
Marlin/src/pins/stm32f4/pins_FYSETC_S6_V2_0.h correctly sets all the {X|Y|Z|E0|E1|E2}_SERIAL_TX_PIN when HAS_TMC_UART is true.
pins_FYSETC_S6_V2_0.h then includes pins_FYSETC_S6.h which sets all the {X|Y|Z|E0|E1|E2}_SERIAL_RX_PIN 
The pin for Y_SERIAL_RX_PIN is set to PE13 but it should be PC4  (verified by user and examining Altium source files of the PCB)

Although pins_FYSETC_S6.h is also included by pins_FYSETC_SPIDER.h, Both lots of SERIAL_TX_PIN and SERIAL_RX_PIN are set before pins_FYSETC_S6.h is included. So this is not a problem

### Requirements

MOTHERBOARD FYSETC_S6_V2_0
Some TMC2208/9 stepper drivers

### Benefits

TMC Software serial  communications for Y axies on a FYSETC_S6_V2_0 works as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/23044