### PR TITLE
disable set_menu_cold_override when no extruders

### DIFF
--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -168,7 +168,9 @@ void MenuEditItemBase::goto_edit_screen(
  */
 void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, const uint8_t top/*=0*/, const uint8_t items/*=0*/) {
   if (currentScreen != screen) {
-    thermalManager.set_menu_cold_override(false);
+    #if E_MANUAL
+      thermalManager.set_menu_cold_override(false);
+    #endif
 
     TERN_(IS_DWIN_MARLINUI, did_first_redraw = false);
 

--- a/Marlin/src/lcd/menu/menu.cpp
+++ b/Marlin/src/lcd/menu/menu.cpp
@@ -168,9 +168,7 @@ void MenuEditItemBase::goto_edit_screen(
  */
 void MarlinUI::goto_screen(screenFunc_t screen, const uint16_t encoder/*=0*/, const uint8_t top/*=0*/, const uint8_t items/*=0*/) {
   if (currentScreen != screen) {
-    #if E_MANUAL
-      thermalManager.set_menu_cold_override(false);
-    #endif
+    thermalManager.set_menu_cold_override(false);
 
     TERN_(IS_DWIN_MARLINUI, did_first_redraw = false);
 

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -166,7 +166,9 @@ void _goto_manual_move(const_float_t scale) {
   ui.defer_status_screen();
   ui.manual_move.menu_scale = scale;
   ui.goto_screen(_manual_move_func_ptr);
-  thermalManager.set_menu_cold_override(true);
+  #if E_MANUAL
+    thermalManager.set_menu_cold_override(true);
+  #endif 
 }
 
 void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int8_t eindex=active_extruder) {

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -35,13 +35,10 @@
 
 #include "../../module/motion.h"
 #include "../../gcode/parser.h" // for inch support
+#include "../../module/temperature.h"
 
 #if ENABLED(DELTA)
   #include "../../module/delta.h"
-#endif
-
-#if ENABLED(PREVENT_COLD_EXTRUSION)
-  #include "../../module/temperature.h"
 #endif
 
 #if HAS_LEVELING
@@ -166,9 +163,7 @@ void _goto_manual_move(const_float_t scale) {
   ui.defer_status_screen();
   ui.manual_move.menu_scale = scale;
   ui.goto_screen(_manual_move_func_ptr);
-  #if E_MANUAL
-    thermalManager.set_menu_cold_override(true);
-  #endif
+  thermalManager.set_menu_cold_override(true);
 }
 
 void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int8_t eindex=active_extruder) {
@@ -224,19 +219,17 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
   }
 
   inline void _menu_move_distance_e_maybe() {
-    #if ENABLED(PREVENT_COLD_EXTRUSION)
-      const bool too_cold = thermalManager.tooColdToExtrude(active_extruder);
-      if (too_cold) {
-        ui.goto_screen([]{
-          MenuItem_confirm::select_screen(
-            GET_TEXT_F(MSG_BUTTON_PROCEED), GET_TEXT_F(MSG_BACK),
-            _goto_menu_move_distance_e, nullptr,
-            GET_TEXT_F(MSG_HOTEND_TOO_COLD), (const char *)nullptr, F("!")
-          );
-        });
-        return;
-      }
-    #endif
+    const bool too_cold = thermalManager.tooColdToExtrude(active_extruder);
+    if (too_cold) {
+      ui.goto_screen([]{
+        MenuItem_confirm::select_screen(
+          GET_TEXT_F(MSG_BUTTON_PROCEED), GET_TEXT_F(MSG_BACK),
+          _goto_menu_move_distance_e, nullptr,
+          GET_TEXT_F(MSG_HOTEND_TOO_COLD), (const char *)nullptr, F("!")
+        );
+      });
+      return;
+    }
     _goto_menu_move_distance_e();
   }
 

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -219,8 +219,7 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
   }
 
   inline void _menu_move_distance_e_maybe() {
-    const bool too_cold = thermalManager.tooColdToExtrude(active_extruder);
-    if (too_cold) {
+    if (thermalManager.tooColdToExtrude(active_extruder)) {
       ui.goto_screen([]{
         MenuItem_confirm::select_screen(
           GET_TEXT_F(MSG_BUTTON_PROCEED), GET_TEXT_F(MSG_BACK),
@@ -228,12 +227,12 @@ void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int
           GET_TEXT_F(MSG_HOTEND_TOO_COLD), (const char *)nullptr, F("!")
         );
       });
-      return;
     }
-    _goto_menu_move_distance_e();
+    else
+      _goto_menu_move_distance_e();
   }
 
-#endif // E_MANUAL
+#endif
 
 void menu_move() {
   START_MENU();

--- a/Marlin/src/lcd/menu/menu_motion.cpp
+++ b/Marlin/src/lcd/menu/menu_motion.cpp
@@ -168,7 +168,7 @@ void _goto_manual_move(const_float_t scale) {
   ui.goto_screen(_manual_move_func_ptr);
   #if E_MANUAL
     thermalManager.set_menu_cold_override(true);
-  #endif 
+  #endif
 }
 
 void _menu_move_distance(const AxisEnum axis, const screenFunc_t func, const int8_t eindex=active_extruder) {


### PR DESCRIPTION
### Description

Update to set_menu_cold_override.
It didn't account for having no extruders and fails to compile when that is the case  

\### Benefits

Now compiles

### Configurations

https://github.com/MarlinFirmware/Marlin/files/8789538/configs_and_Diff_last.zip

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/24254
