### PR TITLE
Remove log2file monitor filter

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -270,7 +270,7 @@ lib_deps          = ${common.lib_deps}
 monitor_speed     = 250000
 monitor_eol       = LF
 monitor_echo      = yes
-monitor_filters   = colorize, time, send_on_enter, log2file
+monitor_filters   = colorize, time, send_on_enter
 
 #
 # Just print the dependency tree


### PR DESCRIPTION
### Description

With this filter enabled, a new log file for any serial monitor is generated in the `Marlin` folder, which I think is not what we want to keep the dev folder clean.

### Requirements

none

### Benefits

Avoid log file creation

### Configurations

<!-- Attach Configurations ZIP and any other files needed to test this PR. -->

### Related Issues

<!-- Does this PR fix a bug or fulfill a Feature Request? Link related Issues here. -->
