### PR TITLE
Add support for priority command execution (bypassing queue)

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2333,12 +2333,12 @@
  * These settings respect the M400 (finish move) command, so if they proceed immediately after an M400, they'll
  * be added to the end of the queue as usual.
  */
-// #define PRIORITY_FEEDRATE_CHANGES  // M220 feed rate adjustments are processed immediately instead of queued.
-// #define PRIORITY_BABYSTEPPING      // M290 babystepping is processed immediately instead of queued.
+#define PRIORITY_FEEDRATE_CHANGES // M220 feed rate adjustments are processed immediately instead of queued.
+#define PRIORITY_BABYSTEPPING     // M290 babystepping is processed immediately instead of queued.
 
 // Space-separated list of g-code commands which will bypass the queue and execute immediately
-// Example: "M220 M290" (feed rate % and babystepping)
-#define PRIORITY_COMMANDS "M220 M290"
+// Example: "M500 M25 M125"
+// #define PRIORITY_COMMANDS "" // Case sensitive, even if GCODE_CASE_INSENSITIVE is set
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2321,6 +2321,25 @@
   //#define FULL_REPORT_TO_HOST_FEATURE   // Auto-report the machine status like Grbl CNC
 #endif
 
+/**
+ * Priority command execution
+ *
+ * When interacting using an attached Marlin LCD display, changes such as babystepping and feed rates
+ * will take effect nearly instantly. However, those same changes via serial host will be queued and may
+ * be delayed significantly, even after the job has completely finished, because of queuing and buffering.
+ *
+ * The following allows you to bypass the queue for certain time-sensitive commands, executing them immediately.
+ *
+ * These settings respect the M400 (finish move) command, so if they proceed immediately after an M400, they'll
+ * be added to the end of the queue as usual.
+ */
+// #define PRIORITY_FEEDRATE_CHANGES  // M220 feed rate adjustments are processed immediately instead of queued.
+// #define PRIORITY_BABYSTEPPING      // M290 babystepping is processed immediately instead of queued.
+
+// Space-separated list of g-code commands which will bypass the queue and execute immediately
+// Example: "M220 M290" (feed rate % and babystepping)
+#define PRIORITY_COMMANDS "M220 M290"
+
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.
 // Some other clients start sending commands while receiving a 'wait'.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2324,21 +2324,21 @@
 /**
  * Priority command execution
  *
- * When interacting using an attached Marlin LCD display, changes such as babystepping and feed rates
- * will take effect nearly instantly. However, those same changes via serial host will be queued and may
- * be delayed significantly, even after the job has completely finished, because of queuing and buffering.
+ * When interacting using an attached Marlin LCD display, changes such as babystepping and feedrates
+ * will take effect nearly instantly. However, those same changes via serial host are enqueued by design
+ * and may be delayed by up to BUFSIZE commands.
  *
- * The following allows you to bypass the queue for certain time-sensitive commands, executing them immediately.
+ * The following options will bypass the queue for certain time-sensitive commands, executing them immediately.
  *
- * These settings respect the M400 (finish move) command, so if they proceed immediately after an M400, they'll
- * be added to the end of the queue as usual.
+ * These settings sort of respect M400 (finish move). If they immediately follow M400, they're added to the
+ * end of the queue in the normal way.
  */
-#define PRIORITY_FEEDRATE_CHANGES // M220 feed rate adjustments are processed immediately instead of queued.
-#define PRIORITY_BABYSTEPPING     // M290 babystepping is processed immediately instead of queued.
+#define PRIORITY_FEEDRATE_CHANGES // M220 feed rate adjustments will be processed immediately.
+#define PRIORITY_BABYSTEPPING     // M290 babystepping commands will be processed immediately.
 
-// Space-separated list of g-code commands which will bypass the queue and execute immediately
+// Space-separated list of G-code commands that will bypass the queue and execute immediately.
 // Example: "M500 M25 M125"
