### PR TITLE
Fix M852 reporting as M851

### DIFF
--- a/Marlin/src/gcode/calibrate/M852.cpp
+++ b/Marlin/src/gcode/calibrate/M852.cpp
@@ -93,7 +93,7 @@ void GcodeSuite::M852() {
 
 void GcodeSuite::M852_report(const bool forReplay/*=true*/) {
   report_heading_etc(forReplay, F(STR_SKEW_FACTOR));
-  SERIAL_ECHOPAIR_F("  M851 I", planner.skew_factor.xy, 6);
+  SERIAL_ECHOPAIR_F("  M852 I", planner.skew_factor.xy, 6);
   #if ENABLED(SKEW_CORRECTION_FOR_Z)
     SERIAL_ECHOPAIR_F(" J", planner.skew_factor.xz, 6);
     SERIAL_ECHOPAIR_F(" K", planner.skew_factor.yz, 6);


### PR DESCRIPTION
### Description

When running M503, or M852 without an argument, Marlin reports the command as M851.

That's an entirely different command, and while M851 may be used more often, M852 is a valuable member of society and should be encouraged to accept its identity instead of denying it and trying to impersonate someone else.

### Requirements

Requires SKEW_CORRECTION and SKEW_CORRECTION_GCODE enabled to cause the issue it fixes, but otherwise no requirements.

### Benefits

Changes this:
```
< M852
> M851 I0.016326 J-0.001415 K0.006608 ; XY, XZ, YZ
```
To this:
```
< M852
> M852 I0.016326 J-0.001415 K0.006608 ; XY, XZ, YZ
```

### Configurations
```
#define SKEW_CORRECTION
#define SKEW_CORRECTION_GCODE
```

### Related Issues

None I know about.
