### PR TITLE
Add MKS Monster8 V2

### DIFF
--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -408,17 +408,18 @@
 #define BOARD_MKS_ROBIN_PRO_V2        4227  // MKS Robin Pro V2 (STM32F407VE)
 #define BOARD_MKS_ROBIN_NANO_V3       4228  // MKS Robin Nano V3 (STM32F407VG)
 #define BOARD_MKS_ROBIN_NANO_V3_1     4229  // MKS Robin Nano V3.1 (STM32F407VE)
-#define BOARD_MKS_MONSTER8            4230  // MKS Monster8 (STM32F407VG)
-#define BOARD_ANET_ET4                4231  // ANET ET4 V1.x (STM32F407VG)
-#define BOARD_ANET_ET4P               4232  // ANET ET4P V1.x (STM32F407VG)
-#define BOARD_FYSETC_CHEETAH_V20      4233  // FYSETC Cheetah V2.0
-#define BOARD_TH3D_EZBOARD_V2         4234  // TH3D EZBoard v2.0
-#define BOARD_OPULO_LUMEN_REV3        4235  // Opulo Lumen PnP Controller REV3 (STM32F407VE/VG)
-#define BOARD_MKS_ROBIN_NANO_V1_3_F4  4236  // MKS Robin Nano V1.3 and MKS Robin Nano-S V1.3 (STM32F407VE)
-#define BOARD_MKS_EAGLE               4237  // MKS Eagle (STM32F407VE)
-#define BOARD_ARTILLERY_RUBY          4238  // Artillery Ruby (STM32F401RC)
-#define BOARD_FYSETC_SPIDER_V2_2      4239  // FYSETC Spider V2.2 (STM32F446VE)
-#define BOARD_CREALITY_V24S1_301F4    4240  // Creality v2.4.S1_301F4 (STM32F401RC) as found in the Ender-3 S1 F4
+#define BOARD_MKS_MONSTER8_V1         4230  // MKS Monster8 V1 (STM32F407VG)
+#define BOARD_MKS_MONSTER8_V2         4231  // MKS Monster8 V2 (STM32F407VG)
+#define BOARD_ANET_ET4                4232  // ANET ET4 V1.x (STM32F407VG)
+#define BOARD_ANET_ET4P               4233  // ANET ET4P V1.x (STM32F407VG)
+#define BOARD_FYSETC_CHEETAH_V20      4234  // FYSETC Cheetah V2.0
+#define BOARD_TH3D_EZBOARD_V2         4235  // TH3D EZBoard v2.0
+#define BOARD_OPULO_LUMEN_REV3        4236  // Opulo Lumen PnP Controller REV3 (STM32F407VE/VG)
+#define BOARD_MKS_ROBIN_NANO_V1_3_F4  4237  // MKS Robin Nano V1.3 and MKS Robin Nano-S V1.3 (STM32F407VE)
+#define BOARD_MKS_EAGLE               4238  // MKS Eagle (STM32F407VE)
+#define BOARD_ARTILLERY_RUBY          4239  // Artillery Ruby (STM32F401RC)
+#define BOARD_FYSETC_SPIDER_V2_2      4240  // FYSETC Spider V2.2 (STM32F446VE)
+#define BOARD_CREALITY_V24S1_301F4    4241  // Creality v2.4.S1_301F4 (STM32F401RC) as found in the Ender-3 S1 F4
 
 //
 // ARM Cortex M7

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -683,8 +683,10 @@
   #include "stm32f4/pins_ANET_ET4P.h"           // STM32F4                                env:Anet_ET4_no_bootloader env:Anet_ET4_OpenBLT
 #elif MB(FYSETC_CHEETAH_V20)
   #include "stm32f4/pins_FYSETC_CHEETAH_V20.h"  // STM32F4                                env:FYSETC_CHEETAH_V20
-#elif MB(MKS_MONSTER8)
-  #include "stm32f4/pins_MKS_MONSTER8.h"        // STM32F4                                env:mks_monster8 env:mks_monster8_usb_flash_drive env:mks_monster8_usb_flash_drive_msc
+#elif MB(MKS_MONSTER8_V1)
+  #include "stm32f4/pins_MKS_MONSTER8_V1.h"     // STM32F4                                env:mks_monster8 env:mks_monster8_usb_flash_drive env:mks_monster8_usb_flash_drive_msc
+#elif MB(MKS_MONSTER8_V2)
+  #include "stm32f4/pins_MKS_MONSTER8_V2.h"     // STM32F4                                env:mks_monster8 env:mks_monster8_usb_flash_drive env:mks_monster8_usb_flash_drive_msc
 #elif MB(TH3D_EZBOARD_V2)
   #include "stm32f4/pins_TH3D_EZBOARD_V2.h"     // STM32F4                                env:TH3D_EZBoard_V2_no_bootloader env:TH3D_EZBoard_V2_OpenBLT
 #elif MB(OPULO_LUMEN_REV3)
