### PR TITLE
Correct Sensorless Probing (cartesian printers broken by PR #24220)

### DIFF
--- a/Marlin/src/module/delta.cpp
+++ b/Marlin/src/module/delta.cpp
@@ -60,10 +60,6 @@ xy_float_t delta_tower[ABC];
 abc_float_t delta_diagonal_rod_2_tower;
 float delta_clip_start_height = Z_MAX_POS;
 abc_float_t delta_diagonal_rod_trim;
-#if HAS_DELTA_SENSORLESS_PROBING
-  abc_float_t offset_sensorless_adj{0};
-  float largest_sensorless_adj = 0;
-#endif
 
 float delta_safe_distance_from_top();
 

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -39,7 +39,6 @@ extern abc_float_t delta_diagonal_rod_2_tower;
 extern float delta_clip_start_height;
 extern abc_float_t delta_diagonal_rod_trim;
 
-
 /**
  * Recalculate factors used for delta kinematics whenever
  * settings have been changed (e.g., by M665).

--- a/Marlin/src/module/delta.h
+++ b/Marlin/src/module/delta.h
@@ -38,10 +38,7 @@ extern xy_float_t delta_tower[ABC];
 extern abc_float_t delta_diagonal_rod_2_tower;
 extern float delta_clip_start_height;
 extern abc_float_t delta_diagonal_rod_trim;
-#if HAS_DELTA_SENSORLESS_PROBING
-  extern abc_float_t offset_sensorless_adj;
-  extern float largest_sensorless_adj;
-#endif
+
 
 /**
  * Recalculate factors used for delta kinematics whenever

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -872,81 +872,38 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
 
 #endif // HAS_Z_SERVO_PROBE
 
-#if USE_SENSORLESS
-
-  sensorless_t stealth_states { false };
-
-  /**
-   * Disable stealthChop if used. Enable diag1 pin on driver.
-   */
-  void Probe::enable_stallguard_diag1() {
-    #if ENABLED(SENSORLESS_PROBING)
-      #if HAS_DELTA_SENSORLESS_PROBING
-        stealth_states.x = tmc_enable_stallguard(stepperX);
-        stealth_states.y = tmc_enable_stallguard(stepperY);
-      #endif
-      stealth_states.z = tmc_enable_stallguard(stepperZ);
-      endstops.enable(true);
-    #endif
-  }
-
-  /**
-   * Re-enable stealthChop if used. Disable diag1 pin on driver.
-   */
-  void Probe::disable_stallguard_diag1() {
-    #if ENABLED(SENSORLESS_PROBING)
-      endstops.not_homing();
-      #if HAS_DELTA_SENSORLESS_PROBING
-        tmc_disable_stallguard(stepperX, stealth_states.x);
-        tmc_disable_stallguard(stepperY, stealth_states.y);
-      #endif
-      tmc_disable_stallguard(stepperZ, stealth_states.z);
-    #endif
-  }
+#if HAS_DELTA_SENSORLESS_PROBING
 
   /**
    * Set the sensorless Z offset
    */
   void Probe::set_offset_sensorless_adj(const_float_t sz) {
-    #if ENABLED(SENSORLESS_PROBING)
-      DEBUG_SECTION(pso, "Probe::set_offset_sensorless_adj", true);
-      #if HAS_DELTA_SENSORLESS_PROBING
-        if (test_sensitivity.x) offset_sensorless_adj.a = sz;
-        if (test_sensitivity.y) offset_sensorless_adj.b = sz;
-      #endif
-      if (test_sensitivity.z) offset_sensorless_adj.c = sz;
-    #endif
+    DEBUG_SECTION(pso, "Probe::set_offset_sensorless_adj", true);
+    if (test_sensitivity.x) offset_sensorless_adj.a = sz;
+    if (test_sensitivity.y) offset_sensorless_adj.b = sz;
+    if (test_sensitivity.z) offset_sensorless_adj.c = sz;
   }
 
   /**
    * Refresh largest_sensorless_adj based on triggered endstops
    */
   void Probe::refresh_largest_sensorless_adj() {
-    #if ENABLED(SENSORLESS_PROBING)
-      DEBUG_SECTION(rso, "Probe::refresh_largest_sensorless_adj", true);
-      largest_sensorless_adj = -3;                                             // A reference away from any real probe height
-      #if HAS_DELTA_SENSORLESS_PROBING
-        if (TEST(endstops.state(), X_MAX)) {
-          NOLESS(largest_sensorless_adj, offset_sensorless_adj.a);
-          DEBUG_ECHOLNPGM("Endstop_X: ", largest_sensorless_adj, " TowerX");
-        }
-        if (TEST(endstops.state(), Y_MAX)) {
-          NOLESS(largest_sensorless_adj, offset_sensorless_adj.b);
-          DEBUG_ECHOLNPGM("Endstop_Y: ", largest_sensorless_adj, " TowerY");
-        }
-        if (TEST(endstops.state(), Z_MAX)) {
-          NOLESS(largest_sensorless_adj, offset_sensorless_adj.c);
-          DEBUG_ECHOLNPGM("Endstop_Z: ", largest_sensorless_adj, " TowerZ");
-        }
-      #else
-        if (TEST(endstops.state(), Z_ENDSTOP)) {
-          NOLESS(largest_sensorless_adj, offset_sensorless_adj.c);
-          DEBUG_ECHOLNPGM("Endstop_Z: ", largest_sensorless_adj, " Z endstop");
-        }
-      #endif
-    #endif
+    DEBUG_SECTION(rso, "Probe::refresh_largest_sensorless_adj", true);
+    largest_sensorless_adj = -3;  // A reference away from any real probe height
+    if (TEST(endstops.state(), X_MAX)) {
+      NOLESS(largest_sensorless_adj, offset_sensorless_adj.a);
+      DEBUG_ECHOLNPGM("Endstop_X: ", largest_sensorless_adj, " TowerX");
+    }
+    if (TEST(endstops.state(), Y_MAX)) {
+      NOLESS(largest_sensorless_adj, offset_sensorless_adj.b);
+      DEBUG_ECHOLNPGM("Endstop_Y: ", largest_sensorless_adj, " TowerY");
+    }
+    if (TEST(endstops.state(), Z_MAX)) {
+      NOLESS(largest_sensorless_adj, offset_sensorless_adj.c);
+      DEBUG_ECHOLNPGM("Endstop_Z: ", largest_sensorless_adj, " TowerZ");
+    }
   }
 
-#endif // SENSORLESS_PROBING || SENSORLESS_HOMING
+#endif
 
 #endif // HAS_BED_PROBE

--- a/Marlin/src/module/probe.cpp
+++ b/Marlin/src/module/probe.cpp
@@ -48,6 +48,11 @@
   #include "delta.h"
 #endif
 
+#if ENABLED(SENSORLESS_PROBING)
+  abc_float_t offset_sensorless_adj{0};
+  float largest_sensorless_adj = 0;
+#endif
+
 #if ANY(HAS_QUIET_PROBING, USE_SENSORLESS)
   #include "stepper/indirection.h"
   #if BOTH(HAS_QUIET_PROBING, PROBING_ESTEPPERS_OFF)
@@ -929,11 +934,16 @@ float Probe::probe_at_point(const_float_t rx, const_float_t ry, const ProbePtRai
           NOLESS(largest_sensorless_adj, offset_sensorless_adj.b);
           DEBUG_ECHOLNPGM("Endstop_Y: ", largest_sensorless_adj, " TowerY");
         }
+        if (TEST(endstops.state(), Z_MAX)) {
+          NOLESS(largest_sensorless_adj, offset_sensorless_adj.c);
+          DEBUG_ECHOLNPGM("Endstop_Z: ", largest_sensorless_adj, " TowerZ");
+        }
+      #else
+        if (TEST(endstops.state(), Z_ENDSTOP)) {
+          NOLESS(largest_sensorless_adj, offset_sensorless_adj.c);
+          DEBUG_ECHOLNPGM("Endstop_Z: ", largest_sensorless_adj, " Z endstop");
+        }
       #endif
-      if (TEST(endstops.state(), Z_MAX)) {
-        NOLESS(largest_sensorless_adj, offset_sensorless_adj.c);
-        DEBUG_ECHOLNPGM("Endstop_Z: ", largest_sensorless_adj, " TowerZ");
-      }
     #endif
   }
 

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -302,9 +302,7 @@ public:
   #endif
 
   // Basic functions for Sensorless Homing and Probing
