### PR TITLE
Filament Width Sensor - Incorrect ADC->MM Calculation Fix

### DIFF
--- a/Marlin/src/feature/filwidth.h
+++ b/Marlin/src/feature/filwidth.h
@@ -67,7 +67,7 @@ public:
   }
 
   // Convert raw measurement to mm
-  static float raw_to_mm(const uint16_t v) { return v * HAL_ADC_VREF * RECIPROCAL(float(MAX_RAW_THERMISTOR_VALUE)); }
+  static float raw_to_mm(const uint16_t v) { return v * float(ADC_VREF) * RECIPROCAL(float(MAX_RAW_THERMISTOR_VALUE)); }
   static float raw_to_mm() { return raw_to_mm(raw); }
 
   // A scaled reading is ready

--- a/Marlin/src/feature/filwidth.h
+++ b/Marlin/src/feature/filwidth.h
@@ -67,7 +67,7 @@ public:
   }
 
   // Convert raw measurement to mm
-  static float raw_to_mm(const uint16_t v) { return v * 5.0f * RECIPROCAL(float(MAX_RAW_THERMISTOR_VALUE)); }
+  static float raw_to_mm(const uint16_t v) { return v * HAL_ADC_VREF * RECIPROCAL(float(MAX_RAW_THERMISTOR_VALUE)); }
   static float raw_to_mm() { return raw_to_mm(raw); }
 
   // A scaled reading is ready


### PR DESCRIPTION
### Description

When using the `FILAMENT_WIDTH_SENSOR` on a 3.3v VREF board, the conversion from the ADC reading to millimeters is scaled incorrectly.  The conversion has 5.0v hard-coded into the formula.

### Requirements

3.3v VREF board
Filament Width Sensor connected to a raw ADC pin

### Benefits

The ADC value is scaled properly depending on the board's VREF value.

### Configurations

Enable `FILAMENT_WIDTH_SENSOR` in any configuration

### Related Issues

I did not find an open issue for this specific problem.