### PR TITLE
Fix issue with Wire.begin mapping to wrong function prototype

### DIFF
--- a/Marlin/src/feature/adc/adc_mcp3426.cpp
+++ b/Marlin/src/feature/adc/adc_mcp3426.cpp
@@ -1,0 +1,119 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * adc_mcp3426.cpp -  library for MicroChip MCP3426 I2C A/D converter
+ *
+ * For implementation details, please take a look at the datasheet:
+ * https://www.microchip.com/en-us/product/MCP3426
+  */
+
+#include "../../inc/MarlinConfig.h"
+
+#if ENABLED(HAS_MCP3426_ADC)
+
+#include "adc_mcp3426.h"
+
+// Read the ADC value from MCP342X on a specific channel
+int16_t MCP3426::ReadValue(uint8_t channel, uint8_t gain)
+{
+  Error = false;
+
+#if PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
+  Wire.setSDA(pin_t(I2C_SDA_PIN));
+  Wire.setSCL(pin_t(I2C_SCL_PIN));
+#endif
+
+  Wire.begin(); // No address joins the BUS as the master
+
+  Wire.beginTransmission(I2C_ADDRESS(MCP342X_ADC_I2C_ADDRESS));
+
+  //Continuous Conversion Mode, 16 bit, Channel 1, Gain x4
+  //26 = 0b00011000
+  //       RXXCSSGG
+  //  R = Ready Bit
+  // XX = Channel (00=1, 01=2, 10=3 (MCP3428), 11=4 (MCP3428))
+  //  C = Conversion Mode Bit (1=  Continuous Conversion Mode (Default))
+  // SS = Sample rate, 10=15 samples per second @ 16 bits
+  // GG = Gain 00 =x1
+  uint8_t controlRegister = 0b00011000;
+
+  if (channel == 2)
+  {
+    //Select channel 2
+    controlRegister |= 0b00100000;
+  }
+
+  if (gain == 2)
+  {
+    controlRegister |= 0b00000001;
+  }
+  else if (gain == 4)
+  {
+    controlRegister |= 0b00000010;
+  }
+  else if (gain == 8)
+  {
+    controlRegister |= 0b00000011;
+  }
+
+  Wire.write(controlRegister);
+  if (Wire.endTransmission() != 0)
+  {
+    Error = true;
+    return 0;
+  }
+
+  const uint8_t len = 3;
+  uint8_t buffer[len] = {};
+
+  do
+  {
+    Wire.requestFrom(I2C_ADDRESS(MCP342X_ADC_I2C_ADDRESS), len);
+    if (Wire.available() != len)
+    {
+      Error = true;
+      return 0;
+    }
+
+    for (uint8_t i = 0; i < len; ++i)
+      buffer[i] = Wire.read();
+
+    //Is conversion ready, if not loop around again
+  } while ((buffer[2] & 0x80) != 0);
+
+  union TwoBytesToInt16
+  {
+    uint8_t bytes[2];
+    int16_t integervalue;
+  };
+  TwoBytesToInt16 ConversionUnion;
+
+  ConversionUnion.bytes[1] = buffer[0];
+  ConversionUnion.bytes[0] = buffer[1];
+
+  return ConversionUnion.integervalue;
+}
+
+MCP3426 mcp3426;
+
+#endif // HAS_MCP3426_ADC

--- a/Marlin/src/feature/adc/adc_mcp3426.h
+++ b/Marlin/src/feature/adc/adc_mcp3426.h
@@ -1,0 +1,43 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Arduino library for MicroChip MCP3426 I2C A/D converter.
+ * https://www.microchip.com/en-us/product/MCP3426
+ */
+
+#include "../../core/types.h"
+
+#include <Wire.h>
+
+// Address of MCP342X chip
+#define MCP342X_ADC_I2C_ADDRESS 104
+
+class MCP3426
+{
+public:
+  int16_t ReadValue(uint8_t channel, uint8_t gain);
+  bool Error;
+};
+
+extern MCP3426 mcp3426;

