### PR TITLE
proui endstop_diag.cpp breaks compiling for all Arduino IDE users

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/endstop_diag.cpp
+++ b/Marlin/src/lcd/e3v2/proui/endstop_diag.cpp
@@ -27,9 +27,13 @@
  * Date: 2022/02/24
  */
 
+
+#include "../../../inc/MarlinConfigPre.h"
+#if ENABLED(DWIN_LCD_PROUI)
+
 #include "dwin_defines.h"
 
-#if BOTH(DWIN_LCD_PROUI, HAS_ESDIAG)
+#if HAS_ESDIAG
 
 #include "endstop_diag.h"
 
@@ -105,4 +109,5 @@ void ESDiagClass::Update() {
   DWIN_UpdateLCD();
 }
 
-#endif // DWIN_LCD_PROUI && HAS_ESDIAG
+#endif // HAS_ESDIAG
+#endif // DWIN_LCD_PROUI

--- a/Marlin/src/lcd/e3v2/proui/endstop_diag.cpp
+++ b/Marlin/src/lcd/e3v2/proui/endstop_diag.cpp
@@ -21,14 +21,14 @@
  */
 
 /**
- * DWIN End Stops diagnostic page for PRO UI
+ * DWIN Endstops diagnostic page for PRO UI
  * Author: Miguel A. Risco-Castillo (MRISCOC)
  * Version: 1.2.2
  * Date: 2022/02/24
  */
 
-
 #include "../../../inc/MarlinConfigPre.h"
+
 #if ENABLED(DWIN_LCD_PROUI)
 
 #include "dwin_defines.h"


### PR DESCRIPTION
### Description

PROUI code endstop_diag.cpp breaks compiling for all Arduino IDE users 

endstop_diag.cpp includes dwin_defines.h before checking that DWIN_LCD_PROUI is enabled and results in the various checks in dwin_defines.h failing and breaking compiling

Results in this error:
```
Marlin/src/lcd/e3v2/proui/dwin_defines.h:38:4: error: #error "INDIVIDUAL_AXIS_HOMING_SUBMENU is required with ProUI."
   #error "INDIVIDUAL_AXIS_HOMING_SUBMENU is required with ProUI."
```

### Requirements

Arduino IDE

### Benefits

Marlin builds under Arduino IDE again

