### PR TITLE
filter PROUI gcode preview on arduino ide

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
+++ b/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp
@@ -42,6 +42,9 @@
  * For commercial applications additional licenses can be requested
  */
 
+#include "../../../inc/MarlinConfigPre.h"
+#if ENABLED(DWIN_LCD_PROUI)
+
 #include "dwin_defines.h"
 
 #if HAS_GCODE_PREVIEW
@@ -251,3 +254,4 @@ void Preview_Reset() {
 }
 
 #endif // HAS_GCODE_PREVIEW
+#endif // DWIN_LCD_PROUI


### PR DESCRIPTION
### Description

Marlin/src/lcd/e3v2/proui/gcode_preview.cpp breaks compiling on Arduino IDE

The file is not filtered out when not in use and leads to many errors that PROUI requires features enabled. When PROUI is not enabled.

```
In file included from /home/kappa95/Scaricati/Marlin-2.0.x-PULSAR/Marlin/src/lcd/e3v2/proui/gcode_preview.cpp:45:0:
/home/kappa95/Scaricati/Marlin-2.0.x-PULSAR/Marlin/src/lcd/e3v2/proui/dwin_defines.h:45:4: error: #error "LIMITED_MAX_FR_EDITING is required with ProUI."
   #error "LIMITED_MAX_FR_EDITING is required with ProUI."
    ^~~~~
/home/kappa95/Scaricati/Marlin-2.0.x-PULSAR/Marlin/src/lcd/e3v2/proui/dwin_defines.h:48:4: error: #error "LIMITED_MAX_ACCEL_EDITING is required with ProUI."
   #error "LIMITED_MAX_ACCEL_EDITING is required with ProUI."
    ^~~~~
/home/kappa95/Scaricati/Marlin-2.0.x-PULSAR/Marlin/src/lcd/e3v2/proui/dwin_defines.h:54:4: error: #error "FILAMENT_RUNOUT_SENSOR is required with ProUI."
   #error "FILAMENT_RUNOUT_SENSOR is required with ProUI."
    ^~~~~
```

### Requirements

Arduino IDE

### Benefits

Marlin compiles on Arduino IDE again

### Related Issues
https://reprap.org/forum/read.php?415,889627,889627#msg-889627
