### PR TITLE
Refactor LCD pins and options

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -2856,6 +2856,7 @@
 //
 // FYSETC OLED 2.42" 128×64 Full Graphics Controller with WS2812 RGB
 // Where to find : https://www.aliexpress.com/item/4000345255731.html
+//
 //#define FYSETC_242_OLED_12864   // Uses the SSD1309 controller
 
 //

--- a/Marlin/src/core/boards.h
+++ b/Marlin/src/core/boards.h
@@ -100,7 +100,7 @@
 #define BOARD_VORON                   1144  // VORON Design
 #define BOARD_TRONXY_V3_1_0           1145  // Tronxy TRONXY-V3-1.0
 #define BOARD_Z_BOLT_X_SERIES         1146  // Z-Bolt X Series
-#define BOARD_TT_OSCAR                1147  // TT OSCAR
+#define BOARD_TT_OSCAR                1147  // thingNthinks TT Oscar v1.0 by YM Tech.LTD
 #define BOARD_OVERLORD                1148  // Overlord/Overlord Pro
 #define BOARD_HJC2560C_REV1           1149  // ADIMLab Gantry v1
 #define BOARD_HJC2560C_REV2           1150  // ADIMLab Gantry v2

--- a/Marlin/src/pins/lcd/ANET_ET4_TFT28.h
+++ b/Marlin/src/pins/lcd/ANET_ET4_TFT28.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ANET_ET4_TFT28
+ */

--- a/Marlin/src/pins/lcd/ANET_ET5_TFT35.h
+++ b/Marlin/src/pins/lcd/ANET_ET5_TFT35.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ANET_ET5_TFT35
+ */

--- a/Marlin/src/pins/lcd/ANET_FULL_GRAPHICS_LCD.h
+++ b/Marlin/src/pins/lcd/ANET_FULL_GRAPHICS_LCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ANET_FULL_GRAPHICS_LCD
+ */

--- a/Marlin/src/pins/lcd/ANET_FULL_GRAPHICS_LCD_ALT_WIRING.h
+++ b/Marlin/src/pins/lcd/ANET_FULL_GRAPHICS_LCD_ALT_WIRING.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ANET_FULL_GRAPHICS_LCD_ALT_WIRING
+ */

--- a/Marlin/src/pins/lcd/ANYCUBIC_LCD_CHIRON.h
+++ b/Marlin/src/pins/lcd/ANYCUBIC_LCD_CHIRON.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ANYCUBIC_LCD_CHIRON
+ */

--- a/Marlin/src/pins/lcd/ANYCUBIC_LCD_I3MEGA.h
+++ b/Marlin/src/pins/lcd/ANYCUBIC_LCD_I3MEGA.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ANYCUBIC_LCD_I3MEGA
+ */

--- a/Marlin/src/pins/lcd/ANYCUBIC_TFT35.h
+++ b/Marlin/src/pins/lcd/ANYCUBIC_TFT35.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ANYCUBIC_TFT35
+ */

--- a/Marlin/src/pins/lcd/AZSMZ_12864.h
+++ b/Marlin/src/pins/lcd/AZSMZ_12864.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * AZSMZ_12864
+ */

--- a/Marlin/src/pins/lcd/BIQU_BX_TFT70.h
+++ b/Marlin/src/pins/lcd/BIQU_BX_TFT70.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * BIQU_BX_TFT70
+ */

--- a/Marlin/src/pins/lcd/BQ_LCD_SMART_CONTROLLER.h
+++ b/Marlin/src/pins/lcd/BQ_LCD_SMART_CONTROLLER.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * BQ_LCD_SMART_CONTROLLER
+ */

--- a/Marlin/src/pins/lcd/BTT_MINI_12864_V1.h
+++ b/Marlin/src/pins/lcd/BTT_MINI_12864_V1.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * BTT_MINI_12864_V1
+ */

--- a/Marlin/src/pins/lcd/BTT_TFT35_SPI_V1_0.h
+++ b/Marlin/src/pins/lcd/BTT_TFT35_SPI_V1_0.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * BTT_TFT35_SPI_V1_0
+ */

--- a/Marlin/src/pins/lcd/CARTESIO_UI.h
+++ b/Marlin/src/pins/lcd/CARTESIO_UI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * CARTESIO_UI
+ */

--- a/Marlin/src/pins/lcd/CR10_STOCKDISPLAY.h
+++ b/Marlin/src/pins/lcd/CR10_STOCKDISPLAY.h
@@ -23,4 +23,29 @@
 
 /**
  * CR10_STOCKDISPLAY
+ * Creality CR-10 Stock Display
+ * Connected by a single 10-wire cable
  */
+
+// LCD interface
+#define LCD_PINS_RS                  EXP1_07_PIN
+#define LCD_PINS_ENABLE              EXP1_08_PIN
+#define LCD_PINS_D4                  EXP1_06_PIN
+
+// Beeper
+#define BEEPER_PIN                   EXP1_01_PIN
+
+// Encoder
+#define BTN_ENC                      EXP1_02_PIN
+#define BTN_EN1                      EXP1_03_PIN
+#define BTN_EN2                      EXP1_05_PIN
+
+// SD Detect
+#ifndef SD_DETECT_PIN
+  #define SD_DETECT_PIN              EXP2_07_PIN
+#endif
+
+// Kill
+#ifndef KILL_PIN
+  #define KILL_PIN                   EXP2_08_PIN
+#endif

--- a/Marlin/src/pins/lcd/CR10_STOCKDISPLAY.h
+++ b/Marlin/src/pins/lcd/CR10_STOCKDISPLAY.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * CR10_STOCKDISPLAY
+ */

--- a/Marlin/src/pins/lcd/DGUS_LCD_UI_FYSETC.h
+++ b/Marlin/src/pins/lcd/DGUS_LCD_UI_FYSETC.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * DGUS_LCD_UI_FYSETC
+ */

--- a/Marlin/src/pins/lcd/DGUS_LCD_UI_HIPRECY.h
+++ b/Marlin/src/pins/lcd/DGUS_LCD_UI_HIPRECY.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * DGUS_LCD_UI_HIPRECY
+ */

--- a/Marlin/src/pins/lcd/DGUS_LCD_UI_MKS.h
+++ b/Marlin/src/pins/lcd/DGUS_LCD_UI_MKS.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * DGUS_LCD_UI_MKS
+ */

--- a/Marlin/src/pins/lcd/DGUS_LCD_UI_ORIGIN.h
+++ b/Marlin/src/pins/lcd/DGUS_LCD_UI_ORIGIN.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * DGUS_LCD_UI_ORIGIN
+ */

--- a/Marlin/src/pins/lcd/DGUS_LCD_UI_RELOADED.h
+++ b/Marlin/src/pins/lcd/DGUS_LCD_UI_RELOADED.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * DGUS_LCD_UI_RELOADED
+ */

