### PR TITLE
Update ULTIMAIN_2 board extruder cooling fan pin

### DIFF
--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -888,16 +888,6 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
     HOTEND_LOOP() {
       if (temp_hotend[e].celsius >= EXTRUDER_AUTO_FAN_TEMPERATURE) {
         SBI(fanState, pgm_read_byte(&fanBit[e]));
-        #if MOTHERBOARD == BOARD_ULTIMAIN_2
-          // For the UM2 the head fan is connected to PJ6, which does not have an Arduino PIN definition. So use direct register access.
-          // https://github.com/Ultimaker/Ultimaker2Marlin/blob/master/Marlin/temperature.cpp#L553
-          SBI(DDRJ, 6); SBI(PORTJ, 6);
-        #endif
-      }
-      else {
-        #if MOTHERBOARD == BOARD_ULTIMAIN_2
-          SBI(DDRJ, 6); CBI(PORTJ, 6);
-        #endif
       }
     }
 

--- a/Marlin/src/pins/ramps/pins_ULTIMAIN_2.h
+++ b/Marlin/src/pins/ramps/pins_ULTIMAIN_2.h
@@ -98,7 +98,7 @@
 #endif
 
 #ifndef E0_AUTO_FAN_PIN
-  #define E0_AUTO_FAN_PIN                     69
+  #define E0_AUTO_FAN_PIN                     77
 #endif
 
 //


### PR DESCRIPTION
### Description

Set  (UMO+/UM2/UM2+) ULTIMAIN_2 board extruder cooling fan to fastio pin 77 which maps to atmega2560 pin 69 PJ6. 

Previously in #23194, PJ6 was directly triggered in `temperature.cpp` due to PJ6 having no Arduino pin mapping but it is mapped in `fastio_1280.h`. This change to use fastio pin mapping allows clean up of `temperature.cpp` code which was Ultimaker 2 specific. 

### Requirements

ULTIMAIN_2

### Benefits

Cleaner code and compatibility

### Configurations

Configuration for UMO+ upgraded with UM2+ extrusion upgrade kit and UM2 LCD controller. 
[Configuration_UMO++.zip](https://github.com/MarlinFirmware/Marlin/files/7819042/Configuration_UMO%2B%2B.zip)

### Related Issues

Improves #23194