### PR TITLE
Add MK3_FAN_PINS Warning

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -597,3 +597,10 @@
 #ifdef __STM32F1__
   #warning "Maple build environments are deprecated. Please use a non-Maple build environment. Report issues to the Marlin Firmware project."
 #endif
+
+/**
+ * Průša MK3/S/+ fan pin reassignment
+ */
+#if MB(BTT_BTT002_V1_0, EINSY_RAMBO) && DISABLED(NO_MK3_FAN_PINS_WARNING)
+  #warning "Define MK3_FAN_PINS to swap hotend and part cooling fan pins. (Define NO_MK3_FAN_PINS_WARNING to suppress this warning.)"
+#endif


### PR DESCRIPTION
### Description

Alert MK3/S/+ owners to use the `MK3_FAN_PINS` flag to swap hotend & part cooling fan pins.

### Requirements

Prusa MK3/S/+ with an Einsy Rambo or BigTreeTech BTT002 motherboard.

### Benefits

Warns affected users that fan pins can be swapped (and were by default in #23093) with the relatively hidden/unknown `MK3_FAN_PINS` flag.

### Configurations

Either of the two MK3/S/+ will work: https://github.com/MarlinFirmware/Configurations/tree/import-2.0.x/config/examples/Prusa

### Related Issues

- #23093
- #21617