### PR TITLE
Lock ESP32SSDP Library to 1.1.1

### DIFF
--- a/ini/features.ini
+++ b/ini/features.ini
@@ -238,5 +238,5 @@ HAS_MICROSTEPS                         = src_filter=+<src/gcode/control/M350_M35
 (ESP3D_)?WIFISUPPORT                   = AsyncTCP, ESP Async WebServer
                                          ESP3DLib=https://github.com/luc-github/ESP3DLib/archive/master.zip
                                          arduinoWebSockets=links2004/WebSockets@2.3.4
-                                         luc-github/ESP32SSDP@^1.1.1
+                                         luc-github/ESP32SSDP@1.1.1
                                          lib_ignore=ESPAsyncTCP


### PR DESCRIPTION
### Description

Lock ESP32SSDP Library to 1.1.1 since newer versions are incompatible.

### Related Issues

https://github.com/MarlinFirmware/Marlin/issues/24479