@@ -800,6 +802,7 @@
   #define BOARD_BTT_SKR_V2_0            99922
   #define BOARD_TH3D_EZBOARD_LITE_V2    99923
   #define BOARD_BTT_SKR_SE_BX           99924
+  #define BOARD_MKS_MONSTER8            99925
 
   #if MB(MKS_13)
     #error "BOARD_MKS_13 has been renamed BOARD_MKS_GEN_13. Please update your configuration."
@@ -853,6 +856,8 @@
     #error "BOARD_TH3D_EZBOARD_LITE_V2 is now BOARD_TH3D_EZBOARD_V2. Please update your configuration."
   #elif MB(BTT_SKR_SE_BX)
     #error "BOARD_BTT_SKR_SE_BX is now BOARD_BTT_SKR_SE_BX_V2 or BOARD_BTT_SKR_SE_BX_V3. Please update your configuration."
+  #elif MB(MKS_MONSTER8)
+    #error "BOARD_MKS_MONSTER8 is now BOARD_MKS_MONSTER8_V1 or BOARD_MKS_MONSTER8_V2. Please update your configuration."
   #elif defined(MOTHERBOARD)
     #error "Unknown MOTHERBOARD value set in Configuration.h."
   #else
@@ -884,6 +889,7 @@
   #undef BOARD_BTT_SKR_V2_0
   #undef BOARD_TH3D_EZBOARD_LITE_V2
   #undef BOARD_BTT_SKR_SE_BX
+  #undef BOARD_MKS_MONSTER8
 
 #endif
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V1.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V1.h
@@ -23,13 +23,16 @@
 
 #define BOARD_INFO_NAME "MKS Monster8 V1"
 
-// Limit Switches for endstops
+//
+// Limit Switches
+//
 #define X_MAX_PIN                           PA13
 #define Y_MAX_PIN                           PC5
 
+//
 // Steppers
-//Driver7
-#define E4_ENABLE_PIN                       PD14
+//
+#define E4_ENABLE_PIN                       PD14  // Driver7
 
 //
 // Misc. Functions

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V1.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V1.h
@@ -1,0 +1,48 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define BOARD_INFO_NAME "MKS Monster8 V1"
+
+// Limit Switches for endstops
+#define X_MAX_PIN                           PA13
+#define Y_MAX_PIN                           PC5
+
+// Steppers
+//Driver7
+#define E4_ENABLE_PIN                       PD14
+
+//
+// Misc. Functions
+//
+#define PW_DET                               PC5  // Y+
+#define PW_OFF                              PB12  // Z+
+#define MT_DET_1_PIN                      PW_DET
+#define MT_DET_2_PIN                      PW_OFF
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN            MT_DET_1_PIN
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN           MT_DET_2_PIN
+#endif
+
+#include "pins_MKS_MONSTER8_common.h"

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
@@ -23,9 +23,10 @@
 
 #define BOARD_INFO_NAME "MKS Monster8 V2"
 
+//
 // Steppers
-//Driver7
-#define E4_ENABLE_PIN                       PB6
+//
+#define E4_ENABLE_PIN                       PB6   // Driver7
 
 //
 // Misc. Functions
@@ -41,7 +42,9 @@
   #define FIL_RUNOUT2_PIN           MT_DET_2_PIN
 #endif
 
+//
 // MKS WIFI MODULE
+//
 //#define WIFI_SERIAL 1// USART1
 #if ENABLED(MKS_WIFI_MODULE)
   #define WIFI_IO0_PIN PB14	// MKS ESP WIFI IO0 PIN

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_V2.h
@@ -1,0 +1,54 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+#define BOARD_INFO_NAME "MKS Monster8 V2"
+
+// Steppers
+//Driver7
+#define E4_ENABLE_PIN                       PB6
+
+//
+// Misc. Functions
+//
+#define PW_DET                              PA13  // MT_DET
+#define PW_OFF                              PB12  // Z+
+#define MT_DET_1_PIN                      PW_DET
+#define MT_DET_2_PIN                      PW_OFF
+#ifndef FIL_RUNOUT_PIN
+  #define FIL_RUNOUT_PIN            MT_DET_1_PIN
+#endif
+#ifndef FIL_RUNOUT2_PIN
+  #define FIL_RUNOUT2_PIN           MT_DET_2_PIN
+#endif
+
+// MKS WIFI MODULE
+//#define WIFI_SERIAL 1// USART1
+#if ENABLED(MKS_WIFI_MODULE)
+  #define WIFI_IO0_PIN PB14	// MKS ESP WIFI IO0 PIN
+  #define WIFI_IO1_PIN PB15	// MKS ESP WIFI IO1 PIN
+  #define WIFI_RESET_PIN PD14 // MKS ESP WIFI RESET PIN
+#endif
+
+#define NEOPIXEL_PIN                         PC5
+
+#include "pins_MKS_MONSTER8_common.h"

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
@@ -71,60 +71,57 @@
 
 //
 // Steppers
