### PR TITLE
✨ BOARD_CREALITY_V24S1_301

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -349,16 +349,17 @@
 #define BOARD_CREALITY_V452           4049  // Creality v4.5.2 (STM32F103RE)
 #define BOARD_CREALITY_V453           4050  // Creality v4.5.3 (STM32F103RE)
 #define BOARD_CREALITY_V24S1          4051  // Creality v2.4.S1 (STM32F103RE) v101 as found in the Ender 7
-#define BOARD_TRIGORILLA_PRO          4052  // Trigorilla Pro (STM32F103ZE)
-#define BOARD_FLY_MINI                4053  // FLYmaker FLY MINI (STM32F103RC)
-#define BOARD_FLSUN_HISPEED           4054  // FLSUN HiSpeedV1 (STM32F103VE)
-#define BOARD_BEAST                   4055  // STM32F103RE Libmaple-based controller
-#define BOARD_MINGDA_MPX_ARM_MINI     4056  // STM32F103ZE Mingda MD-16
-#define BOARD_GTM32_PRO_VD            4057  // STM32F103VE controller
-#define BOARD_ZONESTAR_ZM3E2          4058  // Zonestar ZM3E2    (STM32F103RC)
-#define BOARD_ZONESTAR_ZM3E4          4059  // Zonestar ZM3E4 V1 (STM32F103VC)
-#define BOARD_ZONESTAR_ZM3E4V2        4060  // Zonestar ZM3E4 V2 (STM32F103VC)
-#define BOARD_ERYONE_ERY32_MINI       4061  // Eryone Ery32 mini (STM32F103VE)
+#define BOARD_CREALITY_V24S1_301      4052  // Creality v2.4.S1_301 (STM32F103RCT) as found in the Ender 3 S1
+#define BOARD_TRIGORILLA_PRO          4053  // Trigorilla Pro (STM32F103ZE)
+#define BOARD_FLY_MINI                4054  // FLYmaker FLY MINI (STM32F103RC)
+#define BOARD_FLSUN_HISPEED           4055  // FLSUN HiSpeedV1 (STM32F103VE)
+#define BOARD_BEAST                   4056  // STM32F103RE Libmaple-based controller
+#define BOARD_MINGDA_MPX_ARM_MINI     4057  // STM32F103ZE Mingda MD-16
+#define BOARD_GTM32_PRO_VD            4058  // STM32F103VE controller
+#define BOARD_ZONESTAR_ZM3E2          4059  // Zonestar ZM3E2    (STM32F103RC)
+#define BOARD_ZONESTAR_ZM3E4          4060  // Zonestar ZM3E4 V1 (STM32F103VC)
+#define BOARD_ZONESTAR_ZM3E4V2        4061  // Zonestar ZM3E4 V2 (STM32F103VC)
+#define BOARD_ERYONE_ERY32_MINI       4062  // Eryone Ery32 mini (STM32F103VE)
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -511,6 +511,8 @@
   #ifndef LCD_SERIAL_PORT
     #if MB(BTT_SKR_MINI_E3_V1_0, BTT_SKR_MINI_E3_V1_2, BTT_SKR_MINI_E3_V2_0, BTT_SKR_MINI_E3_V3_0, BTT_SKR_E3_TURBO)
       #define LCD_SERIAL_PORT 1
+    #elif MB(CREALITY_V24S1_301)
+      #define LCD_SERIAL_PORT 2 // Creality Ender3S1 board
     #else
       #define LCD_SERIAL_PORT 3 // Creality 4.x board
     #endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -573,6 +573,8 @@
   #include "stm32f1/pins_CREALITY_V453.h"       // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(CREALITY_V24S1)
   #include "stm32f1/pins_CREALITY_V24S1.h"      // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
+#elif MB(CREALITY_V24S1_301)
+  #include "stm32f1/pins_CREALITY_V24S1_301.h"  // STM32F1                                env:STM32F103RE_creality env:STM32F103RE_creality_xfer env:STM32F103RC_creality env:STM32F103RC_creality_xfer env:STM32F103RE_creality_maple
 #elif MB(TRIGORILLA_PRO)
   #include "stm32f1/pins_TRIGORILLA_PRO.h"      // STM32F1                                env:trigorilla_pro env:trigorilla_pro_maple
 #elif MB(FLY_MINI)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V24S1_301.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V24S1_301.h
@@ -1,0 +1,66 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * Creality V24S1_301 (STM32F103RCT) board pin assignments as found on Ender 3 S1
+ */
+
+#include "env_validate.h"
+
+#if HAS_MULTI_HOTEND || E_STEPPERS > 1
+  #error "Creality V4 only supports one hotend / E-stepper. Comment out this line to continue."
+#endif
+
+#define BOARD_INFO_NAME      "Creality V24S1-301"
+#define DEFAULT_MACHINE_NAME "Ender 3 S1"
+
+//
+// Servos
+//
+#if !defined(SERVO0_PIN) && !defined(HAS_PIN_27_BOARD)
+  #define SERVO0_PIN                        PC13  // BLTouch OUT
+#endif
+
+//
+// Limit Switches
+//
+#define Z_STOP_PIN                          PC14
+
+#ifndef Z_MIN_PROBE_PIN
+  #define Z_MIN_PROBE_PIN                   PC14  // BLTouch IN
+#endif
+
+//
+// Filament Runout Sensor
+//
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN                    PC15  // "Pulled-high"
+#endif
+
+//
+// Heaters / Fans
+//
+#define HEATER_BED_PIN                      PA7   // HOT BED
+#define FAN1_PIN                            PC0   // extruder fan
+
+#include "pins_CREALITY_V4.h"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -72,7 +72,9 @@
 //
 #define X_STOP_PIN                          PA5
 #define Y_STOP_PIN                          PA6
-#define Z_STOP_PIN                          PA7
+#ifndef Z_STOP_PIN
+  #define Z_STOP_PIN                        PA7
+#endif
 
 #ifndef Z_MIN_PROBE_PIN
   #define Z_MIN_PROBE_PIN                   PB1   // BLTouch IN


### PR DESCRIPTION
Redo of #23564 by @mriscoc

---

This PR adds preliminary support for the new Creality Ender3 S1 printer

### Description

Contains changes sugested by @leofaoro and @ellensp from the issue https://github.com/MarlinFirmware/Configurations/issues/645

### Requirements

Ender 3S1 with the original display

### Benefits

Adds preliminary support to Marlin

### Configurations

[Ender3S1-Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/7899042/Ender3S1-Configuration.zip)

### Related Issues

https://github.com/MarlinFirmware/Configurations/issues/645