--- a/Marlin/src/pins/lcd/DWIN_CREALITY_LCD.h
+++ b/Marlin/src/pins/lcd/DWIN_CREALITY_LCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * DWIN_CREALITY_LCD
+ */

--- a/Marlin/src/pins/lcd/DWIN_CREALITY_TOUCHLCD.h
+++ b/Marlin/src/pins/lcd/DWIN_CREALITY_TOUCHLCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * DWIN_CREALITY_TOUCHLCD
+ */

--- a/Marlin/src/pins/lcd/EASYTHREED_UI.h
+++ b/Marlin/src/pins/lcd/EASYTHREED_UI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * EASYTHREED_UI
+ */

--- a/Marlin/src/pins/lcd/ELB_FULL_GRAPHIC_CONTROLLER.h
+++ b/Marlin/src/pins/lcd/ELB_FULL_GRAPHIC_CONTROLLER.h
@@ -1,0 +1,58 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ELB_FULL_GRAPHIC_CONTROLLER
+ *
+ *         ------                 ------
+ *    EN2 | 1  2 | EN1       --- | 1  2 | ---
+ *    --- | 3  4 | ---       ENC | 3  4 | ---
+ *   BEEP | 5  6 | ---        BL | 5  6 | ---
+ *     A0 | 7  8 | CS        SDD | 7  8 | KILL
+ *    --- | 9 10 | ---       --- | 9 10 | ---
+ *         ------                 ------
+ *          EXP1                   EXP2
+ */
+
+// LCD interface
+#define DOGLCD_CS                    EXP1_08_PIN
+#define DOGLCD_A0                    EXP1_07_PIN
+
+// Beeper
+#define BEEPER_PIN                   EXP1_05_PIN
+
+// Encoder
+#define BTN_EN1                      EXP1_02_PIN
+#define BTN_EN2                      EXP1_01_PIN
+#define BTN_ENC                      EXP2_03_PIN
+
+// SD Card
+#define LCD_SDSS                            SDSS
+
+#ifndef SD_DETECT_PIN
+  #define SD_DETECT_PIN              EXP2_07_PIN
+#endif
+
+// Extras
+#define LCD_BACKLIGHT_PIN            EXP2_05_PIN
+#define KILL_PIN                     EXP2_08_PIN

--- a/Marlin/src/pins/lcd/EMOTION_TECH_LCD.h
+++ b/Marlin/src/pins/lcd/EMOTION_TECH_LCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * EMOTION_TECH_LCD
+ */

--- a/Marlin/src/pins/lcd/ENDER2_STOCKDISPLAY.h
+++ b/Marlin/src/pins/lcd/ENDER2_STOCKDISPLAY.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ENDER2_STOCKDISPLAY
+ */

--- a/Marlin/src/pins/lcd/EXTENSIBLE_UI.h
+++ b/Marlin/src/pins/lcd/EXTENSIBLE_UI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * EXTENSIBLE_UI
+ */

--- a/Marlin/src/pins/lcd/FF_INTERFACEBOARD.h
+++ b/Marlin/src/pins/lcd/FF_INTERFACEBOARD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * FF_INTERFACEBOARD
+ */

--- a/Marlin/src/pins/lcd/FYSETC_242_OLED_12864.h
+++ b/Marlin/src/pins/lcd/FYSETC_242_OLED_12864.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * FYSETC_242_OLED_12864
+ */

--- a/Marlin/src/pins/lcd/FYSETC_GENERIC_12864_1_1.h
+++ b/Marlin/src/pins/lcd/FYSETC_GENERIC_12864_1_1.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * FYSETC_GENERIC_12864_1_1
+ */

--- a/Marlin/src/pins/lcd/FYSETC_MINI_12864_1_2.h
+++ b/Marlin/src/pins/lcd/FYSETC_MINI_12864_1_2.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * FYSETC_MINI_12864_1_2
+ */

--- a/Marlin/src/pins/lcd/FYSETC_MINI_12864_2_0.h
+++ b/Marlin/src/pins/lcd/FYSETC_MINI_12864_2_0.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * FYSETC_MINI_12864_2_0
+ */

--- a/Marlin/src/pins/lcd/FYSETC_MINI_12864_2_1.h
+++ b/Marlin/src/pins/lcd/FYSETC_MINI_12864_2_1.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * FYSETC_MINI_12864_2_1
+ */

--- a/Marlin/src/pins/lcd/FYSETC_MINI_12864_X_X.h
+++ b/Marlin/src/pins/lcd/FYSETC_MINI_12864_X_X.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * FYSETC_MINI_12864_X_X
+ */

--- a/Marlin/src/pins/lcd/G3D_PANEL.h
+++ b/Marlin/src/pins/lcd/G3D_PANEL.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * G3D_PANEL
+ */

--- a/Marlin/src/pins/lcd/K3D_242_OLED_CONTROLLER.h
+++ b/Marlin/src/pins/lcd/K3D_242_OLED_CONTROLLER.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * K3D_242_OLED_CONTROLLER
+ */

--- a/Marlin/src/pins/lcd/K3D_FULL_GRAPHIC_SMART_CONTROLLER.h
+++ b/Marlin/src/pins/lcd/K3D_FULL_GRAPHIC_SMART_CONTROLLER.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * K3D_FULL_GRAPHIC_SMART_CONTROLLER
+ */

--- a/Marlin/src/pins/lcd/LCD_FOR_MELZI.h
+++ b/Marlin/src/pins/lcd/LCD_FOR_MELZI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * LCD_FOR_MELZI
+ */

--- a/Marlin/src/pins/lcd/LCD_I2C_PANELOLU2.h
+++ b/Marlin/src/pins/lcd/LCD_I2C_PANELOLU2.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * LCD_I2C_PANELOLU2
+ */

--- a/Marlin/src/pins/lcd/LCD_I2C_VIKI.h
+++ b/Marlin/src/pins/lcd/LCD_I2C_VIKI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * LCD_I2C_VIKI
+ */

--- a/Marlin/src/pins/lcd/LCD_SAINSMART_I2C_1602.h
+++ b/Marlin/src/pins/lcd/LCD_SAINSMART_I2C_1602.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * LCD_SAINSMART_I2C_1602
+ */

--- a/Marlin/src/pins/lcd/LCD_SAINSMART_I2C_2004.h
+++ b/Marlin/src/pins/lcd/LCD_SAINSMART_I2C_2004.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * LCD_SAINSMART_I2C_2004
+ */

--- a/Marlin/src/pins/lcd/LCD_U8GLIB_SSD1306.h
+++ b/Marlin/src/pins/lcd/LCD_U8GLIB_SSD1306.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * LCD_U8GLIB_SSD1306
+ */

--- a/Marlin/src/pins/lcd/LCM1602.h
+++ b/Marlin/src/pins/lcd/LCM1602.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * LCM1602
+ */

