### PR TITLE
Fixes for Anet ET4

### DIFF
--- a/Marlin/src/lcd/dogm/u8g_fontutf8.cpp
+++ b/Marlin/src/lcd/dogm/u8g_fontutf8.cpp
@@ -104,7 +104,7 @@ static void fontgroup_drawwchar(font_group_t *group, const font_t *fnt_default, 
  * Get the screen pixel width of a ROM UTF-8 string
  */
 static void fontgroup_drawstring(font_group_t *group, const font_t *fnt_default, const char *utf8_msg, read_byte_cb_t cb_read_byte, void * userdata, fontgroup_cb_draw_t cb_draw_ram) {
-  const uint8_t *p = (uint8_t*)utf8_msg;
+  const char *p = utf8_msg;
   for (;;) {
     lchar_t ch;
     p = get_utf8_value_cb(p, cb_read_byte, ch);

--- a/Marlin/src/lcd/fontutils.h
+++ b/Marlin/src/lcd/fontutils.h
@@ -57,8 +57,8 @@ int pf_bsearch_r(void *userdata, size_t num_data, pf_bsearch_cb_comp_t cb_comp, 
 /* Get the character, decoding multibyte UTF8 characters and returning a pointer to the start of the next UTF8 character */
 const uint8_t* get_utf8_value_cb(const uint8_t *pstart, read_byte_cb_t cb_read_byte, lchar_t &pval);
 
-inline const char* get_utf8_value_cb(const char *pstart, read_byte_cb_t cb_read_byte, lchar_t &pval) {
-  return (const char *)get_utf8_value_cb((const uint8_t *)pstart, cb_read_byte, pval);
+inline const char * get_utf8_value_cb(const char *pstart, read_byte_cb_t cb_read_byte, lchar_t &pval) {
+  return (const char *)get_utf8_value_cb(FTOP(pstart), cb_read_byte, pval);
 }
 
 /* Returns length of string in CHARACTERS, NOT BYTES */

--- a/Marlin/src/lcd/lcdprint.cpp
+++ b/Marlin/src/lcd/lcdprint.cpp
@@ -44,7 +44,7 @@
  */
 lcd_uint_t lcd_put_u8str_P(PGM_P const ptpl, const int8_t ind, const char *cstr/*=nullptr*/, FSTR_P const fstr/*=nullptr*/, const lcd_uint_t maxlen/*=LCD_WIDTH*/) {
   const uint8_t prop = USE_WIDE_GLYPH ? 2 : 1;
-  const uint8_t *p = (uint8_t*)ptpl;
+  const char *p = ptpl;
   int8_t n = maxlen;
   while (n > 0) {
     lchar_t ch;

--- a/Marlin/src/lcd/marlinui.cpp
+++ b/Marlin/src/lcd/marlinui.cpp
@@ -416,10 +416,10 @@ void MarlinUI::init() {
           SETCURSOR(0, row);              // Simulate carriage return
         };
 
-        const uint8_t *p = (uint8_t*)string;
+        const char *p = string;
         lchar_t ch;
         if (wordwrap) {
-          const uint8_t *wrd = nullptr;
+          const char *wrd = nullptr;
           uint8_t c = 0;
           // find the end of the part
           for (;;) {

--- a/Marlin/src/lcd/tft/tft_string.cpp
+++ b/Marlin/src/lcd/tft/tft_string.cpp
@@ -25,7 +25,7 @@
 #if HAS_GRAPHICAL_TFT
 
 #include "tft_string.h"
-#include "../fontutils.h"
+// #include "../fontutils.h"
 #include "../marlinui.h"
 
 //#define DEBUG_TFT_FONT
@@ -112,7 +112,7 @@ void TFT_String::add(const char *tpl, const int8_t index, const char *cstr/*=nul
         add(index == -2 ? GET_TEXT_F(MSG_CHAMBER) : GET_TEXT_F(MSG_BED));
     }
     else if (ch == '$' && fstr)
-      add(fstr);
+      add(fstr); 
     else if (ch == '$' && cstr)
       add(cstr);
     else if (ch == '@')

--- a/Marlin/src/lcd/tft/tft_string.cpp
+++ b/Marlin/src/lcd/tft/tft_string.cpp
@@ -97,7 +97,7 @@ void TFT_String::add(const char *tpl, const int8_t index, const char *cstr/*=nul
   lchar_t lch;
 
   while (*tpl) {
-    tpl = get_utf8_value_cb(tpl, read_byte_ram, ch);
+    tpl = get_utf8_value_cb(tpl, read_byte_ram, lch);
     if (lch > 255) lch |= 0x0080;
     const uint8_t ch = uint8_t(lch & 0x00FF);
 
@@ -126,7 +126,7 @@ void TFT_String::add(const char *tpl, const int8_t index, const char *cstr/*=nul
 void TFT_String::add(const char *cstr, uint8_t max_len/*=MAX_STRING_LENGTH*/) {
   lchar_t lch;
   while (*cstr && max_len) {
-    cstr = get_utf8_value_cb(cstr, read_byte_ram, ch);
+    cstr = get_utf8_value_cb(cstr, read_byte_ram, lch);
     if (lch > 255) lch |= 0x0080;
     const uint8_t ch = uint8_t(lch & 0x00FF);
     add_character(ch);

--- a/Marlin/src/lcd/tft/tft_string.cpp
+++ b/Marlin/src/lcd/tft/tft_string.cpp
@@ -94,12 +94,12 @@ void TFT_String::set() {
  *   @ displays an axis name such as XYZUVW, or E for an extruder
  */
 void TFT_String::add(const char *tpl, const int8_t index, const char *cstr/*=nullptr*/, FSTR_P const fstr/*=nullptr*/) {
-  lchar_t ch;
+  lchar_t lch;
 
   while (*tpl) {
     tpl = get_utf8_value_cb(tpl, read_byte_ram, ch);
-    if (ch > 255) ch |= 0x0080;
-    const uint8_t ch = uint8_t(ch & 0x00FF);
+    if (lch > 255) lch |= 0x0080;
+    const uint8_t ch = uint8_t(lch & 0x00FF);
 
     if (ch == '=' || ch == '~' || ch == '*') {
       if (index >= 0) {
@@ -124,11 +124,11 @@ void TFT_String::add(const char *tpl, const int8_t index, const char *cstr/*=nul
 }
 
 void TFT_String::add(const char *cstr, uint8_t max_len/*=MAX_STRING_LENGTH*/) {
-  lchar_t ch;
+  lchar_t lch;
   while (*cstr && max_len) {
     cstr = get_utf8_value_cb(cstr, read_byte_ram, ch);
-    if (ch > 255) ch |= 0x0080;
-    const uint8_t ch = uint8_t(ch & 0x00FF);
+    if (lch > 255) lch |= 0x0080;
+    const uint8_t ch = uint8_t(lch & 0x00FF);
     add_character(ch);
     max_len--;
   }

--- a/Marlin/src/lcd/tft/tft_string.h
+++ b/Marlin/src/lcd/tft/tft_string.h
@@ -24,6 +24,7 @@
 // TODO: Make AVR-compatible with separate ROM / RAM string methods
 
 #include <stdint.h>
+#include "../fontutils.h"
 
 extern const uint8_t ISO10646_1_5x7[];
 extern const uint8_t font10x20[];

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -678,9 +678,9 @@
 #elif MB(MKS_ROBIN_NANO_V3_1)
   #include "stm32f4/pins_MKS_ROBIN_NANO_V3.h"   // STM32F4                                env:mks_robin_nano_v3_1 env:mks_robin_nano_v3_1_usb_flash_drive env:mks_robin_nano_v3_1_usb_flash_drive_msc
 #elif MB(ANET_ET4)
-  #include "stm32f4/pins_ANET_ET4.h"            // STM32F4                                env:Anet_ET4 env:Anet_ET4_OpenBLT
+  #include "stm32f4/pins_ANET_ET4.h"            // STM32F4                                env:Anet_ET4_OpenBLT
 #elif MB(ANET_ET4P)
-  #include "stm32f4/pins_ANET_ET4P.h"           // STM32F4                                env:Anet_ET4 env:Anet_ET4_OpenBLT
+  #include "stm32f4/pins_ANET_ET4P.h"           // STM32F4                                env:Anet_ET4_OpenBLT
 #elif MB(FYSETC_CHEETAH_V20)
   #include "stm32f4/pins_FYSETC_CHEETAH_V20.h"  // STM32F4                                env:FYSETC_CHEETAH_V20
 #elif MB(MKS_MONSTER8)

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -678,9 +678,9 @@
 #elif MB(MKS_ROBIN_NANO_V3_1)
   #include "stm32f4/pins_MKS_ROBIN_NANO_V3.h"   // STM32F4                                env:mks_robin_nano_v3_1 env:mks_robin_nano_v3_1_usb_flash_drive env:mks_robin_nano_v3_1_usb_flash_drive_msc
 #elif MB(ANET_ET4)
-  #include "stm32f4/pins_ANET_ET4.h"            // STM32F4                                env:Anet_ET4_OpenBLT
+  #include "stm32f4/pins_ANET_ET4.h"            // STM32F4                                env:Anet_ET4 env:Anet_ET4_OpenBLT
 #elif MB(ANET_ET4P)
-  #include "stm32f4/pins_ANET_ET4P.h"           // STM32F4                                env:Anet_ET4_OpenBLT
+  #include "stm32f4/pins_ANET_ET4P.h"           // STM32F4                                env:Anet_ET4 env:Anet_ET4_OpenBLT
 #elif MB(FYSETC_CHEETAH_V20)
   #include "stm32f4/pins_FYSETC_CHEETAH_V20.h"  // STM32F4                                env:FYSETC_CHEETAH_V20
 #elif MB(MKS_MONSTER8)

--- a/buildroot/share/PlatformIO/scripts/openblt.py
+++ b/buildroot/share/PlatformIO/scripts/openblt.py
@@ -10,11 +10,11 @@ if pioutil.is_pio_build():
 
 	board = env.BoardConfig()
 	board_keys = board.get("build").keys()
-	if 'encrypt' in board_keys:
+	if 'encrypt_openblt' in board_keys:
 		env.AddPostAction(
 			join("$BUILD_DIR", "${PROGNAME}.bin"),
 			env.VerboseAction(" ".join([
 				"$OBJCOPY", "-O", "srec",
-				"\"$BUILD_DIR/${PROGNAME}.elf\"", "\"" + join("$BUILD_DIR", board.get("build.encrypt")) + "\""
+				"\"$BUILD_DIR/${PROGNAME}.elf\"", "\"" + join("$BUILD_DIR", board.get("build.encrypt_openblt")) + "\""
 			]), "Building $TARGET")
 		)

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -550,7 +550,7 @@ build_unflags     = -DUSBD_USE_CDC
 extends                     = stm32_variant
 board                       = genericSTM32F405RG
 board_build.variant         = MARLIN_TH3D_EZBOARD_V2
-board_build.encrypt_mks     = firmware.bin
+board_build.encrypt_openblt = firmware.bin
 board_build.offset          = 0xC000
 board_upload.offset_address = 0x0800C000
 build_flags                 = ${stm32_variant.build_flags} -DHSE_VALUE=12000000U -O0

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -107,7 +107,6 @@ extra_scripts     = ${stm32_variant.extra_scripts}
 #
 # Anet ET4-MB_V1.x/ET4P-MB_V1.x (STM32F407VGT6 ARM Cortex-M4)
 # For use with with davidtgbe's OpenBLT bootloader https://github.com/davidtgbe/openblt/releases
-# Comment out board_build.offset = 0x10000 and if you don't plan to use OpenBLT/flashing directly to 0x08000000.
 #
 [env:Anet_ET4_OpenBLT]
 extends                     = stm32_variant
@@ -122,8 +121,21 @@ build_unflags               = ${stm32_variant.build_unflags}
                               -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
 extra_scripts               = ${stm32_variant.extra_scripts}
                               buildroot/share/PlatformIO/scripts/openblt.py
-debug_tool                  = jlink
-upload_protocol             = jlink
+
+#
+# Anet ET4-MB_V1.x/ET4P-MB_V1.x (STM32F407VGT6 ARM Cortex-M4)
+# For direct flashing with with st-link
+#
+[env:Anet_ET4]
+extends                     = stm32_variant
+board                       = marlin_STM32F407VGT6_CCM
+board_build.variant         = MARLIN_F4x7Vx
+build_flags                 = ${stm32_variant.build_flags}
+                              -DHAL_SD_MODULE_ENABLED -DHAL_SRAM_MODULE_ENABLED
+build_unflags               = ${stm32_variant.build_unflags}
+                              -DUSBCON -DUSBD_USE_CDC -DUSBD_VID=0x0483
+debug_tool                  = stlink
+upload_protocol             = stlink
 
 #
 # BigTreeTech SKR Pro (STM32F407ZGT6 ARM Cortex-M4)

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -107,13 +107,13 @@ extra_scripts     = ${stm32_variant.extra_scripts}
 #
 # Anet ET4-MB_V1.x/ET4P-MB_V1.x (STM32F407VGT6 ARM Cortex-M4)
 # For use with with davidtgbe's OpenBLT bootloader https://github.com/davidtgbe/openblt/releases
-# Comment out board_build.offset = 0x10000 if you don't plan to use OpenBLT/flashing directly to 0x08000000.
+# Comment out board_build.offset = 0x10000 and if you don't plan to use OpenBLT/flashing directly to 0x08000000.
 #
 [env:Anet_ET4_OpenBLT]
 extends                     = stm32_variant
 board                       = marlin_STM32F407VGT6_CCM
 board_build.variant         = MARLIN_F4x7Vx
-board_build.encrypt_mks     = firmware.srec
+board_build.encrypt_openblt = firmware.srec
 board_build.offset          = 0x10000
 board_upload.offset_address = 0x08010000
 build_flags                 = ${stm32_variant.build_flags}

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -124,7 +124,7 @@ extra_scripts               = ${stm32_variant.extra_scripts}
 
 #
 # Anet ET4-MB_V1.x/ET4P-MB_V1.x (STM32F407VGT6 ARM Cortex-M4)
-# For direct flashing with with st-link
+# For direct flashing with st-link
 #
 [env:Anet_ET4]
 extends                     = stm32_variant

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = mega2560
+default_envs = Anet_ET4
 include_dir  = Marlin
 extra_configs =
     ini/avr.ini

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@
 [platformio]
 src_dir      = Marlin
 boards_dir   = buildroot/share/PlatformIO/boards
-default_envs = Anet_ET4
+default_envs = mega2560
 include_dir  = Marlin
 extra_configs =
     ini/avr.ini


### PR DESCRIPTION
Fix encrypt stuff broken in #24391.
Add second env for ET4, for clarity sake.
Do TH3D_EZBoard_V2 actually use OpenBLT? Anyway, fixed encrypt there too.

Kinda fix build of COLOR_UI and CLASSIC_UI in linux, but guys say that it breaks build in windows instead... i have no idea what i'm doing. 
Made it all separate commits for cherrypicking. 
Don't megre that stuff without testing in different OS.