### PR TITLE
fix sd mount loop

### DIFF
--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -494,8 +494,9 @@ void CardReader::manage_media() {
     safe_delay(500);                // Some boards need a delay to get settled
 
     // Try to mount the media (only later with SD_IGNORE_AT_STARTUP)
-    if (TERN1(SD_IGNORE_AT_STARTUP, old_stat != 2)) mount();
-    if (!isMounted()) {             // Not mounted?
+    if (TERN1(SD_IGNORE_AT_STARTUP, old_stat != 2)) {
+      mount();
+    } else {
       stat = 0;
       #if HAS_SD_DETECT && DISABLED(SD_IGNORE_AT_STARTUP)
         prev_stat = 0;
@@ -505,6 +506,7 @@ void CardReader::manage_media() {
     TERN_(RESET_STEPPERS_ON_MEDIA_INSERT, reset_stepper_drivers()); // Workaround for Cheetah bug
   }
   else {
+    ui.reset_status(false); // Clear 'Media Init fail' if present
     TERN_(HAS_SD_DETECT, release()); // Card is released
   }
 

--- a/Marlin/src/sd/cardreader.cpp
+++ b/Marlin/src/sd/cardreader.cpp
@@ -494,19 +494,12 @@ void CardReader::manage_media() {
     safe_delay(500);                // Some boards need a delay to get settled
 
     // Try to mount the media (only later with SD_IGNORE_AT_STARTUP)
-    if (TERN1(SD_IGNORE_AT_STARTUP, old_stat != 2)) {
-      mount();
-    } else {
-      stat = 0;
-      #if HAS_SD_DETECT && DISABLED(SD_IGNORE_AT_STARTUP)
-        prev_stat = 0;
-      #endif
-    }
+    if (TERN1(SD_IGNORE_AT_STARTUP, old_stat != 2)) mount();
+    if (!isMounted()) stat = 0;     // Not mounted?
 
     TERN_(RESET_STEPPERS_ON_MEDIA_INSERT, reset_stepper_drivers()); // Workaround for Cheetah bug
   }
   else {
-    ui.reset_status(false); // Clear 'Media Init fail' if present
     TERN_(HAS_SD_DETECT, release()); // Card is released
   }
 
@@ -514,20 +507,12 @@ void CardReader::manage_media() {
 
   if (!stat) return;                // Exit if no media is present
 
-  static bool did_first_insert = false;
-  if (did_first_insert) return;     // Did a media insert already happen?
-  did_first_insert = true;          // Definitely handling this media insert...
+  if (old_stat != 2) return;        // First mount?
 
   DEBUG_ECHOLNPGM("First mount.");
 
   // Load settings the first time media is inserted (not just during init)
   TERN_(SDCARD_EEPROM_EMULATION, settings.first_load());
-
-  #if HAS_USB_FLASH_DRIVE
-    const millis_t ms = millis();
-    DEBUG_ECHOLNPGM("USB mount waiting time = ", ms);
-    if (ms > 5000) return;          // Too late to be considered "already inserted"?
-  #endif
 
   bool do_auto = true; UNUSED(do_auto);
 


### PR DESCRIPTION
### Description

When the sdcard has a SD_DETECT_PIN and you insert the sdcard but the sdcard is not readable for some reason, Marlin will currently attempt to mount the scard every main loop over and over forever.
This slows marlin down to a crawl most notably in the display updating.

This patch reorders the code so that at most two attempts are made to mount the sdcard before stopping.

### Requirements

SDSUPPORT

### Benefits

Marlin doesn't slow to a unusable crawl on a bad sdcard.

### Related Issues
https://github.com/MarlinFirmware/Marlin/issues/24306
https://github.com/MarlinFirmware/Marlin/pull/24302