### PR TITLE
M21 -  media select and mount, multi volume cap report

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1628,7 +1628,7 @@
 
   /**
    * Multiple volume support - EXPERIMENTAL.
-   * Adds 'M21 S' / 'M21 U' to mount SD Card / USB Drive.
+   * Adds 'M21 Pm' / 'M21 S' / 'M21 U' to mount SD Card / USB Drive.
    */
   //#define MULTI_VOLUME
   #if ENABLED(MULTI_VOLUME)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1626,7 +1626,10 @@
   // Enable if SD detect is rendered useless (e.g., by using an SD extender)
   //#define NO_SD_DETECT
 
-  // Multiple volume support - EXPERIMENTAL.
+  /**
+   * Multiple volume support - EXPERIMENTAL.
+   * Adds 'M21 S' / 'M21 U' to mount SD Card / USB Drive.
+   */
   //#define MULTI_VOLUME
   #if ENABLED(MULTI_VOLUME)
     #define VOLUME_SD_ONBOARD

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -91,7 +91,7 @@
  *
  *** Print from Media (SDSUPPORT) ***
  * M20  - List SD card. (Requires SDSUPPORT)
- * M21  - Init SD card. (Requires SDSUPPORT)
+ * M21  - Init SD card. (Requires SDSUPPORT) With MULTI_VOLUME choose a drive with 'M21 S' / 'M21 U'.
  * M22  - Release SD card. (Requires SDSUPPORT)
  * M23  - Select SD file: "M23 /path/file.gco". (Requires SDSUPPORT)
  * M24  - Start/resume SD print. (Requires SDSUPPORT)

--- a/Marlin/src/gcode/gcode.h
+++ b/Marlin/src/gcode/gcode.h
@@ -91,7 +91,7 @@
  *
  *** Print from Media (SDSUPPORT) ***
  * M20  - List SD card. (Requires SDSUPPORT)
- * M21  - Init SD card. (Requires SDSUPPORT) With MULTI_VOLUME choose a drive with 'M21 S' / 'M21 U'.
+ * M21  - Init SD card. (Requires SDSUPPORT) With MULTI_VOLUME select a drive with `M21 Pn` / 'M21 S' / 'M21 U'.
  * M22  - Release SD card. (Requires SDSUPPORT)
  * M23  - Select SD file: "M23 /path/file.gco". (Requires SDSUPPORT)
  * M24  - Start/resume SD print. (Requires SDSUPPORT)

--- a/Marlin/src/gcode/host/M115.cpp
+++ b/Marlin/src/gcode/host/M115.cpp
@@ -142,6 +142,11 @@ void GcodeSuite::M115() {
     // SDCARD (M20, M23, M24, etc.)
     cap_line(F("SDCARD"), ENABLED(SDSUPPORT));
 
+    // MULTI_VOLUME (M21 S/M21 U)
+    #if ENABLED(SDSUPPORT)
+      cap_line(F("MULTI_VOLUME"), ENABLED(MULTI_VOLUME));
+    #endif
+
     // REPEAT (M808)
     cap_line(F("REPEAT"), ENABLED(GCODE_REPEAT_MARKERS));
 

--- a/Marlin/src/gcode/sd/M21_M22.cpp
+++ b/Marlin/src/gcode/sd/M21_M22.cpp
@@ -30,7 +30,18 @@
 /**
  * M21: Init SD Card
  */
-void GcodeSuite::M21() { card.mount(); }
+void GcodeSuite::M21()
+{
+  #if ENABLED(MULTI_VOLUME)
+    if (parser.seen('S')) {  // "S" for SD Card
+      card.changeMedia(&card.media_driver_sdcard);
+    }
+    else if (parser.seen('U')) {  // "U" for USB
+      card.changeMedia(&card.media_driver_usbFlash);
+    }
+  #endif
+  card.mount();
+}
 
 /**
  * M22: Release SD Card

--- a/Marlin/src/gcode/sd/M21_M22.cpp
+++ b/Marlin/src/gcode/sd/M21_M22.cpp
@@ -31,14 +31,15 @@
  * M21: Init SD Card
  *
  * With MULTI_VOLUME:
- *  S - Change to the SD Card and mount it
- *  U - Change to the USB Drive and mount it
+ *  P0 or S - Change to the SD Card and mount it
+ *  P1 or U - Change to the USB Drive and mount it
  */
 void GcodeSuite::M21() {
   #if ENABLED(MULTI_VOLUME)
-    if (parser.seen_test('S'))       // "S" for SD Card
+    const int8_t vol = parser.intval('P', -1);
+    if (vol == 0 || parser.seen_test('S'))       // "S" for SD Card
       card.changeMedia(&card.media_driver_sdcard);
-    else if (parser.seen_test('U'))  // "U" for USB
+    else if (vol == 1 || parser.seen_test('U'))  // "U" for USB
       card.changeMedia(&card.media_driver_usbFlash);
   #endif
   card.mount();

--- a/Marlin/src/gcode/sd/M21_M22.cpp
+++ b/Marlin/src/gcode/sd/M21_M22.cpp
@@ -29,16 +29,17 @@
 
 /**
  * M21: Init SD Card
+ *
+ * With MULTI_VOLUME:
+ *  S - Change to the SD Card and mount it
+ *  U - Change to the USB Drive and mount it
  */
-void GcodeSuite::M21()
-{
+void GcodeSuite::M21() {
   #if ENABLED(MULTI_VOLUME)
-    if (parser.seen('S')) {  // "S" for SD Card
+    if (parser.seen_test('S'))       // "S" for SD Card
       card.changeMedia(&card.media_driver_sdcard);
-    }
-    else if (parser.seen('U')) {  // "U" for USB
+    else if (parser.seen_test('U'))  // "U" for USB
       card.changeMedia(&card.media_driver_usbFlash);
-    }
   #endif
   card.mount();
 }


### PR DESCRIPTION
### Description

Adds "S'" and "U" parameter to "M21" gcode. "M21 S" selects and mounts SD card and "M21 U" selects and mounts USB storage device.
Reports "MULTI_VOLUME" capability (Cap: MULTI_VOLUME) if it's enabled.

### Requirements

Requires boards that have also USB for storage media.

### Benefits

Hosts would be able to switch between USB and SD Card via gcode.

### Related Issues

Fixes #23551
