### PR TITLE
Creality RCT6 (256K)

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -66,7 +66,7 @@ jobs:
         - mks_robin_lite_maple
         - mks_robin_pro_maple
         #- mks_robin_nano35_maple
-        #- STM32F103RET6_creality_maple
+        #- STM32F103RE_creality_maple
         - STM32F103VE_ZM3E4V2_USB_maple
 
         # STM32 (ST) Environments
@@ -75,7 +75,7 @@ jobs:
         #- STM32F103RC_btt_USB
         - STM32F103RE_btt
         - STM32F103RE_btt_USB
-        - STM32F103RET6_creality
+        - STM32F103RE_creality
         - STM32F103VE_longer
         - STM32F407VE_black
         - STM32F401VE_STEVAL

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -300,26 +300,26 @@
 #define BOARD_MALYAN_M200_V2          4000  // STM32F070CB controller
 #define BOARD_MALYAN_M300             4001  // STM32F070-based delta
 #define BOARD_STM32F103RE             4002  // STM32F103RE Libmaple-based STM32F1 controller
-#define BOARD_MALYAN_M200             4003  // STM32C8T6 Libmaple-based STM32F1 controller
+#define BOARD_MALYAN_M200             4003  // STM32C8 Libmaple-based STM32F1 controller
 #define BOARD_STM3R_MINI              4004  // STM32F103RE Libmaple-based STM32F1 controller
-#define BOARD_GTM32_PRO_VB            4005  // STM32F103VET6 controller
-#define BOARD_GTM32_MINI              4006  // STM32F103VET6 controller
-#define BOARD_GTM32_MINI_A30          4007  // STM32F103VET6 controller
-#define BOARD_GTM32_REV_B             4008  // STM32F103VET6 controller
+#define BOARD_GTM32_PRO_VB            4005  // STM32F103VE controller
+#define BOARD_GTM32_MINI              4006  // STM32F103VE controller
+#define BOARD_GTM32_MINI_A30          4007  // STM32F103VE controller
+#define BOARD_GTM32_REV_B             4008  // STM32F103VE controller
 #define BOARD_MORPHEUS                4009  // STM32F103C8 / STM32F103CB  Libmaple-based STM32F1 controller
-#define BOARD_CHITU3D                 4010  // Chitu3D (STM32F103RET6)
-#define BOARD_MKS_ROBIN               4011  // MKS Robin (STM32F103ZET6)
-#define BOARD_MKS_ROBIN_MINI          4012  // MKS Robin Mini (STM32F103VET6)
-#define BOARD_MKS_ROBIN_NANO          4013  // MKS Robin Nano (STM32F103VET6)
-#define BOARD_MKS_ROBIN_NANO_V2       4014  // MKS Robin Nano V2 (STM32F103VET6)
-#define BOARD_MKS_ROBIN_LITE          4015  // MKS Robin Lite/Lite2 (STM32F103RCT6)
-#define BOARD_MKS_ROBIN_LITE3         4016  // MKS Robin Lite3 (STM32F103RCT6)
-#define BOARD_MKS_ROBIN_PRO           4017  // MKS Robin Pro (STM32F103ZET6)
-#define BOARD_MKS_ROBIN_E3            4018  // MKS Robin E3 (STM32F103RCT6)
-#define BOARD_MKS_ROBIN_E3_V1_1       4019  // MKS Robin E3 V1.1 (STM32F103RCT6)
-#define BOARD_MKS_ROBIN_E3D           4020  // MKS Robin E3D (STM32F103RCT6)
-#define BOARD_MKS_ROBIN_E3D_V1_1      4021  // MKS Robin E3D V1.1 (STM32F103RCT6)
-#define BOARD_MKS_ROBIN_E3P           4022  // MKS Robin E3p (STM32F103VET6)
+#define BOARD_CHITU3D                 4010  // Chitu3D (STM32F103RE)
+#define BOARD_MKS_ROBIN               4011  // MKS Robin (STM32F103ZE)
+#define BOARD_MKS_ROBIN_MINI          4012  // MKS Robin Mini (STM32F103VE)
+#define BOARD_MKS_ROBIN_NANO          4013  // MKS Robin Nano (STM32F103VE)
+#define BOARD_MKS_ROBIN_NANO_V2       4014  // MKS Robin Nano V2 (STM32F103VE)
+#define BOARD_MKS_ROBIN_LITE          4015  // MKS Robin Lite/Lite2 (STM32F103RC)
+#define BOARD_MKS_ROBIN_LITE3         4016  // MKS Robin Lite3 (STM32F103RC)
+#define BOARD_MKS_ROBIN_PRO           4017  // MKS Robin Pro (STM32F103ZE)
+#define BOARD_MKS_ROBIN_E3            4018  // MKS Robin E3 (STM32F103RC)
+#define BOARD_MKS_ROBIN_E3_V1_1       4019  // MKS Robin E3 V1.1 (STM32F103RC)
+#define BOARD_MKS_ROBIN_E3D           4020  // MKS Robin E3D (STM32F103RC)
+#define BOARD_MKS_ROBIN_E3D_V1_1      4021  // MKS Robin E3D V1.1 (STM32F103RC)
+#define BOARD_MKS_ROBIN_E3P           4022  // MKS Robin E3p (STM32F103VE)
 #define BOARD_BTT_SKR_MINI_V1_1       4023  // BigTreeTech SKR Mini v1.1 (STM32F103RC)
 #define BOARD_BTT_SKR_MINI_E3_V1_0    4024  // BigTreeTech SKR Mini E3 (STM32F103RC)
 #define BOARD_BTT_SKR_MINI_E3_V1_2    4025  // BigTreeTech SKR Mini E3 V1.2 (STM32F103RC)
