### PR TITLE
Settings: remove extra line in M501 unit report

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3171,12 +3171,13 @@ void MarlinSettings::reset() {
     // Announce current units, in case inches are being displayed
     //
     CONFIG_ECHO_HEADING("Linear Units");
+    CONFIG_ECHO_START();
     #if ENABLED(INCH_MODE_SUPPORT)
-      SERIAL_ECHO_MSG("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
+      SERIAL_ECHO("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
     #else
-      SERIAL_ECHO_MSG("  G21 ;");
+      SERIAL_ECHO("  G21 ;");
     #endif
-    gcode.say_units();
+    gcode.say_units(); // " (in/mm)"
 
     //
     // M149 Temperature units

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -3173,9 +3173,9 @@ void MarlinSettings::reset() {
     CONFIG_ECHO_HEADING("Linear Units");
     CONFIG_ECHO_START();
     #if ENABLED(INCH_MODE_SUPPORT)
-      SERIAL_ECHO("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
+      SERIAL_ECHOPGM("  G2", AS_DIGIT(parser.linear_unit_factor == 1.0), " ;");
     #else
-      SERIAL_ECHO("  G21 ;");
+      SERIAL_ECHOPGM("  G21 ;");
     #endif
     gcode.say_units(); // " (in/mm)"
 


### PR DESCRIPTION
before
```
02:18:29.101 > echo:Hardcoded Default Settings Loaded
02:18:29.103 > echo:Settings Stored (635 bytes; crc 49115)
02:18:29.155 > echo:; Linear Units:
02:18:29.155 > echo:  G21 ;
02:18:29.157 >  (mm)
02:18:29.157 > echo:; Temperature Units:
02:18:29.158 > echo:  M149 C ; Units in Celsius
```
after
```
03:16:23.528 > echo:V86 stored settings retrieved (635 bytes; crc 45204)
03:16:23.529 > Unified Bed Leveling System v1.01 inactive
03:16:23.580 > Mesh loaded from slot 0
03:16:23.580 > Mesh 0 loaded from storage.
03:16:23.581 > echo:; Linear Units:
03:16:23.583 > echo:  G21 ; (mm)
03:16:23.583 > echo:; Temperature Units:
03:16:23.584 > echo:  M149 C ; Units in Celsius
```