### PR TITLE
Require atmelavr 3.4, to provide updated compiler

### DIFF
--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -22,7 +22,6 @@ src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 # ATmega2560
 #
 [env:mega2560]
-platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = megaatmega2560
 
@@ -34,7 +33,6 @@ board    = megaatmega2560
 # BOARD_EINSTART_S
 #
 [env:mega2560ext]
-platform            = ${common_avr8.platform}
 extends             = env:mega2560
 board_build.variant = MARLIN_MEGA_EXTENDED
 extra_scripts       = ${common.extra_scripts}
@@ -44,7 +42,6 @@ extra_scripts       = ${common.extra_scripts}
 # ATmega1280
 #
 [env:mega1280]
-platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = megaatmega1280
 
@@ -62,7 +59,6 @@ build_flags         = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide
 # MightyBoard ATmega1280
 #
 [env:MightyBoard1280]
-platform = ${common_avr8.platform}
 extends  = mega_extended_optimized
 board    = megaatmega1280
 
@@ -70,7 +66,6 @@ board    = megaatmega1280
 # MightyBoard ATmega2560
 #
 [env:MightyBoard2560]
-platform = ${common_avr8.platform}
 extends  = mega_extended_optimized
 board    = megaatmega2560
 
@@ -78,7 +73,6 @@ board    = megaatmega2560
 # RAMBo
 #
 [env:rambo]
-platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = reprap_rambo
 
@@ -86,7 +80,6 @@ board    = reprap_rambo
 # FYSETC F6 V1.3 / V1.4
 #
 [env:FYSETC_F6]
-platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = fysetc_f6_13
 
@@ -94,7 +87,6 @@ board    = fysetc_f6_13
 # Sanguinololu (ATmega644p)
 #
 [env:sanguino644p]
-platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = sanguino_atmega644p
 
@@ -102,7 +94,6 @@ board    = sanguino_atmega644p
 # Sanguinololu (ATmega1284p)
 #
 [env:sanguino1284p]
-platform                  = ${common_avr8.platform}
 extends                   = common_avr8
 board                     = sanguino_atmega1284p
 board_upload.maximum_size = 126976
@@ -115,7 +106,6 @@ board_upload.maximum_size = 126976
 build_flags = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
 
 [env:sanguino1284p_optimized]
-platform    = ${common_avr8.platform}
 extends     = env:sanguino1284p
 build_flags = ${tuned_1284p.build_flags}
 
@@ -123,12 +113,10 @@ build_flags = ${tuned_1284p.build_flags}
 # Melzi and clones (ATmega1284p)
 #
 [env:melzi]
-platform     = ${common_avr8.platform}
 extends      = env:sanguino1284p
 upload_speed = 57600
 
 [env:melzi_optimized]
-platform     = ${common_avr8.platform}
 extends      = env:sanguino1284p_optimized
 upload_speed = 57600
 
@@ -136,7 +124,6 @@ upload_speed = 57600
 # Melzi and clones (Optiboot bootloader)
 #
 [env:melzi_optiboot]
-platform     = ${common_avr8.platform}
 extends      = common_avr8
 board        = sanguino_atmega1284p
 upload_speed = 115200
@@ -146,6 +133,5 @@ board_upload.maximum_size = 130048
 # Melzi and clones (Zonestar Melzi2 with tuned flags)
 #
 [env:melzi_optiboot_optimized]
-platform    = ${common_avr8.platform}
 extends     = env:melzi_optiboot
 build_flags = ${tuned_1284p.build_flags}

--- a/ini/avr.ini
+++ b/ini/avr.ini
@@ -13,6 +13,7 @@
 # AVR (8-bit) Common Environment values
 #
 [common_avr8]
+platform          = atmelavr@~3.4
 build_flags       = ${common.build_flags} -Wl,--relax
 board_build.f_cpu = 16000000L
 src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
@@ -21,7 +22,7 @@ src_filter        = ${common.default_src_filter} +<src/HAL/AVR>
 # ATmega2560
 #
 [env:mega2560]
-platform = atmelavr
+platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = megaatmega2560
 
@@ -33,7 +34,7 @@ board    = megaatmega2560
 # BOARD_EINSTART_S
 #
 [env:mega2560ext]
-platform            = atmelavr
+platform            = ${common_avr8.platform}
 extends             = env:mega2560
 board_build.variant = MARLIN_MEGA_EXTENDED
 extra_scripts       = ${common.extra_scripts}
@@ -43,7 +44,7 @@ extra_scripts       = ${common.extra_scripts}
 # ATmega1280
 #
 [env:mega1280]
-platform = atmelavr
+platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = megaatmega1280
 
@@ -61,7 +62,7 @@ build_flags         = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide
 # MightyBoard ATmega1280
 #
 [env:MightyBoard1280]
-platform = atmelavr
+platform = ${common_avr8.platform}
 extends  = mega_extended_optimized
 board    = megaatmega1280
 
@@ -69,7 +70,7 @@ board    = megaatmega1280
 # MightyBoard ATmega2560
 #
 [env:MightyBoard2560]
-platform = atmelavr
+platform = ${common_avr8.platform}
 extends  = mega_extended_optimized
 board    = megaatmega2560
 
@@ -77,7 +78,7 @@ board    = megaatmega2560
 # RAMBo
 #
 [env:rambo]
-platform = atmelavr
+platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = reprap_rambo
 
@@ -85,7 +86,7 @@ board    = reprap_rambo
 # FYSETC F6 V1.3 / V1.4
 #
 [env:FYSETC_F6]
-platform = atmelavr
+platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = fysetc_f6_13
 
@@ -93,7 +94,7 @@ board    = fysetc_f6_13
 # Sanguinololu (ATmega644p)
 #
 [env:sanguino644p]
-platform = atmelavr
+platform = ${common_avr8.platform}
 extends  = common_avr8
 board    = sanguino_atmega644p
 
@@ -101,7 +102,7 @@ board    = sanguino_atmega644p
 # Sanguinololu (ATmega1284p)
 #
 [env:sanguino1284p]
-platform                  = atmelavr
+platform                  = ${common_avr8.platform}
 extends                   = common_avr8
 board                     = sanguino_atmega1284p
 board_upload.maximum_size = 126976
@@ -114,7 +115,7 @@ board_upload.maximum_size = 126976
 build_flags = ${common.build_flags} -fno-tree-scev-cprop -fno-split-wide-types -Wl,--relax -mcall-prologues
 
 [env:sanguino1284p_optimized]
-platform    = atmelavr
+platform    = ${common_avr8.platform}
 extends     = env:sanguino1284p
 build_flags = ${tuned_1284p.build_flags}
 
@@ -122,12 +123,12 @@ build_flags = ${tuned_1284p.build_flags}
 # Melzi and clones (ATmega1284p)
 #
 [env:melzi]
-platform     = atmelavr
+platform     = ${common_avr8.platform}
 extends      = env:sanguino1284p
 upload_speed = 57600
 
 [env:melzi_optimized]
-platform     = atmelavr
+platform     = ${common_avr8.platform}
 extends      = env:sanguino1284p_optimized
 upload_speed = 57600
 
@@ -135,7 +136,7 @@ upload_speed = 57600
 # Melzi and clones (Optiboot bootloader)
 #
 [env:melzi_optiboot]