-// Driver 0  1  2  3  4  5  6  7
-// For    X  Y  Z  E0 E1 E2 E3 E4(default pin settings)
 //
-//Driver0
-#define X_ENABLE_PIN                        PC15
+#define X_ENABLE_PIN                        PC15  // Driver0
 #define X_STEP_PIN                          PC14
 #define X_DIR_PIN                           PC13
 #ifndef X_CS_PIN
   #define X_CS_PIN                          PE6
 #endif
-//Driver1
-#define Y_ENABLE_PIN                        PC15
+
+#define Y_ENABLE_PIN                        PC15  // Driver1
 #define Y_STEP_PIN                          PE5
 #define Y_DIR_PIN                           PE4
 #ifndef Y_CS_PIN
   #define Y_CS_PIN                          PE3
 #endif
-//Driver2
-#define Z_ENABLE_PIN                        PE2
+
+#define Z_ENABLE_PIN                        PE2   // Driver2
 #define Z_STEP_PIN                          PE1
 #define Z_DIR_PIN                           PE0
 #ifndef Z_CS_PIN
   #define Z_CS_PIN                          PB7
 #endif
-//Driver3
-#define E0_ENABLE_PIN                       PB6
+
+#define E0_ENABLE_PIN                       PB6   // Driver3
 #define E0_STEP_PIN                         PB5
 #define E0_DIR_PIN                          PB4
 #ifndef E0_CS_PIN
   #define E0_CS_PIN                         PB3
 #endif
-//Driver4
-#define E1_ENABLE_PIN                       PD7
+
+#define E1_ENABLE_PIN                       PD7   // Driver4
 #define E1_STEP_PIN                         PD6
 #define E1_DIR_PIN                          PD5
 #ifndef E1_CS_PIN
   #define E1_CS_PIN                         PD4
 #endif
-//Driver5
-#define E2_ENABLE_PIN                       PD3
+
+#define E2_ENABLE_PIN                       PD3   // Driver5
 #define E2_STEP_PIN                         PD2
 #define E2_DIR_PIN                          PD1
 #ifndef E2_CS_PIN
   #define E2_CS_PIN                         PD0
 #endif
-//Driver6
-#define E3_ENABLE_PIN                       PC8
+
+#define E3_ENABLE_PIN                       PC8   // Driver6
 #define E3_STEP_PIN                         PC7
 #define E3_DIR_PIN                          PC6
 #ifndef E3_CS_PIN
   #define E3_CS_PIN                         PD15
 #endif
-//Driver7
-#define E4_STEP_PIN                         PD13
+
+#define E4_STEP_PIN                         PD13  // Driver7
 #define E4_DIR_PIN                          PD12
 #ifndef E4_CS_PIN
   #define E4_CS_PIN                         PD11
@@ -328,8 +325,8 @@
     #define DOGLCD_CS                EXP1_05_PIN
     #define DOGLCD_SCK               EXP2_09_PIN
     #define DOGLCD_MOSI              EXP2_05_PIN
-    //#define LCD_BACKLIGHT_PIN               -1
-    //#define LCD_RESET_PIN                   -1
+    //#define LCD_BACKLIGHT_PIN             -1
+    //#define LCD_RESET_PIN                 -1
 
   #elif ENABLED(FYSETC_MINI_12864_2_1)
 

--- a/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
+++ b/Marlin/src/pins/stm32f4/pins_MKS_MONSTER8_common.h
@@ -30,8 +30,6 @@
   #error "MKS Monster doesn't support FSMC-based TFT displays."
 #endif
 
-#define BOARD_INFO_NAME "MKS Monster8 V1.x"
-
 #define HAS_OTG_USB_HOST_SUPPORT                  // USB Flash Drive support
 #define USES_DIAG_JUMPERS
 
@@ -54,22 +52,20 @@
 #define SERVO0_PIN                          PA8   // Enable BLTOUCH
 
 //
-// Limit Switches for diag signal
+// Limit Switches for diag signals
 //
