### PR TITLE
Fix sanguino1284p_optimized to not use the melzi upload speed

### DIFF
--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -123,15 +123,16 @@ build_flags = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -
 
 [env:sanguino1284p_optimized]
 platform    = atmelavr
-extends     = env:melzi
+extends     = env:sanguino1284p
 build_flags = ${tuned_1284p.build_flags}
 
 #
-# Melzi and clones (alias for sanguino1284p_optimized)
+# Melzi and clones (ATmega1284p)
 #
 [env:melzi_optimized]
-platform = atmelavr
-extends  = env:sanguino1284p_optimized
+platform    = atmelavr
+extends     = env:melzi
+build_flags = ${tuned_1284p.build_flags}
 
 #
 # Melzi and clones (Optiboot bootloader)


### PR DESCRIPTION
### Description
I tried to use the `sanguino1284p_optimized` target with my Anet A8 board. `sanguino1284p` works fine, but
the `sanguino1284p_optimized` does not.

I noticed that the definition of the  `sanguino1284p_optimized` extends `env:melzi` instead of `env:sanguino1284p`.
But melzi uses a different upload speed.

--> Before: `env:sanguino1284p` and `env:sanguino1284p_optimized` used a different speed, which doesn't work.  
--> Now: they use the same speed and melzi definition and `env:melzi_optimized` definition does now extend melzi  (+optimized flags) and not `sanguino1284p_optimized` which makes more sense.

### Requirements

any `sanguino1284p` board (Anet A8 should be the most used one).

### Benefits

* Working `sanguino1284p_optimized` definition.  
* `env:sanguino1284p_optimized` extends `env:sanguino1284p`
* `env:melzi_optimized` extends `env:melzi`