### PR TITLE
Simple framework for running tests

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -4295,6 +4295,9 @@
 //
 //#define PINS_DEBUGGING
 
+// Enable Tests that will run at startup and produce a report
+//#define MARLIN_TEST_BUILD
+
 // Enable Marlin dev mode which adds some special commands
 //#define MARLIN_DEV_MODE
 

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -39,17 +39,13 @@
 #endif
 #include <math.h>
 
-#include "core/utility.h"
-
+#include "module/endstops.h"
 #include "module/motion.h"
 #include "module/planner.h"
-#include "module/endstops.h"
-#include "module/temperature.h"
-#include "module/settings.h"
 #include "module/printcounter.h" // PrintCounter or Stopwatch
-
+#include "module/settings.h"
 #include "module/stepper.h"
-#include "module/stepper/indirection.h"
+#include "module/temperature.h"
 
 #include "gcode/gcode.h"
 #include "gcode/parser.h"
@@ -246,6 +242,10 @@
 
 #if ENABLED(EASYTHREED_UI)
   #include "feature/easythreed_ui.h"
+#endif
+
+#if ENABLED(MARLIN_TEST_BUILD)
+  #include "tests/marlin_tests.h"
 #endif
 
 PGMSTR(M112_KILL_STR, "M112 Shutdown");
@@ -1635,6 +1635,8 @@ void setup() {
   marlin_state = MF_RUNNING;
 
   SETUP_LOG("setup() completed.");
+
+  TERN_(MARLIN_TEST_BUILD, runStartupTests());
 }
 
 /**
@@ -1668,6 +1670,8 @@ void loop() {
     endstops.event_handler();
 
     TERN_(HAS_TFT_LVGL_UI, printer_state_polling());
+
+    TERN_(MARLIN_TEST_BUILD, runPeriodicTests());
 
   } while (ENABLED(__AVR__)); // Loop forever on slower (AVR) boards
 }

--- a/Marlin/src/tests/marlin_tests.cpp
+++ b/Marlin/src/tests/marlin_tests.cpp
@@ -1,0 +1,47 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "../inc/MarlinConfigPre.h"
+
+#if ENABLED(MARLIN_TEST_BUILD)
+
+#include "../module/endstops.h"
+#include "../module/motion.h"
+#include "../module/planner.h"
+#include "../module/settings.h"
+#include "../module/stepper.h"
+#include "../module/temperature.h"
+
+// Individual tests are localized in each module.
+// Each test produces its own report.
+
+// Startup tests are run at the end of setup()
+void runStartupTests() {
+  // Call post-setup tests here to validate behaviors.
+}
+
+// Periodic tests are run from within loop()
+void runPeriodicTests() {
+  // Call periodic tests here to validate behaviors.
+}
+
+#endif // MARLIN_TEST_BUILD

--- a/Marlin/src/tests/marlin_tests.h
+++ b/Marlin/src/tests/marlin_tests.h
@@ -1,0 +1,25 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+void runStartupTests();
+void runPeriodicTests();

--- a/ini/features.ini
+++ b/ini/features.ini
@@ -14,6 +14,7 @@ YHCB2004                               = red-scorp/LiquidCrystal_AIP31068@^1.0.4
 HAS_TFT_LVGL_UI                        = lvgl=https://github.com/makerbase-mks/LVGL-6.1.1-MKS/archive/master.zip
                                          src_filter=+<src/lcd/extui/mks_ui>
                                          extra_scripts=download_mks_assets.py
+MARLIN_TEST_BUILD                      = src_filter=+<src/tests>
 POSTMORTEM_DEBUGGING                   = src_filter=+<src/HAL/shared/cpu_exception> +<src/HAL/shared/backtrace>
                                          build_flags=-funwind-tables
 MKS_WIFI_MODULE                        = QRCode=https://github.com/makerbase-mks/QRCode/archive/master.zip

--- a/platformio.ini
+++ b/platformio.ini
@@ -51,7 +51,7 @@ extra_scripts      =
   pre:buildroot/share/PlatformIO/scripts/preflight-checks.py
   post:buildroot/share/PlatformIO/scripts/common-dependencies-post.py
 lib_deps           =
-default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared> -<Marlin/Marlin.ino>
+default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared> -<src/tests>
   -<src/lcd/HD44780> -<src/lcd/TFTGLCD> -<src/lcd/dogm> -<src/lcd/tft> -<src/lcd/tft_io>
   -<src/HAL/STM32/tft> -<src/HAL/STM32F1/tft>
   -<src/lcd/e3v2/common> -<src/lcd/e3v2/creality> -<src/lcd/e3v2/proui> -<src/lcd/e3v2/jyersui> -<src/lcd/e3v2/marlinui>


### PR DESCRIPTION
Add the `MARLIN_TEST_BUILD` flag to do a test build of Marlin that will test various modules and produce a report about behavior. The test build does not necessarily need to function for 3D printing, as it may often be better for many tests if `STEP` signals are not actually sent to stepper drivers.

- Add `MARLIN_TEST_BUILD` configuration option.
- Add `src/tests` folder containing `marlin_tests.cpp`.
- Add `runStartupTests()` for tests that should be run at the end of `setup()`.
- Add `runPeriodicTests()` for tests that should be run at the end of `loop()`.

Please add your suggestions for tests to validate that Marlin's functions are producing the expected results.