### PR TITLE
correct Z_STOP_PIN in pins_CHITU3D_V5.h

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
+++ b/Marlin/src/pins/stm32f1/pins_CHITU3D_V5.h
@@ -23,6 +23,6 @@
 
 #define BOARD_INFO_NAME "Chitu3D V5"
 
-#define Z_STOP_PIN                          PG9
+#define Z_STOP_PIN                          PA14
 
 #include "pins_CHITU3D_common.h"


### PR DESCRIPTION
### Description

Z_STOP_PIN is incorrect in pins_CHITU3D_V5.h
Was correct before https://github.com/MarlinFirmware/Marlin/pull/22401
If you examine https://github.com/MarlinFirmware/Marlin/commit/50ada44e7e7e42dd8b04668242a63071300aec27 you can see that Z_STOP_PIN was mistakenly switched to PG9 for the V5 board.

### Requirements

BOARD_CHITU3D_V5

### Benefits

Works as expected 

### Related Issues
Noticed by Eliminateur in Discord and noted in this comment https://github.com/MarlinFirmware/Marlin/pull/22401#issuecomment-999170080