@@ -328,11 +328,11 @@
 #define BOARD_BTT_SKR_MINI_MZ_V1_0    4028  // BigTreeTech SKR Mini MZ V1.0 (STM32F103RC)
 #define BOARD_BTT_SKR_E3_DIP          4029  // BigTreeTech SKR E3 DIP V1.0 (STM32F103RC / STM32F103RE)
 #define BOARD_BTT_SKR_CR6             4030  // BigTreeTech SKR CR6 v1.0 (STM32F103RE)
-#define BOARD_JGAURORA_A5S_A1         4031  // JGAurora A5S A1 (STM32F103ZET6)
+#define BOARD_JGAURORA_A5S_A1         4031  // JGAurora A5S A1 (STM32F103ZE)
 #define BOARD_FYSETC_AIO_II           4032  // FYSETC AIO_II
 #define BOARD_FYSETC_CHEETAH          4033  // FYSETC Cheetah
 #define BOARD_FYSETC_CHEETAH_V12      4034  // FYSETC Cheetah V1.2
-#define BOARD_LONGER3D_LK             4035  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VET6
+#define BOARD_LONGER3D_LK             4035  // Alfawise U20/U20+/U30 (Longer3D LK1/2) / STM32F103VE
 #define BOARD_CCROBOT_MEEB_3DP        4036  // ccrobot-online.com MEEB_3DP (STM32F103RC)
 #define BOARD_CHITU3D_V5              4037  // Chitu3D TronXY X5SA V5 Board
 #define BOARD_CHITU3D_V6              4038  // Chitu3D TronXY X5SA V6 Board
@@ -349,16 +349,16 @@
 #define BOARD_CREALITY_V452           4049  // Creality v4.5.2 (STM32F103RE)
 #define BOARD_CREALITY_V453           4050  // Creality v4.5.3 (STM32F103RE)
 #define BOARD_CREALITY_V24S1          4051  // Creality v2.4.S1 (STM32F103RE) v101 as found in the Ender 7