--- a/Marlin/src/pins/lcd/LONGER_LK_TFT28.h
+++ b/Marlin/src/pins/lcd/LONGER_LK_TFT28.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * LONGER_LK_TFT28
+ */

--- a/Marlin/src/pins/lcd/MAKEBOARD_MINI_2_LINE_DISPLAY_1602.h
+++ b/Marlin/src/pins/lcd/MAKEBOARD_MINI_2_LINE_DISPLAY_1602.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MAKEBOARD_MINI_2_LINE_DISPLAY_1602
+ */

--- a/Marlin/src/pins/lcd/MAKRPANEL.h
+++ b/Marlin/src/pins/lcd/MAKRPANEL.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MAKRPANEL
+ */

--- a/Marlin/src/pins/lcd/MALYAN_LCD.h
+++ b/Marlin/src/pins/lcd/MALYAN_LCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MALYAN_LCD
+ */

--- a/Marlin/src/pins/lcd/MINIPANEL.h
+++ b/Marlin/src/pins/lcd/MINIPANEL.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MINIPANEL
+ */

--- a/Marlin/src/pins/lcd/MKS_12864OLED.h
+++ b/Marlin/src/pins/lcd/MKS_12864OLED.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_12864OLED
+ */

--- a/Marlin/src/pins/lcd/MKS_12864OLED_SSD1306.h
+++ b/Marlin/src/pins/lcd/MKS_12864OLED_SSD1306.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_12864OLED_SSD1306
+ */

--- a/Marlin/src/pins/lcd/MKS_LCD12864A.h
+++ b/Marlin/src/pins/lcd/MKS_LCD12864A.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_LCD12864A
+ */

--- a/Marlin/src/pins/lcd/MKS_LCD12864B.h
+++ b/Marlin/src/pins/lcd/MKS_LCD12864B.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_LCD12864B
+ */

--- a/Marlin/src/pins/lcd/MKS_MINI_12864.h
+++ b/Marlin/src/pins/lcd/MKS_MINI_12864.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_MINI_12864
+ */

--- a/Marlin/src/pins/lcd/MKS_MINI_12864_V3.h
+++ b/Marlin/src/pins/lcd/MKS_MINI_12864_V3.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_MINI_12864_V3
+ */

--- a/Marlin/src/pins/lcd/MKS_ROBIN_TFT24.h
+++ b/Marlin/src/pins/lcd/MKS_ROBIN_TFT24.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_ROBIN_TFT24
+ */

--- a/Marlin/src/pins/lcd/MKS_ROBIN_TFT28.h
+++ b/Marlin/src/pins/lcd/MKS_ROBIN_TFT28.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_ROBIN_TFT28
+ */

--- a/Marlin/src/pins/lcd/MKS_ROBIN_TFT32.h
+++ b/Marlin/src/pins/lcd/MKS_ROBIN_TFT32.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_ROBIN_TFT32
+ */

--- a/Marlin/src/pins/lcd/MKS_ROBIN_TFT35.h
+++ b/Marlin/src/pins/lcd/MKS_ROBIN_TFT35.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_ROBIN_TFT35
+ */

--- a/Marlin/src/pins/lcd/MKS_ROBIN_TFT43.h
+++ b/Marlin/src/pins/lcd/MKS_ROBIN_TFT43.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_ROBIN_TFT43
+ */

--- a/Marlin/src/pins/lcd/MKS_ROBIN_TFT_V1_1R.h
+++ b/Marlin/src/pins/lcd/MKS_ROBIN_TFT_V1_1R.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_ROBIN_TFT_V1_1R
+ */

--- a/Marlin/src/pins/lcd/MKS_TS35_V2_0.h
+++ b/Marlin/src/pins/lcd/MKS_TS35_V2_0.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * MKS_TS35_V2_0
+ */

--- a/Marlin/src/pins/lcd/NEXTION_TFT.h
+++ b/Marlin/src/pins/lcd/NEXTION_TFT.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * NEXTION_TFT
+ */

--- a/Marlin/src/pins/lcd/OLED_PANEL_TINYBOY2.h
+++ b/Marlin/src/pins/lcd/OLED_PANEL_TINYBOY2.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * OLED_PANEL_TINYBOY2
+ */

--- a/Marlin/src/pins/lcd/OVERLORD_OLED.h
+++ b/Marlin/src/pins/lcd/OVERLORD_OLED.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * OVERLORD_OLED
+ */

--- a/Marlin/src/pins/lcd/PANELDUE.h
+++ b/Marlin/src/pins/lcd/PANELDUE.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * PANELDUE
+ */

--- a/Marlin/src/pins/lcd/PANEL_ONE.h
+++ b/Marlin/src/pins/lcd/PANEL_ONE.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * PANEL_ONE <http://blog.think3dprint3d.com/2014/08/panelone-lcd-screen-for-33v-and-5v.html>
+ */

--- a/Marlin/src/pins/lcd/PANEL_ONE.h
+++ b/Marlin/src/pins/lcd/PANEL_ONE.h
@@ -23,4 +23,26 @@
 
 /**
  * PANEL_ONE <http://blog.think3dprint3d.com/2014/08/panelone-lcd-screen-for-33v-and-5v.html>
+ *
+ *         ------                 ------
+ *    NC  | 1  2 | NC        DB4 | 1  2 | DB5
+ *    VCC | 3  4 | ENC         E | 3  4 | DB6
+ *   MISO | 5  6 | MOSI       RS | 5  6 | DB7
+ *    SCK | 7  8 | SDSS      EN2 | 7  8 | EN1
+ *    GND | 9 10 | NC        GND | 9 10 | 5V
+ *         ------                 ------
+ *           P1                     P2
  */
+
+// LCD interface
+#define LCD_PINS_RS                  EXP2_05_PIN
+#define LCD_PINS_ENABLE              EXP2_03_PIN
+#define LCD_PINS_D4                  EXP2_01_PIN
+#define LCD_PINS_D5                  EXP2_02_PIN
+#define LCD_PINS_D6                  EXP2_04_PIN
+#define LCD_PINS_D7                  EXP2_06_PIN
+
+// Encoder
+#define BTN_ENC                      EXP1_04_PIN
+#define BTN_EN1                      EXP2_08_PIN
+#define BTN_EN2                      EXP2_07_PIN

--- a/Marlin/src/pins/lcd/RADDS_DISPLAY.h
+++ b/Marlin/src/pins/lcd/RADDS_DISPLAY.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * RADDS_DISPLAY
+ */

--- a/Marlin/src/pins/lcd/RA_CONTROL_PANEL.h
+++ b/Marlin/src/pins/lcd/RA_CONTROL_PANEL.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * RA_CONTROL_PANEL
+ */

