### PR TITLE
Fix debugging in DWIN screens

### DIFF
--- a/Marlin/src/lcd/extui/dgus/fysetc/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus/fysetc/DGUSScreenHandler.h
@@ -206,7 +206,7 @@ public:
   static void DGUSLCD_SendFloatAsIntValueToDisplay(DGUS_VP_Variable &var) {
     if (var.memadr) {
       float f = *(float *)var.memadr;
-      DEBUG_ECHOLNPGM(" >> ", f, 6);
+      DEBUG_ECHOLNPAIR_F(" >> ", f, 6);
       f *= cpow(10, decimals);
       dgusdisplay.WriteVariable(var.VP, (int16_t)f);
     }

--- a/Marlin/src/lcd/extui/dgus/hiprecy/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus/hiprecy/DGUSScreenHandler.h
@@ -206,7 +206,7 @@ public:
   static void DGUSLCD_SendFloatAsIntValueToDisplay(DGUS_VP_Variable &var) {
     if (var.memadr) {
       float f = *(float *)var.memadr;
-      DEBUG_ECHOLNPGM(" >> ", f, 6);
+      DEBUG_ECHOLNPAIR_F(" >> ", f, 6);
       f *= cpow(10, decimals);
       dgusdisplay.WriteVariable(var.VP, (int16_t)f);
     }

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
@@ -93,7 +93,7 @@ void DGUSScreenHandler::DGUSLCD_SendFanToDisplay(DGUS_VP_Variable &var) {
 
 void DGUSScreenHandler::DGUSLCD_SendBabyStepToDisplay_MKS(DGUS_VP_Variable &var) {
   float value = current_position.z;
-  DEBUG_ECHOLNPGM(" >> ", value, 6);
+  DEBUG_ECHOLNPAIR_F(" >> ", value, 6);
   value *= cpow(10, 2);
   dgusdisplay.WriteVariable(VP_SD_Print_Baby, (uint16_t)value);
 }
@@ -756,7 +756,7 @@ void DGUSScreenHandler::HandleManualMove(DGUS_VP_Variable &var, void *val_ptr) {
   else if (manualMoveStep == 0x02) manualMoveStep =  100;
   else if (manualMoveStep == 0x03) manualMoveStep = 1000;
 
-  DEBUG_ECHOLNPGM("QUEUE LEN:", queue.length);
+  DEBUG_ECHOLNPGM("QUEUE LEN:", queue.ring_buffer.length);
 
   if (!print_job_timer.isPaused() && !queue.ring_buffer.empty())
     return;

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.h
@@ -273,7 +273,7 @@ public:
   static void DGUSLCD_SendFloatAsIntValueToDisplay(DGUS_VP_Variable &var) {
     if (var.memadr) {
       float f = *(float *)var.memadr;
-      DEBUG_ECHOLNPGM(" >> ", f, 6);
+      DEBUG_ECHOLNPAIR_F(" >> ", f, 6);
       f *= cpow(10, decimals);
       dgusdisplay.WriteVariable(var.VP, (int16_t)f);
     }

--- a/Marlin/src/lcd/extui/dgus/origin/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus/origin/DGUSScreenHandler.h
@@ -206,7 +206,7 @@ public:
   static void DGUSLCD_SendFloatAsIntValueToDisplay(DGUS_VP_Variable &var) {
     if (var.memadr) {
       float f = *(float *)var.memadr;
-      DEBUG_ECHOLNPGM(" >> ", f, 6);
+      DEBUG_ECHOLNPAIR_F(" >> ", f, 6);
       f *= cpow(10, decimals);
       dgusdisplay.WriteVariable(var.VP, (int16_t)f);
     }


### PR DESCRIPTION
### Description

Partially reverts commit 755c10d3030ed18762e05b1f86396237bca8dfbf, where `DEBUG_ECHOLNPAIR_F` was swapped to `DEBUG_ECHOLNPGM` in cases where it can not be.

Updates MKS screen handler debugging to be compatible with commit ec42be346d5c0d072feb8a1b63ef2fdbd6dc1e98, which moved queue length into a struct.

I did not see the same issues repeated in the dgus_reloaded code, but I also couldn't find a combination of config options that would pass sanity checks and let it compile either; I didn't edit that code so I'm considering it out-of-scope.

### Requirements

`#define DEBUG_DGUSLCD` must be enabled in Marlin/src/lcd/extui/dgus/DGUSDisplay.h for this to make any difference, along with any of `#define DGUS_LCD_UI_ORIGIN`, `#define DGUS_LCD_UI_FYSETC`, `#define DGUS_LCD_UI_HIPRECY`, or `#define DGUS_LCD_UI_MKS` in Configuration.h.

### Benefits

Once more allows debugging of DWIN displays. Important if, say, someone is trying to port one of the existing display modules to either a different screen resolution or orientation.

### Configurations

[Marlin.zip](https://github.com/MarlinFirmware/Marlin/files/7920017/Marlin.zip)

### Related Issues

Fixes #23513 


