### PR TITLE
E3V2 - Led switches fix up

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -2230,6 +2230,7 @@ void SetPID(celsius_t t, heater_id_t h) {
     if (HMI_data.Baud115K) SetBaud115K(); else SetBaud250K();
   }
   void SetBaudRate() {
+    HMI_data.Baud115K = !HMI_data.Baud115K;
     HMI_SetBaudRate();
     Draw_Chkb_Line(CurrentMenu->line(), HMI_data.Baud115K);
     DWIN_UpdateLCD();

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -2226,11 +2226,9 @@ void SetPID(celsius_t t, heater_id_t h) {
 #endif
 
 #if ENABLED(BAUD_RATE_GCODE)
-  void HMI_SetBaudRate() {
-    if (HMI_data.Baud115K) SetBaud115K(); else SetBaud250K();
-  }
+  void HMI_SetBaudRate() { HMI_data.Baud115K ? SetBaud115K() : SetBaud250K(); }
   void SetBaudRate() {
-    HMI_data.Baud115K = !HMI_data.Baud115K;
+    HMI_data.Baud115K ^= true;
     HMI_SetBaudRate();
     Draw_Chkb_Line(CurrentMenu->line(), HMI_data.Baud115K);
     DWIN_UpdateLCD();

--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -1825,7 +1825,7 @@ void DWIN_SetDataDefaults() {
   #endif
   TERN_(BAUD_RATE_GCODE, SetBaud250K());
   #if BOTH(LED_CONTROL_MENU, HAS_COLOR_LEDS)
-    leds.set_default();
+    TERN_(LED_COLOR_PRESETS, leds.set_default());
     ApplyLEDColor();
   #endif
 }
@@ -2268,9 +2268,7 @@ void SetPID(celsius_t t, heater_id_t h) {
   #endif
   #if HAS_COLOR_LEDS
     void ApplyLEDColor() {
-      HMI_data.Led_Color = LEDColor(
-        TERN(HAS_WHITE_LED, { 0, 0, 0, leds.color.w }, { leds.color.r, leds.color.g, leds.color.b })
-      );
+      HMI_data.Led_Color = LEDColor( {leds.color.r, leds.color.g, leds.color.b OPTARG(HAS_WHITE_LED, HMI_data.Led_Color.w) } );
     }
     void LiveLEDColor(uint8_t *color) { *color = MenuData.Value; leds.update(); }
     void LiveLEDColorR() { LiveLEDColor(&leds.color.r); }
@@ -3415,7 +3413,7 @@ void Draw_GetColor_Menu() {
           EDIT_ITEM_F(ICON_LedControl, MSG_COLORS_GREEN, onDrawPInt8Menu, SetLEDColorG, &leds.color.g);
           EDIT_ITEM_F(ICON_LedControl, MSG_COLORS_BLUE, onDrawPInt8Menu, SetLEDColorB, &leds.color.b);
           #if ENABLED(HAS_WHITE_LED)
-            EDIT_ITEM_F(ICON_LedControl, MSG_COLORS_WHITE, onDrawPInt8Menu, SetLedColorW, &leds.color.w);
+            EDIT_ITEM_F(ICON_LedControl, MSG_COLORS_WHITE, onDrawPInt8Menu, SetLEDColorW, &leds.color.w);
           #endif
         #endif
       #endif

--- a/Marlin/src/lcd/e3v2/proui/dwin_defines.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_defines.h
@@ -38,6 +38,9 @@
 #include "../../../inc/MarlinConfigPre.h"
 #include "../common/dwin_color.h"
 #include <stddef.h>
+#if ENABLED(LED_CONTROL_MENU)
+  #include "../../../feature/leds/leds.h"
+#endif
 
 #if defined(__STM32F1__) || defined(STM32F1)
   #define DASH_REDRAW 1

--- a/Marlin/src/lcd/e3v2/proui/dwin_defines.h
+++ b/Marlin/src/lcd/e3v2/proui/dwin_defines.h
@@ -37,15 +37,14 @@
 
 #include "../../../inc/MarlinConfigPre.h"
 #include "../common/dwin_color.h"
-#include <stddef.h>
 #if ENABLED(LED_CONTROL_MENU)
   #include "../../../feature/leds/leds.h"
 #endif
+#include <stddef.h>
 
 #if defined(__STM32F1__) || defined(STM32F1)
   #define DASH_REDRAW 1
 #endif
-
 
 #define Def_Background_Color  RGB( 1, 12,  8)
 #define Def_Cursor_color      RGB(20, 49, 31)


### PR DESCRIPTION
### Description

Due to simultaneous works on leds with @mriscoc some conditions leads to compile errors.
This PR addresses errors with enabled switches:  `NEOPIXEL_LED`, `LED_CONTROL_MENU` and without `LED_COLOR_PRESETS`
It also resolves some issues for led with the white color (`HAS_WHITE_LED`).

### Requirements

E3V2 ProUI

### Benefits

Allow compile with specified switches

### Configurations

none

### Related Issues

none
