### PR TITLE
Follow Up FAST_PWM_FAN_FREQUENCY. Add a warning.

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2841,6 +2841,7 @@
 //#define NUM_M106_FANS 1
 
 // Increase the FAN PWM frequency. Removes the PWM noise but increases heating in the FET/Arduino
+// Please define FAST_PWM_FAN_FREQUENCY according to your hardware.
 //#define FAST_PWM_FAN
 
 // Use software PWM to drive the fan, as for the heaters. This uses a very low frequency

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2840,10 +2840,6 @@
 // :[1,2,3,4,5,6,7,8]
 //#define NUM_M106_FANS 1
 
-// Increase the FAN PWM frequency. Removes the PWM noise but increases heating in the FET/Arduino
-// Please define FAST_PWM_FAN_FREQUENCY according to your hardware.
-//#define FAST_PWM_FAN
-
 // Use software PWM to drive the fan, as for the heaters. This uses a very low frequency
 // which is not as annoying as with the hardware PWM. On the other hand, if this frequency
 // is too low, you should also increment SOFT_PWM_SCALE.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -557,10 +557,14 @@
  *
  * FAST_PWM_FAN_FREQUENCY [undefined by default]
  *   Set this to your desired frequency.
- *   If left undefined this defaults to F = F_CPU/(2*255*1)
- *   i.e., F = 31.4kHz on 16MHz microcontrollers or F = 39.2kHz on 20MHz microcontrollers.
- *   These defaults are the same as with the old FAST_PWM_FAN implementation - no migration is required
+ *   For AVR, if left undefined this defaults to F = F_CPU/(2*255*1)
+ *            i.e., F = 31.4kHz on 16MHz microcontrollers or F = 39.2kHz on 20MHz microcontrollers.
+ *   For non AVR, if left undefined this defaults to F = 1Khz.
+ *   This F value is only to protect the hardware from an absence of configuration
+ *   and not to complete it when users are not aware that the frequency must be specifically set to support the target board.
+ *
  *   NOTE: Setting very low frequencies (< 10 Hz) may result in unexpected timer behavior.
+ *         Setting very high frequencies can damage your hardware.
  *
  * USE_OCR2A_AS_TOP [undefined by default]
  *   Boards that use TIMER2 for PWM have limitations resulting in only a few possible frequencies on TIMER2:

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -549,13 +549,12 @@
 //#define FAN_MAX_PWM 128
 
 /**
- * FAST PWM FAN Settings
+ * Fan Fast PWM
  *
- * Use to change the FAST FAN PWM frequency (if enabled in Configuration.h)
- * Combinations of PWM Modes, prescale values and TOP resolutions are used internally to produce a
- * frequency as close as possible to the desired frequency.
+ * Combinations of PWM Modes, prescale values and TOP resolutions are used internally
+ * to produce a frequency as close as possible to the desired frequency.
  *
- * FAST_PWM_FAN_FREQUENCY [undefined by default]
+ * FAST_PWM_FAN_FREQUENCY
  *   Set this to your desired frequency.
  *   For AVR, if left undefined this defaults to F = F_CPU/(2*255*1)
  *            i.e., F = 31.4kHz on 16MHz microcontrollers or F = 39.2kHz on 20MHz microcontrollers.
@@ -574,9 +573,17 @@
  *   PWM on pin OC2A. Only use this option if you don't need PWM on 0C2A. (Check your schematic.)
  *   USE_OCR2A_AS_TOP sacrifices duty cycle control resolution to achieve this broader range of frequencies.
  */
+//#define FAST_PWM_FAN    // Increase the fan PWM frequency. Removes the PWM noise but increases heating in the FET/Arduino
 #if ENABLED(FAST_PWM_FAN)
-  //#define FAST_PWM_FAN_FREQUENCY 31400
+  //#define FAST_PWM_FAN_FREQUENCY 31400  // Define here to override the defaults below
   //#define USE_OCR2A_AS_TOP
