### PR TITLE
STM32: Fix set_pwm_duty for TFT_BACKLIGHT_PWM

### DIFF
--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -27,6 +27,11 @@
 #include "../../inc/MarlinConfig.h"
 #include "timers.h"
 
+#ifndef AFIO_NONE
+  // F1 only (first enum), F4 use 0
+  #define AFIO_NONE 0
+#endif
+
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   PinName pin_name = digitalPinToPinName(pin);
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM);

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -33,6 +33,15 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
   uint16_t adj_val = Instance->ARR * v / v_size;
   if (invert) adj_val = Instance->ARR - adj_val;
 
+  uint32_t func = pinmap_function(pin_name, PinMap_PWM);
+  if (func != uint32_t(NC)) {
+    uint16_t afio = STM_PIN_AFNUM(func);
+    if (afio != AFIO_NONE) {
+      // Req. once to set pin alt function
+      analogWrite(pin, v);
+    }
+  }
+
   switch (get_pwm_channel(pin_name)) {
     case TIM_CHANNEL_1: LL_TIM_OC_SetCompareCH1(Instance, adj_val); break;
     case TIM_CHANNEL_2: LL_TIM_OC_SetCompareCH2(Instance, adj_val); break;

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -28,15 +28,13 @@
 #include "timers.h"
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
+  if (!PWM_PIN(pin)) return;            // Don't proceed if no hardware timer
+
   PinName pin_name = digitalPinToPinName(pin);
   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM);
-  #if HAS_LCD_BRIGHTNESS && PIN_EXISTS(TFT_BACKLIGHT)
-    if (pin == TFT_BACKLIGHT_PIN) analogWrite(pin, v); // pwm_start
-  #endif
-  if (!PWM_PIN(pin)) return; // no timer instance
+
   uint16_t adj_val = Instance->ARR * v / v_size;
   if (invert) adj_val = Instance->ARR - adj_val;
