### PR TITLE
More EXP1/2 headers, TFT reset pin, etc.

### DIFF
--- a/Marlin/src/HAL/STM32F1/tft/tft_spi.cpp
+++ b/Marlin/src/HAL/STM32F1/tft/tft_spi.cpp
@@ -30,7 +30,7 @@ SPIClass TFT_SPI::SPIx(1);
 
 void TFT_SPI::Init() {
   #if PIN_EXISTS(TFT_RESET)
-    OUT_WRITE(TFT_RST_PIN, HIGH);
+    OUT_WRITE(TFT_RESET_PIN, HIGH);
     delay(100);
   #endif
 

--- a/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
+++ b/Marlin/src/pins/lpc1768/pins_BTT_SKR_V1_3.h
@@ -314,7 +314,7 @@
     #define TFT_RESET_PIN            EXP1_07_PIN
     #define TFT_BACKLIGHT_PIN        EXP1_08_PIN
 
-    #define TFT_RST_PIN              EXP2_04_PIN
+    //#define TFT_RST_PIN            EXP2_04_PIN
     #define TFT_MOSI_PIN             EXP2_05_PIN
     #define TFT_SCK_PIN              EXP2_09_PIN
     #define TFT_MISO_PIN             EXP2_10_PIN

--- a/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
+++ b/Marlin/src/pins/lpc1769/pins_MKS_SGEN_L_V2.h
@@ -339,9 +339,10 @@
       #define KILL_PIN                     -1     // NC
 
     #elif HAS_SPI_TFT                             // Config for Classic UI (emulated DOGM) and Color UI
+
       #define TFT_CS_PIN             EXP1_04_PIN
-      #define TFT_A0_PIN             EXP1_03_PIN
       #define TFT_DC_PIN             EXP1_03_PIN
+      #define TFT_A0_PIN             TFT_DC_PIN
       #define TFT_MISO_PIN           EXP2_10_PIN
       #define TFT_BACKLIGHT_PIN      EXP1_08_PIN
       #define TFT_RESET_PIN          EXP1_07_PIN

--- a/Marlin/src/pins/mega/pins_CNCONTROLS_11.h
+++ b/Marlin/src/pins/mega/pins_CNCONTROLS_11.h
@@ -135,17 +135,20 @@
 //
 // LCD / Controller
 //
-#define BEEPER_PIN                             6
+#if HAS_WIRED_LCD
+  #define BEEPER_PIN                           6
 
-// Pins for DOGM SPI LCD Support
-#define DOGLCD_A0                             26
-#define DOGLCD_CS                             24
-#define DOGLCD_MOSI                           -1  // Prevent auto-define by Conditionals_post.h
-#define DOGLCD_SCK                            -1
+  #define BTN_EN1                             23
+  #define BTN_EN2                             25
+  #define BTN_ENC                             27
 
-#define BTN_EN1                               23
-#define BTN_EN2                               25
-#define BTN_ENC                               27
+  #if HAS_MARLINUI_U8GLIB
+    #define DOGLCD_A0                         26
+    #define DOGLCD_CS                         24
+    #define DOGLCD_MOSI                       -1  // Prevent auto-define by Conditionals_post.h
+    #define DOGLCD_SCK                        -1
+  #endif
+#endif
 
 // Hardware buttons for manual movement of XYZ
 #define SHIFT_OUT_PIN                         19

--- a/Marlin/src/pins/mega/pins_CNCONTROLS_12.h
+++ b/Marlin/src/pins/mega/pins_CNCONTROLS_12.h
@@ -140,18 +140,20 @@
 //
 // LCD / Controller
 //
-#define BEEPER_PIN                            16
+#if HAS_WIRED_LCD
+  #define BEEPER_PIN                          16
 
-// Pins for DOGM SPI LCD Support
-#define DOGLCD_A0                             39
-#define DOGLCD_CS                             35
-#define DOGLCD_MOSI                           48
-#define DOGLCD_SCK                            49
+  #define BTN_EN1                             36
+  #define BTN_EN2                             34
+  #define BTN_ENC                             38
 
-// The encoder and click button
-#define BTN_EN1                               36
-#define BTN_EN2                               34
-#define BTN_ENC                               38
+  #if HAS_MARLINUI_U8GLIB
+    #define DOGLCD_A0                         39
+    #define DOGLCD_CS                         35
+    #define DOGLCD_MOSI                       48
+    #define DOGLCD_SCK                        49
+  #endif
+#endif
 
 // Hardware buttons for manual movement of XYZ
 #define SHIFT_OUT_PIN                         42

--- a/Marlin/src/pins/ramps/pins_AZTEEG_X3_PRO.h
+++ b/Marlin/src/pins/ramps/pins_AZTEEG_X3_PRO.h
@@ -158,7 +158,7 @@
 #if ENABLED(CASE_LIGHT_ENABLE) && PIN_EXISTS(CASE_LIGHT) && defined(DOGLCD_A0) && DOGLCD_A0 == CASE_LIGHT_PIN
   #undef DOGLCD_A0                                // Steal pin 44 for the case light; if you have a Viki2 and have connected it
   #define DOGLCD_A0                           57  // following the Panucatt wiring diagram, you may need to tweak these pin assignments
-                                // as the wiring diagram uses pin 44 for DOGLCD_A0
+                                                  // as the wiring diagram uses pin 44 for DOGLCD_A0.
 #endif
 
 //

--- a/Marlin/src/pins/sam/pins_RAMPS_FD_V1.h
+++ b/Marlin/src/pins/sam/pins_RAMPS_FD_V1.h
@@ -134,71 +134,98 @@
 #define SDSS                                   4
 #define LED_PIN                               13
 
+/**        ------                     ------
+ *     37 |10  9 | 35      (MISO) 50 |10  9 | 76 (SCK)
+ *     29 | 8  7 | 27       (EN2) 31 | 8  7 |  4 (SD_SS)
+ *     25   6  5 | 23       (EN1) 33   6  5 | 75 (MOSI)
+ *     16 | 4  3 | 17       (SDD) 49 | 4  3 | RESET
+ *    GND | 2  1 | 5V            GND | 2  1 | --
+ *         ------                     ------
+ *          EXP1                       EXP2
+ */
+#define EXP1_03_PIN                           17
+#define EXP1_04_PIN                           16
+#define EXP1_05_PIN                           23
+#define EXP1_06_PIN                           25
+#define EXP1_07_PIN                           27
+#define EXP1_08_PIN                           29
+#define EXP1_09_PIN                           35
+#define EXP1_10_PIN                           37
+
+#define EXP2_03_PIN                           -1
+#define EXP2_04_PIN                           49
+#define EXP2_05_PIN                           75
+#define EXP2_06_PIN                           33
+#define EXP2_07_PIN                            4
+#define EXP2_08_PIN                           31
+#define EXP2_09_PIN                           76
+#define EXP2_10_PIN                           74
+
 //
 // LCD / Controller
 //
 #if HAS_WIRED_LCD
   // ramps-fd lcd adaptor
 
-  #define BEEPER_PIN                          37
-  #define BTN_EN1                             33
-  #define BTN_EN2                             31
-  #define BTN_ENC                             35
-  #define SD_DETECT_PIN                       49
+  #define BEEPER_PIN                 EXP1_10_PIN
+  #define BTN_EN1                    EXP2_06_PIN
+  #define BTN_EN2                    EXP2_08_PIN
+  #define BTN_ENC                    EXP1_09_PIN
+  #define SD_DETECT_PIN              EXP2_04_PIN
 
   #if IS_NEWPANEL
-    #define LCD_PINS_RS                       16
-    #define LCD_PINS_ENABLE                   17
+    #define LCD_PINS_RS              EXP1_04_PIN
+    #define LCD_PINS_ENABLE          EXP1_03_PIN
   #endif
 
   #if ENABLED(FYSETC_MINI_12864)
     #define DOGLCD_CS            LCD_PINS_ENABLE
     #define DOGLCD_A0                LCD_PINS_RS
-    #define DOGLCD_SCK                        76
-    #define DOGLCD_MOSI                       75
+    #define DOGLCD_SCK               EXP2_09_PIN
+    #define DOGLCD_MOSI              EXP2_05_PIN
 
     //#define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
 
-    #define LCD_RESET_PIN                     23  // Must be high or open for LCD to operate normally.
+    #define LCD_RESET_PIN            EXP1_05_PIN  // Must be high or open for LCD to operate normally.
 
     #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
       #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN                 25
+        #define RGB_LED_R_PIN        EXP1_06_PIN
       #endif
       #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN                 27
+        #define RGB_LED_G_PIN        EXP1_07_PIN
       #endif
       #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN                 29
+        #define RGB_LED_B_PIN        EXP1_08_PIN
       #endif
     #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN                    25
+      #define NEOPIXEL_PIN           EXP1_06_PIN
     #endif
 
   #elif IS_NEWPANEL
 
-    #define LCD_PINS_D4                       23
-    #define LCD_PINS_D5                       25
-    #define LCD_PINS_D6                       27
-    #define LCD_PINS_D7                       29
+    #define LCD_PINS_D4              EXP1_05_PIN
+    #define LCD_PINS_D5              EXP1_06_PIN
+    #define LCD_PINS_D6              EXP1_07_PIN
+    #define LCD_PINS_D7              EXP1_08_PIN
 
     #if ENABLED(MINIPANEL)
-      #define DOGLCD_CS                       25
-      #define DOGLCD_A0                       27
+      #define DOGLCD_CS              EXP1_06_PIN
+      #define DOGLCD_A0              EXP1_07_PIN
     #endif
 
   #endif
 
   #if ANY(VIKI2, miniVIKI)
-    #define DOGLCD_A0                         16
+    #define DOGLCD_A0                EXP1_04_PIN
     #define KILL_PIN                          51
-    #define STAT_LED_BLUE_PIN                 29
-    #define STAT_LED_RED_PIN                  23
-    #define DOGLCD_CS                         17
-    #define DOGLCD_SCK                        76  // SCK_PIN   - Required for DUE Hardware SPI
-    #define DOGLCD_MOSI                       75  // MOSI_PIN
-    #define DOGLCD_MISO                       74  // MISO_PIN
+    #define STAT_LED_BLUE_PIN        EXP1_08_PIN
+    #define STAT_LED_RED_PIN         EXP1_05_PIN
+    #define DOGLCD_CS                EXP1_03_PIN
+    #define DOGLCD_SCK               EXP2_09_PIN  // SCK_PIN   - Required for DUE Hardware SPI
+    #define DOGLCD_MOSI              EXP2_05_PIN  // MOSI_PIN
+    #define DOGLCD_MISO              EXP2_10_PIN  // MISO_PIN
   #endif
 
   #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)

--- a/Marlin/src/pins/sam/pins_RURAMPS4D_11.h
+++ b/Marlin/src/pins/sam/pins_RURAMPS4D_11.h
@@ -153,7 +153,7 @@
 // SPI for MAX Thermocouple
 /*
 #if DISABLED(SDSUPPORT)
-  #define TEMP_0_CS_PIN                       53
+  #define TEMP_0_CS_PIN              EXP1_03_PIN
 #else
   #define TEMP_0_CS_PIN                       49
 #endif
@@ -190,59 +190,87 @@
 // 32Mb FLASH
 //#define SPI_FLASH_CS_PIN        ?
 
+/**
+ *              ------                                ------
+ * (BEEPER) 62 |10  9 | 40 (BTN_ENC)  (MISO)      74 |10  9 | 76 (SCK)
+ * (LCD_EN) 64 | 8  7 | 63 (LCD_RS)   (BTN_EN1)   44 | 8  7 | 10 (SD_SS)
+ * (LCD_D4) 48 | 6  5   50 (LCD_D5)   (BTN_EN2)   42 | 6  5   75 (MOSI)
+ * (LCD_D6) 52 | 4  3 | 53 (LCD_D7)   (SD_DETECT) 51 | 4  3 | RESET
+ *         GND | 2  1 | 5V                       GND | 2  1 | --
+ *              ------                                ------
+ *               EXP1                                  EXP2
+ */
+#define EXP1_03_PIN                           53
+#define EXP1_04_PIN                           52
+#define EXP1_05_PIN                           50
+#define EXP1_06_PIN                           48
+#define EXP1_07_PIN                           63
+#define EXP1_08_PIN                           64
+#define EXP1_09_PIN                           40
+#define EXP1_10_PIN                           62
+
+#define EXP2_03_PIN                           -1  // RESET
+#define EXP2_04_PIN                           51
+#define EXP2_05_PIN                           75  // MOSI
+#define EXP2_06_PIN                           42
+#define EXP2_07_PIN                           10
+#define EXP2_08_PIN                           44
+#define EXP2_09_PIN                           76  // SCK
+#define EXP2_10_PIN                           74  // MISO
+
 //
 // LCD / Controller
 //
 #if HAS_WIRED_LCD
 
   #if ANY(RADDS_DISPLAY, IS_RRD_SC, IS_RRD_FG_SC)
-    #define BEEPER_PIN                        62
-    #define LCD_PINS_D4                       48
-    #define LCD_PINS_D5                       50
-    #define LCD_PINS_D6                       52
-    #define LCD_PINS_D7                       53
-    #define SD_DETECT_PIN                     51
+    #define BEEPER_PIN               EXP1_10_PIN
+    #define LCD_PINS_D4              EXP1_06_PIN
+    #define LCD_PINS_D5              EXP1_05_PIN
+    #define LCD_PINS_D6              EXP1_04_PIN
+    #define LCD_PINS_D7              EXP1_03_PIN
+    #define SD_DETECT_PIN            EXP2_04_PIN
   #endif
 
   #if EITHER(RADDS_DISPLAY, IS_RRD_SC)
 
-    #define LCD_PINS_RS                       63
-    #define LCD_PINS_ENABLE                   64
+    #define LCD_PINS_RS              EXP1_07_PIN
+    #define LCD_PINS_ENABLE          EXP1_08_PIN
 
   #elif IS_RRD_FG_SC
 
-    #define LCD_PINS_RS                       52
-    #define LCD_PINS_ENABLE                   53
+    #define LCD_PINS_RS              EXP1_04_PIN
+    #define LCD_PINS_ENABLE          EXP1_03_PIN
 
   #elif HAS_U8GLIB_I2C_OLED
 
-    #define BEEPER_PIN                        62
-    #define LCD_SDSS                          10
-    #define SD_DETECT_PIN                     51
+    #define BEEPER_PIN               EXP1_10_PIN
+    #define LCD_SDSS                 EXP2_07_PIN
+    #define SD_DETECT_PIN            EXP2_04_PIN
 
   #elif ENABLED(FYSETC_MINI_12864)
 
-    #define BEEPER_PIN                        62
-    #define DOGLCD_CS                         64
-    #define DOGLCD_A0                         63
+    #define BEEPER_PIN               EXP1_10_PIN
+    #define DOGLCD_CS                EXP1_08_PIN
+    #define DOGLCD_A0                EXP1_07_PIN
 
     //#define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
 
-    #define LCD_RESET_PIN                     48  // Must be high or open for LCD to operate normally.
+    #define LCD_RESET_PIN            EXP1_06_PIN  // Must be high or open for LCD to operate normally.
 
     #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
       #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN                 50  // D5
+        #define RGB_LED_R_PIN        EXP1_05_PIN  // D5
       #endif
       #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN                 52  // D6
+        #define RGB_LED_G_PIN        EXP1_04_PIN  // D6
       #endif
       #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN                 53  // D7
+        #define RGB_LED_B_PIN        EXP1_03_PIN  // D7
       #endif
     #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN                    50  // D5
+      #define NEOPIXEL_PIN           EXP1_05_PIN  // D5
     #endif
 
   #elif ENABLED(SPARK_FULL_GRAPHICS)
@@ -259,9 +287,9 @@
   #endif // SPARK_FULL_GRAPHICS
 
   #if IS_NEWPANEL
-    #define BTN_EN1                           44
-    #define BTN_EN2                           42
-    #define BTN_ENC                           40
+    #define BTN_EN1                  EXP2_08_PIN
+    #define BTN_EN2                  EXP2_06_PIN
+    #define BTN_ENC                  EXP1_09_PIN
   #endif
 
   #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)

--- a/Marlin/src/pins/sam/pins_RURAMPS4D_13.h
+++ b/Marlin/src/pins/sam/pins_RURAMPS4D_13.h
@@ -173,74 +173,101 @@
 // 32Mb FLASH
 //#define SPI_FLASH_CS_PIN        ?
 
+/**
+ *              ------                                ------
+ * (BEEPER) 62 |10  9 | 40 (BTN_ENC)  (MISO)      74 |10  9 | 76 (SCK)
+ * (LCD_EN) 64 | 8  7 | 63 (LCD_RS)   (BTN_EN1)   44 | 8  7 | 10 (SD_SS)
+ * (LCD_D4) 48 | 6  5   50 (LCD_D5)   (BTN_EN2)   42 | 6  5   75 (MOSI)
+ * (LCD_D6) 52 | 4  3 | 53 (LCD_D7)   (SD_DETECT) 51 | 4  3 | RESET
+ *         GND | 2  1 | 5V                       GND | 2  1 | --
+ *              ------                                ------
+ *               EXP1                                  EXP2
+ */
+#define EXP1_03_PIN                           53
+#define EXP1_04_PIN                           52
+#define EXP1_05_PIN                           50
+#define EXP1_06_PIN                           48
+#define EXP1_07_PIN                           63
+#define EXP1_08_PIN                           64
+#define EXP1_09_PIN                           40
+#define EXP1_10_PIN                           62
+
+#define EXP2_03_PIN                           -1  // RESET
+#define EXP2_04_PIN                           51
+#define EXP2_05_PIN                           75  // MOSI
+#define EXP2_06_PIN                           42
+#define EXP2_07_PIN                           10
+#define EXP2_08_PIN                           44
+#define EXP2_09_PIN                           76  // SCK
+#define EXP2_10_PIN                           74  // MISO
+
 //
 // LCD / Controller
 //
 #if HAS_WIRED_LCD
 
   #if ANY(RADDS_DISPLAY, IS_RRD_SC, IS_RRD_FG_SC)
-    #define BEEPER_PIN                        62
-    #define LCD_PINS_D4                       48
-    #define LCD_PINS_D5                       50
-    #define LCD_PINS_D6                       52
-    #define LCD_PINS_D7                       53
-    #define SD_DETECT_PIN                     51
+    #define BEEPER_PIN               EXP1_10_PIN
+    #define LCD_PINS_D4              EXP1_06_PIN
+    #define LCD_PINS_D5              EXP1_05_PIN
+    #define LCD_PINS_D6              EXP1_04_PIN
+    #define LCD_PINS_D7              EXP1_03_PIN
+    #define SD_DETECT_PIN            EXP2_04_PIN
   #endif
 
   #if EITHER(RADDS_DISPLAY, IS_RRD_SC)
 
-    #define LCD_PINS_RS                       63
-    #define LCD_PINS_ENABLE                   64
+    #define LCD_PINS_RS              EXP1_07_PIN
+    #define LCD_PINS_ENABLE          EXP1_08_PIN
 
   #elif IS_RRD_FG_SC
 
-    #define LCD_PINS_RS                       52
-    #define LCD_PINS_ENABLE                   53
+    #define LCD_PINS_RS              EXP1_04_PIN
+    #define LCD_PINS_ENABLE          EXP1_03_PIN
 
   #elif HAS_U8GLIB_I2C_OLED
 
-    #define BEEPER_PIN                        62
-    #define LCD_SDSS                          10
-    #define SD_DETECT_PIN                     51
+    #define BEEPER_PIN               EXP1_10_PIN
+    #define LCD_SDSS                 EXP2_07_PIN
+    #define SD_DETECT_PIN            EXP2_04_PIN
 
   #elif ENABLED(FYSETC_MINI_12864)
 
-    #define BEEPER_PIN                        62
-    #define DOGLCD_CS                         64
-    #define DOGLCD_A0                         63
+    #define BEEPER_PIN               EXP1_10_PIN
+    #define DOGLCD_CS                EXP1_08_PIN
+    #define DOGLCD_A0                EXP1_07_PIN
 
     //#define FORCE_SOFT_SPI                      // Use this if default of hardware SPI causes display problems
                                                   //   results in LCD soft SPI mode 3, SD soft SPI mode 0
 
-    #define LCD_RESET_PIN                     48  // Must be high or open for LCD to operate normally.
+    #define LCD_RESET_PIN            EXP1_06_PIN  // Must be high or open for LCD to operate normally.
 
     #if EITHER(FYSETC_MINI_12864_1_2, FYSETC_MINI_12864_2_0)
       #ifndef RGB_LED_R_PIN
-        #define RGB_LED_R_PIN                 50  // D5
+        #define RGB_LED_R_PIN        EXP1_05_PIN  // D5
       #endif
       #ifndef RGB_LED_G_PIN
-        #define RGB_LED_G_PIN                 52  // D6
+        #define RGB_LED_G_PIN        EXP1_04_PIN  // D6
       #endif
       #ifndef RGB_LED_B_PIN
-        #define RGB_LED_B_PIN                 53  // D7
+        #define RGB_LED_B_PIN        EXP1_03_PIN  // D7
       #endif
     #elif ENABLED(FYSETC_MINI_12864_2_1)
-      #define NEOPIXEL_PIN                    50  // D5
+      #define NEOPIXEL_PIN           EXP1_05_PIN  // D5
     #endif
 
   #elif ENABLED(MKS_MINI_12864)
+    #define DOGLCD_A0                EXP1_04_PIN
+    #define DOGLCD_CS                EXP1_05_PIN
 
-    #define DOGLCD_A0                         52
-    #define DOGLCD_CS                         50
-
-    #define SD_DETECT_PIN                     51
+    #define SD_DETECT_PIN            EXP2_04_PIN
 
   #endif
 
   #if IS_NEWPANEL
-    #define BTN_EN1                           44
-    #define BTN_EN2                           42
-    #define BTN_ENC                           40
+    #define BTN_EN1                  EXP2_08_PIN
+    #define BTN_EN2                  EXP2_06_PIN
+    #define BTN_ENC                  EXP1_09_PIN
   #endif
 
   #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -256,11 +256,10 @@
   #define TFT_MISO_PIN                      PA6
   #define TFT_MOSI_PIN                      PA7
   #define TFT_DC_PIN                        PD10
-  #define TFT_RST_PIN                       PC6
   #define TFT_A0_PIN                  TFT_DC_PIN
 
   #define TFT_RESET_PIN                     PC6
-  #define TFT_BACKLIGHT_PIN                 PD13
+  #define TFT_BACKLIGHT_PIN    LCD_BACKLIGHT_PIN
 
   #define TOUCH_BUTTONS_HW_SPI
   #define TOUCH_BUTTONS_HW_SPI_DEVICE          1

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_E3P.h
@@ -205,6 +205,34 @@
 
 //#define LED_PIN                           PB2
 
+/**
+ *        ------                  ------
+ *  PC5  |10  9 | PE13       PA6 |10  9 | PA5
+ *  PD13 | 8  7 | PC6        PE8 | 8  7 | PE10
+ *  PE14 | 6  5   PE15      PE11 | 6  5   PA7
+ *  PD11 | 4  3 | PD10      PE12 | 4  3 | RESET
+ *   GND | 2  1 | 5V         GND | 2  1 | 3.3V
+ *        ------                  ------
+ *         EXP1                    EXP2
+ */
+#define EXP1_03_PIN                         PD10
+#define EXP1_04_PIN                         PD11
+#define EXP1_05_PIN                         PE15
+#define EXP1_06_PIN                         PE14
+#define EXP1_07_PIN                         PC6
+#define EXP1_08_PIN                         PD13
+#define EXP1_09_PIN                         PE13
+#define EXP1_10_PIN                         PC5
+
+#define EXP2_03_PIN                         -1
+#define EXP2_04_PIN                         PE12
+#define EXP2_05_PIN                         PA7
+#define EXP2_06_PIN                         PE11
+#define EXP2_07_PIN                         PE10
+#define EXP2_08_PIN                         PE8
+#define EXP2_09_PIN                         PA5
+#define EXP2_10_PIN                         PA6
+
 //
 // SD Card
 //
@@ -219,11 +247,11 @@
   #define ONBOARD_SD_CS_PIN                 PC11
 #elif SD_CONNECTION_IS(LCD)
   #define ENABLE_SPI1
-  #define SDSS                              PE10
-  #define SD_SCK_PIN                        PA5
-  #define SD_MISO_PIN                       PA6
-  #define SD_MOSI_PIN                       PA7
-  #define SD_DETECT_PIN                     PE12
+  #define SDSS                       EXP2_07_PIN
+  #define SD_SCK_PIN                 EXP2_09_PIN
+  #define SD_MISO_PIN                EXP2_10_PIN
+  #define SD_MOSI_PIN                EXP2_05_PIN
+  #define SD_DETECT_PIN              EXP2_04_PIN
 #endif
 
 //
@@ -240,25 +268,25 @@
 
   // Shared SPI TFT
 
-  #define LCD_BACKLIGHT_PIN                 PD13
+  #define LCD_BACKLIGHT_PIN          EXP1_08_PIN
 
-  #define TOUCH_CS_PIN                      PE14  // SPI1_NSS
-  #define TOUCH_SCK_PIN                     PA5   // SPI1_SCK
-  #define TOUCH_MISO_PIN                    PA6   // SPI1_MISO
-  #define TOUCH_MOSI_PIN                    PA7   // SPI1_MOSI
+  #define TOUCH_CS_PIN               EXP1_06_PIN  // SPI1_NSS
+  #define TOUCH_SCK_PIN              EXP2_09_PIN  // SPI1_SCK
+  #define TOUCH_MISO_PIN             EXP2_10_PIN  // SPI1_MISO
+  #define TOUCH_MOSI_PIN             EXP2_05_PIN  // SPI1_MOSI
 
-  #define BTN_EN1                           PE8
-  #define BTN_EN2                           PE11
-  #define BTN_ENC                           PE13
+  #define BTN_EN1                    EXP2_08_PIN
+  #define BTN_EN2                    EXP2_06_PIN
+  #define BTN_ENC                    EXP1_09_PIN
 
-  #define TFT_CS_PIN                        PD11
-  #define TFT_SCK_PIN                       PA5
-  #define TFT_MISO_PIN                      PA6
-  #define TFT_MOSI_PIN                      PA7
-  #define TFT_DC_PIN                        PD10
+  #define TFT_CS_PIN                 EXP1_04_PIN
+  #define TFT_SCK_PIN                EXP2_09_PIN
+  #define TFT_MISO_PIN               EXP2_10_PIN
+  #define TFT_MOSI_PIN               EXP2_05_PIN
+  #define TFT_DC_PIN                 EXP1_03_PIN
   #define TFT_A0_PIN                  TFT_DC_PIN
 
-  #define TFT_RESET_PIN                     PC6
+  #define TFT_RESET_PIN              EXP1_07_PIN
   #define TFT_BACKLIGHT_PIN    LCD_BACKLIGHT_PIN
 
   #define TOUCH_BUTTONS_HW_SPI
@@ -270,22 +298,22 @@
 
 #if ENABLED(TFT_CLASSIC_UI)
   // Emulated DOGM SPI
-  #define LCD_PINS_ENABLE                   PD13
-  #define LCD_PINS_RS                       PC6
-  #define BTN_ENC                           PE13
-  #define BTN_EN1                           PE8
-  #define BTN_EN2                           PE11
+  #define LCD_PINS_ENABLE            EXP1_08_PIN
+  #define LCD_PINS_RS                EXP1_07_PIN
+  #define BTN_ENC                    EXP1_09_PIN
+  #define BTN_EN1                    EXP2_08_PIN
+  #define BTN_EN2                    EXP2_06_PIN
 #elif ENABLED(TFT_COLOR_UI)
   #define TFT_BUFFER_SIZE                  14400
 #endif
 
 #if HAS_WIRED_LCD && !HAS_SPI_TFT
-  #define BEEPER_PIN                        PC5
-  #define BTN_ENC                           PE13
-  #define LCD_PINS_ENABLE                   PD13
-  #define LCD_PINS_RS                       PC6
-  #define BTN_EN1                           PE8
-  #define BTN_EN2                           PE11
+  #define BEEPER_PIN                 EXP1_10_PIN
+  #define BTN_ENC                    EXP1_09_PIN
+  #define LCD_PINS_ENABLE            EXP1_08_PIN
+  #define LCD_PINS_RS                EXP1_07_PIN
+  #define BTN_EN1                    EXP2_08_PIN
+  #define BTN_EN2                    EXP2_06_PIN
   #define LCD_BACKLIGHT_PIN                 -1
 
   #if ENABLED(MKS_MINI_12864)
@@ -295,18 +323,18 @@
 
     #define LCD_BACKLIGHT_PIN               -1
     #define LCD_RESET_PIN                   -1
-    #define DOGLCD_A0                       PD11
-    #define DOGLCD_CS                       PE15
-    #define DOGLCD_SCK                      PA5
-    #define DOGLCD_MOSI                     PA7
+    #define DOGLCD_A0                EXP1_04_PIN
+    #define DOGLCD_CS                EXP1_05_PIN
+    #define DOGLCD_SCK               EXP2_09_PIN
+    #define DOGLCD_MOSI              EXP2_05_PIN
 
   #elif IS_TFTGLCD_PANEL
 
     #if ENABLED(TFTGLCD_PANEL_SPI)
-      #define PIN_SPI_SCK                   PA5
-      #define PIN_TFT_MISO                  PA6
-      #define PIN_TFT_MOSI                  PA7
-      #define TFTGLCD_CS                    PE8
+      #define PIN_SPI_SCK            EXP2_09_PIN
+      #define PIN_TFT_MISO           EXP2_10_PIN
+      #define PIN_TFT_MOSI           EXP2_05_PIN
+      #define TFTGLCD_CS             EXP2_08_PIN
     #endif
 
     #ifndef BEEPER_PIN
@@ -314,14 +342,14 @@
     #endif
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
-    #define LCD_PINS_DC                     PC6
-    #define DOGLCD_CS                       PD13
+    #define LCD_PINS_DC              EXP1_07_PIN
+    #define DOGLCD_CS                EXP1_08_PIN
     #define DOGLCD_A0                  DOGLCD_A0
     #define LCD_BACKLIGHT_PIN               -1
-    #define LCD_RESET_PIN                   PE14
-    #define NEOPIXEL_PIN                    PE15
-    #define DOGLCD_MOSI                     PA7
-    #define DOGLCD_SCK                      PA5
+    #define LCD_RESET_PIN            EXP1_06_PIN
+    #define NEOPIXEL_PIN             EXP1_05_PIN
+    #define DOGLCD_MOSI              EXP2_05_PIN
+    #define DOGLCD_SCK               EXP2_09_PIN
     #if SD_CONNECTION_IS(ONBOARD)
       #define FORCE_SOFT_SPI
     #endif
@@ -329,11 +357,11 @@
 
   #else                                           // !MKS_MINI_12864
 
-    #define LCD_PINS_D4                     PE14
+    #define LCD_PINS_D4              EXP1_06_PIN
     #if IS_ULTIPANEL
-      #define LCD_PINS_D5                   PE15
-      #define LCD_PINS_D6                   PD11
-      #define LCD_PINS_D7                   PD10
+      #define LCD_PINS_D5            EXP1_05_PIN
+      #define LCD_PINS_D6            EXP1_04_PIN
+      #define LCD_PINS_D7            EXP1_03_PIN
 
       #if ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
         #define BTN_ENC_EN           LCD_PINS_D7  // Detect the presence of the encoder
@@ -359,7 +387,7 @@
 #endif
 
 #ifndef BEEPER_PIN
-  #define BEEPER_PIN                        PC5
+  #define BEEPER_PIN                 EXP1_10_PIN
 #endif
 
 #if ENABLED(SPEAKER) && BEEPER_PIN == PC5

--- a/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
+++ b/Marlin/src/pins/stm32f1/pins_MKS_ROBIN_NANO_V2.h
@@ -282,11 +282,10 @@
   #define TFT_MISO_PIN                      PA6
   #define TFT_MOSI_PIN                      PA7
   #define TFT_DC_PIN                        PD10
-  #define TFT_RST_PIN                       PC6
   #define TFT_A0_PIN                  TFT_DC_PIN
 
   #define TFT_RESET_PIN                     PC6
-  #define TFT_BACKLIGHT_PIN                 PD13
+  #define TFT_BACKLIGHT_PIN    LCD_BACKLIGHT_PIN
 
   #define TOUCH_BUTTONS_HW_SPI
   #define TOUCH_BUTTONS_HW_SPI_DEVICE          1

--- a/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
+++ b/Marlin/src/pins/stm32f4/pins_BTT_SKR_V2_0_common.h
@@ -527,6 +527,11 @@
 #endif
 
 #if HAS_SPI_TFT
+
+  #define BTN_EN1                    EXP2_08_PIN
+  #define BTN_EN2                    EXP2_06_PIN
+  #define BTN_ENC                    EXP1_09_PIN
+
   //
   // e.g., BTT_TFT35_SPI_V1_0 (480x320, 3.5", SPI Stock Display with Rotary Encoder in BIQU B1 SE)
   //
@@ -542,9 +547,6 @@
   #define TOUCH_SCK_PIN              EXP1_06_PIN
   #define TOUCH_CS_PIN               EXP1_07_PIN
 
-  #define BTN_EN1                    EXP2_08_PIN
-  #define BTN_EN2                    EXP2_06_PIN
-  #define BTN_ENC                    EXP1_09_PIN
 #endif
 
 //

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8.h
@@ -289,16 +289,16 @@
   #define TFT_MISO_PIN               EXP2_10_PIN
   #define TFT_MOSI_PIN               EXP2_05_PIN
   #define TFT_DC_PIN                 EXP1_03_PIN
-  #define TFT_RST_PIN                EXP1_07_PIN
   #define TFT_A0_PIN                  TFT_DC_PIN
 
   #define TFT_RESET_PIN              EXP1_07_PIN
-  #define TFT_BACKLIGHT_PIN          EXP1_08_PIN
+
+  #define LCD_BACKLIGHT_PIN          EXP1_08_PIN
+  #define TFT_BACKLIGHT_PIN    LCD_BACKLIGHT_PIN
 
   #define TOUCH_BUTTONS_HW_SPI
   #define TOUCH_BUTTONS_HW_SPI_DEVICE          1
 
-  #define LCD_BACKLIGHT_PIN          EXP1_08_PIN
   #ifndef TFT_WIDTH
     #define TFT_WIDTH                        480
   #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_NANO_V3_common.h
@@ -283,16 +283,16 @@
   #define TFT_MISO_PIN               EXP2_10_PIN
   #define TFT_MOSI_PIN               EXP2_05_PIN
   #define TFT_DC_PIN                 EXP1_03_PIN
-  #define TFT_RST_PIN                EXP1_07_PIN
   #define TFT_A0_PIN                  TFT_DC_PIN
 
   #define TFT_RESET_PIN              EXP1_07_PIN
-  #define TFT_BACKLIGHT_PIN          EXP1_08_PIN
+
+  #define LCD_BACKLIGHT_PIN          EXP1_08_PIN
+  #define TFT_BACKLIGHT_PIN    LCD_BACKLIGHT_PIN
 
   #define TOUCH_BUTTONS_HW_SPI
   #define TOUCH_BUTTONS_HW_SPI_DEVICE          1
 
-  #define LCD_BACKLIGHT_PIN          EXP1_08_PIN
   #ifndef TFT_WIDTH
     #define TFT_WIDTH                        480
   #endif

--- a/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_ROBIN_PRO_V2.h
@@ -305,16 +305,15 @@
   #define TFT_MISO_PIN               EXP2_10_PIN
   #define TFT_MOSI_PIN               EXP2_05_PIN
   #define TFT_DC_PIN                 EXP1_03_PIN
-  #define TFT_RST_PIN                EXP1_07_PIN
   #define TFT_A0_PIN                  TFT_DC_PIN
 
   #define TFT_RESET_PIN              EXP1_07_PIN
-  #define TFT_BACKLIGHT_PIN          EXP1_08_PIN
+  #define LCD_BACKLIGHT_PIN          EXP1_08_PIN
+  #define TFT_BACKLIGHT_PIN    LCD_BACKLIGHT_PIN
 
   #define TOUCH_BUTTONS_HW_SPI
   #define TOUCH_BUTTONS_HW_SPI_DEVICE          1
 
-  #define LCD_BACKLIGHT_PIN          EXP1_08_PIN
   #ifndef TFT_WIDTH
     #define TFT_WIDTH                        480
   #endif

--- a/Marlin/src/pins/stm32f4/pins_VAKE403D.h
+++ b/Marlin/src/pins/stm32f4/pins_VAKE403D.h
@@ -161,27 +161,61 @@
 #define POWER_LOSS_PIN                      PA4   // ?? Power loss / nAC_FAULT
 
 #if ENABLED(SDSUPPORT)
-  #define SD_DETECT_PIN                     PB7
-  #define SD_SS_PIN                        PB_15  // USD_CS -> CS for onboard SD
+  #define SD_DETECT_PIN              EXP2_04_PIN
+  #define SD_SS_PIN                         PB15  // USD_CS -> CS for onboard SD
 #endif
+
+/**
+ *        ------                  ------
+ *   PC9 |10  9 | PB12         ? |10  9 | ?
+ *   PD7 | 8  7 | PC12       PD6 | 8  7 | ?
+ *   PD1 | 6  5   PD2        PD0 | 6  5   ?
+ *   PD3 | 4  3 | PD4        PB7 | 4  3 | RESET
+ *   GND | 2  1 | 5V         GND | 2  1 | 3.3V
+ *        ------                  ------
+ *         EXP1                    EXP2
+ */
+#define EXP1_03_PIN                         PD4
+#define EXP1_04_PIN                         PD3
+#define EXP1_05_PIN                         PD2
+#define EXP1_06_PIN                         PD1
+#define EXP1_07_PIN                         PC12
+#define EXP1_08_PIN                         PD7
+#define EXP1_09_PIN                         PB12
+#define EXP1_10_PIN                         PC9
+
+#define EXP2_03_PIN                         -1
+#define EXP2_04_PIN                         PB7
+//#define EXP2_05_PIN                       ?
+#define EXP2_06_PIN                         PD0
+//#define EXP2_07_PIN                       ?
+#define EXP2_08_PIN                         PD6
+//#define EXP2_09_PIN                       ?
+//#define EXP2_10_PIN                       ?
 
 //
 // LCD / Controller
 //
 #if HAS_WIRED_LCD
+
   #if ENABLED(SDSUPPORT)
     #define SDSS                            PB6   // CS for SD card in LCD
   #endif
-  #define BEEPER_PIN                        PC9
-  #define LCD_PINS_RS                       PC12
-  #define LCD_PINS_ENABLE                   PD7
-  #define LCD_PINS_D4                       PD1
-  #define LCD_PINS_D5                       PD2
-  #define LCD_PINS_D6                       PD3
-  #define LCD_PINS_D7                       PD4
-  #define BTN_EN1                           PD6
-  #define BTN_EN2                           PD0
-  #define BTN_ENC                           PB12
+
+  #define BEEPER_PIN                 EXP1_10_PIN
+
+  #define BTN_EN1                    EXP2_08_PIN
+  #define BTN_EN2                    EXP2_06_PIN
+  #define BTN_ENC                    EXP1_09_PIN
+
+  #define LCD_PINS_ENABLE            EXP1_08_PIN
+  #define LCD_PINS_RS                EXP1_07_PIN
+
+  #define LCD_PINS_D4                EXP1_06_PIN
+  #define LCD_PINS_D5                EXP1_05_PIN
+  #define LCD_PINS_D6                EXP1_04_PIN
+  #define LCD_PINS_D7                EXP1_03_PIN
+
 #endif
 
 // Alter timing for graphical display

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX.h
@@ -50,8 +50,6 @@
 #define LED_PIN                             PA13
 #define BEEPER_PIN                          PA14
 
-#define TFT_BACKLIGHT_PIN                   PB5
-
 #define POWER_MONITOR_PIN                   PB0
 #define RPI_POWER_PIN                       PE5
 


### PR DESCRIPTION
- Add more EXP1/2 headers to the pins files, moving towards mapping-based LCD pins.
- Combine `TFT_RST_PIN` with `TFT_RESET_PIN`.
- Adjust where `TFT_BACKLIGHT_PIN` == `LCD_BACKLIGHT_PIN`.