### PR TITLE
Display flow rate instead of feedrate (DOGM, Classic UI)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1302,6 +1302,10 @@
 
   // Show the E position (filament used) during printing
   //#define LCD_SHOW_E_TOTAL
+
+  // Display flow rate instead of feedrate (DOGM, Classic UI)
+  //#define STATUS_FLOW_INSTEAD_OF_FEEDRATE true
+
 #endif
 
 // LCD Print Progress options

--- a/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_DOGM.cpp
@@ -49,6 +49,10 @@
   #include "../../module/planner.h"
 #endif
 
+#if ENABLED(STATUS_FLOW_INSTEAD_OF_FEEDRATE)
+  #include "../../module/planner.h"
+#endif
+
 #if HAS_CUTTER
   #include "../../feature/spindle_laser.h"
 #endif
@@ -903,13 +907,19 @@ void MarlinUI::draw_status_screen() {
   #define EXTRAS_2_BASELINE (EXTRAS_BASELINE + 3)
 
   if (PAGE_CONTAINS(EXTRAS_2_BASELINE - INFO_FONT_ASCENT, EXTRAS_2_BASELINE - 1)) {
-    set_font(FONT_MENU);
-    lcd_put_wchar(3, EXTRAS_2_BASELINE, LCD_STR_FEEDRATE[0]);
-
-    set_font(FONT_STATUSMENU);
-    lcd_put_u8str(12, EXTRAS_2_BASELINE, i16tostr3rj(feedrate_percentage));
-    lcd_put_wchar('%');
-
+    #if ENABLED(STATUS_FLOW_INSTEAD_OF_FEEDRATE)
+      set_font(FONT_MENU);
+      lcd_put_wchar(3, EXTRAS_2_BASELINE, 'F');
+      set_font(FONT_STATUSMENU);
+      lcd_put_u8str(12, EXTRAS_2_BASELINE, i16tostr3rj(planner.flow_percentage[active_extruder]));
+      lcd_put_wchar('%');
+    #else
+      set_font(FONT_MENU);
+      lcd_put_wchar(3, EXTRAS_2_BASELINE, LCD_STR_FEEDRATE[0]);
+      set_font(FONT_STATUSMENU);
+      lcd_put_u8str(12, EXTRAS_2_BASELINE, i16tostr3rj(feedrate_percentage));
+      lcd_put_wchar('%');
+    #endif
     //
     // Filament sensor display if SD is disabled
     //


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Display flow rate instead of feedrate for DOGM and inherit interfaces
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
For any boards which use DOGM and inherited interfaces

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Allow show filament flow rate.
It is very important at time of printing with non standart, especialy self made, filaments 

<!-- What does this PR fix or improve? -->

### Configurations
Aditional configuration parameter included to Configuration_adv.h and commented out
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
No related issue
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
