### PR TITLE
Show mm'ss during first hour

### DIFF
--- a/Marlin/src/libs/duration_t.h
+++ b/Marlin/src/libs/duration_t.h
@@ -154,12 +154,17 @@ struct duration_t {
    */
   uint8_t toDigital(char *buffer, bool with_days=false) const {
     uint16_t h = uint16_t(this->hour()),
-             m = uint16_t(this->minute() % 60UL);
+             m = uint16_t(this->minute() % 60UL),
+			 s = uint16_t(this->second() % 60UL);
     if (with_days) {
       uint16_t d = this->day();
       sprintf_P(buffer, PSTR("%hud %02hu:%02hu"), d, h % 24, m);
       return d >= 10 ? 9 : 8;
     }
+    else if (h < 1) {
+      sprintf_P(buffer, PSTR("%02hu:%02hu"), m, s);
+      return 5;
+	}
     else if (h < 100) {
       sprintf_P(buffer, PSTR("%02hu:%02hu"), h, m);
       return 5;

--- a/Marlin/src/libs/duration_t.h
+++ b/Marlin/src/libs/duration_t.h
@@ -149,6 +149,7 @@ struct duration_t {
    *
    * Output examples:
    *  123456789 (strlen)
+   *  12'34
    *  99:59
    *  11d 12:33
    */
@@ -157,20 +158,20 @@ struct duration_t {
                    m = uint16_t(this->minute() % 60UL);
     if (with_days) {
       const uint16_t d = this->day();
-      sprintf_P(buffer, PSTR("%hud %02hu:%02hu"), d, h % 24, m);
+      sprintf_P(buffer, PSTR("%hud %02hu:%02hu"), d, h % 24, m);  // 1d 23:45
       return d >= 10 ? 9 : 8;
     }
     else if (!h) {
       const uint16_t s = uint16_t(this->second() % 60UL);
-      sprintf_P(buffer, PSTR("%02hu:%02hu"), m, s);
+      sprintf_P(buffer, PSTR("%02hu'%02hu"), m, s);     // 12'34
       return 5;
     }
     else if (h < 100) {
-      sprintf_P(buffer, PSTR("%02hu:%02hu"), h, m);
+      sprintf_P(buffer, PSTR("%02hu:%02hu"), h, m);     // 12:34
       return 5;
     }
     else {
-      sprintf_P(buffer, PSTR("%hu:%02hu"), h, m);
+      sprintf_P(buffer, PSTR("%hu:%02hu"), h, m);       // 123:45
       return 6;
     }
   }

--- a/Marlin/src/libs/duration_t.h
+++ b/Marlin/src/libs/duration_t.h
@@ -127,11 +127,11 @@ struct duration_t {
    *  59s
    */
   char* toString(char * const buffer) const {
-    int y = this->year(),
-        d = this->day() % 365,
-        h = this->hour() % 24,
-        m = this->minute() % 60,
-        s = this->second() % 60;
+    const uint16_t y = this->year(),
+                   d = this->day() % 365,
+                   h = this->hour() % 24,
+                   m = this->minute() % 60,
+                   s = this->second() % 60;
 
          if (y) sprintf_P(buffer, PSTR("%iy %id %ih %im %is"), y, d, h, m, s);
     else if (d) sprintf_P(buffer, PSTR("%id %ih %im %is"), d, h, m, s);
@@ -153,18 +153,18 @@ struct duration_t {
    *  11d 12:33
    */
   uint8_t toDigital(char *buffer, bool with_days=false) const {
-    uint16_t h = uint16_t(this->hour()),
-             m = uint16_t(this->minute() % 60UL),
-			 s = uint16_t(this->second() % 60UL);
+    const uint16_t h = uint16_t(this->hour()),
+                   m = uint16_t(this->minute() % 60UL);
     if (with_days) {
-      uint16_t d = this->day();
+      const uint16_t d = this->day();
       sprintf_P(buffer, PSTR("%hud %02hu:%02hu"), d, h % 24, m);
       return d >= 10 ? 9 : 8;
     }
-    else if (h < 1) {
+    else if (!h) {
+      const uint16_t s = uint16_t(this->second() % 60UL);
       sprintf_P(buffer, PSTR("%02hu:%02hu"), m, s);
       return 5;
-	}
+    }
     else if (h < 100) {
       sprintf_P(buffer, PSTR("%02hu:%02hu"), h, m);
       return 5;


### PR DESCRIPTION
PRINTJOB_TIME shows mm:ss during first hour of printing

### Description

PRINTJOB_TIME used to only show hh:mm of the duration of a print.
Now it shows mm:ss during the first hour of a print

### Requirements

none

### Benefits

More detailed information about the duration of a print, for small or fast prints

No changes to the space used on the LCD

