### PR TITLE
Set XATC default start and spacing values in reset()

### DIFF
--- a/Marlin/src/feature/x_twist.cpp
+++ b/Marlin/src/feature/x_twist.cpp
@@ -24,18 +24,21 @@
 #if ENABLED(X_AXIS_TWIST_COMPENSATION)
 
 #include "x_twist.h"
+#include "../module/probe.h"
 
 XATC xatc;
 
-bool XATC::enabled = true;
+bool XATC::enabled;
 float XATC::spacing, XATC::start;
 xatc_array_t XATC::z_offset; // Initialized by settings.load()
 
 void XATC::reset() {
   constexpr float xzo[] = XATC_Z_OFFSETS;
   static_assert(COUNT(xzo) == XATC_MAX_POINTS, "XATC_Z_OFFSETS is the wrong size.");
-  enabled = false;
   COPY(z_offset, xzo);
+  xatc.spacing = (probe.max_x() - probe.min_x()) / (XATC_MAX_POINTS - 1);
+  xatc.start = probe.min_x();
+  enabled = true;
 }
 
 void XATC::print_points() {

--- a/Marlin/src/lcd/menu/menu_x_twist.cpp
+++ b/Marlin/src/lcd/menu/menu_x_twist.cpp
@@ -189,8 +189,7 @@ void xatc_wizard_homing_done() {
   }
 
   if (ui.use_click()) {
-    xatc.spacing = (probe.max_x() - probe.min_x()) / (XATC_MAX_POINTS - 1);
-    xatc.start = probe.min_x();
+    xatc.reset();
 
     SET_SOFT_ENDSTOP_LOOSE(true); // Disable soft endstops for free Z movement
 


### PR DESCRIPTION
### Description

This should have been part of setting the default XATC values in #23828. Without these values, XATC does not work and either the wizard must be run or config must be loaded from EEPROM. i.e. this PR allows XATC to work with default values without EEPROM.

Also set XATC to enabled in reset() because defaults values will either have no effect (for a virgin `Configuration_adv.h`) or will have the effect explicitly configured by `Configuration_adv.h`.

### Requirements

Some kind of auto bed leveling and an X axis which is subject to twist.

### Configurations

`#define X_AXIS_TWIST_COMPENSATION`

### Related Issues

#23828
