### PR TITLE
Fix compile error with ProUI

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
+++ b/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
@@ -238,7 +238,6 @@ void Preview_DrawFromSD() {
   }
   else {
     HMI_flag.select_flag = 1;
-    wait_for_user = false;
   }
 }
 

--- a/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
+++ b/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
@@ -49,6 +49,7 @@
 #include "../../../core/types.h"
 #include "../../marlinui.h"
 #include "../../../sd/cardreader.h"
+#include "../../../MarlinCore.h" // for wait_for_user
 #include "dwin_lcd.h"
 #include "dwinui.h"
 #include "dwin.h"
@@ -238,6 +239,7 @@ void Preview_DrawFromSD() {
   }
   else {
     HMI_flag.select_flag = 1;
+    wait_for_user = false;
   }
 }
 


### PR DESCRIPTION
Error fixed is:

```
Marlin/src/lcd/e3v2/proui/gcode_preview.cpp: In function 'void Preview_DrawFromSD()':
Marlin/src/lcd/e3v2/proui/gcode_preview.cpp:241:5: error: 'wait_for_user' was not declared in this scope
  241 |     wait_for_user = false;
      |     ^~~~~~~~~~~~~
```