### PR TITLE
remove conflicting definitions from ftdi_eve

### DIFF
--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/ftdi_eve_extui.cpp
@@ -71,7 +71,6 @@ namespace ExtUI {
   }
 
   void onStatusChanged(const char *lcd_msg) { StatusScreen::setStatusMessage(lcd_msg); }
-  void onStatusChanged(FSTR_P lcd_msg) { StatusScreen::setStatusMessage(lcd_msg); }
 
   void onPrintTimerStarted() {
     InterfaceSoundsScreen::playEventSound(InterfaceSoundsScreen::PRINTING_STARTED);

--- a/Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language_en.h
+++ b/Marlin/src/lcd/extui/ftdi_eve_touch_ui/language/language_en.h
@@ -145,7 +145,6 @@ namespace Language_en {
   PROGMEM Language_Str MSG_LEVELING                 = u8"Leveling";
   PROGMEM Language_Str MSG_AXIS_LEVELING            = u8"Axis Leveling";
   PROGMEM Language_Str MSG_PROBE_BED                = u8"Probe Mesh";
-  PROGMEM Language_Str MSG_MESH_VIEW                = u8"View Mesh";
   PROGMEM Language_Str MSG_PRINT_TEST               = u8"Print Test (PLA)";
   PROGMEM Language_Str MSG_MOVE_Z_TO_TOP            = u8"Raise Z to Top";
 


### PR DESCRIPTION
### Description

error: redefinition of 'const char Language_en::MSG_MESH_VIEW []'
Multiple definitions of ExtUI::onStatusChanged


### Requirements
Default_envs = FYSETC_S6_8000
#define SERIAL_PORT 1
#define MOTHERBOARD BOARD_FYSETC_S6_V2_0
#define TOUCH_UI_FTDI_EVE
#define LCD_FYSETC_TFT81050       // FYSETC with 5" (800x480)
#define S6_TFT_PINMAP       // FYSETC S6 pin mapping

### Benefits

compiles as expected

### Related Issues
Fixes https://github.com/MarlinFirmware/Marlin/issues/23126
