### PR TITLE
Fix typo in `Info_PrintFinish_1_buf_ch[]` and user facing string

### DIFF
--- a/Marlin/src/lcd/extui/dgus/mks/DGUSDisplayDef.h
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSDisplayDef.h
@@ -680,8 +680,8 @@ constexpr uint16_t SP_T_Bed_Set   = 0x5040;
   constexpr uint16_t VP_EX_TEMP_INFO2_Dis             = 0x5620;
   constexpr uint16_t VP_EX_TEMP_INFO3_Dis             = 0x5630;
   constexpr uint16_t VP_LCD_BLK_Dis                   = 0x56A0;
-  constexpr uint16_t VP_Info_PrinfFinsh_1_Dis         = 0x5C00;
-  constexpr uint16_t VP_Info_PrinfFinsh_2_Dis         = 0x5C10;
+  constexpr uint16_t VP_Info_PrintFinish_1_Dis        = 0x5C00;
+  constexpr uint16_t VP_Info_PrintFinish_2_Dis        = 0x5C10;
 
   constexpr uint16_t VP_Length_Dis                    = 0x5B00;
 

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
@@ -564,7 +564,7 @@ void DGUSScreenHandlerMKS::MeshLevel(DGUS_VP_Variable &var, void *val_ptr) {
           queue.enqueue_now(F("G29S2"));
           mesh_point_count--;
           if (mks_language_index == MKS_English) {
-            const char level_buf_en2[] = "Level Finish";
+            const char level_buf_en2[] = "Leveling Done";
             dgusdisplay.WriteVariable(VP_AutoLevel_1_Dis, level_buf_en2, 32, true);
           }
           else if (mks_language_index == MKS_SimpleChinese) {

--- a/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
+++ b/Marlin/src/lcd/extui/dgus/mks/DGUSScreenHandler.cpp
@@ -564,7 +564,7 @@ void DGUSScreenHandlerMKS::MeshLevel(DGUS_VP_Variable &var, void *val_ptr) {
           queue.enqueue_now(F("G29S2"));
           mesh_point_count--;
           if (mks_language_index == MKS_English) {
-            const char level_buf_en2[] = "Level Finsh";
+            const char level_buf_en2[] = "Level Finish";
             dgusdisplay.WriteVariable(VP_AutoLevel_1_Dis, level_buf_en2, 32, true);
           }
           else if (mks_language_index == MKS_SimpleChinese) {
@@ -1709,8 +1709,8 @@ void DGUSScreenHandlerMKS::DGUS_LanguageDisplay(uint8_t var) {
     const char Info_EEPROM_2_buf_en[] = "Revert setting?";
     dgusdisplay.WriteVariable(VP_Info_EEPROM_2_Dis, Info_EEPROM_2_buf_en, 32, true);
 
-    const char Info_PrinfFinsh_1_buf_en[] = "Print Done";
-    dgusdisplay.WriteVariable(VP_Info_PrinfFinsh_1_Dis, Info_PrinfFinsh_1_buf_en, 32, true);
+    const char Info_PrintFinish_1_buf_en[] = "Print Done";
+    dgusdisplay.WriteVariable(VP_Info_PrintFinish_1_Dis, Info_PrintFinish_1_buf_en, 32, true);
 
     const char TMC_X_Step_buf_en[] = "X_SenSitivity";
     dgusdisplay.WriteVariable(VP_TMC_X_Step_Dis, TMC_X_Step_buf_en, 32, true);
@@ -1973,8 +1973,8 @@ void DGUSScreenHandlerMKS::DGUS_LanguageDisplay(uint8_t var) {
     const uint16_t TMC_Z_Step_buf_ch[] = { 0x205A, 0xE9C1, 0xF4C3, 0xC8B6, 0x2000 };
     dgusdisplay.WriteVariable(VP_TMC_Z_Step_Dis, TMC_Z_Step_buf_ch, 16, true);
 
-    const uint16_t Info_PrinfFinsh_1_buf_ch[] = { 0xF2B4, 0xA1D3, 0xEACD, 0xC9B3, 0x2000 };
-    dgusdisplay.WriteVariable(VP_Info_PrinfFinsh_1_Dis, Info_PrinfFinsh_1_buf_ch, 32, true);
+    const uint16_t Info_PrintFinish_1_buf_ch[] = { 0xF2B4, 0xA1D3, 0xEACD, 0xC9B3, 0x2000 };
+    dgusdisplay.WriteVariable(VP_Info_PrintFinish_1_Dis, Info_PrintFinish_1_buf_ch, 32, true);
 
     const uint16_t TMC_X_Current_buf_ch[] = { 0x2058, 0xE1D6, 0xE7B5, 0xF7C1, 0x2000 };
     dgusdisplay.WriteVariable(VP_TMC_X_Current_Dis, TMC_X_Current_buf_ch, 16, true);


### PR DESCRIPTION
### Description

Fixed source typos in `Info_PrintFinish_1_buf_ch[]` (was `Info_PrinfFinsh_1_buf_ch[]`). Another `finsh`->`finish` was also fixed as well. 

### Requirements

n/a

### Benefits

code comprehension

### Configurations

n/a

### Related Issues

n/a