### PR TITLE
Support new board PandaPi V2.9

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -364,7 +364,8 @@
 #define BOARD_ZONESTAR_ZM3E4          4061  // Zonestar ZM3E4 V1 (STM32F103VC)
 #define BOARD_ZONESTAR_ZM3E4V2        4062  // Zonestar ZM3E4 V2 (STM32F103VC)
 #define BOARD_ERYONE_ERY32_MINI       4063  // Eryone Ery32 mini (STM32F103VE)
-#define BOARD_PANDA_PI_V29            4064 // PANDA PI V29 stand alone mode (STM32F103RC  )
+#define BOARD_PANDA_PI_V29            4064  // Panda Pi V2.9 - Standalone (STM32F103RC)
+
 //
 // ARM Cortex-M4F
 //

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -364,7 +364,7 @@
 #define BOARD_ZONESTAR_ZM3E4          4061  // Zonestar ZM3E4 V1 (STM32F103VC)
 #define BOARD_ZONESTAR_ZM3E4V2        4062  // Zonestar ZM3E4 V2 (STM32F103VC)
 #define BOARD_ERYONE_ERY32_MINI       4063  // Eryone Ery32 mini (STM32F103VE)
-
+#define BOARD_PANDA_PI_V29            4064 // PANDA PI V29 stand alone mode (STM32F103RC  )
 //
 // ARM Cortex-M4F
 //

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -601,6 +601,8 @@
   #include "stm32f1/pins_ZM3E4_V2_0.h"          // STM32F1                                env:STM32F103VE_ZM3E4V2_USB env:STM32F103VE_ZM3E4V2_USB_maple
 #elif MB(ERYONE_ERY32_MINI)
   #include "stm32f1/pins_ERYONE_ERY32_MINI.h"   // STM32F103VET6                          env:ERYONE_ERY32_MINI_maple
+#elif MB(PANDA_PI_V29)
+  #include "stm32f1/pins_PANDA_PI_V29.h"        // STM32F103RCT6 PANDA_PI_V2.9 for stand alone mode   env:PANDA_PI_V29
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -602,7 +602,7 @@
 #elif MB(ERYONE_ERY32_MINI)
   #include "stm32f1/pins_ERYONE_ERY32_MINI.h"   // STM32F103VET6                          env:ERYONE_ERY32_MINI_maple
 #elif MB(PANDA_PI_V29)
-  #include "stm32f1/pins_PANDA_PI_V29.h"        // STM32F103RCT6 PANDA_PI_V2.9 for stand alone mode   env:PANDA_PI_V29
+  #include "stm32f1/pins_PANDA_PI_V29.h"        // STM32F103RCT6                          env:PANDA_PI_V29
 
 //
 // ARM Cortex-M4F

