### PR TITLE
Update Makefile to avoid Issue #23951 error

### DIFF
--- a/Marlin/Makefile
+++ b/Marlin/Makefile
@@ -132,7 +132,7 @@ CC_MIN:=$(shell $(CC) -dM -E - < /dev/null | grep __GNUC_MINOR__ | cut -f3 -d\ )
 CC_PATCHLEVEL:=$(shell $(CC) -dM -E - < /dev/null | grep __GNUC_PATCHLEVEL__ | cut -f3 -d\ )
 CC_VER:=$(shell echo $$(( $(CC_MAJ) * 10000 + $(CC_MIN) * 100 + $(CC_PATCHLEVEL) )))
 ifeq ($(shell test $(CC_VER) -lt 40901 && echo 1),1)
-  @echo This version of GCC is likely broken. Enabling relocation workaround.
+  $(warning This GCC version $(CC_VER) is likely broken. Enabling relocation workaround.)
   RELOC_WORKAROUND = 1
 endif
 


### PR DESCRIPTION
This line was missing a tab before it calls a shell command and causes this error message:

```
Makefile:135: *** missing separator.  Stop.
```
It does not cause a problem for folks with CC_VER above 40900 because of the enclosing conditional.

See https://github.com/MarlinFirmware/Marlin/issues/23951 for more details.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

A "Makefile:135: *** missing separator. Stop." error is cause by this ill-formed Make syntax around 

https://github.com/MarlinFirmware/Marlin/blob/4a54f8469e66a4f59c6284646885545d52f6e164/Marlin/Makefile#L130-L137

This patch replaces the `@echo ...` shell command with a `$(warning ...)` Make command and avoids the error.

### Requirements

This affects Makefile builds with GCC <4.9.1 

### Benefits

This fixes the missing tab before the echo command with the $(warning ...) message

### Configurations

You need GCC < 4.9.1 to see the problem or test for its resolution.

### Related Issues

Fixes issue https://github.com/MarlinFirmware/Marlin/issues/23951