### PR TITLE
Fix Fan Turn On when Printer Start

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1311,8 +1311,8 @@ void Planner::check_axes_activity() {
   #endif
 
   #if HAS_TAIL_FAN_SPEED
-    static uint8_t tail_fan_speed[FAN_COUNT];
-    bool fans_need_update = true;
+    static uint8_t tail_fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, 255);
+    bool fans_need_update = false;
   #endif
 
   #if ENABLED(BARICUDA)

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1312,7 +1312,7 @@ void Planner::check_axes_activity() {
 
   #if HAS_TAIL_FAN_SPEED
     static uint8_t tail_fan_speed[FAN_COUNT];
-    bool fans_need_update = false;
+    bool fans_need_update = true;
   #endif
 
   #if ENABLED(BARICUDA)


### PR DESCRIPTION
When Printer Power On. Tail Fan Speed = 0 and Spd = 0, therefore if the fan spinning, it will not turn off because the fan not updated. 
bool fans_need_update = true;
will force the extruder fan to update at startup. 

The problem starts from PR #23149
Related to issue #23162 