### PR TITLE
Add LED support (PCA9632) and tune encoder for ULTI_CONTROLLER

### DIFF
--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -209,7 +209,9 @@
   #define LCD_RESET_PIN LCD_PINS_D6 //  This controller need a reset pin
   #define ENCODER_PULSES_PER_STEP 4
   #define ENCODER_STEPS_PER_MENU_ITEM 1
-  #define PCA9632
+  #ifndef PCA9632
+    #define PCA9632
+  #endif
 
 #elif ENABLED(MAKEBOARD_MINI_2_LINE_DISPLAY_1602)
 

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -207,8 +207,9 @@
   #define IS_ULTIPANEL 1
   #define U8GLIB_SSD1309
   #define LCD_RESET_PIN LCD_PINS_D6 //  This controller need a reset pin
-  #define ENCODER_PULSES_PER_STEP 2
-  #define ENCODER_STEPS_PER_MENU_ITEM 2
+  #define ENCODER_PULSES_PER_STEP 4
+  #define ENCODER_STEPS_PER_MENU_ITEM 1
+  #define PCA9632
 
 #elif ENABLED(MAKEBOARD_MINI_2_LINE_DISPLAY_1602)
 


### PR DESCRIPTION
### Description

Ultimaker ULTI_CONTROLLER shipped with Ultimaker 2 has I2C RGB LED functionality using PCA9632 chip. This adds ability to control the LED behind the encoder using M150 or LED_CONTROL_MENU. 

[Ulticontroller Board reference](https://github.com/Ultimaker/Ultimaker2/tree/master/1249_Ulticontroller_Board_(x1))

Equivalent I2C commands to activate the led
```
M260 A96 B00;
M260 A96 B128 S1;
M260 A96 B01;
M260 A96 B28 S1;
M260 A96 B02;
M260 A96 B48 S1;
M260 A96 B03;
M260 A96 B48 S1;
M260 A96 B04;
M260 A96 B60 S1;
M260 A96 B05;
M260 A96 B00 S1;
M260 A96 B06;
M260 A96 B255 S1;
M260 A96 B07;
M260 A96 B00 S1;
M260 A96 B08;
M260 A96 B170 S1;
```
### Requirements

Ultimaker Ulticontroller Board

### Benefits

The LED behind the encoder on the board is now turned on and can be controlled. 

![ulticontroller_led-min](https://user-images.githubusercontent.com/546458/148318096-305729bd-587a-46a3-a7d3-866464b3f4d4.jpg)

### Configurations

Configuration for UMO+ upgraded with UM2+ extrusion upgrade kit and UM2 LCD controller. 
[Configuration_UMO++.zip](https://github.com/MarlinFirmware/Marlin/files/7819042/Configuration_UMO%2B%2B.zip)

Running this configuration on Marlin 2.0.9.3 currently results in unusable stepper motors due to #23454 but the patch is in the issue thread. 