### PR TITLE
Fix X_AXIS_TWIST_COMPENSATION division by zero bug

### DIFF
--- a/Marlin/src/feature/bedlevel/abl/x_twist.cpp
+++ b/Marlin/src/feature/bedlevel/abl/x_twist.cpp
@@ -49,6 +49,7 @@ void XATC::print_points() {
 float lerp(const_float_t t, const_float_t a, const_float_t b) { return a + t * (b - a); }
 
 float XATC::compensation(const xy_pos_t &raw) {
+  if (NEAR_ZERO(spacing)) return 0;
   float t = (raw.x - start) / spacing;
   int i = FLOOR(t);
   LIMIT(i, 0, XATC_MAX_POINTS - 2);


### PR DESCRIPTION
### Description

This PR fixes a bug in the X_AXIS_TWIST_COMPENSATION feature. The [bug](https://github.com/MarlinFirmware/Marlin/pull/23238#issuecomment-1033117535) was reported by @gordo3di in #23238. It was caused by a division by zero when `XATC::spacing` was uninitialized. This would cause every point in the ABL mesh to be NAN.

### Requirements

To test this PR, X_AXIS_TWIST_COMPENSATION and AUTO_BED_LEVELING_BILINEAR should be enabled.

### Benefits

Fixes this [bug](https://github.com/MarlinFirmware/Marlin/pull/23238#issuecomment-1033117535).

### Related Issues

Fixes this [bug](https://github.com/MarlinFirmware/Marlin/pull/23238#issuecomment-1033117535).
