### PR TITLE
Issue #23540, Eliminate unwanted Z movement when parking head 

### DIFF
--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -409,8 +409,20 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
 #if HAS_EXTRUDERS
   void unscaled_e_move(const_float_t length, const_feedRate_t fr_mm_s) {
     TERN_(HAS_FILAMENT_SENSOR, runout.reset());
+
+    #if HAS_LEVELING
+      bool leveling_local = false;
+      leveling_local = planner.leveling_active; // save leveling state
+      set_bed_leveling_enabled(false);  // turn off leveling
+    #endif
+
     current_position.e += length / planner.e_factor[active_extruder];
     line_to_current_position(fr_mm_s);
+
+    #if HAS_LEVELING
+      set_bed_leveling_enabled(leveling_local); // restore leveling
+    #endif
+
     planner.synchronize();
   }
 #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -411,8 +411,7 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
     TERN_(HAS_FILAMENT_SENSOR, runout.reset());
 
     #if HAS_LEVELING
-      bool leveling_local = false;
-      leveling_local = planner.leveling_active; // save leveling state
+      bool leveling_local = planner.leveling_active; // save leveling state
       set_bed_leveling_enabled(false);  // turn off leveling
     #endif
 


### PR DESCRIPTION
### Description

This is a work around for issue #23540.

Root cause is not yet known.

Early in the pause feature it attempts to do a retract but in doing so it also moves the head to the unleveled location.  The same unwanted head movement also happens when restoring the head at the end of the pause.

Normally the unwanted head movement moves the head away from the print (upwards towards the park position) but, in the case where the nozzle is the probe, this is towards the print.

This work around turns off leveling before the E movement command and then restores it to it's former state immediately afterward.

In the case of UBL bilinear leveling, if the leveling matrix value is posiitive then the unwanted head movement will be towards the bed/print.  If the matrix value is negative then the unwanted head movement is away from the bed (toward the park position).

### Requirements

For this to be a problem the bed probe must trigger **AFTER** the nozzle touches the bed, PAUSE must be enabled and LEVELING must be enabled.

The DUET Smart Effector is an example of a probe that triggers after the nozzle touches the bed.

This isn't a problem for  the vast majority of users because they use probes that trigger before the head touches the bed.

### Configurations

See Issue #23540 for config files and for a gcode file that can be used to safely test for this issue.

---

This fix has been tested on a delta printer using a DUET Smart Effector and a BTT Smart Filament Sensor with UBL bilinear leveling enabled.


