### PR TITLE
Add MKS Robin E3/E3D NeoPixel Pin

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -63,6 +63,11 @@
   #define Z_MIN_PROBE_PIN                   PB1
 #endif
 
+// LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA2
+#endif
+
 //
 // Steppers
 //


### PR DESCRIPTION
### Description

MKS E3 & E3D boards have a dedicated NeoPixel pin, but it wasn't in the pins file.

### Benefits

RGB goodness on MKS E3/E3D boards. <img src="https://emoji.gg/assets/emoji/4545_RainbowBlobCat.gif" width="16">