### PR TITLE
setup SPI to stepper drivers before PSU_CONTROL

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1241,6 +1241,17 @@ void setup() {
     SETUP_RUN(tmc_serial_begin());
   #endif
 
+  #if HAS_TMC_SPI
+    #if DISABLED(TMC_USE_SW_SPI)
+      SETUP_RUN(SPI.begin());
+    #endif
+    SETUP_RUN(tmc_init_cs_pins());
+  #endif
+
+  #if HAS_L64XX
+    SETUP_RUN(L64xxManager.init());  // Set up SPI, init drivers
+  #endif
+
   #if ENABLED(PSU_CONTROL)
     SETUP_LOG("PSU_CONTROL");
     powerManager.init();
@@ -1250,19 +1261,8 @@ void setup() {
     SETUP_RUN(recovery.setup());
   #endif
 
-  #if HAS_L64XX
-    SETUP_RUN(L64xxManager.init());  // Set up SPI, init drivers
-  #endif
-
   #if HAS_STEPPER_RESET
     SETUP_RUN(disableStepperDrivers());
-  #endif
-
-  #if HAS_TMC_SPI
-    #if DISABLED(TMC_USE_SW_SPI)
-      SETUP_RUN(SPI.begin());
-    #endif
-    SETUP_RUN(tmc_init_cs_pins());
   #endif
 
   SETUP_RUN(hal.init_board());


### PR DESCRIPTION
### Description

It was noted that enabling PSU_CONTROL with TMC2130 (or other stepper drivers with SPI)  would lock up marlin during boot. 
This was traced to an initialization sequence issue 

In MarlinCore.cpp

PSU_CONTROL  calls powerManager.init();
powerManager.init(); can call power_on()  (depending on PSU_DEFAULT_OFF) 
power_on() calls restore_stepper_drivers() 
restore_stepper_drivers()  talks to the stepper drivers over UART or SPI  

But if SPI is needed marlin locks up as SPI has yet to be initialized

This PR reorders the start up so SPI to stepper drivers is initialized before PSU_CONTROL is set up.

### Requirements

PSU_CONTROL and HAS_TMC_SPI or HAS_L64XX with PSU_DEFAULT_OFF disabled. 

### Benefits

Works as expected

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/24263