### PR TITLE
Fix stutter when drawing arcs

### DIFF
--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -209,14 +209,14 @@ void plan_arc(
   // Number of whole segments based on the nominal segment length
   const float nominal_segments = _MAX(FLOOR(flat_mm / nominal_segment_mm), min_segments);
 
-  // A new segment length based on the required minimum
-  const float segment_mm = constrain(flat_mm / nominal_segments, MIN_ARC_SEGMENT_MM, MAX_ARC_SEGMENT_MM);
-
-  // The number of whole segments in the arc, ignoring the remainder
-  uint16_t segments = CEIL(flat_mm / segment_mm);
+  // The number of whole segments in the arc, with best attempt to honor MIN_ARC_SEGMENT_MM and MAX_ARC_SEGMENT_MM
+  const float segment_mm = flat_mm / nominal_segments;
+  uint16_t segments = segment_mm > MAX_ARC_SEGMENT_MM ? CEIL(flat_mm / MAX_ARC_SEGMENT_MM) :
+                      segment_mm < MIN_ARC_SEGMENT_MM ? _MAX(1, FLOOR(flat_mm / MIN_ARC_SEGMENT_MM)) :
+                      nominal_segments;
 
   #if ENABLED(SCARA_FEEDRATE_SCALING)
-    const float inv_duration = scaled_fr_mm_s / segment_mm;
+    const float inv_duration = scaled_fr_mm_s / flat_mm * segments;
   #endif
 
   /**

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -211,12 +211,12 @@ void plan_arc(
 
   // The number of whole segments in the arc, with best attempt to honor MIN_ARC_SEGMENT_MM and MAX_ARC_SEGMENT_MM
   const float segment_mm = flat_mm / nominal_segments;
-  uint16_t segments = segment_mm > MAX_ARC_SEGMENT_MM ? CEIL(flat_mm / MAX_ARC_SEGMENT_MM) :
-                      segment_mm < MIN_ARC_SEGMENT_MM ? _MAX(1, FLOOR(flat_mm / MIN_ARC_SEGMENT_MM)) :
-                      nominal_segments;
+  const uint16_t segments = segment_mm > (MAX_ARC_SEGMENT_MM) ? CEIL(flat_mm / (MAX_ARC_SEGMENT_MM)) :
+                            segment_mm < (MIN_ARC_SEGMENT_MM) ? _MAX(1, FLOOR(flat_mm / (MIN_ARC_SEGMENT_MM))) :
+                            nominal_segments;
 
   #if ENABLED(SCARA_FEEDRATE_SCALING)
-    const float inv_duration = scaled_fr_mm_s / flat_mm * segments;
+    const float inv_duration = (scaled_fr_mm_s / flat_mm) * segments;
   #endif
 
   /**

--- a/Marlin/src/gcode/motion/G2_G3.cpp
+++ b/Marlin/src/gcode/motion/G2_G3.cpp
@@ -197,8 +197,8 @@ void plan_arc(
   // Feedrate for the move, scaled by the feedrate multiplier
   const feedRate_t scaled_fr_mm_s = MMS_SCALED(feedrate_mm_s);
 
-  // Get the nominal segment length based on settings
-  const float nominal_segment_mm = (
+  // Get the ideal segment length for the move based on settings
+  const float ideal_segment_mm = (
     #if ARC_SEGMENTS_PER_SEC  // Length based on segments per second and feedrate
       constrain(scaled_fr_mm_s * RECIPROCAL(ARC_SEGMENTS_PER_SEC), MIN_ARC_SEGMENT_MM, MAX_ARC_SEGMENT_MM)
     #else
@@ -206,13 +206,13 @@ void plan_arc(
     #endif
   );
 
-  // Number of whole segments based on the nominal segment length
-  const float nominal_segments = _MAX(FLOOR(flat_mm / nominal_segment_mm), min_segments);
+  // Number of whole segments based on the ideal segment length
+  const float nominal_segments = _MAX(FLOOR(flat_mm / ideal_segment_mm), min_segments),
+              nominal_segment_mm = flat_mm / nominal_segments;
 
   // The number of whole segments in the arc, with best attempt to honor MIN_ARC_SEGMENT_MM and MAX_ARC_SEGMENT_MM
-  const float segment_mm = flat_mm / nominal_segments;
-  const uint16_t segments = segment_mm > (MAX_ARC_SEGMENT_MM) ? CEIL(flat_mm / (MAX_ARC_SEGMENT_MM)) :
-                            segment_mm < (MIN_ARC_SEGMENT_MM) ? _MAX(1, FLOOR(flat_mm / (MIN_ARC_SEGMENT_MM))) :
+  const uint16_t segments = nominal_segment_mm > (MAX_ARC_SEGMENT_MM) ? CEIL(flat_mm / (MAX_ARC_SEGMENT_MM)) :
+                            nominal_segment_mm < (MIN_ARC_SEGMENT_MM) ? _MAX(1, FLOOR(flat_mm / (MIN_ARC_SEGMENT_MM))) :
                             nominal_segments;
 
   #if ENABLED(SCARA_FEEDRATE_SCALING)


### PR DESCRIPTION
### Description

#22599 corrected a bug where the arc code could generate a final segment up to twice as long as `MAX_ARC_SEGMENT_MM`. However the change introduced the possibility for the final arc segment to be shorter than `MIN_ARC_SEGMENT_MM`.

For very short final segments, the junction deviation code can introduce stutters. So using arcs with junction deviation sometimes causes stutters. #17342 describes a similar problem with short slicer generated arc segments which may have the same underlying cause in JD.

#### Solution

This PR solves the problem by using @FormLurker's original suggestion in #22571 to replace `FLOOR` with `CEIL` in

https://github.com/MarlinFirmware/Marlin/blob/0a3c42a87c24ff3b5b184f211d5b2549083b61a5/Marlin/src/gcode/motion/G2_G3.cpp#L216

But it only does so in the case where `segment_mm` is longer than `MAX_ARC_SEGMENT_MM`. In the other two cases, where `segment_mm` is less than `MIN_ARC_SEGMENT_MM` or between `MIN_ARC_SEGMENT_MM` and `MAX_ARC_SEGMENT_MM`, the number of segments is calculated as before.

This is guaranteed to result in an acceptable segment length between `MIN_ARC_SEGMENT_MM` and `MAX_ARC_SEGMENT_MM` in all but the pathological case where there is no possible value for `segments` which generates a segment length within range. For the default values of 0.1mm and 1mm, this will only happen if the arc itself is shorter than `MIN_ARC_SEGMENT_MM` (see below).

This change also saves several floating point multiplications and a division in the code around variable `proportion`, improving arc performance.

This PR also takes the opportunity to not calculate the arc parameters if there is only one segment, also improving arc performance.

#### Junction deviation stutter

The junction deviation code bases its calculation on distance in stepper space. So the distances along each axis are affected by aliasing. For very short segments which are just long enough not to be filtered out by `MIN_STEPS_PER_SEGMENT`, this can cause proportionally large errors in segment direction. So the code calculates a larger theta angle between two segments than really exists. Since the segment is short, `JD_HANDLE_SMALL_SEGMENTS` comes into play and the combination of a large angle with a small segment length causes Marlin to think a very small circle is being described, so the cornering speed is limited accordingly.

#### Analysis of resulting segment length

Here is my logic to support the claim that the segment length will always be in range if that is possible.

The code in question is

```
  const float segment_mm = flat_mm / nominal_segments;
  uint16_t segments = segment_mm > MAX_ARC_SEGMENT_MM ? CEIL(flat_mm / MAX_ARC_SEGMENT_MM) :
                      segment_mm < MIN_ARC_SEGMENT_MM ? _MAX(1, FLOOR(flat_mm / MIN_ARC_SEGMENT_MM)) :
                      nominal_segments;
```

Depending on which of the three cases above holds, the segment length will be one of:
1. The longest possible segment that is not longer than `MAX_ARC_SEGMENT_MM`.
2. The shortest possible segment that is not shorter than `MIN_ARC_SEGMENT_MM`. Or, if the `_MAX(1, ...)` has to be invoked, then the pathological case.
3. A length that is known to be between `MIN_ARC_SEGMENT_MM` and `MAX_ARC_SEGMENT_MM`.

Case 3 is trivial. In cases 1 and 2 (other than the pathological case) as long as there exists at least one integer N for which `segments == N` gives a segment length between `MIN_ARC_SEGMENT_MM` and `MAX_ARC_SEGMENT_MM`, then the selected segment count will be the smallest or, respectively, largest possible such value for N. i.e. segment length is in range.

In the pathological case, such N does not exist. This occurs if and only if there exists an integer M for which
```
flat_mm / M > MAX_ARC_SEGMENT_MM
```
and
```
flat_mm / (M + 1) < MIN_ARC_SEGMENT_MM
```
If we substitute the default values of 0.1mm and 1.0mm for `MIN_ARC_SEGMENT_MM` and `MAX_ARC_SEGMENT_MM` then
```
1.0 * M < flat_mm < 0.1 * (M + 1)
```
from which we get `M < 1/9`. The only non-negative integer which obeys this condition is zero. So
```
flat_mm / (0 + 1) < MIN_ARC_SEGMENT_MM
```
i.e. the arc length is less than `MIN_ARC_SEGMENT_MM`. In this case, the `segments` will be set to 1 and the arc code will generate a single segment.

My brain is hurting at this point but I think you could go on to show that as long as `MAX_ARC_SEGMENT_MM` is more than than double `MIN_ARC_SEGMENT_MM` then zero will always be the only possible value for M.

### Requirements

`ARC_SUPPORT` enabled and `CLASSIC_JERK` disabled (i.e. junction deviation in use).

### Benefits

Removes stutters. Ensures arc segments remain within the limits of both `MIN_ARC_SEGMENT_MM` and `MAX_ARC_SEGMENT_MM`.

### Configurations

[config.zip](https://github.com/MarlinFirmware/Marlin/files/8927064/config.zip)

and two gcode files which show the problem:

[tests.zip](https://github.com/MarlinFirmware/Marlin/files/8927067/tests.zip)

### Related Issues

#22599
#22571
#17342