### PR TITLE
BigTreeTech SKR SE BX V3.0

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -428,9 +428,10 @@
 #define BOARD_TEENSY41                5001  // Teensy 4.1
 #define BOARD_T41U5XBB                5002  // T41U5XBB Teensy 4.1 breakout board
 #define BOARD_NUCLEO_F767ZI           5003  // ST NUCLEO-F767ZI Dev Board
-#define BOARD_BTT_SKR_SE_BX           5004  // BigTreeTech SKR SE BX (STM32H743II)
-#define BOARD_BTT_SKR_V3_0            5005  // BigTreeTech SKR V3.0 (STM32H743VG)
-#define BOARD_BTT_SKR_V3_0_EZ         5006  // BigTreeTech SKR V3.0 EZ (STM32H743VG)
+#define BOARD_BTT_SKR_SE_BX_V2        5004  // BigTreeTech SKR SE BX V2.0 (STM32H743II)
+#define BOARD_BTT_SKR_SE_BX_V3        5005  // BigTreeTech SKR SE BX V3.0 (STM32H743II)
+#define BOARD_BTT_SKR_V3_0            5006  // BigTreeTech SKR V3.0 (STM32H743VG)
+#define BOARD_BTT_SKR_V3_0_EZ         5007  // BigTreeTech SKR V3.0 EZ (STM32H743VG)
 
 //
 // Espressif ESP32 WiFi

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -706,8 +706,10 @@
   #include "stm32f7/pins_REMRAM_V1.h"           // STM32F7                                env:REMRAM_V1
 #elif MB(NUCLEO_F767ZI)
   #include "stm32f7/pins_NUCLEO_F767ZI.h"       // STM32F7                                env:NUCLEO_F767ZI
-#elif MB(BTT_SKR_SE_BX)
-  #include "stm32h7/pins_BTT_SKR_SE_BX.h"       // STM32H7                                env:BTT_SKR_SE_BX
+#elif MB(BTT_SKR_SE_BX_V2)
+  #include "stm32h7/pins_BTT_SKR_SE_BX_V2.h"    // STM32H7                                env:BTT_SKR_SE_BX
+#elif MB(BTT_SKR_SE_BX_V3)
+  #include "stm32h7/pins_BTT_SKR_SE_BX_V3.h"    // STM32H7                                env:BTT_SKR_SE_BX
 #elif MB(BTT_SKR_V3_0)
   #include "stm32h7/pins_BTT_SKR_V3_0.h"        // STM32H7                                env:STM32H743Vx_btt
 #elif MB(BTT_SKR_V3_0_EZ)
@@ -797,6 +799,7 @@
   #define BOARD_RAMPS_LONGER3D_LK4PRO   99921
   #define BOARD_BTT_SKR_V2_0            99922
   #define BOARD_TH3D_EZBOARD_LITE_V2    99923
+  #define BOARD_BTT_SKR_SE_BX           99924
 
   #if MB(MKS_13)
     #error "BOARD_MKS_13 has been renamed BOARD_MKS_GEN_13. Please update your configuration."
@@ -848,6 +851,8 @@
     #error "BOARD_BTT_SKR_V2_0 is now BOARD_BTT_SKR_V2_0_REV_A or BOARD_BTT_SKR_V2_0_REV_B. See https://bit.ly/3t5d9JQ for more information. Please update your configuration."
   #elif MB(TH3D_EZBOARD_LITE_V2)
     #error "BOARD_TH3D_EZBOARD_LITE_V2 is now BOARD_TH3D_EZBOARD_V2. Please update your configuration."
+  #elif MB(BTT_SKR_SE_BX)
+    #error "BOARD_BTT_SKR_SE_BX is now BOARD_BTT_SKR_SE_BX_V2 or BOARD_BTT_SKR_SE_BX_V3. Please update your configuration."
   #elif defined(MOTHERBOARD)
     #error "Unknown MOTHERBOARD value set in Configuration.h."
   #else
@@ -878,6 +883,7 @@
   #undef BOARD_RAMPS_LONGER3D_LK4PRO
   #undef BOARD_BTT_SKR_V2_0
   #undef BOARD_TH3D_EZBOARD_LITE_V2
+  #undef BOARD_BTT_SKR_SE_BX
 
 #endif
 

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_V2.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_V2.h
@@ -1,0 +1,28 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define BOARD_INFO_NAME      "BTT SKR SE BX V2.0"
+
+#define SAFE_POWER_PIN                      PI11
+
+#include "pins_BTT_SKR_SE_BX_common.h"

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_V3.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_V3.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define BOARD_INFO_NAME      "BTT SKR SE BX V3.0"
+
+#include "pins_BTT_SKR_SE_BX_common.h"

--- a/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_common.h
+++ b/Marlin/src/pins/stm32h7/pins_BTT_SKR_SE_BX_common.h
@@ -25,8 +25,7 @@
   #error "Oops! Select an STM32H7 board in 'Tools > Board.'"
 #endif
 
-#define BOARD_INFO_NAME      "BTT SKR SE BX"
-#define DEFAULT_MACHINE_NAME "BIQU-BX"
+#define DEFAULT_MACHINE_NAME "Biqu BX"
 
 // Onboard I2C EEPROM
 #define I2C_EEPROM
@@ -56,7 +55,6 @@
 #define POWER_MONITOR_PIN                   PB0
 #define RPI_POWER_PIN                       PE5
 
-#define SAFE_POWER_PIN                      PI11
 #define SERVO0_PIN                          PA2
 
 //

--- a/ini/stm32h7.ini
+++ b/ini/stm32h7.ini
@@ -20,7 +20,7 @@
 #################################
 
 #
-# BigTreeTech SKR SE BX (STM32H743IIT6 ARM Cortex-M7)
+# BigTreeTech SKR SE BX V2.0 / V3.0 (STM32H743IIT6 ARM Cortex-M7)
 #
 [env:BTT_SKR_SE_BX]
 extends            = stm32_variant


### PR DESCRIPTION
### Description

SKR SE BX V3.0 removes the Reverse Driver Protection feature. Needs https://github.com/MarlinFirmware/Configurations/pull/774 to pass CI tests.

### Requirements

Biqu BX with BTT SKR SE BX V2/V3.

### Related Issues

- https://github.com/MarlinFirmware/Configurations/pull/774
