### PR TITLE
Move TMC Test

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1577,10 +1577,6 @@ void setup() {
     SETUP_RUN(hostui.prompt_end());
   #endif
 
-  #if HAS_TRINAMIC_CONFIG && DISABLED(PSU_DEFAULT_OFF)
-    SETUP_RUN(test_tmc_connection());
-  #endif
-
   #if HAS_DRIVER_SAFE_POWER_PROTECT
     SETUP_RUN(stepper_driver_backward_report());
   #endif
@@ -1636,6 +1632,10 @@ void setup() {
 
   #if ENABLED(EASYTHREED_UI)
     SETUP_RUN(easythreed_ui.init());
+  #endif
+
+  #if HAS_TRINAMIC_CONFIG && DISABLED(PSU_DEFAULT_OFF)
+    SETUP_RUN(test_tmc_connection());
   #endif
 
   marlin_state = MF_RUNNING;


### PR DESCRIPTION
### Description

Move TMC test to the very end of Marlin setup.

**Background:** While adding additional board support to my [PrusaAIO fork](https://github.com/thisiskeithb/PrusaAIO), I added support for the MKS Robin Nano V3 and Robin E3 boards and got a TMC CONNECTION ERROR, despite the same settings working fine on other boards.

<details><summary>M122 output was clean, which had me stumped:</summary>

```prolog
SENDING:M122
        X    Y    Z    Z2    E
Address        0    0    0    0    0
Enabled        false    false    true    true    false
Set current    500    600    450    450    550
RMS current    489    581    428    428    520
MAX current    689    819    603    603    733
Run current    15/31    18/31    13/31    13/31    16/31
Hold current    7/31    9/31    6/31    6/31    8/31
CS actual    7/31    9/31    6/31    6/31    8/31
PWM scale
vsense        1=.18    1=.18    1=.18    1=.18    1=.18
stealthChop    true    true    true    true    true
msteps        16    16    16    16    32
interp        true    true    true    true    true
tstep        max    max    max    max    max
PWM thresh.
[mm/s]
OT prewarn    false    false    false    false    false
pwm scale sum    9    11    7    7    10
pwm scale auto    0    0    0    0    0
pwm offset auto    36    36    36    36    36
pwm grad auto    14    14    14    14    14
off time    4    4    4    4    4
blank time    24    24    24    24    24
hysteresis
 -end        2    2    2    2    2
 -start        1    1    1    1    1
Stallguard thrs    90    100    0    0    0
uStep count    56    56    8    56    44
DRVSTATUS    X    Y    Z    Z2    E
sg_result    0    0    0    0    0
stst
olb
ola
s2gb
s2ga
otpw
ot
157C
150C
143C
120C
s2vsa
s2vsb
Driver registers:
        X    0xC0:07:00:00
        Y    0xC0:09:00:00
        Z    0xC0:06:00:00
        Z2    0xC0:06:00:00
        E    0xC0:08:00:00
Testing X connection... OK
Testing Y connection... OK
Testing Z connection... OK
Testing Z2 connection... OK
Testing E connection... OK
```
</details>

I rebuilt the config from scratch using stock bugfix and narrowed it down to having `SQUARE_WAVE_STEPPING` enabled. 

After consulting @InsanityAutomation, he recommend moving `test_tmc_connection()` setup to the very end of Marlin's setup thinking the TMCs were being setup too early...and...magic! The error went away!

**Are there any side effects to moving this to the end of Marlin's setup? I can test on more boards/TMC configs here, but this would probably need some discussion & testing before merging.**

### Requirements

MKS Robin Nano V3

### Benefits

Fixes a TMC CONNECTION ERROR issue I was seeing on a Prusa MK3S/+ build with a MKS Robin Nano V3 & TMC2209s.

### Configurations

[MK3S Robin Nano V3 TMC2209s.zip](https://github.com/MarlinFirmware/Marlin/files/8679823/MK3S.Robin.Nano.V3.TMC2209s.zip)

### Related Issues

- ~~None.~~ Discovered while testing various MK3S/+ configs on a Robin Nano V3.
- https://github.com/MarlinFirmware/Marlin/issues/23809