### PR TITLE
Fix EEPROM_INIT_NOW hash test result

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -1584,7 +1584,7 @@ void MarlinSettings::postprocess() {
       #if ENABLED(EEPROM_INIT_NOW)
         uint32_t stored_hash;
         EEPROM_READ_ALWAYS(stored_hash);
-        if (stored_hash != build_hash) { EEPROM_FINISH(); return true; }
+        if (stored_hash != build_hash) { EEPROM_FINISH(); return false; }
       #endif
 
       uint16_t stored_crc;


### PR DESCRIPTION
Fix the issue: https://github.com/MarlinFirmware/Marlin/issues/23436
[EEPROM_INIT_NOW] Need better understanding of functionality and possible homing defect?


