### PR TITLE
E3V2 ProUI: Fix LED compile errors

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -2259,7 +2259,11 @@ void SetPID(celsius_t t, heater_id_t h) {
     }
   #endif
   #if HAS_COLOR_LEDS
-    void ApplyLEDColor() { HMI_data.Led_Color = TERN(HAS_WHITE_LED, LEDColor({0, 0, 0, leds.color.w}), LEDColor({leds.color.r, leds.color.g, leds.color.b})); }
+    void ApplyLEDColor() {
+      HMI_data.Led_Color = LEDColor(
+        TERN(HAS_WHITE_LED, { 0, 0, 0, leds.color.w }, { leds.color.r, leds.color.g, leds.color.b })
+      );
+    }
     void LiveLEDColor(uint8_t *color) { *color = MenuData.Value; leds.update(); }
     void LiveLEDColorR() { LiveLEDColor(&leds.color.r); }
     void LiveLEDColorG() { LiveLEDColor(&leds.color.g); }

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1850,10 +1850,10 @@ void DWIN_CopySettingsFrom(const char * const buff) {
   #endif
   #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
     leds.set_color(
-      (HMI_data.LED_Color >> 16) & 0xFF,
-      (HMI_data.LED_Color >>  8) & 0xFF,
-      (HMI_data.LED_Color >>  0) & 0xFF
-      OPTARG(HAS_WHITE_LED, (HMI_data.LED_Color >> 24) & 0xFF)
+      HMI_data.Led_Color.r,
+      HMI_data.Led_Color.g,
+      HMI_data.Led_Color.b
+      OPTARG(HAS_WHITE_LED, HMI_data.Led_Color.w)
     );
     leds.update();
   #endif
@@ -2264,7 +2264,7 @@ void SetPID(celsius_t t, heater_id_t h) {
     }
   #endif
   #if HAS_COLOR_LEDS
-    void ApplyLEDColor() { HMI_data.LED_Color = TERN0(HAS_WHITE_LED, (leds.color.w << 24)) | (leds.color.r << 16) | (leds.color.g << 8) | leds.color.b; }
+    void ApplyLEDColor() { HMI_data.Led_Color = TERN(HAS_WHITE_LED, LEDColor({0, 0, 0, leds.color.w}), LEDColor({leds.color.r, leds.color.g, leds.color.b})); }
     void LiveLEDColor(uint8_t *color) { *color = MenuData.Value; leds.update(); }
     void LiveLEDColorR() { LiveLEDColor(&leds.color.r); }
     void LiveLEDColorG() { LiveLEDColor(&leds.color.g); }

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1843,11 +1843,6 @@ void DWIN_CopySettingsFrom(const char * const buff) {
   TERN_(PREVENT_COLD_EXTRUSION, ApplyExtMinT());
   feedrate_percentage = 100;
   TERN_(BAUD_RATE_GCODE, HMI_SetBaudRate());
-  #if BOTH(CASE_LIGHT_MENU, CASELIGHT_USES_BRIGHTNESS)
-    // Apply Case light brightness
-    caselight.brightness = HMI_data.CaseLight_Brightness;
-    caselight.update_brightness();
-  #endif
   #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
     leds.set_color(
       HMI_data.Led_Color.r,

--- a/Marlin/src/lcd/e3v2/proui/dwin_defines.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_defines.h
@@ -69,7 +69,7 @@
 #define HAS_ESDIAG 1
 
 #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
-  #define Def_Leds_Color 0xFFFFFFFF
+  #define Def_Leds_Color      LEDColorWhite()
 #endif
 #if ENABLED(CASELIGHT_USES_BRIGHTNESS)
   #define Def_CaseLight_Brightness 255
@@ -115,12 +115,16 @@ typedef struct {
     bool Baud115K = false;
   #endif
   bool FullManualTramming = false;
-  // Led
   #if ENABLED(MESH_BED_LEVELING)
     float ManualZOffset = 0;
   #endif
+  // Led
   #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
-    uint32_t LED_Color = Def_Leds_Color;
+    LEDColor Led_Color = Def_Leds_Color;
+  #endif
+  // Case Light
+  #if ENABLED(CASELIGHT_USES_BRIGHTNESS)
+    uint8_t CaseLight_Brightness = Def_CaseLight_Brightness;
   #endif
 } HMI_data_t;
 

--- a/Marlin/src/lcd/e3v2/proui/dwin_defines.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_defines.h
@@ -71,9 +71,6 @@
 #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
   #define Def_Leds_Color      LEDColorWhite()
 #endif
-#if ENABLED(CASELIGHT_USES_BRIGHTNESS)
-  #define Def_CaseLight_Brightness 255
-#endif
 
 typedef struct {
   // Color settings
@@ -121,10 +118,6 @@ typedef struct {
   // Led
   #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
     LEDColor Led_Color = Def_Leds_Color;
-  #endif
-  // Case Light
-  #if ENABLED(CASELIGHT_USES_BRIGHTNESS)
-    uint8_t CaseLight_Brightness = Def_CaseLight_Brightness;
   #endif
 } HMI_data_t;
 


### PR DESCRIPTION
### Description

This PR addresses some compile error on ProUI when the switches: `NEOPIXEL_LED`, `LED_CONTROL_MENU` and `CASE_LIGHT_USE_NEOPIXEL` are enabled.

### Requirements

E3V2 - ProUI

### Benefits

Allow compile without errors

### Configurations

none

### Related Issues

none
