### PR TITLE
Fix ACTION_ITEM with nullptr

### DIFF
--- a/Marlin/src/lcd/menu/menu_item.h
+++ b/Marlin/src/lcd/menu/menu_item.h
@@ -55,7 +55,7 @@ class MenuItem_button : public MenuItemBase {
 class MenuItem_function : public MenuItem_button {
   public:
     //static inline void action(PGM_P const, const uint8_t, const menuAction_t func) { (*func)(); };
-    static inline void action(PGM_P const, const menuAction_t func) { (*func)(); };
+    static inline void action(PGM_P const, const menuAction_t func) { if (func) (*func)(); };
 };
 
 // GCODES_ITEM(LABEL, GCODES)

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -256,7 +256,7 @@ void menu_main() {
       }
       else {
         #if PIN_EXISTS(SD_DETECT)
-          ACTION_ITEM(MSG_NO_MEDIA, nullptr);                 // "No Media"
+          ACTION_ITEM(MSG_NO_MEDIA, []{} );                   // "No Media"
         #else
           GCODES_ITEM(MSG_ATTACH_MEDIA, PSTR("M21"));         // M21 Attach Media
         #endif

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -256,7 +256,7 @@ void menu_main() {
       }
       else {
         #if PIN_EXISTS(SD_DETECT)
-          ACTION_ITEM(MSG_NO_MEDIA, []{} );                   // "No Media"
+          ACTION_ITEM(MSG_NO_MEDIA, nullptr);                 // "No Media"
         #else
           GCODES_ITEM(MSG_ATTACH_MEDIA, PSTR("M21"));         // M21 Attach Media
         #endif


### PR DESCRIPTION
### Description

When an SD card is not inserted the menu would dereference `nullptr` and crash. Replace the `nullptr` with an empty lambda to avoid this.

I first attempted to replace `ACTION_ITEM` with `STATIC_ITEM`, but this seemed to behave oddly in the menu. I could scroll down to the static item but it would not appear highlighted. By using the empty lambda I can still select the line, it simply does nothing when selected.

### Requirements

SD_SUPPORT

### Benefits

Fix crash

### Configurations

I discovered and fixed this using the simulator. Enabling SD was the only change from the example.
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/7599467/Configuration.zip)

### Related Issues

N/A
