### PR TITLE
🧑‍💻 Fix up some AUX / EXP pins

### DIFF
--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -120,7 +120,7 @@
 #define SD_MISO_PIN                           19
 #define SD_SCK_PIN                            18
 #define SDSS                                   5
-#define SD_DETECT_PIN                         34  // IO34 default is SD_DET signal(Jump to SDDET)
+#define SD_DETECT_PIN                         34  // IO34 default is SD_DET signal (Jump to SDDET)
 #define USES_SHARED_SPI                           // SPI is shared by SD card with TMC SPI drivers
 
 /**
@@ -177,9 +177,9 @@
 
   #elif ENABLED(MKS_MINI_12864_V3)
 
+    #define LCD_PINS_DC              EXP1_07_PIN
     #define DOGLCD_CS                EXP1_08_PIN
-    #define DOGLCD_A0                EXP1_07_PIN
-    #define LCD_PINS_DC                DOGLCD_A0
+    #define DOGLCD_A0                LCD_PINS_DC
     #define LCD_BACKLIGHT_PIN                 -1
     #define LCD_RESET_PIN            EXP1_06_PIN
     #define NEOPIXEL_PIN             EXP1_05_PIN

--- a/Marlin/src/pins/esp32/pins_PANDA_common.h
+++ b/Marlin/src/pins/esp32/pins_PANDA_common.h
@@ -62,6 +62,13 @@
 #define TEMP_0_PIN                            39  // Analog Input
 #define TEMP_BED_PIN                          36  // Analog Input
 
+#if ENABLED(MAX31856_PANDAPI)
+  #define MAX31856_CLK_PIN                    29
+  #define MAX31856_MISO_PIN                   24
+  #define MAX31856_MOSI_PIN                   28
+  #define MAX31856_CS_PIN                     27
+#endif
+
 //
 // Heaters / Fans
 //
@@ -74,25 +81,48 @@
   #define E0_AUTO_FAN_PIN                    120  // FAN2
 #endif
 
+/**            ------                              ------
+ * (MISO 19?) |10  9 | (18 SCK?)     (BEEPER) 129 |10  9 | 12 (^ENC)
+ *   (EN1) 33 | 8  7 | (5 SDSS?)     (EN)      26 | 8  7 | 27 (RS)
+ *   (EN2) 32   6  5 | (23 MOSI?)    (D4)      14 | 6  5   --
+ * (SDDET 2?) | 4  3 | (RESET)                 -- | 4  3 | --
+ *         -- | 2  1 | --                   (GND) | 2  1 | (5V)
+ *             ------                              ------
+ *              EXP2                                EXP1
+ */
+#define EXP1_06_PIN                           14
+#define EXP1_07_PIN                           27
+#define EXP1_08_PIN                           26
+#define EXP1_09_PIN                           12
+#define EXP1_10_PIN                          129
+
+#define EXP2_04_PIN                            2  // ?
+#define EXP2_05_PIN                           23  // ?
+#define EXP2_06_PIN                           32
+#define EXP2_07_PIN                            5  // ?
+#define EXP2_08_PIN                           33
+#define EXP2_09_PIN                           18  // ?
+#define EXP2_10_PIN                           19  // ?
+
 //
-// SD card
+// SD Card
 //
 #if ENABLED(SDSUPPORT)
-  #define SD_MOSI_PIN                         23
-  #define SD_MISO_PIN                         19
-  #define SD_SCK_PIN                          18
-  #define SDSS                                 5
-  #define SD_DETECT_PIN                        2
+  #define SD_MOSI_PIN                EXP2_05_PIN
+  #define SD_MISO_PIN                EXP2_10_PIN
+  #define SD_SCK_PIN                 EXP2_09_PIN
+  #define SDSS                       EXP2_07_PIN
+  #define SD_DETECT_PIN              EXP2_04_PIN
 #endif
 
 #if HAS_WIRED_LCD
