### PR TITLE
Fix broken compilation tests

### DIFF
--- a/buildroot/tests/teensy31
+++ b/buildroot/tests/teensy31
@@ -15,6 +15,7 @@ exec_test $1 $2 "Teensy3.1 with default config" "$3"
 #
 restore_configs
 opt_set MOTHERBOARD BOARD_TEENSY31_32
+opt_disable USE_XMIN_PLUG USE_YMIN_PLUG USE_ZMIN_PLUG
 opt_set X_HOME_DIR 0
 opt_set Y_HOME_DIR 0
 opt_set Z_HOME_DIR 0

--- a/buildroot/tests/teensy31
+++ b/buildroot/tests/teensy31
@@ -15,7 +15,9 @@ exec_test $1 $2 "Teensy3.1 with default config" "$3"
 #
 restore_configs
 opt_set MOTHERBOARD BOARD_TEENSY31_32
-opt_disable USE_XMIN_PLUG USE_YMIN_PLUG USE_ZMIN_PLUG
+opt_set X_HOME_DIR 0
+opt_set Y_HOME_DIR 0
+opt_set Z_HOME_DIR 0
 exec_test $1 $2 "Teensy3.1 with Zero Endstops" "$3"
 
 #

--- a/buildroot/tests/teensy31
+++ b/buildroot/tests/teensy31
@@ -14,11 +14,8 @@ exec_test $1 $2 "Teensy3.1 with default config" "$3"
 # Zero endstops, as with a CNC
 #
 restore_configs
-opt_set MOTHERBOARD BOARD_TEENSY31_32
+opt_set MOTHERBOARD BOARD_TEENSY31_32 X_HOME_DIR 0 Y_HOME_DIR 0 Z_HOME_DIR 0
 opt_disable USE_XMIN_PLUG USE_YMIN_PLUG USE_ZMIN_PLUG
-opt_set X_HOME_DIR 0
-opt_set Y_HOME_DIR 0
-opt_set Z_HOME_DIR 0
 exec_test $1 $2 "Teensy3.1 with Zero Endstops" "$3"
 
 #


### PR DESCRIPTION
### Description

Recent endstop refactoring caused the teensy test with zero endstops to start failing.

Upon reviewing the code, it appears that setting the HOME_DIR to 0 is the proper solution to fix this build.

### Requirements

N/A

### Benefits

Fixes PR checks

### Configurations

N/A

### Related Issues

N/A
