### PR TITLE
Allow Neopixel to drive more than 128 leds

### DIFF
--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -35,7 +35,7 @@
 #endif
 
 Marlin_NeoPixel neo;
-int16_t Marlin_NeoPixel::neoindex;
+pixel_index_t Marlin_NeoPixel::neoindex;
 
 Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIXEL_TYPE + NEO_KHZ800);
 #if CONJOINED_NEOPIXEL
@@ -116,7 +116,7 @@ void Marlin_NeoPixel::init() {
 
   Marlin_NeoPixel2 neo2;
 
-  int16_t Marlin_NeoPixel2::neoindex;
+  pixel_index_t Marlin_NeoPixel2::neoindex;
   Adafruit_NeoPixel Marlin_NeoPixel2::adaneo(NEOPIXEL2_PIXELS, NEOPIXEL2_PIN, NEOPIXEL2_TYPE);
 
   void Marlin_NeoPixel2::set_color(const uint32_t color) {

--- a/Marlin/src/feature/leds/neopixel.cpp
+++ b/Marlin/src/feature/leds/neopixel.cpp
@@ -35,7 +35,7 @@
 #endif
 
 Marlin_NeoPixel neo;
-int8_t Marlin_NeoPixel::neoindex;
+int16_t Marlin_NeoPixel::neoindex;
 
 Adafruit_NeoPixel Marlin_NeoPixel::adaneo1(NEOPIXEL_PIXELS, NEOPIXEL_PIN, NEOPIXEL_TYPE + NEO_KHZ800);
 #if CONJOINED_NEOPIXEL
@@ -116,7 +116,7 @@ void Marlin_NeoPixel::init() {
 
   Marlin_NeoPixel2 neo2;
 
-  int8_t Marlin_NeoPixel2::neoindex;
+  int16_t Marlin_NeoPixel2::neoindex;
   Adafruit_NeoPixel Marlin_NeoPixel2::adaneo(NEOPIXEL2_PIXELS, NEOPIXEL2_PIN, NEOPIXEL2_TYPE);
 
   void Marlin_NeoPixel2::set_color(const uint32_t color) {

--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -74,7 +74,7 @@ private:
   #endif
 
 public:
-  static int8_t neoindex;
+  static int16_t neoindex;
 
   static void init();
   static void set_color_startup(const uint32_t c);
@@ -150,7 +150,7 @@ extern Marlin_NeoPixel neo;
     static Adafruit_NeoPixel adaneo;
 
   public:
-    static int8_t neoindex;
+    static int16_t neoindex;
 
     static void init();
     static void set_color_startup(const uint32_t c);

--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -25,6 +25,8 @@
  * NeoPixel support
  */
 
+#define MAX_NEOPIXELS 127
+
 #ifndef _NEOPIXEL_INCLUDE_
   #error "Always include 'leds.h' and not 'neopixel.h' directly."
 #endif
@@ -63,7 +65,13 @@
 #endif
 
 // ------------------------
-// Function prototypes
+// Types
+// ------------------------
+
+typedef IF<(MAX_NEOPIXELS > 127), int16_t, int8_t>::type pixel_index_t;
+
+// ------------------------
+// Classes
 // ------------------------
 
 class Marlin_NeoPixel {
@@ -74,7 +82,7 @@ private:
   #endif
 
 public:
-  static int16_t neoindex;
+  static pixel_index_t neoindex;
 
   static void init();
   static void set_color_startup(const uint32_t c);
@@ -150,7 +158,7 @@ extern Marlin_NeoPixel neo;
     static Adafruit_NeoPixel adaneo;
 
   public:
-    static int16_t neoindex;
+    static pixel_index_t neoindex;
 
     static void init();
     static void set_color_startup(const uint32_t c);

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -54,7 +54,7 @@
  */
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-    const int8_t index = parser.intval('I', -1);
+    const int16_t index = parser.intval('I', -1);
     #if ENABLED(NEOPIXEL2_SEPARATE)
       int8_t brightness = neo.brightness(), unit = parser.intval('S', -1);
       switch (unit) {

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -54,7 +54,7 @@
  */
 void GcodeSuite::M150() {
   #if ENABLED(NEOPIXEL_LED)
-    const int16_t index = parser.intval('I', -1);
+    const pixel_index_t index = parser.intval('I', -1);
     #if ENABLED(NEOPIXEL2_SEPARATE)
       int8_t brightness = neo.brightness(), unit = parser.intval('S', -1);
       switch (unit) {


### PR DESCRIPTION
### Description

Problems arises using a led strip with more than 128 leds due to _int8_t_ definition for led index.
The wrap around of _int8_t_ turns indexes>128 to negative values.

### Requirements

N/A

### Benefits

This PR adresses the problem switching to a _int16_t_ and allowing a bigger led index.

### Configurations

Simply enable
`#define NEOPIXEL_PIXELS xxx`
with _xxx_ bigger than 128, and
`#define NEOPIXEL_IS_SEQUENTIAL`

### Related Issues

N/A
