### PR TITLE
Lib maple generic stm32 f103 rc envs

### DIFF
--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -134,6 +134,20 @@ debug_tool           = jlink
 upload_protocol      = jlink
 
 #
+# Creality (STM32F103RCT6)
+#
+[env:STM32F103RE_creality_maple]
+extends              = env:STM32F103RC_maple
+build_flags          = ${common_stm32f1.build_flags} -DTEMP_TIMER_CHAN=4
+board_build.address  = 0x08007000
+board_build.ldscript = creality.ld
+extra_scripts        = ${common_stm32f1.extra_scripts}
+  pre:buildroot/share/PlatformIO/scripts/random-bin.py
+  buildroot/share/PlatformIO/scripts/custom_board.py
+debug_tool           = jlink
+upload_protocol      = jlink
+
+#
 # BigTree SKR Mini E3 V2.0 & DIP / SKR CR6 (STM32F103RET6 ARM Cortex-M3)
 #
 #   STM32F103RE_btt_maple ............. RET6

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -136,7 +136,7 @@ upload_protocol      = jlink
 #
 # Creality (STM32F103RCT6)
 #
-[env:STM32F103RE_creality_maple]
+[env:STM32F103RC_creality_maple]
 extends              = env:STM32F103RC_maple
 build_flags          = ${common_stm32f1.build_flags} -DTEMP_TIMER_CHAN=4
 board_build.address  = 0x08007000

--- a/ini/stm32f1-maple.ini
+++ b/ini/stm32f1-maple.ini
@@ -112,6 +112,14 @@ board             = genericSTM32F103RE
 monitor_speed     = 115200
 
 #
+# Generic STM32F103RC environment
+#
+[env:STM32F103RC_maple]
+extends           = common_stm32f1
+board             = genericSTM32F103RC
+monitor_speed     = 115200
+
+#
 # Creality (STM32F103RET6)
 #
 [env:STM32F103RE_creality_maple]


### PR DESCRIPTION
Add STM32F103RC environments, both a generic and the Creality variant, following new boards shipping with RC chips which require Maple to fully function currently.