### PR TITLE
fix xatc eeprom settings

### DIFF
--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -277,7 +277,9 @@ typedef struct SettingsDataStruct {
   // X_AXIS_TWIST_COMPENSATION
   //
   #if ENABLED(X_AXIS_TWIST_COMPENSATION)
-    XATC xatc;                                          // M423 X Z
+    float xatc_spacing;                                 // M423 X Z
+    float xatc_start;
+    xatc_array_t xatc_z_offset;
   #endif
 
   //
@@ -900,7 +902,7 @@ void MarlinSettings::postprocess() {
     // X Axis Twist Compensation
     //
     #if ENABLED(X_AXIS_TWIST_COMPENSATION)
-      _FIELD_TEST(xatc);
+      _FIELD_TEST(xatc_spacing);
       EEPROM_WRITE(xatc.spacing);
       EEPROM_WRITE(xatc.start);
       EEPROM_WRITE(xatc.z_offset);
@@ -1811,7 +1813,7 @@ void MarlinSettings::postprocess() {
       // X Axis Twist Compensation
       //
       #if ENABLED(X_AXIS_TWIST_COMPENSATION)
-        _FIELD_TEST(xatc);
+        _FIELD_TEST(xatc_spacing);
         EEPROM_READ(xatc.spacing);
         EEPROM_READ(xatc.start);
         EEPROM_READ(xatc.z_offset);


### PR DESCRIPTION
### Description

X_AXIS_TWIST_COMPENSATION incorrectly allocates space in SettingsDataStruct resulting in errors when writing data to eeprom 

### Requirements

X_AXIS_TWIST_COMPENSATION and EEPROM_SETTINGS

### Benefits

Simple things like M502 then M500 don't error 

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/23910
https://github.com/MarlinFirmware/Marlin/issues/23744#issuecomment-1069310196