### PR TITLE
Fix upload firmware error

### DIFF
--- a/buildroot/share/scripts/upload.py
+++ b/buildroot/share/scripts/upload.py
@@ -84,9 +84,9 @@ def Upload(source, target, env):
             try:
                 clean_response = Resp.decode('utf8').rstrip().lstrip()
                 clean_responses.append(clean_response)
+                debugPrint(f'<< {clean_response}')
             except:
                 pass
-            debugPrint(f'<< {clean_response}')
         return clean_responses
 
     #------------------#


### PR DESCRIPTION
### Description

Fix an error condition that can occur in the firmware upload script

### Requirements

Environments with firmware upload enabled

### Benefits

Avoid script error during firmware upload

### Configurations

none

### Related Issues

none
