### PR TITLE
fix missing M423 gcode issue #24359

### DIFF
--- a/Marlin/src/gcode/gcode.cpp
+++ b/Marlin/src/gcode/gcode.cpp
@@ -1050,6 +1050,10 @@ void GcodeSuite::process_parsed_command(const bool no_ok/*=false*/) {
         case 1000: M1000(); break;                                // M1000: [INTERNAL] Resume from power-loss
       #endif
 
+      #if ENABLED(X_AXIS_TWIST_COMPENSATION)
+        case  423: M423(); break;                                 // M423: Reset, modify, or report X-Twist Compensation data
+      #endif
+
       #if ENABLED(SDSUPPORT)
         case 1001: M1001(); break;                                // M1001: [INTERNAL] Handle SD completion
       #endif


### PR DESCRIPTION
### Description

M423 gcode not recognized when X_AXIS_TWIST_COMPENSATION is enabled.

```
Send: M423
Recv: echo:Unknown command: "M423"
Recv: ok

```
Code was found to be missing from gcode.cpp

I added in code to activate M423 

### Requirements

X_AXIS_TWIST_COMPENSATION

### Benefits

M423 is now a valid gcode and responds 

```
Send: M423
Recv:   M423 A2.00 I36.00
Recv:   M423 X0 Z0.00
Recv:   M423 X1 Z0.00
Recv:   M423 X2 Z0.00
Recv:   M423 X3 Z0.00
Recv:   M423 X4 Z0.00
Recv:   M423 X5 Z0.00
Recv:   M423 X6 Z0.00
Recv: ok
```

### Configurations
From issue: https://github.com/MarlinFirmware/Marlin/files/8916185/config.zip

### Related Issues
issue #24359