### PR TITLE
remove mks custom pins and clean up TINYBEE pins

### DIFF
--- a/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
+++ b/Marlin/src/HAL/ESP32/u8g_esp32_spi.cpp
@@ -23,24 +23,17 @@
  */
 #ifdef ARDUINO_ARCH_ESP32
 
-#include "../../inc/MarlinConfigPre.h"
+#include "../../inc/MarlinConfig.h"
 
 #if EITHER(MKS_MINI_12864, FYSETC_MINI_12864_2_1)
 
 #include <U8glib-HAL.h>
-#include "Arduino.h"
 #include "../shared/HAL_SPI.h"
 #include "HAL.h"
 #include "SPI.h"
 
 static SPISettings spiConfig;
 
-#define MDOGLCD_MOSI    23
-#define MDOGLCD_SCK     18
-#define MLCD_RESET_PIN   0
-#define MLCD_PINS_DC     4
-#define MDOGLCD_CS      21
-#define MDOGLCD_A0       4
 
 #ifndef LCD_SPI_SPEED
   #ifdef SD_SPI_SPEED
@@ -61,24 +54,24 @@ uint8_t u8g_eps_hw_spi_fn(u8g_t *u8g, uint8_t msg, uint8_t arg_val, void *arg_pt
     case U8G_COM_MSG_STOP: break;
 
     case U8G_COM_MSG_INIT:
-      OUT_WRITE(MDOGLCD_CS, HIGH);
-      OUT_WRITE(MDOGLCD_A0, HIGH);
-      OUT_WRITE(MLCD_RESET_PIN, HIGH);
+      OUT_WRITE(DOGLCD_CS, HIGH);
+      OUT_WRITE(DOGLCD_A0, HIGH);
+      OUT_WRITE(LCD_RESET_PIN, HIGH);
       u8g_Delay(5);
       spiBegin();
       spiInit(LCD_SPI_SPEED);
       break;
 
     case U8G_COM_MSG_ADDRESS:           /* define cmd (arg_val = 0) or data mode (arg_val = 1) */
-      WRITE(MDOGLCD_A0, arg_val ? HIGH : LOW);
+      WRITE(DOGLCD_A0, arg_val ? HIGH : LOW);
       break;
 
     case U8G_COM_MSG_CHIP_SELECT:       /* arg_val == 0 means HIGH level of U8G_PI_CS */
-      WRITE(MDOGLCD_CS, arg_val ? LOW : HIGH);
+      WRITE(DOGLCD_CS, arg_val ? LOW : HIGH);
       break;
 
     case U8G_COM_MSG_RESET:
-      WRITE(MLCD_RESET_PIN, arg_val);
+      WRITE(LCD_RESET_PIN, arg_val);
       break;
 
     case U8G_COM_MSG_WRITE_BYTE:

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -116,17 +116,7 @@
 //
 // ADC Reference Voltage
 //
-#define ADC_REFERENCE_VOLTAGE                2.5  // 2.5V reference VDDA
-
-//
-// MicroSD card
-//
-#define SD_MOSI_PIN                           23
-#define SD_MISO_PIN                           19
-#define SD_SCK_PIN                            18
-#define SDSS                                   5
-#define SD_DETECT_PIN                         34  // IO34 default is SD_DET signal (Jump to SDDET)
-#define USES_SHARED_SPI                           // SPI is shared by SD card with TMC SPI drivers
+#define ADC_REFERENCE_VOLTAGE                  2.5  // 2.5V reference VDDA
 
 /**
  *                ------                                 ------
@@ -157,56 +147,45 @@
 #define EXP2_09_PIN                           18
 #define EXP2_10_PIN                           19
 
-#if HAS_WIRED_LCD
+//
+// MicroSD card
+//
+//#define SD_MOSI_PIN                EXP2_05_PIN  // uses esp32 default 23
+//#define SD_MISO_PIN                EXP2_10_PIN  // uses esp32 default 19
+//#define SD_SCK_PIN                 EXP2_09_PIN  // uses esp32 default 18
+#define SDSS                         EXP2_07_PIN
+#define SD_DETECT_PIN                EXP2_04_PIN  // IO34 default is SD_DET signal (Jump to SDDET)
+#define USES_SHARED_SPI                           // SPI is shared by SD card with TMC SPI drivers
 
-  #define BEEPER_PIN                         149
-  #define BTN_ENC                             13
-  #define LCD_PINS_ENABLE                     21
-  #define LCD_PINS_RS                          4
-  #define BTN_EN1                             14
-  #define BTN_EN2                             12
+#if HAS_WIRED_LCD
+  #define BEEPER_PIN                 EXP1_10_PIN
+  #define LCD_PINS_ENABLE            EXP1_08_PIN
+  #define LCD_PINS_RS                EXP1_07_PIN
+  #define BTN_ENC                    EXP1_09_PIN
+  #define BTN_EN1                    EXP2_08_PIN
+  #define BTN_EN2                    EXP2_06_PIN
   #define LCD_BACKLIGHT_PIN                   -1
 
-  // MKS MINI12864 and MKS LCD12864B; If using MKS LCD12864A (Need to remove RPK2 resistor)
   #if ENABLED(MKS_MINI_12864)
+  // MKS MINI12864 and MKS LCD12864B; If using MKS LCD12864A (Need to remove RPK2 resistor)
 
-    //#define LCD_BACKLIGHT_PIN               -1
-    //#define LCD_RESET_PIN                   -1
-    #define DOGLCD_A0                         15
-    #define DOGLCD_CS                         16
-    //#define DOGLCD_SCK                      19
-    //#define DOGLCD_MOSI                     23
+    #define DOGLCD_CS                EXP1_05_PIN
+    #define DOGLCD_A0                EXP1_04_PIN
+    #define LCD_RESET_PIN                     -1
 
-    // Required for MKS_MINI_12864 with this board
-    //#define MKS_LCD12864B
-
-  #elif ENABLED(MKS_MINI_12864_V3)
-
-    #define LCD_PINS_DC              EXP1_07_PIN
+  #elif ENABLED(FYSETC_MINI_12864_2_1)
+  // MKS_MINI_12864_V3, BTT_MINI_12864_V1, FYSETC_MINI_12864_2_1
     #define DOGLCD_CS                EXP1_08_PIN
-    #define DOGLCD_A0                LCD_PINS_DC
-    #define LCD_BACKLIGHT_PIN                 -1
+    #define DOGLCD_A0                EXP1_07_PIN
     #define LCD_RESET_PIN            EXP1_06_PIN
+
     #define NEOPIXEL_PIN             EXP1_05_PIN
-    #define DOGLCD_MOSI              EXP2_05_PIN
-    #define DOGLCD_SCK               EXP2_09_PIN
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif
-
-  #else // !MKS_MINI_12864
-
-    #define LCD_PINS_D4                        0
-    #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
-      #define LCD_PINS_D5                     16
-      #define LCD_PINS_D6                     15
-      #define LCD_PINS_D7                     17
-    #endif
-
-    #define BOARD_ST7920_DELAY_1              96
-    #define BOARD_ST7920_DELAY_2              48
-    #define BOARD_ST7920_DELAY_3             600
-
-  #endif // !MKS_MINI_12864
+` 
+  #else
+    #error "You  have Slected a unsupport LCD controller"
+  #endif 
 
 #endif // HAS_WIRED_LCD

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -185,7 +185,16 @@
     #endif
  
   #else
-    #error "You have slected a unsupport LCD controller"
+   #define LCD_PINS_D4               EXP1_06_PIN
+    #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
+      #define LCD_PINS_D5            EXP1_05_PIN
+      #define LCD_PINS_D6            EXP1_04_PIN
+      #define LCD_PINS_D7            EXP1_03_PIN
+    #endif
+
+    #define BOARD_ST7920_DELAY_1              96
+    #define BOARD_ST7920_DELAY_2              48
+    #define BOARD_ST7920_DELAY_3             600  
   #endif 
 
 #endif // HAS_WIRED_LCD

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -185,7 +185,7 @@
     #endif
 ` 
   #else
-    #error "You  have Slected a unsupport LCD controller"
+    #error "You have slected a unsupport LCD controller"
   #endif 
 
 #endif // HAS_WIRED_LCD

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -168,22 +168,18 @@
 
   #if ENABLED(MKS_MINI_12864)
   // MKS MINI12864 and MKS LCD12864B; If using MKS LCD12864A (Need to remove RPK2 resistor)
-
     #define DOGLCD_CS                EXP1_05_PIN
     #define DOGLCD_A0                EXP1_04_PIN
     #define LCD_RESET_PIN                     -1
-
   #elif ENABLED(FYSETC_MINI_12864_2_1)
   // MKS_MINI_12864_V3, BTT_MINI_12864_V1, FYSETC_MINI_12864_2_1
     #define DOGLCD_CS                EXP1_08_PIN
     #define DOGLCD_A0                EXP1_07_PIN
     #define LCD_RESET_PIN            EXP1_06_PIN
-
     #define NEOPIXEL_PIN             EXP1_05_PIN
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif
- 
   #else
    #define LCD_PINS_D4               EXP1_06_PIN
     #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
@@ -191,10 +187,8 @@
       #define LCD_PINS_D6            EXP1_04_PIN
       #define LCD_PINS_D7            EXP1_03_PIN
     #endif
-
     #define BOARD_ST7920_DELAY_1              96
     #define BOARD_ST7920_DELAY_2              48
-    #define BOARD_ST7920_DELAY_3             600  
-  #endif 
-
+    #define BOARD_ST7920_DELAY_3             600
+  #endif
 #endif // HAS_WIRED_LCD

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -183,7 +183,7 @@
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif
-` 
+ 
   #else
     #error "You have slected a unsupport LCD controller"
   #endif 


### PR DESCRIPTION
### Description

MKS implementation of u8g_esp32_spi.cpp uses custom mks pins, not pins defined in the motherboards pin.h file.
Removed these custom pins
Cleaned up pins_MKS_TINYBEE.h
Addressed MKS12864 pin issue 24184 

### Requirements

A MKS TINYBEE
With a supported LCD

### Benefits

Cleaner code
works on MKS12864 displays.

### Related Issues
Issue #24184