### PR TITLE
Add support for EMI noise filter for button state

### DIFF
--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -694,7 +694,7 @@ public:
        */
 
       static bool hw_button_pressed() {
-        for(auto sample=0;sample<EMI_NOISE_FILTER_SAMPLES;sample++) {
+        for(uint8_t sample=0;sample<EMI_NOISE_FILTER_SAMPLES;sample++) {
           if(!BUTTON_CLICK()) { return false;}
           safe_delay(1);
         }

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -685,18 +685,24 @@ public:
       #ifndef EMI_NOISE_FILTER_SAMPLES
         #define EMI_NOISE_FILTER_SAMPLES (10)
       #endif
+
       /*
          Some printers may have issues with EMI noise especially using a motherboard with 3.3V logic levels
          it may cause the logical LOW to float into the undefined region and register as a logical HIGH
          causing it to errorenously register as if someone clicked the button and in worst case make the printer
          unusable in practice.
        */
-      static bool button_pressed() {
+
+      static bool hw_button_pressed() {
         for(auto sample=0;sample<EMI_NOISE_FILTER_SAMPLES;sample++) {
           if(!BUTTON_CLICK()) { return false;}
           safe_delay(1);
         }
-        return TERN(TOUCH_SCREEN, touch_pressed(), false) || true;
+        return true;
+      }
+      
+      static bool button_pressed() {
+        return hw_button_pressed() || TERN(TOUCH_SCREEN, touch_pressed(), false);
       }
     #else
       static bool button_pressed() { return BUTTON_CLICK() || TERN(TOUCH_SCREEN, touch_pressed(), false); }

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -681,32 +681,29 @@ public:
 
     static void update_buttons();
 
-    #ifdef HAS_ENCODER_EMI_NOISE_PROBLEM
-      #ifndef EMI_NOISE_FILTER_SAMPLES
-        #define EMI_NOISE_FILTER_SAMPLES (10)
+    #if HAS_ENCODER_NOISE
+      #ifndef ENCODER_SAMPLES
+        #define ENCODER_SAMPLES 10
       #endif
 
-      /*
-         Some printers may have issues with EMI noise especially using a motherboard with 3.3V logic levels
-         it may cause the logical LOW to float into the undefined region and register as a logical HIGH
-         causing it to errorenously register as if someone clicked the button and in worst case make the printer
-         unusable in practice.
+      /**
+       * Some printers may have issues with EMI noise especially using a motherboard with 3.3V logic levels
+       * it may cause the logical LOW to float into the undefined region and register as a logical HIGH
+       * causing it to errorenously register as if someone clicked the button and in worst case make the printer
+       * unusable in practice.
        */
-
       static bool hw_button_pressed() {
-        for(uint8_t sample=0;sample<EMI_NOISE_FILTER_SAMPLES;sample++) {
-          if(!BUTTON_CLICK()) { return false;}
+        LOOP_L_N(s, ENCODER_SAMPLES) {
+          if (!BUTTON_CLICK()) return false;
           safe_delay(1);
         }
         return true;
       }
-      
-      static bool button_pressed() {
-        return hw_button_pressed() || TERN(TOUCH_SCREEN, touch_pressed(), false);
-      }
     #else
-      static bool button_pressed() { return BUTTON_CLICK() || TERN(TOUCH_SCREEN, touch_pressed(), false); }
+      static bool hw_button_pressed() { return BUTTON_CLICK(); }
     #endif
+
+    static bool button_pressed() { return hw_button_pressed() || TERN0(TOUCH_SCREEN, touch_pressed()); }
 
     #if EITHER(AUTO_BED_LEVELING_UBL, G26_MESH_VALIDATION)
       static void wait_for_release();

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -696,7 +696,7 @@ public:
           if(!BUTTON_CLICK()) { return false;}
           safe_delay(1);
         }
-        return true || TERN(TOUCH_SCREEN, touch_pressed(), false);
+        return TERN(TOUCH_SCREEN, touch_pressed(), false) || true;
       }
     #else
       static bool button_pressed() { return BUTTON_CLICK() || TERN(TOUCH_SCREEN, touch_pressed(), false); }


### PR DESCRIPTION
### Description

Some printers, in particular creality Ender 5 and 3 appears to have significant EMI noise which becomes very obvious when you upgrade to a controller board with 3.3V logic levels, causing the low signal to float in the undefined region and register as ghost keypresses. 

As there is no ambiguity when the logic level is high we can exploit that fact by sampling the signal subsequently for a fixed number of samples (10 by default) and conclude if all samples agree we have a logic high, while on first occurance of a non agreeing sample we can establish that the signal is in fact supposed to be a logic low.

As the sampling occurs a lot faster than you can humanly depress the button this both functions as a debounce and effectively a lowpass filter to reject eventual noise.

### Requirements

Creality Ender 5 and 3, a 3.3V motherboard such as the 4.2.7 silent board or SKR mini E3 and CR10_STOCKDISPLAY (possibly others)

### Benefits

Rejects EMI induced noise on the button logic line, the printer stops clicking by itself and behaves as expected.

### Configurations

NA

### Related Issues

(Open) https://github.com/MarlinFirmware/Marlin/issues/21204
(Closed) https://github.com/MarlinFirmware/Marlin/issues/21408