### PR TITLE
Add support for LCD_FOR_MELZI to BTT E3 RRF mainboard

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -144,16 +144,31 @@
 #define TEMP_BED_PIN                        PA1   // Analog Input "TB"
 #define TEMP_0_PIN                          PA0   // Analog Input "TH0"
 
-#if ENABLED(BTT_E3_RRF_IDEX_BOARD)
-  #define TEMP_1_PIN                    FPC9_PIN  // Analog Input "TH1"
-  #define PT100_PIN                     FPC8_PIN  // Analog Input "PT100" (INA826)
-#endif
+  #define X_SERIAL_TX_PIN                   PD6
+  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
 
+  #define Y_SERIAL_TX_PIN                   PD1
+  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
+
+  #define Z_SERIAL_TX_PIN                   PD15
+  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
+
+  #define E0_SERIAL_TX_PIN                  PD11
+  #define E0_SERIAL_RX_PIN      E0_SERIAL_TX_PIN
+
+  #if ENABLED(BTT_E3_RRF_IDEX_BOARD)
+    #define X2_SERIAL_TX_PIN           FPC12_PIN  // X2UART
+    #define X2_SERIAL_RX_PIN    X2_SERIAL_TX_PIN
+
+    #define E1_SERIAL_TX_PIN            FPC6_PIN  // E1UART
+    #define E1_SERIAL_RX_PIN    E1_SERIAL_TX_PIN
+  #endif
 //
 // Heaters / Fans
 //
 #define HEATER_BED_PIN                      PB4   // "HB"
 #define HEATER_0_PIN                        PB3   // "HE0"
+#define HEATER_1_PIN                        PE4   // "HE1"
 
 #if ENABLED(BTT_E3_RRF_IDEX_BOARD)
   #define HEATER_1_PIN                 FPC16_PIN  // "HE1"
@@ -164,6 +179,11 @@
 #ifndef CONTROLLER_FAN_PIN
   #define CONTROLLER_FAN_PIN                PB6   // "FAN1"
 #endif
+//#define FAN1_PIN                            PB6   // "FAN1"
+//CHANGEME! uncomment following
+//#ifndef CONTROLLER_FAN_PIN
+//  #define CONTROLLER_FAN_PIN                PB6   // "FAN1"
+//#endif
 
 #if ENABLED(BTT_E3_RRF_IDEX_BOARD)
   #define FAN1_PIN                     FPC15_PIN  // "FAN0" in IDEX board
@@ -184,14 +204,14 @@
 #endif
 
 /**
- *              BTT E3 RRF
- *                ------
- * (BEEPER)  PE8 |10  9 | PE9  (BTN_ENC)
- * (BTN_EN1) PE7 | 8  7 | RESET
- * (BTN_EN2) PB2   6  5 | PE10 (LCD_D4)
- * (LCD_RS)  PB1 | 4  3 | PE11 (LCD_EN)
- *           GND | 2  1 | 5V
- *                ------
+ *               BTT E3 RRF
+ *                 -----
+ *             5V | 1 2 | GND
+ *  (LCD_EN) PE11 | 3 4 | PB1  (LCD_RS)
+ *  (LCD_D4) PE10 | 5 6   PB2  (BTN_EN2)
+ *          RESET | 7 8 | PE7  (BTN_EN1)
+ * (BTN_ENC) PE9  | 9 10| PE8  (BEEPER)
+ *                 -----
  *                 EXP1
  */
 
