### PR TITLE
Longer3D: Keep FAN_SOFT_PWM as common default

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -89,22 +89,19 @@
 #define HEATER_BED_PIN                      PA8   // pin 67 (Hot Bed Mosfet)
 
 #define FAN_PIN                             PA15  // pin 77 (4cm Fan)
-#ifdef MAPLE_STM32F1
+
+#if TERN(MAPLE_STM32F1, ENABLED(FAN_SOFT_PWM), ENABLED(FAST_PWM_FAN)) && FAN_MIN_PWM < 5 // Required to avoid issues with heating or STLink
+  #error "FAN_MIN_PWM must be 5 or higher."       // Fan will not start in 1-30 range
+#endif
+
+#if defined(MAPLE_STM32F1) || DISABLED(FAST_PWM_FAN) // STM32 HAL required to allow TIMER2 Hardware PWM
   #define FAN_SOFT_PWM_REQUIRED
-  #if ENABLED(FAN_SOFT_PWM) && FAN_MIN_PWM < 5    // Required to avoid issues with heating or STLink
-    #error "FAN_MIN_PWM must be 5 or higher."     // Fan will not start in 1-30 range
-  #endif
-#elif ENABLED(FAST_PWM_FAN)                       // STM32 HAL required to allow TIMER2 Hardware PWM
+#else
   #if FAST_PWM_FAN_FREQUENCY <= 1000              // Default 1000 is noisy, max 65K (uint16)
     #error "FAST_PWM_FAN_FREQUENCY must be greater than 1000."
   #elif FAST_PWM_FAN_FREQUENCY > 65535
     #error "FAST_PWM_FAN_FREQUENCY must be less than 65536."
   #endif
-  #if FAN_MIN_PWM < 5
-    #error "FAN_MIN_PWM must be 5 or higher."
-  #endif
-#else
-  #define FAN_SOFT_PWM_REQUIRED
 #endif
 
 //#define BEEPER_PIN                        PD13  // pin 60 (Servo PWM output 5V/GND on Board V0G+) made for BL-Touch sensor

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -95,8 +95,10 @@
     #error "FAN_MIN_PWM must be 5 or higher."     // Fan will not start in 1-30 range
   #endif
 #elif ENABLED(FAST_PWM_FAN)                       // STM32 HAL required to allow TIMER2 Hardware PWM
-  #if FAST_PWM_FAN_FREQUENCY == 1000              // Default 1000 is noisy, max 65K (uint16)
-    #error "FAST_PWM_FAN_FREQUENCY must be set to 31400."
+  #if FAST_PWM_FAN_FREQUENCY <= 1000              // Default 1000 is noisy, max 65K (uint16)
+    #error "FAST_PWM_FAN_FREQUENCY must be greater than 1000."
+  #elif FAST_PWM_FAN_FREQUENCY > 65535
+    #error "FAST_PWM_FAN_FREQUENCY must be less than 65536."
   #endif
   #if FAN_MIN_PWM < 5
     #error "FAN_MIN_PWM must be 5 or higher."

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -91,18 +91,18 @@
 #define FAN_PIN                             PA15  // pin 77 (4cm Fan)
 #ifdef MAPLE_STM32F1
   #define FAN_SOFT_PWM_REQUIRED
-  #if ENABLED(FAN_SOFT_PWM) && FAN_MIN_PWM < 35   // Required to avoid issues with heating or STLink
-    #error "FAN_MIN_PWM must be 35 or higher."    // Fan will not start in 1-30 range
+  #if ENABLED(FAN_SOFT_PWM) && FAN_MIN_PWM < 5    // Required to avoid issues with heating or STLink
+    #error "FAN_MIN_PWM must be 5 or higher."     // Fan will not start in 1-30 range
   #endif
-#elif ENABLED(FAST_PWM_FAN)
-  #if FAST_PWM_FAN_FREQUENCY != 31400             // Default 1000 is noisy, max 65K (uint16)
+#elif ENABLED(FAST_PWM_FAN)                       // STM32 HAL required to allow TIMER2 Hardware PWM
+  #if FAST_PWM_FAN_FREQUENCY == 1000              // Default 1000 is noisy, max 65K (uint16)
     #error "FAST_PWM_FAN_FREQUENCY must be set to 31400."
   #endif
   #if FAN_MIN_PWM < 5
     #error "FAN_MIN_PWM must be 5 or higher."
   #endif
 #else
-  #error "FAST_PWM_FAN required to allow TIMER2 Hardware PWM."
+  #define FAN_SOFT_PWM_REQUIRED
 #endif
 
 //#define BEEPER_PIN                        PD13  // pin 60 (Servo PWM output 5V/GND on Board V0G+) made for BL-Touch sensor

--- a/buildroot/share/PlatformIO/scripts/offset_and_rename.py
+++ b/buildroot/share/PlatformIO/scripts/offset_and_rename.py
@@ -57,7 +57,6 @@ if pioutil.is_pio_build():
 
 		def rename_target(source, target, env):
 			firmware = os.path.join(target[0].dir.path, board.get("build.rename"))
-			import shutil
-			shutil.copy(target[0].path, firmware)
+			os.rename(target[0].path, firmware)
 
 		marlin.add_post_action(rename_target)


### PR DESCRIPTION
Reduce the fan config restrictions... user tuning should not create errors...
