### PR TITLE
Enable u8g_esp32_spi with MKS_MINI_12864 lcds also

### DIFF
--- a/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
+++ b/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
@@ -25,7 +25,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ANY(MKS_MINI_12864, FYSETC_MINI_12864_2_1)
+#if EITHER(MKS_MINI_12864, FYSETC_MINI_12864_2_1)
 
 #include <U8glib-HAL.h>
 #include "Arduino.h"
@@ -96,6 +96,6 @@ uint8_t u8g_eps_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_pt
   return 1;
 }
 
-#endif // ANY(MKS_MINI_12864, FYSETC_MINI_12864_2_1)
+#endif // EITHER(MKS_MINI_12864, FYSETC_MINI_12864_2_1)
 
 #endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
+++ b/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
@@ -96,5 +96,6 @@ uint8_t u8g_eps_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_pt
   return 1;
 }
 
-#endif // FYSETC_MINI_12864_2_1
+#endif // ANY(MKS_MINI_12864, FYSETC_MINI_12864_2_1)
+
 #endif // ARDUINO_ARCH_ESP32

--- a/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
+++ b/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
@@ -25,7 +25,7 @@
 
 #include "../../inc/MarlinConfigPre.h"
 
-#if ENABLED(FYSETC_MINI_12864_2_1)
+#if ANY(MKS_MINI_12864, FYSETC_MINI_12864_2_1)
 
 #include <U8glib-HAL.h>
 #include "Arduino.h"


### PR DESCRIPTION
### Description

u8g_esp32_spi is only enabled on a small subset of LCD displays
Presently FYSETC_MINI_12864_2_1  which includes MKS_MINI_12864_V3 and  BTT_MINI_12864_V1
But it should also be enabled with MKS_MINI_12864, which includes MKS_LCD12864A, MKS_LCD12864B, 
At present these error with undefined reference to `u8g_eps_hw_spi_fn(_u8g_t*, unsigned char, unsigned char, void*)'

### Requirements

#define MOTHERBOARD BOARD_MKS_TINYBEE
with #define MKS_MINI_12864 or MKS_LCD12864A or MKS_LCD12864B

### Benefits

Compiles as expected

### Configurations
[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/8546095/Configuration.zip)

### Related Issues
Issue  https://github.com/MarlinFirmware/Marlin/issues/24021