### PR TITLE
Ezboard v2 Timer Fix

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_TH3D_EZBOARD_V2/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_TH3D_EZBOARD_V2/variant.h
@@ -104,7 +104,7 @@ extern "C" {
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #define TIMER_TONE              TIM5
-#define TIMER_SERVO             TIM7
+#define TIMER_SERVO             TIM4
 
 // UART Definitions
 // Define here Serial instance number to map on Serial generic name


### PR DESCRIPTION
### Description

TIMER_SERVO should be TIM4 not TIM7

### Requirements

N/A

### Benefits

Fixes compile errors when using a BLTouch with the EZBoard V2

### Configurations

N/A

### Related Issues

N/A