### PR TITLE
📌 Ask for PlatformIO 6.1.1 or newer

### DIFF
--- a/buildroot/share/PlatformIO/scripts/pioutil.py
+++ b/buildroot/share/PlatformIO/scripts/pioutil.py
@@ -4,5 +4,10 @@
 
 # Make sure 'vscode init' is not the current command
 def is_pio_build():
-	from SCons.Script import COMMAND_LINE_TARGETS
-	return "idedata" not in COMMAND_LINE_TARGETS and "_idedata" not in COMMAND_LINE_TARGETS
+	from SCons.Script import DefaultEnvironment
+	env = DefaultEnvironment()
+	return not env.IsIntegrationDump()
+
+def get_pio_version():
+	from platformio import util
+	return util.pioversion_to_intstr()

--- a/buildroot/share/PlatformIO/scripts/preflight-checks.py
+++ b/buildroot/share/PlatformIO/scripts/preflight-checks.py
@@ -52,6 +52,11 @@ if pioutil.is_pio_build():
 		if 'PIOENV' not in env:
 			raise SystemExit("Error: PIOENV is not defined. This script is intended to be used with PlatformIO")
 
+		# Require PlatformIO 6.1.1 or later
+		vers = pioutil.get_pio_version()
+		if vers < [6, 1, 1]:
+			raise SystemExit("Error: Marlin requires PlatformIO >= 6.1.1. Use 'pio upgrade' to get a newer version.")
+
 		if 'MARLIN_FEATURES' not in env:
 			raise SystemExit("Error: this script should be used after common Marlin scripts")
 

--- a/ini/esp32.ini
+++ b/ini/esp32.ini
@@ -20,6 +20,7 @@ build_src_filter = ${common.default_src_filter} +<src/HAL/ESP32>
 lib_ignore       = NativeEthernet
 upload_speed     = 500000
 monitor_speed    = 250000
+monitor_filters  = colorize, time, send_on_enter, log2file, esp32_exception_decoder
 #upload_port     = marlinesp.local
 #board_build.flash_mode = qio
 
@@ -28,13 +29,13 @@ extends                = env:esp32
 board_build.partitions = default_16MB.csv
 
 [env:PANDA]
-extends       = env:esp32
-build_flags   = ${env:esp32.build_flags} -DUSE_ESP32_EXIO -DUSE_ESP32_TASK_WDT
-lib_deps      = ${common.lib_deps}
-  SoftwareSerialEsp32
+extends                = env:esp32
+build_flags            = ${env:esp32.build_flags} -DUSE_ESP32_EXIO -DUSE_ESP32_TASK_WDT
+lib_deps               = ${common.lib_deps}
+                         SoftwareSerialEsp32
 board_build.partitions = Marlin/src/HAL/ESP32/esp32.csv
-upload_speed  = 115200
-monitor_speed = 115200
+upload_speed           = 115200
+monitor_speed          = 115200
 
 [env:mks_tinybee]
 extends                = env:esp32

--- a/platformio.ini
+++ b/platformio.ini
@@ -267,17 +267,10 @@ framework         = arduino
 extra_scripts     = ${common.extra_scripts}
 build_flags       = ${common.build_flags}
 lib_deps          = ${common.lib_deps}
-platform_packages = platformio/tool-dfuutil@^1.11.0
 monitor_speed     = 250000
-monitor_flags     =
-  --quiet
-  --echo
-  --eol
-    LF
-  --filter
-    colorize
-  --filter
-    time
+monitor_eol       = LF
+monitor_echo      = yes
+monitor_filters   = colorize, time, send_on_enter, log2file
 
 #
 # Just print the dependency tree


### PR DESCRIPTION
The `monitor_flags` field is no longer recognized by PlatformIO 6.1.1 so it is replaced, and a preflight check for version 6.1.1 or higher is added.

This can be merged as soon as 6.1.1 is released officially.

CC: @ivankravets 