### PR TITLE
Fix cutter compile sans SPINDLE_LASER_USE_PWM

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3399,17 +3399,21 @@
      * Speed/Power = (PWMDC / 255 * 100 - SPEED_POWER_INTERCEPT) / SPEED_POWER_SLOPE
      * PWMDC = (spdpwr - SPEED_POWER_MIN) / (SPEED_POWER_MAX - SPEED_POWER_MIN) / SPEED_POWER_SLOPE
      */
-    #define SPEED_POWER_INTERCEPT       0    // (%) 0-100 i.e., Minimum power percentage
-    #define SPEED_POWER_MIN          5000    // (RPM)
-    #define SPEED_POWER_MAX         30000    // (RPM) SuperPID router controller 0 - 30,000 RPM
-    #define SPEED_POWER_STARTUP     25000    // (RPM) M3/M4 speed/power default (with no arguments)
+    #if ENABLED(SPINDLE_LASER_USE_PWM)
+      #define SPEED_POWER_INTERCEPT       0    // (%) 0-100 i.e., Minimum power percentage
+      #define SPEED_POWER_MIN          5000    // (RPM)
+      #define SPEED_POWER_MAX         30000    // (RPM) SuperPID router controller 0 - 30,000 RPM
+      #define SPEED_POWER_STARTUP     25000    // (RPM) M3/M4 speed/power default (with no arguments)
+    #endif
 
   #else
 
-    #define SPEED_POWER_INTERCEPT       0    // (%) 0-100 i.e., Minimum power percentage
-    #define SPEED_POWER_MIN             0    // (%) 0-100
-    #define SPEED_POWER_MAX           100    // (%) 0-100
-    #define SPEED_POWER_STARTUP        80    // (%) M3/M4 speed/power default (with no arguments)   
+    #if ENABLED(SPINDLE_LASER_USE_PWM)
+      #define SPEED_POWER_INTERCEPT       0    // (%) 0-100 i.e., Minimum power percentage
+      #define SPEED_POWER_MIN             0    // (%) 0-100
+      #define SPEED_POWER_MAX           100    // (%) 0-100
+      #define SPEED_POWER_STARTUP        80    // (%) M3/M4 speed/power default (with no arguments)
+    #endif
 
     // Define the minimum and maximum test pulse time values for a laser test fire function
     #define LASER_TEST_PULSE_MIN           1   // Used with Laser Control Menu

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3399,21 +3399,17 @@
      * Speed/Power = (PWMDC / 255 * 100 - SPEED_POWER_INTERCEPT) / SPEED_POWER_SLOPE
      * PWMDC = (spdpwr - SPEED_POWER_MIN) / (SPEED_POWER_MAX - SPEED_POWER_MIN) / SPEED_POWER_SLOPE
      */
-    #if ENABLED(SPINDLE_LASER_USE_PWM)
-      #define SPEED_POWER_INTERCEPT       0    // (%) 0-100 i.e., Minimum power percentage
-      #define SPEED_POWER_MIN          5000    // (RPM)
-      #define SPEED_POWER_MAX         30000    // (RPM) SuperPID router controller 0 - 30,000 RPM
-      #define SPEED_POWER_STARTUP     25000    // (RPM) M3/M4 speed/power default (with no arguments)
-    #endif
+    #define SPEED_POWER_INTERCEPT       0    // (%) 0-100 i.e., Minimum power percentage
+    #define SPEED_POWER_MIN          5000    // (RPM)
+    #define SPEED_POWER_MAX         30000    // (RPM) SuperPID router controller 0 - 30,000 RPM
+    #define SPEED_POWER_STARTUP     25000    // (RPM) M3/M4 speed/power default (with no arguments)
 
   #else
 
-    #if ENABLED(SPINDLE_LASER_USE_PWM)
-      #define SPEED_POWER_INTERCEPT       0    // (%) 0-100 i.e., Minimum power percentage
-      #define SPEED_POWER_MIN             0    // (%) 0-100
-      #define SPEED_POWER_MAX           100    // (%) 0-100
-      #define SPEED_POWER_STARTUP        80    // (%) M3/M4 speed/power default (with no arguments)
-    #endif
+    #define SPEED_POWER_INTERCEPT       0    // (%) 0-100 i.e., Minimum power percentage
+    #define SPEED_POWER_MIN             0    // (%) 0-100
+    #define SPEED_POWER_MAX           100    // (%) 0-100
+    #define SPEED_POWER_STARTUP        80    // (%) M3/M4 speed/power default (with no arguments)   
 
     // Define the minimum and maximum test pulse time values for a laser test fire function
     #define LASER_TEST_PULSE_MIN           1   // Used with Laser Control Menu

--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -49,10 +49,6 @@
 
 class SpindleLaser {
 public:
-  static constexpr float
-    min_pct = TERN(CUTTER_POWER_RELATIVE, 0, TERN(SPINDLE_FEATURE, round(100.0f * (SPEED_POWER_MIN) / (SPEED_POWER_MAX)), SPEED_POWER_MIN)),
-    max_pct = TERN(SPINDLE_FEATURE, 100, SPEED_POWER_MAX);
-
   static const inline uint8_t pct_to_ocr(const_float_t pct) { return uint8_t(PCT_TO_PWM(pct)); }
 
   // cpower = configured values (e.g., SPEED_POWER_MAX)
@@ -158,6 +154,9 @@ public:
     }
 
     static inline cutter_power_t power_to_range(const cutter_power_t pwr, const uint8_t pwrUnit) {
+      static constexpr float
+        min_pct = TERN(CUTTER_POWER_RELATIVE, 0, TERN(SPINDLE_FEATURE, round(100.0f * (SPEED_POWER_MIN) / (SPEED_POWER_MAX)), SPEED_POWER_MIN)),
+        max_pct = TERN(SPINDLE_FEATURE, 100, SPEED_POWER_MAX);
       if (pwr <= 0) return 0;
       cutter_power_t upwr;
       switch (pwrUnit) {
@@ -186,6 +185,7 @@ public:
       }
       return upwr;
     }
