### PR TITLE
use os.replace rather than os.rename, fix build error with TFT_LVGL_UI and PROBE_OFFSET_WIZARD

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_level_settings.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/draw_level_settings.cpp
@@ -74,7 +74,7 @@ void lv_draw_level_settings() {
   #if HAS_BED_PROBE
     lv_screen_menu_item(scr, machine_menu.LevelingAutoZoffsetConf, PARA_UI_POS_X, PARA_UI_POS_Y * 3, event_handler, ID_LEVEL_ZOFFSET, 2);
     #if ENABLED(PROBE_OFFSET_WIZARD)
-      lv_screen_menu_item(scr, machine_menu.LevelingZoffsetWizard, PARA_UI_POS_X, PARA_UI_POS_Y * 4, event_handler, ID_Z_OFFSET_WIZARD, 3);
+      lv_screen_menu_item(scr, machine_menu.LevelingZoffsetTitle, PARA_UI_POS_X, PARA_UI_POS_Y * 4, event_handler, ID_Z_OFFSET_WIZARD, 3);
     #endif
   #endif
   lv_big_button_create(scr, "F:/bmp_back70x40.bin", common_menu.text_back, PARA_UI_BACK_POS_X + 10, PARA_UI_BACK_POS_Y, event_handler, ID_LEVEL_RETURN, true);

--- a/buildroot/share/PlatformIO/scripts/offset_and_rename.py
+++ b/buildroot/share/PlatformIO/scripts/offset_and_rename.py
@@ -57,6 +57,6 @@ if pioutil.is_pio_build():
 
 		def rename_target(source, target, env):
 			firmware = os.path.join(target[0].dir.path, board.get("build.rename"))
-			os.rename(target[0].path, firmware)
+			os.replace(target[0].path, firmware)
 
 		marlin.add_post_action(rename_target)


### PR DESCRIPTION
On Windows OS, the build process will end with an error if the target file already exists.
With os.replace instead of os.rename no error will occur.
Tested on Win10 and elementaryOS

Bord: MKS Robin nano v3
Env: mks_robin_nano_v3_usb_flash_drive_msc"


