### PR TITLE
Preliminary support for the Ender3S1

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -359,6 +359,7 @@
 #define BOARD_ZONESTAR_ZM3E4          4059  // Zonestar ZM3E4 V1 (STM32F103VCT6)
 #define BOARD_ZONESTAR_ZM3E4V2        4060  // Zonestar ZM3E4 V2 (STM32F103VCT6)
 #define BOARD_ERYONE_ERY32_MINI       4061  // Eryone Ery32 mini (STM32F103VET6)
+#define BOARD_CREALITY_V24S1_301      4062  // Creality v2.4.S1_301 (STM32F103RCT) as found in the Ender 3 S1
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -511,6 +511,8 @@
   #ifndef LCD_SERIAL_PORT
     #if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_MINI_E3_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_E3_TURBO)
       #define LCD_SERIAL_PORT 1
+    #elif MB(CREALITY_V24S1_301)
+      #define LCD_SERIAL_PORT 2 // Creality Ender3S1 board
     #else
       #define LCD_SERIAL_PORT 3 // Creality 4.x board
     #endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -573,6 +573,8 @@
   #include "stm32f1/pins_CREALITY_V453.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V24S1)
   #include "stm32f1/pins_CREALITY_V24S1.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
+#elif MB(CREALITY_V24S1_301)
+  #include "stm32f1/pins_CREALITY_V24S1_301.h"  // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro env:trigorilla_pro_maple
 #elif MB(FLY_MINI)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V24S1_301.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V24S1_301.h
