### PR TITLE
Creality 4.2.3

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -358,6 +358,7 @@
 #define BOARD_ZONESTAR_ZM3E4          4058  // Zonestar ZM3E4 V1 (STM32F103VCT6)
 #define BOARD_ZONESTAR_ZM3E4V2        4059  // Zonestar ZM3E4 V2 (STM32F103VCT6)
 #define BOARD_ERYONE_ERY32_MINI       4060  // Eryone Ery32 mini (STM32F103VET6)
+#define BOARD_CREALITY_V423           4061  // Creality v4.2.3 (STM32F103RE)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -338,27 +338,27 @@
 #define BOARD_CHITU3D_V6              4038  // Chitu3D TronXY X5SA V6 Board
 #define BOARD_CHITU3D_V9              4039  // Chitu3D TronXY X5SA V9 Board
 #define BOARD_CREALITY_V4             4040  // Creality v4.x (STM32F103RE)
-#define BOARD_CREALITY_V427           4041  // Creality v4.2.7 (STM32F103RE)
-#define BOARD_CREALITY_V4210          4042  // Creality v4.2.10 (STM32F103RE) as found in the CR-30
-#define BOARD_CREALITY_V431           4043  // Creality v4.3.1 (STM32F103RE)
-#define BOARD_CREALITY_V431_A         4044  // Creality v4.3.1a (STM32F103RE)
-#define BOARD_CREALITY_V431_B         4045  // Creality v4.3.1b (STM32F103RE)
-#define BOARD_CREALITY_V431_C         4046  // Creality v4.3.1c (STM32F103RE)
-#define BOARD_CREALITY_V431_D         4047  // Creality v4.3.1d (STM32F103RE)
-#define BOARD_CREALITY_V452           4048  // Creality v4.5.2 (STM32F103RE)
-#define BOARD_CREALITY_V453           4049  // Creality v4.5.3 (STM32F103RE)
-#define BOARD_CREALITY_V24S1          4050  // Creality v2.4.S1 (STM32F103RE) v101 as found in the Ender 7
-#define BOARD_TRIGORILLA_PRO          4051  // Trigorilla Pro (STM32F103ZET6)
-#define BOARD_FLY_MINI                4052  // FLYmaker FLY MINI (STM32F103RCT6)
-#define BOARD_FLSUN_HISPEED           4053  // FLSUN HiSpeedV1 (STM32F103VET6)
-#define BOARD_BEAST                   4054  // STM32F103RET6 Libmaple-based controller
-#define BOARD_MINGDA_MPX_ARM_MINI     4055  // STM32F103ZET6 Mingda MD-16
-#define BOARD_GTM32_PRO_VD            4056  // STM32F103VET6 controller
-#define BOARD_ZONESTAR_ZM3E2          4057  // Zonestar ZM3E2    (STM32F103RCT6)
-#define BOARD_ZONESTAR_ZM3E4          4058  // Zonestar ZM3E4 V1 (STM32F103VCT6)
-#define BOARD_ZONESTAR_ZM3E4V2        4059  // Zonestar ZM3E4 V2 (STM32F103VCT6)
-#define BOARD_ERYONE_ERY32_MINI       4060  // Eryone Ery32 mini (STM32F103VET6)
-#define BOARD_CREALITY_V423           4061  // Creality v4.2.3 (STM32F103RE)
+#define BOARD_CREALITY_V423           4041  // Creality v4.2.3 (STM32F103RE)
+#define BOARD_CREALITY_V427           4042  // Creality v4.2.7 (STM32F103RE)
+#define BOARD_CREALITY_V4210          4043  // Creality v4.2.10 (STM32F103RE) as found in the CR-30
+#define BOARD_CREALITY_V431           4044  // Creality v4.3.1 (STM32F103RE)
+#define BOARD_CREALITY_V431_A         4045  // Creality v4.3.1a (STM32F103RE)
+#define BOARD_CREALITY_V431_B         4046  // Creality v4.3.1b (STM32F103RE)
+#define BOARD_CREALITY_V431_C         4047  // Creality v4.3.1c (STM32F103RE)
+#define BOARD_CREALITY_V431_D         4048  // Creality v4.3.1d (STM32F103RE)
+#define BOARD_CREALITY_V452           4049  // Creality v4.5.2 (STM32F103RE)
+#define BOARD_CREALITY_V453           4050  // Creality v4.5.3 (STM32F103RE)
+#define BOARD_CREALITY_V24S1          4051  // Creality v2.4.S1 (STM32F103RE) v101 as found in the Ender 7
+#define BOARD_TRIGORILLA_PRO          4052  // Trigorilla Pro (STM32F103ZET6)
+#define BOARD_FLY_MINI                4053  // FLYmaker FLY MINI (STM32F103RCT6)
+#define BOARD_FLSUN_HISPEED           4054  // FLSUN HiSpeedV1 (STM32F103VET6)
+#define BOARD_BEAST                   4055  // STM32F103RET6 Libmaple-based controller
+#define BOARD_MINGDA_MPX_ARM_MINI     4056  // STM32F103ZET6 Mingda MD-16
+#define BOARD_GTM32_PRO_VD            4057  // STM32F103VET6 controller
+#define BOARD_ZONESTAR_ZM3E2          4058  // Zonestar ZM3E2    (STM32F103RCT6)
+#define BOARD_ZONESTAR_ZM3E4          4059  // Zonestar ZM3E4 V1 (STM32F103VCT6)
+#define BOARD_ZONESTAR_ZM3E4V2        4060  // Zonestar ZM3E4 V2 (STM32F103VCT6)
+#define BOARD_ERYONE_ERY32_MINI       4061  // Eryone Ery32 mini (STM32F103VET6)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -557,6 +557,8 @@
   #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V4210)
   #include "stm32f1/pins_CREALITY_V4210.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
