### PR TITLE
Vertical bar graph for idle profiler when panel is at 90 or 270 degrees

### DIFF
--- a/Marlin/src/feature/max7219.cpp
+++ b/Marlin/src/feature/max7219.cpp
@@ -597,7 +597,11 @@ void Max7219::range16(const uint8_t y, const uint8_t ot, const uint8_t nt, const
 // Apply changes to update a quantity
 void Max7219::quantity(const uint8_t pos, const uint8_t ov, const uint8_t nv, uint8_t * const rcm/*=nullptr*/) {
   for (uint8_t i = _MIN(nv, ov); i < _MAX(nv, ov); i++)
+  #if MAX7219_X_LEDS >= MAX7219_Y_LEDS    // Landscape orientation, draw horizontal bar graph.
     led_set(i, pos, nv >= ov, rcm);
+  #else                                   // Portrait orientation, draw vertical bar graph.
+    led_set(pos, i, nv >= ov, rcm);
+  #endif
 }
 
 void Max7219::quantity16(const uint8_t pos, const uint8_t ov, const uint8_t nv, uint8_t * const rcm/*=nullptr*/) {

--- a/Marlin/src/feature/max7219.cpp
+++ b/Marlin/src/feature/max7219.cpp
@@ -52,6 +52,7 @@
   #define HAS_SIDE_BY_SIDE 1
 #endif
 
+#define _ROT ((MAX7219_ROTATE + 360) % 360)
 #if _ROT == 0 || _ROT == 180
   #define MAX7219_X_LEDS TERN(HAS_SIDE_BY_SIDE, 8, MAX7219_LINES)
   #define MAX7219_Y_LEDS TERN(HAS_SIDE_BY_SIDE, MAX7219_LINES, 8)
@@ -597,11 +598,15 @@ void Max7219::range16(const uint8_t y, const uint8_t ot, const uint8_t nt, const
 // Apply changes to update a quantity
 void Max7219::quantity(const uint8_t pos, const uint8_t ov, const uint8_t nv, uint8_t * const rcm/*=nullptr*/) {
   for (uint8_t i = _MIN(nv, ov); i < _MAX(nv, ov); i++)
-  #if MAX7219_X_LEDS >= MAX7219_Y_LEDS    // Landscape orientation, draw horizontal bar graph.
-    led_set(i, pos, nv >= ov, rcm);
-  #else                                   // Portrait orientation, draw vertical bar graph.
-    led_set(pos, i, nv >= ov, rcm);
-  #endif
+    led_set(
+      #if MAX7219_X_LEDS >= MAX7219_Y_LEDS
+        i, pos  // Single matrix or multiple matrices in Landscape
+      #else
+        pos, i  // Multiple matrices in Portrait
+      #endif
+      , nv >= ov
+      , rcm
+    );
 }
 
 void Max7219::quantity16(const uint8_t pos, const uint8_t ov, const uint8_t nv, uint8_t * const rcm/*=nullptr*/) {

--- a/Marlin/src/feature/max7219.h
+++ b/Marlin/src/feature/max7219.h
@@ -47,7 +47,6 @@
 #ifndef MAX7219_ROTATE
   #define MAX7219_ROTATE 0
 #endif
-#define _ROT ((MAX7219_ROTATE + 360) % 360)
 
 #ifndef MAX7219_NUMBER_UNITS
   #define MAX7219_NUMBER_UNITS 1


### PR DESCRIPTION
Following on from #24375, it turns out that the queue depth and head and tail displays swap x and y when the LED panel is oriented vertically. i.e. the bar graphs are vertical rather than horizontal and that give more space. The idle profiler bar did not do this so with `MAX7219_ROTATE` set to 90 or 180, the bars cut across each other at right angles.