### PR TITLE
Fix BOTH Macro for RX BUFFER (issue #23159)

### DIFF
--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -281,7 +281,7 @@ void GCodeQueue::flush_and_request_resend(const serial_index_t serial_ind) {
 
 static bool serial_data_available(serial_index_t index) {
   const int a = SERIAL_IMPL.available(index);
-  #if BOTH(RX_BUFFER_MONITOR, RX_BUFFER_SIZE)
+  #if ENABLED(RX_BUFFER_MONITOR) && RX_BUFFER_SIZE
     if (a > RX_BUFFER_SIZE - 2) {
       PORT_REDIRECT(SERIAL_PORTMASK(index));
       SERIAL_ERROR_MSG("RX BUF overflow, increase RX_BUFFER_SIZE: ", a);


### PR DESCRIPTION
### Description

FIx issue #23159, BOTH macro doesn't work as expected

Because the BOTH or ENABLED only return true if the argument is defined or true or 1, so we cannot use BOTH macro here.

### Related Issues

#23159