### PR TITLE
Update SKR2 Pins def

### DIFF
--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -23,6 +23,8 @@
 
 #include "env_validate.h"
 
+#define USES_DIAG_JUMPERS
+
 // If you have the BigTreeTech driver expansion module, enable BTT_MOTOR_EXPANSION
 // https://github.com/bigtreetech/BTT-Expansion-module/tree/master/BTT%20EXP-MOT
 //#define BTT_MOTOR_EXPANSION


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Updates SKR 2.0 pin definition to indicate DIAG jumpers are used on board.

### Requirements

BigTreeTech SKR 2.0 Rev A or B

### Benefits

Make sure to trigger warning about DIAG jumpers on SKR2 board when sensorless homing is not enabled.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

None