-// #define PRIORITY_COMMANDS "" // Case sensitive, even if GCODE_CASE_INSENSITIVE is set
+//#define PRIORITY_COMMANDS "M500 M25 M125" // Always use uppercase, even with GCODE_CASE_INSENSITIVE
 
 // Bad Serial-connections can miss a received command by sending an 'ok'
 // Therefore some clients abort after 30 seconds in a timeout.

--- a/Marlin/src/gcode/config/M220.cpp
+++ b/Marlin/src/gcode/config/M220.cpp
@@ -44,8 +44,6 @@ void GcodeSuite::M220() {
   if (parser.seenval('S')) feedrate_percentage = parser.value_int();
 
   if (!parser.seen_any()) {
-    SERIAL_ECHOPGM("FR:", feedrate_percentage);
-    SERIAL_CHAR('%');
-    SERIAL_EOL();
+    SERIAL_ECHOLNPGM("FR:", feedrate_percentage, "%");
   }
 }

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -1124,8 +1124,8 @@ void GcodeSuite::process_next_command() {
  * Run a series of commands, bypassing the command queue to allow
  * G-code "macros" to be called from within other G-code handlers.
  */
-void GcodeSuite::process_subcommands_now(FSTR_P fgcode, bool no_ok) {
-  PGM_P pgcode           = FTOP(fgcode);
+void GcodeSuite::process_subcommands_now(FSTR_P fgcode, const bool no_ok/*=true*/) {
+  PGM_P pgcode = FTOP(fgcode);
   char * const saved_cmd = parser.command_ptr;        // Save the parser state
   for (;;) {
     PGM_P const delim = strchr_P(pgcode, '\n');       // Get address of next newline
@@ -1143,7 +1143,7 @@ void GcodeSuite::process_subcommands_now(FSTR_P fgcode, bool no_ok) {
 
 #pragma GCC diagnostic pop
 
-void GcodeSuite::process_subcommands_now(char *gcode, bool no_ok) {
+void GcodeSuite::process_subcommands_now(char *gcode, const bool no_ok/*=true*/) {
   char *const saved_cmd = parser.command_ptr; // Save the parser state
   for (;;) {
     char * const delim = strchr(gcode, '\n');         // Get address of next newline

--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -1124,8 +1124,8 @@ void GcodeSuite::process_next_command() {
  * Run a series of commands, bypassing the command queue to allow
  * G-code "macros" to be called from within other G-code handlers.
  */
-void GcodeSuite::process_subcommands_now(FSTR_P fgcode) {
-  PGM_P pgcode = FTOP(fgcode);
+void GcodeSuite::process_subcommands_now(FSTR_P fgcode, bool no_ok) {
+  PGM_P pgcode           = FTOP(fgcode);
   char * const saved_cmd = parser.command_ptr;        // Save the parser state
   for (;;) {
     PGM_P const delim = strchr_P(pgcode, '\n');       // Get address of next newline
@@ -1134,7 +1134,7 @@ void GcodeSuite::process_subcommands_now(FSTR_P fgcode) {
     strncpy_P(cmd, pgcode, len);                      // Copy the command to the stack
     cmd[len] = '\0';                                  // End with a nul
     parser.parse(cmd);                                // Parse the command
-    process_parsed_command(true);                     // Process it (no "ok")
+    process_parsed_command(no_ok);                    // Process it (no "ok")?
     if (!delim) break;                                // Last command?
     pgcode = delim + 1;                               // Get the next command
   }
@@ -1143,13 +1143,13 @@ void GcodeSuite::process_subcommands_now(FSTR_P fgcode) {
 
 #pragma GCC diagnostic pop
 
-void GcodeSuite::process_subcommands_now(char * gcode) {
-  char * const saved_cmd = parser.command_ptr;        // Save the parser state
+void GcodeSuite::process_subcommands_now(char *gcode, bool no_ok) {
+  char *const saved_cmd = parser.command_ptr; // Save the parser state
   for (;;) {
     char * const delim = strchr(gcode, '\n');         // Get address of next newline
     if (delim) *delim = '\0';                         // Replace with nul
     parser.parse(gcode);                              // Parse the current command
-    process_parsed_command(true);                     // Process it (no "ok")
+    process_parsed_command(no_ok);                    // Process it (no "ok")?
     if (!delim) break;                                // Last command?
     *delim = '\n';                                    // Put back the newline
     gcode = delim + 1;                                // Get the next command

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -418,8 +418,8 @@ public:
   static void process_next_command();
 
   // Execute G-code in-place, preserving current G-code parameters
-  static void process_subcommands_now(FSTR_P fgcode);
-  static void process_subcommands_now(char * gcode);
+  static void process_subcommands_now(FSTR_P fgcode, bool no_ok = true);
+  static void process_subcommands_now(char* gcode, bool no_ok = true);
 
   static void home_all_axes(const bool keep_leveling=false) {
     process_subcommands_now(keep_leveling ? FPSTR(G28_STR) : TERN(CAN_SET_LEVELING_AFTER_G28, F("G28L0"), FPSTR(G28_STR)));

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -418,8 +418,8 @@ public:
   static void process_next_command();
 
   // Execute G-code in-place, preserving current G-code parameters
-  static void process_subcommands_now(FSTR_P fgcode, bool no_ok = true);
-  static void process_subcommands_now(char* gcode, bool no_ok = true);
+  static void process_subcommands_now(FSTR_P fgcode, const bool no_ok=true);
+  static void process_subcommands_now(char* gcode, const bool no_ok=true);
 
   static void home_all_axes(const bool keep_leveling=false) {
     process_subcommands_now(keep_leveling ? FPSTR(G28_STR) : TERN(CAN_SET_LEVELING_AFTER_G28, F("G28L0"), FPSTR(G28_STR)));

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -531,7 +531,7 @@ void GCodeQueue::get_serial_commands() {
         #if ANY(PRIORITY_FEEDRATE_CHANGES, PRIORITY_BABYSTEPPING,defined(PRIORITY_COMMANDS))
           // Don't prioritize commands which are preceded by M400 (finish moves) command
           if (!strstr_P(ring_buffer.last_queued_command(), PSTR("M400"))) {
-            #define DEBUG_PRIORITY_COMMANDS
+            // #define DEBUG_PRIORITY_COMMANDS
             #if ENABLED(PRIORITY_FEEDRATE_CHANGES)
               // Feed rate adjustment
               if (!!strstr_P(command, PSTR("M220")) TERN_(GCODE_CASE_INSENSITIVE, || !!strstr_P(command, PSTR("m220")))) {

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -558,21 +558,18 @@ void GCodeQueue::get_serial_commands() {
             #ifdef PRIORITY_COMMANDS
               // Process matching commands immediately, unless preceded by an M400 (finish moves) command
               if (strlen(PRIORITY_COMMANDS) > 0) {
-                if (!strstr_P(ring_buffer.last_queued_command(), PSTR("M400"))) {
-                  char *pc_token;
-                  char pc_list[strlen(PRIORITY_COMMANDS) + 1] = PRIORITY_COMMANDS;
-                  bool pc_token_found = false, pc_is_first_token = true;
-                  while ((pc_token = strtok((pc_is_first_token) ? pc_list : NULL, " "))) {
-                    pc_is_first_token = false;
-                    if (!!strstr(command, pc_token)) {
-                      DEBUG_ECHOLNPGM("Priority command found: ", pc_token, ", executing ", command);
-                      gcode.process_subcommands_now(command, false);
-                      pc_token_found = true;
-                      break;
-                    }
+                char pc_list[strlen(PRIORITY_COMMANDS) + 1] = PRIORITY_COMMANDS;
+                bool pc_token_found = false, pc_is_first_token = true;
+                while (char * const pc_token = strtok(pc_is_first_token ? pc_list : nullptr, " ")) {
+                  pc_is_first_token = false;
+                  if (!!strstr(command, pc_token)) {
+                    DEBUG_ECHOLNPGM("Priority command found: ", pc_token, ", executing ", command);
+                    gcode.process_subcommands_now(command, false);
+                    pc_token_found = true;
+                    break;
                   }
-                  if (pc_token_found) break;
                 }
+                if (pc_token_found) break;
               }
             #endif
 

--- a/Marlin/src/gcode/queue.cpp
+++ b/Marlin/src/gcode/queue.cpp
@@ -528,45 +528,57 @@ void GCodeQueue::get_serial_commands() {
           }
         #endif
 
-        #if ENABLED(PRIORITY_FEEDRATE_CHANGES)
-          // Feed rate adjustment - process immediately, unless preceded by an M400 (finish moves) command
-          if (!!strstr_P(command, PSTR("M220")) && !strstr_P(ring_buffer.last_queued_command(), PSTR("M400"))) {
-            gcode.process_subcommands_now(command, false);
-            break;
-          }
-        #endif
-
-        #if ENABLED(PRIORITY_BABYSTEPPING)
-          // Feed rate adjustment - process immediately, unless preceded by an M400 (finish moves) command
-          if (!!strstr_P(command, PSTR("M290")) && !strstr_P(ring_buffer.last_queued_command(), PSTR("M400"))) {
-            gcode.process_subcommands_now(command, false);
-            break;
-          }
-        #endif
-
-        #define DEBUG_PRIORITY_COMMANDS
-        #ifdef PRIORITY_COMMANDS
-          // Process matching commands immediately, unless preceded by an M400 (finish moves) command
+        #if ANY(PRIORITY_FEEDRATE_CHANGES, PRIORITY_BABYSTEPPING,defined(PRIORITY_COMMANDS))
+          // Don't prioritize commands which are preceded by M400 (finish moves) command
           if (!strstr_P(ring_buffer.last_queued_command(), PSTR("M400"))) {
-            if (strlen(PRIORITY_COMMANDS) > 0) {
-              char *token;
-              char *priority_command_list;
-              strcpy(priority_command_list, PRIORITY_COMMANDS);
-              bool token_found = false;
-              while ((token = strsep(&priority_command_list, " "))) {
-                if (!!strstr(command, token)) {
-                  #ifdef DEBUG_PRIORITY_COMMANDS
-                    SERIAL_ECHOLNPGM("Prioritizing ", token);
-                  #endif
-                  gcode.process_subcommands_now(command, false);
-                  token_found = true;
-                  break;
-                }
+            #define DEBUG_PRIORITY_COMMANDS
+            #if ENABLED(PRIORITY_FEEDRATE_CHANGES)
+              // Feed rate adjustment
+              if (!!strstr_P(command, PSTR("M220")) TERN_(GCODE_CASE_INSENSITIVE, || !!strstr_P(command, PSTR("m220")))) {
+                #if ENABLED(DEBUG_PRIORITY_COMMANDS)
+                  SERIAL_ECHOLNPGM("Priority command found: ", PSTR("M220"), ", executing ", command);
+                #endif
+                gcode.process_subcommands_now(command, false);
+                break;
               }
-              if (token_found) break;
-            }
-          }
-        #endif
+            #endif
+
+            #if ENABLED(PRIORITY_BABYSTEPPING)
+              // Babystepping adjustments
+              if (!!strstr_P(command, PSTR("M290")) TERN_(GCODE_CASE_INSENSITIVE, || !!strstr_P(command, PSTR("m290")))) {
+                #if ENABLED(DEBUG_PRIORITY_COMMANDS)
+                  SERIAL_ECHOLNPGM("Priority command found: ", PSTR("M290"), ", executing ", command);
+                #endif
+                gcode.process_subcommands_now(command, false);
+                break;
+              }
+            #endif
+
+            #ifdef PRIORITY_COMMANDS
+              // Process matching commands immediately, unless preceded by an M400 (finish moves) command
+              if (strlen(PRIORITY_COMMANDS) > 0) {
+                if (!strstr_P(ring_buffer.last_queued_command(), PSTR("M400"))) {
+                  char *pc_token;
+                  char pc_list[strlen(PRIORITY_COMMANDS) + 1] = PRIORITY_COMMANDS;
+                  bool pc_token_found = false,
+                      pc_is_first_token = true;
+                  while ((pc_token = strtok((pc_is_first_token) ? pc_list : NULL, " "))) {
+                    pc_is_first_token = false;
+                    if (!!strstr(command, pc_token)) {
+                      #if ENABLED(DEBUG_PRIORITY_COMMANDS)
+                        SERIAL_ECHOLNPGM("Priority command found: ", pc_token, ", executing ", command);
+                      #endif
+                      gcode.process_subcommands_now(command, false);
+                      pc_token_found = true;
+                      break;
+                    }
+                  }
+                  if (pc_token_found) break;
+                }
+              }     // strlen(PRIORITY_COMMANDS) > 0
+            #endif  // PRIORITY_COMMANDS
+          }         // Is Last Command M400?
+        #endif      // ANY(PRIORITY_FEEDRATE_CHANGES, PRIORITY_BABYSTEPPING, PRIORITY_COMMANDS)
 
         #if NO_TIMEOUTS > 0
           last_command_time = ms;
@@ -574,10 +586,9 @@ void GCodeQueue::get_serial_commands() {
 
         // Add the command to the queue
         ring_buffer.enqueue(serial.line_buffer, false OPTARG(HAS_MULTI_SERIAL, p));
-      }
-      else
+      } else {
         process_stream_char(serial_char, serial.input_state, serial.line_buffer, serial.count);
-
+      } // ISEOL(serial_char)
     } // NUM_SERIAL loop
   } // queue has space, serial has data
 }

--- a/Marlin/src/gcode/queue.h
+++ b/Marlin/src/gcode/queue.h
@@ -79,6 +79,12 @@ public:
 
     void advance_pos(uint8_t &p, const int inc) { if (++p >= BUFSIZE) p = 0; length += inc; }
 
+    uint8_t previous_ring_pos(uint8_t &p, const int dec = 1) { return (p <= 0) ? (BUFSIZE - 1) : (p - dec); }
+
+    const char* last_queued_command() {
+      return commands[previous_ring_pos(index_w)].buffer;
+    }
+
     void commit_command(bool skip_ok
       OPTARG(HAS_MULTI_SERIAL, serial_index_t serial_ind = serial_index_t())
     );


### PR DESCRIPTION
### Description
## Add priority commands support
- Enables users to specify commands which bypass the g-code queue
- Native support for M220 (feed rate) and M290 (baby-stepping)
- Preceding with M400 will force standard behavior
- Designed to match behavior of direct LCD input (which does not queue changes such as feed rate)

### Requirements
None

### Benefits
- Allows faster execution of time sensitive g-code commands, such as baby stepping and feed rate changes, which a user would expect to take effect immediately instead of being queued behind multiple lengthy moves.
- Matches the responsiveness of attached LCDs which bypass the gcode queue for certain actions, like Feed Rate changes.
- Can be overridden on a per-use basis by using M400 (finish move) as the preceding command.
- Allows ANY command to become a priority command, user configurable.

### Configurations
```cpp
/**
 * Priority command execution
 *
 * When interacting using an attached Marlin LCD display, changes such as babystepping and feed rates
 * will take effect nearly instantly. However, those same changes via serial host will be queued and may
 * be delayed significantly, even after the job has completely finished, because of queuing and buffering.
 *
 * The following allows you to bypass the queue for certain time-sensitive commands, executing them immediately.
 *
 * These settings respect the M400 (finish move) command, so if they proceed immediately after an M400, they'll
 * be added to the end of the queue as usual.
 */
#define PRIORITY_FEEDRATE_CHANGES  // M220 feed rate adjustments are processed immediately instead of queued.
#define PRIORITY_BABYSTEPPING      // M290 babystepping is processed immediately instead of queued.

// Space-separated list of g-code commands which will bypass the queue and execute immediately
// Example: "M500 M25 M125"
// #define PRIORITY_COMMANDS "" // Case sensitive, even if GCODE_CASE_INSENSITIVE is set

```

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/20161 - Support out-of-order command execution
