### PR TITLE
Resolves Anycubic Chiron new TFT panel wont print from SD card after reset 

### DIFF
--- a/Marlin/src/lcd/extui/anycubic_chiron/FileNavigator.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/FileNavigator.cpp
@@ -155,7 +155,7 @@ void FileNavigator::skiptofileindex(uint16_t skip) {
 
     if (currentindex == 0 && currentfolderdepth > 0) { // Add a link to go up a folder
       // The new panel ignores entries that don't end in .GCO or .gcode so add and pad them.
-      if (paneltype == AC_panel_new) {
+      if (paneltype <= AC_panel_new) {
         TFTSer.println("<<.GCO");
         Chiron.SendtoTFTLN(F("..                  .gcode"));
       }
@@ -177,7 +177,7 @@ void FileNavigator::skiptofileindex(uint16_t skip) {
   void FileNavigator::sendFile(panel_type_t paneltype) {
     if (filelist.isDir()) {
       // Add mandatory tags for new panel otherwise lines are ignored.
-      if (paneltype == AC_panel_new) {
+      if (paneltype <= AC_panel_new) {
         TFTSer.print(filelist.shortFilename());
         TFTSer.println(".GCO");
         TFTSer.print(filelist.shortFilename());

--- a/Marlin/src/lcd/extui/anycubic_chiron/chiron_tft_defs.h
+++ b/Marlin/src/lcd/extui/anycubic_chiron/chiron_tft_defs.h
@@ -89,6 +89,10 @@
 #define AC_msg_mesh_changes_saved      F("Mesh changes saved.")
 #define AC_msg_old_panel_detected      F("Standard TFT panel detected!")
 #define AC_msg_new_panel_detected      F("New TFT panel detected!")
+#define AC_msg_auto_panel_detection    F("Auto detect panel type (assuming new panel)")
+#define AC_msg_old_panel_set           F("Set for standard TFT panel.")
+#define AC_msg_new_panel_set           F("Set for new TFT panel.")
+
 #define AC_msg_powerloss_recovery      F("Resuming from power outage! select the same SD file then press resume")
 // Error messages must not contain spaces
 #define AC_msg_error_bed_temp          F("Abnormal_bed_temp")
@@ -161,10 +165,10 @@ namespace Anycubic {
     AC_menu_change_to_file,
     AC_menu_change_to_command
   };
-  enum panel_type_t : uint8_t {
+  enum panel_type_t : uint8_t { // order is important here as we assume new panel if type is unknown 
     AC_panel_unknown,
-    AC_panel_standard,
-    AC_panel_new
+    AC_panel_new,
+    AC_panel_standard
   };
   enum last_error_t : uint8_t {
     AC_error_none,


### PR DESCRIPTION
### Description
Auto detection of the new style TFT panel on the Anycubic Chiron sometimes fails. 
When this happens you cannot print from SD card and the probing menu doesn't work correctly.
This problem does not occur if the panel type has been defined in the configuration files.

### Requirements
New style (Yellow/Blue) TFT panel.

### Benefits
Auto detection now assumes the new panel is fitted and will revert to the standard panel if this is detected.
The standard panel does not suffer from the inconsistent detection behaviour. 

### Configurations
Requires Anycubic Chiron config files from examples folder with now panel type defined.

### Related Issues
Fixes # https://github.com/MarlinFirmware/Marlin/issues/23853