-  #define BEEPER_PIN                         129
-  #define BTN_ENC                             12
+  #define BEEPER_PIN                 EXP1_10_PIN
 
-  #define BTN_EN1                             33
-  #define BTN_EN2                             32
+  #define BTN_ENC                    EXP1_09_PIN
+  #define BTN_EN1                    EXP2_08_PIN
+  #define BTN_EN2                    EXP2_06_PIN
 
-  #define LCD_PINS_RS                         27
-  #define LCD_PINS_ENABLE                     26
-  #define LCD_PINS_D4                         14
+  #define LCD_PINS_RS                EXP1_07_PIN
+  #define LCD_PINS_ENABLE            EXP1_08_PIN
+  #define LCD_PINS_D4                EXP1_06_PIN
 #endif

--- a/Marlin/src/pins/mega/pins_LEAPFROG_XEED2015.h
+++ b/Marlin/src/pins/mega/pins_LEAPFROG_XEED2015.h
@@ -84,7 +84,7 @@
 #define E1_ENABLE_PIN                         33
 
 //
-// Filament runout
+// Filament Runout Sensor
 //
 #define FIL_RUNOUT_PIN                        42  // ROT2 Connector
 #define FIL_RUNOUT2_PIN                       44  // ROT1 Connector

--- a/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
@@ -69,7 +69,7 @@
 #endif
 
 //
-// Filament Runout Pins
+// Filament Runout Sensor
 //
 #ifndef FIL_RUNOUT_PIN
   #define FIL_RUNOUT_PIN                      49

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -120,14 +120,14 @@
 #define X_DIR_PIN                             55
 #define X_ENABLE_PIN                          38
 #ifndef X_CS_PIN
-  #define X_CS_PIN                   AUX3_03_PIN
+  #define X_CS_PIN                            53
 #endif
 
 #define Y_STEP_PIN                            60
 #define Y_DIR_PIN                             61
 #define Y_ENABLE_PIN                          56
 #ifndef Y_CS_PIN
-  #define Y_CS_PIN                   AUX3_07_PIN
+  #define Y_CS_PIN                            49
 #endif
 
 #ifndef Z_STEP_PIN
@@ -241,7 +241,7 @@
 // Misc. Functions
 //
 #ifndef SDSS
-  #define SDSS                       AUX3_03_PIN
+  #define SDSS                       AUX3_06_PIN
 #endif
 #define LED_PIN                               13
 
@@ -423,18 +423,22 @@
 #endif
 
 //
-// AUX1 : 5V GND D2 D1
-//        5V GND A3 A4
-
+// AUX1    5V  GND D2  D1
+//          2   4   6   8
+//          1   3   5   7
+//         5V  GND A3  A4
+//
 #define AUX1_05_PIN                           57  // (A3)
 #define AUX1_06_PIN                            2
 #define AUX1_07_PIN                           58  // (A4)
 #define AUX1_08_PIN                            1
 
 //
-// AUX2 : GND A9 D40 D42 A11
-//        VCC A5 A10 D44 A12
-
+// AUX2    GND A9 D40 D42 A11
+//          2   4   6   8  10
+//          1   3   5   7   9
+//         VCC A5 A10 D44 A12
+//
 #define AUX2_03_PIN                           59  // (A5)
 #define AUX2_04_PIN                           63  // (A9)
 #define AUX2_05_PIN                           64  // (A10)
@@ -445,19 +449,20 @@
 #define AUX2_10_PIN                           65  // (A11)
 
 //
-// AUX3 : GND D52 D50 5V
-//        NC  D53 D51 D49
-
-#define AUX3_03_PIN                           53
-#define AUX3_04_PIN                           52
-#define AUX3_05_PIN                           51
-#define AUX3_06_PIN                           50
-#define AUX3_07_PIN                           49
+// AUX3    GND D52 D50 5V
+//          7   5   3   1
+//          8   6   4   2
+//         NC  D53 D51 D49
+//
+#define AUX3_02_PIN                           49
+#define AUX3_03_PIN                           50
+#define AUX3_04_PIN                           51
+#define AUX3_05_PIN                           52
+#define AUX3_06_PIN                           53
 
 //
