### PR TITLE
Do G34 "Z Backoff" at full current

### DIFF
--- a/Marlin/src/gcode/calibrate/G34.cpp
+++ b/Marlin/src/gcode/calibrate/G34.cpp
@@ -114,10 +114,6 @@ void GcodeSuite::G34() {
   if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Final Z Move");
   do_blocking_move_to_z(zgrind, MMM_TO_MMS(GANTRY_CALIBRATION_FEEDRATE));
 
-  // Back off end plate, back to normal motion range
-  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Z Backoff");
-  do_blocking_move_to_z(zpounce, MMM_TO_MMS(GANTRY_CALIBRATION_FEEDRATE));
-
   #if _REDUCE_CURRENT
     // Reset current to original values
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Restore Current");
@@ -145,6 +141,10 @@ void GcodeSuite::G34() {
       stepperZ4.rms_current(previous_current_arr[3]);
     #endif
   #endif
+
+  // Back off end plate, back to normal motion range
+  if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Z Backoff");
+  do_blocking_move_to_z(zpounce, MMM_TO_MMS(GANTRY_CALIBRATION_FEEDRATE));
 
   #ifdef GANTRY_CALIBRATION_COMMANDS_POST
     if (DEBUGGING(LEVELING)) DEBUG_ECHOLNPGM("Running Post Commands");


### PR DESCRIPTION
moving pr to a separate branch. Closed https://github.com/MarlinFirmware/Marlin/pull/23442

I use G34 on a corexy with 3 Z-steppers on one driver. 
the zpounce here skips after when using a very low current for the zgrind. 
in my set up, zgrind is lowering the bed so the current requirement is very low. 
zpounce is physically raising the bed and always skips steps here.

my full Z-current is 850ma
my zgrind current is 30ma
bed setup is a corexy with multiple z steppers. 
(specifically a 400mm aluminum+glass bed with aluminum support frame, 3 z-steppers on one driver, 4 CF rods & bushings.)

higer zgrind values cause terrible noise/vibration during grind far before it's high enough to reliably pounce. 
