### PR TITLE
Add env stm32g0b1re btt xfer

### DIFF
--- a/Marlin/src/inc/SanityCheck.h
+++ b/Marlin/src/inc/SanityCheck.h
@@ -4137,3 +4137,8 @@ static_assert(_PLUS_TEST(4), "HOMING_FEEDRATE_MM_M values must be positive.");
 #elif ENABLED(DISABLE_JTAG) && !defined(JTAG_DISABLE)
   #error "DISABLE_JTAG is not supported for the selected MCU/Board."
 #endif
+
+// Check requirements for upload.py
+#if ENABLED(XFER_BUILD) && !BOTH(BINARY_FILE_TRANSFER, CUSTOM_FIRMWARE_UPLOAD)
+  #error "BINARY_FILE_TRANSFER and CUSTOM_FIRMWARE_UPLOAD are required for custom upload."
+#endif

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -538,7 +538,7 @@
 #elif MB(BTT_SKR_MINI_E3_V2_0)
   #include "stm32f1/pins_BTT_SKR_MINI_E3_V2_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RE_btt env:STM32F103RE_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple env:STM32F103RE_btt_maple env:STM32F103RE_btt_USB_maple
 #elif MB(BTT_SKR_MINI_E3_V3_0)
-  #include "stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h"  // STM32G0                              env:STM32G0B1RE_btt
+  #include "stm32g0/pins_BTT_SKR_MINI_E3_V3_0.h"  // STM32G0                              env:STM32G0B1RE_btt env:STM32G0B1RE_btt_xfer
 #elif MB(BTT_SKR_MINI_MZ_V1_0)
   #include "stm32f1/pins_BTT_SKR_MINI_MZ_V1_0.h"  // STM32F1                              env:STM32F103RC_btt env:STM32F103RC_btt_USB env:STM32F103RC_btt_maple env:STM32F103RC_btt_USB_maple
 #elif MB(BTT_SKR_E3_DIP)

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -138,6 +138,7 @@ upload_protocol             = jlink
 #
 [STM32F103Rx_creality_xfer]
 extends         = STM32F103Rx_creality
+build_flags     = ${STM32F103Rx_creality.build_flags} -DXFER_BUILD
 extra_scripts   = ${STM32F103Rx_creality.extra_scripts}
                   pre:buildroot/share/scripts/upload.py
 upload_protocol = custom

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -42,6 +42,7 @@ debug_tool                  = stlink
 #
 [env:STM32G0B1RE_btt_xfer]
 extends         = env:STM32G0B1RE_btt
+build_flags     = ${env:STM32G0B1RE_btt.build_flags} -DXFER_BUILD
 extra_scripts   = ${env:STM32G0B1RE_btt.extra_scripts}
                   pre:buildroot/share/scripts/upload.py
 upload_protocol = custom

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -41,7 +41,7 @@ debug_tool                  = stlink
 # Custom upload to SD via Marlin with Binary Protocol
 #
 [env:STM32G0B1RE_btt_xfer]
-extends                     = env:STM32G0B1RE_btt
-extra_scripts               = ${env:STM32G0B1RE_btt.extra_scripts}
-                              pre:buildroot/share/scripts/upload.py
-upload_protocol             = custom
+extends         = env:STM32G0B1RE_btt
+extra_scripts   = ${env:STM32G0B1RE_btt.extra_scripts}
+                  pre:buildroot/share/scripts/upload.py
+upload_protocol = custom

--- a/ini/stm32g0.ini
+++ b/ini/stm32g0.ini
@@ -36,3 +36,12 @@ build_flags                 = ${stm32_variant.build_flags}
                             -DSTEP_TIMER_IRQ_PRIO=0
 upload_protocol             = stlink
 debug_tool                  = stlink
+
+#
+# Custom upload to SD via Marlin with Binary Protocol
+#
+[env:STM32G0B1RE_btt_xfer]
+extends                     = env:STM32G0B1RE_btt
+extra_scripts               = ${env:STM32G0B1RE_btt.extra_scripts}
+                              pre:buildroot/share/scripts/upload.py
+upload_protocol             = custom


### PR DESCRIPTION
Add a new env for BTT SKR Mini E3 V3. This new env allows uploading firmware in platformio over usb.

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

Description
I got tired of having to pull out the sd card on my SKR MINI E3 V3 to update the firmware; therefore, I implemented the same feature as the creality_xfer for the BTT SKR MINI E3 V3. This involves adding a new env STM32G0B1RE_btt_xfer.

Requirements
Only useful for the BTT SKR MINI E3 V3 as it is the only board using STM32G0B1RE at this time. Additionally for the feature to work, BINARY_FILE_TRANSFER and CUSTOM_FIRMWARE_UPLOAD must already be enabled. If these features are not enabled, the user would be required to first upload using SD Card.

Benefits
Less removing and replacing of SD Card in hopes to preserve life of the slot

Configurations
It complies and works on my printer. Let me know if you need the configs, but I think this is pretty straight forward.

Related Issues
No