-// AUX4 : D16 D17 D23 D25 D27 D29 D31 D33 D35 D37 D39 D41 D43 D45 D47 D32 GND 5V
+// AUX4    5V GND D32 D47 D45 D43 D41 D39 D37 D35 D33 D31 D29 D27 D25 D23 D17 D16
 //
-
 #define AUX4_03_PIN                           32
 #define AUX4_04_PIN                           47
 #define AUX4_05_PIN                           45
@@ -476,35 +481,69 @@
 #define AUX4_18_PIN                           16
 
 /**
- * LCD adapter. NOTE: These come in two variants. The socket keys can be
+ * LCD adapters come in different variants. The socket keys can be
  * on either side, and may be backwards on some boards / displays.
- *         ------                     ------
- *    D37 |10  9 | D35    (MISO) D50 |10  9 | D52 (SCK)
- *    D17 | 8  7 | D16           D31 | 8  7 | D53
- *    D23   6  5   D25           D33   6  5   D51 (MOSI)
- *    D27 | 4  3 | D29           D49 | 4  3 | D41
- *    GND | 2  1 | 5V            GND | 2  1 | --
- *         ------                     ------
- *          EXP1                       EXP2
  */
 #ifndef EXP1_03_PIN
+
   #define EXP1_03_PIN                AUX4_13_PIN
   #define EXP1_04_PIN                AUX4_14_PIN
   #define EXP1_05_PIN                AUX4_15_PIN
   #define EXP1_06_PIN                AUX4_16_PIN
   #define EXP1_07_PIN                AUX4_18_PIN
   #define EXP1_08_PIN                AUX4_17_PIN
-  #define EXP1_09_PIN                AUX4_10_PIN
-  #define EXP1_10_PIN                AUX4_09_PIN
 
-  #define EXP2_03_PIN                AUX4_07_PIN
-  #define EXP2_04_PIN                AUX3_07_PIN
-  #define EXP2_05_PIN                AUX3_05_PIN
-  #define EXP2_06_PIN                AUX4_11_PIN
-  #define EXP2_07_PIN                AUX3_03_PIN
-  #define EXP2_08_PIN                AUX4_12_PIN
-  #define EXP2_09_PIN                AUX3_04_PIN
-  #define EXP2_10_PIN                AUX3_06_PIN
+  #define EXP2_04_PIN                AUX3_02_PIN
+  #define EXP2_05_PIN                AUX3_04_PIN
+  #define EXP2_07_PIN                AUX3_06_PIN
+  #define EXP2_09_PIN                AUX3_05_PIN
+  #define EXP2_10_PIN                AUX3_03_PIN
+
+  #if ENABLED(G3D_PANEL)
+    /**                  Gadgets3D Smart Adapter
+     *              ------                        ------
+     *        4-11 |10  9 | 4-12     (MISO) 3-03 |10  9 | 3-05 (SCK)
+     *        4-17 | 8  7 | 4-18            4-10 | 8  7 | 3-06
+     *        4-16   6  5 | 4-15            4-09   6  5 | 3-04 (MOSI)
+     *        4-14 | 4  3 | 4-13            3-02 | 4  3 | 4-07
+     *  (GND) 4-02 | 2  1 | 4-01 (5V)         -- | 2  1 | --
+     *              ------                        ------
+     *               EXP1                          EXP2
+     */
+    #define EXP1_09_PIN              AUX4_12_PIN
+    #define EXP1_10_PIN              AUX4_11_PIN
+
+    #define EXP2_03_PIN              AUX4_07_PIN
+    #define EXP2_06_PIN              AUX4_09_PIN
+    #define EXP2_08_PIN              AUX4_10_PIN
+
+  #else
+
+    /**                     Smart Adapter (c) RRD
+     *             ------                           ------
+     *       4-09 |10  9 | 4-10        (MISO) 3-03 |10  9 | 3-05 (SCK)
+     *       4-17 | 8  7 | 4-18               4-12 | 8  7 | 3-06
+     *       4-16   6  5 | 4-15               4-11   6  5 | 3-04 (MOSI)
+     *       4-14 | 4  3 | 4-13               3-02 | 4  3 | 4-07
+     * (GND) 3-07 | 2  1 | 3-01 (5V)    (GND) 3-07 | 2  1 | --
+     *             ------                           ------
+     *              EXP1                             EXP2
+     */
+    #define EXP1_09_PIN              AUX4_10_PIN
+    #define EXP1_10_PIN              AUX4_09_PIN
+
+    #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
+      #define EXP2_03_PIN                     -1  // RESET
+      #define EXP2_06_PIN            AUX4_12_PIN
+      #define EXP2_08_PIN            AUX4_11_PIN
+    #else
+      #define EXP2_03_PIN            AUX4_07_PIN
+      #define EXP2_06_PIN            AUX4_11_PIN
+      #define EXP2_08_PIN            AUX4_12_PIN
+    #endif
+
+  #endif
+
 #endif
 
 //////////////////////////
