### PR TITLE
Add SPI Stepper Support To Index Rev03

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2181,9 +2181,9 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
  * Test Sensor & Heater pin combos.
  * Pins and Sensor IDs must be set for each heater
  */
-#if !ANY_PIN(TEMP_0, TEMP_0_CS)
+#if HAS_EXTRUDERS && !ANY_PIN(TEMP_0, TEMP_0_CS)
   #error "TEMP_0_PIN or TEMP_0_CS_PIN not defined for this board."
-#elif !HAS_HEATER_0 && EXTRUDERS
+#elif HAS_EXTRUDERS && !HAS_HEATER_0
   #error "HEATER_0_PIN not defined for this board."
 #elif TEMP_SENSOR_0_IS_MAX_TC && !PIN_EXISTS(TEMP_0_CS)
   #error "TEMP_SENSOR_0 MAX thermocouple requires TEMP_0_CS_PIN."

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -97,6 +97,11 @@
 // Note: different jumper configuration needed for SPI stepper drivers!
 // #define SPI_CONNECTION
 #if ENABLED(SPI_CONNECTION)
+  /**
+   * Make sure to configure the jumpers on the back side of the Mobo according to
+   * this diagram: https://github.com/MarlinFirmware/Marlin/pull/23851
+   */
+  #error "SPI drivers require a custom jumper configuration, see comment above! Comment out this line to continue."
   #define X_CS_PIN                          PD8
   #define Y_CS_PIN                          PB12
   #define Z_CS_PIN                          PE8

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -60,12 +60,12 @@
 
 // None of these require limit switches by default, so we leave these commented
 // here for your reference.
-// #define I_MIN_PIN                           PA8
-// #define I_MAX_PIN                           PA8
-// #define J_MIN_PIN                           PD13
-// #define J_MAX_PIN                           PD13
-// #define K_MIN_PIN                           PC9
-// #define K_MAX_PIN                           PC9
+//#define I_MIN_PIN                         PA8
+//#define I_MAX_PIN                         PA8
+//#define J_MIN_PIN                         PD13
+//#define J_MAX_PIN                         PD13
+//#define K_MIN_PIN                         PC9
+//#define K_MAX_PIN                         PC9
 
 //
 // Steppers
@@ -94,64 +94,64 @@
 #define K_DIR_PIN                           PD7
 #define K_ENABLE_PIN                        PA3
 
-#if ANY_AXIS_HAS(SPI)
+#if HAS_TMC_SPI
   /**
    * Make sure to configure the jumpers on the back side of the Mobo according to
    * this diagram: https://github.com/MarlinFirmware/Marlin/pull/23851
    */
   #error "SPI drivers require a custom jumper configuration, see comment above! Comment out this line to continue."
-#endif
 
-#if AXIS_HAS_UART(X)
+  #if AXIS_HAS_SPI(X)
+    #define X_CS_PIN                        PD8
+  #endif
+  #if AXIS_HAS_SPI(Y)
+    #define Y_CS_PIN                        PB12
+  #endif
+  #if AXIS_HAS_SPI(Z)
+    #define Z_CS_PIN                        PE8
+  #endif
+  #if AXIS_HAS_SPI(I)
+    #define I_CS_PIN                        PC5
+  #endif
+  #if AXIS_HAS_SPI(J)
+    #define J_CS_PIN                        PE12
+  #endif
+  #if AXIS_HAS_SPI(K)
+    #define K_CS_PIN                        PA2
+  #endif
+
+#elif HAS_TMC_UART
+
   #define X_SERIAL_TX_PIN                   PD8
-  #define X_SERIAL_RX_PIN                   PD8
-#elif AXIS_HAS_SPI(X)
-  #define X_CS_PIN                          PD8
-#endif
+  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
 
-#if AXIS_HAS_UART(Y)
   #define Y_SERIAL_TX_PIN                   PB12
-  #define Y_SERIAL_RX_PIN                   PB12
-#elif AXIS_HAS_SPI(Y)
-  #define Y_CS_PIN                          PB12
-#endif
+  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
 
-#if AXIS_HAS_UART(Z)
   #define Z_SERIAL_TX_PIN                   PE8
-  #define Z_SERIAL_RX_PIN                   PE8
-#elif AXIS_HAS_SPI(Z)
-  #define Z_CS_PIN                          PE8
-#endif
+  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
 
-#if AXIS_HAS_UART(I)
   #define I_SERIAL_TX_PIN                   PC5
-  #define I_SERIAL_RX_PIN                   PC5
-#elif AXIS_HAS_SPI(I)
-  #define I_CS_PIN                          PC5
-#endif
+  #define I_SERIAL_RX_PIN        I_SERIAL_TX_PIN
 
-#if AXIS_HAS_UART(J)
   #define J_SERIAL_TX_PIN                   PE12
-  #define J_SERIAL_RX_PIN                   PE12
-#elif AXIS_HAS_SPI(J)
-  #define J_CS_PIN                          PE12
-#endif
+  #define J_SERIAL_RX_PIN        J_SERIAL_TX_PIN
 
