### PR TITLE
CNC work+machine coordinates reporting option, other CNC features/fixes

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -1873,7 +1873,7 @@
 //
 // G20/G21 Inch mode support
 //
-//#define INCH_MODE_SUPPORT
+#define INCH_MODE_SUPPORT
 
 //
 // M149 Set temperature units support

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3789,7 +3789,7 @@
  * Enables G53 and G54-G59.3 commands to select coordinate systems
  * and G92.1 to reset the workspace to native machine space.
  */
-#define CNC_COORDINATE_SYSTEMS
+// #define CNC_COORDINATE_SYSTEMS
 
 #if ENABLED(CNC_COORDINATE_SYSTEMS)
   #define REPORT_MACHINE_POSITION // Returns both Work and Machine coordinates in default M114 report, similar to GRBL.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2312,7 +2312,6 @@
  * - During Hold all Emergency Parser commands are available, as usual.
  */
 #define REALTIME_COMMANDS
-#define REALTIME_REPORTING_COMMANDS // For automated GitHub testing compatibility, use REALTIME_COMMANDS instead.
 
   /**
    * Send machine status updates to host (Useful for CNC/Laser)
@@ -4366,3 +4365,12 @@
 
 // Report uncleaned reset reason from register r2 instead of MCUSR. Supported by Optiboot on AVR.
 //#define OPTIBOOT_RESET_REASON
+
+/**
+ * Automated testing compatibility options
+ *
+ * These options are for GitHub testing compatibility ONLY, and are no longer used by Marlin
+ * Updated option names are noted in the proceding comments
+*/
+#define REALTIME_REPORTING_COMMANDS // Use REALTIME_COMMANDS instead.
+#define FULL_REPORT_TO_HOST_FEATURE // Use REPORT_STATUS_TO_HOST instead.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -3733,11 +3733,14 @@
 //#define DISABLE_DRIVER_SAFE_POWER_PROTECT
 
 /**
- * Include capabilities in M115 output
+ * Include enabled features in M115 output
+ * The purpose of this is to enable hosts to adjust to specific machine capabilities.
  */
 #define EXTENDED_CAPABILITIES_REPORT
 #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
-  //#define M115_GEOMETRY_REPORT
+  //#define M115_GEOMETRY_REPORT    // Display bed size and axis limits in the report
+  //#define MINIMAL_CAP_LINES       // Don't mention the disabled features
+
 #endif
 
 /**

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2335,18 +2335,25 @@
   // #define REPORT_STATUS_DURING_MOVES
 #endif
 
-// Use an abbreviated, advanced status report designed to relay maximum information to the host
-// in the smallest number of bytes (not very human-readable, designed for error-free host UI updates)
-// Example: |#|X10.000:Y100.000:Z0.5|X20.000:Y120.000:Z10.5|1|0|1|2|110|2
-// Legend:
-//  Status header [|#], Work coords (G92..), Machine coords (G53), Metric [1] (G21), Absolute pos. mode [0] (G90),
-//  Tool #[1] (active_extruder), Coord set [2] (G55), Feed rate override [110]% (M220 S110), Status: MF_WAITING [2]
-//
-// As you can see, quite a bit of info is transmitted to hosts which support it, saving multiple verbose queries.
+/**
+ * Compact Status Reports
+ *
+ * Use an abbreviated, advanced status report designed to relay maximum information to the host
+ * in the smallest number of bytes (not very human-readable, designed for error-free host UI updates)
+ *
+ * Example: |#|X10.000:Y100.000:Z0.5|X20.000:Y120.000:Z10.5|1|0|1|2|110|2
+ * Legend:
+ *  Status header [|#], Work coords (G92..), Machine coords (G53), Metric [1] (G21), Absolute pos. mode [0] (G90),
+ *  Tool #[1] (active_extruder), Coord set [2] (G55), Feed rate override [110]% (M220 S110), Status: MF_WAITING [2]
+ *
+ * As you can see, quite a bit of info is transmitted to hosts which support it, saving multiple verbose queries.
+ */
 #define COMPACT_STATUS_REPORTS
 #if ENABLED(COMPACT_STATUS_REPORTS)
+
   // M114 will return compact reports instead of the usual verbose report
   // #define M114_USES_COMPACT_REPORTS // CAUTION - May break host UI's which look for M114's verbose output
+
   // #define GRBL_COMPATIBLE_STATES    // Report GRBL-equivalent states instead of Marlin states
 #endif
 

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2299,7 +2299,7 @@
  * Currently handles M108, M112, M410, M876
  * NOTE: Not yet implemented for all platforms.
  */
-#define EMERGENCY_PARSER
+// #define EMERGENCY_PARSER
 #if ENABLED(EMERGENCY_PARSER)
   /**
    * Realtime Commands

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2300,24 +2300,18 @@
  * NOTE: Not yet implemented for all platforms.
  */
 // #define EMERGENCY_PARSER
-#if ENABLED(EMERGENCY_PARSER)
-  /**
-   * Realtime Commands
-   *
-   * Adds support for special real-time commands:
-   *  S000 : Report State and Position (works even while moving).
-   *  P000 : Instant Pause / Hold while moving.
-   *  R000 : Resume from Pause / Hold.
-   *
-   * - During Hold all Emergency Parser commands are available, as usual.
-   */
-  #define REALTIME_COMMANDS
-#endif
 
-// Normally, feed rate (M220) changes will be queued, causing a lengthy delay
-// (even executing after the job is completed) with large planner buffers.
-// Enable this to ensure M220 feed rate adjustments are processed immediately instead of queued.
-#define REALTIME_FEEDRATE_CHANGES
+/**
+ * Realtime Commands
+ *
+ * Adds support for special real-time commands:
+ *  S000 : Report State and Position (works even while moving).
+ *  P000 : Instant Pause / Hold while moving.
+ *  R000 : Resume from Pause / Hold.
+ *
+ * - During Hold all Emergency Parser commands are available, as usual.
+ */
+#define REALTIME_COMMANDS
 
 /**
  * Send machine status updates to host (Useful for CNC/Laser)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2312,24 +2312,25 @@
  * - During Hold all Emergency Parser commands are available, as usual.
  */
 #define REALTIME_COMMANDS
