### PR TITLE
update SAVED_POSITIONS_DEBUG

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2179,8 +2179,8 @@
 //
 // G60/G61 Position Save and Return
 //
-#define SAVED_POSITIONS 1         // Each saved position slot costs 12 bytes
-#define SAVED_POSITIONS_DEBUG
+//#define SAVED_POSITIONS 1         // Each saved position slot costs 12 bytes
+
 //
 // G2/G3 Arc Support
 //

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -2179,8 +2179,8 @@
 //
 // G60/G61 Position Save and Return
 //
-//#define SAVED_POSITIONS 1         // Each saved position slot costs 12 bytes
-
+#define SAVED_POSITIONS 1         // Each saved position slot costs 12 bytes
+#define SAVED_POSITIONS_DEBUG
 //
 // G2/G3 Arc Support
 //

--- a/Marlin/src/gcode/feature/pause/G60.cpp
+++ b/Marlin/src/gcode/feature/pause/G60.cpp
@@ -50,14 +50,14 @@ void GcodeSuite::G60() {
   {
     const xyze_pos_t &pos = stored_position[slot];
     DEBUG_ECHOPGM(STR_SAVED_POS " S", slot, " :");
-    DEBUG_ECHOLNPAIR_F_P(
+    DEBUG_ECHOLNPGM_P(
       LIST_N(DOUBLE(NUM_AXES),
-        SP_Y_STR, pos.x, SP_Y_STR, pos.y, SP_Z_STR, pos.z,
-        SP_I_STR, pos.i, SP_J_STR, pos.j, SP_K_STR, pos.k,
-        SP_U_STR, pos.u, SP_V_STR, pos.v, SP_W_STR, pos.w
+        SP_X_LBL, pos.x, SP_Y_LBL, pos.y, SP_Z_LBL, pos.z,
+        SP_I_LBL, pos.i, SP_J_LBL, pos.j, SP_K_LBL, pos.k,
+        SP_U_LBL, pos.u, SP_V_LBL, pos.v, SP_W_LBL, pos.w
       )
       #if HAS_EXTRUDERS
-        , SP_E_STR, pos.e
+        , SP_E_LBL, pos.e
       #endif
     );
   }


### PR DESCRIPTION
### Requirements

Enable `#define SAVED_POSITIONS 1` to turn on  G60/G61 
Add  `#define SAVED_POSITIONS_DEBUG` to turn on the G60/G61 debugging. 

### Description

Currently this errors with

```CPP
In file included from Marlin/src/gcode/feature/pause/../../../inc/MarlinConfig.h:55:0,
                 from Marlin/src/gcode/feature/pause/G60.cpp:23:
Marlin/src/gcode/feature/pause/G60.cpp: In static member function 'static void GcodeSuite::G60()':
Marlin/src/gcode/feature/pause/../../../inc/../core/serial.h:281:77: warning: invalid conversion from 'const char*' to 'int' [-fpermissive]
 #define SERIAL_ECHOPAIR_F_P(P,V...)   do{ serial_print_P(P); SERIAL_ECHO_F(V); }while(0)
                                                                             ^
Marlin/src/gcode/feature/pause/../../../inc/../core/serial.h:282:43: note: in expansion of macro 'SERIAL_ECHOPAIR_F_P'
 #define SERIAL_ECHOLNPAIR_F_P(P,V...) do{ SERIAL_ECHOPAIR_F_P(P,V); SERIAL_EOL(); }while(0)
                                           ^~~~~~~~~~~~~~~~~~~
Marlin/src/gcode/feature/pause/../../../core/debug_out.h:79:35: note: in expansion of macro 'SERIAL_ECHOLNPAIR_F_P'
   #define DEBUG_ECHOLNPAIR_F_P    SERIAL_ECHOLNPAIR_F_P
                                   ^~~~~~~~~~~~~~~~~~~~~
Marlin/src/gcode/feature/pause/G60.cpp:53:5: note: in expansion of macro 'DEBUG_ECHOLNPAIR_F_P'
     DEBUG_ECHOLNPAIR_F_P(
     ^~~~~~~~~~~~~~~~~~~~
Marlin/src/gcode/feature/pause/../../../inc/../core/serial.h:281:77: error: too many arguments to function 'void SERIAL_ECHO_F(EnsureDouble, int)'

```

Debug statements where updated and a small cut and paste error was corrected (two Y axis, no X axis)  

### Benefits

This now compiles and works as expected

Example debug message after fixes.
`Position saved S0 : X:0.00 Y:0.00 Z:0.00 E:0.00`
