### PR TITLE
Add support for Voxelab Aquila G32 and N32.

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -552,7 +552,7 @@
 #elif MB(CHITU3D_V9)
   #include "stm32f1/pins_CHITU3D_V9.h"          // STM32F1                                env:chitu_f103 env:chitu_f103_maple
 #elif MB(CREALITY_V4)
-  #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple env:STM32F103RET6_voxelab_aquila_G32 env:STM32F103RET6_voxelab_aquila_N32
 #elif MB(CREALITY_V4210)
   #include "stm32f1/pins_CREALITY_V4210.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V427)

--- a/buildroot/share/PlatformIO/ldscripts/aquila.ld
+++ b/buildroot/share/PlatformIO/ldscripts/aquila.ld
@@ -1,0 +1,14 @@
+MEMORY
+{
+  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 48K - 40
+  rom (rx)  : ORIGIN = 0x08007000, LENGTH = 256K - 28K
+}
+
+/* Provide memory region aliases for common.inc */
+REGION_ALIAS("REGION_TEXT", rom);
+REGION_ALIAS("REGION_DATA", ram);
+REGION_ALIAS("REGION_BSS", ram);
+REGION_ALIAS("REGION_RODATA", rom);
+
+/* Let common.inc handle the real work. */
+INCLUDE common.inc

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -133,6 +133,40 @@ debug_tool           = jlink
 upload_protocol      = jlink
 
 #
+# Voxelab (STM32F103RET6)
+#
+[env:STM32F103RET6_voxelab_aquila_G32]
+platform             = ${common_stm32f1.platform}
+extends              = env:STM32F103RE_maple
+build_flags          = ${common_stm32f1.build_flags} -DTEMP_TIMER_CHAN=4
+board_build.address  = 0x08007000
+board_build.ldscript = aquila.ld
+extra_scripts        = ${common_stm32f1.extra_scripts}
+  pre:buildroot/share/PlatformIO/scripts/random-bin.py
+  buildroot/share/PlatformIO/scripts/custom_board.py
+debug_tool           = jlink
+upload_protocol      = jlink
+board_upload.maximum_ram_size = 49112
+board_upload.maximum_size     = 233472
+
+#
+# Voxelab (STM32F103RET6 N32)
+#
+[env:STM32F103RET6_voxelab_aquila_N32]
+platform             = ${common_stm32f1.platform}
+extends              = env:STM32F103RE_maple
+build_flags          = ${common_stm32f1.build_flags} -DTEMP_TIMER_CHAN=4 -DVOXELAB_N32
+board_build.address  = 0x08007000
+board_build.ldscript = aquila.ld
+board_upload.maximum_ram_size = 49112
+board_upload.maximum_size     = 233472
+extra_scripts        = ${common_stm32f1.extra_scripts}
+  pre:buildroot/share/PlatformIO/scripts/random-bin.py
+  buildroot/share/PlatformIO/scripts/custom_board.py
+debug_tool           = jlink
+upload_protocol      = jlink
+
+#
 # BigTree SKR Mini E3 V2.0 & DIP / SKR CR6 (STM32F103RET6 ARM Cortex-M3)
 #
 #   STM32F103RE_btt_maple ............. RET6


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Add support for Voxelab Aquila mainboards v1.0.0 with G32 and N32 cpus in the _maple_ PlatformIO targets.

### Requirements

This is loosely based on the work by @alexqzd, with some additions for properly displaying the RAM/ROM sizes in the output logs and splitting out `aquila.ld` file from the base `creality.ld`.
