### PR TITLE
Remove Facebook UTM code from URLs (fbclid)

### DIFF
--- a/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
+++ b/Marlin/src/pins/ramps/pins_FYSETC_F6_13.h
@@ -234,7 +234,7 @@
 
   #if ENABLED(FYSETC_MINI_12864)
     //
-    // See https://wiki.fysetc.com/Mini12864_Panel/?fbclid=IwAR1FyjuNdVOOy9_xzky3qqo_WeM5h-4gpRnnWhQr_O1Ef3h0AFnFXmCehK8
+    // See https://wiki.fysetc.com/Mini12864_Panel/
     //
     #define DOGLCD_A0                         16
     #define DOGLCD_CS                         17

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -752,7 +752,7 @@
 
       #elif ENABLED(FYSETC_MINI_12864)
 
-        // From https://wiki.fysetc.com/Mini12864_Panel/?fbclid=IwAR1FyjuNdVOOy9_xzky3qqo_WeM5h-4gpRnnWhQr_O1Ef3h0AFnFXmCehK8
+        // From https://wiki.fysetc.com/Mini12864_Panel/
 
         #define DOGLCD_A0            EXP1_07_PIN
         #define DOGLCD_CS            EXP1_08_PIN

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_LITE_V1_0.h
@@ -439,7 +439,7 @@
 
       #elif ENABLED(FYSETC_MINI_12864)
 
-        // From https://wiki.fysetc.com/Mini12864_Panel/?fbclid=IwAR1FyjuNdVOOy9_xzky3qqo_WeM5h-4gpRnnWhQr_O1Ef3h0AFnFXmCehK8
+        // From https://wiki.fysetc.com/Mini12864_Panel/
 
         // TO TEST
         //#define DOGLCD_A0                   16

--- a/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
+++ b/Marlin/src/pins/samd/pins_BRICOLEMON_V1_0.h
@@ -490,7 +490,7 @@
 
       #elif ENABLED(FYSETC_MINI_12864)
 
-        // From https://wiki.fysetc.com/Mini12864_Panel/?fbclid=IwAR1FyjuNdVOOy9_xzky3qqo_WeM5h-4gpRnnWhQr_O1Ef3h0AFnFXmCehK8
+        // From https://wiki.fysetc.com/Mini12864_Panel/
 
         // TO TEST
         //#define DOGLCD_A0                   16

--- a/Marlin/src/pins/stm32f4/pins_ARMED.h
+++ b/Marlin/src/pins/stm32f4/pins_ARMED.h
@@ -150,7 +150,7 @@
 
 #if ENABLED(FYSETC_MINI_12864)
   //
-  // See https://wiki.fysetc.com/Mini12864_Panel/?fbclid=IwAR1FyjuNdVOOy9_xzky3qqo_WeM5h-4gpRnnWhQr_O1Ef3h0AFnFXmCehK8
+  // See https://wiki.fysetc.com/Mini12864_Panel/
   //
   #define DOGLCD_A0                         PE9
   #define DOGLCD_CS                         PE8


### PR DESCRIPTION
### Description

Remove Facebook UTM code from URLs (fbclid)
