### PR TITLE
Fix FLSUN Hispeed FIL_RUNOUT_PIN

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
+++ b/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
@@ -41,7 +41,7 @@
 #define BOARD_NO_NATIVE_USB
 
 // Avoid conflict with TIMER_SERVO when using the STM32 HAL
-#define TEMP_TIMER  5
+#define TEMP_TIMER                             5
 
 //
 // Release PB4 (Y_ENABLE_PIN) from JTAG NRST role
@@ -92,7 +92,7 @@
 #define Z_MAX_PIN                           PC4   // +Z
 
 #ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN            MT_DET_1_PIN
+  #define FIL_RUNOUT_PIN                    PA4   // MT_DET
 #endif
 
 //
@@ -217,14 +217,14 @@
 //
 #if ENABLED(PSU_CONTROL)
   #define KILL_PIN                          PA2   // PW_DET
-  #define KILL_PIN_STATE                   HIGH
+  #define KILL_PIN_STATE                    HIGH
   //#define PS_ON_PIN                       PA3   // PW_CN /PW_OFF
 #endif
 
 #if HAS_TFT_LVGL_UI
-  #define MT_DET_1_PIN                      PA4   // MT_DET
+  #define MT_DET_1_PIN            FIL_RUNOUT_PIN  // MT_DET
   #define MT_DET_2_PIN                      PE6
-  #define MT_DET_PIN_STATE                  LOW
+  #define MT_DET_PIN_STATE                   LOW
 #endif
 
 //


### PR DESCRIPTION
### Description

Explicitly define `FIL_RUNOUT_PIN` since `MT_DET_1_PIN` is only available when LVGL UI is enabled.

### Requirements

FLSUN Hispeed motherboard

### Benefits

`FIL_RUNOUT_PIN` will be defined correctly / work in non-LVGL configs.

### Configurations

[/config/examples/delta/FLSUN/QQS-Pro](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/delta/FLSUN/QQS-Pro)

### Related Issues

https://github.com/MarlinFirmware/Configurations/pull/737