### PR TITLE
SOUND_ON_DEFAULT option

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2328,6 +2328,11 @@
 //#define SPEAKER
 
 //
+// Disable the speaker by default.
+//
+//#define DISABLE_BUZZER_DEFAULT
+
+//
 // The duration and frequency for the UI feedback sound.
 // Set these to 0 to disable audio feedback in the LCD menus.
 //

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2328,11 +2328,6 @@
 //#define SPEAKER
 
 //
-// Disable the speaker by default.
-//
-//#define DISABLE_BUZZER_DEFAULT
-
-//
 // The duration and frequency for the UI feedback sound.
 // Set these to 0 to disable audio feedback in the LCD menus.
 //

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1347,7 +1347,7 @@
 
 #if ANY(HAS_DISPLAY, DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI)
   //#define SOUND_MENU_ITEM   // Add a mute option to the LCD menu
-  //#define SOUND_ON_DEFAULT  // Buzzer/speaker default enabled state
+  #define SOUND_ON_DEFAULT    // Buzzer/speaker default enabled state
 #endif
 
 #if EITHER(HAS_DISPLAY, DWIN_LCD_PROUI)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1346,8 +1346,8 @@
 #endif // HAS_MARLINUI_MENU
 
 #if ANY(HAS_DISPLAY, DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI)
-  //#define SOUND_MENU_ITEM          // Add a mute option to the LCD menu
-  //#define BUZZER_ENABLED_DEFAULT   // Buzzer/speaker default enabled state
+  //#define SOUND_MENU_ITEM   // Add a mute option to the LCD menu
+  //#define SOUND_ON_DEFAULT  // Buzzer/speaker default enabled state
 #endif
 
 #if EITHER(HAS_DISPLAY, DWIN_LCD_PROUI)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1347,7 +1347,7 @@
 
 #if ANY(HAS_DISPLAY, DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI)
   //#define SOUND_MENU_ITEM          // Add a mute option to the LCD menu
-  //#define DISABLE_BUZZER_DEFAULT   // Disable the buzzer/speaker by default
+  //#define BUZZER_ENABLED_DEFAULT   // Buzzer/speaker default enabled state
 #endif
 
 #if EITHER(HAS_DISPLAY, DWIN_LCD_PROUI)

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1346,7 +1346,8 @@
 #endif // HAS_MARLINUI_MENU
 
 #if ANY(HAS_DISPLAY, DWIN_LCD_PROUI, DWIN_CREALITY_LCD_JYERSUI)
-  //#define SOUND_MENU_ITEM   // Add a mute option to the LCD menu
+  //#define SOUND_MENU_ITEM          // Add a mute option to the LCD menu
+  //#define DISABLE_BUZZER_DEFAULT   // Disable the buzzer/speaker by default
 #endif
 
 #if EITHER(HAS_DISPLAY, DWIN_LCD_PROUI)

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -97,7 +97,7 @@
   #include "feature/host_actions.h"
 #endif
 
-#if USE_BEEPER
+#if HAS_BEEPER
   #include "libs/buzzer.h"
 #endif
 
