### PR TITLE
Remove Bidirectional Unicode Text

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1667,7 +1667,7 @@
   //#define STATUS_ALT_FAN_BITMAP     // Use the alternative fan bitmap
   //#define STATUS_FAN_FRAMES 3       // :[0,1,2,3,4] Number of fan animation frames
   //#define STATUS_HEAT_PERCENT       // Show heating in a progress bar
-  //#define BOOT_MARLIN_LOGO_ANIMATED // Animated Marlin logo. Costs ~‭3260 (or ~940) bytes of PROGMEM.
+  //#define BOOT_MARLIN_LOGO_ANIMATED // Animated Marlin logo. Costs ~3260 (or ~940) bytes of PROGMEM.
 
   // Frivolous Game Options
   //#define MARLIN_BRICKOUT


### PR DESCRIPTION
### Description

Remove hidden / bidirectional unicode text:
![image](https://user-images.githubusercontent.com/13375512/143228285-661c33dd-d5f7-4d00-acf5-e78e89b80227.png)

### Benefits

No more warning from `Configuration_adv.h` when viewing it on Github!

### Related Issues

- https://github.com/MarlinFirmware/Configurations/pull/620