### PR TITLE
fix REPRAPWORLD_KEYPAD and ZONESTAR_LCD

### DIFF
--- a/Marlin/src/lcd/buttons.h
+++ b/Marlin/src/lcd/buttons.h
@@ -45,36 +45,6 @@
   #define ENCODER_PHASE_3 1
 #endif
 
-#if IS_RRW_KEYPAD
-  #define BTN_OFFSET          0 // Bit offset into buttons for shift register values
-
-  #define BLEN_KEYPAD_F3      0
-  #define BLEN_KEYPAD_F2      1
-  #define BLEN_KEYPAD_F1      2
-  #define BLEN_KEYPAD_DOWN    3
-  #define BLEN_KEYPAD_RIGHT   4
-  #define BLEN_KEYPAD_MIDDLE  5
-  #define BLEN_KEYPAD_UP      6
-  #define BLEN_KEYPAD_LEFT    7
-
-  #define EN_KEYPAD_F1      _BV(BTN_OFFSET + BLEN_KEYPAD_F1)
-  #define EN_KEYPAD_F2      _BV(BTN_OFFSET + BLEN_KEYPAD_F2)
-  #define EN_KEYPAD_F3      _BV(BTN_OFFSET + BLEN_KEYPAD_F3)
-  #define EN_KEYPAD_DOWN    _BV(BTN_OFFSET + BLEN_KEYPAD_DOWN)
-  #define EN_KEYPAD_RIGHT   _BV(BTN_OFFSET + BLEN_KEYPAD_RIGHT)
-  #define EN_KEYPAD_MIDDLE  _BV(BTN_OFFSET + BLEN_KEYPAD_MIDDLE)
-  #define EN_KEYPAD_UP      _BV(BTN_OFFSET + BLEN_KEYPAD_UP)
-  #define EN_KEYPAD_LEFT    _BV(BTN_OFFSET + BLEN_KEYPAD_LEFT)
-
-  #define RRK(B) (keypad_buttons & (B))
-
-  #ifdef EN_C
-    #define BUTTON_CLICK() ((buttons & EN_C) || RRK(EN_KEYPAD_MIDDLE))
-  #else
-    #define BUTTON_CLICK() RRK(EN_KEYPAD_MIDDLE)
-  #endif
-#endif
-
 #if EITHER(HAS_DIGITAL_BUTTONS, HAS_DWIN_E3V2)
   // Wheel spin pins where BA is 00, 10, 11, 01 (1 bit always changes)
   #define BLEN_A 0
@@ -141,7 +111,39 @@
   #define B_ST _BV(BL_ST)
 
   #ifndef BUTTON_CLICK
-    #define BUTTON_CLICK() (buttons & (B_MI|B_ST))
+    #if EN_C
+      #define BUTTON_CLICK() (buttons & (B_MI|B_ST))
+    #endif
+  #endif
+#endif
+
+#if IS_RRW_KEYPAD
+  #define BTN_OFFSET          0 // Bit offset into buttons for shift register values
+
+  #define BLEN_KEYPAD_F3      0
+  #define BLEN_KEYPAD_F2      1
+  #define BLEN_KEYPAD_F1      2
+  #define BLEN_KEYPAD_DOWN    3
+  #define BLEN_KEYPAD_RIGHT   4
+  #define BLEN_KEYPAD_MIDDLE  5
+  #define BLEN_KEYPAD_UP      6
+  #define BLEN_KEYPAD_LEFT    7
+
+  #define EN_KEYPAD_F1      _BV(BTN_OFFSET + BLEN_KEYPAD_F1)
+  #define EN_KEYPAD_F2      _BV(BTN_OFFSET + BLEN_KEYPAD_F2)
+  #define EN_KEYPAD_F3      _BV(BTN_OFFSET + BLEN_KEYPAD_F3)
+  #define EN_KEYPAD_DOWN    _BV(BTN_OFFSET + BLEN_KEYPAD_DOWN)
+  #define EN_KEYPAD_RIGHT   _BV(BTN_OFFSET + BLEN_KEYPAD_RIGHT)
+  #define EN_KEYPAD_MIDDLE  _BV(BTN_OFFSET + BLEN_KEYPAD_MIDDLE)
+  #define EN_KEYPAD_UP      _BV(BTN_OFFSET + BLEN_KEYPAD_UP)
+  #define EN_KEYPAD_LEFT    _BV(BTN_OFFSET + BLEN_KEYPAD_LEFT)
+
+  #define RRK(B) (keypad_buttons & (B))
+
+  #ifdef EN_C
+    #define BUTTON_CLICK() ((buttons & EN_C) || RRK(EN_KEYPAD_MIDDLE))
+  #else
+    #define BUTTON_CLICK() RRK(EN_KEYPAD_MIDDLE)
   #endif
 #endif
 


### PR DESCRIPTION
### Description

Its been reported that buttons on the ZONESTAR_LCD don't works and  the encoder button on the REPRAPWORLD_KEYPAD doesn't work.

buttons.h line 71 has the test #ifdef EN_C, but EN_C is not defined until line 89.
Rearranged order of code.

I have tested this on a real ZONESTAR_LCD and standard REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER stull fuctions.
A 3rd party is testing with  REPRAPWORLD_KEYPAD

### Requirements

LCD with buttons

### Benefits

Works as expected

### Related Issues
https://reprap.org/forum/read.php?415,887649
https://github.com/MarlinFirmware/Marlin/issues/23287
