### PR TITLE
🚸 Refine stepper-driver-related G-codes

### DIFF
--- a/Marlin/src/feature/tmc_util.h
+++ b/Marlin/src/feature/tmc_util.h
@@ -45,6 +45,12 @@ constexpr uint16_t _tmc_thrs(const uint16_t msteps, const uint32_t thrs, const u
   return 12650000UL * msteps / (256 * thrs * spmm);
 }
 
+typedef struct {
+  uint8_t toff;
+  int8_t hend;
+  uint8_t hstrt;
+} chopper_timing_t;
+
 template<char AXIS_LETTER, char DRIVER_ID>
 class TMCStorage {
   protected:
@@ -296,43 +302,6 @@ class TMCMarlin<TMC2660Stepper, AXIS_LETTER, DRIVER_ID, AXIS_ID> : public TMC266
     static constexpr int8_t sgt_min = -64,
                             sgt_max =  63;
 };
-
-template<typename TMC>
-void tmc_print_current(TMC &st) {
-  st.printLabel();
-  SERIAL_ECHOLNPGM(" driver current: ", st.getMilliamps());
-}
-
-#if ENABLED(MONITOR_DRIVER_STATUS)
-  template<typename TMC>
-  void tmc_report_otpw(TMC &st) {
-    st.printLabel();
-    SERIAL_ECHOPGM(" temperature prewarn triggered: ");
-    serialprint_truefalse(st.getOTPW());
-    SERIAL_EOL();
-  }
-  template<typename TMC>
-  void tmc_clear_otpw(TMC &st) {
-    st.clear_otpw();
-    st.printLabel();
-    SERIAL_ECHOLNPGM(" prewarn flag cleared");
-  }
-#endif
-#if ENABLED(HYBRID_THRESHOLD)
-  template<typename TMC>
-  void tmc_print_pwmthrs(TMC &st) {
-    st.printLabel();
-    SERIAL_ECHOLNPGM(" stealthChop max speed: ", st.get_pwm_thrs());
-  }
-#endif
-#if USE_SENSORLESS
-  template<typename TMC>
-  void tmc_print_sgt(TMC &st) {
-    st.printLabel();
-    SERIAL_ECHOPGM(" homing sensitivity: ");
-    SERIAL_PRINTLN(st.homing_threshold(), PrintBase::Dec);
-  }
-#endif
 
 void monitor_tmc_drivers();
 void test_tmc_connection(LOGICAL_AXIS_DECL(const bool, true));

