### PR TITLE
Fix LCP1768 set_pwm_duty pin setup

### DIFF
--- a/Marlin/src/HAL/LPC1768/fast_pwm.cpp
+++ b/Marlin/src/HAL/LPC1768/fast_pwm.cpp
@@ -25,7 +25,9 @@
 #include <pwm.h>
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
-  LPC176x::pwm_write_ratio(pin, invert ? 1.0f - (float)v / v_size : (float)v / v_size);
+  if (!LPC176x::pin_is_valid(pin)) return;
+  if (LPC176x::pwm_attach_pin(pin)) 
+    LPC176x::pwm_write_ratio(pin, invert ? 1.0f - (float)v / v_size : (float)v / v_size);  // map 1-254 onto PWM range
 }
 
 #if NEEDS_HARDWARE_PWM // Specific meta-flag for features that mandate PWM


### PR DESCRIPTION
Description

Presently set_pwm_duty in the LCP176x HAL does not properly setup a PWM pin if the channel was not previously configured. This PR adds the required calls to correct it.

Requirements

Any LCP1768x Board

Benefits

PWM pins operate consistently

Configurations

Related Issues
#23094