@@ -1,0 +1,214 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Creality V24S1_301 (STM32F103RCT) board pin assignments as found on Ender 3 S1
+ */
+
+#include "env_validate.h"
+
+#if HAS_MULTI_HOTEND || E_STEPPERS > 1
+#error "Creality V4 only supports one hotend / E-stepper. Comment out this line to continue."
+#endif
+
+#ifndef BOARD_INFO_NAME
+#define BOARD_INFO_NAME "CREALITY_V24S1_301"
+#endif
+#ifndef DEFAULT_MACHINE_NAME
+#define DEFAULT_MACHINE_NAME "Ender 3 S1"
+#endif
+
+#define BOARD_NO_NATIVE_USB
+
+//
+// EEPROM
+//
+#if NO_EEPROM_SELECTED
+#define IIC_BL24CXX_EEPROM // EEPROM on I2C-0
+//#define SDCARD_EEPROM_EMULATION
+#endif
+
+#if ENABLED(IIC_BL24CXX_EEPROM)
+#define IIC_EEPROM_SDA PA11
+#define IIC_EEPROM_SCL PA12
+#define MARLIN_EEPROM_SIZE 0x800 // 2Kb (24C16)
+#elif ENABLED(SDCARD_EEPROM_EMULATION)
+#define MARLIN_EEPROM_SIZE 0x800 // 2Kb
+#endif
+
+//
+// Servos
+//
+#ifndef SERVO0_PIN
+#ifndef HAS_PIN_27_BOARD
+#define SERVO0_PIN PC13 // BLTouch OUT
+#else
+#define SERVO0_PIN PC6
+#endif
+#endif
+
+//
+// Limit Switches
+//
+#define X_STOP_PIN PA5
+#define Y_STOP_PIN PA6
+#define Z_STOP_PIN PC14
+
+#ifndef Z_MIN_PROBE_PIN
+#define Z_MIN_PROBE_PIN PC14 // BLTouch IN
+#endif
+
+//
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+#define FIL_RUNOUT_PIN PC15 // "Pulled-high"
+#endif
+
+//
+// Steppers
+//
+#ifndef X_STEP_PIN
+#define X_STEP_PIN PC2
+#endif
+#ifndef X_DIR_PIN
+#define X_DIR_PIN PB9
+#endif
+#define X_ENABLE_PIN PC3 // Shared
+
+#ifndef Y_STEP_PIN
+#define Y_STEP_PIN PB8
+#endif
+#ifndef Y_DIR_PIN
+#define Y_DIR_PIN PB7
+#endif
+#define Y_ENABLE_PIN X_ENABLE_PIN
+
+#ifndef Z_STEP_PIN
+#define Z_STEP_PIN PB6
+#endif
+#ifndef Z_DIR_PIN
+#define Z_DIR_PIN PB5
+#endif
+#define Z_ENABLE_PIN X_ENABLE_PIN
+
+#ifndef E0_STEP_PIN
+#define E0_STEP_PIN PB4
+#endif
+#ifndef E0_DIR_PIN
+#define E0_DIR_PIN PB3
+#endif
+#define E0_ENABLE_PIN X_ENABLE_PIN
+
+//
+// Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
+//
+#define DISABLE_DEBUG
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN PC5   // TH1
+#define TEMP_BED_PIN PC4 // TB1
+
+//
+// Heaters / Fans
+//
+#ifndef HEATER_0_PIN
+#define HEATER_0_PIN PA1 // HEATER1
+#endif
+#ifndef HEATER_BED_PIN
+#define HEATER_BED_PIN PA7 // HOT BED
+#endif
+#ifndef FAN_PIN
+#define FAN_PIN PA0 // part FAN
+#endif
+#if PIN_EXISTS(FAN)
+#define FAN_SOFT_PWM
+#endif
+#define FAN1_PIN PC0 // extruder fan
+
+//
+// SD Card
+//
+#define SD_DETECT_PIN PC7
+#define SDCARD_CONNECTION ONBOARD
+#define ONBOARD_SPI_DEVICE 1
+#define ONBOARD_SD_CS_PIN PA4 // SDSS
+#define SDIO_SUPPORT
+#define NO_SD_HOST_DRIVE // This board's SD is only seen by the printer
+
+#if ENABLED(CR10_STOCKDISPLAY)
+
+#if ENABLED(RET6_12864_LCD)
+
+// RET6 12864 LCD
+#define LCD_PINS_RS PB12
+#define LCD_PINS_ENABLE PB15
+#define LCD_PINS_D4 PB13
+
+#define BTN_ENC PB2
+#define BTN_EN1 PB10
+#define BTN_EN2 PB14
+
+#ifndef HAS_PIN_27_BOARD
+#define BEEPER_PIN PC6
+#endif
+
+#elif ENABLED(VET6_12864_LCD)
+
+// VET6 12864 LCD
+#define LCD_PINS_RS PA4
+#define LCD_PINS_ENABLE PA7
+#define LCD_PINS_D4 PA5
+
+#define BTN_ENC PC5
+#define BTN_EN1 PB10
+#define BTN_EN2 PA6
+
+#else
+#error "Define RET6_12864_LCD or VET6_12864_LCD to select pins for CR10_STOCKDISPLAY with the Creality V4 controller."
+#endif
+
+#elif EITHER(HAS_DWIN_E3V2, IS_DWIN_MARLINUI)
+
+// RET6 DWIN ENCODER LCD
+#define BTN_ENC PB14
+#define BTN_EN1 PB15
+#define BTN_EN2 PB12
+
+//#define LCD_LED_PIN                     PB2
+#ifndef BEEPER_PIN
+#define BEEPER_PIN PB13
+#endif
+
+#elif ENABLED(DWIN_VET6_CREALITY_LCD)
+
+// VET6 DWIN ENCODER LCD
+#define BTN_ENC PA6
+#define BTN_EN1 PA7
+#define BTN_EN2 PA4
+
+#define BEEPER_PIN PA5
+
+#endif


### PR DESCRIPTION
This PR adds preliminary support for the new Creality Ender3 S1 printer

### Description

Contains changes sugested by @leofaoro and @ellensp from the issue https://github.com/MarlinFirmware/Configurations/issues/645

### Requirements

Ender 3S1 with the original display

### Benefits

Adds preliminary support to Marlin

### Configurations

[Ender3S1-Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/7899042/Ender3S1-Configuration.zip)

### Related Issues

https://github.com/MarlinFirmware/Configurations/issues/645
