### PR TITLE
Fix inconsistency in M503 output

### DIFF
--- a/Marlin/src/gcode/config/M304.cpp
+++ b/Marlin/src/gcode/config/M304.cpp
@@ -43,7 +43,7 @@ void GcodeSuite::M304() {
 
 void GcodeSuite::M304_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, F(STR_BED_PID));
-  SERIAL_ECHO_MSG(
+  SERIAL_ECHOLNPGM(
       "  M304 P", thermalManager.temp_bed.pid.Kp
     , " I", unscalePID_i(thermalManager.temp_bed.pid.Ki)
     , " D", unscalePID_d(thermalManager.temp_bed.pid.Kd)

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3067,11 +3067,10 @@ void MarlinSettings::reset() {
     // Announce current units, in case inches are being displayed
     //
     CONFIG_ECHO_HEADING("Linear Units");
-    CONFIG_ECHO_START();
     #if ENABLED(INCH_MODE_SUPPORT)
-      SERIAL_ECHOPGM("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
+      SERIAL_ECHO_MSG("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
     #else
-      SERIAL_ECHOPGM("  G21 ;");
+      SERIAL_ECHO_MSG("  G21 ;");
     #endif
     gcode.say_units();
 

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3067,6 +3067,7 @@ void MarlinSettings::reset() {
     // Announce current units, in case inches are being displayed
     //
     CONFIG_ECHO_HEADING("Linear Units");
+    CONFIG_ECHO_START();
     #if ENABLED(INCH_MODE_SUPPORT)
       SERIAL_ECHOPGM("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
     #else


### PR DESCRIPTION
### Description

    echo:; Linear Units:
      G21 ; (mm)
    echo:; Temperature Units:
    echo:  M149 C ; Units in Celsius
    <...>

All lines start with 'echo:'
The second one didn't, fixed that:

    echo:; Linear Units:
    echo:  G21 ; (mm)
    echo:; Temperature Units:
    echo:  M149 C ; Units in Celsius
    <...>

### Requirements

None

### Benefits

Fix

### Configurations

None

### Related Issues

None?