--- a/Marlin/src/pins/lcd/REPRAPWORLD_GRAPHICAL_LCD.h
+++ b/Marlin/src/pins/lcd/REPRAPWORLD_GRAPHICAL_LCD.h
@@ -1,0 +1,41 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * REPRAPWORLD_GRAPHICAL_LCD
+ */
+
+// LCD interface
+#define LCD_PINS_RS                  EXP2_07_PIN  // CS chip select /SS chip slave select
+#define LCD_PINS_ENABLE              EXP2_06_PIN  // SID (MOSI)
+#define LCD_PINS_D4                  EXP2_02_PIN  // SCK (CLK) clock
+
+// Encoder
+#define BTN_EN1                      AUX2_05_PIN  // TODO: RRW GLCD Adapter
+#define BTN_EN2                      AUX2_03_PIN
+#define BTN_ENC                      AUX2_04_PIN
+
+// SD Card
+#ifndef SD_DETECT_PIN
+  #define SD_DETECT_PIN              AUX2_08_PIN
+#endif

--- a/Marlin/src/pins/lcd/REPRAPWORLD_KEYPAD.h
+++ b/Marlin/src/pins/lcd/REPRAPWORLD_KEYPAD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * REPRAPWORLD_KEYPAD
+ */

--- a/Marlin/src/pins/lcd/REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER.h
+++ b/Marlin/src/pins/lcd/REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER.h
@@ -1,0 +1,53 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER
+ */
+
+// LCD interface
+#define LCD_PINS_RS                  EXP1_04_PIN
+#define LCD_PINS_ENABLE              EXP1_03_PIN
+#define LCD_PINS_D4                  EXP1_05_PIN
+#define LCD_PINS_D5                  EXP1_06_PIN
+#define LCD_PINS_D6                  EXP1_07_PIN
+#define LCD_PINS_D7                  EXP1_08_PIN
+
+// Beeper
+#define BEEPER_PIN                   EXP1_01_PIN
+
+// Encoder
+#define BTN_ENC_EN                   LCD_PINS_D7  // Detect the presence of the encoder
+#define BTN_ENC                      EXP1_02_PIN
+#define BTN_EN1                      EXP2_03_PIN
+#define BTN_EN2                      EXP2_05_PIN
+
+// SD Card
+#ifndef SD_DETECT_PIN
+  #define SD_DETECT_PIN              EXP2_07_PIN
+#endif
+
+// Kill
+#ifndef KILL_PIN
+  #define KILL_PIN                   EXP2_08_PIN
+#endif

--- a/Marlin/src/pins/lcd/REPRAP_DISCOUNT_SMART_CONTROLLER.h
+++ b/Marlin/src/pins/lcd/REPRAP_DISCOUNT_SMART_CONTROLLER.h
@@ -1,0 +1,52 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * REPRAP_DISCOUNT_SMART_CONTROLLER
+ */
+
+// LCD interface
+#define LCD_PINS_RS                  EXP1_04_PIN
+#define LCD_PINS_ENABLE              EXP1_03_PIN
+#define LCD_PINS_D4                  EXP1_05_PIN
+#define LCD_PINS_D5                  EXP1_06_PIN
+#define LCD_PINS_D6                  EXP1_07_PIN
+#define LCD_PINS_D7                  EXP1_08_PIN
+
+// Beeper
+#define BEEPER_PIN                   EXP1_01_PIN
+
+// Encoder
+#define BTN_ENC                      EXP1_02_PIN
+#define BTN_EN1                      EXP2_03_PIN
+#define BTN_EN2                      EXP2_05_PIN
+
+// SD Card
+#ifndef SD_DETECT_PIN
+  #define SD_DETECT_PIN              EXP2_07_PIN
+#endif
+
+// Kill
+#ifndef KILL_PIN
+  #define KILL_PIN                   EXP2_08_PIN
+#endif

--- a/Marlin/src/pins/lcd/RIGIDBOT_PANEL.h
+++ b/Marlin/src/pins/lcd/RIGIDBOT_PANEL.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * RIGIDBOT_PANEL
+ */

--- a/Marlin/src/pins/lcd/SAV_3DGLCD.h
+++ b/Marlin/src/pins/lcd/SAV_3DGLCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * SAV_3DGLCD
+ */

--- a/Marlin/src/pins/lcd/SAV_3DLCD.h
+++ b/Marlin/src/pins/lcd/SAV_3DLCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * SAV_3DLCD
+ */

--- a/Marlin/src/pins/lcd/SILVER_GATE_GLCD_CONTROLLER.h
+++ b/Marlin/src/pins/lcd/SILVER_GATE_GLCD_CONTROLLER.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * SILVER_GATE_GLCD_CONTROLLER
+ */

--- a/Marlin/src/pins/lcd/TFTGLCD_PANEL_I2C.h
+++ b/Marlin/src/pins/lcd/TFTGLCD_PANEL_I2C.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * TFTGLCD_PANEL_I2C
+ */

--- a/Marlin/src/pins/lcd/TFTGLCD_PANEL_SPI.h
+++ b/Marlin/src/pins/lcd/TFTGLCD_PANEL_SPI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * TFTGLCD_PANEL_SPI
+ */

--- a/Marlin/src/pins/lcd/TFT_CLASSIC_UI.h
+++ b/Marlin/src/pins/lcd/TFT_CLASSIC_UI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * TFT_CLASSIC_UI
+ */

--- a/Marlin/src/pins/lcd/TFT_COLOR_UI.h
+++ b/Marlin/src/pins/lcd/TFT_COLOR_UI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * TFT_COLOR_UI
+ */

--- a/Marlin/src/pins/lcd/TFT_GENERIC.h
+++ b/Marlin/src/pins/lcd/TFT_GENERIC.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * TFT_GENERIC
+ */

--- a/Marlin/src/pins/lcd/TFT_LVGL_UI.h
+++ b/Marlin/src/pins/lcd/TFT_LVGL_UI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * TFT_LVGL_UI
+ */

--- a/Marlin/src/pins/lcd/TFT_TRONXY_X5SA.h
+++ b/Marlin/src/pins/lcd/TFT_TRONXY_X5SA.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * TFT_TRONXY_X5SA
+ */

--- a/Marlin/src/pins/lcd/TOUCH_UI_FTDI_EVE.h
+++ b/Marlin/src/pins/lcd/TOUCH_UI_FTDI_EVE.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * TOUCH_UI_FTDI_EVE
+ */

--- a/Marlin/src/pins/lcd/U8GLIB_SH1106_EINSTART.h
+++ b/Marlin/src/pins/lcd/U8GLIB_SH1106_EINSTART.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * U8GLIB_SH1106_EINSTART
+ */

--- a/Marlin/src/pins/lcd/ULTIMAKERCONTROLLER.h
+++ b/Marlin/src/pins/lcd/ULTIMAKERCONTROLLER.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ULTIMAKERCONTROLLER
+ */

--- a/Marlin/src/pins/lcd/ULTIPANEL.h
+++ b/Marlin/src/pins/lcd/ULTIPANEL.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ULTIPANEL
+ */

