### PR TITLE
Improve MKS SGEN_L V2 & Robin Nano V3 Pins

### DIFF
--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -102,6 +102,12 @@
 #endif
 
 //
+// Filament Runout Sensor
+//
+#define FIL_RUNOUT_PIN                     P1_28  // X+
+#define FIL_RUNOUT2_PIN                    P1_26  // Y+
+
+//
 // Steppers
 //
 #define X_STEP_PIN                         P2_02

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -207,6 +207,14 @@
 #define TEMP_1_PIN                      P0_25_A2  // Analog Input A2 (TH2)
 #define TEMP_2_PIN                      P0_26_A3  // Analog Input A3 (P0.26, No pull up)
 
+#if HOTENDS == 1 && !REDUNDANT_TEMP_MATCH(SOURCE, E1)
+  #if TEMP_SENSOR_PROBE
+    #define TEMP_PROBE_PIN            TEMP_1_PIN
+  #elif TEMP_SENSOR_CHAMBER
+    #define TEMP_CHAMBER_PIN          TEMP_1_PIN
+  #endif
+#endif
+
 //
 // Heaters / Fans
 //

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -36,9 +36,7 @@
 // EEPROM, MKS SGEN_L V2.0 hardware has 4K EEPROM on the board
 //
 #if NO_EEPROM_SELECTED
-  //#define SDCARD_EEPROM_EMULATION
-  //#define I2C_EEPROM                            // AT24C32
-  #define FLASH_EEPROM_EMULATION
+  #define I2C_EEPROM                              // AT24C32
   #define MARLIN_EEPROM_SIZE              0x1000  // 4K
 #endif
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -119,6 +119,14 @@
 #define TEMP_1_PIN                          PA2   // TH2
 #define TEMP_BED_PIN                        PC0   // TB1
 
+#if HOTENDS == 1 && !REDUNDANT_TEMP_MATCH(SOURCE, E1)
+  #if TEMP_SENSOR_PROBE
+    #define TEMP_PROBE_PIN            TEMP_1_PIN
+  #elif TEMP_SENSOR_CHAMBER
+    #define TEMP_CHAMBER_PIN          TEMP_1_PIN
+  #endif
+#endif
+
 //
 // Heaters / Fans
 //


### PR DESCRIPTION
### Description

**MKS SGEN_L V2**:
- Enable onboard AT24C32 / 4K EEPROM
- Enable filament runout pins (as X+ and Y+, similar to SKR series)
- Enable Probe & Chamber temperature sensor pins

**MKS Robin Nano V3**:
- Enable Probe & Chamber temperature sensor pins

### Requirements

MKS SGEN_L V2 or Robin Nano V3

### Benefits

Features noted above will work on MKS SGEN_L V2 & Robin Nano V3

### Related Issues

None. Found while adding board/feature support to my [Prusa AIO fork](https://github.com/thisiskeithb/PrusaAIO).