### PR TITLE
Fix conditional M81 suicide issue

### DIFF
--- a/Marlin/src/core/language.h
+++ b/Marlin/src/core/language.h
@@ -105,6 +105,7 @@
 
 #define STR_ENQUEUEING                      "enqueueing \""
 #define STR_POWERUP                         "PowerUp"
+#define STR_POWEROFF                        "PowerOff"
 #define STR_EXTERNAL_RESET                  " External Reset"
 #define STR_BROWNOUT_RESET                  " Brown out Reset"
 #define STR_WATCHDOG_RESET                  " Watchdog Reset"
@@ -306,6 +307,7 @@
 #define STR_Z_PROBE_OFFSET                  "Z-Probe Offset"
 #define STR_TEMPERATURE_UNITS               "Temperature Units"
 #define STR_USER_THERMISTORS                "User thermistors"
+#define STR_DELAYED_POWEROFF                "Delayed poweroff"
 
 //
 // Endstop Names used by Endstops::report_states

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -98,7 +98,7 @@ void Power::power_on() {
  */
 void Power::power_off() {
 
-  SERIAL_ECHOLN("Powering off...");
+  SERIAL_ECHOLNPGM("Powering off...");
 
   TERN_(HAS_SUICIDE, suicide());
 
@@ -113,7 +113,7 @@ void Power::power_off() {
   #endif
 
   OUT_WRITE(PS_ON_PIN, !PSU_ACTIVE_STATE);
-  SERIAL_ECHOLN("Power off pin triggered");
+  SERIAL_ECHOLNPGM("Power off pin triggered");
   psu_on = false;
 
   #if EITHER(POWER_OFF_TIMER, POWER_OFF_WAIT_FOR_COOLDOWN)
@@ -136,7 +136,7 @@ void Power::power_off() {
       if (thermalManager.degCooler() >= (AUTO_POWER_COOLER_TEMP)) return true;
     #endif
 
-    SERIAL_ECHOLN("Power off cooling wait complete.");
+    SERIAL_ECHOLNPGM("Power off cooling wait complete.");
     return false;
   }
 

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -97,8 +97,7 @@ void Power::power_on() {
  * Processes any PSU_POWEROFF_GCODE and makes a PS_OFF_SOUND if enabled.
  */
 void Power::power_off() {
-
-  SERIAL_ECHOLNPGM("Powering off...");
+  SERIAL_ECHOLNPGM(STR_POWEROFF);
 
   TERN_(HAS_SUICIDE, suicide());
 
@@ -113,7 +112,6 @@ void Power::power_off() {
   #endif
 
   OUT_WRITE(PS_ON_PIN, !PSU_ACTIVE_STATE);
-  SERIAL_ECHOLNPGM("Power off pin triggered");
   psu_on = false;
 
   #if EITHER(POWER_OFF_TIMER, POWER_OFF_WAIT_FOR_COOLDOWN)
@@ -136,7 +134,6 @@ void Power::power_off() {
       if (thermalManager.degCooler() >= (AUTO_POWER_COOLER_TEMP)) return true;
     #endif
 
-    SERIAL_ECHOLNPGM("Power off cooling wait complete.");
     return false;
   }
 

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -97,6 +97,9 @@ void Power::power_on() {
  * Processes any PSU_POWEROFF_GCODE and makes a PS_OFF_SOUND if enabled.
  */
 void Power::power_off() {
+
+  TERN_(HAS_SUICIDE, suicide());
+
   if (!psu_on) return;
 
   #ifdef PSU_POWEROFF_GCODE

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -24,7 +24,9 @@
  * power.cpp - power control
  */
 
-#include "../inc/MarlinConfig.h"
+#include "../inc/MarlinConfigPre.h"
+
+#if EITHER(PSU_CONTROL, AUTO_POWER_CONTROL)
 
 #include "power.h"
 #include "../module/planner.h"
@@ -39,8 +41,6 @@
 #if defined(PSU_POWERUP_GCODE) || defined(PSU_POWEROFF_GCODE)
   #include "../gcode/gcode.h"
 #endif
-
-#if EITHER(PSU_CONTROL, AUTO_POWER_CONTROL)
 
 Power powerManager;
 bool Power::psu_on;

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -98,6 +98,8 @@ void Power::power_on() {
  */
 void Power::power_off() {
 
+  SERIAL_ECHOLN("Powering off...");
+
   TERN_(HAS_SUICIDE, suicide());
 
   if (!psu_on) return;
@@ -111,6 +113,7 @@ void Power::power_off() {
   #endif
 
   OUT_WRITE(PS_ON_PIN, !PSU_ACTIVE_STATE);
+  SERIAL_ECHOLN("Power off pin triggered");
   psu_on = false;
 
   #if EITHER(POWER_OFF_TIMER, POWER_OFF_WAIT_FOR_COOLDOWN)
@@ -133,6 +136,7 @@ void Power::power_off() {
       if (thermalManager.degCooler() >= (AUTO_POWER_COOLER_TEMP)) return true;
     #endif
 
+    SERIAL_ECHOLN("Power off cooling wait complete.");
     return false;
   }
 
@@ -156,6 +160,7 @@ void Power::power_off() {
   }
 
   void Power::checkAutoPowerOff() {
+    SERIAL_ECHOLNPGM("Power off conditions: ", power_off_time, " ", power_off_on_cooldown);
     if (TERN1(POWER_OFF_TIMER, !power_off_time) && TERN1(POWER_OFF_WAIT_FOR_COOLDOWN, !power_off_on_cooldown)) return;
     if (TERN0(POWER_OFF_WAIT_FOR_COOLDOWN, power_off_on_cooldown && is_cooling_needed())) return;
     if (TERN0(POWER_OFF_TIMER, power_off_time && PENDING(millis(), power_off_time))) return;

--- a/Marlin/src/feature/power.cpp
+++ b/Marlin/src/feature/power.cpp
@@ -160,7 +160,6 @@ void Power::power_off() {
   }
 
   void Power::checkAutoPowerOff() {
-    SERIAL_ECHOLNPGM("Power off conditions: ", power_off_time, " ", power_off_on_cooldown);
     if (TERN1(POWER_OFF_TIMER, !power_off_time) && TERN1(POWER_OFF_WAIT_FOR_COOLDOWN, !power_off_on_cooldown)) return;
     if (TERN0(POWER_OFF_WAIT_FOR_COOLDOWN, power_off_on_cooldown && is_cooling_needed())) return;
     if (TERN0(POWER_OFF_TIMER, power_off_time && PENDING(millis(), power_off_time))) return;

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -88,6 +88,8 @@ void GcodeSuite::M81() {
 
   LCD_MESSAGE_F(MACHINE_NAME " " STR_OFF ".");
 
+  SERIAL_ECHOLN("M81 command issued.");
+
   bool delayed_power_off = false;
 
   #if ENABLED(POWER_OFF_TIMER)
@@ -107,9 +109,12 @@ void GcodeSuite::M81() {
     }
   #endif
 
-  if (delayed_power_off) return;
+  if (delayed_power_off) {
+    SERIAL_ECHOLN("Delaying power off...");
+    return;
+  }
 
-  #if HAS_SUICIDE
+#if HAS_SUICIDE
     suicide();
   #elif ENABLED(PSU_CONTROL)
     powerManager.power_off_soon();

--- a/Marlin/src/gcode/control/M80_M81.cpp
+++ b/Marlin/src/gcode/control/M80_M81.cpp
@@ -88,8 +88,6 @@ void GcodeSuite::M81() {
 
   LCD_MESSAGE_F(MACHINE_NAME " " STR_OFF ".");
 
-  SERIAL_ECHOLN("M81 command issued.");
-
   bool delayed_power_off = false;
 
   #if ENABLED(POWER_OFF_TIMER)
@@ -110,11 +108,11 @@ void GcodeSuite::M81() {
   #endif
 
   if (delayed_power_off) {
-    SERIAL_ECHOLN("Delaying power off...");
+    SERIAL_ECHOLNPGM(STR_DELAYED_POWEROFF);
     return;
   }
 
-#if HAS_SUICIDE
+  #if HAS_SUICIDE
     suicide();
   #elif ENABLED(PSU_CONTROL)
     powerManager.power_off_soon();

--- a/Marlin/src/libs/MAX31865.cpp
+++ b/Marlin/src/libs/MAX31865.cpp
@@ -300,14 +300,14 @@ uint16_t MAX31865::readRaw() {
         enableBias();
         nextEventStamp = millis() + 11; // wait at least 11msec before enabling 1shot
         nextEvent = SETUP_1_SHOT_MODE;
-        DEBUG_ECHOLN("MAX31865 bias voltage enabled");
+        DEBUG_ECHOLNPGM("MAX31865 bias voltage enabled");
         break;
 
       case SETUP_1_SHOT_MODE:
         oneShot();
         nextEventStamp = millis() + 65; // wait at least 65msec before reading RTD register
         nextEvent = READ_RTD_REG;
-        DEBUG_ECHOLN("MAX31865 1 shot mode enabled");
+        DEBUG_ECHOLNPGM("MAX31865 1 shot mode enabled");
         break;
 
       case READ_RTD_REG: {

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -193,7 +193,9 @@
 //
 #if ENABLED(MKS_PWC)
   #if ENABLED(TFT_LVGL_UI)
-    #undef PSU_CONTROL
+    #if ENABLED(PSU_CONTROL)
+      #error "PSU_CONTROL is incompatible with MKS_PWC plus TFT_LVGL_UI."
+    #endif
     #undef MKS_PWC
     #define SUICIDE_PIN                     PB2
     #define SUICIDE_PIN_STATE               LOW

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
@@ -118,7 +118,9 @@
 //
 #if ENABLED(MKS_PWC)
   #if ENABLED(TFT_LVGL_UI)
-    #undef PSU_CONTROL
+    #if ENABLED(PSU_CONTROL)
+      #error "PSU_CONTROL is incompatible with MKS_PWC plus TFT_LVGL_UI."
+    #endif
     #undef MKS_PWC
     #define SUICIDE_PIN                     PB2
     #define SUICIDE_PIN_STATE               LOW

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_PRO.h
@@ -185,7 +185,9 @@
 //
 #if ENABLED(MKS_PWC)
   #if ENABLED(TFT_LVGL_UI)
-    #undef PSU_CONTROL
+    #if ENABLED(PSU_CONTROL)
+      #error "PSU_CONTROL is incompatible with MKS_PWC plus TFT_LVGL_UI."
+    #endif
     #undef MKS_PWC
     #define SUICIDE_PIN                     PG11
     #define SUICIDE_PIN_STATE               LOW

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -165,7 +165,9 @@
 //
 #if ENABLED(MKS_PWC)
   #if ENABLED(TFT_LVGL_UI)
-    #undef PSU_CONTROL
+    #if ENABLED(PSU_CONTROL)
+      #error "PSU_CONTROL is incompatible with MKS_PWC plus TFT_LVGL_UI."
+    #endif
     #undef MKS_PWC
     #define SUICIDE_PIN                     PB2
     #define SUICIDE_PIN_STATE               LOW


### PR DESCRIPTION
### Description

Recent changes to M81 implementation omitted invocation of suicide() (where it applies) when powering off conditions are met.

### Benefits

Bug fix

### Related Issues

#23396 
