### PR TITLE
Connection between BTT_MINI_12864_V1 and BTT SKR MINI E3 V3.0 with cu…

### DIFF
--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -256,6 +256,45 @@
 
     #endif
 
+  #elif EITHER(BTT_MINI_12864_V1, FYSETC_MINI_12864_2_1)
+
+      /**
+       *
+       *                 Board                               Display
+       *                 ------                               ------
+       *    (EN2)  PB5  |10  9 | PA15(BTN_ENC)            5V |10  9 | GND
+       *  (LCD_CS) PA9  | 8  7 | RST (RESET)              -- | 8  7 | --
+       *  (LCD_A0) PA10 |#6  5 | PB9 (EN1)            (DIN)  | 6  5#| (RESET)
+       *  (LCD_SCK)PB8  | 4  3 | PD6 (MOSI)         (LCD_A0) | 4  3 | (LCD_CS)
+       *            GND | 2  1 | 5V                (BTN_ENC) | 2  1 | --
+       *                 ------                               ------
+       *                  EXP1                                 EXP1
+       *
+       *                                                      ------
+       *                                                  -- |10  9 | --
+       *                   ---                       (RESET) | 8  7 | --
+       *                  | 3 |                      (MOSI)  | 6  5#| (EN2)
+       *                  | 2 | (DIN)                     -- | 4  3 | (EN1)
+       *                  | 1 |                     (LCD_SCK)| 2  1 | --
+       *                   ---                                ------
+       *                Neopixel                               EXP2
+       *
+       * Needs custom cable
+       *
+       */
+    #define BTN_ENC                  EXP1_09_PIN
+    #define BTN_EN1                         PB9
+    #define BTN_EN2                         PB5
+    #define BEEPER_PIN                      -1
+
+    #define DOGLCD_CS                       PA9
+    #define DOGLCD_A0                       PA10
+    #define DOGLCD_SCK                      PB8
+    #define DOGLCD_MOSI                     PD6
+
+    #define FORCE_SOFT_SPI
+    #define LCD_BACKLIGHT_PIN               -1
+
   #else
     #error "Only CR10_STOCKDISPLAY, ZONESTAR_LCD, ENDER2_STOCKDISPLAY, MKS_MINI_12864, and TFTGLCD_PANEL_(SPI|I2C) are currently supported on the BIGTREE_SKR_MINI_E3."
   #endif


### PR DESCRIPTION
…stom cable.

SDCard on display board is not supported.

### Description

Pin definitions for connection between BTT_MINI_12864_V1 display and BTT SKR MINI E3 V3.0 mother board. SDCard and beeper located on display board are not supported. 

### Requirements

Custom cable. The schematics is in the file.

### Configurations

In configuration.h use:

#define BTT_MINI_12864_V1

#define NEOPIXEL_LED
#if ENABLED(NEOPIXEL_LED)
  #define NEOPIXEL_TYPE   NEO_GRB  
  // #define NEOPIXEL_PIN     LED_PIN     // LED driving pin
  // #define NEOPIXEL2_TYPE NEOPIXEL_TYPE
  // #define NEOPIXEL2_PIN    5
  #define NEOPIXEL_PIXELS 3       // Number of LEDs in the strip. (Longest strip when NEOPIXEL2_SEPARATE is disabled.)
  #define NEOPIXEL_IS_SEQUENTIAL   // Sequential display for temperature change - LED by LED. Disable to change all LEDs at once.
  #define NEOPIXEL_BRIGHTNESS 255  // Initial brightness (0-255)

### Related Issues

No related issues.
