### PR TITLE
Fix MKS TinyBee build error (#24440)

### DIFF
--- a/Marlin/src/HAL/ESP32/HAL.h
+++ b/Marlin/src/HAL/ESP32/HAL.h
@@ -60,8 +60,8 @@
   #endif
 #endif
 
-#define CRITICAL_SECTION_START() portENTER_CRITICAL(&spinlock)
-#define CRITICAL_SECTION_END()   portEXIT_CRITICAL(&spinlock)
+#define CRITICAL_SECTION_START() portENTER_CRITICAL(&MarlinHAL::spinlock)
+#define CRITICAL_SECTION_END()   portEXIT_CRITICAL(&MarlinHAL::spinlock)
 
 #define HAL_CAN_SET_PWM_FREQ   // This HAL supports PWM Frequency adjustment
 #define PWM_FREQUENCY  1000u   // Default PWM frequency when set_pwm_duty() is called without set_pwm_frequency()

--- a/Marlin/src/HAL/ESP32/HAL.h
+++ b/Marlin/src/HAL/ESP32/HAL.h
@@ -60,8 +60,8 @@
   #endif
 #endif
 
-#define CRITICAL_SECTION_START() portENTER_CRITICAL(&MarlinHAL::spinlock)
-#define CRITICAL_SECTION_END()   portEXIT_CRITICAL(&MarlinHAL::spinlock)
+#define CRITICAL_SECTION_START() portENTER_CRITICAL(&hal.spinlock)
+#define CRITICAL_SECTION_END()   portEXIT_CRITICAL(&hal.spinlock)
 
 #define HAL_CAN_SET_PWM_FREQ   // This HAL supports PWM Frequency adjustment
 #define PWM_FREQUENCY  1000u   // Default PWM frequency when set_pwm_duty() is called without set_pwm_frequency()


### PR DESCRIPTION
### Description

This PR fixes a regression introduced (presumably) during HAL refactoring and reported in #24440 
It seems that during refactoring the `spinlock` was moved into class and now referencing it directly is not possible.

I barely comprehend C/C++ and this PR needs testing. I have an MKS TinyBee board and will try and see if this fix doesn't break anything.

### Requirements
`Configuration.h`:
```cpp
#define MOTHERBOARD BOARD_MKS_TINYBEE
#define MKS_MINI_12864
#define SPEAKER
```
`platformio.ini`
```ini
default_envs = mks_tinybee
```

### Benefits

Fix build error for MKS TinyBee

### Configurations

[Configuration.zip](https://github.com/MarlinFirmware/Marlin/files/9047339/Configuration.zip)

### Related Issues

- Bug Report #24440
- Regression source #23357
