### PR TITLE
Include Power State Report in Endstops report M119

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -335,6 +335,7 @@
 #define STR_Z_PROBE                         "z_probe"
 #define STR_PROBE_EN                        "probe_en"
 #define STR_FILAMENT                        "filament"
+#define STR_POWER_LOSS                      "power_loss"
 
 // General axis names
 #define STR_X "X"

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -592,7 +592,7 @@ void _O2 Endstops::report_states() {
   TERN_(JOYSTICK_DEBUG, joystick.report());
 
   #if ENABLED(DEBUG_POWER_LOSS_RECOVERY) && PIN_EXISTS(POWER_LOSS)
-    SERIAL_ECHOLNPGM(READ(POWER_LOSS_PIN) == POWER_LOSS_STATE ? "Power State : Power Outage." : "Power State : Power OK.");
+    print_es_state(READ(POWER_LOSS_PIN) == POWER_LOSS_STATE , F(STR_POWER_LOSS));
   #endif
 
 } // Endstops::report_states

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -591,6 +591,10 @@ void _O2 Endstops::report_states() {
   TERN_(BLTOUCH, bltouch._reset_SW_mode());
   TERN_(JOYSTICK_DEBUG, joystick.report());
 
+  #if ENABLED(DEBUG_POWER_LOSS_RECOVERY) && PIN_EXISTS(POWER_LOSS)
+    SERIAL_ECHOLNPGM(READ(POWER_LOSS_PIN) == POWER_LOSS_STATE ? "Power State : Power Outage." : "Power State : Power OK.");
+  #endif
+
 } // Endstops::report_states
 
 // The following routines are called from an ISR context. It could be the temperature ISR, the


### PR DESCRIPTION
Wiring a printer is never easy. 

We use M119 to check our endstops wiring,  including probe and joystick. 
But we cannot find a way to check POWER_LOSS_PIN. 

Therefore, this PR makes M119 also report the Power state (Power Loss Pin compared to Power Loss State). 