### PR TITLE
JyersUI add support for CUSTOM_MENU_CONFIG

### DIFF
--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -3211,28 +3211,6 @@
 #endif
 
 /**
- * Custom menu items with jyersLCD
- */
-#if ANY(HAS_MARLINUI_MENU, EXTENSIBLE_UI, DWIN_CREALITY_LCD_ENHANCED, DWIN_CREALITY_LCD_JYERSUI)
-  #if ENABLED(CUSTOM_MENU_CONFIG)
-    #ifdef CONFIG_MENU_ITEM_5_DESC
-      #define CUSTOM_MENU_COUNT 5
-    #elif defined(CONFIG_MENU_ITEM_4_DESC)
-      #define CUSTOM_MENU_COUNT 4
-    #elif defined(CONFIG_MENU_ITEM_3_DESC)
-      #define CUSTOM_MENU_COUNT 3
-    #elif defined(CONFIG_MENU_ITEM_2_DESC)
-      #define CUSTOM_MENU_COUNT 2
-    #elif defined(CONFIG_MENU_ITEM_1_DESC)
-      #define CUSTOM_MENU_COUNT 1
-    #endif
-  #endif
-  #if CUSTOM_MENU_COUNT && ENABLED(CUSTOM_MENU_CONFIG)
-    #define HAS_CUSTOM_MENU 1
-  #endif
-#endif
-
-/**
  * Helper Macros for heaters and extruder fan
  */
 

--- a/Marlin/src/inc/Conditionals_post.h
+++ b/Marlin/src/inc/Conditionals_post.h
@@ -3211,6 +3211,28 @@
 #endif
 
 /**
+ * Custom menu items with jyersLCD
+ */
+#if ANY(HAS_MARLINUI_MENU, EXTENSIBLE_UI, DWIN_CREALITY_LCD_ENHANCED, DWIN_CREALITY_LCD_JYERSUI)
+  #if ENABLED(CUSTOM_MENU_CONFIG)
+    #ifdef CONFIG_MENU_ITEM_5_DESC
+      #define CUSTOM_MENU_COUNT 5
+    #elif defined(CONFIG_MENU_ITEM_4_DESC)
+      #define CUSTOM_MENU_COUNT 4
+    #elif defined(CONFIG_MENU_ITEM_3_DESC)
+      #define CUSTOM_MENU_COUNT 3
+    #elif defined(CONFIG_MENU_ITEM_2_DESC)
+      #define CUSTOM_MENU_COUNT 2
+    #elif defined(CONFIG_MENU_ITEM_1_DESC)
+      #define CUSTOM_MENU_COUNT 1
+    #endif
+  #endif
+  #if CUSTOM_MENU_COUNT && ENABLED(CUSTOM_MENU_CONFIG)
+    #define HAS_CUSTOM_MENU 1
+  #endif
+#endif
+
+/**
  * Helper Macros for heaters and extruder fan
  */
 

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -121,6 +121,26 @@
   #define MIN_BED_TEMP  0
 #endif
 
+/**
+ * Custom menu items with jyersLCD
+ */
+#if ENABLED(CUSTOM_MENU_CONFIG)
+  #ifdef CONFIG_MENU_ITEM_5_DESC
+    #define CUSTOM_MENU_COUNT 5
+  #elif defined(CONFIG_MENU_ITEM_4_DESC)
+    #define CUSTOM_MENU_COUNT 4
+  #elif defined(CONFIG_MENU_ITEM_3_DESC)
+    #define CUSTOM_MENU_COUNT 3
+  #elif defined(CONFIG_MENU_ITEM_2_DESC)
+    #define CUSTOM_MENU_COUNT 2
+  #elif defined(CONFIG_MENU_ITEM_1_DESC)
+    #define CUSTOM_MENU_COUNT 1
+  #endif
+  #if CUSTOM_MENU_COUNT
+    #define HAS_CUSTOM_MENU 1
+  #endif
+#endif
+
 constexpr uint16_t TROWS = 6, MROWS = TROWS - 1,
                    TITLE_HEIGHT = 30,
                    MLINE = 53,
@@ -1156,16 +1176,13 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
 
         #if HAS_CUSTOM_MENU
           case PREPARE_CUSTOM_MENU:
