### PR TITLE
🔨 E3V2 Enhanced UI shortened print messages

### DIFF
--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -456,6 +456,7 @@ namespace Language_en {
   LSTR MSG_PRINT_PAUSED                   = _UxGT("Print Paused");
   LSTR MSG_PRINTING                       = _UxGT("Printing...");
   LSTR MSG_STOPPING                       = _UxGT("Stopping...");
+  LSTR MSG_REMAINING_TIME                 = _UxGT("Remaining");
   LSTR MSG_PRINT_ABORTED                  = _UxGT("Print Aborted");
   LSTR MSG_PRINT_DONE                     = _UxGT("Print Done");
   LSTR MSG_NO_MOVE                        = _UxGT("No Move.");
@@ -595,12 +596,11 @@ namespace Language_en {
 
   #if LCD_WIDTH >= 20 || HAS_DWIN_E3V2
     LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("No media inserted.");
-    LSTR MSG_REMAINING_TIME               = _UxGT("Remaining time");
     LSTR MSG_PLEASE_WAIT_REBOOT           = _UxGT("Please wait until reboot. ");
     LSTR MSG_PLEASE_PREHEAT               = _UxGT("Please preheat the hot end.");
     LSTR MSG_INFO_PRINT_COUNT_RESET       = _UxGT("Reset Print Count");
     LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Print Count");
-    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total Print Time");
+    LSTR MSG_INFO_PRINT_TIME              = _UxGT("Print Time");
     LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Longest Job Time");
     LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruded Total");
     LSTR MSG_COLORS_GET                   = _UxGT("Get Color");
@@ -616,7 +616,6 @@ namespace Language_en {
     LSTR MSG_MEDIA_NOT_INSERTED           = _UxGT("No Media");
     LSTR MSG_PLEASE_PREHEAT               = _UxGT("Please Preheat");
     LSTR MSG_INFO_PRINT_COUNT             = _UxGT("Prints");
-    LSTR MSG_REMAINING_TIME               = _UxGT("Remaining");
     LSTR MSG_INFO_PRINT_TIME              = _UxGT("Total");
     LSTR MSG_INFO_PRINT_LONGEST           = _UxGT("Longest");
     LSTR MSG_INFO_PRINT_FILAMENT          = _UxGT("Extruded");


### PR DESCRIPTION
### Description

It fixes the issue reported by @mriscoc [here](https://github.com/MarlinFirmware/Marlin/pull/23424#issuecomment-1008676886).

I would like to apologize for any trouble I may have caused from PR #23424.

### Benefits

It makes the text displayed during print time shorter so it can actually fit in the display.

### Related Issues

I hope I haven't broken anything this time and this does actually fix the issue. Unfortunately I can't test this right now as I'm off-site. Feel free to tell me if anything is wrong. 

I'm not sure if this is the right way to do it, but I want to ask @thinkyhead what, in his opinion, needs to be done in order to support Greek, Cyrillic, etc... [Link](https://github.com/MarlinFirmware/Marlin/pull/23424#issuecomment-1008111766) to the original message for more information on the subject. Also is it worth localizing Creality and Jyer's UI as well? Maybe not a priority right now, but doing so, we will simplify the localisation even more as some messages that are present only on the Ender 3 V2 might need to be moved along the other Ender 3 V2 specific messages and not be defined globally.
