### PR TITLE
Fix compilation error with RGB case lights

### DIFF
--- a/Marlin/src/feature/caselight.cpp
+++ b/Marlin/src/feature/caselight.cpp
@@ -39,7 +39,6 @@ CaseLight caselight;
 bool CaseLight::on = CASE_LIGHT_DEFAULT_ON;
 
 #if CASE_LIGHT_IS_COLOR_LED
-  #include "leds/leds.h"
   constexpr uint8_t init_case_light[] = CASE_LIGHT_DEFAULT_COLOR;
   LEDColor CaseLight::color = { init_case_light[0], init_case_light[1], init_case_light[2] OPTARG(HAS_WHITE_LED, init_case_light[3]) };
 #endif
@@ -65,7 +64,7 @@ void CaseLight::update(const bool sflag) {
   #endif
 
   #if CASE_LIGHT_IS_COLOR_LED
-    leds.set_color(LEDColor(color.r, color.g, color.b OPTARG(HAS_WHITE_LED, color.w), n10ct));
+    leds.set_color(LEDColor(color.r, color.g, color.b OPTARG(HAS_WHITE_LED, color.w) OPTARG(NEOPIXEL_LED, n10ct)));
   #else // !CASE_LIGHT_IS_COLOR_LED
 
     #if CASELIGHT_USES_BRIGHTNESS


### PR DESCRIPTION
### Description

When enabling case lights with RGB LEDs, compilation fails. To fix this, the optional (NeoPixel only) argument has to match the [definition](https://github.com/MarlinFirmware/Marlin/blob/49e8defda11c0c62098d86e4ced947468cd2f289/Marlin/src/feature/leds/leds.h#L121) of `leds.set_color()`.

And while on it, I also remove a redundant include (which gets already included in `caselight.h`).

### Requirements

none, compile time error

### Benefits

RGB LEDs, to make your gamer printer run faster.

### Configurations

Default config with `RGB_LED` (and hence `RGB_LED_R_PIN`, `RGB_LED_G_PIN`, `RGB_LED_B_PIN`) enabled, as well as `CASE_LIGHT_ENABLE` and `CASE_LIGHT_USE_RGB_LED`.

Aside: Is it easier for you if I provide you with a description of what to change in your own printer's config (like I did here) or if I provide you with a full config file, which may not match your printers config and makes testing probably harder?

### Related Issues

I found no related issues.
