### PR TITLE
Remove extruder/e stepper override comment, e-stepper => E stepper, suppressible custom wiring warning

### DIFF
--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -338,7 +338,7 @@ void menu_move() {
 
     #elif MULTI_E_MANUAL
 
-      // Independent extruders with one E-stepper per hotend
+      // Independent extruders with one E stepper per hotend
       LOOP_L_N(n, E_MANUAL) SUBMENU_MOVE_E(n);
 
     #endif

--- a/Marlin/src/module/stepper.cpp
+++ b/Marlin/src/module/stepper.cpp
@@ -619,7 +619,7 @@ void Stepper::set_directions() {
   #if DISABLED(LIN_ADVANCE)
     #if ENABLED(MIXING_EXTRUDER)
        // Because this is valid for the whole block we don't know
-       // what e-steppers will step. Likely all. Set all.
+       // what E steppers will step. Likely all. Set all.
       if (motor_direction(E_AXIS)) {
         MIXER_STEPPER_LOOP(j) REV_E_DIR(j);
         count_direction.e = -1;

--- a/Marlin/src/module/stepper.h
+++ b/Marlin/src/module/stepper.h
@@ -214,7 +214,7 @@
     // Directions are set up for MIXING_STEPPERS - like before.
     // Finding the right stepper may last up to MIXING_STEPPERS loops in get_next_stepper().
     //   These loops are a bit faster than advancing a bresenham counter.
-    // Always only one e-stepper is stepped.
+    // Always only one E stepper is stepped.
     #define MIN_ISR_LA_LOOP_CYCLES ((MIXING_STEPPERS) * (ISR_STEPPER_CYCLES))
   #else
     #define MIN_ISR_LA_LOOP_CYCLES ISR_STEPPER_CYCLES

--- a/Marlin/src/pins/esp32/pins_E4D.h
+++ b/Marlin/src/pins/esp32/pins_E4D.h
@@ -31,9 +31,9 @@
 #include "env_validate.h"
 
 #if EXTRUDERS > 1 || E_STEPPERS > 1
-  #error "E4d@box only supports one E Stepper. Comment out this line to continue."
+  #error "E4d@box only supports 1 E stepper."
 #elif HAS_MULTI_HOTEND
-  #error "E4d@box only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "E4d@box only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME       "E4d@box"

--- a/Marlin/src/pins/esp32/pins_FYSETC_E4.h
+++ b/Marlin/src/pins/esp32/pins_FYSETC_E4.h
@@ -31,9 +31,9 @@
 #include "env_validate.h"
 
 #if EXTRUDERS > 1 || E_STEPPERS > 1
-  #error "FYSETC E4 only supports one E Stepper. Comment out this line to continue."
+  #error "FYSETC E4 only supports 1 E stepper."
 #elif HAS_MULTI_HOTEND
-  #error "FYSETC E4 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "FYSETC E4 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME       "FYSETC_E4"

--- a/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
+++ b/Marlin/src/pins/esp32/pins_MKS_TINYBEE.h
@@ -31,9 +31,9 @@
 #include "env_validate.h"
 
 #if EXTRUDERS > 2 || E_STEPPERS > 2
-  #error "MKS ESP Nano only supports two E Steppers. Comment out this line to continue."
+  #error "MKS TinyBee supports up to 2 E steppers."
 #elif HOTENDS > 2
-  #error "MKS ESP Nano only supports two hotend / E-stepper. Comment out this line to continue."
+  #error "MKS TinyBee supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME      "MKS TinyBee"

--- a/Marlin/src/pins/esp32/pins_MRR_ESPA.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPA.h
@@ -31,9 +31,9 @@
 #include "env_validate.h"
 
 #if EXTRUDERS > 1 || E_STEPPERS > 1
-  #error "MRR ESPA only supports one E Stepper. Comment out this line to continue."
+  #error "MRR ESPA only supports 1 E stepper."
 #elif HAS_MULTI_HOTEND
-  #error "MRR ESPA only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MRR ESPA only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME       "MRR ESPA"

--- a/Marlin/src/pins/esp32/pins_MRR_ESPE.h
+++ b/Marlin/src/pins/esp32/pins_MRR_ESPE.h
@@ -32,9 +32,9 @@
 #include "env_validate.h"
 
 #if EXTRUDERS > 2 || E_STEPPERS > 2
-  #error "MRR ESPE only supports two E Steppers. Comment out this line to continue."
+  #error "MRR ESPE supports up to 2 E steppers."
 #elif HAS_MULTI_HOTEND
-  #error "MRR ESPE only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MRR ESPE only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME      "MRR ESPE"

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -223,7 +223,9 @@
 
   #elif ENABLED(ANET_FULL_GRAPHICS_LCD)
 
-    #error "CAUTION! ANET_FULL_GRAPHICS_LCD requires wiring modifications. See 'pins_BTT_SKR_V1_3.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! ANET_FULL_GRAPHICS_LCD requires wiring modifications. See 'pins_BTT_SKR_V1_3.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
    /**
     * 1. Cut the tab off the LCD connector so it can be plugged into the "EXP1" connector the other way.
@@ -257,7 +259,9 @@
 
   #elif ENABLED(WYH_L12864)
 
-    #error "CAUTION! WYH_L12864 requires wiring modifications. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! WYH_L12864 requires wiring modifications. See 'pins_BTT_SKR_V1_3.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     /**
      * 1. Cut the tab off the LCD connector so it can be plugged into the "EXP1" connector the other way.

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_4.h
@@ -286,7 +286,9 @@
 #elif HAS_WIRED_LCD
 
   #if ENABLED(ANET_FULL_GRAPHICS_LCD_ALT_WIRING)
-    #error "CAUTION! ANET_FULL_GRAPHICS_LCD_ALT_WIRING requires wiring modifications. See 'pins_BTT_SKR_V1_4.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! ANET_FULL_GRAPHICS_LCD_ALT_WIRING requires wiring modifications. See 'pins_BTT_SKR_V1_4.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     /**
      * 1. Cut the tab off the LCD connector so it can be plugged into the "EXP1" connector the other way.
@@ -318,7 +320,9 @@
     #define BEEPER_PIN               EXP1_03_PIN
 
   #elif ENABLED(ANET_FULL_GRAPHICS_LCD)
-    #error "CAUTION! ANET_FULL_GRAPHICS_LCD requires wiring modifications. See 'pins_BTT_SKR_V1_4.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! ANET_FULL_GRAPHICS_LCD requires wiring modifications. See 'pins_BTT_SKR_V1_4.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
    /**
     * 1. Cut the tab off the LCD connector so it can be plugged into the "EXP1" connector the other way.

--- a/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
+++ b/Marlin/src/pins/lpc1768/pins_RAMPS_RE_ARM.h
@@ -307,7 +307,9 @@
 
 #elif ENABLED(ZONESTAR_LCD)
 
-  #error "CAUTION! ZONESTAR_LCD on REARM requires wiring modifications. NB. ADCs are not 5V tolerant. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! ZONESTAR_LCD on REARM requires wiring modifications. NB. ADCs are not 5V tolerant. See 'pins_RAMPS_RE_ARM.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
 #elif IS_TFTGLCD_PANEL
 

--- a/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
+++ b/Marlin/src/pins/lpc1769/pins_BTT_SKR_E3_TURBO.h
@@ -204,7 +204,9 @@
 #define EXP1_10_PIN                        P2_08
 
 #if HAS_DWIN_E3V2 || IS_DWIN_MARLINUI
-  #error "Ender-3 V2 display requires a custom cable with TX = P0_15, RX = P0_16. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! Ender-3 V2 display requires a custom cable with TX = P0_15, RX = P0_16. See 'pins_BTT_SKR_E3_TURBO.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
  /**
   *          Ender 3 V2 display                       SKR E3 Turbo (EXP1)                Ender 3 V2 display --> SKR E3 Turbo
@@ -238,7 +240,9 @@
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
-    #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_E3_TURBO.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_E3_TURBO.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     #define LCD_PINS_RS              EXP1_05_PIN
     #define LCD_PINS_ENABLE          EXP1_09_PIN

--- a/Marlin/src/pins/mega/pins_MEGACONTROLLER.h
+++ b/Marlin/src/pins/mega/pins_MEGACONTROLLER.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Mega Controller supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Mega Controller supports up to 2 hotends / E steppers."
 #endif
 
 #include "env_validate.h"

--- a/Marlin/src/pins/mega/pins_MINITRONICS.h
+++ b/Marlin/src/pins/mega/pins_MINITRONICS.h
@@ -34,7 +34,7 @@
 #if NOT_TARGET(__AVR_ATmega1281__)
   #error "Oops! Select 'Minitronics' in 'Tools > Board.'"
 #elif HOTENDS > 2 || E_STEPPERS > 2
-  #error "Minitronics supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Minitronics supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "Minitronics v1.0/1.1"

--- a/Marlin/src/pins/mega/pins_OVERLORD.h
+++ b/Marlin/src/pins/mega/pins_OVERLORD.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Overlord Controller supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Overlord supports up to 2 hotends / E steppers."
 #endif
 
 #include "env_validate.h"

--- a/Marlin/src/pins/ramps/pins_AZTEEG_X3.h
+++ b/Marlin/src/pins/ramps/pins_AZTEEG_X3.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Azteeg X3 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Azteeg X3 supports up to 2 hotends / E steppers."
 #endif
 
 #if ENABLED(CASE_LIGHT_ENABLE) && !PIN_EXISTS(CASE_LIGHT)

--- a/Marlin/src/pins/ramps/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/src/pins/ramps/pins_AZTEEG_X3_PRO.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 5 || E_STEPPERS > 5
-  #error "Azteeg X3 Pro supports up to 5 hotends / E-steppers. Comment out this line to continue."
+  #error "Azteeg X3 Pro supports up to 5 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "Azteeg X3 Pro"

--- a/Marlin/src/pins/ramps/pins_BAM_DICE_DUE.h
+++ b/Marlin/src/pins/ramps/pins_BAM_DICE_DUE.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "2PrintBeta Due supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "2PrintBeta Due supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "2PrintBeta Due"

--- a/Marlin/src/pins/ramps/pins_BIQU_KFB_2.h
+++ b/Marlin/src/pins/ramps/pins_BIQU_KFB_2.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "KFB 2.0 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "KFB 2.0 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "KFB 2.0"

--- a/Marlin/src/pins/ramps/pins_DAGOMA_F5.h
+++ b/Marlin/src/pins/ramps/pins_DAGOMA_F5.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Dagoma3D F5 supports only 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Dagoma3D F5 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "Dagoma3D F5"

--- a/Marlin/src/pins/ramps/pins_FELIX2.h
+++ b/Marlin/src/pins/ramps/pins_FELIX2.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Felix 2.0+ supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Felix 2.0+ supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "Felix 2.0+"

--- a/Marlin/src/pins/ramps/pins_FORMBOT_RAPTOR.h
+++ b/Marlin/src/pins/ramps/pins_FORMBOT_RAPTOR.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "Formbot supports up to 3 hotends / E-steppers. Comment out this line to continue."
+  #error "Formbot supports up to 3 hotends / E steppers."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/ramps/pins_FORMBOT_TREX2PLUS.h
+++ b/Marlin/src/pins/ramps/pins_FORMBOT_TREX2PLUS.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Formbot supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Formbot supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME      "Formbot"

--- a/Marlin/src/pins/ramps/pins_FORMBOT_TREX3.h
+++ b/Marlin/src/pins/ramps/pins_FORMBOT_TREX3.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Formbot supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Formbot supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME      "Formbot"

--- a/Marlin/src/pins/ramps/pins_K8600.h
+++ b/Marlin/src/pins/ramps/pins_K8600.h
@@ -26,7 +26,7 @@
  */
 
 #if HAS_MULTI_HOTEND
-  #error "Only 1 hotend is supported for Vertex Nano."
+  #error "K8600 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME      "K8600"

--- a/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
+++ b/Marlin/src/pins/ramps/pins_LONGER3D_LKx_PRO.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Longer3D LGT KIT V1.0 board only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Longer3D LGT KIT V1.0 only supports 1 hotend / E stepper."
 #endif
 
 #if SERIAL_PORT == 1 || SERIAL_PORT_2 == 1 || SERIAL_PORT_3 == 1

--- a/Marlin/src/pins/ramps/pins_MKS_BASE_10.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_10.h
@@ -28,7 +28,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS BASE 1.0 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS BASE 1.0 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS BASE 1.0"

--- a/Marlin/src/pins/ramps/pins_MKS_BASE_14.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_14.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS BASE 1.4 only supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS BASE 1.4 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS BASE 1.4"

--- a/Marlin/src/pins/ramps/pins_MKS_BASE_15.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_15.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS BASE 1.5 only supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS BASE 1.5 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS BASE 1.5"

--- a/Marlin/src/pins/ramps/pins_MKS_BASE_16.h
+++ b/Marlin/src/pins/ramps/pins_MKS_BASE_16.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS BASE 1.6 only supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS BASE 1.6 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS BASE 1.6"

--- a/Marlin/src/pins/ramps/pins_MKS_GEN_13.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_13.h
@@ -31,7 +31,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS GEN 1.3/1.4 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS GEN 1.3/1.4 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS GEN >= v1.3"

--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS GEN L supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS GEN L supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS GEN L"

--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L_V2.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L_V2.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS GEN L V2 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS GEN L V2 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS GEN L V2"

--- a/Marlin/src/pins/ramps/pins_MKS_GEN_L_V21.h
+++ b/Marlin/src/pins/ramps/pins_MKS_GEN_L_V21.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS GEN L V2.1 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS GEN L V2.1 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS GEN L V2.1"

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -592,7 +592,10 @@
 
     #elif ENABLED(ZONESTAR_LCD)
 
-      #error "CAUTION! ZONESTAR_LCD on RAMPS requires wiring modifications. It plugs into AUX2 but GND and 5V need to be swapped. Comment out this line to continue."
+      #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+        #error "CAUTION! ZONESTAR_LCD on RAMPS requires wiring modifications. It plugs into AUX2 but GND and 5V need to be swapped. See 'pins_RAMPS.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+      #endif
+
       #define LCD_PINS_RS            AUX2_05_PIN
       #define LCD_PINS_ENABLE        AUX2_07_PIN
       #define LCD_PINS_D4            AUX2_04_PIN
@@ -859,7 +862,9 @@
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
 
-  #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_RAMPS.h' for details. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_RAMPS.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
   /**
    * FYSETC TFT-81050 display pinout

--- a/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_CREALITY.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Creality3D RAMPS supports only 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Creality RAMPS supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "Creality3D RAMPS"

--- a/Marlin/src/pins/ramps/pins_RAMPS_ENDER_4.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS_ENDER_4.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Ender-4 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Ender-4 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME "Ender-4"

--- a/Marlin/src/pins/ramps/pins_RL200.h
+++ b/Marlin/src/pins/ramps/pins_RL200.h
@@ -30,9 +30,9 @@
 #define DEFAULT_MACHINE_NAME "Rapide Lite 200"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "RL200v1 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "RL200v1 supports up to 2 hotends / E steppers."
 #elif NUM_Z_STEPPERS != 2
-  #error "RL200 uses dual Z stepper motors. Set NUM_Z_STEPPERS to 2 or comment out this line to continue."
+  #error "RL200 uses dual Z stepper motors. Z_DRIVER_TYPE and Z2_DRIVER_TYPE must be defined."
 #elif !(AXIS_DRIVER_TYPE_X(DRV8825) && AXIS_DRIVER_TYPE_Y(DRV8825) && AXIS_DRIVER_TYPE_Z(DRV8825) && AXIS_DRIVER_TYPE_Z2(DRV8825) && AXIS_DRIVER_TYPE_E0(DRV8825))
   #error "You must set ([XYZ]|Z2|E0)_DRIVER_TYPE to DRV8825 in Configuration.h for RL200."
 #endif

--- a/Marlin/src/pins/ramps/pins_RUMBA.h
+++ b/Marlin/src/pins/ramps/pins_RUMBA.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "RUMBA supports up to 3 hotends / E-steppers. Comment out this line to continue."
+  #error "RUMBA supports up to 3 hotends / E steppers."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/ramps/pins_SAINSMART_2IN1.h
+++ b/Marlin/src/pins/ramps/pins_SAINSMART_2IN1.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Sainsmart 2-in-1 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Sainsmart 2-in-1 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "Sainsmart"

--- a/Marlin/src/pins/ramps/pins_TENLOG_D3_HERO.h
+++ b/Marlin/src/pins/ramps/pins_TENLOG_D3_HERO.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Tenlog supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Tenlog supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME      "Tenlog D3 Hero"

--- a/Marlin/src/pins/ramps/pins_TRONXY_V3_1_0.h
+++ b/Marlin/src/pins/ramps/pins_TRONXY_V3_1_0.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "TRONXY-V3-1.0 supports only 2 hotends/E-steppers. Comment out this line to continue."
+  #error "TRONXY-V3-1.0 supports up to 2 hotends/E steppers."
 #endif
 
 #define BOARD_INFO_NAME "TRONXY-V3-1.0"

--- a/Marlin/src/pins/ramps/pins_TT_OSCAR.h
+++ b/Marlin/src/pins/ramps/pins_TT_OSCAR.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 5 || E_STEPPERS > 5
-  #error "TTOSCAR supports up to 5 hotends / E-steppers. Comment out this line to continue."
+  #error "TTOSCAR supports up to 5 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME      "TT OSCAR"

--- a/Marlin/src/pins/ramps/pins_ZRIB_V52.h
+++ b/Marlin/src/pins/ramps/pins_ZRIB_V52.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "ZRIB V5.2 only supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "ZRIB V5.2 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "ZRIB V5.2"

--- a/Marlin/src/pins/ramps/pins_ZRIB_V53.h
+++ b/Marlin/src/pins/ramps/pins_ZRIB_V53.h
@@ -28,9 +28,9 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2
-  #error "ZRIB V5.3 only supports up to 2 hotends. Comment out this line to continue."
+  #error "ZRIB V5.3 supports up to 2 hotends."
 #elif E_STEPPERS > 3
-  #error "ZRIB V5.3 only supports up to 3 E-steppers. Comment out this line to continue."
+  #error "ZRIB V5.3 supports up to 3 E steppers."
 #endif
 
 #define BOARD_INFO_NAME "ZRIB V5.3"

--- a/Marlin/src/pins/ramps/pins_Z_BOLT_X_SERIES.h
+++ b/Marlin/src/pins/ramps/pins_Z_BOLT_X_SERIES.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 4 || E_STEPPERS > 4
-  #error "Z-Bolt X Series board supports up to 4 hotends / E-steppers."
+  #error "Z-Bolt X Series supports up to 4 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "Z-Bolt X Series"

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_E3_DIP.h
@@ -182,7 +182,9 @@
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
-    #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_DIP.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     #define LCD_PINS_RS                     PB9
     #define LCD_PINS_ENABLE                 PB6
@@ -224,7 +226,9 @@
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
 
-  #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_E3_DIP.h' for details. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_E3_DIP.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
   /** FYSETC TFT TFT81050 display pinout
    *

--- a/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
+++ b/Marlin/src/pins/stm32f1/pins_BTT_SKR_MINI_E3_common.h
@@ -150,7 +150,9 @@
    * All pins are labeled as printed on DWIN PCB. Connect TX-TX, A-A and so on.
    */
 
-  #error "Ender-3 V2 display requires a custom cable, see diagram above this line. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! Ender-3 V2 display requires a custom cable. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
   #define BEEPER_PIN                      EXP1_9
   #define BTN_EN1                         EXP1_3
@@ -173,7 +175,9 @@
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
-    #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     #define LCD_PINS_RS                     PB9
     #define LCD_PINS_ENABLE               EXP1_9
@@ -201,7 +205,9 @@
 
     #if ENABLED(TFTGLCD_PANEL_SPI)
 
-      #error "CAUTION! TFTGLCD_PANEL_SPI requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+      #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+        #error "CAUTION! TFTGLCD_PANEL_SPI requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+      #endif
 
       /**
        * TFTGLCD_PANEL_SPI display pinout
@@ -238,7 +244,9 @@
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
 
-    #error "CAUTION! FYSETC_MINI_12864_2_1 / MKS_MINI_12864_V3 / BTT_MINI_12864_V1 requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! FYSETC_MINI_12864_2_1 / MKS_MINI_12864_V3 / BTT_MINI_12864_V1 requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     /**
      * FYSETC_MINI_12864_2_1 / MKS_MINI_12864_V3 / BTT_MINI_12864_V1 display pinout
@@ -308,7 +316,9 @@
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
 
-  #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
   /**
    * FYSETC TFT TFT81050 display pinout

--- a/Marlin/src/pins/stm32f1/pins_CCROBOT_MEEB_3DP.h
+++ b/Marlin/src/pins/stm32f1/pins_CCROBOT_MEEB_3DP.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "CCROBOT-ONLINE MEEB_3DP only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "CCROBOT-ONLINE MEEB_3DP only supports 1 hotend / E stepper."
 #endif
 
 // https://github.com/ccrobot-online/MEEB_3DP

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V24S1_301.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V24S1_301.h
@@ -29,7 +29,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Creality V24S1 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Creality v24S1 only supports 1 hotend / E stepper."
 #endif
 
 #if BOTH(BLTOUCH, Z_MIN_PROBE_USES_Z_MIN_ENDSTOP_PIN)

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V25S1.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V25S1.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Creality V2.5.S1 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Creality V2.5.S1 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME      "Creality v2.5.S1"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Creality V4 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Creality v4 only supports 1 hotend / E stepper."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V4210.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V4210.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "CREALITY supports up to 1 hotends / E-steppers. Comment out this line to continue."
+  #error "Creality v4.2.10 only supports 1 hotend / E stepper."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V452.h
@@ -26,7 +26,7 @@
  */
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Creality v4.5.2 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Creality v4.5.2 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME "Creality v4.5.2"

--- a/Marlin/src/pins/stm32f1/pins_CREALITY_V453.h
+++ b/Marlin/src/pins/stm32f1/pins_CREALITY_V453.h
@@ -26,7 +26,7 @@
  */
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Creality v4.5.3 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Creality v4.5.3 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME "Creality v4.5.3"

--- a/Marlin/src/pins/stm32f1/pins_ERYONE_ERY32_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_ERYONE_ERY32_MINI.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Eryone Ery32 mini supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Eryone Ery32 mini supports up to 2 hotends / E steppers."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
+++ b/Marlin/src/pins/stm32f1/pins_FLSUN_HISPEED.h
@@ -32,7 +32,7 @@
 #if NOT_TARGET(__STM32F1__, STM32F1xx)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #elif HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "FLSUN HiSpeedV1 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "FLSUN HiSpeedV1 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME      "FLSun HiSpeedV1"

--- a/Marlin/src/pins/stm32f1/pins_JGAURORA_A5S_A1.h
+++ b/Marlin/src/pins/stm32f1/pins_JGAURORA_A5S_A1.h
@@ -33,7 +33,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "JGAurora A5S A1 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "JGAurora A5S A1 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME "JGAurora A5S A1"

--- a/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
+++ b/Marlin/src/pins/stm32f1/pins_LONGER3D_LK.h
@@ -28,7 +28,7 @@
 #if NOT_TARGET(__STM32F1__, STM32F1xx)
   #error "Oops! Select a STM32F1 board in 'Tools > Board.'"
 #elif HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Longer3D only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Longer3D only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME "Longer3D"

--- a/Marlin/src/pins/stm32f1/pins_MINGDA_MPX_ARM_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_MINGDA_MPX_ARM_MINI.h
@@ -28,7 +28,7 @@
 #if NOT_TARGET(STM32F1, STM32F1xx)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #elif HOTENDS > 1 || E_STEPPERS > 1
-  #error "MPX ARM Mini only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MPX ARM Mini only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME "Mingda MPX ARM Mini"

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN.h
@@ -29,7 +29,7 @@
 #if NOT_TARGET(STM32F1, STM32F1xx)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #elif HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS Robin supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS Robin supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS Robin"

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3.h
@@ -26,7 +26,7 @@
  */
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "MKS Robin E3 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MKS Robin E3 only supports 1 hotend / E stepper."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D.h
@@ -26,7 +26,7 @@
  */
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "MKS Robin E3D only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MKS Robin E3D only supports 1 hotend / E stepper."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D_V1_1.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3D_V1_1.h
@@ -26,7 +26,7 @@
  */
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "MKS Robin E3D v1.1 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MKS Robin E3D v1.1 only supports 1 hotend / E stepper."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "MKS Robin E3P only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MKS Robin E3P only supports 1 hotend / E stepper."
 #elif HAS_FSMC_TFT
   #error "MKS Robin E3P doesn't support FSMC-based TFT displays."
 #endif

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_V1_1.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3_V1_1.h
@@ -26,7 +26,7 @@
  */
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "MKS Robin E3 v1.1 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MKS Robin E3 v1.1 only supports 1 hotend / E stepper."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "MKS Robin Lite only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MKS Robin Lite only supports 1 hotend / E stepper."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE3.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_LITE3.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS Robin Lite3 supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS Robin Lite3 supports up to 2 hotends / E steppers."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_MINI.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_MINI.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "MKS Robin mini only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "MKS Robin mini only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME "MKS Robin Mini"

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -28,7 +28,7 @@
 #if NOT_TARGET(__STM32F1__, STM32F1)
   #error "Oops! Select an STM32F1 board in 'Tools > Board.'"
 #elif HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS Robin nano supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS Robin nano supports up to 2 hotends / E steppers."
 #elif HAS_FSMC_TFT
   #error "MKS Robin nano v2 doesn't support FSMC-based TFT displays."
 #endif

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS Robin nano supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS Robin nano supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_NO_NATIVE_USB

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_common.h
@@ -26,7 +26,7 @@
  */
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS Robin nano supports up to 2 hotends / E steppers."
+  #error "MKS Robin nano boards support up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_NO_NATIVE_USB

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_PRO.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "MKS Robin pro supports up to 3 hotends / E-steppers. Comment out this line to continue."
+  #error "MKS Robin pro supports up to 3 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS Robin pro"

--- a/Marlin/src/pins/stm32f1/pins_PANDA_PI_V29.h
+++ b/Marlin/src/pins/stm32f1/pins_PANDA_PI_V29.h
@@ -173,7 +173,9 @@
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
 
-  #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_E3_DIP.h' for details. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_PANDA_PI_V29.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
   /** FYSETC TFT TFT81050 display pinout
    *

--- a/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
+++ b/Marlin/src/pins/stm32f1/pins_TRIGORILLA_PRO.h
@@ -31,7 +31,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Trigorilla Pro supports up to 2 hotends / E-steppers. Comment out this line to continue."
+  #error "Trigorilla Pro supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "Trigorilla Pro"

--- a/Marlin/src/pins/stm32f4/pins_ANET_ET4.h
+++ b/Marlin/src/pins/stm32f4/pins_ANET_ET4.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "Anet ET4 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "Anet ET4 only supports 1 hotend / E stepper."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f4/pins_ARMED.h
+++ b/Marlin/src/pins/stm32f4/pins_ARMED.h
@@ -27,7 +27,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Arm'ed supports up to 2 hotends / E-steppers."
+  #error "Arm'ed supports up to 2 hotends / E steppers."
 #endif
 
 #ifndef ARMED_V1_0

--- a/Marlin/src/pins/stm32f4/pins_ARTILLERY_RUBY.h
+++ b/Marlin/src/pins/stm32f4/pins_ARTILLERY_RUBY.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 1 || E_STEPPERS > 1
-  #error "Artillery Ruby supports up to 1 hotends / E-steppers."
+  #error "Artillery Ruby only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME      "Artillery Ruby"

--- a/Marlin/src/pins/stm32f4/pins_BLACK_STM32F407VE.h
+++ b/Marlin/src/pins/stm32f4/pins_BLACK_STM32F407VE.h
@@ -31,7 +31,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "Black STM32F4VET6 supports up to 2 hotends / E-steppers."
+  #error "Black STM32F4VET6 supports up to 2 hotends / E steppers."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_BTT002_V1_0.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "BIGTREE BTT002 V1.0 only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "BIGTREE BTT002 V1.0 only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME "BTT BTT002 V1.0"

--- a/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_E3_RRF.h
@@ -211,7 +211,9 @@
 
     #if ENABLED(LCD_FOR_MELZI)
 
-      #error "CAUTION! LCD_FOR_MELZI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
+      #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+        #error "CAUTION! LCD_FOR_MELZI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+      #endif
 
      /** LCD_FOR_MELZI display pinout
       *
@@ -245,7 +247,9 @@
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
-    #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     #define LCD_PINS_RS                     PE10
     #define LCD_PINS_ENABLE                 PE9
@@ -273,7 +277,9 @@
 
     #if ENABLED(TFTGLCD_PANEL_SPI)
 
-      #error "CAUTION! TFTGLCD_PANEL_SPI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
+      #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+        #error "CAUTION! TFTGLCD_PANEL_SPI requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+      #endif
 
       /**
        * TFTGLCD_PANEL_SPI display pinout
@@ -327,7 +333,9 @@
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
 
-  #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_E3_RRF.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
   /** FYSETC TFT TFT81050 display pinout
    *

--- a/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_GTR_V1_0.h
@@ -26,7 +26,7 @@
 #if E_STEPPERS > MAX_E_STEPPERS
   #error "Marlin extruder/hotends limit! Increase MAX_E_STEPPERS to continue."
 #elif HOTENDS > 8 || E_STEPPERS > 8
-  #error "BIGTREE GTR V1.0 supports up to 8 hotends / E-steppers."
+  #error "BIGTREE GTR V1.0 supports up to 8 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "BTT GTR V1.0"

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_1.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_1.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "BIGTREE SKR Pro V1.1 supports up to 3 hotends / E-steppers."
+  #error "BIGTREE SKR Pro V1.1 supports up to 3 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "BTT SKR Pro V1.1"

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_2.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_V1_2.h
@@ -22,7 +22,7 @@
 #pragma once
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "BIGTREE SKR Pro V1.2 supports up to 3 hotends / E-steppers."
+  #error "BIGTREE SKR Pro V1.2 supports up to 3 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "BTT SKR Pro V1.2"

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_PRO_common.h
@@ -456,7 +456,9 @@
 
   #elif ENABLED(WYH_L12864)
 
-    #error "CAUTION! WYH_L12864 requires wiring modifications. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! WYH_L12864 requires wiring modifications. See 'pins_BTT_SKR_PRO_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     /**
      * 1. Cut the tab off the LCD connector so it can be plugged into the "EXP1" connector the other way.

--- a/Marlin/src/pins/stm32f4/pins_FLYF407ZG.h
+++ b/Marlin/src/pins/stm32f4/pins_FLYF407ZG.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 6 || E_STEPPERS > 6
-  #error "FLYF407ZG supports up to 6 hotends / E-steppers."
+  #error "FLYF407ZG supports up to 6 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME      "FLYF407ZG"

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_S6.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "FYSETC S6 supports up to 3 hotends / E-steppers."
+  #error "FYSETC S6 supports up to 3 hotends / E steppers."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f4/pins_FYSETC_SPIDER.h
+++ b/Marlin/src/pins/stm32f4/pins_FYSETC_SPIDER.h
@@ -117,7 +117,7 @@
 #endif
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "FYSETC SPIDER supports up to 3 hotends / E-steppers."
+  #error "FYSETC SPIDER supports up to 3 hotends / E steppers."
 #else
   #include "pins_FYSETC_S6.h"
 #endif

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_K.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "LERDGE K supports up to 2 hotends / E-steppers."
+  #error "LERDGE K supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME      "Lerdge K"

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_S.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "LERDGE S supports up to 2 hotends / E-steppers."
+  #error "LERDGE S supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME      "Lerdge S"

--- a/Marlin/src/pins/stm32f4/pins_LERDGE_X.h
+++ b/Marlin/src/pins/stm32f4/pins_LERDGE_X.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "LERDGE X only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "LERDGE X only supports 1 hotend / E stepper."
 #endif
 
 #define BOARD_INFO_NAME      "Lerdge X"

--- a/Marlin/src/pins/stm32f4/pins_MKS_EAGLE.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_EAGLE.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS Eagle supports up to 2 hotends / E-steppers."
+  #error "MKS Eagle supports up to 2 hotends / E steppers."
 #elif HAS_FSMC_TFT
   #error "MKS Eagle doesn't support FSMC-based TFT displays."
 #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 3 || E_STEPPERS > 5
-  #error "MKS Monster supports up to 3 hotends and 5 E-steppers."
+  #error "MKS Monster supports up to 3 hotends and 5 E steppers."
 #elif HAS_FSMC_TFT
   #error "MKS Monster doesn't support FSMC-based TFT displays."
 #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN2.h
@@ -24,7 +24,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS_ROBIN2 supports up to 2 hotends / E-steppers."
+  #error "MKS_ROBIN2 supports up to 2 hotends / E steppers."
 #endif
 
 #ifndef BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS Robin Nano V3 supports up to 2 hotends / E-steppers."
+  #error "MKS Robin Nano V3 supports up to 2 hotends / E steppers."
 #elif HAS_FSMC_TFT
   #error "MKS Robin Nano V3 doesn't support FSMC-based TFT displays."
 #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "MKS Robin Nano V3 supports up to 1 hotends / E-steppers."
+  #error "MKS Robin Nano V3 supports up to 2 hotends / E steppers."
 #endif
 
 #define BOARD_INFO_NAME "MKS Robin PRO V2"

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "RUMBA32 supports up to 3 hotends / E steppers."
+  #error "RUMBA32 boards support up to 3 hotends / E steppers."
 #endif
 
 #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
+++ b/Marlin/src/pins/stm32f4/pins_RUMBA32_common.h
@@ -28,7 +28,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 3 || E_STEPPERS > 3
-  #error "RUMBA32 boards support up to 3 hotends / E-steppers."
+  #error "RUMBA32 supports up to 3 hotends / E steppers."
 #endif
 
 #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME

--- a/Marlin/src/pins/stm32f4/pins_VAKE403D.h
+++ b/Marlin/src/pins/stm32f4/pins_VAKE403D.h
@@ -25,7 +25,7 @@
 #include "env_validate.h"
 
 #if HOTENDS > 2 || E_STEPPERS > 2
-  #error "STM32F4 supports up to 2 hotends / E-steppers."
+  #error "STM32F4 VAkE supports up to 2 hotends / E steppers."
 #endif
 
 #define DEFAULT_MACHINE_NAME "STM32F446VET6"

--- a/Marlin/src/pins/stm32f7/pins_REMRAM_V1.h
+++ b/Marlin/src/pins/stm32f7/pins_REMRAM_V1.h
@@ -33,7 +33,7 @@
 #endif
 
 #if HAS_MULTI_HOTEND || E_STEPPERS > 1
-  #error "RemRam only supports one hotend / E-stepper. Comment out this line to continue."
+  #error "RemRam only supports 1 hotend / E stepper."
 #endif
 
 //

--- a/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
+++ b/Marlin/src/pins/stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h
@@ -170,7 +170,9 @@
    * All pins are labeled as printed on DWIN PCB. Connect TX-TX, A-A and so on.
    */
 
-  #error "DWIN_CREALITY_LCD requires a custom cable, see diagram above this line. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! DWIN_CREALITY_LCD requires a custom cable, see diagram above this line. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
   #define BEEPER_PIN                 EXP1_09_PIN
   #define BTN_EN1                    EXP1_03_PIN
@@ -193,7 +195,9 @@
 
   #elif ENABLED(ZONESTAR_LCD)                     // ANET A8 LCD Controller - Must convert to 3.3V - CONNECTING TO 5V WILL DAMAGE THE BOARD!
 
-    #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+    #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+      #error "CAUTION! ZONESTAR_LCD requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+    #endif
 
     #define LCD_PINS_RS                     PB9
     #define LCD_PINS_ENABLE          EXP1_09_PIN
@@ -221,7 +225,9 @@
 
     #if ENABLED(TFTGLCD_PANEL_SPI)
 
-      #error "CAUTION! TFTGLCD_PANEL_SPI requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+      #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+        #error "CAUTION! TFTGLCD_PANEL_SPI requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+      #endif
 
       /**
        * TFTGLCD_PANEL_SPI display pinout
@@ -258,7 +264,9 @@
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
 
-      #error "CAUTION! FYSETC_MINI_12864_2_1 and clones require wiring modifications. See 'pins_BTT_SKR_MINI_E3_V3_0.h' for details. Comment out this line to continue."
+      #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+        #error "CAUTION! FYSETC_MINI_12864_2_1 and clones require wiring modifications. See 'pins_BTT_SKR_MINI_E3_V3_0.h' for details. Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning"
+      #endif
 
       /**
        *
@@ -307,7 +315,9 @@
 
 #if BOTH(TOUCH_UI_FTDI_EVE, LCD_FYSETC_TFT81050)
 
-  #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. Comment out this line to continue."
+  #ifndef NO_CONTROLLER_CUSTOM_WIRING_WARNING
+    #error "CAUTION! LCD_FYSETC_TFT81050 requires wiring modifications. See 'pins_BTT_SKR_MINI_E3_common.h' for details. (Define NO_CONTROLLER_CUSTOM_WIRING_WARNING to suppress this warning.)"
+  #endif
 
   /**
    * FYSETC TFT TFT81050 display pinout


### PR DESCRIPTION
### Description

- Remove extruder/e stepper "Comment out this line to continue" comment
- e-stepper => E stepper (match the rest of Marlin's use of "E stepper")
- Unify language around extruder/e stepper counts (1/one, 2/two, etc.)
- Suppressible custom wiring warning with a `NO_CONTROLLER_CUSTOM_WIRING_WARNING` define (Users should be allowed to easily disable this warning within a config instead of core Marlin files)
- Fix some other odd sentences, copy & paste typos

### Benefits

Clearer errors when compiling with invalid settings & improved user experience when running custom LCD controller wiring.