### PR TITLE
Mightyboard - Fix LED define, fan overrides

### DIFF
--- a/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
@@ -167,7 +167,7 @@
   #define E0_AUTO_FAN_PIN           MOSFET_2_PIN
 #else
   #ifndef FAN_PIN
-    #define FAN_PIN                   MOSFET_2_PIN
+    #define FAN_PIN                 MOSFET_2_PIN
   #endif
 #endif
 // EX2 FAN (Automatic Fans are disabled by default in Configuration_adv.h - comment that out for auto fans)
@@ -175,7 +175,7 @@
   #define E1_AUTO_FAN_PIN           MOSFET_4_PIN
 #else
   #ifndef FAN1_PIN
-    #define FAN1_PIN                  MOSFET_4_PIN
+    #define FAN1_PIN                MOSFET_4_PIN
   #endif
 #endif
 

--- a/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
@@ -166,13 +166,17 @@
 #ifndef E0_AUTO_FAN_PIN
   #define E0_AUTO_FAN_PIN           MOSFET_2_PIN
 #else
-  #define FAN_PIN                   MOSFET_2_PIN
+  #ifndef FAN_PIN
+    #define FAN_PIN                   MOSFET_2_PIN
+  #endif
 #endif
 // EX2 FAN (Automatic Fans are disabled by default in Configuration_adv.h - comment that out for auto fans)
 #ifndef E1_AUTO_FAN_PIN
   #define E1_AUTO_FAN_PIN           MOSFET_4_PIN
 #else
-  #define FAN1_PIN                  MOSFET_4_PIN
+  #ifndef FAN1_PIN
+    #define FAN1_PIN                  MOSFET_4_PIN
+  #endif
 #endif
 
 //

--- a/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
+++ b/Marlin/src/pins/mega/pins_MIGHTYBOARD_REVE.h
@@ -178,7 +178,7 @@
 //
 // Misc. Functions
 //
-#define LED_PIN                     MOSFET_6_PIN  // B7
+#define LED_PIN                               13  // B7
 #define CUTOFF_RESET_PIN                      16  // H1
 #define CUTOFF_TEST_PIN                       17  // H0
 #define CUTOFF_SR_CHECK_PIN                   70  // G4 (TOSC1)


### PR DESCRIPTION
### Description

Per the Mightyboard Rev.E schematic, the assignment of LED_PIN to MOSFET_6_PIN is incorrect. The RGB controller does not have a direct power cutoff, and the closest simple match (using the pin number still in the code comment) is the 'BLINK' line leading to onboard LED DEBUG1. This PR properly reassigns logical pin 13 to the LED_PIN define, restoring the correct and intended operation.

The second commit fixes the FFCP and alternate configs, allowing the RAMPS-standard fan definitions to be overridden when extruder auto fans are defined.

### Requirements

Mightyboard Rev.E (and D)

### Benefits

This PR fixes an erroneous pin assignment that could result in improper operation.
The incorrect assignment was added in commit 195383bc33e708e533ee7d7199184351d8f6e55b.

Similarly, the fan definitions were enforced to match the RAMPS-style config. This breaks FFCP and other configs where the extruder auto pins are defined and/or the EXTRA port (MOSFET_6_PIN) is used for the parts cooling fan.


### Configurations

N/A

### Related Issues

#24166
