### PR TITLE
fix renamed environment checking on windows

### DIFF
--- a/ini/renamed.ini
+++ b/ini/renamed.ini
@@ -14,7 +14,8 @@
 #
 
 [renamed]
-platform = native
+platform  = ststm32
+board     = genericSTM32F103RE
 
 #
 # List of environment names that are no longer used


### PR DESCRIPTION
### Description

When attempting to use a renamed environment on window platform instead of a nice short error users are getting a long error starting with
"CC"' is not recognized as an internal or external command, 

Updated renamed.ini 
```
[renamed]
platform = native

```
to
```
[renamed]
platform  = ststm32
board     = genericSTM32F103RE

```
now windows and linux is happy as they find a compiler.

### Requirements

Default_env set to any of these retired environments
STM32F103RET6_creality_maple
STM32F103RET6_creality
STM32F103RET6_creality_xfer
STM32F103RC_btt_512K
STM32F103RC_btt_512K_USB
STM32F103RC_btt_512K_maple
STM32F103RC_btt_512K_USB_maple

### Benefits

Works as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/23829