### PR TITLE
Add more serial tests to pins_LONGER3D_LKx_PRO.h 

### DIFF
--- a/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
+++ b/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
@@ -38,7 +38,7 @@
 #if SERIAL_PORT == 2 || SERIAL_PORT_2 == 2 || SERIAL_PORT_3 == 2 || LCD_SERIAL_PORT == 2
   #warning "Serial 2 has no connector. Hardware changes may be required to use it."
 #endif
-#if SERIAL_PORT == 3 || SERIAL_PORT_2 == 3 || SERIAl_PORT_3 == 3 || LCD_SERIAL_PORT == 3
+#if SERIAL_PORT == 3 || SERIAL_PORT_2 == 3 || SERIAL_PORT_3 == 3 || LCD_SERIAL_PORT == 3
   #define CHANGE_Y_LIMIT_PINS
   #warning "Serial 3 is originally reserved to Y limit switches. Hardware changes are required to use it."
 #endif

--- a/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
+++ b/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
@@ -32,13 +32,13 @@
   #error "Longer3D LGT KIT V1.0 board only supports one hotend / E-stepper. Comment out this line to continue."
 #endif
 
-#if SERIAL_PORT == 1 || SERIAL_PORT_2 == 1
+#if SERIAL_PORT == 1 || SERIAL_PORT_2 == 1 || SERIAL_PORT_3 == 1
   #warning "Serial 1 is originally reserved to DGUS LCD."
 #endif
-#if SERIAL_PORT == 2 || SERIAL_PORT_2 == 2
+#if SERIAL_PORT == 2 || SERIAL_PORT_2 == 2 || SERIAL_PORT_3 == 2 || LCD_SERIAL_PORT == 2
   #warning "Serial 2 has no connector. Hardware changes may be required to use it."
 #endif
-#if SERIAL_PORT == 3 || SERIAL_PORT_2 == 3
+#if SERIAL_PORT == 3 || SERIAL_PORT_2 == 3 || SERIAl_PORT_3 == 3 || LCD_SERIAL_PORT == 3
   #define CHANGE_Y_LIMIT_PINS
   #warning "Serial 3 is originally reserved to Y limit switches. Hardware changes are required to use it."
 #endif


### PR DESCRIPTION
### Description

The LONGER3D_LKx_PRO only has some serial ports restrictions.
At present it only checks for issues with SERIAL_PORT and SERIAL_PORT_1
I extended the checks to also check SERIAL_PORT_2 and LCD_SERIAL_PORT

### Requirements

#define MOTHERBOARD BOARD_LONGER3D_LKx_PRO

### Benefits

Less confused users

### Configurations

https://github.com/MarlinFirmware/Marlin/files/7650786/Marlin.zip

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/23255