+#define REALTIME_REPORTING_COMMANDS // For automated GitHub testing compatibility, use REALTIME_COMMANDS instead.
 
-/**
- * Send machine status updates to host (Useful for CNC/Laser)
- *
- * - Auto-report state of the machine (like GRBL does) in numerical format.
- * - Auto-report position during long moves.
- *
- * Possible Marlin statuses (GRBL-compatible equivalent)
- * 0: MF_INITIALIZING    (M_INIT)
- * 1: MF_SD_COMPLETE     (M_ALARM)
- * 2: MF_WAITING         (M_IDLE)
- * 3: MF_STOPPED         (M_END)
- * 4: MF_RUNNING         (M_RUNNING)
- * 5: MF_PAUSED          (M_HOLD)
- * 6: MF_KILLED          (M_ERROR)
- */
-// #define REPORT_STATUS_TO_HOST // Send regular machine status updates to host in GRBL format ("S_XYZ: #")
-#if ENABLED(REPORT_STATUS_TO_HOST)
+  /**
+   * Send machine status updates to host (Useful for CNC/Laser)
+   *
+   * - Auto-report state of the machine (like GRBL does) in numerical format.
+   * - Auto-report position during long moves.
+   *
+   * Possible Marlin statuses (GRBL-compatible equivalent)
+   * 0: MF_INITIALIZING    (M_INIT)
+   * 1: MF_SD_COMPLETE     (M_ALARM)
+   * 2: MF_WAITING         (M_IDLE)
+   * 3: MF_STOPPED         (M_END)
+   * 4: MF_RUNNING         (M_RUNNING)
+   * 5: MF_PAUSED          (M_HOLD)
+   * 6: MF_KILLED          (M_ERROR)
+   */
+  // #define REPORT_STATUS_TO_HOST // Send regular machine status updates to host in GRBL format ("S_XYZ: #")
+  #if ENABLED(REPORT_STATUS_TO_HOST)
   // Report status during long moves
   // Only enable if needed, it is very verbose and will cause the console to scroll quickly
   // #define REPORT_STATUS_DURING_MOVES

--- a/Marlin/src/feature/e_parser.h
+++ b/Marlin/src/feature/e_parser.h
@@ -34,7 +34,7 @@
 // External references
 extern bool wait_for_user, wait_for_heatup;
 
-#if ENABLED(REALTIME_REPORTING_COMMANDS)
+#if ENABLED(REALTIME_COMMANDS)
   // From motion.h, which cannot be included here
   void report_current_position_moving();
   void quickpause_stepper();
@@ -59,7 +59,7 @@ public:
     #if ENABLED(HOST_PROMPT_SUPPORT)
       EP_M8, EP_M87, EP_M876, EP_M876S, EP_M876SN,
     #endif
-    #if ENABLED(REALTIME_REPORTING_COMMANDS)
+    #if ENABLED(REALTIME_COMMANDS)
       EP_S, EP_S0, EP_S00, EP_GRBL_STATUS,
       EP_R, EP_R0, EP_R00, EP_GRBL_RESUME,
       EP_P, EP_P0, EP_P00, EP_GRBL_PAUSE,
@@ -90,7 +90,7 @@ public:
           case ' ': case '\n': case '\r': break;
           case 'N': state = EP_N; break;
           case 'M': state = EP_M; break;
-          #if ENABLED(REALTIME_REPORTING_COMMANDS)
+          #if ENABLED(REALTIME_COMMANDS)
             case 'S': state = EP_S; break;
             case 'P': state = EP_P; break;
             case 'R': state = EP_R; break;
@@ -108,7 +108,7 @@ public:
           case '0' ... '9':
           case '-': case ' ':     break;
           case 'M': state = EP_M; break;
-          #if ENABLED(REALTIME_REPORTING_COMMANDS)
+          #if ENABLED(REALTIME_COMMANDS)
             case 'S': state = EP_S; break;
             case 'P': state = EP_P; break;
             case 'R': state = EP_R; break;
@@ -117,7 +117,7 @@ public:
         }
         break;
 
-      #if ENABLED(REALTIME_REPORTING_COMMANDS)
+      #if ENABLED(REALTIME_COMMANDS)
         case EP_S:   state = (c == '0') ? EP_S0          : EP_IGNORE; break;
         case EP_S0:  state = (c == '0') ? EP_S00         : EP_IGNORE; break;
         case EP_S00: state = (c == '0') ? EP_GRBL_STATUS : EP_IGNORE; break;
@@ -201,7 +201,7 @@ public:
             #if ENABLED(HOST_PROMPT_SUPPORT)
               case EP_M876SN: hostui.handle_response(M876_reason); break;
             #endif
-            #if ENABLED(REALTIME_REPORTING_COMMANDS)
+            #if ENABLED(REALTIME_COMMANDS)
               case EP_GRBL_STATUS: report_current_position_moving(); break;
               case EP_GRBL_PAUSE: quickpause_stepper(); break;
               case EP_GRBL_RESUME: quickresume_stepper(); break;

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -221,7 +221,7 @@ G29_TYPE GcodeSuite::G29() {
 
   TERN_(PROBE_MANUALLY, static) G29_State abl;
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_PROBE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_PROBE));
 
   reset_stepper_timeout();
 
@@ -893,7 +893,7 @@ G29_TYPE GcodeSuite::G29() {
 
   report_current_position();
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_IDLE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_IDLE));
 
   G29_RETURN(isnan(abl.measured_z));
 

