### PR TITLE
Suppressible warnings

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -544,10 +544,12 @@
 //
 // Warn users of potential endstop/DIAG pin conflicts to prevent homing issues when not using sensorless homing
 //
-#if !USE_SENSORLESS && ENABLED(USES_DIAG_JUMPERS) && DISABLED(DIAG_JUMPERS_REMOVED)
-  #warning "Motherboard DIAG jumpers must be removed when SENSORLESS_HOMING is disabled."
-#elif !USE_SENSORLESS && ENABLED(USES_DIAG_PINS) && DISABLED(DIAG_PINS_REMOVED)
-  #warning "Driver DIAG pins must be physically removed unless SENSORLESS_HOMING is enabled. (See https://bit.ly/2ZPRlt0)"
+#if NONE(USE_SENSORLESS, DIAG_JUMPERS_REMOVED)
+  #if ENABLED(USES_DIAG_JUMPERS)
+    #warning "Motherboard DIAG jumpers must be removed when SENSORLESS_HOMING is disabled. (Define DIAG_JUMPERS_REMOVED to suppress this warning.)"
+  #elif ENABLED(USES_DIAG_PINS)
+    #warning "Driver DIAG pins must be physically removed unless SENSORLESS_HOMING is enabled. (See https://bit.ly/2ZPRlt0) (Define DIAG_JUMPERS_REMOVED to suppress this warning.)"
+  #endif
 #endif
 
 #if CANNOT_EMBED_CONFIGURATION

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -59,474 +59,478 @@
   #warning "Your Configuration provides no method to acquire user feedback!"
 #endif
 
