### PR TITLE
fix g29, broken in commit 48b5362cf02ff12c9e9fc4d5825ceebe457ea34b

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -721,7 +721,7 @@ G29_TYPE GcodeSuite::G29() {
 
     #endif // AUTO_BED_LEVELING_3POINT
 
-    ui.reset_status();
+    TERN_(HAS_STATUS_MESSAGE, ui.reset_status());
 
     // Stow the probe. No raise for FIX_MOUNTED_PROBE.
     if (probe.stow()) {


### PR DESCRIPTION
### Description

Commit 48b5362cf02ff12c9e9fc4d5825ceebe457ea34b broke CI tests "[Test DUE] RADDS with ABL (Bilinear), Triple Z Axis, Z_STEPPER_AUTO_ALIGN, E_DUAL_STEPPER_DRIVERS..."
TERN_(HAS_STATUS_MESSAGE, ui.reset_status()); was reverted to ui.reset_status() wich fails when there is no HAS_STATUS_MESSAGE

### Benefits

CI will run again, 
G29 works with HAS_STATUS_MESSAGE again

### Related Issues
https://github.com/MarlinFirmware/Marlin/commit/48b5362cf02ff12c9e9fc4d5825ceebe457ea34b#commitcomment-68446277
