### PR TITLE
Add TIMER0B duty only configuration

### DIFF
--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -187,7 +187,7 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
     Timer timer = get_pwm_timer(pin);
     if (timer.isPWM) {
       if (timer.n == 0) {
-        TCCR0A |= _BV(COM0B1); // Onyy allow a TIMER0B select and OCR0B duty update for pin D4 outputs no frequency changes are permited.
+        TCCR0A |= _BV(COM0B1); // Only allow a TIMER0B select and OCR0B duty update for pin D4 outputs no frequency changes are permited.
         OCR0B = v;
       } else {
       _SET_COMnQ(timer.TCCRnQ, SUM_TERN(HAS_TCCR2, timer.q, timer.q == 2), COM_CLEAR_SET + invert);   // COM20 is on bit 4 of TCCR2, so +1 for q==2

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -69,7 +69,7 @@ Timer get_pwm_timer(const pin_t pin) {
     break;    // Protect reserved timers (TIMER0 & TIMER1)
 
     #ifdef TCCR0A
-      case TIMER0B:   //This is a protected timer, however we will allow duty sets on OCR0B for pin D4 output and nothing else.
+      case TIMER0B:   // Protected timer, but allow setting the duty cycle on OCR0B for pin D4 only
         return Timer({ { &TCCR0A, nullptr, nullptr }, { (uint16_t*)&OCR0B, nullptr, nullptr }, nullptr, 0, 0, true, true });
     #endif
 
@@ -77,7 +77,7 @@ Timer get_pwm_timer(const pin_t pin) {
       case TIMER2:
         return Timer({ { &TCCR2, nullptr, nullptr }, { (uint16_t*)&OCR2, nullptr, nullptr }, nullptr, 2, 0, true, false });
     #elif ENABLED(USE_OCR2A_AS_TOP)
-      case TIMER2A: break; // protect TIMER2A since its OCR is used by TIMER2B
+      case TIMER2A: break; // Protect TIMER2A since its OCR is used by TIMER2B
       case TIMER2B:
         return Timer({ { &TCCR2A, &TCCR2B, nullptr }, { (uint16_t*)&OCR2A, (uint16_t*)&OCR2B, nullptr }, nullptr, 2, 1, true, false });
     #elif defined(TCCR2A)

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -178,7 +178,7 @@ void set_pwm_frequency(const pin_t pin, const uint16_t f_desired) {
 
 void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255*/, const bool invert/*=false*/) {
   // If v is 0 or v_size (max), digitalWrite to LOW or HIGH.
-  // Note that digitalWrite also disables pwm output for us (sets COM bit to 0)
+  // Note that digitalWrite also disables PWM output for us (sets COM bit to 0)
   if (v == 0)
     digitalWrite(pin, invert);
   else if (v == v_size)
@@ -190,9 +190,9 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
         TCCR0A |= _BV(COM0B1); // Only allow a TIMER0B select and OCR0B duty update for pin D4 outputs no frequency changes are permited.
         OCR0B = v;
       }
-      else if (timer.isProtected == false) {
-        _SET_COMnQ(timer.TCCRnQ, SUM_TERN(HAS_TCCR2, timer.q, timer.q == 2), COM_CLEAR_SET + invert);   // COM20 is on bit 4 of TCCR2, so +1 for q==2
+      else if (!timer.isProtected) {
         const uint16_t top = timer.n == 2 ? TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255) : *timer.ICRn;
+        _SET_COMnQ(timer.TCCRnQ, SUM_TERN(HAS_TCCR2, timer.q, timer.q == 2), COM_CLEAR_SET + invert);   // COM20 is on bit 4 of TCCR2, so +1 for q==2
         _SET_OCRnQ(timer.OCRnQ, timer.q, uint16_t(uint32_t(v) * top / v_size)); // Scale 8/16-bit v to top value
       }
     }

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -190,7 +190,7 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
         TCCR0A |= _BV(COM0B1); // Only allow a TIMER0B select and OCR0B duty update for pin D4 outputs no frequency changes are permited.
         OCR0B = v;
       }
-      else {
+      else if (timer.isProtected == false) {
         _SET_COMnQ(timer.TCCRnQ, SUM_TERN(HAS_TCCR2, timer.q, timer.q == 2), COM_CLEAR_SET + invert);   // COM20 is on bit 4 of TCCR2, so +1 for q==2
         const uint16_t top = timer.n == 2 ? TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255) : *timer.ICRn;
         _SET_OCRnQ(timer.OCRnQ, timer.q, uint16_t(uint32_t(v) * top / v_size)); // Scale 8/16-bit v to top value

--- a/Marlin/src/HAL/AVR/fast_pwm.cpp
+++ b/Marlin/src/HAL/AVR/fast_pwm.cpp
@@ -189,10 +189,11 @@ void set_pwm_duty(const pin_t pin, const uint16_t v, const uint16_t v_size/*=255
       if (timer.n == 0) {
         TCCR0A |= _BV(COM0B1); // Only allow a TIMER0B select and OCR0B duty update for pin D4 outputs no frequency changes are permited.
         OCR0B = v;
-      } else {
-      _SET_COMnQ(timer.TCCRnQ, SUM_TERN(HAS_TCCR2, timer.q, timer.q == 2), COM_CLEAR_SET + invert);   // COM20 is on bit 4 of TCCR2, so +1 for q==2
-      const uint16_t top = timer.n == 2 ? TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255) : *timer.ICRn;
-      _SET_OCRnQ(timer.OCRnQ, timer.q, uint16_t(uint32_t(v) * top / v_size)); // Scale 8/16-bit v to top value
+      }
+      else {
+        _SET_COMnQ(timer.TCCRnQ, SUM_TERN(HAS_TCCR2, timer.q, timer.q == 2), COM_CLEAR_SET + invert);   // COM20 is on bit 4 of TCCR2, so +1 for q==2
+        const uint16_t top = timer.n == 2 ? TERN(USE_OCR2A_AS_TOP, *timer.OCRnQ[0], 255) : *timer.ICRn;
+        _SET_OCRnQ(timer.OCRnQ, timer.q, uint16_t(uint32_t(v) * top / v_size)); // Scale 8/16-bit v to top value
       }
     }
     else

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -107,10 +107,6 @@
   #include "../feature/spindle_laser.h"
 #endif
 
-#if HAS_FAN && DISABLED(LASER_SYNCHRONOUS_M106_M107)
-  #define HAS_TAIL_FAN_SPEED 1
-#endif
-
 // Delay for delivery of first block to the stepper ISR, if the queue contains 2 or
 // fewer movements. The delay is measured in milliseconds, and must be less than 250ms
 #define BLOCK_DELAY_FOR_1ST_MOVE 100
@@ -1308,9 +1304,10 @@ void Planner::check_axes_activity() {
     xyze_bool_t axis_active = { false };
   #endif
 
-  #if HAS_TAIL_FAN_SPEED
-    static uint8_t tail_fan_speed[FAN_COUNT];
-    static bool fans_need_update = true;  // Init fan speed once on startup
+  #if HAS_FAN && DISABLED(LASER_SYNCHRONOUS_M106_M107)
+    #define HAS_TAIL_FAN_SPEED 1
+    static uint8_t tail_fan_speed[FAN_COUNT] = ARRAY_N_1(FAN_COUNT, 128);
+    bool fans_need_update = false;
   #endif
 
   #if ENABLED(BARICUDA)

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -206,7 +206,6 @@ skew_factor_t Planner::skew_factor; // Initialized by settings.load()
 // private:
 
 xyze_long_t Planner::position{0};
-TERN_(HAS_TAIL_FAN_SPEED, bool fans_need_update = true);   // Init fan speed on startup
 
 uint32_t Planner::acceleration_long_cutoff;
 
@@ -1311,6 +1310,7 @@ void Planner::check_axes_activity() {
 
   #if HAS_TAIL_FAN_SPEED
     static uint8_t tail_fan_speed[FAN_COUNT];
+    static bool fans_need_update = true;  // Init fan speed once on startup
   #endif
 
   #if ENABLED(BARICUDA)
@@ -1395,7 +1395,12 @@ void Planner::check_axes_activity() {
   // Update Fan speeds
   // Only if synchronous M106/M107 is disabled
   //
-  TERN_(HAS_TAIL_FAN_SPEED, if (fans_need_update) sync_fan_speeds(tail_fan_speed));
+  #if HAS_TAIL_FAN_SPEED
+    if (fans_need_update) {
+      sync_fan_speeds(tail_fan_speed);
+      fans_need_update = false;
+    }
+  #endif
 
   TERN_(AUTOTEMP, autotemp_task());
 
@@ -1403,8 +1408,6 @@ void Planner::check_axes_activity() {
     TERN_(HAS_HEATER_1, set_pwm_duty(pin_t(HEATER_1_PIN), tail_valve_pressure));
     TERN_(HAS_HEATER_2, set_pwm_duty(pin_t(HEATER_2_PIN), tail_e_to_p_pressure));
   #endif
-
-  TERN_(HAS_TAIL_FAN_SPEED, fans_need_update = false);  // Reset global for next pass
 }
 
 #if ENABLED(AUTOTEMP)

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1404,7 +1404,7 @@ void Planner::check_axes_activity() {
     TERN_(HAS_HEATER_2, set_pwm_duty(pin_t(HEATER_2_PIN), tail_e_to_p_pressure));
   #endif
 
-  fans_need_update = false;  // Reset global for next pass
+  TERN_(HAS_TAIL_FAN_SPEED, fans_need_update = false);  // Reset global for next pass
 }
 
 #if ENABLED(AUTOTEMP)


### PR DESCRIPTION
### Description

Bug fix, previously analogWrite was updating TIMER0B which is a protected HAL MF_TIMER_TEMP timer. The operation on TIMER0B is not safe and could potentially change its frequency to a value that will no longer function. This PR fixes that unsafe call and constrains it to only use the existing timer frequency and set duty on OCR0B for pin D4 PWM output.    

### Requirements

AtMega644, AtMega1280,AtMega1281,AtMega1284 and AtMega2560 CPU

### Benefits

Improved stability.

### Configurations

None

### Related Issues

#23418
#23459
#23532