### PR TITLE
BACKLASH_COMPENSATION fails to compile

### DIFF
--- a/Marlin/src/feature/backlash.cpp
+++ b/Marlin/src/feature/backlash.cpp
@@ -173,21 +173,23 @@ public:
   }
 };
 
-void Backlash::set_correction_uint8(const uint8_t v) {
-  StepAdjuster adjuster;
-  correction = v;
-}
-
-void Backlash::set_distance_mm(const AxisEnum axis, const float v) {
-  StepAdjuster adjuster;
-  distance_mm[axis] = v;
-}
-
-#ifdef BACKLASH_SMOOTHING_MM
-  void Backlash::set_smoothing_mm(const float v) {
+#if ENABLED(BACKLASH_GCODE)
+  void Backlash::set_correction_uint8(const uint8_t v) {
     StepAdjuster adjuster;
-    smoothing_mm = v;
+    correction = v;
   }
+
+  void Backlash::set_distance_mm(const AxisEnum axis, const float v) {
+    StepAdjuster adjuster;
+    distance_mm[axis] = v;
+  }
+
+  #ifdef BACKLASH_SMOOTHING_MM
+    void Backlash::set_smoothing_mm(const float v) {
+      StepAdjuster adjuster;
+      smoothing_mm = v;
+    }
+  #endif
 #endif
 
 #if ENABLED(MEASURE_BACKLASH_WHEN_PROBING)

--- a/Marlin/src/feature/backlash.cpp
+++ b/Marlin/src/feature/backlash.cpp
@@ -162,18 +162,20 @@ int32_t Backlash::get_applied_steps(const AxisEnum axis) {
 }
 
 class Backlash::StepAdjuster {
-  xyz_long_t applied_steps;
-public:
-  StepAdjuster() {
-    LOOP_NUM_AXES(axis) applied_steps[axis] = backlash.get_applied_steps((AxisEnum)axis);
-  }
-  ~StepAdjuster() {
-    // after backlash compensation parameter changes, ensure applied step count does not change
-    LOOP_NUM_AXES(axis) residual_error[axis] += backlash.get_applied_steps((AxisEnum)axis) - applied_steps[axis];
-  }
+  private:
+    xyz_long_t applied_steps;
+  public:
+    StepAdjuster() {
+      LOOP_NUM_AXES(axis) applied_steps[axis] = backlash.get_applied_steps((AxisEnum)axis);
+    }
+    ~StepAdjuster() {
+      // after backlash compensation parameter changes, ensure applied step count does not change
+      LOOP_NUM_AXES(axis) residual_error[axis] += backlash.get_applied_steps((AxisEnum)axis) - applied_steps[axis];
+    }
 };
 
 #if ENABLED(BACKLASH_GCODE)
+
   void Backlash::set_correction_uint8(const uint8_t v) {
     StepAdjuster adjuster;
     correction = v;
@@ -190,6 +192,7 @@ public:
       smoothing_mm = v;
     }
   #endif
+
 #endif
 
 #if ENABLED(MEASURE_BACKLASH_WHEN_PROBING)


### PR DESCRIPTION
### Description

With BACKLASH_COMPENSATION enabled in default configs you get

error: no 'void Backlash::set_correction_uint8(uint8_t)' member function declared in class 'Backlash'
   void Backlash::set_correction_uint8(const uint8_t v) {
                                                      ^
error: no 'void Backlash::set_distance_mm(AxisEnum, float)' member function declared in class 'Backlash'
   void Backlash::set_distance_mm(const Ax


Marlin/src/feature/backlash.cpp uses variables that are only defined when BACKLASH_GCODE is defined.

Added a ENABLED(BACKLASH_GCODE) block so that it doesn't error attempting ti use variable that don't yet exist

### Requirements

BACKLASH_COMPENSATION

### Benefits

Compiles as expected

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/24058