--- a/Marlin/src/pins/lcd/ULTI_CONTROLLER.h
+++ b/Marlin/src/pins/lcd/ULTI_CONTROLLER.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ULTI_CONTROLLER
+ */

--- a/Marlin/src/pins/lcd/ULTRA_LCD.h
+++ b/Marlin/src/pins/lcd/ULTRA_LCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ULTRA_LCD
+ */

--- a/Marlin/src/pins/lcd/VIKI2.h
+++ b/Marlin/src/pins/lcd/VIKI2.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * VIKI2
+ */

--- a/Marlin/src/pins/lcd/WYH_L12864.h
+++ b/Marlin/src/pins/lcd/WYH_L12864.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * WYH_L12864
+ */

--- a/Marlin/src/pins/lcd/YHCB2004.h
+++ b/Marlin/src/pins/lcd/YHCB2004.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * YHCB2004
+ */

--- a/Marlin/src/pins/lcd/ZONESTAR_12864LCD.h
+++ b/Marlin/src/pins/lcd/ZONESTAR_12864LCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ZONESTAR_12864LCD
+ */

--- a/Marlin/src/pins/lcd/ZONESTAR_12864OLED.h
+++ b/Marlin/src/pins/lcd/ZONESTAR_12864OLED.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ZONESTAR_12864OLED
+ */

--- a/Marlin/src/pins/lcd/ZONESTAR_12864OLED_SSD1306.h
+++ b/Marlin/src/pins/lcd/ZONESTAR_12864OLED_SSD1306.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ZONESTAR_12864OLED_SSD1306
+ */

--- a/Marlin/src/pins/lcd/ZONESTAR_LCD.h
+++ b/Marlin/src/pins/lcd/ZONESTAR_LCD.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * ZONESTAR_LCD
+ */

--- a/Marlin/src/pins/lcd/miniVIKI.h
+++ b/Marlin/src/pins/lcd/miniVIKI.h
@@ -1,0 +1,26 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * miniVIKI
+ */

--- a/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
+++ b/Marlin/src/pins/linux/pins_RAMPS_LINUX.h
@@ -373,9 +373,70 @@
   #endif
 #endif
 
+//
+// AUX1    5V  GND D2  D1
+//          2   4   6   8
+//          1   3   5   7
+//         5V  GND A3  A4
+//
+#define AUX1_05_PIN                           57  // (A3)
+#define AUX1_06_PIN                            2
+#define AUX1_07_PIN                           58  // (A4)
+#define AUX1_08_PIN                            1
+
+//
+// AUX2    GND A9 D40 D42 A11
+//          2   4   6   8  10
+//          1   3   5   7   9
+//         VCC A5 A10 D44 A12
+//
+#define AUX2_03_PIN                           59  // (A5)
+#define AUX2_04_PIN                           63  // (A9)
+#define AUX2_05_PIN                           64  // (A10)
+#define AUX2_06_PIN                           40
+#define AUX2_07_PIN                           44
+#define AUX2_08_PIN                           42
+#define AUX2_09_PIN                           66  // (A12)
+#define AUX2_10_PIN                           65  // (A11)
+
+//
+// AUX3    GND D52 D50 5V
+//          7   5   3   1
+//          8   6   4   2
+//         NC  D53 D51 D49
+//
+#define AUX3_02_PIN                           49
+#define AUX3_03_PIN                           50
+#define AUX3_04_PIN                           51
+#define AUX3_05_PIN                           52
+#define AUX3_06_PIN                           53
+
+//
+// AUX4    5V GND D32 D47 D45 D43 D41 D39 D37 D35 D33 D31 D29 D27 D25 D23 D17 D16
+//
+#define AUX4_03_PIN                           32
+#define AUX4_04_PIN                           47
+#define AUX4_05_PIN                           45
+#define AUX4_06_PIN                           43
+#define AUX4_07_PIN                           41
+#define AUX4_08_PIN                           39
+#define AUX4_09_PIN                           37
+#define AUX4_10_PIN                           35
+#define AUX4_11_PIN                           33
+#define AUX4_12_PIN                           31
+#define AUX4_13_PIN                           29
+#define AUX4_14_PIN                           27
+#define AUX4_15_PIN                           25
+#define AUX4_16_PIN                           23
+#define AUX4_17_PIN                           17
+#define AUX4_18_PIN                           16
+
 //////////////////////////
 // LCDs and Controllers //
 //////////////////////////
+
+// Custom Simulator Back Button
+#define BTN_BACK                              70
 
 #if ANY(TFT_COLOR_UI, TFT_CLASSIC_UI, TFT_LVGL_UI)
 
@@ -453,8 +514,6 @@
     #endif
   #endif
 
-  #define BTN_BACK                            70
-
 #elif HAS_WIRED_LCD
 
   //
@@ -462,9 +521,9 @@
   //
   #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
 
-    #define LCD_PINS_RS                       49  // CS chip select /SS chip slave select
-    #define LCD_PINS_ENABLE                   51  // SID (MOSI)
-    #define LCD_PINS_D4                       52  // SCK (CLK) clock
+    #define LCD_PINS_RS              EXP2_07_PIN  // CS chip select /SS chip slave select
+    #define LCD_PINS_ENABLE          EXP2_06_PIN  // SID (MOSI)
+    #define LCD_PINS_D4              EXP2_02_PIN  // SCK (CLK) clock
 
   #elif BOTH(IS_NEWPANEL, PANEL_ONE)
 
@@ -689,9 +748,6 @@
         #define KILL_PIN                      41
       #endif
     #endif
-
-    // CUSTOM SIMULATOR INPUTS
-    #define BTN_BACK                          70
 
   #endif // IS_NEWPANEL
 

--- a/Marlin/src/pins/pins.h
+++ b/Marlin/src/pins/pins.h
@@ -898,6 +898,11 @@
 #endif
 
 //
+// Include LCD pins
+//
+#include "pins_lcd.h"
+
+//
 // Post-process pins according to configured settings
 //
 #include "pins_postprocess.h"