+  #ifndef FAST_PWM_FAN_FREQUENCY
+    #ifdef __AVR__
+      #define FAST_PWM_FAN_FREQUENCY ((F_CPU) / (2 * 255 * 1))
+    #else
+      #define FAST_PWM_FAN_FREQUENCY 1000U
+    #endif
+  #endif
 #endif
 
 /**

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2668,18 +2668,6 @@
 #endif
 
 /**
- * FAST PWM FAN default PWM frequency
- */
-#if !defined(FAST_PWM_FAN_FREQUENCY) && ENABLED(FAST_PWM_FAN)
-  #ifdef __AVR__
-    #define FAST_PWM_FAN_FREQUENCY ((F_CPU) / (2 * 255 * 1))
-  #else
-    #define FAST_PWM_FAN_FREQUENCY 1000U
-  #endif
-  #define AUTO_ASSIGNED_FAST_PWM_FAN_FREQUENCY
-#endif
-
-/**
  * Controller Fan Settings
  */
 #if PIN_EXISTS(CONTROLLER_FAN)

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -2676,6 +2676,7 @@
   #else
     #define FAST_PWM_FAN_FREQUENCY 1000U
   #endif
+  #define AUTO_ASSIGNED_FAST_PWM_FAN_FREQUENCY
 #endif
 
 /**

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -528,6 +528,10 @@
   #warning "Auto-assigned CHAMBER_FAN_INDEX to the first free FAN pin."
 #endif
 
+#if ENABLED(AUTO_ASSIGNED_FAST_PWM_FAN_FREQUENCY)
+  #warning "Auto-assigned FAST_PWM_FAN_FREQUENCY, please specify according to your hardware."
+#endif
+
 #if IS_LEGACY_TFT
   #warning "Don't forget to update your TFT settings in Configuration.h."
 #endif

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -528,10 +528,6 @@
   #warning "Auto-assigned CHAMBER_FAN_INDEX to the first free FAN pin."
 #endif
 
-#if ENABLED(AUTO_ASSIGNED_FAST_PWM_FAN_FREQUENCY)
-  #warning "Auto-assigned FAST_PWM_FAN_FREQUENCY, please specify according to your hardware."
-#endif
-
 #if IS_LEGACY_TFT
   #warning "Don't forget to update your TFT settings in Configuration.h."
 #endif

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -95,7 +95,11 @@
   #define FAN_MAX_PWM                        255
 #else
   #define FAST_PWM_FAN                            // STM32 Variant allow TIMER2 Hardware PWM
-  #define FAST_PWM_FAN_FREQUENCY           31400  // This frequency allow a good range, fan starts at 3%, half noise at 50%
+  #if FAST_PWM_FAN_FREQUENCY && FAST_PWM_FAN_FREQUENCY != 31400
+    #warning "FAST_PWM_FAN_FREQUENCY of 31400 is preferred!"
+  #else
+    #define FAST_PWM_FAN_FREQUENCY         31400  // This frequency gives a good range, fan starts at 3%, half noise at 50%
+  #endif
   #define FAN_MIN_PWM                          5
   #define FAN_MAX_PWM                        255
 #endif

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -95,11 +95,6 @@
   #define FAN_MAX_PWM                        255
 #else
   #define FAST_PWM_FAN                            // STM32 Variant allow TIMER2 Hardware PWM
-  #if FAST_PWM_FAN_FREQUENCY && FAST_PWM_FAN_FREQUENCY != 31400
-    #warning "FAST_PWM_FAN_FREQUENCY of 31400 is preferred!"
-  #else
-    #define FAST_PWM_FAN_FREQUENCY         31400  // This frequency gives a good range, fan starts at 3%, half noise at 50%
-  #endif
   #define FAN_MIN_PWM                          5
   #define FAN_MAX_PWM                        255
 #endif


### PR DESCRIPTION
Just add a warning about FAST_PWM_FAN_FREQUENCY. 
Not changing the code. 

To protect users from self-harm. thus not blaming the firmware. 

Check https://github.com/MarlinFirmware/Marlin/issues/23319# for detail.