### PR TITLE
Lerdge Boot Fail: Backout Commit b4904cc Changes to stm32f4.ini & marlin.py

### DIFF
--- a/buildroot/share/PlatformIO/scripts/lerdge.py
+++ b/buildroot/share/PlatformIO/scripts/lerdge.py
@@ -26,10 +26,10 @@ if pioutil.is_pio_build():
 			input_file[i] = encryptByte(input_file[i])
 		output_file.write(input_file)
 
-	# Encrypt ${PROGNAME}.bin and save it with the name given in build.encrypt
+	# Encrypt ${PROGNAME}.bin and save it with the name given in build.crypt_lerdge
 	def encrypt(source, target, env):
 		fwpath = target[0].path
-		enname = board.get("build.encrypt")
+		enname = board.get("build.crypt_lerdge")
 		print("Encrypting %s to %s" % (fwpath, enname))
 		fwfile = open(fwpath, "rb")
 		enfile = open(target[0].dir.path + "/" + enname, "wb")
@@ -41,9 +41,9 @@ if pioutil.is_pio_build():
 		enfile.close()
 		os.remove(fwpath)
 
-	if 'encrypt' in board.get("build").keys():
-		if board.get("build.encrypt") != "":
+	if 'crypt_lerdge' in board.get("build").keys():
+		if board.get("build.crypt_lerdge") != "":
 			marlin.add_post_action(encrypt)
 	else:
-		print("LERDGE builds require output file via board_build.encrypt = 'filename' parameter")
+		print("LERDGE builds require output file via board_build.crypt_lerdge = 'filename' parameter")
 		exit(1)

--- a/buildroot/share/PlatformIO/scripts/marlin.py
+++ b/buildroot/share/PlatformIO/scripts/marlin.py
@@ -52,24 +52,22 @@ def encrypt_mks(source, target, env, new_name):
 	mf = env["MARLIN_FEATURES"]
 	if "FIRMWARE_BIN" in mf: new_name = mf["FIRMWARE_BIN"]
 
-	fwpath = target[0].path
-	fwfile = open(fwpath, "rb")
-	enfile = open(target[0].dir.path + "/" + new_name, "wb")
-	length = os.path.getsize(fwpath)
+	firmware = open(target[0].path, "rb")
+	renamed = open(target[0].dir.path + "/" + new_name, "wb")
+	length = os.path.getsize(target[0].path)
 	position = 0
 	try:
 		while position < length:
-			byte = fwfile.read(1)
+			byte = firmware.read(1)
 			if position >= 320 and position < 31040:
 				byte = chr(ord(byte) ^ key[position & 31])
 				if sys.version_info[0] > 2:
 					byte = bytes(byte, 'latin1')
-			enfile.write(byte)
+			renamed.write(byte)
 			position += 1
 	finally:
-		fwfile.close()
-		enfile.close()
-		os.remove(fwpath)
+		firmware.close()
+		renamed.close()
 
 def add_post_action(action):
 	env.AddPostAction(join("$BUILD_DIR", "${PROGNAME}.bin"), action);

--- a/buildroot/share/PlatformIO/scripts/offset_and_rename.py
+++ b/buildroot/share/PlatformIO/scripts/offset_and_rename.py
@@ -39,15 +39,15 @@ if pioutil.is_pio_build():
 				env["LINKFLAGS"][i] = "-Wl,--defsym=LD_MAX_DATA_SIZE=" + str(maximum_ram_size - 40)
 
 	#
-	# For build.encrypt rename and encode the firmware file.
+	# For build.encrypt_mks rename and encode the firmware file.
 	#
-	if 'encrypt' in board_keys:
+	if 'encrypt_mks' in board_keys:
 
-		# Encrypt ${PROGNAME}.bin and save it with the name given in build.encrypt
+		# Encrypt ${PROGNAME}.bin and save it with the name given in build.encrypt_mks
 		def encrypt(source, target, env):
-			marlin.encrypt_mks(source, target, env, board.get("build.encrypt"))
+			marlin.encrypt_mks(source, target, env, board.get("build.encrypt_mks"))
 
