### PR TITLE
Fix init of delta safe height (for G29, G33, etc.)

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1339,6 +1339,10 @@ void setup() {
 
   SETUP_RUN(endstops.init());         // Init endstops and pullups
 
+  #if ENABLED(DELTA) && !HAS_SOFTWARE_ENDSTOPS
+    SETUP_RUN(refresh_delta_clip_start_height()); // Init safe delta height without soft endstops
+  #endif
+
   SETUP_RUN(stepper.init());          // Init stepper. This enables interrupts!
 
   #if HAS_SERVOS

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -63,6 +63,13 @@ abc_float_t delta_diagonal_rod_trim;
 
 float delta_safe_distance_from_top();
 
+void refresh_delta_clip_start_height() {
+  delta_clip_start_height = TERN(HAS_SOFTWARE_ENDSTOPS,
+    soft_endstop.max.z,
+    DIFF_TERN(HAS_BED_PROBE, delta_height, probe.offset.z)
+  ) - delta_safe_distance_from_top();
+}
+
 /**
  * Recalculate factors used for delta kinematics whenever
  * settings have been changed (e.g., by M665).

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -58,7 +58,7 @@ float delta_radius,
 abc_float_t delta_tower_angle_trim;
 xy_float_t delta_tower[ABC];
 abc_float_t delta_diagonal_rod_2_tower;
-#if !ENABLED(DELTA_FULL_XY_HEIGHT_OFFSET)
+#ifndef DELTA_FULL_XY_HEIGHT_OFFSET
   #define DELTA_FULL_XY_HEIGHT_OFFSET 20;
 #endif
 float delta_clip_start_height = Z_MAX_POS - DELTA_FULL_XY_HEIGHT_OFFSET;  //G33 height is sometimes a little too high

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -58,7 +58,10 @@ float delta_radius,
 abc_float_t delta_tower_angle_trim;
 xy_float_t delta_tower[ABC];
 abc_float_t delta_diagonal_rod_2_tower;
-float delta_clip_start_height = Z_MAX_POS;
+#if !ENABLED(DELTA_FULL_XY_HEIGHT_OFFSET)
+  #define DELTA_FULL_XY_HEIGHT_OFFSET 20;
+#endif
+float delta_clip_start_height = Z_MAX_POS - DELTA_FULL_XY_HEIGHT_OFFSET;  //G33 height is sometimes a little too high
 abc_float_t delta_diagonal_rod_trim;
 
 float delta_safe_distance_from_top();

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -58,10 +58,10 @@ float delta_radius,
 abc_float_t delta_tower_angle_trim;
 xy_float_t delta_tower[ABC];
 abc_float_t delta_diagonal_rod_2_tower;
-#if !ENABLED(DELTA_FULL_XY_HEIGHT_OFFSET)
-  #define DELTA_FULL_XY_HEIGHT_OFFSET 20;
+#ifndef DELTA_FULL_XY_HEIGHT_OFFSET
+  #define DELTA_FULL_XY_HEIGHT_OFFSET 20
 #endif
-float delta_clip_start_height = Z_MAX_POS - DELTA_FULL_XY_HEIGHT_OFFSET;  //G33 height is sometimes a little too high
+float delta_clip_start_height = Z_MAX_POS - (DELTA_FULL_XY_HEIGHT_OFFSET);  // G33 height is sometimes a little too high
 abc_float_t delta_diagonal_rod_trim;
 
 float delta_safe_distance_from_top();

--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -58,10 +58,7 @@ float delta_radius,
 abc_float_t delta_tower_angle_trim;
 xy_float_t delta_tower[ABC];
 abc_float_t delta_diagonal_rod_2_tower;
-#ifndef DELTA_FULL_XY_HEIGHT_OFFSET
-  #define DELTA_FULL_XY_HEIGHT_OFFSET 20
-#endif
-float delta_clip_start_height = Z_MAX_POS - (DELTA_FULL_XY_HEIGHT_OFFSET);  // G33 height is sometimes a little too high
+float delta_clip_start_height = Z_MAX_POS;
 abc_float_t delta_diagonal_rod_trim;
 
 float delta_safe_distance_from_top();

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -82,6 +82,8 @@ void inverse_kinematics(const xyz_pos_t &raw);
  */
 float delta_safe_distance_from_top();
 
+void refresh_delta_clip_start_height();
+
 /**
  * Delta Forward Kinematics
  *

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -347,6 +347,10 @@ void Endstops::init() {
 
   TERN_(ENDSTOP_INTERRUPTS_FEATURE, setup_endstop_interrupts());
 
+  #if !HAS_SOFTWARE_ENDSTOPS && HAS_BED_PROBE && ENABLED(DELTA)
+    delta_clip_start_height = delta_height - probe.offset.z - delta_safe_distance_from_top();  // replicate update_software_endstops() setting
+  #endif
+
   // Enable endstops
   enable_globally(ENABLED(ENDSTOPS_ALWAYS_ON_DEFAULT));
 

--- a/Marlin/src/module/endstops.cpp
+++ b/Marlin/src/module/endstops.cpp
@@ -347,10 +347,6 @@ void Endstops::init() {
 
   TERN_(ENDSTOP_INTERRUPTS_FEATURE, setup_endstop_interrupts());
 
-  #if !HAS_SOFTWARE_ENDSTOPS && HAS_BED_PROBE && ENABLED(DELTA)
-    delta_clip_start_height = delta_height - probe.offset.z - delta_safe_distance_from_top();  // replicate update_software_endstops() setting
-  #endif
-
   // Enable endstops
   enable_globally(ENABLED(ENDSTOPS_ALWAYS_ON_DEFAULT));
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -743,7 +743,7 @@ void restore_feedrate_and_scaling() {
           delta_max_radius_2 = sq(delta_max_radius);
           break;
         case Z_AXIS:
-          delta_clip_start_height = soft_endstop.max[axis] - delta_safe_distance_from_top();
+          refresh_delta_clip_start_height();
         default: break;
       }
 


### PR DESCRIPTION
The first probe point, when doing **G29** with **AUTO_BED_LEVELING_BILINEAR** enabled, moves the head to the extreme XY position via the following steps:

1. Lower Z to **Z_MAX_POS**
2. Lower Z to **delta_clip_start_height**
3. Move to XY  location of the point to be probed
4. Lower Z until Z probe fires

If **Z_MAX_POS** is too high then the XY move of the first G29 bilinear probe may hit the physical endstop which causes lost steps which throws off the resulting leveling grid.

On my Tevo Little Monster delta printer I have  **Z_MAX_POS** set to the height reported by G33.  When I do the G29 command, I see my gamma carriage move lower and the other two move higher, eventually hitting the physical limit which causes audible noise and lost steps.  After that the XYZ positions are invalid and the resulting leveling matrix is wrong.

I'm assuming **Z_MAX_POS** being set to the height reported by G33 is the norm.

My proposed fix is to add an offset to **delta_clip_start_height**.

**FROM:**
`float delta_clip_start_height = Z_MAX_POS`

**TO:**
```
#if !ENABLED(DELTA_FULL_XY_HEIGHT_OFFSET)
  #define DELTA_FULL_XY_HEIGHT_OFFSET 20;
#endif
float delta_clip_start_height = Z_MAX_POS - DELTA_FULL_XY_HEIGHT_OFFSET;  //G33 height is sometimes a little too high
```

---

**TESTING**

I've tested this on my Tevo Little Monster delta printer using bilinear and UBL leveling.

---

**OPTION**

Put the offset into the example delta configiurations rather than into code.  For  this I'd envision something like:

**FROM:**
```
#define Z_MAX_POS MANUAL_Z_HOME_POS
#define MANUAL_Z_HOME_POS DELTA_HEIGHT // Distance between the nozzle to printbed after homing
#define DELTA_HEIGHT 485.75               // (mm) Get this value from G33 auto calibrate
```

**TO**:
```
#define Z_MAX_POS MANUAL_Z_HOME_POS - DELTA_FULL_XY_HEIGHT_OFFSET
#define DELTA_FULL_XY_HEIGHT_OFFSET 2  // always 0 or positive - Distance from home position to where
                                       // full XY motion can start.  On some delta printers the head
                                       // can not extend to the full X/Y reach when at the home position
                                       // because that would force a carriage into the physical Z stop.
#define MANUAL_Z_HOME_POS DELTA_HEIGHT // Distance between the nozzle to printbed after homing
#define DELTA_HEIGHT 485.75               // (mm) Get this value from G33 auto calibrate
```

---

**OPTION**

Another way of attacking this is to change the order of moves in the G29 first probe.  Continue the Z movement down to the probe deploy point (some safe probe height) and then do the XY movement and then do the probing..  This is a common routine so I'm not sure if the new sequence is acceptable in all leveling schemes.

**FROM**
1. Lower Z to **Z_MAX_POS**
2. Lower Z to **delta_clip_start_height**
3. Move to XY  location of the point to be probed
4. Lower Z until Z probe fires

**TO**
1. Lower Z to probe deploy point (some safe probe height)
2. Move to XY  location of the point to be probed
3. Lower Z until Z probe fires
