### PR TITLE
Fix extrapolation of unprobed points for kinetic and bilinear bed leveling

### DIFF
--- a/Marlin/src/feature/bedlevel/abl/bbl.h
+++ b/Marlin/src/feature/bedlevel/abl/bbl.h
@@ -24,6 +24,7 @@
 #include "../../../inc/MarlinConfigPre.h"
 
 class LevelingBilinear {
+private:
   static xy_pos_t grid_spacing, grid_start;
   static xy_float_t grid_factor;
   static bed_mesh_t z_values;

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -508,7 +508,9 @@ G29_TYPE GcodeSuite::G29() {
         abl.reenable = false;
       }
 
+      // Pre-populate local Z values from the stored mesh
       TERN_(IS_KINEMATIC, COPY(abl.z_values, Z_VALUES_ARR));
+
     #endif // AUTO_BED_LEVELING_BILINEAR
 
   } // !g29_in_progress

--- a/Marlin/src/gcode/bedlevel/abl/G29.cpp
+++ b/Marlin/src/gcode/bedlevel/abl/G29.cpp
@@ -507,6 +507,8 @@ G29_TYPE GcodeSuite::G29() {
         // Can't re-enable (on error) until the new grid is written
         abl.reenable = false;
       }
+
+      TERN_(IS_KINEMATIC, COPY(abl.z_values, Z_VALUES_ARR));
     #endif // AUTO_BED_LEVELING_BILINEAR
 
   } // !g29_in_progress

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.cpp
@@ -200,7 +200,7 @@ void DGUSScreenHandler::StoreSettings(char *buff) {
   data.initialized = true;
   data.volume = dgus_display.GetVolume();
   data.brightness = dgus_display.GetBrightness();
-  data.abl = (ExtUI::getLevelingActive() && ExtUI::getMeshValid());
+  data.abl_okay = (ExtUI::getLevelingActive() && ExtUI::getMeshValid());
 
   memcpy(buff, &data, sizeof(data));
 }
@@ -216,8 +216,7 @@ void DGUSScreenHandler::LoadSettings(const char *buff) {
   dgus_display.SetBrightness(data.initialized ? data.brightness : DGUS_DEFAULT_BRIGHTNESS);
 
   if (data.initialized) {
-    leveling_active = (data.abl && ExtUI::getMeshValid());
-
+    leveling_active = (data.abl_okay && ExtUI::getMeshValid());
     ExtUI::setLevelingActive(leveling_active);
   }
 }

--- a/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.h
+++ b/Marlin/src/lcd/extui/dgus_reloaded/DGUSScreenHandler.h
@@ -134,7 +134,7 @@ private:
     bool initialized;
     uint8_t volume;
     uint8_t brightness;
-    bool abl;
+    bool abl_okay;
   } eeprom_data_t;
 };
 


### PR DESCRIPTION
Fix bug introduced in #23868 where the temporary grid does not get populated with NANs and so kinetic does not extrapolate unprobed points.

### Description

#32868 introduced a temporary copy of the grid for leveling so that dryrun could work properly. This does not get populated with NANs when reset_bed_level() is called and so the bilinear extrapolation code assumes the resulting grid has already had all its extrapolation done.

### Requirements

Kinetic machines and bilinear bed leveling.

### Benefits

BBL works for kinetic machines.

### Related Issues

#24094