### PR TITLE
replaced use of DISABLED macro (negative value won't compile) with TEMP_SENSOR_BOARD (which can be negative)

### DIFF
--- a/Marlin/src/inc/Warnings.cpp
+++ b/Marlin/src/inc/Warnings.cpp
@@ -59,9 +59,9 @@
   #warning "Your Configuration provides no method to acquire user feedback!"
 #endif
 
-#if MB(DUE3DOM_MINI) && PIN_EXISTS(TEMP_2) && DISABLED(TEMP_SENSOR_BOARD)
+#if MB(DUE3DOM_MINI) && PIN_EXISTS(TEMP_2) && TEMP_SENSOR_BOARD!=0
   #warning "Onboard temperature sensor for BOARD_DUE3DOM_MINI has moved from TEMP_SENSOR_2 (TEMP_2_PIN) to TEMP_SENSOR_BOARD (TEMP_BOARD_PIN)."
-#elif MB(BTT_SKR_E3_TURBO) && PIN_EXISTS(TEMP_2) && DISABLED(TEMP_SENSOR_BOARD)
+#elif MB(BTT_SKR_E3_TURBO) && PIN_EXISTS(TEMP_2) && TEMP_SENSOR_BOARD!=0
   #warning "Onboard temperature sensor for BOARD_BTT_SKR_E3_TURBO has moved from TEMP_SENSOR_2 (TEMP_2_PIN) to TEMP_SENSOR_BOARD (TEMP_BOARD_PIN)."
 #endif
 


### PR DESCRIPTION
### Description

Replaced the use of DISABLED macro applied to a thermal sensor index, which can be negative.

A negative value applied to DISABLED will cause a no compile issue. Therfore the DISABLED macro has been replaced by a value check.

DISABLED could be reviewed to be more robust and accept negative value,  although it should be rather used on ON/OFF flags instead of values such as this case.

### Requirements

None

### Benefits

TEMP_SENSOR_BOARD can now be any thermal sensor, including the ones identified by a negative value

### Configurations

N/A

### Related Issues

N/A