+
   #endif // SPINDLE_LASER_USE_PWM
 
   /**

--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -41,10 +41,6 @@
 #define PCT_TO_PWM(X) ((X) * 255 / 100)
 #define PCT_TO_SERVO(X) ((X) * 180 / 100)
 
-#ifndef SPEED_POWER_INTERCEPT
-  #define SPEED_POWER_INTERCEPT 0
-#endif
-
 // #define _MAP(N,S1,S2,D1,D2) ((N)*_MAX((D2)-(D1),0)/_MAX((S2)-(S1),1)+(D1))
 
 class SpindleLaser {

--- a/Marlin/src/feature/spindle_laser_types.h
+++ b/Marlin/src/feature/spindle_laser_types.h
@@ -28,12 +28,34 @@
 
 #include "../inc/MarlinConfigPre.h"
 
+#define MSG_CUTTER(M) _MSG_CUTTER(M)
+
+#ifndef SPEED_POWER_INTERCEPT
+  #define SPEED_POWER_INTERCEPT 0
+#endif
 #if ENABLED(SPINDLE_FEATURE)
   #define _MSG_CUTTER(M) MSG_SPINDLE_##M
+  #ifndef SPEED_POWER_MIN
+    #define SPEED_POWER_MIN      5000
+  #endif
+  #ifndef SPEED_POWER_MAX
+    #define SPEED_POWER_MAX     30000
+  #endif
+  #ifndef SPEED_POWER_STARTUP
+    #define SPEED_POWER_STARTUP 25000
+  #endif
 #else
   #define _MSG_CUTTER(M) MSG_LASER_##M
+  #ifndef SPEED_POWER_MIN
+    #define SPEED_POWER_MIN         0
+  #endif
+  #ifndef SPEED_POWER_MAX
+    #define SPEED_POWER_MAX       255
+  #endif
+  #ifndef SPEED_POWER_STARTUP
+    #define SPEED_POWER_STARTUP   255
+  #endif
 #endif
-#define MSG_CUTTER(M) _MSG_CUTTER(M)
 
 typedef IF<(SPEED_POWER_MAX > 255), uint16_t, uint8_t>::type cutter_cpower_t;
 

--- a/Marlin/src/gcode/control/M3-M5.cpp
+++ b/Marlin/src/gcode/control/M3-M5.cpp
@@ -66,21 +66,23 @@
  *  PWM duty cycle goes from 0 (off) to 255 (always on).
  */
 void GcodeSuite::M3_M4(const bool is_M4) {
-  auto get_s_power = [] {
-    if (parser.seenval('S')) {
-      const float spwr = parser.value_float();
-      #if ENABLED(SPINDLE_SERVO)
-        cutter.unitPower = spwr;
-      #else
-        cutter.unitPower = TERN(SPINDLE_LASER_USE_PWM,
-                              cutter.power_to_range(cutter_power_t(round(spwr))),
-                              spwr > 0 ? 255 : 0);
-      #endif
-    }
-    else
-      cutter.unitPower = cutter.cpwr_to_upwr(SPEED_POWER_STARTUP);
-    return cutter.unitPower;
-  };
+  #if EITHER(SPINDLE_LASER_USE_PWM, SPINDLE_SERVO)
+    auto get_s_power = [] {
+      if (parser.seenval('S')) {
+        const float spwr = parser.value_float();
+        #if ENABLED(SPINDLE_SERVO)
+          cutter.unitPower = spwr;
+        #else
+          cutter.unitPower = TERN(SPINDLE_LASER_USE_PWM,
+                                cutter.power_to_range(cutter_power_t(round(spwr))),
+                                spwr > 0 ? 255 : 0);
+        #endif
+      }
+      else
+        cutter.unitPower = cutter.cpwr_to_upwr(SPEED_POWER_STARTUP);
+      return cutter.unitPower;
+    };
+  #endif
 
   #if ENABLED(LASER_POWER_INLINE)
     if (parser.seen('I') == DISABLED(LASER_POWER_INLINE_INVERT)) {

--- a/buildroot/tests/mega1280
+++ b/buildroot/tests/mega1280
@@ -28,6 +28,12 @@ opt_enable SPINDLE_FEATURE ULTIMAKERCONTROLLER LCD_BED_LEVELING \
 exec_test $1 $2 "Spindle, MESH_BED_LEVELING, closed loop, Power Monitor, and LCD" "$3"
 
 #
+# ...and without PWM
+#
+opt_disable SPINDLE_LASER_USE_PWM
+exec_test $1 $2 "(No PWM)" "$3"
+
+#
 # Test DUAL_X_CARRIAGE
 #
 restore_configs


### PR DESCRIPTION
### Description

SPEED_POWER defines are not created due to an incorrect dependency on `SPINDLE_LASER_USE_PWM`.
This PR removes the dependency. 

### Requirements

None

### Benefits

Permits a non PWM config.

### Configurations

### Related Issues

#23166