### PR TITLE
Switch to PlatformIO Core 6.0 Dev

### DIFF
--- a/.github/workflows/test-builds.yml
+++ b/.github/workflows/test-builds.yml
@@ -138,8 +138,9 @@ jobs:
 
     - name: Install PlatformIO
       run: |
-        pip install -U https://github.com/platformio/platformio-core/archive/v5.2.5.zip
-        platformio update
+        pip install -U platformio
+        pio upgrade --dev
+        pio pkg update --global
 
     - name: Run ${{ matrix.test-platform }} Tests
       run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9.0-buster
 
-RUN pip install -U https://github.com/platformio/platformio-core/archive/v5.2.5.zip
-RUN platformio update
+RUN pip install -U platformio
+RUN pio upgrade --dev
 # To get the test platforms
 RUN pip install PyYaml
 #ENV PATH /code/buildroot/bin/:/code/buildroot/tests/:${PATH}


### PR DESCRIPTION
Hi,

Could we ask you to use the development version of PlatformIO? We released yesterday [PIO Core 6.0](https://github.com/platformio/platformio-core/releases/tag/v6.0.0) and made problems for Marlin users. We thought that Marlin uses the latest dev branch and there are no issues otherwise you would ping us. As a result, users faced with https://github.com/platformio/platformio-core/issues/4270

Thanks in advance!

P.S: This is our fault, we added Marlin to our "testing" list, and will test it on our side before each new release.