### PR TITLE
Throw warning when IGNORE_THERMOCOUPLE_ERRORS is enabled

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -54,6 +54,9 @@
 #if ANY_THERMISTOR_IS(998) || ANY_THERMISTOR_IS(999)
   #warning "Warning! Don't use dummy thermistors (998/999) for final build!"
 #endif
+#if HAS_MAX_TC && ENABLED(IGNORE_THERMOCOUPLE_ERRORS)
+  #warning "Safety Alert! Disable IGNORE_THERMOCOUPLE_ERRORS for the final build!"
+#endif
 
 #if NONE(HAS_RESUME_CONTINUE, HOST_PROMPT_SUPPORT)
   #warning "Your Configuration provides no method to acquire user feedback!"

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -54,9 +54,6 @@
 #if ANY_THERMISTOR_IS(998) || ANY_THERMISTOR_IS(999)
   #warning "Warning! Don't use dummy thermistors (998/999) for final build!"
 #endif
-#if HAS_MAX_TC && ENABLED(IGNORE_THERMOCOUPLE_ERRORS)
-  #warning "Safety Alert! Disable IGNORE_THERMOCOUPLE_ERRORS for the final build!"
-#endif
 
 #if NONE(HAS_RESUME_CONTINUE, HOST_PROMPT_SUPPORT)
   #warning "Your Configuration provides no method to acquire user feedback!"

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -226,6 +226,10 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 //
 #if HAS_MAX_TC
 
+  #if ENABLED(IGNORE_THERMOCOUPLE_ERRORS)
+    #warning "Safety Alert! Disable IGNORE_THERMOCOUPLE_ERRORS for the final build!"
+  #endif
+
   #if HAS_MAXTC_SW_SPI
     // Initialize SoftSPI for non-lib Software SPI; Libraries take care of it themselves.
     template<uint8_t MisoPin, uint8_t MosiPin, uint8_t SckPin>

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -226,10 +226,6 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 //
 #if HAS_MAX_TC
 
-  #if ENABLED(IGNORE_THERMOCOUPLE_ERRORS)
-    #warning "Safety Alert! Disable IGNORE_THERMOCOUPLE_ERRORS for the final build!"
-  #endif
-
   #if HAS_MAXTC_SW_SPI
     // Initialize SoftSPI for non-lib Software SPI; Libraries take care of it themselves.
     template<uint8_t MisoPin, uint8_t MosiPin, uint8_t SckPin>
@@ -1357,6 +1353,8 @@ void Temperature::manage_heater() {
       if (degRedundant() > TEMP_SENSOR_REDUNDANT_MAX_TC_TMAX - 1.0) max_temp_error(H_REDUNDANT);
       if (degRedundant() < TEMP_SENSOR_REDUNDANT_MAX_TC_TMIN + .01) min_temp_error(H_REDUNDANT);
     #endif
+  #else
+    #warning "Safety Alert! Disable IGNORE_THERMOCOUPLE_ERRORS for the final build!"
   #endif
 
   millis_t ms = millis();


### PR DESCRIPTION
### Description

Enabling IGNORE_THERMOCOUPLE_ERRORS for testing and then forgetting to disable it, is a potential fire risk. There should be a compiler warning for it.

### Requirements

-

### Benefits

Safety improvement.

### Configurations

Use of thermocouple sensors and defining IGNORE_THERMOCOUPLE_ERRORS.

### Related Issues

-
