### PR TITLE
🔧 Remove CONFIGURATION_EMBEDDING warnings when not enabled

### DIFF
--- a/Marlin/src/inc/Conditionals_adv.h
+++ b/Marlin/src/inc/Conditionals_adv.h
@@ -1006,7 +1006,7 @@
 #endif
 
 // AVR are (usually) too limited in resources to store the configuration into the binary
-#if !defined(FORCE_CONFIG_EMBED) && (defined(__AVR__) || DISABLED(SDSUPPORT) || EITHER(SDCARD_READONLY, DISABLE_M503))
+#if ENABLED(CONFIGURATION_EMBEDDING) && !defined(FORCE_CONFIG_EMBED) && (defined(__AVR__) || DISABLED(SDSUPPORT) || EITHER(SDCARD_READONLY, DISABLE_M503))
   #undef CONFIGURATION_EMBEDDING
   #define CANNOT_EMBED_CONFIGURATION defined(__AVR__)
 #endif


### PR DESCRIPTION
### Description

Warnings.cpp warned about `CONFIGURATION_EMBEDDING` for AVR boards even if the feature was not enabled.
Checking the feature state before testing for other incompatibilities will avoid unnecessary warnings in builds.

### Requirements

N/A

### Benefits

Reduce warnings when not applicable.

### Configurations

Default config, with SDSUPPORT enabled.

### Related Issues

#23405 
