### PR TITLE
Add support for UM2 extruder cooling fan pin PJ6

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -878,23 +878,21 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
     };
 
     uint8_t fanState = 0;
-    HOTEND_LOOP()
+    HOTEND_LOOP() {
       if (temp_hotend[e].celsius >= EXTRUDER_AUTO_FAN_TEMPERATURE) {
         SBI(fanState, pgm_read_byte(&fanBit[e]));
-      #if MOTHERBOARD == BOARD_ULTIMAIN_2
-        //For the UM2 the head fan is connected to PJ6, which does not have an Arduino PIN definition. So use direct register access.
-        //https://github.com/Ultimaker/Ultimaker2Marlin/blob/master/Marlin/temperature.cpp#L553
-        DDRJ |= _BV(6);
-        PORTJ |= _BV(6);
-      #endif
-      } else {
-      #if MOTHERBOARD == BOARD_ULTIMAIN_2
-        //For the UM2 the head fan is connected to PJ6, which does not have an Arduino PIN definition. So use direct register access.
-        //https://github.com/Ultimaker/Ultimaker2Marlin/blob/master/Marlin/temperature.cpp#L553
-        DDRJ |= _BV(6);
-        PORTJ &=~_BV(6);
-      #endif
+        #if MOTHERBOARD == BOARD_ULTIMAIN_2
+          // For the UM2 the head fan is connected to PJ6, which does not have an Arduino PIN definition. So use direct register access.
+          // https://github.com/Ultimaker/Ultimaker2Marlin/blob/master/Marlin/temperature.cpp#L553
+          SBI(DDRJ, 6); SBI(PORTJ, 6);
+        #endif
       }
+      else {
+        #if MOTHERBOARD == BOARD_ULTIMAIN_2
+          SBI(DDRJ, 6); CBI(PORTJ, 6);
+        #endif
+      }
+    }
 
     #if HAS_AUTO_CHAMBER_FAN
       if (temp_chamber.celsius >= CHAMBER_AUTO_FAN_TEMPERATURE)

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -879,8 +879,22 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
 
     uint8_t fanState = 0;
     HOTEND_LOOP()
-      if (temp_hotend[e].celsius >= EXTRUDER_AUTO_FAN_TEMPERATURE)
+      if (temp_hotend[e].celsius >= EXTRUDER_AUTO_FAN_TEMPERATURE) {
         SBI(fanState, pgm_read_byte(&fanBit[e]));
+      #if MOTHERBOARD == BOARD_ULTIMAIN_2
+        //For the UM2 the head fan is connected to PJ6, which does not have an Arduino PIN definition. So use direct register access.
+        //https://github.com/Ultimaker/Ultimaker2Marlin/blob/master/Marlin/temperature.cpp#L553
+        DDRJ |= _BV(6);
+        PORTJ |= _BV(6);
+      #endif
+      } else {
+      #if MOTHERBOARD == BOARD_ULTIMAIN_2
+        //For the UM2 the head fan is connected to PJ6, which does not have an Arduino PIN definition. So use direct register access.
+        //https://github.com/Ultimaker/Ultimaker2Marlin/blob/master/Marlin/temperature.cpp#L553
+        DDRJ |= _BV(6);
+        PORTJ &=~_BV(6);
+      #endif
+      }
 
     #if HAS_AUTO_CHAMBER_FAN
       if (temp_chamber.celsius >= CHAMBER_AUTO_FAN_TEMPERATURE)

--- a/Marlin/src/pins/ramps/pins_ULTIMAIN_2.h
+++ b/Marlin/src/pins/ramps/pins_ULTIMAIN_2.h
@@ -98,7 +98,7 @@
 #endif
 
 #ifndef E0_AUTO_FAN_PIN
-  #define E0_AUTO_FAN_PIN                     77
+  #define E0_AUTO_FAN_PIN                     69
 #endif
 
 //


### PR DESCRIPTION
### Description

Added #if statement in temperature.cpp to add support for Ultimaker 2 (UM2) extruder cooling fan. 

As noted in the official Ultimaker 2 Marlin fork:
> For the UM2 the head fan is connected to PJ6, which does not have an Arduino PIN definition. So use direct register access.
https://github.com/Ultimaker/Ultimaker2Marlin/blob/master/Marlin/temperature.cpp#L553

The pin number for `E0_AUTO_FAN_PIN` in `pins_ULTIMAIN_2.h` is also corrected to pin 69. See attached Ultimainboard v2.1.4 schematic: pin PJ6 (69) goes to the fan. The previous value of 77 goes to the X axis stepper motor input which doesn't make sense. 

### Requirements

This PR adds additional functionality for `MOTHERBOARD` model `BOARD_ULTIMAIN_2`. 
`#define E0_AUTO_FAN_PIN -1` must be commented out in Configuration_adv.h in order leave the extruder cooling fan enabled. 

### Benefits

The Ultimaker 2+ extruder cooling fan now turns on when extruder temperature is above `EXTRUDER_AUTO_FAN_TEMPERATURE`. The cooling fan improves printer performance and safety. 

### Configurations

[Ultimainboard V2.1.4 schematics.PDF](https://github.com/MarlinFirmware/Marlin/files/7598914/Ultimainboard.V2.1.4.schematics.PDF)

Attached configuration for UMO+ printer that has been upgraded with the UM2+ extruder. 
[Configuration_UMO++.zip](https://github.com/MarlinFirmware/Marlin/files/7598908/Configuration_UMO%2B%2B.zip)

