### PR TITLE
Fix DGUS_Reloaded bug

### DIFF
--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.cpp
@@ -57,7 +57,7 @@ void DGUSDisplay::Loop() {
 void DGUSDisplay::Init() {
   LCD_SERIAL.begin(LCD_BAUDRATE);
 
-  Read(DGUS_VERSION, 1);
+  ReadVersions();
 }
 
 void DGUSDisplay::Read(uint16_t addr, uint8_t size) {
@@ -156,6 +156,11 @@ void DGUSDisplay::WriteStringPGM(uint16_t addr, const void* data_ptr, uint8_t si
   while (right_spaces--) {
     LCD_SERIAL.write(use_space ? ' ' : '\0');
   }
+}
+
+void DGUSDisplay::ReadVersions() {
+  if (gui_version != 0 && os_version != 0) return;
+  Read(DGUS_VERSION, 1);
 }
 
 void DGUSDisplay::SwitchScreen(DGUS_Screen screen) {

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSDisplay.h
@@ -69,6 +69,9 @@ public:
   // Until now I did not need to actively read from the display. That's why there is no ReadVariable
   // (I extensively use the auto upload of the display)
 
+  // Read GUI and OS version from screen
+  static void ReadVersions();
+
   // Force display into another screen.
   static void SwitchScreen(DGUS_Screen screen);
   // Play sounds using the display speaker.

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -113,6 +113,8 @@ void DGUSScreenHandler::Loop() {
   if (!booted && ELAPSED(ms, 3000)) {
     booted = true;
 
+    dgus_display.ReadVersions();
+
     if (current_screen == DGUS_Screen::BOOT) {
       MoveToScreen(DGUS_Screen::HOME);
     }

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -100,13 +100,10 @@ void DGUSScreenHandler::Loop() {
   if (new_screen != DGUS_Screen::BOOT) {
     const DGUS_Screen screen = new_screen;
     new_screen = DGUS_Screen::BOOT;
-
-    if (current_screen == screen) {
+    if (current_screen == screen)
       TriggerFullUpdate();
-    }
-    else {
+    else
       MoveToScreen(screen);
-    }
     return;
   }
 
@@ -115,24 +112,25 @@ void DGUSScreenHandler::Loop() {
 
     dgus_display.ReadVersions();
 
-    if (current_screen == DGUS_Screen::BOOT) {
+    if (current_screen == DGUS_Screen::BOOT)
       MoveToScreen(DGUS_Screen::HOME);
-    }
+
     return;
   }
 
   if (ELAPSED(ms, next_event_ms) || full_update) {
     next_event_ms = ms + DGUS_UPDATE_INTERVAL_MS;
 
-    if (!SendScreenVPData(current_screen, full_update)) {
+    if (!SendScreenVPData(current_screen, full_update))
       DEBUG_ECHOLNPGM("SendScreenVPData failed");
-    }
+
     return;
   }
 
   if (current_screen == DGUS_Screen::WAIT
       && ((wait_continue && !wait_for_user)
-          || (!wait_continue && IsPrinterIdle()))) {
+          || (!wait_continue && IsPrinterIdle()))
+  ) {
     MoveToScreen(wait_return_screen, true);
     return;
   }
@@ -153,7 +151,6 @@ void DGUSScreenHandler::Loop() {
 
   if (eeprom_save > 0 && ELAPSED(ms, eeprom_save) && IsPrinterIdle()) {
     eeprom_save = 0;
-
     queue.enqueue_now_P(DGUS_CMD_EEPROM_SAVE);
     return;
   }
@@ -189,7 +186,6 @@ void DGUSScreenHandler::SettingsReset() {
 
   if (!settings_ready) {
     settings_ready = true;
-
     Ready();
   }
 
@@ -227,9 +223,8 @@ void DGUSScreenHandler::LoadSettings(const char *buff) {
 }
 
 void DGUSScreenHandler::ConfigurationStoreWritten(bool success) {
-  if (!success) {
+  if (!success)
     SetStatusMessage(F("EEPROM write failed"));
-  }
 }
 
 void DGUSScreenHandler::ConfigurationStoreRead(bool success) {
@@ -238,7 +233,6 @@ void DGUSScreenHandler::ConfigurationStoreRead(bool success) {
   }
   else if (!settings_ready) {
     settings_ready = true;
-
     Ready();
   }
 }
@@ -247,33 +241,25 @@ void DGUSScreenHandler::PlayTone(const uint16_t frequency, const uint16_t durati
   UNUSED(duration);
 
   if (frequency >= 1 && frequency <= 255) {
-    if (duration >= 1 && duration <= 255) {
+    if (duration >= 1 && duration <= 255)
       dgus_display.PlaySound((uint8_t)frequency, (uint8_t)duration);
-    }
-    else {
+    else
       dgus_display.PlaySound((uint8_t)frequency);
-    }
   }
 }
 
 void DGUSScreenHandler::MeshUpdate(const int8_t xpos, const int8_t ypos) {
   if (current_screen != DGUS_Screen::LEVELING_PROBING) {
-    if (current_screen == DGUS_Screen::LEVELING_AUTOMATIC) {
+    if (current_screen == DGUS_Screen::LEVELING_AUTOMATIC)
       TriggerFullUpdate();
-    }
-
     return;
   }
 
   uint8_t point = ypos * GRID_MAX_POINTS_X + xpos;
   probing_icons[point < 16 ? 0 : 1] |= (1U << (point % 16));
 
-  if (xpos >= GRID_MAX_POINTS_X - 1
-      && ypos >= GRID_MAX_POINTS_Y - 1
-      && !ExtUI::getMeshValid()) {
-    probing_icons[0] = 0;
-    probing_icons[1] = 0;
-  }
+  if (xpos >= GRID_MAX_POINTS_X - 1 && ypos >= GRID_MAX_POINTS_Y - 1 && !ExtUI::getMeshValid())
+    probing_icons[0] = probing_icons[1] = 0;
 
   TriggerFullUpdate();
 }
@@ -284,15 +270,12 @@ void DGUSScreenHandler::PrintTimerStarted() {
 
 void DGUSScreenHandler::PrintTimerPaused() {
   dgus_display.PlaySound(3);
-
   TriggerFullUpdate();
 }
 
 void DGUSScreenHandler::PrintTimerStopped() {
-  if (current_screen != DGUS_Screen::PRINT_STATUS
-      && current_screen != DGUS_Screen::PRINT_ADJUST) {
+  if (current_screen != DGUS_Screen::PRINT_STATUS && current_screen != DGUS_Screen::PRINT_ADJUST)
     return;
-  }
 
   dgus_display.PlaySound(3);
 
@@ -311,23 +294,19 @@ void DGUSScreenHandler::FilamentRunout(const ExtUI::extruder_t extruder) {
 #if ENABLED(SDSUPPORT)
 
   void DGUSScreenHandler::SDCardInserted() {
-    if (current_screen == DGUS_Screen::HOME) {
+    if (current_screen == DGUS_Screen::HOME)
       TriggerScreenChange(DGUS_Screen::PRINT);
-    }
   }
 
   void DGUSScreenHandler::SDCardRemoved() {
-    if (current_screen == DGUS_Screen::PRINT) {
+    if (current_screen == DGUS_Screen::PRINT)
       TriggerScreenChange(DGUS_Screen::HOME);
-    }
   }
 
   void DGUSScreenHandler::SDCardError() {
     SetStatusMessage(GET_TEXT_F(MSG_MEDIA_READ_ERROR));
-
-    if (current_screen == DGUS_Screen::PRINT) {
+    if (current_screen == DGUS_Screen::PRINT)
       TriggerScreenChange(DGUS_Screen::HOME);
-    }
   }
 
 #endif // SDSUPPORT


### PR DESCRIPTION
### Description

This PR fixes a bug in the DGUS_Reloaded extui

Background info:
The DGUS_Reloaded UI has an option in the settings menu to execute G-code. To use this feature you need to flash your lcd with a certain firmware version, which is checked when you try to open the G-code input screen. 

Problem:
Currently it checks the versions when initializing the ```DGUSDisplay```, but appears in the case of the Ender 6 and Ender 3 mainboard (could be the same for other boards, but only had these to test on) that this is too fast and it isn't able to read the versions properly. 
As a result you are not able to open the G-code input screen and you will get a message '**DWIN GUI/OS update required**' while the firmware is in fact up to date.

Solution:
I have had some contact with the developer of the DGUS-reloaded code (See [here](https://github.com/Desuuuu/DGUS-reloaded/discussions/22) for more info) and got a solution of which this PR is based. I had to add an extra call to check the versions after a certain amount of time.

Credits go to Desuuuu for coming up with a fix

### Requirements

Ender 6 and a DWIN T5UID1 touchscreen

### Benefits

Fix a bug in the  DGUS_Reloaded UI

### Configurations

[Configuration files](https://drive.google.com/file/d/16oIcPE2xc0pvRV9d8J_ZHWIqp6r8-aPa/view?usp=sharing)

### Related Issues

-
