### PR TITLE
Neopixel fix on Rumba for MKS MINI12864 display

### DIFF
--- a/Marlin/src/pins/ramps/pins_RUMBA.h
+++ b/Marlin/src/pins/ramps/pins_RUMBA.h
@@ -220,7 +220,7 @@
       #define RGB_LED_B_PIN                   40
     #endif
   #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define NEOPIXEL_PIN                      25
+    #define NEOPIXEL_PIN                      38
   #endif
 
 #else


### PR DESCRIPTION
Per Issue #23580, the Neopixel pin on Rumba for MKS MINI12864 display is wrong.

The correct logical pin number is 38.  The current one (25) is for the E1_DIR function.

I've verified this via the Rumba and MKS MINI12864 V3 schematics.  

I don't have a V3 so I can't test it.  I see no reason to doubt that it works for the issue's author.