### PR TITLE
Fix: Robin Nano v3 MT_DET_#_PINs do not depend on LVGL_UI

### DIFF
--- a/Marlin/src/pins/mega/pins_OVERLORD.h
+++ b/Marlin/src/pins/mega/pins_OVERLORD.h
@@ -49,7 +49,7 @@
   #define Z_MIN_PROBE_PIN                     46  // JP4, Tfeed1
 #endif
 
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+#ifndef FIL_RUNOUT_PIN
   #define FIL_RUNOUT_PIN                      44  // JP3, Tfeed2
 #endif
 

--- a/Marlin/src/pins/pins_postprocess.h
+++ b/Marlin/src/pins/pins_postprocess.h
@@ -546,12 +546,15 @@
   #undef K_MAX_PIN
 #endif
 
-// Filament Sensor first pin alias
 #if HAS_FILAMENT_SENSOR
-  #define FIL_RUNOUT1_PIN FIL_RUNOUT_PIN
+  #define FIL_RUNOUT1_PIN FIL_RUNOUT_PIN  // Filament Sensor first pin alias
 #else
   #undef FIL_RUNOUT_PIN
   #undef FIL_RUNOUT1_PIN
+#endif
+
+#if NUM_RUNOUT_SENSORS < 2
+  #undef FIL_RUNOUT2_PIN
 #endif
 
 #ifndef LCD_PINS_D4

--- a/Marlin/src/pins/ramps/pins_FORMBOT_TREX3.h
+++ b/Marlin/src/pins/ramps/pins_FORMBOT_TREX3.h
@@ -134,7 +134,6 @@
 #define FAN_PIN                                9
 #define FAN1_PIN                              12
 
-#define NUM_RUNOUT_SENSORS                     2
 #define FIL_RUNOUT_PIN                        22
 #define FIL_RUNOUT2_PIN                       21
 

--- a/Marlin/src/pins/sam/pins_RURAMPS4D_11.h
+++ b/Marlin/src/pins/sam/pins_RURAMPS4D_11.h
@@ -121,10 +121,8 @@
   #define Z_MIN_PROBE_PIN                     49
 #endif
 
-#if HAS_FILAMENT_SENSOR
-  #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN             Y_MIN_PIN
-  #endif
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN               Y_MIN_PIN
 #endif
 
 //

--- a/Marlin/src/pins/sam/pins_RURAMPS4D_13.h
+++ b/Marlin/src/pins/sam/pins_RURAMPS4D_13.h
@@ -109,10 +109,8 @@
   #define Z_MIN_PROBE_PIN                     49
 #endif
 
-#if HAS_FILAMENT_SENSOR
-  #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN             Y_MIN_PIN
-  #endif
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN               Y_MIN_PIN
 #endif
 
 //

--- a/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
+++ b/Marlin/src/pins/sanguino/pins_MELZI_CREALITY.h
@@ -68,7 +68,7 @@
   #if SERVO0_PIN == BEEPER_PIN
     #undef BEEPER_PIN
   #endif
-#elif ENABLED(FILAMENT_RUNOUT_SENSOR)
+#elif HAS_FILAMENT_SENSOR
   #ifndef FIL_RUNOUT_PIN
     #define FIL_RUNOUT_PIN                    27
   #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -138,15 +138,19 @@
 //
 // Misc. Functions
 //
-#define MT_DET_1_PIN                      PA4   // MT_DET
-#define MT_DET_2_PIN                      PE6
-#define MT_DET_PIN_STATE                  LOW
-
-#ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN            MT_DET_1_PIN
+#if HAS_TFT_LVGL_UI
+  #define MT_DET_1_PIN                      PA4   // MT_DET
+  #define MT_DET_2_PIN                      PE6
+  #define MT_DET_PIN_STATE                  LOW
 #endif
-#ifndef FIL_RUNOUT2_PIN
-  #define FIL_RUNOUT2_PIN           MT_DET_2_PIN
+
+#if ENABLED(FILAMENT_RUNOUT_SENSOR)
+  #ifndef FIL_RUNOUT_PIN
+    #define FIL_RUNOUT_PIN                  PA4
+  #endif
+  #if !defined(FIL_RUNOUT2_PIN) && NUM_RUNOUT_SENSORS >= 2
+    #define FIL_RUNOUT2_PIN                 PE6
+  #endif
 #endif
 
 #ifndef POWER_LOSS_PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -144,13 +144,11 @@
   #define MT_DET_PIN_STATE                  LOW
 #endif
 
-#if ENABLED(FILAMENT_RUNOUT_SENSOR)
-  #ifndef FIL_RUNOUT_PIN
-    #define FIL_RUNOUT_PIN                  PA4
-  #endif
-  #if !defined(FIL_RUNOUT2_PIN) && NUM_RUNOUT_SENSORS >= 2
-    #define FIL_RUNOUT2_PIN                 PE6
-  #endif
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                    PA4
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN                   PE6
 #endif
 
 #ifndef POWER_LOSS_PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -138,11 +138,9 @@
 //
 // Misc. Functions
 //
-#if HAS_TFT_LVGL_UI
-  #define MT_DET_1_PIN                      PA4   // MT_DET
-  #define MT_DET_2_PIN                      PE6
-  #define MT_DET_PIN_STATE                  LOW
-#endif
+#define MT_DET_1_PIN                      PA4   // MT_DET
+#define MT_DET_2_PIN                      PE6
+#define MT_DET_PIN_STATE                  LOW
 
 #ifndef FIL_RUNOUT_PIN
   #define FIL_RUNOUT_PIN            MT_DET_1_PIN


### PR DESCRIPTION
### Description

MKS Robin Nano V3 default filament runout pins existence do not depend on any external component. MT_DET_1 and MT_DET_2 pins always have to be declared, otherwise, a compilation error will occur in the case the user enables the runout sensor but does not configure FIL_RUNOUT(2)_PIN by hand.

### Requirements

MKS Robin Nano V3

### Benefits

Fixes a compilation error

### Configurations

[configs.zip](https://github.com/MarlinFirmware/Marlin/files/7771884/configs.zip)

### Related Issues
