### PR TITLE
Add SKR Mini V1.1 TMC UART Pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_V1_1.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_V1_1.h
@@ -80,6 +80,23 @@
   #endif
 #endif
 
+#if HAS_TMC_UART                                  // Shared with EXP1
+  #define X_SERIAL_TX_PIN                  PC10
+  #define X_SERIAL_RX_PIN       X_SERIAL_TX_PIN
+
+  #define Y_SERIAL_TX_PIN                  PC11
+  #define Y_SERIAL_RX_PIN       Y_SERIAL_TX_PIN
+
+  #define Z_SERIAL_TX_PIN                  PC12
+  #define Z_SERIAL_RX_PIN       Z_SERIAL_TX_PIN
+
+  #define E0_SERIAL_TX_PIN                 PC14
+  #define E0_SERIAL_RX_PIN     E0_SERIAL_TX_PIN
+
+  // Reduce baud rate to improve software serial reliability
+  #define TMC_BAUD_RATE                   19200
+#endif
+
 //
 // Heaters / Fans
 //


### PR DESCRIPTION
### Description

Add SKR Mini V1.1 TMC UART pins adapted from [BTT's TMC UART wiring guide](https://github.com/bigtreetech/BIGTREETECH-SKR-MINI-V1.1/blob/master/Wiring%20diagram/SKR%20mini%20V1.1-TMC2208-UART-Mode-guide.pdf).

### Requirements

SKR Mini V1.1 with UART drivers & a custom wiring harness/jumper wires to EXP1.

### Benefits

UART TMC drivers like the 2208 & 2209 can now be used on the SKR Mini V1.1 using a custom harness/jumper wires to EXP1.

Note: There's no warning that a custom cable is needed for the existing TMC SPI driver support on this board, so I didn't add one for UART drivers. Either option will eat up pins on EXP1 or EXP2, so your display options are pretty much limited to a serial-connected TFT or going headless when running TMCs in non-standalone modes.