### PR TITLE
Fix Typo in M206_M428.cpp

### DIFF
--- a/Marlin/src/gcode/geometry/M206_M428.cpp
+++ b/Marlin/src/gcode/geometry/M206_M428.cpp
@@ -42,7 +42,7 @@ void GcodeSuite::M206() {
   NUM_AXIS_CODE(
     if (parser.seen('X')) set_home_offset(X_AXIS, parser.value_linear_units()),
     if (parser.seen('Y')) set_home_offset(Y_AXIS, parser.value_linear_units()),
-    if (parser.seen('Z')) set_home_offset(Y_AXIS, parser.value_linear_units()),
+    if (parser.seen('Z')) set_home_offset(Z_AXIS, parser.value_linear_units()),
     if (parser.seen(AXIS4_NAME)) set_home_offset(I_AXIS, parser.TERN(AXIS4_ROTATES, value_float, value_linear_units)()),
     if (parser.seen(AXIS5_NAME)) set_home_offset(J_AXIS, parser.TERN(AXIS5_ROTATES, value_float, value_linear_units)()),
     if (parser.seen(AXIS6_NAME)) set_home_offset(K_AXIS, parser.TERN(AXIS6_ROTATES, value_float, value_linear_units)()),


### PR DESCRIPTION
### Description

A Typo. set_home_offset(Y_AXIS  is updated when set_home_offset(Z_AXIS should be updated

### Benefits

Works as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/24035