-#if AUTO_ASSIGNED_X2_STEPPER
-  #warning "Auto-assigned X2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
-#endif
-#if AUTO_ASSIGNED_X2_MS1
-  #warning "Auto-assigned X2_MS1_PIN to an unused En_MS1_PIN."
-#endif
-#if AUTO_ASSIGNED_X2_MS2
-  #warning "Auto-assigned X2_MS2_PIN to an unused En_MS2_PIN."
-#endif
-#if AUTO_ASSIGNED_X2_MS3
-  #warning "Auto-assigned X2_MS3_PIN to an unused En_MS3_PIN."
-#endif
-#if AUTO_ASSIGNED_X2_CS
-  #warning "Auto-assigned X2_CS_PIN to an unused En_CS_PIN."
-#endif
-#if AUTO_ASSIGNED_X2_DIAG
-  #if X2_USE_ENDSTOP == _XMIN_
-    #warning "Auto-assigned X2_DIAG_PIN to X_MIN_PIN."
-  #elif X2_USE_ENDSTOP == _XMAX_
-    #warning "Auto-assigned X2_DIAG_PIN to X_MAX_PIN."
-  #elif X2_USE_ENDSTOP == _XSTOP_
-    #warning "Auto-assigned X2_DIAG_PIN to X_STOP_PIN."
-  #elif X2_USE_ENDSTOP == _YMIN_
-    #warning "Auto-assigned X2_DIAG_PIN to Y_MIN_PIN."
-  #elif X2_USE_ENDSTOP == _YMAX_
-    #warning "Auto-assigned X2_DIAG_PIN to Y_MAX_PIN."
-  #elif X2_USE_ENDSTOP == _YSTOP_
-    #warning "Auto-assigned X2_DIAG_PIN to Y_STOP_PIN."
-  #elif X2_USE_ENDSTOP == _ZMIN_
-    #warning "Auto-assigned X2_DIAG_PIN to Z_MIN_PIN."
-  #elif X2_USE_ENDSTOP == _ZMAX_
-    #warning "Auto-assigned X2_DIAG_PIN to Z_MAX_PIN."
-  #elif X2_USE_ENDSTOP == _ZSTOP_
-    #warning "Auto-assigned X2_DIAG_PIN to Z_STOP_PIN."
-  #elif X2_USE_ENDSTOP == _XDIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to X_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _YDIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to Y_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _ZDIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to Z_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _E0DIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to E0_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _E1DIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to E1_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _E2DIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to E2_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _E3DIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to E3_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _E4DIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to E4_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _E5DIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to E5_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _E6DIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to E6_DIAG_PIN."
-  #elif X2_USE_ENDSTOP == _E7DIAG_
-    #warning "Auto-assigned X2_DIAG_PIN to E7_DIAG_PIN."
-  #endif
-#endif
-#if AUTO_ASSIGNED_Y2_STEPPER
-  #warning "Auto-assigned Y2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
-#endif
-#if AUTO_ASSIGNED_Y2_MS1
-  #warning "Auto-assigned Y2_MS1_PIN to an unused En_MS1_PIN."
-#endif
-#if AUTO_ASSIGNED_Y2_MS2
-  #warning "Auto-assigned Y2_MS2_PIN to an unused En_MS2_PIN."
-#endif
-#if AUTO_ASSIGNED_Y2_MS3
-  #warning "Auto-assigned Y2_MS3_PIN to an unused En_MS3_PIN."
-#endif
-#if AUTO_ASSIGNED_Y2_CS
-  #warning "Auto-assigned Y2_CS_PIN to an unused En_CS_PIN."
-#endif
-#if AUTO_ASSIGNED_Y2_DIAG
-  #if Y2_USE_ENDSTOP == _XMIN_
-    #warning "Auto-assigned Y2_DIAG_PIN to X_MIN_PIN."
-  #elif Y2_USE_ENDSTOP == _XMAX_
-    #warning "Auto-assigned Y2_DIAG_PIN to X_MAX_PIN."
-  #elif Y2_USE_ENDSTOP == _XSTOP_
-    #warning "Auto-assigned Y2_DIAG_PIN to X_STOP_PIN."
-  #elif Y2_USE_ENDSTOP == _YMIN_
-    #warning "Auto-assigned Y2_DIAG_PIN to Y_MIN_PIN."
-  #elif Y2_USE_ENDSTOP == _YMAX_
-    #warning "Auto-assigned Y2_DIAG_PIN to Y_MAX_PIN."
-  #elif Y2_USE_ENDSTOP == _YSTOP_
-    #warning "Auto-assigned Y2_DIAG_PIN to Y_STOP_PIN."
-  #elif Y2_USE_ENDSTOP == _ZMIN_
-    #warning "Auto-assigned Y2_DIAG_PIN to Z_MIN_PIN."
-  #elif Y2_USE_ENDSTOP == _ZMAX_
-    #warning "Auto-assigned Y2_DIAG_PIN to Z_MAX_PIN."
-  #elif Y2_USE_ENDSTOP == _ZSTOP_
-    #warning "Auto-assigned Y2_DIAG_PIN to Z_STOP_PIN."
-  #elif Y2_USE_ENDSTOP == _XDIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to X_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _YDIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to Y_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _ZDIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to Z_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _E0DIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to E0_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _E1DIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to E1_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _E2DIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to E2_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _E3DIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to E3_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _E4DIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to E4_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _E5DIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to E5_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _E6DIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to E6_DIAG_PIN."
-  #elif Y2_USE_ENDSTOP == _E7DIAG_
-    #warning "Auto-assigned Y2_DIAG_PIN to E7_DIAG_PIN."
-  #endif
-#endif
-#if AUTO_ASSIGNED_Z2_STEPPER
-  #warning "Auto-assigned Z2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
-#endif
-#if AUTO_ASSIGNED_Z2_MS1
-  #warning "Auto-assigned Z2_MS1_PIN to an unused En_MS1_PIN."
-#endif
-#if AUTO_ASSIGNED_Z2_MS2
-  #warning "Auto-assigned Z2_MS2_PIN to an unused En_MS2_PIN."
-#endif
-#if AUTO_ASSIGNED_Z2_MS3
-  #warning "Auto-assigned Z2_MS3_PIN to an unused En_MS3_PIN."
-#endif
-#if AUTO_ASSIGNED_Z2_CS
-  #warning "Auto-assigned Z2_CS_PIN to an unused En_CS_PIN."
-#endif
-#if AUTO_ASSIGNED_Z2_DIAG
-  #if Z2_USE_ENDSTOP == _XMIN_
-    #warning "Auto-assigned Z2_DIAG_PIN to X_MIN_PIN."
-  #elif Z2_USE_ENDSTOP == _XMAX_
-    #warning "Auto-assigned Z2_DIAG_PIN to X_MAX_PIN."
-  #elif Z2_USE_ENDSTOP == _XSTOP_
-    #warning "Auto-assigned Z2_DIAG_PIN to X_STOP_PIN."
-  #elif Z2_USE_ENDSTOP == _YMIN_
-    #warning "Auto-assigned Z2_DIAG_PIN to Y_MIN_PIN."
-  #elif Z2_USE_ENDSTOP == _YMAX_
-    #warning "Auto-assigned Z2_DIAG_PIN to Y_MAX_PIN."
-  #elif Z2_USE_ENDSTOP == _YSTOP_
-    #warning "Auto-assigned Z2_DIAG_PIN to Y_STOP_PIN."
-  #elif Z2_USE_ENDSTOP == _ZMIN_
-    #warning "Auto-assigned Z2_DIAG_PIN to Z_MIN_PIN."
-  #elif Z2_USE_ENDSTOP == _ZMAX_
-    #warning "Auto-assigned Z2_DIAG_PIN to Z_MAX_PIN."
-  #elif Z2_USE_ENDSTOP == _ZSTOP_
-    #warning "Auto-assigned Z2_DIAG_PIN to Z_STOP_PIN."
-  #elif Z2_USE_ENDSTOP == _XDIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to X_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _YDIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to Y_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _ZDIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to Z_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _E0DIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to E0_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _E1DIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to E1_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _E2DIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to E2_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _E3DIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to E3_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _E4DIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to E4_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _E5DIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to E5_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _E6DIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to E6_DIAG_PIN."
-  #elif Z2_USE_ENDSTOP == _E7DIAG_
-    #warning "Auto-assigned Z2_DIAG_PIN to E7_DIAG_PIN."
-  #endif
-#endif
-#if AUTO_ASSIGNED_Z3_STEPPER
-  #warning "Auto-assigned Z3 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
-#endif
-#if AUTO_ASSIGNED_Z3_CS
-  #warning "Auto-assigned Z3_CS_PIN to an unused En_CS_PIN."
-#endif
-#if AUTO_ASSIGNED_Z3_MS1
-  #warning "Auto-assigned Z3_MS1_PIN to an unused En_MS1_PIN."
-#endif
-#if AUTO_ASSIGNED_Z3_MS2
-  #warning "Auto-assigned Z3_MS2_PIN to an unused En_MS2_PIN."
-#endif
-#if AUTO_ASSIGNED_Z3_MS3
-  #warning "Auto-assigned Z3_MS3_PIN to an unused En_MS3_PIN."
-#endif
-#if AUTO_ASSIGNED_Z3_DIAG
-  #if Z3_USE_ENDSTOP == _XMIN_
-    #warning "Auto-assigned Z3_DIAG_PIN to X_MIN_PIN."
-  #elif Z3_USE_ENDSTOP == _XMAX_
-    #warning "Auto-assigned Z3_DIAG_PIN to X_MAX_PIN."
-  #elif Z3_USE_ENDSTOP == _XSTOP_
-    #warning "Auto-assigned Z3_DIAG_PIN to X_STOP_PIN."
-  #elif Z3_USE_ENDSTOP == _YMIN_
-    #warning "Auto-assigned Z3_DIAG_PIN to Y_MIN_PIN."
-  #elif Z3_USE_ENDSTOP == _YMAX_
-    #warning "Auto-assigned Z3_DIAG_PIN to Y_MAX_PIN."
-  #elif Z3_USE_ENDSTOP == _YSTOP_
-    #warning "Auto-assigned Z3_DIAG_PIN to Y_STOP_PIN."
-  #elif Z3_USE_ENDSTOP == _ZMIN_
-    #warning "Auto-assigned Z3_DIAG_PIN to Z_MIN_PIN."
-  #elif Z3_USE_ENDSTOP == _ZMAX_
-    #warning "Auto-assigned Z3_DIAG_PIN to Z_MAX_PIN."
-  #elif Z3_USE_ENDSTOP == _ZSTOP_
-    #warning "Auto-assigned Z3_DIAG_PIN to Z_STOP_PIN."
-  #elif Z3_USE_ENDSTOP == _XDIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to X_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _YDIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to Y_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _ZDIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to Z_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _E0DIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to E0_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _E1DIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to E1_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _E2DIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to E2_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _E3DIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to E3_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _E4DIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to E4_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _E5DIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to E5_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _E6DIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to E6_DIAG_PIN."
-  #elif Z3_USE_ENDSTOP == _E7DIAG_
-    #warning "Auto-assigned Z3_DIAG_PIN to E7_DIAG_PIN."
-  #endif
-#endif
-#if AUTO_ASSIGNED_Z4_STEPPER
-  #warning "Auto-assigned Z4 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
-#endif
-#if AUTO_ASSIGNED_Z4_CS
-  #warning "Auto-assigned Z4_CS_PIN to an unused En_CS_PIN."
-#endif
-#if AUTO_ASSIGNED_Z4_MS1
-  #warning "Auto-assigned Z4_MS1_PIN to an unused En_MS1_PIN."
-#endif
-#if AUTO_ASSIGNED_Z4_MS2
-  #warning "Auto-assigned Z4_MS2_PIN to an unused En_MS2_PIN."
-#endif
-#if AUTO_ASSIGNED_Z4_MS3
-  #warning "Auto-assigned Z4_MS3_PIN to an unused En_MS3_PIN."
-#endif
-#if AUTO_ASSIGNED_Z4_DIAG
-  #if Z4_USE_ENDSTOP == _XMIN_
-    #warning "Auto-assigned Z4_DIAG_PIN to X_MIN_PIN."
-  #elif Z4_USE_ENDSTOP == _XMAX_
-    #warning "Auto-assigned Z4_DIAG_PIN to X_MAX_PIN."
-  #elif Z4_USE_ENDSTOP == _XSTOP_
-    #warning "Auto-assigned Z4_DIAG_PIN to X_STOP_PIN."
-  #elif Z4_USE_ENDSTOP == _YMIN_
-    #warning "Auto-assigned Z4_DIAG_PIN to Y_MIN_PIN."
-  #elif Z4_USE_ENDSTOP == _YMAX_
-    #warning "Auto-assigned Z4_DIAG_PIN to Y_MAX_PIN."
-  #elif Z4_USE_ENDSTOP == _YSTOP_
-    #warning "Auto-assigned Z4_DIAG_PIN to Y_STOP_PIN."
-  #elif Z4_USE_ENDSTOP == _ZMIN_
-    #warning "Auto-assigned Z4_DIAG_PIN to Z_MIN_PIN."
-  #elif Z4_USE_ENDSTOP == _ZMAX_
-    #warning "Auto-assigned Z4_DIAG_PIN to Z_MAX_PIN."
-  #elif Z4_USE_ENDSTOP == _ZSTOP_
-    #warning "Auto-assigned Z4_DIAG_PIN to Z_STOP_PIN."
-  #elif Z4_USE_ENDSTOP == _XDIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to X_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _YDIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to Y_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _ZDIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to Z_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _E0DIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to E0_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _E1DIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to E1_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _E2DIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to E2_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _E3DIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to E3_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _E4DIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to E4_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _E5DIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to E5_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _E6DIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to E6_DIAG_PIN."
-  #elif Z4_USE_ENDSTOP == _E7DIAG_
-    #warning "Auto-assigned Z4_DIAG_PIN to E7_DIAG_PIN."
-  #endif
-#endif
-#if AUTO_ASSIGNED_I_STEPPER
-  #warning "Auto-assigned I STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
-#endif
-#if AUTO_ASSIGNED_I_CS
-  #warning "Auto-assigned I_CS_PIN to an unused En_CS_PIN."
-#endif
-#if AUTO_ASSIGNED_I_MS1
-  #warning "Auto-assigned I_MS1_PIN to an unused En_MS1_PIN."
-#endif
-#if AUTO_ASSIGNED_I_MS2
-  #warning "Auto-assigned I_MS2_PIN to an unused En_MS2_PIN."
-#endif
-#if AUTO_ASSIGNED_I_MS3
-  #warning "Auto-assigned I_MS3_PIN to an unused En_MS3_PIN."
-#endif
-#if AUTO_ASSIGNED_I_DIAG
-  #if I_USE_ENDSTOP == _XMIN_
-    #warning "Auto-assigned I_DIAG_PIN to X_MIN_PIN."
-  #elif I_USE_ENDSTOP == _XMAX_
-    #warning "Auto-assigned I_DIAG_PIN to X_MAX_PIN."
-  #elif I_USE_ENDSTOP == _XSTOP_
-    #warning "Auto-assigned I_DIAG_PIN to X_STOP_PIN."
-  #elif I_USE_ENDSTOP == _YMIN_
-    #warning "Auto-assigned I_DIAG_PIN to Y_MIN_PIN."
-  #elif I_USE_ENDSTOP == _YMAX_
-    #warning "Auto-assigned I_DIAG_PIN to Y_MAX_PIN."
-  #elif I_USE_ENDSTOP == _YSTOP_
-    #warning "Auto-assigned I_DIAG_PIN to Y_STOP_PIN."
-  #elif I_USE_ENDSTOP == _ZMIN_
-    #warning "Auto-assigned I_DIAG_PIN to Z_MIN_PIN."
-  #elif I_USE_ENDSTOP == _ZMAX_
-    #warning "Auto-assigned I_DIAG_PIN to Z_MAX_PIN."
-  #elif I_USE_ENDSTOP == _ZSTOP_
-    #warning "Auto-assigned I_DIAG_PIN to Z_STOP_PIN."
-  #elif I_USE_ENDSTOP == _XDIAG_
-    #warning "Auto-assigned I_DIAG_PIN to X_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _YDIAG_
-    #warning "Auto-assigned I_DIAG_PIN to Y_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _ZDIAG_
-    #warning "Auto-assigned I_DIAG_PIN to Z_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _E0DIAG_
-    #warning "Auto-assigned I_DIAG_PIN to E0_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _E1DIAG_
-    #warning "Auto-assigned I_DIAG_PIN to E1_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _E2DIAG_
-    #warning "Auto-assigned I_DIAG_PIN to E2_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _E3DIAG_
-    #warning "Auto-assigned I_DIAG_PIN to E3_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _E4DIAG_
-    #warning "Auto-assigned I_DIAG_PIN to E4_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _E5DIAG_
-    #warning "Auto-assigned I_DIAG_PIN to E5_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _E6DIAG_
-    #warning "Auto-assigned I_DIAG_PIN to E6_DIAG_PIN."
-  #elif I_USE_ENDSTOP == _E7DIAG_
-    #warning "Auto-assigned I_DIAG_PIN to E7_DIAG_PIN."
-  #endif
-#endif
-#if AUTO_ASSIGNED_J_STEPPER
-  #warning "Auto-assigned J STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
-#endif
-#if AUTO_ASSIGNED_J_CS
-  #warning "Auto-assigned J_CS_PIN to an unused En_CS_PIN."
-#endif
-#if AUTO_ASSIGNED_J_MS1
-  #warning "Auto-assigned J_MS1_PIN to an unused En_MS1_PIN."
-#endif
-#if AUTO_ASSIGNED_J_MS2
-  #warning "Auto-assigned J_MS2_PIN to an unused En_MS2_PIN."
-#endif
-#if AUTO_ASSIGNED_J_MS3
-  #warning "Auto-assigned J_MS3_PIN to an unused En_MS3_PIN."
-#endif
-#if AUTO_ASSIGNED_J_DIAG
-  #if J_USE_ENDSTOP == _XMIN_
-    #warning "Auto-assigned J_DIAG_PIN to X_MIN_PIN."
-  #elif J_USE_ENDSTOP == _XMAX_
-    #warning "Auto-assigned J_DIAG_PIN to X_MAX_PIN."
-  #elif J_USE_ENDSTOP == _XSTOP_
-    #warning "Auto-assigned J_DIAG_PIN to X_STOP_PIN."
-  #elif J_USE_ENDSTOP == _YMIN_
-    #warning "Auto-assigned J_DIAG_PIN to Y_MIN_PIN."
-  #elif J_USE_ENDSTOP == _YMAX_
-    #warning "Auto-assigned J_DIAG_PIN to Y_MAX_PIN."
-  #elif J_USE_ENDSTOP == _YSTOP_
-    #warning "Auto-assigned J_DIAG_PIN to Y_STOP_PIN."
-  #elif J_USE_ENDSTOP == _ZMIN_
-    #warning "Auto-assigned J_DIAG_PIN to Z_MIN_PIN."
-  #elif J_USE_ENDSTOP == _ZMAX_
-    #warning "Auto-assigned J_DIAG_PIN to Z_MAX_PIN."
-  #elif J_USE_ENDSTOP == _ZSTOP_
-    #warning "Auto-assigned J_DIAG_PIN to Z_STOP_PIN."
-  #elif J_USE_ENDSTOP == _XDIAG_
-    #warning "Auto-assigned J_DIAG_PIN to X_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _YDIAG_
-    #warning "Auto-assigned J_DIAG_PIN to Y_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _ZDIAG_
-    #warning "Auto-assigned J_DIAG_PIN to Z_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _E0DIAG_
-    #warning "Auto-assigned J_DIAG_PIN to E0_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _E1DIAG_
-    #warning "Auto-assigned J_DIAG_PIN to E1_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _E2DIAG_
-    #warning "Auto-assigned J_DIAG_PIN to E2_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _E3DIAG_
-    #warning "Auto-assigned J_DIAG_PIN to E3_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _E4DIAG_
-    #warning "Auto-assigned J_DIAG_PIN to E4_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _E5DIAG_
-    #warning "Auto-assigned J_DIAG_PIN to E5_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _E6DIAG_
-    #warning "Auto-assigned J_DIAG_PIN to E6_DIAG_PIN."
-  #elif J_USE_ENDSTOP == _E7DIAG_
-    #warning "Auto-assigned J_DIAG_PIN to E7_DIAG_PIN."
-  #endif
-#endif
-#if AUTO_ASSIGNED_K_STEPPER
-  #warning "Auto-assigned K STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs."
-#endif
-#if AUTO_ASSIGNED_K_CS
-  #warning "Auto-assigned K_CS_PIN to an unused En_CS_PIN."
-#endif
-#if AUTO_ASSIGNED_K_MS1
-  #warning "Auto-assigned K_MS1_PIN to an unused En_MS1_PIN."
-#endif
-#if AUTO_ASSIGNED_K_MS2
-  #warning "Auto-assigned K_MS2_PIN to an unused En_MS2_PIN."
-#endif
-#if AUTO_ASSIGNED_K_MS3
-  #warning "Auto-assigned K_MS3_PIN to an unused En_MS3_PIN."
-#endif
-#if AUTO_ASSIGNED_K_DIAG
-  #if K_USE_ENDSTOP == _XMIN_
-    #warning "Auto-assigned K_DIAG_PIN to X_MIN_PIN."
-  #elif K_USE_ENDSTOP == _XMAX_
-    #warning "Auto-assigned K_DIAG_PIN to X_MAX_PIN."
-  #elif K_USE_ENDSTOP == _XSTOP_
-    #warning "Auto-assigned K_DIAG_PIN to X_STOP_PIN."
-  #elif K_USE_ENDSTOP == _YMIN_
-    #warning "Auto-assigned K_DIAG_PIN to Y_MIN_PIN."
-  #elif K_USE_ENDSTOP == _YMAX_
-    #warning "Auto-assigned K_DIAG_PIN to Y_MAX_PIN."
-  #elif K_USE_ENDSTOP == _YSTOP_
-    #warning "Auto-assigned K_DIAG_PIN to Y_STOP_PIN."
-  #elif K_USE_ENDSTOP == _ZMIN_
-    #warning "Auto-assigned K_DIAG_PIN to Z_MIN_PIN."
-  #elif K_USE_ENDSTOP == _ZMAX_
-    #warning "Auto-assigned K_DIAG_PIN to Z_MAX_PIN."
-  #elif K_USE_ENDSTOP == _ZSTOP_
-    #warning "Auto-assigned K_DIAG_PIN to Z_STOP_PIN."
-  #elif K_USE_ENDSTOP == _XDIAG_
-    #warning "Auto-assigned K_DIAG_PIN to X_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _YDIAG_
-    #warning "Auto-assigned K_DIAG_PIN to Y_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _ZDIAG_
-    #warning "Auto-assigned K_DIAG_PIN to Z_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _E0DIAG_
-    #warning "Auto-assigned K_DIAG_PIN to E0_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _E1DIAG_
-    #warning "Auto-assigned K_DIAG_PIN to E1_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _E2DIAG_
-    #warning "Auto-assigned K_DIAG_PIN to E2_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _E3DIAG_
-    #warning "Auto-assigned K_DIAG_PIN to E3_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _E4DIAG_
-    #warning "Auto-assigned K_DIAG_PIN to E4_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _E5DIAG_
-    #warning "Auto-assigned K_DIAG_PIN to E5_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _E6DIAG_
-    #warning "Auto-assigned K_DIAG_PIN to E6_DIAG_PIN."
-  #elif K_USE_ENDSTOP == _E7DIAG_
-    #warning "Auto-assigned K_DIAG_PIN to E7_DIAG_PIN."
-  #endif
-#endif
+#ifndef NO_AUTO_ASSIGN_WARNING
 
