### PR TITLE
add MMU2_ATTN_BUZZ

### DIFF
--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -143,7 +143,7 @@ uint8_t MMU2::get_current_tool() {
   #define FILAMENT_PRESENT() (READ(FIL_RUNOUT1_PIN) != FIL_RUNOUT1_STATE)
 #endif
 
-inline void ATTN_BUZZ(const bool two=false) { BUZZ(200, 404); if (two) { BUZZ(10, 0); BUZZ(200, 404); } }
+inline void MMU2_ATTN_BUZZ(const bool two=false) { BUZZ(200, 404); if (two) { BUZZ(10, 0); BUZZ(200, 404); } }
 
 void MMU2::mmu_loop() {
 
@@ -819,7 +819,7 @@ void MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
       }
 
       LCD_MESSAGE(MSG_MMU2_RESUMING);
-      ATTN_BUZZ(true);
+      MMU2_ATTN_BUZZ(true);
 
       if (move_axes && all_axes_homed()) {
         // Move XY to starting position, then Z
@@ -896,7 +896,7 @@ void MMU2::load_filament(const uint8_t index) {
 
   command(MMU_CMD_L0 + index);
   manage_response(false, false);
-  ATTN_BUZZ();
+  MMU2_ATTN_BUZZ();
 }
 
 /**
@@ -907,7 +907,7 @@ bool MMU2::load_filament_to_nozzle(const uint8_t index) {
   if (!_enabled) return false;
 
   if (thermalManager.tooColdToExtrude(active_extruder)) {
-    ATTN_BUZZ();
+    MMU2_ATTN_BUZZ();
     LCD_ALERTMESSAGE(MSG_HOTEND_TOO_COLD);
     return false;
   }
@@ -922,7 +922,7 @@ bool MMU2::load_filament_to_nozzle(const uint8_t index) {
     extruder = index;
     active_extruder = 0;
     load_to_nozzle();
-    ATTN_BUZZ();
+    MMU2_ATTN_BUZZ();
   }
   return success;
 }
@@ -943,7 +943,7 @@ bool MMU2::eject_filament(const uint8_t index, const bool recover) {
   if (!_enabled) return false;
 
   if (thermalManager.tooColdToExtrude(active_extruder)) {
-    ATTN_BUZZ();
+    MMU2_ATTN_BUZZ();
     LCD_ALERTMESSAGE(MSG_HOTEND_TOO_COLD);
     return false;
   }
@@ -959,11 +959,11 @@ bool MMU2::eject_filament(const uint8_t index, const bool recover) {
 
   if (recover)  {
     LCD_MESSAGE(MSG_MMU2_EJECT_RECOVER);
-    ATTN_BUZZ();
+    MMU2_ATTN_BUZZ();
     TERN_(HOST_PROMPT_SUPPORT, hostui.prompt_do(PROMPT_USER_CONTINUE, F("MMU2 Eject Recover"), FPSTR(CONTINUE_STR)));
     TERN_(EXTENSIBLE_UI, ExtUI::onUserConfirmRequired(F("MMU2 Eject Recover")));
     TERN_(HAS_RESUME_CONTINUE, wait_for_user_response());
-    ATTN_BUZZ(true);
+    MMU2_ATTN_BUZZ(true);
 
     command(MMU_CMD_R0);
     manage_response(false, false);
@@ -976,7 +976,7 @@ bool MMU2::eject_filament(const uint8_t index, const bool recover) {
 
   set_runout_valid(false);
 
-  ATTN_BUZZ();
+  MMU2_ATTN_BUZZ();
 
   stepper.disable_extruder();
 
@@ -991,7 +991,7 @@ bool MMU2::unload() {
   if (!_enabled) return false;
 
   if (thermalManager.tooColdToExtrude(active_extruder)) {
-    ATTN_BUZZ();
+    MMU2_ATTN_BUZZ();
     LCD_ALERTMESSAGE(MSG_HOTEND_TOO_COLD);
     return false;
   }
@@ -1002,7 +1002,7 @@ bool MMU2::unload() {
   command(MMU_CMD_U0);
   manage_response(false, true);
 
-  ATTN_BUZZ();
+  MMU2_ATTN_BUZZ();
 
   // no active tool
   extruder = MMU2_NO_TOOL;

--- a/Marlin/src/feature/mmu/mmu2.cpp
+++ b/Marlin/src/feature/mmu/mmu2.cpp
@@ -143,7 +143,10 @@ uint8_t MMU2::get_current_tool() {
   #define FILAMENT_PRESENT() (READ(FIL_RUNOUT1_PIN) != FIL_RUNOUT1_STATE)
 #endif
 
-inline void MMU2_ATTN_BUZZ(const bool two=false) { BUZZ(200, 404); if (two) { BUZZ(10, 0); BUZZ(200, 404); } }
+void mmu2_attn_buzz(const bool two=false) {
+  BUZZ(200, 404);
+  if (two) { BUZZ(10, 0); BUZZ(200, 404); }
+}
 
 void MMU2::mmu_loop() {
 
@@ -819,7 +822,7 @@ void MMU2::manage_response(const bool move_axes, const bool turn_off_nozzle) {
       }
 
       LCD_MESSAGE(MSG_MMU2_RESUMING);
-      MMU2_ATTN_BUZZ(true);
+      mmu2_attn_buzz(true);
 
       if (move_axes && all_axes_homed()) {
         // Move XY to starting position, then Z
@@ -896,7 +899,7 @@ void MMU2::load_filament(const uint8_t index) {
 
   command(MMU_CMD_L0 + index);
   manage_response(false, false);
-  MMU2_ATTN_BUZZ();
+  mmu2_attn_buzz();
 }
 
 /**
@@ -907,7 +910,7 @@ bool MMU2::load_filament_to_nozzle(const uint8_t index) {
   if (!_enabled) return false;
 
   if (thermalManager.tooColdToExtrude(active_extruder)) {
-    MMU2_ATTN_BUZZ();
+    mmu2_attn_buzz();
     LCD_ALERTMESSAGE(MSG_HOTEND_TOO_COLD);
     return false;
   }
@@ -922,7 +925,7 @@ bool MMU2::load_filament_to_nozzle(const uint8_t index) {
     extruder = index;
     active_extruder = 0;
     load_to_nozzle();
-    MMU2_ATTN_BUZZ();
+    mmu2_attn_buzz();
   }
   return success;
 }
@@ -943,7 +946,7 @@ bool MMU2::eject_filament(const uint8_t index, const bool recover) {
   if (!_enabled) return false;
 
   if (thermalManager.tooColdToExtrude(active_extruder)) {
-    MMU2_ATTN_BUZZ();
+    mmu2_attn_buzz();
     LCD_ALERTMESSAGE(MSG_HOTEND_TOO_COLD);
     return false;
   }
@@ -959,11 +962,11 @@ bool MMU2::eject_filament(const uint8_t index, const bool recover) {
 
   if (recover)  {
     LCD_MESSAGE(MSG_MMU2_EJECT_RECOVER);
-    MMU2_ATTN_BUZZ();
+    mmu2_attn_buzz();
     TERN_(HOST_PROMPT_SUPPORT, hostui.prompt_do(PROMPT_USER_CONTINUE, F("MMU2 Eject Recover"), FPSTR(CONTINUE_STR)));
     TERN_(EXTENSIBLE_UI, ExtUI::onUserConfirmRequired(F("MMU2 Eject Recover")));
     TERN_(HAS_RESUME_CONTINUE, wait_for_user_response());
-    MMU2_ATTN_BUZZ(true);
+    mmu2_attn_buzz(true);
 
     command(MMU_CMD_R0);
     manage_response(false, false);
@@ -976,7 +979,7 @@ bool MMU2::eject_filament(const uint8_t index, const bool recover) {
 
   set_runout_valid(false);
 
-  MMU2_ATTN_BUZZ();
+  mmu2_attn_buzz();
 
   stepper.disable_extruder();
 
@@ -991,7 +994,7 @@ bool MMU2::unload() {
   if (!_enabled) return false;
 
   if (thermalManager.tooColdToExtrude(active_extruder)) {
-    MMU2_ATTN_BUZZ();
+    mmu2_attn_buzz();
     LCD_ALERTMESSAGE(MSG_HOTEND_TOO_COLD);
     return false;
   }
@@ -1002,7 +1005,7 @@ bool MMU2::unload() {
   command(MMU_CMD_U0);
   manage_response(false, true);
 
-  MMU2_ATTN_BUZZ();
+  mmu2_attn_buzz();
 
   // no active tool
   extruder = MMU2_NO_TOOL;


### PR DESCRIPTION
### Description

MMU2 uses a different ATTN_BUZZ from the rest of Marlin
Recent attempt to unify ATTN_BUZZ resulted in MMU2 code not compiling.

Created separate MMU2_ATTN_BUZZ so conflicts with macro ATTN_BUZZ don't occur

### Requirements

#define MMU_MODEL PRUSA_MMU2

### Benefits

Compiles as expected

### Configurations

[example configs.zip](https://github.com/MarlinFirmware/Marlin/files/8346792/example.configs.zip)

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/23932