@@ -752,7 +791,7 @@
       #define BTN_EN2                AUX2_04_PIN
       #define BTN_ENC                AUX2_03_PIN
 
-      #define SD_DETECT_PIN          AUX3_07_PIN
+      #define SD_DETECT_PIN          AUX3_02_PIN
       #define KILL_PIN               AUX2_05_PIN
 
     #elif ENABLED(ZONESTAR_LCD)
@@ -765,14 +804,14 @@
 
     #elif ENABLED(G3D_PANEL)
 
-      #define BEEPER_PIN             EXP2_06_PIN
+      #define BEEPER_PIN             EXP1_10_PIN
 
       #define SD_DETECT_PIN          EXP2_04_PIN
       #define KILL_PIN               EXP2_03_PIN
 
-      #define BTN_EN1                EXP1_10_PIN
-      #define BTN_EN2                EXP1_09_PIN
-      #define BTN_ENC                EXP2_08_PIN
+      #define BTN_EN1                EXP2_06_PIN
+      #define BTN_EN2                EXP2_08_PIN
+      #define BTN_ENC                EXP1_09_PIN
 
     #elif IS_TFTGLCD_PANEL
 
@@ -785,7 +824,7 @@
       #if ENABLED(PANEL_ONE)                       // Buttons connect directly to AUX-2
         #define BTN_EN1              AUX2_03_PIN
         #define BTN_EN2              AUX2_04_PIN
-        #define BTN_ENC              AUX3_07_PIN
+        #define BTN_ENC              AUX3_02_PIN
       #else
         #define BTN_EN1              EXP1_10_PIN
         #define BTN_EN2              EXP1_09_PIN
