### PR TITLE
Update MarlinCore.cpp

### DIFF
--- a/Marlin/src/MarlinCore.cpp
+++ b/Marlin/src/MarlinCore.cpp
@@ -1270,7 +1270,9 @@ void setup() {
 
   SETUP_RUN(hal.init_board());
 
-  SETUP_RUN(esp_wifi_init());
+  #if ENABLED(WIFISUPPORT) || ENABLED(ESP3D_WIFISUPPORT)
+    SETUP_RUN(esp_wifi_init());
+  #endif
 
   // Report Reset Reason
   if (mcu & RST_POWER_ON)  SERIAL_ECHOLNPGM(STR_POWERUP);


### PR DESCRIPTION
Added a macro to check for esp wifi. 
Just by adding this check you will save some bytes.  
This check redused the size by 106Bytes. 

Test with check:
Sketch uses 144046 bytes (56%) of program storage space. Maximum is 253952 bytes.
Global variables use 4717 bytes (57%) of dynamic memory, leaving 3475 bytes for local variables. Maximum is 8192 bytes.

Test without check:
Sketch uses 144152 bytes (56%) of program storage space. Maximum is 253952 bytes.
Global variables use 4717 bytes (57%) of dynamic memory, leaving 3475 bytes for local variables. Maximum is 8192 bytes.

106 Bytes doesnt sound like much. but when youre compiling for a good old 8 bit AVR, every byte counts :)
 compiler.c.flags=-c -g -Os  ...  compiler.cpp.flags=-c -g -Os  ... flas was used for optimize the size.
I also tried adding --specs=nano.specs in my platform.txt for the arduino ide. but no improvements gained.
Arduino Ide was used to compile. 

<!--

Submitting a Pull Request

- Please fill out all sections of this form. You can delete the helpful comments.
- Pull Requests without clear information will take longer and may even be rejected.
- We get a high volume of submissions so please be patient during review.

-->

### Description

<!--

Clearly describe the submitted changes with lots of details. Include images where helpful. Initial reviewers may not be familiar with the subject, so be as thorough as possible. You can use MarkDown syntax to improve readability with bullet lists, code blocks, and so on. PREVIEW and fix up formatting before submitting.

-->

### Requirements

<!-- Does this PR require a specific board, LCD, etc.? -->

### Benefits

<!-- What does this PR fix or improve? -->

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