--- a/Marlin/src/gcode/bedlevel/mbl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/mbl/G29.cpp
@@ -75,7 +75,7 @@ void GcodeSuite::G29() {
     }
   #endif
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_PROBE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_PROBE));
 
   static int mbl_probe_index = -1;
 
@@ -219,7 +219,7 @@ void GcodeSuite::G29() {
 
   report_current_position();
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_IDLE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_IDLE));
 }
 
 #endif // MESH_BED_LEVELING

--- a/Marlin/src/gcode/bedlevel/ubl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/ubl/G29.cpp
@@ -31,17 +31,17 @@
 #include "../../gcode.h"
 #include "../../../feature/bedlevel/bedlevel.h"
 
-#if ENABLED(FULL_REPORT_TO_HOST_FEATURE)
+#if ENABLED(REPORT_STATUS_TO_HOST)
   #include "../../../module/motion.h"
 #endif
 
 void GcodeSuite::G29() {
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_PROBE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_PROBE));
 
   ubl.G29();
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_IDLE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_IDLE));
 }
 
 #endif // AUTO_BED_LEVELING_UBL

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -214,7 +214,7 @@ void GcodeSuite::G28() {
 
   TERN_(LASER_MOVE_G28_OFF, cutter.set_inline_enabled(false));  // turn off laser
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_HOMING));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_HOMING));
 
   #if ENABLED(DUAL_X_CARRIAGE)
     bool IDEX_saved_duplication_state = extruder_duplication_enabled;
@@ -553,7 +553,7 @@ void GcodeSuite::G28() {
   if (ENABLED(NANODLP_Z_SYNC) && (doZ || ENABLED(NANODLP_ALL_AXIS)))
     SERIAL_ECHOLNPGM(STR_Z_MOVE_COMP);
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_IDLE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_IDLE));
 
   #if HAS_L64XX
     // Set L6470 absolute position registers to counts

--- a/Marlin/src/gcode/calibrate/G33.cpp
+++ b/Marlin/src/gcode/calibrate/G33.cpp
@@ -394,7 +394,7 @@ static float auto_tune_a(const float dcr) {
  */
 void GcodeSuite::G33() {
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_PROBE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_PROBE));
 
   const int8_t probe_points = parser.intval('P', DELTA_CALIBRATION_DEFAULT_POINTS);
   if (!WITHIN(probe_points, 0, 10)) {
@@ -660,7 +660,7 @@ void GcodeSuite::G33() {
 
   ac_cleanup(TERN_(HAS_MULTI_HOTEND, old_tool_index));
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_IDLE));
+  TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_IDLE));
 }
 
 #endif // DELTA_AUTO_CALIBRATION

--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -44,8 +44,6 @@ void GcodeSuite::M220() {
   if (parser.seenval('S')) feedrate_percentage = parser.value_int();
 
   if (!parser.seen_any()) {
-    SERIAL_ECHOPGM("FR:", feedrate_percentage);
-    SERIAL_CHAR('%');
-    SERIAL_EOL();
+    SERIAL_ECHOLNPGM("FR:", feedrate_percentage, "%");
   }
 }

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -569,15 +569,15 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       case 110: M110(); break;                                    // M110: Set Current Line Number
       case 111: M111(); break;                                    // M111: Set debug level
 
-      #if DISABLED(EMERGENCY_PARSER)
-        case 108: M108(); break;                                  // M108: Cancel Waiting
-        case 112: M112(); break;                                  // M112: Full Shutdown
-        case 410: M410(); break;                                  // M410: Quickstop - Abort all the planned moves.
-        TERN_(HOST_PROMPT_SUPPORT, case 876:)                     // M876: Handle Host prompt responses
-      #else
+      #if ENABLED(EMERGENCY_PARSER)                               // Don't respond to features handled by the E-parser
         case 108: case 112: case 410:
         TERN_(HOST_PROMPT_SUPPORT, case 876:)
         break;
+      #else
+        case 108: M108(); break;                                  // M108: Cancel Waiting
+        case 112: M112(); break;                                  // M112: Full Shutdown
+        case 410: M410(); break;                                  // M410: Quickstop - Abort all the planned moves.
+        case 876: TERN_(HOST_PROMPT_SUPPORT, M876()); break;      // M876: Handle Host prompt responses
       #endif
 
       #if ENABLED(HOST_KEEPALIVE_FEATURE)
@@ -1070,7 +1070,7 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
       case 'D': D(parser.codenum); break;                         // Dn: Debug codes
     #endif
 
-    #if ENABLED(REALTIME_REPORTING_COMMANDS)
+    #if ENABLED(REALTIME_COMMANDS)
       case 'S': case 'P': case 'R': break;                        // Invalid S, P, R commands already filtered
     #endif
 
@@ -1173,15 +1173,15 @@ void GcodeSuite::process_subcommands_now(char * gcode) {
         case IN_HANDLER:
         case IN_PROCESS:
           SERIAL_ECHO_MSG(STR_BUSY_PROCESSING);
-          TERN_(FULL_REPORT_TO_HOST_FEATURE, report_current_position_moving());
+          TERN_(REPORT_STATUS_TO_HOST, report_current_position_moving());
           break;
         case PAUSED_FOR_USER:
           SERIAL_ECHO_MSG(STR_BUSY_PAUSED_FOR_USER);
-          TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_HOLD));
+          TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_HOLD));
           break;
         case PAUSED_FOR_INPUT:
           SERIAL_ECHO_MSG(STR_BUSY_PAUSED_FOR_INPUT);
-          TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_HOLD));
+          TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_HOLD));
           break;
         default:
           break;

