### PR TITLE
add _delay_ms to esp32 HAL,  fix u8g_esp32_spi.cpp

### DIFF
--- a/Marlin/src/HAL/ESP32/HAL.cpp
+++ b/Marlin/src/HAL/ESP32/HAL.cpp
@@ -167,6 +167,8 @@ uint8_t MarlinHAL::get_reset_source() { return rtc_get_reset_reason(1); }
 
 void MarlinHAL::reboot() { ESP.restart(); }
 
+void _delay_ms(int delay_ms) { delay(delay_ms); }
+
 // return free memory between end of heap (or end bss) and whatever is current
 int MarlinHAL::freeMemory() { return ESP.getFreeHeap(); }
 

--- a/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
+++ b/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
@@ -30,6 +30,7 @@
 #include <U8glib-HAL.h>
 #include "Arduino.h"
 #include "../shared/HAL_SPI.h"
+#include "HAL.h"
 #include "SPI.h"
 
 static SPISettings spiConfig;


### PR DESCRIPTION
### Description

A basic test of BOARD_MKS_TINYBEE with  MKS_MINI_12864_V3 fails to compile
There are two issues
1) U8glib-HAL uses _delay_ms, this does not exists in esp32 HAL.  I added it.
2) u8g_esp32_spi.cpp was modified to use OUT_WRITE and WRITE, But these macros are not loaded. Added #include "HAL.h"

### Requirements

#define MOTHERBOARD BOARD_MKS_TINYBEE
#define MKS_MINI_12864_V3

### Benefits

This now compiles

### Related Issues
https://github.com/MarlinFirmware/Marlin/pull/23562