### PR TITLE
Planner optimisations

### DIFF
--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -223,7 +223,7 @@ float Planner::previous_nominal_speed;
 #ifdef XY_FREQUENCY_LIMIT
   int8_t Planner::xy_freq_limit_hz = XY_FREQUENCY_LIMIT;
   float Planner::xy_freq_min_speed_factor = (XY_FREQUENCY_MIN_PERCENT) * 0.01f;
-  int32_t Planner::xy_freq_min_interval_us = LROUND(1000000.0 / (XY_FREQUENCY_LIMIT));
+  int32_t Planner::xy_freq_min_interval_us = LROUND(1000000.0f / (XY_FREQUENCY_LIMIT));
 #endif
 
 #if ENABLED(LIN_ADVANCE)
@@ -803,9 +803,9 @@ void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t
   if (accel != 0) {
     // Steps required for acceleration, deceleration to/from nominal rate
     const float nominal_rate_sq = sq(float(block->nominal_rate));
-    float accelerate_steps_float = (nominal_rate_sq - sq(float(initial_rate))) * (0.5 / accel);
+    float accelerate_steps_float = (nominal_rate_sq - sq(float(initial_rate))) * (0.5f / accel);
     accelerate_steps = CEIL(accelerate_steps_float);
-    const float decelerate_steps_float = (nominal_rate_sq - sq(float(final_rate))) * (0.5 / accel);
+    const float decelerate_steps_float = (nominal_rate_sq - sq(float(final_rate))) * (0.5f / accel);
     decelerate_steps = decelerate_steps_float;
 
     // Steps between acceleration and deceleration, if any
@@ -816,7 +816,7 @@ void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t
     // Calculate accel / braking time in order to reach the final_rate exactly
     // at the end of this block.
     if (plateau_steps < 0) {
-      accelerate_steps_float = CEIL((block->step_event_count + accelerate_steps_float - decelerate_steps_float) * 0.5);
+      accelerate_steps_float = CEIL((block->step_event_count + accelerate_steps_float - decelerate_steps_float) * 0.5f);
       accelerate_steps = _MIN(uint32_t(_MAX(accelerate_steps_float, 0)), block->step_event_count);
       decelerate_steps = block->step_event_count - accelerate_steps;
 
@@ -1185,7 +1185,7 @@ void Planner::recalculate_trapezoids(TERN_(HINTS_SAFE_EXIT_SPEED, const_float_t 
 
   // Go from the tail (currently executed block) to the first block, without including it)
   block_t *block = nullptr, *next = nullptr;
-  float current_entry_speed = 0.0, next_entry_speed = 0.0;
+  float current_entry_speed = 0.0f, next_entry_speed = 0.0f;
   while (block_index != head_block_index) {
 
     next = &block_buffer[block_index];
@@ -1489,7 +1489,7 @@ void Planner::check_axes_activity() {
     for (uint8_t b = block_buffer_tail; b != block_buffer_head; b = next_block_index(b)) {
       const block_t * const block = &block_buffer[b];
       if (NUM_AXIS_GANG(block->steps.x, || block->steps.y, || block->steps.z, || block->steps.i, || block->steps.j, || block->steps.k, || block->steps.u, || block->steps.v, || block->steps.w)) {
-        const float se = (float)block->steps.e / block->step_event_count * block->nominal_speed; // mm/sec
+        const float se = float(block->steps.e) / block->step_event_count * block->nominal_speed; // mm/sec
         NOLESS(high, se);
       }
     }
@@ -1940,7 +1940,7 @@ bool Planner::_populate_block(
           #if ENABLED(MIXING_EXTRUDER)
             bool ignore_e = false;
             float collector[MIXING_STEPPERS];
-            mixer.refresh_collector(1.0, mixer.get_current_vtool(), collector);
+            mixer.refresh_collector(1.0f, mixer.get_current_vtool(), collector);
             MIXER_STEPPER_LOOP(e)
               if (e_steps * collector[e] > max_e_steps) { ignore_e = true; break; }
           #else
@@ -2197,7 +2197,7 @@ bool Planner::_populate_block(
       #if SECONDARY_LINEAR_AXES >= 1 && NONE(FOAMCUTTER_XYUV, ARTICULATED_ROBOT_ARM)
         if (NEAR_ZERO(distance_sqr)) {
           // Move does not involve any primary linear axes (xyz) but might involve secondary linear axes
-          distance_sqr = (0.0
+          distance_sqr = (0.0f
             SECONDARY_AXIS_GANG(
               IF_DISABLED(AXIS4_ROTATES, + sq(steps_dist_mm.i)),
               IF_DISABLED(AXIS5_ROTATES, + sq(steps_dist_mm.j)),
@@ -3260,7 +3260,7 @@ void Planner::set_machine_position_mm(const abce_pos_t &abce) {
   );
 
   if (has_blocks_queued()) {
-    //previous_nominal_speed = 0.0; // Reset planner junction speeds. Assume start from rest.
+    //previous_nominal_speed = 0.0f; // Reset planner junction speeds. Assume start from rest.
     //previous_speed.reset();
     buffer_sync_block(BLOCK_BIT_SYNC_POSITION);
   }
@@ -3336,7 +3336,7 @@ void Planner::refresh_positioning() {
 inline void limit_and_warn(float &val, const AxisEnum axis, PGM_P const setting_name, const xyze_float_t &max_limit) {
   const uint8_t lim_axis = TERN_(HAS_EXTRUDERS, axis > E_AXIS ? E_AXIS :) axis;
   const float before = val;
-  LIMIT(val, 0.1, max_limit[lim_axis]);
+  LIMIT(val, 0.1f, max_limit[lim_axis]);
   if (before != val) {
     SERIAL_CHAR(AXIS_CHAR(lim_axis));
     SERIAL_ECHOPGM(" Max ");

--- a/Marlin/src/module/planner.cpp
+++ b/Marlin/src/module/planner.cpp
@@ -821,7 +821,6 @@ void Planner::calculate_trapezoid_for_block(block_t * const block, const_float_t
       accelerate_steps_float = CEIL((block->step_event_count + accelerate_steps_float - decelerate_steps_float) * 0.5);
       accelerate_steps = _MIN(uint32_t(_MAX(accelerate_steps_float, 0)), block->step_event_count);
       decelerate_steps = block->step_event_count - accelerate_steps;
-      plateau_steps = 0;
 
       #if ENABLED(S_CURVE_ACCELERATION)
         // We won't reach the cruising rate. Let's calculate the speed we will reach

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -200,8 +200,8 @@ typedef struct block_t {
 
   // Fields used by the motion planner to manage acceleration
   float nominal_speed,                      // The nominal speed for this block in (mm/sec)
-        entry_speed_sqr,                    // Entry speed at previous-current junction in (mm/sec^2)
-        max_entry_speed_sqr,                // Maximum allowable junction entry speed in (mm/sec^2)
+        entry_speed_sqr,                    // Entry speed at previous-current junction in (mm/sec)^2
+        max_entry_speed_sqr,                // Maximum allowable junction entry speed in (mm/sec)^2
         millimeters,                        // The total travel of this block in mm
         acceleration;                       // acceleration mm/sec^2
 

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -1010,28 +1010,6 @@ class Planner {
     static constexpr uint8_t prev_block_index(const uint8_t block_index) { return BLOCK_MOD(block_index - 1); }
 
     /**
-     * Calculate the distance (not time) it takes to accelerate
-     * from initial_rate to target_rate using the given acceleration:
-     */
-    static float estimate_acceleration_distance(const_float_t initial_rate, const_float_t target_rate, const_float_t accel) {
-      if (accel == 0) return 0; // accel was 0, set acceleration distance to 0
-      return (sq(target_rate) - sq(initial_rate)) / (accel * 2);
-    }
-
-    /**
-     * Return the point at which you must start braking (at the rate of -'accel') if
-     * you start at 'initial_rate', accelerate (until reaching the point), and want to end at
-     * 'final_rate' after traveling 'distance'.
-     *
-     * This is used to compute the intersection point between acceleration and deceleration
-     * in cases where the "trapezoid" has no plateau (i.e., never reaches maximum speed)
-     */
-    static float intersection_distance(const_float_t initial_rate, const_float_t final_rate, const_float_t accel, const_float_t distance) {
-      if (accel == 0) return 0; // accel was 0, set intersection distance to 0
-      return (accel * 2 * distance - sq(initial_rate) + sq(final_rate)) / (accel * 4);
-    }
-
-    /**
      * Calculate the maximum allowable speed squared at this point, in order
      * to reach 'target_velocity_sqr' using 'acceleration' within a given
      * 'distance'.

--- a/Marlin/src/module/planner.h
+++ b/Marlin/src/module/planner.h
@@ -199,9 +199,9 @@ typedef struct block_t {
   volatile bool is_move() { return !(is_sync() || is_page()); }
 
   // Fields used by the motion planner to manage acceleration
-  float nominal_speed_sqr,                  // The nominal speed for this block in (mm/sec)^2
-        entry_speed_sqr,                    // Entry speed at previous-current junction in (mm/sec)^2
-        max_entry_speed_sqr,                // Maximum allowable junction entry speed in (mm/sec)^2
+  float nominal_speed,                      // The nominal speed for this block in (mm/sec)
+        entry_speed_sqr,                    // Entry speed at previous-current junction in (mm/sec^2)
+        max_entry_speed_sqr,                // Maximum allowable junction entry speed in (mm/sec^2)
         millimeters,                        // The total travel of this block in mm
         acceleration;                       // acceleration mm/sec^2
 
@@ -510,7 +510,7 @@ class Planner {
     /**
      * Nominal speed of previous path line segment (mm/s)^2
      */
-    static float previous_nominal_speed_sqr;
+    static float previous_nominal_speed;
 
     /**
      * Limit where 64bit math is necessary for acceleration calculation


### PR DESCRIPTION
### Description

This PR optimises that maths in `Planner::calculate_trapezoid_for_block()` and replaces `block->nominal_speed_sqr` with `block->nominal_speed`.

The latter is a simple matter: it eliminates multiple calls to `SQRT()` in exchange with a few calls to `sq()`.

The former involves manually inlining the functions `Planner::estimate_acceleration_distance()` and `Planner::intersection_distance()`. This makes it possible to re-use some calculations between these functions. The changes to the comments early in `planner.cpp` best explain the maths.

There is also a replacement of a division with a multiplication by an inverse (the compiler cleverly notices `(0.5 / accel)` is used more than once and re-uses the result). And a call to `FLOOR()` is removed because the argument was guaranteed to be a positive number which was going to be stored in an integer anyway, making the `FLOOR()` redundant. (The same could not be done with `CEIL()` on the previous line but does call into question whether `CEIL()` is actually required.)

On my AVR based printer, I profiled `Planner::_buffer_steps()` whilst drawing arcs. Before the changes:
- `G3 I-3 F10000` spent a total of 247ms of non-idle time in `Planner::_buffer_steps()` whilst drawing the arc.
- `G3 I-50 F10000` spent 1.43s.

After the changes:
- `G3 I-3 F10000` spent 217ms.
- `G3 I-50 F10000` spent 1.29s.

So that's well over 10% performance gain.

By `idle time` I mean time spent calling `idle()` whilst the planner waits for a free block in the queue.

### Requirements

Use the planner.

### Benefits

More spare CPU time for other things. Especially beneficial for AVR printers.

### Configurations

My config with which I tested: 
[config.zip](https://github.com/MarlinFirmware/Marlin/files/9087383/config.zip)

### Related Issues

Follow on from #24366.