-#define BOARD_TRIGORILLA_PRO          4052  // Trigorilla Pro (STM32F103ZET6)
-#define BOARD_FLY_MINI                4053  // FLYmaker FLY MINI (STM32F103RCT6)
-#define BOARD_FLSUN_HISPEED           4054  // FLSUN HiSpeedV1 (STM32F103VET6)
-#define BOARD_BEAST                   4055  // STM32F103RET6 Libmaple-based controller
-#define BOARD_MINGDA_MPX_ARM_MINI     4056  // STM32F103ZET6 Mingda MD-16
-#define BOARD_GTM32_PRO_VD            4057  // STM32F103VET6 controller
-#define BOARD_ZONESTAR_ZM3E2          4058  // Zonestar ZM3E2    (STM32F103RCT6)
-#define BOARD_ZONESTAR_ZM3E4          4059  // Zonestar ZM3E4 V1 (STM32F103VCT6)
-#define BOARD_ZONESTAR_ZM3E4V2        4060  // Zonestar ZM3E4 V2 (STM32F103VCT6)
-#define BOARD_ERYONE_ERY32_MINI       4061  // Eryone Ery32 mini (STM32F103VET6)
+#define BOARD_TRIGORILLA_PRO          4052  // Trigorilla Pro (STM32F103ZE)
+#define BOARD_FLY_MINI                4053  // FLYmaker FLY MINI (STM32F103RC)
+#define BOARD_FLSUN_HISPEED           4054  // FLSUN HiSpeedV1 (STM32F103VE)
+#define BOARD_BEAST                   4055  // STM32F103RE Libmaple-based controller
+#define BOARD_MINGDA_MPX_ARM_MINI     4056  // STM32F103ZE Mingda MD-16
+#define BOARD_GTM32_PRO_VD            4057  // STM32F103VE controller
+#define BOARD_ZONESTAR_ZM3E2          4058  // Zonestar ZM3E2    (STM32F103RC)
+#define BOARD_ZONESTAR_ZM3E4          4059  // Zonestar ZM3E4 V1 (STM32F103VC)
+#define BOARD_ZONESTAR_ZM3E4V2        4060  // Zonestar ZM3E4 V2 (STM32F103VC)
+#define BOARD_ERYONE_ERY32_MINI       4061  // Eryone Ery32 mini (STM32F103VE)
 
 //
 // ARM Cortex-M4F
@@ -372,44 +372,44 @@
 //
 
 #define BOARD_ARMED                   4200  // Arm'ed STM32F4-based controller
-#define BOARD_RUMBA32_V1_0            4201  // RUMBA32 STM32F446VET6 based controller from Aus3D
-#define BOARD_RUMBA32_V1_1            4202  // RUMBA32 STM32F446VET6 based controller from Aus3D
-#define BOARD_RUMBA32_MKS             4203  // RUMBA32 STM32F446VET6 based controller from Makerbase
-#define BOARD_RUMBA32_BTT             4204  // RUMBA32 STM32F446VET6 based controller from BIGTREETECH
+#define BOARD_RUMBA32_V1_0            4201  // RUMBA32 STM32F446VE based controller from Aus3D
+#define BOARD_RUMBA32_V1_1            4202  // RUMBA32 STM32F446VE based controller from Aus3D
+#define BOARD_RUMBA32_MKS             4203  // RUMBA32 STM32F446VE based controller from Makerbase
+#define BOARD_RUMBA32_BTT             4204  // RUMBA32 STM32F446VE based controller from BIGTREETECH
 #define BOARD_BLACK_STM32F407VE       4205  // BLACK_STM32F407VE
 #define BOARD_BLACK_STM32F407ZE       4206  // BLACK_STM32F407ZE
 #define BOARD_STEVAL_3DP001V1         4207  // STEVAL-3DP001V1 3D PRINTER BOARD
