### PR TITLE
MKS Robin E3 V1.1: fix EEPROM saving freezing and resetting board

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_V1_1_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_V1_1_common.h
@@ -27,7 +27,10 @@
 // Onboard I2C EEPROM
 #if NO_EEPROM_SELECTED
   #define I2C_EEPROM
+  #define SOFT_I2C_EEPROM
   #define MARLIN_EEPROM_SIZE                0x1000// 4KB
+  #define I2C_SCL_PIN                       PB6
+  #define I2C_SDA_PIN                       PB7
   #undef NO_EEPROM_SELECTED
 #endif
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
MKS Robin E3 V1.1 saving freezes when using EEPROM. Update to use `SOFT_I2C_EEPROM` as other MKS Robin Nano board and other boards with similar issue

PIN numbers based on pins listed at https://github.com/makerbase-mks/MKS-Robin-E3-E3D/blob/master/hardware/MKS%20Robin%20E3%20V1.1_003/MKS%20Robin%20E3%20V1.1_003%20SCH.pdf

Fix based on
https://github.com/MarlinFirmware/Marlin/issues/22524#issuecomment-939383700
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
MKS Robin E3 V1.1 board
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
It fixes freezing and board reset when saving to EEPROM
<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
