### PR TITLE
SPI DMA Fix and correct Default mode.

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/tft_lvgl_configuration.cpp
@@ -270,7 +270,7 @@ void my_disp_flush(lv_disp_drv_t * disp, const lv_area_t * area, lv_color_t * co
   uint16_t width = area->x2 - area->x1 + 1,
           height = area->y2 - area->y1 + 1;
 
-  TERN_(USE_SPI_DMA_TC, disp_drv_p = disp);
+  disp_drv_p = disp;
 
   SPI_TFT.setWindow((uint16_t)area->x1, (uint16_t)area->y1, width, height);
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -369,7 +369,8 @@
 #endif // HAS_WIRED_LCD
 
 #if HAS_TFT_LVGL_UI
-  #define USE_SPI_DMA_TC
+  // Enable SPI DMA, this requires button pins, thus no buttons. Default is DISABLED.
+  //#define USE_SPI_DMA_TC
 #endif
 
 #if ANY(TFT_COLOR_UI, TFT_LVGL_UI, TFT_CLASSIC_UI, HAS_WIRED_LCD)


### PR DESCRIPTION
### Description

Previously the MKS Robin Nano V3 TFT buttons defaults to operational, this was changed and unexpected for users with previously working buttons. Also a renamed variable was not defined correctly based on a USE_SPI_DMA_TC condition check which resulted in boot loops for all MKS TFT LVGL based non SPI DMA configurations. 

### Requirements

TFT_LVGL configured LCD

### Benefits

Obvious

### Configurations

#define BOARD_MKS_ROBIN_NANO_V2
#define SERIAL_PORT 3
#define SERIAL_PORT_2 1
#define MKS_TS35_V2_0
#define TFT_LVGL_UI
#define SDSUPPORT

### Related Issues

#23608
#23464