--- a/Marlin/src/pins/pins_lcd.h
+++ b/Marlin/src/pins/pins_lcd.h
@@ -1,0 +1,239 @@
+/**
+ * Marlin 3D Printer Firmware
+ * Copyright (c) 2022 MarlinFirmware [https://github.com/MarlinFirmware/Marlin]
+ *
+ * Based on Sprinter and grbl.
+ * Copyright (c) 2011 Camiel Gubbels / Erik van der Zalm
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+#pragma once
+
+/**
+ * File: pins/pins_lcd.h
+ *
+ * Include pins for enabled LCD / Encoders
+ *
+ * - EXP1/2/3 headers are defined in the board pins files.
+ *   with consideration for standard display adapters and mappings.
+ *
+ * - LCD pins are defined in terms of their connection to EXP1/2/3
+ *   headers, so AUX / alternative pins must also be EXP-mapped.
+ *
+ */
+
+#ifdef LCD_MODEL
+
+  #define LCD_PATH(M) STRINGIFY_(lcd/M.h)
+  #include LCD_PATH(LCD_MODEL)
+
+#elif ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
+  #include "lcd/REPRAP_DISCOUNT_SMART_CONTROLLER.h"
+#elif ENABLED(YHCB2004)
+  #include "lcd/YHCB2004.h"
+#elif ENABLED(RADDS_DISPLAY)
+  #include "lcd/RADDS_DISPLAY.h"
+#elif ENABLED(ULTIMAKERCONTROLLER)
+  #include "lcd/ULTIMAKERCONTROLLER.h"
+#elif ENABLED(ULTIPANEL)
+  #include "lcd/ULTIPANEL.h"
+#elif ENABLED(PANEL_ONE)
+  #include "lcd/PANEL_ONE.h"
+#elif ENABLED(G3D_PANEL)
+  #include "lcd/G3D_PANEL.h"
+#elif ENABLED(RIGIDBOT_PANEL)
+  #include "lcd/RIGIDBOT_PANEL.h"
+#elif ENABLED(MAKEBOARD_MINI_2_LINE_DISPLAY_1602)
+  #include "lcd/MAKEBOARD_MINI_2_LINE_DISPLAY_1602.h"
+#elif ENABLED(ZONESTAR_LCD)
+  #include "lcd/ZONESTAR_LCD.h"
+#elif ENABLED(ULTRA_LCD)
+  #include "lcd/ULTRA_LCD.h"
+#elif ENABLED(RA_CONTROL_PANEL)
+  #include "lcd/RA_CONTROL_PANEL.h"
+#elif ENABLED(LCD_SAINSMART_I2C_1602)
+  #include "lcd/LCD_SAINSMART_I2C_1602.h"
+#elif ENABLED(LCD_SAINSMART_I2C_2004)
+  #include "lcd/LCD_SAINSMART_I2C_2004.h"
+#elif ENABLED(LCM1602)
+  #include "lcd/LCM1602.h"
+#elif ENABLED(LCD_I2C_PANELOLU2)
+  #include "lcd/LCD_I2C_PANELOLU2.h"
+#elif ENABLED(LCD_I2C_VIKI)
+  #include "lcd/LCD_I2C_VIKI.h"
+#elif ENABLED(SAV_3DLCD)
+  #include "lcd/SAV_3DLCD.h"
+#elif ENABLED(FF_INTERFACEBOARD)
+  #include "lcd/FF_INTERFACEBOARD.h"
+#elif ENABLED(TFTGLCD_PANEL_SPI)
+  #include "lcd/TFTGLCD_PANEL_SPI.h"
+#elif ENABLED(TFTGLCD_PANEL_I2C)
+  #include "lcd/TFTGLCD_PANEL_I2C.h"
+#elif ENABLED(REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER)
+  #include "lcd/REPRAP_DISCOUNT_FULL_GRAPHIC_SMART_CONTROLLER.h"
+#elif ENABLED(K3D_FULL_GRAPHIC_SMART_CONTROLLER)
+  #include "lcd/K3D_FULL_GRAPHIC_SMART_CONTROLLER.h"
+#elif ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+  #include "lcd/REPRAPWORLD_GRAPHICAL_LCD.h"
+#elif ENABLED(VIKI2)
+  #include "lcd/VIKI2.h"
+#elif ENABLED(miniVIKI)
+  #include "lcd/miniVIKI.h"
+#elif ENABLED(WYH_L12864)
+  #include "lcd/WYH_L12864.h"
+#elif ENABLED(MINIPANEL)
+  #include "lcd/MINIPANEL.h"
+#elif ENABLED(MAKRPANEL)
+  #include "lcd/MAKRPANEL.h"
+#elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
+  #include "lcd/ELB_FULL_GRAPHIC_CONTROLLER.h"
+#elif ENABLED(BQ_LCD_SMART_CONTROLLER)
+  #include "lcd/BQ_LCD_SMART_CONTROLLER.h"
+#elif ENABLED(CARTESIO_UI)
+  #include "lcd/CARTESIO_UI.h"
+#elif ENABLED(LCD_FOR_MELZI)
+  #include "lcd/LCD_FOR_MELZI.h"
+#elif ENABLED(ULTI_CONTROLLER)
+  #include "lcd/ULTI_CONTROLLER.h"
+#elif ENABLED(MKS_MINI_12864)
+  #include "lcd/MKS_MINI_12864.h"
+#elif ENABLED(MKS_MINI_12864_V3)
+  #include "lcd/MKS_MINI_12864_V3.h"
+#elif ENABLED(MKS_LCD12864A)
+  #include "lcd/MKS_LCD12864A.h"
+#elif ENABLED(MKS_LCD12864B)
+  #include "lcd/MKS_LCD12864B.h"
+#elif ENABLED(FYSETC_MINI_12864_X_X)
+  #include "lcd/FYSETC_MINI_12864_X_X.h"
+#elif ENABLED(FYSETC_MINI_12864_1_2)
+  #include "lcd/FYSETC_MINI_12864_1_2.h"
+#elif ENABLED(FYSETC_MINI_12864_2_0)
+  #include "lcd/FYSETC_MINI_12864_2_0.h"
+#elif ENABLED(FYSETC_MINI_12864_2_1)
+  #include "lcd/FYSETC_MINI_12864_2_1.h"
+#elif ENABLED(FYSETC_GENERIC_12864_1_1)
+  #include "lcd/FYSETC_GENERIC_12864_1_1.h"
+#elif ENABLED(BTT_MINI_12864_V1)
+  #include "lcd/BTT_MINI_12864_V1.h"
+#elif ENABLED(CR10_STOCKDISPLAY)
+  #include "lcd/CR10_STOCKDISPLAY.h"
+#elif ENABLED(ENDER2_STOCKDISPLAY)
+  #include "lcd/ENDER2_STOCKDISPLAY.h"
+#elif ENABLED(ANET_FULL_GRAPHICS_LCD)
+  #include "lcd/ANET_FULL_GRAPHICS_LCD.h"
+#elif ENABLED(ANET_FULL_GRAPHICS_LCD_ALT_WIRING)
+  #include "lcd/ANET_FULL_GRAPHICS_LCD_ALT_WIRING.h"
+#elif ENABLED(AZSMZ_12864)
+  #include "lcd/AZSMZ_12864.h"
+#elif ENABLED(SILVER_GATE_GLCD_CONTROLLER)
+  #include "lcd/SILVER_GATE_GLCD_CONTROLLER.h"
+#elif ENABLED(EMOTION_TECH_LCD)
+  #include "lcd/EMOTION_TECH_LCD.h"
+#elif ENABLED(LCD_U8GLIB_SSD1306)
+  #include "lcd/LCD_U8GLIB_SSD1306.h"
+#elif ENABLED(SAV_3DGLCD)
+  #include "lcd/SAV_3DGLCD.h"
+#elif ENABLED(OLED_PANEL_TINYBOY2)
+  #include "lcd/OLED_PANEL_TINYBOY2.h"
+#elif ENABLED(MKS_12864OLED)
+  #include "lcd/MKS_12864OLED.h"
+#elif ENABLED(MKS_12864OLED_SSD1306)
+  #include "lcd/MKS_12864OLED_SSD1306.h"
+#elif ENABLED(ZONESTAR_12864LCD)
+  #include "lcd/ZONESTAR_12864LCD.h"
+#elif ENABLED(ZONESTAR_12864OLED)
+  #include "lcd/ZONESTAR_12864OLED.h"
+#elif ENABLED(ZONESTAR_12864OLED_SSD1306)
+  #include "lcd/ZONESTAR_12864OLED_SSD1306.h"
+#elif ENABLED(U8GLIB_SH1106_EINSTART)
+  #include "lcd/U8GLIB_SH1106_EINSTART.h"
+#elif ENABLED(OVERLORD_OLED)
+  #include "lcd/OVERLORD_OLED.h"
+#elif ENABLED(FYSETC_242_OLED_12864)
+  #include "lcd/FYSETC_242_OLED_12864.h"
+#elif ENABLED(K3D_242_OLED_CONTROLLER)
+  #include "lcd/K3D_242_OLED_CONTROLLER.h"
+#elif ENABLED(DGUS_LCD_UI_ORIGIN)
+  #include "lcd/DGUS_LCD_UI_ORIGIN.h"
+#elif ENABLED(DGUS_LCD_UI_FYSETC)
+  #include "lcd/DGUS_LCD_UI_FYSETC.h"
+#elif ENABLED(DGUS_LCD_UI_HIPRECY)
+  #include "lcd/DGUS_LCD_UI_HIPRECY.h"
+#elif ENABLED(DGUS_LCD_UI_MKS)
+  #include "lcd/DGUS_LCD_UI_MKS.h"
+#elif ENABLED(DGUS_LCD_UI_RELOADED)
+  #include "lcd/DGUS_LCD_UI_RELOADED.h"
+#elif ENABLED(DWIN_CREALITY_TOUCHLCD)
+  #include "lcd/DWIN_CREALITY_TOUCHLCD.h"
+#elif ENABLED(MALYAN_LCD)
+  #include "lcd/MALYAN_LCD.h"
+#elif ENABLED(TOUCH_UI_FTDI_EVE)
+  #include "lcd/TOUCH_UI_FTDI_EVE.h"
+#elif ENABLED(ANYCUBIC_LCD_I3MEGA)
+  #include "lcd/ANYCUBIC_LCD_I3MEGA.h"
+#elif ENABLED(ANYCUBIC_LCD_CHIRON)
+  #include "lcd/ANYCUBIC_LCD_CHIRON.h"
+#elif ENABLED(NEXTION_TFT)
+  #include "lcd/NEXTION_TFT.h"
+#elif ENABLED(PANELDUE)
+  #include "lcd/PANELDUE.h"
+#elif ENABLED(EXTENSIBLE_UI)
+  #include "lcd/EXTENSIBLE_UI.h"
+#elif ENABLED(MKS_TS35_V2_0)
+  #include "lcd/MKS_TS35_V2_0.h"
+#elif ENABLED(MKS_ROBIN_TFT24)
+  #include "lcd/MKS_ROBIN_TFT24.h"
+#elif ENABLED(MKS_ROBIN_TFT28)
+  #include "lcd/MKS_ROBIN_TFT28.h"
+#elif ENABLED(MKS_ROBIN_TFT32)
+  #include "lcd/MKS_ROBIN_TFT32.h"
+#elif ENABLED(MKS_ROBIN_TFT35)
+  #include "lcd/MKS_ROBIN_TFT35.h"
+#elif ENABLED(MKS_ROBIN_TFT43)
+  #include "lcd/MKS_ROBIN_TFT43.h"
+#elif ENABLED(MKS_ROBIN_TFT_V1_1R)
+  #include "lcd/MKS_ROBIN_TFT_V1_1R.h"
+#elif ENABLED(TFT_TRONXY_X5SA)
+  #include "lcd/TFT_TRONXY_X5SA.h"
+#elif ENABLED(ANYCUBIC_TFT35)
+  #include "lcd/ANYCUBIC_TFT35.h"
+#elif ENABLED(LONGER_LK_TFT28)
+  #include "lcd/LONGER_LK_TFT28.h"
+#elif ENABLED(ANET_ET4_TFT28)
+  #include "lcd/ANET_ET4_TFT28.h"
+#elif ENABLED(ANET_ET5_TFT35)
+  #include "lcd/ANET_ET5_TFT35.h"
+#elif ENABLED(BIQU_BX_TFT70)
+  #include "lcd/BIQU_BX_TFT70.h"
+#elif ENABLED(BTT_TFT35_SPI_V1_0)
+  #include "lcd/BTT_TFT35_SPI_V1_0.h"
+#elif ENABLED(TFT_GENERIC)
+  #include "lcd/TFT_GENERIC.h"
+#elif ENABLED(TFT_CLASSIC_UI)
+  #include "lcd/TFT_CLASSIC_UI.h"
+#elif ENABLED(TFT_COLOR_UI)
+  #include "lcd/TFT_COLOR_UI.h"
+#elif ENABLED(TFT_LVGL_UI)
+  #include "lcd/TFT_LVGL_UI.h"
+#elif ANY(DWIN_CREALITY_LCD, DWIN_LCD_PROUI, DWIN_MARLINUI_PORTRAIT, DWIN_MARLINUI_LANDSCAPE)
+  #include "lcd/DWIN_CREALITY_LCD.h"
+#endif
+
+// Button panels
+#if ENABLED(REPRAPWORLD_KEYPAD)
+  #include "lcd/REPRAPWORLD_KEYPAD.h"
+#elif ENABLED(EASYTHREED_UI)
+  #include "lcd/EASYTHREED_UI.h"
+#endif

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -594,12 +594,33 @@
 
   #elif BOTH(IS_NEWPANEL, PANEL_ONE)
 
