### PR TITLE
Swap BTT002 Tach Pins

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -190,9 +190,9 @@
 
 #ifndef E0_FAN_TACHO_PIN
   #ifdef MK3_FAN_PINS
-    #define E0_FAN_TACHO_PIN                PE0   // Fan1
+    #define E0_FAN_TACHO_PIN                PE1   // Fan1
   #else
-    #define E0_FAN_TACHO_PIN                PE1   // Fan0
+    #define E0_FAN_TACHO_PIN                PE0   // Fan0
   #endif
 #endif
 


### PR DESCRIPTION
### Description

Heating would halt with a "Fan speed fault" error unless you had the parts cooling fan on, indicating that pins were swapped.

Verified fix on a real Prusa MK3S/BTT002 build.

### Requirements

BTT002 build

### Benefits

Heating no longer halts when monitoring the correct fan/pin.

### Configurations

[Default BTT002 config](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/Prusa/MK3S-BigTreeTech-BTT002)

### Related Issues

None. Found while working on a new build.