-#if AXIS_HAS_UART(K)
   #define K_SERIAL_TX_PIN                   PA2
-  #define K_SERIAL_RX_PIN                   PA2
-#elif AXIS_HAS_SPI(K)
-  #define K_CS_PIN                          PA2
-#endif
+  #define K_SERIAL_RX_PIN        K_SERIAL_TX_PIN
 
-// Reduce baud rate to improve software serial reliability
-#define TMC_BAUD_RATE                      19200
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE                    19200
+
+#endif
 
 // Not required for this board. Fails to compile otherwise.
 // PD0 is not connected on this board.
 #define TEMP_0_PIN                          PD0
 
-// General use mosfets, useful for things like pumps and solenoids
+//
+// Heaters / Fans
+//
 #define FAN_PIN                             PE2
 #define FAN1_PIN                            PE3
 #define FAN2_PIN                            PE4
@@ -159,20 +159,26 @@
 
 #define FAN_SOFT_PWM_REQUIRED
 
-// Neopixel Rings
+//
+// Neopixel
+//
 #define NEOPIXEL_PIN                        PC7
 #define NEOPIXEL2_PIN                       PC8
 
+//
 // SPI
+//
 #define MISO_PIN                            PB4
 #define MOSI_PIN                            PB5
 #define SCK_PIN                             PB3
 
-#define TMC_SW_MISO                         MISO_PIN
-#define TMC_SW_MOSI                         MOSI_PIN
-#define TMC_SW_SCK                          SCK_PIN
+#define TMC_SW_MISO                     MISO_PIN
+#define TMC_SW_MOSI                     MOSI_PIN
+#define TMC_SW_SCK                       SCK_PIN
 
+//
 // I2C
+//
 #define I2C_SDA_PIN                         PB7
 #define I2C_SCL_PIN                         PB6
 

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -145,10 +145,6 @@
 
 #endif
 
-// Not required for this board. Fails to compile otherwise.
-// PD0 is not connected on this board.
-#define TEMP_0_PIN                          PD0
-
 //
 // Heaters / Fans
 //

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -73,38 +73,50 @@
 #define X_STEP_PIN                          PB15
 #define X_DIR_PIN                           PB14
 #define X_ENABLE_PIN                        PD9
-#define X_SERIAL_TX_PIN                     PD8
-#define X_SERIAL_RX_PIN                     PD8
 
 #define Y_STEP_PIN                          PE15
 #define Y_DIR_PIN                           PE14
 #define Y_ENABLE_PIN                        PB13
-#define Y_SERIAL_TX_PIN                     PB12
-#define Y_SERIAL_RX_PIN                     PB12
 
 #define Z_STEP_PIN                          PE7
 #define Z_DIR_PIN                           PB1
 #define Z_ENABLE_PIN                        PE9
-#define Z_SERIAL_TX_PIN                     PE8
-#define Z_SERIAL_RX_PIN                     PE8
 
 #define I_STEP_PIN                          PC4
 #define I_DIR_PIN                           PA4
 #define I_ENABLE_PIN                        PB0
-#define I_SERIAL_TX_PIN                     PC5
-#define I_SERIAL_RX_PIN                     PC5
 
 #define J_STEP_PIN                          PE11
 #define J_DIR_PIN                           PE10
 #define J_ENABLE_PIN                        PE13
-#define J_SERIAL_TX_PIN                     PE12
-#define J_SERIAL_RX_PIN                     PE12
-#define K_SERIAL_TX_PIN                     PA2
-#define K_SERIAL_RX_PIN                     PA2
 
 #define K_STEP_PIN                          PD6
 #define K_DIR_PIN                           PD7
 #define K_ENABLE_PIN                        PA3
+
+// Note: different jumper configuration needed for SPI stepper drivers!
+// #define SPI_CONNECTION
+#if ENABLED(SPI_CONNECTION)
+  #define X_CS_PIN                          PD8
+  #define Y_CS_PIN                          PB12
+  #define Z_CS_PIN                          PE8
+  #define I_CS_PIN                          PC5
+  #define J_CS_PIN                          PE12
+  #define K_CS_PIN                          PA2
+#else
+  #define X_SERIAL_TX_PIN                   PD8
+  #define X_SERIAL_RX_PIN                   PD8
+  #define Y_SERIAL_TX_PIN                   PB12
+  #define Y_SERIAL_RX_PIN                   PB12
+  #define Z_SERIAL_TX_PIN                   PE8
+  #define Z_SERIAL_RX_PIN                   PE8
+  #define I_SERIAL_TX_PIN                   PC5
+  #define I_SERIAL_RX_PIN                   PC5
+  #define J_SERIAL_TX_PIN                   PE12
+  #define J_SERIAL_RX_PIN                   PE12
+  #define K_SERIAL_TX_PIN                   PA2
+  #define K_SERIAL_RX_PIN                   PA2
+#endif
 
 // Reduce baud rate to improve software serial reliability
 #define TMC_BAUD_RATE                      19200