--- a/Marlin/src/feature/twibus.cpp
+++ b/Marlin/src/feature/twibus.cpp
@@ -34,11 +34,14 @@ TWIBus i2c;
 
 TWIBus::TWIBus() {
   #if I2C_SLAVE_ADDRESS == 0
-    Wire.begin(                    // No address joins the BUS as the master
-      #if PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
-        pin_t(I2C_SDA_PIN), pin_t(I2C_SCL_PIN)
-      #endif
-    );
+
+    #if PINS_EXIST(I2C_SCL, I2C_SDA) && DISABLED(SOFT_I2C_EEPROM)
+    Wire.setSDA(pin_t(I2C_SDA_PIN));
+    Wire.setSCL(pin_t(I2C_SCL_PIN));
+    #endif
+
+    Wire.begin();                    // No address joins the BUS as the master
+    
   #else
     Wire.begin(I2C_SLAVE_ADDRESS); // Join the bus as a slave
   #endif

--- a/Marlin/src/gcode/feature/adc/M3426.cpp
+++ b/Marlin/src/gcode/feature/adc/M3426.cpp
@@ -1,0 +1,102 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../../../inc/MarlinConfig.h"
+
+#if ENABLED(HAS_MCP3426_ADC)
+
+#include "../../gcode.h"
+
+#include "../../../feature/adc/adc_mcp3426.h"
+
+/**
+ * M3426: Read 16 bit (signed) value from I2C MCP3426 ADC device
+ *
+ *  M3426 C<byte-1 value in base 10> channel 1 or 2
+ *  M3426 G<byte-1 value in base 10> gain 1, 2, 4 or 8
+ *  M3426 I<byte-2 value in base 10> 0 or 1, invert reply
+ */
+void GcodeSuite::M3426()
+{
+  // Set the target address
+  uint8_t channel = 1;
+  uint8_t gain = 1;
+
+  bool inverted = false;
+
+  // Select the channel 1 or 2
+  if (parser.seen('C'))
+  {
+    channel = parser.value_byte();
+  }
+
+  if (parser.seen('G'))
+  {
+    gain = parser.value_byte();
+  }
+
+  if (parser.seen('I'))
+  {
+    if (parser.value_byte() == 1)
+    {
+      inverted = true;
+    }
+  }
+
+  if ((channel <= 2) && ((gain == 1) || (gain == 2) || (gain == 4) || (gain == 8)))
+  {
+    int16_t result = mcp3426.ReadValue(channel, gain);
+
+    if (mcp3426.Error == false)
+    {
+
+      if (inverted)
+      {
+        //Should we invert the reading (32767 - ADC value) ?
+        //Caters for end devices which expect values to increase when in reality then decrease
+        //For instance pressure sensor in a vacuum when the end device expects a positive pressure
+        result = INT16_MAX - result;
+      }
+
+      SERIAL_ECHOPGM(STR_OK);
+      SERIAL_ECHOPGM(" V:");
+      SERIAL_ECHO(result);
+      SERIAL_ECHOPGM(" C:");
+      SERIAL_ECHO(channel);
+      SERIAL_ECHOPGM(" G:");
+      SERIAL_ECHO(gain);
+      SERIAL_ECHOPGM(" I:");
+      SERIAL_ECHO(inverted ? 1 : 0);
+      SERIAL_EOL();
+    }
+    else
+    {
+      SERIAL_ERROR_MSG("MCP342X i2c error");
+    }
+  }
+  else
+  {
+    SERIAL_ERROR_MSG("MCP342X Bad request");
+  }
+}
+
+#endif

--- a/Marlin/src/gcode/feature/adc/M3426.cpp
+++ b/Marlin/src/gcode/feature/adc/M3426.cpp
@@ -77,8 +77,8 @@ void GcodeSuite::M3426()
         result = INT16_MAX - result;
       }
 
-      SERIAL_ECHOPGM(STR_OK);
-      SERIAL_ECHOPGM(" V:");
+      //SERIAL_ECHOPGM(STR_OK);
+      SERIAL_ECHOPGM("V:");
       SERIAL_ECHO(result);
       SERIAL_ECHOPGM(" C:");
       SERIAL_ECHO(channel);

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -1044,6 +1044,10 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
         case 7219: M7219(); break;                                // M7219: Set LEDs, columns, and rows
       #endif
 
+      #if ENABLED(HAS_MCP3426_ADC)
+      case 3426: M3426(); break;                                  // M3426: Read MCP3426 ADC (over i2c)
+      #endif
+
       default: parser.unknown_command_warning(); break;
     }
     break;

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -297,6 +297,7 @@
  * M918 - L6470 tuning: Increase speed until max or error. (Requires at least one _DRIVER_TYPE L6470)
  * M951 - Set Magnetic Parking Extruder parameters. (Requires MAGNETIC_PARKING_EXTRUDER)
  * M7219 - Control Max7219 Matrix LEDs. (Requires MAX7219_GCODE)
+ * M3426 - Read MCP3426 ADC (over i2c)
  *
  *** SCARA ***
  * M360 - SCARA calibration: Move to cal-position ThetaA (0 deg calibration)
@@ -1201,6 +1202,10 @@ private:
 
   #if ENABLED(MAX7219_GCODE)
     static void M7219();
+  #endif
+
+  #if ENABLED(HAS_MCP3426_ADC)
+    static void M3426();
   #endif
 
   #if ENABLED(CONTROLLER_FAN_EDITABLE)

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -41,6 +41,10 @@
 
 #define SRAM_EEPROM_EMULATION
 #define MARLIN_EEPROM_SIZE                0x2000  // 8KB
+#define FAN_SOFT_PWM
+
+//i2c mcp3426 (16-Bit, 240SPS, Dual Channel ADC)
+#define HAS_MCP3426_ADC
 
 //
 // Servos


### PR DESCRIPTION
### Description

PR #22890 improved the formatting of the experimental i2c feature.  At the time of submission the code was working as expected on STM32 devices.

Since then, the code now appears to compile incorrectly against the Wire library.

The Wire.begin call appears to be mapping incorrectly to a different function prototype in the Wire library, therefore the i2c comms is never correctly started.

This change forces the mapping of both SDA/SCL pins to the correct settings and starts the Wire library.

### Requirements

Not board specific

### Benefits

Makes i2c feature work M260/M261 commands.

### Configurations

Not required

### Related Issues

PR #22890 
