### PR TITLE
Remove date check from StaleBot

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -22,7 +22,7 @@ jobs:
         github-token: ${{ github.token }}
         process-only: 'issues'
         issue-lock-inactive-days: '60'
-        issue-exclude-created-before: '2017-07-01T00:00:00Z'
+        issue-exclude-created-before: ''
         issue-exclude-labels: 'no-locking'
         issue-lock-labels: ''
         issue-lock-comment: >


### PR DESCRIPTION
### Description

There was a GitHub bug preventing closed issues older than 2017 from being locked, but that seems to have been fixed (thanks to @Roxy-3D for verifying!)

### Benefits

Issues older than 2017 can now be locked.