### PR TITLE
Swap extruder speed values on MKS UI extruder screen

### DIFF
--- a/Marlin/src/lcd/extui/mks_ui/draw_ui.h
+++ b/Marlin/src/lcd/extui/mks_ui/draw_ui.h
@@ -236,9 +236,9 @@ typedef struct UI_Config_Struct {
                            eStepMax = 10;
   // Extruder speed (mm/s)
   uint8_t extruSpeed;
-  static constexpr uint8_t eSpeedH =  1,
+  static constexpr uint8_t eSpeedH = 20,
                            eSpeedN = 10,
-                           eSpeedL = 20;
+                           eSpeedL =  1;
   uint8_t print_state;
   uint8_t stepPrintSpeed;
   uint8_t waitEndMoves;


### PR DESCRIPTION
High speed and low speed had their values swapped around, this changes swaps them so that High is 20mm/sec and Low is 1mm/sec.

### Description

Correct "High" and "Low" speeds on the extruder screen in the graphical MKS GUI

eSpeedH was set to 1mm/sec and is now 20mm/sec
eSpeedL was set to 20mm/sec and is now 1mm/sec

These were the wrong way around, so this change swaps the two values so that the extruder speeds match their labels.

### Requirements

Problem was found with the MKS Robin Nano and MKS TFT35

### Benefits

Makes the extruder speeds in the MKS LVGL UI work as advertised instead of being inverted (i.e. "High" speed is slow and "Low" speed is fast.

### Configurations

Requires TFT_LVGL_UI and possibly MKS_ROBIN_TFT35 to be defined.

### Related Issues