### PR TITLE
Changes to fix issue with UBL and ADC Keypad and PAUSE_BEFORE_DEPLOY_STOW

### DIFF
--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -710,6 +710,9 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
 
     #if HAS_ENCODER_ACTION
       if (clear_buttons) buttons = 0;
+      #if HAS_ADC_BUTTONS
+        keypad_buttons = 0;
+      #endif
       next_button_update_ms = millis() + 500;
     #else
       UNUSED(clear_buttons);

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -299,6 +299,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
       TERN_(EXTENSIBLE_UI, ExtUI::onUserConfirmRequired(F("Stow Probe")));
       TERN_(DWIN_CREALITY_LCD_ENHANCED, DWIN_Popup_Confirm(ICON_BLTouch, F("Stow Probe"), FPSTR(CONTINUE_STR)));
       TERN_(HAS_RESUME_CONTINUE, wait_for_user_response());
+      ui.quick_feedback(true);
       ui.reset_status();
 
     } while (ENABLED(PAUSE_PROBE_DEPLOY_WHEN_TRIGGERED));


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Fix for UBL G29 P1 with PAUSE_BEFORE_DEPLOY_STOW. Marlin will jump right to Mesh only partially populated in UBL_G29.cpp and will hand up in while loop without these changes. See issue #23514 for more info. This does not fix the issue with ADC keypress while building mesh which also hangs in wait_for_release() loop. That will require more work.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### ADC Keypad with UBL Enabled and PAUSE_BEFORE_DEPLOY_STOW Enabled. 

<!-- Does this PR require a specific board, LCD, etc.? -->

### Fixes operation with UBL and ADC Keypad and AUSE_BEFORE_DEPLOY_STOW

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