-#define BOARD_BTT_SKR_PRO_V1_1        4208  // BigTreeTech SKR Pro v1.1 (STM32F407ZGT6)
-#define BOARD_BTT_SKR_PRO_V1_2        4209  // BigTreeTech SKR Pro v1.2 (STM32F407ZGT6)
-#define BOARD_BTT_BTT002_V1_0         4210  // BigTreeTech BTT002 v1.0 (STM32F407VGT6)
-#define BOARD_BTT_E3_RRF              4211  // BigTreeTech E3 RRF (STM32F407VGT6)
-#define BOARD_BTT_SKR_V2_0_REV_A      4212  // BigTreeTech SKR v2.0 Rev A (STM32F407VGT6)
-#define BOARD_BTT_SKR_V2_0_REV_B      4213  // BigTreeTech SKR v2.0 Rev B (STM32F407VGT6/STM32F429VGT6)
+#define BOARD_BTT_SKR_PRO_V1_1        4208  // BigTreeTech SKR Pro v1.1 (STM32F407ZG)
+#define BOARD_BTT_SKR_PRO_V1_2        4209  // BigTreeTech SKR Pro v1.2 (STM32F407ZG)
+#define BOARD_BTT_BTT002_V1_0         4210  // BigTreeTech BTT002 v1.0 (STM32F407VG)
+#define BOARD_BTT_E3_RRF              4211  // BigTreeTech E3 RRF (STM32F407VG)
+#define BOARD_BTT_SKR_V2_0_REV_A      4212  // BigTreeTech SKR v2.0 Rev A (STM32F407VG)
+#define BOARD_BTT_SKR_V2_0_REV_B      4213  // BigTreeTech SKR v2.0 Rev B (STM32F407VG/STM32F429VG)
 #define BOARD_BTT_GTR_V1_0            4214  // BigTreeTech GTR v1.0 (STM32F407IGT)
-#define BOARD_BTT_OCTOPUS_V1_0        4215  // BigTreeTech Octopus v1.0 (STM32F446ZET6)
-#define BOARD_BTT_OCTOPUS_V1_1        4216  // BigTreeTech Octopus v1.1 (STM32F446ZET6)
-#define BOARD_BTT_OCTOPUS_PRO_V1_0    4217  // BigTreeTech Octopus Pro v1.0 (STM32F446ZET6/STM32F429ZGT6)
+#define BOARD_BTT_OCTOPUS_V1_0        4215  // BigTreeTech Octopus v1.0 (STM32F446ZE)
+#define BOARD_BTT_OCTOPUS_V1_1        4216  // BigTreeTech Octopus v1.1 (STM32F446ZE)
+#define BOARD_BTT_OCTOPUS_PRO_V1_0    4217  // BigTreeTech Octopus Pro v1.0 (STM32F446ZE/STM32F429ZG)
 #define BOARD_LERDGE_K                4218  // Lerdge K (STM32F407ZG)
 #define BOARD_LERDGE_S                4219  // Lerdge S (STM32F407VE)
 #define BOARD_LERDGE_X                4220  // Lerdge X (STM32F407VE)
-#define BOARD_VAKE403D                4221  // VAkE 403D (STM32F446VET6)
-#define BOARD_FYSETC_S6               4222  // FYSETC S6 (STM32F446VET6)
-#define BOARD_FYSETC_S6_V2_0          4223  // FYSETC S6 v2.0 (STM32F446VET6)
-#define BOARD_FYSETC_SPIDER           4224  // FYSETC Spider (STM32F446VET6)
+#define BOARD_VAKE403D                4221  // VAkE 403D (STM32F446VE)
+#define BOARD_FYSETC_S6               4222  // FYSETC S6 (STM32F446VE)
+#define BOARD_FYSETC_S6_V2_0          4223  // FYSETC S6 v2.0 (STM32F446VE)
+#define BOARD_FYSETC_SPIDER           4224  // FYSETC Spider (STM32F446VE)
 #define BOARD_FLYF407ZG               4225  // FLYmaker FLYF407ZG (STM32F407ZG)
 #define BOARD_MKS_ROBIN2              4226  // MKS_ROBIN2 (STM32F407ZE)
 #define BOARD_MKS_ROBIN_PRO_V2        4227  // MKS Robin Pro V2 (STM32F407VE)
 #define BOARD_MKS_ROBIN_NANO_V3       4228  // MKS Robin Nano V3 (STM32F407VG)
-#define BOARD_MKS_MONSTER8            4229  // MKS Monster8 (STM32F407VGT6)
-#define BOARD_ANET_ET4                4230  // ANET ET4 V1.x (STM32F407VGT6)
-#define BOARD_ANET_ET4P               4231  // ANET ET4P V1.x (STM32F407VGT6)
+#define BOARD_MKS_MONSTER8            4229  // MKS Monster8 (STM32F407VG)
+#define BOARD_ANET_ET4                4230  // ANET ET4 V1.x (STM32F407VG)
+#define BOARD_ANET_ET4P               4231  // ANET ET4P V1.x (STM32F407VG)
 #define BOARD_FYSETC_CHEETAH_V20      4232  // FYSETC Cheetah V2.0
 #define BOARD_TH3D_EZBOARD_V2         4233  // TH3D EZBoard v2.0
