### PR TITLE
Fix linker error mks_robin_e3: undefined reference to `HAL_SD_IRQHandler

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -97,6 +97,7 @@ board_build.encrypt         = Robin_e3.bin
 board_build.offset          = 0x5000
 board_upload.offset_address = 0x08005000
 build_flags                 = ${common_STM32F103RC_variant.build_flags}
+                              -DHAL_SD_MODULE_ENABLED
                               -DTIMER_SERVO=TIM5 -DDEFAULT_SPI=3
 build_unflags               = ${common_STM32F103RC_variant.build_unflags}
                               -DUSBCON -DUSBD_USE_CDC


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
When building Marlin for MKS Robin E3, a linker error happens when SD Card support is enabled. This fix adds the build flag to use `HAL_SD_MODULE_ENABLED` and fix the linker bug.


<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
Requires MKS Robin E3 board and enabling SD card support
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Build/linker error
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
