### PR TITLE
Support DIGIPOT circuit designs using different values of Rsense and Vrefmax

### DIFF
--- a/Marlin/src/feature/digipot/digipot_mcp4018.cpp
+++ b/Marlin/src/feature/digipot/digipot_mcp4018.cpp
@@ -31,9 +31,13 @@
 
 // Settings for the I2C based DIGIPOT (MCP4018) based on WT150
 
-#define DIGIPOT_A4988_Rsx               0.250
-#define DIGIPOT_A4988_Vrefmax           1.666
-#define DIGIPOT_MCP4018_MAX_VALUE     127
+#ifndef DIGIPOT_A4988_Rsx
+  #define DIGIPOT_A4988_Rsx             0.250
+#endif
+#ifndef DIGIPOT_A4988_Vrefmax
+  #define DIGIPOT_A4988_Vrefmax         1.666
+#endif
+#define DIGIPOT_MCP4018_MAX_VALUE       127
 
 #define DIGIPOT_A4988_Itripmax(Vref)    ((Vref) / (8.0 * DIGIPOT_A4988_Rsx))
 


### PR DESCRIPTION
### Description

Change allows for DIGIPOT circuit designs using values of Rsense and Vrefmax other than 0.25 ohms and 1.666 v. The change allows the respective values to be set in the printer configuration file. 

### Requirements

None

### Benefits

Allows printers that use a non "standard" DIGIPOT circuit design to be configured correctly. An example would be the FlashForge line of printers which use an Rsense of 0.270 ohms and Vrefmax of 2.3v.

### Configurations

-

### Related Issues

-