### PR TITLE
fix PROBE_ENABLE_PIN has not init bug

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1353,6 +1353,9 @@ void setup() {
   #endif
 
   #if HAS_BED_PROBE
+    #if PIN_EXISTS(PROBE_ENABLE)
+      OUT_WRITE(PROBE_ENABLE_PIN, LOW); // Disable
+    #endif
     SETUP_RUN(endstops.enable_z_probe(false));
   #endif
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
#23101 `PROBE_ENABLE_PIN` is not initialized, so `WRITE(PROBE_ENABLE_PIN, onoff)` cannot normally control the level of GPIO.

Or  modify here https://github.com/MarlinFirmware/Marlin/blob/36b2650f65e036ce1b02da568364230201a22b80/Marlin/src/module/endstops.cpp#L396 
`WRITE(PROBE_ENABLE_PIN, onoff);` to `OUT_WRITE(PROBE_ENABLE_PIN, onoff);`
In this way, there is no need a new judge for the `PIN_EXISTS(PROBE_ENABLE)` macro definition in initialization. It seems that the code will be more concise. But MCU needs to execute `_SET_OUTPUT` function constantly

I prefer the present way in PR
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
`PROBE_ENABLE_PIN` can work normally
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