--- a/Marlin/src/gcode/feature/L6470/M906.cpp
+++ b/Marlin/src/gcode/feature/L6470/M906.cpp
@@ -202,12 +202,11 @@ void L64XX_report_current(L64XX &motor, const L64XX_axis_t axis) {
  * On L6474 this sets the TVAL register (same address).
  *
  * I - select which driver(s) to change on multi-driver axis
- *     0 - (default) all drivers on the axis or E0
- *     1 - monitor only X, Y, Z or E1
- *     2 - monitor only X2, Y2, Z2 or E2
- *     3 - monitor only Z3 or E3
- *     4 - monitor only Z4 or E4
- *     5 - monitor only E5
+ *         (default) all drivers on the axis
+ *     0 - monitor only the first XYZ... driver
+ *     1 - monitor only X2, Y2, Z2
+ *     2 - monitor only Z3
+ *     3 - monitor only Z4
  * Xxxx, Yxxx, Zxxx, Exxx - axis to change (optional)
  *     L6474 - current in mA (4A max)
  *     All others - 0-255
@@ -227,8 +226,10 @@ void GcodeSuite::M906() {
 
   uint8_t report_current = true;
 
-  #if HAS_L64XX
-    const uint8_t index = parser.byteval('I');
+  #if AXIS_IS_L64XX(X2) || AXIS_IS_L64XX(Y2) || AXIS_IS_L64XX(Z2) || AXIS_IS_L64XX(Z3) || AXIS_IS_L64XX(Z4)
+    const int8_t index = parser.byteval('I', -1);
+  #else
+    constexpr int8_t index = -1;
   #endif
 
   LOOP_LOGICAL_AXES(i) if (uint16_t value = parser.intval(axis_codes[i])) {
@@ -243,20 +244,20 @@ void GcodeSuite::M906() {
     switch (i) {
       case X_AXIS:
         #if AXIS_IS_L64XX(X)
-          if (index == 0) L6470_SET_KVAL_HOLD(X);
+          if (index < 0 || index == 0) L6470_SET_KVAL_HOLD(X);
         #endif
         #if AXIS_IS_L64XX(X2)
-          if (index == 1) L6470_SET_KVAL_HOLD(X2);
+          if (index < 0 || index == 1) L6470_SET_KVAL_HOLD(X2);
         #endif
         break;
 
       #if HAS_Y_AXIS
         case Y_AXIS:
           #if AXIS_IS_L64XX(Y)
-            if (index == 0) L6470_SET_KVAL_HOLD(Y);
+            if (index < 0 || index == 0) L6470_SET_KVAL_HOLD(Y);
           #endif
           #if AXIS_IS_L64XX(Y2)
-            if (index == 1) L6470_SET_KVAL_HOLD(Y2);
+            if (index < 0 || index == 1) L6470_SET_KVAL_HOLD(Y2);
           #endif
           break;
       #endif
@@ -264,50 +265,47 @@ void GcodeSuite::M906() {
       #if HAS_Z_AXIS
         case Z_AXIS:
           #if AXIS_IS_L64XX(Z)
-            if (index == 0) L6470_SET_KVAL_HOLD(Z);
+            if (index < 0 || index == 0) L6470_SET_KVAL_HOLD(Z);
           #endif
           #if AXIS_IS_L64XX(Z2)
-            if (index == 1) L6470_SET_KVAL_HOLD(Z2);
+            if (index < 0 || index == 1) L6470_SET_KVAL_HOLD(Z2);
           #endif
           #if AXIS_IS_L64XX(Z3)
-            if (index == 2) L6470_SET_KVAL_HOLD(Z3);
+            if (index < 0 || index == 2) L6470_SET_KVAL_HOLD(Z3);
           #endif
           #if AXIS_DRIVER_TYPE_Z4(L6470)
-            if (index == 3) L6470_SET_KVAL_HOLD(Z4);
+            if (index < 0 || index == 3) L6470_SET_KVAL_HOLD(Z4);
           #endif
           break;
       #endif
 
       #if E_STEPPERS
         case E_AXIS: {
-          const int8_t target_e_stepper = get_target_e_stepper_from_command(0);
-          if (target_e_stepper < 0) return;
-          switch (target_e_stepper) {
-            #if AXIS_IS_L64XX(E0)
-              case 0: L6470_SET_KVAL_HOLD(E0); break;
-            #endif
-            #if AXIS_IS_L64XX(E1)
-              case 1: L6470_SET_KVAL_HOLD(E1); break;
-            #endif
-            #if AXIS_IS_L64XX(E2)
-              case 2: L6470_SET_KVAL_HOLD(E2); break;
-            #endif
-            #if AXIS_IS_L64XX(E3)
-              case 3: L6470_SET_KVAL_HOLD(E3); break;
-            #endif
-            #if AXIS_IS_L64XX(E4)
-              case 4: L6470_SET_KVAL_HOLD(E4); break;
-            #endif
-            #if AXIS_IS_L64XX(E5)
-              case 5: L6470_SET_KVAL_HOLD(E5); break;
-            #endif
-            #if AXIS_IS_L64XX(E6)
-              case 6: L6470_SET_KVAL_HOLD(E6); break;
-            #endif
-            #if AXIS_IS_L64XX(E7)
-              case 7: L6470_SET_KVAL_HOLD(E7); break;
-            #endif
-          }
+          const int8_t eindex = get_target_e_stepper_from_command();
+          #if AXIS_IS_L64XX(E0)
+            if (eindex < 0 || eindex == 0) L6470_SET_KVAL_HOLD(E0);
+          #endif
+          #if AXIS_IS_L64XX(E1)
+            if (eindex < 0 || eindex == 1) L6470_SET_KVAL_HOLD(E1);
+          #endif
+          #if AXIS_IS_L64XX(E2)
+            if (eindex < 0 || eindex == 2) L6470_SET_KVAL_HOLD(E2);
+          #endif
+          #if AXIS_IS_L64XX(E3)
+            if (eindex < 0 || eindex == 3) L6470_SET_KVAL_HOLD(E3);
+          #endif
+          #if AXIS_IS_L64XX(E4)
+            if (eindex < 0 || eindex == 4) L6470_SET_KVAL_HOLD(E4);
+          #endif
+          #if AXIS_IS_L64XX(E5)
+            if (eindex < 0 || eindex == 5) L6470_SET_KVAL_HOLD(E5);
+          #endif
+          #if AXIS_IS_L64XX(E6)
+            if (eindex < 0 || eindex == 6) L6470_SET_KVAL_HOLD(E6);
+          #endif
+          #if AXIS_IS_L64XX(E7)
+            if (eindex < 0 || eindex == 7) L6470_SET_KVAL_HOLD(E7);
+          #endif
         } break;
       #endif
     }

--- a/Marlin/src/gcode/feature/trinamic/M569.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M569.cpp
@@ -40,35 +40,35 @@ void tmc_set_stealthChop(TMC &st, const bool enable) {
   st.refresh_stepping_mode();
 }
 
-static void set_stealth_status(const bool enable, const int8_t target_e_stepper) {
+static void set_stealth_status(const bool enable, const int8_t eindex) {
   #define TMC_SET_STEALTH(Q) tmc_set_stealthChop(stepper##Q, enable)
 
-  #if    X_HAS_STEALTHCHOP  || Y_HAS_STEALTHCHOP  || Z_HAS_STEALTHCHOP \
-      || I_HAS_STEALTHCHOP  || J_HAS_STEALTHCHOP  || K_HAS_STEALTHCHOP \
-      || X2_HAS_STEALTHCHOP || Y2_HAS_STEALTHCHOP || Z2_HAS_STEALTHCHOP || Z3_HAS_STEALTHCHOP || Z4_HAS_STEALTHCHOP
-    const uint8_t index = parser.byteval('I');
+  #if X2_HAS_STEALTHCHOP || Y2_HAS_STEALTHCHOP || Z2_HAS_STEALTHCHOP || Z3_HAS_STEALTHCHOP || Z4_HAS_STEALTHCHOP
+    const int8_t index = parser.byteval('I', -1);
+  #else
+    constexpr int8_t index = -1;
   #endif
 
   LOOP_LOGICAL_AXES(i) if (parser.seen(axis_codes[i])) {
     switch (i) {
       case X_AXIS:
-        TERN_(X_HAS_STEALTHCHOP,  if (index == 0) TMC_SET_STEALTH(X));
-        TERN_(X2_HAS_STEALTHCHOP, if (index == 1) TMC_SET_STEALTH(X2));
+        TERN_(X_HAS_STEALTHCHOP,  if (index < 0 || index == 0) TMC_SET_STEALTH(X));
+        TERN_(X2_HAS_STEALTHCHOP, if (index < 0 || index == 1) TMC_SET_STEALTH(X2));
         break;
 
       #if HAS_Y_AXIS
         case Y_AXIS:
-          TERN_(Y_HAS_STEALTHCHOP,  if (index == 0) TMC_SET_STEALTH(Y));
-          TERN_(Y2_HAS_STEALTHCHOP, if (index == 1) TMC_SET_STEALTH(Y2));
+          TERN_(Y_HAS_STEALTHCHOP,  if (index < 0 || index == 0) TMC_SET_STEALTH(Y));
+          TERN_(Y2_HAS_STEALTHCHOP, if (index < 0 || index == 1) TMC_SET_STEALTH(Y2));
           break;
       #endif
 
       #if HAS_Z_AXIS
         case Z_AXIS:
-          TERN_(Z_HAS_STEALTHCHOP,  if (index == 0) TMC_SET_STEALTH(Z));
-          TERN_(Z2_HAS_STEALTHCHOP, if (index == 1) TMC_SET_STEALTH(Z2));
-          TERN_(Z3_HAS_STEALTHCHOP, if (index == 2) TMC_SET_STEALTH(Z3));
-          TERN_(Z4_HAS_STEALTHCHOP, if (index == 3) TMC_SET_STEALTH(Z4));
+          TERN_(Z_HAS_STEALTHCHOP,  if (index < 0 || index == 0) TMC_SET_STEALTH(Z));
+          TERN_(Z2_HAS_STEALTHCHOP, if (index < 0 || index == 1) TMC_SET_STEALTH(Z2));
+          TERN_(Z3_HAS_STEALTHCHOP, if (index < 0 || index == 2) TMC_SET_STEALTH(Z3));
+          TERN_(Z4_HAS_STEALTHCHOP, if (index < 0 || index == 3) TMC_SET_STEALTH(Z4));
           break;
       #endif
 
@@ -84,17 +84,14 @@ static void set_stealth_status(const bool enable, const int8_t target_e_stepper)
 
       #if E_STEPPERS
         case E_AXIS: {
-          if (target_e_stepper < 0) return;
-          switch (target_e_stepper) {
-            TERN_(E0_HAS_STEALTHCHOP, case 0: TMC_SET_STEALTH(E0); break;)
-            TERN_(E1_HAS_STEALTHCHOP, case 1: TMC_SET_STEALTH(E1); break;)
-            TERN_(E2_HAS_STEALTHCHOP, case 2: TMC_SET_STEALTH(E2); break;)
-            TERN_(E3_HAS_STEALTHCHOP, case 3: TMC_SET_STEALTH(E3); break;)
-            TERN_(E4_HAS_STEALTHCHOP, case 4: TMC_SET_STEALTH(E4); break;)
-            TERN_(E5_HAS_STEALTHCHOP, case 5: TMC_SET_STEALTH(E5); break;)
-            TERN_(E6_HAS_STEALTHCHOP, case 6: TMC_SET_STEALTH(E6); break;)
-            TERN_(E7_HAS_STEALTHCHOP, case 7: TMC_SET_STEALTH(E7); break;)
-          }
+          TERN_(E0_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 0) TMC_SET_STEALTH(E0));
+          TERN_(E1_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 1) TMC_SET_STEALTH(E1));
+          TERN_(E2_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 2) TMC_SET_STEALTH(E2));
+          TERN_(E3_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 3) TMC_SET_STEALTH(E3));
+          TERN_(E4_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 4) TMC_SET_STEALTH(E4));
+          TERN_(E5_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 5) TMC_SET_STEALTH(E5));
+          TERN_(E6_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 6) TMC_SET_STEALTH(E6));
+          TERN_(E7_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 7) TMC_SET_STEALTH(E7));
         } break;
       #endif
     }
