### PR TITLE
G28: Safe homing. Fix mistaken assignment of Z to Y

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -536,20 +536,9 @@ struct XYZEval {
   // Reset all to 0
   FI void reset()                     { LOGICAL_AXIS_GANG(e =, x =, y =, z =, i =, j =, k =) 0; }
 
-  // Setters taking struct types and arrays
-  FI void set(const T px)             { x = px;               }
-  FI void set(const T px, const T py) { x = px;    y = py;    }
-  FI void set(const XYval<T> pxy)     { x = pxy.x; y = pxy.y; }
-  FI void set(const XYZval<T> pxyz)   { set(LINEAR_AXIS_ELEM(pxyz)); }
-  #if HAS_Z_AXIS
-    FI void set(LINEAR_AXIS_ARGS(const T))         { LINEAR_AXIS_CODE(a = x, b = y, c = z, u = i, v = j, w = k); }
-    FI void set(const XYval<T> pxy, const T pz)    { set(pxy); z = pz; }
-  #endif
-  #if LOGICAL_AXES > LINEAR_AXES
-    FI void set(const XYval<T> pxy, const T pz, const T pe) { set(pxy, pz); e = pe; }
-    FI void set(const XYZval<T> pxyz, const T pe)  { set(pxyz); e = pe; }
-    FI void set(LOGICAL_AXIS_ARGS(const T))        { LOGICAL_AXIS_CODE(_e = e, a = x, b = y, c = z, u = i, v = j, w = k); }
-  #endif
+  // Setters for some number of linear axes, not all
+  FI void set(const T px)                                                   { x = px; }
+  FI void set(const T px, const T py)                                       { x = px; y = py; }
   #if HAS_I_AXIS
     FI void set(const T px, const T py, const T pz)                         { x = px; y = py; z = pz; }
   #endif
@@ -558,6 +547,18 @@ struct XYZEval {
   #endif
   #if HAS_K_AXIS
     FI void set(const T px, const T py, const T pz, const T pi, const T pj) { x = px; y = py; z = pz; i = pi; j = pj; }
+  #endif
+  // Setters taking struct types and arrays
+  FI void set(const XYval<T> pxy)                  { x = pxy.x; y = pxy.y; }
+  FI void set(const XYZval<T> pxyz)                { set(LINEAR_AXIS_ELEM(pxyz)); }
+  #if HAS_Z_AXIS
+    FI void set(LINEAR_AXIS_ARGS(const T))         { LINEAR_AXIS_CODE(a = x, b = y, c = z, u = i, v = j, w = k); }
+  #endif
+  FI void set(const XYval<T> pxy, const T pz)      { set(pxy); TERN_(HAS_Z_AXIS, z = pz); }
+  #if LOGICAL_AXES > LINEAR_AXES
+    FI void set(const XYval<T> pxy, const T pz, const T pe) { set(pxy, pz); e = pe; }
+    FI void set(const XYZval<T> pxyz, const T pe)  { set(pxyz); e = pe; }
+    FI void set(LOGICAL_AXIS_ARGS(const T))        { LOGICAL_AXIS_CODE(_e = e, a = x, b = y, c = z, u = i, v = j, w = k); }
   #endif
 
   // Length reduced to one dimension

--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -543,9 +543,10 @@ struct XYZEval {
   FI void set(const XYZval<T> pxyz)   { set(LINEAR_AXIS_ELEM(pxyz)); }
   #if HAS_Z_AXIS
     FI void set(LINEAR_AXIS_ARGS(const T))         { LINEAR_AXIS_CODE(a = x, b = y, c = z, u = i, v = j, w = k); }
+    FI void set(const XYval<T> pxy, const T pz)    { set(pxy); z = pz; }
   #endif
   #if LOGICAL_AXES > LINEAR_AXES
-    FI void set(const XYval<T> pxy, const T pe)    { set(pxy); e = pe; }
+    FI void set(const XYval<T> pxy, const T pz, const T pe) { set(pxy, pz); e = pe; }
     FI void set(const XYZval<T> pxyz, const T pe)  { set(pxyz); e = pe; }
     FI void set(LOGICAL_AXIS_ARGS(const T))        { LOGICAL_AXIS_CODE(_e = e, a = x, b = y, c = z, u = i, v = j, w = k); }
   #endif

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -137,7 +137,7 @@
       constexpr xy_float_t okay_homing_xy = safe_homing_xy;
     #endif
 
-    destination.set(okay_homing_xy, current_position.z);
+    destination.set(okay_homing_xy.x, okay_homing_xy.y, current_position.z);
 
     TERN_(HOMING_Z_WITH_PROBE, destination -= probe.offset_xy);
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -137,7 +137,7 @@
       constexpr xy_float_t okay_homing_xy = safe_homing_xy;
     #endif
 
-    destination.set(okay_homing_xy.x, okay_homing_xy.y, current_position.z);
+    destination.set(okay_homing_xy, current_position.z);
 
     TERN_(HOMING_Z_WITH_PROBE, destination -= probe.offset_xy);
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
During safe homing, I noticed the value of `Z_HOMING_HEIGHT` was mistakenly assigned to the Y coordinate. I traced it down to line 140, where an incorrect assignment of the destination is made.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

This was found on a RAMPS 1.4 board for an MPCNC. But any setup with `Z_SAFE_HOMING` enabled should do.
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
It fixes the assignment of the Y and Z coordinate to not crash the probe anymore.
<!-- What does this PR fix or improve? -->

### Configurations

My configurations are very specific to my use-case. But enabling `Z_SAFE_HOMING ` and setting `Z_HOMING_HEIGHT` to something unique, like `11`, will reproduce the bug.
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
