### PR TITLE
Add M220 Feed rate changes to emergency parser

### DIFF
--- a/Marlin/src/feature/e_parser.cpp
+++ b/Marlin/src/feature/e_parser.cpp
@@ -34,6 +34,7 @@
 bool EmergencyParser::killed_by_M112, // = false
      EmergencyParser::quickstop_by_M410,
      EmergencyParser::enabled;
+int16_t EmergencyParser::M220_rate; // Feed rate = 100
 
 #if ENABLED(HOST_PROMPT_SUPPORT)
   uint8_t EmergencyParser::M876_reason; // = 0


### PR DESCRIPTION
### Description
M220 (feed rate) gcode gets queued, which can cause significant delays until the change is enacted. This bypasses the queue and uses the emergency parser to enact any changes to feed rates immediately.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
Emergency Parser must be enabled for this to take effect.

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
All feed rate changes happen immediately (critical safety issue for CNC/Laser machines)
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
