### PR TITLE
Enable emergency parser on STM32 when mass storage is enabled

### DIFF
--- a/Marlin/src/HAL/STM32/HAL.cpp
+++ b/Marlin/src/HAL/STM32/HAL.cpp
@@ -89,7 +89,7 @@ void MarlinHAL::init() {
 
   SetTimerInterruptPriorities();
 
-  #if ENABLED(EMERGENCY_PARSER) && USBD_USE_CDC
+  #if ENABLED(EMERGENCY_PARSER) && (USBD_USE_CDC || USBD_USE_CDC_MSC)
     USB_Hook_init();
   #endif
 

--- a/Marlin/src/HAL/STM32/usb_serial.cpp
+++ b/Marlin/src/HAL/STM32/usb_serial.cpp
@@ -26,7 +26,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(EMERGENCY_PARSER) && USBD_USE_CDC
+#if ENABLED(EMERGENCY_PARSER) && (USBD_USE_CDC || USBD_USE_CDC_MSC)
 
 #include "usb_serial.h"
 #include "../../feature/e_parser.h"


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Enable emergency parser on STM32 when mass storage is enabled.

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

A board using the STM32 HAL with mass storage enabled. For example the `BIGTREE_OCTOPUS_V1_USB` environment.

### Benefits

Fixes #23818.

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/8153265/Configuration.zip)

The only change made is to enable `EMERGENCY_PARSER` in `Configuration_adv.h`:
```diff
diff --git a/Marlin/Configuration_adv.h b/Marlin/Configuration_adv.h
index e5379ed84f..4c335e2105 100644
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2307,7 +2307,7 @@
  * Currently handles M108, M112, M410, M876
  * NOTE: Not yet implemented for all platforms.
  */
-//#define EMERGENCY_PARSER
+#define EMERGENCY_PARSER
 
 /**
  * Realtime Reporting (requires EMERGENCY_PARSER)
```

### Related Issues

#23818