@@ -819,15 +858,15 @@
   /**
    * FYSETC TFT-81050 display pinout
    *
-   *               Board                                     Display
-   *               ------                                    ------
-   *          GND |10  9 | --                            5V |10  9 | GND
-   *  (SD_DET) 49 | 8  7 | RESET                      RESET | 8  7 | (SD_DET)
-   * (BTN_EN1) 31   6  5 | 51 (MOSI)                 (MOSI)   6  5 | (LCD_CS)
-   * (BTN_EN2) 33 | 4  3 | 53 (SD_CS)               (SD_CS) | 4  3 | (MOD_RESET)
-   *    (MISO) 50 | 2  1 | 52 (SCK)                   (SCK) | 2  1 | (MISO)
-   *               ------                                    ------
-   *                EXP2                                      EXP1
+   *               Board                            Display
+   *               ------                           ------
+   *    (MISO) 50 |10  9 | 52 (SCK)             5V |10  9 | GND
+   * (BTN_EN2) 33 | 8  7 | 53 (SD_CS)        RESET | 8  7 | (SD_DET)
+   * (BTN_EN1) 31   6  5 | 51 (MOSI)        (MOSI)   6  5 | (LCD_CS)
+   *  (SD_DET) 49 | 4  3 | RESET           (SD_CS) | 4  3 | (MOD_RESET)
+   *          GND | 2  1 | --                (SCK) | 2  1 | (MISO)
+   *               ------                           ------
+   *                EXP2
    *
    * Needs custom cable:
    *
@@ -852,6 +891,7 @@
 
   #define SD_DETECT_PIN              EXP2_04_PIN
 
-  #define CLCD_MOD_RESET             EXP2_08_PIN
-  #define CLCD_SPI_CS                EXP2_06_PIN
+  #define CLCD_MOD_RESET             EXP2_06_PIN
+  #define CLCD_SPI_CS                EXP2_08_PIN
+
 #endif // TOUCH_UI_FTDI_EVE && LCD_FYSETC_TFT81050

--- a/Marlin/src/pins/sanguino/pins_ZMIB_V2.h
+++ b/Marlin/src/pins/sanguino/pins_ZMIB_V2.h
@@ -146,7 +146,7 @@
 #define FAN1_PIN                              -1
 
 //
-//filament run out sensor
+// Filament Runout Sensor
 //
 #if EITHER(Z6S_ZFAULT, Z6BS_ZFAULT)
   #define FIL_RUNOUT_PIN                      13
@@ -162,32 +162,38 @@
 #endif
 #define SD_DETECT_PIN                         -1
 
-/*===================================================
- * ZMIB Version 1 - EXP1 Connector
- *   MOSI(D5)  TX1(D11)  ENA(D12)  ENC(D29/A2) 5V
- *   SCK(D7)   RX1(D10)  SCS(D4)   ENB(D2)     GND
- *===================================================
- * ZMIB Version 2 - EXP1 Connector
- *   MOSI(D5)  TX1(D11)  ENA(D12)  ENC(D29/A2) 5V
- *   SCK(D7)   RX1(D10)  SCS(D3)   ENB(D2)     GND
- *===================================================
- * LCD 128x64
- *==================================================*/
+/**             EXP1
+ *             ------
+ * (MOSI) D5  |10  9 | D7       (SCK)
+ * (CS)   D11 | 8  7 | D10      (DC/D4)
+ * (EN2)  D12   6  5 | D4 or D3 (EN/RS)
+ * (ENC)  D29 | 4  3 | D2       (EN1)
+ *      (GND) | 2  1 | (5V)
+ *             ------
+ */
+#define EXP1_03_PIN                            2
+#define EXP1_04_PIN                           29
+#ifndef IS_ZMIB_V2
+  #define EXP1_05_PIN                          4  // ZMIB V1
+#else
+  #define EXP1_05_PIN                          3  // ZMIB V2
+#endif
+#define EXP1_06_PIN                           12
+#define EXP1_07_PIN                           10
+#define EXP1_08_PIN                           11
+#define EXP1_09_PIN                            7
+#define EXP1_10_PIN                            5
 
 #if ENABLED(ZONESTAR_12864LCD)
   //
   // LCD 128x64
   //
-  #define LCDSCREEN_NAME  "ZONESTAR_12864LCD"
+  #define LCDSCREEN_NAME "ZONESTAR_12864LCD"
   #define FORCE_SOFT_SPI
