### PR TITLE
Fix MKS Robin Mini TFT Pins

### DIFF
--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_MINI.h
@@ -153,6 +153,9 @@
   #define FSMC_CS_PIN                       PD7   // NE4
   #define FSMC_RS_PIN                       PD11  // A0
 
+  #define TFT_CS_PIN                 FSMC_CS_PIN
+  #define TFT_RS_PIN                 FSMC_RS_PIN
+
   #define LCD_USE_DMA_FSMC                        // Use DMA transfers to send data to the TFT
   #define FSMC_DMA_DEV                      DMA2
   #define FSMC_DMA_CHANNEL               DMA_CH5


### PR DESCRIPTION
### Description

Fix MKS Robin Mini TFT Pins

### Benefits

MKS Robin Mini configs will build when using a TFT

### Configurations

[/config/examples/Kingroon/KP3](https://github.com/MarlinFirmware/Configurations/tree/bugfix-2.0.x/config/examples/Kingroon/KP3)

### Related Issues

https://github.com/MarlinFirmware/Configurations/pull/737