-
   switch (get_pwm_channel(pin_name)) {
     case TIM_CHANNEL_1: LL_TIM_OC_SetCompareCH1(Instance, adj_val); break;
     case TIM_CHANNEL_2: LL_TIM_OC_SetCompareCH2(Instance, adj_val); break;

--- a/Marlin/src/HAL/STM32F1/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32F1/fast_pwm.cpp
@@ -28,6 +28,7 @@
 #include "timers.h"
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
+  if (!PWM_PIN(pin)) return;
   timer_dev *timer = PIN_MAP[pin].timer_device;
   uint16_t max_val = timer->regs.bas->ARR * v / v_size;
   if (invert) max_val = v_size - max_val;

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -339,12 +339,14 @@ void MarlinUI::draw_kill_screen() {
 void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
 #if HAS_LCD_BRIGHTNESS
+
   void MarlinUI::_set_brightness() {
     #if PIN_EXISTS(TFT_BACKLIGHT)
       if (PWM_PIN(TFT_BACKLIGHT_PIN))
-        set_pwm_duty(pin_t(TFT_BACKLIGHT_PIN), brightness);
+        analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
     #endif
   }
+
 #endif
 
 #if HAS_LCD_MENU

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -343,7 +343,7 @@ void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
   void MarlinUI::_set_brightness() {
     #if PIN_EXISTS(TFT_BACKLIGHT)
       if (PWM_PIN(TFT_BACKLIGHT_PIN))
-        analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+        analogWrite(pin_t(TFT_BACKLIGHT_PIN), backlight ? brightness : 0);
     #endif
   }
 

--- a/Marlin/src/lcd/tft/ui_common.cpp
+++ b/Marlin/src/lcd/tft/ui_common.cpp
@@ -210,12 +210,14 @@ void MarlinUI::clear_lcd() {
 }
 
 #if HAS_LCD_BRIGHTNESS
+
   void MarlinUI::_set_brightness() {
     #if PIN_EXISTS(TFT_BACKLIGHT)
       if (PWM_PIN(TFT_BACKLIGHT_PIN))
-        set_pwm_duty(pin_t(TFT_BACKLIGHT_PIN), brightness);
+        analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
     #endif
   }
+
 #endif
 
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)

--- a/Marlin/src/lcd/tft/ui_common.cpp
+++ b/Marlin/src/lcd/tft/ui_common.cpp
@@ -214,7 +214,7 @@ void MarlinUI::clear_lcd() {
   void MarlinUI::_set_brightness() {
     #if PIN_EXISTS(TFT_BACKLIGHT)
       if (PWM_PIN(TFT_BACKLIGHT_PIN))
-        analogWrite(pin_t(TFT_BACKLIGHT_PIN), brightness);
+        analogWrite(pin_t(TFT_BACKLIGHT_PIN), backlight ? brightness : 0);
     #endif
   }
 

--- a/Marlin/src/lcd/tft_io/tft_io.cpp
+++ b/Marlin/src/lcd/tft_io/tft_io.cpp
@@ -152,8 +152,7 @@ if (lcd_id != 0xFFFFFFFF) return;
   #endif
 
   #if PIN_EXISTS(TFT_BACKLIGHT) && ENABLED(DELAYED_BACKLIGHT_INIT)
-    WRITE(TFT_BACKLIGHT_PIN, HIGH);
-    TERN_(HAS_LCD_BRIGHTNESS, ui._set_brightness());
+    TERN(HAS_LCD_BRIGHTNESS, ui._set_brightness(), WRITE(TFT_BACKLIGHT_PIN, HIGH));
   #endif
 }
 

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -89,9 +89,15 @@
 #define HEATER_BED_PIN                      PA8   // pin 67 (Hot Bed Mosfet)
 
 #define FAN_PIN                             PA15  // pin 77 (4cm Fan)
-#define FAN_SOFT_PWM                              // Required to avoid issues with heating or STLink
-#define FAN_MIN_PWM                           35  // Fan will not start in 1-30 range
-#define FAN_MAX_PWM                          255
+#ifdef MAPLE_STM32F1
+  #define FAN_SOFT_PWM                            // Required to avoid issues with heating or STLink
+  #define FAN_MIN_PWM                         35  // Fan will not start in 1-30 range
+  #define FAN_MAX_PWM                        255
+#else
+  #define FAST_PWM_FAN                            // STM32 Variant allow TIMER2 Hardware PWM
+  #define FAN_MIN_PWM                         10
+  #define FAN_MAX_PWM                        170  // All over 150 do 100%
+#endif
 
 //#define BEEPER_PIN                        PD13  // pin 60 (Servo PWM output 5V/GND on Board V0G+) made for BL-Touch sensor
                                                   // Can drive a PC Buzzer, if connected between PWM and 5V pins

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -96,6 +96,7 @@
 #else
   #define FAST_PWM_FAN                            // STM32 Variant allow TIMER2 Hardware PWM
   #define FAST_PWM_FAN_FREQUENCY           31400  // This frequency allow a good range, fan starts at 3%, half noise at 50%
+  #define NEEDS_HARDWARE_PWM                   1
   #define FAN_MIN_PWM                          5
   #define FAN_MAX_PWM                        255
 #endif

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -95,8 +95,9 @@
   #define FAN_MAX_PWM                        255
 #else
   #define FAST_PWM_FAN                            // STM32 Variant allow TIMER2 Hardware PWM
-  #define FAN_MIN_PWM                         10
-  #define FAN_MAX_PWM                        170  // All over 150 do 100%
+  #define FAST_PWM_FAN_FREQUENCY           31400  // This frequency allow a good range, fan starts at 3%, half noise at 50%
+  #define FAN_MIN_PWM                          5
+  #define FAN_MAX_PWM                        255
 #endif
 
 //#define BEEPER_PIN                        PD13  // pin 60 (Servo PWM output 5V/GND on Board V0G+) made for BL-Touch sensor


### PR DESCRIPTION
analogWrite() call is required to enable/switch to pwm from off mode (binary/digital)