-  //#define LCD_SDSS                          11
-  #define LCD_PINS_RS                         11  // ST7920_CS_PIN    LCD_PIN_RS    (PIN4 of LCD module)
-  #ifdef IS_ZMIB_V2
-    #define LCD_PINS_ENABLE                    3  // ST7920_DAT_PIN LCD_PIN_R/W   (PIN5 of LCD module)
-  #else
-    #define LCD_PINS_ENABLE                    4  // ST7920_DAT_PIN LCD_PIN_R/W   (PIN5 of LCD module)
-  #endif
-  #define LCD_PINS_D4                         10  // ST7920_CLK_PIN LCD_PIN_ENABLE (PIN6 of LCD module)
+  //#define LCD_SDSS                 EXP1_08_PIN
+  #define LCD_PINS_RS                EXP1_08_PIN  // ST7920_CS_PIN  (LCD module pin 4)
+  #define LCD_PINS_ENABLE            EXP1_05_PIN  // ST7920_DAT_PIN (LCD module pin 5)
+  #define LCD_PINS_D4                EXP1_07_PIN  // ST7920_CLK_PIN (LCD module pin 6)
 
   #define BOARD_ST7920_DELAY_1       DELAY_2_NOP
   #define BOARD_ST7920_DELAY_2       DELAY_2_NOP
@@ -199,34 +205,28 @@
   //
   #define LCDSCREEN_NAME "ZONESTAR 12864OLED"
   #define FORCE_SOFT_SPI
-  #ifdef IS_ZMIB_V2
-    #define LCD_PINS_RS                        3  // RESET
-  #else
-    #define LCD_PINS_RS                        4  // RESET
-  #endif
-  #define LCD_PINS_DC                         10  // DC
-  #define DOGLCD_CS                           11  // CS
+  #define LCD_PINS_RS                EXP1_05_PIN
+  #define LCD_PINS_DC                EXP1_07_PIN
+  #define DOGLCD_CS                  EXP1_08_PIN
+
   #if ENABLED(OLED_HW_IIC)
     #error "Oops! can't choose HW IIC for ZMIB board!!"
-  #elif ENABLED(OLED_HW_SPI)
-    // HW SPI
-    #define DOGLCD_A0                LCD_PINS_DC  // A0 = DC
   #else
-    // SW SPI
-    #define DOGLCD_A0                LCD_PINS_DC  // A0 = DC
-    #define DOGLCD_MOSI             AVR_MOSI_PIN  // SDA
-    #define DOGLCD_SCK               AVR_SCK_PIN  // SCK
+    #define DOGLCD_A0                LCD_PINS_DC
+    #if DISABLED(OLED_HW_SPI)
+      #define DOGLCD_MOSI           AVR_MOSI_PIN  // Software SPI
+      #define DOGLCD_SCK             AVR_SCK_PIN
+    #endif
   #endif
-
 #endif
 
 //
 // All the above are also RRDSC with rotary encoder
 //
 #if IS_RRD_SC
-  #define BTN_EN1                              2
-  #define BTN_EN2                             12
-  #define BTN_ENC                             29
+  #define BTN_EN1                    EXP1_03_PIN
+  #define BTN_EN2                    EXP1_06_PIN
+  #define BTN_ENC                    EXP1_04_PIN
   #define BEEPER_PIN                          -1
   #define KILL_PIN                            -1
 #endif

--- a/Marlin/src/pins/stm32f1/pins_GTM32_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_GTM32_MINI.h
@@ -186,7 +186,7 @@
 #ifdef GTM32_PRO_VB_USE_LCD_BEEPER
   // This is pin 32 on J2 FFC40 and pin, goes to the beeper
   // on Geeetech's version of RepRapDiscount Smart Controller
-  // (e.g. on Rostock 301)
+  // (e.g., on Rostock 301)
   #define BEEPER_PIN                        PE12
 #else
   // This is the beeper on the board itself

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -125,7 +125,7 @@
 //#define TEMP_0_CS_PIN                     PE6   // TC2 - CS2
 
 //
-// Filament runout sensor
+// Filament Runout Sensor
 //
 #define FIL_RUNOUT_PIN                      PF11  // MT_DET
 

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -315,9 +315,9 @@
     #endif
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
+    #define LCD_PINS_DC                     PC6
     #define DOGLCD_CS                       PD13
