### PR TITLE
MightyBoard_RevE fix EX2, EXTRA MOSFET pins

### DIFF
--- a/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
@@ -149,8 +149,8 @@
 
 #define MOSFET_1_PIN                           6  // Plug EX1 Pin 1-2 -> PH3 #15 -> Logical 06
 #define MOSFET_2_PIN                           7  // Plug EX1 Pin 3-4 -> PH4 #16 -> Logical 07
-#define MOSFET_3_PIN                          12  // Plug EX2 1-2 -> PB5 #25 -> Logical 12
-#define MOSFET_4_PIN                          11  // Plug EX2 3-4 -> PB6 #24 -> Logical 11
+#define MOSFET_3_PIN                          11  // Plug EX2 1-2 -> PB6 #24 -> Logical 11
+#define MOSFET_4_PIN                          12  // Plug EX2 3-4 -> PB5 #25 -> Logical 12
 #define MOSFET_5_PIN                          45  // Plug HBD 1-2 -> PL4 #39 -> Logical 45
 #define MOSFET_6_PIN                          13  // Plug Extra 1-2 -> PL5 #40 -> Logical 44 (FET not soldered in all boards)
 

--- a/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
@@ -152,7 +152,7 @@
 #define MOSFET_3_PIN                          11  // Plug EX2 1-2 -> PB6 #24 -> Logical 11
 #define MOSFET_4_PIN                          12  // Plug EX2 3-4 -> PB5 #25 -> Logical 12
 #define MOSFET_5_PIN                          45  // Plug HBD 1-2 -> PL4 #39 -> Logical 45
-#define MOSFET_6_PIN                          13  // Plug Extra 1-2 -> PL5 #40 -> Logical 44 (FET not soldered in all boards)
+#define MOSFET_6_PIN                          44  // Plug Extra 1-2 -> PL5 #40 -> Logical 44 (FET not soldered in all boards)
 
 //
 // Heaters / Fans (24V)


### PR DESCRIPTION
### Description

As per issue #23956, the two MOSFET pins for the EX2-HEAT and EX2-FAN were erroneously swapped thereby causing a safety issue by enabling heat on EX2 when instead the fan should have turned on. This can happen because both extruders in a Replicator 2, FFCP, or clone share a heat break and therefore there will be some heating of EX2 when EX1 is in use.

Additionally, the EXTRA MOSFET pin was also incorrectly assigned.


### Requirements

MightyBoard Rev.E

### Benefits

Correct an incorrect pin assignment resulting in a safety issue

### Configurations

N/A

### Related Issues

Resolution for issue #23956