-            if (draw) {
-                #ifdef CUSTOM_MENU_CONFIG_TITLE
-                  Draw_Menu_Item(row, ICON_Version, F(CUSTOM_MENU_CONFIG_TITLE), nullptr, true);
-                #else
-                  Draw_Menu_Item(row, ICON_Version, F("Custom Commands"), nullptr, true);
-                #endif
-              }
-            else {
-                Draw_Menu(MenuCustom);
-              }
+            #ifndef CUSTOM_MENU_CONFIG_TITLE
+              #define CUSTOM_MENU_CONFIG_TITLE "Custom Commands"
+            #endif
+            if (draw)
+              Draw_Menu_Item(row, ICON_Version, F(CUSTOM_MENU_CONFIG_TITLE));
+            else
+              Draw_Menu(MenuCustom);
             break;
         #endif
 
@@ -1767,15 +1784,16 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
     #endif // FILAMENT_LOAD_UNLOAD_GCODES
 
     #if HAS_CUSTOM_MENU
+
       case MenuCustom:
 
         #define CUSTOM_MENU_BACK 0
-        #define CUSTOM_MENU_1 (CUSTOM_MENU_BACK + (CUSTOM_MENU_COUNT >= 1))
-        #define CUSTOM_MENU_2 (CUSTOM_MENU_1 + (CUSTOM_MENU_COUNT >= 2))
-        #define CUSTOM_MENU_3 (CUSTOM_MENU_2 + (CUSTOM_MENU_COUNT >= 3))
-        #define CUSTOM_MENU_4 (CUSTOM_MENU_3 + (CUSTOM_MENU_COUNT >= 4))
-        #define CUSTOM_MENU_5 (CUSTOM_MENU_4 + (CUSTOM_MENU_COUNT >= 5))
-        #define CUSTOM_MENU_TOTAL CUSTOM_MENU_5
+        #define CUSTOM_MENU_1 1
+        #define CUSTOM_MENU_2 2
+        #define CUSTOM_MENU_3 3
+        #define CUSTOM_MENU_4 4
+        #define CUSTOM_MENU_5 5
+        #define CUSTOM_MENU_TOTAL CUSTOM_MENU_COUNT
 
         switch (item) {
           case CUSTOM_MENU_BACK:
@@ -1790,17 +1808,17 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               if (draw)
                 Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_1_DESC));
               else {
-                 Popup_Handler(Custom);
-                 //queue.inject(F(CONFIG_MENU_ITEM_1_GCODE)); // Old code
-                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_1_GCODE));
-                 planner.synchronize();
-                 Redraw_Menu();
-                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
-                        AudioFeedback();
-                    #endif
-                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
-                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
-                    #endif
+                Popup_Handler(Custom);
+                //queue.inject(F(CONFIG_MENU_ITEM_1_GCODE)); // Old code
+                gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_1_GCODE));
+                planner.synchronize();
+                Redraw_Menu();
+                #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                  AudioFeedback();
+                #endif
+                #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                  queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                #endif
               }
               break;
           #endif
@@ -1810,16 +1828,16 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               if (draw)
                 Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_2_DESC));
               else {
-                 Popup_Handler(Custom);
-                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_2_GCODE));
-                 planner.synchronize();
-                 Redraw_Menu();
-                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
-                        AudioFeedback();
-                    #endif
-                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
-                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
-                    #endif
+                Popup_Handler(Custom);
+                gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_2_GCODE));
+                planner.synchronize();
+                Redraw_Menu();
+                #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                  AudioFeedback();
+                #endif
+                #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                  queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                #endif
               }
               break;
           #endif
@@ -1829,16 +1847,16 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               if (draw)
                 Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_3_DESC));
               else {
-                 Popup_Handler(Custom);
-                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_3_GCODE));
-                 planner.synchronize();
-                 Redraw_Menu();
-                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
-                        AudioFeedback();
-                    #endif
-                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
-                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
-                    #endif
+                Popup_Handler(Custom);
+                gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_3_GCODE));
+                planner.synchronize();
+                Redraw_Menu();
+                #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                  AudioFeedback();
+                #endif
+                #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                  queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                #endif
               }
               break;
           #endif
