### PR TITLE
Fix.lcp1768.pwm

### DIFF
--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -269,7 +269,7 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
         top = TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255);
       else {
         top = *timer.ICRn;  // top = ICRn
-        _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top) / float(v_size)); // Scale 8/16-bit v to top value
+        _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top) / float(v_size) + 0.5f); // Scale 8/16-bit v to top value
       }
     }
 

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -258,18 +258,17 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
       if (timer.n == 0) return; // Don't proceed if protected timer or not recognized
       // Set compare output mode to CLEAR -> SET or SET -> CLEAR (if inverted)
       _SET_COMnQ(timer.TCCRnQ, (timer.q
-        #ifdef TCCR2
-          + (timer.q == 2) // COM20 is on bit 4 of TCCR2, thus requires q + 1 in the macro
-        #endif
+          #ifdef TCCR2
+            + (timer.q == 2) // COM20 is on bit 4 of TCCR2, thus requires q + 1 in the macro
+          #endif
         ), COM_CLEAR_SET + invert
       );
 
       uint16_t top;
-      if (timer.n == 2) { // if TIMER2
-        top = TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0],255);
-      }
+      if (timer.n == 2)     // if TIMER2
+        top = TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255);
       else {
-        top = *timer.ICRn; // top = ICRn
+        top = *timer.ICRn;  // top = ICRn
         _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top) / float(v_size)); // Scale 8/16-bit v to top value
       }
     }

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -269,7 +269,7 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
         top = TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255);
       else {
         top = *timer.ICRn;  // top = ICRn
-        _SET_OCRnQ(timer.OCRnQ, timer.q, v * float(top) / float(v_size) + 0.5f); // Scale 8/16-bit v to top value
+        _SET_OCRnQ(timer.OCRnQ, timer.q, (v * top + v_size / 2) / v_size); // Scale 8/16-bit v to top value
       }
     }
 

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -258,19 +258,18 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
       if (timer.n == 0) return; // Don't proceed if protected timer or not recognized
       // Set compare output mode to CLEAR -> SET or SET -> CLEAR (if inverted)
       _SET_COMnQ(timer.TCCRnQ, (timer.q
-          #ifdef TCCR2
-            + (timer.q == 2) // COM20 is on bit 4 of TCCR2, thus requires q + 1 in the macro
-          #endif
+        #ifdef TCCR2
+          + (timer.q == 2) // COM20 is on bit 4 of TCCR2, thus requires q + 1 in the macro
+        #endif
         ), COM_CLEAR_SET + invert
       );
 
       uint16_t top;
-      if (timer.n == 2)     // if TIMER2
-        top = TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255);
-      else {
-        top = *timer.ICRn;  // top = ICRn
-        _SET_OCRnQ(timer.OCRnQ, timer.q, (v * top + v_size / 2) / v_size); // Scale 8/16-bit v to top value
-      }
+      if (timer.n == 2)  // if TIMER2
+        top = TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0],255);
+      else 
+        top = *timer.ICRn; // top = ICRn
+        _SET_OCRnQ(timer.OCRnQ, timer.q, v * (top / v_size)); // Scale 8/16-bit v to top value
     }
 
   #else

--- a/Marlin/src/HAL/LPC1768/fast_pwm.cpp
+++ b/Marlin/src/HAL/LPC1768/fast_pwm.cpp
@@ -25,7 +25,9 @@
 #include <pwm.h>
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
-  LPC176x::pwm_write_ratio(pin, invert ? 1.0f - (float)v / v_size : (float)v / v_size);
+  if (!LPC176x::pin_is_valid(pin)) return;
+  if (LPC176x::pwm_attach_pin(pin)) 
+    LPC176x::pwm_write_ratio(pin, invert ? 1.0f - (float)v / v_size : (float)v / v_size);  // map 1-254 onto PWM range
 }
 
 #if NEEDS_HARDWARE_PWM // Specific meta-flag for features that mandate PWM

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -74,13 +74,12 @@ void ControllerFan::update() {
 
     #if ENABLED(FAN_SOFT_PWM)
       thermalManager.soft_pwm_controller_speed = speed;
-    #else  
-      if (PWM_PIN(CONTROLLER_FAN_PIN)) {
+    #else
+      if (PWM_PIN(CONTROLLER_FAN_PIN))
         set_pwm_duty(pin_t(CONTROLLER_FAN_PIN), speed);
-      }
       else
         WRITE(CONTROLLER_FAN_PIN, speed > 0);
-    #endif  
+    #endif
   }
 }
 

--- a/Marlin/src/feature/controllerfan.cpp
+++ b/Marlin/src/feature/controllerfan.cpp
@@ -72,10 +72,15 @@ void ControllerFan::update() {
       ? settings.active_speed : settings.idle_speed
     );
 
