### PR TITLE
fix LCD_BED_LEVELING with SLIM_LCD_MENUS

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -345,7 +345,7 @@ void _lcd_draw_homing() {
   }
 }
 
-#if HAS_LEVELING && DISABLED(SLIM_LCD_MENUS)
+#if ENABLED(LCD_BED_LEVELING) || (HAS_LEVELING && DISABLED(SLIM_LCD_MENUS))
   void _lcd_toggle_bed_leveling() { set_bed_leveling_enabled(!planner.leveling_active); }
 #endif
 


### PR DESCRIPTION
### Description

If you enable LCD_BED_LEVELING and SLIM_LCD_MENUS Marlin fails to compile with this error
```
Linking .pio/build/mega2560/firmware.elf
/tmp/ccZZC8zD.ltrans0.ltrans.o: In function `menu_temperature()':
<artificial>:(.text+0x5b64): undefined reference to `_lcd_toggle_bed_leveling()'
<artificial>:(.text+0x5b66): undefined reference to `_lcd_toggle_bed_leveling()'
<artificial>:(.text+0x5b6c): undefined reference to `_lcd_toggle_bed_leveling()'
```
LCD_BED_LEVELING looks to be a an override to always have this menu regardless of if SLIM_LCD_MENUS is enabled or not
But _lcd_toggle_bed_leveling() is not declared when LCD_BED_LEVELING and SLIM_LCD_MENUS are enabled.

Updated declaration test so that it is define on these conditions also 

### Requirements

define BLTOUCH
#define AUTO_BED_LEVELING_BILINEAR
#define LCD_BED_LEVELING
#define Z_SAFE_HOMING
#define SLIM_LCD_MENUS
#define CR10_STOCKDISPLAY

### Benefits

Compiles as expected

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/7708232/Configuration.zip)

### Related Issues
Issue raised by Kolentiv in Marlin Discord Support