### PR TITLE
Fix BX Touch Freeze

### DIFF
--- a/Marlin/src/HAL/STM32/tft/gt911.cpp
+++ b/Marlin/src/HAL/STM32/tft/gt911.cpp
@@ -159,24 +159,28 @@ void GT911::read_reg(uint16_t reg, uint8_t reg_len, uint8_t* r_data, uint8_t r_l
 void GT911::Init() {
   OUT_WRITE(GT911_RST_PIN, LOW);
   OUT_WRITE(GT911_INT_PIN, LOW);
-  delay(20);
+  delay(11);
+  WRITE(GT911_INT_PIN, HIGH);
+  delayMicroseconds(110);
   WRITE(GT911_RST_PIN, HIGH);
+  delay(6);
+  WRITE(GT911_INT_PIN, LOW);
+  delay(55);
   SET_INPUT(GT911_INT_PIN);
 
   sw_iic.init();
 
-  uint8_t clear_reg = 0x0000;
-  write_reg(0x814E, 2, &clear_reg, 2); // Reset to 0 for start
+  uint8_t clear_reg = 0x00;
+  write_reg(0x814E, 2, &clear_reg, 1); // Reset to 0 for start
 }
 
 bool GT911::getFirstTouchPoint(int16_t *x, int16_t *y) {
   read_reg(0x814E, 2, &reg.REG.status, 1);
 
-  if (reg.REG.status & 0x80) {
+  if (reg.REG.status >= 0x80 && reg.REG.status <= 0x85) {
+    read_reg(0x8150, 2, reg.map + 2, 38);
     uint8_t clear_reg = 0x00;
     write_reg(0x814E, 2, &clear_reg, 1); // Reset to 0 for start
-    read_reg(0x8150, 2, reg.map + 2, 8 * (reg.REG.status & 0x0F));
-
     // First touch point
     *x = ((reg.REG.point[0].xh & 0x0F) << 8) | reg.REG.point[0].xl;
     *y = ((reg.REG.point[0].yh & 0x0F) << 8) | reg.REG.point[0].yl;

--- a/Marlin/src/HAL/STM32/tft/gt911.h
+++ b/Marlin/src/HAL/STM32/tft/gt911.h
@@ -23,7 +23,7 @@
 
 #include "../../../inc/MarlinConfig.h"
 
-#define GT911_SLAVE_ADDRESS   0xBA
+#define GT911_SLAVE_ADDRESS   0x28
 
 #if !PIN_EXISTS(GT911_RST)
   #error "GT911_RST_PIN is not defined."


### PR DESCRIPTION
### Description

The touch address was wrong (or it should be configurable?). I took 0x28 from BTT BX repository.

The freeze was happening because it was reading 0xFF from the invalid address and code wasn't handling bad reads.

### Requirements

BX Printer

### Benefits

Fix #24353

### Configurations

Biqu/BX from examples.

### Related Issues

#24353 
