### PR TITLE
Fix typo in DGUS_LCD_UI_RELOADED, DGUSScreenHandler::SetStatusMessage

### DIFF
--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -416,7 +416,7 @@ void DGUSScreenHandler::SetStatusMessage(FSTR_P const fmsg, const millis_t durat
 
 void DGUSScreenHandler::ShowWaitScreen(DGUS_Screen return_screen, bool has_continue) {
   if (return_screen != DGUS_Screen::WAIT) {
-    wait_return_screen = return_screen;f
+    wait_return_screen = return_screen;
   }
   wait_continue = has_continue;
 

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -409,14 +409,14 @@ void DGUSScreenHandler::SetStatusMessage(const char* msg, const millis_t duratio
 }
 
 void DGUSScreenHandler::SetStatusMessage(FSTR_P const fmsg, const millis_t duration) {
-  dgus_display.WriteStringPGM((uint16_t)DGUS_Addr::MESSAGE_Status, FTOP(msg), DGUS_STATUS_LEN, false, true);
+  dgus_display.WriteStringPGM((uint16_t)DGUS_Addr::MESSAGE_Status, FTOP(fmsg), DGUS_STATUS_LEN, false, true);
 
   status_expire = (duration > 0 ? ExtUI::safe_millis() + duration : 0);
 }
 
 void DGUSScreenHandler::ShowWaitScreen(DGUS_Screen return_screen, bool has_continue) {
   if (return_screen != DGUS_Screen::WAIT) {
-    wait_return_screen = return_screen;
+    wait_return_screen = return_screen;f
   }
   wait_continue = has_continue;
 


### PR DESCRIPTION
### Description

In the DGUS_LCD_UI_RELOADED code
void DGUSScreenHandler::SetStatusMessage(FSTR_P const fmsg, const millis_t duration) 
But in the function it attempt to use uses the variable msg when it was defined as fmsg

Updated to use fmsg

### Requirements
DGUS_LCD_UI_RELOADED and all its requirements

### Benefits

Compiles as expected

### Configurations

My test config
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/7491500/Configuration.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/23089