### PR TITLE
Prevent M33 crash due to missing argument

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -359,7 +359,7 @@ void CardReader::ls(TERN_(LONG_FILENAME_HOST_SUPPORT, bool includeLongNames/*=fa
   //
   void CardReader::printLongPath(char * const path) {
 
-    int i, pathLen = strlen(path);
+    int i, pathLen = path ? strlen(path) : 0;
 
     // SERIAL_ECHOPGM("Full Path: "); SERIAL_ECHOLN(path);
 


### PR DESCRIPTION
### Description

When no argument is passed to M33 CardReader::printLongPath is passed a null pointer. This is then passed to strlen which is invalid and causes a crash.

I have implemented this inside CardReader::printLongPath so that all callers will benefit, rather than having to fix this from different call sites. It is currently used from both M33 and tft_lvgl_init.

To reproduce, simply call `M33` with no arguments.
**Old behavior**: Crash
**New Behavior**: Print a blank line prior to the OK.
**Possible Alternative Solution**: Print an error. See suggestion in #21852.

### Requirements

Enable `SD_SUPPORT` and `LONG_FILENAME_HOST_SUPPORT`.

### Benefits

Fix crash due to M33 misuse.

### Configurations

N/A (I reproduced and fixed in the simulator, which is a slight headache to use with an SD image)

### Related Issues

#21852
