### PR TITLE
🐛 Fix typos

### DIFF
--- a/Marlin/src/HAL/STM32F1/onboard_sd.cpp
+++ b/Marlin/src/HAL/STM32F1/onboard_sd.cpp
@@ -278,7 +278,7 @@ DSTATUS disk_initialize (
   if (drv) return STA_NOINIT;                                         // Supports only drive 0
   sd_power_on();                                                      // Initialize SPI
 
-  if (Stat & STA_NODISK) return Stat;                                 // Is a card existing in the soket?
+  if (Stat & STA_NODISK) return Stat;                                 // Is a card existing in the socket?
 
   FCLK_SLOW();
   for (n = 10; n; n--) xchg_spi(0xFF);                                // Send 80 dummy clocks

--- a/Marlin/src/lcd/e3v2/enhanced/dwinui.cpp
+++ b/Marlin/src/lcd/e3v2/enhanced/dwinui.cpp
@@ -93,7 +93,7 @@ uint8_t DWINUI::fontWidth(uint8_t cfont) {
   }
 }
 
-// Get font character heigh
+// Get font character height
 uint8_t DWINUI::fontHeight(uint8_t cfont) {
   switch (cfont) {
     case font6x12 : return 12;
@@ -110,12 +110,12 @@ uint8_t DWINUI::fontHeight(uint8_t cfont) {
   }
 }
 
-// Get screen x coodinates from text column
+// Get screen x coordinates from text column
 uint16_t DWINUI::ColToX(uint8_t col) {
   return col * fontWidth(font);
 }
 
-// Get screen y coodinates from text row
+// Get screen y coordinates from text row
 uint16_t DWINUI::RowToY(uint8_t row) {
   return row * fontHeight(font);
 }

--- a/Marlin/src/lcd/e3v2/enhanced/dwinui.h
+++ b/Marlin/src/lcd/e3v2/enhanced/dwinui.h
@@ -198,13 +198,13 @@ namespace DWINUI {
   // Get font character width
   uint8_t fontWidth(uint8_t cfont);
 
-  // Get font character heigh
+  // Get font character height
   uint8_t fontHeight(uint8_t cfont);
 
-  // Get screen x coodinates from text column
+  // Get screen x coordinates from text column
   uint16_t ColToX(uint8_t col);
 
-  // Get screen y coodinates from text row
+  // Get screen y coordinates from text row
   uint16_t RowToY(uint8_t row);
 
   // Set text/number color

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -4135,7 +4135,7 @@ void CrealityDWINClass::Popup_Handler(PopupID popupid, bool option/*=false*/) {
   switch (popupid) {
     case Pause:         Draw_Popup(F("Pause Print"), F(""), F(""), Popup); break;
     case Stop:          Draw_Popup(F("Stop Print"), F(""), F(""), Popup); break;
-    case Resume:        Draw_Popup(F("Resume Print?"), F("Looks Like the last"), F("print was interupted."), Popup); break;
+    case Resume:        Draw_Popup(F("Resume Print?"), F("Looks Like the last"), F("print was interrupted."), Popup); break;
     case ConfFilChange: Draw_Popup(F("Confirm Filament Change"), F(""), F(""), Popup); break;
     case PurgeMore:     Draw_Popup(F("Purge more filament?"), F("(Cancel to finish process)"), F(""), Popup); break;
     case SaveLevel:     Draw_Popup(F("Leveling Complete"), F("Save to EEPROM?"), F(""), Popup); break;

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
@@ -96,7 +96,7 @@ public:
   static size_t GetFreeTxBuffer();
   static void FlushTx();
 
-  // Checks two things: Can we confirm the presence of the display and has we initiliazed it.
+  // Checks two things: Can we confirm the presence of the display and has we initialized it.
   // (both boils down that the display answered to our chatting)
   static inline bool IsInitialized() {
     return initialized;

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSTxHandler.h
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSTxHandler.h
@@ -35,7 +35,7 @@ namespace DGUSTxHandler {
   #endif
 
   void PositionZ(DGUS_VP &);
-  void Ellapsed(DGUS_VP &);
+  void Elapsed(DGUS_VP &);
   void Percent(DGUS_VP &);
   void StatusIcons(DGUS_VP &);
 

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSTxHandler.h
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSTxHandler.h
@@ -35,7 +35,7 @@ namespace DGUSTxHandler {
   #endif
 
   void PositionZ(DGUS_VP &);
-  void Elapsed(DGUS_VP &);
+  void Ellapsed(DGUS_VP &);
   void Percent(DGUS_VP &);
   void StatusIcons(DGUS_VP &);
 

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
@@ -22,7 +22,7 @@
 #pragma once
 
 /**
- * No offical schematics have been found.
+ * No official schematics have been found.
  * But these differences where noted in https://github.com/bigtreetech/Rumba32/issues/1
  */
 


### PR DESCRIPTION
Found via `codespell -q 3 --builtin=clear,rare,informal,code -S ./Marlin/src/lcd/language -L alo,amin,busses,endcode,stdio,uint`  

This commit has not been tested locally.