### PR TITLE
report_current_position_moving() with LINEAR_AXES >= 4

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -341,6 +341,9 @@
 #define STR_X "X"
 #define STR_Y "Y"
 #define STR_Z "Z"
+#define STR_I AXIS4_STR
+#define STR_J AXIS5_STR
+#define STR_K AXIS6_STR
 #define STR_E "E"
 #if IS_KINEMATIC
   #define STR_A "A"
@@ -467,10 +470,6 @@
 #else
   #define AXIS6_STR   ""
 #endif
-
-#define STR_I AXIS4_STR
-#define STR_J AXIS5_STR
-#define STR_K AXIS6_STR
 
 #if EITHER(HAS_MARLINUI_HD44780, IS_TFTGLCD_PANEL)
 

--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -341,9 +341,6 @@
 #define STR_X "X"
 #define STR_Y "Y"
 #define STR_Z "Z"
-#define STR_I AXIS4_STR
-#define STR_J AXIS5_STR
-#define STR_K AXIS6_STR
 #define STR_E "E"
 #if IS_KINEMATIC
   #define STR_A "A"
@@ -470,6 +467,10 @@
 #else
   #define AXIS6_STR   ""
 #endif
+
+#define STR_I AXIS4_STR
+#define STR_J AXIS5_STR
+#define STR_K AXIS6_STR
 
 #if EITHER(HAS_MARLINUI_HD44780, IS_TFTGLCD_PANEL)
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -261,11 +261,12 @@ void report_current_position_projected() {
    * Output the current position (processed) to serial while moving
    */
   void report_current_position_moving() {
-
     get_cartesian_from_steppers();
     const xyz_pos_t lpos = cartes.asLogical();
+
     SERIAL_ECHOPGM_P(
-      LIST_N(DOUBLE(LINEAR_AXES),
+      LIST_N(DOUBLE(LOGICAL_AXES),
+        SP_E_LBL, current_position.e,
            X_LBL, lpos.x,
         SP_Y_LBL, lpos.y,
         SP_Z_LBL, lpos.z,
@@ -273,16 +274,10 @@ void report_current_position_projected() {
         SP_J_LBL, lpos.j,
         SP_K_LBL, lpos.k
       )
-      #if HAS_EXTRUDERS
-        , SP_E_LBL, current_position.e
-      #endif
     );
 
     stepper.report_positions();
-    #if IS_SCARA
-      scara_report_positions();
-    #endif
-
+    TERN_(IS_SCARA, scara_report_positions());
     report_current_grblstate_moving();
   }
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -217,9 +217,7 @@ void report_real_position() {
   xyze_pos_t npos = LOGICAL_AXIS_ARRAY(
     planner.get_axis_position_mm(E_AXIS),
     cartes.x, cartes.y, cartes.z,
-    planner.get_axis_position_mm(I_AXIS),
-    planner.get_axis_position_mm(J_AXIS),
-    planner.get_axis_position_mm(K_AXIS)
+    cartes.i, cartes.j, cartes.k
   );
 
   TERN_(HAS_POSITION_MODIFIERS, planner.unapply_modifiers(npos, true));
@@ -266,16 +264,17 @@ void report_current_position_projected() {
 
     get_cartesian_from_steppers();
     const xyz_pos_t lpos = cartes.asLogical();
-    SERIAL_ECHOPGM(
-      "X:", lpos.x
-      #if HAS_Y_AXIS
-        , " Y:", lpos.y
-      #endif
-      #if HAS_Z_AXIS
-        , " Z:", lpos.z
-      #endif
+    SERIAL_ECHOPGM_P(
+      LIST_N(DOUBLE(LINEAR_AXES),
+           X_LBL, lpos.x,
+        SP_Y_LBL, lpos.y,
+        SP_Z_LBL, lpos.z,
+        SP_I_LBL, lpos.i,
+        SP_J_LBL, lpos.j,
+        SP_K_LBL, lpos.k
+      )
       #if HAS_EXTRUDERS
-        , " E:", current_position.e
+        , SP_E_LBL, current_position.e
       #endif
     );
 


### PR DESCRIPTION
### Description

Adds output for extra axes (IJK) to the function `report_current_position_moving()`. The output depends on the `LINEAR_AXES` and `EXTRUDERS` setting. output is created for each configured axis. The format is now:
```
X:<cartes.x> [Y:<cartes.y>] [Z:<cartes.z>] [<AXIS4_NAME>:<cartes.i>] [<AXIS5_NAME>:<cartes.j>] [<AXIS6_NAME>:<cartes.k>] [E:<e_pos>]
```
Here, brackets (`[]`) denote optional output. 
`<AXIS4_NAME>` `<AXIS5_NAME>`  and `<AXIS6_NAME>`  are unique axis letters as defined in Configuration.h. These can be one of `A`, `B`, `C`, `U`, `V`, or `W`. 
`<cartes.x>`, `<cartes.y>`, `<cartes.z>` are the current positions in mm along the X, Y, Z axes that constitute the cartesian machine space.
`<cartes.i>`, `<cartes.j>`, `<cartes.k>` are the current positions along the 4th, 5th, and 6th axis in mm (for linear axes) or degrees (for rotational axes).
 `<e_pos>` is the current extruder position in mm.

### Requirements

LINEAR_AXES >= 4 AND (FULL_REPORT_TO_HOST_FEATURE OR REALTIME_REPORTING_COMMANDS)

### Benefits

user or third party software can get feedback about the current position

### Configurations

none

### Related Issues

Reported and discussed on discord dev-talk