### PR TITLE
Archim2 USB Hang Fix

### DIFF
--- a/Marlin/Configuration_adv.h
+++ b/Marlin/Configuration_adv.h
@@ -1585,6 +1585,8 @@
     //#define USE_UHS2_USB
     //#define USE_UHS3_USB
 
+    #define DISABLE_DUE_SD_MMC // Disable USB Host access to USB Drive to prevent hangs on block access for DUE platform
+
     /**
      * Native USB Host supported by some boards (USB OTG)
      */

--- a/Marlin/src/pins/sam/pins_ARCHIM2.h
+++ b/Marlin/src/pins/sam/pins_ARCHIM2.h
@@ -237,7 +237,7 @@
 //
 // LCD / Controller
 //
-#if ANY(HAS_WIRED_LCD, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE)
+#if ANY(HAS_WIRED_LCD, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE, USB_FLASH_DRIVE_SUPPORT)
   #define BEEPER_PIN                          23  // D24 PA15_CTS1
   #define LCD_PINS_RS                         17  // D17 PA12_RXD1
   #define LCD_PINS_ENABLE                     24  // D23 PA14_RTS1
@@ -249,9 +249,13 @@
   #define SD_DETECT_PIN                        2  // D2  PB25_TIOA0
 #endif
 
-#if ANY(IS_ULTIPANEL, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE)
+#if ANY(IS_ULTIPANEL, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE, USB_FLASH_DRIVE_SUPPORT)
   // Buttons on AUX-2
   #define BTN_EN1                             60  // D60 PA3_TIOB1
   #define BTN_EN2                             13  // D13 PB27_TIOB0
   #define BTN_ENC                             16  // D16 PA13_TXD1 // the click
+#endif
+
+#if ENABLED(USB_FLASH_DRIVE_SUPPORT)
+  #define DISABLE_DUE_SD_MMC
 #endif

--- a/Marlin/src/pins/sam/pins_ARCHIM2.h
+++ b/Marlin/src/pins/sam/pins_ARCHIM2.h
@@ -237,7 +237,7 @@
 //
 // LCD / Controller
 //
-#if ANY(HAS_WIRED_LCD, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE, USB_FLASH_DRIVE_SUPPORT)
+#if ANY(HAS_WIRED_LCD, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE)
   #define BEEPER_PIN                          23  // D24 PA15_CTS1
   #define LCD_PINS_RS                         17  // D17 PA12_RXD1
   #define LCD_PINS_ENABLE                     24  // D23 PA14_RTS1
@@ -245,17 +245,18 @@
   #define LCD_PINS_D5                         54  // D54 PA16_SCK1
   #define LCD_PINS_D6                         68  // D68 PA1_CANRX0
   #define LCD_PINS_D7                         34  // D34 PC2_PWML0
-
-  #define SD_DETECT_PIN                        2  // D2  PB25_TIOA0
 #endif
 
-#if ANY(IS_ULTIPANEL, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE, USB_FLASH_DRIVE_SUPPORT)
+#if ANY(IS_ULTIPANEL, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE)
   // Buttons on AUX-2
   #define BTN_EN1                             60  // D60 PA3_TIOB1
   #define BTN_EN2                             13  // D13 PB27_TIOB0
   #define BTN_ENC                             16  // D16 PA13_TXD1 // the click
 #endif
 
-#if ENABLED(USB_FLASH_DRIVE_SUPPORT)
-  #define DISABLE_DUE_SD_MMC
+#if ANY(HAS_WIRED_LCD, TOUCH_UI_ULTIPANEL, TOUCH_UI_FTDI_EVE, USB_FLASH_DRIVE_SUPPORT)
+  #define SD_DETECT_PIN                        2  // D2  PB25_TIOA0
+  #if ENABLED(USB_FLASH_DRIVE_SUPPORT)
+    #define DISABLE_DUE_SD_MMC
+  #endif
 #endif