@@ -244,15 +264,15 @@
       /**
        * TFTGLCD_PANEL_SPI display pinout
        *
-       *                  Board                       Display
-       *                  ------                       ------
-       * (SD_DET)    PE8 |10  9 | PE9 (BEEPER)     5V |10  9 | GND
-       * (MOD_RESET) PE7 | 8  7 | RESET            -- | 8  7 | (SD_DET)
-       * (SD_CS)     PB2   6  5 | PE10        (MOSI)    6  5 | --
-       * (LCD_CS)    PB1 | 4  3 | PE11        (SD_CS) | 4  3 | (LCD_CS)
-       *             GND | 2  1 | 5V          (SCK)   | 2  1 | (MISO)
-       *                  ------                       ------
-       *                   EXP1                         EXP1
+       *               Board                                      Display
+       *               -----                                       -----
+       *           5V | 1 2 | GND                (SPI1-MISO) MISO | 1 2 | SCK   (SPI1-SCK)
+       * (FREE)  PE11 | 3 4 | PB1  (LCD_CS)      (PE7)     LCD_CS | 3 4 | SD_CS (PB2)
+       * (FREE)  PE10 | 5 6 | PB2  (SD_CS)                 (FREE) | 5 6 | MOSI  (SPI1-MOSI)
+       *        RESET | 7 8 | PE7  (MOD_RESET)   (PE8)     SD_DET | 7 8 | (FREE)
+       * (BEEPER) PE9 | 9 10| PE8  (SD_DET)                   GND | 9 10| 5V
+       *               -----                                       -----
+       *                EXP1                                        EXP1
        *
        * Needs custom cable:
        *
@@ -271,18 +291,71 @@
        */
 
       #define TFTGLCD_CS                    PE7
-
     #endif
+  #elif ENABLED(LCD_FOR_MELZI)
+  
+    //#error "CAUTION! LCD_FOR_MELZI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
+    
+    /**
+    * LCD_FOR_MELZI display pinout
+    * Needs custom cable:
+    *               BTT E3 RRF                         LCD_FOR_MELZI Display Ribbon
+    *                 _____                                         _____
+    *             5V | 1 2 | GND                   (LCD_RS) LCD_CS | 1 2 | ENC_B (BTN_EN1)
+    *  (LCD_EN) PE11 | 3 4 | PB1  (LCD_RS)       (LCD_EN) LCD_DATA | 3 4 | ENC_A (BTN_EN2)
+    *  (LCD_D4) PE10 | 5 6   PB2  (BTN_EN2)      (LCD_D4) LCD_SCLK | 5 6 | ENC_BTN (BTN_ENC)
+    *          RESET | 7 8 | PE7  (BTN_EN1)          (RESET) ESTOP | 7 8 | BEEPER
+    * (BTN_ENC) PE9  | 9 10| PE8  (BEEPER)                     5V  | 9 10| GND
+    *                 -----                                         -----
+    *                 EXP1                                          Ribbon
+    * 
+    * 
+    *    Board   Adapter   Display Ribbon (coming from display)
+    *           _________
+    *   EXP1-1 ----------- EXP1-9
+    *   EXP1-2 ----------- EXP1-10
+    *   EXP1-3 ----------- EXP1-3
+    *   EXP1-4 ----------- EXP1-1
+    *   EXP1-5 ----------- EXP1-5
+    *   EXP1-6 ----------- EXP1-4
+    *   EXP1-7 ----------- EXP1-7
+    *   EXP1-8 ----------- EXP1-8
+    *   EXP1-9 ----------- EXP1-6
+    *  EXP1-10 ----------- EXP1-8
+    */
 
+
+    //#define KILL_PIN                        zz //unused?
+    #define BEEPER_PIN                      PE8
+    #define BTN_ENC                         PE9
+    
+    #define BTN_EN1                         PE7
+    #define BTN_EN2                         PB2
+
+    #define LCD_PINS_RS                     PB1
+    #define LCD_PINS_ENABLE                 PE11
+    #define LCD_PINS_D4                     PE10
+
+    //  LCD_FOR_MELZI default timing is too fast, this works but maybe could be reduced:
+  
+    #define BOARD_ST7920_DELAY_1 200
+    #define BOARD_ST7920_DELAY_2 400
+    #define BOARD_ST7920_DELAY_3 1200
   #else
