### PR TITLE
Update fast_pwm.cpp

### DIFF
--- a/Marlin/src/HAL/STM32/fast_pwm.cpp
+++ b/Marlin/src/HAL/STM32/fast_pwm.cpp
@@ -71,8 +71,6 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
 void set_pwm_frequency(const pin_t pin, int f_desired) {
   if (!PWM_PIN(pin)) return; // Don't proceed if no hardware timer
   HardwareTimer *HT;
-  PinName pin_name = digitalPinToPinName(pin);
-  TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); // Get HAL timer instance
 
   const PinName pin_name = digitalPinToPinName(pin);
   TIM_TypeDef * const Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); // Get HAL timer instance


### PR DESCRIPTION
Fixes broken compilation.

`Marlin/src/HAL/STM32/fast_pwm.cpp:77:17: error: conflicting declaration 'const PinName pin_name'
   77 |   const PinName pin_name = digitalPinToPinName(pin);
      |                 ^~~~~~~~
Marlin/src/HAL/STM32/fast_pwm.cpp:74:11: note: previous declaration as 'PinName pin_name'
   74 |   PinName pin_name = digitalPinToPinName(pin);
      |           ^~~~~~~~
Marlin/src/HAL/STM32/fast_pwm.cpp:78:23: error: conflicting declaration 'TIM_TypeDef* const Instance'
   78 |   TIM_TypeDef * const Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); // Get HAL timer instance
      |                       ^~~~~~~~
Marlin/src/HAL/STM32/fast_pwm.cpp:75:16: note: previous declaration as 'TIM_TypeDef* Instance'
   75 |   TIM_TypeDef *Instance = (TIM_TypeDef *)pinmap_peripheral(pin_name, PinMap_PWM); // Get HAL timer instance`

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

A recent change broke compilation due to multiple declarations of variables.

-->

### Benefits

Marlin compiles again.

### Configurations
