### PR TITLE
Add new preflight check check for old files abl.cpp and abl.h

### DIFF
--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -102,6 +102,10 @@ if pioutil.is_pio_build():
 		for f in [ "ultralcd_DOGM.cpp", "ultralcd_DOGM.h" ]:
 			if os.path.isfile(os.path.join(p, f)):
 				mixedin += [ f ]
+		p = os.path.join(env['PROJECT_DIR'], "Marlin", "src", "feature", "bedlevel", "abl")
+		for f in [ "abl.cpp", "abl.h" ]:
+			if os.path.isfile(os.path.join(p, f)):
+				mixedin += [ f ]
 		if mixedin:
 			err = "ERROR: Old files fell into your Marlin folder. Remove %s and try again" % ", ".join(mixedin)
 			raise SystemExit(err)


### PR DESCRIPTION
### Description

Users are extracting bugfix over 2.0.x resulting in mixed code

Add another check for old no longer used files 

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/24005