### PR TITLE
Fix macro expansion error when using ProUI

### DIFF
--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -433,7 +433,13 @@ G29_TYPE GcodeSuite::G29() {
       remember_feedrate_scaling_off();
 
       #if ENABLED(PREHEAT_BEFORE_LEVELING)
-        if (!abl.dryrun) probe.preheat_for_probing(LEVELING_NOZZLE_TEMP, LEVELING_BED_TEMP);
+        if (!abl.dryrun) probe.preheat_for_probing(LEVELING_NOZZLE_TEMP,
+          #if BOTH(DWIN_LCD_PROUI, HAS_HEATED_BED)
+            HMI_data.BedLevT
+          #else
+            LEVELING_BED_TEMP
+          #endif
+        );
       #endif
     }
 

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -2869,16 +2869,7 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               #if ENABLED(AUTO_BED_LEVELING_UBL)
                 #if ENABLED(PREHEAT_BEFORE_LEVELING)
                   Popup_Handler(Heating);
-                  #if HAS_HOTEND
-                    if (thermalManager.degTargetHotend(0) < LEVELING_NOZZLE_TEMP)
-                      thermalManager.setTargetHotend(LEVELING_NOZZLE_TEMP, 0);
-                  #endif
-                  #if HAS_HEATED_BED
-                    if (thermalManager.degTargetBed() < LEVELING_BED_TEMP)
-                      thermalManager.setTargetBed(LEVELING_BED_TEMP);
-                  #endif
-                  thermalManager.wait_for_hotend(0);
-                  TERN_(HAS_HEATED_BED, thermalManager.wait_for_bed_heating());
+                  probe.preheat_for_probing(LEVELING_NOZZLE_TEMP, LEVELING_BED_TEMP);
                 #endif
                 #if HAS_BED_PROBE
                   Popup_Handler(Level);

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1702,7 +1702,7 @@ void DWIN_SetDataDefaults() {
     ApplyExtMinT();
   #endif
   #if BOTH(HAS_HEATED_BED, PREHEAT_BEFORE_LEVELING)
-    HMI_data.BedLevT = PREHEAT_1_TEMP_BED;
+    HMI_data.BedLevT = LEVELING_BED_TEMP;
   #endif
   TERN_(BAUD_RATE_GCODE, SetBaud250K());
 }

--- a/Marlin/src/lcd/e3v2/proui/dwin_defines.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_defines.h
@@ -120,8 +120,12 @@ typedef struct {
   #if ENABLED(PREVENT_COLD_EXTRUSION)
     int16_t ExtMinT = EXTRUDE_MINTEMP;
   #endif
-  int16_t BedLevT = PREHEAT_1_TEMP_BED;
-  TERN_(BAUD_RATE_GCODE, bool Baud115K = false);
+  #if BOTH(HAS_HEATED_BED, PREHEAT_BEFORE_LEVELING)
+    int16_t BedLevT = LEVELING_BED_TEMP;
+  #endif
+  #if ENABLED(BAUD_RATE_GCODE)
+    bool Baud115K = false;
+  #endif
   bool FullManualTramming = false;
   // Led
   #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
@@ -135,8 +139,3 @@ typedef struct {
 
 static constexpr size_t eeprom_data_size = 64;
 extern HMI_data_t HMI_data;
-
-#if PREHEAT_1_TEMP_BED
-  #undef LEVELING_BED_TEMP
-  #define LEVELING_BED_TEMP HMI_data.BedLevT
-#endif

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -380,7 +380,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     #if HAS_HOTEND && (PROBING_NOZZLE_TEMP || LEVELING_NOZZLE_TEMP)
       #define WAIT_FOR_NOZZLE_HEAT
     #endif
-    #if HAS_HEATED_BED && (PROBING_BED_TEMP || defined(LEVELING_BED_TEMP))
+    #if HAS_HEATED_BED && (PROBING_BED_TEMP || LEVELING_BED_TEMP)
       #define WAIT_FOR_BED_HEAT
     #endif
 

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -380,7 +380,7 @@ FORCE_INLINE void probe_specific_action(const bool deploy) {
     #if HAS_HOTEND && (PROBING_NOZZLE_TEMP || LEVELING_NOZZLE_TEMP)
       #define WAIT_FOR_NOZZLE_HEAT
     #endif
-    #if HAS_HEATED_BED && (PROBING_BED_TEMP || LEVELING_BED_TEMP)
+    #if HAS_HEATED_BED && (PROBING_BED_TEMP || defined(LEVELING_BED_TEMP))
       #define WAIT_FOR_BED_HEAT
     #endif
 


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

When trying to compile latest `bugfix-2.0.x` branch with `DWIN_LCD_PROUI` enabled, it fails:
```
Marlin\src\module\../lcd/e3v2/proui/dwin_defines.h:141:37: error: token "." is not valid in preprocessor expressions
  141 |   #define LEVELING_BED_TEMP HMI_data.BedLevT
      |                                     ^
Marlin\src\module\probe.cpp:383:48: note: in expansion of macro 'LEVELING_BED_TEMP'
  383 |     #if HAS_HEATED_BED && (PROBING_BED_TEMP || LEVELING_BED_TEMP)
      |                                                ^~~~~~~~~~~~~~~~~
```
<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->
Compilation no longer fails with `DWIN_LCD_PROUI` enabled.

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->
[Configurations.zip](https://github.com/MarlinFirmware/Marlin/files/8529626/Configurations.zip)

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