-    if (PWM_PIN(CONTROLLER_FAN_PIN))
-      set_pwm_duty(pin_t(CONTROLLER_FAN_PIN), speed);
-    else
-      WRITE(CONTROLLER_FAN_PIN, speed);
+    #if ENABLED(FAN_SOFT_PWM)
+      thermalManager.soft_pwm_controller_speed = speed;
+    #else  
+      if (PWM_PIN(CONTROLLER_FAN_PIN)) {
+        set_pwm_duty(pin_t(CONTROLLER_FAN_PIN), speed);
+      }
+      else
+        WRITE(CONTROLLER_FAN_PIN, speed > 0);
+    #endif  
   }
 }
 

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -266,10 +266,10 @@ void menu_advanced_settings();
   void menu_controller_fan() {
     START_MENU();
     BACK_ITEM(MSG_CONFIGURATION);
-    EDIT_ITEM_FAST(percent, MSG_CONTROLLER_FAN_IDLE_SPEED, &controllerFan.settings.idle_speed, _MAX(1, CONTROLLERFAN_SPEED_MIN) - 1, 255);
+    EDIT_ITEM_FAST(percent, MSG_CONTROLLER_FAN_IDLE_SPEED, &controllerFan.settings.idle_speed, CONTROLLERFAN_SPEED_MIN, 255);
     EDIT_ITEM(bool, MSG_CONTROLLER_FAN_AUTO_ON, &controllerFan.settings.auto_mode);
     if (controllerFan.settings.auto_mode) {
-      EDIT_ITEM_FAST(percent, MSG_CONTROLLER_FAN_SPEED, &controllerFan.settings.active_speed, _MAX(1, CONTROLLERFAN_SPEED_MIN) - 1, 255);
+      EDIT_ITEM_FAST(percent, MSG_CONTROLLER_FAN_SPEED, &controllerFan.settings.active_speed, CONTROLLERFAN_SPEED_MIN, 255);
       EDIT_ITEM(uint16_4, MSG_CONTROLLER_FAN_DURATION, &controllerFan.settings.duration, 0, 4800);
     }
     END_MENU();

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -919,7 +919,7 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
           #endif
           break;
       }
-      
+
       switch (f) {
         #if HAS_AUTO_FAN_0
           case 0: _UPDATE_AUTO_FAN(E0, fan_on, EXTRUDER_AUTO_FAN_SPEED); break;
@@ -3067,11 +3067,11 @@ void Temperature::isr() {
       #if HAS_COOLER
         _PWM_MOD(COOLER, soft_pwm_cooler, temp_cooler);
       #endif
-      
+
       #if BOTH(USE_CONTROLLER_FAN, FAN_SOFT_PWM)
         WRITE(CONTROLLER_FAN_PIN, soft_pwm_controller.add(pwm_mask, soft_pwm_controller_speed));
-      #endif  
-          
+      #endif
+
       #if ENABLED(FAN_SOFT_PWM)
         #define _FAN_PWM(N) do{                                     \
           uint8_t &spcf = soft_pwm_count_fan[N];                    \

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -913,18 +913,13 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
             chamberfan_speed = fan_on ? CHAMBER_AUTO_FAN_SPEED : 0;
             break;
         #endif
-        #if ENABLED(AUTO_POWER_COOLER_FAN)
-          case COOLER_FAN_INDEX:
-            coolerfan_speed = fan_on ? COOLER_AUTO_FAN_SPEED : 0;
-            break;
-        #endif  
         default:
           #if ENABLED(AUTO_POWER_E_FANS)
             autofan_speed[realFan] = fan_on ? EXTRUDER_AUTO_FAN_SPEED : 0;
           #endif
           break;
       }
-
+      
       switch (f) {
         #if HAS_AUTO_FAN_0
           case 0: _UPDATE_AUTO_FAN(E0, fan_on, EXTRUDER_AUTO_FAN_SPEED); break;

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -386,7 +386,11 @@ class Temperature {
       static uint8_t soft_pwm_amount_fan[FAN_COUNT],
                      soft_pwm_count_fan[FAN_COUNT];
     #endif
-
+    
+    #if BOTH(FAN_SOFT_PWM, USE_CONTROLLER_FAN)
+        static uint8_t soft_pwm_controller_speed;
+    #endif
+    
     #if ENABLED(PREVENT_COLD_EXTRUSION)
       static bool allow_cold_extrude;
       static celsius_t extrude_min_temp;

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -386,11 +386,11 @@ class Temperature {
       static uint8_t soft_pwm_amount_fan[FAN_COUNT],
                      soft_pwm_count_fan[FAN_COUNT];
     #endif
-    
+
     #if BOTH(FAN_SOFT_PWM, USE_CONTROLLER_FAN)
-        static uint8_t soft_pwm_controller_speed;
+      static uint8_t soft_pwm_controller_speed;
     #endif
-    
+
     #if ENABLED(PREVENT_COLD_EXTRUSION)
       static bool allow_cold_extrude;
       static celsius_t extrude_min_temp;


### PR DESCRIPTION
### Description

Presently set_pwm_duty in the LCP176x HAL does not properly setup a PWM pin if the channel was not previously configured. This PR adds the required calls to correct it.

### Requirements

Any LCP1768x Board

### Benefits

PWM pins operate consistently 

### Configurations

### Related Issues

