### PR TITLE
STM32: rework timer frequency protection

### DIFF
--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -25,33 +25,30 @@
 #ifdef HAL_STM32
 
 #include "../../inc/MarlinConfig.h"
-#include "timers.h"
 
 // Array to support sticky frequency sets per timer
 static uint16_t timer_freq[TIMER_NUM];
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   if (!PWM_PIN(pin)) return; // Don't proceed if no hardware timer
-  PinName pin_name = digitalPinToPinName(pin);
-  TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM);
+  const PinName pin_name = digitalPinToPinName(pin);
+  TIM_TypeDef * const Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM);
 
-  const uint32_t index = get_timer_index(Instance);
-  bool needs_freq = (HardwareTimer_Handle[index] == nullptr); // A new instance must be set to the default frequency of PWM_FREQUENCY
+  const timer_index_t index = get_timer_index(Instance);
+  const bool needs_freq = HardwareTimer_Handle[index] == nullptr; // A new instance must be set to default frequency PWM_FREQUENCY
   if (needs_freq)
     HardwareTimer_Handle[index]->__this = new HardwareTimer((TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM));
 
   HardwareTimer * const HT = (HardwareTimer *)(HardwareTimer_Handle[index]->__this);
   const uint32_t channel = STM_PIN_CHANNEL(pinmap_function(pin_name, PinMap_PWM));
   const TimerModes_t previousMode = HT->getMode(channel);
+
   if (previousMode != TIMER_OUTPUT_COMPARE_PWM1)
     HT->setMode(channel, TIMER_OUTPUT_COMPARE_PWM1, pin);
 
-  if (needs_freq) {
-    if (timer_freq[index] == 0 ) {                    // If the timer is unconfigured and no freq is set then default PWM_FREQUENCY.
-      timer_freq[index] = PWM_FREQUENCY;
-      set_pwm_frequency(pin_name, timer_freq[index]); // Set the frequency and save the value to the assigned index no.
-    }
-  }
+  if (needs_freq && timer_freq[index] == 0)     // If the timer is unconfigured and no freq is set then default PWM_FREQUENCY
+    set_pwm_frequency(pin_name, PWM_FREQUENCY); // Set the frequency and save the value to the assigned index no.
+
   // Note the resolution is sticky here, the input can be upto 16 bits and that would require RESOLUTION_16B_COMPARE_FORMAT (16)
   // If such a need were to manifest then we would need to calc the resolution based on the v_size parameter and add code for it.
   const uint16_t value = invert ? v_size - v : v;
@@ -62,23 +59,26 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
 
 void set_pwm_frequency(const pin_t pin, int f_desired) {
   if (!PWM_PIN(pin)) return; // Don't proceed if no hardware timer
-
   const PinName pin_name = digitalPinToPinName(pin);
   TIM_TypeDef * const Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); // Get HAL timer instance
-  const uint32_t index = get_timer_index(Instance);
+  const timer_index_t index = get_timer_index(Instance);
 
-  // Protect used timers
-  if (index == MF_TIMER_TEMP || index == MF_TIMER_STEP
-    #if MF_TIMER_PULSE != MF_TIMER_STEP
-      || index == MF_TIMER_PULSE
-    #endif
-  ) return;
+  // Protect used timers.
+  #ifdef STEP_TIMER
+    if (index == TIMER_INDEX(STEP_TIMER)) return;
+  #endif
+  #ifdef TEMP_TIMER
+    if (index == TIMER_INDEX(TEMP_TIMER)) return;
+  #endif
+  #if defined(PULSE_TIMER) && MF_TIMER_PULSE != MF_TIMER_STEP
+    if (index == TIMER_INDEX(PULSE_TIMER)) return;
+  #endif
 
   if (HardwareTimer_Handle[index] == nullptr) // If frequency is set before duty we need to create a handle here.
     HardwareTimer_Handle[index]->__this = new HardwareTimer((TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM));
   HardwareTimer * const HT = (HardwareTimer *)(HardwareTimer_Handle[index]->__this);
-  timer_freq[index] = f_desired; // Save the last frequency so duty will not set the default for this timer number.
   HT->setOverflow(f_desired, HERTZ_FORMAT);
+  timer_freq[index] = f_desired; // Save the last frequency so duty will not set the default for this timer number.
 }
 
 #endif // HAL_STM32

--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -35,14 +35,13 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
   TIM_TypeDef * const Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM);
 
   const timer_index_t index = get_timer_index(Instance);
-  const bool needs_freq = HardwareTimer_Handle[index] == nullptr; // A new instance must be set to default frequency PWM_FREQUENCY
-  if (needs_freq)
+  const bool needs_freq = (HardwareTimer_Handle[index] == nullptr);
+  if (needs_freq) // A new instance must be set to the default frequency of PWM_FREQUENCY
     HardwareTimer_Handle[index]->__this = new HardwareTimer((TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM));
 
   HardwareTimer * const HT = (HardwareTimer *)(HardwareTimer_Handle[index]->__this);
   const uint32_t channel = STM_PIN_CHANNEL(pinmap_function(pin_name, PinMap_PWM));
   const TimerModes_t previousMode = HT->getMode(channel);
-
   if (previousMode != TIMER_OUTPUT_COMPARE_PWM1)
     HT->setMode(channel, TIMER_OUTPUT_COMPARE_PWM1, pin);
 

--- a/Marlin/src/HAL/STM32/timers.h
+++ b/Marlin/src/HAL/STM32/timers.h
@@ -40,17 +40,14 @@
 #define hal_timer_t uint32_t
 #define HAL_TIMER_TYPE_MAX UINT16_MAX
 
+// Marlin timer_instance[] content (unrelated to timer selection)
 #define NUM_HARDWARE_TIMERS 2
+#define MF_TIMER_STEP       0  // Timer Index for Stepper
+#define MF_TIMER_TEMP       1  // Timer Index for Temperature
+#define MF_TIMER_PULSE      MF_TIMER_STEP
 
-#ifndef MF_TIMER_STEP
-  #define MF_TIMER_STEP         0  // Timer Index for Stepper
-#endif
-#ifndef MF_TIMER_PULSE
-  #define MF_TIMER_PULSE        MF_TIMER_STEP
-#endif
-#ifndef MF_TIMER_TEMP
-  #define MF_TIMER_TEMP         1  // Timer Index for Temperature
-#endif
+#define TIMER_INDEX_(T) TIMER##T##_INDEX  // TIMER#_INDEX enums (timer_index_t) depend on TIM#_BASE defines.
+#define TIMER_INDEX(T) TIMER_INDEX_(T)    // Convert Timer ID to HardwareTimer_Handle index.
 
 #define TEMP_TIMER_FREQUENCY 1000   // Temperature::isr() is expected to be called at around 1kHz
 


### PR DESCRIPTION
STEP_TIMER_NUM, TEMP_TIMER_NUM and PULSE_TIMER_NUM are not the indexes returned by the STM32 framework get_timer_index() function. Same thing now with the recently renamed MF_TIMER_xxx constants

In STM32 HAL these constants are defined by Marlin for its own container of custom timers, timer_instance[] which has only 2 records.

follow up for #23125