### PR TITLE
Remove Extraneous BTT Octopus Pro USB 446 Flag

### DIFF
--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -298,9 +298,8 @@ extends           = env:BIGTREE_OCTOPUS_PRO_V1_F429
 platform_packages = ${stm_flash_drive.platform_packages}
 build_unflags     = -DUSBD_USE_CDC
 build_flags       = ${stm_flash_drive.build_flags}
-                    -DSTM32F446_5VX -DUSE_USB_HS_IN_FS
-                    -DUSE_USBHOST_HS -DUSBD_IRQ_PRIO=5
-                    -DUSBD_IRQ_SUBPRIO=6
+                    -DUSE_USB_HS_IN_FS -DUSE_USBHOST_HS
+                    -DUSBD_IRQ_PRIO=5 -DUSBD_IRQ_SUBPRIO=6
                     -DUSBD_USE_CDC_MSC
 
 #


### PR DESCRIPTION
### Description

Remove extraneous `STM32F446_5VX` flag from the `BIGTREE_OCTOPUS_PRO_V1_F429_USB` environment.

### Requirements

Octopus Pro 429

### Related Issues

None. Found while chatting on Discord.
