### PR TITLE
DOGM Display Screen Sleep

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2580,6 +2580,19 @@
 //
 //#define K3D_242_OLED_CONTROLLER   // Software SPI
 
+// =========================================================================
+// ===============Screen Sleep Feature =================================== 
+// =========================================================================
+//  For DOGM Diaplays for which U8g graphics library supports Sleep/Wake
+//  functions. Can be used to to reduce energy consumption and reduce
+//  OLED pixel burn-in.  U8g supports sleep/wake functions of
+//  SH1106/SSD1306/SSD1309  and other DOGM displays. Feature adds Screen
+//  Timeout setting menu to the LCD menu under Configuration. Use menu
+//  to set timeout period between  0 and 99 minutes.  Setting to '0'
+//  disables screen sleep feature.
+
+//#define SCREEN_TIMEOUT 1 // ( 0 - 99  minutes ) Turn off screen with timeout 
+
 //=============================================================================
 //========================== Extensible UI Displays ===========================
 //=============================================================================

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1430,6 +1430,7 @@
 
 /**
  * Screen Timeout Feature
+ */
 #if defined(SCREEN_TIMEOUT)
   #define HAS_SCREEN_TIMEOUT 1
 #endif

--- a/Marlin/src/inc/Conditionals_LCD.h
+++ b/Marlin/src/inc/Conditionals_LCD.h
@@ -1427,3 +1427,9 @@
 #if defined(NEOPIXEL_BKGD_INDEX_FIRST) && !defined(NEOPIXEL_BKGD_INDEX_LAST)
   #define NEOPIXEL_BKGD_INDEX_LAST NEOPIXEL_BKGD_INDEX_FIRST
 #endif
+
+/**
+ * Screen Timeout Feature
+#if defined(SCREEN_TIMEOUT)
+  #define HAS_SCREEN_TIMEOUT 1
+#endif

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2877,14 +2877,10 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
  * Screen Timeout feature not supported by these common displays
 */
 #if HAS_SCREEN_TIMEOUT
-  #if HAS_MARLINUI_HD44780
-    #error "SCREEN_TIMEOUT feature not supported by HD44780 Reprap Discount Smart Controller 2004 LCD"
-  #elif ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+  #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
     #error "SCREEN_TIMEOUT feature not supported by REPRAPWORLD_GRAPHICAL_LCD"
   #elif IS_U8GLIB_ST7920
     #error "SCREEN_TIMEOUT feature not supported by Reprap Discount Full Graphics Smart Controller using ST7920"
-  #elif ENABLED(CARTESIO_UI)
-    #error "SCREEN_TIMEOUT feature not supported by CARTESIO_UI LCD"
   #elif IS_U8GLIB_LM6059_AF
     #error "SCREEN_TIMEOUT feature not supported by U8GLIB_LM6059_AF ST7565"
   #elif IS_U8GLIB_ST7565_64128

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2874,6 +2874,29 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #endif
 
 /**
+ * Screen Timeout feature not supported by these common displays
+*/
+#if HAS_SCREEN_TIMEOUT
+  #if HAS_MARLINUI_HD44780
+    #error "SCREEN_TIMEOUT feature not supported by HD44780 Reprap Discount Smart Controller 2004 LCD"
+  #elif ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+    #error "SCREEN_TIMEOUT feature not supported by REPRAPWORLD_GRAPHICAL_LCD"
+  #elif IS_U8GLIB_ST7920
+    #error "SCREEN_TIMEOUT feature not supported by Reprap Discount Full Graphics Smart Controller using ST7920"
+  #elif ENABLED(CARTESIO_UI)
+    #error "SCREEN_TIMEOUT feature not supported by CARTESIO_UI LCD"
+  #elif IS_U8GLIB_LM6059_AF
+    #error "SCREEN_TIMEOUT feature not supported by U8GLIB_LM6059_AF ST7565"
+  #elif IS_U8GLIB_ST7565_64128
+    #error "SCREEN_TIMEOUT feature not supported by U8GLIB_ST7565_64128"
+  #elif ANY(FYSETC_MINI, MKS_MINI_12864, ENDER2_STOCKDISPLAY)
+    #error "SCREEN_TIMEOUT feature not supported by FYSETC_MINI, MKS_MINI_12864, or ENDER2_STOCKDISPLAY"
+  #elif ENABLED(MINIPANEL)
+    #error "SCREEN_TIMEOUT feature not supported by MINIPANEL display"
+  #endif
+#endif
+
+/**
  * Some boards forbid the use of -1 Native USB
  */
 #if ENABLED(BOARD_NO_NATIVE_USB)