-    #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, and TFTGLCD_PANEL_(SPI|I2C) are currently supported on the BTT_E3_RRF."
+    #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, LCD_FOR_MELZI, and TFTGLCD_PANEL_(SPI|I2C) are currently supported on the BTT_E3_RRF."
   #endif
 
   // Alter timing for graphical display
-  #if IS_U8GLIB_ST7920
-    #define BOARD_ST7920_DELAY_1              96
-    #define BOARD_ST7920_DELAY_2              48
-    #define BOARD_ST7920_DELAY_3             600
+  #if HAS_MARLINUI_U8GLIB
+    #ifndef BOARD_ST7920_DELAY_1
+      #define BOARD_ST7920_DELAY_1 96
+    #endif
+    #ifndef BOARD_ST7920_DELAY_2
+      #define BOARD_ST7920_DELAY_2 48
+    #endif
+    #ifndef BOARD_ST7920_DELAY_3
+      #define BOARD_ST7920_DELAY_3 600
+    #endif
   #endif
 
 #endif // HAS_WIRED_LCD
@@ -293,15 +366,15 @@
 
   /** FYSETC TFT TFT81050 display pinout
    *
-   *                  Board                          Display
-   *                  ------                          ------
-   * (SD_DET)    PE8 |10  9 | PE9 (BEEPER)        5V |10  9 | GND
-   * (MOD_RESET) PE7 | 8  7 | RESET            RESET | 8  7 | (SD_DET)
-   * (SD_CS)     PB2   6  5 | PE10           (MOSI)  | 6  5 | (LCD_CS)
-   * (LCD_CS)    PB1 | 4  3 | PE11           (SD_CS) | 4  3 | (MOD_RESET)
-   *             GND | 2  1 | 5V             (SCK)   | 2  1 | (MISO)
-   *                  ------                          ------
-   *                   EXP1                            EXP1
+   *               Board                                      Display
+   *               -----                                       -----
+   *           5V | 1 2 | GND                (SPI1-MISO) MISO | 1 2 | SCK   (SPI1-SCK)
+   * (FREE)  PE11 | 3 4 | PB1  (LCD_CS)      (PE7)  MOD_RESET | 3 4 | SD_CS (PB2)
+   * (FREE)  PE10 | 5 6 | PB2  (SD_CS)       (PB1)     LCD_CS | 5 6 | MOSI  (SPI1-MOSI)
+   *        RESET | 7 8 | PE7  (MOD_RESET)   (PE8)     SD_DET | 7 8 | RESET
+   * (BEEPER) PE9 | 9 10| PE8  (SD_DET)                   GND | 9 10| 5V
+   *               -----                                       -----
+   *                EXP1                                        EXP1
    *
    * Needs custom cable:
    *
@@ -338,6 +411,13 @@
 
 #if SD_CONNECTION_IS(ONBOARD)
   #define SDIO_SUPPORT                            // Use SDIO for onboard SD
+  #define SDIO_D0_PIN                       PC8
+  #define SDIO_D1_PIN                       PC9
+  #define SDIO_D2_PIN                       PC10
+  #define SDIO_D3_PIN                       PC11
+  #define SDIO_CK_PIN                       PC12
+  #define SDIO_CMD_PIN                      PD2
+
   //#define SDIO_CLOCK                  48000000
   #define SD_DETECT_PIN                     PC4
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -271,6 +271,7 @@
        */
 
       #define TFTGLCD_CS                    PE7
+
     #endif
   #elif ENABLED(LCD_FOR_MELZI)
   
@@ -317,7 +318,6 @@
     #define LCD_PINS_D4                     PE10
 
     //  LCD_FOR_MELZI default timing is too fast, this works but maybe could be reduced:
-  
     #define BOARD_ST7920_DELAY_1 200
     #define BOARD_ST7920_DELAY_2 400
     #define BOARD_ST7920_DELAY_3 1200

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -305,7 +305,7 @@
     */
 
 