-#define X_DIAG_PIN                          PA14  // Driver0 diag signal is connect to X-
-#define Y_DIAG_PIN                          PA15  // Driver1 diag signal is connect to Y-
-#define Z_DIAG_PIN                          PB13  // Driver2 diag signal is connect to Z-
-#define E0_DIAG_PIN                         PA13  // Driver3 diag signal is connect to X+
-#define E1_DIAG_PIN                         PC5   // Driver4 diag signal is connect to Y+
-#define E2_DIAG_PIN                         PB12  // Driver5 diag signal is connect to Z+
-#define E3_DIAG_PIN                         -1    // Driver6 diag signal is not connect
-#define E4_DIAG_PIN                         -1    // Driver7 diag signal is not connect
+#define X_DIAG_PIN                          PA14  // Driver0 diag signal is connected to X-
+#define Y_DIAG_PIN                          PA15  // Driver1 diag signal is connected to Y-
+#define Z_DIAG_PIN                          PB13  // Driver2 diag signal is connected to Z-
+#define E0_DIAG_PIN                         PA13  // Driver3 diag signal is connected to X+
+#define E1_DIAG_PIN                         PC5   // Driver4 diag signal is connected to Y+
+#define E2_DIAG_PIN                         PB12  // Driver5 diag signal is connected to Z+
+#define E3_DIAG_PIN                         -1    // Driver6 diag signal is not connected
+#define E4_DIAG_PIN                         -1    // Driver7 diag signal is not connected
 
-// Limit Switches for endstop
+// Limit Switches for endstops
 #define X_MIN_PIN                           PA14
-#define X_MAX_PIN                           PA13
 #define Y_MIN_PIN                           PA15
-#define Y_MAX_PIN                           PC5
 #define Z_MIN_PIN                           PB13
 #define Z_MAX_PIN                           PB12
 
@@ -128,7 +124,6 @@
   #define E3_CS_PIN                         PD15
 #endif
 //Driver7
-#define E4_ENABLE_PIN                       PD14
 #define E4_STEP_PIN                         PD13
 #define E4_DIR_PIN                          PD12
 #ifndef E4_CS_PIN
@@ -206,20 +201,6 @@
 #define FAN_PIN                             PA2   // FAN0
 #define FAN1_PIN                            PA1   // FAN1
 #define FAN2_PIN                            PA0   // FAN2
-
-//
-// Misc. Functions
-//
-#define PW_DET                              PC5   // Y+
-#define PW_OFF                              PB12  // Z+
-#define MT_DET_1_PIN                      PW_DET
-#define MT_DET_2_PIN                      PW_OFF
-#ifndef FIL_RUNOUT_PIN
-  #define FIL_RUNOUT_PIN            MT_DET_1_PIN
-#endif
-#ifndef FIL_RUNOUT2_PIN
-  #define FIL_RUNOUT2_PIN           MT_DET_2_PIN
-#endif
 
 //
 // Power Supply Control

--- a/ini/stm32f4.ini
+++ b/ini/stm32f4.ini
@@ -515,7 +515,7 @@ build_unflags     = -DUSBD_USE_CDC
 build_flags = -DPIN_WIRE_SCL=PB8 -DPIN_WIRE_SDA=PB9
 
 #
-# MKS Monster8
+# MKS Monster8 V1 / V2 (STM32F407VET6 ARM Cortex-M4)
 #
 [env:mks_monster8]
 extends                     = stm32_variant
@@ -531,7 +531,7 @@ debug_tool                  = jlink
 upload_protocol             = jlink
 
 #
-# MKS Monster8 with USB Flash Drive Support
+# MKS Monster8 V1 / V2 (STM32F407VET6 ARM Cortex-M4) with USB Flash Drive Support
 # Currently, using a STM32duino fork, until USB Host get merged
 #
 [env:mks_monster8_usb_flash_drive]
@@ -544,7 +544,7 @@ build_flags       = ${stm_flash_drive.build_flags} ${stm32f4_I2C1_CAN.build_flag
                     -DUSE_USB_HS_IN_FS
 
 #
-# MKS Monster8 with USB Flash Drive Support and Shared Media
+# MKS Monster8 V1 / V2 (STM32F407VET6 ARM Cortex-M4) with USB Flash Drive Support and Shared Media
 # Currently, using a STM32duino fork, until USB Host and USB Device MSC get merged
 #
 [env:mks_monster8_usb_flash_drive_msc]


### PR DESCRIPTION
### Description

Add MKS Monster8 V2. Notable pins changes include:
- Add NeoPixel pin
- Add WiFi
- Dropped X & Y max pins
- "MT Det"/`FIL_RUNOUT_PIN` changed
- Driver 7 (8)/`E4_STEP_PIN` changed

Note: I kept the existing V1 pins logic for power detect, power off, and material detect/filament runout section in the V2 pins file which is why it may look a bit off. It would be fantastic if MKS' UIs used standard filament runout pin names, but I didn't dig into the reason why they need to be special.