### PR TITLE
Modified pins_BTT_SKR_V2_0_common.h to reuse PB6 as and PB5 for spind…

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -233,13 +233,22 @@
 #ifndef FAN_PIN
   #define FAN_PIN                           PB7   // Fan0
 #endif
-#ifndef FAN1_PIN
-  #define FAN1_PIN                          PB6   // Fan1
-#endif
-#ifndef FAN2_PIN
-  #define FAN2_PIN                          PB5   // Fan2
-#endif
 
+#if EITHER(SPINDLE_FEATURE, LASER_FEATURE)
+  #ifndef SPINDLE_LASER_PWM_PIN
+    #define SPINDLE_LASER_PWM_PIN              PB5
+  #endif
+  #ifndef SPINDLE_LASER_ENA_PIN
+    #define SPINDLE_LASER_ENA_PIN              PB6
+  #endif
+#else
+  #ifndef FAN1_PIN
+    #define FAN1_PIN                          PB6   // Fan1
+  #endif
+  #ifndef FAN2_PIN
+    #define FAN2_PIN                          PB5   // Fan2
+  #endif
+#endif // EITHER(SPINDLE_FEATURE, LASER_FEATURE)
 //
 // Software SPI pins for TMC2130 stepper drivers
 //


### PR DESCRIPTION
…le/laser control depending on SPINDLE_FEATURE and/or LASER_FEATURE

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--
Proposed change is for BTT SKR board only.
This change will allow to easily reuse the PB6 pin (normally FAN1 PIN in 3D printer config) to control the the CNC spindle using PWM signal. 
Also, PB5 pin will be reused as SPINDLE_LASER_ENA_PIN.
Both changes will take place in case SPNDLE_FEATURE or LASER_FEATURE are defined in Configuration_adv.h
All three FAN pins are labeled FAN/CNC on SKR 2 official user manual, however it took a lot of research how to use them from Marlin.
-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