@@ -826,7 +826,7 @@ void idle(bool no_stepper_sleep/*=false*/) {
   TERN_(PRINTCOUNTER, print_job_timer.tick());
 
   // Update the Beeper queue
-  TERN_(USE_BEEPER, buzzer.tick());
+  TERN_(HAS_BEEPER, buzzer.tick());
 
   // Handle UI input / draw events
   TERN(DWIN_CREALITY_LCD, DWIN_Update(), ui.update());
@@ -1286,7 +1286,7 @@ void setup() {
   calibrate_delay_loop();
 
   // Init buzzer pin(s)
-  #if USE_BEEPER
+  #if HAS_BEEPER
     SETUP_RUN(buzzer.init());
   #endif
 

--- a/Marlin/src/feature/spindle_laser.h
+++ b/Marlin/src/feature/spindle_laser.h
@@ -30,7 +30,7 @@
 
 #include "spindle_laser_types.h"
 
-#if USE_BEEPER
+#if HAS_BEEPER
   #include "../libs/buzzer.h"
 #endif
 
@@ -272,7 +272,7 @@ public:
        * If not set defaults to 80% power
        */
       static void test_fire_pulse() {
-        TERN_(USE_BEEPER, buzzer.tone(30, 3000));
+        TERN_(HAS_BEEPER, buzzer.tone(30, 3000));
         enable_forward();                  // Turn Laser on (Spindle speak but same funct)
         delay(testPulse);                  // Delay for time set by user in pulse ms menu screen.
         disable();                         // Turn laser off

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -3552,9 +3552,9 @@
  * Buzzer/Speaker
  */
 #if PIN_EXISTS(BEEPER)
-  #define USE_BEEPER 1
+  #define HAS_BEEPER 1
 #endif
-#if USE_BEEPER || ANY(LCD_USE_I2C_BUZZER, PCA9632_BUZZER)
+#if ANY(HAS_BEEPER, LCD_USE_I2C_BUZZER, PCA9632_BUZZER)
   #define HAS_BUZZER 1
 #endif
 

--- a/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
+++ b/Marlin/src/lcd/HD44780/marlinui_HD44780.cpp
@@ -121,7 +121,7 @@ static void createChar_P(const char c, const byte * const ptr) {
 
 #if ENABLED(LCD_USE_I2C_BUZZER)
   void MarlinUI::buzz(const long duration, const uint16_t freq) {
-    if (!buzzer_enabled) return;
+    if (!sound_on) return;
     lcd.buzz(duration, freq);
   }
 #endif

--- a/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
+++ b/Marlin/src/lcd/TFTGLCD/marlinui_TFTGLCD.cpp
@@ -301,7 +301,7 @@ uint8_t MarlinUI::read_slow_buttons() {
 // Duration in ms, freq in Hz
 void MarlinUI::buzz(const long duration, const uint16_t freq) {
   if (!PanelDetected) return;
-  if (!buzzer_enabled) return;
+  if (!sound_on) return;
   #if ENABLED(TFTGLCD_PANEL_SPI)
     WRITE(TFTGLCD_CS, LOW);
     SPI_SEND_ONE(BUZZER);

--- a/Marlin/src/lcd/e3v2/common/encoder.cpp
+++ b/Marlin/src/lcd/e3v2/common/encoder.cpp
@@ -51,11 +51,7 @@ ENCODER_Rate EncoderRate;
 // TODO: Replace with ui.quick_feedback
 void Encoder_tick() {
   #if PIN_EXISTS(BEEPER)
-    if (ui.buzzer_enabled) {
-      WRITE(BEEPER_PIN, HIGH);
-      delay(10);
-      WRITE(BEEPER_PIN, LOW);
-    }
+    if (ui.sound_on) buzzer.click(10);
   #endif
 }
 

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -2587,11 +2587,11 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
           case ADVANCED_BEEPER:
             if (draw) {
               Draw_Menu_Item(row, ICON_Version, F("LCD Beeper"));
-              Draw_Checkbox(row, ui.buzzer_enabled);
+              Draw_Checkbox(row, ui.sound_on);
             }
             else {
-              ui.buzzer_enabled = !ui.buzzer_enabled;
-              Draw_Checkbox(row, ui.buzzer_enabled);
+              ui.sound_on = !ui.sound_on;
+              Draw_Checkbox(row, ui.sound_on);
             }
             break;
         #endif
@@ -4611,7 +4611,7 @@ void CrealityDWINClass::Screen_Update() {
 }
 
 void CrealityDWINClass::AudioFeedback(const bool success/*=true*/) {
-  if (ui.buzzer_enabled)
+  if (ui.sound_on)
     DONE_BUZZ(success);
   else
     Update_Status(success ? "Success" : "Failed");
@@ -4655,7 +4655,7 @@ void CrealityDWINClass::Reset_Settings() {
   eeprom_settings.coordinates_split_line = 0;
   TERN_(AUTO_BED_LEVELING_UBL, mesh_conf.tilt_grid = eeprom_settings.tilt_grid_size + 1);
   corner_pos = eeprom_settings.corner_pos / 10.0f;
-  TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = ENABLED(BUZZER_ENABLED_DEFAULT));
+  TERN_(SOUND_MENU_ITEM, ui.sound_on = ENABLED(SOUND_ON_DEFAULT));
   Redraw_Screen();
 }
 

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -4655,8 +4655,7 @@ void CrealityDWINClass::Reset_Settings() {
   eeprom_settings.coordinates_split_line = 0;
   TERN_(AUTO_BED_LEVELING_UBL, mesh_conf.tilt_grid = eeprom_settings.tilt_grid_size + 1);
   corner_pos = eeprom_settings.corner_pos / 10.0f;
-  TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = true);
-  TERN_(DISABLE_BUZZER_DEFAULT, ui.buzzer_enabled = false);
+  TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = ENABLED(BUZZER_ENABLED_DEFAULT));
   Redraw_Screen();
 }
 

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -4656,6 +4656,7 @@ void CrealityDWINClass::Reset_Settings() {
   TERN_(AUTO_BED_LEVELING_UBL, mesh_conf.tilt_grid = eeprom_settings.tilt_grid_size + 1);
   corner_pos = eeprom_settings.corner_pos / 10.0f;
   TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = true);
+  TERN_(DISABLE_BUZZER_DEFAULT, ui.buzzer_enabled = false);
   Redraw_Screen();
 }
 

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -2106,8 +2106,8 @@ void SetPID(celsius_t t, heater_id_t h) {
 
 #if ENABLED(SOUND_MENU_ITEM)
   void SetEnableSound() {
-    ui.buzzer_enabled = !ui.buzzer_enabled;
-    Draw_Chkb_Line(CurrentMenu->line(), ui.buzzer_enabled);
+    ui.sound_on = !ui.sound_on;
+    Draw_Chkb_Line(CurrentMenu->line(), ui.sound_on);
     DWIN_UpdateLCD();
   }
 #endif
@@ -2638,7 +2638,7 @@ void onDrawLanguage(MenuItemClass* menuitem, int8_t line) {
 #endif
 
 #if ENABLED(SOUND_MENU_ITEM)
-  void onDrawEnableSound(MenuItemClass* menuitem, int8_t line) { onDrawChkbMenu(menuitem, line, ui.buzzer_enabled); }
+  void onDrawEnableSound(MenuItemClass* menuitem, int8_t line) { onDrawChkbMenu(menuitem, line, ui.sound_on); }
 #endif
 
 #ifdef BLTOUCH_HS_MODE

--- a/Marlin/src/lcd/extui/anycubic_chiron/Tunes.cpp
+++ b/Marlin/src/lcd/extui/anycubic_chiron/Tunes.cpp
@@ -35,6 +35,8 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 
+// TODO: Use Marlin's built-in tone player instead.
+
 #if ENABLED(ANYCUBIC_LCD_CHIRON)
 
 #include "Tunes.h"
@@ -44,15 +46,12 @@ namespace Anycubic {
 
   void PlayTune(uint8_t beeperPin, const uint16_t *tune, uint8_t speed=1) {
     uint8_t pos = 1;
-    uint16_t wholenotelen = tune[0] / speed;
+    const uint16_t wholenotelen = tune[0] / speed;
     do {
-      uint16_t freq = tune[pos];
-      uint16_t notelen = wholenotelen / tune[pos + 1];
-
+      const uint16_t freq = tune[pos], notelen = wholenotelen / tune[pos + 1];
       ::tone(beeperPin, freq, notelen);
       ExtUI::delay_ms(notelen);
       pos += 2;
-
       if (pos >= MAX_TUNE_LENGTH) break;
     } while (tune[pos] != n_END);
   }

--- a/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_extui.cpp
+++ b/Marlin/src/lcd/extui/anycubic_i3mega/anycubic_extui.cpp
@@ -42,9 +42,7 @@ namespace ExtUI {
   void onMediaError()     { AnycubicTFT.OnSDCardError(); }
   void onMediaRemoved()   { AnycubicTFT.OnSDCardStateChange(false); }
   void onPlayTone(const uint16_t frequency, const uint16_t duration) {
-    #if ENABLED(SPEAKER)
-      ::tone(BEEPER_PIN, frequency, duration);
-    #endif
+    TERN_(SPEAKER, ::tone(BEEPER_PIN, frequency, duration));
   }
   void onPrintTimerStarted()  { AnycubicTFT.OnPrintTimerStarted(); }
   void onPrintTimerPaused()   { AnycubicTFT.OnPrintTimerPaused(); }

--- a/Marlin/src/lcd/extui/mks_ui/mks_hardware.cpp
+++ b/Marlin/src/lcd/extui/mks_ui/mks_hardware.cpp
@@ -160,6 +160,8 @@
     #endif
   }
 
+  #include "../../../libs/buzzer.h"
+
   void init_test_gpio() {
     endstops.init();
 
@@ -201,12 +203,7 @@
     #endif
   }
 
-  void mks_test_beeper() {
-    WRITE(BEEPER_PIN, HIGH);
-    delay(100);
-    WRITE(BEEPER_PIN, LOW);
-    delay(100);
-  }
+  void mks_test_beeper() { buzzer.click(100); }
 
   #if ENABLED(SDSUPPORT)
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -117,7 +117,9 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
   }
 #endif
 
-#if ENABLED(SOUND_MENU_ITEM)
+#if ENABLED(DISABLE_BUZZER_DEFAULT)
+  bool MarlinUI::buzzer_enabled = false;
+#elif ENABLED(SOUND_MENU_ITEM)
   bool MarlinUI::buzzer_enabled = true;
 #endif
 

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -117,10 +117,8 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
   }
 #endif
 
-#if ENABLED(DISABLE_BUZZER_DEFAULT)
-  bool MarlinUI::buzzer_enabled = false;
-#elif ENABLED(SOUND_MENU_ITEM)
-  bool MarlinUI::buzzer_enabled = true;
+#if ENABLED(SOUND_MENU_ITEM)
+  bool MarlinUI::buzzer_enabled = ENABLED(BUZZER_ENABLED_DEFAULT);
 #endif
 
 #if EITHER(PCA9632_BUZZER, USE_BEEPER)

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -121,7 +121,7 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
   bool MarlinUI::sound_on = ENABLED(SOUND_ON_DEFAULT);
 #endif
 
-#if EITHER(PCA9632_BUZZER, USE_BEEPER)
+#if EITHER(PCA9632_BUZZER, HAS_BEEPER)
   #if ENABLED(PCA9632_BUZZER)
     #include "../feature/leds/pca9632.h"
   #endif
@@ -129,7 +129,7 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
     if (!sound_on) return;
     #if ENABLED(PCA9632_BUZZER)
       PCA9632_buzz(duration, freq);
-    #elif USE_BEEPER
+    #elif HAS_BEEPER
       buzzer.tone(duration, freq);
     #endif
   }
@@ -747,7 +747,7 @@ void MarlinUI::init() {
 
     #if HAS_CHIRP
       chirp(); // Buzz and wait. Is the delay needed for buttons to settle?
-      #if BOTH(HAS_MARLINUI_MENU, USE_BEEPER)
+      #if BOTH(HAS_MARLINUI_MENU, HAS_BEEPER)
         for (int8_t i = 5; i--;) { buzzer.tick(); delay(2); }
       #elif HAS_MARLINUI_MENU
         delay(10);

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -118,16 +118,15 @@ constexpr uint8_t epps = ENCODER_PULSES_PER_STEP;
 #endif
 
 #if ENABLED(SOUND_MENU_ITEM)
-  bool MarlinUI::buzzer_enabled = ENABLED(BUZZER_ENABLED_DEFAULT);
+  bool MarlinUI::sound_on = ENABLED(SOUND_ON_DEFAULT);
 #endif
 
 #if EITHER(PCA9632_BUZZER, USE_BEEPER)
-  #include "../libs/buzzer.h" // for BUZZ() macro
   #if ENABLED(PCA9632_BUZZER)
     #include "../feature/leds/pca9632.h"
   #endif
   void MarlinUI::buzz(const long duration, const uint16_t freq) {
-    if (!buzzer_enabled) return;
+    if (!sound_on) return;
     #if ENABLED(PCA9632_BUZZER)
       PCA9632_buzz(duration, freq);
     #elif USE_BEEPER
@@ -694,7 +693,7 @@ void MarlinUI::init() {
             const millis_t ms = millis();
           #endif
           if (ELAPSED(ms, next_beep)) {
-            buzz(FEEDRATE_CHANGE_BEEP_DURATION, FEEDRATE_CHANGE_BEEP_FREQUENCY);
+            BUZZ(FEEDRATE_CHANGE_BEEP_DURATION, FEEDRATE_CHANGE_BEEP_FREQUENCY);
             next_beep = ms + 500UL;
           }
         #endif
@@ -1646,7 +1645,7 @@ void MarlinUI::init() {
 
   void MarlinUI::flow_fault() {
     LCD_ALERTMESSAGE(MSG_FLOWMETER_FAULT);
-    TERN_(HAS_BUZZER, buzz(1000, 440));
+    BUZZ(1000, 440);
     TERN_(HAS_MARLINUI_MENU, return_to_status());
   }
 

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -226,10 +226,8 @@ public:
 
   #if ENABLED(SOUND_MENU_ITEM)
     static bool buzzer_enabled; // Initialized by settings.load()
-  #elif ENABLED(DISABLE_BUZZER_DEFAULT)
-    static constexpr bool buzzer_enabled = false;
   #else
-    static constexpr bool buzzer_enabled = true;
+    static constexpr bool buzzer_enabled = ENABLED(BUZZER_ENABLED_DEFAULT);
   #endif
 
   #if HAS_BUZZER

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -189,6 +189,9 @@ typedef bool (*statusResetFunc_t)();
 //////////// MarlinUI Singleton ////////////
 ////////////////////////////////////////////
 
+class MarlinUI;
+extern MarlinUI ui;
+
 class MarlinUI {
 public:
 
@@ -232,7 +235,7 @@ public:
   #endif
 
   FORCE_INLINE static void chirp() {
-    TERN_(HAS_CHIRP, BUZZ(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ));
+    TERN_(HAS_CHIRP, TERN(HAS_BUZZER, buzz, BUZZ)(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ));
   }
 
   #if ENABLED(LCD_HAS_STATUS_INDICATORS)
@@ -781,8 +784,6 @@ private:
     #endif
   #endif
 };
-
-extern MarlinUI ui;
 
 #define LCD_MESSAGE_F(S)       ui.set_status(F(S))
 #define LCD_MESSAGE(M)         ui.set_status(GET_TEXT_F(M))

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -227,7 +227,7 @@ public:
   #if ENABLED(SOUND_MENU_ITEM)
     static bool sound_on; // Initialized by settings.load()
   #else
-    static constexpr bool sound_on = ENABLED(SOUND_ON_DEFAULT);
+    static constexpr bool sound_on = true;
   #endif
 
   #if HAS_BUZZER

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -226,6 +226,8 @@ public:
 
   #if ENABLED(SOUND_MENU_ITEM)
     static bool buzzer_enabled; // Initialized by settings.load()
+  #elif ENABLED(DISABLE_BUZZER_DEFAULT)
+    static constexpr bool buzzer_enabled = false;
   #else
     static constexpr bool buzzer_enabled = true;
   #endif

--- a/Marlin/src/lcd/marlinui.h
+++ b/Marlin/src/lcd/marlinui.h
@@ -21,15 +21,12 @@
  */
 #pragma once
 
+#include "../inc/MarlinConfig.h"
 #include "../sd/cardreader.h"
 #include "../module/motion.h"
+#include "../libs/buzzer.h"
+
 #include "buttons.h"
-
-#include "../inc/MarlinConfig.h"
-
-#if HAS_BUZZER
-  #include "../libs/buzzer.h"
-#endif
 
 #if ENABLED(TOUCH_SCREEN_CALIBRATION)
   #include "tft_io/touch_calibration.h"
@@ -225,9 +222,9 @@ public:
   #endif
 
   #if ENABLED(SOUND_MENU_ITEM)
-    static bool buzzer_enabled; // Initialized by settings.load()
+    static bool sound_on; // Initialized by settings.load()
   #else
-    static constexpr bool buzzer_enabled = ENABLED(BUZZER_ENABLED_DEFAULT);
+    static constexpr bool sound_on = ENABLED(SOUND_ON_DEFAULT);
   #endif
 
   #if HAS_BUZZER
@@ -235,7 +232,7 @@ public:
   #endif
 
   FORCE_INLINE static void chirp() {
-    TERN_(HAS_CHIRP, buzz(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ));
+    TERN_(HAS_CHIRP, BUZZ(LCD_FEEDBACK_FREQUENCY_DURATION_MS, LCD_FEEDBACK_FREQUENCY_HZ));
   }
 
   #if ENABLED(LCD_HAS_STATUS_INDICATORS)

--- a/Marlin/src/lcd/menu/menu_bed_corners.cpp
+++ b/Marlin/src/lcd/menu/menu_bed_corners.cpp
@@ -247,7 +247,7 @@ static void _lcd_level_bed_corners_get_next_position() {
       probe_triggered = PROBE_TRIGGERED();
       if (probe_triggered) {
         endstops.hit_on_purpose();
-        TERN_(LEVEL_CORNERS_AUDIO_FEEDBACK, ui.buzz(200, 600));
+        TERN_(LEVEL_CORNERS_AUDIO_FEEDBACK, BUZZ(200, 600));
       }
       idle();
     }

--- a/Marlin/src/lcd/menu/menu_configuration.cpp
+++ b/Marlin/src/lcd/menu/menu_configuration.cpp
@@ -574,7 +574,7 @@ void menu_configuration() {
   #endif
 
   #if ENABLED(SOUND_MENU_ITEM)
-    EDIT_ITEM(bool, MSG_SOUND, &ui.buzzer_enabled, []{ ui.chirp(); });
+    EDIT_ITEM(bool, MSG_SOUND, &ui.sound_on, []{ ui.chirp(); });
   #endif
 
   #if ENABLED(EEPROM_SETTINGS)

--- a/Marlin/src/lcd/tft/ui_1024x600.cpp
+++ b/Marlin/src/lcd/tft/ui_1024x600.cpp
@@ -596,7 +596,7 @@ MotionAxisState motionAxisState;
 static void quick_feedback() {
   #if HAS_CHIRP
     ui.chirp(); // Buzz and wait. Is the delay needed for buttons to settle?
-    #if BOTH(HAS_MARLINUI_MENU, USE_BEEPER)
+    #if BOTH(HAS_MARLINUI_MENU, HAS_BEEPER)
       for (int8_t i = 5; i--;) { buzzer.tick(); delay(2); }
     #elif HAS_MARLINUI_MENU
       delay(10);

--- a/Marlin/src/lcd/tft/ui_320x240.cpp
+++ b/Marlin/src/lcd/tft/ui_320x240.cpp
@@ -578,7 +578,7 @@ MotionAxisState motionAxisState;
 static void quick_feedback() {
   #if HAS_CHIRP
     ui.chirp(); // Buzz and wait. Is the delay needed for buttons to settle?
-    #if BOTH(HAS_MARLINUI_MENU, USE_BEEPER)
+    #if BOTH(HAS_MARLINUI_MENU, HAS_BEEPER)
       for (int8_t i = 5; i--;) { buzzer.tick(); delay(2); }
     #elif HAS_MARLINUI_MENU
       delay(10);

--- a/Marlin/src/lcd/tft/ui_480x320.cpp
+++ b/Marlin/src/lcd/tft/ui_480x320.cpp
@@ -583,7 +583,7 @@ MotionAxisState motionAxisState;
 static void quick_feedback() {
   #if HAS_CHIRP
     ui.chirp(); // Buzz and wait. Is the delay needed for buttons to settle?
-    #if BOTH(HAS_MARLINUI_MENU, USE_BEEPER)
+    #if BOTH(HAS_MARLINUI_MENU, HAS_BEEPER)
       for (int8_t i = 5; i--;) { buzzer.tick(); delay(2); }
     #elif HAS_MARLINUI_MENU
       delay(10);

--- a/Marlin/src/libs/buzzer.cpp
+++ b/Marlin/src/libs/buzzer.cpp
@@ -45,7 +45,7 @@ Buzzer buzzer;
  * @param frequency Frequency of the tone in hertz
  */
 void Buzzer::tone(const uint16_t duration, const uint16_t frequency/*=0*/) {
-  if (!ui.buzzer_enabled) return;
+  if (!ui.sound_on) return;
   while (buffer.isFull()) {
     tick();
     thermalManager.manage_heater();
@@ -55,7 +55,7 @@ void Buzzer::tone(const uint16_t duration, const uint16_t frequency/*=0*/) {
 }
 
 void Buzzer::tick() {
-  if (!ui.buzzer_enabled) return;
+  if (!ui.sound_on) return;
   const millis_t now = millis();
 
   if (!state.endtime) {

--- a/Marlin/src/libs/buzzer.cpp
+++ b/Marlin/src/libs/buzzer.cpp
@@ -22,7 +22,7 @@
 
 #include "../inc/MarlinConfig.h"
 
-#if USE_BEEPER
+#if HAS_BEEPER
 
 #include "buzzer.h"
 #include "../module/temperature.h"
@@ -81,4 +81,4 @@ void Buzzer::tick() {
   else if (ELAPSED(now, state.endtime)) reset();
 }
 
-#endif // USE_BEEPER
+#endif // HAS_BEEPER

--- a/Marlin/src/libs/buzzer.h
+++ b/Marlin/src/libs/buzzer.h
@@ -23,7 +23,7 @@
 
 #include "../inc/MarlinConfig.h"
 
-#if USE_BEEPER
+#if HAS_BEEPER
 
   #include "circularqueue.h"
 
@@ -121,8 +121,8 @@
 #elif HAS_BUZZER
 
   // Buzz indirectly via the MarlinUI instance
-  #include "../lcd/marlinui.h"
   #define BUZZ(d,f) ui.buzz(d,f)
+  #include "../lcd/marlinui.h"
 
 #else
 

--- a/Marlin/src/libs/buzzer.h
+++ b/Marlin/src/libs/buzzer.h
@@ -62,18 +62,6 @@
       FORCE_INLINE static void invert() { TOGGLE(BEEPER_PIN); }
 
       /**
-       * @brief Turn off a digital PIN
-       * @details Alias of digitalWrite(PIN, LOW) using FastIO
-       */
-      FORCE_INLINE static void off() { WRITE(BEEPER_PIN, LOW); }
-
-      /**
-       * @brief Turn on a digital PIN
-       * @details Alias of digitalWrite(PIN, HIGH) using FastIO
-       */
-      FORCE_INLINE static void on() { WRITE(BEEPER_PIN, HIGH); }
-
-      /**
        * @brief Resets the state of the class
        * @details Brings the class state to a known one.
        */
@@ -90,6 +78,21 @@
         SET_OUTPUT(BEEPER_PIN);
         reset();
       }
+
+      /**
+       * @brief Turn on a digital PIN
+       * @details Alias of digitalWrite(PIN, HIGH) using FastIO
+       */
+      FORCE_INLINE static void on() { WRITE(BEEPER_PIN, HIGH); }
+
+      /**
+       * @brief Turn off a digital PIN
+       * @details Alias of digitalWrite(PIN, LOW) using FastIO
+       */
+      FORCE_INLINE static void off() { WRITE(BEEPER_PIN, LOW); }
+
+      static void click(const uint16_t duration) { on(); delay(duration); off(); }
+
 
       /**
        * @brief Add a tone to the queue

--- a/Marlin/src/libs/buzzer.h
+++ b/Marlin/src/libs/buzzer.h
@@ -93,7 +93,6 @@
 
       static void click(const uint16_t duration) { on(); delay(duration); off(); }
 
-
       /**
        * @brief Add a tone to the queue
        * @details Adds a tone_t structure to the ring buffer, will block IO if the

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2945,7 +2945,11 @@ void MarlinSettings::reset() {
   //
   // Buzzer enable/disable
   //
-  TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = true);
+  #if ENABLED(DISABLE_BUZZER_DEFAULT)
+    TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = false);
+  #else
+    TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = true);
+  #endif
 
   //
   // Magnetic Parking Extruder

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -2945,10 +2945,8 @@ void MarlinSettings::reset() {
   //
   // Buzzer enable/disable
   //
-  #if ENABLED(DISABLE_BUZZER_DEFAULT)
-    TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = false);
-  #else
-    TERN_(SOUND_MENU_ITEM, ui.buzzer_enabled = true);
+  #if ENABLED(SOUND_MENU_ITEM)
+    ui.buzzer_enabled = ENABLED(BUZZER_ENABLED_DEFAULT);
   #endif
 
   //

--- a/Marlin/src/module/settings.cpp
+++ b/Marlin/src/module/settings.cpp
@@ -541,7 +541,7 @@ typedef struct SettingsDataStruct {
   // Buzzer enable/disable
   //
   #if ENABLED(SOUND_MENU_ITEM)
-    bool buzzer_enabled;
+    bool sound_on;
   #endif
 
   //
@@ -1576,7 +1576,7 @@ void MarlinSettings::postprocess() {
     // Buzzer enable/disable
     //
     #if ENABLED(SOUND_MENU_ITEM)
-      EEPROM_WRITE(ui.buzzer_enabled);
+      EEPROM_WRITE(ui.sound_on);
     #endif
 
     //
@@ -2546,8 +2546,8 @@ void MarlinSettings::postprocess() {
       // Buzzer enable/disable
       //
       #if ENABLED(SOUND_MENU_ITEM)
-        _FIELD_TEST(buzzer_enabled);
-        EEPROM_READ(ui.buzzer_enabled);
+        _FIELD_TEST(sound_on);
+        EEPROM_READ(ui.sound_on);
       #endif
 
       //
@@ -2946,7 +2946,7 @@ void MarlinSettings::reset() {
   // Buzzer enable/disable
   //
   #if ENABLED(SOUND_MENU_ITEM)
-    ui.buzzer_enabled = ENABLED(BUZZER_ENABLED_DEFAULT);
+    ui.sound_on = ENABLED(SOUND_ON_DEFAULT);
   #endif
 
   //

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -1226,16 +1226,12 @@ inline void loud_kill(FSTR_P const lcd_msg, const heater_id_t heater_id) {
   thermalManager.disable_all_heaters();
   #if USE_BEEPER
     for (uint8_t i = 20; i--;) {
-      WRITE(BEEPER_PIN, HIGH);
-      delay(25);
       watchdog_refresh();
-      WRITE(BEEPER_PIN, LOW);
-      delay(40);
-      watchdog_refresh();
-      delay(40);
+      buzzer.click(25);
+      delay(80);
       watchdog_refresh();
     }
-    WRITE(BEEPER_PIN, HIGH);
+    buzzer.on();
   #endif
   #if ENABLED(NOZZLE_PARK_FEATURE)
     if (!homing_needed_error()) {

--- a/Marlin/src/module/temperature.cpp
+++ b/Marlin/src/module/temperature.cpp
@@ -178,7 +178,7 @@
   #include "tool_change.h"
 #endif
 
-#if USE_BEEPER
+#if HAS_BEEPER
   #include "../libs/buzzer.h"
 #endif
 
@@ -1224,7 +1224,7 @@ int16_t Temperature::getHeaterPower(const heater_id_t heater_id) {
 inline void loud_kill(FSTR_P const lcd_msg, const heater_id_t heater_id) {
   marlin_state = MF_KILLED;
   thermalManager.disable_all_heaters();
-  #if USE_BEEPER
+  #if HAS_BEEPER
     for (uint8_t i = 20; i--;) {
       watchdog_refresh();
       buzzer.click(25);


### PR DESCRIPTION
### Description

This PR adds a simple option to disable the buzzer/speaker by default, similar to how it's done when the `SOUND_MENU_ITEM` option is defined and disabled via the LCD settings.

Resetting the EEPROM will default to the buzzer/speaker being disabled, so long as `SOUND_ON_DEFAULT` is not defined.

The buzzer/speaker can still be enabled through the LCD, so long as the `SOUND_MENU_ITEM` is also defined.

### Requirements

This should work with a DWIN/LCD display, however it has only been tested with the stock DWIN display that came with my Ender 3 V2.

### Benefits

Those of us who use `SOUND_MENU_ITEM` and usually disable the buzzer/speaker after flashing a new firmware and/or resetting the EEPROM would no longer have to go through the extra step of disabling it manually, and instead have it be disabled by default, while still allowing it to be enabled manually from the LCD.

### Configurations

New configuration option `SOUND_ON_DEFAULT` was added directly to `Marlin/Configuration_adv.h`, along with a helpful comment on its usage.

Note that this is a very simple change/addition, so should be quick to review and safe to merge.