### PR TITLE
Allow Some Probe-Related Overrides

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_CR6.h
@@ -70,9 +70,14 @@
 //
 // Probe
 //
-#define PROBE_TARE_PIN                      PA1
+#ifndef PROBE_TARE_PIN
+  #define PROBE_TARE_PIN                    PA1
+#endif
+
 #if ENABLED(PROBE_ACTIVATION_SWITCH)
-  #define PROBE_ACTIVATION_SWITCH_PIN       PC2   // Optoswitch to Enable Z Probe
+  #ifndef PROBE_ACTIVATION_SWITCH_PIN
+    #define PROBE_ACTIVATION_SWITCH_PIN     PC2   // Optoswitch to Enable Z Probe
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
@@ -36,7 +36,9 @@
 #define FAN_PIN                             PA0   // FAN
 
 #if ENABLED(PROBE_ACTIVATION_SWITCH)
-  #define PROBE_ACTIVATION_SWITCH_PIN       PC6   // Optoswitch to Enable Z Probe
+  #ifndef PROBE_ACTIVATION_SWITCH_PIN
+    #define PROBE_ACTIVATION_SWITCH_PIN     PC6   // Optoswitch to Enable Z Probe
+  #endif
 #endif
 
 #include "pins_CREALITY_V45x.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V453.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V453.h
@@ -36,7 +36,9 @@
 #define FAN_PIN                             PB15  // FAN
 
 #if ENABLED(PROBE_ACTIVATION_SWITCH)
-  #define PROBE_ACTIVATION_SWITCH_PIN       PB2   // Optoswitch to Enable Z Probe
+  #ifndef PROBE_ACTIVATION_SWITCH_PIN
+    #define PROBE_ACTIVATION_SWITCH_PIN     PB2   // Optoswitch to Enable Z Probe
+  #endif
 #endif
 
 #include "pins_CREALITY_V45x.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V45x.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V45x.h
@@ -64,7 +64,9 @@
 //
 // Probe
 //
-#define PROBE_TARE_PIN                      PA5
+#ifndef PROBE_TARE_PIN
+  #define PROBE_TARE_PIN                    PA5
+#endif
 
 //
 // Steppers

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -136,7 +136,9 @@
 // Probe enable
 //
 #if ENABLED(PROBE_ENABLE_DISABLE)
-  #define PROBE_ENABLE_PIN            SERVO0_PIN
+  #ifndef PROBE_ENABLE_PIN
+    #define PROBE_ENABLE_PIN          SERVO0_PIN
+  #endif
 #endif
 
 //


### PR DESCRIPTION
### Description

Since users can override these probe-related pins in `Configuration.h`, it would make sense to wrap them in ifndefs to prevent a wall of redefined warnings (and allow users to actually override the defaults).

### Requirements

`PROBE_TARE_PIN`, `PROBE_ACTIVATION_SWITCH_PIN`, or `PROBE_ENABLE_PIN`-based build.

### Benefits

Users can override these pins without a wall of warnings.

### Related Issues

- https://github.com/MarlinFirmware/Marlin/pull/23101