### PR TITLE
Probe pin in sensor connector is the same of BLTOUCH

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
@@ -37,12 +37,8 @@
   #define TEMP_0_PIN                        PF4   // TH0
 #endif
 
-#include "pins_BTT_OCTOPUS_V1_common.h"
-
-#ifndef Z_MIN_PROBE_PIN
-  #if ENABLED(BLTOUCH)
-    #define Z_MIN_PROBE_PIN                 PB7
-  #else
-    #define Z_MIN_PROBE_PIN                 PC5   // Probe (Proximity switch) port
-  #endif
+#if !defined(Z_MIN_PROBE_PIN) && DISABLED(BLTOUCH)
+  #define Z_MIN_PROBE_PIN                   PC5   // Probe (Proximity switch) port
 #endif
+
+#include "pins_BTT_OCTOPUS_V1_common.h"

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_PRO_V1_0.h
@@ -38,3 +38,11 @@
 #endif
 
 #include "pins_BTT_OCTOPUS_V1_common.h"
+
+#ifndef Z_MIN_PROBE_PIN
+  #if ENABLED(BLTOUCH)
+    #define Z_MIN_PROBE_PIN                 PB7
+  #else
+    #define Z_MIN_PROBE_PIN                 PC5   // Probe (Proximity switch) port
+  #endif
+#endif

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -60,8 +60,9 @@
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-
-#define Z_MIN_PROBE_PIN                 PB7
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PB7
+#endif
 
 //
 // Check for additional used endstop pins

--- a/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_OCTOPUS_V1_common.h
@@ -60,13 +60,8 @@
 //
 // Z Probe (when not Z_MIN_PIN)
 //
-#ifndef Z_MIN_PROBE_PIN
-  #if ENABLED(BLTOUCH)
-    #define Z_MIN_PROBE_PIN                 PB7
-  #else
-    #define Z_MIN_PROBE_PIN                 PC5   // Probe (Proximity switch) port
-  #endif
-#endif
+
+#define Z_MIN_PROBE_PIN                 PB7
 
 //
 // Check for additional used endstop pins


### PR DESCRIPTION
I've notice, while I've been trying to add an induction probe to my btt octopus, that on board' pinout the sensor probe signal pin is PB7 instead of PC5
![sensorPin](https://user-images.githubusercontent.com/20787117/149822010-4ebe17bf-99a0-431a-b565-95c32decc245.png)

