### PR TITLE
Add busy() to planner

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1716,13 +1716,18 @@ float Planner::get_axis_position_mm(const AxisEnum axis) {
   return axis_steps * steps_to_mm[axis];
 }
 
+bool Planner::busy() {
+  return has_blocks_queued() || cleaning_buffer_counter
+      || TERN0(EXTERNAL_CLOSED_LOOP_CONTROLLER, CLOSED_LOOP_WAITING())
+  );
+}
+
 /**
  * Block until all buffered steps are executed / cleaned
  */
 void Planner::synchronize() {
-  while (has_blocks_queued() || cleaning_buffer_counter
-      || TERN0(EXTERNAL_CLOSED_LOOP_CONTROLLER, CLOSED_LOOP_WAITING())
-  ) idle();
+  while (busy())
+    idle();
 }
 
 /**

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -879,6 +879,9 @@ class Planner {
     // Triggered position of an axis in mm (not core-savvy)
     static float triggered_position_mm(const AxisEnum axis);
 
+    // Some buffered steps to be executed / cleaned
+    static bool busy();
+    
     // Block until all buffered steps are executed / cleaned
     static void synchronize();
 


### PR DESCRIPTION
It's good to know if the printer is moving without waiting till the end like in synchronize().

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
It's good to know if the printer is moving without waiting till the end like in synchronize().
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
No
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Non-blocking info.
<!-- What does this PR fix or improve? -->

### Configurations
-
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
-
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