--- a/Marlin/src/pins/stm32f1/pins_PANDA_PI_V29.h
+++ b/Marlin/src/pins/stm32f1/pins_PANDA_PI_V29.h
@@ -1,0 +1,222 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#include "env_validate.h"
+ 
+#define BOARD_INFO_NAME "PANDA PI V2.9"
+
+// Release PB3/PB4 (TMC_SW Pins) from JTAG pins
+#define DISABLE_JTAG
+
+// Ignore temp readings during development.
+//#define BOGUS_TEMPERATURE_GRACE_PERIOD    2000
+
+#if EITHER(NO_EEPROM_SELECTED, FLASH_EEPROM_EMULATION)
+  #define FLASH_EEPROM_EMULATION
+  #define EEPROM_PAGE_SIZE     (0x800U)           // 2KB
+  #define EEPROM_START_ADDRESS (0x8000000UL + (STM32_FLASH_SIZE) * 1024UL - (EEPROM_PAGE_SIZE) * 2UL)
+  #define MARLIN_EEPROM_SIZE    EEPROM_PAGE_SIZE  // 2KB
+#endif
+
+//
+// Servos
+//
+#define SERVO0_PIN                          PA11   // SERVOS
+
+//
+// Limit Switches
+//
+#define X_STOP_PIN                          PA3   // X-STOP
+#define Y_STOP_PIN                          PC9   // Y-STOP
+#define Z_STOP_PIN                          PA1  // Z-STOP
+
+//
+// Z Probe must be this pin
+//
+//#define Z_MIN_PROBE_PIN                     PA1  // PROBE
+
+//
+// Filament Runout Sensor
+//
+//#ifndef FIL_RUNOUT_PIN
+ // #define FIL_RUNOUT_PIN                    PC2   // E0-STOP
+//#endif
+
+//
+// Steppers
+//
+#define X_ENABLE_PIN                        PC12
+#define X_STEP_PIN                          PC11
+#define X_DIR_PIN                           PB6
+
+
+#define Y_ENABLE_PIN                        PC12
+#define Y_STEP_PIN                          PB5
+#define Y_DIR_PIN                           PB4
+
+
+#define Z_ENABLE_PIN                        PC12
+#define Z_STEP_PIN                          PB3
+#define Z_DIR_PIN                           PA15
+
+
+#define E0_ENABLE_PIN                       PC12
+#define E0_STEP_PIN                         PB15
+#define E0_DIR_PIN                          PB14
+
+
+//
+// Software SPI pins for TMC2130 stepper drivers
+//
+#if ENABLED(TMC_USE_SW_SPI)
+  #ifndef TMC_SW_MOSI
+    #define TMC_SW_MOSI                     PB5
+  #endif
+  #ifndef TMC_SW_MISO
+    #define TMC_SW_MISO                     PB4
+  #endif
+  #ifndef TMC_SW_SCK
+    #define TMC_SW_SCK                      PB3
+  #endif
+#endif
+
+#if HAS_TMC_UART
+  /**
+   * TMC2208/TMC2209 stepper drivers
+   *
+   * Hardware serial communication ports.
+   * If undefined software serial is used according to the pins below
+   */
+  //#define X_HARDWARE_SERIAL  MSerial1
+  //#define Y_HARDWARE_SERIAL  MSerial1
+  //#define Z_HARDWARE_SERIAL  MSerial1
+  //#define E0_HARDWARE_SERIAL MSerial1
+
+  #define X_SERIAL_TX_PIN                   PC10
+  #define X_SERIAL_RX_PIN        X_SERIAL_TX_PIN
+
+  #define Y_SERIAL_TX_PIN                   PC11
+  #define Y_SERIAL_RX_PIN        Y_SERIAL_TX_PIN
+
+  #define Z_SERIAL_TX_PIN                   PC12
+  #define Z_SERIAL_RX_PIN        Z_SERIAL_TX_PIN
+
+  #define E0_SERIAL_TX_PIN                  PD2
+  #define E0_SERIAL_RX_PIN      E0_SERIAL_TX_PIN
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE                    19200
+#endif
+
+//
+// Temperature Sensors
+//
+#define TEMP_0_PIN                          PB0   // Analog Input "TH0"
+#define TEMP_BED_PIN                        PB1  // Analog Input "TB0"
+#define TEMP_1_PIN                          PA2
+//
+// Heaters / Fans
+//
+#define HEATER_0_PIN                        PB12   // "HE"
+#define HEATER_BED_PIN                      PB13   // "HB"
+#define FAN_PIN                             PA8   // "FAN0"
+#define HEATER_1_PIN                        PA12
+//
+
+
+    #define BEEPER_PIN                      PC3
+
+    #define BTN_ENC                         PA0
+    #define BTN_EN1                         PC4
+    #define BTN_EN2                         PC5
+
+    #define LCD_PINS_RS                     PC0
+    #define LCD_PINS_ENABLE                 PC2
+    #define LCD_PINS_D4                     PC1
+
+
+
+#if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
+
+  #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_E3_DIP.h' for details. Comment out this line to continue."
+
+  /** FYSETC TFT TFT81050 display pinout
+   *
+   *               Board                                     Display
+   *               -----                                      -----
+   *           5V | 1 2 | GND               (SPI1-MISO) MISO | 1 2 | SCK   (SPI1-SCK)
+   * (FREE)   PB7 | 3 4 | PB8  (LCD_CS)     (PA9)  MOD_RESET | 3 4 | SD_CS (PA10)
+   * (FREE)   PB9 | 5 6   PA10 (SD_CS)      (PB8)     LCD_CS | 5 6   MOSI  (SPI1-MOSI)
+   *        RESET | 7 8 | PA9  (MOD_RESET)  (PA15)    SD_DET | 7 8 | RESET
+   * (BEEPER) PB6 | 9 10| PA15 (SD_DET)                  GND | 9 10| 5V
+   *               -----                                      -----
+   *                EXP1                                       EXP1
+   *
+   * Needs custom cable:
+   *
+   *    Board   Adapter   Display
+   *           _________
+   *   EXP1-1 ----------- EXP1-10
+   *   EXP1-2 ----------- EXP1-9
+   *   SPI1-4 ----------- EXP1-6
+   *   EXP1-4 ----------- EXP1-5
+   *   SP11-3 ----------- EXP1-2
+   *   EXP1-6 ----------- EXP1-4
+   *   EXP1-7 ----------- EXP1-8
+   *   EXP1-8 ----------- EXP1-3
+   *   SPI1-1 ----------- EXP1-1
+   *  EXP1-10 ----------- EXP1-7
+   */
+
+  #define CLCD_SPI_BUS                         1  // SPI1 connector
+
+  #define BEEPER_PIN                        PB6
+
+  #define CLCD_MOD_RESET                    PA9
+  #define CLCD_SPI_CS                       PB8
+
+#endif // TOUCH_UI_FTDI_EVE && LCD_FYSETC_TFT81050
+
+//
+// SD Support
+//
+
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION              ONBOARD
+#endif
+
+#if SD_CONNECTION_IS(ONBOARD)
+ // #define SD_DETECT_PIN                     PA4
+  #define SD_SCK_PIN                        PA5
+  #define SD_MISO_PIN                       PA6
+  #define SD_MOSI_PIN                       PA7
+#elif SD_CONNECTION_IS(LCD) && BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
+  #define SD_DETECT_PIN                     PA15
+  #define SD_SS_PIN                         PA10
+#elif SD_CONNECTION_IS(CUSTOM_CABLE)
+  #error "SD CUSTOM_CABLE is not compatible with SKR E3 DIP."
+#endif
+
+#define ONBOARD_SPI_DEVICE                     1  // SPI1
+#define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
+#define SDSS                   ONBOARD_SD_CS_PIN