-    //#define KILL_PIN                        zz //unused?
+    //#define KILL_PIN                      
     #define BEEPER_PIN                      PE8
     #define BTN_ENC                         PE9
     

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -197,17 +197,51 @@
 
 #if HAS_WIRED_LCD
 
-  #if ENABLED(CR10_STOCKDISPLAY)
+  #if EITHER(CR10_STOCKDISPLAY, LCD_FOR_MELZI)
 
     #define BEEPER_PIN                      PE8
-    #define BTN_ENC                         PE9
 
+    #define BTN_ENC                         PE9
     #define BTN_EN1                         PE7
     #define BTN_EN2                         PB2
 
     #define LCD_PINS_RS                     PB1
     #define LCD_PINS_ENABLE                 PE11
     #define LCD_PINS_D4                     PE10
+
+    #if ENABLED(LCD_FOR_MELZI)
+
+      #error "CAUTION! LCD_FOR_MELZI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
+
+     /** LCD_FOR_MELZI display pinout
+      *
+      *               BTT E3 RRF                                   Display Ribbon
+      *                ------                                         ------
+      * (BEEPER)  PE8 |10  9 | PE9  (BTN_ENC)                    GND |10  9 | 5V
+      * (BTN_EN1) PE7 | 8  7 | RESET                          BEEPER | 8  7 | ESTOP    (RESET)
+      * (BTN_EN2) PB2   6  5 | PE10 (LCD_D4)       (BTN_ENC) ENC_BTN | 6  5 | LCD_SCLK (LCD_D4)
+      * (LCD_RS)  PB1 | 4  3 | PE11 (LCD_EN)       (BTN_EN2) ENC_A   | 4  3 | LCD_DATA (LCD_EN)
+      *           GND | 2  1 | 5V                  (BTN_EN1) ENC_B   | 2  1 | LCD_CS   (LCD_RS)
+      *                ------                                         ------
+      *                 EXP1                                          Ribbon
+      *
+      * Needs custom cable:
+      *
+      *    Board   Adapter   Display Ribbon (coming from display)
+      *
+      *   EXP1-1 ----------- EXP1-9
+      *   EXP1-2 ----------- EXP1-10
+      *   EXP1-3 ----------- EXP1-3
+      *   EXP1-4 ----------- EXP1-1
+      *   EXP1-5 ----------- EXP1-5
+      *   EXP1-6 ----------- EXP1-4
+      *   EXP1-7 ----------- EXP1-7
+      *   EXP1-8 ----------- EXP1-8
+      *   EXP1-9 ----------- EXP1-6
+      *  EXP1-10 ----------- EXP1-8
+      */
+
+    #endif
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
@@ -273,60 +307,17 @@
       #define TFTGLCD_CS                    PE7
 
     #endif
-  #elif ENABLED(LCD_FOR_MELZI)
-  
-    #error "CAUTION! LCD_FOR_MELZI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
-    
-    /**
-    * LCD_FOR_MELZI display pinout
-    * Needs custom cable:
-    *               BTT E3 RRF                         LCD_FOR_MELZI Display Ribbon
-    *                 _____                                         _____
-    *             5V | 1 2 | GND                   (LCD_RS) LCD_CS | 1 2 | ENC_B (BTN_EN1)
-    *  (LCD_EN) PE11 | 3 4 | PB1  (LCD_RS)       (LCD_EN) LCD_DATA | 3 4 | ENC_A (BTN_EN2)
-    *  (LCD_D4) PE10 | 5 6   PB2  (BTN_EN2)      (LCD_D4) LCD_SCLK | 5 6 | ENC_BTN (BTN_ENC)
-    *          RESET | 7 8 | PE7  (BTN_EN1)          (RESET) ESTOP | 7 8 | BEEPER
-    * (BTN_ENC) PE9  | 9 10| PE8  (BEEPER)                     5V  | 9 10| GND
-    *                 -----                                         -----
-    *                 EXP1                                          Ribbon
-    * 
-    * 
-    *    Board   Adapter   Display Ribbon (coming from display)
-    *           _________
-    *   EXP1-1 ----------- EXP1-9
-    *   EXP1-2 ----------- EXP1-10
-    *   EXP1-3 ----------- EXP1-3
-    *   EXP1-4 ----------- EXP1-1
-    *   EXP1-5 ----------- EXP1-5
-    *   EXP1-6 ----------- EXP1-4
-    *   EXP1-7 ----------- EXP1-7
-    *   EXP1-8 ----------- EXP1-8
-    *   EXP1-9 ----------- EXP1-6
-    *  EXP1-10 ----------- EXP1-8
-    */
 
