### PR TITLE
16 times oversampling with 12 bit ADC

### DIFF
--- a/Marlin/src/core/types.h
+++ b/Marlin/src/core/types.h
@@ -128,6 +128,7 @@ typedef float feedRate_t;
 // celsius_t is the native unit of temperature. Signed to handle a disconnected thermistor value (-14).
 // For more resolition (e.g., for a chocolate printer) this may later be changed to Celsius x 100
 //
+typedef uint16_t raw_adc_t;
 typedef int16_t celsius_t;
 typedef float celsius_float_t;
 

--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -91,7 +91,7 @@ Joystick joystick;
       if (READ(JOY_EN_PIN)) return;
     #endif
 
-    auto _normalize_joy = [](float &axis_jog, const uint16_t raw, const uint16_t (&joy_limits)[4]) {
+    auto _normalize_joy = [](float &axis_jog, const raw_adc_t raw, const raw_adc_t (&joy_limits)[4]) {
       if (WITHIN(raw, joy_limits[0], joy_limits[3])) {
         // within limits, check deadzone
         if (raw > joy_limits[2])
@@ -104,15 +104,15 @@ Joystick joystick;
     };
 
     #if HAS_JOY_ADC_X
-      static constexpr uint16_t joy_x_limits[4] = JOY_X_LIMITS;
+      static constexpr raw_adc_t joy_x_limits[4] = JOY_X_LIMITS;
       _normalize_joy(norm_jog.x, JOY_X(x.getraw()), joy_x_limits);
     #endif
     #if HAS_JOY_ADC_Y
-      static constexpr uint16_t joy_y_limits[4] = JOY_Y_LIMITS;
+      static constexpr raw_adc_t joy_y_limits[4] = JOY_Y_LIMITS;
       _normalize_joy(norm_jog.y, JOY_Y(y.getraw()), joy_y_limits);
     #endif
     #if HAS_JOY_ADC_Z
-      static constexpr uint16_t joy_z_limits[4] = JOY_Z_LIMITS;
+      static constexpr raw_adc_t joy_z_limits[4] = JOY_Z_LIMITS;
       _normalize_joy(norm_jog.z, JOY_Z(z.getraw()), joy_z_limits);
     #endif
   }

--- a/Marlin/src/feature/joystick.cpp
+++ b/Marlin/src/feature/joystick.cpp
@@ -68,13 +68,13 @@ Joystick joystick;
   void Joystick::report() {
     SERIAL_ECHOPGM("Joystick");
     #if HAS_JOY_ADC_X
-      SERIAL_ECHOPGM_P(SP_X_STR, JOY_X(x.raw));
+      SERIAL_ECHOPGM_P(SP_X_STR, JOY_X(x.getraw()));
     #endif
     #if HAS_JOY_ADC_Y
-      SERIAL_ECHOPGM_P(SP_Y_STR, JOY_Y(y.raw));
+      SERIAL_ECHOPGM_P(SP_Y_STR, JOY_Y(y.getraw()));
     #endif
     #if HAS_JOY_ADC_Z
-      SERIAL_ECHOPGM_P(SP_Z_STR, JOY_Z(z.raw));
+      SERIAL_ECHOPGM_P(SP_Z_STR, JOY_Z(z.getraw()));
     #endif
     #if HAS_JOY_ADC_EN
       SERIAL_ECHO_TERNARY(READ(JOY_EN_PIN), " EN=", "HIGH (dis", "LOW (en", "abled)");
@@ -91,29 +91,29 @@ Joystick joystick;
       if (READ(JOY_EN_PIN)) return;
     #endif
 
-    auto _normalize_joy = [](float &axis_jog, const int16_t raw, const int16_t (&joy_limits)[4]) {
+    auto _normalize_joy = [](float &axis_jog, const uint16_t raw, const uint16_t (&joy_limits)[4]) {
       if (WITHIN(raw, joy_limits[0], joy_limits[3])) {
         // within limits, check deadzone
         if (raw > joy_limits[2])
           axis_jog = (raw - joy_limits[2]) / float(joy_limits[3] - joy_limits[2]);
         else if (raw < joy_limits[1])
-          axis_jog = (raw - joy_limits[1]) / float(joy_limits[1] - joy_limits[0]);  // negative value
+          axis_jog = int16_t(raw - joy_limits[1]) / float(joy_limits[1] - joy_limits[0]);  // negative value
         // Map normal to jog value via quadratic relationship
         axis_jog = SIGN(axis_jog) * sq(axis_jog);
       }
     };
 
     #if HAS_JOY_ADC_X
-      static constexpr int16_t joy_x_limits[4] = JOY_X_LIMITS;
-      _normalize_joy(norm_jog.x, JOY_X(x.raw), joy_x_limits);
+      static constexpr uint16_t joy_x_limits[4] = JOY_X_LIMITS;
+      _normalize_joy(norm_jog.x, JOY_X(x.getraw()), joy_x_limits);
     #endif
     #if HAS_JOY_ADC_Y
-      static constexpr int16_t joy_y_limits[4] = JOY_Y_LIMITS;
-      _normalize_joy(norm_jog.y, JOY_Y(y.raw), joy_y_limits);
+      static constexpr uint16_t joy_y_limits[4] = JOY_Y_LIMITS;
+      _normalize_joy(norm_jog.y, JOY_Y(y.getraw()), joy_y_limits);
     #endif
     #if HAS_JOY_ADC_Z
-      static constexpr int16_t joy_z_limits[4] = JOY_Z_LIMITS;
-      _normalize_joy(norm_jog.z, JOY_Z(z.raw), joy_z_limits);
+      static constexpr uint16_t joy_z_limits[4] = JOY_Z_LIMITS;
+      _normalize_joy(norm_jog.z, JOY_Z(z.getraw()), joy_z_limits);
     #endif
   }
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1204,7 +1204,7 @@ void MarlinUI::init() {
     #endif
 
     // Calculate the ADC value for the voltage divider with specified pull-down resistor value
-    #define ADC_BUTTON_VALUE(r)  int(HAL_ADC_RANGE * (ADC_BUTTONS_VALUE_SCALE) * r / (r + ADC_BUTTONS_R_PULLUP))
+    #define ADC_BUTTON_VALUE(r)  uint16_t(HAL_ADC_RANGE * (ADC_BUTTONS_VALUE_SCALE) * r / (r + ADC_BUTTONS_R_PULLUP))
 
     static constexpr uint16_t adc_button_tolerance = HAL_ADC_RANGE *   25 / 1024,
                                   adc_other_button = HAL_ADC_RANGE * 1000 / 1024;

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -1177,7 +1177,7 @@ void MarlinUI::init() {
   #if HAS_ADC_BUTTONS
 
     typedef struct {
-      uint16_t ADCKeyValueMin, ADCKeyValueMax;
+      raw_adc_t ADCKeyValueMin, ADCKeyValueMax;
       uint8_t  ADCKeyNo;
     } _stADCKeypadTable_;
 
@@ -1204,10 +1204,10 @@ void MarlinUI::init() {
     #endif
 
     // Calculate the ADC value for the voltage divider with specified pull-down resistor value
-    #define ADC_BUTTON_VALUE(r)  uint16_t(HAL_ADC_RANGE * (ADC_BUTTONS_VALUE_SCALE) * r / (r + ADC_BUTTONS_R_PULLUP))
+    #define ADC_BUTTON_VALUE(r)  raw_adc_t(HAL_ADC_RANGE * (ADC_BUTTONS_VALUE_SCALE) * r / (r + ADC_BUTTONS_R_PULLUP))
 
-    static constexpr uint16_t adc_button_tolerance = HAL_ADC_RANGE *   25 / 1024,
-                                  adc_other_button = HAL_ADC_RANGE * 1000 / 1024;
+    static constexpr raw_adc_t adc_button_tolerance = HAL_ADC_RANGE *   25 / 1024,
+                                   adc_other_button = HAL_ADC_RANGE * 1000 / 1024;
     static const _stADCKeypadTable_ stADCKeyTable[] PROGMEM = {
       // VALUE_MIN, VALUE_MAX, KEY
       { adc_other_button, HAL_ADC_RANGE, 1 + BLEN_KEYPAD_F1     }, // F1
@@ -1227,13 +1227,13 @@ void MarlinUI::init() {
 
     uint8_t get_ADC_keyValue() {
       if (thermalManager.ADCKey_count >= 16) {
-        const uint16_t currentkpADCValue = thermalManager.current_ADCKey_raw;
+        const raw_adc_t currentkpADCValue = thermalManager.current_ADCKey_raw;
         thermalManager.current_ADCKey_raw = HAL_ADC_RANGE;
         thermalManager.ADCKey_count = 0;
         if (currentkpADCValue < adc_other_button)
           LOOP_L_N(i, ADC_KEY_NUM) {
-            const uint16_t lo = pgm_read_word(&stADCKeyTable[i].ADCKeyValueMin),
-                           hi = pgm_read_word(&stADCKeyTable[i].ADCKeyValueMax);
+            const raw_adc_t lo = pgm_read_word(&stADCKeyTable[i].ADCKeyValueMin),
+                            hi = pgm_read_word(&stADCKeyTable[i].ADCKeyValueMax);
             if (WITHIN(currentkpADCValue, lo, hi)) return pgm_read_byte(&stADCKeyTable[i].ADCKeyNo);
           }
       }

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -437,8 +437,8 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 #if HAS_HEATED_BED
   bed_info_t Temperature::temp_bed; // = { 0 }
   // Init min and max temp with extreme values to prevent false errors during startup
-  int16_t Temperature::mintemp_raw_BED = TEMP_SENSOR_BED_RAW_LO_TEMP,
-          Temperature::maxtemp_raw_BED = TEMP_SENSOR_BED_RAW_HI_TEMP;
+  uint16_t Temperature::mintemp_raw_BED = TEMP_SENSOR_BED_RAW_LO_TEMP,
+           Temperature::maxtemp_raw_BED = TEMP_SENSOR_BED_RAW_HI_TEMP;
   TERN_(WATCH_BED, bed_watch_t Temperature::watch_bed); // = { 0 }
   IF_DISABLED(PIDTEMPBED, millis_t Temperature::next_bed_check_ms);
 #endif
@@ -448,8 +448,8 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
   #if HAS_HEATED_CHAMBER
     millis_t next_cool_check_ms_2 = 0;
     celsius_float_t old_temp = 9999;
-    int16_t Temperature::mintemp_raw_CHAMBER = TEMP_SENSOR_CHAMBER_RAW_LO_TEMP,
-            Temperature::maxtemp_raw_CHAMBER = TEMP_SENSOR_CHAMBER_RAW_HI_TEMP;
+    uint16_t Temperature::mintemp_raw_CHAMBER = TEMP_SENSOR_CHAMBER_RAW_LO_TEMP,
+             Temperature::maxtemp_raw_CHAMBER = TEMP_SENSOR_CHAMBER_RAW_HI_TEMP;
     TERN_(WATCH_CHAMBER, chamber_watch_t Temperature::watch_chamber{0});
     IF_DISABLED(PIDTEMPCHAMBER, millis_t Temperature::next_chamber_check_ms);
   #endif
@@ -461,8 +461,8 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
     bool flag_cooler_state;
     //bool flag_cooler_excess = false;
     celsius_float_t previous_temp = 9999;
-    int16_t Temperature::mintemp_raw_COOLER = TEMP_SENSOR_COOLER_RAW_LO_TEMP,
-            Temperature::maxtemp_raw_COOLER = TEMP_SENSOR_COOLER_RAW_HI_TEMP;
+    uint16_t Temperature::mintemp_raw_COOLER = TEMP_SENSOR_COOLER_RAW_LO_TEMP,
+             Temperature::maxtemp_raw_COOLER = TEMP_SENSOR_COOLER_RAW_HI_TEMP;
     #if WATCH_COOLER
       cooler_watch_t Temperature::watch_cooler{0};
     #endif
@@ -477,8 +477,8 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 #if HAS_TEMP_BOARD
   board_info_t Temperature::temp_board; // = { 0 }
   #if ENABLED(THERMAL_PROTECTION_BOARD)
-    int16_t Temperature::mintemp_raw_BOARD = TEMP_SENSOR_BOARD_RAW_LO_TEMP,
-            Temperature::maxtemp_raw_BOARD = TEMP_SENSOR_BOARD_RAW_HI_TEMP;
+    uint16_t Temperature::mintemp_raw_BOARD = TEMP_SENSOR_BOARD_RAW_LO_TEMP,
+             Temperature::maxtemp_raw_BOARD = TEMP_SENSOR_BOARD_RAW_HI_TEMP;
   #endif
 #endif
 
@@ -508,6 +508,7 @@ volatile bool Temperature::raw_temps_ready = false;
 #endif
 
 #define TEMPDIR(N) ((TEMP_SENSOR_##N##_RAW_LO_TEMP) < (TEMP_SENSOR_##N##_RAW_HI_TEMP) ? 1 : -1)
+#define TP_CMP(S,A,B) (TEMPDIR(S) < 0 ? ((A)<(B)) : ((A)>(B)))
 
 #if HAS_HOTEND
   // Init mintemp and maxtemp with extreme values to prevent false errors during startup
@@ -1689,8 +1690,8 @@ void Temperature::manage_heater() {
     m = (l + r) >> 1;                                                     \
     if (!m) return celsius_t(pgm_read_word(&TBL[0].celsius));             \
     if (m == l || m == r) return celsius_t(pgm_read_word(&TBL[LEN-1].celsius)); \
-    int16_t v00 = pgm_read_word(&TBL[m-1].value),                         \
-            v10 = pgm_read_word(&TBL[m-0].value);                         \
+    uint16_t v00 = pgm_read_word(&TBL[m-1].value),                        \
+             v10 = pgm_read_word(&TBL[m-0].value);                        \
          if (raw < v00) r = m;                                            \
     else if (raw > v10) l = m;                                            \
     else {                                                                \
@@ -1784,7 +1785,7 @@ void Temperature::manage_heater() {
     SERIAL_EOL();
   }
 
-  celsius_float_t Temperature::user_thermistor_to_deg_c(const uint8_t t_index, const int16_t raw) {
+  celsius_float_t Temperature::user_thermistor_to_deg_c(const uint8_t t_index, const uint16_t raw) {
 
     if (!WITHIN(t_index, 0, COUNT(user_thermistor) - 1)) return 25;
 
@@ -1799,8 +1800,8 @@ void Temperature::manage_heater() {
     }
 
     // maximum adc value .. take into account the over sampling
-    const int adc_max = MAX_RAW_THERMISTOR_VALUE,
-              adc_raw = constrain(raw, 1, adc_max - 1); // constrain to prevent divide-by-zero
+    constexpr uint16_t adc_max = MAX_RAW_THERMISTOR_VALUE;
+    const uint16_t adc_raw = constrain(raw, 1, adc_max - 1); // constrain to prevent divide-by-zero
 
     const float adc_inverse = (adc_max - adc_raw) - 0.5f,
                 resistance = t.series_res * (adc_raw + 0.5f) / adc_inverse,
@@ -1820,7 +1821,7 @@ void Temperature::manage_heater() {
 #if HAS_HOTEND
   // Derived from RepRap FiveD extruder::getTemperature()
   // For hot end temperature measurement.
-  celsius_float_t Temperature::analog_to_celsius_hotend(const int16_t raw, const uint8_t e) {
+  celsius_float_t Temperature::analog_to_celsius_hotend(const uint16_t raw, const uint8_t e) {
     if (e >= HOTENDS) {
       SERIAL_ERROR_START();
       SERIAL_ECHO(e);
@@ -1836,11 +1837,11 @@ void Temperature::manage_heater() {
         #elif TEMP_SENSOR_0_IS_MAX_TC
           #if TEMP_SENSOR_0_IS_MAX31865
             return TERN(LIB_INTERNAL_MAX31865,
-              max31865_0.temperature((uint16_t)raw),
+              max31865_0.temperature(raw),
               max31865_0.temperature(MAX31865_SENSOR_OHMS_0, MAX31865_CALIBRATION_OHMS_0)
             );
           #else
-            return raw * 0.25;
+            return (int16_t)raw * 0.25;
           #endif
         #elif TEMP_SENSOR_0_IS_AD595
           return TEMP_AD595(raw);
@@ -1855,11 +1856,11 @@ void Temperature::manage_heater() {
         #elif TEMP_SENSOR_1_IS_MAX_TC
           #if TEMP_SENSOR_0_IS_MAX31865
             return TERN(LIB_INTERNAL_MAX31865,
-              max31865_1.temperature((uint16_t)raw),
+              max31865_1.temperature(raw),
               max31865_1.temperature(MAX31865_SENSOR_OHMS_1, MAX31865_CALIBRATION_OHMS_1)
             );
           #else
-            return raw * 0.25;
+            return (int16_t)raw * 0.25;
           #endif
         #elif TEMP_SENSOR_1_IS_AD595
           return TEMP_AD595(raw);
@@ -1943,7 +1944,7 @@ void Temperature::manage_heater() {
 
 #if HAS_HEATED_BED
   // For bed temperature measurement.
-  celsius_float_t Temperature::analog_to_celsius_bed(const int16_t raw) {
+  celsius_float_t Temperature::analog_to_celsius_bed(const uint16_t raw) {
     #if TEMP_SENSOR_BED_IS_CUSTOM
       return user_thermistor_to_deg_c(CTI_BED, raw);
     #elif TEMP_SENSOR_BED_IS_THERMISTOR
@@ -1961,7 +1962,7 @@ void Temperature::manage_heater() {
 
 #if HAS_TEMP_CHAMBER
   // For chamber temperature measurement.
-  celsius_float_t Temperature::analog_to_celsius_chamber(const int16_t raw) {
+  celsius_float_t Temperature::analog_to_celsius_chamber(const uint16_t raw) {
     #if TEMP_SENSOR_CHAMBER_IS_CUSTOM
       return user_thermistor_to_deg_c(CTI_CHAMBER, raw);
     #elif TEMP_SENSOR_CHAMBER_IS_THERMISTOR
@@ -1979,7 +1980,7 @@ void Temperature::manage_heater() {
 
 #if HAS_TEMP_COOLER
   // For cooler temperature measurement.
-  celsius_float_t Temperature::analog_to_celsius_cooler(const int16_t raw) {
+  celsius_float_t Temperature::analog_to_celsius_cooler(const uint16_t raw) {
     #if TEMP_SENSOR_COOLER_IS_CUSTOM
       return user_thermistor_to_deg_c(CTI_COOLER, raw);
     #elif TEMP_SENSOR_COOLER_IS_THERMISTOR
@@ -1997,7 +1998,7 @@ void Temperature::manage_heater() {
 
 #if HAS_TEMP_PROBE
   // For probe temperature measurement.
-  celsius_float_t Temperature::analog_to_celsius_probe(const int16_t raw) {
+  celsius_float_t Temperature::analog_to_celsius_probe(const uint16_t raw) {
     #if TEMP_SENSOR_PROBE_IS_CUSTOM
       return user_thermistor_to_deg_c(CTI_PROBE, raw);
     #elif TEMP_SENSOR_PROBE_IS_THERMISTOR
@@ -2015,7 +2016,7 @@ void Temperature::manage_heater() {
 
 #if HAS_TEMP_BOARD
   // For motherboard temperature measurement.
-  celsius_float_t Temperature::analog_to_celsius_board(const int16_t raw) {
+  celsius_float_t Temperature::analog_to_celsius_board(const uint16_t raw) {
     #if TEMP_SENSOR_BOARD_IS_CUSTOM
       return user_thermistor_to_deg_c(CTI_BOARD, raw);
     #elif TEMP_SENSOR_BOARD_IS_THERMISTOR
@@ -2033,13 +2034,13 @@ void Temperature::manage_heater() {
 
 #if HAS_TEMP_REDUNDANT
   // For redundant temperature measurement.
-  celsius_float_t Temperature::analog_to_celsius_redundant(const int16_t raw) {
+  celsius_float_t Temperature::analog_to_celsius_redundant(const uint16_t raw) {
     #if TEMP_SENSOR_REDUNDANT_IS_CUSTOM
       return user_thermistor_to_deg_c(CTI_REDUNDANT, raw);
     #elif TEMP_SENSOR_REDUNDANT_IS_MAX_TC && REDUNDANT_TEMP_MATCH(SOURCE, E0)
-      return TERN(TEMP_SENSOR_REDUNDANT_IS_MAX31865, max31865_0.temperature((uint16_t)raw), raw * 0.25);
+      return TERN(TEMP_SENSOR_REDUNDANT_IS_MAX31865, max31865_0.temperature(raw), (int16_t)raw * 0.25);
     #elif TEMP_SENSOR_REDUNDANT_IS_MAX_TC && REDUNDANT_TEMP_MATCH(SOURCE, E1)
-      return TERN(TEMP_SENSOR_REDUNDANT_IS_MAX31865, max31865_1.temperature((uint16_t)raw), raw * 0.25);
+      return TERN(TEMP_SENSOR_REDUNDANT_IS_MAX31865, max31865_1.temperature(raw), (int16_t)raw * 0.25);
     #elif TEMP_SENSOR_REDUNDANT_IS_THERMISTOR
       SCAN_THERMISTOR_TABLE(TEMPTABLE_REDUNDANT, TEMPTABLE_REDUNDANT_LEN);
     #elif TEMP_SENSOR_REDUNDANT_IS_AD595
@@ -2069,20 +2070,20 @@ void Temperature::updateTemperaturesFromRawValues() {
 
   watchdog_refresh(); // Reset because raw_temps_ready was set by the interrupt
 
-  TERN_(TEMP_SENSOR_0_IS_MAX_TC, temp_hotend[0].raw = READ_MAX_TC(0));
-  TERN_(TEMP_SENSOR_1_IS_MAX_TC, temp_hotend[1].raw = READ_MAX_TC(1));
-  TERN_(TEMP_SENSOR_REDUNDANT_IS_MAX_TC, temp_redundant.raw = READ_MAX_TC(HEATER_ID(TEMP_SENSOR_REDUNDANT_SOURCE)));
+  TERN_(TEMP_SENSOR_0_IS_MAX_TC, temp_hotend[0].setraw(READ_MAX_TC(0)));
+  TERN_(TEMP_SENSOR_1_IS_MAX_TC, temp_hotend[1].setraw(READ_MAX_TC(1)));
+  TERN_(TEMP_SENSOR_REDUNDANT_IS_MAX_TC, temp_redundant.setraw(READ_MAX_TC(HEATER_ID(TEMP_SENSOR_REDUNDANT_SOURCE))));
 
   #if HAS_HOTEND
-    HOTEND_LOOP() temp_hotend[e].celsius = analog_to_celsius_hotend(temp_hotend[e].raw, e);
+    HOTEND_LOOP() temp_hotend[e].celsius = analog_to_celsius_hotend(temp_hotend[e].getraw(), e);
   #endif
 
-  TERN_(HAS_HEATED_BED,     temp_bed.celsius       = analog_to_celsius_bed(temp_bed.raw));
-  TERN_(HAS_TEMP_CHAMBER,   temp_chamber.celsius   = analog_to_celsius_chamber(temp_chamber.raw));
-  TERN_(HAS_TEMP_COOLER,    temp_cooler.celsius    = analog_to_celsius_cooler(temp_cooler.raw));
-  TERN_(HAS_TEMP_PROBE,     temp_probe.celsius     = analog_to_celsius_probe(temp_probe.raw));
-  TERN_(HAS_TEMP_BOARD,     temp_board.celsius     = analog_to_celsius_board(temp_board.raw));
-  TERN_(HAS_TEMP_REDUNDANT, temp_redundant.celsius = analog_to_celsius_redundant(temp_redundant.raw));
+  TERN_(HAS_HEATED_BED,     temp_bed.celsius       = analog_to_celsius_bed(temp_bed.getraw()));
+  TERN_(HAS_TEMP_CHAMBER,   temp_chamber.celsius   = analog_to_celsius_chamber(temp_chamber.getraw()));
+  TERN_(HAS_TEMP_COOLER,    temp_cooler.celsius    = analog_to_celsius_cooler(temp_cooler.getraw()));
+  TERN_(HAS_TEMP_PROBE,     temp_probe.celsius     = analog_to_celsius_probe(temp_probe.getraw()));
+  TERN_(HAS_TEMP_BOARD,     temp_board.celsius     = analog_to_celsius_board(temp_board.getraw()));
+  TERN_(HAS_TEMP_REDUNDANT, temp_redundant.celsius = analog_to_celsius_redundant(temp_redundant.getraw()));
 
   TERN_(FILAMENT_WIDTH_SENSOR, filwidth.update_measured_mm());
   TERN_(HAS_POWER_MONITOR,     power_monitor.capture_values());
@@ -2108,46 +2109,44 @@ void Temperature::updateTemperaturesFromRawValues() {
     };
 
     LOOP_L_N(e, COUNT(temp_dir)) {
-      const int8_t tdir = temp_dir[e];
-      if (tdir) {
-        const int16_t rawtemp = temp_hotend[e].raw * tdir; // normal direction, +rawtemp, else -rawtemp
-        if (rawtemp > temp_range[e].raw_max * tdir) max_temp_error((heater_id_t)e);
+      if ((temp_dir[e] < 0 && temp_hotend[e].getraw() < temp_range[e].raw_max) ||
+          (temp_dir[e] > 0 && temp_hotend[e].getraw() > temp_range[e].raw_max)) max_temp_error((heater_id_t)e);
 
-        const bool heater_on = temp_hotend[e].target > 0;
-        if (heater_on && rawtemp < temp_range[e].raw_min * tdir && !is_preheating(e)) {
-          #if MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED > 1
-            if (++consecutive_low_temperature_error[e] >= MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED)
-          #endif
-              min_temp_error((heater_id_t)e);
-        }
+      const bool heater_on = temp_hotend[e].target > 0;
+      if (heater_on && ((temp_dir[e] < 0 && temp_hotend[e].getraw() > temp_range[e].raw_min) ||
+                        (temp_dir[e] > 0 && temp_hotend[e].getraw() < temp_range[e].raw_min))) {
         #if MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED > 1
-          else
-            consecutive_low_temperature_error[e] = 0;
+          if (++consecutive_low_temperature_error[e] >= MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED)
         #endif
+            min_temp_error((heater_id_t)e);
       }
+      #if MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED > 1
+        else
+          consecutive_low_temperature_error[e] = 0;
+      #endif
     }
 
   #endif // HAS_HOTEND
 
   #define TP_CMP(S,A,B) (TEMPDIR(S) < 0 ? ((A)<(B)) : ((A)>(B)))
   #if ENABLED(THERMAL_PROTECTION_BED)
-    if (TP_CMP(BED, temp_bed.raw, maxtemp_raw_BED)) max_temp_error(H_BED);
-    if (temp_bed.target > 0 && TP_CMP(BED, mintemp_raw_BED, temp_bed.raw)) min_temp_error(H_BED);
+    if (TP_CMP(BED, temp_bed.getraw(), maxtemp_raw_BED)) max_temp_error(H_BED);
+    if (temp_bed.target > 0 && TP_CMP(BED, mintemp_raw_BED, temp_bed.getraw())) min_temp_error(H_BED);
   #endif
 
   #if BOTH(HAS_HEATED_CHAMBER, THERMAL_PROTECTION_CHAMBER)
-    if (TP_CMP(CHAMBER, temp_chamber.raw, maxtemp_raw_CHAMBER)) max_temp_error(H_CHAMBER);
-    if (temp_chamber.target > 0 && TP_CMP(CHAMBER, mintemp_raw_CHAMBER, temp_chamber.raw)) min_temp_error(H_CHAMBER);
+    if (TP_CMP(CHAMBER, temp_chamber.getraw(), maxtemp_raw_CHAMBER)) max_temp_error(H_CHAMBER);
+    if (temp_chamber.target > 0 && TP_CMP(CHAMBER, mintemp_raw_CHAMBER, temp_chamber.getraw())) min_temp_error(H_CHAMBER);
   #endif
 
   #if BOTH(HAS_COOLER, THERMAL_PROTECTION_COOLER)
-    if (cutter.unitPower > 0 && TP_CMP(COOLER, temp_cooler.raw, maxtemp_raw_COOLER)) max_temp_error(H_COOLER);
-    if (TP_CMP(COOLER, mintemp_raw_COOLER, temp_cooler.raw)) min_temp_error(H_COOLER);
+    if (cutter.unitPower > 0 && TP_CMP(COOLER, temp_cooler.getraw(), maxtemp_raw_COOLER)) max_temp_error(H_COOLER);
+    if (TP_CMP(COOLER, mintemp_raw_COOLER, temp_cooler.getraw())) min_temp_error(H_COOLER);
   #endif
 
   #if BOTH(HAS_TEMP_BOARD, THERMAL_PROTECTION_BOARD)
-    if (TP_CMP(BOARD, temp_board.raw, maxtemp_raw_BOARD)) max_temp_error(H_BOARD);
-    if (TP_CMP(BOARD, mintemp_raw_BOARD, temp_board.raw)) min_temp_error(H_BOARD);
+    if (TP_CMP(BOARD, temp_board.getraw(), maxtemp_raw_BOARD)) max_temp_error(H_BOARD);
+    if (TP_CMP(BOARD, mintemp_raw_BOARD, temp_board.getraw())) min_temp_error(H_BOARD);
   #endif
   #undef TP_CMP
 
@@ -2731,7 +2730,7 @@ void Temperature::disable_all_heaters() {
    * @param  hindex  the hotend we're referencing (if MULTI_MAX_TC)
    * @return         integer representing the board's buffer, to be converted later if needed
    */
-  int16_t Temperature::read_max_tc(TERN_(HAS_MULTI_MAX_TC, const uint8_t hindex/*=0*/)) {
+  uint16_t Temperature::read_max_tc(TERN_(HAS_MULTI_MAX_TC, const uint8_t hindex/*=0*/)) {
     #define MAXTC_HEAT_INTERVAL 250UL
 
     #if HAS_MAX31855
@@ -2750,7 +2749,7 @@ void Temperature::disable_all_heaters() {
 
     #if HAS_MULTI_MAX_TC
       // Needed to return the correct temp when this is called between readings
-      static int16_t max_tc_temp_previous[MAX_TC_COUNT] = { 0 };
+      static uint16_t max_tc_temp_previous[MAX_TC_COUNT] = { 0 };
       #define THERMO_TEMP(I) max_tc_temp_previous[I]
       #define THERMO_SEL(A,B) (hindex ? (B) : (A))
       #define MAXTC_CS_WRITE(V) do{ switch (hindex) { case 1: WRITE(TEMP_1_CS_PIN, V); break; default: WRITE(TEMP_0_CS_PIN, V); } }while(0)
@@ -2779,7 +2778,7 @@ void Temperature::disable_all_heaters() {
     // Return last-read value between readings
     millis_t ms = millis();
     if (PENDING(ms, next_max_tc_ms[hindex]))
-      return (int16_t)THERMO_TEMP(hindex);
+      return THERMO_TEMP(hindex);
 
     next_max_tc_ms[hindex] = ms + MAXTC_HEAT_INTERVAL;
 
@@ -2876,7 +2875,7 @@ void Temperature::disable_all_heaters() {
 
     THERMO_TEMP(hindex) = max_tc_temp;
 
-    return (int16_t)max_tc_temp;
+    return max_tc_temp;
   }
 
 #endif // HAS_MAX_TC
@@ -3017,7 +3016,7 @@ void Temperature::isr() {
   uint8_t pwm_count_tmp = pwm_count;
 
   #if HAS_ADC_BUTTONS
-    static unsigned int raw_ADCKey_value = 0;
+    static uint16_t raw_ADCKey_value = 0;
     static bool ADCKey_pressed = false;
   #endif
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -193,15 +193,15 @@ enum ADCSensorState : char {
 // A temperature sensor
 typedef struct TempInfo {
 private:
-  uint16_t acc;
-  uint16_t raw;
+  raw_adc_t acc;
+  raw_adc_t raw;
 public:
   celsius_float_t celsius;
   inline void reset() { acc = 0; }
-  inline void sample(const uint16_t s) { acc += s; }
+  inline void sample(const raw_adc_t s) { acc += s; }
   inline void update() { raw = acc; }
-  void setraw(const uint16_t r) { raw = r; }
-  uint16_t getraw() { return raw; }
+  void setraw(const raw_adc_t r) { raw = r; }
+  raw_adc_t getraw() { return raw; }
 } temp_info_t;
 
 #if HAS_TEMP_REDUNDANT
@@ -291,7 +291,7 @@ struct HeaterWatch {
 #endif
 
 // Temperature sensor read value ranges
-typedef struct { uint16_t raw_min, raw_max; celsius_t mintemp, maxtemp; } temp_range_t;
+typedef struct { raw_adc_t raw_min, raw_max; celsius_t mintemp, maxtemp; } temp_range_t;
 
 #define THERMISTOR_ABS_ZERO_C           -273.15f  // bbbbrrrrr cold !
 #define THERMISTOR_RESISTANCE_NOMINAL_C 25.0f     // mmmmm comfortable
@@ -494,7 +494,7 @@ class Temperature {
         static bed_watch_t watch_bed;
       #endif
       IF_DISABLED(PIDTEMPBED, static millis_t next_bed_check_ms);
-      static uint16_t mintemp_raw_BED, maxtemp_raw_BED;
+      static raw_adc_t mintemp_raw_BED, maxtemp_raw_BED;
     #endif
 
     #if HAS_HEATED_CHAMBER
@@ -502,7 +502,7 @@ class Temperature {
         static chamber_watch_t watch_chamber;
       #endif
       TERN(PIDTEMPCHAMBER,,static millis_t next_chamber_check_ms);
-      static uint16_t mintemp_raw_CHAMBER, maxtemp_raw_CHAMBER;
+      static raw_adc_t mintemp_raw_CHAMBER, maxtemp_raw_CHAMBER;
     #endif
 
     #if HAS_COOLER
@@ -510,11 +510,11 @@ class Temperature {
         static cooler_watch_t watch_cooler;
       #endif
       static millis_t next_cooler_check_ms, cooler_fan_flush_ms;
-      static uint16_t mintemp_raw_COOLER, maxtemp_raw_COOLER;
+      static raw_adc_t mintemp_raw_COOLER, maxtemp_raw_COOLER;
     #endif
 
     #if HAS_TEMP_BOARD && ENABLED(THERMAL_PROTECTION_BOARD)
-      static uint16_t mintemp_raw_BOARD, maxtemp_raw_BOARD;
+      static raw_adc_t mintemp_raw_BOARD, maxtemp_raw_BOARD;
     #endif
 
     #if MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED > 1
@@ -568,7 +568,7 @@ class Temperature {
       static user_thermistor_t user_thermistor[USER_THERMISTORS];
       static void M305_report(const uint8_t t_index, const bool forReplay=true);
       static void reset_user_thermistors();
-      static celsius_float_t user_thermistor_to_deg_c(const uint8_t t_index, const uint16_t raw);
+      static celsius_float_t user_thermistor_to_deg_c(const uint8_t t_index, const raw_adc_t raw);
       static bool set_pull_up_res(int8_t t_index, float value) {
         //if (!WITHIN(t_index, 0, USER_THERMISTORS - 1)) return false;
         if (!WITHIN(value, 1, 1000000)) return false;
@@ -596,25 +596,25 @@ class Temperature {
     #endif
 
     #if HAS_HOTEND
-      static celsius_float_t analog_to_celsius_hotend(const uint16_t raw, const uint8_t e);
+      static celsius_float_t analog_to_celsius_hotend(const raw_adc_t raw, const uint8_t e);
     #endif
     #if HAS_HEATED_BED
-      static celsius_float_t analog_to_celsius_bed(const uint16_t raw);
+      static celsius_float_t analog_to_celsius_bed(const raw_adc_t raw);
     #endif
     #if HAS_TEMP_CHAMBER
-      static celsius_float_t analog_to_celsius_chamber(const uint16_t raw);
+      static celsius_float_t analog_to_celsius_chamber(const raw_adc_t raw);
     #endif
     #if HAS_TEMP_PROBE
-      static celsius_float_t analog_to_celsius_probe(const uint16_t raw);
+      static celsius_float_t analog_to_celsius_probe(const raw_adc_t raw);
     #endif
     #if HAS_TEMP_COOLER
-      static celsius_float_t analog_to_celsius_cooler(const uint16_t raw);
+      static celsius_float_t analog_to_celsius_cooler(const raw_adc_t raw);
     #endif
     #if HAS_TEMP_BOARD
-      static celsius_float_t analog_to_celsius_board(const uint16_t raw);
+      static celsius_float_t analog_to_celsius_board(const raw_adc_t raw);
     #endif
     #if HAS_TEMP_REDUNDANT
-      static celsius_float_t analog_to_celsius_redundant(const uint16_t raw);
+      static celsius_float_t analog_to_celsius_redundant(const raw_adc_t raw);
     #endif
 
     #if HAS_FAN
@@ -709,7 +709,7 @@ class Temperature {
     }
 
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
-      static uint16_t rawHotendTemp(const uint8_t E_NAME) {
+      static raw_adc_t rawHotendTemp(const uint8_t E_NAME) {
         return TERN0(HAS_HOTEND, temp_hotend[HOTEND_INDEX].getraw());
       }
     #endif
@@ -772,7 +772,7 @@ class Temperature {
     #if HAS_HEATED_BED
 
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static uint16_t rawBedTemp()    { return temp_bed.getraw(); }
+        static raw_adc_t rawBedTemp()  { return temp_bed.getraw(); }
       #endif
       static celsius_float_t degBed()  { return temp_bed.celsius; }
       static celsius_t wholeDegBed()   { return static_cast<celsius_t>(degBed() + 0.5f); }
@@ -803,7 +803,7 @@ class Temperature {
 
     #if HAS_TEMP_PROBE
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static uint16_t rawProbeTemp()    { return temp_probe.getraw(); }
+        static raw_adc_t rawProbeTemp()  { return temp_probe.getraw(); }
       #endif
       static celsius_float_t degProbe()  { return temp_probe.celsius; }
       static celsius_t wholeDegProbe()   { return static_cast<celsius_t>(degProbe() + 0.5f); }
@@ -814,7 +814,7 @@ class Temperature {
 
     #if HAS_TEMP_CHAMBER
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static uint16_t rawChamberTemp()      { return temp_chamber.getraw(); }
+        static raw_adc_t rawChamberTemp()    { return temp_chamber.getraw(); }
       #endif
       static celsius_float_t degChamber()    { return temp_chamber.celsius; }
       static celsius_t wholeDegChamber()     { return static_cast<celsius_t>(degChamber() + 0.5f); }
@@ -837,7 +837,7 @@ class Temperature {
 
     #if HAS_TEMP_COOLER
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static uint16_t rawCoolerTemp()     { return temp_cooler.getraw(); }
+        static raw_adc_t rawCoolerTemp()   { return temp_cooler.getraw(); }
       #endif
       static celsius_float_t degCooler()   { return temp_cooler.celsius; }
       static celsius_t wholeDegCooler()    { return static_cast<celsius_t>(temp_cooler.celsius + 0.5f); }
@@ -851,7 +851,7 @@ class Temperature {
 
     #if HAS_TEMP_BOARD
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static uint16_t rawBoardTemp()    { return temp_board.getraw(); }
+        static raw_adc_t rawBoardTemp()  { return temp_board.getraw(); }
       #endif
       static celsius_float_t degBoard()  { return temp_board.celsius; }
       static celsius_t wholeDegBoard()   { return static_cast<celsius_t>(temp_board.celsius + 0.5f); }
@@ -859,7 +859,7 @@ class Temperature {
 
     #if HAS_TEMP_REDUNDANT
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static uint16_t rawRedundantTemp()         { return temp_redundant.getraw(); }
+        static raw_adc_t rawRedundantTemp()       { return temp_redundant.getraw(); }
       #endif
       static celsius_float_t degRedundant()       { return temp_redundant.celsius; }
       static celsius_float_t degRedundantTarget() { return (*temp_redundant.target).celsius; }
@@ -992,7 +992,7 @@ class Temperature {
       #else
         #define READ_MAX_TC(N) read_max_tc()
       #endif
-      static uint16_t read_max_tc(TERN_(HAS_MULTI_MAX_TC, const uint8_t hindex=0));
+      static raw_adc_t read_max_tc(TERN_(HAS_MULTI_MAX_TC, const uint8_t hindex=0));
     #endif
 
     #if HAS_AUTO_FAN

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -192,12 +192,16 @@ enum ADCSensorState : char {
 
 // A temperature sensor
 typedef struct TempInfo {
+private:
   uint16_t acc;
-  int16_t raw;
+  uint16_t raw;
+public:
   celsius_float_t celsius;
   inline void reset() { acc = 0; }
   inline void sample(const uint16_t s) { acc += s; }
   inline void update() { raw = acc; }
+  void setraw(const uint16_t r) { raw = r; }
+  uint16_t getraw() { return raw; }
 } temp_info_t;
 
 #if HAS_TEMP_REDUNDANT
@@ -287,9 +291,7 @@ struct HeaterWatch {
 #endif
 
 // Temperature sensor read value ranges
-typedef struct { int16_t raw_min, raw_max; } raw_range_t;
-typedef struct { celsius_t mintemp, maxtemp; } celsius_range_t;
-typedef struct { int16_t raw_min, raw_max; celsius_t mintemp, maxtemp; } temp_range_t;
+typedef struct { uint16_t raw_min, raw_max; celsius_t mintemp, maxtemp; } temp_range_t;
 
 #define THERMISTOR_ABS_ZERO_C           -273.15f  // bbbbrrrrr cold !
 #define THERMISTOR_RESISTANCE_NOMINAL_C 25.0f     // mmmmm comfortable
@@ -492,7 +494,7 @@ class Temperature {
         static bed_watch_t watch_bed;
       #endif
       IF_DISABLED(PIDTEMPBED, static millis_t next_bed_check_ms);
-      static int16_t mintemp_raw_BED, maxtemp_raw_BED;
+      static uint16_t mintemp_raw_BED, maxtemp_raw_BED;
     #endif
 
     #if HAS_HEATED_CHAMBER
@@ -500,7 +502,7 @@ class Temperature {
         static chamber_watch_t watch_chamber;
       #endif
       TERN(PIDTEMPCHAMBER,,static millis_t next_chamber_check_ms);
-      static int16_t mintemp_raw_CHAMBER, maxtemp_raw_CHAMBER;
+      static uint16_t mintemp_raw_CHAMBER, maxtemp_raw_CHAMBER;
     #endif
 
     #if HAS_COOLER
@@ -508,11 +510,11 @@ class Temperature {
         static cooler_watch_t watch_cooler;
       #endif
       static millis_t next_cooler_check_ms, cooler_fan_flush_ms;
-      static int16_t mintemp_raw_COOLER, maxtemp_raw_COOLER;
+      static uint16_t mintemp_raw_COOLER, maxtemp_raw_COOLER;
     #endif
 
     #if HAS_TEMP_BOARD && ENABLED(THERMAL_PROTECTION_BOARD)
-      static int16_t mintemp_raw_BOARD, maxtemp_raw_BOARD;
+      static uint16_t mintemp_raw_BOARD, maxtemp_raw_BOARD;
     #endif
 
     #if MAX_CONSECUTIVE_LOW_TEMPERATURE_ERROR_ALLOWED > 1
@@ -566,7 +568,7 @@ class Temperature {
       static user_thermistor_t user_thermistor[USER_THERMISTORS];
       static void M305_report(const uint8_t t_index, const bool forReplay=true);
       static void reset_user_thermistors();
-      static celsius_float_t user_thermistor_to_deg_c(const uint8_t t_index, const int16_t raw);
+      static celsius_float_t user_thermistor_to_deg_c(const uint8_t t_index, const uint16_t raw);
       static bool set_pull_up_res(int8_t t_index, float value) {
         //if (!WITHIN(t_index, 0, USER_THERMISTORS - 1)) return false;
         if (!WITHIN(value, 1, 1000000)) return false;
@@ -594,25 +596,25 @@ class Temperature {
     #endif
 
     #if HAS_HOTEND
-      static celsius_float_t analog_to_celsius_hotend(const int16_t raw, const uint8_t e);
+      static celsius_float_t analog_to_celsius_hotend(const uint16_t raw, const uint8_t e);
     #endif
     #if HAS_HEATED_BED
-      static celsius_float_t analog_to_celsius_bed(const int16_t raw);
+      static celsius_float_t analog_to_celsius_bed(const uint16_t raw);
     #endif
     #if HAS_TEMP_CHAMBER
-      static celsius_float_t analog_to_celsius_chamber(const int16_t raw);
+      static celsius_float_t analog_to_celsius_chamber(const uint16_t raw);
     #endif
     #if HAS_TEMP_PROBE
-      static celsius_float_t analog_to_celsius_probe(const int16_t raw);
+      static celsius_float_t analog_to_celsius_probe(const uint16_t raw);
     #endif
     #if HAS_TEMP_COOLER
-      static celsius_float_t analog_to_celsius_cooler(const int16_t raw);
+      static celsius_float_t analog_to_celsius_cooler(const uint16_t raw);
     #endif
     #if HAS_TEMP_BOARD
-      static celsius_float_t analog_to_celsius_board(const int16_t raw);
+      static celsius_float_t analog_to_celsius_board(const uint16_t raw);
     #endif
     #if HAS_TEMP_REDUNDANT
-      static celsius_float_t analog_to_celsius_redundant(const int16_t raw);
+      static celsius_float_t analog_to_celsius_redundant(const uint16_t raw);
     #endif
 
     #if HAS_FAN
@@ -991,7 +993,7 @@ class Temperature {
       #else
         #define READ_MAX_TC(N) read_max_tc()
       #endif
-      static int16_t read_max_tc(TERN_(HAS_MULTI_MAX_TC, const uint8_t hindex=0));
+      static uint16_t read_max_tc(TERN_(HAS_MULTI_MAX_TC, const uint8_t hindex=0));
     #endif
 
     #if HAS_AUTO_FAN

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -709,8 +709,8 @@ class Temperature {
     }
 
     #if ENABLED(SHOW_TEMP_ADC_VALUES)
-      static int16_t rawHotendTemp(const uint8_t E_NAME) {
-        return TERN0(HAS_HOTEND, temp_hotend[HOTEND_INDEX].raw);
+      static uint16_t rawHotendTemp(const uint8_t E_NAME) {
+        return TERN0(HAS_HOTEND, temp_hotend[HOTEND_INDEX].getraw());
       }
     #endif
 
@@ -772,7 +772,7 @@ class Temperature {
     #if HAS_HEATED_BED
 
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static int16_t rawBedTemp()    { return temp_bed.raw; }
+        static uint16_t rawBedTemp()    { return temp_bed.getraw(); }
       #endif
       static celsius_float_t degBed()  { return temp_bed.celsius; }
       static celsius_t wholeDegBed()   { return static_cast<celsius_t>(degBed() + 0.5f); }
@@ -803,7 +803,7 @@ class Temperature {
 
     #if HAS_TEMP_PROBE
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static int16_t rawProbeTemp()    { return temp_probe.raw; }
+        static uint16_t rawProbeTemp()    { return temp_probe.getraw(); }
       #endif
       static celsius_float_t degProbe()  { return temp_probe.celsius; }
       static celsius_t wholeDegProbe()   { return static_cast<celsius_t>(degProbe() + 0.5f); }
@@ -814,7 +814,7 @@ class Temperature {
 
     #if HAS_TEMP_CHAMBER
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static int16_t rawChamberTemp()      { return temp_chamber.raw; }
+        static uint16_t rawChamberTemp()      { return temp_chamber.getraw(); }
       #endif
       static celsius_float_t degChamber()    { return temp_chamber.celsius; }
       static celsius_t wholeDegChamber()     { return static_cast<celsius_t>(degChamber() + 0.5f); }
@@ -837,7 +837,7 @@ class Temperature {
 
     #if HAS_TEMP_COOLER
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static int16_t rawCoolerTemp()     { return temp_cooler.raw; }
+        static uint16_t rawCoolerTemp()     { return temp_cooler.getraw(); }
       #endif
       static celsius_float_t degCooler()   { return temp_cooler.celsius; }
       static celsius_t wholeDegCooler()    { return static_cast<celsius_t>(temp_cooler.celsius + 0.5f); }
@@ -851,7 +851,7 @@ class Temperature {
 
     #if HAS_TEMP_BOARD
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static int16_t rawBoardTemp()    { return temp_board.raw; }
+        static uint16_t rawBoardTemp()    { return temp_board.getraw(); }
       #endif
       static celsius_float_t degBoard()  { return temp_board.celsius; }
       static celsius_t wholeDegBoard()   { return static_cast<celsius_t>(temp_board.celsius + 0.5f); }
@@ -859,8 +859,7 @@ class Temperature {
 
     #if HAS_TEMP_REDUNDANT
       #if ENABLED(SHOW_TEMP_ADC_VALUES)
-        static int16_t rawRedundantTemp()         { return temp_redundant.raw; }
-        static int16_t rawRedundanTargetTemp()    { return (*temp_redundant.target).raw; }
+        static uint16_t rawRedundantTemp()         { return temp_redundant.getraw(); }
       #endif
       static celsius_float_t degRedundant()       { return temp_redundant.celsius; }
       static celsius_float_t degRedundantTarget() { return (*temp_redundant.target).celsius; }

--- a/Marlin/src/module/thermistor/thermistors.h
+++ b/Marlin/src/module/thermistor/thermistors.h
@@ -27,22 +27,20 @@
 #define THERMISTOR_TABLE_SCALE (HAL_ADC_RANGE / _BV(THERMISTOR_TABLE_ADC_RESOLUTION))
 #if ENABLED(HAL_ADC_FILTERED)
   #define OVERSAMPLENR 1
-#elif HAL_ADC_RESOLUTION > 10
-  #define OVERSAMPLENR (20 - HAL_ADC_RESOLUTION)
 #else
   #define OVERSAMPLENR 16
 #endif
-#define MAX_RAW_THERMISTOR_VALUE (HAL_ADC_RANGE * (OVERSAMPLENR) - 1)
 
-// Currently Marlin stores all oversampled ADC values as int16_t, make sure the HAL settings do not overflow 15bit
-#if MAX_RAW_THERMISTOR_VALUE > ((1 << 15) - 1)
-  #error "MAX_RAW_THERMISTOR_VALUE is too large for int16_t. Reduce OVERSAMPLENR or HAL_ADC_RESOLUTION."
+// Currently Marlin stores all oversampled ADC values as uint16_t, make sure the HAL settings do not overflow 16 bit
+#if (HAL_ADC_RANGE) * (OVERSAMPLENR) > 1 << 16
+  #error "MAX_RAW_THERMISTOR_VALUE is too large for uint16_t. Reduce OVERSAMPLENR or HAL_ADC_RESOLUTION."
 #endif
+#define MAX_RAW_THERMISTOR_VALUE (uint16_t(HAL_ADC_RANGE) * (OVERSAMPLENR) - 1)
 
-#define OV_SCALE(N) (N)
-#define OV(N) int16_t(OV_SCALE(N) * (OVERSAMPLENR) * (THERMISTOR_TABLE_SCALE))
+#define OV_SCALE(N) float(N)
+#define OV(N) uint16_t(OV_SCALE(N) * (OVERSAMPLENR) * (THERMISTOR_TABLE_SCALE))
 
-typedef struct { int16_t value; celsius_t celsius; } temp_entry_t;
+typedef struct { uint16_t value; celsius_t celsius; } temp_entry_t;
 
 // Pt1000 and Pt100 handling
 //

--- a/Marlin/src/module/thermistor/thermistors.h
+++ b/Marlin/src/module/thermistor/thermistors.h
@@ -38,9 +38,9 @@
 #define MAX_RAW_THERMISTOR_VALUE (uint16_t(HAL_ADC_RANGE) * (OVERSAMPLENR) - 1)
 
 #define OV_SCALE(N) float(N)
-#define OV(N) uint16_t(OV_SCALE(N) * (OVERSAMPLENR) * (THERMISTOR_TABLE_SCALE))
+#define OV(N) raw_adc_t(OV_SCALE(N) * (OVERSAMPLENR) * (THERMISTOR_TABLE_SCALE))
 
-typedef struct { uint16_t value; celsius_t celsius; } temp_entry_t;
+typedef struct { raw_adc_t value; celsius_t celsius; } temp_entry_t;
 
 // Pt1000 and Pt100 handling
 //


### PR DESCRIPTION
### Description

This is a fix for #22893. The presenting problem is noisy ADC which began with the change to 12 bit ADC for 32 bit mainboards. The reason for the extra noise is that OVERSAMPLENR was reduced to 8 (from 16) for 12 bit ADC so that the accumulated ADC readings could still fit within a signed 16 bit integer. (Discussion [here](https://github.com/MarlinFirmware/Marlin/pull/20519#pullrequestreview-556221282)).

The actual code is wrong anyway and should look like this:
```
#elif HAL_ADC_RESOLUTION > 11
#define OVERSAMPLENR (1 << (15 - HAL_ADC_RESOLUTION))
```

However since it was a workaround anyway, this PR removes the workaround and increases the 15 bit limit to 16 bits by changing all the related variables, constants and calculations to use `uint16_t`.

Extending to a 32 bit accumulator for 32 bit boards would also be a good idea.

### Requirements

32 bit STM boards.

### Benefits

Restores ADC noise levels to pre 2.0.9.2 levels.

### Configurations

Any config with temperature sensors.

Could also do with testing with joystick:
`#define JOYSTICK`

And ADC buttons:
`#define ZONESTAR_LCD`

And the range of different temperature sensors.

### Related Issues

#22893
