### PR TITLE
Fix potential bootloop after WD timeout on AVR

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4224,3 +4224,6 @@
  */
 //#define SOFT_RESET_VIA_SERIAL         // 'KILL' and '^X' commands will soft-reset the controller
 //#define SOFT_RESET_ON_KILL            // Use a digital button to soft-reset the controller after KILL
+
+// Report uncleaned reset reason from register r2 instead of MCUSR. Supported by Optiboot on AVR.
+//#define OPTIBOOT_RESET_REASON

--- a/Marlin/src/HAL/AVR/HAL.h
+++ b/Marlin/src/HAL/AVR/HAL.h
@@ -91,7 +91,7 @@ typedef int8_t pin_t;
 // Public Variables
 // ------------------------
 
-//extern uint8_t MCUSR;
+extern uint8_t reset_reason;
 
 // Serial ports
 #ifdef USBCON
@@ -152,8 +152,8 @@ void HAL_init();
 
 //void _delay_ms(const int delay);
 
-inline void HAL_clear_reset_source() { MCUSR = 0; }
-inline uint8_t HAL_get_reset_source() { return MCUSR; }
+inline void HAL_clear_reset_source() { }
+inline uint8_t HAL_get_reset_source() { return reset_reason; }
 
 void HAL_reboot();
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2489,6 +2489,11 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #error "An encoder button is required or SOFT_RESET_ON_KILL will reset the printer without notice!"
 #endif
 
+// Reset reason for AVR
+#if ENABLED(OPTIBOOT_RESET_REASON) && !defined(__AVR__)
+  #error "OPTIBOOT_RESET_REASON only applies to AVR."
+#endif
+
 /**
  * I2C bus
  */

--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -142,6 +142,7 @@ extends      = common_avr8
 board        = sanguino_atmega1284p
 upload_speed = 115200
 board_upload.maximum_size = 130048
+build_flags  = ${common_avr8.build_flags} -DOPTIBOOT_RESET_REASON
 
 #
 # Melzi and clones (Zonestar Melzi2 with tuned flags)

--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -142,7 +142,6 @@ extends      = common_avr8
 board        = sanguino_atmega1284p
 upload_speed = 115200
 board_upload.maximum_size = 130048
-build_flags  = ${common_avr8.build_flags} -DOPTIBOOT_RESET_REASON
 
 #
 # Melzi and clones (Zonestar Melzi2 with tuned flags)


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

There is a potential boot-loop an AVR Platforms after the CPU was reset by a watchdog timeout and `watchdog_refresh()` is not called at least every 16ms until `watchdog_init()` gets called.
This can easily happen since there are a few busy waiting loops which don't refresh the watchdog in the first view lines of `setup()` (for example the serial interface is waited for 1000ms).
Also a lot of serial output can trigger this behaviour.

The boot loop, triggered by `D-1` looks like this…

<details><summary>**DETAILS**</summary>

```
start
echo:[0] HAL_init()
echo:[1] esp_wifi_init()
 External Reset
Marlin bugfix-2.0.x
echo: Last Updated: 2021-11-04 | Author: (none, default config)
echo: Compiled: Nov  4 2021
echo: Free Memory: 5546  PlannerBufferBytes: 1168
echo:[9] ui.init()
echo:[10] ui.reset_status()
echo:[11] settings.first_load()
echo:Hardcoded Default Settings Loaded
echo:; Linear Units:
  G21 ; (mm)
echo:; Temperature Units:
echo:  M149 C ; Units in Celsius
echo:; Filament settings (Disabled):
echo:  M200 S0 D1.75
echo:; Steps per unit:
echo:  M92 X80.00 Y80.00 Z400.00 E500.00
echo:; Max feedrates (units/s):
echo:  M203 X300.00 Y300.00 Z5.00 E25.00
echo:; Max Acceleration (units/s2):
echo:  M201 X3000.00 Y3000.00 Z100.00 E10000.00
echo:; Acceleration (units/s2) (P<print-accel> R<retract-accel> T<travel-accel>):
echo:  M204 P3000.00 R3000.00 T3000.00
echo:; Advanced (B<min_segment_time_us> S<min_feedrate> T<min_travel_feedrate> J<junc_dev>):
echo:  M205 B20000.00 S0.00 T0.00 J0.01
echo:; Home offset:
echo:  M206 X0.00 Y0.00 Z0.00
echo:; Hotend PID:
echo:  M301 P22.20 I1.08 D114.00
echo:[45] thermalManager.init()
echo:[49] print_job_timer.init()
echo:[51] endstops.init()
echo:[52] stepper.init()
echo:[53] watchdog_init()
echo:[54] setup() completed.
D-1
start
echo:[0] HAL_init()
echo:[1] esp_wifi_init()
 Watchdog Reset
Marlin bugfix-2.0.x
echo: Last Updated: 2021-11-04 | Author: (none, default config)
echo: Compiled: Nov  4 2021
echo: Free Memory: 5546  PlannerBufferBytes: 1168
echo:[9] ui.init()
echo:[10] ui.reset_status()
echo:[11] settings.first_load()
echo:Hardcoded Default Settings Loaded
echo:; Linear Units:
  G21 ; (mm)
echo:; Tem�start
echo:[0] HAL_init()
echo:[1] esp_wifi_init()
 Watchdog Reset
Marlin bugfix-2.0.x
echo: Last Updated: 2021-11-04 | Author: (none, default config)
echo: Compiled: Nov  4 2021
echo: Free Memory: 5546  PlannerBufferBytes: 1168
echo:[9] ui.init()
echo:[10] ui.reset_status()
echo:[11] settings.first_load()
echo:Hardcoded Default Settings Loaded
echo:; Linear Units:
  G21 ; (mm)
echo:; Tem�start
echo:[0] HAL_init()
echo:[1] esp_wifi_init()
 Watchdog Reset
[... and the loop continues ...]
```
</details>

