### PR TITLE
Add K flag to M150 to allow partial updating of neopixel colors

### DIFF
--- a/Marlin/src/feature/leds/neopixel.h
+++ b/Marlin/src/feature/leds/neopixel.h
@@ -131,6 +131,15 @@ public:
   // Accessors
   static uint16_t pixels() { return adaneo1.numPixels() * TERN1(NEOPIXEL2_INSERIES, 2); }
 
+  static uint32_t pixel_color(const uint16_t n) {
+    #if ENABLED(NEOPIXEL2_INSERIES)
+      if (n >= NEOPIXEL_PIXELS) return adaneo2.getPixelColor(n - (NEOPIXEL_PIXELS));
+      else return adaneo1.getPixelColor(n);
+    #else
+      return adaneo1.getPixelColor(n);
+    #endif
+  }
+
   static uint8_t brightness() { return adaneo1.getBrightness(); }
 
   static uint32_t Color(uint8_t r, uint8_t g, uint8_t b OPTARG(HAS_WHITE_LED, uint8_t w)) {
@@ -174,6 +183,7 @@ extern Marlin_NeoPixel neo;
 
     // Accessors
     static uint16_t pixels() { return adaneo.numPixels();}
+    static uint32_t pixel_color(const uint16_t n) { return adaneo.getPixelColor(n); }
     static uint8_t brightness() { return adaneo.getBrightness(); }
     static uint32_t Color(uint8_t r, uint8_t g, uint8_t b OPTARG(HAS_WHITE_LED2, uint8_t w)) {
       return adaneo.Color(r, g, b OPTARG(HAS_WHITE_LED2, w));

--- a/Marlin/src/gcode/feature/leds/M150.cpp
+++ b/Marlin/src/gcode/feature/leds/M150.cpp
@@ -31,11 +31,13 @@
  * M150: Set Status LED Color - Use R-U-B-W for R-G-B-W
  *       and Brightness       - Use P (for NEOPIXEL only)
  *
- * Always sets all 3 or 4 components. If a component is left out, set to 0.
- *                                    If brightness is left out, no value changed
+ * Always sets all 3 or 4 components unless the K flag is specified.
+ *                              If a component is left out, set to 0.
+ *                              If brightness is left out, no value changed.
  *
  * With NEOPIXEL_LED:
  *  I<index>  Set the NeoPixel index to affect. Default: All
+ *  K         Keep all unspecified values unchanged instead of setting to 0.
  *
  * With NEOPIXEL2_SEPARATE:
  *  S<index>  The NeoPixel strip to set. Default: All.
@@ -51,16 +53,19 @@
  *   M150 P          ; Set LED full brightness
  *   M150 I1 R       ; Set NEOPIXEL index 1 to red
  *   M150 S1 I1 R    ; Set SEPARATE index 1 to red
+ *   M150 K R127     ; Set LED red to 50% without changing blue or green
  */
 void GcodeSuite::M150() {
+  int32_t old_color = 0;
+
   #if ENABLED(NEOPIXEL_LED)
     const pixel_index_t index = parser.intval('I', -1);
     #if ENABLED(NEOPIXEL2_SEPARATE)
       int8_t brightness = neo.brightness(), unit = parser.intval('S', -1);
       switch (unit) {
         case -1: neo2.neoindex = index; // fall-thru
-        case  0:  neo.neoindex = index; break;
-        case  1: neo2.neoindex = index; brightness = neo2.brightness(); break;
+        case  0:  neo.neoindex = index; old_color = parser.seen('K') ? neo.pixel_color(index >= 0 ? index : 0) : 0; break;
+        case  1: neo2.neoindex = index; brightness = neo2.brightness(); old_color = parser.seen('K') ? neo2.pixel_color(index >= 0 ? index : 0) : 0; break;
       }
     #else
       const uint8_t brightness = neo.brightness();
@@ -69,10 +74,10 @@ void GcodeSuite::M150() {
   #endif
 
   const LEDColor color = LEDColor(
-    parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-    parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : 0,
-    parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : 0
-    OPTARG(HAS_WHITE_LED, parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : 0)
+    parser.seen('R') ? (parser.has_value() ? parser.value_byte() : 255) : (old_color >> 16) & 255,
+    parser.seen('U') ? (parser.has_value() ? parser.value_byte() : 255) : (old_color >> 8) & 255,
+    parser.seen('B') ? (parser.has_value() ? parser.value_byte() : 255) : old_color & 255
+    OPTARG(HAS_WHITE_LED, parser.seen('W') ? (parser.has_value() ? parser.value_byte() : 255) : (old_color >> 24) & 255)
     OPTARG(NEOPIXEL_LED, parser.seen('P') ? (parser.has_value() ? parser.value_byte() : 255) : brightness)
   );
 


### PR DESCRIPTION
### Description

This pull requests adds a 'K' flag "Keep unspecified values unchanged" to M150 to allow updating each channel of the Neopixel RGB(W) outputs independently.

### Requirements

Only applies to boards using Neopixel-style RGB(W) lighting.

### Benefits

Currently, Neopixel-style RGB(W) lighting can only be changed via M150 if all colors and brightness variables are specified at once, in a single command.  There are some use cases, such as OpenPnP "profile actuators" where the only way to configure RGB(W) lighting in the host application is if each channel is controllable independently, without affecting the other channels.  This change enables that behavior.  This does not change any existing behavior of the M150 command if the new 'K' flag is not present

Example usage:

```
M150 P255 R
M150 K U # Color is now R255 U255
M150 K B # Color is now R255 U255 B255
```

is functionally equivalent to sending

`M150 P255 R U B`

as a single command.  It also allows you to change the brightness of the current color, without having to re-send the color, e.g.

```
M150 P255 R255 U127
M150 K P127 # Change the brightness while still retaining color R255 U127
```

Note that the K flag only works if the brightness is nonzero, otherwise changes to the other parameters are ignored.  This seems to be due to the way the underlying library works wrt the brightness value (i.e. a brightness of 0 sets the colors to 0 as well).