### PR TITLE
Fix Faux RGB/Suppress "NEO_RGB redefined" warnings

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2448,6 +2448,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #if EITHER(FYSETC_242_OLED_12864, FYSETC_MINI_12864_2_1)
   #ifndef NEO_RGB
     #define NEO_RGB 123
+    #define FAUX_RGB 1
   #endif
   #if defined(NEOPIXEL_TYPE) && NEOPIXEL_TYPE != NEO_RGB
     #error "Your FYSETC/MKS/BTT Mini Panel requires NEOPIXEL_TYPE to be NEO_RGB."
@@ -2456,6 +2457,7 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #endif
   #if FAUX_RGB
     #undef NEO_RGB
+    #undef FAUX_RGB
   #endif
 #elif EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0) && DISABLED(RGB_LED)
   #error "Your FYSETC Mini Panel requires RGB_LED."


### PR DESCRIPTION
### Description

`FAUX_RGB` was dropped in #24111/[5503d4b](https://github.com/MarlinFirmware/Marlin/pull/24111/commits/5503d4b46f00469b544ed3eaa78ba8769e8a33b0) (and thus `#if FAUX_RGB` is no longer triggered), but is still needed to suppress the many "NEO_RGB redefined" warnings:

```prolog
In file included from Marlin/src/feature/leds/neopixel.h:38,
                 from Marlin/src/feature/leds/leds.h:39,
                 from Marlin/src/MarlinCore.cpp:121:
.pio/libdeps/BIGTREE_SKR_2/Adafruit NeoPixel/Adafruit_NeoPixel.h:79: warning: "NEO_RGB" redefined
   79 | #define NEO_RGB  ((0<<6) | (0<<4) | (1<<2) | (2)) ///< Transmit as R,G,B
      | 
In file included from Marlin/src/inc/MarlinConfig.h:50,
                 from Marlin/src/MarlinCore.h:24,
                 from Marlin/src/MarlinCore.cpp:31:
Marlin/src/inc/SanityCheck.h:2450: note: this is the location of the previous definition
 2450 |     #define NEO_RGB 123
      | 
```
Tested on a BTT Mini 12864 V1 and NeoPixels still work as intended.

### Requirements

NeoPixel-based Mini 12864 LCD

### Benefits

No more redefined warnings.

### Related Issues

- #24111
- #24011 