### PR TITLE
MKS Robin E3: Prevent NeoPixel Redefined Warnings

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -64,11 +64,6 @@
   #define Z_MIN_PROBE_PIN                   PB1
 #endif
 
-// LED driving pin
-#ifndef NEOPIXEL_PIN
-  #define NEOPIXEL_PIN                      PA2
-#endif
-
 //
 // Steppers
 //
@@ -243,6 +238,11 @@
   #ifndef BOARD_ST7920_DELAY_3
     #define BOARD_ST7920_DELAY_3             125
   #endif
+#endif
+
+// LED driving pin
+#ifndef NEOPIXEL_PIN
+  #define NEOPIXEL_PIN                      PA2
 #endif
 
 //


### PR DESCRIPTION
### Description

Move MKS Robin E3 NeoPixel pin block below LCD/Controller pins to prevent redefined warnings.

### Requirements

MKS Robin E3 board with an RGB (NeoPixel)-based LCD controller (Fysetc Mini 12864 V2.1, MKS Mini 12864 V3, BTT 12864 Mini V1).

### Benefits

No wall-o-warnings when using one of the RGB/NeoPixel-based LCD controllers.

### Related Issues

None, but there is some work to be done with these RGB/NeoPixel LCDs and them auto-enabling `NEOPIXEL_LED` when some boards have dedicated NeoPixel pins (especially now that we have `NEOPIXEL2_SEPARATE`). This is for another time since I'll have to look at potential conflicts with timers, etc.
