### PR TITLE
Add BTT002 (STM32F407VET6), Use MK3_FAN_PINS Flag

### DIFF
--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -616,7 +616,7 @@
 #elif MB(BTT_GTR_V1_0)
   #include "stm32f4/pins_BTT_GTR_V1_0.h"        // STM32F4                                env:BIGTREE_GTR_V1_0 env:BIGTREE_GTR_V1_0_usb_flash_drive
 #elif MB(BTT_BTT002_V1_0)
-  #include "stm32f4/pins_BTT_BTT002_V1_0.h"     // STM32F4                                env:BIGTREE_BTT002
+  #include "stm32f4/pins_BTT_BTT002_V1_0.h"     // STM32F4                                env:BIGTREE_BTT002 env:BIGTREE_BTT002_VET6
 #elif MB(BTT_E3_RRF)
   #include "stm32f4/pins_BTT_E3_RRF.h"          // STM32F4                                env:BIGTREE_E3_RRF
 #elif MB(BTT_SKR_V2_0_REV_A)

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -29,6 +29,8 @@
 
 #define BOARD_INFO_NAME "BTT BTT002 V1.0"
 
+//#define MK3_FAN_PINS
+
 #define USES_DIAG_PINS
 
 // Ignore temp readings during development.
@@ -169,8 +171,22 @@
 //
 #define HEATER_0_PIN                        PE6   // Heater0
 #define HEATER_BED_PIN                      PE5   // Hotbed
-#define FAN_PIN                             PB8   // Fan1
-#define FAN1_PIN                            PB9   // Fan0
+
+#ifndef FAN_PIN
+  #ifdef MK3_FAN_PINS
+    #define FAN_PIN                         PB8   // Fan1
+  #else
+    #define FAN_PIN                         PB9   // Fan0
+  #endif
+#endif
+
+#ifndef FAN1_PIN
+  #ifdef MK3_FAN_PINS
+    #define FAN1_PIN                        PB9   // Fan0
+  #else
+    #define FAN1_PIN                        PB8   // Fan1
+  #endif
+#endif
 
 /**
  * -----------------------------------BTT002 V1.0----------------------------------------

--- a/buildroot/share/PlatformIO/boards/marlin_BigTree_BTT002_VET6.json
+++ b/buildroot/share/PlatformIO/boards/marlin_BigTree_BTT002_VET6.json
@@ -1,0 +1,46 @@
+{
+  "build": {
+    "core": "stm32",
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32F4 -DSTM32F407xx -DSTM32F40_41xxx",
+    "f_cpu": "168000000L",
+    "hwids": [
+      [
+        "0x1EAF",
+        "0x0003"
+      ],
+      [
+        "0x0483",
+        "0x3748"
+      ]
+    ],
+    "mcu": "stm32f407vet6",
+    "variant": "MARLIN_BIGTREE_BTT002"
+  },
+  "debug": {
+    "jlink_device": "STM32F407VE",
+    "openocd_target": "stm32f4x",
+    "svd_path": "STM32F40x.svd"
+  },
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "STM32F407VE (192k RAM. 512k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 131072,
+    "maximum_size": 524288,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "dfu",
+      "jlink"
+    ],
+    "offset_address": "0x8008000",
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f407ve.html",
+  "vendor": "ST"
+}

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -205,6 +205,14 @@ build_flags        = ${stm32_variant.build_flags}
                      -DPIN_SERIAL2_TX=PD_5
 
 #
+# BigTreeTech BTT002 V1.x with 512k of flash (STM32F407VET6 ARM Cortex-M4)
+#
+[env:BIGTREE_BTT002_VET6]
+platform          = ${env:BIGTREE_BTT002.platform}
+extends           = env:BIGTREE_BTT002
+board             = marlin_BigTree_BTT002_VET6
+
+#
 # BigTreeTech SKR V2.0 (STM32F407VGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
 [env:BIGTREE_SKR_2]


### PR DESCRIPTION
### Description

- Add BTT002 (STM32F407VET6)
- When using the Einsy Rambo/Prusa MK3 config, users can enable `MK3_FAN_PINS` to swap FAN0 & FAN1 pins. This was not possible on the BTT002 (since it wasn't designed for older Prusas), but these boards are being used in the entire line up of MKx printers.

### Requirements

BTT002-based printers.

### Benefits

Allows users to override default fan pins depending on printer config, build for smaller BTT002 builds.

### Configurations

~~I'll update the BTT002 build & readme in https://github.com/MarlinFirmware/Configurations/pull/607 if this is merged.~~ Commit has been pushed, but can be reverted.

### Related Issues

- https://github.com/MarlinFirmware/Configurations/pull/607

I'd recommend a special callout in the release notes since `MK3_FAN_PINS` will need to be enabled for MK3/S/+ users.