### PR TITLE
Probe pin in sensor connector is the same of BLTOUCH

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -60,13 +60,8 @@
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-#ifndef Z_MIN_PROBE_PIN
-  #if ENABLED(BLTOUCH)
-    #define Z_MIN_PROBE_PIN                 PB7
-  #else
-    #define Z_MIN_PROBE_PIN                 PC5   // Probe (Proximity switch) port
-  #endif
-#endif
+
+#define Z_MIN_PROBE_PIN                 PB7
 
 //
 // Check for additional used endstop pins


### PR DESCRIPTION
I've notice, while I've been trying to add an induction probe to my btt octopus, that on board' pinout the sensor probe signal pin is PB7 instead of PC5
![Octopus04 copia](https://user-images.githubusercontent.com/20787117/149821435-d1a1cb7e-3b8c-47a2-939b-c341ca501cdc.png)

