### PR TITLE
Rename and twist logic of apply leveling fuction

### DIFF
--- a/Marlin/src/feature/bedlevel/bedlevel.cpp
+++ b/Marlin/src/feature/bedlevel/bedlevel.cpp
@@ -76,15 +76,15 @@ void set_bed_leveling_enabled(const bool enable/*=true*/) {
     if (planner.leveling_active) {      // leveling from on to off
       if (DEBUGGING(LEVELING)) DEBUG_POS("Leveling ON", current_position);
       // change unleveled current_position to physical current_position without moving steppers.
-      planner.apply_leveling(current_position);
-      planner.leveling_active = false;  // disable only AFTER calling apply_leveling
+      planner.deactivate_leveling(current_position);
+      planner.leveling_active = false;  // disable only AFTER calling deactivate_leveling
       if (DEBUGGING(LEVELING)) DEBUG_POS("...Now OFF", current_position);
     }
     else {                              // leveling from off to on
       if (DEBUGGING(LEVELING)) DEBUG_POS("Leveling OFF", current_position);
-      planner.leveling_active = true;   // enable BEFORE calling unapply_leveling, otherwise ignored
+      planner.leveling_active = true;   // enable BEFORE calling activate_leveling, otherwise ignored
       // change physical current_position to unleveled current_position without moving steppers.
-      planner.unapply_leveling(current_position);
+      planner.activate_leveling(current_position);
       if (DEBUGGING(LEVELING)) DEBUG_POS("...Now ON", current_position);
     }
 

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -833,7 +833,7 @@ G29_TYPE GcodeSuite::G29() {
         if (DEBUGGING(LEVELING)) DEBUG_POS("G29 uncorrected XYZ", current_position);
 
         xyze_pos_t converted = current_position;
-        planner.force_unapply_leveling(converted); // use conversion machinery
+        planner.force_activate_leveling(converted); // use conversion machinery
 
         // Use the last measured distance to the bed, if possible
         if ( NEAR(current_position.x, abl.probePos.x - probe.offset_xy.x)

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -67,12 +67,12 @@
 
     #if HAS_LEVELING
       // Current position with leveling applied
-      SERIAL_ECHOPGM("Leveled:");
+      SERIAL_ECHOPGM("Remove Leveling:");
       planner.deactivate_leveling(leveled);
       report_linear_axis_pos(leveled);
 
       // Test planner un-leveling. This should match the Raw result.
-      SERIAL_ECHOPGM("UnLevel:");
+      SERIAL_ECHOPGM("Reapply Leveling:");
       xyze_pos_t unleveled = leveled;
       planner.activate_leveling(unleveled);
       report_linear_axis_pos(unleveled);

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -68,13 +68,13 @@
     #if HAS_LEVELING
       // Current position with leveling applied
       SERIAL_ECHOPGM("Leveled:");
-      planner.apply_leveling(leveled);
+      planner.deactivate_leveling(leveled);
       report_linear_axis_pos(leveled);
 
       // Test planner un-leveling. This should match the Raw result.
       SERIAL_ECHOPGM("UnLevel:");
       xyze_pos_t unleveled = leveled;
-      planner.unapply_leveling(unleveled);
+      planner.activate_leveling(unleveled);
       report_linear_axis_pos(unleveled);
     #endif
 

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -315,7 +315,7 @@ void plan_arc(
     apply_motion_limits(raw);
 
     #if HAS_LEVELING && !PLANNER_LEVELING
-      planner.apply_leveling(raw);
+      planner.deactivate_leveling(raw);
     #endif
 
     if (!planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, 0 OPTARG(SCARA_FEEDRATE_SCALING, inv_duration)))
@@ -331,7 +331,7 @@ void plan_arc(
   apply_motion_limits(raw);
 
   #if HAS_LEVELING && !PLANNER_LEVELING
-    planner.apply_leveling(raw);
+    planner.deactivate_leveling(raw);
   #endif
 
   planner.buffer_line(raw, scaled_fr_mm_s, active_extruder, 0 OPTARG(SCARA_FEEDRATE_SCALING, inv_duration));

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -353,7 +353,7 @@ void sync_plan_position() {
  *
  * The result is in the current coordinate space with
  * leveling applied. The coordinates need to be run through
- * unapply_leveling to obtain the "ideal" coordinates
+ * activate_leveling to obtain the "ideal" coordinates
  * suitable for current_position, etc.
  */
 void get_cartesian_from_steppers() {

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1564,7 +1564,7 @@ void Planner::check_axes_activity() {
    * rx, ry, rz - Cartesian positions in mm
    *              Leveled XYZ on completion
    */
-  void Planner::apply_leveling(xyz_pos_t &raw) {
+  void Planner::deactivate_leveling(xyz_pos_t &raw) {
     if (!leveling_active) return;
 
     #if ABL_PLANAR
@@ -1594,7 +1594,7 @@ void Planner::check_axes_activity() {
     #endif
   }
 
-  void Planner::unapply_leveling(xyz_pos_t &raw) {
+  void Planner::activate_leveling(xyz_pos_t &raw) {
 
     if (leveling_active) {
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -646,16 +646,16 @@ class Planner {
        * Apply leveling to transform a cartesian position
        * as it will be given to the planner and steppers.
        */
-      static void apply_leveling(xyz_pos_t &raw);
-      static void unapply_leveling(xyz_pos_t &raw);
-      FORCE_INLINE static void force_unapply_leveling(xyz_pos_t &raw) {
+      static void deactivate_leveling(xyz_pos_t &raw);
+      static void activate_leveling(xyz_pos_t &raw);
+      FORCE_INLINE static void force_activate_leveling(xyz_pos_t &raw) {
         leveling_active = true;
-        unapply_leveling(raw);
+        activate_leveling(raw);
         leveling_active = false;
       }
     #else
-      FORCE_INLINE static void apply_leveling(xyz_pos_t&) {}
-      FORCE_INLINE static void unapply_leveling(xyz_pos_t&) {}
+      FORCE_INLINE static void deactivate_leveling(xyz_pos_t&) {}
+      FORCE_INLINE static void activate_leveling(xyz_pos_t&) {}
     #endif
 
     #if ENABLED(FWRETRACT)
@@ -668,13 +668,13 @@ class Planner {
     #if HAS_POSITION_MODIFIERS
       FORCE_INLINE static void apply_modifiers(xyze_pos_t &pos, bool leveling=ENABLED(PLANNER_LEVELING)) {
         TERN_(SKEW_CORRECTION, skew(pos));
-        if (leveling) apply_leveling(pos);
+        if (leveling) deactivate_leveling(pos);
         TERN_(FWRETRACT, apply_retract(pos));
       }
 
       FORCE_INLINE static void unapply_modifiers(xyze_pos_t &pos, bool leveling=ENABLED(PLANNER_LEVELING)) {
         TERN_(FWRETRACT, unapply_retract(pos));
-        if (leveling) unapply_leveling(pos);
+        if (leveling) activate_leveling(pos);
         TERN_(SKEW_CORRECTION, unskew(pos));
       }
     #endif // HAS_POSITION_MODIFIERS

--- a/Marlin/src/module/planner_bezier.cpp
+++ b/Marlin/src/module/planner_bezier.cpp
@@ -195,7 +195,7 @@ void cubic_b_spline(
 
     #if HAS_LEVELING && !PLANNER_LEVELING
       xyze_pos_t pos = bez_target;
-      planner.apply_leveling(pos);
+      planner.deactivate_leveling(pos);
     #else
       const xyze_pos_t &pos = bez_target;
     #endif


### PR DESCRIPTION
If we change leveling state from active to deactive , we call planner.apply_leveling()
and if we change leveling_state to active, we call planner.unapply_leveling()

I think the logic is twisted. Therefore I rename the function 
- apply_leveling to deactivate_leveling
- unapply_leveling to activate_leveling

