### PR TITLE
Assume 4K EEPROM for RUMBA32 BTT

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_BTT.h
@@ -30,7 +30,7 @@
 
 #if NO_EEPROM_SELECTED
   #define I2C_EEPROM
-  #define MARLIN_EEPROM_SIZE            0x2000  // 8KB (24LC64T-I/OT)
+  #define MARLIN_EEPROM_SIZE            0x1000  // 4KB (24LC32AT-I/OT)
 #endif
 
 #if ENABLED(FLASH_EEPROM_EMULATION)


### PR DESCRIPTION
BTT Rumba32 uses smaller EEPROM chip, only 4KB (24LC32AT-I/OT instead of 24LC64T-I/OT)

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