-platform     = atmelavr
+platform     = ${common_avr8.platform}
 extends      = common_avr8
 board        = sanguino_atmega1284p
 upload_speed = 115200
@@ -145,6 +146,6 @@ board_upload.maximum_size = 130048
 # Melzi and clones (Zonestar Melzi2 with tuned flags)
 #
 [env:melzi_optiboot_optimized]
-platform    = atmelavr
+platform    = ${common_avr8.platform}
 extends     = env:melzi_optiboot
 build_flags = ${tuned_1284p.build_flags}

--- a/ini/due.ini
+++ b/ini/due.ini
@@ -21,7 +21,6 @@ board      = due
 src_filter = ${common.default_src_filter} +<src/HAL/DUE> +<src/HAL/shared/backtrace>
 
 [env:DUE_USB]
-platform = atmelsam
 extends  = env:DUE
 board    = dueUSB
 
@@ -29,7 +28,6 @@ board    = dueUSB
 # Archim SAM
 #
 [common_DUE_archim]
-platform                 = atmelsam
 extends                  = env:DUE
 board                    = marlin_archim
 build_flags              = ${common.build_flags}
@@ -39,5 +37,4 @@ extra_scripts            = ${common.extra_scripts}
   Marlin/src/HAL/DUE/upload_extra_script.py
 
 [env:DUE_archim]
-platform = ${common_DUE_archim.platform}
 extends  = common_DUE_archim

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -38,5 +38,4 @@ monitor_speed = 115200
 
 [env:mks_tinybee]
 extends                = env:esp32
-platform               = espressif32@2.1.0
 board_build.partitions = default_8MB.csv

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -24,12 +24,10 @@ monitor_speed = 250000
 #board_build.flash_mode = qio
 
 [env:FYSETC_E4]
-platform               = espressif32@2.1.0
 extends                = env:esp32
 board_build.partitions = default_16MB.csv
 
 [env:PANDA]
-platform      = espressif32@2.1.0
 extends       = env:esp32
 build_flags   = ${env:esp32.build_flags} -DUSE_ESP32_EXIO -DUSE_ESP32_TASK_WDT
 lib_deps      = ${common.lib_deps}

--- a/ini/lpc176x.ini
+++ b/ini/lpc176x.ini
@@ -34,11 +34,9 @@ build_flags       = ${common.build_flags} -DU8G_HAL_LINKS -IMarlin/src/HAL/LPC17
 # NXP LPC176x ARM Cortex-M3
 #
 [env:LPC1768]
-platform = ${common_LPC.platform}
 extends  = common_LPC
 board    = nxp_lpc1768
 
 [env:LPC1769]
-platform = ${common_LPC.platform}
 extends  = common_LPC
 board    = nxp_lpc1769

--- a/ini/native.ini
+++ b/ini/native.ini
@@ -52,12 +52,10 @@ extends     = simulator_common
 build_flags = ${simulator_common.build_flags} -ldl -lpthread -lSDL2 -lSDL2_net -lGL
 
 [env:simulator_linux_debug]
-platform   = ${simulator_linux.platform}
 extends    = simulator_linux
 build_type = debug
 
 [env:simulator_linux_release]
-platform    = ${simulator_linux.platform}
 extends     = simulator_linux
 build_type  = release
 build_flags = ${simulator_linux.build_flags} ${simulator_linux.release_flags}
@@ -92,13 +90,11 @@ build_flags       =
   -lSDL2
 
 [env:simulator_macos_debug]
-platform        = ${env:simulator_linux_release.platform}
 extends         = env:simulator_linux_debug
 build_flags     = ${env:simulator_linux_debug.build_flags} ${simulator_macos.build_flags} -ggdb -Og -D_THREAD_SAFE
 build_unflags   = ${simulator_macos.build_unflags}
 
 [env:simulator_macos_release]
-platform        = ${env:simulator_linux_release.platform}
 extends         = env:simulator_linux_release
 build_flags     = ${env:simulator_linux_release.build_flags} ${simulator_macos.build_flags}
 build_unflags   = ${simulator_macos.build_unflags}
@@ -110,7 +106,6 @@ build_unflags   = ${simulator_macos.build_unflags}
 #  pacman -S --needed base-devel mingw-w64-x86_64-toolchain mingw64/mingw-w64-x86_64-glm mingw64/mingw-w64-x86_64-SDL2 mingw64/mingw-w64-x86_64-SDL2_net mingw-w64-x86_64-dlfcn
 #
 [env:simulator_windows]
-platform    = ${simulator_common.platform}
 extends     = simulator_common
 src_build_flags = ${simulator_common.src_build_flags} -fpermissive
 build_flags = ${simulator_common.build_flags} ${simulator_common.debug_build_flags} -IC:\\msys64\\mingw64\\include\\SDL2 -fno-stack-protector -Wl,-subsystem,windows -ldl -lmingw32 -lSDL2main -lSDL2 -lSDL2_net -lopengl32 -lssp

--- a/ini/stm32f0.ini
+++ b/ini/stm32f0.ini
@@ -23,7 +23,6 @@
 # Malyan M200 v2 (STM32F070RB)
 #
 [env:STM32F070RB_malyan]
-platform    = ${common_stm32.platform}
 extends     = common_stm32
 board       = marlin_malyanM200v2
 build_flags = ${common_stm32.build_flags} -DHAL_PCD_MODULE_ENABLED
@@ -34,7 +33,6 @@ build_flags = ${common_stm32.build_flags} -DHAL_PCD_MODULE_ENABLED
 # Malyan M200 v2 (STM32F070CB)
 #
 [env:STM32F070CB_malyan]
-platform    = ${common_stm32.platform}
 extends     = common_stm32
 board       = malyanm200_f070cb
 build_flags = ${common_stm32.build_flags}
@@ -45,7 +43,6 @@ build_flags = ${common_stm32.build_flags}
 # Malyan M300 (STM32F070CB)
 #
 [env:malyan_M300]
-platform    = ${common_stm32.platform}
 extends     = common_stm32
 board       = malyanm300_f070cb
 build_flags = ${common_stm32.build_flags}

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -42,7 +42,6 @@ extra_scripts     = ${common.extra_scripts}
 # STM32F103RC
 #
 [common_STM32F103RC_maple]
-platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
 monitor_speed     = 115200
@@ -51,7 +50,6 @@ monitor_speed     = 115200
 # MEEB_3DP (STM32F103RCT6 with 512K)
 #
 [env:STM32F103RC_meeb]
-platform          = ${common_stm32f1.platform}
 extends           = common_STM32F103RC_maple
 board             = marlin_MEEB_3DP
 build_flags       = ${common_stm32f1.build_flags}
@@ -75,7 +73,6 @@ upload_protocol   = dfu
 # FYSETC STM32F103RC
 #
 [env:STM32F103RC_fysetc_maple]
-platform          = ${common_stm32f1.platform}
 extends           = common_STM32F103RC_maple
 extra_scripts     = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
@@ -91,7 +88,6 @@ upload_protocol   = serial
 #   STM32F103RC_btt_USB_maple ......... RCT6 with 256K (USB mass storage)
 #
 [env:STM32F103RC_btt_maple]
