### PR TITLE
add pio src filter for I2C_AMMETER

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -32,6 +32,7 @@ LIB_INTERNAL_MAX31865                  = src_filter=+<src/libs/MAX31865.cpp>
 NEOPIXEL_LED                           = adafruit/Adafruit NeoPixel@~1.8.0
                                          src_filter=+<src/feature/leds/neopixel.cpp>
 I2C_AMMETER                            = peterus/INA226Lib@1.1.2
+                                         src_filter=+<src/feature/ammeter.cpp>
 USES_LIQUIDCRYSTAL                     = LiquidCrystal=https://github.com/MarlinFirmware/New-LiquidCrystal/archive/1.5.1.zip
 USES_LIQUIDCRYSTAL_I2C                 = marcoschwartz/LiquidCrystal_I2C@1.1.4
 USES_LIQUIDTWI2                        = LiquidTWI2@1.2.7

--- a/platformio.ini
+++ b/platformio.ini
@@ -96,6 +96,7 @@ default_src_filter = +<src/*> -<src/config> -<src/HAL> +<src/HAL/shared>
   -<src/HAL/shared/eeprom_if_i2c.cpp>
   -<src/HAL/shared/eeprom_if_spi.cpp>
   -<src/feature/adc> -<src/gcode/feature/adc>
+  -<src/feature/ammeter.cpp>
   -<src/feature/babystep.cpp>
   -<src/feature/backlash.cpp>
   -<src/feature/baricuda.cpp> -<src/gcode/feature/baricuda>


### PR DESCRIPTION
### Description

add platformio source filter for I2C_AMMETER.

### Requirements

I2C_AMMETER

### Benefits

No longer see src/feature/ammeter.cpp being compiled when it is not been enabled.

### Related Issues
none