### PR TITLE
Allow CONFIGURATION_EMBEDDING warnings to be suppressed

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -548,11 +548,11 @@
 //
 // Warn users of potential endstop/DIAG pin conflicts to prevent homing issues when not using sensorless homing
 //
-#if NONE(USE_SENSORLESS, DIAG_JUMPERS_REMOVED)
-  #if ENABLED(USES_DIAG_JUMPERS)
+#if !USE_SENSORLESS
+  #if ENABLED(USES_DIAG_JUMPERS) && DISABLED(DIAG_JUMPERS_REMOVED)
     #warning "Motherboard DIAG jumpers must be removed when SENSORLESS_HOMING is disabled. (Define DIAG_JUMPERS_REMOVED to suppress this warning.)"
-  #elif ENABLED(USES_DIAG_PINS)
-    #warning "Driver DIAG pins must be physically removed unless SENSORLESS_HOMING is enabled. (See https://bit.ly/2ZPRlt0) (Define DIAG_JUMPERS_REMOVED to suppress this warning.)"
+  #elif ENABLED(USES_DIAG_PINS) && DISABLED(DIAG_PINS_REMOVED)
+    #warning "Driver DIAG pins must be physically removed unless SENSORLESS_HOMING is enabled. (See https://bit.ly/2ZPRlt0) (Define DIAG_PINS_REMOVED to suppress this warning.)"
   #endif
 #endif
 

--- a/buildroot/share/PlatformIO/scripts/signature.py
+++ b/buildroot/share/PlatformIO/scripts/signature.py
@@ -163,7 +163,9 @@ def compute_build_signature(env):
 
 	# Generate a C source file for storing this array
 	with open('Marlin/src/mczip.h','wb') as result_file:
-		result_file.write(b'#warning "Generated file \'mc.zip\' is embedded"\n')
+		result_file.write(b'#ifndef NO_CONFIGURATION_EMBEDDING_WARNING\n')
+		result_file.write(b'  #warning "Generated file \'mc.zip\' is embedded (Define NO_CONFIGURATION_EMBEDDING_WARNING to suppress this warning.)"\n')
+		result_file.write(b'#endif\n')
 		result_file.write(b'const unsigned char mc_zip[] PROGMEM = {\n ')
 		count = 0
 		for b in open(os.path.join(build_dir, 'mc.zip'), 'rb').read():


### PR DESCRIPTION
### Description

Follow-up to ##23530: Allow `CONFIGURATION_EMBEDDING` warnings to be suppressed. 

### Benefits

Quieter build option.

### Configurations

Any `CONFIGURATION_EMBEDDING`-based build.

### Related Issues

- #23530