### PR TITLE
Wait for cooldown when power-off from menu

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1553,10 +1553,14 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
     TERN_(HAS_LCD_MENU, return_to_status());
   }
 
-  #if BOTH(PSU_CONTROL, PS_OFF_CONFIRM)
+  #if ENABLED(PSU_CONTROL)
     void MarlinUI::poweroff() {
-      queue.inject(F("M81"));
-      goto_previous_screen();
+      #if ENABLED(POWER_OFF_WAIT_FOR_COOLDOWN)
+        queue.inject(F("M81 S"));
+      #else
+        queue.inject(F("M81"));
+      #endif
+      TERN_(HAS_LCD_MENU, return_to_status());
     }
   #endif
 

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -373,7 +373,7 @@ public:
     static void resume_print();
     static void flow_fault();
 
-    #if BOTH(PSU_CONTROL, PS_OFF_CONFIRM)
+    #if ENABLED(PSU_CONTROL)
       static void poweroff();
     #endif
 

--- a/Marlin/src/lcd/menu/menu_main.cpp
+++ b/Marlin/src/lcd/menu/menu_main.cpp
@@ -380,7 +380,7 @@ void menu_main() {
           GET_TEXT(MSG_SWITCH_PS_OFF), (const char *)nullptr, PSTR("?")
         );
       #else
-        GCODES_ITEM(MSG_SWITCH_PS_OFF, PSTR("M81"));
+        ACTION_ITEM(MSG_SWITCH_PS_OFF, ui.poweroff);
       #endif
     else
       GCODES_ITEM(MSG_SWITCH_PS_ON, PSTR("M80"));


### PR DESCRIPTION
### Description

This makes two changes in the power-off functionality :
- if `POWER_OFF_WAIT_FOR_COOLDOWN` is defined, execute `M81 S` instead of `M81` when using "Power off" menu action
- wether `PS_OFF_CONFIRM` is defined or not, go back to main screen, in order to see the "Power off" status message


### Requirements

Only applies to LCD

### Benefits

Prevent heat creep on manual shutdown, and confirm the command has been taken in account.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