--- a/Marlin/src/gcode/host/M114.cpp
+++ b/Marlin/src/gcode/host/M114.cpp
@@ -192,7 +192,7 @@
     SERIAL_ECHOPGM("Diff:   ");
     report_all_axis_pos(diff);
 
-    TERN_(FULL_REPORT_TO_HOST_FEATURE, report_current_grblstate_moving());
+    TERN_(REPORT_STATUS_DURING_MOVES, report_current_grblstate_moving());
   }
 
 #endif // M114_DETAIL
@@ -231,5 +231,5 @@ void GcodeSuite::M114() {
   TERN_(M114_LEGACY, planner.synchronize());
   report_current_position_projected();
 
-  TERN_(FULL_REPORT_TO_HOST_FEATURE, report_current_grblstate_moving());
+  TERN_(REPORT_STATUS_DURING_MOVES, report_current_grblstate_moving());
 }

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -32,8 +32,6 @@
   #include "../../feature/caselight.h"
 #endif
 
-//#define MINIMAL_CAP_LINES // Don't even mention the disabled capabilities
-
 #if ENABLED(EXTENDED_CAPABILITIES_REPORT)
   #if ENABLED(MINIMAL_CAP_LINES)
     #define cap_line(S,C) if (C) _cap_line(S)
@@ -186,6 +184,9 @@ void GcodeSuite::M115() {
 
     // CONFIG_EXPORT
     cap_line(F("CONFIG_EXPORT"), ENABLED(CONFIGURATION_EMBEDDING));
+
+    // COMPACT_STATUS_REPORTS
+    cap_line(F("COMPACT_STATUS"), ENABLED(COMPACT_STATUS_REPORTS));
 
     // Machine Geometry
     #if ENABLED(M115_GEOMETRY_REPORT)

--- a/Marlin/src/gcode/motion/G0_G1.cpp
+++ b/Marlin/src/gcode/motion/G0_G1.cpp
@@ -59,7 +59,7 @@ void GcodeSuite::G0_G1(TERN_(HAS_FAST_MOVES, const bool fast_move/*=false*/)) {
       )
     #endif
   ) {
-    TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_RUNNING));
+    TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_RUNNING));
 
     #ifdef G0_FEEDRATE
       feedRate_t old_feedrate;
@@ -124,9 +124,12 @@ void GcodeSuite::G0_G1(TERN_(HAS_FAST_MOVES, const bool fast_move/*=false*/)) {
         planner.synchronize();
         SERIAL_ECHOLNPGM(STR_Z_MOVE_COMP);
       }
-      TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_IDLE));
+      TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_IDLE));
     #else
-      TERN_(FULL_REPORT_TO_HOST_FEATURE, report_current_grblstate_moving());
+      TERN_(REPORT_STATUS_DURING_MOVES, report_current_grblstate_moving());
     #endif
   }
+  #ifdef G0_FEEDRATE
+    if (fast_move) TERN_(M114_RAPID_REPORTING, report_current_position());
+  #endif
 }

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -373,7 +373,7 @@ void plan_arc(
 void GcodeSuite::G2_G3(const bool clockwise) {
   if (MOTION_CONDITIONS) {
 
-    TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_RUNNING));
+    TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_RUNNING));
 
     #if ENABLED(SF_ARC_FIX)
       const bool relative_mode_backup = relative_mode;
@@ -434,7 +434,7 @@ void GcodeSuite::G2_G3(const bool clockwise) {
     else
       SERIAL_ERROR_MSG(STR_ERR_ARC_ARGS);
 
-    TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_IDLE));
+    TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_IDLE));
   }
 }
 

