### PR TITLE
Two new features: COLD_EXTRUSION_MENU_ITEM and EVENT_GCODE_SD_ABORT_NOTHOMED

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -809,6 +809,10 @@
 #define PREVENT_COLD_EXTRUSION
 #define EXTRUDE_MINTEMP 170
 
+#if ENABLED(PREVENT_COLD_EXTRUSION)
+  //#define COLD_EXTRUSION_MENU_ITEM  // Enable/Disable cold extrusion from the LCD
+#endif
+
 /**
  * Prevent a single extrusion longer than EXTRUDE_MAXLENGTH.
  * Note: For Bowden Extruders make this large enough to allow load/unload.

--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1459,7 +1459,8 @@
 
   //#define MEDIA_MENU_AT_TOP               // Force the media menu to be listed on the top of the main menu
 
-  #define EVENT_GCODE_SD_ABORT "G28XY"      // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
+  #define EVENT_GCODE_SD_ABORT "G91\nG1Z5\nG90\nM84\nM104S0\nM140S0"  // G-code to run on SD Abort Print (e.g., "G28XY" or "G27")
+  #define EVENT_GCODE_SD_ABORT_NOTHOMED "M84\nM104S0\nM140S0"         // G-code to run on SD Abort Print instead of EVENT_GCODE_SD_ABORT, if axis positions is unknown/ not homed (e.g., "M84")
 
   #if ENABLED(PRINTER_EVENT_LEDS)
     #define PE_LEDS_COMPLETED_TIME  (30*60) // (seconds) Time to keep the LED "done" color before restoring normal illumination

--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -373,8 +373,12 @@ void startOrResumeJob() {
 
     TERN_(POWER_LOSS_RECOVERY, recovery.purge());
 
-    #ifdef EVENT_GCODE_SD_ABORT
+    #if defined(EVENT_GCODE_SD_ABORT) && defined(EVENT_GCODE_SD_ABORT_NOTHOMED)
+      queue.inject(all_axes_trusted() ? F(EVENT_GCODE_SD_ABORT) : F(EVENT_GCODE_SD_ABORT_NOTHOMED));
+    #elif defined(EVENT_GCODE_SD_ABORT)
       queue.inject(F(EVENT_GCODE_SD_ABORT));
+    #elif defined(EVENT_GCODE_SD_ABORT_NOTHOMED)
+      if (!all_axes_trusted()) queue.inject(F(EVENT_GCODE_SD_ABORT_NOTHOMED));
     #endif
 
     TERN_(PASSWORD_AFTER_SD_PRINT_ABORT, password.lock_machine());

--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -922,6 +922,10 @@ static_assert(Y_MAX_LENGTH >= Y_BED_SIZE, "Movement bounds (Y_MIN_POS, Y_MAX_POS
   static_assert(nullptr == strstr(EVENT_GCODE_SD_ABORT, "G27"), "NOZZLE_PARK_FEATURE is required to use G27 in EVENT_GCODE_SD_ABORT.");
 #endif
 
+#if defined(EVENT_GCODE_SD_ABORT_NOTHOMED) && DISABLED(NOZZLE_PARK_FEATURE)
+  static_assert(nullptr == strstr(EVENT_GCODE_SD_ABORT_NOTHOMED, "G27"), "NOZZLE_PARK_FEATURE is required to use G27 in EVENT_GCODE_SD_ABORT_NOTHOMED.");
+#endif
+
 /**
  * I2C Position Encoders
  */

--- a/Marlin/src/lcd/language/language_en.h
+++ b/Marlin/src/lcd/language/language_en.h
@@ -320,6 +320,7 @@ namespace Language_en {
   LSTR MSG_MOVE_U                         = _UxGT("Move ") STR_U;
   LSTR MSG_MOVE_V                         = _UxGT("Move ") STR_V;
   LSTR MSG_MOVE_W                         = _UxGT("Move ") STR_W;
+  LSTR MSG_COLD_EXTRUSION                 = _UxGT("Cold Extrusion");
   LSTR MSG_MOVE_E                         = _UxGT("Move Extruder");
   LSTR MSG_MOVE_EN                        = _UxGT("Move E*");
   LSTR MSG_HOTEND_TOO_COLD                = _UxGT("Hotend too cold");

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -248,6 +248,10 @@ void menu_move() {
     EDIT_ITEM(bool, MSG_LCD_SOFT_ENDSTOPS, &soft_endstop._enabled);
   #endif
 
+  #if BOTH(PREVENT_COLD_EXTRUSION, COLD_EXTRUSION_MENU_ITEM)
+    EDIT_ITEM(bool, MSG_COLD_EXTRUSION, &thermalManager.allow_cold_extrude);
+  #endif
+
   if (NONE(IS_KINEMATIC, NO_MOTION_BEFORE_HOMING) || all_axes_homed()) {
     if (TERN1(DELTA, current_position.z <= delta_clip_start_height)) {
       SUBMENU(MSG_MOVE_X, []{ _menu_move_distance(X_AXIS, lcd_move_x); });


### PR DESCRIPTION
As I'm new to GitHub, both my submitted changes has been added to this pull request, without knowing how to separate them. Hope you bear over with me.. I'll do my best and split them into sections here:

**[PREVENT_COLD_EXTRUSION from LCD:](https://github.com/MarlinFirmware/Marlin/commit/0c9e9964c4b718da76b80f25009287ccbc586005)**
### Description
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Make users enable/disable cold extrusion directly from LCD with #define COLD_EXTRUSION_MENU_ITEM in Configuration.h

### Benefits

<!-- What does this fix or improve? -->
This is a feature that I've actually had a lot of request for, when compiling firmware for friends and colleagues from work.

This feature makes it easy to calibrate e-steps, without connecting printer to a terminal. Specially for bowden-systems, where filament only have to run through extruder, and not near hotend.

This feature is tested and works perfectly with LCD12864.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
Configurations/ code changes are commited to this pull request.

---------------------------------------------------

**[Added feature to EVENT_GCODE_SD_ABORT, if printer is not homed:](https://github.com/MarlinFirmware/Marlin/commit/48d712a5989b479846504cc07517da2ee90ce9ad)**
### Description
<!--

We must be able to understand your proposed change from this description. If we can't understand what the code will do from this description, the Pull Request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code recently, so please walk us through the concepts.

-->
Added EVENT_GCODE_SD_ABORT_NOTHOMED below EVENT_GCODE_SD_ABORT in Configuration_adv.h

This feature runs a separate g-code, if printjob is aborted and stepper position is unknown.

### Benefits

<!-- What does this fix or improve? -->
If a printjob is started, steppers are disabled, the bed is heating and the nozzle for example ends up touching the bed before homing, the standard G28XY would grind the nozzle over the bed.

With this feature enabled, it prevents this scenario by not moving XY steppers, sending only M84.

This feature has been tested running in every scenario with both functions commented out, only one function active at a time and both active at the same time.

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->
Configurations/ code changes are commited to this pull request.