-		if board.get("build.encrypt") != "":
+		if board.get("build.encrypt_mks") != "":
 			marlin.add_post_action(encrypt)
 
 	#

--- a/ini/stm32f1.ini
+++ b/ini/stm32f1.ini
@@ -89,22 +89,22 @@ board_upload.offset_address = 0x08005000
 # Uses HAL STM32 to support Marlin UI for TFT screen with optional touch panel
 #
 [env:mks_robin]
-extends              = stm32_variant
-board                = genericSTM32F103ZE
-board_build.variant  = MARLIN_F103Zx
-board_build.encrypt  = Robin.bin
-board_build.offset   = 0x7000
-build_flags          = ${stm32_variant.build_flags}
-                       -DENABLE_HWSERIAL3 -DTIMER_SERIAL=TIM5
-build_unflags        = ${stm32_variant.build_unflags}
-                       -DUSBCON -DUSBD_USE_CDC
+extends                 = stm32_variant
+board                   = genericSTM32F103ZE
+board_build.variant     = MARLIN_F103Zx
+board_build.encrypt_mks = Robin.bin
+board_build.offset      = 0x7000
+build_flags             = ${stm32_variant.build_flags}
+                          -DENABLE_HWSERIAL3 -DTIMER_SERIAL=TIM5
+build_unflags           = ${stm32_variant.build_unflags}
+                          -DUSBCON -DUSBD_USE_CDC
 
 #
 # MKS Robin E3/E3D (STM32F103RCT6) with TMC2209
 #
 [env:mks_robin_e3]
 extends                     = common_STM32F103RC_variant
-board_build.encrypt         = Robin_e3.bin
+board_build.encrypt_mks     = Robin_e3.bin
 board_build.offset          = 0x5000
 board_upload.offset_address = 0x08005000
 build_flags                 = ${common_STM32F103RC_variant.build_flags}
@@ -206,7 +206,7 @@ build_unflags     = ${stm32_variant.build_unflags} -DUSBD_USE_CDC
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
-board_build.encrypt         = Robin_mini.bin
+board_build.encrypt_mks     = Robin_mini.bin
 board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
 build_flags                 = ${stm32_variant.build_flags}
@@ -222,7 +222,7 @@ build_unflags               = ${stm32_variant.build_unflags}
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
-board_build.encrypt         = Robin_nano35.bin
+board_build.encrypt_mks     = Robin_nano35.bin
 board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
 build_flags                 = ${stm32_variant.build_flags}
@@ -275,7 +275,7 @@ build_flags                 = ${stm32_variant.build_flags} -DSS_TIMER=4
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
-board_build.encrypt         = Robin_mini.bin
+board_build.encrypt_mks     = Robin_mini.bin
 board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
 build_flags                 = ${stm32_variant.build_flags}
@@ -288,7 +288,7 @@ build_flags                 = ${stm32_variant.build_flags}
 extends                     = stm32_variant
 board                       = genericSTM32F103RC
 board_build.variant         = MARLIN_F103Rx
-board_build.encrypt         = mksLite.bin
+board_build.encrypt_mks     = mksLite.bin
 board_build.offset          = 0x5000
 board_upload.offset_address = 0x08005000
 
@@ -297,14 +297,14 @@ board_upload.offset_address = 0x08005000
 #
 [env:mks_robin_lite3]
 extends                     = env:mks_robin_lite
-board_build.encrypt         = mksLite3.bin
+board_build.encrypt_mks     = mksLite3.bin
 
 #
 # MKS Robin Pro (STM32F103ZET6)
 #
 [env:mks_robin_pro]
-extends             = env:mks_robin
-board_build.encrypt = Robin_pro.bin
+extends                 = env:mks_robin
+board_build.encrypt_mks = Robin_pro.bin
 
 #
 # MKS Robin E3p (STM32F103VET6)
@@ -314,7 +314,7 @@ board_build.encrypt = Robin_pro.bin
 extends                     = stm32_variant
 board                       = genericSTM32F103VE
 board_build.variant         = MARLIN_F103Vx
