### PR TITLE
TFT_COLOR_UI: Avoid menu item display bug on SD release

### DIFF
--- a/Marlin/src/gcode/sd/M21_M22.cpp
+++ b/Marlin/src/gcode/sd/M21_M22.cpp
@@ -26,11 +26,6 @@
 
 #include "../gcode.h"
 #include "../../sd/cardreader.h"
-#include "../../lcd/marlinui.h"
-
-#if HAS_LCD_MENU
-  #include "../../lcd/menu/menu.h" // encoderTopLine
-#endif
 
 /**
  * M21: Init SD Card
@@ -42,13 +37,6 @@ void GcodeSuite::M21() { card.mount(); }
  */
 void GcodeSuite::M22() {
   if (!IS_SD_PRINTING()) card.release();
-  #if ENABLED(TFT_COLOR_UI)
-    // Menu display issue on item removal with multi language selection menu
-    #if !PIN_EXISTS(SD_DETECT)
-      if (encoderTopLine > 0 && ui.currentScreen == menu_main) encoderTopLine--;
-    #endif
-    ui.refresh(LCDVIEW_CALL_REDRAW_NEXT);
-  #endif
 }
 
 #endif // SDSUPPORT

--- a/Marlin/src/gcode/sd/M21_M22.cpp
+++ b/Marlin/src/gcode/sd/M21_M22.cpp
@@ -28,6 +28,10 @@
 #include "../../sd/cardreader.h"
 #include "../../lcd/marlinui.h"
 
+#if HAS_LCD_MENU
+  #include "../../lcd/menu/menu.h" // encoderTopLine
+#endif
+
 /**
  * M21: Init SD Card
  */
@@ -38,7 +42,13 @@ void GcodeSuite::M21() { card.mount(); }
  */
 void GcodeSuite::M22() {
   if (!IS_SD_PRINTING()) card.release();
-  IF_ENABLED(TFT_COLOR_UI, ui.refresh(LCDVIEW_CALL_REDRAW_NEXT));
+  #if ENABLED(TFT_COLOR_UI)
+    // Menu display issue on item removal with multi language selection menu
+    #if !PIN_EXISTS(SD_DETECT)
+      if (encoderTopLine > 0 && ui.currentScreen == menu_main) encoderTopLine--;
+    #endif
+    ui.refresh(LCDVIEW_CALL_REDRAW_NEXT);
+  #endif
 }
 
 #endif // SDSUPPORT

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -249,7 +249,14 @@ void menu_main() {
           #if PIN_EXISTS(SD_DETECT)
             GCODES_ITEM(MSG_CHANGE_MEDIA, PSTR("M21"));       // M21 Change Media
           #else                                               // - or -
-            GCODES_ITEM(MSG_RELEASE_MEDIA, PSTR("M22"));      // M22 Release Media
+            ACTION_ITEM(MSG_RELEASE_MEDIA, []{                // M22 Release Media
+              queue.inject(PSTR("M22"));
+              #if ENABLED(TFT_COLOR_UI)
+                // Menu display issue on item removal with multi language selection menu
+                if (encoderTopLine > 0) encoderTopLine--;
+                ui.refresh(LCDVIEW_CALL_REDRAW_NEXT);
+              #endif
+            });
           #endif
           SUBMENU(MSG_MEDIA_MENU, MEDIA_MENU_GATEWAY);        // Media Menu (or Password First)
         }


### PR DESCRIPTION
When you have multi language enabled and manual SD mount/unmount menu items
the "Release Media" action will hide the "Print From media" menu and display twice the language item.

May need a specific function to scroll up by one the whole menu items and refresh...