-  #if USE_SENSORLESS
-    static void enable_stallguard_diag1();
-    static void disable_stallguard_diag1();
+  #if HAS_DELTA_SENSORLESS_PROBING
     static void set_offset_sensorless_adj(const_float_t sz);
     static void refresh_largest_sensorless_adj();
   #endif

--- a/Marlin/src/module/probe.h
+++ b/Marlin/src/module/probe.h
@@ -62,16 +62,16 @@
   #endif
 #endif
 
+#if ENABLED(SENSORLESS_PROBING)
+  extern abc_float_t offset_sensorless_adj;
+#endif
+
 class Probe {
 public:
 
   #if ENABLED(SENSORLESS_PROBING)
     typedef struct {
-      #if HAS_DELTA_SENSORLESS_PROBING
         bool x:1, y:1, z:1;
-      #else
-        bool z;
-      #endif
     } sense_bool_t;
     static sense_bool_t test_sensitivity;
   #endif


### PR DESCRIPTION
PNR [#24220](https://github.com/MarlinFirmware/Marlin/pull/24220#:~:text=G28%2C%20G33%2C%20M48%E2%80%9D-,%2324220,-Merged) added sensorless probing for delta printers but it broke the cartesian probing. When selecting a cartesian printer, the variables **test_sensitivity** and **offset_sensorless_adj** were not defined and the Z endstop test assmed Z_MAX only.  The variable issues cause compile time errors

This fixes the bug from Issue #24447.  See that issue for details.

---

**Changes**:

1. Move sensorless probing variables from DELTA to PROBE modules.  **test_sensitivity** and **offset_sensorless_adj** were not used in delta.h or delta.cpp.  Makes more sense to declare & initialize them in modules that use them.

2. Make variable **sense_bool_t** always have X, Y & Z elements.  Cartesian printers use only the Z element.  Costs a couple of float variables but makes the code much easier to follow.

3. Added cartesian specific endstop test to PROBE.CPP and moved the delta specific one in with the other delta endstop tests..  The current test assumed Z_MAX which is OK for deltas but may not be the case for cartsian printers.
