### PR TITLE
update ESP3DLib

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -236,7 +236,7 @@ HAS_SERVOS                             = src_filter=+<src/module/servo.cpp> +<sr
 MORGAN_SCARA                           = src_filter=+<src/gcode/scara>
 HAS_MICROSTEPS                         = src_filter=+<src/gcode/control/M350_M351.cpp>
 (ESP3D_)?WIFISUPPORT                   = AsyncTCP, ESP Async WebServer
-                                         ESP3DLib=https://github.com/luc-github/ESP3DLib/archive/master-2.0.7.zip
+                                         ESP3DLib=https://github.com/luc-github/ESP3DLib/archive/master.zip
                                          arduinoWebSockets=links2004/WebSockets@2.3.4
                                          luc-github/ESP32SSDP@^1.1.1
                                          lib_ignore=ESPAsyncTCP


### PR DESCRIPTION
### Description

ESP3DLib has been updated to work on newer marlin versions. But features.ini still downloads the older version
Updated the url to https://github.com/luc-github/ESP3DLib/archive/master.zip

### Requirements

ESP3DLib and platformio

### Benefits

Compiles on newer marlins including bugfix

### Related Issues
Issue https://github.com/MarlinFirmware/Marlin/issues/24138