### PR TITLE
Update NeoPixel Type Comment

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3051,7 +3051,7 @@
 // Support for Adafruit NeoPixel LED driver
 //#define NEOPIXEL_LED
 #if ENABLED(NEOPIXEL_LED)
-  #define NEOPIXEL_TYPE          NEO_GRBW // NEO_GRBW / NEO_GRB - four/three channel driver type (defined in Adafruit_NeoPixel.h)
+  #define NEOPIXEL_TYPE          NEO_GRBW // NEO_GRBW, NEO_RGBW, etc. / NEO_GRB, NEO_RBG, etc. - four/three channel driver type (defined in https://github.com/adafruit/Adafruit_NeoPixel/blob/master/Adafruit_NeoPixel.h)
   //#define NEOPIXEL_PIN                4 // LED driving pin
   //#define NEOPIXEL2_TYPE  NEOPIXEL_TYPE
   //#define NEOPIXEL2_PIN               5

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -3051,7 +3051,8 @@
 // Support for Adafruit NeoPixel LED driver
 //#define NEOPIXEL_LED
 #if ENABLED(NEOPIXEL_LED)
-  #define NEOPIXEL_TYPE          NEO_GRBW // NEO_GRBW, NEO_RGBW, etc. / NEO_GRB, NEO_RBG, etc. - four/three channel driver type (defined in https://github.com/adafruit/Adafruit_NeoPixel/blob/master/Adafruit_NeoPixel.h)
+  #define NEOPIXEL_TYPE          NEO_GRBW // NEO_GRBW, NEO_RGBW, NEO_GRB, NEO_RBG, etc.
+                                          // See https://github.com/adafruit/Adafruit_NeoPixel/blob/master/Adafruit_NeoPixel.h
   //#define NEOPIXEL_PIN                4 // LED driving pin
   //#define NEOPIXEL2_TYPE  NEOPIXEL_TYPE
   //#define NEOPIXEL2_PIN               5


### PR DESCRIPTION
### Description

Update NeoPixel Type comment to make it clear that you have more than two options and include a full link to Adafruit's NeoPixel library which lists all possible permutations.

### Benefits

Currently, it only looks like two options are available to users (`NEO_GRBW` and `NEO_GRB`), but there's 30 possible values for  `NEOPIXEL_TYPE`.

### Related Issues

I may need to revert https://github.com/MarlinFirmware/Marlin/pull/24011 once tested on more clones of `FYSETC_MINI_12864_2_1` since it wasn't clear why the changes were made in https://github.com/MarlinFirmware/Marlin/pull/23590.