### PR TITLE
fix ZERO macro memset warning - #24177

### DIFF
--- a/Marlin/src/core/macros.h
+++ b/Marlin/src/core/macros.h
@@ -290,7 +290,7 @@
 #define NUMERIC_SIGNED(a)   (NUMERIC(a) || (a) == '-' || (a) == '+')
 #define DECIMAL_SIGNED(a)   (DECIMAL(a) || (a) == '-' || (a) == '+')
 #define COUNT(a)            (sizeof(a)/sizeof(*a))
-#define ZERO(a)             memset(a,0,sizeof(a))
+#define ZERO(a)             memset((void*)a,0,sizeof(a))
 #define COPY(a,b) do{ \
     static_assert(sizeof(a[0]) == sizeof(b[0]), "COPY: '" STRINGIFY(a) "' and '" STRINGIFY(b) "' types (sizes) don't match!"); \
     memcpy(&a[0],&b[0],_MIN(sizeof(a),sizeof(b))); \


### PR DESCRIPTION
fix ZERO macro warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'class SdFile'
with newer platformio development core

with newer platformio 5.x develoment cores (since about one month) with LPC1769 environment and enabled SDSUPPORT you'll get
```
Marlin\src\sd\cardreader.cpp: In constructor 'CardReader::CardReader()':
Marlin\src\sd../inc/../core/macros.h:279:49: warning: 'void* memset(void*, int, size_t)' clearing an object of non-trivial type 'class SdFile'; use assignment or value-initialization instead [-Wclass-memaccess]
279 | #define ZERO(a) memset(a,0,sizeof(a))
| ^
Marlin\src\sd\cardreader.cpp:172:3: note: in expansion of macro 'ZERO'
172 | ZERO(workDirParents);
```
Everything works but the warning is annoying

this simple PR does fix it

see also [Issue #24177 ](https://github.com/MarlinFirmware/Marlin/issues/24177)