--- a/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
+++ b/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
@@ -159,18 +159,18 @@ void DiskIODriver_USBFlash::idle() {
       static uint8_t laststate = 232;
       if (task_state != laststate) {
         laststate = task_state;
-        #define UHS_USB_DEBUG(x) case UHS_STATE(x): SERIAL_ECHOLNPGM(#x); break
+        #define UHS_USB_DEBUG(x,y) case UHS_STATE(x): SERIAL_ECHOLNPGM(y); break
         switch (task_state) {
-          SERIAL_ECHOLNPGM("IDLE");
-          SERIAL_ECHOLNPGM("RESET_DEVICE");
-          SERIAL_ECHOLNPGM("RESET_NOT_COMPLETE");
-          SERIAL_ECHOLNPGM("DEBOUNCE");
-          SERIAL_ECHOLNPGM("DEBOUNCE_NOT_COMPLETE");
-          SERIAL_ECHOLNPGM("WAIT_SOF");
-          SERIAL_ECHOLNPGM("ERROR");
-          SERIAL_ECHOLNPGM("CONFIGURING");
-          SERIAL_ECHOLNPGM("CONFIGURING_DONE");
-          SERIAL_ECHOLNPGM("RUNNING");
+          UHS_USB_DEBUG(IDLE, "IDLE");
+          UHS_USB_DEBUG(RESET_DEVICE, "RESET_DEVICE");
+          UHS_USB_DEBUG(RESET_NOT_COMPLETE, "RESET_NOT_COMPLETE");
+          UHS_USB_DEBUG(DEBOUNCE, "DEBOUNCE");
+          UHS_USB_DEBUG(DEBOUNCE_NOT_COMPLETE, "DEBOUNCE_NOT_COMPLETE");
+          UHS_USB_DEBUG(WAIT_SOF, "WAIT_SOF");
+          UHS_USB_DEBUG(ERROR, "ERROR");
+          UHS_USB_DEBUG(CONFIGURING, "CONFIGURING");
+          UHS_USB_DEBUG(CONFIGURING_DONE, "CONFIGURING_DONE");
+          UHS_USB_DEBUG(RUNNING, "RUNNING");
           default:
             SERIAL_ECHOLNPGM("UHS_USB_HOST_STATE: ", task_state);
             break;

--- a/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
+++ b/Marlin/src/sd/usb_flashdrive/Sd2Card_FlashDrive.cpp
@@ -161,16 +161,16 @@ void DiskIODriver_USBFlash::idle() {
         laststate = task_state;
         #define UHS_USB_DEBUG(x) case UHS_STATE(x): SERIAL_ECHOLNPGM(#x); break
         switch (task_state) {
-          UHS_USB_DEBUG(IDLE);
-          UHS_USB_DEBUG(RESET_DEVICE);
-          UHS_USB_DEBUG(RESET_NOT_COMPLETE);
-          UHS_USB_DEBUG(DEBOUNCE);
-          UHS_USB_DEBUG(DEBOUNCE_NOT_COMPLETE);
-          UHS_USB_DEBUG(WAIT_SOF);
-          UHS_USB_DEBUG(ERROR);
-          UHS_USB_DEBUG(CONFIGURING);
-          UHS_USB_DEBUG(CONFIGURING_DONE);
-          UHS_USB_DEBUG(RUNNING);
+          SERIAL_ECHOLNPGM("IDLE");
+          SERIAL_ECHOLNPGM("RESET_DEVICE");
+          SERIAL_ECHOLNPGM("RESET_NOT_COMPLETE");
+          SERIAL_ECHOLNPGM("DEBOUNCE");
+          SERIAL_ECHOLNPGM("DEBOUNCE_NOT_COMPLETE");
+          SERIAL_ECHOLNPGM("WAIT_SOF");
+          SERIAL_ECHOLNPGM("ERROR");
+          SERIAL_ECHOLNPGM("CONFIGURING");
+          SERIAL_ECHOLNPGM("CONFIGURING_DONE");
+          SERIAL_ECHOLNPGM("RUNNING");
           default:
             SERIAL_ECHOLNPGM("UHS_USB_HOST_STATE: ", task_state);
             break;


### PR DESCRIPTION
Archim2 Board fixes : S
Set pins needed for USB host based on the USB feature, not just the display.
Fix output error in USB host debug
Expose option to disable USB drive exposure to PC host, as shared resource hung the main loop.