-
-    //#define KILL_PIN                      
-    #define BEEPER_PIN                      PE8
-    #define BTN_ENC                         PE9
-    
-    #define BTN_EN1                         PE7
-    #define BTN_EN2                         PB2
-
-    #define LCD_PINS_RS                     PB1
-    #define LCD_PINS_ENABLE                 PE11
-    #define LCD_PINS_D4                     PE10
-
-    //  LCD_FOR_MELZI default timing is too fast, this works but maybe could be reduced:
-    #define BOARD_ST7920_DELAY_1 200
-    #define BOARD_ST7920_DELAY_2 400
-    #define BOARD_ST7920_DELAY_3 1200
   #else
     #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, LCD_FOR_MELZI, and TFTGLCD_PANEL_(SPI|I2C) are currently supported on the BTT_E3_RRF."
   #endif
 
   // Alter timing for graphical display
-  #if IS_U8GLIB_ST7920
+  #if ENABLED(LCD_FOR_MELZI)                      // LCD_FOR_MELZI default timing is too fast. This works but may be reduced.
+    #define BOARD_ST7920_DELAY_1             200
+    #define BOARD_ST7920_DELAY_2             400
+    #define BOARD_ST7920_DELAY_3            1200
+  #elif IS_U8GLIB_ST7920
     #define BOARD_ST7920_DELAY_1              96
     #define BOARD_ST7920_DELAY_2              48
     #define BOARD_ST7920_DELAY_3             600
@@ -353,7 +344,7 @@
    * Needs custom cable:
    *
    *    Board   Adapter   Display
-   *           _________
+   *
    *   EXP1-1 ----------- EXP1-10
    *   EXP1-2 ----------- EXP1-9
    *   SPI1-4 ----------- EXP1-6

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -274,7 +274,7 @@
     #endif
   #elif ENABLED(LCD_FOR_MELZI)
   
