### PR TITLE
Fix UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in pos…

### DIFF
--- a/buildroot/share/PlatformIO/scripts/signature.py
+++ b/buildroot/share/PlatformIO/scripts/signature.py
@@ -12,7 +12,7 @@ import os,subprocess,re,json,hashlib
 # headers.
 #
 def extract_defines(filepath):
-	f = open(filepath).read().split("\n")
+	f = open(filepath, encoding="utf8").read().split("\n")
 	a = []
 	for line in f:
 		sline = line.strip(" \t\n\r")


### PR DESCRIPTION
Cannot Build on vscode. 
UnicodeDecodeError: 'charmap' codec can't decode byte 0x90 in position 79940

SInce this PR : #21321