### PR TITLE
remove marlin rename from build env jgaurora_a5s_a1

### DIFF
--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -331,7 +331,6 @@ extends                     = stm32_variant
 board                       = genericSTM32F103ZE
 board_build.variant         = MARLIN_F103Zx
 board_build.offset          = 0xA000
-board_build.rename          = firmware_for_sd_upload.bin
 board_upload.offset_address = 0x0800A000
 build_flags                 = ${stm32_variant.build_flags}
                               -DSTM32F1xx -DSTM32_XL_DENSITY


### PR DESCRIPTION
### Description

in ini/stm32f1.ini

```
#
# JGAurora A5S A1 (STM32F103ZET6)
#
[env:jgaurora_a5s_a1]
extends                     = stm32_variant
board                       = genericSTM32F103ZE
board_build.variant         = MARLIN_F103Zx
board_build.offset          = 0xA000
board_build.rename          = firmware_for_sd_upload.bin
board_upload.offset_address = 0x0800A000
build_flags                 = ${stm32_variant.build_flags}
                              -DSTM32F1xx -DSTM32_XL_DENSITY
extra_scripts               = ${stm32_variant.extra_scripts}
                              buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py
```

the script buildroot/share/PlatformIO/scripts/jgaurora_a5s_a1_with_bootloader.py renames and builds a version with bootloader
but Marlin saw "board_build.rename          = firmware_for_sd_upload.bin" and renamed it before the script was called.

removing  "board_build.rename          = firmware_for_sd_upload.bin"  from the build environment as it is not needed and is causing issues

### Requirements

a board that uses env:jgaurora_a5s_a1

### Benefits

Builds as expected

### Related Issues
Was noticed in https://github.com/MarlinFirmware/Configurations/pull/737#issuecomment-1128308417 
and https://github.com/MarlinFirmware/Marlin/pull/24316