### PR TITLE
Issue #23540, Eliminate unwanted Z movement when parking head

### DIFF
--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -440,7 +440,18 @@ bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const bool 
   // Initial retract before move to filament change position
   if (retract && thermalManager.hotEnoughToExtrude(active_extruder)) {
     DEBUG_ECHOLNPGM("... retract:", retract);
+
+    #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_UBL)
+      bool leveling_local = planner.leveling_active; // save leveling state
+      void set_bed_leveling_enabled(const bool enable=true);
+      set_bed_leveling_enabled(false);  // turn off leveling
+    #endif
+
     unscaled_e_move(retract, PAUSE_PARK_RETRACT_FEEDRATE);
+
+    #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_UBL)
+      set_bed_leveling_enabled(leveling_local); // restore leveling
+    #endif
   }
 
   // If axes don't need to home then the nozzle can park
@@ -640,8 +651,18 @@ void resume_print(const_float_t slow_load_length/*=0*/, const_float_t fast_load_
     prepare_internal_move_to_destination(NOZZLE_PARK_Z_FEEDRATE);
   }
 
+  #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_UBL)
+    bool leveling_local = planner.leveling_active; // save leveling state
+    void set_bed_leveling_enabled(const bool enable=true);
+    set_bed_leveling_enabled(false);  // turn off leveling
+  #endif
+
   // Unretract
   unscaled_e_move(PAUSE_PARK_RETRACT_LENGTH, feedRate_t(PAUSE_PARK_RETRACT_FEEDRATE));
+
+  #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_UBL)
+    set_bed_leveling_enabled(leveling_local); // restore leveling
+  #endif
 
   // Intelligent resuming
   #if ENABLED(FWRETRACT)

--- a/Marlin/src/feature/pause.cpp
+++ b/Marlin/src/feature/pause.cpp
@@ -39,6 +39,10 @@
 #include "../module/printcounter.h"
 #include "../module/temperature.h"
 
+#if ENABLED(AUTO_BED_LEVELING_UBL)
+  #include "bedlevel/bedlevel.h"
+#endif
+
 #if ENABLED(FWRETRACT)
   #include "fwretract.h"
 #endif
