### PR TITLE
Sanity check for PIN D9 on FAN0 PWM with SPEAKER tone timer2 usage

### DIFF
--- a/Marlin/src/HAL/AVR/inc/SanityCheck.h
+++ b/Marlin/src/HAL/AVR/inc/SanityCheck.h
@@ -29,7 +29,15 @@
  * Checks for FAST PWM
  */
 #if ALL(FAST_PWM_FAN, USE_OCR2A_AS_TOP, HAS_TCCR2)
-  #error "USE_OCR2A_AS_TOP does not apply to devices with a single output TIMER2"
+  #error "USE_OCR2A_AS_TOP does not apply to devices with a single output TIMER2."
+#endif
+
+/**
+ * Checks for SOFT PWM
+ */
+#if HAS_FAN0 && FAN_PIN == 9 && DISABLED(FAN_SOFT_PWM) && ENABLED(SPEAKER)
+  #error "FAN_PIN 9 Hardware PWM uses Timer 2 which conflicts with Arduino AVR Tone Timer (for SPEAKER)."
+  #error "Disable SPEAKER or enable FAN_SOFT_PWM."
 #endif
 
 /**

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2017,12 +2017,14 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #if HAS_FAN0
   #if CONTROLLER_FAN_PIN == FAN_PIN
     #error "You cannot set CONTROLLER_FAN_PIN equal to FAN_PIN."
-  #elif ENABLED(FAN_SOFT_PWM_REQUIRED) && DISABLED(FAN_SOFT_PWM)
-    #error "FAN_SOFT_PWM is required. Enable it to continue."
-  #endif
-  #if ENABLED(SPEAKER) && DISABLED(FAN_SOFT_PWM) && FAN_PIN == 9
-    #error "Part cooling FAN_PIN PWM timer2 conflicts with #define SPEAKER tone timer2 use in AVR library."
-    #error "Use FAN_SOFT_PWM or disable SPEAKER."
+  #elif DISABLED(FAN_SOFT_PWM)
+    #if ENABLED(FAN_SOFT_PWM_REQUIRED)
+      #error "FAN_SOFT_PWM is required for your board. Enable it to continue."
+    #endif
+    #if defined(__AVR__) && ENABLED(SPEAKER) && FAN_PIN == 9
+      #error "FAN_PIN 9 Hardware PWM uses Timer 2 which conflicts with Arduino AVR Tone Timer (for SPEAKER)."
+      #error "Disable SPEAKER or use FAN_SOFT_PWM."
+    #endif
   #endif
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2017,14 +2017,8 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #if HAS_FAN0
   #if CONTROLLER_FAN_PIN == FAN_PIN
     #error "You cannot set CONTROLLER_FAN_PIN equal to FAN_PIN."
-  #elif DISABLED(FAN_SOFT_PWM)
-    #if ENABLED(FAN_SOFT_PWM_REQUIRED)
-      #error "FAN_SOFT_PWM is required for your board. Enable it to continue."
-    #endif
-    #if defined(__AVR__) && ENABLED(SPEAKER) && FAN_PIN == 9
-      #error "FAN_PIN 9 Hardware PWM uses Timer 2 which conflicts with Arduino AVR Tone Timer (for SPEAKER)."
-      #error "Disable SPEAKER or use FAN_SOFT_PWM."
-    #endif
+  #elif ENABLED(FAN_SOFT_PWM_REQUIRED) && DISABLED(FAN_SOFT_PWM)
+    #error "FAN_SOFT_PWM is required for your board. Enable it to continue."
   #endif
 #endif
 

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2020,6 +2020,10 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #elif ENABLED(FAN_SOFT_PWM_REQUIRED) && DISABLED(FAN_SOFT_PWM)
     #error "FAN_SOFT_PWM is required. Enable it to continue."
   #endif
+  #if ENABLED(SPEAKER) && DISABLED(FAN_SOFT_PWM) && FAN_PIN == 9
+    #error "Part cooling FAN_PIN PWM timer2 conflicts with #define SPEAKER tone timer2 use in AVR library."
+    #error "Use FAN_SOFT_PWM or disable SPEAKER."
+  #endif
 #endif
 
 #if ENABLED(USE_CONTROLLER_FAN)


### PR DESCRIPTION
### Description

This PR provides a conflict sanity check in the event a speaker is defined which will use tone timer2 OCR RIQ and fan0 PWM out on pin D9. 
The options of enabling FAN_SOFT_PWM or disable SPEAKER are offered.  

### Requirements

AVR Mega + RAMPS 

### Benefits

Prevents part cooling fan conflict.

### Configurations

#define SPEAKER
#define MOTHERBOARD BOARD_RAMPS_14_EFB

### Related Issues

#23651