The root cause for this issue is that the CPU automatically enables the watchdog with the default configuration (16ms watchdog timeout) if the the reset reason is a watchdog reset (`MCUSR & WDRF`).

To fix this problem, there are a lot of ways:
  1. Call `watchdog_refresh()` really really often in `setup()`
  1. Add a new HAL hook at the start of `setup()` which backups the reset reason and inits or disables the watchdog.
    a. Introduce a HAL struct which can carry HAL related information (like the reset reason) from one HAL hook to the next one during setup. This has the advantage that only more memory on the stack during `setup()` is required.
    b. Save the reset reason in a global variable, which has the disadvantage of permanently "wasting" 1 Byte.
  1. Use some compiler magic to backup the reset reason and init or disable the watchdog even before `setup()` is run (hence guaranteed within 16ms).
    a. Save the reset reason in a global variable, which has the disadvantage of permanently "wasting" 1 Byte.

This PR took route Nr. 3.
This also allows the routine to save the uncleaned reset reason stored by the Optiboot boot loard in register r2.
To accomplish this, the routine has to run as early as possible (so r2 won't be overwritten) but after the 0-register has been initialized.
The Optiboot feature is not terrible important, but it also doesn't hurt (also not in terms of RAM, EEPROM or complex code maintenance).

With this PR applied and `OPTIBOOT_RESET_REASON` not defined (the default) the boot loop is gone and the terminal output looks like the following:
```
start
echo:[0] HAL_init()
echo:[1] esp_wifi_init()
 External Reset
Marlin bugfix-2.0.x
[...]
echo:[54] setup() completed.
D-1
start
echo:[0] HAL_init()
echo:[1] esp_wifi_init()
 Watchdog Reset
Marlin bugfix-2.0.x
[...]
echo:[54] setup() completed.
```

With `OPTIBOOT_RESET_REASON` defined, the output looks like the following (notice the two reset reason at the first boot):
```
start
echo:[0] HAL_init()
echo:[1] esp_wifi_init()
 External Reset
 Watchdog Reset
Marlin bugfix-2.0.x
[...]
echo:[54] setup() completed.
D-1
start
echo:[0] HAL_init()
echo:[1] esp_wifi_init()
 Watchdog Reset
Marlin bugfix-2.0.x
[...]
echo:[54] setup() completed.
```

### Requirements

  * AVR Platform

### Benefits

  * Fix potential boot-loop on watchdog timeout
  * Add debug option to report original/uncleaned reset reason when using [Optiboot](https://github.com/Optiboot/optiboot/blob/68b7a55b1e65e57dc822e2d52c31d2da3c467b8f/optiboot/bootloaders/optiboot/optiboot.c#L728) bootloader

### Configurations

default config with dev mode is sufficient.
```C
#define MARLIN_DEV_MODE
```
(dev mode enables `D-1` to trigger the watchdog, but also slows down setup so the watchdog is not reset within the first 16ms)

### Related Issues

None so far. There are a lot of other ways to fix the problem. If this PR is not the favorable way to go, I guess it's best to open a issue for discussions.
