### PR TITLE
Fix Octopus-Pro Max31865 / SPI

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
@@ -32,6 +32,7 @@
   #define TEMP_0_MISO_PIN                   PA6
   #define TEMP_0_MOSI_PIN                   PA7
   #define SOFTWARE_SPI                            // Max31865 and LCD SD share a set of SPIs, Set SD to softwareSPI for Max31865
+  #define FORCE_SOFT_SPI
 #else
   #define TEMP_0_PIN                        PF4   // TH0
 #endif

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -169,13 +169,6 @@
 #endif
 
 //
-// NeoPixel LED
-//
-#ifndef NEOPIXEL_PIN
-  #define NEOPIXEL_PIN                      PB0
-#endif
-
-//
 // Steppers
 //
 #define X_STEP_PIN                          PF13  // MOTOR 0
@@ -522,6 +515,13 @@
   #define BTN_EN1                    EXP2_08_PIN
   #define BTN_EN2                    EXP2_06_PIN
   #define BTN_ENC                    EXP1_09_PIN
+#endif
+
+//
+// NeoPixel LED
+//
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PB0
 #endif
 
 //


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->
Since the SPI on Max31865 and EXP-2 are multiplexed, when mini12864 is enabled, `SPI.begin();` will be called, resulting in the failure of Max31865 Software SPI to read data normally.

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->
Octopus Pro can use mini12864 and Max31865 normally at the same time.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
