### PR TITLE
Park Nozzle before Halt on temperature error

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1896,6 +1896,7 @@
   #define NOZZLE_PARK_Z_RAISE_MIN   2   // (mm) Always raise Z by at least this distance
   #define NOZZLE_PARK_XY_FEEDRATE 100   // (mm/s) X and Y axes feedrate (also used for delta Z axis)
   #define NOZZLE_PARK_Z_FEEDRATE    5   // (mm/s) Z axis feedrate (not used for delta printers)
+  #define NOZZLE_PARK_ON_TEMP_ERROR     // Park Nozzle before Halt on temperature error
 #endif
 
 /**

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -975,6 +975,11 @@ inline void loud_kill(FSTR_P const lcd_msg, const heater_id_t heater_id) {
     }
     WRITE(BEEPER_PIN, HIGH);
   #endif
+  #if ENABLED(NOZZLE_PARK_ON_TEMP_ERROR)
+    if (homing_needed_error()) return;
+    nozzle.park(parser.ushortval('P'));
+    planner.synchronize();
+  #endif
   kill(lcd_msg, HEATER_FSTR(heater_id));
 }
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -976,9 +976,10 @@ inline void loud_kill(FSTR_P const lcd_msg, const heater_id_t heater_id) {
     WRITE(BEEPER_PIN, HIGH);
   #endif
   #if ENABLED(NOZZLE_PARK_ON_TEMP_ERROR)
-    if (homing_needed_error()) return;
-    nozzle.park(parser.ushortval('P'));
-    planner.synchronize();
+    if (!homing_needed_error()) {
+      nozzle.park(parser.ushortval('P'));
+      planner.synchronize();
+    }
   #endif
   kill(lcd_msg, HEATER_FSTR(heater_id));
 }


### PR DESCRIPTION
Park Nozzle before Halt on temperature error to prevent the residual heat leaks into the surrounding object, or worse, the build plate leaving a mark.

This PR solve issue #3407