+#elif MB(CREALITY_V423)
+  #include "stm32f1/pins_CREALITY_V423.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V427)
   #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V431, CREALITY_V431_A, CREALITY_V431_B, CREALITY_V431_C, CREALITY_V431_D)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -558,7 +558,7 @@
 #elif MB(CREALITY_V4210)
   #include "stm32f1/pins_CREALITY_V4210.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V423)
-  #include "stm32f1/pins_CREALITY_V423.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V423.h"       // STM32F1                                env:STM32F103RET6_creality
 #elif MB(CREALITY_V427)
   #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V431, CREALITY_V431_A, CREALITY_V431_B, CREALITY_V431_C, CREALITY_V431_D)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -167,9 +167,7 @@
     #define LCD_PINS_D4                     PB13
 
     #define BTN_ENC                         PB2
-    #ifndef BTN_EN1
-      #define BTN_EN1                       PB10
-    #endif
+    #define BTN_EN1.                        PB10
     #define BTN_EN2                         PB14
 
     #ifndef HAS_PIN_27_BOARD
@@ -184,9 +182,7 @@
     #define LCD_PINS_D4                     PA5
 
     #define BTN_ENC                         PC5
-    #ifndef BTN_EN1
-      #define BTN_EN1                       PB10
-    #endif
+    #define BTN_EN1                         PB10
     #define BTN_EN2                         PA6
 
   #else
@@ -197,9 +193,7 @@
 
   // RET6 DWIN ENCODER LCD
   #define BTN_ENC                           PB14
-  #ifndef BTN_EN1
-    #define BTN_EN1                         PB15
-  #endif
+  #define BTN_EN1                           PB15
   #define BTN_EN2                           PB12
 
   //#define LCD_LED_PIN                     PB2
@@ -211,9 +205,7 @@
 
   // VET6 DWIN ENCODER LCD
   #define BTN_ENC                           PA6
-  #ifndef BTN_EN1
-    #define BTN_EN1                         PA7
-  #endif
+  #define BTN_EN1                           PA7
   #define BTN_EN2                           PA4
 
   #define BEEPER_PIN                        PA5

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -167,7 +167,9 @@
     #define LCD_PINS_D4                     PB13
 
     #define BTN_ENC                         PB2