-    #define DOGLCD_A0                       PC6
-    #define LCD_PINS_DC                DOGLCD_A0
+    #define DOGLCD_A0                  DOGLCD_A0
     #define LCD_BACKLIGHT_PIN               -1
     #define LCD_RESET_PIN                   PE14
     #define NEOPIXEL_PIN                    PE15

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_common.h
@@ -197,9 +197,10 @@
     #define DOGLCD_MOSI              EXP2_05_PIN
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
+
+    #define LCD_PINS_DC              EXP1_07_PIN
     #define DOGLCD_CS                EXP1_08_PIN
-    #define DOGLCD_A0                EXP1_07_PIN
-    #define LCD_PINS_DC                DOGLCD_A0
+    #define DOGLCD_A0                LCD_PINS_DC
     #define LCD_BACKLIGHT_PIN               -1
     #define LCD_RESET_PIN            EXP1_06_PIN
     #define NEOPIXEL_PIN             EXP1_05_PIN

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -341,9 +341,9 @@
     #endif
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
+    #define LCD_PINS_DC                     PC6
     #define DOGLCD_CS                       PD13
-    #define DOGLCD_A0                       PC6
-    #define LCD_PINS_DC                DOGLCD_A0
+    #define DOGLCD_A0                  DOGLCD_A0
     #define LCD_BACKLIGHT_PIN               -1
     #define LCD_RESET_PIN                   PE14
     #define NEOPIXEL_PIN                    PE15

--- a/Marlin/src/pins/stm32f1/pins_ZM3E2_V1_0.h
+++ b/Marlin/src/pins/stm32f1/pins_ZM3E2_V1_0.h
@@ -224,7 +224,7 @@
   #define LCD_PINS_RS                EXP1_05_PIN  // = LCD_RESET_PIN
   #define LCD_PINS_DC                EXP1_07_PIN  // DC
   #define DOGLCD_CS                  EXP1_08_PIN  // CS
-  #define DOGLCD_A0                  LCD_PINS_DC  // A0 = DC
+  #define DOGLCD_A0                  LCD_PINS_DC
   #define DOGLCD_MOSI                EXP1_10_PIN  // SDA
   #define DOGLCD_SCK                 EXP1_09_PIN  // SCK
   // Encoder

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
@@ -352,9 +352,9 @@
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
 
+    #define LCD_PINS_DC              EXP1_07_PIN
     #define DOGLCD_CS                EXP1_08_PIN
-    #define DOGLCD_A0                EXP1_07_PIN
-    #define LCD_PINS_DC                DOGLCD_A0
+    #define DOGLCD_A0                LCD_PINS_DC
     #define LCD_BACKLIGHT_PIN               -1
     #define LCD_RESET_PIN            EXP1_06_PIN
     #define NEOPIXEL_PIN             EXP1_05_PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -338,9 +338,9 @@
     //#undef SHOW_BOOTSCREEN
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
+    #define LCD_PINS_DC              EXP1_07_PIN
     #define DOGLCD_CS                EXP1_08_PIN
-    #define DOGLCD_A0                EXP1_07_PIN
-    #define LCD_PINS_DC                DOGLCD_A0
+    #define DOGLCD_A0                LCD_PINS_DC
     #define LCD_BACKLIGHT_PIN               -1
     #define LCD_RESET_PIN            EXP1_06_PIN
     #define NEOPIXEL_PIN             EXP1_05_PIN


### PR DESCRIPTION
- Define RAMPS AUX3 pins in schematic order.
- Define EXP2/3 pins for `G3D_PANEL` adapter.
- Define EXP2 pins for `LCD_FYSETC_TFT81050`.
- Define EXP1 header for ZMIB_V2.
- Define `DOGLCD_A0` from `LCD_PINS_DC` (not _vice-versa_)
- Define Panda Pi EXP headers from schematic and best-guess.