### PR TITLE
Set FAST_PWM_FAN default frequency to 1KHz

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2674,7 +2674,7 @@
   #ifdef __AVR__
     #define FAST_PWM_FAN_FREQUENCY ((F_CPU) / (2 * 255 * 1))
   #else
-    #define FAST_PWM_FAN_FREQUENCY 31400
+    #define FAST_PWM_FAN_FREQUENCY 1000U
   #endif
 #endif
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2668,10 +2668,14 @@
 #endif
 
 /**
- * FAST PWM FAN Settings
+ * FAST PWM FAN default PWM frequency
  */
 #if ENABLED(FAST_PWM_FAN) && !defined(FAST_PWM_FAN_FREQUENCY)
-  #define FAST_PWM_FAN_FREQUENCY 1000U // Fan frequency default
+  #if F_CPU >= (31400 * 2 * 255 * 1)
+    #define FAST_PWM_FAN_FREQUENCY 31400
+  #else
+    #define FAST_PWM_FAN_FREQUENCY ((F_CPU) / (2 * 255 * 1))
+  #endif
 #endif
 
 /**

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2670,11 +2670,11 @@
 /**
  * FAST PWM FAN default PWM frequency
  */
-#if ENABLED(FAST_PWM_FAN) && !defined(FAST_PWM_FAN_FREQUENCY)
-  #if F_CPU >= (31400 * 2 * 255 * 1)
-    #define FAST_PWM_FAN_FREQUENCY 31400
-  #else
+#if !defined(FAST_PWM_FAN_FREQUENCY) && ENABLED(FAST_PWM_FAN)
+  #if defined(__AVR__) && F_CPU < (31400 * 2 * 255 * 1)
     #define FAST_PWM_FAN_FREQUENCY ((F_CPU) / (2 * 255 * 1))
+  #else
+    #define FAST_PWM_FAN_FREQUENCY 31400
   #endif
 #endif
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2671,7 +2671,7 @@
  * FAST PWM FAN Settings
  */
 #if ENABLED(FAST_PWM_FAN) && !defined(FAST_PWM_FAN_FREQUENCY)
-  #define FAST_PWM_FAN_FREQUENCY ((F_CPU) / (2 * 255 * 1)) // Fan frequency default
+  #define FAST_PWM_FAN_FREQUENCY 1000U // Fan frequency default
 #endif
 
 /**

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2671,7 +2671,7 @@
  * FAST PWM FAN default PWM frequency
  */
 #if !defined(FAST_PWM_FAN_FREQUENCY) && ENABLED(FAST_PWM_FAN)
-  #if defined(__AVR__) && F_CPU < (31400 * 2 * 255 * 1)
+  #ifdef __AVR__
     #define FAST_PWM_FAN_FREQUENCY ((F_CPU) / (2 * 255 * 1))
   #else
     #define FAST_PWM_FAN_FREQUENCY 31400


### PR DESCRIPTION
### Description

`FAST_PWM_FAN_FREQUENCY` defaults to a potentially damaging value when driving fans. If a user configures the `FAST_PWM_FAN` option and negates to set a reasonable frequency for the target board it may result in overheating and damage to the output MOSFET or Transistor. This PR sets the `FAST_PWM_FAN_FREQUENCY` to `31400` in the event that no define set it to a desirable value for the target board.  

### Requirements

Any board 

### Benefits

Helps avoid unintentional irreversible damage.

### Configurations

```cpp
#define FAST_PWM_FAN
```

### Related Issues

#20638
#23319 
