### PR TITLE
Fix MarlinUI temporary allow cold extrude

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -168,6 +168,8 @@ void MenuEditItemBase::goto_edit_screen(
  */
 void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, const uint8_t top/*=0*/, const uint8_t items/*=0*/) {
   if (currentScreen != screen) {
+    thermalManager.set_menu_cold_override(false);
+
     TERN_(IS_DWIN_MARLINUI, did_first_redraw = false);
 
     TERN_(HAS_TOUCH_BUTTONS, repeat_delay = BUTTON_DELAY_MENU);

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -168,8 +168,6 @@ void MenuEditItemBase::goto_edit_screen(
  */
 void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, const uint8_t top/*=0*/, const uint8_t items/*=0*/) {
   if (currentScreen != screen) {
-    thermalManager.set_menu_cold_override(false);
-
     TERN_(IS_DWIN_MARLINUI, did_first_redraw = false);
 
     TERN_(HAS_TOUCH_BUTTONS, repeat_delay = BUTTON_DELAY_MENU);

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -166,6 +166,7 @@ void _goto_manual_move(const_float_t scale) {
   ui.defer_status_screen();
   ui.manual_move.menu_scale = scale;
   ui.goto_screen(_manual_move_func_ptr);
+  thermalManager.set_menu_cold_override(true);
 }
 
 void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int8_t eindex=active_extruder) {
@@ -228,7 +229,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
         ui.goto_screen([]{
           MenuItem_confirm::select_screen(
             GET_TEXT(MSG_BUTTON_PROCEED), GET_TEXT(MSG_BACK),
-            [] { thermalManager.set_menu_cold_override(true); _goto_menu_move_distance_e(); }, nullptr,
+            _goto_menu_move_distance_e, nullptr,
             GET_TEXT(MSG_HOTEND_TOO_COLD), (const char *)nullptr, PSTR("!")
           );
         });
@@ -322,8 +323,6 @@ void menu_move() {
   #endif
 
   #if E_MANUAL
-
-    thermalManager.set_menu_cold_override(false);
 
     // The current extruder
     SUBMENU(MSG_MOVE_E, []{ _menu_move_distance_e_maybe(); });

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -228,7 +228,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
         ui.goto_screen([]{
           MenuItem_confirm::select_screen(
             GET_TEXT(MSG_BUTTON_PROCEED), GET_TEXT(MSG_BACK),
-            [] { _goto_menu_move_distance_e(); thermalManager.set_menu_cold_override(true); }, nullptr,
+            [] { thermalManager.set_menu_cold_override(true); _goto_menu_move_distance_e(); }, nullptr,
             GET_TEXT(MSG_HOTEND_TOO_COLD), (const char *)nullptr, PSTR("!")
           );
         });
@@ -322,6 +322,8 @@ void menu_move() {
   #endif
 
   #if E_MANUAL
+
+    thermalManager.set_menu_cold_override(false);
 
     // The current extruder
     SUBMENU(MSG_MOVE_E, []{ _menu_move_distance_e_maybe(); });


### PR DESCRIPTION
### Description

With a display that uses menu_motion.cpp  The menu Motion | Move Axis | Move Extruder
Prompts with  "Hotend too cold!" when the hotend is to cold, as It should.

This screen has a option to proceed and cold extrude, which did not work.

Was fixed in https://github.com/MarlinFirmware/Marlin/pull/24045  until code was modified in https://github.com/MarlinFirmware/Marlin/pull/24045/commits/1a7052b950c476c73dbb467dcd63e9949075ac47

Fixed again here.

### Requirements

#define PREVENT_COLD_EXTRUSION
A display that uses menu_motion.cpp

### Benefits

Works as expected

### Related Issues
#22921
