### PR TITLE
Mightyboard - Fix erroneous LED_PIN definition

### DIFF
--- a/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
@@ -178,7 +178,7 @@
 //
 // Misc. Functions
 //
-#define LED_PIN                     MOSFET_6_PIN  // B7
+#define LED_PIN                               13  // B7
 #define CUTOFF_RESET_PIN                      16  // H1
 #define CUTOFF_TEST_PIN                       17  // H0
 #define CUTOFF_SR_CHECK_PIN                   70  // G4 (TOSC1)


### PR DESCRIPTION
### Description

Per the Mightyboard Rev.E schematic, the assignment of LED_PIN to MOSFET_6_PIN is incorrect. The RGB controller does not have a direct power cutoff, and the closest simple match (using the pin number still in the code comment) is the  'BLINK' line leading to onboard LED DEBUG1. This PR properly reassigns logical pin 13 to the LED_PIN define, restoring the correct and intended operation.

### Requirements

Mightyboard Rev.E (and D)

### Benefits

This PR fixes an erroneous pin assignment that could result in improper operation.
The incorrect assignment was added in commit 195383bc33e708e533ee7d7199184351d8f6e55b.

### Configurations

N/A

### Related Issues

#24166
