### PR TITLE
G28: Safe homing. Fix mistaken assignment of Z to Y

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -137,7 +137,7 @@
       constexpr xy_float_t okay_homing_xy = safe_homing_xy;
     #endif
 
-    destination.set(okay_homing_xy, current_position.z);
+    destination.set(okay_homing_xy.x, okay_homing_xy.y, current_position.z);
 
     TERN_(HOMING_Z_WITH_PROBE, destination -= probe.offset_xy);
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
During safe homing, I noticed the value of `Z_HOMING_HEIGHT` was mistakenly assigned to the Y coordinate. I traced it down to line 140, where an incorrect assignment of the destination is made.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

This was found on a RAMPS 1.4 board for an MPCNC. But any setup with `Z_SAFE_HOMING` enabled should do.
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
It fixes the assignment of the Y and Z coordinate to not crash the probe anymore.
<!-- What does this PR fix or improve? -->

### Configurations

My configurations are very specific to my use-case. But enabling `Z_SAFE_HOMING ` and setting `Z_HOMING_HEIGHT` to something unique, like `11`, will reproduce the bug.
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
