### PR TITLE
Fix wrong ADC Vref divisor for MKS TinyBee

### DIFF
--- a/Marlin/src/HAL/ESP32/HAL.cpp
+++ b/Marlin/src/HAL/ESP32/HAL.cpp
@@ -233,7 +233,11 @@ void MarlinHAL::adc_start(const pin_t pin) {
   const adc1_channel_t chan = get_channel(pin);
   uint32_t mv;
   esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
-  adc_result = mv * 1023.0 / 3300.0;
+  #if MB(MKS_TINYBEE)
+    adc_result = mv * 1023.0 / 2500.0; // mod for MKS Tinybee with 2.5v reference VDDA
+  #else
+    adc_result = mv * 1023.0 / 3300.0; // mod for MKS Tinybee with 2.5v reference VDDA
+  #endif
 
   // Change the attenuation level based on the new reading
   adc_atten_t atten;

--- a/Marlin/src/HAL/ESP32/HAL.cpp
+++ b/Marlin/src/HAL/ESP32/HAL.cpp
@@ -229,15 +229,15 @@ void MarlinHAL::adc_init() {
   }
 }
 
+#ifndef ADC_REFERENCE_VOLTAGE
+  #define ADC_REFERENCE_VOLTAGE 3.3
+#endif
+
 void MarlinHAL::adc_start(const pin_t pin) {
   const adc1_channel_t chan = get_channel(pin);
   uint32_t mv;
   esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
-  #if MB(MKS_TINYBEE)
-    adc_result = mv * 1023.0 / 2500.0; // for MKS Tinybee with 2.5v reference VDDA
-  #else
-    adc_result = mv * 1023.0 / 3300.0;
-  #endif
+  adc_result = mv * 1023.0f / float(ADC_REFERENCE_VOLTAGE) / 1000.0f;
 
   // Change the attenuation level based on the new reading
   adc_atten_t atten;

--- a/Marlin/src/HAL/ESP32/HAL.cpp
+++ b/Marlin/src/HAL/ESP32/HAL.cpp
@@ -234,9 +234,9 @@ void MarlinHAL::adc_start(const pin_t pin) {
   uint32_t mv;
   esp_adc_cal_get_voltage((adc_channel_t)chan, &characteristics[attenuations[chan]], &mv);
   #if MB(MKS_TINYBEE)
-    adc_result = mv * 1023.0 / 2500.0; // mod for MKS Tinybee with 2.5v reference VDDA
+    adc_result = mv * 1023.0 / 2500.0; // for MKS Tinybee with 2.5v reference VDDA
   #else
-    adc_result = mv * 1023.0 / 3300.0; // mod for MKS Tinybee with 2.5v reference VDDA
+    adc_result = mv * 1023.0 / 3300.0;
   #endif
 
   // Change the attenuation level based on the new reading

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -114,6 +114,11 @@
 //#define E1_AUTO_FAN_PIN                    149  // need to update Configuration_adv.h @section extruder
 
 //
+// ADC Reference Voltage
+//
+#define ADC_REFERENCE_VOLTAGE                2.5  // 2.5V reference VDDA
+
+//
 // MicroSD card
 //
 #define SD_MOSI_PIN                           23


### PR DESCRIPTION
### Description

Fixes ADC voltage divisor for MKS TinyBee (ESP32 based) to correct thermistor temperature readings.

TinyBee appears (no parts list available AFAIK) to use a 2.5V Zener diode as the thermistor VDDA reference (most ESP32 boards use 3.3V).

See https://github.com/makerbase-mks/MKS-TinyBee/issues/7#issue-1123403716 
 Note that the MKS  Marlin TinyBee firmware (https://github.com/makerbase-mks/MKS-TinyBee/blob/main/firmware/mks%20tinybee%20marlin/Marlin/src/HAL/ESP32/HAL.cpp) uses 2600.0 as the divisor but the measured voltage on boards appears to be 2.5V.