### PR TITLE
add env:BIGTREE_SKR_2_F429

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -382,7 +382,7 @@
 #define BOARD_BTT_BTT002_V1_0         4210  // BigTreeTech BTT002 v1.0 (STM32F407VGT6)
 #define BOARD_BTT_E3_RRF              4211  // BigTreeTech E3 RRF (STM32F407VGT6)
 #define BOARD_BTT_SKR_V2_0_REV_A      4212  // BigTreeTech SKR v2.0 Rev A (STM32F407VGT6)
-#define BOARD_BTT_SKR_V2_0_REV_B      4213  // BigTreeTech SKR v2.0 Rev B (STM32F407VGT6)
+#define BOARD_BTT_SKR_V2_0_REV_B      4213  // BigTreeTech SKR v2.0 Rev B (STM32F407VGT6/STM32F429VGT6)
 #define BOARD_BTT_GTR_V1_0            4214  // BigTreeTech GTR v1.0 (STM32F407IGT)
 #define BOARD_BTT_OCTOPUS_V1_0        4215  // BigTreeTech Octopus v1.0 (STM32F446ZET6)
 #define BOARD_BTT_OCTOPUS_V1_1        4216  // BigTreeTech Octopus v1.1 (STM32F446ZET6)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -622,7 +622,7 @@
 #elif MB(BTT_SKR_V2_0_REV_A)
   #include "stm32f4/pins_BTT_SKR_V2_0_REV_A.h"  // STM32F4                                env:BIGTREE_SKR_2 env:BIGTREE_SKR_2_USB env:BIGTREE_SKR_2_USB_debug
 #elif MB(BTT_SKR_V2_0_REV_B)
-  #include "stm32f4/pins_BTT_SKR_V2_0_REV_B.h"  // STM32F4                                env:BIGTREE_SKR_2 env:BIGTREE_SKR_2_USB env:BIGTREE_SKR_2_USB_debug
+  #include "stm32f4/pins_BTT_SKR_V2_0_REV_B.h"  // STM32F4                                env:BIGTREE_SKR_2 env:BIGTREE_SKR_2_USB env:BIGTREE_SKR_2_USB_debug env:BIGTREE_SKR_2_F429
 #elif MB(BTT_OCTOPUS_V1_0)
   #include "stm32f4/pins_BTT_OCTOPUS_V1_0.h"    // STM32F4                                env:BIGTREE_OCTOPUS_V1 env:BIGTREE_OCTOPUS_V1_USB
 #elif MB(BTT_OCTOPUS_V1_1)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -622,7 +622,7 @@
 #elif MB(BTT_SKR_V2_0_REV_A)
   #include "stm32f4/pins_BTT_SKR_V2_0_REV_A.h"  // STM32F4                                env:BIGTREE_SKR_2 env:BIGTREE_SKR_2_USB env:BIGTREE_SKR_2_USB_debug
 #elif MB(BTT_SKR_V2_0_REV_B)
-  #include "stm32f4/pins_BTT_SKR_V2_0_REV_B.h"  // STM32F4                                env:BIGTREE_SKR_2 env:BIGTREE_SKR_2_USB env:BIGTREE_SKR_2_USB_debug env:BIGTREE_SKR_2_F429
+  #include "stm32f4/pins_BTT_SKR_V2_0_REV_B.h"  // STM32F4                                env:BIGTREE_SKR_2 env:BIGTREE_SKR_2_USB env:BIGTREE_SKR_2_USB_debug env:BIGTREE_SKR_2_F429 env:BIGTREE_SKR_2_F429_USB env:BIGTREE_SKR_2_F429_USB_debug
 #elif MB(BTT_OCTOPUS_V1_0)
   #include "stm32f4/pins_BTT_OCTOPUS_V1_0.h"    // STM32F4                                env:BIGTREE_OCTOPUS_V1 env:BIGTREE_OCTOPUS_V1_USB
 #elif MB(BTT_OCTOPUS_V1_1)

--- a/buildroot/share/PlatformIO/boards/marlin_STM32F429VGT6.json
+++ b/buildroot/share/PlatformIO/boards/marlin_STM32F429VGT6.json
@@ -1,0 +1,50 @@
+{
+  "build": {
+    "cpu": "cortex-m4",
+    "extra_flags": "-DSTM32F4 -DSTM32F429xx",
+    "f_cpu": "168000000L",
+    "mcu": "stm32f429vgt6",
+    "product_line": "STM32F429xx",
+    "variant": "MARLIN_F4x7Vx"
+  },
+  "connectivity": [
+    "can"
+  ],
+  "debug": {
+    "default_tools": [
+      "stlink"
+    ],
+    "jlink_device": "STM32F429VG",
+    "onboard_tools": [
+      "stlink"
+    ],
+    "openocd_board": "stm32f429",
+    "openocd_target": "stm32f4x",
+    "svd_path": "STM32F429x.svd"
+  },
+  "frameworks": [
+    "arduino",
+    "cmsis",
+    "mbed",
+    "stm32cube",
+    "libopencm3",
+    "zephyr"
+  ],
+  "name": "STM32F429VG (128k RAM, 64k CCM RAM, 1024k Flash)",
+  "upload": {
+    "disable_flushing": false,
+    "maximum_ram_size": 131072,
+    "maximum_size": 1048576,
+    "protocol": "stlink",
+    "protocols": [
+      "stlink",
+      "dfu",
+      "jlink"
+    ],
+    "require_upload_port": true,
+    "use_1200bps_touch": false,
+    "wait_for_upload_port": false
+  },
+  "url": "https://www.st.com/en/microcontrollers-microprocessors/stm32f429-439.html",
+  "vendor": "ST"
+}

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -246,6 +246,24 @@ build_flags       = ${env:BIGTREE_SKR_2_USB.build_flags} -O0
 build_unflags     = ${env:BIGTREE_SKR_2_USB.build_unflags} -Os -NDEBUG
 
 #