@@ -441,17 +445,14 @@ bool pause_print(const_float_t retract, const xyz_pos_t &park_point, const bool 
   if (retract && thermalManager.hotEnoughToExtrude(active_extruder)) {
     DEBUG_ECHOLNPGM("... retract:", retract);
 
-    #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_UBL)
-      bool leveling_local = planner.leveling_active; // save leveling state
-      void set_bed_leveling_enabled(const bool enable=true);
+    #if ENABLED(AUTO_BED_LEVELING_UBL)
+      const bool leveling_was_enabled = planner.leveling_active; // save leveling state
       set_bed_leveling_enabled(false);  // turn off leveling
     #endif
 
     unscaled_e_move(retract, PAUSE_PARK_RETRACT_FEEDRATE);
 
-    #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_UBL)
-      set_bed_leveling_enabled(leveling_local); // restore leveling
-    #endif
+    TERN_(AUTO_BED_LEVELING_UBL, set_bed_leveling_enabled(leveling_was_enabled)); // restore leveling
   }
 
   // If axes don't need to home then the nozzle can park
@@ -651,18 +652,15 @@ void resume_print(const_float_t slow_load_length/*=0*/, const_float_t fast_load_
     prepare_internal_move_to_destination(NOZZLE_PARK_Z_FEEDRATE);
   }
 
-  #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_UBL)
-    bool leveling_local = planner.leveling_active; // save leveling state
-    void set_bed_leveling_enabled(const bool enable=true);
+  #if ENABLED(AUTO_BED_LEVELING_UBL)
+    const bool leveling_was_enabled = planner.leveling_active; // save leveling state
     set_bed_leveling_enabled(false);  // turn off leveling
   #endif
 
   // Unretract
   unscaled_e_move(PAUSE_PARK_RETRACT_LENGTH, feedRate_t(PAUSE_PARK_RETRACT_FEEDRATE));
 
-  #if HAS_LEVELING && ENABLED(AUTO_BED_LEVELING_UBL)
-    set_bed_leveling_enabled(leveling_local); // restore leveling
-  #endif
+  TERN_(AUTO_BED_LEVELING_UBL, set_bed_leveling_enabled(leveling_was_enabled)); // restore leveling
 
   // Intelligent resuming
   #if ENABLED(FWRETRACT)

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -409,8 +409,19 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
 #if HAS_EXTRUDERS
   void unscaled_e_move(const_float_t length, const_feedRate_t fr_mm_s) {
     TERN_(HAS_FILAMENT_SENSOR, runout.reset());
+
+    #if HAS_LEVELING
+      bool leveling_local = planner.leveling_active; // save leveling state
+      set_bed_leveling_enabled(false);  // turn off leveling
+    #endif
+
     current_position.e += length / planner.e_factor[active_extruder];
     line_to_current_position(fr_mm_s);
+
+    #if HAS_LEVELING
+      set_bed_leveling_enabled(leveling_local); // restore leveling
+    #endif
+
     planner.synchronize();
   }
 #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -411,16 +411,14 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
     TERN_(HAS_FILAMENT_SENSOR, runout.reset());
 
     #if HAS_LEVELING
-      bool leveling_local = planner.leveling_active; // save leveling state
-      set_bed_leveling_enabled(false);  // turn off leveling
+      const bool leveling_was_active = planner.leveling_active;
+      set_bed_leveling_enabled(false);
     #endif
 
     current_position.e += length / planner.e_factor[active_extruder];
     line_to_current_position(fr_mm_s);
 
-    #if HAS_LEVELING
-      set_bed_leveling_enabled(leveling_local); // restore leveling
-    #endif
+    TERN_(HAS_LEVELING, set_bed_leveling_enabled(leveling_was_active));
 
     planner.synchronize();
   }

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -409,17 +409,8 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
 #if HAS_EXTRUDERS
   void unscaled_e_move(const_float_t length, const_feedRate_t fr_mm_s) {
     TERN_(HAS_FILAMENT_SENSOR, runout.reset());
-
-    #if HAS_LEVELING
-      const bool leveling_was_active = planner.leveling_active;
-      set_bed_leveling_enabled(false);
-    #endif
-
     current_position.e += length / planner.e_factor[active_extruder];
     line_to_current_position(fr_mm_s);
-
-    TERN_(HAS_LEVELING, set_bed_leveling_enabled(leveling_was_active));
-
     planner.synchronize();
   }
 #endif

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -409,19 +409,8 @@ void line_to_current_position(const_feedRate_t fr_mm_s/*=feedrate_mm_s*/) {
 #if HAS_EXTRUDERS
   void unscaled_e_move(const_float_t length, const_feedRate_t fr_mm_s) {
     TERN_(HAS_FILAMENT_SENSOR, runout.reset());
-
-    #if HAS_LEVELING
-      bool leveling_local = planner.leveling_active; // save leveling state
-      set_bed_leveling_enabled(false);  // turn off leveling
-    #endif
-
     current_position.e += length / planner.e_factor[active_extruder];
     line_to_current_position(fr_mm_s);
-
-    #if HAS_LEVELING
-      set_bed_leveling_enabled(leveling_local); // restore leveling
-    #endif
-
     planner.synchronize();
   }
 #endif
@@ -518,8 +507,8 @@ void do_blocking_move_to(LINEAR_AXIS_ARGS(const float), const_feedRate_t fr_mm_s
 
     // when in the danger zone
     if (current_position.z > delta_clip_start_height) {
-      if (z > delta_clip_start_height) {                     // staying in the danger zone
-        destination.set(x, y, z);                          // move directly (uninterpolated)
+      if (z > delta_clip_start_height) {                      // staying in the danger zone
+        destination.set(x, y, z);                             // move directly (uninterpolated)
         prepare_internal_fast_move_to_destination();          // set current_position from destination
         if (DEBUGGING(LEVELING)) DEBUG_POS("danger zone move", current_position);
         return;
@@ -529,7 +518,7 @@ void do_blocking_move_to(LINEAR_AXIS_ARGS(const float), const_feedRate_t fr_mm_s
       if (DEBUGGING(LEVELING)) DEBUG_POS("zone border move", current_position);
     }
 
-    if (z > current_position.z) {                            // raising?
+    if (z > current_position.z) {                             // raising?
       destination.z = z;
       prepare_internal_fast_move_to_destination(z_feedrate);  // set current_position from destination
       if (DEBUGGING(LEVELING)) DEBUG_POS("z raise move", current_position);
@@ -539,7 +528,7 @@ void do_blocking_move_to(LINEAR_AXIS_ARGS(const float), const_feedRate_t fr_mm_s
     prepare_internal_move_to_destination();                   // set current_position from destination
     if (DEBUGGING(LEVELING)) DEBUG_POS("xy move", current_position);
 
-    if (z < current_position.z) {                            // lowering?
+    if (z < current_position.z) {                             // lowering?
       destination.z = z;
       prepare_internal_fast_move_to_destination(z_feedrate);  // set current_position from destination
       if (DEBUGGING(LEVELING)) DEBUG_POS("z lower move", current_position);
@@ -548,39 +537,32 @@ void do_blocking_move_to(LINEAR_AXIS_ARGS(const float), const_feedRate_t fr_mm_s
   #elif IS_SCARA
 
     // If Z needs to raise, do it before moving XY
-    if (destination.z < z) {
-      destination.z = z;
-      prepare_internal_fast_move_to_destination(z_feedrate);
-    }
+    if (destination.z < z) { destination.z = z; prepare_internal_fast_move_to_destination(z_feedrate); }
 
-    destination.set(x, y);
-    prepare_internal_fast_move_to_destination(xy_feedrate);
+    destination.set(x, y); prepare_internal_fast_move_to_destination(xy_feedrate);
 
     // If Z needs to lower, do it after moving XY
-    if (destination.z > z) {
-      destination.z = z;
-      prepare_internal_fast_move_to_destination(z_feedrate);
-    }
+    if (destination.z > z) { destination.z = z; prepare_internal_fast_move_to_destination(z_feedrate); }
 
   #else
 
-    #if HAS_Z_AXIS
-      // If Z needs to raise, do it before moving XY
-      if (current_position.z < z) {
-        current_position.z = z;
-        line_to_current_position(z_feedrate);
-      }
+    #if HAS_Z_AXIS  // If Z needs to raise, do it before moving XY
+      if (current_position.z < z) { current_position.z = z; line_to_current_position(z_feedrate); }
     #endif
 
-    current_position.set(x, y);
-    line_to_current_position(xy_feedrate);
+    current_position.set(x, y); line_to_current_position(xy_feedrate);
 
-    #if HAS_Z_AXIS
-      // If Z needs to lower, do it after moving XY
-      if (current_position.z > z) {
-        current_position.z = z;
-        line_to_current_position(z_feedrate);
-      }
+    #if HAS_I_AXIS
+      current_position.i = i; line_to_current_position(i_feedrate);
+    #endif
+    #if HAS_J_AXIS
+      current_position.j = j; line_to_current_position(j_feedrate);
+    #endif
+    #if HAS_K_AXIS
+      current_position.k = k; line_to_current_position(k_feedrate);
+    #endif
+    #if HAS_Z_AXIS  // If Z needs to lower, do it after moving XY...
+      if (current_position.z > z) { current_position.z = z; line_to_current_position(z_feedrate); }
     #endif
 
   #endif
@@ -1422,6 +1404,15 @@ void prepare_line_to_destination() {
             #endif
             break;
         #endif
+        #if I_SENSORLESS
+          case I_AXIS: stealth_states.i = tmc_enable_stallguard(stepperI); break;
+        #endif
+        #if J_SENSORLESS
+          case J_AXIS: stealth_states.j = tmc_enable_stallguard(stepperJ); break;
+        #endif
+        #if K_SENSORLESS
+          case K_AXIS: stealth_states.k = tmc_enable_stallguard(stepperK); break;
+        #endif
       }
 
       #if ENABLED(SPI_ENDSTOPS)
@@ -1498,6 +1489,15 @@ void prepare_line_to_destination() {
               tmc_disable_stallguard(stepperY, enable_stealth.y);
             #endif
             break;
+        #endif
+        #if I_SENSORLESS
+          case I_AXIS: tmc_disable_stallguard(stepperI, enable_stealth.i); break;
+        #endif
+        #if J_SENSORLESS
+          case J_AXIS: tmc_disable_stallguard(stepperJ, enable_stealth.j); break;
+        #endif
+        #if K_SENSORLESS
+          case K_AXIS: tmc_disable_stallguard(stepperK, enable_stealth.k); break;
         #endif
       }
 
@@ -1835,8 +1835,12 @@ void prepare_line_to_destination() {
         switch (axis) {
           default:
           case X_AXIS: es = X_ENDSTOP; break;
-          case Y_AXIS: es = Y_ENDSTOP; break;
-          case Z_AXIS: es = Z_ENDSTOP; break;
+          #if HAS_Y_AXIS
+            case Y_AXIS: es = Y_ENDSTOP; break;
+          #endif
+          #if HAS_Z_AXIS
+            case Z_AXIS: es = Z_ENDSTOP; break;
+          #endif
           #if HAS_I_AXIS
             case I_AXIS: es = I_ENDSTOP; break;
           #endif


### PR DESCRIPTION
### Description

This is a work around for issue #23540.

Root cause is not yet known.

Early in the pause feature it attempts to do a retract but in doing so it also moves the head to the unleveled location.  The same unwanted head movement also happens when restoring the head at the end of the pause.

Normally the unwanted head movement moves the head away from the print (upwards towards the park position) but, in the case where the nozzle is the probe, this is towards the print.

This work around turns off leveling before the E movement command and then restores it to it's former state immediately afterward.

In the case of UBL bilinear leveling, if the leveling matrix value is posiitive then the unwanted head movement will be towards the bed/print.  If the matrix value is negative then the unwanted head movement is away from the bed (toward the park position).

### Requirements

For this to be a problem the bed probe must trigger **AFTER** the nozzle touches the bed, PAUSE must be enabled and LEVELING must be enabled.

The DUET Smart Effector is an example of a probe that triggers after the nozzle touches the bed.

This isn't a problem for  the vast majority of users because they use probes that trigger before the head touches the bed.

### Configurations

See Issue #23540 for config files and for a gcode file that can be used to safely test for this issue.

---

This fix has been tested on a delta printer using a DUET Smart Effector and a BTT Smart Filament Sensor with UBL bilinear leveling enabled.

---

This PR replaces PRs #23565 and #23566 which were pulled against the wrong branch.  This PR is an exat copy of the previous PRs.