@@ -1848,16 +1866,16 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               if (draw)
                 Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_4_DESC));
               else {
-                 Popup_Handler(Custom);
-                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_4_GCODE));
-                 planner.synchronize();
-                 Redraw_Menu();
-                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
-                        AudioFeedback();
-                    #endif
-                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
-                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
-                    #endif
+                Popup_Handler(Custom);
+                gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_4_GCODE));
+                planner.synchronize();
+                Redraw_Menu();
+                #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                  AudioFeedback();
+                #endif
+                #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                  queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                #endif
               }
               break;
           #endif
@@ -1867,22 +1885,23 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               if (draw)
                 Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_5_DESC));
               else {
-                 Popup_Handler(Custom);
-                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_5_GCODE));
-                 planner.synchronize();
-                 Redraw_Menu();
-                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
-                        AudioFeedback();
-                    #endif
-                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
-                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
-                    #endif
+                Popup_Handler(Custom);
+                gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_5_GCODE));
+                planner.synchronize();
+                Redraw_Menu();
+                #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                  AudioFeedback();
+                #endif
+                #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                  queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                #endif
               }
               break;
           #endif // Custom Menu
         }
         break;
-    #endif
+
+    #endif // HAS_CUSTOM_MENU
 
     case Control:
 
@@ -3823,12 +3842,12 @@ FSTR_P CrealityDWINClass::Get_Menu_Title(uint8_t menu) {
       case ChangeFilament:  return F("Change Filament");
     #endif
     #if HAS_CUSTOM_MENU
-    case MenuCustom:
-      #ifdef CUSTOM_MENU_CONFIG_TITLE
-        return F(CUSTOM_MENU_CONFIG_TITLE);
-      #else
-        return F("Custom Commands");
-      #endif
+      case MenuCustom:
+        #ifdef CUSTOM_MENU_CONFIG_TITLE
+          return F(CUSTOM_MENU_CONFIG_TITLE);
+        #else
+          return F("Custom Commands");
+        #endif
     #endif
     case Control:           return F("Control");
     case TempMenu:          return F("Temperature");
@@ -3896,7 +3915,7 @@ uint8_t CrealityDWINClass::Get_Menu_Size(uint8_t menu) {
       case ChangeFilament:  return CHANGEFIL_TOTAL;
     #endif
     #if HAS_CUSTOM_MENU
-    case MenuCustom:       return CUSTOM_MENU_TOTAL;
+      case MenuCustom:      return CUSTOM_MENU_TOTAL;
     #endif
     case Control:           return CONTROL_TOTAL;
     case TempMenu:          return TEMP_TOTAL;

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.cpp
@@ -1078,7 +1078,8 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
       #define PREPARE_PREHEAT (PREPARE_ZOFFSET + ENABLED(HAS_PREHEAT))
       #define PREPARE_COOLDOWN (PREPARE_PREHEAT + EITHER(HAS_HOTEND, HAS_HEATED_BED))
       #define PREPARE_CHANGEFIL (PREPARE_COOLDOWN + ENABLED(ADVANCED_PAUSE_FEATURE))
-      #define PREPARE_TOTAL PREPARE_CHANGEFIL
+      #define PREPARE_CUSTOM_MENU (PREPARE_CHANGEFIL + ENABLED(HAS_CUSTOM_MENU))
+      #define PREPARE_TOTAL PREPARE_CUSTOM_MENU
 
       switch (item) {
         case PREPARE_BACK:
@@ -1150,6 +1151,21 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
               Draw_Menu_Item(row, ICON_Cool, F("Cooldown"));
             else
               thermalManager.cooldown();
+            break;
+        #endif
+
+        #if HAS_CUSTOM_MENU
+          case PREPARE_CUSTOM_MENU:
+            if (draw) {
+                #ifdef CUSTOM_MENU_CONFIG_TITLE
+                  Draw_Menu_Item(row, ICON_Version, F(CUSTOM_MENU_CONFIG_TITLE), nullptr, true);
+                #else
+                  Draw_Menu_Item(row, ICON_Version, F("Custom Commands"), nullptr, true);
+                #endif
+              }
+            else {
+                Draw_Menu(MenuCustom);
+              }
             break;
         #endif
 
@@ -1749,6 +1765,124 @@ void CrealityDWINClass::Menu_Item_Handler(uint8_t menu, uint8_t item, bool draw/
         }
         break;
     #endif // FILAMENT_LOAD_UNLOAD_GCODES
+
+    #if HAS_CUSTOM_MENU
+      case MenuCustom:
+
+        #define CUSTOM_MENU_BACK 0
+        #define CUSTOM_MENU_1 (CUSTOM_MENU_BACK + (CUSTOM_MENU_COUNT >= 1))
+        #define CUSTOM_MENU_2 (CUSTOM_MENU_1 + (CUSTOM_MENU_COUNT >= 2))
+        #define CUSTOM_MENU_3 (CUSTOM_MENU_2 + (CUSTOM_MENU_COUNT >= 3))
+        #define CUSTOM_MENU_4 (CUSTOM_MENU_3 + (CUSTOM_MENU_COUNT >= 4))
+        #define CUSTOM_MENU_5 (CUSTOM_MENU_4 + (CUSTOM_MENU_COUNT >= 5))
+        #define CUSTOM_MENU_TOTAL CUSTOM_MENU_5
+
+        switch (item) {
+          case CUSTOM_MENU_BACK:
+            if (draw)
+              Draw_Menu_Item(row, ICON_Back, F("Back"));
+            else
+              Draw_Menu(Prepare, PREPARE_CUSTOM_MENU);
+            break;
+
+          #if CUSTOM_MENU_COUNT >= 1
+            case CUSTOM_MENU_1:
+              if (draw)
+                Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_1_DESC));
+              else {
+                 Popup_Handler(Custom);
+                 //queue.inject(F(CONFIG_MENU_ITEM_1_GCODE)); // Old code
+                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_1_GCODE));
+                 planner.synchronize();
+                 Redraw_Menu();
+                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                        AudioFeedback();
+                    #endif
+                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                    #endif
+              }
+              break;
+          #endif
+
+          #if CUSTOM_MENU_COUNT >= 2
+            case CUSTOM_MENU_2:
+              if (draw)
+                Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_2_DESC));
+              else {
+                 Popup_Handler(Custom);
+                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_2_GCODE));
+                 planner.synchronize();
+                 Redraw_Menu();
+                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                        AudioFeedback();
+                    #endif
+                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                    #endif
+              }
+              break;
+          #endif
+
+          #if CUSTOM_MENU_COUNT >= 3
+            case CUSTOM_MENU_3:
+              if (draw)
+                Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_3_DESC));
+              else {
+                 Popup_Handler(Custom);
+                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_3_GCODE));
+                 planner.synchronize();
+                 Redraw_Menu();
+                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                        AudioFeedback();
+                    #endif
+                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                    #endif
+              }
+              break;
+          #endif
+
+          #if CUSTOM_MENU_COUNT >= 4
+            case CUSTOM_MENU_4:
+              if (draw)
+                Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_4_DESC));
+              else {
+                 Popup_Handler(Custom);
+                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_4_GCODE));
+                 planner.synchronize();
+                 Redraw_Menu();
+                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                        AudioFeedback();
+                    #endif
+                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                    #endif
+              }
+              break;
+          #endif
+
+          #if CUSTOM_MENU_COUNT >= 5
+            case CUSTOM_MENU_5:
+              if (draw)
+                Draw_Menu_Item(row, ICON_Info, F(CONFIG_MENU_ITEM_5_DESC));
+              else {
+                 Popup_Handler(Custom);
+                 gcode.process_subcommands_now(F(CONFIG_MENU_ITEM_5_GCODE));
+                 planner.synchronize();
+                 Redraw_Menu();
+                    #if ENABLED(CUSTOM_MENU_CONFIG_SCRIPT_AUDIBLE_FEEDBACK)
+                        AudioFeedback();
+                    #endif
+                    #ifdef CUSTOM_MENU_CONFIG_SCRIPT_RETURN
+                        queue.inject(F(CUSTOM_MENU_CONFIG_SCRIPT_DONE));
+                    #endif
+              }
+              break;
+          #endif // Custom Menu
+        }
+        break;
+    #endif
 
     case Control:
 
