### PR TITLE
TH3D EZ Board V2: Add Default TMC Slave Addresses

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_TH3D_EZBOARD_V2.h
@@ -130,6 +130,20 @@
 
   // Reduce baud rate to improve software serial reliability
   #define TMC_BAUD_RATE                    19200
+
+  // Default TMC slave addresses
+  #ifndef X_SLAVE_ADDRESS
+    #define X_SLAVE_ADDRESS  0
+  #endif
+  #ifndef Y_SLAVE_ADDRESS
+    #define Y_SLAVE_ADDRESS  1
+  #endif
+  #ifndef Z_SLAVE_ADDRESS
+    #define Z_SLAVE_ADDRESS  2
+  #endif
+  #ifndef E0_SLAVE_ADDRESS
+    #define E0_SLAVE_ADDRESS 3
+  #endif
 #endif
 
 //


### PR DESCRIPTION
### Description

Add default TMC slave addresses for the TH3D EZ Board V2, similar to the BTT & Fysetc boards.

### Requirements

TH3D EZ Board V2

### Benefits

Users won't have to manually set addresses in their config and invalid addresses won't accidentally get transferred to other builds if the user upgrades their board.

### Configurations

[Default TH3D EZ Board V2 config](https://github.com/MarlinFirmware/Configurations/blob/import-2.0.x/config/examples/Creality/Ender-3/TH3D%20EZBoard%20Lite%20V2/).

### Related Issues

Found while removing slave addresses from configs.
- https://github.com/MarlinFirmware/Configurations/pull/696
- https://github.com/MarlinFirmware/Marlin/pull/20498

cc: @houseofbugs