### PR TITLE
Fix Marlin Simulator Build for Mac M1

### DIFF
--- a/ini/native.ini
+++ b/ini/native.ini
@@ -78,7 +78,7 @@ build_flags = ${simulator_linux.build_flags} ${simulator_linux.release_flags}
 # If Xcode is installed be sure to run `xcode-select --install` first.
 #
 [simulator_macos]
-build_unflags     = -lGL
+build_unflags     = -lGL -fstack-protector-strong
 build_flags       =
   -I/opt/local/include
   -I/opt/local/include/freetype2
@@ -87,6 +87,7 @@ build_flags       =
   -Wl,-framework,OpenGl
   -Wl,-framework,CoreFoundation
   -lSDL2
+  -fno-stack-protector
 
 [env:simulator_macos_debug]
 extends         = env:simulator_linux_debug


### PR DESCRIPTION
Gcc generate bad assembly for stack protector on M1 Macs. Disabling it to use simulator on Mac m1.