-#if ENABLED(CHAMBER_FAN) && !defined(CHAMBER_FAN_INDEX)
-  #warning "Auto-assigned CHAMBER_FAN_INDEX to the first free FAN pin."
-#endif
+  #if AUTO_ASSIGNED_X2_STEPPER
+    #warning "Note: Auto-assigned X2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_X2_MS1
+    #warning "Note: Auto-assigned X2_MS1_PIN to an unused En_MS1_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_X2_MS2
+    #warning "Note: Auto-assigned X2_MS2_PIN to an unused En_MS2_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_X2_MS3
+    #warning "Note: Auto-assigned X2_MS3_PIN to an unused En_MS3_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_X2_CS
+    #warning "Note: Auto-assigned X2_CS_PIN to an unused En_CS_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_X2_DIAG
+    #if X2_USE_ENDSTOP == _XMIN_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to X_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _XMAX_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to X_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _XSTOP_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to X_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _YMIN_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to Y_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _YMAX_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to Y_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _YSTOP_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to Y_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _ZMIN_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to Z_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _ZMAX_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to Z_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _ZSTOP_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to Z_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _XDIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to X_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _YDIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to Y_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _ZDIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to Z_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _E0DIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to E0_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _E1DIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to E1_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _E2DIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to E2_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _E3DIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to E3_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _E4DIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to E4_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _E5DIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to E5_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _E6DIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to E6_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif X2_USE_ENDSTOP == _E7DIAG_
+      #warning "Note: Auto-assigned X2_DIAG_PIN to E7_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #endif
+  #endif
+  #if AUTO_ASSIGNED_Y2_STEPPER
+    #warning "Note: Auto-assigned Y2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Y2_MS1
+    #warning "Note: Auto-assigned Y2_MS1_PIN to an unused En_MS1_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Y2_MS2
+    #warning "Note: Auto-assigned Y2_MS2_PIN to an unused En_MS2_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Y2_MS3
+    #warning "Note: Auto-assigned Y2_MS3_PIN to an unused En_MS3_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Y2_CS
+    #warning "Note: Auto-assigned Y2_CS_PIN to an unused En_CS_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Y2_DIAG
+    #if Y2_USE_ENDSTOP == _XMIN_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to X_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _XMAX_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to X_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _XSTOP_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to X_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _YMIN_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to Y_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _YMAX_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to Y_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _YSTOP_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to Y_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _ZMIN_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to Z_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _ZMAX_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to Z_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _ZSTOP_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to Z_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _XDIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to X_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _YDIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to Y_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _ZDIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to Z_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _E0DIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to E0_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _E1DIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to E1_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _E2DIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to E2_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _E3DIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to E3_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _E4DIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to E4_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _E5DIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to E5_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _E6DIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to E6_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Y2_USE_ENDSTOP == _E7DIAG_
+      #warning "Note: Auto-assigned Y2_DIAG_PIN to E7_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #endif
+  #endif
+  #if AUTO_ASSIGNED_Z2_STEPPER
+    #warning "Note: Auto-assigned Z2 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z2_MS1
+    #warning "Note: Auto-assigned Z2_MS1_PIN to an unused En_MS1_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z2_MS2
+    #warning "Note: Auto-assigned Z2_MS2_PIN to an unused En_MS2_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z2_MS3
+    #warning "Note: Auto-assigned Z2_MS3_PIN to an unused En_MS3_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z2_CS
+    #warning "Note: Auto-assigned Z2_CS_PIN to an unused En_CS_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z2_DIAG
+    #if Z2_USE_ENDSTOP == _XMIN_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to X_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _XMAX_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to X_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _XSTOP_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to X_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _YMIN_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to Y_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _YMAX_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to Y_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _YSTOP_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to Y_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _ZMIN_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to Z_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _ZMAX_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to Z_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _ZSTOP_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to Z_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _XDIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to X_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _YDIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to Y_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _ZDIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to Z_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _E0DIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to E0_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _E1DIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to E1_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _E2DIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to E2_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _E3DIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to E3_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _E4DIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to E4_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _E5DIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to E5_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _E6DIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to E6_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z2_USE_ENDSTOP == _E7DIAG_
+      #warning "Note: Auto-assigned Z2_DIAG_PIN to E7_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #endif
+  #endif
+  #if AUTO_ASSIGNED_Z3_STEPPER
+    #warning "Note: Auto-assigned Z3 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z3_CS
+    #warning "Note: Auto-assigned Z3_CS_PIN to an unused En_CS_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z3_MS1
+    #warning "Note: Auto-assigned Z3_MS1_PIN to an unused En_MS1_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z3_MS2
+    #warning "Note: Auto-assigned Z3_MS2_PIN to an unused En_MS2_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z3_MS3
+    #warning "Note: Auto-assigned Z3_MS3_PIN to an unused En_MS3_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z3_DIAG
+    #if Z3_USE_ENDSTOP == _XMIN_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to X_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _XMAX_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to X_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _XSTOP_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to X_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _YMIN_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to Y_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _YMAX_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to Y_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _YSTOP_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to Y_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _ZMIN_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to Z_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _ZMAX_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to Z_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _ZSTOP_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to Z_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _XDIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to X_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _YDIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to Y_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _ZDIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to Z_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _E0DIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to E0_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _E1DIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to E1_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _E2DIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to E2_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _E3DIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to E3_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _E4DIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to E4_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _E5DIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to E5_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _E6DIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to E6_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z3_USE_ENDSTOP == _E7DIAG_
+      #warning "Note: Auto-assigned Z3_DIAG_PIN to E7_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #endif
+  #endif
+  #if AUTO_ASSIGNED_Z4_STEPPER
+    #warning "Note: Auto-assigned Z4 STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z4_CS
+    #warning "Note: Auto-assigned Z4_CS_PIN to an unused En_CS_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z4_MS1
+    #warning "Note: Auto-assigned Z4_MS1_PIN to an unused En_MS1_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z4_MS2
+    #warning "Note: Auto-assigned Z4_MS2_PIN to an unused En_MS2_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z4_MS3
+    #warning "Note: Auto-assigned Z4_MS3_PIN to an unused En_MS3_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_Z4_DIAG
+    #if Z4_USE_ENDSTOP == _XMIN_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to X_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _XMAX_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to X_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _XSTOP_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to X_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _YMIN_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to Y_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _YMAX_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to Y_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _YSTOP_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to Y_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _ZMIN_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to Z_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _ZMAX_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to Z_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _ZSTOP_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to Z_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _XDIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to X_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _YDIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to Y_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _ZDIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to Z_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _E0DIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to E0_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _E1DIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to E1_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _E2DIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to E2_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _E3DIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to E3_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _E4DIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to E4_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _E5DIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to E5_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _E6DIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to E6_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif Z4_USE_ENDSTOP == _E7DIAG_
+      #warning "Note: Auto-assigned Z4_DIAG_PIN to E7_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #endif
+  #endif
+  #if AUTO_ASSIGNED_I_STEPPER
+    #warning "Note: Auto-assigned I STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_I_CS
+    #warning "Note: Auto-assigned I_CS_PIN to an unused En_CS_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_I_MS1
+    #warning "Note: Auto-assigned I_MS1_PIN to an unused En_MS1_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_I_MS2
+    #warning "Note: Auto-assigned I_MS2_PIN to an unused En_MS2_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_I_MS3
+    #warning "Note: Auto-assigned I_MS3_PIN to an unused En_MS3_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_I_DIAG
+    #if I_USE_ENDSTOP == _XMIN_
+      #warning "Note: Auto-assigned I_DIAG_PIN to X_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _XMAX_
+      #warning "Note: Auto-assigned I_DIAG_PIN to X_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _XSTOP_
+      #warning "Note: Auto-assigned I_DIAG_PIN to X_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _YMIN_
+      #warning "Note: Auto-assigned I_DIAG_PIN to Y_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _YMAX_
+      #warning "Note: Auto-assigned I_DIAG_PIN to Y_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _YSTOP_
+      #warning "Note: Auto-assigned I_DIAG_PIN to Y_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _ZMIN_
+      #warning "Note: Auto-assigned I_DIAG_PIN to Z_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _ZMAX_
+      #warning "Note: Auto-assigned I_DIAG_PIN to Z_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _ZSTOP_
+      #warning "Note: Auto-assigned I_DIAG_PIN to Z_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _XDIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to X_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _YDIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to Y_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _ZDIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to Z_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _E0DIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to E0_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _E1DIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to E1_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _E2DIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to E2_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _E3DIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to E3_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _E4DIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to E4_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _E5DIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to E5_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _E6DIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to E6_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif I_USE_ENDSTOP == _E7DIAG_
+      #warning "Note: Auto-assigned I_DIAG_PIN to E7_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #endif
+  #endif
+  #if AUTO_ASSIGNED_J_STEPPER
+    #warning "Note: Auto-assigned J STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_J_CS
+    #warning "Note: Auto-assigned J_CS_PIN to an unused En_CS_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_J_MS1
+    #warning "Note: Auto-assigned J_MS1_PIN to an unused En_MS1_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_J_MS2
+    #warning "Note: Auto-assigned J_MS2_PIN to an unused En_MS2_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_J_MS3
+    #warning "Note: Auto-assigned J_MS3_PIN to an unused En_MS3_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_J_DIAG
+    #if J_USE_ENDSTOP == _XMIN_
+      #warning "Note: Auto-assigned J_DIAG_PIN to X_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _XMAX_
+      #warning "Note: Auto-assigned J_DIAG_PIN to X_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _XSTOP_
+      #warning "Note: Auto-assigned J_DIAG_PIN to X_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _YMIN_
+      #warning "Note: Auto-assigned J_DIAG_PIN to Y_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _YMAX_
+      #warning "Note: Auto-assigned J_DIAG_PIN to Y_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _YSTOP_
+      #warning "Note: Auto-assigned J_DIAG_PIN to Y_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _ZMIN_
+      #warning "Note: Auto-assigned J_DIAG_PIN to Z_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _ZMAX_
+      #warning "Note: Auto-assigned J_DIAG_PIN to Z_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _ZSTOP_
+      #warning "Note: Auto-assigned J_DIAG_PIN to Z_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _XDIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to X_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _YDIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to Y_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _ZDIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to Z_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _E0DIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to E0_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _E1DIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to E1_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _E2DIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to E2_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _E3DIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to E3_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _E4DIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to E4_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _E5DIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to E5_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _E6DIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to E6_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif J_USE_ENDSTOP == _E7DIAG_
+      #warning "Note: Auto-assigned J_DIAG_PIN to E7_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #endif
+  #endif
+  #if AUTO_ASSIGNED_K_STEPPER
+    #warning "Note: Auto-assigned K STEP/DIR/ENABLE_PINs to unused En_STEP/DIR/ENABLE_PINs. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_K_CS
+    #warning "Note: Auto-assigned K_CS_PIN to an unused En_CS_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_K_MS1
+    #warning "Note: Auto-assigned K_MS1_PIN to an unused En_MS1_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_K_MS2
+    #warning "Note: Auto-assigned K_MS2_PIN to an unused En_MS2_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_K_MS3
+    #warning "Note: Auto-assigned K_MS3_PIN to an unused En_MS3_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+  #if AUTO_ASSIGNED_K_DIAG
+    #if K_USE_ENDSTOP == _XMIN_
+      #warning "Note: Auto-assigned K_DIAG_PIN to X_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _XMAX_
+      #warning "Note: Auto-assigned K_DIAG_PIN to X_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _XSTOP_
+      #warning "Note: Auto-assigned K_DIAG_PIN to X_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _YMIN_
+      #warning "Note: Auto-assigned K_DIAG_PIN to Y_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _YMAX_
+      #warning "Note: Auto-assigned K_DIAG_PIN to Y_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _YSTOP_
+      #warning "Note: Auto-assigned K_DIAG_PIN to Y_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _ZMIN_
+      #warning "Note: Auto-assigned K_DIAG_PIN to Z_MIN_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _ZMAX_
+      #warning "Note: Auto-assigned K_DIAG_PIN to Z_MAX_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _ZSTOP_
+      #warning "Note: Auto-assigned K_DIAG_PIN to Z_STOP_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _XDIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to X_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _YDIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to Y_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _ZDIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to Z_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _E0DIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to E0_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _E1DIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to E1_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _E2DIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to E2_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _E3DIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to E3_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _E4DIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to E4_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _E5DIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to E5_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _E6DIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to E6_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #elif K_USE_ENDSTOP == _E7DIAG_
+      #warning "Note: Auto-assigned K_DIAG_PIN to E7_DIAG_PIN. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+    #endif
+  #endif
+
+  #if ENABLED(CHAMBER_FAN) && !defined(CHAMBER_FAN_INDEX)
+    #warning "Note: Auto-assigned CHAMBER_FAN_INDEX to the first free FAN pin. (Define NO_AUTO_ASSIGN_WARNING to suppress this warning.)"
+  #endif
+
+#endif // !NO_AUTO_ASSIGN_WARNING
 
 #if IS_LEGACY_TFT
   #warning "Don't forget to update your TFT settings in Configuration.h."