--- a/Marlin/src/pins/stm32f1/pins_PANDA_PI_V29.h
+++ b/Marlin/src/pins/stm32f1/pins_PANDA_PI_V29.h
@@ -1,6 +1,6 @@
 /**
  * Marlin 3D Printer Firmware
- * Copyright (c) 2020 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
  *
  * Based on Sprinter and grbl.
  * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
@@ -41,25 +41,25 @@
 //
 // Servos
 //
-#define SERVO0_PIN                          PA11   // SERVOS
+#define SERVO0_PIN                          PA11  // SERVOS
 
 //
 // Limit Switches
 //
 #define X_STOP_PIN                          PA3   // X-STOP
 #define Y_STOP_PIN                          PC9   // Y-STOP
-#define Z_STOP_PIN                          PA1  // Z-STOP
+#define Z_STOP_PIN                          PA1   // Z-STOP
 
 //
 // Z Probe must be this pin
 //
-//#define Z_MIN_PROBE_PIN                     PA1  // PROBE
+//#define Z_MIN_PROBE_PIN                   PA1   // PROBE
 
 //
 // Filament Runout Sensor
 //
 //#ifndef FIL_RUNOUT_PIN
- // #define FIL_RUNOUT_PIN                    PC2   // E0-STOP
+//  #define FIL_RUNOUT_PIN                  PC2   // E0-STOP
 //#endif
 
 //
@@ -69,21 +69,17 @@
 #define X_STEP_PIN                          PC11
 #define X_DIR_PIN                           PB6
 
-
 #define Y_ENABLE_PIN                        PC12
 #define Y_STEP_PIN                          PB5
 #define Y_DIR_PIN                           PB4
-
 
 #define Z_ENABLE_PIN                        PC12
 #define Z_STEP_PIN                          PB3
 #define Z_DIR_PIN                           PA15
 
-
 #define E0_ENABLE_PIN                       PC12
 #define E0_STEP_PIN                         PB15
 #define E0_DIR_PIN                          PB14
-
 
 //
 // Software SPI pins for TMC2130 stepper drivers
@@ -132,29 +128,48 @@
 // Temperature Sensors
 //
 #define TEMP_0_PIN                          PB0   // Analog Input "TH0"
-#define TEMP_BED_PIN                        PB1  // Analog Input "TB0"
+#define TEMP_BED_PIN                        PB1   // Analog Input "TB0"
 #define TEMP_1_PIN                          PA2
+
 //
 // Heaters / Fans
 //
-#define HEATER_0_PIN                        PB12   // "HE"
-#define HEATER_BED_PIN                      PB13   // "HB"
+#define HEATER_0_PIN                        PB12  // "HE"
+#define HEATER_BED_PIN                      PB13  // "HB"
 #define FAN_PIN                             PA8   // "FAN0"
 #define HEATER_1_PIN                        PA12
+
 //
+// SD Support
+//
+#define ONBOARD_SPI_DEVICE                     1  // SPI1
+#define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
+#define SDSS                   ONBOARD_SD_CS_PIN
 
+#ifndef SDCARD_CONNECTION
+  #define SDCARD_CONNECTION              ONBOARD
+#endif
+#if SD_CONNECTION_IS(ONBOARD)
+  //#define SD_DETECT_PIN                   PA4
+  #define SD_SCK_PIN                        PA5
+  #define SD_MISO_PIN                       PA6
+  #define SD_MOSI_PIN                       PA7
+#elif SD_CONNECTION_IS(CUSTOM_CABLE)
+  #error "SD CUSTOM_CABLE is not compatible with SKR E3 DIP."
+#endif
 
-    #define BEEPER_PIN                      PC3
+//
+// LCD / Controller
+//
+#if HAS_WIRED_LCD
+  #define BTN_ENC                           PA0
+  #define BTN_EN1                           PC4
+  #define BTN_EN2                           PC5
 
-    #define BTN_ENC                         PA0
-    #define BTN_EN1                         PC4
-    #define BTN_EN2                         PC5
-
-    #define LCD_PINS_RS                     PC0
-    #define LCD_PINS_ENABLE                 PC2
-    #define LCD_PINS_D4                     PC1
-
-
+  #define LCD_PINS_RS                       PC0
+  #define LCD_PINS_ENABLE                   PC2
+  #define LCD_PINS_D4                       PC1
+#endif
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
 
@@ -195,28 +210,13 @@
   #define CLCD_MOD_RESET                    PA9
   #define CLCD_SPI_CS                       PB8
 
-#endif // TOUCH_UI_FTDI_EVE && LCD_FYSETC_TFT81050
+  #if SD_CONNECTION_IS(LCD) && BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
+    #define SD_DETECT_PIN                   PA15
+    #define SD_SS_PIN                       PA10
+  #endif
 
-//
-// SD Support
-//
+#elif HAS_WIRED_LCD
 
-#ifndef SDCARD_CONNECTION
-  #define SDCARD_CONNECTION              ONBOARD
+  #define BEEPER_PIN                        PC3
+
 #endif
-
-#if SD_CONNECTION_IS(ONBOARD)
- // #define SD_DETECT_PIN                     PA4
-  #define SD_SCK_PIN                        PA5
-  #define SD_MISO_PIN                       PA6
-  #define SD_MOSI_PIN                       PA7
-#elif SD_CONNECTION_IS(LCD) && BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
-  #define SD_DETECT_PIN                     PA15
-  #define SD_SS_PIN                         PA10
-#elif SD_CONNECTION_IS(CUSTOM_CABLE)
-  #error "SD CUSTOM_CABLE is not compatible with SKR E3 DIP."
-#endif
-
-#define ONBOARD_SPI_DEVICE                     1  // SPI1
-#define ONBOARD_SD_CS_PIN                   PA4   // Chip select for "System" SD card
-#define SDSS                   ONBOARD_SD_CS_PIN

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -63,6 +63,13 @@ build_flags                 = ${common_STM32F103RC_variant.build_flags}
 board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
 
+[env:PANDA_PI_V29]
+platform                    = ${common_stm32.platform}
+extends                     = common_STM32F103RC_variant
+build_flags                 = ${common_STM32F103RC_variant.build_flags}
+                              -DTIMER_SERVO=TIM1
+board_build.offset          = 0x5000
+board_upload.offset_address = 0x08005000
 [env:STM32F103RC_btt_USB]
 extends           = env:STM32F103RC_btt
 platform_packages = ${stm_flash_drive.platform_packages}

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -63,13 +63,6 @@ build_flags                 = ${common_STM32F103RC_variant.build_flags}
 board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
 
-[env:PANDA_PI_V29]
-platform                    = ${common_stm32.platform}
-extends                     = common_STM32F103RC_variant
-build_flags                 = ${common_STM32F103RC_variant.build_flags}
-                              -DTIMER_SERVO=TIM1
-board_build.offset          = 0x5000
-board_upload.offset_address = 0x08005000
 [env:STM32F103RC_btt_USB]
 extends           = env:STM32F103RC_btt
 platform_packages = ${stm_flash_drive.platform_packages}
@@ -79,6 +72,17 @@ build_flags       = ${env:STM32F103RC_btt.build_flags}
                     -DUSBD_IRQ_SUBPRIO=6
                     -DUSBD_USE_CDC_MSC
 build_unflags     = ${common_stm32.build_unflags} -DUSBD_USE_CDC
+
+#
+# Panda Pi V2.9 - Standalone (STM32F103RC)
+# Headless, without direct Pi control, but potentially hosting OctoPrint, stepdaemon, etc.
+#
+[env:PANDA_PI_V29]
+extends                     = common_STM32F103RC_variant
+build_flags                 = ${common_STM32F103RC_variant.build_flags}
+                              -DTIMER_SERVO=TIM1
+board_build.offset          = 0x5000
+board_upload.offset_address = 0x08005000
 
 #
 # MKS Robin (STM32F103ZET6)


### PR DESCRIPTION
Support new stm32f1 board PandaPi V2.9

Modified 4 files:
boards.h
pins.h
stm32f1.ini
add pin file pins_PANDA_PI_V29.h for stm32f1

### Description

Support new stm32f103rct6 3D printer main board PandaPi V2.9.
we can run marlin on pandapi V2.9 with standalone mode which works without raspberry pi like normal stm32f103 main board.
more document and details: 
https://www.pandapi3d.com/product-page/pandapi-2-8 
or 
https://github.com/markniu/PandaPi

### Requirements

PandaPi Version 2.9 board


### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/8262683/Configuration.zip)

