### PR TITLE
Make get_remaining_time available

### DIFF
--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -293,20 +293,20 @@ public:
       static void set_progress(const progress_t p) { progress_override = _MIN(p, 100U * (PROGRESS_SCALE)); }
       static void set_progress_done() { progress_override = (PROGRESS_MASK + 1U) + 100U * (PROGRESS_SCALE); }
       static void progress_reset() { if (progress_override & (PROGRESS_MASK + 1U)) set_progress(0); }
-      #if ENABLED(SHOW_REMAINING_TIME)
-        static uint32_t _calculated_remaining_time() {
-          const duration_t elapsed = print_job_timer.duration();
-          const progress_t progress = _get_progress();
-          return progress ? elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress : 0;
-        }
-        #if ENABLED(USE_M73_REMAINING_TIME)
-          static uint32_t remaining_time;
-          FORCE_INLINE static void set_remaining_time(const uint32_t r) { remaining_time = r; }
-          FORCE_INLINE static uint32_t get_remaining_time() { return remaining_time ?: _calculated_remaining_time(); }
-          FORCE_INLINE static void reset_remaining_time() { set_remaining_time(0); }
-        #else
-          FORCE_INLINE static uint32_t get_remaining_time() { return _calculated_remaining_time(); }
-        #endif
+    #endif
+    #if ENABLED(SHOW_REMAINING_TIME)
+      static uint32_t _calculated_remaining_time() {
+        const duration_t elapsed = print_job_timer.duration();
+        const progress_t progress = _get_progress();
+        return progress ? elapsed.value * (100 * (PROGRESS_SCALE) - progress) / progress : 0;
+      }
+      #if ENABLED(USE_M73_REMAINING_TIME)
+        static uint32_t remaining_time;
+        FORCE_INLINE static void set_remaining_time(const uint32_t r) { remaining_time = r; }
+        FORCE_INLINE static uint32_t get_remaining_time() { return remaining_time ?: _calculated_remaining_time(); }
+        FORCE_INLINE static void reset_remaining_time() { set_remaining_time(0); }
+      #else
+        FORCE_INLINE static uint32_t get_remaining_time() { return _calculated_remaining_time(); }
       #endif
     #endif
     static progress_t _get_progress();


### PR DESCRIPTION
The get_remaining_time() inline function only seems to get defined if LCD_SET_PROGRESS_MANUALLY is defined.  This causes a compile error if you've selected SDSUPPORT (which sets HAS_PRINT_PROGRESS) but want the calculated remaining time to be displayed (i.e. not manual)

This change moves the definition of the inline function outside the #if ENABLED(LCD_SET_PROGRESS_MANUALLY) block so it gets defined.

### Requirements

This change is only apparent if you have SDSUPPORT and SHOW_REMAINING_TIME enabled and are using Marlin UI on an LCD

### Benefits

Allows compile without error 

### Configurations

Using these Configs and platform def.

[configs.zip](https://github.com/MarlinFirmware/Marlin/files/7848930/configs.zip)

