### PR TITLE
Allow board & probe dummy thermistors

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -2374,8 +2374,6 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #if TEMP_SENSOR_PROBE
   #if !PIN_EXISTS(TEMP_PROBE)
     #error "TEMP_SENSOR_PROBE requires TEMP_PROBE_PIN."
-  #elif !HAS_TEMP_ADC_PROBE
-    #error "TEMP_PROBE_PIN must be an ADC pin."
   #elif DISABLED(FIX_MOUNTED_PROBE)
     #error "TEMP_SENSOR_PROBE shouldn't be set without FIX_MOUNTED_PROBE."
   #endif
@@ -2384,8 +2382,6 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
 #if TEMP_SENSOR_BOARD
   #if !PIN_EXISTS(TEMP_BOARD)
     #error "TEMP_SENSOR_BOARD requires TEMP_BOARD_PIN."
-  #elif !HAS_TEMP_ADC_BOARD
-    #error "TEMP_BOARD_PIN must be an ADC pin."
   #elif ENABLED(THERMAL_PROTECTION_BOARD) && (!defined(BOARD_MINTEMP) || !defined(BOARD_MAXTEMP))
     #error "THERMAL_PROTECTION_BOARD requires BOARD_MINTEMP and BOARD_MAXTEMP."
   #endif


### PR DESCRIPTION
### Description

Current sanity checks are a bit too restrictive and don't allow dummy thermistors for board or probe, so this PR removes those requirements.

### Requirements

Motherboard or probe with thermistors

### Benefits

Users/devs can build with dummy thermistors for testing

### Configurations

[Configurations -> examples/Prusa/MK3S-BigTreeTech-BTT002](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/Prusa/MK3S-BigTreeTech-BTT002) and set `TEMP_SENSOR_PROBE` or `TEMP_SENSOR_BOARD` to `998/999`.

### Related Issues

None. Discovered while building out another test config.