### PR TITLE
🔧Add CompileTimeString::contains for substrings

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -471,6 +471,16 @@
       return *str ? findStringEnd(str + 1) : str;
     }
 
+    // Check whether a string begins with the specified substring
+    constexpr bool startsWith(const char *str, const char *substr) {
+      return (*substr == 0) || ((*str != 0) && *str == *substr && startsWith(str + 1, substr + 1));
+    }
+
+    // Check whether a string contains a specified substring
+    constexpr bool contains(const char *str, const char *substr) {
+      return *str && (startsWith(str, substr) || contains(str + 1, substr));
+    }
+
     // Check whether a string contains a specific character
     constexpr bool contains(const char *str, const char ch) {
       return *str == ch ? true : (*str ? contains(str + 1, ch) : false);

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -894,7 +894,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #endif
 
 #if defined(EVENT_GCODE_SD_ABORT) && DISABLED(NOZZLE_PARK_FEATURE)
-  static_assert(nullptr == strstr(EVENT_GCODE_SD_ABORT, "G27"), "NOZZLE_PARK_FEATURE is required to use G27 in EVENT_GCODE_SD_ABORT.");
+  static_assert(!CompileTimeString::contains(EVENT_GCODE_SD_ABORT, "G27"), "NOZZLE_PARK_FEATURE is required to use G27 in EVENT_GCODE_SD_ABORT.");
 #endif
 
 /**
@@ -985,7 +985,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #elif FILAMENT_RUNOUT_DISTANCE_MM < 0
     #error "FILAMENT_RUNOUT_DISTANCE_MM must be greater than or equal to zero."
   #elif DISABLED(ADVANCED_PAUSE_FEATURE)
-    static_assert(nullptr == strstr(FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with FILAMENT_RUNOUT_SENSOR.");
+    static_assert(!CompileTimeString::contains(FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with FILAMENT_RUNOUT_SENSOR.");
   #endif
 #endif
 
@@ -1074,7 +1074,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #elif ENABLED(MMU2_MENUS) && !HAS_LCD_MENU
     #error "MMU2_MENUS requires an LCD supporting MarlinUI."
   #elif DISABLED(ADVANCED_PAUSE_FEATURE)
-    static_assert(nullptr == strstr(MMU2_FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with PRUSA_MMU2(S) / HAS_EXTENDABLE_MMU(S).");
+    static_assert(!CompileTimeString::contains(MMU2_FILAMENT_RUNOUT_SCRIPT, "M600"), "ADVANCED_PAUSE_FEATURE is required to use M600 with PRUSA_MMU2(S) / HAS_EXTENDABLE_MMU(S).");
   #endif
 #endif
 


### PR DESCRIPTION
### Description

Several static_asserts use `strstr`. When building for AVR, this cannot be evaluated at compile-time if the substring exists but is not the beginning of the string.

For example, the previous code works with `FILAMENT_RUNOUT_SCRIPT "M600"` but fails to evaluate the static_assert with `FILAMENT_RUNOUT_SCRIPT "G28;M600"`. (I know that sequence doesn't make sense, it is just an example.

To resolve this, I have implemented a CompileTimeString::contains function which accepts a string argument. This can be used to search for a substring regardless of its location in the string.

### Requirements

N/A

### Benefits

Avoids build failures if users have string matches that are not at the beginning of the string.

### Configurations

N/A

### Related Issues

I discovered this while trying to write some additional checks against FILAMENT_RUNOUT_SCRIPT, but opted to submit those as a separate PR after this change goes in.
