### PR TITLE
Fix M81 delay feature

### DIFF
--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -153,6 +153,7 @@ void Power::power_off() {
   }
 
   void Power::checkAutoPowerOff() {
+    if (TERN1(POWER_OFF_TIMER, !power_off_time) && TERN1(POWER_OFF_WAIT_FOR_COOLDOWN, !power_off_on_cooldown)) return;
     if (TERN0(POWER_OFF_WAIT_FOR_COOLDOWN, power_off_on_cooldown && is_cooling_needed())) return;
     if (TERN0(POWER_OFF_TIMER, power_off_time && PENDING(millis(), power_off_time))) return;
     power_off();

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -84,14 +84,19 @@ void GcodeSuite::M81() {
     ZERO(thermalManager.saved_fan_speed);
   #endif
 
+  safe_delay(1000); // Wait 1 second before switching off
+
   LCD_MESSAGE_F(MACHINE_NAME " " STR_OFF ".");
 
   bool delayed_power_off = false;
 
   #if ENABLED(POWER_OFF_TIMER)
     if (parser.seenval('D')) {
-      delayed_power_off = true;
-      powerManager.setPowerOffTimer(SEC_TO_MS(parser.value_ushort()));
+      uint16_t delay = parser.value_ushort();
+      if (delay > 1) { // skip already observed 1s delay
+        delayed_power_off = true;
+        powerManager.setPowerOffTimer(SEC_TO_MS(delay - 1));
+      }
     }
   #endif
 
@@ -103,8 +108,6 @@ void GcodeSuite::M81() {
   #endif
 
   if (delayed_power_off) return;
-
-  safe_delay(1000); // Wait 1 second before switching off
 
   #if HAS_SUICIDE
     suicide();


### PR DESCRIPTION
Fix for the recently closed #23396. 

1. If any of the two M81 delay features is enabled, M80 powers the printer on and immediately off.
2. The 1s delay for safely powering down motors is not observed when S1 is used on a cooled down printer.