### PR TITLE
Fix SDIO Init bootloop on STM32F1

### DIFF
--- a/Marlin/src/HAL/STM32/sdio.cpp
+++ b/Marlin/src/HAL/STM32/sdio.cpp
@@ -200,7 +200,8 @@ static uint32_t clock_to_divider(uint32_t clk) {
 
 bool SDIO_Init() {
   HAL_StatusTypeDef sd_state = HAL_OK;
-  HAL_SD_DeInit(&hsd);
+  if (hsd.Instance == SDIO)
+    HAL_SD_DeInit(&hsd);
 
   /* HAL SD initialization */
   hsd.Instance = SDIO;


### PR DESCRIPTION
Fixes issue #24273 on the Longer3D LK board STM32F103VE