--- a/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
+++ b/Marlin/src/pins/stm32f4/pins_INDEX_REV03.h
@@ -94,33 +94,54 @@
 #define K_DIR_PIN                           PD7
 #define K_ENABLE_PIN                        PA3
 
-// Note: different jumper configuration needed for SPI stepper drivers!
-// #define SPI_CONNECTION
-#if ENABLED(SPI_CONNECTION)
+#if ANY_AXIS_HAS(SPI)
   /**
    * Make sure to configure the jumpers on the back side of the Mobo according to
    * this diagram: https://github.com/MarlinFirmware/Marlin/pull/23851
    */
   #error "SPI drivers require a custom jumper configuration, see comment above! Comment out this line to continue."
-  #define X_CS_PIN                          PD8
-  #define Y_CS_PIN                          PB12
-  #define Z_CS_PIN                          PE8
-  #define I_CS_PIN                          PC5
-  #define J_CS_PIN                          PE12
-  #define K_CS_PIN                          PA2
-#else
+#endif
+
+#if AXIS_HAS_UART(X)
   #define X_SERIAL_TX_PIN                   PD8
   #define X_SERIAL_RX_PIN                   PD8
+#elif AXIS_HAS_SPI(X)
+  #define X_CS_PIN                          PD8
+#endif
+
+#if AXIS_HAS_UART(Y)
   #define Y_SERIAL_TX_PIN                   PB12
   #define Y_SERIAL_RX_PIN                   PB12
+#elif AXIS_HAS_SPI(Y)
+  #define Y_CS_PIN                          PB12
+#endif
+
+#if AXIS_HAS_UART(Z)
   #define Z_SERIAL_TX_PIN                   PE8
   #define Z_SERIAL_RX_PIN                   PE8
+#elif AXIS_HAS_SPI(Z)
+  #define Z_CS_PIN                          PE8
+#endif
+
+#if AXIS_HAS_UART(I)
   #define I_SERIAL_TX_PIN                   PC5
   #define I_SERIAL_RX_PIN                   PC5
+#elif AXIS_HAS_SPI(I)
+  #define I_CS_PIN                          PC5
+#endif
+
+#if AXIS_HAS_UART(J)
   #define J_SERIAL_TX_PIN                   PE12
   #define J_SERIAL_RX_PIN                   PE12
+#elif AXIS_HAS_SPI(J)
+  #define J_CS_PIN                          PE12
+#endif
+
+#if AXIS_HAS_UART(K)
   #define K_SERIAL_TX_PIN                   PA2
   #define K_SERIAL_RX_PIN                   PA2
+#elif AXIS_HAS_SPI(K)
+  #define K_CS_PIN                          PA2
 #endif
 
 // Reduce baud rate to improve software serial reliability
@@ -146,6 +167,10 @@
 #define MISO_PIN                            PB4
 #define MOSI_PIN                            PB5
 #define SCK_PIN                             PB3
+
+#define TMC_SW_MISO                         MISO_PIN
+#define TMC_SW_MOSI                         MOSI_PIN
+#define TMC_SW_SCK                          SCK_PIN
 
 // I2C
 #define I2C_SDA_PIN                         PB7


### PR DESCRIPTION
### Description (UPDATED 03.06.2022)

This PR enables a simple configuration of non-UART / SPI stepper drivers (e.g. TMC2130, TMC5160, ...). Below you can find a detailed guide on how to setup the TMC2130 drivers inside Marlin.

### Requirements

* [Index/LumenPnP](https://github.com/index-machines/index) Mobo Rev03
* SPI enabled stepper drivers (TMC2130 in this example)
* Correct jumper configuration on the back side of the Mobo Rev03
![config](https://user-images.githubusercontent.com/19287308/156871062-383c0ef7-7e64-47f5-9520-53081029e4ce.jpg)

### Setup
1.) Copy the official [Index/LumenPnP](https://github.com/index-machines/index) `Configuration.h` and `Configuration_adv.h` files into your Marlin session.
2.) Change the following definitions (depending on your drivers) in the `Configuration.h` file.
```
#define X_DRIVER_TYPE  TMC2130
#define Y_DRIVER_TYPE  TMC2130
#define Z_DRIVER_TYPE  TMC2130
#define I_DRIVER_TYPE  TMC2130
#define J_DRIVER_TYPE  TMC2130
#define K_DRIVER_TYPE  TMC2130
```
3.) Comment out the `#error...` line in the `pins_INDEX_REV03.h` file and double check that you correctly configured the jumper configuration mentioned above!
4.) Upload and enjoy 🎉

### Benefits

This PR removes the need to separately define the CS pins for the stepper drivers and gives users a short introduction on how to get the SPI drivers up and running.

### Configurations

In the attached .zip file, you can find the 4 Marlin files that need to be changed in general to flash the Mobo Rev03 including the proposed changes from above (TMC2130 setup) as well as the compiled binary for easy usage.

[SetupFiles.zip](https://github.com/MarlinFirmware/Marlin/files/8193005/SetupFiles.zip)