-    #define LCD_PINS_RS              AUX2_06_PIN
-    #define LCD_PINS_ENABLE          AUX2_08_PIN
-    #define LCD_PINS_D4              AUX2_10_PIN
-    #define LCD_PINS_D5              AUX2_09_PIN
-    #define LCD_PINS_D6              AUX2_07_PIN
-    #define LCD_PINS_D7              AUX2_05_PIN
+    /**
+     *                  PANEL_ONE
+     *         ------                 ------
+     *    NC  | 1  2 | NC        DB4 | 1  2 | DB5
+     *    VCC | 3  4 | ENC         E | 3  4 | DB6
+     *   MISO | 5  6 | MOSI       RS | 5  6 | DB7
+     *    SCK | 7  8 | SDSS      EN2 | 7  8 | EN1
+     *    GND | 9 10 | NC        GND | 9 10 | 5V
+     *         ------                 ------
+     *           P1                     P2
+     */
+
+    // Each board defines its own EXP adapters
+    #define EXP1_04_PIN              AUX3_02_PIN  // ENC
+    #define EXP1_05_PIN                     MISO
+    #define EXP1_06_PIN                     MOSI
+    #define EXP1_07_PIN                      SCK
+    #define EXP1_08_PIN                     SDSS
+
+    #define EXP2_01_PIN              AUX2_10_PIN  // DB4
+    #define EXP2_02_PIN              AUX2_09_PIN  // DB5
+    #define EXP2_03_PIN              AUX2_08_PIN  // ENA
+    #define EXP2_04_PIN              AUX2_07_PIN  // DB6
+    #define EXP2_05_PIN              AUX2_06_PIN  // RS
+    #define EXP2_06_PIN              AUX2_05_PIN  // DB7
+    #define EXP2_07_PIN              AUX2_04_PIN  // EN2
+    #define EXP2_08_PIN              AUX2_03_PIN  // EN1
 
   #elif ENABLED(TFTGLCD_PANEL_SPI)
 
