### PR TITLE
use os.replace rather than os.rename

### DIFF
--- a/buildroot/share/PlatformIO/scripts/offset_and_rename.py
+++ b/buildroot/share/PlatformIO/scripts/offset_and_rename.py
@@ -57,6 +57,6 @@ if pioutil.is_pio_build():
 
 		def rename_target(source, target, env):
 			firmware = os.path.join(target[0].dir.path, board.get("build.rename"))
-			os.rename(target[0].path, firmware)
+			os.replace(target[0].path, firmware)
 
 		marlin.add_post_action(rename_target)


### PR DESCRIPTION
On Windows OS, the build process will end with an error if the target file already exists.
With os.replace instead of os.rename no error will occur.
Tested on Win10 and elementaryOS.


