### PR TITLE
PWM: avoid OUT_WRITE on TFT backlight sleep

### DIFF
--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -288,16 +288,14 @@ bool Touch::get_point(int16_t *x, int16_t *y) {
 
   void Touch::sleepTimeout() {
     #if PIN_EXISTS(TFT_BACKLIGHT)
-      OUT_WRITE(TFT_BACKLIGHT_PIN, LOW);
+      TERN(HAS_LCD_BRIGHTNESS, ui.set_brightness(0), OUT_WRITE(TFT_BACKLIGHT_PIN, LOW));
     #endif
     next_sleep_ms = TSLP_SLEEPING;
   }
   void Touch::wakeUp() {
     if (isSleeping()) {
-      #if HAS_LCD_BRIGHTNESS
-        ui._set_brightness();
-      #elif PIN_EXISTS(TFT_BACKLIGHT)
-        WRITE(TFT_BACKLIGHT_PIN, HIGH);
+      #if PIN_EXISTS(TFT_BACKLIGHT)
+        TERN(HAS_LCD_BRIGHTNESS, ui.set_brightness(ui.brightness), WRITE(TFT_BACKLIGHT_PIN, HIGH));
       #endif
     }
     next_sleep_ms = millis() + SEC_TO_MS(TOUCH_IDLE_SLEEP);

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -297,7 +297,7 @@ bool Touch::get_point(int16_t *x, int16_t *y) {
   void Touch::wakeUp() {
     if (isSleeping()) {
       #if HAS_LCD_BRIGHTNESS
-        ui._set_brightness();
+        ui.set_brightness(ui.brightness);
       #elif PIN_EXISTS(TFT_BACKLIGHT)
         WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -297,7 +297,7 @@ bool Touch::get_point(int16_t *x, int16_t *y) {
   void Touch::wakeUp() {
     if (isSleeping()) {
       #if HAS_LCD_BRIGHTNESS
-        ui.set_brightness(ui.brightness);
+        ui._set_brightness();
       #elif PIN_EXISTS(TFT_BACKLIGHT)
         WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif

--- a/Marlin/src/lcd/tft/touch.cpp
+++ b/Marlin/src/lcd/tft/touch.cpp
@@ -287,15 +287,19 @@ bool Touch::get_point(int16_t *x, int16_t *y) {
 #if HAS_TOUCH_SLEEP
 
   void Touch::sleepTimeout() {
-    #if PIN_EXISTS(TFT_BACKLIGHT)
-      TERN(HAS_LCD_BRIGHTNESS, ui.set_brightness(0), OUT_WRITE(TFT_BACKLIGHT_PIN, LOW));
+    #if HAS_LCD_BRIGHTNESS
+      ui.set_brightness(0);
+    #elif PIN_EXISTS(TFT_BACKLIGHT)
+      WRITE(TFT_BACKLIGHT_PIN, LOW);
     #endif
     next_sleep_ms = TSLP_SLEEPING;
   }
   void Touch::wakeUp() {
     if (isSleeping()) {
-      #if PIN_EXISTS(TFT_BACKLIGHT)
-        TERN(HAS_LCD_BRIGHTNESS, ui.set_brightness(ui.brightness), WRITE(TFT_BACKLIGHT_PIN, HIGH));
+      #if HAS_LCD_BRIGHTNESS
+        ui.set_brightness(ui.brightness);
+      #elif PIN_EXISTS(TFT_BACKLIGHT)
+        WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif
     }
     next_sleep_ms = millis() + SEC_TO_MS(TOUCH_IDLE_SLEEP);

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -125,7 +125,7 @@ uint8_t TouchButtons::read_buttons() {
   void TouchButtons::wakeUp() {
     if (isSleeping()) {
       #if HAS_LCD_BRIGHTNESS
-        ui.set_brightness(ui.brightness);
+        ui._set_brightness();
       #elif PIN_EXISTS(TFT_BACKLIGHT)
         WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -115,15 +115,19 @@ uint8_t TouchButtons::read_buttons() {
 #if HAS_TOUCH_SLEEP
 
   void TouchButtons::sleepTimeout() {
-    #if PIN_EXISTS(TFT_BACKLIGHT)
-      TERN(HAS_LCD_BRIGHTNESS, ui.set_brightness(0), OUT_WRITE(TFT_BACKLIGHT_PIN, LOW));
+    #if HAS_LCD_BRIGHTNESS
+      ui.set_brightness(0);
+    #elif PIN_EXISTS(TFT_BACKLIGHT)
+      WRITE(TFT_BACKLIGHT_PIN, LOW);
     #endif
     next_sleep_ms = TSLP_SLEEPING;
   }
   void TouchButtons::wakeUp() {
     if (isSleeping()) {
-      #if PIN_EXISTS(TFT_BACKLIGHT)
-        TERN(HAS_LCD_BRIGHTNESS, ui.set_brightness(ui.brightness), WRITE(TFT_BACKLIGHT_PIN, HIGH));
+      #if HAS_LCD_BRIGHTNESS
+        ui.set_brightness(ui.brightness);
+      #elif PIN_EXISTS(TFT_BACKLIGHT)
+        WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif
     }
     next_sleep_ms = millis() + SEC_TO_MS(TOUCH_IDLE_SLEEP);

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -125,7 +125,7 @@ uint8_t TouchButtons::read_buttons() {
   void TouchButtons::wakeUp() {
     if (isSleeping()) {
       #if HAS_LCD_BRIGHTNESS
-        ui._set_brightness();
+        ui.set_brightness(ui.brightness);
       #elif PIN_EXISTS(TFT_BACKLIGHT)
         WRITE(TFT_BACKLIGHT_PIN, HIGH);
       #endif

--- a/Marlin/src/lcd/touch/touch_buttons.cpp
+++ b/Marlin/src/lcd/touch/touch_buttons.cpp
@@ -116,16 +116,14 @@ uint8_t TouchButtons::read_buttons() {
 
   void TouchButtons::sleepTimeout() {
     #if PIN_EXISTS(TFT_BACKLIGHT)
-      OUT_WRITE(TFT_BACKLIGHT_PIN, LOW);
+      TERN(HAS_LCD_BRIGHTNESS, ui.set_brightness(0), OUT_WRITE(TFT_BACKLIGHT_PIN, LOW));
     #endif
     next_sleep_ms = TSLP_SLEEPING;
   }
   void TouchButtons::wakeUp() {
     if (isSleeping()) {
-      #if HAS_LCD_BRIGHTNESS
-        ui._set_brightness();
-      #elif PIN_EXISTS(TFT_BACKLIGHT)
-        WRITE(TFT_BACKLIGHT_PIN, HIGH);
+      #if PIN_EXISTS(TFT_BACKLIGHT)
+        TERN(HAS_LCD_BRIGHTNESS, ui.set_brightness(ui.brightness), WRITE(TFT_BACKLIGHT_PIN, HIGH));
       #endif
     }
     next_sleep_ms = millis() + SEC_TO_MS(TOUCH_IDLE_SLEEP);


### PR DESCRIPTION
Now the 2 variables are handled (backlight ? brightness : 0)
so we can use ui.set_brightness(0) to turn it off without the risk
of stopping the PWM pin which deallocate/reallocate a HardwareTimer and its settings.

Note: set_brightness(0) will just put backlight to false and keep previous brightness value.