@@ -133,7 +130,7 @@ static void say_stealth_status() {
  */
 void GcodeSuite::M569() {
   if (parser.seen('S'))
-    set_stealth_status(parser.value_bool(), get_target_e_stepper_from_command(0));
+    set_stealth_status(parser.value_bool(), get_target_e_stepper_from_command());
   else
     say_stealth_status();
 }

--- a/Marlin/src/gcode/feature/trinamic/M906.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M906.cpp
@@ -28,6 +28,12 @@
 #include "../../../feature/tmc_util.h"
 #include "../../../module/stepper/indirection.h"
 
+template<typename TMC>
+static void tmc_print_current(TMC &st) {
+  st.printLabel();
+  SERIAL_ECHOLNPGM(" driver current: ", st.getMilliamps());
+}
+
 /**
  * M906: Set motor current in milliamps.
  *
@@ -48,8 +54,10 @@ void GcodeSuite::M906() {
 
   bool report = true;
 
-  #if AXIS_IS_TMC(X) || AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z) || AXIS_IS_TMC(Z2) || AXIS_IS_TMC(Z3) || AXIS_IS_TMC(Z4) || AXIS_IS_TMC(I) || AXIS_IS_TMC(J) || AXIS_IS_TMC(K)
-    const uint8_t index = parser.byteval('I');
+  #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2) || AXIS_IS_TMC(Z3) || AXIS_IS_TMC(Z4)
+    const int8_t index = parser.byteval('I', -1);
+  #else
+    constexpr int8_t index = -1;
   #endif
 
   LOOP_LOGICAL_AXES(i) if (uint16_t value = parser.intval(axis_codes[i])) {
@@ -57,20 +65,20 @@ void GcodeSuite::M906() {
     switch (i) {
       case X_AXIS:
         #if AXIS_IS_TMC(X)
-          if (index == 0) TMC_SET_CURRENT(X);
+          if (index < 0 || index == 0) TMC_SET_CURRENT(X);
         #endif
         #if AXIS_IS_TMC(X2)
-          if (index == 1) TMC_SET_CURRENT(X2);
+          if (index < 0 || index == 1) TMC_SET_CURRENT(X2);
         #endif
         break;
 
       #if HAS_Y_AXIS
         case Y_AXIS:
           #if AXIS_IS_TMC(Y)
-            if (index == 0) TMC_SET_CURRENT(Y);
+            if (index < 0 || index == 0) TMC_SET_CURRENT(Y);
           #endif
           #if AXIS_IS_TMC(Y2)
-            if (index == 1) TMC_SET_CURRENT(Y2);
+            if (index < 0 || index == 1) TMC_SET_CURRENT(Y2);
           #endif
           break;
       #endif
@@ -78,16 +86,16 @@ void GcodeSuite::M906() {
       #if HAS_Z_AXIS
         case Z_AXIS:
           #if AXIS_IS_TMC(Z)
-            if (index == 0) TMC_SET_CURRENT(Z);
+            if (index < 0 || index == 0) TMC_SET_CURRENT(Z);
           #endif
           #if AXIS_IS_TMC(Z2)
-            if (index == 1) TMC_SET_CURRENT(Z2);
+            if (index < 0 || index == 1) TMC_SET_CURRENT(Z2);
           #endif
           #if AXIS_IS_TMC(Z3)
-            if (index == 2) TMC_SET_CURRENT(Z3);
+            if (index < 0 || index == 2) TMC_SET_CURRENT(Z3);
           #endif
           #if AXIS_IS_TMC(Z4)
-            if (index == 3) TMC_SET_CURRENT(Z4);
+            if (index < 0 || index == 3) TMC_SET_CURRENT(Z4);
           #endif
           break;
       #endif
@@ -104,34 +112,31 @@ void GcodeSuite::M906() {
 
       #if E_STEPPERS
         case E_AXIS: {
-          const int8_t target_e_stepper = get_target_e_stepper_from_command(0);
-          if (target_e_stepper < 0) return;
-          switch (target_e_stepper) {
-            #if AXIS_IS_TMC(E0)
-              case 0: TMC_SET_CURRENT(E0); break;
-            #endif
-            #if AXIS_IS_TMC(E1)
-              case 1: TMC_SET_CURRENT(E1); break;
-            #endif
-            #if AXIS_IS_TMC(E2)
-              case 2: TMC_SET_CURRENT(E2); break;
-            #endif
-            #if AXIS_IS_TMC(E3)
-              case 3: TMC_SET_CURRENT(E3); break;
-            #endif
-            #if AXIS_IS_TMC(E4)
-              case 4: TMC_SET_CURRENT(E4); break;
-            #endif
-            #if AXIS_IS_TMC(E5)
-              case 5: TMC_SET_CURRENT(E5); break;
-            #endif
-            #if AXIS_IS_TMC(E6)
-              case 6: TMC_SET_CURRENT(E6); break;
-            #endif
-            #if AXIS_IS_TMC(E7)
-              case 7: TMC_SET_CURRENT(E7); break;
-            #endif
-          }
+          const int8_t eindex = get_target_e_stepper_from_command();
+          #if AXIS_IS_TMC(E0)
+            if (eindex < 0 || eindex == 0) TMC_SET_CURRENT(E0);
+          #endif
+          #if AXIS_IS_TMC(E1)
+            if (eindex < 0 || eindex == 1) TMC_SET_CURRENT(E1);
+          #endif
+          #if AXIS_IS_TMC(E2)
+            if (eindex < 0 || eindex == 2) TMC_SET_CURRENT(E2);
+          #endif
+          #if AXIS_IS_TMC(E3)
+            if (eindex < 0 || eindex == 3) TMC_SET_CURRENT(E3);
+          #endif
+          #if AXIS_IS_TMC(E4)
+            if (eindex < 0 || eindex == 4) TMC_SET_CURRENT(E4);
+          #endif
+          #if AXIS_IS_TMC(E5)
+            if (eindex < 0 || eindex == 5) TMC_SET_CURRENT(E5);
+          #endif
+          #if AXIS_IS_TMC(E6)
+            if (eindex < 0 || eindex == 6) TMC_SET_CURRENT(E6);
+          #endif
+          #if AXIS_IS_TMC(E7)
+            if (eindex < 0 || eindex == 7) TMC_SET_CURRENT(E7);
+          #endif
         } break;
       #endif
     }

--- a/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
+++ b/Marlin/src/gcode/feature/trinamic/M911-M914.cpp
@@ -62,6 +62,21 @@
     #error "MONITOR_DRIVER_STATUS requires at least one TMC2130, 2160, 2208, 2209, 2660, 5130, or 5160."
   #endif
 
+  template<typename TMC>
+  static void tmc_report_otpw(TMC &st) {
+    st.printLabel();
+    SERIAL_ECHOPGM(" temperature prewarn triggered: ");
+    serialprint_truefalse(st.getOTPW());
+    SERIAL_EOL();
+  }
+
+  template<typename TMC>
+  static void tmc_clear_otpw(TMC &st) {
+    st.clear_otpw();
+    st.printLabel();
+    SERIAL_ECHOLNPGM(" prewarn flag cleared");
+  }
+
   /**
    * M911: Report TMC stepper driver overtemperature pre-warn flag
    *       This flag is held by the library, persisting until cleared by M912
@@ -223,11 +238,17 @@
 
 #endif // MONITOR_DRIVER_STATUS
 
-/**
- * M913: Set HYBRID_THRESHOLD speed.
- */
 #if ENABLED(HYBRID_THRESHOLD)
 
+  template<typename TMC>
+  static void tmc_print_pwmthrs(TMC &st) {
+    st.printLabel();
+    SERIAL_ECHOLNPGM(" stealthChop max speed: ", st.get_pwm_thrs());
+  }
+
+  /**
+   * M913: Set HYBRID_THRESHOLD speed.
+   */
   void GcodeSuite::M913() {
     #define TMC_SAY_PWMTHRS(A,Q) tmc_print_pwmthrs(stepper##Q)
     #define TMC_SET_PWMTHRS(A,Q) stepper##Q.set_pwm_thrs(value)
@@ -235,19 +256,21 @@
     #define TMC_SET_PWMTHRS_E(E) stepperE##E.set_pwm_thrs(value)
 
     bool report = true;
-    #if AXIS_IS_TMC(X) || AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z) || AXIS_IS_TMC(Z2) || AXIS_IS_TMC(Z3) || AXIS_IS_TMC(Z4) || AXIS_IS_TMC(I) || AXIS_IS_TMC(J) || AXIS_IS_TMC(K)
-      const uint8_t index = parser.byteval('I');
+    #if AXIS_IS_TMC(X2) || AXIS_IS_TMC(Y2) || AXIS_IS_TMC(Z2) || AXIS_IS_TMC(Z3) || AXIS_IS_TMC(Z4)
+      const int8_t index = parser.byteval('I', -1);
+    #else
+      constexpr int8_t index = -1;
     #endif
     LOOP_LOGICAL_AXES(i) if (int32_t value = parser.longval(axis_codes[i])) {
       report = false;
       switch (i) {
         case X_AXIS:
-          TERN_(X_HAS_STEALTHCHOP,  if (index < 2) TMC_SET_PWMTHRS(X,X));
-          TERN_(X2_HAS_STEALTHCHOP, if (!(index & 1)) TMC_SET_PWMTHRS(X,X2));
+          TERN_(X_HAS_STEALTHCHOP,  if (index < 0 || index == 0) TMC_SET_PWMTHRS(X,X));
+          TERN_(X2_HAS_STEALTHCHOP, if (index < 0 || index == 1) TMC_SET_PWMTHRS(X,X2));
           break;
         case Y_AXIS:
-          TERN_(Y_HAS_STEALTHCHOP,  if (index < 2) TMC_SET_PWMTHRS(Y,Y));
-          TERN_(Y2_HAS_STEALTHCHOP, if (!(index & 1)) TMC_SET_PWMTHRS(Y,Y2));
+          TERN_(Y_HAS_STEALTHCHOP,  if (index < 0 || index == 0) TMC_SET_PWMTHRS(Y,Y));
+          TERN_(Y2_HAS_STEALTHCHOP, if (index < 0 || index == 1) TMC_SET_PWMTHRS(Y,Y2));
           break;
 
         #if I_HAS_STEALTHCHOP
@@ -261,25 +284,22 @@
         #endif
 
         case Z_AXIS:
-          TERN_(Z_HAS_STEALTHCHOP, if (index < 2) TMC_SET_PWMTHRS(Z,Z));
-          TERN_(Z2_HAS_STEALTHCHOP, if (index == 0 || index == 2) TMC_SET_PWMTHRS(Z,Z2));
-          TERN_(Z3_HAS_STEALTHCHOP, if (index == 0 || index == 3) TMC_SET_PWMTHRS(Z,Z3));
-          TERN_(Z4_HAS_STEALTHCHOP, if (index == 0 || index == 4) TMC_SET_PWMTHRS(Z,Z4));
+          TERN_(Z_HAS_STEALTHCHOP,  if (index < 0 || index == 0) TMC_SET_PWMTHRS(Z,Z));
+          TERN_(Z2_HAS_STEALTHCHOP, if (index < 0 || index == 1) TMC_SET_PWMTHRS(Z,Z2));
+          TERN_(Z3_HAS_STEALTHCHOP, if (index < 0 || index == 2) TMC_SET_PWMTHRS(Z,Z3));
+          TERN_(Z4_HAS_STEALTHCHOP, if (index < 0 || index == 3) TMC_SET_PWMTHRS(Z,Z4));
           break;
         #if E_STEPPERS
           case E_AXIS: {
-            const int8_t target_e_stepper = get_target_e_stepper_from_command(0);
-            if (target_e_stepper < 0) return;
-            switch (target_e_stepper) {
-              TERN_(E0_HAS_STEALTHCHOP, case 0: TMC_SET_PWMTHRS_E(0); break;)
-              TERN_(E1_HAS_STEALTHCHOP, case 1: TMC_SET_PWMTHRS_E(1); break;)
-              TERN_(E2_HAS_STEALTHCHOP, case 2: TMC_SET_PWMTHRS_E(2); break;)
-              TERN_(E3_HAS_STEALTHCHOP, case 3: TMC_SET_PWMTHRS_E(3); break;)
-              TERN_(E4_HAS_STEALTHCHOP, case 4: TMC_SET_PWMTHRS_E(4); break;)
-              TERN_(E5_HAS_STEALTHCHOP, case 5: TMC_SET_PWMTHRS_E(5); break;)
-              TERN_(E6_HAS_STEALTHCHOP, case 6: TMC_SET_PWMTHRS_E(6); break;)
-              TERN_(E7_HAS_STEALTHCHOP, case 7: TMC_SET_PWMTHRS_E(7); break;)
-            }
+            const int8_t eindex = get_target_e_stepper_from_command();
+            TERN_(E0_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 0) TMC_SET_PWMTHRS_E(0));
+            TERN_(E1_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 1) TMC_SET_PWMTHRS_E(1));
+            TERN_(E2_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 2) TMC_SET_PWMTHRS_E(2));
+            TERN_(E3_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 3) TMC_SET_PWMTHRS_E(3));
+            TERN_(E4_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 4) TMC_SET_PWMTHRS_E(4));
+            TERN_(E5_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 5) TMC_SET_PWMTHRS_E(5));
+            TERN_(E6_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 6) TMC_SET_PWMTHRS_E(6));
+            TERN_(E7_HAS_STEALTHCHOP, if (eindex < 0 || eindex == 7) TMC_SET_PWMTHRS_E(7));
           } break;
         #endif // E_STEPPERS
       }
