### PR TITLE
Fix LCD Menu Move extruder  - Proceed

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -28,6 +28,7 @@
 #include "../../module/planner.h"
 #include "../../module/motion.h"
 #include "../../module/printcounter.h"
+#include "../../module/temperature.h"
 #include "../../gcode/queue.h"
 
 #if HAS_BUZZER
@@ -171,6 +172,7 @@ bool printer_busy() {
  */
 void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, const uint8_t top/*=0*/, const uint8_t items/*=0*/) {
   if (currentScreen != screen) {
+    thermalManager.set_menu_cold_override(false);
 
     TERN_(IS_DWIN_MARLINUI, did_first_redraw = false);
 

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -219,7 +219,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
         ui.goto_screen([]{
           MenuItem_confirm::select_screen(
             GET_TEXT(MSG_BUTTON_PROCEED), GET_TEXT(MSG_BACK),
-            _goto_menu_move_distance_e, nullptr,
+            [] { Temperature::allow_cold_extrude = true; _goto_menu_move_distance_e(); Temperature::allow_cold_extrude = false;}, nullptr ,
             GET_TEXT(MSG_HOTEND_TOO_COLD), (const char *)nullptr, PSTR("!")
           );
         });

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -305,7 +305,9 @@ void menu_move() {
 
   #if E_MANUAL
 
-    Temperature::allow_cold_extrude_menu_overide = false;
+    #if ENABLED(PREVENT_COLD_EXTRUSION)
+      Temperature::allow_cold_extrude_menu_overide = false;
+    #endif
 
     // The current extruder
     SUBMENU(MSG_MOVE_E, []{ _menu_move_distance_e_maybe(); });

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -219,7 +219,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
         ui.goto_screen([]{
           MenuItem_confirm::select_screen(
             GET_TEXT(MSG_BUTTON_PROCEED), GET_TEXT(MSG_BACK),
-            [] { Temperature::allow_cold_extrude_menu_overide = true; _goto_menu_move_distance_e();}, nullptr ,
+            [] { _goto_menu_move_distance_e(); thermalManager.set_menu_cold_override(true); }, nullptr,
             GET_TEXT(MSG_HOTEND_TOO_COLD), (const char *)nullptr, PSTR("!")
           );
         });
@@ -304,10 +304,6 @@ void menu_move() {
   #endif
 
   #if E_MANUAL
-
-    #if ENABLED(PREVENT_COLD_EXTRUSION)
-      Temperature::allow_cold_extrude_menu_overide = false;
-    #endif
 
     // The current extruder
     SUBMENU(MSG_MOVE_E, []{ _menu_move_distance_e_maybe(); });

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -219,7 +219,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
         ui.goto_screen([]{
           MenuItem_confirm::select_screen(
             GET_TEXT(MSG_BUTTON_PROCEED), GET_TEXT(MSG_BACK),
-            [] { Temperature::allow_cold_extrude = true; _goto_menu_move_distance_e(); Temperature::allow_cold_extrude = false;}, nullptr ,
+            [] { Temperature::allow_cold_extrude_menu_overide = true; _goto_menu_move_distance_e();}, nullptr ,
             GET_TEXT(MSG_HOTEND_TOO_COLD), (const char *)nullptr, PSTR("!")
           );
         });
@@ -304,6 +304,8 @@ void menu_move() {
   #endif
 
   #if E_MANUAL
+
+    Temperature::allow_cold_extrude_menu_overide = false;
 
     // The current extruder
     SUBMENU(MSG_MOVE_E, []{ _menu_move_distance_e_maybe(); });

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -484,6 +484,7 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
 
 #if ENABLED(PREVENT_COLD_EXTRUSION)
   bool Temperature::allow_cold_extrude = false;
+  bool Temperature::allow_cold_extrude_menu_overide = false;
   celsius_t Temperature::extrude_min_temp = EXTRUDE_MINTEMP;
 #endif
 

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -482,9 +482,14 @@ PGMSTR(str_t_heating_failed, STR_T_HEATING_FAILED);
   #endif
 #endif
 
+#if BOTH(HAS_MARLINUI_MENU, PREVENT_COLD_EXTRUSION) && E_MANUAL > 0
+  bool Temperature::allow_cold_extrude_override = false;
+#else
+  constexpr bool Temperature::allow_cold_extrude_override;
+#endif
+
 #if ENABLED(PREVENT_COLD_EXTRUSION)
   bool Temperature::allow_cold_extrude = false;
-  bool Temperature::allow_cold_extrude_menu_overide = false;
   celsius_t Temperature::extrude_min_temp = EXTRUDE_MINTEMP;
 #endif
 

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -404,8 +404,9 @@ class Temperature {
 
     #if ENABLED(PREVENT_COLD_EXTRUSION)
       static bool allow_cold_extrude;
+      static bool allow_cold_extrude_menu_overide;
       static celsius_t extrude_min_temp;
-      static bool tooCold(const celsius_t temp) { return allow_cold_extrude ? false : temp < extrude_min_temp - (TEMP_WINDOW); }
+      static bool tooCold(const celsius_t temp) { return (allow_cold_extrude || allow_cold_extrude_menu_overide) ? false : temp < extrude_min_temp - (TEMP_WINDOW); }
       static bool tooColdToExtrude(const uint8_t E_NAME)       { return tooCold(wholeDegHotend(HOTEND_INDEX)); }
       static bool targetTooColdToExtrude(const uint8_t E_NAME) { return tooCold(degTargetHotend(HOTEND_INDEX)); }
     #else

--- a/Marlin/src/module/temperature.h
+++ b/Marlin/src/module/temperature.h
@@ -402,11 +402,18 @@ class Temperature {
       static uint8_t soft_pwm_controller_speed;
     #endif
 
+    #if BOTH(HAS_MARLINUI_MENU, PREVENT_COLD_EXTRUSION) && E_MANUAL > 0
+      static bool allow_cold_extrude_override;
+      static void set_menu_cold_override(const bool allow) { allow_cold_extrude_override = allow; }
+    #else
+      static constexpr bool allow_cold_extrude_override = false;
+      static void set_menu_cold_override(const bool) {}
+    #endif
+
     #if ENABLED(PREVENT_COLD_EXTRUSION)
       static bool allow_cold_extrude;
-      static bool allow_cold_extrude_menu_overide;
       static celsius_t extrude_min_temp;
-      static bool tooCold(const celsius_t temp) { return (allow_cold_extrude || allow_cold_extrude_menu_overide) ? false : temp < extrude_min_temp - (TEMP_WINDOW); }
+      static bool tooCold(const celsius_t temp) { return !allow_cold_extrude && !allow_cold_extrude_override && temp < extrude_min_temp - (TEMP_WINDOW); }
       static bool tooColdToExtrude(const uint8_t E_NAME)       { return tooCold(wholeDegHotend(HOTEND_INDEX)); }
       static bool targetTooColdToExtrude(const uint8_t E_NAME) { return tooCold(degTargetHotend(HOTEND_INDEX)); }
     #else


### PR DESCRIPTION
### Description

With a display that uses menu_motion.cpp  The menu Motion | Move Axis | Move Extruder
Prompts with  "Hotend too cold!" when the hotend is to cold, as It should.

This screen has a option to proceed and cold extrude, which did not work.
It used to go to the Move Extruder menu but all moves result in "echo: cold extrusion prevented" on the console.

Added a second Independent flag allow_cold_extrude_menu_overide that allows this to work as expected

On entering proceed the flag is set and you can cold extrude. 
On returning to the motion  menu the flag is reset so the user gets the  "Hotend too cold!" screen every time.

### Requirements

#define PREVENT_COLD_EXTRUSION
A display that uses menu_motion.cpp

### Benefits

Works as expected

### Related Issues
#22921
