### PR TITLE
Keep homing feedrate in quick home

### DIFF
--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -76,12 +76,9 @@
 
     const int x_axis_home_dir = TOOL_X_HOME_DIR(active_extruder);
 
-    const float hfx = homing_feedrate(X_AXIS), hfy = homing_feedrate(Y_AXIS),
-                r_xy = hfx / hfy, r_yx = hfy / hfx,
-                r_length = max_length(X_AXIS) / max_length(Y_AXIS),
-                mlx = r_length < r_xy ? max_length(Y_AXIS) * r_xy : max_length(X_AXIS),
-                mly = r_length > r_xy ? max_length(X_AXIS) * r_yx : max_length(Y_AXIS),
-                fr_mm_s = HYPOT(hfx, hfy);
+    // Use a higher diagonal feedrate so axes move at homing speed
+    const float minfr = _MIN(homing_feedrate(X_AXIS), homing_feedrate(Y_AXIS)),
+                fr_mm_s = HYPOT(minfr, minfr);
 
     #if ENABLED(SENSORLESS_HOMING)
       sensorless_t stealth_states {
@@ -97,7 +94,7 @@
       };
     #endif
 
-    do_blocking_move_to_xy(1.5 * mlx * x_axis_home_dir, 1.5 * mly * Y_HOME_DIR, fr_mm_s);
+    do_blocking_move_to_xy(1.5 * max_length(X_AXIS) * x_axis_home_dir, 1.5 * max_length(Y_AXIS) * Y_HOME_DIR, fr_mm_s);
 
     endstops.validate_homing_move();
 

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -76,10 +76,14 @@
 
     const int x_axis_home_dir = TOOL_X_HOME_DIR(active_extruder);
 
-    const float mlx = max_length(X_AXIS),
-                mly = max_length(Y_AXIS),
-                mlratio = mlx > mly ? mly / mlx : mlx / mly,
-                fr_mm_s = _MIN(homing_feedrate(X_AXIS), homing_feedrate(Y_AXIS)) * SQRT(sq(mlratio) + 1.0);
+    const float speed_ratio = homing_feedrate(X_AXIS) / homing_feedrate(Y_AXIS);
+    const float speed_ratio_inv = homing_feedrate(Y_AXIS) / homing_feedrate(X_AXIS);
+    const float length_ratio = max_length(X_AXIS) / max_length(Y_AXIS);
+    const bool length_r_less_than_speed_r = length_ratio < speed_ratio;
+
+    const float mlx = length_r_less_than_speed_r ? (max_length(Y_AXIS) * speed_ratio) : (max_length(X_AXIS));
+    const float mly = length_r_less_than_speed_r ? (max_length(Y_AXIS)) : (max_length(X_AXIS) * speed_ratio_inv);
+    const float fr_mm_s = SQRT(sq(homing_feedrate(X_AXIS)) + sq(homing_feedrate(Y_AXIS)));
 
     #if ENABLED(SENSORLESS_HOMING)
       sensorless_t stealth_states {

--- a/Marlin/src/gcode/calibrate/G28.cpp
+++ b/Marlin/src/gcode/calibrate/G28.cpp
@@ -76,14 +76,12 @@
 
     const int x_axis_home_dir = TOOL_X_HOME_DIR(active_extruder);
 
-    const float speed_ratio = homing_feedrate(X_AXIS) / homing_feedrate(Y_AXIS);
-    const float speed_ratio_inv = homing_feedrate(Y_AXIS) / homing_feedrate(X_AXIS);
-    const float length_ratio = max_length(X_AXIS) / max_length(Y_AXIS);
-    const bool length_r_less_than_speed_r = length_ratio < speed_ratio;
-
-    const float mlx = length_r_less_than_speed_r ? (max_length(Y_AXIS) * speed_ratio) : (max_length(X_AXIS));
-    const float mly = length_r_less_than_speed_r ? (max_length(Y_AXIS)) : (max_length(X_AXIS) * speed_ratio_inv);
-    const float fr_mm_s = SQRT(sq(homing_feedrate(X_AXIS)) + sq(homing_feedrate(Y_AXIS)));
+    const float hfx = homing_feedrate(X_AXIS), hfy = homing_feedrate(Y_AXIS),
+                r_xy = hfx / hfy, r_yx = hfy / hfx,
+                r_length = max_length(X_AXIS) / max_length(Y_AXIS),
+                mlx = r_length < r_xy ? max_length(Y_AXIS) * r_xy : max_length(X_AXIS),
+                mly = r_length > r_xy ? max_length(X_AXIS) * r_yx : max_length(Y_AXIS),
+                fr_mm_s = HYPOT(hfx, hfy);
 
     #if ENABLED(SENSORLESS_HOMING)
       sensorless_t stealth_states {


### PR DESCRIPTION


<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description
Feedrates and lengths of X and Y can differ. This could led to wrong feedrate of an axis in quick home.
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements
--
<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits
Homing quality is kept if quick home is turned on.
<!-- What does this PR fix or improve? -->

### Configurations
--
<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues
--
<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
