### PR TITLE
Add Optional Verbose Preheating to Probing/Leveling

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1288,7 +1288,6 @@
 #if ENABLED(PREHEAT_BEFORE_PROBING)
   #define PROBING_NOZZLE_TEMP 120   // (°C) Only applies to E0 at this time
   #define PROBING_BED_TEMP     50
-  #define VERBOSE_PREHEAT_BEFORE_PROBING // Show a "Preheating..." message while heating
 #endif
 
 // For Inverting Stepper Enable Pins (Active Low) use 0, Non Inverting (Active High) use 1
@@ -1555,7 +1554,6 @@
 #if ENABLED(PREHEAT_BEFORE_LEVELING)
   #define LEVELING_NOZZLE_TEMP 120   // (°C) Only applies to E0 at this time
   #define LEVELING_BED_TEMP     50
-  #define VERBOSE_PREHEAT_BEFORE_LEVELING // Show a "Preheating..." message while heating
 #endif
 
 /**

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1288,6 +1288,7 @@
 #if ENABLED(PREHEAT_BEFORE_PROBING)
   #define PROBING_NOZZLE_TEMP 120   // (°C) Only applies to E0 at this time
   #define PROBING_BED_TEMP     50
+  #define VERBOSE_PREHEAT_BEFORE_PROBING // Show a "Preheating..." message while heating
 #endif
 
 // For Inverting Stepper Enable Pins (Active Low) use 0, Non Inverting (Active High) use 1
@@ -1554,6 +1555,7 @@
 #if ENABLED(PREHEAT_BEFORE_LEVELING)
   #define LEVELING_NOZZLE_TEMP 120   // (°C) Only applies to E0 at this time
   #define LEVELING_BED_TEMP     50
+  #define VERBOSE_PREHEAT_BEFORE_LEVELING // Show a "Preheating..." message while heating
 #endif
 
 /**

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -531,6 +531,7 @@ namespace Language_en {
   LSTR MSG_ERR_MINTEMP                    = _UxGT("Err: MINTEMP");
   LSTR MSG_HALTED                         = _UxGT("PRINTER HALTED");
   LSTR MSG_PLEASE_RESET                   = _UxGT("Please Reset");
+  LSTR MSG_PREHEATING                     = _UxGT("Preheating...");
   LSTR MSG_HEATING                        = _UxGT("Heating...");
   LSTR MSG_COOLING                        = _UxGT("Cooling...");
   LSTR MSG_BED_HEATING                    = _UxGT("Bed Heating...");

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -362,11 +362,9 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
       #define WAIT_FOR_BED_HEAT
     #endif
 
-    DEBUG_ECHOPGM("Preheating ");
+    LCD_MESSAGE(MSG_PREHEATING);
 
-    #if EITHER(VERBOSE_PREHEAT_BEFORE_PROBING, VERBOSE_PREHEAT_BEFORE_LEVELING)
-      LCD_MESSAGE(MSG_PREHEATING);
-    #endif
+    DEBUG_ECHOPGM("Preheating ");
 
     #if ENABLED(WAIT_FOR_NOZZLE_HEAT)
       const celsius_t hotendPreheat = hotend_temp > thermalManager.degTargetHotend(0) ? hotend_temp : 0;

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -364,6 +364,10 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
 
     DEBUG_ECHOPGM("Preheating ");
 
+    #if EITHER(VERBOSE_PREHEAT_BEFORE_PROBING, VERBOSE_PREHEAT_BEFORE_LEVELING)
+      LCD_MESSAGE(MSG_PREHEATING);
+    #endif
+
     #if ENABLED(WAIT_FOR_NOZZLE_HEAT)
       const celsius_t hotendPreheat = hotend_temp > thermalManager.degTargetHotend(0) ? hotend_temp : 0;
       if (hotendPreheat) {


### PR DESCRIPTION
### Description

For printers using the nozzle & a strain gauge as a probe (Anycubic Vyper,  CR-6 SE, Biqu B1 SE, B1 SE Plus, etc.), it's recommended to enable `PREHEAT_BEFORE_PROBING` or `PREHEAT_BEFORE_LEVELING` since cold plastic stuck the the nozzle will cause issues with a proper first layer.

This works great, except the only feedback the user receives is `Preheating...` sent over serial & the hotend/bed temperatures increasing. Having feedback in the status area, would clue the user into what's going on.

I've added & enabled a verbose mode for `PREHEAT_BEFORE_PROBING` and `PREHEAT_BEFORE_LEVELING` to make it clearer what the printer is doing.

### Requirements

Any `PREHEAT_BEFORE_PROBING` or `PREHEAT_BEFORE_LEVELING` config.

### Benefits

Users will have better idea of what their printer is up to.

### Related Issues

None. Found while working on the B1 SE / SE Plus builds.