### PR TITLE
Update pins_TENLOG_D3_HERO.h

### DIFF
--- a/Marlin/src/pins/ramps/pins_TENLOG_D3_HERO.h
+++ b/Marlin/src/pins/ramps/pins_TENLOG_D3_HERO.h
@@ -35,8 +35,6 @@
 #define BOARD_INFO_NAME      "Tenlog D3 Hero"
 #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
 
-//#define PS_ON_PIN          40 // Pin 40 is the power supply unit pin for M81 gcode command if your tenlog v2.1, v2.2 or v2.3 mainboard supports it. 
-
 //
 // Servos
 //
@@ -150,6 +148,7 @@
 //
 // Misc. Functions
 //
+//#define PS_ON_PIN                           40  // The M80/M81 PSU pin for boards v2.1-2.3
 //#define CASE_LIGHT_PIN                       5
 #define SDSS                                  53
 //#ifndef LED_PIN

--- a/Marlin/src/pins/ramps/pins_TENLOG_D3_HERO.h
+++ b/Marlin/src/pins/ramps/pins_TENLOG_D3_HERO.h
@@ -35,6 +35,8 @@
 #define BOARD_INFO_NAME      "Tenlog D3 Hero"
 #define DEFAULT_MACHINE_NAME BOARD_INFO_NAME
 
+//#define PS_ON_PIN          40 // Pin 40 is the power supply unit pin for M81 gcode command if your tenlog v2.1, v2.2 or v2.3 mainboard supports it. 
+
 //
 // Servos
 //


### PR DESCRIPTION
`#define PS_ON_PIN          40`




### Description

Pin 40 is the power supply unit pin for M81 gcode command if your tenlog v2.1, v2.2 or v2.3 mainboard supports it. 
Some tenlog boards will auto power off on startup if the pin is not defined. When you flip the power switch, the printer powers up for a moment and then powers off.
I reccomend this change should be commented out by default as I'm not sure it is applicable for all tenlog boards.


### Requirements

I have needed this pin defined on my "Tenlog 3D MB1" [v2.1, v2.2, and v2.3] or my printer will not stay powered on.
I have a P600W24V (Input: 115/230 VAC 50/60 Hz. Output: 24VDC 25A Max) PSU with a Power Loss Recovery (PLR) board.
This all came stock on my Hictop 3D Hero (which is an offical clone of the Tenlog TL-D3 pro).

### Benefits

printer won't stay powered on without this change

### Configurations

### Related Issues