-    #define BTN_EN1                         PB10
+    #ifndef BTN_EN1
+      #define BTN_EN1                       PB10
+    #endif
     #define BTN_EN2                         PB14
 
     #ifndef HAS_PIN_27_BOARD
@@ -182,7 +184,9 @@
     #define LCD_PINS_D4                     PA5
 
     #define BTN_ENC                         PC5
-    #define BTN_EN1                         PB10
+    #ifndef BTN_EN1
+      #define BTN_EN1                       PB10
+    #endif
     #define BTN_EN2                         PA6
 
   #else
@@ -193,7 +197,9 @@
 
   // RET6 DWIN ENCODER LCD
   #define BTN_ENC                           PB14
-  #define BTN_EN1                           PB15
+  #ifndef BTN_EN1
+    #define BTN_EN1                         PB15
+  #endif
   #define BTN_EN2                           PB12
 
   //#define LCD_LED_PIN                     PB2
@@ -205,7 +211,9 @@
 
   // VET6 DWIN ENCODER LCD
   #define BTN_ENC                           PA6
-  #define BTN_EN1                           PA7
+  #ifndef BTN_EN1
+    #define BTN_EN1                         PA7
+  #endif
   #define BTN_EN2                           PA4
 
   #define BEEPER_PIN                        PA5

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -167,7 +167,7 @@
     #define LCD_PINS_D4                     PB13
 
     #define BTN_ENC                         PB2
-    #define BTN_EN1.                        PB10
+    #define BTN_EN1                         PB10
     #define BTN_EN2                         PB14
 
     #ifndef HAS_PIN_27_BOARD

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
@@ -32,6 +32,10 @@
 // Heaters
 //
 #define HEATER_BED_PIN                      PB10  // HOT BED
-#define BTN_EN1                             PA2   // Rotary Encoder
 
 #include "pins_CREALITY_V4.h"
+
+#if BTN_EN1 == PB10
+  #undef BTN_EN1
+  #define BTN_EN1                           PA2   // Rotary Encoder
+#endif

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2021 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -32,6 +32,6 @@
 // Heaters
 //
 #define HEATER_BED_PIN                      PB10  // HOT BED
-#define BTN_EN1                             PA2  // Rotary Encoder
+#define BTN_EN1                             PA2   // Rotary Encoder
 
 #include "pins_CREALITY_V4.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
@@ -35,6 +35,9 @@
 
 #include "pins_CREALITY_V4.h"
 
+//
+// Encoder
+//
 #if BTN_EN1 == PB10
   #undef BTN_EN1
   #define BTN_EN1                           PA2   // Rotary Encoder

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
@@ -32,5 +32,6 @@
 // Heaters
 //
 #define HEATER_BED_PIN                      PB10  // HOT BED
+#define BTN_ENC1                            PB2  // Rotary Encoder
 
 #include "pins_CREALITY_V4.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
@@ -32,6 +32,6 @@
 // Heaters
 //
 #define HEATER_BED_PIN                      PB10  // HOT BED
-#define BTN_ENC1                            PB2  // Rotary Encoder
+#define BTN_EN1                             PA2  // Rotary Encoder
 
 #include "pins_CREALITY_V4.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V423.h
@@ -1,0 +1,36 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * CREALITY v4.2.3 (STM32F103) board pin assignments
+ */
+
+#define BOARD_INFO_NAME      "Creality v4.2.3"
+#define DEFAULT_MACHINE_NAME "Creality3D"
+
+//
+// Heaters
+//
+#define HEATER_BED_PIN                      PB10  // HOT BED
+
+#include "pins_CREALITY_V4.h"


### PR DESCRIPTION
Adds a definition for the creality 4.2.3 board that was recently released with the Ender 2 Pro. 

Additional information in this pull request: https://github.com/MarlinFirmware/Configurations/pull/633#issuecomment-995424611

Ender2-Pro is fairly similar to the Ender 7 https://github.com/MarlinFirmware/Marlin/pull/23010