-platform             = ${common_stm32f1.platform}
 extends              = common_STM32F103RC_maple
 board_build.address  = 0x08007000
 board_build.ldscript = STM32F103RC_SKR_MINI_256K.ld
@@ -102,7 +98,6 @@ build_flags          = ${common_stm32f1.build_flags}
 monitor_speed        = 115200
 
 [env:STM32F103RC_btt_USB_maple]
-platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RC_btt_maple
 build_flags       = ${env:STM32F103RC_btt_maple.build_flags} -DUSE_USB_COMPOSITE
 lib_deps          = ${env:STM32F103RC_btt_maple.lib_deps}
@@ -112,7 +107,6 @@ lib_deps          = ${env:STM32F103RC_btt_maple.lib_deps}
 # Generic STM32F103RE environment
 #
 [env:STM32F103RE_maple]
-platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RE
 monitor_speed     = 115200
@@ -121,7 +115,6 @@ monitor_speed     = 115200
 # Creality (STM32F103RET6)
 #
 [env:STM32F103RET6_creality_maple]
-platform             = ${common_stm32f1.platform}
 extends              = env:STM32F103RE_maple
 build_flags          = ${common_stm32f1.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000
@@ -139,7 +132,6 @@ upload_protocol      = jlink
 #   STM32F103RE_btt_USB_maple ......... RET6 (USB mass storage)
 #
 [env:STM32F103RE_btt_maple]
-platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RE_maple
 board_build.address  = 0x08007000
 board_build.ldscript = STM32F103RE_SKR_MINI_512K.ld
@@ -150,7 +142,6 @@ debug_tool        = stlink
 upload_protocol   = stlink
 
 [env:STM32F103RE_btt_USB_maple]
-platform          = ${common_stm32f1.platform}
 extends           = env:STM32F103RE_btt_maple
 build_flags       = ${env:STM32F103RE_btt_maple.build_flags} -DUSE_USB_COMPOSITE
 lib_deps          = ${common_stm32f1.lib_deps}
@@ -160,7 +151,6 @@ lib_deps          = ${common_stm32f1.lib_deps}
 # Geeetech GTM32 (STM32F103VET6)
 #
 [env:STM32F103VE_GTM32]
-platform        = ${common_stm32f1.platform}
 extends         = common_stm32f1
 board           = genericSTM32F103VE
 build_flags     = ${common_stm32f1.build_flags}
@@ -174,7 +164,6 @@ upload_protocol = serial
 # Longer 3D board in Alfawise U20 (STM32F103VET6)
 #
 [env:STM32F103VE_longer_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103VE
 board_build.address  = 0x08010000
@@ -191,7 +180,6 @@ build_unflags = ${common_stm32f1.build_unflags}
 # MKS Robin Mini (STM32F103VET6)
 #
 [env:mks_robin_mini_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103VE
 extra_scripts = ${common_stm32f1.extra_scripts}
@@ -203,7 +191,6 @@ build_flags   = ${common_stm32f1.build_flags}
 # MKS Robin Nano (STM32F103VET6)
 #
 [env:mks_robin_nano35_maple]
-platform        = ${common_stm32f1.platform}
 extends         = common_stm32f1
 board           = genericSTM32F103VE
 extra_scripts   = ${common_stm32f1.extra_scripts}
@@ -217,7 +204,6 @@ upload_protocol = jlink
 # MKS Robin (STM32F103ZET6)
 #
 [env:mks_robin_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103ZE
 extra_scripts = ${common_stm32f1.extra_scripts}
@@ -229,7 +215,6 @@ build_flags   = ${common_stm32f1.build_flags}
 # MKS Robin Pro (STM32F103ZET6)
 #
 [env:mks_robin_pro_maple]
-platform      = ${common_stm32f1.platform}
 extends       = env:mks_robin_maple
 extra_scripts = ${common_stm32f1.extra_scripts}
   buildroot/share/PlatformIO/scripts/mks_robin_pro.py
@@ -238,7 +223,6 @@ extra_scripts = ${common_stm32f1.extra_scripts}
 # TRIGORILLA PRO (STM32F103ZET6)
 #
 [env:trigorilla_pro_maple]
-platform      = ${common_stm32f1.platform}
 extends       = env:mks_robin_maple
 extra_scripts = ${common_stm32f1.extra_scripts}
 
@@ -247,7 +231,6 @@ extra_scripts = ${common_stm32f1.extra_scripts}
 # MKS Robin E3 with TMC2209
 #
 [env:mks_robin_e3_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103RC
 extra_scripts = ${common_stm32f1.extra_scripts}
@@ -260,7 +243,6 @@ build_flags   = ${common_stm32f1.build_flags}
 #  - LVGL UI
 #
 [env:mks_robin_e3p_maple]
-platform        = ${common_stm32f1.platform}
 extends         = common_stm32f1
 board           = genericSTM32F103VE
 extra_scripts   = ${common_stm32f1.extra_scripts}
@@ -274,7 +256,6 @@ upload_protocol = jlink
 # MKS Robin Lite/Lite2 (STM32F103RCT6)
 #
 [env:mks_robin_lite_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103RC
 extra_scripts = ${common_stm32f1.extra_scripts}
@@ -284,7 +265,6 @@ extra_scripts = ${common_stm32f1.extra_scripts}
 # MKS ROBIN LITE3 (STM32F103RCT6)
 #
 [env:mks_robin_lite3_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103RC
 extra_scripts = ${common_stm32f1.extra_scripts}
@@ -294,7 +274,6 @@ extra_scripts = ${common_stm32f1.extra_scripts}
 # JGAurora A5S A1 (STM32F103ZET6)
 #
 [env:jgaurora_a5s_a1_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = genericSTM32F103ZE
 board_build.address  = 0x0800A000
@@ -309,7 +288,6 @@ build_flags   = ${common_stm32f1.build_flags}
 # Malyan M200 (STM32F103CB)
 #
 [env:STM32F103CB_malyan_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = marlin_malyanM200
 build_flags   = ${common_stm32f1.build_flags}
@@ -322,7 +300,6 @@ lib_ignore    = ${common_stm32f1.lib_ignore}
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
 #
 [env:chitu_f103_maple]
-platform      = ${common_stm32f1.platform}
 extends       = common_stm32f1
 board         = marlin_CHITU_F103
 extra_scripts = ${common_stm32f1.extra_scripts}
@@ -338,7 +315,6 @@ build_unflags = ${common_stm32f1.build_unflags}
 # Use this target if G28 or G29 are always failing.
 #
 [env:chitu_v5_gpio_init_maple]
-platform      = ${common_stm32f1.platform}
 extends       = env:chitu_f103_maple
 build_flags   = ${env:chitu_f103_maple.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
 
@@ -346,7 +322,6 @@ build_flags   = ${env:chitu_f103_maple.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
 # FLYmaker FLY Mini (STM32F103RCT6)
 #
 [env:FLY_MINI_maple]
-platform          = ${common_stm32f1.platform}
 extends           = common_stm32f1
 board             = genericSTM32F103RC
 board_build.address  = 0x08005000
@@ -364,7 +339,6 @@ build_flags       = ${common_stm32f1.build_flags}
 #  STM32F103VE_ZM3E4V2_USB_maple ......... VET6 with 512K
 #
 [ZONESTAR_ZM3E_maple]
-platform                  = ${common_stm32f1.platform}
 extends                   = common_stm32f1
 platform_packages         = tool-stm32duino
 board_build.address       = 0x08005000
@@ -380,20 +354,17 @@ lib_deps                  = ${common_stm32f1.lib_deps}
 lib_ignore                = Adafruit NeoPixel, SPI, SailfishLCD, SailfishRGB_LED, SlowSoftI2CMaster, TMCStepper
 
 [env:STM32F103RC_ZM3E2_USB_maple]
-platform             = ${ZONESTAR_ZM3E_maple.platform}
 extends              = ZONESTAR_ZM3E_maple
 board                = genericSTM32F103RC
 board_build.ldscript = ZONESTAR_ZM3E_256K.ld
 
 [env:STM32F103VC_ZM3E4_USB_maple]
-platform             = ${ZONESTAR_ZM3E_maple.platform}
 extends              = ZONESTAR_ZM3E_maple
 board                = genericSTM32F103VC
 board_build.ldscript = ZONESTAR_ZM3E_256K.ld
 build_flags          = ${ZONESTAR_ZM3E_maple.build_flags} -DTONE_TIMER=1 -DTONE_CHANNEL=2
 
 [env:STM32F103VE_ZM3E4V2_USB_maple]
-platform             = ${ZONESTAR_ZM3E_maple.platform}
 extends              = ZONESTAR_ZM3E_maple
 board                = genericSTM32F103VE
 board_build.ldscript = ZONESTAR_ZM3E_512K.ld
@@ -404,7 +375,6 @@ board_upload.maximum_size = 499712
 # ERYONE ERY32 Mini (STM32F103VET6)
 #
 [env:ERYONE_ERY32_MINI_maple]
-platform             = ${common_stm32f1.platform}
 extends              = common_stm32f1
 board                = genericSTM32F103VE
 build_flags          = ${common_stm32f1.build_flags}

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -30,7 +30,6 @@ monitor_speed        = 115200
 # STM32F103RE
 #
 [env:STM32F103RE]
-platform      = ${common_stm32.platform}
 extends       = common_stm32
 board         = genericSTM32F103RE
 monitor_speed = 115200
@@ -39,7 +38,6 @@ monitor_speed = 115200
 # STM32F103VE
 #
 [env:STM32F103VE]
-platform      = ${common_stm32.platform}
 extends       = common_stm32
 board         = genericSTM32F103VE
 monitor_speed = 115200
@@ -48,7 +46,6 @@ monitor_speed = 115200
 # STM32F103ZE
 #
 [env:STM32F103ZE]
-platform      = ${common_stm32.platform}
 extends       = common_stm32
 board         = genericSTM32F103ZE
 monitor_speed = 115200
@@ -60,7 +57,6 @@ monitor_speed = 115200
 #   STM32F103RC_btt_USB ......... RCT6 with 256K (USB mass storage)
 #
 [env:STM32F103RC_btt]
-platform                    = ${common_stm32.platform}
 extends                     = common_STM32F103RC_variant
 build_flags                 = ${common_STM32F103RC_variant.build_flags}
                               -DTIMER_SERVO=TIM5
@@ -68,7 +64,6 @@ board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
 
 [env:STM32F103RC_btt_USB]
-platform          = ${common_stm32.platform}
 extends           = env:STM32F103RC_btt
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${env:STM32F103RC_btt.build_flags}
@@ -83,7 +78,6 @@ build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
 # Uses HAL STM32 to support Marlin UI for TFT screen with optional touch panel
 #
 [env:mks_robin]
-platform             = ${common_stm32.platform}
 extends              = stm32_variant
 board                = genericSTM32F103ZE
 board_build.variant  = MARLIN_F103Zx
@@ -98,7 +92,6 @@ build_unflags        = ${stm32_variant.build_unflags}
 # MKS Robin E3/E3D (STM32F103RCT6) with TMC2209
 #
 [env:mks_robin_e3]
-platform                    = ${common_stm32.platform}
 extends                     = common_STM32F103RC_variant
 board_build.encrypt         = Robin_e3.bin
 board_build.offset          = 0x5000
@@ -114,7 +107,6 @@ debug_tool                  = stlink
 # Creality (STM32F103RET6)
 #
 [env:STM32F103RET6_creality]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103RE
 board_build.variant         = MARLIN_F103Rx
@@ -139,7 +131,6 @@ upload_protocol             = jlink
 #   STM32F103RE_btt_USB ......... RET6 (USB mass storage)
 #
 [env:STM32F103RE_btt]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103RE
 board_build.variant         = MARLIN_F103Rx
@@ -154,7 +145,6 @@ debug_tool                  = jlink
 upload_protocol             = jlink
 
 [env:STM32F103RE_btt_USB]
-platform          = ${common_stm32.platform}
 extends           = env:STM32F103RE_btt
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${env:STM32F103RE_btt.build_flags}
@@ -167,7 +157,6 @@ build_unflags     = ${stm32_variant.build_unflags} -DUSBD_USE_CDC
 # board Hispeedv1
 #
 [env:flsun_hispeedv1]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
@@ -184,7 +173,6 @@ build_unflags               = ${stm32_variant.build_unflags}
 # MKS Robin Nano V1.2 and V2
 #
 [env:mks_robin_nano35]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
@@ -203,7 +191,6 @@ upload_protocol             = jlink
 # Mingda MPX_ARM_MINI
 #
 [env:mingda_mpx_arm_mini]
-platform             = ${common_stm32.platform}
 extends              = stm32_variant
 board                = genericSTM32F103ZE
 board_build.variant  = MARLIN_F103Zx
@@ -217,7 +204,6 @@ build_unflags        = ${stm32_variant.build_unflags}
 # Malyan M200 (STM32F103CB)
 #
 [env:STM32F103CB_malyan]
-platform    = ${common_stm32.platform}
 extends     = common_stm32
 board       = malyanm200_f103cb
 build_flags = ${common_stm32.build_flags}
@@ -229,7 +215,6 @@ src_filter  = ${common.default_src_filter} +<src/HAL/STM32>
 # FLYmaker FLY Mini (STM32F103RCT6)
 #
 [env:FLY_MINI]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103RC
 board_build.variant         = MARLIN_F103Rx
@@ -241,7 +226,6 @@ build_flags                 = ${stm32_variant.build_flags} -DSS_TIMER=4
 # MKS Robin Mini (STM32F103VET6)
 #
 [env:mks_robin_mini]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
@@ -255,7 +239,6 @@ build_flags                 = ${stm32_variant.build_flags}
 # MKS Robin Lite/Lite2 (STM32F103RCT6)
 #
 [env:mks_robin_lite]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103RC
 board_build.variant         = MARLIN_F103Rx
@@ -267,7 +250,6 @@ board_upload.offset_address = 0x08005000
 # MKS ROBIN LITE3 (STM32F103RCT6)
 #
 [env:mks_robin_lite3]
-platform                    = ${common_stm32.platform}
 extends                     = env:mks_robin_lite
 board_build.encrypt         = mksLite3.bin
 
@@ -275,7 +257,6 @@ board_build.encrypt         = mksLite3.bin
 # MKS Robin Pro (STM32F103ZET6)
 #
 [env:mks_robin_pro]
-platform            = ${common_stm32.platform}
 extends             = env:mks_robin
 board_build.encrypt = Robin_pro.bin
 
@@ -284,7 +265,6 @@ board_build.encrypt = Robin_pro.bin
 #  - LVGL UI
 #
 [env:mks_robin_e3p]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
@@ -301,7 +281,6 @@ upload_protocol             = jlink
 # JGAurora A5S A1 (STM32F103ZET6)
 #
 [env:jgaurora_a5s_a1]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = genericSTM32F103ZE
 board_build.variant         = MARLIN_F103Zx
@@ -317,7 +296,6 @@ extra_scripts               = ${stm32_variant.extra_scripts}
 # FYSETC STM32F103RC
 #
 [env:STM32F103RC_fysetc]
-platform        = ${common_stm32.platform}
 extends         = common_STM32F103RC_variant
 extra_scripts   = ${common_STM32F103RC_variant.extra_scripts}
                   buildroot/share/PlatformIO/scripts/STM32F103RC_fysetc.py
@@ -348,7 +326,6 @@ debug_tool                  = stlink
 # TRIGORILLA PRO (STM32F103ZET6)
 #
 [env:trigorilla_pro]
-platform             = ${stm32_variant.platform}
 extends              = stm32_variant
 board                = genericSTM32F103ZE
 board_build.variant  = MARLIN_F103Zx
@@ -361,7 +338,6 @@ build_unflags        = ${stm32_variant.build_unflags}
 # Chitu boards like Tronxy X5s (STM32F103ZET6)
 #
 [env:chitu_f103]
-platform             = ${common_stm32.platform}
 extends              = stm32_variant
 board                = genericSTM32F103ZE
 board_build.variant  = MARLIN_F103Zx
@@ -377,7 +353,6 @@ extra_scripts        = ${stm32_variant.extra_scripts}
 # Use this target if G28 or G29 are always failing.
 #
 [env:chitu_v5_gpio_init]
-platform      = ${common_stm32.platform}
 extends       = env:chitu_f103
 build_flags   = ${env:chitu_f103.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
 
@@ -389,7 +364,6 @@ build_flags   = ${env:chitu_f103.build_flags} -DCHITU_V5_Z_MIN_BUGFIX
 #  STM32F103VE_ZM3E4V2_USB ......... VET6 with 512K
 #
 [ZONESTAR_ZM3E]
-platform                  = ${common_stm32.platform}
 extends                   = stm32_variant
 platform_packages         = ${stm_flash_drive.platform_packages}
 board_upload.offset_address = 0x08005000
@@ -401,20 +375,17 @@ build_flags               = ${common_stm32.build_flags}
 build_unflags             = ${stm32_variant.build_unflags} -DUSBD_USE_CDC
 
 [env:STM32F103RC_ZM3E2_USB]
-platform             = ${ZONESTAR_ZM3E.platform}
 extends              = ZONESTAR_ZM3E
 board                = genericSTM32F103RC
 board_build.variant  = MARLIN_F103Rx
 
 [env:STM32F103VC_ZM3E4_USB]
-platform             = ${ZONESTAR_ZM3E.platform}
 extends              = ZONESTAR_ZM3E
 board                = genericSTM32F103VC
 board_build.variant  = MARLIN_F103Vx
 build_flags          = ${ZONESTAR_ZM3E.build_flags} -DTIMER_TONE=TIM1
 
 [env:STM32F103VE_ZM3E4V2_USB]
-platform             = ${ZONESTAR_ZM3E.platform}
 extends              = ZONESTAR_ZM3E
 board                = genericSTM32F103VE
 board_build.variant  = MARLIN_F103Vx

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -307,10 +307,9 @@ upload_protocol = serial
 # Longer 3D board in Alfawise U20 (STM32F103VET6)
 #
 [env:STM32F103VE_longer]
-platform                    = ${common_stm32.platform}
+extends                     = stm32_variant
 lib_deps                    = ${common.lib_deps}
   https://github.com/tpruvot/STM32_Servo_OpenDrain/archive/2.0.zip
-extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103VE_LONGER
 board_build.rename          = project.bin

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -23,7 +23,6 @@
 # ARMED (STM32)
 #
 [env:ARMED]
-platform      = ${common_stm32.platform}
 extends       = common_stm32
 board         = armed_v1
 build_flags   = ${common_stm32.build_flags}
@@ -34,7 +33,6 @@ build_flags   = ${common_stm32.build_flags}
 # 'STEVAL-3DP001V1' STM32F401VE board - https://www.st.com/en/evaluation-tools/steval-3dp001v1.html
 #
 [env:STM32F401VE_STEVAL]
-platform          = ${common_stm32.platform}
 extends           = stm32_variant
 board             = marlin_STEVAL_STM32F401VE
 build_flags       = ${stm32_variant.build_flags}
@@ -45,7 +43,6 @@ build_flags       = ${stm32_variant.build_flags}
 # STM32F401RC
 #
 [env:FYSETC_CHEETAH_V20]
-platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_FYSETC_CHEETAH_V20
 board_build.offset = 0x8000
@@ -55,7 +52,6 @@ build_flags        = ${stm32_variant.build_flags} -DSTM32F401xC
 # FLYF407ZG
 #
 [env:FLYF407ZG]
-platform            = ${common_stm32.platform}
 extends             = stm32_variant
 board               = marlin_STM32F407ZGT6
 board_build.variant = MARLIN_FLY_F407ZG
@@ -66,7 +62,6 @@ upload_protocol     = dfu
 # FYSETC S6 (STM32F446RET6 ARM Cortex-M4)
 #
 [env:FYSETC_S6]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = marlin_fysetc_s6
 board_build.offset          = 0x10000
@@ -80,7 +75,6 @@ upload_command              = dfu-util -a 0 -s 0x08010000:leave -D "$SOURCE"
 # FYSETC S6 new bootloader
 #
 [env:FYSETC_S6_8000]
-platform                    = ${common_stm32.platform}
 extends                     = env:FYSETC_S6
 board                       = marlin_fysetc_s6
 board_build.offset          = 0x8000
@@ -93,7 +87,6 @@ upload_command              = dfu-util -a 0 -s 0x08008000:leave -D "$SOURCE"
 # Shield - https://github.com/jmz52/Hardware
 #
 [env:STM32F407VE_black]
-platform          = ${common_stm32.platform}
 extends           = stm32_variant
 board             = marlin_blackSTM32F407VET6
 build_flags       = ${stm32_variant.build_flags}
@@ -103,7 +96,6 @@ build_flags       = ${stm32_variant.build_flags}
 # STM32F407VET6 Index Mobo Rev 03
 #
 [env:Index_Mobo_Rev03]
-platform          = ${common_stm32.platform}
 extends           = stm32_variant
 board             = marlin_index_mobo_rev03
 build_flags       = ${stm32_variant.build_flags}
@@ -117,7 +109,6 @@ extra_scripts     = ${stm32_variant.extra_scripts}
 # Comment out board_build.offset = 0x10000 if you don't plan to use OpenBLT/flashing directly to 0x08000000.
 #
 [env:Anet_ET4_OpenBLT]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = marlin_STM32F407VGT6_CCM
 board_build.variant         = MARLIN_F4x7Vx
@@ -137,7 +128,6 @@ upload_protocol             = jlink
 # BigTreeTech SKR Pro (STM32F407ZGT6 ARM Cortex-M4)
 #
 [env:BIGTREE_SKR_PRO]
-platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_BigTree_SKR_Pro
 board_build.offset = 0x8000
@@ -149,7 +139,6 @@ upload_protocol    = stlink
 # BigTreeTech SKR Pro (STM32F407ZGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
 [env:BIGTREE_SKR_PRO_usb_flash_drive]
-platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_SKR_PRO
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${stm_flash_drive.build_flags} -DSTM32F407_5ZX
@@ -159,7 +148,6 @@ build_unflags     = ${env:BIGTREE_SKR_PRO.build_unflags} -DUSBCON -DUSBD_USE_CDC
 # BigTreeTech E3 RRF (STM32F407VGT6 ARM Cortex-M4)
 #
 [env:BIGTREE_E3_RRF]
-platform            = ${common_stm32.platform}
 extends             = stm32_variant
 board               = marlin_STM32F407VGT6_CCM
 board_build.variant = MARLIN_BIGTREE_E3_RRF
@@ -173,7 +161,6 @@ build_flags         = ${stm32_variant.build_flags}
 # Bigtreetech GTR V1.0 (STM32F407IGT6 ARM Cortex-M4)
 #
 [env:BIGTREE_GTR_V1_0]
-platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_BigTree_GTR_v1
 board_build.offset = 0x8000
@@ -183,7 +170,6 @@ build_flags        = ${stm32_variant.build_flags} -DSTM32F407IX
 # Bigtreetech GTR V1.0 (STM32F407IGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
 [env:BIGTREE_GTR_V1_0_usb_flash_drive]
-platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_GTR_V1_0
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${stm_flash_drive.build_flags} -DSTM32F407IX
@@ -193,7 +179,6 @@ build_unflags     = ${env:BIGTREE_GTR_V1_0.build_unflags} -DUSBCON -DUSBD_USE_CD
 # BigTreeTech BTT002 V1.0 (STM32F407VGT6 ARM Cortex-M4)
 #
 [env:BIGTREE_BTT002]
-platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_BigTree_BTT002
 board_build.offset = 0x8000
@@ -208,7 +193,6 @@ build_flags        = ${stm32_variant.build_flags}
 # BigTreeTech BTT002 V1.x with 512k of flash (STM32F407VET6 ARM Cortex-M4)
 #
 [env:BIGTREE_BTT002_VET6]
-platform          = ${env:BIGTREE_BTT002.platform}
 extends           = env:BIGTREE_BTT002
 board             = marlin_BigTree_BTT002_VET6
 
@@ -216,7 +200,6 @@ board             = marlin_BigTree_BTT002_VET6
 # BigTreeTech SKR V2.0 (STM32F407VGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
 [env:BIGTREE_SKR_2]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 platform_packages           = ${stm_flash_drive.platform_packages}
 board                       = marlin_STM32F407VGT6_CCM
@@ -234,13 +217,11 @@ upload_protocol             = stlink
 # BigTreeTech SKR V2.0 (STM32F407VGT6 ARM Cortex-M4) with USB Media Share Support
 #
 [env:BIGTREE_SKR_2_USB]
-platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_SKR_2
 build_flags       = ${env:BIGTREE_SKR_2.build_flags} -DUSBD_USE_CDC_MSC
 build_unflags     = ${env:BIGTREE_SKR_2.build_unflags} -DUSBD_USE_CDC
 
 [env:BIGTREE_SKR_2_USB_debug]
-platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_SKR_2_USB
 build_flags       = ${env:BIGTREE_SKR_2_USB.build_flags} -O0
 build_unflags     = ${env:BIGTREE_SKR_2_USB.build_unflags} -Os -NDEBUG
@@ -249,7 +230,6 @@ build_unflags     = ${env:BIGTREE_SKR_2_USB.build_unflags} -Os -NDEBUG
 # Bigtreetech SKR V2.0 F429 (STM32F429VGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
 [env:BIGTREE_SKR_2_F429]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 platform_packages           = ${stm_flash_drive.platform_packages}
 board                       = marlin_STM32F429VGT6
@@ -267,13 +247,11 @@ upload_protocol             = stlink
 # BigTreeTech SKR V2.0 F429 (STM32F429VGT6 ARM Cortex-M4) with USB Media Share Support
 #
 [env:BIGTREE_SKR_2_F429_USB]
-platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_SKR_2_F429
 build_flags       = ${env:BIGTREE_SKR_2_F429.build_flags} -DUSBD_USE_CDC_MSC
 build_unflags     = ${env:BIGTREE_SKR_2_F429.build_unflags} -DUSBD_USE_CDC
 
 [env:BIGTREE_SKR_2_F429_USB_debug]
-platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_SKR_2_F429_USB
 build_flags       = ${env:BIGTREE_SKR_2_F429_USB.build_flags} -O0
 build_unflags     = ${env:BIGTREE_SKR_2_F429_USB.build_unflags} -Os -NDEBUG
@@ -282,7 +260,6 @@ build_unflags     = ${env:BIGTREE_SKR_2_F429_USB.build_unflags} -Os -NDEBUG
 # BigTreeTech Octopus V1.0/1.1 / Octopus Pro V1.0 (STM32F446ZET6 ARM Cortex-M4)
 #
 [env:BIGTREE_OCTOPUS_V1]
-platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_BigTree_Octopus_v1
 board_build.offset = 0x8000
@@ -293,7 +270,6 @@ build_flags        = ${stm32_variant.build_flags}
 # BigTreeTech Octopus V1.0/1.1 / Octopus Pro V1.0 (STM32F446ZET6 ARM Cortex-M4) with USB Flash Drive Support
 #
 [env:BIGTREE_OCTOPUS_V1_USB]
-platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_OCTOPUS_V1
 platform_packages = ${stm_flash_drive.platform_packages}
 build_unflags     = -DUSBD_USE_CDC
@@ -307,7 +283,6 @@ build_flags       = ${stm_flash_drive.build_flags}
 # BigTreeTech Octopus Pro V1.0 (STM32F429ZGT6 ARM Cortex-M4)
 #
 [env:BIGTREE_OCTOPUS_PRO_V1_F429]
-platform           = ${common_stm32.platform}
 extends            = stm32_variant
 board              = marlin_BigTree_Octopus_Pro_v1_F429
 board_build.offset = 0x8000
@@ -318,7 +293,6 @@ build_flags        = ${stm32_variant.build_flags}
 # BigTreeTech Octopus Pro V1.0 (STM32F429ZGT6 ARM Cortex-M4) with USB Flash Drive Support
 #
 [env:BIGTREE_OCTOPUS_PRO_V1_F429_USB]
-platform          = ${common_stm32.platform}
 extends           = env:BIGTREE_OCTOPUS_PRO_V1_F429
 platform_packages = ${stm_flash_drive.platform_packages}
 build_unflags     = -DUSBD_USE_CDC
@@ -332,7 +306,6 @@ build_flags       = ${stm_flash_drive.build_flags}
 # Lerdge base
 #
 [lerdge_common]
-platform            = ${common_stm32.platform}
 extends             = stm32_variant
 board               = marlin_STM32F407ZGT6
 board_build.variant = MARLIN_LERDGE
@@ -349,7 +322,6 @@ extra_scripts       = ${common_stm32.extra_scripts}
 # Lerdge X (STM32F407VE)
 #
 [env:LERDGEX]
-platform            = ${lerdge_common.platform}
 extends             = lerdge_common
 board_build.encrypt = Lerdge_X_firmware_force.bin
 
@@ -357,7 +329,6 @@ board_build.encrypt = Lerdge_X_firmware_force.bin
 # Lerdge X with USB Flash Drive Support
 #
 [env:LERDGEX_usb_flash_drive]
-platform          = ${env:LERDGEX.platform}
 extends           = env:LERDGEX
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
@@ -366,7 +337,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
 # Lerdge S (STM32F407ZG)
 #
 [env:LERDGES]
-platform            = ${lerdge_common.platform}
 extends             = lerdge_common
 board_build.encrypt = Lerdge_firmware_force.bin
 
@@ -374,7 +344,6 @@ board_build.encrypt = Lerdge_firmware_force.bin
 # Lerdge S with USB Flash Drive Support
 #
 [env:LERDGES_usb_flash_drive]
-platform          = ${env:LERDGES.platform}
 extends           = env:LERDGES
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
@@ -383,7 +352,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
 # Lerdge K (STM32F407ZG)
 #
 [env:LERDGEK]
-platform            = ${lerdge_common.platform}
 extends             = lerdge_common
 board_build.encrypt = Lerdge_K_firmware_force.bin
 build_flags         = ${lerdge_common.build_flags} -DLERDGEK
@@ -392,7 +360,6 @@ build_flags         = ${lerdge_common.build_flags} -DLERDGEK
 # Lerdge K with USB Flash Drive Support
 #
 [env:LERDGEK_usb_flash_drive]
-platform          = ${env:LERDGEK.platform}
 extends           = env:LERDGEK
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
@@ -401,7 +368,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
 # RUMBA32
 #
 [env:rumba32]
-platform             = ${common_stm32.platform}
 extends              = stm32_variant
 board                = rumba32_f446ve
 board_build.variant  = MARLIN_F446VE
@@ -418,7 +384,6 @@ upload_protocol      = dfu
 # MKS Robin Pro V2
 #
 [env:mks_robin_pro2]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 platform_packages           = ${stm_flash_drive.platform_packages}
 board                       = genericSTM32F407VET6
@@ -440,7 +405,6 @@ build_flags = -DPIN_WIRE_SCL=PB6 -DPIN_WIRE_SDA=PB7
 # MKS Robin Nano V3
 #
 [env:mks_robin_nano_v3]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = marlin_STM32F407VGT6_CCM
 board_build.variant         = MARLIN_F4x7Vx
@@ -457,7 +421,6 @@ upload_protocol             = jlink
 # Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_robin_nano_v3_usb_flash_drive]
-platform          = ${common_stm32.platform}
 extends           = env:mks_robin_nano_v3
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
@@ -471,7 +434,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 # Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_robin_nano_v3_usb_flash_drive_msc]
-platform          = ${common_stm32.platform}
 extends           = env:mks_robin_nano_v3_usb_flash_drive
 build_flags       = ${env:mks_robin_nano_v3_usb_flash_drive.build_flags}
                     -DUSBD_USE_CDC_MSC
@@ -482,7 +444,6 @@ build_unflags     = -DUSBD_USE_CDC
 # 5 TMC2209 uart mode on board
 #
 [env:mks_eagle]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = marlin_STM32F407VGT6_CCM
 board_build.variant         = MARLIN_F4x7Vx
@@ -500,7 +461,6 @@ upload_protocol             = jlink
 # Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_eagle_usb_flash_drive]
-platform          = ${common_stm32.platform}
 extends           = env:mks_eagle
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
@@ -514,7 +474,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1.build_flags}
 # Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_eagle_usb_flash_drive_msc]
-platform          = ${common_stm32.platform}
 extends           = env:mks_eagle_usb_flash_drive
 build_flags       = ${env:mks_eagle_usb_flash_drive.build_flags}
                     -DUSBD_USE_CDC_MSC
@@ -530,7 +489,6 @@ build_flags = -DPIN_WIRE_SCL=PB8 -DPIN_WIRE_SDA=PB9
 # MKS Monster8
 #
 [env:mks_monster8]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = marlin_STM32F407VGT6_CCM
 board_build.variant         = MARLIN_F4x7Vx
@@ -548,7 +506,6 @@ upload_protocol             = jlink
 # Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_monster8_usb_flash_drive]
-platform          = ${common_stm32.platform}
 extends           = env:mks_monster8
 platform_packages = ${stm_flash_drive.platform_packages}
 build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1_CAN.build_flags}
@@ -562,7 +519,6 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1_CAN.build_flag
 # Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_monster8_usb_flash_drive_msc]
-platform          = ${common_stm32.platform}
 extends           = env:mks_monster8_usb_flash_drive
 build_flags       = ${env:mks_monster8_usb_flash_drive.build_flags}
                     -DUSBD_USE_CDC_MSC
@@ -572,7 +528,6 @@ build_unflags     = -DUSBD_USE_CDC
 # TH3D EZBoard v2.0 (STM32F405RGT6 ARM Cortex-M4)
 #
 [env:TH3D_EZBoard_V2]
-platform            = ${common_stm32.platform}
 extends             = stm32_variant
 board               = genericSTM32F405RG
 board_build.variant = MARLIN_TH3D_EZBOARD_V2
@@ -588,7 +543,6 @@ upload_protocol     = stlink
 #  - MKS Robin Nano-S V1.3 (STM32F407VET6) 4 TMC2225 + 1 Pololu Plug
 #
 [env:mks_robin_nano_v1_3_f4]
-platform                    = ${common_stm32.platform}
 extends                     = stm32_variant
 board                       = marlin_STM32F407VGT6_CCM
 board_build.variant         = MARLIN_F4x7Vx
@@ -610,7 +564,6 @@ upload_protocol             = jlink
 # Artillery Ruby
 #
 [env:Artillery_Ruby]
-platform          = ${common_stm32.platform}
 extends           = common_stm32
 board             = marlin_Artillery_Ruby
 build_flags       = ${common_stm32.build_flags}

--- a/ini/stm32f7.ini
+++ b/ini/stm32f7.ini
@@ -25,7 +25,6 @@
 # being readily available based on STM32F7 MCUs
 #
 [env:NUCLEO_F767ZI]
-platform      = ${common_stm32.platform}
 extends       = common_stm32
 board         = nucleo_f767zi
 build_flags   = ${common_stm32.build_flags} -DTIMER_SERIAL=TIM9
@@ -34,6 +33,5 @@ build_flags   = ${common_stm32.build_flags} -DTIMER_SERIAL=TIM9
 # REMRAM_V1
 #
 [env:REMRAM_V1]
-platform      = ${common_stm32.platform}
 extends       = common_stm32
 board         = remram_v1

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -23,17 +23,17 @@
 # BigTree SKR mini E3 V3.0 (STM32G0B1RET6 ARM Cortex-M0+)
 #
 [env:STM32G0B1RE_btt]
-platform          = ststm32@~14.1.0
-platform_packages = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
-extends            = stm32_variant
-board              = marlin_STM32G0B1RE
+extends                     = stm32_variant
+platform                    = ststm32@~14.1.0
+platform_packages           = framework-arduinoststm32@https://github.com/stm32duino/Arduino_Core_STM32/archive/main.zip
+board                       = marlin_STM32G0B1RE
 board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000
-build_flags        = ${stm32_variant.build_flags}
-                   -DADC_RESOLUTION=12
-                   -DPIN_SERIAL4_RX=PC_11 -DPIN_SERIAL4_TX=PC_10
-                   -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
-                   -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
-                   -DSTEP_TIMER_IRQ_PRIO=0
-upload_protocol   = stlink
-debug_tool        = stlink
+build_flags                 = ${stm32_variant.build_flags}
+                            -DADC_RESOLUTION=12
+                            -DPIN_SERIAL4_RX=PC_11 -DPIN_SERIAL4_TX=PC_10
+                            -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
+                            -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4
+                            -DSTEP_TIMER_IRQ_PRIO=0
+upload_protocol             = stlink
+debug_tool                  = stlink

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -23,7 +23,6 @@
 # BigTreeTech SKR SE BX (STM32H743IIT6 ARM Cortex-M7)
 #
 [env:BTT_SKR_SE_BX]
-platform           = ${common_stm32.platform}
 extends            = stm32_variant
 platform_packages  = framework-arduinoststm32@https://github.com/thisiskeithb/Arduino_Core_STM32/archive/biqu-bx-workaround.zip
 board              = marlin_BTT_SKR_SE_BX

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -10,60 +10,70 @@
 #################################
 
 #
+# Teensy AVR
+#
+[teensy_avr]
+platform   = teensy
+extends    = common_avr8
+lib_ignore = ${env:common_avr8.lib_ignore}, NativeEthernet
+
+#
 # AT90USB1286 boards using CDC bootloader
 # e.g., BRAINWAVE, BRAINWAVE_PRO, SAV_MKI, TEENSYLU
 #
 [env:at90usb1286_cdc]
-platform          = teensy
-platform_packages = toolchain-atmelavr@~1.70300.0
-extends           = common_avr8
-board             = marlin_at90usb1286
-lib_ignore        = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
+extends    = teensy_avr
+board      = marlin_at90usb1286
+lib_ignore = ${teensy_avr.lib_ignore}, Teensy_ADC
 
 #
 # AT90USB1286 boards using DFU bootloader
 # e.g., Printrboard, Printrboard Rev.F, 5DPRINT
 #
 [env:at90usb1286_dfu]
-extends  = env:at90usb1286_cdc
+extends = env:at90usb1286_cdc
 
 #
 # Teensy++ 2.0
 #
 [env:teensy20]
-platform   = teensy
-extends    = common_avr8
-board      = teensy2pp
-lib_ignore = ${env:common_avr8.lib_ignore}, NativeEthernet
+extends = teensy_avr
+board   = teensy2pp
+
+#
+# Teensy 3.x - 4.x
+#
+[teensy_arm]
+platform   = teensy@~4.12.0
+src_filter = ${common.default_src_filter}
+lib_ignore = NativeEthernet
 
 #
 # Teensy 3.1 / 3.2 (ARM Cortex-M4)
 #
 [env:teensy31]
-platform      = teensy@~4.12.0
-board         = teensy31
-src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY31_32>
-lib_ignore    = NativeEthernet
+extends    = teensy_arm
+board      = teensy31
+src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY31_32>
 
 #
 # Teensy 3.5 / 3.6 (ARM Cortex-M4)
 #
 [env:teensy35]
-platform      = teensy@~4.12.0
-board         = teensy35
-src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
-lib_ignore    = NativeEthernet
+extends    = teensy_arm
+board      = teensy35
+src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY35_36>
 
 [env:teensy36]
-platform      = teensy@~4.12.0
-board         = teensy36
-src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY35_36>
-lib_ignore    = NativeEthernet
+extends    = teensy_arm
+board      = teensy36
+src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY35_36>
 
 #
 # Teensy 4.0 / 4.1 (ARM Cortex-M7)
 #
 [env:teensy41]
-platform      = teensy@~4.12.0
-board         = teensy41
-src_filter    = ${common.default_src_filter} +<src/HAL/TEENSY40_41>
+extends    = teensy_arm
+board      = teensy41
+src_filter = ${teensy_arm.src_filter} +<src/HAL/TEENSY40_41>
+lib_ignore =

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -25,7 +25,6 @@ lib_ignore        = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
 # e.g., Printrboard, Printrboard Rev.F, 5DPRINT
 #
 [env:at90usb1286_dfu]
-platform = teensy
 extends  = env:at90usb1286_cdc
 
 #

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -14,10 +14,11 @@
 # e.g., BRAINWAVE, BRAINWAVE_PRO, SAV_MKI, TEENSYLU
 #
 [env:at90usb1286_cdc]
-platform   = teensy
-extends    = common_avr8
-board      = marlin_at90usb1286
-lib_ignore = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
+platform          = teensy
+platform_packages = toolchain-atmelavr@~1.70300.0
+extends           = common_avr8
+board             = marlin_at90usb1286
+lib_ignore        = ${env:common_avr8.lib_ignore}, Teensy_ADC, NativeEthernet
 
 #
 # AT90USB1286 boards using DFU bootloader

--- a/ini/teensy.ini
+++ b/ini/teensy.ini
@@ -13,9 +13,10 @@
 # Teensy AVR
 #
 [teensy_avr]
-platform   = teensy
-extends    = common_avr8
-lib_ignore = ${env:common_avr8.lib_ignore}, NativeEthernet
+platform          = teensy
+platform_packages = toolchain-atmelavr@~1.70300.0
+extends           = common_avr8
+lib_ignore        = ${env:common_avr8.lib_ignore}, NativeEthernet
 
 #
 # AT90USB1286 boards using CDC bootloader


### PR DESCRIPTION
### Description

PIO has recently updated the AVR toolchain to use GCC 7.3 rather than 5.4. Anyone with an outdated AVR platform installed may fail to build due to the old compiler.

Specifying the version of the AVR platform to use will ensure that all Marlin users are compiling with the same GCC version.

**Open questions / testing needed:**
1. ~~Does the latest Arduino contain this matching version as well? If so, that minimum requirement should be documented somewhere.~~
**I verified that the latest Arduino for Windows uses GCC 7.3. It is also prone to caching issues like PIO, so for me it was necessary for me to delete the previously downloaded AVR toolchain from my user folder so that Arduino would use the new compiler.**
2. ~~I have not deployed this to hardware yet. I need to test that before this goes in.~~
  I have loaded firmware as a sanity test on two different boards. On each I performed homing and basic movements to ensure the firmware seems to work.
    - Anycubic Trigorilla (mega2560)
    - Printrboard Rev F (at90usb1286_dfu)

### Requirements

N/A

### Benefits

- Avoids mismatching compiler versions between users.
- This should allow using up to C++17 on AVR.

### Configurations

N/A

### Related Issues

N/A
