### PR TITLE
M401 enhance - query/feedback

### DIFF
--- a/Marlin/src/gcode/probe/M401_M402.cpp
+++ b/Marlin/src/gcode/probe/M401_M402.cpp
@@ -36,14 +36,15 @@
  * M401: Deploy and activate the Z probe
  *
  * With BLTOUCH_HS_MODE:
+ *  H       Report the current BLTouch HS mode state and exit
  *  S<bool> Set High Speed (HS) Mode and exit without deploy
  */
 void GcodeSuite::M401() {
-  if (parser.seen('S')) {
+  const bool seenH = parser.seen_test('H'),
+             seenS = parser.seen('S');
+  if (seenH || seenS) {
     #ifdef BLTOUCH_HS_MODE
-      if (parser.has_value()) {  // if no value after "S" than just query
-        bltouch.high_speed_mode = parser.value_bool();
-      }
+      if (seenS) bltouch.high_speed_mode = parser.value_bool();
       SERIAL_ECHO_START();
       SERIAL_ECHOPGM("BLTouch HS mode ");
       serialprintln_onoff(bltouch.high_speed_mode);

--- a/Marlin/src/gcode/probe/M401_M402.cpp
+++ b/Marlin/src/gcode/probe/M401_M402.cpp
@@ -41,7 +41,12 @@
 void GcodeSuite::M401() {
   if (parser.seen('S')) {
     #ifdef BLTOUCH_HS_MODE
-      bltouch.high_speed_mode = parser.value_bool();
+      if (parser.has_value()) {  // if no value after "S" than just query
+        bltouch.high_speed_mode = parser.value_bool();
+      }
+      SERIAL_ECHO_START();
+      SERIAL_ECHOPGM("BLTouch HS mode ");
+      serialprintln_onoff(bltouch.high_speed_mode);
     #endif
   }
   else {


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

This PR adds the ability to query by gcode the state of BLTouch high speed mode and give feedback when HS mode is enabled or disabled.
The query is done by "M401 S" gcode without any value after "S".

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

HIGH SPEED mode enabled for BLTouch

### Benefits

<!-- What does this PR fix or improve? -->

 - hosts that want to set the HS mode and query it (ex.: printers with screens that communicate with Marlin only by gcodes over UART)

### Notes

First I made the query with "Q" parameter ("M401 Q") but that just adds unnecessary code.