### PR TITLE
Fix PTC defined but not used warnings / remove duplicate TEMP_SENSOR_PROBE sanity check

### DIFF
--- a/Marlin/src/gcode/calibrate/G76_M871.cpp
+++ b/Marlin/src/gcode/calibrate/G76_M871.cpp
@@ -82,12 +82,12 @@
  *  - `P` - Run probe temperature calibration.
  */
 
-static void say_waiting_for()               { SERIAL_ECHOPGM("Waiting for "); }
-static void say_waiting_for_probe_heating() { say_waiting_for(); SERIAL_ECHOLNPGM("probe heating."); }
-static void say_successfully_calibrated()   { SERIAL_ECHOPGM("Successfully calibrated"); }
-static void say_failed_to_calibrate()       { SERIAL_ECHOPGM("!Failed to calibrate"); }
-
 #if BOTH(PTC_PROBE, PTC_BED)
+
+  static void say_waiting_for()               { SERIAL_ECHOPGM("Waiting for "); }
+  static void say_waiting_for_probe_heating() { say_waiting_for(); SERIAL_ECHOLNPGM("probe heating."); }
+  static void say_successfully_calibrated()   { SERIAL_ECHOPGM("Successfully calibrated"); }
+  static void say_failed_to_calibrate()       { SERIAL_ECHOPGM("!Failed to calibrate"); }
 
   void GcodeSuite::G76() {
     auto report_temps = [](millis_t &ntr, millis_t timeout=0) {

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2381,16 +2381,6 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   #endif
 #endif
 
-#if TEMP_SENSOR_PROBE
-  #if !PIN_EXISTS(TEMP_PROBE)
-    #error "TEMP_SENSOR_PROBE requires TEMP_PROBE_PIN."
-  #elif !HAS_TEMP_ADC_PROBE
-    #error "TEMP_PROBE_PIN must be an ADC pin."
-  #elif DISABLED(FIX_MOUNTED_PROBE)
-    #error "TEMP_SENSOR_PROBE shouldn't be set without FIX_MOUNTED_PROBE."
-  #endif
-#endif
-
 #if TEMP_SENSOR_BOARD
   #if !PIN_EXISTS(TEMP_BOARD)
     #error "TEMP_SENSOR_BOARD requires TEMP_BOARD_PIN."


### PR DESCRIPTION
### Description

`PTC_PROBE` is [silently undefined](https://github.com/MarlinFirmware/Marlin/blob/d1e9f53cb80e110a980b77e1a352935318d5bc19/Marlin/src/inc/Conditionals_adv.h#L559-L562) if there's no probe with a temperature sensor defined (`!TEMP_SENSOR_PROBE`), but this causes some "`defined but not used`" warnings if you have `PTC_BED` defined:

  <details><summary>click me for warning output!</summary>

```prolog
  Marlin/src/gcode/calibrate/G76_M871.cpp:88:15: warning: 'void say_failed_to_calibrate()' defined but not used [-Wunused-function]
   88 |   static void say_failed_to_calibrate()       { SERIAL_ECHOPGM("!Failed to calibrate"); }
      |               ^~~~~~~~~~~~~~~~~~~~~~~
Marlin/src/gcode/calibrate/G76_M871.cpp:87:15: warning: 'void say_successfully_calibrated()' defined but not used [-Wunused-function]
   87 |   static void say_successfully_calibrated()   { SERIAL_ECHOPGM("Successfully calibrated"); }
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
Marlin/src/gcode/calibrate/G76_M871.cpp:86:15: warning: 'void say_waiting_for_probe_heating()' defined but not used [-Wunused-function]
   86 |   static void say_waiting_for_probe_heating() { say_waiting_for(); SERIAL_ECHOLNPGM("probe heating."); }
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
</details>

Since those functions are only used if both `PTC_PROBE` and `PTC_BED` are defined, I moved them under the `BOTH(PTC_PROBE, PTC_BED)` conditional.

Also, I removed a duplicate `TEMP_SENSOR_PROBE` sanity check.

### Requirements

Various PTC-related combinations

### Benefits

No "`defined but not used`" warnings

### Configurations

[Configurations -> examples/Prusa/MK3S-BigTreeTech-BTT002](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/Prusa/MK3S-BigTreeTech-BTT002) and set `TEMP_SENSOR_PROBE` to `0`.

### Related Issues

None. Found while testing some other code/configs.