### PR TITLE
fix rename bugs when building

### DIFF
--- a/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/buildroot/share/PlatformIO/scripts/marlin.py
@@ -51,7 +51,7 @@ def encrypt_mks(source, target, env, new_name):
 	# If FIRMWARE_BIN is defined by config, override all
 	import re
 	patt = re.compile("^\\s*#define\\s+FIRMWARE_BIN\\s+\"?(.+)\"?")
-	with open(join("Marlin", "Configuration.h")) as f:
+	with open(join("Marlin", "Configuration.h"), encoding="utf-8") as f:
 		for line in f:
 			m = patt.search(line)
 			if m != None:


### PR DESCRIPTION

### Description

When some utf-8 characters like Chinese are in configuration.h and python defaultly open file and encode it with gbk, it will cause some errors like `'gbk' codec can't decode byte 0xaf in position 1338: illegal multibyte sequence`.  Forcing to encode it with utf-8 may solve it.

### Requirements

None

### Benefits

fix building errors when some utf-8 characters like Chinese are in configuration.h

### Configurations

add some Chinese notes in `configuration.h`

### Related Issues

(https://github.com/MarlinFirmware/Marlin/commit/a2349fc411321ae4ff2bb286af04bb7543963c72#commitcomment-62487252)