@@ -407,11 +427,18 @@
 
 #endif // HYBRID_THRESHOLD
 
-/**
- * M914: Set StallGuard sensitivity.
- */
 #if USE_SENSORLESS
 
+  template<typename TMC>
+  static void tmc_print_sgt(TMC &st) {
+    st.printLabel();
+    SERIAL_ECHOPGM(" homing sensitivity: ");
+    SERIAL_PRINTLN(st.homing_threshold(), PrintBase::Dec);
+  }
+
+  /**
+   * M914: Set StallGuard sensitivity.
+   */
   void GcodeSuite::M914() {
 
     bool report = true;

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -159,7 +159,7 @@ int8_t GcodeSuite::get_target_e_stepper_from_command(const int8_t dval/*=-1*/) {
 }
 
 /**
- * Set XYZIJKE destination and feedrate from the current GCode command
+ * Set XYZ...E destination and feedrate from the current GCode command
  *
  *  - Set destination from included axis codes
  *  - Set to current for missing axis codes

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -284,7 +284,7 @@
  * M871 - Print/reset/clear first layer temperature offset values. (Requires PTC_PROBE, PTC_BED, or PTC_HOTEND)
  * M876 - Handle Prompt Response. (Requires HOST_PROMPT_SUPPORT and not EMERGENCY_PARSER)
  * M900 - Get or Set Linear Advance K-factor. (Requires LIN_ADVANCE)
- * M906 - Set or get motor current in milliamps using axis codes X, Y, Z, E. Report values if no axis codes given. (Requires at least one _DRIVER_TYPE defined as TMC2130/2160/5130/5160/2208/2209/2660 or L6470)
+ * M906 - Set or get motor current in milliamps using axis codes XYZE, etc. Report values if no axis codes given. (Requires at least one _DRIVER_TYPE defined as TMC2130/2160/5130/5160/2208/2209/2660 or L6470)
  * M907 - Set digital trimpot motor current using axis codes. (Requires a board with digital trimpots)
  * M908 - Control digital trimpot directly. (Requires HAS_MOTOR_CURRENT_DAC or DIGIPOTSS_PIN)
  * M909 - Print digipot/DAC current value. (Requires HAS_MOTOR_CURRENT_DAC)

--- a/Marlin/src/module/stepper/trinamic.h
+++ b/Marlin/src/module/stepper/trinamic.h
@@ -74,12 +74,6 @@
   #define TMC_CLASS_E(N) TMC_CLASS(E##N, E)
 #endif
 
-typedef struct {
-  uint8_t toff;
-  int8_t hend;
-  uint8_t hstrt;
-} chopper_timing_t;
-
 #ifndef CHOPPER_TIMING_X
   #define CHOPPER_TIMING_X CHOPPER_TIMING
 #endif


### PR DESCRIPTION
- Change the behavior of stepper-driver-related G-codes so that when the `I` or `T` parameters are omitted, all drivers on the specified axes / extruders are updated.
- Move G-code specific template functions to their respective G-code implementation files.