-#define BOARD_INDEX_REV03             4234  // Index PnP Controller REV03 (STM32F407VET6/VGT6)
-#define BOARD_MKS_ROBIN_NANO_V1_3_F4  4235  // MKS Robin Nano V1.3 and MKS Robin Nano-S V1.3 (STM32F407VET6)
-#define BOARD_MKS_EAGLE               4236  // MKS Eagle (STM32F407VET6)
-#define BOARD_ARTILLERY_RUBY          4237  // Artillery Ruby (STM32F401RCT6)
-#define BOARD_FYSETC_SPIDER_V2_2      4238  // FYSETC Spider V2.2 (STM32F446VET6)
+#define BOARD_INDEX_REV03             4234  // Index PnP Controller REV03 (STM32F407VE/VG)
+#define BOARD_MKS_ROBIN_NANO_V1_3_F4  4235  // MKS Robin Nano V1.3 and MKS Robin Nano-S V1.3 (STM32F407VE)
+#define BOARD_MKS_EAGLE               4236  // MKS Eagle (STM32F407VE)
+#define BOARD_ARTILLERY_RUBY          4237  // Artillery Ruby (STM32F401RC)
+#define BOARD_FYSETC_SPIDER_V2_2      4238  // FYSETC Spider V2.2 (STM32F446VE)
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -558,21 +558,21 @@
 #elif MB(CHITU3D_V9)
   #include "stm32f1/pins_CHITU3D_V9.h"          // STM32F1                                env:chitu_f103 env:chitu_f103_maple
 #elif MB(CREALITY_V4)
-  #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V4210)
-  #include "stm32f1/pins_CREALITY_V4210.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V4210.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V423)
   #include "stm32f1/pins_CREALITY_V423.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer
 #elif MB(CREALITY_V427)
-  #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V431, CREALITY_V431_A, CREALITY_V431_B, CREALITY_V431_C, CREALITY_V431_D)
-  #include "stm32f1/pins_CREALITY_V431.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V431.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V452)
-  #include "stm32f1/pins_CREALITY_V452.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V452.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V453)
-  #include "stm32f1/pins_CREALITY_V453.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V453.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(CREALITY_V24S1)
-  #include "stm32f1/pins_CREALITY_V24S1.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V24S1.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro env:trigorilla_pro_maple
 #elif MB(FLY_MINI)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -558,21 +558,21 @@
 #elif MB(CHITU3D_V9)
   #include "stm32f1/pins_CHITU3D_V9.h"          // STM32F1                                env:chitu_f103 env:chitu_f103_maple
 #elif MB(CREALITY_V4)
-  #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V4.h"         // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(CREALITY_V4210)
-  #include "stm32f1/pins_CREALITY_V4210.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V4210.h"      // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(CREALITY_V423)
-  #include "stm32f1/pins_CREALITY_V423.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer
+  #include "stm32f1/pins_CREALITY_V423.h"       // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer
 #elif MB(CREALITY_V427)
-  #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V427.h"       // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(CREALITY_V431, CREALITY_V431_A, CREALITY_V431_B, CREALITY_V431_C, CREALITY_V431_D)
-  #include "stm32f1/pins_CREALITY_V431.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V431.h"       // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(CREALITY_V452)
-  #include "stm32f1/pins_CREALITY_V452.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V452.h"       // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(CREALITY_V453)
-  #include "stm32f1/pins_CREALITY_V453.h"       // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V453.h"       // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(CREALITY_V24S1)
-  #include "stm32f1/pins_CREALITY_V24S1.h"      // STM32F1                                env:STM32F103RET6_creality env:STM32F103RET6_creality_xfer env:STM32F103RCT6_creality env:STM32F103RCT6_creality_xfer env:STM32F103RET6_creality_maple
+  #include "stm32f1/pins_CREALITY_V24S1.h"      // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro env:trigorilla_pro_maple
 #elif MB(FLY_MINI)

