### PR TITLE
Fix contrast with K8800 board and ??? display

### DIFF
--- a/Marlin/src/pins/ramps/pins_K8800.h
+++ b/Marlin/src/pins/ramps/pins_K8800.h
@@ -105,9 +105,6 @@
   #define LCD_PINS_D6                         33
   #define LCD_PINS_D7                         31
 
-  #define LCD_CONTRAST_MIN                     0
-  #define LCD_CONTRAST_MAX                   100
-  #define LCD_CONTRAST_INIT                   30
   //#define LCD_SCREEN_ROTATE                180  // 0, 90, 180, 270
 
   #if IS_NEWPANEL


### PR DESCRIPTION
Removed LCD_CONTRAST_* settings. The ones here do not work with the AZSMZ_12864
display, which is the closest match for the part used in the K8800. The default
LCD_CONTRAST_* values work fine for this part.

### Description

For the most part, I have confirmed that the values in the current version of pins_K8800.h are an accurate match for the Velleman Vertex Delta K8800 hardware. I have checked the schematics; the machine boots and responds to serial commands correctly; with further configuration in Configuration and Configuration_Adv.h files (attached), it prints well. The only bugbear is that the display is blank. The closest match for the K8800 display turns out to be the AZSMZ_12864 and this works fine providing the default contrast value range for this device is used (120,190,255); the values set in pins_K8800.h render the display unreadable even at maximum contrast (100). IMHO It is questionable as to whether the values belonged here in the first place, given the range of possible displays that might be fitted to the same main board. I have therefore removed these defines from the file:
```
  #define LCD_CONTRAST_MIN                     0
  #define LCD_CONTRAST_MAX                   100
  #define LCD_CONTRAST_INIT                   30
```
The values now assigned are:
```
  #define LCD_CONTRAST_MIN                     120
  #define LCD_CONTRAST_MAX                   190
  #define LCD_CONTRAST_INIT                   255
```
These are assigned by `Marlin/src/inc/Conditionals_post.h`.

The configuration I now have is working well and nearly ready to be submitted to the Configurations repo - but needs this fix.

### Requirements

This applies to the stock Velleman Vertex Delta K8800 as purchased Dec 2020. I cannot confirm whether it affects other revisions or customisations, but I think any needed changes to these values should be done elsewhere.

### Benefits

It allows a basic build of Marlin to work correctly on a Velleman Vertex Delta K8800 and will allow me to submit a working configuration for it to the Configuration repository.

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/8985433/Configuration.zip)

### Related Issues

Bug #24292

