### PR TITLE
EZBoard V2 Environment Settings Fix

### DIFF
--- a/buildroot/share/PlatformIO/variants/MARLIN_TH3D_EZBOARD_V2/variant.h
+++ b/buildroot/share/PlatformIO/variants/MARLIN_TH3D_EZBOARD_V2/variant.h
@@ -104,7 +104,7 @@ extern "C" {
 // Timer Definitions
 // Use TIM6/TIM7 when possible as servo and tone don't need GPIO output pin
 #define TIMER_TONE              TIM5
-#define TIMER_SERVO             TIM7
+#define TIMER_SERVO             TIM4
 
 // UART Definitions
 // Define here Serial instance number to map on Serial generic name

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -532,11 +532,14 @@ build_unflags     = -DUSBD_USE_CDC
 extends             = stm32_variant
 board               = genericSTM32F405RG
 board_build.variant = MARLIN_TH3D_EZBOARD_V2
+board_build.encrypt = firmware.bin
 board_build.offset  = 0xC000
 board_upload.offset_address = 0x0800C000
 build_flags         = ${stm32_variant.build_flags} -DHSE_VALUE=12000000U -O0
 debug_tool          = stlink
 upload_protocol     = stlink
+extra_scripts       = ${stm32_variant.extra_scripts}
+                      buildroot/share/PlatformIO/scripts/openblt.py
 
 #
 # BOARD_MKS_ROBIN_NANO_V1_3_F4


### PR DESCRIPTION
### Description

build.encrypt and the openBLT script need to be present for the EZBoard V2.

### Requirements

EZBoard V2

### Benefits

Fixes firmware not flashing on the EZBoard V2

### Configurations

N/A

### Related Issues

N/A