--- a/buildroot/tests/STM32F103RE_creality
+++ b/buildroot/tests/STM32F103RE_creality
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Build tests for STM32F103RET6_creality
+# Build tests for STM32F103RE_creality
 #
 
 # exit on first failure

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -114,7 +114,7 @@ monitor_speed     = 115200
 #
 # Creality (STM32F103RET6)
 #
-[env:STM32F103RET6_creality_maple]
+[env:STM32F103RE_creality_maple]
 extends              = env:STM32F103RE_maple
 build_flags          = ${common_stm32f1.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -122,6 +122,9 @@ monitor_speed               = 115200
 debug_tool                  = jlink
 upload_protocol             = jlink
 
+#
+# Custom upload to SD via Marlin with Binary Protocol
+#
 [STM32F103RxT6_creality_xfer]
 extends         = STM32F103RxT6_creality
 extra_scripts   = ${STM32F103RxT6_creality.extra_scripts}

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -103,11 +103,10 @@ build_unflags               = ${common_STM32F103RC_variant.build_unflags}
 debug_tool                  = stlink
 
 #
-# Creality (STM32F103RET6)
+# Creality (STM32F103RxT6)
 #
-[env:STM32F103RET6_creality]
+[STM32F103RxT6_creality]
 extends                     = stm32_variant
-board                       = genericSTM32F103RE
 board_build.variant         = MARLIN_F103Rx
 board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
@@ -123,22 +122,33 @@ monitor_speed               = 115200
 debug_tool                  = jlink
 upload_protocol             = jlink
 
-[env:STM32F103RET6_creality_xfer]
-extends         = env:STM32F103RET6_creality
-extra_scripts   = ${env:STM32F103RET6_creality.extra_scripts}
+[STM32F103RxT6_creality_xfer]
+extends         = STM32F103RxT6_creality
+extra_scripts   = ${STM32F103RxT6_creality.extra_scripts}
                   pre:buildroot/share/scripts/upload.py
 upload_protocol = custom
 
 #
-# Creality (STM32F103RCT6)
+# Creality 512K (STM32F103RET6)
+#
+[env:STM32F103RET6_creality]
+extends = STM32F103RxT6_creality
+board   = genericSTM32F103RE
+
+[env:STM32F103RET6_creality_xfer]
+extends = STM32F103RxT6_creality_xfer
+board   = genericSTM32F103RE
+
+#
+# Creality 256K (STM32F103RCT6)
 #
 [env:STM32F103RCT6_creality]
-extends         = env:STM32F103RET6_creality
-board           = genericSTM32F103RC
+extends = STM32F103RxT6_creality
+board   = genericSTM32F103RC
 
 [env:STM32F103RCT6_creality_xfer]
-extends         = env:STM32F103RET6_creality_xfer
-board           = genericSTM32F103RC
+extends = STM32F103RxT6_creality_xfer
+board   = genericSTM32F103RC
 
 #
 # BigTree SKR Mini E3 V2.0 & DIP / SKR CR6 (STM32F103RET6 ARM Cortex-M3)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -130,6 +130,19 @@ extra_scripts   = ${env:STM32F103RET6_creality.extra_scripts}
 upload_protocol = custom
 
 #
+# Creality (STM32F103RCT6)
+#
+[env:STM32F103RCT6_creality]
+extends                     = STM32F103RET6_creality
+board                       = genericSTM32F103RC
+
+[env:STM32F103RCT6_creality_xfer]
+extends         = env:STM32F103RCT6_creality
+extra_scripts   = ${env:STM32F103RCT6_creality.extra_scripts}
+                  pre:buildroot/share/scripts/upload.py
+upload_protocol = custom
+
+#
 # BigTree SKR Mini E3 V2.0 & DIP / SKR CR6 (STM32F103RET6 ARM Cortex-M3)
 #
 #   STM32F103RE_btt ............. RET6

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -133,8 +133,8 @@ upload_protocol = custom
 # Creality (STM32F103RCT6)
 #
 [env:STM32F103RCT6_creality]
-extends                     = STM32F103RET6_creality
-board                       = genericSTM32F103RC
+extends         = STM32F103RET6_creality
+board           = genericSTM32F103RC
 
 [env:STM32F103RCT6_creality_xfer]
 extends         = env:STM32F103RCT6_creality

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -133,14 +133,12 @@ upload_protocol = custom
 # Creality (STM32F103RCT6)
 #
 [env:STM32F103RCT6_creality]
-extends         = STM32F103RET6_creality
+extends         = env:STM32F103RET6_creality
 board           = genericSTM32F103RC
 
 [env:STM32F103RCT6_creality_xfer]
-extends         = env:STM32F103RCT6_creality
-extra_scripts   = ${env:STM32F103RET6_creality.extra_scripts}
-                  pre:buildroot/share/scripts/upload.py
-upload_protocol = custom
+extends         = env:STM32F103RET6_creality_xfer
+board           = genericSTM32F103RC
 
 #
 # BigTree SKR Mini E3 V2.0 & DIP / SKR CR6 (STM32F103RET6 ARM Cortex-M3)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -103,9 +103,9 @@ build_unflags               = ${common_STM32F103RC_variant.build_unflags}
 debug_tool                  = stlink
 
 #
-# Creality (STM32F103RxT6)
+# Creality (STM32F103Rx)
 #
-[STM32F103RxT6_creality]
+[STM32F103Rx_creality]
 extends                     = stm32_variant
 board_build.variant         = MARLIN_F103Rx
 board_build.offset          = 0x7000
@@ -125,32 +125,32 @@ upload_protocol             = jlink
 #
 # Custom upload to SD via Marlin with Binary Protocol
 #
-[STM32F103RxT6_creality_xfer]
-extends         = STM32F103RxT6_creality
-extra_scripts   = ${STM32F103RxT6_creality.extra_scripts}
+[STM32F103Rx_creality_xfer]
+extends         = STM32F103Rx_creality
+extra_scripts   = ${STM32F103Rx_creality.extra_scripts}
                   pre:buildroot/share/scripts/upload.py
 upload_protocol = custom
 
 #
-# Creality 512K (STM32F103RET6)
+# Creality 512K (STM32F103RE)
 #
-[env:STM32F103RET6_creality]
-extends = STM32F103RxT6_creality
+[env:STM32F103RE_creality]
+extends = STM32F103Rx_creality
 board   = genericSTM32F103RE
 
-[env:STM32F103RET6_creality_xfer]
-extends = STM32F103RxT6_creality_xfer
+[env:STM32F103RE_creality_xfer]
+extends = STM32F103Rx_creality_xfer
 board   = genericSTM32F103RE
 
 #
-# Creality 256K (STM32F103RCT6)
+# Creality 256K (STM32F103RC)
 #
-[env:STM32F103RCT6_creality]
-extends = STM32F103RxT6_creality
+[env:STM32F103RC_creality]
+extends = STM32F103Rx_creality
 board   = genericSTM32F103RC
 
-[env:STM32F103RCT6_creality_xfer]
-extends = STM32F103RxT6_creality_xfer
+[env:STM32F103RC_creality_xfer]
+extends = STM32F103Rx_creality_xfer
 board   = genericSTM32F103RC
 
 #

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -138,7 +138,7 @@ board                       = genericSTM32F103RC
 
 [env:STM32F103RCT6_creality_xfer]
 extends         = env:STM32F103RCT6_creality
-extra_scripts   = ${env:STM32F103RCT6_creality.extra_scripts}
+extra_scripts   = ${env:STM32F103RET6_creality.extra_scripts}
                   pre:buildroot/share/scripts/upload.py
 upload_protocol = custom
 


### PR DESCRIPTION
### Description

Creality has started shipping some of their boards with RCT6 (256K) chips instead of RET6 (512K), so this new PIO environment will allow users to update their boards with the correct MCU enabled.

### Requirements

STM32-based Crealtiy board

### Related Issues

- https://github.com/MarlinFirmware/Marlin/issues/23596