### PR TITLE
Biqu BX Temporary Framework Workaround

### DIFF
--- a/buildroot/share/PlatformIO/scripts/generic_create_variant.py
+++ b/buildroot/share/PlatformIO/scripts/generic_create_variant.py
@@ -30,7 +30,7 @@ if pioutil.is_pio_build():
 	else:
 		platform_name = PackageSpec(platform_packages[0]).name
 
-	if platform_name in [ "usb-host-msc", "usb-host-msc-cdc-msc", "usb-host-msc-cdc-msc-2", "usb-host-msc-cdc-msc-3", "tool-stm32duino" ]:
+	if platform_name in [ "usb-host-msc", "usb-host-msc-cdc-msc", "usb-host-msc-cdc-msc-2", "usb-host-msc-cdc-msc-3", "tool-stm32duino", "biqu-bx-workaround" ]:
 		platform_name = "framework-arduinoststm32"
 
 	FRAMEWORK_DIR = platform.get_package_dir(platform_name)

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -25,7 +25,7 @@
 [env:BTT_SKR_SE_BX]
 platform           = ${common_stm32.platform}
 extends            = stm32_variant
-platform_packages  = ${stm_flash_drive.platform_packages}
+platform_packages  = framework-arduinoststm32@https://github.com/thisiskeithb/Arduino_Core_STM32/archive/biqu-bx-workaround.zip
 board              = marlin_BTT_SKR_SE_BX
 board_build.offset = 0x20000
 build_flags        = ${stm32_variant.build_flags} ${stm_flash_drive.build_flags}


### PR DESCRIPTION
### Description

Use a pre-patched version of `framework-arduinoststm32` for the Biqu BX based on [rhapsodyv/Arduino_Core_STM32/tree/usb-host-msc-cdc-msc-3](https://github.com/rhapsodyv/Arduino_Core_STM32/tree/usb-host-msc-cdc-msc-3) (previously inherited from `stm_flash_drive.platform_packages`) with the temporary workaround [from BigTreeTech](https://github.com/MarlinFirmware/Marlin/issues/23070#issuecomment-960429968) applied.

### Requirements

Biqu BX

### Benefits

Biqu BX configs will boot

### Configurations

[Biqu BX configs](https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/BIQU/BX)

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/23070