--- a/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
+++ b/Marlin/src/lcd/dogm/marlinui_DOGM.cpp
@@ -342,6 +342,13 @@ void MarlinUI::draw_kill_screen() {
 
 void MarlinUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
+void MarlinUI::sleep_on () {
+  u8g.sleepOn();
+}
+void MarlinUI::sleep_off () {
+  u8g.sleepOff();
+}
+
 #if HAS_LCD_BRIGHTNESS
 
   void MarlinUI::_set_brightness() {

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -404,6 +404,7 @@ namespace Language_en {
   LSTR MSG_CONTRAST                       = _UxGT("LCD Contrast");
   LSTR MSG_BRIGHTNESS                     = _UxGT("LCD Brightness");
   LSTR MSG_LCD_BKL_TIMEOUT                = _UxGT("LCD Timeout (s)");
+  LSTR MSG_SCREEN_TIMEOUT                 = _UxGT("ScreenTimeout(m)"); 
   LSTR MSG_BRIGHTNESS_OFF                 = _UxGT("Backlight Off");
   LSTR MSG_STORE_EEPROM                   = _UxGT("Store Settings");
   LSTR MSG_LOAD_EEPROM                    = _UxGT("Load Settings");

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -188,6 +188,15 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
   }
 #endif
 
+#if HAS_SCREEN_TIMEOUT
+  uint16_t MarlinUI::screen_timeout; // Initialized by settings.load( )
+  millis_t MarlinUI::screen_timeout_millis = 0;
+  void MarlinUI::refresh_screen_timeout() {
+    screen_timeout_millis = screen_timeout ? millis() + screen_timeout * 60000UL : 0;
+    sleep_off(); 
+  }
+#endif
+
 void MarlinUI::init() {
 
   init_lcd();
@@ -1045,6 +1054,10 @@ void MarlinUI::init() {
             refresh_backlight_timeout();
           #endif
 
+          #if HAS_SCREEN_TIMEOUT
+            refresh_screen_timeout();
+          #endif
+          
           refresh(LCDVIEW_REDRAW_NOW);
 
           #if LED_POWEROFF_TIMEOUT > 0
@@ -1155,6 +1168,12 @@ void MarlinUI::init() {
           backlight_off_ms = 0;
         }
       #endif
+      
+      #if HAS_SCREEN_TIMEOUT
+        if (screen_timeout_millis && ELAPSED(ms, screen_timeout_millis)) {
+          sleep_on();
+        }
+      #endif      
 
       // Change state of drawing flag between screen updates
       if (!drawing_screen) switch (lcdDrawUpdate) {

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -246,7 +246,10 @@ public:
 
   // LCD implementations
   static void clear_lcd();
-
+  
+  static void sleep_on();
+  static void sleep_off();
+  
   #if BOTH(HAS_MARLINUI_MENU, TOUCH_SCREEN_CALIBRATION)
     static void check_touch_calibration() {
       if (touch_calibration.need_calibration()) currentScreen = touch_calibration_screen;
@@ -282,7 +285,15 @@ public:
     static millis_t backlight_off_ms;
     static void refresh_backlight_timeout();
   #endif
-
+ 
+  #if HAS_SCREEN_TIMEOUT
+    #define SCREEN_TIMEOUT_MIN 0    // units in minutes
+    #define SCREEN_TIMEOUT_MAX 99   // units in minutes
+    static uint16_t screen_timeout;
+    static millis_t screen_timeout_millis;
+    static void refresh_screen_timeout();
+  #endif
+  
   #if HAS_DWIN_E3V2_BASIC
     static void refresh();
   #else

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -544,6 +544,10 @@ void menu_configuration() {
   #if LCD_BACKLIGHT_TIMEOUT && LCD_BKL_TIMEOUT_MIN < LCD_BKL_TIMEOUT_MAX
     EDIT_ITEM(uint16_4, MSG_LCD_BKL_TIMEOUT, &ui.lcd_backlight_timeout, LCD_BKL_TIMEOUT_MIN, LCD_BKL_TIMEOUT_MAX, ui.refresh_backlight_timeout);
   #endif
+  
+  #if HAS_SCREEN_TIMEOUT
+    EDIT_ITEM(uint16_3, MSG_SCREEN_TIMEOUT, &ui.screen_timeout, SCREEN_TIMEOUT_MIN, SCREEN_TIMEOUT_MAX, ui.refresh_screen_timeout);
+  #endif
 
   #if ENABLED(FWRETRACT)
     SUBMENU(MSG_RETRACT, menu_config_retract);

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -403,7 +403,14 @@ typedef struct SettingsDataStruct {
   #if LCD_BACKLIGHT_TIMEOUT
     uint16_t lcd_backlight_timeout;                     // (G-code needed)
   #endif
-
+  
+  //
+  // SCREEN_TIMEOUT
+  //
+  #if HAS_SCREEN_TIMEOUT
+    uint16_t screen_timeout;
+  #endif
+  
   //
   // Controller fan settings
   //
@@ -623,6 +630,10 @@ void MarlinSettings::postprocess() {
 
   #if LCD_BACKLIGHT_TIMEOUT
     ui.refresh_backlight_timeout();
+  #endif
+  
+  #if HAS_SCREEN_TIMEOUT
+    ui.refresh_screen_timeout();
   #endif
 }
 
@@ -1135,7 +1146,15 @@ void MarlinSettings::postprocess() {
     #if LCD_BACKLIGHT_TIMEOUT
       EEPROM_WRITE(ui.lcd_backlight_timeout);
     #endif
-
+    
+    //
+    // Screen Timeout
+    //
+    #if HAS_SCREEN_TIMEOUT
+      EEPROM_WRITE(ui.screen_timeout);
+    #endif
+    
+    
     //
     // Controller Fan
     //
@@ -2059,7 +2078,14 @@ void MarlinSettings::postprocess() {
       #if LCD_BACKLIGHT_TIMEOUT
         EEPROM_READ(ui.lcd_backlight_timeout);
       #endif
-
+      
+      //
+      // Screen Timeout
+      //
+      #if HAS_SCREEN_TIMEOUT
+        EEPROM_READ(ui.screen_timeout);
+      #endif
+      
       //
       // Controller Fan
       //
@@ -3100,6 +3126,13 @@ void MarlinSettings::reset() {
     ui.lcd_backlight_timeout = LCD_BACKLIGHT_TIMEOUT;
   #endif
 
+  //
+  // Screen Timeout
+  //
+  #if HAS_SCREEN_TIMEOUT
+    ui.screen_timeout = SCREEN_TIMEOUT;
+  #endif
+  
   //
   // Controller Fan
   //


### PR DESCRIPTION
### Description

Adds Screen Sleep feature for U8g DOGM displays which supports Sleep and Wake functions.
  - #define SCREEN_TIMEOUT in `Configuration.h` file is, by default, commented out (disabled).
  - Adds to LCD Menu under Configuration Menu, a timeout setting menu.
  - User can disable screen timeout feature by setting timeout value to '0'.
  - Timeout setting changes will be saved to EEPROM with other setting changes being saved.
  - Supports timeout times between 1 and 99 minutes in 1 minute increments. 
  - Rotation of rotary encoder, or press of rotary encoder button, wakes display when in display is in sleep mode. 


### Requirements

U8g DOGM supported displays.

### Benefits

Helps reduce energy consumption during printing.  Reduces pixel burn-in with OLED displays.

### Configurations

`Configuration.h` file has been modified and is included with this PR.

### Related Issues

None found.
