### PR TITLE
Add missing startup code and build flags for Artillery Ruby motherboard

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_ARTILLERY_RUBY/startup.S
+++ b/buildroot/share/PlatformIO/variants/MARLIN_ARTILLERY_RUBY/startup.S
@@ -1,0 +1,124 @@
+ /**
+  ******************************************************************************
+  * @file      startup_stm32f401xc.s
+  * @author    MCD Application Team
+  * @version   V2.4.2
+  * @date      13-November-2015
+  * @brief     STM32F401xCxx Devices vector table for GCC based toolchains.
+  *            This module performs:
+  *                - Set the initial SP
+  *                - Set the initial PC == Reset_Handler,
+  *                - Set the vector table entries with the exceptions ISR address
+  *                - Branches to main in the C library (which eventually
+  *                  calls main()).
+  *            After Reset the Cortex-M4 processor is in Thread mode,
+  *            priority is Privileged, and the Stack is set to Main.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+  .syntax unified
+  .cpu cortex-m4
+  .fpu softvfp
+  .thumb
+
+/**
+ * @brief  This is the code that gets called when the processor first
+ *          starts execution following a reset event. Only the absolutely
+ *          necessary set is performed, after which the application
+ *          supplied main() routine is called.
+ * @param  None
+ * @retval : None
+ */
+
+  .section  .text.Reset_Handler
+  .globl Reset_Handler
+  .type  Reset_Handler, %function
+Reset_Handler:
+/* Check for magic code at the end of SRAM to detemine whether to jump to DFU */
+  ldr   r0, =0x2000FFF0 // End of SRAM for your CPU
+  ldr   r1, =0xDEADBEEF
+  ldr   r2, [r0, #0]
+  str   r0, [r0, #0] // Invalidate
+  cmp   r2, r1
+  beq   Jump_To_DFU
+
+/* Original Reset_Handler code */
+  ldr   sp, =_estack      /* set stack pointer */
+
+/* Copy the data segment initializers from flash to SRAM */
+  movs  r1, #0
+  b  LoopCopyDataInit
+
+CopyDataInit:
+  ldr  r3, =_sidata
+  ldr  r3, [r3, r1]
+  str  r3, [r0, r1]
+  adds  r1, r1, #4
+
+LoopCopyDataInit:
+  ldr  r0, =_sdata
+  ldr  r3, =_edata
+  adds  r2, r0, r1
+  cmp  r2, r3
+  bcc  CopyDataInit
+  ldr  r2, =_sbss
+  b  LoopFillZerobss
+/* Zero fill the bss segment. */
+FillZerobss:
+  movs  r3, #0
+  str  r3, [r2], #4
+
+LoopFillZerobss:
+  ldr  r3, = _ebss
+  cmp  r2, r3
+  bcc  FillZerobss
+
+/* Call the clock system intitialization function.*/
+  bl  SystemInit
+/* Call static constructors */
+  bl __libc_init_array
+/* Call the application's entry point.*/
+  bl  main
+  bx  lr
+
+Jump_To_DFU:
+  ldr   r0, =0x40023844 // RCC_APB2ENR
+  ldr   r1, =0x00004000 // ENABLE SYSCFG CLOCK
+  str   r1, [r0, #0]
+  ldr   r0, =0x40013800 // SYSCFG_MEMRMP
+  ldr   r1, =0x00000001 // MAP ROM AT ZERO
+  str   r1, [r0, #0]
+  ldr   r0, =0x1FFF0000 // ROM BASE
+  ldr   sp, [r0, #0]    // SP @ +0
+  ldr   r0, [r0, #4]    // PC @ +4
+  bx    r0
+.size  Reset_Handler, .-Reset_Handler
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -617,5 +617,6 @@ build_flags       = ${common_stm32.build_flags}
                     -DSTM32F401xC -DTARGET_STM32F4 -DDISABLE_GENERIC_SERIALUSB -DARDUINO_ARCH_STM32
                     -DUSBD_USE_CDC_COMPOSITE -DUSE_USB_FS
                     -DUSB_PRODUCT=\"Artillery_3D_Printer\"
+                    -DFLASH_DATA_SECTOR=1U -DFLASH_BASE_ADDRESS=0x08004000
 extra_scripts     = ${common_stm32.extra_scripts}
   pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py


### PR DESCRIPTION
### Description

The startup code of Artillery Ruby motherboard was missing due to .gitignore skipping *.s files and ignorecase=true in config, thus `startup.S` was ignored when committing.

I also noticed that `-DFLASH_DATA_SECTOR=1U` and `-DFLASH_BASE_ADDRESS=0x08004000` flags are missing in `ini/stm32f4.ini`, which are required to FLASH_EEPROM_EMULATION to work correctly on the special flash layout of STM32F4.

### Related Issues

#23393