### PR TITLE
Fix for preheat selecting the wrong device

### DIFF
--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -496,14 +496,15 @@ public:
   #endif
 
   #if HAS_PREHEAT
-    enum PreheatMask : uint8_t { PM_HOTEND = _BV(0), PM_BED = _BV(1), PM_FAN = _BV(2), PM_CHAMBER = _BV(3) };
+    enum PreheatMask : uint8_t { PM_HOTEND = 0, PM_BED = 1, PM_FAN = 2, PM_CHAMBER = 3 }; //these values are the bit indexes used, NOT the actual values. 
+                                                                                          //Since the TEST() macro does bit-shifting on the second value, doing so here as well causes mismatches.
     static preheat_t material_preset[PREHEAT_COUNT];
     static PGM_P get_preheat_label(const uint8_t m);
     static void apply_preheat(const uint8_t m, const uint8_t pmask, const uint8_t e=active_extruder);
-    static void preheat_set_fan(const uint8_t m) { TERN_(HAS_FAN, apply_preheat(m, PM_FAN)); }
-    static void preheat_hotend(const uint8_t m, const uint8_t e=active_extruder) { TERN_(HAS_HOTEND, apply_preheat(m, PM_HOTEND)); }
-    static void preheat_hotend_and_fan(const uint8_t m, const uint8_t e=active_extruder) { preheat_hotend(m, e); preheat_set_fan(m); }
-    static void preheat_bed(const uint8_t m) { TERN_(HAS_HEATED_BED, apply_preheat(m, PM_BED)); }
+    static void preheat_set_fan(const uint8_t m) { TERN_(HAS_FAN, apply_preheat(m, _BV(PM_FAN))); }
+    static void preheat_hotend(const uint8_t m, const uint8_t e=active_extruder) { TERN_(HAS_HOTEND, apply_preheat(m, _BV(PM_HOTEND))); }
+    static void preheat_hotend_and_fan(const uint8_t m, const uint8_t e=active_extruder) { TERN_(ANY(HAS_HOTEND, HAS_FAN), apply_preheat(m, _BV(PM_HOTEND) + _BV(PM_FAN), e)); } //the check inside apply_preheat will mask off non-available devices
+    static void preheat_bed(const uint8_t m) { TERN_(HAS_HEATED_BED, apply_preheat(m, _BV(PM_BED))); }
     static void preheat_all(const uint8_t m) { apply_preheat(m, 0xFF); }
   #endif
 

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -503,7 +503,7 @@ public:
     static void apply_preheat(const uint8_t m, const uint8_t pmask, const uint8_t e=active_extruder);
     static void preheat_set_fan(const uint8_t m) { TERN_(HAS_FAN, apply_preheat(m, _BV(PM_FAN))); }
     static void preheat_hotend(const uint8_t m, const uint8_t e=active_extruder) { TERN_(HAS_HOTEND, apply_preheat(m, _BV(PM_HOTEND))); }
-    static void preheat_hotend_and_fan(const uint8_t m, const uint8_t e=active_extruder) { TERN_(ANY(HAS_HOTEND, HAS_FAN), apply_preheat(m, _BV(PM_HOTEND) + _BV(PM_FAN), e)); } //the check inside apply_preheat will mask off non-available devices
+    static void preheat_hotend_and_fan(const uint8_t m, const uint8_t e=active_extruder) { preheat_hotend(m, e); preheat_set_fan(m); }
     static void preheat_bed(const uint8_t m) { TERN_(HAS_HEATED_BED, apply_preheat(m, _BV(PM_BED))); }
     static void preheat_all(const uint8_t m) { apply_preheat(m, 0xFF); }
   #endif


### PR DESCRIPTION
Originally caused by the TEST() macro bitshifting the second value once more before comparison
Fix changes values sent to the macro, and performs the bitshifting as part of function invocation

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

The current workflow is selecting the wrong device when put through the function apply_preheat() and its shortcuts. This is caused by the apply_preheat() function using the TEST() macro, which bit-shifts the second argument passed to it before comparison. Rather than modify the macro (since it is used in other parts of Marlin), it is better to manipulate the constants used. 

Previously, the masking values were constantly increasing by powers of two via bitshifting. However, the TEST() macro would then bit-shift them again as part of its comparison. This PR changes them to increasing by one, such that the only round of bitshifting done is in the TEST() macro. To facilitate this, the pmask value is bit-shifted at the time of calling the shortcut functions. 

Bitshift operations performed
| |pmask|compared constant|
|---|---|---|
| Current | One (as part of definition of the constants) | Two (one as definition of constants, one as part of TEST() macro) |
| PR | One (as part of the function call to apply_preheat() ) | One (as part of TEST() macro) |

### Requirements

Any board/interface using these functions in marlinui.cpp/marlinui.h

### Benefits

This ensures that the preheat commands are run on the expected devices (bed, nozzle, fan). Before changes, a call to preheat_hotend does nothing, while a call to preheat_bed will trigger preheat on the hotend, and a call to preheat_set_fan will trigger the bed. 

### Configurations

N/A

### Related Issues

Fixes Jyers/Marlin#1651