@@ -3688,6 +3822,14 @@ FSTR_P CrealityDWINClass::Get_Menu_Title(uint8_t menu) {
     #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
       case ChangeFilament:  return F("Change Filament");
     #endif
+    #if HAS_CUSTOM_MENU
+    case MenuCustom:
+      #ifdef CUSTOM_MENU_CONFIG_TITLE
+        return F(CUSTOM_MENU_CONFIG_TITLE);
+      #else
+        return F("Custom Commands");
+      #endif
+    #endif
     case Control:           return F("Control");
     case TempMenu:          return F("Temperature");
     #if HAS_HOTEND || HAS_HEATED_BED
@@ -3752,6 +3894,9 @@ uint8_t CrealityDWINClass::Get_Menu_Size(uint8_t menu) {
     #endif
     #if ENABLED(FILAMENT_LOAD_UNLOAD_GCODES)
       case ChangeFilament:  return CHANGEFIL_TOTAL;
+    #endif
+    #if HAS_CUSTOM_MENU
+    case MenuCustom:       return CUSTOM_MENU_TOTAL;
     #endif
     case Control:           return CONTROL_TOTAL;
     case TempMenu:          return TEMP_TOTAL;
@@ -3831,6 +3976,7 @@ void CrealityDWINClass::Popup_Handler(PopupID popupid, bool option/*=false*/) {
     case Runout:        Draw_Popup(F("Filament Runout"), F(""), F(""), Wait, ICON_BLTouch); break;
     case PIDWait:       Draw_Popup(F("PID Autotune"), F("in process"), F("Please wait until done."), Wait, ICON_BLTouch); break;
     case Resuming:      Draw_Popup(F("Resuming Print"), F("Please wait until done."), F(""), Wait, ICON_BLTouch); break;
+    case Custom:        Draw_Popup(F("Running Custom GCode"), F("Please wait until done."), F(""), Wait, ICON_BLTouch); break;
     default: break;
   }
 }

--- a/Marlin/src/lcd/e3v2/jyersui/dwin.h
+++ b/Marlin/src/lcd/e3v2/jyersui/dwin.h
@@ -43,7 +43,7 @@ enum processID : uint8_t {
 enum PopupID : uint8_t {
   Pause, Stop, Resume, SaveLevel, ETemp, ConfFilChange, PurgeMore, MeshSlot,
   Level, Home, MoveWait, Heating,  FilLoad, FilChange, TempWarn, Runout, PIDWait, Resuming, ManualProbing,
-  FilInsert, HeaterTime, UserInput, LevelError, InvalidMesh, UI, Complete
+  FilInsert, HeaterTime, UserInput, LevelError, InvalidMesh, UI, Complete, Custom
 };
 
 enum menuID : uint8_t {
@@ -55,6 +55,7 @@ enum menuID : uint8_t {
       ZOffset,
       Preheat,
       ChangeFilament,
+      MenuCustom,
     Control,
       TempMenu,
         PID,


### PR DESCRIPTION
<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

Add basic support for CUSTOM_MENU_CONFIG to JyersUI. I sometimes use custom GCode commands like G26 or G34 and the current JyersUI in bugfix doesn't have support for a terminal or manual GCode entry. 

If the Gcode locks the queue like using G34 or G26, a popup will show until the process is complete. Otherwise, it'll just show a quick flash of the popup before disappearing.

Works with:
`#define CUSTOM_MENU_CONFIG_TITLE`
`#define CONFIG_MENU_ITEM_[x]_DESC`
`#define CONFIG_MENU_ITEM_[x]_GCODE`

Haven't tested with:
`#define CUSTOM_MENU_CONFIG_SCRIPT_DONE`
`#define CUSTOM_MENU_CONFIG_SCRIPT_RETURN`
`#define CONFIG_MENU_ITEM_[x]_CONFIRM`

Based on code provided by [tititopher68-dev](https://github.com/tititopher68-dev) @ https://github.com/Jyers/Marlin/discussions/1646

### Requirements

Tested with a BTT SKR Mini E3 V2.0 + Voxelab DWIN display but should work with any of the Creality V2 setups using a DWIN display + JyersUI.

### Benefits

Gives users who compile their own firmware the ability to use CUSTOM_MENU_CONFIG on JyersUI.

### Limitations

`#define CONFIG_MENU_ITEM_[x]_DESC` should not exceed 20 characters