-    //#error "CAUTION! LCD_FOR_MELZI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
+    #error "CAUTION! LCD_FOR_MELZI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
     
     /**
     * LCD_FOR_MELZI display pinout

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -144,31 +144,16 @@
 #define TEMP_BED_PIN                        PA1   // Analog Input "TB"
 #define TEMP_0_PIN                          PA0   // Analog Input "TH0"
 
-  #define X_SERIAL_TX_PIN                   PD6
-  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
+#if ENABLED(BTT_E3_RRF_IDEX_BOARD)
+  #define TEMP_1_PIN                    FPC9_PIN  // Analog Input "TH1"
+  #define PT100_PIN                     FPC8_PIN  // Analog Input "PT100" (INA826)
+#endif
 
-  #define Y_SERIAL_TX_PIN                   PD1
-  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
-
-  #define Z_SERIAL_TX_PIN                   PD15
-  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
-
-  #define E0_SERIAL_TX_PIN                  PD11
-  #define E0_SERIAL_RX_PIN      E0_SERIAL_TX_PIN
-
-  #if ENABLED(BTT_E3_RRF_IDEX_BOARD)
-    #define X2_SERIAL_TX_PIN           FPC12_PIN  // X2UART
-    #define X2_SERIAL_RX_PIN    X2_SERIAL_TX_PIN
-
-    #define E1_SERIAL_TX_PIN            FPC6_PIN  // E1UART
-    #define E1_SERIAL_RX_PIN    E1_SERIAL_TX_PIN
-  #endif
 //
 // Heaters / Fans
 //
 #define HEATER_BED_PIN                      PB4   // "HB"
 #define HEATER_0_PIN                        PB3   // "HE0"
-#define HEATER_1_PIN                        PE4   // "HE1"
 
 #if ENABLED(BTT_E3_RRF_IDEX_BOARD)
   #define HEATER_1_PIN                 FPC16_PIN  // "HE1"
@@ -179,11 +164,6 @@
 #ifndef CONTROLLER_FAN_PIN
   #define CONTROLLER_FAN_PIN                PB6   // "FAN1"
 #endif
-//#define FAN1_PIN                            PB6   // "FAN1"
-//CHANGEME! uncomment following
-//#ifndef CONTROLLER_FAN_PIN
-//  #define CONTROLLER_FAN_PIN                PB6   // "FAN1"
-//#endif
 
 #if ENABLED(BTT_E3_RRF_IDEX_BOARD)
   #define FAN1_PIN                     FPC15_PIN  // "FAN0" in IDEX board
@@ -204,14 +184,14 @@
 #endif
 
 /**
- *               BTT E3 RRF
- *                 -----
- *             5V | 1 2 | GND
- *  (LCD_EN) PE11 | 3 4 | PB1  (LCD_RS)
- *  (LCD_D4) PE10 | 5 6   PB2  (BTN_EN2)
- *          RESET | 7 8 | PE7  (BTN_EN1)
- * (BTN_ENC) PE9  | 9 10| PE8  (BEEPER)
- *                 -----
+ *              BTT E3 RRF
+ *                ------
+ * (BEEPER)  PE8 |10  9 | PE9  (BTN_ENC)
+ * (BTN_EN1) PE7 | 8  7 | RESET
+ * (BTN_EN2) PB2   6  5 | PE10 (LCD_D4)
+ * (LCD_RS)  PB1 | 4  3 | PE11 (LCD_EN)
+ *           GND | 2  1 | 5V
+ *                ------
  *                 EXP1
  */
 
