### PR TITLE
 Fix sanguino1284p_optimized to not use the melzi upload speed

### DIFF
--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -123,15 +123,16 @@ build_flags = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -
 
 [env:sanguino1284p_optimized]
 platform    = atmelavr
-extends     = env:melzi
+extends     = env:sanguino1284p
 build_flags = ${tuned_1284p.build_flags}
 
 #
-# Melzi and clones (alias for sanguino1284p_optimized)
+# Melzi and clones (ATmega1284p)
 #
 [env:melzi_optimized]
-platform = atmelavr
-extends  = env:sanguino1284p_optimized
+platform    = atmelavr
+extends     = env:melzi
+build_flags = ${tuned_1284p.build_flags}
 
 #
 # Melzi and clones (Optiboot bootloader)

--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -107,14 +107,6 @@ board                     = sanguino_atmega1284p
 board_upload.maximum_size = 126976
 
 #
-# Melzi and clones (ATmega1284p)
-#
-[env:melzi]
-platform     = atmelavr
-extends      = env:sanguino1284p
-upload_speed = 57600
-
-#
 # Sanguinololu (ATmega1284p stock bootloader with tuned flags)
 #
 
@@ -129,10 +121,15 @@ build_flags = ${tuned_1284p.build_flags}
 #
 # Melzi and clones (ATmega1284p)
 #
+[env:melzi]
+platform     = atmelavr
+extends      = env:sanguino1284p
+upload_speed = 57600
+
 [env:melzi_optimized]
-platform    = atmelavr
-extends     = env:melzi
-build_flags = ${tuned_1284p.build_flags}
+platform     = atmelavr
+extends      = env:sanguino1284p_optimized
+upload_speed = 57600
 
 #
 # Melzi and clones (Optiboot bootloader)
@@ -151,26 +148,3 @@ board_upload.maximum_size = 130048
 platform    = atmelavr
 extends     = env:melzi_optiboot
 build_flags = ${tuned_1284p.build_flags}
-
-#
-# AT90USB1286 boards using CDC bootloader
-# - BRAINWAVE
-# - BRAINWAVE_PRO
-# - SAV_MKI
-# - TEENSYLU
-#
-[env:at90usb1286_cdc]
-platform   = teensy
-extends    = common_avr8
-board      = marlin_at90usb1286
-lib_ignore = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
-
-#
-# AT90USB1286 boards using DFU bootloader
-# - Printrboard
-# - Printrboard Rev.F
-# - ? 5DPRINT ?
-#
-[env:at90usb1286_dfu]
-platform = teensy
-extends  = env:at90usb1286_cdc

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -10,6 +10,24 @@
 #################################
 
 #
+# AT90USB1286 boards using CDC bootloader
+# e.g., BRAINWAVE, BRAINWAVE_PRO, SAV_MKI, TEENSYLU
+#
+[env:at90usb1286_cdc]
+platform   = teensy
+extends    = common_avr8
+board      = marlin_at90usb1286
+lib_ignore = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
+
+#
+# AT90USB1286 boards using DFU bootloader
+# e.g., Printrboard, Printrboard Rev.F, 5DPRINT
+#
+[env:at90usb1286_dfu]
+platform = teensy
+extends  = env:at90usb1286_cdc
+
+#
 # Teensy++ 2.0
 #
 [env:teensy20]


### PR DESCRIPTION
### Description
I tried to use the `sanguino1284p_optimized` target with my Anet A8 board. `sanguino1284p` works fine, but
the `sanguino1284p_optimized` does not.

I noticed that the definition of the  `sanguino1284p_optimized` extends `env:melzi` instead of `env:sanguino1284p`.
But melzi uses a different upload speed.

--> Before: `env:sanguino1284p` and `env:sanguino1284p_optimized` used a different speed, which doesn't work.  
--> Now: they use the same speed   
  and  the `env:melzi` definition and `env:melzi_optimized` definition does now extend melzi  (+optimized flags) and not `sanguino1284p_optimized` which makes more sense.

### Requirements

any `sanguino1284p` board (Anet A8 should be the most common one).

### Benefits

* Working `sanguino1284p_optimized` definition.  
* `env:sanguino1284p_optimized` extends `env:sanguino1284p`
* `env:melzi_optimized` extends `env:melzi`