@@ -859,10 +880,8 @@
 
       #define BEEPER_PIN             EXP2_05_PIN
 
-      #if ENABLED(PANEL_ONE)                       // Buttons connect directly to AUX-2
-        #define BTN_EN1              AUX2_03_PIN
-        #define BTN_EN2              AUX2_04_PIN
-        #define BTN_ENC              AUX3_02_PIN
+      #if ENABLED(PANEL_ONE)                      // Buttons connect directly to AUX-2
+        // Moved
       #else
         #define BTN_EN1              EXP1_01_PIN
         #define BTN_EN2              EXP1_02_PIN

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -706,6 +706,8 @@
 
     #elif ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
 
+      // TODO: Define adapters that connect to AUX ports
+
       #define BTN_EN1                AUX2_05_PIN
       #define BTN_EN2                AUX2_03_PIN
       #define BTN_ENC                AUX2_04_PIN

--- a/Marlin/src/pins/ramps/pins_RAMPS.h
+++ b/Marlin/src/pins/ramps/pins_RAMPS.h
@@ -630,13 +630,7 @@
 
     #if ENABLED(CR10_STOCKDISPLAY)
 
-      #define LCD_PINS_RS            EXP1_07_PIN
-      #define LCD_PINS_ENABLE        EXP1_08_PIN
-      #define LCD_PINS_D4            EXP1_06_PIN
-
-      #if !IS_NEWPANEL
-        #define BEEPER_PIN           EXP1_01_PIN
-      #endif
+      // Moved
 
     #elif ENABLED(ZONESTAR_LCD)
 
@@ -706,8 +700,7 @@
       #define BEEPER_PIN             EXP1_01_PIN
 
       #if ENABLED(CR10_STOCKDISPLAY)
-        #define BTN_EN1              EXP1_03_PIN
-        #define BTN_EN2              EXP1_05_PIN
+        // Moved
       #else
         #define BTN_EN1              EXP2_03_PIN
         #define BTN_EN2              EXP2_05_PIN

--- a/Marlin/src/pins/ramps/pins_TT_OSCAR.h
+++ b/Marlin/src/pins/ramps/pins_TT_OSCAR.h
@@ -284,12 +284,12 @@
 
   #elif BOTH(IS_NEWPANEL, PANEL_ONE)
 
-    #define LCD_PINS_RS                       40
-    #define LCD_PINS_ENABLE                   42
-    #define LCD_PINS_D4                       65
-    #define LCD_PINS_D5                       66
-    #define LCD_PINS_D6                       44
-    #define LCD_PINS_D7                       64
+    #define EXP2_01_PIN                       65
+    #define EXP2_02_PIN                       66
+    #define EXP2_03_PIN                       42
+    #define EXP2_04_PIN                       44
+    #define EXP2_05_PIN                       40
+    #define EXP2_06_PIN                       64
 
   #elif ENABLED(ZONESTAR_LCD)
 
@@ -491,9 +491,9 @@
         #define BTN_EN2                       59
         #define BTN_ENC                       63
       #elif ENABLED(PANEL_ONE)
-        #define BTN_EN1                       59  // AUX2 PIN 3
-        #define BTN_EN2                       63  // AUX2 PIN 4
-        #define BTN_ENC                       49  // AUX3 PIN 7
+        #define EXP1_04_PIN                   49
+        #define EXP2_07_PIN                   63
+        #define EXP2_08_PIN                   59
       #else
         #define BTN_EN1                       37
         #define BTN_EN2                       35

--- a/Marlin/src/pins/ramps/pins_TT_OSCAR.h
+++ b/Marlin/src/pins/ramps/pins_TT_OSCAR.h
@@ -21,6 +21,9 @@
  */
 #pragma once
 
+/**
+ * thingNthinks TT Oscar v1.0 by YM Tech.LTD
+ */
 #include "env_validate.h"
 
 #if HOTENDS > 5 || E_STEPPERS > 5

--- a/Marlin/src/pins/ramps/pins_TT_OSCAR.h
+++ b/Marlin/src/pins/ramps/pins_TT_OSCAR.h
@@ -305,13 +305,10 @@
 
     #if ENABLED(CR10_STOCKDISPLAY)
 
-      #define LCD_PINS_RS                     27
-      #define LCD_PINS_ENABLE                 29
-      #define LCD_PINS_D4                     25
-
-      #if !IS_NEWPANEL
-        #define BEEPER_PIN                    37
-      #endif
+      #define EXP1_01_PIN                     37
+      #define EXP1_06_PIN                     25
+      #define EXP1_07_PIN                     27
+      #define EXP1_08_PIN                     29
 
     #else
 
@@ -364,14 +361,15 @@
       #define BEEPER_PIN                      37
 
       #if ENABLED(CR10_STOCKDISPLAY)
-        #define BTN_EN1                       17
-        #define BTN_EN2                       23
+        #define EXP1_02_PIN                   35  // ENC
+        #define EXP2_03_PIN                   17  // EN1
+        #define EXP2_05_PIN                   23  // EN2
       #else
+        #define BTN_ENC                       35
         #define BTN_EN1                       31
         #define BTN_EN2                       33
       #endif
 
-      #define BTN_ENC                         35
       #define SD_DETECT_PIN                   49
       //#define KILL_PIN                      41
 


### PR DESCRIPTION
It should be possible to define LCD pins in terms of the EXP headers, so this PR begins the process of that conversion. Where LCDs are not yet defined in terms of EXP headers, adapters may be defined to provide the correct mappings to the EXP headers of those adapters.