@@ -264,15 +244,15 @@
       /**
        * TFTGLCD_PANEL_SPI display pinout
        *
-       *               Board                                      Display
-       *               -----                                       -----
-       *           5V | 1 2 | GND                (SPI1-MISO) MISO | 1 2 | SCK   (SPI1-SCK)
-       * (FREE)  PE11 | 3 4 | PB1  (LCD_CS)      (PE7)     LCD_CS | 3 4 | SD_CS (PB2)
-       * (FREE)  PE10 | 5 6 | PB2  (SD_CS)                 (FREE) | 5 6 | MOSI  (SPI1-MOSI)
-       *        RESET | 7 8 | PE7  (MOD_RESET)   (PE8)     SD_DET | 7 8 | (FREE)
-       * (BEEPER) PE9 | 9 10| PE8  (SD_DET)                   GND | 9 10| 5V
-       *               -----                                       -----
-       *                EXP1                                        EXP1
+       *                  Board                       Display
+       *                  ------                       ------
+       * (SD_DET)    PE8 |10  9 | PE9 (BEEPER)     5V |10  9 | GND
+       * (MOD_RESET) PE7 | 8  7 | RESET            -- | 8  7 | (SD_DET)
+       * (SD_CS)     PB2   6  5 | PE10        (MOSI)    6  5 | --
+       * (LCD_CS)    PB1 | 4  3 | PE11        (SD_CS) | 4  3 | (LCD_CS)
+       *             GND | 2  1 | 5V          (SCK)   | 2  1 | (MISO)
+       *                  ------                       ------
+       *                   EXP1                         EXP1
        *
        * Needs custom cable:
        *
@@ -346,16 +326,10 @@
   #endif
 
   // Alter timing for graphical display
-  #if HAS_MARLINUI_U8GLIB
-    #ifndef BOARD_ST7920_DELAY_1
-      #define BOARD_ST7920_DELAY_1 96
-    #endif
-    #ifndef BOARD_ST7920_DELAY_2
-      #define BOARD_ST7920_DELAY_2 48
-    #endif
-    #ifndef BOARD_ST7920_DELAY_3
-      #define BOARD_ST7920_DELAY_3 600
-    #endif
+  #if IS_U8GLIB_ST7920
+    #define BOARD_ST7920_DELAY_1              96
+    #define BOARD_ST7920_DELAY_2              48
+    #define BOARD_ST7920_DELAY_3             600
   #endif
 
 #endif // HAS_WIRED_LCD
@@ -366,15 +340,15 @@
 
   /** FYSETC TFT TFT81050 display pinout
    *
-   *               Board                                      Display
-   *               -----                                       -----
-   *           5V | 1 2 | GND                (SPI1-MISO) MISO | 1 2 | SCK   (SPI1-SCK)
-   * (FREE)  PE11 | 3 4 | PB1  (LCD_CS)      (PE7)  MOD_RESET | 3 4 | SD_CS (PB2)
-   * (FREE)  PE10 | 5 6 | PB2  (SD_CS)       (PB1)     LCD_CS | 5 6 | MOSI  (SPI1-MOSI)
-   *        RESET | 7 8 | PE7  (MOD_RESET)   (PE8)     SD_DET | 7 8 | RESET
-   * (BEEPER) PE9 | 9 10| PE8  (SD_DET)                   GND | 9 10| 5V
-   *               -----                                       -----
-   *                EXP1                                        EXP1
+   *                  Board                          Display
+   *                  ------                          ------
+   * (SD_DET)    PE8 |10  9 | PE9 (BEEPER)        5V |10  9 | GND
+   * (MOD_RESET) PE7 | 8  7 | RESET            RESET | 8  7 | (SD_DET)
+   * (SD_CS)     PB2   6  5 | PE10           (MOSI)  | 6  5 | (LCD_CS)
+   * (LCD_CS)    PB1 | 4  3 | PE11           (SD_CS) | 4  3 | (MOD_RESET)
+   *             GND | 2  1 | 5V             (SCK)   | 2  1 | (MISO)
+   *                  ------                          ------
+   *                   EXP1                            EXP1
    *
    * Needs custom cable:
    *
@@ -411,13 +385,6 @@
 
 #if SD_CONNECTION_IS(ONBOARD)
   #define SDIO_SUPPORT                            // Use SDIO for onboard SD
-  #define SDIO_D0_PIN                       PC8
-  #define SDIO_D1_PIN                       PC9
-  #define SDIO_D2_PIN                       PC10
-  #define SDIO_D3_PIN                       PC11
-  #define SDIO_CK_PIN                       PC12
-  #define SDIO_CMD_PIN                      PD2
-
   //#define SDIO_CLOCK                  48000000
   #define SD_DETECT_PIN                     PC4
 #elif SD_CONNECTION_IS(CUSTOM_CABLE)


### PR DESCRIPTION
### Description

Upgraded my Monoprice Maker Select v2.1 to a 32bit mainboard (BTT E3 RRF v1.1) and discovered the stock LCD (LCD_FOR_MELZI) display wasn't compatible without a custom cable and pins*.h file. I dug into the available documentation for my display, and created the custom cable and added the relevant sections in pins_BTT_E3_RRF.h to allow this display to work, including an error to be raised to alert the user about the need for a custom cable. I believe this custom cable and pins*.h would allow LCD_FOR_MELZI to be used on many other mainboards, but I have only tested against BTT E3 RRF.

### Requirements

- LCD_FOR_MELZI display from stock Wanhao Di3, Monoprice Maker Select, or Cocoon Create
- BTT E3 RRF Mainboard (others may be supported, but not in this PR)