-board_build.encrypt         = Robin_e3p.bin
+board_build.encrypt_mks     = Robin_e3p.bin
 board_build.offset          = 0x7000
 board_upload.offset_address = 0x08007000
 build_flags                 = ${stm32_variant.build_flags}

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -113,7 +113,7 @@ extra_scripts     = ${stm32_variant.extra_scripts}
 extends                     = stm32_variant
 board                       = marlin_STM32F407VGT6_CCM
 board_build.variant         = MARLIN_F4x7Vx
-board_build.encrypt         = firmware.srec
+board_build.encrypt_mks     = firmware.srec
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
 build_flags                 = ${stm32_variant.build_flags}
@@ -302,24 +302,24 @@ build_flags       = ${stm_flash_drive.build_flags}
 # Lerdge base
 #
 [lerdge_common]
-extends             = stm32_variant
-board               = marlin_STM32F407ZGT6
-board_build.variant = MARLIN_LERDGE
-board_build.encrypt = firmware.bin
-board_build.offset  = 0x10000
-build_flags         = ${stm32_variant.build_flags}
-                      -DSTM32F4 -DSTM32F4xx -DTARGET_STM32F4
-                      -DDISABLE_GENERIC_SERIALUSB -DARDUINO_ARCH_STM32 -DLERDGE_TFT35
-build_unflags       = ${stm32_variant.build_unflags} -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
-extra_scripts       = ${stm32_variant.extra_scripts}
-                      buildroot/share/PlatformIO/scripts/lerdge.py
+extends                  = stm32_variant
+board                    = marlin_STM32F407ZGT6
+board_build.variant      = MARLIN_LERDGE
+board_build.crypt_lerdge = firmware.bin
+board_build.offset       = 0x10000
+build_flags              = ${stm32_variant.build_flags}
+                           -DSTM32F4 -DSTM32F4xx -DTARGET_STM32F4
+                           -DDISABLE_GENERIC_SERIALUSB -DARDUINO_ARCH_STM32 -DLERDGE_TFT35
+build_unflags            = ${stm32_variant.build_unflags} -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
+extra_scripts            = ${stm32_variant.extra_scripts}
+                           buildroot/share/PlatformIO/scripts/lerdge.py
 
 #
 # Lerdge X (STM32F407VE)
 #
 [env:LERDGEX]
-extends             = lerdge_common
-board_build.encrypt = Lerdge_X_firmware_force.bin
+extends                  = lerdge_common
+board_build.crypt_lerdge = Lerdge_X_firmware_force.bin
 
 #
 # Lerdge X with USB Flash Drive Support
@@ -333,8 +333,8 @@ build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
 # Lerdge S (STM32F407ZG)
 #
 [env:LERDGES]
-extends             = lerdge_common
-board_build.encrypt = Lerdge_firmware_force.bin
+extends                  = lerdge_common
+board_build.crypt_lerdge = Lerdge_firmware_force.bin
 
 #
 # Lerdge S with USB Flash Drive Support
@@ -348,9 +348,9 @@ build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
 # Lerdge K (STM32F407ZG)
 #
 [env:LERDGEK]
-extends             = lerdge_common
-board_build.encrypt = Lerdge_K_firmware_force.bin
-build_flags         = ${lerdge_common.build_flags} -DLERDGEK
+extends                  = lerdge_common
+board_build.crypt_lerdge = Lerdge_K_firmware_force.bin
+build_flags              = ${lerdge_common.build_flags} -DLERDGEK
 
 #
 # Lerdge K with USB Flash Drive Support
@@ -364,17 +364,17 @@ build_flags       = ${stm_flash_drive.build_flags} ${lerdge_common.build_flags}
 # RUMBA32
 #
 [env:rumba32]
-extends              = stm32_variant
-board                = rumba32_f446ve
-board_build.variant  = MARLIN_F446VE
-board_build.offset   = 0x0000
-build_flags          = ${stm32_variant.build_flags}
-                       -Os -DHAL_PCD_MODULE_ENABLED
-                       -DDISABLE_GENERIC_SERIALUSB
-                       -DHAL_UART_MODULE_ENABLED
-                       -DTIMER_SERIAL=TIM9
-monitor_speed        = 500000
-upload_protocol      = dfu
+extends             = stm32_variant
+board               = rumba32_f446ve
+board_build.variant = MARLIN_F446VE
+board_build.offset  = 0x0000
+build_flags         = ${stm32_variant.build_flags}
+                      -Os -DHAL_PCD_MODULE_ENABLED
+                      -DDISABLE_GENERIC_SERIALUSB
+                      -DHAL_UART_MODULE_ENABLED
+                      -DTIMER_SERIAL=TIM9
+monitor_speed       = 500000
+upload_protocol     = dfu
 
 #
 # MKS Robin Pro V2
