### PR TITLE
E3V2 - Fix switch baud 115<->250

### DIFF
--- a/Marlin/src/lcd/e3v2/proui/dwin.cpp
+++ b/Marlin/src/lcd/e3v2/proui/dwin.cpp
@@ -2230,6 +2230,7 @@ void SetPID(celsius_t t, heater_id_t h) {
     if (HMI_data.Baud115K) SetBaud115K(); else SetBaud250K();
   }
   void SetBaudRate() {
+    HMI_data.Baud115K = !HMI_data.Baud115K;
     HMI_SetBaudRate();
     Draw_Chkb_Line(CurrentMenu->line(), HMI_data.Baud115K);
     DWIN_UpdateLCD();


### PR DESCRIPTION
### Description

In the ProUI the checkbox switch for 115k <-> 250k baud doesn't works. Clicking it doesn't change the UI nor the serial speed.
This PR fix the problem.

### Requirements

E3V2 ProUI

### Benefits

Allow switch of baud rate 115k <-> 250k

### Configurations

none

### Related Issues

none
