### PR TITLE
Restore 12 bit ADC to STM32 and STM32F1

### DIFF
--- a/Marlin/src/HAL/STM32F1/HAL.cpp
+++ b/Marlin/src/HAL/STM32F1/HAL.cpp
@@ -335,7 +335,7 @@ void MarlinHAL::adc_start(const pin_t pin) {
     _TCASE(POWER_MONITOR_CURRENT, POWER_MONITOR_CURRENT_PIN, POWERMON_CURRENT)
     _TCASE(POWER_MONITOR_VOLTAGE, POWER_MONITOR_VOLTAGE_PIN, POWERMON_VOLTS)
   }
-  adc_result = adc_results[(int)pin_index] >> (12 - HAL_ADC_RESOLUTION); // shift out unused bits
+  adc_result = (adc_results[(int)pin_index] & 0xFFF) >> (12 - HAL_ADC_RESOLUTION); // shift out unused bits
 }
 
 #endif // __STM32F1__

--- a/ini/stm32-common.ini
+++ b/ini/stm32-common.ini
@@ -16,6 +16,7 @@ build_flags      = ${common.build_flags}
                    -std=gnu++14 -DHAL_STM32
                    -DUSBCON -DUSBD_USE_CDC
                    -DTIM_IRQ_PRIO=13
+                   -DADC_RESOLUTION=12
 build_unflags    = -std=gnu++11
 src_filter       = ${common.default_src_filter} +<src/HAL/STM32> +<src/HAL/shared/backtrace>
 extra_scripts    = ${common.extra_scripts}

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -30,7 +30,6 @@ board                       = marlin_STM32G0B1RE
 board_build.offset          = 0x2000
 board_upload.offset_address = 0x08002000
 build_flags                 = ${stm32_variant.build_flags}
-                            -DADC_RESOLUTION=12
                             -DPIN_SERIAL4_RX=PC_11 -DPIN_SERIAL4_TX=PC_10
                             -DSERIAL_RX_BUFFER_SIZE=1024 -DSERIAL_TX_BUFFER_SIZE=1024
                             -DTIMER_SERVO=TIM3 -DTIMER_TONE=TIM4


### PR DESCRIPTION
### Description
#22789 inadvertently returned almost all STM32 and STM32F1 boards to 10 bit ADC. It was intended to make 12 bit the default unless `ADC_RESOLUTION` was defined, in which case that value would be used. However `framework-arduinoststm32/cores/arduino/pins_arduino.h` has

`#define ADC_RESOLUTION 10`

Which turned the logic on its head. Now all boards get 10 bit unless explicitly overridden (and the only board with an override is `BTT_SKR_MINI_E3_V3_0`). See https://github.com/MarlinFirmware/Marlin/issues/22893#issuecomment-1062019993.

This PR resolves the problem by setting `-DADC_RESOLUTION=12` in `stm32-common.ini`.

Also since the changes to 12 bit, #22893 reports spurious ADC values sporadically being returned. At least some of this may be caused by the removal of a 12 bit bitmask as discussed in #22798. In that discussion there was uncertainty about whether the upper 4 bits of 16 bit ADC buffer variable might contain junk. In the end the bitmask was removed but I think #22893 may indicate that it would be better to keep it in. It costs almost nothing for the processor to apply so this PR puts it back.

### Requirements

All STM32 boards.

### Benefits

Higher resolution ADC. Possibly lower noise.

### Configurations

[config.zip](https://github.com/MarlinFirmware/Marlin/files/8209685/config.zip)
[config_maple.zip](https://github.com/MarlinFirmware/Marlin/files/8209686/config_maple.zip)

### Related Issues

#22893