@@ -547,17 +547,17 @@ build_unflags     = -DUSBD_USE_CDC
 # TH3D EZBoard v2.0 (STM32F405RGT6 ARM Cortex-M4)
 #
 [env:TH3D_EZBoard_V2]
-extends             = stm32_variant
-board               = genericSTM32F405RG
-board_build.variant = MARLIN_TH3D_EZBOARD_V2
-board_build.encrypt = firmware.bin
-board_build.offset  = 0xC000
+extends                     = stm32_variant
+board                       = genericSTM32F405RG
+board_build.variant         = MARLIN_TH3D_EZBOARD_V2
+board_build.encrypt_mks     = firmware.bin
+board_build.offset          = 0xC000
 board_upload.offset_address = 0x0800C000
-build_flags         = ${stm32_variant.build_flags} -DHSE_VALUE=12000000U -O0
-debug_tool          = stlink
-upload_protocol     = stlink
-extra_scripts       = ${stm32_variant.extra_scripts}
-                      buildroot/share/PlatformIO/scripts/openblt.py
+build_flags                 = ${stm32_variant.build_flags} -DHSE_VALUE=12000000U -O0
+debug_tool                  = stlink
+upload_protocol             = stlink
+extra_scripts               = ${stm32_variant.extra_scripts}
+                              buildroot/share/PlatformIO/scripts/openblt.py
 
 #
 # BOARD_MKS_ROBIN_NANO_V1_3_F4

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -305,13 +305,13 @@ build_flags       = ${stm_flash_drive.build_flags}
 extends             = stm32_variant
 board               = marlin_STM32F407ZGT6
 board_build.variant = MARLIN_LERDGE
+board_build.encrypt = firmware.bin
 board_build.offset  = 0x10000
 build_flags         = ${stm32_variant.build_flags}
                       -DSTM32F4 -DSTM32F4xx -DTARGET_STM32F4
                       -DDISABLE_GENERIC_SERIALUSB -DARDUINO_ARCH_STM32 -DLERDGE_TFT35
 build_unflags       = ${stm32_variant.build_unflags} -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
-extra_scripts       = ${common_stm32.extra_scripts}
-                      pre:buildroot/share/PlatformIO/scripts/generic_create_variant.py
+extra_scripts       = ${stm32_variant.extra_scripts}
                       buildroot/share/PlatformIO/scripts/lerdge.py
 
 #


### PR DESCRIPTION
### Description

This PR fixes a problem introduced by commit [b4904cc]((https://github.com/MarlinFirmware/Marlin/commit/b4904cc53e3a8a97fe8047ebe918bc8ea474e120)) Delete after encrypt. Lerdge encrypt only once.

This is commit is part of the 2.0.9.3 release.

Only the changes to stm32f4.ini & marlin.py need to be backed out.  The Lerdge.py changes are not involved in this PR.

### Requirements

This PR affects only the Lerdge series of boards.

### Benefits

The Lerdge boards will now boot and work properly.

The Lerdge boards stopped booting because of commit [b4904cc]((https://github.com/MarlinFirmware/Marlin/commit/b4904cc53e3a8a97fe8047ebe918bc8ea474e120)).  The firmware would load off the SD card but the display would stop at the "firmware update OK" display with no USB coms.  After removing the SD card and power cycling, there were no USB coms and sometimes the LCD would say "App no found".

### Configurations

The testing was done on a Lerdge K using the TFT that ships with the board.  The configuration for it is:
[Configuration.h.zip](https://github.com/MarlinFirmware/Marlin/files/8970996/Configuration.h.zip)

### Related Issues

This problem was identified in issue [#24355.](https://github.com/MarlinFirmware/Marlin/issues/24355)
