### PR TITLE
Remove Unused "digs" Variable

### DIFF
--- a/Marlin/src/lcd/menu/menu_x_twist.cpp
+++ b/Marlin/src/lcd/menu/menu_x_twist.cpp
@@ -100,9 +100,6 @@ void xatc_wizard_menu() {
   SUBMENU(MSG_MOVE_01MM, []{ _goto_manual_move_z( 0.1f); });
 
   if ((FINE_MANUAL_MOVE) > 0.0f && (FINE_MANUAL_MOVE) < 0.1f) {
-    // Determine digits needed right of decimal
-    const uint8_t digs = !UNEAR_ZERO((FINE_MANUAL_MOVE) * 1000 - int((FINE_MANUAL_MOVE) * 1000)) ? 4 :
-                         !UNEAR_ZERO((FINE_MANUAL_MOVE) *  100 - int((FINE_MANUAL_MOVE) *  100)) ? 3 : 2;
     SUBMENU_f(F(STRINGIFY(FINE_MANUAL_MOVE)), MSG_MOVE_N_MM, []{ _goto_manual_move_z(float(FINE_MANUAL_MOVE)); });
   }
 


### PR DESCRIPTION
### Description

The usage of `digs` was removed in #24278, but the variable was left behind and generates an unused variable warning while compiling (as reported in #24357)

### Requirements

`X_AXIS_TWIST_COMPENSATION`

### Benefits

No unused variable warning

### Configurations

[Marlin.zip from #24357](https://github.com/MarlinFirmware/Marlin/files/8914380/Marlin.zip)

### Related Issues

- #24278
- #24357