--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -544,9 +544,9 @@
 //
 // Warn users of potential endstop/DIAG pin conflicts to prevent homing issues when not using sensorless homing
 //
-#if !USE_SENSORLESS && ENABLED(USES_DIAG_JUMPERS)
+#if !USE_SENSORLESS && ENABLED(USES_DIAG_JUMPERS) && DISABLED(DIAG_JUMPERS_REMOVED)
   #warning "Motherboard DIAG jumpers must be removed when SENSORLESS_HOMING is disabled."
-#elif !USE_SENSORLESS && ENABLED(USES_DIAG_PINS)
+#elif !USE_SENSORLESS && ENABLED(USES_DIAG_PINS) && DISABLED(DIAG_PINS_REMOVED)
   #warning "Driver DIAG pins must be physically removed unless SENSORLESS_HOMING is enabled. (See https://bit.ly/2ZPRlt0)"
 #endif
 


### PR DESCRIPTION
### Description

Compilation on certain boards that provide DIAG pins / jumpers always produces a warning for removing the pins / jumpers when mechanical endstops are used. User should be able to define a macro in their config files to acknowledge and suppress this warning if they have already taken care of the issue.

### Requirements

-

### Benefits

Option to remove unnecessary compilation warning

### Configurations

Add
`#define DIAG_JUMPERS_REMOVED`
or 
`#define DIAG_PINS_REMOVED`
to remove warning

### Related Issues

-
