### PR TITLE
Implement LCD_SHOW_E_TOTAL for TFT_COLOR_UI

### DIFF
--- a/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
+++ b/Marlin/src/lcd/dogm/status_screen_lite_ST7920.cpp
@@ -672,20 +672,20 @@ void ST7920_Lite_Status_Screen::draw_position(const xyze_pos_t &pos, const bool 
   // If position is unknown, flash the labels.
   const unsigned char alt_label = position_trusted ? 0 : (ui.get_blink() ? ' ' : 0);
 
-  if (TERN1(LCD_SHOW_E_TOTAL, !printingIsActive())) {
-    write_byte(alt_label ? alt_label : 'X');
-    write_str(dtostrf(pos.x, -4, 0, str), 4);
-
-    write_byte(alt_label ? alt_label : 'Y');
-    write_str(dtostrf(pos.y, -4, 0, str), 4);
-  }
-  else {
+  if (TERN0(LCD_SHOW_E_TOTAL, printingIsActive())) {
     #if ENABLED(LCD_SHOW_E_TOTAL)
       char tmp[15];
       const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
       sprintf_P(tmp, PSTR("E%-7ld%cm "), uint32_t(_MAX(e_move_accumulator, 0.0f)) / escale, escale == 10 ? 'c' : 'm'); // 1234567mm
       write_str(tmp);
     #endif
+  }
+  else {
+    write_byte(alt_label ? alt_label : 'X');
+    write_str(dtostrf(pos.x, -4, 0, str), 4);
+
+    write_byte(alt_label ? alt_label : 'Y');
+    write_str(dtostrf(pos.y, -4, 0, str), 4);
   }
 
   write_byte(alt_label ? alt_label : 'Z');

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -259,7 +259,17 @@ void MarlinUI::draw_status_screen() {
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
   bool not_homed;
-  if (!TERN1(LCD_SHOW_E_TOTAL, !printingIsActive())) {
+  if (TERN0(LCD_SHOW_E_TOTAL, printingIsActive())) {
+    #if ENABLED(LCD_SHOW_E_TOTAL)
+      tft.add_text(200, 3, COLOR_AXIS_HOMED , "E");
+      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+      tft_string.set(ftostr4sign(e_move_accumulator / escale));
+      tft_string.add(escale == 10 ? 'c' : 'm');
+      tft_string.add('m');
+      tft.add_text(500 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+    #endif
+  }
+  else {
     tft.add_text(200, 3, COLOR_AXIS_HOMED , "X");
     not_homed = axis_should_home(X_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
@@ -269,16 +279,6 @@ void MarlinUI::draw_status_screen() {
     not_homed = axis_should_home(Y_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
     tft.add_text(600 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-  }
-  else {
-    #if ENABLED(LCD_SHOW_E_TOTAL)
-      tft.add_text(200, 3, COLOR_AXIS_HOMED , "E");
-      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
-      tft_string.set(ftostr4sign(e_move_accumulator / escale));
-      tft_string.add(escale == 10 ? 'c' : 'm');
-      tft_string.add('m');
-      tft.add_text(500 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
-    #endif
   }
   tft.add_text(800, 3, COLOR_AXIS_HOMED , "Z");
   uint16_t offset = 32;

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -258,18 +258,31 @@ void MarlinUI::draw_status_screen() {
   tft.set_background(COLOR_BACKGROUND);
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
-  tft.add_text(200, 3, COLOR_AXIS_HOMED , "X");
-  tft.add_text(500, 3, COLOR_AXIS_HOMED , "Y");
+  bool not_homed;
+  if (!TERN1(LCD_SHOW_E_TOTAL, !printingIsActive())) {
+    tft.add_text(200, 3, COLOR_AXIS_HOMED , "X");
+    not_homed = axis_should_home(X_AXIS);
+    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
+    tft.add_text(300 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+
+    tft.add_text(500, 3, COLOR_AXIS_HOMED , "Y");
+    not_homed = axis_should_home(Y_AXIS);
+    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
+    tft.add_text(600 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  }
+  else {
+    #if ENABLED(LCD_SHOW_E_TOTAL)
+      tft.add_text( 200, 3, COLOR_AXIS_HOMED , "E");
+      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+      tft_string.set(ftostr4sign(e_move_accumulator / escale));
+      tft_string.add(escale == 10 ? 'c' : 'm');
+      tft_string.add('m');
+      tft.add_text(500 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+    #endif
+  }
+
+  }
   tft.add_text(800, 3, COLOR_AXIS_HOMED , "Z");
-
-  bool not_homed = axis_should_home(X_AXIS);
-  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
-  tft.add_text(300 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
-  not_homed = axis_should_home(Y_AXIS);
-  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
-  tft.add_text(600 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
   uint16_t offset = 32;
   not_homed = axis_should_home(Z_AXIS);
   if (blink && not_homed)

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -258,7 +258,6 @@ void MarlinUI::draw_status_screen() {
   tft.set_background(COLOR_BACKGROUND);
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
-  bool not_homed;
   if (TERN0(LCD_SHOW_E_TOTAL, printingIsActive())) {
     #if ENABLED(LCD_SHOW_E_TOTAL)
       tft.add_text(200, 3, COLOR_AXIS_HOMED , "E");
@@ -271,19 +270,19 @@ void MarlinUI::draw_status_screen() {
   }
   else {
     tft.add_text(200, 3, COLOR_AXIS_HOMED , "X");
-    not_homed = axis_should_home(X_AXIS);
-    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
-    tft.add_text(300 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+    const bool nhx = axis_should_home(X_AXIS);
+    tft_string.set(blink && nhx ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
+    tft.add_text(300 - tft_string.width(), 3, nhx ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
 
     tft.add_text(500, 3, COLOR_AXIS_HOMED , "Y");
-    not_homed = axis_should_home(Y_AXIS);
-    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
-    tft.add_text(600 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+    const bool nhy = axis_should_home(Y_AXIS);
+    tft_string.set(blink && nhy ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
+    tft.add_text(600 - tft_string.width(), 3, nhy ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
   }
   tft.add_text(800, 3, COLOR_AXIS_HOMED , "Z");
   uint16_t offset = 32;
-  not_homed = axis_should_home(Z_AXIS);
-  if (blink && not_homed)
+  const bool nhz = axis_should_home(Z_AXIS);
+  if (blink && nhz)
     tft_string.set("?");
   else {
     const float z = LOGICAL_Z_POSITION(current_position.z);
@@ -294,7 +293,7 @@ void MarlinUI::draw_status_screen() {
     tft_string.set(ftostr52sp(z));
     offset -= tft_string.width();
   }
-  tft.add_text(900 - tft_string.width() - offset, 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  tft.add_text(900 - tft_string.width() - offset, 3, nhz ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
   TERN_(TOUCH_SCREEN, touch.add_control(MOVE_AXIS, 4, y, TFT_WIDTH - 8, FONT_LINE_HEIGHT));
 
   y += 100;

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -280,8 +280,6 @@ void MarlinUI::draw_status_screen() {
       tft.add_text(500 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
     #endif
   }
-
-  }
   tft.add_text(800, 3, COLOR_AXIS_HOMED , "Z");
   uint16_t offset = 32;
   not_homed = axis_should_home(Z_AXIS);

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -272,7 +272,7 @@ void MarlinUI::draw_status_screen() {
   }
   else {
     #if ENABLED(LCD_SHOW_E_TOTAL)
-      tft.add_text( 200, 3, COLOR_AXIS_HOMED , "E");
+      tft.add_text(200, 3, COLOR_AXIS_HOMED , "E");
       const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
       tft_string.set(ftostr4sign(e_move_accumulator / escale));
       tft_string.add(escale == 10 ? 'c' : 'm');

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -258,18 +258,26 @@ void MarlinUI::draw_status_screen() {
   tft.set_background(COLOR_BACKGROUND);
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
-  tft.add_text(200, 3, COLOR_AXIS_HOMED , "X");
-  tft.add_text(500, 3, COLOR_AXIS_HOMED , "Y");
+  bool not_homed;
+  if (TERN1(LCD_SHOW_E_TOTAL, printingIsActive())) {
+    tft.add_text( 200, 3, COLOR_AXIS_HOMED , "E");
+    const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+    tft_string.set(ftostr4sign(e_move_accumulator / escale));
+    tft_string.add(escale == 10 ? 'c' : 'm');
+    tft_string.add('m');
+    tft.add_text(500 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+  } else {
+    tft.add_text(200, 3, COLOR_AXIS_HOMED , "X");
+    not_homed = axis_should_home(X_AXIS);
+    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
+    tft.add_text(300 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+
+    tft.add_text(500, 3, COLOR_AXIS_HOMED , "Y");
+    not_homed = axis_should_home(Y_AXIS);
+    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
+    tft.add_text(600 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  }
   tft.add_text(800, 3, COLOR_AXIS_HOMED , "Z");
-
-  bool not_homed = axis_should_home(X_AXIS);
-  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
-  tft.add_text(300 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
-  not_homed = axis_should_home(Y_AXIS);
-  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
-  tft.add_text(600 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
   uint16_t offset = 32;
   not_homed = axis_should_home(Z_AXIS);
   if (blink && not_homed)

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -258,26 +258,18 @@ void MarlinUI::draw_status_screen() {
   tft.set_background(COLOR_BACKGROUND);
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
-  bool not_homed;
-  if (TERN1(LCD_SHOW_E_TOTAL, printingIsActive())) {
-    tft.add_text( 200, 3, COLOR_AXIS_HOMED , "E");
-    const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
-    tft_string.set(ftostr4sign(e_move_accumulator / escale));
-    tft_string.add(escale == 10 ? 'c' : 'm');
-    tft_string.add('m');
-    tft.add_text(500 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
-  } else {
-    tft.add_text(200, 3, COLOR_AXIS_HOMED , "X");
-    not_homed = axis_should_home(X_AXIS);
-    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
-    tft.add_text(300 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
-    tft.add_text(500, 3, COLOR_AXIS_HOMED , "Y");
-    not_homed = axis_should_home(Y_AXIS);
-    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
-    tft.add_text(600 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-  }
+  tft.add_text(200, 3, COLOR_AXIS_HOMED , "X");
+  tft.add_text(500, 3, COLOR_AXIS_HOMED , "Y");
   tft.add_text(800, 3, COLOR_AXIS_HOMED , "Z");
+
+  bool not_homed = axis_should_home(X_AXIS);
+  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
+  tft.add_text(300 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+
+  not_homed = axis_should_home(Y_AXIS);
+  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
+  tft.add_text(600 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+
   uint16_t offset = 32;
   not_homed = axis_should_home(Z_AXIS);
   if (blink && not_homed)

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -256,7 +256,6 @@ void MarlinUI::draw_status_screen() {
   tft.set_background(COLOR_BACKGROUND);
   tft.add_rectangle(0, 0, 312, 24, COLOR_AXIS_HOMED);
 
-  bool not_homed;
   if (TERN0(LCD_SHOW_E_TOTAL, printingIsActive())) {
     #if ENABLED(LCD_SHOW_E_TOTAL)
       tft.add_text( 10, 3, COLOR_AXIS_HOMED , "E");
@@ -269,20 +268,20 @@ void MarlinUI::draw_status_screen() {
   }
   else {
     tft.add_text( 10, 3, COLOR_AXIS_HOMED , "X");
-    not_homed = axis_should_home(X_AXIS);
-    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
-    tft.add_text( 68 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+    const bool nhx = axis_should_home(X_AXIS);
+    tft_string.set(blink && nhx ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
+    tft.add_text( 68 - tft_string.width(), 3, nhx ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
 
     tft.add_text(127, 3, COLOR_AXIS_HOMED , "Y");
-    not_homed = axis_should_home(Y_AXIS);
-    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
-    tft.add_text(185 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+    const bool nhy = axis_should_home(Y_AXIS);
+    tft_string.set(blink && nhy ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
+    tft.add_text(185 - tft_string.width(), 3, nhy ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
   }
 
   tft.add_text(219, 3, COLOR_AXIS_HOMED , "Z");
-  not_homed = axis_should_home(Z_AXIS);
+  const bool nhz = axis_should_home(Z_AXIS);
   uint16_t offset = 25;
-  if (blink && not_homed)
+  if (blink && nhz)
     tft_string.set("?");
   else {
     const float z = LOGICAL_Z_POSITION(current_position.z);
@@ -293,7 +292,7 @@ void MarlinUI::draw_status_screen() {
     tft_string.set(ftostr52sp(z));
     offset -= tft_string.width();
   }
-  tft.add_text(301 - tft_string.width() - offset, 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  tft.add_text(301 - tft_string.width() - offset, 3, nhz ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
   TERN_(TOUCH_SCREEN, touch.add_control(MOVE_AXIS, 0, 103, 312, 24));
 
   // feed rate

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -257,14 +257,7 @@ void MarlinUI::draw_status_screen() {
   tft.add_rectangle(0, 0, 312, 24, COLOR_AXIS_HOMED);
 
   bool not_homed;
-  if (TERN1(LCD_SHOW_E_TOTAL, printingIsActive())) {
-    tft.add_text( 10, 3, COLOR_AXIS_HOMED , "E");
-    const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
-    tft_string.set(ftostr4sign(e_move_accumulator / escale));
-    tft_string.add(escale == 10 ? 'c' : 'm');
-    tft_string.add('m');
-    tft.add_text(127 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
-  } else {
+  if (!TERN1(LCD_SHOW_E_TOTAL, !printingIsActive())) {
     tft.add_text( 10, 3, COLOR_AXIS_HOMED , "X");
     not_homed = axis_should_home(X_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
@@ -274,6 +267,16 @@ void MarlinUI::draw_status_screen() {
     not_homed = axis_should_home(Y_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
     tft.add_text(185 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  }
+  else {
+    #if ENABLED(LCD_SHOW_E_TOTAL)
+      tft.add_text( 10, 3, COLOR_AXIS_HOMED , "E");
+      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+      tft_string.set(ftostr4sign(e_move_accumulator / escale));
+      tft_string.add(escale == 10 ? 'c' : 'm');
+      tft_string.add('m');
+      tft.add_text(127 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+    #endif
   }
 
   tft.add_text(219, 3, COLOR_AXIS_HOMED , "Z");

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -257,7 +257,17 @@ void MarlinUI::draw_status_screen() {
   tft.add_rectangle(0, 0, 312, 24, COLOR_AXIS_HOMED);
 
   bool not_homed;
-  if (!TERN1(LCD_SHOW_E_TOTAL, !printingIsActive())) {
+  if (TERN0(LCD_SHOW_E_TOTAL, printingIsActive())) {
+    #if ENABLED(LCD_SHOW_E_TOTAL)
+      tft.add_text( 10, 3, COLOR_AXIS_HOMED , "E");
+      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+      tft_string.set(ftostr4sign(e_move_accumulator / escale));
+      tft_string.add(escale == 10 ? 'c' : 'm');
+      tft_string.add('m');
+      tft.add_text(127 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+    #endif
+  }
+  else {
     tft.add_text( 10, 3, COLOR_AXIS_HOMED , "X");
     not_homed = axis_should_home(X_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
@@ -267,16 +277,6 @@ void MarlinUI::draw_status_screen() {
     not_homed = axis_should_home(Y_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
     tft.add_text(185 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-  }
-  else {
-    #if ENABLED(LCD_SHOW_E_TOTAL)
-      tft.add_text( 10, 3, COLOR_AXIS_HOMED , "E");
-      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
-      tft_string.set(ftostr4sign(e_move_accumulator / escale));
-      tft_string.add(escale == 10 ? 'c' : 'm');
-      tft_string.add('m');
-      tft.add_text(127 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
-    #endif
   }
 
   tft.add_text(219, 3, COLOR_AXIS_HOMED , "Z");

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -256,18 +256,27 @@ void MarlinUI::draw_status_screen() {
   tft.set_background(COLOR_BACKGROUND);
   tft.add_rectangle(0, 0, 312, 24, COLOR_AXIS_HOMED);
 
-  tft.add_text( 10, 3, COLOR_AXIS_HOMED , "X");
-  tft.add_text(127, 3, COLOR_AXIS_HOMED , "Y");
+  bool not_homed;
+  if (TERN1(LCD_SHOW_E_TOTAL, printingIsActive())) {
+    tft.add_text( 10, 3, COLOR_AXIS_HOMED , "E");
+    const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+    tft_string.set(ftostr4sign(e_move_accumulator / escale));
+    tft_string.add(escale == 10 ? 'c' : 'm');
+    tft_string.add('m');
+    tft.add_text(127 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+  } else {
+    tft.add_text( 10, 3, COLOR_AXIS_HOMED , "X");
+    not_homed = axis_should_home(X_AXIS);
+    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
+    tft.add_text( 68 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+
+    tft.add_text(127, 3, COLOR_AXIS_HOMED , "Y");
+    not_homed = axis_should_home(Y_AXIS);
+    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
+    tft.add_text(185 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  }
+
   tft.add_text(219, 3, COLOR_AXIS_HOMED , "Z");
-
-  bool not_homed = axis_should_home(X_AXIS);
-  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
-  tft.add_text( 68 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
-  not_homed = axis_should_home(Y_AXIS);
-  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
-  tft.add_text(185 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
   not_homed = axis_should_home(Z_AXIS);
   uint16_t offset = 25;
   if (blink && not_homed)

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -259,14 +259,7 @@ void MarlinUI::draw_status_screen() {
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
   bool not_homed;
-  if (TERN1(LCD_SHOW_E_TOTAL, printingIsActive())) {
-    tft.add_text( 16, 3, COLOR_AXIS_HOMED , "E");
-    const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
-    tft_string.set(ftostr4sign(e_move_accumulator / escale));
-    tft_string.add(escale == 10 ? 'c' : 'm');
-    tft_string.add('m');
-    tft.add_text(192 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
-  } else {
+  if (!TERN1(LCD_SHOW_E_TOTAL, !printingIsActive())) {
     tft.add_text( 16, 3, COLOR_AXIS_HOMED , "X");
     not_homed = axis_should_home(X_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
@@ -276,6 +269,16 @@ void MarlinUI::draw_status_screen() {
     not_homed = axis_should_home(Y_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
     tft.add_text(280 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  }
+  else {
+    #if ENABLED(LCD_SHOW_E_TOTAL)
+      tft.add_text( 16, 3, COLOR_AXIS_HOMED , "E");
+      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+      tft_string.set(ftostr4sign(e_move_accumulator / escale));
+      tft_string.add(escale == 10 ? 'c' : 'm');
+      tft_string.add('m');
+      tft.add_text(192 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+    #endif
   }
   tft.add_text(330, 3, COLOR_AXIS_HOMED , "Z");
   uint16_t offset = 32;

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -259,7 +259,17 @@ void MarlinUI::draw_status_screen() {
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
   bool not_homed;
-  if (!TERN1(LCD_SHOW_E_TOTAL, !printingIsActive())) {
+  if (TERN0(LCD_SHOW_E_TOTAL, printingIsActive())) {
+    #if ENABLED(LCD_SHOW_E_TOTAL)
+      tft.add_text( 16, 3, COLOR_AXIS_HOMED , "E");
+      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+      tft_string.set(ftostr4sign(e_move_accumulator / escale));
+      tft_string.add(escale == 10 ? 'c' : 'm');
+      tft_string.add('m');
+      tft.add_text(192 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+    #endif
+  }
+  else {
     tft.add_text( 16, 3, COLOR_AXIS_HOMED , "X");
     not_homed = axis_should_home(X_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
@@ -269,16 +279,6 @@ void MarlinUI::draw_status_screen() {
     not_homed = axis_should_home(Y_AXIS);
     tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
     tft.add_text(280 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-  }
-  else {
-    #if ENABLED(LCD_SHOW_E_TOTAL)
-      tft.add_text( 16, 3, COLOR_AXIS_HOMED , "E");
-      const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
-      tft_string.set(ftostr4sign(e_move_accumulator / escale));
-      tft_string.add(escale == 10 ? 'c' : 'm');
-      tft_string.add('m');
-      tft.add_text(192 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
-    #endif
   }
   tft.add_text(330, 3, COLOR_AXIS_HOMED , "Z");
   uint16_t offset = 32;

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -258,18 +258,26 @@ void MarlinUI::draw_status_screen() {
   tft.set_background(COLOR_BACKGROUND);
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
-  tft.add_text( 16, 3, COLOR_AXIS_HOMED , "X");
-  tft.add_text(192, 3, COLOR_AXIS_HOMED , "Y");
+  bool not_homed;
+  if (TERN1(LCD_SHOW_E_TOTAL, printingIsActive())) {
+    tft.add_text( 16, 3, COLOR_AXIS_HOMED , "E");
+    const uint8_t escale = e_move_accumulator >= 100000.0f ? 10 : 1; // After 100m switch to cm
+    tft_string.set(ftostr4sign(e_move_accumulator / escale));
+    tft_string.add(escale == 10 ? 'c' : 'm');
+    tft_string.add('m');
+    tft.add_text(192 - tft_string.width(), 3, COLOR_AXIS_HOMED, tft_string);
+  } else {
+    tft.add_text( 16, 3, COLOR_AXIS_HOMED , "X");
+    not_homed = axis_should_home(X_AXIS);
+    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
+    tft.add_text(102 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+
+    tft.add_text(192, 3, COLOR_AXIS_HOMED , "Y");
+    not_homed = axis_should_home(Y_AXIS);
+    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
+    tft.add_text(280 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  }
   tft.add_text(330, 3, COLOR_AXIS_HOMED , "Z");
-
-  bool not_homed = axis_should_home(X_AXIS);
-  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
-  tft.add_text(102 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
-  not_homed = axis_should_home(Y_AXIS);
-  tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
-  tft.add_text(280 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
-
   uint16_t offset = 32;
   not_homed = axis_should_home(Z_AXIS);
   if (blink && not_homed)

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -258,7 +258,6 @@ void MarlinUI::draw_status_screen() {
   tft.set_background(COLOR_BACKGROUND);
   tft.add_rectangle(0, 0, TFT_WIDTH - 8, FONT_LINE_HEIGHT, COLOR_AXIS_HOMED);
 
-  bool not_homed;
   if (TERN0(LCD_SHOW_E_TOTAL, printingIsActive())) {
     #if ENABLED(LCD_SHOW_E_TOTAL)
       tft.add_text( 16, 3, COLOR_AXIS_HOMED , "E");
@@ -271,19 +270,19 @@ void MarlinUI::draw_status_screen() {
   }
   else {
     tft.add_text( 16, 3, COLOR_AXIS_HOMED , "X");
-    not_homed = axis_should_home(X_AXIS);
-    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
-    tft.add_text(102 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+    const bool nhx = axis_should_home(X_AXIS);
+    tft_string.set(blink && nhx ? "?" : ftostr4sign(LOGICAL_X_POSITION(current_position.x)));
+    tft.add_text(102 - tft_string.width(), 3, nhx ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
 
     tft.add_text(192, 3, COLOR_AXIS_HOMED , "Y");
-    not_homed = axis_should_home(Y_AXIS);
-    tft_string.set(blink && not_homed ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
-    tft.add_text(280 - tft_string.width(), 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+    const bool nhy = axis_should_home(Y_AXIS);
+    tft_string.set(blink && nhy ? "?" : ftostr4sign(LOGICAL_Y_POSITION(current_position.y)));
+    tft.add_text(280 - tft_string.width(), 3, nhy ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
   }
   tft.add_text(330, 3, COLOR_AXIS_HOMED , "Z");
   uint16_t offset = 32;
-  not_homed = axis_should_home(Z_AXIS);
-  if (blink && not_homed)
+  const bool nhz = axis_should_home(Z_AXIS);
+  if (blink && nhz)
     tft_string.set("?");
   else {
     const float z = LOGICAL_Z_POSITION(current_position.z);
@@ -294,7 +293,7 @@ void MarlinUI::draw_status_screen() {
     tft_string.set(ftostr52sp(z));
     offset -= tft_string.width();
   }
-  tft.add_text(455 - tft_string.width() - offset, 3, not_homed ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
+  tft.add_text(455 - tft_string.width() - offset, 3, nhz ? COLOR_AXIS_NOT_HOMED : COLOR_AXIS_HOMED, tft_string);
   TERN_(TOUCH_SCREEN, touch.add_control(MOVE_AXIS, 4, y, TFT_WIDTH - 8, FONT_LINE_HEIGHT));
 
   y += TERN(HAS_UI_480x272, 38, 48);


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Display consumed filament during print if option LCD_SHOW_E_TOTAL enabled in Configuration_adv.h
![photo5226864269272921820](https://user-images.githubusercontent.com/5613740/141690221-5609072d-50b0-49d0-9bf4-0e0277d5d71a.jpg)
![photo5226864269272921821](https://user-images.githubusercontent.com/5613740/141690229-bf546d51-2d6e-46ca-8b87-d6f960f8de63.jpg)
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
TFT_COLOR_UI need to be enabled
Test performed on 480x320 ыскуут
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Add useful functionality which already exists in TFT_CLASSIC_UI
<!-- What does this PR fix or improve? -->

### Configurations
Reuse existing configuration (LCD_SOW_E_TOTAL in Configuration_adv.h)
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
No related issue
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. --
![photo5226864269272921820](https://user-images.githubusercontent.com/5613740/141690221-5609072d-50b0-49d0-9bf4-0e0277d5d71a.jpg)
![photo5226864269272921821](https://user-images.githubusercontent.com/5613740/141690229-bf546d51-2d6e-46ca-8b87-d6f960f8de63.jpg)
>