--- a/Marlin/src/gcode/parser.cpp
+++ b/Marlin/src/gcode/parser.cpp
@@ -153,7 +153,7 @@ void GCodeParser::parse(char *p) {
    * Screen for good command letters.
    * With Realtime Reporting, commands S000, P000, and R000 are allowed.
    */
-  #if ENABLED(REALTIME_REPORTING_COMMANDS)
+  #if ENABLED(REALTIME_COMMANDS)
     switch (letter) {
       case 'P': case 'R' ... 'S': {
         uint8_t digits = 0;

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -63,7 +63,7 @@ PGMSTR(G28_STR, "G28");
 GCodeQueue::SerialState GCodeQueue::serial_state[NUM_SERIAL] = { 0 };
 GCodeQueue::RingBuffer GCodeQueue::ring_buffer = { 0 };
 
-#if NO_TIMEOUTS > 0
+#if TIMEOUT_PREVENTION_DELAY > 0
   static millis_t last_command_time = 0;
 #endif
 
@@ -241,7 +241,7 @@ void GCodeQueue::enqueue_now_P(PGM_P const pgcode) {
  *   B<int>  Block queue space remaining
  */
 void GCodeQueue::RingBuffer::ok_to_send() {
-  #if NO_TIMEOUTS > 0
+  #if TIMEOUT_PREVENTION_DELAY > 0
     // Start counting from the last command's execution
     last_command_time = millis();
   #endif
@@ -290,7 +290,7 @@ static bool serial_data_available(serial_index_t index) {
   return a > 0;
 }
 
-#if NO_TIMEOUTS > 0
+#if TIMEOUT_PREVENTION_DELAY > 0
   // Multiserial already handles dispatch to/from multiple ports
   static bool any_serial_data_available() {
     LOOP_L_N(p, NUM_SERIAL)
@@ -409,9 +409,9 @@ void GCodeQueue::get_serial_commands() {
 
   // If the command buffer is empty for too long,
   // send "wait" to indicate Marlin is still waiting.
-  #if NO_TIMEOUTS > 0
+  #if TIMEOUT_PREVENTION_DELAY > 0
     const millis_t ms = millis();
-    if (ring_buffer.empty() && !any_serial_data_available() && ELAPSED(ms, last_command_time + NO_TIMEOUTS)) {
+    if (ring_buffer.empty() && !any_serial_data_available() && ELAPSED(ms, last_command_time + TIMEOUT_PREVENTION_DELAY)) {
       SERIAL_ECHOLNPGM(STR_WAIT);
       last_command_time = ms;
     }
@@ -528,7 +528,7 @@ void GCodeQueue::get_serial_commands() {
           }
         #endif
 
-        #if NO_TIMEOUTS > 0
+        #if TIMEOUT_PREVENTION_DELAY > 0
           last_command_time = ms;
         #endif
 

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -266,9 +266,13 @@ void report_compact_status(const xyze_pos_t &rpos) {
   #endif
   SERIAL_ECHOPGM("|", (relative_mode) ? 1 : 0);                 // Absolute = 0 (G90), Relative = 1 (G91)
   SERIAL_ECHOPGM("|", active_extruder);                         // Current tool (AKA: active_extruder)
-  SERIAL_ECHOPGM("|", GcodeSuite::active_coordinate_system);    // CNC Coordinate system (-1 = G53 native, 0-8 = G54-G59.3)
+  #if ENABLED(CNC_COORDINATE_SYSTEMS)
+  SERIAL_ECHOPGM("|", gcode.active_coordinate_system); // CNC Coordinate system (-1 = G53 native, 0-8 = G54-G59.3)
+  #else
+    SERIAL_ECHO("|1"); // Always -1 without CNC_COORDINATE_SYSTEMS
+  #endif
   SERIAL_ECHOPGM("|", feedrate_percentage);                     // Feed rate % (M220)
-  #ifdef GRBL_COMPATIBLE_STATES
+  #if ENABLED(GRBL_COMPATIBLE_STATES)
     SERIAL_ECHOLNPGM("|", grbl_state_for_marlin_state());       // GRBL compatible status (state) eg: M_IDLE
   #else
     SERIAL_ECHOLNPGM("|", marlin_state);                        // Marlin status (state) eg: MF_WAITING

--- a/Marlin/src/module/motion.cpp
+++ b/Marlin/src/module/motion.cpp
@@ -226,58 +226,58 @@ inline void report_machine_position(const xyze_pos_t &rpos) {
   );
 }
 
-#ifdef COMPACT_STATUS_REPORTS
-// Example: |#|X10.000:Y100.000:Z0.5|X20.000:Y120.000:Z10.5|1|0|1|2|110|2
-// Legend:  Status header [|#] | Work coords (G92) | Machine coords (G53) | Metric [1] (G21)
-//          | Absolute positioning [0] (G90) | Tool #[1] | Coord system [-1] (G53)
-//          | Feed rate override [110]% (M220 S110) | Status: MF_WAITING [2]
-//
-// As you can see, quite a bit of info is transmitted to hosts which support it, saving multiple verbose queries.
-void report_compact_status(const xyze_pos_t &rpos) {
-  const xyze_pos_t lpos = rpos.asLogical();
-  const xyze_pos_t mpos = rpos.asFloat();
-  SERIAL_ECHO("|#"); // Header
-  // Work coords
-  SERIAL_ECHOPGM_P(
-    LIST_N(DOUBLE(LINEAR_AXES),
-      "|X", lpos.x,
-      ":Y", lpos.y,
-      ":Z", lpos.z,
-      ":I", lpos.i,
-      ":J", lpos.j,
-      ":K", lpos.k
-    )
-  );
-  // Machine coords
-  SERIAL_ECHOPGM_P(
-    LIST_N(DOUBLE(LINEAR_AXES),
-      "|X", mpos.x,
-      ":Y", mpos.y,
-      ":Z", mpos.z,
-      ":I", mpos.i,
-      ":J", mpos.j,
-      ":K", mpos.k
-    )
-  );
-  #if ENABLED(INCH_MODE_SUPPORT)
-    SERIAL_ECHOPGM("|", (parser.linear_unit_factor > 1.0f) ? 0 : 1); // Inch = 0 (G20), Metric = 1 (G21)
-  #else
-    SERIAL_ECHO("|1"); // Always metric without INCH_MODE_SUPPORT
-  #endif
-  SERIAL_ECHOPGM("|", (relative_mode) ? 1 : 0);                 // Absolute = 0 (G90), Relative = 1 (G91)
-  SERIAL_ECHOPGM("|", active_extruder);                         // Current tool (AKA: active_extruder)
-  #if ENABLED(CNC_COORDINATE_SYSTEMS)
-  SERIAL_ECHOPGM("|", gcode.active_coordinate_system); // CNC Coordinate system (-1 = G53 native, 0-8 = G54-G59.3)
-  #else
-    SERIAL_ECHO("|1"); // Always -1 without CNC_COORDINATE_SYSTEMS
-  #endif
-  SERIAL_ECHOPGM("|", feedrate_percentage);                     // Feed rate % (M220)
-  #if ENABLED(GRBL_COMPATIBLE_STATES)
-    SERIAL_ECHOLNPGM("|", grbl_state_for_marlin_state());       // GRBL compatible status (state) eg: M_IDLE
-  #else
-    SERIAL_ECHOLNPGM("|", marlin_state);                        // Marlin status (state) eg: MF_WAITING
-  #endif
-}
+#if ENABLED(COMPACT_STATUS_REPORTS)
+  // Example: |#|X10.000:Y100.000:Z0.5|X20.000:Y120.000:Z10.5|1|0|1|2|110|2
+  // Legend:  Status header [|#] | Work coords (G92) | Machine coords (G53) | Metric [1] (G21)
+  //          | Absolute positioning [0] (G90) | Tool #[1] | Coord system [-1] (G53)
+  //          | Feed rate override [110]% (M220 S110) | Status: MF_WAITING [2]
+  //
+  // As you can see, quite a bit of info is transmitted to hosts which support it, saving multiple verbose queries.
+  void report_compact_status(const xyze_pos_t &rpos) {
+    const xyze_pos_t lpos = rpos.asLogical();
+    const xyze_pos_t mpos = rpos.asFloat();
+    SERIAL_ECHO("|#"); // Header
+    // Work coords
+    SERIAL_ECHOPGM_P(
+      LIST_N(DOUBLE(LINEAR_AXES),
+        "|X", lpos.x,
+        ":Y", lpos.y,
+        ":Z", lpos.z,
+        ":I", lpos.i,
+        ":J", lpos.j,
+        ":K", lpos.k
+      )
+    );
+    // Machine coords
+    SERIAL_ECHOPGM_P(
+      LIST_N(DOUBLE(LINEAR_AXES),
+        "|X", mpos.x,
+        ":Y", mpos.y,
+        ":Z", mpos.z,
+        ":I", mpos.i,
+        ":J", mpos.j,
+        ":K", mpos.k
+      )
+    );
+    #if ENABLED(INCH_MODE_SUPPORT)
+      SERIAL_ECHOPGM("|", (parser.linear_unit_factor > 1.0f) ? 0 : 1); // Inch = 0 (G20), Metric = 1 (G21)
+    #else
+      SERIAL_ECHO("|1"); // Always metric without INCH_MODE_SUPPORT
+    #endif
+    SERIAL_ECHOPGM("|", (relative_mode) ? 1 : 0);                 // Absolute = 0 (G90), Relative = 1 (G91)
+    SERIAL_ECHOPGM("|", active_extruder);                         // Current tool (AKA: active_extruder)
+    #if ENABLED(CNC_COORDINATE_SYSTEMS)
+      SERIAL_ECHOPGM("|", gcode.active_coordinate_system); // CNC Coordinate system (-1 = G53 native, 0-8 = G54-G59.3)
+    #else
+      SERIAL_ECHO("|-1"); // Always -1 without CNC_COORDINATE_SYSTEMS
+    #endif
+    SERIAL_ECHOPGM("|", feedrate_percentage);                     // Feed rate % (M220)
+    #if ENABLED(GRBL_COMPATIBLE_STATES)
+      SERIAL_ECHOLNPGM("|", grbl_state_for_marlin_state());       // GRBL compatible status (state) eg: M_IDLE
+    #else
+      SERIAL_ECHOLNPGM("|", marlin_state);                        // Marlin status (state) eg: MF_WAITING
+    #endif
+  }
 #endif
 
 // Report the real current position according to the steppers.
@@ -296,7 +296,7 @@ void report_real_position() {
     report_compact_status(npos);
   #else
     report_logical_position(npos);
-    #ifdef REPORT_MACHINE_POSITION
+    #if ENABLED(REPORT_MACHINE_POSITION)
       report_machine_position(npos);
     #endif
     report_more_positions();
@@ -305,11 +305,11 @@ void report_real_position() {
 
 // Report the logical current position according to the most recent G-code command
 void report_current_position() {
-  #ifdef COMPACT_STATUS_REPORTS
+  #if ENABLED(COMPACT_STATUS_REPORTS)
     report_compact_status();
   #else
     report_logical_position(current_position);
-    #ifdef REPORT_MACHINE_POSITION
+    #if ENABLED(REPORT_MACHINE_POSITION)
       report_machine_position(current_position);
     #endif
     report_more_positions();
@@ -327,7 +327,7 @@ void report_current_position_projected() {
     report_compact_status();
   #else
     report_logical_position(current_position);
-    #ifdef REPORT_MACHINE_POSITION
+    #if ENABLED(REPORT_MACHINE_POSITION)
       report_machine_position(current_position);
     #endif
     stepper.report_a_position(planner.position);
@@ -353,11 +353,11 @@ void report_current_position_projected() {
    */
   void report_current_position_moving() {
     get_cartesian_from_steppers();
-    #ifdef COMPACT_STATUS_REPORTS
+    #if ENABLED(COMPACT_STATUS_REPORTS)
       report_compact_status(cartes);
     #else
       report_logical_position(cartes);
-      #ifdef REPORT_MACHINE_POSITION
+      #if ENABLED(REPORT_MACHINE_POSITION)
         report_machine_position(cartes);
       #endif
       stepper.report_positions();

--- a/Marlin/src/module/motion.h
+++ b/Marlin/src/module/motion.h
@@ -233,6 +233,7 @@ inline float home_bump_mm(const AxisEnum axis) {
 void report_real_position();
 void report_current_position();
 void report_current_position_projected();
+void report_compact_status(const xyze_pos_t &rpos = current_position);
 
 #if ENABLED(AUTO_REPORT_POSITION)
   #include "../libs/autoreport.h"
@@ -240,7 +241,7 @@ void report_current_position_projected();
   extern AutoReporter<PositionReport> position_auto_reporter;
 #endif
 
-#if EITHER(FULL_REPORT_TO_HOST_FEATURE, REALTIME_REPORTING_COMMANDS)
+#if ANY(REPORT_STATUS_TO_HOST, REALTIME_COMMANDS, GRBL_COMPATIBLE_STATES)
   #define HAS_GRBL_STATE 1
   /**
    * Machine states for GRBL or TinyG
@@ -264,14 +265,14 @@ void report_current_position_projected();
   void report_current_grblstate_moving();
   void report_current_position_moving();
 
-  #if ENABLED(FULL_REPORT_TO_HOST_FEATURE)
+  #if ENABLED(REPORT_STATUS_TO_HOST)
     inline void set_and_report_grblstate(const M_StateEnum state) {
       M_State_grbl = state;
       report_current_grblstate_moving();
     }
   #endif
 
-  #if ENABLED(REALTIME_REPORTING_COMMANDS)
+  #if ENABLED(REALTIME_COMMANDS)
     void quickpause_stepper();
     void quickresume_stepper();
   #endif

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -1682,19 +1682,19 @@ void Planner::quick_stop() {
   stepper.quick_stop();
 }
 
-#if ENABLED(REALTIME_REPORTING_COMMANDS)
+#if ENABLED(REALTIME_COMMANDS)
 
   void Planner::quick_pause() {
     // Suspend until quick_resume is called
     // Don't empty buffers or queues
     const bool did_suspend = stepper.suspend();
     if (did_suspend)
-      TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(M_HOLD));
+      TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(M_HOLD));
   }
 
   // Resume if suspended
   void Planner::quick_resume() {
-    TERN_(FULL_REPORT_TO_HOST_FEATURE, set_and_report_grblstate(grbl_state_for_marlin_state()));
+    TERN_(REPORT_STATUS_TO_HOST, set_and_report_grblstate(grbl_state_for_marlin_state()));
     stepper.wake_up();
   }
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -856,7 +856,7 @@ class Planner {
     // a Full Shutdown is required, or when endstops are hit)
     static void quick_stop();
 
-    #if ENABLED(REALTIME_REPORTING_COMMANDS)
+    #if ENABLED(REALTIME_COMMANDS)
       // Force a quick pause of the machine (e.g., when a pause is required in the middle of move).
       // NOTE: Hard-stops will lose steps so encoders are highly recommended if using these!
       static void quick_pause();

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -78,7 +78,20 @@
   #define Z_MAX_PIN                        P1_24  // Z+
 #endif
 
-#define ONBOARD_ENDSTOPPULLUPS                    // Board has built-in pullups
+#define ONBOARD_ENDSTOPPULLUPS
+                   // Board has built-in pullups
+//
+// M3/M4/M5 - Spindle/Laser Control
+//
+#if HAS_CUTTER && !defined(SPINDLE_LASER_ENA_PIN)
+  #if !NUM_SERVOS                       // Use servo connector if possible
+    #define SPINDLE_LASER_ENA_PIN P2_00 // Pullup or pulldown!
+    #define SPINDLE_LASER_PWM_PIN P2_07 // Hardware PWM
+  //#define SPINDLE_DIR_PIN           5
+  #else
+    #error "No auto-assignable Spindle/Laser pins available."
+  #endif
+#endif
 
 //
 // Servos
@@ -125,33 +138,48 @@
   #define Z_CS_PIN                         P1_10
 #endif
 
-#define E0_STEP_PIN                        P2_13
-#define E0_DIR_PIN                         P0_11
-#define E0_ENABLE_PIN                      P2_12
-#ifndef E0_CS_PIN
-  #define E0_CS_PIN                        P1_08
+#if HAS_EXTRUDERS
+  #define E0_STEP_PIN                        P2_13
+  #define E0_DIR_PIN                         P0_11
+  #define E0_ENABLE_PIN                      P2_12
+  #ifndef E0_CS_PIN
+    #define E0_CS_PIN                        P1_08
+  #endif
+  #ifndef E1_CS_PIN
+    #define E1_CS_PIN                        P1_01
+  #endif
+#elif defined(X2_DRIVER_TYPE)
+  #define X2_STEP_PIN   P2_13
+  #define X2_DIR_PIN    P0_11
+  #define X2_ENABLE_PIN P2_12
+  #ifndef X2_CS_PIN
+    #define X2_CS_PIN P1_08
+  #endif
+#elif defined(Y2_DRIVER_TYPE)
+  #define Y2_STEP_PIN   P2_13
+  #define Y2_DIR_PIN    P0_11
+  #define Y2_ENABLE_PIN P2_12
+  #ifndef Y2_CS_PIN
+    #define Y2_CS_PIN P1_08
+  #endif
 #endif
 
-#ifndef E1_CS_PIN
-  #define E1_CS_PIN                        P1_01
-#endif
+  //
+  // Software SPI pins for TMC2130 stepper drivers
+  //
+  #if ENABLED(TMC_USE_SW_SPI)
+    #ifndef TMC_SW_MOSI
+      #define TMC_SW_MOSI P4_28
+    #endif
+    #ifndef TMC_SW_MISO
+      #define TMC_SW_MISO P0_05
+    #endif
+    #ifndef TMC_SW_SCK
+      #define TMC_SW_SCK P0_04
+    #endif
+  #endif
 
-//
-// Software SPI pins for TMC2130 stepper drivers
-//
-#if ENABLED(TMC_USE_SW_SPI)
-  #ifndef TMC_SW_MOSI
-    #define TMC_SW_MOSI                    P4_28
-  #endif
-  #ifndef TMC_SW_MISO
-    #define TMC_SW_MISO                    P0_05
-  #endif
-  #ifndef TMC_SW_SCK
-    #define TMC_SW_SCK                     P0_04
-  #endif
-#endif
-
-#if HAS_TMC_UART
+  #if HAS_TMC_UART
   /**
    * TMC2208/TMC2209 stepper drivers
    *

--- a/Marlin/src/sd/SdBaseFile.cpp
+++ b/Marlin/src/sd/SdBaseFile.cpp
@@ -38,8 +38,9 @@
 #if ENABLED(SDSUPPORT)
 
 #include "SdBaseFile.h"
+  #include "cardreader.h"
 
-#include "../MarlinCore.h"
+  #include "../MarlinCore.h"
 SdBaseFile *SdBaseFile::cwd_ = 0;   // Pointer to Current Working Directory
 
 // callback function for date/time
@@ -1140,12 +1141,12 @@ bool SdBaseFile::openNext(SdBaseFile *dirFile, uint8_t oflag) {
         // We can't reconvert to UTF-8 here as UTF-8 is variable-size encoding, but joining LFN blocks
         // needs static bytes addressing. So here just store full UTF-16LE words to re-convert later.
         uint16_t idx = (startOffset + i) * 2; // This is fixed as FAT LFN always contain UTF-16LE encoding
-        longFilename[idx] = utf16_ch & 0xFF;
-        longFilename[idx + 1] = (utf16_ch >> 8) & 0xFF;
-      #else
-        // Replace all multibyte characters to '_'
-        lname[startOffset + i] = (utf16_ch > 0xFF) ? '_' : (utf16_ch & 0xFF);
-      #endif
+        card.longFilename[idx]     = utf16_ch & 0xFF;
+        card.longFilename[idx + 1] = (utf16_ch >> 8) & 0xFF;
+    #else
+      // Replace all multibyte characters to '_'
+      lname[startOffset + i] = (utf16_ch > 0xFF) ? '_' : (utf16_ch & 0xFF);
+    #endif
     }
   }
 


### PR DESCRIPTION
### Description
- Add optional machine coordinates to position reports
- Added optional Compact Status reporting - optimized machine state reporting designed for fast host updates
- Fix for M876 not getting properly enabled unless EMERGENCY_PARSER is enabled.
- Optional GRBL-compatible status reporting
- Optional position report every G0 move
- Improved config option layout/naming/grouping for related options
  - Rename NO_TIMEOUTS to TIMEOUT_PREVENTION_DELAY for user clarity, since it's an integer not a boolean.
  - Rename FULL_REPORT_TO_HOST_FEATURE to REPORT_STATUS_TO_HOST for user clarity, since it is anything but "full". 
    - In fact, it only reports machine status and that's it. Hence the name change.
  - Rename REALTIME_REPORTING_COMMANDS to REALTIME_COMMANDS for user clarity, since only 1 is a reporting command, the others are control commands.
  - Minor config documentation tweaks for clarity
- Fixed unrelated bug in SD card long filenames, where SdBaseFile.cpp was calling longFilename without including the source of it (cardreader.h), causing compilation to fail.
- Added missing spindle and Y2 config support to LPC1768 boards. Now users only need to enable SPINDLE_FEATURE and it's configured.

## Notable Config additions/changes:
```
/**
 * Send machine status updates to host (Useful for CNC/Laser)
 *
 * - Auto-report state of the machine (like GRBL does) in numerical format.
 * - Auto-report position during long moves.
 *
 * Possible Marlin statuses (GRBL-compatible equivalent)
 * 0: MF_INITIALIZING    (M_INIT)
 * 1: MF_SD_COMPLETE     (M_ALARM)
 * 2: MF_WAITING         (M_IDLE)
 * 3: MF_STOPPED         (M_END)
 * 4: MF_RUNNING         (M_RUNNING)
 * 5: MF_PAUSED          (M_HOLD)
 * 6: MF_KILLED          (M_ERROR)
 */
// #define REPORT_STATUS_TO_HOST // Send regular machine status updates to host in GRBL format ("S_XYZ: #")
#if ENABLED(REPORT_STATUS_TO_HOST)
  // Report status during long moves
  // Only enable if needed, it is very verbose and will cause the console to scroll quickly
  // #define REPORT_STATUS_DURING_MOVES
#endif

// Use an abbreviated, advanced status report designed to relay maximum information to the host
// in the smallest number of bytes (not very human-readable, designed for error-free host UI updates)
// Example: |#|X10.000:Y100.000:Z0.5|X20.000:Y120.000:Z10.5|1|0|1|2|110|2
// Legend:
//  Status header [|#], Work coords (G92..), Machine coords (G53), Metric [1] (G21), Absolute pos. mode [0] (G90),
//  Tool #[1] (active_extruder), Coord set [2] (G55), Feed rate override [110]% (M220 S110), Status: MF_WAITING [2]
//
// As you can see, quite a bit of info is transmitted to hosts which support it, saving multiple verbose queries.
#define COMPACT_STATUS_REPORTS
#if ENABLED(COMPACT_STATUS_REPORTS)
  // M114 will return compact reports instead of the usual verbose report
  // #define M114_USES_COMPACT_REPORTS // CAUTION - May break host UI's which look for M114's verbose output
  // #define GRBL_COMPATIBLE_STATES    // Report GRBL-equivalent states instead of Marlin states
#endif

```

```
#define M114_RAPID_REPORTING    // Outputs M114 position report to host after every G0 (rapid) move (for faster host UI updates), requires G0_FEEDRATE

/**
 * CNC Coordinate Systems
 *
 * Enables G53 and G54-G59.3 commands to select coordinate systems
 * and G92.1 to reset the workspace to native machine space.
 */
#define CNC_COORDINATE_SYSTEMS

#if ENABLED(CNC_COORDINATE_SYSTEMS)
  #define REPORT_MACHINE_POSITION // Returns both Work and Machine coordinates in default M114 report, similar to GRBL.
#endif

```
### Requirements
- As you might guess, most additions/changes are only enabled when CNC-focused config options are enabled:
  - CNC_COORDINATE_SYSTEMS
  - REPORT_MACHINE_POSITION // Returns both Work and Machine coordinates in default M114 report, similar to GRBL.
  - G0_FEEDRATE
  - M114_RAPID_REPORTING

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
- Multiple:
- No more guessing what the machine coordinates are (or having to switch to G53, do an M114, then switch back)
- No more host errors or spindle nose dives, where a switch to G90/G91 mode or G20/G21 mode does not register with the host because it was set prior to loading the host UI.
- Faster position reporting
- GRBL compatible statuses
- Status reporting for hosts which rely on them
- Saves a ton of serial bandwidth and consolidates multiple report/status requests into one
- Easier to understand config documentation

### Configurations
- Compatible with all configurations, but focused on CNC

- All changes/additions are optional, so no existing configurations/systems should break.
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/15073 - Machine position reporting
https://github.com/MarlinFirmware/Marlin/issues/12192 - Motion mode reporting
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
