### PR TITLE
Add config-dump custom target that dumps current config as a set of opt_* calls

### DIFF
--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -251,12 +251,12 @@ if pioutil.is_pio_build():
 
 	from signature import compute_build_signature
 	compute_build_signature(env)
-		
+
 	def config_dump_target(*args, **kwargs):
 		if 'BUILD_SIGNATURE' not in env:
 			print("Can't generate config dump")
 			return
-		
+
 		opt_output = True
 		key = 'config-dump'
 		output_suffix = '.sh'

--- a/buildroot/share/PlatformIO/scripts/common-dependencies.py
+++ b/buildroot/share/PlatformIO/scripts/common-dependencies.py
@@ -251,3 +251,30 @@ if pioutil.is_pio_build():
 
 	from signature import compute_build_signature
 	compute_build_signature(env)
+		
+	def config_dump_target(*args, **kwargs):
+		if 'BUILD_SIGNATURE' not in env:
+			print("Can't generate config dump")
+			return
+		
+		opt_output = True
+		key = 'config-dump'
+		output_suffix = '.sh'
+		outfile = open('./' + key + output_suffix, 'w')
+		for k, v in env['BUILD_SIGNATURE'].items():
+			if opt_output:
+				if v != '':
+					if '"' in v:
+						v = "'%s'" % v
+					elif ' ' in v:
+						v = '"%s"' % v
+					define = 'opt_set ' + k + ' ' + v + '\n'
+				else:
+					define = 'opt_enable ' + k + '\n'
+			else:
+				define = '#define ' + k + ' ' + v + '\n'
+			print(define)
+			outfile.write(define)
+		outfile.close()
+
+	env.AddCustomTarget("dump-config", None, config_dump_target)

--- a/buildroot/share/PlatformIO/scripts/signature.py
+++ b/buildroot/share/PlatformIO/scripts/signature.py
@@ -109,9 +109,6 @@ def compute_build_signature(env):
 
 		defines[key] = value if len(value) else ""
 
-	if not 'CONFIGURATION_EMBEDDING' in defines:
-		return
-
 	# Second step is to filter useless macro
 	resolved_defines = {}
 	for key in defines:
@@ -130,6 +127,10 @@ def compute_build_signature(env):
 
 		# Don't be that smart guy here
 		resolved_defines[key] = defines[key]
+
+	env['BUILD_SIGNATURE'] = resolved_defines
+	if not 'CONFIGURATION_EMBEDDING' in defines:
+		return
 
 	# Generate a build signature now
 	# We are making an object that's a bit more complex than a basic dictionary here


### PR DESCRIPTION
### Description

It's a draft of a config-dump target. 

The idea comes from @ellensp hint to use a set of `opt_*` calls to do `git bisect` instead of the actual configuration headers.

you run:
```
 ~/.platformio/penv/bin/pio run -t dump-config 
```
it will generate the file `config-dump.sh` with all `opt_set` and `opt_enable` to recreate the current config.

