### PR TITLE
Remove Posible USE_XXXX_PLUG redefinition warning

### DIFF
--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -1261,22 +1261,34 @@
 //
 #define _STOP_IN_USE(N) (X2_USE_ENDSTOP == N || Y2_USE_ENDSTOP == N || Z2_USE_ENDSTOP == N || Z3_USE_ENDSTOP == N || Z4_USE_ENDSTOP == N)
 #if _STOP_IN_USE(_XMAX_)
-  #define USE_XMAX_PLUG
+  #ifndef USE_XMAX_PLUG
+    #define USE_XMAX_PLUG
+  #endif
 #endif
 #if _STOP_IN_USE(_YMAX_)
-  #define USE_YMAX_PLUG
+  #ifndef USE_YMAX_PLUG
+    #define USE_YMAX_PLUG
+  #endif
 #endif
 #if _STOP_IN_USE(_ZMAX_)
-  #define USE_ZMAX_PLUG
+  #ifndef USE_ZMAX_PLUG
+    #define USE_ZMAX_PLUG
+  #endif
 #endif
 #if _STOP_IN_USE(_XMIN_)
-  #define USE_XMIN_PLUG
+  #ifndef USE_XMIN_PLUG
+    #define USE_XMIN_PLUG
+  #endif
 #endif
 #if _STOP_IN_USE(_YMIN_)
-  #define USE_YMIN_PLUG
+  #ifndef USE_YMIN_PLUG
+    #define USE_YMIN_PLUG
+  #endif
 #endif
 #if _STOP_IN_USE(_ZMIN_)
-  #define USE_ZMIN_PLUG
+  #ifndef USE_ZMIN_PLUG
+    #define USE_ZMIN_PLUG
+  #endif
 #endif
 #undef _STOP_IN_USE
 #if !USES_Z_MIN_PROBE_PIN

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -1260,35 +1260,23 @@
 // Disable unused endstop / probe pins
 //
 #define _STOP_IN_USE(N) (X2_USE_ENDSTOP == N || Y2_USE_ENDSTOP == N || Z2_USE_ENDSTOP == N || Z3_USE_ENDSTOP == N || Z4_USE_ENDSTOP == N)
-#if _STOP_IN_USE(_XMAX_)
-  #ifndef USE_XMAX_PLUG
-    #define USE_XMAX_PLUG
-  #endif
+#if !defined(USE_XMAX_PLUG) && _STOP_IN_USE(_XMAX_)
+  #define USE_XMAX_PLUG
 #endif
-#if _STOP_IN_USE(_YMAX_)
-  #ifndef USE_YMAX_PLUG
-    #define USE_YMAX_PLUG
-  #endif
+#if !defined(USE_YMAX_PLUG) && _STOP_IN_USE(_YMAX_)
+  #define USE_YMAX_PLUG
 #endif
-#if _STOP_IN_USE(_ZMAX_)
-  #ifndef USE_ZMAX_PLUG
-    #define USE_ZMAX_PLUG
-  #endif
+#if !defined(USE_ZMAX_PLUG) && _STOP_IN_USE(_ZMAX_)
+  #define USE_ZMAX_PLUG
 #endif
-#if _STOP_IN_USE(_XMIN_)
-  #ifndef USE_XMIN_PLUG
-    #define USE_XMIN_PLUG
-  #endif
+#if !defined(USE_XMIN_PLUG) && _STOP_IN_USE(_XMIN_)
+  #define USE_XMIN_PLUG
 #endif
-#if _STOP_IN_USE(_YMIN_)
-  #ifndef USE_YMIN_PLUG
-    #define USE_YMIN_PLUG
-  #endif
+#if !defined(USE_YMIN_PLUG) && _STOP_IN_USE(_YMIN_)
+  #define USE_YMIN_PLUG
 #endif
-#if _STOP_IN_USE(_ZMIN_)
-  #ifndef USE_ZMIN_PLUG
-    #define USE_ZMIN_PLUG
-  #endif
+#if !defined(USE_ZMIN_PLUG) && _STOP_IN_USE(_ZMIN_)
+  #define USE_ZMIN_PLUG
 #endif
 #undef _STOP_IN_USE
 #if !USES_Z_MIN_PROBE_PIN


### PR DESCRIPTION
We used to define USE_XXXX_PLUG at configuration.h 
This only removes the warnings because marlin silently redefine the USE_XXXX_PLUG