+# Bigtreetech SKR V2.0 F429 (STM32F429VGT6 ARM Cortex-M4) with USB Flash Drive Support
+#
+[env:BIGTREE_SKR_2_F429]
+platform                    = ${common_stm32.platform}
+extends                     = stm32_variant
+platform_packages           = ${stm_flash_drive.platform_packages}
+board                       = marlin_STM32F429VGT6
+board_build.variant         = MARLIN_F4x7Vx
+board_build.offset          = 0x8000
+board_upload.offset_address = 0x08008000
+build_flags                 = ${stm_flash_drive.build_flags}
+                              -DUSE_USBHOST_HS -DUSE_USB_HS_IN_FS
+                              -DUSBD_IRQ_PRIO=5 -DUSBD_IRQ_SUBPRIO=6
+                              -DHSE_VALUE=8000000U -DHAL_SD_MODULE_ENABLED
+                              -DPIN_SERIAL3_RX=PD_9 -DPIN_SERIAL3_TX=PD_8
+upload_protocol             = stlink
+
+#
 # BigTreeTech Octopus V1.0/1.1 / Octopus Pro V1.0 (STM32F446ZET6 ARM Cortex-M4)
 #
 [env:BIGTREE_OCTOPUS_V1]

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -269,15 +269,14 @@ upload_protocol             = stlink
 [env:BIGTREE_SKR_2_F429_USB]
 platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_SKR_2_F429
-build_flags       = ${env:BIGTREE_SKR_2.build_flags} -DUSBD_USE_CDC_MSC
-build_unflags     = ${env:BIGTREE_SKR_2.build_unflags} -DUSBD_USE_CDC
+build_flags       = ${env:BIGTREE_SKR_2_F429.build_flags} -DUSBD_USE_CDC_MSC
+build_unflags     = ${env:BIGTREE_SKR_2_F429.build_unflags} -DUSBD_USE_CDC
 
 [env:BIGTREE_SKR_2_F429_USB_debug]
 platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_SKR_2_F429_USB
-build_flags       = ${env:BIGTREE_SKR_2_USB.build_flags} -O0
-build_unflags     = ${env:BIGTREE_SKR_2_USB.build_unflags} -Os -NDEBUG
-
+build_flags       = ${env:BIGTREE_SKR_2_F429_USB.build_flags} -O0
+build_unflags     = ${env:BIGTREE_SKR_2_F429_USB.build_unflags} -Os -NDEBUG
 
 #
 # BigTreeTech Octopus V1.0/1.1 / Octopus Pro V1.0 (STM32F446ZET6 ARM Cortex-M4)

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -264,6 +264,22 @@ build_flags                 = ${stm_flash_drive.build_flags}
 upload_protocol             = stlink
 
 #
+# BigTreeTech SKR V2.0 F429 (STM32F429VGT6 ARM Cortex-M4) with USB Media Share Support
+#
+[env:BIGTREE_SKR_2_F429_USB]
+platform          = ${common_stm32.platform}
+extends           = env:BIGTREE_SKR_2_F429
+build_flags       = ${env:BIGTREE_SKR_2.build_flags} -DUSBD_USE_CDC_MSC
+build_unflags     = ${env:BIGTREE_SKR_2.build_unflags} -DUSBD_USE_CDC
+
+[env:BIGTREE_SKR_2_F429_USB_debug]
+platform          = ${common_stm32.platform}
+extends           = env:BIGTREE_SKR_2_F429_USB
+build_flags       = ${env:BIGTREE_SKR_2_USB.build_flags} -O0
+build_unflags     = ${env:BIGTREE_SKR_2_USB.build_unflags} -Os -NDEBUG
+
+
+#
 # BigTreeTech Octopus V1.0/1.1 / Octopus Pro V1.0 (STM32F446ZET6 ARM Cortex-M4)
 #
 [env:BIGTREE_OCTOPUS_V1]


### PR DESCRIPTION
### Description

BTT changed processor on the SKR 2 to a STM32F429
Add a build environment for this processor
Extracted it from BTT github and tidied and created _USB variants

### Requirements

BTT SKR 2 with a STM32F429VGT6

### Benefits

Users can Compile for this prcessor

### Related Issues
FR https://github.com/MarlinFirmware/Marlin/issues/23176

### NOTE
I do not have this board, can only test it compiles.
Will see if the above person who requested this FR can test it